### PR TITLE
docs(audit): fix onboarding-breaking + operator-hazard defects (Tier 0+1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Then log out and back in so the docker group takes effect, and:
 
 ```bash
 switchroom setup                       # interactive: Telegram + vault + first agent
-switchroom auth add me --from-oauth    # OAuth into your Claude Pro or Max account (one flow, fleet-wide)
+switchroom auth add me --via-claude    # OAuth into your Claude Pro/Max account, broader scope (first-time setup)
 switchroom apply                       # write ~/.switchroom/compose/docker-compose.yml
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 ```
@@ -329,10 +329,11 @@ Model aliases: the bare names `opus`, `sonnet`, `haiku` are accepted alongside t
 The **Anthropic account is the unit of authentication.** One OAuth flow per account, then every agent in the fleet inherits the fleet-wide active account. The `switchroom-auth-broker` daemon owns the refresh loop and is the sole writer of every `credentials.json`. Per-account quota state fans out across the fleet in seconds. See [`docs/auth.md`](docs/auth.md) for the full operator guide.
 
 ```bash
-switchroom auth add <label> --from-oauth          # New account via OAuth (one flow per Anthropic account)
+switchroom auth add <label> --via-claude          # New account, broader scope — recommended for first-time
+switchroom auth add <label> --from-oauth          # Narrow scope=user:inference (rejected by agents in server: mode)
 switchroom auth add <label> --from-agent <name>   # Seed from an existing agent's creds
 switchroom auth add <label> --from-credentials <path>  # Import a credentials.json
-switchroom auth add <label> --from-oauth --replace     # Re-auth an existing label (drift recovery)
+switchroom auth add <label> --via-claude --replace     # Re-auth an existing label (drift recovery)
 
 switchroom auth list                              # Accounts + health + which one is fleet-active
 switchroom auth show [agent]                      # Full snapshot (fleet + agents + consumers), or one agent

--- a/docs/botfather-walkthrough.md
+++ b/docs/botfather-walkthrough.md
@@ -124,7 +124,7 @@ For each bot, open it in Telegram (search by username, or use the
 direct link BotFather sent: `t.me/<bot_username>`) and tap **Start**.
 
 The agent bot won't reply until setup, authentication
-(`switchroom auth add me --from-oauth && switchroom auth use me`), and
+(`switchroom auth add me --via-claude && switchroom auth use me`), and
 `docker compose ... up -d` are done.
 
 ## Optional: profile picture + description

--- a/docs/install.md
+++ b/docs/install.md
@@ -141,13 +141,16 @@ You can skip this step for a single-agent install.
 ## Step 5 — Authenticate with your Claude subscription
 
 ```sh
-switchroom auth add me --from-oauth
+switchroom auth add me --via-claude
 switchroom auth use me
 ```
 
-`auth add` opens an OAuth browser flow — log in with your Claude Pro or
-Max account, paste the code back at the prompt. `auth use` makes that
-account the fleet-wide active account; every agent inherits.
+`--via-claude` drives `claude`'s own native OAuth flow (broader scope)
+— log in with your Claude Pro or Max account when prompted. Use
+`--via-claude` for first-time setup: `--from-oauth` mints
+`scope=user:inference` only, which agents running in `server:` mode
+reject at boot. `auth use` makes that account the fleet-wide active
+account; every agent inherits it via the auth-broker.
 
 One OAuth flow per Anthropic account, ever. New agents you add later
 don't need their own login — they inherit the fleet active. See

--- a/docs/operators/install.md
+++ b/docs/operators/install.md
@@ -1,7 +1,9 @@
 # Operator install — Docker fleet from GHCR
 
 Switchroom publishes its container images to GitHub Container Registry
-(GHCR) at `ghcr.io/switchroom/switchroom-{base,agent,broker,kernel}`.
+(GHCR). The fleet pulls four runtime images —
+`ghcr.io/switchroom/switchroom-{agent,broker,kernel,auth-broker}`
+(`switchroom-base` is a build-stage parent, not pulled at runtime).
 The supported install path on Linux pulls those images and brings the
 fleet up via `docker compose`. No `docker build` on the operator's host.
 
@@ -21,9 +23,12 @@ curl -fsSL https://github.com/switchroom/switchroom/raw/main/install.sh | sh
 ```
 
 This drops a self-contained `switchroom` binary in `/usr/local/bin`
-(falls back to `~/.local/bin` if the former isn't writable). No `bun`,
-no `node`, no source checkout required on the host. The binary is the
-operator CLI; the agent runtime is pulled from GHCR by Docker.
+(falls back to `~/.local/bin` if the former isn't writable). The
+`switchroom` binary itself needs no `bun`, `node`, or source checkout;
+the agent runtime is pulled from GHCR by Docker. Note: the OAuth step
+below still requires the `claude` CLI on the host (Node 20.11+, per
+Prerequisites) — that requirement is not optional even on the binary
+install.
 
 Then bring up your fleet:
 
@@ -34,7 +39,7 @@ switchroom setup
 # 2. Authenticate with your Claude subscription (one OAuth flow,
 #    fleet-wide). The auth-broker becomes the sole writer of every
 #    agent's credentials.
-switchroom auth add me --from-oauth
+switchroom auth add me --via-claude
 switchroom auth use me
 
 # 3. Scaffold agents + write ~/.switchroom/compose/docker-compose.yml.
@@ -71,8 +76,13 @@ The generated compose pins each service to a tagged GHCR ref:
 ```
 ghcr.io/switchroom/switchroom-broker:latest
 ghcr.io/switchroom/switchroom-kernel:latest
+ghcr.io/switchroom/switchroom-auth-broker:latest
 ghcr.io/switchroom/switchroom-agent:latest
 ```
+
+(Four runtime images: `broker`, `kernel`, `auth-broker`, `agent`.
+`base` is a build-stage parent, not pulled; `hindsight`/`hostd` run in
+their own separate compose projects.)
 
 `:latest` floats with the canonical repo's `main`. To pin to a specific
 release tag, set `imageTag` directly when calling `generateCompose()`
@@ -123,7 +133,7 @@ docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 
 ## Troubleshooting
 
-- **First `docker compose up` is slow** — pulls 5 images
+- **First `docker compose up` is slow** — pulls 4 images
   (~1-2 GB total) on a fresh host. Subsequent `up` calls only pull
   changed layers.
 - **`unauthorized` on pull** — the published images are public; if you

--- a/docs/operators/runtime-mode.md
+++ b/docs/operators/runtime-mode.md
@@ -4,17 +4,33 @@ Switchroom runs its agent fleet as Docker containers brought up by a
 generated `docker-compose.yml`. This is the only supported production
 runtime.
 
-Three commands cover the full lifecycle:
+The canonical lifecycle command is **`switchroom update`** — it pulls
+images, runs `apply`, recreates changed containers, and runs a focused
+`doctor` sweep, in one operator step:
+
+```sh
+switchroom update              # pull + apply + recreate + doctor
+switchroom update --check      # dry-run: print the plan, exit 0
+```
+
+`switchroom apply` (scaffold every agent + write the compose file from
+`switchroom.yaml`) is also available standalone for a scaffold-only
+change.
+
+Raw `docker compose` is a **debugging fallback only**:
 
 ```sh
 switchroom apply
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml pull
-docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d --remove-orphans
+docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 ```
 
-`switchroom apply` scaffolds every agent and writes the compose file
-derived from your `switchroom.yaml`. The CLI deliberately does not call
-`docker` for you — operators control the bring-up.
+> ⚠️ Do **not** routinely use raw `docker compose up -d
+> --remove-orphans` for fleet bring-up. It bypasses the operator
+> restart-marker, so the agents' boot cards render as a *crash* (and
+> notify the fleet) instead of a clean restart. Use `switchroom
+> update` (or `switchroom agent restart`) for normal operation; reach
+> for raw compose only when diagnosing the compose layer itself.
 
 See [`install.md`](./install.md) for the full operator install flow
 (curl one-liner, prerequisites, GHCR auth, dev-time `--build-local`


### PR DESCRIPTION
Docs-audit highest-severity bundle. Verified against code before editing.

**Tier 0 — a fresh user dead-ends today:** README / install.md / operators/install.md / botfather all taught first-time `auth add me --from-oauth`, which mints `scope=user:inference` only — agents in `server:` mode reject it at boot (`auth.ts:346-349`, `auth.md:39-44`). Every entry point contradicted the authoritative auth doc + the CLI's own help. → `--via-claude` on the happy path; `--from-oauth` kept in the reference list, labelled narrow-scope.

**Tier 1:** runtime-mode.md presented raw `docker compose … up -d --remove-orphans` as canonical (it skips the restart-marker → boot cards render as crash + fleet notify) → reframed to `switchroom update` canonical, raw compose a debugging fallback w/ hazard warning. Image count was stated 3 ways (a list omitted `auth-broker`, the sole credential writer) → standardised on the true 4. Static-binary "no Node" vs mandatory host-`claude` OAuth contradiction clarified.

Docs only. **Auto-merge intentionally OFF until fresh review returns** (#1378 lesson).

🤖 Generated with Claude Code