### PR TITLE
fix(telegram-plugin): suppress sandbox-hint false positives on successful tools (#1303)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2897,15 +2897,23 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           ],
         },
         {
-          // Layer 2 of the sandbox UX work — fires on every PostToolUse,
-          // detects EROFS / read-only / sandbox-related errors in
-          // tool_response, and injects a one-line hint via
-          // additionalContext so the agent responds usefully on Telegram
-          // instead of silently retrying or echoing the raw kernel
-          // error. Pairs with the SANDBOX primer in
-          // --append-system-prompt. Hook is fail-silent: a broken hint
-          // never blocks the tool flow.
-          matcher: ".*",
+          // Layer 2 of the sandbox UX work — detects EROFS / read-only
+          // / sandbox-related errors in tool_response and injects a
+          // one-line hint via additionalContext so the agent responds
+          // usefully on Telegram instead of silently retrying or
+          // echoing the raw kernel error. Pairs with the SANDBOX
+          // primer in --append-system-prompt. Hook is fail-silent: a
+          // broken hint never blocks the tool flow.
+          //
+          // #1303: matcher narrowed from ".*" to write-capable tools +
+          // MCP tools only. Read/Grep/Glob/WebFetch/etc. cannot hit a
+          // kernel sandbox boundary by definition, and the old
+          // matcher caused false positives every time a Read/Grep
+          // payload merely MENTIONED EROFS / read-only-fs strings
+          // (file content, code comments, the hook source itself).
+          // The hook script also gates on these tools internally as
+          // defence in depth.
+          matcher: "^(Edit|Write|NotebookEdit|Bash|mcp__.*)$",
           hooks: [
             {
               type: "command",

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2913,7 +2913,7 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           // (file content, code comments, the hook source itself).
           // The hook script also gates on these tools internally as
           // defence in depth.
-          matcher: "^(Edit|Write|NotebookEdit|Bash|mcp__.*)$",
+          matcher: "^(Edit|MultiEdit|Write|NotebookEdit|Bash|mcp__.*)$",
           hooks: [
             {
               type: "command",

--- a/telegram-plugin/hooks/sandbox-hint-posttool.mjs
+++ b/telegram-plugin/hooks/sandbox-hint-posttool.mjs
@@ -90,6 +90,85 @@ function emitContext(text) {
   process.stdout.write(JSON.stringify(payload) + '\n')
 }
 
+/**
+ * #1303: classify a tool_response as a failure. Only failures can have
+ * hit a kernel sandbox boundary. Pre-fix the hook stringified the whole
+ * tool_response and pattern-matched against it — that meant a SUCCESSFUL
+ * Read/Edit/Bash whose payload merely MENTIONED "EROFS" or "Read-only
+ * file system" (e.g. file content, code comments, grep results, the hook
+ * source itself) tripped the advisory. Verified live during #1291/#1292
+ * PR work: every `Read` on a file talking about the sandbox model
+ * produced a false positive; every `Edit` adding a comment that
+ * mentioned read-only-fs did too.
+ *
+ * Recognise failure across the three observed tool_response shapes:
+ *   - Edit / Write / NotebookEdit / MCP: `{ is_error: true, ... }`
+ *   - Bash: `{ exit_code: <non-zero>, stdout, stderr, ... }`
+ *   - Free-form string body: assume failure if the string parses; the
+ *     pattern match downstream still gates the advisory text.
+ *
+ * Also exported as `legacy.error` style for forward-compat: any
+ * non-null `tool_response.error` field is treated as failure.
+ *
+ * If no failure signal is found we have no kernel error to advise on,
+ * and the hook stays silent.
+ */
+function classifyFailure(toolResponse) {
+  if (toolResponse == null) return null
+  if (typeof toolResponse === 'string') {
+    // Bare string body — no structured failure marker. Treat as a
+    // candidate; the pattern match decides.
+    return { kind: 'bare-string', body: toolResponse }
+  }
+  if (typeof toolResponse !== 'object') return null
+  const isError =
+    toolResponse.is_error === true
+    || toolResponse.success === false
+    || toolResponse.error != null
+    || (typeof toolResponse.exit_code === 'number'
+        && toolResponse.exit_code !== 0)
+  if (!isError) return null
+  // Extract error-bearing fields only — never the full response. For a
+  // failed Bash, stdout may carry the relevant kernel message alongside
+  // stderr (some commands write errors to stdout), so include stdout
+  // when there's a non-zero exit code.
+  const parts = []
+  if (typeof toolResponse.error === 'string') parts.push(toolResponse.error)
+  if (typeof toolResponse.stderr === 'string') parts.push(toolResponse.stderr)
+  if (toolResponse.exit_code != null && toolResponse.exit_code !== 0
+      && typeof toolResponse.stdout === 'string') {
+    parts.push(toolResponse.stdout)
+  }
+  // Fallback: failure was signalled but no error-bearing field
+  // surfaced — stringify the structured response so we don't miss an
+  // unusual tool that puts the kernel error in an unexpected key.
+  // Bounded by the 64 KiB cap downstream.
+  if (parts.length === 0) {
+    try { parts.push(JSON.stringify(toolResponse)) } catch { /* unprintable */ }
+  }
+  return { kind: 'structured-failure', body: parts.join('\n') }
+}
+
+/**
+ * #1303 secondary defence: only write-capable tools can hit a kernel
+ * sandbox boundary. Read/Grep/Glob/WebFetch/etc. cannot EROFS — even if
+ * settings.json wires this hook with matcher ".*", we gate at the
+ * script level so a future scaffold change can't re-introduce the
+ * false-positive class. Bash is included because it's the canonical
+ * write surface (mkdir, rm, install, apt, etc.). MCP tools that may
+ * proxy writes are included by an `mcp__` prefix check.
+ */
+const WRITE_CAPABLE_TOOLS = new Set([
+  'Edit', 'Write', 'NotebookEdit', 'Bash',
+])
+
+function isWriteCapableTool(toolName) {
+  if (typeof toolName !== 'string') return false
+  if (WRITE_CAPABLE_TOOLS.has(toolName)) return true
+  if (toolName.startsWith('mcp__')) return true
+  return false
+}
+
 function main() {
   const raw = readStdin()
   if (!raw) return
@@ -101,18 +180,18 @@ function main() {
     return
   }
 
-  // tool_response shape varies by tool — string for Bash, object with
-  // file/oldString/newString for Edit/Write, etc. Stringify the whole
-  // thing so we match against every nested error field at once. Cap the
-  // scan window to keep memory bounded if the model just dumped a 10MB
-  // log into the tool_response.
-  let body
-  try {
-    body = JSON.stringify(evt.tool_response ?? '')
-  } catch {
-    return
-  }
-  if (!body) return
+  if (!isWriteCapableTool(evt.tool_name)) return
+
+  // #1303 primary fix: classify success vs failure FIRST. A successful
+  // tool can't have hit a kernel sandbox boundary by definition — its
+  // payload may mention EROFS / read-only-fs in benign content but
+  // that's not a kernel error.
+  const failure = classifyFailure(evt.tool_response)
+  if (failure == null) return
+
+  let body = failure.body
+  if (typeof body !== 'string') return
+  if (body.length === 0) return
   if (body.length > 64 * 1024) body = body.slice(0, 64 * 1024)
 
   for (const [pattern, key] of PATTERNS) {
@@ -121,6 +200,18 @@ function main() {
       return
     }
   }
+}
+
+// Test-only export hooks. Node ESM doesn't expose internal symbols
+// without a named export; tests import `__internals` and assert against
+// `classifyFailure` / `isWriteCapableTool` directly. Production paths
+// use `main()` and never touch this object.
+export const __internals = {
+  classifyFailure,
+  isWriteCapableTool,
+  WRITE_CAPABLE_TOOLS,
+  PATTERNS,
+  buildHint,
 }
 
 try {

--- a/telegram-plugin/hooks/sandbox-hint-posttool.mjs
+++ b/telegram-plugin/hooks/sandbox-hint-posttool.mjs
@@ -159,7 +159,7 @@ function classifyFailure(toolResponse) {
  * proxy writes are included by an `mcp__` prefix check.
  */
 const WRITE_CAPABLE_TOOLS = new Set([
-  'Edit', 'Write', 'NotebookEdit', 'Bash',
+  'Edit', 'MultiEdit', 'Write', 'NotebookEdit', 'Bash',
 ])
 
 function isWriteCapableTool(toolName) {

--- a/telegram-plugin/tests/sandbox-hint-posttool.test.ts
+++ b/telegram-plugin/tests/sandbox-hint-posttool.test.ts
@@ -338,7 +338,7 @@ describe('sandbox-hint-posttool', () => {
   describe('isWriteCapableTool', () => {
     it('returns true for the canonical write tools', async () => {
       const mod = await import('../hooks/sandbox-hint-posttool.mjs')
-      for (const n of ['Edit', 'Write', 'NotebookEdit', 'Bash']) {
+      for (const n of ['Edit', 'MultiEdit', 'Write', 'NotebookEdit', 'Bash']) {
         expect(mod.__internals.isWriteCapableTool(n)).toBe(true)
       }
     })

--- a/telegram-plugin/tests/sandbox-hint-posttool.test.ts
+++ b/telegram-plugin/tests/sandbox-hint-posttool.test.ts
@@ -70,6 +70,7 @@ describe('sandbox-hint-posttool', () => {
       tool_name: 'Bash',
       tool_use_id: 'toolu_003',
       tool_response: {
+        exit_code: 100,
         stderr:
           'E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?',
       },
@@ -141,15 +142,224 @@ describe('sandbox-hint-posttool', () => {
   it('caps the scan window for huge tool_response payloads', () => {
     // 100 KiB of harmless output followed by an EROFS — we cap at 64 KiB
     // so this should NOT match. Keeps a runaway tool_response from
-    // pinning the hook on a regex scan.
+    // pinning the hook on a regex scan. The exit_code is set so the
+    // failure-classifier reaches the scan path — without it, #1303's
+    // success-gate would return early for a different reason.
     const huge = 'x'.repeat(100 * 1024) + ' EROFS happened'
     const result = runHook({
       tool_name: 'Bash',
       tool_use_id: 'toolu_007',
-      tool_response: { stdout: huge },
+      tool_response: { exit_code: 1, stdout: huge },
     })
 
     expect(result.status).toBe(0)
     expect(result.stdout.trim()).toBe('')
+  })
+
+  // #1303 — the hook used to fire on every tool whose payload merely
+  // MENTIONED EROFS / read-only-fs / EACCES /usr / dpkg, regardless of
+  // whether the tool actually failed. Concrete repro: reading a file
+  // whose content describes the sandbox model triggered the advisory
+  // every time. Fix: classify tool_response as success-or-failure FIRST
+  // (only failures can have hit a kernel boundary), AND gate on
+  // write-capable tools only (Read/Grep/Glob can't EROFS).
+  describe('#1303 — false-positive guard', () => {
+    it('does NOT emit when a Read on a file MENTIONS EROFS (Read is not write-capable)', () => {
+      const result = runHook({
+        tool_name: 'Read',
+        tool_use_id: 'toolu_fp_read',
+        // Realistic: an Edit on a file whose Read returns content that
+        // happens to talk about the sandbox model. Pre-fix this fired.
+        tool_response: {
+          file: '/state/agent/home/some-doc.md',
+          content:
+            '# Sandbox notes\n\nWhen a write hits EROFS we say "Read-only file system".\n',
+        },
+      })
+
+      expect(result.status).toBe(0)
+      expect(result.stdout.trim()).toBe('')
+    })
+
+    it('does NOT emit when a Grep finds a line containing "Read-only file system"', () => {
+      const result = runHook({
+        tool_name: 'Grep',
+        tool_use_id: 'toolu_fp_grep',
+        tool_response: { stdout: 'docs/sandbox.md:42: Read-only file system semantics' },
+      })
+
+      expect(result.status).toBe(0)
+      expect(result.stdout.trim()).toBe('')
+    })
+
+    it('does NOT emit when a successful Bash mentions EROFS in stdout (exit_code=0)', () => {
+      const result = runHook({
+        tool_name: 'Bash',
+        tool_use_id: 'toolu_fp_bash_success',
+        tool_response: {
+          exit_code: 0,
+          stdout: 'I tested EROFS handling: all good.',
+        },
+      })
+
+      expect(result.status).toBe(0)
+      expect(result.stdout.trim()).toBe('')
+    })
+
+    it('does NOT emit when a successful Edit echoes new content containing "EROFS"', () => {
+      // The Edit tool's tool_response echoes the modified content. If
+      // the new content mentions EROFS — e.g. when editing this very
+      // hook source — the pre-fix logic fired falsely on every keystroke.
+      const result = runHook({
+        tool_name: 'Edit',
+        tool_use_id: 'toolu_fp_edit_success',
+        tool_response: {
+          // is_error explicitly false; no error field; no exit_code.
+          is_error: false,
+          file_path: '/state/agent/home/hook.mjs',
+          old_string: '// old',
+          new_string: '// new code mentioning EROFS and read-only file system semantics',
+        },
+      })
+
+      expect(result.status).toBe(0)
+      expect(result.stdout.trim()).toBe('')
+    })
+
+    it('still emits when an Edit FAILED with is_error=true on a real EROFS', () => {
+      const result = runHook({
+        tool_name: 'Edit',
+        tool_use_id: 'toolu_real_failure',
+        tool_response: {
+          is_error: true,
+          error: "EROFS: read-only file system, open '/opt/switchroom/skills/foo.md'",
+        },
+      })
+
+      expect(result.status).toBe(0)
+      const ctx = parseContext(result.stdout)
+      expect(ctx).toContain('Sandbox boundary hit')
+    })
+
+    it('still emits when a Bash FAILED with non-zero exit_code and stderr containing EROFS', () => {
+      const result = runHook({
+        tool_name: 'Bash',
+        tool_use_id: 'toolu_real_bash_failure',
+        tool_response: {
+          exit_code: 1,
+          stderr: "mkdir: cannot create directory '/opt/foo': Read-only file system",
+          stdout: '',
+        },
+      })
+
+      expect(result.status).toBe(0)
+      const ctx = parseContext(result.stdout)
+      expect(ctx).toContain('Sandbox boundary hit')
+    })
+
+    it('does NOT emit for tools not in the write-capable allowlist, even on failure-shaped payload', () => {
+      // Even a payload that LOOKS like a failure — `is_error: true` —
+      // cannot reflect a kernel sandbox hit if the tool isn't write-
+      // capable. Read can't EROFS. We refuse to advise.
+      const result = runHook({
+        tool_name: 'WebFetch',
+        tool_use_id: 'toolu_fp_webfetch',
+        tool_response: { is_error: true, error: 'EROFS lookalike in HTTP body' },
+      })
+
+      expect(result.status).toBe(0)
+      expect(result.stdout.trim()).toBe('')
+    })
+
+    it('DOES emit for an MCP tool failure (proxies can write)', () => {
+      const result = runHook({
+        tool_name: 'mcp__some-server__write_file',
+        tool_use_id: 'toolu_mcp_failure',
+        tool_response: {
+          is_error: true,
+          error: 'EROFS: read-only file system on /opt/foo',
+        },
+      })
+
+      expect(result.status).toBe(0)
+      const ctx = parseContext(result.stdout)
+      expect(ctx).toContain('Sandbox boundary hit')
+    })
+  })
+
+  // Direct unit tests on the classifier helper.
+  describe('classifyFailure', () => {
+    it('returns null for a successful object response', async () => {
+      const mod = await import('../hooks/sandbox-hint-posttool.mjs')
+      expect(mod.__internals.classifyFailure({ exit_code: 0, stdout: 'EROFS mentioned' }))
+        .toBeNull()
+      expect(mod.__internals.classifyFailure({ is_error: false, content: 'EROFS mentioned' }))
+        .toBeNull()
+    })
+
+    it('returns a structured-failure for is_error=true', async () => {
+      const mod = await import('../hooks/sandbox-hint-posttool.mjs')
+      const got = mod.__internals.classifyFailure({
+        is_error: true,
+        error: 'EROFS: ...',
+      })
+      expect(got?.kind).toBe('structured-failure')
+      expect(got?.body).toContain('EROFS')
+    })
+
+    it('returns a structured-failure for non-zero exit_code with stderr', async () => {
+      const mod = await import('../hooks/sandbox-hint-posttool.mjs')
+      const got = mod.__internals.classifyFailure({
+        exit_code: 1,
+        stderr: 'Read-only file system',
+        stdout: 'also relevant context',
+      })
+      expect(got?.kind).toBe('structured-failure')
+      // Both stderr and stdout included on failed Bash.
+      expect(got?.body).toContain('Read-only file system')
+      expect(got?.body).toContain('also relevant context')
+    })
+
+    it('treats a bare string as a candidate to scan', async () => {
+      const mod = await import('../hooks/sandbox-hint-posttool.mjs')
+      const got = mod.__internals.classifyFailure('mkdir: Read-only file system')
+      expect(got?.kind).toBe('bare-string')
+      expect(got?.body).toContain('Read-only file system')
+    })
+
+    it('returns null for null / undefined / primitives', async () => {
+      const mod = await import('../hooks/sandbox-hint-posttool.mjs')
+      expect(mod.__internals.classifyFailure(null)).toBeNull()
+      expect(mod.__internals.classifyFailure(undefined)).toBeNull()
+      expect(mod.__internals.classifyFailure(42)).toBeNull()
+    })
+  })
+
+  describe('isWriteCapableTool', () => {
+    it('returns true for the canonical write tools', async () => {
+      const mod = await import('../hooks/sandbox-hint-posttool.mjs')
+      for (const n of ['Edit', 'Write', 'NotebookEdit', 'Bash']) {
+        expect(mod.__internals.isWriteCapableTool(n)).toBe(true)
+      }
+    })
+
+    it('returns false for read-only tools', async () => {
+      const mod = await import('../hooks/sandbox-hint-posttool.mjs')
+      for (const n of ['Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch', 'TodoWrite']) {
+        expect(mod.__internals.isWriteCapableTool(n)).toBe(false)
+      }
+    })
+
+    it('returns true for any MCP tool (proxy writes possible)', async () => {
+      const mod = await import('../hooks/sandbox-hint-posttool.mjs')
+      expect(mod.__internals.isWriteCapableTool('mcp__server__do_thing')).toBe(true)
+    })
+
+    it('returns false for empty / non-string', async () => {
+      const mod = await import('../hooks/sandbox-hint-posttool.mjs')
+      expect(mod.__internals.isWriteCapableTool('')).toBe(false)
+      expect(mod.__internals.isWriteCapableTool(null as any)).toBe(false)
+      expect(mod.__internals.isWriteCapableTool(undefined as any)).toBe(false)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Closes #1303.

The PostToolUse `sandbox-hint` hook fired its "Sandbox boundary hit" advisory on every tool whose payload merely **mentioned** the trigger strings (EROFS, read-only file system, EACCES /usr, dpkg permission denied), regardless of whether the tool actually failed. Verified live during #1289 / #1291 / #1292 PR work — every Read on a sandbox-related file, every Edit whose new content described it, every grep against the codebase fired the false advisory. Worker sub-agents took the advisory at face value and bailed; the foreground model wasted tokens correcting each false report.

### Root cause

`telegram-plugin/hooks/sandbox-hint-posttool.mjs` stringified the entire `tool_response` and substring-matched against the patterns. A successful tool can't have hit a kernel sandbox boundary, but the matcher didn't distinguish "kernel returned EROFS" from "file content contains the string EROFS." With `matcher: ".*"` in `settings.json` the hook also ran on Read/Grep/Glob — tools that physically can't EROFS.

### Fix (two layers, both needed)

**1. `sandbox-hint-posttool.mjs`** — classify success vs failure FIRST:

```js
classifyFailure(tool_response):
  - null for null/undefined/non-object/non-string
  - structured-failure when is_error / success:false / error / exit_code != 0
  - bare-string for free-form string bodies (let pattern decide)
```

Pattern matching runs only on error-bearing fields (`error`, `stderr`, plus stdout for failed Bash where some commands write errors there), never on the full response. Successful tools return early.

Plus `isWriteCapableTool(name)` gating: Edit, Write, NotebookEdit, Bash, and any `mcp__*` tool can hit the boundary; nothing else.

**2. `src/agents/scaffold.ts`** — narrow the settings.json matcher from `".*"` to `"^(Edit|Write|NotebookEdit|Bash|mcp__.*)$"`. New agents stop invoking the hook on read-only tools entirely; the script-level gate protects existing agents whose settings.json still has the broad matcher until next `switchroom apply`.

### Internal export for tests

The hook now exports `__internals` (`classifyFailure`, `isWriteCapableTool`, `WRITE_CAPABLE_TOOLS`, `PATTERNS`, `buildHint`) so the unit tests can hit the classifier directly without spinning subprocesses for every branch.

## Test plan

- [x] `bun test tests/sandbox-hint-posttool.test.ts` — 26/26 (was 9, +17 new)
- [x] `npm run lint` — clean
- [ ] Manual: after `switchroom apply` (operator-side), Read on a file mentioning EROFS → no advisory. Edit on a file whose new content mentions read-only-fs → no advisory. Genuine EROFS failure (e.g. `Bash: touch /opt/foo`) → advisory still fires.

## New tests added

**`#1303 — false-positive guard`** (8):
1. Read on a file MENTIONING EROFS → no emit (Read not write-capable)
2. Grep finding "Read-only file system" → no emit
3. Successful Bash mentioning EROFS in stdout (`exit_code=0`) → no emit
4. Successful Edit echoing new content containing EROFS (`is_error=false`) → no emit
5. Failed Edit with `is_error=true` on real EROFS → still emits
6. Failed Bash with non-zero exit + stderr EROFS → still emits
7. Non-write-capable tool (WebFetch) with failure-shaped payload → no emit
8. MCP tool failure → still emits (proxies can write)

**`classifyFailure`** (5): success object / `is_error=true` / non-zero `exit_code` with stderr+stdout / bare-string / null+undefined+primitives.

**`isWriteCapableTool`** (4): canonical write tools / read-only tools / `mcp__` prefix / edge cases.

## Related

- #1289 — silence-poke fires after clean turn end (#1293)
- #1291 — auto-flush post-reply tail (#1298)
- #1292 — tool-aware silence-poke fallback (#1301)

All three #1289-area PRs were authored against a barrage of these hook false positives. This PR's existence vindicates every one of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)