### PR TITLE
feat(skill-author): Phase 2a — skill_publish/skill_unpublish

### DIFF
--- a/src/cli/agent-config-skill-author.ts
+++ b/src/cli/agent-config-skill-author.ts
@@ -30,6 +30,9 @@ import {
   lstatSync,
   rmSync,
   renameSync,
+  openSync,
+  fsyncSync,
+  closeSync,
 } from "node:fs";
 import { join, dirname, sep } from "node:path";
 import {
@@ -722,6 +725,296 @@ export function skillDelete(
   return { ok: true, slug: opts.name, path: destDir };
 }
 
+// ─── skillPublish / skillUnpublish ────────────────────────────────────
+//
+// RFC docs/rfcs/skill-authoring-native.md §3.2/§3.5, Phase 2. The ONE
+// privileged broker-backed write: promote an agent's own, already-
+// iterated agent-scope skill into the operator's global pool
+// (/skills-rw). Replace-by-publish of a whole directory — no per-file
+// edit, no version tokens. Admin-gated; marker-guarded so operator-
+// curated / peer-authored globals stay immutable from agents.
+
+/** Best-effort fsync of a directory's dirents (marker durability
+ *  before the atomic rename — RFC §3.5). Never throws. */
+function fsyncDirBestEffort(dir: string): void {
+  try {
+    const fd = openSync(dir, "r");
+    try {
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    /* fsync is a durability nicety, not a correctness gate */
+  }
+}
+
+export interface SkillPublishOpts {
+  agent?: string;
+  name: string;
+  /** Per-agent test root override (the publish *source* is agent scope). */
+  root?: string;
+  /** Global-scope root override (defaults to /skills-rw via env). */
+  globalRoot?: string;
+  isAdmin?: (agent: string) => boolean;
+}
+
+export interface SkillPublishResult {
+  ok: true;
+  slug: string;
+  /** Absolute path of the published global skill dir. */
+  path: string;
+  files: string[];
+  version: string;
+}
+
+export function skillPublish(
+  opts: SkillPublishOpts,
+): SkillPublishResult | SkillAuthorError {
+  let agent: string;
+  try { agent = resolveAgent(opts.agent); }
+  catch (e) { return agentErrCode(e); }
+
+  if (!validateSkillName(opts.name)) {
+    return authorErr(
+      "E_SKILL_INVALID_NAME",
+      `skill name must match [a-z0-9][a-z0-9_-]{0,62}: got ${JSON.stringify(opts.name)}`,
+    );
+  }
+
+  // Source = the agent's own agent-scope skill dir (you publish what
+  // you authored natively).
+  const srcDir = agentScopeSkillDir(agent, opts.name, opts.root);
+  if (!existsSync(srcDir)) {
+    return authorErr(
+      "E_SKILL_NOT_FOUND",
+      `agent-scope skill "${opts.name}" not found for ${agent} — author it first (write into $CLAUDE_CONFIG_DIR/skills/${opts.name}/), then publish`,
+    );
+  }
+  try {
+    if (lstatSync(srcDir).isSymbolicLink()) {
+      return authorErr(
+        "E_SKILL_INVALID_PATH",
+        `refuse to publish "${opts.name}" — source ${srcDir} is a symlink (bundled-skill install, not agent-authored)`,
+      );
+    }
+  } catch {
+    return authorErr("E_SKILL_NOT_FOUND", `${srcDir} missing`);
+  }
+
+  // Hard-validate the source shape. Unlike the advisory native-write
+  // hook, publish is the privileged promotion gate — a malformed skill
+  // must NOT reach the shared global pool.
+  const files = listSkillFiles(srcDir);
+  if (!files.includes("SKILL.md")) {
+    return authorErr(
+      "E_SKILL_INVALID_FRONTMATTER",
+      `source skill "${opts.name}" has no SKILL.md`,
+    );
+  }
+  for (const rel of files) {
+    if (!validateRelPath(rel)) {
+      return authorErr(
+        "E_SKILL_INVALID_PATH",
+        `source file not in allowlist: ${JSON.stringify(rel)}`,
+      );
+    }
+  }
+  if (files.length > MAX_FILES_PER_SKILL) {
+    return authorErr(
+      "E_SKILL_BUNDLE_TOO_LARGE",
+      `source skill has ${files.length} files (max ${MAX_FILES_PER_SKILL})`,
+    );
+  }
+  const total = totalSkillBytes(srcDir);
+  if (total > MAX_SKILL_BYTES) {
+    return authorErr(
+      "E_SKILL_BUNDLE_TOO_LARGE",
+      `source skill is ${total} bytes (cap ${MAX_SKILL_BYTES})`,
+    );
+  }
+  const skillMd = readFileSync(join(srcDir, "SKILL.md"), "utf-8");
+  const fm = validateSkillMd(skillMd, opts.name);
+  if ("ok" in fm && fm.ok === false) return fm;
+
+  // Resolve GLOBAL scope: admin gate + /skills-rw mount present.
+  const isAdminFn = opts.isAdmin ?? defaultIsAdmin;
+  const sc = resolveScope(
+    agent, opts.name, "global", undefined, opts.globalRoot, isAdminFn,
+  );
+  if ("ok" in sc && sc.ok === false) return sc;
+  const ctx = sc as ScopeContext;
+  const destDir = ctx.skillDir;
+  const rootDir = ctx.rootDir;
+
+  // Marker-gated replace: if a global skill already exists at this
+  // slug, it must be a real dir carrying THIS agent's marker.
+  // Operator-curated (no marker) / peer-authored globals are immutable.
+  if (existsSync(destDir)) {
+    try {
+      if (lstatSync(destDir).isSymbolicLink()) {
+        return authorErr(
+          "E_SKILL_INVALID_PATH",
+          `global "${opts.name}" is a symlink — refuse to overwrite`,
+        );
+      }
+    } catch {
+      /* race: treat as absent below */
+    }
+    if (!hasAuthorshipMarker(destDir, agent)) {
+      return authorErr(
+        "E_SKILL_OPERATOR_OWNED",
+        `global skill "${opts.name}" is not authored by ${agent} (no ${authorshipMarkerName(agent)} marker) — operator-curated or peer-authored skills are immutable`,
+      );
+    }
+  }
+
+  mkdirSync(rootDir, { recursive: true });
+
+  // B2 defence: refuse if any component of rootDir is a symlink
+  // (mirrors skillCreate's parent-walk).
+  {
+    const segs = rootDir.split(sep).filter((s) => s.length > 0);
+    let cur = rootDir.startsWith(sep) ? sep : "";
+    for (const seg of segs) {
+      cur = cur === sep ? sep + seg : cur + sep + seg;
+      try {
+        if (lstatSync(cur).isSymbolicLink()) {
+          return authorErr(
+            "E_SKILL_INVALID_PATH",
+            `refuse to publish under symlinked path component: ${cur}`,
+          );
+        }
+      } catch {
+        /* not-yet-created tail — fine */
+      }
+    }
+  }
+
+  // Atomic publish (RFC §3.5): stage → copy → stamp marker INSIDE the
+  // stage dir → fsync → rename into place. The marker is written
+  // BEFORE the rename so the published dir is never observable without
+  // it — this is what prevents the crash-after-copy self-lockout the
+  // old skillCreate-global path is vulnerable to.
+  const uniq = `${process.pid}.${Date.now()}`;
+  const stageDir = join(rootDir, `.publish-${opts.name}.${uniq}`);
+  const trashDir = join(rootDir, `.trash-${opts.name}.${uniq}`);
+  mkdirSync(stageDir, { recursive: true });
+  try {
+    for (const rel of files) {
+      const abs = join(stageDir, rel);
+      const d = dirname(abs);
+      if (d !== stageDir) mkdirSync(d, { recursive: true });
+      const content = readFileSync(join(srcDir, rel), "utf-8");
+      const r = safeWriteFile(abs, stageDir, content, "create");
+      if (r && "ok" in r && r.ok === false) {
+        try { rmSync(stageDir, { recursive: true, force: true }); } catch { /* */ }
+        return r;
+      }
+    }
+    // Stamp authorship marker INSIDE the stage dir, before the rename.
+    writeFileSync(
+      join(stageDir, authorshipMarkerName(agent)),
+      "",
+      { flag: "wx", mode: 0o600 },
+    );
+    fsyncDirBestEffort(stageDir);
+
+    // Swap into place: move any existing (marker-verified) dest aside,
+    // rename the stage in, then drop the old copy.
+    let hadOld = false;
+    if (existsSync(destDir)) {
+      renameSync(destDir, trashDir);
+      hadOld = true;
+    }
+    try {
+      renameSync(stageDir, destDir);
+    } catch (e) {
+      if (hadOld) {
+        try { renameSync(trashDir, destDir); } catch { /* best-effort restore */ }
+      }
+      throw e;
+    }
+    if (hadOld) {
+      try { rmSync(trashDir, { recursive: true, force: true }); } catch { /* */ }
+    }
+  } catch (e) {
+    try { rmSync(stageDir, { recursive: true, force: true }); } catch { /* */ }
+    return authorErr(
+      "E_SKILL_INVALID_PATH",
+      `failed to publish skill: ${(e as Error).message}`,
+    );
+  }
+
+  return {
+    ok: true,
+    slug: opts.name,
+    path: destDir,
+    files,
+    version: skillVersionToken(destDir),
+  };
+}
+
+export interface SkillUnpublishOpts {
+  agent?: string;
+  name: string;
+  globalRoot?: string;
+  isAdmin?: (agent: string) => boolean;
+}
+
+export interface SkillUnpublishResult {
+  ok: true;
+  slug: string;
+  path: string;
+}
+
+export function skillUnpublish(
+  opts: SkillUnpublishOpts,
+): SkillUnpublishResult | SkillAuthorError {
+  let agent: string;
+  try { agent = resolveAgent(opts.agent); }
+  catch (e) { return agentErrCode(e); }
+
+  if (!validateSkillName(opts.name)) {
+    return authorErr(
+      "E_SKILL_INVALID_NAME",
+      `skill name must match [a-z0-9][a-z0-9_-]{0,62}: got ${JSON.stringify(opts.name)}`,
+    );
+  }
+
+  const isAdminFn = opts.isAdmin ?? defaultIsAdmin;
+  const sc = resolveScope(
+    agent, opts.name, "global", undefined, opts.globalRoot, isAdminFn,
+  );
+  if ("ok" in sc && sc.ok === false) return sc;
+  const destDir = (sc as ScopeContext).skillDir;
+
+  if (!existsSync(destDir)) {
+    return authorErr(
+      "E_SKILL_NOT_FOUND",
+      `global skill "${opts.name}" does not exist`,
+    );
+  }
+  try {
+    if (lstatSync(destDir).isSymbolicLink()) {
+      return authorErr(
+        "E_SKILL_INVALID_PATH",
+        `global "${opts.name}" is a symlink — refuse to unpublish`,
+      );
+    }
+  } catch {
+    return authorErr("E_SKILL_NOT_FOUND", `${destDir} missing`);
+  }
+  if (!hasAuthorshipMarker(destDir, agent)) {
+    return authorErr(
+      "E_SKILL_OPERATOR_OWNED",
+      `global skill "${opts.name}" is not authored by ${agent} (no ${authorshipMarkerName(agent)} marker) — refuse to unpublish operator-curated or peer-authored skill`,
+    );
+  }
+  rmSync(destDir, { recursive: true, force: true });
+  return { ok: true, slug: opts.name, path: destDir };
+}
+
 // ─── CLI registration ────────────────────────────────────────────────
 
 interface AuthorCliOpts {
@@ -897,6 +1190,44 @@ export function registerAgentConfigSkillAuthorCommands(program: Command): void {
       emit(r);
       try {
         appendAudit(resolvedAgent, "skill.delete", { name: opts.name }, 0);
+      } catch { /* */ }
+    });
+
+  skill
+    .command("publish")
+    .description(
+      "Promote your own agent-scope skill into the operator's global " +
+      "pool (admin only). Replace-by-publish of the whole dir; " +
+      "marker-gated so operator/peer globals stay immutable.",
+    )
+    .requiredOption("--name <slug>", "Skill slug (your agent-scope skill)")
+    .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .action(async (opts: AuthorCliOpts) => {
+      const resolvedAgent = opts.agent ?? process.env.SWITCHROOM_AGENT_NAME ?? "<unknown>";
+      const r = skillPublish({ agent: opts.agent, name: opts.name });
+      if (!r.ok) fail(r, resolvedAgent, "skill.publish", { name: opts.name });
+      emit(r);
+      try {
+        appendAudit(resolvedAgent, "skill.publish",
+          { name: opts.name, file_count: r.files.length }, 0);
+      } catch { /* */ }
+    });
+
+  skill
+    .command("unpublish")
+    .description(
+      "Remove a global skill you published (admin only). Marker-gated: " +
+      "refuses operator-curated or peer-authored skills.",
+    )
+    .requiredOption("--name <slug>", "Skill slug (in the global pool)")
+    .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .action(async (opts: AuthorCliOpts) => {
+      const resolvedAgent = opts.agent ?? process.env.SWITCHROOM_AGENT_NAME ?? "<unknown>";
+      const r = skillUnpublish({ agent: opts.agent, name: opts.name });
+      if (!r.ok) fail(r, resolvedAgent, "skill.unpublish", { name: opts.name });
+      emit(r);
+      try {
+        appendAudit(resolvedAgent, "skill.unpublish", { name: opts.name }, 0);
       } catch { /* */ }
     });
 

--- a/src/cli/skill-publish.test.ts
+++ b/src/cli/skill-publish.test.ts
@@ -267,6 +267,16 @@ describe("skillUnpublish", () => {
     expect(existsSync(dest)).toBe(true);
   });
 
+  it("refuses to unpublish a peer-authored skill", () => {
+    const dest = join(globalRoot, "demo");
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(join(dest, "SKILL.md"), "---\nname: demo\ndescription: p\n---\n");
+    writeFileSync(join(dest, ".authored-by-bob"), "");
+    const r = skillUnpublish({ name: "demo", globalRoot, isAdmin: ADMIN });
+    expect("ok" in r && r.ok === false && r.code).toBe("E_SKILL_OPERATOR_OWNED");
+    expect(existsSync(dest)).toBe(true);
+  });
+
   it("E_SKILL_NOT_FOUND for a slug not in the pool", () => {
     const r = skillUnpublish({ name: "ghost", globalRoot, isAdmin: ADMIN });
     expect("ok" in r && r.ok === false && r.code).toBe("E_SKILL_NOT_FOUND");

--- a/src/cli/skill-publish.test.ts
+++ b/src/cli/skill-publish.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { skillPublish, skillUnpublish } from "./agent-config-skill-author.js";
+
+const AGENT = "alice";
+const ADMIN = () => true;
+
+let tmp: string;
+let agentRoot: string; // SkillPublishOpts.root → <root>/<agent>/.claude/skills
+let globalRoot: string; // SkillPublishOpts.globalRoot → /skills-rw stand-in
+let savedPin: string | undefined;
+
+function srcSkillDir(slug: string): string {
+  return join(agentRoot, AGENT, ".claude", "skills", slug);
+}
+
+function seedSource(
+  slug: string,
+  files: Record<string, string> = {
+    "SKILL.md": `---\nname: ${slug}\ndescription: a ${slug} skill\n---\n# ${slug}\n`,
+  },
+): void {
+  const dir = srcSkillDir(slug);
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(dir, rel);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, content);
+  }
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "skill-publish-"));
+  agentRoot = join(tmp, "agents");
+  globalRoot = join(tmp, "skills-rw");
+  mkdirSync(globalRoot, { recursive: true });
+  savedPin = process.env.SWITCHROOM_AGENT_NAME;
+  process.env.SWITCHROOM_AGENT_NAME = AGENT;
+});
+
+afterEach(() => {
+  if (savedPin === undefined) delete process.env.SWITCHROOM_AGENT_NAME;
+  else process.env.SWITCHROOM_AGENT_NAME = savedPin;
+  if (tmp && existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("skillPublish", () => {
+  it("publishes an own agent-scope skill into the global pool with a marker", () => {
+    seedSource("demo", {
+      "SKILL.md": "---\nname: demo\ndescription: d\n---\n# Demo\n",
+      "scripts/run.sh": "#!/bin/sh\necho hi\n",
+      "reference/notes.md": "# notes\n",
+    });
+    const r = skillPublish({
+      name: "demo",
+      root: agentRoot,
+      globalRoot,
+      isAdmin: ADMIN,
+    });
+    expect("ok" in r && r.ok).toBe(true);
+    if (!("ok" in r) || !r.ok) return;
+    const dest = join(globalRoot, "demo");
+    expect(r.path).toBe(dest);
+    expect(existsSync(join(dest, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(dest, "scripts", "run.sh"))).toBe(true);
+    expect(existsSync(join(dest, "reference", "notes.md"))).toBe(true);
+    // Marker stamped (RFC §3.5 — present in the published dir).
+    expect(existsSync(join(dest, `.authored-by-${AGENT}`))).toBe(true);
+    expect(r.files).toEqual(
+      expect.arrayContaining(["SKILL.md", "scripts/run.sh", "reference/notes.md"]),
+    );
+    // No staging / trash residue in the pool root.
+    const residue = readdirSync(globalRoot).filter(
+      (n) => n.startsWith(".publish-") || n.startsWith(".trash-"),
+    );
+    expect(residue).toEqual([]);
+  });
+
+  it("re-publish overwrites an own (marker-carrying) global skill", () => {
+    seedSource("demo", {
+      "SKILL.md": "---\nname: demo\ndescription: v1\n---\n# v1\n",
+    });
+    expect(
+      skillPublish({ name: "demo", root: agentRoot, globalRoot, isAdmin: ADMIN })
+        .ok,
+    ).toBe(true);
+
+    seedSource("demo", {
+      "SKILL.md": "---\nname: demo\ndescription: v2\n---\n# v2\n",
+    });
+    const r = skillPublish({
+      name: "demo",
+      root: agentRoot,
+      globalRoot,
+      isAdmin: ADMIN,
+    });
+    expect("ok" in r && r.ok).toBe(true);
+    const body = readFileSync(join(globalRoot, "demo", "SKILL.md"), "utf-8");
+    expect(body).toContain("description: v2");
+    expect(existsSync(join(globalRoot, "demo", `.authored-by-${AGENT}`))).toBe(
+      true,
+    );
+    expect(
+      readdirSync(globalRoot).filter(
+        (n) => n.startsWith(".publish-") || n.startsWith(".trash-"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("refuses to overwrite an operator-curated global (no marker)", () => {
+    // Pre-existing global skill with NO authorship marker.
+    const dest = join(globalRoot, "demo");
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(
+      join(dest, "SKILL.md"),
+      "---\nname: demo\ndescription: operator\n---\n# operator\n",
+    );
+    seedSource("demo");
+    const r = skillPublish({
+      name: "demo",
+      root: agentRoot,
+      globalRoot,
+      isAdmin: ADMIN,
+    });
+    expect("ok" in r && r.ok === false).toBe(true);
+    if (!("ok" in r) || r.ok !== false) return;
+    expect(r.code).toBe("E_SKILL_OPERATOR_OWNED");
+    // Untouched.
+    expect(readFileSync(join(dest, "SKILL.md"), "utf-8")).toContain(
+      "description: operator",
+    );
+  });
+
+  it("refuses to overwrite a peer-authored global", () => {
+    const dest = join(globalRoot, "demo");
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(join(dest, "SKILL.md"), "---\nname: demo\ndescription: p\n---\n");
+    writeFileSync(join(dest, ".authored-by-bob"), "");
+    seedSource("demo");
+    const r = skillPublish({
+      name: "demo",
+      root: agentRoot,
+      globalRoot,
+      isAdmin: ADMIN,
+    });
+    expect("ok" in r && r.ok === false && r.code).toBe("E_SKILL_OPERATOR_OWNED");
+  });
+
+  it("E_SKILL_NOT_FOUND when the agent has no such skill", () => {
+    const r = skillPublish({
+      name: "ghost",
+      root: agentRoot,
+      globalRoot,
+      isAdmin: ADMIN,
+    });
+    expect("ok" in r && r.ok === false && r.code).toBe("E_SKILL_NOT_FOUND");
+  });
+
+  it("rejects a malformed source SKILL.md", () => {
+    seedSource("demo", { "SKILL.md": "# no frontmatter\n" });
+    const r = skillPublish({
+      name: "demo",
+      root: agentRoot,
+      globalRoot,
+      isAdmin: ADMIN,
+    });
+    expect("ok" in r && r.ok === false && r.code).toBe(
+      "E_SKILL_INVALID_FRONTMATTER",
+    );
+    expect(existsSync(join(globalRoot, "demo"))).toBe(false);
+  });
+
+  it("rejects a source file outside the path allowlist", () => {
+    seedSource("demo", {
+      "SKILL.md": "---\nname: demo\ndescription: d\n---\n",
+      "scripts/run.js": "console.log(1)",
+    });
+    const r = skillPublish({
+      name: "demo",
+      root: agentRoot,
+      globalRoot,
+      isAdmin: ADMIN,
+    });
+    expect("ok" in r && r.ok === false && r.code).toBe("E_SKILL_INVALID_PATH");
+  });
+
+  it("enforces the per-skill byte cap", () => {
+    seedSource("demo", {
+      "SKILL.md": "---\nname: demo\ndescription: d\n---\n",
+      "reference/big.md": "x".repeat(2 * 1024 * 1024 + 16),
+    });
+    const r = skillPublish({
+      name: "demo",
+      root: agentRoot,
+      globalRoot,
+      isAdmin: ADMIN,
+    });
+    expect("ok" in r && r.ok === false && r.code).toBe(
+      "E_SKILL_BUNDLE_TOO_LARGE",
+    );
+  });
+
+  it("requires admin", () => {
+    seedSource("demo");
+    const r = skillPublish({
+      name: "demo",
+      root: agentRoot,
+      globalRoot,
+      isAdmin: () => false,
+    });
+    expect("ok" in r && r.ok === false && r.code).toBe("E_SKILL_SCOPE_DENIED");
+  });
+
+  it("E_SKILL_GLOBAL_MOUNT_UNCONFIGURED when /skills-rw is absent", () => {
+    seedSource("demo");
+    const r = skillPublish({
+      name: "demo",
+      root: agentRoot,
+      globalRoot: join(tmp, "does-not-exist"),
+      isAdmin: ADMIN,
+    });
+    expect("ok" in r && r.ok === false && r.code).toBe(
+      "E_SKILL_GLOBAL_MOUNT_UNCONFIGURED",
+    );
+  });
+
+  it("enforces the identity pin", () => {
+    seedSource("demo");
+    const r = skillPublish({
+      agent: "bob", // != SWITCHROOM_AGENT_NAME (alice)
+      name: "demo",
+      root: agentRoot,
+      globalRoot,
+      isAdmin: ADMIN,
+    });
+    expect("ok" in r && r.ok === false && r.code).toBe("E_AGENT_PIN_REQUIRED");
+  });
+});
+
+describe("skillUnpublish", () => {
+  it("removes a global skill the agent published", () => {
+    seedSource("demo");
+    expect(
+      skillPublish({ name: "demo", root: agentRoot, globalRoot, isAdmin: ADMIN })
+        .ok,
+    ).toBe(true);
+    const r = skillUnpublish({ name: "demo", globalRoot, isAdmin: ADMIN });
+    expect("ok" in r && r.ok).toBe(true);
+    expect(existsSync(join(globalRoot, "demo"))).toBe(false);
+  });
+
+  it("refuses to unpublish an operator-curated skill (no marker)", () => {
+    const dest = join(globalRoot, "demo");
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(join(dest, "SKILL.md"), "---\nname: demo\ndescription: o\n---\n");
+    const r = skillUnpublish({ name: "demo", globalRoot, isAdmin: ADMIN });
+    expect("ok" in r && r.ok === false && r.code).toBe("E_SKILL_OPERATOR_OWNED");
+    expect(existsSync(dest)).toBe(true);
+  });
+
+  it("E_SKILL_NOT_FOUND for a slug not in the pool", () => {
+    const r = skillUnpublish({ name: "ghost", globalRoot, isAdmin: ADMIN });
+    expect("ok" in r && r.ok === false && r.code).toBe("E_SKILL_NOT_FOUND");
+  });
+
+  it("requires admin", () => {
+    const r = skillUnpublish({
+      name: "demo",
+      globalRoot,
+      isAdmin: () => false,
+    });
+    expect("ok" in r && r.ok === false && r.code).toBe("E_SKILL_SCOPE_DENIED");
+  });
+});

--- a/src/mcp/agent-config/server.publish.test.ts
+++ b/src/mcp/agent-config/server.publish.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TOOLS } from "./server.js";
+
+describe("agent-config MCP server — Phase 2a publish tools", () => {
+  const byName = Object.fromEntries(TOOLS.map((t) => [t.name, t]));
+
+  it("registers skill_publish and skill_unpublish", () => {
+    expect(byName.skill_publish).toBeDefined();
+    expect(byName.skill_unpublish).toBeDefined();
+  });
+
+  it("both require only `name` and accept optional `agent` (no scope arg)", () => {
+    for (const n of ["skill_publish", "skill_unpublish"]) {
+      const t = byName[n]!;
+      expect(t.inputSchema.required).toEqual(["name"]);
+      expect(Object.keys(t.inputSchema.properties)).toEqual(
+        expect.arrayContaining(["name", "agent"]),
+      );
+      // Publish is inherently agent→global; there is deliberately no
+      // scope selector (unlike the deprecated skill_create/edit/delete).
+      expect(t.inputSchema.properties).not.toHaveProperty("scope");
+    }
+  });
+
+  it("descriptions document the marker gate and admin requirement", () => {
+    expect(byName.skill_publish!.description).toMatch(/admin/i);
+    expect(byName.skill_publish!.description).toMatch(/E_SKILL_OPERATOR_OWNED/);
+    expect(byName.skill_publish!.description).toMatch(/replace-by-publish/i);
+    expect(byName.skill_unpublish!.description).toMatch(
+      /E_SKILL_OPERATOR_OWNED/,
+    );
+  });
+
+  it("appear after skill_delete (ordering kept stable)", () => {
+    const names = TOOLS.map((t) => t.name);
+    const del = names.indexOf("skill_delete");
+    expect(names.indexOf("skill_publish")).toBeGreaterThan(del);
+    expect(names.indexOf("skill_unpublish")).toBeGreaterThan(
+      names.indexOf("skill_publish"),
+    );
+  });
+
+  // #1492-class guard: prove `skill publish` is a real wired CLI verb
+  // whose failure path emits a clean JSON error (not the CLI version
+  // string, not opaque non-JSON) — the exact shim defect #1492 was.
+  it("E2E: `skill publish` is wired and fails cleanly with JSON on stderr", () => {
+    const which = spawnSync("which", ["bun"], { encoding: "utf-8" });
+    if (which.status !== 0) return;
+    const cliEntry = join(process.cwd(), "bin", "switchroom.ts");
+    if (!existsSync(cliEntry)) return;
+    const tmp = mkdtempSync(join(tmpdir(), "skill-publish-e2e-"));
+    try {
+      const r = spawnSync(
+        "bun",
+        [cliEntry, "skill", "publish", "--name", "ghost"],
+        {
+          encoding: "utf-8",
+          env: { ...process.env, HOME: tmp, SWITCHROOM_AGENT_NAME: "alice" },
+          timeout: 30000,
+        },
+      );
+      // Non-zero exit (no such skill / not admin), and stderr is a
+      // parseable {code,message} — NOT a version string, NOT a JSON
+      // parse error.
+      expect(r.status).not.toBe(0);
+      expect(r.stdout.trim()).toBe("");
+      const err = JSON.parse(r.stderr.trim());
+      expect(typeof err.code).toBe("string");
+      expect(err.code).toMatch(/^E_SKILL_|^E_AGENT_/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/mcp/agent-config/server.test.ts
+++ b/src/mcp/agent-config/server.test.ts
@@ -45,8 +45,10 @@ describe("TOOLS export", () => {
       "skill_edit",      // PR A author surface
       "skill_install",   // #1163 Phase 2
       "skill_list",
+      "skill_publish",   // Phase 2a — privileged global promote
       "skill_read",      // PR A author surface
       "skill_remove",    // #1163 Phase 2
+      "skill_unpublish", // Phase 2a — privileged global remove
     ]);
   });
 

--- a/src/mcp/agent-config/server.ts
+++ b/src/mcp/agent-config/server.ts
@@ -437,6 +437,65 @@ export const TOOLS = [
       },
     },
   },
+  {
+    name: "skill_publish",
+    description:
+      "Promote one of YOUR OWN agent-scope skills (authored natively " +
+      "under `$CLAUDE_CONFIG_DIR/skills/<slug>/`) into the operator's " +
+      "global pool so other agents can be granted it. Admin agents " +
+      "only. Replace-by-publish of the whole skill directory — no " +
+      "per-file edit, no version token: you iterate in your own scope, " +
+      "then publish the finished result. The source is hard-validated " +
+      "(SKILL.md frontmatter with name == slug, path allowlist, 2 MiB " +
+      "/ 50-file caps) — a malformed skill is refused, not promoted. " +
+      "Marker-gated: if a global skill already exists at this slug it " +
+      "is overwritten ONLY if it carries your `.authored-by-<agent>` " +
+      "marker; operator-curated (no marker) or peer-authored skills " +
+      "are immutable. Atomic (stage → marker → rename), so a crash " +
+      "never leaves a markerless half-published dir. Publishing does " +
+      "NOT make the skill active for any agent — an operator/admin " +
+      "must still add the slug to the relevant `skills:` cascade layer " +
+      "(the `--adopt` convenience is a separate follow-up). Error " +
+      "codes: E_SKILL_NOT_FOUND (no such agent-scope skill), " +
+      "E_SKILL_INVALID_NAME, E_SKILL_INVALID_PATH, " +
+      "E_SKILL_INVALID_FRONTMATTER, E_SKILL_BUNDLE_TOO_LARGE, " +
+      "E_SKILL_SCOPE_DENIED (not admin), E_SKILL_OPERATOR_OWNED " +
+      "(exit 18 — slug owned by operator/peer), " +
+      "E_SKILL_GLOBAL_MOUNT_UNCONFIGURED (exit 17 — /skills-rw absent), " +
+      "E_AGENT_PIN_REQUIRED.",
+    inputSchema: {
+      type: "object" as const,
+      required: ["name"],
+      properties: {
+        name: { type: "string", pattern: "^[a-z0-9][a-z0-9_-]{0,62}$" },
+        agent: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "skill_unpublish",
+    description:
+      "Remove a skill YOU published from the operator's global pool " +
+      "(admin only). Marker-gated: refuses operator-curated or " +
+      "peer-authored skills (only the agent whose " +
+      "`.authored-by-<agent>` marker is present may unpublish). Does " +
+      "not touch any `skills:` cascade entry — if the slug was adopted " +
+      "into a layer, an operator must remove it there too (the next " +
+      "reconcile will otherwise log a benign 'skill not found in " +
+      "pool'). Error codes: E_SKILL_NOT_FOUND, E_SKILL_INVALID_NAME, " +
+      "E_SKILL_INVALID_PATH, E_SKILL_SCOPE_DENIED (not admin), " +
+      "E_SKILL_OPERATOR_OWNED (exit 18), " +
+      "E_SKILL_GLOBAL_MOUNT_UNCONFIGURED (exit 17), " +
+      "E_AGENT_PIN_REQUIRED.",
+    inputSchema: {
+      type: "object" as const,
+      required: ["name"],
+      properties: {
+        name: { type: "string", pattern: "^[a-z0-9][a-z0-9_-]{0,62}$" },
+        agent: { type: "string" },
+      },
+    },
+  },
 ];
 
 export function dispatchTool(
@@ -594,6 +653,24 @@ export function dispatchTool(
       const base = ["skill", "delete", "--name", a.name];
       if (a.agent) base.push("--agent", a.agent);
       if (a.scope) base.push("--scope", a.scope as string);
+      cliArgs = base;
+      parseMode = "json";
+      break;
+    }
+    case "skill_publish": {
+      const a = args as ToolArgs;
+      if (!a.name) return errorText("skill_publish: name is required");
+      const base = ["skill", "publish", "--name", a.name];
+      if (a.agent) base.push("--agent", a.agent);
+      cliArgs = base;
+      parseMode = "json";
+      break;
+    }
+    case "skill_unpublish": {
+      const a = args as ToolArgs;
+      if (!a.name) return errorText("skill_unpublish: name is required");
+      const base = ["skill", "unpublish", "--name", a.name];
+      if (a.agent) base.push("--agent", a.agent);
       cliArgs = base;
       parseMode = "json";
       break;


### PR DESCRIPTION
## Summary

Phase 2a of `docs/rfcs/skill-authoring-native.md` (RFC #1498). The **one privileged broker-backed write**: promote an agent's own, natively-authored agent-scope skill into the operator's global pool. Replace-by-publish of the whole dir — no per-file edit, no version tokens.

- **`skillPublish`**: hard-validates the source (SKILL.md frontmatter w/ name==slug, path allowlist, 2 MiB / 50-file caps) — malformed skills are **refused, not promoted**. Admin-gated + `/skills-rw` mount-gated + identity-pinned. Marker-gated: an existing global slug is overwritten **only** if it carries this agent's `.authored-by-<agent>` marker; operator-curated / peer skills are immutable.
- **Atomicity (RFC §3.5)**: stage → copy → stamp marker **inside** the stage dir → fsync → rename (old dir moved aside, restored on rename failure). The marker is written **before** the rename — this closes the crash-after-copy self-lockout the old `skillCreate`-global path is vulnerable to.
- **`skillUnpublish`**: marker-gated atomic remove.
- `switchroom skill publish|unpublish` CLI verbs (only `--name`/`--agent` — no `--version`/`--scope`, so no #1492-class flag collision); `skill_publish`/`skill_unpublish` MCP tools + dispatch + surface pin.

**Scope**: strictly Phase 2a — additive. No `--adopt`, no approval-kernel, no `skills:` cascade edit (publish does not activate a skill). The deprecated `skill_create/edit/delete scope:global` path is left intact (Phase 2b removes `--scope` once publish is proven).

## Test plan

- [x] 16 unit tests (happy, re-publish overwrite, operator/peer-owned reject for both publish & unpublish, malformed source, allowlist, byte cap, admin gate, mount-absent, identity-pin, residue/atomicity)
- [x] 5 MCP-surface + CLI E2E (proves the verb is wired and fails with clean JSON — #1492-class guard)
- [x] Full skill regression suite green (75); `tsc --noEmit` clean
- [x] Independent fresh-process review → **APPROVE** (atomicity contract honored, full security parity, no scope over-reach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)