### PR TITLE
fix(oauth): correct device-code client type + 401 invalid_client tier-fallthrough

### DIFF
--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -91,7 +91,8 @@ The wizard:
 
 1. Walks you through the GCP Console screens (create project → enable
    Drive/Docs/Sheets/Calendar APIs → OAuth consent screen, add yourself
-   as a test user → create a **Desktop** OAuth client).
+   as a test user → create an OAuth client of type **"TVs and Limited
+   Input devices"**).
 2. Prompts for the client id + secret and stores them in the vault
    **via the vault-broker** (`google-oauth-client-id` /
    `google-oauth-client-secret`) — the broker owns `vault.enc`, so the
@@ -113,7 +114,17 @@ If you'd rather do it by hand (the wizard automates exactly this):
    **Google Drive, Docs, Sheets, and Calendar** APIs; under *OAuth
    consent screen* pick **External**, add yourself as a **Test user**;
    under *Credentials → Create credentials → OAuth client ID* choose
-   **Desktop app**. Copy the client id and secret.
+   **"TVs and Limited Input devices"**. Copy the client id and secret.
+
+   > **Client type matters.** It must be **TVs and Limited Input
+   > devices**, not Desktop. `switchroom auth google account add`
+   > authorizes via Google's device-code flow (you approve from your
+   > phone — ideal for a headless 24/7 server), and Google only
+   > supports device-code for that client type. A Desktop client gets
+   > `invalid_client` / "Invalid client type." This is **different
+   > from** `examples/personal-google-workspace-mcp/`, which uses a
+   > Desktop client with browser loopback for the operator's own
+   > host-side Claude Code — a different surface with a different flow.
 2. **Vault the secrets** so they never land in YAML:
 
    ```bash

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -161,11 +161,17 @@ function registerConnect(googleParent: Command, program: Command): void {
         console.log(
           "    4. Credentials → Create credentials → OAuth client ID →",
         );
-        console.log("       Application type: Desktop app.");
+        console.log(
+          '       Application type: "TVs and Limited Input devices".',
+        );
         console.log(
           chalk.gray(
-            "\n  NOT the examples/personal-google-workspace-mcp/ client — that's\n" +
-              "  a separate host-side surface; the fleet needs its own client.\n",
+            "\n  Must be the TVs-and-Limited-Input type, NOT Desktop: agents\n" +
+              "  authorize via Google's device-code flow (you approve from\n" +
+              "  your phone), which only that client type supports. The\n" +
+              "  examples/personal-google-workspace-mcp/ host client is a\n" +
+              "  separate Desktop client for a different surface — the fleet\n" +
+              "  needs its own.\n",
           ),
         );
 
@@ -823,9 +829,11 @@ export function oauthClientSetupGuidance(reason: string): string {
     "",
     "    switchroom auth google connect",
     "",
-    "  Manual: create a Desktop OAuth client at",
-    "  https://console.cloud.google.com (enable the Drive/Docs/Sheets/",
-    "  Calendar APIs, add yourself as a test user), then:",
+    "  Manual: at https://console.cloud.google.com create an OAuth",
+    '  client of type "TVs and Limited Input devices" (NOT Desktop —',
+    "  agents authorize via the device-code flow, which only that type",
+    "  supports), enable the Drive/Docs/Sheets/Calendar APIs, add",
+    "  yourself as a test user, then:",
     "",
     "    switchroom vault set google-oauth-client-id",
     "    switchroom vault set google-oauth-client-secret",

--- a/src/drive/oauth.test.ts
+++ b/src/drive/oauth.test.ts
@@ -15,6 +15,8 @@ import {
   revokeRefreshToken,
   runLoopbackOAuth,
   buildLoopbackAuthUrl,
+  requestDeviceCode,
+  OAuthTierRejected,
 } from "./oauth.js";
 
 const cfg = {
@@ -229,6 +231,70 @@ describe("OOB-paste flow", () => {
     ) as unknown as typeof fetch;
     const tok = await exchangeOobCode(cfg, "pasted-code", fakeFetch);
     expect(tok.refresh_token).toBe("rt");
+  });
+});
+
+describe("requestDeviceCode — tier-rejection classification", () => {
+  const resp = (status: number, body: unknown) =>
+    mock(async () =>
+      new Response(typeof body === "string" ? body : JSON.stringify(body), {
+        status,
+      }),
+    ) as unknown as typeof fetch;
+
+  it("200 → returns the device-code response", async () => {
+    const f = resp(200, {
+      device_code: "dc",
+      user_code: "UC",
+      verification_url: "https://g/v",
+      expires_in: 1800,
+      interval: 5,
+    });
+    const r = await requestDeviceCode(cfg, f);
+    expect(r.device_code).toBe("dc");
+  });
+
+  it("401 invalid_client (\"Invalid client type\") → OAuthTierRejected, not a hard error", async () => {
+    // Exactly what Google returns for a Desktop/Web client hitting the
+    // device endpoint — must fall through, not crash.
+    const f = resp(401, {
+      error: "invalid_client",
+      error_description: "Invalid client type.",
+    });
+    await expect(requestDeviceCode(cfg, f)).rejects.toBeInstanceOf(
+      OAuthTierRejected,
+    );
+  });
+
+  it("400 / 403 still classify as OAuthTierRejected (unchanged)", async () => {
+    await expect(
+      requestDeviceCode(cfg, resp(400, { error: "invalid_scope" })),
+    ).rejects.toBeInstanceOf(OAuthTierRejected);
+    await expect(
+      requestDeviceCode(cfg, resp(403, { error: "disabled_client" })),
+    ).rejects.toBeInstanceOf(OAuthTierRejected);
+  });
+
+  it("401 WITHOUT invalid_client → hard Error (don't over-broaden)", async () => {
+    let err: unknown;
+    try {
+      await requestDeviceCode(cfg, resp(401, { error: "something_else" }));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(OAuthTierRejected);
+  });
+
+  it("500 → hard Error (a server fault is not a tier rejection)", async () => {
+    let err: unknown;
+    try {
+      await requestDeviceCode(cfg, resp(500, "upstream boom"));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(OAuthTierRejected);
   });
 });
 

--- a/src/drive/oauth.ts
+++ b/src/drive/oauth.ts
@@ -177,9 +177,21 @@ export async function requestDeviceCode(
   });
   if (!res.ok) {
     const text = await res.text();
-    // Google returns 403 / 400 with `invalid_scope` or `disabled_client` when
-    // device-code is not whitelisted for the requested scopes.
-    if (res.status === 400 || res.status === 403) {
+    // Tier-rejection signals — all mean "this client/scope combo can't
+    // do device-code; fall through to the next tier" rather than a hard
+    // crash:
+    //   - 400 / 403 (invalid_scope / disabled_client): device-code not
+    //     whitelisted for the requested scopes.
+    //   - 401 invalid_client ("Invalid client type."): the OAuth client
+    //     is a Desktop/Web type, not "TVs and Limited Input devices".
+    //     Common operator mistake (setup docs historically said
+    //     "Desktop app"); the desktop_loopback tier handles those
+    //     clients, so fall through instead of dumping a raw stack.
+    if (
+      res.status === 400 ||
+      res.status === 403 ||
+      (res.status === 401 && /invalid_client/.test(text))
+    ) {
       throw new OAuthTierRejected(
         `device_code rejected (${res.status}): ${text}`,
       );

--- a/src/drive/oauth.ts
+++ b/src/drive/oauth.ts
@@ -185,8 +185,9 @@ export async function requestDeviceCode(
     //   - 401 invalid_client ("Invalid client type."): the OAuth client
     //     is a Desktop/Web type, not "TVs and Limited Input devices".
     //     Common operator mistake (setup docs historically said
-    //     "Desktop app"); the desktop_loopback tier handles those
-    //     clients, so fall through instead of dumping a raw stack.
+    //     "Desktop app"). Falling through reaches oob_paste, which
+    //     works with any client type — so degrade gracefully instead
+    //     of dumping a raw stack.
     if (
       res.status === 400 ||
       res.status === 403 ||


### PR DESCRIPTION
## Summary

Surfaced in live UAT: `switchroom auth google account add` died with a raw stack trace —

```
device_code request failed (401): { "error": "invalid_client",
  "error_description": "Invalid client type." }
```

Two real defects behind one symptom:

### 1. Wrong OAuth client-type guidance (docs/wizard)
`account add` leads with Google's **device-code** flow — the right UX for a headless 24/7 server (operator approves from their phone). Google only supports device-code for OAuth clients of type **"TVs and Limited Input devices"**. The `connect` wizard, `oauthClientSetupGuidance`, and `docs/google-workspace.md` told operators to create a **Desktop** client — correct for `examples/personal-google-workspace-mcp/` (browser loopback), wrong for this flow. A Desktop client → `invalid_client` / "Invalid client type." Corrected all four places and contrasted explicitly with the host example.

### 2. 401 not classified as a tier-rejection (code)
`requestDeviceCode` (`src/drive/oauth.ts`) only mapped **400/403** to `OAuthTierRejected` (which drives the device_code → oob → desktop_loopback fallthrough in `src/cli/drive.ts:261`). **401** fell through to a hard `Error`, so a wrong client type produced a stack trace instead of graceful degradation. Now `401 && /invalid_client/` → `OAuthTierRejected`. Deliberately narrow: a 401 *without* `invalid_client`, or any 5xx, still hard-fails so a genuinely bad/revoked client id isn't masked.

## Test plan

- [x] `npm run lint` clean
- [x] New `requestDeviceCode` tests: 200 ok; 401 invalid_client → `OAuthTierRejected`; 400/403 → rejected (unchanged); 401-without-invalid_client and 500 → hard `Error`
- [x] 594 vitest + 36 oauth bun tests green, no regressions
- [ ] CI: 15 required GHA checks
- [ ] Live UAT: create a "TVs and Limited Input devices" client, rotate the two vault keys, `account add` completes device-code

## Note
The `connect` wizard already shipped (#1347) and works; this only fixes the *client-type instruction* it prints and the downstream `account add` device-code path. Operators who already ran `connect` with a Desktop client just rotate the two vault keys to a new "TVs and Limited Input devices" client's id/secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)