### PR TITLE
feat(drive): RFC E §4.1 — folder-picker Telegram glue (/folders + drvpick:)

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -82,7 +82,8 @@ ALLOWLIST=(
   # `wouldFireFleetAutoFallback` synchronous-check insertion (~10
   # lines added between the modelUnavailable detection and the
   # broadcast loop).
-  "telegram-plugin/gateway/gateway.ts:2250-2330:operator-event broadcast; no thread_id in opts"
+  # Re-bumped 2026-05-15 for #1308 folder-picker handler (callsite now ~2331).
+  "telegram-plugin/gateway/gateway.ts:2250-2350:operator-event broadcast; no thread_id in opts"
 
   # permission-request keyboard send. opts only has reply_markup. No thread_id.
   # Range bumped 2026-05-13 for stuck-turn-recovery v2 cleanup expansion
@@ -109,6 +110,7 @@ ALLOWLIST=(
   # (insertions earlier in the file shifted the chunk-loop down).
   # Re-bumped 2026-05-15 post-Path-A-Cut-2 (drive-write IPC handler
   # added ~60 lines higher up; chunk-loop callsite shifted further to ~3451).
+  # Re-bumped 2026-05-15 for #1308 folder-picker handler.
   "telegram-plugin/gateway/gateway.ts:3160-3500:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).

--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -96,6 +96,7 @@ ALLOWLIST=(
   # throttle map + reaper added ~8 lines above this block; runAutoFallbackCheck
   # deletion subtracted ~80 lines below — net shift varies between
   # local + CI grep (line counting drift); widened window to 2960.
+  # Re-bumped 2026-05-15 for #1308 folder-picker handler integration.
   "telegram-plugin/gateway/gateway.ts:2695-2960:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
@@ -129,6 +130,7 @@ ALLOWLIST=(
   # Re-bumped 2026-05-15 for the /audit hostd command insertion
   # (~85 lines added near line 8475 shifted the vault wizard callsites
   # further down past the prior 10100 ceiling).
+  # Re-bumped 2026-05-15 for #1308 folder-picker handler integration.
   "telegram-plugin/gateway/gateway.ts:9340-10300:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter

--- a/telegram-plugin/gateway/folder-picker-handler.test.ts
+++ b/telegram-plugin/gateway/folder-picker-handler.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Tests for folder-picker Telegram handlers — RFC E §4.1 wire-up.
+ *
+ * The handlers are kernel/Drive/grammy-agnostic via injected deps;
+ * tests use minimal stub contexts + fake deps.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Context } from "grammy";
+
+import { FolderListCache } from "../../src/drive/folder-list.js";
+import type { FolderPage } from "../../src/drive/folder-list.js";
+import {
+  handleFolderPickerCallback,
+  handleFoldersCommand,
+  type FolderPickerHandlerDeps,
+} from "./folder-picker-handler.js";
+
+interface FakeCtx {
+  from: { id: number };
+  replies: Array<{ text: string; keyboardRows: string[][] }>;
+  edits: Array<{ text: string; keyboardRows: string[][] | undefined }>;
+  callbackAnswers: Array<{ text?: string }>;
+}
+
+function fakeCtx(userId = 12345): { ctx: Context; spy: FakeCtx } {
+  const spy: FakeCtx = {
+    from: { id: userId },
+    replies: [],
+    edits: [],
+    callbackAnswers: [],
+  };
+  const ctx = {
+    from: spy.from,
+    reply: async (text: string, opts?: { reply_markup?: { inline_keyboard?: unknown[][] } }) => {
+      const rows = (opts?.reply_markup?.inline_keyboard ?? []) as Array<
+        Array<{ text: string }>
+      >;
+      spy.replies.push({
+        text,
+        keyboardRows: rows.map((r) => r.map((b) => b.text)),
+      });
+      return { message_id: 1 };
+    },
+    editMessageText: async (text: string, opts?: { reply_markup?: { inline_keyboard?: unknown[][] } }) => {
+      const rows = (opts?.reply_markup?.inline_keyboard ?? []) as Array<
+        Array<{ text: string }>
+      >;
+      spy.edits.push({
+        text,
+        keyboardRows: opts?.reply_markup
+          ? rows.map((r) => r.map((b) => b.text))
+          : undefined,
+      });
+      return true;
+    },
+    answerCallbackQuery: async (arg?: { text?: string }) => {
+      spy.callbackAnswers.push(arg ?? {});
+      return true;
+    },
+  } as unknown as Context;
+  return { ctx, spy };
+}
+
+interface FakeKernel {
+  requests: Array<{ scope: string; action: string }>;
+  consumed: string[];
+  recorded: Array<{
+    request_id: string;
+    decision: string;
+    approver_set: string[];
+  }>;
+  nextRequestId: string;
+  failRequest?: boolean;
+  failConsume?: boolean;
+  failRecord?: boolean;
+}
+
+function depsFor(args: {
+  agentName?: string;
+  fetchPage?: FolderPickerHandlerDeps["fetchPage"];
+  cache?: FolderListCache;
+  kernel?: FakeKernel;
+}): { deps: FolderPickerHandlerDeps; kernel: FakeKernel; cache: FolderListCache } {
+  const cache = args.cache ?? new FolderListCache({ now: () => 1000 });
+  const kernel: FakeKernel = args.kernel ?? {
+    requests: [],
+    consumed: [],
+    recorded: [],
+    nextRequestId: "abcdef01",
+  };
+  const deps: FolderPickerHandlerDeps = {
+    agentName: args.agentName ?? "klanker",
+    cache,
+    fetchPage:
+      args.fetchPage ??
+      (async () => ({ folders: [{ id: "F1", name: "Work" }] })),
+    approvalRequest: async (a) => {
+      if (kernel.failRequest) return null;
+      kernel.requests.push({ scope: a.scope, action: a.action });
+      return { request_id: kernel.nextRequestId };
+    },
+    approvalConsume: async (id) => {
+      if (kernel.failConsume) return false;
+      kernel.consumed.push(id);
+      return true;
+    },
+    approvalRecord: async (a) => {
+      if (kernel.failRecord) return null;
+      kernel.recorded.push({
+        request_id: a.request_id,
+        decision: a.decision,
+        approver_set: a.approver_set,
+      });
+      return "dec-1";
+    },
+  };
+  return { deps, kernel, cache };
+}
+
+describe("handleFoldersCommand", () => {
+  it("posts a picker card with the top-level folders", async () => {
+    const { ctx, spy } = fakeCtx();
+    const { deps } = depsFor({});
+    await handleFoldersCommand(ctx, deps);
+    expect(spy.replies).toHaveLength(1);
+    expect(spy.replies[0]?.text).toContain("📁");
+    expect(spy.replies[0]?.text).toContain("1 folder");
+    // Two folder rows ([Allow] + [Browse]) plus nav row.
+    expect(spy.replies[0]?.keyboardRows.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("hits the cache on a re-issued /folders within TTL", async () => {
+    const { ctx, spy } = fakeCtx();
+    let fetches = 0;
+    const { deps } = depsFor({
+      fetchPage: async () => {
+        fetches += 1;
+        return { folders: [{ id: "F1", name: "Work" }] };
+      },
+    });
+    await handleFoldersCommand(ctx, deps);
+    await handleFoldersCommand(ctx, deps);
+    expect(fetches).toBe(1);
+    expect(spy.replies).toHaveLength(2);
+  });
+
+  it("surfaces a Drive failure as a friendly error message (no crash)", async () => {
+    const { ctx, spy } = fakeCtx();
+    const { deps } = depsFor({
+      fetchPage: async () => {
+        throw new Error("HTTP 401");
+      },
+    });
+    await handleFoldersCommand(ctx, deps);
+    expect(spy.replies[0]?.text).toContain("Drive folder listing failed");
+    expect(spy.replies[0]?.text).toContain("HTTP 401");
+  });
+});
+
+describe("handleFolderPickerCallback — refusal cases", () => {
+  it("rejects a malformed callback", async () => {
+    const { ctx, spy } = fakeCtx();
+    const { deps } = depsFor({});
+    await handleFolderPickerCallback(ctx, "not-a-drvpick-callback", deps);
+    expect(spy.callbackAnswers[0]?.text).toMatch(/malformed/);
+    expect(spy.edits).toEqual([]);
+  });
+
+  it("refuses callbacks for a different agent (path-scoped guard)", async () => {
+    const { ctx, spy } = fakeCtx();
+    const { deps } = depsFor({ agentName: "klanker" });
+    await handleFolderPickerCallback(ctx, "drvpick:grant:clerk:F1", deps);
+    expect(spy.callbackAnswers[0]?.text).toMatch(/this gateway serves 'klanker'/);
+    expect(spy.edits).toEqual([]);
+  });
+});
+
+describe("handleFolderPickerCallback — navigation", () => {
+  it("enter drills into a sub-folder (cache miss → fetchPage with parent_id)", async () => {
+    const { ctx, spy } = fakeCtx();
+    const fetched: string[] = [];
+    const { deps } = depsFor({
+      fetchPage: async ({ parent_id }) => {
+        fetched.push(parent_id ?? "<top>");
+        return { folders: [{ id: "SUB1", name: "Q3" }] };
+      },
+    });
+    await handleFolderPickerCallback(ctx, "drvpick:enter:klanker:F1", deps);
+    expect(fetched).toEqual(["F1"]);
+    expect(spy.edits[0]?.text).toContain("/F1");
+    expect(spy.callbackAnswers[0]).toEqual({});
+  });
+
+  it("back returns to the named parent level", async () => {
+    const { ctx, spy } = fakeCtx();
+    const fetched: string[] = [];
+    const { deps } = depsFor({
+      fetchPage: async ({ parent_id }) => {
+        fetched.push(parent_id ?? "<top>");
+        return { folders: [] };
+      },
+    });
+    await handleFolderPickerCallback(ctx, "drvpick:back:klanker:PARENT1", deps);
+    expect(fetched).toEqual(["PARENT1"]);
+  });
+
+  it("back to top-of-Drive (empty parent_id) fetches the top page", async () => {
+    const { ctx, spy } = fakeCtx();
+    const fetched: Array<string | undefined> = [];
+    const { deps } = depsFor({
+      fetchPage: async ({ parent_id }) => {
+        fetched.push(parent_id);
+        return { folders: [] };
+      },
+    });
+    await handleFolderPickerCallback(ctx, "drvpick:back:klanker:", deps);
+    expect(fetched).toEqual([undefined]);
+  });
+
+  it("refresh bypasses cache (forceRefresh)", async () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    cache.set("klanker", { folders: [{ id: "STALE", name: "S" }] });
+    let fetches = 0;
+    const { ctx, spy } = fakeCtx();
+    const { deps } = depsFor({
+      cache,
+      fetchPage: async () => {
+        fetches += 1;
+        return { folders: [{ id: "FRESH", name: "F" }] };
+      },
+    });
+    await handleFolderPickerCallback(ctx, "drvpick:refresh:klanker:", deps);
+    expect(fetches).toBe(1);
+    expect(spy.edits[0]?.text).toContain("📁");
+  });
+
+  it("open resolves a page-token handle back to the real Drive token", async () => {
+    const cache = new FolderListCache({ now: () => 1000 });
+    const handle = cache.registerPageToken("klanker", "REAL_DRIVE_TOKEN_120_CHARS_XXXXXX");
+    const { ctx, spy } = fakeCtx();
+    let observedToken: string | undefined;
+    const { deps } = depsFor({
+      cache,
+      fetchPage: async ({ page_token }) => {
+        observedToken = page_token;
+        return { folders: [{ id: "F2", name: "Page 2" }] };
+      },
+    });
+    await handleFolderPickerCallback(
+      ctx,
+      `drvpick:open:klanker::${handle}`,
+      deps,
+    );
+    expect(observedToken).toBe("REAL_DRIVE_TOKEN_120_CHARS_XXXXXX");
+    // The folder name lands in the [Allow / Browse] keyboard rows,
+    // not the body line.
+    const flat = spy.edits[0]?.keyboardRows.flat() ?? [];
+    expect(flat.some((b) => b.includes("Page 2"))).toBe(true);
+  });
+});
+
+describe("handleFolderPickerCallback — grant", () => {
+  it("records the grant via the three-step kernel call and confirms in-place", async () => {
+    const { ctx, spy } = fakeCtx(99999);
+    const { deps, kernel } = depsFor({});
+    await handleFolderPickerCallback(ctx, "drvpick:grant:klanker:F1", deps);
+    expect(kernel.requests).toEqual([
+      { scope: "doc:gdrive:folder/F1/**", action: "read" },
+    ]);
+    expect(kernel.consumed).toEqual(["abcdef01"]);
+    expect(kernel.recorded).toEqual([
+      {
+        request_id: "abcdef01",
+        decision: "allow_always",
+        approver_set: ["99999"],
+      },
+    ]);
+    expect(spy.edits[0]?.text).toContain("✅ Granted klanker");
+    expect(spy.edits[0]?.text).toContain("doc:gdrive:folder/F1/**");
+    expect(spy.edits[0]?.text).toContain("/approvals revoke dec-1");
+    // Confirmation keyboard has Open-in-Drive URL.
+    expect(spy.edits[0]?.keyboardRows[0]).toEqual(["📖 Open in Drive"]);
+    expect(spy.callbackAnswers[0]?.text).toBe("Allowed");
+  });
+
+  it("surfaces each kernel failure step with a clear toast", async () => {
+    for (const failure of [
+      { failRequest: true, msg: /request failed/ },
+      { failConsume: true, msg: /consume failed/ },
+      { failRecord: true, msg: /record failed/ },
+    ] as const) {
+      const { ctx, spy } = fakeCtx();
+      const kernel: FakeKernel = {
+        requests: [],
+        consumed: [],
+        recorded: [],
+        nextRequestId: "abcdef01",
+        ...failure,
+      };
+      const { deps } = depsFor({ kernel });
+      await handleFolderPickerCallback(ctx, "drvpick:grant:klanker:F1", deps);
+      expect(spy.callbackAnswers[0]?.text).toMatch(failure.msg);
+      expect(spy.edits).toEqual([]); // no confirmation edit on failure
+    }
+  });
+
+  it("refuses when ctx.from is missing (no user id)", async () => {
+    const { ctx, spy } = fakeCtx(0);
+    const { deps } = depsFor({});
+    await handleFolderPickerCallback(ctx, "drvpick:grant:klanker:F1", deps);
+    expect(spy.callbackAnswers[0]?.text).toMatch(/user id/);
+  });
+});

--- a/telegram-plugin/gateway/folder-picker-handler.ts
+++ b/telegram-plugin/gateway/folder-picker-handler.ts
@@ -1,0 +1,348 @@
+/**
+ * Folder-picker Telegram handlers — RFC E §4.1 wire-up.
+ *
+ * Two entry points the gateway dispatcher calls into:
+ *
+ *   - `handleFoldersCommand(ctx, deps)`        ← `/folders` slash command
+ *   - `handleFolderPickerCallback(ctx, data, deps)` ← `drvpick:` callback_query
+ *
+ * Both are kernel-agnostic — Drive API + approval-kernel + access-token
+ * sources are injected via `FolderPickerHandlerDeps` so the handlers
+ * are unit-testable without docker / Google / SQLite / grammy in the
+ * loop. The gateway construct module wires concrete deps from
+ * `src/drive/folder-list.ts`, `src/vault/approvals/client.ts`, and the
+ * auth-broker.
+ *
+ * Operator UX:
+ *
+ *   1. User types `/folders` in the agent's DM.
+ *   2. Gateway fetches the user's top-level Drive folders and posts
+ *      a picker card with one row per folder ([Allow] + [Browse]).
+ *   3. Tapping [Browse "Work"] drills in — the gateway re-renders the
+ *      card in place with the sub-folder list + a [⬅ Back] button.
+ *   4. Tapping [✅ Allow "<folder>"] writes a kernel `allow_always`
+ *      grant at `doc:gdrive:folder/<id>/**` and edits the card to a
+ *      green confirmation.
+ *
+ * Authorisation: same gate as the rest of the slash commands —
+ * `isAuthorizedSender(ctx)` upstream. The handler itself trusts the
+ * caller did the gate.
+ */
+
+import type { Context } from "grammy";
+import { InlineKeyboard } from "grammy";
+
+import type { FolderListCache, FolderPage } from "../../src/drive/folder-list.js";
+import {
+  buildFolderPickerCard,
+  parseFolderPickerCallback,
+  type FolderPickerCallback,
+  type FolderPickerCardSpec,
+} from "../../src/drive/folder-picker.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Deps — injected by the gateway construct module
+// ────────────────────────────────────────────────────────────────────────
+
+export interface FolderPickerHandlerDeps {
+  /** Agent slug this gateway instance serves. */
+  agentName: string;
+  /**
+   * Fetch a single folder page from Drive. Production wires this to
+   * `fetchFolderPage()` from src/drive/folder-list.ts with the
+   * agent's Drive access-token injected. Tests pass a fake.
+   */
+  fetchPage: (args: {
+    parent_id?: string;
+    page_token?: string;
+  }) => Promise<FolderPage>;
+  /**
+   * Per-gateway-process folder-list cache. The cache holds the
+   * 5-min folder-page payloads AND the short-handle ↔ Drive
+   * page-token map used by `[Next ▶]` callbacks.
+   */
+  cache: FolderListCache;
+  /**
+   * Build a fresh kernel `request_id` for an upcoming grant. The
+   * gateway mints a request right before recording the decision —
+   * the kernel's request/consume/record flow is the only path to
+   * write an `approval_decisions` row.
+   */
+  approvalRequest: (args: {
+    agent_unit: string;
+    scope: string;
+    action: string;
+    approver_set: string[];
+    why?: string | null;
+    ttl_ms?: number | null;
+  }) => Promise<{ request_id: string } | null>;
+  /** Consume the pending request_id so approvalRecord can land the row. */
+  approvalConsume: (request_id: string) => Promise<boolean>;
+  /** Write the granted decision. */
+  approvalRecord: (args: {
+    request_id: string;
+    decision: "allow_always";
+    approver_set: string[];
+    granted_by_user_id: number;
+    ttl_ms?: number | null;
+  }) => Promise<string | null>;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// `/folders` entry point
+// ────────────────────────────────────────────────────────────────────────
+
+export async function handleFoldersCommand(
+  ctx: Context,
+  deps: FolderPickerHandlerDeps,
+): Promise<void> {
+  let page: FolderPage;
+  try {
+    // First-page hit goes through the cache so a re-issued /folders
+    // within 5 min doesn't slam Drive's quota.
+    const hit = deps.cache.get(deps.agentName);
+    if (hit !== null) {
+      page = hit;
+    } else {
+      page = await deps.fetchPage({});
+      deps.cache.set(deps.agentName, page);
+    }
+  } catch (err) {
+    await ctx.reply(
+      `Drive folder listing failed: ${describe(err)}. Run \`switchroom drive connect ${deps.agentName}\` if the agent isn't authenticated.`,
+    );
+    return;
+  }
+
+  const card = buildFolderPickerCard({
+    agent: deps.agentName,
+    page,
+    cache: deps.cache,
+  });
+  await ctx.reply(card.body, { reply_markup: toKeyboard(card) });
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// `drvpick:` callback entry point
+// ────────────────────────────────────────────────────────────────────────
+
+export async function handleFolderPickerCallback(
+  ctx: Context,
+  data: string,
+  deps: FolderPickerHandlerDeps,
+): Promise<void> {
+  const parsed = parseFolderPickerCallback(data);
+  if (parsed === null) {
+    await ctx.answerCallbackQuery({ text: "malformed picker callback" });
+    return;
+  }
+
+  // Path-scoped agent guard — the picker callback names an agent in
+  // the data string. A gateway running for agent `klanker` MUST
+  // refuse callbacks meant for `clerk` (defense in depth on top of
+  // the per-agent socket isolation; relevant if a card from one
+  // agent's topic somehow leaks into another).
+  if (parsed.agent !== deps.agentName) {
+    await ctx.answerCallbackQuery({
+      text: `card is for agent '${parsed.agent}', this gateway serves '${deps.agentName}'`,
+    });
+    return;
+  }
+
+  switch (parsed.kind) {
+    case "open":
+      await renderPage(ctx, deps, {
+        parent_id: parsed.parent_id,
+        page_token_handle: parsed.page_token_handle,
+        forceRefresh: false,
+      });
+      break;
+    case "enter":
+      await renderPage(ctx, deps, {
+        parent_id: parsed.folder_id,
+        forceRefresh: false,
+      });
+      break;
+    case "back":
+      // RFC §4.1: tapping Back returns to the parent level. The
+      // callback payload carries the parent we're returning TO
+      // (empty string = top of Drive). The current breadcrumb
+      // chain is rebuilt by the card builder — we just need the
+      // target parent id.
+      await renderPage(ctx, deps, {
+        parent_id: parsed.parent_id,
+        forceRefresh: false,
+      });
+      break;
+    case "refresh":
+      await renderPage(ctx, deps, {
+        parent_id: parsed.parent_id,
+        forceRefresh: true,
+      });
+      break;
+    case "grant":
+      await recordGrantAndConfirm(ctx, deps, parsed);
+      break;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Sub-handlers
+// ────────────────────────────────────────────────────────────────────────
+
+async function renderPage(
+  ctx: Context,
+  deps: FolderPickerHandlerDeps,
+  args: {
+    parent_id?: string;
+    page_token_handle?: string;
+    forceRefresh: boolean;
+  },
+): Promise<void> {
+  let page: FolderPage;
+  try {
+    // Page-token handles bypass cache by design — they target a
+    // specific subsequent page that's not held in the first-page
+    // cache slot. Resolve the handle BEFORE attempting cache.
+    const resolved =
+      args.page_token_handle !== undefined
+        ? deps.cache.getPageToken(deps.agentName, args.page_token_handle)
+        : null;
+
+    if (resolved !== null) {
+      page = await deps.fetchPage({
+        parent_id: args.parent_id,
+        page_token: resolved,
+      });
+    } else if (
+      !args.forceRefresh &&
+      args.page_token_handle === undefined
+    ) {
+      const hit = deps.cache.get(deps.agentName, args.parent_id);
+      if (hit !== null) {
+        page = hit;
+      } else {
+        page = await deps.fetchPage({ parent_id: args.parent_id });
+        deps.cache.set(deps.agentName, page, args.parent_id);
+      }
+    } else {
+      // forceRefresh OR a handle that's expired ([↻ Refresh] / stale).
+      page = await deps.fetchPage({ parent_id: args.parent_id });
+      deps.cache.set(deps.agentName, page, args.parent_id);
+    }
+  } catch (err) {
+    await ctx.answerCallbackQuery({ text: `Drive error: ${describe(err)}` });
+    return;
+  }
+
+  const card = buildFolderPickerCard({
+    agent: deps.agentName,
+    page,
+    ...(args.parent_id !== undefined && args.parent_id.length > 0
+      ? { parent: { id: args.parent_id, name: args.parent_id } }
+      : {}),
+    cache: deps.cache,
+  });
+  try {
+    await ctx.editMessageText(card.body, { reply_markup: toKeyboard(card) });
+  } catch {
+    // Card may have been edited/deleted under us — operator can
+    // re-issue /folders to start over.
+  }
+  await ctx.answerCallbackQuery({});
+}
+
+async function recordGrantAndConfirm(
+  ctx: Context,
+  deps: FolderPickerHandlerDeps,
+  parsed: Extract<FolderPickerCallback, { kind: "grant" }>,
+): Promise<void> {
+  const granted_by_user_id = ctx.from?.id ?? 0;
+  if (granted_by_user_id === 0) {
+    await ctx.answerCallbackQuery({ text: "missing user id" });
+    return;
+  }
+
+  const scope = `doc:gdrive:folder/${parsed.folder_id}/**`;
+  const action = "read";
+
+  // Three-step kernel call: request → consume → record. The kernel
+  // requires the request-id chain even for operator-driven grants
+  // (no direct-record op as of the v0.10 schema). All three round-
+  // trips are UDS to the local kernel — no user-visible latency.
+  const requested = await deps.approvalRequest({
+    agent_unit: deps.agentName,
+    scope,
+    action,
+    approver_set: [String(granted_by_user_id)],
+    why: `folder picker grant via /folders`,
+  });
+  if (requested === null) {
+    await ctx.answerCallbackQuery({ text: "kernel request failed" });
+    return;
+  }
+
+  const consumed = await deps.approvalConsume(requested.request_id);
+  if (!consumed) {
+    await ctx.answerCallbackQuery({ text: "kernel consume failed" });
+    return;
+  }
+
+  const decisionId = await deps.approvalRecord({
+    request_id: requested.request_id,
+    decision: "allow_always",
+    approver_set: [String(granted_by_user_id)],
+    granted_by_user_id,
+    ttl_ms: null,
+  });
+  if (decisionId === null) {
+    await ctx.answerCallbackQuery({ text: "kernel record failed" });
+    return;
+  }
+
+  const confirmText =
+    `✅ Granted ${deps.agentName} access to folder ${parsed.folder_id}\n` +
+    `Scope: <code>${scope}</code>\n` +
+    `Revoke with: <code>/approvals revoke ${decisionId}</code>`;
+
+  // Keep an [Open in Drive] URL button on the confirmation so the
+  // operator can verify which folder they granted.
+  const kb = new InlineKeyboard().url(
+    "📖 Open in Drive",
+    `https://drive.google.com/drive/folders/${parsed.folder_id}`,
+  );
+  try {
+    await ctx.editMessageText(confirmText, {
+      parse_mode: "HTML",
+      reply_markup: kb,
+    });
+  } catch {
+    // Best-effort.
+  }
+  await ctx.answerCallbackQuery({ text: "Allowed" });
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────
+
+function toKeyboard(spec: FolderPickerCardSpec): InlineKeyboard {
+  const kb = new InlineKeyboard();
+  for (let r = 0; r < spec.rows.length; r++) {
+    const row = spec.rows[r]!;
+    for (const btn of row) {
+      kb.text(btn.text, btn.callback_data);
+    }
+    if (r < spec.rows.length - 1) kb.row();
+  }
+  return kb;
+}
+
+function describe(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -237,9 +237,6 @@ import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js'
 import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
-import {
-  approvalRequest as kernelApprovalRequest,
-} from '../../src/vault/approvals/client.js'
 import { createPendingInboundBuffer } from './pending-inbound-buffer.js'
 import {
   buildVaultGrantApprovedInbound,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -192,6 +192,21 @@ import { sweepActiveReactions } from '../active-reactions-sweep.js'
 import { flushOnAgentDisconnect } from './disconnect-flush.js'
 import { PreambleSuppressor } from './preamble-suppressor.js'
 import {
+  fetchFolderPage,
+  FolderListCache,
+} from '../../src/drive/folder-list.js'
+import { loadFromAuthBroker } from '../../src/drive/wrapper-broker.js'
+import {
+  handleFoldersCommand,
+  handleFolderPickerCallback,
+  type FolderPickerHandlerDeps,
+} from './folder-picker-handler.js'
+import {
+  approvalConsume as kernelApprovalConsume,
+  approvalRecord as kernelApprovalRecord,
+  approvalRequest as kernelApprovalRequest,
+} from '../../src/vault/approvals/client.js'
+import {
   fetchQuota,
   formatQuotaBlock,
 } from '../quota-check.js'
@@ -8687,6 +8702,59 @@ async function handlePermissionSlash(ctx: Context, behavior: 'allow' | 'deny'): 
 bot.command('approve', async ctx => handlePermissionSlash(ctx, 'allow'))
 bot.command('deny', async ctx => handlePermissionSlash(ctx, 'deny'))
 
+// ─── Drive folder picker (RFC E §4.1) ───────────────────────────────────
+// /folders — post a Telegram picker card listing this agent's top-level
+// Drive folders. Tap [Allow] on a folder to grant the agent
+// allow_always at doc:gdrive:folder/<id>/**; tap [Browse] to drill in.
+//
+// Authorisation: same dmCommandGate as the other operator slash
+// commands — only allowFrom users can post-trigger.
+
+const folderPickerCache = new FolderListCache()
+
+function buildFolderPickerDeps(): FolderPickerHandlerDeps {
+  const agentName = getMyAgentName()
+  return {
+    agentName,
+    cache: folderPickerCache,
+    fetchPage: async ({ parent_id, page_token }) => {
+      const handle = await loadFromAuthBroker()
+      if (handle === null) {
+        throw new Error(
+          `auth-broker unreachable for agent ${agentName} — is the broker container running?`,
+        )
+      }
+      return fetchFolderPage({
+        access_token: handle.access_token,
+        ...(parent_id !== undefined ? { parent_id } : {}),
+        ...(page_token !== undefined ? { page_token } : {}),
+      })
+    },
+    approvalRequest: async (args) => {
+      const r = await kernelApprovalRequest({
+        agent_unit: args.agent_unit,
+        scope: args.scope,
+        action: args.action,
+        approver_set: args.approver_set,
+        ...(args.why !== null && args.why !== undefined ? { why: args.why } : {}),
+        ...(args.ttl_ms !== null && args.ttl_ms !== undefined ? { ttl_ms: args.ttl_ms } : {}),
+      })
+      if (r === null || r.state === 'rate_limited') return null
+      return { request_id: r.request_id }
+    },
+    approvalConsume: async (id) => {
+      const r = await kernelApprovalConsume(id)
+      return r !== null && r.consumed
+    },
+    approvalRecord: async (args) => kernelApprovalRecord(args),
+  }
+}
+
+bot.command('folders', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  await handleFoldersCommand(ctx, buildFolderPickerDeps())
+})
+
 // /pending — list current pending permission prompts with their ids, so the
 // user can target a specific one via /approve <id> or /deny <id>.
 // Restricted to access.allowFrom DMs to match /approve and /deny — it
@@ -11409,6 +11477,15 @@ bot.on('callback_query:data', async ctx => {
   if (data.startsWith('apv:')) {
     const { handleApprovalCallback } = await import('./approval-callback.js')
     await handleApprovalCallback(ctx, data)
+    return
+  }
+
+  // RFC E §4.1: drvpick:<verb>:<agent>[:<...>] — folder-picker card taps.
+  // open / enter / back / refresh re-render the card in place;
+  // grant writes an allow_always kernel decision at
+  // doc:gdrive:folder/<id>/** and edits the card to a confirmation.
+  if (data.startsWith('drvpick:')) {
+    await handleFolderPickerCallback(ctx, data, buildFolderPickerDeps())
     return
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -11484,7 +11484,21 @@ bot.on('callback_query:data', async ctx => {
   // open / enter / back / refresh re-render the card in place;
   // grant writes an allow_always kernel decision at
   // doc:gdrive:folder/<id>/** and edits the card to a confirmation.
+  //
+  // Auth gate: the picker grant is an OPERATOR action (mirrors the
+  // `op:`/`vd:`/`vg:` family, not the `apv:` agent-approval shape).
+  // Mirror those patterns — refuse callbacks from anyone outside
+  // `access.allowFrom`. Without this, a group member who isn't in
+  // the operator allowlist could still tap [✅ Allow "<folder>"] on
+  // a card that landed in the group and write an `allow_always`
+  // decision attributed to themselves.
   if (data.startsWith('drvpick:')) {
+    const access = loadAccess()
+    const senderId = String(ctx.from?.id ?? '')
+    if (!access.allowFrom.includes(senderId)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' })
+      return
+    }
     await handleFolderPickerCallback(ctx, data, buildFolderPickerDeps())
     return
   }


### PR DESCRIPTION
## Summary

Wires A2's pure primitives (#1296) end-to-end. Operator UX:

1. User types \`/folders\` in the agent's DM.
2. Gateway fetches the user's top-level Drive folders via the auth-broker access token and posts a picker card with one row per folder ([Allow] + [Browse]).
3. Tapping [Browse "Work"] drills in — gateway re-renders the card in place with sub-folder list + [⬅ Back].
4. Tapping [✅ Allow "\<folder>"] writes a kernel \`allow_always\` decision at \`doc:gdrive:folder/<id>/**\` and edits the card to a green confirmation with [📖 Open in Drive] + the revoke command.

## What ships

**\`telegram-plugin/gateway/folder-picker-handler.ts\`** (new, 350 LoC) — two kernel-agnostic entry points:
- \`handleFoldersCommand(ctx, deps)\` — \`/folders\` slash command.
- \`handleFolderPickerCallback(ctx, data, deps)\` — \`drvpick:\` dispatcher.

Drive API + approval-kernel + auth-broker sources are injected via \`FolderPickerHandlerDeps\` so the handlers are unit-testable without docker/Google/SQLite/grammy in the loop.

**\`telegram-plugin/gateway/gateway.ts\`** (77 LoC added):
- Imports for \`fetchFolderPage\`, \`FolderListCache\`, \`loadFromAuthBroker\`, \`approvalRequest/Consume/Record\`, and the new handler module
- Module-level \`folderPickerCache\` singleton (5-min TTL, handle-store for Drive page tokens)
- \`buildFolderPickerDeps()\` constructs the dep bundle each tap (cache stable across taps; fresh access token per tap)
- \`bot.command('folders', ...)\` near other operator slash commands; gated by \`isAuthorizedSender\`
- \`if (data.startsWith('drvpick:'))\` route in the existing callback dispatcher

## Design notes

**Three-step kernel call for the grant flow** (\`approvalRequest → approvalConsume → approvalRecord\`) — no direct-record op exists as of v0.10, all three are UDS round-trips to the local kernel. Each step has a clear toast on failure.

**Path-scoped agent guard** — a gateway running for agent \`klanker\` refuses callbacks naming a different agent in the data string. Defense in depth on top of per-agent socket isolation.

**Page-token handles round-trip correctly** — Drive's \`nextPageToken\` (50–200 chars, doesn't fit in Telegram's 64-byte callback cap) is stored server-side via the cache. Cache-expired handle falls back to a fresh first-page fetch.

## Test plan

- [x] \`bun test telegram-plugin/gateway/folder-picker-handler.test.ts\` — 13 pass
- [x] \`bun test src/drive/\` — 307 pass
- [x] \`bun run lint\` — clean
- [x] \`bun run build\` — bundles cleanly
- [ ] Independent reviewer verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)