### PR TITLE
fix(scaffold): gdrive MCP env block + enabledMcpjsonServers trust (the real root cause)

### DIFF
--- a/src/agents/scaffold-gdrive-entry.test.ts
+++ b/src/agents/scaffold-gdrive-entry.test.ts
@@ -81,6 +81,37 @@ describe("resolveGdriveMcpEntry — emits when broker-authorized", () => {
     const args = entry?.value.args ?? [];
     expect(args[args.indexOf("--tier") + 1]).toBe("extended");
   });
+
+  // Bug A regression: Claude Code spawns MCP servers with a sanitized
+  // env, so the launcher gets none of the compose container env unless
+  // the entry carries it explicitly. All six keys must mirror
+  // src/agents/compose.ts emitAgentService env exactly.
+  it("emits the full sanitized-env block with agentName threaded", () => {
+    const entry = resolveGdriveMcpEntry(
+      "carrie",
+      agent({ google_workspace: { account: "pixsoul@gmail.com" } }),
+      ENABLED,
+    );
+    expect(entry?.value.env).toEqual({
+      SWITCHROOM_CONFIG: "/state/config/switchroom.yaml",
+      SWITCHROOM_AGENT_NAME: "carrie",
+      SWITCHROOM_CONTAINER: "1",
+      SWITCHROOM_AUTH_BROKER_SOCKET: "/run/switchroom/auth-broker/sock",
+      SWITCHROOM_VAULT_BROKER_SOCK: "/run/switchroom/broker/sock",
+      HOME: "/state/agent/home",
+    });
+  });
+
+  it("threads a different agent name through SWITCHROOM_AGENT_NAME", () => {
+    const entry = resolveGdriveMcpEntry(
+      "clerk",
+      agent({ google_workspace: { account: "pixsoul@gmail.com" } }),
+      ENABLED,
+    );
+    expect(entry?.value.env?.SWITCHROOM_AGENT_NAME).toBe("clerk");
+    // tier arg still preserved alongside the env block
+    expect(entry?.value.args).toEqual(["drive-mcp-launcher"]);
+  });
 });
 
 describe("resolveGdriveMcpEntry — does NOT emit", () => {

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -125,6 +125,7 @@ import {
   findExistingClaudeJson,
   copyOnboardingState,
   preTrustWorkspace,
+  ensureMcpServersTrusted,
   createMinimalClaudeConfig,
   loadUserConfig,
 } from "../setup/onboarding.js";
@@ -1764,6 +1765,32 @@ export const DOCKER_CONFIG_PATH = "/state/config/switchroom.yaml";
 export const DOCKER_SWITCHROOM_CLI_PATH = "/usr/local/bin/switchroom";
 
 /**
+ * In-container path to the auth-broker UDS. The gdrive launcher resolves
+ * Google credentials through the auth-broker; Claude Code spawns MCP
+ * servers with a sanitized env (NOT the container env), so this MUST be
+ * threaded explicitly onto the gdrive `.mcp.json` entry or the launcher
+ * talks to the wrong (default) socket and dies.
+ * MUST mirror src/agents/compose.ts emitAgentService env (compose.ts:1312).
+ */
+export const DOCKER_AUTH_BROKER_SOCKET = "/run/switchroom/auth-broker/sock";
+
+/**
+ * In-container path to the vault-broker UDS. Needed when the configured
+ * `google_client_secret` is a `vault:` reference the launcher must
+ * resolve through the vault broker.
+ * MUST mirror src/agents/compose.ts emitAgentService env (compose.ts:1304).
+ */
+export const DOCKER_VAULT_BROKER_SOCKET = "/run/switchroom/broker/sock";
+
+/**
+ * In-container HOME for the agent. The launcher (and uvx beneath it)
+ * writes to ~/.cache, ~/.config, ~/.local; without HOME pointed at the
+ * writable bind mount it defaults to "/" on the read-only root fs.
+ * MUST mirror src/agents/compose.ts emitAgentService env (compose.ts:1248).
+ */
+export const DOCKER_AGENT_HOME = "/state/agent/home";
+
+/**
  * Decide whether the per-agent `gdrive` MCP entry should be written into
  * `mcpServers`, and if so produce it.
  *
@@ -1799,10 +1826,27 @@ export function resolveGdriveMcpEntry(
   const tier =
     agentConfig.google_workspace?.tier ??
     switchroomConfig?.google_workspace?.tier;
-  return getGdriveMcpSettingsEntry(
+  const entry = getGdriveMcpSettingsEntry(
     DOCKER_SWITCHROOM_CLI_PATH,
     tier ? { tier } : {},
   );
+  // Claude Code spawns MCP servers with a SANITIZED env (not the
+  // parent/container env), so the drive-mcp-launcher gets none of the
+  // compose-emitted SWITCHROOM_* / HOME vars unless we thread them onto
+  // the entry explicitly. Without this block the launcher dies at spawn
+  // ("No switchroom.yaml found", or it connects to the wrong broker
+  // socket). Every value here MUST mirror the canonical value emitted by
+  // src/agents/compose.ts emitAgentService env (line cited per key) so
+  // the in-MCP-spawn env can never disagree with the container env.
+  entry.value.env = {
+    SWITCHROOM_CONFIG: DOCKER_CONFIG_PATH, // compose.ts SWITCHROOM_CONFIG / volume mount (scaffold.ts:1755)
+    SWITCHROOM_AGENT_NAME: agentName, // compose.ts:1275 (a.name)
+    SWITCHROOM_CONTAINER: "1", // compose.ts:1276
+    SWITCHROOM_AUTH_BROKER_SOCKET: DOCKER_AUTH_BROKER_SOCKET, // compose.ts:1312
+    SWITCHROOM_VAULT_BROKER_SOCK: DOCKER_VAULT_BROKER_SOCKET, // compose.ts:1304
+    HOME: DOCKER_AGENT_HOME, // compose.ts:1248
+  };
+  return entry;
 }
 
 export function scaffoldAgent(
@@ -2207,6 +2251,13 @@ export function scaffoldAgent(
       skipped,
       0o600,
     );
+    // Claude Code only loads project `.mcp.json` servers that are on the
+    // per-project trust allowlist. preTrustWorkspace sets
+    // hasTrustDialogAccepted but never enabledMcpjsonServers, so any
+    // server scaffolded after original onboarding (gdrive, plus
+    // agent-config/hostd for non-original agents) is silently ignored.
+    // Union every server we just wrote into the allowlist.
+    ensureMcpServersTrusted(agentDir, Object.keys(mcpServers));
   }
 
   // --- Render template-specific files ---
@@ -3986,6 +4037,11 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
       writeFileSync(mcpJsonPath, after, { encoding: "utf-8", mode: 0o600 });
       changes.push(mcpJsonPath);
     }
+    // Mirror scaffoldAgent: keep every scaffolded server on Claude
+    // Code's per-project trust allowlist (idempotent — runs every
+    // reconcile so a newly-added gdrive/hostd is trusted on the next
+    // `switchroom apply`, not just at original onboarding).
+    ensureMcpServersTrusted(agentDir, Object.keys(mcpServers));
   }
 
   // --- Re-seed workspace bootstrap files from the profile.

--- a/src/setup/ensure-mcp-trusted.test.ts
+++ b/src/setup/ensure-mcp-trusted.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for `ensureMcpServersTrusted` in setup/onboarding.ts (Bug B).
+ *
+ * Claude Code only loads project `.mcp.json` servers listed in
+ * `.claude.json` `projects[<absDir>].enabledMcpjsonServers`.
+ * `preTrustWorkspace` never set that array, so servers scaffolded after
+ * original onboarding (gdrive, agent-config/hostd on non-original agents)
+ * were silently dropped. This helper unions the just-written server keys
+ * into that allowlist, idempotently, preserving hasTrustDialogAccepted.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { ensureMcpServersTrusted } from "./onboarding.js";
+
+let agentDir: string;
+
+function writeClaudeJson(obj: unknown): void {
+  const claudeDir = join(agentDir, ".claude");
+  mkdirSync(claudeDir, { recursive: true });
+  writeFileSync(join(claudeDir, ".claude.json"), JSON.stringify(obj, null, 2));
+}
+
+function readClaudeJson(): {
+  projects: Record<
+    string,
+    {
+      hasTrustDialogAccepted?: boolean;
+      enabledMcpjsonServers?: string[];
+      allowedTools?: string[];
+    }
+  >;
+} {
+  return JSON.parse(
+    readFileSync(join(agentDir, ".claude", ".claude.json"), "utf-8"),
+  );
+}
+
+beforeEach(() => {
+  agentDir = mkdtempSync(join(tmpdir(), "switchroom-trust-"));
+});
+
+afterEach(() => {
+  rmSync(agentDir, { recursive: true, force: true });
+});
+
+describe("ensureMcpServersTrusted", () => {
+  it("unions server keys into enabledMcpjsonServers (⊇ [a,b])", () => {
+    writeClaudeJson({
+      projects: {
+        [resolve(agentDir)]: {
+          hasTrustDialogAccepted: true,
+          allowedTools: [],
+        },
+      },
+    });
+
+    ensureMcpServersTrusted(agentDir, ["a", "b"]);
+
+    const project = readClaudeJson().projects[resolve(agentDir)];
+    expect(project.enabledMcpjsonServers).toEqual(
+      expect.arrayContaining(["a", "b"]),
+    );
+    expect(project.hasTrustDialogAccepted).toBe(true);
+  });
+
+  it("is idempotent on a second call (no duplicates, trust preserved)", () => {
+    writeClaudeJson({
+      projects: {
+        [resolve(agentDir)]: { hasTrustDialogAccepted: true },
+      },
+    });
+
+    ensureMcpServersTrusted(agentDir, ["a", "b"]);
+    ensureMcpServersTrusted(agentDir, ["a", "b"]);
+
+    const project = readClaudeJson().projects[resolve(agentDir)];
+    expect(project.enabledMcpjsonServers).toEqual(["a", "b"]);
+    expect(project.hasTrustDialogAccepted).toBe(true);
+  });
+
+  it("unions with pre-existing enabledMcpjsonServers entries", () => {
+    writeClaudeJson({
+      projects: {
+        [resolve(agentDir)]: {
+          hasTrustDialogAccepted: true,
+          enabledMcpjsonServers: ["switchroom-telegram"],
+        },
+      },
+    });
+
+    ensureMcpServersTrusted(agentDir, ["agent-config", "gdrive"]);
+
+    const project = readClaudeJson().projects[resolve(agentDir)];
+    expect(project.enabledMcpjsonServers).toEqual(
+      expect.arrayContaining([
+        "switchroom-telegram",
+        "agent-config",
+        "gdrive",
+      ]),
+    );
+    expect(project.enabledMcpjsonServers).toHaveLength(3);
+  });
+
+  it("creates the projects entry/array when missing", () => {
+    writeClaudeJson({ hasCompletedOnboarding: true });
+
+    ensureMcpServersTrusted(agentDir, ["gdrive"]);
+
+    const project = readClaudeJson().projects[resolve(agentDir)];
+    expect(project.enabledMcpjsonServers).toEqual(["gdrive"]);
+    expect(project.hasTrustDialogAccepted).toBe(true);
+    expect(project.allowedTools).toEqual([]);
+  });
+
+  it("skips silently when .claude.json is absent", () => {
+    // no writeClaudeJson() — file does not exist
+    expect(() =>
+      ensureMcpServersTrusted(agentDir, ["gdrive"]),
+    ).not.toThrow();
+    expect(existsSync(join(agentDir, ".claude", ".claude.json"))).toBe(false);
+  });
+
+  it("skips silently when .claude.json is unparseable", () => {
+    const claudeDir = join(agentDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, ".claude.json"), "{ not valid json");
+
+    expect(() =>
+      ensureMcpServersTrusted(agentDir, ["gdrive"]),
+    ).not.toThrow();
+  });
+});

--- a/src/setup/onboarding.ts
+++ b/src/setup/onboarding.ts
@@ -274,6 +274,66 @@ export function preTrustWorkspace(agentDir: string): void {
 }
 
 /**
+ * Ensure every scaffolded `.mcp.json` server is on Claude Code's
+ * per-project trust allowlist.
+ *
+ * Claude Code only loads project `.mcp.json` servers that are listed in
+ * `.claude.json` `projects[<absDir>].enabledMcpjsonServers`. `preTrustWorkspace`
+ * sets `hasTrustDialogAccepted` but never touches that array, so any
+ * server scaffolded AFTER original onboarding (gdrive, plus agent-config
+ * / hostd for non-original agents) is silently ignored — it never spawns
+ * as a Claude Code child. This unions `serverKeys` into that allowlist
+ * (idempotent), creating the project entry/array if missing and keeping
+ * `hasTrustDialogAccepted: true`.
+ *
+ * Same `.claude.json` path + project key (`resolve(agentDir)`) +
+ * skip-silently-if-absent contract as `preTrustWorkspace`. Call it from
+ * every `.mcp.json` write site with the keys of the object just written.
+ */
+export function ensureMcpServersTrusted(
+  agentDir: string,
+  serverKeys: string[],
+): void {
+  const configPath = join(agentDir, ".claude", ".claude.json");
+
+  if (!existsSync(configPath)) {
+    return;
+  }
+
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    const config = JSON.parse(raw);
+
+    if (!config.projects) {
+      config.projects = {};
+    }
+
+    const absDir = resolve(agentDir);
+    const project = config.projects[absDir] ?? {};
+    project.hasTrustDialogAccepted = true;
+    if (!Array.isArray(project.allowedTools)) {
+      project.allowedTools = [];
+    }
+
+    const existing = Array.isArray(project.enabledMcpjsonServers)
+      ? project.enabledMcpjsonServers
+      : [];
+    project.enabledMcpjsonServers = Array.from(
+      new Set([...existing, ...serverKeys]),
+    );
+    config.projects[absDir] = project;
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+  } catch {
+    // If we can't read/parse the config, skip silently (mirrors
+    // preTrustWorkspace).
+  }
+}
+
+/**
  * Create a minimal .claude config.json when no existing Claude installation
  * is available. The agent will need to complete onboarding via `switchroom agent attach`.
  */


### PR DESCRIPTION
## Summary

The actual root cause of the entire agent-Drive saga, found by reading Claude Code's own `.claude.json` + session transcript + process tree in a live agent container. Two scaffold-layer bugs; every prior fix (vault, OAuth, scope, launcher, uv, entrypoint, aiofile, `.mcp.json` wiring) was real and necessary downstream but the agent's Claude **never spawned the gdrive MCP** because of these:

**Bug A — no `env` block on the gdrive `.mcp.json` entry.** Claude Code spawns MCP servers with a *sanitized* env (NOT the parent/container env). `resolveGdriveMcpEntry()` emitted `{command,args}` with no `env`, so the launcher ran without `SWITCHROOM_CONFIG`/broker-socket/`HOME` and died instantly (`drive-mcp-launcher: No switchroom.yaml found`). **This is why every manual test passed but the real agent path never did** — manual runs inherited the ambient container env that masked it. Fix: `resolveGdriveMcpEntry` sets `entry.value.env` to the 6 vars, each a named constant byte-mirroring `src/agents/compose.ts emitAgentService` (reviewer verified line-for-line).

**Bug B — scaffolded servers never added to Claude's trust-allowlist.** Claude Code only loads project `.mcp.json` servers in `.claude.json` `projects[agentDir].enabledMcpjsonServers`. switchroom set `hasTrustDialogAccepted` but never that allowlist, so any server not approved at original onboarding (gdrive — and latently `agent-config`/`hostd` for non-original agents) was silently ignored. Fix: new `ensureMcpServersTrusted()` unions the just-written `.mcp.json` server keys into the allowlist, idempotent, called at **both** `.mcp.json` write sites (scaffoldAgent + reconcileAgent — the reconcile site is intentionally outside the if-changed guard so existing agents self-heal on `switchroom apply`).

Both proven end-to-end in a live container: with both applied, `claude → drive-mcp-launcher → uvx → workspace-mcp` runs as a stable child and the upstream MCP serves protocol (first-ever claude-spawned instance).

## Test plan
- [x] `npm run lint` clean
- [x] 16 tests: env-block pins all 6 keys/values + agentName threading; trust helper covers union/idempotent/missing-project/absent/unparseable
- [x] 666 src/agents|memory|cli|setup vitest pass, no regressions
- [x] Independent review APPROVE — 6 env values byte-match compose.ts; both write sites wired
- [ ] CI required checks
- [ ] Post-merge: host CLI rebuild → `switchroom update` regenerates `.mcp.json` (with env) + `.claude.json` (trust) → carrie's claude spawns gdrive through the real scaffold path (not manual stopgaps), survives reconcile

Host-side scaffold logic — no agent-image rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)