### PR TITLE
fix(docs): vault.md — restore  (#1378 introduced a false 'set auto-creates' claim)

### DIFF
--- a/docs/vault.md
+++ b/docs/vault.md
@@ -75,10 +75,13 @@ passphrase — the broker is for scheduled (non-interactive) access.
 
 ### Populate the vault
 
-The vault store is created on first `set` (it prompts for a passphrase
-when no store exists yet — there is no separate `vault init` verb).
+Create the encrypted vault store first with `switchroom vault init` (or
+the `switchroom setup` wizard does it for you); both prompt for a
+passphrase. `switchroom vault set` requires an existing store and
+errors with `Vault file not found` if you skip init.
 
 ```sh
+switchroom vault init                          # create the encrypted vault store (prompts for passphrase)
 switchroom vault set <key>                     # set a secret interactively
 switchroom vault set <key> --file /path/to     # read value from file (PEM, JSON, etc.)
 switchroom vault get <key>                     # decrypt and print (direct, not via broker)


### PR DESCRIPTION
Forward fix for a factual error #1378's docs sweep landed on main.

**Bug:** `docs/vault.md` claimed the vault store is created on first `switchroom vault set` and that "there is no separate `vault init` verb", and dropped `vault init` from the command list. Both false — `switchroom vault init` is registered (`src/cli/vault.ts:302` → `createVault()`); `vault set` errors `Vault file not found` on an absent store (`src/vault/vault.ts:363,400`). An operator following it fails on their first command.

**Fix:** restored `switchroom vault init` in the command fence + corrected the prose (init, or the `setup` wizard, creates the store; `set` requires it).

**Process note:** #1378 had auto-merge enabled before its independent reviewer returned; docs CI is fast and it merged (08:50) before the reviewer flagged this. Single-file doc fix; **not enabling auto-merge until reviewed** this time.

🤖 Generated with Claude Code