### PR TITLE
fix(telegram-plugin): drain silence-poke state on flush-backstop turn-end (#1289)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5144,6 +5144,21 @@ function handleSessionEvent(ev: SessionEvent): void {
         // backup; reset the preamble buffer (its content is already in
         // the captured `capturedText`, which turn-flush is about to send).
         preambleSuppressor.dropNow()
+        // #1289 fix — drain silence-poke + signal-tracker state for this
+        // turn. The three sibling turn_end exit branches (context-exhaust
+        // at ~5098, silent-marker at ~5097-5098, default reply-called tail
+        // at ~5348-5349) all call signalTracker.clear + silencePoke.endTurn.
+        // The flush-backstop branch was retrofitted in #1067 to null
+        // currentTurn early but never had this cleanup added — leaving the
+        // silence-poke state in the Map, so 300s after the original turn
+        // start the framework fallback fires and the user sees
+        // "still working… (no update from agent in 5 min)" on a turn the
+        // gateway already considers over.
+        {
+          const tKey = statusKey(chatId, threadId)
+          signalTracker.clear(tKey)
+          silencePoke.endTurn(tKey)
+        }
 
         void (async () => {
           await new Promise<void>(resolve => setTimeout(resolve, 500))

--- a/telegram-plugin/tests/silence-poke.test.ts
+++ b/telegram-plugin/tests/silence-poke.test.ts
@@ -309,6 +309,35 @@ describe('silence-poke — abnormal turn-end invariants (CC-5 follow-up)', () =>
     ).toHaveLength(1) // unchanged: only the original soft
     expect(fx.fallbacks).toHaveLength(0)
   })
+
+  // #1289: the flush-backstop turn-end branch in the gateway (the path
+  // taken when the agent emits assistant text but never calls the reply
+  // tool) was retrofitted in #1067 to null `currentTurn` early but never
+  // had `silencePoke.endTurn` added — leaving state2 populated so the
+  // 300s framework fallback fired after the gateway already flushed the
+  // captured prose and considered the turn over. Pin the contract at
+  // the silence-poke level: a turn that records an outbound (the
+  // flushed message) and then calls endTurn must not later fire a
+  // fallback even if 300s elapses from the original turn start.
+  it('#1289: flush-backstop turn-end (outbound + endTurn) suppresses the 300s fallback', () => {
+    const fx = setupDeps()
+    startTurn('k', 0)
+    // Some time passes while the agent generates prose without calling
+    // the reply tool. No soft/firm armed yet.
+    __tickForTests(60_000)
+    // Gateway turn-flush fires: captured text is sent as an outbound,
+    // then the flush branch nulls currentTurn AND (post-fix) calls
+    // signalTracker.clear + silencePoke.endTurn.
+    noteOutbound('k', 60_000)
+    endTurn('k')
+    // 300s elapses from the original turn start. Pre-fix: the framework
+    // fallback fired here. Post-fix: the state is drained, no fallback.
+    __tickForTests(240_000)
+    expect(fx.fallbacks).toHaveLength(0)
+    expect(
+      fx.emitted.filter((e) => e.kind === 'silence_fallback_sent'),
+    ).toHaveLength(0)
+  })
 })
 
 describe('silence-poke — consumeArmedPoke draining', () => {


### PR DESCRIPTION
## Summary

Closes #1289.

The telegram-plugin gateway's `silence-poke` was firing `still working… (no update from agent in 5 min)` after turns that had already ended cleanly. Log signature:

```
telegram gateway: silence-poke framework-fallback ended wedged turn
chat=... silence_ms=302468 currentTurn_nulled=false
```

### Root cause

`silence-poke` keeps its own state map (`state2` in `silence-poke.ts`), populated by `startTurn` on inbound and drained by `endTurn`. The wedge detector iterates that map directly — it never consults `currentTurn`. So a stuck entry in `state2` alone is sufficient to fire the 300s fallback.

`gateway.ts`'s `turn_end` handler has four exit branches. Three call `silencePoke.endTurn(tKey)`. One didn't:

| Branch | Nulls `currentTurn` | Calls `silencePoke.endTurn` |
|---|---|---|
| context-exhaust (within `assistant_text`) | ✅ | ✅ |
| silent-marker skip | ✅ | ✅ |
| **flush-backstop** | ✅ (added in #1067) | ❌ |
| reply-called default tail | ✅ | ✅ |

The flush-backstop fires when an agent emits assistant text without calling the `reply` tool. It was retrofitted in #1067 to null `currentTurn` early (re-entry race) but never had silence-poke cleanup. The `state2` entry leaked; 300s later the framework fallback fired; `currentTurn` had since been nulled, so the diagnostic log recorded `currentTurn_nulled=false` (misleading field name — really means "the wedged turn isn't the current turn anymore").

### Fix

In `telegram-plugin/gateway/gateway.ts`, inside the `flushDecision.kind === 'flush'` branch, immediately after the existing `preambleSuppressor.dropNow()`:

```ts
{
  const tKey = statusKey(chatId, threadId)
  signalTracker.clear(tKey)
  silencePoke.endTurn(tKey)
}
```

Matches the sibling branches' cleanup exactly. One-line behavioral change.

### Test

New case in `telegram-plugin/tests/silence-poke.test.ts` under the existing "abnormal turn-end invariants (CC-5 follow-up)" describe block, pinning the flush scenario: outbound recorded + `endTurn` called → no fallback at 300s.

## Test plan

- [x] `bun test tests/silence-poke.test.ts` — 36 pass (was 35, +1 new)
- [ ] Manual: send an inbound that causes the agent to emit prose without calling `reply`, wait 6 minutes, verify no silence-poke
- [ ] Verify the existing CC-5 abnormal-turn-end tests still pass

## Related

- #1067 — added the early `currentTurn = null` in this branch; introduced the silence-poke leak by reordering without adding `endTurn`
- #654 — deterministic double-message fix (same branch, different cleanup)
- Comment at `gateway.ts:4899` already warned about omitted `silencePoke.endTurn` causing stale state — the context-exhaust author hit this exact class of bug; the flush branch was never retrofitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)