### PR TITLE
fix(vault-broker): unlock gets a generous timeout (RFC J Phase 4b)

### DIFF
--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -41,6 +41,19 @@ import { unlockSocketFor } from "./peercred.js";
 import { isDockerRuntime } from "../../runtime-mode.js";
 
 const DEFAULT_TIMEOUT_MS = 2000;
+// `unlock` is NOT a cheap RPC like status/get: the broker performs a
+// full synchronous vault decrypt (detectVaultLayoutDrift + openVault,
+// AES-256-GCM) BEFORE it writes "OK\n". On a loaded host (concurrent
+// docker builds / image pulls / many agents) that easily exceeds the
+// 2s generic-RPC budget, so the client timed out and destroyed the
+// socket WHILE the broker was successfully unlocking — reporting a
+// false "Timeout waiting for broker" for an unlock that actually
+// succeeded (install-validation 2026-05-18 / RFC J Phase 4b). A
+// genuinely unreachable broker still fails fast via the connection
+// error path (ECONNREFUSED/ENOENT settle immediately, not via this
+// timer); this longer budget only covers "connected, decrypt in
+// progress". Callers may still override via opts.timeoutMs.
+const UNLOCK_TIMEOUT_MS = 30_000;
 /**
  * v0.6 legacy host-side socket path. Pre-v0.7 the broker daemon ran
  * directly on the host as a systemd-user unit and bound its data socket
@@ -654,7 +667,7 @@ export async function unlockViaBroker(
   // the v0.6 flat-shape legacy socket (foo.sock → foo.unlock.sock)
   // both pair correctly.
   const unlockSocketPath = unlockSocketFor(dataSocketPath);
-  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs = opts?.timeoutMs ?? UNLOCK_TIMEOUT_MS;
 
   return new Promise<UnlockResult>((resolve) => {
     let settled = false;


### PR DESCRIPTION
## Summary

**RFC J Phase 4b** — the deferred unlock "Timeout-on-success" race, now root-caused.

`unlockViaBroker` defaulted to the 2s generic-RPC `DEFAULT_TIMEOUT_MS`. But `unlock` is not a cheap RPC: the broker's `_handleUnlockConnection` performs a **full synchronous vault decrypt** (`detectVaultLayoutDrift` + `openVault`, AES-256-GCM) **before** it writes `OK\n`. On a loaded host (concurrent docker builds / GHCR pulls / many agents — exactly the install-validation VM) that exceeds 2s, so the client's timer fired, `client.destroy()`'d the socket, and returned `{ok:false,"Timeout waiting for broker"}` **while the broker successfully unlocked** (then wrote `OK` to a dead socket). Observed on the VM: `vault broker status` flipped to `unlocked:true` yet the CLI said `unlock failed: Timeout waiting for broker`.

**Fix:** a dedicated `UNLOCK_TIMEOUT_MS = 30_000` as unlock's default (callers may still override via `opts.timeoutMs`). The generic `rpc()` path keeps the 2s default (status/get are sub-ms — unchanged).

**Why this doesn't slow genuine-failure detection:** an unreachable broker fails *fast* — `ENOENT`/`ECONNREFUSED` settle immediately via the `client.on("error")` handler, **not** this timer. The longer budget only covers the "connected, decrypt in progress" window.

## Validation
- `tsc --noEmit` clean. No test pins the unlock timeout / `DEFAULT_TIMEOUT_MS` / "Timeout waiting for broker" (grepped `tests/`). acl suite 35/35 (sanity, unrelated).
- Single-constant + default-selection change, no logic/control-flow altered; end-to-end proof is the consolidated re-validation (unlock under load no longer false-times-out).

## Test plan
- [ ] CI `lint` + `vitest` green
- [ ] Reviewer confirms: generic `rpc()` 2s budget unchanged; unreachable-broker still fails fast via the error path (not the timer); 30s is a reasonable ceiling for a vault decrypt under load
- [ ] Consolidated re-validation: `switchroom vault broker unlock` under load reports success, not a false timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)