### PR TITLE
fix(ci): restore exec bits on shared dist/ artifact (ci-tests-core silent-red since #1323)

### DIFF
--- a/.github/workflows/ci-tests-core.yml
+++ b/.github/workflows/ci-tests-core.yml
@@ -137,6 +137,19 @@ jobs:
           name: dist-built
           path: dist/
 
+      - name: Restore exec bits on bundled CLIs
+        # actions/upload-artifact@v4 stores artifacts as zip and strips
+        # POSIX exec bits on download. scripts/build.mjs chmods every
+        # entry-point bundle 0o755 because the runtime invokes them
+        # directly (start.sh shells `switchroom`, claude spawns the
+        # hooks, autoaccept-poll is exec'd). Without re-applying here,
+        # tests/autoaccept-poll-bundled.test.ts fails on `st.mode &
+        # 0o100 !== 0` — silently red on every push-to-main since #1323
+        # introduced the shared-artifact pattern.
+        run: |
+          chmod +x dist/cli/*.js dist/cli/*.mjs 2>/dev/null || true
+          ls -l dist/cli/
+
       - name: Vitest shard ${{ matrix.shard }}/4 (PR — changed-files only)
         if: github.event_name == 'pull_request'
         # --changed traces the import graph from files changed against


### PR DESCRIPTION
## Summary

`ci-tests-core` has been silently red on **every push-to-main run** since #1323. PRs masked the failure (`vitest --changed` didn't pick up `tests/autoaccept-poll-bundled.test.ts` unless a changed file pulled it in).

## Root cause

`actions/upload-artifact@v4` stores artifacts as zip and **strips POSIX exec bits** on download. `scripts/build.mjs` chmods every entry-point bundle (`switchroom.js`, `autoaccept-poll.js`, `drive-write-pretool.mjs`) to 0o755 because the runtime invokes them directly. `tests/autoaccept-poll-bundled.test.ts` asserts `st.mode & 0o100 !== 0` and was failing with `expected +0 not to be +0`.

## Fix

`chmod +x dist/cli/*.{js,mjs}` immediately after `download-artifact` in the vitest shard. Tiny step; preserves the shared-build speedup from #1323.

## Confirmed silent-red history

`gh run list --workflow ci-tests-core --branch main` shows 7 consecutive failures:

| Commit | PR | Result |
|---|---|---|
| 7738aa0 | #1331 (skip-as-pass) | failure |
| 9750303 | (3ecc318c retry?) | failure |
| 2b505a3 | | failure |
| 592045b | #1330 (docker opts) | failure |
| 45c4750 | | failure |
| 5dc7ca1 | | failure |
| **7f5bf4e** | **#1323 (speedups)** | **failure ← regression here** |

## Why I didn't catch this in earlier reviews

The first run on PR #1323 was a PR (not push), so vitest ran with `--changed origin/main` — and the only file changed was `.github/workflows/*.yml`, which pulls in zero source tests via vitest's import-graph. The failing test never executed on PR runs. Only push-to-main runs (full suite) trip it, and main-branch reds don't block subsequent merges by default.

This was the lesson: `vitest --changed` hides failures from PR runs even when they'd fail on full-suite runs. Push-to-main is the canary.

## Test plan

- [ ] PR fires ci-tests-core with vitest --changed — should pass (no changed source pulls the failing test).
- [ ] After merge: ci-tests-core on main runs full suite — should be **green** for the first time since #1323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)