### PR TITLE
fix(drive-mcp): pin aiofile==3.8.8 (defuse upstream KeyError crash)

### DIFF
--- a/src/cli/drive-mcp-launcher.test.ts
+++ b/src/cli/drive-mcp-launcher.test.ts
@@ -117,6 +117,13 @@ describe("buildUvxArgs — pinned upstream + --single-user", () => {
     expect(args).toEqual([
       "--from",
       `git+https://github.com/taylorwilsdon/google_workspace_mcp.git@${GOOGLE_WORKSPACE_MCP_PINNED_SHA}`,
+      // `--with aiofile==3.8.8` is load-bearing, not optional: without
+      // it the modern fastmcp→key_value→aiofile import chain crashes
+      // with `KeyError: 'Author'` and the MCP never starts (verified
+      // in-container; ==1.20.4 and latest PyPI crash identically). Must
+      // sit BEFORE the entrypoint positional (it's a uvx option).
+      "--with",
+      "aiofile==3.8.8",
       // MUST be `workspace-mcp` — the upstream package provides only
       // `workspace-mcp` and `workspace-cli`. The original
       // `google-workspace-mcp` made uvx exit "executable not provided
@@ -126,6 +133,10 @@ describe("buildUvxArgs — pinned upstream + --single-user", () => {
       "--single-user",
     ]);
     expect(args).not.toContain("google-workspace-mcp");
+    // Regression guard for the aiofile landmine — order matters
+    // (uvx options precede the entrypoint).
+    expect(args.indexOf("--with")).toBeLessThan(args.indexOf("workspace-mcp"));
+    expect(args).toContain("aiofile==3.8.8");
   });
 
   it("appends --tool-tier <tier> after --single-user when a tier is given", () => {

--- a/src/cli/drive-mcp-launcher.ts
+++ b/src/cli/drive-mcp-launcher.ts
@@ -172,10 +172,30 @@ export function buildSeedCredentials(
  * package `workspace-mcp`" — verified in-container against the pinned
  * SHA.
  */
+// Upstream dependency landmine. `workspace-mcp` pulls a modern
+// `fastmcp` whose `oauth_proxy → key_value → filetree` import chain
+// imports `aiofile`. `aiofile/version.py` (still, on master) does
+// `package_metadata["Author"]`; under the `importlib_metadata`
+// backport's #371 behavior change (KeyError on a missing key) and
+// aiofile's newer wheels emitting only `Author-email`, that import
+// raises `KeyError: 'Author'` and the MCP server never starts. NOT a
+// switchroom bug and NOT fixed by repinning workspace-mcp (==1.20.4
+// and latest PyPI both crash identically — verified in-container).
+// Constraining the leaf package to a version whose wheel metadata
+// still carries `Author` defuses it with minimal blast radius (vs.
+// pinning the foundational importlib_metadata). `aiofile==3.8.8`
+// validated end-to-end in a real agent container: reaches "Starting
+// MCP server 'google_workspace' (stdio)". Bump in lockstep with the
+// upstream SHA + a re-test of the import+startup path.
+const AIOFILE_PIN = "aiofile==3.8.8";
+
 export function buildUvxArgs(tier?: string): string[] {
   const args = [
     "--from",
     `git+https://github.com/taylorwilsdon/google_workspace_mcp.git@${GOOGLE_WORKSPACE_MCP_PINNED_SHA}`,
+    // uvx option — must precede the `workspace-mcp` entrypoint positional.
+    "--with",
+    AIOFILE_PIN,
     "workspace-mcp",
     "--single-user",
   ];


### PR DESCRIPTION
## Summary

Final blocker in the agent-Drive chain. After #1361 (uv in image) + #1364 (`workspace-mcp` entrypoint), the launcher reaches upstream MCP startup but it **crashes on import**, verified in a live agent container:

```
fastmcp.oauth_proxy → key_value → filetree → aiofile/version.py:6
__author__ = package_metadata["Author"]   → KeyError: 'Author'
```

**Root cause is upstream, not switchroom**: `aiofile/version.py` does `package_metadata["Author"]` (still unfixed on aiofile master); modern `importlib_metadata` (behavior change #371) raises `KeyError` on missing keys; aiofile's newer wheels ship only `Author-email`. **Repinning `workspace-mcp` does not help** — `==1.20.4` (the working host-example's pin) *and* latest PyPI both crash identically in-container.

## Fix
`uvx --with aiofile==3.8.8` — constrain the offending **leaf** package to a version whose wheel metadata still carries `Author`. Chosen over pinning `importlib_metadata` (foundational, far broader blast radius). `--with` is placed before the `workspace-mcp` entrypoint positional (uvx option ordering).

## Validation (empirical, in a real agent container — the lesson of this saga)
With the pin, `workspace-mcp --single-user --tool-tier extended` reaches:
```
FastMCP 3.3.1 — Server: google_workspace, 3.3.1
INFO  Starting MCP server 'google_workspace' with transport 'stdio'
```
Past **every** import *and* the aiofile-backed runtime store. Probed alternatives in-container too: `==1.20.4`/latest PyPI crash; `--with importlib-metadata==6.11.0` also works but pins a foundational lib (rejected).

## Test plan
- [x] `npm run lint` clean
- [x] 20 launcher tests pass; `buildUvxArgs` asserts `--with aiofile==3.8.8` present + ordered before the entrypoint (regression guard)
- [ ] CI required checks
- [ ] Post-merge: agent image rebuild → `switchroom update` → launcher in carrie starts the MCP → **the long-sought end-to-end** (Carrie reads/creates in `/linkedin`, RFC E approval card)

Every switchroom layer (launcher, broker token, seed, entrypoint, uv, scaffold `.mcp.json`) was already verified; this defuses the last upstream landmine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)