### PR TITLE
feat(doctor): hostd visibility + image-drift WARN (closes #1471)

### DIFF
--- a/src/cli/doctor-hostd.ts
+++ b/src/cli/doctor-hostd.ts
@@ -1,0 +1,170 @@
+/**
+ * Host-control daemon (hostd) doctor checks (#1471).
+ *
+ * `doctor` had ZERO visibility into hostd — operators only discovered a
+ * missing/drifted daemon when `/update apply` silently fell back to the
+ * broken legacy path. These probes surface it up front:
+ *
+ *   1. configured   — is `host_control.enabled: true`? (Default-on
+ *      since RFC C Phase 2 / #1338; a disabled state means /restart and
+ *      /update apply use the legacy in-agent fallback, which fails on
+ *      docker installs — #926.)
+ *   2. running      — when enabled, is the `switchroom-hostd` container
+ *      actually up?
+ *   3. image drift  — is the running hostd image meaningfully older
+ *      than the agent fleet's image? This is the field failure mode:
+ *      `switchroom update --skip-images` intentionally skips the
+ *      `refresh-hostd` step, so a fleet that rolled forward while hostd
+ *      did not ends up with a stale daemon and a CLI↔daemon version
+ *      gap. Remediation: `switchroom hostd install` (or a
+ *      `switchroom update` WITHOUT `--skip-images`).
+ *
+ * All probes accept dependency-injected docker access so
+ * `tests/doctor-hostd.test.ts` drives every branch without containers.
+ */
+
+import { spawnSync } from "node:child_process";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+
+export type CheckStatus = "ok" | "warn" | "fail";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+export const HOSTD_CONTAINER = "switchroom-hostd";
+
+/** Hours the hostd image may lag the agent image before it's flagged.
+ *  Same-release builds (one docker-images workflow run) are minutes
+ *  apart; a real drift is the fleet rolled and hostd didn't — hours+. */
+export const HOSTD_DRIFT_HOURS = 2;
+
+/** Docker injection seam. Tests pass fakes; production uses spawnSync. */
+export interface HostdProbeDeps {
+  /**
+   * `docker inspect <ref> --format <fmt>` → trimmed stdout, or null on
+   * any failure (no docker, missing ref, transient error).
+   */
+  dockerInspect?: (ref: string, format: string) => string | null;
+}
+
+function realDockerInspect(ref: string, format: string): string | null {
+  try {
+    const r = spawnSync("docker", ["inspect", ref, "--format", format], {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    if (r.status !== 0) return null;
+    const out = (r.stdout ?? "").trim();
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Created-timestamp (ISO) of the image a container runs, or null. */
+function imageCreatedAt(
+  container: string,
+  dockerInspect: (ref: string, format: string) => string | null,
+): string | null {
+  const imageId = dockerInspect(container, "{{.Image}}");
+  if (!imageId) return null;
+  return dockerInspect(imageId, "{{.Created}}");
+}
+
+export function runHostdChecks(
+  config: SwitchroomConfig,
+  deps: HostdProbeDeps = {},
+): CheckResult[] {
+  const dockerInspect = deps.dockerInspect ?? realDockerInspect;
+  const enabled = config.host_control?.enabled === true;
+
+  if (!enabled) {
+    return [
+      {
+        name: "hostd: configured",
+        status: "warn",
+        detail:
+          "host_control.enabled is not true — /restart and /update apply " +
+          "use the legacy in-agent fallback, which fails on docker installs (#926)",
+        fix: "Set `host_control: { enabled: true }` in switchroom.yaml and run `switchroom hostd install`",
+      },
+    ];
+  }
+
+  const results: CheckResult[] = [
+    {
+      name: "hostd: configured",
+      status: "ok",
+      detail: "host_control.enabled: true",
+    },
+  ];
+
+  const status = dockerInspect(HOSTD_CONTAINER, "{{.State.Status}}");
+  if (status !== "running") {
+    results.push({
+      name: "hostd: running",
+      status: "fail",
+      detail:
+        status === null
+          ? `${HOSTD_CONTAINER} container not found`
+          : `${HOSTD_CONTAINER} is ${status}, not running`,
+      fix: "Run `switchroom hostd install` on the host to (re)create the daemon",
+    });
+    return results; // drift check is meaningless without a running daemon
+  }
+  results.push({
+    name: "hostd: running",
+    status: "ok",
+    detail: `${HOSTD_CONTAINER} running`,
+  });
+
+  // Image-drift: compare hostd's image vintage to a running agent's.
+  const hostdCreated = imageCreatedAt(HOSTD_CONTAINER, dockerInspect);
+  let agentCreated: string | null = null;
+  for (const name of Object.keys(config.agents ?? {})) {
+    agentCreated = imageCreatedAt(`switchroom-${name}`, dockerInspect);
+    if (agentCreated) break;
+  }
+  if (!hostdCreated || !agentCreated) {
+    results.push({
+      name: "hostd: image drift",
+      status: "ok",
+      detail: "skipped — no running agent image to compare against",
+    });
+    return results;
+  }
+  const hostdMs = Date.parse(hostdCreated);
+  const agentMs = Date.parse(agentCreated);
+  if (Number.isNaN(hostdMs) || Number.isNaN(agentMs)) {
+    results.push({
+      name: "hostd: image drift",
+      status: "ok",
+      detail: "skipped — unparseable image timestamps",
+    });
+    return results;
+  }
+  const lagHours = (agentMs - hostdMs) / 3_600_000;
+  if (lagHours > HOSTD_DRIFT_HOURS) {
+    results.push({
+      name: "hostd: image drift",
+      status: "warn",
+      detail:
+        `hostd image is ~${lagHours.toFixed(1)}h older than the agent fleet ` +
+        `image — likely a \`switchroom update --skip-images\` left it behind ` +
+        `(that flag skips the refresh-hostd step)`,
+      fix: "Run `switchroom hostd install` (or `switchroom update` without `--skip-images`)",
+    });
+  } else {
+    results.push({
+      name: "hostd: image drift",
+      status: "ok",
+      detail: `in sync with the agent fleet image (±${HOSTD_DRIFT_HOURS}h)`,
+    });
+  }
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -26,6 +26,7 @@ import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
 import { probeHindsight, isHindsightEnabled } from "../memory/hindsight.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
+import { runHostdChecks } from "./doctor-hostd.js";
 import { runDriveChecks } from "./doctor-drive.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
 import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
@@ -2317,6 +2318,7 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Audit integrity (WS10-F4)", results: runAuditIntegrityChecks() },
           { title: "Docker (Phase 1a)", results: runDockerSection(config) },
           { title: "Auth Broker", results: runAuthBrokerChecks(config) },
+          { title: "Host control (hostd)", results: runHostdChecks(config) },
           { title: "Google Drive", results: runDriveChecks(config) },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath, config) },
         ];

--- a/tests/doctor-hostd.test.ts
+++ b/tests/doctor-hostd.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  runHostdChecks,
+  HOSTD_DRIFT_HOURS,
+  type HostdProbeDeps,
+} from "../src/cli/doctor-hostd.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+function cfg(enabled: boolean, agents: string[] = ["a"]): SwitchroomConfig {
+  return {
+    host_control: enabled ? { enabled: true } : { enabled: false },
+    agents: Object.fromEntries(agents.map((n) => [n, {}])),
+  } as unknown as SwitchroomConfig;
+}
+
+/** Build a dockerInspect fake from a {`ref|format`: value} map. */
+function fakeInspect(map: Record<string, string | null>): HostdProbeDeps {
+  return {
+    dockerInspect: (ref, format) => map[`${ref}|${format}`] ?? null,
+  };
+}
+
+const HOSTD = "switchroom-hostd";
+
+describe("runHostdChecks", () => {
+  it("warns once when host_control is not enabled", () => {
+    const r = runHostdChecks(cfg(false));
+    expect(r).toHaveLength(1);
+    expect(r[0].name).toBe("hostd: configured");
+    expect(r[0].status).toBe("warn");
+    expect(r[0].fix).toContain("switchroom hostd install");
+  });
+
+  it("fails 'running' when enabled but the container is absent", () => {
+    const r = runHostdChecks(cfg(true), fakeInspect({}));
+    expect(r.find((x) => x.name === "hostd: configured")?.status).toBe("ok");
+    const running = r.find((x) => x.name === "hostd: running");
+    expect(running?.status).toBe("fail");
+    expect(running?.detail).toContain("not found");
+    // drift check skipped when not running
+    expect(r.find((x) => x.name === "hostd: image drift")).toBeUndefined();
+  });
+
+  it("fails 'running' when the container is stopped", () => {
+    const r = runHostdChecks(
+      cfg(true),
+      fakeInspect({ [`${HOSTD}|{{.State.Status}}`]: "exited" }),
+    );
+    expect(r.find((x) => x.name === "hostd: running")?.status).toBe("fail");
+    expect(r.find((x) => x.name === "hostd: running")?.detail).toContain(
+      "exited",
+    );
+  });
+
+  it("all-ok when running and image vintage is in sync", () => {
+    const now = "2026-05-18T10:00:00.000Z";
+    const r = runHostdChecks(
+      cfg(true),
+      fakeInspect({
+        [`${HOSTD}|{{.State.Status}}`]: "running",
+        [`${HOSTD}|{{.Image}}`]: "sha256:hostdimg",
+        ["sha256:hostdimg|{{.Created}}"]: now,
+        ["switchroom-a|{{.Image}}"]: "sha256:agentimg",
+        ["sha256:agentimg|{{.Created}}"]: now,
+      }),
+    );
+    expect(r.map((x) => x.status)).toEqual(["ok", "ok", "ok"]);
+    expect(r.find((x) => x.name === "hostd: image drift")?.detail).toContain(
+      "in sync",
+    );
+  });
+
+  it("warns on image drift when hostd lags the agent fleet", () => {
+    const hostd = "2026-05-17T09:00:00.000Z";
+    const agent = "2026-05-18T10:00:00.000Z"; // ~25h newer
+    const r = runHostdChecks(
+      cfg(true),
+      fakeInspect({
+        [`${HOSTD}|{{.State.Status}}`]: "running",
+        [`${HOSTD}|{{.Image}}`]: "sha256:old",
+        ["sha256:old|{{.Created}}"]: hostd,
+        ["switchroom-a|{{.Image}}"]: "sha256:new",
+        ["sha256:new|{{.Created}}"]: agent,
+      }),
+    );
+    const drift = r.find((x) => x.name === "hostd: image drift");
+    expect(drift?.status).toBe("warn");
+    expect(drift?.detail).toContain("--skip-images");
+    expect(drift?.fix).toContain("switchroom hostd install");
+  });
+
+  it("does not warn when lag is within the threshold", () => {
+    const base = Date.parse("2026-05-18T10:00:00.000Z");
+    const hostd = new Date(
+      base - (HOSTD_DRIFT_HOURS - 0.5) * 3_600_000,
+    ).toISOString();
+    const r = runHostdChecks(
+      cfg(true),
+      fakeInspect({
+        [`${HOSTD}|{{.State.Status}}`]: "running",
+        [`${HOSTD}|{{.Image}}`]: "sha256:h",
+        ["sha256:h|{{.Created}}"]: hostd,
+        ["switchroom-a|{{.Image}}"]: "sha256:a",
+        ["sha256:a|{{.Created}}"]: "2026-05-18T10:00:00.000Z",
+      }),
+    );
+    expect(r.find((x) => x.name === "hostd: image drift")?.status).toBe("ok");
+  });
+
+  it("skips drift gracefully when no agent image is resolvable", () => {
+    const r = runHostdChecks(
+      cfg(true, ["a"]),
+      fakeInspect({
+        [`${HOSTD}|{{.State.Status}}`]: "running",
+        [`${HOSTD}|{{.Image}}`]: "sha256:h",
+        ["sha256:h|{{.Created}}"]: "2026-05-18T10:00:00.000Z",
+        // no switchroom-a image entries
+      }),
+    );
+    const drift = r.find((x) => x.name === "hostd: image drift");
+    expect(drift?.status).toBe("ok");
+    expect(drift?.detail).toContain("skipped");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1471. `switchroom doctor` had **zero hostd coverage** — operators only found out hostd was missing or stale when `/update apply` silently fell back to the legacy in-agent path (broken on docker installs, #926). Adds a **"Host control (hostd)"** doctor section:

- **configured** — `warn` when `host_control.enabled` is not true.
- **running** — `fail` when enabled but `switchroom-hostd` isn't up.
- **image drift** — `warn` when the running hostd image is >2h older than the agent fleet image. This is the actual field failure mode: `switchroom update --skip-images` *intentionally* skips the `refresh-hostd` step (update.ts), so a fleet that rolled forward while hostd didn't ends up with a stale daemon and a CLI↔daemon version gap. Remediation points at `switchroom hostd install` (or `switchroom update` without `--skip-images`).

Found in the field on a dev install: hostd was up + enabled + admin-socketed but running a ~13h-old image because the session's credential-fix updates all used `--skip-images`. `switchroom hostd install` fixed it — but nothing had *told* the operator. This adds that signal.

**Scope:** network-free (compares local image `Created` timestamps via injected `docker inspect`), no `update.ts` change (refresh-hostd already rolls hostd on a normal `switchroom update` — the gap was purely visibility).

## Test plan
- [x] `npm run lint` clean
- [x] `tests/doctor-hostd.test.ts` — 7 pass: disabled→warn, absent→fail, stopped→fail, in-sync→ok, drift→warn, within-threshold→ok, no-agent-image→graceful skip
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)