### PR TITLE
fix(telegram-plugin): flush post-reply tail of terminal text (#1291)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1086,6 +1086,14 @@ type CurrentTurn = {
   gatewayReceiveAt: number
   replyCalled: boolean
   capturedText: string[]
+  // #1291: snapshot of capturedText.length at the moment of the most
+  // recent reply / stream_reply tool call. Used by decideTurnFlush to
+  // isolate the post-reply tail (e.g. a soft-commit reply followed by
+  // the real substantive answer in terminal text only) and flush it as
+  // a follow-up message. Pre-#1291 the existence of ANY reply call
+  // suppressed flush entirely — that lost long terminal-only answers
+  // after a "let me check" interim reply.
+  capturedTextLenAtLastReply: number
   orphanedReplyTimeoutId: ReturnType<typeof setTimeout> | null
   registryKey: string | null
   // Last assistant outbound message id for the current turn — populated
@@ -4638,6 +4646,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           gatewayReceiveAt: startedAt,
           replyCalled: false,
           capturedText: [],
+          capturedTextLenAtLastReply: 0,
           orphanedReplyTimeoutId: null,
           registryKey: null,
           lastAssistantMsgId: null,
@@ -4734,6 +4743,12 @@ function handleSessionEvent(ev: SessionEvent): void {
       // placeholder-heartbeat label, which has been retired.
       if (isTelegramReplyTool(name)) {
         turn.replyCalled = true
+        // #1291: pin the captured-text index at the moment of this reply
+        // tool call. Anything pushed into capturedText after this point
+        // is the post-reply tail (e.g. the substantive answer composed
+        // in terminal text after a soft-commit "on it, back in a few").
+        // decideTurnFlush slices from this index to flush the tail.
+        turn.capturedTextLenAtLastReply = turn.capturedText.length
         if (turn.orphanedReplyTimeoutId != null) {
           clearTimeout(turn.orphanedReplyTimeoutId)
           turn.orphanedReplyTimeoutId = null
@@ -4993,8 +5008,20 @@ function handleSessionEvent(ev: SessionEvent): void {
         chatId: turn.sessionChatId,
         replyCalled: turn.replyCalled,
         capturedText: turn.capturedText,
+        capturedTextLenAtLastReply: turn.capturedTextLenAtLastReply,
         flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
       })
+      // #1291: when the model emitted a soft-commit reply followed by a
+      // substantive terminal-only answer, decideTurnFlush returns
+      // kind:'flush' with the post-reply tail. Log WARN so this case is
+      // auditable — the model SHOULD have called reply for the tail, but
+      // didn't, and the framework is covering for it.
+      if (flushDecision.kind === 'flush' && turn.replyCalled) {
+        process.stderr.write(
+          `telegram gateway: WARN post-reply-tail flush (#1291) — model emitted ${flushDecision.text.length} chars after a prior reply call without a follow-up reply tool` +
+          ` chat=${chatId} turnStartedAt=${turn.startedAt}\n`,
+        )
+      }
       if (flushDecision.kind === 'skip' && flushDecision.reason !== 'reply-called') {
         process.stderr.write(
           `telegram gateway: turn-flush skipped — reason=${flushDecision.reason}\n`,

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -137,6 +137,118 @@ describe('decideTurnFlush', () => {
       }),
     ).toEqual({ kind: 'skip', reason: 'reply-called' })
   })
+
+  // #1291 — when the model emits a soft-commit reply ("on it, back in a
+  // few") and then composes the real substantive answer in terminal text
+  // only, the pre-#1291 behaviour skipped flush entirely because
+  // replyCalled was true. The fix: track capturedTextLenAtLastReply and
+  // flush the post-reply tail when it meets the substantive threshold.
+  describe('#1291 — post-reply tail flush', () => {
+    it('flushes the post-reply tail when it meets the substantive threshold', () => {
+      const decision = decideTurnFlush({
+        chatId: '700',
+        replyCalled: true,
+        // Index 0 = the captured text BEFORE the reply tool was called
+        // (some thinking-as-text). Indices 1..2 are post-reply.
+        capturedText: [
+          'thinking out loud before the reply',
+          'Now here is the actual substantive answer the model composed ',
+          'in terminal text only after the interim reply call.',
+        ],
+        capturedTextLenAtLastReply: 1,
+      })
+      expect(decision).toEqual({
+        kind: 'flush',
+        text:
+          'Now here is the actual substantive answer the model composed ' +
+          '\nin terminal text only after the interim reply call.',
+      })
+    })
+
+    it('skips with reply-called-no-new-text when post-reply tail is below threshold', () => {
+      const decision = decideTurnFlush({
+        chatId: '701',
+        replyCalled: true,
+        capturedText: ['the pre-reply scratch', 'ok.'], // tail = "ok." (3 chars)
+        capturedTextLenAtLastReply: 1,
+      })
+      expect(decision).toEqual({
+        kind: 'skip',
+        reason: 'reply-called-no-new-text',
+      })
+    })
+
+    it('skips with reply-called when there is no post-reply text at all', () => {
+      const decision = decideTurnFlush({
+        chatId: '702',
+        replyCalled: true,
+        capturedText: ['everything-was-before-the-reply'],
+        capturedTextLenAtLastReply: 1, // tail slice is empty
+      })
+      expect(decision).toEqual({ kind: 'skip', reason: 'reply-called' })
+    })
+
+    it('post-reply tail honors a silent marker (skip)', () => {
+      const decision = decideTurnFlush({
+        chatId: '703',
+        replyCalled: true,
+        capturedText: ['real answer pre-reply', 'NO_REPLY'],
+        capturedTextLenAtLastReply: 1,
+        replyCalledTailMinChars: 1, // force the marker check
+      })
+      expect(decision).toEqual({ kind: 'skip', reason: 'silent-marker' })
+    })
+
+    it('post-reply tail with null chatId still skips (no-inbound-chat)', () => {
+      const decision = decideTurnFlush({
+        chatId: null,
+        replyCalled: true,
+        capturedText: [
+          'pre',
+          'this tail would have been substantive enough to flush normally',
+        ],
+        capturedTextLenAtLastReply: 1,
+      })
+      expect(decision).toEqual({ kind: 'skip', reason: 'no-inbound-chat' })
+    })
+
+    it('preserves pre-#1291 behaviour when capturedTextLenAtLastReply is omitted', () => {
+      // Legacy caller doesn't track the marker — defaults to
+      // capturedText.length, so the tail slice is empty and we skip
+      // with reason 'reply-called' (the original behaviour).
+      const decision = decideTurnFlush({
+        chatId: '704',
+        replyCalled: true,
+        capturedText: ['some answer the model emitted'],
+      })
+      expect(decision).toEqual({ kind: 'skip', reason: 'reply-called' })
+    })
+
+    it('respects a custom replyCalledTailMinChars threshold', () => {
+      const decision = decideTurnFlush({
+        chatId: '705',
+        replyCalled: true,
+        capturedText: ['pre-reply', 'short but substantive in this test'],
+        capturedTextLenAtLastReply: 1,
+        replyCalledTailMinChars: 10,
+      })
+      expect(decision.kind).toBe('flush')
+    })
+
+    it('feature flag off still wins over post-reply tail flush', () => {
+      const decision = decideTurnFlush({
+        chatId: '706',
+        replyCalled: true,
+        capturedText: [
+          'pre',
+          'a long substantive post-reply tail that would otherwise flush',
+        ],
+        capturedTextLenAtLastReply: 1,
+        flushEnabled: false,
+      })
+      expect(decision).toEqual({ kind: 'skip', reason: 'flag-disabled' })
+    })
+  })
 })
 
 describe('isSilentFlushMarker', () => {

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -57,6 +57,7 @@ export type FlushDecision =
 export type FlushSkipReason =
   | 'flag-disabled'
   | 'reply-called'
+  | 'reply-called-no-new-text'
   | 'no-inbound-chat'
   | 'empty-text'
   | 'silent-marker'
@@ -71,9 +72,32 @@ export interface FlushDecisionInput {
   /** Raw text content blocks accumulated from assistant events across the
    * turn. Joined + trimmed internally. */
   capturedText: string[]
+  /** Snapshot of `capturedText.length` at the moment of the most recent
+   * reply / stream_reply tool call in this turn. Indices `[capturedText
+   * length-at-last-reply, capturedText.length)` are the post-reply tail
+   * — substantive content the model emitted AFTER the reply (e.g. soft
+   * commit "on it, back in a few" followed by the real answer in
+   * terminal text only, the #1291 repro). When the tail meets
+   * `replyCalledTailMinChars` we flush it; otherwise we skip.
+   *
+   * Defaults to `capturedText.length` (treat all captured text as
+   * pre-reply, preserve the pre-#1291 behaviour where any reply tool
+   * call suppressed flush entirely) so callers that don't track the
+   * marker keep the old contract. */
+  capturedTextLenAtLastReply?: number
+  /** Minimum trimmed-tail length to qualify a post-reply tail flush.
+   * Defaults to `REPLY_CALLED_TAIL_MIN_CHARS` (40). Below this we skip
+   * with `reply-called-no-new-text` — typical for trailing markdown
+   * artifacts or a one-word afterthought. */
+  replyCalledTailMinChars?: number
   /** Feature flag — defaults to true. Pass `false` to force skip everywhere. */
   flushEnabled?: boolean
 }
+
+/** Default minimum trimmed length for the post-reply tail to be flushed
+ * as a follow-up message. Below this we treat the tail as noise / artifact
+ * and skip silently. */
+export const REPLY_CALLED_TAIL_MIN_CHARS = 40
 
 /**
  * Pure decision: should the gateway deterministically send the model's
@@ -82,11 +106,41 @@ export interface FlushDecisionInput {
  *
  * Ordering of checks is deliberate: cheapest/strongest first so logs
  * attribute a skip to the most specific cause.
+ *
+ * #1291 — when `replyCalled` is true we no longer suppress unconditionally.
+ * The model may have emitted a soft-commit reply ("on it, back in a few")
+ * followed by the real substantive answer in terminal text only. Using
+ * `capturedTextLenAtLastReply` we isolate the post-reply tail and flush
+ * it if it's substantive enough; otherwise we skip with
+ * `reply-called-no-new-text` (logged) or `reply-called` (silent, no tail).
  */
 export function decideTurnFlush(input: FlushDecisionInput): FlushDecision {
   const flushEnabled = input.flushEnabled !== false
   if (!flushEnabled) return { kind: 'skip', reason: 'flag-disabled' }
-  if (input.replyCalled) return { kind: 'skip', reason: 'reply-called' }
+
+  if (input.replyCalled) {
+    const tailIdx = input.capturedTextLenAtLastReply ?? input.capturedText.length
+    const tail = input.capturedText.slice(tailIdx).join('\n').trim()
+    const minChars = input.replyCalledTailMinChars ?? REPLY_CALLED_TAIL_MIN_CHARS
+    if (tail.length === 0) {
+      // The reply tool was called and nothing of substance came after —
+      // the turn is fully served by the reply. Skip silently (the gateway
+      // WARN gate excludes this reason from logs).
+      return { kind: 'skip', reason: 'reply-called' }
+    }
+    if (tail.length < minChars) {
+      // Post-reply tail exists but is below the substantive-content
+      // threshold — typically trailing markdown artifacts or a one-word
+      // afterthought. Skip but with a distinct reason so this case IS
+      // logged (auditable for #1291 regressions, vs the silent
+      // 'reply-called' which is the expected steady state).
+      return { kind: 'skip', reason: 'reply-called-no-new-text' }
+    }
+    if (input.chatId == null) return { kind: 'skip', reason: 'no-inbound-chat' }
+    if (isSilentFlushMarker(tail)) return { kind: 'skip', reason: 'silent-marker' }
+    return { kind: 'flush', text: tail }
+  }
+
   if (input.chatId == null) return { kind: 'skip', reason: 'no-inbound-chat' }
   const joined = input.capturedText.join('\n').trim()
   if (joined.length === 0) return { kind: 'skip', reason: 'empty-text' }


### PR DESCRIPTION
## Summary

Closes #1291.

The turn-flush safety net suppressed ALL flushes when `replyCalled=true`, on the assumption that any reply call meant the user had been served. That's wrong for the canonical conversational pattern: **a soft-commit reply ("on it, back in a few") followed by the real substantive answer in terminal text only.** When that happened the user was silently ghosted — the model's full answer existed in `turn.capturedText` but was classified as junk at `turn_end` and dropped.

Live repro on 2026-05-14: assistant sent an interim `reply` at 21:20:14, then composed a 400-word answer in terminal text without calling `reply` again. User asked "you didnt respond again. why?" at 21:24:14.

### The gap

`turn-flush-safety.ts:89` (pre-fix):
```ts
if (input.replyCalled) return { kind: 'skip', reason: 'reply-called' }
```

Hard-suppressed, silently — the WARN gate at `gateway.ts:4998` explicitly excludes `reply-called` from logs. Combined with `turn.capturedText` accumulating *every* assistant text chunk regardless of where it falls relative to reply tool calls, the post-reply tail was invisible to both the user AND the logs.

### Fix

Track `capturedTextLenAtLastReply` on every reply / stream_reply tool_use (`gateway.ts:4741`). In `decideTurnFlush`:

- If `replyCalled=true` AND the post-reply tail (capturedText.slice(lenAtLastReply)) meets `REPLY_CALLED_TAIL_MIN_CHARS` (40), flush the tail.
- If the tail is below threshold, skip with new reason `reply-called-no-new-text` (loggable — auditable for regressions).
- If the tail is empty, skip with legacy `reply-called` (silent — expected steady state).
- Legacy callers that don't pass `capturedTextLenAtLastReply` get the old contract via the default (`= capturedText.length`).

A WARN log fires when the tail flush actually triggers, so the case is auditable from logs in production.

## Test plan

- [x] `bun test tests/turn-flush-safety.test.ts` — 26/26 (was 19, +7 new)
- [x] `bun test tests/silence-poke.test.ts tests/turn-flush-safety.test.ts tests/turn-flush-dedup-controller.test.ts tests/gateway-disconnect-flush.test.ts` — 70/70 pass
- [x] `npm run lint` — clean (strict tsc + plugin-references + bot-api wrapping + bun-test-imports)
- [ ] Manual: agent sends interim "on it" reply, then composes substantive answer in terminal-only text, verify tail lands in Telegram with #1291 WARN log
- [ ] Manual: agent sends interim "on it" reply and then a trivial "ok." trailing artifact — verify skip with `reply-called-no-new-text` reason (loggable)

## New tests added (7)

In `turn-flush-safety.test.ts` under "#1291 — post-reply tail flush":
1. Flushes substantive post-reply tail
2. Skips below-threshold tail with `reply-called-no-new-text`
3. Skips no-tail with legacy `reply-called`
4. Silent-marker tail → skip
5. Null chatId tail → `no-inbound-chat`
6. Legacy default (omitted `capturedTextLenAtLastReply`) preserves old behaviour
7. Custom `replyCalledTailMinChars` threshold respected
8. (Plus: `flushEnabled=false` still wins over tail flush — precedence test)

## Related

- #1289 — silence-poke fires after clean turn end (merged in #1293, same area)
- #1292 — tool-stream progress indicator (next, sibling under "chat-state transitions belong to the gateway, not the model")

🤖 Generated with [Claude Code](https://claude.com/claude-code)