### PR TITLE
feat(host-control): RFC C Phase 2 default-flip — host_control.enabled → true

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -656,11 +656,16 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // Tests override this so phase fleets get unique names that can't
   // collide with a production install on the same host.
   const containerNamePrefix = opts.containerNamePrefix ?? "switchroom";
-  // Host-control daemon (RFC C, Phase 1) — opt-in via top-level
-  // host_control.enabled. When false (default) compose emits the
-  // same shape as before; when true, admin agents get an extra
-  // bind-mount line for the daemon's per-agent UDS.
-  const hostControlEnabled = config.host_control?.enabled === true;
+  // Host-control daemon (RFC C, Phase 2). Default-on since the Phase 2
+  // default-flip: the schema gives `host_control.enabled` a `.default(true)`
+  // and the block itself defaults to `{}`, so an absent block resolves to
+  // enabled=true. Use `!== false` semantics here so the compose generator
+  // matches the parsed-schema view even on the legacy test/code paths that
+  // construct config objects directly (bypassing Zod). Operators who want
+  // the legacy systemd-mode behaviour set `host_control: { enabled: false }`
+  // explicitly. When enabled, admin agents get an extra bind-mount line
+  // for the daemon's per-agent UDS.
+  const hostControlEnabled = config.host_control?.enabled !== false;
   // For existsSync() decisions on optional bind-mount sources (#907):
   // emission uses `homePrefix` (which may be the literal "${HOME}" so
   // sudo-bake works), but the existsSync probe must use the real host

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1727,9 +1727,13 @@ export const QuotaConfigSchema = z.object({
 export const HostControlConfigSchema = z.object({
   enabled: z
     .boolean()
-    .optional()
+    .default(true)
     .describe(
-      "Opt-in to the host-control daemon. Default: false. " +
+      "Whether the host-control daemon is in use. Default: true (since " +
+      "RFC C Phase 2 default-flip — the gateway's /restart, /new, /reset, " +
+      "and /update apply slash-commands all dispatch through hostd, and " +
+      "without it those verbs fail on docker-mode installs because the " +
+      "agent container has no docker binary/socket). " +
       "When true, the compose generator emits per-agent bind mounts " +
       "at `~/.switchroom/hostd/<name>/sock` for every admin-flagged " +
       "agent. Install the daemon with `switchroom hostd install` — " +
@@ -1737,13 +1741,9 @@ export const HostControlConfigSchema = z.object({
       "(`switchroom-hostd`), separate from the agent fleet's compose " +
       "project so `up -d --remove-orphans` cycles of the fleet " +
       "can't recreate the daemon mid-RPC. See RFC C §5.1. " +
-      "Since Phase 2 (#1175 PR γ) the gateway's /restart, /new, /reset, " +
-      "and /update apply slash-commands automatically dispatch through " +
-      "hostd when enabled — replacing the in-container " +
-      "`spawnSwitchroomDetached` shellout that requires docker access. " +
-      "Set enabled: true on docker-mode installs to make those verbs work " +
-      "(they otherwise fail because the agent container has no docker " +
-      "binary/socket).",
+      "Set enabled: false only on legacy systemd-mode installs that " +
+      "still rely on the in-container `spawnSwitchroomDetached` " +
+      "shellout (removal is tracked as RFC C Phase 3).",
     ),
 });
 
@@ -1869,10 +1869,11 @@ export const SwitchroomConfigSchema = z.object({
     "Optional weekly/monthly USD spend budgets rendered in the session " +
     "greeting. Usage is read from ccusage at runtime; no network calls.",
   ),
-  host_control: HostControlConfigSchema.optional().describe(
-    "Optional host-control daemon configuration. See RFC C " +
-    "(docs/rfcs/host-control-daemon.md) and the field-level help on " +
-    "`enabled` for the Phase 1 scope.",
+  host_control: HostControlConfigSchema.default({}).describe(
+    "Host-control daemon configuration. Defaults to enabled=true since " +
+    "RFC C Phase 2 (docs/rfcs/host-control-daemon.md). Omit the block " +
+    "to accept defaults; set `enabled: false` only on legacy systemd-" +
+    "mode installs (removal tracked as RFC C Phase 3).",
   ),
   google_accounts: z
     .record(

--- a/telegram-plugin/gateway/hostd-dispatch.ts
+++ b/telegram-plugin/gateway/hostd-dispatch.ts
@@ -30,15 +30,23 @@ let _hostdEnabled: boolean | undefined;
  * Cached for the gateway's lifetime — config doesn't change without a
  * restart, and the file-read isn't free.
  *
+ * Default-on since the RFC C Phase 2 default-flip: the schema gives
+ * `host_control.enabled` a `.default(true)` and the block itself a
+ * `.default({})`, so any config parsed through Zod will have the
+ * field populated. We use `!== false` semantics here so this helper
+ * also matches the default-on view on paths that bypass the parser
+ * (tests with partial mocks, code that constructs configs directly).
+ *
  * Best-effort: if the config can't be loaded (gateway running in a
  * dir where loadConfig fails), returns false so the dispatch helper
- * falls through to the legacy spawn path.
+ * falls through to the legacy spawn path — better to fail closed
+ * than to attempt a hostd RPC against a daemon that might not exist.
  */
 export function isHostdEnabled(): boolean {
   if (_hostdEnabled !== undefined) return _hostdEnabled;
   try {
     const cfg = loadSwitchroomConfig();
-    _hostdEnabled = cfg.host_control?.enabled === true;
+    _hostdEnabled = cfg.host_control?.enabled !== false;
   } catch {
     _hostdEnabled = false;
   }

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -1521,8 +1521,10 @@ describe("host-control daemon bind mount (RFC C Phase 1)", () => {
   // Admin agents get an extra per-agent UDS bind mount when
   // host_control.enabled is true AND the host-side directory
   // exists (compose `up` hard-fails on missing bind sources).
+  // Since RFC C Phase 2 default-flip the schema defaults `enabled`
+  // to true, so the bind mount appears when the block is absent.
 
-  it("does NOT emit the hostd bind mount when host_control.enabled is unset", async () => {
+  it("does NOT emit the hostd bind mount when host_control.enabled is explicitly false", async () => {
     const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
@@ -1530,10 +1532,33 @@ describe("host-control daemon bind mount (RFC C Phase 1)", () => {
     try {
       mkdirSync(join(tmp, ".switchroom/hostd/klanker"), { recursive: true });
       const out = generateCompose({
-        config: makeConfig({ klanker: { admin: true } }),
+        config: makeConfig(
+          { klanker: { admin: true } },
+          { host_control: { enabled: false } },
+        ),
         homeDir: tmp,
       });
       expect(out).not.toMatch(
+        /agent-klanker:[\s\S]*?\.switchroom\/hostd\/klanker:\/run\/switchroom\/hostd\/klanker/,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("emits the hostd bind mount when host_control is absent (default-on since RFC C Phase 2)", async () => {
+    const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "hostd-mount-default-on-"));
+    try {
+      mkdirSync(join(tmp, ".switchroom/hostd/klanker"), { recursive: true });
+      const out = generateCompose({
+        // No host_control block — schema default kicks in.
+        config: makeConfig({ klanker: { admin: true } }),
+        homeDir: tmp,
+      });
+      expect(out).toMatch(
         /agent-klanker:[\s\S]*?\.switchroom\/hostd\/klanker:\/run\/switchroom\/hostd\/klanker/,
       );
     } finally {

--- a/tests/host-control/hostd-dispatch.test.ts
+++ b/tests/host-control/hostd-dispatch.test.ts
@@ -68,17 +68,22 @@ afterEach(() => {
 });
 
 describe("isHostdEnabled() — config gate", () => {
-  it("returns false when host_control absent", () => {
+  it("returns true when host_control is absent (default-on since RFC C Phase 2)", () => {
+    // Mock returns a partial config without host_control — simulates an
+    // older config object or a path that bypassed Zod. The helper now
+    // uses `!== false` semantics, matching the schema's `.default(true)`
+    // so default-on stays default-on across both parsed and unparsed
+    // config paths.
     loadConfigMock.mockReturnValue({});
-    expect(isHostdEnabled()).toBe(false);
+    expect(isHostdEnabled()).toBe(true);
   });
 
-  it("returns false when host_control.enabled is false", () => {
+  it("returns false when host_control.enabled is explicitly false", () => {
     loadConfigMock.mockReturnValue({ host_control: { enabled: false } });
     expect(isHostdEnabled()).toBe(false);
   });
 
-  it("returns true when host_control.enabled is true", () => {
+  it("returns true when host_control.enabled is explicitly true", () => {
     loadConfigMock.mockReturnValue({ host_control: { enabled: true } });
     expect(isHostdEnabled()).toBe(true);
   });
@@ -104,7 +109,7 @@ describe("isHostdEnabled() — config gate", () => {
 
 describe("hostdWillBeUsed() — config + socket existence", () => {
   it("false when hostd disabled even if socket would be present", () => {
-    loadConfigMock.mockReturnValue({});
+    loadConfigMock.mockReturnValue({ host_control: { enabled: false } });
     expect(hostdWillBeUsed("klanker")).toBe(false);
   });
 
@@ -117,7 +122,7 @@ describe("hostdWillBeUsed() — config + socket existence", () => {
 
 describe("tryHostdDispatch()", () => {
   it("returns 'not-configured' when hostd disabled", async () => {
-    loadConfigMock.mockReturnValue({});
+    loadConfigMock.mockReturnValue({ host_control: { enabled: false } });
     const result = await tryHostdDispatch("klanker", {
       v: 1,
       op: "agent_restart",
@@ -304,7 +309,7 @@ describe("pollHostdStatus() — long-running verb completion polling", () => {
   });
 
   it("returns 'not-configured' when hostd is disabled", async () => {
-    loadConfigMock.mockReturnValue({});
+    loadConfigMock.mockReturnValue({ host_control: { enabled: false } });
     const resp = await pollHostdStatus("klanker", "gw-x", {
       timeoutMs: 1000,
       intervalMs: 50,
@@ -368,7 +373,7 @@ describe("warnLegacySpawnIfHostdDisabled() — deprecation noise", () => {
   });
 
   it("emits exactly one warning per verb per process", () => {
-    loadConfigMock.mockReturnValue({});
+    loadConfigMock.mockReturnValue({ host_control: { enabled: false } });
     warnLegacySpawnIfHostdDisabled("agent_restart");
     warnLegacySpawnIfHostdDisabled("agent_restart");
     warnLegacySpawnIfHostdDisabled("agent_restart");
@@ -379,7 +384,7 @@ describe("warnLegacySpawnIfHostdDisabled() — deprecation noise", () => {
   });
 
   it("emits per distinct verb", () => {
-    loadConfigMock.mockReturnValue({});
+    loadConfigMock.mockReturnValue({ host_control: { enabled: false } });
     warnLegacySpawnIfHostdDisabled("agent_restart");
     warnLegacySpawnIfHostdDisabled("update_apply");
     warnLegacySpawnIfHostdDisabled("agent_start");


### PR DESCRIPTION
## Summary
Flip the schema default for \`host_control.enabled\` from \`false\` to \`true\`. New installs and existing installs that omitted the block both get hostd auto-enabled.

## Why now
The gateway's \`/restart\`, \`/new\`, \`/reset\`, \`/update apply\`, and \`/audit hostd\` all dispatch through hostd. On docker-mode installs (the canonical path), the agent container has no docker binary or socket — so without hostd those verbs silently fail. Flipping the default is the smallest change that makes the documented path work out of the box.

## Effects per operator state
- **Omitted block:** previously off → now on. Verbs that needed hostd start working. The operator still needs \`switchroom hostd install\` if they want to actually use them; field-help on \`enabled\` surfaces this.
- **Explicitly \`enabled: false\`:** unchanged.
- **Explicitly \`enabled: true\`:** unchanged.

## Consumer-side semantics
Three call sites that read \`host_control?.enabled\` are now \`!== false\` rather than \`=== true\`. The schema default kicks in for any config parsed through Zod, but the \`!== false\` form keeps default-on consistent on paths that bypass the parser (test mocks, code constructing configs directly). Documented inline.

## Unblocks
RFC C Phase 3 — legacy \`spawnSwitchroomDetached\` removal — which needs this default to be on for at least one release of soak before deletion.

## Test plan
- [x] New compose-generator test: bind mount appears when block is absent (default-on path)
- [x] Existing compose-generator test reframed: absence requires explicit \`enabled: false\`
- [x] \`isHostdEnabled()\` test reframed: absent host_control now returns true (default-on)
- [x] All 85 host-control tests pass
- [x] \`npm run lint\` clean
- [x] Full vitest count unchanged from upstream/main baseline (45 pre-existing failures, none new)

## Sequencing
This PR is independent of #1337 (audit-log mount fix) — they can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)