### PR TITLE
fix(skill-author): stop --version shadowing skill_edit's concurrency token (#1492)

### DIFF
--- a/src/cli/agent-config-skill-author.ts
+++ b/src/cli/agent-config-skill-author.ts
@@ -730,7 +730,7 @@ interface AuthorCliOpts {
   file?: string;
   content?: string;
   fromStdin?: boolean;
-  version?: string;
+  expectVersion?: string;
   scope?: string;
 }
 
@@ -812,7 +812,12 @@ export function registerAgentConfigSkillAuthorCommands(program: Command): void {
     )
     .requiredOption("--name <slug>", "Skill slug")
     .requiredOption("--file <relpath>", "File within the skill (e.g. SKILL.md)")
-    .requiredOption("--version <token>", "Version token from skillRead")
+    .requiredOption(
+      "--expect-version <token>",
+      "Optimistic-concurrency token from skillRead. NOT --version: that " +
+      "long flag is owned by the root program's version printer and would " +
+      "shadow this option (see #1492).",
+    )
     .option("--content <string>", "New file content (or use --from-stdin)")
     .option("--from-stdin", "Read raw content from stdin", false)
     .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
@@ -832,7 +837,7 @@ export function registerAgentConfigSkillAuthorCommands(program: Command): void {
         name: opts.name,
         file: opts.file!,
         content,
-        version: opts.version!,
+        version: opts.expectVersion!,
         scope: sp as SkillScope,
       });
       if (!r.ok) fail(r, resolvedAgent, "skill.edit",

--- a/src/mcp/agent-config/server.author.test.ts
+++ b/src/mcp/agent-config/server.author.test.ts
@@ -91,6 +91,76 @@ describe("agent-config MCP server — PR A author tools", () => {
     }
   });
 
+  it("E2E #1492: skill_edit round-trips via the real CLI (not shadowed by --version)", () => {
+    // Regression for #1492. The MCP server shells out with the
+    // optimistic-concurrency token; if that CLI flag is `--version`
+    // the root program's version printer eats it, emits `0.x.y` on
+    // stdout, exits 0 — and the MCP server's JSON.parse blows up with
+    // "Unable to parse JSON string" while nothing lands on disk. This
+    // drives the real create→read→edit→read loop so the collision
+    // can never silently come back. (The skill_create E2E above did
+    // NOT cover edit, which is why #1491 shipped green.)
+    const which = spawnSync("which", ["bun"], { encoding: "utf-8" });
+    if (which.status !== 0) return;
+    const cliEntry = join(process.cwd(), "bin", "switchroom.ts");
+    if (!existsSync(cliEntry)) return;
+    const tmp = mkdtempSync(join(tmpdir(), "skill-edit-e2e-"));
+    try {
+      const env = {
+        ...process.env,
+        HOME: tmp,
+        SWITCHROOM_AGENT_NAME: "alice",
+      } as NodeJS.ProcessEnv;
+      const create = spawnSync(
+        "bun",
+        [cliEntry, "skill", "create", "--name", "ed", "--from-stdin"],
+        {
+          encoding: "utf-8",
+          env,
+          input: JSON.stringify({
+            "SKILL.md": `---\nname: ed\ndescription: edit roundtrip\n---\n# v1\n`,
+          }),
+          timeout: 30000,
+        },
+      );
+      expect(create.status, `create: ${create.stderr}`).toBe(0);
+      const v1 = JSON.parse(
+        spawnSync("bun", [cliEntry, "skill", "read", "--name", "ed"], {
+          encoding: "utf-8",
+          env,
+          timeout: 30000,
+        }).stdout.trim(),
+      ).version as string;
+
+      const edit = spawnSync(
+        "bun",
+        [
+          cliEntry, "skill", "edit",
+          "--name", "ed",
+          "--file", "scripts/run.py",
+          "--expect-version", v1,
+          "--from-stdin",
+        ],
+        { encoding: "utf-8", env, input: `print("hi")\n`, timeout: 30000 },
+      );
+      expect(edit.status, `edit: ${edit.stderr}`).toBe(0);
+      // The actual #1492 assertion: stdout is parseable JSON, NOT the
+      // CLI version string. JSON.parse("0.11.1") throws exactly the
+      // reported error.
+      const parsed = JSON.parse(edit.stdout.trim());
+      expect(parsed.ok).toBe(true);
+      expect(parsed.file).toBe("scripts/run.py");
+      const written = join(
+        tmp, ".switchroom", "agents", "alice", ".claude",
+        "skills", "ed", "scripts", "run.py",
+      );
+      expect(existsSync(written)).toBe(true);
+      expect(readFileSync(written, "utf-8")).toContain('print("hi")');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("S2: spawnSyncWithStdin uses a 30s timeout", () => {
     // Sanity-check that the helper actually executes; with a no-op
     // command we should get a quick exit. The real assertion is the

--- a/src/mcp/agent-config/server.ts
+++ b/src/mcp/agent-config/server.ts
@@ -537,7 +537,7 @@ export function dispatchTool(
         "skill", "edit",
         "--name", a.name,
         "--file", a.file,
-        "--version", a.version,
+        "--expect-version", a.version,
         "--from-stdin",
       ];
       if (a.agent) base.push("--agent", a.agent);


### PR DESCRIPTION
## Summary

Fixes #1492. Every `mcp__agent-config__skill_edit` call returned
`failed to parse CLI output: JSON Parse error` and nothing landed on
disk, while `skill_read`/`skill_create` worked.

**Root cause:** the CLI subcommand `skill edit` declared
`.requiredOption("--version <token>")`. That long flag collides with
the root commander program's `.version(VERSION)` — commander's version
printer intercepts `--version`, prints the CLI version (`0.11.1`) to
stdout and exits 0. The edit action never runs; the MCP server then
`JSON.parse("0.11.1")` → "Unable to parse JSON string". `skill_read`/
`skill_create` have no `--version` flag, so they were unaffected — and
#1491's only E2E test covered `skill_create`, so CI stayed green.

**Fix:** rename the internal CLI flag to `--expect-version`. The
agent-facing MCP `version` argument is unchanged (no breaking change
for agents already calling the tool). Add an E2E regression that
drives the real create→read→edit→read loop so the collision can't
silently come back.

Serves JTBD: admin/agent skill authoring end-to-end from inside the
container (the loop #1491 was meant to close).

## Test plan

- [x] `npx vitest run src/mcp/agent-config/server.author.test.ts` — new
      `E2E #1492` test spawns the real CLI and round-trips edit
- [x] skill-author + agent-config suites (55 tests) green
- [x] `npx tsc --noEmit` clean
- [x] Manual repro pre-fix (stdout=`0.11.1`) and post-fix (clean JSON,
      file on disk)
- [x] Independent fresh-process reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)