### PR TITLE
feat(agent-config): restart-required readback on skill_install / schedule add+remove

### DIFF
--- a/src/cli/agent-config-skill-write.test.ts
+++ b/src/cli/agent-config-skill-write.test.ts
@@ -57,6 +57,14 @@ describe("skillInstall — happy path", () => {
     expect(content).toContain("webapp-testing");
   });
 
+  it("returns a restart-required readback naming the agent", () => {
+    const r = install();
+    if (!r.ok) throw new Error(`expected ok, got ${JSON.stringify(r)}`);
+    expect(r.restart_required).toBe(true);
+    expect(r.restart_hint).toContain("test-agent");
+    expect(r.restart_hint).toMatch(/restart/i);
+  });
+
   it("uses opts.name as the slug when provided", () => {
     const r = install({ source: "bundled:pdf", name: "my-pdf-skill" });
     if (!r.ok) throw new Error(`expected ok, got ${JSON.stringify(r)}`);
@@ -162,6 +170,8 @@ describe("skillRemove", () => {
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.slug).toBe(i.slug);
+    expect(r.restart_required).toBe(true);
+    expect(r.restart_hint).toContain("test-agent");
     const files = readdirSync(join(tmpRoot, FAKE_AGENT, "skills.d")).filter((f) => f.endsWith(".yaml"));
     expect(files).toEqual([]);
   });

--- a/src/cli/agent-config-skill-write.ts
+++ b/src/cli/agent-config-skill-write.ts
@@ -38,7 +38,7 @@ import { getBundledSkillsPoolDir } from "../agents/reconcile-default-skills.js";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { ReconcileFn } from "./agent-config-write.js";
-import { appendAudit } from "./agent-config.js";
+import { appendAudit, restartRequiredNote } from "./agent-config.js";
 
 /** Per-agent skill cap. Matches the schedule cap (20). */
 export const MAX_SKILLS_PER_AGENT = 20;
@@ -84,6 +84,11 @@ export interface SkillResult {
   source: string;
   resolved_skill_name: string;
   would_recreate: false;
+  /** On disk + reconciled, but claude loads skills at process start —
+   *  not live until the agent restarts (skill hot-reload is unbuilt
+   *  Phase C; see lifecycle.ts:classifyChangeKind). */
+  restart_required: true;
+  restart_hint: string;
 }
 
 export interface SkillErrorResult {
@@ -266,11 +271,20 @@ export function skillInstall(opts: SkillInstallOpts): SkillResult | SkillErrorRe
     source: opts.source,
     resolved_skill_name: skillName,
     would_recreate: false,
+    restart_required: true,
+    restart_hint: restartRequiredNote(agent),
   };
 }
 
 /** Remove a skill from the agent's overlay. */
-export function skillRemove(opts: SkillRemoveOpts): { ok: true; slug: string } | SkillErrorResult {
+export interface SkillRemoveResult {
+  ok: true;
+  slug: string;
+  restart_required: true;
+  restart_hint: string;
+}
+
+export function skillRemove(opts: SkillRemoveOpts): SkillRemoveResult | SkillErrorResult {
   let agent: string;
   try {
     agent = resolveAgentName(opts.agent);
@@ -323,7 +337,12 @@ export function skillRemove(opts: SkillRemoveOpts): { ok: true; slug: string } |
       }
     }
   }
-  return { ok: true, slug };
+  return {
+    ok: true,
+    slug,
+    restart_required: true,
+    restart_hint: restartRequiredNote(agent),
+  };
 }
 
 export function registerAgentConfigSkillWriteCommands(program: Command): void {
@@ -385,6 +404,8 @@ export function registerAgentConfigSkillWriteCommands(program: Command): void {
         path: r.path,
         source: r.source,
         resolved_skill_name: r.resolved_skill_name,
+        restart_required: r.restart_required,
+        restart_hint: r.restart_hint,
       }) + "\n");
       try {
         appendAudit(
@@ -402,7 +423,7 @@ export function registerAgentConfigSkillWriteCommands(program: Command): void {
     .requiredOption("--name <slug>", "Slug passed at install time")
     .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
     .action(async (opts: { agent?: string; name: string }) => {
-      let r: { ok: true; slug: string } | SkillErrorResult;
+      let r: SkillRemoveResult | SkillErrorResult;
       let resolvedAgent = opts.agent ?? "<unknown>";
       try {
         r = skillRemove({ agent: opts.agent, name: opts.name });
@@ -429,7 +450,12 @@ export function registerAgentConfigSkillWriteCommands(program: Command): void {
         } catch { /* ignore */ }
         process.exit(r.exit);
       }
-      process.stdout.write(JSON.stringify({ ok: true, slug: r.slug }) + "\n");
+      process.stdout.write(JSON.stringify({
+        ok: true,
+        slug: r.slug,
+        restart_required: r.restart_required,
+        restart_hint: r.restart_hint,
+      }) + "\n");
       try {
         appendAudit(resolvedAgent, "skill.remove", { slug: r.slug }, 0);
       } catch { /* ignore */ }

--- a/src/cli/agent-config-write.test.ts
+++ b/src/cli/agent-config-write.test.ts
@@ -32,6 +32,9 @@ describe("scheduleAdd — happy path", () => {
     expect(r.cron_hash).toBe(expected);
     expect(r.slug).toBe(`cron-${expected}`);
     expect(r.would_recreate).toBe(false);
+    expect(r.restart_required).toBe(true);
+    expect(r.restart_hint).toContain("alice");
+    expect(r.restart_hint).toMatch(/restart/i);
     expect(existsSync(r.path)).toBe(true);
     const content = readFileSync(r.path, "utf-8");
     expect(content).toContain("prompt: morning standup");
@@ -85,6 +88,9 @@ describe("scheduleRemove", () => {
     if (!add.ok) return;
     const r = scheduleRemove({ cronHash: add.cron_hash, root });
     expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.restart_required).toBe(true);
+    expect(r.restart_hint).toContain("alice");
     expect(existsSync(add.path)).toBe(false);
   });
 

--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -37,6 +37,7 @@ import { parse as parseYaml, stringify as yamlStringify } from "yaml";
 import {
   appendAudit,
   resolveTargetAgent,
+  restartRequiredNote,
 } from "./agent-config.js";
 import {
   writeOverlayEntry,
@@ -175,6 +176,10 @@ export interface ScheduleAddResult {
   path: string;
   cron_hash: string;
   would_recreate: false;
+  /** Entry is on disk but the in-container scheduler captured its
+   *  entries at boot — not live until the agent restarts. */
+  restart_required: true;
+  restart_hint: string;
 }
 
 export interface ScheduleErrorResult {
@@ -344,6 +349,8 @@ export function scheduleAdd(opts: AddOpts): ScheduleAddResult | ScheduleErrorRes
     path,
     cron_hash: hash,
     would_recreate: false,
+    restart_required: true,
+    restart_hint: restartRequiredNote(agent),
   };
 }
 
@@ -418,6 +425,8 @@ export interface ScheduleRemoveResult {
   ok: true;
   slug: string;
   path: string;
+  restart_required: true;
+  restart_hint: string;
 }
 
 export function scheduleRemove(opts: RemoveOpts): ScheduleRemoveResult | ScheduleErrorResult {
@@ -496,7 +505,13 @@ export function scheduleRemove(opts: RemoveOpts): ScheduleRemoveResult | Schedul
       };
     }
   }
-  return { ok: true, slug: match.slug, path: match.path };
+  return {
+    ok: true,
+    slug: match.slug,
+    path: match.path,
+    restart_required: true,
+    restart_hint: restartRequiredNote(agent),
+  };
 }
 
 export function registerAgentConfigWriteCommands(program: Command): void {
@@ -586,6 +601,8 @@ export function registerAgentConfigWriteCommands(program: Command): void {
         cron_hash: r.cron_hash,
         path: r.path,
         would_recreate: false,
+        restart_required: r.restart_required,
+        restart_hint: r.restart_hint,
       }) + "\n");
       appendAudit(
         resolvedAgent,
@@ -712,7 +729,13 @@ export function registerAgentConfigWriteCommands(program: Command): void {
         appendAudit(resolvedAgent, "schedule.remove", { ...opts, code: r.code }, r.exit);
         process.exit(r.exit);
       }
-      process.stdout.write(JSON.stringify({ ok: true, slug: r.slug, path: r.path }) + "\n");
+      process.stdout.write(JSON.stringify({
+        ok: true,
+        slug: r.slug,
+        path: r.path,
+        restart_required: r.restart_required,
+        restart_hint: r.restart_hint,
+      }) + "\n");
       appendAudit(resolvedAgent, "schedule.remove", { ...opts, slug: r.slug }, 0);
     });
 }

--- a/src/cli/agent-config.ts
+++ b/src/cli/agent-config.ts
@@ -186,6 +186,26 @@ export function stripSecretValues<T>(value: T): T {
   return value;
 }
 
+/**
+ * Human-readable readback appended to every overlay write that lands
+ * on disk but is NOT live in the running agent. claude-code reads
+ * skills, `.mcp.json` and (post cron-fold-in) the in-container
+ * scheduler's entries at PROCESS START — see
+ * `lifecycle.ts:classifyChangeKind` ("settings"/"skill" are
+ * restart-required; skill hot-reload is unbuilt Phase C). Without this
+ * line a self-service `skill_install` / `schedule add` returns
+ * `{ok:true}` and the change silently does nothing until the next
+ * bounce. Same wording across skill + schedule by design (consistency
+ * principle).
+ */
+export function restartRequiredNote(agent: string): string {
+  return (
+    `Not live yet — claude loads skills, MCP servers and scheduled ` +
+    `tasks at process start. Run \`switchroom agent restart ${agent}\` ` +
+    `for this to take effect.`
+  );
+}
+
 function getAgentSlice(config: SwitchroomConfig, agent: string): unknown {
   const slice = config.agents?.[agent];
   if (!slice) {


### PR DESCRIPTION
## Summary

Sibling of #1424 in the trustable-config initiative. Self-service overlay writes (`skill_install`, `skill_remove`, `schedule add`, `schedule remove`) land on disk and reconcile, but claude-code loads skills, `.mcp.json`, and the in-container scheduler's entries at **process start** — so the change is **silently inert until the agent restarts** (authoritative in `lifecycle.ts:classifyChangeKind`; skill hot-reload is an unbuilt Phase C). Today these return `{ok:true}` with no signal: an agent self-installs a skill, the tool says success, nothing happens until the next bounce.

- Adds typed `restart_required: true` + human `restart_hint` to `SkillResult`, `SkillRemoveResult`, `ScheduleAddResult`, `ScheduleRemoveResult`, surfaced in the CLI/MCP stdout envelopes.
- Shared `restartRequiredNote(agent)` in `agent-config.ts` — identical wording across skill + schedule by the **consistency principle** — built with the resolved agent name.
- Staged/denied schedule envelopes deliberately untouched (not live by design — pending operator approval).
- Additive, non-breaking (new keys only). 5 new assertions in existing direct-call unit tests.

## JTBD / design contract

Serves **keep-switchroom-feeling-like-one-product** + the visibility outcome: the engine worked, the user just couldn't tell. **Docs test**: the readback self-documents in the agent's reply (no doc rendered wrong). **Consistency test**: one shared note, four envelopes. **Defaults test**: unaffected.

## Review

Independently reviewed by a fresh separate-process agent: **APPROVE**. Verified the readback is *truthful* for all four paths (traced the in-container scheduler's boot-snapshot at `agent-scheduler/index.ts:219-246`; confirmed `applyCronChangesHot` is not a real hot-reload), type integrity (every return site sets the literal `true`; stale inline annotation fixed), correct resolved-agent name, non-breaking (no exact-shape consumers; MCP forwards stdout verbatim), tests meaningful. tsc + 55/55 green.

## Test plan

- [x] `npm run lint` clean (incl. tsc --noEmit)
- [x] `npx vitest run src/cli/agent-config-skill-write.test.ts src/cli/agent-config-write.test.ts src/cli/agent-config.test.ts` — 55/55
- [ ] CI: 15 required GHA checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)