### PR TITLE
feat(drive): RFC E §4.2 — edit-preparation helpers for the four MCP tools

### DIFF
--- a/src/drive/edits.test.ts
+++ b/src/drive/edits.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Tests for edit-preparation helpers — RFC E §4.2 MCP-tool
+ * foundations.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { DocumentSnapshot } from "./anchors.js";
+import {
+  countLines,
+  prepareAppendToDoc,
+  prepareApplyEdit,
+  prepareCreateDoc,
+  prepareSuggestEdit,
+} from "./edits.js";
+
+/** Fixture: a small headed doc with one paragraph per section. */
+function fixtureDoc(): DocumentSnapshot {
+  return {
+    paragraphs: [
+      { kind: "heading", level: 1, text: "Q3 Plan", index: 0 },
+      { kind: "text", text: "Intro paragraph.", index: 1 },
+      { kind: "heading", level: 2, text: "Goals", index: 2 },
+      { kind: "text", text: "Ship the picker.", index: 3 },
+      { kind: "heading", level: 2, text: "Hiring", index: 4 },
+      { kind: "text", text: "TBD.", index: 5 },
+    ],
+  };
+}
+
+const ctxBase = {
+  agentName: "klanker",
+  fileId: "DOC1",
+  docTitle: "Q3 Strategy Notes",
+};
+
+describe("countLines", () => {
+  it("zero lines for empty text", () => {
+    expect(countLines("")).toBe(0);
+  });
+
+  it("one line for a single line without trailing newline", () => {
+    expect(countLines("hello")).toBe(1);
+  });
+
+  it("counts paragraph breaks", () => {
+    expect(countLines("one\ntwo\nthree")).toBe(3);
+  });
+
+  it("trailing newline doesn't open a new paragraph", () => {
+    expect(countLines("one\ntwo\n")).toBe(2);
+  });
+
+  it("counts multiple blank-line separated paragraphs", () => {
+    expect(countLines("para 1\n\npara 2")).toBe(3);
+  });
+});
+
+describe("prepareSuggestEdit — success cases", () => {
+  it("resolves a heading anchor and returns mode: suggest", () => {
+    const r = prepareSuggestEdit({
+      ...ctxBase,
+      doc: fixtureDoc(),
+      anchor: { after_heading: "Goals", level: 2 },
+      text: "New goal: ship the folder picker.",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.mode).toBe("suggest");
+    expect(r.resolved.displayName).toMatch(/Goals/);
+    expect(r.operations).toEqual([
+      { kind: "insert_after", paragraphIndex: 2, text: "New goal: ship the folder picker." },
+    ]);
+    expect(r.preview.mode).toBe("suggest");
+    expect(r.preview.metrics).toEqual({ linesAdded: 1, linesRemoved: 0 });
+    expect(r.preview.fileId).toBe("DOC1");
+    expect(r.preview.docTitle).toBe("Q3 Strategy Notes");
+  });
+
+  it("resolves an append_to_section anchor and emits the right edit-plan op", () => {
+    const r = prepareSuggestEdit({
+      ...ctxBase,
+      doc: fixtureDoc(),
+      anchor: { append_to_section: "Hiring", level: 2 },
+      text: "Reach out to Alice.",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.operations[0]?.kind).toBe("append_to_section_end");
+  });
+
+  it("counts removed line for replace_line_matching", () => {
+    const r = prepareSuggestEdit({
+      ...ctxBase,
+      doc: fixtureDoc(),
+      anchor: { replace_line_matching: /TBD/ },
+      text: "Filled in.",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.metrics).toEqual({ linesAdded: 1, linesRemoved: 1 });
+    expect(r.operations[0]?.kind).toBe("replace_paragraph");
+  });
+
+  it("threads through agent summary + mimeType + discussionId", () => {
+    const r = prepareSuggestEdit({
+      ...ctxBase,
+      mimeType: "application/vnd.google-apps.document",
+      discussionId: "thr-1",
+      agentSummary: "Added a goal",
+      doc: fixtureDoc(),
+      anchor: { after_heading: "Goals" },
+      text: "Goal text",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.mimeType).toBe("application/vnd.google-apps.document");
+    expect(r.preview.discussionId).toBe("thr-1");
+    expect(r.preview.agentSummary).toBe("Added a goal");
+  });
+});
+
+describe("prepareSuggestEdit — anchor errors surface verbatim", () => {
+  it("HEADING_NOT_FOUND for unknown heading", () => {
+    const r = prepareSuggestEdit({
+      ...ctxBase,
+      doc: fixtureDoc(),
+      anchor: { after_heading: "Nonexistent" },
+      text: "x",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe("HEADING_NOT_FOUND");
+  });
+
+  it("SNIPPET_NOT_FOUND for unknown snippet", () => {
+    const r = prepareSuggestEdit({
+      ...ctxBase,
+      doc: fixtureDoc(),
+      anchor: { after_line_containing: "never appears" },
+      text: "x",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe("SNIPPET_NOT_FOUND");
+  });
+
+  it("INVALID_ANCHOR for empty edit text", () => {
+    const r = prepareSuggestEdit({
+      ...ctxBase,
+      doc: fixtureDoc(),
+      anchor: { after_heading: "Goals" },
+      text: "",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe("INVALID_ANCHOR");
+  });
+});
+
+describe("prepareApplyEdit", () => {
+  it("returns mode: write for the same anchor input as suggest", () => {
+    const r = prepareApplyEdit({
+      ...ctxBase,
+      doc: fixtureDoc(),
+      anchor: { after_heading: "Goals" },
+      text: "Goal text",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.mode).toBe("write");
+    expect(r.preview.mode).toBe("write");
+  });
+
+  it("emits the identical edit plan to suggest — only the mode tag differs", () => {
+    const args = {
+      ...ctxBase,
+      doc: fixtureDoc(),
+      anchor: { after_heading: "Goals" as const },
+      text: "Goal text",
+    };
+    const s = prepareSuggestEdit(args);
+    const w = prepareApplyEdit(args);
+    expect(s.ok && w.ok).toBe(true);
+    if (!s.ok || !w.ok) return;
+    expect(s.operations).toEqual(w.operations);
+  });
+});
+
+describe("prepareCreateDoc", () => {
+  it("emits a create_doc op + synthetic resolved anchor", () => {
+    const r = prepareCreateDoc({
+      agentName: "klanker",
+      title: "New Plan",
+      body: "Line 1\nLine 2",
+      parentFolderId: "FOLDER1",
+      parentFolderName: "Work",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.mode).toBe("write");
+    expect(r.operations).toEqual([
+      {
+        kind: "create_doc",
+        title: "New Plan",
+        parentFolderId: "FOLDER1",
+        body: "Line 1\nLine 2",
+      },
+    ]);
+    expect(r.resolved.displayName).toBe("new doc in /Work");
+    expect(r.preview.metrics).toEqual({ linesAdded: 2, linesRemoved: 0 });
+    expect(r.preview.fileId).toBe("pending-create");
+  });
+
+  it("falls back to the folder id when no parent name is provided", () => {
+    const r = prepareCreateDoc({
+      agentName: "klanker",
+      title: "New Plan",
+      body: "x",
+      parentFolderId: "FOLDER1",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.resolved.displayName).toBe("new doc in /FOLDER1");
+  });
+
+  it("renders 'root' for top-of-Drive", () => {
+    const r = prepareCreateDoc({
+      agentName: "klanker",
+      title: "Top",
+      body: "x",
+      parentFolderId: "root",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.resolved.displayName).toBe("new doc in /root");
+  });
+
+  it("rejects empty title", () => {
+    const r = prepareCreateDoc({
+      agentName: "klanker",
+      title: "   ",
+      body: "x",
+      parentFolderId: "F1",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe("INVALID_ANCHOR");
+  });
+
+  it("rejects empty parent folder id", () => {
+    const r = prepareCreateDoc({
+      agentName: "klanker",
+      title: "T",
+      body: "x",
+      parentFolderId: "",
+    });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("prepareAppendToDoc", () => {
+  it("emits append_to_doc with the right line metrics + display name", () => {
+    const r = prepareAppendToDoc({
+      agentName: "klanker",
+      fileId: "DOC1",
+      docTitle: "Daily Log",
+      text: "Entry 1\nEntry 2\nEntry 3",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.operations).toEqual([
+      { kind: "append_to_doc", text: "Entry 1\nEntry 2\nEntry 3" },
+    ]);
+    expect(r.resolved.displayName).toBe("at end of doc (append)");
+    expect(r.preview.metrics).toEqual({ linesAdded: 3, linesRemoved: 0 });
+    expect(r.mode).toBe("write");
+  });
+
+  it("rejects empty text", () => {
+    const r = prepareAppendToDoc({
+      agentName: "klanker",
+      fileId: "DOC1",
+      docTitle: "X",
+      text: "",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe("INVALID_ANCHOR");
+  });
+});
+
+describe("wrapper-attested invariants (RFC E §4.2)", () => {
+  it("agentSummary cannot override the wrapper's resolved.displayName", () => {
+    const r = prepareSuggestEdit({
+      ...ctxBase,
+      doc: fixtureDoc(),
+      anchor: { after_heading: "Goals" },
+      text: "Edit text",
+      agentSummary: "Added Hiring section",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // Agent claimed Hiring; wrapper says Goals. Both are surfaced
+    // separately on the preview; the resolved displayName is from
+    // the wrapper.
+    expect(r.resolved.displayName).toMatch(/Goals/);
+    expect(r.preview.agentSummary).toBe("Added Hiring section");
+    expect(r.preview.resolvedAnchor.displayName).toMatch(/Goals/);
+    expect(r.preview.resolvedAnchor.displayName).not.toMatch(/Hiring/);
+  });
+
+  it("agent cannot inflate line counts via the summary string", () => {
+    const r = prepareSuggestEdit({
+      ...ctxBase,
+      doc: fixtureDoc(),
+      anchor: { after_heading: "Goals" },
+      text: "single line",
+      agentSummary: "+5 lines",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.metrics).toEqual({ linesAdded: 1, linesRemoved: 0 });
+  });
+});

--- a/src/drive/edits.ts
+++ b/src/drive/edits.ts
@@ -1,0 +1,406 @@
+/**
+ * Edit-preparation helpers — RFC E §4.2 MCP-tool foundations.
+ *
+ * Pure functions that turn the four agent-facing edit operations into
+ * structured edit plans + diff-preview inputs:
+ *
+ *   - `prepareSuggestEdit(...)`   → gdrive_suggest_edit(doc_id, anchor, text)
+ *   - `prepareApplyEdit(...)`     → gdrive_apply_edit(doc_id, anchor, text)
+ *   - `prepareCreateDoc(...)`     → gdrive_create_doc(title, content, parent_folder)
+ *   - `prepareAppendToDoc(...)`   → gdrive_append_to_doc(doc_id, text)
+ *
+ * Each returns either a typed `AnchorError` (HEADING_NOT_FOUND /
+ * SNIPPET_AMBIGUOUS / SNIPPET_NOT_FOUND / NTH_MATCH_OUT_OF_RANGE /
+ * EMPTY_DOC_NEEDS_POSITION / INVALID_ANCHOR) verbatim from the
+ * resolver in `anchors.ts`, OR a `PrepareSuccess` carrying:
+ *
+ *   1. The structured `EditOperation[]` plan (paragraph-index-keyed —
+ *      what the eventual MCP-server tool wrapper translates into a
+ *      Google Docs `documents.batchUpdate` request).
+ *   2. A ready-to-go `DiffPreviewInput` for `buildDiffPreview` (B3
+ *      wires that into the approval kernel).
+ *
+ * The kernel-agnostic seam is deliberate — the MCP-server tool
+ * registration + the actual Drive API call live in follow-up wiring.
+ *
+ * Suggest-vs-write semantics (RFC E §4.2 nuance worth pinning):
+ *
+ *   The two modes produce IDENTICAL edit-plan operations. Google
+ *   Docs has no first-class "create a suggestion" API endpoint —
+ *   `documents.batchUpdate` lands as a Suggestion automatically
+ *   when the caller's OAuth token has Commenter (not Editor)
+ *   permission on the doc. From switchroom's side the `mode` field
+ *   drives:
+ *
+ *     - which kernel action namespace the call must be authorised
+ *       against (`doc:gdrive:suggest:<id>` vs
+ *       `doc:gdrive:write:<id>` — RFC E §4.2);
+ *     - which card icon + button emphasis the diff-preview surfaces
+ *       (✏️ + "Apply as suggestion" vs ⚠ + "Apply directly");
+ *     - which audit row gets written (RFC B §5).
+ *
+ *   The OAuth sharing posture on the doc itself is the operator's
+ *   responsibility — the wrapper just attests intent and surfaces
+ *   the right card.
+ */
+
+import {
+  resolveAnchor,
+  type Anchor,
+  type AnchorError,
+  type DocumentSnapshot,
+  type ResolvedAnchor,
+} from "./anchors.js";
+import type { DiffPreviewInput } from "./diff-preview.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Edit-plan operations
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Structured edit-plan element. Maps 1:1 onto a Google Docs
+ * `documents.batchUpdate` request, but expressed in paragraph-index
+ * terms (matching `anchors.ts`'s ResolvedOp shape) so it stays
+ * Google-API-agnostic. The eventual MCP-server wrapper computes the
+ * underlying character ranges from these.
+ */
+export type EditOperation =
+  | { kind: "insert_after"; paragraphIndex: number; text: string }
+  | { kind: "insert_before"; paragraphIndex: number; text: string }
+  | { kind: "replace_paragraph"; paragraphIndex: number; text: string }
+  | {
+      kind: "append_to_section_end";
+      /** Last body paragraph in the section. */
+      paragraphIndex: number;
+      text: string;
+    }
+  | {
+      kind: "append_to_empty_section";
+      /** Heading itself — wrapper inserts a fresh body paragraph immediately after. */
+      paragraphIndex: number;
+      text: string;
+    }
+  | {
+      kind: "create_doc";
+      /** Title for the new Drive file. */
+      title: string;
+      /** Parent folder id; "root" for top-of-Drive. */
+      parentFolderId: string;
+      /** Initial body content (plain text — newlines preserved). */
+      body: string;
+    }
+  | {
+      kind: "append_to_doc";
+      /** Plain-text content appended at end-of-document. */
+      text: string;
+    };
+
+// ────────────────────────────────────────────────────────────────────────
+// Common inputs (per-call)
+// ────────────────────────────────────────────────────────────────────────
+
+export interface EditCallContext {
+  /** Agent slug — appears in the diff-preview title + kernel scope. */
+  agentName: string;
+  /** Drive file id — feeds the Open-in-Drive deep link + kernel scope. */
+  fileId: string;
+  /** Drive file title — diff-preview card surfaces this verbatim. */
+  docTitle: string;
+  /** mimeType from `files.get` — drives the deep-link kind. */
+  mimeType?: string;
+  /** Optional pre-allocated suggestion-thread id. */
+  discussionId?: string;
+  /**
+   * Optional agent-supplied "what / why" summary. Stored separately
+   * from wrapper-attested fields so the diff-preview can render both
+   * sides side-by-side (per RFC E §4.2's intent-lie defense).
+   */
+  agentSummary?: string;
+}
+
+export interface AnchoredEditInputs extends EditCallContext {
+  /** Document snapshot from `documents.get` — feeds the anchor resolver. */
+  doc: DocumentSnapshot;
+  /** Where to land the edit, in agent-stated terms. */
+  anchor: Anchor;
+  /**
+   * Body text to insert. Newlines split into paragraphs by the
+   * wrapper (`countLines()` below tracks the delta the diff-preview
+   * surfaces).
+   */
+  text: string;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Outputs
+// ────────────────────────────────────────────────────────────────────────
+
+export type PrepareSuccess<TMode extends "suggest" | "write"> = {
+  ok: true;
+  mode: TMode;
+  /** Resolved anchor — wrapper-attested display name (RFC §4.2). */
+  resolved: ResolvedAnchor;
+  /** Structured edit plan — feeds the eventual Docs-API caller. */
+  operations: EditOperation[];
+  /** Ready-to-go input for `buildDiffPreview` (B3). */
+  preview: DiffPreviewInput;
+};
+
+/** Convenience union — both modes have identical body shape (different mode tag). */
+export type PrepareEditResult =
+  | { ok: false; error: AnchorError }
+  | PrepareSuccess<"suggest">
+  | PrepareSuccess<"write">;
+
+export type PrepareCreateResult =
+  | { ok: false; error: AnchorError }
+  | (Omit<PrepareSuccess<"write">, "resolved"> & {
+      /**
+       * Synthetic resolved anchor for create-doc: there's no anchor
+       * to resolve, but the diff-preview card surfaces "📍 New doc in
+       * /<folder>" via the same DiffPreviewInput shape so users see
+       * the same wrapper-truth alongside the agent's summary.
+       */
+      resolved: ResolvedAnchor;
+    });
+
+export type PrepareAppendResult =
+  | { ok: false; error: AnchorError }
+  | (Omit<PrepareSuccess<"write">, "resolved"> & { resolved: ResolvedAnchor });
+
+// ────────────────────────────────────────────────────────────────────────
+// Public prep functions
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Prepare `gdrive_suggest_edit(doc_id, anchor, text)` — RFC E §4.2.
+ *
+ * Resolves the anchor; on success returns the edit plan + a
+ * diff-preview input with `mode: "suggest"`. The eventual MCP tool
+ * wrapper checks kernel authorisation against
+ * `doc:gdrive:suggest:<doc_id>` before executing the plan.
+ */
+export function prepareSuggestEdit(
+  input: AnchoredEditInputs,
+): PrepareEditResult {
+  return prepareAnchoredEdit(input, "suggest");
+}
+
+/**
+ * Prepare `gdrive_apply_edit(doc_id, anchor, text)` — RFC E §4.2.
+ *
+ * Same shape as suggest; the `mode: "write"` distinction drives
+ * kernel-side authorisation against `doc:gdrive:write:<doc_id>` and
+ * the diff-preview's ⚠ "Apply directly" emphasis (per RFC §4.2).
+ */
+export function prepareApplyEdit(
+  input: AnchoredEditInputs,
+): PrepareEditResult {
+  return prepareAnchoredEdit(input, "write");
+}
+
+/**
+ * Prepare `gdrive_create_doc(title, content, parent_folder)` — RFC E §4.2.
+ *
+ * Always `write` namespace (no Suggestions equivalent for a fresh
+ * doc — the doc doesn't exist yet, there's nothing to suggest into).
+ * The MCP tool wrapper authorises against
+ * `doc:gdrive:write:folder/<parent_folder_id>/**`.
+ */
+export function prepareCreateDoc(input: {
+  agentName: string;
+  /** Title for the new doc — surfaced on the diff-preview. */
+  title: string;
+  /** Body content (plain text, newlines preserved). */
+  body: string;
+  /** Parent folder id; `"root"` for top-of-Drive. */
+  parentFolderId: string;
+  /** Optional human-readable parent folder name for the preview. */
+  parentFolderName?: string;
+  /** Optional agent-supplied "what / why" summary. */
+  agentSummary?: string;
+}): PrepareCreateResult {
+  if (input.title.trim().length === 0) {
+    return invalidAnchor("Doc title must not be empty.");
+  }
+  if (input.parentFolderId.length === 0) {
+    return invalidAnchor("Parent folder id must not be empty (use 'root' for top-of-Drive).");
+  }
+
+  const operations: EditOperation[] = [
+    {
+      kind: "create_doc",
+      title: input.title,
+      parentFolderId: input.parentFolderId,
+      body: input.body,
+    },
+  ];
+
+  const folderLabel =
+    input.parentFolderName !== undefined && input.parentFolderName.length > 0
+      ? input.parentFolderName
+      : input.parentFolderId === "root"
+        ? "root"
+        : input.parentFolderId;
+
+  const resolved: ResolvedAnchor = {
+    op: { kind: "insert_after", paragraphIndex: -1 },
+    displayName: `new doc in /${folderLabel}`,
+  };
+
+  const preview: DiffPreviewInput = {
+    agentName: input.agentName,
+    docTitle: input.title,
+    // Create-doc has no fileId yet — the open-in-Drive button is
+    // synthesised post-creation. The kernel-side card builder
+    // patches fileId in once Drive returns it. Use a placeholder
+    // that the consumer can check for.
+    fileId: "pending-create",
+    resolvedAnchor: resolved,
+    metrics: {
+      linesAdded: countLines(input.body),
+      linesRemoved: 0,
+    },
+    mode: "write",
+    ...(input.agentSummary !== undefined ? { agentSummary: input.agentSummary } : {}),
+  };
+
+  return { ok: true, mode: "write", resolved, operations, preview };
+}
+
+/**
+ * Prepare `gdrive_append_to_doc(doc_id, text)` — RFC E §4.2.
+ *
+ * Always `write` namespace (no Suggestions equivalent for pure
+ * appends — see RFC §9 first bullet "Drive's Suggestions API has
+ * gaps"). The MCP tool wrapper authorises against
+ * `doc:gdrive:write:<doc_id>`.
+ */
+export function prepareAppendToDoc(input: {
+  agentName: string;
+  fileId: string;
+  docTitle: string;
+  mimeType?: string;
+  text: string;
+  agentSummary?: string;
+}): PrepareAppendResult {
+  if (input.text.length === 0) {
+    return invalidAnchor("Append text must not be empty.");
+  }
+
+  const operations: EditOperation[] = [
+    { kind: "append_to_doc", text: input.text },
+  ];
+
+  const resolved: ResolvedAnchor = {
+    op: { kind: "insert_after", paragraphIndex: -1 },
+    displayName: "at end of doc (append)",
+  };
+
+  const preview: DiffPreviewInput = {
+    agentName: input.agentName,
+    docTitle: input.docTitle,
+    fileId: input.fileId,
+    resolvedAnchor: resolved,
+    metrics: { linesAdded: countLines(input.text), linesRemoved: 0 },
+    mode: "write",
+    ...(input.mimeType !== undefined ? { mimeType: input.mimeType } : {}),
+    ...(input.agentSummary !== undefined ? { agentSummary: input.agentSummary } : {}),
+  };
+
+  return { ok: true, mode: "write", resolved, operations, preview };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Internals
+// ────────────────────────────────────────────────────────────────────────
+
+function prepareAnchoredEdit(
+  input: AnchoredEditInputs,
+  mode: "suggest" | "write",
+): PrepareEditResult {
+  if (input.text.length === 0) {
+    return invalidAnchor("Edit text must not be empty.");
+  }
+
+  const result = resolveAnchor(input.anchor, input.doc);
+  if (!result.ok) return { ok: false, error: result.error };
+
+  const op = result.resolved.op;
+  const operations = anchoredOpToEditPlan(op, input.text, input.doc);
+
+  // Diff-metrics calculation. `replace_paragraph` removes one line
+  // from the existing doc; everything else is additive. The wrapper
+  // computes both sides so the agent's summary cannot lie about
+  // size (RFC E §4.2 "size lies" defense).
+  const linesAdded = countLines(input.text);
+  const linesRemoved = op.kind === "replace_paragraph" ? 1 : 0;
+
+  const preview: DiffPreviewInput = {
+    agentName: input.agentName,
+    docTitle: input.docTitle,
+    fileId: input.fileId,
+    resolvedAnchor: result.resolved,
+    metrics: { linesAdded, linesRemoved },
+    mode,
+    ...(input.mimeType !== undefined ? { mimeType: input.mimeType } : {}),
+    ...(input.discussionId !== undefined ? { discussionId: input.discussionId } : {}),
+    ...(input.agentSummary !== undefined ? { agentSummary: input.agentSummary } : {}),
+  };
+
+  if (mode === "suggest") {
+    return { ok: true, mode: "suggest", resolved: result.resolved, operations, preview };
+  }
+  return { ok: true, mode: "write", resolved: result.resolved, operations, preview };
+}
+
+function anchoredOpToEditPlan(
+  op: ResolvedAnchor["op"],
+  text: string,
+  _doc: DocumentSnapshot,
+): EditOperation[] {
+  switch (op.kind) {
+    case "insert_after":
+      return [{ kind: "insert_after", paragraphIndex: op.paragraphIndex, text }];
+    case "insert_before":
+      return [{ kind: "insert_before", paragraphIndex: op.paragraphIndex, text }];
+    case "replace_paragraph":
+      return [{ kind: "replace_paragraph", paragraphIndex: op.paragraphIndex, text }];
+    case "append_to_section_end":
+      return [
+        { kind: "append_to_section_end", paragraphIndex: op.paragraphIndex, text },
+      ];
+    case "append_to_empty_section":
+      return [
+        { kind: "append_to_empty_section", paragraphIndex: op.paragraphIndex, text },
+      ];
+  }
+}
+
+/**
+ * Wrapper-attested line count for a proposed insertion. Counts
+ * "lines" the same way the diff-preview card surfaces them —
+ * paragraph-breaks (`\n`) plus the implicit first line. Empty text
+ * counts as zero lines (the prep functions reject empty bodies
+ * upstream, but the counter stays consistent in case a follow-up
+ * relaxes that).
+ */
+export function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  // `\n` count + 1 — same metric as `wc -l` for files without a
+  // trailing newline. Lines that don't end in \n still count as a
+  // line.
+  let count = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) count += 1;
+  }
+  // If the text ends in a trailing newline, that newline doesn't
+  // open a new paragraph in the Drive view — subtract one so the
+  // count matches what the user sees.
+  if (text.charCodeAt(text.length - 1) === 10) count -= 1;
+  return count;
+}
+
+function invalidAnchor(message: string): { ok: false; error: AnchorError } {
+  return { ok: false, error: { code: "INVALID_ANCHOR", message } };
+}


### PR DESCRIPTION
## Summary

Ships pure prep functions for the four agent-facing edit operations described in RFC E §4.2:

- `prepareSuggestEdit` → `gdrive_suggest_edit(doc_id, anchor, text)`
- `prepareApplyEdit` → `gdrive_apply_edit(doc_id, anchor, text)`
- `prepareCreateDoc` → `gdrive_create_doc(title, content, parent_folder)`
- `prepareAppendToDoc` → `gdrive_append_to_doc(doc_id, text)`

Each takes the agent's inputs + a `DocumentSnapshot`, resolves the anchor via `anchors.ts` (#1250), and returns either a typed `AnchorError` verbatim OR a `PrepareSuccess` carrying:
1. The structured `EditOperation[]` plan (paragraph-index keyed — the eventual MCP-server wrapper translates into a Docs API `batchUpdate` request).
2. A ready-to-go `DiffPreviewInput` for `buildDiffPreview` (#1252).

Kernel-agnostic seam is deliberate — MCP tool registration + the actual Drive API call live in a follow-up. Same shipped-helper-then-wire pattern as anchors (#1250), diff-preview (#1252), deep-links (#1251), folder picker (#1296), recovery detector (#1249).

## Suggest-vs-write nuance (load-bearing — pinned in docstring)

The two modes produce **identical** edit-plan operations. Google Docs has no first-class "create a suggestion" API; `batchUpdate` lands as a Suggestion automatically when the caller's OAuth token has Commenter (not Editor) permission. From switchroom's side the `mode` field drives:

- Kernel action namespace (`doc:gdrive:suggest:<id>` vs `:write:<id>`)
- Card icon / button emphasis (✏️ + "Apply as suggestion" vs ⚠ + "Apply directly")
- Audit-row action grammar

The OAuth sharing posture on the doc itself is operator-controlled — the wrapper just attests intent and surfaces the right card.

## Wrapper-attested invariants (RFC E §4.2 — covered by tests)

- Resolved anchor `displayName` comes from the wrapper, never the agent.
- `linesAdded` / `linesRemoved` counts come from the wrapper — agent's summary cannot inflate or deflate them.
- `countLines()` matches what the user sees in Drive (paragraph breaks; trailing newline doesn't open a new paragraph).

`create_doc` + `append_to_doc` are always `write` mode (no Suggestions equivalent — RFC §9 first bullet "Drive's Suggestions API has gaps"). Both synthesise a wrapper-attested displayName so the diff-preview surfaces the same shape across all four operations.

## Test plan

- [x] `bun test src/drive/` — 220 pass (23 new cases in `edits.test.ts`)
- [x] `bun run lint` — clean
- [ ] Independent reviewer verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)