### PR TITLE
fix(codex): pre-Docker assumptions wrong on live agent/operator paths

### DIFF
--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -137,7 +137,7 @@ Use your available tools when appropriate. If you lack the right tool for a task
 
 {{#if schedule}}
 ## Scheduled Tasks
-You have scheduled tasks configured. These run independently as one-shot `claude -p` calls on a schedule that fires across reboots. They don't use your session or context, they fire on their own (typically Sonnet for cost efficiency) and send output directly to Telegram.
+You have scheduled tasks configured. At fire time an in-container scheduler sidecar injects a synthesized inbound turn into **your running session** — a scheduled task arrives as an ordinary turn tagged `<channel source="cron">`, using your normal session, context, and model, and it shows up in your transcript and Hindsight memory like any other turn (it is *not* an isolated one-shot `claude -p` process). They survive reboots via the container restart policy plus an at-least-once boot replay.
 
-You don't need to manage them. If the user asks about scheduled tasks, explain that they run automatically and are configured in switchroom.yaml under `schedule:`.
+You don't need to manage them. If the user asks about scheduled tasks, explain that they fire into your session automatically and are configured in switchroom.yaml under `schedule:`.
 {{/if}}

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -349,8 +349,13 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
       : ''
     degradedRows.push(`⚠️ <b>Restart</b>  ${escapeHtml(REASON_LABEL.crash)}${ageStr}`)
     // Principle 1: every failure carries its next step. The crash row
-    // tells the user how to inspect why.
-    degradedRows.push(`    ↳ Tail logs: <code>journalctl --user -u switchroom-${escapeHtml(agentSlug)} -n 100</code>`)
+    // tells the user how to inspect why. Runtime-aware: v0.7+ agents run
+    // in Docker (no systemd/journalctl in-container) — the canonical
+    // detection is SWITCHROOM_RUNTIME (see doctor-docker.ts).
+    const tailCmd = process.env.SWITCHROOM_RUNTIME === 'docker'
+      ? `docker logs --tail 100 switchroom-${escapeHtml(agentSlug)}`
+      : `journalctl --user -u switchroom-${escapeHtml(agentSlug)} -n 100`
+    degradedRows.push(`    ↳ Tail logs: <code>${tailCmd}</code>`)
   }
 
   // Probe rows — only those that surfaced as degraded/fail. Healthy

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -959,7 +959,9 @@ export async function probeHindsight(
         status: 'fail',
         label: 'Hindsight',
         detail: 'unreachable',
-        nextStep: 'Hindsight server not responding on 127.0.0.1:18888 — start it with `hindsight serve` or check `systemctl --user status hindsight`',
+        nextStep: process.env.SWITCHROOM_RUNTIME === 'docker'
+          ? 'Hindsight server not responding on 127.0.0.1:18888 — check the hindsight container (`docker ps` / `docker logs`); it must be reachable on the host network.'
+          : 'Hindsight server not responding on 127.0.0.1:18888 — start it with `hindsight serve` (or check `systemctl --user status hindsight`).',
       }
     }
 

--- a/telegram-plugin/server.ts
+++ b/telegram-plugin/server.ts
@@ -159,13 +159,16 @@ installPluginLogger()
   //     missing-feature bugs (no /issues card, no quota notifications, no
   //     graceful failover). A clean error is more honest.
   //
-  // To install the gateway: `switchroom setup` provisions the
-  // `switchroom-telegram-gateway` systemd unit. Inspect with
-  // `systemctl --user status switchroom-telegram-gateway`.
+  // In v0.7+ the gateway is an in-container sidecar started by start.sh
+  // (no systemd unit). On a Docker host inspect/recover with
+  // `docker logs switchroom-<agent>` / `switchroom agent restart <agent>`;
+  // on a legacy non-docker install it's the gateway systemd user unit.
+  const recover = process.env.SWITCHROOM_RUNTIME === 'docker'
+    ? 'check `docker logs switchroom-<agent>` then `switchroom agent restart <agent>`'
+    : 'run `switchroom setup` to install the gateway, or check `systemctl --user status switchroom-telegram-gateway`'
   process.stderr.write(
     `telegram channel: no gateway socket at ${_gatewaySocket}. ` +
-    `Run \`switchroom setup\` to install the gateway daemon, or check ` +
-    `\`systemctl --user status switchroom-telegram-gateway\`. Exiting sidecar.\n`,
+    `The gateway sidecar is not running — ${recover}. Exiting sidecar.\n`,
   )
   process.exit(1)
 }


### PR DESCRIPTION
Bundle 1 of 3 (pre-Docker codex audit). **Code bugs** — surfaces that actively misinform agents/operators on *live* paths, grounded against current behavior before rewriting.

- **profiles/default/CLAUDE.md.hbs** — scaffolded "Scheduled Tasks" block told every default agent its cron is isolated one-shot `claude -p`, no shared session/context, Sonnet, output→Telegram. All false post-Phase-4 (cron fires a synthesized inbound turn into the running session, normal session/context/model, in transcript+Hindsight). Rewritten to the accurate model (per scheduling.md:3).
- **Runtime-aware remediation** (v0.7+ agents are Dockerized — no systemd/journalctl in-container; gate on `SWITCHROOM_RUNTIME==='docker'`, the canonical detection): boot-card.ts crash row (was unconditional, pinned to Telegram every crash) → `docker logs`; boot-probes.ts Hindsight-down nextStep → drop bogus `systemctl --user status hindsight`; server.ts sidecar-exit → `docker logs`/`agent restart` instead of a nonexistent gateway systemd unit.

tsc + 3 lint checks clean; 107 boot + 171 scaffold tests pass.

🤖 Generated with Claude Code