### PR TITLE
fix(gateway): fleet-admin verbs are operator-private (sec WS7-F2)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7809,23 +7809,57 @@ async function runSwitchroomCommandFormatted(ctx: Context, args: string[], label
 // Invariant: when AGENT_ADMIN=true, this middleware is a no-op — bot.command()
 // handlers run normally for all admin verbs and Claude never sees them.
 bot.use(async (ctx, next) => {
-  if (!AGENT_ADMIN && ctx.message?.text) {
+  if (ctx.message?.text) {
     const myName = getMyAgentName()
     const decision = classifyAdminGate(ctx.message.text, myName)
     if (decision.action === 'block') {
-      // Block admin commands the LLM should never see. Reply with a concise
-      // "admin required" warning instead of forwarding to Claude.
-      process.stderr.write(
-        `telegram gateway: admin-gate blocked cmd=/${decision.cmd} agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} reason=${decision.reason} (AGENT_ADMIN=false)\n`,
-      )
+      // `block` = a fleet-admin verb (ADMIN_COMMAND_NAMES) or
+      // `/restart <other-agent>`. classifyAdminGate already lets
+      // `/restart`-self and every non-admin command pass through, so
+      // this branch is exactly the privileged set.
       const cmdHtml = escapeHtmlForTg(`/${decision.cmd}`)
       const nameHtml = escapeHtmlForTg(myName)
-      const text =
+      const notFlagged =
         decision.reason === 'other-agent'
           ? `⚠️ <code>${cmdHtml}</code> targeting another agent is an admin operation — this agent (<code>${nameHtml}</code>) isn't admin-flagged. Run it from an admin agent, or set <code>admin: true</code> for this agent in switchroom.yaml. (Self-restart is allowed: send <code>/restart</code> with no arg.)`
           : `⚠️ <code>${cmdHtml}</code> is an admin command — this agent (<code>${nameHtml}</code>) isn't admin-flagged. Run it from an admin agent, or set <code>admin: true</code> for this agent in switchroom.yaml.`
-      await switchroomReply(ctx, text, { html: true })
-      return
+      if (!AGENT_ADMIN) {
+        // Unchanged behaviour: a non-admin agent never executes admin
+        // verbs locally and must not forward them to Claude.
+        process.stderr.write(
+          `telegram gateway: admin-gate blocked cmd=/${decision.cmd} agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} reason=${decision.reason} (AGENT_ADMIN=false)\n`,
+        )
+        await switchroomReply(ctx, notFlagged, { html: true })
+        return
+      }
+      // sec WS7-F2 (#1394): fleet-admin is OPERATOR-PRIVATE. Honor it
+      // ONLY in a private chat from an `access.allowFrom` sender.
+      // Before this, when AGENT_ADMIN=true the middleware was a no-op
+      // and the per-command `isAuthorizedSender` gate treats an empty
+      // group `allowFrom` as "allow every member" — so any member of
+      // an admin agent's forum/group could run /vault, /update apply,
+      // /grant, /dangerous, etc. (the default shape for an agent
+      // created via `agent add --topology forum` + `admin: true`).
+      // Strict `access.allowFrom` + private-chat-only — never the
+      // group-permissive isAuthorizedSender.
+      const senderId = String(ctx.from?.id ?? '')
+      const operatorPrivate =
+        ctx.chat?.type === 'private' &&
+        loadAccess().allowFrom.includes(senderId)
+      if (!operatorPrivate) {
+        process.stderr.write(
+          `telegram gateway: admin-gate refused (not operator-private) cmd=/${decision.cmd} agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} chat=${ctx.chat?.type ?? '?'} sender=${senderId}\n`,
+        )
+        await switchroomReply(
+          ctx,
+          `⚠️ <code>${cmdHtml}</code> is a fleet-admin command — it is <b>operator-private</b>. Send it as a direct message to me from your operator account (a private chat where your Telegram ID is on the access allowlist), not in a group or forum.`,
+          { html: true },
+        )
+        return
+      }
+      // operator-private admin verb on an admin agent → fall through
+      // to the bot.command() handler (which re-checks isAuthorizedSender
+      // — redundant but harmless in a private allowFrom chat).
     }
   }
   await next()

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7806,8 +7806,13 @@ async function runSwitchroomCommandFormatted(ctx: Context, args: string[], label
 // every agent can self-restart without admin privilege. `/restart <other>`
 // is blocked just like any other admin verb.
 //
-// Invariant: when AGENT_ADMIN=true, this middleware is a no-op — bot.command()
-// handlers run normally for all admin verbs and Claude never sees them.
+// sec WS7-F2 (#1394): when AGENT_ADMIN=true this middleware is NO LONGER a
+// no-op — a `block`-classified verb (fleet-admin / `/restart <other>`)
+// requires OPERATOR-PRIVATE (a private chat from a strict
+// `access.allowFrom` sender), because the per-command `isAuthorizedSender`
+// gate treats an empty group `allowFrom` as "allow every member". Non-
+// admin-verb traffic (`pass-through`, incl. `/restart`-self and all normal
+// chat) is untouched and reaches `next()` exactly as before.
 bot.use(async (ctx, next) => {
   if (ctx.message?.text) {
     const myName = getMyAgentName()


### PR DESCRIPTION
## Summary

Remediates **WS7-F2 (HIGH)** from the security audit (#1394, epic #1389).

Privileged verbs gated only on `isAuthorizedSender`, which treats an empty group `allowFrom` as "allow every member". The default `agent add --topology forum` shape is `groups.<forum>={requireMention:false,allowFrom:[]}`, so an `admin:true` forum agent let **any forum/supergroup member** run `/vault`, `/update apply`, `/grant`, `/dangerous`, `/restart <any>`, `/stop` — fleet/secrets/host control, no second factor (the admin middleware was a no-op when `AGENT_ADMIN=true`, and there is no operator principal distinct from "passes the ordinary-chat gate").

**Fix:** the pre-command admin middleware now requires, for a `block`-classified message when `AGENT_ADMIN=true`, **operator-private** — a private chat whose sender is in strict `access.allowFrom` (never the group-permissive `isAuthorizedSender`). Not operator-private → refused with an actionable "DM me from your operator account" message; never executed, never forwarded to Claude. `classifyAdminGate` is unchanged, so `/restart`-self and all non-admin chat still `pass-through` untouched (no self-restart regression, normal forum chat unaffected). The non-admin-agent path is byte-unchanged.

## Verification

Fresh separate-process review: **APPROVE** — full case matrix verified (pass-through unchanged incl. self-restart; `!AGENT_ADMIN` unchanged; AGENT_ADMIN+operator-private → handler runs; AGENT_ADMIN+not-private → refused); strict `loadAccess().allowFrom` (not group-permissive); middleware runs before every command handler (no bypass); minimal diff; `npm run lint` clean; 59/0 admin+authz tests. The reviewer surfaced a **distinct follow-up** (filed as WS7-F2b on #1394): `/auth` is not in `ADMIN_COMMAND_NAMES` so it bypasses this gate via the same group-permissive path — separate command path, tracked for a follow-up scoped PR (out of WS7-F2's literal scope). Stale "no-op" comment corrected in the second commit.

## Scope

WS7-F2 (the `ADMIN_COMMAND_NAMES` command path) only. Already-strict callbacks (apv:/op:/vd:/vg:/…) are not the vuln. Audit/remediation separate per epic §6.

Refs #1394, #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)