### PR TITLE
fix(telegram-plugin): tool-aware silence-poke fallback message (#1292)

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -83,13 +83,17 @@ ALLOWLIST=(
   # permission-request keyboard send. opts only has reply_markup. No thread_id.
   # Range bumped 2026-05-13 for stuck-turn-recovery v2 cleanup expansion
   # (~100 lines total added around line 2510).
-  "telegram-plugin/gateway/gateway.ts:2695-2880:permission-request keyboard; no thread_id"
+  # Range bumped 2026-05-15 for #1292 tool-aware silence-poke fallback
+  # (~32 lines added in onSessionEvent + ctx threading).
+  "telegram-plugin/gateway/gateway.ts:2695-2920:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
   # The caller dropped the thread; this raw sendMessage retries on the
   # main chat. Wrapping would re-enter the THREAD_NOT_FOUND throw on a
   # phantom second deletion.
-  "telegram-plugin/gateway/gateway.ts:3160-3360:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
+  # Range bumped 2026-05-15 for #1292 tool-aware silence-poke fallback
+  # (~32 lines added earlier in the file shift this band down).
+  "telegram-plugin/gateway/gateway.ts:3160-3400:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -52,6 +52,7 @@ import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import { createInboundCoalescer, inboundCoalesceKey } from './inbound-coalesce.js'
 import { StatusReactionController } from '../status-reactions.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
+import { toolLabel } from '../tool-labels.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
 import { handlePtyPartialPure, type PtyHandlerState } from '../pty-partial-handler.js'
@@ -2513,6 +2514,7 @@ silencePoke.startTimer({
     const text = silencePoke.formatFrameworkFallbackText(
       ctx.fallbackKind,
       ctx.silenceMs,
+      ctx.inFlightTools,
     )
     try {
       await robustApiCall(
@@ -2820,9 +2822,46 @@ const ipcServer: IpcServer = createIpcServer({
       const key = statusKey(currentTurn.sessionChatId, currentTurn.sessionThreadId)
       if (ev.kind === 'thinking') {
         silencePoke.noteThinking(key, Date.now())
-      } else if (ev.kind === 'tool_use' && (ev.toolName === 'Task' || ev.toolName === 'Agent')) {
-        // Built-in claude sub-agent dispatch — extends soft threshold to 5min.
-        silencePoke.noteSubagentDispatch(key)
+      } else if (ev.kind === 'tool_use') {
+        if (ev.toolName === 'Task' || ev.toolName === 'Agent') {
+          // Built-in claude sub-agent dispatch — extends soft threshold to 5min.
+          silencePoke.noteSubagentDispatch(key)
+        }
+        // #1292: track in-flight tool calls so the 300s framework
+        // fallback message can name the actual observable (e.g.
+        // "running Grep \"foo\" for 4m") instead of the dishonest
+        // generic "still working… no update in 5 min" when the agent
+        // is clearly busy on tool calls. Telegram-surface tools are
+        // excluded — their job IS the outbound message, the silence
+        // clock resets via noteOutbound when they fire. Sub-agent
+        // tool_use events (kind='sub_agent_tool_use') intentionally
+        // NOT tracked: the parent's Task tool_use is already on the
+        // map and represents the user-observable wait.
+        if (
+          ev.toolUseId != null
+          && ev.toolUseId.length > 0
+          && !isTelegramSurfaceTool(ev.toolName)
+        ) {
+          const label = toolLabel(
+            ev.toolName,
+            ev.input,
+            /*preamble*/ undefined,
+            ev.precomputedLabel,
+          )
+          silencePoke.noteToolStart(
+            key,
+            ev.toolUseId,
+            ev.toolName,
+            label.length > 0 ? label : null,
+            Date.now(),
+          )
+        }
+      } else if (ev.kind === 'tool_result') {
+        // #1292: drain the in-flight entry. Idempotent on unknown ids
+        // (covers Telegram-surface tools we skipped at start time).
+        if (ev.toolUseId != null && ev.toolUseId.length > 0) {
+          silencePoke.noteToolEnd(key, ev.toolUseId, Date.now())
+        }
       }
     }
   },

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -45,6 +45,22 @@
 
 export type PokeLevel = 'soft' | 'firm'
 
+/** #1292: snapshot of an in-flight tool call, surfaced in the 300s
+ * framework-fallback message so the user sees the actual observable
+ * ("running Grep \"foo\" for 4m") instead of the dishonest generic
+ * "still working… no update in 5 min" when the agent is clearly busy
+ * grinding through tool calls. */
+export interface ToolSnapshot {
+  /** Bare tool name as it came off the wire (e.g. "Grep", "Read", "Bash"). */
+  name: string
+  /** Natural-language descriptor from `toolLabel()` if available (e.g. the
+   * query for Grep, basename for Read/Edit/Write, hostname for WebFetch),
+   * or null when no useful label could be derived. */
+  label: string | null
+  /** Time since this tool call started, in ms. */
+  durationMs: number
+}
+
 export interface SilencePokeState {
   /** Wall-clock ms of turn start. Silence clock zero-point when no outbound yet. */
   turnStartedAt: number
@@ -62,6 +78,16 @@ export interface SilencePokeState {
   fallbackFired: boolean
   /** Wall-clock ms of last poke fire — used for poke-success latency. */
   lastPokeFiredAt: number | null
+  /** #1292: in-flight tool calls keyed by toolUseId. Populated by
+   * `noteToolStart` on every parent-agent `tool_use` event the gateway
+   * sees and drained by `noteToolEnd` on the matching `tool_result`.
+   * Read only inside `tick()` when the 300s fallback fires — at that
+   * point we snapshot the entries (sorted by startedAt ascending) and
+   * include the longest-running one in the fallback message body.
+   * NOTE: presence of in-flight tools does NOT reset the silence
+   * clock — the design choice in this module's header is preserved.
+   * We only enrich the fallback TEXT, not the timing. */
+  inFlightTools: Map<string, { name: string; startedAt: number; label: string | null }>
 }
 
 export interface ThresholdsMs {
@@ -89,9 +115,19 @@ export interface FrameworkFallbackContext {
   chatId: string
   threadId: number | null
   /** Picked from lastThinkingAt: 'thinking' if a thinking event landed in
-   *  the last 30s of silence, else 'working'. */
+   *  the last 30s of silence, else 'working'. Note: 'working' is the
+   *  default base; when `inFlightTools` is non-empty the fallback text
+   *  uses the tool-aware wording instead of either 'working' / 'thinking'
+   *  (see `formatFrameworkFallbackText`). */
   fallbackKind: 'working' | 'thinking'
   silenceMs: number
+  /** #1292: snapshot of in-flight tool calls at the moment the fallback
+   *  fires, sorted by startedAt ascending. Empty when no tools were
+   *  in flight (e.g. agent genuinely silent, or all tools completed
+   *  faster than the 300s threshold). The format helper uses entry [0]
+   *  (longest-running) for the message body and "+ N more" when
+   *  length > 1. */
+  inFlightTools: ToolSnapshot[]
 }
 
 export type SilencePokeMetric =
@@ -141,6 +177,7 @@ export function startTurn(key: string, now: number): void {
     lastThinkingAt: null,
     fallbackFired: false,
     lastPokeFiredAt: null,
+    inFlightTools: new Map(),
   })
 }
 
@@ -203,6 +240,72 @@ export function noteThinking(key: string, now: number): void {
   const s = state.get(key)
   if (s == null) return
   s.lastThinkingAt = now
+}
+
+/**
+ * #1292: record the start of a tool call. Stored in `inFlightTools` keyed
+ * by `toolUseId` so a later `noteToolEnd` can drain the entry. Read only
+ * by `tick()` when the 300s fallback fires, where we snapshot the map
+ * into the fallback context so the user-visible message can name the
+ * actual observable (e.g. "running Grep \"foo\" for 4m") instead of the
+ * dishonest generic "still working… no update in 5 min".
+ *
+ * Idempotent: calling twice with the same toolUseId overwrites — useful
+ * when a late `noteToolLabel` arrives but the caller wants to reuse the
+ * start-side API. The `startedAt` is updated; for label-only refreshes
+ * use `noteToolLabel` instead so duration stays correct.
+ *
+ * No-op when the kill switch is on (state Map will be empty for this key).
+ */
+export function noteToolStart(
+  key: string,
+  toolUseId: string,
+  name: string,
+  label: string | null,
+  now: number,
+): void {
+  const s = state.get(key)
+  if (s == null) return
+  s.inFlightTools.set(toolUseId, { name, startedAt: now, label })
+}
+
+/**
+ * #1292: record completion of a tool call. Removes the entry from
+ * `inFlightTools`. Idempotent — calling on an unknown toolUseId is a
+ * no-op. Sub-second tools that start and end inside one poll interval
+ * are still safe because the map is only read inside `tick()` at the
+ * 300s fallback boundary; the churn never gets observed.
+ */
+export function noteToolEnd(
+  key: string,
+  toolUseId: string,
+  _now: number,
+): void {
+  const s = state.get(key)
+  if (s == null) return
+  s.inFlightTools.delete(toolUseId)
+}
+
+/**
+ * #1292: late label update for an in-flight tool. The tool-label sidecar
+ * (PreToolUse hook, polled every 250ms via `tool-label-sidecar.ts`) can
+ * publish a richer label some time after the `tool_use` event landed.
+ * When that arrives, refresh the entry in-place so the fallback message
+ * — if it fires later — picks up the better label.
+ *
+ * No-op when the toolUseId isn't tracked (e.g. tool already completed,
+ * or the start event was skipped because the tool is a Telegram surface).
+ */
+export function noteToolLabel(
+  key: string,
+  toolUseId: string,
+  label: string,
+): void {
+  const s = state.get(key)
+  if (s == null) return
+  const entry = s.inFlightTools.get(toolUseId)
+  if (entry == null) return
+  entry.label = label
 }
 
 /**
@@ -273,12 +376,50 @@ export function formatPokeText(level: PokeLevel): string {
 export function formatFrameworkFallbackText(
   fallbackKind: 'working' | 'thinking',
   silenceMs: number,
+  inFlightTools: ToolSnapshot[] = [],
 ): string {
   const minutes = Math.max(1, Math.round(silenceMs / 60_000))
   const suffix = `(no update from agent in ${minutes} min)`
+  // #1292 case (a): tools in flight. Name the longest-running one
+  // (entry[0] — caller pre-sorts by startedAt ascending). Avoid the
+  // "still working" framing #1292 explicitly calls out as dishonest:
+  // the agent IS doing work, we can see the tool. Format:
+  //   running Grep "foo" for 4m (no update from agent in 5 min)
+  //   running Grep "foo" + 2 more (4m) (no update from agent in 5 min)
+  //   running Grep (no label) for 4m (no update from agent in 5 min)
+  if (inFlightTools.length > 0) {
+    const longest = inFlightTools[0]!
+    const dur = formatDurationShort(longest.durationMs)
+    const labelTail = longest.label && longest.label.length > 0
+      ? ` ${truncateLabel(longest.label)}`
+      : ''
+    const more = inFlightTools.length > 1
+      ? ` + ${inFlightTools.length - 1} more`
+      : ''
+    return `running ${longest.name}${labelTail}${more} for ${dur} ${suffix}`
+  }
   return fallbackKind === 'thinking'
     ? `still thinking… ${suffix}`
     : `still working… ${suffix}`
+}
+
+/** Compact m/s rendering for the fallback message. Anything under a
+ *  minute reads as `${s}s`, otherwise `${m}m`. Always rounds toward the
+ *  user-honest direction — "4m" for 4m 30s, "5m" for 4m 45s. */
+function formatDurationShort(ms: number): string {
+  const totalSec = Math.max(0, Math.round(ms / 1000))
+  if (totalSec < 60) return `${totalSec}s`
+  const minutes = Math.round(totalSec / 60)
+  return `${minutes}m`
+}
+
+/** Telegram lines are short on mobile. Clip the label to keep the
+ *  fallback message readable. Truncation point is generous (60 chars)
+ *  because tool labels are pre-truncated by `toolLabel()` already. */
+function truncateLabel(label: string): string {
+  const MAX = 60
+  if (label.length <= MAX) return label
+  return label.slice(0, MAX - 1) + '…'
 }
 
 /**
@@ -331,6 +472,16 @@ function tick(now: number): void {
       const recentThinking = s.lastThinkingAt != null
         && (now - s.lastThinkingAt) < 30_000
       const fallbackKind: 'working' | 'thinking' = recentThinking ? 'thinking' : 'working'
+      // #1292: snapshot in-flight tools at fire time, sorted by
+      // startedAt ascending so entry[0] is the longest-running.
+      // Pre-computed durations in ms; the formatter just renders.
+      const inFlightTools: ToolSnapshot[] = Array.from(s.inFlightTools.values())
+        .sort((a, b) => a.startedAt - b.startedAt)
+        .map(t => ({
+          name: t.name,
+          label: t.label,
+          durationMs: now - t.startedAt,
+        }))
       activeDeps.emitMetric({
         kind: 'silence_fallback_sent',
         key,
@@ -345,6 +496,7 @@ function tick(now: number): void {
           threadId,
           fallbackKind,
           silenceMs: silence,
+          inFlightTools,
         })
         if (r != null && typeof (r as Promise<void>).catch === 'function') {
           ;(r as Promise<void>).catch((err) => {

--- a/telegram-plugin/tests/silence-poke.test.ts
+++ b/telegram-plugin/tests/silence-poke.test.ts
@@ -4,6 +4,9 @@ import {
   noteOutbound,
   noteSubagentDispatch,
   noteThinking,
+  noteToolStart,
+  noteToolEnd,
+  noteToolLabel,
   consumeArmedPoke,
   endTurn,
   silencePokeEnabled,
@@ -337,6 +340,211 @@ describe('silence-poke — abnormal turn-end invariants (CC-5 follow-up)', () =>
     expect(
       fx.emitted.filter((e) => e.kind === 'silence_fallback_sent'),
     ).toHaveLength(0)
+  })
+})
+
+// #1292 — drive a deterministic, tool-aware fallback message from the
+// gateway's `tool_use` / `tool_result` event stream. The progress card
+// was retired in #1122 PR3 in favour of the conversational shape; the
+// remaining honesty gap was that the 300s framework fallback said
+// "still working… no update in 5 min" on turns where the agent was
+// clearly grinding through tool calls. These tests pin the behaviour:
+// the silence clock is NOT reset by tool churn (header invariant
+// preserved), but the fallback message body becomes tool-aware so the
+// user sees the actual observable.
+describe('silence-poke — #1292 tool-aware framework fallback', () => {
+  it('fallback context exposes in-flight tool snapshot with duration', () => {
+    const fx = setupDeps()
+    startTurn('k', 0)
+    noteToolStart('k', 'T1', 'Grep', 'foo', 30_000)
+    __tickForTests(75_000)
+    __tickForTests(180_000)
+    __tickForTests(305_000)
+    expect(fx.fallbacks).toHaveLength(1)
+    const ctx = fx.fallbacks[0]!
+    expect(ctx.inFlightTools).toHaveLength(1)
+    expect(ctx.inFlightTools[0]!.name).toBe('Grep')
+    expect(ctx.inFlightTools[0]!.label).toBe('foo')
+    expect(ctx.inFlightTools[0]!.durationMs).toBe(305_000 - 30_000)
+  })
+
+  it('formatFrameworkFallbackText names the longest-running tool with duration', () => {
+    const text = formatFrameworkFallbackText('working', 305_000, [
+      { name: 'Grep', label: '"foo"', durationMs: 275_000 },
+    ])
+    expect(text).toBe(
+      'running Grep "foo" for 5m (no update from agent in 5 min)',
+    )
+  })
+
+  it('multiple in-flight tools render as "+ N more"', () => {
+    const text = formatFrameworkFallbackText('working', 305_000, [
+      { name: 'Grep', label: '"foo"', durationMs: 275_000 },
+      { name: 'Read', label: 'config.ts', durationMs: 120_000 },
+      { name: 'Bash', label: null, durationMs: 60_000 },
+    ])
+    expect(text).toBe(
+      'running Grep "foo" + 2 more for 5m (no update from agent in 5 min)',
+    )
+  })
+
+  it('tool with no label renders the bare name', () => {
+    const text = formatFrameworkFallbackText('working', 305_000, [
+      { name: 'Bash', label: null, durationMs: 305_000 },
+    ])
+    expect(text).toBe(
+      'running Bash for 5m (no update from agent in 5 min)',
+    )
+  })
+
+  it('empty inFlightTools falls back to the base "still working" wording', () => {
+    expect(
+      formatFrameworkFallbackText('working', 305_000, []),
+    ).toBe('still working… (no update from agent in 5 min)')
+    expect(
+      formatFrameworkFallbackText('thinking', 305_000, []),
+    ).toBe('still thinking… (no update from agent in 5 min)')
+    // No third arg → same as empty array.
+    expect(
+      formatFrameworkFallbackText('working', 305_000),
+    ).toBe('still working… (no update from agent in 5 min)')
+  })
+
+  it('tool-aware wording wins over "thinking" — the actual observable beats the inferred kind', () => {
+    const text = formatFrameworkFallbackText('thinking', 305_000, [
+      { name: 'Grep', label: '"foo"', durationMs: 305_000 },
+    ])
+    expect(text.startsWith('running Grep')).toBe(true)
+    expect(text).not.toContain('still thinking')
+  })
+
+  it('tool completed before the fallback → empty snapshot → base wording', () => {
+    const fx = setupDeps()
+    startTurn('k', 0)
+    noteToolStart('k', 'T1', 'Grep', 'foo', 30_000)
+    noteToolEnd('k', 'T1', 200_000)
+    __tickForTests(75_000)
+    __tickForTests(180_000)
+    __tickForTests(305_000)
+    expect(fx.fallbacks).toHaveLength(1)
+    expect(fx.fallbacks[0]!.inFlightTools).toHaveLength(0)
+  })
+
+  it('late noteToolLabel updates the in-flight entry in place', () => {
+    const fx = setupDeps()
+    startTurn('k', 0)
+    noteToolStart('k', 'T1', 'Grep', null, 30_000)
+    noteToolLabel('k', 'T1', '"refined-from-sidecar"')
+    __tickForTests(75_000)
+    __tickForTests(180_000)
+    __tickForTests(305_000)
+    expect(fx.fallbacks[0]!.inFlightTools[0]!.label).toBe('"refined-from-sidecar"')
+  })
+
+  it('endTurn drains inFlightTools', () => {
+    setupDeps()
+    startTurn('k', 0)
+    noteToolStart('k', 'T1', 'Grep', 'foo', 30_000)
+    expect(__getStateForTests('k')!.inFlightTools.size).toBe(1)
+    endTurn('k')
+    // A fresh turn under the same key has an empty map.
+    startTurn('k', 1_000_000)
+    expect(__getStateForTests('k')!.inFlightTools.size).toBe(0)
+  })
+
+  it('parallel tools sort by startedAt ascending — longest-running rendered first', () => {
+    const fx = setupDeps()
+    startTurn('k', 0)
+    // Order intentionally NOT chronological to verify sort.
+    noteToolStart('k', 'T-late', 'Read', 'recent.ts', 250_000)
+    noteToolStart('k', 'T-early', 'Grep', '"oldest"', 20_000)
+    noteToolStart('k', 'T-mid', 'Bash', null, 100_000)
+    __tickForTests(75_000)
+    __tickForTests(180_000)
+    __tickForTests(305_000)
+    const snap = fx.fallbacks[0]!.inFlightTools
+    expect(snap.map(t => t.name)).toEqual(['Grep', 'Bash', 'Read'])
+  })
+
+  it('tool churn does NOT reset the silence clock (header invariant preserved)', () => {
+    // The whole point of #1292 (b) over (a) is that we enrich the
+    // fallback TEXT, never the timing. Tool activity must not delay
+    // or suppress the soft/firm/fallback escalation ladder.
+    const fx = setupDeps()
+    startTurn('k', 0)
+    // A constant stream of tool churn through the entire 5min window —
+    // each tool ends quickly so inFlightTools is empty by fallback.
+    for (let t = 5_000; t <= 295_000; t += 10_000) {
+      noteToolStart('k', `T-${t}`, 'Grep', 'foo', t)
+      noteToolEnd('k', `T-${t}`, t + 500)
+    }
+    __tickForTests(75_000) // soft
+    __tickForTests(180_000) // firm
+    __tickForTests(305_000) // fallback
+    expect(
+      fx.emitted.filter(e => e.kind === 'silence_poke_fired'),
+    ).toHaveLength(2)
+    expect(fx.fallbacks).toHaveLength(1)
+  })
+
+  it('Task tool sets subagentDispatchActive AND populates inFlightTools', () => {
+    // Two flags are independent: the soft-threshold extension still
+    // works for sub-agent waits (existing behaviour), AND the fallback
+    // message names the Task tool as the actual observable.
+    const fx = setupDeps()
+    startTurn('k', 0)
+    // Gateway calls both for a Task tool_use (mirrors the wiring at
+    // gateway.ts onSessionEvent).
+    noteSubagentDispatch('k')
+    noteToolStart('k', 'T1', 'Task', 'spinning up @researcher', 10_000)
+    // Soft threshold extends to 300s under subagent — so no soft poke
+    // fires at 75s and no firm fires at 180s (firm requires pokesFired===1,
+    // i.e. soft must fire first). Once we cross the 300s subagent-soft,
+    // soft fires; each tick fires one level via the `continue` in tick(),
+    // so we need three ticks to walk soft → firm → fallback.
+    __tickForTests(75_000)   // suppressed by subagent
+    __tickForTests(180_000)  // still suppressed
+    __tickForTests(305_000)  // soft fires (subagent soft = 300s)
+    __tickForTests(305_001)  // firm fires
+    __tickForTests(305_002)  // fallback fires
+    expect(fx.fallbacks).toHaveLength(1)
+    const snap = fx.fallbacks[0]!.inFlightTools
+    expect(snap[0]!.name).toBe('Task')
+    expect(snap[0]!.label).toBe('spinning up @researcher')
+  })
+
+  it('noteToolStart on an unknown key is a no-op (no crash, no state)', () => {
+    setupDeps()
+    // No startTurn first — silence-poke ignores the call.
+    noteToolStart('k-never-started', 'T1', 'Grep', 'foo', 30_000)
+    expect(__getStateForTests('k-never-started')).toBeUndefined()
+  })
+
+  it('noteToolEnd on an unknown id is a no-op', () => {
+    setupDeps()
+    startTurn('k', 0)
+    noteToolEnd('k', 'never-started', 100_000)
+    expect(__getStateForTests('k')!.inFlightTools.size).toBe(0)
+  })
+
+  it('formatFrameworkFallbackText sub-minute durations render as "Ns"', () => {
+    const text = formatFrameworkFallbackText('working', 305_000, [
+      { name: 'Grep', label: 'foo', durationMs: 12_000 },
+    ])
+    expect(text).toBe(
+      'running Grep foo for 12s (no update from agent in 5 min)',
+    )
+  })
+
+  it('formatFrameworkFallbackText truncates very long labels', () => {
+    const longLabel = '"' + 'x'.repeat(120) + '"'
+    const text = formatFrameworkFallbackText('working', 305_000, [
+      { name: 'Grep', label: longLabel, durationMs: 305_000 },
+    ])
+    // 60-char cap (with trailing ellipsis) — verify clipping without
+    // pinning exact bytes.
+    expect(text.length).toBeLessThan(120)
+    expect(text).toContain('…')
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #1292.

The 300s framework fallback emitted `still working… (no update from agent in 5 min)` even on turns where the agent was clearly grinding through tool calls. That's dishonest: the gateway can see the `tool_use` / `tool_result` event stream, so it knows the actual observable. The fix surfaces it.

### Approach — option (b)

The issue offered two paths:
- (a) Revive the pinned progress card that was retired in #1122 PR3.
- (b) Keep the conversational shape #1122 chose, just enrich the fallback message body.

This PR ships (b). Smaller blast radius, doesn't reintroduce a UI surface that was deliberately removed, and addresses the "the framework is lying to the user" half of #1292 directly.

**The silence clock is NOT reset by tool churn** — the header invariant in `silence-poke.ts:14-19` is preserved. We only change what the 300s fallback *says*, not when it fires. Pin test included.

### Behaviour

Before:
```
still working… (no update from agent in 5 min)
```

After (single tool):
```
running Grep "foo" for 4m (no update from agent in 5 min)
```

After (multiple in-flight):
```
running Grep "foo" + 2 more for 4m (no update from agent in 5 min)
```

After (no tools, recent `thinking` event):
```
still thinking… (no update from agent in 5 min)        # unchanged
```

After (no tools, no thinking — genuine silence):
```
still working… (no update from agent in 5 min)         # unchanged
```

## Implementation

**`silence-poke.ts`:**
- New state field `inFlightTools: Map<toolUseId, {name, startedAt, label}>`.
- Three new exports: `noteToolStart`, `noteToolEnd`, `noteToolLabel`.
- `FrameworkFallbackContext` carries an `inFlightTools[]` snapshot (sorted by `startedAt` ascending) computed at fire time.
- `formatFrameworkFallbackText` takes a third `inFlightTools` arg. Non-empty → tool-aware wording. Empty → legacy `still working` / `still thinking`.

**`gateway.ts`:**
- Import `toolLabel` from `tool-labels.js`.
- In `onSessionEvent`: on `tool_use`, eager-resolve via `toolLabel(name, input, undefined, precomputedLabel)`, then `noteToolStart`. Gate on `!isTelegramSurfaceTool(name)` (their job IS the outbound) and require non-empty `toolUseId`. On `tool_result`, call `noteToolEnd`. Sub-agent `tool_use` / `tool_result` events intentionally NOT tracked — the parent's `Task` tool_use is already on the map.
- Plumb `ctx.inFlightTools` into the existing `formatFrameworkFallbackText` call.

**`scripts/check-bot-api-wrapping.sh`:**
- Bumped two pre-existing line-range allowlist entries to cover the ~32-line shift from the new tool-tracking block. No new raw `bot.api.*` calls introduced.

## Test plan

- [x] `bun test tests/silence-poke.test.ts` — 52/52 pass (was 36, +16 new)
- [x] `bun test tests/{silence-poke,turn-flush-safety,turn-flush-dedup-controller,gateway-disconnect-flush,tool-labels}.test.ts` — 133/133 pass
- [x] `npm run lint` — clean
- [ ] Manual: trigger a 5-min tool-heavy turn (e.g. a long Grep), verify fallback message reads "running Grep \"foo\" for 5m …"
- [ ] Manual: 5-min turn with no tools active, verify fallback stays "still working…"

## New tests (16)

Under `silence-poke — #1292 tool-aware framework fallback`:
1. Fallback context exposes in-flight tool snapshot with duration
2. Format helper names longest-running tool with duration
3. Multiple tools render as "+ N more"
4. Tool with no label renders bare name
5. Empty inFlightTools → base wording
6. Tool-aware wording wins over "thinking" (actual observable)
7. Tool completed before fallback → empty snapshot → base wording
8. Late `noteToolLabel` updates in place
9. `endTurn` drains the map
10. Parallel tools sort by startedAt ascending
11. **Tool churn does NOT reset the silence clock** (header invariant pin)
12. Task tool sets `subagentDispatchActive` AND populates `inFlightTools`
13. `noteToolStart` on unknown key is a no-op
14. `noteToolEnd` on unknown id is a no-op
15. Sub-minute durations render as "Ns"
16. Very long labels truncate with ellipsis

## Related

- #1289 — silence-poke fires after clean turn end (merged in #1293, same module)
- #1291 — auto-flush terminal text (sibling, PR #1298, "chat-state transitions belong to the gateway, not the model")

🤖 Generated with [Claude Code](https://claude.com/claude-code)