### PR TITLE
feat(telegram): HTML→plaintext fallback on Telegram 400 parse-reject

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -118,7 +118,13 @@ ALLOWLIST=(
   # Re-bumped 2026-05-15 for #1345 (quota align): +2 lines inserted above
   # (quota-check import + a startBootCard wiring line) shifted the
   # unchanged callsite 3499 -> 3501, just past the old 3500 bound.
-  "telegram-plugin/gateway/gateway.ts:3160-3505:reply chunk-loop THREAD_NOT_FOUND fallback (intentional raw)"
+  # Re-bumped 2026-05-16 for the HTML→plaintext parse-reject fallback:
+  # the sendChunkPlainText helper + restructured try/catch (~25 lines)
+  # shifted the THREAD_NOT_FOUND raw send 3501 -> 3519. The new
+  # sendChunkPlainText raw send (~3498) is the SAME intentional-raw
+  # rationale — a terminal last-resort resend that must not re-enter
+  # the retry/parse-mode policy that just rejected the payload.
+  "telegram-plugin/gateway/gateway.ts:3160-3540:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.11.1";
-export const COMMIT_SHA: string | null = "f3525f59";
-export const COMMIT_DATE: string | null = "2026-05-15T22:41:43Z";
-export const LATEST_PR: number | null = 1354;
-export const COMMITS_AHEAD_OF_TAG: number | null = 11;
+export const COMMIT_SHA: string | null = "2e9ab264";
+export const COMMIT_DATE: string | null = "2026-05-16T10:27:12+10:00";
+export const LATEST_PR: number | null = null;
+export const COMMITS_AHEAD_OF_TAG: number | null = 12;

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.11.1";
-export const COMMIT_SHA: string | null = "0cb3e47b";
-export const COMMIT_DATE: string | null = "2026-05-15T21:08:03+10:00";
-export const LATEST_PR: number | null = 1351;
-export const COMMITS_AHEAD_OF_TAG: number | null = 7;
+export const COMMIT_SHA: string | null = "f3525f59";
+export const COMMIT_DATE: string | null = "2026-05-15T22:41:43Z";
+export const LATEST_PR: number | null = 1354;
+export const COMMITS_AHEAD_OF_TAG: number | null = 11;

--- a/telegram-plugin/format.ts
+++ b/telegram-plugin/format.ts
@@ -380,6 +380,77 @@ export function escapeHtml(text: string): string {
     .replace(/"/g, '&quot;')
 }
 
+/**
+ * Last-resort renderer: turn (possibly malformed) Telegram HTML into
+ * readable plain text. Used by the gateway's send/edit path when
+ * Telegram rejects a chunk with a 400 "can't parse entities" /
+ * "unsupported start tag" — i.e. our HTML prevention (markdownToHtml +
+ * sanitizeForTelegram + splitHtmlChunks) let something through anyway.
+ *
+ * The caller resends the result with `parse_mode` UNSET, so the output
+ * is literal text — we intentionally do NOT re-escape `< > &`. The goal
+ * is "the agent's answer lands unformatted" instead of "the answer
+ * silently vanishes" (visibility + always-on).
+ *
+ * Transforms, in order:
+ *  1. `<a href="u">label</a>` → `label (u)` (or just `u` when label is
+ *     empty or equals the href). href/label are themselves stripped +
+ *     entity-decoded so we never emit nested markup.
+ *  2. Block / break boundaries → newline: `<br>`, `</p>`, `</div>`,
+ *     `</li>`, `</blockquote>`, `</pre>`. (These aren't Telegram-
+ *     supported tags, but a markdown→HTML slip that emits one is a
+ *     prime cause of the parse reject we're recovering from.)
+ *  3. Strip every remaining tag.
+ *  4. Decode the standard HTML entities Telegram uses.
+ *  5. Collapse 3+ blank lines to 2; trim trailing per-line whitespace.
+ */
+export function telegramHtmlToPlainText(html: string): string {
+  const decodeEntities = (s: string): string =>
+    s
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#0*39;|&#x0*27;|&apos;/gi, "'")
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&#(\d+);/g, (_m, d: string) => {
+        const cp = Number(d)
+        return Number.isFinite(cp) && cp > 0 && cp <= 0x10ffff
+          ? String.fromCodePoint(cp)
+          : _m
+      })
+      .replace(/&#x([0-9a-fA-F]+);/g, (_m, h: string) => {
+        const cp = parseInt(h, 16)
+        return Number.isFinite(cp) && cp > 0 && cp <= 0x10ffff
+          ? String.fromCodePoint(cp)
+          : _m
+      })
+
+  const stripTags = (s: string): string =>
+    decodeEntities(
+      s
+        .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+        .replace(/<\/\s*(?:p|div|li|blockquote|pre|h[1-6])\s*>/gi, '\n')
+        .replace(/<[^>]*>/g, ''),
+    )
+
+  // 1. Anchors → "label (href)". Handle double/single/unquoted href.
+  const withPlainLinks = html.replace(
+    /<a\b[^>]*\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a>/gi,
+    (_m, dq: string | undefined, sq: string | undefined, uq: string | undefined, label: string) => {
+      const href = decodeEntities((dq ?? sq ?? uq ?? '').trim())
+      const text = stripTags(label).trim()
+      if (!href) return text
+      return !text || text === href ? href : `${text} (${href})`
+    },
+  )
+
+  return stripTags(withPlainLinks)
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
 // ---------------------------------------------------------------------------
 // Output sanitizer — enforces fleet-wide Telegram formatting invariants
 // ---------------------------------------------------------------------------

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -62,6 +62,7 @@ import {
   createRetryApiCall,
   createSwallowingRetryApiCall,
   retryWithThreadFallback,
+  isHtmlParseRejectError,
 } from '../retry-api-call.js'
 import { installTgPostLogger, withTgPostTags } from '../shared/bot-runtime.js'
 import { buildAttachmentPath, assertInsideInbox } from '../attachment-path.js'
@@ -137,7 +138,7 @@ import { validateStringArray } from './access-validator.js'
  * identical envelope shapes.
  */
 const REPLY_TO_TEXT_MAX = 200
-import { markdownToHtml, splitHtmlChunks, repairEscapedWhitespace } from '../format.js'
+import { markdownToHtml, splitHtmlChunks, repairEscapedWhitespace, telegramHtmlToPlainText } from '../format.js'
 import {
   validateInlineKeyboard,
   type AnyButton,
@@ -3486,6 +3487,22 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         }
       }
 
+      // Last-resort: resend this chunk as plain text (parse_mode unset).
+      // Keeps thread / reply / markup params; only the formatting is
+      // sacrificed. Used when Telegram rejects our HTML — better an
+      // unformatted answer than a vanished one.
+      const sendChunkPlainText = async (opts: Record<string, unknown>): Promise<void> => {
+        const plainOpts = { ...opts }
+        delete (plainOpts as { parse_mode?: unknown }).parse_mode
+        const plain = telegramHtmlToPlainText(chunks[i])
+        const sent = await lockedBot.api.sendMessage(chat_id, plain, plainOpts as never)
+        sentIds.push(sent.message_id)
+        logOutbound('reply', chat_id, sent.message_id, plain.length, `chunk=${i + 1}/${chunks.length} plaintext-fallback`)
+        process.stderr.write(
+          `telegram gateway: HTML parse-reject — resent chunk ${i + 1}/${chunks.length} as plain text\n`,
+        )
+      }
+
       try {
         const sent = await robustApiCall(
           () => lockedBot.api.sendMessage(chat_id, chunks[i], sendOpts as never),
@@ -3498,8 +3515,16 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
           threadId = undefined
           const retryOpts = { ...sendOpts }
           delete (retryOpts as any).message_thread_id
-          const sent = await lockedBot.api.sendMessage(chat_id, chunks[i], retryOpts as never)
-          sentIds.push(sent.message_id)
+          try {
+            const sent = await lockedBot.api.sendMessage(chat_id, chunks[i], retryOpts as never)
+            sentIds.push(sent.message_id)
+          } catch (retryErr) {
+            // Thread dropped, but the HTML is also unparseable — go plain.
+            if (isHtmlParseRejectError(retryErr)) await sendChunkPlainText(retryOpts)
+            else throw retryErr
+          }
+        } else if (isHtmlParseRejectError(err)) {
+          await sendChunkPlainText(sendOpts)
         } else {
           throw err
         }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3494,7 +3494,16 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       const sendChunkPlainText = async (opts: Record<string, unknown>): Promise<void> => {
         const plainOpts = { ...opts }
         delete (plainOpts as { parse_mode?: unknown }).parse_mode
-        const plain = telegramHtmlToPlainText(chunks[i])
+        // A chunk that was pure markup (no text content) strips to ''.
+        // Sending '' is a Telegram 400 "message text is empty" — i.e.
+        // the answer would still vanish, in the exact path that exists
+        // to prevent that. Substitute an honest placeholder so the
+        // user at least sees that a fragment was unrenderable.
+        const stripped = telegramHtmlToPlainText(chunks[i])
+        const plain =
+          stripped.length > 0
+            ? stripped
+            : '⚠️ (a formatted fragment could not be rendered for Telegram)'
         const sent = await lockedBot.api.sendMessage(chat_id, plain, plainOpts as never)
         sentIds.push(sent.message_id)
         logOutbound('reply', chat_id, sent.message_id, plain.length, `chunk=${i + 1}/${chunks.length} plaintext-fallback`)

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -270,7 +270,7 @@ export function isHtmlParseRejectError(err: unknown): boolean {
     d.includes('unsupported start tag') ||
     d.includes('unclosed start tag') ||
     d.includes("can't find end of the entity") ||
-    d.includes('unexpected end tag') ||
+    // covers both "expected end tag" and "unexpected end tag"
     d.includes('expected end tag')
   )
 }

--- a/telegram-plugin/retry-api-call.ts
+++ b/telegram-plugin/retry-api-call.ts
@@ -250,3 +250,27 @@ export async function retryWithThreadFallback<T>(
     throw err
   }
 }
+
+/**
+ * True when Telegram rejected a message because it couldn't parse the
+ * HTML/entities we sent — our prevention (markdownToHtml +
+ * sanitizeForTelegram + splitHtmlChunks) let something malformed
+ * through anyway. These 400s are deliberately NOT swallowed or retried
+ * by `retryApiCall` (only not-modified / not-found / thread-not-found
+ * are) — they surface to the caller, which recovers by resending the
+ * chunk as plain text (parse_mode unset). Same "caller-level fallback"
+ * shape as the THREAD_NOT_FOUND contract above.
+ */
+export function isHtmlParseRejectError(err: unknown): boolean {
+  if (!(err instanceof GrammyError) || err.error_code !== 400) return false
+  const d = (err.description || '').toLowerCase()
+  return (
+    d.includes("can't parse entities") ||
+    d.includes('can’t parse entities') ||
+    d.includes('unsupported start tag') ||
+    d.includes('unclosed start tag') ||
+    d.includes("can't find end of the entity") ||
+    d.includes('unexpected end tag') ||
+    d.includes('expected end tag')
+  )
+}

--- a/telegram-plugin/tests/retry-api-call.test.ts
+++ b/telegram-plugin/tests/retry-api-call.test.ts
@@ -14,6 +14,7 @@ import {
   createRetryApiCall,
   createSwallowingRetryApiCall,
   retryWithThreadFallback,
+  isHtmlParseRejectError,
   type RetryObserver,
 } from '../retry-api-call.js'
 import { errors, makeGrammyError } from './fake-bot-api.js'
@@ -434,5 +435,80 @@ describe('retryWithThreadFallback (#1075)', () => {
       verb: 'editMessageText',
     })
     expect(result).toBe(true)
+  })
+})
+
+describe('isHtmlParseRejectError', () => {
+  it('matches the real Telegram parse-failure 400 descriptions', () => {
+    const descriptions = [
+      "can't parse entities: Unsupported start tag \"h2\" at byte offset 12",
+      'Bad Request: unsupported start tag "span"',
+      "can't find end of the entity starting at byte offset 40",
+      'Bad Request: unclosed start tag at byte offset 5',
+      'Bad Request: unexpected end tag at byte offset 9',
+      "Bad Request: can't parse entities: expected end tag",
+    ]
+    for (const d of descriptions) {
+      expect(
+        isHtmlParseRejectError(
+          makeGrammyError({ error_code: 400, description: d, method: 'sendMessage' }),
+        ),
+      ).toBe(true)
+    }
+  })
+
+  it('does NOT match other 400s (those have their own handling)', () => {
+    for (const d of [
+      'Bad Request: message is not modified',
+      'Bad Request: message to edit not found',
+      'Bad Request: message thread not found',
+      'Bad Request: chat not found',
+    ]) {
+      expect(
+        isHtmlParseRejectError(
+          makeGrammyError({ error_code: 400, description: d, method: 'sendMessage' }),
+        ),
+      ).toBe(false)
+    }
+  })
+
+  it('does not match non-400 GrammyErrors', () => {
+    expect(
+      isHtmlParseRejectError(
+        makeGrammyError({
+          error_code: 429,
+          description: "can't parse entities",
+          method: 'sendMessage',
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      isHtmlParseRejectError(
+        makeGrammyError({
+          error_code: 403,
+          description: 'Forbidden: bot was blocked',
+          method: 'sendMessage',
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('does not match plain Errors or non-error values', () => {
+    expect(isHtmlParseRejectError(new Error("can't parse entities"))).toBe(false)
+    expect(isHtmlParseRejectError('string')).toBe(false)
+    expect(isHtmlParseRejectError(null)).toBe(false)
+    expect(isHtmlParseRejectError(undefined)).toBe(false)
+  })
+
+  it('matches the curly-apostrophe variant Telegram sometimes emits', () => {
+    expect(
+      isHtmlParseRejectError(
+        makeGrammyError({
+          error_code: 400,
+          description: 'Bad Request: can’t parse entities: bad tag',
+          method: 'sendMessage',
+        }),
+      ),
+    ).toBe(true)
   })
 })

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -1165,4 +1165,12 @@ describe('telegramHtmlToPlainText (HTML parse-reject fallback)', () => {
     expect(telegramHtmlToPlainText('')).toBe('')
     expect(telegramHtmlToPlainText('   \n  ')).toBe('')
   })
+
+  test('pure-markup chunk collapses to empty (gateway substitutes a placeholder)', () => {
+    // Documents the trigger for the empty-string guard in
+    // gateway.ts:sendChunkPlainText — a chunk with no text content
+    // strips to '', so the send path must substitute rather than
+    // post an empty message (Telegram 400 "message text is empty").
+    expect(telegramHtmlToPlainText('<b></b><i></i><br><span></span>')).toBe('')
+  })
 })

--- a/telegram-plugin/tests/telegram-format.test.ts
+++ b/telegram-plugin/tests/telegram-format.test.ts
@@ -6,7 +6,7 @@ import { describe, test, expect } from 'vitest'
 
 // Import from the side-effect-free format module so tests don't trigger
 // server.ts's startup (env load, token check, grammy init).
-import { markdownToHtml, splitHtmlChunks, isLikelyTelegramHtml, repairEscapedWhitespace, sanitizeForTelegram } from '../format.js'
+import { markdownToHtml, splitHtmlChunks, isLikelyTelegramHtml, repairEscapedWhitespace, sanitizeForTelegram, telegramHtmlToPlainText } from '../format.js'
 
 // ---------------------------------------------------------------------------
 // markdownToHtml
@@ -1089,5 +1089,80 @@ describe('markdownToHtml — markdown table rendering', () => {
     // Output is still a bullet list
     expect(result).toContain('• <b>AND</b>')
     expect(result).toContain('• <b>OR</b>')
+  })
+})
+
+describe('telegramHtmlToPlainText (HTML parse-reject fallback)', () => {
+  test('strips supported formatting tags, keeps the text', () => {
+    const out = telegramHtmlToPlainText('<b>Bold</b> and <i>italic</i> and <code>x=1</code>')
+    expect(out).toBe('Bold and italic and x=1')
+  })
+
+  test('anchors become "label (href)"', () => {
+    const out = telegramHtmlToPlainText('see <a href="https://example.com/x">the docs</a> now')
+    expect(out).toBe('see the docs (https://example.com/x) now')
+  })
+
+  test('anchor with label equal to href collapses to the bare url', () => {
+    const out = telegramHtmlToPlainText('<a href="https://example.com">https://example.com</a>')
+    expect(out).toBe('https://example.com')
+  })
+
+  test('anchor with empty label yields just the href', () => {
+    expect(telegramHtmlToPlainText('<a href="https://e.com"></a>')).toBe('https://e.com')
+  })
+
+  test('single-quoted and unquoted href forms are handled', () => {
+    expect(telegramHtmlToPlainText("<a href='https://a.co'>A</a>")).toBe('A (https://a.co)')
+    expect(telegramHtmlToPlainText('<a href=https://b.co>B</a>')).toBe('B (https://b.co)')
+  })
+
+  test('decodes the standard HTML entities (no double-decode of the result)', () => {
+    const out = telegramHtmlToPlainText('a &amp; b &lt;tag&gt; &quot;q&quot; &#39;s&#39; 5 &nbsp;€')
+    expect(out).toBe('a & b <tag> "q" \'s\' 5  €')
+  })
+
+  test('numeric + hex char references decode', () => {
+    expect(telegramHtmlToPlainText('&#8594; &#x2192;')).toBe('→ →')
+  })
+
+  test('out-of-range / malformed char refs are left literal', () => {
+    expect(telegramHtmlToPlainText('&#0; &#1114112; &#xZZ;')).toBe('&#0; &#1114112; &#xZZ;')
+  })
+
+  test('block/break boundaries become newlines', () => {
+    const out = telegramHtmlToPlainText('one<br>two<br/>three</p>four</blockquote>five')
+    expect(out).toBe('one\ntwo\nthree\nfour\nfive')
+  })
+
+  test('unsupported / malformed tags (the actual reject cause) are stripped, not escaped', () => {
+    // A markdown→HTML slip that emitted an unsupported tag is exactly
+    // what triggers Telegram's 400; the fallback must yield clean text.
+    const out = telegramHtmlToPlainText('<h2>Title</h2><span class=x>body </span><unknowntag>tail')
+    expect(out).toBe('Title\nbody tail')
+  })
+
+  test('result is literal (parse_mode unset) — no re-escaping of < > &', () => {
+    // We resend with parse_mode UNSET, so the output must be the raw
+    // characters, not HTML entities.
+    const out = telegramHtmlToPlainText('a &lt; b &amp;&amp; c &gt; d')
+    expect(out).toBe('a < b && c > d')
+    expect(out).not.toContain('&lt;')
+    expect(out).not.toContain('&amp;')
+  })
+
+  test('collapses 3+ blank lines and trims trailing line whitespace', () => {
+    const out = telegramHtmlToPlainText('a   \n\n\n\n\nb')
+    expect(out).toBe('a\n\nb')
+  })
+
+  test('nested formatting inside an anchor label is flattened', () => {
+    const out = telegramHtmlToPlainText('<a href="https://x.io"><b>Big</b> link</a>')
+    expect(out).toBe('Big link (https://x.io)')
+  })
+
+  test('empty / whitespace input is safe', () => {
+    expect(telegramHtmlToPlainText('')).toBe('')
+    expect(telegramHtmlToPlainText('   \n  ')).toBe('')
   })
 })


### PR DESCRIPTION
## Summary
Adopted from OpenClaw's `telegramHtmlToPlainTextFallback` ([their docs](https://docs.openclaw.ai/channels/telegram#formatting-and-html-fallback)) after a structured assessment of their recent Telegram work.

switchroom invests heavily in *preventing* malformed Telegram HTML (`markdownToHtml` + `sanitizeForTelegram` + tag-aware `splitHtmlChunks`) but had **no last-resort path**. When prevention misses — and `format.ts:326` documents a bug class that shipped — Telegram returns a 400 `can't parse entities`, which `retry-api-call.ts` deliberately does **not** swallow (only not-modified / not-found / thread-not-found are). The chunk throws and **the agent's entire reply silently never lands**. Direct hit on the visibility + always-on outcomes.

Now: on that specific 400, resend the chunk as plain text with `parse_mode` unset. The answer lands unformatted instead of vanishing.

## Changes
- **`telegramHtmlToPlainText()`** (`format.ts`) — anchors → `label (href)`, block/break/heading boundaries → newline, strip remaining tags, decode standard entities (incl. numeric/hex, out-of-range left literal). Output is literal (parse_mode unset) so it deliberately does **not** re-escape `< > &`.
- **`isHtmlParseRejectError()`** (`retry-api-call.ts`) — GrammyError classifier placed with the other 400 sub-case policy; side-effect-free and unit-testable (gateway.ts has import-time side effects).
- **`executeReply` send loop** (`gateway.ts`) — new catch arm; also covers the post-THREAD_NOT_FOUND retry hitting a parse reject. Preview-edit path already falls through to this send block on any edit error, so one wiring point suffices.
- **Allowlist range bump** (`check-bot-api-wrapping.sh`) — the new helper shifted the pre-existing THREAD_NOT_FOUND raw send; the new plaintext raw send is the same intentional-raw rationale (terminal resend must not re-enter the policy that just rejected it).

## Scope discipline
Only category 1 of the OpenClaw comparison. Assessed and **skipped**: chunking (already at parity/better — switchroom's `splitHtmlChunks` is tag-aware, reopens `<a>` across chunks), truncated-finals (no shared failure mode — `reply()` payload is authoritative), ingress-backlog (covered by `poll-health` + `silence-poke`), room-events (product-model mismatch — community-bot feature).

## Test plan
- [x] +13 `telegram-format.test.ts` cases — anchors (quoted/unquoted/empty/nested), entities (named/numeric/hex/out-of-range), block boundaries, unsupported-tag strip, literal-output (no re-escape), blank-line collapse, empty input
- [x] +5 `retry-api-call.test.ts` cases — real Telegram parse-failure descriptions, non-matching 400s, non-400, non-error values, curly-apostrophe variant
- [x] Full telegram-plugin vitest suite: 2422 passed
- [x] `npm run lint` clean · `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)