### PR TITLE
docs(codex): correct pre-Docker model in CLAUDE.md + agent skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,10 +109,19 @@ operation. Future work: an opt-in strict-isolation mode with
 `extra_hosts: host.docker.internal`.
 
 **Self-restart commands (`/restart`, `/new`, `/reset`, `/update apply`).**
-The gateway shells `switchroom <verb>` via `spawnSwitchroomDetached`
-(`telegram-plugin/gateway/gateway.ts`). Two load-bearing primitives in
-that helper that are easy to "simplify away" and break the self-
-restart case:
+Since RFC C Phase 2 (default-flip, #1338) `host_control.enabled`
+defaults **true**, so the gateway dispatches these four verbs through
+the **`switchroom-hostd`** daemon (a host-side container in its own
+compose project with the docker socket mounted) over UDS —
+`telegram-plugin/gateway/hostd-dispatch.ts` is the primary path.
+`spawnSwitchroomDetached` (`telegram-plugin/gateway/gateway.ts`) is now
+the **fallback**, used only when hostd is `"not-configured"`
+(host_control explicitly disabled, per-agent socket absent, or daemon
+unreachable). There is deliberately *no* silent spawn fallback when
+hostd is configured-on.
+
+Two load-bearing primitives in the spawn-detached *fallback* path that
+are easy to "simplify away" and break the self-restart case:
 
   1. **Detached spawn + restart-marker dance.** The gateway runs
      inside the agent container in v0.7+; when it asks docker (via
@@ -138,15 +147,15 @@ restart case:
 
 **`/update apply` docker-availability guard (#926).** The agent
 container has no docker binary or `/var/run/docker.sock` mount.
-`isDockerReachable()` in the gateway probes both before invoking
-`switchroom update`; on failure it surfaces a clean error pointing
-at the host CLI rather than letting the detached child fail with
-opaque exit-127. The proper fix is the host-control daemon (RFC C
-at `docs/rfcs/host-control-daemon.md`): a host-side docker
-container — outside the switchroom compose project, with the
-docker socket mounted — that the gateway calls into via UDS.
-Phase 1 (library + opt-in flag + per-agent socket bind mounts) has
-landed; Phase 2 swaps the gateway callsites.
+`isDockerReachable()` in the gateway probes both before the
+spawn-detached fallback; on failure it surfaces a clean error
+pointing at the host CLI rather than an opaque exit-127. The proper
+fix — the host-control daemon (RFC C,
+`docs/rfcs/host-control-daemon.md`) — **has landed**: Phase 1
+(library + per-agent socket bind mounts) and Phase 2 (gateway
+callsites swapped, default-on, #1306/#1338) are both shipped, so
+hostd is the primary path described above. Phase 3 (removing the
+legacy `systemd-run` fallback branch) is the only remaining step.
 
 **Agent-scheduler env knobs.**
 - `SWITCHROOM_INLINE_SCHEDULER` — set to `0` in the compose env to

--- a/skills/file-bug/SKILL.md
+++ b/skills/file-bug/SKILL.md
@@ -74,11 +74,13 @@ Switchroom's standard log map (resolve `<agent>` from the user or from `SWITCHRO
 |---|---|---|
 | Gateway events | `~/.switchroom/agents/<agent>/telegram/gateway.log` | Inbound/outbound messages, IPC, progress card, watcher, classifier output |
 | Claude stdout/stderr | `~/.switchroom/agents/<agent>/service.log` | The agent's own session output, tool calls, errors |
-| Systemd lifecycle | `journalctl --user -u switchroom-agent-<agent>` | Boot/restart/crash, exit codes |
-| Cron lifecycle | `journalctl --user -u switchroom-agent-<agent>-cron` | Scheduled-task firings |
-| Vault broker | `journalctl --user -u switchroom-vault-broker` | Audit log, ACL gates |
+| Container lifecycle | `docker logs switchroom-<agent>` | Boot/restart/crash, exit codes |
+| Cron firings | `docker logs switchroom-<agent>` (lines prefixed `agent-scheduler:`) | Scheduled-task firings (in-container sidecar since Phase 4) |
+| Vault broker | `docker logs switchroom-vault-broker` | Audit log, ACL gates |
 
-For each relevant source: extract the slice that brackets the symptom window. Use `awk '/<start-ts>/,/<end-ts>/'` or `journalctl --since "10 min ago"`. Do **not** paste raw multi-MB dumps; cap each excerpt at the lines that actually matter and signpost what was clipped.
+(v0.7+ agents run in Docker — there is no systemd/`journalctl` in-container; logs are `docker logs`. Only a legacy non-docker install would use `journalctl --user -u switchroom-…`.)
+
+For each relevant source: extract the slice that brackets the symptom window. Use `docker logs --since 10m switchroom-<agent>` or pipe through `awk '/<start-ts>/,/<end-ts>/'`. Do **not** paste raw multi-MB dumps; cap each excerpt at the lines that actually matter and signpost what was clipped.
 
 If the gateway.log doesn't have what you need, check whether `progress-card.log`, `bridge.log`, or `subagent-watcher.log` are configured separately on this agent (some setups split).
 

--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -234,11 +234,14 @@ List cron jobs and scheduled tasks.
 
 ### Step 1 — Show live timers
 
-Cron timers in v0.7+ run inside the per-agent scheduler container. Inspect
-its log to see fired jobs:
+Since Phase 4 (#893) cron runs **in-container** as the `agent-scheduler`
+sidecar inside each agent — the old `switchroom-<agent>-scheduler` /
+`switchroom-cron` singleton container no longer exists. Inspect fired
+jobs in the agent's own log; scheduler lines are prefixed
+`agent-scheduler:`:
 
 ```bash
-docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml logs switchroom-<agent>-scheduler --tail 100
+docker logs --tail 100 switchroom-<agent> 2>&1 | grep agent-scheduler:
 ```
 
 ### Step 2 — Show declared schedule entries

--- a/skills/switchroom-install/SKILL.md
+++ b/skills/switchroom-install/SKILL.md
@@ -107,7 +107,7 @@ This is the default. One OAuth flow per Anthropic account, then every agent in t
 ## What not to do
 
 - **Do not** run `switchroom setup` non-interactively or pipe input to it — it's designed for a human.
-- **Do not** edit `~/.switchroom/vault.enc` or any file under `~/.switchroom/` directly. Use the CLI.
-- **Do not** run `docker build` on the operator's host. The 5 fleet images are published on GHCR; `switchroom apply` writes a compose file that pulls them.
-- **Do not** suggest the legacy `switchroom up` / `switchroom init` / `switchroom update` verbs — they were removed in v0.7. The current flow is `switchroom apply && docker compose pull && docker compose up -d`.
+- **Do not** edit the vault (`~/.switchroom/vault/`) or any file under `~/.switchroom/` directly. Use the CLI.
+- **Do not** run `docker build` on the operator's host. The fleet images are published on GHCR; `switchroom apply` writes a compose file that pulls them.
+- **Do not** suggest the legacy `switchroom up` / `switchroom init` verbs — they were removed. NOTE: `switchroom update` is **current and canonical** — it is the one-shot upgrade path (pull images + apply + recreate + doctor); recommend it for "how do I update". A fresh install/redeploy is `switchroom apply && docker compose pull && docker compose up -d`.
 - **Do not** reinstall over an existing install without asking. If the user wants a clean slate, have them run `switchroom uninstall` first (or confirm they want to blow away `~/.switchroom/`).


### PR DESCRIPTION
Bundle 2 of 3. **Agent-facing** guidance that steered agents wrong.

- **CLAUDE.md** self-restart section presented spawn-detached as THE path + "Phase 2 swaps the gateway callsites" as future. Phase 2 shipped (#1306/#1338): host_control default-on, the 4 verbs dispatch via switchroom-hostd (primary), spawn-detached is the not-configured/unreachable fallback. Load-bearing primitives kept; Phase 3 noted as the only remaining step.
- **skills/switchroom-install** falsely said `switchroom update` was "removed in v0.7" (it's the canonical current upgrade verb — an onboarding agent would refuse it). Fixed; up/init stay removed; vault.enc→vault/.
- **skills/switchroom-cli** told agents to `docker compose logs switchroom-<agent>-scheduler` — that container was retired Phase 4; 404s. → `docker logs switchroom-<agent>` / `agent-scheduler:` lines.
- **skills/file-bug** log-source table's 3 `journalctl --user -u` rows don't exist in-container → `docker logs` + runtime caveat.

Docs/skills only. bun lint clean.

🤖 Generated with Claude Code