### PR TITLE
fix(gateway): /auth is operator-private (sec WS7-F2b)

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -146,7 +146,13 @@ ALLOWLIST=(
   # (~85 lines added near line 8475 shifted the vault wizard callsites
   # further down past the prior 10100 ceiling).
   # Re-bumped 2026-05-15 for #1308 folder-picker handler integration.
-  "telegram-plugin/gateway/gateway.ts:9340-10300:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-17 for sec WS7-F2b (#1394): the /auth
+  # operator-private gate inserted ~32 lines above bot.command("auth"),
+  # shifting the vault-wizard callsites past the prior 10300 ceiling
+  # (the flagged callsite moved 10270 -> 10302). End extended with
+  # headroom; the inserted code uses switchroomReply (wrapped), so the
+  # slightly-wider span introduces no un-allowlisted raw call.
+  "telegram-plugin/gateway/gateway.ts:9340-10340:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9088,7 +9088,39 @@ async function runCreditWatch(): Promise<void> {
 }
 
 bot.command("auth", async ctx => {
-  if (!isAuthorizedSender(ctx)) return
+  // sec WS7-F2b (#1394): `/auth` drives the auth-broker credential
+  // lifecycle (`/auth add` mints/attaches an Anthropic account token,
+  // `/auth use` switches the active account, …). It is NOT in
+  // ADMIN_COMMAND_NAMES (deliberately gateway-handled even on
+  // non-admin agents so it works when the model is unreachable — that
+  // routing is unchanged), so the WS7-F2 operator-private middleware
+  // does not cover it, and its only sender gate was the
+  // group-permissive `isAuthorizedSender` (empty group `allowFrom` =
+  // allow every member). On an `admin:true` forum agent any
+  // forum/supergroup member could therefore run privileged `/auth`.
+  // Credential-plane admin is OPERATOR-PRIVATE, exactly like the
+  // ADMIN_COMMAND_NAMES verbs (WS7-F2 / #1408): honor `/auth` ONLY in
+  // a private chat from a strict `access.allowFrom` sender — never the
+  // group-permissive isAuthorizedSender. The agent-admin-flag /
+  // broker-side enforcement (isAuthAdmin below) is orthogonal and
+  // unchanged; operator auth-recovery is via DM (same as #1408).
+  const authSenderId = String(ctx.from?.id ?? '')
+  const authOperatorPrivate =
+    ctx.chat?.type === 'private' &&
+    loadAccess().allowFrom.includes(authSenderId)
+  if (!authOperatorPrivate) {
+    if (ctx.chat?.type !== 'private') {
+      process.stderr.write(
+        `telegram gateway: /auth refused (not operator-private) agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} chat=${ctx.chat?.type ?? '?'} sender=${authSenderId}\n`,
+      )
+      await switchroomReply(
+        ctx,
+        `⚠️ <code>/auth</code> manages account credentials — it is <b>operator-private</b>. Send it as a direct message to me from your operator account (a private chat where your Telegram ID is on the access allowlist), not in a group or forum.`,
+        { html: true },
+      ).catch(() => {})
+    }
+    return
+  }
   const text = ctx.message?.text ?? ""
   const parsed = parseAuthCommand(text)
   if (!parsed) return


### PR DESCRIPTION
## Summary

Remediates **WS7-F2b (HIGH, #1394)** — discovered by the WS7-F2 (#1408) fresh reviewer.

`/auth` drives the auth-broker credential lifecycle (`/auth add` mints/attaches an Anthropic account token, `/auth use` switches the active account). It is deliberately **not** in `ADMIN_COMMAND_NAMES` (stays gateway-handled even on non-admin agents / when the model is unreachable — that routing is unchanged), so the WS7-F2 operator-private middleware (#1408) does not cover it; its only sender gate was the group-permissive `isAuthorizedSender` (empty group `allowFrom` ⇒ allow every member). On an `admin:true` forum agent (the default `agent add --topology forum` shape) **any forum/supergroup member could run privileged `/auth`** — same vuln class as WS7-F2, distinct command path, credential-plane.

**Fix:** require **operator-private** (private chat from a strict `access.allowFrom` sender — never the group-permissive `isAuthorizedSender`) at the top of `bot.command("auth")`, mirroring the merged WS7-F2 posture. Group/forum attempt → actionable "DM me" refusal; non-allowFrom private sender → silent drop (matches the codebase's existing unknown-DM-sender philosophy). Agent-admin-flag / broker-side enforcement (`isAuthAdmin`) and routing are untouched → the deliberate "`/auth` works on non-admin agents / when model unreachable for recovery" properties are preserved (operator recovery is via DM, same model as #1408).

Second commit: a required CI-maintenance bump — the +32-line insertion shifted a legitimately-allowlisted vault-wizard `editMessageText` callsite (`10270→10302`) past the `check-bot-api-wrapping` allowlist ceiling; range extended (the script's own documented pattern for code shifts) so this PR's own `lint` gate passes.

## Verification

Fresh separate-process security review of the gate: **APPROVE** — predicate byte-identical to merged #1408; placed before any broker/credential side effect; no routing/recovery regression; no sibling gap (`handleAuthDashboardCallback` callbacks already broker-enforced; `pendingAuthAddFlows` paste-continuation closed by `gate()` running first in `handleInbound`). `npm run lint` exit 0 (tsc + all 3 structural checks clean); 59/0 targeted plugin tests.

Audit/remediation separate per epic #1389 §6.

Refs #1394, #1389

🤖 Generated with [Claude Code](https://claude.com/claude-code)