### PR TITLE
fix(tests/docker): pass --user 0 to read-only-rootfs + cap_drop probes

### DIFF
--- a/tests/docker/e2e.test.ts
+++ b/tests/docker/e2e.test.ts
@@ -205,12 +205,22 @@ describe.skipIf(!dockerOk || !allImagesPresent)(
     // inside the agent image via the bundled agent-scheduler sidecar.
 
     it("agent image enforces read-only rootfs (touch /etc/passwd → EROFS)", () => {
+      // Run as root inside the container so DAC permission isn't what
+      // stops us. The agent image now defaults to USER 10001 (WS6-F5,
+      // #1435) — without --user 0 the touch fails with EACCES at the
+      // DAC layer before the kernel ever consults rootfs-readonly,
+      // making this test assert on the wrong layer of defense. The
+      // property under test is "the runtime --read-only flag prevents
+      // even root from writing to the rootfs", which is what compose
+      // gives every agent in production.
       const r = spawnSync(
         "docker",
         [
           "run",
           "--rm",
           ...LABELS_ARGV,
+          "--user",
+          "0",
           "--read-only",
           "--cap-drop=ALL",
           "--security-opt=no-new-privileges",
@@ -302,12 +312,22 @@ describe.skipIf(!dockerOk || !allImagesPresent)(
     });
 
     it("agent image with cap_drop=ALL blocks mount (mount -t tmpfs → EPERM)", () => {
+      // Run as root inside the container so the test exercises the
+      // capability-drop defense rather than the DAC "must be superuser"
+      // shortcut. The agent image now defaults to USER 10001
+      // (WS6-F5, #1435); without --user 0 mount(8) refuses before the
+      // kernel ever consults capabilities, making the assertion lie
+      // about which layer of defense is being verified. cap_drop=ALL
+      // is what compose gives every agent in production, so this is
+      // what we actually want to prove.
       const r = spawnSync(
         "docker",
         [
           "run",
           "--rm",
           ...LABELS_ARGV,
+          "--user",
+          "0",
           "--read-only",
           "--cap-drop=ALL",
           "--security-opt=no-new-privileges",


### PR DESCRIPTION
## Summary

PR #1435 added \`USER 10001\` to the agent image (WS6-F5). Two tests in \`tests/docker/e2e.test.ts\` were written under the old root-default assumption and now fail on every main-branch push because DAC bounces the syscall as uid 10001 long before the kernel reaches the rootfs-readonly check or the cap_drop check.

Fix: pass \`--user 0\` so each test actually exercises the layer of defense it claims to verify. \`--read-only\` + \`cap_drop=ALL\` are what production compose gives every agent — those defenses still hold for root inside the container, which is what the test names assert.

## What this unblocks

- \`docker-e2e\` check on main (HEAD \`25a6c2f5\`) goes green.
- PR #1443 (docker/setup-buildx-action 3.12→4.0) — same red check, will go green on rebase.
- PR #1438 (node:22→26 base bump) — same.
- The update-flow redesign PR C (currently in flight) will not inherit a red \`docker-e2e\`.

## Test plan

- [x] Walked the regex assertion vs. real stderr — DAC fires first at uid 10001.
- [x] Per-test inline comment explains the \`--user 0\` choice + the WS6-F5 reference.
- [ ] CI \`docker-e2e\` job goes green (auto-verified on PR).