### PR TITLE
fix(docker): bake the switchroom CLI into the broker image (RFC J Phase 3b)

### DIFF
--- a/docker/Dockerfile.broker
+++ b/docker/Dockerfile.broker
@@ -37,6 +37,20 @@ RUN install -d -m 0755 /run/switchroom/broker
 # broker has no native deps so no in-image npm install is required.
 COPY dist/vault/broker/server.js /opt/switchroom/dist/vault/broker/server.js
 
+# Bake the switchroom CLI onto PATH so the documented in-container
+# recovery — `docker exec -it switchroom-vault-broker switchroom vault
+# broker unlock` (referenced by src/telegram/materialize-bot-token.ts
+# and docs/vault.md) — actually works. Without this the broker image
+# had no `switchroom` binary, so that fallback exited 127 and the only
+# operator unlock path in the docker model was the host CLI
+# (RFC J Phase 3b / install-validation 2026-05-17 finding #32).
+# Mirrors docker/Dockerfile.agent:164-166 exactly; the bundle's
+# `#!/usr/bin/env bun` shebang resolves against the bun already in the
+# base image (the broker CMD itself runs bun).
+COPY dist/cli/switchroom.js /opt/switchroom/switchroom.js
+RUN chmod 0755 /opt/switchroom/switchroom.js \
+ && ln -s /opt/switchroom/switchroom.js /usr/local/bin/switchroom
+
 USER 0:0
 
 ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION
## Summary

**RFC J Phase 3b** — the broker image shipped only the broker server bundle, so the documented in-container recovery `docker exec -it switchroom-vault-broker switchroom vault broker unlock` (referenced by `src/telegram/materialize-bot-token.ts` and `docs/vault.md`) exited **127 — "switchroom: not found"**. Combined with the #32 phantom-host-daemon confusion (fixed in #1457), operators on a docker host had *no* working unlock path during the install-validation run.

Change: mirror `docker/Dockerfile.agent:164-166` exactly — `COPY dist/cli/switchroom.js → /opt/switchroom/switchroom.js`, `chmod 0755`, symlink onto `/usr/local/bin/switchroom`. The bundle's `#!/usr/bin/env bun` shebang resolves against the bun already in the base image (the broker CMD itself runs bun). `scripts/build.mjs:87` emits `dist/cli/switchroom.js`, and the agent image already COPYs it from the same build context, so it's present.

**Safe by construction:** `tests/entry-guard-bundler.test.ts` already pins that the broker server's `main()`-entry-guard regex **rejects** `dist/cli/switchroom.js` (✓ "broker regex rejects the merged CLI bundle"), so running `switchroom …` inside the broker container can never spuriously start the broker daemon; the suite also smoke-asserts `bun dist/cli/switchroom.js --help` emits no `vault-broker fatal` banner.

## Validation

- Dockerfile-only change; no TS/logic touched.
- `tests/entry-guard-bundler.test.ts`: the **6 regex assertions pass** (incl. the two broker-safety ones). The 1 failing case is the `spawnSync("bun", ["dist/cli/switchroom.js","--help"])` smoke test failing **only because this fresh worktree has no built `dist/`** (no `npm run build`) — an environment artifact, not introduced by this change (which cannot affect the CLI bundle). CI builds `dist/` before tests, so it passes there.

## Test plan

- [ ] CI `lint` + `vitest` + `build-dependents (broker)` green (CI builds dist/ → the smoke test runs for real)
- [ ] Reviewer confirms: COPY source in build context; mirrors the agent pattern; entry-guard rejects the CLI bundle so no broker-daemon misfire; image-size delta acceptable
- [ ] Consolidated re-validation: `docker exec switchroom-vault-broker switchroom vault broker unlock` works in-container

🤖 Generated with [Claude Code](https://claude.com/claude-code)