### PR TITLE
fix(examples): one bot per agent — runnable single-agent default, others commented

### DIFF
--- a/docs/botfather-walkthrough.md
+++ b/docs/botfather-walkthrough.md
@@ -12,19 +12,27 @@ screenshots; everything below is exactly what you type or tap.
 
 ## What you'll create
 
-Switchroom uses **one Telegram bot per agent**. For a minimal install
-you create one bot; for an admin-bot setup you create two. There's no
-separate "admin bot" concept — an admin agent is just a regular agent
-whose gateway intercepts fleet-management slash commands (the
+Switchroom uses **one Telegram bot per agent — always**. This is not
+optional: if two agents resolve to the same bot token, both long-poll
+`getUpdates` and Telegram 409-Conflicts them in a loop so neither
+replies. One agent ⇒ one BotFather bot ⇒ one token ⇒ one vault key.
+
+For a minimal install you create one bot (the `assistant` agent the
+example ships). Every additional agent you enable — including a
+separate `admin: true` agent that exposes `/agents`, `/restart`,
+`/update`, `/logs`, etc. — needs **its own** bot. There's no separate
+"admin bot" concept; an admin agent is just a regular agent whose
+gateway intercepts fleet-management slash commands (the
 [three-tier model](architecture.md) — see docs/architecture.md).
 
 | Bot | Purpose | Where the token goes |
 |---|---|---|
-| **First agent bot** | The bot you actually chat with. Required. | `switchroom setup` (interactive) or vault |
-| **Admin agent bot** (optional) | A second bot for an agent with `admin: true` — exposes `/agents`, `/restart`, `/update`, `/logs`, etc. | vault, referenced from the agent's `bot_token` |
+| **First agent bot** (`assistant`) | The bot you actually chat with. Required. | `switchroom setup` → vault key `telegram-bot-token` |
+| **Each additional agent's bot** | One per agent you uncomment in `switchroom.yaml` (incl. an `admin: true` agent). | vault key `telegram-<agent>-bot-token`, referenced by that agent's `bot_token:` |
 
-You can create more bots later (one per additional agent). The
-process is identical.
+Creating more bots later is the same process — repeat Step 2 once per
+agent, and vault each token under its own `telegram-<agent>-bot-token`
+key.
 
 ## Step 1 — Open BotFather
 
@@ -91,28 +99,34 @@ privacy mode doesn't affect DMs.
 In your switchroom host's shell:
 
 ```sh
-# First agent — interactive setup prompts for the token directly:
+# First agent (`assistant`) — interactive setup prompts for the token
+# directly and vaults it under `telegram-bot-token`:
 switchroom setup
 
-# Admin agent (if you created a second bot) — add the token to the
-# vault and reference it from the agent block in switchroom.yaml:
-switchroom vault set telegram-admin-bot-token
-# (paste the admin bot token at the prompt)
+# Every ADDITIONAL agent — vault its bot's token under that agent's
+# own key, then uncomment its block in switchroom.yaml:
+switchroom vault set telegram-<agent>-bot-token
+# e.g. telegram-coach-bot-token, telegram-admin-bot-token
+# (paste that bot's token at the prompt)
 ```
 
-Then edit `~/.switchroom/switchroom.yaml`:
+Then edit `~/.switchroom/switchroom.yaml` — uncomment the agent's
+template block (each already carries its own `bot_token`). For an
+admin agent it looks like:
 
 ```yaml
 agents:
   admin:
     topic_name: "Admin"
-    bot_token: "vault:telegram-admin-bot-token"
+    bot_token: "vault:telegram-admin-bot-token"   # its own bot
     admin: true                   # gateway intercepts admin commands
     system_prompt_append: |
       You are the fleet admin agent.
 ```
 
-Run `switchroom apply` after editing.
+Run `switchroom apply` after editing — no need to re-run
+`switchroom setup` for additional agents; `apply` reads the vaulted
+per-agent token directly.
 
 If you don't know your Telegram user ID, message `@userinfobot` in
 Telegram — it replies with your numeric ID immediately. You'll need
@@ -123,9 +137,12 @@ it during `switchroom setup` for the `allowFrom` ACL.
 For each bot, open it in Telegram (search by username, or use the
 direct link BotFather sent: `t.me/<bot_username>`) and tap **Start**.
 
-The agent bot won't reply until setup, authentication
-(`switchroom auth add me --via-claude && switchroom auth use me`), and
-`docker compose ... up -d` are done.
+The agent bot won't reply until setup, the fleet is up, and
+authentication is done. Note the order: bring the fleet up
+(`switchroom apply && docker compose … up -d`) **before**
+`switchroom auth add default --via-claude && switchroom auth use
+default` — the auth-broker that registers the account only exists
+once the fleet is up. See [install.md](install.md) Steps 5–6.
 
 ## Optional: profile picture + description
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -53,13 +53,27 @@ sudo npm install -g bun @anthropic-ai/claude-code switchroom
 
 ## Step 2 — Create your bots in BotFather
 
-Switchroom uses one Telegram bot per agent. For a minimal install you
-need **one** bot — the agent you'll talk to. If you want a separate
-"admin" bot that exposes fleet-management slash commands (`/agents`,
-`/restart`, `/update apply`, etc.), create **two** bots and flag one
-agent with `admin: true` in your `switchroom.yaml`. There's no
-separate "admin bot" concept — admin agents are regular agents whose
-gateway intercepts admin slash commands before Claude sees them.
+Switchroom uses **one Telegram bot per agent — always, no
+exceptions**. Two agents sharing a bot token both long-poll
+`getUpdates` and Telegram 409-Conflicts them in a loop, so neither
+replies. The bundled `examples/switchroom.yaml` ships **one** active
+agent (`assistant`); every additional agent is a commented-out
+template that already carries its own `bot_token` — you mint a
+separate bot for each one you enable.
+
+For a minimal install you create **one** bot — the agent you'll talk
+to. For each extra agent you later enable (including a separate
+"admin" agent that exposes `/agents`, `/restart`, `/update apply`,
+etc. via `admin: true`), create **another** bot and store its token
+in the vault under its own key:
+
+```sh
+switchroom vault set telegram-<agent>-bot-token   # one per extra agent
+```
+
+There's no separate "admin bot" concept — admin agents are regular
+agents whose gateway intercepts admin slash commands before Claude
+sees them; they still need their own bot like any other agent.
 
 See [BotFather walkthrough](botfather-walkthrough.md) for the exact
 steps. Total time: ~3 minutes per bot. Keep the HTTP API tokens in a

--- a/examples/switchroom.yaml
+++ b/examples/switchroom.yaml
@@ -5,8 +5,22 @@
 #   2. profiles:  → named presets agents opt into via `extends:`
 #   3. agents:    → per-agent overrides (only express differences)
 #
-# Each agent gets its own Telegram topic in a forum group.
-# Create bots via @BotFather: /newbot for each agent.
+# ┌─ ONE TELEGRAM BOT PER AGENT — NON-NEGOTIABLE ───────────────────┐
+# │ Every agent MUST have its own Telegram bot + its own token.     │
+# │ Two agents sharing a token both long-poll getUpdates and        │
+# │ Telegram 409-Conflicts them in a loop — neither one replies.    │
+# │                                                                 │
+# │ For each agent: create a separate @BotFather bot (`/newbot`),   │
+# │ vault its token under its own key                               │
+# │ (`switchroom vault set telegram-<agent>-bot-token`), and give   │
+# │ the agent its own `bot_token: "vault:telegram-<agent>-bot-      │
+# │ token"`. This file ships ONE active agent (`assistant`); every  │
+# │ extra agent below is commented out WITH its own bot_token —     │
+# │ uncomment one only after you've minted its bot + vaulted its    │
+# │ token, then `switchroom apply` (no need to re-run setup).       │
+# └─────────────────────────────────────────────────────────────────┘
+#
+# See docs/botfather-walkthrough.md for the ~3-min-per-bot steps.
 
 switchroom:
   version: 1
@@ -14,6 +28,12 @@ switchroom:
   skills_dir: ~/.switchroom/skills           # shared skill pool (symlinked per agent)
 
 telegram:
+  # Single-agent fallback ONLY. This is the bot the one shipped agent
+  # (`assistant`) uses — `switchroom setup` stores your first
+  # BotFather token in the vault under `telegram-bot-token`. The
+  # moment you run more than one agent, this global token is NOT
+  # enough: give EACH agent its own `bot_token:` (see the agents
+  # section). Never let two agents resolve to the same token.
   bot_token: "vault:telegram-bot-token"
   # DM-only sentinel; v0.7+ defaults to per-agent DM-pair topology.
   # Legacy forum-mode installs keep a real chat id here.
@@ -155,52 +175,80 @@ profiles:
 
 # --- Agents ---
 # Minimal per-agent declarations. Everything else inherited.
+#
+# This file ships exactly ONE active agent so a fresh `switchroom
+# setup` → `apply` → `up` brings up a single, working bot (the
+# `assistant` below uses the single global telegram.bot_token that
+# setup vaulted). Every other agent is a commented-out TEMPLATE.
+#
+# To add any agent: (1) @BotFather `/newbot` → a NEW bot just for it;
+# (2) `switchroom vault set telegram-<agent>-bot-token` (paste that
+# bot's token); (3) uncomment its block below — note each already
+# carries its own `bot_token: "vault:telegram-<agent>-bot-token"`;
+# (4) `switchroom apply`. Do NOT re-run `switchroom setup` for this —
+# `apply` reads the vaulted per-agent token directly.
+#
+# Sharing one token across agents is the single most common
+# multi-agent install failure: both bots long-poll getUpdates and
+# Telegram 409-Conflicts them forever. One bot per agent, always.
 agents:
-  coach:
-    topic_name: "Fitness"
-    topic_emoji: "🏋️"
-    extends: advisor                    # inherits from inline profile above
-    soul:
-      name: Coach
-      style: motivational, direct       # overrides advisor.soul.style
-    memory:
-      collection: fitness
-    schedule:
-      - cron: "0 8 * * *"
-        prompt: "Good morning check-in: ask about sleep, energy, and plans for today"
-      - cron: "0 20 * * 0"
-        prompt: "Weekly review: summarize this week's activity and progress"
-
-  dev:
-    topic_name: "Code"
-    topic_emoji: "💻"
-    extends: coder                      # inherits from inline profile above
-    model: claude-opus-4-7              # override defaults.model for this agent
-    memory:
-      collection: coding
-    cli_args: ["--effort", "high"]      # escape hatch: extra exec claude flags
-
   assistant:
     topic_name: "General"
     topic_emoji: "💬"
     memory:
       collection: general
+    # Uses the global telegram.bot_token above (the one `switchroom
+    # setup` vaulted as `telegram-bot-token`). This is the ONLY agent
+    # allowed to rely on the global token — because it's the only one
+    # shipped active. Give every agent you add its own bot_token.
     # No `extends:` → uses the "default" filesystem profile (profiles/default/)
     # No tool/model overrides → inherits everything from defaults:
 
-  exec:
-    topic_name: "Executive"
-    topic_emoji: "📋"
-    extends: advisor
-    soul:
-      name: Friday
-      style: efficient, proactive, anticipates needs
-    skills: [daily-briefing, meeting-prep]
-    memory:
-      collection: executive
-    schedule:
-      - cron: "0 7 * * 1-5"
-        prompt: "Daily briefing: summarize today's calendar, pending tasks, and priorities"
+  # ── Additional agents — each needs its OWN BotFather bot ──────────
+  # Before uncommenting any block: create its bot, then
+  #   switchroom vault set telegram-coach-bot-token   # (etc.)
+  # The `bot_token:` line in each block points at that per-agent key.
+
+  # coach:
+  #   topic_name: "Fitness"
+  #   topic_emoji: "🏋️"
+  #   bot_token: "vault:telegram-coach-bot-token"   # its own bot
+  #   extends: advisor                    # inherits from inline profile above
+  #   soul:
+  #     name: Coach
+  #     style: motivational, direct       # overrides advisor.soul.style
+  #   memory:
+  #     collection: fitness
+  #   schedule:
+  #     - cron: "0 8 * * *"
+  #       prompt: "Good morning check-in: ask about sleep, energy, and plans for today"
+  #     - cron: "0 20 * * 0"
+  #       prompt: "Weekly review: summarize this week's activity and progress"
+
+  # dev:
+  #   topic_name: "Code"
+  #   topic_emoji: "💻"
+  #   bot_token: "vault:telegram-dev-bot-token"     # its own bot
+  #   extends: coder                      # inherits from inline profile above
+  #   model: claude-opus-4-7              # override defaults.model for this agent
+  #   memory:
+  #     collection: coding
+  #   cli_args: ["--effort", "high"]      # escape hatch: extra exec claude flags
+
+  # exec:
+  #   topic_name: "Executive"
+  #   topic_emoji: "📋"
+  #   bot_token: "vault:telegram-exec-bot-token"    # its own bot
+  #   extends: advisor
+  #   soul:
+  #     name: Friday
+  #     style: efficient, proactive, anticipates needs
+  #   skills: [daily-briefing, meeting-prep]
+  #   memory:
+  #     collection: executive
+  #   schedule:
+  #     - cron: "0 7 * * 1-5"
+  #       prompt: "Daily briefing: summarize today's calendar, pending tasks, and priorities"
 
   # Example admin agent — its gateway intercepts fleet-management slash
   # commands (/agents, /restart, /update, /logs, etc.) and runs them
@@ -209,12 +257,13 @@ agents:
   # on every agent regardless of admin status. See the three-tier
   # command model in docs/architecture.md.
   #
-  # Uncomment after creating a second BotFather bot and adding its
-  # token to the vault (`switchroom vault set telegram-admin-bot-token`).
+  # Like every agent it needs its OWN bot — create a separate BotFather
+  # bot and `switchroom vault set telegram-admin-bot-token` before
+  # uncommenting.
   # admin:
   #   topic_name: "Admin"
   #   topic_emoji: "🛠️"
-  #   bot_token: "vault:telegram-admin-bot-token"
+  #   bot_token: "vault:telegram-admin-bot-token"   # its own bot
   #   admin: true
   #   system_prompt_append: |
   #     You are the fleet admin agent. Always respond concisely.


### PR DESCRIPTION
## Summary

The bundled `examples/switchroom.yaml` scaffolded **4 agents sharing one `telegram.bot_token`** → bringing the fleet up made 4 bots long-poll `getUpdates` on one token → Telegram 409-Conflict loop, no replies (install-validation 2026-05-17, R3/R7). `docs/install.md` also said setup "scaffolds your first agent (assistant)" — singular — which the 4-agent example contradicted.

Per product decision — **one bot per agent, always**:

- `examples/switchroom.yaml`: ships exactly **one active agent** (`assistant`, on the global token `switchroom setup` vaults). `coach`/`dev`/`exec`/`admin` are commented-out templates, each carrying its **own** `bot_token: "vault:telegram-<agent>-bot-token"` + an explicit enable recipe (mint a separate BotFather bot → `switchroom vault set telegram-<agent>-bot-token` → uncomment → `switchroom apply`, no setup re-run). Boxed non-negotiable note + 409 rationale lead the file.
- `docs/install.md` Step 2 + `docs/botfather-walkthrough.md`: state the rule plainly, the per-agent vault-key pattern, and that the example ships one active agent. Walkthrough's auth example aligned to fleet-up-before-auth + `default` label (matches #1422).

**Why safe:** the single active agent keeps a fresh `switchroom setup` → `apply` → `up` runnable (unchanged single-global-token path). Per-agent vault refs appear only on commented templates the user wires via `switchroom vault set` + `apply` (runtime-resolved; already works). YAML validated (`yaml.safe_load` → only `assistant` active, global `telegram.bot_token` preserved).

Closes R3/R7; makes the "scaffolds your first agent (assistant)" doc claim true.

Note (separate follow-up, not fixed here): `src/cli/setup.ts`'s per-agent token path (lines ~292-319) validates per-agent tokens but does not `storeTokenInVault`, so hand-written per-agent `vault:` refs aren't seeded by a non-interactive `setup` re-run. This change deliberately routes additional agents through `switchroom vault set` + `apply` to avoid that path entirely.

## Test plan

- [ ] CI `lint` green (docs/yaml only — no code paths touched)
- [ ] Fresh `switchroom setup --non-interactive` + `apply` + `up` brings up exactly one working `assistant` bot (no 409)
- [ ] Uncommenting `coach` after `vault set telegram-coach-bot-token` + `apply` brings up a second non-conflicting bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)