### PR TITLE
feat(audit): /audit hostd Telegram command + switchroom hostd audit CLI

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -122,7 +122,10 @@ ALLOWLIST=(
   # callsites further down).
   # Re-bumped 2026-05-15 post-Path-A-Cut-2 (drive-write IPC handler
   # added ~60 lines).
-  "telegram-plugin/gateway/gateway.ts:9340-10200:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-15 for the /audit hostd command insertion
+  # (~85 lines added near line 8475 shifted the vault wizard callsites
+  # further down past the prior 10100 ceiling).
+  "telegram-plugin/gateway/gateway.ts:9340-10300:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.8.0";
-export const COMMIT_SHA: string | null = "b660380";
-export const COMMIT_DATE: string | null = "2026-05-13T04:16:37+00:00";
-export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 9;
+export const VERSION: string = "0.10.0";
+export const COMMIT_SHA: string | null = "6391f219";
+export const COMMIT_DATE: string | null = "2026-05-15T14:39:34+10:00";
+export const LATEST_PR: number | null = 1317;
+export const COMMITS_AHEAD_OF_TAG: number | null = 24;

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -23,11 +23,16 @@
 
 import type { Command } from "commander";
 import chalk from "chalk";
-import { existsSync, mkdirSync, readdirSync, writeFileSync, statSync, copyFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, statSync, copyFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { getConfig, withConfigError } from "./helpers.js";
+import {
+  defaultAuditLogPath,
+  formatForCli,
+  readAndFilter,
+} from "../host-control/audit-reader.js";
 
 /**
  * Image tag the install verb pins. Defaults to `:latest`. Override
@@ -363,4 +368,82 @@ export function registerHostdCommand(program: Command): void {
     .command("uninstall")
     .description("Stop the hostd container. Leaves the compose file in place for re-install.")
     .action(() => doUninstall());
+
+  // `switchroom hostd audit` — tail/filter the audit log of privileged-
+  // verb calls. Read-only (does not call hostd itself); the audit log is
+  // append-only JSONL at ~/.switchroom/host-control-audit.log.
+  hostd
+    .command("audit")
+    .description("Tail and filter the hostd audit log (privileged-verb call history)")
+    .option("--tail <n>", "Number of matching entries to show (default: 50)", "50")
+    .option("--agent <name>", "Filter to a specific caller agent")
+    .option("--op <verb>", "Filter to a specific hostd verb (e.g. update_apply, agent_restart)")
+    .option("--error", "Show only failed (error/denied) entries")
+    .option("--path <file>", "Override audit log path (for debugging)")
+    .action((opts: {
+      tail?: string;
+      agent?: string;
+      op?: string;
+      error?: boolean;
+      path?: string;
+    }) => {
+      const logPath = opts.path ?? defaultAuditLogPath();
+      if (!existsSync(logPath)) {
+        console.error(
+          chalk.yellow(`Audit log not found at ${logPath}.`) +
+            chalk.gray(
+              "\nThe log is created when hostd handles its first privileged-verb request.",
+            ),
+        );
+        return;
+      }
+      const raw = readFileSync(logPath, "utf-8");
+      const limit = Math.max(1, parseInt(opts.tail ?? "50", 10) || 50);
+      const filters = {
+        agent: opts.agent,
+        op: opts.op,
+        errorOnly: !!opts.error,
+      };
+      const entries = readAndFilter(raw, filters, limit);
+      if (entries.length === 0) {
+        const parts: string[] = [];
+        if (opts.agent) parts.push(`agent=${opts.agent}`);
+        if (opts.op) parts.push(`op=${opts.op}`);
+        if (opts.error) parts.push("errors-only");
+        const desc = parts.length > 0 ? ` matching ${parts.join(", ")}` : "";
+        console.log(chalk.dim(`No hostd audit entries${desc}.`));
+        return;
+      }
+      const header =
+        "ts".padEnd(20) +
+        " " +
+        "caller".padEnd(15) +
+        " " +
+        "op".padEnd(16) +
+        " " +
+        "result".padEnd(10) +
+        " " +
+        "exit".padStart(3) +
+        " " +
+        "dur".padStart(8);
+      console.log(chalk.dim(header));
+      console.log(chalk.dim("─".repeat(header.length)));
+      for (const line of formatForCli(entries)) {
+        if (line.includes(" error ") || line.includes(" denied ")) {
+          console.log(chalk.red(line));
+        } else if (line.includes(" started ")) {
+          console.log(chalk.yellow(line));
+        } else {
+          console.log(line);
+        }
+      }
+      console.log();
+      console.log(
+        chalk.dim(
+          `${entries.length} entr${entries.length === 1 ? "y" : "ies"} shown` +
+            (entries.length === limit ? ` (--tail ${limit})` : "") +
+            `  ·  log: ${logPath}`,
+        ),
+      );
+    });
 }

--- a/src/host-control/audit-reader.ts
+++ b/src/host-control/audit-reader.ts
@@ -1,0 +1,151 @@
+/**
+ * Reader / formatter for the hostd audit log
+ * (~/.switchroom/host-control-audit.log).
+ *
+ * The log is written by {@link HostControlServer.writeAudit} as
+ * append-only JSONL. Each row captures one privileged verb invocation:
+ *
+ *   {ts, op, caller:{kind,name?}, request_id, result, exit_code,
+ *    duration_ms, error?}
+ *
+ * Pure functions only — the CLI verb at `src/cli/audit.ts` and the
+ * Telegram `/audit hostd` handler in the gateway both depend on this
+ * module to share parsing + filtering semantics.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface AuditEntry {
+  ts: string;
+  op: string;
+  caller: { kind: "agent"; name: string } | { kind: "operator" };
+  request_id: string;
+  result: string;
+  exit_code: number | null;
+  duration_ms: number;
+  error?: string;
+}
+
+export interface AuditFilters {
+  agent?: string;
+  op?: string;
+  errorOnly?: boolean;
+}
+
+export function defaultAuditLogPath(home: string = homedir()): string {
+  return join(home, ".switchroom", "host-control-audit.log");
+}
+
+/** Parse a single JSONL line. Returns null on malformed input — the log
+ *  is best-effort append-only so we tolerate the occasional partial
+ *  write (interrupted fsync). */
+export function parseAuditLine(line: string): AuditEntry | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof obj !== "object" || obj === null) return null;
+  const o = obj as Record<string, unknown>;
+  if (typeof o.ts !== "string" || typeof o.op !== "string") return null;
+  if (typeof o.request_id !== "string" || typeof o.result !== "string") return null;
+  if (typeof o.duration_ms !== "number") return null;
+  const callerRaw = o.caller as Record<string, unknown> | undefined;
+  let caller: AuditEntry["caller"];
+  if (callerRaw && callerRaw.kind === "agent" && typeof callerRaw.name === "string") {
+    caller = { kind: "agent", name: callerRaw.name };
+  } else if (callerRaw && callerRaw.kind === "operator") {
+    caller = { kind: "operator" };
+  } else {
+    return null;
+  }
+  const exit_code = o.exit_code === null || typeof o.exit_code === "number"
+    ? (o.exit_code as number | null)
+    : null;
+  const entry: AuditEntry = {
+    ts: o.ts,
+    op: o.op,
+    caller,
+    request_id: o.request_id,
+    result: o.result,
+    exit_code,
+    duration_ms: o.duration_ms,
+  };
+  if (typeof o.error === "string") entry.error = o.error;
+  return entry;
+}
+
+/** Apply filters in-order, return matching entries unchanged. */
+export function filterEntries(
+  entries: readonly AuditEntry[],
+  filters: AuditFilters,
+): AuditEntry[] {
+  return entries.filter((e) => {
+    if (filters.agent != null) {
+      if (e.caller.kind !== "agent") return false;
+      if (e.caller.name !== filters.agent) return false;
+    }
+    if (filters.op != null && e.op !== filters.op) return false;
+    if (filters.errorOnly) {
+      // Treat `error` and `denied` as failure-shaped. `started` is in-
+      // flight (long-running async ops), excluded from error filter
+      // because by itself it's not a failure.
+      if (e.result !== "error" && e.result !== "denied") return false;
+    }
+    return true;
+  });
+}
+
+/** Parse + filter + take last N (most-recent). Bounded reads — caller
+ *  passes the whole file contents; for huge logs the CLI/gateway should
+ *  pre-tail before calling. */
+export function readAndFilter(
+  raw: string,
+  filters: AuditFilters,
+  limit: number,
+): AuditEntry[] {
+  const lines = raw.split("\n");
+  const parsed: AuditEntry[] = [];
+  for (const line of lines) {
+    const e = parseAuditLine(line);
+    if (e != null) parsed.push(e);
+  }
+  const filtered = filterEntries(parsed, filters);
+  return filtered.slice(-Math.max(1, limit));
+}
+
+function shortCaller(caller: AuditEntry["caller"]): string {
+  return caller.kind === "agent" ? caller.name : "operator";
+}
+
+function shortTs(ts: string): string {
+  // 2026-05-15T04:15:13.465Z → 2026-05-15 04:15:13
+  return ts.replace("T", " ").replace(/\.\d+Z$/, "").slice(0, 19);
+}
+
+/** Plain-text formatter for CLI stdout. Fixed-width columns. */
+export function formatForCli(entries: readonly AuditEntry[]): string[] {
+  const out: string[] = [];
+  for (const e of entries) {
+    const ts = shortTs(e.ts).padEnd(20);
+    const caller = shortCaller(e.caller).padEnd(15);
+    const op = e.op.padEnd(16);
+    const result = e.result.padEnd(10);
+    const exit = e.exit_code == null ? "  -" : String(e.exit_code).padStart(3);
+    const ms = `${e.duration_ms}ms`.padStart(8);
+    out.push(`${ts} ${caller} ${op} ${result} ${exit} ${ms}`);
+  }
+  return out;
+}
+
+/** Telegram-flavoured formatter — same columns, suited for fenced code
+ *  block. Caller wraps in <pre>…</pre>. */
+export function formatForTelegram(entries: readonly AuditEntry[]): string {
+  if (entries.length === 0) return "(no matching entries)";
+  const lines = formatForCli(entries);
+  return lines.join("\n");
+}

--- a/telegram-plugin/admin-commands/dispatch.test.ts
+++ b/telegram-plugin/admin-commands/dispatch.test.ts
@@ -41,7 +41,7 @@ describe('parseCommandName', () => {
 
 describe('ADMIN_COMMAND_NAMES', () => {
   it('contains the fleet-management admin commands', () => {
-    const required = ['agents', 'logs', 'restart', 'update', 'reconcile', 'stop', 'agentstart', 'grant', 'dangerous', 'permissions', 'vault']
+    const required = ['agents', 'logs', 'restart', 'update', 'reconcile', 'stop', 'agentstart', 'grant', 'dangerous', 'permissions', 'vault', 'audit']
     for (const cmd of required) {
       expect(ADMIN_COMMAND_NAMES.has(cmd)).toBe(true)
     }

--- a/telegram-plugin/admin-commands/index.ts
+++ b/telegram-plugin/admin-commands/index.ts
@@ -61,6 +61,8 @@ export const ADMIN_COMMAND_NAMES = new Set<string>([
   // Per-agent ops that read shared fleet state via the switchroom CLI
   'memory',
   'topics',
+  // Observability of privileged-verb history
+  'audit',
 ])
 
 /**

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8541,6 +8541,81 @@ bot.command('upgrade', async ctx => {
   )
 })
 
+// /audit hostd — tail/filter the hostd audit log. Mirrors `/vault audit`
+// in spirit (operator observability over a privileged subsystem from any
+// admin DM). Admin-gated via ADMIN_COMMAND_NAMES. Reads the audit JSONL
+// at ~/.switchroom/host-control-audit.log directly — no hostd RPC needed
+// because the file is shared via the host bind mount on docker installs.
+bot.command('audit', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  const arg = (ctx.match ?? '').trim()
+  if (arg === '' || arg === 'help' || arg === '--help') {
+    await switchroomReply(
+      ctx,
+      'Usage: <code>/audit hostd [--tail N] [--agent &lt;name&gt;] [--op &lt;verb&gt;] [--error]</code>',
+      { html: true },
+    )
+    return
+  }
+  const tokens = arg.split(/\s+/)
+  const sub = tokens[0]
+  if (sub !== 'hostd') {
+    await switchroomReply(
+      ctx,
+      `Unknown audit target <code>${escapeHtmlForTg(sub ?? '')}</code>. ` +
+      `Supported: <code>hostd</code>.`,
+      { html: true },
+    )
+    return
+  }
+  // Build the CLI argv for switchroom hostd audit. Validate each
+  // operator-supplied value to keep argv injection out of the picture.
+  const ALLOWED_OPS = new Set([
+    'agent_start', 'agent_stop', 'agent_restart', 'apply',
+    'update_check', 'update_apply', 'update_status', 'upgrade_status',
+    'get_status', 'doctor', 'fleet_state',
+  ])
+  const argv: string[] = ['hostd', 'audit']
+  for (let i = 1; i < tokens.length; i++) {
+    const t = tokens[i]!
+    if (t === '--error') { argv.push('--error'); continue }
+    if (t === '--tail' || t === '--agent' || t === '--op') {
+      const v = tokens[++i]
+      if (v == null) {
+        await switchroomReply(ctx, `Flag <code>${t}</code> requires a value.`, { html: true })
+        return
+      }
+      if (t === '--tail' && !/^[0-9]{1,4}$/.test(v)) {
+        await switchroomReply(ctx, `<code>--tail</code> must be an integer (1-9999).`, { html: true })
+        return
+      }
+      if (t === '--agent' && !/^[a-z][a-z0-9-]{0,62}$/i.test(v)) {
+        await switchroomReply(ctx, `<code>--agent</code> name has an invalid shape.`, { html: true })
+        return
+      }
+      if (t === '--op' && !ALLOWED_OPS.has(v)) {
+        await switchroomReply(
+          ctx,
+          `Unknown hostd verb <code>${escapeHtmlForTg(v)}</code>. ` +
+          `Known: ${[...ALLOWED_OPS].sort().map(o => `<code>${o}</code>`).join(', ')}.`,
+          { html: true },
+        )
+        return
+      }
+      argv.push(t, v)
+      continue
+    }
+    await switchroomReply(
+      ctx,
+      `Unknown flag <code>${escapeHtmlForTg(t)}</code>. ` +
+      `Allowed: <code>--tail</code>, <code>--agent</code>, <code>--op</code>, <code>--error</code>.`,
+      { html: true },
+    )
+    return
+  }
+  await runSwitchroomCommand(ctx, argv, `hostd audit${argv.length > 2 ? ' …' : ''}`)
+})
+
 // ─── /approve, /deny, /pending ────────────────────────────────────────────
 // Slash-command alternatives to the inline-button approval flow (useful for
 // desktop-only sessions and power-users). Share pendingPermissions state

--- a/tests/host-control/audit-reader.test.ts
+++ b/tests/host-control/audit-reader.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterEntries,
+  formatForCli,
+  parseAuditLine,
+  readAndFilter,
+} from "../../src/host-control/audit-reader.js";
+
+const SAMPLE_AGENT_LINE = JSON.stringify({
+  ts: "2026-05-15T04:15:13.465Z",
+  op: "update_apply",
+  caller: { kind: "agent", name: "klanker" },
+  request_id: "gw-update-1",
+  result: "started",
+  exit_code: null,
+  duration_ms: 1,
+});
+const SAMPLE_OPERATOR_LINE = JSON.stringify({
+  ts: "2026-05-15T04:16:01.505Z",
+  op: "get_status",
+  caller: { kind: "operator" },
+  request_id: "op-poll-1",
+  result: "error",
+  exit_code: 1,
+  duration_ms: 47148,
+  error: "subprocess exited non-zero",
+});
+
+describe("parseAuditLine", () => {
+  it("parses a well-formed agent-caller line", () => {
+    const entry = parseAuditLine(SAMPLE_AGENT_LINE);
+    expect(entry).not.toBeNull();
+    expect(entry!.op).toBe("update_apply");
+    expect(entry!.caller).toEqual({ kind: "agent", name: "klanker" });
+    expect(entry!.exit_code).toBeNull();
+  });
+
+  it("parses an operator-caller line and surfaces the error field", () => {
+    const entry = parseAuditLine(SAMPLE_OPERATOR_LINE);
+    expect(entry).not.toBeNull();
+    expect(entry!.caller).toEqual({ kind: "operator" });
+    expect(entry!.error).toBe("subprocess exited non-zero");
+    expect(entry!.exit_code).toBe(1);
+  });
+
+  it("returns null on malformed JSON (partial write tolerance)", () => {
+    expect(parseAuditLine('{"ts":"2026-05')).toBeNull();
+    expect(parseAuditLine("not json")).toBeNull();
+    expect(parseAuditLine("")).toBeNull();
+    expect(parseAuditLine("   ")).toBeNull();
+  });
+
+  it("returns null when required fields are missing or wrong-typed", () => {
+    expect(parseAuditLine(JSON.stringify({ ts: "x", op: "y" }))).toBeNull();
+    expect(
+      parseAuditLine(
+        JSON.stringify({
+          ts: "x",
+          op: "y",
+          caller: { kind: "agent", name: "k" },
+          request_id: "r",
+          result: "ok",
+          duration_ms: "not-a-number",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects unknown caller kinds", () => {
+    expect(
+      parseAuditLine(
+        JSON.stringify({
+          ts: "x",
+          op: "y",
+          caller: { kind: "wat" },
+          request_id: "r",
+          result: "ok",
+          duration_ms: 1,
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("filterEntries", () => {
+  const entries = [
+    parseAuditLine(SAMPLE_AGENT_LINE)!,
+    parseAuditLine(SAMPLE_OPERATOR_LINE)!,
+    parseAuditLine(
+      JSON.stringify({
+        ts: "2026-05-15T04:20:00.000Z",
+        op: "agent_restart",
+        caller: { kind: "agent", name: "carrie" },
+        request_id: "r2",
+        result: "completed",
+        exit_code: 0,
+        duration_ms: 500,
+      }),
+    )!,
+  ];
+
+  it("filters by agent name (operator entries dropped)", () => {
+    const out = filterEntries(entries, { agent: "klanker" });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.op).toBe("update_apply");
+  });
+
+  it("filters by op", () => {
+    const out = filterEntries(entries, { op: "agent_restart" });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.result).toBe("completed");
+  });
+
+  it("errorOnly keeps error and denied; drops completed and started", () => {
+    const out = filterEntries(entries, { errorOnly: true });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.request_id).toBe("op-poll-1");
+  });
+
+  it("combines filters (AND-semantics)", () => {
+    const out = filterEntries(entries, { agent: "klanker", errorOnly: true });
+    // klanker's only entry is `started`, not error, so AND yields none.
+    expect(out).toHaveLength(0);
+  });
+
+  it("returns input unchanged when filters are empty", () => {
+    expect(filterEntries(entries, {})).toEqual(entries);
+  });
+});
+
+describe("readAndFilter", () => {
+  it("tolerates blank lines and partial writes", () => {
+    const raw =
+      SAMPLE_AGENT_LINE + "\n" + "" + "\n" + "{partial" + "\n" + SAMPLE_OPERATOR_LINE + "\n";
+    const out = readAndFilter(raw, {}, 50);
+    expect(out).toHaveLength(2);
+  });
+
+  it("respects the limit (tail semantics — most recent N)", () => {
+    const lines = Array.from({ length: 10 }, (_, i) =>
+      JSON.stringify({
+        ts: `2026-05-15T04:${String(i).padStart(2, "0")}:00.000Z`,
+        op: "agent_start",
+        caller: { kind: "agent", name: "klanker" },
+        request_id: `r-${i}`,
+        result: "completed",
+        exit_code: 0,
+        duration_ms: 100,
+      }),
+    );
+    const out = readAndFilter(lines.join("\n"), {}, 3);
+    expect(out).toHaveLength(3);
+    expect(out.map((e) => e.request_id)).toEqual(["r-7", "r-8", "r-9"]);
+  });
+
+  it("limit floor is 1 (rejects 0 / negative)", () => {
+    const out = readAndFilter(SAMPLE_AGENT_LINE, {}, 0);
+    expect(out).toHaveLength(1);
+  });
+});
+
+describe("formatForCli", () => {
+  it("emits one fixed-width row per entry with the canonical columns", () => {
+    const entries = [parseAuditLine(SAMPLE_OPERATOR_LINE)!];
+    const lines = formatForCli(entries);
+    expect(lines).toHaveLength(1);
+    const line = lines[0]!;
+    // ts + caller + op + result + exit + duration
+    expect(line).toMatch(/^2026-05-15 04:16:01/);
+    expect(line).toContain("operator");
+    expect(line).toContain("get_status");
+    expect(line).toContain("error");
+    expect(line).toContain("47148ms");
+  });
+
+  it("renders null exit codes as a dash", () => {
+    const entries = [parseAuditLine(SAMPLE_AGENT_LINE)!];
+    const line = formatForCli(entries)[0]!;
+    // exit_code: null → '  -' padded
+    expect(line).toMatch(/\s-\s/);
+  });
+});


### PR DESCRIPTION
## Summary
- New `switchroom hostd audit` CLI verb tails/filters the hostd audit log (~/.switchroom/host-control-audit.log)
- New `/audit hostd` Telegram command (admin-gated) — same shape, fenced output for DM
- Shared `src/host-control/audit-reader.ts` — pure parse/filter/format functions, tolerant of partial-write JSONL

## Why
Yesterday's `/update apply` debug session needed me to SSH onto the host and `tail` the audit log to see what hostd actually did. This puts the answer in the DM. Mirrors `/vault audit` in spirit — one mental model for "what happened on this fleet recently."

Closes the last introspection gap before RFC C Phase 3 (legacy `spawnSwitchroomDetached` removal) — you need observability into the hostd path before you can confidently delete the fallback.

## Surfaces
- `switchroom hostd audit` — default 50 entries, `--tail N`, `--agent <name>`, `--op <verb>`, `--error`, `--path <override>`
- `/audit hostd [--tail N] [--agent <name>] [--op <verb>] [--error]`
  - `--op` value validated against an allowlist (`update_apply`, `agent_restart`, …) to keep argv injection out of the picture
  - `--agent` name validated against the same charset constraint as `assertSafeAgentName`
  - `--tail` constrained to 1–4 digits

## Test plan
- [x] Vitest: `tests/host-control/audit-reader.test.ts` — 15 tests covering parse / filter / format / partial-write tolerance / tail semantics
- [x] Vitest: `telegram-plugin/admin-commands/dispatch.test.ts` extended to assert `audit` is in `ADMIN_COMMAND_NAMES`
- [x] Live smoke: `switchroom hostd audit --tail 5` and `--error` and `--op update_apply` against the live audit log
- [x] `npm run lint` clean (allowlist range bumped for the vault grant wizard band, which shifted past the prior 10100 ceiling — see updated comment in `scripts/check-bot-api-wrapping.sh`)

## Out of scope
- `/audit vault`, `/audit auth-broker` — natural follow-ups but vault already has its own audit verb shape and the auth-broker doesn't append a dedicated audit log today
- Hostd default-flip + legacy spawn removal (RFC C §7 Phase 2 / Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)