### PR TITLE
feat(web): Approvals dashboard panel — read-only kernel ledger (P2b)

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -26,6 +26,11 @@ import {
   type DispatchResult,
 } from "../scheduler/dispatch.js";
 import { readRecentFires } from "../agent-scheduler/replay.js";
+import {
+  approvalList,
+  resolveKernelOperatorSocket,
+} from "../vault/approvals/client.js";
+import type { ApprovalDecisionMeta } from "../vault/broker/protocol.js";
 import { captureEvent, captureException } from "../analytics/posthog.js";
 import { resolveAgentsDir } from "../config/loader.js";
 import { resolveAgentConfig } from "../config/merge.js";
@@ -547,4 +552,48 @@ export function handleGetSchedule(
     if (rows.length > 0) recentByAgent[agent] = rows.slice(-10);
   }
   return { entries, recentByAgent };
+}
+
+/**
+ * Approval-kernel decision ledger (RFC B) — the host read-only view
+ * over the operator socket added in #1362. The kernel restricts that
+ * socket to `approval_list`, so this is observation only: no grant /
+ * consume / revoke is reachable from here by construction.
+ *
+ * Three states, each rendered distinctly rather than collapsed:
+ *   - operator socket absent  → kernel not host-reachable on this
+ *     install (pre-#1362 deploy, or operatorUid unset). `reachable:false`.
+ *   - socket present, RPC null → kernel down / protocol error.
+ *   - ok → decisions[] (newest first for the table).
+ */
+export interface ApprovalsDashboard {
+  reachable: boolean;
+  decisions: ApprovalDecisionMeta[];
+  error?: string;
+}
+
+export async function handleGetApprovals(): Promise<ApprovalsDashboard> {
+  const opSock = resolveKernelOperatorSocket();
+  if (opSock === null) {
+    return {
+      reachable: false,
+      decisions: [],
+      error:
+        "approval-kernel operator socket not present — host-side approval " +
+        "listing needs operatorUid set (compose) and a post-#1362 deploy.",
+    };
+  }
+  // No agent_unit filter → fleet-wide. Pin opts.socket to the operator
+  // socket so the resolver doesn't fall through to the broker.
+  const decisions = await approvalList(undefined, { socket: opSock });
+  if (decisions === null) {
+    return {
+      reachable: false,
+      decisions: [],
+      error: "approval-kernel unreachable or returned an error",
+    };
+  }
+  // Newest first — most relevant grant at the top of the table.
+  const sorted = [...decisions].sort((a, b) => b.granted_at - a.granted_at);
+  return { reachable: true, decisions: sorted };
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -30,6 +30,7 @@ import {
   handleGetSystemHealth,
   handleGetGoogleAccounts,
   handleGetSchedule,
+  handleGetApprovals,
 } from "./api.js";
 import { handleWebhookIngest } from "./webhook-handler.js";
 
@@ -350,6 +351,11 @@ function parseRoute(
     return { handler: "getSchedule", params: {} };
   }
 
+  // GET /api/approvals
+  if (method === "GET" && pathname === "/api/approvals") {
+    return { handler: "getApprovals", params: {} };
+  }
+
   // GET /api/accounts
   if (method === "GET" && pathname === "/api/accounts") {
     return { handler: "getAccounts", params: {} };
@@ -537,6 +543,10 @@ export function startWebServer(
 
           case "getSchedule":
             return jsonResponse(handleGetSchedule(config));
+
+          case "getApprovals":
+            return (async () =>
+              jsonResponse(await handleGetApprovals()))();
 
           case "getAccounts":
             return (async () => jsonResponse(await handleGetAccounts(config)))();

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -410,6 +410,7 @@
     <button id="tab-system" onclick="switchTab('system')">System</button>
     <button id="tab-google" onclick="switchTab('google')">Google</button>
     <button id="tab-schedule" onclick="switchTab('schedule')">Schedule</button>
+    <button id="tab-approvals" onclick="switchTab('approvals')">Approvals</button>
   </nav>
   <main>
     <div id="error"></div>
@@ -418,6 +419,7 @@
     <div id="system" style="display:none"></div>
     <div id="google" style="display:none"></div>
     <div id="schedule" style="display:none"></div>
+    <div id="approvals" style="display:none"></div>
   </main>
 
   <script>
@@ -511,8 +513,19 @@
       }
     }
 
+    async function fetchApprovals() {
+      try {
+        const res = await fetch(`${API}/api/approvals`, { headers: authHeaders() });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        renderApprovals(await res.json());
+        clearError();
+      } catch (err) {
+        showError(`Failed to fetch approvals: ${err.message}`);
+      }
+    }
+
     function switchTab(tab) {
-      const tabs = ['agents', 'accounts', 'system', 'google', 'schedule'];
+      const tabs = ['agents', 'accounts', 'system', 'google', 'schedule', 'approvals'];
       for (const t of tabs) {
         document.getElementById(`tab-${t}`).classList.toggle('active', tab === t);
         document.getElementById(t).style.display = tab === t ? '' : 'none';
@@ -521,6 +534,7 @@
       if (tab === 'system') fetchSystemHealth();
       if (tab === 'google') fetchGoogleAccounts();
       if (tab === 'schedule') fetchSchedule();
+      if (tab === 'approvals') fetchApprovals();
     }
 
     function showError(msg) {
@@ -894,6 +908,60 @@
         </div>`;
       }).join('');
       container.innerHTML = cards;
+    }
+
+    function renderApprovals(data) {
+      const container = document.getElementById('approvals');
+      const dim = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
+      if (!data || data.reachable === false) {
+        const why = (data && data.error) ? escapeHtml(data.error) : 'approval-kernel not reachable from host';
+        container.innerHTML = `<div class="loading">Approval ledger unavailable — ${why}</div>`;
+        return;
+      }
+      const decisions = data.decisions || [];
+      if (decisions.length === 0) {
+        container.innerHTML = '<div class="loading">No approval decisions recorded yet.</div>';
+        return;
+      }
+      const now = Date.now();
+      const statusOf = (d) => {
+        if (d.revoked_at) return ['revoked', 'inactive'];
+        if (d.ttl_expires_at && d.ttl_expires_at < now) return ['expired', 'inactive'];
+        return ['active', 'active'];
+      };
+      const rows = decisions.map(d => {
+        const [label, dot] = statusOf(d);
+        // Drive write scopes are the headline use of the approval flow —
+        // make them visually distinct.
+        const isDrive = /(^|:)(doc|drive|gdrive|sheets)/i.test(d.scope || '');
+        const scopeCell = isDrive
+          ? `<span class="usage-pill primary">${escapeHtml(d.scope)}</span>`
+          : escapeHtml(d.scope || '—');
+        return `
+        <tr>
+          <td><span class="status-dot ${dot}" style="display:inline-block;vertical-align:middle"></span> ${escapeHtml(label)}</td>
+          <td>${escapeHtml(d.agent_unit || '—')}</td>
+          <td>${scopeCell}</td>
+          <td>${escapeHtml(d.action || '—')}</td>
+          <td>${escapeHtml(d.decision || '—')}</td>
+          <td>${d.granted_at ? formatTimestamp(d.granted_at) : dim('—')}</td>
+          <td>${d.ttl_expires_at ? formatTimestamp(d.ttl_expires_at) : dim('—')}</td>
+          <td title="${d.revoke_reason ? escapeHtml(d.revoke_reason) : ''}">${d.revoked_at ? formatTimestamp(d.revoked_at) : dim('—')}</td>
+        </tr>`;
+      }).join('');
+      container.innerHTML = `
+        <div style="margin-bottom:0.6rem;font-size:0.8rem;color:var(--text-dim)">
+          Read-only view via the kernel operator socket — ${decisions.length} decision(s). Drive scopes highlighted.
+        </div>
+        <div class="accounts-table-wrap">
+          <table class="accounts-table">
+            <thead><tr>
+              <th>Status</th><th>Agent</th><th>Scope</th><th>Action</th>
+              <th>Decision</th><th>Granted</th><th>TTL expires</th><th>Revoked</th>
+            </tr></thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>`;
     }
 
     function openPromoteModal(label) {

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -31,6 +31,14 @@ vi.mock("../src/analytics/posthog.js", () => ({
   captureException: vi.fn(),
 }));
 
+// Approval-kernel client — handleGetApprovals reads the kernel's
+// read-only operator socket. Stub the resolver + list call so the
+// unit test never opens a real UDS.
+vi.mock("../src/vault/approvals/client.js", () => ({
+  resolveKernelOperatorSocket: vi.fn(() => null),
+  approvalList: vi.fn(async () => null),
+}));
+
 // Mock child_process
 vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
@@ -86,10 +94,15 @@ import {
   handleGetSchedule,
   handleGetAccounts,
   handleUseAccount,
+  handleGetApprovals,
   type AgentInfo,
 } from "../src/web/api.js";
 import { resolveAgentsDir } from "../src/config/loader.js";
 import { getAccountInfos } from "../src/auth/account-store.js";
+import {
+  resolveKernelOperatorSocket,
+  approvalList,
+} from "../src/vault/approvals/client.js";
 import { isOriginAllowed, isTailscaleIdentified } from "../src/web/server.js";
 import { getAllAgentStatuses, startAgent, stopAgent, restartAgent } from "../src/agents/lifecycle.js";
 import { getAllAuthStatuses } from "../src/auth/manager.js";
@@ -760,5 +773,45 @@ describe("handleGetAccounts / handleUseAccount shape (RFC-H)", () => {
     const r = await handleUseAccount("ken@x.com");
     expect(r.ok).toBe(false);
     expect(r.error).toContain("broker down");
+  });
+});
+
+describe("handleGetApprovals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports unreachable when the operator socket is absent", async () => {
+    asMock(resolveKernelOperatorSocket).mockReturnValue(null);
+    const r = await handleGetApprovals();
+    expect(r.reachable).toBe(false);
+    expect(r.decisions).toEqual([]);
+    expect(r.error).toMatch(/operator socket not present/i);
+    // Must not even attempt the RPC when there's no socket.
+    expect(approvalList).not.toHaveBeenCalled();
+  });
+
+  it("reports unreachable when approvalList returns null (kernel down)", async () => {
+    asMock(resolveKernelOperatorSocket).mockReturnValue("/run/op/sock");
+    asMock(approvalList).mockResolvedValue(null);
+    const r = await handleGetApprovals();
+    expect(r.reachable).toBe(false);
+    expect(r.error).toMatch(/unreachable or returned an error/i);
+  });
+
+  it("returns decisions newest-first and pins the socket opt", async () => {
+    asMock(resolveKernelOperatorSocket).mockReturnValue("/run/op/sock");
+    asMock(approvalList).mockResolvedValue([
+      { id: "old", agent_unit: "carrie", scope: "doc:gdrive:write", action: "docs:edit", decision: "allow_ttl", granted_at: 100, granted_by_user_id: 1, ttl_expires_at: null, last_used_at: null, revoked_at: null, revoke_reason: null },
+      { id: "new", agent_unit: "clerk", scope: "vault:read", action: "get", decision: "allow_always", granted_at: 999, granted_by_user_id: 1, ttl_expires_at: null, last_used_at: null, revoked_at: null, revoke_reason: null },
+    ] as never);
+    const r = await handleGetApprovals();
+    expect(r.reachable).toBe(true);
+    expect(r.decisions.map((d) => d.id)).toEqual(["new", "old"]);
+    // No agent filter (fleet-wide) + socket pinned so the resolver
+    // can't fall through to the broker.
+    expect(approvalList).toHaveBeenCalledWith(undefined, {
+      socket: "/run/op/sock",
+    });
   });
 });


### PR DESCRIPTION
## Summary

The **final** piece of the phased dashboard refresh. Surfaces the approval-kernel decision ledger (RFC B — Drive write-preview grants et al.) over the read-only host operator socket added in #1362.

- `GET /api/approvals` → `handleGetApprovals`: resolves the kernel operator socket (`resolveKernelOperatorSocket`, existsSync-gated), calls `approvalList(undefined, { socket })` — fleet-wide, socket pinned so the resolver can't fall through to the broker. Three honest states: operator socket absent (pre-#1362 / no operatorUid), kernel down (RPC null), or `decisions[]` newest-first.
- **Approvals tab**: status (active/expired/revoked derived from `ttl_expires_at`/`revoked_at`), agent, scope, action, decision mode, granted/ttl/revoked times. Drive scopes (`doc/drive/gdrive/sheets`) highlighted.

**Read-only by construction**: #1362's deny-by-default ACL restricts the kernel operator socket to `approval_list`, so no grant/consume/revoke is reachable from the dashboard even in principle.

## Phasing — this completes the initiative

| Phase | PR |
|---|---|
| P0 logs + accounts/RFC-H regressions | #1357 ✅ |
| P1 broker/hindsight/hostd health | #1359 ✅ |
| P2a Google Workspace + Schedule + account tests | #1360 ✅ |
| Infra: kernel read-only operator socket | #1362 ✅ |
| **P2b Approvals panel** | this PR |

## Test plan

- [ ] `npm run lint` — tsc clean
- [ ] `npx vitest run tests/web.test.ts src/web/` — 96 pass (3 new: socket-absent skips RPC, kernel-down → unreachable, decisions newest-first + socket-pinned)
- [ ] Manual on the live host post-deploy: Approvals tab lists kernel decisions (Drive scopes highlighted); pre-deploy it renders the explicit "operator socket not present" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)