### PR TITLE
fix(gateway): require operator authz on apv: approval callback (sec WS7-F1)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -11566,7 +11566,24 @@ bot.on('callback_query:data', async ctx => {
   // Routed through the generic kernel handler so any surface that uses
   // buildApprovalCard inherits consume → record → confirmation UX without
   // each surface re-implementing it.
+  //
+  // SECURITY (sec WS7-F1, #1394): this is the human-in-the-loop gate for
+  // EVERY dangerous tool call + Drive write. handleApprovalCallback records
+  // whoever tapped as the approver (`granted_by_user_id = ctx.from.id`) and
+  // the approval-kernel performs NO server-side approver validation, so an
+  // unauthorized tap is laundered into a real grant. The card is delivered
+  // to the agent's chat(s) — for a forum/group agent that is every member.
+  // Refuse callbacks from anyone outside `access.allowFrom`, BEFORE the
+  // approval_consume nonce burn. Strict `access.allowFrom` — identical to
+  // the drvpick:/op:/vd:/vg:/vra:/vrs:/vrd: families; the absence of this
+  // check (not a deliberate exemption) was the vulnerability.
   if (data.startsWith('apv:')) {
+    const access = loadAccess()
+    const senderId = String(ctx.from?.id ?? '')
+    if (!access.allowFrom.includes(senderId)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' })
+      return
+    }
     const { handleApprovalCallback } = await import('./approval-callback.js')
     await handleApprovalCallback(ctx, data)
     return
@@ -11577,10 +11594,11 @@ bot.on('callback_query:data', async ctx => {
   // grant writes an allow_always kernel decision at
   // doc:gdrive:folder/<id>/** and edits the card to a confirmation.
   //
-  // Auth gate: the picker grant is an OPERATOR action (mirrors the
-  // `op:`/`vd:`/`vg:` family, not the `apv:` agent-approval shape).
-  // Mirror those patterns — refuse callbacks from anyone outside
-  // `access.allowFrom`. Without this, a group member who isn't in
+  // Auth gate: the picker grant is an OPERATOR action — same strict
+  // `access.allowFrom` check as every other callback family (`op:`/
+  // `vd:`/`vg:`/`apv:` since sec WS7-F1, …). Refuse callbacks from
+  // anyone outside `access.allowFrom`. Without this, a group member
+  // who isn't in
   // the operator allowlist could still tap [✅ Allow "<folder>"] on
   // a card that landed in the group and write an `allow_always`
   // decision attributed to themselves.


### PR DESCRIPTION
## Summary

Remediates **WS7-F1 (CRITICAL)** from the security audit (#1394, epic #1389) — the single highest-priority finding across WS6–WS10.

The generic `apv:` approval-kernel callback — the human-in-the-loop gate for **every** dangerous tool call + Drive write (RFC B §6.1) — performed **no sender authorization**. `handleApprovalCallback` records whoever tapped as the approver (`granted_by_user_id = ctx.from.id`) and the approval-kernel does **no** server-side approver validation (independently verified), so an unauthorized tap was laundered into a real grant. Approval cards are delivered to the agent's chat(s) — for a forum/group agent, that is **every member** — so any non-operator could approve a pending dangerous action.

Every sibling callback family (`drvpick:`/`op:`/`vd:`/`vg:`/`vra:`/`vrs:`/`vrd:`) already gates on strict `access.allowFrom`; `apv:` was the lone unauthenticated route. This adds the **identical** gate at the dispatcher, **before** `handleApprovalCallback` (so an unauthorized tap doesn't even burn the single-use `approval_consume` nonce). The stale `drvpick:` comment that framed `apv:` as a deliberately-exempt shape is corrected.

## Verification

- Fresh separate-process security review: **APPROVE** — confirmed byte-identical to the verified-correct sibling gates; `loadAccess`/`ctx` in scope; placed before the nonce burn; the *only* caller of `handleApprovalCallback` is this route; no residual ungated path to a kernel grant (`drvpick:`/`vd:`/`vra:`/`vrs:`/`vrd:`/`vg:`/`op:`/`aq:` all gate; `recordDeferredSecretKernelDecision` only behind the gated `vd:` handler); no operator false-negative (strict `access.allowFrom`, matching `/approve`,`/deny`,`drvpick:`).
- `npm run lint` clean; `approval-callback.test.ts` + `access-validator.test.ts` 16/0.

## Scope

Audit and remediation are separate per epic §6 — this is the scoped fix PR for WS7-F1 only. Minimal diff (1 file, gate mirrors an existing in-file pattern).

Refs #1394, #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)