### PR TITLE
feat(drive): RFC E §4.2 Cut 2 — gateway IPC verb that posts the diff-preview card (PR-2B)

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -102,7 +102,9 @@ ALLOWLIST=(
   # (~32 lines added earlier in the file shift this band down).
   # Re-bumped 2026-05-15 for the auth-snapshot Format 2 PR
   # (insertions earlier in the file shifted the chunk-loop down).
-  "telegram-plugin/gateway/gateway.ts:3160-3420:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
+  # Re-bumped 2026-05-15 post-Path-A-Cut-2 (drive-write IPC handler
+  # added ~60 lines higher up; chunk-loop callsite shifted further to ~3451).
+  "telegram-plugin/gateway/gateway.ts:3160-3500:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -118,7 +120,9 @@ ALLOWLIST=(
   # (~180 lines added across handleAuthDashboardCallback +
   # fireFleetAutoFallback re-entry guard shifted the vault wizard
   # callsites further down).
-  "telegram-plugin/gateway/gateway.ts:9340-10100:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-15 post-Path-A-Cut-2 (drive-write IPC handler
+  # added ~60 lines).
+  "telegram-plugin/gateway/gateway.ts:9340-10200:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/drive-write-approval.test.ts
+++ b/telegram-plugin/gateway/drive-write-approval.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for the Drive-write IPC handler — RFC E §4.2 Cut 2.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  DriveApprovalPostedEvent,
+  RequestDriveApprovalMessage,
+} from "./ipc-protocol.js";
+import {
+  type DriveApprovalHandlerDeps,
+  handleRequestDriveApproval,
+} from "./drive-write-approval.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ────────────────────────────────────────────────────────────────────────
+
+/** Valid DiffPreviewInput shape — matches src/drive/diff-preview.ts. */
+function validPreview(): Record<string, unknown> {
+  return {
+    agentName: "klanker",
+    docTitle: "Q3 Strategy Notes",
+    fileId: "DOC1",
+    mimeType: "application/vnd.google-apps.document",
+    resolvedAnchor: {
+      op: { kind: "insert_after", paragraphIndex: 4 },
+      displayName: "inside section 'Goals' (level 2)",
+    },
+    metrics: { linesAdded: 5, linesRemoved: 0 },
+    mode: "write",
+  };
+}
+
+interface Spy {
+  sent: DriveApprovalPostedEvent[];
+  registered: Array<{
+    scope: string;
+    action: string;
+    ttl_ms: number;
+    approver_set: string[];
+  }>;
+  posted: Array<{
+    chatId: number | string;
+    threadId?: number;
+    text: string;
+  }>;
+  logs: string[];
+}
+
+function makeSpy(): Spy {
+  return { sent: [], registered: [], posted: [], logs: [] };
+}
+
+function deps(overrides: Partial<DriveApprovalHandlerDeps> & { spy: Spy }): DriveApprovalHandlerDeps {
+  const spy = overrides.spy;
+  return {
+    agentName: "klanker",
+    loadAllowFrom: () => ["12345"],
+    loadTargetChat: () => ({ chatId: 999 }),
+    registerApproval: async (args) => {
+      spy.registered.push({
+        scope: args.scope,
+        action: args.action,
+        ttl_ms: args.ttl_ms,
+        approver_set: args.approver_set,
+      });
+      return { request_id: "aabbccdd", expires_at_ms: Date.now() + args.ttl_ms };
+    },
+    postCard: async (args) => {
+      spy.posted.push({
+        chatId: args.chatId,
+        ...(args.threadId !== undefined ? { threadId: args.threadId } : {}),
+        text: args.text,
+      });
+      return { messageId: 42 };
+    },
+    buildCard: () => ({ text: "diff-preview card body", reply_markup: { stub: true } }),
+    log: (m) => spy.logs.push(m),
+    ...overrides,
+  };
+}
+
+function clientFor(spy: Spy): { send: (msg: unknown) => void } {
+  return {
+    send: (msg) => {
+      const m = msg as DriveApprovalPostedEvent;
+      if (m.type === "drive_approval_posted") spy.sent.push(m);
+    },
+  };
+}
+
+function msgFor(overrides: Partial<RequestDriveApprovalMessage> = {}): RequestDriveApprovalMessage {
+  return {
+    type: "request_drive_approval",
+    correlationId: "corr-1",
+    agentName: "klanker",
+    preview: validPreview(),
+    ...overrides,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Happy path
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — happy path", () => {
+  it("registers the kernel request + posts the card + replies success", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(clientFor(spy), msgFor(), deps({ spy }));
+    expect(spy.registered).toHaveLength(1);
+    expect(spy.registered[0]).toEqual({
+      scope: "doc:gdrive:write:DOC1",
+      action: "write",
+      ttl_ms: 5 * 60 * 1000,
+      approver_set: ["12345"],
+    });
+    expect(spy.posted).toHaveLength(1);
+    expect(spy.posted[0]?.chatId).toBe(999);
+    expect(spy.sent).toHaveLength(1);
+    expect(spy.sent[0]).toMatchObject({
+      type: "drive_approval_posted",
+      correlationId: "corr-1",
+      ok: true,
+      requestId: "aabbccdd",
+    });
+    expect(spy.sent[0]?.expiresAtMs).toBeGreaterThan(Date.now());
+  });
+
+  it("threads threadId through to postCard when targetChat has one", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({ spy, loadTargetChat: () => ({ chatId: 999, threadId: 7 }) }),
+    );
+    expect(spy.posted[0]?.threadId).toBe(7);
+  });
+
+  it("respects a caller-supplied ttlMs (within clamp)", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor({ ttlMs: 90_000 }),
+      deps({ spy }),
+    );
+    expect(spy.registered[0]?.ttl_ms).toBe(90_000);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Refusals
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — refusals", () => {
+  it("refuses cross-agent requests", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor({ agentName: "clerk" }),
+      deps({ spy }),
+    );
+    expect(spy.registered).toEqual([]);
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/serves 'klanker'/);
+  });
+
+  it("refuses malformed preview payloads", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor({ preview: { junk: true } }),
+      deps({ spy }),
+    );
+    expect(spy.registered).toEqual([]);
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/invalid preview/);
+  });
+
+  it("refuses when no operator allowFrom is configured", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({ spy, loadAllowFrom: () => [] }),
+    );
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/allowFrom/);
+  });
+
+  it("refuses when no target chat is available", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({ spy, loadTargetChat: () => null }),
+    );
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/target chat/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Failure modes
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — downstream failures", () => {
+  it("kernel approval_request failure → ok:false with diagnostic reason", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({ spy, registerApproval: async () => null }),
+    );
+    expect(spy.posted).toEqual([]); // card not posted
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/kernel approval_request/);
+  });
+
+  it("card build throw → ok:false (caught + reported)", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({
+        spy,
+        buildCard: () => {
+          throw new Error("invalid request id");
+        },
+      }),
+    );
+    expect(spy.posted).toEqual([]);
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/card build failed/);
+  });
+
+  it("Telegram sendMessage failure → ok:false", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({ spy, postCard: async () => null }),
+    );
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/sendMessage failed/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// TTL clamping
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — TTL clamping", () => {
+  it("clamps below-min TTL up to the minimum", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor({ ttlMs: 1000 }),
+      deps({ spy }),
+    );
+    expect(spy.registered[0]?.ttl_ms).toBe(30_000); // min default
+  });
+
+  it("clamps above-max TTL down to the maximum", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor({ ttlMs: 999_999_999 }),
+      deps({ spy }),
+    );
+    expect(spy.registered[0]?.ttl_ms).toBe(30 * 60 * 1000); // max default
+  });
+
+  it("uses the configured default when ttlMs is undefined", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(clientFor(spy), msgFor(), deps({ spy }));
+    expect(spy.registered[0]?.ttl_ms).toBe(5 * 60 * 1000);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Always responds (no path drops the response)
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — invariant: always sends a reply", () => {
+  it("every refusal path emits exactly one drive_approval_posted event", async () => {
+    const cases: Array<Partial<DriveApprovalHandlerDeps> | "cross-agent" | "bad-preview"> = [
+      "cross-agent",
+      "bad-preview",
+      { loadAllowFrom: () => [] },
+      { loadTargetChat: () => null },
+      { registerApproval: async () => null },
+      { postCard: async () => null },
+    ];
+    for (const c of cases) {
+      const spy = makeSpy();
+      const msg =
+        c === "cross-agent"
+          ? msgFor({ agentName: "clerk" })
+          : c === "bad-preview"
+            ? msgFor({ preview: { bad: true } })
+            : msgFor();
+      const dep =
+        c === "cross-agent" || c === "bad-preview"
+          ? deps({ spy })
+          : deps({ spy, ...c });
+      await handleRequestDriveApproval(clientFor(spy), msg, dep);
+      expect(spy.sent).toHaveLength(1);
+    }
+  });
+});

--- a/telegram-plugin/gateway/drive-write-approval.ts
+++ b/telegram-plugin/gateway/drive-write-approval.ts
@@ -1,0 +1,243 @@
+/**
+ * Drive-write approval handler — RFC E §4.2 Cut 2.
+ *
+ * Called by the gateway's IPC dispatcher when the Drive-write
+ * PreToolUse hook sends a `request_drive_approval` message. The
+ * handler:
+ *
+ *   1. Validates the inbound preview payload via `buildDiffPreview`
+ *      (which fails closed on malformed inputs).
+ *   2. Registers a kernel approval request at scope
+ *      `doc:gdrive:write:<fileId>`, action `write`, approver_set =
+ *      operator allowFrom.
+ *   3. Builds the Telegram card via `buildDiffPreviewCard` (#1299).
+ *   4. Posts the card to the operator chat via grammy.
+ *   5. Sends a `drive_approval_posted` event back over IPC with the
+ *      kernel request_id + expires_at so the hook can poll
+ *      `approval_lookup` for the verdict.
+ *
+ * On any failure the handler sends `drive_approval_posted { ok:
+ * false, reason: ... }` so the hook fails closed (blocks the tool).
+ *
+ * Kept in its own module so the unit tests for the orchestration
+ * (kernel call + card build + post + response) live separately
+ * from the gateway monolith.
+ */
+
+import { buildDiffPreview, type DiffPreviewInput } from "../../src/drive/diff-preview.js";
+import type { IpcClient } from "./ipc-server.js";
+import type {
+  DriveApprovalPostedEvent,
+  RequestDriveApprovalMessage,
+} from "./ipc-protocol.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Injected deps — caller (gateway.ts) wires these from the existing
+// surface area. Kept abstract so the handler unit-tests don't need
+// grammy / the kernel / the gateway in scope.
+// ────────────────────────────────────────────────────────────────────────
+
+export interface DriveApprovalHandlerDeps {
+  /** This gateway's agent name — cross-agent requests rejected. */
+  agentName: string;
+  /**
+   * Operator allowFrom list (Telegram user ids as strings) — used
+   * as the kernel's approver_set, and to pick the target chat for
+   * the card post.
+   */
+  loadAllowFrom: () => string[];
+  /**
+   * The chat (and optional topic) the picker card should land in.
+   * For the standard DM-based operator setup this is the operator's
+   * private chat with the bot; for group-based setups the operator
+   * group chat + the agent's topic id.
+   */
+  loadTargetChat: () => {
+    chatId: number | string;
+    threadId?: number;
+  } | null;
+  /**
+   * Register a kernel approval request. Returns the kernel's
+   * request_id + expires_at_ms on success, null on failure (rate
+   * limit, broker unreachable, etc.).
+   */
+  registerApproval: (args: {
+    agent_unit: string;
+    scope: string;
+    action: string;
+    approver_set: string[];
+    why: string;
+    ttl_ms: number;
+  }) => Promise<{ request_id: string; expires_at_ms: number } | null>;
+  /**
+   * Post the diff-preview card to Telegram. Returns a posted
+   * message id on success, null on failure.
+   */
+  postCard: (args: {
+    chatId: number | string;
+    threadId?: number;
+    text: string;
+    /** grammy's InlineKeyboard, passed straight through. */
+    replyMarkup: unknown;
+  }) => Promise<{ messageId: number } | null>;
+  /**
+   * Build the Telegram-shaped card from a DiffPreview. Pass-through
+   * to `buildDiffPreviewCard` (#1299); deferred via deps so the
+   * handler tests don't need grammy.
+   */
+  buildCard: (args: {
+    preview: ReturnType<typeof buildDiffPreview>;
+    suggestRequestId: string;
+  }) => { text: string; reply_markup: unknown };
+  log?: (msg: string) => void;
+  /** TTL clamping policy. */
+  defaultTtlMs?: number;
+  maxTtlMs?: number;
+  minTtlMs?: number;
+}
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const MIN_TTL_MS = 30 * 1000; // 30 seconds
+
+/**
+ * Top-level handler called by ipc-server's onRequestDriveApproval.
+ * Always sends a single `drive_approval_posted` reply (success or
+ * failure) before returning.
+ */
+export async function handleRequestDriveApproval(
+  client: Pick<IpcClient, "send">,
+  msg: RequestDriveApprovalMessage,
+  deps: DriveApprovalHandlerDeps,
+): Promise<void> {
+  const reply = (event: Omit<DriveApprovalPostedEvent, "type">) => {
+    try {
+      client.send({ type: "drive_approval_posted", ...event });
+    } catch (err) {
+      deps.log?.(
+        `drive_approval_posted send failed (correlation=${msg.correlationId}): ${(err as Error).message}`,
+      );
+    }
+  };
+
+  // 1. Cross-agent guard.
+  if (msg.agentName !== deps.agentName) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: `gateway serves '${deps.agentName}', not '${msg.agentName}'`,
+    });
+    return;
+  }
+
+  // 2. Validate preview shape — buildDiffPreview throws on
+  // malformed inputs (fileId missing, metrics invalid, etc).
+  let preview: ReturnType<typeof buildDiffPreview>;
+  try {
+    preview = buildDiffPreview(msg.preview as unknown as DiffPreviewInput);
+  } catch (err) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: `invalid preview payload: ${(err as Error).message}`,
+    });
+    return;
+  }
+
+  // 3. Pull operator targeting + allowFrom.
+  const allowFrom = deps.loadAllowFrom();
+  if (allowFrom.length === 0) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: "no operator allowFrom configured — cannot route approval",
+    });
+    return;
+  }
+  const target = deps.loadTargetChat();
+  if (target === null) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: "no target chat available — operator not paired?",
+    });
+    return;
+  }
+
+  // 4. TTL clamp.
+  const ttlMs = clampTtl(
+    msg.ttlMs,
+    deps.defaultTtlMs ?? DEFAULT_TTL_MS,
+    deps.minTtlMs ?? MIN_TTL_MS,
+    deps.maxTtlMs ?? MAX_TTL_MS,
+  );
+
+  // 5. Kernel approval request.
+  const fileId = preview.audit.wrapperAttested.fileId;
+  const scope = `doc:gdrive:write:${fileId}`;
+  const registered = await deps.registerApproval({
+    agent_unit: deps.agentName,
+    scope,
+    action: "write",
+    approver_set: allowFrom,
+    why: `Drive write — ${preview.audit.wrapperAttested.docTitle}`,
+    ttl_ms: ttlMs,
+  });
+  if (registered === null) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: "kernel approval_request failed (rate limit or broker unreachable)",
+    });
+    return;
+  }
+
+  // 6. Build + post the card.
+  let card: { text: string; reply_markup: unknown };
+  try {
+    card = deps.buildCard({ preview, suggestRequestId: registered.request_id });
+  } catch (err) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: `card build failed: ${(err as Error).message}`,
+    });
+    return;
+  }
+  const posted = await deps.postCard({
+    chatId: target.chatId,
+    ...(target.threadId !== undefined ? { threadId: target.threadId } : {}),
+    text: card.text,
+    replyMarkup: card.reply_markup,
+  });
+  if (posted === null) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: "Telegram sendMessage failed",
+    });
+    return;
+  }
+
+  deps.log?.(
+    `drive_approval_posted ok correlation=${msg.correlationId} request_id=${registered.request_id} file=${fileId}`,
+  );
+  reply({
+    correlationId: msg.correlationId,
+    ok: true,
+    requestId: registered.request_id,
+    expiresAtMs: registered.expires_at_ms,
+  });
+}
+
+function clampTtl(
+  requested: number | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const t = requested === undefined || !Number.isFinite(requested) ? fallback : requested;
+  if (t < min) return min;
+  if (t > max) return max;
+  return t;
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -225,6 +225,11 @@ import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 
 import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js'
+import { handleRequestDriveApproval } from './drive-write-approval.js'
+import { buildDiffPreviewCard } from './diff-preview-card.js'
+import {
+  approvalRequest as kernelApprovalRequest,
+} from '../../src/vault/approvals/client.js'
 import { createPendingInboundBuffer } from './pending-inbound-buffer.js'
 import {
   buildVaultGrantApprovedInbound,
@@ -3033,6 +3038,69 @@ const ipcServer: IpcServer = createIpcServer({
    * Logs every fire so an operator can correlate the agent's
    * transcript turn against the scheduler's audit row by `prompt_key`.
    */
+  async onRequestDriveApproval(client: IpcClient, msg) {
+    // RFC E §4.2 Cut 2 — Drive-write PreToolUse hook is asking the
+    // gateway to post a diff-preview card so the user can decide.
+    await handleRequestDriveApproval(client, msg, {
+      agentName: getMyAgentName(),
+      loadAllowFrom: () => loadAccess().allowFrom,
+      loadTargetChat: () => {
+        const access = loadAccess()
+        const operator = access.allowFrom[0]
+        if (operator === undefined) return null
+        // For DM-paired setups the target chat IS the operator's
+        // user id. For group setups the gateway already has a topic
+        // routing surface (see how /folders posts) — this picks the
+        // DM path which is the common case; group-routing follow-up
+        // can extend this.
+        return { chatId: operator }
+      },
+      registerApproval: async (args) => {
+        const r = await kernelApprovalRequest({
+          agent_unit: args.agent_unit,
+          scope: args.scope,
+          action: args.action,
+          approver_set: args.approver_set,
+          why: args.why,
+          ttl_ms: args.ttl_ms,
+        })
+        if (r === null || r.state === 'rate_limited') return null
+        return {
+          request_id: r.request_id,
+          expires_at_ms: r.expires_at,
+        }
+      },
+      postCard: async (args) => {
+        try {
+          const sent = await robustApiCall(
+            () =>
+              bot.api.sendMessage(args.chatId, args.text, {
+                parse_mode: 'HTML',
+                ...(args.threadId !== undefined
+                  ? { message_thread_id: args.threadId }
+                  : {}),
+                reply_markup: args.replyMarkup as never,
+              }),
+            {
+              chat_id: String(args.chatId),
+              verb: 'drive-approval-card',
+              ...(args.threadId !== undefined ? { threadId: args.threadId } : {}),
+            },
+          )
+          return { messageId: (sent as { message_id: number }).message_id }
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: drive-approval postCard failed: ${(err as Error).message}\n`,
+          )
+          return null
+        }
+      },
+      buildCard: ({ preview, suggestRequestId }) =>
+        buildDiffPreviewCard({ preview, suggestRequestId }),
+      log: (m) => process.stderr.write(`telegram gateway: drive-approval — ${m}\n`),
+    })
+  },
+
   onInjectInbound(_client: IpcClient, msg: InjectInboundMessage) {
     const promptKey = typeof msg.inbound.meta?.prompt_key === 'string'
       ? msg.inbound.meta.prompt_key

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -59,12 +59,47 @@ export interface ScheduleRestartResult {
   error?: string;
 }
 
+/**
+ * RFC E §4.2 Cut 2 — sent by the gateway to acknowledge that a
+ * Drive-write approval card has been posted (or that posting
+ * failed). The Drive-write PreToolUse hook (a separate process)
+ * uses the `request_id` to poll the kernel's `approval_lookup` for
+ * the verdict; if posting fails, the hook fails closed.
+ *
+ * Why response-shaped: the hook is synchronous from Claude Code's
+ * perspective (PreToolUse blocks the tool call). The hook can't
+ * return its `decision: "approve" | "block"` until either the
+ * card has been posted (so the user can decide) OR posting failed
+ * (so the hook can return block immediately). A response message
+ * is the cleanest way to surface that.
+ */
+export interface DriveApprovalPostedEvent {
+  type: "drive_approval_posted";
+  /** Same correlation_id the client sent on the request. */
+  correlationId: string;
+  ok: boolean;
+  /**
+   * Kernel request_id the hook will pass to `approval_lookup` once
+   * it starts polling. Only present when `ok: true`.
+   */
+  requestId?: string;
+  /**
+   * Unix-ms expiry of the kernel request, mirrors the ttl_ms the
+   * gateway used. Hook uses this as its polling deadline. Only
+   * present when `ok: true`.
+   */
+  expiresAtMs?: number;
+  /** Diagnostic detail on failure. */
+  reason?: string;
+}
+
 export type GatewayToClient =
   | InboundMessage
   | PermissionEvent
   | StatusEvent
   | ToolCallResult
-  | ScheduleRestartResult;
+  | ScheduleRestartResult
+  | DriveApprovalPostedEvent;
 
 // === Bridge (Client) -> Gateway messages ===
 
@@ -189,6 +224,51 @@ export interface InjectInboundMessage {
   inbound: InboundMessage;
 }
 
+/**
+ * RFC E §4.2 Cut 2 — sent by the Drive-write PreToolUse hook to
+ * the gateway to register a diff-preview approval card with the
+ * kernel + post it to Telegram. The hook waits on the
+ * corresponding `drive_approval_posted` reply (matching
+ * `correlationId`), then polls `approval_lookup` for the verdict.
+ *
+ * The `preview` payload is shaped like
+ * `src/drive/diff-preview.ts:DiffPreviewInput`. We don't restate
+ * the full shape on the wire — the IPC validator does a structural
+ * check (required fields present, types right) and the gateway-side
+ * consumer feeds it straight to `buildDiffPreview()` which is
+ * already defensive against malformed inputs.
+ *
+ * Trust model: same as `inject_inbound` — the gateway socket lives
+ * inside the agent container, only that-UID processes can connect,
+ * so the hook is as trusted as anything else in the container.
+ */
+export interface RequestDriveApprovalMessage {
+  type: "request_drive_approval";
+  /**
+   * Hook-generated correlation id (any unique string ≤ 64 chars).
+   * Echoed back in `drive_approval_posted` so the hook can match
+   * the response if multiple Drive-write taps are in flight.
+   */
+  correlationId: string;
+  /**
+   * Target agent the gateway serves. Defense in depth — the gateway
+   * verifies this matches its own SWITCHROOM_AGENT_NAME and refuses
+   * cross-agent requests.
+   */
+  agentName: string;
+  /**
+   * DiffPreviewInput payload — see `src/drive/diff-preview.ts`.
+   * Carried as an opaque object on the wire; the gateway
+   * deserialises it via `buildDiffPreview()`.
+   */
+  preview: Record<string, unknown>;
+  /**
+   * TTL for the kernel approval request, in ms. Hook typically
+   * passes 5 min; gateway clamps to a sensible range.
+   */
+  ttlMs?: number;
+}
+
 export type ClientToGateway =
   | RegisterMessage
   | ToolCallMessage
@@ -199,4 +279,5 @@ export type ClientToGateway =
   | OperatorEventForward
   | PtyPartialForward
   | UpdatePlaceholderMessage
-  | InjectInboundMessage;
+  | InjectInboundMessage
+  | RequestDriveApprovalMessage;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -8,6 +8,7 @@ import type {
   PermissionRequestForward,
   PtyPartialForward,
   RegisterMessage,
+  RequestDriveApprovalMessage,
   ScheduleRestartMessage,
   SessionEventForward,
   ToolCallMessage,
@@ -40,6 +41,18 @@ export interface IpcServerOptions {
    * inline scheduler simply ignore inject_inbound messages.
    */
   onInjectInbound?: (client: IpcClient, msg: InjectInboundMessage) => void;
+  /**
+   * RFC E §4.2 Cut 2 — Drive-write PreToolUse hook asks the gateway
+   * to register a kernel approval request + post a diff-preview
+   * card to Telegram. Handler is expected to send a
+   * `drive_approval_posted` event back over the same connection
+   * (`client.send(...)`). Optional: gateways without the hook
+   * configured ignore these messages.
+   */
+  onRequestDriveApproval?: (
+    client: IpcClient,
+    msg: RequestDriveApprovalMessage,
+  ) => Promise<void>;
   log?: (msg: string) => void;
   /**
    * How long (in ms) to wait without a heartbeat before force-closing the
@@ -192,6 +205,23 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
         && typeof inb.meta === "object"
         && inb.meta !== null;
     }
+    case "request_drive_approval": {
+      // RFC E §4.2 Cut 2. Validate the wire-shaped fields the
+      // gateway will route on; the inner `preview` is treated as
+      // an opaque object and gets defensively re-validated by
+      // `buildDiffPreview()` downstream.
+      if (typeof m.correlationId !== "string"
+        || (m.correlationId as string).length === 0
+        || (m.correlationId as string).length > 64) return false;
+      if (typeof m.agentName !== "string"
+        || !AGENT_NAME_RE.test(m.agentName as string)) return false;
+      if (typeof m.preview !== "object" || m.preview === null) return false;
+      if (m.ttlMs !== undefined
+        && (typeof m.ttlMs !== "number"
+          || !Number.isFinite(m.ttlMs)
+          || (m.ttlMs as number) < 0)) return false;
+      return true;
+    }
     default:
       return false;
   }
@@ -210,6 +240,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onOperatorEvent,
     onPtyPartial,
     onInjectInbound,
+    onRequestDriveApproval,
     log = () => {},
     heartbeatTimeoutMs = 30_000,
   } = options;
@@ -297,6 +328,44 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
         break;
       case "inject_inbound":
         if (onInjectInbound) onInjectInbound(client, msg as InjectInboundMessage);
+        break;
+      case "request_drive_approval":
+        if (onRequestDriveApproval) {
+          // Handler is async — fire-and-forget here; the handler
+          // is responsible for sending its `drive_approval_posted`
+          // response (success or failure) back to the client.
+          onRequestDriveApproval(client, msg as RequestDriveApprovalMessage).catch(
+            (err) => {
+              log(
+                `request_drive_approval handler threw (client=${client.id}): ${(err as Error).message}`,
+              );
+              try {
+                client.send({
+                  type: "drive_approval_posted",
+                  correlationId: (msg as RequestDriveApprovalMessage).correlationId,
+                  ok: false,
+                  reason: `gateway handler error: ${(err as Error).message}`,
+                });
+              } catch {
+                /* best effort */
+              }
+            },
+          );
+        } else {
+          // No handler wired — fail closed and tell the hook so it
+          // can fall back to blocking the tool. Better than leaving
+          // the hook timing out.
+          try {
+            client.send({
+              type: "drive_approval_posted",
+              correlationId: (msg as RequestDriveApprovalMessage).correlationId,
+              ok: false,
+              reason: "gateway not configured for Drive-write approval",
+            });
+          } catch {
+            /* best effort */
+          }
+        }
         break;
       case "update_placeholder":
         // Legacy recall.py IPC — placeholder UX was removed in #553 PR 5.


### PR DESCRIPTION
## Summary

Path A Cut 2, **PR-2B of 3**. The runtime side that turns PR-2A's preview spec into a real Telegram approval card.

## Architecture

\`\`\`
agent container
├── PreToolUse hook (PR-2C, .mjs script)
│     reads tool_input, fetches doc, builds preview spec via
│     buildWritePreview() (PR-2A), then…
│     sends IPC \`request_drive_approval\` to gateway
│     waits for \`drive_approval_posted\` reply on same socket
│     polls kernel approval_lookup until verdict
│     returns {decision: approve|block} to Claude Code
│
└── gateway sidecar (this PR's territory)
      on \`request_drive_approval\`:
        1. validate cross-agent + preview shape
        2. kernel approval_request → request_id + expires_at
        3. buildDiffPreviewCard (#1299) → {text, reply_markup}
        4. robustApiCall(bot.api.sendMessage) → post to operator chat
        5. reply \`drive_approval_posted {ok, requestId, expiresAtMs}\`
\`\`\`

## What ships

- **\`ipc-protocol.ts\`** — \`RequestDriveApprovalMessage\` + \`DriveApprovalPostedEvent\`
- **\`ipc-server.ts\`** — validator + dispatch + fail-closed reply when handler unconfigured (hook times out cleanly instead of hanging)
- **\`drive-write-approval.ts\`** — pure orchestrator, fully dep-injected; **always emits exactly one reply** (invariant pinned by test)
- **\`gateway.ts\`** — wires the orchestrator to the real kernel + \`bot.api.sendMessage\` via \`robustApiCall\` (THREAD_NOT_FOUND retry policy)
- **\`check-bot-api-wrapping.sh\`** — allowlist range bumps for the line shift

## Test plan

- [x] \`bun test src/drive/\` — 404 pass
- [x] \`bun test telegram-plugin/gateway/drive-write-approval.test.ts\` — 14 pass
- [x] \`bun run lint\` — clean
- [x] \`bun run build\` — bundles cleanly
- [ ] Independent reviewer verdict

## Depends on

#1314 + #1316. Rebased on \`origin/feat/drive-write-pretool-hook\`; lands after both merge.

## What's next

**PR-2C** = the actual \`drive-write-pretool.mjs\` hook script (~300 LoC) + scaffold.ts registration + end-to-end test. That's where Cut 2 becomes user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)