### PR TITLE
feat(web): surface auth-broker / hindsight / hostd health (P1)

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import {
@@ -10,6 +11,15 @@ import {
 } from "../agents/lifecycle.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
 import { getCollectionForAgent } from "../memory/hindsight.js";
+import {
+  getHindsightStatus,
+  isHindsightRunning,
+} from "../setup/hindsight.js";
+import {
+  defaultAuditLogPath,
+  readAndFilter,
+  type AuditEntry,
+} from "../host-control/audit-reader.js";
 import { captureEvent, captureException } from "../analytics/posthog.js";
 import { resolveAgentsDir } from "../config/loader.js";
 import { resolveAgentConfig } from "../config/merge.js";
@@ -303,4 +313,138 @@ export function handleGetAgentConfig(
 ): AgentConfig {
   const agent = config.agents[agentName];
   return resolveAgentConfig(config.defaults, config.profiles, agent);
+}
+
+/**
+ * Fleet infrastructure health — the three singletons the dashboard
+ * never surfaced (auth-broker, hindsight, hostd). All reads are
+ * best-effort and degrade independently: a broker timeout doesn't
+ * blank the hindsight panel and vice versa. This is observability,
+ * not control — no mutating ops live here.
+ */
+export interface SystemHealth {
+  broker: {
+    reachable: boolean;
+    active?: string;
+    accounts?: number;
+    agents?: number;
+    consumers?: number;
+    error?: string;
+  };
+  hindsight: {
+    /** Raw `docker ps` Status string, or null when the container is absent. */
+    containerStatus: string | null;
+    running: boolean;
+    /** Live values read from the running container's env (truth, not the
+     *  compile-time default) — null when the container isn't inspectable. */
+    model: string | null;
+    provider: string | null;
+    mcpStateless: boolean | null;
+  };
+  hostd: {
+    auditLogPresent: boolean;
+    /** Most-recent privileged-verb audit rows (newest last), capped. */
+    recent: AuditEntry[];
+    error?: string;
+  };
+}
+
+/**
+ * Pull a single env var out of `docker inspect`'s Config.Env array for
+ * a container. Returns null when the container is absent or the var
+ * isn't set — the caller renders that as "unknown" rather than guessing
+ * from the compile-time default (the running container is the truth).
+ */
+function inspectEnv(
+  container: string,
+  keys: readonly string[],
+): Record<string, string | null> {
+  const out: Record<string, string | null> = {};
+  for (const k of keys) out[k] = null;
+  const res = spawnSync(
+    "docker",
+    ["inspect", "--format", "{{json .Config.Env}}", container],
+    { encoding: "utf-8", timeout: 4000 },
+  );
+  if (res.error || res.status !== 0 || !res.stdout) return out;
+  try {
+    const env = JSON.parse(res.stdout.trim()) as string[];
+    for (const pair of env) {
+      const eq = pair.indexOf("=");
+      if (eq < 0) continue;
+      const name = pair.slice(0, eq);
+      if (name in out) out[name] = pair.slice(eq + 1);
+    }
+  } catch {
+    /* malformed inspect output — leave nulls */
+  }
+  return out;
+}
+
+export async function handleGetSystemHealth(
+  home?: string,
+): Promise<SystemHealth> {
+  // ── auth-broker ──────────────────────────────────────────────────
+  const broker: SystemHealth["broker"] = { reachable: false };
+  try {
+    await withAuthBrokerClient(async (client) => {
+      const state = await client.listState();
+      broker.reachable = true;
+      broker.active = state.active;
+      broker.accounts = state.accounts.length;
+      broker.agents = state.agents.length;
+      broker.consumers = state.consumers.length;
+    });
+  } catch (err) {
+    broker.reachable = false;
+    if (err instanceof AuthBrokerUnreachableError) {
+      broker.error = err.message;
+    } else if (err instanceof AuthBrokerError) {
+      broker.error = `${err.code}: ${err.message}`;
+    } else {
+      broker.error = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  // ── hindsight ────────────────────────────────────────────────────
+  const containerStatus = getHindsightStatus();
+  const running = isHindsightRunning();
+  const env = running
+    ? inspectEnv("switchroom-hindsight", [
+        "HINDSIGHT_API_LLM_MODEL",
+        "HINDSIGHT_API_LLM_PROVIDER",
+        "HINDSIGHT_API_MCP_STATELESS",
+      ])
+    : {
+        HINDSIGHT_API_LLM_MODEL: null,
+        HINDSIGHT_API_LLM_PROVIDER: null,
+        HINDSIGHT_API_MCP_STATELESS: null,
+      };
+  const statelessRaw = env.HINDSIGHT_API_MCP_STATELESS;
+  const hindsight: SystemHealth["hindsight"] = {
+    containerStatus,
+    running,
+    model: env.HINDSIGHT_API_LLM_MODEL,
+    provider: env.HINDSIGHT_API_LLM_PROVIDER,
+    mcpStateless:
+      statelessRaw == null ? null : statelessRaw.toLowerCase() === "true",
+  };
+
+  // ── hostd ────────────────────────────────────────────────────────
+  const hostd: SystemHealth["hostd"] = {
+    auditLogPresent: false,
+    recent: [],
+  };
+  try {
+    const logPath = defaultAuditLogPath(home);
+    if (existsSync(logPath)) {
+      hostd.auditLogPresent = true;
+      const raw = readFileSync(logPath, "utf-8");
+      hostd.recent = readAndFilter(raw, {}, 10);
+    }
+  } catch (err) {
+    hostd.error = err instanceof Error ? err.message : String(err);
+  }
+
+  return { broker, hindsight, hostd };
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -27,6 +27,7 @@ import {
   handleGetAgentAccounts,
   handleGetAgentConfig,
   handleUseAccount,
+  handleGetSystemHealth,
 } from "./api.js";
 import { handleWebhookIngest } from "./webhook-handler.js";
 
@@ -332,6 +333,11 @@ function parseRoute(
     return { handler: "getSubagents", params: { name: subagentsMatch[1] } };
   }
 
+  // GET /api/system-health
+  if (method === "GET" && pathname === "/api/system-health") {
+    return { handler: "getSystemHealth", params: {} };
+  }
+
   // GET /api/accounts
   if (method === "GET" && pathname === "/api/accounts") {
     return { handler: "getAccounts", params: {} };
@@ -509,6 +515,9 @@ export function startWebServer(
             }
             return jsonResponse(result.subagents);
           }
+
+          case "getSystemHealth":
+            return (async () => jsonResponse(await handleGetSystemHealth()))();
 
           case "getAccounts":
             return (async () => jsonResponse(await handleGetAccounts(config)))();

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -407,11 +407,13 @@
   <nav class="tabs">
     <button id="tab-agents" class="active" onclick="switchTab('agents')">Agents</button>
     <button id="tab-accounts" onclick="switchTab('accounts')">Accounts</button>
+    <button id="tab-system" onclick="switchTab('system')">System</button>
   </nav>
   <main>
     <div id="error"></div>
     <div id="agents" class="loading">Loading agents...</div>
     <div id="accounts" style="display:none"></div>
+    <div id="system" style="display:none"></div>
   </main>
 
   <script>
@@ -472,12 +474,25 @@
       }
     }
 
+    async function fetchSystemHealth() {
+      try {
+        const res = await fetch(`${API}/api/system-health`, { headers: authHeaders() });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        renderSystemHealth(await res.json());
+        clearError();
+      } catch (err) {
+        showError(`Failed to fetch system health: ${err.message}`);
+      }
+    }
+
     function switchTab(tab) {
-      document.getElementById('tab-agents').classList.toggle('active', tab === 'agents');
-      document.getElementById('tab-accounts').classList.toggle('active', tab === 'accounts');
-      document.getElementById('agents').style.display = tab === 'agents' ? '' : 'none';
-      document.getElementById('accounts').style.display = tab === 'accounts' ? '' : 'none';
+      const tabs = ['agents', 'accounts', 'system'];
+      for (const t of tabs) {
+        document.getElementById(`tab-${t}`).classList.toggle('active', tab === t);
+        document.getElementById(t).style.display = tab === t ? '' : 'none';
+      }
       if (tab === 'accounts') fetchAccounts();
+      if (tab === 'system') fetchSystemHealth();
     }
 
     function showError(msg) {
@@ -698,6 +713,76 @@
         ? usedBy.map(escapeHtml).join(', ')
         : `${usedBy.slice(0, MAX_INLINE).map(escapeHtml).join(', ')} +${usedBy.length - MAX_INLINE}`;
       return `<span class="usage-pill primary" title="${escapeHtml(title)}">${shown}</span>`;
+    }
+
+    function renderSystemHealth(h) {
+      const container = document.getElementById('system');
+      const b = h.broker || {};
+      const hs = h.hindsight || {};
+      const hd = h.hostd || {};
+
+      const dot = (ok) => `<span class="status-dot ${ok ? 'active' : 'inactive'}" style="display:inline-block;vertical-align:middle"></span>`;
+      const dim = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
+
+      const brokerBody = b.reachable
+        ? `<div class="card-meta" style="padding:0">
+             <div class="meta-item"><label>Fleet-active </label><span>${escapeHtml(b.active || '—')}</span></div>
+             <div class="meta-item"><label>Accounts </label><span>${b.accounts ?? '—'}</span></div>
+             <div class="meta-item"><label>Agents </label><span>${b.agents ?? '—'}</span></div>
+             <div class="meta-item"><label>Consumers </label><span>${b.consumers ?? '—'}</span></div>
+           </div>`
+        : `<div style="color:var(--red)">unreachable${b.error ? ' — ' + escapeHtml(b.error) : ''}</div>`;
+
+      const statelessCell = hs.mcpStateless == null
+        ? dim('unknown')
+        : hs.mcpStateless ? 'stateless' : '<span style="color:var(--yellow)">stateful</span>';
+      const hindsightBody = `
+        <div class="card-meta" style="padding:0">
+          <div class="meta-item"><label>Container </label><span>${hs.containerStatus ? escapeHtml(hs.containerStatus) : dim('absent')}</span></div>
+          <div class="meta-item"><label>Model </label><span>${hs.model ? escapeHtml(hs.model) : dim('unknown')}</span></div>
+          <div class="meta-item"><label>Provider </label><span>${hs.provider ? escapeHtml(hs.provider) : dim('unknown')}</span></div>
+          <div class="meta-item"><label>MCP </label><span>${statelessCell}</span></div>
+        </div>`;
+
+      let hostdBody;
+      if (!hd.auditLogPresent) {
+        hostdBody = dim(hd.error ? `audit log error: ${hd.error}` : 'no audit log yet (hostd has handled no privileged verbs)');
+      } else if (!hd.recent || hd.recent.length === 0) {
+        hostdBody = dim('audit log present, no entries');
+      } else {
+        const rows = hd.recent.slice().reverse().map(e => {
+          const caller = e.caller && e.caller.kind === 'agent' ? escapeHtml(e.caller.name) : 'operator';
+          const ok = e.result === 'ok' || e.exit_code === 0;
+          return `<tr>
+            <td>${dot(ok)} ${escapeHtml(e.op || '?')}</td>
+            <td>${caller}</td>
+            <td>${escapeHtml(e.result || '?')}${e.exit_code != null ? ` (${e.exit_code})` : ''}</td>
+            <td>${escapeHtml(shortTs(e.ts))}</td>
+          </tr>`;
+        }).join('');
+        hostdBody = `<table class="accounts-table" style="margin-top:0.5rem">
+          <thead><tr><th>Verb</th><th>Caller</th><th>Result</th><th>When</th></tr></thead>
+          <tbody>${rows}</tbody></table>`;
+      }
+
+      container.innerHTML = `
+        <div class="agents-grid">
+          <div class="agent-card"><div class="card-header" style="cursor:default">
+            ${dot(b.reachable)}<span class="agent-name">auth-broker</span></div>
+            <div style="padding:0 1.25rem 1rem">${brokerBody}</div></div>
+          <div class="agent-card"><div class="card-header" style="cursor:default">
+            ${dot(hs.running)}<span class="agent-name">hindsight</span></div>
+            <div style="padding:0 1.25rem 1rem">${hindsightBody}</div></div>
+        </div>
+        <div class="agent-card" style="margin-top:1rem"><div class="card-header" style="cursor:default">
+          ${dot(hd.auditLogPresent)}<span class="agent-name">hostd — recent privileged verbs</span></div>
+          <div style="padding:0 1.25rem 1rem">${hostdBody}</div></div>`;
+    }
+
+    function shortTs(ts) {
+      if (!ts) return '—';
+      // 2026-05-15T04:15:13.465Z → 2026-05-15 04:15:13
+      return String(ts).replace('T', ' ').replace(/\.\d+Z?$/, '').replace(/Z$/, '');
     }
 
     function openPromoteModal(label) {

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock lifecycle module
 vi.mock("../src/agents/lifecycle.js", () => ({
@@ -27,18 +27,59 @@ vi.mock("node:child_process", () => ({
   spawn: vi.fn(),
 }));
 
+// Auth-broker client — used by the accounts handlers and the new
+// system-health handler. vi.mock is hoisted above all top-level decls,
+// so the shared state + error classes must live inside vi.hoisted().
+const brokerHoist = vi.hoisted(() => {
+  class FakeUnreachable extends Error {}
+  class FakeBrokerError extends Error {
+    code: string;
+    constructor(code: string, msg: string) {
+      super(msg);
+      this.code = code;
+    }
+  }
+  return {
+    FakeUnreachable,
+    FakeBrokerError,
+    impl: { run: null as null | ((client: unknown) => Promise<unknown>) },
+  };
+});
+const brokerImpl = brokerHoist.impl;
+vi.mock("../src/auth/broker/client.js", () => ({
+  AuthBrokerUnreachableError: brokerHoist.FakeUnreachable,
+  AuthBrokerError: brokerHoist.FakeBrokerError,
+  withAuthBrokerClient: vi.fn(async (fn: (c: unknown) => Promise<unknown>) => {
+    if (!brokerHoist.impl.run) {
+      throw new brokerHoist.FakeUnreachable("broker down");
+    }
+    return brokerHoist.impl.run(fn);
+  }),
+}));
+
+// Hindsight container probes.
+vi.mock("../src/setup/hindsight.js", () => ({
+  getHindsightStatus: vi.fn(() => null),
+  isHindsightRunning: vi.fn(() => false),
+}));
+
 import {
   handleGetAgents,
   handleStartAgent,
   handleStopAgent,
   handleRestartAgent,
   handleGetLogs,
+  handleGetSystemHealth,
   type AgentInfo,
 } from "../src/web/api.js";
 import { isOriginAllowed, isTailscaleIdentified } from "../src/web/server.js";
 import { getAllAgentStatuses, startAgent, stopAgent, restartAgent } from "../src/agents/lifecycle.js";
 import { getAllAuthStatuses } from "../src/auth/manager.js";
+import { getHindsightStatus, isHindsightRunning } from "../src/setup/hindsight.js";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { SwitchroomConfig } from "../src/config/schema.js";
 
 // Bun's vitest compat layer doesn't implement vi.mocked(). Use a
@@ -383,5 +424,113 @@ describe("isTailscaleIdentified", () => {
     const req = makeTsRequest();
     const server = makeServerStub(null);
     expect(isTailscaleIdentified(req, server)).toBe(false);
+  });
+});
+
+describe("handleGetSystemHealth", () => {
+  let home: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    brokerImpl.run = null;
+    asMock(getHindsightStatus).mockReturnValue(null);
+    asMock(isHindsightRunning).mockReturnValue(false);
+    home = mkdtempSync(join(tmpdir(), "syshealth-"));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("reports broker reachable with fleet snapshot", async () => {
+    brokerImpl.run = async (fn) =>
+      (fn as (c: unknown) => Promise<unknown>)({
+        listState: async () => ({
+          active: "ken@example.com",
+          fallback_order: [],
+          accounts: [{ label: "a" }, { label: "b" }],
+          agents: [{ name: "x" }],
+          consumers: [{ name: "hindsight" }],
+        }),
+      });
+
+    const h = await handleGetSystemHealth(home);
+    expect(h.broker.reachable).toBe(true);
+    expect(h.broker.active).toBe("ken@example.com");
+    expect(h.broker.accounts).toBe(2);
+    expect(h.broker.agents).toBe(1);
+    expect(h.broker.consumers).toBe(1);
+  });
+
+  it("reports broker unreachable without throwing", async () => {
+    brokerImpl.run = null; // withAuthBrokerClient throws FakeUnreachable
+    const h = await handleGetSystemHealth(home);
+    expect(h.broker.reachable).toBe(false);
+    expect(h.broker.error).toContain("broker down");
+  });
+
+  it("reads live hindsight env from docker inspect when running", async () => {
+    asMock(getHindsightStatus).mockReturnValue("Up 3 hours");
+    asMock(isHindsightRunning).mockReturnValue(true);
+    asMock(spawnSync).mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify([
+        "PATH=/usr/bin",
+        "HINDSIGHT_API_LLM_MODEL=claude-sonnet-4-6",
+        "HINDSIGHT_API_LLM_PROVIDER=claude-code",
+        "HINDSIGHT_API_MCP_STATELESS=true",
+      ]),
+      stderr: "",
+    } as never);
+
+    const h = await handleGetSystemHealth(home);
+    expect(h.hindsight.running).toBe(true);
+    expect(h.hindsight.containerStatus).toBe("Up 3 hours");
+    expect(h.hindsight.model).toBe("claude-sonnet-4-6");
+    expect(h.hindsight.provider).toBe("claude-code");
+    expect(h.hindsight.mcpStateless).toBe(true);
+  });
+
+  it("leaves hindsight env null when the container is absent", async () => {
+    asMock(getHindsightStatus).mockReturnValue(null);
+    asMock(isHindsightRunning).mockReturnValue(false);
+    const h = await handleGetSystemHealth(home);
+    expect(h.hindsight.running).toBe(false);
+    expect(h.hindsight.model).toBeNull();
+    expect(h.hindsight.mcpStateless).toBeNull();
+    // docker inspect must NOT be probed when the container isn't running.
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it("parses the hostd audit log when present (newest entries, capped)", async () => {
+    mkdirSync(join(home, ".switchroom"), { recursive: true });
+    const line = (op: string, code: number) =>
+      JSON.stringify({
+        ts: "2026-05-16T10:00:00.000Z",
+        op,
+        caller: { kind: "agent", name: "carrie" },
+        request_id: "r",
+        result: code === 0 ? "ok" : "error",
+        exit_code: code,
+        duration_ms: 12,
+      });
+    writeFileSync(
+      join(home, ".switchroom", "host-control-audit.log"),
+      [line("restart", 0), line("update-apply", 1)].join("\n") + "\n",
+    );
+
+    const h = await handleGetSystemHealth(home);
+    expect(h.hostd.auditLogPresent).toBe(true);
+    expect(h.hostd.recent).toHaveLength(2);
+    expect(h.hostd.recent.map((e) => e.op)).toEqual([
+      "restart",
+      "update-apply",
+    ]);
+  });
+
+  it("reports hostd audit absent on a fresh install (no crash)", async () => {
+    const h = await handleGetSystemHealth(home);
+    expect(h.hostd.auditLogPresent).toBe(false);
+    expect(h.hostd.recent).toEqual([]);
   });
 });

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -469,6 +469,15 @@ describe("handleGetSystemHealth", () => {
     expect(h.broker.error).toContain("broker down");
   });
 
+  it("formats an AuthBrokerError as `code: message` (reachable but protocol error)", async () => {
+    brokerImpl.run = async () => {
+      throw new brokerHoist.FakeBrokerError("EPROTO", "bad frame");
+    };
+    const h = await handleGetSystemHealth(home);
+    expect(h.broker.reachable).toBe(false);
+    expect(h.broker.error).toBe("EPROTO: bad frame");
+  });
+
   it("reads live hindsight env from docker inspect when running", async () => {
     asMock(getHindsightStatus).mockReturnValue("Up 3 hours");
     asMock(isHindsightRunning).mockReturnValue(true);


### PR DESCRIPTION
## Summary

The dashboard never showed the three singletons everything depends on. Adds `GET /api/system-health` and a **System** tab.

- **auth-broker** — reachability + fleet-active label + account/agent/consumer counts (`withAuthBrokerClient` + `listState`). Explicit "unreachable" on timeout, not a blank panel.
- **hindsight** — container status + **live** model / provider / MCP-stateless read from the running container's env via `docker inspect` (the truth, so an operator override is visible), with "unknown" fallback when not inspectable.
- **hostd** — presence + last 10 privileged-verb audit rows (`defaultAuditLogPath` + `readAndFilter`). Fresh-install "no audit log yet" rendered as info, not error.

All three reads are independent + best-effort. Observability only — no mutating ops.

## Phasing

P0 (#1357, merged) fixed the Docker/RFC-H regressions. This is P1. P2 will add Google Workspace + Drive write-preview + scheduler panels. The P0 reviewer's non-blocking nit (add `handleGetAccounts`/`handleUseAccount` shape tests) rides with P2 since it touches the same account surface — called out for tracking, not dropped.

## Test plan

- [ ] `npm run lint` — tsc clean
- [ ] `npx vitest run tests/web.test.ts src/web/` — 82 pass (6 new: broker up/down, live hindsight env, absent-container skips `docker inspect`, hostd audit parse + fresh-install)
- [ ] Manual: System tab shows broker counts, hindsight model/stateless, recent hostd verbs on the live host

🤖 Generated with [Claude Code](https://claude.com/claude-code)