### PR TITLE
fix(drive): doctor EACCES false-positive + bump pins to fixed upstream + executable pin-regression

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -40,7 +40,9 @@ RUN mkdir -p /tmp/tmux-shared
 # uv / uvx — required by the Google Workspace MCP launcher
 # (`switchroom drive-mcp-launcher`, RFC G). The launcher execs
 # `uvx --from git+https://github.com/taylorwilsdon/google_workspace_mcp.git@<SHA>
-# --with aiofile==3.8.8 workspace-mcp --single-user`; without `uvx` on PATH the
+# --refresh-package aiofile --with aiofile==<pin> workspace-mcp --single-user`
+# (exact SHA/pin are single-sourced in src/, deliberately not repeated
+# here so this comment can't rot on a bump); without `uvx` on PATH the
 # launcher fails fast with exit 127 ("Executable not found in $PATH:
 # uvx") and the agent gets no Drive tools. Same pre-bake rationale as
 # playwright below: bake it into the image, version-pinned, instead of

--- a/src/cli/doctor-drive.test.ts
+++ b/src/cli/doctor-drive.test.ts
@@ -199,4 +199,52 @@ describe("runDriveChecks — deployed scaffold wiring (bug-8 / bug-9)", () => {
       rs.find((r) => r.name === "drive: carrie scaffold")?.status,
     ).toBe("warn");
   });
+
+  // Regression for the #1368 doctor false-positive: in the canonical
+  // docker topology the scaffold files are agent-UID-owned 0600 and
+  // `doctor` runs as the host operator → EACCES. That must read as a
+  // single honest "unverifiable from host" WARN, never a `fail`
+  // (the original code mislabeled EACCES as ".mcp.json is unparseable"
+  // and failed all 9 agents on a perfectly healthy fleet).
+  it("WARNS (not fail) when scaffold files are host-unreadable (EACCES)", () => {
+    const rs = runDriveChecks(base, {
+      agentsDir: "/agents",
+      existsSync: (p) =>
+        p === "/agents/carrie" ||
+        p === "/agents/carrie/.mcp.json" ||
+        p === "/agents/carrie/.claude/.claude.json",
+      readFileSync: () => {
+        throw Object.assign(new Error("EACCES: permission denied"), {
+          code: "EACCES",
+        });
+      },
+    });
+    const w = rs.find((r) => r.name === "drive: carrie scaffold");
+    expect(w?.status).toBe("warn");
+    expect(w?.detail).toContain("unverifiable from the host");
+    // Crucially: nothing in the section is a `fail` purely because the
+    // host can't read agent-UID-owned files.
+    expect(rs.filter((r) => r.status === "fail")).toEqual([]);
+  });
+
+  it("FAILS when a readable .mcp.json is genuinely corrupt (not EACCES)", () => {
+    const rs = runDriveChecks(base, {
+      agentsDir: "/agents",
+      existsSync: (p) =>
+        p === "/agents/carrie" ||
+        p === "/agents/carrie/.mcp.json" ||
+        p === "/agents/carrie/.claude/.claude.json",
+      readFileSync: (p) =>
+        p.endsWith(".mcp.json")
+          ? "{ this is not json"
+          : JSON.stringify({
+              projects: {
+                "/agents/carrie": { enabledMcpjsonServers: ["gdrive"] },
+              },
+            }),
+    });
+    const w = rs.find((r) => r.name === "drive: carrie scaffold");
+    expect(w?.status).toBe("fail");
+    expect(w?.detail).toContain("corrupt");
+  });
 });

--- a/src/cli/doctor-drive.ts
+++ b/src/cli/doctor-drive.ts
@@ -245,45 +245,63 @@ function checkScaffoldWiring(
       continue;
     }
 
-    // .mcp.json must carry gdrive WITH a non-empty env block.
+    // Read both scaffold artifacts. In the canonical docker topology
+    // these are mode-0600 files owned by the per-agent UID, while
+    // `doctor` runs as the host operator — so the host genuinely
+    // cannot read them (EACCES). That is NOT a scaffold failure: the
+    // agent process reads them fine. Mirror the doctor-auth-broker
+    // "unverifiable from host" contract — one honest warn per agent —
+    // rather than crying a false `fail`. Only a file we COULD read but
+    // that is corrupt / mis-wired is a real `fail`.
     const mcpPath = join(agentDir, ".mcp.json");
+    const claudeJsonPath = join(agentDir, ".claude", ".claude.json");
+
+    const mcpRead = readJson(d, mcpPath);
+    const trustRead = readJson(d, claudeJsonPath);
+
+    if (mcpRead.kind === "unreadable" || trustRead.kind === "unreadable") {
+      results.push({
+        name: `drive: ${name} scaffold`,
+        status: "warn",
+        detail:
+          "scaffold files are agent-UID-owned (mode 0600) — unverifiable from the host operator; the agent process reads them fine. Verify in-container if needed: `docker exec switchroom-" +
+          name +
+          " sh -lc 'python3 -m json.tool /state/agent/.mcp.json >/dev/null && echo ok'`",
+      });
+      continue;
+    }
+
+    // .mcp.json must carry gdrive WITH a non-empty env block.
     let mcpOk = false;
     let mcpDetail = "no .mcp.json";
-    if (d.existsSync(mcpPath)) {
-      try {
-        const mcp = JSON.parse(d.readFileSync(mcpPath));
-        const g = mcp?.mcpServers?.gdrive;
-        if (!g) {
-          mcpDetail = ".mcp.json has no gdrive server";
-        } else if (!g.env || Object.keys(g.env).length === 0) {
-          mcpDetail =
-            "gdrive entry has no env block — Claude spawns MCP with a sanitized env; the launcher can't reach switchroom.yaml/the broker (bug-8 class)";
-        } else {
-          mcpOk = true;
-        }
-      } catch {
-        mcpDetail = ".mcp.json is unparseable";
+    if (mcpRead.kind === "ok") {
+      const g = mcpRead.data?.mcpServers?.gdrive;
+      if (!g) {
+        mcpDetail = ".mcp.json has no gdrive server";
+      } else if (!g.env || Object.keys(g.env).length === 0) {
+        mcpDetail =
+          "gdrive entry has no env block — Claude spawns MCP with a sanitized env; the launcher can't reach switchroom.yaml/the broker (bug-8 class)";
+      } else {
+        mcpOk = true;
       }
+    } else if (mcpRead.kind === "corrupt") {
+      mcpDetail = ".mcp.json exists but is not valid JSON (corrupt)";
     }
 
     // .claude.json must TRUST gdrive under the agent's project key.
-    const claudeJsonPath = join(agentDir, ".claude", ".claude.json");
     let trustOk = false;
     let trustDetail = "no .claude/.claude.json";
-    if (d.existsSync(claudeJsonPath)) {
-      try {
-        const cj = JSON.parse(d.readFileSync(claudeJsonPath));
-        const proj = cj?.projects?.[resolve(agentDir)];
-        const enabled: unknown = proj?.enabledMcpjsonServers;
-        if (Array.isArray(enabled) && enabled.includes("gdrive")) {
-          trustOk = true;
-        } else {
-          trustDetail =
-            "gdrive not in projects[].enabledMcpjsonServers — Claude silently ignores the un-allowlisted server (bug-9 / scaffold-ordering class)";
-        }
-      } catch {
-        trustDetail = ".claude.json is unparseable";
+    if (trustRead.kind === "ok") {
+      const proj = trustRead.data?.projects?.[resolve(agentDir)];
+      const enabled: unknown = proj?.enabledMcpjsonServers;
+      if (Array.isArray(enabled) && enabled.includes("gdrive")) {
+        trustOk = true;
+      } else {
+        trustDetail =
+          "gdrive not in projects[].enabledMcpjsonServers — Claude silently ignores the un-allowlisted server (bug-9 / scaffold-ordering class)";
       }
+    } else if (trustRead.kind === "corrupt") {
+      trustDetail = ".claude.json exists but is not valid JSON (corrupt)";
     }
 
     if (mcpOk && trustOk) {
@@ -302,6 +320,37 @@ function checkScaffoldWiring(
     }
   }
   return results;
+}
+
+type ReadJsonResult =
+  | { kind: "ok"; data: any }
+  | { kind: "absent" }
+  | { kind: "unreadable" } // exists but host can't read it (EACCES/EPERM)
+  | { kind: "corrupt" }; // read OK but not valid JSON
+
+/**
+ * Read + parse a JSON file, classifying the failure mode. The
+ * EACCES/EPERM split is load-bearing: in docker the scaffold artifacts
+ * are agent-UID-owned 0600 and the host operator running `doctor`
+ * cannot read them — that must NOT read as corruption/failure.
+ */
+function readJson(d: ResolvedDeps, path: string): ReadJsonResult {
+  if (!d.existsSync(path)) return { kind: "absent" };
+  let raw: string;
+  try {
+    raw = d.readFileSync(path);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "EACCES" || code === "EPERM") return { kind: "unreadable" };
+    // Any other read error (e.g. the file vanished mid-check) — treat
+    // as absent rather than corrupt; we have no parsed content to judge.
+    return { kind: "absent" };
+  }
+  try {
+    return { kind: "ok", data: JSON.parse(raw) };
+  } catch {
+    return { kind: "corrupt" };
+  }
 }
 
 /**

--- a/src/cli/drive-mcp-launcher.test.ts
+++ b/src/cli/drive-mcp-launcher.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   AIOFILE_PIN,
+  AIOFILE_PKG,
   buildChildEnv,
   buildSeedCredentials,
   buildUvxArgs,
@@ -130,11 +131,18 @@ describe("buildUvxArgs — pinned upstream + --single-user", () => {
     expect(args).toEqual([
       "--from",
       `git+https://github.com/taylorwilsdon/google_workspace_mcp.git@${GOOGLE_WORKSPACE_MCP_PINNED_SHA}`,
-      // `--with aiofile==3.8.8` is load-bearing, not optional: without
-      // it the modern fastmcp→key_value→aiofile import chain crashes
-      // with `KeyError: 'Author'` and the MCP never starts (verified
-      // in-container; ==1.20.4 and latest PyPI crash identically). Must
-      // sit BEFORE the entrypoint positional (it's a uvx option).
+      // `--refresh-package aiofile` is load-bearing: AIOFILE_PIN tracks
+      // a freshly-released upstream fix; without forcing uv to re-fetch
+      // aiofile's index, an agent whose uv cache predates the release
+      // resolves "no version of aiofile==<pin>" and the MCP never
+      // starts (reproduced in-container). Targeted (not a blanket
+      // --refresh) so the upstream git clone / dep tree stay cached.
+      "--refresh-package",
+      AIOFILE_PKG,
+      // `--with aiofile==<pin>` is load-bearing: the modern
+      // fastmcp→aiofile import chain raised `KeyError: 'Author'` until
+      // aiofile PR #106 (>=3.10.1). Must sit BEFORE the entrypoint
+      // positional (it's a uvx option).
       "--with",
       AIOFILE_PIN,
       // MUST be `workspace-mcp` — the upstream package provides only
@@ -149,7 +157,32 @@ describe("buildUvxArgs — pinned upstream + --single-user", () => {
     // Regression guard for the aiofile landmine — order matters
     // (uvx options precede the entrypoint).
     expect(args.indexOf("--with")).toBeLessThan(args.indexOf("workspace-mcp"));
+    expect(
+      args.indexOf("--refresh-package"),
+    ).toBeLessThan(args.indexOf("workspace-mcp"));
     expect(args).toContain(AIOFILE_PIN);
+    expect(args).toContain(AIOFILE_PKG);
+  });
+
+  // Floor guard (research rec #2): aiofile's `KeyError: 'Author'` was
+  // fixed in commit c27fdc7e8, first released in 3.10.1. Pinning BELOW
+  // that re-introduces the import crash. This fails CI on a careless
+  // downgrade into the buggy range, independent of any in-container
+  // smoke test.
+  it("AIOFILE_PIN is at or above the first fixed release (>= 3.10.1)", () => {
+    const m = AIOFILE_PIN.match(/^aiofile==(\d+)\.(\d+)\.(\d+)$/);
+    expect(m, `AIOFILE_PIN must be an exact aiofile==X.Y.Z pin, got "${AIOFILE_PIN}"`).not.toBeNull();
+    const [maj, min, pat] = (m as RegExpMatchArray).slice(1).map(Number);
+    // >= 3.10.1
+    const atLeast =
+      maj > 3 ||
+      (maj === 3 && min > 10) ||
+      (maj === 3 && min === 10 && pat >= 1);
+    expect(
+      atLeast,
+      `aiofile ${maj}.${min}.${pat} is below the first KeyError-fixed release 3.10.1 (aiofile PR #106 / commit c27fdc7e8)`,
+    ).toBe(true);
+    expect(AIOFILE_PKG).toBe("aiofile");
   });
 
   it("appends --tool-tier <tier> after --single-user when a tier is given", () => {

--- a/src/cli/drive-mcp-launcher.ts
+++ b/src/cli/drive-mcp-launcher.ts
@@ -184,30 +184,50 @@ export function buildSeedCredentials(
  * package `workspace-mcp`" — verified in-container against the pinned
  * SHA.
  */
-// Upstream dependency landmine. `workspace-mcp` pulls a modern
-// `fastmcp` whose `oauth_proxy → key_value → filetree` import chain
-// imports `aiofile`. `aiofile/version.py` (still, on master) does
-// `package_metadata["Author"]`; under the `importlib_metadata`
-// backport's #371 behavior change (KeyError on a missing key) and
-// aiofile's newer wheels emitting only `Author-email`, that import
-// raises `KeyError: 'Author'` and the MCP server never starts. NOT a
-// switchroom bug and NOT fixed by repinning workspace-mcp (==1.20.4
-// and latest PyPI both crash identically — verified in-container).
-// Constraining the leaf package to a version whose wheel metadata
-// still carries `Author` defuses it with minimal blast radius (vs.
-// pinning the foundational importlib_metadata). `aiofile==3.8.8`
-// validated end-to-end in a real agent container: reaches "Starting
-// MCP server 'google_workspace' (stdio)". Bump in lockstep with the
-// upstream SHA + a re-test of the import+startup path.
+// Upstream dependency landmine — NOW FIXED UPSTREAM, so this pins the
+// FIX, not a workaround. `workspace-mcp` pulls a modern `fastmcp` whose
+// import chain imports `aiofile`. `aiofile/version.py` historically did
+// `package_metadata["Author"]`, which raises `KeyError: 'Author'` under
+// modern `importlib_metadata` (newer wheels emit only `Author-email`) —
+// the MCP server never started. `aiofile==3.8.8` only "worked" by the
+// accident of an old wheel still carrying `Author`: a fragile pin.
+//
+// Resolved upstream in aiofile PR mosquito/aiofile#106 (commit
+// c27fdc7e8, 2026-05-16): the crashing subscript is now
+// `package_metadata.get("Author", <fallback>)`. First fixed releases:
+// 3.10.1 / 3.10.2 / 3.11.0. We pin `aiofile==3.10.2` — a fixed release
+// that resolves on the agent image's Python (3.11.2) — instead of
+// sitting on the accidental 3.8.8. The floor (>= 3.10.1, the first
+// commit-c27fdc7e8 release) is asserted in the launcher test so a
+// careless downgrade back into the buggy range fails CI.
+//
+// Bump in lockstep with the upstream SHA + a re-test of the
+// import+startup path (the docker pin-smoke test does exactly this).
 // Exported so the test imports the single source of truth instead of
 // re-typing the literal — a bump here can't silently pass a stale test.
-export const AIOFILE_PIN = "aiofile==3.8.8";
+export const AIOFILE_PIN = "aiofile==3.10.2";
+
+/**
+ * The bare package name from {@link AIOFILE_PIN} (single-sourced). Used
+ * for `uvx --refresh-package <name>` below.
+ */
+export const AIOFILE_PKG = AIOFILE_PIN.split("==")[0];
 
 export function buildUvxArgs(tier?: string): string[] {
   const args = [
     "--from",
     `git+https://github.com/taylorwilsdon/google_workspace_mcp.git@${GOOGLE_WORKSPACE_MCP_PINNED_SHA}`,
-    // uvx option — must precede the `workspace-mcp` entrypoint positional.
+    // Load-bearing, not optional. AIOFILE_PIN tracks a freshly-released
+    // upstream fix; uv caches its package index, so an agent whose
+    // cache was populated before the fixed release existed resolves
+    // "no version of aiofile==<pin>" and the MCP never starts —
+    // reproduced in-container. `--refresh-package aiofile` forces uv to
+    // re-fetch ONLY aiofile's index (not the whole upstream git clone /
+    // dep tree, so startup stays cheap), guaranteeing the pinned fixed
+    // version is always resolvable regardless of cache age. uvx option
+    // — must precede the `workspace-mcp` entrypoint positional.
+    "--refresh-package",
+    AIOFILE_PKG,
     "--with",
     AIOFILE_PIN,
     "workspace-mcp",

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -62,18 +62,27 @@ export type GdriveMcpTier = "core" | "extended" | "complete";
  * Pinned upstream commit SHA for `taylorwilsdon/google_workspace_mcp`.
  *
  * Specific commit SHA — bump deliberately. Pinning to a 40-char commit
- * SHA (not a tag) means upstream history rewrites can't change what we
- * run. google_workspace_mcp v1.20.3 = this SHA; verified MIT-licensed
- * at this SHA on 2026-05-06. (Note: RFC C originally referenced v0.5.0;
- * that tag does not exist on upstream — v1.20.3 is the latest stable as
- * of this pin.)
+ * SHA (not the moving tag ref) means upstream history rewrites can't
+ * change what we run, while still tracking a tagged release. This SHA
+ * is the commit annotated tag `v1.20.4` dereferences to
+ * (`gh api repos/taylorwilsdon/google_workspace_mcp/git/refs/tags/v1.20.4`
+ * → tag obj → `.object.sha`). v1.20.4 (2026-05-07) supersedes the prior
+ * pin v1.20.3 (`f3c7dc5…`): it hardens the `--single-user` stdio OAuth
+ * callback path switchroom depends on (upstream PR #762, "missing state
+ * parameter fallback for single-user stdio OAuth callbacks"). The
+ * `workspace-mcp` entrypoint is unchanged at this tag (pyproject
+ * `[project.scripts]` still defines `workspace-mcp = "main:main"` —
+ * the bug-6 guard). Validated end-to-end in a real agent container at
+ * this SHA: MCP starts and a real Drive call authenticates the seeded
+ * single-user account. When bumping: re-deref a NEW tag to its commit
+ * SHA, confirm the entrypoint, and re-run the docker pin-smoke test.
  *
  * Exported as the single source of truth: the scaffold MCP entry and
  * the in-container `drive-mcp-launcher` both reference this constant so
  * the spawned upstream revision is identical on both code paths.
  */
 export const GOOGLE_WORKSPACE_MCP_PINNED_SHA =
-  "f3c7dc5df2641c8545abc9e8f402d794f2853745";
+  "9d69115b63e6bc2ef0d4b5d7a3b962396382b44c";
 
 export interface GdriveMcpEntryOptions {
   /**

--- a/tests/docker/drive-mcp-pin-smoke.test.ts
+++ b/tests/docker/drive-mcp-pin-smoke.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Executable regression for the two reactive version pins behind the
+ * Drive integration (Drive reliability audit, 2026-05-16).
+ *
+ * The pure `buildUvxArgs` unit tests guard ARG ASSEMBLY (the entrypoint
+ * name, the `--with`/`--refresh-package` ordering, the AIOFILE_PIN
+ * floor). They CANNOT catch the actual bug class that bit us ~10 times:
+ * the pinned combination failing to *resolve or start* against the
+ * upstream SHA at runtime —
+ *
+ *   - bug-6: wrong uvx entrypoint name → "executable not provided"
+ *   - bug-7: aiofile `KeyError: 'Author'` → MCP never starts
+ *   - the freshly-released-fix / stale-uv-index case → "no version of
+ *     aiofile==<pin>" → MCP never starts
+ *
+ * Each was a SILENT/DEFERRED failure invisible until an agent was asked
+ * to use Drive. This test runs the EXACT pinned invocation
+ * (`GOOGLE_WORKSPACE_MCP_PINNED_SHA` + `AIOFILE_PIN` imported from src,
+ * not re-typed) inside the agent image (which bakes uv/uvx, #1361) and
+ * asserts it reaches the upstream "Starting MCP server" marker with no
+ * KeyError / Traceback / resolution failure. Any future pin bump that
+ * re-breaks the chain fails CI here instead of in production.
+ *
+ * Skipped (not failed) when docker or the agent image is unavailable —
+ * same contract as the other tests/docker/ suites. Network is required
+ * (uvx git-clones the upstream + resolves PyPI); the `e2e` CI job has
+ * it. Containers carry the mandatory `switchroom.test=phase1c` +
+ * per-run labels and `--rm`; afterAll does a label-scoped sweep.
+ */
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execSync, spawnSync } from "node:child_process";
+
+import {
+  newRunId,
+  dockerRunLabelsArgv,
+  safeLabelTeardown,
+} from "./_label-helpers.js";
+import {
+  AIOFILE_PIN,
+  AIOFILE_PKG,
+} from "../../src/cli/drive-mcp-launcher.js";
+import { GOOGLE_WORKSPACE_MCP_PINNED_SHA } from "../../src/memory/scaffold-integration.js";
+
+const RUN_ID = newRunId();
+const LABELS_ARGV = dockerRunLabelsArgv(RUN_ID);
+
+afterAll(() => {
+  safeLabelTeardown(RUN_ID);
+});
+
+const TAG = "phase1b-test";
+const AGENT_IMAGE = `switchroom/agent:${TAG}`;
+
+function hasDocker(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasImage(ref: string): boolean {
+  try {
+    execSync(`docker image inspect ${ref}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const dockerOk = hasDocker();
+const imageOk = dockerOk && hasImage(AGENT_IMAGE);
+
+describe.skipIf(!dockerOk || !imageOk)(
+  "drive-mcp pinned uvx invocation actually starts (skipped without docker/agent image)",
+  () => {
+    it(
+      "uvx @PINNED_SHA --refresh-package aiofile --with AIOFILE_PIN workspace-mcp --single-user reaches 'Starting MCP server'",
+      () => {
+        const fromArg = `git+https://github.com/taylorwilsdon/google_workspace_mcp.git@${GOOGLE_WORKSPACE_MCP_PINNED_SHA}`;
+        // Reproduce exactly what buildUvxArgs() emits. `env -i` mirrors
+        // Claude Code's sanitized MCP-spawn env (the conditions bug-8
+        // surfaced under). stdin from /dev/null so the stdio server
+        // sees EOF; `timeout` bounds the cold git-clone + resolve.
+        const inner = [
+          "env -i PATH=/usr/local/bin:/usr/bin:/bin HOME=/tmp",
+          "timeout 280",
+          "uvx",
+          "--from",
+          fromArg,
+          "--refresh-package",
+          AIOFILE_PKG,
+          "--with",
+          AIOFILE_PIN,
+          "workspace-mcp",
+          "--single-user",
+          "--tool-tier",
+          "extended",
+          "</dev/null 2>&1 | head -60",
+        ].join(" ");
+
+        const r = spawnSync(
+          "docker",
+          [
+            "run",
+            "--rm",
+            ...LABELS_ARGV,
+            "--entrypoint",
+            "sh",
+            AGENT_IMAGE,
+            "-c",
+            inner,
+          ],
+          { encoding: "utf8", timeout: 330_000 },
+        );
+
+        const out = `${r.stdout ?? ""}${r.stderr ?? ""}`;
+
+        // The bug classes this guards — each must NOT appear:
+        expect(out).not.toMatch(/KeyError: ['"]Author['"]/);
+        expect(out).not.toMatch(/Traceback \(most recent call last\)/);
+        expect(out).not.toMatch(/No solution found when resolving/);
+        expect(out).not.toMatch(/no version of aiofile/i);
+        expect(out).not.toMatch(
+          /is not provided by package|executable.*not provided/i,
+        );
+        // The positive proof the whole chain resolved + imported + booted:
+        expect(out).toMatch(/Starting MCP server/);
+      },
+      // Generous: a cold uvx run git-clones upstream + resolves the
+      // full dep tree before the server prints anything.
+      330_000,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Follow-up to #1368, addressing two things its deploy surfaced + the explicit ask to harden the version-pin regression coverage.

- **doctor-drive EACCES false-positive (#1368 defect).** In the canonical docker topology the scaffold artifacts are agent-UID-owned mode-0600 while `doctor` runs as the host operator → EACCES. The original `checkScaffoldWiring` mislabeled that as ".mcp.json is unparseable" and emitted a false `fail` for **all 9 agents on a healthy fleet** — undermining the very tool meant to make Drive legible. Now classified via a `readJson` helper: EACCES/EPERM → one honest "unverifiable from host (agent reads it fine)" **warn** (mirrors the `doctor-auth-broker` contract); only a readable-but-corrupt/mis-wired file is a `fail`. Regression tests for both the warn-not-fail and the still-fail-on-corrupt paths.
- **Pins moved to the FIXED upstream** (per "pinned to appropriate versions unless bug resolved"). The aiofile `KeyError:'Author'` was resolved upstream in mosquito/aiofile PR #106 (commit `c27fdc7e8`, first in 3.10.1); `aiofile==3.8.8` only ever worked by old-wheel accident. → `aiofile==3.10.2`. Upstream SHA `v1.20.3` → **`v1.20.4`** (`9d69115b…`), which hardens the `--single-user` stdio OAuth path we depend on (upstream PR #762); entrypoint unchanged. `buildUvxArgs` now emits `--refresh-package aiofile` (the fixed release is hours-old; uv's cached index otherwise resolves "no version of aiofile==3.10.2" — reproduced in-container; targeted refresh keeps the upstream clone cached so startup stays cheap). **Validated end-to-end in a real agent container before landing:** reaches "Starting MCP server" AND a real Drive call authenticates the seeded account.
- **Executable pin-regression coverage** (the gap behind ~10 silent bugs). `tests/docker/drive-mcp-pin-smoke.test.ts` runs the exact pinned uvx invocation (constants imported from src) in the agent image and asserts "Starting MCP server" with no KeyError/Traceback/resolution-failure — the bug recurs in CI, not production. Plus a unit floor-guard (`AIOFILE_PIN` must be ≥ 3.10.1). `Dockerfile.agent` example comment made version-agnostic (the M1 lesson).

## Design contract

JTBD: agents reliably collaborate on Drive docs. Pinning to the *fixed* upstream (not a fragile accident) + a smoke test that fails CI on a re-broken pin is the docs/defaults/consistency-test answer for "is this reliable now".

## Test plan

- [x] Pin combo validated in a live agent container (MCP starts + real Drive call as the seeded account)
- [x] `npm run lint` clean; 411 tests pass; docker smoke skips cleanly without docker/image
- [x] Independent fresh-process review: APPROVE
- [ ] Post-merge: agent image republished → `switchroom update` → `switchroom doctor` Google Drive section all-green for 9 agents (no EACCES false-fails); spot-check a non-Carrie agent does a real Drive call on the new pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)