### PR TITLE
fix(auth-ux): four follow-ups to #1317 — gate primitive + broker honesty + refresh throttle + retire poller

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -92,7 +92,11 @@ ALLOWLIST=(
   # Re-bumped 2026-05-15 for the auth-snapshot Format 2 PR: card-path
   # `willAutoFallback` branching added a few lines just above this
   # block, shifting the permission send down ~5 lines.
-  "telegram-plugin/gateway/gateway.ts:2695-2940:permission-request keyboard; no thread_id"
+  # Re-bumped 2026-05-15 for the auth-ux follow-ups PR: auth:refresh
+  # throttle map + reaper added ~8 lines above this block; runAutoFallbackCheck
+  # deletion subtracted ~80 lines below — net shift varies between
+  # local + CI grep (line counting drift); widened window to 2960.
+  "telegram-plugin/gateway/gateway.ts:2695-2960:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
   # The caller dropped the thread; this raw sendMessage retries on the

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.8.0";
-export const COMMIT_SHA: string | null = "b660380";
-export const COMMIT_DATE: string | null = "2026-05-13T04:16:37+00:00";
-export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 9;
+export const VERSION: string = "0.10.0";
+export const COMMIT_SHA: string | null = "6391f219";
+export const COMMIT_DATE: string | null = "2026-05-15T14:39:34+10:00";
+export const LATEST_PR: number | null = 1317;
+export const COMMITS_AHEAD_OF_TAG: number | null = 24;

--- a/telegram-plugin/fleet-fallback-gate.ts
+++ b/telegram-plugin/fleet-fallback-gate.ts
@@ -1,0 +1,105 @@
+/**
+ * Re-entry guard + dedup window for fleet-wide auto-fallback.
+ *
+ * Lifted out of gateway.ts so the dedup state is constructable per-test
+ * (gateway.ts module state was hard to reach from vitest — every test
+ * shared the same in-flight Promise + last-fired timestamp).
+ *
+ * Contract (the "honesty contract" from PR #1317 review):
+ *
+ *   `wouldFire()` is the SYNCHRONOUS read the model-unavailable card
+ *   uses to decide whether to advertise "Auto-failover in progress".
+ *   It MUST agree with the dispatcher's actual behavior — otherwise
+ *   the card lies (claims a swap is coming when the dispatcher will
+ *   dedup-drop or bail).
+ *
+ *   Three reasons `wouldFire()` returns false:
+ *     1. A swap is already in flight (collapse concurrent fires).
+ *     2. The post-trigger dedup window is still active (the user
+ *        already saw a swap announcement; another one would oscillate).
+ *     3. The broker is unreachable — the dispatcher would just bail
+ *        with `reason=no-broker-client`, leaving the card to lie.
+ *        Optional: only checked when `brokerReachable` is supplied.
+ *
+ *   `markFired()` is called ONLY on actual swaps (kind: 'switched').
+ *   No-ops (no broker, no eligible target, idempotent skip) DO NOT
+ *   arm the suppression window — otherwise a transient hiccup blocks
+ *   the next 30s of legitimate fires.
+ */
+
+export interface FleetFallbackGateOptions {
+  /** Suppression window in ms after a successful swap. */
+  dedupMs: number;
+  /** Time source (overridable in tests). */
+  nowFn?: () => number;
+  /**
+   * Synchronous probe of broker reachability. Optional. Returning false
+   * makes `wouldFire()` return false so the card stays honest about a
+   * fire that would otherwise bail in the dispatcher.
+   *
+   * Synchronous on purpose: `wouldFire()` runs on the card-render path
+   * and must not block. A connection-cached flag (e.g. a UDS reachability
+   * check populated by a background heartbeat) fits this shape.
+   */
+  brokerReachable?: () => boolean;
+}
+
+export interface FleetFallbackGate {
+  /** True iff a fresh fire would actually invoke the dispatcher. */
+  wouldFire(): boolean;
+  /** Run a fire-and-forget action under the gate. Collapses concurrent
+   *  callers to the same in-flight Promise. The action's resolved value
+   *  controls whether the dedup window arms (true = arm, false = skip).
+   *  Caller-thrown errors are swallowed (logged via `onError`). */
+  fire(action: () => Promise<boolean>, onError?: (err: unknown) => void): Promise<void>;
+  /** Test seam — reset to fresh state. Production code should not call this. */
+  reset(): void;
+  /** Test/debug — current internal state. */
+  inspect(): { inFlight: boolean; lastFiredAtMs: number };
+}
+
+export function createFleetFallbackGate(opts: FleetFallbackGateOptions): FleetFallbackGate {
+  const nowFn = opts.nowFn ?? (() => Date.now());
+  let inFlight: Promise<void> | null = null;
+  // -Infinity = never fired. Concrete number = wall-clock ms of the
+  // last actual swap. Sentinel matters in tests (fake clocks at t=0
+  // would otherwise look like "just fired" and falsely arm dedup).
+  let lastFiredAtMs = Number.NEGATIVE_INFINITY;
+
+  function wouldFire(): boolean {
+    if (inFlight) return false;
+    if (nowFn() - lastFiredAtMs < opts.dedupMs) return false;
+    if (opts.brokerReachable && !opts.brokerReachable()) return false;
+    return true;
+  }
+
+  function fire(action: () => Promise<boolean>, onError?: (err: unknown) => void): Promise<void> {
+    if (inFlight) return inFlight;
+    if (nowFn() - lastFiredAtMs < opts.dedupMs) return Promise.resolve();
+    if (opts.brokerReachable && !opts.brokerReachable()) return Promise.resolve();
+
+    inFlight = (async () => {
+      try {
+        const didSwap = await action();
+        if (didSwap) lastFiredAtMs = nowFn();
+      } catch (err) {
+        if (onError) onError(err);
+      } finally {
+        inFlight = null;
+      }
+    })();
+    return inFlight;
+  }
+
+  return {
+    wouldFire,
+    fire,
+    reset() {
+      inFlight = null;
+      lastFiredAtMs = Number.NEGATIVE_INFINITY;
+    },
+    inspect() {
+      return { inFlight: inFlight !== null, lastFiredAtMs };
+    },
+  };
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -95,6 +95,8 @@ import {
 import type { AuthBrokerClient } from './auth-command.js'
 import type { ListStateData } from './auth-line.js'
 import { getAuthBrokerClient, addAccountViaBroker } from './auth-broker-client.js'
+import { resolveAuthBrokerSocketPath } from '../../src/auth/broker/client.js'
+import { createFleetFallbackGate } from '../fleet-fallback-gate.js'
 import {
   pendingAuthAddFlows,
   startAccountAuthSession,
@@ -194,23 +196,16 @@ import {
   formatQuotaBlock,
 } from '../quota-check.js'
 import {
-  evaluateFallbackTrigger,
-  performAutoFallback,
-  emptyLockout,
   loadLockout,
-  nextLockout,
-  saveLockout,
   DEFAULT_FALLBACK_COOLDOWN_MS,
-  type LockoutRecord,
   type LockoutPersistOps,
 } from '../auto-fallback.js'
-import { markSlotQuotaExhausted, DEFAULT_SLOT } from '../../src/auth/accounts.js'
-import { fallbackToNextSlot, currentActiveSlot, type AuthCodeOutcome } from '../../src/auth/manager.js'
+import { DEFAULT_SLOT } from '../../src/auth/accounts.js'
+import { currentActiveSlot, type AuthCodeOutcome } from '../../src/auth/manager.js'
 import { injectSlashCommand as injectSlashCommandImpl } from '../../src/agents/inject.js'
 import { handleInjectCommand } from './inject-handler.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
-import { dispatchFallbackNotification } from '../auto-fallback-dispatcher.js'
 import { loadConfig as loadSwitchroomConfig } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
 import {
   tryHostdDispatch,
@@ -1988,6 +1983,13 @@ const awaitingAuthCodeAt = new Map<string, number>()
 const AUTH_CODE_CONTEXT_TTL_MS = 5 * 60_000 // 5 min — OAuth code lifetime
 const DEFERRED_SECRET_TTL_MS = 24 * 60 * 60_000 // 24 h — ignored one-tap cards
 
+// Freshness throttle for `auth:refresh` taps. Keyed by `<chat_id>:<message_id>`
+// so two different snapshot messages throttle independently. Each refresh
+// fan-fires N live api.anthropic.com probes (one per account), so we cap
+// rapid re-taps to one per AUTH_REFRESH_THROTTLE_MS.
+const lastAuthRefreshAtMs = new Map<string, number>()
+const AUTH_REFRESH_THROTTLE_MS = 5_000
+
 // ─── TTL reaper ───────────────────────────────────────────────────────────
 // Pending state maps above all grow whenever a flow starts and only shrink
 // when the flow completes. Users abandoning a flow (closing Telegram, losing
@@ -2050,6 +2052,12 @@ const pendingStateReaper = setInterval(() => {
   }
   for (const [k, v] of awaitingAuthCodeAt) {
     if (now - v > AUTH_CODE_CONTEXT_TTL_MS) awaitingAuthCodeAt.delete(k)
+  }
+  // Auth-refresh throttle entries decay quickly (5s window); sweep
+  // anything older than 60s so abandoned snapshot messages don't pin
+  // their key forever.
+  for (const [k, v] of lastAuthRefreshAtMs) {
+    if (now - v > 60_000) lastAuthRefreshAtMs.delete(k)
   }
   // /auth rm two-step confirm window — self-expires at `expiresAt`.
   for (const [k, v] of pendingAuthRmFlows) {
@@ -8567,40 +8575,18 @@ bot.command('interrupt', async ctx => {
   await runSwitchroomCommand(ctx, ['agent', 'interrupt', name], `interrupt ${name}`)
 })
 
-// Shared auto-fallback state. `lockout` is a per-process in-memory
-// guard against rapid re-fire between the scheduled poll and any
-// manual trigger (see telegram-plugin/auto-fallback.ts).
-//
-// Pre-#417 fix this was always emptyLockout() at process start, so a
-// gateway restart inside the cooldown window reset the timer and a
-// quota-flap on the recovering slot could re-trigger fallback the
-// moment the gateway came back. We now seed from disk on first use
-// and persist on every transition. Errors are swallowed: losing the
-// lockout file just degrades to in-memory-only behaviour.
+// Persist-ops bundle for the legacy auto-fallback lockout file. The
+// only remaining reader is `isAutoFallbackCooldownActive` (line ~2030)
+// — used by the pending-restart drain cap to defer a forced restart
+// stacking on top of an in-flight slot rotation. The legacy poller
+// that USED to write this file was retired alongside this refactor;
+// existing on-disk lockouts age out via DEFAULT_FALLBACK_COOLDOWN_MS.
 const lockoutOps: LockoutPersistOps = {
   readFileSync: (p, enc) => readFileSync(p, enc),
   writeFileSync: (p, data, opts) => writeFileSync(p, data, opts),
   existsSync: (p) => existsSync(p),
   mkdirSync: (p, opts) => mkdirSync(p, opts),
   joinPath: (...parts) => join(...parts),
-}
-let autoFallbackLockout: LockoutRecord = emptyLockout()
-let autoFallbackLockoutSeeded = false
-function seedAutoFallbackLockoutIfNeeded(agentDir: string): void {
-  if (autoFallbackLockoutSeeded) return
-  autoFallbackLockoutSeeded = true
-  try {
-    autoFallbackLockout = loadLockout(agentDir, lockoutOps)
-  } catch (err) {
-    process.stderr.write(`telegram gateway: auto-fallback lockout seed failed (using empty): ${(err as Error).message}\n`)
-  }
-}
-function persistLockout(agentDir: string): void {
-  try {
-    saveLockout(agentDir, autoFallbackLockout, lockoutOps)
-  } catch (err) {
-    process.stderr.write(`telegram gateway: auto-fallback lockout persist failed: ${(err as Error).message}\n`)
-  }
 }
 
 // Pinned slot-banner state (#421). One banner per gateway process,
@@ -8632,46 +8618,37 @@ async function refreshPinnedBanner(reason: string): Promise<void> {
   }
 }
 
-type AutoFallbackCheckResult =
-  | { kind: 'no-action'; reason: string; decision: 'noop' | 'fallback-skipped' }
-  | { kind: 'executed'; previousSlot: string; newSlot: string }
-  | { kind: 'exhausted-all'; activeSlot: string }
-  | { kind: 'error'; message: string }
-
 /**
- * Re-entry guard for `fireFleetAutoFallback`. Without this, N
- * concurrent agent turns hitting 429 within ~1s each fire a separate
- * fleet swap — N broadcasts, N broker writes, N quota probes per
- * account, possibly oscillating swap targets. The guard collapses
- * concurrent triggers from the same agent into one in-flight
- * promise, and suppresses re-fires for `FLEET_FALLBACK_DEDUP_MS`
- * after the most recent successful trigger (the suppression survives
- * the announcement → user-side observed swap; if quota is still bad
- * the next event will fire after the window closes).
+ * Re-entry guard + dedup window for `fireFleetAutoFallback`. The state
+ * was lifted into `fleet-fallback-gate.ts` so it can be tested in
+ * isolation (gateway.ts module state was unreachable from vitest). The
+ * gate ALSO enforces the broker-reachability honesty contract: when the
+ * broker is down, `wouldFire()` returns false so the model-unavailable
+ * card stays honest instead of advertising a swap that would bail with
+ * `reason=no-broker-client`.
  */
 const FLEET_FALLBACK_DEDUP_MS = 30_000
-let fleetFallbackInFlight: Promise<void> | null = null
-/** Wall-clock ms of the last ACTUAL swap (kind: 'switched' from
- *  runFleetAutoFallback). Skipped no-ops (no broker client, no
- *  eligible target, idempotent skip) DO NOT update this — the user
- *  hasn't seen a swap announcement, so suppressing future fires
- *  off a non-event would create the "card lies" gap. */
-let fleetFallbackLastFiredAtMs = 0
 
-/**
- * Pure read of the dedup state. Returns true when a fresh
- * `fireFleetAutoFallback` call would actually invoke the dispatcher
- * (vs. being short-circuited by the in-flight or post-fire window).
- *
- * Used by the model-unavailable card render path to decide whether to
- * advertise "Auto-failover in progress" — calling
- * `fireFleetAutoFallback` and blindly trusting the announcement to
- * land would lie when the dispatcher dedup-drops.
- */
+/** Synchronous reachability check for the auth-broker UDS. Used by the
+ *  fleet-fallback gate to keep the model-unavailable card honest: if the
+ *  broker socket isn't bound, the dispatcher would bail with
+ *  `reason=no-broker-client`, so `wouldFire()` should return false and
+ *  the card should fall back to the manual `/auth use <label>` hint. */
+function isAuthBrokerSocketReachable(): boolean {
+  try {
+    return existsSync(resolveAuthBrokerSocketPath())
+  } catch {
+    return false
+  }
+}
+
+const fleetFallbackGate = createFleetFallbackGate({
+  dedupMs: FLEET_FALLBACK_DEDUP_MS,
+  brokerReachable: isAuthBrokerSocketReachable,
+})
+
 function wouldFireFleetAutoFallback(): boolean {
-  if (fleetFallbackInFlight) return false
-  const sinceLastMs = Date.now() - fleetFallbackLastFiredAtMs
-  return sinceLastMs >= FLEET_FALLBACK_DEDUP_MS
+  return fleetFallbackGate.wouldFire()
 }
 
 /**
@@ -8696,36 +8673,14 @@ function wouldFireFleetAutoFallback(): boolean {
  * unavailable" card.
  */
 async function fireFleetAutoFallback(triggerAgent: string): Promise<void> {
-  // Dedup: collapse concurrent fires into the in-flight promise.
-  if (fleetFallbackInFlight) {
-    process.stderr.write(
-      `telegram gateway: [fleet-fallback] dropped (in-flight) agent=${triggerAgent}\n`,
-    )
-    return fleetFallbackInFlight
-  }
-  // Dedup: suppress re-fires within the post-trigger window. The
-  // broker write + announcement broadcast already informed every
-  // user surface of the swap — a second swap N seconds later
-  // would oscillate targets and spam.
-  const sinceLastMs = Date.now() - fleetFallbackLastFiredAtMs
-  if (sinceLastMs < FLEET_FALLBACK_DEDUP_MS) {
-    process.stderr.write(
-      `telegram gateway: [fleet-fallback] dropped (dedup ${sinceLastMs}ms < ${FLEET_FALLBACK_DEDUP_MS}ms) agent=${triggerAgent}\n`,
-    )
-    return
-  }
-  // Stamp `lastFiredAtMs` ONLY on actual swaps (kind: 'switched').
-  // No-ops (no broker, no eligible target, idempotent skip, error)
-  // do NOT arm the suppression window — otherwise a transient
-  // broker hiccup would block the next 30s of legitimate fires.
-  fleetFallbackInFlight = doFireFleetAutoFallback(triggerAgent)
-    .then((didSwap) => {
-      if (didSwap) fleetFallbackLastFiredAtMs = Date.now()
-    })
-    .finally(() => {
-      fleetFallbackInFlight = null
-    })
-  return fleetFallbackInFlight
+  return fleetFallbackGate.fire(
+    () => doFireFleetAutoFallback(triggerAgent),
+    (err) => {
+      process.stderr.write(
+        `telegram gateway: [fleet-fallback] error agent=${triggerAgent}: ${(err as Error)?.message ?? err}\n`,
+      )
+    },
+  )
 }
 
 /** Returns true iff the dispatcher actually performed a swap (and the
@@ -8780,88 +8735,6 @@ async function doFireFleetAutoFallback(triggerAgent: string): Promise<boolean> {
       `telegram gateway: [fleet-fallback] error agent=${triggerAgent}: ${(err as Error)?.message ?? err}\n`,
     )
     return false
-  }
-}
-
-async function runAutoFallbackCheck(opts: { trigger: 'scheduled' | 'manual' }): Promise<AutoFallbackCheckResult> {
-  // All log lines in this path use the `[autofallback]` tag so a single
-  // grep against journalctl reconstructs the full decision history of
-  // a slot rotation: `journalctl -u switchroom-<agent>-gateway -g autofallback`.
-  try {
-    const agentDir = resolveAgentDirFromEnv()
-    if (!agentDir) {
-      return { kind: 'no-action', reason: 'no agent dir', decision: 'noop' }
-    }
-    const agentName = getMyAgentName()
-    seedAutoFallbackLockoutIfNeeded(agentDir)
-    const active = currentActiveSlot(agentDir)
-    const quota = await fetchQuota({ claudeConfigDir: join(agentDir, '.claude') })
-    const decision = evaluateFallbackTrigger({
-      quota,
-      activeSlot: active,
-      now: Date.now(),
-      lockout: autoFallbackLockout,
-    })
-    if (decision.action !== 'fallback') {
-      process.stderr.write(
-        `telegram gateway: [autofallback] noop trigger=${opts.trigger} agent=${agentName} active=${active ?? 'none'} reason=${decision.reason}\n`,
-      )
-      return { kind: 'no-action', reason: decision.reason, decision: 'noop' }
-    }
-    process.stderr.write(
-      `telegram gateway: [autofallback] decision=fallback trigger=${opts.trigger} agent=${agentName} active=${active ?? 'none'} reason=${decision.triggerReason} util=${decision.utilizationPct?.toFixed(1) ?? 'n/a'}%\n`,
-    )
-    const plan = performAutoFallback({
-      agentDir,
-      agentName,
-      decision,
-      deps: { currentActiveSlot, markSlotQuotaExhausted, fallbackToNextSlot },
-    })
-    const ownerChatId = loadAccess().allowFrom[0]
-    await dispatchFallbackNotification({
-      bot,
-      ownerChatId,
-      plan,
-      onError: (err) => {
-        process.stderr.write(`telegram gateway: [autofallback] notify failed trigger=${opts.trigger} agent=${agentName}: ${err}\n`)
-      },
-    })
-    if (plan.kind === 'executed') {
-      try { assertSafeAgentName(plan.agentName) }
-      catch {
-        process.stderr.write(`telegram gateway: [autofallback] invalid-agent-name agent=${plan.agentName}\n`)
-        return { kind: 'error', message: `invalid agent name: ${plan.agentName}` }
-      }
-      try {
-        // Preemptive failover (utilization-over-threshold / explicit) waits
-        // for the active turn to drain. Reactive failover (429-response)
-        // hard-restarts because the request that triggered it has already
-        // failed — there's no in-flight turn worth preserving. See #420.
-        const restartArgs = ['agent', 'restart', plan.agentName]
-        if (plan.triggerReason !== '429-response') {
-          restartArgs.push('--graceful-restart')
-        }
-        process.stderr.write(
-          `telegram gateway: [autofallback] executed agent=${plan.agentName} prev=${plan.previousSlot} next=${plan.newSlot} restart=${plan.triggerReason === '429-response' ? 'hard' : 'graceful'}\n`,
-        )
-        switchroomExec(restartArgs)
-      } catch (err) {
-        process.stderr.write(`telegram gateway: [autofallback] restart failed agent=${plan.agentName}: ${err}\n`)
-      }
-      autoFallbackLockout = nextLockout(plan.previousSlot, Date.now())
-      persistLockout(agentDir)
-      void refreshPinnedBanner('auto-fallback')
-      return { kind: 'executed', previousSlot: plan.previousSlot, newSlot: plan.newSlot }
-    }
-    process.stderr.write(
-      `telegram gateway: [autofallback] exhausted-all agent=${agentName} active=${plan.activeSlot}\n`,
-    )
-    autoFallbackLockout = nextLockout(plan.activeSlot, Date.now())
-    persistLockout(agentDir)
-    return { kind: 'exhausted-all', activeSlot: plan.activeSlot }
-  } catch (err) {
-    process.stderr.write(`telegram gateway: [autofallback] ${opts.trigger} poll error: ${err}\n`)
-    return { kind: 'error', message: String((err as Error).message ?? err) }
   }
 }
 
@@ -8920,15 +8793,6 @@ async function runCreditWatch(): Promise<void> {
     process.stderr.write(`telegram gateway: credit-watch state persist failed: ${err}\n`)
   }
 }
-
-// /authfallback was removed in v0.6.12 — it duplicated the work of
-// the dashboard's Switch primary picker (operator-facing surface) and
-// the auto-fallback poller (transparent on-quota-wall case).
-// Operators who want to manually shuffle the active credential now
-// use the picker. The `runAutoFallbackCheck` function and the
-// `case 'fallback':` callback dispatch stay in the codebase: any
-// pinned messages from earlier versions still work, and the
-// auto-fallback poller still calls runAutoFallbackCheck directly.
 
 bot.command("auth", async ctx => {
   if (!isAuthorizedSender(ctx)) return
@@ -10751,6 +10615,28 @@ async function handleAuthDashboardCallback(ctx: Context): Promise<void> {
   // auth:refresh — re-render the /auth snapshot in-place with a fresh
   // live probe. Replaces the message body; keyboard stays.
   if (data === 'auth:refresh') {
+    // Freshness throttle: each refresh fan-fires N live api.anthropic.com
+    // probes (one per account, force=true bypasses the 5-min cache).
+    // Without this, a user double-tapping the ↻ button burns through
+    // their account's RPM budget on duplicate work. Cap at one per
+    // AUTH_REFRESH_THROTTLE_MS per (chat, message) pair.
+    const refreshMsg = ctx.callbackQuery?.message
+    if (refreshMsg) {
+      const key = `${refreshMsg.chat.id}:${refreshMsg.message_id}`
+      const lastAtMs = lastAuthRefreshAtMs.get(key) ?? 0
+      const sinceLastMs = Date.now() - lastAtMs
+      if (sinceLastMs < AUTH_REFRESH_THROTTLE_MS) {
+        const waitS = Math.ceil((AUTH_REFRESH_THROTTLE_MS - sinceLastMs) / 1000)
+        try {
+          await ctx.answerCallbackQuery({
+            text: `Just refreshed — try again in ${waitS}s`,
+            show_alert: false,
+          })
+        } catch { /* */ }
+        return
+      }
+      lastAuthRefreshAtMs.set(key, Date.now())
+    }
     try {
       const client = await getAuthBrokerClient(currentAgent)
       if (!client) {
@@ -13322,23 +13208,6 @@ void (async () => {
             process.stderr.write(`telegram gateway: writeSessionMarker failed: ${err}\n`)
           }
         } catch {}
-
-        // Auto-fallback on quota exhaustion. Periodically polls
-        // the active slot's rate-limit headers; when utilization >= 99.5%
-        // or a 429 is observed, marks the slot exhausted, swaps to the
-        // next healthy slot via src/auth, restarts the agent, and posts
-        // a notification to the owner chat. See telegram-plugin/auto-fallback.ts
-        // for the pure decision logic + notification builder.
-        //
-        // Default poll cadence: every 60 minutes. Set
-        // SWITCHROOM_AUTO_FALLBACK_POLL_MS=0 to disable the background
-        // poller. Pre-v0.6.12 a manual `/authfallback` typed command
-        // also ran the same check; that command was removed in favour
-        // of the `/auth` dashboard's Switch primary picker.
-        const AUTO_FALLBACK_POLL_MS = Number(process.env.SWITCHROOM_AUTO_FALLBACK_POLL_MS ?? 60 * 60_000)
-        if (AUTO_FALLBACK_POLL_MS > 0) {
-          setInterval(() => { void runAutoFallbackCheck({ trigger: 'scheduled' }) }, AUTO_FALLBACK_POLL_MS).unref()
-        }
 
         // Credit-exhaustion watcher (#348). Reads `<agentDir>/.claude/.claude.json`
         // for `cachedExtraUsageDisabledReason`. Fires a Telegram notification

--- a/telegram-plugin/tests/fleet-fallback-gate.test.ts
+++ b/telegram-plugin/tests/fleet-fallback-gate.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import { createFleetFallbackGate } from "../fleet-fallback-gate.js";
+
+function fakeClock(start = 0) {
+  let now = start;
+  return {
+    nowFn: () => now,
+    advance(ms: number) { now += ms; },
+    set(ms: number) { now = ms; },
+  };
+}
+
+describe("createFleetFallbackGate — wouldFire honesty contract", () => {
+  test("fresh state: wouldFire is true", () => {
+    const gate = createFleetFallbackGate({ dedupMs: 30_000, nowFn: fakeClock().nowFn });
+    expect(gate.wouldFire()).toBe(true);
+  });
+
+  test("in-flight: wouldFire is false until action resolves", async () => {
+    const clock = fakeClock();
+    const gate = createFleetFallbackGate({ dedupMs: 30_000, nowFn: clock.nowFn });
+
+    let resolveAction: (b: boolean) => void = () => {};
+    const action = () => new Promise<boolean>((r) => { resolveAction = r; });
+
+    const firePromise = gate.fire(action);
+
+    expect(gate.wouldFire()).toBe(false);
+    expect(gate.inspect().inFlight).toBe(true);
+
+    resolveAction(true);
+    await firePromise;
+
+    // After fire stamps lastFiredAtMs, dedup window blocks until clock advances.
+    expect(gate.wouldFire()).toBe(false);
+    clock.advance(30_000);
+    expect(gate.wouldFire()).toBe(true);
+  });
+
+  test("post-fire dedup window blocks wouldFire", async () => {
+    const clock = fakeClock();
+    const gate = createFleetFallbackGate({ dedupMs: 30_000, nowFn: clock.nowFn });
+
+    await gate.fire(async () => true);
+    expect(gate.wouldFire()).toBe(false);
+
+    clock.advance(29_999);
+    expect(gate.wouldFire()).toBe(false);
+
+    clock.advance(1);
+    expect(gate.wouldFire()).toBe(true);
+  });
+
+  test("no-op fires (action returns false) DO NOT arm dedup window", async () => {
+    const clock = fakeClock();
+    const gate = createFleetFallbackGate({ dedupMs: 30_000, nowFn: clock.nowFn });
+
+    await gate.fire(async () => false);
+    // Window NOT armed — wouldFire should still be true immediately.
+    expect(gate.wouldFire()).toBe(true);
+    expect(gate.inspect().lastFiredAtMs).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  test("thrown action: dedup window NOT armed, gate releases in-flight", async () => {
+    const clock = fakeClock();
+    const gate = createFleetFallbackGate({ dedupMs: 30_000, nowFn: clock.nowFn });
+    const errors: unknown[] = [];
+
+    await gate.fire(async () => { throw new Error("broker exploded"); }, (e) => errors.push(e));
+
+    expect(gate.inspect().inFlight).toBe(false);
+    expect(gate.inspect().lastFiredAtMs).toBe(Number.NEGATIVE_INFINITY);
+    expect(gate.wouldFire()).toBe(true);
+    expect((errors[0] as Error).message).toBe("broker exploded");
+  });
+
+  test("no onError: thrown action still releases in-flight without crashing", async () => {
+    const gate = createFleetFallbackGate({ dedupMs: 30_000, nowFn: fakeClock().nowFn });
+
+    await gate.fire(async () => { throw new Error("silent"); });
+
+    expect(gate.inspect().inFlight).toBe(false);
+    expect(gate.wouldFire()).toBe(true);
+  });
+});
+
+describe("createFleetFallbackGate — fire semantics", () => {
+  test("collapses concurrent callers to one in-flight Promise", async () => {
+    const clock = fakeClock();
+    const gate = createFleetFallbackGate({ dedupMs: 30_000, nowFn: clock.nowFn });
+    let calls = 0;
+    let resolveAction: (b: boolean) => void = () => {};
+
+    const action = () => {
+      calls += 1;
+      return new Promise<boolean>((r) => { resolveAction = r; });
+    };
+
+    const p1 = gate.fire(action);
+    const p2 = gate.fire(action);
+    const p3 = gate.fire(action);
+
+    // Same in-flight promise returned to all three callers.
+    expect(p1).toBe(p2);
+    expect(p2).toBe(p3);
+    expect(calls).toBe(1);
+
+    resolveAction(true);
+    await Promise.all([p1, p2, p3]);
+    expect(calls).toBe(1);
+  });
+
+  test("fire during dedup window resolves immediately without invoking action", async () => {
+    const clock = fakeClock();
+    const gate = createFleetFallbackGate({ dedupMs: 30_000, nowFn: clock.nowFn });
+    let calls = 0;
+
+    await gate.fire(async () => { calls += 1; return true; });
+    expect(calls).toBe(1);
+
+    await gate.fire(async () => { calls += 1; return true; });
+    expect(calls).toBe(1);
+
+    clock.advance(30_000);
+
+    await gate.fire(async () => { calls += 1; return true; });
+    expect(calls).toBe(2);
+  });
+});
+
+describe("createFleetFallbackGate — broker reachability check", () => {
+  test("brokerReachable=false makes wouldFire return false even on fresh state", () => {
+    const gate = createFleetFallbackGate({
+      dedupMs: 30_000,
+      nowFn: fakeClock().nowFn,
+      brokerReachable: () => false,
+    });
+    expect(gate.wouldFire()).toBe(false);
+  });
+
+  test("brokerReachable=true gates as if no check provided", () => {
+    const gate = createFleetFallbackGate({
+      dedupMs: 30_000,
+      nowFn: fakeClock().nowFn,
+      brokerReachable: () => true,
+    });
+    expect(gate.wouldFire()).toBe(true);
+  });
+
+  test("brokerReachable=false makes fire() short-circuit without invoking action", async () => {
+    let calls = 0;
+    const gate = createFleetFallbackGate({
+      dedupMs: 30_000,
+      nowFn: fakeClock().nowFn,
+      brokerReachable: () => false,
+    });
+
+    await gate.fire(async () => { calls += 1; return true; });
+    expect(calls).toBe(0);
+    expect(gate.inspect().lastFiredAtMs).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  test("brokerReachable can flip from false to true between calls", async () => {
+    let reachable = false;
+    let calls = 0;
+    const gate = createFleetFallbackGate({
+      dedupMs: 30_000,
+      nowFn: fakeClock().nowFn,
+      brokerReachable: () => reachable,
+    });
+
+    expect(gate.wouldFire()).toBe(false);
+    await gate.fire(async () => { calls += 1; return true; });
+    expect(calls).toBe(0);
+
+    reachable = true;
+    expect(gate.wouldFire()).toBe(true);
+    await gate.fire(async () => { calls += 1; return true; });
+    expect(calls).toBe(1);
+  });
+});
+
+describe("createFleetFallbackGate — reset (test seam)", () => {
+  test("reset clears in-flight + lastFiredAtMs", async () => {
+    const clock = fakeClock();
+    const gate = createFleetFallbackGate({ dedupMs: 30_000, nowFn: clock.nowFn });
+
+    await gate.fire(async () => true);
+    expect(gate.inspect().lastFiredAtMs).toBeGreaterThan(Number.NEGATIVE_INFINITY);
+    expect(gate.wouldFire()).toBe(false);
+
+    gate.reset();
+    expect(gate.inspect().lastFiredAtMs).toBe(Number.NEGATIVE_INFINITY);
+    expect(gate.inspect().inFlight).toBe(false);
+    expect(gate.wouldFire()).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -134,6 +134,8 @@ export default defineConfig({
       "**/telegram-plugin/tests/history-reaper.test.ts",
       // sandbox-hint-posttool.test.ts uses bun:test — run via test:bun.
       "**/telegram-plugin/tests/sandbox-hint-posttool.test.ts",
+      // fleet-fallback-gate.test.ts uses bun:test — run via test:bun.
+      "**/telegram-plugin/tests/fleet-fallback-gate.test.ts",
       "**/telegram-plugin/tests/ipc-server-client.test.ts",
       "**/telegram-plugin/tests/ipc-server-race.test.ts",
       "**/telegram-plugin/tests/gateway-bridge.test.ts",


### PR DESCRIPTION
## Summary

Four deferred follow-ups to PR #1317 (Format 2 /auth + causal auto-fallback). Each scoped to lock down a specific corner the reviewer flagged but moved out of #1317.

### (D) Lift `createFleetFallbackGate` primitive
- Extract `telegram-plugin/fleet-fallback-gate.ts` with `wouldFire / fire / reset / inspect`.
- Module-level `fleetFallbackInFlight` + `lastFiredAtMs` in gateway.ts replaced by an injectable gate.
- 13 unit tests cover the honesty contract: fresh state → fire, in-flight → no fire, dedup-window-active → no fire, no-op fire (action returns false) does NOT arm dedup, thrown action does NOT arm dedup, concurrent fires collapse to one Promise, broker-unreachable short-circuits without invoking action.

### (C) Broker reachability — keep the card honest
- Gate now accepts `brokerReachable: () => boolean`; gateway wires `existsSync(resolveAuthBrokerSocketPath())`.
- Closes the "card lies" gap from #1317 round-2 review: previously the model-unavailable card could promise "auto-failover in progress" while the dispatcher bailed silently with `reason=no-broker-client`.

### (B) `auth:refresh` freshness guard
- Per-`(chat_id, message_id)` Map throttles refresh taps to 5s.
- Each tap fan-fires N live `api.anthropic.com` probes (`force=true` bypasses the 5-min cache); rapid re-taps now get a "Just refreshed — try again in Xs" toast instead of duplicate API churn.
- Reaper sweeps stale entries (>60s) on the existing TTL pass.

### (A) Retire legacy `runAutoFallbackCheck` poller
- Delete the function + `setInterval` driven by `SWITCHROOM_AUTO_FALLBACK_POLL_MS`.
- Fleet path on the model-unavailable card render fully supersedes it (single fleet-wide swap vs per-agent local rotation).
- Drops 7 now-unused imports from `auto-fallback.ts` / `auth/manager.ts` / `auto-fallback-dispatcher.ts`.
- Lockout file format stays read-supported via `isAutoFallbackCooldownActive` (pending-restart drain cap reads it); existing on-disk lockouts age out via `DEFAULT_FALLBACK_COOLDOWN_MS`.

Net: gateway.ts −215 / +86. Tests: type-check ✓; bun-test 752/754 (only pre-existing skips); vitest pass except a pre-existing `doctor.mff.test.ts` MFF probe flake unrelated to this branch.

## Test plan

- [x] `npm run lint` (tsc + plugin-references + bot-api wrapping + bun-test imports) — clean
- [x] `npm run test:bun` — 752 pass, 0 fail
- [x] `npm run test:vitest` — 6171 pass, 1 unrelated flake (doctor.mff)
- [x] `npm run build` — clean
- [ ] Reviewer agent verdict (separate process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)