### PR TITLE
feat(doctor): flag inlined plaintext secrets in switchroom.yaml (sec WS6-F3 #1421)

### DIFF
--- a/src/cli/doctor-inlined-secrets.test.ts
+++ b/src/cli/doctor-inlined-secrets.test.ts
@@ -1,0 +1,111 @@
+/**
+ * doctor-inlined-secrets — WS6-F3 (#1421). The whole switchroom.yaml
+ * is bind-mounted read-only into every agent, so any secret-shaped
+ * key carrying a literal (non-`vault:`) value is a cross-agent secret
+ * read. These cases pin the detector's signal/no-noise contract.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const cfg = {} as unknown as SwitchroomConfig;
+
+function run(yaml: string) {
+  return runInlinedSecretChecks(cfg, {
+    configPath: "/x/switchroom.yaml",
+    readFileSync: () => yaml,
+  });
+}
+
+describe("runInlinedSecretChecks", () => {
+  it("returns [] when there is no config file to scan", () => {
+    expect(runInlinedSecretChecks(cfg, {})).toEqual([]);
+  });
+
+  it("OK when every secret-shaped key is a vault: reference", () => {
+    const r = run(
+      [
+        "telegram:",
+        "  bot_token: vault:tg-bot",
+        "google_accounts:",
+        "  ws:",
+        "    google_client_secret: vault:gws-secret",
+      ].join("\n"),
+    );
+    expect(r).toHaveLength(1);
+    expect(r[0].status).toBe("ok");
+  });
+
+  it("flags a top-level inlined bot_token and never echoes the value", () => {
+    const secret = "123456:SUPER-SECRET-BOT-TOKEN";
+    const r = run(`telegram:\n  bot_token: ${secret}\n`);
+    const warn = r.find((c) => c.status === "warn");
+    expect(warn).toBeDefined();
+    expect(warn!.name).toContain("telegram.bot_token");
+    // The secret value must NEVER appear in any field of the result.
+    const serialized = JSON.stringify(r);
+    expect(serialized).not.toContain(secret);
+    expect(warn!.fix).toMatch(/switchroom vault set/);
+  });
+
+  it("flags a nested per-agent inlined secret with a dotted path", () => {
+    const r = run(
+      [
+        "agents:",
+        "  klanker:",
+        "    bot_token: 999:INLINED",
+        "  bob:",
+        "    bot_token: vault:bob-tg",
+      ].join("\n"),
+    );
+    const warns = r.filter((c) => c.status === "warn");
+    expect(warns).toHaveLength(1);
+    expect(warns[0].name).toContain("agents.klanker.bot_token");
+  });
+
+  it("flags google_client_secret and *_token / *_secret suffixes", () => {
+    const r = run(
+      [
+        "google_accounts:",
+        "  ws:",
+        "    google_client_secret: gcs-abc123",
+        "custom:",
+        "  refresh_token: rt-literal",
+        "  webhook_secret: wh-literal",
+      ].join("\n"),
+    );
+    const names = r.filter((c) => c.status === "warn").map((c) => c.name);
+    expect(names.some((n) => n.includes("google_client_secret"))).toBe(true);
+    expect(names.some((n) => n.includes("refresh_token"))).toBe(true);
+    expect(names.some((n) => n.includes("webhook_secret"))).toBe(true);
+  });
+
+  it("does not nag on placeholders / empty values", () => {
+    const r = run(
+      [
+        "telegram:",
+        "  bot_token: <your-bot-token>",
+        "a:",
+        "  api_key: changeme",
+        "b:",
+        "  client_secret: ''",
+      ].join("\n"),
+    );
+    expect(r).toHaveLength(1);
+    expect(r[0].status).toBe("ok");
+  });
+
+  it("does not false-positive on benign non-secret keys", () => {
+    const r = run(
+      ["agents:", "  a:", "    topic_name: Health", "    model: opus"].join("\n"),
+    );
+    expect(r[0].status).toBe("ok");
+  });
+
+  it("warns (not throws) on unparseable YAML", () => {
+    const r = run("this: : : not valid yaml: [");
+    expect(r[0].status).toBe("warn");
+  });
+});

--- a/src/cli/doctor-inlined-secrets.ts
+++ b/src/cli/doctor-inlined-secrets.ts
@@ -1,0 +1,169 @@
+/**
+ * doctor-inlined-secrets — WS6-F3 (MEDIUM), audit #1390 / epic #1389.
+ *
+ * `src/agents/compose.ts` bind-mounts the FULL `switchroom.yaml`
+ * read-only into every agent container. Any agent — including a
+ * prompt-injected one — can therefore read the entire fleet config,
+ * and crucially any operator-inlined *plaintext* secret (the schema
+ * permits literal `bot_token` / `google_client_secret` / …; this has
+ * been observed inlined in a real install). That's a direct
+ * cross-agent secret read.
+ *
+ * This is the **proportionate Part 1** remediation: a detection-only
+ * doctor probe that flags secret-shaped keys carrying a literal value
+ * (not a `vault:` reference) and tells the operator to move them into
+ * the per-agent-ACL'd vault. It NEVER rewrites the file and NEVER
+ * echoes a secret value. Part 2 — emitting a per-agent reduced config
+ * instead of the whole file — is a tracked design-led follow-up
+ * (see #1421), not a quick patch.
+ *
+ * DI seam mirrors doctor-drive.ts: tests inject a fake reader; prod
+ * uses real syscalls.
+ */
+
+import { readFileSync as fsReadFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+
+export type CheckStatus = "ok" | "warn" | "fail";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+export interface InlinedSecretDeps {
+  /** Absolute path to the switchroom.yaml the operator runs from. */
+  configPath?: string;
+  /** Reads the raw YAML text. Defaults to fs.readFileSync. */
+  readFileSync?: (p: string) => string;
+}
+
+/**
+ * Secret-shaped key matcher. Deliberately tight — operator-facing
+ * doctor output that cries wolf erodes trust (the consistency /
+ * defaults principle). Matches the exact names the schema permits as
+ * inlinable secrets plus the conventional `*_secret` / `*_token`
+ * suffixes; intentionally NOT bare `*_key` (too many benign hits like
+ * `topic_*`, `*_key` config knobs).
+ */
+const SECRET_KEY_EXACT = new Set([
+  "bot_token",
+  "client_secret",
+  "google_client_secret",
+  "password",
+  "passphrase",
+  "api_key",
+  "secret_key",
+  "private_key",
+  "anthropic_api_key",
+  "openai_api_key",
+]);
+
+function isSecretShapedKey(key: string): boolean {
+  const k = key.toLowerCase();
+  if (SECRET_KEY_EXACT.has(k)) return true;
+  return k.endsWith("_secret") || k.endsWith("_token") || k.endsWith("_apikey");
+}
+
+/** A scalar is "safe" only when it's a `vault:` reference. Empty /
+ *  whitespace / obvious placeholder comments are treated as not-a-leak
+ *  so we don't nag on a fresh scaffold. */
+function isInlinedLiteralSecret(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  const v = value.trim();
+  if (v.length === 0) return false;
+  if (v.startsWith("vault:")) return false; // the sanctioned form
+  // Common "unset" sentinels a setup wizard / example leaves behind.
+  if (/^(changeme|xxx+|<.*>|your[-_ ]?.*|todo)$/i.test(v)) return false;
+  return true;
+}
+
+/** Recursively collect dotted paths of secret-shaped keys whose value
+ *  is an inlined literal. Never collects the value itself. */
+function walk(
+  node: unknown,
+  path: string,
+  out: string[],
+): void {
+  if (Array.isArray(node)) {
+    node.forEach((el, i) => walk(el, `${path}[${i}]`, out));
+    return;
+  }
+  if (node !== null && typeof node === "object") {
+    for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+      const childPath = path.length > 0 ? `${path}.${k}` : k;
+      if (isSecretShapedKey(k) && isInlinedLiteralSecret(v)) {
+        out.push(childPath);
+      } else {
+        walk(v, childPath, out);
+      }
+    }
+  }
+}
+
+/**
+ * @param config the loaded config (unused for the scan itself — we
+ *   read the RAW file because that exact file is what compose
+ *   bind-mounts; but accepted for signature symmetry with the other
+ *   doctor modules and future per-agent scoping).
+ */
+export function runInlinedSecretChecks(
+  _config: SwitchroomConfig,
+  deps: InlinedSecretDeps = {},
+): CheckResult[] {
+  const configPath = deps.configPath;
+  if (!configPath) return []; // no file to scan (e.g. synthetic config)
+  const read = deps.readFileSync ?? ((p: string) => fsReadFileSync(p, "utf8"));
+
+  let raw: string;
+  try {
+    raw = read(configPath);
+  } catch {
+    return []; // unreadable here ≠ a finding; other checks cover that
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch {
+    return [
+      {
+        name: "switchroom.yaml parses",
+        status: "warn",
+        detail: "could not parse switchroom.yaml to scan for inlined secrets",
+      },
+    ];
+  }
+
+  const hits: string[] = [];
+  walk(parsed, "", hits);
+
+  if (hits.length === 0) {
+    return [
+      {
+        name: "No inlined plaintext secrets in switchroom.yaml",
+        status: "ok",
+        detail:
+          "the full switchroom.yaml is bind-mounted read-only into every agent (WS6-F3) — no secret-shaped keys carry a literal value",
+      },
+    ];
+  }
+
+  return hits.map((p) => ({
+    name: `Inlined secret in switchroom.yaml: ${p}`,
+    status: "warn" as const,
+    detail:
+      `\`${p}\` is a literal value, not a \`vault:\` reference. The entire ` +
+      `switchroom.yaml is bind-mounted read-only into EVERY agent ` +
+      `container, so a prompt-injected agent can read this secret and ` +
+      `every other agent's secrets (WS6-F3, #1421).`,
+    fix:
+      `Move it to the per-agent-ACL'd vault: \`switchroom vault set <name>\` ` +
+      `then replace the literal with \`vault:<name>\`. Rotate the exposed ` +
+      `value if any agent may already have read it.`,
+  }));
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -28,6 +28,7 @@ import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runDriveChecks } from "./doctor-drive.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
+import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
 
 /**
  * Result of a single doctor check.
@@ -2220,6 +2221,10 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Skills Prerequisites", results: checkSkillsPrerequisites() },
           { title: "Manifest Drift", results: await checkManifestDrift() },
           { title: "Configuration", results: checkConfig(config, configPath) },
+          {
+            title: "Config secrets (WS6-F3)",
+            results: runInlinedSecretChecks(config, { configPath }),
+          },
           { title: "Legacy State", results: checkLegacyState() },
           { title: "Vault", results: checkVault(config) },
           { title: "Memory (Hindsight)", results: await checkHindsight(config) },


### PR DESCRIPTION
## Summary

**Part 1 of #1421** — WS6-F3 (MEDIUM), audit #1390, epic #1389. Distinct from the WS6-F2 *credentials* fix (#1407, already merged); this is the *config* exposure.

**Finding:** `compose.ts` bind-mounts the **full `switchroom.yaml` read-only into every agent**. Any agent (incl. a prompt-injected one) can read every other agent's config and **any operator-inlined plaintext secret** (the schema permits literal `bot_token` / `google_client_secret`; observed inlined in a real install).

**Part 1 (this PR — proportionate, detection-only):** a new `doctor` probe (`doctor-inlined-secrets.ts`, DI-tested, mirrors the `doctor-drive.ts` module pattern). It scans the **raw `switchroom.yaml`** — the exact file compose mounts — for secret-shaped keys (`bot_token`, `google_client_secret`, `*_secret`, `*_token`, …) whose value is a **literal** rather than a `vault:` reference, and reports each as a `warn` with the dotted path + a "move it to the vault & rotate" fix. It **never rewrites** the file and **never echoes a secret value** (test-asserted). The matcher is deliberately tight (no bare `*_key`) and skips placeholders/empties so it doesn't cry wolf on a fresh scaffold (consistency/defaults principle).

**Part 2 (tracked follow-up, NOT this PR):** emit a *per-agent reduced config* instead of the whole file (kills topology / approver-ID / cross-agent disclosure). Design-led change filed under #1421 — proportionate to do later, akin to WS6-F1 #1413.

## Test plan

- [x] `tsc --noEmit` clean (pre-existing unrelated `@mtcute/node` env error filtered)
- [x] 8 new DI tests (`doctor-inlined-secrets.test.ts`): vault-ref=OK, top-level + nested-per-agent literals flagged with dotted path, **value never echoed**, `google_client_secret`/`*_token`/`*_secret` suffixes, placeholders/empties not nagged, benign keys clean, unparseable-YAML→warn-not-throw
- [x] doctor suites green (`doctor.test.ts` 53, `doctor-drive` 12, repo-hygiene 14, …). The 1 failing `doctor.mff.test.ts` case is **pre-existing & environmental** — reproduces identically on pristine `upstream/main`; my diff does not touch MFF.
- [ ] CI green

Serves JTBD: subscription-honest (secret containment) + always-on fleet safety. Refs #1421 #1390 #1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)