### PR TITLE
fix(boot-probes): list every skill bucketed by source in /status (#1467)

### DIFF
--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -1318,7 +1318,14 @@ export async function probeKernel(
  */
 export async function probeSkills(
   agentDir: string,
-  opts: { fs?: SkillsFsImpl; maxNamesShown?: number; agentName?: string } = {},
+  opts: {
+    fs?: SkillsFsImpl
+    maxNamesShown?: number
+    agentName?: string
+    /** Override skills.d overlay dir. Defaults to `<agentDir>/skills.d`
+     *  on host installs; tests inject a path. */
+    overlaySkillsDir?: string
+  } = {},
 ): Promise<ProbeResult> {
   return withTimeout('Skills', (async (): Promise<ProbeResult> => {
     const fs = opts.fs ?? realSkillsFs
@@ -1359,8 +1366,32 @@ export async function probeSkills(
         continue
       }
     }
+
+    // Bucket entries by source: agent-overlay slugs come from filenames
+    // under <agentRoot>/skills.d/<slug>.yaml (written by skill_install).
+    // Everything else is operator-baseline from switchroom.yaml.
+    const overlayDir = opts.overlaySkillsDir ?? join(agentDir, 'skills.d')
+    const overlaySlugs = new Set<string>()
+    if (fs.exists(overlayDir)) {
+      let overlayEntries: string[] = []
+      try {
+        overlayEntries = fs.readdir(overlayDir)
+      } catch {
+        /* unreadable overlay — fall through with empty set */
+      }
+      for (const name of overlayEntries) {
+        const m = name.match(/^(.+)\.ya?ml$/i)
+        if (!m) continue
+        overlaySlugs.add(m[1])
+      }
+    }
+    const liveEntries = entries.filter(n => !dangling.includes(n)).sort()
+    const switchroomSkills = liveEntries.filter(n => !overlaySlugs.has(n))
+    const agentSkills = liveEntries.filter(n => overlaySlugs.has(n))
+    const bucketed = renderBucketedSkills(switchroomSkills, agentSkills)
+
     if (dangling.length === 0) {
-      return { status: 'ok', label: 'Skills', detail: `${entries.length} resolved` }
+      return { status: 'ok', label: 'Skills', detail: bucketed }
     }
     const named = dangling.slice(0, max).join(', ')
     const more = dangling.length > max ? ` +${dangling.length - max} more` : ''
@@ -1368,10 +1399,19 @@ export async function probeSkills(
     return {
       status: 'degraded',
       label: 'Skills',
-      detail: `${dangling.length}/${entries.length} dangling: ${named}${more}`,
+      detail: `${dangling.length}/${entries.length} dangling: ${named}${more} · ${bucketed}`,
       nextStep: `Run \`switchroom agent reconcile${reconcileTarget}\` to rebuild symlinks, or remove unused entries from switchroom.yaml`,
     }
   })())
+}
+
+/** Format the two source-buckets into a single mobile-readable line.
+ *  Empty buckets are omitted. `none` covers the all-dangling edge case. */
+function renderBucketedSkills(switchroom: string[], agent: string[]): string {
+  const parts: string[] = []
+  if (switchroom.length > 0) parts.push(`Switchroom: ${switchroom.join(', ')}`)
+  if (agent.length > 0) parts.push(`Agent: ${agent.join(', ')}`)
+  return parts.length === 0 ? 'none resolved' : parts.join(' · ')
 }
 
 export interface SkillsFsImpl {

--- a/telegram-plugin/tests/boot-probes.test.ts
+++ b/telegram-plugin/tests/boot-probes.test.ts
@@ -883,7 +883,7 @@ describe('probeSkills', () => {
     expect(result.detail).toContain('no skills dir')
   })
 
-  it('returns ok with count when every skill resolves', async () => {
+  it('returns ok with every skill listed under Switchroom bucket when no overlay', async () => {
     const fs = makeSkillsFs(
       { [skillsDir]: ['simplify', 'review'] },
       new Set([
@@ -893,7 +893,40 @@ describe('probeSkills', () => {
     )
     const result = await probeSkills(agentDir, { fs })
     expect(result.status).toBe('ok')
-    expect(result.detail).toContain('2 resolved')
+    expect(result.detail).toBe('Switchroom: review, simplify')
+  })
+
+  it('buckets overlay-installed skills under Agent', async () => {
+    const overlayDir = '/state/agent/skills.d'
+    const fs = makeSkillsFs(
+      {
+        [skillsDir]: ['simplify', 'review', 'webapp-testing'],
+        [overlayDir]: ['webapp-testing.yaml'],
+      },
+      new Set([
+        `${skillsDir}/simplify`, `${skillsDir}/simplify/SKILL.md`,
+        `${skillsDir}/review`, `${skillsDir}/review/SKILL.md`,
+        `${skillsDir}/webapp-testing`, `${skillsDir}/webapp-testing/SKILL.md`,
+        overlayDir,
+      ]),
+    )
+    const result = await probeSkills(agentDir, { fs })
+    expect(result.status).toBe('ok')
+    expect(result.detail).toBe('Switchroom: review, simplify · Agent: webapp-testing')
+  })
+
+  it('lists every skill without a +N more truncation in the healthy case', async () => {
+    const names = Array.from({ length: 12 }, (_, i) => `skill-${i.toString().padStart(2, '0')}`)
+    const fileSet = new Set<string>()
+    for (const n of names) {
+      fileSet.add(`${skillsDir}/${n}`)
+      fileSet.add(`${skillsDir}/${n}/SKILL.md`)
+    }
+    const fs = makeSkillsFs({ [skillsDir]: names }, fileSet)
+    const result = await probeSkills(agentDir, { fs })
+    expect(result.status).toBe('ok')
+    expect(result.detail).not.toContain('+')
+    for (const n of names) expect(result.detail).toContain(n)
   })
 
   it('degraded when at least one symlink dangles, names them up to cap', async () => {
@@ -912,6 +945,8 @@ describe('probeSkills', () => {
     expect(result.detail).toContain('also-gone')
     expect(result.detail).toContain('+1 more')
     expect(result.detail).not.toContain('and-this')
+    // resolved skills still surface alongside the dangling summary
+    expect(result.detail).toContain('Switchroom: review, simplify')
   })
 
   it('returns ok when entries dir is empty', async () => {


### PR DESCRIPTION
## Summary
- `/status`'s Skills row now lists every resolved skill instead of `N resolved`
- Skills are bucketed into **Switchroom** (operator-baseline from `switchroom.yaml`) vs **Agent** (overlay-installed via `skill_install` → `skills.d/<slug>.yaml`)
- `+N more` cap removed from the healthy path; dangling case still truncates the failure list but now appends the resolved buckets

## Test plan
- [x] `bun test tests/boot-probes.test.ts` (67 pass)
- [ ] Live `/status` on klanker shows two buckets when an overlay skill is installed
- [ ] Live `/status` on an agent with no overlay shows a single `Switchroom: …` line

Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)