### PR TITLE
docs(audit): coverage gaps + reference Status banners (Tier 3+4)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,136 @@
+# CLI reference — supplementary verbs
+
+The top-level CLI reference lives in the project [`README.md`](../README.md#cli-reference).
+This page documents verbs that have no dedicated doc and don't fit the
+README's setup/agent/auth/workspace groupings. Synopsis + behaviour +
+common usage for each; grounded in `src/cli/*.ts`.
+
+## `switchroom worktree` — git worktree isolation for parallel agents
+
+Multiple agents (and sub-agents) can run concurrently on one host and
+touch the same repo. Working directly on a repo's primary checkout
+collides — mid-edit files, branch switches under another agent's feet,
+half-staged commits clobbered. `switchroom worktree` is the supported
+way to hand each task its own isolated git worktree on a fresh branch,
+with a registry so stale ones get reaped instead of accumulating.
+
+```sh
+switchroom worktree claim <repo> [--task <name>] [--agent <name>] [--json]
+switchroom worktree list [--json]
+switchroom worktree release <id> [--json]
+switchroom worktree reap [--dry-run] [--json]
+```
+
+- **`claim <repo>`** — claim a worktree for a repo (alias or absolute
+  path). Prints the worktree **id**, **branch**, and **path**. `--task`
+  becomes the branch suffix so the branch name says what it's for;
+  `--agent` associates the claim with an agent so the registry shows
+  who owns it.
+- **`list`** — every active claim, with repo, branch, path, owning
+  agent, and heartbeat age (claims that stop heart-beating are
+  candidates for the reaper). `fresh` means the heartbeat is under
+  120s old.
+- **`release <id>`** — release a claim by id. If the underlying `git
+  worktree remove` fails (e.g. dirty tree) the registry entry is still
+  cleaned up and the result is reported as *partial* so it doesn't leak.
+- **`reap`** — remove stale / orphaned worktrees (no heartbeat for
+  >10 min). `--dry-run` prints what *would* be reaped without acting —
+  always sanity-check with `--dry-run` first on a shared host.
+
+Typical flow for a non-trivial change on a shared box:
+
+```sh
+ID=$(switchroom worktree claim switchroom --task fix-card --agent clerk --json | jq -r .id)
+# ...work in the printed path, commit, push, open PR...
+switchroom worktree release "$ID"
+```
+
+*Grounded in:* `src/cli/worktree.ts`, `src/worktree/{claim,release,list,reaper}.ts`.
+
+## `switchroom web` — local monitoring dashboard
+
+```sh
+switchroom web [--port <n>] [--bind <host>]
+```
+
+Starts the browser dashboard for watching the fleet (Summary / Agents /
+Accounts / System / Google / Schedule / Approvals tabs). Default port
+`8080`, default bind `127.0.0.1` (localhost-only). Binding to a
+network-reachable host prints a short-lived access token the browser
+must present. Full tab-by-tab behaviour is documented under "Web
+dashboard" in [`docs/telegram-features.md`](telegram-features.md#web-dashboard).
+
+*Grounded in:* `src/cli/web.ts`, `src/web/server.ts`.
+
+## `switchroom issues` — per-agent issue sink
+
+A per-agent sink that surfaces *silent* failures (the CLI said
+success, something is actually broken) to Telegram instead of leaving
+them buried in a log. Occurrences coalesce by `source+code` so a
+flapping failure doesn't spam the chat.
+
+```sh
+switchroom issues record --source <s> --code <c> [--detail <text>] [--agent <name>]
+switchroom issues list [--severity <level>] [--include-resolved] [--json]
+switchroom issues resolve [fingerprint] [--source <s> --code <c>]
+switchroom issues prune
+```
+
+- **`record`** — record (or coalesce into) an issue occurrence.
+  Mostly called by switchroom internals and hooks, not by hand.
+- **`list`** — current issues from the sink; `--severity` filters to
+  at-or-above a level, `--include-resolved` also shows cleared ones.
+- **`resolve`** — mark an issue (by fingerprint, or all matching a
+  `--source`/`--code`) resolved.
+- **`prune`** — drop entries per the retention rules.
+
+*Grounded in:* `src/cli/issues.ts`.
+
+## `switchroom perf` — per-agent cache-hit telemetry
+
+```sh
+switchroom perf <name> [--last <n>] [--full] [--json]
+```
+
+Reads the agent's latest session JSONL and reports prompt-cache
+telemetry (`cache_read` / `cache_creation` tokens per assistant turn).
+Defaults to the last 20 assistant turns; `--last <n>` widens the
+window, `--full` analyses every turn in the JSONL. Use it to see
+whether an agent is actually getting cache hits (a low cache-read ratio
+means the prompt prefix is churning and burning quota).
+
+*Grounded in:* `src/cli/perf.ts`.
+
+## `switchroom versions` — manifest-vs-installed drift (hidden)
+
+```sh
+switchroom versions
+```
+
+Prints the pinned dependency manifest (switchroom + dependents like
+hindsight, broker protocol) against what's actually installed, and
+highlights drift. The verb is **hidden** from `--help` because it's
+easily confused with `switchroom version` (singular — running-agent
+health summary); a follow-up may rename it to `drift` or fold it into
+`switchroom doctor`. Until then it's still callable by name.
+
+*Grounded in:* `src/cli/versions.ts`.
+
+## Internal / host-side verbs (not for everyday use)
+
+- **`switchroom handoff <agent>`** *(hidden)* — summarises the agent's
+  last session into a handoff briefing (`.handoff.md`) and a topic line
+  (`.handoff-topic`). Run automatically by the Stop hook for
+  cross-session continuity; not something you invoke by hand. Flags:
+  `--timeout`, `--max-turns`, `--model`. *Grounded in:* `src/cli/handoff.ts`.
+- **`switchroom hostd <install|status|uninstall|audit>`** — manage
+  `switchroom-hostd`, the host-control daemon for admin agents (RFC C).
+  `install` writes `~/.switchroom/hostd/docker-compose.yml` and brings
+  the hostd container up (it lives in a *separate* compose project from
+  the agent fleet by design); `status` shows daemon state + bound
+  sockets; `uninstall` stops the container but leaves the compose file
+  for re-install; `audit` tails/filters the privileged-verb call log
+  (`--tail`, `--agent`, `--op`, `--error`). Since recent `switchroom
+  update` runs refresh hostd automatically — the manual `install` path
+  is the fallback for debugging a stuck daemon. *Grounded in:*
+  `src/cli/hostd.ts`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -86,10 +86,10 @@ switchroom issues prune
 
 *Grounded in:* `src/cli/issues.ts`.
 
-## `switchroom perf` — per-agent cache-hit telemetry
+## `switchroom agent perf` — per-agent cache-hit telemetry
 
 ```sh
-switchroom perf <name> [--last <n>] [--full] [--json]
+switchroom agent perf <name> [--last <n>] [--full] [--json]
 ```
 
 Reads the agent's latest session JSONL and reports prompt-cache

--- a/docs/skill-coverage/audit.md
+++ b/docs/skill-coverage/audit.md
@@ -4,9 +4,25 @@ Companion to `inventory.md`. Read that first — this file references skills by 
 
 This audit feeds the probabilistic skill-coverage harness. Verdicts are biased toward "what will the fuzzer actually fire on?" rather than reading the SKILL.md charitably.
 
+> **`buildkite-*` scope caveat.** The `NEEDS-FIX` verdicts on the eight
+> `buildkite-*` skills below describe their *trigger-precision* shape
+> for the harness — they are **not** a recommendation to invest in
+> fixing those descriptions, and not a retirement call either. Whether
+> the `buildkite-*` skills stay in the bundle at all (switchroom's own
+> Buildkite CI is retired) is an unresolved maintainer decision tracked
+> in [#1384](https://github.com/switchroom/switchroom/issues/1384).
+> Treat any "highest-impact fix" / priority-ordering language about
+> `buildkite-*` in this file as conditional on #1384 resolving *keep*;
+> if it resolves *remove*, these rows simply drop out of harness scope.
+> Don't action `buildkite-*` description fixes ahead of #1384.
+>
+> The estimates in §5 are *predictions* (the harness has not been
+> live-run end-to-end against a real agent here); read them as relative
+> risk ordering, not measured precision/recall.
+
 ## 1. Executive summary
 
-- **Pervasive missing negatives.** 21 of 27 skills carry `no-negatives` — most buildkite-* skills, `humanizer`, `humanizer-calibrate`, `mcp-builder`, `pdf`, `pptx`, `telegram-test-harness`, `webapp-testing`. Adjacent-but-wrong phrasings will rubber-stamp a fire. Highest-impact fixes are the `buildkite-cli` / `buildkite-pipelines` / `buildkite-api` triangle and the `pdf` / `pptx` / `webapp-testing` set.
+- **Pervasive missing negatives.** 21 of 27 skills carry `no-negatives` — most buildkite-* skills, `humanizer`, `humanizer-calibrate`, `mcp-builder`, `pdf`, `pptx`, `telegram-test-harness`, `webapp-testing`. Adjacent-but-wrong phrasings will rubber-stamp a fire. Among the non-`buildkite-*` skills the most exposed are the `pdf` / `pptx` / `webapp-testing` set; the `buildkite-cli` / `buildkite-pipelines` / `buildkite-api` triangle is the worst-overlapping cluster but its prioritisation is gated on #1384 (see caveat above).
 - **Switchroom-internal cluster is the cleanest negative-control discipline in the bundle** (`switchroom-cli`, `switchroom-status`, `switchroom-manage`, `switchroom-install`, `switchroom-architecture` all cite the rivals to defer to). The harness should expect ≥0.9 F1 there.
 - **`humanizer-calibrate`, `webapp-testing`, `mcp-builder` are likely under-triggers** — descriptions are abstract, no plain-language utterance enumeration. Will miss natural phrasings.
 - **`switchroom-runtime` cannot be fully NL-fuzzed.** Three of its five gates are side-channel signals (env var, sentinel file) — the harness must label those triggers as non-NL.

--- a/docs/skill-coverage/inventory.md
+++ b/docs/skill-coverage/inventory.md
@@ -1,8 +1,15 @@
 # Switchroom skill bundle inventory
 
-Source: `/home/kenthompson/code/switchroom-skill-coverage/skills/*/SKILL.md` at the worktree HEAD. Read-only inventory feeding the probabilistic skill-coverage harness.
+Source: the repo's `skills/*/SKILL.md` tree at HEAD. Read-only inventory feeding the probabilistic skill-coverage harness.
 
-Skill count: **27**. Profile-overlay count: **7** (3 `_shared` fragments + 4 profile `CLAUDE.md.hbs`).
+Skill count: **27** (matches `ls skills/`). Profile-overlay count: **7** (3 `_shared` fragments + 4 profile `CLAUDE.md.hbs`).
+
+> **`buildkite-*` retention:** the eight `buildkite-*` skills below are
+> inventoried as-shipped. Whether they stay in the bundle or get
+> removed (switchroom's own Buildkite CI is retired) is an unresolved
+> maintainer decision tracked in
+> [#1384](https://github.com/switchroom/switchroom/issues/1384) — this
+> inventory neither prescribes nor pre-empts that call.
 
 ## Summary table
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -8,8 +8,8 @@ Switchroom distinguishes four populations, each living in a different place and 
 
 | Population | Where they live | When they get installed | Audience |
 |---|---|---|---|
-| **Bundled-default skills** | `<repo>/skills/` — vendored Anthropic skills (skill-creator, mcp-builder, webapp-testing, pdf, docx, xlsx, pptx) + slim switchroom-core (switchroom-cli, switchroom-status, switchroom-health) | Auto-symlinked into every agent's `.claude/skills/` on scaffold and on `switchroom apply`, regardless of role. Per-key opt-out via `defaults.bundled_skills`. See `reconcileAgentDefaultSkills` in `src/agents/reconcile-default-skills.ts` | **Every agent** |
-| **Switchroom foreman-only skills** | `<repo>/skills/` (`switchroom-install`, `switchroom-manage`, `switchroom-architecture`) | Auto-symlinked only when the agent has `role: foreman`. See `installSwitchroomSkills` in `src/agents/scaffold.ts` | Foreman agents (operator) |
+| **Bundled-default skills** | `<repo>/skills/` — vendored Anthropic skills (skill-creator, mcp-builder, webapp-testing, pdf, docx, xlsx, pptx) + the slim universal switchroom trio (switchroom-cli, switchroom-status, switchroom-health) | Auto-symlinked into every agent's `.claude/skills/` on scaffold and on `switchroom apply`, regardless of role. Per-key opt-out via `defaults.bundled_skills`. See `reconcileAgentDefaultSkills` in `src/agents/reconcile-default-skills.ts` | **Every agent** |
+| **Switchroom foreman-only skills** | `<repo>/skills/` — every `switchroom-*` skill *except* the universal trio (`switchroom-install`, `switchroom-manage`, `switchroom-architecture`, `switchroom-runtime`) | Auto-symlinked only when the agent has `role: foreman`. See `installSwitchroomSkills` in `src/agents/scaffold.ts` | Foreman agents (operator) |
 | **Switchroom-bundled developer skills** | `<repo>/skills/` (without `switchroom-` prefix — e.g. `buildkite-*`, `file-bug`, `telegram-test-harness`, `humanizer*`, `token-helpers`) | NOT auto-installed; a developer agent opts in via `defaults.skills:` or per-agent `skills:` in switchroom.yaml | Switchroom developers + power-user operators |
 | **User-managed personal skills** | `~/.switchroom/skills/` (or wherever `switchroom.skills_dir` points) | Symlinked into agents that name them in `defaults.skills` or `agents.<name>.skills`. See `syncGlobalSkills` in `src/agents/scaffold.ts` | Fleet agents — calendar, garmin, doctor-appointments, etc. — anything personal to the operator |
 
@@ -57,7 +57,7 @@ Per-agent values override `defaults.bundled_skills` (so an agent can re-enable a
 
 Different populations answer different questions:
 
-- "What does *every* agent need?" → bundled-default skills (anthropic-vendored + switchroom-core, see section above)
+- "What does *every* agent need?" → bundled-default skills (anthropic-vendored + the universal `switchroom-cli`/`status`/`health` trio, see section above)
 - "What does an operator running the *whole fleet* need?" → switchroom foreman-only skills (`role: foreman` auto-installs them)
 - "What does a *developer* working on switchroom need?" → bundled developer skills (opt in via `defaults.skills`, not auto-injected)
 - "What does *this user's* fleet need beyond the defaults?" → user-managed personal skills
@@ -78,11 +78,18 @@ agents:
 
 Reconcile honors role flips both ways: `assistant → foreman` installs the symlinks, `foreman → assistant` retracts them (only switchroom-installed symlinks; never real dirs the operator placed manually).
 
-The 3 foreman-only skills:
+The foreman-only skills (the gate auto-installs every `switchroom-*`
+skill **except** the universal `cli`/`status`/`health` trio — see
+`universalDefaultSkills` in `src/agents/scaffold.ts`):
 
 - `switchroom-install` — bootstrap switchroom on a fresh machine
-- `switchroom-manage` — add/remove agents and edit fleet config
+- `switchroom-manage` — add/remove/reinstall/list agents (fleet-level)
 - `switchroom-architecture` — internal design context for fleet-management decisions
+- `switchroom-runtime` — conditional runtime protocols: the agent
+  answering for *itself* about a crash, restart, hand-off resume, or
+  mid-turn interrupt ("why did you restart?", "did you crash?", "still
+  there after the restart?"). Three of its gates are side-channel
+  signals (env var / sentinel file), not natural-language triggers.
 
 A fleet agent like `clerk` doing user-facing tasks never needs to call `switchroom-install` or `switchroom-manage`, so the assistant default keeps their tool list focused. The slim `switchroom-cli` / `switchroom-status` / `switchroom-health` trio every agent benefits from is bundled-default (see the section above).
 
@@ -102,15 +109,34 @@ Current `<repo>/skills/` inventory:
 | `switchroom-cli` | bundled-default (every agent) | Logs / restart / version / config / schedule |
 | `switchroom-status` | bundled-default (every agent) | Show running agents + fleet health |
 | `switchroom-health` | bundled-default (every agent) | "Something is broken" diagnostics |
-| `switchroom-install` | foreman-only (auto when `role: foreman`) | Operator skill |
-| `switchroom-manage` | foreman-only (auto when `role: foreman`) | Operator skill |
-| `switchroom-architecture` | foreman-only (auto when `role: foreman`) | Operator skill |
+| `switchroom-install` | foreman-only (auto when `role: foreman`) | First-time bootstrap on a fresh machine |
+| `switchroom-manage` | foreman-only (auto when `role: foreman`) | Add/remove/reinstall/list agents (fleet-level) |
+| `switchroom-architecture` | foreman-only (auto when `role: foreman`) | Internal design context for fleet-mgmt decisions |
+| `switchroom-runtime` | foreman-only (auto when `role: foreman`) | Agent answering for itself about crash/restart/interrupt/hand-off |
 | `humanizer` | developer (opt-in) | Strips AI-writing patterns from replies; opt in via `defaults.skills` |
 | `humanizer-calibrate` | developer (opt-in) | Builds a personal voice template; companion to `humanizer` |
-| `buildkite-*` (8 skills) | developer (opt-in) | Switchroom CI work; not for fleet agents |
-| `file-bug` | developer (opt-in) | Files structured bug reports; switchroom dev workflow |
+| `buildkite-agent-infrastructure` | developer (opt-in) | Buildkite CI — cluster/queue/agent provisioning |
+| `buildkite-agent-runtime` | developer (opt-in) | Buildkite CI — `buildkite-agent` in-step subcommands |
+| `buildkite-api` | developer (opt-in) | Buildkite CI — REST/GraphQL/webhooks automation |
+| `buildkite-cli` | developer (opt-in) | Buildkite CI — terminal `bk` CLI |
+| `buildkite-migration` | developer (opt-in) | Buildkite CI — convert pipelines from other CI systems |
+| `buildkite-pipelines` | developer (opt-in) | Buildkite CI — author `.buildkite/pipeline.yml` |
+| `buildkite-secure-delivery` | developer (opt-in) | Buildkite CI — OIDC / SLSA / signing |
+| `buildkite-test-engine` | developer (opt-in) | Buildkite CI — `bktec` test splitting / flaky detection |
+| `file-bug` | developer (opt-in) | Files structured bug reports via `gh issue create` |
 | `telegram-test-harness` | developer (opt-in) | Guidance for writing Telegram tests against the harness |
-| `token-helpers` | developer (opt-in) | OAuth token refresh for Google Calendar / MS Graph |
+| `token-helpers` | developer (opt-in) | Library skill — OAuth token refresh for Google Calendar / MS Graph |
+
+> The eight `buildkite-*` skills are still vendored in `skills/` for
+> switchroom's own (now-retired) Buildkite CI work. Whether to keep or
+> remove them from the bundle is an unresolved maintainer decision —
+> tracked in **[#1384](https://github.com/switchroom/switchroom/issues/1384)**.
+> They are opt-in only; fleet agents never get them auto-installed.
+
+That's the full `skills/` tree as of the audit (27 directories: 7
+vendored Anthropic + 7 `switchroom-*` + 8 `buildkite-*` +
+`humanizer`/`humanizer-calibrate` + `file-bug` + `telegram-test-harness`
++ `token-helpers`). Verify with `ls skills/`.
 
 Real fleet agents (clerk, klanker, etc.) load their personal skills from `~/.switchroom/skills/` — that directory holds calendar, compass, coolify, doctor-appointments, fully-kiosk, garmin, and similar. **The repo doesn't track those** — they're operator-managed.
 

--- a/docs/telegram-features.md
+++ b/docs/telegram-features.md
@@ -84,3 +84,133 @@ switchroom telegram enable webhook --agent klanker \
 ```
 
 See `docs/webhook-ingest.md` for the underlying signature scheme.
+
+## /usage & account usage
+
+**`/usage`** shows where your Claude Pro/Max plan stands across both
+rolling rate-limit windows. Any allowed sender can call it (it is *not*
+admin-gated) — it has to work even when the model is unreachable.
+
+When the auth-broker is reachable and the fleet has one or more
+accounts, `/usage` renders the **fleet snapshot**: every account in the
+broker's known set, live-probed in parallel, grouped by health
+(blocked-first, then throttling, then healthy). Each account row shows
+its `5h` and `7d` utilisation percentages plus a per-window reset line
+("5h refills 11:00 AM (in 6m) · 7d resets Sun 11:00 AM"). The
+fleet-active account is marked. This is the same renderer `/auth show`
+uses, so the two commands speak one dialect.
+
+If the broker is unreachable (boot timing, broken socket), `/usage`
+falls back to a single-agent block:
+
+```
+Claude plan quota
+
+5h window  29% · resets in 4h 12m
+7d window  33% · resets in 3d 6h
+
+Binding window: five hour
+```
+
+The *binding window* line names which limit is the closer ceiling
+(whichever resets first / is more utilised); an `Overage:` line appears
+only if the account has overage disabled.
+
+The percentages and reset times come straight from Anthropic's
+`anthropic-ratelimit-unified-{5h,7d}-{utilization,reset}` response
+headers — Switchroom does not estimate them.
+
+*Grounded in:* `telegram-plugin/gateway/gateway.ts` (`bot.command('usage')`),
+`telegram-plugin/quota-check.ts` (`formatQuotaBlock`, `parseQuotaHeaders`),
+`telegram-plugin/auth-snapshot-format.ts` (`renderAuthSnapshotFormat2`).
+
+### Web dashboard
+
+`switchroom web` starts a local HTTP dashboard for watching the fleet
+from a browser (read-mostly, with a few action buttons).
+
+```sh
+switchroom web                      # http://127.0.0.1:8080 (localhost-only)
+switchroom web --port 9000          # different port
+switchroom web --bind 0.0.0.0       # LAN-accessible (prints a token to use)
+```
+
+The default bind is `127.0.0.1` (localhost-only). Binding to a
+network-reachable address prints a short-lived access token that the
+browser must present — don't expose it to an untrusted network without
+a reverse proxy in front.
+
+Tabs:
+
+- **Summary** (landing tab) — fleet overview tiles built client-side
+  from the cheap endpoints: agents up/total, broker / hindsight / hostd
+  health, pending approvals, schedule status, and the worst-account
+  quota headroom. Each tile degrades independently if its endpoint is
+  down. Loaded on open and on tab-switch only — *not* on the 10s poll.
+- **Agents** — per-agent status, recent turns, sub-agents, logs, plus
+  start / stop / restart buttons.
+- **Accounts** — auth accounts with health badges and quota
+  utilisation. Quota percentages are cached: the default load shows the
+  last cached value (and flags it stale); a per-account or "refresh
+  all" button triggers a live broker probe (a real billed Anthropic
+  call) with a TTL so the poll and the buttons can't storm the API.
+  A "use" action performs a fleet-wide active-account swap.
+- **System** — broker / kernel / hindsight / hostd health.
+- **Google**, **Schedule**, **Approvals** — Google Drive accounts,
+  scheduled cron entries, and pending approval requests.
+
+The page auto-refreshes most tabs every 10 seconds.
+
+*Grounded in:* `src/cli/web.ts`, `src/web/server.ts` (route table),
+`src/web/api.ts` (account/quota endpoints + cache), `src/web/ui/index.html`
+(tabs).
+
+## /queue & mid-flight steering
+
+A message that arrives while the agent's previous turn is still running
+is **queued by default** — it waits for the in-flight turn to finish,
+then runs as its own turn (the model sees `queued="true"` on the
+channel meta so it knows the message was held).
+
+To instead treat a mid-flight message as a *course-correction for the
+running turn* (not a new task), prefix it:
+
+- `/steer <text>` or `/s <text>` — mark this as steering the in-flight
+  turn (`steering="true"`).
+- `/queue <text>` or `/q <text>` — legacy alias for the default queued
+  behaviour; still accepted so old muscle-memory and scripts keep
+  working.
+
+The prefix rules are strict: exactly one leading slash, the keyword
+must be `queue`/`q`/`steer`/`s` exactly, and a mandatory single space
+must follow (`/queue` with no trailing space is treated as literal
+text, not a prefix). Only the first prefix is stripped — `/queue /q
+foo` queues with body `/q foo`.
+
+*Grounded in:* `telegram-plugin/steering.ts` (`parseQueuePrefix`,
+`parseSteerPrefix`, `buildChannelMetaAttributes`),
+`telegram-plugin/gateway/gateway.ts` (queue/steer parse on inbound).
+
+## Fleet & host commands
+
+These slash commands are surfaced in any agent's chat (mutating ones
+are admin-gated against the per-agent `admin: true` flag — the same
+flag that gates `/restart`, `/update`, `/agents`).
+
+| Command | Admin-gated | What it does |
+|---|---|---|
+| `/upgradestatus` | no (read-only) | Snapshot of where the host stands — CLI version, image age, container age per service. Wraps `switchroom update --status`. (Telegram forbids hyphens in command names, so it's `/upgradestatus`, not `/upgrade-status`; `/upgrade` is a polite redirect.) |
+| `/folders` | operator (allowFrom) | Google Drive folder-picker card — browse the connected account's Drive and grant an agent a scoped `allow_always` write capability on a folder by tapping it. This is the Telegram surface for Google Drive write approvals; there is no `/drive` slash command (Drive is managed from the CLI via `switchroom drive`). |
+| `/audit hostd` | admin | Tail / filter the hostd (host-control daemon) audit log — privileged-verb call history (`update_apply`, `agent_restart`, …). Mirrors `/vault audit`. There is no standalone `/hostd` command; hostd is dispatched-into transparently by `/update apply`, `/restart`, etc. when configured. |
+
+> **Note on `/handoff` and `/hostd`:** these are *not* Telegram slash
+> commands. `switchroom handoff <agent>` is an internal CLI verb run by
+> the Stop hook to write the cross-session briefing; `switchroom hostd`
+> is the host-side CLI for the host-control daemon. Telegram only
+> exposes hostd observability via `/audit hostd` (above). See the CLI
+> reference for both verbs: [`docs/cli-reference.md`](cli-reference.md).
+
+*Grounded in:* `telegram-plugin/gateway/gateway.ts`
+(`bot.command('upgradestatus')`, `bot.command('folders')`,
+`bot.command('audit')`), `telegram-plugin/welcome-text.ts`
+(`TELEGRAM_MENU_COMMANDS`, `switchroomHelpText`).

--- a/docs/telegram-plugin.md
+++ b/docs/telegram-plugin.md
@@ -94,6 +94,21 @@ broker logs the state and agents see expired-token errors until the
 window resets or an operator runs `switchroom auth add` for a new
 account. See `src/auth/broker/` for the implementation.
 
+**There is no `/authfallback` command.** Pre-RFC-H builds had a
+per-agent `/authfallback` verb that switched an agent to the next slot.
+It was retired with the slot-pool model — fallback is now automatic and
+fleet-wide (the broker rewires every affected agent without a command),
+and the canonical *manual* control is `/auth use <label>` (swap the
+whole fleet to a named healthy account) or `/auth rotate` (cycle to the
+next non-exhausted account in `auth.fallback_order`). When the model is
+unreachable, the "model unavailable" card now points at `/auth use`,
+`/auth add`, and `/usage` — not `/authfallback`.
+
+*Grounded in:* `telegram-plugin/model-unavailable.ts` (the card's
+"What to try" block explicitly notes `/authfallback` is no longer a
+verb post-RFC-H), `telegram-plugin/welcome-text.ts`,
+`telegram-plugin/gateway/auth-command.ts`.
+
 ### Forum topic support
 
 Messages from Telegram forum topics carry `message_thread_id`. The plugin:

--- a/reference/onboarding-gap-analysis.md
+++ b/reference/onboarding-gap-analysis.md
@@ -1,5 +1,17 @@
 # Switchroom Onboarding — Gap Analysis & Phased Fix Plan
 
+## Status — historical (last updated 2026-04-25); no longer tracks closure
+
+This document is a **point-in-time analysis**, not a live tracker.
+Despite being indexed as "tracks gaps as they close," it does **not**
+track closure and is stale. Several of the gaps below have since
+shipped fixes. It is deliberately **not** re-adjudicated gap-by-gap
+here (per-gap status would itself go stale and risks introducing
+errors). Read it as a snapshot of the onboarding pain that motivated a
+batch of fixes — not as the current state of any individual gap. For
+present-day onboarding behaviour, follow the docs and the CLI, not
+this list.
+
 ## Problem
 
 Bringing up a new switchroom agent with a real corpus is still a babysitting

--- a/reference/share-auth-across-the-fleet.md
+++ b/reference/share-auth-across-the-fleet.md
@@ -4,6 +4,27 @@ outcome: One `claude setup-token` per Anthropic account covers every agent, sub-
 stakes: When auth is per-agent, six agents on one Pro subscription means six OAuth flows, six independent refresh cycles, six places quota state can drift, and six 401-storms when the user adds a seventh agent. The user starts to feel the fleet — and asks why "one subscription" demands six logins.
 ---
 
+## Status — SHIPPED (RFC H)
+
+**This is built and is the current model.** The `switchroom-auth-broker`
+daemon (`src/auth/broker/`) is the sole writer of every
+`credentials.json`; authentication is per **Anthropic account**, not
+per agent; the fleet shares one `auth.active` and quota / fallback
+state fans out across every consumer in seconds. Operator surface:
+`switchroom auth add|list|show|use|rotate|rm` (CLI) and `/auth
+show|use|rotate` (Telegram). See [`docs/auth.md`](../docs/auth.md) for
+the operator guide and `src/auth/broker/protocol.ts` for the wire
+protocol.
+
+> **Read the body below as the *pre-RFC-H problem statement*, not a
+> description of current behaviour.** Present-tense passages like
+> "Today, every agent has its own private OAuth slot pool", "the user
+> runs `claude setup-token` six times", and any "no migration shipped"
+> language describe the world *before* this RFC and are **false as of
+> the v0.7+ broker rollout**. They are retained as design history — the
+> reasoning that motivated the account-as-unit model — not as an
+> open to-do list.
+
 # The job
 
 The user pays Anthropic for a subscription. That subscription is the

--- a/reference/sub-agent-visibility-rfc.md
+++ b/reference/sub-agent-visibility-rfc.md
@@ -1,11 +1,36 @@
 ---
-status: rfc — draft, awaiting sign-off
+status: shipped (closed) — TDD verification landed; 2 narrow follow-ups tracked
 serves: `know-what-my-agent-is-doing.md`
 supersedes: nothing (extends `reference/status-card-design.md` with TDD verification)
 relates: #709 #776 #782 #788 #64 #757
 ---
 
 # Sub-agent visibility — TDD verification + design RFC
+
+## Status — SHIPPED / CLOSED
+
+The frontmatter previously read `rfc — draft, awaiting sign-off`; that
+is stale. The verification work this RFC proposed **landed**: the UAT
+scenarios were written and run, and Bugs 1–5 in the changelog table
+below merged (#1057, #1059, #1060, #1063, #1066). Five of six
+acceptance assertions pass. Treat this RFC as **closed** — its purpose
+(prove the background-dispatch path with a regression-locked test) is
+done. Two narrow defects remain open as ordinary tracked follow-ups,
+**not** as RFC-blocking work: Bug 6 (bg `sub_agent_turn_end` never
+fires for some Claude Code bg dispatches → card can stay on 🌀
+Background until the heartbeat ceiling) and Bug 7 (driver-side
+parent-tool-use correlation race). They have their own diagnoses in
+§"Bug 6 diagnosis" below.
+
+> **Card model superseded.** This RFC reasons about the *two-zone*
+> progress-card model from `reference/status-card-design.md`. That
+> two-zone design has since been **superseded by
+> [`reference/conversational-pacing.md`](conversational-pacing.md)**,
+> and `reference/status-card-design.md` is archived. The acceptance
+> criteria and bug diagnoses here are still valid as the historical
+> record of how sub-agent visibility was verified, but the current
+> card-pacing contract lives in `conversational-pacing.md` — read that
+> for present-day behaviour.
 
 ## TL;DR
 


### PR DESCRIPTION
Docs-audit coverage bundle. Agent-implemented, diff-reviewed by me, command-existence claims **verified against code** (the agent correctly overrode the brief where it was factually wrong).

**Coverage** (grounded; accuracy over completeness):
- `docs/telegram-features.md`: `/usage` + web dashboard; `/queue`//`/steer` documented correctly as **inbound message prefixes** (`steering.ts:parseQueuePrefix/parseSteerPrefix`, verified) — not invented slash commands; `/upgradestatus`, `/folders`. Explicit "no `/drive` slash command" (Drive = `switchroom drive` CLI).
- `docs/telegram-plugin.md`: `/authfallback` documented as **retired** post-RFC-H (verified `model-unavailable.ts:257`).
- NEW `docs/cli-reference.md`: `worktree` (full), `web`, `issues`, `perf`, `versions`, `handoff`/`hostd`. (Brief said document `/hostd`//`/drive`//`/handoff` as Telegram commands — verification showed they are NOT registered; the agent documented reality. Brief was wrong; doc is right.)
- `docs/skills.md` regenerated to the real 27-dir tree; 8 `buildkite-*` enumerated with a neutral #1384 note (no removal — maintainer decision).
- `docs/skill-coverage/{audit,inventory}.md`: stale paths fixed, buildkite priority framing → neutral #1384 banner, predicted numbers labelled.

**reference/ Status banners** (modeled on `rfc-docker-multi-container.md`): share-auth-across-the-fleet → SHIPPED (RFC H); sub-agent-visibility-rfc → SHIPPED/CLOSED (Bugs 1–5 merged, 6–7 open — no over-claim; two-zone card superseded); onboarding-gap-analysis → historical banner.

8 files +267/-15, +1 new. Docs/reference only; no code; disjoint from #1385/#1386. **Auto-merge OFF until fresh review** (standing policy).

🤖 Generated with Claude Code