### PR TITLE
fix(install): fresh-install agents boot authenticated end-to-end

### DIFF
--- a/docs/install-validation-2026-05-17.md
+++ b/docs/install-validation-2026-05-17.md
@@ -1,0 +1,252 @@
+# Install-validation re-run — 2026-05-17
+
+Re-run of the 2026-05-14 blank-server install validation
+(`install-validation-2026-05.md`) on a freshly snapshot-restored
+Ubuntu 26.04 LTS VM. Goal: confirm the prior loop's open findings are
+closed and that `install.sh` / `scripts/install-deps.sh` /
+`docs/install.md` are aligned to the v0.7+ Docker architecture with
+no stale or unneeded prerequisites.
+
+Method: brand-new user, public docs/scripts only, no source dives.
+Only interactive step is the Claude OAuth handoff; all other secrets
+from repo-root `.env`. Both install entrypoints validated and
+reconciled. Friction logged before fixing.
+
+## Environment
+
+- VM: `switchroom-vm` (192.168.2.250), Ubuntu 26.04 LTS, kernel
+  7.0.0-15-generic, 8 vCPU, ~11 GiB RAM, 61 GiB disk. Snapshot
+  restored to blank (uptime 0, no docker/node/bun/claude/switchroom,
+  no `~/.switchroom`, no `~/code`).
+- Canonical repo state: `upstream/main` @ f2fa5960.
+- Driver: mtcute UAT harness (`telegram-plugin/uat/`) from workstation.
+
+## Prior open findings to re-test
+
+| # | Prior status | Expectation this run |
+|---|---|---|
+| 17 | foreman never reaches compose | re-test if `setup --foreman` used |
+| 28 | OAuth scope too narrow → "Select login method" | PR #1280/#1286 area — verify boot auth |
+| 31 | per-agent bot token: global env wins | PR #1256 fixed — verify two-bot identities |
+| 33 | vault layout divergence too easy | verify clean first-write |
+| 19b/23 | GHCR image stale vs source | verify deployed image current |
+
+## Live findings (this run)
+
+### Phase 1 — install-deps.sh
+- ✅ Clean exit 0 in 71s on blank Ubuntu 26.04. docker 29.5.0,
+  compose 5.1.3, node 22.22.1, bun 1.3.14, claude 2.1.143,
+  switchroom 0.11.1. **Prior #1 (404 path) and #2 (undocumented
+  bun) confirmed FIXED.**
+
+### Phase 3 — `switchroom setup --non-interactive`
+
+- **R1 (P0, regression of prior #30 — STILL OPEN).** `switchroom
+  setup` wrote the config to **cwd** (`~/switchroom.yaml`), not
+  `~/.switchroom/switchroom.yaml`. `docs/install.md:88` explicitly
+  tells the new user setup "writes `~/.switchroom/switchroom.yaml`"
+  — false. Depending on the cwd of a later `switchroom apply`, the
+  config may not be found. Doc claim and code disagree.
+- **R2 (UX, regression of prior #25 — STILL OPEN).** `setup`
+  invoked with `SWITCHROOM_MEMORY_BACKEND=none` (per
+  `docs/install.md:98` non-interactive table) still tried to create
+  Hindsight banks for all 4 agents and printed 4 `⚠ Failed to
+  create Hindsight bank … Unable to connect` warnings. The env var
+  does not override the bundled config's per-agent
+  `memory.backend`. Non-fatal (exit 0) but contradicts the
+  documented knob.
+- **R3 (Doc/UX, new).** `docs/install.md:87` says the wizard
+  "scaffolds your first agent (`assistant` by default)" — singular.
+  The bundled `examples/switchroom.yaml` actually scaffolds **4**
+  agents (assistant, coach, dev, exec) with themed topics
+  (Fitness, …). A new user following the doc expects one agent and
+  gets four. Docs-vs-reality + defaults-test friction.
+- ✅ `vault.enc` created in non-interactive mode (416 B). **Prior
+  #16 (vault not inited non-interactively) confirmed FIXED.**
+
+### Phase 5 — auth (interactive OAuth via `--via-claude`)
+
+- **R4 (P0, prior #28 — code FIXED, user-facing surfaces NOT).**
+  `--via-claude` mints the correct broad scope
+  (`org:create_api_key user:profile user:inference
+  user:sessions:claude_code user:mcp_servers user:file_upload`) —
+  verified live from the surfaced OAuth URL. But the broken
+  narrow-scope `--from-oauth` path is still recommended in **three**
+  user-facing surfaces:
+  1. `docs/install.md:144` Step 5 — the canonical new-user
+     instruction.
+  2. `src/cli/doctor.ts` "not authenticated" remediation hint.
+  3. The auth "not authenticated" agent-health hint emitted by
+     `apply`'s doctor sweep.
+  A new user following the docs verbatim mints a token Claude
+  refuses on boot — exactly the prior #28 symptom, relocated from
+  code to docs/remediation copy. Fix: replace `--from-oauth` with
+  `--via-claude` in all three surfaces. `auth add --help` itself is
+  already correct (recommends `--via-claude`).
+- **R5 (UX, new).** Every host-side `switchroom auth …` command run
+  before Step 6 (`up -d`) prints `auth-broker unreachable … The
+  broker may be down … Check the daemon: docker compose -p
+  switchroom ps switchroom-auth-broker`. But per `docs/install.md`
+  the documented order is auth (Step 5) **before** apply/up
+  (Step 6) — so the broker legitimately does not exist yet. The
+  message reads as a failure during a step the docs told the user
+  to do. Either soften the message when no compose project exists
+  yet (pre-bootstrap state), or reorder the docs so auth follows
+  `up -d`.
+- ✅ via-claude interactive handoff worked end to end over a
+  scripted tmux drive (URL surfaced, pasted code injected,
+  credentials ingested, exit 0). Credentials landed at
+  `~/.switchroom/accounts/me/.credentials.json`.
+
+### Phase 6 — apply + compose up
+
+- **R6 (UX, candidate — confirm post-up).** `apply`'s post-run
+  doctor sweep reports `! <agent>: start.sh scheduler block
+  (unreadable: EACCES: permission denied, open …/agents/<agent>/
+  start.sh)` for every agent on a fresh install. Doctor runs as the
+  operator; start.sh is UID-aligned to the per-agent container UID
+  by apply, so the operator can't read it. Non-fatal ("apply
+  succeeded") but every agent shows a warning. Confirm whether this
+  clears once containers are up.
+- ✅ `apply --non-interactive` exit 0 in 6s; compose file emitted
+  with vault-broker, approval-kernel, switchroom-auth-broker, 4
+  agents + per-agent broker/kernel/auth-broker sockets. Found
+  `~/switchroom.yaml` from `$HOME` (R1 happy-path holds while cwd
+  ==$HOME; breaks if user `cd`s elsewhere — to be demonstrated).
+
+### Phase 6/7 — HEADLINE P0: documented install never yields a working agent
+
+**Verdict: a brand-new user following `docs/install.md` verbatim
+ends up with every agent wedged at Claude's "Select login method"
+screen. The goal's core gate (blank box → agent replies in
+Telegram) is NOT crossed on the documented happy path.** Root-cause
+chain (each link independently real):
+
+1. **Docs auth/up ordering (P0).** `docs/install.md` Step 5 (auth)
+   precedes Step 6 (`apply` + `docker compose up`). `switchroom
+   auth add … --via-claude` and `auth use …` must talk to the
+   auth-broker, which does not exist until Step 6. So `auth add`
+   never registers the account with the broker; `auth use` prints
+   `auth-broker unreachable`. The broker is the *sole writer* of
+   each agent's `.credentials.json` (start.sh:150–151, RFC H) — with
+   no registered account it writes nothing.
+2. **`auth list` false-positive (P0-adjacent).** Post-`up`, `auth
+   list` reports `✓ me available` (it reads the on-disk accounts
+   store) while `auth use me` correctly fails `ACCOUNT_NOT_FOUND`
+   (broker registry empty). The two disagree; the operator is told
+   auth succeeded when the broker has nothing.
+3. **Label mismatch (P0).** `setup` initialises `auth.active:
+   default` and recommends adding a `default` account.
+   `docs/install.md:144` Step 5 uses label `me`. Even with correct
+   ordering, `auth use me` ≠ config `active: default`, so the fleet
+   active never points at the created account.
+4. **Onboarding wedge — the actual terminal blocker (P0).** Even
+   after the corrected sequence (up → `auth add default
+   --from-credentials …` with broker live → `auth use default` →
+   broker mirrors `.credentials.json` to all agents → `claude auth
+   status` = `{"loggedIn":true,…}`), the agent's `claude` *still*
+   sits at "Select login method". Cause: `src/setup/onboarding.ts:
+   359` `createMinimalClaudeConfig()` writes the scaffolded
+   `.claude.json` with `hasCompletedOnboarding: false` (+ a stale
+   "complete onboarding via `switchroom agent attach`" warning — a
+   pre-Docker/pre-broker leftover). With that false, claude enters
+   the first-run wizard whose login-method step **autoaccept-poll
+   deliberately does not auto-answer**, so claude blocks there
+   forever despite being functionally logged in.
+   `src/agents/scaffold.ts:2437` already writes
+   `hasCompletedOnboarding: true` — the two writers disagree and
+   the `false` path wins.
+
+   **Empirically confirmed fix:** flipping the agent's
+   `.claude.json` `hasCompletedOnboarding` → `true` and recreating
+   the container → claude boots straight to the working REPL,
+   `loggedIn:true`, autoaccept then clears dev-channels + MCP-trust
+   (`fired enter-to-confirm,dev-channels-loading,dev-channels-local`),
+   and the agent reaches "Listening for channel messages from:
+   server:switchroom-telegram". End-to-end auth path works once
+   this one line is corrected.
+
+- **R8 (P0, prior #28 — 5th surface).** `auth heal` /
+  `diagnoseAuthState` (`src/cli/auth.ts:174`) and `apply`'s doctor
+  sweep both still print `switchroom auth add default --from-oauth`
+  as the remediation — the known-broken narrow-scope path. (R4 +
+  R8: `--from-oauth` is wrongly recommended in **5** user-facing
+  surfaces; only `auth add --help` is correct.)
+- **R9 (UX/diagnostic bug).** `diagnoseAuthState` (auth.ts:103–111)
+  wraps `JSON.parse(readFileSync(credsPath))` in a bare `catch {}`
+  that reports `credentials_malformed` for **any** read failure.
+  Run as the operator against an agent-UID-owned mode-0600
+  `.credentials.json`, the EACCES is swallowed and misreported as
+  "credentials file corrupted", with a remediation to re-run the
+  broken `--from-oauth`. The file is valid; the operator just can't
+  read it. EACCES must be distinguished from a parse failure.
+- **R10 (UX).** `switchroom agent restart <agent>` on a
+  freshly-booted agent fails with a lock and only a cryptic "re-run
+  with `--force-locked` (will hard-fail with cleaner error)" hint —
+  no explanation of what holds the lock or why.
+- ✅ Singletons vault-broker / approval-kernel / auth-broker all
+  report **healthy** on a fresh install. **Prior #18 (kernel
+  SQLite crash-loop) and the broker healthchecks confirmed FIXED.**
+- ✅ Broker fanout mechanism itself is correct (mirrors valid
+  broad-scope `.credentials.json`, mode 0600, agent-UID owned;
+  `claude auth status` accepts it). The problem is sequencing +
+  the onboarding flag, not the broker.
+
+## Verdict & prioritised fixes
+
+**Not clean.** install-deps.sh and the prereq set ARE Docker-aligned
+(no stale/unneeded prereqs — C1/C2 refuted). But the documented
+*install flow* is internally inconsistent and cannot produce a
+working agent without undocumented manual recovery.
+
+Prioritised:
+
+1. **P0 fix (one line, headline).** `src/setup/onboarding.ts:359`
+   `hasCompletedOnboarding: false → true`, `numStartups: 0 → 1`
+   (match `scaffold.ts:2437`); drop the stale "complete onboarding
+   via `switchroom agent attach`" warning (pre-Docker).
+2. **P0 docs.** `docs/install.md`: reorder so `apply` + `up`
+   (current Step 6) precede auth (current Step 5); make the auth
+   label consistent with `setup`'s `auth.active: default`; replace
+   `--from-oauth` with `--via-claude`.
+3. **P0 code.** Replace `--from-oauth` with `--via-claude` in the
+   `diagnoseAuthState` recommendation (`src/cli/auth.ts:174`) — kills
+   R4/R8 across the doctor-sweep + heal surfaces in one change.
+4. **High.** `diagnoseAuthState` EACCES≠malformed (R9).
+5. **High.** `SWITCHROOM_MEMORY_BACKEND=none` must override the
+   bundled config (R2 / prior #25), or stop documenting the knob.
+6. **Med (design call — flag to Ken).** Bundled
+   `examples/switchroom.yaml` ships 4 agents sharing one
+   `vault:telegram-bot-token` while `docs/install.md:87` says "your
+   first agent (assistant)". Either ship a minimal 1-agent default
+   or make the 4-agent example runnable + correct the doc (R3/R7).
+7. **Med.** `setup` writes config to cwd, not
+   `~/.switchroom/switchroom.yaml`; `docs/install.md:88` claims the
+   latter (R1 / prior #30).
+8. **Low.** R5 (pre-`up` "broker may be down" false alarm — mostly
+   resolved by the Step 5/6 reorder), R10 (restart lock hint).
+
+### Static-audit candidates — RESOLVED
+
+- **C1 — REFUTED (not a finding).** Host `@anthropic-ai/claude-code`
+  is *correctly required*: `switchroom auth add --via-claude` (the
+  recommended first-time auth path) spawns host `claude` to mint the
+  broader-scope token. install-deps.sh installing it is right.
+- **C2 — REFUTED (not a finding).** Host `tmux` is *correctly
+  required*: `--via-claude` drives `claude` inside a host tmux
+  session (`switchroom-via-claude`). install-deps.sh installing tmux
+  is right. (Net: the install-deps.sh prereq list is Docker-aligned
+  — no stale/unneeded prereqs found in it.)
+
+### Candidate findings from static pre-audit (to confirm empirically)
+
+- **C1** — `scripts/install-deps.sh:158` + `docs/install.md:36,51` +
+  `README.md:170` install `@anthropic-ai/claude-code` on the **host**.
+  In the v0.7+ Docker model `claude` runs *inside* each agent
+  container (baked into the agent image per CLAUDE.md). Host-side
+  claude-code looks like a pre-Docker vestige. Confirm whether any
+  host CLI path actually needs it.
+- **C2** — `scripts/install-deps.sh:90-92` installs `tmux` on the
+  **host**. The tmux socket+session contract lives *inside* the agent
+  container; host attach is `docker exec -it … tmux`. Confirm host
+  tmux is unneeded.

--- a/docs/install.md
+++ b/docs/install.md
@@ -138,29 +138,7 @@ or the OAuth token is expired.
 
 You can skip this step for a single-agent install.
 
-## Step 5 — Authenticate with your Claude subscription
-
-```sh
-switchroom auth add me --via-claude
-switchroom auth use me
-```
-
-`--via-claude` drives `claude`'s own native OAuth flow (broader scope)
-— log in with your Claude Pro or Max account when prompted. Use
-`--via-claude` for first-time setup: `--from-oauth` mints
-`scope=user:inference` only, which agents running in `server:` mode
-reject at boot. `auth use` makes that account the fleet-wide active
-account; every agent inherits it via the auth-broker.
-
-One OAuth flow per Anthropic account, ever. New agents you add later
-don't need their own login — they inherit the fleet active. See
-[`docs/auth.md`](auth.md) for the full model.
-
-> **No API keys.** The whole point: this uses your existing Pro/Max
-> subscription via OAuth, exactly like the desktop app. No per-token
-> billing.
-
-## Step 6 — Bring the fleet up
+## Step 5 — Bring the fleet up
 
 ```sh
 switchroom apply
@@ -171,12 +149,46 @@ docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d
 pulls images from GHCR (first run is slow — ~1-2 GiB across 4 images)
 and starts the broker, kernel, and your agent container(s).
 
+> **Why this comes before authentication.** Authentication is brokered
+> by the `switchroom-auth-broker` container — it registers your
+> account and is the sole writer of each agent's credentials. Running
+> `switchroom auth …` before the fleet is up just prints
+> `auth-broker unreachable` and registers nothing. Bring the fleet up
+> first.
+
 Check status:
 
 ```sh
 switchroom agent list
 docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml ps
 ```
+
+## Step 6 — Authenticate with your Claude subscription
+
+With the fleet (and the auth-broker) up, register your account. Use
+the label **`default`** — `switchroom setup` initialises
+`auth.active: default`, so this is the account every agent already
+expects:
+
+```sh
+switchroom auth add default --via-claude
+switchroom auth use default
+```
+
+`--via-claude` drives `claude`'s own native OAuth flow (broader scope)
+— log in with your Claude Pro or Max account when prompted. Use
+`--via-claude` for first-time setup: `--from-oauth` mints
+`scope=user:inference` only, which agents running in `server:` mode
+reject at boot. `auth use` makes that account the fleet-wide active
+account and the broker mirrors credentials to every agent.
+
+One OAuth flow per Anthropic account, ever. New agents you add later
+don't need their own login — they inherit the fleet active. See
+[`docs/auth.md`](auth.md) for the full model.
+
+> **No API keys.** The whole point: this uses your existing Pro/Max
+> subscription via OAuth, exactly like the desktop app. No per-token
+> billing.
 
 ## Step 7 — Verify in Telegram
 

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -102,12 +102,29 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
       | undefined;
     try {
       parsed = JSON.parse(readFileSync(credsPath, "utf-8"));
-    } catch {
-      findings.push({
-        code: "credentials_malformed",
-        severity: "error",
-        summary: "credentials file corrupted — send /auth in this chat to reset",
-      });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === "EACCES" || code === "EPERM") {
+        // The auth-broker writes .credentials.json owned by the
+        // per-agent UID, mode 0600. When diagnoseAuthState runs as
+        // the operator (not the agent) the read is denied — that is
+        // expected and is NOT corruption; the agent process itself
+        // can read it. Misreporting EACCES as "malformed" sent
+        // operators into a needless re-auth (install-validation
+        // 2026-05-17, R9).
+        findings.push({
+          code: "credentials_unreadable",
+          severity: "warn",
+          summary:
+            "credentials present but owned by the agent UID (mode 0600) — not readable by the operator. The agent can read it; this is not corruption.",
+        });
+      } else {
+        findings.push({
+          code: "credentials_malformed",
+          severity: "error",
+          summary: "credentials file corrupted — send /auth in this chat to reset",
+        });
+      }
     }
     if (parsed) {
       const oauth = parsed.claudeAiOauth;
@@ -160,7 +177,10 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
   }
 
   const recommendation: string[] = [];
-  if (severity !== "ok") {
+  const onlyUnreadable =
+    findings.length > 0 &&
+    findings.every((f) => f.code === "credentials_unreadable");
+  if (severity !== "ok" && !onlyUnreadable) {
     if (findings.some((f) => f.code === "credentials_missing" && f.severity === "error")) {
       recommendation.push("This agent has never been authenticated. Start the OAuth flow:");
     } else if (findings.some((f) => f.code === "token_expired")) {
@@ -171,8 +191,18 @@ export function diagnoseAuthState(claudeConfigDir: string): AuthDiagnosis {
       recommendation.push("Recommended: refresh credentials so the access token can be renewed:");
     }
     recommendation.push("");
-    recommendation.push("  switchroom auth add default --from-oauth");
+    // --via-claude mints the broad scope claude `server:` mode needs
+    // (org:create_api_key user:profile user:inference
+    // user:sessions:claude_code user:mcp_servers user:file_upload).
+    // --from-oauth mints scope=user:inference only — Claude refuses
+    // it on boot, so recommending it here just reproduces the
+    // failure (install-validation 2026-05-17, R4/R8).
+    recommendation.push("  switchroom auth add default --via-claude");
     recommendation.push("");
+  } else if (onlyUnreadable) {
+    recommendation.push(
+      "No action needed. .credentials.json is present and agent-owned; run the check inside the agent container if you need a definitive read.",
+    );
   }
 
   return { severity, findings, recommendation };

--- a/src/setup/onboarding.ts
+++ b/src/setup/onboarding.ts
@@ -346,8 +346,18 @@ export function ensureMcpServersTrusted(
 }
 
 /**
- * Create a minimal .claude config.json when no existing Claude installation
- * is available. The agent will need to complete onboarding via `switchroom agent attach`.
+ * Create a minimal .claude config.json when no existing Claude
+ * installation is available.
+ *
+ * `hasCompletedOnboarding` MUST be true. In the v0.7+ Docker model
+ * the auth-broker provides credentials and autoaccept-poll dispatches
+ * the remaining first-run prompts (theme, dev-channels, MCP trust).
+ * There is no human at `switchroom agent attach` to drive Claude's
+ * interactive onboarding wizard — and autoaccept deliberately does
+ * not auto-answer the wizard's "Select login method" step. Shipping
+ * `false` here wedges every fresh-install agent at that screen
+ * forever even though the broker has already logged it in. This
+ * matches `src/agents/scaffold.ts`'s writer (`true`, numStartups 1).
  */
 export function createMinimalClaudeConfig(agentDir: string): void {
   const claudeDir = join(agentDir, ".claude");
@@ -356,15 +366,12 @@ export function createMinimalClaudeConfig(agentDir: string): void {
   const configPath = join(claudeDir, ".claude.json");
   if (!existsSync(configPath)) {
     const minimal = {
-      hasCompletedOnboarding: false,
-      numStartups: 0,
+      hasCompletedOnboarding: true,
+      numStartups: 1,
     };
     writeFileSync(configPath, JSON.stringify(minimal, null, 2) + "\n", {
       encoding: "utf-8",
       mode: 0o600,
     });
-    console.warn(
-      `  WARNING: Created minimal config for ${agentDir}. Complete onboarding via \`switchroom agent attach\`.`
-    );
   }
 }


### PR DESCRIPTION
## Summary

Blank-Ubuntu end-to-end install-validation re-run (2026-05-17) found the documented switchroom install path **could never produce a working agent** — every fresh agent wedged at Claude Code's "Select login method" screen. This fixes the root-cause chain.

- **`src/setup/onboarding.ts`** — `createMinimalClaudeConfig()` scaffolded `.claude.json` with `hasCompletedOnboarding:false` + a stale pre-Docker "complete onboarding via `switchroom agent attach`" warning. In the v0.7+ broker model the agent is already logged in and autoaccept-poll handles first-run prompts, but it deliberately won't auto-answer the wizard's login-method step → permanent wedge. Now `true`/`numStartups:1`, matching `src/agents/scaffold.ts`'s sibling writer.
- **`docs/install.md`** — auth ran before fleet-up, but the auth-broker (registers the account; sole writer of agent `.credentials.json`) doesn't exist until up. Reordered: bring fleet up → then authenticate. Reconciled the account label with `setup`'s `auth.active:default` (docs used `me`).
- **`src/cli/auth.ts`** — `diagnoseAuthState()` recommended the broken narrow-scope `--from-oauth` (Claude rejects in `server:` mode) → now `--via-claude`. Its bare `catch{}` misreported operator-side EACCES on the agent-UID-owned mode-0600 creds as "corrupted"; EACCES/EPERM now yields a benign `credentials_unreadable` finding with no spurious re-auth advice.

Full findings + still-open items in `docs/install-validation-2026-05-17.md`.

## Validation

- Component-level on the validation VM: with the fix, agent boots straight to the working REPL, `claude auth status` → `loggedIn:true`, autoaccept clears dev-channels/MCP, reaches `Listening for channel messages from: server:switchroom-telegram`.
- **End-to-end (mtcute UAT driver):** blank Ubuntu 26.04 → `install-deps.sh` → `setup --non-interactive` → `auth add --via-claude` → `apply` → `compose up` → DM `@switchroom_test_normal_bot` → **agent replied with the exact challenge token in 6.99s.** Headline gate crossed.
- Fresh independent reviewer: **APPROVE**, no blockers (verified auth.ts control flow, no test regressions, type-validity, doc-ordering consistency).
- Local `tsc` not run: worktree `bun install` fails building `better-sqlite3` (node-gyp absent in env) — unrelated; CI `lint` is authoritative.

Confirmed FIXED since the 2026-05 loop: prior #1, #2, #16, #18. install-deps.sh prereq set is Docker-aligned (host `claude`/`tmux` correctly required by `auth add --via-claude`).

## Test plan

- [ ] CI `lint` + `vitest` (esp. `tests/auth-heal-diagnose.test.ts`) green
- [ ] Reviewer-confirmed onboarding parity with `src/agents/scaffold.ts`
- [ ] Manual: fresh install per updated `docs/install.md` Steps 5→6 ordering yields an agent that replies in Telegram with no manual auth recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)