### PR TITLE
fix(ci): constrain Dependabot docker to digest/patch, not Node major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,20 @@ updates:
     labels:
       - "dependencies"
       - "security"
+    # WS9-F4's intent is reviewed *digest* refreshes of the pinned
+    # base images (security rebuilds WITHIN the chosen, tested major)
+    # — not being dragged onto a brand-new Node major that breaks the
+    # build. Unconstrained, Dependabot proposed node 22→26 (#1438,
+    # e2e-red). Ignore major/minor version-updates for node so it only
+    # raises digest + 22.x-patch PRs; a base-image major bump is a
+    # deliberate, separately-validated decision, never an auto-PR.
+    # (hindsight is pinned via `:latest@sha256` — no semver applies, so
+    # its digest-follow PRs are unaffected by this rule.)
+    ignore:
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

**Fixes the failing CI from #1438.** #1418/WS9-F4 enabled Dependabot's `docker` ecosystem to keep the `@sha256`-pinned base images fresh. Unconstrained, it immediately opened **#1438 — `node 22-bookworm-slim → 26-bookworm-slim`**, a major Node jump that **fails `docker-e2e`** and is the opposite of WS9-F4's intent (reviewed *digest* refreshes within the chosen/tested major, not auto-upgrading the runtime).

Root-cause fix: add an `ignore` rule to the docker ecosystem dropping `node` `semver-major` + `semver-minor` version-updates. Dependabot now raises only the `node:22-bookworm-slim` **digest** (+ 22.x patch) PRs WS9-F4 actually wanted; a base-image major bump becomes a deliberate, separately-validated decision rather than a red auto-PR. `hindsight` (`:latest@sha256`, no semver) is unaffected — its digest-follow PRs still flow.

Once merged, Dependabot re-evaluates and supersedes #1438 with a digest-only PR; #1438 will be closed referencing this.

## Test plan

- [x] `.github/dependabot.yml` valid (parsed; ignore rule asserted: node major+minor)
- [x] Diagnosis confirmed from #1438's e2e log: `FROM node:26-bookworm-slim@sha256:…` is the build that fails
- [x] `#1443` (github-actions setup-buildx bump) `e2e fail` is the known-flaky `docker-e2e` class (sibling github-actions bumps #1440/#1441 passed) — not a config-content issue; a re-run clears it (no code change warranted)
- [ ] CI green

Config-only; no application/code surface. Refs #1418 #1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)