### PR TITLE
fix(hostd): harden agent_exec argv — `--` separator + NUL/CR/LF rejection (#1401)

### DIFF
--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -736,8 +736,21 @@ export class HostdServer {
         Date.now() - started,
       );
     }
+    // #1401: reject NUL / newline / CR in any argv element (audit-log
+    // line injection + arg smuggling) before the call.
+    if (!req.args.argv.every(isSafeExecArgvElement)) {
+      return deniedResponse(
+        req.request_id,
+        `agent_exec: an argv element contains a NUL or newline/CR ` +
+          `control character, which is not permitted (#1401).`,
+        Date.now() - started,
+      );
+    }
     const container = `switchroom-${req.args.name}`;
-    const res = await this.runDocker(["exec", container, ...req.args.argv]);
+    // #1401: `--` terminates docker's own option parsing, so no
+    // user-supplied argv element can be reinterpreted as a `docker
+    // exec` flag (-e / -u / -w / --privileged / --entrypoint, …).
+    const res = await this.runDocker(["exec", container, "--", ...req.args.argv]);
     return {
       v: 1,
       request_id: req.request_id,
@@ -1089,6 +1102,18 @@ export const READONLY_EXEC_ALLOWLIST = [
 
 export function isAllowlistedReadOnlyArgv(argv0: string): boolean {
   return (READONLY_EXEC_ALLOWLIST as readonly string[]).includes(argv0);
+}
+
+/**
+ * #1401: every argv element must be free of NUL / LF / CR. Those have
+ * no legitimate place in a read-only inspection command (paths, flags
+ * like `-n`, and grep patterns are all unaffected) and exist only to
+ * smuggle behaviour: a newline/CR enables audit-log line injection and,
+ * before the `--` separator landed, docker-flag confusion. argv[0] is
+ * separately allowlist-gated by isAllowlistedReadOnlyArgv.
+ */
+export function isSafeExecArgvElement(s: string): boolean {
+  return !/[\u0000\n\r]/.test(s);
 }
 
 /** Probe whether an agent socket exists at the canonical in-container

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -841,9 +841,29 @@ describe("hostd server — Phase 2 fleet mutations + lock", () => {
       },
     );
     expect(resp.result).toBe("completed");
+    // #1401: `--` separates the fixed `docker exec <container>` prefix
+    // from caller-supplied argv so no element can be reparsed as a
+    // docker flag.
     expect(resp.stdout_tail).toContain(
-      "docker: exec switchroom-bob ls -la /state",
+      "docker: exec switchroom-bob -- ls -la /state",
     );
+  });
+
+  it("agent_exec: argv element with a newline/NUL/CR is denied (#1401)", async () => {
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "agent_exec",
+        request_id: "exec-ctrl-1",
+        // argv[0] is allowlisted; the smuggle is in a later element.
+        args: { name: "bob", argv: ["cat", "/state\n--privileged"] },
+      },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/NUL or newline\/CR/);
+    expect(resp.error).toMatch(/#1401/);
   });
 
   it("agent_exec: non-allowlisted argv[0] is denied with a clear pointer to the deferred scope", async () => {


### PR DESCRIPTION
Part of security epic #1389. Closes the concrete `agent_exec` argv defect from **#1401**.

## Problem

`handleAgentExec` (`src/host-control/server.ts`) allowlisted only `argv[0]`; the full caller-supplied `argv` was splatted into `docker exec <container> ...argv` with **no `--` separator** and **no per-element validation**. `runDocker` uses `spawn` (no shell), so this was in-container, not host RCE — but:
- without `--`, a crafted element could be reparsed by `docker exec`'s own option parser (`-e`/`-u`/`-w`/`--privileged`/`--entrypoint`);
- NUL/CR/LF in an element enabled audit-log line injection.

## Fix

- **`--` separator**: `["exec", container, "--", ...argv]` — terminates docker's option parsing so no caller element is read as a docker flag.
- **`isSafeExecArgvElement`** (exported): rejects NUL / LF / CR in *every* argv element (paths, `-n`, grep patterns are unaffected); `argv[0]` stays allowlist-gated. Applied to all elements before the docker call.
- Existing exec test updated to assert the `--`; new test pins the control-char denial.

## Scope (deliberate)

This PR is **only** #1401's argv defect — self-contained, no architecture change. Explicitly NOT in this PR:
- The **#1400 tiered approval gate** (hostd independently verifying a human approval via a new dedicated kernel host-verify socket + the agent-side consumer) — a cross-container security build, its own scoped PR.
- The `host_control.enabled` **opt-in default-flip** — must ship *with* its loud upgrade migration (silent capability loss on existing installs is a non-negotiable-to-avoid sleeper risk), so it's bundled into that PR, not here.

Per CPO decision: admin agents keep cross-agent/host privilege, gated by human approval (full posture tracked on #1389). This PR is the safe, immediately-shippable slice.

## Test plan

- [x] `npm run build` green
- [x] `npm run lint` green (tsc + plugin/bot-api/bun-test-import checks)
- [x] `npx vitest run tests/host-control/` — **95/95 pass** (5 files), incl. the updated `--` assertion and the new `agent_exec: argv element with a newline/NUL/CR is denied (#1401)` regression
- [x] Scoped diff: exactly `src/host-control/server.ts` + `tests/host-control/server.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)