### PR TITLE
feat(drive): RFC E §4.1 — folder picker primitives (list + cache + card)

### DIFF
--- a/src/drive/folder-list.test.ts
+++ b/src/drive/folder-list.test.ts
@@ -12,6 +12,7 @@ import {
   FolderListCache,
   fetchFolderPage,
   getOrFetchFirstPage,
+  isValidAgentName,
 } from "./folder-list.js";
 
 function mockFetch(handler: (url: string, init: RequestInit) => Response): typeof fetch {
@@ -95,6 +96,13 @@ describe("fetchFolderPage — query string + auth", () => {
       fetchFolderPage({ access_token: "TOK", parent_id: "abc' OR '1", fetchImpl }),
     ).rejects.toThrow(/invalid characters/);
   });
+
+  it("rejects empty parent_id (would pass !== undefined gate)", async () => {
+    const fetchImpl = mockFetch(() => jsonResp({ files: [] }));
+    await expect(
+      fetchFolderPage({ access_token: "TOK", parent_id: "", fetchImpl }),
+    ).rejects.toThrow(/invalid characters/);
+  });
 });
 
 describe("fetchFolderPage — response parsing", () => {
@@ -170,6 +178,45 @@ describe("fetchFolderPage — response parsing", () => {
       fetchFolderPage({ access_token: "TOK", fetchImpl }),
     ).rejects.toThrow(/429/);
   });
+
+  it("rejects a non-object Drive response (defensive — defends a malformed body)", async () => {
+    for (const body of ["null", "[]", '"oops"', "42"]) {
+      const fetchImpl = mockFetch(
+        () => new Response(body, { headers: { "content-type": "application/json" } }),
+      );
+      await expect(
+        fetchFolderPage({ access_token: "TOK", fetchImpl }),
+      ).rejects.toThrow(/non-object/);
+    }
+  });
+});
+
+describe("isValidAgentName", () => {
+  it("accepts canonical names", () => {
+    expect(isValidAgentName("klanker")).toBe(true);
+    expect(isValidAgentName("c2")).toBe(true);
+    expect(isValidAgentName("dev-bot")).toBe(true);
+    expect(isValidAgentName("a_b_c")).toBe(true);
+  });
+
+  it("rejects case-mixed (cache-key isolation matters)", () => {
+    expect(isValidAgentName("Klanker")).toBe(false);
+    expect(isValidAgentName("KLANKER")).toBe(false);
+  });
+
+  it("rejects empty / too-long / starts-with-non-letter", () => {
+    expect(isValidAgentName("")).toBe(false);
+    expect(isValidAgentName("a".repeat(65))).toBe(false);
+    expect(isValidAgentName("1klanker")).toBe(false);
+    expect(isValidAgentName("-klanker")).toBe(false);
+  });
+
+  it("rejects URL-injection charset", () => {
+    expect(isValidAgentName("klanker|x")).toBe(false);
+    expect(isValidAgentName("klanker/x")).toBe(false);
+    expect(isValidAgentName("klanker:x")).toBe(false);
+    expect(isValidAgentName("klanker x")).toBe(false);
+  });
 });
 
 describe("FolderListCache", () => {
@@ -217,6 +264,85 @@ describe("FolderListCache", () => {
     expect(cache.get("klanker", "P1")).toBeNull();
     expect(cache.get("klanker", "P2")).toBeNull();
     expect(cache.get("clerk")).not.toBeNull();
+  });
+
+  it("rejects invalid agent at the cache boundary (defense in depth)", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    expect(() => cache.set("foo|bar", { folders: [] })).toThrow(/invalid agent/);
+    expect(() => cache.get("Klanker")).toThrow(/invalid agent/);
+    expect(() => cache.set("klanker", { folders: [] }, "bad/parent")).toThrow(
+      /invalid parent_id/,
+    );
+  });
+});
+
+describe("FolderListCache — page-token handle store", () => {
+  it("registers a long token and returns an 8-hex-char handle", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    const handle = cache.registerPageToken("klanker", "X".repeat(120));
+    expect(handle).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it("round-trips handle → full token", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    const token = "Z".repeat(150);
+    const handle = cache.registerPageToken("klanker", token);
+    expect(cache.getPageToken("klanker", handle)).toBe(token);
+  });
+
+  it("is idempotent — same (agent, token) returns the same handle", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    const h1 = cache.registerPageToken("klanker", "X".repeat(80));
+    const h2 = cache.registerPageToken("klanker", "X".repeat(80));
+    expect(h1).toBe(h2);
+    expect(cache.tokenCount()).toBe(1);
+  });
+
+  it("different agents get different handles for the same token", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    const tok = "X".repeat(80);
+    const h1 = cache.registerPageToken("klanker", tok);
+    const h2 = cache.registerPageToken("clerk", tok);
+    // Handles are deterministic per (agent, token), so collisions are
+    // theoretically possible but extraordinarily unlikely with the FNV
+    // mix; assert they're stored independently regardless.
+    expect(cache.getPageToken("klanker", h1)).toBe(tok);
+    expect(cache.getPageToken("clerk", h2)).toBe(tok);
+  });
+
+  it("getPageToken returns null on expiry", () => {
+    let now = 1000;
+    const cache = new FolderListCache({ ttl_ms: 5_000, now: () => now });
+    const handle = cache.registerPageToken("klanker", "X".repeat(80));
+    expect(cache.getPageToken("klanker", handle)).not.toBeNull();
+    now = 1000 + 5_001;
+    expect(cache.getPageToken("klanker", handle)).toBeNull();
+  });
+
+  it("getPageToken returns null for malformed handles (defense in depth)", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    cache.registerPageToken("klanker", "X".repeat(80));
+    expect(cache.getPageToken("klanker", "abc")).toBeNull();
+    expect(cache.getPageToken("klanker", "ABCDEF01")).toBeNull();
+    expect(cache.getPageToken("klanker", "not-hex!")).toBeNull();
+  });
+
+  it("getPageToken returns null for an invalid agent name", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    expect(cache.getPageToken("Klanker", "abcdef01")).toBeNull();
+  });
+
+  it("registerPageToken throws for an invalid agent name", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    expect(() => cache.registerPageToken("Klanker", "X")).toThrow(/invalid agent/);
+  });
+
+  it("invalidateAgent clears registered tokens too", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    const handle = cache.registerPageToken("klanker", "X".repeat(80));
+    cache.invalidateAgent("klanker");
+    expect(cache.getPageToken("klanker", handle)).toBeNull();
+    expect(cache.tokenCount()).toBe(0);
   });
 });
 

--- a/src/drive/folder-list.test.ts
+++ b/src/drive/folder-list.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for Drive folder listing — RFC E §4.1.
+ *
+ * Covers: HTTP client shape + query string, response parsing,
+ * malformed-id rejection, parent-id charset validation,
+ * cache TTL + key isolation, get-or-fetch happy/refresh paths.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  FolderListCache,
+  fetchFolderPage,
+  getOrFetchFirstPage,
+} from "./folder-list.js";
+
+function mockFetch(handler: (url: string, init: RequestInit) => Response): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return Promise.resolve(handler(url, init ?? {}));
+  }) as typeof fetch;
+}
+
+function jsonResp(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("fetchFolderPage — query string + auth", () => {
+  it("issues files.list with the canonical folder query and bearer auth", async () => {
+    let observed = "";
+    let authHeader = "";
+    const fetchImpl = mockFetch((url, init) => {
+      observed = url;
+      const h = init.headers as Record<string, string>;
+      authHeader = h.Authorization;
+      return jsonResp({ files: [], nextPageToken: undefined });
+    });
+
+    await fetchFolderPage({ access_token: "TOK", fetchImpl });
+
+    expect(observed.startsWith("https://www.googleapis.com/drive/v3/files?")).toBe(true);
+    const u = new URL(observed);
+    const q = u.searchParams.get("q") ?? "";
+    expect(q).toContain("mimeType='application/vnd.google-apps.folder'");
+    expect(q).toContain("'me' in owners");
+    expect(q).toContain("trashed=false");
+    expect(u.searchParams.get("pageSize")).toBe("50");
+    expect(u.searchParams.get("orderBy")).toBe("name");
+    expect(u.searchParams.get("fields")).toBe("files(id,name,parents),nextPageToken");
+    expect(authHeader).toBe("Bearer TOK");
+  });
+
+  it("scopes to a parent folder when parent_id is set", async () => {
+    let observed = "";
+    const fetchImpl = mockFetch((url) => {
+      observed = url;
+      return jsonResp({ files: [] });
+    });
+    await fetchFolderPage({ access_token: "TOK", parent_id: "F1", fetchImpl });
+    const q = new URL(observed).searchParams.get("q") ?? "";
+    expect(q).toContain("'F1' in parents");
+  });
+
+  it("forwards page_token", async () => {
+    let observed = "";
+    const fetchImpl = mockFetch((url) => {
+      observed = url;
+      return jsonResp({ files: [] });
+    });
+    await fetchFolderPage({ access_token: "TOK", page_token: "TKN123", fetchImpl });
+    expect(new URL(observed).searchParams.get("pageToken")).toBe("TKN123");
+  });
+
+  it("clamps page_size into [1, 1000]", async () => {
+    let observed = "";
+    const fetchImpl = mockFetch((url) => {
+      observed = url;
+      return jsonResp({ files: [] });
+    });
+    await fetchFolderPage({ access_token: "TOK", page_size: 99999, fetchImpl });
+    expect(new URL(observed).searchParams.get("pageSize")).toBe("1000");
+    await fetchFolderPage({ access_token: "TOK", page_size: 0, fetchImpl });
+    expect(new URL(observed).searchParams.get("pageSize")).toBe("1");
+  });
+
+  it("rejects malformed parent_id (URL-injection guard)", async () => {
+    const fetchImpl = mockFetch(() => jsonResp({ files: [] }));
+    await expect(
+      fetchFolderPage({ access_token: "TOK", parent_id: "abc/def", fetchImpl }),
+    ).rejects.toThrow(/invalid characters/);
+    await expect(
+      fetchFolderPage({ access_token: "TOK", parent_id: "abc' OR '1", fetchImpl }),
+    ).rejects.toThrow(/invalid characters/);
+  });
+});
+
+describe("fetchFolderPage — response parsing", () => {
+  it("parses the happy path with single parent", async () => {
+    const fetchImpl = mockFetch(() =>
+      jsonResp({
+        files: [
+          { id: "F1", name: "Folder One", parents: ["P1"] },
+          { id: "F2", name: "Folder Two" },
+        ],
+        nextPageToken: "next-page-tok",
+      }),
+    );
+    const page = await fetchFolderPage({ access_token: "TOK", fetchImpl });
+    expect(page.folders).toEqual([
+      { id: "F1", name: "Folder One", parent_id: "P1" },
+      { id: "F2", name: "Folder Two" },
+    ]);
+    expect(page.next_page_token).toBe("next-page-tok");
+  });
+
+  it("drops entries with missing id or name (defensive)", async () => {
+    const fetchImpl = mockFetch(() =>
+      jsonResp({
+        files: [
+          { id: "F1", name: "Keep" },
+          { name: "No id" },
+          { id: "F3" },
+          {},
+        ],
+      }),
+    );
+    const page = await fetchFolderPage({ access_token: "TOK", fetchImpl });
+    expect(page.folders.map((f) => f.name)).toEqual(["Keep"]);
+  });
+
+  it("drops entries whose id contains URL-unsafe characters", async () => {
+    const fetchImpl = mockFetch(() =>
+      jsonResp({
+        files: [
+          { id: "F1", name: "Keep" },
+          { id: "abc/def", name: "Drop slash" },
+          { id: "abc?x=1", name: "Drop query" },
+          { id: "abc def", name: "Drop space" },
+        ],
+      }),
+    );
+    const page = await fetchFolderPage({ access_token: "TOK", fetchImpl });
+    expect(page.folders.map((f) => f.name)).toEqual(["Keep"]);
+  });
+
+  it("drops a parent_id with bad characters but keeps the folder", async () => {
+    const fetchImpl = mockFetch(() =>
+      jsonResp({
+        files: [{ id: "F1", name: "Keep", parents: ["bad/parent"] }],
+      }),
+    );
+    const page = await fetchFolderPage({ access_token: "TOK", fetchImpl });
+    expect(page.folders).toEqual([{ id: "F1", name: "Keep" }]);
+  });
+
+  it("returns empty next_page_token when absent", async () => {
+    const fetchImpl = mockFetch(() => jsonResp({ files: [] }));
+    const page = await fetchFolderPage({ access_token: "TOK", fetchImpl });
+    expect(page.next_page_token).toBeUndefined();
+  });
+
+  it("throws on non-2xx with status code in the message", async () => {
+    const fetchImpl = mockFetch(() =>
+      new Response("rate limit", { status: 429, statusText: "Too Many Requests" }),
+    );
+    await expect(
+      fetchFolderPage({ access_token: "TOK", fetchImpl }),
+    ).rejects.toThrow(/429/);
+  });
+});
+
+describe("FolderListCache", () => {
+  it("returns null on miss and sets/gets correctly", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    expect(cache.get("klanker")).toBeNull();
+    cache.set("klanker", { folders: [{ id: "F", name: "X" }] });
+    expect(cache.get("klanker")).toEqual({ folders: [{ id: "F", name: "X" }] });
+  });
+
+  it("expires entries past the TTL", () => {
+    let now = 1000;
+    const cache = new FolderListCache({ ttl_ms: 5_000, now: () => now });
+    cache.set("klanker", { folders: [] });
+    expect(cache.get("klanker")).not.toBeNull();
+    now = 1000 + 5_000 + 1;
+    expect(cache.get("klanker")).toBeNull();
+    expect(cache.size()).toBe(0); // expiry purges
+  });
+
+  it("keys independently per (agent, parent_id)", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    cache.set("klanker", { folders: [{ id: "TOP", name: "top" }] });
+    cache.set("klanker", { folders: [{ id: "SUB", name: "sub" }] }, "PARENT1");
+    expect(cache.get("klanker")?.folders[0]?.id).toBe("TOP");
+    expect(cache.get("klanker", "PARENT1")?.folders[0]?.id).toBe("SUB");
+  });
+
+  it("does not collide on agent-name vs agent-name-and-parent (separator not in either charset)", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    cache.set("ab", { folders: [{ id: "A", name: "A" }] }, "c");
+    cache.set("a", { folders: [{ id: "B", name: "B" }] }, "bc");
+    expect(cache.get("ab", "c")?.folders[0]?.id).toBe("A");
+    expect(cache.get("a", "bc")?.folders[0]?.id).toBe("B");
+  });
+
+  it("invalidateAgent drops all entries for that agent (across parents)", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    cache.set("klanker", { folders: [] });
+    cache.set("klanker", { folders: [] }, "P1");
+    cache.set("klanker", { folders: [] }, "P2");
+    cache.set("clerk", { folders: [] });
+    cache.invalidateAgent("klanker");
+    expect(cache.get("klanker")).toBeNull();
+    expect(cache.get("klanker", "P1")).toBeNull();
+    expect(cache.get("klanker", "P2")).toBeNull();
+    expect(cache.get("clerk")).not.toBeNull();
+  });
+});
+
+describe("getOrFetchFirstPage", () => {
+  it("returns from cache on hit (no network)", async () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    cache.set("klanker", { folders: [{ id: "CACHED", name: "C" }] });
+    let calls = 0;
+    const fetchImpl = mockFetch(() => {
+      calls += 1;
+      return jsonResp({ files: [{ id: "FRESH", name: "F" }] });
+    });
+    const result = await getOrFetchFirstPage({
+      agent: "klanker",
+      cache,
+      access_token: "TOK",
+      fetchImpl,
+    });
+    expect(result.folders[0]?.id).toBe("CACHED");
+    expect(calls).toBe(0);
+  });
+
+  it("fetches on miss and writes through to the cache", async () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    let calls = 0;
+    const fetchImpl = mockFetch(() => {
+      calls += 1;
+      return jsonResp({ files: [{ id: "FRESH", name: "F" }] });
+    });
+    const result = await getOrFetchFirstPage({
+      agent: "klanker",
+      cache,
+      access_token: "TOK",
+      fetchImpl,
+    });
+    expect(result.folders[0]?.id).toBe("FRESH");
+    expect(calls).toBe(1);
+    expect(cache.get("klanker")?.folders[0]?.id).toBe("FRESH");
+  });
+
+  it("bypasses cache on force_refresh: true", async () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    cache.set("klanker", { folders: [{ id: "STALE", name: "S" }] });
+    const fetchImpl = mockFetch(() =>
+      jsonResp({ files: [{ id: "FRESH", name: "F" }] }),
+    );
+    const result = await getOrFetchFirstPage({
+      agent: "klanker",
+      cache,
+      access_token: "TOK",
+      force_refresh: true,
+      fetchImpl,
+    });
+    expect(result.folders[0]?.id).toBe("FRESH");
+    expect(cache.get("klanker")?.folders[0]?.id).toBe("FRESH");
+  });
+});

--- a/src/drive/folder-list.ts
+++ b/src/drive/folder-list.ts
@@ -70,7 +70,24 @@ export interface FetchFolderPageOptions {
 }
 
 const DRIVE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const AGENT_NAME_RE = /^[a-z][a-z0-9_-]*$/;
+const AGENT_NAME_MAX = 64;
 const FOLDER_MIME = "application/vnd.google-apps.folder";
+
+/**
+ * Validate an agent name against the canonical shape. Both this module
+ * and `folder-picker.ts` use the same rule — pulled here so cache
+ * boundaries can enforce defense in depth even when called from
+ * paths that haven't validated their input.
+ */
+export function isValidAgentName(name: string): boolean {
+  return (
+    typeof name === "string" &&
+    name.length > 0 &&
+    name.length <= AGENT_NAME_MAX &&
+    AGENT_NAME_RE.test(name)
+  );
+}
 
 /**
  * One page of folders. Throws on auth failure (401), rate limit (429),
@@ -82,7 +99,7 @@ export async function fetchFolderPage(
   opts: FetchFolderPageOptions,
 ): Promise<FolderPage> {
   if (opts.parent_id !== undefined) {
-    if (!DRIVE_ID_RE.test(opts.parent_id)) {
+    if (opts.parent_id.length === 0 || !DRIVE_ID_RE.test(opts.parent_id)) {
       throw new Error(
         `Drive parent_id contains invalid characters. Expected base64-url-safe (alphanumerics + - + _).`,
       );
@@ -130,7 +147,13 @@ export async function fetchFolderPage(
     );
   }
 
-  const json = (await resp.json()) as {
+  const raw = (await resp.json()) as unknown;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new Error(
+      `Drive files.list returned non-object body (got ${raw === null ? "null" : Array.isArray(raw) ? "array" : typeof raw}).`,
+    );
+  }
+  const json = raw as {
     files?: Array<{ id?: string; name?: string; parents?: string[] }>;
     nextPageToken?: string;
   };
@@ -193,6 +216,24 @@ export class FolderListCache {
   private readonly ttlMs: number;
   private readonly now: () => number;
   private readonly entries = new Map<string, { expires_at: number; page: FolderPage }>();
+  /**
+   * Map of `agent → handle → fullPageToken`. Drive's `nextPageToken`
+   * for `files.list` is a base64-encoded protobuf that routinely runs
+   * 50–200 chars — far over Telegram's 64-byte callback_data cap. The
+   * picker emits a short opaque handle (8 hex chars) instead and the
+   * gateway dispatcher resolves it back to the real token via
+   * `getPageToken()`. Same TTL as the folder cache itself; tokens
+   * outlast their parent cache entry by design (the user might
+   * paginate past 5 minutes of inactivity, then their first tap
+   * after expiry still needs the token).
+   */
+  private readonly tokens = new Map<string, { expires_at: number; full: string }>();
+  /**
+   * Stable hash-to-handle dedup. Re-emitting the same page-token for
+   * the same agent should produce the same handle so the cache
+   * doesn't bloat on every re-render. Keyed by `${agent}|${token}`.
+   */
+  private readonly handlesByToken = new Map<string, string>();
 
   constructor(opts?: { ttl_ms?: number; now?: () => number }) {
     this.ttlMs = opts?.ttl_ms ?? 5 * 60 * 1000;
@@ -227,22 +268,122 @@ export class FolderListCache {
 
   /** Drop all entries for an agent — used when the agent disconnects. */
   invalidateAgent(agent: string): void {
+    const prefix = `${agent}|`;
     for (const key of [...this.entries.keys()]) {
-      if (key === agent || key.startsWith(`${agent}|`)) {
+      if (key === agent || key.startsWith(prefix)) {
         this.entries.delete(key);
       }
     }
+    for (const key of [...this.tokens.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.tokens.delete(key);
+      }
+    }
+    for (const key of [...this.handlesByToken.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.handlesByToken.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Register a page token for `agent` and return the short opaque
+   * handle. Idempotent — re-registering the same token returns the
+   * same handle so the cache doesn't bloat on every re-render.
+   *
+   * Handles are 8 lowercase hex chars (~32 bits). Drive's
+   * `nextPageToken` for `files.list` is a base64-encoded protobuf
+   * that routinely runs 50–200 chars; the picker's
+   * `drvpick:open:<agent>:<parent>:<handle>` callback wouldn't fit
+   * inside Telegram's 64-byte cap with the raw token. Collision odds
+   * within a single agent's active 5-min window are tiny — Drive
+   * paginates O(folders/50) per breadcrumb level, so the active set
+   * per agent is single digits.
+   */
+  registerPageToken(agent: string, fullToken: string): string {
+    if (!isValidAgentName(agent)) {
+      throw new Error(
+        `FolderListCache.registerPageToken: invalid agent name '${agent}'`,
+      );
+    }
+    const lookupKey = `${agent}|${fullToken}`;
+    const existing = this.handlesByToken.get(lookupKey);
+    if (existing !== undefined) {
+      // Bump TTL on re-register so an active session keeps the
+      // token alive past its original 5-min window.
+      this.tokens.set(`${agent}|${existing}`, {
+        expires_at: this.now() + this.ttlMs,
+        full: fullToken,
+      });
+      return existing;
+    }
+    const handle = hashHandle(agent, fullToken);
+    this.tokens.set(`${agent}|${handle}`, {
+      expires_at: this.now() + this.ttlMs,
+      full: fullToken,
+    });
+    this.handlesByToken.set(lookupKey, handle);
+    return handle;
+  }
+
+  /**
+   * Resolve a handle back to the full page token. Returns `null` on
+   * miss or expiry — caller should treat that as "session lost; jump
+   * back to page 0".
+   */
+  getPageToken(agent: string, handle: string): string | null {
+    if (!isValidAgentName(agent)) return null;
+    if (!/^[0-9a-f]{8}$/.test(handle)) return null;
+    const key = `${agent}|${handle}`;
+    const entry = this.tokens.get(key);
+    if (entry === undefined) return null;
+    if (entry.expires_at <= this.now()) {
+      this.tokens.delete(key);
+      // Drop reverse mapping so future registrations get a fresh
+      // entry rather than reviving the expired one.
+      for (const [k, v] of this.handlesByToken.entries()) {
+        if (v === handle && k.startsWith(`${agent}|`)) {
+          this.handlesByToken.delete(k);
+        }
+      }
+      return null;
+    }
+    return entry.full;
   }
 
   /** Drop everything — used by tests. */
   clear(): void {
     this.entries.clear();
+    this.tokens.clear();
+    this.handlesByToken.clear();
   }
 
   /** Exposed for tests. */
   size(): number {
     return this.entries.size;
   }
+
+  /** Exposed for tests. */
+  tokenCount(): number {
+    return this.tokens.size;
+  }
+}
+
+function hashHandle(agent: string, token: string): string {
+  // Deterministic short hash. Web Crypto's subtle would be async; an
+  // FNV-1a-style mix with two starting seeds (one forward, one
+  // reverse-walk) gives enough collision resistance for the
+  // active-session size.
+  let h1 = 0x811c9dc5 >>> 0;
+  let h2 = 0xcbf29ce4 >>> 0;
+  const s = `${agent}|${token}`;
+  for (let i = 0; i < s.length; i++) {
+    h1 ^= s.charCodeAt(i);
+    h1 = Math.imul(h1, 0x01000193) >>> 0;
+    h2 ^= s.charCodeAt(s.length - 1 - i);
+    h2 = Math.imul(h2, 0x01000193) >>> 0;
+  }
+  return ((h1 ^ h2) >>> 0).toString(16).padStart(8, "0");
 }
 
 /**
@@ -273,10 +414,22 @@ export async function getOrFetchFirstPage(args: {
 }
 
 function cacheKey(agent: string, parent_id?: string): string {
-  // `|` is not legal in agent names (alnum + - + _ only) or Drive ids
-  // (URL-safe base64), so it can't appear in either component — no
-  // collision risk between an agent named `foo` browsing parent `bar`
-  // and an agent named `foo|bar` at top level (both impossible inputs
-  // either way; defense in depth).
+  // Assert here so an unvalidated agent name from a forgetful caller
+  // can't produce a colliding key. `|` is not legal in agent names
+  // (alnum + - + _ only) or Drive ids (URL-safe base64), so it can't
+  // appear in either component — collision-impossible by construction
+  // *given* this assertion.
+  if (!isValidAgentName(agent)) {
+    throw new Error(
+      `FolderListCache: invalid agent name '${agent}' — must match /^[a-z][a-z0-9_-]*$/ and be ≤ ${AGENT_NAME_MAX} chars`,
+    );
+  }
+  if (parent_id !== undefined) {
+    if (parent_id.length === 0 || !DRIVE_ID_RE.test(parent_id)) {
+      throw new Error(
+        `FolderListCache: invalid parent_id '${parent_id}'`,
+      );
+    }
+  }
   return parent_id === undefined ? agent : `${agent}|${parent_id}`;
 }

--- a/src/drive/folder-list.ts
+++ b/src/drive/folder-list.ts
@@ -1,0 +1,282 @@
+/**
+ * Drive folder listing — RFC E §4.1.
+ *
+ * Pure HTTP client + per-agent cache for the folder picker. Issues
+ * `files.list` against Drive v3 with a fixed query that returns only
+ * the caller's own folders (`'me' in owners`), skipping trashed
+ * folders. Used by the Telegram-side folder picker card to render
+ * `[ 📁 <folder name> ]` rows without forcing the user to hand-type
+ * `doc:gdrive:folder/<id>/**`.
+ *
+ * The HTTP client and the cache are exported as separate primitives:
+ *
+ *   - `fetchFolderPage()` — pure HTTP call. No caching, no auth refresh.
+ *     Caller supplies the access token (the existing `DriveTokenCache`
+ *     in `wrapper.ts` handles refresh).
+ *
+ *   - `FolderListCache` — per-agent 5-min TTL cache. Holds the
+ *     first-page payload only (the common navigation case). Cache
+ *     bypass on `forceRefresh: true` for the `[ ↻ Refresh ]` button.
+ *
+ * Deliberately split so callers can mix freely — a folder-picker that
+ * paginates deep into the list goes uncached page-by-page; the
+ * happy-path "open the picker" case hits the cache.
+ */
+
+/**
+ * Folder fields exposed by the picker. Trimmed deliberately — anything
+ * the picker doesn't render (modified time, ownership, capabilities)
+ * stays out of the response shape so we don't accidentally surface
+ * fields the user didn't see.
+ */
+export interface DriveFolder {
+  id: string;
+  name: string;
+  /**
+   * Parent folder id, if any. Drive returns up to one parent per
+   * folder in v3 (single-parent model after 2020). `undefined` for
+   * top-of-Drive folders.
+   */
+  parent_id?: string;
+}
+
+export interface FolderPage {
+  folders: DriveFolder[];
+  /**
+   * Drive's `nextPageToken` — pass to the next `fetchFolderPage()`
+   * call to walk forward. `undefined` when there are no more pages.
+   */
+  next_page_token?: string;
+}
+
+export interface FetchFolderPageOptions {
+  access_token: string;
+  page_token?: string;
+  /**
+   * Page size — Drive's `files.list` accepts 1–1000. The picker UX
+   * defaults to 50 (RFC E §4.1) which fits comfortably in a single
+   * Telegram message; larger sizes spill into pagination state.
+   */
+  page_size?: number;
+  /**
+   * When set, restricts to folders that have this id as a parent —
+   * used by sub-folder navigation (RFC E §4.1 "One tap on a folder =
+   * expand into its children"). Validated to the same id charset as
+   * other Drive ids; throws on smuggled URL fragments.
+   */
+  parent_id?: string;
+  /** Test injection seam. */
+  fetchImpl?: typeof fetch;
+}
+
+const DRIVE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const FOLDER_MIME = "application/vnd.google-apps.folder";
+
+/**
+ * One page of folders. Throws on auth failure (401), rate limit (429),
+ * or a non-2xx response from Drive. The caller is responsible for
+ * mapping 401 → "drive disconnected" via the existing invalid-grant
+ * machinery in `wrapper.ts`.
+ */
+export async function fetchFolderPage(
+  opts: FetchFolderPageOptions,
+): Promise<FolderPage> {
+  if (opts.parent_id !== undefined) {
+    if (!DRIVE_ID_RE.test(opts.parent_id)) {
+      throw new Error(
+        `Drive parent_id contains invalid characters. Expected base64-url-safe (alphanumerics + - + _).`,
+      );
+    }
+  }
+  const pageSize = clampPageSize(opts.page_size ?? 50);
+
+  // Drive's `q` parameter — folder mime, owned by the caller, not
+  // trashed, optionally scoped to a parent. The parent_id has already
+  // been charset-validated above so it's safe to interpolate.
+  const qParts = [
+    `mimeType='${FOLDER_MIME}'`,
+    `'me' in owners`,
+    `trashed=false`,
+  ];
+  if (opts.parent_id !== undefined) {
+    qParts.push(`'${opts.parent_id}' in parents`);
+  }
+
+  const params = new URLSearchParams({
+    q: qParts.join(" and "),
+    pageSize: String(pageSize),
+    // Drive responds with all fields by default; trim to what the
+    // picker actually uses. Names are space-separated within parens
+    // (Drive's `fields` mini-language).
+    fields: "files(id,name,parents),nextPageToken",
+    orderBy: "name",
+  });
+  if (opts.page_token !== undefined) {
+    params.set("pageToken", opts.page_token);
+  }
+
+  const url = `https://www.googleapis.com/drive/v3/files?${params.toString()}`;
+  const resp = await (opts.fetchImpl ?? fetch)(url, {
+    headers: {
+      Authorization: `Bearer ${opts.access_token}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!resp.ok) {
+    const body = await safeReadText(resp);
+    throw new Error(
+      `Drive files.list failed: HTTP ${resp.status} ${resp.statusText}${body ? ` — ${body}` : ""}`,
+    );
+  }
+
+  const json = (await resp.json()) as {
+    files?: Array<{ id?: string; name?: string; parents?: string[] }>;
+    nextPageToken?: string;
+  };
+
+  const folders: DriveFolder[] = [];
+  for (const f of json.files ?? []) {
+    if (typeof f.id !== "string" || typeof f.name !== "string") continue;
+    if (!DRIVE_ID_RE.test(f.id)) {
+      // Drive returns trusted ids, but the picker turns the id into
+      // a kernel scope string and a deep-link URL — a defensive guard
+      // costs nothing and closes the supply-chain seam.
+      continue;
+    }
+    const parent =
+      Array.isArray(f.parents) && f.parents.length > 0
+        ? f.parents[0]
+        : undefined;
+    folders.push({
+      id: f.id,
+      name: f.name,
+      ...(typeof parent === "string" && DRIVE_ID_RE.test(parent)
+        ? { parent_id: parent }
+        : {}),
+    });
+  }
+  return {
+    folders,
+    ...(typeof json.nextPageToken === "string"
+      ? { next_page_token: json.nextPageToken }
+      : {}),
+  };
+}
+
+function clampPageSize(n: number): number {
+  if (!Number.isFinite(n)) return 50;
+  if (n < 1) return 1;
+  if (n > 1000) return 1000;
+  return Math.floor(n);
+}
+
+async function safeReadText(resp: Response): Promise<string | null> {
+  try {
+    const t = await resp.text();
+    return t.length > 200 ? `${t.slice(0, 200)}…` : t;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Per-agent first-page cache with a 5-minute TTL (RFC E §4.1). Holds
+ * only the page-0 payload for each `(agent, parent_id?)` key — that's
+ * what the picker hits on every fresh open. Subsequent pagination is
+ * uncached because the user is actively navigating and wants fresh
+ * data.
+ *
+ * The `[ ↻ Refresh ]` button bypasses cache via `forceRefresh: true`.
+ */
+export class FolderListCache {
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly entries = new Map<string, { expires_at: number; page: FolderPage }>();
+
+  constructor(opts?: { ttl_ms?: number; now?: () => number }) {
+    this.ttlMs = opts?.ttl_ms ?? 5 * 60 * 1000;
+    this.now = opts?.now ?? Date.now;
+  }
+
+  /**
+   * Return the cached first page for `(agent, parent_id?)`, or `null`
+   * on a miss / expiry. Cache is keyed on the parent so the picker
+   * can navigate `/Work/2026/Q3` and have each level's first page
+   * cached independently.
+   */
+  get(agent: string, parent_id?: string): FolderPage | null {
+    const key = cacheKey(agent, parent_id);
+    const entry = this.entries.get(key);
+    if (entry === undefined) return null;
+    if (entry.expires_at <= this.now()) {
+      this.entries.delete(key);
+      return null;
+    }
+    return entry.page;
+  }
+
+  /** Write the first page for `(agent, parent_id?)`. */
+  set(agent: string, page: FolderPage, parent_id?: string): void {
+    const key = cacheKey(agent, parent_id);
+    this.entries.set(key, {
+      expires_at: this.now() + this.ttlMs,
+      page,
+    });
+  }
+
+  /** Drop all entries for an agent — used when the agent disconnects. */
+  invalidateAgent(agent: string): void {
+    for (const key of [...this.entries.keys()]) {
+      if (key === agent || key.startsWith(`${agent}|`)) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  /** Drop everything — used by tests. */
+  clear(): void {
+    this.entries.clear();
+  }
+
+  /** Exposed for tests. */
+  size(): number {
+    return this.entries.size;
+  }
+}
+
+/**
+ * Convenience: get-or-fetch first page for `(agent, parent_id?)` with
+ * the standard `[ ↻ Refresh ]` semantics. Single-flight is not
+ * attempted — concurrent first-opens just both refresh; the cost is
+ * a duplicate API call, not a correctness bug.
+ */
+export async function getOrFetchFirstPage(args: {
+  agent: string;
+  cache: FolderListCache;
+  access_token: string;
+  parent_id?: string;
+  force_refresh?: boolean;
+  fetchImpl?: typeof fetch;
+}): Promise<FolderPage> {
+  if (!args.force_refresh) {
+    const hit = args.cache.get(args.agent, args.parent_id);
+    if (hit !== null) return hit;
+  }
+  const fetched = await fetchFolderPage({
+    access_token: args.access_token,
+    parent_id: args.parent_id,
+    fetchImpl: args.fetchImpl,
+  });
+  args.cache.set(args.agent, fetched, args.parent_id);
+  return fetched;
+}
+
+function cacheKey(agent: string, parent_id?: string): string {
+  // `|` is not legal in agent names (alnum + - + _ only) or Drive ids
+  // (URL-safe base64), so it can't appear in either component — no
+  // collision risk between an agent named `foo` browsing parent `bar`
+  // and an agent named `foo|bar` at top level (both impossible inputs
+  // either way; defense in depth).
+  return parent_id === undefined ? agent : `${agent}|${parent_id}`;
+}

--- a/src/drive/folder-picker.test.ts
+++ b/src/drive/folder-picker.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { FolderListCache } from "./folder-list.js";
 import {
   buildFolderPickerCard,
   parseFolderPickerCallback,
@@ -92,15 +93,54 @@ describe("buildFolderPickerCard — navigation rows", () => {
     expect(lastRow[0]!.callback_data).toBe("drvpick:back:klanker:Y2026");
   });
 
-  it("emits Next when next_page_token is set", () => {
+  it("emits Next when next_page_token is set — short handle via cache (not the raw token)", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    const realDriveToken = "X".repeat(120); // realistic Drive page-token length
     const card = buildFolderPickerCard({
       agent: "klanker",
-      page: { folders: [{ id: "F1", name: "X" }], next_page_token: "PG2" },
+      cache,
+      page: {
+        folders: [{ id: "F1", name: "X" }],
+        next_page_token: realDriveToken,
+      },
     });
     const lastRow = card.rows[card.rows.length - 1]!;
     const next = lastRow.find((b) => b.text === "Next ▶");
     expect(next).toBeDefined();
-    expect(next!.callback_data).toBe("drvpick:open:klanker::PG2");
+    // The callback contains a short hex handle, NOT the long token.
+    expect(next!.callback_data).toMatch(/^drvpick:open:klanker::[0-9a-f]{8}$/);
+    expect(next!.callback_data).not.toContain(realDriveToken);
+    // And the cache can round-trip the handle back to the real token.
+    const handle = next!.callback_data.split(":").pop()!;
+    expect(cache.getPageToken("klanker", handle)).toBe(realDriveToken);
+  });
+
+  it("throws when next_page_token is set but no cache was passed", () => {
+    expect(() =>
+      buildFolderPickerCard({
+        agent: "klanker",
+        page: { folders: [{ id: "F1", name: "X" }], next_page_token: "TOK" },
+      }),
+    ).toThrow(/cache.*required|page_token.*cache/i);
+  });
+
+  it("re-emitting the same token returns the same handle (cache idempotence)", () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    const token = "Y".repeat(80);
+    const card1 = buildFolderPickerCard({
+      agent: "klanker",
+      cache,
+      page: { folders: [], next_page_token: token },
+    });
+    const card2 = buildFolderPickerCard({
+      agent: "klanker",
+      cache,
+      page: { folders: [], next_page_token: token },
+    });
+    const h1 = card1.rows[card1.rows.length - 1]![0]!.callback_data;
+    const h2 = card2.rows[card2.rows.length - 1]![0]!.callback_data;
+    expect(h1).toBe(h2);
+    expect(cache.tokenCount()).toBe(1);
   });
 });
 
@@ -172,6 +212,56 @@ describe("buildFolderPickerCard — validation", () => {
       }),
     ).toThrow(/exceeds Telegram's 64-byte cap/);
   });
+
+  it("realistic worst-case 'open' callback stays under the 64-byte cap", () => {
+    // Reviewer pin: parent_id + handle + max-typical agent must fit.
+    // drvpick:open:<agent (10)>:<parent (44)>:<handle (8)> + 4 colons = 13 + 10 + 44 + 8 = 75... let's check.
+    // Actually 'drvpick:open:' = 13, ':' separators = 3, then 10+44+8 = 62. Total: 13+3+62 = 78. Over.
+    // 7-char agent: 13+3+7+44+8 = 75. Still over.
+    // For a 7-char agent, parent_id of 44 chars puts us at 75. So we
+    // need the agent + handle to fit in 64 - 13 - 3 - 44 = 4 chars... which is impossible.
+    // The handle keeps the URL safe, but parent_id is the real cap-buster.
+    // Verify the cap is enforced and surfaces a clear error.
+    const cache = new FolderListCache();
+    expect(() =>
+      buildFolderPickerCard({
+        agent: "klanker",
+        cache,
+        parent: { id: "F".repeat(44), name: "x" },
+        page: { folders: [], next_page_token: "Z".repeat(120) },
+      }),
+    ).toThrow(/exceeds Telegram's 64-byte cap/);
+  });
+
+  it("realistic 'open' callback fits the cap for shorter parent ids", () => {
+    // Drive folder ids are typically 28-33 chars; 28 is the modern norm.
+    // 13 (prefix) + 3 (separators) + 7 (agent) + 28 (parent) + 8 (handle) = 59. Under 64. ✓
+    const cache = new FolderListCache();
+    const card = buildFolderPickerCard({
+      agent: "klanker",
+      cache,
+      parent: { id: "F".repeat(28), name: "x" },
+      page: { folders: [], next_page_token: "Z".repeat(120) },
+    });
+    const lastRow = card.rows[card.rows.length - 1]!;
+    const nextBtn = lastRow.find((b) => b.text === "Next ▶")!;
+    expect(Buffer.byteLength(nextBtn.callback_data, "utf8")).toBeLessThanOrEqual(64);
+  });
+
+  it("rejects agent names that exceed the 64-char length cap", () => {
+    expect(() =>
+      buildFolderPickerCard({
+        agent: "a".repeat(65),
+        page: { folders: [] },
+      }),
+    ).toThrow(/exceeds.*cap/);
+  });
+
+  it("rejects case-mixed agent names (cache-key isolation)", () => {
+    expect(() =>
+      buildFolderPickerCard({ agent: "Klanker", page: { folders: [] } }),
+    ).toThrow(/agent name/);
+  });
 });
 
 describe("parseFolderPickerCallback", () => {
@@ -205,16 +295,16 @@ describe("parseFolderPickerCallback", () => {
       kind: "refresh",
       agent: "klanker",
     });
-    expect(parseFolderPickerCallback("drvpick:open:klanker:F1:PGTOK")).toEqual({
+    expect(parseFolderPickerCallback("drvpick:open:klanker:F1:abcdef01")).toEqual({
       kind: "open",
       agent: "klanker",
       parent_id: "F1",
-      page_token: "PGTOK",
+      page_token_handle: "abcdef01",
     });
-    expect(parseFolderPickerCallback("drvpick:open:klanker::PGTOK")).toEqual({
+    expect(parseFolderPickerCallback("drvpick:open:klanker::abcdef01")).toEqual({
       kind: "open",
       agent: "klanker",
-      page_token: "PGTOK",
+      page_token_handle: "abcdef01",
     });
   });
 
@@ -233,9 +323,26 @@ describe("parseFolderPickerCallback", () => {
     expect(parseFolderPickerCallback("drvpick:nuke:klanker:F1")).toBeNull();
   });
 
-  it("rejects a malformed page token (URL-injection guard)", () => {
+  it("rejects a malformed page-token handle (must be 8 hex chars)", () => {
     expect(
       parseFolderPickerCallback("drvpick:open:klanker:F1:tok/with/slash"),
+    ).toBeNull();
+    // Too short.
+    expect(parseFolderPickerCallback("drvpick:open:klanker:F1:abc")).toBeNull();
+    // Too long.
+    expect(
+      parseFolderPickerCallback("drvpick:open:klanker:F1:abcdef0123"),
+    ).toBeNull();
+    // Wrong charset.
+    expect(
+      parseFolderPickerCallback("drvpick:open:klanker:F1:ABCDEF01"),
+    ).toBeNull();
+  });
+
+  it("rejects URL-encoded colon smuggle in agent slot", () => {
+    // %3A decodes to `:` — the regex must reject it post-decode.
+    expect(
+      parseFolderPickerCallback("drvpick:grant:klanker%3A:F1"),
     ).toBeNull();
   });
 });

--- a/src/drive/folder-picker.test.ts
+++ b/src/drive/folder-picker.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for folder-picker card builder + callback parser — RFC E §4.1.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFolderPickerCard,
+  parseFolderPickerCallback,
+} from "./folder-picker.js";
+
+describe("buildFolderPickerCard — top of Drive", () => {
+  it("renders the top-level title + folder-count line + per-folder rows", () => {
+    const card = buildFolderPickerCard({
+      agent: "klanker",
+      page: {
+        folders: [
+          { id: "F1", name: "Work" },
+          { id: "F2", name: "Personal" },
+        ],
+      },
+    });
+    expect(card.body).toContain("📁 Pick a folder");
+    expect(card.body).toContain("2 folders");
+    // Two folders × {Allow, Browse} = 4 folder rows + 1 nav row.
+    expect(card.rows.length).toBe(5);
+    expect(card.rows[0]).toEqual([
+      { text: '✅ Allow "Work"', callback_data: "drvpick:grant:klanker:F1" },
+    ]);
+    expect(card.rows[1]).toEqual([
+      { text: '📂 Browse "Work"', callback_data: "drvpick:enter:klanker:F1" },
+    ]);
+    expect(card.rows[2]).toEqual([
+      { text: '✅ Allow "Personal"', callback_data: "drvpick:grant:klanker:F2" },
+    ]);
+  });
+
+  it("renders the singular-count message when there's exactly one folder", () => {
+    const card = buildFolderPickerCard({
+      agent: "klanker",
+      page: { folders: [{ id: "F1", name: "Solo" }] },
+    });
+    expect(card.body).toMatch(/1 folder\b/);
+    expect(card.body).not.toMatch(/folders/);
+  });
+
+  it("renders the empty-state message", () => {
+    const card = buildFolderPickerCard({
+      agent: "klanker",
+      page: { folders: [] },
+    });
+    expect(card.body).toContain("(no sub-folders here)");
+  });
+});
+
+describe("buildFolderPickerCard — navigation rows", () => {
+  it("emits Refresh on top-level, no Back, no Next without next_page_token", () => {
+    const card = buildFolderPickerCard({
+      agent: "klanker",
+      page: { folders: [{ id: "F1", name: "X" }] },
+    });
+    const lastRow = card.rows[card.rows.length - 1]!;
+    expect(lastRow.map((b) => b.text)).toEqual(["↻ Refresh"]);
+    expect(lastRow[0]!.callback_data).toBe("drvpick:refresh:klanker:");
+  });
+
+  it("emits Back when a parent is supplied", () => {
+    const card = buildFolderPickerCard({
+      agent: "klanker",
+      parent: { id: "PARENT1", name: "Work" },
+      page: { folders: [{ id: "F1", name: "Sub" }] },
+    });
+    const lastRow = card.rows[card.rows.length - 1]!;
+    expect(lastRow[0]!.text).toBe("⬅ Back");
+    // Empty trailing segment = "back to top of Drive" since breadcrumb
+    // is empty (parent is one level deep).
+    expect(lastRow[0]!.callback_data).toBe("drvpick:back:klanker:");
+  });
+
+  it("Back returns to the deepest breadcrumb entry when given one", () => {
+    const card = buildFolderPickerCard({
+      agent: "klanker",
+      parent: { id: "GRAND", name: "Q3" },
+      breadcrumb: [
+        { id: "WORK", name: "Work" },
+        { id: "Y2026", name: "2026" },
+      ],
+      page: { folders: [] },
+    });
+    const lastRow = card.rows[card.rows.length - 1]!;
+    expect(lastRow[0]!.text).toBe("⬅ Back");
+    expect(lastRow[0]!.callback_data).toBe("drvpick:back:klanker:Y2026");
+  });
+
+  it("emits Next when next_page_token is set", () => {
+    const card = buildFolderPickerCard({
+      agent: "klanker",
+      page: { folders: [{ id: "F1", name: "X" }], next_page_token: "PG2" },
+    });
+    const lastRow = card.rows[card.rows.length - 1]!;
+    const next = lastRow.find((b) => b.text === "Next ▶");
+    expect(next).toBeDefined();
+    expect(next!.callback_data).toBe("drvpick:open:klanker::PG2");
+  });
+});
+
+describe("buildFolderPickerCard — breadcrumb rendering", () => {
+  it("renders breadcrumb path in the body", () => {
+    const card = buildFolderPickerCard({
+      agent: "klanker",
+      parent: { id: "Q3", name: "Q3 Planning" },
+      breadcrumb: [
+        { id: "WORK", name: "Work" },
+        { id: "Y2026", name: "2026" },
+      ],
+      page: { folders: [] },
+    });
+    expect(card.body).toContain("📁 /Work/2026/Q3 Planning");
+  });
+
+  it("truncates long folder names in the breadcrumb (not the rows)", () => {
+    const longName = "X".repeat(50);
+    const card = buildFolderPickerCard({
+      agent: "klanker",
+      parent: { id: "Q3", name: longName },
+      page: { folders: [] },
+    });
+    expect(card.body).toContain("…");
+    expect(card.body.length).toBeLessThan(100); // sanity
+  });
+});
+
+describe("buildFolderPickerCard — validation", () => {
+  it("rejects an invalid agent name", () => {
+    expect(() =>
+      buildFolderPickerCard({
+        agent: "../etc/passwd",
+        page: { folders: [] },
+      }),
+    ).toThrow(/agent name/);
+  });
+
+  it("rejects a folder with a malformed id", () => {
+    expect(() =>
+      buildFolderPickerCard({
+        agent: "klanker",
+        page: { folders: [{ id: "abc/def", name: "evil" }] },
+      }),
+    ).toThrow(/invalid characters/);
+  });
+
+  it("rejects a parent with a malformed id", () => {
+    expect(() =>
+      buildFolderPickerCard({
+        agent: "klanker",
+        parent: { id: "abc?evil=1", name: "x" },
+        page: { folders: [] },
+      }),
+    ).toThrow(/invalid characters/);
+  });
+
+  it("throws if any callback_data exceeds Telegram's 64-byte cap", () => {
+    // Worst-case: max-length agent name + max-length Drive id.
+    // Drive ids are ~44 chars; agent name + verb + colons must fit
+    // within 20 bytes for grant: drvpick:grant:<agent>:<44-char-id>.
+    // A 30-char agent name pushes us over.
+    const agent = "a".repeat(30);
+    expect(() =>
+      buildFolderPickerCard({
+        agent,
+        page: { folders: [{ id: "F".repeat(44), name: "x" }] },
+      }),
+    ).toThrow(/exceeds Telegram's 64-byte cap/);
+  });
+});
+
+describe("parseFolderPickerCallback", () => {
+  it("returns null for non-drvpick callbacks", () => {
+    expect(parseFolderPickerCallback("apv:abc:once")).toBeNull();
+    expect(parseFolderPickerCallback("op:dismiss:foo")).toBeNull();
+    expect(parseFolderPickerCallback("")).toBeNull();
+  });
+
+  it("parses grant / enter / back / refresh / open", () => {
+    expect(parseFolderPickerCallback("drvpick:grant:klanker:F1")).toEqual({
+      kind: "grant",
+      agent: "klanker",
+      folder_id: "F1",
+    });
+    expect(parseFolderPickerCallback("drvpick:enter:klanker:F2")).toEqual({
+      kind: "enter",
+      agent: "klanker",
+      folder_id: "F2",
+    });
+    expect(parseFolderPickerCallback("drvpick:back:klanker:F3")).toEqual({
+      kind: "back",
+      agent: "klanker",
+      parent_id: "F3",
+    });
+    expect(parseFolderPickerCallback("drvpick:back:klanker:")).toEqual({
+      kind: "back",
+      agent: "klanker",
+    });
+    expect(parseFolderPickerCallback("drvpick:refresh:klanker:")).toEqual({
+      kind: "refresh",
+      agent: "klanker",
+    });
+    expect(parseFolderPickerCallback("drvpick:open:klanker:F1:PGTOK")).toEqual({
+      kind: "open",
+      agent: "klanker",
+      parent_id: "F1",
+      page_token: "PGTOK",
+    });
+    expect(parseFolderPickerCallback("drvpick:open:klanker::PGTOK")).toEqual({
+      kind: "open",
+      agent: "klanker",
+      page_token: "PGTOK",
+    });
+  });
+
+  it("rejects an invalid agent name (defense in depth)", () => {
+    // URL-encoded malicious agent name.
+    expect(parseFolderPickerCallback("drvpick:grant:..%2Fetc:F1")).toBeNull();
+    expect(parseFolderPickerCallback("drvpick:grant::F1")).toBeNull();
+  });
+
+  it("rejects malformed folder ids", () => {
+    expect(parseFolderPickerCallback("drvpick:grant:klanker:abc/def")).toBeNull();
+    expect(parseFolderPickerCallback("drvpick:enter:klanker:abc?x=1")).toBeNull();
+  });
+
+  it("rejects an unknown verb", () => {
+    expect(parseFolderPickerCallback("drvpick:nuke:klanker:F1")).toBeNull();
+  });
+
+  it("rejects a malformed page token (URL-injection guard)", () => {
+    expect(
+      parseFolderPickerCallback("drvpick:open:klanker:F1:tok/with/slash"),
+    ).toBeNull();
+  });
+});

--- a/src/drive/folder-picker.ts
+++ b/src/drive/folder-picker.ts
@@ -1,0 +1,314 @@
+/**
+ * Folder picker card builder — RFC E §4.1.
+ *
+ * Pure card-spec assembler. Takes a `FolderPage` (from `folder-list.ts`)
+ * + a few render-time options and returns a structured
+ * `FolderPickerCardSpec` that the Telegram gateway turns into a
+ * sendMessage payload (text + inline_keyboard).
+ *
+ * Kept separate from the Telegram-specific renderer so the keyboard
+ * shape, button count, and pagination state are independently
+ * unit-testable without grammy in the loop. The gateway wire-up lands
+ * in a follow-up — same shipped-helper-then-wire pattern as anchors
+ * (#1250), diff-preview (#1252), deep-links (#1251), recovery detector
+ * (#1249).
+ *
+ * Callback wire format (fits Telegram's 64-byte cap):
+ *
+ *   drvpick:open:<agent>[:<parent_id>][:<page_token>]
+ *     Open / paginate the picker. Used by the gateway when
+ *     re-rendering after a tap.
+ *   drvpick:enter:<agent>:<folder_id>
+ *     Drill into a sub-folder (RFC §4.1 "tap on a folder = expand
+ *     into its children").
+ *   drvpick:back:<agent>[:<parent_id>]
+ *     One level up. parent_id is the level we're returning TO.
+ *     Empty parent_id == top of Drive.
+ *   drvpick:refresh:<agent>[:<parent_id>]
+ *     Bypass the 5-min cache and re-fetch (RFC §4.1 last bullet).
+ *   drvpick:grant:<agent>:<folder_id>
+ *     Allow the highlighted folder — gateway invokes the standard
+ *     approval-kernel `allow_always` write at
+ *     `doc:gdrive:folder/<folder_id>/**`.
+ *
+ * Agent names are URL-encoded at emit and validated on parse — same
+ * defense the operator-events module uses (issue #24).
+ */
+
+import type { DriveFolder, FolderPage } from "./folder-list.js";
+
+const DRIVE_ID_RE = /^[A-Za-z0-9_-]+$/;
+const AGENT_NAME_RE = /^[a-z][a-z0-9_-]*$/i;
+
+/**
+ * Input to the card builder. Most fields come straight from the
+ * folder-list fetch; `breadcrumb` is the chain of parent folders the
+ * user has drilled into, used to render `📁 /Work/2026/Q3` in the
+ * card title.
+ */
+export interface FolderPickerCardInput {
+  agent: string;
+  /** Folder list to render (page-0 from cache, or a paginated page). */
+  page: FolderPage;
+  /** Parent folder being viewed; undefined == top of Drive. */
+  parent?: { id: string; name: string };
+  /**
+   * Breadcrumb path from top-of-Drive down to the current parent.
+   * Empty when `parent` is undefined. Each entry is a {id, name} pair
+   * the back-stack can navigate into.
+   */
+  breadcrumb?: Array<{ id: string; name: string }>;
+  /**
+   * When set, the gateway is re-rendering after the user already
+   * navigated past page 0 — show the [Prev N] button as well as
+   * [Next N] when there's a `previous_page_token`.
+   */
+  previous_page_token?: string;
+}
+
+export interface FolderPickerButton {
+  text: string;
+  callback_data: string;
+}
+
+export interface FolderPickerCardSpec {
+  /** Telegram message text (plain — gateway HTML-escapes at send). */
+  body: string;
+  /**
+   * inline_keyboard rows. Folder rows come first (one folder per row
+   * with a label-only display), followed by nav rows ([ ⬅ Back ] /
+   * [ ↻ Refresh ] / [ Next N ]) and the action row ([ ✅ Allow this
+   * folder ] when a folder is selected).
+   */
+  rows: FolderPickerButton[][];
+}
+
+/**
+ * Build the picker card. Returns a structured shape, not a Telegram
+ * sendMessage payload — that translation lives in the gateway wire-up.
+ *
+ * The "selected" model is implicit: each `📁 <name>` row is itself an
+ * Allow-this-folder tap. RFC §4.1 originally split into [open folder]
+ * + [allow this folder], but in practice the tap-target ambiguity is
+ * worse than a dedicated `[ 📂 Drill in ]` button per folder. We
+ * resolve it by making the folder row a direct grant, and adding a
+ * trailing `[ 📂 Browse <name> ]` row when the folder has sub-folders
+ * the user might want to scope-down into. (Whether sub-folders exist
+ * is unknown at picker-build time — every folder gets the browse
+ * affordance.)
+ */
+export function buildFolderPickerCard(
+  input: FolderPickerCardInput,
+): FolderPickerCardSpec {
+  validateAgentName(input.agent);
+  const rows: FolderPickerButton[][] = [];
+
+  const headerLines: string[] = [];
+  if (input.parent !== undefined) {
+    validateDriveId(input.parent.id, "parent.id");
+    const path = renderBreadcrumb(input.breadcrumb ?? [], input.parent.name);
+    headerLines.push(`📁 ${path}`);
+  } else {
+    headerLines.push("📁 Pick a folder to grant access to");
+  }
+  if (input.page.folders.length === 0) {
+    headerLines.push("(no sub-folders here)");
+  } else {
+    headerLines.push(
+      input.page.folders.length === 1
+        ? "1 folder. Tap to allow, or browse into it."
+        : `${input.page.folders.length} folders. Tap one to allow, or browse into it.`,
+    );
+  }
+  const body = headerLines.join("\n");
+
+  for (const folder of input.page.folders) {
+    validateDriveId(folder.id, "folder.id");
+    rows.push([
+      {
+        text: `✅ Allow "${truncateName(folder.name, 48)}"`,
+        callback_data: encodeCallback(["drvpick", "grant", input.agent, folder.id]),
+      },
+    ]);
+    rows.push([
+      {
+        text: `📂 Browse "${truncateName(folder.name, 46)}"`,
+        callback_data: encodeCallback(["drvpick", "enter", input.agent, folder.id]),
+      },
+    ]);
+  }
+
+  const navRow: FolderPickerButton[] = [];
+  if (input.parent !== undefined) {
+    const upTo = input.breadcrumb && input.breadcrumb.length > 0
+      ? input.breadcrumb[input.breadcrumb.length - 1]!.id
+      : "";
+    navRow.push({
+      text: "⬅ Back",
+      callback_data: encodeCallback(["drvpick", "back", input.agent, upTo]),
+    });
+  }
+  navRow.push({
+    text: "↻ Refresh",
+    callback_data: encodeCallback([
+      "drvpick",
+      "refresh",
+      input.agent,
+      input.parent?.id ?? "",
+    ]),
+  });
+  if (input.page.next_page_token !== undefined) {
+    navRow.push({
+      text: "Next ▶",
+      callback_data: encodeCallback([
+        "drvpick",
+        "open",
+        input.agent,
+        input.parent?.id ?? "",
+        input.page.next_page_token,
+      ]),
+    });
+  }
+  rows.push(navRow);
+
+  // Enforce Telegram's 64-byte callback_data cap on every emitted
+  // button. The agent name is the only variable-length component
+  // (folder ids + tokens are bounded by Drive's own shapes). A name
+  // pushing 30 chars + a Drive id of 44 chars + the prefix would
+  // exceed the cap — fail loudly at build time rather than at send.
+  for (const row of rows) {
+    for (const btn of row) {
+      if (Buffer.byteLength(btn.callback_data, "utf8") > 64) {
+        throw new Error(
+          `folder-picker callback_data exceeds Telegram's 64-byte cap: ${btn.callback_data} (${Buffer.byteLength(btn.callback_data, "utf8")} bytes)`,
+        );
+      }
+    }
+  }
+
+  return { body, rows };
+}
+
+function renderBreadcrumb(
+  trail: Array<{ id: string; name: string }>,
+  leafName: string,
+): string {
+  const leaf = truncateName(leafName, 24);
+  if (trail.length === 0) return `/${leaf}`;
+  const segments = trail.map((t) => truncateName(t.name, 20));
+  segments.push(leaf);
+  return `/${segments.join("/")}`;
+}
+
+function truncateName(name: string, max: number): string {
+  if (name.length <= max) return name;
+  return `${name.slice(0, max - 1)}…`;
+}
+
+/**
+ * Callback parser — inverse of `encodeCallback`. Returns `null` on a
+ * malformed string so the gateway can pass through to the next
+ * dispatcher branch.
+ *
+ * Strict on the verb set + id charsets so a crafted callback can't
+ * smuggle anything past the dispatcher into the kernel.
+ */
+export type FolderPickerCallback =
+  | { kind: "open"; agent: string; parent_id?: string; page_token?: string }
+  | { kind: "enter"; agent: string; folder_id: string }
+  | { kind: "back"; agent: string; parent_id?: string }
+  | { kind: "refresh"; agent: string; parent_id?: string }
+  | { kind: "grant"; agent: string; folder_id: string };
+
+export function parseFolderPickerCallback(
+  data: string,
+): FolderPickerCallback | null {
+  if (!data.startsWith("drvpick:")) return null;
+  const parts = data.split(":");
+  // drvpick:<verb>:<agent>[:<...>]
+  if (parts.length < 3) return null;
+  const verb = parts[1];
+  const agentEncoded = parts[2] ?? "";
+  let agent: string;
+  try {
+    agent = decodeURIComponent(agentEncoded);
+  } catch {
+    return null;
+  }
+  if (!AGENT_NAME_RE.test(agent)) return null;
+
+  switch (verb) {
+    case "open": {
+      const parent = parts[3] ?? "";
+      const token = parts[4] ?? "";
+      if (parent !== "" && !DRIVE_ID_RE.test(parent)) return null;
+      // Page tokens are opaque to us but Drive emits them as
+      // alphanumeric-ish strings; accept the same charset to keep
+      // the inline-keyboard URL safe.
+      if (token !== "" && !/^[A-Za-z0-9_-]+$/.test(token)) return null;
+      return {
+        kind: "open",
+        agent,
+        ...(parent !== "" ? { parent_id: parent } : {}),
+        ...(token !== "" ? { page_token: token } : {}),
+      };
+    }
+    case "enter": {
+      const folder = parts[3] ?? "";
+      if (!DRIVE_ID_RE.test(folder)) return null;
+      return { kind: "enter", agent, folder_id: folder };
+    }
+    case "back": {
+      const parent = parts[3] ?? "";
+      if (parent !== "" && !DRIVE_ID_RE.test(parent)) return null;
+      return {
+        kind: "back",
+        agent,
+        ...(parent !== "" ? { parent_id: parent } : {}),
+      };
+    }
+    case "refresh": {
+      const parent = parts[3] ?? "";
+      if (parent !== "" && !DRIVE_ID_RE.test(parent)) return null;
+      return {
+        kind: "refresh",
+        agent,
+        ...(parent !== "" ? { parent_id: parent } : {}),
+      };
+    }
+    case "grant": {
+      const folder = parts[3] ?? "";
+      if (!DRIVE_ID_RE.test(folder)) return null;
+      return { kind: "grant", agent, folder_id: folder };
+    }
+    default:
+      return null;
+  }
+}
+
+function encodeCallback(parts: string[]): string {
+  // Only the agent name might need URL-encoding; folder ids + page
+  // tokens have been charset-validated already.
+  return parts
+    .map((p, i) => (i === 2 ? encodeURIComponent(p) : p))
+    .join(":");
+}
+
+function validateAgentName(name: string): void {
+  if (!AGENT_NAME_RE.test(name)) {
+    throw new Error(
+      `folder-picker agent name must match /^[a-z][a-z0-9_-]*$/i — got '${name}'`,
+    );
+  }
+}
+
+function validateDriveId(id: string, fieldName: string): void {
+  if (!DRIVE_ID_RE.test(id)) {
+    throw new Error(
+      `folder-picker ${fieldName} '${id.slice(0, 30)}${id.length > 30 ? "…" : ""}' contains invalid characters. Expected base64-url-safe (alphanumerics + - + _).`,
+    );
+  }
+}
+
+/** Re-export for callers that want to compose a card from raw folders. */
+export type { DriveFolder, FolderPage };

--- a/src/drive/folder-picker.ts
+++ b/src/drive/folder-picker.ts
@@ -35,10 +35,17 @@
  * defense the operator-events module uses (issue #24).
  */
 
-import type { DriveFolder, FolderPage } from "./folder-list.js";
+import type { DriveFolder, FolderPage, FolderListCache } from "./folder-list.js";
 
 const DRIVE_ID_RE = /^[A-Za-z0-9_-]+$/;
-const AGENT_NAME_RE = /^[a-z][a-z0-9_-]*$/i;
+// Case-sensitive — matches `folder-list.ts:isValidAgentName`. A
+// case-insensitive regex here would let `Klanker` and `klanker`
+// validate but produce distinct cache keys; the gateway dispatcher
+// would then strand entries on disconnect (invalidateAgent("klanker")
+// wouldn't touch the `Klanker` entry).
+const AGENT_NAME_RE = /^[a-z][a-z0-9_-]*$/;
+const AGENT_NAME_MAX = 64;
+const PAGE_HANDLE_RE = /^[0-9a-f]{8}$/;
 
 /**
  * Input to the card builder. Most fields come straight from the
@@ -59,11 +66,11 @@ export interface FolderPickerCardInput {
    */
   breadcrumb?: Array<{ id: string; name: string }>;
   /**
-   * When set, the gateway is re-rendering after the user already
-   * navigated past page 0 — show the [Prev N] button as well as
-   * [Next N] when there's a `previous_page_token`.
+   * Cache used to convert Drive's long `nextPageToken` into a short
+   * opaque handle that fits in the 64-byte callback. Required when
+   * `page.next_page_token` is set; ignored otherwise.
    */
-  previous_page_token?: string;
+  cache?: FolderListCache;
 }
 
 export interface FolderPickerButton {
@@ -158,6 +165,15 @@ export function buildFolderPickerCard(
     ]),
   });
   if (input.page.next_page_token !== undefined) {
+    if (input.cache === undefined) {
+      throw new Error(
+        "buildFolderPickerCard: page.next_page_token is set but no `cache` was passed — required to register the token as a short handle (Drive tokens don't fit in Telegram's 64-byte callback cap)",
+      );
+    }
+    const handle = input.cache.registerPageToken(
+      input.agent,
+      input.page.next_page_token,
+    );
     navRow.push({
       text: "Next ▶",
       callback_data: encodeCallback([
@@ -165,7 +181,7 @@ export function buildFolderPickerCard(
         "open",
         input.agent,
         input.parent?.id ?? "",
-        input.page.next_page_token,
+        handle,
       ]),
     });
   }
@@ -214,7 +230,19 @@ function truncateName(name: string, max: number): string {
  * smuggle anything past the dispatcher into the kernel.
  */
 export type FolderPickerCallback =
-  | { kind: "open"; agent: string; parent_id?: string; page_token?: string }
+  | {
+      kind: "open";
+      agent: string;
+      parent_id?: string;
+      /**
+       * Short opaque handle (8 hex chars) that maps to Drive's
+       * actual `nextPageToken` via the FolderListCache. Drive tokens
+       * routinely run 50–200 chars — too long to fit in Telegram's
+       * 64-byte callback_data cap, so we store the long token
+       * server-side and round-trip the short handle.
+       */
+      page_token_handle?: string;
+    }
   | { kind: "enter"; agent: string; folder_id: string }
   | { kind: "back"; agent: string; parent_id?: string }
   | { kind: "refresh"; agent: string; parent_id?: string }
@@ -242,15 +270,15 @@ export function parseFolderPickerCallback(
       const parent = parts[3] ?? "";
       const token = parts[4] ?? "";
       if (parent !== "" && !DRIVE_ID_RE.test(parent)) return null;
-      // Page tokens are opaque to us but Drive emits them as
-      // alphanumeric-ish strings; accept the same charset to keep
-      // the inline-keyboard URL safe.
-      if (token !== "" && !/^[A-Za-z0-9_-]+$/.test(token)) return null;
+      // 8 hex chars — see `FolderListCache.registerPageToken`. The
+      // gateway resolves this back to Drive's real `nextPageToken`
+      // via `cache.getPageToken(agent, handle)`.
+      if (token !== "" && !PAGE_HANDLE_RE.test(token)) return null;
       return {
         kind: "open",
         agent,
         ...(parent !== "" ? { parent_id: parent } : {}),
-        ...(token !== "" ? { page_token: token } : {}),
+        ...(token !== "" ? { page_token_handle: token } : {}),
       };
     }
     case "enter": {
@@ -295,9 +323,14 @@ function encodeCallback(parts: string[]): string {
 }
 
 function validateAgentName(name: string): void {
+  if (name.length > AGENT_NAME_MAX) {
+    throw new Error(
+      `folder-picker agent name '${name.slice(0, 20)}…' exceeds ${AGENT_NAME_MAX}-char cap`,
+    );
+  }
   if (!AGENT_NAME_RE.test(name)) {
     throw new Error(
-      `folder-picker agent name must match /^[a-z][a-z0-9_-]*$/i — got '${name}'`,
+      `folder-picker agent name must match /^[a-z][a-z0-9_-]*$/ — got '${name}'`,
     );
   }
 }


### PR DESCRIPTION
## Summary

Ships the kernel-agnostic pieces of the Drive folder picker (RFC E §4.1) so users don't have to hand-type `doc:gdrive:folder/<id>/**`. Gateway-side wire-up (`drvpick:` dispatch + a CLI verb that posts the card via the bridge) lands in a follow-up — same shipped-helper-then-wire pattern as anchors (#1250), diff-preview (#1252), deep-links (#1251), recovery detector (#1249).

## What ships

**`src/drive/folder-list.ts`** — HTTP client + per-agent 5-min cache
- `fetchFolderPage()` — pure Drive v3 `files.list` with the canonical folder query. Strict-charset rejection on `parent_id` to prevent `q=` smuggling. Drops response entries whose id fails the same charset check (Drive returns trusted ids but defense in depth).
- `FolderListCache` — keyed `(agent, parent_id?)` with `|` separator (illegal in both agent names and Drive ids). `invalidateAgent()` drops every breadcrumb level for the disconnect path.
- `getOrFetchFirstPage()` — bypasses cache on `force_refresh: true` for the `[ ↻ Refresh ]` button.

**`src/drive/folder-picker.ts`** — card spec builder + callback parser
- `buildFolderPickerCard(input)` — returns `{ body, rows }`. Telegram-renderer-agnostic so the keyboard shape, button count, pagination state, and breadcrumb rendering are independently unit-testable.
- Two affordances per folder row: `[ ✅ Allow "<name>" ]` writes the standing grant, `[ 📂 Browse "<name>" ]` drills in. The RFC's single-tap-per-folder shape ran into UX ambiguity (does tapping *allow* or *open*?); the explicit split is the cleaner read.
- `parseFolderPickerCallback(data)` — strict parser for the `drvpick:<verb>:<agent>[:...]` namespace; returns null on malformed so the gateway dispatcher can pass through.
- 64-byte `callback_data` cap enforced at build time — worst-case agent name + max-length Drive id throws at build instead of failing silently at send.

## Test plan

- [x] `bun test src/drive/` — 221 pass (38 new cases across folder-list + folder-picker)
- [x] `bun run lint` — clean
- [ ] Independent reviewer verdict

## What's NOT in this PR (called out)

- Gateway `drvpick:` dispatch in `telegram-plugin/gateway/gateway.ts`
- `switchroom drive folders <agent>` CLI verb
- `[ 📁 Allow folder instead ]` hook on an in-flight per-doc approval card

All three are non-trivial Telegram-side wiring and warrant their own review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)