### PR TITLE
feat(gateway): deterministic in-flight status for hostd update_apply (klanker incident)

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -102,7 +102,10 @@ ALLOWLIST=(
   # Re-bumped 2026-05-15 for #1308 folder-picker handler integration.
   # Re-bumped 2026-05-15 for RFC E §4.2 PR-2C drive PreToolUse hook
   # (#1319) — added ~2 more lines above this block.
-  "telegram-plugin/gateway/gateway.ts:2695-3000:permission-request keyboard; no thread_id"
+  # End 3000 -> 3010: feat/hostd-deterministic-status inserted the
+  # inFlightUpdate var + the silence-fallback update-status branch
+  # above this block; the permission-keyboard raw send moved to 3002.
+  "telegram-plugin/gateway/gateway.ts:2695-3010:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
   # The caller dropped the thread; this raw sendMessage retries on the
@@ -124,7 +127,9 @@ ALLOWLIST=(
   # sendChunkPlainText raw send (~3498) is the SAME intentional-raw
   # rationale — a terminal last-resort resend that must not re-enter
   # the retry/parse-mode policy that just rejected the payload.
-  "telegram-plugin/gateway/gateway.ts:3160-3540:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
+  # End 3540 -> 3580: same insertion shifted the chunk-loop fallback
+  # raw sends to 3545/3566.
+  "telegram-plugin/gateway/gateway.ts:3160-3580:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -158,7 +163,9 @@ ALLOWLIST=(
   # editMessageText to 10358/10382 (past 10340). New ceiling stops before
   # executeGrantWizard (10408); inserted code uses listViaBroker (not a
   # raw bot.api call), so the wider span adds no un-allowlisted call.
-  "telegram-plugin/gateway/gateway.ts:9340-10400:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # End 10400 -> 10430: same insertion shifted the vault-wizard
+  # editMessageText callsite to 10422.
+  "telegram-plugin/gateway/gateway.ts:9340-10430:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -233,9 +233,11 @@ import {
   hostdRequestId,
   hostdWillBeUsed,
   pollHostdStatus,
+  hostdGetStatusOnce,
   warnLegacySpawnIfHostdDisabled,
   _resetHostdEnabledCache,
 } from './hostd-dispatch.js'
+import { formatUpdateStatusLine } from './update-status-line.js'
 import type { HostdRequest } from '../../src/host-control/protocol.js'
 import type { AgentAudit } from '../welcome-text.js'
 import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
@@ -2567,22 +2569,50 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
 // the framework itself sends a user-visible "still working… / still
 // thinking…" message. Honours SWITCHROOM_DISABLE_SILENCE_POKE=1 kill
 // switch (no-op if set).
+// Set when this gateway dispatches an `update_apply` to hostd that
+// returns `started`; cleared when the dispatch poll resolves (terminal
+// / not-configured / timeout). While set, the framework silence
+// fallback substitutes hostd's real phase + elapsed for the generic
+// "still working…" text — deterministic, model-free, the klanker
+// incident fix. In-memory only; a gateway recreate naturally resets it.
+let inFlightUpdate: { requestId: string; startedAt: number } | null = null
+
 silencePoke.startTimer({
   emitMetric: (event) => {
     // Re-emit through the unified runtime-metrics fan-out (PostHog + JSONL).
     emitRuntimeMetric(event)
   },
   onFrameworkFallback: async (ctx) => {
-    // Wording is load-bearing — extracted to `formatFrameworkFallbackText`
-    // in `silence-poke.ts` so it can be snapshot-tested in isolation
-    // (CC-4 in `docs/status-ask-cause-classes.md`). Derives "N min" suffix
-    // from `ctx.silenceMs` so the wording stays honest if the 300s
-    // threshold is tuned.
-    const text = silencePoke.formatFrameworkFallbackText(
-      ctx.fallbackKind,
-      ctx.silenceMs,
-      ctx.inFlightTools,
-    )
+    // Deterministic in-flight update status (klanker incident). If this
+    // gateway dispatched an update_apply that's still running, the
+    // recurring framework fallback carries hostd's REAL phase + elapsed
+    // instead of the content-free "still working…". No model: pure
+    // get_status snapshot → pure formatter. Any hostd unavailability
+    // degrades silently to the existing generic text (zero regression).
+    let text: string | null = null
+    const upd = inFlightUpdate
+    if (upd != null) {
+      try {
+        const st = await hostdGetStatusOnce(getMyAgentName(), upd.requestId)
+        if (st !== 'not-configured' && st !== 'unavailable') {
+          text = formatUpdateStatusLine(st, upd.startedAt, Date.now())
+        }
+      } catch {
+        /* degrade to generic fallback below */
+      }
+    }
+    if (text == null) {
+      // Wording is load-bearing — extracted to `formatFrameworkFallbackText`
+      // in `silence-poke.ts` so it can be snapshot-tested in isolation
+      // (CC-4 in `docs/status-ask-cause-classes.md`). Derives "N min" suffix
+      // from `ctx.silenceMs` so the wording stays honest if the 300s
+      // threshold is tuned.
+      text = silencePoke.formatFrameworkFallbackText(
+        ctx.fallbackKind,
+        ctx.silenceMs,
+        ctx.inFlightTools,
+      )
+    }
     try {
       await robustApiCall(
         () => bot.api.sendMessage(ctx.chatId, text, {
@@ -8594,6 +8624,10 @@ bot.command('update', async ctx => {
     return
   }
   if (hostdResp.result === 'started') {
+    // Mark in-flight so the framework silence fallback renders hostd's
+    // real phase + elapsed (deterministic, model-free) instead of the
+    // content-free "still working…" — the klanker incident fix.
+    inFlightUpdate = { requestId: updateRequestId, startedAt: Date.now() }
     // RFC C §5.3: long-running mutation. Poll get_status until terminal
     // or until the recreate kills this gateway (whichever happens first).
     // The success signal is the post-restart greeting card edited into
@@ -8602,6 +8636,7 @@ bot.command('update', async ctx => {
     // doesn't leave the operator staring at the orphan "🚀 update started"
     // ack indefinitely. Live repro: PR #1305.
     void (async () => {
+     try {
       // 60s budget: RFC C §5.3 specs `apply` at 30s and `update_apply`
       // at 60s. Image pulls + scaffold regeneration dominate the wall
       // clock for update_apply, hence the larger budget. The poll
@@ -8648,6 +8683,11 @@ bot.command('update', async ctx => {
           await switchroomReply(ctx, editedText, { html: true })
         } catch {}
       }
+     } finally {
+       // Poll resolved (terminal / completed / not-configured /
+       // timeout) — stop substituting in-flight update status.
+       inFlightUpdate = null
+     }
     })()
     return
   }

--- a/telegram-plugin/gateway/hostd-dispatch.ts
+++ b/telegram-plugin/gateway/hostd-dispatch.ts
@@ -125,6 +125,44 @@ export function hostdRequestId(prefix: string): string {
 }
 
 /**
+ * Single-shot `get_status` snapshot for `targetRequestId` (NOT a
+ * poll-until-terminal — {@link pollHostdStatus} does that). Used by
+ * the framework silence-fallback to render a deterministic in-flight
+ * status line. Returns `"not-configured"` (hostd off / socket absent)
+ * or `"unavailable"` (wire error / hostd couldn't answer) so the
+ * caller can cleanly fall back to the generic fallback text — never
+ * throws, never blocks the fallback.
+ */
+export async function hostdGetStatusOnce(
+  agentName: string,
+  targetRequestId: string,
+): Promise<HostdResponse | "not-configured" | "unavailable"> {
+  if (!isHostdEnabled()) return "not-configured";
+  const sockPath = hostdSocketPath(agentName);
+  if (!existsSync(sockPath)) return "not-configured";
+  try {
+    const resp = await hostdRequest(
+      { socketPath: sockPath, timeoutMs: 3000 },
+      {
+        v: 1,
+        op: "get_status",
+        request_id: hostdRequestId("gw-poke-status"),
+        args: { target_request_id: targetRequestId },
+      },
+    );
+    // hostd answered but couldn't resolve the entry → treat as
+    // unavailable so we degrade to the generic fallback, not a
+    // confusing "error" status line.
+    if (resp.result === "denied" || resp.result === "error") {
+      return "unavailable";
+    }
+    return resp;
+  } catch {
+    return "unavailable";
+  }
+}
+
+/**
  * Poll hostd's `get_status` verb until the target request reaches a
  * terminal state (`completed` / `error` / `denied`) or the caller's
  * timeout elapses.

--- a/telegram-plugin/gateway/update-status-line.ts
+++ b/telegram-plugin/gateway/update-status-line.ts
@@ -1,0 +1,61 @@
+/**
+ * Deterministic, model-free status line for an in-flight hostd
+ * `update_apply`. Pure function over hostd's `get_status` response —
+ * no model, no I/O. Used by the gateway's framework silence-fallback
+ * so the recurring "is it still going?" message carries hostd's
+ * actual phase + elapsed instead of the content-free
+ * "still working… no update from agent in N min" (the klanker
+ * incident: a multi-minute fleet update with zero visible status).
+ *
+ * The hostd CLI prints step banners as `▸ <step>` lines (pull-images,
+ * apply-config, recreate-containers, doctor, …) into stdout; hostd
+ * surfaces the last 4 KiB as `stdout_tail`. The phase is the LAST such
+ * banner — a deterministic string parse, no interpretation.
+ */
+
+export interface UpdateStatusResponse {
+  result: string;
+  stdout_tail?: string;
+  stderr_tail?: string;
+}
+
+/** Latest `▸ <step>` banner in the tail, or null if none yet. */
+export function latestHostdPhase(tail: string | undefined): string | null {
+  if (!tail) return null;
+  let phase: string | null = null;
+  for (const raw of tail.split("\n")) {
+    const m = /^\s*▸\s*(.+?)\s*$/.exec(raw);
+    if (m && m[1]) phase = m[1];
+  }
+  return phase;
+}
+
+function elapsedMin(startedAt: number, now: number): number {
+  return Math.max(1, Math.round((now - startedAt) / 60_000));
+}
+
+/**
+ * Compose the deterministic status line. `resp` is hostd's get_status
+ * for the in-flight update_apply; `startedAt` is when the gateway
+ * dispatched it; `now` is the current time.
+ */
+export function formatUpdateStatusLine(
+  resp: UpdateStatusResponse,
+  startedAt: number,
+  now: number,
+): string {
+  const mins = elapsedMin(startedAt, now);
+  const tail = `Recreating the fleet (including me) — I'll report the result here when it's done.`;
+
+  // Terminal-but-gateway-still-alive: recreate hasn't killed us yet, or
+  // it failed before recreate. The dedicated terminal/boot path owns the
+  // final verdict; here we just stop claiming "in progress".
+  if (resp.result !== "started") {
+    return `⏳ Fleet update finishing — hostd reported \`${resp.result}\` (~${mins}m). ${tail}`;
+  }
+
+  const phase = latestHostdPhase(resp.stdout_tail);
+  return phase
+    ? `⏳ Fleet update in progress — phase: ${phase} (~${mins}m). ${tail}`
+    : `⏳ Fleet update in progress — starting (~${mins}m). ${tail}`;
+}

--- a/telegram-plugin/tests/update-status-line.test.ts
+++ b/telegram-plugin/tests/update-status-line.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import {
+  latestHostdPhase,
+  formatUpdateStatusLine,
+} from '../gateway/update-status-line.js'
+
+const T0 = 1_000_000_000_000
+
+describe('latestHostdPhase', () => {
+  it('returns null for empty / no-banner tail', () => {
+    expect(latestHostdPhase(undefined)).toBeNull()
+    expect(latestHostdPhase('')).toBeNull()
+    expect(latestHostdPhase('Applying switchroom config...\nWrote compose')).toBeNull()
+  })
+
+  it('returns the LAST ▸ banner (deterministic, last wins)', () => {
+    const tail =
+      '▸ pull-images\n some docker output\n▸ apply-config\n▸ recreate-containers\n'
+    expect(latestHostdPhase(tail)).toBe('recreate-containers')
+  })
+
+  it('tolerates leading/trailing whitespace around the banner', () => {
+    expect(latestHostdPhase('  ▸   doctor   \n')).toBe('doctor')
+  })
+})
+
+describe('formatUpdateStatusLine', () => {
+  it('in-progress with a phase: shows phase + elapsed + report-back tail', () => {
+    const line = formatUpdateStatusLine(
+      { result: 'started', stdout_tail: '▸ pull-images\n▸ apply-config\n' },
+      T0,
+      T0 + 2 * 60_000 + 5_000, // ~2m
+    )
+    expect(line).toContain('Fleet update in progress')
+    expect(line).toContain('phase: apply-config')
+    expect(line).toContain('~2m')
+    expect(line).toMatch(/report the result here/i)
+    expect(line).not.toMatch(/still working|no update from agent/i)
+  })
+
+  it('in-progress before any banner: "starting"', () => {
+    const line = formatUpdateStatusLine(
+      { result: 'started', stdout_tail: 'Image ... Pulling' },
+      T0,
+      T0 + 30_000,
+    )
+    expect(line).toContain('Fleet update in progress')
+    expect(line).toContain('starting')
+    expect(line).not.toContain('phase:')
+    expect(line).toContain('~1m') // min 1m floor
+  })
+
+  it('elapsed rounds to nearest minute, floored at 1', () => {
+    expect(formatUpdateStatusLine({ result: 'started' }, T0, T0 + 5_000)).toContain('~1m')
+    expect(
+      formatUpdateStatusLine({ result: 'started' }, T0, T0 + 7 * 60_000 + 40_000),
+    ).toContain('~8m')
+  })
+
+  it('terminal-but-gateway-alive: stops claiming in-progress, defers to verdict path', () => {
+    const line = formatUpdateStatusLine(
+      { result: 'error', stderr_tail: 'boom' },
+      T0,
+      T0 + 3 * 60_000,
+    )
+    expect(line).toContain('finishing')
+    expect(line).toContain('`error`')
+    expect(line).not.toContain('in progress')
+  })
+})


### PR DESCRIPTION
## Summary

Closes the visibility half of the klanker incident. An admin agent's `/update apply` runs async in hostd for minutes and **recreates the requesting agent itself** — the user saw only the content-free framework backstop ("still working… no update from agent in N min") and had to keep asking "Status??". Violated the `know-what-my-agent-is-doing` JTBD + Visibility outcome.

**Deterministic, model-free, reuses existing surfaces** (operator/CPO requirement — the model is wedged/dead during the op so it cannot reliably narrate):
- `update-status-line.ts` (new, **pure**) — parse hostd's last `▸ <step>` banner from `get_status` `stdout_tail` + elapsed → a real status line. No I/O, time injected.
- `hostd-dispatch.ts` — `hostdGetStatusOnce()`: single-shot snapshot; never throws; returns `not-configured`/`unavailable` so callers degrade cleanly.
- `gateway.ts` — record `inFlightUpdate{requestId,startedAt}` when hostd returns `started`; cleared via `try/finally` on **every** poll-resolve path. The **existing** silence-fallback, when an update is in flight, substitutes hostd's real phase+elapsed; any hostd unavailability degrades **byte-identically** to the prior generic text. `silence-poke.ts` untouched; send + wedged-turn cleanup unchanged.

The post-recreate **terminal verdict already exists** (`updateOutcomeLine`/`update-announce`, "PR C") — deliberately not duplicated; the formatter's terminal branch is a brief "finishing…" that defers to it.

This is the *existing* backstop message content-upgraded — not a new card/widget — so "chat IS the artifact" holds; the framework-status exception is the safety-net role `principles.md` explicitly carves out (model physically dead during self-recreate).

## Test plan

- [x] 7 pure-formatter tests (phase last-wins, no-phase→starting, elapsed round/floor, terminal-defer, whitespace, negative "not still-working")
- [x] 52 silence-poke regression (file unmodified) + 23 hostd-dispatch green; tsc 0 errors; build ok
- [x] Independent fresh-process review → **APPROVE** (stale-state lifecycle + zero-regression verified byte-exact; `silence-poke.ts` diff empty)
- [ ] Post-release: ships in the agent GHCR image (gateway = agent sidecar); refresh fleet; live-verify the in-flight line + existing terminal verdict appear deterministically

🤖 Generated with [Claude Code](https://claude.com/claude-code)