### PR TITLE
fix(web): dashboard caught up with v0.7 Docker + RFC-H migrations (P0)

### DIFF
--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -118,7 +118,7 @@ export interface AgentStatus {
 const COMPOSE_PROJECT = "switchroom";
 
 /** Container name for an agent (set via `container_name:` in compose.ts). */
-function containerName(name: string): string {
+export function containerName(name: string): string {
   return `switchroom-${name}`;
 }
 

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -249,8 +249,9 @@ export interface UseAccountResult {
 
 /**
  * Set the fleet-wide active account. Replaces the pre-RFC-H
- * `/api/auth/promote` endpoint. No YAML rewrite from this code path —
- * the broker owns mirror writes; the CLI handles YAML when present.
+ * `/api/accounts/:label/promote` endpoint. No YAML rewrite from this
+ * code path — the broker owns mirror writes; the CLI handles YAML
+ * when present.
  */
 export async function handleUseAccount(label: string): Promise<UseAccountResult> {
   try {

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import {
@@ -6,6 +6,7 @@ import {
   startAgent,
   stopAgent,
   restartAgent,
+  containerName,
 } from "../agents/lifecycle.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
 import { getCollectionForAgent } from "../memory/hindsight.js";
@@ -113,19 +114,27 @@ export function handleGetLogs(
   name: string,
   lines: number = 50
 ): { ok: boolean; logs?: string; error?: string } {
-  try {
-    const output = execFileSync(
-      "journalctl",
-      ["--user", "-u", `switchroom-${name}`, "--no-pager", "-n", String(lines)],
-      { encoding: "utf-8", timeout: 5000 }
-    );
-    return { ok: true, logs: output };
-  } catch (err) {
+  // Agents are Docker containers since v0.7 — there is no
+  // `switchroom-<name>` systemd user unit to journalctl against.
+  // `docker logs` splits the container's stdout/stderr across the two
+  // fds; a container can log to either, so merge both for a complete
+  // view. spawnSync hands back both streams regardless of exit code.
+  const res = spawnSync(
+    "docker",
+    ["logs", "--tail", String(lines), containerName(name)],
+    { encoding: "utf-8", timeout: 5000 },
+  );
+  if (res.error) {
+    return { ok: false, error: res.error.message };
+  }
+  if (res.status !== 0) {
+    const stderr = (res.stderr ?? "").trim();
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: stderr || `docker logs exited ${res.status ?? "non-zero"}`,
     };
   }
+  return { ok: true, logs: `${res.stdout ?? ""}${res.stderr ?? ""}` };
 }
 
 export function handleGetTurns(

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -14,6 +14,7 @@ import { spawn } from "node:child_process";
 import { timingSafeEqual, randomBytes } from "node:crypto";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
+import { containerName } from "../agents/lifecycle.js";
 import {
   handleGetAgents,
   handleStartAgent,
@@ -613,9 +614,13 @@ export function startWebServer(
               (ws as any)._logProcess = null;
             }
 
+            // Agents are Docker containers since v0.7 — stream the
+            // container log, not a (nonexistent) systemd user unit.
+            // docker logs splits container stdout/stderr across the
+            // two fds; both are forwarded to the client below.
             const child = spawn(
-              "journalctl",
-              ["--user", "-u", `switchroom-${agentName}`, "-f", "--no-pager", "-n", "20"],
+              "docker",
+              ["logs", "-f", "--tail", "20", containerName(agentName)],
               { stdio: ["ignore", "pipe", "pipe"] }
             );
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -624,6 +624,23 @@ export function startWebServer(
               { stdio: ["ignore", "pipe", "pipe"] }
             );
 
+            // A missing `docker` binary (or exec failure) emits an
+            // 'error' event with no stdout/stderr; without a handler
+            // Node treats it as unhandled and crashes the server.
+            // Surface it to the client as a log_error instead.
+            child.on("error", (err: Error) => {
+              try {
+                ws.send(JSON.stringify({
+                  type: "log_error",
+                  agent: agentName,
+                  data: `failed to stream logs: ${err.message}\n`,
+                }));
+              } catch {
+                // Client already gone — nothing to clean up; the
+                // process never started so there's no pid to kill.
+              }
+            });
+
             child.stdout.on("data", (chunk: Buffer) => {
               try {
                 ws.send(JSON.stringify({

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -606,61 +606,65 @@
         container.innerHTML = '<div class="loading">No accounts. Run <code>switchroom auth account add &lt;label&gt;</code>.</div>';
         return;
       }
+      // RFC-H shape: the API returns `usedBy` (agents bound via the
+      // fleet-active account or a per-agent override) and a broker
+      // `quota` AccountState ({exhausted, exhausted_until,
+      // threshold_violations, last_refreshed_at}). The pre-RFC-H
+      // primaryFor/fallbackFor lists and quota.fiveHourPct utilization
+      // fields no longer exist on the wire.
       const enriched = accounts.map(a => {
-        const capturedMs = a.quota && a.quota.capturedAt ? new Date(a.quota.capturedAt).getTime() : null;
-        const captured = a.quota && a.quota.capturedAt ? new Date(a.quota.capturedAt).toLocaleString() : 'never';
+        const q = a.quota || null;
+        const exhausted = q ? !!q.exhausted : null;
         return {
           a,
-          capturedMs,
-          fiveH: renderQuotaPct(a.quota && a.quota.fiveHourPct, capturedMs),
-          sevenD: renderQuotaPct(a.quota && a.quota.sevenDayPct, capturedMs),
-          usageTitle: `Quota captured: ${captured}`,
-          primaryFor: a.primaryFor || [],
-          fallbackFor: a.fallbackFor || [],
-          refreshed: capturedMs ? formatTimestamp(capturedMs) : '<span style="color:var(--text-dim)">—</span>',
-          fiveReset: a.quota && a.quota.fiveHourResetAt ? formatTimestamp(a.quota.fiveHourResetAt) : '<span style="color:var(--text-dim)">—</span>',
-          sevenReset: a.quota && a.quota.sevenDayResetAt ? formatTimestamp(a.quota.sevenDayResetAt) : '<span style="color:var(--text-dim)">—</span>',
+          usedBy: a.usedBy || [],
+          exhausted,
+          exhaustedCell: q == null
+            ? '<span style="color:var(--text-dim)">broker offline</span>'
+            : exhausted
+              ? `<span class="quota-pct high">exhausted${q.exhausted_until ? ' → ' + formatTimestamp(q.exhausted_until) : ''}</span>`
+              : '<span class="quota-pct">ok</span>',
+          violations: q && q.threshold_violations
+            ? `<span class="quota-pct mid">${q.threshold_violations}</span>`
+            : '<span style="color:var(--text-dim)">0</span>',
+          refreshed: q && q.last_refreshed_at
+            ? formatTimestamp(q.last_refreshed_at)
+            : '<span style="color:var(--text-dim)">—</span>',
           expires: formatTimestamp(a.expiresAt),
         };
       });
       const rows = enriched.map(e => {
-        const { a, fiveH, sevenD, usageTitle, primaryFor, fallbackFor, refreshed, fiveReset, sevenReset, expires } = e;
-        const usageCell = renderUsageCell(primaryFor, fallbackFor);
+        const { a, usedBy, exhaustedCell, violations, refreshed, expires } = e;
         return `
         <tr>
           <td>${escapeHtml(a.label)}</td>
           <td><span class="health-badge ${escapeHtml(a.health)}">${escapeHtml(a.health)}</span></td>
-          <td>${usageCell}</td>
-          <td title="${escapeHtml(usageTitle)}">${fiveH}</td>
-          <td title="${escapeHtml(usageTitle)}">${sevenD}</td>
-          <td title="${escapeHtml(usageTitle)}">${refreshed}</td>
-          <td>${fiveReset}</td>
-          <td>${sevenReset}</td>
+          <td>${renderUsedByCell(usedBy)}</td>
+          <td>${exhaustedCell}</td>
+          <td>${violations}</td>
+          <td>${refreshed}</td>
           <td>${expires}</td>
-          <td><button class="btn" onclick="openPromoteModal('${escapeHtml(a.label)}')">Make primary…</button></td>
+          <td><button class="btn" onclick="openPromoteModal('${escapeHtml(a.label)}')">Make fleet-active…</button></td>
         </tr>
       `;
       }).join('');
       const cards = enriched.map(e => {
-        const { a, fiveH, sevenD, usageTitle, primaryFor, fallbackFor, refreshed, fiveReset, sevenReset, expires } = e;
-        const usageCell = renderUsageCell(primaryFor, fallbackFor);
+        const { a, usedBy, exhaustedCell, violations, refreshed, expires } = e;
         return `
         <div class="account-card">
           <div class="account-card-header">
             <div class="account-label">${escapeHtml(a.label)}</div>
             <span class="health-badge ${escapeHtml(a.health)}" style="margin-left:auto">${escapeHtml(a.health)}</span>
           </div>
-          <div class="account-usage">${usageCell}</div>
+          <div class="account-usage">${renderUsedByCell(usedBy)}</div>
           <div class="card-meta" style="padding:0">
-            <div class="meta-item" title="${escapeHtml(usageTitle)}"><label>5h% </label><span>${fiveH}</span></div>
-            <div class="meta-item" title="${escapeHtml(usageTitle)}"><label>7d% </label><span>${sevenD}</span></div>
-            <div class="meta-item" title="${escapeHtml(usageTitle)}"><label>Refreshed </label><span>${refreshed}</span></div>
-            <div class="meta-item"><label>5h reset </label><span>${fiveReset}</span></div>
-            <div class="meta-item"><label>7d reset </label><span>${sevenReset}</span></div>
+            <div class="meta-item"><label>Quota </label><span>${exhaustedCell}</span></div>
+            <div class="meta-item"><label>Threshold viols </label><span>${violations}</span></div>
+            <div class="meta-item"><label>Last refresh </label><span>${refreshed}</span></div>
             <div class="meta-item"><label>Expires </label><span>${expires}</span></div>
           </div>
           <div style="margin-top:0.75rem">
-            <button class="btn" onclick="openPromoteModal('${escapeHtml(a.label)}')">Make primary…</button>
+            <button class="btn" onclick="openPromoteModal('${escapeHtml(a.label)}')">Make fleet-active…</button>
           </div>
         </div>
       `;
@@ -670,9 +674,8 @@
           <table class="accounts-table">
             <thead><tr>
               <th>Label</th><th>Health</th><th>Used by</th>
-              <th>5h%</th><th>7d%</th>
-              <th>Refreshed</th><th>5h reset</th><th>7d reset</th>
-              <th>Expires</th><th></th>
+              <th>Quota</th><th>Threshold viols</th>
+              <th>Last refresh</th><th>Expires</th><th></th>
             </tr></thead>
             <tbody>${rows}</tbody>
           </table>
@@ -681,78 +684,40 @@
       `;
     }
 
-    function renderQuotaPct(pct, capturedAt) {
-      if (pct == null) return '<span class="quota-pct stale">—</span>';
-      // Stale = capture older than 1 hour. Quota refreshes opportunistically;
-      // anything beyond an hour likely doesn't reflect current consumption.
-      // Accept either an ISO string or a unix-ms number for capturedAt.
-      const capMs = capturedAt == null ? null
-        : typeof capturedAt === 'number' ? capturedAt
-        : new Date(capturedAt).getTime();
-      const stale = capMs && (Date.now() - capMs > 60 * 60 * 1000);
-      let cls = 'quota-pct';
-      if (stale) cls += ' stale';
-      else if (pct >= 80) cls += ' high';
-      else if (pct >= 50) cls += ' mid';
-      return `<span class="${cls}">${Math.round(pct)}%</span>`;
-    }
-
-    function renderUsageCell(primaryFor, fallbackFor) {
-      // Show primary agents inline as a green pill (most important signal),
-      // fallback on a second muted line. Truncate long lists with a count
-      // and a tooltip carrying the full enumeration.
-      if (primaryFor.length === 0 && fallbackFor.length === 0) {
+    function renderUsedByCell(usedBy) {
+      // RFC-H: a single fleet-active account plus optional per-agent
+      // overrides. `usedBy` is the flat list of agents currently bound
+      // to this account (either via fleet-active or an override). No
+      // more primary/fallback split — binding is singular post-RFC-H.
+      if (!usedBy || usedBy.length === 0) {
         return '<span style="color:var(--text-dim)">unused</span>';
       }
-      const MAX_INLINE = 3;
-      const fmt = (list) => {
-        if (list.length <= MAX_INLINE) return list.map(escapeHtml).join(', ');
-        const head = list.slice(0, MAX_INLINE).map(escapeHtml).join(', ');
-        return `${head} +${list.length - MAX_INLINE}`;
-      };
-      const parts = [];
-      if (primaryFor.length > 0) {
-        const title = `primary for: ${primaryFor.join(', ')}`;
-        parts.push(`<div><span class="usage-pill primary" title="${escapeHtml(title)}">Primary: ${fmt(primaryFor)}</span></div>`);
-      }
-      if (fallbackFor.length > 0) {
-        const title = `fallback for: ${fallbackFor.join(', ')}`;
-        parts.push(`<div class="agent-list" title="${escapeHtml(title)}" style="margin-top:0.2rem">Fallback: ${fmt(fallbackFor)}</div>`);
-      }
-      return parts.join('');
+      const MAX_INLINE = 4;
+      const title = `bound: ${usedBy.join(', ')}`;
+      const shown = usedBy.length <= MAX_INLINE
+        ? usedBy.map(escapeHtml).join(', ')
+        : `${usedBy.slice(0, MAX_INLINE).map(escapeHtml).join(', ')} +${usedBy.length - MAX_INLINE}`;
+      return `<span class="usage-pill primary" title="${escapeHtml(title)}">${shown}</span>`;
     }
 
     function openPromoteModal(label) {
-      // We need the list of agents that already have this account in their
-      // auth.accounts list — we can promote to any of them. Cross-reference
-      // primaryFor/fallbackFor on the cached account info.
-      const acct = accounts.find(a => a.label === label);
-      if (!acct) return;
-      const candidates = [...(acct.fallbackFor || [])].sort();
-      // Already-primary agents are valid targets (no-op) but not interesting;
-      // surface them as disabled options for clarity.
-      const alreadyPrimary = [...(acct.primaryFor || [])].sort();
-      if (candidates.length === 0 && alreadyPrimary.length === 0) {
-        showToast(`${label} isn't enabled on any agent yet — run \`switchroom auth enable ${label} <agent>\` first.`, false);
-        return;
-      }
-      const opts = candidates.map(n => `<option value="${escapeHtml(n)}">${escapeHtml(n)}</option>`).join('') +
-        alreadyPrimary.map(n => `<option value="${escapeHtml(n)}" disabled>${escapeHtml(n)} (already primary)</option>`).join('');
+      // RFC-H: there is no per-agent promote. Setting the fleet-active
+      // account is a single fleet-wide knob (POST /api/auth/use); the
+      // broker fans the new credentials out to every agent's per-agent
+      // mirror. Confirm intent, then call.
       const html = `
         <div class="modal-backdrop" id="promote-backdrop">
           <div class="modal">
-            <h3>Make <code>${escapeHtml(label)}</code> primary</h3>
-            <label>Agent</label>
-            <select id="promote-agent">
-              <option value="all">all agents that already have this account</option>
-              ${opts}
-            </select>
-            <div style="margin-top:0.5rem; font-size:0.75rem; color:var(--text-dim)">
-              The promoted agents will need a restart to load the new credentials.
+            <h3>Make <code>${escapeHtml(label)}</code> the fleet-active account</h3>
+            <div style="margin-top:0.5rem; font-size:0.85rem;">
+              Every agent without a per-agent <code>auth.override</code> will
+              switch to <code>${escapeHtml(label)}</code>. The broker fans
+              the credentials out immediately; agents pick them up on their
+              next turn (no manual restart needed post-RFC-H).
             </div>
             <div class="modal-actions">
               <button class="btn" onclick="closePromoteModal()">Cancel</button>
-              <button class="btn btn-restart" onclick="confirmPromote('${escapeHtml(label)}')">Promote</button>
+              <button class="btn btn-restart" onclick="confirmPromote('${escapeHtml(label)}')">Make fleet-active</button>
             </div>
           </div>
         </div>`;
@@ -765,37 +730,28 @@
     }
 
     async function confirmPromote(label) {
-      const sel = document.getElementById('promote-agent');
-      if (!sel) return;
-      const agent = sel.value;
       closePromoteModal();
       try {
-        const res = await fetch(`${API}/api/accounts/${encodeURIComponent(label)}/promote`, {
+        // RFC-H endpoint. Body carries the label (avoids URL-encoding
+        // past the account-label charset). Response: { ok, active, fanned }.
+        const res = await fetch(`${API}/api/auth/use`, {
           method: 'POST',
           headers: { ...authHeaders(), 'Content-Type': 'application/json' },
-          body: JSON.stringify({ agent }),
+          body: JSON.stringify({ account: label }),
         });
         const data = await res.json();
         if (!res.ok || !data.ok) {
-          showToast(`Promote failed: ${data.error || `HTTP ${res.status}`}`, false);
+          showToast(`Set fleet-active failed: ${data.error || `HTTP ${res.status}`}`, false);
           return;
         }
-        const promoted = data.promoted || [];
-        const already = data.alreadyPrimary || [];
-        const fanFails = data.fanFails || [];
-        let msg;
-        if (promoted.length === 0 && already.length > 0) {
-          msg = `${label} already primary on: ${already.join(', ')}`;
-        } else {
-          msg = `${label} promoted on: ${promoted.join(', ')}. Restart needed.`;
-        }
-        if (fanFails.length > 0) {
-          msg += ` Fanout failed for: ${fanFails.map(f => f.agent).join(', ')}.`;
-        }
-        showToast(msg, fanFails.length === 0);
+        const fanned = data.fanned || [];
+        const msg = fanned.length > 0
+          ? `Fleet-active is now ${data.active}. Broker fanned to: ${fanned.join(', ')}.`
+          : `Fleet-active is now ${data.active}.`;
+        showToast(msg, true);
         fetchAccounts();
       } catch (err) {
-        showToast(`Promote failed: ${err.message}`, false);
+        showToast(`Set fleet-active failed: ${err.message}`, false);
       }
     }
 

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -6,6 +6,7 @@ vi.mock("../src/agents/lifecycle.js", () => ({
   startAgent: vi.fn(),
   stopAgent: vi.fn(),
   restartAgent: vi.fn(),
+  containerName: (name: string) => `switchroom-${name}`,
 }));
 
 // Mock auth module
@@ -22,6 +23,7 @@ vi.mock("../src/config/loader.js", () => ({
 vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
   execFileSync: vi.fn(),
+  spawnSync: vi.fn(),
   spawn: vi.fn(),
 }));
 
@@ -36,7 +38,7 @@ import {
 import { isOriginAllowed, isTailscaleIdentified } from "../src/web/server.js";
 import { getAllAgentStatuses, startAgent, stopAgent, restartAgent } from "../src/agents/lifecycle.js";
 import { getAllAuthStatuses } from "../src/auth/manager.js";
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import type { SwitchroomConfig } from "../src/config/schema.js";
 
 // Bun's vitest compat layer doesn't implement vi.mocked(). Use a
@@ -204,38 +206,56 @@ describe("handleGetLogs", () => {
     vi.clearAllMocks();
   });
 
-  it("returns logs from journalctl", () => {
-    asMock(execFileSync).mockReturnValue("line 1\nline 2\nline 3\n" as any);
+  it("returns merged container stdout+stderr from docker logs", () => {
+    asMock(spawnSync).mockReturnValue({
+      status: 0,
+      stdout: "line 1\nline 2\n",
+      stderr: "boot warn\n",
+    } as any);
 
     const result = handleGetLogs("coach", 50);
     expect(result.ok).toBe(true);
     expect(result.logs).toContain("line 1");
-    expect(execFileSync).toHaveBeenCalledWith(
-      "journalctl",
-      ["--user", "-u", "switchroom-coach", "--no-pager", "-n", "50"],
+    // docker logs splits container stdout/stderr; both are surfaced.
+    expect(result.logs).toContain("boot warn");
+    expect(spawnSync).toHaveBeenCalledWith(
+      "docker",
+      ["logs", "--tail", "50", "switchroom-coach"],
       expect.objectContaining({ encoding: "utf-8" })
     );
   });
 
   it("uses default of 50 lines", () => {
-    asMock(execFileSync).mockReturnValue("output" as any);
+    asMock(spawnSync).mockReturnValue({ status: 0, stdout: "output", stderr: "" } as any);
 
     handleGetLogs("sage");
-    expect(execFileSync).toHaveBeenCalledWith(
-      "journalctl",
-      ["--user", "-u", "switchroom-sage", "--no-pager", "-n", "50"],
+    expect(spawnSync).toHaveBeenCalledWith(
+      "docker",
+      ["logs", "--tail", "50", "switchroom-sage"],
       expect.any(Object)
     );
   });
 
-  it("returns error when journalctl fails", () => {
-    asMock(execFileSync).mockImplementation(() => {
-      throw new Error("no journal data");
-    });
+  it("returns error when docker logs exits non-zero (no such container)", () => {
+    asMock(spawnSync).mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "Error: No such container: switchroom-missing\n",
+    } as any);
 
     const result = handleGetLogs("missing", 10);
     expect(result.ok).toBe(false);
-    expect(result.error).toContain("no journal data");
+    expect(result.error).toContain("No such container");
+  });
+
+  it("returns error when docker binary is unavailable", () => {
+    asMock(spawnSync).mockReturnValue({
+      error: new Error("spawn docker ENOENT"),
+    } as any);
+
+    const result = handleGetLogs("coach", 10);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("ENOENT");
   });
 });
 


### PR DESCRIPTION
## Summary

Two dashboard regressions that were never tracked through the v0.7 Docker migration and the RFC-H auth-broker rework.

**1. Logs were completely dead.** `handleGetLogs` (api.ts) and the WebSocket log streamer (server.ts) both shelled `journalctl --user -u switchroom-<name>`. Agents have been Docker containers since v0.7 — no systemd user unit exists, so every log view + the live tail errored. Both now use `docker logs` (`--tail` one-shot, `-f` stream), merging container stdout+stderr since a container can log to either. Exported the canonical `containerName()` from `lifecycle.ts` so the name shape isn't re-hardcoded.

**2. Accounts panel + promote flow ran on the pre-RFC-H contract.** The UI read `primaryFor`/`fallbackFor` and `quota.fiveHourPct` — fields the RFC-H `handleGetAccounts` no longer returns — so "Used by" always showed `unused` and every quota column showed `—`. The "Make primary" modal POSTed to the deleted `/api/accounts/:label/promote` with a stale response shape. Rebuilt: the panel now renders `usedBy` + broker `AccountState` (exhausted / exhausted_until / threshold_violations / last_refreshed_at), and the action is a fleet-wide "Make fleet-active" on `POST /api/auth/use` (`{ok, active, fanned}`).

This is P0 of a phased dashboard refresh (P1: broker/hindsight/hostd health; P2: Google Workspace + Drive + scheduler panels).

## Test plan

- [ ] `npm run lint` — tsc clean
- [ ] `npx vitest run tests/web.test.ts src/web/` — 76 pass (log tests re-pinned to the docker-logs contract)
- [ ] Manual: dashboard logs render for a running agent; "Make fleet-active" sets `auth.active` via the broker

🤖 Generated with [Claude Code](https://claude.com/claude-code)