### PR TITLE
ci(security): close sentinel path-filter blind spot + SHA-pin all actions (sec WS9-F1/F6)

### DIFF
--- a/.github/actions/setup-switchroom/action.yml
+++ b/.github/actions/setup-switchroom/action.yml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - name: Set up Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
       with:
         bun-version: ${{ inputs.bun-version }}
 
@@ -36,7 +36,7 @@ runs:
     # shadow described above. Letting `bun install --frozen-lockfile` rehydrate
     # node_modules from the warm cache is fast enough (~5s warm vs ~30s cold).
     - name: Restore bun package cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       with:
         path: ~/.bun/install/cache
         key: bun-${{ runner.os }}-${{ hashFiles('bun.lock', 'telegram-plugin/bun.lock') }}

--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -57,14 +57,14 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
         # No `cache: pip` — we install only `pyyaml`. The pip cache dir
         # never materialises (no requirements.txt, single tiny package
         # already wheel-cached on hosted images) and the post-job
         # cleanup errors with "Cache folder path doesn't exist on disk".
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
@@ -73,12 +73,12 @@ jobs:
         # install (`npm i -g @anthropic-ai/claude-code` is unconfigured
         # by the repo lockfile). Cache the ~/.npm dir explicitly in the
         # next step instead, matching BK's `v1-claude-code-global` key.
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "22"
 
       - name: Cache claude-code global install
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.npm
           key: v1-claude-code-global-${{ runner.os }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload eval results
         if: always() && steps.auth.outputs.auth != 'none'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: evals-trigger-results
           path: evals/results/**/*.json
@@ -137,14 +137,14 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
         # No `cache: pip` — we install only `pyyaml`. The pip cache dir
         # never materialises (no requirements.txt, single tiny package
         # already wheel-cached on hosted images) and the post-job
         # cleanup errors with "Cache folder path doesn't exist on disk".
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
@@ -153,12 +153,12 @@ jobs:
         # install (`npm i -g @anthropic-ai/claude-code` is unconfigured
         # by the repo lockfile). Cache the ~/.npm dir explicitly in the
         # next step instead, matching BK's `v1-claude-code-global` key.
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "22"
 
       - name: Cache claude-code global install
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.npm
           key: v1-claude-code-global-${{ runner.os }}
@@ -195,7 +195,7 @@ jobs:
 
       - name: Upload eval results
         if: always() && steps.auth.outputs.auth != 'none'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: evals-quality-results
           path: evals/results/**/*.json
@@ -213,10 +213,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Download eval artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: evals/results
           merge-multiple: true

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -40,10 +40,10 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Filter changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
         with:
           filters: |
             relevant:
@@ -58,6 +58,15 @@ jobs:
               - 'scripts/check-bot-api-wrapping.sh'
               - '.github/actions/setup-switchroom/**'
               - '.github/workflows/ci-lint.yml'
+              # sec WS9-F1 (#1402): don't skip→pass the required gate on
+              # a security-load-bearing non-.ts change (agent boot/hook
+              # templates, image-baked hook scripts/skills, Dockerfiles,
+              # CI). See ci-tests-core.yml for the rationale.
+              - 'profiles/**'
+              - 'bin/**'
+              - 'skills/**'
+              - 'docker/**'
+              - '.github/workflows/**'
 
   lint-run:
     needs: changes
@@ -68,7 +77,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up workspace
         uses: ./.github/actions/setup-switchroom

--- a/.github/workflows/ci-tests-core.yml
+++ b/.github/workflows/ci-tests-core.yml
@@ -65,10 +65,10 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Filter changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
         with:
           filters: |
             relevant:
@@ -84,6 +84,19 @@ jobs:
               - 'telegram-plugin/bun.lock'
               - '.github/actions/setup-switchroom/**'
               - '.github/workflows/ci-tests-core.yml'
+              # sec WS9-F1 (#1402): security-load-bearing non-src paths.
+              # profiles/ renders every agent's start.sh + the WS8
+              # tool-safety hooks; bin/*-hook.sh + skills/ are baked into
+              # the agent image; docker/ + workflows are the supply-chain
+              # root. Without these a profiles/bin/skills/docker/.github-
+              # only PR skipped→passed this required gate with no tests.
+              # The scaffold/profile-render tests live under src/+tests/
+              # which this `vitest` sentinel runs.
+              - 'profiles/**'
+              - 'bin/**'
+              - 'skills/**'
+              - 'docker/**'
+              - '.github/workflows/**'
 
   # ─── Build dist/ once, share with all shards ──────────────────────
   build-dist:
@@ -93,7 +106,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up workspace
         uses: ./.github/actions/setup-switchroom
@@ -102,7 +115,7 @@ jobs:
         run: bun scripts/build.mjs
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: dist-built
           path: dist/
@@ -133,7 +146,7 @@ jobs:
         # the merge-base against the PR's target branch. The default
         # shallow clone (depth: 1) breaks --changed silently — vitest
         # falls back to running everything, defeating the optimisation.
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
@@ -145,7 +158,7 @@ jobs:
           install-jq: "true"
 
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist-built
           path: dist/
@@ -182,7 +195,7 @@ jobs:
 
       - name: Upload coverage (if produced)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: coverage-shard-${{ matrix.shard }}
           path: coverage/

--- a/.github/workflows/ci-tests-plugin.yml
+++ b/.github/workflows/ci-tests-plugin.yml
@@ -41,10 +41,10 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Filter changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
         with:
           filters: |
             relevant:
@@ -55,6 +55,14 @@ jobs:
               - 'telegram-plugin/bun.lock'
               - '.github/actions/setup-switchroom/**'
               - '.github/workflows/ci-tests-plugin.yml'
+              # sec WS9-F1 (#1402): don't skip→pass the required gate on
+              # a security-load-bearing non-telegram-plugin change. See
+              # ci-tests-core.yml for the rationale.
+              - 'profiles/**'
+              - 'bin/**'
+              - 'skills/**'
+              - 'docker/**'
+              - '.github/workflows/**'
 
   bun-test-run:
     needs: changes
@@ -65,7 +73,7 @@ jobs:
       TELEGRAM_BOT_TOKEN: "123456:stub-for-tests"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up workspace
         uses: ./.github/actions/setup-switchroom

--- a/.github/workflows/ci-tests-python.yml
+++ b/.github/workflows/ci-tests-python.yml
@@ -34,10 +34,10 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Filter changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
         with:
           filters: |
             relevant:
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Run unittest discover
         working-directory: vendor/hindsight-memory/scripts

--- a/.github/workflows/ci-tests-race-long.yml
+++ b/.github/workflows/ci-tests-race-long.yml
@@ -49,7 +49,7 @@ jobs:
       SWITCHROOM_RACE_LONG: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up workspace
         uses: ./.github/actions/setup-switchroom

--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -71,7 +71,7 @@ jobs:
       TELEGRAM_TEST_BOT_USERNAME: ${{ secrets.TELEGRAM_TEST_BOT_USERNAME }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Secrets gate
         # If any of the 4 UAT secrets are missing (rotation gap, fork

--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -57,10 +57,10 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Filter changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590  # v3
         with:
           filters: |
             relevant:
@@ -84,7 +84,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up workspace
         uses: ./.github/actions/setup-switchroom
@@ -96,7 +96,7 @@ jobs:
         # is ~90s. On a hit we skip dist build, buildx setup, and the
         # whole image build sequence.
         id: img-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: /tmp/switchroom-images.tar
           key: docker-images-${{ hashFiles('docker/Dockerfile.base', 'docker/Dockerfile.broker', 'docker/Dockerfile.kernel', 'docker/Dockerfile.agent', 'docker/Dockerfile.auth-broker', 'tests/docker/build-images.sh', 'src/vault/**', 'src/agents/compose.ts', 'src/agent-scheduler/**', 'src/auth/broker/**', 'src/cli/apply.ts', 'bun.lock', 'telegram-plugin/bun.lock', 'scripts/build.mjs') }}
@@ -122,7 +122,7 @@ jobs:
         # "pull access denied" against the (non-existent)
         # docker.io/switchroom/base image.
         if: steps.img-cache.outputs.cache-hit != 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
           driver: docker
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -58,15 +58,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Node (for dist/ bundling)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "22"
 
       - name: Set up Bun (build.mjs invokes bun build)
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: latest
 
@@ -81,14 +81,14 @@ jobs:
         # skip the QEMU setup — saves ~5s + cuts the resulting image
         # surface area.
         if: github.event_name != 'pull_request'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GHCR (push only on main / tags)
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -110,7 +110,7 @@ jobs:
           fi
 
       - name: Build (and push on main/tag) base
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: docker/Dockerfile.base
@@ -154,15 +154,15 @@ jobs:
           # `vectorize-io/hindsight:latest`, not switchroom-base.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Node (for dist/ bundling)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: "22"
 
       - name: Set up Bun (build.mjs invokes bun build)
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: latest
 
@@ -173,14 +173,14 @@ jobs:
 
       - name: Set up QEMU (only when arm64 build runs)
         if: github.event_name != 'pull_request'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GHCR (push only on main / tags)
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -206,7 +206,7 @@ jobs:
           fi
 
       - name: Build (and push on main/tag) ${{ matrix.image.name }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: ${{ matrix.image.file }}
@@ -227,18 +227,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up QEMU (only when arm64 build runs)
         if: github.event_name != 'pull_request'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GHCR (push only on main / tags)
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -259,7 +259,7 @@ jobs:
           fi
 
       - name: Build (and push on main/tag) hindsight
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: docker/Dockerfile.hindsight


### PR DESCRIPTION
## Summary

Remediates **WS9-F1 (CRITICAL)** + **WS9-F6 (MEDIUM)** from the security audit (#1402, epic #1389).

**F1:** the three required test/lint checks (`vitest`/`lint`/`bun-test`) are skip→pass sentinels whose `relevant:` path filters omitted `profiles/**`, `bin/**`, `skills/**`, `docker/**`, `.github/workflows/**`. A PR touching only those passed all three with shards skipped and — given the ruleset has no `pull_request` review rule + auto-merge — shipped to every fleet with **zero tests and zero review**. `profiles/` renders every agent's `start.sh` + the WS8 tool-safety hooks; this was the supply-chain end of "the gate is bypassable." Fix: add those globs to all three sentinel `relevant:` filters so the scaffold/profile-render tests (under `src/`+`tests/`, run by `vitest`) actually gate that surface. Aggregator/pass-fail logic unchanged — only what counts as "relevant" is widened (run-instead-of-skip; over-running a required test is never a security hole).

**F6:** every third-party Action was a mutable major tag. `dorny/paths-filter@v3` *is* the sentinel mechanism (a malicious retag re-defeats the F1 fix); `docker/build-push-action@v6`/`docker/login-action@v3` run in the GHCR `:latest` publish. All 12 pinned to the exact commit SHA the current tag resolves to (behavior unchanged, now immutable), `# vX` comment retained for readability/Dependabot.

## Verification

- Fresh separate-process review: **APPROVE** — independently re-resolved **all 12 SHAs** via `gh api …/commits/<vTag>`, all exact (no version bump smuggled); globs correctly placed in the `relevant:` lists; aggregator logic byte-identical; confirmed this PR is itself fully gated (base-branch filters already match the modified workflow files — not skip-passed); YAML valid; no local `./` actions touched; diff purely mechanical, zero out-of-scope changes.

## Scope

Audit/remediation separate per epic §6. This is the WS9-F1 **code half** + F6. The ruleset required-review rule + admin-bypass lock (WS9-F1 policy half + F2) are tracked and applied **last** so they don't deadlock in-flight remediation PRs' auto-merge.

Refs #1402, #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)