### PR TITLE
feat: PR C of update-flow redesign — gateway surfacing + smoke test + CI promote (3/3)

### DIFF
--- a/docs/proposed/docker-images.yml
+++ b/docs/proposed/docker-images.yml
@@ -1,0 +1,363 @@
+name: docker-images
+
+# Multi-arch build + push for switchroom's container images.
+#
+# Triggers:
+#   - push to main: build all images for linux/amd64 + linux/arm64,
+#     push as `:latest` and `:sha-<short>` to
+#     ghcr.io/<owner>/switchroom-<image>.
+#   - tag push v*: same matrix, push as `:<tag>` and `:latest`.
+#   - pull_request: build only (no push) to validate Dockerfile changes.
+#
+# Two parallel pipelines:
+#   - build-base + build-dependents: switchroom-{base,agent,broker,kernel,
+#     hostd,auth-broker}. Dependents extend base, so base builds first.
+#   - build-hindsight: extends upstream `vectorize-io/hindsight:latest`,
+#     no switchroom-base dependency. Runs in parallel with build-base.
+#
+# This workflow is staged at docs/proposed/docker-images.yml because the
+# OAuth token used to land code changes here lacks the `workflow` scope
+# GitHub requires for writes under `.github/workflows/`. To activate it,
+# an operator with a workflow-scoped token must:
+#
+#   git mv docs/proposed/docker-images.yml .github/workflows/docker-images.yml
+#   git commit -m "ci: enable docker-images workflow"
+#   git push
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  # Manual re-trigger. GHA marks a run failed (no auto-retry) when its
+  # jobs sit queued past the hosted-runner scheduling window during a
+  # capacity blip; `gh run rerun` then refuses ("cannot be retried")
+  # once the run is stale. Without a manual entrypoint the only way to
+  # republish `:latest` is another push to main. workflow_dispatch
+  # gives `gh workflow run docker-images.yml --ref main` as the
+  # recovery lever. (#1336 queue-fail surfaced this gap.)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-images-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  # Owner is taken from the repo path so a fork builds against the
+  # forker's GHCR namespace.
+  IMAGE_NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Node (for dist/ bundling)
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "22"
+
+      - name: Set up Bun (build.mjs invokes bun build)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: latest
+
+      - name: Install deps + build dist/
+        run: |
+          bun install
+          npm run build
+
+      - name: Set up QEMU (only when arm64 build runs)
+        # QEMU is only needed for cross-arch arm64 emulation on amd64
+        # hosts. PR builds are amd64-only (see `platforms` below), so
+        # skip the QEMU setup — saves ~5s + cuts the resulting image
+        # surface area.
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Log in to GHCR (push only on main / tags)
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-base"
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/}"
+            echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+          elif [[ ( "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ) && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            # PR C: keep :latest as the canonical install per
+            # docs/operators/install.md, BUT also publish :sha-<7> for
+            # rollback / promote.yml retagging. (The :dev floating tag
+            # is gated by the smoke-test job and assigned by a separate
+            # retag step below — NOT included in this initial push so
+            # that a failed smoke run can't leave a broken :dev behind.)
+            echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          else
+            # PR builds: synthesize a non-pushed tag for build-only mode.
+            echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build (and push on main/tag) base
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          file: docker/Dockerfile.base
+          # PR validation: amd64 only — arm64 via QEMU is ~3-4 min per
+          # image and PRs don't merge until amd64 is green anyway. Full
+          # multi-arch matrix runs on push to main + tags where the
+          # arm64 artifact is consumed by operators.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=base
+          cache-to: type=gha,mode=max,scope=base
+          # sec WS9-F3 (#1418): signed build provenance + SBOM so an
+          # operator's `switchroom update` pull can verify the image
+          # was built by THIS pipeline from THIS source (SLSA-style).
+          provenance: mode=max
+          sbom: true
+          # CACHE_BUST is paired with the `ARG CACHE_BUST` in
+          # Dockerfile.base immediately before `npm install -g
+          # @anthropic-ai/claude-code@latest`. `github.run_attempt`
+          # increments only on `gh run rerun` (fresh pushes start at
+          # 1), so original commits hit the buildkit cache for fast
+          # builds, while a rerun forces a fresh npm resolve and
+          # picks up the current `@latest` from the registry. This
+          # is the canonical "give me the newest claude" lever:
+          # `gh run rerun <run-id>` → fresh image → `switchroom
+          # update` → fleet bumps.
+          build-args: |
+            CACHE_BUST=${{ github.run_attempt }}
+
+  build-dependents:
+    needs: build-base
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - { name: agent,        file: docker/Dockerfile.agent }
+          - { name: broker,       file: docker/Dockerfile.broker }
+          - { name: kernel,       file: docker/Dockerfile.kernel }
+          - { name: hostd,        file: docker/Dockerfile.hostd }
+          - { name: auth-broker,  file: docker/Dockerfile.auth-broker }
+          # hindsight is NOT here — it has its own `build-hindsight`
+          # job (PR #1310) that runs in parallel with build-base
+          # because Dockerfile.hindsight extends upstream
+          # `vectorize-io/hindsight:latest`, not switchroom-base.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Node (for dist/ bundling)
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "22"
+
+      - name: Set up Bun (build.mjs invokes bun build)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: latest
+
+      - name: Install deps + build dist/
+        run: |
+          bun install
+          npm run build
+
+      - name: Set up QEMU (only when arm64 build runs)
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Log in to GHCR (push only on main / tags)
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags + base ref
+        id: tags
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image.name }}"
+          BASE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-base"
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/}"
+            echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+            echo "base=${BASE}:${TAG_VERSION}" >> "$GITHUB_OUTPUT"
+          elif [[ ( "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ) && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+            echo "base=${BASE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            # On PRs the base wasn't pushed, so depend on local layer cache.
+            echo "base=${BASE}:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build (and push on main/tag) ${{ matrix.image.name }}
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          file: ${{ matrix.image.file }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            BASE_IMAGE=${{ steps.tags.outputs.base }}
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+          # sec WS9-F3 (#1418): provenance + SBOM on every fleet image.
+          provenance: mode=max
+          sbom: true
+
+  build-hindsight:
+    # Hindsight extends upstream `ghcr.io/vectorize-io/hindsight:latest`
+    # rather than `switchroom-base`, so it has no dependency on the
+    # base job and runs in parallel. See docker/Dockerfile.hindsight
+    # for why we extend instead of running upstream as-is (claude-code
+    # provider + claude-agent-sdk + UID pin).
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up QEMU (only when arm64 build runs)
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Log in to GHCR (push only on main / tags)
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-hindsight"
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/}"
+            echo "tags=${IMAGE}:${TAG_VERSION},${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+          elif [[ ( "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ) && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "tags=${IMAGE}:latest,${IMAGE}:sha-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tags=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build (and push on main/tag) hindsight
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          file: docker/Dockerfile.hindsight
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=hindsight
+          cache-to: type=gha,mode=max,scope=hindsight
+          # sec WS9-F3 (#1418): provenance + SBOM on the hindsight image too.
+          provenance: mode=max
+          sbom: true
+
+  # PR C: smoke test the freshly-pushed :sha-<7> agent image — runs the
+  # MCP tools/list harness inside a throwaway container with the
+  # channels.telegram.enabled:false fixture (no bot-token needed at
+  # boot). Validates every tool's input_schema against Anthropic's
+  # tool-use constraints (root type:object, no top-level
+  # oneOf/anyOf/allOf). Gates the floating :dev tag below — a failed
+  # smoke run leaves :sha-<7> pushed (for rollback) but does NOT
+  # promote to :dev. Job timeout 5 min.
+  smoke-test:
+    needs: [build-dependents]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "22"
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: latest
+
+      - name: Install deps
+        run: bun install
+
+      - name: Log in to GHCR (smoke pulls private images)
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull freshly-pushed :sha-<7> agent image
+        run: |
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-agent:sha-${SHA_SHORT}"
+          docker pull "$IMAGE"
+          echo "SMOKE_AGENT_IMAGE=$IMAGE" >> "$GITHUB_ENV"
+
+      - name: Run MCP tools/list smoke test
+        env:
+          RUN_DOCKER_SMOKE: "1"
+        run: npx vitest run tests/docker/mcp-tools-list.smoke.test.ts
+
+  # PR C: promote :sha-<7> → :dev for every image when smoke passes.
+  # Matrix-fanout retag using buildx imagetools so we don't rebuild.
+  promote-to-dev:
+    needs: [smoke-test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [base, agent, broker, kernel, hostd, auth-broker, hindsight]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag :sha-<7> as :dev (no rebuild)
+        run: |
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image }}"
+          docker buildx imagetools create -t "${IMAGE}:dev" "${IMAGE}:sha-${SHA_SHORT}"

--- a/docs/proposed/promote.yml
+++ b/docs/proposed/promote.yml
@@ -1,0 +1,99 @@
+name: promote
+
+# Hand-promote a published image tag across channels — `dev → rc`,
+# `rc → latest`, or any arbitrary `from → to` pair an operator needs
+# (e.g. `dev → operator-canary` for a one-off dogfood ring).
+#
+# This is the operator surface for PR C's channel-based release model:
+#
+#   build pipeline:    main push → :sha-<7> → smoke test → :dev (auto)
+#   promote (this):    :dev → :rc → :latest (gated by human dispatch)
+#
+# What this workflow guarantees:
+#
+#   1. Source tag MUST exist in the registry. We `buildx imagetools
+#      inspect` it as a precheck and exit with an actionable message
+#      ("source tag :<from> not found — check for typos or wait for the
+#      build pipeline to publish :<from>") if it doesn't.
+#   2. We retag, never rebuild. `buildx imagetools create -t :<to>
+#      :<from>` carries the same manifest digest and signed provenance
+#      to the destination tag — operators pulling :latest after
+#      promotion get bit-for-bit the same image as those who pulled
+#      :dev a week earlier.
+#   3. We verify digest equality post-retag. If the destination tag's
+#      manifest digest doesn't match the source's (registry race, push
+#      conflict), the job fails loudly so the promotion is treated as
+#      "did not happen" rather than "happened with a different image."
+#
+# Matrix fans out across all 7 fleet images. `fail-fast: true` so a
+# single bad image stops the promotion mid-flight rather than leaving a
+# half-promoted channel.
+
+on:
+  workflow_dispatch:
+    inputs:
+      from:
+        description: "Source tag (e.g. dev, rc, sha-abc1234)"
+        required: true
+        type: string
+      to:
+        description: "Destination tag (e.g. rc, latest)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        image: [base, agent, broker, kernel, hostd, auth-broker, hindsight]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Precheck — source tag exists
+        run: |
+          IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image }}"
+          FROM="${IMAGE}:${{ inputs.from }}"
+          if ! docker buildx imagetools inspect "$FROM" >/dev/null 2>&1; then
+            echo "::error::Source tag ${FROM} not found in registry."
+            echo "::error::Check for typos or wait for the build pipeline to publish :${{ inputs.from }}."
+            exit 1
+          fi
+          # Capture source digest for the post-retag verification step.
+          SRC_DIGEST=$(docker buildx imagetools inspect "$FROM" --format '{{.Manifest.Digest}}')
+          echo "SRC_DIGEST=$SRC_DIGEST" >> "$GITHUB_ENV"
+          echo "FROM_REF=$FROM" >> "$GITHUB_ENV"
+          echo "TO_REF=${IMAGE}:${{ inputs.to }}" >> "$GITHUB_ENV"
+
+      - name: Retag (no rebuild)
+        run: |
+          docker buildx imagetools create -t "${TO_REF}" "${FROM_REF}"
+
+      - name: Verify digest equality post-retag
+        run: |
+          DST_DIGEST=$(docker buildx imagetools inspect "${TO_REF}" --format '{{.Manifest.Digest}}')
+          if [ "${SRC_DIGEST}" != "${DST_DIGEST}" ]; then
+            echo "::error::Digest mismatch after retag!"
+            echo "::error::  source ${FROM_REF} → ${SRC_DIGEST}"
+            echo "::error::  dest   ${TO_REF}   → ${DST_DIGEST}"
+            echo "::error::Promotion did NOT happen as a no-op manifest copy. Investigate registry race / push conflict."
+            exit 1
+          fi
+          echo "Promoted ${FROM_REF} → ${TO_REF} (digest ${DST_DIGEST})"

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -74,6 +74,12 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   }
 
   # 1) Gateway daemon — the long-running Telegram bot client.
+  #    Honors channels.telegram.enabled (PR A schema, PR C wiring).
+  #    When the operator sets enabled:false, skip the gateway sidecar
+  #    entirely so the agent boots without bot-token requirements —
+  #    used by the CI smoke-test harness and any offline-dev setup.
+  #    Default behavior preserved: when the var is unset/empty, treat
+  #    as enabled (no operator action required for existing agents).
   #    Polls Telegram, writes gateway.sock for the in-claude MCP
   #    sidecar to bridge through. Mirrors the v0.6 sibling
   #    switchroom-<name>-gateway.service unit. Talks to the broker
@@ -83,9 +89,12 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   #    invalid → 401 from Telegram, gateway exits, same loop. The
   #    cap avoids an infinite vault-locked respawn storm.
   _gateway_bundle=/opt/switchroom/telegram-plugin/dist/gateway/gateway.js
-  if [ -f "$_gateway_bundle" ] && command -v bun >/dev/null 2>&1; then
+  _telegram_enabled={{#if telegramEnabledFlag}}{{telegramEnabledFlag}}{{else}}true{{/if}}
+  if [ "$_telegram_enabled" = "true" ] && [ -f "$_gateway_bundle" ] && command -v bun >/dev/null 2>&1; then
     _switchroom_supervise gateway /var/log/switchroom/gateway-supervisor.log \
       bun "$_gateway_bundle" &
+  elif [ "$_telegram_enabled" != "true" ]; then
+    echo "[start.sh] channels.telegram.enabled=false — skipping gateway sidecar" >&2
   fi
 
   # 2) autoaccept-poll — first-run TUI prompt dispatcher. Single-shot

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1611,6 +1611,10 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     dangerousMode: agentConfig.dangerous_mode === true,
     useSwitchroomPlugin: usesSwitchroomTelegramPlugin(agentConfig),
     useHotReloadStable: agentConfig.channels?.telegram?.hotReloadStable === true,
+    // PR C: surface channels.telegram.enabled into start.sh as a literal
+    // "true"/"false" string. Default true preserves prior behavior.
+    telegramEnabledFlag:
+      agentConfig.channels?.telegram?.enabled === false ? "false" : "true",
     // sec WS8-F1 / #1416: unconditional read-only image-baked
     // security-hooks plugin dir. Always set — it is the unstrippable
     // tool-safety authority, not an opt-in feature.
@@ -3542,6 +3546,11 @@ export function reconcileAgent(
       // {{#unless useHotReloadStable}} block always renders, so flipping
       // hotReloadStable on never removes the _WS_STABLE bake from start.sh.
       useHotReloadStable: agentConfig.channels?.telegram?.hotReloadStable === true,
+      // PR C: see buildWorkspaceContext for rationale — mirror here so
+      // reconcile (apply on existing agents) re-renders start.sh with
+      // the current enabled flag.
+      telegramEnabledFlag:
+        agentConfig.channels?.telegram?.enabled === false ? "false" : "true",
       // sec WS8-F1 / #1416: reconcile re-asserts the security-plugin
       // --plugin-dir on every `switchroom apply` so the boundary
       // self-heals if an older start.sh (without it) is on disk.

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -56,6 +56,7 @@ import {
   ConfigError,
 } from "../config/loader.js";
 import { scaffoldAgent, alignAgentUid } from "../agents/scaffold.js";
+import { installUpdatePromptHook } from "./update-prompt-hook.js";
 import { generateCompose, allocateAgentUid } from "../agents/compose.js";
 import { resolveImageTag, resolveRelease } from "../config/release-resolve.js";
 import { detectInstallType } from "./install-detect.js";
@@ -585,6 +586,18 @@ export async function runApply(
         chalk.green(`  + ${name}`) +
           chalk.gray(` (${agentConfig.extends ?? "default"}) — ${detail}\n`),
       );
+      // PR C: install the UserPromptSubmit hook that surfaces
+      // mid-conversation MCP-originated update_apply outcomes. Fail-soft
+      // — a hook install failure should never break apply.
+      try {
+        installUpdatePromptHook(join(agentsDir, name));
+      } catch (hookErr) {
+        writeOut(
+          chalk.gray(
+            `    (update-prompt hook install failed for ${name}: ${(hookErr as Error).message})\n`,
+          ),
+        );
+      }
       // Align per-agent dir ownership with the container UID assigned
       // by compose.ts. Without this the bind-mount lands read-only
       // for the in-container UID and the agent fails on first write.

--- a/src/cli/update-prompt-hook.test.ts
+++ b/src/cli/update-prompt-hook.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, statSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { installUpdatePromptHook, UPDATE_PROMPT_HOOK_FILENAME } from "./update-prompt-hook.js";
+
+describe("installUpdatePromptHook — PR C UserPromptSubmit hook", () => {
+  let tmp: string;
+  let agentDir: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "update-prompt-hook-"));
+    agentDir = join(tmp, "agent");
+    mkdirSync(join(agentDir, ".claude"), { recursive: true });
+    // Pre-seed a minimal settings.json — the real scaffold writes one
+    // before our hook installer runs.
+    writeFileSync(
+      join(agentDir, ".claude", "settings.json"),
+      JSON.stringify({ permissions: { allow: [] } }, null, 2),
+      "utf-8",
+    );
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it("writes the script at the expected path with mode 0o755", () => {
+    const res = installUpdatePromptHook(agentDir);
+    expect(res.scriptPath).toBe(join(agentDir, ".claude", "hooks", UPDATE_PROMPT_HOOK_FILENAME));
+    expect(existsSync(res.scriptPath)).toBe(true);
+    const mode = statSync(res.scriptPath).mode & 0o777;
+    expect(mode).toBe(0o755);
+    const body = readFileSync(res.scriptPath, "utf-8");
+    expect(body).toMatch(/UserPromptSubmit hook/);
+    expect(body).toMatch(/update_apply/);
+  });
+
+  it("registers the hook entry in settings.json", () => {
+    installUpdatePromptHook(agentDir);
+    const settings = JSON.parse(readFileSync(join(agentDir, ".claude", "settings.json"), "utf-8"));
+    expect(Array.isArray(settings.hooks?.UserPromptSubmit)).toBe(true);
+    const list = settings.hooks.UserPromptSubmit as Array<Record<string, unknown>>;
+    const flat = list.flatMap(e => (Array.isArray(e.hooks) ? e.hooks : []));
+    const cmds = flat.map((h: any) => h.command).filter(Boolean);
+    expect(cmds.some(c => c.includes(UPDATE_PROMPT_HOOK_FILENAME))).toBe(true);
+  });
+
+  it("is idempotent — second run does not duplicate the entry", () => {
+    installUpdatePromptHook(agentDir);
+    installUpdatePromptHook(agentDir);
+    const settings = JSON.parse(readFileSync(join(agentDir, ".claude", "settings.json"), "utf-8"));
+    const list = settings.hooks.UserPromptSubmit as Array<Record<string, unknown>>;
+    const flat = list.flatMap(e => (Array.isArray(e.hooks) ? e.hooks : []));
+    const matches = flat.filter((h: any) => typeof h.command === "string" && h.command.includes(UPDATE_PROMPT_HOOK_FILENAME));
+    expect(matches.length).toBe(1);
+  });
+
+  it("returns gracefully when settings.json is absent (scaffold not yet run)", () => {
+    rmSync(join(agentDir, ".claude", "settings.json"));
+    const res = installUpdatePromptHook(agentDir);
+    expect(existsSync(res.scriptPath)).toBe(true);
+  });
+});

--- a/src/cli/update-prompt-hook.ts
+++ b/src/cli/update-prompt-hook.ts
@@ -1,0 +1,187 @@
+/**
+ * PR C — install a UserPromptSubmit hook script into each agent that
+ * surfaces mid-conversation MCP-originated update_apply outcomes.
+ *
+ * The gateway boot-card path (telegram-plugin/gateway/update-announce.ts)
+ * handles updates that trigger a restart of THIS agent. But when a
+ * peer agent (e.g. klanker) runs `mcp__hostd__update_apply` targeting
+ * the fleet, this agent doesn't necessarily restart — yet the operator
+ * should still see the outcome in chat. The hook fires on the next user
+ * prompt, scans the audit log for any terminal update_apply rows newer
+ * than the last ack, sends a notification line to the agent's chat, and
+ * records the ack mtime.
+ *
+ * The script is invoked by Claude Code's `UserPromptSubmit` hook with
+ * stdin = the user's prompt. The hook short-circuits when the gateway
+ * boot-card path has already announced the same request_id (via the
+ * `update-announced/<request_id>` sentinel — boot-card wins).
+ *
+ * Idempotent install: re-running apply overwrites the script with the
+ * current content and ensures the hook entry is present in
+ * .claude/settings.json without duplicating it.
+ */
+
+import { existsSync, readFileSync, writeFileSync, chmodSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+const HOOK_FILENAME = "update-card-on-prompt.sh";
+
+export function updatePromptHookScript(): string {
+  // Bash, POSIX-portable, fail-soft. Reads ~/.switchroom/host-control-audit.log
+  // (the canonical hostd log path — see audit-reader.defaultAuditLogPath),
+  // scans for terminal update_apply rows newer than the per-agent
+  // .update-prompt-acked mtime, and writes one Telegram message via the
+  // installed CLI if available. Always exits 0 so it never blocks the
+  // user's prompt.
+  return `#!/bin/bash
+# Switchroom — UserPromptSubmit hook for mid-conversation update surfacing.
+# Installed by \`switchroom apply\` (src/cli/update-prompt-hook.ts).
+# Reads the hostd audit log for terminal update_apply rows newer than
+# this hook's last-ack timestamp, and (when a new row is found AND the
+# boot-card path hasn't already claimed it) sends a one-line summary to
+# the agent's Telegram chat. Always exits 0 so it never blocks the user.
+
+set +e
+AUDIT_LOG="\${HOME}/.switchroom/host-control-audit.log"
+STATE_DIR="\${TELEGRAM_STATE_DIR:-\${HOME}/.switchroom/agents/\${SWITCHROOM_AGENT_NAME:-unknown}/telegram}"
+ACK_FILE="\${STATE_DIR}/.update-prompt-acked"
+ANNOUNCED_DIR="\${STATE_DIR}/update-announced"
+
+[ -f "\$AUDIT_LOG" ] || exit 0
+mkdir -p "\$STATE_DIR" 2>/dev/null || true
+
+ACK_TS=0
+if [ -f "\$ACK_FILE" ]; then
+  ACK_TS=$(stat -c %Y "\$ACK_FILE" 2>/dev/null || stat -f %m "\$ACK_FILE" 2>/dev/null || echo 0)
+fi
+
+# Tail last 200 lines, then awk-filter for terminal update_apply rows.
+LATEST_LINE=\$(tail -n 200 "\$AUDIT_LOG" 2>/dev/null | grep -F '"phase":"terminal"' | grep -F '"op":"update_apply"' | tail -n 1)
+[ -z "\$LATEST_LINE" ] && exit 0
+
+# Extract ts (ISO 8601) and request_id with grep -oP — fall back to
+# silent exit if either parse fails.
+TS_STR=\$(echo "\$LATEST_LINE" | grep -oP '"ts":"[^"]+"' | head -n1 | sed 's/"ts":"//;s/"//')
+REQ_ID=\$(echo "\$LATEST_LINE" | grep -oP '"request_id":"[^"]+"' | head -n1 | sed 's/"request_id":"//;s/"//')
+[ -z "\$TS_STR" ] && exit 0
+[ -z "\$REQ_ID" ] && exit 0
+
+# Convert ts → epoch. date -d on GNU coreutils; macOS BSD date needs -j -f.
+TS_EPOCH=\$(date -d "\$TS_STR" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S" "\${TS_STR%.*Z}" +%s 2>/dev/null || echo 0)
+[ "\$TS_EPOCH" -le "\$ACK_TS" ] && exit 0
+
+# Boot-card wins: skip if the gateway path already claimed this row.
+if [ -f "\${ANNOUNCED_DIR}/\${REQ_ID}" ]; then
+  : > "\$ACK_FILE"
+  exit 0
+fi
+
+# Cheap, best-effort notification. We don't try to render the full
+# outcome here (the gateway path does that with proper HTML + recovery
+# hints) — this is the "you missed it" breadcrumb pointing at the audit
+# log for detail. If \`switchroom\` CLI isn't on PATH we still touch the
+# ack-file so we don't re-fire on the next prompt.
+if command -v switchroom >/dev/null 2>&1; then
+  CHAT_ID="\${SWITCHROOM_DEFAULT_CHAT_ID:-}"
+  if [ -n "\$CHAT_ID" ]; then
+    switchroom telegram send --chat-id "\$CHAT_ID" \\
+      --text "🔄 Update completed via MCP (request_id: \$REQ_ID). Run \\\`switchroom audit hostd\\\` for detail." \\
+      >/dev/null 2>&1 || true
+  fi
+fi
+
+# Atomic-touch the ack file so re-fires on the next prompt are skipped.
+: > "\$ACK_FILE"
+exit 0
+`;
+}
+
+export interface InstallHookResult {
+  scriptPath: string;
+  settingsPath: string;
+  installed: boolean;
+}
+
+/**
+ * Install the UserPromptSubmit hook script + register it in the agent's
+ * settings.json. Idempotent.
+ *
+ * Returns:
+ *   - scriptPath: absolute path the script was written to
+ *   - settingsPath: absolute path to the agent's settings.json
+ *   - installed: true if anything was newly written (script or
+ *                settings entry); false if everything was already in
+ *                place
+ */
+export function installUpdatePromptHook(agentDir: string): InstallHookResult {
+  const hooksDir = join(agentDir, ".claude", "hooks");
+  mkdirSync(hooksDir, { recursive: true });
+  const scriptPath = join(hooksDir, HOOK_FILENAME);
+  const desired = updatePromptHookScript();
+  let installed = false;
+  const existing = existsSync(scriptPath) ? readFileSync(scriptPath, "utf-8") : "";
+  if (existing !== desired) {
+    writeFileSync(scriptPath, desired, { mode: 0o755 });
+    chmodSync(scriptPath, 0o755);
+    installed = true;
+  } else {
+    // Ensure executable bit even if content matched.
+    try { chmodSync(scriptPath, 0o755); } catch {}
+  }
+
+  const settingsPath = join(agentDir, ".claude", "settings.json");
+  if (!existsSync(settingsPath)) {
+    // No settings.json yet — scaffold writes it. We'll be re-invoked on
+    // the next apply pass once it exists.
+    return { scriptPath, settingsPath, installed };
+  }
+
+  const raw = readFileSync(settingsPath, "utf-8");
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return { scriptPath, settingsPath, installed };
+  }
+  const hooks = (parsed.hooks ??= {}) as Record<string, unknown>;
+  // Claude Code's hooks shape: { UserPromptSubmit: [{ matcher?: string,
+  // hooks: [{ type: "command", command: "..." }] }] }
+  const list = Array.isArray(hooks.UserPromptSubmit)
+    ? (hooks.UserPromptSubmit as Array<Record<string, unknown>>)
+    : [];
+
+  const expectedCommand = scriptPath;
+  let alreadyPresent = false;
+  for (const entry of list) {
+    const inner = entry.hooks;
+    if (!Array.isArray(inner)) continue;
+    for (const h of inner) {
+      if (h && typeof h === "object") {
+        const cmd = (h as Record<string, unknown>).command;
+        if (typeof cmd === "string" && cmd.includes(HOOK_FILENAME)) {
+          alreadyPresent = true;
+          break;
+        }
+      }
+    }
+    if (alreadyPresent) break;
+  }
+
+  if (!alreadyPresent) {
+    list.push({
+      hooks: [{ type: "command", command: expectedCommand }],
+    });
+    hooks.UserPromptSubmit = list;
+    parsed.hooks = hooks;
+    writeFileSync(settingsPath, JSON.stringify(parsed, null, 2) + "\n", { mode: 0o600 });
+    installed = true;
+  }
+
+  return { scriptPath, settingsPath, installed };
+}
+
+// Re-export filename for tests.
+export const UPDATE_PROMPT_HOOK_FILENAME = HOOK_FILENAME;
+// `dirname` is imported to satisfy the eslint rule even though it's
+// not currently used; future revisions may need it for path math.
+void dirname;

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -292,6 +292,12 @@ export interface RenderBootCardOpts {
   snoozeRows?: ReadonlyArray<ProbeKey>
   /** Clock injection point for tests; defaults to `new Date()`. */
   now?: Date
+  /** PR C update-flow: outcome line for the most recent terminal
+   *  update_apply audit row (rendered by `update-announce.ts`). When
+   *  present, appended as a stand-alone section below the probe rows so
+   *  the operator sees what happened with the update that triggered
+   *  this boot without trawling the audit log. */
+  updateOutcomeLine?: string
 }
 
 /**
@@ -400,6 +406,12 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
   const sections: string[] = [ack]
   if (degradedRows.length > 0) sections.push('', ...degradedRows)
   if (accountRows.length > 0) sections.push('', ...accountRows)
+  if (opts.updateOutcomeLine) {
+    // PR C: each line of the update-outcome blob is its own row in the
+    // sections array so the join('\n') below renders the multi-line
+    // failure-with-recovery hint cleanly.
+    sections.push('', ...opts.updateOutcomeLine.split('\n'))
+  }
   if (sections.length === 1) return ack
   return sections.join('\n')
 }
@@ -501,6 +513,13 @@ export interface RunProbesOpts {
    *  and externally-managed surface text instead of execing systemctl
    *  (which doesn't exist in the agent image). See `runtime-mode.ts`. */
   dockerMode?: boolean
+  /** PR C: pass-through to the renderer. When the gateway boot path
+   *  detects a recent terminal `update_apply` audit row, it computes the
+   *  outcome line via `update-announce.ts` and passes it here so the
+   *  card surfaces "✅ update completed (channel:dev, sha:…)" or the
+   *  failure body with a recovery hint. Append-only — never replaces
+   *  the existing ack/probe sections. */
+  updateOutcomeLine?: string
 }
 
 /** Run all six probes concurrently with their own per-probe timeouts.
@@ -555,6 +574,7 @@ export async function startBootCard(
     version: opts.version,
     restartReason: opts.restartReason,
     restartAgeMs: opts.restartAgeMs,
+    ...(opts.updateOutcomeLine ? { updateOutcomeLine: opts.updateOutcomeLine } : {}),
   })
 
   // Silence the notification for operator-initiated redeploys. A
@@ -661,6 +681,7 @@ export async function startBootCard(
           ...(accountRows ? { accounts: accountRows } : {}),
           ...(resolvedRows.length > 0 ? { resolvedRows } : {}),
           ...(snoozeRows.length > 0 ? { snoozeRows } : {}),
+          ...(opts.updateOutcomeLine ? { updateOutcomeLine: opts.updateOutcomeLine } : {}),
         })
 
         if (currentText !== ackText) {
@@ -712,6 +733,7 @@ export async function startBootCard(
             // cache write from the live-watch loop.
             ...(resolvedRows.length > 0 ? { resolvedRows } : {}),
             ...(snoozeRows.length > 0 ? { snoozeRows } : {}),
+            ...(opts.updateOutcomeLine ? { updateOutcomeLine: opts.updateOutcomeLine } : {}),
           })
 
           if (updatedText === currentText) continue

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -303,6 +303,7 @@ import {
 } from './boot-card.js'
 import { determineRestartReason } from './boot-reason.js'
 import { shouldSkipDuplicateBootCard, type RestartReason } from './boot-card.js'
+import { maybeRenderUpdateAnnouncement } from './update-announce.js'
 import { createIssuesCardHandle, type IssuesCardHandle } from '../issues-card.js'
 import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.js'
 import { list as listIssues, resolve as resolveIssue } from '../../src/issues/index.js'
@@ -2777,6 +2778,12 @@ const ipcServer: IpcServer = createIpcServer({
           // second bridge-reconnect in the same lifetime can't race against
           // an in-flight sendMessage here either (#489).
           bootCardPending = true
+          // PR C: surface the most recent terminal update_apply audit
+          // row if it lands within the lookback window AND no other
+          // boot has claimed it. Cheap (one file read + one O_EXCL).
+          const updateOutcomeLine = (() => {
+            try { return maybeRenderUpdateAnnouncement() ?? undefined } catch { return undefined }
+          })()
           startBootCard(chatId, threadId, botApiForCard, {
             agentName: agentDisplayName,
             agentSlug,
@@ -2790,6 +2797,7 @@ const ipcServer: IpcServer = createIpcServer({
             probeQuotaViaBroker: (t) => probeQuotaForBootCard(agentSlug, t),
             tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
             dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
+            ...(updateOutcomeLine ? { updateOutcomeLine } : {}),
           }, ackMsgId).then(handle => {
             activeBootCard = handle
           }).catch((err: Error) => {
@@ -13587,6 +13595,13 @@ void (async () => {
                   // sendMessage round-trip) sees an in-flight emit. See #489.
                   bootCardPending = true
                   try {
+                    // PR C: mirror the bridge-reconnect path — surface
+                    // a recent terminal update_apply outcome with claim
+                    // dedupe so it doesn't render twice if bridge
+                    // re-connects within the lookback window.
+                    const updateOutcomeLine = (() => {
+                      try { return maybeRenderUpdateAnnouncement() ?? undefined } catch { return undefined }
+                    })()
                     const handle = await startBootCard(chatId, threadId, botApiForCard, {
                       agentName: agentDisplayName,
                       agentSlug,
@@ -13600,6 +13615,7 @@ void (async () => {
                       probeQuotaViaBroker: (t) => probeQuotaForBootCard(agentSlug, t),
                       tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
                       dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
+                      ...(updateOutcomeLine ? { updateOutcomeLine } : {}),
                     }, ackMsgId)
                     activeBootCard = handle
                   } catch (err) {

--- a/telegram-plugin/gateway/update-announce.ts
+++ b/telegram-plugin/gateway/update-announce.ts
@@ -1,0 +1,167 @@
+/**
+ * Update-flow PR C — boot-card surfacing for MCP-originated updates.
+ *
+ * When an agent (e.g. klanker) runs `mcp__hostd__update_apply` the work
+ * happens hostd-side, the agent itself restarts at the end, and the
+ * resulting boot card for THIS agent (the one that just restarted via
+ * the redeploy) needs to surface the outcome — success or failure with a
+ * recovery hint — so the operator sees what happened without trawling
+ * the audit log.
+ *
+ * Implementation: on boot, scan ~/.switchroom/host-control-audit.log for
+ * the most recent `phase: "terminal"` `update_apply` row within a recent
+ * window. Dedupe via an atomic O_EXCL marker so a respawn within the
+ * window doesn't re-announce. Render a single line that's appended to
+ * the existing boot-card body.
+ *
+ * Pure & test-friendly — `readLastTerminalUpdateAudit` accepts an
+ * injectable file-reader, `renderUpdateOutcomeLine` is a pure function,
+ * and `claimUpdateAnnouncement` accepts an injectable claim-dir + clock.
+ */
+
+import { existsSync, mkdirSync, openSync, closeSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { readAndFilter, defaultAuditLogPath, type AuditEntry } from '../../src/host-control/audit-reader.js'
+
+/** Default lookback window: 10 minutes is enough to catch the boot that
+ *  follows a normal update_apply but small enough that an audit row from
+ *  yesterday's run can't re-trigger an announcement after a long
+ *  outage. */
+export const DEFAULT_LOOKBACK_MS = 10 * 60 * 1000
+
+export interface ReadOpts {
+  /** Read the file system. Override in tests. */
+  readFile?: (path: string) => string
+  /** Exists check. Override in tests. */
+  exists?: (path: string) => boolean
+  /** Override the audit-log path (defaults to ~/.switchroom/host-control-audit.log). */
+  auditLogPath?: string
+  /** Wall-clock for the lookback comparison. */
+  now?: number
+  /** Lookback window in ms. Defaults to {@link DEFAULT_LOOKBACK_MS}. */
+  lookbackMs?: number
+}
+
+/**
+ * Read the audit log and return the most-recent `update_apply` terminal
+ * row within the lookback window, or null if none. We deliberately do
+ * not filter by caller — any update_apply outcome is interesting to the
+ * person watching this chat regardless of which agent ran the verb.
+ */
+export function readLastTerminalUpdateAudit(opts: ReadOpts = {}): AuditEntry | null {
+  const path = opts.auditLogPath ?? defaultAuditLogPath()
+  const exists = opts.exists ?? existsSync
+  const readFile = opts.readFile ?? ((p: string) => readFileSync(p, 'utf-8'))
+  if (!exists(path)) return null
+  let raw: string
+  try {
+    raw = readFile(path)
+  } catch {
+    return null
+  }
+  // Pull recent update_apply rows, then trim to terminal-phase within window.
+  const recent = readAndFilter(raw, { op: 'update_apply' }, 200)
+  const now = opts.now ?? Date.now()
+  const since = now - (opts.lookbackMs ?? DEFAULT_LOOKBACK_MS)
+  let best: AuditEntry | null = null
+  for (const e of recent) {
+    if (e.phase !== 'terminal') continue
+    const ts = Date.parse(e.ts)
+    if (Number.isNaN(ts)) continue
+    if (ts < since) continue
+    if (best == null || Date.parse(best.ts) < ts) best = e
+  }
+  return best
+}
+
+const RECOVERY_HINTS: Record<string, string> = {
+  binary:
+    'curl https://switchroom.ai/install.sh | sh && switchroom update',
+  source:
+    'cd ~/code/switchroom && git pull && bun install && bun run build && switchroom update',
+  'source-unlinked':
+    'cd ~/code/switchroom && bun link && switchroom update  # ensures binary is in PATH first',
+  docker:
+    'docker compose -p switchroom pull && docker compose -p switchroom up -d',
+  unknown:
+    'Cannot auto-detect install type. Run `switchroom apply` to refresh ~/.switchroom/install-type.json, then retry.',
+}
+
+function recoveryHint(installType: string | undefined): string {
+  if (!installType) return RECOVERY_HINTS.unknown
+  return RECOVERY_HINTS[installType] ?? RECOVERY_HINTS.unknown
+}
+
+function shortSha(s: string): string {
+  return s.replace(/^sha256:/, '').slice(0, 12)
+}
+
+/**
+ * Pure renderer. Returns the single line (HTML-safe — plain ASCII)
+ * to append to the boot card body. `null` means nothing to surface
+ * (entry too stale, schema invalid, etc.).
+ */
+export function renderUpdateOutcomeLine(entry: AuditEntry): string {
+  const success = entry.exit_code === 0 && entry.result !== 'error' && entry.result !== 'denied'
+  if (success) {
+    const channel = entry.channel ? `channel:${entry.channel}` : entry.pin ? `pin:${entry.pin}` : 'channel:?'
+    let shaStr = ''
+    if (entry.resolved_sha) {
+      const firstSha = Object.values(entry.resolved_sha)[0]
+      if (firstSha) shaStr = `, sha:${shortSha(firstSha)}`
+    }
+    return `✅ update completed (${channel}${shaStr})`
+  }
+  const stderrTail = (entry.stderr_tail ?? entry.error ?? '').slice(-400)
+  const opStep = entry.op
+  const hint = recoveryHint(entry.install_context?.install_type)
+  // Single line is reader-friendly when short; multi-line when stderr is present.
+  const lines = [`❌ update failed at ${opStep}: ${stderrTail || '(no stderr captured)'}`, `    ↳ Recovery: ${hint}`]
+  return lines.join('\n')
+}
+
+export interface ClaimOpts {
+  /** Override state-dir base (default: $TELEGRAM_STATE_DIR or ~/.switchroom/<agent>/telegram). */
+  stateDir?: string
+}
+
+/**
+ * Atomic claim via `O_CREAT|O_EXCL` — returns true if THIS process is
+ * the first to announce this request_id. Idempotent across respawns
+ * within the same state-dir. We deliberately don't clean up old
+ * markers — they're tiny and bounded by the lookback window above.
+ */
+export function claimUpdateAnnouncement(requestId: string, opts: ClaimOpts = {}): boolean {
+  const stateDir = opts.stateDir ?? process.env.TELEGRAM_STATE_DIR ?? join(homedir(), '.switchroom')
+  const dir = join(stateDir, 'update-announced')
+  try {
+    mkdirSync(dir, { recursive: true })
+  } catch {
+    return false
+  }
+  const safeId = requestId.replace(/[^A-Za-z0-9_.-]/g, '_').slice(0, 200)
+  const path = join(dir, safeId)
+  try {
+    // O_CREAT | O_EXCL — fails with EEXIST if another boot already
+    // claimed this request_id.
+    const fd = openSync(path, 'wx')
+    closeSync(fd)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Combined entry-point used by the gateway boot path: read + claim +
+ * render. Returns the line to append (already escaped for HTML — plain
+ * ASCII text — caller embeds with no further processing) or null when
+ * there's nothing to surface OR another boot already claimed the row.
+ */
+export function maybeRenderUpdateAnnouncement(opts: ReadOpts & ClaimOpts = {}): string | null {
+  const entry = readLastTerminalUpdateAudit(opts)
+  if (!entry) return null
+  if (!claimUpdateAnnouncement(entry.request_id, opts)) return null
+  return renderUpdateOutcomeLine(entry)
+}

--- a/telegram-plugin/tests/update-announce.test.ts
+++ b/telegram-plugin/tests/update-announce.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readLastTerminalUpdateAudit,
+  renderUpdateOutcomeLine,
+  claimUpdateAnnouncement,
+  maybeRenderUpdateAnnouncement,
+} from "../gateway/update-announce.js";
+
+function makeRow(o: Record<string, unknown>): string {
+  return JSON.stringify(o) + "\n";
+}
+
+describe("update-announce — PR C boot-card surfacing", () => {
+  let tmp: string;
+  let auditPath: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "update-announce-"));
+    auditPath = join(tmp, "host-control-audit.log");
+    stateDir = join(tmp, "state");
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns null when audit log missing", () => {
+    expect(readLastTerminalUpdateAudit({ auditLogPath: auditPath })).toBeNull();
+  });
+
+  it("returns most recent terminal update_apply row within lookback", () => {
+    const now = Date.parse("2026-05-17T12:00:00.000Z");
+    const lines =
+      makeRow({
+        ts: "2026-05-17T11:59:00.000Z",
+        op: "update_apply",
+        caller: { kind: "operator" },
+        request_id: "req-1",
+        result: "ok",
+        exit_code: 0,
+        duration_ms: 1234,
+        phase: "terminal",
+        channel: "dev",
+        resolved_sha: { "switchroom-agent": "sha256:abcdef1234567890" },
+        install_context: { install_type: "binary", detected_at: "2026-05-17T11:00:00Z" },
+      }) +
+      makeRow({
+        ts: "2026-05-17T11:58:00.000Z",
+        op: "update_apply",
+        caller: { kind: "operator" },
+        request_id: "req-0",
+        result: "started",
+        exit_code: null,
+        duration_ms: 0,
+      });
+    writeFileSync(auditPath, lines, "utf-8");
+    const entry = readLastTerminalUpdateAudit({ auditLogPath: auditPath, now });
+    expect(entry).not.toBeNull();
+    expect(entry!.request_id).toBe("req-1");
+  });
+
+  it("skips entries outside lookback window", () => {
+    const now = Date.parse("2026-05-17T12:00:00.000Z");
+    writeFileSync(auditPath, makeRow({
+      ts: "2026-05-17T11:00:00.000Z", // 60 minutes ago
+      op: "update_apply",
+      caller: { kind: "operator" },
+      request_id: "stale",
+      result: "ok",
+      exit_code: 0,
+      duration_ms: 1,
+      phase: "terminal",
+    }), "utf-8");
+    expect(readLastTerminalUpdateAudit({ auditLogPath: auditPath, now, lookbackMs: 10 * 60 * 1000 })).toBeNull();
+  });
+
+  it("renders success line with channel + short sha", () => {
+    const line = renderUpdateOutcomeLine({
+      ts: "2026-05-17T11:59:00.000Z",
+      op: "update_apply",
+      caller: { kind: "operator" },
+      request_id: "req-1",
+      result: "ok",
+      exit_code: 0,
+      duration_ms: 100,
+      phase: "terminal",
+      channel: "dev",
+      resolved_sha: { "switchroom-agent": "sha256:abcdef1234567890aaaa" },
+    });
+    expect(line).toContain("✅ update completed");
+    expect(line).toContain("channel:dev");
+    expect(line).toContain("sha:abcdef123456");
+  });
+
+  it("renders failure line with stderr + recovery hint for binary install", () => {
+    const line = renderUpdateOutcomeLine({
+      ts: "2026-05-17T11:59:00.000Z",
+      op: "update_apply",
+      caller: { kind: "operator" },
+      request_id: "req-2",
+      result: "error",
+      exit_code: 1,
+      duration_ms: 100,
+      phase: "terminal",
+      stderr_tail: "compose pull failed: registry timeout",
+      install_context: { install_type: "binary", detected_at: "2026-05-17T11:00:00Z" },
+    });
+    expect(line).toContain("❌ update failed at update_apply");
+    expect(line).toContain("compose pull failed");
+    expect(line).toContain("Recovery:");
+    expect(line).toContain("install.sh");
+  });
+
+  it("renders unknown recovery hint when install_type missing", () => {
+    const line = renderUpdateOutcomeLine({
+      ts: "2026-05-17T11:59:00.000Z",
+      op: "update_apply",
+      caller: { kind: "operator" },
+      request_id: "req-3",
+      result: "error",
+      exit_code: 1,
+      duration_ms: 100,
+      phase: "terminal",
+    });
+    expect(line).toContain("Cannot auto-detect install type");
+  });
+
+  it("claimUpdateAnnouncement is atomic — second call returns false", () => {
+    expect(claimUpdateAnnouncement("req-abc", { stateDir })).toBe(true);
+    expect(claimUpdateAnnouncement("req-abc", { stateDir })).toBe(false);
+  });
+
+  it("maybeRenderUpdateAnnouncement dedupes on second call", () => {
+    const now = Date.parse("2026-05-17T12:00:00.000Z");
+    writeFileSync(auditPath, makeRow({
+      ts: "2026-05-17T11:59:00.000Z",
+      op: "update_apply",
+      caller: { kind: "operator" },
+      request_id: "req-dedup",
+      result: "ok",
+      exit_code: 0,
+      duration_ms: 1,
+      phase: "terminal",
+      channel: "dev",
+    }), "utf-8");
+    const first = maybeRenderUpdateAnnouncement({ auditLogPath: auditPath, now, stateDir });
+    expect(first).not.toBeNull();
+    const second = maybeRenderUpdateAnnouncement({ auditLogPath: auditPath, now, stateDir });
+    expect(second).toBeNull();
+  });
+});

--- a/tests/docker/anthropic-tool-schema-validator.test.ts
+++ b/tests/docker/anthropic-tool-schema-validator.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { validateAnthropicToolSchemas } from "./anthropic-tool-schema-validator.js";
+
+describe("validateAnthropicToolSchemas", () => {
+  it("accepts a well-formed object schema", () => {
+    const issues = validateAnthropicToolSchemas([
+      {
+        name: "good_tool",
+        inputSchema: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            count: { type: "integer" },
+          },
+          required: ["name"],
+        },
+      },
+    ]);
+    expect(issues).toEqual([]);
+  });
+
+  it("flags missing inputSchema", () => {
+    const issues = validateAnthropicToolSchemas([{ name: "no_schema" }]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatch(/missing inputSchema/);
+  });
+
+  it("flags root.type !== object", () => {
+    const issues = validateAnthropicToolSchemas([
+      { name: "wrong_root", inputSchema: { type: "string" } },
+    ]);
+    expect(issues[0]).toMatch(/root schema type/);
+  });
+
+  it("flags top-level oneOf / anyOf / allOf", () => {
+    const issues = validateAnthropicToolSchemas([
+      { name: "tool_oneof", inputSchema: { type: "object", oneOf: [{ type: "object" }] } },
+      { name: "tool_anyof", inputSchema: { type: "object", anyOf: [{ type: "object" }] } },
+      { name: "tool_allof", inputSchema: { type: "object", allOf: [{ type: "object" }] } },
+    ]);
+    expect(issues).toHaveLength(3);
+    expect(issues.join("\n")).toMatch(/oneOf/);
+    expect(issues.join("\n")).toMatch(/anyOf/);
+    expect(issues.join("\n")).toMatch(/allOf/);
+  });
+
+  it("recurses into property schemas", () => {
+    const issues = validateAnthropicToolSchemas([
+      {
+        name: "nested_bad",
+        inputSchema: {
+          type: "object",
+          properties: {
+            bad_field: { type: "object", oneOf: [{ type: "string" }] },
+          },
+        },
+      },
+    ]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatch(/properties\.bad_field/);
+    expect(issues[0]).toMatch(/oneOf/);
+  });
+
+  it("returns one diagnostic per offending tool", () => {
+    const issues = validateAnthropicToolSchemas([
+      { name: "ok", inputSchema: { type: "object" } },
+      { name: "bad1", inputSchema: { type: "object", oneOf: [] } },
+      { name: "bad2", inputSchema: { type: "array" } },
+    ]);
+    expect(issues).toHaveLength(2);
+  });
+});

--- a/tests/docker/anthropic-tool-schema-validator.ts
+++ b/tests/docker/anthropic-tool-schema-validator.ts
@@ -1,0 +1,88 @@
+/**
+ * Anthropic tool-schema validator — PR C smoke-test gate.
+ *
+ * Anthropic's beta tool-use API requires every tool's `input_schema` to
+ * be a JSON Schema object with `"type": "object"` at the root and NO
+ * top-level `oneOf` / `anyOf` / `allOf` combinators. Per-property
+ * sub-schemas may not use root-level `oneOf` either (some clients
+ * accept it, ours does not).
+ *
+ * Tool-schemas authored as discriminated unions (zod's `.union()`,
+ * TypeBox `Union`, hand-written `oneOf` blocks) compile to schemas that
+ * pass JSON-schema linting but get rejected by Anthropic's tool-use
+ * validator at request time. By that point the tool is on the wire to
+ * users and the agent silently loses access.
+ *
+ * The CI smoke test (Step 4 / `mcp-tools-list.smoke.test.ts`) lists
+ * every tool from a running agent's MCP servers and runs each through
+ * this validator. Any returned message fails the job before the image
+ * promotes to `:dev` — see Step 5 for the gating wire-up.
+ *
+ * Reference sanitizer pattern: `src/cli/drive-mcp-launcher.ts` (PR
+ * #1388) — same family of constraints, server-side guard.
+ */
+
+type AnyJsonSchema = Record<string, unknown>;
+
+export interface ToolForValidation {
+  name?: string;
+  inputSchema?: AnyJsonSchema;
+}
+
+const FORBIDDEN_TOP_LEVEL_KEYS = ["oneOf", "anyOf", "allOf"] as const;
+
+function validateSchemaShape(
+  toolName: string,
+  schema: AnyJsonSchema,
+  path: string,
+  out: string[],
+  depth = 0,
+): void {
+  // Depth gate — schemas are rarely nested past 6 levels in real-world
+  // tool definitions; bail before pathological inputs blow the stack.
+  if (depth > 6) return;
+  if (path === "root") {
+    if (schema.type !== "object") {
+      out.push(`${toolName}: root schema type=${JSON.stringify(schema.type)} (must be "object")`);
+    }
+  }
+  for (const key of FORBIDDEN_TOP_LEVEL_KEYS) {
+    if (key in schema) {
+      out.push(`${toolName}: ${path} contains forbidden combinator '${key}' — Anthropic tool-use rejects discriminated-union schemas`);
+    }
+  }
+  const props = schema.properties;
+  if (props && typeof props === "object" && !Array.isArray(props)) {
+    for (const [propName, propSchema] of Object.entries(props as Record<string, unknown>)) {
+      if (propSchema && typeof propSchema === "object" && !Array.isArray(propSchema)) {
+        validateSchemaShape(
+          toolName,
+          propSchema as AnyJsonSchema,
+          `${path}.properties.${propName}`,
+          out,
+          depth + 1,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Validate a list of MCP tools. Returns one diagnostic per offending
+ * tool; an empty array means all tools are Anthropic-compatible.
+ */
+export function validateAnthropicToolSchemas(
+  tools: ReadonlyArray<ToolForValidation>,
+): string[] {
+  const out: string[] = [];
+  for (const tool of tools) {
+    const name = tool.name ?? "<unnamed>";
+    const schema = tool.inputSchema;
+    if (!schema || typeof schema !== "object") {
+      out.push(`${name}: missing inputSchema`);
+      continue;
+    }
+    validateSchemaShape(name, schema as AnyJsonSchema, "root", out);
+  }
+  return out;
+}

--- a/tests/docker/mcp-tools-list.smoke.test.ts
+++ b/tests/docker/mcp-tools-list.smoke.test.ts
@@ -1,0 +1,98 @@
+/**
+ * MCP tools/list smoke test — PR C Step 4.
+ *
+ * Boots a minimal agent container with `channels.telegram.enabled: false`
+ * (no bot token required at boot — PR C step 1 wired this into the
+ * start.sh template), opens an MCP `StdioClientTransport` over
+ * `docker exec -i <ctr> switchroom mcp agent-config`, lists all tools,
+ * and runs them through {@link validateAnthropicToolSchemas} so we
+ * catch oneOf/anyOf regressions BEFORE the image promotes to `:dev`.
+ *
+ * Gating:
+ *   - `RUN_DOCKER_SMOKE=1` in the environment turns the suite on. In
+ *     normal CI / dev `npm test` runs it skips so unit-test cycles stay
+ *     fast and don't require Docker.
+ *   - The harness runs the SDK transport spike first
+ *     (`spikeStdioOverDockerExec`) — if the underlying transport is
+ *     broken in the pinned SDK version, we fail-fast with the spike's
+ *     verbatim message rather than time out trying to list tools.
+ *
+ * Lifecycle:
+ *   - The harness owns the container. Image tag taken from
+ *     `SMOKE_AGENT_IMAGE` (default ghcr.io/switchroom/switchroom-agent:dev).
+ *   - Container is created, started, polled-until-ready, listed, then
+ *     torn down in a `finally` block — even on assertion failure.
+ *   - Timeout: vitest default per-test (10s) extended to 5min via
+ *     `testTimeout` below.
+ */
+
+import { describe, it, expect } from "vitest";
+import { execSync, spawnSync } from "node:child_process";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { validateAnthropicToolSchemas } from "./anthropic-tool-schema-validator.js";
+import { spikeStdioOverDockerExec } from "./spike-stdio-transport.js";
+
+const RUN = process.env.RUN_DOCKER_SMOKE === "1";
+const SMOKE_IMAGE =
+  process.env.SMOKE_AGENT_IMAGE ?? "ghcr.io/switchroom/switchroom-agent:dev";
+const CONTAINER_NAME = `switchroom-smoke-${process.pid}`;
+
+function dockerAvailable(): boolean {
+  try {
+    spawnSync("docker", ["version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(!RUN || !dockerAvailable())("mcp tools/list smoke test", () => {
+  it(
+    "all MCP tools pass Anthropic tool-schema constraints",
+    { timeout: 5 * 60 * 1000 },
+    async () => {
+      let started = false;
+      try {
+        // 1. Start a throwaway container with telegram disabled.
+        execSync(
+          `docker run -d --rm --name ${CONTAINER_NAME} ` +
+            `-e SWITCHROOM_RUNTIME=docker ` +
+            `-e SWITCHROOM_AGENT_NAME=smoke ` +
+            `-e TELEGRAM_ENABLED=false ` +
+            `--entrypoint sleep ${SMOKE_IMAGE} 600`,
+          { stdio: "pipe" },
+        );
+        started = true;
+
+        // 2. Spike the transport BEFORE relying on it for the real call.
+        await spikeStdioOverDockerExec({ containerId: CONTAINER_NAME });
+
+        // 3. Connect for real to the agent-config MCP server.
+        const transport = new StdioClientTransport({
+          command: "docker",
+          args: ["exec", "-i", CONTAINER_NAME, "switchroom", "mcp", "agent-config"],
+        });
+        const client = new Client(
+          { name: "switchroom-smoke", version: "0.0.1" },
+          { capabilities: {} },
+        );
+        await client.connect(transport);
+
+        // 4. List tools and validate every schema.
+        const result = await client.listTools();
+        const issues = validateAnthropicToolSchemas(result.tools);
+        await client.close();
+        expect(issues, issues.join("\n")).toEqual([]);
+      } finally {
+        if (started) {
+          try {
+            execSync(`docker rm -f ${CONTAINER_NAME}`, { stdio: "ignore" });
+          } catch {
+            // best-effort teardown
+          }
+        }
+      }
+    },
+  );
+});

--- a/tests/docker/spike-stdio-transport.ts
+++ b/tests/docker/spike-stdio-transport.ts
@@ -1,0 +1,84 @@
+/**
+ * Spike — does @modelcontextprotocol/sdk's StdioClientTransport tolerate
+ * being pointed at a `docker exec -i <ctr> <cmd>` shell wrapper?
+ *
+ * The PR C smoke test depends on this: we want to list tools from an
+ * MCP server running inside a fresh agent container WITHOUT having to
+ * implement a custom transport. If `StdioClientTransport`'s spawn
+ * argument list happily forwards stdio through `docker exec`, we're
+ * done. If not, the smoke test can't work in its current shape.
+ *
+ * Run standalone with `bun tests/docker/spike-stdio-transport.ts <ctr>`
+ * or via the test harness which probes a throwaway `docker exec echo`
+ * pipe before launching the real MCP server.
+ *
+ * Returns true on success; throws with a descriptive message on
+ * failure. The thrown message is the exact actionable string the
+ * smoke-test harness re-raises.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+export interface SpikeOpts {
+  /** Container name or id to docker exec into. */
+  containerId: string;
+  /** Command to run inside the container — defaults to `cat` which
+   *  trivially echoes whatever JSONRPC handshake bytes the SDK writes
+   *  back at it (useful for testing the transport pipe only, NOT for
+   *  any actual MCP behaviour). */
+  command?: string;
+  /** Args to pass after the command. */
+  args?: string[];
+  /** Connection timeout in ms (default 5000). */
+  timeoutMs?: number;
+}
+
+const SPIKE_FAIL_MESSAGE =
+  "stdio-over-docker-exec transport is broken in this SDK version — pin or patch before re-running smoke-test";
+
+export async function spikeStdioOverDockerExec(opts: SpikeOpts): Promise<boolean> {
+  const { containerId, command = "cat", args = [], timeoutMs = 5000 } = opts;
+  const transport = new StdioClientTransport({
+    command: "docker",
+    args: ["exec", "-i", containerId, command, ...args],
+  });
+  const client = new Client(
+    { name: "switchroom-smoke-spike", version: "0.0.1" },
+    { capabilities: {} },
+  );
+  const connectPromise = client.connect(transport);
+  const timeoutPromise = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error("connect timeout")), timeoutMs),
+  );
+  try {
+    await Promise.race([connectPromise, timeoutPromise]);
+    await client.close();
+    return true;
+  } catch (err) {
+    // Some SDK versions surface the docker-exec wrapping issue as a
+    // "Cannot spawn ..." error — others as a hang. Either way, fail
+    // fast with the actionable string.
+    throw new Error(
+      `${SPIKE_FAIL_MESSAGE}: ${(err as Error).message ?? String(err)}`,
+    );
+  }
+}
+
+// Standalone CLI mode for ad-hoc verification: `bun spike-stdio-transport.ts <ctr>`
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const ctr = process.argv[2];
+  if (!ctr) {
+    console.error("usage: bun spike-stdio-transport.ts <container-id-or-name>");
+    process.exit(2);
+  }
+  spikeStdioOverDockerExec({ containerId: ctr })
+    .then(() => {
+      console.log("spike PASS — StdioClientTransport works over docker exec");
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error(`spike FAIL: ${(err as Error).message}`);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

Final piece (3 of 3) of the v10 update-flow redesign. PRs A (#1415) and B (#1431) landed the schema field + CLI/MCP plumbing; this PR delivers the operator-visible outcome.

**What lands:**
- **Gateway boot-card auto-surfaces update outcomes.** On boot, the gateway scans the hostd audit log for the most-recent terminal `update_apply` row within a 10-minute window, atomic-claims it via `O_EXCL`, and appends a success line or failure-with-recovery-hint block to the boot-card body. Recovery hint switches on the `install_context.install_type` captured by PR B.
- **`telegram.enabled: false` is now wired into start.sh** — PR A added the schema field, this PR makes it actually skip the gateway sidecar so the smoke-test harness can boot an agent container without a bot token.
- **`UserPromptSubmit` hook** for mid-conversation MCP-originated updates (when a peer agent fires update_apply, THIS agent doesn't restart — the hook surfaces the outcome on the next prompt, deduped against the boot-card path via the same `update-announced/<request_id>` sentinel; boot-card wins). Installed idempotently by `switchroom apply`.
- **CI smoke-test** (staged at `docs/proposed/docker-images.yml`): boots the freshly-pushed `:sha-<7>` agent image, opens an MCP `StdioClientTransport` over `docker exec`, lists every tool, runs them through a new validator that catches Anthropic tool-schema regressions (`root.type !== object`, top-level `oneOf`/`anyOf`/`allOf`). Gates the floating `:dev` tag.
- **`promote.yml` workflow** (staged at `docs/proposed/promote.yml`) for hand-promoting `dev → rc → latest`. Precheck + retag (no rebuild) + post-retag digest equality verification.

**Workflow files staged at `docs/proposed/`** because this OAuth token lacks the `workflow` scope — operator must `git mv` into `.github/workflows/` to activate.

## Test plan

- [x] update-announce tests (8 new)
- [x] update-prompt-hook tests (4 new)
- [x] anthropic-tool-schema-validator tests (6 new)
- [x] scaffold + apply suites green
- [x] Full suite: 6491 pass / 49 skipped / 2 pre-existing flakes (pass in isolation)
- [ ] CI smoke job validates a real agent image once workflow is activated
- [ ] Operator-triggered promote.yml dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)