### PR TITLE
docs(drive): correct the access model + retire stale pin literals

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -421,6 +421,37 @@ only: one OAuth client per switchroom install. A per-agent
 `google_workspace:` override may narrow `approvers` or pick a different
 `tier`, but not the client credentials (RFC G Phase 1).
 
+### Per-account ACL + per-agent selection (`google_accounts:` + `google_workspace.account`)
+
+The `google_workspace:` block above only configures the OAuth *client*.
+Two more pieces gate whether a given agent can actually reach Drive —
+**both are required; one without the other silently fails:**
+
+```yaml
+google_accounts:                 # top-level; keyed by the Google EMAIL
+  alice@example.com:             #   (validated + lowercased — NOT an
+    enabled_for: [carrie, finn]  #   arbitrary label)
+
+agents:
+  carrie:
+    google_workspace:
+      account: alice@example.com  # the account THIS agent uses
+```
+
+| Field | Notes |
+|---|---|
+| `google_accounts.<email>.enabled_for[]` | The cross-agent ACL: which agents may read that account's broker-held refresh token. Set by `switchroom auth google enable <email> <agents…>` (or by hand). |
+| `agents.<name>.google_workspace.account` | The account the broker returns for that agent. The launcher passes **no** account — the broker derives it from this field (path-as-identity) and then enforces `enabled_for[]`. Must be a key in `google_accounts:`. |
+
+Being listed in `enabled_for[]` is **necessary but not sufficient**: an
+agent with no `google_workspace.account` gets `ACCOUNT_NOT_FOUND` from
+the broker; an agent with `account:` set but absent from that account's
+`enabled_for[]` gets `ACCESS_DENIED`. Both are silent at config time and
+only surface when the agent tries to use Drive — so `switchroom doctor`
+has a **Google Drive** section that flags every such mismatch (and the
+deployed `.mcp.json`/trust wiring) up front. Run it after any change
+here.
+
 ## Escape Hatches
 
 For Claude Code settings switchroom doesn't wrap:

--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -21,12 +21,22 @@ Google account, not a service account. Nothing leaves your subscription.
 switchroom auth google connect
 
 # 1. Connect a Google account to the auth-broker (one-time per account).
-switchroom auth google account add ken-personal
+#    <account> is the Google EMAIL, not a label.
+switchroom auth google account add you@gmail.com
 
-# 2. Allow an agent to use that account.
-switchroom auth google enable ken-personal klanker
+# 2. Allow an agent to use that account (the ACL — enabled_for[]).
+switchroom auth google enable you@gmail.com klanker
 
-# 3. (Optional) Pick the Workspace tier — defaults to "core".
+# 3. REQUIRED, separate from step 2: set the agent's account selector
+#    in switchroom.yaml, then reconcile. Without this the broker returns
+#    ACCOUNT_NOT_FOUND and the agent silently has no Drive.
+#      agents: { klanker: { google_workspace: { account: you@gmail.com } } }
+switchroom agent restart klanker      # or `switchroom update` for the fleet
+
+# 4. Verify (catches the step-3 trap up front):
+switchroom doctor                     # see the "Google Drive" section
+
+# 5. (Optional) Pick the Workspace tier — defaults to "core".
 #    See docs/configuration.md § google_workspace for the cascade.
 ```
 
@@ -42,25 +52,34 @@ one of:
 ```
             ┌─ auth-broker ──────────────────────┐
             │                                    │
-operator ───▶ google account add <label>         │
-            │   → device-flow OAuth              │
+operator ───▶ google account add <email>          │
+            │   → loopback OAuth                 │
             │   → refresh_token stored in        │
             │     ~/.switchroom/auth-broker/     │
             │                                    │
-operator ───▶ google enable <agent> <label>      │
-            │   → adds <agent> to the per-       │
-            │     account ACL                    │
+operator ───▶ google enable <email> <agents…>     │
+            │   → adds agents to the per-        │
+            │     account ACL (enabled_for[])    │
             │                                    │
-agent ──────▶ get_credentials(provider=google,   │
-            │   account=<label>)                 │
-            │   → access_token (refreshed on     │
-            │     demand by the broker)          │
+operator ───▶ set agents.<name>.google_workspace. │
+            │   account: <email>  (REQUIRED —    │
+            │   the broker selects the account   │
+            │   from this, not a per-call arg)   │
+            │                                    │
+agent ──────▶ get_credentials(provider=google)    │
+            │   → broker derives account from    │
+            │     the agent's config + enforces  │
+            │     enabled_for[] → access_token   │
             └────────────────────────────────────┘
 ```
 
-**Per-account, not per-agent.** One Google account → many agents that
-can use it (controlled by the ACL). One agent → can have multiple
-accounts (the agent picks `account=<label>` per call). RFC G §4.4
+**Accounts are identified by Google email, not an arbitrary label.**
+`account add`, `google_accounts:` keys, and `google_workspace.account`
+are all the email (validated + lowercased). One Google account → many
+agents (gated by `enabled_for[]`); one agent → exactly one Google
+account, named in its `google_workspace.account`. Granting access is
+**two fields, both required** — `enabled_for[]` *and* the per-agent
+`google_workspace.account` (see "Granting an agent access"). RFC G §4.4
 spells out why this shape is load-bearing.
 
 ## Prerequisite — your OAuth client (one-time per install)
@@ -153,11 +172,13 @@ If you'd rather do it by hand (the wizard automates exactly this):
 ## Connecting an account
 
 ```bash
-switchroom auth google account add ken-personal
+switchroom auth google account add you@gmail.com
 ```
 
-This runs Google's **loopback** flow (device-code and OOB do not work
-for Drive — see the client-type note above):
+`<account>` is the **Google account email** — it is validated and
+lowercased, not a free-form label. This runs Google's **loopback** flow
+(device-code and OOB do not work for Drive — see the client-type note
+above):
 
 1. Prints a consent URL and binds an ephemeral `127.0.0.1:<port>`
    listener.
@@ -169,9 +190,10 @@ for Drive — see the client-type note above):
    rest of switchroom).
 4. Account is now visible in `switchroom auth google account list`.
 
-If you have multiple Google accounts to attach, repeat with different
-labels (`ken-personal`, `ken-work`, etc.). The label is just for your
-own reference — agents reference accounts by label, not by Google email.
+If you have multiple Google accounts to attach, repeat with each
+account's email. Agents reference accounts by that email everywhere
+(`google_accounts:` keys, `google_workspace.account`) — there is no
+separate label.
 
 ### Scopes — read by default, write is opt-in
 
@@ -185,9 +207,9 @@ let agents *create and edit* docs (e.g. draft a new doc into a folder),
 pass `--write`:
 
 ```bash
-switchroom auth google account add ken-personal --write
+switchroom auth google account add you@gmail.com --write
 # re-consent an already-connected account to add write:
-switchroom auth google account add ken-personal --replace --write
+switchroom auth google account add you@gmail.com --replace --write
 ```
 
 `--write` adds **`drive.file`** — least-privilege: agents can create
@@ -201,7 +223,7 @@ exposed — it is independent of these OAuth scopes.
 ### Removing an account
 
 ```bash
-switchroom auth google account remove ken-personal
+switchroom auth google account remove you@gmail.com
 ```
 
 Deletes the refresh token from the broker AND best-effort-revokes it
@@ -210,23 +232,50 @@ Google.
 
 ## Granting an agent access
 
-By default a new Google account is reachable by **no agents**. Enable
-explicitly:
+Granting an agent Drive access is **two required steps** — doing only
+the first is the most common failure mode (it fails *silently* until
+the agent is asked to use Drive).
+
+**Step 1 — the ACL.** By default a new account is reachable by no
+agents. Add agents to its `enabled_for[]`:
 
 ```bash
-# Enable one or more agents on an account ("all" expands to every agent):
-switchroom auth google enable ken-personal klanker
-switchroom auth google enable ken-personal klanker clerk
-switchroom auth google enable ken-personal all
+# "all" expands to every declared agent:
+switchroom auth google enable you@gmail.com klanker
+switchroom auth google enable you@gmail.com klanker clerk
+switchroom auth google enable you@gmail.com all
 
 # Inspect / revoke:
-switchroom auth google list                       # show the full agent × account matrix
-switchroom auth google disable ken-personal klanker
+switchroom auth google list                       # full agent × account matrix
+switchroom auth google disable you@gmail.com klanker
 ```
 
-ACL changes take effect on the next `get_credentials` call — no agent
-restart needed. The auth-broker is the source of truth (RFC G §4.4
-+ RFC H Phase 3b).
+**Step 2 — the per-agent account selector (REQUIRED, separate).**
+`auth google enable` only writes `enabled_for[]`. The broker selects
+which account to return for an agent from that agent's own
+`google_workspace.account` (path-as-identity — the launcher passes no
+account). Without it the broker returns `ACCOUNT_NOT_FOUND` and the
+agent has no Drive tools, with **no error at config time**:
+
+```yaml
+agents:
+  klanker:
+    google_workspace:
+      account: you@gmail.com    # must match a google_accounts: key
+```
+
+Then apply the scaffold so the agent's `.mcp.json` + trust are
+regenerated: `switchroom update` (fleet) or `switchroom agent restart
+klanker`. A *pure* `enabled_for[]` change on an already-wired agent
+takes effect on the next `get_credentials` call with no restart; adding
+a brand-new Drive agent needs the reconcile because its MCP wiring
+doesn't exist yet.
+
+**Verify.** `switchroom doctor` has a **Google Drive** section that
+flags every `enabled_for[]` ↔ `google_workspace.account` mismatch and
+the deployed scaffold wiring — run it after any change here instead of
+discovering the gap when an agent says "Drive's blocked". The
+auth-broker is the source of truth (RFC G §4.4 + RFC H Phase 3b).
 
 ## Working with the agent over Telegram
 
@@ -322,8 +371,13 @@ google_workspace:
   # tools: { include: [...], exclude: [...] }  # optional per-tool override
 ```
 
-Per-agent ACL is set via `auth google enable/disable`, not the YAML —
-ACL changes need to be auditable without an agent restart (RFC G §4.4).
+Two distinct knobs, don't conflate them: the **ACL**
+(`google_accounts.<email>.enabled_for[]`) is set via `auth google
+enable/disable` (or by hand in YAML) and a pure ACL change takes effect
+on the next `get_credentials` with no restart (RFC G §4.4); the
+**per-agent account selector** (`agents.<name>.google_workspace.account`)
+is YAML and is *required* — see `docs/configuration.md` § "Per-account
+ACL + per-agent selection" and "Granting an agent access" above.
 
 ## Troubleshooting
 
@@ -332,15 +386,17 @@ ACL changes need to be auditable without an agent restart (RFC G §4.4).
 The refresh token has been revoked or rotated. Re-run:
 
 ```bash
-switchroom auth google account add ken-personal  # OAuth flow
+switchroom auth google account add you@gmail.com --replace  # re-consent
 # OR if the broker still has the slot but the token is dead:
-switchroom auth google account remove ken-personal
-switchroom auth google account add ken-personal
+switchroom auth google account remove you@gmail.com
+switchroom auth google account add you@gmail.com
 ```
 
-Causes: the user changed their Google password, revoked switchroom in
-the Google Account dashboard, or the OAuth client's verification
-expired (7-day Testing-mode token lifetimes).
+Causes: the user changed their Google password, or revoked switchroom
+in the Google Account dashboard. Note the **7-day refresh-token
+lifetime applies only to Testing-mode OAuth clients** — move the client
+to Production in the GCP console (the recommended posture) and that
+clock goes away; it is not a cause there.
 
 ### Agent says "Not logged in" right after `switchroom update`
 

--- a/docs/rfcs/doc-connection-completion.md
+++ b/docs/rfcs/doc-connection-completion.md
@@ -162,8 +162,9 @@ trees (>100 top-level folders) are common. Ship paginated on day 1.
 > resolve every anchor before posting the diff-preview card.
 >
 > Implementation landed differently. Agents reach Drive via the
-> upstream `taylorwilsdon/google_workspace_mcp` server (pinned at
-> `f3c7dc5df2641c8545abc9e8f402d794f2853745`), which exposes 9
+> upstream `taylorwilsdon/google_workspace_mcp` server (pinned to the
+> commit in `GOOGLE_WORKSPACE_MCP_PINNED_SHA`, single-sourced in
+> `src/memory/scaffold-integration.ts`), which exposes 9
 > direct write tools (`modify_doc_text`, `find_and_replace_doc`,
 > `insert_doc_elements`, `insert_doc_image`, `batch_update_doc`,
 > `create_table_with_data`, `update_doc_headers_footers`,

--- a/docs/rfcs/gdrive-mcp.md
+++ b/docs/rfcs/gdrive-mcp.md
@@ -20,7 +20,7 @@ Add a Google Drive MCP server so agents can read and (with explicit approval) wr
 
 ## 2. MCP server choice
 
-**Pinned:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp), pinned to **v1.20.3** (commit `f3c7dc5df2641c8545abc9e8f402d794f2853745`), MIT-licensed. The RFC originally targeted `v0.5.x`, but no such tag exists upstream — v1.20.3 is the validated pin used by the implementation. Track the explicit commit SHA in `switchroom.yaml` rather than a floating tag so upgrades are explicit.
+**Pinned:** [`taylorwilsdon/google_workspace_mcp`](https://github.com/taylorwilsdon/google_workspace_mcp), MIT-licensed, pinned to an explicit upstream **commit SHA** (a tag's deref'd commit, not a floating ref, so upstream history rewrites can't change what we run). The RFC originally targeted `v0.5.x`, but no such tag exists upstream. The live pin is single-sourced in code as `GOOGLE_WORKSPACE_MCP_PINNED_SHA` (`src/memory/scaffold-integration.ts`) — that constant, with its doc comment, is the source of truth (currently the `v1.20.4` commit); do not duplicate the literal here, it only rots. Bump deliberately per the procedure in that comment + the `tests/docker/drive-mcp-pin-smoke.test.ts` guard.
 
 - **Runtime:** Python 3.11+, run via `uvx` so no system-wide install is required. Switchroom's existing MCP-subprocess machinery already supports `uvx`-launched servers.
 - **License:** MIT.


### PR DESCRIPTION
## Summary

Accuracy pass over the Drive docs after #1367–#1369 + the 9-agent enablement. **No new content for its own sake** — only fixes for statements provably wrong against shipped behaviour (independently verified against the code by a fresh reviewer).

- **Email, not a label.** The guide used a `ken-personal` label model; the implementation is email-keyed end to end (`account add` runs `validateAndNormalizeAccountEmail()`; `google_accounts:` keys + `google_workspace.account` are the email). Old examples literally failed validation. Corrected throughout.
- **The R1 trap, documented.** Docs presented `auth google enable` (writes only `enabled_for[]`) as sufficient. The broker also requires the per-agent `agents.<name>.google_workspace.account` or it returns `ACCOUNT_NOT_FOUND` and the agent silently has no Drive — the exact incident where 8 of 9 "enabled" agents didn't work. Now two explicit required steps + a pointer to the `switchroom doctor` Google Drive section. `configuration.md` gains the previously-absent `google_accounts:` / `google_workspace.account` reference.
- **Stale pin literals retired.** `gdrive-mcp.md` / `doc-connection-completion.md` hardcoded `v1.20.3`/`f3c7dc5…` (now wrong post-v1.20.4) and falsely claimed the SHA lives in `switchroom.yaml`. Replaced with a pointer to the single-sourced `GOOGLE_WORKSPACE_MCP_PINNED_SHA` constant (the M1/M2 don't-hardcode-a-rotting-version lesson).
- **Smaller corrections:** the 30-second model diagram (no per-call `account=` arg), the "ACL not the YAML" cascade note, and the Testing-mode-only nature of the 7-day token lifetime.

CLAUDE.md, skills/, CLI `--help` audited — no Drive/pin inaccuracies, deliberately untouched. Docs-only; no runtime/deploy impact.

## Test plan

- [x] Every claim independently verified against the code by a fresh reviewer (APPROVE)
- [x] No stale `ken-personal`/`v1.20.3`/`f3c7dc5`/`aiofile==3.8.8` literals remain; markdown well-formed; cross-refs resolve
- [x] Scoped away from the separate Anthropic `auth account add <label>` subsystem (correctly label-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)