### PR TITLE
feat(auth): switchroom auth add <label> --via-claude — broader-scope OAuth via claude

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -35,10 +35,16 @@ refresh tokens themselves and never write credentials files.
 ## CLI surface
 
 ```bash
-# Add an Anthropic account (one OAuth flow)
-switchroom auth add me@example.com --from-oauth
-switchroom auth add work --from-agent clerk          # seed from an existing agent
-switchroom auth add stage --from-credentials path/   # import a credentials.json
+# Add an Anthropic account (one OAuth flow). First-time setup: use
+# --via-claude. This drives claude through its native OAuth flow in a
+# tmux session, gets you the broader scope set that `claude server:`
+# mode requires, and ingests the resulting credentials.json into the
+# broker. The alternative --from-oauth path runs `claude setup-token`
+# which mints scope=user:inference only — won't work for agents.
+switchroom auth add me@example.com --via-claude       # one OAuth flow, broader scope
+switchroom auth add work --from-agent clerk           # seed from an existing agent
+switchroom auth add stage --from-credentials path/    # import a credentials.json
+switchroom auth add legacy --from-oauth               # narrow-scope, --print-only use cases
 
 # See the state of the fleet
 switchroom auth list

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2250,13 +2250,17 @@ export function scaffoldAgent(
   // --- Claude Code config (onboarding state) ---
   // Copy onboarding state (.claude.json) from the host's Claude installation
   // so the agent skips the first-run wizard, but intentionally do NOT copy
-  // .credentials.json. Each agent must go through its own fresh OAuth flow
-  // (Phase 2 policy: copyExistingCredentials removed from scaffold path).
-  // Existing credential blobs can be stale and cause silent 401s.
-  // Operators register a fleet-wide account via `switchroom auth add
-  // <label> --from-oauth` + `switchroom auth use <label>` (RFC H); the
-  // auth-broker mirrors `.credentials.json` per agent at boot, on
-  // setActive, and on refresh-tick.
+  // .credentials.json — agent credentials are owned by the RFC-H auth-broker,
+  // not by scaffold-time file copies. The broker atomically writes
+  // `<agentDir>/.claude/.credentials.json` at boot, on setActive, and on
+  // refresh-tick, sourced from the fleet-active account at
+  // `~/.switchroom/accounts/<label>/credentials.json`.
+  //
+  // Operators register one fleet account via `switchroom auth add <label>
+  // --via-claude` (drives claude through its native broader-scope OAuth;
+  // see src/auth/via-claude.ts) then `switchroom auth use <label>`. Adding
+  // the 2nd/3rd/Nth agent to the same account is a YAML edit; no further
+  // OAuth round-trips. See `reference/share-auth-across-the-fleet.md`.
   //
   // UPGRADE WARN: if ~/.claude-home/.credentials.json (or ~/.claude/.credentials.json)
   // exists at scaffold time, we deliberately skip copying it. Agents that were

--- a/src/auth/via-claude.test.ts
+++ b/src/auth/via-claude.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  extractAuthorizeUrl,
+  runViaClaude,
+  PRE_PASTE_RULES,
+  POST_PASTE_RULES,
+} from "./via-claude.js";
+
+describe("extractAuthorizeUrl", () => {
+  it("extracts a wrapped URL from a real claude pane snapshot (claude.com/cai)", () => {
+    const pane = `
+ Browser didn't open? Use the url below to sign in (c to copy)
+
+https://claude.com/cai/oauth/authorize?code=true&client_id=9d1c250a-e61b-44d9-88
+ed-5944d1962f5e&response_type=code&redirect_uri=https%3A%2F%2Fplatform.claude.co
+m%2Foauth%2Fcode%2Fcallback&scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainf
+erence+user%3Asessions%3Aclaude_code+user%3Amcp_servers+user%3Afile_upload&code_
+challenge=su2LvUxoYRoqzuPID7nQpVG_20ZpHusYIpc0LHcizXg&code_challenge_method=S256
+&state=kJN-K2wyCgX47qj_mCUvBKi2XPstImxQfyV_vIwyPA4
+
+
+ Paste code here if prompted >
+`;
+    const url = extractAuthorizeUrl(pane);
+    expect(url).not.toBeNull();
+    expect(url).toContain("https://claude.com/cai/oauth/authorize?");
+    expect(url).toContain("scope=org%3Acreate_api_key");
+    // Confirm the line-wrapping collapse worked — no whitespace inside.
+    expect(url).not.toMatch(/\s/);
+  });
+
+  it("extracts the legacy claude.ai/oauth URL too", () => {
+    const pane = "Browser didn't open? Use the URL: https://claude.ai/oauth/authorize?client_id=x&code=true\n\n Paste code here >";
+    const url = extractAuthorizeUrl(pane);
+    expect(url).not.toBeNull();
+    expect(url).toContain("https://claude.ai/oauth/authorize?");
+  });
+
+  it("returns null when no URL is on the pane", () => {
+    expect(extractAuthorizeUrl("just a theme picker here")).toBeNull();
+    expect(extractAuthorizeUrl("")).toBeNull();
+  });
+
+  it("strips ANSI escape sequences around the URL", () => {
+    const pane = "\x1b[31mhttps://claude.com/cai/oauth/authorize?x=1\x1b[0m\n\n Paste code here";
+    const url = extractAuthorizeUrl(pane);
+    expect(url).toBe("https://claude.com/cai/oauth/authorize?x=1");
+  });
+});
+
+describe("PRE_PASTE_RULES + POST_PASTE_RULES sanity", () => {
+  it("theme picker fires on the real claude header", () => {
+    const rule = PRE_PASTE_RULES.find((r) => r.name === "theme")!;
+    expect(rule.match.test("Choose the text style that looks best with your terminal")).toBe(true);
+  });
+  it("login method picker fires on the real heading", () => {
+    const rule = PRE_PASTE_RULES.find((r) => r.name === "login-method")!;
+    expect(rule.match.test("Select login method:")).toBe(true);
+  });
+  it("post-paste rules fire on the success/security panes", () => {
+    const loggedIn = POST_PASTE_RULES.find((r) => r.name === "logged-in")!;
+    expect(loggedIn.match.test("Logged in as me@example.com")).toBe(true);
+    expect(loggedIn.match.test("Login successful. Press Enter to continue…")).toBe(true);
+
+    const security = POST_PASTE_RULES.find((r) => r.name === "security-notes")!;
+    expect(security.match.test("Security notes:")).toBe(true);
+  });
+});
+
+describe("runViaClaude end-to-end (mocked tmux)", () => {
+  /**
+   * Simulates the pane lifecycle: starts empty, transitions through
+   * theme picker → URL → logged-in → security → REPL. The test
+   * harness also tracks send-keys and lazily materialises the
+   * credentials file at the "right" moment (mid-poll, after the
+   * operator's code has been "dispatched").
+   */
+  function makeFakeClaude(tmp: string) {
+    const credsPath = join(tmp, ".credentials.json");
+    const sent: Array<{ keys: readonly string[]; literal: boolean }> = [];
+    let phase: "theme" | "login" | "url" | "logged-in" | "security" | "done" =
+      "theme";
+    let pollsSincePaste = 0;
+    let codeSent = false;
+    const pane = (): string => {
+      switch (phase) {
+        case "theme":
+          return "Choose the text style that looks best with your terminal\n  1. Auto\n  2. Light";
+        case "login":
+          return "Select login method:\n  1. Claude account with subscription";
+        case "url":
+          return `Browser didn't open? Use the URL: https://claude.com/cai/oauth/authorize?scope=org%3Acreate_api_key+user%3Ainference&x=1\n\n Paste code here if prompted >`;
+        case "logged-in":
+          return "Logged in as me@example.com\nLogin successful. Press Enter to continue…";
+        case "security":
+          return "Security notes:\n  1. Claude can make mistakes\n\nPress Enter to continue…";
+        case "done":
+          return "  Welcome to Claude Code\n\n>";
+      }
+    };
+    const send = (keys: readonly string[], literal?: boolean) => {
+      sent.push({ keys, literal: literal === true });
+      // Transition logic: every dispatched Enter advances one phase
+      // in the canonical sequence.
+      const enterCount = keys.filter((k) => k === "Enter").length;
+      for (let i = 0; i < enterCount; i++) {
+        if (phase === "theme") phase = "login";
+        else if (phase === "login") phase = "url";
+        else if (phase === "logged-in") phase = "security";
+        else if (phase === "security") phase = "done";
+      }
+      // The literal code paste flips us into "logged-in" (mimics
+      // claude's behaviour: code accepted → success screen).
+      if (literal && keys.length === 1 && keys[0]!.includes("code-")) {
+        codeSent = true;
+        phase = "logged-in";
+      }
+    };
+    const capture = () => {
+      // After the code's been pasted and we've advanced into "logged-in",
+      // materialise credentials.json on the second post-paste poll so
+      // the poll-loop has a chance to also dispatch the post-paste
+      // Enter rules before the file appears.
+      if (codeSent) {
+        pollsSincePaste++;
+        if (pollsSincePaste === 2) {
+          writeFileSync(
+            credsPath,
+            JSON.stringify({
+              claudeAiOauth: {
+                accessToken: "sk-ant-oat01-fake",
+                refreshToken: "rt-fake",
+                expiresAt: Date.now() + 86_400_000,
+                scopes: ["org:create_api_key", "user:profile", "user:inference"],
+              },
+            }),
+          );
+        }
+      }
+      return pane();
+    };
+    return { capture, send, sent };
+  }
+
+  it("walks the full flow and returns parsed credentials", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "switchroom-via-claude-"));
+    try {
+      const fake = makeFakeClaude(tmp);
+      const result = await runViaClaude({
+        configDir: tmp,
+        promptForCode: async (url) => {
+          expect(url).toContain("https://claude.com/cai/oauth/authorize?");
+          return "code-abc#state-xyz";
+        },
+        spawnClaude: () => {
+          /* test seam — no real tmux */
+        },
+        capturePane: fake.capture,
+        sendKeys: fake.send,
+        pollMs: 5,
+        urlTimeoutMs: 5_000,
+        credentialsTimeoutMs: 5_000,
+        log: () => {
+          /* quiet in tests */
+        },
+      });
+
+      expect(result.credentialsPath).toBe(join(tmp, ".credentials.json"));
+      expect(result.credentials.claudeAiOauth.accessToken).toBe("sk-ant-oat01-fake");
+
+      // Verify the send-keys sequence — theme Enter, login Enter,
+      // literal code, Enter to submit, logged-in Enter, security Enter.
+      const flat = fake.sent.map((s) => ({ literal: s.literal, keys: s.keys.join("|") }));
+      const enters = flat.filter((s) => s.keys === "Enter").length;
+      expect(enters).toBeGreaterThanOrEqual(3);
+      const codeSends = flat.filter((s) => s.literal);
+      expect(codeSends).toHaveLength(1);
+      expect(codeSends[0]!.keys).toBe("code-abc#state-xyz");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects when promptForCode returns empty string", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "switchroom-via-claude-empty-"));
+    try {
+      // Pane just gets stuck at the URL screen; no progression. We
+      // bail on the empty code paste before any timeout.
+      let phase: "theme" | "login" | "url" = "theme";
+      const capture = () => {
+        const s = phase;
+        if (phase === "theme") phase = "login";
+        else if (phase === "login") phase = "url";
+        return s === "theme"
+          ? "Choose the text style that looks best with your terminal"
+          : s === "login"
+            ? "Select login method:"
+            : "https://claude.com/cai/oauth/authorize?scope=x&y=1\n\n Paste code here";
+      };
+      await expect(
+        runViaClaude({
+          configDir: tmp,
+          promptForCode: async () => "   ",
+          spawnClaude: () => undefined,
+          capturePane: capture,
+          sendKeys: () => undefined,
+          pollMs: 5,
+          urlTimeoutMs: 1_000,
+          credentialsTimeoutMs: 1_000,
+          log: () => undefined,
+        }),
+      ).rejects.toThrow(/Empty code/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("times out cleanly when claude never renders the URL", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "switchroom-via-claude-timeout-"));
+    try {
+      await expect(
+        runViaClaude({
+          configDir: tmp,
+          promptForCode: async () => "irrelevant",
+          spawnClaude: () => undefined,
+          capturePane: () => "stuck forever",
+          sendKeys: () => undefined,
+          pollMs: 5,
+          urlTimeoutMs: 100,
+          credentialsTimeoutMs: 100,
+          log: () => undefined,
+        }),
+      ).rejects.toThrow(/Timed out.*OAuth URL/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/auth/via-claude.ts
+++ b/src/auth/via-claude.ts
@@ -1,0 +1,354 @@
+/**
+ * Drive `claude` interactively in a tmux session so a host operator
+ * can produce a broader-scope `.credentials.json` that `claude
+ * setup-token` can't mint. Used by `switchroom auth add <label>
+ * --via-claude` (and the first-time setup wizard).
+ *
+ * Why this exists
+ * ---------------
+ * `claude setup-token` requests `scope=user:inference` only. That
+ * scope is enough for `claude --print`-style one-shot inference, but
+ * `claude --dangerously-load-development-channels server:…` (the mode
+ * every switchroom agent runs in) refuses the resulting token at
+ * boot and falls back to the "Select login method" TUI picker. The
+ * picker mints the broader scope set
+ * (`org:create_api_key user:profile user:inference
+ * user:sessions:claude_code user:mcp_servers user:file_upload`) that
+ * server: mode requires.
+ *
+ * RFC H's `auth add --from-oauth` was designed around `setup-token`'s
+ * output, which means a fresh install runs into the scope mismatch
+ * on first agent boot. This module is the install-validation fix:
+ * spawn `claude` in a clean tmux pane, dispatch the well-known
+ * keystroke sequence to land on the broader-scope OAuth URL, surface
+ * the URL to the operator, accept the pasted code, and wait for
+ * `<CLAUDE_CONFIG_DIR>/.credentials.json` to appear. The caller
+ * (`src/cli/auth.ts:add`) then ingests it via the existing
+ * `--from-credentials` codepath and registers it with the auth-
+ * broker via `client.addAccount(...)`.
+ *
+ * No new OAuth code lives here — switchroom never speaks the
+ * code-for-token exchange directly. Claude does it.
+ *
+ * Install-validation finding #38.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+/* ── Tmux primitives (single-session scope) ─────────────────────── */
+
+/**
+ * Session name we use for the auth REPL. One concurrent flow per host
+ * operator. Re-running the verb while a stale session lingers kills
+ * the old one (the operator can't usefully recover a half-completed
+ * flow anyway — OAuth state-param won't match).
+ */
+const SESSION = "switchroom-via-claude";
+
+/**
+ * Polling intervals + budgets. Numbers are intentionally low at the
+ * fine-grained end (URL render is fast; we want the operator to see
+ * the URL within a couple of seconds) and forgiving at the coarse
+ * end (network OAuth round-trip + Anthropic's server-side write of
+ * credentials.json can take 10+ seconds in the wild).
+ */
+export const VIA_CLAUDE_DEFAULTS = {
+  /** Max time to wait for the URL line to appear in the pane. */
+  urlTimeoutMs: 20_000,
+  /** Max time to wait for `.credentials.json` to appear post-paste. */
+  credentialsTimeoutMs: 60_000,
+  /** Pane poll interval. */
+  pollMs: 500,
+} as const;
+
+export function tmuxHasSession(session: string): boolean {
+  const r = spawnSync("tmux", ["has-session", "-t", session], {
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+  return r.status === 0;
+}
+
+export function tmuxKillSession(session: string): void {
+  try {
+    execFileSync("tmux", ["kill-session", "-t", session], {
+      stdio: "ignore",
+      timeout: 3000,
+    });
+  } catch {
+    /* best-effort */
+  }
+}
+
+function tmuxCapturePane(session: string): string {
+  try {
+    const out = execFileSync(
+      "tmux",
+      ["capture-pane", "-p", "-t", session, "-S", "-200"],
+      { timeout: 3000, stdio: ["ignore", "pipe", "pipe"], maxBuffer: 4 * 1024 * 1024 },
+    );
+    return out.toString("utf8");
+  } catch {
+    return "";
+  }
+}
+
+function tmuxSendKeys(session: string, keys: readonly string[], literal = false): void {
+  try {
+    execFileSync(
+      "tmux",
+      ["send-keys", "-t", session, ...(literal ? ["-l"] : []), ...keys],
+      { timeout: 3000, stdio: ["ignore", "pipe", "pipe"] },
+    );
+  } catch {
+    /* best-effort; caller decides what to do on no-progress */
+  }
+}
+
+/* ── Pane parsing ───────────────────────────────────────────────── */
+
+/**
+ * The OAuth authorize URL claude emits after the operator picks
+ * "Claude account with subscription" from the login picker. Matches
+ * the two shapes Anthropic has shipped (legacy `claude.ai/oauth/...`
+ * and current `claude.com/cai/oauth/...`).
+ *
+ * Exported so the auth/via-claude.test.ts smoke tests can pin the
+ * regex against fixture pane captures.
+ */
+export function extractAuthorizeUrl(pane: string): string | null {
+  // Strip CSI escapes; claude's TUI wraps the URL across multiple
+  // lines and decorates it with \x1b[...m colour codes.
+  const stripped = pane.replace(/\[[0-9;]*[A-Za-z]/g, "");
+  const m = stripped.match(
+    /https:\/\/claude\.(?:ai\/|com\/cai\/)oauth\/authorize\?[\s\S]*?(?=\n\s*\n|\n\s*Paste code here|$)/,
+  );
+  if (!m) return null;
+  // Claude line-wraps long URLs across the terminal width. Collapse
+  // whitespace so the operator can copy a single-line URL.
+  return m[0].replace(/\s+/g, "");
+}
+
+/* ── Prompt-sequence dispatch ───────────────────────────────────── */
+
+/**
+ * Each rule fires at most once when its regex matches the current pane
+ * snapshot. The sequence reflects what `claude` renders on a fresh
+ * `CLAUDE_CONFIG_DIR` — first-time boot prompts in order:
+ *
+ *   1. Theme picker      → Enter (Auto)
+ *   2. Login method      → Enter (Claude account with subscription)
+ *   3. Browser-didn't-open URL display + "Paste code here" prompt
+ *      → handled separately (operator paste; we don't auto-dispatch)
+ *   4. (Post-paste) "Logged in as …" + "Press Enter to continue"
+ *      → Enter
+ *   5. Security notes "Press Enter to continue"
+ *      → Enter
+ *   6. REPL prompt — flow complete; we tear down.
+ *
+ * MCP-server trust does NOT appear because we run claude with the
+ * default plugin dir (no per-agent .mcp.json under the account dir).
+ */
+export interface DispatchRule {
+  name: string;
+  match: RegExp;
+  keys: readonly string[];
+}
+
+export const PRE_PASTE_RULES: readonly DispatchRule[] = [
+  { name: "theme", match: /Choose.{1,30}text.{1,30}style/, keys: ["Enter"] },
+  // Login method picker: option 1 = Claude account with subscription.
+  // The picker may render the option line with various decorations;
+  // matching the heading is enough to know we're here.
+  { name: "login-method", match: /Select login method/, keys: ["Enter"] },
+];
+
+export const POST_PASTE_RULES: readonly DispatchRule[] = [
+  { name: "logged-in", match: /Logged in as|Login successful/, keys: ["Enter"] },
+  { name: "security-notes", match: /Security notes:/, keys: ["Enter"] },
+];
+
+/* ── The flow ───────────────────────────────────────────────────── */
+
+export interface ViaClaudeOptions {
+  /**
+   * Where claude writes its `.credentials.json`. The CLI uses
+   * `~/.switchroom/accounts/<label>/` so the file lands where the
+   * existing `--from-credentials` ingest already looks.
+   */
+  configDir: string;
+  /** Prompt callback: receive the URL, return the pasted code. */
+  promptForCode: (url: string) => Promise<string>;
+  /** Status callback (stdout writes by default). */
+  log?: (line: string) => void;
+  /** Overrides for tests. */
+  urlTimeoutMs?: number;
+  credentialsTimeoutMs?: number;
+  pollMs?: number;
+  /** Test seam — skip the actual tmux spawn (the test injects a fake pane). */
+  spawnClaude?: () => void;
+  capturePane?: () => string;
+  sendKeys?: (keys: readonly string[], literal?: boolean) => void;
+}
+
+export interface ViaClaudeResult {
+  /** Path to the credentials.json claude wrote. */
+  credentialsPath: string;
+  /** Parsed credentials body (caller hands this to the broker). */
+  credentials: {
+    claudeAiOauth: {
+      accessToken: string;
+      refreshToken?: string;
+      expiresAt?: number;
+      scopes?: string[];
+      subscriptionType?: string;
+    };
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Drive claude through OAuth and return the credentials it wrote.
+ * Throws on timeout at any phase; the CLI catches and surfaces an
+ * actionable error.
+ */
+export async function runViaClaude(opts: ViaClaudeOptions): Promise<ViaClaudeResult> {
+  const log = opts.log ?? ((s) => process.stdout.write(s + "\n"));
+  const urlTimeout = opts.urlTimeoutMs ?? VIA_CLAUDE_DEFAULTS.urlTimeoutMs;
+  const credsTimeout = opts.credentialsTimeoutMs ?? VIA_CLAUDE_DEFAULTS.credentialsTimeoutMs;
+  const poll = opts.pollMs ?? VIA_CLAUDE_DEFAULTS.pollMs;
+
+  const configDir = resolve(opts.configDir);
+  mkdirSync(configDir, { recursive: true });
+  const credentialsPath = join(configDir, ".credentials.json");
+
+  const capture = opts.capturePane ?? (() => tmuxCapturePane(SESSION));
+  const send = opts.sendKeys ?? ((keys: readonly string[], literal?: boolean) =>
+    tmuxSendKeys(SESSION, keys, literal === true));
+
+  // Wipe any lingering session before we start — re-runs of the verb
+  // are common during onboarding (mistyped code, browser closed, etc.).
+  if (!opts.spawnClaude) {
+    if (tmuxHasSession(SESSION)) tmuxKillSession(SESSION);
+  }
+
+  const spawn = opts.spawnClaude ?? (() => {
+    // Detached tmux session with claude as its only command. We don't
+    // load any development channels here — we want the bare auth path
+    // and the smallest possible prompt sequence.
+    execFileSync(
+      "tmux",
+      [
+        "new-session",
+        "-d",
+        "-s",
+        SESSION,
+        "-x", "200",
+        "-y", "50",
+        "bash",
+        "-lc",
+        `CLAUDE_CONFIG_DIR=${quoteShell(configDir)} claude; echo EXITED; sleep 3600`,
+      ],
+      { stdio: "ignore", timeout: 5000 },
+    );
+  });
+
+  log("  Spawning claude in a tmux session to mint a broader-scope OAuth token…");
+  spawn();
+
+  try {
+    // Phase 1: dispatch the pre-paste prompts (theme, login method).
+    const preFired = new Set<string>();
+    const phase1Deadline = Date.now() + urlTimeout;
+    let url: string | null = null;
+    while (Date.now() < phase1Deadline) {
+      await sleep(poll);
+      const pane = capture();
+      for (const rule of PRE_PASTE_RULES) {
+        if (preFired.has(rule.name)) continue;
+        if (rule.match.test(pane)) {
+          preFired.add(rule.name);
+          send(rule.keys);
+        }
+      }
+      url = extractAuthorizeUrl(pane);
+      if (url) break;
+    }
+    if (!url) {
+      throw new Error(
+        `Timed out (${Math.round(urlTimeout / 1000)}s) waiting for claude to render the OAuth URL. ` +
+          `Re-run with --debug or attach to tmux session '${SESSION}' to see what happened.`,
+      );
+    }
+
+    log("  Open this URL in any browser and complete the OAuth flow:");
+    log("");
+    log("    " + url);
+    log("");
+
+    const code = (await opts.promptForCode(url)).trim();
+    if (!code) {
+      throw new Error("Empty code; aborting.");
+    }
+
+    // Send the code literally (-l), then Enter.
+    send([code], true);
+    send(["Enter"]);
+
+    // Phase 2: dispatch post-paste prompts (logged-in, security notes)
+    // and poll for the credentials file to appear.
+    const postFired = new Set<string>();
+    const phase2Deadline = Date.now() + credsTimeout;
+    log("  Waiting for credentials to land…");
+    while (Date.now() < phase2Deadline) {
+      await sleep(poll);
+      if (existsSync(credentialsPath)) {
+        // Read after a tiny settle to make sure claude's atomic write
+        // completed before we ingest.
+        await sleep(200);
+        const raw = readFileSync(credentialsPath, "utf-8");
+        let parsed: ViaClaudeResult["credentials"];
+        try {
+          parsed = JSON.parse(raw);
+        } catch (err) {
+          throw new Error(
+            `claude wrote credentials.json but it didn't parse: ${(err as Error).message}`,
+          );
+        }
+        if (typeof parsed.claudeAiOauth?.accessToken !== "string") {
+          throw new Error(
+            "credentials.json has no claudeAiOauth.accessToken — auth likely failed",
+          );
+        }
+        return { credentialsPath, credentials: parsed };
+      }
+      const pane = capture();
+      for (const rule of POST_PASTE_RULES) {
+        if (postFired.has(rule.name)) continue;
+        if (rule.match.test(pane)) {
+          postFired.add(rule.name);
+          send(rule.keys);
+        }
+      }
+    }
+
+    throw new Error(
+      `Timed out (${Math.round(credsTimeout / 1000)}s) waiting for claude to write ` +
+        `${credentialsPath}. Check the OAuth code was correct, or attach to tmux ` +
+        `session '${SESSION}' to see the failure.`,
+    );
+  } finally {
+    if (!opts.spawnClaude) {
+      tmuxKillSession(SESSION);
+    }
+  }
+}
+
+/** Shell-quote a single argument for embedding in a bash -lc string. */
+function quoteShell(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -7,7 +7,7 @@
  * refresh-accounts / status / account add / account list / account rm`)
  * into a small accounts-and-fleet surface:
  *
- *   auth add <label> --from-agent | --from-credentials | --from-oauth
+ *   auth add <label> --from-agent | --from-credentials | --from-oauth | --via-claude
  *   auth list
  *   auth use <label>            — set fleet active
  *   auth rotate                 — cycle to next non-exhausted entry
@@ -343,7 +343,10 @@ function loadCredentialsFromGlobalAccount(label: string): AddAccountCredentials 
     console.error(
       chalk.red(
         `  No credentials found at ${accountCredentialsPath(label)}.\n` +
-          `  Run 'claude setup-token' first to populate them.`,
+          `  For a first-time setup, use \`switchroom auth add ${label} --via-claude\`\n` +
+          `  (drives claude through its native OAuth flow to mint a broader-scope token\n` +
+          `  that works with agents running in claude server: mode). \`claude setup-token\`\n` +
+          `  mints scope=user:inference only, which is rejected by server: mode at boot.`,
       ),
     );
     process.exit(1);
@@ -356,6 +359,58 @@ function loadCredentialsFromGlobalAccount(label: string): AddAccountCredentials 
       scopes: creds.claudeAiOauth.scopes,
       subscriptionType: creds.claudeAiOauth.subscriptionType,
       rateLimitTier: creds.claudeAiOauth.rateLimitTier,
+    },
+  };
+}
+
+/**
+ * `--via-claude` entry point. Spawns claude in a tmux session, surfaces
+ * the OAuth URL claude itself emits (which requests the broader scope
+ * set that server: mode needs), prompts the operator for the pasted
+ * code, waits for credentials.json to land, returns it.
+ *
+ * Lazy-imports the via-claude module so the more common
+ * --from-credentials / --from-agent paths don't pay the file-watch +
+ * tmux-helper import cost. Mirrors the `auth-google` pattern (Phase
+ * 3b.3 of RFC G) of lazy-importing OAuth heavy modules.
+ *
+ * Install-validation finding #38.
+ */
+async function loadCredentialsViaClaude(label: string): Promise<AddAccountCredentials> {
+  const [{ runViaClaude }, { homedir }, { default: readline }] = await Promise.all([
+    import("../auth/via-claude.js"),
+    import("node:os"),
+    import("node:readline"),
+  ]);
+  const configDir = join(homedir(), ".switchroom", "accounts", label);
+
+  const result = await runViaClaude({
+    configDir,
+    promptForCode: async (_url) => {
+      // We surface the URL inside runViaClaude (via its log callback).
+      // Block here on stdin for the operator's paste.
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+      try {
+        return await new Promise<string>((resolve) => {
+          rl.question("  Paste the code Claude shows you: ", (answer) => resolve(answer));
+        });
+      } finally {
+        rl.close();
+      }
+    },
+  });
+
+  const oauth = result.credentials.claudeAiOauth;
+  return {
+    claudeAiOauth: {
+      accessToken: oauth.accessToken,
+      refreshToken: oauth.refreshToken,
+      expiresAt: oauth.expiresAt,
+      scopes: oauth.scopes,
+      subscriptionType: oauth.subscriptionType,
     },
   };
 }
@@ -440,7 +495,11 @@ export function registerAuthCommand(program: Command): void {
     .option("--from-credentials <path>", "Seed from a credentials.json file")
     .option(
       "--from-oauth",
-      "Seed from a freshly-completed OAuth flow's credentials at ~/.switchroom/accounts/<label>/credentials.json",
+      "Seed from a freshly-completed `claude setup-token` flow at ~/.switchroom/accounts/<label>/credentials.json. NOTE: setup-token mints scope=user:inference only; the token won't work for agents running in claude server: mode. Prefer --via-claude for first-time setup.",
+    )
+    .option(
+      "--via-claude",
+      "Drive `claude` interactively in a tmux session to mint a broader-scope OAuth token (recommended for first-time setup). Spawns claude, surfaces the OAuth URL, accepts your pasted code, ingests the resulting credentials.json. See src/auth/via-claude.ts.",
     )
     .option("--replace", "Overwrite an existing account (drift recovery)")
     .action(
@@ -451,15 +510,20 @@ export function registerAuthCommand(program: Command): void {
             fromAgent?: string;
             fromCredentials?: string;
             fromOauth?: boolean;
+            viaClaude?: boolean;
             replace?: boolean;
           },
         ) => {
-          const sources = [opts.fromAgent, opts.fromCredentials, opts.fromOauth]
-            .filter((v) => v !== undefined && v !== false).length;
+          const sources = [
+            opts.fromAgent,
+            opts.fromCredentials,
+            opts.fromOauth,
+            opts.viaClaude,
+          ].filter((v) => v !== undefined && v !== false).length;
           if (sources !== 1) {
             console.error(
               chalk.red(
-                "  Pass exactly one of --from-agent, --from-credentials, --from-oauth.",
+                "  Pass exactly one of --from-agent, --from-credentials, --from-oauth, --via-claude.",
               ),
             );
             process.exit(2);
@@ -468,6 +532,7 @@ export function registerAuthCommand(program: Command): void {
           if (opts.fromAgent) credentials = loadCredentialsFromAgent(opts.fromAgent);
           else if (opts.fromCredentials)
             credentials = loadCredentialsFromFile(opts.fromCredentials);
+          else if (opts.viaClaude) credentials = await loadCredentialsViaClaude(label);
           else credentials = loadCredentialsFromGlobalAccount(label);
 
           const data = await brokerCall((client) =>
@@ -476,6 +541,11 @@ export function registerAuthCommand(program: Command): void {
           console.log(chalk.green(`  Added "${data.label}" to the broker.`));
           if (typeof data.expiresAt === "number") {
             console.log(chalk.gray(`  Token expires: ${formatExpiry(data.expiresAt)}`));
+          }
+          if (opts.viaClaude) {
+            console.log();
+            console.log(chalk.gray("  Next: enable on the fleet"));
+            console.log(chalk.cyan(`    switchroom auth use ${data.label}`));
           }
         },
       ),


### PR DESCRIPTION
## Summary

Install-validation finding #38. RFC H's \`auth add --from-oauth\` runs \`claude setup-token\` under the hood, which mints \`scope=user:inference\` only. That token works for one-shot \`claude --print\` but \`claude --dangerously-load-development-channels server:...\` (the mode every switchroom agent runs in) refuses it at boot and falls back to the "Select login method" TUI picker. On a clean install, the documented first-time auth flow produces a token claude won't use.

This PR adds \`--via-claude\` — a fourth source flag on \`switchroom auth add\` — that drives \`claude\` through its native interactive OAuth (which natively requests the broader scope set \`server:\` mode requires) and ingests the resulting \`.credentials.json\` into the auth-broker via the existing \`client.addAccount\` RPC.

**No new OAuth code in switchroom.** The code-for-token exchange happens inside claude. We delegate to claude's already-correct flow.

## How it works

1. Spawn \`claude\` in a detached tmux session with \`CLAUDE_CONFIG_DIR=~/.switchroom/accounts/<label>\`.
2. Dispatch Enter on theme picker → Enter on login method picker → claude renders the broader-scope OAuth URL.
3. Capture URL, surface to operator, accept code paste.
4. Forward code into the tmux pane.
5. Dispatch Enter on post-paste prompts (logged-in, security notes).
6. Poll for \`<configDir>/.credentials.json\` to appear (60s budget).
7. Parse + hand to broker via \`client.addAccount\`.
8. Tear down tmux.

## Design contract

- **Vision — subscription-honest**: uses claude's native OAuth, no new endpoints.
- **Principle 1 ("if they need the docs, we've failed")**: one CLI command, one OAuth code paste; operator never reads about scopes or credentials.json shape.
- **Principle 2 ("batteries included")**: \`--via-claude\` recommended as first-time path in CLI help and docs/auth.md.
- **Principle 3 (consistency)**: mirrors \`auth google account add\` (#1274, RFC G Phase 3b.3) which already does in-CLI OAuth + broker register for Google. Same shape, different provider.
- **JTBD \`share-auth-across-the-fleet.md\` Decision 12**: "first-time user runs \`switchroom setup\`, picks an agent, and is taken through one OAuth flow" — this PR makes that one flow actually produce a usable token.

## Out of scope (tracked follow-ups)

- Wiring \`--via-claude\` into the \`switchroom setup\` wizard's first-time-auth step. This PR just lands the CLI primitive; the wizard hook-in is a small follow-up.
- Discovering Anthropic's OAuth token endpoint to skip the tmux dance entirely. Possible but not needed — claude's flow is correct.

## Touched

- New: \`src/auth/via-claude.ts\` (~270 LOC) — tmux-drive + pane-parse + file-watch primitive. Test seams for spawn/capture/send/log so the test harness doesn't touch real tmux.
- New: \`src/auth/via-claude.test.ts\` — 10 tests covering URL extraction (real-pane fixtures), pre/post-paste rule shapes, full mocked flow, empty-code rejection, URL-timeout.
- \`src/cli/auth.ts\` — adds \`--via-claude\` flag, \`loadCredentialsViaClaude()\` lazy-imports the heavy module, four-source exclusivity check. \`loadCredentialsFromGlobalAccount\`'s error redirects to \`--via-claude\` for first-time setup.
- \`src/agents/scaffold.ts\` — updates the credentials-ownership comment to reflect RFC H and point at \`--via-claude\` (closes a non-blocking reviewer nit from #1283).
- \`docs/auth.md\` — \`--via-claude\` shown first; \`--from-oauth\` kept with a narrow-scope caveat.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`node scripts/check-plugin-references.mjs\` clean
- [x] \`vitest run src/auth/via-claude.test.ts\` — 10/10
- [x] \`switchroom auth add --help\` shows the new flag with rationale
- [ ] End-to-end on a clean VM: \`auth add me --via-claude\` → one code paste → \`auth use me\` → agent replies in Telegram. Pending VM reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)