### PR TITLE
feat(auth-google): native Drive onboarding wizard + self-documenting setup

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `settings_raw` | deep merge | Escape hatch: raw settings.json overrides |
 | `claude_md_raw` | concatenate | Escape hatch: append to CLAUDE.md on scaffold |
 | `cli_args` | concatenate | Escape hatch: extra `exec claude` flags |
+| `google_workspace` | deep merge | Google Drive/Docs/Sheets/Calendar integration. `google_client_id` / `google_client_secret` are install-wide (top level only); `tier` + `approvers` cascade per-agent. See § Google Workspace below. |
 
 ## Built-in MCP Servers
 
@@ -386,6 +387,39 @@ non-zero only when every refresh attempt failed AND nothing was already
 fresh — partial failures stay visible without taking the timer down.
 
 Source: `src/auth/token-refresh.ts`.
+
+## Google Workspace (`google_workspace:`)
+
+Centralizes the Google OAuth client + the Drive/Docs/Sheets/Calendar
+tier knob. The legacy RFC D key `drive:` is an accepted alias (identical
+shape); the loader errors if both are set to different values.
+
+```yaml
+google_workspace:
+  google_client_id: "vault:google-oauth-client-id"
+  google_client_secret: "vault:google-oauth-client-secret"
+  approvers: [123456789]      # ≥1 Telegram numeric user id
+  tier: core                  # core | extended | complete
+```
+
+| Field | Cascade | Notes |
+|---|---|---|
+| `google_client_id` | top level only | OAuth client id. Literal or `vault:<key>` ref. One client per install (Google ToS) — **not** per-agent. Env override: `SWITCHROOM_GOOGLE_CLIENT_ID`. |
+| `google_client_secret` | top level only | OAuth client secret. Literal or `vault:<key>` ref. Env override: `SWITCHROOM_GOOGLE_CLIENT_SECRET`. |
+| `approvers` | override (per-agent may narrow) | ≥1 Telegram numeric user id authorized to approve Drive onboarding. Env override: `SWITCHROOM_APPROVER_USER_ID`. |
+| `tier` | override | Upstream `google_workspace_mcp` tool tier. `core` (default, ~16 tools: Drive+Docs+Sheets+Calendar), `extended` (~40: +Slides/Forms/Tasks/Chat), `complete` (~60+: +Gmail — not recommended; Gmail's per-thread approval shape is unsuitable today, see RFC G §5). |
+
+The block is optional. When absent, `switchroom auth google account
+add` and the rest of the fleet Drive surface error with a guided
+next-step (run `switchroom auth google connect`, the one-time
+onboarding wizard). The wizard writes this block for you. Full setup
+walkthrough — including the GCP Console steps and why switchroom ships
+no shared client — is in `docs/google-workspace.md` § Prerequisite.
+
+`google_client_id` / `google_client_secret` are deliberately top-level
+only: one OAuth client per switchroom install. A per-agent
+`google_workspace:` override may narrow `approvers` or pick a different
+`tier`, but not the client credentials (RFC G Phase 1).
 
 ## Escape Hatches
 

--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -96,8 +96,8 @@ The wizard:
    (`google-oauth-client-id` / `google-oauth-client-secret`).
 3. Offers to write the `google_workspace:` block into your
    `switchroom.yaml` (atomic write, comment-preserving; it
-   re-validates the file before saving and never overwrites an
-   existing block).
+   re-validates the file afterward and never overwrites an existing
+   block).
 4. Points you at `switchroom auth google account add` to continue.
 
 ### The manual equivalent

--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -95,8 +95,9 @@ The wizard:
 2. Prompts for the client id + secret and stores them in the vault
    (`google-oauth-client-id` / `google-oauth-client-secret`).
 3. Offers to write the `google_workspace:` block into your
-   `switchroom.yaml` (it backs the file up and re-validates before
-   saving; it never overwrites an existing block).
+   `switchroom.yaml` (atomic write, comment-preserving; it
+   re-validates the file before saving and never overwrites an
+   existing block).
 4. Points you at `switchroom auth google account add` to continue.
 
 ### The manual equivalent

--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -14,17 +14,26 @@ Google account, not a service account. Nothing leaves your subscription.
 ## TL;DR
 
 ```bash
+# 0. One-time per install — create + register your Google OAuth client.
+#    The wizard walks you through the GCP Console, stores the client
+#    id/secret in the vault, and writes the google_workspace: config
+#    block for you. (Manual equivalent: see "Prerequisite" below.)
+switchroom auth google connect
+
 # 1. Connect a Google account to the auth-broker (one-time per account).
 switchroom auth google account add ken-personal
 
 # 2. Allow an agent to use that account.
 switchroom auth google enable ken-personal klanker
 
-# 3. (Optional) Configure which Workspace tier an agent gets.
-#    See docs/configuration.md for the cascade — defaults to "core".
+# 3. (Optional) Pick the Workspace tier — defaults to "core".
+#    See docs/configuration.md § google_workspace for the cascade.
 ```
 
-That's the operator surface. Everything else is one of:
+Step 0 is **required and one-time per switchroom install** — switchroom
+deliberately ships no OAuth client (see "Prerequisite" below for why).
+Steps 1–2 are the per-account / per-agent surface. Everything else is
+one of:
 - The agent already having access and doing the right thing.
 - Telegram approval cards the operator taps when the agent asks.
 
@@ -53,6 +62,76 @@ agent ──────▶ get_credentials(provider=google,   │
 can use it (controlled by the ACL). One agent → can have multiple
 accounts (the agent picks `account=<label>` per call). RFC G §4.4
 spells out why this shape is load-bearing.
+
+## Prerequisite — your OAuth client (one-time per install)
+
+Before any agent can touch Drive you need **one Google OAuth client,
+registered with switchroom**. Switchroom intentionally ships no shared
+client: per-user OAuth against *your* client is what keeps the
+integration subscription-honest (no service account, nothing routed
+through a switchroom-owned credential), and Google's terms expect one
+OAuth client per install. So this step is unavoidable by design — but
+it's one-time, and the wizard does the mechanical parts.
+
+> **This is not the host-side example.**
+> `examples/personal-google-workspace-mcp/` sets up a *different* OAuth
+> client for your own host Claude Code's pair-design loop. It is
+> deliberately separate and its client must **not** be reused for the
+> agent fleet — different trust posture (approval-kernel-mediated vs.
+> single-identity). If you followed that README, you still need this
+> step for agents.
+
+### The native way
+
+```bash
+switchroom auth google connect
+```
+
+The wizard:
+
+1. Walks you through the GCP Console screens (create project → enable
+   Drive/Docs/Sheets/Calendar APIs → OAuth consent screen, add yourself
+   as a test user → create a **Desktop** OAuth client).
+2. Prompts for the client id + secret and stores them in the vault
+   (`google-oauth-client-id` / `google-oauth-client-secret`).
+3. Offers to write the `google_workspace:` block into your
+   `switchroom.yaml` (it backs the file up and re-validates before
+   saving; it never overwrites an existing block).
+4. Points you at `switchroom auth google account add` to continue.
+
+### The manual equivalent
+
+If you'd rather do it by hand (the wizard automates exactly this):
+
+1. **GCP Console** (≈5 min) — at <https://console.cloud.google.com>:
+   create a project; under *APIs & Services → Library* enable the
+   **Google Drive, Docs, Sheets, and Calendar** APIs; under *OAuth
+   consent screen* pick **External**, add yourself as a **Test user**;
+   under *Credentials → Create credentials → OAuth client ID* choose
+   **Desktop app**. Copy the client id and secret.
+2. **Vault the secrets** so they never land in YAML:
+
+   ```bash
+   switchroom vault set google-oauth-client-id
+   switchroom vault set google-oauth-client-secret
+   ```
+
+3. **Add the block** to `~/.switchroom/switchroom.yaml` (top-level —
+   the client id/secret are install-wide, not per-agent):
+
+   ```yaml
+   google_workspace:
+     google_client_id: "vault:google-oauth-client-id"
+     google_client_secret: "vault:google-oauth-client-secret"
+     approvers: [123456789]   # your Telegram numeric user id
+     tier: core               # core | extended | complete (default: core)
+   ```
+
+   See `docs/configuration.md` § `google_workspace` for the cascade
+   and every field. `SWITCHROOM_GOOGLE_CLIENT_ID` /
+   `SWITCHROOM_GOOGLE_CLIENT_SECRET` env vars override the block for
+   one-off operator debugging, but the vault + YAML block is the
+   persistent baseline switchroom expects.
 
 ## Connecting an account
 

--- a/examples/personal-google-workspace-mcp/README.md
+++ b/examples/personal-google-workspace-mcp/README.md
@@ -6,9 +6,14 @@ tools to **your own Claude Code session on the host** (not to switchroom
 agents).
 
 It is intentionally **separate from the agent-side feature.** Agents get
-Workspace access via `switchroom auth google connect <agent>` (RFC G
-§4.5, available after Phase 3 lands). This example is for the
-operator's pair-design loop with their own host-side `claude`.
+Workspace access via `switchroom auth google connect` →
+`switchroom auth google account add` (RFC G §4.5, shipped) — see
+[`docs/google-workspace.md`](../../docs/google-workspace.md) for the
+fleet setup. **Do not reuse this example's OAuth client for the
+fleet:** different trust posture (approval-kernel-mediated vs.
+single-identity), and switchroom expects its own client. This example
+is only for the operator's pair-design loop with their own host-side
+`claude`.
 
 > **Why two paths?** Agents run inside switchroom containers with
 > approval-kernel-mediated tool access; the per-agent OAuth posture is

--- a/src/cli/auth-google.test.ts
+++ b/src/cli/auth-google.test.ts
@@ -86,3 +86,38 @@ describe("buildGoogleCredentials", () => {
     ).toThrow(/refresh_token/);
   });
 });
+
+describe("oauthClientSetupGuidance", () => {
+  const { oauthClientSetupGuidance } = _testing;
+
+  it("leads with the caller-supplied reason", () => {
+    const msg = oauthClientSetupGuidance("SPECIFIC_REASON_X");
+    expect(msg.startsWith("SPECIFIC_REASON_X")).toBe(true);
+  });
+
+  it("surfaces the native one-command fix first, then the manual path", () => {
+    const msg = oauthClientSetupGuidance("r");
+    expect(msg).toContain("switchroom auth google connect");
+    expect(msg).toContain("switchroom vault set google-oauth-client-id");
+    expect(msg).toContain("switchroom vault set google-oauth-client-secret");
+    expect(msg).toContain("google_workspace:");
+    const nativeIdx = msg.indexOf("switchroom auth google connect");
+    const manualIdx = msg.indexOf("switchroom vault set");
+    expect(nativeIdx).toBeGreaterThan(-1);
+    expect(nativeIdx).toBeLessThan(manualIdx);
+  });
+
+  it("points at the canonical doc section", () => {
+    expect(oauthClientSetupGuidance("r")).toContain(
+      "docs/google-workspace.md",
+    );
+  });
+
+  it("distinguishes the two callsites by reason", () => {
+    const a = oauthClientSetupGuidance("no block");
+    const b = oauthClientSetupGuidance("empty id/secret");
+    expect(a).not.toBe(b);
+    expect(a).toContain("no block");
+    expect(b).toContain("empty id/secret");
+  });
+});

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -12,9 +12,13 @@
  * Phase 3a (this file) intentionally OMITS:
  *   - account add / remove (need OAuth flow refactor — Phase 3b)
  *   - share (one-shot enable + add) — Phase 3b
- *   - connect (wizard alias for first-run UX) — Phase 3b
  *   - drive connect/disconnect aliasing — Phase 3b
  *   - apply-time legacy-slot detector wiring — Phase 3b
+ *
+ * `connect` (the one-time install onboarding wizard — GCP client →
+ * vault → `google_workspace:` block) is implemented below in
+ * `registerConnect`; it is the native equivalent of the manual
+ * prerequisite documented in docs/google-workspace.md § Prerequisite.
  *
  * The reason for the split: the OAuth flow is currently inlined in
  * `src/cli/drive.ts:runConnect()` (lines 259–620, narrowly wired to the
@@ -50,6 +54,7 @@ export function registerAuthGoogleSubcommands(
       "Manage Google Workspace accounts shared across agents (RFC G — see docs/rfcs/google-workspace-generalization.md)",
     );
 
+  registerConnect(google, program);
   registerEnable(google, program);
   registerDisable(google, program);
   registerList(google, program);
@@ -63,6 +68,244 @@ export function registerAuthGoogleSubcommands(
   registerAccountAdd(account);
   registerAccountRemove(account);
   registerAccountList(account);
+}
+
+/**
+ * `switchroom auth google connect` — one-time-per-install onboarding
+ * wizard. The native equivalent of the manual prerequisite in
+ * docs/google-workspace.md § Prerequisite: walks the operator through
+ * the GCP Console, vaults the OAuth client id/secret, and writes the
+ * `google_workspace:` block into switchroom.yaml (comment-preserving
+ * via the shared yaml Document pattern; never clobbers an existing
+ * block).
+ *
+ * Conservative by construction:
+ *   - refuses on a non-TTY (a wizard in CI is meaningless),
+ *   - refuses if the block (or its legacy `drive:` alias) already
+ *     exists — prints the block for manual paste instead of touching
+ *     a configured file,
+ *   - re-validates switchroom.yaml after the write and surfaces a
+ *     clear error if (somehow) invalid.
+ */
+function registerConnect(googleParent: Command, program: Command): void {
+  googleParent
+    .command("connect")
+    .description(
+      "One-time install wizard: create + register your Google OAuth client (GCP Console → vault → google_workspace: block). Run once, then `auth google account add`.",
+    )
+    .action(
+      withConfigError(async () => {
+        if (!process.stdin.isTTY) {
+          throw new Error(
+            oauthClientSetupGuidance(
+              "`switchroom auth google connect` is an interactive wizard and needs a TTY.",
+            ),
+          );
+        }
+
+        const [
+          { loadConfig, resolvePath },
+          { setStringSecret },
+          { setGoogleWorkspaceBlock },
+          { atomicWriteFileSync },
+        ] = await Promise.all([
+          import("../config/loader.js"),
+          import("../vault/vault.js"),
+          import("./google-workspace-yaml.js"),
+          import("../util/atomic.js"),
+        ]);
+
+        const configPath = getConfigPath(program);
+        const config = loadConfig(configPath);
+        const gw = config.google_workspace;
+        if (gw?.google_client_id && gw?.google_client_secret) {
+          console.log();
+          console.log(
+            chalk.green(
+              "  ✓ A Google OAuth client is already configured in switchroom.yaml.",
+            ),
+          );
+          console.log();
+          console.log("  Nothing to do here. Next: connect a Google account:");
+          console.log(
+            chalk.cyan(
+              "    switchroom auth google account add <your-google-email>",
+            ),
+          );
+          console.log();
+          return;
+        }
+
+        console.log();
+        console.log(
+          chalk.bold("Google Workspace — one-time OAuth client setup"),
+        );
+        console.log(
+          chalk.gray(
+            "  Switchroom ships no shared client by design (per-install client\n" +
+              "  keeps the integration subscription-honest). This is one-time.\n",
+          ),
+        );
+        console.log("  In the Google Cloud Console (~5 min):");
+        console.log(
+          "    1. https://console.cloud.google.com — create a project.",
+        );
+        console.log(
+          "    2. APIs & Services → Library — enable the Drive, Docs,",
+        );
+        console.log("       Sheets, and Calendar APIs.");
+        console.log(
+          "    3. OAuth consent screen → External; add yourself as a Test user.",
+        );
+        console.log(
+          "    4. Credentials → Create credentials → OAuth client ID →",
+        );
+        console.log("       Application type: Desktop app.");
+        console.log(
+          chalk.gray(
+            "\n  NOT the examples/personal-google-workspace-mcp/ client — that's\n" +
+              "  a separate host-side surface; the fleet needs its own client.\n",
+          ),
+        );
+
+        const clientId = (
+          await readVisibleLine("  Paste the OAuth client ID: ")
+        ).trim();
+        const clientSecret = (
+          await readHiddenLine("  Paste the OAuth client secret: ")
+        ).trim();
+        if (!clientId || !clientSecret) {
+          throw new Error(
+            "Client id and secret are both required. Re-run `switchroom auth google connect` when you have them.",
+          );
+        }
+
+        const approversRaw = (
+          await readVisibleLine(
+            "  Telegram numeric user id(s) allowed to approve Drive onboarding\n" +
+              "  (comma-separated, ≥1): ",
+          )
+        ).trim();
+        const approvers = approversRaw
+          .split(/[,\s]+/)
+          .filter(Boolean)
+          .map((s) => {
+            if (!/^\d+$/.test(s)) {
+              throw new Error(
+                `"${s}" is not a numeric Telegram user id. Approvers must be numeric ids.`,
+              );
+            }
+            return Number(s);
+          });
+        if (approvers.length === 0) {
+          throw new Error(
+            "At least one approver Telegram user id is required.",
+          );
+        }
+
+        const tierRaw = (
+          await readVisibleLine(
+            "  Workspace tier [core] / extended / complete: ",
+          )
+        )
+          .trim()
+          .toLowerCase();
+        const tier =
+          tierRaw === "" ? "core" : (tierRaw as "core" | "extended" | "complete");
+        if (!["core", "extended", "complete"].includes(tier)) {
+          throw new Error(
+            `Unknown tier "${tierRaw}". Use core, extended, or complete.`,
+          );
+        }
+
+        const vaultPath = resolvePath(
+          config.vault?.path ?? "~/.switchroom/vault.enc",
+        );
+        const passphrase =
+          process.env.SWITCHROOM_VAULT_PASSPHRASE ??
+          (await readHiddenLine("  Vault passphrase: "));
+        setStringSecret(
+          passphrase,
+          vaultPath,
+          "google-oauth-client-id",
+          clientId,
+        );
+        setStringSecret(
+          passphrase,
+          vaultPath,
+          "google-oauth-client-secret",
+          clientSecret,
+        );
+        console.log(
+          chalk.green(
+            "\n  ✓ Stored client id + secret in the vault (google-oauth-client-id /\n" +
+              "    google-oauth-client-secret).",
+          ),
+        );
+
+        const blockYaml = [
+          "google_workspace:",
+          '  google_client_id: "vault:google-oauth-client-id"',
+          '  google_client_secret: "vault:google-oauth-client-secret"',
+          `  approvers: [${approvers.join(", ")}]`,
+          `  tier: ${tier}`,
+        ].join("\n");
+
+        const raw = readFileSync(configPath, "utf-8");
+        const patched = setGoogleWorkspaceBlock(raw, {
+          clientIdRef: "vault:google-oauth-client-id",
+          clientSecretRef: "vault:google-oauth-client-secret",
+          approvers,
+          tier,
+        });
+
+        if (patched === raw) {
+          console.log(
+            chalk.yellow(
+              "\n  switchroom.yaml already has a google_workspace:/drive: block —\n" +
+                "  leaving it untouched. Merge these values yourself if needed:\n",
+            ),
+          );
+          console.log(blockYaml.replace(/^/gm, "    "));
+          console.log();
+          return;
+        }
+
+        let mode = 0o644;
+        try {
+          const { statSync } = await import("node:fs");
+          mode = statSync(configPath).mode & 0o777;
+        } catch {
+          /* default 0644 */
+        }
+        atomicWriteFileSync(configPath, patched, mode);
+
+        try {
+          loadConfig(configPath);
+        } catch (err) {
+          throw new Error(
+            `Wrote google_workspace: to ${configPath} but it no longer validates: ` +
+              `${err instanceof Error ? err.message : String(err)}. ` +
+              `The OAuth client id/secret are safely in the vault — fix or remove ` +
+              `the block by hand (it is the last top-level key).`,
+          );
+        }
+
+        console.log(
+          chalk.green(
+            `\n  ✓ Wrote the google_workspace: block to ${configPath}.`,
+          ),
+        );
+        console.log();
+        console.log("  Next: connect a Google account:");
+        console.log(
+          chalk.cyan(
+            "    switchroom auth google account add <your-google-email>",
+          ),
+        );
+        console.log();
+      }),
+    );
 }
 
 function registerEnable(googleParent: Command, program: Command): void {
@@ -347,7 +590,9 @@ function registerAccountAdd(accountParent: Command): void {
         const gw = config.google_workspace;
         if (!gw) {
           throw new Error(
-            "switchroom.yaml is missing a `google_workspace:` block. Add `google_workspace: { google_client_id: ..., google_client_secret: ... }` (vault:<key> refs supported) before connecting accounts.",
+            oauthClientSetupGuidance(
+              "switchroom.yaml has no `google_workspace:` block, so there is no Google OAuth client to connect accounts against.",
+            ),
           );
         }
 
@@ -361,7 +606,9 @@ function registerAccountAdd(accountParent: Command): void {
           gw.google_client_secret;
         if (!clientIdRaw || !clientSecretRaw) {
           throw new Error(
-            "Missing Google OAuth client credentials. Set google_workspace.google_client_id + google_client_secret in switchroom.yaml, or env SWITCHROOM_GOOGLE_CLIENT_ID + SWITCHROOM_GOOGLE_CLIENT_SECRET.",
+            oauthClientSetupGuidance(
+              "The `google_workspace:` block is present but `google_client_id` and/or `google_client_secret` is empty.",
+            ),
           );
         }
 
@@ -469,6 +716,70 @@ function registerAccountAdd(accountParent: Command): void {
         console.log();
       }),
     );
+}
+
+/**
+ * Build the guided error shown when the Google OAuth client isn't
+ * configured. The CLI is the doc here (principles.md "docs test"): the
+ * operator should be able to recover from the error text alone without
+ * opening docs/. Leads with the native one-command fix, then the manual
+ * equivalent, then the doc pointer. `reason` is the specific thing that
+ * was missing so the two callsites stay distinguishable.
+ *
+ * Exported for the unit test that pins this contract.
+ */
+export function oauthClientSetupGuidance(reason: string): string {
+  return [
+    reason,
+    "",
+    "Switchroom ships no shared OAuth client by design (per-install",
+    "client keeps the integration subscription-honest). Set one up —",
+    "one-time per install:",
+    "",
+    "  Native (recommended): a wizard that walks the GCP Console, vaults",
+    "  the secrets, and writes the config block for you —",
+    "",
+    "    switchroom auth google connect",
+    "",
+    "  Manual: create a Desktop OAuth client at",
+    "  https://console.cloud.google.com (enable the Drive/Docs/Sheets/",
+    "  Calendar APIs, add yourself as a test user), then:",
+    "",
+    "    switchroom vault set google-oauth-client-id",
+    "    switchroom vault set google-oauth-client-secret",
+    "",
+    "  and add to ~/.switchroom/switchroom.yaml (top level):",
+    "",
+    "    google_workspace:",
+    '      google_client_id: "vault:google-oauth-client-id"',
+    '      google_client_secret: "vault:google-oauth-client-secret"',
+    "      approvers: [<your-telegram-user-id>]",
+    "      tier: core",
+    "",
+    "Env vars SWITCHROOM_GOOGLE_CLIENT_ID / _SECRET override the block",
+    "for one-off debugging. Full walkthrough: docs/google-workspace.md",
+    "§ Prerequisite.",
+  ].join("\n");
+}
+
+/**
+ * Read a single visible line (echoed) — for non-secret wizard prompts
+ * (client id, approver ids, tier). The client *secret* and vault
+ * passphrase use readHiddenLine instead.
+ */
+async function readVisibleLine(prompt: string): Promise<string> {
+  const { createInterface } = await import("node:readline");
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    return await new Promise<string>((resolve) => {
+      rl.question(prompt, (answer) => resolve(answer));
+    });
+  } finally {
+    rl.close();
+  }
 }
 
 /**
@@ -696,5 +1007,6 @@ export const _testing = {
   getEnabledAgentsBefore,
   expandAllAgents,
   buildGoogleCredentials,
+  oauthClientSetupGuidance,
 };
 

--- a/src/cli/google-workspace-yaml.test.ts
+++ b/src/cli/google-workspace-yaml.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { setGoogleWorkspaceBlock } from "./google-workspace-yaml.js";
+
+const BASE = `# top-level comment
+switchroom:
+  version: 1
+telegram:
+  bot_token: "x"  # inline comment
+agents:
+  clerk:
+    extends: default
+`;
+
+const BLOCK = {
+  clientIdRef: "vault:google-oauth-client-id",
+  clientSecretRef: "vault:google-oauth-client-secret",
+  approvers: [123, 456],
+  tier: "core" as const,
+};
+
+describe("setGoogleWorkspaceBlock", () => {
+  it("adds the block when absent and preserves surrounding content + comments", () => {
+    const out = setGoogleWorkspaceBlock(BASE, BLOCK);
+    expect(out).toMatch(/^# top-level comment/m);
+    expect(out).toContain("# inline comment");
+    expect(out).toContain("clerk:");
+    expect(out).toMatch(/^google_workspace:$/m);
+    // The yaml lib emits `vault:...` as a valid unquoted plain scalar;
+    // assert on the key/value pair without pinning quote style (parse
+    // round-trip is covered by the next test).
+    expect(out).toMatch(
+      /google_client_id:\s*"?vault:google-oauth-client-id"?/,
+    );
+    expect(out).toMatch(
+      /google_client_secret:\s*"?vault:google-oauth-client-secret"?/,
+    );
+    expect(out).toMatch(/approvers:\s*\n?\s*(- 123|\[\s*123)/);
+    expect(out).toContain("tier: core");
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  it("re-parses to the expected shape", async () => {
+    const { parse } = await import("yaml");
+    const parsed = parse(setGoogleWorkspaceBlock(BASE, BLOCK));
+    expect(parsed.google_workspace.google_client_id).toBe(
+      "vault:google-oauth-client-id",
+    );
+    expect(parsed.google_workspace.approvers).toEqual([123, 456]);
+    expect(parsed.google_workspace.tier).toBe("core");
+    // Untouched siblings survive.
+    expect(parsed.switchroom.version).toBe(1);
+  });
+
+  it("never clobbers an existing google_workspace: block (returns input verbatim)", () => {
+    const withBlock = `google_workspace:\n  google_client_id: "existing"\n  tier: extended\n${BASE}`;
+    expect(setGoogleWorkspaceBlock(withBlock, BLOCK)).toBe(withBlock);
+  });
+
+  it("never clobbers the legacy drive: alias", () => {
+    const withDrive = `drive:\n  google_client_id: "legacy"\n${BASE}`;
+    expect(setGoogleWorkspaceBlock(withDrive, BLOCK)).toBe(withDrive);
+  });
+
+  it("rejects empty refs and empty approvers", () => {
+    expect(() =>
+      setGoogleWorkspaceBlock(BASE, { ...BLOCK, clientIdRef: "" }),
+    ).toThrow(/clientIdRef/);
+    expect(() =>
+      setGoogleWorkspaceBlock(BASE, { ...BLOCK, approvers: [] }),
+    ).toThrow(/approver/);
+  });
+
+  it("throws when the YAML root is not a map", () => {
+    expect(() => setGoogleWorkspaceBlock("- a\n- b\n", BLOCK)).toThrow(
+      /root is not a map/,
+    );
+  });
+});

--- a/src/cli/google-workspace-yaml.ts
+++ b/src/cli/google-workspace-yaml.ts
@@ -1,0 +1,71 @@
+/**
+ * YAML editor for the top-level `google_workspace:` block.
+ *
+ * Pure module — string-in / string-out — so the CLI can read the
+ * existing file, mutate, and atomic-write the result without losing
+ * comments or surrounding formatting. Mirrors the pattern in
+ * `auth-active-yaml.ts` / `google-accounts-yaml.ts`.
+ *
+ * One caller today: the `switchroom auth google connect` onboarding
+ * wizard, which writes the block after vaulting the OAuth client
+ * id/secret. The wizard already refuses to run when the block exists;
+ * the never-clobber guard here is defense-in-depth + makes the
+ * function idempotent and independently testable.
+ */
+
+import { parseDocument, isMap } from "yaml";
+
+export interface GoogleWorkspaceBlock {
+  /** Vault ref or literal for the OAuth client id, e.g. `vault:google-oauth-client-id`. */
+  clientIdRef: string;
+  /** Vault ref or literal for the OAuth client secret. */
+  clientSecretRef: string;
+  /** ≥1 Telegram numeric user id authorized to approve Drive onboarding. */
+  approvers: number[];
+  /** Upstream MCP tool tier. */
+  tier: "core" | "extended" | "complete";
+}
+
+/**
+ * Add a `google_workspace:` block to the YAML text. Returns the input
+ * verbatim (byte-equal) when a `google_workspace:` OR the legacy
+ * `drive:` alias key already exists — the loader treats `drive:` as
+ * the same block, so clobbering either would silently drop operator
+ * config. Caller owns the atomic-write + mode preservation.
+ */
+export function setGoogleWorkspaceBlock(
+  yamlText: string,
+  block: GoogleWorkspaceBlock,
+): string {
+  if (!block.clientIdRef || !block.clientSecretRef) {
+    throw new Error(
+      "setGoogleWorkspaceBlock: clientIdRef and clientSecretRef are required",
+    );
+  }
+  if (!Array.isArray(block.approvers) || block.approvers.length === 0) {
+    throw new Error(
+      "setGoogleWorkspaceBlock: at least one approver id is required",
+    );
+  }
+
+  const doc = parseDocument(yamlText);
+  const root = doc.contents;
+  if (!isMap(root)) {
+    throw new Error("setGoogleWorkspaceBlock: YAML root is not a map");
+  }
+
+  // Never clobber an existing block (canonical key or legacy alias).
+  if (root.has("google_workspace") || root.has("drive")) {
+    return yamlText;
+  }
+
+  doc.set("google_workspace", {
+    google_client_id: block.clientIdRef,
+    google_client_secret: block.clientSecretRef,
+    approvers: block.approvers,
+    tier: block.tier,
+  });
+
+  const out = String(doc);
+  return out.endsWith("\n") ? out : out + "\n";
+}


### PR DESCRIPTION
## Summary

Closes the **docs-test** gap on the agent-fleet Google Workspace (Drive) integration (RFC E/G). The prerequisite — a per-install Google OAuth client + `google_workspace:` block in `switchroom.yaml` — was only documented in the *host-side* example README and RFC G. An operator following `docs/google-workspace.md` hit `switchroom auth google account add`'s one-line error with no documented way forward (`docs/configuration.md` had zero `google_workspace` content).

Three tiers:

- **Docs** — `docs/google-workspace.md` gains a "Prerequisite — your OAuth client" section (native vs. manual, explicitly distinct from the host example); `docs/configuration.md` gains the missing `google_workspace:` field reference + cascade; the host example README cross-links the fleet guide and warns against reusing its OAuth client (different trust posture).
- **Self-documenting CLI** — the two `account add` config errors now route through a shared `oauthClientSetupGuidance(reason)` helper (native fix first, then manual, then doc pointer) instead of a one-liner. The CLI *is* the doc.
- **`switchroom auth google connect` wizard** — the planned-but-absent one-time install onboarding: GCP walkthrough → vault the client id/secret → comment-preserving `google_workspace:` block via the shared yaml Document pattern. Refuses on non-TTY, never clobbers an existing block (or the legacy `drive:` alias), re-validates the written config. Pure string→string YAML mutation isolated in `src/cli/google-workspace-yaml.ts` (mirrors `auth-active-yaml.ts`).

JTBD: `share-auth-across-the-fleet` / `talk-to-agents-from-anywhere`. Principle: fixes a **docs test** failure on a feature that shipped 2026-05-15.

## Review

Reviewed by a fresh separate-process agent: REQUEST_CHANGES (one doc/impl mismatch — a false "backs the file up" claim) → fixed → re-reviewed → **APPROVE**.

## Test plan

- [x] `npm run lint` clean (tsc + structural checks, incl. bun-test-imports)
- [x] New `src/cli/google-workspace-yaml.test.ts` + `oauthClientSetupGuidance` tests pass
- [x] Full `src/cli` + `src/config` vitest green (403 tests, no regressions)
- [ ] CI: 15 required GHA checks
- [ ] Real-world: run `switchroom auth google connect` on a host, confirm vault + block write, then `account add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)