### PR TITLE
fix(update): --rebuild hard-refuses on a published install (fail-fast)

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { planUpdate, runUpdate, isGitCheckout } from "./update.js";
+import { planUpdate, runUpdate, isGitCheckout, rebuildRefusalMessage } from "./update.js";
 
 function fakeRunner() {
   const calls: Array<{ cmd: string; args: string[] }> = [];
@@ -118,6 +118,117 @@ describe("planUpdate", () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  describe("--rebuild guardrail (published-install refusal)", () => {
+    it("rebuildRefusalMessage: null inside a git checkout, message otherwise", () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-guard-"));
+      try {
+        // No .git anywhere up the chain → published install → refuse.
+        const noGit = join(tmp, "lib", "node_modules", "switchroom", "x.js");
+        const msg = rebuildRefusalMessage(noGit);
+        expect(msg).not.toBeNull();
+        expect(msg!).toContain("npm i -g switchroom@latest && switchroom update");
+        expect(msg!).toMatch(/published install/);
+
+        // .git ancestor present → real source checkout → allowed.
+        mkdirSync(join(tmp, ".git"), { recursive: true });
+        const inCheckout = join(tmp, "dist", "cli", "switchroom.js");
+        expect(rebuildRefusalMessage(inCheckout)).toBeNull();
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("runUpdate hard-refuses --rebuild on a published install (exit 2, nothing runs)", async () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-guard-run-"));
+      try {
+        const composePath = join(tmp, "docker-compose.yml");
+        writeFileSync(composePath, "services: {}\n");
+        const out: string[] = [];
+        const err: string[] = [];
+        const runner = fakeRunner();
+        const code = await runUpdate({
+          rebuild: true,
+          scriptPath: join(tmp, "node_modules", "switchroom", "cli.js"), // no .git
+          composePath,
+          stdout: (s) => out.push(s),
+          stderr: (s) => err.push(s),
+          runner: runner.fn,
+        });
+        expect(code).toBe(2);
+        expect(runner.calls).toHaveLength(0); // preflight: nothing executed
+        expect(err.join("")).toContain("npm i -g switchroom@latest");
+        expect(err.join("")).toMatch(/published install/);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("the refusal fires even under --check (no plan printed)", async () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-guard-check-"));
+      try {
+        const composePath = join(tmp, "docker-compose.yml");
+        writeFileSync(composePath, "services: {}\n");
+        const out: string[] = [];
+        const err: string[] = [];
+        const code = await runUpdate({
+          check: true,
+          rebuild: true,
+          scriptPath: join(tmp, "bin", "switchroom"), // no .git
+          composePath,
+          stdout: (s) => out.push(s),
+          stderr: (s) => err.push(s),
+          runner: fakeRunner().fn,
+        });
+        expect(code).toBe(2);
+        expect(out.join("")).not.toMatch(/dry-run/);
+        expect(err.join("")).toContain("switchroom update");
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("in-step defence-in-depth: planUpdate's rebuild-source.run() throws on a published install", () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-guard-step-"));
+      try {
+        const composePath = join(tmp, "docker-compose.yml");
+        writeFileSync(composePath, "services: {}\n");
+        const steps = planUpdate({
+          composePath,
+          rebuild: true,
+          hostControlEnabled: false,
+          scriptPath: join(tmp, "node_modules", "switchroom", "cli.js"),
+        });
+        const rebuild = steps.find((s) => s.name === "rebuild-source")!;
+        expect(rebuild).toBeDefined();
+        expect(() => rebuild.run()).toThrow(/npm i -g switchroom@latest/);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it("does NOT refuse when running from a real source checkout", () => {
+      const tmp = mkdtempSync(join(tmpdir(), "update-guard-ok-"));
+      try {
+        mkdirSync(join(tmp, ".git"), { recursive: true });
+        const scriptPath = join(tmp, "dist", "cli", "switchroom.js");
+        expect(rebuildRefusalMessage(scriptPath)).toBeNull();
+        const composePath = join(tmp, "docker-compose.yml");
+        writeFileSync(composePath, "services: {}\n");
+        const steps = planUpdate({
+          composePath,
+          rebuild: true,
+          hostControlEnabled: false,
+          scriptPath,
+        });
+        // rebuild-source present and its guard does not throw.
+        const rebuild = steps.find((s) => s.name === "rebuild-source")!;
+        expect(rebuild).toBeDefined();
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
   });
 
   // refresh-hostd: PR ε — closes the gap that hostd lives in a separate
@@ -503,7 +614,10 @@ describe("--rebuild against a non-checkout install fails loudly (#923 reviewer)"
         const rebuild = steps.find((s) => s.name === "rebuild-source");
         expect(rebuild).toBeDefined();
         expect(rebuild?.skipReason).toBeUndefined(); // not silently skipped
-        expect(() => rebuild!.run()).toThrow(/--rebuild requires a git checkout/);
+        // Message was upgraded to point at the published path (the
+        // preflight in runUpdate now refuses before this even runs;
+        // this remains as in-step defence-in-depth).
+        expect(() => rebuild!.run()).toThrow(/npm i -g switchroom@latest/);
       } finally {
         process.argv[1] = origArgv1;
       }

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -26,8 +26,11 @@
  * Flags:
  *   --check          dry-run; print the steps that would run, exit 0.
  *   --skip-images    skip step 1 (offline mode).
- *   --rebuild        run step 2 (source-checkout users; auto-skipped
- *                    when not in a git repo).
+ *   --rebuild        run step 2. Source-checkout / maintainer only —
+ *                    HARD-REFUSED (exit 2) on a published install,
+ *                    which is told to use `npm i -g switchroom@latest
+ *                    && switchroom update` instead. Refusal is a
+ *                    preflight: nothing runs before it fires.
  *
  * Legacy `--phase=post-build` is still accepted as a no-op so any
  * in-flight v0.6 → v0.7 self-reexec path doesn't crash mid-flight.
@@ -55,6 +58,9 @@ interface UpdateOptions {
   force?: boolean;
   /** Compose-file override for tests. */
   composePath?: string;
+  /** Test seam — override the running-script path used by the
+   *  `--rebuild` source-checkout guard (default: process.argv[1]). */
+  scriptPath?: string;
   /** stdout/stderr writers for tests. */
   stdout?: (s: string) => void;
   stderr?: (s: string) => void;
@@ -114,6 +120,34 @@ export function isGitCheckout(scriptPath: string): boolean {
 }
 
 /**
+ * `--rebuild` (git pull + bun install + npm run build) is a
+ * **source-checkout / maintainer-only** operation. On a published
+ * install (npm-global, /usr/local/bin, any non-checkout) building
+ * from source is meaningless AND silently drifts the host off the
+ * reviewed, CI-published release — the exact failure mode the
+ * published-artifact model exists to prevent.
+ *
+ * Returns `null` when `--rebuild` is legitimate (running from a git
+ * checkout), or the operator-facing refusal message otherwise.
+ * Exported so the preflight, the in-step defence-in-depth, and unit
+ * tests all share one source of truth.
+ */
+export function rebuildRefusalMessage(scriptPath: string): string | null {
+  if (isGitCheckout(scriptPath)) return null;
+  return (
+    `--rebuild builds the CLI from a git checkout, but switchroom is ` +
+    `running from "${scriptPath}" — a published install (no .git ` +
+    `ancestor). Rebuilding from source here would drift this host off ` +
+    `the reviewed, CI-published release. Use the published path:\n` +
+    `\n` +
+    `  npm i -g switchroom@latest && switchroom update\n` +
+    `\n` +
+    `(\`--rebuild\` is for switchroom maintainers iterating on a source ` +
+    `checkout — not for published installs.)`
+  );
+}
+
+/**
  * Build the ordered list of update steps. Pure function — no side
  * effects. The action handler iterates this list and either prints
  * (--check) or executes (default).
@@ -121,7 +155,7 @@ export function isGitCheckout(scriptPath: string): boolean {
 export function planUpdate(opts: UpdateOptions): UpdateStep[] {
   const composePath = opts.composePath ?? DEFAULT_COMPOSE_PATH;
   const runner = opts.runner ?? defaultRunner;
-  const scriptPath = process.argv[1] ?? "";
+  const scriptPath = opts.scriptPath ?? process.argv[1] ?? "";
   const steps: UpdateStep[] = [];
 
   // When --channel / --pin is set, the resolved image tag in compose
@@ -169,23 +203,21 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
     },
   });
 
-  // Source-checkout step. Only added when --rebuild is explicit. If
-  // the user passed --rebuild but the CLI isn't running from a git
-  // checkout, the runUpdate dispatcher will fail loudly — the explicit
-  // flag is treated as a hard intent, not a hint we can quietly drop
-  // (#923 reviewer feedback).
+  // Source-checkout step. Only added when --rebuild is explicit.
+  // `runUpdate` preflights `rebuildRefusalMessage` and hard-refuses
+  // BEFORE any step runs on a published install (so a fat-fingered
+  // `--rebuild` on a consumer host can't half-apply then drift to
+  // unreviewed source). The in-step check below is defence-in-depth
+  // for callers that drive `planUpdate` directly (e.g. unit tests),
+  // sharing the same single-source-of-truth message.
   if (opts.rebuild) {
     steps.push({
       name: "rebuild-source",
       description: "git pull upstream main + bun install + npm run build",
       run: () => {
-        if (!isGitCheckout(scriptPath)) {
-          throw new Error(
-            `--rebuild requires a git checkout, but the CLI is running ` +
-            `from ${scriptPath} which has no .git ancestor (looks like ` +
-            `an installed binary). Drop --rebuild or invoke from a ` +
-            `source checkout.`,
-          );
+        const refusal = rebuildRefusalMessage(scriptPath);
+        if (refusal) {
+          throw new Error(refusal);
         }
         // CWD matters: git/bun/npm run from process.cwd(). Operator
         // is expected to invoke `update --rebuild` from inside the
@@ -761,6 +793,20 @@ async function runUpdate(opts: UpdateOptions): Promise<number> {
     return 2;
   }
 
+  // Preflight: --rebuild is source-checkout-only. Refuse BEFORE any
+  // step (or even the --check plan) on a published install — fail
+  // fast with the published-path remediation rather than letting
+  // pull-images run and then dying mid-pipeline.
+  if (opts.rebuild) {
+    const refusal = rebuildRefusalMessage(
+      opts.scriptPath ?? process.argv[1] ?? "",
+    );
+    if (refusal) {
+      stderr(chalk.red(refusal + "\n"));
+      return 2;
+    }
+  }
+
   const steps = planUpdate(opts);
 
   if (opts.check) {
@@ -804,7 +850,7 @@ export function registerUpdateCommand(program: Command): void {
     .option("--skip-images", "Skip the docker image pull (offline mode).")
     .option(
       "--rebuild",
-      "Source-checkout users: also git pull + bun install + npm run build before applying. Auto-skipped when the CLI is an installed binary.",
+      "Source-checkout / maintainer only: git pull + bun install + npm run build before applying. REFUSED on a published install — use `npm i -g switchroom@latest && switchroom update` there.",
     )
     .option(
       "--status",


### PR DESCRIPTION
## Summary

`switchroom update --rebuild` (git pull + build from source) is a **source-checkout / maintainer-only** operation. On a published install it's meaningless and silently drifts the host off the reviewed, CI-published release — the exact failure mode the published-artifact model exists to prevent.

- **Before:** a late in-step throw — `pull-images` (and any `--channel/--pin` compose regen) had already run before it died mid-pipeline, with a message ("invoke from a source checkout") that's wrong advice for a consumer host.
- **Now:** a shared `rebuildRefusalMessage()` helper drives a **fail-fast preflight** in `runUpdate` — refuses **before any step** (and before the `--check` plan), exit 2, nothing runs, with the correct remediation: `npm i -g switchroom@latest && switchroom update`. The in-step guard delegates to the same helper as defence-in-depth for direct `planUpdate` callers. Header/option help corrected (it claimed "auto-skipped"; it hard-refuses). `scriptPath?` test seam added.

Keeps the maintainer dev loop **byte-unchanged** on real source checkouts (incl. git worktrees); makes a published host **structurally un-driftable** via this flag. This is the guardrail discussed instead of deleting `--rebuild` outright (preserves the legitimate maintainer use, closes the footgun).

## Test plan

- [x] 5 new guardrail tests (exit 2, runner NOT called, message content, `--check` still refuses, in-step throw, true-negative source-checkout) + pre-existing #923 test re-pointed to the upgraded message
- [x] 42 update/install-detect tests green; `tsc --noEmit` clean; build ok
- [x] Scope = `update.ts` + `update.test.ts` only; source-checkout path unchanged; `--status` unaffected (returns before preflight)
- [x] Independent fresh-process review → **APPROVE** (worktree case verified not regressed; no collateral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)