### PR TITLE
fix(hindsight): use uv pip install instead of nonexistent venv pip

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -41,9 +41,12 @@ RUN npm install -g @anthropic-ai/claude-code@latest \
 # Install claude-agent-sdk into the same venv the hindsight API runs from.
 # The upstream start-all.sh activates this venv before launching uvicorn,
 # so `from claude_agent_sdk import query` resolves to this install.
-# `uv pip install` is faster than plain pip and the venv is already
-# uv-managed by upstream.
-RUN /app/api/.venv/bin/pip install --no-cache-dir claude-agent-sdk \
+#
+# Upstream builds the venv with `uv sync` and never installs pip into it
+# (only uv-managed binaries land in /app/api/.venv/bin/). So we use
+# `uv pip install` against the existing venv via VIRTUAL_ENV — same
+# package manager the venv is already authored by, no pip required.
+RUN VIRTUAL_ENV=/app/api/.venv uv pip install --no-cache-dir claude-agent-sdk \
  && /app/api/.venv/bin/python -c "from claude_agent_sdk import query; print('claude-agent-sdk ok')" >&2
 
 # Pin the upstream `hindsight` user to UID 11000 to match


### PR DESCRIPTION
## Summary

#1310 enabled the build-hindsight GHCR job but the first workflow run failed at `Dockerfile.hindsight:46` with `/app/api/.venv/bin/pip: not found`.

Upstream \`vectorize-io/hindsight:latest\` builds its venv with \`uv sync\` and never installs pip into the venv — only uv-managed entry points land in \`/app/api/.venv/bin/\`. The original RUN line predates an upstream change to pure-uv venv management; the comment immediately above it already names \`uv pip install\` as the intent, the command just didn't match.

**Fix:** invoke \`uv pip install\` against the existing venv via \`VIRTUAL_ENV=/app/api/.venv\` (the standard way to point uv at a venv when there's no pyproject in the working dir).

This closes the v0.9.1-vintage CHANGELOG-vs-reality gap: the CHANGELOG announced \`ghcr.io/switchroom/switchroom-hindsight:latest\` was published, but it never actually was (because every prior attempt to push it would have hit this same line).

## Test plan

- [x] Local multi-arch build succeeds: \`docker build -f docker/Dockerfile.hindsight .\` printed both \`claude-agent-sdk ok\` and \`uid=11000(hindsight)\`, ending at \`Successfully tagged switchroom-hindsight-localtest:probe\`.
- [ ] On merge: build-hindsight job in next docker-images run succeeds and publishes \`ghcr.io/switchroom/switchroom-hindsight:latest\`.
- [ ] Post-merge: \`gh api /orgs/switchroom/packages\` includes \`switchroom-hindsight\` with a recent \`updated_at\`.
- [x] Fresh-process review dispatched after PR creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)