### PR TITLE
fix(doctor): query auth-broker container for hindsight socket, not host

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -533,12 +533,14 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
  *   1. `auth.consumers[]` in `switchroom.yaml` contains an entry named
  *      `hindsight`. The auth-broker only binds a per-consumer socket
  *      when this is set.
- *   2. The bound socket exists on the host side at
- *      `~/.switchroom/state/auth-broker/<host-socket-path>/sock`.
- *      The hindsight side bind-mounts the named volume
- *      `auth-broker-hindsight-sock` (managed by compose) into its own
- *      container; the host-side state dir is where the broker writes
- *      the socket.
+ *   2. The broker container has actually bound the socket at
+ *      `/run/switchroom/auth-broker/hindsight/sock` (in-container path).
+ *      We `docker exec ... test -S <path>` because the host-side docker
+ *      volume mountpoint at `/var/lib/docker/volumes/.../_data/sock`
+ *      lives under a root-only-traversable parent (`/var/lib/docker` is
+ *      mode 0711 root:root on the common docker.io install), so an
+ *      operator-uid `existsSync()` returns false even when the socket
+ *      is present and healthy — false positive (#1281).
  *
  * Replaces the pre-#1245 `hindsight env leak` probe — that was
  * defending against an OpenAI-key shape that the broker-fed flow
@@ -548,7 +550,7 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
  */
 export function checkHindsightConsumer(
   config: SwitchroomConfig,
-  opts?: { socketProbe?: (path: string) => boolean },
+  opts?: { socketProbe?: (consumerName: string) => "present" | "missing" | "unreachable" },
 ): CheckResult {
   const consumers = config.auth?.consumers ?? [];
   const entry = consumers.find((c) => c.name === "hindsight");
@@ -568,31 +570,37 @@ export function checkHindsightConsumer(
     };
   }
 
-  // Host-side path the broker container chowns its consumer socket into.
-  // Mirrors the named volume `auth-broker-hindsight-sock` populated by
-  // compose. The hindsight container itself sees this at
-  // /run/switchroom/auth-broker/sock, but the doctor runs on the host
-  // and inspects the docker volume's mountpoint via the
-  // ~/.switchroom/state/auth-broker- side. We just check it's there
-  // (volume mount may not be filesystem-visible without inspecting
-  // the named volume; treat absence as warn, not fail).
-  const socketProbe = opts?.socketProbe ?? ((p: string) => existsSync(p));
-  const home = process.env.HOME ?? "";
-  const dockerVolPath = `/var/lib/docker/volumes/switchroom_auth-broker-hindsight-sock/_data/sock`;
-  const altVolPath = join(home, ".local", "share", "docker", "volumes", "switchroom_auth-broker-hindsight-sock", "_data", "sock");
-  const present = socketProbe(dockerVolPath) || socketProbe(altVolPath);
+  // Ask the broker container — it owns the socket bind and runs as root
+  // inside the container, so it can stat its own socket regardless of
+  // host-side docker volume permissions.
+  const probe = opts?.socketProbe ?? probeAuthBrokerSocket;
+  const state = probe(entry.name);
 
-  if (!present) {
+  if (state === "unreachable") {
+    // Broker container isn't around to ask. Don't speculate about the
+    // socket — the auth-broker service-health probe covers that case
+    // separately. Just surface what we know.
     return {
       name: "hindsight consumer",
       status: "warn",
       detail:
         `auth.consumers[hindsight] -> ${entry.account} (uid ${entry.uid ?? 0}); ` +
-        `socket not yet bound on disk`,
+        `couldn't query auth-broker container (not running / docker unavailable)`,
       fix:
-        "Run `switchroom apply` to bring up the auth-broker singleton " +
-        "and bind the per-consumer socket. The hindsight container will " +
-        "fetch credentials from it via `get-credentials` at boot.",
+        "Check `auth-broker: service health` row above; if the broker is " +
+        "down, `switchroom apply` will bring it back and bind the socket.",
+    };
+  }
+
+  if (state === "missing") {
+    return {
+      name: "hindsight consumer",
+      status: "warn",
+      detail:
+        `auth.consumers[hindsight] -> ${entry.account} (uid ${entry.uid ?? 0}); ` +
+        `auth-broker is running but socket not bound at /run/switchroom/auth-broker/${entry.name}/sock`,
+      fix:
+        "Run `switchroom apply` to refresh compose and rebind per-consumer sockets.",
     };
   }
 
@@ -601,6 +609,32 @@ export function checkHindsightConsumer(
     status: "ok",
     detail: `auth.consumers[hindsight] -> ${entry.account} (uid ${entry.uid ?? 0})`,
   };
+}
+
+/**
+ * Ask the auth-broker container whether a consumer's UDS is bound.
+ * `docker exec switchroom-auth-broker test -S <path>` exits 0 if the
+ * path is a socket; non-zero otherwise. Distinguishes "container not
+ * reachable" (e.g. docker isn't installed, broker isn't up) from
+ * "broker says no socket" so the doctor row can route the operator to
+ * the right fix.
+ */
+function probeAuthBrokerSocket(
+  consumerName: string,
+): "present" | "missing" | "unreachable" {
+  const containerPath = `/run/switchroom/auth-broker/${consumerName}/sock`;
+  const r = spawnSync(
+    "docker",
+    ["exec", "switchroom-auth-broker", "test", "-S", containerPath],
+    { stdio: "pipe", timeout: 3000 },
+  );
+  if (r.error || r.status === null) return "unreachable";
+  if (r.status === 0) return "present";
+  // Distinguish "broker says no socket" (test exit 1) from "docker
+  // couldn't reach the container at all" (exit 125+, the docker CLI
+  // family of "no such container" / daemon errors).
+  if (r.status >= 125) return "unreachable";
+  return "missing";
 }
 
 async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> {

--- a/tests/cli.doctor.hindsight-consumer.test.ts
+++ b/tests/cli.doctor.hindsight-consumer.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { checkHindsightConsumer } from "../src/cli/doctor.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+// Pins the contract that the hindsight-consumer probe queries the broker
+// CONTAINER (which can stat its own bound sockets) rather than the host
+// `/var/lib/docker/volumes/.../sock` path. The latter lives under a
+// root-only-traversable `/var/lib/docker` on common docker.io installs;
+// `existsSync` from the operator UID returns false even when the socket
+// is bound and healthy. See #1281 for the regression.
+
+function configWithConsumer(): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: "~/.switchroom/agents" },
+    telegram: { bot_token: "test-token", forum_chat_id: "-100123" },
+    agents: {},
+    auth: {
+      consumers: [
+        { name: "hindsight", account: "me@example.com", uid: 11000 },
+      ],
+    },
+  } as SwitchroomConfig;
+}
+
+function configWithoutConsumer(): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: "~/.switchroom/agents" },
+    telegram: { bot_token: "test-token", forum_chat_id: "-100123" },
+    agents: {},
+  } as SwitchroomConfig;
+}
+
+describe("checkHindsightConsumer", () => {
+  it("warns when no auth.consumers[] entry named hindsight exists", () => {
+    const result = checkHindsightConsumer(configWithoutConsumer());
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("no `auth.consumers[]` entry named `hindsight`");
+    // Fix points the operator at switchroom.yaml, not at restart magic.
+    expect(result.fix).toContain("auth:");
+    expect(result.fix).toContain("consumers:");
+  });
+
+  it("reports ok when the consumer is declared AND the broker confirms the socket is bound", () => {
+    const result = checkHindsightConsumer(configWithConsumer(), {
+      socketProbe: () => "present",
+    });
+    expect(result.status).toBe("ok");
+    expect(result.detail).toContain("auth.consumers[hindsight]");
+    expect(result.detail).toContain("me@example.com");
+    expect(result.detail).toContain("uid 11000");
+  });
+
+  it("warns with a 'socket not bound' message when the broker says missing", () => {
+    const result = checkHindsightConsumer(configWithConsumer(), {
+      socketProbe: () => "missing",
+    });
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("socket not bound");
+    // The fix points at `switchroom apply`, not raw docker compose —
+    // matches the operator-restart-marker discipline in CLAUDE.md.
+    expect(result.fix).toContain("switchroom apply");
+  });
+
+  it("warns distinctly when the broker container itself is unreachable", () => {
+    // This is the case the regression was about: probe couldn't reach
+    // the broker, but historically it conflated that with "socket not
+    // bound." Operator was told to `switchroom apply` when the real
+    // issue might be docker / broker down. New behaviour routes the
+    // operator to the auth-broker service health row first.
+    const result = checkHindsightConsumer(configWithConsumer(), {
+      socketProbe: () => "unreachable",
+    });
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("couldn't query auth-broker container");
+    expect(result.fix).toContain("service health");
+  });
+
+  it("queries the broker by consumer name, not by a hardcoded path", () => {
+    // Structural pin: the probe receives the consumer name so a future
+    // consumer (e.g. cron, custom MCP) can reuse the same probe shape.
+    // If someone refactors this to a hardcoded "hindsight" string the
+    // probe stops being reusable.
+    let probedName: string | undefined;
+    checkHindsightConsumer(configWithConsumer(), {
+      socketProbe: (name) => {
+        probedName = name;
+        return "present";
+      },
+    });
+    expect(probedName).toBe("hindsight");
+  });
+});


### PR DESCRIPTION
## Summary

- `checkHindsightConsumer()` was reporting false-positive `! socket not yet bound on disk` on every doctor run because `existsSync()` can't traverse into `/var/lib/docker` (mode `0711 root:root` on docker.io defaults) from the operator UID — even when the socket is bound and healthy.
- Replaces the host-side path probe with `docker exec switchroom-auth-broker test -S /run/switchroom/auth-broker/<name>/sock`. Broker runs as root inside its own namespace and can authoritatively answer "is my socket bound?".
- Three-state result (`present` / `missing` / `unreachable`) routes operators to the correct fix instead of conflating "broker down" with "config drift".

## Test plan

- [x] `npm run lint` clean (`tsc --noEmit` + plugin-ref + bot-api + bun-test-import lints)
- [x] `npx vitest run tests/cli.doctor*` — 14 pass, including 5 new cases in `tests/cli.doctor.hindsight-consumer.test.ts` pinning all three probe states + the "no consumer entry" warn + the structural contract that probe is parameterised by consumer name
- [x] Verified live on a host that was reporting the false positive — doctor row flipped `! → ✓` after build
- [x] Fresh-process review (separate agent, no shared context) — APPROVE

## Notes

- Reviewer flagged a theoretical follow-up: `containerNamePrefix` (in `src/agents/compose.ts:658`) defaults to `"switchroom"` but isn't currently plumbed from any user-facing config field. The probe hardcodes `switchroom-auth-broker` to match. If/when `containerNamePrefix` ever becomes a real config option, the probe needs to read it too. Not blocking for #1281.
- The fix preserves the `socketProbe` injection point for tests so we don't shell out to docker in CI; signature changed from `(path: string) => boolean` to `(consumerName: string) => "present" | "missing" | "unreachable"`. No callers outside `doctor.ts` + the test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)