### PR TITLE
fix(rfch): harmonise boot-probes hints + /status auth panel on RFC H verbs

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -102,7 +102,7 @@ ALLOWLIST=(
   # Re-bumped 2026-05-15 for #1308 folder-picker handler integration.
   # Re-bumped 2026-05-15 for RFC E §4.2 PR-2C drive PreToolUse hook
   # (#1319) — added ~2 more lines above this block.
-  "telegram-plugin/gateway/gateway.ts:2695-2960:permission-request keyboard; no thread_id"
+  "telegram-plugin/gateway/gateway.ts:2695-3000:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
   # The caller dropped the thread; this raw sendMessage retries on the

--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -83,6 +83,8 @@ ALLOWLIST=(
   # lines added between the modelUnavailable detection and the
   # broadcast loop).
   # Re-bumped 2026-05-15 for #1308 folder-picker handler (callsite now ~2331).
+  # Re-bumped 2026-05-15 post-#1328 (/audit hostd) + #1329 (auth-ux
+  # follow-ups) — broadcast loop now at ~2334 after combined drift.
   "telegram-plugin/gateway/gateway.ts:2250-2350:operator-event broadcast; no thread_id in opts"
 
   # permission-request keyboard send. opts only has reply_markup. No thread_id.

--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -98,6 +98,8 @@ ALLOWLIST=(
   # deletion subtracted ~80 lines below — net shift varies between
   # local + CI grep (line counting drift); widened window to 2960.
   # Re-bumped 2026-05-15 for #1308 folder-picker handler integration.
+  # Re-bumped 2026-05-15 for RFC E §4.2 PR-2C drive PreToolUse hook
+  # (#1319) — added ~2 more lines above this block.
   "telegram-plugin/gateway/gateway.ts:2695-2960:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.

--- a/telegram-plugin/gateway/auth-status-adapter.ts
+++ b/telegram-plugin/gateway/auth-status-adapter.ts
@@ -1,0 +1,101 @@
+/**
+ * Adapt the RFC H broker `auth show --json` / `auth list --json` payload
+ * (a `ListStateData`) into the per-agent `AuthSummary` shape the
+ * /status panel renders via `formatAuthLine`.
+ *
+ * Pre-RFC-H, gateway shelled out to `switchroom auth status --json`
+ * which already returned per-agent records in `AuthSummary` shape.
+ * That verb was retired; this adapter does the per-agent projection
+ * over the new fleet-broker payload.
+ *
+ * Pure & dependency-free so it can be unit-tested without a grammy
+ * Context or live broker.
+ */
+import type { AuthSummary } from '../welcome-text.js'
+
+/** Mirrors `ListStateData` in src/auth/broker/client.ts — duplicated as
+ *  a structural type so this adapter stays in the telegram-plugin
+ *  workspace without importing across the src/ boundary. */
+export interface BrokerStateView {
+  active: string
+  fallback_order: string[]
+  accounts: Array<{
+    label: string
+    expiresAt?: number
+    exhausted: boolean
+  }>
+  agents: Array<{
+    name: string
+    account: string
+    override: string | null
+  }>
+}
+
+/** Subset of `.claude.json` we need for billingType — duplicated for
+ *  the same reason as BrokerStateView. */
+export interface ClaudeJsonView {
+  oauthAccount?: {
+    billingType?: string
+  }
+}
+
+export function formatExpiresInRelative(expiresAt: number | undefined, now: number = Date.now()): string | null {
+  if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt)) return null
+  const delta = expiresAt - now
+  if (delta <= 0) return 'expired'
+  const days = Math.floor(delta / 86_400_000)
+  if (days >= 1) return `in ${days} day${days === 1 ? '' : 's'}`
+  const hours = Math.floor(delta / 3_600_000)
+  if (hours >= 1) return `in ${hours} hour${hours === 1 ? '' : 's'}`
+  const minutes = Math.max(1, Math.floor(delta / 60_000))
+  return `in ${minutes} minute${minutes === 1 ? '' : 's'}`
+}
+
+function mapBillingTypeToPlan(billingType: string | undefined): string | null {
+  if (!billingType) return null
+  const t = billingType.toLowerCase()
+  if (t.includes('max')) return 'Max'
+  if (t.includes('pro')) return 'Pro'
+  return billingType
+}
+
+/**
+ * Build the per-agent AuthSummary from broker state.
+ *
+ * - `authenticated` = the agent is bound to an account that the broker
+ *   knows about. Quota exhaustion is NOT counted as unauthenticated —
+ *   the agent still has valid credentials, it just can't make calls
+ *   until the broker rotates (which is a separate signal).
+ * - `auth_source` surfaces the bound account label (e.g. the email).
+ *   Under RFC H all auth flows through the broker, so the source is
+ *   "which account is currently mirrored to this agent", not the
+ *   transport.
+ * - `subscription_type` is read from the agent's `.claude.json`
+ *   because the broker doesn't track plan tier.
+ * - `expires_in` is computed from the bound account's `expiresAt`.
+ */
+export function buildAuthSummaryFromBroker(
+  state: BrokerStateView | null | undefined,
+  agentName: string,
+  claudeJson: ClaudeJsonView | null | undefined,
+  now: number = Date.now(),
+): AuthSummary | null {
+  if (!state) return null
+  const binding = state.agents.find((a) => a.name === agentName)
+  if (!binding) {
+    return {
+      authenticated: false,
+      subscription_type: mapBillingTypeToPlan(claudeJson?.oauthAccount?.billingType),
+      expires_in: null,
+      auth_source: null,
+    }
+  }
+  const account = state.accounts.find((a) => a.label === binding.account)
+  const authenticated = account !== undefined
+  return {
+    authenticated,
+    subscription_type: mapBillingTypeToPlan(claudeJson?.oauthAccount?.billingType),
+    expires_in: account ? formatExpiresInRelative(account.expiresAt, now) : null,
+    auth_source: binding.account,
+  }
+}

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -499,7 +499,7 @@ export async function runAllProbes(opts: RunProbesOpts): Promise<ProbeMap> {
   const slug = opts.agentSlug ?? opts.agentName
 
   await Promise.allSettled([
-    probeAccount(opts.agentDir, { agentName: opts.agentSlug ?? opts.agentName }).then(r => { probes.account = r }),
+    probeAccount(opts.agentDir).then(r => { probes.account = r }),
     probeAgentProcess(slug, { execFileImpl: opts.probeExecFileImpl, tmuxSupervisor: opts.tmuxSupervisor, dockerMode: opts.dockerMode }).then(r => { probes.agent = r }),
     probeGateway(opts.gatewayInfo).then(r => { probes.gateway = r }),
     probeQuota(claudeDir, opts.agentDir, opts.fetchImpl).then(r => { probes.quota = r }),

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -121,16 +121,10 @@ const TOKEN_EXPIRING_SOON_DAYS = 7
  */
 export async function probeAccount(
   agentDir: string,
-  opts: { agentName?: string } = {},
 ): Promise<ProbeResult> {
   return withTimeout('Account', (async (): Promise<ProbeResult> => {
     const claudeDir = join(agentDir, '.claude')
     const claudeJsonPath = join(claudeDir, '.claude.json')
-    // Fall back to the literal placeholder only when no agentName is plumbed
-    // through — the renderer's <code> escape will keep that safe in Telegram
-    // HTML, but real call sites should always pass the name so users can
-    // tap-to-copy a working command.
-    const agentRef = opts.agentName ?? '<agent>'
     let cfg: ClaudeJson = {}
     try {
       const raw = readFileSync(claudeJsonPath, 'utf8')
@@ -145,7 +139,10 @@ export async function probeAccount(
         status: 'degraded',
         label: 'Account',
         detail: 'not signed in',
-        nextStep: `Run \`switchroom auth login ${agentRef}\` to start the OAuth flow`,
+        // RFC H: auth is fleet-wide. Recovery is `auth add` + `auth use` —
+        // the broker then fans the active label out to every agent. There
+        // is no per-agent `auth login` verb anymore.
+        nextStep: 'Run `switchroom auth add <label> --from-oauth` then `switchroom auth use <label>` to authenticate the fleet',
       }
     }
 
@@ -176,9 +173,9 @@ export async function probeAccount(
     }
 
     const nextStep = status === 'fail'
-      ? `OAuth token expired — run \`switchroom auth login ${agentRef}\` to re-authenticate`
+      ? 'OAuth token expired — broker should auto-refresh; force with `switchroom auth refresh` or `switchroom auth add <label> --from-oauth --replace` if the refresh token is also bad'
       : status === 'degraded'
-        ? `Token expiring soon — run \`switchroom auth login ${agentRef}\` before it lapses`
+        ? 'Token expiring soon — broker auto-refreshes < 60min before expiry; force now with `switchroom auth refresh`'
         : undefined
     return {
       status,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -166,6 +166,11 @@ import {
   type AgentMetadata, type AuthSummary, type StatusProbeRow,
 } from '../welcome-text.js'
 import {
+  type BrokerStateView,
+  type ClaudeJsonView,
+  buildAuthSummaryFromBroker,
+} from './auth-status-adapter.js'
+import {
   isContextExhaustionText,
   shouldArmOrphanedReplyTimeout,
   ORPHANED_REPLY_TIMEOUT_MS,
@@ -7885,13 +7890,13 @@ function buildAgentAudit(agentName: string): AgentAudit | undefined {
 }
 
 // Build an AgentMetadata snapshot for the current agent by shelling out
-// to `switchroom agent list --json` and `switchroom auth status --json`.
-// TODO(rfc-h): the `auth status` verb was retired by RFC H. The shell
-// fails silently and `authSummary` lands as null — /status renders
-// without auth detail. Replace with an `auth show --json` adapter that
-// maps the new fleet-broker shape to the per-agent AuthSummary fields.
+// to `switchroom agent list --json` and `switchroom auth show --json`.
 // Best-effort — any missing piece renders as a placeholder in the text
-// templates rather than blocking the reply.
+// templates rather than blocking the reply. RFC H retired the per-agent
+// `auth status --json` shape; auth state is now derived from the
+// broker's fleet-wide `ListStateData` payload via
+// `buildAuthSummaryFromBroker`, with billingType pulled from the
+// agent's `.claude.json` (the broker doesn't track plan tier).
 async function buildAgentMetadata(agentName: string): Promise<AgentMetadata> {
   type AgentListResp = {
     agents: Array<{
@@ -7901,24 +7906,22 @@ async function buildAgentMetadata(agentName: string): Promise<AgentMetadata> {
       model?: string | null;
     }>
   }
-  type AuthStatusResp = {
-    agents: Array<{
-      name: string; authenticated: boolean; auth_source: string | null;
-      subscription_type: string | null; expires_in: string | null;
-    }>
-  }
   const list = switchroomExecJson<AgentListResp>(['agent', 'list'])
-  const auth = switchroomExecJson<AuthStatusResp>(['auth', 'status'])
+  const brokerState = switchroomExecJson<BrokerStateView>(['auth', 'show'])
   const a = list?.agents?.find(x => x.name === agentName) ?? null
-  const au = auth?.agents?.find(x => x.name === agentName) ?? null
-  const authSummary: AuthSummary | null = au
-    ? {
-        authenticated: au.authenticated,
-        subscription_type: au.subscription_type,
-        expires_in: au.expires_in,
-        auth_source: au.auth_source,
-      }
-    : null
+  let claudeJson: ClaudeJsonView | null = null
+  try {
+    const agentDir = resolveAgentDirFromEnv()
+    if (agentDir) {
+      const raw = readFileSync(join(agentDir, '.claude', '.claude.json'), 'utf8')
+      claudeJson = JSON.parse(raw) as ClaudeJsonView
+    }
+  } catch { /* leave null — billingType becomes null in the summary */ }
+  const authSummary: AuthSummary | null = buildAuthSummaryFromBroker(
+    brokerState,
+    agentName,
+    claudeJson,
+  )
   return {
     agentName,
     model: a?.model ?? null,

--- a/telegram-plugin/tests/auth-status-adapter.test.ts
+++ b/telegram-plugin/tests/auth-status-adapter.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type BrokerStateView,
+  type ClaudeJsonView,
+  buildAuthSummaryFromBroker,
+  formatExpiresInRelative,
+} from '../gateway/auth-status-adapter.js'
+
+const NOW = 1_700_000_000_000
+
+function state(over: Partial<BrokerStateView> = {}): BrokerStateView {
+  return {
+    active: 'ken@example.com',
+    fallback_order: ['ken@example.com'],
+    accounts: [
+      { label: 'ken@example.com', expiresAt: NOW + 29 * 86_400_000, exhausted: false },
+    ],
+    agents: [{ name: 'clerk', account: 'ken@example.com', override: null }],
+    ...over,
+  }
+}
+
+const claudeMax: ClaudeJsonView = { oauthAccount: { billingType: 'claude_max' } }
+
+describe('formatExpiresInRelative', () => {
+  it('returns null for missing / non-finite', () => {
+    expect(formatExpiresInRelative(undefined, NOW)).toBeNull()
+    expect(formatExpiresInRelative(NaN, NOW)).toBeNull()
+  })
+
+  it('returns "expired" when in the past', () => {
+    expect(formatExpiresInRelative(NOW - 1, NOW)).toBe('expired')
+    expect(formatExpiresInRelative(NOW - 86_400_000, NOW)).toBe('expired')
+  })
+
+  it('formats days for ≥ 24h', () => {
+    expect(formatExpiresInRelative(NOW + 29 * 86_400_000, NOW)).toBe('in 29 days')
+    expect(formatExpiresInRelative(NOW + 86_400_000, NOW)).toBe('in 1 day')
+  })
+
+  it('formats hours when < 24h but ≥ 1h', () => {
+    expect(formatExpiresInRelative(NOW + 5 * 3_600_000, NOW)).toBe('in 5 hours')
+    expect(formatExpiresInRelative(NOW + 3_600_000, NOW)).toBe('in 1 hour')
+  })
+
+  it('formats minutes when < 1h', () => {
+    expect(formatExpiresInRelative(NOW + 30 * 60_000, NOW)).toBe('in 30 minutes')
+    expect(formatExpiresInRelative(NOW + 60_000, NOW)).toBe('in 1 minute')
+  })
+})
+
+describe('buildAuthSummaryFromBroker', () => {
+  it('returns null when state is null', () => {
+    expect(buildAuthSummaryFromBroker(null, 'clerk', claudeMax, NOW)).toBeNull()
+  })
+
+  it('happy path — agent bound to a known account with future expiry', () => {
+    const summary = buildAuthSummaryFromBroker(state(), 'clerk', claudeMax, NOW)
+    expect(summary).toEqual({
+      authenticated: true,
+      subscription_type: 'Max',
+      expires_in: 'in 29 days',
+      auth_source: 'ken@example.com',
+    })
+  })
+
+  it('agent missing from broker.agents → not authenticated, no source', () => {
+    const summary = buildAuthSummaryFromBroker(state(), 'unknown-agent', claudeMax, NOW)
+    expect(summary).toEqual({
+      authenticated: false,
+      subscription_type: 'Max',
+      expires_in: null,
+      auth_source: null,
+    })
+  })
+
+  it('agent bound to an account broker has no record of → not authenticated', () => {
+    const s = state({
+      accounts: [], // no matching account
+      agents: [{ name: 'clerk', account: 'ghost@example.com', override: null }],
+    })
+    const summary = buildAuthSummaryFromBroker(s, 'clerk', claudeMax, NOW)
+    expect(summary?.authenticated).toBe(false)
+    expect(summary?.auth_source).toBe('ghost@example.com')
+    expect(summary?.expires_in).toBeNull()
+  })
+
+  it('expired account → authenticated stays true; expires_in says "expired"', () => {
+    const s = state({
+      accounts: [{ label: 'ken@example.com', expiresAt: NOW - 1, exhausted: false }],
+    })
+    const summary = buildAuthSummaryFromBroker(s, 'clerk', claudeMax, NOW)
+    expect(summary?.authenticated).toBe(true)
+    expect(summary?.expires_in).toBe('expired')
+  })
+
+  it('subscription_type pulled from claude.json — Pro tier', () => {
+    const summary = buildAuthSummaryFromBroker(
+      state(),
+      'clerk',
+      { oauthAccount: { billingType: 'claude_pro' } },
+      NOW,
+    )
+    expect(summary?.subscription_type).toBe('Pro')
+  })
+
+  it('subscription_type is null when claudeJson is missing', () => {
+    const summary = buildAuthSummaryFromBroker(state(), 'clerk', null, NOW)
+    expect(summary?.subscription_type).toBeNull()
+  })
+
+  it('passes through unknown billingType verbatim', () => {
+    const summary = buildAuthSummaryFromBroker(
+      state(),
+      'clerk',
+      { oauthAccount: { billingType: 'team' } },
+      NOW,
+    )
+    expect(summary?.subscription_type).toBe('team')
+  })
+
+  it('exhausted account still authenticated (quota state separate from auth state)', () => {
+    const s = state({
+      accounts: [{ label: 'ken@example.com', expiresAt: NOW + 86_400_000, exhausted: true }],
+    })
+    const summary = buildAuthSummaryFromBroker(s, 'clerk', claudeMax, NOW)
+    expect(summary?.authenticated).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -896,42 +896,40 @@ describe('probeAccount — nextStep agent-name interpolation', () => {
     }
   })
 
-  it('not-signed-in hint interpolates agentName instead of <agent>', async () => {
+  it('not-signed-in hint points at RFC H fleet-wide auth verbs', async () => {
     tmpDir = setupAgentDir({})
-    const result = await probeAccount(tmpDir, { agentName: 'finn' })
+    const result = await probeAccount(tmpDir)
     expect(result.status).toBe('degraded')
     expect(result.detail).toBe('not signed in')
     expect(result.nextStep).toBeDefined()
-    expect(result.nextStep).toContain('switchroom auth login finn')
-    expect(result.nextStep).not.toContain('<agent>')
+    expect(result.nextStep).toContain('switchroom auth add')
+    expect(result.nextStep).toContain('--from-oauth')
+    expect(result.nextStep).toContain('switchroom auth use')
+    // RFC H: hint must not point at the retired per-agent `auth login` verb.
+    expect(result.nextStep).not.toContain('auth login')
   })
 
-  it('expired-token hint interpolates agentName', async () => {
+  it('expired-token hint points at broker auto-refresh + manual fallback', async () => {
     tmpDir = setupAgentDir(
       { oauthAccount: { emailAddress: 'me@example.com', billingType: 'max' } },
       { expiresAt: Date.now() - 86_400_000 }, // expired yesterday
     )
-    const result = await probeAccount(tmpDir, { agentName: 'klanker' })
+    const result = await probeAccount(tmpDir)
     expect(result.status).toBe('fail')
-    expect(result.nextStep).toContain('switchroom auth login klanker')
-    expect(result.nextStep).not.toContain('<agent>')
+    expect(result.nextStep).toContain('switchroom auth refresh')
+    expect(result.nextStep).toContain('--replace')
+    expect(result.nextStep).not.toContain('auth login')
   })
 
-  it('expiring-soon hint interpolates agentName', async () => {
+  it('expiring-soon hint points at broker auto-refresh window', async () => {
     tmpDir = setupAgentDir(
       { oauthAccount: { emailAddress: 'me@example.com', billingType: 'max' } },
       { expiresAt: Date.now() + 3 * 86_400_000 }, // 3 days left (< 7)
     )
-    const result = await probeAccount(tmpDir, { agentName: 'lawgpt' })
-    expect(result.status).toBe('degraded')
-    expect(result.nextStep).toContain('switchroom auth login lawgpt')
-    expect(result.nextStep).not.toContain('<agent>')
-  })
-
-  it('falls back to <agent> placeholder when no agentName provided (backwards-compat)', async () => {
-    tmpDir = setupAgentDir({})
     const result = await probeAccount(tmpDir)
-    expect(result.nextStep).toContain('<agent>')
+    expect(result.status).toBe('degraded')
+    expect(result.nextStep).toContain('switchroom auth refresh')
+    expect(result.nextStep).not.toContain('auth login')
   })
 })
 


### PR DESCRIPTION
## Summary

Two surfaces still emitted the pre-RFC-H auth vocabulary; both are user-facing in the Telegram bot.

- **`boot-probes.ts`** — three `nextStep` hints in `probeAccount` pointed at the retired `switchroom auth login <agent>` verb. Rewritten to the RFC H fleet-wide flow (`auth add … --from-oauth` + `auth use …` for not-signed-in; `auth refresh` / broker auto-refresh for expired / expiring-soon). `agentName` interpolation dropped — under RFC H the *fix* is fleet-wide, not per-agent.
- **`gateway.ts:buildAgentMetadata`** — shelled out to `switchroom auth status --json` (also retired by RFC H), so `authSummary` always landed as null and `/status` rendered without auth detail. Replaced with `switchroom auth show --json` + a small pure adapter (`auth-status-adapter.ts`) that maps the broker's `ListStateData` into the per-agent `AuthSummary` shape `formatAuthLine` consumes.

The adapter is intentionally extracted as a standalone module so it can be unit-tested without a grammy Context or live broker.

## Test plan

- [x] `bun test telegram-plugin/tests/boot-probes.test.ts` — 62/62
- [x] `npx vitest run telegram-plugin/tests/auth-status-adapter.test.ts` — 14/14 (new)
- [x] `npx vitest run telegram-plugin/tests/` — 2432/2432
- [x] `npm run lint` — clean (tsc + plugin-refs + bot-api + bun-test-imports)
- [ ] Live: after merge + apply, `/status` panel in any agent renders the auth line instead of "— auth state unknown".

🤖 Generated with [Claude Code](https://claude.com/claude-code)