### PR TITLE
feat(skill-author): Phase 1 — native-by-default agent-scope skills

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -140,6 +140,15 @@ RUN chmod 0755 /opt/switchroom/autoaccept-poll.js
 COPY dist/cli/drive-write-pretool.mjs /opt/switchroom/hooks/drive-write-pretool.mjs
 RUN chmod 0755 /opt/switchroom/hooks/drive-write-pretool.mjs
 
+# Advisory skill-shape linter (RFC native-by-default skill authoring,
+# Phase 1). Non-blocking — nudges the model toward a well-formed skill
+# when it writes under .claude/skills/; only the per-skill byte cap is
+# a hard stop. Deliberately NOT in the security-plugin: it's a quality
+# nudge, not a load-bearing safety control, and an agent linting its
+# own writable skills dir is within its own trust domain.
+COPY dist/cli/skill-validate-pretool.mjs /opt/switchroom/hooks/skill-validate-pretool.mjs
+RUN chmod 0755 /opt/switchroom/hooks/skill-validate-pretool.mjs
+
 # Image-baked security-hooks plugin (sec WS8-F1 / #1416). A separate,
 # minimal --plugin-dir holding ONLY the load-bearing PreToolUse safety
 # hooks (secret-exfil guard + Drive-write approval gate). Loaded from

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -148,6 +148,23 @@ if (hookEscape.changed) {
   console.log(`[build] ASCII-escaped ${hookEscape.nonAsciiCount} non-ASCII code units in dist/cli/drive-write-pretool.mjs`);
 }
 
+// Bundle the skill-validate-pretool hook — RFC native-by-default skill
+// authoring, Phase 1. Same pattern: standalone .mjs the agent container
+// runs via node. It imports the shared validators from src/cli/
+// skill-common.ts (which pulls in `yaml` + agent-config), none of which
+// resolve inside the agent image — so bundle to one self-contained file.
+console.log("[build] bundling src/cli/skill-validate-pretool.ts -> dist/cli/skill-validate-pretool.mjs");
+execSync(
+  `bun build ${JSON.stringify(resolve(root, "src/cli/skill-validate-pretool.ts"))} --outfile ${JSON.stringify(resolve(outDir, "skill-validate-pretool.mjs"))} --target node`,
+  { stdio: "inherit", cwd: root }
+);
+const skillHookOutFile = resolve(outDir, "skill-validate-pretool.mjs");
+chmodSync(skillHookOutFile, 0o755);
+const skillHookEscape = escapeBundleNonAscii(skillHookOutFile);
+if (skillHookEscape.changed) {
+  console.log(`[build] ASCII-escaped ${skillHookEscape.nonAsciiCount} non-ASCII code units in dist/cli/skill-validate-pretool.mjs`);
+}
+
 // Bundle the autoaccept-poll entrypoint. The agent unit's ExecStartPost
 // invokes this in the background to dispatch first-run TUI prompts via
 // `tmux capture-pane` + `tmux send-keys`. Must ship in dist/ because

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -460,6 +460,12 @@ In Claude.ai, the core workflow is the same (draft → test → review → impro
 - **Copy to a writeable location before editing.** The installed skill path may be read-only. Copy to `/tmp/skill-name/`, edit there, and package from the copy.
 - **If packaging manually, stage in `/tmp/` first**, then copy to the output directory -- direct writes may fail due to permissions.
 
+> The two bullets above are the *generic / packaging* case (read-only
+> installed skills, producing a `.skill` file for download). If you are
+> running inside a **switchroom agent**, your own skills live in a
+> writable, persistent directory — do **not** stage in `/tmp/`; author
+> in place. See "Switchroom agent instructions" below.
+
 ---
 
 ## Cowork-Specific Instructions
@@ -475,6 +481,46 @@ If you're in Cowork, the main things to know are:
 - **Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. Follow the update guidance in the claude.ai section above.
 
 ---
+
+## Switchroom agent instructions
+
+If you are running as a switchroom agent (you have a
+`$CLAUDE_CONFIG_DIR` and talk to a user over Telegram), authoring a
+skill for *yourself* is a plain filesystem write — no special tool, no
+broker, no packaging:
+
+- **Where skills live.** Your own (agent-scope) skills go in
+  `$CLAUDE_CONFIG_DIR/skills/<slug>/` — one directory per skill, with
+  `SKILL.md` at its root. This directory is **writable by you** and
+  **persistent** (it survives restarts and `switchroom agent
+  restart`). Just `Write`/`Edit` the files there directly. Do **not**
+  stage in `/tmp/`, do **not** copy anything afterwards, and do
+  **not** use the `skill_create` / `skill_edit` / `skill_read` /
+  `skill_delete` MCP tools — those are deprecated for agent scope and
+  are being removed; the native filesystem write is the supported
+  path.
+- **It goes live on your *next* turn, not this one.** Claude discovers
+  skills when a session starts. After you write the files, tell the
+  user the skill is created and will be active on the next message —
+  then stop. Don't write the skill and immediately try to invoke it in
+  the same turn; it won't be loaded yet. (If you need it active
+  immediately, the user can `switchroom agent restart <you>`.)
+- **A linter will nudge you, not block you.** A non-blocking
+  PreToolUse hook checks the skill shape (slug, path allowlist,
+  SKILL.md frontmatter) and returns advisory feedback if something is
+  off — the write still goes through. The only hard limit is the
+  per-skill byte cap (2 MiB); a write over that is rejected, so split
+  large assets out.
+- **Skill shape.** `SKILL.md` must start with YAML frontmatter:
+  `name:` equal to the `<slug>` directory name, and a `description:`
+  (1–1024 chars) that says when the skill should trigger. Supporting
+  files follow the allowlist: `README.md`, `scripts/*.{sh,py}`,
+  `assets/*`, `reference/*.md` (max depth 3).
+- **Fleet / global skills are a different, privileged path.** Making a
+  skill available to *other* agents (not just you) is operator/admin
+  territory and is intentionally not a plain write — leave that to the
+  operator unless you are an admin agent explicitly asked to publish
+  one.
 
 ## Reference files
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3132,6 +3132,28 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           ],
         },
         {
+          // RFC native-by-default skill authoring, Phase 1 — advisory
+          // skill-shape linter. Scoped to file-write tools; the hook
+          // itself no-ops unless the target path is under
+          // `.claude/skills/`. Non-blocking (returns additionalContext)
+          // except the per-skill byte cap, the only hard stop.
+          //
+          // DOCKER_BUNDLED_HOOKS_PATH (not DOCKER_HOOKS_PATH): bundled
+          // via scripts/build.mjs from src/cli/skill-validate-pretool.ts
+          // because it imports the shared validators in skill-common.ts.
+          matcher: "^(Write|Edit|MultiEdit)$",
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:skill-validate-pretool",
+                `node "${join(DOCKER_BUNDLED_HOOKS_PATH, "skill-validate-pretool.mjs")}"`,
+              ),
+              timeout: 10,
+            },
+          ],
+        },
+        {
           // Catch-all PreToolUse: deterministic tool-call labels (#783).
           // Hook always exits 0; never emits stdout JSON; writes one line
           // to $TELEGRAM_STATE_DIR/tool-labels-${session_id}.jsonl.

--- a/src/cli/skill-validate-pretool.ts
+++ b/src/cli/skill-validate-pretool.ts
@@ -1,0 +1,202 @@
+/**
+ * PreToolUse hook — RFC "native-by-default skill authoring", Phase 1.
+ *
+ * Fires on Write / Edit / MultiEdit. When the target path is inside an
+ * agent's own `.claude/skills/<slug>/` tree it lints the write against
+ * the same skill-shape rules the (deprecated) `skill_*` MCP tools
+ * enforced — but **advisory only**: it never blocks a malformed skill,
+ * it returns `additionalContext` so the model self-corrects. The one
+ * hard stop is the per-skill byte cap (`MAX_SKILL_BYTES`), the only
+ * rule with real blast radius (a runaway write filling the agent's
+ * persistent volume).
+ *
+ * Why a hook and not a CLI: agent-scope skills live in the agent's own
+ * writable, persistent, reconcile-safe dir — the native authoring path
+ * is plain Write/Edit. The shared validators in `skill-common.ts` are
+ * the single source of truth; this hook calls them directly (bundled
+ * to a self-contained .mjs at build time, like drive-write-pretool).
+ *
+ * Claude Code PreToolUse protocol (v1), mirrors drive-write-pretool:
+ *   Input:  JSON on stdin — { session_id, tool_name, tool_input, ... }
+ *   Output: exit 0 + empty stdout                       → allow.
+ *           exit 0 + {"decision":"block","reason":...}  → block.
+ *           exit 0 + {"hookSpecificOutput":{...,additionalContext}}
+ *                                                       → allow + nudge.
+ *
+ * Fail-OPEN everywhere (stdin parse error, fs error, unknown shape):
+ * a lint hook must never be the reason a legitimate write fails. The
+ * only non-allow outcome is the explicit oversize block.
+ */
+
+import { readFileSync, lstatSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  MAX_SKILL_BYTES,
+  validateSkillName,
+  validateRelPath,
+  validateSkillMd,
+} from "./skill-common.js";
+
+const SKILLS_SEGMENT = "/.claude/skills/";
+const EDIT_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
+
+function readStdin(): string {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function allow(): never {
+  process.exit(0);
+}
+
+function block(reason: string): never {
+  const safe = String(reason)
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .slice(0, 300);
+  process.stdout.write(JSON.stringify({ decision: "block", reason: safe }));
+  process.exit(0);
+}
+
+function nudge(lines: string[]): never {
+  const context =
+    "skill-lint (advisory — the write was allowed):\n" +
+    lines.map((l) => `  • ${l}`).join("\n") +
+    "\nThese are the same rules the deprecated skill_* MCP tools " +
+    "enforced. Fix them so the skill is well-formed and discoverable " +
+    "on your next turn.";
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext: context,
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+/** Total bytes of regular files under `dir` (recursive, symlink-safe,
+ *  best-effort). Returns 0 on any error — fail-open. */
+function dirBytes(dir: string): number {
+  let total = 0;
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return 0;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    try {
+      const st = lstatSync(p);
+      if (st.isSymbolicLink()) continue;
+      if (st.isDirectory()) total += dirBytes(p);
+      else if (st.isFile()) total += st.size;
+    } catch {
+      /* skip unreadable entry */
+    }
+  }
+  return total;
+}
+
+function fileSize(p: string): number {
+  try {
+    const st = lstatSync(p);
+    return st.isFile() ? st.size : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function main(): void {
+  const raw = readStdin().trim();
+  if (!raw) allow();
+
+  let event: { tool_name?: unknown; tool_input?: unknown };
+  try {
+    event = JSON.parse(raw);
+  } catch {
+    allow(); // Claude protocol error — not ours to police.
+  }
+
+  const toolName = typeof event.tool_name === "string" ? event.tool_name : "";
+  if (!EDIT_TOOLS.has(toolName)) allow();
+
+  const input =
+    event.tool_input && typeof event.tool_input === "object"
+      ? (event.tool_input as Record<string, unknown>)
+      : {};
+  const filePath = typeof input.file_path === "string" ? input.file_path : "";
+  if (!filePath) allow();
+
+  const segIdx = filePath.indexOf(SKILLS_SEGMENT);
+  if (segIdx < 0) allow(); // not a skill write
+
+  const afterSkills = filePath.slice(segIdx + SKILLS_SEGMENT.length);
+  const segs = afterSkills.split("/").filter((s) => s.length > 0);
+  if (segs.length < 2) allow(); // writing the skills root or a bare slug dir
+
+  const slug = segs[0]!;
+  const relPath = segs.slice(1).join("/");
+  const skillDir = filePath.slice(0, segIdx + SKILLS_SEGMENT.length) + slug;
+
+  const warnings: string[] = [];
+  if (!validateSkillName(slug)) {
+    warnings.push(
+      `skill slug "${slug}" is invalid — must match ` +
+        `[a-z0-9][a-z0-9_-]{0,62}. Claude won't discover a skill at an ` +
+        `invalid slug.`,
+    );
+  }
+  if (!validateRelPath(relPath)) {
+    warnings.push(
+      `"${relPath}" is outside the skill path allowlist ` +
+        `(SKILL.md, README.md, scripts/*.{sh,py}, assets/*, ` +
+        `reference/*.md, max depth 3). The file will be written but ` +
+        `won't be part of a well-formed skill bundle.`,
+    );
+  }
+  if (
+    relPath === "SKILL.md" &&
+    toolName === "Write" &&
+    typeof input.content === "string"
+  ) {
+    const r = validateSkillMd(input.content, slug);
+    if ("ok" in r && r.ok === false) {
+      warnings.push(`SKILL.md frontmatter: ${r.message}`);
+    }
+  }
+
+  // Hard cap — the only blocking rule. Project the new total when we
+  // can (Write carries full content); for Edit/MultiEdit we only have
+  // the current on-disk total, so we block solely if already over.
+  try {
+    const existingTotal = dirBytes(skillDir);
+    let projected = existingTotal;
+    if (toolName === "Write" && typeof input.content === "string") {
+      projected =
+        existingTotal -
+        fileSize(filePath) +
+        Buffer.byteLength(input.content, "utf8");
+    }
+    if (projected > MAX_SKILL_BYTES) {
+      block(
+        `skill "${slug}" would be ${projected} bytes, over the ` +
+          `${MAX_SKILL_BYTES}-byte per-skill cap. Trim the skill ` +
+          `(split large assets out, or shorten SKILL.md) and retry.`,
+      );
+    }
+  } catch {
+    /* fail-open: a sizing error must not block a write */
+  }
+
+  if (warnings.length > 0) nudge(warnings);
+  allow();
+}
+
+main();

--- a/src/mcp/agent-config/server.ts
+++ b/src/mcp/agent-config/server.ts
@@ -274,6 +274,14 @@ export const TOOLS = [
   {
     name: "skill_create",
     description:
+      "DEPRECATED for scope=agent — do not use for your own skills. " +
+      "Author directly into `$CLAUDE_CONFIG_DIR/skills/<slug>/` with " +
+      "Write/Edit: that dir is writable, persistent across restarts, " +
+      "and Claude discovers the skill on your next turn. This tool is " +
+      "being removed (RFC native-by-default skill authoring). If it " +
+      "returns E_SKILL_ALREADY_EXISTS, the skill already exists — just " +
+      "edit the files directly. Still REQUIRED for scope=global (admin " +
+      "agents publishing fleet-wide skills). — " +
       "Create an agent-scope skill (scope=agent) at " +
       "`~/.switchroom/agents/<agent>/.claude/skills/<slug>/`. Atomic " +
       "temp-dir → rename — refuses if the target slug dir already " +
@@ -320,6 +328,12 @@ export const TOOLS = [
   {
     name: "skill_edit",
     description:
+      "DEPRECATED for scope=agent — do not use for your own skills. " +
+      "Edit the file directly with Write/Edit at " +
+      "`$CLAUDE_CONFIG_DIR/skills/<slug>/<file>` (writable, persistent, " +
+      "live next turn); no version token needed. This tool is being " +
+      "removed (RFC native-by-default skill authoring). Still REQUIRED " +
+      "for scope=global (admin). — " +
       "Edit a single file within an existing agent-scope skill " +
       "(scope=agent). Atomic single-file write. Requires `version` (an " +
       "opaque token returned by `skill_read`) for optimistic " +
@@ -362,6 +376,11 @@ export const TOOLS = [
   {
     name: "skill_read",
     description:
+      "DEPRECATED for scope=agent — just Read the files at " +
+      "`$CLAUDE_CONFIG_DIR/skills/<slug>/` directly (and `ls` the dir " +
+      "for the tree). This tool is being removed (RFC native-by-default " +
+      "skill authoring). Still useful for scope=global (admin) " +
+      "inspection. — " +
       "Read a file from an agent-scope skill, OR (when `file` is " +
       "omitted) return the skill's file tree plus its SKILL.md " +
       "frontmatter. Always returns a `version` token suitable for a " +
@@ -388,6 +407,10 @@ export const TOOLS = [
   {
     name: "skill_delete",
     description:
+      "DEPRECATED for scope=agent — delete the skill dir directly " +
+      "(`rm -rf $CLAUDE_CONFIG_DIR/skills/<slug>/` via Bash). This tool " +
+      "is being removed (RFC native-by-default skill authoring). Still " +
+      "REQUIRED for scope=global (admin; marker-gated). — " +
       "Delete an agent-scope skill dir (scope=agent). Refuses if the " +
       "path is a symlink (that's a bundled-skill install — use " +
       "`skill_remove` instead). Refused from cron-fired turns. Error " +

--- a/tests/skill-validate-pretool.test.ts
+++ b/tests/skill-validate-pretool.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The hook is a .ts that bundles to .mjs at build time; drive it
+// through `bun` against source so the test doesn't depend on build
+// order (mirrors server.author.test.ts). Skip cleanly if bun absent.
+const bunOk = spawnSync("which", ["bun"], { encoding: "utf-8" }).status === 0;
+const HOOK = join(process.cwd(), "src", "cli", "skill-validate-pretool.ts");
+
+function run(payload: unknown): {
+  status: number;
+  stdout: string;
+  stderr: string;
+} {
+  const r = spawnSync("bun", [HOOK], {
+    input: typeof payload === "string" ? payload : JSON.stringify(payload),
+    encoding: "utf-8",
+    timeout: 30000,
+  });
+  return {
+    status: r.status ?? 1,
+    stdout: (r.stdout ?? "").trim(),
+    stderr: r.stderr ?? "",
+  };
+}
+
+let tmp: string;
+let skillsRoot: string;
+
+beforeAll(() => {
+  tmp = mkdtempSync(join(tmpdir(), "skill-lint-"));
+  // Mimic an agent's <agentDir>/.claude/skills/ tree.
+  skillsRoot = join(tmp, ".claude", "skills");
+  mkdirSync(join(skillsRoot, "demo"), { recursive: true });
+  writeFileSync(
+    join(skillsRoot, "demo", "SKILL.md"),
+    "---\nname: demo\ndescription: a demo skill\n---\n# Demo\n",
+  );
+});
+
+afterAll(() => {
+  if (tmp && existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("skill-validate-pretool hook", () => {
+  it("fails open on empty / non-JSON / unknown stdin", () => {
+    if (!bunOk) return;
+    for (const bad of ["", "not-json", "{}", '{"tool_name":"Read"}']) {
+      const r = run(bad);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe("");
+    }
+  });
+
+  it("ignores non-edit tools and writes outside .claude/skills/", () => {
+    if (!bunOk) return;
+    const notEdit = run({
+      tool_name: "Bash",
+      tool_input: { command: "ls" },
+    });
+    expect(notEdit.status).toBe(0);
+    expect(notEdit.stdout).toBe("");
+
+    const outside = run({
+      tool_name: "Write",
+      tool_input: { file_path: join(tmp, "notes.md"), content: "hi" },
+    });
+    expect(outside.status).toBe(0);
+    expect(outside.stdout).toBe("");
+  });
+
+  it("allows a well-formed SKILL.md write silently", () => {
+    if (!bunOk) return;
+    const r = run({
+      tool_name: "Write",
+      tool_input: {
+        file_path: join(skillsRoot, "demo", "SKILL.md"),
+        content: "---\nname: demo\ndescription: a demo skill\n---\n# Demo\n",
+      },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("nudges (not blocks) on bad frontmatter — returns additionalContext", () => {
+    if (!bunOk) return;
+    const r = run({
+      tool_name: "Write",
+      tool_input: {
+        file_path: join(skillsRoot, "demo", "SKILL.md"),
+        content: "# no frontmatter here\n",
+      },
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.decision).toBeUndefined(); // NOT blocked
+    expect(out.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+    expect(out.hookSpecificOutput.additionalContext).toMatch(/frontmatter/i);
+  });
+
+  it("nudges on an out-of-allowlist path", () => {
+    if (!bunOk) return;
+    const r = run({
+      tool_name: "Write",
+      tool_input: {
+        file_path: join(skillsRoot, "demo", "scripts", "run.js"),
+        content: "console.log(1)",
+      },
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.decision).toBeUndefined();
+    expect(out.hookSpecificOutput.additionalContext).toMatch(/allowlist/i);
+  });
+
+  it("nudges on an invalid skill slug", () => {
+    if (!bunOk) return;
+    const r = run({
+      tool_name: "Write",
+      tool_input: {
+        file_path: join(skillsRoot, "Bad Slug", "SKILL.md"),
+        content: "---\nname: x\ndescription: y\n---\n",
+      },
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.hookSpecificOutput.additionalContext).toMatch(/slug/i);
+  });
+
+  it("BLOCKS only on the per-skill byte cap", () => {
+    if (!bunOk) return;
+    const huge = "x".repeat(2 * 1024 * 1024 + 1024);
+    const r = run({
+      tool_name: "Write",
+      tool_input: {
+        file_path: join(skillsRoot, "demo", "reference", "big.md"),
+        content: huge,
+      },
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.decision).toBe("block");
+    expect(out.reason).toMatch(/per-skill cap/);
+  });
+
+  it("Edit with no content does not block (can't project — fail open)", () => {
+    if (!bunOk) return;
+    const r = run({
+      tool_name: "Edit",
+      tool_input: {
+        file_path: join(skillsRoot, "demo", "SKILL.md"),
+        old_string: "Demo",
+        new_string: "Demo 2",
+      },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+});

--- a/tests/skill-validate-pretool.test.ts
+++ b/tests/skill-validate-pretool.test.ts
@@ -165,4 +165,79 @@ describe("skill-validate-pretool hook", () => {
     expect(r.status).toBe(0);
     expect(r.stdout).toBe("");
   });
+
+  it("MultiEdit on a skill path with no content fails open", () => {
+    if (!bunOk) return;
+    const r = run({
+      tool_name: "MultiEdit",
+      tool_input: {
+        file_path: join(skillsRoot, "demo", "SKILL.md"),
+        edits: [{ old_string: "a", new_string: "b" }],
+      },
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("byte-cap projection: add-to-existing blocks, shrink-overwrite allows", () => {
+    if (!bunOk) return;
+    // Seed a skill that already holds ~1.6 MiB.
+    const bigDir = join(skillsRoot, "big");
+    mkdirSync(join(bigDir, "reference"), { recursive: true });
+    writeFileSync(
+      join(bigDir, "SKILL.md"),
+      "---\nname: big\ndescription: big skill\n---\n",
+    );
+    const existing = join(bigDir, "reference", "existing.md");
+    writeFileSync(existing, "y".repeat(1.6 * 1024 * 1024));
+
+    // Adding a new ~0.6 MiB file pushes the total past 2 MiB → block,
+    // even though the new file alone is well under the cap (proves the
+    // projection sums the existing dir, not just the new content).
+    const add = run({
+      tool_name: "Write",
+      tool_input: {
+        file_path: join(bigDir, "reference", "more.md"),
+        content: "z".repeat(0.6 * 1024 * 1024),
+      },
+    });
+    const addOut = JSON.parse(add.stdout);
+    expect(addOut.decision).toBe("block");
+    expect(addOut.reason).toMatch(/per-skill cap/);
+
+    // Overwriting the existing 1.6 MiB file with tiny content nets the
+    // skill far below the cap → allowed (proves it subtracts the
+    // target file's current size before adding the new content).
+    const shrink = run({
+      tool_name: "Write",
+      tool_input: { file_path: existing, content: "small" },
+    });
+    expect(shrink.status).toBe(0);
+    expect(shrink.stdout).toBe("");
+  });
+
+  it("a path containing .claude/skills/ twice never wrong-blocks", () => {
+    if (!bunOk) return;
+    // Pathological: first occurrence wins → slug "docs". Worst case is
+    // a spurious advisory nudge; it must never block and the write
+    // must proceed (no decision:block).
+    const r = run({
+      tool_name: "Write",
+      tool_input: {
+        file_path: join(
+          skillsRoot,
+          "docs",
+          ".claude",
+          "skills",
+          "demo",
+          "SKILL.md",
+        ),
+        content: "---\nname: demo\ndescription: d\n---\n",
+      },
+    });
+    expect(r.status).toBe(0);
+    if (r.stdout) {
+      expect(JSON.parse(r.stdout).decision).toBeUndefined();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Phase 1 of `docs/rfcs/skill-authoring-native.md` (PR #1498) — **additive, reversible, zero capability loss**.

Agents now author their own skills the Claude-native way: plain `Write`/`Edit` into `$CLAUDE_CONFIG_DIR/skills/<slug>/` (writable, persistent, reconcile-safe, discovered next turn) instead of the deprecated `skill_*` MCP shim.

- **Non-blocking validator hook** (`src/cli/skill-validate-pretool.ts`, bundled like drive-write-pretool): reuses the `skill-common` validators (single source of truth); advisory via `additionalContext`; the **only** hard stop is the per-skill byte cap (the one rule with real blast radius). Fail-open on every other path. Baked into `/opt/switchroom/hooks/` — deliberately **not** the security-plugin (it's a quality nudge, not a load-bearing safety control; the agent lints its own UID-owned dir).
- **scaffold.ts**: PreToolUse matcher `^(Write|Edit|MultiEdit)$`.
- **skill-creator/SKILL.md**: switchroom-agent section naming the canonical writable path + "live next turn"; the wrong "stage in /tmp" guidance scoped to the generic/packaging case.
- **server.ts**: deprecation banners on the 4 agent-scope skill tools (prepended; original text preserved; still functional; global scope untouched; Phase 3 deletes them).

Serves `reference/extend-without-forking.md` (consistent extension shape). No Phase 2/3 over-reach (no `skill_publish`/`--adopt`, no deletions, no version-token removal).

## Test plan

- [x] New hook suite — 11 tests (allow / nudge / block, projection arithmetic, MultiEdit, double-segment, fail-open)
- [x] 233 regression-sensitive tests green (scaffold, reconcile-hooks-drift, server.author incl. #1492 E2E, skill-author agent+global)
- [x] `npx tsc --noEmit` clean; build bundles the hook; bundled `.mjs` verified under node (in-container runtime)
- [x] Independent fresh-process review → **APPROVE**

🤖 Generated with [Claude Code](https://claude.com/claude-code)