### PR TITLE
fix(vault-broker): route host CLI to the containerized broker — RFC J Phase 3

### DIFF
--- a/src/cli/vault-broker.ts
+++ b/src/cli/vault-broker.ts
@@ -25,6 +25,7 @@ import {
   statusViaBroker,
   lockViaBroker,
   unlockViaBroker,
+  brokerIsComposeManaged,
   resolveBrokerSocketPath,
 } from "../vault/broker/client.js";
 import { VaultBroker, registerShutdownHandlers } from "../vault/broker/server.js";
@@ -222,8 +223,25 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
           console.error(`[vault-broker] Failed to start: ${msg}`);
           process.exit(1);
         }
+      } else if (brokerIsComposeManaged()) {
+        // A dockerized broker is already serving here (operator socket
+        // present). Spawning a detached HOST daemon would create a
+        // phantom second broker that `status` then reports on while
+        // the real containerized one is ignored — exactly the #32
+        // confusion that masked install-validation 2026-05-17. The
+        // container's lifecycle is docker compose's job.
+        console.log(
+          "vault-broker is managed by docker compose (operator socket present).",
+        );
+        console.log(
+          "  It starts with the project: `switchroom apply` / " +
+            "`docker compose -p switchroom -f ~/.switchroom/compose/docker-compose.yml up -d`.",
+        );
+        console.log("  To unlock it: `switchroom vault broker unlock`.");
+        process.exit(0);
       } else {
-        // Detached mode: spawn a background process and exit.
+        // Detached mode (v0.6 host/systemd): spawn a background
+        // process and exit.
         const self = process.argv[1];
         const args = ["vault", "broker", "start", "--foreground"];
         if (parentOpts.config) args.unshift("--config", parentOpts.config);
@@ -248,10 +266,24 @@ export function registerVaultBrokerCommand(vaultCmd: Command, program: Command):
         socket: getSocketPath(parentOpts.config),
       });
 
-      // Send lock RPC first (best-effort)
+      // Send lock RPC first (best-effort) — routes to the operator
+      // socket under docker, so this locks the real containerized
+      // broker (the security-relevant effect of "stop").
       await lockViaBroker({ socket });
 
-      // Read PID file and send SIGTERM
+      if (brokerIsComposeManaged()) {
+        // No host PID to kill — the container's lifecycle is docker
+        // compose's. The broker is now locked; stopping the container
+        // is a separate compose operation (RFC J Phase 3 / #32).
+        console.log("vault-broker locked. It is managed by docker compose;");
+        console.log(
+          "  to stop the container: `docker compose -p switchroom " +
+            "-f ~/.switchroom/compose/docker-compose.yml stop vault-broker`.",
+        );
+        process.exit(0);
+      }
+
+      // v0.6 host/systemd: read PID file and send SIGTERM
       const pidPath = resolvePath(DEFAULT_PID_FILE);
       if (!existsSync(pidPath)) {
         console.error("vault-broker PID file not found — is the daemon running?");

--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -67,22 +67,43 @@ const OPERATOR_SOCKET_PATH = join(homedir(), ".switchroom", "broker-operator", "
  * Under systemd mode (v0.6), the legacy `~/.switchroom/vault-broker.sock`
  * is bound directly by the host-side broker daemon.
  *
- * If we're in Docker mode but the operator socket isn't there yet
- * (broker container not yet recreated post-`switchroom apply`), fall
- * back to the legacy path so the resulting "unreachable" error message
- * points operators at a path they actually expect rather than at the
- * dummy operator path.
+ * Deployment truth beats runtime guessing (RFC J Phase 3 / #32).
+ * `isDockerRuntime()` is just `SWITCHROOM_RUNTIME==="docker"`, which
+ * compose sets on the CONTAINERS but is unset in a plain host
+ * operator shell. The previous `if (isDockerRuntime())` gate
+ * therefore mis-routed `switchroom vault broker {status,unlock,lock}`
+ * run from the docker host to the LEGACY host-daemon socket — so
+ * `status` reported a phantom host daemon (and `start` spawned one)
+ * while the real containerized broker, serving an operator socket
+ * right there on disk, was ignored and reported "down" while up
+ * (install-validation 2026-05-17). The operator socket is bound +
+ * chowned ONLY by the dockerized broker, so its presence on disk is
+ * unambiguous proof that a containerized broker is serving here —
+ * regardless of whether this shell happens to have SWITCHROOM_RUNTIME
+ * set. Check that first.
  */
 function defaultBrokerSocketPath(): string {
-  if (isDockerRuntime()) {
-    if (fs.existsSync(OPERATOR_SOCKET_PATH)) return OPERATOR_SOCKET_PATH;
-    // Docker mode but no operator socket yet — try operator path anyway
-    // (so the connect error names the path operators should see). Falls
-    // through to legacy below only if the operator path also isn't
-    // configured at all (extremely unusual).
-    return OPERATOR_SOCKET_PATH;
-  }
+  // 1. Operator socket present → a dockerized broker is serving it
+  //    (deployment truth; works from host shells too).
+  if (fs.existsSync(OPERATOR_SOCKET_PATH)) return OPERATOR_SOCKET_PATH;
+  // 2. In-container docker mode before the operator socket is bound
+  //    (broker not yet recreated post-`apply`) — name the operator
+  //    path so the "unreachable" error points where operators expect.
+  if (isDockerRuntime()) return OPERATOR_SOCKET_PATH;
+  // 3. v0.6 host/systemd mode — legacy host-daemon socket.
   return LEGACY_SOCKET_PATH;
+}
+
+/**
+ * True when a dockerized (compose-managed) broker is serving here.
+ * The operator socket is bound + chowned ONLY by the containerized
+ * broker, so its presence is unambiguous deployment truth from a
+ * host shell (where SWITCHROOM_RUNTIME is unset). Used to stop
+ * `vault broker start/stop` from spawning/killing a phantom host
+ * daemon on a docker host (RFC J Phase 3 / #32).
+ */
+export function brokerIsComposeManaged(): boolean {
+  return fs.existsSync(OPERATOR_SOCKET_PATH);
 }
 
 const DEFAULT_SOCKET_PATH = LEGACY_SOCKET_PATH; // preserved for tests / back-compat


### PR DESCRIPTION
## Summary

**RFC J Phase 3** — the #32 fix. Precise root cause: `isDockerRuntime()` is just `SWITCHROOM_RUNTIME==="docker"`, which compose sets on the **containers** but is **unset in a plain host operator shell**. So `switchroom vault broker {status,unlock,lock,start,stop}` run from the docker host fell through to the **legacy host-daemon socket** — `status` reported a phantom host daemon (and `start` spawned one) while the real containerized broker, serving an operator socket right there on disk, was reported "down" while up. This is exactly why the install-validation 2026-05-17 two-bot matrix couldn't unlock the broker.

- **`src/vault/broker/client.ts`** `defaultBrokerSocketPath`: prefer the operator socket whenever it **exists on disk**, *before* the `isDockerRuntime()` gate. It's bound + chowned only by the dockerized broker, so presence = unambiguous deployment truth (works from host shells). v0.6 host mode (no operator socket, not docker) is **unchanged** → legacy socket. Adds exported `brokerIsComposeManaged()`.
- **`src/cli/vault-broker.ts`**: `start` (detached host-spawn) and `stop` (host PID-kill) now no-op with clear guidance when a compose-managed broker is present, instead of spawning/killing a phantom the resolver/`status` would misreport. The `--foreground` entrypoint and v0.6 host paths are unchanged. `stop` still sends the lock RPC first (routes to the operator socket → locks the real container broker — the security-relevant effect).

**Phase 3b (tracked follow-up):** bake the `switchroom` CLI into `docker/Dockerfile.broker` so `docker exec switchroom-vault-broker switchroom vault broker unlock` works — an image/build change with larger blast radius; the primary host unlock path is fixed here. **Phase 4b** (the `vault broker unlock` "Timeout-on-success" race) also still pending.

## Validation

- `tsc --noEmit` clean. compose-generator 140/140; vault.test + cli-vault-get-token 63/63. No pinned-behavior test breaks (the resolver change is a provably-correct reordering; the only prior behaviors — docker-in-container, v0.6 host — are unchanged).
- The resolver has no injectable test seam without a disproportionate refactor; end-to-end #32 proof is the **consolidated fresh-VM re-validation** (RFC §6).

## Test plan

- [ ] CI `lint` + `vitest` green
- [ ] Reviewer confirms: v0.6 host path byte-unchanged; in-container docker path unchanged; only the host-shell-on-docker-host case changes (now correctly reaches the container); `--foreground` entrypoint untouched; `stop` still locks the real broker
- [ ] Phase 3b + 4b tracked
- [ ] Consolidated fresh-VM re-validation (RFC §6) once 3b/4b land

🤖 Generated with [Claude Code](https://claude.com/claude-code)