### PR TITLE
feat(drive): RFC E §4.2 — `doc:gdrive:suggest:*` scope namespace

### DIFF
--- a/src/drive/grants.test.ts
+++ b/src/drive/grants.test.ts
@@ -1,13 +1,24 @@
 /**
- * Drive grants — write-namespace separation tests (RFC C §12).
+ * Drive grants — namespace separation + implication tests.
+ *
+ * Covers RFC D §12 (read/write isolation) and RFC E §4.2 (suggest
+ * namespace + `write → suggest` implication).
  */
 
 import { describe, expect, it } from "bun:test";
-import { scopeFor, canFulfill, prefixMatches } from "./grants.js";
+import {
+  scopeFor,
+  canFulfill,
+  prefixMatches,
+  scopeNamespace,
+} from "./grants.js";
 
 describe("scopeFor", () => {
   it("read all → doc:gdrive:**", () => {
     expect(scopeFor({ kind: "all" }, "read")).toBe("doc:gdrive:**");
+  });
+  it("suggest all → doc:gdrive:suggest:**", () => {
+    expect(scopeFor({ kind: "all" }, "suggest")).toBe("doc:gdrive:suggest:**");
   });
   it("write all → doc:gdrive:write:**", () => {
     expect(scopeFor({ kind: "all" }, "write")).toBe("doc:gdrive:write:**");
@@ -15,6 +26,11 @@ describe("scopeFor", () => {
   it("read folder", () => {
     expect(scopeFor({ kind: "folder", folder_id: "F1" }, "read")).toBe(
       "doc:gdrive:folder/F1/**",
+    );
+  });
+  it("suggest folder", () => {
+    expect(scopeFor({ kind: "folder", folder_id: "F1" }, "suggest")).toBe(
+      "doc:gdrive:suggest:folder/F1/**",
     );
   });
   it("write folder", () => {
@@ -27,6 +43,11 @@ describe("scopeFor", () => {
       "doc:gdrive:D1",
     );
   });
+  it("suggest doc", () => {
+    expect(scopeFor({ kind: "doc", doc_id: "D1" }, "suggest")).toBe(
+      "doc:gdrive:suggest:D1",
+    );
+  });
   it("write doc", () => {
     expect(scopeFor({ kind: "doc", doc_id: "D1" }, "write")).toBe(
       "doc:gdrive:write:D1",
@@ -34,8 +55,26 @@ describe("scopeFor", () => {
   });
 });
 
-describe("canFulfill — write isolation (the load-bearing rule)", () => {
-  it("read grant CANNOT fulfill a write request, even on the same doc id", () => {
+describe("scopeNamespace", () => {
+  it("classifies read", () => {
+    expect(scopeNamespace("doc:gdrive:**")).toBe("read");
+    expect(scopeNamespace("doc:gdrive:folder/F/**")).toBe("read");
+    expect(scopeNamespace("doc:gdrive:D1")).toBe("read");
+  });
+  it("classifies suggest", () => {
+    expect(scopeNamespace("doc:gdrive:suggest:**")).toBe("suggest");
+    expect(scopeNamespace("doc:gdrive:suggest:folder/F/**")).toBe("suggest");
+    expect(scopeNamespace("doc:gdrive:suggest:D1")).toBe("suggest");
+  });
+  it("classifies write", () => {
+    expect(scopeNamespace("doc:gdrive:write:**")).toBe("write");
+    expect(scopeNamespace("doc:gdrive:write:folder/F/**")).toBe("write");
+    expect(scopeNamespace("doc:gdrive:write:D1")).toBe("write");
+  });
+});
+
+describe("canFulfill — read/write isolation (RFC D §12)", () => {
+  it("read grant CANNOT fulfil a write request, even on the same doc id", () => {
     expect(
       canFulfill({
         decisionScope: "doc:gdrive:D1",
@@ -46,7 +85,7 @@ describe("canFulfill — write isolation (the load-bearing rule)", () => {
     ).toBe(false);
   });
 
-  it("read grant on doc:gdrive:** CANNOT fulfill a write request", () => {
+  it("read grant on doc:gdrive:** CANNOT fulfil a write request", () => {
     expect(
       canFulfill({
         decisionScope: "doc:gdrive:**",
@@ -57,7 +96,7 @@ describe("canFulfill — write isolation (the load-bearing rule)", () => {
     ).toBe(false);
   });
 
-  it("write grant CAN fulfill a write request on a covered doc", () => {
+  it("write grant CAN fulfil a write request on a covered doc", () => {
     expect(
       canFulfill({
         decisionScope: "doc:gdrive:write:**",
@@ -68,7 +107,7 @@ describe("canFulfill — write isolation (the load-bearing rule)", () => {
     ).toBe(true);
   });
 
-  it("read grant fulfills a read request via prefix match", () => {
+  it("read grant fulfils a read request via prefix match", () => {
     expect(
       canFulfill({
         decisionScope: "doc:gdrive:folder/F1/**",
@@ -79,7 +118,7 @@ describe("canFulfill — write isolation (the load-bearing rule)", () => {
     ).toBe(true);
   });
 
-  it("action mismatch (read decision, write request) is rejected even when scope matches", () => {
+  it("action mismatch (write decision, read request) rejected even on identical scope-string", () => {
     expect(
       canFulfill({
         decisionScope: "doc:gdrive:write:D1",
@@ -88,6 +127,96 @@ describe("canFulfill — write isolation (the load-bearing rule)", () => {
         requestedAction: "read",
       }),
     ).toBe(false);
+  });
+});
+
+describe("canFulfill — suggest namespace + implication (RFC E §4.2)", () => {
+  it("suggest grant CAN fulfil a suggest request on the same doc", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:suggest:D1",
+        decisionAction: "suggest",
+        requestedScope: "doc:gdrive:suggest:D1",
+        requestedAction: "suggest",
+      }),
+    ).toBe(true);
+  });
+
+  it("suggest grant on a folder CAN fulfil a suggest request on a child doc", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:suggest:folder/F1/**",
+        decisionAction: "suggest",
+        requestedScope: "doc:gdrive:suggest:folder/F1/sub/D1",
+        requestedAction: "suggest",
+      }),
+    ).toBe(true);
+  });
+
+  it("suggest grant CANNOT fulfil a write request (suggest does not imply write)", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:suggest:D1",
+        decisionAction: "suggest",
+        requestedScope: "doc:gdrive:write:D1",
+        requestedAction: "write",
+      }),
+    ).toBe(false);
+  });
+
+  it("write grant CAN fulfil a suggest request on the same doc (write implies suggest)", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:write:D1",
+        decisionAction: "write",
+        requestedScope: "doc:gdrive:suggest:D1",
+        requestedAction: "suggest",
+      }),
+    ).toBe(true);
+  });
+
+  it("write grant on a folder CAN fulfil a suggest request on a child doc", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:write:folder/F1/**",
+        decisionAction: "write",
+        requestedScope: "doc:gdrive:suggest:folder/F1/sub/D1",
+        requestedAction: "suggest",
+      }),
+    ).toBe(true);
+  });
+
+  it("write grant on a different folder does NOT fulfil a suggest on an unrelated doc", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:write:folder/F1/**",
+        decisionAction: "write",
+        requestedScope: "doc:gdrive:suggest:folder/F2/D1",
+        requestedAction: "suggest",
+      }),
+    ).toBe(false);
+  });
+
+  it("read grant CANNOT fulfil a suggest request (read does not cross into mutation)", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:**",
+        decisionAction: "read",
+        requestedScope: "doc:gdrive:suggest:D1",
+        requestedAction: "suggest",
+      }),
+    ).toBe(false);
+  });
+
+  it("write-all grant CAN fulfil any suggest request", () => {
+    expect(
+      canFulfill({
+        decisionScope: "doc:gdrive:write:**",
+        decisionAction: "write",
+        requestedScope: "doc:gdrive:suggest:D1",
+        requestedAction: "suggest",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/src/drive/grants.ts
+++ b/src/drive/grants.ts
@@ -1,24 +1,44 @@
 /**
- * Drive grants — scope shapes + write-namespace separation per RFC C §12.
+ * Drive grants — scope shapes + namespace separation per RFC D §12 and RFC E §4.2.
  *
- * Read scopes:
- *   doc:gdrive:**                  whole-Drive read (default onboarding pick)
- *   doc:gdrive:folder/<id>/**      folder + descendants
- *   doc:gdrive:<id>                single doc
+ * Three action namespaces:
  *
- * Write scopes (separate namespace — a read grant NEVER fulfills a write):
- *   doc:gdrive:write:**
- *   doc:gdrive:write:folder/<id>/**
- *   doc:gdrive:write:<id>
+ *   read     (default; non-mutating)
+ *     doc:gdrive:**                  whole-Drive read
+ *     doc:gdrive:folder/<id>/**      folder + descendants
+ *     doc:gdrive:<id>                single doc
+ *
+ *   suggest  (non-destructive proposal — RFC E §4.2, lands as a Drive Suggestion)
+ *     doc:gdrive:suggest:**
+ *     doc:gdrive:suggest:folder/<id>/**
+ *     doc:gdrive:suggest:<id>
+ *
+ *   write    (direct mutation — RFC D §12, RFC E §4.2)
+ *     doc:gdrive:write:**
+ *     doc:gdrive:write:folder/<id>/**
+ *     doc:gdrive:write:<id>
+ *
+ * Implication rules (RFC E §4.2):
+ *   - A `write` grant implies `suggest` on the same target. The user
+ *     authorised something stronger; honouring a non-destructive proposal
+ *     under the same authorisation is strictly less privileged.
+ *   - A `suggest` grant does NOT imply `write`. The whole point of
+ *     Suggesting mode is that the user reviews each change in Drive
+ *     before it lands; a standing direct-write authorisation is a
+ *     materially different decision.
+ *   - Read does not cross into either mutation namespace, and neither
+ *     mutation namespace fulfils a read request (mutation grants are
+ *     scope-distinct so the kernel's prefix matcher already rejects).
  *
  * The kernel's scope-prefix matching (RFC B) handles the `**` glob. This
- * module provides `scopeForRead/Write()` builders, `actionGrammar()` to map
- * an operation to the action keyword stored on the decision row, and
- * `canFulfill()` to assert at lookup time that a candidate decision actually
- * authorizes the requested action.
+ * module provides `scopeFor()` to build the kernel `scope` string for a
+ * target + action, `actionGrammar()` to map an operation to the action
+ * keyword stored on the decision row, and `canFulfill()` to assert at
+ * lookup time that a candidate decision actually authorises the
+ * requested action — including the `write → suggest` implication.
  */
 
-export type DriveAction = "read" | "write";
+export type DriveAction = "read" | "suggest" | "write";
 
 export type DriveTarget =
   | { kind: "all" }
@@ -27,14 +47,14 @@ export type DriveTarget =
 
 /** Build the kernel `scope` string for a given target + action. */
 export function scopeFor(target: DriveTarget, action: DriveAction): string {
-  const writePrefix = action === "write" ? "write:" : "";
+  const actionPrefix = action === "read" ? "" : `${action}:`;
   switch (target.kind) {
     case "all":
-      return `doc:gdrive:${writePrefix}**`;
+      return `doc:gdrive:${actionPrefix}**`;
     case "folder":
-      return `doc:gdrive:${writePrefix}folder/${target.folder_id}/**`;
+      return `doc:gdrive:${actionPrefix}folder/${target.folder_id}/**`;
     case "doc":
-      return `doc:gdrive:${writePrefix}${target.doc_id}`;
+      return `doc:gdrive:${actionPrefix}${target.doc_id}`;
   }
 }
 
@@ -45,14 +65,10 @@ export function actionGrammar(action: DriveAction): string {
 
 /**
  * Predicate: can a decision recorded for `decisionScope` (with its stored
- * `action_grammar`) fulfill an incoming request for `requestedScope` +
+ * `action_grammar`) fulfil an incoming request for `requestedScope` +
  * `requestedAction`?
  *
- * Hard constraint per §12: read grants do NOT fulfill write requests, even
- * when the doc/folder id matches. This is enforced here regardless of what
- * the kernel's scope-prefix matcher might say — the write namespace prefix
- * (`doc:gdrive:write:`) is structurally distinct so the kernel matcher
- * already rejects, but we double-check by looking at the action_grammar.
+ * Enforces the namespace + implication rules in the module header.
  */
 export function canFulfill(args: {
   decisionScope: string;
@@ -60,18 +76,42 @@ export function canFulfill(args: {
   requestedScope: string;
   requestedAction: DriveAction;
 }): boolean {
-  // Action mismatch — always reject.
-  if (args.decisionAction !== args.requestedAction) return false;
+  // Action implication. Same-action always allowed (subject to scope check
+  // below). The single cross-action allowance is `write` decision → `suggest`
+  // request; nothing else crosses.
+  const sameAction = args.decisionAction === args.requestedAction;
+  const writeFulfilsSuggest =
+    args.decisionAction === "write" && args.requestedAction === "suggest";
+  if (!sameAction && !writeFulfilsSuggest) return false;
 
-  // Both scopes must live in the SAME namespace (read vs write). A read
-  // scope cannot match a write request even if the kernel's prefix matcher
-  // is loosened in future.
-  const decisionIsWrite = args.decisionScope.startsWith("doc:gdrive:write:");
-  const requestedIsWrite = args.requestedScope.startsWith("doc:gdrive:write:");
-  if (decisionIsWrite !== requestedIsWrite) return false;
+  const decisionNs = scopeNamespace(args.decisionScope);
+  const requestedNs = scopeNamespace(args.requestedScope);
 
-  // Prefix match (handles `**` globs the kernel stores literally).
-  return prefixMatches(args.decisionScope, args.requestedScope);
+  // Same namespace: ordinary prefix match.
+  if (decisionNs === requestedNs) {
+    return prefixMatches(args.decisionScope, args.requestedScope);
+  }
+
+  // Cross-namespace only allowed when write fulfils suggest. Rewrite the
+  // request into the write namespace and prefix-match against the decision.
+  if (writeFulfilsSuggest && decisionNs === "write" && requestedNs === "suggest") {
+    const rewritten = args.requestedScope.replace(
+      /^doc:gdrive:suggest:/,
+      "doc:gdrive:write:",
+    );
+    return prefixMatches(args.decisionScope, rewritten);
+  }
+
+  return false;
+}
+
+export type DriveNamespace = "read" | "suggest" | "write";
+
+/** Classify a scope string by its action namespace. */
+export function scopeNamespace(scope: string): DriveNamespace {
+  if (scope.startsWith("doc:gdrive:write:")) return "write";
+  if (scope.startsWith("doc:gdrive:suggest:")) return "suggest";
+  return "read";
 }
 
 /**
@@ -81,8 +121,8 @@ export function canFulfill(args: {
  *   exact strings match themselves.
  *
  * The real kernel matcher is more elaborate; here we only need enough to
- * correctly answer "does this decision authorize this request" for unit
- * tests of the write-isolation rule.
+ * correctly answer "does this decision authorise this request" for unit
+ * tests of the namespace + implication rules.
  */
 export function prefixMatches(decisionScope: string, requestedScope: string): boolean {
   if (decisionScope === requestedScope) return true;


### PR DESCRIPTION
## Summary

RFC E §4.2 — adds the third action namespace to `src/drive/grants.ts`. With this kernel-side primitive in place, the next two PRs (B2 — MCP wrapper tools, B3 — diff-preview approval card) have a scope to authorise against.

## Implication contract (RFC E §4.2)

| decision \ request | read | suggest | write |
|---|---|---|---|
| **read**    | ✅ (prefix) | ❌ | ❌ |
| **suggest** | ❌ | ✅ (prefix) | ❌ |
| **write**   | ❌ | ✅ (prefix, write→suggest implication) | ✅ (prefix) |

`write` grants imply `suggest` because under the same authorisation the non-destructive proposal is strictly less privileged. `suggest` does NOT imply `write` because the whole point of Suggesting mode is per-change review in Drive's UI — a standing direct-write authorisation is a materially different decision.

Implemented via a namespace-rewrite in `canFulfill`: if `decision=write` + `request=suggest`, rewrite `doc:gdrive:suggest:<target>` → `doc:gdrive:write:<target>` and prefix-match against the decision.

## What ships

- `DriveAction = "read" | "suggest" | "write"` (was read/write)
- `scopeFor()` extended — `suggest:` prefix for the suggest namespace
- `scopeNamespace()` new export — used by `canFulfill` (and by callers in PR B3)
- `canFulfill()` extended with the `write → suggest` implication
- Tests grew from 11 → 28 cases — added namespace classification + all 4 implication directions + cross-folder negatives

## Test plan

- [x] `bun test src/drive/grants.test.ts` — 28 pass
- [x] `bun test src/drive/` — 197 pass (no callsite regressions from `DriveAction` widening)
- [x] `bun run lint` — clean
- [ ] Independent reviewer verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)