### PR TITLE
feat(kernel): read-only host operator socket (deny-by-default)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -947,9 +947,17 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   lines.push(`      - "FOWNER"`);
   lines.push(`      - "DAC_READ_SEARCH"`);
   lines.push(`      - "DAC_OVERRIDE"`);
-  if (switchroomConfigPath) {
+  if (switchroomConfigPath || opts.operatorUid !== undefined) {
     lines.push(`    environment:`);
-    lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);
+    if (switchroomConfigPath) {
+      lines.push(`      SWITCHROOM_CONFIG: /state/config/switchroom.yaml`);
+    }
+    // Enables the read-only host operator listener. Gated on the same
+    // operatorUid the auth-broker uses; absent ⇒ no operator socket,
+    // kernel behaviour unchanged.
+    if (opts.operatorUid !== undefined) {
+      lines.push(`      SWITCHROOM_KERNEL_OPERATOR_UID: "${opts.operatorUid}"`);
+    }
   }
   lines.push(`    volumes:`);
   for (const a of describeAgents(config)) {
@@ -957,6 +965,16 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   }
   if (switchroomConfigPath) {
     lines.push(`      - ${switchroomConfigPath}:/state/config/switchroom.yaml:ro`);
+  }
+  // Operator socket — host-mounted bind so host-side `approvalList`
+  // (e.g. the web dashboard) can read decision metadata. Mirrors the
+  // auth-broker operator bind; only emitted when operatorUid is set so
+  // a legacy install doesn't get a confusingly-empty dir. The kernel
+  // restricts this socket to the read-only approval_list op.
+  if (opts.operatorUid !== undefined) {
+    lines.push(
+      `      - ${homePrefix}/.switchroom/state/kernel-operator:/run/switchroom/kernel/operator`,
+    );
   }
   lines.push(`      - ${homePrefix}/.switchroom/approvals:/state/approvals`);
   lines.push(``);

--- a/src/vault/approvals/client.test.ts
+++ b/src/vault/approvals/client.test.ts
@@ -7,7 +7,14 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { resolveKernelSocketPath } from "./client.js";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  resolveKernelSocketPath,
+  resolveKernelOperatorSocket,
+  kernelOperatorSocketPath,
+} from "./client.js";
 
 describe("resolveKernelSocketPath (Phase 2b)", () => {
   let savedEnv: string | undefined;
@@ -62,5 +69,35 @@ describe("resolveKernelSocketPath (Phase 2b)", () => {
     expect(
       resolveKernelSocketPath({ kernelSocket: "/tmp/programmatic.sock" }),
     ).toBe("/run/switchroom/kernel/alice/sock");
+  });
+
+  it("host fallback resolver stays OUT of the pure resolver", () => {
+    // Even if the operator socket exists, resolveKernelSocketPath must
+    // not pick it up — that path is opt-in by the host caller only.
+    expect(resolveKernelSocketPath()).toBeNull();
+  });
+});
+
+describe("resolveKernelOperatorSocket (host operator fallback)", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kern-op-home-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("returns the operator sock path when it exists on disk", () => {
+    const dir = join(home, ".switchroom", "state", "kernel-operator");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "sock"), "");
+    expect(resolveKernelOperatorSocket(home)).toBe(
+      kernelOperatorSocketPath(home),
+    );
+  });
+
+  it("returns null when the operator sock is absent (host-mode unchanged)", () => {
+    expect(resolveKernelOperatorSocket(home)).toBeNull();
   });
 });

--- a/src/vault/approvals/client.ts
+++ b/src/vault/approvals/client.ts
@@ -11,6 +11,9 @@
  * helpers below normalize that field name out for callers.
  */
 
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { rpcRaw, type BrokerClientOpts } from "../broker/client.js";
 import type {
   ApprovalDecisionMeta,
@@ -51,6 +54,37 @@ export interface ApprovalKernelClientOpts extends BrokerClientOpts {
    * rather than via the environment.
    */
   kernelSocket?: string;
+}
+
+/**
+ * Host-side operator socket path — the host end of the compose bind
+ * `~/.switchroom/state/kernel-operator → /run/switchroom/kernel/operator`.
+ * The kernel restricts this socket to the read-only `approval_list`
+ * op, so it is safe for host observers (the web dashboard) but cannot
+ * be used for grant/consume/revoke.
+ *
+ * Deliberately NOT folded into `resolveKernelSocketPath` (which stays a
+ * pure env/opts function): host-fs probing inside the shared resolver
+ * would make every caller's behaviour depend on whether the operator
+ * socket happens to exist on the box. Instead the one host caller (the
+ * dashboard's approvals view) probes this explicitly and passes it as
+ * `opts.kernelSocket` when present.
+ */
+export function kernelOperatorSocketPath(home: string = homedir()): string {
+  return join(home, ".switchroom", "state", "kernel-operator", "sock");
+}
+
+/**
+ * Resolve the host operator socket iff it exists, else null. The
+ * read-only host caller uses this to decide whether to pass
+ * `opts.kernelSocket`; absent ⇒ caller degrades (kernel unreachable
+ * from host) rather than silently changing the resolver contract.
+ */
+export function resolveKernelOperatorSocket(
+  home: string = homedir(),
+): string | null {
+  const p = kernelOperatorSocketPath(home);
+  return existsSync(p) ? p : null;
 }
 
 export function resolveKernelSocketPath(

--- a/src/vault/approvals/kernel-operator-acl.test.ts
+++ b/src/vault/approvals/kernel-operator-acl.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Operator-socket ACL — the security contract for the host operator
+ * listener (RFC: dashboard read-only kernel access).
+ *
+ * The kernel's mutating ops (approval_request/consume/revoke/record)
+ * carry NO op-level ACL — their only gate is per-agent socket
+ * isolation. The operator socket bypasses that isolation by design, so
+ * it MUST be deny-by-default: only `approval_list` is permitted. These
+ * tests pin that inversion over a real bound socket so a refactor that
+ * reorders the op chain or widens the allowlist fails loudly.
+ *
+ * bun test (openKernelDb → bun:sqlite); excluded from vitest.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import * as net from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  bootstrap,
+  KERNEL_OPERATOR_NAME,
+  type KernelServerHandle,
+} from "./kernel-server.js";
+import { encodeRequest } from "../broker/protocol.js";
+
+/** One-shot NDJSON round-trip against a bound unix socket. */
+function rpc(sockPath: string, req: unknown): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection(sockPath);
+    let buf = "";
+    const timer = setTimeout(() => {
+      sock.destroy();
+      reject(new Error("rpc timeout"));
+    }, 4000);
+    sock.on("connect", () => sock.write(encodeRequest(req as never)));
+    sock.on("data", (d) => {
+      buf += d.toString("utf8");
+      const nl = buf.indexOf("\n");
+      if (nl >= 0) {
+        clearTimeout(timer);
+        sock.end();
+        try {
+          resolve(JSON.parse(buf.slice(0, nl)));
+        } catch (e) {
+          reject(e);
+        }
+      }
+    });
+    sock.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+}
+
+describe("kernel operator socket — deny-by-default ACL", () => {
+  let dir: string;
+  let handle: KernelServerHandle;
+  let opSock: string;
+  let agentSock: string;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "kernel-op-"));
+    // operatorUid = our own uid: the try/catch chown is a no-op, the
+    // socket binds connectable as the test user either way.
+    handle = await bootstrap({
+      socketParent: dir,
+      agents: ["alice"],
+      dbPath: ":memory:",
+      operatorUid: process.getuid?.() ?? 0,
+    });
+    opSock = join(dir, KERNEL_OPERATOR_NAME, "sock");
+    agentSock = join(dir, "alice", "sock");
+  });
+
+  afterEach(() => {
+    try {
+      handle.stop();
+    } catch {
+      /* ignore */
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("allows approval_list on the operator socket", async () => {
+    const resp = await rpc(opSock, {
+      v: 1,
+      op: "approval_list",
+      agent_unit: "alice",
+    });
+    expect(resp.ok).toBe(true);
+    expect(Array.isArray(resp.decisions)).toBe(true);
+  });
+
+  // Every mutating op (and the per-agent-scoped reads) must be refused
+  // on the operator socket with the read-only DENIED error — BEFORE any
+  // op handler runs.
+  const forbidden: Array<[string, Record<string, unknown>]> = [
+    [
+      "approval_request",
+      {
+        v: 1,
+        op: "approval_request",
+        agent_unit: "alice",
+        scope: "doc:gdrive:write",
+        action: "docs:edit",
+        approver_set: ["u1"],
+      },
+    ],
+    [
+      "approval_lookup",
+      {
+        v: 1,
+        op: "approval_lookup",
+        agent_unit: "alice",
+        scope: "doc:gdrive:write",
+        action: "docs:edit",
+        current_approver_set: ["u1"],
+      },
+    ],
+    [
+      "approval_consume",
+      { v: 1, op: "approval_consume", request_id: "0badf00d" },
+    ],
+    [
+      "approval_revoke",
+      { v: 1, op: "approval_revoke", decision_id: "d1", actor: "attacker" },
+    ],
+    [
+      "approval_record",
+      {
+        v: 1,
+        op: "approval_record",
+        request_id: "0badf00d",
+        decision: "allow_always",
+        approver_set: ["u1"],
+        granted_by_user_id: 1,
+      },
+    ],
+  ];
+
+  for (const [op, req] of forbidden) {
+    it(`refuses ${op} on the operator socket (read-only DENIED)`, async () => {
+      const resp = await rpc(opSock, req);
+      expect(resp.ok).toBe(false);
+      expect(resp.code).toBe("DENIED");
+      expect(String(resp.msg)).toMatch(/read-only/i);
+      // Crucially the message names the op restriction, proving the
+      // top-of-handler gate fired — not an incidental downstream error.
+      expect(String(resp.msg)).toContain("not permitted");
+    });
+  }
+
+  it("does NOT apply the operator restriction to per-agent sockets", async () => {
+    // approval_record on alice's own socket must not hit the operator
+    // gate. It may fail for an unrelated reason (no such request_id),
+    // but it must NOT be the operator read-only DENIED message.
+    const resp = await rpc(agentSock, {
+      v: 1,
+      op: "approval_record",
+      request_id: "0badf00d",
+      decision: "allow_always",
+      approver_set: ["u1"],
+      granted_by_user_id: 1,
+    });
+    const msg = String(resp.msg ?? "");
+    expect(msg).not.toMatch(/operator socket is read-only/i);
+  });
+
+  it("never binds the operator dir as a per-agent listener", () => {
+    const names = handle.listeners.map((l) => l.agent).sort();
+    expect(names).toContain("alice");
+    expect(names).toContain(KERNEL_OPERATOR_NAME);
+    // Exactly one operator listener — the reserved name wasn't also
+    // enumerated as an agent.
+    expect(names.filter((n) => n === KERNEL_OPERATOR_NAME)).toHaveLength(1);
+  });
+});

--- a/src/vault/approvals/kernel-server.ts
+++ b/src/vault/approvals/kernel-server.ts
@@ -174,12 +174,69 @@ async function bindAgentSocket(
   });
 }
 
+/**
+ * Bind the host operator socket at /run/switchroom/kernel/operator/sock.
+ *
+ * Same bind plumbing as bindAgentSocket (root-owned dir → listen →
+ * chown to the operator UID), but:
+ *   - the directory name is the reserved KERNEL_OPERATOR_NAME, excluded
+ *     from per-agent enumeration so it can never be treated as an agent;
+ *   - the socket is mode 0600 (operator-only), tighter than the 0660
+ *     per-agent sockets — only the single host operator UID connects;
+ *   - connections are flagged `isOperator`, which the deny-by-default
+ *     allowlist in handleRequest restricts to approval_list.
+ *
+ * Bound only when SWITCHROOM_KERNEL_OPERATOR_UID is set (compose emits
+ * it alongside the operator bind mount, gated on the same operatorUid
+ * config the auth-broker uses). Absent ⇒ no operator listener, behaviour
+ * unchanged.
+ */
+async function bindOperatorSocket(
+  parentDir: string,
+  operatorUid: number,
+  db: Database,
+): Promise<AgentListener> {
+  const dir = resolve(parentDir, KERNEL_OPERATOR_NAME);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try { chownSync(dir, 0, 0); } catch { /* outside docker / no CAP_CHOWN */ }
+  try { chmodSync(dir, 0o700); } catch { /* idempotent */ }
+  const socketPath = resolve(dir, "sock");
+  if (existsSync(socketPath)) {
+    try {
+      unlinkSync(socketPath);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[kernel] could not unlink stale operator socket sock=${socketPath}: ${msg}\n`,
+      );
+    }
+  }
+  return new Promise((resolveP, rejectP) => {
+    const server = net.createServer((sock) =>
+      handleConnection(sock, KERNEL_OPERATOR_NAME, db, true),
+    );
+    server.on("error", (err) => {
+      process.stderr.write(`[kernel] listen error operator sock=${socketPath}: ${err.message}\n`);
+      rejectP(err);
+    });
+    server.listen(socketPath, () => {
+      // 0600: only the operator UID may connect. Tighter than the
+      // per-agent 0660 because there is exactly one legitimate peer.
+      try { chmodSync(socketPath, 0o600); } catch { /* ignore */ }
+      try { chownSync(socketPath, operatorUid, operatorUid); } catch { /* see bindAgentSocket */ }
+      try { chownSync(dir, operatorUid, operatorUid); } catch { /* see bindAgentSocket */ }
+      resolveP({ agent: KERNEL_OPERATOR_NAME, socketPath, server });
+    });
+  });
+}
+
 // ─── Connection handling ─────────────────────────────────────────────────────
 
 function handleConnection(
   socket: net.Socket,
   agent: string,
   db: Database,
+  isOperator = false,
 ): void {
   // `agent` is the trusted identity — it came from the listener's directory
   // name, established at bind time before the connection existed. No
@@ -221,7 +278,7 @@ function handleConnection(
         continue;
       }
       try {
-        handleRequest(socket, req, agent, db, peerUid);
+        handleRequest(socket, req, agent, db, peerUid, isOperator);
       } catch (err) {
         socket.write(encodeResponse(errorResponse("INTERNAL", (err as Error).message)));
       }
@@ -230,13 +287,57 @@ function handleConnection(
   socket.on("error", () => { /* peer dropped — best-effort */ });
 }
 
+/**
+ * Connections accepted on the host operator socket
+ * (`/run/switchroom/kernel/operator/sock`, bound only when an operator
+ * UID is configured). Path-as-identity: this name is reserved and
+ * excluded from per-agent enumeration, so a connection is "operator"
+ * iff it arrived on the operator listener — never inferred from the
+ * wire.
+ */
+export const KERNEL_OPERATOR_NAME = "operator";
+
+/**
+ * Ops the operator socket may invoke. DENY-BY-DEFAULT — this is the
+ * inverse of the auth-broker's `operator ⇒ admin ⇒ allow-all` model,
+ * and that inversion is the entire security point of this socket.
+ *
+ * The kernel's mutating ops (`approval_consume` / `approval_revoke` /
+ * `approval_record` / `approval_request`) carry NO op-level ACL: their
+ * only gate is per-agent socket isolation. The operator socket is, by
+ * construction, not in any agent's per-agent dir, so it bypasses that
+ * isolation. An operator connection that could reach those ops would be
+ * unauthenticated fleet-wide grant forgery / nonce burning. So the
+ * operator socket is restricted to the single read-only op the
+ * dashboard needs — listing decision metadata. Widening this set
+ * without a per-op authorization story is a security regression.
+ */
+const OPERATOR_ALLOWED_OPS: ReadonlySet<string> = new Set(["approval_list"]);
+
 function handleRequest(
   socket: net.Socket,
   req: BrokerRequest,
   agent: string,
   db: Database,
   peerUid: number | null,
+  isOperator = false,
 ): void {
+  // Deny-by-default allowlist for the operator socket. Must be the
+  // FIRST check — before any op dispatch — so a mutating op can never
+  // execute on an operator connection even if a future refactor
+  // reorders the chain below.
+  if (isOperator && !OPERATOR_ALLOWED_OPS.has(req.op)) {
+    socket.write(
+      encodeResponse(
+        errorResponse(
+          "DENIED",
+          `kernel operator socket is read-only: '${req.op}' is not permitted (only ${[...OPERATOR_ALLOWED_OPS].join(", ")})`,
+        ),
+      ),
+    );
+    return;
+  }
+
   // Only approval ops are served here. Anything else (vault_get, list_grants,
   // etc.) is the broker's territory and gets a hard error.
   if (req.op === "approval_request") {
@@ -370,16 +471,20 @@ function handleRequest(
 
 // ─── Top-level entrypoint ─────────────────────────────────────────────────────
 
-interface KernelServerHandle {
+/** @internal exported for the operator-ACL integration test. */
+export interface KernelServerHandle {
   listeners: AgentListener[];
   db: Database;
   stop(): void;
 }
 
-async function bootstrap(opts: {
+/** @internal exported for the operator-ACL integration test. */
+export async function bootstrap(opts: {
   socketParent: string;
   agents: string[];
   dbPath: string;
+  /** When set, also bind the read-only host operator socket. */
+  operatorUid?: number;
 }): Promise<KernelServerHandle> {
   process.umask(0o077);
   mkdirSync(opts.socketParent, { recursive: true, mode: 0o755 });
@@ -391,6 +496,13 @@ async function bootstrap(opts: {
   for (const agent of opts.agents) {
     const l = await bindAgentSocket(opts.socketParent, agent, db);
     listeners.push(l);
+  }
+  if (opts.operatorUid !== undefined) {
+    const l = await bindOperatorSocket(opts.socketParent, opts.operatorUid, db);
+    listeners.push(l);
+    process.stdout.write(
+      `approval-kernel: operator socket bound at ${l.socketPath} (read-only: approval_list)\n`,
+    );
   }
   return {
     listeners,
@@ -412,6 +524,16 @@ export async function main(): Promise<void> {
   const socketParent = dirname(resolve(socketEnv));
   const dbPath = process.env.SWITCHROOM_KERNEL_DB_PATH ?? DEFAULT_DB_PATH;
   const configPath = process.env.SWITCHROOM_CONFIG;
+  // Host operator socket — opt-in via SWITCHROOM_KERNEL_OPERATOR_UID
+  // (compose emits it next to the operator bind mount, gated on the
+  // same operatorUid config the auth-broker uses). A non-integer /
+  // unset value leaves the operator listener unbound (behaviour
+  // unchanged). Read-only by construction (see OPERATOR_ALLOWED_OPS).
+  const operatorUidRaw = process.env.SWITCHROOM_KERNEL_OPERATOR_UID;
+  const operatorUid =
+    operatorUidRaw && /^\d+$/.test(operatorUidRaw)
+      ? Number(operatorUidRaw)
+      : undefined;
 
   let agents: string[] = [];
   // Primary: enumerate per-agent socket dirs that compose mounted in.
@@ -424,6 +546,11 @@ export async function main(): Promise<void> {
     if (existsSync(socketParent)) {
       agents = readdirSync(socketParent)
         .filter((name) => {
+          // The operator dir is NOT an agent. Excluding it here is
+          // defence-in-depth: even if the operator bind mount exists,
+          // it must never be bound as a per-agent listener (which
+          // would skip the deny-by-default operator allowlist).
+          if (name === KERNEL_OPERATOR_NAME) return false;
           try {
             const p = resolve(socketParent, name);
             return statSync(p).isDirectory();
@@ -476,7 +603,7 @@ export async function main(): Promise<void> {
     return;
   }
 
-  const handle = await bootstrap({ socketParent, agents, dbPath });
+  const handle = await bootstrap({ socketParent, agents, dbPath, operatorUid });
   for (const l of handle.listeners) {
     process.stdout.write(`approval-kernel: listening agent=${l.agent} sock=${l.socketPath}\n`);
   }

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -764,6 +764,42 @@ describe("generateCompose", () => {
     expect(block).not.toContain("SWITCHROOM_AUTH_BROKER_OPERATOR_UID");
   });
 
+  // The approval-kernel mirrors the same operator-socket bind so
+  // host-side `approvalList` (the web dashboard) can read decision
+  // metadata. SWITCHROOM_KERNEL_OPERATOR_UID enables the kernel's
+  // READ-ONLY operator listener (approval_list only — the kernel
+  // enforces that, not compose). Both halves pinned.
+  it("emits kernel operator bind + UID env when operatorUid is set", () => {
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+      operatorUid: 1000,
+    });
+    const block = /approval-kernel:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toMatch(/SWITCHROOM_KERNEL_OPERATOR_UID:\s*"1000"/);
+    expect(block).toMatch(
+      /-\s+\$\{HOME\}\/\.switchroom\/state\/kernel-operator:\/run\/switchroom\/kernel\/operator/,
+    );
+  });
+
+  it("omits kernel operator bind + UID env when operatorUid is not set (back-compat)", () => {
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const block = /approval-kernel:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).not.toContain("SWITCHROOM_KERNEL_OPERATOR_UID");
+    expect(block).not.toContain("kernel-operator:/run/switchroom/kernel/operator");
+  });
+
+  it("bakes the absolute kernel operator-bind host path under homeDir override", () => {
+    const out = generateCompose({
+      config: makeConfig({ a: {} }),
+      operatorUid: 1000,
+      homeDir: "/home/op",
+    });
+    const block = /approval-kernel:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toContain(
+      "/home/op/.switchroom/state/kernel-operator:/run/switchroom/kernel/operator",
+    );
+  });
+
   // PR #1278: the auth-broker entry script reads `--operator-uid` as a
   // CLI flag, not an env var. The env var above is a fallback the
   // broker entry consumes (PR #1277) but the canonical wiring is a

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
       "**/src/vault/grants.test.ts",
       // Approval-kernel suites use bun:sqlite — run via test:bun.
       "**/src/vault/approvals/kernel.test.ts",
+      "**/src/vault/approvals/kernel-operator-acl.test.ts",
       "**/src/vault/approvals/schema-idempotent.test.ts",
       "**/src/vault/approvals/vd-unlock-dual-dispatch.test.ts",
       "**/src/vault/approvals/vault-grant-dual-dispatch.test.ts",
@@ -211,6 +212,7 @@ export default defineConfig({
       "**/src/drive/wrapper.test.ts",
       // Approval-kernel tests (RFC B) use bun:test + in-memory bun:sqlite.
       "**/src/vault/approvals/kernel.test.ts",
+      "**/src/vault/approvals/kernel-operator-acl.test.ts",
       "**/src/vault/broker/server-approvals.test.ts",
       // reaction-trigger tests (#1074) use bun:test — run via test:bun.
       "**/telegram-plugin/tests/reaction-trigger.test.ts",


### PR DESCRIPTION
## Summary

Adds a host-reachable operator socket to the approval-kernel so host-side observers (the web dashboard's upcoming P2b approvals view) can read decision metadata — **without widening the kernel's mutating surface**.

## Security model — the load-bearing part

This is deliberately the **inverse** of the auth-broker's operator socket. The auth-broker treats `operator ⇒ admin ⇒ allow-all`. **Mirroring that here would be a critical vulnerability**: the kernel's mutating ops (`approval_request/consume/revoke/record`) carry **no op-level ACL** — their only gate is per-agent socket isolation, which an operator socket bypasses by construction. A naive operator socket = unauthenticated fleet-wide grant forgery / nonce burning.

So the operator socket is **deny-by-default**: an allowlist of exactly `approval_list`, enforced at the **very top of `handleRequest`** (before any op dispatch) so a future chain reorder can't silently regress it. `operator` is a reserved dir name, **excluded from per-agent enumeration** (defence-in-depth — it can never be bound as a fake agent listener that would skip the allowlist).

## Plumbing (mirrors the auth-broker's proven shape)

- `bindOperatorSocket`: root-owned dir → listen → chown to operator UID, socket mode **0600** (tighter than the 0660 per-agent sockets — one legitimate peer).
- Opt-in via `SWITCHROOM_KERNEL_OPERATOR_UID`, emitted by compose alongside the `~/.switchroom/state/kernel-operator` bind, gated on the same `operatorUid` the auth-broker uses. **Absent ⇒ no operator listener, behaviour unchanged.**
- `resolveKernelSocketPath` stays a **pure** env/opts resolver; the host fallback is a separate explicit `resolveKernelOperatorSocket` helper (injectable `home`, `existsSync`-gated) so the shared resolver's contract doesn't become host-fs-dependent.

## Test plan

- [ ] `npm run lint` — tsc clean
- [ ] `bun test src/vault/approvals/kernel-operator-acl.test.ts` — 8 pass: `approval_list` permitted; `request/lookup/consume/revoke/record` all DENIED with read-only message; per-agent sockets unaffected; operator dir never enumerated as an agent
- [ ] `bun test src/vault/approvals/kernel.test.ts` — 19 pass (no regression)
- [ ] `npx vitest run tests/docker/compose-generator.test.ts src/vault/approvals/client.test.ts` — 140 pass (operator env+bind gated on operatorUid; pure resolver unchanged; host-fallback helper)

## Why

Unblocks the phased web-dashboard refresh's final piece (P2b approvals panel). P0/P1/P2a already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)