### PR TITLE
fix(compose,image): UID-collision hard-fail + non-root agent image + logdir perms (sec WS6-F4/F5/F6 #1419)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -19,17 +19,22 @@ RUN echo "switchroom/agent building for arch=${TARGETARCH}" >&2
 #
 # /var/log/switchroom is the destination for `_switchroom_supervise`
 # log files (gateway-supervisor, autoaccept, agent-scheduler) written
-# by start.sh. The compose `user:` directive runs start.sh as the
-# per-agent UID (10001-10999, see Dockerfile.base) — but the dir is
-# created here as root with default umask. Without an explicit
-# 0777, start.sh hits "Permission denied" writing the supervisor
-# logs and the three sidecars (gateway / autoaccept / scheduler)
-# never start; the agent then hangs forever on the Claude Code
-# first-run theme picker because autoaccept-poll isn't there to
-# dispatch keystrokes. (Install-validation finding #19.)
+# by start.sh, which runs as a per-agent UID (10001-10999).
+#
+# In the production compose path this dir is bind-mounted from
+# ~/.switchroom/logs/<name> (host-side, chowned to that agent's UID),
+# so the image dir's perms are shadowed entirely. The image perms only
+# matter in a non-compose `docker run` of the image — and there the
+# process runs as the image default `USER 10001` (sec WS6-F5, set at
+# the end of this file). So chown to the sentinel UID 10001 + 0755 is
+# both correct for the unshadowed path AND closes WS6-F6: pre-#1419
+# this was `chmod 0777` (world-writable in any unshadowed run — finding
+# #19's fix, but over-broad). 10001 = AGENT_UID_MIN (Dockerfile.base
+# pre-creates passwd entries for 10001-10999).
 RUN mkdir -p /state/agent /state/.claude /var/log/switchroom \
  && mkdir -p /run/switchroom \
- && chmod 0777 /var/log/switchroom
+ && chown 10001:10001 /var/log/switchroom \
+ && chmod 0755 /var/log/switchroom
 
 # Make sure tmux's runtime dir exists; the per-agent UID will own it via
 # the compose `user:` directive at runtime.
@@ -168,6 +173,17 @@ COPY telegram-plugin/dist /opt/switchroom/telegram-plugin/dist
 # agent-scheduler bundle. node-cron was npm-installed above; this COPY
 # only drops the (frequently-changing) bundle into the existing dir.
 COPY dist/agent-scheduler/index.js /opt/switchroom/agent-scheduler/index.js
+
+# sec WS6-F5 (#1419): non-root image default. Pre-#1419 the agent
+# image had NO `USER`, so its effective default was root — all agent
+# privilege-reduction was compose-emitted only (the four root
+# singletons even bake `USER 0:0`, so least-privilege was inverted for
+# the agent). Set the image default to the sentinel non-root UID so
+# root is never the effective default even on a non-compose `docker
+# run`. The compose path's per-agent `user: <10001-10999>` still
+# overrides this at runtime; 10001 has a passwd entry from
+# Dockerfile.base. Placed last — every preceding COPY/RUN needs root.
+USER 10001
 
 # tini handles zombies + signal forwarding. The actual command is
 # /state/agent/start.sh, which the scaffold renders into the bind-mount.

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -186,6 +186,44 @@ export function allocateAgentUid(name: string): number {
   return AGENT_UID_MIN + (u32 % range);
 }
 
+/**
+ * sec WS6-F4 (#1419): UID collision is a HARD FAIL at compose
+ * generation, not a doctor warning.
+ *
+ * `allocateAgentUid` is a hash mod 999, so two agent names can map to
+ * the same UID. Pre-#1419 this was only an advisory `doctor` check —
+ * `apply` would silently emit a compose file where the colliding pair
+ * share a UID, collapsing per-agent file-ownership isolation (each
+ * can read/write the other's credentials, vault socket, scaffold).
+ * That's a silent isolation failure reachable with zero operator
+ * intent, so the right posture is fail-closed: refuse to generate
+ * compose until the operator renames a collider. Deterministic
+ * allocation is preserved (no name→UID persisted map, no chown-sweep
+ * migration risk); the operator picks the rename.
+ */
+export function assertNoAgentUidCollision(config: SwitchroomConfig): void {
+  const byUid = new Map<number, string[]>();
+  for (const name of Object.keys(config.agents ?? {})) {
+    const uid = allocateAgentUid(name);
+    const names = byUid.get(uid);
+    if (names) names.push(name);
+    else byUid.set(uid, [name]);
+  }
+  const collisions = [...byUid.entries()].filter(([, n]) => n.length > 1);
+  if (collisions.length === 0) return;
+  const detail = collisions
+    .map(([uid, n]) => `  UID ${uid} ← ${n.sort().join(", ")}`)
+    .join("\n");
+  throw new Error(
+    `agent UID collision — refusing to generate compose (sec WS6-F4 / #1419).\n` +
+      `These agents hash to the same container UID, which collapses their ` +
+      `file-ownership isolation (each could read the other's credentials / ` +
+      `vault socket / scaffold):\n${detail}\n` +
+      `Rename one agent in each colliding set (the UID is a deterministic ` +
+      `hash of the name) and re-run. \`switchroom doctor\` also reports this.`,
+  );
+}
+
 export interface ComposeGeneratorOptions {
   config: SwitchroomConfig;
   /** Image tag — same for every service in a release. */
@@ -640,6 +678,9 @@ function readStrippedCaps(agent: AgentConfig): string[] {
  */
 export function generateCompose(opts: ComposeGeneratorOptions): string {
   const { config } = opts;
+  // sec WS6-F4 (#1419): fail-closed before emitting anything if two
+  // agents would share a container UID.
+  assertNoAgentUidCollision(config);
   const imageTag = opts.imageTag ?? "latest";
   const warn = opts.warn ?? ((m: string) => process.stderr.write(m + "\n"));
   const buildMode = opts.buildMode ?? "pull";

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -24,6 +24,7 @@ import { describe, it, expect } from "vitest";
 import {
   generateCompose,
   allocateAgentUid,
+  assertNoAgentUidCollision,
   AGENT_UID_MIN,
   AGENT_UID_MAX,
   describeAgents,
@@ -76,6 +77,48 @@ function makeConfig(
     host_control: topLevel?.host_control,
   } as unknown as SwitchroomConfig;
 }
+
+// Discover a real colliding name pair deterministically (don't
+// hard-code a brittle SHA-derived pair). 999 UID buckets → a scan of
+// a few hundred candidates always finds one (birthday paradox).
+function findCollidingPair(): [string, string] {
+  const seen = new Map<number, string>();
+  for (let i = 0; i < 20000; i++) {
+    const name = `coll-agent-${i}`;
+    const uid = allocateAgentUid(name);
+    const prev = seen.get(uid);
+    if (prev) return [prev, name];
+    seen.set(uid, name);
+  }
+  throw new Error("no collision found in 20000 candidates (impossible for 999 buckets)");
+}
+
+describe("assertNoAgentUidCollision — sec WS6-F4 (#1419)", () => {
+  it("passes for a distinct-UID fleet", () => {
+    expect(() =>
+      assertNoAgentUidCollision(makeConfig({ klanker: {}, bob: {} })),
+    ).not.toThrow();
+  });
+
+  it("HARD-FAILS (not warn) when two agents share a UID", () => {
+    const [a, b] = findCollidingPair();
+    expect(allocateAgentUid(a)).toBe(allocateAgentUid(b));
+    expect(() =>
+      assertNoAgentUidCollision(makeConfig({ [a]: {}, [b]: {} })),
+    ).toThrow(/UID collision.*WS6-F4|WS6-F4.*collision/s);
+  });
+
+  it("generateCompose refuses to emit on a collision (fail-closed)", () => {
+    const [a, b] = findCollidingPair();
+    expect(() =>
+      generateCompose({ config: makeConfig({ [a]: {}, [b]: {} }) }),
+    ).toThrow(/UID collision/);
+    // …and still emits normally for a clean fleet.
+    expect(() =>
+      generateCompose({ config: makeConfig({ klanker: {}, bob: {} }) }),
+    ).not.toThrow();
+  });
+});
 
 describe("allocateAgentUid", () => {
   it("returns UID in the reserved range", () => {
@@ -308,12 +351,16 @@ describe("generateCompose", () => {
   });
 
   it("each agent mounts ONLY its own broker socket volume", () => {
-    const out = generateCompose({ config: makeConfig({ a: {}, b: {}, c: {} }) });
+    // NB: "c" hashes to the same UID as "a" (10939) — pre-#1419 this
+    // fixture silently demonstrated the exact WS6-F4 collision; the
+    // new hard-fail guard rejects it. Use "d" (distinct UID) so the
+    // test exercises the broker-socket scoping, not the guard.
+    const out = generateCompose({ config: makeConfig({ a: {}, b: {}, d: {} }) });
     // Pull the volumes block of agent-a; it must only mention broker-a-sock.
     const aBlock = /agent-a:[\s\S]*?(?=\n  agent-|\nvolumes:)/.exec(out)?.[0] ?? "";
     expect(aBlock).toContain("broker-a-sock");
     expect(aBlock).not.toContain("broker-b-sock");
-    expect(aBlock).not.toContain("broker-c-sock");
+    expect(aBlock).not.toContain("broker-d-sock");
   });
 
   it("byte-determinism: same input → same output", () => {


### PR DESCRIPTION
## Summary

Coherent WS6 image/compose hardening batch — **WS6-F4/F5/F6** (MED/LOW), audit #1390, epic #1389.

- **WS6-F4 (MED) — UID-collision is now fail-closed.** `allocateAgentUid` is `SHA256(name) mod 999`; two names can map to the same container UID, collapsing the colliding pair's file-ownership isolation (each can read the other's credentials / vault socket / scaffold). Pre-#1419 this was only an advisory `doctor` warning — `apply` silently emitted the broken compose. `generateCompose` now calls `assertNoAgentUidCollision()` and **hard-fails** with an actionable rename message before emitting anything. Deterministic allocation preserved (no persisted name→UID map → no chown-sweep migration risk). This **surfaced + fixed a pre-existing latent collision in an existing test fixture** (`a` and `c` both hash to UID 10939 — the exact WS6-F4 condition the old fixture unknowingly demonstrated).
- **WS6-F5 (MED) — non-root image default.** `Dockerfile.agent` had no `USER`, so its effective default was root (the root singletons even bake `USER 0:0` — least-privilege was inverted for the agent). Added `USER 10001` (sentinel non-root UID, passwd entry from `Dockerfile.base`) as the final directive. Per-agent compose `user:` still overrides at runtime.
- **WS6-F6 (LOW) — logdir perms.** `/var/log/switchroom` was `chmod 0777` (world-writable in any unshadowed run). Now `chown 10001:10001` + `0755`: shadowed by the per-agent bind-mount in the compose path; in a non-compose `docker run` the process is now `USER 10001` so it still owns the dir (the finding-#19 supervisor-log regression is avoided) and it's no longer world-writable.

## Test plan

- [x] `tsc --noEmit` clean (pre-existing unrelated `@mtcute/node` env error filtered)
- [x] `tests/docker/compose-generator.test.ts` — 134 pass incl. 3 new WS6-F4 tests (clean fleet OK; hard-fail on a programmatically-discovered colliding pair; `generateCompose` refuses to emit) + the latent-collision fixture de-collided (`c`→`d`)
- [x] other `generateCompose`-calling suites (`broker-ipc-race`, `compose-generator-posthog`, `per-agent-isolation`, `doctor-checks`) green — no other fixture trips the new guard
- [ ] CI green
- [ ] post-merge: Dockerfile F5/F6 land via agent-image rebuild; WS9-F1 image sentinel + a non-compose `docker run` smoke confirm `USER 10001` + logdir `0755`

Serves JTBD: always-on fleet safety (per-agent isolation integrity). Refs #1419 #1390 #1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)