### PR TITLE
fix(broker): honest healthcheck + correct unlock string — RFC J Phase 4a

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -804,11 +804,17 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // sockets) reports unhealthy. Acceptable: a switchroom install
   // without any agents has no business running the broker; an
   // operator who's mid-install has minutes-scale exposure to this.
-  // We do NOT speak the broker's app protocol here — that requires
-  // peercred-checked auth and would generate audit-log noise on
-  // every healthcheck tick. Bind-presence is the right level.
+  // We still do NOT speak the broker's auth'd app protocol here
+  // (peercred + audit-log noise). Instead the probe also requires a
+  // 0-byte readiness sentinel the broker writes on unlock and
+  // unlinks on lock (SWITCHROOM_VAULT_BROKER_READY_PATH). So the
+  // health state is `serving AND unlocked` — a LOCKED broker now
+  // reads unhealthy. Reporting a locked broker "healthy" is exactly
+  // what masked the install-validation 2026-05-17 incident, where a
+  // routine `apply` relocked the broker and `docker compose ps`
+  // still said healthy (RFC J §2.4 / Phase 4).
   lines.push(`    healthcheck:`);
-  lines.push(`      test: ["CMD-SHELL", "ls /run/switchroom/broker/*/sock 2>/dev/null | head -1 | grep -q ."]`);
+  lines.push(`      test: ["CMD-SHELL", "ls /run/switchroom/broker/*/sock 2>/dev/null | head -1 | grep -q . && test -f /run/switchroom/broker/.ready"]`);
   lines.push(`      interval: 30s`);
   lines.push(`      timeout: 5s`);
   lines.push(`      retries: 3`);
@@ -867,6 +873,10 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // parent dir so saveVault's write-temp-then-rename works.
   lines.push(`      SWITCHROOM_VAULT_PATH: /state/vault/vault.enc`);
   lines.push(`      SWITCHROOM_VAULT_BROKER_AUTO_UNLOCK_PATH: /state/vault-auto-unlock`);
+  // Readiness sentinel the broker writes on unlock / unlinks on lock.
+  // The healthcheck above tests it so `docker compose ps` reflects
+  // unlocked-AND-serving, not just socket bind-presence (RFC J Phase 4).
+  lines.push(`      SWITCHROOM_VAULT_BROKER_READY_PATH: /run/switchroom/broker/.ready`);
   // Operator UID — when set, the broker binds an additional listener at
   // /run/switchroom/broker/operator/sock and chowns it to this UID so
   // the host operator's shell can talk to the broker through the bind

--- a/src/telegram/materialize-bot-token.ts
+++ b/src/telegram/materialize-bot-token.ts
@@ -158,7 +158,7 @@ export async function materializeBotToken(opts: MaterializeOpts = {}): Promise<s
 
   if (!brokerResult.ok && brokerResult.reason === "locked") {
     throw new BotTokenMaterializeError(
-      "Bot token is a vault reference but vault is locked. Run: switchroom vault unlock",
+      "Bot token is a vault reference but the vault is locked. Run `switchroom vault broker unlock` (or set SWITCHROOM_VAULT_PASSPHRASE / enable auto-unlock).",
       "locked",
     );
   }
@@ -194,7 +194,7 @@ export async function materializeBotToken(opts: MaterializeOpts = {}): Promise<s
   // container itself is down and needs to be brought up first.
   const unlockHint = isDockerRuntime()
     ? "Bring up the project (docker compose -p switchroom up -d), then `switchroom vault broker unlock` (or `docker exec -it switchroom-vault-broker switchroom vault broker unlock`), or set SWITCHROOM_VAULT_PASSPHRASE."
-    : "Start the broker (switchroom vault unlock) or set SWITCHROOM_VAULT_PASSPHRASE.";
+    : "Start + unlock the broker (`switchroom vault broker unlock`) or set SWITCHROOM_VAULT_PASSPHRASE.";
   throw new BotTokenMaterializeError(
     `Bot token is a vault reference (${configured}) but vault broker is unreachable and no SWITCHROOM_VAULT_PASSPHRASE is available for direct decrypt. ` +
     unlockHint,

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -357,6 +357,34 @@ export class VaultBroker {
     // lifetime; the broker's retained reference is the only authorised
     // long-lived store.
     this.passphrase = passphrase;
+    this._setReadinessSentinel(true);
+  }
+
+  /**
+   * Best-effort readiness sentinel for the docker healthcheck (RFC J
+   * Phase 4). On unlock we touch SWITCHROOM_VAULT_BROKER_READY_PATH;
+   * on lock we remove it. The compose healthcheck tests this file so
+   * `docker compose ps` reflects unlocked-AND-serving — a locked
+   * broker reads unhealthy instead of the bind-presence-only "healthy"
+   * that masked the install-validation 2026-05-17 incident.
+   *
+   * MUST NOT throw: this runs inside the security-critical unlock/lock
+   * paths and a sentinel I/O hiccup must never affect vault state. The
+   * env var is set only by the dockerized vault-broker service; unset
+   * (host/test) → no-op, so non-docker behaviour is unchanged.
+   */
+  private _setReadinessSentinel(ready: boolean): void {
+    const p = process.env.SWITCHROOM_VAULT_BROKER_READY_PATH;
+    if (!p || p.length === 0) return;
+    try {
+      if (ready) {
+        writeFileSync(p, "", { mode: 0o600 });
+      } else if (existsSync(p)) {
+        unlinkSync(p);
+      }
+    } catch {
+      /* best-effort: never let sentinel I/O affect lock/unlock */
+    }
   }
 
   /**
@@ -381,6 +409,7 @@ export class VaultBroker {
     // caveat as the secret values above — the underlying bytes survive in the
     // string-pool until GC, but the broker's only reference is gone.
     this.passphrase = null;
+    this._setReadinessSentinel(false);
   }
 
   /**

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -2140,8 +2140,22 @@ describe("singleton healthchecks (silent-down regression — see plans/singleton
     // it actually exercises the binding code, not some sibling pidfile
     // or status sentinel. Pin the exact glob.
     const out = generateCompose({ config: makeConfig({ alice: {} }) });
-    expect(out).toContain(`"ls /run/switchroom/broker/*/sock 2>/dev/null | head -1 | grep -q ."`);
+    expect(out).toContain(`"ls /run/switchroom/broker/*/sock 2>/dev/null | head -1 | grep -q . && test -f /run/switchroom/broker/.ready"`);
     expect(out).toContain(`"ls /run/switchroom/kernel/*/sock 2>/dev/null | head -1 | grep -q ."`);
+  });
+
+  it("broker health = serving AND unlocked (RFC J Phase 4 readiness sentinel)", () => {
+    // A locked broker reading "healthy" (bind-presence only) masked
+    // the install-validation 2026-05-17 incident. The probe now also
+    // requires the readiness sentinel the broker writes on unlock /
+    // unlinks on lock, fed via SWITCHROOM_VAULT_BROKER_READY_PATH.
+    const out = generateCompose({ config: makeConfig({ alice: {} }) });
+    const block = blockFor(out, "vault-broker");
+    expect(block).toContain("SWITCHROOM_VAULT_BROKER_READY_PATH: /run/switchroom/broker/.ready");
+    expect(block).toContain("test -f /run/switchroom/broker/.ready");
+    // kernel healthcheck unchanged (no readiness sentinel there).
+    const kblock = blockFor(out, "approval-kernel");
+    expect(kblock).not.toContain(".ready");
   });
 });
 


### PR DESCRIPTION
## Summary

**RFC J Phase 4a** — two of the three observability fixes. The third (the `vault broker unlock` "Timeout waiting for broker" false-negative, `client.ts:648`) is a genuine networking race; **split out as tracked Phase 4b** to keep this PR provably correct rather than ship a guessed timeout fix.

1. **Healthcheck = serving AND unlocked.** The broker healthcheck was socket-bind-presence only — a **locked** broker read "healthy", which is exactly what masked the install-validation 2026-05-17 incident (a routine `apply` relocked the broker; `docker compose ps` still said healthy). The broker now writes a 0-byte readiness sentinel on unlock / unlinks on lock (path from compose-injected `SWITCHROOM_VAULT_BROKER_READY_PATH`; **unset → no-op**, so host/test behaviour is unchanged); the compose healthcheck additionally `test -f`s it. `_setReadinessSentinel` is fully best-effort and **must not throw** — it runs inside the security-critical unlock/lock paths.
2. **Stale operator string.** `materialize-bot-token.ts` told operators to "Run: switchroom vault unlock" — a non-existent v0.6 command. Corrected to `switchroom vault broker unlock` in both the locked-vault error and the non-docker hint.

## Validation

- `tsc --noEmit` clean.
- `tests/docker/compose-generator.test.ts` 141/141 — updated the pinned exact-healthcheck assertion and added a readiness-contract test (env var emitted; probe requires `.ready`; kernel unchanged).
- `vault-auto-unlock` 9/9. server.ts unlock/lock semantics are unchanged outside docker by construction (env-unset ⇒ `_setReadinessSentinel` early-returns).

## Test plan

- [ ] CI `lint` + `vitest` green
- [ ] Reviewer confirms `_setReadinessSentinel` cannot throw into unlock/lock; env-unset is a true no-op; the healthcheck change makes a locked broker unhealthy without flapping a healthy one
- [ ] Phase 4b (timeout-race) tracked separately
- [ ] Consolidated fresh-VM re-validation after Phase 3 (RFC §6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)