### PR TITLE
fix(drive): reliability hardening — close the silent-failure class

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -40,7 +40,7 @@ RUN mkdir -p /tmp/tmux-shared
 # uv / uvx — required by the Google Workspace MCP launcher
 # (`switchroom drive-mcp-launcher`, RFC G). The launcher execs
 # `uvx --from git+https://github.com/taylorwilsdon/google_workspace_mcp.git@<SHA>
-# google-workspace-mcp --single-user`; without `uvx` on PATH the
+# --with aiofile==3.8.8 workspace-mcp --single-user`; without `uvx` on PATH the
 # launcher fails fast with exit 127 ("Executable not found in $PATH:
 # uvx") and the agent gets no Drive tools. Same pre-bake rationale as
 # playwright below: bake it into the image, version-pinned, instead of

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2172,6 +2172,14 @@ export function scaffoldAgent(
   // the MCP server definition from the project-level .mcp.json in the
   // working directory — NOT from settings.json mcpServers. Write it here
   // so the enhanced Telegram plugin can be launched as a dev channel.
+  //
+  // Captured here, applied to the trust allowlist a SECOND time after
+  // `.claude.json` is created (~`preTrustWorkspace` below). The in-block
+  // ensureMcpServersTrusted call is a silent no-op on a brand-new agent
+  // (`.claude.json` doesn't exist that early) — without the post-create
+  // pass a net-new agent's gdrive/agent-config/hostd servers are never
+  // trusted and Claude silently ignores them.
+  let mcpServerKeysToTrust: string[] | null = null;
   if (usesSwitchroomTelegramPlugin(agentConfig)) {
     const mcpJsonPath = join(agentDir, ".mcp.json");
     // The agent image (Dockerfile.agent) COPYs the plugin to a stable
@@ -2256,8 +2264,14 @@ export function scaffoldAgent(
     // hasTrustDialogAccepted but never enabledMcpjsonServers, so any
     // server scaffolded after original onboarding (gdrive, plus
     // agent-config/hostd for non-original agents) is silently ignored.
-    // Union every server we just wrote into the allowlist.
-    ensureMcpServersTrusted(agentDir, Object.keys(mcpServers));
+    // Union every server we just wrote into the allowlist. NOTE: on a
+    // brand-new agent `.claude.json` does not exist yet at this point —
+    // this call silently no-ops and the post-`preTrustWorkspace` pass
+    // below is what actually lands the trust. Kept here too because it
+    // is idempotent and covers the re-scaffold path where the file
+    // already exists.
+    mcpServerKeysToTrust = Object.keys(mcpServers);
+    ensureMcpServersTrusted(agentDir, mcpServerKeysToTrust);
   }
 
   // --- Render template-specific files ---
@@ -2436,6 +2450,19 @@ export function scaffoldAgent(
 
   // Pre-trust the agent's workspace directory
   preTrustWorkspace(agentDir);
+
+  // Now that `.claude.json` is guaranteed to exist (copyOnboardingState /
+  // createMinimalClaudeConfig + preTrustWorkspace just ran), re-apply the
+  // MCP trust allowlist. The in-block call during .mcp.json write is a
+  // silent no-op on a net-new agent (`.claude.json` absent that early),
+  // so without this pass a fresh agent's gdrive/agent-config/hostd
+  // servers are never added to enabledMcpjsonServers and Claude Code
+  // silently ignores them — the integration would only "work" because
+  // reconcileAgent re-trusts on the next restart. ensureMcpServersTrusted
+  // is idempotent; running it twice is safe.
+  if (mcpServerKeysToTrust) {
+    ensureMcpServersTrusted(agentDir, mcpServerKeysToTrust);
+  }
 
   // --- Memory index ---
   writeIfMissing(

--- a/src/cli/doctor-drive.test.ts
+++ b/src/cli/doctor-drive.test.ts
@@ -1,0 +1,202 @@
+/**
+ * doctor-drive — surfaces the Drive integration's silent-failure class.
+ *
+ * Each case pins a bug class that escaped to a live deploy precisely
+ * because nothing checked it up front:
+ *   - R1: in enabled_for[] but no per-agent account → broker
+ *     ACCOUNT_NOT_FOUND (the "1 of 9 agents work, no warning" finding)
+ *   - reverse: per-agent account but not in enabled_for[] → ACCESS_DENIED
+ *   - bug-8: .mcp.json gdrive entry missing its env block
+ *   - bug-9 / C1: gdrive not trusted in .claude.json
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { runDriveChecks, type DriveProbeDeps } from "./doctor-drive.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+function cfg(partial: Partial<SwitchroomConfig>): SwitchroomConfig {
+  return partial as unknown as SwitchroomConfig;
+}
+
+const GOOD_CLIENT = {
+  google_client_id: "cid.apps.googleusercontent.com",
+  google_client_secret: "GOCSPX-secret",
+} as SwitchroomConfig["google_workspace"];
+
+function statuses(rs: { name: string; status: string }[]) {
+  return rs.map((r) => `${r.status}:${r.name}`);
+}
+
+describe("runDriveChecks — Drive unused", () => {
+  it("returns [] when there is no google_accounts and no per-agent account", () => {
+    expect(runDriveChecks(cfg({ agents: { carrie: {} as never } }))).toEqual(
+      [],
+    );
+  });
+});
+
+describe("runDriveChecks — R1 config-matrix consistency", () => {
+  it("FAILS an agent in enabled_for[] with no per-agent google_workspace.account", () => {
+    const config = cfg({
+      google_workspace: GOOD_CLIENT,
+      google_accounts: { "a@gmail.com": { enabled_for: ["clerk", "carrie"] } },
+      agents: {
+        carrie: { google_workspace: { account: "a@gmail.com" } } as never,
+        clerk: {} as never, // in enabled_for[] but NOT matrixed
+      },
+    });
+    const rs = runDriveChecks(config, { existsSync: () => false });
+    const clerk = rs.find((r) => r.name.includes("clerk"));
+    expect(clerk?.status).toBe("fail");
+    expect(clerk?.detail).toContain("ACCOUNT_NOT_FOUND");
+    expect(clerk?.fix).toContain("google_workspace.account: a@gmail.com");
+    // carrie (correctly matrixed) is ok
+    expect(rs.find((r) => r.name.includes("carrie"))?.status).toBe("ok");
+  });
+
+  it("FAILS an agent that points at an account but isn't in its enabled_for[]", () => {
+    const config = cfg({
+      google_workspace: GOOD_CLIENT,
+      google_accounts: { "a@gmail.com": { enabled_for: ["carrie"] } },
+      agents: {
+        carrie: { google_workspace: { account: "a@gmail.com" } } as never,
+        ziggy: { google_workspace: { account: "a@gmail.com" } } as never,
+      },
+    });
+    const rs = runDriveChecks(config, { existsSync: () => false });
+    const ziggy = rs.find((r) => r.name.includes("ziggy"));
+    expect(ziggy?.status).toBe("fail");
+    expect(ziggy?.detail).toContain("ACCESS_DENIED");
+  });
+
+  it("FAILS an agent whose account has no google_accounts block at all", () => {
+    const config = cfg({
+      google_workspace: GOOD_CLIENT,
+      google_accounts: { "a@gmail.com": { enabled_for: [] } },
+      agents: {
+        finn: { google_workspace: { account: "ghost@gmail.com" } } as never,
+      },
+    });
+    const rs = runDriveChecks(config, { existsSync: () => false });
+    const finn = rs.find((r) => r.name.includes("finn"));
+    expect(finn?.status).toBe("fail");
+    expect(finn?.detail).toContain("no google_accounts['ghost@gmail.com']");
+  });
+});
+
+describe("runDriveChecks — OAuth client", () => {
+  it("FAILS when a matrixed agent exists but client_secret is unset", () => {
+    const config = cfg({
+      google_workspace: {
+        google_client_id: "cid",
+      } as SwitchroomConfig["google_workspace"],
+      google_accounts: { "a@gmail.com": { enabled_for: ["carrie"] } },
+      agents: {
+        carrie: { google_workspace: { account: "a@gmail.com" } } as never,
+      },
+    });
+    const rs = runDriveChecks(config, { existsSync: () => false });
+    const oauth = rs.find((r) => r.name.includes("OAuth client"));
+    expect(oauth?.status).toBe("fail");
+    expect(oauth?.detail).toContain("google_client_secret");
+  });
+
+  it("is ok when both client values are present", () => {
+    const config = cfg({
+      google_workspace: GOOD_CLIENT,
+      google_accounts: { "a@gmail.com": { enabled_for: ["carrie"] } },
+      agents: {
+        carrie: { google_workspace: { account: "a@gmail.com" } } as never,
+      },
+    });
+    const rs = runDriveChecks(config, { existsSync: () => false });
+    expect(rs.find((r) => r.name.includes("OAuth client"))?.status).toBe("ok");
+  });
+});
+
+describe("runDriveChecks — deployed scaffold wiring (bug-8 / bug-9)", () => {
+  const base = cfg({
+    google_workspace: GOOD_CLIENT,
+    google_accounts: { "a@gmail.com": { enabled_for: ["carrie"] } },
+    agents: {
+      carrie: { google_workspace: { account: "a@gmail.com" } } as never,
+    },
+  });
+
+  function fsFakes(files: Record<string, string>): DriveProbeDeps {
+    return {
+      agentsDir: "/agents",
+      existsSync: (p) => p === "/agents/carrie" || p in files,
+      readFileSync: (p) => {
+        if (!(p in files)) throw new Error(`ENOENT ${p}`);
+        return files[p];
+      },
+    };
+  }
+
+  it("FAILS when .mcp.json gdrive entry has no env block (bug-8)", () => {
+    const rs = runDriveChecks(
+      base,
+      fsFakes({
+        "/agents/carrie/.mcp.json": JSON.stringify({
+          mcpServers: { gdrive: { command: "x", args: [] } },
+        }),
+        "/agents/carrie/.claude/.claude.json": JSON.stringify({
+          projects: {
+            "/agents/carrie": { enabledMcpjsonServers: ["gdrive"] },
+          },
+        }),
+      }),
+    );
+    const w = rs.find((r) => r.name === "drive: carrie scaffold");
+    expect(w?.status).toBe("fail");
+    expect(w?.detail).toContain("no env block");
+  });
+
+  it("FAILS when gdrive is not trusted in .claude.json (bug-9 / C1)", () => {
+    const rs = runDriveChecks(
+      base,
+      fsFakes({
+        "/agents/carrie/.mcp.json": JSON.stringify({
+          mcpServers: { gdrive: { command: "x", args: [], env: { HOME: "/h" } } },
+        }),
+        "/agents/carrie/.claude/.claude.json": JSON.stringify({
+          projects: { "/agents/carrie": { enabledMcpjsonServers: [] } },
+        }),
+      }),
+    );
+    const w = rs.find((r) => r.name === "drive: carrie scaffold");
+    expect(w?.status).toBe("fail");
+    expect(w?.detail).toContain("enabledMcpjsonServers");
+  });
+
+  it("is ok when .mcp.json has gdrive+env AND .claude.json trusts it", () => {
+    const rs = runDriveChecks(
+      base,
+      fsFakes({
+        "/agents/carrie/.mcp.json": JSON.stringify({
+          mcpServers: { gdrive: { command: "x", args: [], env: { HOME: "/h" } } },
+        }),
+        "/agents/carrie/.claude/.claude.json": JSON.stringify({
+          projects: {
+            "/agents/carrie": { enabledMcpjsonServers: ["gdrive"] },
+          },
+        }),
+      }),
+    );
+    expect(
+      rs.find((r) => r.name === "drive: carrie scaffold")?.status,
+    ).toBe("ok");
+  });
+
+  it("WARNS (not fail) when the agent isn't scaffolded yet", () => {
+    const rs = runDriveChecks(base, {
+      agentsDir: "/agents",
+      existsSync: () => false,
+    });
+    expect(
+      rs.find((r) => r.name === "drive: carrie scaffold")?.status,
+    ).toBe("warn");
+  });
+});

--- a/src/cli/doctor-drive.ts
+++ b/src/cli/doctor-drive.ts
@@ -1,0 +1,347 @@
+/**
+ * Google Drive integration doctor checks (RFC G / RFC D / RFC E).
+ *
+ * The Drive integration shipped through ~10 production bugs, every one
+ * of which was a SILENT or DEFERRED failure: the misconfiguration
+ * produced no error at the layer that was wrong; it surfaced much later
+ * as an opaque "agent has no Drive tools" / "Drive's blocked" symptom,
+ * invisible to the operator until an agent was actually asked to use
+ * Drive. `doctor` had ZERO Drive coverage, so none of it was catchable
+ * up front.
+ *
+ * These probes convert that whole failure class into one upfront,
+ * operator-visible section. Each check maps directly to a bug class
+ * that escaped:
+ *
+ *   1. config matrix      — `google_accounts.<acct>.enabled_for[]` and
+ *      per-agent `google_workspace.account` MUST agree, bidirectionally.
+ *      Being in `enabled_for[]` is necessary-but-NOT-sufficient: the
+ *      broker selects the account from the per-agent field and only
+ *      then enforces the ACL, so an agent in `enabled_for[]` without
+ *      the matching per-agent account fails `ACCOUNT_NOT_FOUND` and an
+ *      agent with the account but not in `enabled_for[]` fails
+ *      `ACCESS_DENIED`. This was the "works for 1 of 9 agents, no
+ *      warning" finding.
+ *   2. OAuth client       — a correctly-matrixed agent still can't
+ *      start the MCP if `google_workspace.google_client_id/_secret`
+ *      is unset (the launcher exits 1 — historically opaque).
+ *   3. scaffold wiring     — for each Drive-enabled agent that HAS been
+ *      scaffolded: the written `.mcp.json` must carry a `gdrive` entry
+ *      WITH its sanitized env block (bug: Claude spawns MCP servers
+ *      with a stripped env; without the block the launcher can't reach
+ *      switchroom.yaml/the broker), and `.claude.json` must TRUST
+ *      `gdrive` (bug: Claude silently ignores un-allowlisted .mcp.json
+ *      servers — the C1 scaffold-ordering defect lived here).
+ *
+ * Filesystem access is dependency-injected so the unit tests drive
+ * every branch without a real scaffold tree (mirrors
+ * `doctor-auth-broker.ts`).
+ */
+
+import {
+  existsSync as realExistsSync,
+  readFileSync as realReadFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+
+import { resolveAgentsDir } from "../config/loader.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+export type CheckStatus = "ok" | "warn" | "fail";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/** FS injection seam. Tests pass fakes; production uses real syscalls. */
+export interface DriveProbeDeps {
+  /** Defaults to `resolveAgentsDir(config)`, resolved lazily + guarded. */
+  agentsDir?: string;
+  existsSync?: (p: string) => boolean;
+  readFileSync?: (p: string) => string;
+}
+
+interface ResolvedDeps {
+  /** undefined when the agents dir can't be resolved (no switchroom block). */
+  agentsDir: string | undefined;
+  existsSync: (p: string) => boolean;
+  readFileSync: (p: string) => string;
+}
+
+function resolveDeps(
+  config: SwitchroomConfig,
+  deps: DriveProbeDeps,
+): ResolvedDeps {
+  let agentsDir = deps.agentsDir;
+  if (agentsDir === undefined) {
+    // Lazy + guarded: resolveAgentsDir reads config.switchroom.agents_dir
+    // and throws if the block is absent. Doctor must never throw — a
+    // missing agents dir downgrades the scaffold check to a warn.
+    try {
+      agentsDir = resolveAgentsDir(config);
+    } catch {
+      agentsDir = undefined;
+    }
+  }
+  return {
+    agentsDir,
+    existsSync: deps.existsSync ?? ((p) => realExistsSync(p)),
+    readFileSync:
+      deps.readFileSync ?? ((p) => realReadFileSync(p, "utf-8")),
+  };
+}
+
+/** Per-agent google_workspace.account, normalized the way the schema does. */
+function agentAccount(
+  config: SwitchroomConfig,
+  name: string,
+): string | undefined {
+  const raw = config.agents?.[name]?.google_workspace?.account;
+  return typeof raw === "string" && raw.length > 0
+    ? raw.trim().toLowerCase()
+    : undefined;
+}
+
+/** True if a top-level OAuth client value is present (literal or vault: ref). */
+function clientValuePresent(v: unknown): boolean {
+  return typeof v === "string" && v.trim().length > 0;
+}
+
+/**
+ * Check 1 — bidirectional config-matrix consistency. The single
+ * highest-value Drive probe: it is the difference between "config looks
+ * like N agents are enabled" and "N agents actually work".
+ */
+function checkConfigMatrix(config: SwitchroomConfig): CheckResult[] {
+  const accounts = config.google_accounts;
+  if (!accounts || Object.keys(accounts).length === 0) {
+    return [
+      {
+        name: "drive: google_accounts configured",
+        status: "ok",
+        detail: "no google_accounts block — Drive integration not in use",
+      },
+    ];
+  }
+
+  const results: CheckResult[] = [];
+
+  // Forward: every agent listed in an account's enabled_for[] must point
+  // its per-agent google_workspace.account back at that account.
+  for (const [acct, entry] of Object.entries(accounts)) {
+    const enabledFor = entry?.enabled_for ?? [];
+    for (const name of enabledFor) {
+      const have = agentAccount(config, name);
+      if (have === acct) {
+        results.push({
+          name: `drive: ${name} ↔ ${acct}`,
+          status: "ok",
+          detail: "enabled_for[] and google_workspace.account agree",
+        });
+      } else {
+        results.push({
+          name: `drive: ${name} ↔ ${acct}`,
+          status: "fail",
+          detail:
+            have === undefined
+              ? `'${name}' is in google_accounts['${acct}'].enabled_for[] but has no agents.${name}.google_workspace.account — the broker rejects it (ACCOUNT_NOT_FOUND) and Drive silently never works for this agent`
+              : `'${name}' is in enabled_for['${acct}'] but its google_workspace.account is '${have}' — mismatch; the broker will not return '${acct}' creds for it`,
+          fix: `set agents.${name}.google_workspace.account: ${acct} in switchroom.yaml, then \`switchroom update\``,
+        });
+      }
+    }
+  }
+
+  // Reverse: an agent that points at an account but isn't in its
+  // enabled_for[] fails ACCESS_DENIED at the broker.
+  for (const name of Object.keys(config.agents ?? {})) {
+    const acct = agentAccount(config, name);
+    if (!acct) continue;
+    const entry = accounts[acct];
+    if (!entry) {
+      results.push({
+        name: `drive: ${name} → ${acct}`,
+        status: "fail",
+        detail: `agents.${name}.google_workspace.account is '${acct}' but there is no google_accounts['${acct}'] block`,
+        fix: `add a google_accounts['${acct}'] entry with enabled_for: [${name}], or remove the per-agent account`,
+      });
+    } else if (!(entry.enabled_for ?? []).includes(name)) {
+      results.push({
+        name: `drive: ${name} → ${acct}`,
+        status: "fail",
+        detail: `agents.${name}.google_workspace.account is '${acct}' but '${name}' is not in that account's enabled_for[] — the broker denies it (ACCESS_DENIED)`,
+        fix: `add '${name}' to google_accounts['${acct}'].enabled_for[] in switchroom.yaml`,
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Check 2 — OAuth client presence. Only meaningful if at least one
+ * agent is correctly matrixed (otherwise Drive isn't in use).
+ */
+function checkOAuthClient(
+  config: SwitchroomConfig,
+  anyDriveAgent: boolean,
+): CheckResult[] {
+  if (!anyDriveAgent) return [];
+  const gw = config.google_workspace;
+  const idOk = clientValuePresent(gw?.google_client_id);
+  const secretOk = clientValuePresent(gw?.google_client_secret);
+  if (idOk && secretOk) {
+    return [
+      {
+        name: "drive: OAuth client configured",
+        status: "ok",
+        detail: "google_client_id + google_client_secret set",
+      },
+    ];
+  }
+  return [
+    {
+      name: "drive: OAuth client configured",
+      status: "fail",
+      detail: `google_workspace.${!idOk ? "google_client_id" : "google_client_secret"} is unset/empty — the launcher exits 1 before spawning the MCP`,
+      fix: "set google_workspace.google_client_id and google_client_secret (literal or vault: ref) in switchroom.yaml",
+    },
+  ];
+}
+
+/**
+ * Check 3 — deployed scaffold wiring for each correctly-matrixed agent
+ * that has been scaffolded. Surfaces bug-8 (missing env block) and
+ * bug-9 / the C1 ordering defect (gdrive not in enabledMcpjsonServers)
+ * in the actual on-disk state, not just the config.
+ */
+function checkScaffoldWiring(
+  config: SwitchroomConfig,
+  driveAgents: string[],
+  d: ResolvedDeps,
+): CheckResult[] {
+  const results: CheckResult[] = [];
+  if (d.agentsDir === undefined) {
+    return [
+      {
+        name: "drive: scaffold wiring",
+        status: "warn",
+        detail:
+          "could not resolve the agents directory (no switchroom block) — skipped scaffold wiring check",
+      },
+    ];
+  }
+  for (const name of driveAgents) {
+    const agentDir = resolve(d.agentsDir, name);
+    if (!d.existsSync(agentDir)) {
+      results.push({
+        name: `drive: ${name} scaffold`,
+        status: "warn",
+        detail: `${agentDir} not scaffolded yet — run \`switchroom apply\``,
+      });
+      continue;
+    }
+
+    // .mcp.json must carry gdrive WITH a non-empty env block.
+    const mcpPath = join(agentDir, ".mcp.json");
+    let mcpOk = false;
+    let mcpDetail = "no .mcp.json";
+    if (d.existsSync(mcpPath)) {
+      try {
+        const mcp = JSON.parse(d.readFileSync(mcpPath));
+        const g = mcp?.mcpServers?.gdrive;
+        if (!g) {
+          mcpDetail = ".mcp.json has no gdrive server";
+        } else if (!g.env || Object.keys(g.env).length === 0) {
+          mcpDetail =
+            "gdrive entry has no env block — Claude spawns MCP with a sanitized env; the launcher can't reach switchroom.yaml/the broker (bug-8 class)";
+        } else {
+          mcpOk = true;
+        }
+      } catch {
+        mcpDetail = ".mcp.json is unparseable";
+      }
+    }
+
+    // .claude.json must TRUST gdrive under the agent's project key.
+    const claudeJsonPath = join(agentDir, ".claude", ".claude.json");
+    let trustOk = false;
+    let trustDetail = "no .claude/.claude.json";
+    if (d.existsSync(claudeJsonPath)) {
+      try {
+        const cj = JSON.parse(d.readFileSync(claudeJsonPath));
+        const proj = cj?.projects?.[resolve(agentDir)];
+        const enabled: unknown = proj?.enabledMcpjsonServers;
+        if (Array.isArray(enabled) && enabled.includes("gdrive")) {
+          trustOk = true;
+        } else {
+          trustDetail =
+            "gdrive not in projects[].enabledMcpjsonServers — Claude silently ignores the un-allowlisted server (bug-9 / scaffold-ordering class)";
+        }
+      } catch {
+        trustDetail = ".claude.json is unparseable";
+      }
+    }
+
+    if (mcpOk && trustOk) {
+      results.push({
+        name: `drive: ${name} scaffold`,
+        status: "ok",
+        detail: "gdrive wired in .mcp.json (with env) and trusted in .claude.json",
+      });
+    } else {
+      results.push({
+        name: `drive: ${name} scaffold`,
+        status: "fail",
+        detail: !mcpOk ? mcpDetail : trustDetail,
+        fix: "`switchroom agent restart " + name + "` (reconcile regenerates .mcp.json + re-trusts); if it persists, this is a scaffold bug — report it",
+      });
+    }
+  }
+  return results;
+}
+
+/**
+ * Run all Drive checks. Returns [] when Drive is entirely unused (no
+ * google_accounts AND no agent with google_workspace.account) so the
+ * section stays silent on installs that don't use Drive.
+ */
+export function runDriveChecks(
+  config: SwitchroomConfig,
+  deps: DriveProbeDeps = {},
+): CheckResult[] {
+  const accounts = config.google_accounts;
+  const anyAgentAccount = Object.keys(config.agents ?? {}).some(
+    (n) => agentAccount(config, n) !== undefined,
+  );
+  const accountsConfigured =
+    !!accounts && Object.keys(accounts).length > 0;
+  if (!accountsConfigured && !anyAgentAccount) {
+    return [];
+  }
+
+  const d = resolveDeps(config, deps);
+  const results: CheckResult[] = [];
+
+  const matrix = checkConfigMatrix(config);
+  results.push(...matrix);
+
+  // An agent is "Drive-enabled" only when BOTH sides of the matrix
+  // agree — that's exactly the set the launcher will succeed for.
+  const driveAgents = Object.keys(config.agents ?? {}).filter((name) => {
+    const acct = agentAccount(config, name);
+    return (
+      !!acct &&
+      !!accounts?.[acct] &&
+      (accounts[acct].enabled_for ?? []).includes(name)
+    );
+  });
+
+  results.push(...checkOAuthClient(config, driveAgents.length > 0));
+  results.push(...checkScaffoldWiring(config, driveAgents, d));
+
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -26,6 +26,7 @@ import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
 import { probeHindsight } from "../memory/hindsight.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
+import { runDriveChecks } from "./doctor-drive.js";
 
 /**
  * Result of a single doctor check.
@@ -2172,6 +2173,7 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Agents", results: checkAgents(config, configPath) },
           { title: "Docker (Phase 1a)", results: runDockerSection(config) },
           { title: "Auth Broker", results: runAuthBrokerChecks(config) },
+          { title: "Google Drive", results: runDriveChecks(config) },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath) },
         ];
 

--- a/src/cli/drive-mcp-launcher.test.ts
+++ b/src/cli/drive-mcp-launcher.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  AIOFILE_PIN,
   buildChildEnv,
   buildSeedCredentials,
   buildUvxArgs,
@@ -54,14 +55,26 @@ describe("buildSeedCredentials — exact upstream shape", () => {
     expect(seed.scopes).toEqual(["scope.a", "scope.b", "scope.c"]);
   });
 
-  it("yields an empty scopes array for an empty scope string", () => {
-    const seed = buildSeedCredentials({
-      refreshToken: "rt",
-      clientId: "cid",
-      clientSecret: "sec",
-      scope: "",
-    });
-    expect(seed.scopes).toEqual([]);
+  it("throws on an empty/whitespace scope string (fail loud, never seed scopeless)", () => {
+    // A scopeless seed starts upstream with zero Drive scopes — every
+    // tool call 403s downstream. Consistent with the other required-
+    // field guards; the broker should never return an empty scope.
+    expect(() =>
+      buildSeedCredentials({
+        refreshToken: "rt",
+        clientId: "cid",
+        clientSecret: "sec",
+        scope: "",
+      }),
+    ).toThrow(/scope is required/);
+    expect(() =>
+      buildSeedCredentials({
+        refreshToken: "rt",
+        clientId: "cid",
+        clientSecret: "sec",
+        scope: "   \t  ",
+      }),
+    ).toThrow(/scope is required/);
   });
 
   it("injects the client secret verbatim (not from the broker schema)", () => {
@@ -123,7 +136,7 @@ describe("buildUvxArgs — pinned upstream + --single-user", () => {
       // in-container; ==1.20.4 and latest PyPI crash identically). Must
       // sit BEFORE the entrypoint positional (it's a uvx option).
       "--with",
-      "aiofile==3.8.8",
+      AIOFILE_PIN,
       // MUST be `workspace-mcp` — the upstream package provides only
       // `workspace-mcp` and `workspace-cli`. The original
       // `google-workspace-mcp` made uvx exit "executable not provided
@@ -136,7 +149,7 @@ describe("buildUvxArgs — pinned upstream + --single-user", () => {
     // Regression guard for the aiofile landmine — order matters
     // (uvx options precede the entrypoint).
     expect(args.indexOf("--with")).toBeLessThan(args.indexOf("workspace-mcp"));
-    expect(args).toContain("aiofile==3.8.8");
+    expect(args).toContain(AIOFILE_PIN);
   });
 
   it("appends --tool-tier <tier> after --single-user when a tier is given", () => {

--- a/src/cli/drive-mcp-launcher.ts
+++ b/src/cli/drive-mcp-launcher.ts
@@ -145,6 +145,18 @@ export function buildSeedCredentials(
     .split(/\s+/)
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
+  if (scopes.length === 0) {
+    // Fail loud, consistent with the other required-field guards above.
+    // A scopeless seed starts upstream with zero Drive scopes — every
+    // tool call then 403s downstream, a deferred/opaque symptom with no
+    // signal at the layer that was actually wrong. The broker should
+    // never return an empty scope string for a Google credential; if it
+    // does, that's the bug to surface, not paper over.
+    throw new Error(
+      "buildSeedCredentials: scope is required (empty scope string would " +
+        "seed upstream with zero Drive scopes — every tool call 403s)",
+    );
+  }
   return {
     token: null,
     refresh_token: input.refreshToken,
@@ -187,7 +199,9 @@ export function buildSeedCredentials(
 // validated end-to-end in a real agent container: reaches "Starting
 // MCP server 'google_workspace' (stdio)". Bump in lockstep with the
 // upstream SHA + a re-test of the import+startup path.
-const AIOFILE_PIN = "aiofile==3.8.8";
+// Exported so the test imports the single source of truth instead of
+// re-typing the literal — a bump here can't silently pass a stale test.
+export const AIOFILE_PIN = "aiofile==3.8.8";
 
 export function buildUvxArgs(tier?: string): string[] {
   const args = [

--- a/src/setup/onboarding.ts
+++ b/src/setup/onboarding.ts
@@ -327,9 +327,21 @@ export function ensureMcpServersTrusted(
       encoding: "utf-8",
       mode: 0o600,
     });
-  } catch {
-    // If we can't read/parse the config, skip silently (mirrors
-    // preTrustWorkspace).
+  } catch (err) {
+    // The absent-file case is handled by the early return above and is
+    // a legitimate transient during scaffold (the first call runs
+    // before `.claude.json` exists; a later pass re-applies). But a
+    // present-yet-unreadable/unparseable/unwritable `.claude.json`
+    // silently dropping the trust allowlist is exactly the kind of
+    // invisible failure that made the Drive integration so hard to
+    // debug — the only symptom is "agent has no Drive tools". Warn so
+    // it is at least visible without failing the whole scaffold.
+    console.warn(
+      `  WARNING: could not update MCP trust allowlist in ${configPath} ` +
+        `(${err instanceof Error ? err.message : String(err)}). ` +
+        `Scaffolded MCP servers (gdrive, agent-config, hostd) may be ` +
+        `silently ignored by Claude Code for this agent.`,
+    );
   }
 }
 

--- a/tests/scaffold.fresh-agent-mcp-trust.test.ts
+++ b/tests/scaffold.fresh-agent-mcp-trust.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type {
+  AgentConfig,
+  SwitchroomConfig,
+  TelegramConfig,
+} from "../src/config/schema.js";
+
+/**
+ * Regression for the C1 ordering defect (Drive reliability audit,
+ * 2026-05-16). In `scaffoldAgent`, `.mcp.json` is written and
+ * `ensureMcpServersTrusted` is called BEFORE `.claude.json` is created
+ * (copyOnboardingState / createMinimalClaudeConfig + preTrustWorkspace
+ * run ~150 lines later). `ensureMcpServersTrusted` is
+ * skip-silently-if-`.claude.json`-absent, so on a BRAND-NEW agent the
+ * in-block call no-ops and `gdrive` (plus agent-config/hostd) is never
+ * added to `enabledMcpjsonServers` → Claude Code silently ignores the
+ * server → "agent has no Drive tools". The bug was masked in production
+ * only because `reconcileAgent` re-trusts on every restart, and masked
+ * in tests because the existing suites either re-scaffold (so
+ * `.claude.json` exists on the 2nd pass) or pre-write `.claude.json`.
+ *
+ * This test exercises the TRUE net-new path: HOME points at an empty
+ * dir so `findExistingClaudeJson()` returns null and scaffold takes the
+ * `createMinimalClaudeConfig` branch — i.e. `.claude.json` genuinely
+ * does not exist until late in scaffold. It must fail pre-fix and pass
+ * post-fix (the post-`preTrustWorkspace` idempotent re-trust pass).
+ */
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+describe("scaffoldAgent: net-new agent trusts .mcp.json servers (C1)", () => {
+  let agentsDir: string;
+  let fakeHome: string;
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    agentsDir = mkdtempSync(join(tmpdir(), "switchroom-c1-agents-"));
+    // Empty HOME → findExistingClaudeJson() finds nothing → scaffold
+    // takes the createMinimalClaudeConfig path: the genuine net-new
+    // agent topology where .claude.json does not exist early.
+    fakeHome = mkdtempSync(join(tmpdir(), "switchroom-c1-home-"));
+    savedHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    rmSync(agentsDir, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it("adds gdrive to enabledMcpjsonServers on first scaffold (no prior .claude.json)", () => {
+    const name = "fresh-drive-agent";
+    const account = "pixsoul@gmail.com";
+    const agentConfig = makeAgentConfig({
+      google_workspace: { account },
+    } as Partial<AgentConfig>);
+    const switchroomConfig = {
+      switchroom: {
+        version: 1,
+        agents_dir: "~/.switchroom/agents",
+        skills_dir: "~/.switchroom/skills",
+      },
+      telegram: telegramConfig,
+      agents: { [name]: agentConfig },
+      google_accounts: { [account]: { enabled_for: [name] } },
+      google_workspace: { tier: "extended" },
+    } as unknown as SwitchroomConfig;
+
+    const res = scaffoldAgent(
+      name,
+      agentConfig,
+      agentsDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+
+    const claudeJsonPath = join(res.agentDir, ".claude", ".claude.json");
+    expect(existsSync(claudeJsonPath)).toBe(true);
+
+    const cfg = JSON.parse(readFileSync(claudeJsonPath, "utf-8"));
+    const project = cfg.projects?.[resolve(res.agentDir)];
+    expect(project).toBeDefined();
+    expect(project.hasTrustDialogAccepted).toBe(true);
+    expect(Array.isArray(project.enabledMcpjsonServers)).toBe(true);
+
+    // The core C1 assertion: gdrive must be trusted after a SINGLE
+    // scaffold of a brand-new agent — no reconcile/restart papering
+    // over it.
+    expect(project.enabledMcpjsonServers).toContain("gdrive");
+    // The other scaffolded servers ride the same trust pass; assert one
+    // to pin that the whole written set is unioned, not just gdrive.
+    expect(project.enabledMcpjsonServers).toContain("switchroom-telegram");
+
+    // And the .mcp.json that was written must actually contain gdrive
+    // (guards against the test passing because gdrive was never emitted).
+    const mcp = JSON.parse(
+      readFileSync(join(res.agentDir, ".mcp.json"), "utf-8"),
+    );
+    expect(Object.keys(mcp.mcpServers)).toContain("gdrive");
+  });
+});

--- a/tests/scaffold.mcp-json-builder-parity.test.ts
+++ b/tests/scaffold.mcp-json-builder-parity.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent, reconcileAgent } from "../src/agents/scaffold.js";
+import type {
+  AgentConfig,
+  SwitchroomConfig,
+  TelegramConfig,
+} from "../src/config/schema.js";
+
+/**
+ * H2 drift guard (Drive reliability audit, 2026-05-16). `scaffoldAgent`
+ * and `reconcileAgent` build the project `.mcp.json` `mcpServers` object
+ * with two INDEPENDENT literal copies. The `gdrive` entry is single-
+ * sourced via `resolveGdriveMcpEntry`, but the surrounding servers
+ * (switchroom-telegram, agent-config, hostd) are hand-duplicated — a
+ * future edit to one builder only would silently diverge scaffold-vs-
+ * reconcile output, exactly the bug-4/bug-8 class (the .mcp.json Claude
+ * actually loads no longer matching what scaffold intended).
+ *
+ * This pins byte-identical output for a representative Drive-enabled
+ * config across both builders. If it ever fails, the two builders have
+ * drifted and must be reconciled (ideally collapsed into one shared
+ * `buildMcpServersObject()` — tracked follow-up).
+ */
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+describe("scaffoldAgent vs reconcileAgent: .mcp.json builder parity (H2)", () => {
+  let agentsDir: string;
+
+  beforeEach(() => {
+    agentsDir = mkdtempSync(join(tmpdir(), "switchroom-mcp-parity-"));
+  });
+
+  afterEach(() => {
+    rmSync(agentsDir, { recursive: true, force: true });
+  });
+
+  it("emits a byte-identical .mcp.json from scaffold and from reconcile", () => {
+    const name = "parity-agent";
+    const account = "pixsoul@gmail.com";
+    const agentConfig = makeAgentConfig({
+      google_workspace: { account },
+    } as Partial<AgentConfig>);
+    const switchroomConfig = {
+      switchroom: {
+        version: 1,
+        agents_dir: "~/.switchroom/agents",
+        skills_dir: "~/.switchroom/skills",
+      },
+      telegram: telegramConfig,
+      agents: { [name]: agentConfig },
+      google_accounts: { [account]: { enabled_for: [name] } },
+      google_workspace: { tier: "extended" },
+    } as unknown as SwitchroomConfig;
+
+    const res = scaffoldAgent(
+      name,
+      agentConfig,
+      agentsDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+    const mcpPath = join(res.agentDir, ".mcp.json");
+    const afterScaffold = readFileSync(mcpPath, "utf-8");
+
+    // Sanity: the representative config must actually exercise gdrive +
+    // the hand-duplicated siblings, else the parity assertion is vacuous.
+    const parsed = JSON.parse(afterScaffold);
+    expect(Object.keys(parsed.mcpServers)).toContain("gdrive");
+    expect(Object.keys(parsed.mcpServers)).toContain("switchroom-telegram");
+
+    reconcileAgent(
+      name,
+      agentConfig,
+      agentsDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+    const afterReconcile = readFileSync(mcpPath, "utf-8");
+
+    expect(afterReconcile).toBe(afterScaffold);
+  });
+});


### PR DESCRIPTION
## Summary

Post-ship reliability audit of the Google Drive integration (which shipped through ~10 production bugs, every one a **silent/deferred failure**). An independent reviewer + a runtime fleet probe found the pattern still live. This closes it.

- **C1 (CRITICAL):** `scaffoldAgent` trusted `.mcp.json` servers *before* `.claude.json` exists → on a net-new agent gdrive is never added to `enabledMcpjsonServers` and Claude silently ignores it (masked in prod only by reconcile-on-restart). Fixed with an idempotent post-`preTrustWorkspace` re-trust pass + a regression test that scaffolds a true net-new agent (fails on the pre-fix tree, passes here).
- **R1/R2 (CRITICAL/HIGH):** `doctor` had **zero** Drive coverage, so the "config lists 9 agents but only 1 works" footgun (`enabled_for[]` is necessary-but-not-sufficient — the broker selects the account from per-agent `google_workspace.account` then enforces the ACL) was invisible until an agent was asked to use Drive. New `Google Drive` doctor section: bidirectional config-matrix consistency + OAuth-client presence + per-agent deployed scaffold wiring — the check that would have caught the whole saga.
- **M1/M2/M3/L2/H2:** stale Dockerfile comment (re-seeds bug-6); `AIOFILE_PIN` single-sourced into the test; `ensureMcpServersTrusted` warns on a present-but-unreadable `.claude.json` (absent stays silent — legitimately expected mid-scaffold); `buildSeedCredentials` fails loud on an empty scope string; byte-equality guard pinning the two independent `.mcp.json` builders.

**Out of scope (deliberately, to avoid over-engineering):** broker write-back of a rotated refresh token (RFC-level; doctor surfaces the symptom), the `.mcp.json` builder extraction refactor (the equality test gives the safety without the blast radius), the `writeSeedFile` TOCTOU (benign in the single-account model).

## Design contract

- **JTBD:** agents collaborate on shared Drive docs (RFC E). This makes the integration *reliably* usable, not Carrie-only.
- **Docs/Defaults/Consistency:** the doctor section IS the docs-test answer for Drive (operator sees misconfig up front, zero config); fixes cite exact YAML keys; mirrors the `doctor-auth-broker` section shape.

## Test plan

- [x] C1 regression fails on unfixed `upstream/main`, passes here (verified on both trees by the reviewer)
- [x] `npm run lint` clean (incl. `check-bun-test-imports`)
- [x] 109/109 tests across 11 files (doctor-drive, launcher, setup, scaffold suites)
- [x] Independent fresh-process review: APPROVE
- [ ] Post-merge: `switchroom update` → `switchroom doctor` shows the new Google Drive section flagging the 8 misconfigured agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)