### PR TITLE
fix(atomic): O_NOFOLLOW + O_EXCL on the broker tempfile open (sec #1410)

### DIFF
--- a/src/util/atomic.test.ts
+++ b/src/util/atomic.test.ts
@@ -1,0 +1,78 @@
+/**
+ * atomic — sec #1410 (TOCTOU follow-up to CRITICAL #1393). The two
+ * brokers run as ROOT through this primitive, so the symlink-safety
+ * guarantees matter. Pre-#1410 atomic.ts had no direct test.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  symlinkSync,
+  readFileSync,
+  lstatSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { atomicWriteFileSync, atomicWriteJsonSync } from "./atomic.js";
+
+describe("atomicWriteFileSync", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "atomic-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes content at 0600 by default and leaves no tempfile", () => {
+    const p = join(dir, "secret.json");
+    atomicWriteFileSync(p, "hello");
+    expect(readFileSync(p, "utf8")).toBe("hello");
+    expect(statSync(p).mode & 0o777).toBe(0o600);
+    // No `.tmp-` leak on the success path.
+    expect(readdirSync(dir).filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  it("atomically replaces an existing regular file", () => {
+    const p = join(dir, "f");
+    writeFileSync(p, "OLD");
+    atomicWriteFileSync(p, "NEW");
+    expect(readFileSync(p, "utf8")).toBe("NEW");
+  });
+
+  it("atomicWriteJsonSync writes pretty JSON + trailing newline", () => {
+    const p = join(dir, "c.json");
+    atomicWriteJsonSync(p, { a: 1 });
+    expect(readFileSync(p, "utf8")).toBe('{\n  "a": 1\n}\n');
+  });
+
+  // THE security property (#1393/#1410): if the destination is an
+  // attacker-planted symlink to a sensitive file, the write must NOT
+  // follow it — rename(2) replaces the symlink itself, so the pointed-
+  // at victim is never modified and dest becomes a real file.
+  it("does not write through a symlinked destination (no symlink-follow)", () => {
+    const victim = join(dir, "victim-secret");
+    writeFileSync(victim, "SECRET-UNTOUCHED");
+    const dest = join(dir, "dest");
+    symlinkSync(victim, dest);
+    expect(lstatSync(dest).isSymbolicLink()).toBe(true);
+
+    atomicWriteFileSync(dest, "ATTACKER-CONTROLLED-PAYLOAD");
+
+    // dest is now a regular file with the new bytes …
+    expect(lstatSync(dest).isSymbolicLink()).toBe(false);
+    expect(readFileSync(dest, "utf8")).toBe("ATTACKER-CONTROLLED-PAYLOAD");
+    // … and the symlink's victim was NEVER written through.
+    expect(readFileSync(victim, "utf8")).toBe("SECRET-UNTOUCHED");
+  });
+
+  it("propagates errors fail-closed (bad dir → throws, dest untouched)", () => {
+    const p = join(dir, "nope", "deep", "x");
+    expect(() => atomicWriteFileSync(p, "data")).toThrow();
+  });
+});

--- a/src/util/atomic.ts
+++ b/src/util/atomic.ts
@@ -39,8 +39,9 @@ import { closeSync, constants, fsyncSync, openSync, renameSync, rmSync, writeSyn
  * attacker who wins the race could plant a symlink at the tempfile
  * path and have the root broker write a secret through it.
  *
- *   - `O_NOFOLLOW` — if the final component is a symlink, fail (ELOOP)
- *     instead of following it. Closes the planted-symlink race.
+ *   - `O_NOFOLLOW` — if the final component is a symlink, fail
+ *     instead of following it (ELOOP; or EEXIST when O_EXCL fires
+ *     first on the planted inode). Closes the planted-symlink race.
  *   - `O_EXCL` (with `O_CREAT`) — the open MUST create the file; fail
  *     if anything already exists at the tempfile path. The temp name
  *     is unique per-pid + 4 random bytes so this never trips in

--- a/src/util/atomic.ts
+++ b/src/util/atomic.ts
@@ -27,7 +27,37 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { closeSync, fsyncSync, openSync, renameSync, rmSync, writeSync } from "node:fs";
+import { closeSync, constants, fsyncSync, openSync, renameSync, rmSync, writeSync } from "node:fs";
+
+/**
+ * Tempfile open flags — sec #1410 (follow-up to CRITICAL #1393).
+ *
+ * Both brokers run as ROOT and write secret-bearing files. #1409's
+ * `resolveMirrorPathsSafe` lstat-guards the auth-broker mirror's
+ * directory components, but a narrow sub-millisecond TOCTOU remained
+ * between that lstat sweep and the final tempfile `openSync` here: an
+ * attacker who wins the race could plant a symlink at the tempfile
+ * path and have the root broker write a secret through it.
+ *
+ *   - `O_NOFOLLOW` — if the final component is a symlink, fail (ELOOP)
+ *     instead of following it. Closes the planted-symlink race.
+ *   - `O_EXCL` (with `O_CREAT`) — the open MUST create the file; fail
+ *     if anything already exists at the tempfile path. The temp name
+ *     is unique per-pid + 4 random bytes so this never trips in
+ *     legitimate use; it defeats a pre-planted file/FIFO at a guessed
+ *     path and makes the old `"w"` flag's `O_TRUNC` unnecessary (the
+ *     file is always brand-new).
+ *
+ * Fail-closed: any of these tripping throws; the caller cleans the
+ * tempfile and rethrows; the destination is left untouched.
+ * O_NOFOLLOW is Linux/macOS (the broker runtime); `?? 0` keeps the
+ * primitive importable where it's absent.
+ */
+const TMP_OPEN_FLAGS =
+  constants.O_WRONLY |
+  constants.O_CREAT |
+  constants.O_EXCL |
+  (constants.O_NOFOLLOW ?? 0);
 
 export function atomicWriteFileSync(
   destPath: string,
@@ -38,7 +68,7 @@ export function atomicWriteFileSync(
   const buf = typeof contents === "string" ? Buffer.from(contents, "utf-8") : contents;
   let fd: number | null = null;
   try {
-    fd = openSync(tmp, "w", mode);
+    fd = openSync(tmp, TMP_OPEN_FLAGS, mode);
     writeSync(fd, buf, 0, buf.length, 0);
     fsyncSync(fd);
     closeSync(fd);


### PR DESCRIPTION
## Summary

LOW-priority hardening follow-up to **CRITICAL #1393** / PR #1409 (epic #1389). #1409's `resolveMirrorPathsSafe` lstat-guard fully defeated the *persistent pre-planted symlink* exploit (the actual #1393 attack — no race needed). A **narrow** residual remained: a sub-millisecond TOCTOU between that lstat sweep and the final tempfile `openSync` in the **shared** `atomicWriteFileSync` — a root broker could be raced into writing a secret through a symlink planted at the tempfile path. Closing it was deliberately scoped out of the CRITICAL hotfix (disclosed in #1409) to keep that minimal.

**Fix:** harden the shared primitive (`src/util/atomic.ts`) — replace the `"w"` open with explicit `O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW`:
- `O_NOFOLLOW` → fail (ELOOP) instead of following a symlink at the final component.
- `O_EXCL` (with `O_CREAT`) → the open must create the file; defeats a pre-planted file/FIFO at a guessed path (the temp name is already unique per-pid+random so this never trips legitimately) and makes the old `O_TRUNC` moot.
- Fail-closed: any trip throws, caller cleans the tempfile, destination untouched. `O_NOFOLLOW ?? 0` keeps it importable off Linux/macOS.

This benefits **every root-broker writer** (vault-broker, auth-broker mirror, google-storage) — the "shared symlink-safe write helper" #1410 asked for.

## Test plan

- [x] `tsc --noEmit` clean (pre-existing unrelated `@mtcute/node` env error filtered)
- [x] new `src/util/atomic.test.ts` (the primitive had **no direct test**) — regression (content/0600/json/no-tmp-leak/atomic-replace/fail-closed) + **the security property**: a symlinked destination is replaced by `rename`, never written through (victim file provably untouched)
- [x] #1393 `server-mirror-symlink-guard` suite stays green (5/5) + `mirror-enrich` — hardening doesn't regress the mirror path (19 tests total)
- [ ] CI green

Serves JTBD: subscription-honest (no cross-write of secret state). Refs #1410 #1393 #1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)