### PR TITLE
perf(docker): three image-build optimisations — skip arm64 on PRs, cache mounts, COPY reorder

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -67,7 +67,12 @@ jobs:
           bun install
           npm run build
 
-      - name: Set up QEMU (for arm64 cross-build)
+      - name: Set up QEMU (only when arm64 build runs)
+        # QEMU is only needed for cross-arch arm64 emulation on amd64
+        # hosts. PR builds are amd64-only (see `platforms` below), so
+        # skip the QEMU setup — saves ~5s + cuts the resulting image
+        # surface area.
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -101,7 +106,11 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.base
-          platforms: linux/amd64,linux/arm64
+          # PR validation: amd64 only — arm64 via QEMU is ~3-4 min per
+          # image and PRs don't merge until amd64 is green anyway. Full
+          # multi-arch matrix runs on push to main + tags where the
+          # arm64 artifact is consumed by operators.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           tags: ${{ steps.tags.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=base
@@ -150,7 +159,8 @@ jobs:
           bun install
           npm run build
 
-      - name: Set up QEMU (for arm64 cross-build)
+      - name: Set up QEMU (only when arm64 build runs)
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -188,7 +198,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.image.file }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           tags: ${{ steps.tags.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
@@ -207,7 +217,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU (for arm64 cross-build)
+      - name: Set up QEMU (only when arm64 build runs)
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -240,7 +251,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.hindsight
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           tags: ${{ steps.tags.outputs.tags }}
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=hindsight

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # switchroom/agent — one container per agent.
 #
 # PID 1 is tini. ENTRYPOINT runs start.sh (rendered into the agent's
@@ -34,98 +35,12 @@ RUN mkdir -p /state/agent /state/.claude /var/log/switchroom \
 # the compose `user:` directive at runtime.
 RUN mkdir -p /tmp/tmux-shared
 
-# autoaccept-poll bundle: a small bun-runnable JS that uses
-# `tmux capture-pane / send-keys` to dispatch keystrokes for first-run
-# claude TUI prompts (theme picker, MCP trust, dev-channels
-# acknowledgement, API provider picker). Under v0.6 systemd this was
-# spawned as ExecStartPost on the host; under v0.7 docker the agent
-# runs claude inside an in-container tmux (see start.sh's docker
-# preamble) and start.sh forks autoaccept-poll as a sidecar. Bake the
-# self-contained bundle into the image so start.sh has a stable path
-# (`/opt/switchroom/autoaccept-poll.js`) to invoke regardless of
-# operator install layout.
-COPY dist/cli/autoaccept-poll.js /opt/switchroom/autoaccept-poll.js
-RUN chmod 0755 /opt/switchroom/autoaccept-poll.js
-
-# Drive-write PreToolUse hook (RFC E §4.2 Cut 2). Bundled self-
-# contained .mjs that intercepts `mcp__google-workspace__*` write
-# tool calls and gates them behind a Telegram diff-preview approval
-# card. Bake under /opt/switchroom/hooks/ so the scaffold's hook
-# command path is stable across operator installs.
-COPY dist/cli/drive-write-pretool.mjs /opt/switchroom/hooks/drive-write-pretool.mjs
-RUN chmod 0755 /opt/switchroom/hooks/drive-write-pretool.mjs
-
-# switchroom CLI bundle: the in-container telegram-plugin gateway sidecar
-# shells out to `switchroom <verb>` for /auth, /vault, /agent, /topics
-# and friends (see telegram-plugin/gateway/gateway.ts:switchroomExec). On
-# v0.6 systemd the host's installed CLI was on PATH; under v0.7+ docker
-# the agent container is its own filesystem and the host CLI isn't
-# reachable. Without this bake, every gateway shell-out hits ENOENT and
-# Telegram-driven `/auth add`, `/auth code`, `/auth list`, `/vault …`,
-# `/agent restart` (the post-fallback restart) all fail silently. The
-# bundle is self-contained (bun build --target node + bun shebang) and
-# bun is already in the base image, so a symlink onto PATH is enough.
-COPY dist/cli/switchroom.js /opt/switchroom/switchroom.js
-RUN chmod 0755 /opt/switchroom/switchroom.js \
- && ln -s /opt/switchroom/switchroom.js /usr/local/bin/switchroom
-
-# telegram-plugin: the MCP channel server claude spawns when invoked
-# with `--dangerously-load-development-channels server:switchroom-telegram`.
-# Resolved by bun via `bun run --cwd /opt/switchroom/telegram-plugin
-# --silent start` (see scaffold.ts:.mcp.json under SWITCHROOM_RUNTIME=docker).
-# The plugin needs three pieces:
-#   - dist/server.js     — the MCP entry (start.js falls back to source if
-#                          dist absent; the bake guarantees dist is present)
-#   - dist/gateway/      — the long-running gateway daemon that polls
-#                          Telegram and writes ~/.../telegram/gateway.sock;
-#                          spawned by start.sh as a sidecar
-#   - start.js           — entry shim that picks dist over source
-#   - package.json       — `bun run start` resolution
-# Under v0.6 systemd the plugin was reachable via the dev checkout path
-# (or npm-global install path on prod hosts); under v0.7 docker the
-# image is the source of truth, and `.mcp.json` points at the in-image
-# path. Without this COPY, the MCP sidecar exits at boot:
-#   "telegram channel: no gateway socket at <path>. Run `switchroom
-#    setup` to install the gateway daemon..."
-COPY telegram-plugin/dist /opt/switchroom/telegram-plugin/dist
-COPY telegram-plugin/start.js /opt/switchroom/telegram-plugin/start.js
-COPY telegram-plugin/package.json /opt/switchroom/telegram-plugin/package.json
-# Hooks (PreToolUse / PostToolUse / Stop / UserPromptSubmit) — Claude Code
-# spawns these as child processes whenever the corresponding hook fires
-# (see `<agentDir>/.claude/settings.json` `hooks` block, scaffolded by
-# `src/agents/scaffold.ts:buildSettingsHooksBlock`). Pre-this-bake the
-# scaffolded paths pointed at the operator's host repo checkout, which
-# doesn't exist inside the container — Claude Code silently skipped them
-# and the bg-sub-agent tracking, secret-redaction, tool-label, and silent-
-# end paths all went dark in docker mode. Surfaced by RFC Phase 3 §Bug 3
-# (reference/sub-agent-visibility-rfc.md); confirmed via the test-harness
-# registry.db being a 4096-byte file with zero tables.
-COPY telegram-plugin/hooks /opt/switchroom/telegram-plugin/hooks
-COPY bin/run-hook.sh /opt/switchroom/bin/run-hook.sh
-COPY bin/timezone-hook.sh /opt/switchroom/bin/timezone-hook.sh
-COPY bin/user-profile-refresh-hook.sh /opt/switchroom/bin/user-profile-refresh-hook.sh
-COPY bin/workspace-stable-hook.sh /opt/switchroom/bin/workspace-stable-hook.sh
-COPY bin/workspace-dynamic-hook.sh /opt/switchroom/bin/workspace-dynamic-hook.sh
-RUN chmod +x /opt/switchroom/bin/*.sh
-
-# Phase 2 cron-fold-in: the in-agent scheduler bundle plus its node-cron
-# runtime dep. Started by start.sh as a third supervised sidecar (after
-# gateway + autoaccept-poll) only when SWITCHROOM_INLINE_SCHEDULER=1 —
-# off by default until Phase 4 cuts the singleton over. Bundle is built
-# by scripts/build.mjs with --external node-cron, so the image must
-# provide it. node-cron is pure JS (no native compilation), so install
-# is fast and arch-independent.
-COPY dist/agent-scheduler/index.js /opt/switchroom/agent-scheduler/index.js
-WORKDIR /opt/switchroom/agent-scheduler
-RUN npm init -y >/dev/null \
- && node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));p.type='module';fs.writeFileSync('package.json',JSON.stringify(p,null,2));" \
- && npm install --omit=dev --build-from-source=false node-cron@^3.0.3
-WORKDIR /
-
+# ─── Rare-changed install layers (FIRST, so dist/ churn doesn't bust them) ───
+#
 # Playwright — pre-baked for skills that use browser automation
 # (calendar / scrape / UI-test). Pre-this-bake, agents called
-# \`npx playwright\` which triggered an on-demand download of the
-# browser binaries into \`~/.cache/ms-playwright/\` per agent on
+# `npx playwright` which triggered an on-demand download of the
+# browser binaries into `~/.cache/ms-playwright/` per agent on
 # first call (~30s latency, plus N copies of ~150MB browsers across
 # the fleet). Baking it in:
 #
@@ -135,20 +50,87 @@ WORKDIR /
 #
 # Major-version pin: the npm install resolves to the latest 1.x at
 # image build time; CI re-builds the image when a new patch lands.
-# Bumping the major requires CI to re-run \`playwright install
-# --with-deps\` in case browser-binary versions changed.
+# Bumping the major requires CI to re-run `playwright install
+# --with-deps` in case browser-binary versions changed.
 #
-# \`--with-deps chromium\` installs the apt packages chromium needs
+# `--with-deps chromium` installs the apt packages chromium needs
 # at runtime (libnss3, libatk1.0-0, libcups2 etc.). Firefox / Webkit
-# can be added per-agent via \`npx playwright install <browser>\`
+# can be added per-agent via `npx playwright install <browser>`
 # without re-baking; chromium is the default because most skills
 # use it.
 #
-# Browser binaries land at \$PLAYWRIGHT_BROWSERS_PATH (image layer,
-# OS-independent) instead of \$HOME/.cache/.
+# Browser binaries land at $PLAYWRIGHT_BROWSERS_PATH (image layer,
+# OS-independent) instead of $HOME/.cache/.
+#
+# Placed here — well above the `COPY dist/**` block — so a typical
+# src-only PR rebuilds 3-4 small COPY layers instead of triggering
+# this ~150MB layer (which would also pay ~20s of `playwright install`).
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright/browsers
-RUN npm install -g playwright@^1.49.0 \
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm install -g playwright@^1.49.0 \
  && npx playwright install --with-deps chromium
+
+# Phase 2 cron-fold-in: the in-agent scheduler's node-cron runtime dep.
+# Bundle is built by scripts/build.mjs with --external node-cron, so the
+# image must provide it. node-cron is pure JS (no native compilation),
+# so install is fast and arch-independent. The bundle itself (`index.js`)
+# is COPYed in the dist block below — only the npm install is layered
+# here so a src-only change doesn't re-run npm install.
+WORKDIR /opt/switchroom/agent-scheduler
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    npm init -y >/dev/null \
+ && node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json'));p.type='module';fs.writeFileSync('package.json',JSON.stringify(p,null,2));" \
+ && npm install --omit=dev --build-from-source=false node-cron@^3.0.3
+WORKDIR /
+
+# telegram-plugin metadata + hooks — rarely changed compared to the
+# plugin's built dist. Hooks (PreToolUse / PostToolUse / Stop /
+# UserPromptSubmit) are Claude-Code-spawned child processes; pre-this-
+# bake the scaffolded paths pointed at the operator's host repo checkout
+# which doesn't exist inside the container — Claude Code silently
+# skipped them and bg-sub-agent tracking, secret-redaction, tool-label,
+# and silent-end paths all went dark in docker mode (RFC Phase 3 §Bug 3,
+# reference/sub-agent-visibility-rfc.md).
+COPY telegram-plugin/start.js /opt/switchroom/telegram-plugin/start.js
+COPY telegram-plugin/package.json /opt/switchroom/telegram-plugin/package.json
+COPY telegram-plugin/hooks /opt/switchroom/telegram-plugin/hooks
+COPY bin/run-hook.sh /opt/switchroom/bin/run-hook.sh
+COPY bin/timezone-hook.sh /opt/switchroom/bin/timezone-hook.sh
+COPY bin/user-profile-refresh-hook.sh /opt/switchroom/bin/user-profile-refresh-hook.sh
+COPY bin/workspace-stable-hook.sh /opt/switchroom/bin/workspace-stable-hook.sh
+COPY bin/workspace-dynamic-hook.sh /opt/switchroom/bin/workspace-dynamic-hook.sh
+RUN chmod +x /opt/switchroom/bin/*.sh
+
+# ─── Frequently-changed dist COPYs (LAST, only these bust on src-only PRs) ───
+#
+# autoaccept-poll bundle: a small bun-runnable JS that uses
+# `tmux capture-pane / send-keys` to dispatch keystrokes for first-run
+# claude TUI prompts (theme picker, MCP trust, dev-channels
+# acknowledgement, API provider picker). start.sh forks it as a sidecar.
+COPY dist/cli/autoaccept-poll.js /opt/switchroom/autoaccept-poll.js
+RUN chmod 0755 /opt/switchroom/autoaccept-poll.js
+
+# Drive-write PreToolUse hook (RFC E §4.2 Cut 2). Bundled self-contained
+# .mjs that intercepts `mcp__google-workspace__*` write tool calls and
+# gates them behind a Telegram diff-preview approval card.
+COPY dist/cli/drive-write-pretool.mjs /opt/switchroom/hooks/drive-write-pretool.mjs
+RUN chmod 0755 /opt/switchroom/hooks/drive-write-pretool.mjs
+
+# switchroom CLI bundle: the in-container telegram-plugin gateway sidecar
+# shells out to `switchroom <verb>` for /auth, /vault, /agent, /topics
+# and friends (see telegram-plugin/gateway/gateway.ts:switchroomExec).
+COPY dist/cli/switchroom.js /opt/switchroom/switchroom.js
+RUN chmod 0755 /opt/switchroom/switchroom.js \
+ && ln -s /opt/switchroom/switchroom.js /usr/local/bin/switchroom
+
+# telegram-plugin dist — the MCP channel server claude spawns + the
+# gateway daemon. Resolved by bun via `bun run --cwd
+# /opt/switchroom/telegram-plugin --silent start` (see scaffold.ts).
+COPY telegram-plugin/dist /opt/switchroom/telegram-plugin/dist
+
+# agent-scheduler bundle. node-cron was npm-installed above; this COPY
+# only drops the (frequently-changing) bundle into the existing dir.
+COPY dist/agent-scheduler/index.js /opt/switchroom/agent-scheduler/index.js
 
 # tini handles zombies + signal forwarding. The actual command is
 # /state/agent/start.sh, which the scaffold renders into the bind-mount.

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # switchroom/base — shared image for agent / broker / kernel / scheduler.
 #
 # Multi-arch: declare TARGETARCH so buildx (linux/amd64 + linux/arm64) picks
@@ -48,7 +49,18 @@ RUN echo "switchroom/base building for arch=${TARGETARCH}" >&2
 #   tree, file                 — directory orientation + content sniffing
 #   dnsutils, iputils-ping,
 #   netcat-openbsd             — network connectivity debugging trio
-RUN apt-get update \
+# BuildKit cache mounts persist /var/cache/apt + /var/lib/apt/lists across
+# layer-cache invalidations. The default debian docker-clean hook deletes
+# downloaded .debs after each apt-get install — the `rm -f docker-clean`
+# line disables that so the cache actually accumulates. `sharing=locked`
+# serialises concurrent buildx layers writing to the same cache. On a cold
+# CI build with no buildkit cache yet, the apt download phase still runs
+# fully; on warm builds (cache-from=gha hit, but layer hash changed e.g.
+# via a Dockerfile edit) the .debs are reused → ~25-30s saved.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
       tini \
       tmux \
@@ -81,8 +93,7 @@ RUN apt-get update \
       dnsutils \
       iputils-ping \
       netcat-openbsd \
- && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
- && rm -rf /var/lib/apt/lists/*
+ && ln -sf /usr/bin/fdfind /usr/local/bin/fd
 
 # GitHub CLI (`gh`) — promoted to Tier 1 because `gh auth login` is
 # table stakes once Layer 1's persistent HOME makes the credentials
@@ -91,14 +102,15 @@ RUN apt-get update \
 # cli.github.com/manual/installation). Keyring goes in
 # /usr/share/keyrings (modern Debian convention) rather than
 # apt-key (deprecated).
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
  && chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg \
  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
       > /etc/apt/sources.list.d/github-cli.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends gh \
- && rm -rf /var/lib/apt/lists/* \
  && gh --version >&2
 
 # Pin claude CLI version in the base image so every agent / scheduler
@@ -119,7 +131,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 # Default `default` so local `docker build` (no build-arg) still
 # works deterministically.
 ARG CACHE_BUST=default
-RUN echo "cache-bust=${CACHE_BUST}" > /dev/null \
+# Cache the npm download dir so a CACHE_BUST-driven re-run only pays the
+# version-resolve + install cost, not the ~30s re-download. /root/.npm is
+# npm's content-addressed tarball cache — invariant across CACHE_BUST
+# bumps.
+RUN --mount=type=cache,target=/root/.npm,sharing=locked \
+    echo "cache-bust=${CACHE_BUST}" > /dev/null \
  && npm install -g @anthropic-ai/claude-code@latest \
  && claude --version >&2
 

--- a/docker/Dockerfile.hostd
+++ b/docker/Dockerfile.hostd
@@ -61,7 +61,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       docker-ce-cli \
       docker-compose-plugin \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb
 
 # Socket parent dir — keep 0o755 here so a stale Dockerfile-level
 # default can't override what the daemon enforces at runtime.


### PR DESCRIPTION
## Summary

Three independent, additive docker speedups on top of the CI baseline (#1320, #1321, #1323).

| Optimisation | Where | Savings (estimated) |
|---|---|---|
| Skip arm64 on PRs (build amd64 only) | `docker-images.yml` | ~3-4 min/PR (QEMU avoidance) |
| \`RUN --mount=type=cache\` for apt + npm | \`Dockerfile.base\` | ~25-30s on warm runs |
| COPY reorder (rare-changed first, dist/ last) | \`Dockerfile.agent\` | ~10-20s warm builds |

## 1. Skip arm64 on PR validations

\`docker-images.yml\` previously built every image on \`linux/amd64,linux/arm64\` for every PR. arm64 on a hosted amd64 runner means QEMU emulation — slow. With 7 images in the matrix that's the dominant cost on PR validation.

Replaces \`platforms:\` with a conditional that builds amd64-only on PRs and the full matrix on push to main + tags. Also gates \`docker/setup-qemu-action@v3\` on the same condition (no QEMU needed for native amd64). PRs still catch Dockerfile syntax + amd64 buildability; arm64 catches at merge time when the artifact actually ships to operators.

## 2. BuildKit cache mounts in \`Dockerfile.base\`

Adds \`# syntax=docker/dockerfile:1.7\` and wraps the 3 install \`RUN\`s with \`--mount=type=cache\`:

- \`apt-get install\` (Tier 1 packages) → \`/var/cache/apt\` + \`/var/lib/apt/lists\`
- \`apt-get install gh\` (GitHub CLI) → same paths
- \`npm install -g @anthropic-ai/claude-code\` → \`/root/.npm\`

Disables the default Debian docker-clean hook (\`rm -f /etc/apt/apt.conf.d/docker-clean\`) so the cache mount accumulates. Drops the trailing \`rm -rf /var/lib/apt/lists/*\` (cache mount supersedes).

**Persists across layer-cache invalidations.** On a \`gh run rerun\` (which bumps \`CACHE_BUST=\${{ github.run_attempt }}\` and forces the claude-code layer to re-resolve \`@latest\`), the npm download cache still hits → re-resolve happens without re-downloading every tarball.

## 3. \`Dockerfile.agent\` COPY reorder

Pre-this-change every \`dist/cli/*.js\` COPY (changes every src commit) sat **above** \`playwright install\` (~150MB) and the \`node-cron\` npm install. A typical src-only PR busted both, paying ~20s of \`playwright install\` for no good reason.

**New order:**
1. \`mkdir\` layers (state, log, tmux runtime)
2. ENV \`PLAYWRIGHT_BROWSERS_PATH\` + \`npm install playwright\` + chromium browsers
3. \`agent-scheduler\` WORKDIR + node-cron npm install (no source COPY here — only the install)
4. \`telegram-plugin/{start.js, package.json, hooks}\` + \`bin/*.sh\` (rare)
5. **All \`dist/*\` COPYs at the end** — autoaccept-poll, drive-write-pretool, switchroom.js, telegram-plugin/dist, agent-scheduler/index.js

The agent-scheduler dir is created by WORKDIR + npm init in step 3; the (frequently-changed) bundle COPYs in step 5 land alongside the (rarely-changed) node_modules. Identical bytes in the final image; just better layer-cache locality.

## Test plan

- [ ] PR CI: \`docker-images\` matrix runs amd64-only — verify no arm64 build steps fire
- [ ] PR CI: cold cache run completes (build-base + 5 dependents + hindsight)
- [ ] Manually re-run on this PR — observe \`docker-images\` is faster on second run due to cache mounts hitting
- [ ] After merge to main: verify full arm64+amd64 matrix runs as before

## Combined with #1323

Stacking against the previous speedup:
- vitest: ~1m10s → ~25s combined on small PRs
- docker-e2e: cold ~2m → warm ~30-40s
- docker-images.yml (PR validation): ~6-8 min cold → ~3-4 min after arm64 skip + cache mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)