### PR TITLE
fix(hostd): reject all C0/DEL controls + cap argv element size (sec #1400 t3)

### DIFF
--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -180,7 +180,13 @@ export const AgentExecRequestSchema = z.object({
   args: z.object({
     name: AgentNameSchema,
     /** Command + args as a list, e.g. ["ls", "-la", "/state"]. argv[0]
-     *  is the program; argv[1..] are its arguments. */
+     *  is the program; argv[1..] are its arguments. argv[0] is
+     *  allowlist-gated and every element is charclass/length-gated
+     *  server-side — see isAllowlistedReadOnlyArgv +
+     *  isSafeExecArgvElement / MAX_EXEC_ARGV_ELEMENT_BYTES in
+     *  host-control/server.ts (#1401 / #1400 target 3). The wire
+     *  schema stays permissive-but-bounded; the security charclass is
+     *  enforced at dispatch so the denial carries a clear reason. */
     argv: z.array(z.string().min(1)).min(1).max(32),
   }),
 });

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -736,13 +736,17 @@ export class HostdServer {
         Date.now() - started,
       );
     }
-    // #1401: reject NUL / newline / CR in any argv element (audit-log
-    // line injection + arg smuggling) before the call.
+    // #1401 / #1400 target 3: reject any argv element carrying a C0
+    // control byte (NUL/LF/CR + ESC and the rest of U+0000–U+001F),
+    // DEL, or exceeding the per-element size cap — audit-log line
+    // injection, ANSI-escape spoofing of the operator audit trail,
+    // and arg-vector padding, all before the call.
     if (!req.args.argv.every(isSafeExecArgvElement)) {
       return deniedResponse(
         req.request_id,
-        `agent_exec: an argv element contains a NUL or newline/CR ` +
-          `control character, which is not permitted (#1401).`,
+        `agent_exec: an argv element contains a control character ` +
+          `(C0 / DEL) or exceeds ${MAX_EXEC_ARGV_ELEMENT_BYTES} bytes, ` +
+          `which is not permitted (#1401 / #1400).`,
         Date.now() - started,
       );
     }
@@ -1105,15 +1109,35 @@ export function isAllowlistedReadOnlyArgv(argv0: string): boolean {
 }
 
 /**
- * #1401: every argv element must be free of NUL / LF / CR. Those have
- * no legitimate place in a read-only inspection command (paths, flags
- * like `-n`, and grep patterns are all unaffected) and exist only to
- * smuggle behaviour: a newline/CR enables audit-log line injection and,
- * before the `--` separator landed, docker-flag confusion. argv[0] is
- * separately allowlist-gated by isAllowlistedReadOnlyArgv.
+ * Upper bound on a single argv element. A read-only inspection
+ * command's longest legitimate element is a path or a grep pattern —
+ * 4 KiB is already absurdly generous for either. The cap stops a
+ * post-approval admin agent padding the audit row / docker arg vector
+ * with a multi-megabyte element.
+ */
+export const MAX_EXEC_ARGV_ELEMENT_BYTES = 4096;
+
+/**
+ * #1401 / #1400 target 3 — completes the WS5 per-element charclass
+ * finding. Every argv element must be free of ALL C0 control bytes
+ * (U+0000–U+001F) and DEL (U+007F), and must not exceed
+ * {@link MAX_EXEC_ARGV_ELEMENT_BYTES}.
+ *
+ * #1401 already rejected NUL/LF/CR (audit-log line injection +
+ * pre-`--` docker-flag confusion). The residual the WS5 audit flagged
+ * is the *other* C0 controls — ESC (U+001B), backspace, the SGR /
+ * cursor introducers — which have no place in a path, a `-n`-style
+ * flag, or a grep pattern, but DO let a prompt-injected admin agent
+ * smuggle ANSI escape sequences into the operator-facing
+ * `switchroom audit hostd` trail (terminal / log spoofing). argv[0]
+ * is separately allowlist-gated by isAllowlistedReadOnlyArgv; the
+ * cross-agent credential-read residual is the explicitly-accepted
+ * admin-surface trade-off whose sanctioned fix is the deferred
+ * `host_os.exec` approval-kernel scope, not this charclass.
  */
 export function isSafeExecArgvElement(s: string): boolean {
-  return !/[\u0000\n\r]/.test(s);
+  if (Buffer.byteLength(s, "utf8") > MAX_EXEC_ARGV_ELEMENT_BYTES) return false;
+  return !/[\u0000-\u001f\u007f]/.test(s);
 }
 
 /** Probe whether an agent socket exists at the canonical in-container

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -862,8 +862,52 @@ describe("hostd server — Phase 2 fleet mutations + lock", () => {
       },
     );
     expect(resp.result).toBe("denied");
-    expect(resp.error).toMatch(/NUL or newline\/CR/);
+    expect(resp.error).toMatch(/control character/);
     expect(resp.error).toMatch(/#1401/);
+  });
+
+  // #1400 target 3 — completes the WS5 per-element charclass finding:
+  // #1401 only blocked NUL/LF/CR. ESC (U+001B) and the other C0
+  // controls let a (now approval-gated, but still prompt-injectable)
+  // admin agent smuggle ANSI escape sequences into the operator-facing
+  // `switchroom audit hostd` trail. They must be rejected too.
+  it("agent_exec: argv element with ESC / other C0 control is denied (#1400 target 3)", async () => {
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "agent_exec",
+        request_id: "exec-esc-1",
+        // ESC + an SGR sequence. No NUL/LF/CR, so #1401
+        // alone would have passed it. ESC byte built at
+        // runtime so no source-level escape mangling can
+        // weaken the test.
+        args: {
+          name: "bob",
+          argv: ["grep", `${String.fromCharCode(27)}[31mpwned`, "/x"],
+        },
+      },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/control character/);
+    expect(resp.error).toMatch(/#1400/);
+  });
+
+  it("agent_exec: an over-long argv element is denied (#1400 target 3)", async () => {
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      {
+        v: 1,
+        op: "agent_exec",
+        request_id: "exec-long-1",
+        // 4097 bytes — one past MAX_EXEC_ARGV_ELEMENT_BYTES (4096).
+        args: { name: "bob", argv: ["cat", "/".padEnd(4097, "a")] },
+      },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/exceeds 4096 bytes/);
   });
 
   it("agent_exec: non-allowlisted argv[0] is denied with a clear pointer to the deferred scope", async () => {


### PR DESCRIPTION
## Summary

Completes the **WS5 per-element argv charclass finding** (#1401 / #1400 **target 3**), epic #1389.

Prior art already closed the *exploitable* surface: #1411 landed the `--` separator + argv[0] allowlist + NUL/LF/CR rejection, and #1427 removed the silent MCP pre-approval (agent_exec now requires a human Telegram approval card). The fresh-reviewer verdict on #1401 confirmed `agent_exec` alone is in-container read-only — CRITICAL only as a composite chain link, now broken.

This PR closes the **residual charclass gap the WS5 audit explicitly flagged**: #1401 rejected only NUL/LF/CR, so **ESC (U+001B)** and the other C0 controls still pass — letting a (now approval-gated, still prompt-injectable) admin agent smuggle **ANSI escape sequences into the operator-facing `switchroom audit hostd` trail** (terminal / log spoofing).

- `isSafeExecArgvElement` now rejects the **full C0 range (U+0000–U+001F) + DEL (U+007F)** and caps each element at `MAX_EXEC_ARGV_ELEMENT_BYTES` (4 KiB — absurdly generous for any path/grep pattern; stops audit-row / arg-vector padding).
- Denial message + protocol schema doc updated to reflect the boundary.

## Explicitly out of scope (by design, not omission)

The cross-agent credential-read residual (`cat /state/agent/.../credentials.json` on a peer) is the **deliberately-accepted admin-surface trade-off** documented at `server.ts` `READONLY_EXEC_ALLOWLIST`; its sanctioned fix is the deferred `host_os.exec` approval-kernel scope (tracked separately under #1401's HIGH). Not patched here to avoid contradicting a documented design decision with a cosmetic denylist.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tests/host-control/server.test.ts` — 35 pass incl. 2 new (ESC-in-argv denied; >4096-byte element denied) + the existing #1401 NUL/LF/CR test updated to the new message
- [x] full `tests/host-control` + `src/mcp/hostd` — 114 pass
- [ ] CI green

Serves JTBD: always-on fleet safety + audit integrity. Refs #1400 #1401 #1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)