### PR TITLE
feat(hostd): complete Phase 2 gateway swap — close silent /update apply (#1305)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -214,8 +214,11 @@ import {
   tryHostdDispatch,
   hostdRequestId,
   hostdWillBeUsed,
+  pollHostdStatus,
+  warnLegacySpawnIfHostdDisabled,
   _resetHostdEnabledCache,
 } from './hostd-dispatch.js'
+import type { HostdRequest } from '../../src/host-control/protocol.js'
 import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 
@@ -7469,6 +7472,75 @@ async function executeVaultOp(ctx: Context, chatId: string, op: 'list' | 'get' |
   }
 }
 
+/**
+ * Dispatch a short-running verb (agent_start, agent_stop, cross-agent
+ * agent_restart) through hostd when available, else fall back to the
+ * legacy in-container CLI shell-out.
+ *
+ * Why: on docker-mode hosts the agent container has no docker binary,
+ * so the legacy `runSwitchroomCommand` path silently exits 127 for any
+ * verb that touches compose (RFC C §1, #926). Hostd runs on the host
+ * with the docker socket mounted, so the verb actually works.
+ *
+ * Result handling:
+ *   - `not-configured` → fall back to {@link runSwitchroomCommand}.
+ *     (Operator opted out; let the legacy path's existing error
+ *     surfacing handle the exit-127 case.)
+ *   - `completed` → reply with the stdout tail (mirrors the legacy
+ *     path's formatted-output reply).
+ *   - `started`   → reply with a brief "🔄 dispatched" ack. Verbs that
+ *     return `started` (agent_restart) finish asynchronously on the
+ *     daemon; the audit log is the canonical record.
+ *   - `error` / `denied` → reply with the error tail inline. No
+ *     fallback (RFC §7 hard-fail contract — operator opted in).
+ */
+async function dispatchShortVerbViaHostd(
+  ctx: Context,
+  req: HostdRequest,
+  label: string,
+  legacyArgs: string[],
+): Promise<void> {
+  const hostdResp = await tryHostdDispatch(getMyAgentName(), req)
+  if (hostdResp === 'not-configured') {
+    warnLegacySpawnIfHostdDisabled(req.op)
+    await runSwitchroomCommand(ctx, legacyArgs, label)
+    return
+  }
+  if (hostdResp.result === 'completed') {
+    const body = hostdResp.stdout_tail?.trim() || `${label}: done (exit ${hostdResp.exit_code})`
+    const formatted = formatSwitchroomOutput(stripAnsi(body))
+    if (formatted) {
+      await switchroomReply(ctx, preBlock(formatted), { html: true })
+    } else {
+      await switchroomReply(ctx, `${label}: done (no output)`)
+    }
+    return
+  }
+  if (hostdResp.result === 'started') {
+    await switchroomReply(
+      ctx,
+      `🔄 <b>${escapeHtmlForTg(label)}</b> dispatched via hostd ` +
+        `(request_id=<code>${escapeHtmlForTg(hostdResp.request_id)}</code>). ` +
+        `Check audit log for completion.`,
+      { html: true },
+    )
+    return
+  }
+  // error / denied — surface inline. RFC §7 hard-fail: no spawn fallback.
+  const errBody =
+    hostdResp.error ??
+    hostdResp.stderr_tail ??
+    hostdResp.stdout_tail ??
+    '(no error tail returned)'
+  await switchroomReply(
+    ctx,
+    `❌ <b>${escapeHtmlForTg(label)} failed via hostd</b> ` +
+      `(result=${escapeHtmlForTg(hostdResp.result)}):\n` +
+      preBlock(stripAnsi(errBody)),
+    { html: true },
+  )
+}
+
 async function runSwitchroomCommand(ctx: Context, args: string[], label: string): Promise<void> {
   try {
     const output = stripAnsi(switchroomExec(args))
@@ -7879,14 +7951,24 @@ bot.command('agentstart', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   const name = ctx.match?.trim() || getMyAgentName()
   try { assertSafeAgentName(name) } catch { await switchroomReply(ctx, 'Invalid agent name.'); return }
-  await runSwitchroomCommand(ctx, ['agent', 'start', name], `start ${name}`)
+  await dispatchShortVerbViaHostd(
+    ctx,
+    { v: 1, op: 'agent_start', request_id: hostdRequestId('gw-start'), args: { name } },
+    `start ${name}`,
+    ['agent', 'start', name],
+  )
 })
 
 bot.command('stop', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   const name = ctx.match?.trim() || getMyAgentName()
   try { assertSafeAgentName(name) } catch { await switchroomReply(ctx, 'Invalid agent name.'); return }
-  await runSwitchroomCommand(ctx, ['agent', 'stop', name], `stop ${name}`)
+  await dispatchShortVerbViaHostd(
+    ctx,
+    { v: 1, op: 'agent_stop', request_id: hostdRequestId('gw-stop'), args: { name } },
+    `stop ${name}`,
+    ['agent', 'stop', name],
+  )
 })
 
 bot.command('restart', async ctx => {
@@ -7933,6 +8015,7 @@ bot.command('restart', async ctx => {
       args: { name, force: true, reason: 'user: /restart from chat' },
     })
     if (hostdResp === 'not-configured') {
+      warnLegacySpawnIfHostdDisabled('agent_restart')
       spawnSwitchroomDetached(
         ['agent', 'restart', name, '--force'],
         notifyDetachedFailure(chatId, threadId ?? null, `restart ${name}`),
@@ -7955,7 +8038,22 @@ bot.command('restart', async ctx => {
     )
     return
   }
-  await runSwitchroomCommand(ctx, ['agent', 'restart', name], `restart ${name}`)
+  // Cross-agent /restart <other>. Same hostd-first shape as self-target,
+  // but no restart marker / no self-kill: another agent's container is
+  // about to bounce, not ours. The daemon spawns the work and returns
+  // "started" (per handleAgentRestart at server.ts:466), so the user
+  // sees a brief dispatch ack and the audit log carries the outcome.
+  await dispatchShortVerbViaHostd(
+    ctx,
+    {
+      v: 1,
+      op: 'agent_restart',
+      request_id: hostdRequestId('gw-restart-cross'),
+      args: { name, force: true, reason: `user: /restart ${name} from chat` },
+    },
+    `restart ${name}`,
+    ['agent', 'restart', name],
+  )
 })
 
 // ─── /new and /reset ──────────────────────────────────────────────────────
@@ -8074,6 +8172,7 @@ async function handleNewOrResetCommand(ctx: Context, kind: 'new' | 'reset'): Pro
     args: { name, force: true, reason: `user: /${kind} from chat` },
   })
   if (hostdResp === 'not-configured') {
+    warnLegacySpawnIfHostdDisabled('agent_restart')
     spawnSwitchroomDetached(
       ['agent', 'restart', name, '--force'],
       notifyDetachedFailure(chatId, threadId ?? null, `${kind} ${name}`),
@@ -8237,23 +8336,79 @@ bot.command('update', async ctx => {
   await sweepBeforeSelfRestart()
   const skipImages = passthrough.includes('--skip-images')
   const rebuild = passthrough.includes('--rebuild')
+  const updateRequestId = hostdRequestId('gw-update')
   const hostdResp = await tryHostdDispatch(getMyAgentName(), {
     v: 1,
     op: 'update_apply',
-    request_id: hostdRequestId('gw-update'),
+    request_id: updateRequestId,
     args: {
       ...(skipImages ? { skip_images: true } : {}),
       ...(rebuild ? { rebuild: true } : {}),
     },
   })
   if (hostdResp === 'not-configured') {
+    warnLegacySpawnIfHostdDisabled('update_apply')
     spawnSwitchroomDetached(
       ['update', ...passthrough],
       notifyDetachedFailure(chatId, threadId ?? null, 'update'),
     )
     return
   }
-  if (hostdResp.result === 'started' || hostdResp.result === 'completed') {
+  if (hostdResp.result === 'completed') {
+    return
+  }
+  if (hostdResp.result === 'started') {
+    // RFC C §5.3: long-running mutation. Poll get_status until terminal
+    // or until the recreate kills this gateway (whichever happens first).
+    // The success signal is the post-restart greeting card edited into
+    // ackId via the restart marker. The poll is here so that
+    // *fail-before-recreate* (image pull error, scaffold regen crash)
+    // doesn't leave the operator staring at the orphan "🚀 update started"
+    // ack indefinitely. Live repro: PR #1305.
+    void (async () => {
+      const terminal = await pollHostdStatus(getMyAgentName(), updateRequestId, {
+        timeoutMs: 60_000,
+      })
+      if (terminal === 'not-configured') return
+      // completed → recreate is about to run / has run; let the post-
+      // restart greeting card handle the success message.
+      if (terminal.result === 'completed') return
+      // Anything else means the daemon's mutation failed before it could
+      // kill us. Edit the ack to surface the tail and clear the marker
+      // so the next gateway boot doesn't render a false success card.
+      clearRestartMarker()
+      const errBody =
+        terminal.error ??
+        terminal.stderr_tail ??
+        terminal.stdout_tail ??
+        '(no error tail returned)'
+      const editedText =
+        `🚀 <b>update started</b> — <b>FAILED</b> via hostd ` +
+        `(result=${escapeHtmlForTg(terminal.result)}):\n` +
+        preBlock(errBody)
+      if (ackId != null) {
+        try {
+          await robustApiCall(
+            () =>
+              lockedBot.api.editMessageText(chatId, ackId!, editedText, {
+                parse_mode: 'HTML',
+                link_preview_options: { is_disabled: true },
+              }),
+            { verb: 'update.poll.editAck' },
+          )
+        } catch {
+          // edit-failed (message deleted, parse error) — fall back to
+          // a fresh reply so the failure isn't silent.
+          try {
+            await switchroomReply(ctx, editedText, { html: true })
+          } catch {}
+        }
+      } else {
+        try {
+          await switchroomReply(ctx, editedText, { html: true })
+        } catch {}
+      }
+    })()
     return
   }
   clearRestartMarker()

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8366,6 +8366,10 @@ bot.command('update', async ctx => {
     // doesn't leave the operator staring at the orphan "🚀 update started"
     // ack indefinitely. Live repro: PR #1305.
     void (async () => {
+      // 60s budget: RFC C §5.3 specs `apply` at 30s and `update_apply`
+      // at 60s. Image pulls + scaffold regeneration dominate the wall
+      // clock for update_apply, hence the larger budget. The poll
+      // resolves earlier on any terminal state from the daemon.
       const terminal = await pollHostdStatus(getMyAgentName(), updateRequestId, {
         timeoutMs: 60_000,
       })

--- a/telegram-plugin/gateway/hostd-dispatch.ts
+++ b/telegram-plugin/gateway/hostd-dispatch.ts
@@ -137,10 +137,14 @@ export function hostdRequestId(prefix: string): string {
  *     a timeout often means the recreate succeeded and killed the
  *     gateway; the *new* gateway's post-restart greeting card is the
  *     true success signal.
- *   - On a wire error from a poll tick, retries (transient net.Server
- *     errors during the recreate are expected). The last wire error is
- *     remembered and surfaced in the timeout response if we never see
- *     a successful poll.
+ *   - Any terminal state from the daemon (`completed`/`error`/`denied`)
+ *     bails immediately and returns that response. Wire errors are
+ *     synthesized by {@link tryHostdDispatch} as `result: "error"`,
+ *     which also bails — there's no separate retry on transient wire
+ *     failures because (a) the daemon doesn't actually go down except
+ *     during a recreate that kills us anyway, and (b) waiting until
+ *     timeout to surface a clear error is worse UX than surfacing it
+ *     immediately.
  *   - Returns immediately if hostd is unconfigured (treats as
  *     `not-configured`, same as {@link tryHostdDispatch}).
  */

--- a/telegram-plugin/gateway/hostd-dispatch.ts
+++ b/telegram-plugin/gateway/hostd-dispatch.ts
@@ -115,3 +115,126 @@ export async function tryHostdDispatch(
 export function hostdRequestId(prefix: string): string {
   return `${prefix}-${Date.now()}-${randomBytes(4).toString("hex")}`;
 }
+
+/**
+ * Poll hostd's `get_status` verb until the target request reaches a
+ * terminal state (`completed` / `error` / `denied`) or the caller's
+ * timeout elapses.
+ *
+ * Motivation: the long-running mutating verbs (`update_apply`, `apply`)
+ * respond `result: "started"` immediately and run the work in a
+ * detached child on the daemon side. Without polling, callers that
+ * acked "started" to the operator have no way to surface a *fail
+ * before recreate* (image-pull error, scaffold regeneration crash,
+ * etc.) — the gateway dies if recreate succeeds, but stays alive and
+ * silent if it fails. Polling closes that observability hole.
+ *
+ * Behaviour:
+ *   - Polls every {@link opts.intervalMs} ms (default 2000 per RFC C §5.3).
+ *   - Bails out after {@link opts.timeoutMs} with a synthesized
+ *     `result: "error"` response describing the timeout. Caller should
+ *     treat that as inconclusive — for `update_apply` specifically,
+ *     a timeout often means the recreate succeeded and killed the
+ *     gateway; the *new* gateway's post-restart greeting card is the
+ *     true success signal.
+ *   - On a wire error from a poll tick, retries (transient net.Server
+ *     errors during the recreate are expected). The last wire error is
+ *     remembered and surfaced in the timeout response if we never see
+ *     a successful poll.
+ *   - Returns immediately if hostd is unconfigured (treats as
+ *     `not-configured`, same as {@link tryHostdDispatch}).
+ */
+export async function pollHostdStatus(
+  agentName: string,
+  targetRequestId: string,
+  opts: {
+    /** Hard cap. update_apply: 60_000; apply: 30_000. */
+    timeoutMs: number;
+    /** Default 2000. */
+    intervalMs?: number;
+    /** Test seam — defaults to `Date.now`. */
+    now?: () => number;
+    /** Test seam — defaults to `setTimeout`. */
+    sleep?: (ms: number) => Promise<void>;
+  },
+): Promise<HostdResponse | "not-configured"> {
+  if (!isHostdEnabled()) return "not-configured";
+  const sockPath = hostdSocketPath(agentName);
+  if (!existsSync(sockPath)) return "not-configured";
+  const now = opts.now ?? Date.now;
+  const sleep =
+    opts.sleep ?? ((ms) => new Promise<void>((r) => setTimeout(r, ms)));
+  const intervalMs = opts.intervalMs ?? 2000;
+  const deadline = now() + opts.timeoutMs;
+  // Initial wait — the caller just sent the kick-off request. Give the
+  // daemon a tick to begin work before the first poll.
+  await sleep(intervalMs);
+  while (now() < deadline) {
+    const pollId = hostdRequestId("gw-poll");
+    const resp = await tryHostdDispatch(agentName, {
+      v: 1,
+      op: "get_status",
+      request_id: pollId,
+      args: { target_request_id: targetRequestId },
+    });
+    if (resp === "not-configured") {
+      // Socket disappeared mid-poll — daemon was stopped. Surface that
+      // distinctly from a target-request error so callers can decide
+      // whether to retry or bail.
+      return resp;
+    }
+    // get_status returns the StatusEntry's result, which IS the target
+    // request's result. Any terminal state (completed/error/denied) is
+    // the target's final answer — bail with it. The previous draft of
+    // this helper retried on `error`/`denied` in case the daemon was
+    // transiently busy; that policy masked real errors as
+    // "still polling" until the 60s cap, then synthesized a misleading
+    // "timeout" response. Bailing immediately surfaces the daemon's
+    // audit-log truth directly to the operator.
+    if (
+      resp.result === "completed" ||
+      resp.result === "error" ||
+      resp.result === "denied"
+    ) {
+      return resp;
+    }
+    // result: "started" — get_status reflects the latest StatusEntry,
+    // which is still `started` until the daemon's mutation finishes.
+    // Keep polling.
+    await sleep(intervalMs);
+  }
+  return {
+    v: 1,
+    request_id: hostdRequestId("gw-poll-timeout"),
+    result: "error",
+    exit_code: null,
+    duration_ms: opts.timeoutMs,
+    error:
+      `hostd poll timeout after ${opts.timeoutMs}ms waiting for ` +
+      `target_request_id=${targetRequestId}`,
+  };
+}
+
+/**
+ * Emit a one-line operator-visible deprecation warning when a verb that
+ * hostd supports is being dispatched via the legacy spawn path. Quiet
+ * by design — operators see it once per verb per process in journald,
+ * never in chat. RFC C §7 Phase 2 → Phase 3.
+ */
+const _deprecationSeen = new Set<string>();
+export function warnLegacySpawnIfHostdDisabled(verb: string): void {
+  if (isHostdEnabled()) return;
+  if (_deprecationSeen.has(verb)) return;
+  _deprecationSeen.add(verb);
+  process.stderr.write(
+    `telegram gateway: spawnSwitchroomDetached(${verb}) — set ` +
+      `host_control.enabled: true and run \`switchroom hostd install\` ` +
+      `to route through audited hostd. Legacy path scheduled for ` +
+      `removal in v0.10 (RFC C Phase 3).\n`,
+  );
+}
+
+/** @internal Reset both caches so tests can re-assert behaviour. */
+export function _resetDeprecationSeen(): void {
+  _deprecationSeen.clear();
+}

--- a/telegram-plugin/tests/hostd-dispatch.test.ts
+++ b/telegram-plugin/tests/hostd-dispatch.test.ts
@@ -26,22 +26,45 @@ vi.mock("../../src/config/loader.js", () => ({
   loadConfig: loadConfigMock,
 }));
 
-// Import AFTER the mock so the module captures the mocked function.
+const hostdRequestMock = vi.fn();
+vi.mock("../../src/host-control/client.js", () => ({
+  hostdRequest: hostdRequestMock,
+}));
+
+const existsSyncMock = vi.fn();
+vi.mock("node:fs", async () => {
+  const real = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...real,
+    existsSync: (p: string) => existsSyncMock(p),
+  };
+});
+
+// Import AFTER the mocks so the module captures the mocked functions.
 const {
   tryHostdDispatch,
   hostdWillBeUsed,
   isHostdEnabled,
   hostdSocketPath,
+  pollHostdStatus,
+  warnLegacySpawnIfHostdDisabled,
   _resetHostdEnabledCache,
+  _resetDeprecationSeen,
 } = await import("../gateway/hostd-dispatch.js");
 
 beforeEach(() => {
   _resetHostdEnabledCache();
+  _resetDeprecationSeen();
   loadConfigMock.mockReset();
+  hostdRequestMock.mockReset();
+  existsSyncMock.mockReset();
+  // Default: pretend the socket exists so dispatch reaches the wire.
+  existsSyncMock.mockReturnValue(true);
 });
 
 afterEach(() => {
   _resetHostdEnabledCache();
+  _resetDeprecationSeen();
 });
 
 describe("isHostdEnabled() — config gate", () => {
@@ -87,9 +110,7 @@ describe("hostdWillBeUsed() — config + socket existence", () => {
 
   it("false when hostd enabled but per-agent socket isn't bound", () => {
     loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
-    // hostdSocketPath() is hard-coded to /run/switchroom/hostd/<name>/sock
-    // — that path doesn't exist in the test env, so existsSync returns
-    // false and hostdWillBeUsed is false.
+    existsSyncMock.mockReturnValue(false);
     expect(hostdWillBeUsed("klanker-no-such-agent")).toBe(false);
   });
 });
@@ -108,6 +129,7 @@ describe("tryHostdDispatch()", () => {
 
   it("returns 'not-configured' when socket absent", async () => {
     loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    existsSyncMock.mockReturnValue(false);
     const result = await tryHostdDispatch("nonexistent-agent", {
       v: 1,
       op: "agent_restart",
@@ -125,5 +147,315 @@ describe("tryHostdDispatch()", () => {
     expect(hostdSocketPath("klanker")).toBe(
       "/run/switchroom/hostd/klanker/sock",
     );
+  });
+
+  // RFC C §5.4 trust model: cross-agent verbs go through the same
+  // `tryHostdDispatch` pipeline as self-target ones. The admin gate
+  // lives in the daemon (server.ts:checkGate), not the gateway — so
+  // from the dispatch helper's perspective there's no distinction.
+  // These cases pin that "the helper treats agent_start, agent_stop,
+  // and cross-agent agent_restart the same as the self-restart it
+  // was originally written for".
+  it("round-trips agent_start through hostd when enabled", async () => {
+    loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    hostdRequestMock.mockResolvedValue({
+      v: 1,
+      request_id: "test-start",
+      result: "completed",
+      exit_code: 0,
+      duration_ms: 12,
+    });
+    const result = await tryHostdDispatch("klanker", {
+      v: 1,
+      op: "agent_start",
+      request_id: "test-start",
+      args: { name: "bob" },
+    });
+    expect(result).not.toBe("not-configured");
+    expect((result as { result: string }).result).toBe("completed");
+  });
+
+  it("round-trips agent_stop through hostd when enabled", async () => {
+    loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    hostdRequestMock.mockResolvedValue({
+      v: 1,
+      request_id: "test-stop",
+      result: "completed",
+      exit_code: 0,
+      duration_ms: 8,
+    });
+    const result = await tryHostdDispatch("klanker", {
+      v: 1,
+      op: "agent_stop",
+      request_id: "test-stop",
+      args: { name: "bob" },
+    });
+    expect(result).not.toBe("not-configured");
+    expect((result as { result: string }).result).toBe("completed");
+  });
+
+  it("round-trips cross-agent agent_restart through hostd when enabled", async () => {
+    loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    hostdRequestMock.mockResolvedValue({
+      v: 1,
+      request_id: "test-rx",
+      result: "started",
+      exit_code: null,
+      duration_ms: 2,
+    });
+    const result = await tryHostdDispatch("klanker", {
+      v: 1,
+      op: "agent_restart",
+      request_id: "test-rx",
+      args: { name: "bob", force: true, reason: "user: /restart bob from chat" },
+    });
+    expect(result).not.toBe("not-configured");
+    expect((result as { result: string }).result).toBe("started");
+  });
+});
+
+describe("pollHostdStatus() — long-running verb completion polling", () => {
+  // Helper: zero-delay sleep so the polling loop drains instantly.
+  const noSleep = (_ms: number) => Promise.resolve();
+  let nowCursor = 0;
+  const advancingNow = () => {
+    nowCursor += 100;
+    return nowCursor;
+  };
+
+  beforeEach(() => {
+    nowCursor = 0;
+  });
+
+  it("returns the terminal response when get_status reaches completed", async () => {
+    loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    hostdRequestMock
+      .mockResolvedValueOnce({
+        v: 1,
+        request_id: "poll-1",
+        result: "started",
+        exit_code: null,
+        duration_ms: 100,
+      })
+      .mockResolvedValueOnce({
+        v: 1,
+        request_id: "poll-2",
+        result: "completed",
+        exit_code: 0,
+        duration_ms: 4_200,
+      });
+    const resp = await pollHostdStatus("klanker", "gw-update-abc", {
+      timeoutMs: 60_000,
+      intervalMs: 50,
+      sleep: noSleep,
+      now: advancingNow,
+    });
+    expect(resp).not.toBe("not-configured");
+    expect((resp as { result: string }).result).toBe("completed");
+  });
+
+  it("returns the error response when the target request fails on the daemon", async () => {
+    // The exact bug from the live repro: update_apply returns started,
+    // then the recreate's image-pull fails on the daemon and the gateway
+    // never finds out. With polling, the next tick returns the error
+    // and the gateway can edit the ack.
+    loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    hostdRequestMock.mockResolvedValueOnce({
+      v: 1,
+      request_id: "poll-err",
+      result: "error",
+      exit_code: 1,
+      duration_ms: 5_000,
+      error: "image pull failed: manifest unknown",
+    });
+    const resp = await pollHostdStatus("klanker", "gw-update-abc", {
+      timeoutMs: 60_000,
+      intervalMs: 50,
+      sleep: noSleep,
+      now: advancingNow,
+    });
+    expect(resp).not.toBe("not-configured");
+    expect((resp as { result: string }).result).toBe("error");
+    expect((resp as { error?: string }).error).toContain("image pull failed");
+  });
+
+  it("returns a synthesized error response on timeout", async () => {
+    // started → started → started → … until deadline. Verifies the
+    // caller gets a clear timeout reason instead of an indefinite hang.
+    loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    hostdRequestMock.mockResolvedValue({
+      v: 1,
+      request_id: "poll-stuck",
+      result: "started",
+      exit_code: null,
+      duration_ms: 100,
+    });
+    // Slow time so deadline hits after ~3 polls (interval 50 × now=100/tick).
+    const resp = await pollHostdStatus("klanker", "gw-stuck-xyz", {
+      timeoutMs: 200,
+      intervalMs: 50,
+      sleep: noSleep,
+      now: advancingNow,
+    });
+    expect(resp).not.toBe("not-configured");
+    expect((resp as { result: string }).result).toBe("error");
+    expect((resp as { error?: string }).error).toMatch(/timeout/);
+    expect((resp as { error?: string }).error).toMatch(/gw-stuck-xyz/);
+  });
+
+  it("returns 'not-configured' when hostd is disabled", async () => {
+    loadConfigMock.mockReturnValue({});
+    const resp = await pollHostdStatus("klanker", "gw-x", {
+      timeoutMs: 1000,
+      intervalMs: 50,
+      sleep: noSleep,
+      now: advancingNow,
+    });
+    expect(resp).toBe("not-configured");
+  });
+
+  it("returns 'not-configured' when socket disappears mid-poll", async () => {
+    // Daemon was stopped during the verb. The gateway should bail
+    // instead of looping forever on a vanished socket.
+    loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    // First poll tick: socket gone.
+    existsSyncMock.mockReturnValueOnce(true).mockReturnValue(false);
+    const resp = await pollHostdStatus("klanker", "gw-x", {
+      timeoutMs: 1000,
+      intervalMs: 50,
+      sleep: noSleep,
+      now: advancingNow,
+    });
+    expect(resp).toBe("not-configured");
+  });
+
+  it("bails immediately when get_status says target_request_id is not visible", async () => {
+    // No point retrying — the daemon explicitly said the request is
+    // unknown / cross-agent restricted. Retrying just spams the audit log.
+    loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    hostdRequestMock.mockResolvedValue({
+      v: 1,
+      request_id: "poll-notfound",
+      result: "denied",
+      exit_code: null,
+      duration_ms: 1,
+      error: "get_status: request_id not found or not visible to caller \"klanker\"",
+    });
+    const resp = await pollHostdStatus("klanker", "gw-vanished", {
+      timeoutMs: 60_000,
+      intervalMs: 50,
+      sleep: noSleep,
+      now: advancingNow,
+    });
+    expect(resp).not.toBe("not-configured");
+    expect((resp as { result: string }).result).toBe("denied");
+    // Bailed fast — only one wire call after the initial sleep, not many.
+    expect(hostdRequestMock.mock.calls.length).toBe(1);
+  });
+});
+
+describe("warnLegacySpawnIfHostdDisabled() — deprecation noise", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it("emits exactly one warning per verb per process", () => {
+    loadConfigMock.mockReturnValue({});
+    warnLegacySpawnIfHostdDisabled("agent_restart");
+    warnLegacySpawnIfHostdDisabled("agent_restart");
+    warnLegacySpawnIfHostdDisabled("agent_restart");
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toMatch(
+      /spawnSwitchroomDetached\(agent_restart\)/,
+    );
+  });
+
+  it("emits per distinct verb", () => {
+    loadConfigMock.mockReturnValue({});
+    warnLegacySpawnIfHostdDisabled("agent_restart");
+    warnLegacySpawnIfHostdDisabled("update_apply");
+    warnLegacySpawnIfHostdDisabled("agent_start");
+    expect(stderrSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("is silent when hostd is enabled (no deprecation needed)", () => {
+    loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    warnLegacySpawnIfHostdDisabled("agent_restart");
+    warnLegacySpawnIfHostdDisabled("update_apply");
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("regression — issue #1305 silent /update apply", () => {
+  // Live repro 2026-05-14: /update apply from a DM stamped the
+  // clean-shutdown marker, posted "🚀 update started" to chat, and
+  // went silent — no fleet recreate ever happened, no error ever came
+  // back. Root cause: gateway dispatched update_apply via hostd, got
+  // result: "started", and returned without polling get_status. When
+  // the daemon's mutation failed before recreate (image pull, scaffold
+  // regen crash, etc.) the gateway stayed alive but never surfaced
+  // anything to the operator. Polling closes that gap.
+  //
+  // This test wires the exact failure shape and asserts the helper
+  // surfaces a usable terminal response that the gateway can edit
+  // into the ack. Without the polling helper, the test couldn't even
+  // express the bug — the gateway's only post-started behaviour was
+  // `return`.
+  const noSleep = (_ms: number) => Promise.resolve();
+  let nowCursor = 0;
+  const advancingNow = () => {
+    nowCursor += 100;
+    return nowCursor;
+  };
+
+  beforeEach(() => {
+    nowCursor = 0;
+  });
+
+  it("surfaces image-pull failure as a terminal error response", async () => {
+    loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
+    // 1. Gateway calls update_apply, daemon returns "started" (we
+    //    simulate this happening before the polling test — the
+    //    polling test starts AFTER the kickoff).
+    // 2. Gateway polls get_status. Daemon reports the failure.
+    hostdRequestMock.mockResolvedValueOnce({
+      v: 1,
+      request_id: "poll-1",
+      result: "error",
+      exit_code: 1,
+      duration_ms: 5_120,
+      error: "image pull failed: manifest unknown",
+      stderr_tail:
+        "Error response from daemon: manifest for " +
+        "ghcr.io/switchroom/switchroom-agent:latest not found",
+    });
+    const terminal = await pollHostdStatus("klanker", "gw-update-2026-05-14", {
+      timeoutMs: 60_000,
+      intervalMs: 50,
+      sleep: noSleep,
+      now: advancingNow,
+    });
+    expect(terminal).not.toBe("not-configured");
+    const t = terminal as {
+      result: string;
+      error?: string;
+      stderr_tail?: string;
+    };
+    // The terminal response carries enough detail for the gateway
+    // to edit the "🚀 update started" ack into a "❌ FAILED" message
+    // with a stderr tail the operator can act on. This is the exact
+    // payload the gateway's editMessageText wiring at gateway.ts
+    // expects (see the polling block in the /update apply handler).
+    expect(t.result).toBe("error");
+    expect(t.error).toContain("image pull failed");
+    expect(t.stderr_tail).toContain("manifest for");
   });
 });


### PR DESCRIPTION
Closes #1305.

## Summary

Closes the residual Phase 2 gateway-swap gaps that left `/update apply` silently failing and three privileged callsites going through the legacy in-container CLI shell-out on docker hosts.

**Live repro 2026-05-14:** `/update apply` from a DM stamped the clean-shutdown marker, posted "🚀 update started" to chat, then went silent. The gateway had dispatched `update_apply` via hostd, got `result: "started"`, and returned with no `get_status` polling. When the daemon's mutation failed before recreate (image pull, scaffold crash, etc.) the operator was left staring at an orphan ack indefinitely.

**Three callsites that weren't swapped yet** — `/start`, `/stop`, cross-agent `/restart <other>` — went through `runSwitchroomCommand`, which on docker hosts silently exits 127 because the agent container has no docker socket. Same class of bug `/update apply` had pre-Phase-2-swap.

## Changes

- `hostd-dispatch.ts`: adds `pollHostdStatus` (polls `get_status` every 2s, bails on terminal state, returns synthesized error on timeout) and `warnLegacySpawnIfHostdDisabled` (one stderr line per verb per process).
- `gateway.ts`:
  - wires polling into `/update apply` after `started`. On error/denied/timeout, edits the ack with the failure tail and clears the restart marker so the post-restart greeting card doesn't false-positive a successful restart.
  - swaps `/start`, `/stop`, cross-agent `/restart <other>` via a new `dispatchShortVerbViaHostd` helper. Falls back to legacy `runSwitchroomCommand` only on `not-configured`. RFC §7 hard-fail: no fallback on error/denied.
  - calls `warnLegacySpawnIfHostdDisabled` at every remaining `spawnSwitchroomDetached` callsite that has a hostd equivalent.
- `hostd-dispatch.test.ts`: +11 cases covering polling (terminal, timeout, socket vanish, denied bailout), cross-agent verb round-trips, deprecation rate-limiting, and a #1305-named regression test.

## Review

Reviewed by an independent fresh-process reviewer: **APPROVE** with two cosmetic nits (JSDoc drift on `pollHostdStatus`, missing comment on the 60s budget) — both fixed in the follow-up commit. Reviewer specifically walked the polling correctness, async-IIFE lifetime, ack-edit race, RFC §7 hard-fail contract, cross-agent gating, and back-compat path.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npx vitest run telegram-plugin/tests/hostd-dispatch.test.ts tests/host-control/\` — 117/117
- [x] \`bun test telegram-plugin/tests/gateway-update-placeholder-dispatch.test.ts\` — 2/2
- [x] Pre-existing test failures verified against \`upstream/main\` (unrelated to this PR — agent-scheduler/idle-smoke, cli.issues, boot-self-test etc.)
- [ ] Operator-side: Step 7 of #1305 (manual klanker verification) on next \`switchroom update\`

## Acceptance criteria (from #1305)

- ✅ All five privileged callsites route through hostd when enabled.
- ✅ \`/update apply\` never leaves an orphaned "🚀 update started" ack.
- ✅ Legacy \`spawnSwitchroomDetached\` stays selectable + emits one-line deprecation.
- ✅ New regression test names the bug and pins the failure shape.
- ✅ Audit-log behaviour unchanged (server-side untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)