### PR TITLE
feat(drive): RFC E §4.2 Cut 2 — Docs API client + write-preview spec builder (PR-2A)

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -533,12 +533,14 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
  *   1. `auth.consumers[]` in `switchroom.yaml` contains an entry named
  *      `hindsight`. The auth-broker only binds a per-consumer socket
  *      when this is set.
- *   2. The bound socket exists on the host side at
- *      `~/.switchroom/state/auth-broker/<host-socket-path>/sock`.
- *      The hindsight side bind-mounts the named volume
- *      `auth-broker-hindsight-sock` (managed by compose) into its own
- *      container; the host-side state dir is where the broker writes
- *      the socket.
+ *   2. The broker container has actually bound the socket at
+ *      `/run/switchroom/auth-broker/hindsight/sock` (in-container path).
+ *      We `docker exec ... test -S <path>` because the host-side docker
+ *      volume mountpoint at `/var/lib/docker/volumes/.../_data/sock`
+ *      lives under a root-only-traversable parent (`/var/lib/docker` is
+ *      mode 0711 root:root on the common docker.io install), so an
+ *      operator-uid `existsSync()` returns false even when the socket
+ *      is present and healthy — false positive (#1281).
  *
  * Replaces the pre-#1245 `hindsight env leak` probe — that was
  * defending against an OpenAI-key shape that the broker-fed flow
@@ -548,7 +550,7 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
  */
 export function checkHindsightConsumer(
   config: SwitchroomConfig,
-  opts?: { socketProbe?: (path: string) => boolean },
+  opts?: { socketProbe?: (consumerName: string) => "present" | "missing" | "unreachable" },
 ): CheckResult {
   const consumers = config.auth?.consumers ?? [];
   const entry = consumers.find((c) => c.name === "hindsight");
@@ -568,31 +570,37 @@ export function checkHindsightConsumer(
     };
   }
 
-  // Host-side path the broker container chowns its consumer socket into.
-  // Mirrors the named volume `auth-broker-hindsight-sock` populated by
-  // compose. The hindsight container itself sees this at
-  // /run/switchroom/auth-broker/sock, but the doctor runs on the host
-  // and inspects the docker volume's mountpoint via the
-  // ~/.switchroom/state/auth-broker- side. We just check it's there
-  // (volume mount may not be filesystem-visible without inspecting
-  // the named volume; treat absence as warn, not fail).
-  const socketProbe = opts?.socketProbe ?? ((p: string) => existsSync(p));
-  const home = process.env.HOME ?? "";
-  const dockerVolPath = `/var/lib/docker/volumes/switchroom_auth-broker-hindsight-sock/_data/sock`;
-  const altVolPath = join(home, ".local", "share", "docker", "volumes", "switchroom_auth-broker-hindsight-sock", "_data", "sock");
-  const present = socketProbe(dockerVolPath) || socketProbe(altVolPath);
+  // Ask the broker container — it owns the socket bind and runs as root
+  // inside the container, so it can stat its own socket regardless of
+  // host-side docker volume permissions.
+  const probe = opts?.socketProbe ?? probeAuthBrokerSocket;
+  const state = probe(entry.name);
 
-  if (!present) {
+  if (state === "unreachable") {
+    // Broker container isn't around to ask. Don't speculate about the
+    // socket — the auth-broker service-health probe covers that case
+    // separately. Just surface what we know.
     return {
       name: "hindsight consumer",
       status: "warn",
       detail:
         `auth.consumers[hindsight] -> ${entry.account} (uid ${entry.uid ?? 0}); ` +
-        `socket not yet bound on disk`,
+        `couldn't query auth-broker container (not running / docker unavailable)`,
       fix:
-        "Run `switchroom apply` to bring up the auth-broker singleton " +
-        "and bind the per-consumer socket. The hindsight container will " +
-        "fetch credentials from it via `get-credentials` at boot.",
+        "Check `auth-broker: service health` row above; if the broker is " +
+        "down, `switchroom apply` will bring it back and bind the socket.",
+    };
+  }
+
+  if (state === "missing") {
+    return {
+      name: "hindsight consumer",
+      status: "warn",
+      detail:
+        `auth.consumers[hindsight] -> ${entry.account} (uid ${entry.uid ?? 0}); ` +
+        `auth-broker is running but socket not bound at /run/switchroom/auth-broker/${entry.name}/sock`,
+      fix:
+        "Run `switchroom apply` to refresh compose and rebind per-consumer sockets.",
     };
   }
 
@@ -601,6 +609,32 @@ export function checkHindsightConsumer(
     status: "ok",
     detail: `auth.consumers[hindsight] -> ${entry.account} (uid ${entry.uid ?? 0})`,
   };
+}
+
+/**
+ * Ask the auth-broker container whether a consumer's UDS is bound.
+ * `docker exec switchroom-auth-broker test -S <path>` exits 0 if the
+ * path is a socket; non-zero otherwise. Distinguishes "container not
+ * reachable" (e.g. docker isn't installed, broker isn't up) from
+ * "broker says no socket" so the doctor row can route the operator to
+ * the right fix.
+ */
+function probeAuthBrokerSocket(
+  consumerName: string,
+): "present" | "missing" | "unreachable" {
+  const containerPath = `/run/switchroom/auth-broker/${consumerName}/sock`;
+  const r = spawnSync(
+    "docker",
+    ["exec", "switchroom-auth-broker", "test", "-S", containerPath],
+    { stdio: "pipe", timeout: 3000 },
+  );
+  if (r.error || r.status === null) return "unreachable";
+  if (r.status === 0) return "present";
+  // Distinguish "broker says no socket" (test exit 1) from "docker
+  // couldn't reach the container at all" (exit 125+, the docker CLI
+  // family of "no such container" / daemon errors).
+  if (r.status >= 125) return "unreachable";
+  return "missing";
 }
 
 async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> {

--- a/src/drive/anchors.test.ts
+++ b/src/drive/anchors.test.ts
@@ -561,9 +561,17 @@ describe("describeOffset", () => {
     expect(d.nearestHeading).toBeNull();
   });
 
-  it("rejects negative or non-finite offsets with a literal", () => {
+  it("rejects negative offsets with a literal; non-finite offsets get the constant", () => {
+    // Negative offsets still surface the number — the literal is
+    // honest about what the agent passed. Non-finite offsets
+    // (NaN, Infinity) get the constant since template-literal
+    // coercion of those values is shaped enough to potentially
+    // smuggle text.
     expect(describeOffset(offsetDoc, -1).displayName).toBe("at offset -1");
-    expect(describeOffset(offsetDoc, NaN).displayName).toBe("at offset NaN");
+    expect(describeOffset(offsetDoc, NaN).displayName).toBe("at unknown offset");
+    expect(describeOffset(offsetDoc, Number.POSITIVE_INFINITY).displayName).toBe(
+      "at unknown offset",
+    );
   });
 
   it("truncates very long heading text in the display name", () => {
@@ -591,6 +599,110 @@ describe("describeOffset", () => {
     const d = describeOffset(proseDoc, 10);
     expect(d.displayName).toContain("before first heading");
     expect(d.nearestHeading).toBeNull();
+  });
+});
+
+describe("describeOffset — boundary correctness", () => {
+  it("offset BEFORE the first paragraph renders 'at start of doc' (not end-of-doc)", () => {
+    // Reviewer-flagged blocker: offset=0 in a real Drive doc (which
+    // starts at startIndex=1) used to fall through to "at end of
+    // doc" and let the wrapper itself lie about location.
+    const d = describeOffset(offsetDoc, 0);
+    expect(d.displayName).toBe("at start of doc");
+    expect(d.paragraph).toBeNull();
+    expect(d.nearestHeading).toBeNull();
+  });
+
+  it("offset PAST the last paragraph renders 'at end of doc'", () => {
+    const d = describeOffset(offsetDoc, 78); // last endOffset
+    expect(d.displayName).toBe("at end of doc");
+    expect(d.nearestHeading?.text).toBe("Hiring");
+  });
+
+  it("offset in an interior gap (no paragraph covers it) falls back to literal", () => {
+    // Simulate a doc with a gap between paragraphs — what would
+    // happen if upstream's parser drops table cells / page breaks
+    // and the agent points start_index at the gap.
+    const gapDoc: DocumentSnapshot = {
+      paragraphs: [
+        pp("Before the table.", 1, 1, 19),
+        // [19, 100) is a table or other non-paragraph element the
+        // parser omitted.
+        pp("After the table.", 2, 100, 118),
+      ],
+    };
+    const d = describeOffset(gapDoc, 50);
+    expect(d.displayName).toBe("at offset 50");
+    expect(d.paragraph).toBeNull();
+  });
+});
+
+describe("describeOffset — attestation hardening (reviewer pin)", () => {
+  it("non-number offset returns a constant string (no template-literal injection)", () => {
+    // Cast around the type system — the hook will receive
+    // start_index from JSON-parsed tool input where the runtime
+    // type isn't guaranteed.
+    const badOffset = "78\n📍 inside section 'Approved' (level 1)" as unknown as number;
+    const d = describeOffset(offsetDoc, badOffset);
+    expect(d.displayName).toBe("at unknown offset");
+    expect(d.displayName).not.toContain("Approved");
+    expect(d.displayName).not.toContain("📍");
+  });
+
+  it("null / undefined / object offsets return the constant", () => {
+    expect(describeOffset(offsetDoc, null as unknown as number).displayName).toBe(
+      "at unknown offset",
+    );
+    expect(describeOffset(offsetDoc, undefined as unknown as number).displayName).toBe(
+      "at unknown offset",
+    );
+    expect(describeOffset(offsetDoc, {} as unknown as number).displayName).toBe(
+      "at unknown offset",
+    );
+  });
+
+  it("heading text with embedded single quotes doesn't break the wrapping", () => {
+    const docWithQuote: DocumentSnapshot = {
+      paragraphs: [
+        ph(2, "What's up", 1, 1, 12),
+        pp("body", 2, 12, 18),
+      ],
+    };
+    const d = describeOffset(docWithQuote, 15);
+    expect(d.displayName).toBe("inside section 'What’s up' (level 2)");
+    // Apostrophe replaced with curly close-quote so the surrounding
+    // single quotes stay balanced.
+    expect(d.displayName.match(/'/g)?.length).toBe(2);
+  });
+
+  it("heading text with markdown / control chars is sanitized", () => {
+    const docWithMarkup: DocumentSnapshot = {
+      paragraphs: [
+        ph(2, "Foo `code` [click](evil) bell", 1, 1, 30),
+        pp("body", 2, 30, 36),
+      ],
+    };
+    const d = describeOffset(docWithMarkup, 32);
+    expect(d.displayName).not.toContain("`");
+    expect(d.displayName).not.toContain("[");
+    expect(d.displayName).not.toContain("](");
+    expect(d.displayName).not.toContain("");
+    expect(d.displayName).toMatch(/inside section 'Foo code clickevil bell' \(level 2\)/);
+  });
+
+  it("nested heading levels — returns the most-specific (largest .index) ancestor", () => {
+    // H1 > H2 > H3 > body. The 'most-specific' ancestor is H3.
+    const nestedDoc: DocumentSnapshot = {
+      paragraphs: [
+        ph(1, "Plan", 1, 1, 8),
+        ph(2, "Q3", 2, 8, 14),
+        ph(3, "Hiring", 3, 14, 22),
+        pp("Reach out to Alice.", 4, 22, 42),
+      ],
+    };
+    const d = describeOffset(nestedDoc, 30);
+    expect(d.displayName).toBe("inside section 'Hiring' (level 3)");
+    expect(d.nearestHeading?.level).toBe(3);
   });
 });
 

--- a/src/drive/anchors.test.ts
+++ b/src/drive/anchors.test.ts
@@ -10,6 +10,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  describeOffset,
+  findParagraphForOffset,
+  nearestHeadingAbove,
   resolveAnchor,
   type DocumentSnapshot,
   type HeadingParagraph,
@@ -417,5 +420,195 @@ describe("resolved displayName never contains agent-controlled text", () => {
       unheadedDoc,
     );
     expect(r.ok && r.resolved.displayName).toContain("We agreed to ship by Q3.");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Reverse direction — describeOffset / findParagraphForOffset
+// ────────────────────────────────────────────────────────────────────────
+//
+// Used by the PreToolUse hook on Drive write tools to translate
+// upstream's character `start_index` into a wrapper-attested
+// location string like "inside section 'Hiring' (level 2)".
+
+/**
+ * Build a paragraph with explicit char-offset metadata. Mirrors the
+ * Docs API's flat-stream char-range model that `documents.get`
+ * returns (each `body.content[]` element has `startIndex`/`endIndex`).
+ */
+function ph(
+  level: number,
+  text: string,
+  index: number,
+  startOffset: number,
+  endOffset: number,
+): HeadingParagraph {
+  return { kind: "heading", level, text, index, startOffset, endOffset };
+}
+
+function pp(
+  text: string,
+  index: number,
+  startOffset: number,
+  endOffset: number,
+): TextParagraph {
+  return { kind: "text", text, index, startOffset, endOffset };
+}
+
+/**
+ * Realistic char-range doc — a Q3 plan with a body paragraph, two
+ * H2 sections, and a body paragraph under each.
+ *
+ *   offsets   paragraph
+ *   1..18     [H1] "Q3 Plan"
+ *   18..36    Intro paragraph.
+ *   36..44    [H2] "Goals"
+ *   44..62    Ship the picker.
+ *   62..72    [H2] "Hiring"
+ *   72..78    TBD.
+ *
+ * Open intervals match Docs API: an offset that's exactly endOffset
+ * of one paragraph lands in the next.
+ */
+const offsetDoc: DocumentSnapshot = {
+  paragraphs: [
+    ph(1, "Q3 Plan", 1, 1, 18),
+    pp("Intro paragraph.", 2, 18, 36),
+    ph(2, "Goals", 3, 36, 44),
+    pp("Ship the picker.", 4, 44, 62),
+    ph(2, "Hiring", 5, 62, 72),
+    pp("TBD.", 6, 72, 78),
+  ],
+};
+
+describe("findParagraphForOffset", () => {
+  it("returns the paragraph whose [start, end) range covers the offset", () => {
+    expect(findParagraphForOffset(offsetDoc, 1)?.index).toBe(1);
+    expect(findParagraphForOffset(offsetDoc, 17)?.index).toBe(1);
+    expect(findParagraphForOffset(offsetDoc, 18)?.index).toBe(2); // join-point lands in next
+    expect(findParagraphForOffset(offsetDoc, 50)?.index).toBe(4);
+    expect(findParagraphForOffset(offsetDoc, 77)?.index).toBe(6);
+  });
+
+  it("returns null past the last paragraph end", () => {
+    expect(findParagraphForOffset(offsetDoc, 78)).toBeNull();
+    expect(findParagraphForOffset(offsetDoc, 9999)).toBeNull();
+  });
+
+  it("returns null when no paragraph has offset metadata", () => {
+    expect(findParagraphForOffset(headedDoc, 50)).toBeNull();
+  });
+});
+
+describe("nearestHeadingAbove", () => {
+  it("walks backward from a position to the nearest heading", () => {
+    expect(nearestHeadingAbove(offsetDoc, 6)?.text).toBe("Hiring"); // body under Hiring
+    expect(nearestHeadingAbove(offsetDoc, 4)?.text).toBe("Goals"); // body under Goals
+    expect(nearestHeadingAbove(offsetDoc, 5)?.text).toBe("Goals"); // 5 itself is Hiring; "above" excludes it
+  });
+
+  it("returns null when no heading exists above", () => {
+    expect(nearestHeadingAbove(offsetDoc, 1)).toBeNull(); // position 1 is the H1 itself; nothing above
+    expect(nearestHeadingAbove(offsetDoc, 0)).toBeNull(); // before everything
+  });
+
+  it("with a large position-argument returns the last (highest-index) heading", () => {
+    expect(nearestHeadingAbove(offsetDoc, 9999)?.text).toBe("Hiring");
+    expect(nearestHeadingAbove(offsetDoc, Number.POSITIVE_INFINITY)?.text).toBe("Hiring");
+  });
+});
+
+describe("describeOffset", () => {
+  it("renders 'inside section <heading>' for a body offset under a heading", () => {
+    const d = describeOffset(offsetDoc, 50);
+    expect(d.displayName).toBe("inside section 'Goals' (level 2)");
+    expect(d.paragraph?.index).toBe(4);
+    expect(d.nearestHeading?.text).toBe("Goals");
+  });
+
+  it("renders 'on heading <X>' when the offset lands on the heading line itself", () => {
+    const d = describeOffset(offsetDoc, 40); // inside the [H2] "Goals" range
+    expect(d.displayName).toBe("on heading 'Goals' (level 2)");
+    expect(d.nearestHeading?.text).toBe("Goals");
+  });
+
+  it("renders 'before first heading' when the offset is before any heading", () => {
+    // Build a doc whose first paragraph is body text, not a heading.
+    const preHeadingDoc: DocumentSnapshot = {
+      paragraphs: [
+        pp("Cover note paragraph.", 1, 1, 22),
+        ph(1, "Heading later", 2, 22, 36),
+        pp("Body.", 3, 36, 42),
+      ],
+    };
+    const d = describeOffset(preHeadingDoc, 5);
+    expect(d.displayName).toContain("before first heading");
+    expect(d.displayName).toContain("Cover note");
+    expect(d.nearestHeading).toBeNull();
+  });
+
+  it("renders 'at end of doc' when offset is past the last paragraph end", () => {
+    const d = describeOffset(offsetDoc, 78);
+    expect(d.displayName).toBe("at end of doc");
+    expect(d.nearestHeading?.text).toBe("Hiring");
+  });
+
+  it("falls back to a literal offset when the snapshot has no range metadata", () => {
+    // `headedDoc` is the existing forward-resolver fixture, no offsets.
+    const d = describeOffset(headedDoc, 1234);
+    expect(d.displayName).toBe("at offset 1234");
+    expect(d.paragraph).toBeNull();
+    expect(d.nearestHeading).toBeNull();
+  });
+
+  it("rejects negative or non-finite offsets with a literal", () => {
+    expect(describeOffset(offsetDoc, -1).displayName).toBe("at offset -1");
+    expect(describeOffset(offsetDoc, NaN).displayName).toBe("at offset NaN");
+  });
+
+  it("truncates very long heading text in the display name", () => {
+    const longName = "A very long heading title that exceeds the ellipsis budget by a comfortable margin";
+    const doc: DocumentSnapshot = {
+      paragraphs: [
+        ph(2, longName, 1, 1, 100),
+        pp("body", 2, 100, 110),
+      ],
+    };
+    const d = describeOffset(doc, 105);
+    // Expect inside-section to truncate at 60 chars + ellipsis.
+    expect(d.displayName).toContain("'");
+    expect(d.displayName).toContain("…");
+    expect(d.displayName.length).toBeLessThan(longName.length + 30);
+  });
+
+  it("handles a doc with no headings at all (unheaded prose)", () => {
+    const proseDoc: DocumentSnapshot = {
+      paragraphs: [
+        pp("Meeting notes line 1.", 1, 1, 22),
+        pp("Meeting notes line 2.", 2, 22, 44),
+      ],
+    };
+    const d = describeOffset(proseDoc, 10);
+    expect(d.displayName).toContain("before first heading");
+    expect(d.nearestHeading).toBeNull();
+  });
+});
+
+describe("describeOffset — attestation invariant (RFC E §4.2)", () => {
+  it("displayName is computed from the doc snapshot, never from agent input", () => {
+    // The agent-controlled value here is `offset`. It cannot inject
+    // text into displayName beyond appearing as the literal number
+    // in the fallback path — and the fallback only fires when no
+    // doc metadata is available.
+    const d = describeOffset(offsetDoc, 50);
+    expect(d.displayName).not.toContain("50"); // structured path; offset doesn't appear
+    expect(d.displayName).toBe("inside section 'Goals' (level 2)");
+  });
+
+  it("fallback literal contains the offset but no other agent-controlled text", () => {
+    const d = describeOffset(headedDoc, 1234);
+    expect(d.displayName).toBe("at offset 1234");
+    // No room for an agent to inject anything else — the format is
+    // pinned to "at offset <number>".
   });
 });

--- a/src/drive/anchors.test.ts
+++ b/src/drive/anchors.test.ts
@@ -547,6 +547,22 @@ describe("describeOffset", () => {
     expect(d.nearestHeading).toBeNull();
   });
 
+  it("'before first heading' preview wraps in single quotes (apostrophe-balanced)", () => {
+    // The body preview is wrapped in `'…'` so truncateLine's `'`→`’`
+    // substitution keeps the wrapping balanced even when the body
+    // contains literal apostrophes.
+    const preHeadingDoc: DocumentSnapshot = {
+      paragraphs: [
+        pp("It's a cover note.", 1, 1, 19),
+        ph(1, "Later", 2, 19, 27),
+      ],
+    };
+    const d = describeOffset(preHeadingDoc, 5);
+    expect(d.displayName).toBe("before first heading (near 'It’s a cover note.')");
+    expect(d.displayName.match(/'/g)?.length).toBe(2);
+    expect(d.displayName.match(/"/g)).toBeNull();
+  });
+
   it("renders 'at end of doc' when offset is past the last paragraph end", () => {
     const d = describeOffset(offsetDoc, 78);
     expect(d.displayName).toBe("at end of doc");

--- a/src/drive/anchors.ts
+++ b/src/drive/anchors.ts
@@ -79,6 +79,16 @@ export interface HeadingParagraph {
   text: string;
   /** Stable per-doc index — what the wrapper uses to address insert/delete. */
   index: number;
+  /**
+   * Optional inclusive char-range covering this paragraph in the Docs
+   * API `body.content[]` model. Required for `describeOffset()` to
+   * find which paragraph an arbitrary character offset (the unit
+   * `taylorwilsdon/google_workspace_mcp` write tools take as
+   * `start_index`/`end_index`) lands in. Optional so the
+   * resolver-direction tests don't need to specify ranges.
+   */
+  startOffset?: number;
+  endOffset?: number;
 }
 
 export interface TextParagraph {
@@ -87,6 +97,9 @@ export interface TextParagraph {
   text: string;
   /** Stable per-doc index — what the wrapper uses to address insert/delete. */
   index: number;
+  /** See `HeadingParagraph.startOffset`. */
+  startOffset?: number;
+  endOffset?: number;
 }
 
 export interface DocumentSnapshot {
@@ -529,4 +542,193 @@ function outOfRange(
 
 function invalidAnchor(message: string): ResolveResult {
   return { ok: false, error: { code: "INVALID_ANCHOR", message } };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Reverse direction — character offset → wrapper-attested location
+// ────────────────────────────────────────────────────────────────────────
+//
+// The forward path (resolveAnchor) is "agent gives an anchor name,
+// wrapper computes the doc position." Reverse goes the other way:
+// "upstream MCP write tool gives a `start_index` (Docs API character
+// offset), wrapper computes the human-readable location the agent
+// can't override." This is the load-bearing piece of the PreToolUse
+// hook gating mcp__google-workspace__* writes — the user has to see
+// where the edit lands, attested by the wrapper, before they tap
+// Allow.
+//
+// taylorwilsdon/google_workspace_mcp tools all take character
+// offsets (`start_index`, `end_index`) into the Docs API's
+// flat character stream. `documents.get` returns each paragraph
+// with its own `startIndex`/`endIndex` range in that stream;
+// `parseDocsApiResponse` (callsite, not here) flattens that into
+// our `DocumentSnapshot` with `startOffset`/`endOffset` per
+// paragraph. `describeOffset` then locates which paragraph
+// contains the requested offset and renders the heading-based
+// display name.
+
+export interface OffsetDescription {
+  /** Human-readable, wrapper-attested. Goes on the `📍` line of the diff-preview card. */
+  displayName: string;
+  /** The paragraph the offset lands in, or null if the snapshot has no offset metadata. */
+  paragraph: Paragraph | null;
+  /** Nearest heading at or above the located paragraph, if any. */
+  nearestHeading: HeadingParagraph | null;
+}
+
+/**
+ * Locate which paragraph contains a Docs-API character offset and
+ * render a wrapper-attested display name like `after heading
+ * 'Goals' (level 2)` or `inside section 'Hiring'` or `at end of
+ * doc`.
+ *
+ * Falls back to a literal `at offset N` when the snapshot has no
+ * `startOffset`/`endOffset` metadata — the hook prefers the
+ * structured form when Drive returned full paragraph ranges, and
+ * the literal form when it couldn't (e.g. `documents.get` quota
+ * error and the hook proceeds without doc context).
+ */
+export function describeOffset(
+  doc: DocumentSnapshot,
+  offset: number,
+): OffsetDescription {
+  if (!Number.isFinite(offset) || offset < 0) {
+    return {
+      displayName: `at offset ${offset}`,
+      paragraph: null,
+      nearestHeading: null,
+    };
+  }
+
+  const located = findParagraphForOffset(doc, offset);
+  if (located === null) {
+    // No offset metadata on any paragraph, or offset falls beyond
+    // the last paragraph's end. Both surface as a literal offset so
+    // the user at least sees the number from the tool call.
+    if (doc.paragraphs.length > 0 && hasOffsets(doc.paragraphs[doc.paragraphs.length - 1]!)) {
+      // For "end of doc" we want the *last* heading in the entire
+      // document, regardless of its `.index` value. Pass Infinity
+      // so the "strictly above" filter degenerates to "any
+      // heading", and the largest-index one wins.
+      return {
+        displayName: "at end of doc",
+        paragraph: null,
+        nearestHeading: nearestHeadingAbove(doc, Number.POSITIVE_INFINITY),
+      };
+    }
+    return {
+      displayName: `at offset ${offset}`,
+      paragraph: null,
+      nearestHeading: null,
+    };
+  }
+
+  // If the located paragraph IS a heading, the agent is editing the
+  // heading line itself — surface that directly so the user sees
+  // they're touching the section title, not the body.
+  if (located.kind === "heading") {
+    return {
+      displayName: `on heading '${truncateLine(located.text)}' (${ordinalLevel(located.level)})`,
+      paragraph: located,
+      nearestHeading: located,
+    };
+  }
+
+  const heading = nearestHeadingAbove(doc, located.index);
+  if (heading === null) {
+    // No heading above — either an unheaded doc or the edit lands
+    // before the first heading.
+    const preview = previewOfNeighborhood(doc, located.index);
+    return {
+      displayName: preview
+        ? `before first heading (near "${preview}")`
+        : `before first heading`,
+      paragraph: located,
+      nearestHeading: null,
+    };
+  }
+
+  return {
+    displayName: `inside section '${truncateLine(heading.text)}' (${ordinalLevel(heading.level)})`,
+    paragraph: located,
+    nearestHeading: heading,
+  };
+}
+
+/**
+ * Find the paragraph whose char-range covers `offset`. Returns null
+ * when no paragraph has offset metadata, or when `offset` lies
+ * past the last paragraph's `endOffset`.
+ *
+ * Linear walk — doc paragraph counts are O(100s) for the realistic
+ * case; binary search would be premature.
+ */
+export function findParagraphForOffset(
+  doc: DocumentSnapshot,
+  offset: number,
+): Paragraph | null {
+  for (const p of doc.paragraphs) {
+    if (!hasOffsets(p)) continue;
+    // Docs API ranges are half-open: paragraph covers [startIndex, endIndex).
+    // Replicate that semantics so an offset that's the exact endOffset
+    // of paragraph N lands in paragraph N+1 (the join-point).
+    if (offset >= p.startOffset! && offset < p.endOffset!) {
+      return p;
+    }
+  }
+  return null;
+}
+
+/**
+ * Find the heading with the largest `.index` that's STRICTLY less
+ * than `paragraphPosition` (i.e. strictly above). Returns null when
+ * no such heading exists.
+ *
+ * Semantics work in terms of the paragraph `.index` field — not
+ * the position in `doc.paragraphs[]`. Mirrors how the forward
+ * resolvers index into the doc, and lets callers reason in the
+ * same coordinate system the agent-facing tools use.
+ *
+ * Callers should typically NOT call this with a heading's own
+ * `.index` and expect to get that heading back — the "strictly
+ * above" semantics deliberately excludes self. See `describeOffset`
+ * for the offset-lands-on-a-heading case, which short-circuits
+ * before calling here.
+ */
+export function nearestHeadingAbove(
+  doc: DocumentSnapshot,
+  paragraphPosition: number,
+): HeadingParagraph | null {
+  let best: HeadingParagraph | null = null;
+  for (const p of doc.paragraphs) {
+    if (p.kind !== "heading") continue;
+    if (p.index >= paragraphPosition) continue;
+    if (best === null || p.index > best.index) best = p;
+  }
+  return best;
+}
+
+function hasOffsets(p: Paragraph): p is Paragraph & { startOffset: number; endOffset: number } {
+  return (
+    typeof p.startOffset === "number" &&
+    typeof p.endOffset === "number" &&
+    p.endOffset > p.startOffset
+  );
+}
+
+function truncateLine(s: string): string {
+  return ellipsize(s.replace(/\s+/g, " ").trim(), 60);
+}
+
+function previewOfNeighborhood(
+  doc: DocumentSnapshot,
+  paragraphIndex: number,
+): string | null {
+  for (let i = 0; i < doc.paragraphs.length; i++) {
+    const p = doc.paragraphs[i]!;
+    if (p.index === paragraphIndex && p.text.trim().length > 0) {
+      return truncateLine(p.text);
+    }
+  }
+  return null;
 }

--- a/src/drive/anchors.ts
+++ b/src/drive/anchors.ts
@@ -684,7 +684,12 @@ export function describeOffset(
     const preview = previewOfNeighborhood(doc, located.index);
     return {
       displayName: preview
-        ? `before first heading (near "${preview}")`
+        // Same single-quote wrapping as the other displayName shapes
+        // so truncateLine's `'` → `’` substitution covers the
+        // body-text-contains-quote case symmetrically (otherwise a
+        // body line with a literal `"` would unbalance the
+        // parenthetical).
+        ? `before first heading (near '${preview}')`
         : `before first heading`,
       paragraph: located,
       nearestHeading: null,

--- a/src/drive/anchors.ts
+++ b/src/drive/anchors.ts
@@ -592,9 +592,18 @@ export function describeOffset(
   doc: DocumentSnapshot,
   offset: number,
 ): OffsetDescription {
-  if (!Number.isFinite(offset) || offset < 0) {
+  // Hard runtime guard on the agent-controlled value. The PreToolUse
+  // hook will pass `start_index` straight from a JSON-parsed tool
+  // input; if a non-number sneaks past TypeScript (e.g. via the JSON
+  // path), template-literal coercion would let the value land
+  // verbatim in `displayName`. That's an attestation hole — return a
+  // constant string instead.
+  if (typeof offset !== "number" || !Number.isFinite(offset) || offset < 0) {
     return {
-      displayName: `at offset ${offset}`,
+      displayName:
+        typeof offset === "number" && Number.isFinite(offset)
+          ? `at offset ${offset}`
+          : "at unknown offset",
       paragraph: null,
       nearestHeading: null,
     };
@@ -602,10 +611,41 @@ export function describeOffset(
 
   const located = findParagraphForOffset(doc, offset);
   if (located === null) {
-    // No offset metadata on any paragraph, or offset falls beyond
-    // the last paragraph's end. Both surface as a literal offset so
-    // the user at least sees the number from the tool call.
-    if (doc.paragraphs.length > 0 && hasOffsets(doc.paragraphs[doc.paragraphs.length - 1]!)) {
+    // Distinguish before-start, past-end, and "no metadata" — the
+    // earlier code treated all three as "at end of doc" which lets
+    // an offset=0 write be attested as end-of-doc (RFC §4.2 lie-by-
+    // wrapper). Now:
+    //   * No paragraph has offset metadata → literal fallback.
+    //   * Offset < first paragraph startOffset → "at start of doc".
+    //   * Offset >= last paragraph endOffset → "at end of doc".
+    //   * Offset in an interior gap (table cells, page breaks, etc.
+    //     between paragraphs) → literal fallback rather than
+    //     guessing — the parser is upstream's concern and we'd
+    //     rather mis-render than mis-attest.
+    if (doc.paragraphs.length === 0) {
+      return {
+        displayName: `at offset ${offset}`,
+        paragraph: null,
+        nearestHeading: null,
+      };
+    }
+    const first = doc.paragraphs[0]!;
+    const last = doc.paragraphs[doc.paragraphs.length - 1]!;
+    if (!hasOffsets(first) || !hasOffsets(last)) {
+      return {
+        displayName: `at offset ${offset}`,
+        paragraph: null,
+        nearestHeading: null,
+      };
+    }
+    if (offset < first.startOffset!) {
+      return {
+        displayName: "at start of doc",
+        paragraph: null,
+        nearestHeading: null,
+      };
+    }
+    if (offset >= last.endOffset!) {
       // For "end of doc" we want the *last* heading in the entire
       // document, regardless of its `.index` value. Pass Infinity
       // so the "strictly above" filter degenerates to "any
@@ -616,6 +656,9 @@ export function describeOffset(
         nearestHeading: nearestHeadingAbove(doc, Number.POSITIVE_INFINITY),
       };
     }
+    // Interior gap — surface the literal offset and let the user
+    // see the raw number rather than confidently attesting the
+    // wrong location.
     return {
       displayName: `at offset ${offset}`,
       paragraph: null,
@@ -716,8 +759,29 @@ function hasOffsets(p: Paragraph): p is Paragraph & { startOffset: number; endOf
   );
 }
 
+/**
+ * Sanitize doc-content text before embedding in the `displayName`
+ * string. The wrapper-attested name lands on the diff-preview card
+ * and (after PR-2) gets HTML-escaped by the gateway renderer — but
+ * defense in depth here keeps the *intermediate* form safe in the
+ * audit row, log lines, and any non-Telegram surface that doesn't
+ * apply its own escape.
+ *
+ * Strips: control chars, backticks (markdown code marker), brackets
+ * and parens that could form a markdown link. Escapes embedded
+ * single quotes so the surrounding `'…'` wrapping in the
+ * displayName ("on heading 'X' (level 2)") doesn't get
+ * unbalanced by a heading whose text already contains `'`.
+ */
 function truncateLine(s: string): string {
-  return ellipsize(s.replace(/\s+/g, " ").trim(), 60);
+  const cleaned = s
+    // eslint-disable-next-line no-control-regex -- intentional strip
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .replace(/[`[\]()]/g, "")
+    .replace(/'/g, "’") // ' → ’ (curly close-single-quote)
+    .replace(/\s+/g, " ")
+    .trim();
+  return ellipsize(cleaned, 60);
 }
 
 function previewOfNeighborhood(

--- a/src/drive/docs-get.test.ts
+++ b/src/drive/docs-get.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Tests for Google Docs API client + response parser — RFC E §4.2.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { fetchDocumentSnapshot, parseDocumentResponse } from "./docs-get.js";
+
+function mockFetch(handler: (url: string, init: RequestInit) => Response): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return Promise.resolve(handler(url, init ?? {}));
+  }) as typeof fetch;
+}
+
+function jsonResp(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Fixtures — shape mirrors what the Docs v1 API actually returns
+// ────────────────────────────────────────────────────────────────────────
+
+function paragraphElement(
+  startIndex: number,
+  endIndex: number,
+  text: string,
+  namedStyleType?: string,
+): Record<string, unknown> {
+  return {
+    startIndex,
+    endIndex,
+    paragraph: {
+      elements: [{ textRun: { content: text } }],
+      paragraphStyle: namedStyleType ? { namedStyleType } : {},
+    },
+  };
+}
+
+function tableElement(
+  startIndex: number,
+  endIndex: number,
+): Record<string, unknown> {
+  return {
+    startIndex,
+    endIndex,
+    table: { rows: 2, columns: 3 },
+  };
+}
+
+const sampleDoc = {
+  documentId: "DOC1ABCDEF",
+  title: "Q3 Strategy Notes",
+  body: {
+    content: [
+      paragraphElement(1, 18, "Q3 Plan\n", "HEADING_1"),
+      paragraphElement(18, 36, "Intro paragraph.\n", "NORMAL_TEXT"),
+      paragraphElement(36, 44, "Goals\n", "HEADING_2"),
+      paragraphElement(44, 62, "Ship the picker.\n", "NORMAL_TEXT"),
+    ],
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────────
+// parseDocumentResponse — pure parser tests
+// ────────────────────────────────────────────────────────────────────────
+
+describe("parseDocumentResponse — happy path", () => {
+  it("parses doc title + paragraph tree with offsets", () => {
+    const r = parseDocumentResponse(sampleDoc);
+    expect(r.title).toBe("Q3 Strategy Notes");
+    expect(r.document_id).toBe("DOC1ABCDEF");
+    expect(r.snapshot.paragraphs).toHaveLength(4);
+  });
+
+  it("maps HEADING_N → heading kind with the right level", () => {
+    const r = parseDocumentResponse(sampleDoc);
+    const h1 = r.snapshot.paragraphs[0]!;
+    const h2 = r.snapshot.paragraphs[2]!;
+    expect(h1.kind).toBe("heading");
+    if (h1.kind === "heading") expect(h1.level).toBe(1);
+    expect(h2.kind).toBe("heading");
+    if (h2.kind === "heading") expect(h2.level).toBe(2);
+  });
+
+  it("maps NORMAL_TEXT → text kind", () => {
+    const r = parseDocumentResponse(sampleDoc);
+    const body = r.snapshot.paragraphs[1]!;
+    expect(body.kind).toBe("text");
+  });
+
+  it("populates startOffset / endOffset from Docs API range", () => {
+    const r = parseDocumentResponse(sampleDoc);
+    const h1 = r.snapshot.paragraphs[0]!;
+    expect(h1.startOffset).toBe(1);
+    expect(h1.endOffset).toBe(18);
+    const body = r.snapshot.paragraphs[1]!;
+    expect(body.startOffset).toBe(18);
+    expect(body.endOffset).toBe(36);
+  });
+
+  it("strips a single trailing newline from paragraph text", () => {
+    const r = parseDocumentResponse(sampleDoc);
+    expect(r.snapshot.paragraphs[0]!.text).toBe("Q3 Plan");
+    expect(r.snapshot.paragraphs[1]!.text).toBe("Intro paragraph.");
+  });
+
+  it("assigns sequential .index starting at 1", () => {
+    const r = parseDocumentResponse(sampleDoc);
+    expect(r.snapshot.paragraphs.map((p) => p.index)).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("parseDocumentResponse — heading levels", () => {
+  it("maps all 6 heading levels", () => {
+    const doc = {
+      documentId: "D",
+      title: "T",
+      body: {
+        content: [
+          paragraphElement(1, 5, "H1\n", "HEADING_1"),
+          paragraphElement(5, 9, "H2\n", "HEADING_2"),
+          paragraphElement(9, 13, "H3\n", "HEADING_3"),
+          paragraphElement(13, 17, "H4\n", "HEADING_4"),
+          paragraphElement(17, 21, "H5\n", "HEADING_5"),
+          paragraphElement(21, 25, "H6\n", "HEADING_6"),
+        ],
+      },
+    };
+    const r = parseDocumentResponse(doc);
+    const levels = r.snapshot.paragraphs
+      .filter((p) => p.kind === "heading")
+      .map((p) => (p.kind === "heading" ? p.level : 0));
+    expect(levels).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("treats TITLE and SUBTITLE as text (not headings)", () => {
+    const doc = {
+      documentId: "D",
+      title: "T",
+      body: {
+        content: [
+          paragraphElement(1, 10, "The Title\n", "TITLE"),
+          paragraphElement(10, 20, "A subtitle\n", "SUBTITLE"),
+        ],
+      },
+    };
+    const r = parseDocumentResponse(doc);
+    expect(r.snapshot.paragraphs.every((p) => p.kind === "text")).toBe(true);
+  });
+
+  it("treats unknown namedStyleType as text", () => {
+    const doc = {
+      documentId: "D",
+      title: "T",
+      body: {
+        content: [paragraphElement(1, 10, "Body\n", "WEIRD_STYLE")],
+      },
+    };
+    const r = parseDocumentResponse(doc);
+    expect(r.snapshot.paragraphs[0]!.kind).toBe("text");
+  });
+});
+
+describe("parseDocumentResponse — gap handling (non-paragraph elements)", () => {
+  it("skips tables — offsets between paragraphs reflect the gap", () => {
+    const doc = {
+      documentId: "D",
+      title: "T",
+      body: {
+        content: [
+          paragraphElement(1, 19, "Before table.\n", "NORMAL_TEXT"),
+          tableElement(19, 100),
+          paragraphElement(100, 118, "After table.\n", "NORMAL_TEXT"),
+        ],
+      },
+    };
+    const r = parseDocumentResponse(doc);
+    expect(r.snapshot.paragraphs).toHaveLength(2);
+    expect(r.snapshot.paragraphs[0]!.endOffset).toBe(19);
+    expect(r.snapshot.paragraphs[1]!.startOffset).toBe(100);
+  });
+
+  it("skips sectionBreak elements", () => {
+    const doc = {
+      documentId: "D",
+      title: "T",
+      body: {
+        content: [
+          paragraphElement(1, 10, "Body.\n", "NORMAL_TEXT"),
+          { startIndex: 10, endIndex: 12, sectionBreak: {} },
+          paragraphElement(12, 20, "After.\n", "NORMAL_TEXT"),
+        ],
+      },
+    };
+    const r = parseDocumentResponse(doc);
+    expect(r.snapshot.paragraphs).toHaveLength(2);
+  });
+});
+
+describe("parseDocumentResponse — malformed response", () => {
+  it("throws on non-object body", () => {
+    expect(() => parseDocumentResponse(null)).toThrow(/non-object/);
+    expect(() => parseDocumentResponse([1, 2, 3])).toThrow(/non-object/);
+    expect(() => parseDocumentResponse("oops")).toThrow(/non-object/);
+  });
+
+  it("throws on missing documentId", () => {
+    expect(() => parseDocumentResponse({ title: "x" })).toThrow(/documentId/);
+  });
+
+  it("throws on documentId with invalid charset (URL-injection guard)", () => {
+    expect(() => parseDocumentResponse({ documentId: "abc/def" })).toThrow(/documentId/);
+    expect(() => parseDocumentResponse({ documentId: "abc?evil=1" })).toThrow(/documentId/);
+  });
+
+  it("returns empty snapshot when body is missing or content is empty", () => {
+    const r1 = parseDocumentResponse({ documentId: "D", title: "T" });
+    expect(r1.snapshot.paragraphs).toEqual([]);
+    const r2 = parseDocumentResponse({ documentId: "D", title: "T", body: { content: [] } });
+    expect(r2.snapshot.paragraphs).toEqual([]);
+  });
+
+  it("skips paragraph entries with missing or inverted offsets", () => {
+    const doc = {
+      documentId: "D",
+      title: "T",
+      body: {
+        content: [
+          paragraphElement(1, 10, "OK\n", "NORMAL_TEXT"),
+          { startIndex: 10, paragraph: { elements: [] } }, // no endIndex
+          { startIndex: 30, endIndex: 20, paragraph: { elements: [] } }, // inverted
+          paragraphElement(40, 50, "Also OK\n", "NORMAL_TEXT"),
+        ],
+      },
+    };
+    const r = parseDocumentResponse(doc);
+    expect(r.snapshot.paragraphs).toHaveLength(2);
+    expect(r.snapshot.paragraphs.map((p) => p.text)).toEqual(["OK", "Also OK"]);
+  });
+
+  it("handles paragraphs with multiple textRun elements", () => {
+    const doc = {
+      documentId: "D",
+      title: "T",
+      body: {
+        content: [
+          {
+            startIndex: 1,
+            endIndex: 30,
+            paragraph: {
+              elements: [
+                { textRun: { content: "Hello " } },
+                { textRun: { content: "world" } },
+                { textRun: { content: "!\n" } },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const r = parseDocumentResponse(doc);
+    expect(r.snapshot.paragraphs[0]!.text).toBe("Hello world!");
+  });
+
+  it("handles paragraphs with no textRun elements (e.g. inline-image-only)", () => {
+    const doc = {
+      documentId: "D",
+      title: "T",
+      body: {
+        content: [
+          {
+            startIndex: 1,
+            endIndex: 10,
+            paragraph: {
+              elements: [{ inlineObjectElement: { inlineObjectId: "obj1" } }],
+            },
+          },
+        ],
+      },
+    };
+    const r = parseDocumentResponse(doc);
+    expect(r.snapshot.paragraphs[0]!.text).toBe("");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// fetchDocumentSnapshot — HTTP integration
+// ────────────────────────────────────────────────────────────────────────
+
+describe("fetchDocumentSnapshot — request shape", () => {
+  it("calls documents.get with bearer auth and the right URL", async () => {
+    let observedUrl = "";
+    let observedAuth = "";
+    const fetchImpl = mockFetch((url, init) => {
+      observedUrl = url;
+      const h = (init.headers ?? {}) as Record<string, string>;
+      observedAuth = h.Authorization;
+      return jsonResp(sampleDoc);
+    });
+    await fetchDocumentSnapshot({
+      access_token: "TOK",
+      document_id: "DOC1ABCDEF",
+      fetchImpl,
+    });
+    expect(observedUrl).toBe("https://docs.googleapis.com/v1/documents/DOC1ABCDEF");
+    expect(observedAuth).toBe("Bearer TOK");
+  });
+
+  it("forwards suggestions_view_mode as a query param", async () => {
+    let observedUrl = "";
+    const fetchImpl = mockFetch((url) => {
+      observedUrl = url;
+      return jsonResp(sampleDoc);
+    });
+    await fetchDocumentSnapshot({
+      access_token: "TOK",
+      document_id: "DOC1ABCDEF",
+      suggestions_view_mode: "PREVIEW_WITHOUT_SUGGESTIONS",
+      fetchImpl,
+    });
+    expect(observedUrl).toContain("suggestionsViewMode=PREVIEW_WITHOUT_SUGGESTIONS");
+  });
+
+  it("throws on non-2xx with status in the message", async () => {
+    const fetchImpl = mockFetch(
+      () => new Response("Unauthorized", { status: 401, statusText: "Unauthorized" }),
+    );
+    await expect(
+      fetchDocumentSnapshot({ access_token: "TOK", document_id: "DOC1ABCDEF", fetchImpl }),
+    ).rejects.toThrow(/401/);
+  });
+
+  it("rejects malformed document_id (URL-injection guard)", async () => {
+    const fetchImpl = mockFetch(() => jsonResp(sampleDoc));
+    await expect(
+      fetchDocumentSnapshot({ access_token: "TOK", document_id: "../etc/passwd", fetchImpl }),
+    ).rejects.toThrow(/invalid document_id/);
+  });
+});

--- a/src/drive/docs-get.ts
+++ b/src/drive/docs-get.ts
@@ -1,0 +1,260 @@
+/**
+ * Google Docs API `documents.get` client + parser — RFC E §4.2.
+ *
+ * The PreToolUse hook (Path A Cut 2) intercepts upstream
+ * `mcp__google-workspace__*` write tools and needs the doc's
+ * paragraph structure to translate the agent's char-offset
+ * `start_index` into a wrapper-attested location string. The
+ * upstream MCP doesn't expose the unparsed Docs response shape, so
+ * switchroom calls Docs API v1 directly using the same access token
+ * the broker hands out.
+ *
+ * What this module ships:
+ *   - `fetchDocumentSnapshot(args)`: HTTP call + parse to
+ *     `DocumentSnapshot` (from `anchors.ts`) with paragraph-level
+ *     `startOffset`/`endOffset` populated. Drops non-paragraph
+ *     `body.content[]` elements (tables, page breaks, section
+ *     breaks) — the reverse-anchor resolver handles their gaps as
+ *     literal-offset fallbacks.
+ *   - `parseDocumentResponse(raw)`: pure parser, exported for tests
+ *     so the HTTP client doesn't have to be exercised every time.
+ *
+ * Used only by the PreToolUse hook today. Could be reused if more
+ * features need read access to doc structure, but the agent-facing
+ * read tools live in `taylorwilsdon/google_workspace_mcp` — this is
+ * deliberately a private hook-side path.
+ */
+
+import type {
+  DocumentSnapshot,
+  HeadingParagraph,
+  Paragraph,
+  TextParagraph,
+} from "./anchors.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Public types
+// ────────────────────────────────────────────────────────────────────────
+
+export interface FetchDocumentOptions {
+  /** Bearer token from auth-broker `get-credentials` (provider=google). */
+  access_token: string;
+  /** Drive doc id. */
+  document_id: string;
+  /** Test injection seam. */
+  fetchImpl?: typeof fetch;
+  /**
+   * Optional include suggestions in the response. Default `DEFAULT_FOR_CURRENT_ACCESS`
+   * which matches what upstream MCP does for its read tools.
+   */
+  suggestions_view_mode?:
+    | "DEFAULT_FOR_CURRENT_ACCESS"
+    | "SUGGESTIONS_INLINE"
+    | "PREVIEW_SUGGESTIONS_ACCEPTED"
+    | "PREVIEW_WITHOUT_SUGGESTIONS";
+}
+
+export interface FetchDocumentResult {
+  /** The doc's title from Docs API `title` field. */
+  title: string;
+  /** Doc id (echoed for callers that pipe this straight into card builders). */
+  document_id: string;
+  /** Parsed paragraph tree, with offsets, ready for `describeOffset`. */
+  snapshot: DocumentSnapshot;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// HTTP client
+// ────────────────────────────────────────────────────────────────────────
+
+const DRIVE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Call `documents.get` and parse the response into a structured
+ * snapshot. Throws on non-2xx response or malformed body.
+ *
+ * Auth failure (401) is surfaced as an Error — the caller (hook)
+ * maps that to the existing invalid_grant reconnect path. Rate
+ * limits (429) and other 5xx errors get the literal HTTP status
+ * in the error message so the hook's log line is diagnostic.
+ */
+export async function fetchDocumentSnapshot(
+  options: FetchDocumentOptions,
+): Promise<FetchDocumentResult> {
+  if (!DRIVE_ID_RE.test(options.document_id)) {
+    throw new Error(
+      `Docs documents.get: invalid document_id '${options.document_id.slice(0, 30)}' — expected URL-safe-base64`,
+    );
+  }
+
+  const url = new URL(
+    `https://docs.googleapis.com/v1/documents/${encodeURIComponent(options.document_id)}`,
+  );
+  if (options.suggestions_view_mode !== undefined) {
+    url.searchParams.set("suggestionsViewMode", options.suggestions_view_mode);
+  }
+
+  const resp = await (options.fetchImpl ?? fetch)(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${options.access_token}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!resp.ok) {
+    const body = await safeReadText(resp);
+    throw new Error(
+      `Docs documents.get failed: HTTP ${resp.status} ${resp.statusText}${body ? ` — ${body}` : ""}`,
+    );
+  }
+
+  const raw = (await resp.json()) as unknown;
+  return parseDocumentResponse(raw);
+}
+
+async function safeReadText(resp: Response): Promise<string | null> {
+  try {
+    const t = await resp.text();
+    return t.length > 200 ? `${t.slice(0, 200)}…` : t;
+  } catch {
+    return null;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Parser
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Docs API response → DocumentSnapshot.
+ *
+ * The Docs v1 response shape we care about:
+ *   {
+ *     title: string,
+ *     documentId: string,
+ *     body: { content: [
+ *       { startIndex, endIndex, paragraph: { elements: [{ textRun: { content } }], paragraphStyle: { namedStyleType } } },
+ *       { startIndex, endIndex, table: ... },           // skipped
+ *       { startIndex, endIndex, sectionBreak: ... },    // skipped
+ *       { startIndex, endIndex, tableOfContents: ... }, // skipped
+ *     ] }
+ *   }
+ *
+ * paragraphStyle.namedStyleType determines whether a paragraph is a
+ * heading: `HEADING_1` through `HEADING_6` map to levels 1-6;
+ * anything else (`NORMAL_TEXT`, `TITLE`, `SUBTITLE`, undefined) is
+ * a text paragraph.
+ *
+ * Pure — no I/O — so tests can verify the gap-handling, heading
+ * level mapping, and edge cases without an HTTP stub.
+ */
+export function parseDocumentResponse(raw: unknown): FetchDocumentResult {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new Error(
+      `Docs documents.get returned non-object body (got ${describeShape(raw)})`,
+    );
+  }
+  const doc = raw as Record<string, unknown>;
+  const documentId = typeof doc.documentId === "string" ? doc.documentId : "";
+  if (!DRIVE_ID_RE.test(documentId)) {
+    throw new Error(
+      `Docs documents.get response missing valid documentId (got '${String(doc.documentId).slice(0, 30)}')`,
+    );
+  }
+  const title = typeof doc.title === "string" ? doc.title : "";
+  const body = doc.body as Record<string, unknown> | undefined;
+  const contentArr = body !== undefined && Array.isArray(body.content)
+    ? (body.content as Array<Record<string, unknown>>)
+    : [];
+
+  const paragraphs: Paragraph[] = [];
+  let nextIndex = 1; // matches the .index field convention used by the forward resolver
+
+  for (const element of contentArr) {
+    if (typeof element !== "object" || element === null) continue;
+    const startOffset = numberOr(element.startIndex);
+    const endOffset = numberOr(element.endIndex);
+    if (startOffset === null || endOffset === null) continue;
+    if (endOffset <= startOffset) continue;
+
+    const paragraph = element.paragraph as Record<string, unknown> | undefined;
+    if (paragraph === undefined) {
+      // Table / sectionBreak / tableOfContents / etc. — skip;
+      // describeOffset's interior-gap branch handles offsets that
+      // land in these regions.
+      continue;
+    }
+
+    const text = flattenParagraphText(paragraph);
+    const headingLevel = headingLevelFromStyle(paragraph);
+    if (headingLevel !== null) {
+      const h: HeadingParagraph = {
+        kind: "heading",
+        level: headingLevel,
+        text,
+        index: nextIndex,
+        startOffset,
+        endOffset,
+      };
+      paragraphs.push(h);
+    } else {
+      const p: TextParagraph = {
+        kind: "text",
+        text,
+        index: nextIndex,
+        startOffset,
+        endOffset,
+      };
+      paragraphs.push(p);
+    }
+    nextIndex += 1;
+  }
+
+  return {
+    title,
+    document_id: documentId,
+    snapshot: { paragraphs },
+  };
+}
+
+function flattenParagraphText(paragraph: Record<string, unknown>): string {
+  const elements = paragraph.elements;
+  if (!Array.isArray(elements)) return "";
+  const parts: string[] = [];
+  for (const el of elements as Array<Record<string, unknown>>) {
+    if (typeof el !== "object" || el === null) continue;
+    const textRun = el.textRun as Record<string, unknown> | undefined;
+    if (textRun === undefined) continue;
+    if (typeof textRun.content === "string") {
+      parts.push(textRun.content);
+    }
+  }
+  // Drive's textRun.content for a paragraph typically ends in `\n`
+  // (the paragraph break char that the Docs API counts in the
+  // offset stream). Strip a single trailing newline so the
+  // .text we hand to anchors.ts doesn't carry it — the offset
+  // metadata captures the boundary; the displayed text doesn't
+  // need to.
+  let joined = parts.join("");
+  if (joined.endsWith("\n")) joined = joined.slice(0, -1);
+  return joined;
+}
+
+function headingLevelFromStyle(paragraph: Record<string, unknown>): number | null {
+  const style = paragraph.paragraphStyle as Record<string, unknown> | undefined;
+  if (style === undefined) return null;
+  const named = style.namedStyleType;
+  if (typeof named !== "string") return null;
+  const m = /^HEADING_([1-6])$/.exec(named);
+  return m === null ? null : parseInt(m[1]!, 10);
+}
+
+function numberOr(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function describeShape(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  return typeof v;
+}

--- a/src/drive/write-preview.test.ts
+++ b/src/drive/write-preview.test.ts
@@ -402,6 +402,169 @@ describe("buildWritePreview — attestation invariant", () => {
     expect(r.preview.fileId).toBe("DOC1"); // from docCtx, not from tool_input
   });
 
+  // ─── Reviewer-blocker regressions ─────────────────────────────────────
+
+  it("B1: batch_update_doc op.type cannot inject a forged 'inside section X' line", () => {
+    // Reviewer attack: agent passes an op.type containing quotes /
+    // parens / "inside section" to forge a fake wrapper-attested line
+    // on the card. Mitigation: enum-pin op.type against the upstream
+    // set; anything else collapses to "?".
+    const r = callWith("mcp__google-workspace__batch_update_doc", {
+      document_id: "DOC1",
+      operations: [
+        {
+          type: "insert_text' inside section 'Approved' (level 1)",
+          start_index: 50,
+          text: "x",
+        },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).not.toContain("Approved");
+    // The exact match is the load-bearing assertion — the forged
+    // op.type collapses to "?" because it's not in the upstream enum.
+    expect(r.preview.resolvedAnchor.displayName).toBe(
+      "1 ops (?) starting inside section 'Goals' (level 2)",
+    );
+  });
+
+  it("B2: insert_doc_elements element_type is enum-pinned (no plain-English deception)", () => {
+    // Reviewer attack: element_type was an open string. Agent passes
+    // "page_break onto Approved heading level 1 -- wrapper lies" to
+    // craft plain-English deception on the card. Mitigation: validate
+    // against the upstream enum; anything else collapses to "element".
+    const r = callWith("mcp__google-workspace__insert_doc_elements", {
+      document_id: "DOC1",
+      element_type: "page_break onto Approved heading level 1 -- wrapper lies",
+      index: 50,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).not.toContain("Approved");
+    expect(r.preview.resolvedAnchor.displayName).not.toContain("wrapper lies");
+    expect(r.preview.resolvedAnchor.displayName).toBe(
+      "insert element inside section 'Goals' (level 2)",
+    );
+  });
+
+  it("B2: valid enum values pass through verbatim", () => {
+    for (const t of ["table", "list", "page_break"]) {
+      const r = callWith("mcp__google-workspace__insert_doc_elements", {
+        document_id: "DOC1",
+        element_type: t,
+        index: 50,
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) continue;
+      expect(r.preview.resolvedAnchor.displayName).toContain(`insert ${t}`);
+    }
+  });
+
+  it("B3: modify_doc_text refuses tab_id (off-body — would mis-attest body location)", () => {
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "DOC1",
+      tab_id: "TAB1",
+      start_index: 50,
+      text: "x",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("off_body_target");
+    expect(r.detail).toContain("tab_id");
+  });
+
+  it("B3: modify_doc_text refuses segment_id (off-body)", () => {
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "DOC1",
+      segment_id: "header-id-1",
+      start_index: 50,
+      text: "x",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("off_body_target");
+    expect(r.detail).toContain("segment_id");
+  });
+
+  it("B3: modify_doc_text refuses end_of_segment === true (off-body)", () => {
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "DOC1",
+      end_of_segment: true,
+      text: "x",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("off_body_target");
+    expect(r.detail).toContain("end_of_segment");
+  });
+
+  it("B3: modify_doc_text with tab_id='' and end_of_segment=false stays on body", () => {
+    // Defensive: empty string tab_id and falsy end_of_segment must
+    // NOT trip the off-body refusal (these are upstream's "not set"
+    // signals).
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "DOC1",
+      tab_id: "",
+      end_of_segment: false,
+      start_index: 50,
+      text: "x",
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("B3: batch_update_doc refuses when any op targets off-body", () => {
+    const r = callWith("mcp__google-workspace__batch_update_doc", {
+      document_id: "DOC1",
+      operations: [
+        { type: "insert_text", start_index: 50, text: "x" }, // body op
+        { type: "insert_text", tab_id: "TAB1", start_index: 0, text: "y" },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("off_body_target");
+  });
+
+  it("B3: create_table_with_data refuses tab_id", () => {
+    const r = callWith("mcp__google-workspace__create_table_with_data", {
+      document_id: "DOC1",
+      tab_id: "TAB1",
+      index: 50,
+      table_data: [["A", "B"]],
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("off_body_target");
+  });
+
+  it("B3: update_paragraph_style refuses segment_id", () => {
+    const r = callWith("mcp__google-workspace__update_paragraph_style", {
+      document_id: "DOC1",
+      segment_id: "footer-id",
+      start_index: 50,
+      end_index: 60,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("off_body_target");
+  });
+
+  it("batch_update_doc op count reflects real entries, not array length (sparse-array defence)", () => {
+    const r = callWith("mcp__google-workspace__batch_update_doc", {
+      document_id: "DOC1",
+      operations: [
+        { type: "insert_text", start_index: 50, text: "x" },
+        null,
+        "not an object",
+        { type: "delete_text", start_index: 60, end_index: 70 },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toContain("2 ops");
+  });
+
   it("preview.mode is always 'write' — Suggesting mode is not reachable via upstream MCP", () => {
     const r = callWith("mcp__google-workspace__modify_doc_text", {
       document_id: "DOC1",

--- a/src/drive/write-preview.test.ts
+++ b/src/drive/write-preview.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Tests for the write-preview spec builder — RFC E §4.2 Path A Cut 2.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { DocumentSnapshot } from "./anchors.js";
+import {
+  GATED_DRIVE_WRITE_TOOLS,
+  buildWritePreview,
+  stripPrefix,
+} from "./write-preview.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ────────────────────────────────────────────────────────────────────────
+
+const sampleSnapshot: DocumentSnapshot = {
+  paragraphs: [
+    { kind: "heading", level: 1, text: "Q3 Plan", index: 1, startOffset: 1, endOffset: 18 },
+    { kind: "text", text: "Intro paragraph.", index: 2, startOffset: 18, endOffset: 36 },
+    { kind: "heading", level: 2, text: "Goals", index: 3, startOffset: 36, endOffset: 44 },
+    { kind: "text", text: "Ship the picker.", index: 4, startOffset: 44, endOffset: 62 },
+    { kind: "heading", level: 2, text: "Hiring", index: 5, startOffset: 62, endOffset: 72 },
+    { kind: "text", text: "TBD.", index: 6, startOffset: 72, endOffset: 78 },
+  ],
+};
+
+const docCtx = {
+  title: "Q3 Strategy Notes",
+  document_id: "DOC1",
+  snapshot: sampleSnapshot,
+};
+
+function callWith(
+  toolName: string,
+  toolInput: unknown,
+): ReturnType<typeof buildWritePreview> {
+  return buildWritePreview({
+    agentName: "klanker",
+    toolName,
+    toolInput,
+    doc: docCtx,
+    mimeType: "application/vnd.google-apps.document",
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// stripPrefix
+// ────────────────────────────────────────────────────────────────────────
+
+describe("stripPrefix", () => {
+  it("strips the google-workspace MCP prefix", () => {
+    expect(stripPrefix("mcp__google-workspace__modify_doc_text")).toBe("modify_doc_text");
+  });
+  it("returns null for non-MCP tool names", () => {
+    expect(stripPrefix("Read")).toBeNull();
+    expect(stripPrefix("mcp__hindsight__sync_retain")).toBeNull();
+    expect(stripPrefix("")).toBeNull();
+  });
+});
+
+describe("GATED_DRIVE_WRITE_TOOLS", () => {
+  it("includes the canonical mutation tools", () => {
+    expect(GATED_DRIVE_WRITE_TOOLS.has("modify_doc_text")).toBe(true);
+    expect(GATED_DRIVE_WRITE_TOOLS.has("find_and_replace_doc")).toBe(true);
+    expect(GATED_DRIVE_WRITE_TOOLS.has("batch_update_doc")).toBe(true);
+    expect(GATED_DRIVE_WRITE_TOOLS.has("manage_doc_tab")).toBe(true);
+  });
+  it("excludes read tools + Drive metadata tools (out of scope for this hook)", () => {
+    expect(GATED_DRIVE_WRITE_TOOLS.has("get_doc_content")).toBe(false);
+    expect(GATED_DRIVE_WRITE_TOOLS.has("update_drive_file")).toBe(false);
+    expect(GATED_DRIVE_WRITE_TOOLS.has("manage_drive_access")).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// buildWritePreview — refusal cases
+// ────────────────────────────────────────────────────────────────────────
+
+describe("buildWritePreview — refuses unrecognised inputs", () => {
+  it("refuses non-MCP-google tool names", () => {
+    const r = callWith("Read", {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("unrecognized_tool");
+  });
+
+  it("refuses unknown MCP-google tool names (allows safe fall-through)", () => {
+    const r = callWith("mcp__google-workspace__future_new_tool", {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("unrecognized_tool");
+  });
+
+  it("refuses non-object tool_input", () => {
+    const r = callWith("mcp__google-workspace__modify_doc_text", "not an object");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("missing_required_arg");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Per-tool: modify_doc_text
+// ────────────────────────────────────────────────────────────────────────
+
+describe("modify_doc_text", () => {
+  it("renders wrapper-attested location for an insert in a section", () => {
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "DOC1",
+      start_index: 50, // inside "Ship the picker." paragraph under Goals
+      text: "Updated plan.\n",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toBe("inside section 'Goals' (level 2)");
+    expect(r.preview.metrics.linesAdded).toBe(1);
+    expect(r.preview.metrics.linesRemoved).toBe(0);
+    expect(r.preview.fileId).toBe("DOC1");
+    expect(r.preview.docTitle).toBe("Q3 Strategy Notes");
+  });
+
+  it("counts removed lines when end_index > start_index (replace)", () => {
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "DOC1",
+      start_index: 50,
+      end_index: 75, // spans into "Hiring" section
+      text: "Replacement.",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.metrics.linesRemoved).toBeGreaterThan(0);
+  });
+
+  it("falls back to literal offset when document snapshot has no offset metadata", () => {
+    const r = buildWritePreview({
+      agentName: "klanker",
+      toolName: "mcp__google-workspace__modify_doc_text",
+      toolInput: { document_id: "DOC1", start_index: 50, text: "x" },
+      doc: { title: "X", document_id: "DOC1", snapshot: { paragraphs: [] } },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toBe("at offset 50");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Per-tool: find_and_replace_doc
+// ────────────────────────────────────────────────────────────────────────
+
+describe("find_and_replace_doc", () => {
+  it("renders 'every match of <find>' displayName + sanitizes find text", () => {
+    const r = callWith("mcp__google-workspace__find_and_replace_doc", {
+      document_id: "DOC1",
+      find_text: "TBD",
+      replace_text: "Done\nFollowup",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toBe("every match of 'TBD'");
+    expect(r.preview.metrics.linesAdded).toBe(2);
+  });
+
+  it("strips markdown / control chars from find_text in the displayName", () => {
+    const r = callWith("mcp__google-workspace__find_and_replace_doc", {
+      document_id: "DOC1",
+      find_text: "Foo `code` [click](evil)",
+      replace_text: "Bar",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).not.toContain("`");
+    expect(r.preview.resolvedAnchor.displayName).not.toContain("[");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Per-tool: insert_doc_elements
+// ────────────────────────────────────────────────────────────────────────
+
+describe("insert_doc_elements", () => {
+  it("renders 'insert <type> <location>' with sanitized element_type", () => {
+    const r = callWith("mcp__google-workspace__insert_doc_elements", {
+      document_id: "DOC1",
+      element_type: "table",
+      index: 50,
+      rows: 3,
+      columns: 4,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toContain("insert table");
+    expect(r.preview.resolvedAnchor.displayName).toContain("inside section 'Goals'");
+  });
+});
+
+describe("insert_doc_image", () => {
+  it("renders 'insert image <location>'", () => {
+    const r = callWith("mcp__google-workspace__insert_doc_image", {
+      document_id: "DOC1",
+      image_source: "https://example.com/img.png",
+      index: 50,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toContain("insert image");
+    expect(r.preview.resolvedAnchor.displayName).toContain("Goals");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Per-tool: batch_update_doc
+// ────────────────────────────────────────────────────────────────────────
+
+describe("batch_update_doc", () => {
+  it("aggregates multiple ops with op types + lowest offset location", () => {
+    const r = callWith("mcp__google-workspace__batch_update_doc", {
+      document_id: "DOC1",
+      operations: [
+        { type: "insert_text", start_index: 70, text: "Add to Hiring.\n" },
+        { type: "find_replace", find_text: "TBD", replace_text: "Done" },
+        { type: "insert_table", index: 50, rows: 2, columns: 3 },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toContain("3 ops");
+    expect(r.preview.resolvedAnchor.displayName).toContain("insert_text");
+    expect(r.preview.resolvedAnchor.displayName).toContain("starting inside section 'Goals'");
+    // Sum of text contributions: insert_text "Add to Hiring.\n" = 1
+    // line, find_replace "Done" = 1 line, insert_table no text = 0.
+    expect(r.preview.metrics.linesAdded).toBe(2);
+  });
+
+  it("truncates the op-types list to 3 + 'more'", () => {
+    const ops = Array.from({ length: 7 }, (_, i) => ({
+      type: `op_${i}`,
+      start_index: 50 + i,
+    }));
+    const r = callWith("mcp__google-workspace__batch_update_doc", {
+      document_id: "DOC1",
+      operations: ops,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toContain("+4 more");
+  });
+
+  it("refuses when operations is missing", () => {
+    const r = callWith("mcp__google-workspace__batch_update_doc", {
+      document_id: "DOC1",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("missing_required_arg");
+  });
+
+  it("falls back to 'across doc' when no op has a numeric offset", () => {
+    const r = callWith("mcp__google-workspace__batch_update_doc", {
+      document_id: "DOC1",
+      operations: [
+        { type: "find_replace", find_text: "x", replace_text: "y" },
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toContain("across doc");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Per-tool: rest
+// ────────────────────────────────────────────────────────────────────────
+
+describe("create_table_with_data", () => {
+  it("renders 'insert N-row table'", () => {
+    const r = callWith("mcp__google-workspace__create_table_with_data", {
+      document_id: "DOC1",
+      index: 50,
+      table_data: [
+        ["A", "B"],
+        ["C", "D"],
+        ["E", "F"],
+      ],
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toContain("3-row table");
+    expect(r.preview.metrics.linesAdded).toBe(3);
+  });
+});
+
+describe("update_doc_headers_footers", () => {
+  it("renders 'update <header|footer>'", () => {
+    const r = callWith("mcp__google-workspace__update_doc_headers_footers", {
+      document_id: "DOC1",
+      section_type: "header",
+      content: "New header line",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toBe("update header");
+    expect(r.preview.metrics.linesAdded).toBe(1);
+  });
+});
+
+describe("update_paragraph_style", () => {
+  it("renders 'restyle paragraphs <location>' (no line delta)", () => {
+    const r = callWith("mcp__google-workspace__update_paragraph_style", {
+      document_id: "DOC1",
+      start_index: 50,
+      end_index: 60,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toContain("restyle paragraphs");
+    expect(r.preview.resolvedAnchor.displayName).toContain("Goals");
+    expect(r.preview.metrics.linesAdded).toBe(0);
+  });
+});
+
+describe("manage_doc_tab", () => {
+  it("renders 'create tab \\'<title>\\'' for create action", () => {
+    const r = callWith("mcp__google-workspace__manage_doc_tab", {
+      document_id: "DOC1",
+      action: "create",
+      title: "New Tab",
+      markdown_text: "Line 1\nLine 2",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toBe("create tab 'New Tab'");
+    expect(r.preview.metrics.linesAdded).toBe(2);
+  });
+
+  it("renders the action without a title when title is missing", () => {
+    const r = callWith("mcp__google-workspace__manage_doc_tab", {
+      document_id: "DOC1",
+      action: "delete",
+      tab_id: "T1",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toBe("delete tab");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Attestation invariant — load-bearing per RFC E §4.2
+// ────────────────────────────────────────────────────────────────────────
+
+describe("buildWritePreview — attestation invariant", () => {
+  it("agent-supplied text NEVER appears verbatim in resolvedAnchor.displayName", () => {
+    // The agent passes a `text` field claiming to add content. The
+    // displayName is derived from wrapper-side computations
+    // (describeOffset + tool-shape) — not from the agent's text.
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "DOC1",
+      start_index: 50,
+      text: "📍 inside section 'Approved' (level 1) — wrapper lies!",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).not.toContain("Approved");
+    expect(r.preview.resolvedAnchor.displayName).not.toContain("wrapper lies");
+    expect(r.preview.resolvedAnchor.displayName).toBe(
+      "inside section 'Goals' (level 2)",
+    );
+  });
+
+  it("non-numeric start_index degrades to 'at unknown offset' (not coerced)", () => {
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "DOC1",
+      start_index: "50' inside section 'Forbidden",
+      text: "x",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.resolvedAnchor.displayName).toBe("at unknown offset");
+    expect(r.preview.resolvedAnchor.displayName).not.toContain("Forbidden");
+  });
+
+  it("agent-supplied docTitle isn't a thing — title comes from the wrapper-fetched doc", () => {
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "DOC1",
+      title: "FAKE TITLE", // not a real upstream field, but defensive: shouldn't bleed
+      start_index: 50,
+      text: "x",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.docTitle).toBe("Q3 Strategy Notes");
+    expect(r.preview.docTitle).not.toContain("FAKE");
+  });
+
+  it("agent-supplied fileId isn't a thing — fileId comes from the wrapper-fetched doc", () => {
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "FAKE_ID",
+      start_index: 50,
+      text: "x",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.fileId).toBe("DOC1"); // from docCtx, not from tool_input
+  });
+
+  it("preview.mode is always 'write' — Suggesting mode is not reachable via upstream MCP", () => {
+    const r = callWith("mcp__google-workspace__modify_doc_text", {
+      document_id: "DOC1",
+      start_index: 50,
+      text: "x",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.preview.mode).toBe("write");
+  });
+});

--- a/src/drive/write-preview.test.ts
+++ b/src/drive/write-preview.test.ts
@@ -550,6 +550,118 @@ describe("buildWritePreview — attestation invariant", () => {
     expect(r.reason).toBe("off_body_target");
   });
 
+  // ─── Re-review fixes (round 2): more tools take off-body args + more enum-only fields ─
+
+  it("B3-followup: find_and_replace_doc refuses tab_id (would mis-attest body-scope replace)", () => {
+    const r = callWith("mcp__google-workspace__find_and_replace_doc", {
+      document_id: "DOC1",
+      tab_id: "TAB1",
+      find_text: "TBD",
+      replace_text: "Done",
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("off_body_target");
+    expect(r.detail).toContain("tab_id");
+  });
+
+  it("B2-followup: update_doc_headers_footers section_type is enum-pinned", () => {
+    // Plain-English deception attempt:
+    const r1 = callWith("mcp__google-workspace__update_doc_headers_footers", {
+      document_id: "DOC1",
+      section_type: "footer onto Approved heading -- lies",
+      content: "x",
+    });
+    expect(r1.ok).toBe(true);
+    if (!r1.ok) return;
+    expect(r1.preview.resolvedAnchor.displayName).toBe("update section");
+    expect(r1.preview.resolvedAnchor.displayName).not.toContain("Approved");
+
+    // Legitimate values pass through:
+    for (const t of ["header", "footer"]) {
+      const r = callWith("mcp__google-workspace__update_doc_headers_footers", {
+        document_id: "DOC1",
+        section_type: t,
+        content: "x",
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) continue;
+      expect(r.preview.resolvedAnchor.displayName).toBe(`update ${t}`);
+    }
+  });
+
+  it("B2-followup: manage_doc_tab action is enum-pinned", () => {
+    const r1 = callWith("mcp__google-workspace__manage_doc_tab", {
+      document_id: "DOC1",
+      action: "create' inside section 'Approved",
+      title: "x",
+    });
+    expect(r1.ok).toBe(true);
+    if (!r1.ok) return;
+    expect(r1.preview.resolvedAnchor.displayName).toBe("? tab 'x'");
+    expect(r1.preview.resolvedAnchor.displayName).not.toContain("Approved");
+
+    // Legitimate values pass through:
+    for (const a of ["create", "rename", "delete", "populate_from_markdown"]) {
+      const r = callWith("mcp__google-workspace__manage_doc_tab", {
+        document_id: "DOC1",
+        action: a,
+        title: "X",
+      });
+      expect(r.ok).toBe(true);
+      if (!r.ok) continue;
+      expect(r.preview.resolvedAnchor.displayName).toBe(`${a} tab 'X'`);
+    }
+  });
+
+  it("B3-followup: detectOffBodyTargeting catches non-string truthy values", () => {
+    // Reviewer attack: pass tab_id as a number / array / object. Older
+    // truthiness gate required `typeof === "string" && length > 0`,
+    // missing these. Upstream might coerce to a valid id; we MUST
+    // refuse rather than render a body-scope card.
+    for (const tabId of [1, [1, 2], { id: "x" }, true]) {
+      const r = callWith("mcp__google-workspace__modify_doc_text", {
+        document_id: "DOC1",
+        tab_id: tabId,
+        start_index: 50,
+        text: "x",
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.reason).toBe("off_body_target");
+    }
+  });
+
+  it("B3-followup: end_of_segment truthy non-true values still trip the refusal", () => {
+    for (const eos of [1, "true", { x: 1 }, [true]]) {
+      const r = callWith("mcp__google-workspace__modify_doc_text", {
+        document_id: "DOC1",
+        end_of_segment: eos,
+        text: "x",
+      });
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.reason).toBe("off_body_target");
+    }
+  });
+
+  it("B3-followup: '0' / null / false / empty-string / undefined are correctly treated as 'not set'", () => {
+    // The defensive cases — these are upstream's "not set" signals,
+    // the hook MUST NOT trip the refusal on them.
+    for (const eos of [false, 0, null, undefined]) {
+      for (const tab of ["", null, undefined]) {
+        const r = callWith("mcp__google-workspace__modify_doc_text", {
+          document_id: "DOC1",
+          end_of_segment: eos,
+          tab_id: tab,
+          start_index: 50,
+          text: "x",
+        });
+        expect(r.ok).toBe(true);
+      }
+    }
+  });
+
   it("batch_update_doc op count reflects real entries, not array length (sparse-array defence)", () => {
     const r = callWith("mcp__google-workspace__batch_update_doc", {
       document_id: "DOC1",

--- a/src/drive/write-preview.ts
+++ b/src/drive/write-preview.ts
@@ -210,22 +210,49 @@ function modifyDocText(
  *     segment (header/footer/tab end), NOT at end of body
  */
 function detectOffBodyTargeting(input: Record<string, unknown>): string | null {
-  if (typeof input.tab_id === "string" && input.tab_id.length > 0) {
-    return "tab_id";
-  }
-  if (typeof input.segment_id === "string" && input.segment_id.length > 0) {
-    return "segment_id";
-  }
-  if (input.end_of_segment === true) {
+  // Truthiness gate is broad — non-string truthy values
+  // (`tab_id: 1`, `tab_id: {}`, `end_of_segment: 1`) MUST still
+  // trip the off-body refusal because upstream's argument coercion
+  // could turn them into a valid tab/segment id. The only inputs
+  // that mean "not set" are: undefined, null, empty string, false,
+  // 0. Anything else gets treated as "operator-controlled
+  // off-body targeting" and we refuse rather than render a
+  // body-stream location string.
+  if (isTruthyNonEmpty(input.tab_id)) return "tab_id";
+  if (isTruthyNonEmpty(input.segment_id)) return "segment_id";
+  if (input.end_of_segment !== undefined && input.end_of_segment !== false && input.end_of_segment !== 0 && input.end_of_segment !== null) {
     return "end_of_segment";
   }
   return null;
+}
+
+function isTruthyNonEmpty(v: unknown): boolean {
+  if (v === undefined || v === null) return false;
+  if (typeof v === "string") return v.length > 0;
+  if (typeof v === "boolean") return v;
+  if (typeof v === "number") return v !== 0 && Number.isFinite(v);
+  // Objects, arrays, anything else — treat as set. The card MUST
+  // refuse rather than guess about coercion behaviour.
+  return true;
 }
 
 function findAndReplace(
   args: BuildWritePreviewArgs,
   input: Record<string, unknown>,
 ): BuildWritePreviewResult {
+  // RFC §4.2 attestation: upstream's find_and_replace_doc accepts
+  // a `tab_id` to scope the replacement to a single tab. The card
+  // would otherwise render "every match of '<find>'" with no tab
+  // qualifier, falsely implying body-scope. Refuse rather than
+  // mis-attest.
+  const offBody = detectOffBodyTargeting(input);
+  if (offBody !== null) {
+    return {
+      ok: false,
+      reason: "off_body_target",
+      detail: `find_and_replace_doc uses ${offBody}; refusing to attest a body-scope replace for an off-body call`,
+    };
+  }
   const findText = stringOr(input.find_text, "");
   const replaceText = stringOr(input.replace_text, "");
   // find_and_replace doesn't take offsets — wrap the location as
@@ -409,15 +436,23 @@ function createTable(
   return ok(args, resolved, rowCount, 0);
 }
 
+// Upstream `update_doc_headers_footers.section_type` is enum-bound
+// to `header | footer`. Enum-pin so an agent can't smuggle
+// arbitrary plain-English deception via this field.
+const HEADER_FOOTER_SECTION_TYPES = new Set<string>(["header", "footer"]);
+
 function updateHeadersFooters(
   args: BuildWritePreviewArgs,
   input: Record<string, unknown>,
 ): BuildWritePreviewResult {
-  const sectionType = stringOr(input.section_type, "header");
+  const rawSection = stringOr(input.section_type, "");
+  const sectionType = HEADER_FOOTER_SECTION_TYPES.has(rawSection)
+    ? rawSection
+    : "section";
   const content = stringOr(input.content, "");
   const resolved: ResolvedAnchor = {
     op: { kind: "replace_paragraph", paragraphIndex: -1 },
-    displayName: `update ${truncateLine(sectionType)}`,
+    displayName: `update ${sectionType}`,
   };
   return ok(args, resolved, countLines(content), 0);
 }
@@ -443,15 +478,26 @@ function updateParagraphStyle(
   return ok(args, resolved, 0, 0);
 }
 
+// Upstream `manage_doc_tab.action` is enum-bound. Enum-pin so the
+// agent can't smuggle plain-English deception in the
+// `<action> tab '<title>'` displayName.
+const MANAGE_DOC_TAB_ACTIONS = new Set<string>([
+  "create",
+  "rename",
+  "delete",
+  "populate_from_markdown",
+]);
+
 function manageDocTab(
   args: BuildWritePreviewArgs,
   input: Record<string, unknown>,
 ): BuildWritePreviewResult {
-  const action = stringOr(input.action, "?");
+  const rawAction = stringOr(input.action, "");
+  const action = MANAGE_DOC_TAB_ACTIONS.has(rawAction) ? rawAction : "?";
   const title = stringOr(input.title, "");
   const resolved: ResolvedAnchor = {
     op: { kind: "insert_after", paragraphIndex: -1 },
-    displayName: `${truncateLine(action)} tab${title ? ` '${truncateLine(title)}'` : ""}`,
+    displayName: `${action} tab${title ? ` '${truncateLine(title)}'` : ""}`,
   };
   // markdown_text drives the line count when populating; otherwise 0
   const md = stringOr(input.markdown_text, "");

--- a/src/drive/write-preview.ts
+++ b/src/drive/write-preview.ts
@@ -346,6 +346,14 @@ const BATCH_UPDATE_OP_TYPES = new Set<string>([
   "update_document_style",
   "update_section_style",
   "create_header_footer",
+  // Round-3 review followup — additional valid upstream ops the
+  // initial pin missed. Without these, legit agent calls collapse
+  // to "?" on the card (under-accurate, not forgery). Source:
+  // `taylorwilsdon/google_workspace_mcp` `gdocs/docs_tools.py:1242-1248`.
+  "insert_image",
+  "insert_doc_tab",
+  "delete_doc_tab",
+  "update_doc_tab",
 ]);
 
 function batchUpdateDoc(

--- a/src/drive/write-preview.ts
+++ b/src/drive/write-preview.ts
@@ -70,7 +70,11 @@ export interface BuildWritePreviewArgs {
 
 export type BuildWritePreviewResult =
   | { ok: true; preview: DiffPreviewInput }
-  | { ok: false; reason: "unrecognized_tool" | "missing_required_arg"; detail: string };
+  | {
+      ok: false;
+      reason: "unrecognized_tool" | "missing_required_arg" | "off_body_target";
+      detail: string;
+    };
 
 export function buildWritePreview(
   args: BuildWritePreviewArgs,
@@ -154,6 +158,24 @@ function modifyDocText(
   args: BuildWritePreviewArgs,
   input: Record<string, unknown>,
 ): BuildWritePreviewResult {
+  // RFC §4.2 attestation blocker: `tab_id`, `segment_id`, and
+  // `end_of_segment` all redirect the write off the main body —
+  // into a tab / header / footer / footnote / end-of-segment that
+  // `documents.get`'s body-only paragraph stream cannot describe.
+  // Refusing here is the safer call than rendering a body-stream
+  // location string that doesn't match where the bytes will land.
+  // The hook surfaces the refusal as a block-decision to the
+  // operator, who can then choose to grant access via a different
+  // path or deny the write.
+  const offBody = detectOffBodyTargeting(input);
+  if (offBody !== null) {
+    return {
+      ok: false,
+      reason: "off_body_target",
+      detail: `modify_doc_text uses ${offBody} which redirects the write off the main body — refusing to attest a body-stream location for an off-body edit`,
+    };
+  }
+
   const startIndex = numberOr(input.start_index, NaN);
   const endIndex = numberOr(input.end_index, NaN);
   const text = stringOr(input.text, "");
@@ -173,6 +195,31 @@ function modifyDocText(
   const linesRemoved = isReplace ? estimateRemovedLines(args.doc.snapshot, startIndex, endIndex) : 0;
 
   return ok(args, resolved, linesAdded, linesRemoved);
+}
+
+/**
+ * Detect off-body targeting that would make the wrapper-attested
+ * body-stream location wrong. Returns a short human-readable name
+ * for the field that triggered the detection, or null when the
+ * input targets the main body.
+ *
+ * Upstream surface (from taylorwilsdon/google_workspace_mcp):
+ *   - `tab_id`: edit lands in the named tab, not the main body
+ *   - `segment_id`: edit lands in a footnote/header/footer segment
+ *   - `end_of_segment === true`: edit lands at end of the current
+ *     segment (header/footer/tab end), NOT at end of body
+ */
+function detectOffBodyTargeting(input: Record<string, unknown>): string | null {
+  if (typeof input.tab_id === "string" && input.tab_id.length > 0) {
+    return "tab_id";
+  }
+  if (typeof input.segment_id === "string" && input.segment_id.length > 0) {
+    return "segment_id";
+  }
+  if (input.end_of_segment === true) {
+    return "end_of_segment";
+  }
+  return null;
 }
 
 function findAndReplace(
@@ -204,16 +251,26 @@ function findAndReplace(
   );
 }
 
+// Upstream `insert_doc_elements.element_type` is enum-bound — see
+// `taylorwilsdon/google_workspace_mcp` `gdocs/docs_tools.py`. We
+// pin against the known set so an attacker can't smuggle plain-
+// English deception (e.g. `"page_break onto Approved heading level
+// 1"`) into the displayName.
+const INSERT_DOC_ELEMENT_TYPES = new Set<string>(["table", "list", "page_break"]);
+
 function insertDocElements(
   args: BuildWritePreviewArgs,
   input: Record<string, unknown>,
 ): BuildWritePreviewResult {
   const index = numberOr(input.index, NaN);
-  const elementType = stringOr(input.element_type, "element");
+  const rawElementType = stringOr(input.element_type, "");
+  const elementType = INSERT_DOC_ELEMENT_TYPES.has(rawElementType)
+    ? rawElementType
+    : "element";
   const description = describeOffset(args.doc.snapshot, index);
   const resolved: ResolvedAnchor = {
     op: { kind: "insert_after", paragraphIndex: -1 },
-    displayName: `insert ${truncateLine(elementType)} ${description.displayName}`,
+    displayName: `insert ${elementType} ${description.displayName}`,
   };
   return ok(args, resolved, 1, 0);
 }
@@ -231,6 +288,39 @@ function insertDocImage(
   return ok(args, resolved, 1, 0);
 }
 
+// Upstream `batch_update_doc.operations[].type` is enum-bound to
+// the set of mutation kinds the upstream MCP supports. We pin
+// against the known set so an attacker can't smuggle quote /
+// parenthesis attestation forgeries via the displayName-embedded
+// type label. Full set from `taylorwilsdon/google_workspace_mcp`
+// `gdocs/docs_tools.py:1139-1240`.
+const BATCH_UPDATE_OP_TYPES = new Set<string>([
+  "insert_text",
+  "delete_text",
+  "replace_text",
+  "format_text",
+  "update_paragraph_style",
+  "update_table_cell_style",
+  "insert_table",
+  "insert_table_row",
+  "delete_table_row",
+  "insert_table_column",
+  "delete_table_column",
+  "merge_table_cells",
+  "unmerge_table_cells",
+  "update_table_column_properties",
+  "insert_page_break",
+  "insert_section_break",
+  "find_replace",
+  "create_bullet_list",
+  "create_named_range",
+  "replace_named_range_content",
+  "delete_named_range",
+  "update_document_style",
+  "update_section_style",
+  "create_header_footer",
+]);
+
 function batchUpdateDoc(
   args: BuildWritePreviewArgs,
   input: Record<string, unknown>,
@@ -243,14 +333,37 @@ function batchUpdateDoc(
       detail: "batch_update_doc requires operations: array",
     };
   }
-  // Aggregate: count distinct mutation ops, find the lowest start
-  // offset for the location surface.
-  let minOffset = Number.POSITIVE_INFINITY;
-  let opTypes: string[] = [];
-  let totalAdded = 0;
+  // RFC §4.2 attestation: if ANY op targets off-body (tab_id /
+  // segment_id / end_of_segment), refuse the whole batch. We
+  // can't faithfully attest a body-stream location for a batch
+  // that mixes body + off-body ops, and partial attestation would
+  // be worse than refusal.
   for (const op of ops as Array<Record<string, unknown>>) {
     if (typeof op !== "object" || op === null) continue;
-    const type = stringOr(op.type, "?");
+    const offBody = detectOffBodyTargeting(op);
+    if (offBody !== null) {
+      return {
+        ok: false,
+        reason: "off_body_target",
+        detail: `batch_update_doc op uses ${offBody} which redirects off the main body — refusing to attest a body-stream location for an off-body batch`,
+      };
+    }
+  }
+  // Aggregate: count distinct mutation ops, find the lowest start
+  // offset for the location surface. Only count real-object entries
+  // toward the displayed op-count so a sparse array with garbage
+  // entries doesn't inflate the user-visible total.
+  let minOffset = Number.POSITIVE_INFINITY;
+  const opTypes: string[] = [];
+  let totalAdded = 0;
+  let realOpCount = 0;
+  for (const op of ops as Array<Record<string, unknown>>) {
+    if (typeof op !== "object" || op === null) continue;
+    realOpCount += 1;
+    // Pin against the upstream enum — anything else collapses to
+    // "?" so the displayName remains structurally clean.
+    const rawType = stringOr(op.type, "");
+    const type = BATCH_UPDATE_OP_TYPES.has(rawType) ? rawType : "?";
     opTypes.push(type);
     const start = numberOr(op.start_index ?? op.index, NaN);
     if (Number.isFinite(start) && start < minOffset) {
@@ -268,7 +381,7 @@ function batchUpdateDoc(
       : `${opTypes.slice(0, 3).join(", ")} +${opTypes.length - 3} more`;
   const resolved: ResolvedAnchor = {
     op: { kind: "insert_after", paragraphIndex: -1 },
-    displayName: `${ops.length} ops (${typesLabel}) starting ${description}`,
+    displayName: `${realOpCount} ops (${typesLabel}) starting ${description}`,
   };
   return ok(args, resolved, totalAdded, 0);
 }
@@ -277,6 +390,14 @@ function createTable(
   args: BuildWritePreviewArgs,
   input: Record<string, unknown>,
 ): BuildWritePreviewResult {
+  const offBody = detectOffBodyTargeting(input);
+  if (offBody !== null) {
+    return {
+      ok: false,
+      reason: "off_body_target",
+      detail: `create_table_with_data uses ${offBody}; refusing to attest a body-stream location`,
+    };
+  }
   const index = numberOr(input.index, NaN);
   const data = input.table_data;
   const rowCount = Array.isArray(data) ? data.length : 0;
@@ -305,6 +426,14 @@ function updateParagraphStyle(
   args: BuildWritePreviewArgs,
   input: Record<string, unknown>,
 ): BuildWritePreviewResult {
+  const offBody = detectOffBodyTargeting(input);
+  if (offBody !== null) {
+    return {
+      ok: false,
+      reason: "off_body_target",
+      detail: `update_paragraph_style uses ${offBody}; refusing to attest a body-stream location`,
+    };
+  }
   const startIndex = numberOr(input.start_index, NaN);
   const description = describeOffset(args.doc.snapshot, startIndex);
   const resolved: ResolvedAnchor = {

--- a/src/drive/write-preview.ts
+++ b/src/drive/write-preview.ts
@@ -1,0 +1,407 @@
+/**
+ * Diff-preview spec builder for the PreToolUse Drive-write hook —
+ * RFC E §4.2 Path A Cut 2.
+ *
+ * Takes:
+ *   1. An upstream `mcp__google-workspace__*` write tool name + its
+ *      raw `tool_input` JSON (what the agent passed).
+ *   2. A `FetchDocumentResult` (from `docs-get.ts`) — doc title +
+ *      paragraph snapshot with offsets.
+ *
+ * Returns a `DiffPreviewInput` ready to feed `buildDiffPreview()`
+ * (and from there `buildDiffPreviewCard()` for the actual Telegram
+ * render).
+ *
+ * What this module ISN'T:
+ *   - Not the HTTP client (that's `docs-get.ts`).
+ *   - Not the kernel/IPC/Telegram caller (that's PR-2B + PR-2C).
+ *   - Not the agent-summary parser (the agent doesn't supply one
+ *     today — the hook receives raw tool_input from Claude Code,
+ *     not a synthesized "intent" string. Future cuts may add an
+ *     out-of-band sidecar; for now `agentSummary` stays undefined).
+ *
+ * Tool-shape-specific logic lives here because each upstream tool
+ * encodes "where" and "what" differently:
+ *   - `modify_doc_text` uses `start_index` + `text`
+ *   - `find_and_replace_doc` uses `find_text` (no offset)
+ *   - `insert_doc_elements` uses `index` + `element_type`
+ *   - `batch_update_doc` uses a heterogeneous `operations[]` array
+ *   - `create_doc` / `create_drive_file` use no offset (top of doc)
+ *   - `update_drive_file` / `manage_drive_access` are metadata-only
+ *
+ * Each gets a translator below that produces a uniform
+ * `DiffPreviewInput`. Tools we don't recognise return null — the
+ * hook falls back to letting the tool fire ungated (defensive
+ * default: hook gates known shapes only, so an upstream MCP
+ * version bump that adds a new tool doesn't break agents).
+ */
+
+import { describeOffset, type DocumentSnapshot, type ResolvedAnchor } from "./anchors.js";
+import type { DiffPreviewInput } from "./diff-preview.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Public API
+// ────────────────────────────────────────────────────────────────────────
+
+export interface BuildWritePreviewArgs {
+  /** Agent slug — appears on the diff-preview card title. */
+  agentName: string;
+  /** Tool name as Claude Code sees it: `mcp__google-workspace__<fn>`. */
+  toolName: string;
+  /**
+   * The raw tool_input the agent passed. Treated as untrusted JSON
+   * — every field accessor narrows via runtime check.
+   */
+  toolInput: unknown;
+  /** `documents.get` result for the doc the agent is editing. */
+  doc: {
+    title: string;
+    document_id: string;
+    snapshot: DocumentSnapshot;
+  };
+  /**
+   * mimeType to feed the Open-in-Drive deep-link. Always
+   * `application/vnd.google-apps.document` for Docs writes; passed
+   * in rather than hard-coded so a future Sheets/Slides write
+   * tool can reuse this path.
+   */
+  mimeType?: string;
+}
+
+export type BuildWritePreviewResult =
+  | { ok: true; preview: DiffPreviewInput }
+  | { ok: false; reason: "unrecognized_tool" | "missing_required_arg"; detail: string };
+
+export function buildWritePreview(
+  args: BuildWritePreviewArgs,
+): BuildWritePreviewResult {
+  const input = args.toolInput;
+  if (typeof input !== "object" || input === null) {
+    return {
+      ok: false,
+      reason: "missing_required_arg",
+      detail: "tool_input is not a JSON object",
+    };
+  }
+  const toolFn = stripPrefix(args.toolName);
+  if (toolFn === null) {
+    return {
+      ok: false,
+      reason: "unrecognized_tool",
+      detail: `tool name '${args.toolName}' is not an MCP google-workspace tool`,
+    };
+  }
+  const inputObj = input as Record<string, unknown>;
+
+  switch (toolFn) {
+    case "modify_doc_text":
+      return modifyDocText(args, inputObj);
+    case "find_and_replace_doc":
+      return findAndReplace(args, inputObj);
+    case "insert_doc_elements":
+      return insertDocElements(args, inputObj);
+    case "insert_doc_image":
+      return insertDocImage(args, inputObj);
+    case "batch_update_doc":
+      return batchUpdateDoc(args, inputObj);
+    case "create_table_with_data":
+      return createTable(args, inputObj);
+    case "update_doc_headers_footers":
+      return updateHeadersFooters(args, inputObj);
+    case "update_paragraph_style":
+      return updateParagraphStyle(args, inputObj);
+    case "manage_doc_tab":
+      return manageDocTab(args, inputObj);
+    default:
+      return {
+        ok: false,
+        reason: "unrecognized_tool",
+        detail: `tool '${toolFn}' has no diff-preview translator (gating skipped)`,
+      };
+  }
+}
+
+// Tool names we know about. The hook script imports this so the
+// PreToolUse matcher can skip the heavy work for non-gated calls.
+export const GATED_DRIVE_WRITE_TOOLS = new Set<string>([
+  "modify_doc_text",
+  "find_and_replace_doc",
+  "insert_doc_elements",
+  "insert_doc_image",
+  "batch_update_doc",
+  "create_table_with_data",
+  "update_doc_headers_footers",
+  "update_paragraph_style",
+  "manage_doc_tab",
+]);
+
+/**
+ * Mirrors how Claude Code prefixes MCP tools. The configured server
+ * label in switchroom is `google-workspace` (see
+ * `examples/personal-google-workspace-mcp/README.md`).
+ */
+export function stripPrefix(toolName: string): string | null {
+  const prefix = "mcp__google-workspace__";
+  if (!toolName.startsWith(prefix)) return null;
+  return toolName.slice(prefix.length);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Per-tool translators
+// ────────────────────────────────────────────────────────────────────────
+
+function modifyDocText(
+  args: BuildWritePreviewArgs,
+  input: Record<string, unknown>,
+): BuildWritePreviewResult {
+  const startIndex = numberOr(input.start_index, NaN);
+  const endIndex = numberOr(input.end_index, NaN);
+  const text = stringOr(input.text, "");
+
+  const description = describeOffset(args.doc.snapshot, startIndex);
+  const resolved: ResolvedAnchor = {
+    op: { kind: "insert_after", paragraphIndex: -1 },
+    displayName: description.displayName,
+  };
+
+  // `modify_doc_text` is the most flexible upstream tool — it can
+  // insert (when start==end), replace (start<end with text), or
+  // delete (start<end without text). All three are mutations the
+  // user should see.
+  const isReplace = Number.isFinite(endIndex) && endIndex > startIndex;
+  const linesAdded = countLines(text);
+  const linesRemoved = isReplace ? estimateRemovedLines(args.doc.snapshot, startIndex, endIndex) : 0;
+
+  return ok(args, resolved, linesAdded, linesRemoved);
+}
+
+function findAndReplace(
+  args: BuildWritePreviewArgs,
+  input: Record<string, unknown>,
+): BuildWritePreviewResult {
+  const findText = stringOr(input.find_text, "");
+  const replaceText = stringOr(input.replace_text, "");
+  // find_and_replace doesn't take offsets — wrap the location as
+  // "every match of '<find>'". The agent's search string IS on the
+  // card here, but it's structurally tied to "find X, replace
+  // with Y" semantics that the user can verify, and the wrapper
+  // computes the count of matches (well, after the call lands —
+  // upstream doesn't tell us up front). For pre-flight we surface
+  // "every match" without a count.
+  const resolved: ResolvedAnchor = {
+    op: { kind: "replace_paragraph", paragraphIndex: -1 },
+    displayName: `every match of '${truncateLine(findText)}'`,
+  };
+
+  return ok(
+    args,
+    resolved,
+    countLines(replaceText),
+    // Removed-line estimate is unknown without scanning the doc for
+    // matches; surface 0 and let the user understand "replace" via
+    // the resolved name.
+    0,
+  );
+}
+
+function insertDocElements(
+  args: BuildWritePreviewArgs,
+  input: Record<string, unknown>,
+): BuildWritePreviewResult {
+  const index = numberOr(input.index, NaN);
+  const elementType = stringOr(input.element_type, "element");
+  const description = describeOffset(args.doc.snapshot, index);
+  const resolved: ResolvedAnchor = {
+    op: { kind: "insert_after", paragraphIndex: -1 },
+    displayName: `insert ${truncateLine(elementType)} ${description.displayName}`,
+  };
+  return ok(args, resolved, 1, 0);
+}
+
+function insertDocImage(
+  args: BuildWritePreviewArgs,
+  input: Record<string, unknown>,
+): BuildWritePreviewResult {
+  const index = numberOr(input.index, NaN);
+  const description = describeOffset(args.doc.snapshot, index);
+  const resolved: ResolvedAnchor = {
+    op: { kind: "insert_after", paragraphIndex: -1 },
+    displayName: `insert image ${description.displayName}`,
+  };
+  return ok(args, resolved, 1, 0);
+}
+
+function batchUpdateDoc(
+  args: BuildWritePreviewArgs,
+  input: Record<string, unknown>,
+): BuildWritePreviewResult {
+  const ops = input.operations;
+  if (!Array.isArray(ops)) {
+    return {
+      ok: false,
+      reason: "missing_required_arg",
+      detail: "batch_update_doc requires operations: array",
+    };
+  }
+  // Aggregate: count distinct mutation ops, find the lowest start
+  // offset for the location surface.
+  let minOffset = Number.POSITIVE_INFINITY;
+  let opTypes: string[] = [];
+  let totalAdded = 0;
+  for (const op of ops as Array<Record<string, unknown>>) {
+    if (typeof op !== "object" || op === null) continue;
+    const type = stringOr(op.type, "?");
+    opTypes.push(type);
+    const start = numberOr(op.start_index ?? op.index, NaN);
+    if (Number.isFinite(start) && start < minOffset) {
+      minOffset = start;
+    }
+    const text = stringOr(op.text ?? op.replace_text, "");
+    totalAdded += countLines(text);
+  }
+  const description = Number.isFinite(minOffset)
+    ? describeOffset(args.doc.snapshot, minOffset).displayName
+    : "across doc";
+  const typesLabel =
+    opTypes.length <= 3
+      ? opTypes.join(", ")
+      : `${opTypes.slice(0, 3).join(", ")} +${opTypes.length - 3} more`;
+  const resolved: ResolvedAnchor = {
+    op: { kind: "insert_after", paragraphIndex: -1 },
+    displayName: `${ops.length} ops (${typesLabel}) starting ${description}`,
+  };
+  return ok(args, resolved, totalAdded, 0);
+}
+
+function createTable(
+  args: BuildWritePreviewArgs,
+  input: Record<string, unknown>,
+): BuildWritePreviewResult {
+  const index = numberOr(input.index, NaN);
+  const data = input.table_data;
+  const rowCount = Array.isArray(data) ? data.length : 0;
+  const description = describeOffset(args.doc.snapshot, index);
+  const resolved: ResolvedAnchor = {
+    op: { kind: "insert_after", paragraphIndex: -1 },
+    displayName: `insert ${rowCount}-row table ${description.displayName}`,
+  };
+  return ok(args, resolved, rowCount, 0);
+}
+
+function updateHeadersFooters(
+  args: BuildWritePreviewArgs,
+  input: Record<string, unknown>,
+): BuildWritePreviewResult {
+  const sectionType = stringOr(input.section_type, "header");
+  const content = stringOr(input.content, "");
+  const resolved: ResolvedAnchor = {
+    op: { kind: "replace_paragraph", paragraphIndex: -1 },
+    displayName: `update ${truncateLine(sectionType)}`,
+  };
+  return ok(args, resolved, countLines(content), 0);
+}
+
+function updateParagraphStyle(
+  args: BuildWritePreviewArgs,
+  input: Record<string, unknown>,
+): BuildWritePreviewResult {
+  const startIndex = numberOr(input.start_index, NaN);
+  const description = describeOffset(args.doc.snapshot, startIndex);
+  const resolved: ResolvedAnchor = {
+    op: { kind: "replace_paragraph", paragraphIndex: -1 },
+    displayName: `restyle paragraphs ${description.displayName}`,
+  };
+  return ok(args, resolved, 0, 0);
+}
+
+function manageDocTab(
+  args: BuildWritePreviewArgs,
+  input: Record<string, unknown>,
+): BuildWritePreviewResult {
+  const action = stringOr(input.action, "?");
+  const title = stringOr(input.title, "");
+  const resolved: ResolvedAnchor = {
+    op: { kind: "insert_after", paragraphIndex: -1 },
+    displayName: `${truncateLine(action)} tab${title ? ` '${truncateLine(title)}'` : ""}`,
+  };
+  // markdown_text drives the line count when populating; otherwise 0
+  const md = stringOr(input.markdown_text, "");
+  return ok(args, resolved, countLines(md), 0);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────
+
+function ok(
+  args: BuildWritePreviewArgs,
+  resolved: ResolvedAnchor,
+  linesAdded: number,
+  linesRemoved: number,
+): BuildWritePreviewResult {
+  return {
+    ok: true,
+    preview: {
+      agentName: args.agentName,
+      docTitle: args.doc.title,
+      fileId: args.doc.document_id,
+      resolvedAnchor: resolved,
+      metrics: { linesAdded, linesRemoved },
+      mode: "write",
+      ...(args.mimeType !== undefined ? { mimeType: args.mimeType } : {}),
+    },
+  };
+}
+
+function numberOr(v: unknown, fallback: number): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : fallback;
+}
+
+function stringOr(v: unknown, fallback: string): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  let count = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) count += 1;
+  }
+  if (text.charCodeAt(text.length - 1) === 10) count -= 1;
+  return count;
+}
+
+function estimateRemovedLines(
+  snapshot: DocumentSnapshot,
+  start: number,
+  end: number,
+): number {
+  // Walk paragraphs that overlap [start, end) and sum their line
+  // contribution. Each paragraph counts for at minimum 1 line.
+  let removed = 0;
+  for (const p of snapshot.paragraphs) {
+    if (typeof p.startOffset !== "number" || typeof p.endOffset !== "number") continue;
+    if (p.endOffset <= start) continue;
+    if (p.startOffset >= end) break;
+    removed += 1;
+  }
+  return removed;
+}
+
+/**
+ * Identical-shape sanitizer to `anchors.ts:truncateLine` — kept
+ * local rather than imported because anchors.ts doesn't export it
+ * and the displayName-sanitization concerns are independent here
+ * (this module composes displayName fragments that get passed back
+ * into describeOffset's output via `${frag} ${description.displayName}`).
+ */
+function truncateLine(s: string): string {
+  const cleaned = s
+    // eslint-disable-next-line no-control-regex -- intentional strip of C0 + DEL
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .replace(/[`[\]()]/g, "")
+    .replace(/'/g, "’")
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned.length <= 60 ? cleaned : `${cleaned.slice(0, 59)}…`;
+}

--- a/tests/cli.doctor.hindsight-consumer.test.ts
+++ b/tests/cli.doctor.hindsight-consumer.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { checkHindsightConsumer } from "../src/cli/doctor.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+// Pins the contract that the hindsight-consumer probe queries the broker
+// CONTAINER (which can stat its own bound sockets) rather than the host
+// `/var/lib/docker/volumes/.../sock` path. The latter lives under a
+// root-only-traversable `/var/lib/docker` on common docker.io installs;
+// `existsSync` from the operator UID returns false even when the socket
+// is bound and healthy. See #1281 for the regression.
+
+function configWithConsumer(): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: "~/.switchroom/agents" },
+    telegram: { bot_token: "test-token", forum_chat_id: "-100123" },
+    agents: {},
+    auth: {
+      consumers: [
+        { name: "hindsight", account: "me@example.com", uid: 11000 },
+      ],
+    },
+  } as SwitchroomConfig;
+}
+
+function configWithoutConsumer(): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: "~/.switchroom/agents" },
+    telegram: { bot_token: "test-token", forum_chat_id: "-100123" },
+    agents: {},
+  } as SwitchroomConfig;
+}
+
+describe("checkHindsightConsumer", () => {
+  it("warns when no auth.consumers[] entry named hindsight exists", () => {
+    const result = checkHindsightConsumer(configWithoutConsumer());
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("no `auth.consumers[]` entry named `hindsight`");
+    // Fix points the operator at switchroom.yaml, not at restart magic.
+    expect(result.fix).toContain("auth:");
+    expect(result.fix).toContain("consumers:");
+  });
+
+  it("reports ok when the consumer is declared AND the broker confirms the socket is bound", () => {
+    const result = checkHindsightConsumer(configWithConsumer(), {
+      socketProbe: () => "present",
+    });
+    expect(result.status).toBe("ok");
+    expect(result.detail).toContain("auth.consumers[hindsight]");
+    expect(result.detail).toContain("me@example.com");
+    expect(result.detail).toContain("uid 11000");
+  });
+
+  it("warns with a 'socket not bound' message when the broker says missing", () => {
+    const result = checkHindsightConsumer(configWithConsumer(), {
+      socketProbe: () => "missing",
+    });
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("socket not bound");
+    // The fix points at `switchroom apply`, not raw docker compose —
+    // matches the operator-restart-marker discipline in CLAUDE.md.
+    expect(result.fix).toContain("switchroom apply");
+  });
+
+  it("warns distinctly when the broker container itself is unreachable", () => {
+    // This is the case the regression was about: probe couldn't reach
+    // the broker, but historically it conflated that with "socket not
+    // bound." Operator was told to `switchroom apply` when the real
+    // issue might be docker / broker down. New behaviour routes the
+    // operator to the auth-broker service health row first.
+    const result = checkHindsightConsumer(configWithConsumer(), {
+      socketProbe: () => "unreachable",
+    });
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("couldn't query auth-broker container");
+    expect(result.fix).toContain("service health");
+  });
+
+  it("queries the broker by consumer name, not by a hardcoded path", () => {
+    // Structural pin: the probe receives the consumer name so a future
+    // consumer (e.g. cron, custom MCP) can reuse the same probe shape.
+    // If someone refactors this to a hardcoded "hindsight" string the
+    // probe stops being reusable.
+    let probedName: string | undefined;
+    checkHindsightConsumer(configWithConsumer(), {
+      socketProbe: (name) => {
+        probedName = name;
+        return "present";
+      },
+    });
+    expect(probedName).toBe("hindsight");
+  });
+});


### PR DESCRIPTION
## Summary

Path A Cut 2 of the Drive-write hook epic, **PR-2A of 3**. Pure data-layer helpers — no runtime caller in this PR.

The full Cut 2 is split across three PRs for reviewability:
- **PR-2A (this one)** — Docs API client + write-preview spec builder
- **PR-2B** — Gateway IPC verb that posts the diff-preview card via grammy
- **PR-2C** — The PreToolUse \`.mjs\` hook + scaffold registration + e2e tests

## What ships

**\`src/drive/docs-get.ts\`** — Google Docs API v1 \`documents.get\` client + pure parser
- Bearer auth, URL-safe document_id validation, JSON-shape guard.
- Maps the response to a \`DocumentSnapshot\` (from #1250 / #1314) with paragraph-level offsets.
- HEADING_1..HEADING_6 → heading paragraph; TITLE/SUBTITLE/NORMAL_TEXT/unknown → text paragraph.
- Tables / sectionBreaks / tableOfContents silently skipped (interior gaps fall through to \`describeOffset\`'s literal-offset fallback).

**\`src/drive/write-preview.ts\`** — tool-shape-specific translator
- \`buildWritePreview()\` maps each upstream \`mcp__google-workspace__*\` write tool's argument shape into a uniform \`DiffPreviewInput\`.
- 9 tools in scope: \`modify_doc_text\`, \`find_and_replace_doc\`, \`insert_doc_elements\`, \`insert_doc_image\`, \`batch_update_doc\`, \`create_table_with_data\`, \`update_doc_headers_footers\`, \`update_paragraph_style\`, \`manage_doc_tab\`.
- Out-of-scope tools return \`{ok: false, reason: "unrecognized_tool"}\` so the hook can fall through ungated — whitelist-shaped matcher.
- \`GATED_DRIVE_WRITE_TOOLS\` exported as a Set the hook's PreToolUse matcher uses for the fast no-gate path.

## Attestation invariants pinned by tests (RFC E §4.2)

| Property | Defense |
|---|---|
| Agent text never appears in displayName | Wrapper builds location from \`describeOffset()\` + tool-shape labels |
| Non-numeric \`start_index\` | Degrades to \`"at unknown offset"\` via typeof guard |
| \`docTitle\` / \`fileId\` | From wrapper-fetched doc, never from \`tool_input\` |
| \`mode\` is always \`"write"\` | Honest: upstream MCP doesn't expose Suggesting mode |
| Markdown / control chars | Stripped before embedding in displayName |

## Test plan

- [x] \`bun test src/drive/\` — 404 pass (51 new cases)
- [x] \`bun run lint\` — clean
- [ ] Independent reviewer verdict

## Depends on

#1314 (reverse anchor resolver). This branch is rebased on \`origin/feat/drive-reverse-anchor\`; lands after #1314 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)