### PR TITLE
fix(vault-broker): fall through to standing ACL when a presented token is unusable (get/list)

### DIFF
--- a/src/vault/broker/server-grants.test.ts
+++ b/src/vault/broker/server-grants.test.ts
@@ -355,12 +355,16 @@ describe("VaultBroker: token-based get access (issue #225)", () => {
     expect(grantGet).toBeUndefined();
   });
 
-  it("get with expired token: returns denied:grant-expired", async () => {
-    // Mint a grant with ttl_seconds=-1 (already expired)
-    // We can't pass negative ttl to mintGrant directly, so we mint and then
-    // manipulate the DB to back-date the expires_at.
+  // Behaviour change (read-path unusable-token fall-through): an EXPIRED
+  // token is no longer hard-denied on `get`/`list` — like the in-prod
+  // `put` precedent, it falls through to path-as-identity so an agent
+  // with a standing schedule.secrets[] grant is still served. In this
+  // harness no agent identity is parsed from the /tmp socket, so the
+  // fall-through lands on the path-as-identity DENIED — but the denial
+  // reason is NO LONGER "grant-expired" (proving fall-through, not a
+  // token hard-deny).
+  it("get with expired token: falls through to path-as-identity (not denied:grant-expired)", async () => {
     const { token, id } = await mintGrant(grantsDb, "myagent", ["foo"], 3600);
-    // Set expires_at to the past
     const past = Math.floor(Date.now() / 1000) - 100;
     grantsDb.run("UPDATE vault_grants SET expires_at = ? WHERE id = ?", [past, id]);
 
@@ -368,19 +372,21 @@ describe("VaultBroker: token-based get access (issue #225)", () => {
     expect(resp.ok).toBe(false);
     if (!resp.ok) {
       expect(resp.code).toBe("DENIED");
-      expect(resp.msg).toContain("grant-expired");
+      expect(resp.msg).not.toContain("grant-expired"); // fell through
     }
   });
 
-  it("get with key-not-in-allowlist: returns denied:grant-key-not-allowed", async () => {
-    // Grant only allows "baz", but we request "foo"
+  it("get with key-not-in-allowlist: falls through to path-as-identity (not denied:grant-key-not-allowed)", async () => {
+    // Grant only allows "baz", but we request "foo". The token is valid
+    // but grants nothing for "foo" → unusable for this key → fall through
+    // (an agent with schedule.secrets[] for "foo" should still be served).
     const { token } = await mintGrant(grantsDb, "myagent", ["baz"], null);
 
     const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token });
     expect(resp.ok).toBe(false);
     if (!resp.ok) {
       expect(resp.code).toBe("DENIED");
-      expect(resp.msg).toContain("grant-key-not-allowed");
+      expect(resp.msg).not.toContain("grant-key-not-allowed"); // fell through
     }
   });
 

--- a/src/vault/broker/server-token-fallthrough.test.ts
+++ b/src/vault/broker/server-token-fallthrough.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for the READ-path unusable-token fall-through (the deterministic
+ * fix to "stale .vault-token shadows the standing schedule.secrets ACL").
+ *
+ * Mirrors the proven `put` precedent in server-write-grants.test.ts:
+ * `validateGrantForWrite` already falls through on grant-invalid /
+ * grant-write-not-allowed and hard-denies grant-revoked/expired. This
+ * brings `get`/`list` into line, with one deliberate divergence on the
+ * READ path (owner decision): only `grant-revoked` hard-denies;
+ * `grant-invalid`, `grant-key-not-allowed` AND `grant-expired` fall
+ * through (an unusable token must never be MORE restrictive than
+ * presenting no token when the agent has a standing ACL).
+ *
+ * Harness limitation (same as the put precedent): a per-agent socket
+ * path must literally be /run/switchroom/broker/<agent>/sock, which a
+ * /tmp test cannot bind, so `agentName` is null here and the no-token
+ * fall-through lands on the path-as-identity DENIED in test mode. The
+ * positive "fall-through → standing ACL → secret served" path is
+ * proven by the live gymbro repro + the identical, in-production `put`
+ * fall-through. What IS unit-asserted here and is the highest-risk
+ * invariant (reviewer B1): on fall-through there is exactly ONE
+ * terminal audit row and it is NOT method:"grant" — the token-branch
+ * deny-audit must be gone, or the #1433 hash-chain double-rows.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { Database } from "bun:sqlite";
+import { VaultBroker } from "./server.js";
+import { encodeRequest, decodeResponse, type BrokerResponse } from "./protocol.js";
+import type { VaultEntry } from "../vault.js";
+import type { AuditEntry } from "./audit-log.js";
+import { migrateGrantsSchema, mintGrant } from "../grants.js";
+
+const TEST_SECRETS: Record<string, VaultEntry> = {
+  foo: { kind: "string", value: "bar-value" },
+};
+
+function cloneSecrets(): Record<string, VaultEntry> {
+  return JSON.parse(JSON.stringify(TEST_SECRETS));
+}
+
+function makeMinimalConfig() {
+  return {
+    switchroom: { version: 1 },
+    telegram: { bot_token: "test", forum_chat_id: "123" },
+    vault: {
+      path: "~/.switchroom/vault.enc",
+      broker: { socket: "~/.switchroom/vault-broker.sock", enabled: true },
+    },
+    agents: {},
+  } as any;
+}
+
+function makeInMemoryGrantsDb(): Database {
+  const db = new Database(":memory:");
+  migrateGrantsSchema(db);
+  return db;
+}
+
+async function rpc(
+  socketPath: string,
+  req: Parameters<typeof encodeRequest>[0],
+): Promise<BrokerResponse> {
+  return new Promise((resolve, reject) => {
+    const client = net.createConnection({ path: socketPath });
+    let buffer = "";
+    client.on("error", reject);
+    client.on("data", (chunk: Buffer) => {
+      buffer += chunk.toString("utf8");
+      const idx = buffer.indexOf("\n");
+      if (idx !== -1) {
+        client.destroy();
+        try { resolve(decodeResponse(buffer.slice(0, idx))); } catch (e) { reject(e); }
+      }
+    });
+    client.on("connect", () => client.write(encodeRequest(req)));
+  });
+}
+
+describe("VaultBroker: read-path unusable-token fall-through", () => {
+  let broker: VaultBroker;
+  let socketPath: string;
+  let tmpDir: string;
+  let grantsDb: Database;
+  let auditEntries: AuditEntry[];
+  let prevNonLinuxFlag: string | undefined;
+
+  beforeEach(async () => {
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-tokenft-test-"));
+    socketPath = path.join(tmpDir, "test.sock");
+    grantsDb = makeInMemoryGrantsDb();
+    auditEntries = [];
+    broker = new VaultBroker({
+      _testSecrets: cloneSecrets(),
+      _testConfig: makeMinimalConfig(),
+      _testGrantsDb: grantsDb,
+      _testAuditLogger: { write: (e: AuditEntry) => { auditEntries.push(e); } },
+    });
+    await broker.start(socketPath, undefined, undefined);
+  });
+
+  afterEach(() => {
+    broker.stop();
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    else process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+  });
+
+  const getAudits = () => auditEntries.filter((e) => e.op === "get");
+  const listAudits = () => auditEntries.filter((e) => e.op === "list");
+
+  // ── revoked: hard-deny preserved (the only deliberate kill-switch) ──
+  it("get with REVOKED token → DENIED grant-revoked, audited method:grant (no fall-through)", async () => {
+    const { token, id } = await mintGrant(grantsDb, "agent1", ["foo"], null);
+    grantsDb.run(`UPDATE vault_grants SET revoked_at = ? WHERE id = ?`, [Math.floor(Date.now() / 1000), id]);
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token });
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) { expect(resp.code).toBe("DENIED"); expect(resp.msg).toContain("grant-revoked"); }
+    const a = getAudits();
+    expect(a).toHaveLength(1);
+    expect(a[0].result).toBe("denied:grant-revoked");
+    expect(a[0].method).toBe("grant"); // hard-deny stays grant-attributed
+  });
+
+  // ── invalid: falls through (NOT hard-denied on the token). B1: exactly
+  //    one terminal row, NOT method:"grant". ──
+  it("get with INVALID/garbage token → falls through (reason ≠ grant-invalid), single non-grant audit row", async () => {
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token: "vg_deadbe.0000000000000000000000000000000000000000000000000000000000000000" });
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) {
+      expect(resp.code).toBe("DENIED");
+      // Proof of fall-through: the denial is the path-as-identity/ACL
+      // reason, NOT the token reason. If it said grant-invalid the
+      // token branch hard-denied (bug).
+      expect(resp.msg).not.toContain("grant-invalid");
+    }
+    const a = getAudits();
+    expect(a).toHaveLength(1);                       // B1: not double
+    expect(a[0].method).not.toBe("grant");           // B1: token-branch audit gone
+    expect(a.some((e) => e.result === "denied:grant-invalid" && e.method === "grant")).toBe(false);
+  });
+
+  // ── expired: owner divergence from `put` — expired ALSO falls through
+  //    on the read path. ──
+  it("get with EXPIRED token → falls through (reason ≠ grant-expired), single non-grant audit row", async () => {
+    const { token, id } = await mintGrant(grantsDb, "agent1", ["foo"], null);
+    grantsDb.run(`UPDATE vault_grants SET expires_at = ? WHERE id = ?`, [Math.floor(Date.now() / 1000) - 3600, id]);
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token });
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) { expect(resp.code).toBe("DENIED"); expect(resp.msg).not.toContain("grant-expired"); }
+    const a = getAudits();
+    expect(a).toHaveLength(1);
+    expect(a[0].method).not.toBe("grant");
+  });
+
+  // ── valid token: success arm untouched (regression guard) ──
+  it("get with VALID in-scope token → ok, secret returned, audited method:grant", async () => {
+    const { token } = await mintGrant(grantsDb, "agent1", ["foo"], null);
+    const resp = await rpc(socketPath, { v: 1, op: "get", key: "foo", token });
+    expect(resp.ok).toBe(true);
+    if (resp.ok && "entry" in resp) expect((resp as any).entry.value).toBe("bar-value");
+    const a = getAudits();
+    expect(a).toHaveLength(1);
+    expect(a[0].result).toBe("allowed");
+    expect(a[0].method).toBe("grant");
+  });
+
+  // ── list parallels ──
+  it("list with REVOKED token → DENIED grant-revoked (hard-deny)", async () => {
+    const { token, id } = await mintGrant(grantsDb, "agent1", ["foo"], null);
+    grantsDb.run(`UPDATE vault_grants SET revoked_at = ? WHERE id = ?`, [Math.floor(Date.now() / 1000), id]);
+    const resp = await rpc(socketPath, { v: 1, op: "list", token });
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) { expect(resp.code).toBe("DENIED"); expect(resp.msg).toContain("grant-revoked"); }
+    const a = listAudits();
+    expect(a).toHaveLength(1);
+    expect(a[0].method).toBe("grant");
+  });
+
+  it("list with INVALID token → falls through to no-token list (ACL-filtered, single non-grant audit row)", async () => {
+    // Unlike `get` (which hard-denies when the ACL grants nothing),
+    // `list` post-fall-through behaves exactly like a no-token list:
+    // it returns ok:true with the ACL-visible key set (empty in this
+    // harness since config.agents={}), NOT a DENIED. The point of the
+    // fix: an unusable token must behave identically to NO token.
+    const resp = await rpc(socketPath, { v: 1, op: "list", token: "vg_deadbe.0000000000000000000000000000000000000000000000000000000000000000" });
+    expect(resp.ok).toBe(true);
+    if (resp.ok && "keys" in resp) expect(Array.isArray((resp as any).keys)).toBe(true);
+    const a = listAudits();
+    expect(a).toHaveLength(1);                              // B1: single terminal row
+    expect(a[0].method).not.toBe("grant");                 // B1: token-branch audit gone
+    expect(a.some((e) => e.result === "denied:grant-invalid" && e.method === "grant")).toBe(false);
+  });
+
+  it("list with VALID token → ok (returns covered+existing keys), audited method:grant", async () => {
+    const { token } = await mintGrant(grantsDb, "agent1", ["foo"], null);
+    const resp = await rpc(socketPath, { v: 1, op: "list", token });
+    expect(resp.ok).toBe(true);
+    if (resp.ok && "keys" in resp) expect((resp as any).keys).toContain("foo");
+    const a = listAudits();
+    expect(a).toHaveLength(1);
+    expect(a[0].method).toBe("grant");
+  });
+});

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -857,53 +857,62 @@ export class VaultBroker {
         const sentinelKey = Object.keys(this.secrets)[0] ?? "__list_check__";
         const tokenCheck = await validateGrant(this.grantsDb, req.token, sentinelKey);
 
-        // If the token is invalid/expired/revoked, deny
-        if (!tokenCheck.ok && tokenCheck.reason !== "grant-key-not-allowed") {
+        // Only an explicitly REVOKED token hard-denies (deliberate
+        // operator kill-switch — don't mask it by switching auth paths).
+        if (!tokenCheck.ok && tokenCheck.reason === "grant-revoked") {
           this.auditLogger.write({
             ts: new Date().toISOString(),
             op: "list",
             caller: auditCaller,
             pid: auditPid,
             cgroup: auditCgroup,
-            result: `denied:${tokenCheck.reason}`,
+            result: `denied:grant-revoked`,
             method: "grant",
             grant_id: grantId,
           });
-          socket.write(encodeResponse(errorResponse("DENIED", tokenCheck.reason)));
+          socket.write(encodeResponse(errorResponse("DENIED", "grant-revoked")));
           return;
         }
 
-        // Token is valid (ok or key-not-allowed means auth is fine).
-        // Get the key_allow list from the grant row.
-        const grantRow = tokenCheck.ok
-          ? tokenCheck.grant
-          : this.grantsDb
-              .query<{ key_allow: string }, [string]>(
-                "SELECT key_allow FROM vault_grants WHERE id = ?",
-              )
-              .get(grantId ?? "");
+        if (tokenCheck.ok || tokenCheck.reason === "grant-key-not-allowed") {
+          // Token authenticates (ok, or key-not-allowed → token itself is
+          // valid). Return only the keys the grant's key_allow covers.
+          const grantRow = tokenCheck.ok
+            ? tokenCheck.grant
+            : this.grantsDb
+                .query<{ key_allow: string }, [string]>(
+                  "SELECT key_allow FROM vault_grants WHERE id = ?",
+                )
+                .get(grantId ?? "");
 
-        const allowedKeys: string[] = grantRow
-          ? (typeof (grantRow as { key_allow: string[] | string }).key_allow === "string"
-              ? JSON.parse((grantRow as { key_allow: string }).key_allow)
-              : (grantRow as { key_allow: string[] }).key_allow)
-          : [];
+          const allowedKeys: string[] = grantRow
+            ? (typeof (grantRow as { key_allow: string[] | string }).key_allow === "string"
+                ? JSON.parse((grantRow as { key_allow: string }).key_allow)
+                : (grantRow as { key_allow: string[] }).key_allow)
+            : [];
 
-        // Filter to keys that exist in the vault AND are allowed by the grant
-        const visibleKeys = allowedKeys.filter((k) => k in this.secrets!);
+          // Filter to keys that exist in the vault AND are allowed by the grant
+          const visibleKeys = allowedKeys.filter((k) => k in this.secrets!);
 
-        this.auditLogger.write({
-          ts: new Date().toISOString(),
-          op: "list",
-          caller: auditCaller,
-          pid: auditPid,
-          cgroup: auditCgroup,
-          result: `allowed:${visibleKeys.length}`,
-          method: "grant",
-          grant_id: grantId,
-        });
-        socket.write(encodeResponse({ ok: true, keys: visibleKeys }));
-        return;
+          this.auditLogger.write({
+            ts: new Date().toISOString(),
+            op: "list",
+            caller: auditCaller,
+            pid: auditPid,
+            cgroup: auditCgroup,
+            result: `allowed:${visibleKeys.length}`,
+            method: "grant",
+            grant_id: grantId,
+          });
+          socket.write(encodeResponse({ ok: true, keys: visibleKeys }));
+          return;
+        }
+
+        // grant-invalid / grant-expired (not revoked, not a usable token):
+        // fall through to the no-token peercred/ACL list path below —
+        // behave exactly as if no token were presented. No audit here
+        // (#B1): the no-token path writes the single terminal row, so the
+        // request still yields exactly one audit entry (#1433 hash-chain).
       }
 
       // ── Peercred path (no token) ────────────────────────────────────────
@@ -1055,11 +1064,14 @@ export class VaultBroker {
           });
           socket.write(encodeResponse(entryResponse(entry)));
           return;
-        } else {
-          // Token present but invalid — extract grant_id for audit (ID portion only)
+        } else if (grantResult.reason === "grant-revoked") {
+          // Token recognised but explicitly REVOKED — hard-deny. Revocation
+          // is a deliberate operator kill-switch; falling through to the
+          // standing per-agent-socket ACL would mask that signal. (Mirrors
+          // the put path's grant-revoked branch.) Only `grant-revoked`
+          // hard-denies on the READ path — see the fall-through note below.
           const dotIdx = req.token.indexOf(".");
           const grantId = dotIdx !== -1 ? req.token.slice(0, dotIdx) : undefined;
-          const denyReason = grantResult.reason; // e.g. "grant-expired"
           this.auditLogger.write({
             ts: new Date().toISOString(),
             op: "get",
@@ -1067,15 +1079,25 @@ export class VaultBroker {
             caller: auditCaller,
             pid: auditPid,
             cgroup: auditCgroup,
-            result: `denied:${denyReason}`,
+            result: `denied:grant-revoked`,
             method: "grant",
             grant_id: grantId,
           });
           socket.write(
-            encodeResponse(errorResponse("DENIED", denyReason)),
+            encodeResponse(errorResponse("DENIED", "grant-revoked")),
           );
           return;
         }
+        // grant-invalid / grant-expired / grant-key-not-allowed: the
+        // presented token grants nothing usable. Deliberately DO NOT audit
+        // or return here — fall through to the standing-ACL path below so
+        // an agent that ALSO has a schedule.secrets[] grant for this key is
+        // still served (an unusable token must never be MORE restrictive
+        // than presenting no token). Not auditing here is load-bearing:
+        // the no-token ACL path writes the single terminal row, so the
+        // request still produces exactly one audit entry (preserves the
+        // #1433 hash-chain). Mirrors the put precedent at the
+        // validateGrantForWrite branch.
       }
 
       // ── ACL path (no token) ─────────────────────────────────────────────

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -90,6 +90,9 @@ export default defineConfig({
       "**/src/watchdog/state.test.ts",
       "**/src/watchdog/policy.test.ts",
       "**/src/vault/broker/server-grants.test.ts",
+      // Read-path unusable-token fall-through suite (#1487) — bun:sqlite,
+      // run via test:bun (same as the sibling server-grants suites).
+      "**/src/vault/broker/server-token-fallthrough.test.ts",
       // Write-grant suites (issue #969 P1b) also use bun:sqlite — run via test:bun.
       "**/src/vault/write-grants.test.ts",
       "**/src/vault/broker/server-write-grants.test.ts",


### PR DESCRIPTION
## Summary

**Recreated on the post-history-rewrite `upstream/main`** (the prior PR #1487 sat on dead history and is being closed in favour of this). The diff is **byte-identical** to the independently security-reviewed version (verdict APPROVE) — I confirmed new main's `server.ts` get/list/put and `server-grants.test.ts` are unchanged from the reviewed baseline before re-applying.

A stale/rotted `~/.switchroom/agents/<agent>/.vault-token` made the broker **more restrictive than presenting no token**: `get`/`list` treated token presence as terminal and never fell through to the no-token standing-ACL path (`checkAclByAgent` → `schedule.secrets[]`) — the gymbro stranding, latent for every agent. Brings `get`/`list` into line with the in-production `put` precedent. Read-path divergence (owner-approved): only `grant-revoked` hard-denies; `grant-invalid` / `grant-key-not-allowed` / `grant-expired` fall through.

Invariant preserved (`allow iff valid-token OR standing-ACL else deny`; identity = closure-captured socket path, never wire). **B1**: on fall-through the token-branch deny audit is *deleted*, not just the `return` — exactly one terminal audit row (no double/zero; #1433 hash-chain intact).

## Test plan

- [x] `tsc --noEmit` clean
- [x] **105 broker `bun test` pass, 0 fail** (token-fallthrough + grants + write-grants + server + audit-log + acl)
- [x] `vitest.config` excludes the new bun:sqlite suite (verified: not loaded by vitest)
- [ ] CI green — the one unrelated `vitest` red (`resolve-socket-path`, pre-existing on main) is fixed by **#1495**, which must merge first to green the gate
- [ ] supersedes #1487 (dead-history)

Fix B (vault_request_access standing-ACL-aware) follows as a separate PR that must land after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)