### PR TITLE
fix(test): resolve-socket-path pins delegation to the runtime-aware default (unblocks vitest gate)

### DIFF
--- a/src/vault/broker/client.ts
+++ b/src/vault/broker/client.ts
@@ -95,7 +95,7 @@ const OPERATOR_SOCKET_PATH = join(homedir(), ".switchroom", "broker-operator", "
  * regardless of whether this shell happens to have SWITCHROOM_RUNTIME
  * set. Check that first.
  */
-function defaultBrokerSocketPath(): string {
+export function defaultBrokerSocketPath(): string {
   // 1. Operator socket present → a dockerized broker is serving it
   //    (deployment truth; works from host shells too).
   if (fs.existsSync(OPERATOR_SOCKET_PATH)) return OPERATOR_SOCKET_PATH;

--- a/src/vault/broker/resolve-socket-path.test.ts
+++ b/src/vault/broker/resolve-socket-path.test.ts
@@ -9,7 +9,14 @@
  *   1. opts.socket      — explicit caller override
  *   2. SWITCHROOM_VAULT_BROKER_SOCK env — set by compose into agents
  *   3. opts.vaultBrokerSocket — config-derived path
- *   4. ~/.switchroom/vault-broker.sock — legacy default
+ *   4. defaultBrokerSocketPath() — RUNTIME-AWARE default (RFC J):
+ *      operator socket if present / docker mode → broker-operator/sock;
+ *      else the legacy ~/.switchroom/vault-broker.sock (v0.6 systemd).
+ *      Step 4 is NOT a fixed path — asserting an absolute legacy path
+ *      here was environment-sensitive (it fails on any box where the
+ *      operator socket exists or docker runtime is detected) and
+ *      encoded pre-RFC-J behaviour. We pin DELEGATION to that single
+ *      source of truth instead.
  *
  * Pre-fix the CLI (`src/cli/vault.ts`, `vault-broker.ts`,
  * `vault-doctor.ts`, `vault-grant.ts`, `vault-auto-unlock.ts`) all
@@ -28,12 +35,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { homedir } from "node:os";
-import { join } from "node:path";
-import { resolveBrokerSocketPath } from "./client.js";
+import { resolveBrokerSocketPath, defaultBrokerSocketPath } from "./client.js";
 
 const ENV_KEY = "SWITCHROOM_VAULT_BROKER_SOCK";
-const LEGACY_DEFAULT = join(homedir(), ".switchroom", "vault-broker.sock");
 
 describe("resolveBrokerSocketPath", () => {
   let savedEnv: string | undefined;
@@ -74,9 +78,16 @@ describe("resolveBrokerSocketPath", () => {
     expect(result).toBe("/from-config");
   });
 
-  it("falls back to ~/.switchroom/vault-broker.sock when nothing else is set", () => {
+  it("delegates to the runtime-aware default when no override/env/config is set", () => {
+    // Step 4 is NOT a fixed legacy path — it's defaultBrokerSocketPath()
+    // (operator-socket-if-present / docker → broker-operator/sock; else
+    // legacy). Asserting an absolute path here was environment-sensitive
+    // and reded `vitest` on any box where the operator socket exists.
+    // Pin the actual contract: the no-opts/no-env branch delegates to
+    // that single source of truth (client.ts: `return
+    // defaultBrokerSocketPath()`), which is deterministic per-env.
     const result = resolveBrokerSocketPath();
-    expect(result).toBe(LEGACY_DEFAULT);
+    expect(result).toBe(defaultBrokerSocketPath());
   });
 
   it("treats empty SWITCHROOM_VAULT_BROKER_SOCK env as unset", () => {


### PR DESCRIPTION
## Summary

`src/vault/broker/resolve-socket-path.test.ts` had an **environment-sensitive, pre-existing failure** that reds the `vitest` required check for **every PR** (not just one) on any host where `~/.switchroom/broker-operator/sock` exists or docker runtime is detected — i.e. the whole merge queue is blocked.

Root cause (forensic): the "falls back when nothing else is set" case asserted `resolveBrokerSocketPath()` === a hard-coded `~/.switchroom/vault-broker.sock`. But that no-opts/no-env branch returns `defaultBrokerSocketPath()`, which is **runtime-aware** (RFC J #1457/#1485): operator socket if present / docker → `broker-operator/sock`; legacy path only under v0.6 systemd. The **code is correct and intentional**; the **test is stale** (encodes pre-RFC-J behaviour, doesn't control the runtime inputs).

Fix the test, not the code: export `defaultBrokerSocketPath` and assert the actual contract — the branch *delegates* to it (`client.ts` literally `return defaultBrokerSocketPath()`). Deterministic per-environment; still pins the load-bearing precedence steps 1–3 (opts.socket / env / config). Header docstring updated to describe step 4 as the runtime-aware default.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `src/vault/broker/resolve-socket-path.test.ts` — **6/6 pass** (was 1 failing)
- [ ] CI green (this PR is what makes the `vitest` gate green again)

Standalone, test-only + a one-word `export`; no behaviour change. Unblocks the post-history-rewrite merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)