### PR TITLE
fix(scaffold): honor SWITCHROOM_MEMORY_BACKEND=none (R2/#25)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1922,8 +1922,16 @@ export function scaffoldAgent(
   const hadExplicitAllow = rawAllow.length > 0;
   const readOnlyDefaults =
     !dangerousMode && !hadExplicitAllow ? DEFAULT_READ_ONLY_PREAPPROVED_TOOLS : [];
+  // SWITCHROOM_MEMORY_BACKEND=none force-disables hindsight even when the
+  // (bundled) config hardcodes `memory.backend: hindsight`. This mirrors
+  // the precedence in src/cli/setup.ts:stepMemoryBackend — the two sites
+  // MUST agree, or scaffold tries to create banks for an install the
+  // operator explicitly opted out of (install-validation 2026-05-17, R2 /
+  // prior #25: 4 spurious "Failed to create Hindsight bank" warnings on a
+  // `SWITCHROOM_MEMORY_BACKEND=none` setup).
+  const envBackend = process.env.SWITCHROOM_MEMORY_BACKEND;
   const memoryBackend = switchroomConfig?.memory?.backend;
-  const hindsightEnabled = memoryBackend === "hindsight";
+  const hindsightEnabled = envBackend !== "none" && memoryBackend === "hindsight";
   const permissionAllow = dedupe([
     ...baseAllow,
     ...readOnlyDefaults,

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -115,7 +115,7 @@ import {
 import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
 import { applyTelegramProgressGuidance, applyCronTelegramGuidance } from "./sub-agent-telegram-prompt.js";
 import type { McpServerConfig } from "../memory/hindsight.js";
-import { createBank, updateBankMissions, ensureUserProfileMentalModel, DEFAULT_RETAIN_MISSION } from "../memory/hindsight.js";
+import { createBank, updateBankMissions, ensureUserProfileMentalModel, DEFAULT_RETAIN_MISSION, isHindsightEnabled } from "../memory/hindsight.js";
 import { loadTopicState } from "../telegram/state.js";
 import { resolveDualPath } from "../config/paths.js";
 import { resolvePath } from "../config/loader.js";
@@ -1922,16 +1922,9 @@ export function scaffoldAgent(
   const hadExplicitAllow = rawAllow.length > 0;
   const readOnlyDefaults =
     !dangerousMode && !hadExplicitAllow ? DEFAULT_READ_ONLY_PREAPPROVED_TOOLS : [];
-  // SWITCHROOM_MEMORY_BACKEND=none force-disables hindsight even when the
-  // (bundled) config hardcodes `memory.backend: hindsight`. This mirrors
-  // the precedence in src/cli/setup.ts:stepMemoryBackend — the two sites
-  // MUST agree, or scaffold tries to create banks for an install the
-  // operator explicitly opted out of (install-validation 2026-05-17, R2 /
-  // prior #25: 4 spurious "Failed to create Hindsight bank" warnings on a
-  // `SWITCHROOM_MEMORY_BACKEND=none` setup).
-  const envBackend = process.env.SWITCHROOM_MEMORY_BACKEND;
-  const memoryBackend = switchroomConfig?.memory?.backend;
-  const hindsightEnabled = envBackend !== "none" && memoryBackend === "hindsight";
+  // Single source of truth — honors SWITCHROOM_MEMORY_BACKEND=none
+  // (install-validation 2026-05-17, R2 / prior #25).
+  const hindsightEnabled = isHindsightEnabled(switchroomConfig);
   const permissionAllow = dedupe([
     ...baseAllow,
     ...readOnlyDefaults,
@@ -2116,7 +2109,7 @@ export function scaffoldAgent(
       // get dueling instructions (write to local .md files vs use
       // Hindsight). The settings flag gates the memory system-prompt
       // block at the source.
-      const hindsightOn = switchroomConfig.memory?.backend === "hindsight"
+      const hindsightOn = isHindsightEnabled(switchroomConfig)
         && switchroomConfig.agents[name]?.memory?.auto_recall !== false;
       if (hindsightOn) {
         settings.autoMemoryEnabled = false;
@@ -3415,8 +3408,11 @@ export function reconcileAgent(
     !reconcileDangerousMode && !reconcileHadExplicitAllow
       ? DEFAULT_READ_ONLY_PREAPPROVED_TOOLS
       : [];
-  const memoryBackend = switchroomConfig.memory?.backend;
-  const hindsightEnabled = memoryBackend === "hindsight";
+  // Single source of truth — must honor SWITCHROOM_MEMORY_BACKEND=none
+  // here too: `switchroom agent restart` always reconciles first, so a
+  // config-only check would re-wire Hindsight on every restart of a
+  // `none` install (install-validation 2026-05-17, R2 review round 2).
+  const hindsightEnabled = isHindsightEnabled(switchroomConfig);
   // #235: drop legacy mcp__switchroom__* tokens from any pre-existing
   // allowlist on every reconcile so existing agents converge on the
   // same shape new ones get.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1437,7 +1437,16 @@ export function installHindsightPlugin(
 ): HindsightPluginInstall | null {
   if (!switchroomConfig) return null;
   const memory = switchroomConfig.memory;
-  if (memory?.backend !== "hindsight") return null;
+  // Same SWITCHROOM_MEMORY_BACKEND=none precedence as every other
+  // hindsight gate — this runs unconditionally on scaffold AND
+  // reconcile/restart, so a config-only check would re-copy the
+  // hindsight plugin tree (re-activating its memory hooks) on a
+  // `none` install (install-validation 2026-05-17, R2 review round 3).
+  if (!isHindsightEnabled(switchroomConfig)) return null;
+  // isHindsightEnabled true ⇒ memory.backend === "hindsight" ⇒ memory
+  // is defined. Explicit narrowing for the type-checker (the old
+  // `memory?.backend !== "hindsight"` gate used to provide it).
+  if (!memory) return null;
 
   const agentMemory = switchroomConfig.agents[agentName]?.memory;
   if (agentMemory?.auto_recall === false) return null;

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { getSchedulerState, formatSchedulerState } from "../agents/scheduler-state.js";
 import YAML from "yaml";
 import { resolveAgentsDir, loadConfig } from "../config/loader.js";
+import { isHindsightEnabled } from "../memory/hindsight.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import { scaffoldAgent, reconcileAgent, buildSettingsHooksBlock, detectHooksDrift } from "../agents/scaffold.js";
@@ -298,9 +299,9 @@ function buildStatusInputs(
 
   let hindsightApiUrl: string | null = null;
   let hindsightBankId = name;
-  if (config.memory?.backend === "hindsight") {
+  if (isHindsightEnabled(config)) {
     const baseUrl =
-      (config.memory.config?.url as string | undefined) ??
+      (config.memory?.config?.url as string | undefined) ??
       "http://localhost:8888/mcp/";
     hindsightApiUrl = baseUrl.endsWith("/mcp/")
       ? baseUrl
@@ -815,8 +816,8 @@ export function registerAgentCommand(program: Command): void {
         // the probe is skipped and the check reports "not configured".
         let hindsightApiUrl: string | null = null;
         let hindsightBankId = name;
-        if (config.memory?.backend === "hindsight") {
-          const baseUrl = (config.memory.config?.url as string | undefined)
+        if (isHindsightEnabled(config)) {
+          const baseUrl = (config.memory?.config?.url as string | undefined)
             ?? "http://localhost:8888/mcp/";
           // Normalize to end in /mcp/
           hindsightApiUrl = baseUrl.endsWith("/mcp/")

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1542,8 +1542,7 @@ export function registerAgentCommand(program: Command): void {
               continue;
             }
             const agentConfig = resolveAgentConfig(config.defaults, config.profiles, agentConfigRaw);
-            const memoryBackend = config.memory?.backend;
-            const hindsightEnabled = memoryBackend === "hindsight"
+            const hindsightEnabled = isHindsightEnabled(config)
               && agentConfig.memory?.auto_recall !== false;
 
             const expected = buildSettingsHooksBlock({

--- a/src/cli/debug.ts
+++ b/src/cli/debug.ts
@@ -11,6 +11,7 @@ import {
   resolveAgentWorkspaceDir,
 } from "../agents/workspace.js";
 import { resolveAgentConfig, usesSwitchroomTelegramPlugin } from "../config/merge.js";
+import { isHindsightEnabled } from "../memory/hindsight.js";
 
 /**
  * `switchroom debug` commands for observability into what the model sees.
@@ -329,7 +330,7 @@ export function registerDebugCommand(program: Command): void {
         // Hindsight recall (we can't recover the exact recall from logs easily,
         // so we just note whether it would have fired)
         const hindsightEnabled =
-          config.memory?.backend === "hindsight" &&
+          isHindsightEnabled(config) &&
           agentConfig.memory?.auto_recall !== false;
 
         if (hindsightEnabled) {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -693,8 +693,7 @@ function probeAuthBrokerSocket(
 }
 
 async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> {
-  const memoryBackend = config.memory?.backend;
-  if (memoryBackend !== "hindsight") {
+  if (!isHindsightEnabled(config)) {
     return [];
   }
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -23,7 +23,7 @@ import { getAllAuthStatuses } from "../auth/manager.js";
 import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
-import { probeHindsight } from "../memory/hindsight.js";
+import { probeHindsight, isHindsightEnabled } from "../memory/hindsight.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runDriveChecks } from "./doctor-drive.js";
@@ -1510,7 +1510,7 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
         try {
           const mcp = JSON.parse(readFileSync(mcpJsonPath, "utf-8"));
           const hasSwitchroomTelegram = !!mcp.mcpServers?.["switchroom-telegram"];
-          const memoryEnabled = config.memory?.backend === "hindsight";
+          const memoryEnabled = isHindsightEnabled(config);
           const hasHindsight = !!mcp.mcpServers?.hindsight;
 
           if (!hasSwitchroomTelegram) {

--- a/src/cli/vault-sweep.ts
+++ b/src/cli/vault-sweep.ts
@@ -27,6 +27,7 @@ import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { loadConfig, resolvePath } from '../config/loader.js'
 import { openVault, VaultError } from '../vault/vault.js'
+import { isHindsightEnabled } from '../memory/hindsight.js'
 import type { SwitchroomConfig } from '../config/schema.js'
 
 function getVaultPath(configPath?: string): string {
@@ -408,7 +409,7 @@ export function registerVaultSweep(vault: Command, program: Command): void {
         fullConfig = undefined
       }
       const hindsightUrl = (fullConfig?.memory?.config?.url as string | undefined)
-      if (fullConfig?.memory?.backend === 'hindsight' && hindsightUrl) {
+      if (isHindsightEnabled(fullConfig) && hindsightUrl) {
         const banks = getBanksToSweep(fullConfig)
         if (banks.length === 0) {
           console.log(chalk.dim('note: no Hindsight banks configured — skipping memory sweep.'))

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -89,6 +89,33 @@ export function isStrictIsolation(
 }
 
 /**
+ * Single source of truth for "is Hindsight memory wiring active for
+ * this config" — gates MCP tool injection, auto-recall, bank
+ * creation/mission ops, and the memory system-prompt block.
+ *
+ * `SWITCHROOM_MEMORY_BACKEND=none` force-disables Hindsight regardless
+ * of `memory.backend`, matching the precedence in
+ * `src/cli/setup.ts:stepMemoryBackend`. Factored here after
+ * install-validation 2026-05-17 (R2 / prior #25) found THREE
+ * independent copies of `config.memory?.backend === "hindsight"` in
+ * scaffold.ts, only one of which honored the env override — so a
+ * `SWITCHROOM_MEMORY_BACKEND=none` install stayed clean through
+ * `setup` but re-introduced Hindsight wiring (and "Failed to create
+ * Hindsight bank" warnings) on the next `switchroom agent
+ * restart`/`reconcile`. Keep this the only place that decides.
+ *
+ * Semantics preserved from the prior inline expression: config unset
+ * or any non-"hindsight" value ⇒ false; only `backend: "hindsight"`
+ * (and env not "none") ⇒ true.
+ */
+export function isHindsightEnabled(
+  config: SwitchroomConfig | undefined,
+): boolean {
+  if (process.env.SWITCHROOM_MEMORY_BACKEND === "none") return false;
+  return config?.memory?.backend === "hindsight";
+}
+
+/**
  * Recommended default `retain_mission` for new agents.
  *
  * Sourced verbatim from upstream Hindsight's per-user-memory guide:

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -2,6 +2,7 @@ import type { SwitchroomConfig } from "../config/schema.js";
 import {
   generateHindsightMcpConfig,
   getCollectionForAgent,
+  isHindsightEnabled,
   type McpServerConfig,
 } from "./hindsight.js";
 
@@ -15,8 +16,17 @@ export function getHindsightSettingsEntry(
   agentName: string,
   config: SwitchroomConfig,
 ): { key: string; value: McpServerConfig } | null {
+  // Honors SWITCHROOM_MEMORY_BACKEND=none like every other hindsight
+  // gate (install-validation 2026-05-17, R2 review round 3). Guarding
+  // INSIDE this function makes every caller correct — including the
+  // un-gated scaffold/reconcile settings.json merge sites — so a
+  // `none` install no longer writes the hindsight MCP server entry.
   const memoryConfig = config.memory;
-  if (!memoryConfig || memoryConfig.backend !== "hindsight") {
+  if (!isHindsightEnabled(config)) {
+    return null;
+  }
+  // isHindsightEnabled true ⇒ memory.backend === "hindsight" ⇒ defined.
+  if (!memoryConfig) {
     return null;
   }
 

--- a/tests/cli.doctor.memory.test.ts
+++ b/tests/cli.doctor.memory.test.ts
@@ -8,11 +8,14 @@ describe("doctor memory section — source structure", () => {
   // hindsight backend, probes the URL via MCP rather than container
   // name, and validates per-agent missions.
 
-  it("checkHindsight skips when backend is not hindsight", () => {
+  it("checkHindsight skips when hindsight is not enabled", () => {
     const fs = require("fs");
     const doctorSource = fs.readFileSync("src/cli/doctor.ts", "utf-8");
     expect(doctorSource).toContain("async function checkHindsight");
-    expect(doctorSource).toContain('if (memoryBackend !== "hindsight")');
+    // Gated via the shared isHindsightEnabled() helper (honors
+    // SWITCHROOM_MEMORY_BACKEND=none, not just config.memory.backend)
+    // — install-validation 2026-05-17 R2.
+    expect(doctorSource).toContain("if (!isHindsightEnabled(config))");
   });
 
   it("checkHindsight probes the URL via MCP initialize, not container name", () => {


### PR DESCRIPTION
## Summary

`src/agents/scaffold.ts` derived `hindsightEnabled` solely from `config.memory.backend`, ignoring the `SWITCHROOM_MEMORY_BACKEND` env override that `src/cli/setup.ts:stepMemoryBackend` (line ~620) already honors. A `SWITCHROOM_MEMORY_BACKEND=none switchroom setup` against the bundled config (which hardcodes `memory.backend: hindsight`) still triggered per-agent Hindsight bank creation → 4 spurious `⚠ Failed to create Hindsight bank` warnings on a fresh blank-server install (install-validation 2026-05-17, R2 / prior #25).

Fix: `hindsightEnabled = envBackend !== "none" && memoryBackend === "hindsight"` — mirrors setup.ts's precedence (env `none` force-disables; otherwise config decides). Env unset ⇒ behavior unchanged.

One-line behavioral change + comment noting the two sites must stay in sync. `tsc --noEmit` clean.

## Test plan

- [ ] CI `lint` + `vitest` green
- [ ] `SWITCHROOM_MEMORY_BACKEND=none switchroom setup --non-interactive` against bundled config → no "Failed to create Hindsight bank" warnings
- [ ] Unset env + `memory.backend: hindsight` → bank creation still occurs (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)