### PR TITLE
ci(gha): dual-run CI on GitHub Actions alongside Buildkite

### DIFF
--- a/.github/actions/setup-switchroom/action.yml
+++ b/.github/actions/setup-switchroom/action.yml
@@ -1,0 +1,58 @@
+name: setup-switchroom
+description: |
+  Composite step: checkout, set up bun, restore the bun package cache, and
+  run `bun install --frozen-lockfile` at the repo root.
+
+  This is the ONLY install path. Do NOT add a second
+  `cd telegram-plugin && bun install` — telegram-plugin is a bun workspace
+  of the root, and a per-package install creates a shadow `@mtcute/node`
+  that breaks vi.mock-based tests in cross-package coverage. See the long
+  comment block in .buildkite/pipeline.yml:137 for the full diagnosis (we
+  spent 10+ red builds on main before that was caught).
+
+inputs:
+  bun-version:
+    description: bun version to install
+    required: false
+    default: "1.3.13"
+  install-jq:
+    description: |
+      Whether to ensure jq is on PATH. Required for tests/boot-self-test.test.ts
+      which shells bin/boot-self-test.sh + jq-parses `switchroom auth heal --json`.
+      Cheap to skip when not needed.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    # Cache only the bun package cache (~/.bun/install/cache). Do NOT cache
+    # node_modules/ — a stale workspace tree can resurface the `@mtcute/node`
+    # shadow described above. Letting `bun install --frozen-lockfile` rehydrate
+    # node_modules from the warm cache is fast enough (~5s warm vs ~30s cold).
+    - name: Restore bun package cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock', 'telegram-plugin/bun.lock') }}
+        restore-keys: |
+          bun-${{ runner.os }}-
+
+    - name: Install jq (only when requested)
+      if: inputs.install-jq == 'true'
+      shell: bash
+      run: |
+        if ! command -v jq >/dev/null 2>&1; then
+          sudo apt-get update && sudo apt-get install -y jq
+        fi
+        jq --version
+
+    - name: Install workspace dependencies
+      shell: bash
+      run: |
+        bun install --frozen-lockfile --prefer-offline --no-progress

--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -1,0 +1,222 @@
+name: ci-evals
+
+# Skills evals — trigger routing + quality. Mirrors Buildkite
+# :compass: + :sparkles: + :bar_chart: steps.
+#
+# Auth precedence (same as BK pipeline.yml:483-489):
+#   1. ANTHROPIC_API_KEY (separate billing pool)
+#   2. CLAUDE_CODE_OAUTH_TOKEN (subscription, weekly cap)
+#   3. neither → step exits 0 (clean no-op)
+#
+# Quota protection: GHA concurrency group serialises eval runs across
+# parallel builds on the same workflow file. `cancel-in-progress: false`
+# is LOAD-BEARING — a fresh push must NOT kill an in-flight eval (it
+# already burned the quota; the result is what we want). Subsequent
+# pushes queue behind it. BK's `concurrency: 1` + `concurrency_group`
+# is the same idea.
+#
+# PR-from-fork: secrets are intentionally unavailable for fork PRs on
+# public repos (GitHub policy — no cross-repo token escape). The auth
+# block detects the empty-string case and exits 0 with a clear log line.
+# Maintainers running the workflow via push-to-branch or workflow_dispatch
+# get the full eval run.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      # Skill text changes can flip routing decisions
+      - "skills/**/SKILL.md"
+      # Eval framework + datasets
+      - "evals/run_trigger.py"
+      - "evals/run_quality.py"
+      - "evals/trigger_dataset.yaml"
+      - "evals/dataset.yaml"
+      # Profile CLAUDE.md influences how the model interprets queries
+      - "profiles/**/CLAUDE.md*"
+      - ".github/workflows/ci-evals.yml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialise eval runs across builds — share quota fairly with concurrent
+# pushes/PRs. NOT cancel-in-progress.
+concurrency:
+  group: ci-evals-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ─── Trigger routing eval ────────────────────────────────────────
+  evals-trigger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Set up Node (for claude-code CLI)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Auth gate
+        # Mirror BK behaviour: prefer API key over OAuth token; if neither
+        # is set, exit 0 cleanly so the build doesn't block on missing
+        # secrets (eg PR-from-fork on a public repo).
+        id: auth
+        run: |
+          if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+            echo "auth=api_key" >>"$GITHUB_OUTPUT"
+            # Don't pass both — explicit precedence.
+            echo "CLAUDE_CODE_OAUTH_TOKEN=" >>"$GITHUB_ENV"
+          elif [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+            echo "auth=oauth_token" >>"$GITHUB_OUTPUT"
+          else
+            echo "auth=none" >>"$GITHUB_OUTPUT"
+            echo "::notice::No Anthropic credential in env — skipping eval (this is expected for PRs from forks)"
+          fi
+
+      - name: Install claude-code CLI
+        if: steps.auth.outputs.auth != 'none'
+        # Skip the global re-install if `claude` is already on PATH from
+        # an earlier step or warm action cache.
+        run: |
+          if ! command -v claude >/dev/null 2>&1; then
+            npm i -g --prefer-offline --no-audit --no-fund @anthropic-ai/claude-code
+          fi
+          claude --version || true
+
+      - name: Install python deps
+        if: steps.auth.outputs.auth != 'none'
+        run: pip install -q pyyaml
+
+      - name: Run trigger-routing eval
+        if: steps.auth.outputs.auth != 'none'
+        continue-on-error: true
+        run: python3 evals/run_trigger.py --parallel 5
+
+      - name: Upload eval results
+        if: always() && steps.auth.outputs.auth != 'none'
+        uses: actions/upload-artifact@v4
+        with:
+          name: evals-trigger-results
+          path: evals/results/**/*.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ─── Quality eval ────────────────────────────────────────────────
+  evals-quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Set up Node (for claude-code CLI)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Auth gate
+        id: auth
+        run: |
+          if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+            echo "auth=api_key" >>"$GITHUB_OUTPUT"
+            echo "CLAUDE_CODE_OAUTH_TOKEN=" >>"$GITHUB_ENV"
+          elif [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+            echo "auth=oauth_token" >>"$GITHUB_OUTPUT"
+          else
+            echo "auth=none" >>"$GITHUB_OUTPUT"
+            echo "::notice::No Anthropic credential in env — skipping eval (this is expected for PRs from forks)"
+          fi
+
+      - name: Install claude-code CLI
+        if: steps.auth.outputs.auth != 'none'
+        run: |
+          if ! command -v claude >/dev/null 2>&1; then
+            npm i -g --prefer-offline --no-audit --no-fund @anthropic-ai/claude-code
+          fi
+          claude --version || true
+
+      - name: Install python deps
+        if: steps.auth.outputs.auth != 'none'
+        run: pip install -q pyyaml
+
+      - name: Run quality eval
+        if: steps.auth.outputs.auth != 'none'
+        continue-on-error: true
+        run: python3 evals/run_quality.py --parallel 5
+
+      - name: Upload eval results
+        if: always() && steps.auth.outputs.auth != 'none'
+        uses: actions/upload-artifact@v4
+        with:
+          name: evals-quality-results
+          path: evals/results/**/*.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ─── Summary ─────────────────────────────────────────────────────
+  evals-summary:
+    runs-on: ubuntu-latest
+    needs: [evals-trigger, evals-quality]
+    if: always()
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download eval artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: evals/results
+          merge-multiple: true
+
+      - name: Annotate evals
+        # Best-effort — same posture as BK's annotate-evals.sh step.
+        # A failure here must NOT mask a passing eval run.
+        continue-on-error: true
+        run: |
+          if [ -f .buildkite/annotate-evals.sh ]; then
+            bash .buildkite/annotate-evals.sh || echo "annotate-evals.sh failed (continuing)"
+          else
+            echo "annotate-evals.sh not present — skipping"
+          fi
+
+      - name: Publish badges
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        env:
+          GITHUB_GIST_TOKEN: ${{ secrets.GITHUB_GIST_TOKEN }}
+        run: |
+          if [ -f .buildkite/publish-badges.sh ] && [ -n "$GITHUB_GIST_TOKEN" ]; then
+            bash .buildkite/publish-badges.sh || echo "publish-badges.sh failed (continuing)"
+          else
+            echo "publish-badges.sh prerequisites missing — skipping"
+          fi

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,49 @@
+name: ci-lint
+
+# Type-check + 3 lint scripts. Mirrors Buildkite step :lock: Type check.
+# Triggers narrowly so docs-only / profile-only PRs skip entirely.
+#
+# Dual-run: this runs alongside Buildkite, status check is named distinctly
+# (`ci-lint / lint`) so branch protection can keep BK as the required check
+# while we monitor GHA.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "tsconfig.json"
+      - "package.json"
+      - "bun.lock"
+      - "telegram-plugin/package.json"
+      - "telegram-plugin/bun.lock"
+      - "scripts/check-*.mjs"
+      - "scripts/check-bot-api-wrapping.sh"
+      - ".github/actions/setup-switchroom/**"
+      - ".github/workflows/ci-lint.yml"
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up workspace
+        uses: ./.github/actions/setup-switchroom
+
+      - name: Run lint
+        # `bun lint` = tsc --noEmit + plugin-references + bot-api-wrapping +
+        # bun-test-imports. Same command path as Buildkite.
+        run: bun lint

--- a/.github/workflows/ci-tests-core.yml
+++ b/.github/workflows/ci-tests-core.yml
@@ -1,0 +1,89 @@
+name: ci-tests-core
+
+# Vitest core suite. Mirrors Buildkite :vitest: Core tests, with 4-way
+# matrix sharding for parallelism. Single sequential BK step (~10 min)
+# becomes 4 parallel ~3 min shards on GHA.
+#
+# Sharding determinism: `vitest --shard X/Y` hashes test file paths so a
+# given file always lands in the same shard for a given Y. Adding a test
+# file may re-balance, but every file still gets run exactly once across
+# the matrix.
+#
+# Fork-pool tuning: vitest.config.ts honours VITEST_MAX_FORKS (default 4).
+# 4 shards × 4 forks on a 2-core GHA runner = 16 concurrent workers per
+# runner, OOM/thrash territory. Set VITEST_MAX_FORKS=2 in matrix env to
+# keep the box honest. 4×2 = 8 workers/runner, still oversubscribed but
+# manageable (each shard is also working on ~25% of the suite).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "telegram-plugin/**/*.ts"
+      - "scripts/build.mjs"
+      - "vitest.config.ts"
+      - "tsconfig.json"
+      - "package.json"
+      - "bun.lock"
+      - "telegram-plugin/package.json"
+      - "telegram-plugin/bun.lock"
+      - ".github/actions/setup-switchroom/**"
+      - ".github/workflows/ci-tests-core.yml"
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-tests-core-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  vitest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    env:
+      # Stub bot token — same rationale as BK pipeline.yml:103. Tests
+      # never actually poll Telegram; this just lets import of server.ts
+      # via cross-package coverage avoid the "TELEGRAM_BOT_TOKEN required"
+      # exit path.
+      TELEGRAM_BOT_TOKEN: "123456:stub-for-tests"
+      # Cap fork concurrency — see header note. Honored by vitest.config.ts.
+      VITEST_MAX_FORKS: "2"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up workspace
+        # install-jq=true — tests/boot-self-test.test.ts shells boot-self-test.sh
+        # which jq-parses `switchroom auth heal --json`. Same fix as
+        # .buildkite/pipeline.yml:128-135.
+        uses: ./.github/actions/setup-switchroom
+        with:
+          install-jq: "true"
+
+      - name: Build dist/
+        # Several integration tests (cli.issues, run-hook, boot-self-test)
+        # shell out to dist/cli/switchroom.js. Build is ~1s — every shard
+        # rebuilds rather than caching the artifact (cache overhead would
+        # exceed the rebuild time).
+        run: bun scripts/build.mjs
+
+      - name: Vitest shard ${{ matrix.shard }}/4
+        run: bunx vitest run --shard ${{ matrix.shard }}/4
+
+      - name: Upload coverage (if produced)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-shard-${{ matrix.shard }}
+          path: coverage/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/ci-tests-plugin.yml
+++ b/.github/workflows/ci-tests-plugin.yml
@@ -1,0 +1,56 @@
+name: ci-tests-plugin
+
+# Bun test suite for telegram-plugin/ (bun-runtime-only tests that vitest
+# can't load). Mirrors Buildkite :telegram: Plugin tests (402).
+#
+# Workspace install discipline: we do NOT `cd telegram-plugin && bun install`.
+# telegram-plugin is a bun workspace of the root, and the root install via
+# the composite action already brings in its deps via the hoisted node_modules.
+# A per-package install creates a shadow `@mtcute/node` that breaks
+# vi.mock-based driver tests — see .buildkite/pipeline.yml:137-152 for the
+# full diagnosis. Tests run against the hoisted root install.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "telegram-plugin/**"
+      - "package.json"
+      - "bun.lock"
+      - "telegram-plugin/package.json"
+      - "telegram-plugin/bun.lock"
+      - ".github/actions/setup-switchroom/**"
+      - ".github/workflows/ci-tests-plugin.yml"
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-tests-plugin-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bun-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    env:
+      TELEGRAM_BOT_TOKEN: "123456:stub-for-tests"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up workspace
+        uses: ./.github/actions/setup-switchroom
+
+      - name: Bun test (telegram-plugin)
+        # Same explicit dir list as Buildkite — running `bun test` with no
+        # args recurses into telegram-plugin/uat/scenarios/ which fail
+        # without TELEGRAM_API_ID/HASH. The dir list scopes to the unit
+        # surface only.
+        working-directory: telegram-plugin
+        run: |
+          bun test \
+            admin-commands gateway registry secret-detect tests \
+            channel-envelope-safety.test.ts

--- a/.github/workflows/ci-tests-python.yml
+++ b/.github/workflows/ci-tests-python.yml
@@ -1,0 +1,33 @@
+name: ci-tests-python
+
+# Python tests for vendored Hindsight scripts. Mirrors Buildkite
+# :snake: Python tests (Hindsight scripts). No bun, no node — pure
+# python3 stdlib unittest.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "vendor/hindsight-memory/scripts/**"
+      - ".github/workflows/ci-tests-python.yml"
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-tests-python-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run unittest discover
+        working-directory: vendor/hindsight-memory/scripts
+        run: python3 -m unittest discover tests/

--- a/.github/workflows/ci-tests-race-long.yml
+++ b/.github/workflows/ci-tests-race-long.yml
@@ -1,0 +1,58 @@
+name: ci-tests-race-long
+
+# RFC-faithful race-test long mode for tests/docker/broker-ipc-race.test.ts.
+# Fast-mode (45 lookups @ 200ms ≈ 9s) runs in ci-tests-core.yml; long mode
+# (45 lookups @ 2s ≈ 90s) is gated behind SWITCHROOM_RACE_LONG=1 so dev
+# iteration stays snappy. CI runs it on every PR that touches the broker
+# surface so the RFC-faithful pattern is actually exercised.
+#
+# Mirrors Buildkite :stopwatch: Race test (long mode). Soft-fail via
+# continue-on-error — the test self-skips when docker is unavailable,
+# we don't want that to block PRs.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "tests/docker/broker-ipc-race.test.ts"
+      - "tests/docker/**"
+      - "src/vault/broker/**"
+      - "src/kernel/**"
+      - "src/scheduler/**"
+      - "scripts/build.mjs"
+      - "vitest.config.ts"
+      - ".github/actions/setup-switchroom/**"
+      - ".github/workflows/ci-tests-race-long.yml"
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-tests-race-long-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  race-long:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TELEGRAM_BOT_TOKEN: "123456:stub-for-tests"
+      SWITCHROOM_RACE_LONG: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up workspace
+        uses: ./.github/actions/setup-switchroom
+
+      - name: Build dist/
+        run: bun scripts/build.mjs
+
+      - name: Race test (long mode)
+        # Test self-skips cleanly when docker is unavailable. Mark
+        # continue-on-error so an infrastructure-flavoured fail doesn't
+        # block the PR (Buildkite uses soft_fail for the same reason).
+        continue-on-error: true
+        run: bunx vitest run tests/docker/broker-ipc-race.test.ts

--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -1,0 +1,99 @@
+name: ci-uat
+
+# UAT fuzz — drives a real mtcute MTProto user session against the
+# live test-harness bot in a real supergroup. Mirrors Buildkite
+# pipeline.uat.yml.
+#
+# Why a self-hosted runner?
+#   The harness needs surfaces that DON'T exist on hosted runners:
+#   the test-harness container, the vault, the broker, and a real
+#   mtcute driver session string that must never land on shared
+#   ephemeral infrastructure. The `uat-host` self-hosted runner is
+#   tagged on the box that already runs test-harness + the broker.
+#
+# OPERATOR FAILURE MODE — "queued forever":
+#   If no self-hosted runner is registered with the `uat-host` label,
+#   this job sits queued indefinitely until the workflow's timeout
+#   fires (see timeout-minutes below). GHA shows "Waiting for a
+#   runner to pick up this job" — there is no built-in "queue empty"
+#   signal that auto-fails. Mitigations:
+#     - timeout-minutes bounds the wait (35 min, same as BK soft cap).
+#     - This workflow is gated on a repo variable `UAT_GATE_ENABLED`
+#       (mirrors BK's SWITCHROOM_UAT_GATE_ENABLED). When the operator
+#       hasn't yet provisioned the self-hosted runner, leave the var
+#       unset and the workflow no-ops.
+#     - The self-skip block at the top of the job exits 0 if any of
+#       the 4 Telegram secrets are missing, so an env reset that
+#       rotates secrets out without replacement won't wedge the queue.
+#   Long-term, monitor runner registration via repo Settings →
+#   Actions → Runners; a missing `uat-host` runner is the canonical
+#   "queued forever" cause.
+#
+# PR-from-fork: secrets unavailable, same fallback as ci-evals — the
+# job exits 0 cleanly with a notice.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "telegram-plugin/**"
+      - "src/agents/**"
+      - "telegram-plugin/uat/**"
+      - "vitest.uat.config.ts"
+      - ".github/workflows/ci-uat.yml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Sequential — Telegram's per-bot rate limits are global; two parallel
+# UAT runs interleave inbounds on the same chat. NOT cancel-in-progress
+# (a fresh push must let the running job complete to release the
+# test-harness singleton cleanly).
+concurrency:
+  group: ci-uat-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  uat-fuzz:
+    # Gate on a repo variable so the workflow is invisible on hosts
+    # without a self-hosted runner registered — keeps PRs green until
+    # the operator opts in.
+    if: vars.UAT_GATE_ENABLED == 'true'
+    runs-on: [self-hosted, uat-host]
+    timeout-minutes: 35
+    env:
+      TELEGRAM_API_ID: ${{ secrets.TELEGRAM_API_ID }}
+      TELEGRAM_API_HASH: ${{ secrets.TELEGRAM_API_HASH }}
+      TELEGRAM_UAT_DRIVER_SESSION: ${{ secrets.TELEGRAM_UAT_DRIVER_SESSION }}
+      TELEGRAM_TEST_BOT_USERNAME: ${{ secrets.TELEGRAM_TEST_BOT_USERNAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Secrets gate
+        # If any of the 4 UAT secrets are missing (rotation gap, fork
+        # PR, etc), skip cleanly with a clear log line. Mirrors BK
+        # pipeline.uat.yml:62-67.
+        id: secrets
+        run: |
+          if [[ -z "${TELEGRAM_API_ID:-}" || -z "${TELEGRAM_API_HASH:-}" || -z "${TELEGRAM_UAT_DRIVER_SESSION:-}" || -z "${TELEGRAM_TEST_BOT_USERNAME:-}" ]]; then
+            echo "ok=false" >>"$GITHUB_OUTPUT"
+            echo "::warning::UAT fuzz skipped: one or more secrets missing (TELEGRAM_API_ID / TELEGRAM_API_HASH / TELEGRAM_UAT_DRIVER_SESSION / TELEGRAM_TEST_BOT_USERNAME). Expected for PRs from forks."
+          else
+            echo "ok=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up workspace
+        if: steps.secrets.outputs.ok == 'true'
+        uses: ./.github/actions/setup-switchroom
+
+      - name: UAT fuzz (scoped to fuzz-*.test.ts)
+        if: steps.secrets.outputs.ok == 'true'
+        # Positional filter narrows vitest collection to fuzz-*.test.ts
+        # only — the vitest.uat.config.ts include glob picks up every
+        # scenario file, but only fuzz scenarios are PR-gate-stable.
+        working-directory: telegram-plugin
+        run: bun run test:uat fuzz-

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -94,28 +94,29 @@ jobs:
           docker tag switchroom/broker:phase1b-test switchroom/broker:phase2a-test
           docker tag switchroom/kernel:phase1b-test switchroom/kernel:phase2b-test
 
-      - name: Run docker e2e suite
-        # Full tests/docker/ suite. Two issues that previously made
-        # the broader suite unrunnable on GHA were fixed in the same
-        # PR that introduces this workflow:
+      - name: Run docker e2e suite (with pre/post snapshot gate)
+        # Matches Buildkite step 6 — wraps vitest in a docker-ps
+        # pre/post snapshot diff. Catches the case where vitest crashes
+        # before afterAll() runs and leaks containers (the recurring
+        # `friendly_chatelet` flake — see #1102). Ephemeral GHA runner
+        # still benefits: a leak between assertions inside a single
+        # run is exactly what this catches.
+        #
+        # Two GHA-specific fixes that previously kept this suite from
+        # running on hosted runners landed alongside this workflow:
         #
         #   1. broker-ipc-race.test.ts:265 — `kernelLookup` defaulted
         #      its `container` arg to `switchroom-${agent}` (the
         #      production container name). On a clean-room runner
         #      that container doesn't exist → every exec returns
-        #      exit=1 → 0/45 succeed → drops != 0. The default is
-        #      now required-by-type; callsites pass the project-
-        #      prefixed container.
+        #      exit=1 → 0/45 succeed. The default is now required.
         #
         #   2. _prod-snapshot.ts:27 — the PHASE_TEST_NAME regex only
-        #      matched `switchroom-phase<digit>` (single-container
-        #      pattern); it didn't match the compose-project pattern
-        #      `phase<digit><letter>-...` used by broker-ipc-race
-        #      and per-agent-isolation. A leaked container from one
-        #      fleet test cascaded into the prod-drift assertion of
-        #      the next test. Filter now covers both shapes.
-        run: |
-          npx vitest run tests/docker/
+        #      matched `switchroom-phase<digit>`; it didn't match the
+        #      compose-project pattern `phase<digit><letter>-...` used
+        #      by broker-ipc-race + per-agent-isolation. Filter now
+        #      covers both shapes.
+        run: bash .buildkite/docker-snapshot-gate.sh
 
       - name: Capture broker / kernel logs on failure
         if: failure()


### PR DESCRIPTION
## Summary

Adds 7 new GHA workflows + 1 composite action so we can dual-run CI on GitHub Actions alongside the existing Buildkite pipeline. **Buildkite stays as the required branch-protection check** until we have confidence in GHA stability — both pipelines run on every PR for the dual-run period.

**Why:** Buildkite hosted-agent queue waits are the #1 dev-loop drag (often 2–5 min queue time before the first byte of build). GHA gives us 20 concurrent free runners on public repos with 0s queue.

## What's in the diff

| Workflow | Purpose | Timeout |
|---|---|---|
| `ci-lint` | type-check + 3 lint scripts | 5 min |
| `ci-tests-core` | vitest, 4-way matrix shard | 15 min |
| `ci-tests-plugin` | bun test on `telegram-plugin/` unit dirs | 8 min |
| `ci-tests-python` | unittest on vendored hindsight scripts | 5 min |
| `ci-tests-race-long` | broker-ipc-race long mode, soft-fail | 10 min |
| `docker-e2e` (extended) | adds the pre/post `docker ps` snapshot gate wrapper | 30 min |
| `ci-evals` | trigger + quality + summary, serialised on weekly quota | 30 min |
| `ci-uat` | self-hosted runs, gated on `UAT_GATE_ENABLED` repo var | 35 min |
| `setup-switchroom` (composite) | shared bun setup + cache + install | — |

## GHA-native choices (not a 1:1 Buildkite port)

- **Workflow-level path filters** — pure-doc PRs skip every job entirely.
- **One file per concern** — Buildkite's monolith pipeline becomes 7 narrowly-triggered workflows that run in parallel by default.
- **Cache only `~/.bun/install/cache`, NOT `node_modules/`** — a stale workspace tree resurfaces the `@mtcute/node` shadow we burned 10+ red builds on (see `.buildkite/pipeline.yml:137` for the full diagnosis).
- **Matrix sharding** via `vitest --shard X/4` (deterministic by file hash). The composite + workflow set `VITEST_MAX_FORKS=2` to avoid 4×4 fork×shard oversubscription on 2-core runners (4×2 = 8 workers, still oversubscribed but manageable).
- **PR-from-fork posture:** secrets are unreachable by policy on public repos. The auth gates in `ci-evals` + `ci-uat` detect the empty-string case and exit 0 cleanly with a `::notice` so forked PRs stay green.
- **Eval concurrency group with `cancel-in-progress: false`** — a fresh push must NOT kill a running eval that already burned weekly Anthropic quota. Subsequent pushes queue behind it (matches BK's `concurrency: 1`).

## Reviewer-feedback blockers addressed

The plan went through a separate-process review pass before implementation. The 7 raised blockers are all resolved in this diff:

1. ✅ `VITEST_MAX_FORKS=2` on matrix env (was unbounded → OOM risk)
2. ✅ Plugin job uses hoisted root install only — no second `bun install` in `telegram-plugin/`
3. ✅ PR-from-fork: auth gates in evals/uat detect missing secrets, exit 0 cleanly
4. ✅ `cancel-in-progress: false` on evals + uat (quota + singleton hardware)
5. ✅ Cache scoped to `~/.bun/install/cache`, never `node_modules/`
6. ✅ `dist/` rebuilt per-job (build is ~1s; cache overhead exceeds rebuild time)
7. ✅ UAT \"queued forever\" failure mode documented at top of `ci-uat.yml` with mitigations (gate-var, timeout, secrets self-skip)

## Self-hosted UAT failure mode

If no self-hosted runner is registered with the `uat-host` label, the UAT job sits queued indefinitely until `timeout-minutes` fires. Mitigations:
- Workflow is gated on repo variable `UAT_GATE_ENABLED` — leave unset until a runner is provisioned.
- `timeout-minutes: 35` bounds the wait.
- Secret-presence self-skip exits 0 if any of the 4 Telegram secrets are missing.

## Test plan

- [ ] Open this PR → confirm GHA workflows fire alongside Buildkite
- [ ] Confirm `ci-lint`, `ci-tests-core` (4 shards), `ci-tests-plugin`, `ci-tests-python` all pass on this branch
- [ ] Confirm `ci-tests-race-long` self-skips cleanly when docker is unavailable on the runner
- [ ] Confirm `docker-e2e` snapshot gate fires (it was already in this workflow; the change is wrapping vitest in `docker-snapshot-gate.sh`)
- [ ] Confirm `ci-evals` skips cleanly (no `ANTHROPIC_API_KEY` secret yet on the canonical repo)
- [ ] Confirm `ci-uat` is invisible (no `UAT_GATE_ENABLED` repo var set)
- [ ] After a green dual-run window (~1 week), promote GHA checks to required and retire Buildkite

🤖 Generated with [Claude Code](https://claude.com/claude-code)