### PR TITLE
fix(drive-mcp): gdrive must land in .mcp.json, not just settings.json

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2186,6 +2186,17 @@ export function scaffoldAgent(
       }
     }
 
+    // Per-agent conditional `gdrive` MCP. THIS .mcp.json (not
+    // settings.json.mcpServers) is the surface Claude Code actually
+    // loads for switchroom-telegram-plugin agents — see the block
+    // comment at the top of this branch. Same shared broker-ACL gate.
+    if (switchroomConfig) {
+      const gdrive = resolveGdriveMcpEntry(name, agentConfig, switchroomConfig);
+      if (gdrive) {
+        mcpServers[gdrive.key] = gdrive.value;
+      }
+    }
+
     // .mcp.json is purely template-driven. writeIfChanged so a stale
     // file from a pre-v0.7.6 release (different plugin path resolution)
     // is rewritten on the next `switchroom apply`.
@@ -3950,6 +3961,19 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
       const hindsightEntry = getHindsightSettingsEntry(name, switchroomConfig);
       if (hindsightEntry) {
         mcpServers[hindsightEntry.key] = hindsightEntry.value;
+      }
+    }
+
+    // Per-agent conditional `gdrive` MCP. THIS .mcp.json (not
+    // settings.json.mcpServers) is the surface Claude Code actually
+    // loads for switchroom-telegram-plugin agents. mcpServers is rebuilt
+    // fresh from the hardcoded set each reconcile, so a retracted gdrive
+    // simply isn't re-added (no explicit delete needed). Same shared
+    // broker-ACL gate as scaffoldAgent / settings paths.
+    {
+      const gdrive = resolveGdriveMcpEntry(name, agentConfig, switchroomConfig);
+      if (gdrive) {
+        mcpServers[gdrive.key] = gdrive.value;
       }
     }
 

--- a/tests/scaffold.regenerate-mcp-json.test.ts
+++ b/tests/scaffold.regenerate-mcp-json.test.ts
@@ -106,3 +106,79 @@ describe("scaffoldAgent: .mcp.json content-aware regeneration (#883)", () => {
     expect(second.skipped).toContain(mcpPath);
   });
 });
+
+// Regression: the per-agent `gdrive` MCP must land in the written
+// .mcp.json — the file Claude Code actually loads for
+// switchroom-telegram-plugin agents — NOT only in
+// settings.json.mcpServers. PR #1355 wired it solely into the settings
+// path, so `resolveGdriveMcpEntry` returned the entry and unit tests
+// passed, yet the agent never saw a Drive tool (verified empirically:
+// carrie's in-container .mcp.json had no `gdrive`). These tests assert
+// the actual .mcp.json output, which is what was missing.
+describe("scaffoldAgent: gdrive lands in .mcp.json (not just settings)", () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-gdrive-mcpjson-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function cfg(
+    name: string,
+    agentConfig: AgentConfig,
+    googleAccounts?: Record<string, { enabled_for?: string[] }>,
+  ): SwitchroomConfig {
+    return {
+      ...makeSwitchroomConfig(name, agentConfig),
+      ...(googleAccounts ? { google_accounts: googleAccounts } : {}),
+    } as SwitchroomConfig;
+  }
+
+  it("broker-authorized agent → .mcp.json contains the gdrive entry", () => {
+    const name = "carrie";
+    const agentConfig = makeAgentConfig({
+      google_workspace: { account: "pixsoul@gmail.com" },
+    } as Partial<AgentConfig>);
+    const sc = cfg(name, agentConfig, {
+      "pixsoul@gmail.com": { enabled_for: ["carrie"] },
+    });
+
+    const res = scaffoldAgent(name, agentConfig, tmpDir, telegramConfig, sc);
+    const mcp = JSON.parse(
+      readFileSync(join(res.agentDir, ".mcp.json"), "utf-8"),
+    );
+    expect(Object.keys(mcp.mcpServers)).toContain("gdrive");
+    expect(mcp.mcpServers.gdrive.command).toBeTruthy();
+  });
+
+  it("agent NOT in enabled_for → .mcp.json has NO gdrive entry", () => {
+    const name = "carrie";
+    const agentConfig = makeAgentConfig({
+      google_workspace: { account: "pixsoul@gmail.com" },
+    } as Partial<AgentConfig>);
+    const sc = cfg(name, agentConfig, {
+      "pixsoul@gmail.com": { enabled_for: ["someone-else"] },
+    });
+
+    const res = scaffoldAgent(name, agentConfig, tmpDir, telegramConfig, sc);
+    const mcp = JSON.parse(
+      readFileSync(join(res.agentDir, ".mcp.json"), "utf-8"),
+    );
+    expect(Object.keys(mcp.mcpServers)).not.toContain("gdrive");
+  });
+
+  it("no google_workspace.account → .mcp.json has NO gdrive entry", () => {
+    const name = "carrie";
+    const agentConfig = makeAgentConfig();
+    const sc = cfg(name, agentConfig, {
+      "pixsoul@gmail.com": { enabled_for: ["carrie"] },
+    });
+
+    const res = scaffoldAgent(name, agentConfig, tmpDir, telegramConfig, sc);
+    const mcp = JSON.parse(
+      readFileSync(join(res.agentDir, ".mcp.json"), "utf-8"),
+    );
+    expect(Object.keys(mcp.mcpServers)).not.toContain("gdrive");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up bugfix to #1355. The per-agent `gdrive` MCP entry was wired **only** into `settings.json.mcpServers`. But switchroom-telegram-plugin agents load MCP servers from the project-level **`.mcp.json`** — *not* `settings.json.mcpServers` (stated explicitly in the scaffold.ts block comment). So `resolveGdriveMcpEntry` returned the entry, all #1355 unit tests passed, yet **no agent ever got a Drive tool**.

**Verified empirically:** after #1355 merged + deployed + `switchroom update`, `carrie`'s in-container `.mcp.json` = `{switchroom-telegram, agent-config, hostd, hindsight}` (no gdrive), while her `settings.json.mcpServers` *did* contain `gdrive`. Claude Code loads the former.

## Fix
Inject `resolveGdriveMcpEntry` into **both `.mcp.json` builders** — the `scaffoldAgent` path and the `reconcileAgent` path — using the same shared broker-ACL gate. The reconcile builder rebuilds `mcpServers` fresh from the hardcoded set every run, so a retracted entry is naturally not re-added (no stale persistence). The settings.json wiring is left as-is (out of scope; harmless).

## The missing assertion (root cause of why #1355 shipped broken)
#1355's tests only asserted the pure `resolveGdriveMcpEntry` return value, never that the entry reaches the written `.mcp.json`. This PR adds 3 regression tests that scaffold a real agent and assert the **written `.mcp.json`** contains `gdrive` (broker-authorized) or correctly omits it (not in `enabled_for[]`; no `google_workspace.account`).

## Test plan
- [x] `npm run lint` clean
- [x] 13 targeted tests pass incl. the 3 new `.mcp.json`-output regression tests
- [x] The broader sweep "failures" were unbuilt-`dist/` artifacts (CLI/boot/bundled tests needing a build) — 60/60 pass post-`bun run build`; unrelated to this change
- [ ] CI required checks
- [ ] Post-merge: deploy, `switchroom update`, **verify carrie's in-container `.mcp.json` now contains `gdrive`** (the empirical proof), then the long-sought end-to-end (Carrie creates a doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)