### PR TITLE
fix(ci): GHA dual-run followups — plugin test, evals cache, docker-e2e composite

### DIFF
--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -61,16 +61,28 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
+        # No `cache: pip` — we install only `pyyaml`. The pip cache dir
+        # never materialises (no requirements.txt, single tiny package
+        # already wheel-cached on hosted images) and the post-job
+        # cleanup errors with "Cache folder path doesn't exist on disk".
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: pip
 
       - name: Set up Node (for claude-code CLI)
+        # No `cache: npm` — we don't have a package-lock for the global
+        # install (`npm i -g @anthropic-ai/claude-code` is unconfigured
+        # by the repo lockfile). Cache the ~/.npm dir explicitly in the
+        # next step instead, matching BK's `v1-claude-code-global` key.
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
+
+      - name: Cache claude-code global install
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: v1-claude-code-global-${{ runner.os }}
 
       - name: Auth gate
         # Mirror BK behaviour: prefer API key over OAuth token; if neither
@@ -129,16 +141,28 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
+        # No `cache: pip` — we install only `pyyaml`. The pip cache dir
+        # never materialises (no requirements.txt, single tiny package
+        # already wheel-cached on hosted images) and the post-job
+        # cleanup errors with "Cache folder path doesn't exist on disk".
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: pip
 
       - name: Set up Node (for claude-code CLI)
+        # No `cache: npm` — we don't have a package-lock for the global
+        # install (`npm i -g @anthropic-ai/claude-code` is unconfigured
+        # by the repo lockfile). Cache the ~/.npm dir explicitly in the
+        # next step instead, matching BK's `v1-claude-code-global` key.
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
+
+      - name: Cache claude-code global install
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: v1-claude-code-global-${{ runner.os }}
 
       - name: Auth gate
         id: auth

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -50,20 +50,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
+      - name: Set up workspace
+        # Use the shared composite — same cache key as every other
+        # workflow, same install discipline. Drops the uncached
+        # `bun install` + non-deterministic `bun-version: latest` that
+        # used to live here.
+        uses: ./.github/actions/setup-switchroom
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install deps + build dist/
-        run: |
-          bun install
-          npm run build
+      - name: Build dist/
+        run: bun scripts/build.mjs
 
       - name: Set up Docker Buildx (docker driver — writes to local daemon)
         # Important: must use the `docker` driver, NOT the default

--- a/tests/host-control/hostd-dispatch.test.ts
+++ b/tests/host-control/hostd-dispatch.test.ts
@@ -50,7 +50,7 @@ const {
   warnLegacySpawnIfHostdDisabled,
   _resetHostdEnabledCache,
   _resetDeprecationSeen,
-} = await import("../gateway/hostd-dispatch.js");
+} = await import("../../telegram-plugin/gateway/hostd-dispatch.js");
 
 beforeEach(() => {
   _resetHostdEnabledCache();


### PR DESCRIPTION
## Summary

Fixes the two red workflows from the first GHA dual-run on `main` (#1320) and lands a third caching win.

After #1320 merged, the first GHA run on main was:

| Workflow | Result |
|---|---|
| ci-lint | ✅ |
| ci-tests-core (×4) | ✅ |
| ci-tests-python | ✅ |
| ci-tests-race-long | ✅ |
| docker-e2e | ✅ |
| ci-uat | ⏭️ skipped (correct) |
| **ci-tests-plugin** | ❌ |
| **ci-evals** | ❌ |

This PR addresses both reds + audits caching across the workflow set.

## Fix 1 — relocate `hostd-dispatch.test.ts` to `tests/host-control/`

The test imports `vi.importActual` from `"vitest"` but lived in `telegram-plugin/tests/`, which is on the `bun test` arg list in `ci-tests-plugin.yml`. bun:test's `vi` shim has no `importActual`, so the test errored out on every plugin-tests run.

Moved to `tests/host-control/` (root) — vitest's globs pick it up, bun:test never traverses there. Same fix unblocks Buildkite's plugin step (silently red since #1305/#1211 landed but not a required check — GHA caught it on the first dual-run).

## Fix 2 — `ci-evals.yml` caching hygiene

- **Drop `cache: pip`** on `actions/setup-python@v5`. We install only `pyyaml` — the cache dir never materialises and the post-job cleanup errors with `Cache folder path doesn't exist on disk`. This is the actual failure mode.
- **Drop `cache: npm`** on `actions/setup-node@v4` — no repo-level package-lock for the global `@anthropic-ai/claude-code` install, so the action's cache mode has nothing to key on.
- **Add explicit `~/.npm` cache step** keyed `v1-claude-code-global-${{ runner.os }}` — mirrors Buildkite's same-named cache key. Saves the 20-30s global install on warm runs.

## Fix 3 — `docker-e2e.yml` converges on the composite action

`docker-e2e` was bypassing `setup-switchroom`: separate Node+Bun setup, `bun-version: latest` (non-deterministic), and `bun install` without any cache restore. Swapped to the composite — picks up the shared `~/.bun/install/cache` key, pins bun to `1.3.13`, drops the unused Node setup (the build runs `bun scripts/build.mjs` directly).

## Caching audit after this PR

| Cache | Used by | Status |
|---|---|---|
| `~/.bun/install/cache` (bun deps) | composite — 6 workflows | ✅ |
| `~/.npm` (claude-code global) | ci-evals × 2 jobs | ✅ |
| pip wheels | n/a — hosted runner ships `pyyaml` wheel | ✅ no cache needed |
| Docker layer cache | docker-e2e | ⏭️ intentional skip |

**Why no Docker layer cache:** `docker-e2e.yml:79` pins the buildx driver to `docker` (not `docker-container`) because `tests/docker/build-images.sh` chains `FROM switchroom/base:phase1b-test` in the agent/broker/kernel Dockerfiles — that only resolves against the local daemon. `docker-container` keeps a separate buildkit cache and the chained `FROM` would fail. Layer caching here would need a custom `docker save`/`load` dance, out of scope for this PR.

## Test plan

- [ ] All 8 workflows green on this branch (verify before merge)
- [ ] `ci-tests-plugin` passes locally with the relocated test under vitest
- [ ] `ci-evals` no longer errors on post-job cleanup
- [ ] `docker-e2e` warm-cache rebuild < cold-cache time

🤖 Generated with [Claude Code](https://claude.com/claude-code)