### PR TITLE
fix(auth-google): account add resolves vault: refs via the broker

### DIFF
--- a/src/cli/auth-google.test.ts
+++ b/src/cli/auth-google.test.ts
@@ -172,3 +172,66 @@ describe("interpretConnectPutResult", () => {
     expect(v.message.toLowerCase()).toContain("attest");
   });
 });
+
+describe("interpretRefGetResult", () => {
+  const { interpretRefGetResult } = _testing;
+
+  it("string entry → resolved value", () => {
+    const v = interpretRefGetResult("google_client_id", "google-oauth-client-id", {
+      kind: "ok",
+      entry: { kind: "string", value: "abc.apps.googleusercontent.com" },
+    });
+    expect(v).toEqual({ ok: true, value: "abc.apps.googleusercontent.com" });
+  });
+
+  it("non-string entry → hard error, no fallback", () => {
+    const v = interpretRefGetResult("google_client_secret", "k", {
+      kind: "ok",
+      entry: { kind: "binary", value: "deadbeef" },
+    });
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error("unreachable");
+    expect(v.fallback).toBe(false);
+    if (v.fallback) throw new Error("unreachable");
+    expect(v.message).toContain("is not a string");
+    expect(v.message).toContain("kind=binary");
+  });
+
+  it("unreachable → fallback to direct read (the only fallback-eligible case)", () => {
+    const v = interpretRefGetResult("google_client_id", "k", {
+      kind: "unreachable",
+      msg: "no socket",
+    });
+    expect(v).toEqual({ ok: false, fallback: true });
+  });
+
+  it("not_found → hard error, NOT fallback (reached broker is authoritative)", () => {
+    const v = interpretRefGetResult("google_client_id", "google-oauth-client-id", {
+      kind: "not_found",
+      code: "UNKNOWN_KEY",
+      msg: "Key not found",
+    });
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error("unreachable");
+    expect(v.fallback).toBe(false);
+    if (v.fallback) throw new Error("unreachable");
+    expect(v.message).toContain("google-oauth-client-id");
+    expect(v.message).toContain("[UNKNOWN_KEY]");
+  });
+
+  it("denied → hard error with operator-scope hint, NOT fallback", () => {
+    const v = interpretRefGetResult("google_client_secret", "google-oauth-client-secret", {
+      kind: "denied",
+      code: "DENIED",
+      msg: "scope excludes operator",
+    });
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error("unreachable");
+    expect(v.fallback).toBe(false);
+    if (v.fallback) throw new Error("unreachable");
+    expect(v.message).toContain("[DENIED]");
+    expect(v.message.toLowerCase()).toContain("operator");
+    // Must not silently mask a real ACL/scope problem by reading the file.
+    expect(v.message).toContain("scope excludes operator");
+  });
+});

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -41,7 +41,7 @@ import {
   getEnabledAgentsForGoogleAccount,
   listGoogleAccounts,
 } from "./google-accounts-yaml.js";
-import type { PutResult } from "../vault/broker/client.js";
+import type { PutResult, GetResult } from "../vault/broker/client.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
@@ -599,6 +599,7 @@ function registerAccountAdd(accountParent: Command): void {
           { loadConfig, resolvePath },
           { getSecret },
           { isVaultReference, parseVaultReference },
+          { getViaBrokerStructured, statusViaBroker, resolveBrokerSocketPath },
         ] = await Promise.all([
           import("./drive.js"),
           import("../drive/oauth.js"),
@@ -606,6 +607,7 @@ function registerAccountAdd(accountParent: Command): void {
           import("../config/loader.js"),
           import("../vault/vault.js"),
           import("../vault/resolver.js"),
+          import("../vault/broker/client.js"),
         ]);
 
         const config = loadConfig();
@@ -637,16 +639,57 @@ function registerAccountAdd(accountParent: Command): void {
         const needsVault =
           isVaultReference(clientIdRaw) || isVaultReference(clientSecretRaw);
         if (needsVault) {
-          const vaultPath = resolvePath(
-            config.vault?.path ?? "~/.switchroom/vault.enc",
-          );
-          const passphrase =
-            process.env.SWITCHROOM_VAULT_PASSPHRASE ??
-            (await readHiddenLine("Vault passphrase: "));
-          const resolveRef = (raw: string, label: string): string => {
+          // Broker-first, mirroring `switchroom vault get`. On a host
+          // running the vault-broker, the broker owns vault.enc as root
+          // — a direct `getSecret` then fails with root:root EACCES
+          // (the same failure connect hit before #1347). When the
+          // broker is reachable + unlocked we read through it (the
+          // operator socket can read any key without an "operator"-
+          // excluding scope — connect writes these keys unscoped). We
+          // only fall back to a direct file read when there is no
+          // usable broker, in which case the file isn't broker-owned
+          // anyway so the direct read is correct (the documented
+          // `--no-broker` interactive path).
+          let brokerSocket: string | undefined;
+          try {
+            brokerSocket = resolveBrokerSocketPath({
+              vaultBrokerSocket: config.vault?.broker?.socket
+                ? resolvePath(config.vault.broker.socket)
+                : undefined,
+            });
+          } catch {
+            brokerSocket = resolveBrokerSocketPath();
+          }
+          const status = await statusViaBroker({ socket: brokerSocket });
+          const viaBroker = status !== null && status.unlocked;
+
+          let directVaultPath: string | undefined;
+          let directPassphrase: string | undefined;
+          const resolveRef = async (
+            raw: string,
+            label: string,
+          ): Promise<string> => {
             if (!isVaultReference(raw)) return raw;
             const key = parseVaultReference(raw);
-            const entry = getSecret(passphrase, vaultPath, key);
+
+            if (viaBroker) {
+              const result = await getViaBrokerStructured(key, {
+                socket: brokerSocket,
+              });
+              const verdict = interpretRefGetResult(label, key, result);
+              if (verdict.ok) return verdict.value;
+              if (!verdict.fallback) throw new Error(verdict.message);
+              // fallback: broker vanished between status and get — fall
+              // through to the direct path below.
+            }
+
+            directVaultPath ??= resolvePath(
+              config.vault?.path ?? "~/.switchroom/vault.enc",
+            );
+            directPassphrase ??=
+              process.env.SWITCHROOM_VAULT_PASSPHRASE ??
+              (await readHiddenLine("Vault passphrase: "));
+            const entry = getSecret(directPassphrase, directVaultPath, key);
             if (!entry) {
               throw new Error(
                 `${label} references vault key '${key}' but no such secret in vault.`,
@@ -659,8 +702,11 @@ function registerAccountAdd(accountParent: Command): void {
             }
             return entry.value;
           };
-          clientIdRaw = resolveRef(clientIdRaw, "google_client_id");
-          clientSecretRaw = resolveRef(clientSecretRaw, "google_client_secret");
+          clientIdRaw = await resolveRef(clientIdRaw, "google_client_id");
+          clientSecretRaw = await resolveRef(
+            clientSecretRaw,
+            "google_client_secret",
+          );
         }
 
         const oauthCfg = {
@@ -834,6 +880,65 @@ export function interpretConnectPutResult(
           `operator-passphrase attestation and the supplied passphrase ` +
           `did not attest. Re-run with the real vault passphrase (the ` +
           `one the broker is unlocked with).`,
+      };
+  }
+}
+
+/**
+ * Interpret a broker `get` result while resolving a `vault:` ref for
+ * `account add`. Pure + exported so the contract is unit-tested
+ * without a live broker.
+ *
+ * Three outcomes:
+ *   - { ok: true, value }              — string entry resolved.
+ *   - { ok: false, fallback: true }    — broker unreachable; caller
+ *                                        should fall through to the
+ *                                        direct-file read (legacy /
+ *                                        broker-disabled path).
+ *   - { ok: false, fallback: false }   — hard error (key missing,
+ *                                        wrong kind, or ACL/scope
+ *                                        denial) — abort with message.
+ *
+ * Only `unreachable` is fallback-eligible: a reached broker that says
+ * not_found / denied is authoritative — silently reading the file
+ * instead would mask a real misconfiguration (and reintroduce the
+ * root-owned-vault failure mode).
+ */
+export function interpretRefGetResult(
+  label: string,
+  key: string,
+  result: GetResult,
+):
+  | { ok: true; value: string }
+  | { ok: false; fallback: true }
+  | { ok: false; fallback: false; message: string } {
+  switch (result.kind) {
+    case "ok":
+      if (result.entry.kind !== "string") {
+        return {
+          ok: false,
+          fallback: false,
+          message: `${label} vault entry '${key}' is not a string (kind=${result.entry.kind}).`,
+        };
+      }
+      return { ok: true, value: result.entry.value };
+    case "unreachable":
+      return { ok: false, fallback: true };
+    case "not_found":
+      return {
+        ok: false,
+        fallback: false,
+        message: `${label} references vault key '${key}' but the broker has no such secret [${result.code}]: ${result.msg}.`,
+      };
+    case "denied":
+      return {
+        ok: false,
+        fallback: false,
+        message:
+          `${label} vault key '${key}' was refused by the broker ` +
+          `[${result.code}]: ${result.msg}. If the entry is scoped, it ` +
+          `must allow "operator"; re-store it unscoped via 'switchroom ` +
+          `auth google connect' or 'switchroom vault set ${key}'.`,
       };
   }
 }
@@ -1085,5 +1190,6 @@ export const _testing = {
   buildGoogleCredentials,
   oauthClientSetupGuidance,
   interpretConnectPutResult,
+  interpretRefGetResult,
 };
 


### PR DESCRIPTION
## Summary

Sibling of #1347, and **the second half of the same bug on the UAT critical path**. `switchroom auth google account add` resolves the `google_client_id` / `google_client_secret` `vault:` refs via `getSecret` → `openVault` — a **direct `vault.enc` read**. On a host running the vault-broker, the broker owns `vault.enc` as root, so that read fails with the same `root:root` EACCES #1347 fixed for the connect wizard.

This matters because it's **step 2 of the operator flow**: `connect` writes `google_client_id: "vault:…"` into config, then `account add` must read it back. Pre-this-fix the chain succeeded at `connect` and died at `account add`.

## Fix

Mirror the canonical `switchroom vault get` host pattern (`src/cli/vault.ts:708-799`):
- Resolve broker socket, `statusViaBroker`.
- Broker reachable + unlocked → resolve each ref via `getViaBrokerStructured` on the operator socket. The broker's **operator path** (`server.ts:1056`) serves any key without an operator-excluding `scope`; `connect` writes these keys unscoped, so they're operator-readable.
- Fall back to the direct `getSecret` read **only** when there is no usable broker — in which case `vault.enc` isn't broker-owned and the direct read is correct (the documented `--no-broker` interactive path). This keeps broker-disabled/locked hosts working and is not a regression (unlike the *write* case in #1347, a read fallback is the intended legacy path).
- A reached broker returning `not_found`/`denied` is **authoritative — not fallback-eligible**: silently reading the file would mask real misconfiguration and reintroduce the EACCES.

`interpretRefGetResult` (pure, exported, unit-tested) encodes the three outcomes. Note the asymmetry vs. #1347: broker **reads** authorize via operator-socket peercred + entry scope, not passphrase attestation, so no passphrase is forwarded on the broker path (only on the direct fallback, as today).

## Test plan

- [x] `npm run lint` clean
- [x] `interpretRefGetResult` unit tests: ok/string, wrong-kind, unreachable→fallback, not_found→hard, denied→hard+operator-scope hint
- [x] 620 `src/cli`+`src/config`+`src/vault` vitest green, no regressions
- [ ] CI: 15 required GHA checks
- [ ] Live UAT: full `connect → account add → enable → list` chain on the host with the broker-owned vault, zero manual chown

🤖 Generated with [Claude Code](https://claude.com/claude-code)