### PR TITLE
fix(doctor): MFF probes per-agent + WS6-F2 agent-private aware

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -11,7 +11,7 @@ import {
   readdirSync,
   statSync,
 } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { createPublicKey, createPrivateKey } from "node:crypto";
 import { listSecrets, getStringSecret } from "../vault/vault.js";
 import { resolveAgentsDir, resolvePath } from "../config/loader.js";
@@ -1584,14 +1584,53 @@ export function printSection(title: string, results: CheckResult[]): {
 export const MFF_VAULT_KEY = "mff/agent-private-key";
 
 /**
- * Default .env path for the MFF skill credentials.
+ * Name of the first agent that enables the MFF skill, if any. Since
+ * WS6-F2 (#1390) MFF credentials live per-agent under
+ * `~/.switchroom/credentials/<agent>/my-family-finance/`, so the doctor
+ * resolves the path from config rather than the retired flat location.
  * @internal exported for testing
  */
-export function mffEnvPath(): string {
-  return resolve(
-    process.env.HOME ?? "/root",
-    ".switchroom/credentials/my-family-finance/.env",
-  );
+export function mffAgentName(config?: SwitchroomConfig): string | undefined {
+  for (const [name, ac] of Object.entries(config?.agents ?? {})) {
+    if (((ac?.skills as string[] | undefined) ?? []).includes("my-family-finance")) {
+      return name;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the MFF skill `.env` path. Per-agent since WS6-F2; falls back
+ * to the legacy flat path when no MFF agent is configured (preserves
+ * behaviour for pre-WS6-F2 installs and explicit-path test calls).
+ * @internal exported for testing
+ */
+export function mffEnvPath(config?: SwitchroomConfig): string {
+  const home = process.env.HOME ?? "/root";
+  const agent = mffAgentName(config);
+  return agent
+    ? resolve(home, ".switchroom/credentials", agent, "my-family-finance/.env")
+    : resolve(home, ".switchroom/credentials/my-family-finance/.env");
+}
+
+/**
+ * Classify the MFF env path. `agent-private` is the EXPECTED healthy
+ * post-WS6-F2 state: the file exists but is owned by the agent UID
+ * (mode 600), so the operator-run doctor cannot read it BY DESIGN —
+ * that is the security boundary working, not a failure. `absent` is a
+ * real misconfig; `readable` is a legacy-flat or test path the host
+ * can fully validate.
+ * @internal exported for testing
+ */
+export type MffEnvState = "absent" | "agent-private" | "readable";
+export function mffEnvState(envPath: string): MffEnvState {
+  if (!existsSync(envPath)) return "absent";
+  try {
+    accessSync(envPath, fsConstants.R_OK);
+    return "readable";
+  } catch {
+    return "agent-private";
+  }
 }
 
 /**
@@ -1737,12 +1776,20 @@ export function checkMffVaultKeyFormat(
 export function checkMffEnvFile(
   envPath: string = mffEnvPath(),
 ): CheckResult {
-  if (!existsSync(envPath)) {
+  const state = mffEnvState(envPath);
+  if (state === "absent") {
     return {
       name: "mff: .env present",
       status: "fail",
       detail: `${envPath} not found`,
-      fix: "Create ~/.switchroom/credentials/my-family-finance/.env with MFF_API_URL=https://...",
+      fix: "Place the MFF skill's .env in the per-agent credentials dir, e.g. `~/.switchroom/credentials/<agent>/my-family-finance/.env` (MFF_API_URL=https://...), then `switchroom update`",
+    };
+  }
+  if (state === "agent-private") {
+    return {
+      name: "mff: .env present",
+      status: "ok",
+      detail: `present, agent-private (${envPath}) — per-agent since WS6-F2; the operator-run doctor cannot read it by design`,
     };
   }
   const env = parseEnvFile(envPath);
@@ -1770,6 +1817,17 @@ export async function checkMffApiReachable(
   envPath: string = mffEnvPath(),
   timeoutMs = 5000,
 ): Promise<CheckResult> {
+  const state = mffEnvState(envPath);
+  if (state !== "readable") {
+    return {
+      name: "mff: API reachable",
+      status: "warn",
+      detail:
+        state === "agent-private"
+          ? "skipped — MFF creds are per-agent/agent-private since WS6-F2; deep probe must run in-agent"
+          : "skipped (MFF .env not found — see 'mff: .env present')",
+    };
+  }
   const env = parseEnvFile(envPath);
   const apiUrl = env.MFF_API_URL?.trim();
   if (!apiUrl) {
@@ -1827,6 +1885,17 @@ export async function checkMffAuthFlow(
   envPath: string = mffEnvPath(),
   timeoutMs = 8000,
 ): Promise<CheckResult> {
+  const state = mffEnvState(envPath);
+  if (state !== "readable") {
+    return {
+      name: "mff: auth flow",
+      status: "warn",
+      detail:
+        state === "agent-private"
+          ? "skipped — MFF creds are per-agent/agent-private since WS6-F2; deep probe must run in-agent"
+          : "skipped (MFF .env not found — see 'mff: .env present')",
+    };
+  }
   const env = parseEnvFile(envPath);
   const apiUrl = env.MFF_API_URL?.trim();
   if (!apiUrl) {
@@ -1837,8 +1906,9 @@ export async function checkMffAuthFlow(
     };
   }
 
-  // Locate claude-auth.py relative to the MFF credentials dir.
-  const credDir = resolve(process.env.HOME ?? "/root", ".switchroom/credentials/my-family-finance");
+  // Locate claude-auth.py next to the .env (per-agent dir since
+  // WS6-F2 — colocated with the skill's other credential files).
+  const credDir = dirname(envPath);
   const authScript = join(credDir, "claude-auth.py");
   if (!existsSync(authScript)) {
     return {
@@ -1937,6 +2007,17 @@ export async function checkMffCloudflareUa(
   envPath: string = mffEnvPath(),
   timeoutMs = 5000,
 ): Promise<CheckResult> {
+  const state = mffEnvState(envPath);
+  if (state !== "readable") {
+    return {
+      name: "mff: Cloudflare UA bypass",
+      status: "warn",
+      detail:
+        state === "agent-private"
+          ? "skipped — MFF creds are per-agent/agent-private since WS6-F2; deep probe must run in-agent"
+          : "skipped (MFF .env not found — see 'mff: .env present')",
+    };
+  }
   const env = parseEnvFile(envPath);
   const apiUrl = env.MFF_API_URL?.trim();
   if (!apiUrl) {
@@ -2016,7 +2097,8 @@ export async function checkMffCloudflareUa(
 export async function checkMff(
   passphrase: string | undefined,
   vaultPath: string,
-  envPath: string = mffEnvPath(),
+  config?: SwitchroomConfig,
+  envPath: string = mffEnvPath(config),
 ): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
   results.push(checkMffVaultKeyPresent(passphrase, vaultPath));
@@ -2193,7 +2275,7 @@ export function registerDoctorCommand(program: Command): void {
 
         // --skill mff: run MFF probes only
         if (opts.skill === "mff") {
-          const mffResults = await checkMff(passphrase, vaultPath);
+          const mffResults = await checkMff(passphrase, vaultPath, config);
           if (opts.json) {
             console.log(
               JSON.stringify(
@@ -2236,7 +2318,7 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Docker (Phase 1a)", results: runDockerSection(config) },
           { title: "Auth Broker", results: runAuthBrokerChecks(config) },
           { title: "Google Drive", results: runDriveChecks(config) },
-          { title: "MFF Skill", results: await checkMff(passphrase, vaultPath) },
+          { title: "MFF Skill", results: await checkMff(passphrase, vaultPath, config) },
         ];
 
         // Repo Hygiene (#1072): only when doctor runs from a switchroom

--- a/tests/doctor.mff.test.ts
+++ b/tests/doctor.mff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, writeFileSync, rmSync, chmodSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -12,7 +12,11 @@ import {
   checkMffAuthFlow,
   checkMffCloudflareUa,
   checkMff,
+  mffAgentName,
+  mffEnvPath,
+  mffEnvState,
 } from "../src/cli/doctor.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
 import { generateKeyPairSync } from "node:crypto";
 import { createVault, setStringSecret } from "../src/vault/vault.js";
 
@@ -359,10 +363,13 @@ describe("checkMffAuthFlow", () => {
   });
 
   it("returns fail when claude-auth.py exits non-zero", async () => {
-    const envPath = join(tempDir, ".env");
-    writeFileSync(envPath, `MFF_API_URL=https://mff.example.com\n`);
     const credDir = join(tempDir, ".switchroom/credentials/my-family-finance");
     mkdirSync(credDir, { recursive: true });
+    // .env and claude-auth.py are colocated in the per-agent dir (the
+    // real WS6-F2 layout) — the probe resolves the script from
+    // dirname(envPath).
+    const envPath = join(credDir, ".env");
+    writeFileSync(envPath, `MFF_API_URL=https://mff.example.com\n`);
     const authScript = join(credDir, "claude-auth.py");
     writeFileSync(authScript, "import sys\nprint('error: auth failed', file=sys.stderr)\nsys.exit(1)\n");
 
@@ -378,10 +385,13 @@ describe("checkMffAuthFlow", () => {
   });
 
   it("returns fail when claude-auth.py prints no token", async () => {
-    const envPath = join(tempDir, ".env");
-    writeFileSync(envPath, `MFF_API_URL=https://mff.example.com\n`);
     const credDir = join(tempDir, ".switchroom/credentials/my-family-finance");
     mkdirSync(credDir, { recursive: true });
+    // .env and claude-auth.py are colocated in the per-agent dir (the
+    // real WS6-F2 layout) — the probe resolves the script from
+    // dirname(envPath).
+    const envPath = join(credDir, ".env");
+    writeFileSync(envPath, `MFF_API_URL=https://mff.example.com\n`);
     const authScript = join(credDir, "claude-auth.py");
     writeFileSync(authScript, "# empty output\n");
 
@@ -397,10 +407,13 @@ describe("checkMffAuthFlow", () => {
   });
 
   it("returns ok when auth script produces a token accepted by the API", async () => {
-    const envPath = join(tempDir, ".env");
-    writeFileSync(envPath, `MFF_API_URL=https://mff.example.com\n`);
     const credDir = join(tempDir, ".switchroom/credentials/my-family-finance");
     mkdirSync(credDir, { recursive: true });
+    // .env and claude-auth.py are colocated in the per-agent dir (the
+    // real WS6-F2 layout) — the probe resolves the script from
+    // dirname(envPath).
+    const envPath = join(credDir, ".env");
+    writeFileSync(envPath, `MFF_API_URL=https://mff.example.com\n`);
     const authScript = join(credDir, "claude-auth.py");
     writeFileSync(authScript, "print('valid-session-token-abc')\n");
 
@@ -418,10 +431,13 @@ describe("checkMffAuthFlow", () => {
   });
 
   it("returns fail when token is rejected by the API", async () => {
-    const envPath = join(tempDir, ".env");
-    writeFileSync(envPath, `MFF_API_URL=https://mff.example.com\n`);
     const credDir = join(tempDir, ".switchroom/credentials/my-family-finance");
     mkdirSync(credDir, { recursive: true });
+    // .env and claude-auth.py are colocated in the per-agent dir (the
+    // real WS6-F2 layout) — the probe resolves the script from
+    // dirname(envPath).
+    const envPath = join(credDir, ".env");
+    writeFileSync(envPath, `MFF_API_URL=https://mff.example.com\n`);
     const authScript = join(credDir, "claude-auth.py");
     writeFileSync(authScript, "print('bad-token')\n");
 
@@ -519,7 +535,7 @@ describe("checkMff", () => {
     const envPath = join(tempDir, ".env");
     writeFileSync(envPath, "OTHER=x\n");
     globalThis.fetch = vi.fn(async () => ({ ok: true, status: 200 })) as typeof fetch;
-    const results = await checkMff(undefined, vaultPath, envPath);
+    const results = await checkMff(undefined, vaultPath, undefined, envPath);
     expect(results).toHaveLength(6);
   });
 
@@ -536,11 +552,109 @@ describe("checkMff", () => {
     // Stub fetch — /api/health and /api/categories both return 200
     globalThis.fetch = vi.fn(async () => ({ ok: true, status: 200 })) as typeof fetch;
 
-    const results = await checkMff(passphrase, vaultPath, envPath);
+    const results = await checkMff(passphrase, vaultPath, undefined, envPath);
     expect(results).toHaveLength(6);
 
     for (const r of results) {
       expect(["ok", "warn"]).toContain(r.status);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-agent resolution + WS6-F2 agent-private semantics (#1390 follow-up)
+// ---------------------------------------------------------------------------
+
+const isRoot =
+  typeof process.getuid === "function" && process.getuid() === 0;
+
+function cfg(agents: Record<string, { skills?: string[] }>): SwitchroomConfig {
+  return { agents } as unknown as SwitchroomConfig;
+}
+
+describe("mffAgentName", () => {
+  it("returns the first agent that enables the MFF skill", () => {
+    expect(
+      mffAgentName(cfg({ clerk: { skills: ["foo", "my-family-finance"] }, finn: {} })),
+    ).toBe("clerk");
+  });
+  it("returns undefined when no agent enables MFF", () => {
+    expect(mffAgentName(cfg({ clerk: { skills: ["foo"] } }))).toBeUndefined();
+  });
+  it("returns undefined for missing/empty config", () => {
+    expect(mffAgentName(undefined)).toBeUndefined();
+    expect(mffAgentName(cfg({}))).toBeUndefined();
+  });
+});
+
+describe("mffEnvPath", () => {
+  it("resolves the per-agent path when an MFF agent is configured", () => {
+    const p = mffEnvPath(cfg({ clerk: { skills: ["my-family-finance"] } }));
+    expect(p).toContain("/credentials/clerk/my-family-finance/.env");
+  });
+  it("falls back to the legacy flat path when no MFF agent", () => {
+    const p = mffEnvPath(cfg({ clerk: { skills: [] } }));
+    expect(p).toContain("/credentials/my-family-finance/.env");
+    expect(p).not.toContain("/credentials/clerk/");
+  });
+});
+
+describe("mffEnvState", () => {
+  let tempDir: string;
+  beforeEach(() => { tempDir = makeTempDir(); });
+  afterEach(() => { rmSync(tempDir, { recursive: true, force: true }); });
+
+  it("returns 'absent' when the path does not exist", () => {
+    expect(mffEnvState(join(tempDir, "nope.env"))).toBe("absent");
+  });
+  it("returns 'readable' for a normal file", () => {
+    const p = join(tempDir, ".env");
+    writeFileSync(p, "MFF_API_URL=https://x\n");
+    expect(mffEnvState(p)).toBe("readable");
+  });
+  it.skipIf(isRoot)(
+    "returns 'agent-private' when the file exists but is unreadable",
+    () => {
+      const p = join(tempDir, ".env");
+      writeFileSync(p, "MFF_API_URL=https://x\n");
+      chmodSync(p, 0o000);
+      expect(mffEnvState(p)).toBe("agent-private");
+    },
+  );
+});
+
+describe("WS6-F2 agent-private behaviour", () => {
+  let tempDir: string;
+  beforeEach(() => { tempDir = makeTempDir(); });
+  afterEach(() => { rmSync(tempDir, { recursive: true, force: true }); });
+
+  it.skipIf(isRoot)(
+    "checkMffEnvFile returns ok (not fail) for an agent-private .env",
+    () => {
+      const p = join(tempDir, ".env");
+      writeFileSync(p, "MFF_API_URL=https://x\n");
+      chmodSync(p, 0o000);
+      const r = checkMffEnvFile(p);
+      expect(r.status).toBe("ok");
+      expect(r.detail).toContain("agent-private");
+    },
+  );
+
+  it.skipIf(isRoot)(
+    "deep probes skip (warn) on an agent-private .env — no host read of agent secrets",
+    async () => {
+      const p = join(tempDir, ".env");
+      writeFileSync(p, "MFF_API_URL=https://x\n");
+      chmodSync(p, 0o000);
+      const api = await checkMffApiReachable(p);
+      expect(api.status).toBe("warn");
+      expect(api.detail).toContain("agent-private");
+    },
+  );
+
+  it("deep probes skip (warn) when the .env is absent", async () => {
+    const api = await checkMffApiReachable(join(tempDir, "nope.env"));
+    expect(api.status).toBe("warn");
+    expect(api.detail).toContain("not found");
   });
 });


### PR DESCRIPTION
## Summary

`switchroom doctor` false-FAILs the MFF probes once MFF credentials are correctly migrated per-agent (WS6-F2 / #1390). The probes hard-coded the retired flat path `~/.switchroom/credentials/my-family-finance/.env`; post-WS6-F2 those creds live under `credentials/<agent>/…`, owned by the agent UID (mode 600), so the operator-run doctor **cannot and — by the WS6-F2 security boundary — should not** read them.

Found while migrating a live fleet's MFF creds per-agent: the agents work, but `doctor` reported `mff: .env present → fail` against a path nothing uses anymore.

### Fix
- `mffAgentName(config)` / `mffEnvPath(config)` — resolve from the first MFF-skill agent's per-agent dir; legacy flat fallback for pre-WS6-F2 / explicit-path tests.
- `mffEnvState()` → `absent | agent-private | readable`. **`agent-private` (exists, operator can't read) is the expected healthy state**, reported `ok`.
- Deep probes (API / auth-flow / Cloudflare-UA) **skip with `warn`** ("deep probe must run in-agent") when not host-readable, instead of failing on secrets the host is not allowed to read.
- `checkMffAuthFlow` resolves `claude-auth.py` from `dirname(envPath)` (colocated per-agent) instead of the dead flat path.
- `checkMff` threads `config` at both call sites.

Design choice (operator-confirmed): **presence-only host check**; true API/auth validation is agent-scoped now and intentionally not done from the host.

## Test plan

- [x] `npm run lint` clean
- [x] `tests/doctor.mff.test.ts` — 48 pass incl. new per-agent / agent-private / deep-probe-skip coverage
- [x] de-flakes the pre-existing "all probes ok/warn on a fully healthy setup" (no longer reads the host's real `~/.switchroom/credentials`)
- [x] `doctor-credentials-migration.test.ts` unaffected (52 pass together)
- [ ] On deploy: live `switchroom doctor` MFF section → 0 fail with per-agent creds

🤖 Generated with [Claude Code](https://claude.com/claude-code)