### PR TITLE
fix(compose): per-agent credentials/ scope + migration-safe doctor warn (sec WS6-F2)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1525,20 +1525,36 @@ function emitAgentService(
   lines.push(`      - ${homePrefix}/.switchroom/logs/${a.name}:/var/log/switchroom`);
   lines.push(`      - ${homePrefix}/.switchroom/agents/${a.name}:${homePrefix}/.switchroom/agents/${a.name}`);
   lines.push(`      - ${homePrefix}/.claude/projects/${a.name}:${homePrefix}/.claude/projects/${a.name}`);
-  // Shared read-only bind mounts for skills + credentials (#907). Cron
-  // yaml prompts widely reference `~/.switchroom/skills/...` (calendar,
-  // mail, garmin, home-assistant) and `~/.switchroom/credentials/...`.
-  // Mounted at the operator's host path so absolute paths in scaffolded
-  // start.sh and yaml prompts Just Work; tilde resolution is fixed by
-  // start.sh.hbs's $HOME/.switchroom symlink (see #910). Conditional on
-  // existsSync because docker compose `up` hard-fails when a `:ro`
-  // source is missing — many operators keep all secrets in vault and
-  // never create a `credentials/` dir at all.
+  // Shared read-only `skills/` bind mount (#907). Cron yaml prompts
+  // reference `~/.switchroom/skills/...` (calendar, mail, garmin,
+  // home-assistant). Mounted at the operator's host path so absolute
+  // paths in scaffolded start.sh and yaml prompts Just Work; tilde
+  // resolution is fixed by start.sh.hbs's $HOME/.switchroom symlink
+  // (#910). existsSync-guarded: docker compose `up` hard-fails on a
+  // missing `:ro` source. skills/ is operator-authored, non-secret
+  // content (WS6 audit: LOW info-disclosure only) so it stays
+  // fleet-wide.
   if (existsSync(`${hostHomeForChecks}/.switchroom/skills`)) {
     lines.push(`      - ${homePrefix}/.switchroom/skills:${homePrefix}/.switchroom/skills:ro`);
   }
-  if (existsSync(`${hostHomeForChecks}/.switchroom/credentials`)) {
-    lines.push(`      - ${homePrefix}/.switchroom/credentials:${homePrefix}/.switchroom/credentials:ro`);
+  // PER-AGENT credentials mount (sec WS6-F2, #1390). Previously the
+  // ENTIRE `~/.switchroom/credentials/` dir was bind-mounted `:ro`
+  // into EVERY agent — so a prompt-injected agent could read every
+  // credential the operator placed there for any agent/purpose
+  // (cross-agent credential exfil reachable from untrusted input).
+  // Now scoped to `~/.switchroom/credentials/<name>/`, mirroring the
+  // per-agent `audit/<name>` pattern below (and its "never mount the
+  // parent" rule). Mounted at BOTH the canonical flat in-container
+  // path AND the host-absolute path so existing yaml prompts that
+  // reference `~/.switchroom/credentials/<file>` keep resolving — the
+  // agent now sees only ITS OWN credentials there. Migration of any
+  // pre-existing flat `~/.switchroom/credentials/*` files into per-
+  // agent subdirs is surfaced as a loud `doctor` warning (see
+  // checkFlatCredentialsMigration) — never a silent break.
+  if (existsSync(`${hostHomeForChecks}/.switchroom/credentials/${a.name}`)) {
+    lines.push(
+      `      - ${homePrefix}/.switchroom/credentials/${a.name}:${homePrefix}/.switchroom/credentials:ro`,
+    );
   }
   // Ensure the host-side per-agent audit dir exists before docker
   // compose tries to bind-mount it (docker auto-creates as root, which

--- a/src/cli/doctor-credentials-migration.test.ts
+++ b/src/cli/doctor-credentials-migration.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+function cfg(agents: string[]): SwitchroomConfig {
+  return {
+    agents: Object.fromEntries(agents.map((a) => [a, {}])),
+  } as unknown as SwitchroomConfig;
+}
+
+function deps(
+  entries: string[],
+  dirs: Set<string>,
+  credentialsDir = "/cred",
+) {
+  return {
+    credentialsDir,
+    existsSync: (p: string) => p === credentialsDir,
+    readdirSync: (_: string) => entries,
+    isDirectory: (p: string) => dirs.has(p),
+  };
+}
+
+describe("runCredentialsMigrationChecks (sec WS6-F2)", () => {
+  it("silent ([]) when no credentials dir exists", () => {
+    expect(
+      runCredentialsMigrationChecks(cfg(["a"]), {
+        credentialsDir: "/cred",
+        existsSync: () => false,
+      }),
+    ).toEqual([]);
+  });
+
+  it("ok when only per-agent subdirs (declared agents) exist", () => {
+    const rs = runCredentialsMigrationChecks(
+      cfg(["a", "b"]),
+      deps(["a", "b"], new Set(["/cred/a", "/cred/b"])),
+    );
+    expect(rs).toHaveLength(1);
+    expect(rs[0]!.status).toBe("ok");
+  });
+
+  it("WARNS (not fail, not silent) on a flat credential FILE", () => {
+    const rs = runCredentialsMigrationChecks(
+      cfg(["a"]),
+      deps(["a", "shared-token.json"], new Set(["/cred/a"])),
+    );
+    const w = rs.find((r) => r.name.includes("flat entries"));
+    expect(w?.status).toBe("warn");
+    expect(w?.detail).toContain("shared-token.json");
+    expect(w?.fix).toContain("mv");
+  });
+
+  it("treats a non-agent-named directory as flat (no agent mounts it)", () => {
+    const rs = runCredentialsMigrationChecks(
+      cfg(["a"]),
+      deps(["a", "legacy"], new Set(["/cred/a", "/cred/legacy"])),
+    );
+    expect(rs[0]!.status).toBe("warn");
+    expect(rs[0]!.detail).toContain("legacy");
+  });
+});

--- a/src/cli/doctor-credentials-migration.ts
+++ b/src/cli/doctor-credentials-migration.ts
@@ -1,0 +1,128 @@
+/**
+ * Credentials-mount migration check (sec WS6-F2, #1390).
+ *
+ * The fix for WS6-F2 scoped the per-agent credentials bind mount from
+ * the fleet-wide `~/.switchroom/credentials/` to per-agent
+ * `~/.switchroom/credentials/<agent>/` (compose.ts). That closes a
+ * cross-agent credential-exfil hole, but it also means any credential
+ * file an operator previously placed FLAT under
+ * `~/.switchroom/credentials/<file>` is no longer visible to agents.
+ *
+ * To guarantee the security fix never causes a SILENT credential
+ * outage, this check loudly surfaces any flat (non-per-agent) entry
+ * directly under `~/.switchroom/credentials/` and tells the operator
+ * exactly how to migrate it. It is detection-only — it never moves or
+ * deletes anything.
+ *
+ * Returns [] (silent) when there is no `credentials/` dir or it
+ * contains only per-agent subdirectories — i.e. nothing to migrate.
+ */
+
+import {
+  existsSync as realExistsSync,
+  readdirSync as realReaddirSync,
+  statSync as realStatSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+
+export type CheckStatus = "ok" | "warn" | "fail";
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/** FS injection seam — tests pass fakes; production uses real syscalls. */
+export interface CredMigrationDeps {
+  /** Defaults to `~/.switchroom/credentials`. */
+  credentialsDir?: string;
+  existsSync?: (p: string) => boolean;
+  readdirSync?: (p: string) => string[];
+  isDirectory?: (p: string) => boolean;
+}
+
+export function runCredentialsMigrationChecks(
+  config: SwitchroomConfig,
+  deps: CredMigrationDeps = {},
+): CheckResult[] {
+  const credDir =
+    deps.credentialsDir ?? join(homedir(), ".switchroom", "credentials");
+  const existsSync = deps.existsSync ?? ((p: string) => realExistsSync(p));
+  const readdirSync = deps.readdirSync ?? ((p: string) => realReaddirSync(p));
+  const isDirectory =
+    deps.isDirectory ??
+    ((p: string) => {
+      try {
+        return realStatSync(p).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+
+  if (!existsSync(credDir)) return [];
+
+  const agentNames = new Set(Object.keys(config.agents ?? {}));
+  let entries: string[];
+  try {
+    entries = readdirSync(credDir);
+  } catch {
+    return [
+      {
+        name: "credentials: layout",
+        status: "warn",
+        detail: `could not read ${credDir} — skipped migration check`,
+      },
+    ];
+  }
+
+  const flat: string[] = [];
+  const perAgentDirs: string[] = [];
+  for (const e of entries) {
+    const full = join(credDir, e);
+    if (isDirectory(full) && agentNames.has(e)) {
+      perAgentDirs.push(e);
+    } else {
+      // A flat file, OR a directory whose name isn't a declared agent
+      // (still flat from the agents' POV — no agent mounts it).
+      flat.push(e);
+    }
+  }
+
+  if (flat.length === 0) {
+    return [
+      {
+        name: "credentials: layout",
+        status: "ok",
+        detail:
+          perAgentDirs.length > 0
+            ? `per-agent only (${perAgentDirs.length} agent dir(s)); no fleet-wide-readable entries`
+            : "no flat entries",
+      },
+    ];
+  }
+
+  // Flat entries exist → they are NOT mounted into any agent after the
+  // WS6-F2 fix. Loud WARN (not fail — this is a migration prompt, the
+  // operator may have intentionally retired these), with the exact
+  // remediation. Never silent.
+  return [
+    {
+      name: "credentials: flat entries not visible to agents (sec WS6-F2)",
+      status: "warn",
+      detail:
+        `${flat.length} entr(y/ies) directly under ${credDir} ` +
+        `(${flat.slice(0, 5).join(", ")}${flat.length > 5 ? ", …" : ""}) ` +
+        `are NOT bind-mounted into any agent since the WS6-F2 per-agent ` +
+        `scoping fix — agents that relied on them will fail to find them`,
+      fix:
+        `move each file under the per-agent dir(s) that need it, e.g. ` +
+        `\`mkdir -p ${credDir}/<agent> && mv ${credDir}/<file> ${credDir}/<agent>/\`, ` +
+        `then \`switchroom update\`. Prefer the per-agent-ACL'd vault ` +
+        `(\`switchroom vault set\`) for new secrets — see docs/configuration.md.`,
+    },
+  ];
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -27,6 +27,7 @@ import { probeHindsight } from "../memory/hindsight.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runDriveChecks } from "./doctor-drive.js";
+import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
 
 /**
  * Result of a single doctor check.
@@ -2225,6 +2226,7 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Memory (Hindsight)", results: await checkHindsight(config) },
           { title: "Telegram", results: await checkTelegram(config) },
           { title: "Agents", results: checkAgents(config, configPath) },
+          { title: "Credentials", results: runCredentialsMigrationChecks(config) },
           { title: "Docker (Phase 1a)", results: runDockerSection(config) },
           { title: "Auth Broker", results: runAuthBrokerChecks(config) },
           { title: "Google Drive", results: runDriveChecks(config) },

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -434,24 +434,42 @@ describe("generateCompose", () => {
     expect(out).not.toContain("${HOME}");
   });
 
-  it("emits skills + credentials :ro mounts when host dirs exist (#907)", async () => {
+  it("emits skills (fleet-wide) + PER-AGENT credentials :ro mount (sec WS6-F2)", async () => {
     const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
     const tmp = mkdtempSync(join(tmpdir(), "compose-mounts-"));
     mkdirSync(join(tmp, ".switchroom", "skills"), { recursive: true });
-    mkdirSync(join(tmp, ".switchroom", "credentials"), { recursive: true });
+    // Per-agent credentials dir for agent "a" + a different agent's
+    // dir that must NOT leak into "a" post-WS6-F2.
+    mkdirSync(join(tmp, ".switchroom", "credentials", "a"), {
+      recursive: true,
+    });
+    mkdirSync(join(tmp, ".switchroom", "credentials", "b-other"), {
+      recursive: true,
+    });
     try {
       const out = generateCompose({
         config: makeConfig({ a: {} }),
         homeDir: tmp,
       });
+      // skills/ stays fleet-wide (operator-authored, non-secret).
       expect(out).toContain(
         `${tmp}/.switchroom/skills:${tmp}/.switchroom/skills:ro`,
       );
+      // credentials are PER-AGENT: agent "a" sees only its own subdir,
+      // mounted at the canonical flat in-container path.
       expect(out).toContain(
+        `${tmp}/.switchroom/credentials/a:${tmp}/.switchroom/credentials:ro`,
+      );
+      // WS6-F2 regression guard: the OLD fleet-wide flat mount
+      // (which let any agent read every other agent's/purpose's
+      // credentials) must NEVER be emitted again, and agent "a" must
+      // not receive b-other's dir.
+      expect(out).not.toContain(
         `${tmp}/.switchroom/credentials:${tmp}/.switchroom/credentials:ro`,
       );
+      expect(out).not.toContain(`/.switchroom/credentials/b-other`);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Remediates **WS6-F2 (HIGH)** from the security audit (#1390, epic #1389).

The entire `~/.switchroom/credentials/` dir was bind-mounted `:ro` into **every** agent — a prompt-injected agent could read every credential the operator placed there for any agent/purpose (cross-agent credential exfil reachable from untrusted input; the product actively directs secrets there via cron prompts). The same `compose.ts` already scopes `audit/<name>` per-agent and explicitly forbids mounting the parent — `credentials/` did exactly that forbidden thing.

- **Fix:** scope the mount to `~/.switchroom/credentials/<name>/`, mounted at the canonical flat in-container path so existing `~/.switchroom/credentials/<file>` yaml-prompt references keep resolving — the agent now sees only **its own** credentials. `skills/` stays fleet-wide (operator-authored, non-secret — WS6 rated LOW).
- **No silent fleet breakage** (executing-with-care): a bare mount swap would silently break every operator with flat `credentials/` files at their next `switchroom update`. Paired with a loud, **detection-only** `doctor` "Credentials" section that flags any flat (non-per-agent) entry and prints the exact `mkdir/mv` migration + steers new secrets to the per-agent-ACL'd vault. Never moves/deletes; silent when nothing to migrate.
- Snapshot test updated to lock in per-agent scoping + regression guards (old fleet-wide flat mount never re-emitted; sibling agent's dir never leaks).

## Verification

Fresh separate-process review: **APPROVE** — fix correct & mirrors the per-agent `audit/<name>` pattern; `${a.name}` injection-safe (regex-validated at creation); no silent-break false-negative (all non-declared-agent entries flagged); no false-positive for migrated operators; no other in-container flat-credentials consumer breaks (MFF readers already use per-agent paths, host-side); 135/135 tests; lint clean.

## Scope

WS6-F2 only. WS6-F3 (full `switchroom.yaml` exposure / inlined secrets — distinct file/threat; full fix is a per-agent reduced-config view, a design change) folds into the MEDIUM/LOW batch + a tracked follow-up. Audit/remediation separate per epic §6.

Refs #1390, #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)