### PR TITLE
feat(drive): RFC E §4.2 Cut 2 — PreToolUse hook + scaffold registration (PR-2C)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -47,6 +47,14 @@ RUN mkdir -p /tmp/tmux-shared
 COPY dist/cli/autoaccept-poll.js /opt/switchroom/autoaccept-poll.js
 RUN chmod 0755 /opt/switchroom/autoaccept-poll.js
 
+# Drive-write PreToolUse hook (RFC E §4.2 Cut 2). Bundled self-
+# contained .mjs that intercepts `mcp__google-workspace__*` write
+# tool calls and gates them behind a Telegram diff-preview approval
+# card. Bake under /opt/switchroom/hooks/ so the scaffold's hook
+# command path is stable across operator installs.
+COPY dist/cli/drive-write-pretool.mjs /opt/switchroom/hooks/drive-write-pretool.mjs
+RUN chmod 0755 /opt/switchroom/hooks/drive-write-pretool.mjs
+
 # switchroom CLI bundle: the in-container telegram-plugin gateway sidecar
 # shells out to `switchroom <verb>` for /auth, /vault, /agent, /topics
 # and friends (see telegram-plugin/gateway/gateway.ts:switchroomExec). On

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -113,6 +113,24 @@ if (cliEscape.changed) {
   console.log(`[build] ASCII-escaped ${cliEscape.nonAsciiCount} non-ASCII code units in dist/cli/switchroom.js`);
 }
 
+// Bundle the drive-write-pretool hook — RFC E §4.2 Cut 2. Same
+// pattern as autoaccept-poll below: standalone .mjs that the agent
+// container runs via node from a fixed path. The hook itself imports
+// from src/drive/*, src/auth/broker/* etc., none of which are
+// available inside the agent image — so we bundle to a single self-
+// contained file.
+console.log("[build] bundling src/cli/drive-write-pretool.ts -> dist/cli/drive-write-pretool.mjs");
+execSync(
+  `bun build ${JSON.stringify(resolve(root, "src/cli/drive-write-pretool.ts"))} --outfile ${JSON.stringify(resolve(outDir, "drive-write-pretool.mjs"))} --target node`,
+  { stdio: "inherit", cwd: root }
+);
+const hookOutFile = resolve(outDir, "drive-write-pretool.mjs");
+chmodSync(hookOutFile, 0o755);
+const hookEscape = escapeBundleNonAscii(hookOutFile);
+if (hookEscape.changed) {
+  console.log(`[build] ASCII-escaped ${hookEscape.nonAsciiCount} non-ASCII code units in dist/cli/drive-write-pretool.mjs`);
+}
+
 // Bundle the autoaccept-poll entrypoint. The agent unit's ExecStartPost
 // invokes this in the background to dispatch first-run TUI prompts via
 // `tmux capture-pane` + `tmux send-keys`. Must ship in dist/ because

--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -102,7 +102,9 @@ ALLOWLIST=(
   # (~32 lines added earlier in the file shift this band down).
   # Re-bumped 2026-05-15 for the auth-snapshot Format 2 PR
   # (insertions earlier in the file shifted the chunk-loop down).
-  "telegram-plugin/gateway/gateway.ts:3160-3420:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
+  # Re-bumped 2026-05-15 post-Path-A-Cut-2 (drive-write IPC handler
+  # added ~60 lines higher up; chunk-loop callsite shifted further to ~3451).
+  "telegram-plugin/gateway/gateway.ts:3160-3500:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -118,7 +120,9 @@ ALLOWLIST=(
   # (~180 lines added across handleAuthDashboardCallback +
   # fireFleetAutoFallback re-entry guard shifted the vault wizard
   # callsites further down).
-  "telegram-plugin/gateway/gateway.ts:9340-10100:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-15 post-Path-A-Cut-2 (drive-write IPC handler
+  # added ~60 lines).
+  "telegram-plugin/gateway/gateway.ts:9340-10200:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1721,6 +1721,16 @@ export const DOCKER_TELEGRAM_PLUGIN_PATH = "/opt/switchroom/telegram-plugin";
 export const DOCKER_HOOKS_PATH = `${DOCKER_TELEGRAM_PLUGIN_PATH}/hooks`;
 
 /**
+ * In-image path for hooks bundled from src/ TypeScript at build time
+ * (rather than copied from telegram-plugin/hooks/*.mjs source).
+ * Today: only the RFC E §4.2 Cut 2 drive-write hook lives here. The
+ * bundle is emitted by `scripts/build.mjs` to `dist/cli/*.mjs` and
+ * baked into the agent image at `/opt/switchroom/hooks/` (see
+ * docker/Dockerfile.agent).
+ */
+export const DOCKER_BUNDLED_HOOKS_PATH = "/opt/switchroom/hooks";
+
+/**
  * In-image path where Dockerfile.agent COPYs the `bin/*-hook.sh` family
  * (run-hook.sh, timezone-hook.sh, workspace-stable-hook.sh,
  * workspace-dynamic-hook.sh, user-profile-refresh-hook.sh). Same
@@ -2855,6 +2865,32 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
                 `node "${join(DOCKER_HOOKS_PATH, "subagent-tracker-pretool.mjs")}"`,
               ),
               timeout: 10,
+            },
+          ],
+        },
+        {
+          // RFC E §4.2 Cut 2 — gates upstream Drive write tools behind
+          // a Telegram diff-preview approval card. Scoped matcher so
+          // the hook only runs for `mcp__google-workspace__*` tools,
+          // avoiding the cost of stdin parse + broker call on every
+          // tool fire. Timeout = approval TTL + slack.
+          //
+          // Path is DOCKER_BUNDLED_HOOKS_PATH (not DOCKER_HOOKS_PATH)
+          // because this hook is bundled via scripts/build.mjs from
+          // src/cli/drive-write-pretool.ts — it imports src/drive/*
+          // helpers that aren't otherwise available inside the agent
+          // image. Built output lives at /opt/switchroom/hooks/.
+          matcher: "^mcp__google-workspace__",
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:drive-write-pretool",
+                `node "${join(DOCKER_BUNDLED_HOOKS_PATH, "drive-write-pretool.mjs")}"`,
+              ),
+              // Claude Code timeout is in seconds. 5min approval TTL
+              // + 30s slack so a near-timeout grant still lands cleanly.
+              timeout: 5 * 60 + 30,
             },
           ],
         },

--- a/src/cli/drive-write-pretool.ts
+++ b/src/cli/drive-write-pretool.ts
@@ -1,0 +1,424 @@
+/**
+ * PreToolUse hook entry — RFC E §4.2 Cut 2. Bundled to a self-
+ * contained .mjs at build time (`scripts/build.mjs` → `dist/cli/
+ * drive-write-pretool.mjs`) so it can run inside the agent
+ * container with zero relative imports.
+ *
+ * Claude Code PreToolUse protocol (v1):
+ *   Input:  JSON on stdin — { session_id, tool_name, tool_input, ... }
+ *   Output: exit 0 + empty stdout → allow.
+ *           exit 0 + JSON on stdout with `decision: "block"` + `reason` → block.
+ *
+ * Flow:
+ *   1. Read tool_input. If tool isn't a gated Drive write, exit 0 (allow).
+ *   2. Check kernel for an existing always-grant on doc:gdrive:write:<file_id>.
+ *      If granted, exit 0 (allow). The user already said yes for this doc.
+ *   3. Fetch Google access token via auth-broker.
+ *   4. Fetch documents.get for the target doc.
+ *   5. Build DiffPreviewInput via buildWritePreview.
+ *   6. Send IPC `request_drive_approval` to the gateway socket; the
+ *      gateway posts the card to Telegram and replies with
+ *      `drive_approval_posted` carrying the kernel request_id.
+ *   7. Poll approval_lookup until verdict (granted / denied / expired)
+ *      or the kernel-side expires_at_ms deadline.
+ *   8. Return decision: granted → allow, anything else → block.
+ *
+ * Fail-closed:
+ *   - Broker unreachable → block (user can't see card; can't approve).
+ *   - Gateway unreachable → block.
+ *   - Docs.get failure → block (no wrapper-attested location to show).
+ *   - Timeout / no decision → block.
+ *
+ * Fail-open ONLY when:
+ *   - Tool isn't in the gated set (unknown / non-gated upstream tools).
+ *   - stdin parse fails (Claude Code protocol error — not our concern).
+ *   - SWITCHROOM_AGENT_NAME missing (we don't know which agent we're
+ *     gating).
+ */
+
+import { readFileSync } from "node:fs";
+import { createConnection } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+import { fetchDocumentSnapshot } from "../drive/docs-get.js";
+import { loadFromAuthBroker } from "../drive/wrapper-broker.js";
+import {
+  GATED_DRIVE_WRITE_TOOLS,
+  buildWritePreview,
+  stripPrefix,
+} from "../drive/write-preview.js";
+
+// ─── Tunables ─────────────────────────────────────────────────────────────
+
+const HOOK_TIMEOUT_MS = 5 * 60 * 1000; // 5 min — matches kernel default TTL
+const KERNEL_POLL_INTERVAL_MS = 2000;
+const IPC_CONNECT_TIMEOUT_MS = 3000;
+const IPC_REPLY_TIMEOUT_MS = 10_000;
+const KERNEL_RPC_TIMEOUT_MS = 3000;
+
+const GATEWAY_SOCKET =
+  process.env.SWITCHROOM_GATEWAY_SOCKET ??
+  join(homedir(), ".claude", "channels", "telegram", "gateway.sock");
+
+// ─── Stdin parse ──────────────────────────────────────────────────────────
+
+function readStdin(): string {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+// ─── Decision helpers ─────────────────────────────────────────────────────
+
+function allow(): never {
+  process.exit(0);
+}
+
+function block(reason: string): never {
+  // Truncate reason to keep the toast readable — Claude Code surfaces this
+  // back to the user as "tool blocked: <reason>" or similar.
+  const safe = String(reason)
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .slice(0, 200);
+  process.stdout.write(JSON.stringify({ decision: "block", reason: safe }));
+  process.exit(0);
+}
+
+// ─── Agent name ───────────────────────────────────────────────────────────
+
+const agentName = process.env.SWITCHROOM_AGENT_NAME;
+if (!agentName) {
+  // Hook can't function without the agent context. Fail-open here is the
+  // safe choice — secret-guard-pretool.mjs makes the same call.
+  allow();
+}
+
+// ─── Kernel client (NDJSON over UDS) ──────────────────────────────────────
+
+const KERNEL_SOCKET =
+  process.env.SWITCHROOM_APPROVAL_KERNEL_SOCK ??
+  join("/run/switchroom/kernel", agentName as string, "sock");
+
+interface KernelResponse {
+  ok?: boolean;
+  state?: string;
+  [k: string]: unknown;
+}
+
+async function rpcKernel(
+  payload: Record<string, unknown>,
+  timeoutMs = KERNEL_RPC_TIMEOUT_MS,
+): Promise<KernelResponse | null> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const finalize = (v: KernelResponse | null) => {
+      if (resolved) return;
+      resolved = true;
+      try {
+        sock?.destroy();
+      } catch {
+        /* ignore */
+      }
+      resolve(v);
+    };
+    let sock: ReturnType<typeof createConnection> | null = null;
+    const timer = setTimeout(() => finalize(null), timeoutMs);
+    try {
+      sock = createConnection({ path: KERNEL_SOCKET });
+    } catch {
+      clearTimeout(timer);
+      finalize(null);
+      return;
+    }
+    let buf = "";
+    sock.on("connect", () => {
+      sock!.write(JSON.stringify(payload) + "\n");
+    });
+    sock.on("data", (chunk: Buffer) => {
+      buf += chunk.toString("utf8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        const line = buf.slice(0, nl);
+        clearTimeout(timer);
+        try {
+          finalize(JSON.parse(line));
+        } catch {
+          finalize(null);
+        }
+      }
+    });
+    sock.on("error", () => {
+      clearTimeout(timer);
+      finalize(null);
+    });
+  });
+}
+
+async function approvalLookup(
+  scope: string,
+  approverSet: string[],
+): Promise<string | null> {
+  const r = await rpcKernel({
+    v: 1,
+    op: "approval_lookup",
+    agent_unit: agentName,
+    scope,
+    action: "write",
+    current_approver_set: approverSet,
+  });
+  if (r === null || r.ok !== true) return null;
+  return typeof r.state === "string" ? r.state : null;
+}
+
+// ─── Operator allowFrom discovery ─────────────────────────────────────────
+
+function loadAllowFrom(): string[] {
+  // Mirrors the gateway's loadAccess() — reads from the standard state
+  // path. We need this to populate approval_lookup's `current_approver_set`.
+  const accessPath = join(
+    homedir(),
+    ".switchroom",
+    "agents",
+    agentName as string,
+    ".switchroom",
+    "state",
+    "telegram-plugin",
+    "access.json",
+  );
+  try {
+    const raw = readFileSync(accessPath, "utf8");
+    const j = JSON.parse(raw) as { allowFrom?: unknown };
+    if (Array.isArray(j.allowFrom)) {
+      return (j.allowFrom as unknown[]).filter(
+        (s): s is string => typeof s === "string",
+      );
+    }
+  } catch {
+    /* not paired or no access file */
+  }
+  return [];
+}
+
+// ─── Gateway IPC (NDJSON over UDS) ────────────────────────────────────────
+
+interface GatewayReply {
+  ok: boolean;
+  reason?: string;
+  requestId?: string;
+  expiresAtMs?: number;
+}
+
+async function requestDriveApprovalViaGateway(
+  correlationId: string,
+  preview: Record<string, unknown>,
+): Promise<GatewayReply> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const finalize = (v: GatewayReply) => {
+      if (resolved) return;
+      resolved = true;
+      try {
+        sock?.destroy();
+      } catch {
+        /* ignore */
+      }
+      resolve(v);
+    };
+    let sock: ReturnType<typeof createConnection> | null = null;
+    const connectTimer = setTimeout(
+      () => finalize({ ok: false, reason: "gateway IPC connect timeout" }),
+      IPC_CONNECT_TIMEOUT_MS,
+    );
+    try {
+      sock = createConnection({ path: GATEWAY_SOCKET });
+    } catch (err) {
+      clearTimeout(connectTimer);
+      finalize({
+        ok: false,
+        reason: `gateway IPC connect failed: ${(err as Error).message}`,
+      });
+      return;
+    }
+    let buf = "";
+    let replyTimer: NodeJS.Timeout | null = null;
+    sock.on("connect", () => {
+      clearTimeout(connectTimer);
+      sock!.write(
+        JSON.stringify({
+          type: "request_drive_approval",
+          correlationId,
+          agentName,
+          preview,
+          ttlMs: HOOK_TIMEOUT_MS,
+        }) + "\n",
+      );
+      replyTimer = setTimeout(
+        () => finalize({ ok: false, reason: "gateway reply timeout" }),
+        IPC_REPLY_TIMEOUT_MS,
+      );
+    });
+    sock.on("data", (chunk: Buffer) => {
+      buf += chunk.toString("utf8");
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+        if (
+          msg.type === "drive_approval_posted" &&
+          msg.correlationId === correlationId
+        ) {
+          if (replyTimer) clearTimeout(replyTimer);
+          finalize({
+            ok: msg.ok === true,
+            reason: typeof msg.reason === "string" ? msg.reason : undefined,
+            requestId:
+              typeof msg.requestId === "string" ? msg.requestId : undefined,
+            expiresAtMs:
+              typeof msg.expiresAtMs === "number" ? msg.expiresAtMs : undefined,
+          });
+          return;
+        }
+      }
+    });
+    sock.on("error", (err: Error) => {
+      clearTimeout(connectTimer);
+      if (replyTimer) clearTimeout(replyTimer);
+      finalize({ ok: false, reason: `gateway IPC error: ${err.message}` });
+    });
+  });
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const raw = readStdin().trim();
+  if (!raw) allow();
+  let event: Record<string, unknown>;
+  try {
+    event = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    allow();
+    return;
+  }
+  const toolName = event.tool_name;
+  const toolInput = event.tool_input;
+  if (typeof toolName !== "string" || toolInput == null) allow();
+  const tn = toolName as string;
+
+  // 1. Fast no-gate path — anything that isn't an upstream Drive write
+  // we whitelisted falls through ungated.
+  const fn = stripPrefix(tn);
+  if (fn === null || !GATED_DRIVE_WRITE_TOOLS.has(fn)) allow();
+
+  // 2. Fast already-allowed path. If the user previously tapped Always
+  // on a card for this doc, lookup returns 'granted' and we let the
+  // tool through with no card.
+  const input = toolInput as Record<string, unknown>;
+  const documentId =
+    typeof input.document_id === "string" ? input.document_id : null;
+  if (documentId === null) {
+    block("upstream tool_input missing document_id (cannot gate)");
+  }
+  const scope = `doc:gdrive:write:${documentId}`;
+  const allowFrom = loadAllowFrom();
+  if (allowFrom.length === 0) {
+    // No paired operator → no one can approve. Fail closed.
+    block("no operator paired — cannot post approval card");
+  }
+  const existing = await approvalLookup(scope, allowFrom);
+  if (existing === "granted") {
+    allow();
+  }
+
+  // 3. Auth-broker access token.
+  let handle: { access_token: string } | null;
+  try {
+    handle = await loadFromAuthBroker();
+  } catch (err) {
+    block(`auth-broker error: ${(err as Error).message}`);
+  }
+  if (handle === null) {
+    block("auth-broker unreachable — Google not connected for this agent");
+  }
+
+  // 4. Fetch doc snapshot for the wrapper-attested location.
+  let doc;
+  try {
+    doc = await fetchDocumentSnapshot({
+      access_token: handle!.access_token,
+      document_id: documentId as string,
+    });
+  } catch (err) {
+    block(`documents.get failed: ${(err as Error).message}`);
+  }
+
+  // 5. Build the preview spec.
+  const previewResult = buildWritePreview({
+    agentName: agentName as string,
+    toolName: tn,
+    toolInput: input,
+    doc: doc!,
+    mimeType: "application/vnd.google-apps.document",
+  });
+  if (!previewResult.ok) {
+    // Unrecognised tool shape — defensive default is allow, since the
+    // GATED_DRIVE_WRITE_TOOLS filter at step 1 should already have caught
+    // this case. If we hit it, the upstream MCP added a new tool we
+    // haven't taught the previewer about; better to let it through than
+    // block silently.
+    if (previewResult.reason === "unrecognized_tool") {
+      allow();
+    }
+    block(`preview build failed: ${previewResult.detail}`);
+  }
+
+  // 6. IPC to gateway — register kernel request + post card.
+  const correlationId = randomBytes(8).toString("hex");
+  const ipcReply = await requestDriveApprovalViaGateway(
+    correlationId,
+    previewResult.preview as unknown as Record<string, unknown>,
+  );
+  if (!ipcReply.ok) {
+    block(`gateway: ${ipcReply.reason ?? "unknown"}`);
+  }
+  const expiresAtMs = ipcReply.expiresAtMs ?? Date.now() + HOOK_TIMEOUT_MS;
+
+  // 7. Poll kernel until verdict.
+  const deadline = Math.min(Date.now() + HOOK_TIMEOUT_MS, expiresAtMs);
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, KERNEL_POLL_INTERVAL_MS));
+    const state = await approvalLookup(scope, allowFrom);
+    if (state === "granted") {
+      allow();
+    }
+    if (state === "denied" || state === "drift_revoked") {
+      block(`user denied Drive write (kernel verdict: ${state})`);
+    }
+    if (state === "expired") {
+      block("approval timed out");
+    }
+    // 'pending' / 'no_decision' / null → continue polling
+  }
+  block("approval timed out — user did not tap within 5 min");
+}
+
+main().catch((err) => {
+  // Last-resort catch — anything we haven't handled cleanly above falls
+  // here. Block fails closed.
+  try {
+    block(`hook crash: ${(err as Error).message ?? String(err)}`);
+  } catch {
+    process.exit(0);
+  }
+});

--- a/src/cli/drive-write-pretool.ts
+++ b/src/cli/drive-write-pretool.ts
@@ -58,9 +58,16 @@ const IPC_CONNECT_TIMEOUT_MS = 3000;
 const IPC_REPLY_TIMEOUT_MS = 10_000;
 const KERNEL_RPC_TIMEOUT_MS = 3000;
 
+// Gateway IPC socket. Compose / start.sh export TELEGRAM_STATE_DIR
+// into every agent-container child process; `gateway.sock` lives at
+// `<TELEGRAM_STATE_DIR>/gateway.sock` (see gateway.ts:362-363 for the
+// gateway side of this contract). The `SWITCHROOM_GATEWAY_SOCKET`
+// override lets tests / host invocations point elsewhere.
 const GATEWAY_SOCKET =
   process.env.SWITCHROOM_GATEWAY_SOCKET ??
-  join(homedir(), ".claude", "channels", "telegram", "gateway.sock");
+  (process.env.TELEGRAM_STATE_DIR !== undefined
+    ? join(process.env.TELEGRAM_STATE_DIR, "gateway.sock")
+    : join(homedir(), ".claude", "channels", "telegram", "gateway.sock"));
 
 // ─── Stdin parse ──────────────────────────────────────────────────────────
 
@@ -99,10 +106,15 @@ if (!agentName) {
 }
 
 // ─── Kernel client (NDJSON over UDS) ──────────────────────────────────────
+//
+// Canonical env name is `SWITCHROOM_KERNEL_SOCKET` (the docker compose
+// generator sets this, see `src/agents/compose.ts`); the canonical
+// in-container path is `/run/switchroom/kernel/sock` — there's no
+// per-agent subdirectory on the agent side, the kernel multiplexes by
+// peercred. Mirroring `src/vault/approvals/client.ts:resolveKernelSocketPath`.
 
 const KERNEL_SOCKET =
-  process.env.SWITCHROOM_APPROVAL_KERNEL_SOCK ??
-  join("/run/switchroom/kernel", agentName as string, "sock");
+  process.env.SWITCHROOM_KERNEL_SOCKET ?? "/run/switchroom/kernel/sock";
 
 interface KernelResponse {
   ok?: boolean;
@@ -178,18 +190,16 @@ async function approvalLookup(
 // ─── Operator allowFrom discovery ─────────────────────────────────────────
 
 function loadAllowFrom(): string[] {
-  // Mirrors the gateway's loadAccess() — reads from the standard state
-  // path. We need this to populate approval_lookup's `current_approver_set`.
-  const accessPath = join(
-    homedir(),
-    ".switchroom",
-    "agents",
-    agentName as string,
-    ".switchroom",
-    "state",
-    "telegram-plugin",
-    "access.json",
-  );
+  // Mirrors the gateway's loadAccess() (see gateway.ts:362-363).
+  // access.json lives at `<TELEGRAM_STATE_DIR>/access.json` inside
+  // the agent container; the host scaffold path
+  // `~/.switchroom/agents/<agent>/.switchroom/state/telegram-plugin/access.json`
+  // doesn't exist in the container. Fallback only kicks in for
+  // host-side invocations (tests, debug tools).
+  const stateDir =
+    process.env.TELEGRAM_STATE_DIR ??
+    join(homedir(), ".claude", "channels", "telegram");
+  const accessPath = join(stateDir, "access.json");
   try {
     const raw = readFileSync(accessPath, "utf8");
     const j = JSON.parse(raw) as { allowFrom?: unknown };
@@ -377,10 +387,9 @@ async function main(): Promise<void> {
     // this case. If we hit it, the upstream MCP added a new tool we
     // haven't taught the previewer about; better to let it through than
     // block silently.
-    if (previewResult.reason === "unrecognized_tool") {
-      allow();
-    }
-    block(`preview build failed: ${previewResult.detail}`);
+    if (previewResult.reason === "unrecognized_tool") allow();
+    else block(`preview build failed: ${previewResult.detail}`);
+    return;
   }
 
   // 6. IPC to gateway — register kernel request + post card.
@@ -394,10 +403,22 @@ async function main(): Promise<void> {
   }
   const expiresAtMs = ipcReply.expiresAtMs ?? Date.now() + HOOK_TIMEOUT_MS;
 
-  // 7. Poll kernel until verdict.
-  const deadline = Math.min(Date.now() + HOOK_TIMEOUT_MS, expiresAtMs);
-  while (Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, KERNEL_POLL_INTERVAL_MS));
+  // 7. Poll kernel until verdict. The deadline is the kernel's own
+  // expires_at (gateway-computed) plus one poll interval of slack so
+  // a grant that lands in the last sub-poll window before kernel
+  // expiry is still observed.
+  const deadline = Math.min(
+    Date.now() + HOOK_TIMEOUT_MS,
+    expiresAtMs + KERNEL_POLL_INTERVAL_MS,
+  );
+  // Immediate first poll — the user could already have tapped the
+  // card by the time the IPC reply lands (gateway sends synchronously,
+  // the round-trip is ms). Polling after a 2s sleep on the first
+  // iteration would wait unnecessarily.
+  for (let first = true; Date.now() < deadline; first = false) {
+    if (!first) {
+      await new Promise((r) => setTimeout(r, KERNEL_POLL_INTERVAL_MS));
+    }
     const state = await approvalLookup(scope, allowFrom);
     if (state === "granted") {
       allow();

--- a/telegram-plugin/gateway/drive-write-approval.test.ts
+++ b/telegram-plugin/gateway/drive-write-approval.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for the Drive-write IPC handler — RFC E §4.2 Cut 2.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  DriveApprovalPostedEvent,
+  RequestDriveApprovalMessage,
+} from "./ipc-protocol.js";
+import {
+  type DriveApprovalHandlerDeps,
+  handleRequestDriveApproval,
+} from "./drive-write-approval.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ────────────────────────────────────────────────────────────────────────
+
+/** Valid DiffPreviewInput shape — matches src/drive/diff-preview.ts. */
+function validPreview(): Record<string, unknown> {
+  return {
+    agentName: "klanker",
+    docTitle: "Q3 Strategy Notes",
+    fileId: "DOC1",
+    mimeType: "application/vnd.google-apps.document",
+    resolvedAnchor: {
+      op: { kind: "insert_after", paragraphIndex: 4 },
+      displayName: "inside section 'Goals' (level 2)",
+    },
+    metrics: { linesAdded: 5, linesRemoved: 0 },
+    mode: "write",
+  };
+}
+
+interface Spy {
+  sent: DriveApprovalPostedEvent[];
+  registered: Array<{
+    scope: string;
+    action: string;
+    ttl_ms: number;
+    approver_set: string[];
+  }>;
+  posted: Array<{
+    chatId: number | string;
+    threadId?: number;
+    text: string;
+  }>;
+  logs: string[];
+}
+
+function makeSpy(): Spy {
+  return { sent: [], registered: [], posted: [], logs: [] };
+}
+
+function deps(overrides: Partial<DriveApprovalHandlerDeps> & { spy: Spy }): DriveApprovalHandlerDeps {
+  const spy = overrides.spy;
+  return {
+    agentName: "klanker",
+    loadAllowFrom: () => ["12345"],
+    loadTargetChat: () => ({ chatId: 999 }),
+    registerApproval: async (args) => {
+      spy.registered.push({
+        scope: args.scope,
+        action: args.action,
+        ttl_ms: args.ttl_ms,
+        approver_set: args.approver_set,
+      });
+      return { request_id: "aabbccdd", expires_at_ms: Date.now() + args.ttl_ms };
+    },
+    postCard: async (args) => {
+      spy.posted.push({
+        chatId: args.chatId,
+        ...(args.threadId !== undefined ? { threadId: args.threadId } : {}),
+        text: args.text,
+      });
+      return { messageId: 42 };
+    },
+    buildCard: () => ({ text: "diff-preview card body", reply_markup: { stub: true } }),
+    log: (m) => spy.logs.push(m),
+    ...overrides,
+  };
+}
+
+function clientFor(spy: Spy): { send: (msg: unknown) => void } {
+  return {
+    send: (msg) => {
+      const m = msg as DriveApprovalPostedEvent;
+      if (m.type === "drive_approval_posted") spy.sent.push(m);
+    },
+  };
+}
+
+function msgFor(overrides: Partial<RequestDriveApprovalMessage> = {}): RequestDriveApprovalMessage {
+  return {
+    type: "request_drive_approval",
+    correlationId: "corr-1",
+    agentName: "klanker",
+    preview: validPreview(),
+    ...overrides,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Happy path
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — happy path", () => {
+  it("registers the kernel request + posts the card + replies success", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(clientFor(spy), msgFor(), deps({ spy }));
+    expect(spy.registered).toHaveLength(1);
+    expect(spy.registered[0]).toEqual({
+      scope: "doc:gdrive:write:DOC1",
+      action: "write",
+      ttl_ms: 5 * 60 * 1000,
+      approver_set: ["12345"],
+    });
+    expect(spy.posted).toHaveLength(1);
+    expect(spy.posted[0]?.chatId).toBe(999);
+    expect(spy.sent).toHaveLength(1);
+    expect(spy.sent[0]).toMatchObject({
+      type: "drive_approval_posted",
+      correlationId: "corr-1",
+      ok: true,
+      requestId: "aabbccdd",
+    });
+    expect(spy.sent[0]?.expiresAtMs).toBeGreaterThan(Date.now());
+  });
+
+  it("threads threadId through to postCard when targetChat has one", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({ spy, loadTargetChat: () => ({ chatId: 999, threadId: 7 }) }),
+    );
+    expect(spy.posted[0]?.threadId).toBe(7);
+  });
+
+  it("respects a caller-supplied ttlMs (within clamp)", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor({ ttlMs: 90_000 }),
+      deps({ spy }),
+    );
+    expect(spy.registered[0]?.ttl_ms).toBe(90_000);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Refusals
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — refusals", () => {
+  it("refuses cross-agent requests", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor({ agentName: "clerk" }),
+      deps({ spy }),
+    );
+    expect(spy.registered).toEqual([]);
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/serves 'klanker'/);
+  });
+
+  it("refuses malformed preview payloads", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor({ preview: { junk: true } }),
+      deps({ spy }),
+    );
+    expect(spy.registered).toEqual([]);
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/invalid preview/);
+  });
+
+  it("refuses when no operator allowFrom is configured", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({ spy, loadAllowFrom: () => [] }),
+    );
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/allowFrom/);
+  });
+
+  it("refuses when no target chat is available", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({ spy, loadTargetChat: () => null }),
+    );
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/target chat/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Failure modes
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — downstream failures", () => {
+  it("kernel approval_request failure → ok:false with diagnostic reason", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({ spy, registerApproval: async () => null }),
+    );
+    expect(spy.posted).toEqual([]); // card not posted
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/kernel approval_request/);
+  });
+
+  it("card build throw → ok:false (caught + reported)", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({
+        spy,
+        buildCard: () => {
+          throw new Error("invalid request id");
+        },
+      }),
+    );
+    expect(spy.posted).toEqual([]);
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/card build failed/);
+  });
+
+  it("Telegram sendMessage failure → ok:false", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({ spy, postCard: async () => null }),
+    );
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/sendMessage failed/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// TTL clamping
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — TTL clamping", () => {
+  it("clamps below-min TTL up to the minimum", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor({ ttlMs: 1000 }),
+      deps({ spy }),
+    );
+    expect(spy.registered[0]?.ttl_ms).toBe(30_000); // min default
+  });
+
+  it("clamps above-max TTL down to the maximum", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor({ ttlMs: 999_999_999 }),
+      deps({ spy }),
+    );
+    expect(spy.registered[0]?.ttl_ms).toBe(30 * 60 * 1000); // max default
+  });
+
+  it("uses the configured default when ttlMs is undefined", async () => {
+    const spy = makeSpy();
+    await handleRequestDriveApproval(clientFor(spy), msgFor(), deps({ spy }));
+    expect(spy.registered[0]?.ttl_ms).toBe(5 * 60 * 1000);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Always responds (no path drops the response)
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — invariant: always sends a reply", () => {
+  it("every refusal path emits exactly one drive_approval_posted event", async () => {
+    const cases: Array<Partial<DriveApprovalHandlerDeps> | "cross-agent" | "bad-preview"> = [
+      "cross-agent",
+      "bad-preview",
+      { loadAllowFrom: () => [] },
+      { loadTargetChat: () => null },
+      { registerApproval: async () => null },
+      { postCard: async () => null },
+    ];
+    for (const c of cases) {
+      const spy = makeSpy();
+      const msg =
+        c === "cross-agent"
+          ? msgFor({ agentName: "clerk" })
+          : c === "bad-preview"
+            ? msgFor({ preview: { bad: true } })
+            : msgFor();
+      const dep =
+        c === "cross-agent" || c === "bad-preview"
+          ? deps({ spy })
+          : deps({ spy, ...c });
+      await handleRequestDriveApproval(clientFor(spy), msg, dep);
+      expect(spy.sent).toHaveLength(1);
+    }
+  });
+});

--- a/telegram-plugin/gateway/drive-write-approval.ts
+++ b/telegram-plugin/gateway/drive-write-approval.ts
@@ -1,0 +1,243 @@
+/**
+ * Drive-write approval handler — RFC E §4.2 Cut 2.
+ *
+ * Called by the gateway's IPC dispatcher when the Drive-write
+ * PreToolUse hook sends a `request_drive_approval` message. The
+ * handler:
+ *
+ *   1. Validates the inbound preview payload via `buildDiffPreview`
+ *      (which fails closed on malformed inputs).
+ *   2. Registers a kernel approval request at scope
+ *      `doc:gdrive:write:<fileId>`, action `write`, approver_set =
+ *      operator allowFrom.
+ *   3. Builds the Telegram card via `buildDiffPreviewCard` (#1299).
+ *   4. Posts the card to the operator chat via grammy.
+ *   5. Sends a `drive_approval_posted` event back over IPC with the
+ *      kernel request_id + expires_at so the hook can poll
+ *      `approval_lookup` for the verdict.
+ *
+ * On any failure the handler sends `drive_approval_posted { ok:
+ * false, reason: ... }` so the hook fails closed (blocks the tool).
+ *
+ * Kept in its own module so the unit tests for the orchestration
+ * (kernel call + card build + post + response) live separately
+ * from the gateway monolith.
+ */
+
+import { buildDiffPreview, type DiffPreviewInput } from "../../src/drive/diff-preview.js";
+import type { IpcClient } from "./ipc-server.js";
+import type {
+  DriveApprovalPostedEvent,
+  RequestDriveApprovalMessage,
+} from "./ipc-protocol.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Injected deps — caller (gateway.ts) wires these from the existing
+// surface area. Kept abstract so the handler unit-tests don't need
+// grammy / the kernel / the gateway in scope.
+// ────────────────────────────────────────────────────────────────────────
+
+export interface DriveApprovalHandlerDeps {
+  /** This gateway's agent name — cross-agent requests rejected. */
+  agentName: string;
+  /**
+   * Operator allowFrom list (Telegram user ids as strings) — used
+   * as the kernel's approver_set, and to pick the target chat for
+   * the card post.
+   */
+  loadAllowFrom: () => string[];
+  /**
+   * The chat (and optional topic) the picker card should land in.
+   * For the standard DM-based operator setup this is the operator's
+   * private chat with the bot; for group-based setups the operator
+   * group chat + the agent's topic id.
+   */
+  loadTargetChat: () => {
+    chatId: number | string;
+    threadId?: number;
+  } | null;
+  /**
+   * Register a kernel approval request. Returns the kernel's
+   * request_id + expires_at_ms on success, null on failure (rate
+   * limit, broker unreachable, etc.).
+   */
+  registerApproval: (args: {
+    agent_unit: string;
+    scope: string;
+    action: string;
+    approver_set: string[];
+    why: string;
+    ttl_ms: number;
+  }) => Promise<{ request_id: string; expires_at_ms: number } | null>;
+  /**
+   * Post the diff-preview card to Telegram. Returns a posted
+   * message id on success, null on failure.
+   */
+  postCard: (args: {
+    chatId: number | string;
+    threadId?: number;
+    text: string;
+    /** grammy's InlineKeyboard, passed straight through. */
+    replyMarkup: unknown;
+  }) => Promise<{ messageId: number } | null>;
+  /**
+   * Build the Telegram-shaped card from a DiffPreview. Pass-through
+   * to `buildDiffPreviewCard` (#1299); deferred via deps so the
+   * handler tests don't need grammy.
+   */
+  buildCard: (args: {
+    preview: ReturnType<typeof buildDiffPreview>;
+    suggestRequestId: string;
+  }) => { text: string; reply_markup: unknown };
+  log?: (msg: string) => void;
+  /** TTL clamping policy. */
+  defaultTtlMs?: number;
+  maxTtlMs?: number;
+  minTtlMs?: number;
+}
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const MIN_TTL_MS = 30 * 1000; // 30 seconds
+
+/**
+ * Top-level handler called by ipc-server's onRequestDriveApproval.
+ * Always sends a single `drive_approval_posted` reply (success or
+ * failure) before returning.
+ */
+export async function handleRequestDriveApproval(
+  client: Pick<IpcClient, "send">,
+  msg: RequestDriveApprovalMessage,
+  deps: DriveApprovalHandlerDeps,
+): Promise<void> {
+  const reply = (event: Omit<DriveApprovalPostedEvent, "type">) => {
+    try {
+      client.send({ type: "drive_approval_posted", ...event });
+    } catch (err) {
+      deps.log?.(
+        `drive_approval_posted send failed (correlation=${msg.correlationId}): ${(err as Error).message}`,
+      );
+    }
+  };
+
+  // 1. Cross-agent guard.
+  if (msg.agentName !== deps.agentName) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: `gateway serves '${deps.agentName}', not '${msg.agentName}'`,
+    });
+    return;
+  }
+
+  // 2. Validate preview shape — buildDiffPreview throws on
+  // malformed inputs (fileId missing, metrics invalid, etc).
+  let preview: ReturnType<typeof buildDiffPreview>;
+  try {
+    preview = buildDiffPreview(msg.preview as unknown as DiffPreviewInput);
+  } catch (err) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: `invalid preview payload: ${(err as Error).message}`,
+    });
+    return;
+  }
+
+  // 3. Pull operator targeting + allowFrom.
+  const allowFrom = deps.loadAllowFrom();
+  if (allowFrom.length === 0) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: "no operator allowFrom configured — cannot route approval",
+    });
+    return;
+  }
+  const target = deps.loadTargetChat();
+  if (target === null) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: "no target chat available — operator not paired?",
+    });
+    return;
+  }
+
+  // 4. TTL clamp.
+  const ttlMs = clampTtl(
+    msg.ttlMs,
+    deps.defaultTtlMs ?? DEFAULT_TTL_MS,
+    deps.minTtlMs ?? MIN_TTL_MS,
+    deps.maxTtlMs ?? MAX_TTL_MS,
+  );
+
+  // 5. Kernel approval request.
+  const fileId = preview.audit.wrapperAttested.fileId;
+  const scope = `doc:gdrive:write:${fileId}`;
+  const registered = await deps.registerApproval({
+    agent_unit: deps.agentName,
+    scope,
+    action: "write",
+    approver_set: allowFrom,
+    why: `Drive write — ${preview.audit.wrapperAttested.docTitle}`,
+    ttl_ms: ttlMs,
+  });
+  if (registered === null) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: "kernel approval_request failed (rate limit or broker unreachable)",
+    });
+    return;
+  }
+
+  // 6. Build + post the card.
+  let card: { text: string; reply_markup: unknown };
+  try {
+    card = deps.buildCard({ preview, suggestRequestId: registered.request_id });
+  } catch (err) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: `card build failed: ${(err as Error).message}`,
+    });
+    return;
+  }
+  const posted = await deps.postCard({
+    chatId: target.chatId,
+    ...(target.threadId !== undefined ? { threadId: target.threadId } : {}),
+    text: card.text,
+    replyMarkup: card.reply_markup,
+  });
+  if (posted === null) {
+    reply({
+      correlationId: msg.correlationId,
+      ok: false,
+      reason: "Telegram sendMessage failed",
+    });
+    return;
+  }
+
+  deps.log?.(
+    `drive_approval_posted ok correlation=${msg.correlationId} request_id=${registered.request_id} file=${fileId}`,
+  );
+  reply({
+    correlationId: msg.correlationId,
+    ok: true,
+    requestId: registered.request_id,
+    expiresAtMs: registered.expires_at_ms,
+  });
+}
+
+function clampTtl(
+  requested: number | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const t = requested === undefined || !Number.isFinite(requested) ? fallback : requested;
+  if (t < min) return min;
+  if (t > max) return max;
+  return t;
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -225,6 +225,11 @@ import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 
 import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js'
+import { handleRequestDriveApproval } from './drive-write-approval.js'
+import { buildDiffPreviewCard } from './diff-preview-card.js'
+import {
+  approvalRequest as kernelApprovalRequest,
+} from '../../src/vault/approvals/client.js'
 import { createPendingInboundBuffer } from './pending-inbound-buffer.js'
 import {
   buildVaultGrantApprovedInbound,
@@ -3033,6 +3038,69 @@ const ipcServer: IpcServer = createIpcServer({
    * Logs every fire so an operator can correlate the agent's
    * transcript turn against the scheduler's audit row by `prompt_key`.
    */
+  async onRequestDriveApproval(client: IpcClient, msg) {
+    // RFC E §4.2 Cut 2 — Drive-write PreToolUse hook is asking the
+    // gateway to post a diff-preview card so the user can decide.
+    await handleRequestDriveApproval(client, msg, {
+      agentName: getMyAgentName(),
+      loadAllowFrom: () => loadAccess().allowFrom,
+      loadTargetChat: () => {
+        const access = loadAccess()
+        const operator = access.allowFrom[0]
+        if (operator === undefined) return null
+        // For DM-paired setups the target chat IS the operator's
+        // user id. For group setups the gateway already has a topic
+        // routing surface (see how /folders posts) — this picks the
+        // DM path which is the common case; group-routing follow-up
+        // can extend this.
+        return { chatId: operator }
+      },
+      registerApproval: async (args) => {
+        const r = await kernelApprovalRequest({
+          agent_unit: args.agent_unit,
+          scope: args.scope,
+          action: args.action,
+          approver_set: args.approver_set,
+          why: args.why,
+          ttl_ms: args.ttl_ms,
+        })
+        if (r === null || r.state === 'rate_limited') return null
+        return {
+          request_id: r.request_id,
+          expires_at_ms: r.expires_at,
+        }
+      },
+      postCard: async (args) => {
+        try {
+          const sent = await robustApiCall(
+            () =>
+              bot.api.sendMessage(args.chatId, args.text, {
+                parse_mode: 'HTML',
+                ...(args.threadId !== undefined
+                  ? { message_thread_id: args.threadId }
+                  : {}),
+                reply_markup: args.replyMarkup as never,
+              }),
+            {
+              chat_id: String(args.chatId),
+              verb: 'drive-approval-card',
+              ...(args.threadId !== undefined ? { threadId: args.threadId } : {}),
+            },
+          )
+          return { messageId: (sent as { message_id: number }).message_id }
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: drive-approval postCard failed: ${(err as Error).message}\n`,
+          )
+          return null
+        }
+      },
+      buildCard: ({ preview, suggestRequestId }) =>
+        buildDiffPreviewCard({ preview, suggestRequestId }),
+      log: (m) => process.stderr.write(`telegram gateway: drive-approval — ${m}\n`),
+    })
+  },
+
   onInjectInbound(_client: IpcClient, msg: InjectInboundMessage) {
     const promptKey = typeof msg.inbound.meta?.prompt_key === 'string'
       ? msg.inbound.meta.prompt_key

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -59,12 +59,47 @@ export interface ScheduleRestartResult {
   error?: string;
 }
 
+/**
+ * RFC E §4.2 Cut 2 — sent by the gateway to acknowledge that a
+ * Drive-write approval card has been posted (or that posting
+ * failed). The Drive-write PreToolUse hook (a separate process)
+ * uses the `request_id` to poll the kernel's `approval_lookup` for
+ * the verdict; if posting fails, the hook fails closed.
+ *
+ * Why response-shaped: the hook is synchronous from Claude Code's
+ * perspective (PreToolUse blocks the tool call). The hook can't
+ * return its `decision: "approve" | "block"` until either the
+ * card has been posted (so the user can decide) OR posting failed
+ * (so the hook can return block immediately). A response message
+ * is the cleanest way to surface that.
+ */
+export interface DriveApprovalPostedEvent {
+  type: "drive_approval_posted";
+  /** Same correlation_id the client sent on the request. */
+  correlationId: string;
+  ok: boolean;
+  /**
+   * Kernel request_id the hook will pass to `approval_lookup` once
+   * it starts polling. Only present when `ok: true`.
+   */
+  requestId?: string;
+  /**
+   * Unix-ms expiry of the kernel request, mirrors the ttl_ms the
+   * gateway used. Hook uses this as its polling deadline. Only
+   * present when `ok: true`.
+   */
+  expiresAtMs?: number;
+  /** Diagnostic detail on failure. */
+  reason?: string;
+}
+
 export type GatewayToClient =
   | InboundMessage
   | PermissionEvent
   | StatusEvent
   | ToolCallResult
-  | ScheduleRestartResult;
+  | ScheduleRestartResult
+  | DriveApprovalPostedEvent;
 
 // === Bridge (Client) -> Gateway messages ===
 
@@ -189,6 +224,51 @@ export interface InjectInboundMessage {
   inbound: InboundMessage;
 }
 
+/**
+ * RFC E §4.2 Cut 2 — sent by the Drive-write PreToolUse hook to
+ * the gateway to register a diff-preview approval card with the
+ * kernel + post it to Telegram. The hook waits on the
+ * corresponding `drive_approval_posted` reply (matching
+ * `correlationId`), then polls `approval_lookup` for the verdict.
+ *
+ * The `preview` payload is shaped like
+ * `src/drive/diff-preview.ts:DiffPreviewInput`. We don't restate
+ * the full shape on the wire — the IPC validator does a structural
+ * check (required fields present, types right) and the gateway-side
+ * consumer feeds it straight to `buildDiffPreview()` which is
+ * already defensive against malformed inputs.
+ *
+ * Trust model: same as `inject_inbound` — the gateway socket lives
+ * inside the agent container, only that-UID processes can connect,
+ * so the hook is as trusted as anything else in the container.
+ */
+export interface RequestDriveApprovalMessage {
+  type: "request_drive_approval";
+  /**
+   * Hook-generated correlation id (any unique string ≤ 64 chars).
+   * Echoed back in `drive_approval_posted` so the hook can match
+   * the response if multiple Drive-write taps are in flight.
+   */
+  correlationId: string;
+  /**
+   * Target agent the gateway serves. Defense in depth — the gateway
+   * verifies this matches its own SWITCHROOM_AGENT_NAME and refuses
+   * cross-agent requests.
+   */
+  agentName: string;
+  /**
+   * DiffPreviewInput payload — see `src/drive/diff-preview.ts`.
+   * Carried as an opaque object on the wire; the gateway
+   * deserialises it via `buildDiffPreview()`.
+   */
+  preview: Record<string, unknown>;
+  /**
+   * TTL for the kernel approval request, in ms. Hook typically
+   * passes 5 min; gateway clamps to a sensible range.
+   */
+  ttlMs?: number;
+}
+
 export type ClientToGateway =
   | RegisterMessage
   | ToolCallMessage
@@ -199,4 +279,5 @@ export type ClientToGateway =
   | OperatorEventForward
   | PtyPartialForward
   | UpdatePlaceholderMessage
-  | InjectInboundMessage;
+  | InjectInboundMessage
+  | RequestDriveApprovalMessage;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -8,6 +8,7 @@ import type {
   PermissionRequestForward,
   PtyPartialForward,
   RegisterMessage,
+  RequestDriveApprovalMessage,
   ScheduleRestartMessage,
   SessionEventForward,
   ToolCallMessage,
@@ -40,6 +41,18 @@ export interface IpcServerOptions {
    * inline scheduler simply ignore inject_inbound messages.
    */
   onInjectInbound?: (client: IpcClient, msg: InjectInboundMessage) => void;
+  /**
+   * RFC E §4.2 Cut 2 — Drive-write PreToolUse hook asks the gateway
+   * to register a kernel approval request + post a diff-preview
+   * card to Telegram. Handler is expected to send a
+   * `drive_approval_posted` event back over the same connection
+   * (`client.send(...)`). Optional: gateways without the hook
+   * configured ignore these messages.
+   */
+  onRequestDriveApproval?: (
+    client: IpcClient,
+    msg: RequestDriveApprovalMessage,
+  ) => Promise<void>;
   log?: (msg: string) => void;
   /**
    * How long (in ms) to wait without a heartbeat before force-closing the
@@ -192,6 +205,23 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
         && typeof inb.meta === "object"
         && inb.meta !== null;
     }
+    case "request_drive_approval": {
+      // RFC E §4.2 Cut 2. Validate the wire-shaped fields the
+      // gateway will route on; the inner `preview` is treated as
+      // an opaque object and gets defensively re-validated by
+      // `buildDiffPreview()` downstream.
+      if (typeof m.correlationId !== "string"
+        || (m.correlationId as string).length === 0
+        || (m.correlationId as string).length > 64) return false;
+      if (typeof m.agentName !== "string"
+        || !AGENT_NAME_RE.test(m.agentName as string)) return false;
+      if (typeof m.preview !== "object" || m.preview === null) return false;
+      if (m.ttlMs !== undefined
+        && (typeof m.ttlMs !== "number"
+          || !Number.isFinite(m.ttlMs)
+          || (m.ttlMs as number) < 0)) return false;
+      return true;
+    }
     default:
       return false;
   }
@@ -210,6 +240,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onOperatorEvent,
     onPtyPartial,
     onInjectInbound,
+    onRequestDriveApproval,
     log = () => {},
     heartbeatTimeoutMs = 30_000,
   } = options;
@@ -297,6 +328,44 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
         break;
       case "inject_inbound":
         if (onInjectInbound) onInjectInbound(client, msg as InjectInboundMessage);
+        break;
+      case "request_drive_approval":
+        if (onRequestDriveApproval) {
+          // Handler is async — fire-and-forget here; the handler
+          // is responsible for sending its `drive_approval_posted`
+          // response (success or failure) back to the client.
+          onRequestDriveApproval(client, msg as RequestDriveApprovalMessage).catch(
+            (err) => {
+              log(
+                `request_drive_approval handler threw (client=${client.id}): ${(err as Error).message}`,
+              );
+              try {
+                client.send({
+                  type: "drive_approval_posted",
+                  correlationId: (msg as RequestDriveApprovalMessage).correlationId,
+                  ok: false,
+                  reason: `gateway handler error: ${(err as Error).message}`,
+                });
+              } catch {
+                /* best effort */
+              }
+            },
+          );
+        } else {
+          // No handler wired — fail closed and tell the hook so it
+          // can fall back to blocking the tool. Better than leaving
+          // the hook timing out.
+          try {
+            client.send({
+              type: "drive_approval_posted",
+              correlationId: (msg as RequestDriveApprovalMessage).correlationId,
+              ok: false,
+              reason: "gateway not configured for Drive-write approval",
+            });
+          } catch {
+            /* best effort */
+          }
+        }
         break;
       case "update_placeholder":
         // Legacy recall.py IPC — placeholder UX was removed in #553 PR 5.


### PR DESCRIPTION
## Summary

**Path A Cut 2, part 3 of 3 — the user-visible part.** With this PR merged, agents that write to Google Docs trigger a Telegram diff-preview approval card with wrapper-attested location + line counts. The user taps Allow or Cancel.

## What ships

**\`src/cli/drive-write-pretool.ts\`** — TypeScript hook entry, bundled to a self-contained .mjs at build time.

Flow:
1. Stdin parse via \`readFileSync(0)\`
2. Fast no-gate path: tools outside \`GATED_DRIVE_WRITE_TOOLS\` exit 0 before any I/O
3. Fast already-allowed path: kernel \`approval_lookup\` — if granted, no card
4. Auth-broker access token → \`documents.get\` → build preview spec
5. IPC \`request_drive_approval\` to gateway (PR-2B) — gateway posts the card
6. Poll kernel until verdict or 5min deadline
7. Return \`{decision: "block"}\` on every failure (fail-closed)

**\`scripts/build.mjs\`** — bundles to \`dist/cli/drive-write-pretool.mjs\` via \`bun build --target node\` (~169KB, same pattern as \`autoaccept-poll\`).

**\`docker/Dockerfile.agent\`** — COPY to \`/opt/switchroom/hooks/drive-write-pretool.mjs\`.

**\`src/agents/scaffold.ts\`** — new \`DOCKER_BUNDLED_HOOKS_PATH\` constant; PreToolUse hook registered with matcher \`^mcp__google-workspace__\` (avoids per-tool stdin parse cost on Read/Edit/Bash/etc).

## Fail-closed posture (RFC §4.2)

| Condition | Behaviour |
|---|---|
| \`SWITCHROOM_AGENT_NAME\` missing | fail-open (matches \`secret-guard-pretool\`) |
| Tool not gated | fail-open (whitelist matcher) |
| Upstream MCP added unknown tool | fail-open (\`unrecognized_tool\` reason) |
| Broker unreachable | **block** |
| \`documents.get\` failure | **block** |
| Gateway IPC failure | **block** |
| Kernel poll timeout / no operator paired | **block** |
| User denial | **block** |

## Smoke test

\`\`\`
$ SWITCHROOM_AGENT_NAME=klanker echo '{"tool_name":"Read",…}' | node dist/cli/drive-write-pretool.mjs
(exit 0, no stdout — allow)

$ SWITCHROOM_AGENT_NAME=klanker echo '{"tool_name":"mcp__google-workspace__modify_doc_text",…}' | node dist/cli/drive-write-pretool.mjs
{"decision":"block","reason":"no operator paired — cannot post approval card"}
\`\`\`

## Test plan

- [x] \`bun run build\` — bundles cleanly (~169KB)
- [x] \`bun run lint\` — clean
- [x] \`bun test tests/scaffold\` — 211 pass (scaffold registration verified)
- [x] Smoke test (above)
- [ ] Independent reviewer verdict
- [ ] End-to-end test in a real agent container (operator verification post-merge)

## Depends on

#1314 + #1316 + #1318. Rebased on \`origin/feat/drive-write-ipc\`; lands after all three merge.

## What's left for Cut 2 completion

After PR-2A/B/C land:
- RFC E §4.2 amendment documenting the PreToolUse architectural pivot (Path A vs Path C alternatives)
- E2E verification in a real agent container

🤖 Generated with [Claude Code](https://claude.com/claude-code)