### PR TITLE
feat(compose): pin Claude runtime for the immutable 24/7 fleet (perf/correctness)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1365,6 +1365,29 @@ function emitAgentService(
     // restart via the /state/agent bind mount.
     PIP_BREAK_SYSTEM_PACKAGES: "1",
     PIP_USER: "1",
+    // ── Claude-runtime invariants for a pinned-image, cache-engineered
+    //    24/7 fleet (these are fleet-wide truths, not per-agent knobs) ──
+    //
+    // DISABLE_AUTOUPDATER: the `claude` binary is delivered by the
+    // agent image, which is rebuilt/rolled forward deliberately via
+    // `switchroom update` (and, for the base, digest-pinned — sec
+    // WS9-F4 #1418). An in-container autoupdater silently mutating
+    // `claude` underneath a pinned image defeats that pin and the
+    // docker-first immutable-image model: the running binary would no
+    // longer match the audited/built image. Disabling it is a
+    // correctness/supply-chain fix that also removes the periodic
+    // update-check network traffic from every agent.
+    DISABLE_AUTOUPDATER: "1",
+    // CLAUDE_CODE_ATTRIBUTION_HEADER=0: documented to omit the
+    // attribution block, which improves prompt-cache hit rate.
+    // Switchroom already invests heavily and deliberately in a
+    // cache-stable prompt prefix (e.g. bin/timezone-hook.sh rounds the
+    // per-turn timestamp to a 900s bucket "so Anthropic's
+    // content-addressed cache isn't invalidated every turn"); a
+    // volatile attribution header works directly against that existing
+    // design. Unknown/renamed env vars are ignored by the runtime, so
+    // this is at worst a no-op — never a regression.
+    CLAUDE_CODE_ATTRIBUTION_HEADER: "0",
     SWITCHROOM_AGENT_NAME: a.name,
     // Belt-and-braces in-container marker for the agent-config CLI's
     // isContainerContext() probe (the primary signal is /.dockerenv,

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -941,6 +941,22 @@ describe("agent service env (Phase 2c F2 — IPC wiring)", () => {
     }
   });
 
+  // Claude-runtime invariants for the pinned-image, cache-engineered
+  // 24/7 fleet. DISABLE_AUTOUPDATER keeps the running `claude` binary
+  // identical to the audited/digest-pinned image (sec WS9-F4 #1418);
+  // CLAUDE_CODE_ATTRIBUTION_HEADER=0 complements the deliberate
+  // cache-stable prompt prefix (bin/timezone-hook.sh 900s bucket).
+  it("sets the pinned-fleet Claude-runtime env on each agent container", () => {
+    const out = generateCompose({
+      config: makeConfig({ alice: {}, bob: {} }),
+    });
+    for (const a of ["alice", "bob"]) {
+      const env = envBlockFor(out, a);
+      expect(env).toMatch(/DISABLE_AUTOUPDATER:\s*"1"/);
+      expect(env).toMatch(/CLAUDE_CODE_ATTRIBUTION_HEADER:\s*"0"/);
+    }
+  });
+
   it("sets TINI_KILL_PROCESS_GROUP=1 so SIGTERM reaches the gateway sidecar", () => {
     // Without this env, tini forwards SIGTERM only to its direct child
     // (tmux at PID 7); the gateway/scheduler/autoaccept sidecars share


### PR DESCRIPTION
## Summary

Tier-1 output of the forensic Claude-CLI caching/perf review — the subset that is **provably safe + documented**, not speculative tuning. Two fleet-wide Claude-runtime env invariants added to the agent container env block (`emitAgentService`, sorted/byte-deterministic):

- **`DISABLE_AUTOUPDATER=1`** — correctness/supply-chain, not merely perf. `claude` ships in the agent image, rolled forward deliberately via `switchroom update` over a digest-pinned base (**sec WS9-F4 #1418**) under the docker-first immutable-image model. An in-container autoupdater silently mutating `claude` underneath the pinned image makes the running binary diverge from the audited/built image and defeats the pin. Also removes periodic update-check traffic from every agent.
- **`CLAUDE_CODE_ATTRIBUTION_HEADER=0`** — documented to omit the attribution block, improving prompt-cache hit rate. Switchroom *already* deliberately engineers a cache-stable prompt prefix (`bin/timezone-hook.sh` rounds the per-turn timestamp to a 900s bucket explicitly so Anthropic's content-addressed cache isn't invalidated each turn); a volatile attribution header works directly against that existing design. Unknown/renamed env vars are runtime-ignored → at worst a no-op, never a regression.

## Deliberately NOT included (scoping, not oversight)

- **Compaction / max-output-token knobs** (`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS`): the review flagged their *net effect* as runtime-only (handoff-default sessions may not grow much). Hard-coding a guessed value is speculation — recommend measure-first, ship no number.
- **De-duplicating the doubly-registered `secret-guard` PreToolUse hook**: saves one process spawn per tool call but re-opens the settings.json strippability that #1432 closed — a security regression for a micro-perf win. Intentionally left as-is.

## Reviewer notes

- Env-var names are per the authoritative `claude-code-guide` reference (it marked both [DOCUMENTED]). `DISABLE_AUTOUPDATER` is long-established; please independently sanity-check `CLAUDE_CODE_ATTRIBUTION_HEADER` against current Claude Code docs — but note an incorrect name is a harmless no-op (env vars are silently ignored), so this is zero-behaviour-risk regardless.
- Config-only; no change to model output. Byte-determinism of the emitted compose is preserved (env keys emitted sorted; the determinism tests pass).

## Test plan

- [x] `tsc --noEmit` clean (pre-existing unrelated `@mtcute/node` env error filtered)
- [x] `tests/docker/compose-generator.test.ts` — 142 pass incl. the new env assertion + the byte-determinism / input-order-independence tests (would fail if env emission order regressed)
- [ ] CI green
- [ ] post-merge: visible on every agent via `printenv` after the next `switchroom update` agent-image cycle

Serves JTBD: subscription-honest + always-on (verifiable runtime, cache-efficient fleet). Follows the forensic review; no guessing shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)