### PR TITLE
feat: PR A of update-flow redesign — schema + install-detect (1/3)

### DIFF
--- a/src/cli/install-detect.test.ts
+++ b/src/cli/install-detect.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for `detectInstallType`.
+ *
+ * `node:fs` is mocked via vi.mock so each test can simulate the
+ * presence / absence / symlink-state of `/usr/local/bin/switchroom`
+ * and the source build artifact independently of the host.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+
+vi.mock("node:fs", async () => {
+  return {
+    existsSync: vi.fn(),
+    lstatSync: vi.fn(),
+    readlinkSync: vi.fn(),
+  };
+});
+
+import { detectInstallType } from "./install-detect.js";
+
+const BIN = "/usr/local/bin/switchroom";
+const REPO = path.join(os.homedir(), "code", "switchroom", "dist", "cli", "switchroom.js");
+const DIST_PREFIX = path.join(os.homedir(), "code", "switchroom", "dist") + path.sep;
+
+function fakeStat(isSymlink: boolean): fs.Stats {
+  return { isSymbolicLink: () => isSymlink } as unknown as fs.Stats;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("detectInstallType", () => {
+  it("returns 'binary' when /usr/local/bin/switchroom is a regular file", () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === BIN);
+    vi.mocked(fs.lstatSync).mockReturnValue(fakeStat(false));
+    const ctx = detectInstallType();
+    expect(ctx.install_type).toBe("binary");
+    expect(ctx.source_paths.bin).toBe(BIN);
+  });
+
+  it("returns 'binary' when the symlink points outside the source dist tree", () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === BIN);
+    vi.mocked(fs.lstatSync).mockReturnValue(fakeStat(true));
+    vi.mocked(fs.readlinkSync).mockReturnValue(
+      "/usr/local/lib/node_modules/@switchroom/cli/dist/cli/switchroom.js" as unknown as string,
+    );
+    const ctx = detectInstallType();
+    expect(ctx.install_type).toBe("binary");
+  });
+
+  it("returns 'source' when the symlink target lives under $HOME/code/switchroom/dist/", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.lstatSync).mockReturnValue(fakeStat(true));
+    vi.mocked(fs.readlinkSync).mockReturnValue(
+      (DIST_PREFIX + "cli/switchroom.js") as unknown as string,
+    );
+    const ctx = detectInstallType();
+    expect(ctx.install_type).toBe("source");
+    expect(ctx.source_paths.bin).toBe(BIN);
+    expect(ctx.source_paths.repo).toBe(REPO);
+  });
+
+  it("returns 'source-unlinked' when the source artifact exists but the bin is missing", () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => p === REPO);
+    const ctx = detectInstallType();
+    expect(ctx.install_type).toBe("source-unlinked");
+    expect(ctx.source_paths.repo).toBe(REPO);
+    expect(ctx.source_paths.bin).toBeUndefined();
+  });
+
+  it("returns 'docker' when neither artifact is present", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    const ctx = detectInstallType();
+    expect(ctx.install_type).toBe("docker");
+    expect(ctx.source_paths).toEqual({});
+  });
+
+  it("returns 'unknown' when fs probing throws", () => {
+    vi.mocked(fs.existsSync).mockImplementation(() => {
+      throw new Error("EACCES");
+    });
+    const ctx = detectInstallType();
+    expect(ctx.install_type).toBe("unknown");
+    expect(ctx.source_paths).toEqual({});
+  });
+});

--- a/src/cli/install-detect.ts
+++ b/src/cli/install-detect.ts
@@ -1,0 +1,116 @@
+/**
+ * Install-type detector for the switchroom update flow.
+ *
+ * Categorises how the currently-running switchroom CLI is installed so
+ * downstream code (hostd audit, update flow, MCP introspection) can
+ * decide whether `switchroom apply` should attempt a self-update,
+ * delegate to `npm i -g`, or stay out of the way (docker / unknown).
+ *
+ * Pure function — performs only synchronous fs reads (existsSync /
+ * lstatSync / readlinkSync) and never throws. Any error during
+ * detection collapses to `"unknown"`.
+ *
+ * Probes:
+ *   - `/usr/local/bin/switchroom`               — the globally-linked CLI
+ *   - `$HOME/code/switchroom/dist/cli/switchroom.js` — source build artifact
+ *     (matches the `bin` entry in this repo's package.json)
+ *
+ * Categories (decided in this order):
+ *   - `binary`           — `/usr/local/bin/switchroom` exists AND is a
+ *                          regular file OR a symlink whose target is NOT
+ *                          under `$HOME/code/switchroom/` (e.g. npm-global
+ *                          install path).
+ *   - `source`           — `/usr/local/bin/switchroom` is a symlink AND
+ *                          its target lives under
+ *                          `$HOME/code/switchroom/dist/`.
+ *   - `source-unlinked`  — the source build artifact exists but
+ *                          `/usr/local/bin/switchroom` does not (developer
+ *                          forgot to `npm link`).
+ *   - `docker`           — neither artifact is present (running inside a
+ *                          container with the CLI shipped elsewhere).
+ *   - `unknown`          — any thrown error during probing.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+export type InstallType =
+  | "binary"
+  | "source"
+  | "source-unlinked"
+  | "docker"
+  | "unknown";
+
+export interface InstallContext {
+  install_type: InstallType;
+  source_paths: { bin?: string; repo?: string };
+}
+
+const BIN_PATH = "/usr/local/bin/switchroom";
+
+/**
+ * Path to the source build artifact, derived from the project's
+ * package.json `bin` entry (`./dist/cli/switchroom.js`). Anchored at
+ * `$HOME/code/switchroom/` to match the canonical source-checkout
+ * location.
+ */
+function sourceArtifactPath(): string {
+  return path.join(os.homedir(), "code", "switchroom", "dist", "cli", "switchroom.js");
+}
+
+/**
+ * Anchor for the source-build directory tree. Used to decide whether a
+ * symlink target counts as a "source" install.
+ */
+function sourceDistPrefix(): string {
+  return path.join(os.homedir(), "code", "switchroom", "dist") + path.sep;
+}
+
+export function detectInstallType(): InstallContext {
+  try {
+    const repoArtifact = sourceArtifactPath();
+    const distPrefix = sourceDistPrefix();
+
+    const binExists = fs.existsSync(BIN_PATH);
+    const repoExists = fs.existsSync(repoArtifact);
+
+    if (binExists) {
+      const lst = fs.lstatSync(BIN_PATH);
+      if (lst.isSymbolicLink()) {
+        const target = fs.readlinkSync(BIN_PATH);
+        const resolved = path.isAbsolute(target)
+          ? target
+          : path.resolve(path.dirname(BIN_PATH), target);
+        if (resolved.startsWith(distPrefix)) {
+          return {
+            install_type: "source",
+            source_paths: { bin: BIN_PATH, repo: repoExists ? repoArtifact : undefined },
+          };
+        }
+        // Symlink to somewhere other than the source dist tree (e.g.
+        // npm-global). Treat as a binary install.
+        return {
+          install_type: "binary",
+          source_paths: { bin: BIN_PATH },
+        };
+      }
+      // Regular file at /usr/local/bin/switchroom.
+      return {
+        install_type: "binary",
+        source_paths: { bin: BIN_PATH },
+      };
+    }
+
+    if (repoExists) {
+      return {
+        install_type: "source-unlinked",
+        source_paths: { repo: repoArtifact },
+      };
+    }
+
+    return { install_type: "docker", source_paths: {} };
+  } catch {
+    return { install_type: "unknown", source_paths: {} };
+  }
+}

--- a/src/config/merge.test.ts
+++ b/src/config/merge.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for `mergeAgentConfig` — focused on the `release` block cascade.
+ *
+ * The release block uses REPLACE semantics (no field-merge between
+ * defaults and agent) so a pinned agent does not silently inherit a
+ * channel from the fleet defaults, and vice versa.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mergeAgentConfig } from "./merge.js";
+import type { AgentConfig, AgentDefaults } from "./schema.js";
+
+function baseAgent(extra: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    topic_name: "Test",
+    ...extra,
+  } as AgentConfig;
+}
+
+describe("mergeAgentConfig — release cascade", () => {
+  it("inherits root release.channel when agent has none", () => {
+    const defaults = { release: { channel: "latest" } } as AgentDefaults;
+    const agent = baseAgent();
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.release).toEqual({ channel: "latest" });
+  });
+
+  it("REPLACES root entirely when agent provides a pin (no field merge)", () => {
+    const defaults = { release: { channel: "latest" } } as AgentDefaults;
+    const agent = baseAgent({
+      release: { pin: "sha-abc1234" },
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.release).toEqual({ pin: "sha-abc1234" });
+    expect(result.release?.channel).toBeUndefined();
+  });
+
+  it("uses agent release when defaults absent", () => {
+    const agent = baseAgent({
+      release: { channel: "dev" },
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig(undefined, agent);
+    expect(result.release).toEqual({ channel: "dev" });
+  });
+
+  it("leaves release undefined when neither layer sets it", () => {
+    const result = mergeAgentConfig({} as AgentDefaults, baseAgent());
+    expect(result.release).toBeUndefined();
+  });
+});

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -482,6 +482,17 @@ export function mergeAgentConfig(
     merged.session_continuity = combined as AgentConfig["session_continuity"];
   }
 
+  // --- release: REPLACE, not field-merge ---
+  //
+  // A per-agent `release` block fully replaces the defaults `release`.
+  // We intentionally do NOT shallow-merge `channel` + `pin` from the
+  // two layers — a pinned agent must not silently inherit a channel
+  // from the fleet defaults (or vice versa). If the agent declared
+  // anything, take it whole; otherwise inherit defaults whole.
+  if (merged.release === undefined && defaults.release !== undefined) {
+    merged.release = defaults.release;
+  }
+
   // --- channels: per-channel shallow merge, agent wins ---
   //
   // Today only telegram exists; the structure generalizes for future

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -629,3 +629,54 @@ describe("AgentGoogleWorkspaceConfigSchema (RFC G per-agent override)", () => {
     expect(result.google_workspace?.tier).toBe("extended");
   });
 });
+
+describe("ReleaseBlock (release-channel pin / pointer)", () => {
+  it("accepts a bare channel", () => {
+    const result = AgentSchema.parse(baseAgentInput({ release: { channel: "dev" } }));
+    expect(result.release).toEqual({ channel: "dev" });
+  });
+
+  it("accepts a sha pin", () => {
+    const result = AgentSchema.parse(
+      baseAgentInput({ release: { pin: "sha-abc1234" } }),
+    );
+    expect(result.release).toEqual({ pin: "sha-abc1234" });
+  });
+
+  it("accepts a semver pin", () => {
+    const result = AgentSchema.parse(
+      baseAgentInput({ release: { pin: "v1.2.3" } }),
+    );
+    expect(result.release).toEqual({ pin: "v1.2.3" });
+  });
+
+  it("rejects channel + pin together (mutually exclusive)", () => {
+    expect(() =>
+      AgentSchema.parse(
+        baseAgentInput({ release: { channel: "dev", pin: "sha-abc1234" } }),
+      ),
+    ).toThrow(/mutually exclusive/);
+  });
+
+  it("rejects a malformed pin (non-hex)", () => {
+    expect(() =>
+      AgentSchema.parse(baseAgentInput({ release: { pin: "sha-zzz" } })),
+    ).toThrow();
+  });
+
+  it("rejects an unknown channel value", () => {
+    expect(() =>
+      AgentSchema.parse(baseAgentInput({ release: { channel: "stable" } })),
+    ).toThrow();
+  });
+
+  it("attaches to the root SwitchroomConfigSchema as well", () => {
+    const result = SwitchroomConfigSchema.parse({
+      switchroom: { version: 1 },
+      telegram: { bot_token: "x", forum_chat_id: "1" },
+      release: { channel: "latest" },
+      agents: {},
+    });
+    expect(result.release).toEqual({ channel: "latest" });
+  });
+});

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -680,3 +680,19 @@ describe("ReleaseBlock (release-channel pin / pointer)", () => {
     expect(result.release).toEqual({ channel: "latest" });
   });
 });
+
+describe("TelegramChannelSchema.enabled (offline-dev master switch)", () => {
+  it("defaults to true when omitted", () => {
+    const result = AgentSchema.parse(
+      baseAgentInput({ channels: { telegram: {} } }),
+    );
+    expect(result.channels?.telegram?.enabled).toBe(true);
+  });
+
+  it("accepts an explicit false to disable the gateway sidecar", () => {
+    const result = AgentSchema.parse(
+      baseAgentInput({ channels: { telegram: { enabled: false } } }),
+    );
+    expect(result.channels?.telegram?.enabled).toBe(false);
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -906,9 +906,40 @@ export const ReactionsSchema = z
   })
   .optional();
 
+/**
+ * Release-channel pin / pointer for the update flow.
+ *
+ * Either `channel` (track a moving pointer — dev / rc / latest) OR
+ * `pin` (lock to a specific build identifier — `sha-<7-40 hex>` or
+ * `v<semver>`). The two are mutually exclusive: a pin overrides any
+ * channel implication and a channel implies "follow the pointer."
+ *
+ * Allowed at the root (fleet default) and per-agent (override).
+ * Per-agent `release` REPLACES the root entirely — it is NOT field-
+ * merged (a pinned agent should not silently inherit a channel from
+ * the root, and vice versa).
+ */
+export const ReleaseBlock = z
+  .object({
+    channel: z.enum(["dev", "rc", "latest"]).optional(),
+    pin: z
+      .string()
+      .regex(/^(sha-[0-9a-f]{7,40}|v\d+\.\d+\.\d+)$/)
+      .optional(),
+  })
+  .strict()
+  .refine((r) => !(r.channel && r.pin), {
+    message: "release.channel and release.pin are mutually exclusive",
+  });
+
 const profileFields = {
   extends: z.string().optional(),
   bot_token: z.string().optional(),
+  release: ReleaseBlock.optional().describe(
+    "Release-channel pin / pointer. Either `channel` (dev|rc|latest) or " +
+    "`pin` (sha-<hex>|v<semver>) — mutually exclusive. Per-agent value " +
+    "REPLACES the root entirely (no field merge).",
+  ),
   timezone: z
     .string()
     .regex(
@@ -1145,6 +1176,11 @@ export const AgentSchema = z.object({
     .string()
     .optional()
     .describe("Per-agent Telegram bot token or vault reference (overrides global telegram.bot_token)"),
+  release: ReleaseBlock.optional().describe(
+    "Per-agent release-channel pin / pointer. REPLACES the root " +
+    "`release` block entirely (no field merge) — a pinned agent does " +
+    "not inherit the fleet channel, and vice versa.",
+  ),
   bot_username: z
     .string()
     .optional()
@@ -1793,6 +1829,11 @@ export const SwitchroomConfigSchema = z.object({
       ),
   }),
   telegram: TelegramConfigSchema,
+  release: ReleaseBlock.optional().describe(
+    "Fleet-wide default release-channel pin / pointer for the update " +
+    "flow. Either `channel` (dev|rc|latest) or `pin` (sha-<hex>|v<semver>) " +
+    "— mutually exclusive. Per-agent `release` REPLACES this entirely.",
+  ),
   memory: MemoryBackendConfigSchema.optional(),
   vault: VaultConfigSchema.optional(),
   auth: z

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -420,6 +420,15 @@ export const SessionContinuitySchema = z
  */
 export const TelegramChannelSchema = z
   .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "Master switch for the per-agent Telegram gateway sidecar. " +
+        "When false, start.sh skips the gateway supervise loop and the " +
+        "agent boots without bot-token requirements (smoke-test + " +
+        "offline-dev use case).",
+      ),
     plugin: z
       .enum(["switchroom", "official"])
       .optional()


### PR DESCRIPTION
## Summary

This is **1 of 3 PRs** splitting the v10 update-flow redesign into bounded, reviewable chunks.

- **PR A (this PR):** schema + helper only, no wiring. Unit-testable in isolation.
- **PR B (queued):** CLI plumb (apply.ts writing the cached install-context file) + hostd audit + MCP wiring. Depends on A.
- **PR C (queued):** gateway boot-card + smoke-test harness + CI workflows. Depends on B.

Designed via 10 plan↔review iterations on 2026-05-17. PR #1388 fixed tonight's actual outage (`oneOf` in agent-config); this PR begins the broader redesign for observability and channel-pinning.

## What's in PR A

Three commits, each focused on a single piece:

1. **`release` block on config schema** (root + per-agent). Either `channel` (dev|rc|latest) or `pin` (sha-<hex>|v<semver>) — mutually exclusive via `strict().refine()`. Per-agent value REPLACES the root entirely (no field merge) so a pinned agent never silently inherits a fleet channel. Merge wiring added to `mergeAgentConfig` alongside the existing session / channels blocks.

2. **`telegram.enabled` field** on `TelegramChannelSchema`. Master switch for the per-agent gateway sidecar (`default: true`). Enables the smoke-test / offline-dev boot path where start.sh will skip the supervise loop. The start.sh integration itself lands in PR B.

3. **`install-detect.ts` helper.** Pure sync function that probes `/usr/local/bin/switchroom` and the source build artifact under `\$HOME/code/switchroom/dist/cli/switchroom.js` (matches `package.json` `bin`) and returns one of `binary | source | source-unlinked | docker | unknown`. Wrapped in a single try/catch — never throws. No runtime imports added; consumers land in PR B and C.

## Tests

- `src/config/merge.test.ts` (new): 4 release-cascade cases including REPLACE semantics.
- `src/config/schema.test.ts`: 7 ReleaseBlock cases + 2 telegram.enabled cases.
- `src/cli/install-detect.test.ts` (new): 6 cases — binary (regular file), binary (off-tree symlink), source, source-unlinked, docker, unknown (thrown).

Full suite: **6401 passed / 48 skipped / 0 failed.**

## Test plan

- [ ] CI green
- [ ] Schema additions don't break any existing config-load tests
- [ ] No runtime imports of the new helper / fields land in this PR (verify with grep before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)