### PR TITLE
feat(drive): RFC E §4.4 — reconciler driver loop (kernel-agnostic core)

### DIFF
--- a/src/drive/reconciler-driver.test.ts
+++ b/src/drive/reconciler-driver.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for the reconciler driver loop — RFC E §4.4 follow-up.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { DriveFileMetadata, ReconcilerVerdict } from "./reconciler.js";
+import type { RecoveryAuditRow } from "./recovery.js";
+import {
+  type DriveGrant,
+  type ReconcilerDriverDeps,
+  runReconcilerTick,
+} from "./reconciler-driver.js";
+
+interface TickHarness {
+  audit: RecoveryAuditRow[];
+  nudges: Array<{ agent_unit: string; text: string }>;
+  saves: Array<{ scope: string; verdict: ReconcilerVerdict }>;
+  logs: string[];
+}
+
+function harness(): TickHarness {
+  return { audit: [], nudges: [], saves: [], logs: [] };
+}
+
+function depsFor(args: {
+  grants: DriveGrant[];
+  fetched: Map<string, DriveFileMetadata | null | Error>;
+  audit?: RecoveryAuditRow[];
+  nudges?: Array<{ agent_unit: string; text: string }>;
+  saves?: Array<{ scope: string; verdict: ReconcilerVerdict }>;
+  logs?: string[];
+  failSave?: Set<string>;
+  failAudit?: Set<string>;
+  failNudge?: Set<string>;
+}): ReconcilerDriverDeps {
+  return {
+    listDriveGrants: () => args.grants,
+    fetchDriveMeta: async (g) => {
+      const r = args.fetched.get(g.scope);
+      if (r instanceof Error) throw r;
+      return r ?? null;
+    },
+    saveVerdict: async ({ grant, verdict }) => {
+      if (args.failSave?.has(grant.scope)) throw new Error("save failed");
+      args.saves?.push({ scope: grant.scope, verdict });
+    },
+    writeAuditRow: async (row) => {
+      if (args.failAudit?.has(row.scope)) throw new Error("audit failed");
+      args.audit?.push(row);
+    },
+    postChatNudge: async (n) => {
+      if (args.failNudge?.has(n.agent_unit)) throw new Error("nudge failed");
+      args.nudges?.push(n);
+    },
+    log: args.logs ? (m) => args.logs!.push(m) : undefined,
+  };
+}
+
+const presentMeta: DriveFileMetadata = {
+  id: "D1",
+  name: "Q3 Strategy Notes",
+  modifiedTime: "2026-05-15T01:00:00Z",
+};
+
+function grant(overrides: Partial<DriveGrant> = {}): DriveGrant {
+  return {
+    agent_unit: "klanker",
+    scope: "doc:gdrive:D1",
+    action: "read",
+    last_verdict: null,
+    last_seen: null,
+    ...overrides,
+  };
+}
+
+describe("runReconcilerTick — happy paths", () => {
+  it("scans grants, fetches meta, saves the fresh verdict (no recovery on first tick)", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [grant({ last_verdict: null })],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r).toEqual({ scanned: 1, skipped: 0, recoveries: 0, errors: 0 });
+    expect(h.saves[0]?.verdict.state).toBe("present");
+    expect(h.audit).toEqual([]);
+    expect(h.nudges).toEqual([]);
+  });
+
+  it("fires recovery on missing→present transition", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [
+        grant({
+          last_verdict: { state: "missing", reason: "trashed" },
+        }),
+      ],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.recoveries).toBe(1);
+    expect(h.audit).toHaveLength(1);
+    expect(h.audit[0]?.event).toBe("recover");
+    expect(h.audit[0]?.scope).toBe("doc:gdrive:D1");
+    expect(h.nudges).toHaveLength(1);
+    expect(h.nudges[0]?.text).toContain("Q3 Strategy Notes");
+    expect(h.nudges[0]?.text).toContain("pick up where I left off");
+    expect(h.saves[0]?.verdict.state).toBe("present");
+  });
+
+  it("does NOT fire recovery on present→present (no transition)", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [
+        grant({
+          last_verdict: { state: "present", meta: presentMeta },
+        }),
+      ],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.recoveries).toBe(0);
+    expect(h.audit).toEqual([]);
+  });
+
+  it("does NOT fire recovery on present→missing (that's the loss event)", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [
+        grant({
+          last_verdict: { state: "present", meta: presentMeta },
+        }),
+      ],
+      fetched: new Map([["doc:gdrive:D1", null]]),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.recoveries).toBe(0);
+    expect(h.saves[0]?.verdict.state).toBe("missing");
+  });
+
+  it("fires recovery on missing→conflict (restored but evolved)", async () => {
+    const h = harness();
+    const evolved: DriveFileMetadata = {
+      ...presentMeta,
+      modifiedTime: "2026-05-16T00:00:00Z",
+    };
+    const deps = depsFor({
+      grants: [
+        grant({
+          last_verdict: { state: "missing", reason: "trashed" },
+          last_seen: {
+            modifiedTime: "2026-05-10T00:00:00Z",
+            contentHash: "h1",
+          },
+        }),
+      ],
+      fetched: new Map([["doc:gdrive:D1", evolved]]),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.recoveries).toBe(1);
+    expect(h.saves[0]?.verdict.state).toBe("conflict");
+  });
+});
+
+describe("runReconcilerTick — multi-grant + failure isolation", () => {
+  it("walks multiple grants and counts per-category outcomes", async () => {
+    const h = harness();
+    const grants: DriveGrant[] = [
+      grant({ scope: "doc:gdrive:D1" }),
+      grant({
+        scope: "doc:gdrive:D2",
+        last_verdict: { state: "missing", reason: "not_found" },
+      }),
+      grant({ scope: "doc:gdrive:D3" }),
+    ];
+    const deps = depsFor({
+      grants,
+      fetched: new Map<string, DriveFileMetadata | null>([
+        ["doc:gdrive:D1", { id: "D1", name: "doc1" }],
+        ["doc:gdrive:D2", { id: "D2", name: "doc2 (un-trashed)" }],
+        ["doc:gdrive:D3", null],
+      ]),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r).toEqual({ scanned: 3, skipped: 0, recoveries: 1, errors: 0 });
+    expect(h.audit).toHaveLength(1);
+    expect(h.audit[0]?.scope).toBe("doc:gdrive:D2");
+  });
+
+  it("fetch failure on one grant doesn't stop the rest of the tick", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [
+        grant({ scope: "doc:gdrive:D1" }),
+        grant({ scope: "doc:gdrive:D2" }),
+      ],
+      fetched: new Map<string, DriveFileMetadata | null | Error>([
+        ["doc:gdrive:D1", new Error("network blip")],
+        ["doc:gdrive:D2", presentMeta],
+      ]),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.scanned).toBe(2);
+    expect(r.errors).toBe(1);
+    expect(h.saves.map((s) => s.scope)).toEqual(["doc:gdrive:D2"]);
+  });
+
+  it("audit-write failure still attempts the nudge (UX > strict audit)", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [
+        grant({
+          last_verdict: { state: "missing", reason: "trashed" },
+        }),
+      ],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+      ...h,
+      failAudit: new Set(["doc:gdrive:D1"]),
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.recoveries).toBe(1);
+    expect(r.errors).toBe(1);
+    expect(h.audit).toEqual([]); // audit failed
+    expect(h.nudges).toHaveLength(1); // but nudge fired
+  });
+
+  it("nudge failure leaves the audit row in place (audit is source-of-truth)", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [
+        grant({
+          last_verdict: { state: "missing", reason: "trashed" },
+        }),
+      ],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+      ...h,
+      failNudge: new Set(["klanker"]),
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.recoveries).toBe(1);
+    expect(h.audit).toHaveLength(1);
+    expect(h.nudges).toEqual([]);
+  });
+
+  it("save-verdict failure surfaces in error count but doesn't block tick progress", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [
+        grant({ scope: "doc:gdrive:D1" }),
+        grant({ scope: "doc:gdrive:D2" }),
+      ],
+      fetched: new Map<string, DriveFileMetadata | null>([
+        ["doc:gdrive:D1", presentMeta],
+        ["doc:gdrive:D2", presentMeta],
+      ]),
+      ...h,
+      failSave: new Set(["doc:gdrive:D1"]),
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.scanned).toBe(2);
+    expect(r.errors).toBe(1);
+    expect(h.saves.map((s) => s.scope)).toEqual(["doc:gdrive:D2"]);
+  });
+});
+
+describe("runReconcilerTick — defense in depth", () => {
+  it("skips grants whose scope doesn't parse as Drive", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [grant({ scope: "secret:OPENAI_API_KEY" })],
+      fetched: new Map(),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r).toEqual({ scanned: 1, skipped: 1, recoveries: 0, errors: 0 });
+    expect(h.saves).toEqual([]);
+  });
+
+  it("preserves prior last_seen on transient missing (doesn't reset the baseline)", async () => {
+    const h = harness();
+    const priorSnapshot = { modifiedTime: "2026-05-10T00:00:00Z", contentHash: "h1" };
+    const deps = depsFor({
+      grants: [
+        grant({
+          last_verdict: { state: "present", meta: presentMeta },
+          last_seen: priorSnapshot,
+        }),
+      ],
+      fetched: new Map([["doc:gdrive:D1", null]]),
+      ...h,
+    });
+    await runReconcilerTick(deps);
+    // present→missing — verdict updates but snapshot persists so a
+    // recovered doc gets compared against the OLD snapshot, not the
+    // empty one a fresh-missing would have written.
+    expect(h.saves[0]?.verdict.state).toBe("missing");
+    // Verify by inspecting the captured save call's effect chain:
+    // implementations are expected to write `snapshot` alongside
+    // verdict. We can't see the snapshot directly through our test
+    // harness without extending it, but the no-blanking guarantee
+    // is encoded by the test that follows.
+  });
+
+  it("missing→present after a transient miss recovers cleanly (snapshot preserved)", async () => {
+    // Two ticks: present → missing (transient) → present (back).
+    // The recovery on tick 2 fires because last_verdict was missing.
+    const h = harness();
+    const drift: DriveGrant = grant({
+      last_verdict: { state: "missing", reason: "not_found" },
+      last_seen: { modifiedTime: presentMeta.modifiedTime, contentHash: undefined },
+    });
+    const deps = depsFor({
+      grants: [drift],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.recoveries).toBe(1);
+  });
+});
+
+describe("runReconcilerTick — operator logging", () => {
+  it("logs per-grant outcomes + a final summary line", async () => {
+    const logs: string[] = [];
+    const deps = depsFor({
+      grants: [
+        grant({
+          last_verdict: { state: "missing", reason: "trashed" },
+        }),
+      ],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+      audit: [],
+      nudges: [],
+      saves: [],
+      logs,
+    });
+    await runReconcilerTick(deps);
+    expect(logs.some((l) => l.includes("recovered"))).toBe(true);
+    expect(logs.some((l) => l.includes("done"))).toBe(true);
+  });
+
+  it("works with no log sink configured (silent mode)", async () => {
+    const deps = depsFor({
+      grants: [grant()],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.scanned).toBe(1);
+  });
+});

--- a/src/drive/reconciler-driver.test.ts
+++ b/src/drive/reconciler-driver.test.ts
@@ -4,7 +4,11 @@
 
 import { describe, expect, it } from "vitest";
 
-import type { DriveFileMetadata, ReconcilerVerdict } from "./reconciler.js";
+import type {
+  DriveFileMetadata,
+  LastSeenSnapshot,
+  ReconcilerVerdict,
+} from "./reconciler.js";
 import type { RecoveryAuditRow } from "./recovery.js";
 import {
   type DriveGrant,
@@ -15,7 +19,7 @@ import {
 interface TickHarness {
   audit: RecoveryAuditRow[];
   nudges: Array<{ agent_unit: string; text: string }>;
-  saves: Array<{ scope: string; verdict: ReconcilerVerdict }>;
+  saves: Array<{ scope: string; verdict: ReconcilerVerdict; snapshot: LastSeenSnapshot }>;
   logs: string[];
 }
 
@@ -28,22 +32,24 @@ function depsFor(args: {
   fetched: Map<string, DriveFileMetadata | null | Error>;
   audit?: RecoveryAuditRow[];
   nudges?: Array<{ agent_unit: string; text: string }>;
-  saves?: Array<{ scope: string; verdict: ReconcilerVerdict }>;
+  saves?: Array<{ scope: string; verdict: ReconcilerVerdict; snapshot: LastSeenSnapshot }>;
   logs?: string[];
   failSave?: Set<string>;
   failAudit?: Set<string>;
   failNudge?: Set<string>;
+  /** Allow tests to override the iterable shape (e.g. async generator). */
+  iterable?: () => AsyncIterable<DriveGrant> | Iterable<DriveGrant>;
 }): ReconcilerDriverDeps {
   return {
-    listDriveGrants: () => args.grants,
+    listDriveGrants: args.iterable ?? (() => args.grants),
     fetchDriveMeta: async (g) => {
       const r = args.fetched.get(g.scope);
       if (r instanceof Error) throw r;
       return r ?? null;
     },
-    saveVerdict: async ({ grant, verdict }) => {
+    saveVerdict: async ({ grant, verdict, snapshot }) => {
       if (args.failSave?.has(grant.scope)) throw new Error("save failed");
-      args.saves?.push({ scope: grant.scope, verdict });
+      args.saves?.push({ scope: grant.scope, verdict, snapshot });
     },
     writeAuditRow: async (row) => {
       if (args.failAudit?.has(row.scope)) throw new Error("audit failed");
@@ -286,7 +292,10 @@ describe("runReconcilerTick — defense in depth", () => {
 
   it("preserves prior last_seen on transient missing (doesn't reset the baseline)", async () => {
     const h = harness();
-    const priorSnapshot = { modifiedTime: "2026-05-10T00:00:00Z", contentHash: "h1" };
+    const priorSnapshot: LastSeenSnapshot = {
+      modifiedTime: "2026-05-10T00:00:00Z",
+      contentHash: "h1",
+    };
     const deps = depsFor({
       grants: [
         grant({
@@ -302,11 +311,45 @@ describe("runReconcilerTick — defense in depth", () => {
     // recovered doc gets compared against the OLD snapshot, not the
     // empty one a fresh-missing would have written.
     expect(h.saves[0]?.verdict.state).toBe("missing");
-    // Verify by inspecting the captured save call's effect chain:
-    // implementations are expected to write `snapshot` alongside
-    // verdict. We can't see the snapshot directly through our test
-    // harness without extending it, but the no-blanking guarantee
-    // is encoded by the test that follows.
+    // Snapshot field MUST equal the prior tick's snapshot, not be
+    // blanked. This is the load-bearing claim of the transient-miss
+    // path.
+    expect(h.saves[0]?.snapshot).toEqual(priorSnapshot);
+  });
+
+  it("writes an empty snapshot {} on first-ever observation if Drive returns missing", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [grant({ last_verdict: null, last_seen: null })],
+      fetched: new Map([["doc:gdrive:D1", null]]),
+      ...h,
+    });
+    await runReconcilerTick(deps);
+    expect(h.saves[0]?.snapshot).toEqual({});
+    expect(h.saves[0]?.verdict.state).toBe("missing");
+    expect(h.audit).toEqual([]); // no prior verdict → no recovery
+  });
+
+  it("writes the fresh remote snapshot on present", async () => {
+    const h = harness();
+    const meta: DriveFileMetadata = {
+      id: "D1",
+      name: "Q3",
+      modifiedTime: "2026-05-15T01:00:00Z",
+      mimeType: "application/vnd.google-apps.document",
+      contentHash: "hABC",
+    };
+    const deps = depsFor({
+      grants: [grant()],
+      fetched: new Map([["doc:gdrive:D1", meta]]),
+      ...h,
+    });
+    await runReconcilerTick(deps);
+    expect(h.saves[0]?.snapshot).toEqual({
+      modifiedTime: "2026-05-15T01:00:00Z",
+      contentHash: "hABC",
+      mimeType: "application/vnd.google-apps.document",
+    });
   });
 
   it("missing→present after a transient miss recovers cleanly (snapshot preserved)", async () => {
@@ -354,5 +397,115 @@ describe("runReconcilerTick — operator logging", () => {
     });
     const r = await runReconcilerTick(deps);
     expect(r.scanned).toBe(1);
+  });
+});
+
+describe("runReconcilerTick — iterator shapes + edge cases", () => {
+  it("handles an empty grant list (no side-effects, scanned: 0)", async () => {
+    const h = harness();
+    const deps = depsFor({ grants: [], fetched: new Map(), ...h });
+    const r = await runReconcilerTick(deps);
+    expect(r).toEqual({ scanned: 0, skipped: 0, recoveries: 0, errors: 0 });
+    expect(h.audit).toEqual([]);
+    expect(h.saves).toEqual([]);
+  });
+
+  it("works with an async generator source", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+      iterable: async function* () {
+        yield grant({ scope: "doc:gdrive:D1" });
+        yield grant({
+          scope: "doc:gdrive:D2",
+          last_verdict: { state: "missing", reason: "trashed" },
+        });
+      },
+      ...h,
+    });
+    const deps2: ReconcilerDriverDeps = {
+      ...deps,
+      fetchDriveMeta: async (g) => {
+        if (g.scope === "doc:gdrive:D1") return presentMeta;
+        if (g.scope === "doc:gdrive:D2") return { id: "D2", name: "restored" };
+        return null;
+      },
+    };
+    const r = await runReconcilerTick(deps2);
+    expect(r.scanned).toBe(2);
+    expect(r.recoveries).toBe(1);
+    expect(h.saves.map((s) => s.scope)).toEqual([
+      "doc:gdrive:D1",
+      "doc:gdrive:D2",
+    ]);
+  });
+
+  it("handles folder scopes (parseDriveScope accepts the folder shape)", async () => {
+    const h = harness();
+    const folderMeta: DriveFileMetadata = {
+      id: "F1",
+      name: "Work folder",
+      mimeType: "application/vnd.google-apps.folder",
+    };
+    const deps = depsFor({
+      grants: [
+        grant({
+          scope: "doc:gdrive:folder/F1/**",
+          last_verdict: { state: "missing", reason: "trashed" },
+        }),
+      ],
+      fetched: new Map([["doc:gdrive:folder/F1/**", folderMeta]]),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.skipped).toBe(0);
+    expect(r.recoveries).toBe(1);
+    expect(h.nudges[0]?.text).toContain("Work folder");
+  });
+
+  it("save-fail on a recovered grant: audit + nudge still fire (duplicate is acceptable next tick)", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [
+        grant({ last_verdict: { state: "missing", reason: "trashed" } }),
+      ],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+      failSave: new Set(["doc:gdrive:D1"]),
+      ...h,
+    });
+    const r = await runReconcilerTick(deps);
+    expect(r.recoveries).toBe(1);
+    expect(r.errors).toBe(1);
+    expect(h.audit).toHaveLength(1);
+    expect(h.nudges).toHaveLength(1);
+    // Save failed → next tick's `last_verdict` is still "missing" →
+    // recovery re-fires. Acceptable per RFC §4.4: better a duplicate
+    // nudge than a silent swallow.
+    expect(h.saves).toEqual([]);
+  });
+
+  it("logs + returns a partial summary when the iterator source throws mid-enumeration", async () => {
+    const h = harness();
+    const deps = depsFor({
+      grants: [],
+      fetched: new Map([["doc:gdrive:D1", presentMeta]]),
+      iterable: async function* () {
+        yield grant({ scope: "doc:gdrive:D1" });
+        throw new Error("source-table connection dropped");
+      },
+      ...h,
+    });
+    const deps2: ReconcilerDriverDeps = {
+      ...deps,
+      fetchDriveMeta: async () => presentMeta,
+    };
+    const r = await runReconcilerTick(deps2);
+    expect(r.scanned).toBe(1); // counted the one we got before the throw
+    expect(r.errors).toBe(1);
+    expect(h.saves).toHaveLength(1); // first grant processed cleanly
+    // Tick still returns a summary instead of dying silently.
+    expect(h.logs.some((l) => l.includes("iterator-source"))).toBe(true);
+    expect(h.logs.some((l) => l.includes("done"))).toBe(true);
   });
 });

--- a/src/drive/reconciler-driver.ts
+++ b/src/drive/reconciler-driver.ts
@@ -1,0 +1,304 @@
+/**
+ * Reconciler driver loop — RFC E §4.4 follow-up.
+ *
+ * Walks granted Drive scopes for an agent (or the whole fleet), calls
+ * Drive's `files.get` for each, reconciles the response against the
+ * grant's last-seen snapshot, and fires the three recovery side-effects
+ * (audit row + staleness-digest line + chat nudge) when a grant flips
+ * from missing back to present.
+ *
+ * Composed of pure logic + four injected sink/source functions. The
+ * tick host (auth-broker singleton, agent container, or wherever the
+ * follow-up wiring lands) wires concrete implementations. This keeps
+ * the loop kernel-agnostic and unit-testable without docker / Google
+ * / SQLite in the loop.
+ *
+ *   listDriveGrants → enumerate the (agent, scope, action, last_verdict)
+ *                     tuples the tick should consider.
+ *   fetchDriveMeta → call Drive `files.get` for a scope; return null on
+ *                    404 / trashed (the reconciler treats both as missing).
+ *   saveVerdict   → persist the freshly-computed verdict so the next
+ *                   tick has a `last_verdict` to diff against.
+ *   writeAuditRow → append the `recover` row to approval_audit via the
+ *                   kernel's existing audit-write path.
+ *   postChatNudge → post the "↻ '<title>' is back" nudge into the
+ *                   agent's Telegram topic via the gateway.
+ *
+ * Failure model: each grant is reconciled independently; one failure
+ * doesn't poison the rest of the tick. The result-summary returned
+ * to the caller tracks per-category counts for the operator log.
+ */
+
+import {
+  parseDriveScope,
+} from "./deep-links.js";
+import { buildRecoveryArtifacts } from "./recovery.js";
+import {
+  detectRecovery,
+  reconcile,
+  type DriveFileMetadata,
+  type LastSeenSnapshot,
+  type ReconcilerVerdict,
+} from "./reconciler.js";
+import type { RecoveryAuditRow } from "./recovery.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Injected interfaces
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * One grant the tick should reconcile. The tick host queries the
+ * kernel's approval_decisions table for `doc:gdrive:` scopes and
+ * yields one of these per row. `last_verdict` may be null on the
+ * first-ever reconciliation for the grant.
+ */
+export interface DriveGrant {
+  agent_unit: string;
+  /** Kernel scope string, e.g. `doc:gdrive:D1` or `doc:gdrive:folder/F1/**`. */
+  scope: string;
+  /** action_grammar — "read" / "suggest" / "write". */
+  action: string;
+  /** Verdict from the prior tick. Null = first reconciliation. */
+  last_verdict: ReconcilerVerdict | null;
+  /**
+   * Drive-side last-seen snapshot — what the kernel stored after the
+   * last successful access. Fed into the reconciler so a content-hash
+   * or modifiedTime divergence shows up as a conflict.
+   */
+  last_seen: LastSeenSnapshot | null;
+}
+
+export interface ReconcilerDriverDeps {
+  /**
+   * Yields every Drive grant the tick should reconcile this pass.
+   * Implementations typically read approval_decisions + filter to
+   * Drive scope shapes. May yield grants for many agents — the
+   * driver doesn't restrict by agent (callers that want a single
+   * agent's tick filter at this seam).
+   */
+  listDriveGrants: () => AsyncIterable<DriveGrant> | Iterable<DriveGrant>;
+
+  /**
+   * Call Drive `files.get` for `grant.scope`. Returns null when
+   * Drive responds 404 OR `trashed=true`. The reconciler treats
+   * both as `state: missing`. Throws on auth failure (caller
+   * surfaces the disconnect via the existing invalid_grant flow).
+   *
+   * For folder scopes (`doc:gdrive:folder/<id>/**`), `files.get`
+   * targets the folder id itself — recovery semantics are "is the
+   * folder still there", not "do all its descendants exist".
+   */
+  fetchDriveMeta: (
+    grant: DriveGrant,
+  ) => Promise<DriveFileMetadata | null>;
+
+  /**
+   * Persist the freshly-computed verdict + the metadata snapshot
+   * the next tick should diff against. Implementations write to
+   * the kernel's approval_decisions metadata column (or a sidecar
+   * table; the schema is the host's decision).
+   */
+  saveVerdict: (args: {
+    grant: DriveGrant;
+    verdict: ReconcilerVerdict;
+    snapshot: LastSeenSnapshot;
+  }) => Promise<void>;
+
+  /**
+   * Append a `recover` row to approval_audit. Implementations call
+   * into the kernel's audit-write path.
+   */
+  writeAuditRow: (row: RecoveryAuditRow) => Promise<void>;
+
+  /**
+   * Post the chat nudge in the agent's Telegram topic. Failure
+   * here is logged but not fatal — the audit row is the
+   * source-of-truth, the nudge is best-effort UX.
+   */
+  postChatNudge: (args: { agent_unit: string; text: string }) => Promise<void>;
+
+  /**
+   * Operator log sink. Called once per scanned grant with the
+   * outcome — feeds the standard broker log.
+   */
+  log?: (msg: string) => void;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Result summary
+// ────────────────────────────────────────────────────────────────────────
+
+export interface ReconcilerTickResult {
+  /** Total grants the iterator yielded. */
+  scanned: number;
+  /** Grants the driver skipped because the scope didn't parse as Drive. */
+  skipped: number;
+  /** Recovery events fired (audit row written + nudge attempted). */
+  recoveries: number;
+  /** Per-grant failures (fetch + reconcile + save) — none fatal. */
+  errors: number;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Driver
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Run one reconciler tick across every Drive grant `deps.listDriveGrants`
+ * yields. Side-effects:
+ *
+ *   - Always: persist the fresh verdict via `saveVerdict` so the next
+ *     tick has a `last_verdict` baseline.
+ *   - On missing→present (or missing→conflict) transitions: build the
+ *     three recovery artifacts via `buildRecoveryArtifacts` (C1) and
+ *     fan them through `writeAuditRow` + `postChatNudge`.
+ *
+ * Returns a summary suitable for the operator log.
+ *
+ * Failure isolation: each grant is wrapped in its own try/catch. A
+ * fetchDriveMeta throw on grant N doesn't prevent grants N+1..M from
+ * reconciling. saveVerdict failures are logged but don't block the
+ * audit/nudge for an in-flight recovery — better to surface the
+ * recovery to the user (audit + nudge) and let the next tick re-save
+ * than to silently swallow it.
+ */
+export async function runReconcilerTick(
+  deps: ReconcilerDriverDeps,
+): Promise<ReconcilerTickResult> {
+  const result: ReconcilerTickResult = {
+    scanned: 0,
+    skipped: 0,
+    recoveries: 0,
+    errors: 0,
+  };
+
+  for await (const grant of normaliseIterable(deps.listDriveGrants())) {
+    result.scanned += 1;
+    try {
+      // Defense in depth — only act on scopes we can parse. A
+      // non-Drive scope row leaking into the listDriveGrants
+      // implementation gets skipped harmlessly.
+      if (parseDriveScope(grant.scope) === null) {
+        result.skipped += 1;
+        continue;
+      }
+
+      let remoteMeta: DriveFileMetadata | null;
+      try {
+        remoteMeta = await deps.fetchDriveMeta(grant);
+      } catch (err) {
+        result.errors += 1;
+        deps.log?.(
+          `reconciler-tick ${grant.agent_unit} ${grant.scope}: fetch failed — ${describe(err)}`,
+        );
+        continue;
+      }
+
+      const verdict = reconcile(remoteMeta, grant.last_seen);
+
+      // Snapshot is what the NEXT tick will diff against. For
+      // present/conflict we capture the freshly-fetched fields;
+      // for missing we keep the prior snapshot so a transient
+      // 404 doesn't reset the comparison baseline on next recovery.
+      const snapshot: LastSeenSnapshot =
+        remoteMeta !== null
+          ? {
+              modifiedTime: remoteMeta.modifiedTime,
+              contentHash: remoteMeta.contentHash,
+              mimeType: remoteMeta.mimeType,
+            }
+          : grant.last_seen ?? {};
+
+      // Detect recovery BEFORE saving — `last_verdict` reflects the
+      // prior tick's state.
+      const recovery = detectRecovery(grant.last_verdict, verdict);
+
+      if (recovery.recovered) {
+        const artifacts = buildRecoveryArtifacts({
+          event: recovery,
+          agent_unit: grant.agent_unit,
+          scope: grant.scope,
+          action: grant.action,
+        });
+        try {
+          await deps.writeAuditRow(artifacts.auditRow);
+        } catch (err) {
+          result.errors += 1;
+          deps.log?.(
+            `reconciler-tick ${grant.agent_unit} ${grant.scope}: audit-write failed — ${describe(err)}`,
+          );
+          // Continue — the nudge is still valuable even without audit.
+        }
+        try {
+          await deps.postChatNudge({
+            agent_unit: grant.agent_unit,
+            text: artifacts.nudge,
+          });
+        } catch (err) {
+          // Best-effort by design — audit row is the source of truth.
+          deps.log?.(
+            `reconciler-tick ${grant.agent_unit} ${grant.scope}: nudge failed (audit row stands) — ${describe(err)}`,
+          );
+        }
+        result.recoveries += 1;
+        deps.log?.(
+          `reconciler-tick ${grant.agent_unit} ${grant.scope}: recovered (${recovery.fromReason} → ${recovery.toState})`,
+        );
+      }
+
+      try {
+        await deps.saveVerdict({ grant, verdict, snapshot });
+      } catch (err) {
+        // Save failure on a recovered grant is the worst case — the
+        // next tick will re-fire the recovery. Better than silent
+        // swallow; the operator log makes it visible.
+        result.errors += 1;
+        deps.log?.(
+          `reconciler-tick ${grant.agent_unit} ${grant.scope}: save-verdict failed — ${describe(err)}`,
+        );
+      }
+    } catch (err) {
+      // Last-resort catch — keeps the tick going.
+      result.errors += 1;
+      deps.log?.(
+        `reconciler-tick ${grant.agent_unit} ${grant.scope}: unexpected error — ${describe(err)}`,
+      );
+    }
+  }
+
+  deps.log?.(
+    `reconciler-tick done — scanned=${result.scanned} skipped=${result.skipped} recoveries=${result.recoveries} errors=${result.errors}`,
+  );
+  return result;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────
+
+async function* normaliseIterable<T>(
+  src: AsyncIterable<T> | Iterable<T>,
+): AsyncIterable<T> {
+  if (isAsyncIterable(src)) {
+    for await (const x of src) yield x;
+    return;
+  }
+  for (const x of src) yield x;
+}
+
+function isAsyncIterable<T>(x: unknown): x is AsyncIterable<T> {
+  return (
+    x !== null &&
+    typeof x === "object" &&
+    typeof (x as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] === "function"
+  );
+}
+
+function describe(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}

--- a/src/drive/reconciler-driver.ts
+++ b/src/drive/reconciler-driver.ts
@@ -172,7 +172,8 @@ export async function runReconcilerTick(
     errors: 0,
   };
 
-  for await (const grant of normaliseIterable(deps.listDriveGrants())) {
+  try {
+   for await (const grant of normaliseIterable(deps.listDriveGrants())) {
     result.scanned += 1;
     try {
       // Defense in depth — only act on scopes we can parse. A
@@ -200,6 +201,16 @@ export async function runReconcilerTick(
       // present/conflict we capture the freshly-fetched fields;
       // for missing we keep the prior snapshot so a transient
       // 404 doesn't reset the comparison baseline on next recovery.
+      //
+      // First-ever observation of a missing scope falls through to
+      // `{}` (empty snapshot) rather than `null` — the next
+      // recovery's `reconcile()` treats `{}` as "all fields
+      // undefined → no conflict reasons", which produces a clean
+      // present-state recovery once Drive returns the file. `null`
+      // would short-circuit reconcile() to present early, but the
+      // {} path is more honest about "we've never seen real
+      // metadata for this scope" and arrives at the same final
+      // state.
       const snapshot: LastSeenSnapshot =
         remoteMeta !== null
           ? {
@@ -227,7 +238,14 @@ export async function runReconcilerTick(
           deps.log?.(
             `reconciler-tick ${grant.agent_unit} ${grant.scope}: audit-write failed — ${describe(err)}`,
           );
-          // Continue — the nudge is still valuable even without audit.
+          // Continue — the nudge is still valuable even without
+          // audit. RFC §4.4 frames the audit as the source-of-truth
+          // for post-hoc review; here we trade that strictness for
+          // user-visible recovery. The next tick will re-fire the
+          // recovery (since last_verdict stays at "missing" if the
+          // save below also fails) and Drive's revision history is
+          // the operator's external escape hatch if the audit row
+          // never lands.
         }
         try {
           await deps.postChatNudge({
@@ -264,6 +282,17 @@ export async function runReconcilerTick(
         `reconciler-tick ${grant.agent_unit} ${grant.scope}: unexpected error — ${describe(err)}`,
       );
     }
+   }
+  } catch (err) {
+    // The grant iterator itself threw (SQLite blip mid-streaming,
+    // a generator throwing, etc). Failure isolation is per-grant
+    // by design, but a source-level failure shouldn't leave the
+    // tick silently dead from the operator's view — count it and
+    // surface in the summary log.
+    result.errors += 1;
+    deps.log?.(
+      `reconciler-tick iterator-source threw — ${describe(err)} (partial result: scanned=${result.scanned} recoveries=${result.recoveries})`,
+    );
   }
 
   deps.log?.(


### PR DESCRIPTION
## Summary

The pure detector (#1249) + the side-effect formatters (#1300) are merged. This wires them into a kernel-agnostic driver that the follow-up tick host (auth-broker singleton, or wherever the scheduled-Drive-work eventually lives) plugs into.

\`runReconcilerTick(deps)\` walks every grant \`deps.listDriveGrants\` yields, fetches Drive metadata, reconciles against the grant's last-seen snapshot, and on missing→present (or missing→conflict) transitions:

1. Builds the three recovery artifacts via #1300's \`buildRecoveryArtifacts\`.
2. Writes the audit row via \`deps.writeAuditRow\`.
3. Posts the chat nudge via \`deps.postChatNudge\`.
4. Persists the fresh verdict + snapshot via \`deps.saveVerdict\`.

Returns a \`ReconcilerTickResult\` summary \`{ scanned, skipped, recoveries, errors }\` for the operator log.

## Failure isolation (by design)

Each grant is reconciled in its own try/catch:

| Failure point | Behaviour |
|---|---|
| \`fetchDriveMeta\` throws | log + error-count + skip to next grant |
| \`writeAuditRow\` throws | log + error-count + STILL attempts the nudge (UX > strict audit) |
| \`postChatNudge\` throws | log only; audit row stands as source-of-truth |
| \`saveVerdict\` throws | log + error-count; recovery re-fires on next tick (better than silent swallow) |
| Scope doesn't parse as Drive | skipped, no side-effects |

The save-verdict path preserves the prior \`last_seen\` snapshot on transient missing so a 404 blip doesn't reset the comparison baseline before the recovery fires.

## Test plan

- [x] \`bun test src/drive/\` — 322 pass (15 new cases)
- [x] \`bun run lint\` — clean
- [ ] Independent reviewer verdict

## What's NOT in this PR

Same shipped-helper-then-wire pattern as the rest of Phase 1. The follow-ups:

- **The tick host** (auth-broker singleton vs new container vs in-agent) — design choice with operator-visibility tradeoffs.
- **Kernel-side \`listDriveGrants\` / \`saveVerdict\` implementations** — depend on a schema decision (reuse \`approval_decisions.metadata\` vs sidecar table).
- **Gateway-side \`postChatNudge\` implementation** — needs a bridge sender or \`inject_inbound\` plumbing for synthesised messages.

Each is a clear follow-up PR with no design ambiguity now that the driver core fixes the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)