### PR TITLE
fix(auth-google): connect wizard writes secrets via the vault-broker

### DIFF
--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -93,7 +93,11 @@ The wizard:
    Drive/Docs/Sheets/Calendar APIs → OAuth consent screen, add yourself
    as a test user → create a **Desktop** OAuth client).
 2. Prompts for the client id + secret and stores them in the vault
-   (`google-oauth-client-id` / `google-oauth-client-secret`).
+   **via the vault-broker** (`google-oauth-client-id` /
+   `google-oauth-client-secret`) — the broker owns `vault.enc`, so the
+   write works regardless of file ownership. The vault passphrase you
+   enter is forwarded to the broker as operator attestation; it must
+   match the passphrase the broker is unlocked with.
 3. Offers to write the `google_workspace:` block into your
    `switchroom.yaml` (atomic write, comment-preserving; it
    re-validates the file afterward and never overwrites an existing

--- a/src/cli/auth-google.test.ts
+++ b/src/cli/auth-google.test.ts
@@ -121,3 +121,54 @@ describe("oauthClientSetupGuidance", () => {
     expect(b).toContain("empty id/secret");
   });
 });
+
+describe("interpretConnectPutResult", () => {
+  const { interpretConnectPutResult } = _testing;
+
+  it("passes a successful put through", () => {
+    expect(interpretConnectPutResult("k", { kind: "ok" })).toEqual({
+      ok: true,
+    });
+  });
+
+  it("unreachable → not stored + points at broker recovery, no direct-file fallback", () => {
+    const v = interpretConnectPutResult("google-oauth-client-id", {
+      kind: "unreachable",
+      msg: "ENOENT socket",
+    });
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error("unreachable");
+    expect(v.message).toContain("google-oauth-client-id");
+    expect(v.message).toContain("was not");
+    expect(v.message).toContain("switchroom vault broker status");
+    expect(v.message).toContain("ENOENT socket");
+    // Must NOT suggest bypassing the broker — that's the bug we removed.
+    expect(v.message.toLowerCase()).not.toContain("--no-broker");
+    expect(v.message.toLowerCase()).not.toContain("vault.enc");
+  });
+
+  it("denied → surfaces code/msg and the passphrase-mismatch hint", () => {
+    const v = interpretConnectPutResult("google-oauth-client-secret", {
+      kind: "denied",
+      code: "DENIED",
+      msg: "supplied passphrase does not match",
+    });
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error("unreachable");
+    expect(v.message).toContain("[DENIED]");
+    expect(v.message).toContain("supplied passphrase does not match");
+    expect(v.message.toLowerCase()).toContain("passphrase");
+  });
+
+  it("not_found → explains operator attestation is required", () => {
+    const v = interpretConnectPutResult("google-oauth-client-id", {
+      kind: "not_found",
+      code: "UNKNOWN_KEY",
+      msg: "unknown key",
+    });
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error("unreachable");
+    expect(v.message).toContain("[UNKNOWN_KEY]");
+    expect(v.message.toLowerCase()).toContain("attest");
+  });
+});

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -41,6 +41,7 @@ import {
   getEnabledAgentsForGoogleAccount,
   listGoogleAccounts,
 } from "./google-accounts-yaml.js";
+import type { PutResult } from "../vault/broker/client.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
@@ -105,12 +106,12 @@ function registerConnect(googleParent: Command, program: Command): void {
 
         const [
           { loadConfig, resolvePath },
-          { setStringSecret },
+          { putViaBroker, resolveBrokerSocketPath },
           { setGoogleWorkspaceBlock },
           { atomicWriteFileSync },
         ] = await Promise.all([
           import("../config/loader.js"),
-          import("../vault/vault.js"),
+          import("../vault/broker/client.js"),
           import("./google-workspace-yaml.js"),
           import("../util/atomic.js"),
         ]);
@@ -218,28 +219,49 @@ function registerConnect(googleParent: Command, program: Command): void {
           );
         }
 
-        const vaultPath = resolvePath(
-          config.vault?.path ?? "~/.switchroom/vault.enc",
-        );
+        // Write the secrets through the vault-broker, not the vault file
+        // directly. The broker is the single owner/writer of vault.enc
+        // (it runs as root and rewrites the file on its own schedule);
+        // a host-side direct write races it and breaks the moment the
+        // broker has re-owned the file (the classic root:root EACCES).
+        // `switchroom vault set` is broker-routed for the same reason —
+        // `--no-broker` direct-file is the legacy escape hatch, not the
+        // default. We forward the operator passphrase as attestation
+        // (#969 P1a): when it matches the broker's unlocked passphrase
+        // the broker treats the call as operator-issued and bypasses
+        // the unknown-key gate, so it can create these brand-new keys —
+        // the same path the Telegram one-tap save uses.
+        let brokerSocket: string | undefined;
+        try {
+          brokerSocket = resolveBrokerSocketPath({
+            vaultBrokerSocket: config.vault?.broker?.socket
+              ? resolvePath(config.vault.broker.socket)
+              : undefined,
+          });
+        } catch {
+          brokerSocket = resolveBrokerSocketPath();
+        }
         const passphrase =
           process.env.SWITCHROOM_VAULT_PASSPHRASE ??
           (await readHiddenLine("  Vault passphrase: "));
-        setStringSecret(
-          passphrase,
-          vaultPath,
-          "google-oauth-client-id",
-          clientId,
-        );
-        setStringSecret(
-          passphrase,
-          vaultPath,
-          "google-oauth-client-secret",
-          clientSecret,
-        );
+        for (const [key, value] of [
+          ["google-oauth-client-id", clientId],
+          ["google-oauth-client-secret", clientSecret],
+        ] as const) {
+          const result = await putViaBroker(
+            key,
+            { kind: "string", value },
+            { socket: brokerSocket, passphrase },
+          );
+          const verdict = interpretConnectPutResult(key, result);
+          if (!verdict.ok) {
+            throw new Error(verdict.message);
+          }
+        }
         console.log(
           chalk.green(
-            "\n  ✓ Stored client id + secret in the vault (google-oauth-client-id /\n" +
-              "    google-oauth-client-secret).",
+            "\n  ✓ Stored client id + secret in the vault via the broker\n" +
+              "    (google-oauth-client-id / google-oauth-client-secret).",
           ),
         );
 
@@ -763,6 +785,60 @@ export function oauthClientSetupGuidance(reason: string): string {
 }
 
 /**
+ * Decide whether a broker `put` during `connect` succeeded, and if not,
+ * produce the operator-facing recovery message. Pure + exported so the
+ * broker-failure contract is unit-tested without driving the
+ * interactive wizard (the wizard action itself is smoke-tested per the
+ * file header).
+ *
+ * Deliberately does NOT fall back to a direct vault.enc write on
+ * failure: the broker owns the file, so a host-side direct write is the
+ * exact thing that breaks under a broker-owned (root:root) vault.
+ * Stopping with an actionable message beats silently regressing to the
+ * path this change exists to remove.
+ */
+export function interpretConnectPutResult(
+  key: string,
+  result: PutResult,
+): { ok: true } | { ok: false; message: string } {
+  switch (result.kind) {
+    case "ok":
+      return { ok: true };
+    case "unreachable":
+      return {
+        ok: false,
+        message:
+          `Vault broker is unreachable (${result.msg}); '${key}' was not ` +
+          `stored. connect writes secrets through the broker, not the ` +
+          `vault file. Check it on the host — 'switchroom vault broker ` +
+          `status'; if wedged, 'docker compose -p switchroom restart ` +
+          `vault-broker' — then re-run 'switchroom auth google connect' ` +
+          `(the write is idempotent).`,
+      };
+    case "denied":
+      return {
+        ok: false,
+        message:
+          `Vault broker refused to store '${key}' [${result.code}]: ` +
+          `${result.msg}. Most common cause: the passphrase does not ` +
+          `match the broker's unlocked passphrase. Re-run 'switchroom ` +
+          `auth google connect' with the vault passphrase the broker is ` +
+          `unlocked with.`,
+      };
+    case "not_found":
+      return {
+        ok: false,
+        message:
+          `Vault broker reached but rejected creating '${key}' ` +
+          `[${result.code}]: ${result.msg}. Creating a new key needs ` +
+          `operator-passphrase attestation and the supplied passphrase ` +
+          `did not attest. Re-run with the real vault passphrase (the ` +
+          `one the broker is unlocked with).`,
+      };
+  }
+}
+
+/**
  * Read a single visible line (echoed) — for non-secret wizard prompts
  * (client id, approver ids, tier). The client *secret* and vault
  * passphrase use readHiddenLine instead.
@@ -1008,5 +1084,6 @@ export const _testing = {
   expandAllAgents,
   buildGoogleCredentials,
   oauthClientSetupGuidance,
+  interpretConnectPutResult,
 };
 


### PR DESCRIPTION
## Summary

Follow-up to #1344. The `switchroom auth google connect` wizard wrote the OAuth client id/secret with `setStringSecret` → `openVault` — a **direct `vault.enc` write**. The vault-broker runs as root and is the single owner/writer of `vault.enc` (it rewrites + re-owns the file on its own schedule), so a host-side direct write fails with `root:root` EACCES the moment the broker has touched the file:

```
VaultError: Failed to read vault file: /home/.../.switchroom/vault.enc
  at openVault → setSecret → setStringSecret → registerConnect
```

This is exactly why `switchroom vault set` is **broker-routed by default** and `--no-broker` direct-file is the documented legacy escape hatch. The wizard (new code) should never have used the legacy path.

## Fix

- Route both puts through `putViaBroker(key, {kind:"string",value}, { socket, passphrase })`, mirroring `src/cli/vault.ts`.
- The operator passphrase the wizard already prompts for is forwarded as **attestation (#969 P1a)**: matching the broker's unlocked passphrase ⇒ operator-issued ⇒ bypasses the unknown-key gate ⇒ can create the brand-new keys. Verified an auto-unlocked broker holds `this.passphrase` (`server.ts:2494` reads the passphrase from the auto-unlock blob → `2513 unlockFromPassphrase`), so this works with zero interactive unlock — and is the same primitive the Telegram one-tap save uses, keeping the future in-Telegram path consistent.
- **No silent fallback** to the direct path on broker failure — that's the regression being removed. `interpretConnectPutResult` (pure, exported, unit-tested) maps each `PutResult` to an actionable operator message.
- Doc updated to match (docs-match-impl, per the #1344 review).

## Out of scope (flagged follow-up)

`auth google account add`'s `vault:` ref resolution still reads via direct `getSecret` and has the same latent root-owned-vault failure. Separate change — kept this PR tight.

## Test plan

- [x] `npm run lint` clean
- [x] `interpretConnectPutResult` unit tests (ok / unreachable / denied / not_found; asserts no `--no-broker`/`vault.enc` fallback language)
- [x] 615 `src/cli` + `src/config` + `src/vault` vitest green, no regressions
- [ ] CI: 15 required GHA checks
- [ ] Live UAT on the host: `switchroom auth google connect` against the running auto-unlocked broker creates both keys via broker (no EACCES, no manual chown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)