### PR TITLE
docs(codex): retire pre-Docker/pre-RFC-H narrative in user docs + comments

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,7 @@ Key flags:
 Environment variables set before exec:
 
 - `CLAUDE_CONFIG_DIR` — pinned to `/agent/.claude/` (the agent's per-container config dir, host-mounted from `~/.switchroom/agents/<agent>/.claude/`). Fully isolates each agent's auth, settings, transcripts, and MCP config from every other agent and from the user's personal Claude setup.
-- `CLAUDE_CODE_OAUTH_TOKEN` — populated from the active slot or shared Anthropic account.
+- `CLAUDE_CODE_OAUTH_TOKEN` — **defensively unset** by `start.sh`. Switchroom does not inject an OAuth token via env; `claude` reads `<CLAUDE_CONFIG_DIR>/.credentials.json`, which the `switchroom-auth-broker` container is the sole writer of.
 
 This is an **interactive REPL**, not `claude -p`. The session is persistent and long-lived; continuity across container restarts is provided by the switchroom layer (handoff briefing + Hindsight recall + Telegram history buffer), not by `--continue` (which is off by default).
 

--- a/docs/botfather-walkthrough.md
+++ b/docs/botfather-walkthrough.md
@@ -123,7 +123,8 @@ it during `switchroom setup` for the `allowFrom` ACL.
 For each bot, open it in Telegram (search by username, or use the
 direct link BotFather sent: `t.me/<bot_username>`) and tap **Start**.
 
-The agent bot won't reply until setup, `switchroom auth login`, and
+The agent bot won't reply until setup, authentication
+(`switchroom auth add me --from-oauth && switchroom auth use me`), and
 `docker compose ... up -d` are done.
 
 ## Optional: profile picture + description

--- a/docs/compliance-attestation.md
+++ b/docs/compliance-attestation.md
@@ -15,7 +15,9 @@ Switchroom is a multi-agent orchestration tool for Claude Code. This document pr
 Switchroom is scaffolding and lifecycle management for multiple Claude Code sessions. It:
 
 1. Creates directory structures and configuration files for each agent
-2. Generates systemd units to keep agents running
+2. Generates a Docker Compose project to keep agents running (one
+   container per agent, plus shared singleton containers; the container
+   restart policy keeps sessions alive — no systemd units are generated)
 3. Assigns one Telegram bot per agent, each using the official Telegram plugin
 4. Provides a CLI for managing agent lifecycle (start, stop, restart, logs)
 5. Manages an encrypted vault for secrets
@@ -43,7 +45,7 @@ Switchroom does **not**:
 
 **Source:** [Legal and compliance - Claude Code Docs](https://code.claude.com/docs/en/legal-and-compliance) (OAuth prohibition); [Anthropic clarifies ban on third-party tool access to Claude — The Register, 2026-02-20](https://www.theregister.com/2026/02/20/anthropic_clarifies_ban_third_party_claude_access/) (Agent SDK and third-party tools clarification); [Anthropic tests removing Claude Code from Pro — The Register, 2026-04-22](https://www.theregister.com/2026/04/22/anthropic_removes_claude_code_pro/) (pricing-page packaging change)
 
-**Switchroom's compliance:** Switchroom leverages Claude Code natively — no Agent SDK, no direct API usage, no custom runtime. Each agent is an unmodified `claude` CLI process started the same way a user would start one, authenticated via Claude Code's own OAuth flow completed in the terminal. Switchroom reads the OAuth token from the agent's local `.credentials.json` solely to manage multi-account slot rotation on the same machine (writing a companion slot file, `accounts/<slot>/.oauth-token`). The token is never transmitted off-device, never forwarded to a third party, and never used by switchroom to make inference calls on the user's behalf. All inference happens between the user's Claude Code session and Anthropic's servers directly, via Claude Code's built-in client.
+**Switchroom's compliance:** Switchroom leverages Claude Code natively — no Agent SDK, no direct API usage, no custom runtime. Each agent is an unmodified `claude` CLI process started the same way a user would start one, authenticated via Claude Code's own OAuth flow completed in the terminal. A local `switchroom-auth-broker` container holds the per-account OAuth credentials on the same machine and writes a per-agent `.credentials.json` mirror into each agent's host-mounted Claude config directory — the same on-disk file Claude Code reads natively — solely to manage multi-account use and refresh locally. The token is never transmitted off-device, never forwarded to a third party, and never used by switchroom to make inference calls on the user's behalf. All inference happens between the user's Claude Code session and Anthropic's servers directly, via Claude Code's built-in client.
 
 Switchroom's auth flow Phase 1 (`src/auth/pane-ready-probe.ts`) automates only keystroke entry into the terminal during the OAuth flow. The authentication relationship is directly between the user's Claude Code session and Anthropic.
 
@@ -76,13 +78,13 @@ Operators who require strict use of Anthropic-published code paths should set `c
 
 **Switchroom's compliance:** The switchroom-telegram plugin is a standard MCP server using the official `@modelcontextprotocol/sdk` package (confirmed in `telegram-plugin/package.json` v1.0.0) and follows the documented MCP protocol. (The legacy `switchroom-mcp/` management server was removed under #235; its 4 tools were dormant and the functionality is now covered natively by Hindsight's MCP and Claude Code's built-in `Read`/`Grep`.)
 
-### 4. systemd/tmux Process Management Is Standard Operations
+### 4. Docker/tmux Process Management Is Standard Operations
 
 **Anthropic's documentation:** "For an always-on setup you run Claude in a background process or persistent terminal." The Telegram channel documentation specifically notes using persistent terminals.
 
 **Source:** [Channels - Claude Code Docs](https://code.claude.com/docs/en/channels)
 
-**Switchroom's compliance:** Switchroom generates systemd user units that keep Claude Code sessions running. This is standard Linux process management — the same as running Claude Code in tmux, screen, or any other process supervisor. Anthropic explicitly acknowledges this use case in their channels documentation.
+**Switchroom's compliance:** Switchroom runs each agent as a Docker container whose restart policy keeps the Claude Code session running, with `claude` itself executing inside a persistent `tmux` session in that container. This is standard process management — the same as running Claude Code under tmux, screen, or any other process supervisor. Anthropic explicitly acknowledges this use case in their channels documentation.
 
 ### 5. No Modification of Claude Code
 
@@ -123,7 +125,7 @@ Users must explicitly grant access via sender allowlists in `access.json` and th
 4. It routes outbound Claude Code responses back through Telegram
 5. It never handles, stores, or forwards OAuth tokens or subscription credentials
 
-The gateway stays alive across Claude Code session restarts (via systemd), allowing persistent Telegram connectivity without restarting the OAuth flow. This is explicitly permissible per Anthropic's documentation on persistent terminals.
+The gateway stays alive across Claude Code session restarts (it runs as a supervised sidecar in the agent's container, alongside the tmux-hosted `claude` session), allowing persistent Telegram connectivity without restarting the OAuth flow. This is explicitly permissible per Anthropic's documentation on persistent terminals.
 
 ### Auth Flow Phase 1 (OAuth Keystroke Automation)
 
@@ -131,8 +133,8 @@ The gateway stays alive across Claude Code session restarts (via systemd), allow
 
 **Compliance take:** This is **compliant** because:
 1. It only automates manual keystroke entry (pasting the code shown in the browser)
-2. The token is written directly by `claude setup-token` into `.credentials.json` in the agent's local Claude directory
-3. Switchroom reads the token locally from `.credentials.json` solely to write the companion slot file (`accounts/<slot>/.oauth-token`) for multi-account rotation — it does not route the token through any external infrastructure
+2. The token is written directly by the native Claude Code OAuth flow into `.credentials.json` in the agent's local Claude directory
+3. The local `switchroom-auth-broker` container holds the per-account OAuth credentials and writes a per-agent `.credentials.json` mirror into the agent's host-mounted Claude config directory for multi-account use — it does not route the token through any external infrastructure
 4. The token never leaves the machine
 
 ---
@@ -140,8 +142,13 @@ The gateway stays alive across Claude Code session restarts (via systemd), allow
 ## Architecture Evidence
 
 ### Each agent is a real Claude Code session:
+
+Each agent is one Docker container whose `CMD` runs `{agentDir}/start.sh`
+under `tini`; `start.sh` enters a persistent `tmux` session and `exec`s
+the unmodified `claude` CLI. Container stdout/stderr is captured by the
+Docker logging driver (`docker logs`):
 ```
-ExecStart=/usr/bin/script -qfc "/bin/bash -l {agentDir}/start.sh" {logFile}
+CMD ["/state/agent/start.sh"]   # under tini (PID 1); start.sh → tmux → bash → claude
 ```
 
 ### start.sh runs the unmodified claude CLI with one of the two channel modes:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,84 +309,66 @@ Host prerequisites:
 - Python venvs need `python3-venv` (on Debian/Ubuntu: `apt install python3.12-venv`). `switchroom health` reports missing deps.
 - Node envs use `bun` by default. `npm` is available as an alternate installer.
 
-## Multi-Account OAuth (Slot Pool)
+## Multi-Account OAuth (auth-broker)
 
-Each agent owns a **pool** of Claude OAuth account slots. One slot is
-active at a time; the others sit in the pool as automatic fallbacks when
-the active slot hits a quota window. Nothing in `switchroom.yaml`
-describes the pool — it's managed at runtime via `switchroom auth` (or
-`/auth` inside Telegram).
+Authentication is **account-scoped and fleet-wide**, not per-agent. One
+OAuth flow per Anthropic account; "use this account on these agents" is
+configuration, not another OAuth round. The `switchroom-auth-broker`
+compose singleton is the **sole writer** of every agent's
+`<agentDir>/.claude/.credentials.json` — agents never refresh tokens or
+write credentials themselves. There is no per-agent OAuth slot tree and
+no `CLAUDE_CODE_OAUTH_TOKEN` injection; `start.sh` defensively unsets
+that env var and `claude` reads `.credentials.json` directly.
 
-On-disk layout per agent:
+`switchroom.yaml` carries the fleet-wide `auth.active` (plus an
+optional `fallback_order` and rare per-agent `auth.override`):
 
+```yaml
+auth:
+  active: me@example.com        # fleet-wide active account
+  fallback_order:               # cycle list for `auth rotate` / 429 failover
+    - me@example.com
+    - work
 ```
-<agentDir>/.claude/
-  accounts/
-    <slot>/
-      .oauth-token             # token value
-      .oauth-token.meta.json   # { createdAt, expiresAt, quotaExhaustedUntil?, source }
-  active                       # text file: name of the active slot
-  .oauth-token                 # LEGACY path, mirrored from the active slot
-  .oauth-token.meta.json       # LEGACY path, mirrored from the active slot
+
+Bootstrap and day-to-day verbs:
+
+```bash
+switchroom auth add me --from-oauth   # browser OAuth flow
+switchroom auth add me --via-claude   # drives claude's native OAuth (broader scope)
+switchroom auth use me                # make it the fleet active account
+switchroom auth list                  # state of the fleet
+switchroom auth rotate                # cycle to next non-exhausted account
+switchroom auth refresh               # force a broker refresh tick
 ```
 
-Slot names must match `[A-Za-z0-9._-]+` (max 64 chars). The legacy
-top-level token paths are always kept in sync with the active slot so
-`start.sh` and the `claude` CLI see no layout change.
+> `switchroom auth login` and `switchroom auth status` were **removed**
+> with the auth-broker migration (RFC H). Use `auth add` / `auth use`
+> to authenticate and `auth list` / `auth show` to inspect state.
 
 ### Auto-fallback on quota exhaustion
 
-The switchroom telegram plugin polls each agent's quota. When the active
-slot crosses the exhaustion threshold (~99.5% utilisation) the plugin:
+Quota handling is broker-internal — there is no plugin-polled fallback
+loop. When any consumer (agent or hindsight) hits a 429 it calls the
+broker's `mark-exhausted` verb; the broker marks the account exhausted,
+walks every agent on it, looks up each agent's next non-exhausted
+account from `fallback_order`, and atomically rewrites their per-agent
+`.credentials.json`. Failover propagates in seconds without per-agent
+restarts. When the exhaustion window passes the broker clears the mark
+and agents that prefer the cleared account drift back on next idle.
 
-1. Marks the slot `quota-exhausted` (writes `quotaExhaustedUntil` into
-   the slot's meta file).
-2. Picks the next healthy slot in the pool and switches to it.
-3. Restarts the agent so the new token is picked up.
-4. Posts a short notice into the chat; if no fallback slot is available,
-   prompts you to `/auth add <agent>` another subscription.
+### Broker-internal token refresh
 
-A per-slot cooldown prevents fallback-loop storms if two polls race.
-Source: `telegram-plugin/auto-fallback.ts`, `src/auth/accounts.ts`.
+The broker runs one refresh loop per account (not per agent) and
+rewrites the canonical credentials when an access token's remaining
+lifetime drops below the refresh threshold. `switchroom auth refresh`
+forces a refresh tick; the broker decides which accounts actually need
+it. There is no host-side `refresh-tick` verb or cron line to wire up —
+the broker owns the cadence.
 
-### Switchroom-managed token refresh (`auth refresh-tick`)
-
-Anthropic's OAuth access tokens are short-lived (typically 8 hours). Pre-#429
-the only thing that rotated them was the agent's own `claude` process noticing
-expiry mid-turn — which fails for stop-hook subprocesses (where claude code
-strips `CLAUDE_CODE_OAUTH_TOKEN` from env) and for agents that haven't received
-a turn in 24h+. The result was silent 401s on the next inbound message.
-
-`switchroom auth refresh-tick` rotates tokens proactively. Iterate every
-agent, check `<agentDir>/.claude/.credentials.json`, and POST to Anthropic's
-OAuth refresh endpoint when the access token's remaining lifetime is below
-the threshold (default 1h) AND a `refreshToken` is present. The new token
-is atomically rewritten into both `.credentials.json` and the active slot's
-`.oauth-token` (so start.sh and the legacy mirror see it).
-
-```bash
-switchroom auth refresh-tick                       # default 1h threshold, prose output
-switchroom auth refresh-tick --json                # structured summary for logs
-switchroom auth refresh-tick --threshold-ms 7200000  # custom threshold (2h here)
-```
-
-The tick is idempotent and safe to run as often as you like — when nothing
-needs refreshing it makes no network calls and writes no files. Wire it to
-a cron line on the host (or to an agent's `schedule:` block, which fires
-through the in-agent scheduler sidecar — see [scheduling.md](./scheduling.md)):
-
-```
-# crontab — every 15 minutes
-*/15 * * * * switchroom auth refresh-tick --json >> ~/.switchroom/refresh.log 2>&1
-```
-
-Outcomes per agent: `refreshed`, `skipped-fresh`, `skipped-no-refresh-token`
-(boot-self-test will already be prompting the user to re-auth in chat),
-`skipped-no-credentials`, `skipped-malformed`, `failed`. Process exits
-non-zero only when every refresh attempt failed AND nothing was already
-fresh — partial failures stay visible without taking the timer down.
-
-Source: `src/auth/token-refresh.ts`.
+See [`docs/auth.md`](auth.md) for the full model (mental model,
+filename conventions, refresh windows, drift detection, the Telegram
+`/auth` surface, and ephemeral consumers).
 
 ## Google Workspace (`google_workspace:`)
 

--- a/docs/operators/install.md
+++ b/docs/operators/install.md
@@ -10,8 +10,9 @@ fleet up via `docker compose`. No `docker build` on the operator's host.
 - Linux (Ubuntu 24.04 LTS canonical; other distros work).
 - Docker Engine 24+ with the compose v2 plugin (`docker compose ...`).
 - The `claude` CLI on the host (`npm i -g @anthropic-ai/claude-code`,
-  Node 20.11+) for OAuth login. The agent runtime itself ships in
-  containers — the host only needs `claude` for `switchroom auth login`.
+  Node 20.11+) for OAuth. The agent runtime itself ships in
+  containers — the host only needs `claude` for the
+  `switchroom auth add --via-claude` flow.
 
 ## Install — one-liner (recommended)
 
@@ -30,10 +31,16 @@ Then bring up your fleet:
 # 1. Interactive first-time wiring (Telegram bot token, vault, first agent).
 switchroom setup
 
-# 2. Scaffold agents + write ~/.switchroom/compose/docker-compose.yml.
+# 2. Authenticate with your Claude subscription (one OAuth flow,
+#    fleet-wide). The auth-broker becomes the sole writer of every
+#    agent's credentials.
+switchroom auth add me --from-oauth
+switchroom auth use me
+
+# 3. Scaffold agents + write ~/.switchroom/compose/docker-compose.yml.
 switchroom apply
 
-# 3. Bring the fleet up.
+# 4. Bring the fleet up.
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 ```

--- a/docs/posthog.md
+++ b/docs/posthog.md
@@ -38,7 +38,7 @@ A random UUID is generated on first run and persisted at
 `~/.switchroom/analytics-id`. That file is the only personally identifiable
 value we keep. It's not tied to any OS-level identifier (username, MAC, etc.).
 
-If you run `switchroom auth login` and we gain access to a user-scoped identity
+If you run `switchroom auth add` and we gain access to a user-scoped identity
 in the future, call `client.identify({ distinctId, $anon_distinct_id: <uuid> })`
 to merge the anonymous ID into the real one. We don't do that today.
 

--- a/docs/vault-broker.md
+++ b/docs/vault-broker.md
@@ -1,46 +1,58 @@
 # Vault Broker — ACL model and access guide
 
-> **v0.7 note.** Under v0.7+ the broker runs as the `switchroom-broker`
-> container and authenticates connecting clients by the socket path the
-> connection arrived on (`/run/switchroom/broker/<agent>/sock`,
-> broker-controlled per-agent socket), not by parsing systemd cgroups.
-> The terms "cron unit" / "systemd unit" / cgroup parsing below describe
-> the v0.6 host-native broker; the ACL contract — "only declared cron
-> secrets, only the cron caller for that agent" — is identical, and the
-> per-agent `secrets:` allowlist still drives what each cron can read.
+The vault broker runs as the `switchroom-vault-broker` container (a
+`docker compose` singleton in the `switchroom` project) and
+authenticates connecting clients by the socket path the connection
+arrived on (`/run/switchroom/broker/<agent>/sock`, a broker-controlled
+per-agent socket), not by parsing systemd cgroups. Cron is the in-agent
+`agent-scheduler` sidecar (since Phase 4 — see
+[scheduling.md](scheduling.md)); there are no
+`switchroom-<agent>-cron-N.service` systemd units. The ACL contract —
+"only declared `secrets:`, only the scheduled run for that agent" — and
+the per-agent `secrets:` allowlist drive what each scheduled task can
+read.
 
 ## What is the vault broker?
 
-The vault broker is a per-host daemon that holds the decrypted vault in
-memory and serves secrets to authorised **switchroom scheduler containers**
-over a Unix socket. It avoids re-prompting for the vault passphrase on
-every scheduled run.
+The vault broker is a long-running container that holds the decrypted
+vault in memory and serves secrets to authorised **switchroom agents'
+scheduled runs** over a per-agent Unix socket. It avoids re-prompting
+for the vault passphrase on every scheduled run.
 
-The broker is **not** a general-purpose secret server.  It only serves callers
-it can positively identify as a switchroom cron unit — it does not serve
-interactive shells, Claude Code sessions, or arbitrary scripts.
+The broker is **not** a general-purpose secret server.  It only serves a
+scheduled run's declared `secrets[]` keys for the agent that owns the
+socket — it does not serve interactive shells, Claude Code sessions, or
+arbitrary scripts.
 
 ## Who can read from the broker?
 
 | Caller context | Broker access |
 |---|---|
-| systemd unit `switchroom-<agent>-cron-<N>.service` | Allowed if the requested key is in `schedule[N].secrets` |
+| Scheduled run for `agent-<name>` (via that agent's bound socket) | Allowed if the requested key is in `schedule[N].secrets` |
 | Interactive shell (`switchroom vault get`) | **Denied** — use `--no-broker` |
 | Claude Code / agent session | **Denied** — use `--no-broker` |
 | Any other caller | **Denied** |
 
-Identity is established via Linux cgroup membership (peercred + `/proc`).
-When systemd starts a cron unit it places the process in a dedicated cgroup
-that it writes as root — processes cannot move themselves between cgroups, so
-the unit name is unspoofable.
+Identity is **path-as-identity**: compose binds one socket per agent at
+`/run/switchroom/broker/<agent>/sock`, chowned to that agent's UID at
+mode 0600 at bind time. The broker derives the calling agent's name from
+that bind path via `socketPathToAgent` (`src/vault/broker/peercred.ts`).
+Because the path is broker-controlled — never sent by the caller — it
+cannot be forged from userspace.
 
 ## Why are agents denied?
 
 The broker's ACL is misconfiguration protection, not a security boundary
 (see `docs/architecture.md`).  Allowing arbitrary agent sessions to read the
-vault would mean any skill or sub-agent could exfiltrate any secret.  Cron
-units receive only the keys explicitly listed in their `schedule[N].secrets`
-allowlist.
+vault would mean any skill or sub-agent could exfiltrate any secret.  A
+scheduled run receives only the keys explicitly listed in its
+`schedule[N].secrets` allowlist.
+
+> The CLI's denial string and some legacy ACL internals still say
+> "switchroom cron unit" — that vocabulary predates the Phase 4
+> cron-fold-in. It now means "a scheduled run dispatched by the
+> in-agent `agent-scheduler` sidecar", identified by the per-agent
+> socket bind path.
 
 Agent sessions are expected to receive secrets as environment variables
 injected by the cron job itself, not by querying the broker at runtime.

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -1,9 +1,10 @@
 # Vault — Operator Guide
 
-Switchroom's vault is an AES-256-GCM encrypted file (`vault.enc`) that stores
-secrets used by agents and scheduled cron tasks.  This guide covers the
-architecture, how to declare and scope secrets, Telegram commands for runtime
-management, the audit log, and the threat model.
+Switchroom's vault is a directory (`~/.switchroom/vault/`) holding an
+AES-256-GCM encrypted store (`vault.enc`) that keeps secrets used by
+agents and scheduled tasks.  This guide covers the architecture, how to
+declare and scope secrets, Telegram commands for runtime management, the
+audit log, and the threat model.
 
 > ## v0.7.12 layout change
 >
@@ -35,39 +36,49 @@ management, the audit log, and the threat model.
 ## Architecture
 
 ```
-vault.enc (AES-256-GCM, passphrase-derived)
+~/.switchroom/vault/vault.enc (AES-256-GCM, passphrase-derived)
     │
-    └── vault broker daemon  (Unix socket: ~/.switchroom/vault-broker.sock)
-            │  mode 0600 — only the owner UID may connect
-            │  identity via peercred + cgroup — not spoofable from userspace
+    └── switchroom-vault-broker  (Docker compose singleton)
+            │  per-agent Unix socket: /run/switchroom/broker/<agent>/sock
+            │  mode 0600, chowned to the agent UID at bind time
+            │  identity = the bind path (path-as-identity), not a wire payload
             │
-            ├── switchroom-<agent>-cron-0.service   (allowed, if key in secrets[])
-            ├── switchroom-<agent>-cron-1.service   (allowed, if key in secrets[])
-            └── (all other callers)                 → DENIED
+            ├── agent-<name>  (scheduled run)  (allowed, if key in secrets[])
+            └── (all other callers)            → DENIED
 ```
 
-The broker is a long-running user-level systemd unit
-(`~/.config/systemd/user/switchroom-vault-broker.service`).  It holds the
-decrypted vault in memory after a one-time passphrase unlock.  When a cron
-unit makes a `get` request the broker:
+The broker is a long-running Docker container — a `docker compose`
+singleton in the `switchroom` project, not a systemd user unit.  It
+holds the decrypted vault in memory after a one-time passphrase unlock
+(or machine-bound auto-unlock).  Compose binds one socket per agent at
+`/run/switchroom/broker/<agent>/sock`; the broker derives the calling
+agent's identity from that **bind path** via `socketPathToAgent`
+(`src/vault/broker/peercred.ts`) — never from systemd cgroups, and
+never from anything the caller sends on the wire.  When a scheduled
+run makes a `get` request the broker:
 
-1. Identifies the caller via Linux cgroup membership (cgroups are written by
-   systemd as root — processes cannot move themselves between cgroups).
+1. Parses the agent name from the socket the connection arrived on
+   (path-as-identity; the path is broker-controlled at bind time).
 2. Checks the per-schedule `secrets[]` allowlist.
 3. Checks the per-key scope ACL (if set via `--allow` / `--deny`).
 4. Returns the value or denies with a logged reason.
 
-Interactive calls (`switchroom vault get`) go directly to the vault file with
-the user's passphrase — the broker is for cron-only access.
+Cron is the in-agent `agent-scheduler` sidecar (since Phase 4 — see
+[scheduling.md](scheduling.md)); there are no
+`switchroom-<agent>-cron-N.service` systemd units.  Interactive calls
+(`switchroom vault get`) go directly to the vault store with the user's
+passphrase — the broker is for scheduled (non-interactive) access.
 
 ---
 
 ## Commands
 
-### Initialise and populate the vault
+### Populate the vault
+
+The vault store is created on first `set` (it prompts for a passphrase
+when no store exists yet — there is no separate `vault init` verb).
 
 ```sh
-switchroom vault init                          # create vault.enc (prompts for passphrase)
 switchroom vault set <key>                     # set a secret interactively
 switchroom vault set <key> --file /path/to     # read value from file (PEM, JSON, etc.)
 switchroom vault get <key>                     # decrypt and print (direct, not via broker)
@@ -230,9 +241,11 @@ switchroom vault audit --who my-agent-cron-0
   access to another cron's keys.  Each cron task only sees keys explicitly
   listed for it.
 - **Hijacked agent on this UID**: a compromised agent Claude session cannot
-  read vault keys via the broker — the broker only serves systemd cron units,
-  not interactive Claude processes.  The cgroup identity is set by systemd as
-  root and cannot be spoofed from userspace.
+  read vault keys via the broker — the broker only answers a scheduled run's
+  `secrets[]`-listed keys, not arbitrary interactive Claude requests.  The
+  caller's agent identity is the bind path of the per-agent socket, which
+  the broker controls at bind time (chowned to the agent UID, mode 0600) —
+  it cannot be forged by a wire payload.
 - **Per-key scoping**: `--allow` / `--deny` narrows access further, so even a
   legitimate cron unit cannot read keys it is not explicitly permitted to read.
 

--- a/src/auth/accounts.ts
+++ b/src/auth/accounts.ts
@@ -1,7 +1,21 @@
 /**
  * Multi-account Claude OAuth slot management.
  *
- * Storage layout (per agent):
+ * ┌─ LEGACY (post-RFC-H) ───────────────────────────────────────────────┐
+ * │ This module is legacy per-agent slot scaffolding. Since the          │
+ * │ auth-broker migration (RFC H), the `switchroom-auth-broker`          │
+ * │ container is the SOLE writer of every agent's                        │
+ * │ <agentDir>/.claude/.credentials.json, and `claude` reads that        │
+ * │ dotfile directly. There is no per-agent OAuth slot tree in the       │
+ * │ current runtime, no `CLAUDE_CODE_OAUTH_TOKEN` injection (start.sh    │
+ * │ defensively unsets it), and the legacy `.oauth-token` mirror is no   │
+ * │ longer load-bearing for booting an agent. The slot/active/mirror     │
+ * │ machinery below is retained for back-compat and migration paths      │
+ * │ only — see docs/auth.md for the authoritative current model. Do not  │
+ * │ build new behavior on this layout.                                   │
+ * └─────────────────────────────────────────────────────────────────────┘
+ *
+ * Historical storage layout (per agent), as described by this module:
  *   <agentDir>/.claude/
  *     accounts/
  *       <slot>/
@@ -12,8 +26,10 @@
  *     .oauth-token              — LEGACY path, kept in sync with the active slot
  *     .oauth-token.meta.json    — LEGACY path, kept in sync with the active slot
  *
- * The legacy `.oauth-token` / meta files are always mirrored from the active
- * slot so that start.sh.hbs and Claude Code itself see no layout change.
+ * The legacy `.oauth-token` / meta files were historically mirrored from
+ * the active slot so that start.sh.hbs and Claude Code saw no layout
+ * change; under the broker model this mirror is no longer the path
+ * Claude Code reads.
  *
  * Slot names are validated: [A-Za-z0-9._-]+, max 64 chars, no `..`, no `/`.
  */
@@ -257,11 +273,17 @@ export function setSlotLabel(
   writeSlotMeta(agentDir, slot, meta);
 }
 
-/* ── Legacy mirror ───────────────────────────────────────────────────── */
+/* ── Legacy mirror (post-RFC-H: no longer load-bearing) ──────────────── */
 
 /**
- * Sync the legacy top-level .oauth-token (+ meta) path from the active slot
- * so that start.sh / Claude Code see no layout change.
+ * Sync the legacy top-level .oauth-token (+ meta) path from the active slot.
+ *
+ * LEGACY: this mirror was load-bearing pre-RFC-H, when start.sh / Claude
+ * Code read the top-level `.oauth-token`. Under the auth-broker model the
+ * broker owns `.credentials.json` (which is what `claude` reads) and
+ * start.sh defensively unsets `CLAUDE_CODE_OAUTH_TOKEN`, so this mirror
+ * no longer gates an agent's authentication. Retained for back-compat /
+ * migration only.
  *
  * Atomic write: read source → write to a sibling tempfile in the same
  * directory → renameSync onto the destination. Pre-fix this used

--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -296,7 +296,13 @@ function authFilesAreInaccessible(agentDir: string): boolean {
 
 /**
  * Write the token into the slot-aware storage AND mirror the legacy
- * top-level .oauth-token path so start.sh.hbs / Claude Code keep working.
+ * top-level .oauth-token path.
+ *
+ * LEGACY (post-RFC-H): the `.oauth-token` mirror is no longer
+ * load-bearing — the `switchroom-auth-broker` container is the sole
+ * writer of `.credentials.json` (which is what `claude` reads), and
+ * start.sh defensively unsets `CLAUDE_CODE_OAUTH_TOKEN`. This path is
+ * retained for back-compat / migration only.
  *
  * If `slot` is unspecified, writes to the active slot (migrating legacy
  * layout if needed); if no active slot exists, creates "default".
@@ -526,6 +532,9 @@ export function getAuthStatus(name: string, agentDir: string): AuthStatus {
   // accounts/ slot was written (e.g. during scaffold) but syncLegacyFromActive
   // hadn't run yet — legacy path was empty → status read "✗" until the next
   // restart actually mirrored the file.
+  // LEGACY (post-RFC-H): the `.oauth-token` mirror is no longer the path
+  // Claude Code reads at runtime — the auth-broker owns `.credentials.json`.
+  // This sync only affects this legacy status read, not agent boot.
   if (!existsSync(oauthTokenPath(agentDir))) {
     const activeSlot = readActiveSlot(agentDir);
     if (activeSlot && existsSync(slotTokenPath(agentDir, activeSlot))) {
@@ -823,7 +832,7 @@ export function submitAuthCode(
       tokenSaved: false,
       instructions: [
         `No pending auth session for agent "${name}".`,
-        `Start one with: switchroom auth login ${name}`,
+        `Start one with: switchroom auth add ${name}`,
       ],
     };
   }
@@ -967,9 +976,13 @@ export function submitAuthCode(
   rmSync(authLogPath(agentDir), { force: true });
   // Fix 2 (2026-04-25 gymbro incident): remove the agent's .credentials.json
   // so the running claude CLI doesn't shadow the new .oauth-token with a
-  // stale (possibly expired) credentials file. The env-var path
-  // (CLAUDE_CODE_OAUTH_TOKEN exported from start.sh) is the single source
-  // of truth at runtime. For the force path, credentials.json lives in the
+  // stale (possibly expired) credentials file.
+  // LEGACY (post-RFC-H): this comment's premise — that
+  // CLAUDE_CODE_OAUTH_TOKEN exported from start.sh is the runtime source
+  // of truth — no longer holds. start.sh defensively unsets that env var
+  // and the auth-broker is the sole writer of `.credentials.json`, which
+  // is what `claude` reads. This cleanup remains valid for the legacy
+  // slot-auth path. For the force path, credentials.json lives in the
   // throwaway temp dir which cleanupAuthTempDirs just wiped; this call is
   // a no-op there (force: true makes it safe).
   rmSync(credentialsPath(agentDir), { force: true });

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1624,7 +1624,7 @@ export function registerAgentCommand(program: Command): void {
                 const restartRequired = [...semantics.restartRequired, ...unitChanges];
 
                 if (restartRequired.length > 0) {
-                  console.log(chalk.yellow("\n  Changed (restart required — soul/MCP/settings/launch/systemd):"));
+                  console.log(chalk.yellow("\n  Changed (restart required — soul/MCP/settings/start.sh):"));
                   for (const f of restartRequired) {
                     console.log(chalk.yellow(`    - ${f}`));
                   }

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -635,7 +635,7 @@ export function registerVaultCommand(program: Command): void {
   vault
     .command("get <key>")
     .description("Get a secret from the vault (tries broker first)")
-    .option("--no-broker", "Bypass the broker and read directly from the vault file. Required for interactive (non-cron) access — the broker only serves switchroom cron units.")
+    .option("--no-broker", "Bypass the broker and read directly from the vault store. Required for interactive (non-scheduled) access — the broker only serves an agent's scheduled runs (the in-agent agent-scheduler sidecar) over that agent's per-agent socket.")
     .option(
       "--expect <format>",
       `Warn if the stored format hint does not match. Allowed values: ${VAULT_FORMAT_HINTS.join(", ")}. Exits with code 4 on mismatch (warn-and-proceed is the default; use --strict-format to fail-closed).`

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -121,9 +121,12 @@ export function printHealthSummary(config: ReturnType<typeof getConfig>): void {
       const isUp = s.active === "active" || s.active === "running";
       const uptime = formatUptime(s.uptime);
       if (isUp) {
-        // Read the SHA the agent was started under from its systemd unit's
-        // Environment= block (baked in at install time via SWITCHROOM_AGENT_START_SHA).
-        // Falls back to "?" if the unit pre-dates #66 or systemctl is unavailable.
+        // Read the SHA the agent was started under via `docker inspect`
+        // (SWITCHROOM_AGENT_START_SHA container env, then the
+        // `switchroom.commit` container label, then the
+        // `org.opencontainers.image.revision` image label — see
+        // getAgentStartSha in agents/lifecycle.ts). Falls back to "?"
+        // if none are present or the container isn't running.
         const agentSha = getAgentStartSha(name) ?? "?";
         lines.push(chalk.green(`✓ ${name} → up ${uptime}, on ${agentSha}`));
       } else {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1725,11 +1725,13 @@ export const QuotaConfigSchema = z.object({
 });
 
 /**
- * Host-control daemon (`switchroom-hostd`) — opt-in Phase 1 surface
- * defined in `docs/rfcs/host-control-daemon.md`. When enabled, the
- * compose generator emits per-agent UDS bind mounts for admin agents
- * so the daemon (a systemd user unit on the host) can dispatch a
- * closed set of operator verbs reached from inside the containers.
+ * Host-control daemon (`switchroom-hostd`) — default-on since RFC C
+ * Phase 2 (#1338); see `docs/rfcs/host-control-daemon.md`. The daemon
+ * is the `switchroom-hostd` Docker container, running in its own
+ * compose project (separate from the agent fleet's project). When
+ * enabled (the default), the compose generator emits per-agent UDS
+ * bind mounts for admin agents so the daemon can dispatch a closed
+ * set of operator verbs reached from inside the containers.
  */
 export const HostControlConfigSchema = z.object({
   enabled: z


### PR DESCRIPTION
Bundle 3 of 3 (largest). User/external-facing docs + stale code comments describing the retired architecture as current. Agent-implemented, diff-reviewed by me, independently re-verified (tsc + 3 lint checks clean).

- **configuration.md**: "Slot Pool" section → auth-broker model; dropped slot-tree ASCII + retired `auth refresh-tick`.
- **vault.md / vault-broker.md**: file→directory; systemd-unit/cgroup-identity → Docker container + path-as-identity; no cron .service units; `vault init` removed.
- **botfather/operators-install/posthog**: removed verb `auth login` → current broker flow; install bring-up gained the missing fleet-auth step.
- **compliance-attestation.md** (externally cited): systemd-unit generation → Docker Compose; slot-file → broker `.credentials.json` mirror.
- **architecture.md**: CLAUDE_CODE_OAUTH_TOKEN bullet corrected.
- **Stale comments** (logic untouched): schema.ts HostControl JSDoc, auth/accounts.ts + manager.ts legacy banners, agent.ts operator string, vault.ts help, version.ts (verified getAgentStartSha *is* Docker-aware — comment fixed, NOT a latent bug).

14 files, +213/−151.

🤖 Generated with Claude Code