### PR TITLE
chore(auth-google): sharpen two post-review edge-case messages

### DIFF
--- a/src/cli/auth-google.test.ts
+++ b/src/cli/auth-google.test.ts
@@ -147,6 +147,24 @@ describe("interpretConnectPutResult", () => {
     expect(v.message.toLowerCase()).not.toContain("vault.enc");
   });
 
+  it("unreachable + broker deliberately disabled → manual-seed guidance, not 'restart the broker'", () => {
+    const v = interpretConnectPutResult(
+      "google-oauth-client-id",
+      { kind: "unreachable", msg: "broker disabled" },
+      true,
+    );
+    expect(v.ok).toBe(false);
+    if (v.ok) throw new Error("unreachable");
+    expect(v.message).toContain("vault.broker.enabled is false");
+    // Broker-disabled host: --no-broker direct seed is the CORRECT path
+    // here (file isn't broker-owned), so it must be offered.
+    expect(v.message).toContain("--no-broker");
+    expect(v.message).toContain("google-oauth-client-secret");
+    expect(v.message).toContain("docs/google-workspace.md");
+    // Don't tell them to restart a broker they intentionally don't run.
+    expect(v.message).not.toContain("docker compose");
+  });
+
   it("denied → surfaces code/msg and the passphrase-mismatch hint", () => {
     const v = interpretConnectPutResult("google-oauth-client-secret", {
       kind: "denied",

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -253,7 +253,11 @@ function registerConnect(googleParent: Command, program: Command): void {
             { kind: "string", value },
             { socket: brokerSocket, passphrase },
           );
-          const verdict = interpretConnectPutResult(key, result);
+          const verdict = interpretConnectPutResult(
+            key,
+            result,
+            config.vault?.broker?.enabled === false,
+          );
           if (!verdict.ok) {
             throw new Error(verdict.message);
           }
@@ -680,7 +684,17 @@ function registerAccountAdd(accountParent: Command): void {
               if (verdict.ok) return verdict.value;
               if (!verdict.fallback) throw new Error(verdict.message);
               // fallback: broker vanished between status and get — fall
-              // through to the direct path below.
+              // through to the direct path below. Don't do it silently
+              // (mirrors the yellow notice `vault get` prints on the
+              // same transition); a direct read of a broker-owned vault
+              // can EACCES, so the operator should know why we're now
+              // prompting for the passphrase.
+              console.error(
+                chalk.yellow(
+                  `  vault-broker became unreachable mid-request — ` +
+                    `falling back to a direct vault read for '${key}'.`,
+                ),
+              );
             }
 
             directVaultPath ??= resolvePath(
@@ -846,20 +860,34 @@ export function oauthClientSetupGuidance(reason: string): string {
 export function interpretConnectPutResult(
   key: string,
   result: PutResult,
+  brokerDisabled = false,
 ): { ok: true } | { ok: false; message: string } {
   switch (result.kind) {
     case "ok":
       return { ok: true };
     case "unreachable":
+      // Two very different causes, two different next steps. If the
+      // operator deliberately runs vault.broker.enabled:false, telling
+      // them to restart the broker is useless — point them at the
+      // manual seed path (the documented `--no-broker` direct write,
+      // which is correct there because the file isn't broker-owned).
       return {
         ok: false,
-        message:
-          `Vault broker is unreachable (${result.msg}); '${key}' was not ` +
-          `stored. connect writes secrets through the broker, not the ` +
-          `vault file. Check it on the host — 'switchroom vault broker ` +
-          `status'; if wedged, 'docker compose -p switchroom restart ` +
-          `vault-broker' — then re-run 'switchroom auth google connect' ` +
-          `(the write is idempotent).`,
+        message: brokerDisabled
+          ? `'${key}' was not stored: connect writes secrets through the ` +
+            `vault-broker, but vault.broker.enabled is false in your ` +
+            `config (${result.msg}). On a broker-disabled host, seed the ` +
+            `two keys directly instead — 'switchroom vault set ` +
+            `--no-broker google-oauth-client-id' and ' --no-broker ` +
+            `google-oauth-client-secret' — then add the google_workspace: ` +
+            `block by hand (docs/google-workspace.md § Prerequisite). Or ` +
+            `enable the broker and re-run 'switchroom auth google connect'.`
+          : `Vault broker is unreachable (${result.msg}); '${key}' was ` +
+            `not stored. connect writes secrets through the broker, not ` +
+            `the vault file. Check it on the host — 'switchroom vault ` +
+            `broker status'; if wedged, 'docker compose -p switchroom ` +
+            `restart vault-broker' — then re-run 'switchroom auth google ` +
+            `connect' (the write is idempotent).`,
       };
     case "denied":
       return {


### PR DESCRIPTION
## Summary

Bundles the two **non-blocking** follow-ups flagged by the independent reviewers of #1347 and #1348. Message/log-only — no control-flow change.

1. **#1347 reviewer finding** — `interpretConnectPutResult`'s `unreachable` branch told the operator to restart the vault-broker. On a host deliberately running `vault.broker.enabled: false` that's useless guidance. The callsite now passes the disabled flag (`config.vault?.broker?.enabled === false`); in that case the message points at the correct path: seed the two keys with `switchroom vault set --no-broker …` and hand-add the `google_workspace:` block (the file isn't broker-owned there, so the direct write is right). The broker-enabled message is unchanged.

2. **#1348 reviewer nit** — in `account add`, the broker-vanished-mid-request fallback (status reported unlocked, the subsequent `get` returned `unreachable`) silently dropped to the direct passphrase prompt. Now prints the same yellow notice `switchroom vault get` prints on that transition, so the operator knows why they're suddenly being prompted (and that a direct read of a broker-owned vault may EACCES).

Neither path affects the canonical broker-enabled+healthy host (i.e. not the UAT flow); this is edge-case polish.

## Test plan

- [x] `npm run lint` clean
- [x] New test: `interpretConnectPutResult` broker-disabled branch asserts `--no-broker` seed guidance + no "docker compose restart" noise; existing broker-enabled test still asserts no `--no-broker`/`vault.enc`
- [x] 294 `src/cli` vitest green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)