### PR TITLE
fix(supervisor): exponential backoff, never give up — RFC J Phase 2

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -32,44 +32,56 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   # same path the rest of start.sh + the MCP sidecar expects.
   export TELEGRAM_STATE_DIR="{{agentDir}}/telegram"
 
-  # Tiny in-process supervisor: runs cmd in a respawn loop. Caps at
-  # 10 restarts in 60s before giving up — protects against tight
-  # crash loops that would otherwise burn CPU and obscure the root
-  # cause in logs. The sidecar's own structured logging is written
+  # Tiny in-process supervisor: runs cmd in a respawn loop with
+  # exponential backoff (1→2→4…→60s cap) and NEVER permanently gives
+  # up. Rationale (RFC J / install-validation 2026-05-17): the
+  # gateway's hardest dependency is the vault-broker, which gets
+  # recreated+relocked by a routine `switchroom apply`. The old
+  # "10 restarts in 60s → give up forever" turned that transient
+  # outage into a dead agent until a human recreated the container —
+  # a direct violation of the always-on outcome. Backoff bounds CPU
+  # during an outage; indefinite retry means the agent self-heals
+  # within one backoff cycle the moment the broker is back. The ONLY
+  # non-retry path is EX_CONFIG=78 (genuine permanent misconfig).
+  # The sidecar's own structured logging is written
   # directly to its log file; this wrapper only handles process
   # lifecycle. Ampersand-backgrounded by callers below.
   _switchroom_supervise() {
     local _name="$1"; local _logfile="$2"; shift 2
-    local _restarts=0
-    local _window_start=$SECONDS
+    local _cap=60
+    local _delay=1
+    local _attempt=0
     while true; do
+      local _start=$SECONDS
       "$@" >> "$_logfile" 2>&1
       local _exit=$?
-      local _now=$SECONDS
+      local _ran=$((SECONDS - _start))
       # Exit 78 = sysexits EX_CONFIG, the "permanent config error, do
       # not restart" sentinel. The gateway uses this on a 401 from
       # Telegram (#1076 — revoked / wrong-typed bot token). Restarting
-      # would just re-hit the same 401, burn the 10-in-60 s budget,
-      # and leave the agent silently dead. The supervisor instead
-      # records the quarantine in the log and stops — the host CLI
-      # (`switchroom doctor`, `switchroom agent restart`) reads the
-      # quarantine marker at <TELEGRAM_STATE_DIR>/quarantine.json and
-      # surfaces it to the operator.
+      # just re-hits the same 401, so we quarantine and stop — the
+      # host CLI (`switchroom doctor`, `switchroom agent restart`)
+      # reads the marker at <TELEGRAM_STATE_DIR>/quarantine.json and
+      # surfaces it. This is the ONLY non-retry path: a transient
+      # dependency (vault-broker locked/recreating — RFC J) must never
+      # be terminal for an always-on agent.
       if [ $_exit -eq 78 ]; then
         echo "[supervise] $_name exit 78 (EX_CONFIG) — quarantined, not restarting. Operator action required." >> "$_logfile"
         return 0
       fi
-      if [ $((_now - _window_start)) -ge 60 ]; then
-        _restarts=0
-        _window_start=$_now
+      # A run that stayed up for at least the backoff cap means the
+      # dependency was healthy and this exit is a fresh transient
+      # blip — reset backoff so recovery latency is minimal. Only
+      # consecutive fast failures escalate the delay.
+      if [ $_ran -ge $_cap ]; then
+        _delay=1
+        _attempt=0
       fi
-      _restarts=$((_restarts + 1))
-      echo "[supervise] $_name exited (status=$_exit, restart=$_restarts in $((_now - _window_start))s window)" >> "$_logfile"
-      if [ $_restarts -ge 10 ]; then
-        echo "[supervise] $_name hit 10 restarts in <60s — giving up" >> "$_logfile"
-        return 1
-      fi
-      sleep 1
+      _attempt=$((_attempt + 1))
+      echo "[supervise] $_name exited (status=$_exit, ran=${_ran}s, attempt=$_attempt) — retrying in ${_delay}s (transient deps self-heal; never gives up)" >> "$_logfile"
+      sleep $_delay
+      _delay=$((_delay * 2))
+      [ $_delay -gt $_cap ] && _delay=$_cap
     done
   }
 
@@ -79,9 +91,10 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   #    switchroom-<name>-gateway.service unit. Talks to the broker
   #    over SWITCHROOM_VAULT_BROKER_SOCK (set by compose) for the bot
   #    token. Failure modes: vault locked → gateway boots, fails to
-  #    fetch token, exits non-zero, supervisor respawns; bot token
-  #    invalid → 401 from Telegram, gateway exits, same loop. The
-  #    cap avoids an infinite vault-locked respawn storm.
+  #    fetch token, exits non-zero, supervisor backs off and keeps
+  #    retrying — it recovers on its own the moment the broker
+  #    unlocks (no human, no container recreate); bot token invalid
+  #    → 401 → gateway exits 78 → quarantined (operator action).
   _gateway_bundle=/opt/switchroom/telegram-plugin/dist/gateway/gateway.js
   if [ -f "$_gateway_bundle" ] && command -v bun >/dev/null 2>&1; then
     _switchroom_supervise gateway /var/log/switchroom/gateway-supervisor.log \
@@ -90,8 +103,8 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
 
   # 2) autoaccept-poll — first-run TUI prompt dispatcher. Single-shot
   #    by design (exits cleanly after idle-timeout once prompts have
-  #    fired); supervisor's restart cap means a flaky autoaccept won't
-  #    masquerade as a tight loop.
+  #    fired); the supervisor's exponential backoff keeps a flaky
+  #    autoaccept from busy-looping.
   if [ -f /opt/switchroom/autoaccept-poll.js ] && command -v bun >/dev/null 2>&1; then
     _switchroom_supervise autoaccept /var/log/switchroom/autoaccept.log \
       bun /opt/switchroom/autoaccept-poll.js "{{name}}" &

--- a/tests/gateway-supervisor-backoff.test.ts
+++ b/tests/gateway-supervisor-backoff.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// RFC J Phase 2: the _switchroom_supervise gateway supervisor must
+// (a) preserve the EX_CONFIG=78 immediate-quarantine path, and
+// (b) for every OTHER non-zero exit, back off exponentially and
+//     retry INDEFINITELY (never permanently give up) so an agent
+//     self-heals when a transient dependency (the vault-broker,
+//     recreated+relocked by a routine `switchroom apply`) returns.
+// Regression guard for install-validation 2026-05-17: the old
+// "10 restarts in 60s -> give up forever" turned a broker recreate
+// into a dead fleet until a human intervened.
+
+const TEMPLATE = join(__dirname, "..", "profiles", "_base", "start.sh.hbs");
+
+// Extract the pure-shell _switchroom_supervise function from the
+// handlebars template (the function body contains no {{ }} tokens —
+// asserted below so this test fails loudly if that ever changes).
+function extractSupervisor(): string {
+  const src = readFileSync(TEMPLATE, "utf-8");
+  const lines = src.split("\n");
+  const start = lines.findIndex((l) => l.includes("_switchroom_supervise() {"));
+  expect(start, "_switchroom_supervise() not found in start.sh.hbs").toBeGreaterThanOrEqual(0);
+  // Function ends at the first subsequent line that is exactly the
+  // 2-space-indented closing brace.
+  let end = -1;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i] === "  }") { end = i; break; }
+  }
+  expect(end, "closing brace of _switchroom_supervise not found").toBeGreaterThan(start);
+  // De-indent two spaces so it's a valid top-level function.
+  const fn = lines.slice(start, end + 1).map((l) => l.replace(/^ {2}/, "")).join("\n");
+  expect(fn).not.toContain("{{"); // no handlebars inside the function
+  return fn;
+}
+
+let dir: string;
+let fnPath: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "sup-test-"));
+  // Shrink the 60s cap to 4s so exponential backoff (1,2,4,4) is
+  // observable in a fast test without changing the logic under test.
+  const fn = extractSupervisor().replace("local _cap=60", "local _cap=4");
+  fnPath = join(dir, "sup.fn");
+  writeFileSync(fnPath, fn);
+});
+
+function runBash(script: string, timeoutMs: number): string {
+  const p = join(dir, `drv-${Math.random().toString(36).slice(2)}.sh`);
+  writeFileSync(p, `set -u\nsource ${JSON.stringify(fnPath)}\n${script}\n`);
+  try {
+    return execFileSync("bash", [p], { encoding: "utf-8", timeout: timeoutMs });
+  } finally {
+    rmSync(p, { force: true });
+  }
+}
+
+describe("gateway supervisor — RFC J Phase 2 backoff", () => {
+  it("exit 78 (EX_CONFIG) quarantines, returns 0, never retries", () => {
+    const log = join(dir, "a.log");
+    const out = runBash(
+      `_switchroom_supervise tA ${JSON.stringify(log)} sh -c 'exit 78'; echo "RC=$?"`,
+      10_000,
+    );
+    expect(out).toContain("RC=0");
+    const l = readFileSync(log, "utf-8");
+    expect(l).toContain("quarantined, not restarting");
+    expect(l).not.toContain("retrying in");
+  });
+
+  it("transient non-zero exits back off exponentially and NEVER give up", () => {
+    const log = join(dir, "b.log");
+    // Supervisor in background; kill after ~9s (enough for attempts
+    // 1..4 with delays 1+2+4 = 7s elapsed before attempt 4 logs).
+    runBash(
+      `_switchroom_supervise tB ${JSON.stringify(log)} sh -c 'exit 1' & SPID=$!
+       sleep 9; kill "$SPID" 2>/dev/null; wait "$SPID" 2>/dev/null; true`,
+      20_000,
+    );
+    const l = readFileSync(log, "utf-8");
+    expect(l).toContain("attempt=1) — retrying in 1s");
+    expect(l).toContain("attempt=2) — retrying in 2s");
+    expect(l).toContain("attempt=3) — retrying in 4s");
+    expect(l).toContain("attempt=4) — retrying in 4s"); // capped at _cap
+    expect(l).not.toMatch(/giving up|hit 10 restarts/i);
+  }, 20_000);
+
+  it("a run lasting >= cap resets the backoff (attempt back to 1)", () => {
+    const log = join(dir, "c.log");
+    const cnt = join(dir, "c.cnt");
+    writeFileSync(cnt, "0");
+    // 1st,2nd exits fast (attempt climbs to 3); 3rd run sleeps 5s
+    // (>= cap 4) then exits — the NEXT failure must show attempt=1.
+    runBash(
+      `_switchroom_supervise tC ${JSON.stringify(log)} sh -c '
+         n=$(cat ${JSON.stringify(cnt)}); n=$((n+1)); echo $n > ${JSON.stringify(cnt)}
+         if [ $n -eq 3 ]; then sleep 5; fi
+         exit 1' & SPID=$!
+       sleep 14; kill "$SPID" 2>/dev/null; wait "$SPID" 2>/dev/null; true`,
+      25_000,
+    );
+    const l = readFileSync(log, "utf-8");
+    // The failure after the long (>=cap) run reports a long ran= and
+    // attempt=1 (backoff was reset).
+    expect(l).toMatch(/ran=[4-9][0-9]?s, attempt=1\)/);
+  }, 30_000);
+});

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1030,9 +1030,9 @@ describe("scaffoldAgent — docker-mode tmux supervisor preamble (v0.7.5)", () =
     // sides are pinned in tests so a Dockerfile rename surfaces here.
     expect(startSh).toContain("/opt/switchroom/autoaccept-poll.js");
     // v0.7.6: autoaccept now runs under _switchroom_supervise, which
-    // restarts it on crash up to a per-window cap. The supervisor
-    // line backgrounds with `&` and writes through the supervisor
-    // logfile (not the bare command's stdout).
+    // restarts it on crash with exponential backoff (RFC J Phase 2).
+    // The supervisor line backgrounds with `&` and writes through
+    // the supervisor logfile (not the bare command's stdout).
     expect(startSh).toMatch(
       /_switchroom_supervise autoaccept \/var\/log\/switchroom\/autoaccept\.log[\s\S]*?bun \/opt\/switchroom\/autoaccept-poll\.js "carol" &/,
     );
@@ -1075,16 +1075,27 @@ describe("scaffoldAgent — docker-mode tmux supervisor preamble (v0.7.5)", () =
     expect(gatewayForkIdx).toBeGreaterThan(stateDirIdx);
   });
 
-  it("supervisor caps restarts at 10 in 60s (avoids tight-loop CPU burn)", () => {
-    // Pin the cap shape so a future "make it 100" change forces a
-    // discussion: 10/60s is "give up after a clearly-broken
-    // first-minute" without making operators wait too long.
+  it("supervisor backs off exponentially and never permanently gives up (RFC J Phase 2)", () => {
+    // The old "10 restarts in 60s -> give up forever" turned a
+    // routine broker recreate (which relocks the dockerized broker)
+    // into a dead fleet until a human intervened — a direct
+    // always-on violation (install-validation 2026-05-17 / RFC J).
+    // New contract: EX_CONFIG=78 is the ONLY non-retry path; every
+    // other exit backs off exponentially (capped) and retries
+    // INDEFINITELY so the agent self-heals when the broker returns.
+    // Reintroducing a permanent give-up must fail this test.
     const config = makeAgentConfig({ topic_id: 1 });
     const result = scaffoldAgent("greta", config, tmpDir, telegramConfig);
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
     expect(startSh).toContain("_switchroom_supervise()");
-    expect(startSh).toContain("if [ $_restarts -ge 10 ]");
-    expect(startSh).toMatch(/if \[ \$\(\(_now - _window_start\)\) -ge 60 \]/);
+    // EX_CONFIG=78 quarantine preserved — the only stop path.
+    expect(startSh).toContain("if [ $_exit -eq 78 ]");
+    expect(startSh).toContain("quarantined, not restarting");
+    // Exponential backoff with a cap; no permanent give-up.
+    expect(startSh).toMatch(/_delay=\$\(\(_delay \* 2\)\)/);
+    expect(startSh).toMatch(/_delay -gt \$_cap/);
+    expect(startSh).not.toContain("if [ $_restarts -ge 10 ]");
+    expect(startSh).not.toMatch(/giving up|hit 10 restarts/i);
   });
 
   it("re-execs into tmux with the v0.6-systemd socket+session contract", () => {


### PR DESCRIPTION
## Summary

**RFC J Phase 2** (`docs/rfcs/vault-broker-resilience.md`, PR #1450) — the highest-leverage, fully-independent resilience fix.

The agent supervisor (`profiles/_base/start.sh.hbs:_switchroom_supervise`) gave up **permanently after 10 restarts in 60s**. A routine `switchroom apply` recreates + relocks the dockerized `switchroom-vault-broker`; every gateway whose `bot_token` is a `vault:` ref then exhausted that budget and the bot went dark **until a human recreated the container** — the exact failure that blocked the install-validation two-bot matrix, and a direct violation of the always-on outcome (`reference/vision.md`).

Now:
- **EX_CONFIG=78 quarantine preserved** — genuine permanent misconfig (401 on a revoked/wrong-typed token, #1076) still stops immediately with the operator marker. This is the **only** non-retry path.
- **Every other non-zero exit:** exponential backoff (1→2→4…→**60s cap**) and **retry indefinitely**. A run lasting ≥ the cap resets the backoff (a fresh transient blip recovers fast; only consecutive fast failures escalate). The agent self-heals within one backoff cycle the moment the broker returns — **no human, no container recreate**.

This alone converts "a routine `apply` permanently bricks the fleet" into "agents self-heal when the broker is back," independent of the auto-unlock root-cause fix (Phase 1).

## Validation

- New `tests/gateway-supervisor-backoff.test.ts` — extracts the shell function and **behaviorally** verifies (via bash subprocess): exit-78 quarantine returns 0 without retry; transient exits back off 1→2→4→cap and **never** log "giving up"; a run ≥ cap resets the backoff.
- `tests/scaffold.test.ts`: the brittle "caps at 10 in 60s" assertion pinned the removed behavior — its own comment asked for a discussion before changing; RFC J **is** that discussion. Rewritten to pin the new contract (EX_CONFIG-only stop, exponential backoff, no give-up). Stale comment fixed.
- **233/233** in the touched suites (`scaffold`, `doctor`, `scaffold.regenerate-start-sh`, the new test); `tsc --noEmit` clean.

## Test plan

- [ ] CI `lint` + `vitest` green
- [ ] Reviewer confirms EX_CONFIG=78 path unchanged; backoff/reset logic sound; no test pins removed behavior
- [ ] (post-merge, Phase 1) re-run two-bot matrix: `switchroom apply` recreates the broker → admin agent self-heals within one backoff cycle without intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)