### PR TITLE
fix(update): --rebuild guard must require a switchroom checkout, not any .git

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -121,20 +121,59 @@ describe("planUpdate", () => {
   });
 
   describe("--rebuild guardrail (published-install refusal)", () => {
-    it("rebuildRefusalMessage: null inside a git checkout, message otherwise", () => {
+    it("rebuildRefusalMessage: allow ONLY a real switchroom checkout", () => {
       const tmp = mkdtempSync(join(tmpdir(), "update-guard-"));
       try {
-        // No .git anywhere up the chain → published install → refuse.
+        // (a) No .git anywhere up the chain → published install → refuse.
         const noGit = join(tmp, "lib", "node_modules", "switchroom", "x.js");
         const msg = rebuildRefusalMessage(noGit);
         expect(msg).not.toBeNull();
         expect(msg!).toContain("npm i -g switchroom@latest && switchroom update");
-        expect(msg!).toMatch(/published install/);
 
-        // .git ancestor present → real source checkout → allowed.
-        mkdirSync(join(tmp, ".git"), { recursive: true });
-        const inCheckout = join(tmp, "dist", "cli", "switchroom.js");
+        // (b) REGRESSION for the v0.12.2 defect: a .git ancestor that
+        // is NOT a switchroom checkout (e.g. ~/.nvm is a git clone, or
+        // a dotfiles $HOME). An npm-global install lives under such a
+        // path. MUST still refuse — a bare ".git ancestor" check did
+        // not, so the guard never fired on the very host it protects.
+        const nvmLike = join(tmp, ".nvm");
+        mkdirSync(join(nvmLike, ".git"), { recursive: true }); // nvm's own repo, no switchroom pkg
+        const installed = join(
+          nvmLike, "versions", "node", "vX", "lib",
+          "node_modules", "switchroom", "dist", "cli", "switchroom.js",
+        );
+        mkdirSync(join(nvmLike, "versions", "node", "vX", "lib",
+          "node_modules", "switchroom"), { recursive: true });
+        // even with switchroom's own package.json present (no .git there):
+        writeFileSync(
+          join(nvmLike, "versions", "node", "vX", "lib", "node_modules",
+            "switchroom", "package.json"),
+          JSON.stringify({ name: "switchroom", version: "0.0.0" }),
+        );
+        expect(rebuildRefusalMessage(installed)).not.toBeNull();
+
+        // (c) Real switchroom checkout: .git AND switchroom package.json
+        // at the SAME dir → allowed.
+        const repo = join(tmp, "repo");
+        mkdirSync(join(repo, ".git"), { recursive: true });
+        writeFileSync(
+          join(repo, "package.json"),
+          JSON.stringify({ name: "switchroom", version: "0.0.0" }),
+        );
+        const inCheckout = join(repo, "dist", "cli", "switchroom.js");
         expect(rebuildRefusalMessage(inCheckout)).toBeNull();
+
+        // (d) git worktree of switchroom: .git is a FILE (gitlink),
+        // package.json still name=switchroom → allowed.
+        const wt = join(tmp, "wt");
+        mkdirSync(wt, { recursive: true });
+        writeFileSync(join(wt, ".git"), "gitdir: /somewhere/.git/worktrees/wt\n");
+        writeFileSync(
+          join(wt, "package.json"),
+          JSON.stringify({ name: "switchroom", version: "0.0.0" }),
+        );
+        expect(
+          rebuildRefusalMessage(join(wt, "dist", "cli", "switchroom.js")),
+        ).toBeNull();
       } finally {
         rmSync(tmp, { recursive: true, force: true });
       }
@@ -212,6 +251,10 @@ describe("planUpdate", () => {
       const tmp = mkdtempSync(join(tmpdir(), "update-guard-ok-"));
       try {
         mkdirSync(join(tmp, ".git"), { recursive: true });
+        writeFileSync(
+          join(tmp, "package.json"),
+          JSON.stringify({ name: "switchroom", version: "0.0.0" }),
+        );
         const scriptPath = join(tmp, "dist", "cli", "switchroom.js");
         expect(rebuildRefusalMessage(scriptPath)).toBeNull();
         const composePath = join(tmp, "docker-compose.yml");

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -120,6 +120,44 @@ export function isGitCheckout(scriptPath: string): boolean {
 }
 
 /**
+ * True iff `scriptPath` runs from inside an actual **switchroom source
+ * checkout** — a directory that has BOTH a `.git` (dir *or* file, so
+ * git worktrees count) AND a `package.json` whose `name` is
+ * `"switchroom"`, at the same level.
+ *
+ * Why not "any `.git` ancestor" (the old `isGitCheckout`): an
+ * npm-global install commonly sits under `~/.nvm/...`, and **nvm
+ * itself is a git clone** (`~/.nvm/.git` exists). A dotfiles `$HOME`
+ * is often a git repo too. A bare `.git`-ancestor walk therefore
+ * reports *every* nvm/npm-global install as a "checkout" so the
+ * `--rebuild` guard never fired on the exact host it must protect
+ * (this is the v0.12.2 defect). Requiring the switchroom
+ * `package.json` at the *same* dir as the `.git` eliminates those
+ * false positives: nvm/dotfiles `.git` dirs have no switchroom
+ * package.json; an installed package dir has the package.json but no
+ * `.git`.
+ */
+export function runningFromSwitchroomCheckout(scriptPath: string): boolean {
+  let dir = dirname(scriptPath);
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(join(dir, ".git"))) {
+      try {
+        const pkg = JSON.parse(
+          readFileSync(join(dir, "package.json"), "utf-8"),
+        ) as { name?: string };
+        if (pkg.name === "switchroom") return true;
+      } catch {
+        /* no / invalid package.json at this .git level — keep walking */
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return false;
+}
+
+/**
  * `--rebuild` (git pull + bun install + npm run build) is a
  * **source-checkout / maintainer-only** operation. On a published
  * install (npm-global, /usr/local/bin, any non-checkout) building
@@ -127,18 +165,19 @@ export function isGitCheckout(scriptPath: string): boolean {
  * reviewed, CI-published release — the exact failure mode the
  * published-artifact model exists to prevent.
  *
- * Returns `null` when `--rebuild` is legitimate (running from a git
- * checkout), or the operator-facing refusal message otherwise.
- * Exported so the preflight, the in-step defence-in-depth, and unit
- * tests all share one source of truth.
+ * Returns `null` when `--rebuild` is legitimate (running from a real
+ * switchroom source checkout), or the operator-facing refusal message
+ * otherwise. Exported so the preflight, the in-step defence-in-depth,
+ * and unit tests all share one source of truth.
  */
 export function rebuildRefusalMessage(scriptPath: string): string | null {
-  if (isGitCheckout(scriptPath)) return null;
+  if (runningFromSwitchroomCheckout(scriptPath)) return null;
   return (
     `--rebuild builds the CLI from a git checkout, but switchroom is ` +
-    `running from "${scriptPath}" — a published install (no .git ` +
-    `ancestor). Rebuilding from source here would drift this host off ` +
-    `the reviewed, CI-published release. Use the published path:\n` +
+    `running from "${scriptPath}" — not a switchroom source checkout ` +
+    `(this is a published / installed copy). Rebuilding from source ` +
+    `here would drift this host off the reviewed, CI-published ` +
+    `release. Use the published path:\n` +
     `\n` +
     `  npm i -g switchroom@latest && switchroom update\n` +
     `\n` +


### PR DESCRIPTION
## Summary

**Fixes a defect shipped in v0.12.2.** The `--rebuild` published-install guardrail never fired on the install model it protects. It used `isGitCheckout` = "any `.git` within 10 parent dirs" — but **nvm is itself a git clone** (`~/.nvm/.git` exists) and an npm-global install lives under `~/.nvm/...`, so the guard saw a `.git` ancestor and *allowed* `--rebuild` on exactly the published host it must refuse. Confirmed live: on a 0.12.2 npm-global install, `switchroom update --rebuild --check` printed the plan instead of refusing.

**Fix:** new `runningFromSwitchroomCheckout(scriptPath)` requires a directory with **both** a `.git` (dir *or* file — git worktrees still count) **and** a `package.json` whose `name === "switchroom"` *at the same level*. nvm/dotfiles `.git` dirs have no switchroom package.json; an installed package dir has the package.json but no `.git` — both correctly refuse now. `rebuildRefusalMessage` uses the precise predicate; `isGitCheckout` is kept (unused by the guard, still exported/tested) so nothing else regresses. Message reworded to "not a switchroom source checkout".

## Test plan

- [x] Explicit regression: a `~/.nvm/.git`-style ancestor + an installed switchroom `package.json` (no `.git` at the pkg dir) → MUST refuse (would pass-incorrectly under the old guard)
- [x] Allow cases preserved: real checkout (`.git` dir + switchroom pkg) and git **worktree** (`.git` file + switchroom pkg)
- [x] 36 update tests green; `tsc --noEmit` clean; preflight/`--check`/in-step paths intact
- [x] Independent fresh-process review → **APPROVE** (defect-closure traced by hand + reproduced old-guard failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)