### PR TITLE
fix(audit,doctor): canonical agent_name attribution + audit-integrity doctor (sec WS10-F6/F4 #1420 PR-A)

### DIFF
--- a/src/cli/doctor-audit-integrity.test.ts
+++ b/src/cli/doctor-audit-integrity.test.ts
@@ -1,0 +1,89 @@
+/**
+ * doctor-audit-integrity — WS10-F4 (#1420). Pins the detection
+ * contract: missing/empty/unchained-legacy → warn (actionable, not a
+ * tamper signal), chained-valid → ok, chained-broken → fail.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { runAuditIntegrityChecks } from "./doctor-audit-integrity.js";
+import { chainRow, CHAIN_GENESIS, type ChainState } from "../util/audit-hashchain.js";
+
+const HOME = "/h";
+const VAULT = "/h/.switchroom/vault-audit.log";
+const HOSTD = "/h/.switchroom/host-control-audit.log";
+
+function chainedLog(rows: Record<string, unknown>[]): string {
+  let st: ChainState = { seq: 0, lastHash: CHAIN_GENESIS };
+  let t = "";
+  for (const r of rows) {
+    const { line, next } = chainRow(st, r);
+    t += line;
+    st = next;
+  }
+  return t;
+}
+
+/** A reader that serves `files[path]`; absent path → throw (ENOENT). */
+function reader(files: Record<string, string>) {
+  return (p: string) => {
+    if (!(p in files)) throw new Error("ENOENT");
+    return files[p];
+  };
+}
+
+function run(files: Record<string, string>) {
+  return runAuditIntegrityChecks({ homeDir: HOME, readFileSync: reader(files) });
+}
+
+describe("runAuditIntegrityChecks", () => {
+  it("warns when a root audit log is missing", () => {
+    const r = run({ [VAULT]: chainedLog([{ ts: "t", op: "get" }]) });
+    const hostd = r.find((c) => c.name.includes("hostd audit log present"));
+    expect(hostd?.status).toBe("warn");
+  });
+
+  it("warns when a log exists but is empty (F3 fail-open symptom)", () => {
+    const r = run({ [VAULT]: "", [HOSTD]: chainedLog([{ ts: "t", op: "x" }]) });
+    expect(
+      r.find((c) => c.name.includes("vault-broker audit log non-empty"))?.status,
+    ).toBe("warn");
+  });
+
+  it("warns (NOT fail) on a pre-#1433 legacy unchained log", () => {
+    const legacy =
+      JSON.stringify({ ts: "t", op: "get", caller: "c", pid: 1, result: "allowed" }) +
+      "\n";
+    const r = run({ [VAULT]: legacy, [HOSTD]: legacy });
+    const c = r.find((x) => x.name.includes("vault-broker audit tamper-evidence"));
+    expect(c?.status).toBe("warn");
+    expect(c?.detail).toMatch(/legacy log/);
+  });
+
+  it("ok when the chain verifies from genesis", () => {
+    const good = chainedLog([
+      { ts: "t1", op: "get" },
+      { ts: "t2", op: "put" },
+    ]);
+    const r = run({ [VAULT]: good, [HOSTD]: good });
+    expect(
+      r.filter((c) => c.name.includes("audit chain valid") && c.status === "ok"),
+    ).toHaveLength(2);
+  });
+
+  it("FAILS when a chained log was tampered", () => {
+    const good = chainedLog([
+      { ts: "t1", op: "get", key: "a" },
+      { ts: "t2", op: "put", key: "b" },
+    ]);
+    const lines = good.trim().split("\n");
+    const row0 = JSON.parse(lines[0]);
+    row0.key = "TAMPERED";
+    lines[0] = JSON.stringify(row0);
+    const tampered = lines.join("\n") + "\n";
+    const r = run({ [VAULT]: tampered, [HOSTD]: chainedLog([{ ts: "t", op: "x" }]) });
+    const broken = r.find((c) => c.name.includes("vault-broker audit chain BROKEN"));
+    expect(broken?.status).toBe("fail");
+    expect(broken?.detail).toMatch(/row 1/);
+  });
+});

--- a/src/cli/doctor-audit-integrity.ts
+++ b/src/cli/doctor-audit-integrity.ts
@@ -1,0 +1,141 @@
+/**
+ * doctor-audit-integrity — WS10-F4 (MEDIUM), audit #1403 / epic #1389.
+ *
+ * Pre-#1420 `doctor` had ZERO audit-integrity detection: nothing
+ * checked that the vault / hostd audit logs are actually being
+ * written, haven't been truncated, or — once #1417/#1433 landed the
+ * per-row hash chain — that the chain still verifies. Audit-blinding
+ * is a cheap pre-attack step (WS10-F3: vault audit fails OPEN), so a
+ * silently-empty or rewritten log must surface to the operator.
+ *
+ * This probe (DI-testable, mirrors doctor-drive.ts /
+ * doctor-inlined-secrets.ts) reports per root-written log:
+ *   - missing            → warn (no audit trail at all)
+ *   - empty              → warn (audit-blinding / F3 fail-open symptom)
+ *   - present, unchained → warn, ACTIONABLE: deploy the post-#1433
+ *     broker/hostd image to enable tamper-evidence (NOT a fail — a
+ *     pre-chain legacy log is expected during the rollout window)
+ *   - chained + valid    → ok
+ *   - chained + BROKEN   → fail (tamper signal: a row was edited,
+ *     deleted, reordered, or the head truncated)
+ *
+ * Scope note: this is the F4 *detection* half. F3 (a configurable
+ * fail-closed secret-release mode + the fail-open counter) and F5
+ * (proactive integrity events) are the higher-risk / cross-cutting
+ * follow-up (tracked on #1420) — deliberately not bundled.
+ */
+
+import { readFileSync as fsReadFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { verifyAuditChain, CHAIN_GENESIS } from "../util/audit-hashchain.js";
+
+export type CheckStatus = "ok" | "warn" | "fail";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+export interface AuditIntegrityDeps {
+  /** Override the home dir used to resolve default log paths. */
+  homeDir?: string;
+  /** Reads a log file's text. Defaults to fs.readFileSync; a thrown
+   *  ENOENT is treated as "missing". */
+  readFileSync?: (p: string) => string;
+}
+
+interface LogTarget {
+  label: string;
+  path: string;
+}
+
+function rootWrittenLogs(home: string): LogTarget[] {
+  return [
+    { label: "vault-broker", path: join(home, ".switchroom", "vault-audit.log") },
+    {
+      label: "hostd",
+      path: join(home, ".switchroom", "host-control-audit.log"),
+    },
+  ];
+}
+
+/** True when the first non-empty row carries the chain fields. A
+ *  wholly-unchained file is a pre-#1433 legacy log, not tampering. */
+function looksChained(text: string): boolean {
+  for (const raw of text.split("\n")) {
+    if (raw.length === 0) continue;
+    try {
+      const o = JSON.parse(raw) as { _seq?: unknown };
+      return typeof o._seq === "number";
+    } catch {
+      return false; // first row not JSON → let verify report it
+    }
+  }
+  return false;
+}
+
+export function runAuditIntegrityChecks(
+  deps: AuditIntegrityDeps = {},
+): CheckResult[] {
+  const home = deps.homeDir ?? homedir();
+  const read =
+    deps.readFileSync ?? ((p: string) => fsReadFileSync(p, "utf8"));
+  const results: CheckResult[] = [];
+
+  for (const { label, path } of rootWrittenLogs(home)) {
+    let text: string;
+    try {
+      text = read(path);
+    } catch {
+      results.push({
+        name: `${label} audit log present`,
+        status: "warn",
+        detail: `no audit log at ${path} — the ${label} may never have written one, or it was removed (audit-blinding is a cheap pre-attack step; WS10-F3/F4)`,
+        fix: `Confirm the ${label} is running and its audit volume is mounted; investigate if the file vanished.`,
+      });
+      continue;
+    }
+
+    if (text.trim().length === 0) {
+      results.push({
+        name: `${label} audit log non-empty`,
+        status: "warn",
+        detail: `${path} exists but is empty — expected at least boot/activity rows; an emptied audit trail is the WS10-F3 fail-open symptom`,
+        fix: `Investigate whether audit writes are failing (check ${label} stderr) and whether the file was truncated.`,
+      });
+      continue;
+    }
+
+    if (!looksChained(text)) {
+      results.push({
+        name: `${label} audit tamper-evidence`,
+        status: "warn",
+        detail: `${path} is present but its rows are NOT hash-chained — this is a pre-#1433 legacy log; tamper-evidence is inactive until the post-#1433 ${label} image is deployed`,
+        fix: `Run \`switchroom update\` to roll the ${label} image forward (#1433 added the chain). Expected during the rollout window; not itself a tamper signal.`,
+      });
+      continue;
+    }
+
+    const v = verifyAuditChain(text, CHAIN_GENESIS);
+    if (v.ok) {
+      results.push({
+        name: `${label} audit chain valid`,
+        status: "ok",
+        detail: `${v.rows} rows, hash chain intact from genesis`,
+      });
+    } else {
+      results.push({
+        name: `${label} audit chain BROKEN`,
+        status: "fail",
+        detail: `${path}: chain breaks at row ${v.brokenAtLine} — ${v.reason}. A row was edited, deleted, reordered, or the head was truncated (WS10-F2 tamper signal).`,
+        fix: `Treat the ${label} audit trail as compromised from row ${v.brokenAtLine} onward. Preserve the file for forensics; investigate host/broker compromise before trusting subsequent rows.`,
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -29,6 +29,7 @@ import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runDriveChecks } from "./doctor-drive.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
 import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
+import { runAuditIntegrityChecks } from "./doctor-audit-integrity.js";
 
 /**
  * Result of a single doctor check.
@@ -2231,6 +2232,7 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Telegram", results: await checkTelegram(config) },
           { title: "Agents", results: checkAgents(config, configPath) },
           { title: "Credentials", results: runCredentialsMigrationChecks(config) },
+          { title: "Audit integrity (WS10-F4)", results: runAuditIntegrityChecks() },
           { title: "Docker (Phase 1a)", results: runDockerSection(config) },
           { title: "Auth Broker", results: runAuthBrokerChecks(config) },
           { title: "Google Drive", results: runDriveChecks(config) },

--- a/src/vault/audit-reader.ts
+++ b/src/vault/audit-reader.ts
@@ -56,6 +56,14 @@ export function parseAuditLine(line: string): AuditEntry | null {
       caller: obj.caller,
       pid: obj.pid,
       cgroup: typeof obj.cgroup === "string" ? obj.cgroup : undefined,
+      // sec WS10-F6 (#1420): `agent_name` is the socket-path-derived
+      // TRUSTED identity (the ACL field). Pre-#1420 parseAuditLine
+      // dropped it, so every consumer attributed by `caller` (cgroup
+      // unit OR `pid:<n>` — frequently null/legacy post-docker, #1383
+      // identity drift). Surface it so it can be the canonical
+      // attribution; caller/cgroup are informational.
+      agent_name:
+        typeof obj.agent_name === "string" ? obj.agent_name : undefined,
       result: obj.result,
     };
   } catch {
@@ -75,7 +83,14 @@ export function filterAuditEntries(
 
   if (filters.who !== undefined) {
     const needle = filters.who.toLowerCase();
-    result = result.filter((e) => e.caller.toLowerCase().includes(needle));
+    // sec WS10-F6 (#1420): match the canonical trusted agent_name too,
+    // not just the informational caller — otherwise filtering by an
+    // agent's real name misses rows where caller drifted to pid:<n>.
+    result = result.filter(
+      (e) =>
+        e.caller.toLowerCase().includes(needle) ||
+        (e.agent_name?.toLowerCase().includes(needle) ?? false),
+    );
   }
 
   if (filters.key !== undefined) {
@@ -104,9 +119,14 @@ export function filterAuditEntries(
 /**
  * Format a single AuditEntry as a human-readable line.
  *
- * Format: timestamp · op · key · caller · result
- * Example:
- *   2026-04-28 14:33:00  get    stripe/live-key       switchroom-my-agent-cron-0.service  allowed
+ * Format: timestamp · op · key · who · result
+ *
+ * sec WS10-F6 (#1420): `who` is the TRUSTED `agent_name`
+ * (socket-path-derived, the ACL field) when present, falling back to
+ * the informational `caller` (cgroup unit / `pid:<n>`) only on the
+ * legacy/host paths where no agent_name was recorded. Pre-#1420 this
+ * displayed `caller` unconditionally, so post-docker identity drift
+ * (#1383) routinely showed `pid:<n>` for a known agent.
  */
 export function formatAuditEntry(entry: AuditEntry): string {
   // Shorten ISO timestamp to local-ish display: "2026-04-28 14:33:00"
@@ -114,15 +134,14 @@ export function formatAuditEntry(entry: AuditEntry): string {
 
   const op = entry.op.padEnd(8);
   const key = (entry.key ?? "(no key)").padEnd(28);
-  // Truncate long caller names for readability
-  const caller =
-    entry.caller.length > 50
-      ? entry.caller.slice(0, 47) + "..."
-      : entry.caller;
-  const callerPadded = caller.padEnd(52);
+  // Canonical attribution: trusted agent_name first, caller as fallback.
+  const whoRaw = entry.agent_name ?? entry.caller;
+  const who =
+    whoRaw.length > 50 ? whoRaw.slice(0, 47) + "..." : whoRaw;
+  const whoPadded = who.padEnd(52);
   const result = entry.result;
 
-  return `${ts}  ${op}  ${key}  ${callerPadded}  ${result}`;
+  return `${ts}  ${op}  ${key}  ${whoPadded}  ${result}`;
 }
 
 /**

--- a/tests/vault-audit.test.ts
+++ b/tests/vault-audit.test.ts
@@ -234,3 +234,53 @@ describe("formatAuditLines", () => {
     expect(result).toHaveLength(50);
   });
 });
+
+// ── WS10-F6 (#1420): agent_name attribution ────────────────────────────────
+
+describe("WS10-F6 — agent_name canonical attribution", () => {
+  const chained = JSON.stringify({
+    ts: "2026-05-17T00:00:00.000Z",
+    op: "get",
+    key: "k",
+    caller: "pid:9999", // drifted/legacy informational identity
+    pid: 9999,
+    agent_name: "klanker", // trusted socket-path identity
+    result: "allowed",
+  });
+
+  it("parseAuditLine surfaces agent_name (previously dropped)", () => {
+    const e = parseAuditLine(chained)!;
+    expect(e).not.toBeNull();
+    expect(e.agent_name).toBe("klanker");
+    expect(e.caller).toBe("pid:9999");
+  });
+
+  it("formatAuditEntry shows the trusted agent_name, not the drifted caller", () => {
+    const e = parseAuditLine(chained)!;
+    const line = formatAuditEntry(e);
+    expect(line).toContain("klanker");
+    expect(line).not.toContain("pid:9999");
+  });
+
+  it("formatAuditEntry falls back to caller when no agent_name (host/legacy rows)", () => {
+    const e = parseAuditLine(
+      JSON.stringify({
+        ts: "2026-05-17T00:00:00.000Z",
+        op: "unlock",
+        caller: "switchroom-host.service",
+        pid: 1,
+        result: "allowed",
+      }),
+    )!;
+    expect(e.agent_name).toBeUndefined();
+    expect(formatAuditEntry(e)).toContain("switchroom-host.service");
+  });
+
+  it("--who filter matches the canonical agent_name even when caller drifted", () => {
+    const e = parseAuditLine(chained)!;
+    expect(filterAuditEntries([e], { who: "klanker" })).toHaveLength(1);
+    // still matches the informational caller too (back-compat)
+    expect(filterAuditEntries([e], { who: "pid:9999" })).toHaveLength(1);
+    expect(filterAuditEntries([e], { who: "nope" })).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

**PR-A of #1420** (audit #1403, epic #1389) — the bounded, fully in-repo-verifiable detection/attribution half.

- **WS10-F6 — attribution.** `parseAuditLine` (`src/vault/audit-reader.ts`) structurally **dropped `agent_name`** (the socket-path-derived **trusted** ACL identity), so every consumer attributed by `caller` (cgroup unit OR `pid:<n>` — frequently null/legacy post-docker, #1383 identity drift). Now: `parseAuditLine` surfaces it; `formatAuditEntry` shows `agent_name` as the canonical identity (falls back to `caller` only on legacy/host rows where none was recorded); the `--who` filter matches `agent_name` too. `caller`/`cgroup` are now informational.
- **WS10-F4 — doctor audit-integrity detection (there was none).** New DI-testable `doctor-audit-integrity.ts` (mirrors `doctor-drive` / `doctor-inlined-secrets`) checks the two root-written logs: missing → `warn`, empty → `warn` (the F3 fail-open symptom), **pre-#1433 unchained legacy → `warn` (actionable: deploy the chained image; explicitly NOT a tamper `fail` during the rollout window)**, chained+valid → `ok`, chained+**BROKEN** → `fail` (consumes the merged #1433 `verifyAuditChain`, names the broken row). Wired as a new doctor section.

## Deliberately scoped (PR-B, tracked on #1420)

**F3** (a configurable *fail-closed* secret-release mode + the fail-open counter) is a secret-release **behaviour change** needing a config knob (default must stay fail-open for compat) + a broker image rebuild. **F5** (proactive integrity events) is cross-cutting (ties #1416 boot-integrity + the approval kernel). Both are higher-risk → separate focused PR-B, not bundled into a detection PR.

## Test plan

- [x] `tsc --noEmit` clean (pre-existing unrelated `@mtcute/node` env error filtered)
- [x] 72 tests green: 5 new F4 (`doctor-audit-integrity.test.ts` — missing/empty/legacy-unchained/valid/tampered) + 4 new F6 (`vault-audit.test.ts` — agent_name surfaced, canonical in format, caller fallback, `--who` matches agent_name) + **no regression** in audit-reader/audit-log/host-control-audit-reader
- [x] doctor suites green (73) — new section doesn't break section-set tests
- [ ] CI green

Serves JTBD: always-on fleet safety + forensic integrity/attribution. Refs #1420 #1403 #1389. Cross-links #1433 (chain), #1416 (F5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)