### PR TITLE
fix(vault-broker): an agent may read its OWN configured bot_token (ACL)

### DIFF
--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -444,3 +444,81 @@ describe("ACL: google: slot routing through google_accounts[]", () => {
     if (!r.allow) expect(r.reason).toContain("not configured");
   });
 });
+
+describe("ACL: an agent may read its OWN configured bot_token (install-validation 2026-05-18)", () => {
+  // Regression: a per-agent bot token added via the documented
+  // `switchroom vault set telegram-<agent>-bot-token` + uncomment-the-
+  // agent flow was broker-ACL-denied to its own agent (no schedule
+  // secrets, no bot-token allowance) — masked before because the
+  // global token only ever resolved via the <agent>/telegram/.env
+  // materialization side-channel. #31/#1428-adjacent.
+  function cfg(
+    agents: Record<string, unknown>,
+    globalBotToken: string,
+  ): SwitchroomConfig {
+    return {
+      switchroom: { version: 1 },
+      telegram: { bot_token: globalBotToken, forum_chat_id: "123" },
+      vault: { path: "~/.switchroom/vault.enc", broker: { socket: "s", enabled: true } },
+      agents,
+    } as unknown as SwitchroomConfig;
+  }
+
+  it("per-agent bot_token vault ref → that agent may read that key (no schedule needed)", () => {
+    const config = cfg(
+      { admin: { topic_name: "Admin", bot_token: "vault:telegram-admin-bot-token", admin: true } },
+      "vault:telegram-bot-token",
+    );
+    expect(checkAclByAgent(config, "admin", "telegram-admin-bot-token").allow).toBe(true);
+  });
+
+  it("agent on the GLOBAL telegram.bot_token vault ref may read the global key", () => {
+    const config = cfg(
+      { assistant: { topic_name: "General" } },
+      "vault:telegram-bot-token",
+    );
+    expect(checkAclByAgent(config, "assistant", "telegram-bot-token").allow).toBe(true);
+  });
+
+  it("per-agent override wins: admin reads its own key, NOT the global, NOT another agent's", () => {
+    const config = cfg(
+      {
+        admin: { topic_name: "Admin", bot_token: "vault:telegram-admin-bot-token", admin: true },
+        coach: { topic_name: "Fitness", bot_token: "vault:telegram-coach-bot-token" },
+      },
+      "vault:telegram-bot-token",
+    );
+    expect(checkAclByAgent(config, "admin", "telegram-admin-bot-token").allow).toBe(true);
+    // admin overrides the global → must NOT get the global key via this path…
+    expect(checkAclByAgent(config, "admin", "telegram-bot-token").allow).toBe(false);
+    // …and definitely not a sibling agent's per-agent bot token.
+    expect(checkAclByAgent(config, "admin", "telegram-coach-bot-token").allow).toBe(false);
+    expect(checkAclByAgent(config, "coach", "telegram-admin-bot-token").allow).toBe(false);
+  });
+
+  it("does not open a hole: a literal (non-vault:) bot_token grants nothing; unrelated keys still gated", () => {
+    const config = cfg(
+      { admin: { topic_name: "Admin", bot_token: "123:literaltoken", admin: true } },
+      "alsoliteral",
+    );
+    // literal token isn't a vault key → no allowance, and no schedule → deny
+    expect(checkAclByAgent(config, "admin", "123:literaltoken").allow).toBe(false);
+    expect(checkAclByAgent(config, "admin", "some-other-key").allow).toBe(false);
+  });
+
+  it("regression: schedule.secrets gating for NON-bot keys is unchanged", () => {
+    const config = cfg(
+      {
+        admin: {
+          topic_name: "Admin",
+          bot_token: "vault:telegram-admin-bot-token",
+          schedule: [{ cron: "0 8 * * *", prompt: "x", secrets: ["briefing_key"] }],
+        } as unknown as SwitchroomConfig["agents"][string],
+      },
+      "vault:telegram-bot-token",
+    );
+    expect(checkAclByAgent(config, "admin", "telegram-admin-bot-token").allow).toBe(true); // own bot token
+    expect(checkAclByAgent(config, "admin", "briefing_key").allow).toBe(true);  // schedule.secrets still works
+    expect(checkAclByAgent(config, "admin", "random_key").allow).toBe(false);   // still gated
+  });
+});

--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -496,6 +496,17 @@ describe("ACL: an agent may read its OWN configured bot_token (install-validatio
     expect(checkAclByAgent(config, "coach", "telegram-admin-bot-token").allow).toBe(false);
   });
 
+  it("empty-string per-agent bot_token falls back to the global key (matches getEffectiveBotToken)", () => {
+    const config = cfg(
+      { admin: { topic_name: "Admin", bot_token: "", admin: true } },
+      "vault:telegram-bot-token",
+    );
+    // The gateway's getEffectiveBotToken treats "" as unset → uses the
+    // global; the ACL must allow exactly that key (never deny the key
+    // the gateway will actually request).
+    expect(checkAclByAgent(config, "admin", "telegram-bot-token").allow).toBe(true);
+  });
+
   it("does not open a hole: a literal (non-vault:) bot_token grants nothing; unrelated keys still gated", () => {
     const config = cfg(
       { admin: { topic_name: "Admin", bot_token: "123:literaltoken", admin: true } },

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -269,9 +269,14 @@ export function checkAclByAgent(
   // token historically only "worked" via the <agent>/telegram/.env
   // materialization side-channel, which never fires for a hand-added
   // per-agent agent.
+  // Exactly mirror materialize-bot-token.ts:getEffectiveBotToken —
+  // the per-agent override is preferred only when it's a NON-EMPTY
+  // string (an empty-string `bot_token` falls back to the global,
+  // same as the gateway does), so the ACL can never deny the very
+  // key the gateway will actually try to use.
+  const agentBot = (agentConfig as { bot_token?: string }).bot_token;
   const botRef =
-    (agentConfig as { bot_token?: string }).bot_token ??
-    config.telegram?.bot_token;
+    agentBot && agentBot.length > 0 ? agentBot : config.telegram?.bot_token;
   if (typeof botRef === "string" && botRef.startsWith("vault:")) {
     const botKey = botRef.slice("vault:".length).split("#")[0];
     if (botKey.length > 0 && botKey === key) {

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -254,6 +254,31 @@ export function checkAclByAgent(
     return checkGoogleAccountAcl(config, agentName, googleSlot.account, key);
   }
 
+  // An agent legitimately needs to read its OWN configured bot token.
+  // The gateway resolves `agents.<name>.bot_token` (per-agent override,
+  // wins) or the global `telegram.bot_token` — see
+  // materialize-bot-token.ts:getEffectiveBotToken. That is
+  // identity-bound access to the single key the config assigns to THIS
+  // agent (path-as-identity already proved who the caller is) — NOT
+  // cross-agent secret access — so it must not be gated behind
+  // schedule[].secrets[] (which is cron-misconfiguration protection,
+  // not the auth boundary). Without this, a per-agent bot token added
+  // via the documented `switchroom vault set telegram-<agent>-bot-token`
+  // + uncomment flow is broker-ACL-denied to its own agent
+  // (install-validation 2026-05-18; #31/#1428-adjacent). The global
+  // token historically only "worked" via the <agent>/telegram/.env
+  // materialization side-channel, which never fires for a hand-added
+  // per-agent agent.
+  const botRef =
+    (agentConfig as { bot_token?: string }).bot_token ??
+    config.telegram?.bot_token;
+  if (typeof botRef === "string" && botRef.startsWith("vault:")) {
+    const botKey = botRef.slice("vault:".length).split("#")[0];
+    if (botKey.length > 0 && botKey === key) {
+      return { allow: true };
+    }
+  }
+
   const schedule = agentConfig.schedule ?? [];
   if (schedule.length === 0) {
     return {


### PR DESCRIPTION
## Summary

Discovered by the **RFC J consolidated re-validation** (2026-05-18): once RFC J unblocked the broker (auto-unlock works), the next layer became reachable and the **documented multi-agent flow broke** — `switchroom vault set telegram-<agent>-bot-token` + uncomment the agent in `switchroom.yaml` → that agent's gateway crash-loops on `Bot token resolution denied by vault broker (ACL)`.

**Root cause:** `checkAclByAgent` (`src/vault/broker/acl.ts`) only allowed keys in the agent's `schedule[*].secrets[]` (or `google:` slots) — **no allowance for an agent's own bot token**. The global `telegram.bot_token` only ever "worked" because setup/apply materializes it into `<agent>/telegram/.env`, a side-channel the gateway reads *before* the broker. A hand-added per-agent agent gets no `.env` materialization → its gateway must use the broker → denied. So per-agent bot tokens were broker-unreadable by their own agent (**#31/#1428-adjacent**), masked in prior runs only because the broker was locked and never reached the ACL check.

**Fix:** `checkAclByAgent` now allows an agent to read the vault key that is its own **effective** configured bot_token — `agents.<name>.bot_token` (per-agent override wins) or the global `telegram.bot_token` — mirroring `materialize-bot-token.ts:getEffectiveBotToken`. This is identity-bound access to the single key the config assigns to THIS agent (path-as-identity already proved the caller); **not** cross-agent access, and correctly **not** gated by `schedule.secrets` (cron-misconfig protection, not the auth boundary).

Security: per-agent override does not leak the global key; siblings can't read each other's bot tokens; literal (non-`vault:`) tokens grant nothing; `schedule.secrets` gating for non-bot keys is unchanged. All asserted in tests.

## Validation

- `tsc --noEmit` clean. `src/vault/broker/acl.test.ts` **34/34** (+6 new cases: per-agent ref, global ref, override precedence + cross-agent denial, no-hole-for-literals, schedule.secrets regression).
- VM root cause was confirmed empirically (isolation test: removing `--allow` didn't help; `.env`-materialization mechanism confirmed — `assistant` reads `.env`, `admin` had none → broker → denied).
- Server-side change (runs in the vault-broker image) → end-to-end proof deferred to the next consolidated re-validation once broker images carry it (same constraint as RFC J Phase 4a #1455).

## Test plan

- [ ] CI `lint` + `vitest` green
- [ ] Reviewer confirms: own-bot-token allow is sound & not cross-agent; override precedence; no hole for literal tokens; schedule.secrets path unchanged; mirrors `getEffectiveBotToken`
- [ ] Consolidated re-validation: admin agent (per-agent bot token via documented flow) resolves its token from the broker and the two-bot matrix admin-bot half passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)