### PR TITLE
fix(scaffold): admin agents get the admin CLAUDE.md branch (klanker incident)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1619,6 +1619,16 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     botToken: resolvedBotToken ?? rawBotToken,
     forumChatId: telegramConfig.forum_chat_id,
     dangerousMode: agentConfig.dangerous_mode === true,
+    // `{{#if admin}}` in CLAUDE.md.hbs (the "Admin operations" section)
+    // keys off this. MUST mirror the reconcile path's claudeContext
+    // (~scaffold.ts `admin: agentConfig.admin === true`). It was
+    // missing here, so the `switchroom apply` / scaffoldAgent render
+    // (which uses THIS context) always rendered the non-admin
+    // `{{else}}` branch — every admin agent's CLAUDE.md told it "you
+    // are NOT admin, hand fleet ops off", the klanker incident. The
+    // two render sites diverging on exactly this field is the hazard
+    // the comment at the reconcile site warns about.
+    admin: agentConfig.admin === true,
     useSwitchroomPlugin: usesSwitchroomTelegramPlugin(agentConfig),
     useHotReloadStable: agentConfig.channels?.telegram?.hotReloadStable === true,
     // PR C: surface channels.telegram.enabled into start.sh as a literal

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -74,6 +74,24 @@ describe("scaffoldAgent", () => {
     expect(soulMd).toContain("not a doctor");
   });
 
+  it("admin:true agent gets the admin branch in CLAUDE.md (klanker incident regression)", () => {
+    // buildWorkspaceContext omitted `admin`, so scaffoldAgent (the
+    // `switchroom apply` render path) always rendered the non-admin
+    // `{{else}}` branch — admin agents were told "you are NOT admin".
+    const adminCfg = makeAgentConfig({ extends: "default", admin: true });
+    const a = scaffoldAgent("admin-agent", adminCfg, tmpDir, telegramConfig);
+    const adminMd = readFileSync(join(a.agentDir, "CLAUDE.md"), "utf-8");
+    expect(adminMd).toMatch(/Fleet operations live on the `hostd`/);
+    expect(adminMd).toContain("update_apply");
+    expect(adminMd).not.toMatch(/You're NOT `admin: true`/);
+
+    const plainCfg = makeAgentConfig({ extends: "default" });
+    const p = scaffoldAgent("plain-agent", plainCfg, tmpDir, telegramConfig);
+    const plainMd = readFileSync(join(p.agentDir, "CLAUDE.md"), "utf-8");
+    expect(plainMd).toMatch(/You're NOT `admin: true`/);
+    expect(plainMd).not.toMatch(/Fleet operations live on the `hostd`/);
+  });
+
   it("generates start.sh with correct env vars", () => {
     const config = makeAgentConfig({ topic_id: 42 });
     const result = scaffoldAgent("my-agent", config, tmpDir, telegramConfig);


### PR DESCRIPTION
## Summary

Validated production bug. `profiles/default/CLAUDE.md.hbs` gates its "Admin operations" section on `{{#if admin}}`. There are two CLAUDE.md render sites in `scaffold.ts`: the **reconcile** path correctly set `admin` in its context; the **scaffoldAgent** path — used by `switchroom apply` / `update_apply` / `agent restart→reconcile` — renders with `buildWorkspaceContext()` (scaffold.ts:1579) which **omitted `admin`**. So on the apply path `{{#if admin}}` was always falsy: **every admin agent's switchroom-managed CLAUDE.md rendered the non-admin `{{else}}` branch** ("You're NOT `admin: true` … hand fleet ops to a peer"), and it never self-heals (fresh render == stale file → apply reports "up to date").

Confirmed live: klanker is `admin:true` (switchroom.yaml + `config get`), but its `/state/agent/CLAUDE.md` had the non-admin branch — so the admin agent was told by its own protocol file it is **not** admin, directly defeating the in-Telegram admin fleet-ops this work has been hardening.

**Fix (one line):** add `admin: agentConfig.admin === true` to `buildWorkspaceContext()`'s return, character-identical to the reconcile site — single source, both sites now agree (the divergence the reconcile site's own comment warned about). + a regression test (admin cfg → admin branch; plain cfg → else branch) that reproduces the incident when the line is reverted.

Once shipped, klanker's CLAUDE.md self-heals on the next `apply` (fresh render = admin branch ≠ stale non-admin → rewritten).

## Test plan

- [x] 176 scaffold tests green incl. new regression (empirically verified it fails pre-fix)
- [x] tsc 0 errors; build ok; scope = 2 files; reconcile path / fingerprint-rerender / start.sh / settings untouched (no other .hbs references `admin`)
- [x] Independent fresh-process review → **APPROVE** (complete for scope; empirically verified regression guard)
- [ ] Post-release: bump host CLI, `switchroom apply`, **live-verify** klanker `/state/agent/CLAUDE.md` flips to the admin branch (non-admin agent stays non-admin)

Non-blocking follow-up: only the `default` profile has the `{{#if admin}}` section; `coding`/`executive-assistant`/`health-coach` profiles have no admin branch at all — separate pre-existing gap (klanker is on `default`, fully fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)