### PR TITLE
fix(build): ship web dashboard UI in the bundled CLI (dist/cli/ui)

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -2,7 +2,7 @@
 // Build script for npm publish — bundles CLI + fixes shebang for Node.
 // Runs under bun (preferred) or node (with esbuild fallback if bun missing).
 import { execSync } from "node:child_process";
-import { readFileSync, writeFileSync, chmodSync, mkdirSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, chmodSync, mkdirSync, rmSync, cpSync, existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { escapeBundleNonAscii } from "./escape-bundle-non-ascii.mjs";
@@ -111,6 +111,23 @@ chmodSync(outFile, 0o755);
 const cliEscape = escapeBundleNonAscii(outFile);
 if (cliEscape.changed) {
   console.log(`[build] ASCII-escaped ${cliEscape.nonAsciiCount} non-ASCII code units in dist/cli/switchroom.js`);
+}
+
+// Copy the web dashboard static assets next to the bundled CLI. The
+// web server resolves its UI dir as `resolve(import.meta.dirname,
+// "ui")` — at runtime that's `dist/cli/ui/` (the bundle lives in
+// dist/cli/). Without this copy `switchroom web` serves the API but
+// 404s `GET /` because package.json `files` ships only `dist/`, not
+// `src/`. The dashboard only ever rendered via `bun run dev` from a
+// source checkout (where import.meta.dirname is src/web/). Ship the
+// HTML so the built/published CLI serves a usable dashboard.
+const webUiSrc = resolve(root, "src/web/ui");
+const webUiDest = resolve(outDir, "ui");
+if (existsSync(webUiSrc)) {
+  cpSync(webUiSrc, webUiDest, { recursive: true });
+  console.log("[build] copied src/web/ui -> dist/cli/ui (dashboard static assets)");
+} else {
+  console.warn("[build] WARNING: src/web/ui not found — dashboard UI will 404");
 }
 
 // Bundle the drive-write-pretool hook — RFC E §4.2 Cut 2. Same


### PR DESCRIPTION
## Summary

End-to-end testing the merged dashboard refresh (P0 #1357 → P2b #1363) on the live host surfaced a **pre-existing packaging bug**: `switchroom web` from the built/published CLI serves the API but **404s `GET /`** — the dashboard page itself never loads.

## Root cause (predates this work)

The web server resolves its UI dir as `resolve(import.meta.dirname, "ui")` → at runtime that's `dist/cli/ui/` (the bundle lives in `dist/cli/`). `scripts/build.mjs` bundles the CLI but never copied `src/web/ui/` there, and `package.json` `files` ships only `dist/`, not `src/`. So the dashboard HTML only ever rendered via `bun run dev` from a source checkout (where `import.meta.dirname` is `src/web/`). Every per-PR reviewer validated via `vitest`/source and never exercised the built bundle, so the gap stayed latent across the whole refresh — and was already broken before it.

Net effect: all five merged dashboard PRs' UI is invisible in any built/npm-installed `switchroom web` until this lands.

## Fix

One copy step in `scripts/build.mjs`: `cpSync(src/web/ui → dist/cli/ui)` after the CLI bundle. `dist/` is already in `files[]`, so the npm tarball now includes it.

## Verified (live host, built bundle under bun)

- `GET /` → **200 / 43 KB**, `<title>Switchroom Fleet</title>`, all 6 tabs (`agents accounts system google schedule approvals`)
- `/api/*` unchanged (auth gate 401/401/200; `/api/approvals` → `{"reachable":true,"decisions":[]}` through the live kernel operator socket)
- Path-traversal `/../../package.json` → 404; unknown asset → 404
- Adversarial production check: live kernel operator socket refuses `approval_revoke`/`approval_record`/`approval_request` (DENIED, read-only) while `approval_list` succeeds — the #1362 deny-by-default invariant holds in production

## Test plan

- [ ] `npm run build` then run the bundle under bun: `GET /` returns the dashboard HTML
- [ ] `npm run lint` / `npm test` unaffected (build-script-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)