### PR TITLE
fix(quota): align /auth show + boot card on broker-canonical quota

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -115,7 +115,10 @@ ALLOWLIST=(
   # Re-bumped 2026-05-15 post-Path-A-Cut-2 (drive-write IPC handler
   # added ~60 lines higher up; chunk-loop callsite shifted further to ~3451).
   # Re-bumped 2026-05-15 for #1308 folder-picker handler.
-  "telegram-plugin/gateway/gateway.ts:3160-3500:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
+  # Re-bumped 2026-05-15 for #1345 (quota align): +2 lines inserted above
+  # (quota-check import + a startBootCard wiring line) shifted the
+  # unchanged callsite 3499 -> 3501, just past the old 3500 bound.
+  "telegram-plugin/gateway/gateway.ts:3160-3505:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup

--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -51,6 +51,21 @@ import {
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
+/**
+ * Revive a wire value back into `Date | null`. The broker serialises
+ * Date fields to ISO strings over NDJSON (JSON has no Date type); a
+ * blind `as` cast leaves them as strings, so `.getTime()` in the
+ * format layer throws. Accepts Date (already revived), string/number
+ * (epoch or ISO), or null/undefined. Invalid dates collapse to null
+ * rather than producing an `Invalid Date` that crashes formatters.
+ */
+function reviveDate(v: Date | string | number | null | undefined): Date | null {
+  if (v == null) return null;
+  if (v instanceof Date) return Number.isNaN(v.getTime()) ? null : v;
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
 /** Resolved operator socket — bind-mount target from the broker container. */
 function operatorSocketPath(home: string = homedir()): string {
   return join(home, ".switchroom", "state", "auth-broker-operator", "sock");
@@ -351,7 +366,19 @@ export class AuthBrokerClient {
       accounts: [...accounts],
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     });
-    return data as ProbeQuotaData;
+    // JSON.parse does not revive Date. The broker serialises
+    // fiveHourResetAt/sevenDayResetAt as Date → ISO string on the wire,
+    // so the typed `Date | null` is a lie until we revive here. Without
+    // this, every `.getTime()` in the format layer (auth-snapshot-format,
+    // /auth show) throws "target.getTime is not a function".
+    const parsed = data as ProbeQuotaData;
+    for (const entry of parsed.results) {
+      if (entry.result.ok) {
+        entry.result.data.fiveHourResetAt = reviveDate(entry.result.data.fiveHourResetAt);
+        entry.result.data.sevenDayResetAt = reviveDate(entry.result.data.sevenDayResetAt);
+      }
+    }
+    return parsed;
   }
 
   async setActive(account: string): Promise<SetActiveData> {

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import * as net from "node:net";
 
 import { AuthBroker } from "./server.js";
+import { AuthBrokerClient } from "./client.js";
 import type { Identity } from "./peercred.js";
 import { decodeResponse, encodeRequest } from "./protocol.js";
 import type { SwitchroomConfig } from "../../config/schema.js";
@@ -1261,6 +1262,53 @@ describe("AuthBroker — probe-quota", () => {
       expect(seenTokens).toContain("Bearer at-secondary");
     } finally {
       globalThis.fetch = origFetch;
+      broker.stop();
+    }
+  });
+
+  it("AuthBrokerClient.probeQuota revives reset fields into Date (regression: /auth show target.getTime crash)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { active: "default", agents: { ziggy: {} } });
+    seedAccount(h, "default", { expiresAt: 9_999_999_999_999 });
+
+    const reset5hEpoch = Math.floor(Date.now() / 1000) + 3600;
+    const reset7dEpoch = Math.floor(Date.now() / 1000) + 86_400;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, _init?: RequestInit): Promise<Response> => {
+      return new Response("ok", {
+        status: 200,
+        headers: {
+          "anthropic-ratelimit-unified-5h-utilization": "0.20",
+          "anthropic-ratelimit-unified-7d-utilization": "0.10",
+          "anthropic-ratelimit-unified-5h-reset": String(reset5hEpoch),
+          "anthropic-ratelimit-unified-7d-reset": String(reset7dEpoch),
+        },
+      });
+    }) as typeof fetch;
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    const client = new AuthBrokerClient({ socket: join(h.socketRoot, "ziggy", "sock") });
+    try {
+      await broker.start();
+      const data = await client.probeQuota(["default"]);
+      const entry = data.results[0];
+      expect(entry?.result.ok).toBe(true);
+      if (!entry || !entry.result.ok) throw new Error("probe failed");
+      // The core regression: these MUST be real Dates, not ISO strings.
+      // Pre-fix the wire value survived as a string and `.getTime()` in
+      // auth-snapshot-format.ts threw "target.getTime is not a function".
+      expect(entry.result.data.fiveHourResetAt).toBeInstanceOf(Date);
+      expect(entry.result.data.sevenDayResetAt).toBeInstanceOf(Date);
+      expect(entry.result.data.fiveHourResetAt?.getTime()).toBe(reset5hEpoch * 1000);
+      expect(entry.result.data.sevenDayResetAt?.getTime()).toBe(reset7dEpoch * 1000);
+    } finally {
+      globalThis.fetch = origFetch;
+      await client.close();
       broker.stop();
     }
   });

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -33,6 +33,7 @@
  */
 
 import type { ProbeResult, GatewayRuntimeInfo } from './boot-probes.js'
+import type { QuotaResult } from '../quota-check.js'
 import type { ListStateData } from './auth-line.js'
 import { renderAuthLine } from './auth-line.js'
 import {
@@ -469,6 +470,15 @@ export interface RunProbesOpts {
     | ListStateData
     | null
     | Promise<ListStateData | null>
+  /**
+   * Canonical quota source (#1336): probes this agent's effective
+   * account via the broker (server-side /v1/messages). Returns null
+   * when the broker is unreachable / no active account → `probeQuota`
+   * falls back to a direct probe. Wired from gateway.ts
+   * (`probeQuotaForBootCard`); omitted in non-docker / unit tests where
+   * the direct fallback preserves prior behaviour.
+   */
+  probeQuotaViaBroker?: (timeoutMs?: number) => Promise<QuotaResult | null>
   /** When true, resolve the agent PID via cgroup walk instead of MainPID
    *  (which is the tmux server pid under tmux supervisor). */
   tmuxSupervisor?: boolean
@@ -502,7 +512,7 @@ export async function runAllProbes(opts: RunProbesOpts): Promise<ProbeMap> {
     probeAccount(opts.agentDir).then(r => { probes.account = r }),
     probeAgentProcess(slug, { execFileImpl: opts.probeExecFileImpl, tmuxSupervisor: opts.tmuxSupervisor, dockerMode: opts.dockerMode }).then(r => { probes.agent = r }),
     probeGateway(opts.gatewayInfo).then(r => { probes.gateway = r }),
-    probeQuota(claudeDir, opts.agentDir, opts.fetchImpl).then(r => { probes.quota = r }),
+    probeQuota(claudeDir, opts.agentDir, opts.fetchImpl, { brokerProbe: opts.probeQuotaViaBroker }).then(r => { probes.quota = r }),
     probeHindsight(opts.bankName, opts.fetchImpl).then(r => { probes.hindsight = r }),
     probeScheduler(slug, { dockerMode: opts.dockerMode }).then(r => { probes.scheduler = r }),
     probeBroker(undefined, { dockerMode: opts.dockerMode }).then(r => { probes.broker = r }),

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -17,7 +17,7 @@ import { execFile as execFileCb } from 'child_process'
 import { promisify } from 'util'
 
 import { readQuotaCache, writeQuotaCache } from './quota-cache.js'
-import { fetchQuota, formatQuotaLine } from '../quota-check.js'
+import { fetchQuota, formatQuotaLine, type QuotaResult } from '../quota-check.js'
 
 const execFile = promisify(execFileCb)
 
@@ -46,6 +46,25 @@ export interface ProbeResult {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 const PROBE_TIMEOUT_MS = 2000
+
+/**
+ * Quota is the one probe that legitimately needs a network round-trip.
+ * The boot card is NOT blocked on probes — it's posted immediately and
+ * probe rows edit in at the 6s settle window (see boot-card.ts
+ * SETTLE_WINDOW_MS) — so the old 1.8s direct-fetch budget was a
+ * self-inflicted abort, not a real constraint. Post-#1336 the broker
+ * owns the canonical probe; the gateway just awaits a local UDS
+ * round-trip while the broker does the Anthropic call server-side.
+ *
+ *   BROKER   — passed to client.probeQuota(); the broker's server-side
+ *              /v1/messages timeout.
+ *   DIRECT   — fallback direct fetch when the broker is unreachable
+ *              (non-docker, boot-time socket race). Still bounded.
+ *   OUTER    — withTimeout() guard; must exceed BROKER + UDS RTT.
+ */
+const QUOTA_BROKER_TIMEOUT_MS = 7000
+const QUOTA_DIRECT_FALLBACK_TIMEOUT_MS = 5000
+const QUOTA_PROBE_OUTER_TIMEOUT_MS = 9000
 
 /**
  * Race a probe against a hard timeout. Returns a fail ProbeResult if the
@@ -831,6 +850,14 @@ export async function probeQuota(
   claudeConfigDir: string,
   _agentDir: string,
   fetchImpl: typeof fetch = fetch,
+  opts: {
+    /** Canonical path (#1336): the broker probes Anthropic server-side
+     *  for this agent's effective account. Returns null when the broker
+     *  is unreachable / no active account → caller falls back to a
+     *  direct probe. Injected from gateway.ts (probeQuotaForBootCard);
+     *  omitted in non-docker / unit tests. */
+    brokerProbe?: (timeoutMs?: number) => Promise<QuotaResult | null>
+  } = {},
 ): Promise<ProbeResult> {
   return withTimeout('Quota', (async (): Promise<ProbeResult> => {
     const cached = readQuotaCache()
@@ -838,35 +865,50 @@ export async function probeQuota(
       return cached
     }
 
-    // The fallback per-agent token path is `accounts/default/.oauth-token`;
-    // fetchQuota's own resolver only checks the top-level `.oauth-token`,
-    // so prefer that, and if it's missing surface the same degraded row
-    // we did before (no live probe — that's a setup issue, not a runtime
-    // one).
-    let claudeDirForProbe: string | null = null
-    for (const candidate of [
-      claudeConfigDir,
-      join(claudeConfigDir, 'accounts', 'default'),
-    ]) {
-      if (existsSync(join(candidate, '.oauth-token'))) {
-        claudeDirForProbe = candidate
-        break
-      }
-    }
-    if (!claudeDirForProbe) {
-      return {
-        status: 'degraded',
-        label: 'Quota',
-        detail: 'no OAuth token',
-        nextStep: 'No OAuth token on disk — register a fleet account: `switchroom auth add <label> --from-oauth` then `switchroom auth use <label>` (RFC H)',
+    // Prefer the broker (canonical since #1336). It does the /v1/messages
+    // call server-side with its own timeout; we just await the local UDS
+    // round-trip. Reset Dates are revived at the client boundary
+    // (src/auth/broker/client.ts) so formatQuotaLine is safe.
+    let probe: QuotaResult | null = null
+    if (opts.brokerProbe) {
+      try {
+        probe = await opts.brokerProbe(QUOTA_BROKER_TIMEOUT_MS)
+      } catch {
+        probe = null
       }
     }
 
-    const probe = await fetchQuota({
-      claudeConfigDir: claudeDirForProbe,
-      fetchImpl,
-      timeoutMs: 1800,
-    })
+    if (!probe) {
+      // Fallback: broker absent/unreachable (non-docker install, or a
+      // boot-time socket race). Direct probe — the per-agent token path
+      // is `accounts/default/.oauth-token`; fetchQuota's resolver only
+      // checks the top-level `.oauth-token`, so prefer that. Missing
+      // token is a setup issue, surfaced as the same degraded row.
+      let claudeDirForProbe: string | null = null
+      for (const candidate of [
+        claudeConfigDir,
+        join(claudeConfigDir, 'accounts', 'default'),
+      ]) {
+        if (existsSync(join(candidate, '.oauth-token'))) {
+          claudeDirForProbe = candidate
+          break
+        }
+      }
+      if (!claudeDirForProbe) {
+        return {
+          status: 'degraded',
+          label: 'Quota',
+          detail: 'no OAuth token',
+          nextStep: 'No OAuth token on disk — register a fleet account: `switchroom auth add <label> --from-oauth` then `switchroom auth use <label>` (RFC H)',
+        }
+      }
+      probe = await fetchQuota({
+        claudeConfigDir: claudeDirForProbe,
+        fetchImpl,
+        timeoutMs: QUOTA_DIRECT_FALLBACK_TIMEOUT_MS,
+      })
+    }
+
     if (!probe.ok) {
       // Auth rejection from /v1/messages is a strong signal — the same
       // endpoint claude itself uses. Other errors are surfaced verbatim
@@ -889,7 +931,7 @@ export async function probeQuota(
     }
     writeQuotaCache(result)
     return result
-  })())
+  })(), QUOTA_PROBE_OUTER_TIMEOUT_MS)
 }
 
 // ─── Probe: Hindsight ────────────────────────────────────────────────────────

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -213,6 +213,7 @@ import {
 import {
   fetchQuota,
   formatQuotaBlock,
+  type QuotaResult,
 } from '../quota-check.js'
 import {
   loadLockout,
@@ -2785,6 +2786,7 @@ const ipcServer: IpcServer = createIpcServer({
             restartAgeMs: markerAgeMs,
             restartReasonDetail: cleanMarker?.reason,
             loadAccounts: () => loadAccountsForBootCard(agentSlug),
+            probeQuotaViaBroker: (t) => probeQuotaForBootCard(agentSlug, t),
             tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
             dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
           }, ackMsgId).then(handle => {
@@ -7958,6 +7960,7 @@ async function buildLiveProbeRows(agentName: string): Promise<StatusProbeRow[]> 
       gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
       tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
       dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
+      probeQuotaViaBroker: (t) => probeQuotaForBootCard(agentName, t),
     })
     const rows: StatusProbeRow[] = []
     // Render order matches the boot card's PROBE_KEYS so the two
@@ -9170,6 +9173,33 @@ async function loadAccountsForBootCard(agent: string): Promise<ListStateData | n
     return await client.listState()
   } catch (err) {
     process.stderr.write(`telegram gateway: boot-card auth probe failed: ${(err as Error)?.message ?? String(err)}\n`)
+    return null
+  }
+}
+
+/**
+ * Canonical boot-card quota probe (#1336): resolve this agent's
+ * effective account, then have the broker probe Anthropic server-side.
+ * Returns null on any failure (broker unreachable, no active account)
+ * so `probeQuota` falls back to a direct probe. Mirrors
+ * `loadAccountsForBootCard`'s broker-client + swallow-to-null shape,
+ * and the override→account→active resolution used by auth-line.ts.
+ */
+async function probeQuotaForBootCard(
+  agent: string,
+  timeoutMs?: number,
+): Promise<QuotaResult | null> {
+  try {
+    const client = await getAuthBrokerClient(agent)
+    if (!client) return null
+    const state = await client.listState()
+    const entry = state.agents.find((a) => a.name === agent)
+    const label = entry?.override ?? entry?.account ?? state.active
+    if (!label) return null
+    const { results } = await client.probeQuota([label], timeoutMs)
+    return results.find((r) => r.label === label)?.result ?? null
+  } catch (err) {
+    process.stderr.write(`telegram gateway: boot-card quota probe failed: ${(err as Error)?.message ?? String(err)}\n`)
     return null
   }
 }
@@ -13443,6 +13473,7 @@ void (async () => {
                       restartAgeMs: markerAgeMs,
                       restartReasonDetail: cleanMarker?.reason,
                       loadAccounts: () => loadAccountsForBootCard(agentSlug),
+                      probeQuotaViaBroker: (t) => probeQuotaForBootCard(agentSlug, t),
                       tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
                       dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
                     }, ackMsgId)

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -292,6 +292,59 @@ describe('probeQuota — #1163: /v1/messages headers path', () => {
     expect(result.detail).toContain('18% / 7d')
   })
 
+  it('prefers the broker probe and does NOT do a direct fetch when it succeeds (Option A / #1336)', async () => {
+    const directFetch: typeof fetch = async () => {
+      throw new Error('direct fetch must not run when the broker probe returns a result')
+    }
+    const brokerProbe = async () => ({
+      ok: true as const,
+      data: {
+        fiveHourUtilizationPct: 30,
+        sevenDayUtilizationPct: 12,
+        fiveHourResetAt: null,
+        sevenDayResetAt: null,
+        representativeClaim: null,
+        overageStatus: null,
+        overageDisabledReason: null,
+      },
+    })
+    const result = await probeQuota(claudeDir, agentDir, directFetch, { brokerProbe })
+    expect(result.status).toBe('ok')
+    expect(result.detail).toContain('30% / 5h')
+    expect(result.detail).toContain('12% / 7d')
+  })
+
+  it('falls back to a direct probe when the broker probe returns null (broker unreachable)', async () => {
+    const headers = new Headers({
+      'anthropic-ratelimit-unified-5h-utilization': '0.55',
+      'anthropic-ratelimit-unified-7d-utilization': '0.22',
+    })
+    const directFetch: typeof fetch = async () =>
+      new Response('{}', { status: 200, headers }) as Response
+    const brokerProbe = async () => null
+
+    const result = await probeQuota(claudeDir, agentDir, directFetch, { brokerProbe })
+    expect(result.status).toBe('ok')
+    expect(result.detail).toContain('55% / 5h')
+    expect(result.detail).toContain('22% / 7d')
+  })
+
+  it('falls back to a direct probe when the broker probe throws', async () => {
+    const headers = new Headers({
+      'anthropic-ratelimit-unified-5h-utilization': '0.10',
+      'anthropic-ratelimit-unified-7d-utilization': '0.05',
+    })
+    const directFetch: typeof fetch = async () =>
+      new Response('{}', { status: 200, headers }) as Response
+    const brokerProbe = async () => {
+      throw new Error('broker UDS connect failed')
+    }
+
+    const result = await probeQuota(claudeDir, agentDir, directFetch, { brokerProbe })
+    expect(result.status).toBe('ok')
+    expect(result.detail).toContain('10% / 5h')
+  })
+
   it('surfaces auth rejection with the RFC-H replace-account hint on 403', async () => {
     const fakeFetch: typeof fetch = async () =>
       new Response(null, { status: 403 }) as Response


### PR DESCRIPTION
Two bugs, one root cause: the gateway↔broker quota boundary wasn't aligned after #1336 routed quota probes through the broker.

## Bug B — `/auth show` crash (v0.11.1) — **in this PR**
`/auth show failed: target.getTime is not a function`. `client.ts probeQuota()` blind-casts the NDJSON payload; `fiveHourResetAt`/`sevenDayResetAt` are typed `Date|null` but cross the wire as ISO strings, so `auth-snapshot-format.ts` `.getTime()` calls throw. Fixed by reviving `Date` at the single client boundary (`reviveDate()`), with a regression test that exercises a real broker round-trip (verified to fail pre-fix). Reviewed APPROVE by a fresh separate-process reviewer.

## Bug A — boot-card "Quota: operation was aborted" — **Option A, in this PR**
`boot-probes.ts` did its own 1.8 s direct `fetchQuota` (bypassing the broker), aborting before a real Anthropic round-trip completes → spurious degraded row. Routed through the broker `probe-quota` path (canonical since #1336; benefits from the bug-B Date fix) with the timeout right-sized to the boot card's actual post-settle edit-in-place model (the card is never blocked on probes). _(commit follows)_

## Follow-up — not in this PR
`list-state`/`AccountState` carries only **exhaustion** (`exhausted`, `exhausted_until`), not utilization%/reset. The broker is not yet canonical for *utilization* — every % is a live probe. Tracked separately: broker caches last-known utilization + exposes it so the boot card (and web dashboard) render instantly with zero live network.

## Test plan
- [ ] `npx vitest run src/auth/broker/server.test.ts -t "probe-quota"` green (incl. new regression)
- [ ] `tsc --noEmit` clean
- [ ] boot-card quota probe path tests

Generated with Claude Code