### PR TITLE
fix(drive-mcp): uvx entrypoint is workspace-mcp, not google-workspace-mcp

### DIFF
--- a/src/cli/drive-mcp-launcher.test.ts
+++ b/src/cli/drive-mcp-launcher.test.ts
@@ -117,9 +117,15 @@ describe("buildUvxArgs — pinned upstream + --single-user", () => {
     expect(args).toEqual([
       "--from",
       `git+https://github.com/taylorwilsdon/google_workspace_mcp.git@${GOOGLE_WORKSPACE_MCP_PINNED_SHA}`,
-      "google-workspace-mcp",
+      // MUST be `workspace-mcp` — the upstream package provides only
+      // `workspace-mcp` and `workspace-cli`. The original
+      // `google-workspace-mcp` made uvx exit "executable not provided
+      // by package workspace-mcp" (verified in-container). This is the
+      // assertion that previously encoded the bug.
+      "workspace-mcp",
       "--single-user",
     ]);
+    expect(args).not.toContain("google-workspace-mcp");
   });
 
   it("appends --tool-tier <tier> after --single-user when a tier is given", () => {

--- a/src/cli/drive-mcp-launcher.ts
+++ b/src/cli/drive-mcp-launcher.ts
@@ -162,13 +162,21 @@ export function buildSeedCredentials(
  * different upstream revisions.
  *
  *   uvx --from git+https://github.com/taylorwilsdon/google_workspace_mcp.git@<sha> \
- *       google-workspace-mcp --single-user [--tool-tier <tier>]
+ *       workspace-mcp --single-user [--tool-tier <tier>]
+ *
+ * NB: the executable is `workspace-mcp`, NOT `google-workspace-mcp`.
+ * The upstream package is named `workspace-mcp` and provides exactly
+ * two entrypoints — `workspace-mcp` (the MCP server) and
+ * `workspace-cli`. Passing `google-workspace-mcp` makes uvx exit with
+ * "An executable named `google-workspace-mcp` is not provided by
+ * package `workspace-mcp`" — verified in-container against the pinned
+ * SHA.
  */
 export function buildUvxArgs(tier?: string): string[] {
   const args = [
     "--from",
     `git+https://github.com/taylorwilsdon/google_workspace_mcp.git@${GOOGLE_WORKSPACE_MCP_PINNED_SHA}`,
-    "google-workspace-mcp",
+    "workspace-mcp",
     "--single-user",
   ];
   if (tier && tier.length > 0) {

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -107,8 +107,10 @@ export interface GdriveMcpEntryOptions {
  *   2. resolves the OAuth client_secret from config / vault-broker,
  *   3. pre-seeds a credentials file (`{token:null, refresh_token, ...,
  *      expiry:null}`) into a per-agent `WORKSPACE_MCP_CREDENTIALS_DIR`,
- *   4. `exec`s `uvx --from git+...@<pinned-sha> google-workspace-mcp
- *      --single-user [--tool-tier <tier>]`.
+ *   4. `exec`s `uvx --from git+...@<pinned-sha> workspace-mcp
+ *      --single-user [--tool-tier <tier>]` (the upstream package's
+ *      MCP-server entrypoint is `workspace-mcp`, not
+ *      `google-workspace-mcp`).
  *
  * The `--single-user` + pre-seeded-file shape is what makes upstream run
  * browserless: token/expiry null forces the refresh branch, no OAuth


### PR DESCRIPTION
## Summary

Follow-on to #1361 (uv now in the agent image). The launcher now reaches the final step — verified empirically in carrie's live container: auth-broker fetch ✓, client_secret ✓, seed-file write ✓, `uvx` git-fetch + build of the pinned upstream package ✓ (96 deps installed) — then exits:

```
An executable named `google-workspace-mcp` is not provided by package `workspace-mcp`.
The following executables are available: workspace-cli, workspace-mcp
```

`buildUvxArgs` passed `google-workspace-mcp` as the uvx entrypoint. The upstream package is **`workspace-mcp`**, exposing exactly `workspace-mcp` (the MCP server) and `workspace-cli`. The host-side example (`examples/personal-google-workspace-mcp/compose.yaml`) already runs `uvx --from workspace-mcp workspace-mcp` — same fact.

## Fix
- `buildUvxArgs` entrypoint: `google-workspace-mcp` → `workspace-mcp` (the one functional change).
- The unit test **previously asserted the wrong constant** (`toEqual([… "google-workspace-mcp" …])`) — a green test encoding the bug, the same failure pattern as the earlier `.mcp.json` issue. Corrected to pin `workspace-mcp` + `expect(args).not.toContain("google-workspace-mcp")` with a why-comment so it can't regress.
- Doc comments aligned. The per-agent credentials *directory* name (launcher.ts:217) is left descriptive — it's a folder, not the entrypoint; no behavior.

## Test plan
- [x] `npm run lint` clean
- [x] 28 launcher + scaffold-gdrive tests pass (incl. the corrected `buildUvxArgs` assertion)
- [ ] CI required checks
- [ ] Post-merge: `switchroom update` → re-run launcher in carrie → upstream MCP actually starts → end-to-end (Carrie creates a `/linkedin` doc, RFC E approval card)

Every other layer is verified working; this is the last identified gap in the spawn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)