### PR TITLE
deprecate(state): legacy ~/.clerk + v0.6 broker-socket removal notice (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.12.0 — legacy-state deprecation notices
+
+Schedules the long-lived `clerk → switchroom` rename shims for removal so they don't sit indefinitely. No behaviour change for migrated hosts; no automatic migration is performed.
+
+### Changes
+
+#### Deprecations
+
+- **deprecate(state):** `switchroom doctor` now WARNs (exit 0) when legacy `~/.clerk` state or the v0.6 host-side `~/.switchroom/vault-broker.sock` is present. Additionally, any CLI/agent invocation that actually reads from `~/.clerk` now emits a one-time stderr deprecation notice (doctor alone is insufficient — the silent dual-read failure mode is total state loss). These back-compat shims (`src/config/paths.ts` dual-read, the top-level `clerk:` switchroom.yaml alias, and `src/vault/broker/client.ts` `LEGACY_SOCKET_PATH`) are **REMOVED in v0.13.0**.
+
+### Upgrade notes
+
+- If `~/.clerk` exists on a host: migrate before upgrading to v0.13.0 with `mv ~/.clerk ~/.switchroom`, and rename any top-level `clerk:` key in `switchroom.yaml` to `switchroom:`. There is no automatic migration — v0.13.0 silently treats un-migrated state as a fresh install (vault/agents/auth read as absent).
+
 ## v0.11.1 — hostd default-on + CI infra-resilience follow-ups
 
 A small follow-up release: RFC C Phase 2 flips the host-control daemon on by default (so `/restart`, `/new`, `/reset`, `/update apply` work on docker-mode installs without per-install opt-in), `/audit hostd` gets its bind-mount, and the GHA queue-fail class (#1336) gets a manual recovery lever plus an alert backstop.

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -15,7 +15,7 @@ import { join, resolve } from "node:path";
 import { createPublicKey, createPrivateKey } from "node:crypto";
 import { listSecrets, getStringSecret } from "../vault/vault.js";
 import { resolveAgentsDir, resolvePath } from "../config/loader.js";
-import { resolveStatePath } from "../config/paths.js";
+import { resolveStatePath, LEGACY_STATE_DIR } from "../config/paths.js";
 import { getConfig, getConfigPath, withConfigError } from "./helpers.js";
 import { getAllAgentStatuses } from "../agents/lifecycle.js";
 import { readQuarantineMarkerForAgent } from "../agents/quarantine.js";
@@ -439,6 +439,59 @@ export function checkConfig(config: SwitchroomConfig, configPath: string): Check
         ? undefined
         : "Add defaults.subagents to switchroom.yaml to enable Sonnet/Haiku delegation. See docs/sub-agents.md for the worker/researcher/reviewer pattern.",
   });
+
+  return results;
+}
+
+/**
+ * Deprecation notice (announced v0.12.0 → shims removed v0.13.0): WARN when
+ * legacy `~/.clerk` state or the v0.6 host-side broker socket is present, so
+ * operators migrate before the back-compat shims (src/config/paths.ts dual-
+ * read + the `clerk:` YAML alias + src/vault/broker/client.ts
+ * LEGACY_SOCKET_PATH) are deleted. There is no automatic migration. `warn`
+ * keeps exit 0, so this never breaks CI/automation.
+ */
+export function checkLegacyState(): CheckResult[] {
+  const results: CheckResult[] = [];
+  const h = process.env.HOME ?? "/root";
+
+  const clerkDir = join(h, LEGACY_STATE_DIR);
+  const clerkPresent = existsSync(clerkDir);
+  results.push({
+    name: "legacy ~/.clerk state",
+    status: clerkPresent ? "warn" : "ok",
+    detail: clerkPresent ? `${clerkDir} present` : "none",
+    ...(clerkPresent
+      ? {
+          fix:
+            "Legacy state detected. Run `mv ~/.clerk ~/.switchroom` and rename "
+            + "any top-level `clerk:` key in switchroom.yaml to `switchroom:`. "
+            + "This back-compat shim is REMOVED in v0.13.0 — no automatic "
+            + "migration exists.",
+        }
+      : {}),
+  });
+
+  const legacySock = join(h, ".switchroom", "vault-broker.sock");
+  let sockStat: ReturnType<typeof lstatSync> | null = null;
+  try {
+    sockStat = lstatSync(legacySock);
+  } catch {
+    /* absent — fine */
+  }
+  if (sockStat) {
+    results.push({
+      name: "legacy v0.6 broker socket",
+      status: "warn",
+      detail: sockStat.isSymbolicLink()
+        ? `${legacySock} (symlink) present`
+        : `${legacySock} present`,
+      fix:
+        "v0.6 host-side broker socket detected. v0.7+ docker installs use the "
+        + "per-agent broker-operator socket; remove the legacy socket. The "
+        + "LEGACY_SOCKET_PATH fallback is REMOVED in v0.13.0.",
+    });
+  }
 
   return results;
 }
@@ -2167,6 +2220,7 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Skills Prerequisites", results: checkSkillsPrerequisites() },
           { title: "Manifest Drift", results: await checkManifestDrift() },
           { title: "Configuration", results: checkConfig(config, configPath) },
+          { title: "Legacy State", results: checkLegacyState() },
           { title: "Vault", results: checkVault(config) },
           { title: "Memory (Hindsight)", results: await checkHindsight(config) },
           { title: "Telegram", results: await checkTelegram(config) },

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -10,7 +10,11 @@ import { resolve } from "node:path";
  * `~/.clerk/<fragment>` when only the legacy path exists on disk.
  *
  * Once the filesystem is migrated (`mv ~/.clerk ~/.switchroom`), the fallback
- * is a no-op. Remove this shim in a future release.
+ * is a no-op. DEPRECATED as of v0.12.0; this shim (and the `clerk:`
+ * switchroom.yaml alias) is REMOVED in v0.13.0. `switchroom doctor` warns
+ * when legacy state is present, and the hit-path warn below fires on any
+ * CLI/agent invocation that actually reads from `~/.clerk` — there is no
+ * automatic filesystem migration.
  */
 
 export const DEFAULT_STATE_DIR = ".switchroom";
@@ -18,6 +22,26 @@ export const LEGACY_STATE_DIR = ".clerk";
 
 function home(): string {
   return process.env.HOME ?? "/root";
+}
+
+let _legacyStateWarned = false;
+/**
+ * One-time stderr warning emitted the moment a `~/.clerk` legacy path is
+ * actually returned. doctor-only is insufficient: the operator may never
+ * run `doctor`, and the silent-fallback failure mode (deleting the shim
+ * while a host is still on `.clerk`) is total state loss. Fires at most
+ * once per process and only on hosts genuinely still on legacy state —
+ * zero noise for migrated hosts.
+ */
+function warnLegacyStateOnce(legacy: string): void {
+  if (_legacyStateWarned) return;
+  _legacyStateWarned = true;
+  process.stderr.write(
+    `[switchroom] DEPRECATED: reading legacy state from ${legacy}. ` +
+      "Run `mv ~/.clerk ~/.switchroom` (and rename any top-level `clerk:` " +
+      "key in switchroom.yaml to `switchroom:`). This back-compat shim is " +
+      "REMOVED in v0.13.0 — no automatic migration exists.\n",
+  );
 }
 
 /**
@@ -33,6 +57,7 @@ export function resolveStatePath(fragment: string): string {
   const primary = resolve(h, DEFAULT_STATE_DIR, fragment);
   const legacy = resolve(h, LEGACY_STATE_DIR, fragment);
   if (!existsSync(primary) && existsSync(legacy)) {
+    warnLegacyStateOnce(legacy);
     return legacy;
   }
   return primary;
@@ -55,7 +80,10 @@ export function resolveDualPath(pathStr: string): string {
       const frag = rest.slice(DEFAULT_STATE_DIR.length + 1);
       if (!existsSync(absolute)) {
         const legacy = resolve(h, LEGACY_STATE_DIR, frag);
-        if (existsSync(legacy)) return legacy;
+        if (existsSync(legacy)) {
+          warnLegacyStateOnce(legacy);
+          return legacy;
+        }
       }
     }
     return absolute;


### PR DESCRIPTION
Converts two indefinitely-held `clerk → switchroom` back-compat shims into a **dated removal contract** (announced v0.12.0 → removed v0.13.0). **No shim removed here** — that's the v0.13.0 PR.

## Why a notice, not a removal / not a perpetual hold
Sub-agent traced the blast radius: the `.clerk` dual-read is the only **silent-catastrophic** shim — deleting it while a host is still on `~/.clerk` makes vault/agents/auth all read as absent with no error (looks freshly installed). There is **no automatic filesystem migration** anywhere. So it can't be silently removed, and leaving it forever is the status quo we're fixing.

## What ships (v0.12.0)
- **`src/cli/doctor.ts`** — new `checkLegacyState()` section: WARNs (exit 0 — never breaks CI/automation) when `~/.clerk` or the v0.6 `~/.switchroom/vault-broker.sock` is present, with the exact migration fix string.
- **`src/config/paths.ts`** — a one-time, process-deduped **stderr deprecation notice** the moment a `~/.clerk` path is actually returned (doctor-only is insufficient — the operator may never run doctor; this fires on any CLI/agent invocation on a genuinely-legacy host, zero noise for migrated hosts).
- **`CHANGELOG.md`** — v0.12.0 Deprecations entry + Upgrade notes (exact `mv` + yaml-key steps; v0.13.0 removal scope).

## Verification
`tsc` + 3 lint checks clean; 181/182 doctor-suite tests pass — the 1 failure is the **pre-existing, branch-independent** `checkMff` host-state flake on this shared box (checkMff is untouched here; `doctor.test.ts` itself passes).

🤖 Generated with Claude Code