### PR TITLE
feat(doctor): vault operator-lockout + per-agent secret-access ACL (closes #1473)

### DIFF
--- a/src/cli/doctor-secret-access.ts
+++ b/src/cli/doctor-secret-access.ts
@@ -214,11 +214,22 @@ export function runSecretAccessChecks(
       config.agents[name],
     );
 
-    const needed = new Set<string>();
+    // Provenance matters. Cron `schedule[].secrets[]` are served at
+    // runtime BY THE BROKER, so the broker's cron allowlist
+    // (checkAclByAgent) AND the per-key scope (checkEntryScope) both
+    // gate them. Plain `vault:` config refs (bot_token, env, mcp, …)
+    // are resolved operator-side at scaffold time via openVault — they
+    // do NOT pass through checkAclByAgent (applying it here would
+    // falsely FAIL the canonical `bot_token: "vault:…"` config on any
+    // agent without a cron schedule). Per-key scope still applies to
+    // them wherever the broker serves them.
+    const cronKeys = new Set<string>();
     for (const entry of (resolved as { schedule?: Array<{ secrets?: string[] }> }).schedule ?? []) {
-      for (const s of entry.secrets ?? []) needed.add(s);
+      for (const s of entry.secrets ?? []) cronKeys.add(s);
     }
-    collectVaultRefs(resolved, needed);
+    const refKeys = new Set<string>();
+    collectVaultRefs(resolved, refKeys);
+    const needed = new Set<string>([...cronKeys, ...refKeys]);
 
     if (needed.size === 0) {
       results.push({
@@ -239,11 +250,16 @@ export function runSecretAccessChecks(
         gaps.push(`'${key}' missing from the vault`);
         continue;
       }
-      const byAgent = checkAclByAgent(config, name, key);
       const byScope = checkEntryScope(entries[key]?.scope, name);
-      if (!byAgent.allow) {
-        gaps.push(`'${key}' — no static ACL grants read (${byAgent.reason})`);
-      } else if (!byScope.allow) {
+      if (cronKeys.has(key)) {
+        // broker-served cron secret → full broker predicate
+        const byAgent = checkAclByAgent(config, name, key);
+        if (!byAgent.allow) {
+          gaps.push(`'${key}' (cron) — no static ACL grants read (${byAgent.reason})`);
+          continue;
+        }
+      }
+      if (!byScope.allow) {
         gaps.push(`'${key}' — per-key scope denies read (${byScope.reason})`);
       }
     }

--- a/src/cli/doctor-secret-access.ts
+++ b/src/cli/doctor-secret-access.ts
@@ -1,0 +1,272 @@
+/**
+ * Vault access doctor checks (#1473).
+ *
+ * Two gaps that were invisible until something failed at runtime:
+ *
+ *  A. **Operator lockout.** A root-mode write (sudo apply / hostd /
+ *     broker fanout) can leave `vault.enc` owned `root:root` 0600. The
+ *     broker keeps working (it reads via CAP_DAC_READ_SEARCH), so
+ *     cron/agents look fine — but every operator `switchroom vault …`
+ *     fails. Probe the file AS THE OPERATOR and FAIL with the chown
+ *     fix.
+ *
+ *  B. **Agent secret access.** For every agent, the secrets it needs —
+ *     cron `schedule[].secrets[]` and `vault:` refs anywhere in its
+ *     resolved config — must (1) exist in the vault and (2) be readable
+ *     by that agent under the broker ACL. We reuse the broker's own
+ *     predicates (`checkAclByAgent` + `checkEntryScope`) so the doctor
+ *     verdict matches what the broker will actually do at runtime.
+ *
+ * Scope (v1): cron secrets + `vault:` refs. Skill secret needs are
+ * documentation-only (no machine-readable manifest) so they're covered
+ * transitively wherever a skill surfaces a `vault:` ref in env/mcp;
+ * a skill that reads a key purely at runtime is out of scope. Ephemeral
+ * capability grants are invisible to a static check — ACL failures are
+ * worded "no *static* ACL" to avoid false alarms.
+ *
+ * All IO is dependency-injected so tests drive every branch without a
+ * real vault or containers.
+ */
+
+import {
+  accessSync,
+  constants as fsConstants,
+  existsSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { userInfo } from "node:os";
+
+import { resolveStatePath } from "../config/paths.js";
+import { resolveAgentConfig } from "../config/merge.js";
+import { openVault, type VaultEntry } from "../vault/vault.js";
+import { checkAclByAgent, checkEntryScope } from "../vault/broker/acl.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+export type CheckStatus = "ok" | "warn" | "fail";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/** Result of probing the vault file as the current (operator) user. */
+export interface VaultFileStat {
+  exists: boolean;
+  readable: boolean;
+  uid: number;
+  mode: number;
+  realPath: string;
+}
+
+export interface SecretAccessDeps {
+  /** Override the resolved vault path. */
+  vaultPath?: string;
+  /** Override the passphrase (defaults to SWITCHROOM_VAULT_PASSPHRASE). */
+  passphrase?: string;
+  /** Probe the vault file as the operator. Default: realpath + stat + access(R_OK). */
+  statVault?: (path: string) => VaultFileStat;
+  /** Decrypt + load the vault. Default: real `openVault`. */
+  openVault?: (passphrase: string, path: string) => Record<string, VaultEntry>;
+  /** Current operator uid (default process uid). */
+  selfUid?: number;
+  /** Current operator username (default os.userInfo().username). */
+  selfUser?: string;
+}
+
+function resolveVaultPath(config: SwitchroomConfig): string {
+  return config.vault?.path
+    ? config.vault.path.replace(/^~/, process.env.HOME ?? "")
+    : resolveStatePath("vault.enc");
+}
+
+function defaultStatVault(path: string): VaultFileStat {
+  if (!existsSync(path)) {
+    return { exists: false, readable: false, uid: -1, mode: 0, realPath: path };
+  }
+  let real = path;
+  try {
+    real = realpathSync(path);
+  } catch {
+    /* broken symlink — fall through with the literal path */
+  }
+  let uid = -1;
+  let mode = 0;
+  try {
+    const s = statSync(real);
+    uid = s.uid;
+    mode = s.mode & 0o777;
+  } catch {
+    return { exists: true, readable: false, uid, mode, realPath: real };
+  }
+  let readable = false;
+  try {
+    accessSync(real, fsConstants.R_OK);
+    readable = true;
+  } catch {
+    readable = false;
+  }
+  return { exists: true, readable, uid, mode, realPath: real };
+}
+
+/** Field-agnostic recursive walk for `vault:<key>` references. Mirrors
+ *  src/vault/resolver.ts collectVaultRefs (kept local to avoid widening
+ *  that module's export surface). Strips the `#filename` selector. */
+function collectVaultRefs(value: unknown, out: Set<string>): void {
+  if (typeof value === "string") {
+    if (value.startsWith("vault:")) {
+      const key = value.slice("vault:".length).split("#")[0]!.trim();
+      if (key) out.add(key);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) collectVaultRefs(v, out);
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      collectVaultRefs(v, out);
+    }
+  }
+}
+
+export function runSecretAccessChecks(
+  config: SwitchroomConfig,
+  deps: SecretAccessDeps = {},
+): CheckResult[] {
+  const results: CheckResult[] = [];
+  const vaultPath = deps.vaultPath ?? resolveVaultPath(config);
+  const statVault = deps.statVault ?? defaultStatVault;
+  const selfUid = deps.selfUid ?? (typeof process.getuid === "function" ? process.getuid() : -1);
+  let selfUser = deps.selfUser;
+  if (selfUser === undefined) {
+    try {
+      selfUser = userInfo().username;
+    } catch {
+      selfUser = "<you>";
+    }
+  }
+
+  // ---- Check A: operator can read the vault file --------------------
+  const vf = statVault(vaultPath);
+  if (!vf.exists) {
+    results.push({
+      name: "vault: operator readable",
+      status: "ok",
+      detail: `vault file not present at ${vaultPath} — see the Vault section`,
+    });
+  } else if (!vf.readable) {
+    results.push({
+      name: "vault: operator readable",
+      status: "fail",
+      detail:
+        `${vf.realPath} is owned by uid ${vf.uid} (mode 0${vf.mode.toString(8)}) — ` +
+        `the operator (uid ${selfUid} ${selfUser}) cannot read it, so every ` +
+        `\`switchroom vault …\` fails. The broker still works (CAP_DAC_READ_SEARCH), ` +
+        `which masks this until you touch the vault directly.`,
+      fix: `sudo chown ${selfUser}:${selfUser} ${vf.realPath}`,
+    });
+  } else {
+    results.push({
+      name: "vault: operator readable",
+      status: "ok",
+      detail: `operator can read ${vf.realPath}`,
+    });
+  }
+
+  // ---- Check B: per-agent secret existence + ACL --------------------
+  const passphrase = deps.passphrase ?? process.env.SWITCHROOM_VAULT_PASSPHRASE;
+  if (!passphrase) {
+    results.push({
+      name: "agent secret access",
+      status: "warn",
+      detail:
+        "SWITCHROOM_VAULT_PASSPHRASE not set — cannot enumerate vault keys/ACLs " +
+        "to verify per-agent secret access",
+      fix: "Export SWITCHROOM_VAULT_PASSPHRASE and re-run `switchroom doctor`",
+    });
+    return results;
+  }
+
+  let entries: Record<string, VaultEntry>;
+  try {
+    entries = (deps.openVault ?? openVault)(passphrase, vaultPath);
+  } catch (err) {
+    results.push({
+      name: "agent secret access",
+      status: vf.readable ? "fail" : "warn",
+      detail: `cannot open the vault: ${(err as Error).message}`,
+      fix: vf.readable
+        ? "SWITCHROOM_VAULT_PASSPHRASE may be wrong, or the vault is corrupt"
+        : "fix the vault file ownership above first (operator cannot read it)",
+    });
+    return results;
+  }
+
+  const agents = Object.keys(config.agents ?? {});
+  for (const name of agents) {
+    const resolved = resolveAgentConfig(
+      config.defaults,
+      config.profiles,
+      config.agents[name],
+    );
+
+    const needed = new Set<string>();
+    for (const entry of (resolved as { schedule?: Array<{ secrets?: string[] }> }).schedule ?? []) {
+      for (const s of entry.secrets ?? []) needed.add(s);
+    }
+    collectVaultRefs(resolved, needed);
+
+    if (needed.size === 0) {
+      results.push({
+        name: `secret access: ${name}`,
+        status: "ok",
+        detail: "no declared vault secrets",
+      });
+      continue;
+    }
+
+    const gaps: string[] = [];
+    for (const key of [...needed].sort()) {
+      // google:<acct>:* are auth-broker slots, not literal vault keys —
+      // existence is governed by google_accounts, not the vault blob;
+      // the ACL predicate already routes them, so check ACL only.
+      const isGoogleSlot = key.startsWith("google:");
+      if (!isGoogleSlot && !(key in entries)) {
+        gaps.push(`'${key}' missing from the vault`);
+        continue;
+      }
+      const byAgent = checkAclByAgent(config, name, key);
+      const byScope = checkEntryScope(entries[key]?.scope, name);
+      if (!byAgent.allow) {
+        gaps.push(`'${key}' — no static ACL grants read (${byAgent.reason})`);
+      } else if (!byScope.allow) {
+        gaps.push(`'${key}' — per-key scope denies read (${byScope.reason})`);
+      }
+    }
+
+    if (gaps.length === 0) {
+      results.push({
+        name: `secret access: ${name}`,
+        status: "ok",
+        detail: `${needed.size} secret(s): all present + ACL ok`,
+      });
+    } else {
+      results.push({
+        name: `secret access: ${name}`,
+        status: "fail",
+        detail: `${gaps.length}/${needed.size} unreachable — ${gaps.join("; ")}`,
+        fix:
+          "`switchroom vault set <key>` for missing keys; " +
+          "`switchroom vault set <key> --allow " +
+          name +
+          "` to grant this agent read access",
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -29,6 +29,7 @@ import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runHostdChecks } from "./doctor-hostd.js";
 import { runDriveChecks } from "./doctor-drive.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
+import { runSecretAccessChecks } from "./doctor-secret-access.js";
 import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
 import { runAuditIntegrityChecks } from "./doctor-audit-integrity.js";
 
@@ -2311,6 +2312,7 @@ export function registerDoctorCommand(program: Command): void {
           },
           { title: "Legacy State", results: checkLegacyState() },
           { title: "Vault", results: checkVault(config) },
+          { title: "Vault access (#1473)", results: runSecretAccessChecks(config) },
           { title: "Memory (Hindsight)", results: await checkHindsight(config) },
           { title: "Telegram", results: await checkTelegram(config) },
           { title: "Agents", results: checkAgents(config, configPath) },

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2312,7 +2312,7 @@ export function registerDoctorCommand(program: Command): void {
           },
           { title: "Legacy State", results: checkLegacyState() },
           { title: "Vault", results: checkVault(config) },
-          { title: "Vault access (#1473)", results: runSecretAccessChecks(config) },
+          { title: "Vault access", results: runSecretAccessChecks(config) },
           { title: "Memory (Hindsight)", results: await checkHindsight(config) },
           { title: "Telegram", results: await checkTelegram(config) },
           { title: "Agents", results: checkAgents(config, configPath) },

--- a/tests/doctor-secret-access.test.ts
+++ b/tests/doctor-secret-access.test.ts
@@ -169,6 +169,36 @@ describe("runSecretAccessChecks — Check B (per-agent access)", () => {
     expect(s?.detail).toContain("'bot' missing from the vault");
   });
 
+  it("OK for the canonical bot_token vault: ref with no cron schedule (no false ACL fail)", () => {
+    // Regression for the BLOCK: bot_token is resolved operator-side at
+    // scaffold time, NOT via the broker cron allowlist. An agent with
+    // no schedule[] must NOT be failed by checkAclByAgent.
+    const config = cfg({
+      tgbot: { channels: { telegram: { bot_token: "vault:tok" } } },
+    });
+    const entries: Record<string, VaultEntry> = {
+      tok: { kind: "string", value: "123:ABC" }, // exists, default (open) scope
+    };
+    const r = runSecretAccessChecks(config, deps({ openVault: () => entries }));
+    const s = get(r, "secret access: tgbot");
+    expect(s?.status).toBe("ok");
+    expect(s?.detail).toContain("all present");
+  });
+
+  it("config vault: ref is still per-key-scope checked (deny ⇒ fail)", () => {
+    const config = cfg({
+      tgbot: { channels: { telegram: { bot_token: "vault:tok" } } },
+    });
+    const entries: Record<string, VaultEntry> = {
+      tok: { kind: "string", value: "v", scope: { deny: ["tgbot"] } },
+    };
+    const r = runSecretAccessChecks(config, deps({ openVault: () => entries }));
+    const s = get(r, "secret access: tgbot");
+    expect(s?.status).toBe("fail");
+    expect(s?.detail).toContain("per-key scope denies");
+    expect(s?.detail).not.toContain("no static ACL"); // not run through checkAclByAgent
+  });
+
   it("does not false-'missing' a google:<acct> slot ref (existence skipped)", () => {
     const config = cfg({
       g: {

--- a/tests/doctor-secret-access.test.ts
+++ b/tests/doctor-secret-access.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  runSecretAccessChecks,
+  type VaultFileStat,
+  type SecretAccessDeps,
+} from "../src/cli/doctor-secret-access.js";
+import type { VaultEntry } from "../src/vault/vault.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+function cfg(agents: Record<string, unknown>): SwitchroomConfig {
+  return { agents, defaults: {}, profiles: {} } as unknown as SwitchroomConfig;
+}
+
+const READABLE: VaultFileStat = {
+  exists: true,
+  readable: true,
+  uid: 1000,
+  mode: 0o600,
+  realPath: "/home/op/.switchroom/vault/vault.enc",
+};
+
+function deps(over: Partial<SecretAccessDeps> = {}): SecretAccessDeps {
+  return {
+    vaultPath: "/v",
+    selfUid: 1000,
+    selfUser: "op",
+    statVault: () => READABLE,
+    passphrase: "pp",
+    openVault: () => ({}),
+    ...over,
+  };
+}
+
+const get = (r: ReturnType<typeof runSecretAccessChecks>, name: string) =>
+  r.find((x) => x.name === name);
+
+describe("runSecretAccessChecks — Check A (operator readable)", () => {
+  it("ok when the vault file is absent (defers to Vault section)", () => {
+    const r = runSecretAccessChecks(
+      cfg({}),
+      deps({
+        statVault: () => ({
+          exists: false,
+          readable: false,
+          uid: -1,
+          mode: 0,
+          realPath: "/v",
+        }),
+      }),
+    );
+    const a = get(r, "vault: operator readable");
+    expect(a?.status).toBe("ok");
+    expect(a?.detail).toContain("not present");
+  });
+
+  it("FAILs with a chown fix when the file is root-locked", () => {
+    const r = runSecretAccessChecks(
+      cfg({}),
+      deps({
+        statVault: () => ({
+          exists: true,
+          readable: false,
+          uid: 0,
+          mode: 0o600,
+          realPath: "/home/op/.switchroom/vault/vault.enc",
+        }),
+      }),
+    );
+    const a = get(r, "vault: operator readable");
+    expect(a?.status).toBe("fail");
+    expect(a?.detail).toContain("uid 0");
+    expect(a?.fix).toBe(
+      "sudo chown op:op /home/op/.switchroom/vault/vault.enc",
+    );
+  });
+
+  it("ok when the operator can read it", () => {
+    const r = runSecretAccessChecks(cfg({}), deps());
+    expect(get(r, "vault: operator readable")?.status).toBe("ok");
+  });
+});
+
+describe("runSecretAccessChecks — Check B (per-agent access)", () => {
+  it("warns (cannot verify) when the passphrase is unset", () => {
+    const saved = process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
+    try {
+      const r = runSecretAccessChecks(
+        cfg({ a: {} }),
+        deps({ passphrase: undefined }),
+      );
+      const b = get(r, "agent secret access");
+      expect(b?.status).toBe("warn");
+      expect(b?.detail).toContain("SWITCHROOM_VAULT_PASSPHRASE not set");
+    } finally {
+      if (saved !== undefined) process.env.SWITCHROOM_VAULT_PASSPHRASE = saved;
+    }
+  });
+
+  it("fails 'agent secret access' when the vault won't open and the file IS readable", () => {
+    const r = runSecretAccessChecks(
+      cfg({ a: {} }),
+      deps({
+        openVault: () => {
+          throw new Error("bad passphrase");
+        },
+      }),
+    );
+    const b = get(r, "agent secret access");
+    expect(b?.status).toBe("fail");
+    expect(b?.detail).toContain("bad passphrase");
+  });
+
+  it("ok per agent when declared cron secrets exist and ACL allows", () => {
+    const config = cfg({
+      scout: {
+        schedule: [{ cron: "0 8 * * *", prompt: "x", secrets: ["api-key"] }],
+      },
+      bare: {},
+    });
+    const entries: Record<string, VaultEntry> = {
+      "api-key": { kind: "string", value: "v" },
+    };
+    const r = runSecretAccessChecks(config, deps({ openVault: () => entries }));
+    expect(get(r, "secret access: scout")?.status).toBe("ok");
+    expect(get(r, "secret access: scout")?.detail).toContain("all present");
+    expect(get(r, "secret access: bare")?.status).toBe("ok");
+    expect(get(r, "secret access: bare")?.detail).toContain(
+      "no declared vault secrets",
+    );
+  });
+
+  it("FAILs when a declared cron secret is missing from the vault", () => {
+    const config = cfg({
+      scout: {
+        schedule: [{ cron: "0 8 * * *", prompt: "x", secrets: ["api-key"] }],
+      },
+    });
+    const r = runSecretAccessChecks(config, deps({ openVault: () => ({}) }));
+    const s = get(r, "secret access: scout");
+    expect(s?.status).toBe("fail");
+    expect(s?.detail).toContain("'api-key' missing from the vault");
+    expect(s?.fix).toContain("--allow scout");
+  });
+
+  it("FAILs when the per-key scope denies the agent", () => {
+    const config = cfg({
+      scout: {
+        schedule: [{ cron: "0 8 * * *", prompt: "x", secrets: ["api-key"] }],
+      },
+    });
+    const entries: Record<string, VaultEntry> = {
+      "api-key": { kind: "string", value: "v", scope: { deny: ["scout"] } },
+    };
+    const r = runSecretAccessChecks(config, deps({ openVault: () => entries }));
+    const s = get(r, "secret access: scout");
+    expect(s?.status).toBe("fail");
+    expect(s?.detail).toContain("per-key scope denies");
+  });
+
+  it("picks up `vault:` refs from config (not just cron) and flags missing", () => {
+    const config = cfg({
+      tgbot: { channels: { telegram: { bot_token: "vault:bot#x" } } },
+    });
+    const r = runSecretAccessChecks(config, deps({ openVault: () => ({}) }));
+    const s = get(r, "secret access: tgbot");
+    expect(s?.status).toBe("fail");
+    expect(s?.detail).toContain("'bot' missing from the vault");
+  });
+
+  it("does not false-'missing' a google:<acct> slot ref (existence skipped)", () => {
+    const config = cfg({
+      g: {
+        schedule: [
+          { cron: "0 8 * * *", prompt: "x", secrets: ["google:a@x:drive"] },
+        ],
+      },
+    });
+    // not in the vault blob, but isGoogleSlot ⇒ existence skipped; ACL
+    // is evaluated via checkAclByAgent (no google_accounts ⇒ denied).
+    const r = runSecretAccessChecks(config, deps({ openVault: () => ({}) }));
+    const s = get(r, "secret access: g");
+    expect(s?.status).toBe("fail");
+    expect(s?.detail).not.toContain("missing from the vault");
+    expect(s?.detail).toContain("no static ACL");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1473. New **"Vault access (#1473)"** doctor section — two checks for failure modes that were invisible until a cron/skill broke at runtime (this is exactly what cost a long debugging session on a dev install):

**A. `vault: operator readable`** — probes `vault.enc` *as the operator* (realpath → stat → `access(R_OK)`). Detects the `root:root` lockout: a root-mode write (sudo `apply`/hostd/broker fanout) didn't chown back, so every `switchroom vault …` fails while the broker keeps working (CAP_DAC_READ_SEARCH) and masks it. `fail` with the exact `sudo chown <user>:<user> <realpath>` fix. No passphrase needed — always runs.

**B. `secret access: <agent>`** — for each agent, the union of cron `schedule[].secrets[]` (cascade-resolved via `resolveAgentConfig`) and `vault:` refs anywhere in its resolved config must (1) exist in the vault and (2) be readable by that agent. **Reuses the broker's own predicates** (`checkAclByAgent` + `checkEntryScope` from `src/vault/broker/acl.ts`) so doctor's verdict == runtime behavior. Gated on `SWITCHROOM_VAULT_PASSPHRASE` (warn-degrades when unset, mirroring `checkVault`).

Scope/limits (documented in-file): `google:<acct>` slots skip the blob-existence check (auth-broker slots, ACL-routed); skill secret needs have no machine-readable manifest so they're covered transitively via `vault:` refs and noted deferred; ephemeral capability grants are invisible to a static check, so ACL gaps are worded "no *static* ACL".

Mirrors the established `doctor-<area>.ts` module + deps-injection pattern (hostd/auth-broker/credentials-migration).

## Test plan
- [x] `npm run lint` clean
- [x] `tests/doctor-secret-access.test.ts` — 10 pass: Check A absent/root-locked/ok; Check B passphrase-unset warn, open-fail, cron-secret ok, missing-key fail, per-key-scope-deny fail, config `vault:` ref pickup, google-slot no-false-missing. Real `checkAclByAgent`/`checkEntryScope`/`resolveAgentConfig` exercised end-to-end.
- [ ] CI green; post-merge: live `switchroom doctor` shows the new section green on this host

🤖 Generated with [Claude Code](https://claude.com/claude-code)