### PR TITLE
ci: real sentinel pattern for required checks (fixes #1331; docs-only PRs hard-block)

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -91,9 +91,16 @@ jobs:
     steps:
       - name: Verdict
         run: |
+          c='${{ needs.changes.result }}'
           r='${{ needs.lint-run.result }}'
+          # If the path-filter job itself broke, lint-run is skipped for
+          # an infra reason (not "irrelevant PR") — don't false-green.
+          if [ "$c" = "failure" ] || [ "$c" = "cancelled" ]; then
+            echo "::error::changes=$c — path-filter infra failed; can't trust skip"
+            exit 1
+          fi
           if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
             echo "::error::lint-run=$r — real lint failure, blocking"
             exit 1
           fi
-          echo "lint-run=$r → pass (ran=success, or skipped on irrelevant PR)"
+          echo "changes=$c lint-run=$r → pass (ran=success, or skipped on irrelevant PR)"

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -2,15 +2,15 @@ name: ci-lint
 
 # Type-check + 3 lint scripts. Mirrors Buildkite step :lock: Type check.
 #
-# Skip-as-pass pattern (#1320 followup):
-#   Workflow ALWAYS runs on every PR so the `lint` check fires. The
-#   precursor `changes` job uses dorny/paths-filter to compute whether
-#   anything lint-relevant changed; the real `lint` job is `if:`-gated
-#   on that output and reports `skipped` (= success for branch
-#   protection) on irrelevant PRs. Net effect is the same compute
-#   saving as the old workflow-level paths: filter, without the
-#   "never reported" trap that blocks doc-only PRs on classic branch
-#   protection.
+# Sentinel pattern (corrects the #1331 if:-skip approach):
+#   A skipped *required* status check is NOT success on classic branch
+#   protection — it blocks (proven by #1343, a docs-only PR, hard-
+#   BLOCKED). So the real work runs in `lint-run` (path-gated, may
+#   skip), and the required context `lint` is a SENTINEL job that
+#   ALWAYS runs and reports success when lint-run succeeded OR skipped,
+#   failure only when lint-run actually failed. Branch protection keeps
+#   requiring `lint` — now always-reporting — so doc/CI-only PRs merge
+#   without --admin while real lint failures still block.
 
 on:
   pull_request:
@@ -59,7 +59,7 @@ jobs:
               - '.github/actions/setup-switchroom/**'
               - '.github/workflows/ci-lint.yml'
 
-  lint:
+  lint-run:
     needs: changes
     # Push to main: always run (don't gamble on main).
     # PR: gate on changed paths.
@@ -77,3 +77,23 @@ jobs:
         # `bun lint` = tsc --noEmit + plugin-references + bot-api-wrapping +
         # bun-test-imports. Same command path as Buildkite.
         run: bun lint
+
+  # ─── Sentinel ─────────────────────────────────────────────────────
+  # The branch-protection-required context. ALWAYS runs (if: always(),
+  # no path gate) so it always reports. Pass when lint-run succeeded or
+  # was skipped (irrelevant PR); fail only when lint-run truly failed
+  # or was cancelled.
+  lint:
+    needs: [changes, lint-run]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verdict
+        run: |
+          r='${{ needs.lint-run.result }}'
+          if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+            echo "::error::lint-run=$r — real lint failure, blocking"
+            exit 1
+          fi
+          echo "lint-run=$r → pass (ran=success, or skipped on irrelevant PR)"

--- a/.github/workflows/ci-tests-core.yml
+++ b/.github/workflows/ci-tests-core.yml
@@ -203,9 +203,14 @@ jobs:
     steps:
       - name: Verdict
         run: |
+          c='${{ needs.changes.result }}'
           r='${{ needs.vitest-shard.result }}'
+          if [ "$c" = "failure" ] || [ "$c" = "cancelled" ]; then
+            echo "::error::changes=$c — path-filter infra failed; can't trust skip"
+            exit 1
+          fi
           if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
             echo "::error::vitest-shard=$r — a shard failed, blocking"
             exit 1
           fi
-          echo "vitest-shard=$r → pass (all shards green, or skipped on irrelevant PR)"
+          echo "changes=$c vitest-shard=$r → pass (all shards green, or skipped on irrelevant PR)"

--- a/.github/workflows/ci-tests-core.yml
+++ b/.github/workflows/ci-tests-core.yml
@@ -50,11 +50,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ─── Path-change filter (skip-as-pass pattern, #1320 followup) ────
-  # Workflow ALWAYS runs so the required `vitest (1-4)` check fires
-  # on every PR. The real jobs are if:-gated on this output and
-  # report `skipped` (= success for branch protection) when no
-  # vitest-relevant paths changed.
+  # ─── Path-change filter (sentinel pattern) ────────────────────────
+  # Real work runs in the `vitest-shard` matrix (path-gated, may skip).
+  # The branch-protection-required context is the `vitest` SENTINEL
+  # below — it ALWAYS runs and aggregates the shards, so a docs-only
+  # PR (shards skipped) still reports pass instead of blocking (#1343).
+  # NOTE: branch protection must require `vitest` (the sentinel), NOT
+  # the old `vitest (1..4)` matrix contexts — see the PR description
+  # for the one-time required-status-checks retune.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -109,7 +112,10 @@ jobs:
           if-no-files-found: error
 
   # ─── Sharded vitest run ───────────────────────────────────────────
-  vitest:
+  # Renamed vitest → vitest-shard so the required context is the
+  # always-running `vitest` sentinel, not the path-skippable matrix
+  # contexts `vitest (1..4)` (those blocked docs-only PRs, #1343).
+  vitest-shard:
     needs: [changes, build-dist]
     if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
@@ -182,3 +188,24 @@ jobs:
           path: coverage/
           if-no-files-found: ignore
           retention-days: 7
+
+  # ─── Sentinel ─────────────────────────────────────────────────────
+  # Branch-protection-required context. ALWAYS runs and aggregates the
+  # 4 shards. `needs.vitest-shard.result` is success only if every
+  # matrix shard succeeded, failure if any failed, skipped if the whole
+  # matrix was path-skipped (irrelevant PR → pass). Branch protection
+  # must require `vitest` (this job), NOT `vitest (1..4)`.
+  vitest:
+    needs: [changes, vitest-shard]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verdict
+        run: |
+          r='${{ needs.vitest-shard.result }}'
+          if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+            echo "::error::vitest-shard=$r — a shard failed, blocking"
+            exit 1
+          fi
+          echo "vitest-shard=$r → pass (all shards green, or skipped on irrelevant PR)"

--- a/.github/workflows/ci-tests-plugin.yml
+++ b/.github/workflows/ci-tests-plugin.yml
@@ -56,7 +56,7 @@ jobs:
               - '.github/actions/setup-switchroom/**'
               - '.github/workflows/ci-tests-plugin.yml'
 
-  bun-test:
+  bun-test-run:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
@@ -80,3 +80,22 @@ jobs:
           bun test \
             admin-commands gateway registry secret-detect tests \
             channel-envelope-safety.test.ts
+
+  # ─── Sentinel ─────────────────────────────────────────────────────
+  # Branch-protection-required context. ALWAYS runs so it always
+  # reports. See ci-lint.yml for the rationale (corrects #1331's
+  # if:-skip approach that blocked docs-only PRs, e.g. #1343).
+  bun-test:
+    needs: [changes, bun-test-run]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verdict
+        run: |
+          r='${{ needs.bun-test-run.result }}'
+          if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+            echo "::error::bun-test-run=$r — real test failure, blocking"
+            exit 1
+          fi
+          echo "bun-test-run=$r → pass (ran=success, or skipped on irrelevant PR)"

--- a/.github/workflows/ci-tests-plugin.yml
+++ b/.github/workflows/ci-tests-plugin.yml
@@ -93,9 +93,14 @@ jobs:
     steps:
       - name: Verdict
         run: |
+          c='${{ needs.changes.result }}'
           r='${{ needs.bun-test-run.result }}'
+          if [ "$c" = "failure" ] || [ "$c" = "cancelled" ]; then
+            echo "::error::changes=$c — path-filter infra failed; can't trust skip"
+            exit 1
+          fi
           if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
             echo "::error::bun-test-run=$r — real test failure, blocking"
             exit 1
           fi
-          echo "bun-test-run=$r → pass (ran=success, or skipped on irrelevant PR)"
+          echo "changes=$c bun-test-run=$r → pass (ran=success, or skipped on irrelevant PR)"


### PR DESCRIPTION
## Problem

`#1331` tried to make narrow-scope PRs mergeable by `if:`-skipping the required `lint`/`bun-test`/`vitest` jobs, on the belief that a skipped *required* status check counts as success. **It does not** — classic branch protection treats a skipped required context as unsatisfied. Proven by **#1343** (docs-only): `mergeable=MERGEABLE` but `mergeState=BLOCKED`, only landable via `gh pr merge --admin`. Every docs/CI-only PR hits this.

## Fix — real sentinel pattern

Per workflow: rename the worker (`lint`→`lint-run`, `bun-test`→`bun-test-run`, `vitest`→`vitest-shard`, keeping path `if:` gates) and add an `if: always()` **sentinel** job *named as the required context* that `needs:` the worker and fails only when the worker `result` is `failure`/`cancelled` (passes on `success` **or** `skipped`). Sentinels also block when the `changes` path-filter job itself fails (no infra false-green). Real failures still block.

- `lint`, `bun-test` sentinels **reuse the existing required-context names** → no branch-protection change.
- `vitest` was a 4-way matrix → required contexts `vitest (1..4)`. Those are renamed to `vitest-shard (1..4)`; the new required context is a single `vitest` sentinel.

## ⚠️ MANDATORY owner action — branch-protection retune (do this with the merge)

Until branch protection stops requiring `vitest (1..4)` (which will never report after this merges) **and** starts requiring `vitest`, **every PR — including code PRs — will block**. This PR itself cannot satisfy `vitest (1..4)` either.

**Sequencing:** apply the retune **first** (it can reference `vitest` before it exists — it just shows pending until this PR's run reports it), then this PR goes green and merges normally. (Or admin-merge this PR and retune immediately after — narrower window but all PRs block until you do.)

Exact command (owner; preserves `strict` + all other contexts, swaps only the vitest ones):

```
gh api repos/switchroom/switchroom/branches/main/protection/required_status_checks \
  --jq '{strict: .strict, contexts: ((.contexts | map(select(startswith("vitest (") | not))) + ["vitest"])}' \
  > /tmp/rsc.json
gh api -X PUT repos/switchroom/switchroom/branches/main/protection/required_status_checks \
  --input /tmp/rsc.json
# verify:
gh api repos/switchroom/switchroom/branches/main/protection/required_status_checks --jq '.contexts'
```

## Post-merge verification
- A docs-only PR: `lint`/`bun-test`/`vitest` all report **pass** (sentinels run, workers skip) → mergeable without `--admin`.
- A code PR with a real lint/test failure: the relevant sentinel reports **fail** → blocked (no regression in protection strength).

## Out of scope
`ci-tests-python` (`unittest`) and `docker-e2e` (`e2e`) are not required contexts — left as-is.

🤖 Generated with Claude Code