### PR TITLE
test(evals): cover restart-required readback + skip-notice in skill guidance & ci-evals

### DIFF
--- a/evals/dataset.yaml
+++ b/evals/dataset.yaml
@@ -198,10 +198,15 @@ evals:
   - id: "schedule-007"
     question: "I just added a cron entry to my agent's schedule. Is it running now?"
     primary_skill: "switchroom-cli"
+    # Positive terms only appear in a correct restart-aware answer
+    # (bare "restart" was dropped — it matches "no restart needed" too).
     expected_contains:
-      - "restart|not (yet )?live|take effect|won'?t .* until|switchroom (agent )?restart|reconcile"
+      - "not (yet )?live|won'?t take effect|will not take effect|takes? effect (only )?(on|after|once|when) .*restart|switchroom (agent )?restart|(needs?|requires?|need) (a )?restart"
+    # Phrases that only occur in a WRONG (claims-live) answer. Avoid bare
+    # "running now"/"live now" — they substring-match the correct
+    # negation "not running now" and would false-fail.
     expected_not_contains:
-      - "yes,? it'?s (now )?running|already (active|live)|it'?s live now"
+      - "no restart (is )?(needed|required)|does ?n'?t (need|require) (a )?restart|picks? (it|the change|the entry)? ?up automatically|already (active|live|scheduled and running)"
     tags: ["schedule", "restart-required"]
 
   - id: "schedule-008"
@@ -217,9 +222,9 @@ evals:
     question: "Install the pdf skill onto the assistant agent — will it work right away?"
     primary_skill: "switchroom-cli"
     expected_contains:
-      - "restart|not (yet )?live|take effect|won'?t .* until|switchroom (agent )?restart"
+      - "not (yet )?live|won'?t take effect|will not take effect|not .* until .*restart|switchroom (agent )?restart|(needs?|requires?|need) (a )?restart|after (a |the )?restart"
     expected_not_contains:
-      - "works right away|immediately available|ready to use now|already active"
+      - "works right away|immediately (available|active|usable)|ready to use (now|right away)|no restart (is )?(needed|required)|does ?n'?t (need|require) (a )?restart|already (active|loaded|available)"
     tags: ["schedule", "restart-required", "skill-install"]
 
   # ── switchroom-restart ─────────────────────────────────────────────────────────────

--- a/evals/dataset.yaml
+++ b/evals/dataset.yaml
@@ -198,15 +198,19 @@ evals:
   - id: "schedule-007"
     question: "I just added a cron entry to my agent's schedule. Is it running now?"
     primary_skill: "switchroom-cli"
-    # Positive terms only appear in a correct restart-aware answer
-    # (bare "restart" was dropped — it matches "no restart needed" too).
+    # NOTE: the grader (run_quality.py:check_assertions) does
+    # pattern.split("|") then re.search per fragment with NO try/except,
+    # so a "(a|b)" group splits into invalid regex fragments and throws.
+    # Convention here is FLAT top-level `|` only — never `|` inside `()`.
+    # Positive terms occur only in a correct restart-aware answer (bare
+    # "restart" dropped — it matches "no restart needed" too).
     expected_contains:
-      - "not (yet )?live|won'?t take effect|will not take effect|takes? effect (only )?(on|after|once|when) .*restart|switchroom (agent )?restart|(needs?|requires?|need) (a )?restart"
-    # Phrases that only occur in a WRONG (claims-live) answer. Avoid bare
-    # "running now"/"live now" — they substring-match the correct
-    # negation "not running now" and would false-fail.
+      - "not yet live|not live|won'?t take effect|will not take effect|takes effect after .*restart|takes effect once .*restart|take effect after .*restart|switchroom restart|switchroom agent restart|needs a restart|need a restart|requires a restart|must restart|until you restart|until the agent restarts|after a restart|after the restart"
+    # WRONG (claims-live) phrases. Deliberately no bare "running now"/
+    # "live now" — they substring-match the correct negation "not
+    # running now" and would false-fail.
     expected_not_contains:
-      - "no restart (is )?(needed|required)|does ?n'?t (need|require) (a )?restart|picks? (it|the change|the entry)? ?up automatically|already (active|live|scheduled and running)"
+      - "no restart needed|no restart is needed|no restart required|no restart is required|does not need a restart|doesn't need a restart|does not require a restart|doesn't require a restart|picks it up automatically|picks the change up automatically|already active|already live|already scheduled and running|works right away"
     tags: ["schedule", "restart-required"]
 
   - id: "schedule-008"
@@ -221,10 +225,12 @@ evals:
   - id: "schedule-009"
     question: "Install the pdf skill onto the assistant agent — will it work right away?"
     primary_skill: "switchroom-cli"
+    # Flat top-level `|` only — see schedule-007 note on the grader's
+    # split("|") behaviour.
     expected_contains:
-      - "not (yet )?live|won'?t take effect|will not take effect|not .* until .*restart|switchroom (agent )?restart|(needs?|requires?|need) (a )?restart|after (a |the )?restart"
+      - "not right away|not yet live|not live|won'?t take effect|will not take effect|takes effect after .*restart|after a restart|after the restart|until you restart|until the agent restarts|switchroom restart|switchroom agent restart|needs a restart|need a restart|need to restart|requires a restart|must restart"
     expected_not_contains:
-      - "works right away|immediately (available|active|usable)|ready to use (now|right away)|no restart (is )?(needed|required)|does ?n'?t (need|require) (a )?restart|already (active|loaded|available)"
+      - "works right away|immediately available|immediately active|immediately usable|ready to use now|ready to use right away|no restart needed|no restart is needed|no restart required|does not need a restart|doesn't need a restart|already active|already loaded|already available"
     tags: ["schedule", "restart-required", "skill-install"]
 
   # ── switchroom-restart ─────────────────────────────────────────────────────────────

--- a/evals/dataset.yaml
+++ b/evals/dataset.yaml
@@ -194,6 +194,34 @@ evals:
       - "schedule|cron|trigger|every hour|0 \\*"
     tags: ["schedule", "cron"]
 
+  # ── restart-required readback (#1430) + skip-notice (#1424) ────────────────────────
+  - id: "schedule-007"
+    question: "I just added a cron entry to my agent's schedule. Is it running now?"
+    primary_skill: "switchroom-cli"
+    expected_contains:
+      - "restart|not (yet )?live|take effect|won'?t .* until|switchroom (agent )?restart|reconcile"
+    expected_not_contains:
+      - "yes,? it'?s (now )?running|already (active|live)|it'?s live now"
+    tags: ["schedule", "restart-required"]
+
+  - id: "schedule-008"
+    question: "Did my agent miss any scheduled tasks while it was offline last night?"
+    primary_skill: "switchroom-cli"
+    expected_contains:
+      - "agent-scheduler|scheduler\\.jsonl|skipped|replay|missed run|boot notice"
+    expected_not_contains:
+      - "I cannot|no way to know|impossible to tell|I don'?t have access"
+    tags: ["schedule", "skip-notice"]
+
+  - id: "schedule-009"
+    question: "Install the pdf skill onto the assistant agent — will it work right away?"
+    primary_skill: "switchroom-cli"
+    expected_contains:
+      - "restart|not (yet )?live|take effect|won'?t .* until|switchroom (agent )?restart"
+    expected_not_contains:
+      - "works right away|immediately available|ready to use now|already active"
+    tags: ["schedule", "restart-required", "skill-install"]
+
   # ── switchroom-restart ─────────────────────────────────────────────────────────────
   - id: "restart-001"
     question: "Restart the assistant agent"

--- a/evals/trigger_dataset.yaml
+++ b/evals/trigger_dataset.yaml
@@ -255,3 +255,26 @@ trigger_evals:
     expected_skill: "switchroom-manage"
     expected_not_skills: ["switchroom-cli", "switchroom-architecture"]
     tags: ["routing", "manage", "vault"]
+
+  # ── schedule/skill liveness + missed runs → cli ───────────────────────────────
+  # "Is my config change live?" / "did runs get skipped?" are CLI
+  # operational questions (scheduler + restart), NOT status snapshots
+  # and NOT agent lifecycle management.
+
+  - id: "t-cli-sched-live-001"
+    query: "I edited the schedule in switchroom.yaml — is the new cron live yet?"
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-status", "switchroom-manage"]
+    tags: ["routing", "cli", "schedule", "restart-required"]
+
+  - id: "t-cli-sched-missed-001"
+    query: "Did the assistant agent skip any scheduled runs while it was down?"
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-status", "switchroom-health"]
+    tags: ["routing", "cli", "schedule", "skip-notice"]
+
+  - id: "t-cli-skill-restart-001"
+    query: "I installed a new skill on my agent — do I need to restart for it to work?"
+    expected_skill: "switchroom-cli"
+    expected_not_skills: ["switchroom-manage", "switchroom-install"]
+    tags: ["routing", "cli", "skill-install", "restart-required"]

--- a/skills/switchroom-cli/SKILL.md
+++ b/skills/switchroom-cli/SKILL.md
@@ -246,7 +246,20 @@ docker logs --tail 100 switchroom-<agent> 2>&1 | grep agent-scheduler:
 
 ### Step 2 — Show declared schedule entries
 
-From `switchroom.yaml`, the `schedule:` array under each agent specifies `cron` + `prompt` + optional `model`. Read the relevant agent block and enumerate the entries with their next-fire times.
+From `switchroom.yaml`, the `schedule:` array under each agent specifies `cron` + `prompt`. (A `model:` field may appear but is **ignored** — since the v0.8 cron-fold-in the fire runs in the agent's existing session and uses the agent's configured model, not a per-task one. Don't tell the user a per-task model is honoured.) Cron expressions are evaluated in the agent's resolved timezone (the `switchroom.timezone` / per-agent `timezone` cascade), not hard-coded UTC. Read the relevant agent block and enumerate the entries with their next-fire times in that zone.
+
+### Step 3 — A schedule change is NOT live until the agent restarts
+
+The in-container `agent-scheduler` reads its entries **once at boot**. Editing the `schedule:` array in `switchroom.yaml`, or adding/removing an entry via the agent-config `schedule add` / `schedule remove` tools, writes the change to disk but does **not** register it in the running scheduler. The same is true for `skill_install` and `.mcp.json` changes — claude loads skills and MCP servers at process start.
+
+So whenever you (or the user) change a schedule, skill, or MCP config:
+
+- The `schedule add` / `skill_install` tool result includes `restart_required: true` and a `restart_hint`. **Surface it.** Tell the user plainly that the change is on disk but won't take effect until `switchroom agent restart <name>` (or `switchroom restart <name>` for the reconcile+restart path).
+- Never report a just-added schedule or skill as already active. It is staged, not live.
+
+### Step 4 — Missed runs while the agent was offline
+
+If the user asks whether scheduled runs were missed during downtime: the scheduler replays fires missed within the last ~30 min on boot, but runs older than that window are **not** re-run (cron is not a queue). It is not silent about this — on boot it emits a one-time notice listing every schedule that had a skipped run, delivered as a normal turn and recorded in `agent-scheduler:` log lines / `/state/agent/scheduler.jsonl`. Check those to answer honestly; never claim a run happened if the skip notice says it was dropped.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #1424 (scheduler skipped-runs boot notice) and #1430 (restart-required readback). The runtime emits these signals but **no skill taught the agent to surface them** — so the `ci-evals` trigger/quality suite measured luck. This makes the skill teach the behaviour, then evals it.

- **`skills/switchroom-cli/SKILL.md`** (owns scheduled-tasks / restart / apply): fixed the `model:` lie (matches #1424's schema/doc fix), noted cron uses the resolved timezone (not hard-coded UTC), added **Step 3** (a schedule/skill/MCP change is NOT live until restart — surface `restart_required`/`restart_hint`, never report a just-added entry as active) and **Step 4** (missed-run honesty via the boot skip-notice + `agent-scheduler:`/`scheduler.jsonl`).
- **`evals/dataset.yaml`**: +3 quality cases (schedule-007/008/009) asserting the answer surfaces the restart caveat / skip-notice and does not claim the change is already live.
- **`evals/trigger_dataset.yaml`**: +3 routing cases (is-it-live / missed-runs / skill-restart) → `switchroom-cli`.

`ci-evals.yml` already path-filters `skills/**/SKILL.md` + both datasets and runs on push-to-main, so this is exercised on the PR **and** post-merge with no workflow change. ci-evals is non-gating (`continue-on-error`) by design — this adds regression signal, not a new merge gate.

## JTBD / design contract

Serves **keep-switchroom-feeling-like-one-product** (consistency: the skill now teaches what the runtime does) and closes the "engine works, user can't tell" trust gap end-to-end. Docs/defaults/consistency checks hold.

## Review

Three independent fresh-process reviews. R1 caught non-discriminating regexes; R2 caught that the R1 fix's grouped alternation `(a|b)` crashes the grader (it `split("|")`s then `re.search`es each fragment, no try/except); R3 **APPROVE** after flattening to pure top-level `|` and verifying against the *real* imported `check_assertions` (3 correct pass / 3 wrong fail / no throw, per case).

## Test plan

- [x] YAML valid; ids unique; `expected_skill` ∈ ROUTABLE_SKILLS
- [x] schedule-007/008/009 driven through the actual `run_quality.py:check_assertions` — discriminating, no regex throw
- [x] Skill guidance cross-checked accurate vs schema / lifecycle / scheduler / docs
- [ ] CI: 15 required GHA checks + ci-evals (non-gating) exercises the new cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)