### PR TITLE
fix(hostd): bake apply assets + fail-fast preflight (the klanker incident)

### DIFF
--- a/docker/Dockerfile.hostd
+++ b/docker/Dockerfile.hostd
@@ -76,6 +76,28 @@ RUN install -d -m 0755 /host-home /host-home/.switchroom
 COPY dist/cli/switchroom.js /opt/switchroom/dist/cli/switchroom.js
 COPY dist/host-control/main.js /opt/switchroom/dist/host-control/main.js
 
+# Apply-time assets the bundled CLI resolves RELATIVE TO ITSELF.
+# `switchroom apply` (reached here via the `apply` / `update_apply`
+# verbs) does NOT take a profiles/vendor path — it hardcodes them
+# relative to the CLI module:
+#   src/agents/profiles.ts:  resolve(import.meta.dirname,"../../profiles")
+#   src/agents/scaffold.ts:  resolve(import.meta.dirname,"../../vendor/hindsight-memory")
+# The CLI bundle lives at /opt/switchroom/dist/cli/switchroom.js, so
+# those resolve to /opt/switchroom/profiles and
+# /opt/switchroom/vendor/hindsight-memory. Without these, hostd's
+# update_apply pulls images then dies at apply-config with
+# "Profile not found: default (searched /opt/switchroom/profiles)",
+# stranding the fleet on the old image (the klanker incident).
+# Agent images intentionally do NOT bake these (agents never run
+# apply — their start.sh is rendered host-side); hostd is the ONE
+# container that runs apply, so it alone needs the apply asset tree.
+# Keep this in sync with every package-relative
+# resolve(import.meta.dirname,"../../<asset>") on the apply path
+# (the Part-2 preflight in src/host-control/server.ts hard-fails
+# fast if any are missing rather than stranding a fleet).
+COPY profiles/ /opt/switchroom/profiles/
+COPY vendor/hindsight-memory/ /opt/switchroom/vendor/hindsight-memory/
+
 # Tiny wrapper so `switchroom <verb>` invocations from hostd resolve
 # to the bundled CLI. Uses `bun` (not `node`) because the CLI bundle
 # imports bun-specific modules (bun:sqlite, bun:test, etc. — produced

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -34,7 +34,7 @@ import {
   renameSync,
   mkdirSync,
 } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import {
   decodeRequest,
@@ -81,6 +81,15 @@ export interface ServerOptions {
   auditLogPath?: string;
   /** Allow non-Linux dev mode (skips chown). */
   allowNonLinux?: boolean;
+  /**
+   * Root the apply-asset preflight resolves package-relative apply
+   * assets against (`<root>/profiles`, `<root>/vendor/hindsight-
+   * memory`). Default: two dirs up from this module — for the bundled
+   * daemon (`/opt/switchroom/dist/host-control/main.js`) that is
+   * `/opt/switchroom`, exactly where Dockerfile.hostd bakes them and
+   * the same root the CLI bundle resolves to. Test seam only.
+   */
+  applyAssetsRoot?: string;
   /**
    * Filesystem root the daemon uses to read host-side artifacts (e.g.
    * the install-type cache at `<bindRoot>/.switchroom/install-type.json`).
@@ -699,6 +708,51 @@ export class HostdServer {
    * `denied` with the in-flight request_id so the caller can poll
    * `get_status` instead of racing.
    */
+  /**
+   * Apply-asset preflight. `apply` / `update_apply` shell out to the
+   * bundled `switchroom` CLI, which resolves profiles + the vendored
+   * hindsight plugin RELATIVE TO ITSELF (no path arg):
+   *   profiles.ts:  resolve(import.meta.dirname,"../../profiles")
+   *   scaffold.ts:  resolve(import.meta.dirname,"../../vendor/hindsight-memory")
+   * If the hostd image was built without those (the klanker incident),
+   * `update_apply` pulls images then dies at apply-config, stranding
+   * the fleet on the old image. We refuse BEFORE anything is pulled
+   * or changed — same fail-fast principle as the `--rebuild` guard.
+   * Future-proofs the per-asset fragility: any new package-relative
+   * apply asset added here can't silently strand a fleet again.
+   */
+  private missingApplyAssets(): string[] {
+    const root =
+      this.opts.applyAssetsRoot ?? resolve(import.meta.dirname, "../..");
+    return [
+      join(root, "profiles"),
+      join(root, "profiles", "default"),
+      join(root, "vendor", "hindsight-memory"),
+    ].filter((p) => !existsSync(p));
+  }
+
+  /** Operator-facing refusal if apply assets are missing, else null.
+   *  Shared by handleUpdateApply + handleApply. */
+  private applyAssetPreflight(
+    request_id: string,
+    started: number,
+  ): HostdResponse | null {
+    const missing = this.missingApplyAssets();
+    if (missing.length === 0) return null;
+    return deniedResponse(
+      request_id,
+      `refused: this switchroom-hostd image is missing apply-time ` +
+        `assets [${missing.join(", ")}]. hostd's in-container ` +
+        `\`switchroom apply\` cannot scaffold agents without them and ` +
+        `would pull images then strand the fleet on the old image ` +
+        `(the klanker incident). Nothing was pulled or changed. Fix: ` +
+        `rebuild/refresh the hostd image — \`switchroom update\` ` +
+        `(refreshes hostd) or \`switchroom hostd install\` on the ` +
+        `host; meanwhile run \`switchroom update\` host-side.`,
+      Date.now() - started,
+    );
+  }
+
   private handleUpdateApply(
     req: Extract<HostdRequest, { op: "update_apply" }>,
     caller: SocketIdentity,
@@ -706,6 +760,9 @@ export class HostdServer {
   ): HostdResponse {
     const denied = this.checkFleetMutationLock(req.op, req.request_id, started);
     if (denied) return denied;
+
+    const assetDenied = this.applyAssetPreflight(req.request_id, started);
+    if (assetDenied) return assetDenied;
 
     // Mutual exclusion of channel vs pin. Schema accepts both optional;
     // server-side enforcement here keeps the contract honest at the
@@ -784,6 +841,9 @@ export class HostdServer {
   ): HostdResponse {
     const denied = this.checkFleetMutationLock(req.op, req.request_id, started);
     if (denied) return denied;
+
+    const assetDenied = this.applyAssetPreflight(req.request_id, started);
+    if (assetDenied) return assetDenied;
 
     const args = ["apply", "--non-interactive"];
     const entry: StatusEntry = {

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -975,3 +975,81 @@ describe("hostd server — Phase 2 fleet mutations + lock", () => {
     expect(peragent.result).toBe("completed");
   });
 });
+
+describe("hostd server — apply-asset preflight (klanker incident)", () => {
+  async function freshServer(applyAssetsRoot: string): Promise<HostdServer> {
+    if (server) await server.stop();
+    server = new HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: stubBin,
+      auditLogPath: join(tmp, "audit.log"),
+      allowNonLinux: true,
+      applyAssetsRoot,
+    });
+    await server.start();
+    return server;
+  }
+  const adminSock = () =>
+    server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+
+  it("update_apply: REFUSES (denied, nothing spawned) when apply assets are missing", async () => {
+    const bare = join(tmp, "assets-missing"); // no profiles/ or vendor/
+    mkdirSync(bare, { recursive: true });
+    await freshServer(bare);
+    const resp = await hostdRequest(
+      { socketPath: adminSock() },
+      { v: 1, op: "update_apply", request_id: "pf-ua", args: {} },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/missing apply-time assets/);
+    expect(resp.error).toContain(join(bare, "profiles"));
+    expect(resp.error).toMatch(/Nothing was pulled or changed/);
+    expect(resp.error).toMatch(/switchroom update/);
+    // Denied ⇒ spawnFleetMutation never ran: no status entry exists.
+    const poll = await hostdRequest(
+      { socketPath: adminSock() },
+      { v: 1, op: "get_status", request_id: "pf-poll", args: { target_request_id: "pf-ua" } },
+    );
+    expect(poll.result).not.toBe("started");
+  });
+
+  it("apply: also refused when assets missing (shared preflight)", async () => {
+    const bare = join(tmp, "assets-missing-2");
+    mkdirSync(bare, { recursive: true });
+    await freshServer(bare);
+    const resp = await hostdRequest(
+      { socketPath: adminSock() },
+      { v: 1, op: "apply", request_id: "pf-ap", args: {} },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/missing apply-time assets/);
+  });
+
+  it("update_apply: PROCEEDS when profiles/default + vendor/hindsight-memory are present", async () => {
+    const ok = join(tmp, "assets-ok");
+    mkdirSync(join(ok, "profiles", "default"), { recursive: true });
+    mkdirSync(join(ok, "vendor", "hindsight-memory"), { recursive: true });
+    await freshServer(ok);
+    const resp = await hostdRequest(
+      { socketPath: adminSock() },
+      { v: 1, op: "update_apply", request_id: "pf-ok", args: {} },
+    );
+    // Preflight passes → proceeds to spawn the stub → "started".
+    expect(resp.result).toBe("started");
+  });
+
+  it("partial assets (profiles present, vendor missing) still refuses, naming the gap", async () => {
+    const partial = join(tmp, "assets-partial");
+    mkdirSync(join(partial, "profiles", "default"), { recursive: true });
+    await freshServer(partial);
+    const resp = await hostdRequest(
+      { socketPath: adminSock() },
+      { v: 1, op: "update_apply", request_id: "pf-partial", args: {} },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toContain(join(partial, "vendor", "hindsight-memory"));
+    expect(resp.error).not.toContain(join(partial, "profiles") + ",");
+  });
+});


### PR DESCRIPTION
## Summary

Makes the operator's intended flow reliable: **admin agent fires `/update apply` from Telegram → hostd → operator attests → fleet updates**, with agents staying unprivileged (hostd remains the audited broker — no container ever gets host root).

**Bug:** hostd's image baked only the CLI bundle, not the apply-time assets the bundled CLI resolves *relative to itself* (`profiles.ts` → `resolve(import.meta.dirname,"../../profiles")`; `scaffold.ts` → `"../../vendor/hindsight-memory"`). So hostd's `switchroom apply` died `Profile not found: default (searched /opt/switchroom/profiles)` **after `pull-images`, before `recreate-containers`** — the whole fleet stranded on the old image, the agent turn wedged. (Agent images deliberately don't bake these either — agents never run apply; hostd is the one container that does.)

- **Part 1 — `docker/Dockerfile.hostd`:** `COPY profiles/ /opt/switchroom/profiles/` + `COPY vendor/hindsight-memory/ /opt/switchroom/vendor/hindsight-memory/` — exactly the paths the bundled CLI computes at runtime. hostd's in-container apply now behaves like host-side.
- **Part 2 — `src/host-control/server.ts`:** `applyAssetPreflight()` in `handleUpdateApply` + `handleApply` — refuses with a clear actionable `denied` **before pull or any state change** if assets are missing (same fail-fast principle as the `--rebuild` guard). Converts silent-pull-then-strand into a clean refusal and future-proofs the per-asset fragility. `applyAssetsRoot` test seam.

## Test plan

- [x] 4 new preflight tests (refuse-on-missing for update_apply *and* apply, nothing spawned; proceed-when-present; partial-gap names the missing asset) + 39/39 hostd-server tests, 132/132 hostd suite
- [x] `tsc --noEmit` clean; build ok; COPY targets byte-match the CLI's runtime resolution (reviewer empirically verified the bundle preserves `import.meta.dirname`)
- [x] Scope = 3 files; no change to verb ACL / admin gating / fleet-mutation lock / audit / spawn path
- [x] Independent fresh-process review → **APPROVE**
- [ ] Post-release: rebuild+publish `switchroom-hostd` GHCR image, refresh hostd on host, **live-verify** admin `/update apply` from Telegram end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)