### PR TITLE
fix(apply): restore operator ownership after self-elevated apply (#1473 prevention)

### DIFF
--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -60,6 +60,10 @@ import { installUpdatePromptHook } from "./update-prompt-hook.js";
 import { generateCompose, allocateAgentUid } from "../agents/compose.js";
 import { resolveImageTag, resolveRelease } from "../config/release-resolve.js";
 import { detectInstallType } from "./install-detect.js";
+import {
+  resolveOperatorUid,
+  restoreOperatorOwnership,
+} from "./operator-uid.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { captureEvent, captureException } from "../analytics/posthog.js";
 
@@ -816,18 +820,7 @@ export async function runApply(
   // or unparseable. On Windows / non-POSIX, getuid is unavailable; the
   // operator listener simply isn't bound (broker skips when env var
   // is unset).
-  const operatorUid: number | undefined = (() => {
-    const sudoUid = process.env.SUDO_UID;
-    if (sudoUid !== undefined) {
-      const parsed = parseInt(sudoUid, 10);
-      if (Number.isFinite(parsed) && parsed > 0) return parsed;
-    }
-    if (typeof process.getuid === "function") {
-      const uid = process.getuid();
-      if (uid > 0) return uid;
-    }
-    return undefined;
-  })();
+  const operatorUid: number | undefined = resolveOperatorUid();
   // Resolve the release block for this apply run. Priority:
   //   1. CLI flag override (--channel/--pin on `apply` or `update`)
   //   2. Root `release` block from switchroom.yaml
@@ -880,6 +873,23 @@ export async function runApply(
       `  (If pull returns 401, login to ghcr.io first: see docs/operators/install.md#ghcr-auth)\n`,
     ),
   );
+
+  // Prevention (#1473): a self-elevated (sudo) apply just re-rendered
+  // the vault/audit/accounts/compose artifacts AS ROOT (migrateVaultLayout
+  // et al.). Restore operator ownership so `switchroom vault …` keeps
+  // working instead of silently EACCES-ing (the broker masks it via
+  // CAP_DAC_READ_SEARCH). No-op when not elevated or the operator uid
+  // is unknown; per-agent dirs are owned by alignAgentUid and untouched.
+  if (process.geteuid?.() === 0 && operatorUid !== undefined) {
+    const restored = restoreOperatorOwnership(homedir(), operatorUid);
+    if (restored.length > 0) {
+      writeOut(
+        chalk.gray(
+          `  Restored operator ownership of ${restored.length} ~/.switchroom path(s)\n`,
+        ),
+      );
+    }
+  }
 
   writeOut(
     chalk.bold(

--- a/src/cli/operator-uid.ts
+++ b/src/cli/operator-uid.ts
@@ -1,0 +1,157 @@
+/**
+ * Operator-identity + post-sudo ownership restore (#1473 prevention).
+ *
+ * `switchroom apply` self-elevates by re-exec'ing the WHOLE process
+ * under `sudo` (`reexecUnderSudo`). Everything it then writes —
+ * `migrateVaultLayout` rewriting `vault/vault.enc`, the audit-log
+ * mkdirs, etc. — is created as root, with no chown-back. The broker
+ * still reads via CAP_DAC_READ_SEARCH, so it's invisible until the
+ * operator runs `switchroom vault …` and gets EACCES (the recurring
+ * lockout this prevents — detected by doctor since #1474, now also
+ * prevented at the source).
+ *
+ * Scattered per-artifact chowns regress every time a new operator-owned
+ * artifact lands, so this is ONE generic sweep over the operator-owned
+ * `~/.switchroom` subtree. Per-agent state dirs are intentionally NOT
+ * touched — `alignAgentUid` owns those at the per-agent UID.
+ */
+
+import {
+  chownSync,
+  existsSync,
+  lstatSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Resolve the real invoking operator's uid even under sudo. `sudo`
+ * exports the underlying user's uid as `SUDO_UID` (process.getuid()
+ * would return 0). Falls back to getuid() when >0, else undefined
+ * (root with no SUDO_UID, or non-POSIX where getuid is unavailable).
+ */
+export function resolveOperatorUid(): number | undefined {
+  const sudoUid = process.env.SUDO_UID;
+  if (sudoUid !== undefined) {
+    const parsed = parseInt(sudoUid, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  if (typeof process.getuid === "function") {
+    const uid = process.getuid();
+    if (uid > 0) return uid;
+  }
+  return undefined;
+}
+
+export interface OwnershipRestoreDeps {
+  chown?: (path: string, uid: number, gid: number) => void;
+  exists?: (path: string) => boolean;
+  /** True if path is a directory (follows symlinks). */
+  isDir?: (path: string) => boolean;
+  /** True if path is itself a symlink (no follow). */
+  isSymlink?: (path: string) => boolean;
+  realpath?: (path: string) => string;
+  readdir?: (path: string) => string[];
+}
+
+/**
+ * Operator-owned artifacts directly under `~/.switchroom` that a
+ * root-mode `apply` can leave root-owned and thereby lock the operator
+ * out of. NOT per-agent dirs (alignAgentUid handles those at the agent
+ * UID — chowning them to the operator would itself break the agents).
+ */
+export function operatorOwnedPaths(home: string): string[] {
+  const root = join(home, ".switchroom");
+  return [
+    join(root, "vault"), // dir (recursive) — holds vault.enc
+    join(root, "vault-auto-unlock"), // machine-id-keyed unlock blob
+    join(root, "vault-audit.log"),
+    join(root, "host-control-audit.log"),
+    join(root, "accounts"), // dir (recursive) — OAuth account store
+    join(root, "compose"), // dir (recursive) — generated docker-compose.yml
+  ];
+}
+
+/**
+ * Best-effort: chown the operator-owned `~/.switchroom` subtree back to
+ * `operatorUid:operatorUid`. Recurses into directories. Every chown is
+ * best-effort (dev/non-docker, missing path, no CAP_CHOWN, raced
+ * delete) — a failure on one path never aborts the rest. Returns the
+ * realpaths it successfully chowned (logging/tests).
+ *
+ * For the `vault` dir this resolves the real target so the v0.7.12
+ * legacy symlink (`vault.enc -> vault/vault.enc`) doesn't matter.
+ */
+export function restoreOperatorOwnership(
+  home: string,
+  operatorUid: number,
+  deps: OwnershipRestoreDeps = {},
+): string[] {
+  const chown = deps.chown ?? ((p, u, g) => chownSync(p, u, g));
+  const exists = deps.exists ?? ((p) => existsSync(p));
+  const isSymlink =
+    deps.isSymlink ??
+    ((p) => {
+      try {
+        return lstatSync(p).isSymbolicLink();
+      } catch {
+        return false;
+      }
+    });
+  const isDir =
+    deps.isDir ??
+    ((p) => {
+      try {
+        return statSync(p).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+  const realpath =
+    deps.realpath ??
+    ((p) => {
+      try {
+        return realpathSync(p);
+      } catch {
+        return p;
+      }
+    });
+  const readdir =
+    deps.readdir ??
+    ((p) => {
+      try {
+        return readdirSync(p);
+      } catch {
+        return [];
+      }
+    });
+
+  const chowned: string[] = [];
+  const seen = new Set<string>();
+
+  const visit = (path: string): void => {
+    if (!exists(path)) return;
+    // Resolve symlinks to the real target (the v0.7.12 vault.enc
+    // legacy link, accounts symlinks, …) so we chown the actual file,
+    // not the link entry.
+    const target = isSymlink(path) ? realpath(path) : path;
+    if (seen.has(target)) return;
+    seen.add(target);
+    try {
+      chown(target, operatorUid, operatorUid);
+      chowned.push(target);
+    } catch {
+      /* best-effort: dev/no CAP_CHOWN/raced; keep going */
+    }
+    if (isDir(target)) {
+      for (const entry of readdir(target)) {
+        visit(join(target, entry));
+      }
+    }
+  };
+
+  for (const p of operatorOwnedPaths(home)) visit(p);
+  return chowned;
+}

--- a/tests/operator-uid.test.ts
+++ b/tests/operator-uid.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import {
+  resolveOperatorUid,
+  restoreOperatorOwnership,
+  operatorOwnedPaths,
+  type OwnershipRestoreDeps,
+} from "../src/cli/operator-uid.js";
+
+const savedSudoUid = process.env.SUDO_UID;
+afterEach(() => {
+  if (savedSudoUid === undefined) delete process.env.SUDO_UID;
+  else process.env.SUDO_UID = savedSudoUid;
+  vi.restoreAllMocks();
+});
+
+describe("resolveOperatorUid", () => {
+  it("prefers a valid SUDO_UID", () => {
+    process.env.SUDO_UID = "1234";
+    expect(resolveOperatorUid()).toBe(1234);
+  });
+
+  it("ignores SUDO_UID=0 and non-numeric, falling back to getuid()", () => {
+    vi.spyOn(process, "getuid").mockReturnValue(1000);
+    process.env.SUDO_UID = "0";
+    expect(resolveOperatorUid()).toBe(1000);
+    process.env.SUDO_UID = "notanumber";
+    expect(resolveOperatorUid()).toBe(1000);
+  });
+
+  it("returns undefined when running as real root with no SUDO_UID", () => {
+    delete process.env.SUDO_UID;
+    vi.spyOn(process, "getuid").mockReturnValue(0);
+    expect(resolveOperatorUid()).toBeUndefined();
+  });
+});
+
+describe("operatorOwnedPaths", () => {
+  it("covers vault, auto-unlock, audit logs, accounts, compose — not per-agent dirs", () => {
+    const p = operatorOwnedPaths("/home/op");
+    expect(p).toContain("/home/op/.switchroom/vault");
+    expect(p).toContain("/home/op/.switchroom/vault-auto-unlock");
+    expect(p).toContain("/home/op/.switchroom/vault-audit.log");
+    expect(p).toContain("/home/op/.switchroom/host-control-audit.log");
+    expect(p).toContain("/home/op/.switchroom/accounts");
+    expect(p).toContain("/home/op/.switchroom/compose");
+    expect(p.some((x) => x.includes("/agents"))).toBe(false);
+  });
+});
+
+describe("restoreOperatorOwnership", () => {
+  function fs(
+    layout: Record<string, "file" | "dir" | "symlink">,
+    children: Record<string, string[]> = {},
+    realpaths: Record<string, string> = {},
+  ): { calls: Array<[string, number, number]>; deps: OwnershipRestoreDeps } {
+    const calls: Array<[string, number, number]> = [];
+    return {
+      calls,
+      deps: {
+        chown: (p, u, g) => {
+          calls.push([p, u, g]);
+        },
+        exists: (p) => p in layout,
+        isDir: (p) => layout[realpaths[p] ?? p] === "dir",
+        isSymlink: (p) => layout[p] === "symlink",
+        realpath: (p) => realpaths[p] ?? p,
+        readdir: (p) => children[p] ?? [],
+      },
+    };
+  }
+
+  it("chowns every existing operator-owned path to operatorUid:operatorUid", () => {
+    const root = "/h/.switchroom";
+    const { calls, deps } = fs({
+      [`${root}/vault`]: "dir",
+      [`${root}/vault/vault.enc`]: "file",
+      [`${root}/vault-audit.log`]: "file",
+      // accounts/auto-unlock/host-control-audit/compose absent
+    }, { [`${root}/vault`]: ["vault.enc"] });
+    const done = restoreOperatorOwnership("/h", 1000, deps);
+    expect(calls).toContainEqual([`${root}/vault`, 1000, 1000]);
+    expect(calls).toContainEqual([`${root}/vault/vault.enc`, 1000, 1000]);
+    expect(calls).toContainEqual([`${root}/vault-audit.log`, 1000, 1000]);
+    expect(done).toContain(`${root}/vault/vault.enc`);
+    // absent paths never chowned
+    expect(calls.some(([p]) => p.includes("accounts"))).toBe(false);
+  });
+
+  it("follows a symlink to its realpath (v0.7.12 vault.enc legacy link)", () => {
+    const root = "/h/.switchroom";
+    const { calls, deps } = fs(
+      {
+        [`${root}/vault`]: "dir",
+        [`${root}/vault/vault.enc`]: "file",
+      },
+      { [`${root}/vault`]: ["vault.enc", "vault.enc.legacy"] },
+      { [`${root}/vault/vault.enc.legacy`]: `${root}/vault/vault.enc` },
+    );
+    // legacy entry is a symlink → resolves to the same real file (dedup)
+    deps.isSymlink = (p) => p === `${root}/vault/vault.enc.legacy`;
+    deps.exists = (p) =>
+      p === `${root}/vault` ||
+      p === `${root}/vault/vault.enc` ||
+      p === `${root}/vault/vault.enc.legacy`;
+    restoreOperatorOwnership("/h", 42, deps);
+    const realFileChowns = calls.filter(
+      ([p]) => p === `${root}/vault/vault.enc`,
+    );
+    expect(realFileChowns).toHaveLength(1); // deduped, not chowned twice
+  });
+
+  it("is best-effort: one failing chown does not abort the rest", () => {
+    const root = "/h/.switchroom";
+    const { deps } = fs({
+      [`${root}/vault`]: "file",
+      [`${root}/accounts`]: "file",
+    });
+    const got: string[] = [];
+    deps.chown = (p) => {
+      if (p === `${root}/vault`) throw new Error("EPERM");
+      got.push(p);
+    };
+    const done = restoreOperatorOwnership("/h", 7, deps);
+    expect(got).toContain(`${root}/accounts`);
+    expect(done).toContain(`${root}/accounts`);
+    expect(done).not.toContain(`${root}/vault`);
+  });
+
+  it("no-ops cleanly when nothing exists", () => {
+    const { calls, deps } = fs({});
+    expect(restoreOperatorOwnership("/h", 1000, deps)).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

The prevention half of #1473 (detection shipped in #1474). `switchroom apply` self-elevates by re-exec'ing the **whole process** under `sudo` (`reexecUnderSudo`). Everything it then writes as root — `migrateVaultLayout` rewriting `vault/vault.enc`, the audit-log mkdirs, `accounts/`, the generated compose — was left **root-owned with no chown-back**. The broker keeps reading via `CAP_DAC_READ_SEARCH` so it's invisible until the operator runs `switchroom vault …` and gets EACCES. **Confirmed to recur on every `switchroom update --rebuild`** this session.

- **`resolveOperatorUid()`** — extracted from apply's inline IIFE (the `SUDO_UID`-aware operator-uid resolution; now a reusable, tested helper used both for the existing compose call and the new sweep).
- **`restoreOperatorOwnership()`** — ONE generic best-effort sweep over the operator-owned `~/.switchroom` subtree (`vault/`, `vault-auto-unlock`, `vault-audit.log`, `host-control-audit.log`, `accounts/`, `compose/`), recursing dirs, symlink-resolving (v0.7.12 `vault.enc` legacy link), deduped. Scattered per-artifact chowns regress as new artifacts land — one sweep is the durable shape.
- **apply**: replace the IIFE with the helper; call the sweep at the end of an elevated run, gated `geteuid()===0 && operatorUid`. **Per-agent dirs are deliberately untouched** — `alignAgentUid` owns those at the per-agent UID.

### Scope / what's deferred
Fixes **writer (a)** — the sudo-`apply`/`migrateVaultLayout` path, the *confirmed* `update --rebuild` recurrence. **Writer (b)** — the root broker's `op:put` (`broker/server.ts:1533` → `vault.ts` atomic write as root) re-rooting `vault.enc` *between* applies — is a separate, higher-risk change to the security-critical long-lived daemon and is tracked as a follow-up issue (doctor #1474 detects-not-masks it in the meantime). Also deferred (follow-up): generalizing doctor Check A to the full sweep set; the known `accounts/credentials.json` sudo-chown analogue.

## Test plan
- [x] `npm run lint` clean
- [x] `tests/operator-uid.test.ts` — 8 pass: `resolveOperatorUid` (SUDO_UID precedence, getuid fallback, real-root→undefined); `restoreOperatorOwnership` (chowns the set to uid:uid, recurses, symlink-dedup, best-effort on failure, no-op when absent); `operatorOwnedPaths` excludes per-agent dirs
- [ ] CI green; post-merge: `switchroom update --rebuild` then `switchroom doctor` → `vault: operator readable` stays ✓ with no manual chown

🤖 Generated with [Claude Code](https://claude.com/claude-code)