### PR TITLE
fix(hindsight): pre-create /usr/local/lib/switchroom with 0755 (dir mode bug)

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -73,6 +73,18 @@ RUN OLD_UID=$(id -u hindsight) && NEW_UID=11000 \
 # Credential fetcher — small Node program reused by both the boot
 # fetch and the background refresh loop. Pulled out of the entrypoint
 # so both code paths exercise the exact same wire shape.
+#
+# Pre-create the parent dir before the COPY: buildkit's `--chmod` flag
+# propagates to ANY auto-created intermediate directories on the
+# multi-arch CI build path. That gave the parent `/usr/local/lib/switchroom`
+# mode 0644 (drw-r--r-- — no x/traverse bit), so the non-root
+# `hindsight` user (UID 11000) couldn't enter the dir at runtime and
+# the entrypoint died with `Cannot find module '...fetch-creds.cjs'` →
+# `boot credential fetch failed; refusing to boot hindsight` →
+# restart loop. Local single-arch builds didn't hit it because layer
+# ordering left an existing 0755 dir at that path. Pre-creating with
+# explicit mode pins both the dir and the file to the right shape.
+RUN mkdir -p /usr/local/lib/switchroom && chmod 0755 /usr/local/lib/switchroom
 COPY --chmod=0644 docker/hindsight-fetch-creds.cjs /usr/local/lib/switchroom/hindsight-fetch-creds.cjs
 
 # Entrypoint shim — runs the fetcher at boot, spawns a refresh sidecar,


### PR DESCRIPTION
## Summary — load-bearing image bug

PR #1310/#1311 published \`ghcr.io/switchroom/switchroom-hindsight:latest\` for the first time. **First attempt to deploy it restart-looped:**

\`\`\`
Cannot find module '/usr/local/lib/switchroom/hindsight-fetch-creds.cjs'
switchroom-hindsight-entrypoint: boot credential fetch failed;
refusing to boot hindsight
\`\`\`

The file exists in the image. The parent dir \`/usr/local/lib/switchroom/\` is mode 0644 (\`drw-r--r--\`) — **no execute / traverse bit**. The non-root \`hindsight\` user (UID 11000) can't enter the dir to read the .cjs, so Node sees it as missing.

## Root cause

Buildkit's \`COPY --chmod=0644 docker/foo.cjs /usr/local/lib/switchroom/foo.cjs\` propagates \`--chmod\` to ANY auto-created intermediate directory. The chmod intent is "file is world-readable, not world-executable" — fine for a file, fatal for a directory (no traverse → no access).

Single-arch local builds didn't hit it because layer ordering left a pre-existing 0755 dir at that path. The multi-arch CI build (linux/amd64 + linux/arm64) starts clean and reproduces it deterministically.

## Fix

\`RUN mkdir -p /usr/local/lib/switchroom && chmod 0755 ...\` BEFORE the COPY. Dir gets explicit mode 0755; \`--chmod=0644\` only applies to the file.

## Verification

\`\`\`
$ docker build -f docker/Dockerfile.hindsight .
$ docker run --rm <image> sh -c 'ls -la /usr/local/lib/switchroom/'
drwxr-xr-x 1 root root 4096 May 15 01:19 .
-rw-r--r-- 1 root root 3721 May 15 01:18 hindsight-fetch-creds.cjs

$ docker run --rm <image> /app/api/.venv/bin/python -c \\
    'import os; print(os.access("/usr/local/lib/switchroom/hindsight-fetch-creds.cjs", os.R_OK))'
True
\`\`\`

## Service impact

Live container restored via a tagged rollback of the prior locally-built image (which had the right dir mode by accident), plus the new \`HINDSIGHT_API_LLM_MODEL=claude-sonnet-4-6\` env from #1312. Boot log on the restored container confirms \`model=claude-sonnet-4-6\`.

After this PR merges and docker-images republishes \`:latest\`, the rollback image can be retired and a fresh deploy validates end-to-end.

## Test plan

- [x] Local multi-stage build produces \`drwxr-xr-x\` parent dir.
- [x] Python access check \`os.access(R_OK)\` returns \`True\` from the in-image venv interpreter.
- [ ] After merge: \`docker pull ghcr.io/switchroom/switchroom-hindsight:latest && docker run\` boots cleanly past the entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)