### PR TITLE
ci(gha): skip-as-pass pattern — flexible required checks for narrow-scope PRs

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,27 +1,20 @@
 name: ci-lint
 
 # Type-check + 3 lint scripts. Mirrors Buildkite step :lock: Type check.
-# Triggers narrowly so docs-only / profile-only PRs skip entirely.
 #
-# Dual-run: this runs alongside Buildkite, status check is named distinctly
-# (`ci-lint / lint`) so branch protection can keep BK as the required check
-# while we monitor GHA.
+# Skip-as-pass pattern (#1320 followup):
+#   Workflow ALWAYS runs on every PR so the `lint` check fires. The
+#   precursor `changes` job uses dorny/paths-filter to compute whether
+#   anything lint-relevant changed; the real `lint` job is `if:`-gated
+#   on that output and reports `skipped` (= success for branch
+#   protection) on irrelevant PRs. Net effect is the same compute
+#   saving as the old workflow-level paths: filter, without the
+#   "never reported" trap that blocks doc-only PRs on classic branch
+#   protection.
 
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "tsconfig.json"
-      - "package.json"
-      - "bun.lock"
-      - "telegram-plugin/package.json"
-      - "telegram-plugin/bun.lock"
-      - "scripts/check-*.mjs"
-      - "scripts/check-bot-api-wrapping.sh"
-      - ".github/actions/setup-switchroom/**"
-      - ".github/workflows/ci-lint.yml"
   push:
     branches: [main]
 
@@ -33,7 +26,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - '**/*.ts'
+              - '**/*.tsx'
+              - 'tsconfig.json'
+              - 'package.json'
+              - 'bun.lock'
+              - 'telegram-plugin/package.json'
+              - 'telegram-plugin/bun.lock'
+              - 'scripts/check-*.mjs'
+              - 'scripts/check-bot-api-wrapping.sh'
+              - '.github/actions/setup-switchroom/**'
+              - '.github/workflows/ci-lint.yml'
+
   lint:
+    needs: changes
+    # Push to main: always run (don't gamble on main).
+    # PR: gate on changed paths.
+    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ci-tests-core.yml
+++ b/.github/workflows/ci-tests-core.yml
@@ -32,19 +32,6 @@ name: ci-tests-core
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "src/**"
-      - "tests/**"
-      - "telegram-plugin/**/*.ts"
-      - "scripts/build.mjs"
-      - "vitest.config.ts"
-      - "tsconfig.json"
-      - "package.json"
-      - "bun.lock"
-      - "telegram-plugin/package.json"
-      - "telegram-plugin/bun.lock"
-      - ".github/actions/setup-switchroom/**"
-      - ".github/workflows/ci-tests-core.yml"
   push:
     branches: [main]
 
@@ -56,8 +43,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ─── Path-change filter (skip-as-pass pattern, #1320 followup) ────
+  # Workflow ALWAYS runs so the required `vitest (1-4)` check fires
+  # on every PR. The real jobs are if:-gated on this output and
+  # report `skipped` (= success for branch protection) when no
+  # vitest-relevant paths changed.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'tests/**'
+              - 'telegram-plugin/**/*.ts'
+              - 'scripts/build.mjs'
+              - 'vitest.config.ts'
+              - 'tsconfig.json'
+              - 'package.json'
+              - 'bun.lock'
+              - 'telegram-plugin/package.json'
+              - 'telegram-plugin/bun.lock'
+              - '.github/actions/setup-switchroom/**'
+              - '.github/workflows/ci-tests-core.yml'
+
   # ─── Build dist/ once, share with all shards ──────────────────────
   build-dist:
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -82,7 +103,8 @@ jobs:
 
   # ─── Sharded vitest run ───────────────────────────────────────────
   vitest:
-    needs: build-dist
+    needs: [changes, build-dist]
+    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/ci-tests-plugin.yml
+++ b/.github/workflows/ci-tests-plugin.yml
@@ -3,6 +3,8 @@ name: ci-tests-plugin
 # Bun test suite for telegram-plugin/ (bun-runtime-only tests that vitest
 # can't load). Mirrors Buildkite :telegram: Plugin tests (402).
 #
+# Skip-as-pass pattern (#1320 followup): see ci-lint.yml header.
+#
 # Workspace install discipline: we do NOT `cd telegram-plugin && bun install`.
 # telegram-plugin is a bun workspace of the root, and the root install via
 # the composite action already brings in its deps via the hoisted node_modules.
@@ -13,14 +15,6 @@ name: ci-tests-plugin
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "telegram-plugin/**"
-      - "package.json"
-      - "bun.lock"
-      - "telegram-plugin/package.json"
-      - "telegram-plugin/bun.lock"
-      - ".github/actions/setup-switchroom/**"
-      - ".github/workflows/ci-tests-plugin.yml"
   push:
     branches: [main]
 
@@ -32,7 +26,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'telegram-plugin/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'telegram-plugin/package.json'
+              - 'telegram-plugin/bun.lock'
+              - '.github/actions/setup-switchroom/**'
+              - '.github/workflows/ci-tests-plugin.yml'
+
   bun-test:
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 8
     env:

--- a/.github/workflows/ci-tests-python.yml
+++ b/.github/workflows/ci-tests-python.yml
@@ -3,13 +3,12 @@ name: ci-tests-python
 # Python tests for vendored Hindsight scripts. Mirrors Buildkite
 # :snake: Python tests (Hindsight scripts). No bun, no node — pure
 # python3 stdlib unittest.
+#
+# Skip-as-pass pattern (#1320 followup): see ci-lint.yml header.
 
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "vendor/hindsight-memory/scripts/**"
-      - ".github/workflows/ci-tests-python.yml"
   push:
     branches: [main]
 
@@ -21,7 +20,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'vendor/hindsight-memory/scripts/**'
+              - '.github/workflows/ci-tests-python.yml'
+
   unittest:
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -28,19 +28,6 @@ name: docker-e2e
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "src/vault/**"
-      - "src/cli/apply.ts"
-      - "src/agents/compose.ts"
-      - "src/agent-scheduler/**"
-      - "docker/Dockerfile.base"
-      - "docker/Dockerfile.broker"
-      - "docker/Dockerfile.kernel"
-      - "docker/Dockerfile.agent"
-      - "docker/Dockerfile.auth-broker"
-      - "src/auth/broker/**"
-      - "tests/docker/**"
-      - ".github/workflows/docker-e2e.yml"
   push:
     branches: [main]
 
@@ -52,7 +39,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ─── Path-change filter (skip-as-pass pattern, #1320 followup) ────
+  # Workflow ALWAYS runs so the required `e2e` check fires on every
+  # PR. Real job is if:-gated and reports `skipped` (= success for
+  # branch protection) on PRs that don't touch image-affecting paths.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'src/vault/**'
+              - 'src/cli/apply.ts'
+              - 'src/agents/compose.ts'
+              - 'src/agent-scheduler/**'
+              - 'docker/Dockerfile.base'
+              - 'docker/Dockerfile.broker'
+              - 'docker/Dockerfile.kernel'
+              - 'docker/Dockerfile.agent'
+              - 'docker/Dockerfile.auth-broker'
+              - 'src/auth/broker/**'
+              - 'tests/docker/**'
+              - '.github/workflows/docker-e2e.yml'
+
   e2e:
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary

Fixes the branch-protection trap that's been forcing \`--admin\` merges on PRs #1323 and #1330 (and would have hit any docs-only / badge-only / CI-only PR going forward).

**Root cause:** GitHub's classic branch protection (and Rulesets — same gap) treats a required status check that *never reports* as blocking. Workflow-level \`paths:\` filters prevent the check from ever firing on irrelevant PRs → permanent \"Expected\" → can't merge. Multi-year open community feature request, no native fix.

**Canonical pattern:** drop the workflow-level \`paths:\` filter, add a tiny precursor \`changes\` job using \`dorny/paths-filter@v3\`, and \`if:\`-gate the real job on its output. A job skipped via \`if:\` reports \`success\` to branch protection — unlike a workflow skipped via \`paths:\` which reports nothing at all.

## Workflows refactored (5)

| Workflow | Required check | Pattern |
|---|---|---|
| \`ci-lint\` | \`lint\` | \`changes\` job + \`if:\` on real job |
| \`ci-tests-plugin\` | \`bun-test\` | same |
| \`ci-tests-python\` | \`unittest\` | same |
| \`ci-tests-core\` | \`vitest (1-4)\` | gate on both \`build-dist\` precursor + 4-shard matrix |
| \`docker-e2e\` | \`e2e\` | same |

\`docker-images.yml\` has no path filter and runs on every PR already — \`build-base\`, \`build-hindsight\`, \`build-dependents (×5)\` are unaffected.

## What changes for each PR shape

| PR type | Before | After |
|---|---|---|
| src-only | runs full pipeline | unchanged — full pipeline |
| docs-only | required checks never report → \`--admin\` merge | \`changes\` job runs, real jobs skip-as-success, merges cleanly |
| profile-only | same as docs-only | same fix |
| CI-only (\`.github/workflows/foo.yml\`) | self-trigger only, others stay pending | all checks fire, irrelevant ones skip-as-success |

## Compute cost

Each refactored workflow gains one new ~30s \`changes\` job. On a narrow-scope PR, that's the *only* compute spent (instead of nothing) — a small price for the merge-flow fix. On a regular src-touching PR, the \`changes\` job runs in parallel with nothing else, so no critical path impact.

Push to main always runs the full real job (\`github.event_name == 'push' || needs.changes.outputs.relevant == 'true'\`) — we don't gamble on main.

## Test plan

- [ ] This PR itself touches only \`.github/workflows/*.yml\` files. After landing, the next docs-only PR should merge cleanly **without admin bypass**.
- [ ] Push to main runs the full vitest suite (not changed-files only) so the test corpus stays trustworthy.
- [ ] Each \`changes\` job completes in <30s with dorny/paths-filter cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)