### PR TITLE
feat(skill-author): global-scope authoring for admin agents (PR B)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1602,6 +1602,22 @@ function emitAgentService(
         `      - ${homePrefix}/.switchroom/hostd/${a.name}:/run/switchroom/hostd/${a.name}`,
       );
     }
+    // PR B (#TBD) global-scope skill authoring. Admin agents get a
+    // writable bind of the operator's skills_dir at the in-container
+    // path /skills-rw. The agent-config `skill_create/edit/delete`
+    // tools with scope:"global" resolve against this mount. Non-admin
+    // agents never get it — global authoring is admin-only by
+    // construction (no env, no opt-in, no schema field). The agent
+    // self-serve guard ALSO refuses scope:"global" for non-admin
+    // (defence in depth) and refuses when /skills-rw is missing for
+    // any reason. existsSync-guarded: docker compose up hard-fails on
+    // a missing :rw source (same pattern as the :ro skills mount
+    // below).
+    if (existsSync(`${hostHomeForChecks}/.switchroom/skills`)) {
+      lines.push(
+        `      - ${homePrefix}/.switchroom/skills:/skills-rw:rw`,
+      );
+    }
   }
   // Operator-declared extra bind-mounts (#1164). ADMIN-ONLY: emitting
   // anything for a non-admin agent is a hard error — bind_mounts is the

--- a/src/cli/agent-config-skill-author.global.test.ts
+++ b/src/cli/agent-config-skill-author.global.test.ts
@@ -1,0 +1,240 @@
+/**
+ * PR B tests: global-scope skill authoring (admin agents only) plus the
+ * operator-overwrite guard (`.authored-by-<agent>` marker).
+ *
+ * Scope-resolution fixturing: instead of needing a real `/skills-rw`
+ * mount, the lib functions accept a `globalRoot` override and the
+ * underlying `resolveGlobalScopeRoot()` honours
+ * `SWITCHROOM_SKILLS_RW_ROOT` as a fallback. Tests pass `globalRoot`
+ * directly so they can use a fresh tmpdir per case.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  writeFileSync,
+  readFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  skillCreate,
+  skillEdit,
+  skillDelete,
+  skillRead,
+} from "./agent-config-skill-author.js";
+import {
+  authorshipMarkerName,
+  globalScopeSkillDir,
+} from "./skill-common.js";
+
+const ADMIN = "alice";
+const NON_ADMIN = "bob";
+const PEER_ADMIN = "carrie";
+
+function isAdmin(agent: string): boolean {
+  return agent === ADMIN || agent === PEER_ADMIN;
+}
+
+function validSkillMd(name: string, desc = "a test skill"): string {
+  return `---\nname: ${name}\ndescription: ${desc}\n---\n# body\n`;
+}
+
+describe("agent-config-skill-author (PR B: global scope + ownership)", () => {
+  let perAgentRoot: string;
+  let globalRoot: string;
+
+  beforeEach(() => {
+    perAgentRoot = mkdtempSync(join(tmpdir(), "skill-author-perag-"));
+    globalRoot = mkdtempSync(join(tmpdir(), "skill-author-global-"));
+    process.env.SWITCHROOM_AGENT_NAME = ADMIN;
+    delete process.env.SWITCHROOM_TURN_SOURCE;
+  });
+  afterEach(() => {
+    for (const d of [perAgentRoot, globalRoot]) {
+      try { rmSync(d, { recursive: true, force: true }); } catch { /* */ }
+    }
+  });
+
+  it("global create writes under /skills-rw + drops the authorship marker", () => {
+    const r = skillCreate({
+      agent: ADMIN,
+      name: "my-global",
+      scope: "global",
+      isAdmin,
+      globalRoot,
+      files: { "SKILL.md": validSkillMd("my-global") },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.path).toBe(globalScopeSkillDir("my-global", globalRoot));
+    expect(existsSync(join(r.path, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(r.path, authorshipMarkerName(ADMIN)))).toBe(true);
+    // Peer agent's marker must NOT be present.
+    expect(existsSync(join(r.path, authorshipMarkerName(PEER_ADMIN)))).toBe(false);
+  });
+
+  it("global create denied for non-admin agent", () => {
+    process.env.SWITCHROOM_AGENT_NAME = NON_ADMIN;
+    const r = skillCreate({
+      agent: NON_ADMIN,
+      name: "evil",
+      scope: "global",
+      isAdmin,
+      globalRoot,
+      files: { "SKILL.md": validSkillMd("evil") },
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.code).toBe("E_SKILL_SCOPE_DENIED");
+  });
+
+  it("global create denied when /skills-rw mount is missing", () => {
+    const missing = join(globalRoot, "not-there");
+    const r = skillCreate({
+      agent: ADMIN,
+      name: "no-mount",
+      scope: "global",
+      isAdmin,
+      globalRoot: missing,
+      files: { "SKILL.md": validSkillMd("no-mount") },
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.code).toBe("E_SKILL_GLOBAL_MOUNT_UNCONFIGURED");
+    expect(r.exit).toBe(17);
+  });
+
+  it("global edit of own-authored skill succeeds", () => {
+    const cr = skillCreate({
+      agent: ADMIN, name: "mine", scope: "global", isAdmin, globalRoot,
+      files: { "SKILL.md": validSkillMd("mine") },
+    });
+    if (!cr.ok) throw new Error("setup failed");
+    const rd = skillRead({
+      agent: ADMIN, name: "mine", file: "SKILL.md",
+      scope: "global", isAdmin, globalRoot,
+    });
+    if (!rd.ok || !("version" in rd)) throw new Error("read failed");
+    const ed = skillEdit({
+      agent: ADMIN, name: "mine", file: "SKILL.md",
+      content: validSkillMd("mine", "updated"),
+      version: rd.version,
+      scope: "global", isAdmin, globalRoot,
+    });
+    expect(ed.ok).toBe(true);
+    expect(readFileSync(join(cr.path, "SKILL.md"), "utf-8")).toContain("updated");
+  });
+
+  it("global edit of peer-authored skill refused with E_SKILL_OPERATOR_OWNED", () => {
+    // Peer ADMIN creates it (env-pinned as that agent for the call)...
+    process.env.SWITCHROOM_AGENT_NAME = PEER_ADMIN;
+    const cr = skillCreate({
+      agent: PEER_ADMIN, name: "shared", scope: "global", isAdmin, globalRoot,
+      files: { "SKILL.md": validSkillMd("shared") },
+    });
+    if (!cr.ok) throw new Error(`setup failed: ${cr.code} ${cr.message}`);
+    // ...then ADMIN tries to edit it.
+    process.env.SWITCHROOM_AGENT_NAME = ADMIN;
+    const rd = skillRead({
+      agent: ADMIN, name: "shared", file: "SKILL.md",
+      scope: "global", isAdmin, globalRoot,
+    });
+    if (!rd.ok || !("version" in rd)) throw new Error("read failed");
+    const ed = skillEdit({
+      agent: ADMIN, name: "shared", file: "SKILL.md",
+      content: validSkillMd("shared", "hijacked"),
+      version: rd.version,
+      scope: "global", isAdmin, globalRoot,
+    });
+    expect(ed.ok).toBe(false);
+    if (ed.ok) return;
+    expect(ed.code).toBe("E_SKILL_OPERATOR_OWNED");
+    expect(ed.exit).toBe(18);
+  });
+
+  it("global edit of operator-curated skill (no marker) refused", () => {
+    // Pre-place a skill dir with no authorship marker (operator-curated).
+    const dir = globalScopeSkillDir("operator-skill", globalRoot);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), validSkillMd("operator-skill"));
+    const rd = skillRead({
+      agent: ADMIN, name: "operator-skill", file: "SKILL.md",
+      scope: "global", isAdmin, globalRoot,
+    });
+    if (!rd.ok || !("version" in rd)) throw new Error("read failed");
+    const ed = skillEdit({
+      agent: ADMIN, name: "operator-skill", file: "SKILL.md",
+      content: validSkillMd("operator-skill", "hijacked"),
+      version: rd.version,
+      scope: "global", isAdmin, globalRoot,
+    });
+    expect(ed.ok).toBe(false);
+    if (ed.ok) return;
+    expect(ed.code).toBe("E_SKILL_OPERATOR_OWNED");
+  });
+
+  it("global delete of own-authored succeeds, of peer/operator refused", () => {
+    // own
+    const own = skillCreate({
+      agent: ADMIN, name: "mine2", scope: "global", isAdmin, globalRoot,
+      files: { "SKILL.md": validSkillMd("mine2") },
+    });
+    if (!own.ok) throw new Error("setup");
+    const delOwn = skillDelete({
+      agent: ADMIN, name: "mine2", scope: "global", isAdmin, globalRoot,
+    });
+    expect(delOwn.ok).toBe(true);
+
+    // peer-authored
+    process.env.SWITCHROOM_AGENT_NAME = PEER_ADMIN;
+    const peer = skillCreate({
+      agent: PEER_ADMIN, name: "peer-skill", scope: "global", isAdmin, globalRoot,
+      files: { "SKILL.md": validSkillMd("peer-skill") },
+    });
+    if (!peer.ok) throw new Error(`setup: ${peer.code} ${peer.message}`);
+    process.env.SWITCHROOM_AGENT_NAME = ADMIN;
+    const delPeer = skillDelete({
+      agent: ADMIN, name: "peer-skill", scope: "global", isAdmin, globalRoot,
+    });
+    expect(delPeer.ok).toBe(false);
+    if (delPeer.ok) return;
+    expect(delPeer.code).toBe("E_SKILL_OPERATOR_OWNED");
+
+    // operator-curated (no marker)
+    const opDir = globalScopeSkillDir("op-skill", globalRoot);
+    mkdirSync(opDir, { recursive: true });
+    writeFileSync(join(opDir, "SKILL.md"), validSkillMd("op-skill"));
+    const delOp = skillDelete({
+      agent: ADMIN, name: "op-skill", scope: "global", isAdmin, globalRoot,
+    });
+    expect(delOp.ok).toBe(false);
+    if (delOp.ok) return;
+    expect(delOp.code).toBe("E_SKILL_OPERATOR_OWNED");
+  });
+
+  it("agent-scope writes still ignore the marker entirely (no regression)", () => {
+    const r = skillCreate({
+      agent: ADMIN, name: "agent-scoped", root: perAgentRoot, isAdmin,
+      files: { "SKILL.md": validSkillMd("agent-scoped") },
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // No marker in agent-scope dirs.
+    expect(existsSync(join(r.path, authorshipMarkerName(ADMIN)))).toBe(false);
+    // Edit works without marker.
+    const rd = skillRead({
+      agent: ADMIN, name: "agent-scoped", file: "SKILL.md", root: perAgentRoot,
+    });
+    if (!rd.ok || !("version" in rd)) throw new Error("read");
+    const ed = skillEdit({
+      agent: ADMIN, name: "agent-scoped", file: "SKILL.md",
+      content: validSkillMd("agent-scoped", "updated"),
+      version: rd.version, root: perAgentRoot,
+    });
+    expect(ed.ok).toBe(true);
+  });
+});

--- a/src/cli/agent-config-skill-author.ts
+++ b/src/cli/agent-config-skill-author.ts
@@ -38,12 +38,17 @@ import {
   appendAudit,
   authorErr,
   authorExitCodeFor,
+  authorshipMarkerName,
   ensureSkillsRoot,
+  globalScopeSkillDir,
+  globalScopeSkillsRoot,
+  hasAuthorshipMarker,
   isCronTurn,
   listSkillFiles,
   MAX_FILES_PER_SKILL,
   MAX_SKILL_BYTES,
   readSkillFrontmatter,
+  resolveGlobalScopeRoot,
   safeWriteFile,
   skillVersionToken,
   totalSkillBytes,
@@ -52,6 +57,74 @@ import {
   validateSkillName,
   type SkillAuthorError,
 } from "./skill-common.js";
+import { existsSync as fsExistsSync, writeFileSync } from "node:fs";
+import { loadConfig } from "../config/loader.js";
+
+export type SkillScope = "agent" | "global";
+
+/** Resolve whether `agent` is `admin: true` in the merged switchroom
+ *  config. Used to gate global-scope writes (PR B).
+ *
+ *  Tests can inject `isAdminOverride` to bypass disk-loading the yaml. */
+export function defaultIsAdmin(agent: string): boolean {
+  try {
+    const cfg = loadConfig();
+    const slice = cfg.agents?.[agent] as { admin?: boolean } | undefined;
+    return slice?.admin === true;
+  } catch {
+    return false;
+  }
+}
+
+interface ScopeContext {
+  scope: SkillScope;
+  /** Absolute root dir for this scope (parent of all skill dirs). */
+  rootDir: string;
+  /** Absolute path to this specific skill's dir. */
+  skillDir: string;
+}
+
+function resolveScope(
+  agent: string,
+  slug: string,
+  scope: SkillScope | undefined,
+  perAgentRoot: string | undefined,
+  globalRoot: string | undefined,
+  isAdminFn: (a: string) => boolean,
+): ScopeContext | SkillAuthorError {
+  const s: SkillScope = scope ?? "agent";
+  if (s === "agent") {
+    return {
+      scope: "agent",
+      rootDir: agentScopeSkillsRoot(agent, perAgentRoot),
+      skillDir: agentScopeSkillDir(agent, slug, perAgentRoot),
+    };
+  }
+  if (s === "global") {
+    if (!isAdminFn(agent)) {
+      return authorErr(
+        "E_SKILL_SCOPE_DENIED",
+        `global-scope skill authoring requires admin: true on agent "${agent}"`,
+      );
+    }
+    const root = globalRoot ?? resolveGlobalScopeRoot();
+    if (!fsExistsSync(root)) {
+      return authorErr(
+        "E_SKILL_GLOBAL_MOUNT_UNCONFIGURED",
+        `global scope root ${root} is not present — the /skills-rw bind mount is missing (rebuild compose with admin: true)`,
+      );
+    }
+    return {
+      scope: "global",
+      rootDir: globalScopeSkillsRoot(root),
+      skillDir: globalScopeSkillDir(slug, root),
+    };
+  }
+  return authorErr(
+    "E_SKILL_SCOPE_DENIED",
+    `unknown scope ${JSON.stringify(s)} — must be "agent" or "global"`,
+  );
+}
 
 /**
  * Identity-pin enforcement.
@@ -120,7 +193,14 @@ export interface SkillCreateOpts {
   name: string;
   /** Map of skill-relative path → file content. MUST include SKILL.md. */
   files: Record<string, string>;
+  /** Per-agent test root override (agent scope only). */
   root?: string;
+  /** Scope: "agent" (default) or "global" (admin only, PR B). */
+  scope?: SkillScope;
+  /** Global-scope root override (defaults to /skills-rw via env). */
+  globalRoot?: string;
+  /** Admin lookup override (defaults to merged-config check). */
+  isAdmin?: (agent: string) => boolean;
 }
 
 export interface SkillCreateResult {
@@ -195,8 +275,15 @@ export function skillCreate(
   const fmCheck = validateSkillMd(opts.files["SKILL.md"]!, opts.name);
   if ("ok" in fmCheck && fmCheck.ok === false) return fmCheck;
 
+  // Resolve scope (agent | global). Global requires admin + mount.
+  const isAdminFn = opts.isAdmin ?? defaultIsAdmin;
+  const sc = resolveScope(
+    agent, opts.name, opts.scope, opts.root, opts.globalRoot, isAdminFn,
+  );
+  if ("ok" in sc && sc.ok === false) return sc;
+  const ctx = sc as ScopeContext;
   // Refuse if the destination dir already exists.
-  const destDir = agentScopeSkillDir(agent, opts.name, opts.root);
+  const destDir = ctx.skillDir;
   if (existsSync(destDir)) {
     return authorErr(
       "E_SKILL_ALREADY_EXISTS",
@@ -221,14 +308,19 @@ export function skillCreate(
     /* ENOENT — good, we want it absent */
   }
 
-  ensureSkillsRoot(agent, opts.root);
+  if (ctx.scope === "agent") {
+    ensureSkillsRoot(agent, opts.root);
+  } else {
+    // /skills-rw already exists (we checked above); create the slug parent.
+    mkdirSync(ctx.rootDir, { recursive: true });
+  }
 
   // B2 defence: refuse if any path component leading to skillsRoot is
   // itself a symlink. This catches the "swap .claude/skills for a
   // symlink to /tmp" attack BEFORE we materialize a stage dir under
   // the attacker-controlled location. Best-effort vs full TOCTOU; see
   // safeWriteFile() for the parent-walk invariant + O_EXCL pairing.
-  const rootDir = agentScopeSkillsRoot(agent, opts.root);
+  const rootDir = ctx.rootDir;
   {
     // Walk every component of rootDir. lstatSync each one; refuse on
     // any symlink hit.
@@ -270,6 +362,22 @@ export function skillCreate(
       }
     }
     renameSync(stageDir, destDir);
+    // PR B operator-overwrite guard: drop an authorship marker on
+    // global-scope creates so future edit/delete can verify ownership.
+    // Agent-scope skills don't need a marker — the dir is already
+    // per-agent.
+    if (ctx.scope === "global") {
+      try {
+        writeFileSync(
+          join(destDir, authorshipMarkerName(agent)),
+          "",
+          { flag: "wx", mode: 0o600 },
+        );
+      } catch {
+        // best-effort: even if marker write fails, the skill exists.
+        // Surfacing this as a hard error would leave an orphan dir.
+      }
+    }
   } catch (e) {
     try { rmSync(stageDir, { recursive: true, force: true }); } catch { /* */ }
     return authorErr(
@@ -297,6 +405,9 @@ export interface SkillEditOpts {
   /** Optimistic-concurrency token from a prior skillRead. */
   version: string;
   root?: string;
+  scope?: SkillScope;
+  globalRoot?: string;
+  isAdmin?: (agent: string) => boolean;
 }
 
 export interface SkillEditResult {
@@ -339,7 +450,13 @@ export function skillEdit(
     );
   }
 
-  const destDir = agentScopeSkillDir(agent, opts.name, opts.root);
+  const isAdminFn = opts.isAdmin ?? defaultIsAdmin;
+  const sc = resolveScope(
+    agent, opts.name, opts.scope, opts.root, opts.globalRoot, isAdminFn,
+  );
+  if ("ok" in sc && sc.ok === false) return sc;
+  const ctx = sc as ScopeContext;
+  const destDir = ctx.skillDir;
   if (!existsSync(destDir)) {
     return authorErr(
       "E_SKILL_NOT_FOUND",
@@ -357,6 +474,15 @@ export function skillEdit(
     }
   } catch {
     return authorErr("E_SKILL_NOT_FOUND", `${destDir} missing`);
+  }
+
+  // PR B operator-overwrite guard: global-scope edits are denied
+  // unless the agent's own authorship marker is present.
+  if (ctx.scope === "global" && !hasAuthorshipMarker(destDir, agent)) {
+    return authorErr(
+      "E_SKILL_OPERATOR_OWNED",
+      `global skill ${opts.name} is not authored by ${agent} (no ${authorshipMarkerName(agent)} marker) — operator-curated or peer-authored skills are immutable`,
+    );
   }
 
   const currentToken = skillVersionToken(destDir);
@@ -422,6 +548,9 @@ export interface SkillReadOpts {
   name: string;
   file?: string;
   root?: string;
+  scope?: SkillScope;
+  globalRoot?: string;
+  isAdmin?: (agent: string) => boolean;
 }
 
 export type SkillReadResult =
@@ -455,7 +584,13 @@ export function skillRead(
       `skill name must match [a-z0-9][a-z0-9_-]{0,62}: got ${JSON.stringify(opts.name)}`,
     );
   }
-  const destDir = agentScopeSkillDir(agent, opts.name, opts.root);
+  const isAdminFn = opts.isAdmin ?? defaultIsAdmin;
+  const sc = resolveScope(
+    agent, opts.name, opts.scope, opts.root, opts.globalRoot, isAdminFn,
+  );
+  if ("ok" in sc && sc.ok === false) return sc;
+  const ctx = sc as ScopeContext;
+  const destDir = ctx.skillDir;
   if (!existsSync(destDir)) {
     return authorErr(
       "E_SKILL_NOT_FOUND",
@@ -524,6 +659,9 @@ export interface SkillDeleteOpts {
   agent?: string;
   name: string;
   root?: string;
+  scope?: SkillScope;
+  globalRoot?: string;
+  isAdmin?: (agent: string) => boolean;
 }
 
 export interface SkillDeleteResult {
@@ -548,7 +686,13 @@ export function skillDelete(
       `skill name must match [a-z0-9][a-z0-9_-]{0,62}: got ${JSON.stringify(opts.name)}`,
     );
   }
-  const destDir = agentScopeSkillDir(agent, opts.name, opts.root);
+  const isAdminFn = opts.isAdmin ?? defaultIsAdmin;
+  const sc = resolveScope(
+    agent, opts.name, opts.scope, opts.root, opts.globalRoot, isAdminFn,
+  );
+  if ("ok" in sc && sc.ok === false) return sc;
+  const ctx = sc as ScopeContext;
+  const destDir = ctx.skillDir;
   if (!existsSync(destDir)) {
     return authorErr(
       "E_SKILL_NOT_FOUND",
@@ -567,6 +711,13 @@ export function skillDelete(
   } catch {
     return authorErr("E_SKILL_NOT_FOUND", `${destDir} missing`);
   }
+  // PR B operator-overwrite guard.
+  if (ctx.scope === "global" && !hasAuthorshipMarker(destDir, agent)) {
+    return authorErr(
+      "E_SKILL_OPERATOR_OWNED",
+      `global skill ${opts.name} is not authored by ${agent} (no ${authorshipMarkerName(agent)} marker) — refuse to delete operator-curated or peer-authored skill`,
+    );
+  }
   rmSync(destDir, { recursive: true, force: true });
   return { ok: true, slug: opts.name, path: destDir };
 }
@@ -580,6 +731,16 @@ interface AuthorCliOpts {
   content?: string;
   fromStdin?: boolean;
   version?: string;
+  scope?: string;
+}
+
+function parseScope(raw: string | undefined): SkillScope | SkillAuthorError {
+  if (raw == null || raw === "agent") return "agent";
+  if (raw === "global") return "global";
+  return authorErr(
+    "E_SKILL_SCOPE_DENIED",
+    `--scope must be "agent" or "global" (got ${JSON.stringify(raw)})`,
+  );
 }
 
 function readStdin(): Promise<string> {
@@ -616,6 +777,7 @@ export function registerAgentConfigSkillAuthorCommands(program: Command): void {
     )
     .requiredOption("--name <slug>", "Skill slug (must match [a-z0-9][a-z0-9_-]{0,62})")
     .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .option("--scope <agent|global>", "Authoring scope (default: agent)")
     .option("--from-stdin", "Read {path: content} JSON map from stdin", false)
     .action(async (opts: AuthorCliOpts) => {
       const resolvedAgent = opts.agent ?? process.env.SWITCHROOM_AGENT_NAME ?? "<unknown>";
@@ -623,6 +785,8 @@ export function registerAgentConfigSkillAuthorCommands(program: Command): void {
         process.stderr.write("--from-stdin is required for skill create\n");
         process.exit(2);
       }
+      const sp = parseScope(opts.scope);
+      if (typeof sp !== "string") fail(sp, resolvedAgent, "skill.create", { name: opts.name, scope: opts.scope });
       const raw = await readStdin();
       let files: Record<string, string>;
       try {
@@ -631,8 +795,8 @@ export function registerAgentConfigSkillAuthorCommands(program: Command): void {
         process.stderr.write(`failed to parse stdin JSON: ${(e as Error).message}\n`);
         process.exit(2);
       }
-      const r = skillCreate({ agent: opts.agent, name: opts.name, files });
-      if (!r.ok) fail(r, resolvedAgent, "skill.create", { name: opts.name });
+      const r = skillCreate({ agent: opts.agent, name: opts.name, files, scope: sp as SkillScope });
+      if (!r.ok) fail(r, resolvedAgent, "skill.create", { name: opts.name, scope: sp });
       emit(r);
       try {
         appendAudit(resolvedAgent, "skill.create",
@@ -652,6 +816,7 @@ export function registerAgentConfigSkillAuthorCommands(program: Command): void {
     .option("--content <string>", "New file content (or use --from-stdin)")
     .option("--from-stdin", "Read raw content from stdin", false)
     .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .option("--scope <agent|global>", "Authoring scope (default: agent)")
     .action(async (opts: AuthorCliOpts) => {
       const resolvedAgent = opts.agent ?? process.env.SWITCHROOM_AGENT_NAME ?? "<unknown>";
       let content = opts.content;
@@ -660,12 +825,15 @@ export function registerAgentConfigSkillAuthorCommands(program: Command): void {
         process.stderr.write("--content or --from-stdin required\n");
         process.exit(2);
       }
+      const sp = parseScope(opts.scope);
+      if (typeof sp !== "string") fail(sp, resolvedAgent, "skill.edit", { name: opts.name, scope: opts.scope });
       const r = skillEdit({
         agent: opts.agent,
         name: opts.name,
         file: opts.file!,
         content,
         version: opts.version!,
+        scope: sp as SkillScope,
       });
       if (!r.ok) fail(r, resolvedAgent, "skill.edit",
         { name: opts.name, file: opts.file });
@@ -685,12 +853,16 @@ export function registerAgentConfigSkillAuthorCommands(program: Command): void {
     .requiredOption("--name <slug>", "Skill slug")
     .option("--file <relpath>", "Specific file to read (omit for tree summary)")
     .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .option("--scope <agent|global>", "Read scope (default: agent)")
     .action(async (opts: AuthorCliOpts) => {
       const resolvedAgent = opts.agent ?? process.env.SWITCHROOM_AGENT_NAME ?? "<unknown>";
+      const sp = parseScope(opts.scope);
+      if (typeof sp !== "string") fail(sp, resolvedAgent, "skill.read", { name: opts.name, scope: opts.scope });
       const r = skillRead({
         agent: opts.agent,
         name: opts.name,
         file: opts.file,
+        scope: sp as SkillScope,
       });
       if (!("ok" in r) || r.ok !== true) {
         fail(r, resolvedAgent, "skill.read", { name: opts.name, file: opts.file });
@@ -710,9 +882,12 @@ export function registerAgentConfigSkillAuthorCommands(program: Command): void {
     )
     .requiredOption("--name <slug>", "Skill slug")
     .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .option("--scope <agent|global>", "Delete scope (default: agent)")
     .action(async (opts: AuthorCliOpts) => {
       const resolvedAgent = opts.agent ?? process.env.SWITCHROOM_AGENT_NAME ?? "<unknown>";
-      const r = skillDelete({ agent: opts.agent, name: opts.name });
+      const sp = parseScope(opts.scope);
+      if (typeof sp !== "string") fail(sp, resolvedAgent, "skill.delete", { name: opts.name, scope: opts.scope });
+      const r = skillDelete({ agent: opts.agent, name: opts.name, scope: sp as SkillScope });
       if (!r.ok) fail(r, resolvedAgent, "skill.delete", { name: opts.name });
       emit(r);
       try {

--- a/src/cli/agent-config.test.ts
+++ b/src/cli/agent-config.test.ts
@@ -296,6 +296,25 @@ describe("registered commands", () => {
     expect(parsed.bundled_skills).toEqual({ "skill-creator": true });
   });
 
+  it("skill list editable_scopes is ['agent','global'] for admin agents", async () => {
+    // PR B: admin agents may author into global scope; the list verb
+    // surfaces that capability so callers can branch on it without a
+    // separate config_get round-trip. `a` is admin: true in this fixture.
+    process.env.SWITCHROOM_AGENT_NAME = "a";
+    const program = buildProgram();
+    await program.parseAsync(["node", "switchroom", "skill", "list"]);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.editable_scopes).toEqual(["agent", "global"]);
+  });
+
+  it("skill list editable_scopes is ['agent'] for non-admin agents", async () => {
+    process.env.SWITCHROOM_AGENT_NAME = "b";
+    const program = buildProgram();
+    await program.parseAsync(["node", "switchroom", "skill", "list"]);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.editable_scopes).toEqual(["agent"]);
+  });
+
   it("peers list excludes the caller and includes name + purpose + admin for every other agent", async () => {
     process.env.SWITCHROOM_AGENT_NAME = "a";
     const program = buildProgram();

--- a/src/cli/agent-config.ts
+++ b/src/cli/agent-config.ts
@@ -329,14 +329,19 @@ export function registerAgentConfigCommands(program: Command): void {
           const slice = getAgentSlice(cfg, agent) as {
             skills?: string[];
             bundled_skills?: Record<string, boolean>;
+            admin?: boolean;
           };
+          // PR B: admin agents can also author into global scope
+          // (host's skills_dir, mounted at /skills-rw). Non-admin
+          // agents see ["agent"] only. The admin lookup matches the
+          // bind-mount + global-write gate exactly.
+          const editableScopes: string[] = slice.admin === true
+            ? ["agent", "global"]
+            : ["agent"];
           const out = {
             skills: slice.skills ?? [],
             bundled_skills: slice.bundled_skills ?? {},
-            // PR A of agent-skill-authoring: agents can author into their
-            // own .claude/skills/<slug>/. Global scope (operator-owned
-            // bundled pool) comes in PR B.
-            editable_scopes: ["agent"] as string[],
+            editable_scopes: editableScopes,
           };
           process.stdout.write(JSON.stringify(out) + "\n");
           appendAudit(agent, "skill.list", { ...opts }, 0);

--- a/src/cli/skill-common.ts
+++ b/src/cli/skill-common.ts
@@ -69,7 +69,9 @@ export type SkillAuthorErrorCode =
   | "E_SKILL_VERSION_STALE"
   | "E_SKILL_AUTHOR_REQUIRES_INTERACTIVE"
   | "E_SKILL_NOT_FOUND"
-  | "E_AGENT_PIN_REQUIRED";
+  | "E_AGENT_PIN_REQUIRED"
+  | "E_SKILL_OPERATOR_OWNED"
+  | "E_SKILL_GLOBAL_MOUNT_UNCONFIGURED";
 
 export interface SkillAuthorError {
   ok: false;
@@ -98,7 +100,54 @@ export function authorExitCodeFor(code: SkillAuthorErrorCode): number {
       return 9;
     case "E_AGENT_PIN_REQUIRED":
       return 16;
+    case "E_SKILL_GLOBAL_MOUNT_UNCONFIGURED":
+      return 17;
+    case "E_SKILL_OPERATOR_OWNED":
+      return 18;
   }
+}
+
+// ─── PR B: global-scope authoring (admin agents only) ────────────────
+
+/** In-container path where the host's `skills_dir` is bind-mounted
+ *  `:rw` for admin agents. PR B (#TBD). Non-admin agents do NOT get
+ *  this mount; the dispatcher refuses with E_SKILL_SCOPE_DENIED before
+ *  we ever resolve a path against /skills-rw.
+ *
+ *  Tests may override this via `SWITCHROOM_SKILLS_RW_ROOT` env var so
+ *  fixtures can point at a temp dir without needing a real mount. */
+export const DEFAULT_GLOBAL_SCOPE_ROOT = "/skills-rw";
+
+export function resolveGlobalScopeRoot(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return env.SWITCHROOM_SKILLS_RW_ROOT ?? DEFAULT_GLOBAL_SCOPE_ROOT;
+}
+
+export function globalScopeSkillsRoot(root?: string): string {
+  return root ?? resolveGlobalScopeRoot();
+}
+
+export function globalScopeSkillDir(slug: string, root?: string): string {
+  return join(globalScopeSkillsRoot(root), slug);
+}
+
+/** Marker filename written into a global-scope skill dir on create
+ *  to record the agent that authored it. Operator-curated skills have
+ *  no marker, so they're immune from agent edits/deletes. */
+export function authorshipMarkerName(agent: string): string {
+  return `.authored-by-${agent}`;
+}
+
+/** Check whether `skillDir` carries an authorship marker for `agent`.
+ *  Returns true ONLY if the exact `.authored-by-<agent>` file is
+ *  present. A marker for a different agent (or no marker at all)
+ *  returns false. */
+export function hasAuthorshipMarker(
+  skillDir: string,
+  agent: string,
+): boolean {
+  return existsSync(join(skillDir, authorshipMarkerName(agent)));
 }
 
 export function authorErr(

--- a/src/mcp/agent-config/server.ts
+++ b/src/mcp/agent-config/server.ts
@@ -100,6 +100,8 @@ interface ToolArgs {
   file?: string;
   content?: string;
   version?: string;
+  // PR B: scope selector for skill_create/edit/read/delete.
+  scope?: "agent" | "global";
 }
 
 function buildArgs(base: string[], a: ToolArgs): string[] {
@@ -285,7 +287,13 @@ export const TOOLS = [
       "E_SKILL_INVALID_NAME, E_SKILL_INVALID_PATH, " +
       "E_SKILL_INVALID_FRONTMATTER, E_SKILL_FILE_TOO_LARGE, " +
       "E_SKILL_BUNDLE_TOO_LARGE, E_SKILL_ALREADY_EXISTS, " +
-      "E_SKILL_AUTHOR_REQUIRES_INTERACTIVE, E_SKILL_SCOPE_DENIED.",
+      "E_SKILL_AUTHOR_REQUIRES_INTERACTIVE, E_SKILL_SCOPE_DENIED. " +
+      "PR B: pass `scope: \"global\"` (admin agents only) to author into " +
+      "the operator's skills_dir (mounted at /skills-rw). Global creates " +
+      "drop a `.authored-by-<agent>` marker so future edit/delete can " +
+      "verify ownership — operator-curated globals (no marker) are " +
+      "immutable from agents. Additional errors: E_SKILL_OPERATOR_OWNED " +
+      "(exit 18), E_SKILL_GLOBAL_MOUNT_UNCONFIGURED (exit 17).",
     inputSchema: {
       type: "object" as const,
       required: ["name", "files"],
@@ -298,6 +306,14 @@ export const TOOLS = [
             "Map of skill-relative path → file content. Must include SKILL.md.",
         },
         agent: { type: "string" },
+        scope: {
+          type: "string",
+          enum: ["agent", "global"],
+          description:
+            "Authoring scope. \"agent\" (default) writes under the " +
+            "calling agent's overlay. \"global\" writes under /skills-rw " +
+            "(operator's skills_dir) — admin agents only.",
+        },
       },
     },
   },
@@ -317,7 +333,12 @@ export const TOOLS = [
       "E_SKILL_INVALID_PATH, E_SKILL_INVALID_NAME, " +
       "E_SKILL_INVALID_FRONTMATTER, E_SKILL_VERSION_STALE, " +
       "E_SKILL_FILE_TOO_LARGE, E_SKILL_BUNDLE_TOO_LARGE, " +
-      "E_SKILL_AUTHOR_REQUIRES_INTERACTIVE, E_SKILL_SCOPE_DENIED.",
+      "E_SKILL_AUTHOR_REQUIRES_INTERACTIVE, E_SKILL_SCOPE_DENIED. " +
+      "PR B: with `scope: \"global\"` (admin only) the edit is refused " +
+      "with E_SKILL_OPERATOR_OWNED (exit 18) unless the agent's own " +
+      "`.authored-by-<agent>` marker is present in the skill dir. Also: " +
+      "E_SKILL_GLOBAL_MOUNT_UNCONFIGURED (exit 17) if /skills-rw is " +
+      "missing.",
     inputSchema: {
       type: "object" as const,
       required: ["name", "file", "content", "version"],
@@ -327,6 +348,14 @@ export const TOOLS = [
         content: { type: "string" },
         version: { type: "string" },
         agent: { type: "string" },
+        scope: {
+          type: "string",
+          enum: ["agent", "global"],
+          description:
+            "Edit scope. \"agent\" (default) or \"global\" (admin-only; " +
+            "operator-curated skills without an authorship marker are " +
+            "immutable).",
+        },
       },
     },
   },
@@ -338,7 +367,8 @@ export const TOOLS = [
       "frontmatter. Always returns a `version` token suitable for a " +
       "subsequent `skill_edit` call. Symlinks are refused for safety. " +
       "Error codes: E_SKILL_NOT_FOUND, E_SKILL_INVALID_PATH, " +
-      "E_SKILL_INVALID_NAME, E_SKILL_SCOPE_DENIED.",
+      "E_SKILL_INVALID_NAME, E_SKILL_SCOPE_DENIED, " +
+      "E_SKILL_GLOBAL_MOUNT_UNCONFIGURED (exit 17 — only with scope=global).",
     inputSchema: {
       type: "object" as const,
       required: ["name"],
@@ -346,6 +376,12 @@ export const TOOLS = [
         name: { type: "string", pattern: "^[a-z0-9][a-z0-9_-]{0,62}$" },
         file: { type: "string" },
         agent: { type: "string" },
+        scope: {
+          type: "string",
+          enum: ["agent", "global"],
+          description:
+            "Read scope. \"agent\" (default) or \"global\" (admin only).",
+        },
       },
     },
   },
@@ -357,13 +393,24 @@ export const TOOLS = [
       "`skill_remove` instead). Refused from cron-fired turns. Error " +
       "codes: E_SKILL_NOT_FOUND, E_SKILL_INVALID_PATH, " +
       "E_SKILL_INVALID_NAME, E_SKILL_AUTHOR_REQUIRES_INTERACTIVE, " +
-      "E_SKILL_SCOPE_DENIED.",
+      "E_SKILL_SCOPE_DENIED. PR B: with `scope: \"global\"` (admin " +
+      "only), refused with E_SKILL_OPERATOR_OWNED (exit 18) unless the " +
+      "agent's own `.authored-by-<agent>` marker is present. Also " +
+      "E_SKILL_GLOBAL_MOUNT_UNCONFIGURED (exit 17) if /skills-rw is " +
+      "missing.",
     inputSchema: {
       type: "object" as const,
       required: ["name"],
       properties: {
         name: { type: "string", pattern: "^[a-z0-9][a-z0-9_-]{0,62}$" },
         agent: { type: "string" },
+        scope: {
+          type: "string",
+          enum: ["agent", "global"],
+          description:
+            "Delete scope. \"agent\" (default) or \"global\" (admin only; " +
+            "marker-gated).",
+        },
       },
     },
   },
@@ -466,6 +513,7 @@ export function dispatchTool(
       }
       const base = ["skill", "create", "--name", a.name, "--from-stdin"];
       if (a.agent) base.push("--agent", a.agent);
+      if (a.scope) base.push("--scope", a.scope as string);
       const r = spawnSyncWithStdin(base, JSON.stringify(a.files));
       if (r.status !== 0) {
         return errorText(
@@ -493,6 +541,7 @@ export function dispatchTool(
         "--from-stdin",
       ];
       if (a.agent) base.push("--agent", a.agent);
+      if (a.scope) base.push("--scope", a.scope as string);
       const r = spawnSyncWithStdin(base, a.content);
       if (r.status !== 0) {
         return errorText(
@@ -511,6 +560,7 @@ export function dispatchTool(
       const base = ["skill", "read", "--name", a.name];
       if (a.file) base.push("--file", a.file);
       if (a.agent) base.push("--agent", a.agent);
+      if (a.scope) base.push("--scope", a.scope as string);
       cliArgs = base;
       parseMode = "json";
       break;
@@ -520,6 +570,7 @@ export function dispatchTool(
       if (!a.name) return errorText("skill_delete: name is required");
       const base = ["skill", "delete", "--name", a.name];
       if (a.agent) base.push("--agent", a.agent);
+      if (a.scope) base.push("--scope", a.scope as string);
       cliArgs = base;
       parseMode = "json";
       break;

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -2349,3 +2349,62 @@ describe("network_isolation — sec WS6-F1 / feature #1413", () => {
     expect(out).not.toContain("switchroom-net-hostagent:");
   });
 });
+
+describe("PR B: /skills-rw admin bind-mount for global skill authoring", () => {
+  // The agent-config skill-author CLI (scope:"global") writes under
+  // /skills-rw inside the container, which is the host's skills_dir
+  // bind-mounted :rw. The mount is implicit on `admin: true` — no
+  // schema field — and MUST NOT appear for non-admin agents.
+
+  it("admin agent gets the /skills-rw bind when skills dir exists on host", async () => {
+    const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-skills-rw-"));
+    mkdirSync(join(tmp, ".switchroom", "skills"), { recursive: true });
+    try {
+      const out = generateCompose({
+        config: makeConfig({ alice: { admin: true } }),
+        homeDir: tmp,
+      });
+      expect(out).toMatch(new RegExp(
+        `agent-alice:[\\s\\S]*?- ${tmp}/.switchroom/skills:/skills-rw:rw`,
+      ));
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("non-admin agent does NOT get /skills-rw even when skills dir exists", async () => {
+    const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-skills-rw-deny-"));
+    mkdirSync(join(tmp, ".switchroom", "skills"), { recursive: true });
+    try {
+      const out = generateCompose({
+        config: makeConfig({ bob: { admin: false } }),
+        homeDir: tmp,
+      });
+      expect(out).not.toContain("/skills-rw:rw");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("admin agent skips /skills-rw when host skills dir is missing", async () => {
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-skills-rw-empty-"));
+    try {
+      const out = generateCompose({
+        config: makeConfig({ alice: { admin: true } }),
+        homeDir: tmp,
+      });
+      expect(out).not.toContain("/skills-rw:rw");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

PR B of the agent-skill-authoring feature (PR A: #1490). Extends
`skill_create / edit / read / delete` with a `scope: "agent" | "global"`
parameter, gated on `admin: true` and protected by a per-agent
authorship marker so operator-curated globals stay immutable.

- **Implicit admin bind-mount.** Admin agents get the host's
  `skills_dir` bind-mounted `:rw` at the in-container path
  `/skills-rw`. No new schema field — implicit on `admin: true`,
  `existsSync`-guarded the same way the `:ro` skills mount is.
- **Scope routing.** Agent-scope (default) keeps the PR-A behaviour
  (writes under `~/.switchroom/agents/<agent>/.claude/skills/`).
  Global-scope writes resolve against `/skills-rw` (overridable for
  tests via `SWITCHROOM_SKILLS_RW_ROOT`). All PR-A rails — frontmatter,
  path allowlist, symlink walks, size caps, version tokens,
  cron-source denial — apply identically.
- **Operator-overwrite guard (per reviewer).** `skill_create(scope=global)`
  drops a `.authored-by-<agent>` sidecar in the skill dir after the
  atomic rename. `skill_edit/skill_delete(scope=global)` refuse with
  `E_SKILL_OPERATOR_OWNED` (exit 18) unless the marker exists and the
  agent in the filename matches `$SWITCHROOM_AGENT_NAME`. Operator-
  curated skills (no marker) are immune; per-agent globals are
  editable only by their author.
- **skill_list.editable_scopes** is now computed dynamically:
  `["agent", "global"]` for admin, `["agent"]` otherwise.
- **MCP tool descriptions** updated for the new `scope` param plus
  the new error codes (`E_SKILL_OPERATOR_OWNED`,
  `E_SKILL_GLOBAL_MOUNT_UNCONFIGURED`).

## Rationale: the marker, not a registry

Reviewer flagged a real footgun: with multiple admin agents (klanker,
carrie), naive global authoring would let any admin clobber any other
admin's skills, or worse, overwrite operator-curated skills the
operator hand-maintains in `switchroom.yaml`. A sidecar marker file
gives us a per-skill ACL with no new schema, no registry, no MCP
state — POSIX file presence is the source of truth. Operator-curated
skills (always written by the operator, never via this CLI) get no
marker and are therefore immutable from agents.

## Deferred

- `skill_publish` (agent-scope → global promotion). Deferred
  indefinitely per the brief; the explicit-scope path covers the
  workflow without the publish ceremony.
- Quota on global-scope skills (per the brief: "NO QUOTA enforcement").

## Test plan

- [x] Author tests pass (`agent-config-skill-author.test.ts`, 15 tests)
- [x] New global-scope tests pass (`agent-config-skill-author.global.test.ts`, 8 tests covering: create happy path + marker, non-admin denial, missing-mount denial, own-edit success, peer-edit refused, operator-curated-edit refused, delete with all three ownership states, agent-scope regression check)
- [x] Compose tests pass (`compose-generator.test.ts`, 145 tests including 3 new `/skills-rw` cases)
- [x] `editable_scopes` differs for admin vs non-admin (`agent-config.test.ts`)
- [x] MCP server dispatcher tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)