### PR TITLE
feat(auth-google): opt-in Drive write scope (--write) + fix wrong setup docs

### DIFF
--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -91,8 +91,8 @@ The wizard:
 
 1. Walks you through the GCP Console screens (create project → enable
    Drive/Docs/Sheets/Calendar APIs → OAuth consent screen, add yourself
-   as a test user → create an OAuth client of type **"TVs and Limited
-   Input devices"**).
+   as a test user → create an OAuth client of type **"Desktop app"**
+   — Drive uses the loopback flow; see the client-type note below).
 2. Prompts for the client id + secret and stores them in the vault
    **via the vault-broker** (`google-oauth-client-id` /
    `google-oauth-client-secret`) — the broker owns `vault.enc`, so the

--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -114,17 +114,18 @@ If you'd rather do it by hand (the wizard automates exactly this):
    **Google Drive, Docs, Sheets, and Calendar** APIs; under *OAuth
    consent screen* pick **External**, add yourself as a **Test user**;
    under *Credentials → Create credentials → OAuth client ID* choose
-   **"TVs and Limited Input devices"**. Copy the client id and secret.
+   **"Desktop app"**. Copy the client id and secret.
 
-   > **Client type matters.** It must be **TVs and Limited Input
-   > devices**, not Desktop. `switchroom auth google account add`
-   > authorizes via Google's device-code flow (you approve from your
-   > phone — ideal for a headless 24/7 server), and Google only
-   > supports device-code for that client type. A Desktop client gets
-   > `invalid_client` / "Invalid client type." This is **different
-   > from** `examples/personal-google-workspace-mcp/`, which uses a
-   > Desktop client with browser loopback for the operator's own
-   > host-side Claude Code — a different surface with a different flow.
+   > **Client type matters — Desktop app.** Drive auth uses Google's
+   > **loopback** flow, which requires a Desktop client. The other two
+   > flows are dead ends for Drive: **device-code** returns
+   > `invalid_scope` for Drive scopes (Google does not allow Drive on
+   > device flow), and **OOB** was retired by Google in 2022. On a
+   > **headless server** you complete the single browser step over an
+   > SSH port-forward — `switchroom auth google account add` prints the
+   > exact URL and `localhost` port; you `ssh -L <port>:127.0.0.1:<port>`,
+   > open the URL, approve. Same Desktop+loopback shape the
+   > `examples/personal-google-workspace-mcp/` host MCP uses.
 2. **Vault the secrets** so they never land in YAML:
 
    ```bash
@@ -155,33 +156,47 @@ If you'd rather do it by hand (the wizard automates exactly this):
 switchroom auth google account add ken-personal
 ```
 
-This runs Google's device-code flow:
+This runs Google's **loopback** flow (device-code and OOB do not work
+for Drive — see the client-type note above):
 
-1. Prints a URL + 6-digit user code. Open the URL on any device, paste
-   the code, sign into Google.
-2. Polls Google every 5s until you complete the flow.
-3. Stores the refresh token in `~/.switchroom/auth-broker/` (encrypted
-   at rest — same machine-bound vault posture as the rest of switchroom).
+1. Prints a consent URL and binds an ephemeral `127.0.0.1:<port>`
+   listener.
+2. Open the URL, sign in, approve. On a headless server, first
+   `ssh -L <port>:127.0.0.1:<port> …` so the browser callback reaches
+   the listener.
+3. The listener exchanges the code and stores the refresh token in the
+   broker (encrypted at rest — same machine-bound vault posture as the
+   rest of switchroom).
 4. Account is now visible in `switchroom auth google account list`.
 
 If you have multiple Google accounts to attach, repeat with different
 labels (`ken-personal`, `ken-work`, etc.). The label is just for your
 own reference — agents reference accounts by label, not by Google email.
 
-### Scopes
+### Scopes — read by default, write is opt-in
 
-Default scopes (Workspace tier `core`):
+`account add` requests **read-only** scopes by default:
 
-- `drive.readonly` — list folders, list files, read doc bodies
-- `docs.readonly` — read Google Docs content + structure
-- `sheets.readonly` — read Sheet cell values
-- `userinfo.email` — identity sanity check on the refresh
+- `drive.readonly` — read doc/sheet bodies
+- `drive.metadata.readonly` — list folders + files
 
-Wider tiers (`extended`, `complete`) add write scopes, Calendar, Gmail.
-The tier knob lives in the `google_workspace:` config block (see
-"Configuration cascade" below) and the cascade rules are the same as
-every other config field — `docs/configuration.md` covers the
-general cascade model.
+A read grant **never silently becomes a write grant** (RFC D §12). To
+let agents *create and edit* docs (e.g. draft a new doc into a folder),
+pass `--write`:
+
+```bash
+switchroom auth google account add ken-personal --write
+# re-consent an already-connected account to add write:
+switchroom auth google account add ken-personal --replace --write
+```
+
+`--write` adds **`drive.file`** — least-privilege: agents can create
+files and edit files **they create**, but cannot edit your pre-existing
+unrelated Drive files (that would be the full `drive` scope, which
+switchroom deliberately does not request). It does **not** change
+behaviour for read-only accounts. The Workspace `tier` knob
+(`core`/`extended`/`complete`) controls which upstream MCP *tools* are
+exposed — it is independent of these OAuth scopes.
 
 ### Removing an account
 

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -749,13 +749,26 @@ function registerAccountAdd(accountParent: Command): void {
         // OAuthEnv is a shaped subset of process.env — picking the
         // fields the selector reads (rather than passing process.env
         // wholesale) keeps the call typed.
+        //
+        // `account add` ALWAYS requests Drive scopes, and for Drive the
+        // device-code and OOB tiers are dead ends (Google returns
+        // invalid_scope for Drive on device-code; OOB was retired in
+        // 2022). On a headless host the generic ladder doesn't recover —
+        // the OOB tier blocks on an un-answerable paste prompt and
+        // nextTier() dead-ends at null before loopback. So default the
+        // initial tier to desktop-loopback here (the one flow that works
+        // for Drive); the operator can still override via
+        // SWITCHROOM_DRIVE_OAUTH_TIER. selectInitialTier honours the
+        // override ahead of its headless-avoidance, so loopback is
+        // selected even headless (operator completes the browser step
+        // over an SSH port-forward to the printed 127.0.0.1:<port>).
         const oauthEnv = {
           DISPLAY: process.env.DISPLAY,
           WAYLAND_DISPLAY: process.env.WAYLAND_DISPLAY,
           SSH_CONNECTION: process.env.SSH_CONNECTION,
           SSH_TTY: process.env.SSH_TTY,
           SWITCHROOM_DRIVE_OAUTH_TIER:
-            process.env.SWITCHROOM_DRIVE_OAUTH_TIER,
+            process.env.SWITCHROOM_DRIVE_OAUTH_TIER ?? "desktop_loopback",
         };
         const initialTier = selectInitialTier(oauthEnv);
 

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -161,17 +161,15 @@ function registerConnect(googleParent: Command, program: Command): void {
         console.log(
           "    4. Credentials → Create credentials → OAuth client ID →",
         );
-        console.log(
-          '       Application type: "TVs and Limited Input devices".',
-        );
+        console.log('       Application type: "Desktop app".');
         console.log(
           chalk.gray(
-            "\n  Must be the TVs-and-Limited-Input type, NOT Desktop: agents\n" +
-              "  authorize via Google's device-code flow (you approve from\n" +
-              "  your phone), which only that client type supports. The\n" +
-              "  examples/personal-google-workspace-mcp/ host client is a\n" +
-              "  separate Desktop client for a different surface — the fleet\n" +
-              "  needs its own.\n",
+            "\n  Must be Desktop app. Google's device-code flow does NOT\n" +
+              "  support Drive scopes (it returns invalid_scope), and OOB is\n" +
+              "  retired — so Drive auth uses the loopback flow, which\n" +
+              "  requires a Desktop client. On a headless server you complete\n" +
+              "  the one browser step over an SSH port-forward (the CLI\n" +
+              "  prints the exact URL + port).\n",
           ),
         );
 
@@ -595,15 +593,21 @@ function registerAccountAdd(accountParent: Command): void {
       "Overwrite existing credentials for <account> (default refuses if account already registered)",
       false,
     )
+    .option(
+      "--write",
+      "Request Drive WRITE scope (drive.file: create + edit app-created files) in addition to read. Default is read-only — a read grant never silently becomes a write grant. Re-consent an existing account with `--replace --write`.",
+      false,
+    )
     .action(
-      withConfigError(async (account: string, opts: { replace?: boolean }) => {
+      withConfigError(
+        async (account: string, opts: { replace?: boolean; write?: boolean }) => {
         const normalizedAccount = validateAndNormalizeAccountEmail(account);
 
         // Lazy-import the OAuth flow + vault resolver — they pull in
         // sizeable trees (Drive scaffolding, AES vault) that the
         // sibling enable/disable/list verbs don't need.
         const [
-          { runDriveOAuthFlow, DRIVE_READONLY_SCOPES },
+          { runDriveOAuthFlow, selectDriveAccountScopes },
           { selectInitialTier },
           { brokerCall },
           { loadConfig, resolvePath },
@@ -729,11 +733,19 @@ function registerAccountAdd(accountParent: Command): void {
           );
         }
 
+        const accountScopes = selectDriveAccountScopes(opts.write ?? false);
         const oauthCfg = {
           client_id: clientIdRaw,
           client_secret: clientSecretRaw,
-          scopes: DRIVE_READONLY_SCOPES,
+          scopes: accountScopes,
         };
+        if (opts.write) {
+          console.log(
+            chalk.yellow(
+              "  Requesting Drive WRITE scope (drive.file — create/edit app-created files).",
+            ),
+          );
+        }
         // OAuthEnv is a shaped subset of process.env — picking the
         // fields the selector reads (rather than passing process.env
         // wholesale) keeps the call typed.
@@ -776,7 +788,7 @@ function registerAccountAdd(accountParent: Command): void {
           tokens,
           clientId: clientIdRaw,
           accountEmail: normalizedAccount,
-          fallbackScope: DRIVE_READONLY_SCOPES.join(" "),
+          fallbackScope: accountScopes.join(" "),
         });
 
         await brokerCall(async (client) => {
@@ -830,10 +842,10 @@ export function oauthClientSetupGuidance(reason: string): string {
     "    switchroom auth google connect",
     "",
     "  Manual: at https://console.cloud.google.com create an OAuth",
-    '  client of type "TVs and Limited Input devices" (NOT Desktop —',
-    "  agents authorize via the device-code flow, which only that type",
-    "  supports), enable the Drive/Docs/Sheets/Calendar APIs, add",
-    "  yourself as a test user, then:",
+    '  client of type "Desktop app" (Drive uses the loopback flow —',
+    "  device-code returns invalid_scope for Drive and OOB is retired),",
+    "  enable the Drive/Docs/Sheets/Calendar APIs, add yourself as a",
+    "  test user, then:",
     "",
     "    switchroom vault set google-oauth-client-id",
     "    switchroom vault set google-oauth-client-secret",

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -586,7 +586,7 @@ function registerAccountAdd(accountParent: Command): void {
   accountParent
     .command("add <account>")
     .description(
-      "Mint a Google OAuth refresh token for <account> and register it with the auth-broker. Three-tier OAuth: device-code → OOB-paste → desktop-loopback (RFC D §3, RFC G §4.5).",
+      "Mint a Google OAuth refresh token for <account> and register it with the auth-broker. For Drive scopes the effective flow is desktop-loopback (device-code returns invalid_scope for Drive; OOB is retired) — use a Desktop OAuth client; on a headless host complete the browser step over an SSH port-forward. Add --write for create/edit (drive.file); default is read-only.",
     )
     .option(
       "--replace",

--- a/src/cli/drive.test.ts
+++ b/src/cli/drive.test.ts
@@ -36,7 +36,13 @@ vi.mock("../vault/vault.js", () => ({
   ),
 }));
 
-import { __test, type DriveCliDeps } from "./drive.js";
+import {
+  __test,
+  selectDriveAccountScopes,
+  DRIVE_READONLY_SCOPES,
+  DRIVE_WRITE_SCOPES,
+  type DriveCliDeps,
+} from "./drive.js";
 import type { WaitForApprovalResult } from "../vault/approvals/wait.js";
 import type { TokenResponse } from "../drive/oauth.js";
 
@@ -420,5 +426,26 @@ describe("drive disconnect", () => {
     const { deps, exit } = makeDeps();
     await __test.runDisconnect({ agentName: "ghost" }, deps);
     expect(exit.code).toBe(4);
+  });
+});
+
+describe("selectDriveAccountScopes", () => {
+  it("defaults to read-only — a read grant never silently becomes write", () => {
+    const s = selectDriveAccountScopes(false);
+    expect(s).toEqual(DRIVE_READONLY_SCOPES);
+    expect(s).not.toContain("https://www.googleapis.com/auth/drive.file");
+  });
+
+  it("write=true adds drive.file (least-privilege) and keeps read scopes", () => {
+    const s = selectDriveAccountScopes(true);
+    expect(s).toEqual(DRIVE_WRITE_SCOPES);
+    expect(s).toContain("https://www.googleapis.com/auth/drive.file");
+    // Read scopes retained so the browse+read collab loop still works.
+    expect(s).toContain("https://www.googleapis.com/auth/drive.readonly");
+    expect(s).toContain(
+      "https://www.googleapis.com/auth/drive.metadata.readonly",
+    );
+    // Least-privilege: NOT the full read/write `drive` scope.
+    expect(s).not.toContain("https://www.googleapis.com/auth/drive");
   });
 });

--- a/src/cli/drive.ts
+++ b/src/cli/drive.ts
@@ -79,7 +79,30 @@ export const DRIVE_READONLY_SCOPES = [
   "https://www.googleapis.com/auth/drive.readonly",
   "https://www.googleapis.com/auth/drive.metadata.readonly",
 ];
+
+// Opt-in write scope set. `drive.file` is least-privilege: it grants
+// create + edit ONLY for files the app itself creates (or that the user
+// explicitly opens with it) — it does NOT grant edit of arbitrary
+// pre-existing user files (that would be the full `drive` scope). The
+// read scopes are retained so the collab loop (browse folders, read an
+// existing doc, draft a NEW doc next to it) still works. A read grant
+// never silently becomes a write grant (RFC D §12) — callers must
+// explicitly request these (the `--write` flag on `account add`).
+export const DRIVE_WRITE_SCOPES = [
+  ...DRIVE_READONLY_SCOPES,
+  "https://www.googleapis.com/auth/drive.file",
+];
 const DEFAULT_SCOPES = DRIVE_READONLY_SCOPES;
+
+/**
+ * Pick the OAuth scope set for `auth google account add`. Default is
+ * read-only; write is strictly opt-in (RFC D §12 — a read grant must
+ * never silently authorize writes). Pure + exported so the
+ * default-is-read invariant is unit-pinned.
+ */
+export function selectDriveAccountScopes(write: boolean): string[] {
+  return write ? DRIVE_WRITE_SCOPES : DRIVE_READONLY_SCOPES;
+}
 
 export interface DriveCliDeps {
   /** Test seam: substitute the OAuth flow runner. */

--- a/src/drive/oauth.test.ts
+++ b/src/drive/oauth.test.ts
@@ -84,6 +84,22 @@ describe("selectInitialTier", () => {
       }),
     ).toBe("desktop_loopback");
   });
+
+  // Load-bearing for the `account add` Drive default: the override must
+  // win even on a headless host (no DISPLAY, inside SSH), ahead of the
+  // headless-avoidance. account add defaults the env to
+  // desktop_loopback for Drive precisely because device-code/OOB are
+  // dead ends for Drive and the ladder otherwise dead-ends headless.
+  it("override beats headless-avoidance (desktop_loopback on a headless SSH host)", () => {
+    expect(
+      selectInitialTier({
+        DISPLAY: undefined,
+        WAYLAND_DISPLAY: undefined,
+        SSH_CONNECTION: "10.0.0.2 5 10.0.0.1 22",
+        SWITCHROOM_DRIVE_OAUTH_TIER: "desktop_loopback",
+      }),
+    ).toBe("desktop_loopback");
+  });
 });
 
 describe("nextTier", () => {

--- a/src/drive/oauth.ts
+++ b/src/drive/oauth.ts
@@ -10,14 +10,20 @@
  * Drive scopes switchroom requests, tiers 1 and 2 are dead ends — Google
  * returns `invalid_scope` for Drive on the device-code endpoint, and the
  * OOB redirect (`urn:ietf:wg:oauth:2.0:oob`) was retired by Google in
- * 2022 (HTTP 400 `invalid_request`). So for Drive the effective working
- * tier is **desktop-loopback with a Desktop OAuth client**; on a headless
- * host the operator completes the one browser step over an SSH
- * port-forward to the printed `127.0.0.1:<port>`. The ladder still
- * degrades gracefully (#1352 maps the device-code rejection to a
- * tier-fallthrough, not a crash), so the runtime is correct — it just
- * lands on loopback after two no-op attempts. The generic ladder stays
- * accurate for any future non-Drive scope set.
+ * 2022 (HTTP 400 `invalid_request`). The generic ladder does NOT
+ * self-recover on a headless host: #1352 keeps device-code's rejection
+ * from crashing, but the next tier (OOB) then blocks on an
+ * un-answerable paste prompt and `nextTier()` returns `null` before
+ * loopback — so an unguided headless Drive `account add` aborts without
+ * ever trying loopback. The only Drive-viable flow is
+ * **desktop-loopback with a Desktop OAuth client**. Therefore
+ * `account add` defaults its initial tier to `desktop_loopback` for
+ * Drive (see `src/cli/auth-google.ts`; operator-overridable via
+ * `SWITCHROOM_DRIVE_OAUTH_TIER`), and `selectInitialTier` honours that
+ * override ahead of its headless-avoidance — so loopback is selected
+ * even headless, and the operator completes the one browser step over
+ * an SSH port-forward to the printed `127.0.0.1:<port>`. The generic
+ * ladder stays accurate for any future non-Drive scope set.
  *
  * Auto-detect headlessness from env: if `$DISPLAY` and `$WAYLAND_DISPLAY` are
  * both empty AND we are inside an SSH session (`$SSH_CONNECTION` present),

--- a/src/drive/oauth.ts
+++ b/src/drive/oauth.ts
@@ -1,10 +1,23 @@
 /**
  * Google Drive OAuth flow — three-tier auto-selection (RFC C §3).
  *
- * Tier preference (in order):
- *   1. RFC 8628 device-code (preferred — works over SSH, no port binding).
- *   2. OOB-paste (fallback — Google may reject device-code for Drive scopes).
- *   3. Desktop loopback (last resort — only when a local browser is reachable).
+ * Generic tier ladder (in order):
+ *   1. RFC 8628 device-code (works over SSH, no port binding).
+ *   2. OOB-paste.
+ *   3. Desktop loopback (needs a reachable browser / SSH port-forward).
+ *
+ * **Drive-scope reality (load-bearing — verified empirically):** for the
+ * Drive scopes switchroom requests, tiers 1 and 2 are dead ends — Google
+ * returns `invalid_scope` for Drive on the device-code endpoint, and the
+ * OOB redirect (`urn:ietf:wg:oauth:2.0:oob`) was retired by Google in
+ * 2022 (HTTP 400 `invalid_request`). So for Drive the effective working
+ * tier is **desktop-loopback with a Desktop OAuth client**; on a headless
+ * host the operator completes the one browser step over an SSH
+ * port-forward to the printed `127.0.0.1:<port>`. The ladder still
+ * degrades gracefully (#1352 maps the device-code rejection to a
+ * tier-fallthrough, not a crash), so the runtime is correct — it just
+ * lands on loopback after two no-op attempts. The generic ladder stays
+ * accurate for any future non-Drive scope set.
  *
  * Auto-detect headlessness from env: if `$DISPLAY` and `$WAYLAND_DISPLAY` are
  * both empty AND we are inside an SSH session (`$SSH_CONNECTION` present),


### PR DESCRIPTION
## Summary

**Agent write-to-Drive never worked.** `DRIVE_READONLY_SCOPES` was the *only* Google OAuth scope set anywhere in the codebase. RFC E shipped the write approval card + PreToolUse hook but its spec explicitly says *"read scopes unchanged"* — so every actual Drive write 403s at Google. The feature was non-functional at the API layer.

This makes write **possible, opt-in, least-privilege**:

- `src/cli/drive.ts`: `DRIVE_WRITE_SCOPES` = read scopes + `https://www.googleapis.com/auth/drive.file`. Pure `selectDriveAccountScopes(write)`.
- `src/cli/auth-google.ts`: `account add --write` requests the write set; `--replace --write` re-consents an existing account. **Default stays read-only — a read grant never silently becomes write (RFC D §12).**
- `drive.file` is least-privilege by design: create/edit *app-created* files only — agents cannot edit pre-existing unrelated user files (that's the full `drive` scope, deliberately not requested).

### Also: corrects actively-wrong setup docs (#1352 regression)

#1352 told operators to create a *"TVs and Limited Input devices"* client for device-code. But Google returns **`invalid_scope`** for Drive on device flow, and **OOB is retired**. The *only* working Drive flow is **loopback**, which needs a **Desktop app** client (completed over an SSH port-forward on headless hosts). That wrong guidance cost days of real UAT. Fixed in all three places (connect wizard stdout, `oauthClientSetupGuidance`, `docs/google-workspace.md`), plus the docs now state scopes are independent of the `tier` knob and document `--write` + the `--replace --write` re-consent.

## Test plan

- [x] `npm run lint` clean
- [x] `selectDriveAccountScopes` tests: default = read-only (no `drive.file`); `--write` adds `drive.file`, keeps read scopes, is NOT full `drive`
- [x] 296 `src/cli` vitest green, no regressions
- [ ] CI: required checks
- [ ] Post-merge: re-consent `pixsoul@gmail.com` with `--replace --write`; end-to-end verify an agent can create a file in Drive via the upstream MCP write tool + RFC E approval hook (RFC E §10 marked merged but never exercised with a write-capable token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)