### PR TITLE
fix(scaffold): de-pre-approve mutating hostd MCP verbs (sec #1400 link 1)

### DIFF
--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -122,6 +122,8 @@ A config-summary greeting card is sent automatically by the SessionStart hook �
 ## Admin surface
 
 You're `admin: true`. Fleet operations live on the `hostd` MCP server: `agent_restart` / `agent_start` / `agent_stop` (lifecycle of any peer), `agent_logs` (peer container logs), `agent_exec` (read-only inspection inside any peer — argv[0] must be on the safe-command allowlist), `update_check` / `update_apply`. Treat these like a root shell on the host: confirm intent before destructive actions, refuse if unsure who's asking.
+
+Only `update_check` (a read-only dry-run) runs immediately. Every mutating / host verb — `update_apply`, `agent_exec`, `agent_restart` / `agent_start` / `agent_stop`, `agent_logs` — pauses for an **operator approval card in Telegram before it executes**: a human must tap approve. This is deliberate (you are a prompt-injectable process; the human in the loop is the safety boundary, not your own judgement). Expect the call to block until approved or denied; if denied, don't retry — relay the denial and stop.
 {{else}}
 ## Admin operations
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -439,17 +439,32 @@ const AGENT_CONFIG_MCP_TOOLS = [
 ];
 
 /**
- * Pre-approved MCP tool names for the `hostd` server. Bind-mounted
- * only when the agent is `admin: true` (compose.ts gates the socket
- * mount); pre-approving the wildcard for non-admin agents is harmless
- * because the daemon-side gate (src/host-control/server.ts checkGate)
- * is the security boundary, not the client-side allow list. Avoids
- * the same first-use approval wedge for agent_restart / agent_logs /
- * agent_exec / update_check / update_apply.
+ * Pre-approved hostd MCP tool names. ONLY the pure read-only verb
+ * (`update_check` — a `switchroom update --check` dry-run, no side
+ * effects) is pre-approved; pre-approving it just avoids a first-use
+ * permission wedge on a harmless query.
+ *
+ * The mutating / host-control verbs the hostd MCP server also exposes
+ * — `update_apply`, `agent_exec`, `agent_restart`, `agent_start`,
+ * `agent_stop`, `agent_logs` — are deliberately ABSENT from this list
+ * and the old blanket `mcp__hostd` / `mcp__hostd__*` wildcard is gone.
+ * A prompt-injected admin agent invoking one of them now hits the
+ * Telegram approval card (human-in-the-loop) instead of executing
+ * silently. That is the fix for apex-chain link 1 of #1400: the
+ * daemon-side checkGate still authorizes, but it is no longer the
+ * ONLY thing between an injected agent and a host-root-equivalent
+ * `update_apply`/`agent_exec`. Operator-initiated `/restart`,
+ * `/update apply`, etc. are unaffected — those dispatch through the
+ * gateway's direct hostd UDS path, not the agent's MCP tool surface.
+ *
+ * See docs/rfcs/host-control-daemon.md §5.4 and the
+ * project_hostd_admin_privilege_human_approval design call: autonomous
+ * only for self + read-only; mutating / host verbs gated by approval.
+ * Existing fleet agents that already baked in the wildcard are
+ * converged by the LEGACY_HOSTD_BLANKET_TOKENS retraction on reconcile.
  */
 const HOSTD_MCP_TOOLS = [
-  "mcp__hostd",
-  "mcp__hostd__*",
+  "mcp__hostd__update_check",
 ];
 
 /**
@@ -461,6 +476,19 @@ const HOSTD_MCP_TOOLS = [
  * these so existing agents don't keep stale entries forever.
  */
 const LEGACY_SWITCHROOM_MCP_TOKENS = ["mcp__switchroom", "mcp__switchroom__*"];
+
+/**
+ * The pre-#1400 blanket hostd grant. Earlier scaffolds pre-approved
+ * `mcp__hostd` + `mcp__hostd__*` unconditionally, so a prompt-injected
+ * admin agent could invoke the mutating host-control verbs
+ * (`update_apply` / `agent_exec` / `agent_restart` / …) with NO
+ * Telegram approval prompt — apex-chain link 1 of #1400. Reconcile
+ * actively strips these tokens so existing fleet agents converge on
+ * the narrowed read-only-only HOSTD_MCP_TOOLS set and the mutating
+ * verbs fall through to the human approval card. Mirrors the
+ * LEGACY_SWITCHROOM_MCP_TOKENS retraction pattern.
+ */
+const LEGACY_HOSTD_BLANKET_TOKENS = ["mcp__hostd", "mcp__hostd__*"];
 
 /**
  * Read-only built-in tools that are safe to pre-approve for every agent,
@@ -2052,9 +2080,14 @@ export function scaffoldAgent(
       // approve via Telegram one-tool-at-a-time. See the UAT for
       // PR #1215 (skill_list screenshot).
       settings.permissions = settings.permissions ?? {};
-      const allow: string[] = Array.isArray(settings.permissions.allow)
+      // #1400 link 1: actively retract the pre-#1400 blanket hostd
+      // grant before re-seeding the narrowed read-only-only set, so
+      // an existing agent that baked in `mcp__hostd__*` stops having
+      // the mutating verbs pre-approved.
+      const allow: string[] = (Array.isArray(settings.permissions.allow)
         ? settings.permissions.allow
-        : [];
+        : []
+      ).filter((p: string) => !LEGACY_HOSTD_BLANKET_TOKENS.includes(p));
       for (const t of [...AGENT_CONFIG_MCP_TOOLS, ...HOSTD_MCP_TOOLS]) {
         if (!allow.includes(t)) allow.push(t);
       }
@@ -3411,9 +3444,16 @@ export function reconcileAgent(
   const hindsightEnabled = memoryBackend === "hindsight";
   // #235: drop legacy mcp__switchroom__* tokens from any pre-existing
   // allowlist on every reconcile so existing agents converge on the
-  // same shape new ones get.
+  // same shape new ones get. #1400 link 1: same treatment for the
+  // pre-#1400 blanket hostd grant so a `mcp__hostd__*` left in an
+  // agent's switchroom.yaml tools.allow can't silently re-pre-approve
+  // the mutating host-control verbs past the human approval card.
   if (Array.isArray(tools.allow)) {
-    tools.allow = tools.allow.filter(p => !LEGACY_SWITCHROOM_MCP_TOKENS.includes(p));
+    tools.allow = tools.allow.filter(
+      p =>
+        !LEGACY_SWITCHROOM_MCP_TOKENS.includes(p) &&
+        !LEGACY_HOSTD_BLANKET_TOKENS.includes(p),
+    );
   }
   const desiredAllow = dedupe([
     ...baseAllow,

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -377,6 +377,79 @@ describe("scaffoldAgent", () => {
     expect(settings.permissions.defaultMode).toBeUndefined();
   });
 
+  // #1400 apex-chain link 1: the hostd MCP server exposes mutating /
+  // host-control verbs (update_apply, agent_exec, agent_restart, …).
+  // The pre-#1400 scaffold blanket-pre-approved `mcp__hostd__*`, so a
+  // prompt-injected admin agent could invoke them with NO Telegram
+  // approval prompt. Only the pure read-only `update_check` may be
+  // pre-approved; everything else must fall through to the human
+  // approval card. A typo here silently re-wedges or re-opens the
+  // chain — same drift-guard rationale as the switchroom-telegram
+  // tool-list test below.
+  it("pre-approves ONLY hostd update_check, never the mutating verbs or the blanket wildcard", () => {
+    const config = makeAgentConfig({ tools: { allow: [], deny: [] } });
+    const result = scaffoldAgent("hostd-narrow", config, tmpDir, telegramConfig);
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const allow: string[] = settings.permissions.allow;
+
+    // The one safe read-only verb stays pre-approved (no first-use wedge).
+    expect(allow).toContain("mcp__hostd__update_check");
+    // The blanket grants are gone.
+    expect(allow).not.toContain("mcp__hostd");
+    expect(allow).not.toContain("mcp__hostd__*");
+    // Every mutating / host-control verb must be ABSENT so it routes
+    // through the Telegram approval card.
+    for (const verb of [
+      "mcp__hostd__update_apply",
+      "mcp__hostd__agent_exec",
+      "mcp__hostd__agent_restart",
+      "mcp__hostd__agent_start",
+      "mcp__hostd__agent_stop",
+      "mcp__hostd__agent_logs",
+    ]) {
+      expect(allow).not.toContain(verb);
+    }
+  });
+
+  it("reconcile actively retracts a pre-existing blanket mcp__hostd__* from settings.json", () => {
+    const config = makeAgentConfig({ tools: { allow: [], deny: [] } });
+    const scaffolded = scaffoldAgent("hostd-retract", config, tmpDir, telegramConfig);
+    const settingsPath = join(scaffolded.agentDir, ".claude", "settings.json");
+
+    // Simulate a pre-#1400 agent: hand-inject the old blanket grant
+    // into the persisted allowlist the way old scaffolds baked it in.
+    const pre = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    pre.permissions.allow = [
+      ...pre.permissions.allow.filter(
+        (t: string) => t !== "mcp__hostd__update_check",
+      ),
+      "mcp__hostd",
+      "mcp__hostd__*",
+    ];
+    writeFileSync(settingsPath, JSON.stringify(pre, null, 2));
+
+    reconcileAgent(
+      "hostd-retract",
+      config,
+      tmpDir,
+      telegramConfig,
+      {
+        switchroom: { version: 1, agents_dir: tmpDir },
+        telegram: telegramConfig,
+        agents: { "hostd-retract": config },
+      } as SwitchroomConfig,
+    );
+
+    const after: string[] = JSON.parse(
+      readFileSync(settingsPath, "utf-8"),
+    ).permissions.allow;
+    expect(after).not.toContain("mcp__hostd");
+    expect(after).not.toContain("mcp__hostd__*");
+    expect(after).toContain("mcp__hostd__update_check");
+  });
+
   it("expands tools.allow: [all] into the full built-in tool list", () => {
     // Claude Code rejects the literal string "all" in permissions.allow.
     // When users write `tools.allow: [all]` in switchroom.yaml, the scaffold


### PR DESCRIPTION
## Summary

Closes **apex-chain link 1 of #1400** (the security epic #1389 apex CRITICAL). Pre-#1400 scaffolds blanket-pre-approved `mcp__hostd` + `mcp__hostd__*`, so a single prompt injection into an `admin: true` agent could invoke `update_apply` / `agent_exec` / `agent_restart` / … with **no Telegram approval prompt** — the defining "single injection → silent host-root-equivalent" property of the apex chain.

- Narrow `HOSTD_MCP_TOOLS` to the one pure read-only verb the hostd MCP server exposes (`update_check`, a `switchroom update --check` dry-run). The six mutating / host-control verbs (`update_apply`, `agent_exec`, `agent_restart`, `agent_start`, `agent_stop`, `agent_logs`) are no longer pre-approved → they fall through to the human approval card (the flow that was unblocked when #1399's kernel-ACL fix merged).
- Active retraction (`LEGACY_HOSTD_BLANKET_TOKENS`) converges existing fleet agents that already baked in the wildcard — mirrors the established `#235` `LEGACY_SWITCHROOM_MCP_TOKENS` pattern — in **both** the scaffold additive-merge path and the reconcile path.
- Admin prompt fragment (`profiles/default/CLAUDE.md.hbs`) updated so the agent expects the approval pause and doesn't retry on denial.

## Why this doesn't regress the update-flow-reliability work

Operator-initiated `/restart`, `/new`, `/reset`, `/update apply` dispatch through the **gateway's direct hostd UDS path**, not the agent's MCP tool surface. Only an agent *autonomously* invoking a privileged hostd MCP verb is affected — which is exactly the injection vector. The in-flight update-flow redesign (PR A #1415; PR B/C queued) is untouched.

## Scope

This is #1400 **target 2** only. Targets 1 (operator-attest gate), 3 (per-element argv allowlist), 4 (docker-socket-proxy) are separate scoped PRs per the issue's own guidance. Target 5 (default-off) is resolved as won't-do (owner call: would conflict with update-flow reliability; the gate supersedes it).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tests/scaffold.test.ts` — 173 pass, incl. 2 new: (a) only `update_check` pre-approved, blanket + 6 mutating verbs absent; (b) reconcile retracts a pre-existing baked-in `mcp__hostd__*`
- [x] persona / rerender-claude-md / fresh-agent-mcp-trust suites green
- [ ] CI green

Serves JTBD: subscription-honest + always-on fleet safety. Refs #1400 #1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)