### PR TITLE
feat(drive): RFC E §4.3 — Open-in-Drive button on granted approval cards

### DIFF
--- a/src/drive/deep-links.test.ts
+++ b/src/drive/deep-links.test.ts
@@ -6,17 +6,21 @@ import { describe, expect, it } from "vitest";
 
 import {
   classifyMimeType,
+  myDriveButton,
   openInDriveButton,
   openInDriveUrl,
+  parseDriveScope,
+  scopeToOpenInDriveButton,
 } from "./deep-links.js";
 
 describe("classifyMimeType", () => {
-  it("classifies the four core Workspace mime types", () => {
+  it("classifies the core Workspace mime types", () => {
     expect(classifyMimeType("application/vnd.google-apps.document")).toBe("doc");
     expect(classifyMimeType("application/vnd.google-apps.spreadsheet")).toBe("spreadsheet");
     expect(classifyMimeType("application/vnd.google-apps.presentation")).toBe("presentation");
     expect(classifyMimeType("application/vnd.google-apps.form")).toBe("form");
     expect(classifyMimeType("application/vnd.google-apps.drawing")).toBe("drawing");
+    expect(classifyMimeType("application/vnd.google-apps.folder")).toBe("folder");
   });
 
   it("falls back to 'file' for non-Workspace mime types", () => {
@@ -119,6 +123,171 @@ describe("openInDriveButton", () => {
     expect(btn).toEqual({
       text: "📖 Open in Drive",
       url: "https://docs.google.com/document/d/1abc/edit",
+    });
+  });
+
+  it("builds the canonical folder URL when isFolder is set", () => {
+    expect(openInDriveUrl({ fileId: "F1", isFolder: true })).toBe(
+      "https://drive.google.com/drive/folders/F1",
+    );
+  });
+
+  it("isFolder overrides the mimeType-derived kind", () => {
+    expect(
+      openInDriveUrl({
+        fileId: "F1",
+        isFolder: true,
+        mimeType: "application/vnd.google-apps.document",
+      }),
+    ).toBe("https://drive.google.com/drive/folders/F1");
+  });
+
+  it("folder mimeType also yields the folder URL", () => {
+    expect(
+      openInDriveUrl({
+        fileId: "F1",
+        mimeType: "application/vnd.google-apps.folder",
+      }),
+    ).toBe("https://drive.google.com/drive/folders/F1");
+  });
+});
+
+describe("parseDriveScope", () => {
+  it("returns null for non-Drive scopes", () => {
+    expect(parseDriveScope("secret:OPENAI_API_KEY")).toBeNull();
+    expect(parseDriveScope("system:reconnect:gdrive")).toBeNull();
+    expect(parseDriveScope("")).toBeNull();
+  });
+
+  it("parses the read namespace shapes", () => {
+    expect(parseDriveScope("doc:gdrive:**")).toEqual({
+      action: "read",
+      target: { kind: "all" },
+    });
+    expect(parseDriveScope("doc:gdrive:folder/F1/**")).toEqual({
+      action: "read",
+      target: { kind: "folder", folder_id: "F1" },
+    });
+    expect(parseDriveScope("doc:gdrive:D1")).toEqual({
+      action: "read",
+      target: { kind: "doc", doc_id: "D1" },
+    });
+  });
+
+  it("parses the suggest namespace shapes", () => {
+    expect(parseDriveScope("doc:gdrive:suggest:**")).toEqual({
+      action: "suggest",
+      target: { kind: "all" },
+    });
+    expect(parseDriveScope("doc:gdrive:suggest:folder/F1/**")).toEqual({
+      action: "suggest",
+      target: { kind: "folder", folder_id: "F1" },
+    });
+    expect(parseDriveScope("doc:gdrive:suggest:D1")).toEqual({
+      action: "suggest",
+      target: { kind: "doc", doc_id: "D1" },
+    });
+  });
+
+  it("parses the write namespace shapes", () => {
+    expect(parseDriveScope("doc:gdrive:write:**")).toEqual({
+      action: "write",
+      target: { kind: "all" },
+    });
+    expect(parseDriveScope("doc:gdrive:write:folder/F1/**")).toEqual({
+      action: "write",
+      target: { kind: "folder", folder_id: "F1" },
+    });
+    expect(parseDriveScope("doc:gdrive:write:D1")).toEqual({
+      action: "write",
+      target: { kind: "doc", doc_id: "D1" },
+    });
+  });
+
+  it("rejects malformed folder ids (URL-injection guard)", () => {
+    // A folder id containing a slash would let a crafted scope smuggle
+    // a path into the inline-keyboard URL — same rule as validateDriveId.
+    expect(parseDriveScope("doc:gdrive:folder/abc/def/**")).toBeNull();
+    expect(parseDriveScope("doc:gdrive:folder//**")).toBeNull();
+    expect(parseDriveScope("doc:gdrive:folder/F?evil=1/**")).toBeNull();
+  });
+
+  it("rejects malformed doc ids", () => {
+    expect(parseDriveScope("doc:gdrive:abc/def")).toBeNull();
+    expect(parseDriveScope("doc:gdrive:abc?evil=1")).toBeNull();
+    expect(parseDriveScope("doc:gdrive:abc#frag")).toBeNull();
+  });
+
+  it("rejects an unterminated folder scope (no /**)", () => {
+    expect(parseDriveScope("doc:gdrive:folder/F1")).toBeNull();
+    expect(parseDriveScope("doc:gdrive:folder/F1/*")).toBeNull();
+  });
+});
+
+describe("scopeToOpenInDriveButton", () => {
+  it("returns null for non-Drive scopes", () => {
+    expect(scopeToOpenInDriveButton("secret:FOO")).toBeNull();
+  });
+
+  it("returns null for the whole-Drive globs (no specific artifact)", () => {
+    expect(scopeToOpenInDriveButton("doc:gdrive:**")).toBeNull();
+    expect(scopeToOpenInDriveButton("doc:gdrive:suggest:**")).toBeNull();
+    expect(scopeToOpenInDriveButton("doc:gdrive:write:**")).toBeNull();
+  });
+
+  it("builds a folder button for folder scopes (all namespaces)", () => {
+    const expected = {
+      text: "📖 Open in Drive",
+      url: "https://drive.google.com/drive/folders/F1",
+    };
+    expect(scopeToOpenInDriveButton("doc:gdrive:folder/F1/**")).toEqual(expected);
+    expect(scopeToOpenInDriveButton("doc:gdrive:suggest:folder/F1/**")).toEqual(expected);
+    expect(scopeToOpenInDriveButton("doc:gdrive:write:folder/F1/**")).toEqual(expected);
+  });
+
+  it("builds a doc button for single-doc scopes (all namespaces)", () => {
+    // No mimeType hint → generic file-viewer URL.
+    const expected = {
+      text: "📖 Open in Drive",
+      url: "https://drive.google.com/file/d/D1/view",
+    };
+    expect(scopeToOpenInDriveButton("doc:gdrive:D1")).toEqual(expected);
+    expect(scopeToOpenInDriveButton("doc:gdrive:suggest:D1")).toEqual(expected);
+    expect(scopeToOpenInDriveButton("doc:gdrive:write:D1")).toEqual(expected);
+  });
+
+  it("uses the mimeType hint to pick the canonical edit URL", () => {
+    expect(
+      scopeToOpenInDriveButton(
+        "doc:gdrive:D1",
+        "application/vnd.google-apps.document",
+      ),
+    ).toEqual({
+      text: "📖 Open in Drive",
+      url: "https://docs.google.com/document/d/D1/edit",
+    });
+    expect(
+      scopeToOpenInDriveButton(
+        "doc:gdrive:write:D1",
+        "application/vnd.google-apps.spreadsheet",
+      ),
+    ).toEqual({
+      text: "📖 Open in Drive",
+      url: "https://docs.google.com/spreadsheets/d/D1/edit",
+    });
+  });
+
+  it("returns null for unparseable Drive scopes (safe default)", () => {
+    expect(scopeToOpenInDriveButton("doc:gdrive:abc/def")).toBeNull();
+    expect(scopeToOpenInDriveButton("doc:gdrive:folder/abc?x=1/**")).toBeNull();
+  });
+});
+
+describe("myDriveButton", () => {
+  it("returns the my-drive homepage URL button", () => {
+    expect(myDriveButton()).toEqual({
+      text: "📂 Open my Drive",
+      url: "https://drive.google.com/drive/my-drive",
     });
   });
 });

--- a/src/drive/deep-links.ts
+++ b/src/drive/deep-links.ts
@@ -10,24 +10,25 @@
  *
  * No new auth needed — these are the same shareable URLs the user would
  * copy from Drive's "Share" dialog.
- *
- * Phase 1a ships the URL builders + tests. Wiring them onto the actual
- * approval-card inline-keyboard rows lives in the kernel/gateway code
- * (separate PR — touches `src/vault/approvals/kernel.ts` and
- * `telegram-plugin/gateway/gateway.ts` approval-card builders, both
- * substantial enough to warrant their own change).
  */
 
 /**
- * Drive file mime types that have first-class web UIs. Other mime types
- * (PDFs, images, .docx, etc.) get the generic `/file/d/<id>/view` URL.
+ * Drive surfaces that have first-class web UIs. Other mime types (PDFs,
+ * images, .docx, etc.) get the generic `/file/d/<id>/view` URL.
  */
-export type DriveDocKind = "doc" | "spreadsheet" | "presentation" | "form" | "drawing" | "file";
+export type DriveDocKind =
+  | "doc"
+  | "spreadsheet"
+  | "presentation"
+  | "form"
+  | "drawing"
+  | "folder"
+  | "file";
 
 /**
  * Map a Google Workspace mime type string to a DriveDocKind. Returns
  * "file" (the generic viewer) for anything we don't recognize as a
- * first-class Workspace doc.
+ * first-class Workspace surface.
  */
 export function classifyMimeType(mimeType: string | undefined): DriveDocKind {
   if (!mimeType) return "file";
@@ -42,6 +43,8 @@ export function classifyMimeType(mimeType: string | undefined): DriveDocKind {
       return "form";
     case "application/vnd.google-apps.drawing":
       return "drawing";
+    case "application/vnd.google-apps.folder":
+      return "folder";
     default:
       return "file";
   }
@@ -68,6 +71,13 @@ export interface OpenInDriveOptions {
    * as fileId.
    */
   discussionId?: string;
+  /**
+   * Treat the target as a folder regardless of mimeType. Used by the
+   * grant-confirmation card on `doc:gdrive:folder/<id>/**` scopes,
+   * where we only have the scope string and no `files.get` lookup
+   * has happened.
+   */
+  isFolder?: boolean;
 }
 
 /**
@@ -82,7 +92,8 @@ export function openInDriveUrl(options: OpenInDriveOptions): string {
   if (options.discussionId !== undefined) {
     validateDriveId(options.discussionId, "discussionId");
   }
-  const base = baseUrlFor(classifyMimeType(options.mimeType), options.fileId);
+  const kind = options.isFolder ? "folder" : classifyMimeType(options.mimeType);
+  const base = baseUrlFor(kind, options.fileId);
   if (options.discussionId !== undefined) {
     // `?disco=<id>` is Drive's documented discussion-thread anchor.
     // We append it as a query string so it survives the Workspace
@@ -105,6 +116,8 @@ function baseUrlFor(kind: DriveDocKind, fileId: string): string {
       return `https://docs.google.com/forms/d/${fileId}/edit`;
     case "drawing":
       return `https://docs.google.com/drawings/d/${fileId}/edit`;
+    case "folder":
+      return `https://drive.google.com/drive/folders/${fileId}`;
     case "file":
       return `https://drive.google.com/file/d/${fileId}/view`;
   }
@@ -133,10 +146,10 @@ function validateDriveId(id: string, fieldName: string): void {
 /**
  * Convenience builder for the common "render an inline-keyboard
  * button on an approval card" case. Returns the {text, url} pair the
- * Telegram bot library expects. Phase 1a callers (gateway approval-
- * card builders) construct InlineKeyboardButton objects directly from
- * this; the literal `📖 Open in Drive` text matches the RFC E §4.3
- * mockup.
+ * Telegram bot library expects. Callers (gateway approval-card
+ * builders, grant-confirmation edits) construct InlineKeyboardButton
+ * objects directly from this; the literal `📖 Open in Drive` text
+ * matches the RFC E §4.3 mockup.
  */
 export function openInDriveButton(
   options: OpenInDriveOptions,
@@ -145,4 +158,94 @@ export function openInDriveButton(
     text: "📖 Open in Drive",
     url: openInDriveUrl(options),
   };
+}
+
+/**
+ * Inspect a kernel `scope` string and, if it points at a specific Drive
+ * surface, return the {text, url} button pair for `[ 📖 Open in Drive ]`.
+ * Returns `null` for non-Drive scopes and for the whole-Drive globs
+ * (where there's no single artifact to deep-link to — the user can
+ * navigate from `[ 📂 Open my Drive ]` instead; see `myDriveButton`).
+ *
+ * Handles all three action namespaces — `read` (`doc:gdrive:…`),
+ * `suggest` (`doc:gdrive:suggest:…`), `write` (`doc:gdrive:write:…`) —
+ * because once the user has tapped Allow, the target artifact is the
+ * same in all three.
+ *
+ * Designed for the grant-confirmation card edit in
+ * `telegram-plugin/gateway/approval-callback.ts`: the kernel returns
+ * the scope alongside the consume result, this helper turns it into a
+ * keyboard button, or null if no button applies. Callers that have a
+ * mimeType (e.g. a diff-preview card with the file already fetched)
+ * should pass it via `mimeTypeHint` so doc/sheet/slide gets the right
+ * base URL; otherwise we infer from scope shape.
+ */
+export function scopeToOpenInDriveButton(
+  scope: string,
+  mimeTypeHint?: string,
+): { text: string; url: string } | null {
+  const parsed = parseDriveScope(scope);
+  if (parsed === null) return null;
+  if (parsed.target.kind === "all") return null;
+  if (parsed.target.kind === "folder") {
+    return openInDriveButton({ fileId: parsed.target.folder_id, isFolder: true });
+  }
+  return openInDriveButton({
+    fileId: parsed.target.doc_id,
+    mimeType: mimeTypeHint,
+  });
+}
+
+/**
+ * Whole-Drive equivalent of `openInDriveButton`. For onboarding /
+ * granted-Drive scopes like `doc:gdrive:**` where no specific artifact
+ * exists, surfacing a `[ 📂 Open my Drive ]` URL button is the closest
+ * useful affordance.
+ */
+export function myDriveButton(): { text: string; url: string } {
+  return {
+    text: "📂 Open my Drive",
+    url: "https://drive.google.com/drive/my-drive",
+  };
+}
+
+export type DriveScopeTarget =
+  | { kind: "all" }
+  | { kind: "folder"; folder_id: string }
+  | { kind: "doc"; doc_id: string };
+
+export interface DriveScope {
+  /** Action namespace per RFC E §4.2 + grants.ts. */
+  action: "read" | "suggest" | "write";
+  target: DriveScopeTarget;
+}
+
+/**
+ * Parse a kernel scope string into its action namespace + target. Returns
+ * `null` for anything that doesn't look like a Drive scope. Strict on
+ * id character set to prevent a malformed scope from rendering an unsafe
+ * URL — same `[A-Za-z0-9_-]+` rule as `validateDriveId`.
+ */
+export function parseDriveScope(scope: string): DriveScope | null {
+  if (!scope.startsWith("doc:gdrive:")) return null;
+  let rest = scope.slice("doc:gdrive:".length);
+  let action: DriveScope["action"] = "read";
+  if (rest.startsWith("write:")) {
+    action = "write";
+    rest = rest.slice("write:".length);
+  } else if (rest.startsWith("suggest:")) {
+    action = "suggest";
+    rest = rest.slice("suggest:".length);
+  }
+  if (rest === "**") return { action, target: { kind: "all" } };
+  if (rest.startsWith("folder/")) {
+    const tail = rest.slice("folder/".length);
+    if (!tail.endsWith("/**")) return null;
+    const folder_id = tail.slice(0, -"/**".length);
+    if (!/^[A-Za-z0-9_-]+$/.test(folder_id)) return null;
+    return { action, target: { kind: "folder", folder_id } };
+  }
+  // Single-doc form. Must be a bare id — no slashes, no glob.
+  if (!/^[A-Za-z0-9_-]+$/.test(rest)) return null;
+  return { action, target: { kind: "doc", doc_id: rest } };
 }

--- a/telegram-plugin/gateway/approval-callback.test.ts
+++ b/telegram-plugin/gateway/approval-callback.test.ts
@@ -10,7 +10,7 @@
  * builder.
  */
 
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { InlineKeyboard } from "grammy";
 import { buildGrantedKeyboard } from "./approval-callback.js";
 

--- a/telegram-plugin/gateway/approval-callback.test.ts
+++ b/telegram-plugin/gateway/approval-callback.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for `buildGrantedKeyboard` — the post-tap inline-keyboard
+ * surfaced on a granted approval card (RFC E §4.3 — granted-card
+ * confirmations gain the [ 📖 Open in Drive ] deep-link button).
+ *
+ * Scope-driven and pure, so the test runs without mocking grammy's
+ * Context or the approval kernel. The full handler in
+ * `approval-callback.ts` glues this onto the consumed-scope payload
+ * the kernel returns; the routing decision lives entirely in this
+ * builder.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { InlineKeyboard } from "grammy";
+import { buildGrantedKeyboard } from "./approval-callback.js";
+
+/**
+ * Helper — pull the `[{text, url}]` rows out of a grammy InlineKeyboard
+ * so we can assert without poking into its internal shape too hard.
+ */
+function rows(kb: InlineKeyboard): Array<Array<{ text: string; url?: string }>> {
+  return kb.inline_keyboard.map((row) =>
+    row.map((btn) => ({
+      text: btn.text,
+      ...("url" in btn ? { url: btn.url } : {}),
+    })),
+  );
+}
+
+describe("buildGrantedKeyboard — Drive scopes", () => {
+  it("emits Open-in-Drive for a single-doc grant", () => {
+    const kb = buildGrantedKeyboard("doc:gdrive:D1");
+    expect(kb).toBeDefined();
+    expect(rows(kb!)).toEqual([
+      [
+        {
+          text: "📖 Open in Drive",
+          url: "https://drive.google.com/file/d/D1/view",
+        },
+      ],
+    ]);
+  });
+
+  it("emits Open-in-Drive for a folder grant (canonical folder URL)", () => {
+    const kb = buildGrantedKeyboard("doc:gdrive:folder/F1/**");
+    expect(kb).toBeDefined();
+    expect(rows(kb!)).toEqual([
+      [
+        {
+          text: "📖 Open in Drive",
+          url: "https://drive.google.com/drive/folders/F1",
+        },
+      ],
+    ]);
+  });
+
+  it("emits Open-in-Drive for write-namespace grants on a single doc", () => {
+    const kb = buildGrantedKeyboard("doc:gdrive:write:D1");
+    expect(kb).toBeDefined();
+    expect(rows(kb!)).toEqual([
+      [
+        {
+          text: "📖 Open in Drive",
+          url: "https://drive.google.com/file/d/D1/view",
+        },
+      ],
+    ]);
+  });
+
+  it("emits Open-in-Drive for suggest-namespace folder grants", () => {
+    const kb = buildGrantedKeyboard("doc:gdrive:suggest:folder/F1/**");
+    expect(kb).toBeDefined();
+    expect(rows(kb!)).toEqual([
+      [
+        {
+          text: "📖 Open in Drive",
+          url: "https://drive.google.com/drive/folders/F1",
+        },
+      ],
+    ]);
+  });
+});
+
+describe("buildGrantedKeyboard — no button cases", () => {
+  it("returns undefined for the whole-Drive grant (no specific artifact)", () => {
+    expect(buildGrantedKeyboard("doc:gdrive:**")).toBeUndefined();
+    expect(buildGrantedKeyboard("doc:gdrive:suggest:**")).toBeUndefined();
+    expect(buildGrantedKeyboard("doc:gdrive:write:**")).toBeUndefined();
+  });
+
+  it("returns undefined for non-Drive scopes (secrets, system, vault)", () => {
+    expect(buildGrantedKeyboard("secret:OPENAI_API_KEY")).toBeUndefined();
+    expect(buildGrantedKeyboard("system:reconnect:gdrive")).toBeUndefined();
+    expect(buildGrantedKeyboard("vault:read:gdrive:klanker:refresh_token")).toBeUndefined();
+  });
+
+  it("returns undefined for unparseable Drive scopes (defense in depth)", () => {
+    // A folder id containing a slash slips past prefix matching but is
+    // rejected by parseDriveScope's id-charset check — the granted-card
+    // edit MUST NOT render a URL button derived from such a string.
+    expect(buildGrantedKeyboard("doc:gdrive:folder/abc/def/**")).toBeUndefined();
+    expect(buildGrantedKeyboard("doc:gdrive:write:abc?evil=1")).toBeUndefined();
+  });
+});

--- a/telegram-plugin/gateway/approval-callback.ts
+++ b/telegram-plugin/gateway/approval-callback.ts
@@ -21,13 +21,31 @@
  * approval_lookup (RFC §10) to discover the outcome and proceed.
  */
 
-import type { Context } from "grammy";
+import { type Context, InlineKeyboard } from "grammy";
 import { parseApprovalCallback, ttlMsFromToken } from "./approval-card.js";
 import {
   approvalConsume,
   approvalRecord,
 } from "../../src/vault/approvals/client.js";
 import type { ApprovalDecisionMode } from "../../src/vault/approvals/schema.js";
+import { scopeToOpenInDriveButton } from "../../src/drive/deep-links.js";
+
+/**
+ * Build the post-tap keyboard for a granted decision. Today this is
+ * just the `[ 📖 Open in Drive ]` button when the granted scope names
+ * a specific Drive doc or folder (RFC E §4.3 — granted-card
+ * confirmations gain the deep-link). Returns `undefined` when no
+ * post-tap keyboard applies, which the gateway translates into
+ * `reply_markup: undefined` to strip the original action buttons.
+ *
+ * Pure / scope-driven — no kernel I/O — so it stays unit-testable
+ * without mocking grammy's Context.
+ */
+export function buildGrantedKeyboard(scope: string): InlineKeyboard | undefined {
+  const btn = scopeToOpenInDriveButton(scope);
+  if (btn === null) return undefined;
+  return new InlineKeyboard().url(btn.text, btn.url);
+}
 
 export async function handleApprovalCallback(
   ctx: Context,
@@ -109,7 +127,10 @@ export async function handleApprovalCallback(
     return;
   }
 
-  // Edit the original card to its post-tap state and drop the keyboard.
+  // Edit the original card to its post-tap state. Drop the original
+  // action keyboard either way; on a successful grant for a Drive
+  // scope, surface `[ 📖 Open in Drive ]` so the user can jump
+  // straight from "agent has access" to the doc (RFC E §4.3).
   const icon = granted ? "✅" : "🚫";
   const newBody =
     `${icon} ${displayMode}` +
@@ -117,8 +138,15 @@ export async function handleApprovalCallback(
       ? ` · /approvals revoke <code>${decision_id}</code>`
       : "");
 
+  const postTapKeyboard = granted && consumed.scope
+    ? buildGrantedKeyboard(consumed.scope)
+    : undefined;
+
   try {
-    await ctx.editMessageText(newBody, { parse_mode: "HTML", reply_markup: undefined });
+    await ctx.editMessageText(newBody, {
+      parse_mode: "HTML",
+      reply_markup: postTapKeyboard,
+    });
   } catch {
     // Best-effort: card may have been edited or deleted under us.
   }


### PR DESCRIPTION
## Summary

Wires the existing `openInDriveButton` helper (from #1251) into the post-tap edit of every granted approval card. When the kernel's `approval_consume` returns a Drive scope, the granted-card edit now keeps an inline keyboard with `[ 📖 Open in Drive ]` so the user can tap straight from "agent has access" to the doc / folder itself — RFC E §4.3's chat→doc→chat handoff.

## What's new in `deep-links.ts`

- **Folder support** — new `folder` kind in `DriveDocKind`, recognises `application/vnd.google-apps.folder`, emits `https://drive.google.com/drive/folders/<id>`.
- **`isFolder` option** — forces folder URL when only the scope string is available (no `files.get` lookup). Used by the granted-card path.
- **`parseDriveScope(scope)`** — strict-charset parser for all three namespaces × all three target shapes; rejects malformed folder ids and smuggled URL fragments at the scope layer (defense in depth on top of `validateDriveId` at the URL layer).
- **`scopeToOpenInDriveButton(scope, mimeTypeHint?)`** — scope-driven button builder; returns null for whole-Drive globs (no specific artifact) and non-Drive scopes.
- **`myDriveButton()`** — `[ 📂 Open my Drive ]` for whole-Drive grants. Reserved for the onboarding-card follow-up.

## Wire-up in `approval-callback.ts`

New exported `buildGrantedKeyboard(scope)` — pure, scope-driven, returns the InlineKeyboard or undefined. `handleApprovalCallback` calls it on a successful grant and passes the result as `reply_markup` instead of stripping the keyboard outright. Denials still strip — no point surfacing a deep-link the user just refused.

## Scope coverage decisions

- All three action namespaces (read/suggest/write) get the button once the user has tapped Allow — once authorised, the target artifact is the same. Matters for the diff-preview path landing in PR B3.
- Whole-Drive grants return undefined — no single artifact. `myDriveButton()` is reserved for the onboarding-card follow-up where "open my Drive" is contextually right.

## Test plan

- [x] `bun test src/drive/` — 200 pass (23 new cases in `deep-links.test.ts`)
- [x] `bun test telegram-plugin/gateway/` — 56 pass (new `approval-callback.test.ts`, 7 cases)
- [x] `bun run lint` — clean
- [x] `bun run build` — bundles cleanly
- [ ] Independent reviewer verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)