### PR TITLE
fix(drive-mcp): pin USER_GOOGLE_EMAIL to the seeded account (single-user identity)

### DIFF
--- a/src/cli/drive-mcp-launcher.test.ts
+++ b/src/cli/drive-mcp-launcher.test.ts
@@ -161,6 +161,7 @@ describe("buildChildEnv — strips --single-user-incompatible knobs", () => {
         WORKSPACE_MCP_SERVICE_ACCOUNT_FILE: "/sa2.json",
       },
       "/state/agent/google-workspace-mcp/credentials",
+      "pixsoul@gmail.com",
     );
     expect(env.WORKSPACE_MCP_CREDENTIALS_DIR).toBe(
       "/state/agent/google-workspace-mcp/credentials",
@@ -173,9 +174,27 @@ describe("buildChildEnv — strips --single-user-incompatible knobs", () => {
     expect(env.PATH).toBe("/usr/bin");
   });
 
+  it("pins USER_GOOGLE_EMAIL to the seeded account (single-user identity)", () => {
+    // Load-bearing: upstream single-user refuses to fall back to the
+    // seed when the agent's per-call user_google_email doesn't match;
+    // USER_GOOGLE_EMAIL makes core.server treat this address as THE
+    // single user. MUST equal the value writeSeedFile used.
+    const env = buildChildEnv({}, "/tmp/c", "pixsoul@gmail.com");
+    expect(env.USER_GOOGLE_EMAIL).toBe("pixsoul@gmail.com");
+  });
+
+  it("overrides any inherited USER_GOOGLE_EMAIL with the seeded account", () => {
+    const env = buildChildEnv(
+      { USER_GOOGLE_EMAIL: "stale@example.com" },
+      "/tmp/c",
+      "pixsoul@gmail.com",
+    );
+    expect(env.USER_GOOGLE_EMAIL).toBe("pixsoul@gmail.com");
+  });
+
   it("does not mutate the passed-in base env object", () => {
     const base = { MCP_ENABLE_OAUTH21: "1" };
-    buildChildEnv(base, "/tmp/c");
+    buildChildEnv(base, "/tmp/c", "pixsoul@gmail.com");
     expect(base.MCP_ENABLE_OAUTH21).toBe("1");
   });
 });

--- a/src/cli/drive-mcp-launcher.ts
+++ b/src/cli/drive-mcp-launcher.ts
@@ -208,16 +208,33 @@ export function buildUvxArgs(tier?: string): string[] {
 /**
  * Build the child-process environment for upstream. Starts from the
  * current env, points `WORKSPACE_MCP_CREDENTIALS_DIR` at the seed dir,
- * and DELETES the three env knobs that are incompatible with
- * `--single-user` (so an operator-set or inherited value can't silently
- * break the browserless path).
+ * pins `USER_GOOGLE_EMAIL` to the seeded account, and DELETES the env
+ * knobs that are incompatible with `--single-user` (so an operator-set
+ * or inherited value can't silently break the browserless path).
+ *
+ * `USER_GOOGLE_EMAIL` is load-bearing, not cosmetic. Upstream
+ * single-user resolves auth per tool call by the agent-supplied
+ * `user_google_email` arg and, when it doesn't match a seeded file,
+ * *refuses to fall back* — it drops to interactive OAuth instead
+ * (`get_credentials:951` "no credentials for requested user …; not
+ * falling back to another user" → port-8000 bind → fail). The agent's
+ * notion of "the user" (e.g. its own operator email) is unrelated to
+ * the Google account we seeded. Setting `USER_GOOGLE_EMAIL` makes
+ * `core.server` configure that address as THE single user and marks
+ * the per-call arg optional (`server.py:106`,
+ * `service_decorator.py:78`), so every call authenticates against the
+ * seed regardless of what the agent passes. It MUST be the exact same
+ * value handed to `writeSeedFile` (the broker's `accountEmail`) — same
+ * source ⇒ seed filename and single-user pin can never diverge.
  */
 export function buildChildEnv(
   baseEnv: NodeJS.ProcessEnv,
   credentialsDir: string,
+  accountEmail: string,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
   env.WORKSPACE_MCP_CREDENTIALS_DIR = credentialsDir;
+  env.USER_GOOGLE_EMAIL = accountEmail;
   // Incompatible with --single-user — see upstream. Strip unconditionally.
   delete env.MCP_ENABLE_OAUTH21;
   delete env.WORKSPACE_MCP_STATELESS_MODE;
@@ -489,7 +506,11 @@ export async function runDriveMcpLauncher(opts: {
   // wins over the config top-level tier.
   const tier = opts.tier ?? configSecrets.tier;
   const args = buildUvxArgs(tier);
-  const env = buildChildEnv(process.env, credentialsDir);
+  const env = buildChildEnv(
+    process.env,
+    credentialsDir,
+    brokerCreds.accountEmail,
+  );
 
   // Replace this process with upstream so Claude Code's MCP stdio
   // transport talks directly to it and signals/exit propagate. Node has


### PR DESCRIPTION
## Summary

- Layer-C fix for the Drive integration: agents could not use Drive even with valid seeded credentials.
- Upstream `google_workspace_mcp` `--single-user` resolves auth **per tool call** by the agent-supplied `user_google_email` arg. When that doesn't match the seeded `<email>.json` it *refuses to fall back* (`get_credentials:951` "no credentials for requested user …; not falling back to another user") and drops to interactive OAuth → port-8000 bind → fail. The agent's notion of "the user" (its own operator email, e.g. `me@kenthompson.com.au`) is unrelated to the Google account we seeded (`pixsoul@gmail.com`), so every Drive call failed.
- Fix: `buildChildEnv()` now sets `USER_GOOGLE_EMAIL` to the broker's `accountEmail` — the **exact same value** `writeSeedFile()` uses for the seed filename. Upstream then has `core.server` configure that address as THE single user and marks the per-call arg optional (`server.py:106`, `service_decorator.py:78`). Same source for both ⇒ seed filename and single-user pin can never diverge.

## Evidence

Proven in the live agent container: a launcher run with `USER_GOOGLE_EMAIL=pixsoul@gmail.com` set logs `INFO:core.server:Server instructions configured for user: pixsoul@gmail.com`; the run without it falls through to the per-call `me@kenthompson.com.au` and the port-8000 failure.

## Design contract

- **JTBD**: agents collaborate on shared docs via Drive (RFC E collab loop) — this unblocks it end-to-end.
- **Docs test**: no new user-facing surface; the pin is automatic and invisible.
- **Defaults test**: works on a fresh setup — the launcher always seeds one account and always runs `--single-user`, so the pin is unconditionally correct.
- **Consistency test**: single broker-sourced `accountEmail` feeds both seed + pin (no new config knob).

## Test plan

- [x] `npx vitest run src/cli/drive-mcp-launcher.test.ts` — 22/22 (incl. new happy-path + inherited-override assertions)
- [x] `tsc --noEmit` clean
- [x] Fresh separate-process review: APPROVE
- [ ] Post-merge: `switchroom update` regenerates Carrie's launcher path; verify a Drive tool call authenticates as the seeded account (no port-8000 fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)