### PR TITLE
ci(security): image provenance/SBOM + pin base images @sha256 (sec WS9-F3/F4 #1418)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# sec WS9-F4 (#1418), epic #1389 — supply-chain image integrity.
+#
+# WS9-F4 pins the fleet's base images by @sha256 digest
+# (docker/Dockerfile.base, docker/Dockerfile.hindsight). A pinned
+# digest is only safe if there's a *reviewed* path to move it forward
+# when upstream ships security fixes — otherwise operators run a
+# frozen, eventually-vulnerable base. Dependabot's `docker` ecosystem
+# raises those digest bumps as PRs (gated by the same 15 required
+# checks as any other change). The `github-actions` ecosystem does the
+# same for the SHA-pinned actions introduced by #1405/WS9-F1/F6 —
+# without it those pins rot the same way.
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "security"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "security"

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -123,6 +123,11 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=base
           cache-to: type=gha,mode=max,scope=base
+          # sec WS9-F3 (#1418): signed build provenance + SBOM so an
+          # operator's `switchroom update` pull can verify the image
+          # was built by THIS pipeline from THIS source (SLSA-style).
+          provenance: mode=max
+          sbom: true
           # CACHE_BUST is paired with the `ARG CACHE_BUST` in
           # Dockerfile.base immediately before `npm install -g
           # @anthropic-ai/claude-code@latest`. `github.run_attempt`
@@ -217,6 +222,9 @@ jobs:
             BASE_IMAGE=${{ steps.tags.outputs.base }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+          # sec WS9-F3 (#1418): provenance + SBOM on every fleet image.
+          provenance: mode=max
+          sbom: true
 
   build-hindsight:
     # Hindsight extends upstream `ghcr.io/vectorize-io/hindsight:latest`
@@ -268,3 +276,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=hindsight
           cache-to: type=gha,mode=max,scope=hindsight
+          # sec WS9-F3 (#1418): provenance + SBOM on the hindsight image too.
+          provenance: mode=max
+          sbom: true

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -10,7 +10,12 @@
 # ARG TARGETARCH is informational here (logged at build time for forensics).
 ARG TARGETARCH=amd64
 
-FROM node:22-bookworm-slim
+# sec WS9-F4 (#1418): pinned by digest. The mutable `:22-bookworm-slim`
+# tag is the base for the WHOLE fleet (incl. the root singletons); an
+# upstream tag repoint would flow into published images undetected.
+# Tag retained for readability + Dependabot `docker` ecosystem, which
+# raises digest bumps as reviewed PRs (.github/dependabot.yml).
+FROM node:22-bookworm-slim@sha256:689c11043dad91472750cd824c97dd5e2318e9dd6f954e492fe7af0135d33ceb
 
 ARG TARGETARCH
 RUN echo "switchroom/base building for arch=${TARGETARCH}" >&2

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -27,7 +27,10 @@
 # before exec'ing the upstream start-all.sh. The credentials never
 # touch persistent disk and the broker remains the single writer of
 # OAuth state (RFC H invariant).
-FROM ghcr.io/vectorize-io/hindsight:latest
+# sec WS9-F4 (#1418): pinned by digest — third-party mutable `:latest`
+# from another org; an upstream repoint would otherwise flow into the
+# published hindsight image undetected. Dependabot tracks bumps.
+FROM ghcr.io/vectorize-io/hindsight:latest@sha256:f0f9e9a73d6aedde9eaf4010ab604c3e015494e494318b26f1011144856b8112
 
 USER root
 


### PR DESCRIPTION
## Summary

Supply-chain image-integrity batch — **WS9-F3 + WS9-F4** (MED), audit #1402, epic #1389. No logic risk; same proven SHA-pin pattern as merged #1405 (WS9-F6).

- **WS9-F3 — provenance/SBOM.** `docker-images.yml` published `ghcr.io/switchroom/switchroom-*` with **no** provenance/SBOM, so an operator's `switchroom update` pull couldn't verify the image came from this pipeline/source. Added `provenance: mode=max` + `sbom: true` to **all three** `docker/build-push-action` steps (base · the 5-image dependent matrix · hindsight).
- **WS9-F4 — pin base images.** `Dockerfile.base` `FROM node:22-bookworm-slim` (base for the **whole fleet**, incl. root singletons) and `Dockerfile.hindsight` `FROM ghcr.io/vectorize-io/hindsight:latest` (third-party mutable) were unpinned — an upstream tag repoint would flow into published fleet images undetected. Pinned both to their **current `@sha256` index digests, resolved live** (`node`=`689c1104…`, `hindsight`=`f0f9e9a7…`); tag retained for readability + Dependabot. Added `.github/dependabot.yml` enabling the `docker` ecosystem (digest bumps via reviewed PRs — required so a pinned base still receives upstream security fixes) and `github-actions` (keeps #1405's SHA-pinned actions from rotting — same supply-chain concern).

## Test plan

- [x] `.github/workflows/docker-images.yml` + `.github/dependabot.yml` valid YAML
- [x] both `FROM` lines carry a real resolved `@sha256:` digest; `provenance`+`sbom` present on all 3 build steps
- [x] touches `docker/**` + `.github/workflows/**` → covered by the WS9-F1 sentinel-filter (#1405), so CI actually exercises it
- [ ] CI green
- [ ] post-merge: first `docker-images` run publishes attestations; a subsequent Dependabot digest-bump PR confirms the review loop

No application code changed (zero vitest surface). Serves JTBD: subscription-honest + always-on (operators run verifiable, reproducible images). Refs #1418 #1402 #1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)