### PR TITLE
fix(approval-kernel): listener-identity ACL on consume/revoke/record + 128-bit request ids (#1399)

### DIFF
--- a/src/vault/approvals/acl.ts
+++ b/src/vault/approvals/acl.ts
@@ -15,10 +15,14 @@
  *     but this helper is fail-closed for tests / future callers that pass
  *     an empty string.)
  *
- *   - Does the wire-claimed `agent_unit` match the listener's agent? When
- *     they disagree the request is DENIED — the wire claim has no power,
- *     and we surface the mismatch in the audit row so a forensic reviewer
- *     can spot misconfigured agent-side code.
+ *   - Does the candidate `agent_unit` match the listener's agent? When
+ *     they disagree the request is DENIED. The candidate is the
+ *     wire-claimed `agent_unit` for `approval_request`/`approval_lookup`,
+ *     and the *resolved DB row's* `agent_unit` for the mutating ops
+ *     (`approval_consume`/`approval_revoke`/`approval_record`, #1399) —
+ *     either way the listener's bind-time identity is the only authority;
+ *     the caller-supplied id selects the row but cannot grant cross-agent
+ *     reach. Mismatches surface in the audit row for forensics.
  *
  * The kernel does NOT carry a per-key allowlist analogous to the broker's
  * `schedule[i].secrets`. Per-agent isolation IS the security model: every

--- a/src/vault/approvals/kernel-listener-acl.test.ts
+++ b/src/vault/approvals/kernel-listener-acl.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Listener-identity ACL on the kernel's mutating ops (#1399).
+ *
+ * Regression for the approval-integrity bypass: `approval_consume`,
+ * `approval_record`, and `approval_revoke` used to operate purely on the
+ * wire-supplied `request_id` / `decision_id` with NO check that the
+ * resolved nonce/decision belonged to the connecting per-agent listener.
+ * A compromised agent on its own legitimate socket could therefore
+ * self-consume + self-record an `allow_always` for a gated tool call no
+ * operator approved, or burn/revoke a peer's grant.
+ *
+ * These tests pin, over real bound per-agent sockets, that:
+ *   - agent B cannot consume / record / revoke agent A's nonce/decision
+ *     (DENIED, and A's state is untouched);
+ *   - the legitimate same-agent path still works (request → consume →
+ *     record → revoke for the listener's own agent);
+ *   - request_id carries 128-bit entropy (32 hex chars, not the old 8).
+ *
+ * bun test (openKernelDb → bun:sqlite); excluded from vitest.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import * as net from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { bootstrap, type KernelServerHandle } from "./kernel-server.js";
+import { encodeRequest } from "../broker/protocol.js";
+
+/** One-shot NDJSON round-trip against a bound unix socket. */
+function rpc(sockPath: string, req: unknown): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection(sockPath);
+    let buf = "";
+    const timer = setTimeout(() => {
+      sock.destroy();
+      reject(new Error("rpc timeout"));
+    }, 4000);
+    sock.on("connect", () => sock.write(encodeRequest(req as never)));
+    sock.on("data", (d) => {
+      buf += d.toString("utf8");
+      const nl = buf.indexOf("\n");
+      if (nl >= 0) {
+        clearTimeout(timer);
+        sock.end();
+        try {
+          resolve(JSON.parse(buf.slice(0, nl)));
+        } catch (e) {
+          reject(e);
+        }
+      }
+    });
+    sock.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+}
+
+describe("kernel listener-identity ACL on mutating ops (#1399)", () => {
+  let dir: string;
+  let handle: KernelServerHandle;
+  let aliceSock: string;
+  let bobSock: string;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "kernel-lacl-"));
+    handle = await bootstrap({
+      socketParent: dir,
+      agents: ["alice", "bob"],
+      dbPath: ":memory:",
+      operatorUid: process.getuid?.() ?? 0,
+    });
+    aliceSock = join(dir, "alice", "sock");
+    bobSock = join(dir, "bob", "sock");
+  });
+
+  afterEach(() => {
+    try {
+      handle.stop();
+    } catch {
+      /* ignore */
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function aliceRequest(): Promise<string> {
+    const resp = await rpc(aliceSock, {
+      v: 1,
+      op: "approval_request",
+      agent_unit: "alice",
+      scope: "secret:TEST_KEY",
+      action: "read",
+      approver_set: ["op1"],
+      why: "regression",
+    });
+    expect(resp.ok).toBe(true);
+    expect(resp.state).toBe("pending");
+    return resp.request_id as string;
+  }
+
+  it("mints 128-bit (32-hex) request ids, not the old 32-bit (8-hex)", async () => {
+    const rid = await aliceRequest();
+    expect(rid).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("denies cross-agent approval_consume and leaves the nonce intact", async () => {
+    const rid = await aliceRequest();
+
+    // bob, on his own legitimate socket, tries to burn alice's nonce.
+    const denied = await rpc(bobSock, {
+      v: 1,
+      op: "approval_consume",
+      request_id: rid,
+    });
+    expect(denied.ok).toBe(false);
+    expect(denied.code).toBe("DENIED");
+    // The denial must not echo the owning agent name (no oracle).
+    expect(String(denied.msg)).not.toContain("alice");
+
+    // alice can still consume her own nonce — bob's attempt was a no-op.
+    const ok = await rpc(aliceSock, {
+      v: 1,
+      op: "approval_consume",
+      request_id: rid,
+    });
+    expect(ok.ok).toBe(true);
+    expect(ok.consumed).toBe(true);
+    expect(ok.agent_unit).toBe("alice");
+  });
+
+  it("denies cross-agent approval_record (the self-grant bypass)", async () => {
+    const rid = await aliceRequest();
+    // Consume on alice's own socket so the nonce is in the recordable state.
+    const consumed = await rpc(aliceSock, {
+      v: 1,
+      op: "approval_consume",
+      request_id: rid,
+    });
+    expect(consumed.consumed).toBe(true);
+
+    // bob tries to forge an allow_always decision for alice's nonce.
+    const denied = await rpc(bobSock, {
+      v: 1,
+      op: "approval_record",
+      request_id: rid,
+      decision: "allow_always",
+      approver_set: ["op1"],
+      granted_by_user_id: 12345,
+    });
+    expect(denied.ok).toBe(false);
+    expect(denied.code).toBe("DENIED");
+
+    // The legitimate owner can still record (regression: same-agent works).
+    const ok = await rpc(aliceSock, {
+      v: 1,
+      op: "approval_record",
+      request_id: rid,
+      decision: "allow_always",
+      approver_set: ["op1"],
+      granted_by_user_id: 12345,
+    });
+    expect(ok.ok).toBe(true);
+    expect(typeof ok.decision_id).toBe("string");
+  });
+
+  it("denies cross-agent approval_revoke; owner can revoke its own", async () => {
+    // Build a real decision owned by alice.
+    const rid = await aliceRequest();
+    await rpc(aliceSock, { v: 1, op: "approval_consume", request_id: rid });
+    const rec = await rpc(aliceSock, {
+      v: 1,
+      op: "approval_record",
+      request_id: rid,
+      decision: "allow_always",
+      approver_set: ["op1"],
+      granted_by_user_id: 12345,
+    });
+    const decisionId = rec.decision_id as string;
+    expect(decisionId).toBeTruthy();
+
+    // bob tries to revoke alice's grant.
+    const denied = await rpc(bobSock, {
+      v: 1,
+      op: "approval_revoke",
+      decision_id: decisionId,
+      actor: "attacker",
+      reason: "grief",
+    });
+    expect(denied.ok).toBe(false);
+    expect(denied.code).toBe("DENIED");
+
+    // alice revokes her own — still works.
+    const ok = await rpc(aliceSock, {
+      v: 1,
+      op: "approval_revoke",
+      decision_id: decisionId,
+      actor: "alice",
+      reason: "done",
+    });
+    expect(ok.ok).toBe(true);
+    expect(ok.revoked).toBe(true);
+  });
+});

--- a/src/vault/approvals/kernel-operator-acl.test.ts
+++ b/src/vault/approvals/kernel-operator-acl.test.ts
@@ -3,11 +3,13 @@
  * listener (RFC: dashboard read-only kernel access).
  *
  * The kernel's mutating ops (approval_request/consume/revoke/record)
- * carry NO op-level ACL — their only gate is per-agent socket
- * isolation. The operator socket bypasses that isolation by design, so
- * it MUST be deny-by-default: only `approval_list` is permitted. These
- * tests pin that inversion over a real bound socket so a refactor that
- * reorders the op chain or widens the allowlist fails loudly.
+ * are gated by the listener-identity ACL (#1399 — see
+ * kernel-listener-acl.test.ts). That ACL keys off the bound agent name,
+ * so it cannot be satisfied on the operator socket (no agent identity).
+ * Independently, the operator socket MUST be deny-by-default: only
+ * `approval_list` is permitted. These tests pin that inversion over a
+ * real bound socket so a refactor that reorders the op chain or widens
+ * the allowlist fails loudly.
  *
  * bun test (openKernelDb → bun:sqlite); excluded from vitest.
  */
@@ -120,7 +122,7 @@ describe("kernel operator socket — deny-by-default ACL", () => {
     ],
     [
       "approval_consume",
-      { v: 1, op: "approval_consume", request_id: "0badf00d" },
+      { v: 1, op: "approval_consume", request_id: "0badf00d0badf00d0badf00d0badf00d" },
     ],
     [
       "approval_revoke",
@@ -131,7 +133,7 @@ describe("kernel operator socket — deny-by-default ACL", () => {
       {
         v: 1,
         op: "approval_record",
-        request_id: "0badf00d",
+        request_id: "0badf00d0badf00d0badf00d0badf00d",
         decision: "allow_always",
         approver_set: ["u1"],
         granted_by_user_id: 1,
@@ -158,7 +160,7 @@ describe("kernel operator socket — deny-by-default ACL", () => {
     const resp = await rpc(agentSock, {
       v: 1,
       op: "approval_record",
-      request_id: "0badf00d",
+      request_id: "0badf00d0badf00d0badf00d0badf00d",
       decision: "allow_always",
       approver_set: ["u1"],
       granted_by_user_id: 1,

--- a/src/vault/approvals/kernel-server.ts
+++ b/src/vault/approvals/kernel-server.ts
@@ -54,6 +54,7 @@ import {
   listDecisions,
   recordDecision,
   getNonce,
+  getDecision,
   countPendingNonces,
   computeRetryAfterMs,
   MAX_PENDING_PER_AGENT,
@@ -303,14 +304,16 @@ export const KERNEL_OPERATOR_NAME = "operator";
  * and that inversion is the entire security point of this socket.
  *
  * The kernel's mutating ops (`approval_consume` / `approval_revoke` /
- * `approval_record` / `approval_request`) carry NO op-level ACL: their
- * only gate is per-agent socket isolation. The operator socket is, by
- * construction, not in any agent's per-agent dir, so it bypasses that
- * isolation. An operator connection that could reach those ops would be
- * unauthenticated fleet-wide grant forgery / nonce burning. So the
- * operator socket is restricted to the single read-only op the
- * dashboard needs — listing decision metadata. Widening this set
- * without a per-op authorization story is a security regression.
+ * `approval_record` / `approval_request`) are gated by a listener-identity
+ * ACL: the resolved nonce/decision's `agent_unit` must equal the listener's
+ * bind-time agent name (#1399 — `checkApprovalAclByAgent`). That ACL keys
+ * off the *bound listener*, so it cannot be satisfied on the operator
+ * socket at all (no agent identity). An operator connection reaching those
+ * ops would still be unauthenticated fleet-wide grant forgery / nonce
+ * burning, so the operator socket is independently restricted to the
+ * single read-only op the dashboard needs — listing decision metadata.
+ * Widening this set without a per-op authorization story is a security
+ * regression.
  */
 const OPERATOR_ALLOWED_OPS: ReadonlySet<string> = new Set(["approval_list"]);
 
@@ -408,6 +411,21 @@ function handleRequest(
     return;
   }
   if (req.op === "approval_consume") {
+    // Listener-identity ACL (#1399): resolve the nonce's owning agent_unit
+    // and refuse if it is not the listener's bound agent. Without this a
+    // compromised agent on its own legitimate socket could burn / self-
+    // consume any peer's (or its own unrequested) nonce. The generic DENIED
+    // message deliberately omits the owning agent name (no cross-agent
+    // existence/identity oracle); a null peek falls through to the existing
+    // {consumed:false} non-committal path.
+    const peek = getNonce(db, req.request_id);
+    if (peek !== null) {
+      const acl = checkApprovalAclByAgent(agent, peek.agent_unit);
+      if (!acl.allow) {
+        socket.write(encodeResponse(errorResponse("DENIED", "approval_consume denied: nonce does not belong to the calling agent")));
+        return;
+      }
+    }
     const nonce = consumeNonce(db, req.request_id);
     if (nonce === null) {
       socket.write(encodeResponse({ ok: true, consumed: false }));
@@ -424,6 +442,17 @@ function handleRequest(
     return;
   }
   if (req.op === "approval_revoke") {
+    // Listener-identity ACL (#1399): a decision may only be revoked from
+    // the socket of the agent it belongs to. A null lookup falls through
+    // to revokeDecision, which returns {revoked:false} (unchanged).
+    const dec = getDecision(db, req.decision_id);
+    if (dec !== null) {
+      const acl = checkApprovalAclByAgent(agent, dec.agent_unit);
+      if (!acl.allow) {
+        socket.write(encodeResponse(errorResponse("DENIED", "approval_revoke denied: decision does not belong to the calling agent")));
+        return;
+      }
+    }
     const revoked = revokeDecision(db, req.decision_id, req.actor, req.reason);
     socket.write(encodeResponse({ ok: true, revoked }));
     return;
@@ -436,6 +465,15 @@ function handleRequest(
     }
     if (nonce.consumed_at === null) {
       socket.write(encodeResponse(errorResponse("BAD_REQUEST", "nonce must be consumed before recording — call approval_consume first")));
+      return;
+    }
+    // Listener-identity ACL (#1399): the nonce being recorded must belong
+    // to the listener's bound agent. Without this a compromised agent could
+    // self-consume + self-record an allow_always decision for a gated tool
+    // call no operator ever approved (approval-integrity bypass).
+    const recordAcl = checkApprovalAclByAgent(agent, nonce.agent_unit);
+    if (!recordAcl.allow) {
+      socket.write(encodeResponse(errorResponse("DENIED", "approval_record denied: nonce does not belong to the calling agent")));
       return;
     }
     const decision_id = recordDecision(db, {

--- a/src/vault/approvals/kernel.test.ts
+++ b/src/vault/approvals/kernel.test.ts
@@ -111,7 +111,7 @@ describe("approval kernel — request/consume/record/lookup", () => {
       approver_set: ["123"],
       why: "needs to call OpenAI",
     });
-    expect(r.request_id).toMatch(/^[0-9a-f]{8}$/);
+    expect(r.request_id).toMatch(/^[0-9a-f]{32}$/);
 
     expect(
       lookupDecision(db, {

--- a/src/vault/approvals/kernel.ts
+++ b/src/vault/approvals/kernel.ts
@@ -48,7 +48,7 @@ export interface ApprovalRequestInput {
 }
 
 export interface RequestApprovalResult {
-  request_id: string;       // 8-hex; goes on the apv: callback_data
+  request_id: string;       // 32-hex (128-bit, #1399); goes on the apv: callback_data
   expires_at: number;       // unix-ms when the prompt times out
 }
 
@@ -84,8 +84,11 @@ export type LookupResult =
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function generateRequestId(): string {
-  // 8 hex chars — matches generateAskId convention in telegram-plugin/ask-user.ts
-  return randomBytes(4).toString("hex");
+  // 128-bit (32 hex chars). #1399: 32-bit (randomBytes(4)) was online-
+  // guessable against a long-lived daemon and compounded the cross-agent
+  // nonce/decision attack surface. Still well under Telegram's 64-byte
+  // callback_data limit (`apv:<32hex>:allow_always` ≈ 49 bytes).
+  return randomBytes(16).toString("hex");
 }
 
 function audit(

--- a/src/vault/approvals/wait.test.ts
+++ b/src/vault/approvals/wait.test.ts
@@ -53,7 +53,7 @@ describe("waitForApproval", () => {
       _request: async () =>
         ({
           state: "pending",
-          request_id: "abc12345",
+          request_id: "abc12345abc12345abc12345abc12345",
           expires_at: 9_999_999_999,
         }) satisfies ApprovalRequestResult,
       _lookup: async () => lookups.shift() ?? null,
@@ -63,7 +63,7 @@ describe("waitForApproval", () => {
       kind: "decided",
       state: "granted",
       decision: fakeDecision(),
-      request_id: "abc12345",
+      request_id: "abc12345abc12345abc12345abc12345",
     });
     expect(sleepSpy).toHaveBeenCalled();
   });

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -232,7 +232,7 @@ export const ApprovalLookupRequestSchema = z.object({
 export const ApprovalConsumeRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("approval_consume"),
-  request_id: z.string().regex(/^[0-9a-f]{8}$/),
+  request_id: z.string().regex(/^[0-9a-f]{32}$/),
 });
 
 export const ApprovalRevokeRequestSchema = z.object({
@@ -261,7 +261,7 @@ export type ApprovalDecisionMode = z.infer<typeof ApprovalDecisionModeSchema>;
 export const ApprovalRecordRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("approval_record"),
-  request_id: z.string().regex(/^[0-9a-f]{8}$/),
+  request_id: z.string().regex(/^[0-9a-f]{32}$/),
   decision: ApprovalDecisionModeSchema,
   approver_set: z.array(z.string()),
   granted_by_user_id: z.number().int(),

--- a/src/vault/broker/server-approvals.test.ts
+++ b/src/vault/broker/server-approvals.test.ts
@@ -94,7 +94,7 @@ describe("VaultBroker: approval-kernel ops", () => {
     if (!(r1.ok && "kind" in r1 && r1.kind === "approval_request")) throw new Error("bad shape");
     if (r1.state !== "pending") throw new Error(`unexpected state ${r1.state}`);
     const reqId = r1.request_id;
-    expect(reqId).toMatch(/^[0-9a-f]{8}$/);
+    expect(reqId).toMatch(/^[0-9a-f]{32}$/);
 
     const r2 = await rpc(socketPath, {
       v: 1, op: "approval_lookup",

--- a/telegram-plugin/gateway/approval-card.test.ts
+++ b/telegram-plugin/gateway/approval-card.test.ts
@@ -12,7 +12,7 @@ import {
 describe("approval card", () => {
   it("renders the pristine card with default buttons", () => {
     const card = buildApprovalCard({
-      request_id: "a3f1b9c2",
+      request_id: "a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2",
       agent: "klanker",
       scope_humanized: "secret:OPENAI_API_KEY",
       why: "needs to call OpenAI",
@@ -24,14 +24,14 @@ describe("approval card", () => {
     // Validate the inline_keyboard structure carries our four callback shapes
     const flat = card.reply_markup.inline_keyboard.flat();
     const datas = flat.map((b) => ("callback_data" in b ? b.callback_data : ""));
-    expect(datas).toContain("apv:a3f1b9c2:once");
-    expect(datas).toContain("apv:a3f1b9c2:deny");
-    expect(datas).toContain("apv:a3f1b9c2:always");
+    expect(datas).toContain("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:once");
+    expect(datas).toContain("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:deny");
+    expect(datas).toContain("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:always");
   });
 
   it("respects offer_always=false and offer_ttl=true", () => {
     const card = buildApprovalCard({
-      request_id: "a3f1b9c2",
+      request_id: "a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2",
       agent: "k",
       scope_humanized: "x",
       offer_always: false,
@@ -40,13 +40,13 @@ describe("approval card", () => {
     const datas = card.reply_markup.inline_keyboard
       .flat()
       .map((b) => ("callback_data" in b ? b.callback_data : ""));
-    expect(datas).not.toContain("apv:a3f1b9c2:always");
-    expect(datas).toContain("apv:a3f1b9c2:ttl:1h");
+    expect(datas).not.toContain("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:always");
+    expect(datas).toContain("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:ttl:1h");
   });
 
   it("escapes HTML metacharacters in agent and scope", () => {
     const card = buildApprovalCard({
-      request_id: "deadbeef",
+      request_id: "deadbeefdeadbeefdeadbeefdeadbeef",
       agent: "<script>",
       scope_humanized: "a&b",
     });
@@ -58,21 +58,21 @@ describe("approval card", () => {
 
 describe("parseApprovalCallback", () => {
   it("parses every choice variant", () => {
-    expect(parseApprovalCallback("apv:a3f1b9c2:once"))
-      .toEqual({ request_id: "a3f1b9c2", choice: { kind: "once" } });
-    expect(parseApprovalCallback("apv:a3f1b9c2:always"))
-      .toEqual({ request_id: "a3f1b9c2", choice: { kind: "always" } });
-    expect(parseApprovalCallback("apv:a3f1b9c2:deny"))
-      .toEqual({ request_id: "a3f1b9c2", choice: { kind: "deny" } });
-    expect(parseApprovalCallback("apv:a3f1b9c2:ttl:1h"))
-      .toEqual({ request_id: "a3f1b9c2", choice: { kind: "ttl", param: "1h" } });
+    expect(parseApprovalCallback("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:once"))
+      .toEqual({ request_id: "a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2", choice: { kind: "once" } });
+    expect(parseApprovalCallback("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:always"))
+      .toEqual({ request_id: "a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2", choice: { kind: "always" } });
+    expect(parseApprovalCallback("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:deny"))
+      .toEqual({ request_id: "a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2", choice: { kind: "deny" } });
+    expect(parseApprovalCallback("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:ttl:1h"))
+      .toEqual({ request_id: "a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2", choice: { kind: "ttl", param: "1h" } });
   });
 
   it("rejects malformed prefixes and bad ids", () => {
     expect(parseApprovalCallback("perm:more:abc")).toBeNull();
     expect(parseApprovalCallback("apv:NOTHEX12:once")).toBeNull();
-    expect(parseApprovalCallback("apv:a3f1b9c2:bogus")).toBeNull();
-    expect(parseApprovalCallback("apv:a3f1b9c2:ttl")).toBeNull();
+    expect(parseApprovalCallback("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:bogus")).toBeNull();
+    expect(parseApprovalCallback("apv:a3f1b9c2a3f1b9c2a3f1b9c2a3f1b9c2:ttl")).toBeNull();
   });
 });
 

--- a/telegram-plugin/gateway/approval-card.ts
+++ b/telegram-plugin/gateway/approval-card.ts
@@ -89,7 +89,7 @@ export function parseApprovalCallback(data: string): ParsedApprovalCallback | nu
   if (parts.length < 3) return null;
   const request_id = parts[1];
   const choiceStr = parts[2];
-  if (!/^[0-9a-f]{8}$/.test(request_id ?? "")) return null;
+  if (!/^[0-9a-f]{32}$/.test(request_id ?? "")) return null;
   switch (choiceStr) {
     case "once":
       return { request_id: request_id as string, choice: { kind: "once" } };

--- a/telegram-plugin/gateway/diff-preview-card.test.ts
+++ b/telegram-plugin/gateway/diff-preview-card.test.ts
@@ -41,8 +41,8 @@ describe("buildDiffPreviewCard — suggest mode (default)", () => {
     const preview = buildDiffPreview(baseInput({ agentSummary: "Added Hiring section" }));
     const card = buildDiffPreviewCard({
       preview,
-      suggestRequestId: "aabbccdd",
-      writeRequestId: "11223344",
+      suggestRequestId: "aabbccddaabbccddaabbccddaabbccdd",
+      writeRequestId: "11223344112233441122334411223344",
     });
 
     // Body: title bold + all preview lines.
@@ -59,19 +59,19 @@ describe("buildDiffPreviewCard — suggest mode (default)", () => {
     expect(r[0]?.[0]?.text).toBe("📖 Open in Drive");
     expect(r[0]?.[0]?.url).toBe("https://docs.google.com/document/d/DOC1/edit");
     expect(r[0]?.[1]?.text).toBe("✅ Apply as suggestion");
-    expect(r[0]?.[1]?.callback_data).toBe("apv:aabbccdd:once");
+    expect(r[0]?.[1]?.callback_data).toBe("apv:aabbccddaabbccddaabbccddaabbccdd:once");
     // Row 2: [Apply directly] [Cancel]
     expect(r[1]?.[0]?.text).toBe("⚠ Apply directly");
-    expect(r[1]?.[0]?.callback_data).toBe("apv:11223344:once");
+    expect(r[1]?.[0]?.callback_data).toBe("apv:11223344112233441122334411223344:once");
     expect(r[1]?.[1]?.text).toBe("🚫 Cancel");
-    expect(r[1]?.[1]?.callback_data).toBe("apv:aabbccdd:deny");
+    expect(r[1]?.[1]?.callback_data).toBe("apv:aabbccddaabbccddaabbccddaabbccdd:deny");
   });
 
   it("hides 'Apply directly' when writeRequestId is undefined", () => {
     const preview = buildDiffPreview(baseInput());
     const card = buildDiffPreviewCard({
       preview,
-      suggestRequestId: "aabbccdd",
+      suggestRequestId: "aabbccddaabbccddaabbccddaabbccdd",
     });
     const flat = rows(card.reply_markup).flat();
     expect(flat.find((b) => b.text === "⚠ Apply directly")).toBeUndefined();
@@ -91,8 +91,8 @@ describe("buildDiffPreviewCard — write mode (opt-in via expand)", () => {
       // callback's deny channel — semantically Cancel is "don't grant
       // either scope" but reusing the suggest id keeps the existing
       // approval-callback handler stateless.
-      suggestRequestId: "aabbccdd",
-      writeRequestId: "11223344",
+      suggestRequestId: "aabbccddaabbccddaabbccddaabbccdd",
+      writeRequestId: "11223344112233441122334411223344",
     });
 
     const r = rows(card.reply_markup);
@@ -100,7 +100,7 @@ describe("buildDiffPreviewCard — write mode (opt-in via expand)", () => {
     expect(flat.find((b) => b.text === "✅ Apply as suggestion")).toBeUndefined();
     const directly = flat.find((b) => b.text === "⚠ Apply directly");
     expect(directly).toBeDefined();
-    expect(directly?.callback_data).toBe("apv:11223344:once");
+    expect(directly?.callback_data).toBe("apv:11223344112233441122334411223344:once");
     // Title icon swaps to ⚠.
     expect(card.text).toContain("⚠");
   });
@@ -119,7 +119,7 @@ describe("buildDiffPreviewCard — input validation", () => {
     expect(() =>
       buildDiffPreviewCard({
         preview,
-        suggestRequestId: "aabbccdd",
+        suggestRequestId: "aabbccddaabbccddaabbccddaabbccdd",
         writeRequestId: "ABCDEF01", // wrong case
       }),
     ).toThrow(/8 hex chars/);
@@ -136,7 +136,7 @@ describe("buildDiffPreviewCard — fragility guards", () => {
     );
     const card = buildDiffPreviewCard({
       preview,
-      suggestRequestId: "aabbccdd",
+      suggestRequestId: "aabbccddaabbccddaabbccddaabbccdd",
     });
     const flat = rows(card.reply_markup).flat();
     expect(flat.find((b) => b.text === "📖 Open in Drive")).toBeUndefined();
@@ -150,7 +150,7 @@ describe("buildDiffPreviewCard — fragility guards", () => {
     );
     const card = buildDiffPreviewCard({
       preview,
-      suggestRequestId: "aabbccdd",
+      suggestRequestId: "aabbccddaabbccddaabbccddaabbccdd",
     });
     expect(card.text).not.toContain("<script>");
     expect(card.text).toContain("&lt;script&gt;");
@@ -162,7 +162,7 @@ describe("buildDiffPreviewCard — fragility guards", () => {
     );
     const card = buildDiffPreviewCard({
       preview,
-      suggestRequestId: "aabbccdd",
+      suggestRequestId: "aabbccddaabbccddaabbccddaabbccdd",
     });
     expect(card.text).not.toMatch(/💬.*<b>/);
     expect(card.text).toContain("&lt;b&gt;");
@@ -175,8 +175,8 @@ describe("buildDiffPreviewCard — audit fidelity", () => {
     const preview = buildDiffPreview(input);
     const card = buildDiffPreviewCard({
       preview,
-      suggestRequestId: "aabbccdd",
-      writeRequestId: "11223344",
+      suggestRequestId: "aabbccddaabbccddaabbccddaabbccdd",
+      writeRequestId: "11223344112233441122334411223344",
     });
     // The audit row captures both wrapper truth + agent framing,
     // exactly as surfaced on the card.

--- a/telegram-plugin/gateway/diff-preview-card.ts
+++ b/telegram-plugin/gateway/diff-preview-card.ts
@@ -55,7 +55,7 @@ export interface DiffPreviewCardInput {
  * callback_data that the dispatcher rejects, but we'd rather fail
  * loudly at build time.
  */
-const REQUEST_ID_RE = /^[0-9a-f]{8}$/;
+const REQUEST_ID_RE = /^[0-9a-f]{32}$/;
 
 /**
  * Fragility-guard from B2 review: the `create_doc` prep helper

--- a/telegram-plugin/gateway/drive-write-approval.test.ts
+++ b/telegram-plugin/gateway/drive-write-approval.test.ts
@@ -66,7 +66,7 @@ function deps(overrides: Partial<DriveApprovalHandlerDeps> & { spy: Spy }): Driv
         ttl_ms: args.ttl_ms,
         approver_set: args.approver_set,
       });
-      return { request_id: "aabbccdd", expires_at_ms: Date.now() + args.ttl_ms };
+      return { request_id: "aabbccddaabbccddaabbccddaabbccdd", expires_at_ms: Date.now() + args.ttl_ms };
     },
     postCard: async (args) => {
       spy.posted.push({
@@ -123,7 +123,7 @@ describe("handleRequestDriveApproval — happy path", () => {
       type: "drive_approval_posted",
       correlationId: "corr-1",
       ok: true,
-      requestId: "aabbccdd",
+      requestId: "aabbccddaabbccddaabbccddaabbccdd",
     });
     expect(spy.sent[0]?.expiresAtMs).toBeGreaterThan(Date.now());
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -82,6 +82,7 @@ export default defineConfig({
       // Approval-kernel suites use bun:sqlite — run via test:bun.
       "**/src/vault/approvals/kernel.test.ts",
       "**/src/vault/approvals/kernel-operator-acl.test.ts",
+      "**/src/vault/approvals/kernel-listener-acl.test.ts",
       "**/src/vault/approvals/schema-idempotent.test.ts",
       "**/src/vault/approvals/vd-unlock-dual-dispatch.test.ts",
       "**/src/vault/approvals/vault-grant-dual-dispatch.test.ts",


### PR DESCRIPTION
Closes #1399. First remediation PR of security epic #1389 (top-priority CRITICAL).

## Problem

`approval_consume` / `approval_revoke` / `approval_record` (`src/vault/approvals/kernel-server.ts`) operated purely on the wire-supplied `request_id` / `decision_id` with **no check that the resolved nonce/decision belonged to the connecting per-agent listener** — unlike `approval_request`/`approval_lookup` which gate on `checkApprovalAclByAgent`. The kernel client is reachable by anything in the agent container via `SWITCHROOM_KERNEL_SOCKET`, so a prompt-injected/compromised agent on its **own legitimate** socket could:

- self-`approval_request` → self-`approval_consume` → self-`approval_record({decision:"allow_always"})` → its `approval_lookup` returns `granted` → a gated tool call **no operator approved** executes (approval-integrity bypass);
- burn / revoke a peer's grant (cross-agent), made online-guessable by the 32-bit `request_id` (`randomBytes(4)`).

Independently confirmed by three fresh analyses (WS3 review, WS4 audit, WS4 review) — see #1399 / #1395 / #1398.

## Fix

- **Listener-identity ACL** on all three mutating ops: resolve the nonce (`getNonce`) / decision (`getDecision`) first, then `checkApprovalAclByAgent(agent, row.agent_unit)`; DENY on mismatch. The denial message is generic (no cross-agent existence/identity oracle — does not echo the owning agent name). A null lookup falls through to the existing non-committal path (`{consumed:false}` / `{revoked:false}`), unchanged. **Legitimate same-agent flow is unchanged.**
- **Entropy**: `request_id` 32-bit → **128-bit** (`randomBytes(16)`, 32 hex). Updated the two wire schemas (`ApprovalConsume/RecordRequestSchema`), the `apv:` (`approval-card.ts`) and diff-preview (`diff-preview-card.ts`) callback parsers, and the now-stale 8-hex fixtures/shape assertions. `apv:<32hex>:allow_always` ≈ 49 bytes, well under Telegram's 64-byte callback_data limit.
- New regression suite `kernel-listener-acl.test.ts`: pins cross-agent `consume`/`record`/`revoke` denial + same-agent regression + 128-bit entropy. Corrected the stale "mutating ops carry NO op-level ACL" doc comments in `kernel-server.ts` and `kernel-operator-acl.test.ts`.

The operator-socket deny-by-default invariant is untouched and still enforced as the first dispatch check.

## Scope / non-goals

Only the kernel ACL + entropy. The sibling `apv:` Telegram-callback authz gap (audit #1397) was **already remediated upstream by #1404** (`ac21f2fd`, sec WS7-F1) — this branch is rebased on top of it; no overlap. hostd findings (#1400/#1401) and the rest of the epic remain separate scoped PRs.

## Test plan

- [x] `npm run lint` clean (tsc --noEmit + plugin/bot-api/bun-test-import checks).
- [x] `npm run build` green.
- [x] Touched bun suites: 80/80 pass incl. the new `kernel-listener-acl.test.ts` (cross-agent denial, same-agent regression, entropy) and `kernel`/`server-approvals`/`approval-card`/`diff-preview-card`/`wait`/`drive-write-approval`.
- [x] Full `vitest run`: 6369 pass / 1 pre-existing **unrelated** failure — `tests/doctor.mff.test.ts > checkMff > all probes report ok or warn` (`expected ['ok','warn'] to include 'fail'`). That file and the MFF doctor source are **not in this diff** (`git diff --name-only` is exclusively `src/vault/approvals/*`, `protocol.ts`, gateway card files, tests, `vitest.config.ts`); it's a host-health probe failing on the shared dev box's state, not caused by this change. Flagged for the reviewer to confirm independently; candidate for its own ticket.

### Upgrade note
A nonce minted just before the cutover (8-hex) fails the new 32-hex validator on `approval_consume` post-upgrade — benign and self-healing (the agent re-requests; 5-min TTL). No migration shim, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)