### PR TITLE
fix(setup): bootstrap config to ~/.switchroom, mirror findConfigFile (R1/#30)

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,8 +1,8 @@
 import type { Command } from "commander";
 import chalk from "chalk";
-import { existsSync, copyFileSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
-import { loadConfig, resolveAgentsDir, resolvePath, ConfigError } from "../config/loader.js";
+import { existsSync, copyFileSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { loadConfig, resolveAgentsDir, resolvePath, findConfigFile, ConfigError } from "../config/loader.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { scaffoldAgent } from "../agents/scaffold.js";
 import { syncTopics } from "../telegram/topic-manager.js";
@@ -179,14 +179,20 @@ async function stepConfigFile(
 ): Promise<LoadedConfig> {
   stepHeader(1, "Config file", STEP_ACTIVE);
 
-  const cwd = process.cwd();
-  const existingConfig =
-    configPath ??
-    (existsSync(resolve(cwd, "switchroom.yaml"))
-      ? resolve(cwd, "switchroom.yaml")
-      : existsSync(resolve(cwd, "switchroom.yml"))
-        ? resolve(cwd, "switchroom.yml")
-        : null);
+  // Mirror the loader's own resolution ($SWITCHROOM_CONFIG → cwd →
+  // ~/.switchroom/switchroom.yaml) so re-running setup from any
+  // directory finds an existing user-wide config instead of
+  // bootstrapping a duplicate (install-validation 2026-05-17, R1 /
+  // prior #30: setup only checked cwd, so an existing
+  // ~/.switchroom/switchroom.yaml was invisible from any other cwd).
+  let existingConfig: string | null = configPath ?? null;
+  if (!existingConfig) {
+    try {
+      existingConfig = findConfigFile();
+    } catch {
+      existingConfig = null;
+    }
+  }
 
   if (existingConfig && existsSync(existingConfig)) {
     if (!nonInteractive) {
@@ -195,7 +201,7 @@ async function stepConfigFile(
         true,
       );
       if (!useExisting) {
-        return await copyExampleConfig(cwd, nonInteractive);
+        return await copyExampleConfig(nonInteractive);
       }
     }
     console.log(chalk.gray(`  Loading ${existingConfig}`));
@@ -215,11 +221,10 @@ async function stepConfigFile(
   // fresh install, which was a P0 blocker for any scripted/CI install
   // (the same code path that works interactively works fine
   // non-interactively; nothing about the bootstrap requires a TTY).
-  return await copyExampleConfig(cwd, nonInteractive);
+  return await copyExampleConfig(nonInteractive);
 }
 
 async function copyExampleConfig(
-  cwd: string,
   nonInteractive: boolean,
 ): Promise<LoadedConfig> {
   const examplesDir = resolve(import.meta.dirname, "../../examples");
@@ -229,23 +234,31 @@ async function copyExampleConfig(
     choice = "switchroom";
   } else {
     choice = await askChoice("  Which example config?", [
-      "switchroom — Full example with 4 agents",
+      "switchroom — Full example: one active agent + commented templates",
       "minimal — Minimal single-agent config",
     ]);
     choice = choice.split(" ")[0];
   }
 
   const srcFile = resolve(examplesDir, `${choice}.yaml`);
-  const destFile = resolve(cwd, "switchroom.yaml");
+  // Bootstrap to the canonical user-wide path, NOT cwd. Every later
+  // command (apply, agent ops, daemonized gateways) resolves config
+  // via findConfigFile, which ranks ~/.switchroom/switchroom.yaml as
+  // the user-wide default. Writing to cwd made the freshly
+  // bootstrapped config invisible the moment the operator changed
+  // directories (install-validation 2026-05-17, R1 / prior #30).
+  // docs/install.md has always told users it lands here.
+  const destFile = resolvePath("~/.switchroom/switchroom.yaml");
 
   if (!existsSync(srcFile)) {
     throw new ConfigError(`Example config not found: ${choice}.yaml`);
   }
 
+  mkdirSync(dirname(destFile), { recursive: true });
   copyFileSync(srcFile, destFile);
-  console.log(chalk.green(`  Copied ${choice}.yaml -> switchroom.yaml`));
+  console.log(chalk.green(`  Copied ${choice}.yaml -> ${destFile}`));
   console.log(
-    chalk.yellow("  Edit switchroom.yaml to customize, then re-run switchroom setup."),
+    chalk.yellow(`  Edit ${destFile} to customize, then re-run switchroom setup.`),
   );
 
   const config = loadConfig(destFile);


### PR DESCRIPTION
## Summary

`copyExampleConfig` wrote the bootstrapped `switchroom.yaml` to the operator's **cwd**, but `findConfigFile` ranks `~/.switchroom/switchroom.yaml` as the user-wide default (cwd is only a higher-priority hit). So a fresh `switchroom setup` from `$HOME` wrote `~/switchroom.yaml`, and the next `switchroom apply`/agent command from any other directory failed with "No switchroom.yaml found" (install-validation 2026-05-17, R1 / prior #30). `docs/install.md:101-102` has always promised `~/.switchroom/switchroom.yaml`.

- `copyExampleConfig` writes canonical `~/.switchroom/switchroom.yaml` (mkdir -p parent), drops the now-unused `cwd` param.
- `stepConfigFile` detects existing config via `findConfigFile()` (mirrors loader's `$SWITCHROOM_CONFIG → cwd → ~/.switchroom` search) instead of cwd-only — re-running setup from any dir reuses the user-wide config instead of duplicating it.
- Fixed stale interactive prompt "Full example with 4 agents" (post-#1423 the example ships one active agent + commented templates).

A power-user's cwd-local `switchroom.yaml` still wins (findConfigFile ranks cwd above `~/.switchroom`); only the bootstrap destination changes. Makes the docs claim true.

## Validation

- `tsc --noEmit` clean.
- `tests/config.test.ts` ✓, `tests/setup.test.ts` ✓.
- Note: 3 failures in `tests/auth-heal-cli.test.ts` in my local run are a node_modules-symlink-skew artifact ("Module not found" from a spawned CLI against stale dist; that suite is unrelated to setup config bootstrap). CI runs in a clean environment and is authoritative.

## Test plan

- [ ] CI `lint` + `vitest` green
- [ ] Fresh `switchroom setup --non-interactive` from `$HOME` writes `~/.switchroom/switchroom.yaml`; `cd /tmp && switchroom apply` then resolves it
- [ ] Re-running `setup` from a different cwd reuses the existing `~/.switchroom/switchroom.yaml` (no duplicate bootstrap)
- [ ] A cwd-local `switchroom.yaml` is still detected + used (power-user path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)