### PR TITLE
feat(vault): auto-unlock as the unattended default — RFC J Phase 1

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -982,8 +982,18 @@ async function stepAutoUnlock(
 ): Promise<void> {
   stepHeader(8, "Vault auto-unlock at boot", STEP_ACTIVE);
 
-  if (nonInteractive) {
-    console.log(chalk.gray("  Skipping in non-interactive mode."));
+  const envPass = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+  if (nonInteractive && !(envPass && envPass.length > 0)) {
+    // Unattended install that did NOT supply the passphrase signal:
+    // leave auto-unlock unconfigured — do not weaken an install that
+    // didn't opt into unattended operation. With the passphrase
+    // present we proceed: an always-on fleet MUST survive a broker
+    // recreate (routine `switchroom apply`) with no human in the
+    // loop. Previously this ALWAYS skipped non-interactively, so the
+    // canonical unattended install could never auto-unlock — every
+    // `apply` then bricked vault-ref agents (install-validation
+    // 2026-05-17 / RFC J Phase 1).
+    console.log(chalk.gray("  Skipping (non-interactive, no SWITCHROOM_VAULT_PASSPHRASE)."));
     return;
   }
 
@@ -1009,19 +1019,32 @@ async function stepAutoUnlock(
 
   console.log(chalk.gray("  Without this, vault must be unlocked manually after every reboot."));
   console.log(chalk.gray("  Encrypted with a key derived from this machine's id — disk theft is safe; the same user on this box is not."));
-  const enable = await askYesNo("  Enable vault auto-unlock at boot?", true);
-  if (!enable) {
-    console.log(chalk.gray("  Skipped. Run later with: switchroom vault broker enable-auto-unlock"));
-    return;
+  if (!nonInteractive) {
+    const enable = await askYesNo("  Enable vault auto-unlock at boot?", true);
+    if (!enable) {
+      console.log(chalk.gray("  Skipped. Run later with: switchroom vault broker enable-auto-unlock"));
+      return;
+    }
+  } else {
+    // Non-interactive + passphrase present (guarded at the top): the
+    // operator opted into unattended operation, so auto-unlock is the
+    // correct default — proceed without prompting (RFC J Phase 1).
+    console.log(chalk.gray("  Enabling (non-interactive, SWITCHROOM_VAULT_PASSPHRASE present)."));
   }
 
-  // Masked passphrase prompt — handing it to AES-GCM, not echoing.
+  // $SWITCHROOM_VAULT_PASSPHRASE is the unattended signal (same source
+  // setup/gateway use); else masked prompt. Handed to AES-GCM, not
+  // echoed.
   let passphrase: string;
-  try {
-    passphrase = await promptPassphrase();
-  } catch (err) {
-    console.log(chalk.yellow(`  Skipped: ${err instanceof Error ? err.message : String(err)}`));
-    return;
+  if (envPass && envPass.length > 0) {
+    passphrase = envPass;
+  } else {
+    try {
+      passphrase = await promptPassphrase();
+    } catch (err) {
+      console.log(chalk.yellow(`  Skipped: ${err instanceof Error ? err.message : String(err)}`));
+      return;
+    }
   }
 
   try {
@@ -1062,6 +1085,14 @@ async function stepAutoUnlock(
       ),
     );
     console.log(chalk.gray("  Retry with: switchroom apply && docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml restart vault-broker"));
+  }
+
+  if (nonInteractive) {
+    // The approval-posture choice below is interactive-only. A
+    // non-interactive install keeps the default (passphrase /
+    // two-factor) posture — auto-unlock is now configured, which was
+    // the goal of this step.
+    return;
   }
 
   // Posture prompt: passphrase (two-factor, default) vs telegram-id

--- a/src/cli/vault-broker.ts
+++ b/src/cli/vault-broker.ts
@@ -356,18 +356,26 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
     });
 
   // ── enable-auto-unlock ───────────────────────────────────────────────────
-  // Encrypt the vault passphrase via systemd-creds and write it to the
-  // configured credential path, then flip vault.broker.autoUnlock=true,
-  // reconcile, and restart the broker. After this the broker unit declares
-  // LoadCredentialEncrypted= and systemd injects the passphrase at every
-  // boot — no user interaction required. See issue #152.
+  // Encrypt the vault passphrase machine-bound (key derived from
+  // /etc/machine-id, HKDF-SHA256 — NOT systemd-creds; that wording was
+  // vestigial v0.6 text, see RFC J §2.1) and write it to the configured
+  // credential path, then flip vault.broker.autoUnlock=true, reconcile,
+  // and restart the broker. The dockerized broker decrypts it from the
+  // host-mounted /etc/machine-id at every boot — no user interaction,
+  // and a stolen vault+blob off-host is useless without that host's
+  // machine-id. See issue #152 / RFC J.
   //
-  // The encryption cascade (user-scope → host-scope → sudo) is handled in
-  // ./vault-auto-unlock.ts so the same flow can run inside the setup wizard.
+  // The encryption cascade is handled in ./vault-auto-unlock.ts so the
+  // same flow runs inside `switchroom setup`. The passphrase is sourced
+  // from $SWITCHROOM_VAULT_PASSPHRASE when set (the unattended signal
+  // used by setup + the gateway), else prompted/piped — so an
+  // unattended `setup --non-interactive` can establish auto-unlock
+  // (RFC J Phase 1; previously it could not — install-validation
+  // 2026-05-17).
   broker
     .command("enable-auto-unlock")
     .description(
-      "Set up vault auto-unlock at boot: encrypt the passphrase via systemd-creds, " +
+      "Set up vault auto-unlock at boot: encrypt the passphrase machine-bound, " +
       "enable vault.broker.autoUnlock, and restart the broker.",
     )
     .option(
@@ -392,13 +400,23 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
       const vaultPath = getVaultPath(parentOpts.config);
 
       // Prompt + verify BEFORE writing anything. We must not encrypt a typo.
+      // $SWITCHROOM_VAULT_PASSPHRASE is the established unattended signal
+      // (setup --non-interactive, the gateway, materialize-bot-token all
+      // honor it); consume it here so an unattended install can establish
+      // auto-unlock without a TTY. Falls back to the interactive/piped
+      // prompt otherwise. (RFC J Phase 1.)
       let passphrase: string;
-      try {
-        passphrase = await promptPassphrase();
-      } catch (err) {
-        console.error(err instanceof Error ? err.message : String(err));
-        process.exit(1);
-        return; // unreachable; satisfies TS narrowing
+      const envPass = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+      if (envPass && envPass.length > 0) {
+        passphrase = envPass;
+      } else {
+        try {
+          passphrase = await promptPassphrase();
+        } catch (err) {
+          console.error(err instanceof Error ? err.message : String(err));
+          process.exit(1);
+          return; // unreachable; satisfies TS narrowing
+        }
       }
 
       try {

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -2488,6 +2488,19 @@ export class VaultBroker {
       DEFAULT_AUTO_UNLOCK_PATH;
     const filePath = resolvePath(configuredPath);
     if (!existsSync(filePath)) return false;
+    // A zero-length blob is semantically "nothing provisioned", not
+    // "corrupt": the docker-compose bind-mount auto-materializes an
+    // empty host file when ~/.switchroom/vault-auto-unlock doesn't
+    // exist (non-interactive setup that didn't enable auto-unlock).
+    // Treat it exactly like absent — quiet fall-through, NOT the
+    // alarming "auto-unlock decrypt failed (format): malformed (wrong
+    // length or version)" line that masked the real state in
+    // install-validation 2026-05-17 (RFC J Phase 1 / §2.4).
+    try {
+      if (statSync(filePath).size === 0) return false;
+    } catch {
+      return false;
+    }
 
     let passphrase: string;
     try {


### PR DESCRIPTION
## Summary

**RFC J Phase 1** — the root-cause fix. The docker-native machine-id auto-unlock mechanism already existed and ran (`src/vault/broker/server.ts` + `src/vault/auto-unlock.ts`), but the canonical unattended install could **never establish it**: `switchroom setup --non-interactive` always skipped Step 8, and `vault broker enable-auto-unlock` had no non-interactive path (aborted "Empty passphrase" even with `SWITCHROOM_VAULT_PASSPHRASE` set). Result: every `switchroom apply` recreated the broker **locked** and bricked vault-ref agents (install-validation 2026-05-17 / RFC J §2.1).

- **`src/cli/vault-broker.ts`** — `enable-auto-unlock` consumes `$SWITCHROOM_VAULT_PASSPHRASE` (the unattended signal `setup`, the gateway, and `materialize-bot-token` already honor) before the interactive/piped prompt. Corrected the vestigial "systemd-creds" help/comment (impl is machine-bound HKDF, not systemd-creds).
- **`src/cli/setup.ts`** — `stepAutoUnlock` proceeds non-interactively **iff** `SWITCHROOM_VAULT_PASSPHRASE` is present (writes a real machine-bound blob + `applyAutoUnlock`); skips the interactive enable/posture prompts. **Strictly gated on the passphrase signal** so an install that did *not* opt into unattended operation is never weakened (threat model: machine-bound key from `/etc/machine-id`; a vault+blob stolen off-host is useless).
- **`src/vault/broker/server.ts`** — a 0-byte blob (docker bind-mount auto-materializes an empty host file when none was provisioned) is now treated exactly like *absent* — quiet fall-through, not the alarming "auto-unlock decrypt failed (format): malformed (wrong length or version)" that masked the real state (§2.4).

`promptPassphrase` and `readAutoUnlockFile`/`decryptAutoUnlock` are intentionally **unchanged** — the env path is added at the command/setup layer, the empty-blob guard at the broker layer — so existing units (`vault-broker-passphrase`, `vault-auto-unlock`) are unaffected.

## Validation

- `tsc --noEmit` clean. setup 38/38, vault-auto-unlock 9/9, vault-broker-passphrase green.
- End-to-end proof (fresh `--non-interactive` VM → `apply` recreates broker → auto-unlocks, no human) is the RFC §6 definition-of-done — run as the **consolidated fresh-VM re-validation** once Phases 1/2/4 land (per-phase on the heavily-mutated current VM would not be a clean signal).

## Test plan

- [ ] CI `lint` + `vitest` green
- [ ] Reviewer confirms the unattended gating (passphrase-present-only) genuinely never weakens a non-opted-in install; the three call sites are consistent
- [ ] Consolidated fresh-VM re-validation after Phase 4 (RFC §6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)