### PR TITLE
ci: add workflow_dispatch recovery trigger to push-gated workflows

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,6 +17,13 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual recovery lever. GHA marks a run failed (no auto-retry) when
+  # its jobs sit queued past the hosted-runner scheduling window during
+  # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
+  # on the stale run. workflow_dispatch gives `gh workflow run
+  # ci-lint.yml --ref main` as the re-trigger. (#1336 queue-fail
+  # surfaced this gap.)
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-tests-core.yml
+++ b/.github/workflows/ci-tests-core.yml
@@ -34,6 +34,13 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual recovery lever. GHA marks a run failed (no auto-retry) when
+  # its jobs sit queued past the hosted-runner scheduling window during
+  # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
+  # on the stale run. workflow_dispatch gives `gh workflow run
+  # ci-tests-core.yml --ref main` as the re-trigger. (#1336 queue-fail
+  # surfaced this gap.)
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-tests-plugin.yml
+++ b/.github/workflows/ci-tests-plugin.yml
@@ -18,6 +18,13 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual recovery lever. GHA marks a run failed (no auto-retry) when
+  # its jobs sit queued past the hosted-runner scheduling window during
+  # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
+  # on the stale run. workflow_dispatch gives `gh workflow run
+  # ci-tests-plugin.yml --ref main` as the re-trigger. (#1336 queue-fail
+  # surfaced this gap.)
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-tests-python.yml
+++ b/.github/workflows/ci-tests-python.yml
@@ -11,6 +11,13 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual recovery lever. GHA marks a run failed (no auto-retry) when
+  # its jobs sit queued past the hosted-runner scheduling window during
+  # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
+  # on the stale run. workflow_dispatch gives `gh workflow run
+  # ci-tests-python.yml --ref main` as the re-trigger. (#1336 queue-fail
+  # surfaced this gap.)
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-tests-race-long.yml
+++ b/.github/workflows/ci-tests-race-long.yml
@@ -25,6 +25,13 @@ on:
       - ".github/workflows/ci-tests-race-long.yml"
   push:
     branches: [main]
+  # Manual recovery lever. GHA marks a run failed (no auto-retry) when
+  # its jobs sit queued past the hosted-runner scheduling window during
+  # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
+  # on the stale run. workflow_dispatch gives `gh workflow run
+  # ci-tests-race-long.yml --ref main` as the re-trigger. (#1336
+  # queue-fail surfaced this gap.)
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -30,6 +30,13 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual recovery lever. GHA marks a run failed (no auto-retry) when
+  # its jobs sit queued past the hosted-runner scheduling window during
+  # a capacity blip; `gh run rerun` then refuses ("cannot be retried")
+  # on the stale run. workflow_dispatch gives `gh workflow run
+  # docker-e2e.yml --ref main` as the re-trigger. (#1336 queue-fail
+  # surfaced this gap.)
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- `main` is currently red at its tip (`6b030e80` / #1336) because four required workflows — `ci-tests-core`, `ci-tests-python`, `ci-tests-race-long`, `docker-images` — were **force-failed without their test code ever running**. During a GHA hosted-runner capacity blip at ~07:48 UTC 2026-05-15, the heavy jobs (`unittest`, `vitest`, `build-base`, `build-dist`) sat in `queued` for ~23 min, never got a runner, and GHA marked the runs failed (`completedAt: 0001-01-01`).
- Not a code regression: every job that *did* get a runner for `6b030e80` — `docker-e2e`, `ci-tests-plugin`, `ci-lint`, `ci-evals` — **passed**, and the v0.11.0 release push (`abff20c7`) an hour earlier was fully green on the identical workflows.
- `gh run rerun --failed` refused (`"This workflow run cannot be retried"`) on the stale runs, and these workflows had **no `workflow_dispatch`** — so the only recovery was waiting for the next push to `main`.
- This adds `workflow_dispatch:` to every push-gated required workflow that lacked it. `ci-evals`/`ci-uat` already had it; `docker-images` is covered by #1339. Together these close the recovery gap fleet-wide.

## Effect

- Gives `gh workflow run <file> --ref main` as a manual recovery lever for this exact queue-fail mode.
- Merging this PR re-triggers the four failed required workflows on the merge commit (which includes #1336), **clearing main's current red**.

## Design contract

- **Visibility / Always-on** outcome — keeps the fleet's gating signal recoverable without waiting on the next unrelated merge.
- Docs test: n/a (CI infra). Defaults test: no config; trigger is always available. Consistency test: matches the exact `workflow_dispatch:` shape already in `ci-evals.yml` / `ci-uat.yml` and PR #1339.

## Test plan

- [x] All 6 workflow files parse as valid YAML and expose `workflow_dispatch` under `on:`.
- [ ] CI green on this PR (required checks).
- [ ] Post-merge: confirm the four previously-failed workflows re-run green on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)