### PR TITLE
feat(drive): RFC E §4.2 — Telegram renderer for the diff-preview card

### DIFF
--- a/telegram-plugin/gateway/diff-preview-card.test.ts
+++ b/telegram-plugin/gateway/diff-preview-card.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the Telegram diff-preview card renderer — RFC E §4.2.
+ */
+
+import { describe, expect, it } from "vitest";
+import { InlineKeyboard } from "grammy";
+
+import { buildDiffPreview } from "../../src/drive/diff-preview.js";
+import type { DiffPreviewInput } from "../../src/drive/diff-preview.js";
+import { buildDiffPreviewCard } from "./diff-preview-card.js";
+
+/** Pull row-major button shape out of grammy's InlineKeyboard. */
+function rows(kb: InlineKeyboard): Array<Array<{ text: string; callback_data?: string; url?: string }>> {
+  return kb.inline_keyboard.map((row) =>
+    row.map((b) => ({
+      text: b.text,
+      ...("callback_data" in b ? { callback_data: b.callback_data } : {}),
+      ...("url" in b ? { url: b.url } : {}),
+    })),
+  );
+}
+
+function baseInput(overrides: Partial<DiffPreviewInput> = {}): DiffPreviewInput {
+  return {
+    agentName: "klanker",
+    docTitle: "Q3 Strategy Notes",
+    fileId: "DOC1",
+    mimeType: "application/vnd.google-apps.document",
+    resolvedAnchor: {
+      op: { kind: "insert_after", paragraphIndex: 4 },
+      displayName: "after heading 'Goals' (level 2)",
+    },
+    metrics: { linesAdded: 47, linesRemoved: 0 },
+    mode: "suggest",
+    ...overrides,
+  };
+}
+
+describe("buildDiffPreviewCard — suggest mode (default)", () => {
+  it("emits the wrapper-attested body + all four buttons in the RFC layout", () => {
+    const preview = buildDiffPreview(baseInput({ agentSummary: "Added Hiring section" }));
+    const card = buildDiffPreviewCard({
+      preview,
+      suggestRequestId: "aabbccdd",
+      writeRequestId: "11223344",
+    });
+
+    // Body: title bold + all preview lines.
+    expect(card.text).toContain("<b>");
+    expect(card.text).toContain("klanker");
+    expect(card.text).toContain("Q3 Strategy Notes");
+    expect(card.text).toContain("📍 after heading 'Goals' (level 2)");
+    expect(card.text).toContain("+47");
+    expect(card.text).toContain("💬");
+    expect(card.text).toContain("Added Hiring section");
+
+    const r = rows(card.reply_markup);
+    // Row 1: [Open in Drive] [Apply as suggestion]
+    expect(r[0]?.[0]?.text).toBe("📖 Open in Drive");
+    expect(r[0]?.[0]?.url).toBe("https://docs.google.com/document/d/DOC1/edit");
+    expect(r[0]?.[1]?.text).toBe("✅ Apply as suggestion");
+    expect(r[0]?.[1]?.callback_data).toBe("apv:aabbccdd:once");
+    // Row 2: [Apply directly] [Cancel]
+    expect(r[1]?.[0]?.text).toBe("⚠ Apply directly");
+    expect(r[1]?.[0]?.callback_data).toBe("apv:11223344:once");
+    expect(r[1]?.[1]?.text).toBe("🚫 Cancel");
+    expect(r[1]?.[1]?.callback_data).toBe("apv:aabbccdd:deny");
+  });
+
+  it("hides 'Apply directly' when writeRequestId is undefined", () => {
+    const preview = buildDiffPreview(baseInput());
+    const card = buildDiffPreviewCard({
+      preview,
+      suggestRequestId: "aabbccdd",
+    });
+    const flat = rows(card.reply_markup).flat();
+    expect(flat.find((b) => b.text === "⚠ Apply directly")).toBeUndefined();
+    // The other three buttons still present.
+    expect(flat.find((b) => b.text === "📖 Open in Drive")).toBeDefined();
+    expect(flat.find((b) => b.text === "✅ Apply as suggestion")).toBeDefined();
+    expect(flat.find((b) => b.text === "🚫 Cancel")).toBeDefined();
+  });
+});
+
+describe("buildDiffPreviewCard — write mode (opt-in via expand)", () => {
+  it("only emits Apply-directly + Open-in-Drive + Cancel (no suggest button)", () => {
+    const preview = buildDiffPreview(baseInput({ mode: "write" }));
+    const card = buildDiffPreviewCard({
+      preview,
+      // In write-mode the suggest id is still needed for the Cancel
+      // callback's deny channel — semantically Cancel is "don't grant
+      // either scope" but reusing the suggest id keeps the existing
+      // approval-callback handler stateless.
+      suggestRequestId: "aabbccdd",
+      writeRequestId: "11223344",
+    });
+
+    const r = rows(card.reply_markup);
+    const flat = r.flat();
+    expect(flat.find((b) => b.text === "✅ Apply as suggestion")).toBeUndefined();
+    const directly = flat.find((b) => b.text === "⚠ Apply directly");
+    expect(directly).toBeDefined();
+    expect(directly?.callback_data).toBe("apv:11223344:once");
+    // Title icon swaps to ⚠.
+    expect(card.text).toContain("⚠");
+  });
+});
+
+describe("buildDiffPreviewCard — input validation", () => {
+  it("throws on a malformed suggestRequestId", () => {
+    const preview = buildDiffPreview(baseInput());
+    expect(() =>
+      buildDiffPreviewCard({ preview, suggestRequestId: "not-hex" }),
+    ).toThrow(/8 hex chars/);
+  });
+
+  it("throws on a malformed writeRequestId", () => {
+    const preview = buildDiffPreview(baseInput());
+    expect(() =>
+      buildDiffPreviewCard({
+        preview,
+        suggestRequestId: "aabbccdd",
+        writeRequestId: "ABCDEF01", // wrong case
+      }),
+    ).toThrow(/8 hex chars/);
+  });
+});
+
+describe("buildDiffPreviewCard — fragility guards", () => {
+  it("drops the Open-in-Drive button when fileId is the 'pending-create' sentinel", () => {
+    // create_doc prep emits "pending-create" as a placeholder fileId
+    // (the doc doesn't exist yet). The renderer must NOT emit a Drive
+    // URL pointing at a nonexistent doc.
+    const preview = buildDiffPreview(
+      baseInput({ fileId: "pending-create" }),
+    );
+    const card = buildDiffPreviewCard({
+      preview,
+      suggestRequestId: "aabbccdd",
+    });
+    const flat = rows(card.reply_markup).flat();
+    expect(flat.find((b) => b.text === "📖 Open in Drive")).toBeUndefined();
+    // Apply buttons still present — the doc creation flow is still actionable.
+    expect(flat.find((b) => b.text === "✅ Apply as suggestion")).toBeDefined();
+  });
+
+  it("HTML-escapes title + lines (no markup injection from doc names)", () => {
+    const preview = buildDiffPreview(
+      baseInput({ docTitle: "<script>alert(1)</script>" }),
+    );
+    const card = buildDiffPreviewCard({
+      preview,
+      suggestRequestId: "aabbccdd",
+    });
+    expect(card.text).not.toContain("<script>");
+    expect(card.text).toContain("&lt;script&gt;");
+  });
+
+  it("HTML-escapes the agent-supplied summary", () => {
+    const preview = buildDiffPreview(
+      baseInput({ agentSummary: "Hi <b>bold</b> & <i>tags</i>" }),
+    );
+    const card = buildDiffPreviewCard({
+      preview,
+      suggestRequestId: "aabbccdd",
+    });
+    expect(card.text).not.toMatch(/💬.*<b>/);
+    expect(card.text).toContain("&lt;b&gt;");
+  });
+});
+
+describe("buildDiffPreviewCard — audit fidelity", () => {
+  it("preview audit row matches what the user sees on the card", () => {
+    const input = baseInput({ agentSummary: "Added the Hiring section" });
+    const preview = buildDiffPreview(input);
+    const card = buildDiffPreviewCard({
+      preview,
+      suggestRequestId: "aabbccdd",
+      writeRequestId: "11223344",
+    });
+    // The audit row captures both wrapper truth + agent framing,
+    // exactly as surfaced on the card.
+    expect(preview.audit.wrapperAttested.anchorDisplayName).toBe(
+      "after heading 'Goals' (level 2)",
+    );
+    expect(preview.audit.wrapperAttested.linesAdded).toBe(47);
+    expect(preview.audit.agentSupplied.summary).toBe("Added the Hiring section");
+    // Card body contains both.
+    expect(card.text).toContain("after heading 'Goals' (level 2)");
+    expect(card.text).toContain("Added the Hiring section");
+  });
+});

--- a/telegram-plugin/gateway/diff-preview-card.ts
+++ b/telegram-plugin/gateway/diff-preview-card.ts
@@ -1,0 +1,170 @@
+/**
+ * Telegram renderer for the diff-preview approval card — RFC E §4.2.
+ *
+ * Takes a `DiffPreview` (output of `src/drive/diff-preview.ts`) plus the
+ * two pre-registered approval-kernel request ids — one for the suggest
+ * scope, one for the write scope — and emits a `BuiltApprovalCard`
+ * (HTML body + grammy InlineKeyboard).
+ *
+ * Why two request ids? The card surfaces both "Apply as suggestion"
+ * and "Apply directly" buttons; each one grants a different kernel
+ * scope (`doc:gdrive:suggest:<id>` vs `doc:gdrive:write:<id>`). The
+ * upstream caller (the MCP-tool wrapper, or whoever's posting the
+ * card) registers BOTH up front with `approval_request`, then passes
+ * both ids into this renderer. The user taps one; the other expires
+ * naturally on the kernel side.
+ *
+ * Each action button reuses the existing `apv:<request_id>:once`
+ * callback shape so the generic kernel handler at
+ * `approval-callback.ts` records the grant without surface-specific
+ * routing. The "✅ once" semantics line up with the diff-preview's
+ * single-shot "do this edit now" intent.
+ */
+
+import { InlineKeyboard } from "grammy";
+import type { DiffPreview } from "../../src/drive/diff-preview.js";
+
+export interface BuiltDiffPreviewCard {
+  text: string;
+  reply_markup: InlineKeyboard;
+}
+
+export interface DiffPreviewCardInput {
+  preview: DiffPreview;
+  /**
+   * Kernel request id pre-registered for `doc:gdrive:suggest:<doc_id>`.
+   * Required — the suggest path is the RFC's default. When undefined
+   * the renderer throws (an "approval card with no Apply button"
+   * isn't a coherent UX).
+   */
+  suggestRequestId: string;
+  /**
+   * Kernel request id pre-registered for `doc:gdrive:write:<doc_id>`.
+   * Optional — when omitted, the "⚠ Apply directly" button is hidden
+   * (used for `gdrive_suggest_edit` callers that don't want to offer
+   * the direct-write escalation at all). When `preview.buttons` has
+   * an `apply_directly` entry but this is omitted, the button is
+   * dropped silently.
+   */
+  writeRequestId?: string;
+}
+
+/**
+ * 8-hex request id shape — same regex the kernel uses (RFC B §6.1).
+ * Defense in depth — a malformed request id would render an invalid
+ * callback_data that the dispatcher rejects, but we'd rather fail
+ * loudly at build time.
+ */
+const REQUEST_ID_RE = /^[0-9a-f]{8}$/;
+
+/**
+ * Fragility-guard from B2 review: the `create_doc` prep helper
+ * synthesises a "pending-create" placeholder fileId because the
+ * doc doesn't exist yet. `validateDriveId` happily accepts the
+ * literal "pending-create" string (it's alnum + `-`), so a naive
+ * Open-in-Drive button would emit a broken link. The renderer
+ * detects the sentinel and drops the open-in-drive row instead of
+ * rendering a dead link.
+ */
+const PENDING_FILE_ID_SENTINEL = "pending-create";
+
+export function buildDiffPreviewCard(
+  input: DiffPreviewCardInput,
+): BuiltDiffPreviewCard {
+  if (!REQUEST_ID_RE.test(input.suggestRequestId)) {
+    throw new Error(
+      `buildDiffPreviewCard: suggestRequestId must be 8 hex chars (got '${input.suggestRequestId}')`,
+    );
+  }
+  if (input.writeRequestId !== undefined && !REQUEST_ID_RE.test(input.writeRequestId)) {
+    throw new Error(
+      `buildDiffPreviewCard: writeRequestId must be 8 hex chars (got '${input.writeRequestId}')`,
+    );
+  }
+
+  const preview = input.preview;
+
+  // Body: title + every diff-preview line in order, HTML-escaped.
+  // The 📍 + line-count rows are surfaced verbatim — they're
+  // wrapper-attested and the agent has no input into their content.
+  const bodyLines: string[] = [];
+  bodyLines.push(`<b>${escapeHtml(preview.title)}</b>`);
+  for (const line of preview.lines) {
+    bodyLines.push(escapeHtml(line.text));
+  }
+  const text = bodyLines.join("\n");
+
+  const kb = new InlineKeyboard();
+
+  // Layout per RFC E §4.2 mockup:
+  //   row 1: [ 📖 Open in Drive ]  [ ✅ Apply as suggestion ]
+  //   row 2: [ ⚠ Apply directly ]   [ 🚫 Cancel ]
+  //
+  // Buttons whose `action` doesn't match a known shape are dropped
+  // silently — the diff-preview builder is the source of truth for
+  // which buttons exist; the renderer just maps them to callbacks.
+  const ROW_BREAK_AFTER: Array<DiffPreview["buttons"][number]["action"]> = [
+    "apply_suggestion",
+  ];
+  // `DiffPreview` doesn't carry the original mode, so infer from the
+  // button set: in suggest mode the builder always emits both
+  // `apply_suggestion` and `apply_directly`; in write mode it emits
+  // only `apply_directly`. The renderer drops `apply_directly` when
+  // a writeRequestId wasn't provided AND a suggestion path exists
+  // — caller chose to offer only Suggesting.
+  const offeringSuggestion = preview.buttons.some(
+    (b) => b.action === "apply_suggestion",
+  );
+  const droppedDirectly =
+    offeringSuggestion && input.writeRequestId === undefined;
+
+  const isPendingFileId =
+    preview.audit.wrapperAttested.fileId === PENDING_FILE_ID_SENTINEL;
+
+  let rowStarted = false;
+  const breakRow = () => {
+    if (rowStarted) {
+      kb.row();
+      rowStarted = false;
+    }
+  };
+
+  for (const btn of preview.buttons) {
+    switch (btn.action) {
+      case "open_in_drive": {
+        if (isPendingFileId) break; // drop sentinel-URL buttons
+        if (typeof btn.url !== "string" || btn.url.length === 0) break;
+        kb.url(btn.text, btn.url);
+        rowStarted = true;
+        break;
+      }
+      case "apply_suggestion": {
+        kb.text(btn.text, `apv:${input.suggestRequestId}:once`);
+        rowStarted = true;
+        break;
+      }
+      case "apply_directly": {
+        if (droppedDirectly) break;
+        const id = input.writeRequestId ?? input.suggestRequestId;
+        kb.text(btn.text, `apv:${id}:once`);
+        rowStarted = true;
+        break;
+      }
+      case "cancel": {
+        kb.text(btn.text, `apv:${input.suggestRequestId}:deny`);
+        rowStarted = true;
+        break;
+      }
+    }
+    if (ROW_BREAK_AFTER.includes(btn.action)) breakRow();
+  }
+
+  return { text, reply_markup: kb };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}


### PR DESCRIPTION
## Summary

Wires the kernel-agnostic diff-preview builder (#1252) onto a Telegram-shaped card. New file `telegram-plugin/gateway/diff-preview-card.ts` exports `buildDiffPreviewCard(input)` that takes the structured `DiffPreview` + two pre-registered kernel request ids (one for suggest scope, one for write scope) and emits a `BuiltDiffPreviewCard` (HTML body + grammy InlineKeyboard).

## Card layout (RFC §4.2 mockup)

```
row 1: [ 📖 Open in Drive ]  [ ✅ Apply as suggestion ]
row 2: [ ⚠ Apply directly ]   [ 🚫 Cancel ]
```

## Callback mapping

Reuses the existing `apv:` namespace so the generic kernel handler at `approval-callback.ts` records the grant without surface-specific routing:

| Button | Callback |
|---|---|
| ✅ Apply as suggestion | `apv:<suggestRequestId>:once` |
| ⚠ Apply directly | `apv:<writeRequestId>:once` |
| 🚫 Cancel | `apv:<suggestRequestId>:deny` |
| 📖 Open in Drive | URL button |

## Why two request ids?

The card surfaces both action buttons; each one grants a different kernel scope (`doc:gdrive:suggest:<id>` vs `:write:<id>`). The upstream caller registers BOTH up front with `approval_request` and passes both ids to this renderer; the user taps one, the other expires naturally.

## Fragility guard from B2 review

The `create_doc` prep helper synthesises a `"pending-create"` placeholder fileId (the doc doesn't exist yet). `validateDriveId` happily accepts the literal "pending-create" (alnum + `-`), so a naive Open-in-Drive button would emit a broken link. This renderer detects the sentinel and drops the button row instead.

## Test plan

- [x] `bun test telegram-plugin/gateway/` — 58 pass (9 new cases)
- [x] `bun run lint` — clean
- [ ] Independent reviewer verdict

## Pairs with

- #1252 — `buildDiffPreview()` (consumed input)
- #1297 — edit-prep helpers (B2; produces `DiffPreviewInput` for this renderer)
- The MCP-tool wrapper + kernel-side double-request_id coordination land in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)