### PR TITLE
fix(audit-hostd): bind-mount host-control-audit.log into admin agents

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1425,6 +1425,19 @@ function emitAgentService(
         `      - ${homePrefix}/.switchroom/vault-audit.log:/state/agent/home/.switchroom/vault-audit.log:ro`,
       );
     }
+    // Same shape, for the hostd audit log (#1328): admin DMs can run
+    // `/audit hostd` to tail the privileged-verb history. Hostd is the
+    // sole writer (its own container with --cap-drop=ALL + appendFile);
+    // mounting :ro keeps a compromised admin agent from rewriting
+    // history. Same existsSync guard as the vault audit log — hostd
+    // creates the file lazily on the first privileged-verb request, so
+    // a fresh install may not have it yet and compose `up` would
+    // hard-fail on a missing :ro source.
+    if (existsSync(`${hostHomeForChecks}/.switchroom/host-control-audit.log`)) {
+      lines.push(
+        `      - ${homePrefix}/.switchroom/host-control-audit.log:/state/agent/home/.switchroom/host-control-audit.log:ro`,
+      );
+    }
     // Host-control daemon socket (#1164 follow-up — RFC C).
     // ADMIN-ONLY and gated on `host_control.enabled: true`. The
     // daemon (a systemd user unit on the host) binds the per-agent

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -303,6 +303,17 @@ async function ensureHostMountSources(config: SwitchroomConfig): Promise<void> {
   if (!existsSync(auditLogPath)) {
     writeFileSync(auditLogPath, "", { mode: 0o644 });
   }
+
+  // host-control-audit.log: same pattern as vault-audit.log — hostd
+  // is the writer (from inside its own container at /host-home),
+  // admin agents bind-mount it :ro so `/audit hostd` (#1328) can
+  // tail the privileged-verb history from DM. Pre-create here so
+  // docker compose `up` doesn't hard-fail on a missing :ro source
+  // before hostd has handled its first request.
+  const hostdAuditLogPath = join(home, ".switchroom", "host-control-audit.log");
+  if (!existsSync(hostdAuditLogPath)) {
+    writeFileSync(hostdAuditLogPath, "", { mode: 0o644 });
+  }
 }
 
 /**

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -992,6 +992,65 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
     }
   });
 
+  it("admin agents get a read-only host-control-audit.log mount when the host log exists (#1328 follow-up)", async () => {
+    // fails when: the hostd-audit-log mount is dropped from admin
+    // agent compose. /audit hostd in DM (#1328) shells out to
+    // `switchroom hostd audit` inside the agent container, which
+    // reads `${HOME}/.switchroom/host-control-audit.log` via
+    // defaultAuditLogPath(). Without the mount the lookup resolves
+    // to a path that doesn't exist inside the container and the
+    // command returns "log not found" regardless of real log state.
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-hostd-audit-mount-"));
+    try {
+      mkdirSync(join(tmp, ".switchroom"), { recursive: true });
+      writeFileSync(join(tmp, ".switchroom", "host-control-audit.log"), "");
+      const out = generateCompose({
+        config: makeConfig({
+          alice: { admin: true },
+          bob: {},
+        }),
+        homeDir: tmp,
+      });
+      expect(out).toMatch(
+        /agent-alice:[\s\S]*?\.switchroom\/host-control-audit\.log:\/state\/agent\/home\/\.switchroom\/host-control-audit\.log:ro/,
+      );
+      // Non-admin: no audit-log mount. Operator state never reaches
+      // an ordinary agent's container.
+      expect(out).not.toMatch(
+        /agent-bob:[\s\S]*?host-control-audit\.log/,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the hostd-audit-log mount on fresh installs where the host log doesn't exist yet (no docker compose hard-fail)", async () => {
+    // fails when: the existsSync guard on the host-control-audit.log
+    // mount is dropped. Hostd creates the log lazily on the first
+    // privileged-verb request, so a brand-new install may not have it
+    // yet — without the guard, docker compose `up` would hard-fail
+    // on a missing :ro source. Same pattern as the vault-audit.log
+    // guard above.
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-hostd-audit-fresh-"));
+    try {
+      const out = generateCompose({
+        config: makeConfig({ alice: { admin: true } }),
+        homeDir: tmp,
+      });
+      expect(out).not.toMatch(
+        /agent-alice:[\s\S]*?host-control-audit\.log/,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("admin agents get NO operator-socket mount or routing env (#1021 Design B handles grant-mgmt server-side)", () => {
     // fails when: a refactor re-introduces the pre-#1021 attempt of
     // mounting the operator socket directly into admin agents. That


### PR DESCRIPTION
## Summary
Follow-up to #1328. The new \`/audit hostd\` DM command and \`switchroom hostd audit\` CLI verb shell out to the in-container CLI, which reads \`\${HOME}/.switchroom/host-control-audit.log\` via \`defaultAuditLogPath()\`. But there's no bind mount for that file in admin agent compose — so the verb returns \"log not found\" regardless of real audit state.

This mirrors the existing vault-audit.log mount pattern exactly:
- \`src/agents/compose.ts\` — admin-only, \`:ro\`, \`existsSync\`-gated
- \`src/cli/apply.ts\` \`ensureHostMountSources\` — pre-creates the file so \`compose up\` doesn't hard-fail on a missing \`:ro\` source before hostd has handled its first privileged-verb request

Live-validated: \`docker exec switchroom-klanker switchroom hostd audit\` now reads the host audit log correctly after \`switchroom apply\` + \`switchroom agent restart all\`.

## Test plan
- [x] Two new vitest tests in \`tests/docker/compose-generator.test.ts\`: presence on admin, absence on non-admin, absence on fresh-install (no log yet)
- [x] All 127 compose-generator tests pass
- [x] \`npm run lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)