### PR TITLE
fix(auth-broker): symlink-guard the per-agent credential mirror (#1393)

### DIFF
--- a/src/auth/broker/server-mirror-symlink-guard.test.ts
+++ b/src/auth/broker/server-mirror-symlink-guard.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Regression test for #1393 (WS1 fresh-reviewer gate, epic #1389).
+ *
+ * BUG: `mirrorAccountToAgent` (auth-broker, runs as root with
+ * CAP_DAC_OVERRIDE) wrote the per-agent OAuth mirror into
+ * `~/.switchroom/agents/<name>/.claude/.credentials.json` with
+ * `mkdirSync({recursive})` + atomic-write + `chownSync` and NO
+ * symlink guard. That tree is agent-UID-owned and RW bind-mounted
+ * into the (potentially prompt-injected) agent container, so the
+ * agent could pre-plant `.claude` (or `agentDir`, or the target
+ * file) as a symlink and the root broker would dereference it on
+ * the next fanout → arbitrary host-path root-owned write.
+ *
+ * FIX: `resolveMirrorPathsSafe` lstats every controllable path
+ * component (agentsDir / agentDir / .claude / target) BEFORE any
+ * mkdir/write/chown and fails closed (skips that agent's mirror,
+ * logs + audits) if any is a symlink or the wrong type — never
+ * crashing the whole fanout.
+ *
+ * These tests drive the real fanout (boot `fanoutAll`) through a
+ * temp HOME, exactly like `server-mirror-enrich.test.ts`.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AuthBroker } from "./server.js";
+import { accountCredentialsPath, accountDir } from "../account-store.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-symlink-guard-test-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try {
+      rmSync(h.tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  harnesses = [];
+});
+
+function makeConfig(h: Harness, agents: Record<string, object>): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents,
+    auth: { active: "default" },
+  } as unknown as SwitchroomConfig;
+}
+
+function writeSourceCreds(h: Harness, label: string): void {
+  mkdirSync(accountDir(label, h.home), { recursive: true });
+  writeFileSync(
+    accountCredentialsPath(label, h.home),
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "at-default",
+        refreshToken: "rt-default",
+        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        scopes: ["user:inference"],
+        subscriptionType: "max",
+      },
+    }),
+  );
+}
+
+function readAudit(h: Harness): string {
+  const p = join(h.stateDir, "audit.jsonl");
+  return existsSync(p) ? readFileSync(p, "utf-8") : "";
+}
+
+describe("AuthBroker — symlink-guarded per-agent mirror (#1393)", () => {
+  it("REFUSES to write through a pre-planted `.claude` symlink (no root-owned write at the symlink target)", async () => {
+    const h = makeHarness();
+    writeSourceCreds(h, "default");
+
+    // The agent owns ~/.switchroom/agents/ziggy/ and pre-plants
+    // `.claude` -> an attacker-chosen escape target.
+    const agentDir = join(h.agentsDir, "ziggy");
+    mkdirSync(agentDir, { recursive: true });
+    const escapeTarget = join(h.tmp, "escape-target");
+    mkdirSync(escapeTarget, { recursive: true });
+    symlinkSync(escapeTarget, join(agentDir, ".claude"));
+
+    const broker = new AuthBroker(makeConfig(h, { ziggy: {} }), {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start(); // boot fanout fires here
+    broker.stop();
+
+    // The broker must NOT have dereferenced the symlink: nothing
+    // written into the escape target.
+    expect(existsSync(join(escapeTarget, ".credentials.json"))).toBe(false);
+    // And the symlink is left intact (not replaced by a real file/dir).
+    expect(existsSync(join(agentDir, ".claude", ".credentials.json"))).toBe(
+      false,
+    );
+
+    // The refusal is audited as a structured security event.
+    const audit = readAudit(h);
+    expect(audit).toContain('"op":"mirror-symlink-refused"');
+    expect(audit).toContain(".claude:is-a-symlink");
+  });
+
+  it("REFUSES to write through a pre-planted symlinked `agentDir`", async () => {
+    const h = makeHarness();
+    writeSourceCreds(h, "default");
+
+    const escapeTarget = join(h.tmp, "escape-target-2");
+    mkdirSync(escapeTarget, { recursive: true });
+    // agentDir itself is a symlink to an attacker-chosen dir.
+    symlinkSync(escapeTarget, join(h.agentsDir, "ziggy"));
+
+    const broker = new AuthBroker(makeConfig(h, { ziggy: {} }), {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    broker.stop();
+
+    expect(existsSync(join(escapeTarget, ".claude", ".credentials.json"))).toBe(
+      false,
+    );
+    const audit = readAudit(h);
+    expect(audit).toContain('"op":"mirror-symlink-refused"');
+    expect(audit).toContain("agentDir:is-a-symlink");
+  });
+
+  it("REFUSES a symlinked `.credentials.json` target file", async () => {
+    const h = makeHarness();
+    writeSourceCreds(h, "default");
+
+    const agentDir = join(h.agentsDir, "ziggy");
+    const claudeDir = join(agentDir, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    const escapeFile = join(h.tmp, "escape-file");
+    writeFileSync(escapeFile, "original");
+    symlinkSync(escapeFile, join(claudeDir, ".credentials.json"));
+
+    const broker = new AuthBroker(makeConfig(h, { ziggy: {} }), {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    broker.stop();
+
+    // The escape file must not have been overwritten with creds.
+    expect(readFileSync(escapeFile, "utf-8")).toBe("original");
+    const audit = readAudit(h);
+    expect(audit).toContain('"op":"mirror-symlink-refused"');
+    expect(audit).toContain(".credentials.json:is-a-symlink");
+  });
+
+  it("one poisoned agent does NOT block a legitimate agent's mirror (fail-closed, not fail-stop)", async () => {
+    const h = makeHarness();
+    writeSourceCreds(h, "default");
+
+    // Poisoned agent.
+    const evil = join(h.agentsDir, "evil");
+    mkdirSync(evil, { recursive: true });
+    const escapeTarget = join(h.tmp, "escape-target-3");
+    mkdirSync(escapeTarget, { recursive: true });
+    symlinkSync(escapeTarget, join(evil, ".claude"));
+
+    // Legitimate agent — a normal scaffolded dir.
+    mkdirSync(join(h.agentsDir, "good"), { recursive: true });
+
+    const broker = new AuthBroker(
+      makeConfig(h, { evil: {}, good: {} }),
+      {
+        home: h.home,
+        stateDir: h.stateDir,
+        socketRoot: h.socketRoot,
+        disableRefreshLoop: true,
+      },
+    );
+    await broker.start();
+    broker.stop();
+
+    // Evil agent skipped, no escape write.
+    expect(existsSync(join(escapeTarget, ".credentials.json"))).toBe(false);
+    // Good agent still got a correct mirror.
+    const good = JSON.parse(
+      readFileSync(
+        join(h.agentsDir, "good", ".claude", ".credentials.json"),
+        "utf-8",
+      ),
+    );
+    expect(good.claudeAiOauth.accessToken).toBe("at-default");
+  });
+
+  it("REGRESSION: a legitimate non-symlink path still mirrors correctly", async () => {
+    const h = makeHarness();
+    writeSourceCreds(h, "default");
+    mkdirSync(join(h.agentsDir, "ziggy"), { recursive: true });
+
+    const broker = new AuthBroker(makeConfig(h, { ziggy: {} }), {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    broker.stop();
+
+    const mirrorPath = join(
+      h.agentsDir,
+      "ziggy",
+      ".claude",
+      ".credentials.json",
+    );
+    expect(existsSync(mirrorPath)).toBe(true);
+    // Real file, not a symlink, and lands at the expected path.
+    expect(realpathSync(mirrorPath)).toBe(mirrorPath);
+    const mirror = JSON.parse(readFileSync(mirrorPath, "utf-8"));
+    expect(mirror.claudeAiOauth.accessToken).toBe("at-default");
+    expect(mirror.claudeAiOauth.refreshToken).toBe("rt-default");
+    // No spurious refusal audited on the happy path.
+    expect(readAudit(h)).not.toContain("mirror-symlink-refused");
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -24,6 +24,7 @@ import {
   chmodSync,
   chownSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -1621,16 +1622,126 @@ export class AuthBroker {
     return this.mirrorAccountToAgent(effective, name);
   }
 
+  /**
+   * Symlink guard for the per-agent mirror write path (#1393, WS1).
+   *
+   * `~/.switchroom/agents/<name>/` is recursively chowned to the
+   * agent's per-agent UID (`scaffold.ts` `chown -R`) and RW
+   * bind-mounted into the agent container. A prompt-injected /
+   * compromised agent owns that tree and can pre-plant `.claude`
+   * (or `agentDir`, or the target file) as a **symlink**. The
+   * auth-broker runs as root with `CAP_DAC_OVERRIDE`; if it then
+   * does `mkdirSync({recursive})` / `openSync` / `chownSync` over
+   * that path it dereferences the attacker-controlled symlink and
+   * writes a root-owned file at an arbitrary host path — an
+   * agent→host trust-boundary crossing on every fanout
+   * (`switchroom update` boot, set-active, refresh-tick, …).
+   *
+   * `atomicWriteFileSync`'s tempfile+rename only defeats a swap of
+   * the *final* file, not a symlinked *parent dir* (both the
+   * recursive mkdir and the tempfile `openSync` resolve through a
+   * symlinked `claudeDir`). So we must `lstat` every controllable
+   * component — `agentsDir`, `agentDir`, `agentDir/.claude`, and
+   * the target file — and refuse if any existing component is a
+   * symlink (or not the expected type). Fail closed: skip *this*
+   * agent's mirror with a logged + audited reason; never crash the
+   * whole fanout (one poisoned agent must not deny-of-service the
+   * fleet's auth).
+   *
+   * Returns the validated paths on success, or `null` if the mirror
+   * must be skipped (reason already logged + audited).
+   */
+  private resolveMirrorPathsSafe(
+    agentName: string,
+  ): { agentDir: string; claudeDir: string; targetPath: string } | null {
+    const agentsDir = resolveAgentsDir(this.config);
+    const agentDir = resolve(agentsDir, agentName);
+    const claudeDir = join(agentDir, ".claude");
+    const targetPath = join(claudeDir, ".credentials.json");
+
+    const refuse = (component: string, reason: string): null => {
+      this.logErr(
+        `fanout ${agentName}: REFUSING mirror — ${component} ${reason} ` +
+          `(symlink-guard #1393; agent-owned tree may be attacker-poisoned)`,
+      );
+      this.audit({
+        op: "mirror-symlink-refused",
+        identity: { kind: "agent", name: agentName, admin: false },
+        ok: false,
+        error: `${component}:${reason}`,
+      });
+      return null;
+    };
+
+    // `agentsDir` is operator/root-owned and bind-mounted from the
+    // host root of the agents tree — must be a real directory, not a
+    // symlink the agent could have swapped (it can't write here, but
+    // guard the anchor anyway for defence-in-depth).
+    const agentsStat = this.lstatOrNull(agentsDir);
+    if (!agentsStat) return refuse("agentsDir", "does-not-exist");
+    if (agentsStat.isSymbolicLink())
+      return refuse("agentsDir", "is-a-symlink");
+    if (!agentsStat.isDirectory())
+      return refuse("agentsDir", "is-not-a-directory");
+
+    // `agentDir` (~/.switchroom/agents/<name>) — agent-UID-owned and
+    // agent-writable. If it doesn't exist there is nothing to mirror
+    // (mirror only lands for scaffolded agents); a symlink here means
+    // a poisoned tree.
+    const agentDirStat = this.lstatOrNull(agentDir);
+    if (!agentDirStat) return null; // not scaffolded yet — silently skip (matches prior !existsSync behaviour)
+    if (agentDirStat.isSymbolicLink())
+      return refuse("agentDir", "is-a-symlink");
+    if (!agentDirStat.isDirectory())
+      return refuse("agentDir", "is-not-a-directory");
+
+    // `.claude` — the primary attack target. `mkdirSync({recursive})`
+    // would dereference an existing symlink here; reject before any
+    // mkdir. If it doesn't exist yet that's fine (we create it).
+    const claudeStat = this.lstatOrNull(claudeDir);
+    if (claudeStat) {
+      if (claudeStat.isSymbolicLink())
+        return refuse(".claude", "is-a-symlink");
+      if (!claudeStat.isDirectory())
+        return refuse(".claude", "is-not-a-directory");
+    }
+
+    // The target file — `atomicWriteFileSync` renames over it, so a
+    // symlink here is largely defeated by the tempfile dance, but a
+    // dangling/regular-vs-symlink mismatch is still a clear poisoning
+    // signal. Reject a symlink; allow absent or a regular file.
+    const targetStat = this.lstatOrNull(targetPath);
+    if (targetStat) {
+      if (targetStat.isSymbolicLink())
+        return refuse(".credentials.json", "is-a-symlink");
+      if (!targetStat.isFile())
+        return refuse(".credentials.json", "is-not-a-regular-file");
+    }
+
+    return { agentDir, claudeDir, targetPath };
+  }
+
+  private lstatOrNull(path: string): ReturnType<typeof lstatSync> | null {
+    try {
+      return lstatSync(path);
+    } catch {
+      return null;
+    }
+  }
+
   private mirrorAccountToAgent(label: string, agentName: string): boolean {
     const credsPath = accountCredentialsPath(label, this.home);
     if (!existsSync(credsPath)) return false;
     // enrichMirrorContent: defense-in-depth on top of #1280's write-
     // time enrichment for stale legacy source files. See its docstring.
     const mirrorContent = enrichMirrorContent(readFileSync(credsPath, "utf-8"));
-    const agentsDir = resolveAgentsDir(this.config);
-    const agentDir = resolve(agentsDir, agentName);
-    if (!existsSync(agentDir)) return false;
-    const claudeDir = join(agentDir, ".claude");
+    // Symlink guard (#1393): validate every controllable path
+    // component is a real (non-symlink) dir/file BEFORE any
+    // mkdir/write/chown. Fail closed — skip this agent, don't crash
+    // the fanout.
+    const safe = this.resolveMirrorPathsSafe(agentName);
+    if (!safe) return false;
+    const { claudeDir, targetPath } = safe;
     mkdirSync(claudeDir, { recursive: true, mode: 0o700 });
     // Claude Code (2.x) reads OAuth credentials from `.credentials.json`
     // (dotfile, see the binary string table). The pre-RFC-H fanout used
@@ -1639,8 +1750,8 @@ export class AuthBroker {
     // .oauth-token — claude never actually read the on-disk mirror.
     // RFC H §7.4 deletes the env-injection path, so the on-disk mirror
     // must land at the dotfile path or agents silently lose auth on
-    // first restart. Pinned by tests in server.test.ts.
-    const targetPath = join(claudeDir, ".credentials.json");
+    // first restart. Pinned by tests in server.test.ts. `targetPath`
+    // is the symlink-guarded path from `resolveMirrorPathsSafe`.
     try {
       atomicWriteFileSync(targetPath, mirrorContent, 0o600);
       try {


### PR DESCRIPTION
## Summary

Remediation of **CRITICAL #1393** (epic #1389, WS1 fresh-reviewer gate #1391): agent→host root-write via a symlinked `.claude` dir in the auth-broker fanout.

**Closes #1393.** cc epic #1389.

## The bug (static-confirmed, not exploited)

`mirrorAccountToAgent` (`src/auth/broker/server.ts`) runs in the **auth-broker container as root (`user:"0:0"`) with `CAP_DAC_OVERRIDE`**. It did:

```
mkdirSync(claudeDir, {recursive:true, mode:0o700})  // follows a symlinked .claude
atomicWriteFileSync(targetPath, mirrorContent, 0o600)
chownSync(targetPath, uid, uid)
```

over `~/.switchroom/agents/<name>/.claude/.credentials.json` with **no `lstat`/`O_NOFOLLOW`/realpath guard anywhere**. That tree is recursively chowned to the per-agent UID (`scaffold.ts` `chown -R`) and **RW bind-mounted** into the agent container (`compose.ts`). A prompt-injected / compromised agent owns the tree and can **pre-plant `.claude` (or `agentDir`, or the target file) as a symlink**; the root broker dereferences it on the **next fanout** — boot (`fanoutAll`, i.e. **every `switchroom update`**), `set-active`, `add-account`, `mark-exhausted` failover, `set-override`, refresh-tick. Result: **root-owned file creation/overwrite at an arbitrary host path** (then re-owned to the agent UID), crossing the agent→host trust boundary. No race — the symlink is pre-planted in a persistent agent-owned dir. `atomicWriteFileSync`'s tempfile+rename only defeats a *final-file* swap, **not** the symlinked-**parent-dir** vector (both `mkdirSync({recursive})` and the tempfile `openSync` resolve through a symlinked `claudeDir`).

## The fix

New `resolveMirrorPathsSafe(agentName)` is called at the top of `mirrorAccountToAgent`, **before any mkdir/write/chown**. It `lstat`s every controllable path component — `agentsDir`, `agentDir`, `agentDir/.claude`, and the target `.credentials.json` — and **fails closed** (skips that agent's mirror, logs a clear reason + writes a structured audit row `op:"mirror-symlink-refused"`) if any *existing* component is a symlink or not the expected type (dir for dirs, regular file for the target). Absent `.claude`/target is fine (created/written normally). Non-symlink legitimate path is unaffected (regression-tested). **One poisoned agent is skipped, never crashing the whole fanout** — a single compromised agent must not DoS the fleet's auth.

Scoped strictly to this writer; `atomicWriteFileSync` (shared util) untouched. The realistic vector per the issue is a *pre-planted persistent* symlink, which lstat-before-use fully defeats; no shared-util refactor needed.

## CAP_DAC_OVERRIDE decision — **LEFT IN PLACE (deliberate, documented)**

I assessed dropping it (`compose.ts` auth-broker section). **It is not safely droppable.** With `cap_drop: ALL`, the container-root broker has **no implicit DAC bypass** — it must hold `DAC_OVERRIDE` explicitly to write into the agent-UID-owned `0o700` `.claude` dir (the broker's UID 0 is not the directory owner). This is the identical, already-documented rationale as vault-broker (`compose.ts:785-796`, verified against a v0.7.12 cutover). Dropping it would silently break the mirror write under Docker. **The cap was never the vuln — the missing symlink guard was, and that is now closed.** Per the task's "do not guess-drop a cap" guidance, it stays, with reasoning recorded in the commit + here.

## Test plan

New `src/auth/broker/server-mirror-symlink-guard.test.ts` (vitest, modeled on `server-mirror-enrich.test.ts`, drives the real boot fanout through a temp HOME):

- [x] pre-planted `.claude` symlink → REFUSED, no write at escape target, audited `.claude:is-a-symlink`
- [x] pre-planted symlinked `agentDir` → REFUSED, audited `agentDir:is-a-symlink`
- [x] symlinked `.credentials.json` target → REFUSED, escape file untouched
- [x] one poisoned agent does NOT block a legitimate agent's mirror (fail-closed, not fail-stop)
- [x] **regression:** legitimate non-symlink path still mirrors correctly, real file, no spurious audit

Results (local, build/unit only per shared-host constraint — no live broker/docker testing):

- `npm run build` — green
- `npm run lint` (`tsc --noEmit` + plugin/bot-api/bun-test-import checks) — green
- `npx vitest run src/auth/` — **198/198 pass across 15 files** (incl. existing `server.test.ts` structural pins, `server-mirror-enrich`, and the 5 new tests). No pre-existing failures observed in the auth suite. No bun-only auth-broker tests exist (nothing excluded from vitest for this area).

## Notes for reviewer

- Sibling anti-pattern flagged in #1393 (`scaffold.ts` `chown -R` over the agent tree; other broker write paths) is **out of scope here by design** — folded into WS3/WS6 per the issue. This PR is the scoped #1393 remediation only.
- TOCTOU: the guard defeats the pre-planted-symlink vector the issue describes (persistent, agent-owned dir). A pure same-process O_NOFOLLOW-on-final-open would additionally close a (much narrower, racing) TOCTOU window but requires touching the shared `atomicWriteFileSync` — explicitly kept out of scope to keep the change minimal to this writer, as instructed.
- `src/build-info.ts` build churn was reverted, not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)