### PR TITLE
fix(auth): remaining user-facing --from-oauth → --via-claude (doctor + setup)

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1428,7 +1428,7 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
           detail: auth?.pendingAuth
             ? "pending (auth flow in progress)"
             : "not authenticated",
-          fix: `Run \`switchroom auth add <label> --from-oauth\` then \`switchroom auth use <label>\` (RFC H — see docs/auth.md)`,
+          fix: `Run \`switchroom auth add <label> --via-claude\` then \`switchroom auth use <label>\` (RFC H — see docs/auth.md)`,
         });
       }
     } else {
@@ -1490,7 +1490,7 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
             quotaOut > 0
               ? `Quota-exhausted account(s) will auto-recover when the window resets; broker auto-rotates per \`auth.fallback_order\` (see \`switchroom auth show\`).`
               : expired > 0
-                ? `Expired account(s) — add a fresh one via \`switchroom auth add <label> --from-oauth\` and \`switchroom auth use <label>\` (RFC H).`
+                ? `Expired account(s) — add a fresh one via \`switchroom auth add <label> --via-claude\` and \`switchroom auth use <label>\` (RFC H).`
                 : undefined,
         });
       }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -959,7 +959,7 @@ async function stepScaffoldAgents(
       await ensureAuthActiveDefault(switchroomConfigPath);
       console.log(
         chalk.gray(
-          "  Set auth.active: default — run `switchroom auth add default --from-oauth` to log in",
+          "  Set auth.active: default — run `switchroom auth add default --via-claude` to log in",
         ),
       );
     } catch (err) {


### PR DESCRIPTION
## Summary

#1422 corrected `diagnoseAuthState`'s recommendation, but the install-validation re-run surfaced the broken narrow-scope `--from-oauth` still recommended in **3 more user-facing remediation strings**:

- `src/cli/doctor.ts:1431` — agent-health "not authenticated" fix (the exact line the apply post-doctor sweep prints — the "6th surface" from the validation report).
- `src/cli/doctor.ts:1493` — "Expired account(s)" remediation.
- `src/cli/setup.ts:962` — setup's "Set auth.active: default — run …" hint.

All now recommend `--via-claude`, which mints the broad scope agents in `claude server:` mode require. `--from-oauth` mints `scope=user:inference` only and Claude refuses it on boot (RFC J §2.1 / install-validation R4/R8). Remaining `--from-oauth` strings in `src/` are explanatory comments (incl. `via-claude.ts` documenting *why* it's narrow) — correctly left.

## Validation
- `tsc --noEmit` clean. No test pins these strings (grepped `tests/`).
- Completeness: no remaining user-facing `auth add … --from-oauth` recommendation in `src/` (only comments + the legit CLI usage list `--from-agent | --from-credentials | --from-oauth | --via-claude`).

## Test plan
- [ ] CI `lint` + `vitest` green
- [ ] Reviewer confirms all 3 are user-facing remediations (not comments/usage) and `--via-claude` is the correct scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)