### PR TITLE
fix(agent): image-baked unstrippable security-hooks plugin (sec WS8-F1 #1416)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -135,6 +135,24 @@ RUN chmod 0755 /opt/switchroom/autoaccept-poll.js
 COPY dist/cli/drive-write-pretool.mjs /opt/switchroom/hooks/drive-write-pretool.mjs
 RUN chmod 0755 /opt/switchroom/hooks/drive-write-pretool.mjs
 
+# Image-baked security-hooks plugin (sec WS8-F1 / #1416). A separate,
+# minimal --plugin-dir holding ONLY the load-bearing PreToolUse safety
+# hooks (secret-exfil guard + Drive-write approval gate). Loaded from
+# this read-only in-image path by start.sh; Claude Code unions
+# plugin-dir hooks with settings.json hooks and an agent CANNOT
+# suppress plugin-dir-loaded hooks by rewriting its own
+# /state/agent/.claude/settings.json. The settings.json copy stays as
+# a harmless union fallback — this copy is the unstrippable authority.
+# Deliberately NOT --plugin-dir /opt/switchroom/telegram-plugin to
+# avoid any interaction with the --dangerously-load-development-channels
+# load of the same-named plugin. The two .mjs are self-contained
+# (node builtins / pre-bundled), so a flat copy is sufficient.
+COPY docker/security-plugin/.claude-plugin /opt/switchroom/security-plugin/.claude-plugin
+COPY docker/security-plugin/hooks/hooks.json /opt/switchroom/security-plugin/hooks/hooks.json
+COPY telegram-plugin/hooks/secret-guard-pretool.mjs /opt/switchroom/security-plugin/hooks/secret-guard-pretool.mjs
+COPY dist/cli/drive-write-pretool.mjs /opt/switchroom/security-plugin/hooks/drive-write-pretool.mjs
+RUN chmod 0755 /opt/switchroom/security-plugin/hooks/*.mjs
+
 # switchroom CLI bundle: the in-container telegram-plugin gateway sidecar
 # shells out to `switchroom <verb>` for /auth, /vault, /agent, /topics
 # and friends (see telegram-plugin/gateway/gateway.ts:switchroomExec).

--- a/docker/security-plugin/.claude-plugin/plugin.json
+++ b/docker/security-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "switchroom-security",
+  "description": "Switchroom's image-baked, agent-unstrippable security hooks: PreToolUse secret-exfil guard and Drive-write approval gate. Loaded from a read-only in-image path via --plugin-dir so a prompt-injected agent cannot disable tool safety by rewriting its own settings.json (sec WS8-F1 / #1416). Unions with the settings.json copy; this copy is the authority.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Ken Thompson",
+    "email": "me@kenthompson.com.au"
+  },
+  "homepage": "https://github.com/mekenthompson/switchroom",
+  "repository": "https://github.com/mekenthompson/switchroom"
+}

--- a/docker/security-plugin/hooks/hooks.json
+++ b/docker/security-plugin/hooks/hooks.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/secret-guard-pretool.mjs\"",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/drive-write-pretool.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -514,16 +514,34 @@ if [ -x "{{repoRoot}}/bin/boot-self-test.sh" ]; then
 fi
 {{/if}}
 
+# --- Security-hooks plugin integrity check (sec WS8-F1 / #1416) ---
+# The image-baked, agent-unstrippable tool-safety plugin is loaded via
+# --plugin-dir below. If the image copy is missing/empty (bad build,
+# tampering, downgrade) we DON'T fail boot — Claude Code unions
+# plugin-dir hooks with the settings.json copy, which still protects —
+# but we surface it loudly to stderr so the gap is visible instead of
+# silently relying on the strippable fallback.
+SR_SECPLUGIN="{{securityPluginDir}}"
+for f in \
+  "$SR_SECPLUGIN/.claude-plugin/plugin.json" \
+  "$SR_SECPLUGIN/hooks/hooks.json" \
+  "$SR_SECPLUGIN/hooks/secret-guard-pretool.mjs" \
+  "$SR_SECPLUGIN/hooks/drive-write-pretool.mjs"; do
+  if [ ! -s "$f" ]; then
+    echo "WARNING sec WS8-F1 (#1416): security-hooks plugin artifact missing or empty: $f — tool-safety is running on the settings.json fallback only (strippable). Rebuild/redeploy the agent image." >&2
+  fi
+done
+
 {{#if useSwitchroomPlugin}}
 if [ -n "$APPEND_PROMPT" ]; then
-  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 else
-  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 fi
 {{else}}
 if [ -n "$APPEND_PROMPT" ]; then
-  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 else
-  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 fi
 {{/if}}

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1602,6 +1602,10 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     dangerousMode: agentConfig.dangerous_mode === true,
     useSwitchroomPlugin: usesSwitchroomTelegramPlugin(agentConfig),
     useHotReloadStable: agentConfig.channels?.telegram?.hotReloadStable === true,
+    // sec WS8-F1 / #1416: unconditional read-only image-baked
+    // security-hooks plugin dir. Always set — it is the unstrippable
+    // tool-safety authority, not an opt-in feature.
+    securityPluginDir: DOCKER_SECURITY_PLUGIN_PATH,
     hindsightEnabled: hindsightAutoRecallEnabled,
     hindsightBankIdQ: shellSingleQuote(hindsightBankId),
     hindsightApiBaseUrlQ: shellSingleQuote(hindsightApiBaseUrl),
@@ -1772,6 +1776,22 @@ export const DOCKER_BUNDLED_HOOKS_PATH = "/opt/switchroom/hooks";
  * scaffolded settings.json hooks block.
  */
 export const DOCKER_BIN_PATH = "/opt/switchroom/bin";
+
+/**
+ * In-image path of the minimal security-hooks plugin (sec WS8-F1 /
+ * #1416). Dockerfile.agent assembles `.claude-plugin/plugin.json` +
+ * `hooks/hooks.json` + the two load-bearing PreToolUse safety hooks
+ * (secret-guard-pretool, drive-write-pretool) here. start.sh passes
+ * this as `--plugin-dir` on every claude exec variant, unconditionally
+ * — it is THE security boundary, not optional like hindsight. Because
+ * Claude Code unions plugin-dir hooks with settings.json hooks and a
+ * plugin-dir-loaded hook cannot be suppressed by an agent rewriting
+ * its own settings.json, this read-only image copy is the unstrippable
+ * authority; the settings.json copy (still emitted) is a harmless
+ * zero-regression fallback. Never point this at the agent-writable
+ * scaffold dir.
+ */
+export const DOCKER_SECURITY_PLUGIN_PATH = "/opt/switchroom/security-plugin";
 
 /**
  * In-container path where compose bind-mounts the operator's
@@ -3509,6 +3529,10 @@ export function reconcileAgent(
       // {{#unless useHotReloadStable}} block always renders, so flipping
       // hotReloadStable on never removes the _WS_STABLE bake from start.sh.
       useHotReloadStable: agentConfig.channels?.telegram?.hotReloadStable === true,
+      // sec WS8-F1 / #1416: reconcile re-asserts the security-plugin
+      // --plugin-dir on every `switchroom apply` so the boundary
+      // self-heals if an older start.sh (without it) is on disk.
+      securityPluginDir: DOCKER_SECURITY_PLUGIN_PATH,
       hindsightEnabled: hindsightAutoRecallEnabled,
       hindsightBankIdQ: shellSingleQuote(hindsightBankId),
       hindsightApiBaseUrlQ: shellSingleQuote(hindsightApiBaseUrl),

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2508,6 +2508,51 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(startSh).toContain("--dangerously-load-development-channels server:switchroom-telegram");
   });
 
+  // sec WS8-F1 / #1416: the image-baked security-hooks plugin must be
+  // loaded via --plugin-dir from the read-only in-image path on EVERY
+  // claude exec variant, unconditionally (not gated on hindsight or
+  // any opt-in), and never from the agent-writable scaffold dir. It's
+  // the unstrippable tool-safety authority.
+  it("start.sh loads the image-baked security plugin unconditionally (#1416)", () => {
+    const agentConfig = makeAgentConfig(); // hindsight off by default
+    const result = scaffoldAgent("secplugin-agent", agentConfig, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+
+    // Present on the active exec line even with hindsight disabled.
+    expect(startSh).toContain('--plugin-dir "/opt/switchroom/security-plugin"');
+    // Never the agent-writable scaffold dir for the security plugin.
+    expect(startSh).not.toContain(
+      `--plugin-dir "${result.agentDir}/.claude/plugins/security`,
+    );
+    // Boot integrity check surfaces a missing/empty image copy loudly
+    // (non-fatal — the settings.json union fallback still protects).
+    expect(startSh).toContain("sec WS8-F1 (#1416): security-hooks plugin artifact missing");
+    expect(startSh).toContain('SR_SECPLUGIN="/opt/switchroom/security-plugin"');
+    expect(startSh).toContain('"$SR_SECPLUGIN/hooks/secret-guard-pretool.mjs"');
+    expect(startSh).toContain('"$SR_SECPLUGIN/hooks/drive-write-pretool.mjs"');
+  });
+
+  it("reconcile re-asserts the security --plugin-dir so it self-heals (#1416)", () => {
+    const agentConfig = makeAgentConfig();
+    scaffoldAgent("secplugin-reconcile", agentConfig, tmpDir, telegramConfig);
+    // Simulate an older start.sh on disk that predates the security plugin.
+    const startShPath = join(tmpDir, "secplugin-reconcile", "start.sh");
+    writeFileSync(startShPath, "#!/bin/bash\nexec claude\n");
+    reconcileAgent(
+      "secplugin-reconcile",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+      {
+        switchroom: { version: 1, agents_dir: tmpDir },
+        telegram: telegramConfig,
+        agents: { "secplugin-reconcile": agentConfig },
+      } as SwitchroomConfig,
+    );
+    const startSh = readFileSync(startShPath, "utf-8");
+    expect(startSh).toContain('--plugin-dir "/opt/switchroom/security-plugin"');
+  });
+
   it("channels.telegram.plugin: 'official' keeps the upstream marketplace plugin", () => {
     const agentConfig = makeAgentConfig({
       channels: { telegram: { plugin: "official" } },
@@ -2523,6 +2568,8 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(existsSync(join(result.agentDir, ".mcp.json"))).toBe(false);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
     expect(startSh).toContain("--channels plugin:telegram@claude-plugins-official");
+    // #1416: the security plugin-dir is on the official variant too.
+    expect(startSh).toContain('--plugin-dir "/opt/switchroom/security-plugin"');
   });
 
   it("channels.telegram.format and rate_limit_ms become env vars in start.sh", () => {


### PR DESCRIPTION
## Summary

Remediates **WS8-F1 (HIGH)** — epic #1389. Implements the **fully verified design** from #1396 (the "WS8-F1 remediation — verified design (R5a)" comment).

**Finding:** the load-bearing PreToolUse safety hooks (`secret-guard-pretool` secret-exfil block + `drive-write-pretool` approval gate) were declared only in the **agent-writable** `/state/agent/.claude/settings.json`. A prompt-injected agent could strip them and force a non-reconcile restart so they stayed stripped — disabling secret redaction + the human-in-the-loop approval gate. The image-baked `telegram-plugin/hooks/hooks.json` was dead code (nothing `--plugin-dir`'d it).

**Fix (zero-regression, union/fallback):**
- New minimal image-baked plugin `docker/security-plugin/` (manifest + `hooks.json` with **only** the two load-bearing security hooks).
- `Dockerfile.agent` assembles it at `/opt/switchroom/security-plugin/` — a *separate* dir (not the telegram-plugin `--plugin-dir`) to avoid interaction with `--dangerously-load-development-channels`. Both `.mjs` verified self-contained (node builtins / pre-bundled).
- `start.sh.hbs`: `--plugin-dir` on **all 4** claude exec variants, unconditional; threaded via `DOCKER_SECURITY_PLUGIN_PATH` into **both** scaffold + reconcile render contexts (reconcile self-heals an older start.sh).
- settings.json hooks **kept** — Claude Code unions plugin-dir + settings.json hooks and an agent **cannot** suppress plugin-dir-loaded hooks via settings.json, so the image copy is the **unstrippable authority** and the settings.json copy is a harmless zero-regression fallback (a botched/old-CC plugin load can't disable safety).
- Boot integrity check: loud stderr warning if the image artifacts are missing/empty (non-fatal — fallback still protects).

## ⚠️ Post-merge validation gate (per #1416)

The remediation's value only fully materializes after an **agent-image rebuild** (`docker-images.yml` on merge) + **in-container proof** that `secret-guard` fires from the read-only `/opt/switchroom/security-plugin` path **even with a stripped `settings.json`**. The union/fallback design guarantees **zero interim regression** (settings.json hooks still protect until then). This PR is the implement→merge step; the image-rebuild → `switchroom update` → in-container verify must be done before WS8-F1 is marked closed on #1396.

Step 6 of the design (`allowManagedHooksOnly` via *managed* settings, to also block the start.sh-rewrite vector) is a tracked separate deployment-infra follow-up.

## Test plan

- [x] `tsc --noEmit` clean (the `@mtcute/node` lint error is pre-existing on `upstream/main` in untouched `telegram-plugin/uat/login.ts` — env dep-gap, not this PR)
- [x] `tests/scaffold.test.ts` + `regenerate-start-sh` + `hot-reload-stable` — 188 pass, incl. 3 new (security `--plugin-dir` on switchroom + official variants unconditionally; not the agent-writable dir; reconcile self-heal; boot integrity block present)
- [x] new `plugin.json` / `hooks.json` valid JSON
- [ ] CI green
- [ ] **post-merge:** agent-image rebuild + in-container hook-fires-from-readonly-path-with-stripped-settings.json proof

Serves JTBD: always-on fleet safety + subscription-honest (secret containment). Refs #1416 #1396 #1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)