### PR TITLE
fix(docker): install uv/uvx in agent image (Drive MCP launcher dep)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -37,6 +37,23 @@ RUN mkdir -p /tmp/tmux-shared
 
 # ─── Rare-changed install layers (FIRST, so dist/ churn doesn't bust them) ───
 #
+# uv / uvx — required by the Google Workspace MCP launcher
+# (`switchroom drive-mcp-launcher`, RFC G). The launcher execs
+# `uvx --from git+https://github.com/taylorwilsdon/google_workspace_mcp.git@<SHA>
+# google-workspace-mcp --single-user`; without `uvx` on PATH the
+# launcher fails fast with exit 127 ("Executable not found in $PATH:
+# uvx") and the agent gets no Drive tools. Same pre-bake rationale as
+# playwright below: bake it into the image, version-pinned, instead of
+# an on-demand per-agent install.
+#
+# astral's officially-recommended Docker install: copy the static
+# `uv`/`uvx` binaries from the published image. No network install
+# script, fully reproducible. Pin the uv version deliberately (bump in
+# lockstep with re-testing the Drive MCP launcher) — mirrors how the
+# google_workspace_mcp commit SHA is pinned in
+# src/memory/scaffold-integration.ts.
+COPY --from=ghcr.io/astral-sh/uv:0.7.13 /uv /uvx /usr/local/bin/
+
 # Playwright — pre-baked for skills that use browser automation
 # (calendar / scrape / UI-test). Pre-this-bake, agents called
 # `npx playwright` which triggered an on-demand download of the


### PR DESCRIPTION
## Summary

**Root cause of agent Drive not working**, found by running `switchroom drive-mcp-launcher` inside carrie's live container: the launcher succeeds at every step — auth-broker fetch, `client_secret` resolution, seed-file write — then fails at the final exec:

```
drive-mcp-launcher: failed to exec uvx: Executable not found in $PATH: "uvx".
Is `uv` installed in the agent image?   (exit 127)
```

The agent image (`switchroom/base` → `node:22-bookworm-slim`) ships `python3` but **not `uv`**. The launcher (RFC G) execs `uvx --from git+...google_workspace_mcp@<SHA> google-workspace-mcp --single-user` to run the upstream MCP. No `uvx` → no Drive tools for *any* agent. This was a flagged-but-unverified plan risk; now confirmed empirically — every other piece of the chain (launcher logic, broker write-scoped token, scaffold `.mcp.json` wiring) is verified working.

## Fix
Pre-bake `uv`/`uvx` into `docker/Dockerfile.agent` via astral's officially-recommended Docker method — `COPY --from=ghcr.io/astral-sh/uv:0.7.13 /uv /uvx /usr/local/bin/` (static binaries, no network install script, fully reproducible). Version-pinned deliberately (mirrors the pinned `google_workspace_mcp` SHA). Placed in the rare-changed install layer, same rationale as the adjacent playwright pre-bake.

## Validation
- `ghcr.io/astral-sh/uv:0.7.13` manifest confirmed pullable.
- Standalone micro `docker build` proves the exact `COPY --from` line works and `uvx 0.7.13` / `uv 0.7.13` run.
- Dockerfile-only change — no TS/JS, lint N/A. **Full agent-image build is gated by CI `build-dependents (agent)`** (required check).
- [ ] Post-merge: `switchroom update` pulls the rebuilt agent image + recreates carrie; re-run the launcher in-container → `uvx` resolves → full end-to-end (Carrie creates a `/linkedin` doc, RFC E approval card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)