### PR TITLE
fix(memory): tolerate stateless Hindsight MCP (no mcp-session-id)

### DIFF
--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -294,10 +294,16 @@ export async function ensureUserProfileMentalModel(
       return { ok: false, reason: `HTTP ${initResponse.status}` };
     }
 
+    // Hindsight MCP is stateless by design and does not issue an
+    // mcp-session-id; the MCP spec makes that header optional. Forward
+    // it only when a stateful server actually returns one. Hard-failing
+    // on its absence silently broke every scaffold memory-onboarding op
+    // (bank create / mission / mental model) fleet-wide against the
+    // stateless Hindsight server.
     const sessionId = initResponse.headers.get("mcp-session-id");
-    if (!sessionId) {
-      return { ok: false, reason: "No session ID returned" };
-    }
+    const sessionHeader: Record<string, string> = sessionId
+      ? { "mcp-session-id": sessionId }
+      : {};
 
     // Step 2: Check if MM already exists
     const timeout2 = setTimeout(() => controller.abort(), timeoutMs);
@@ -307,7 +313,7 @@ export async function ensureUserProfileMentalModel(
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
         "X-Bank-Id": bankId,
-        "mcp-session-id": sessionId,
+        ...sessionHeader,
       },
       body: JSON.stringify({
         jsonrpc: "2.0",
@@ -347,7 +353,7 @@ export async function ensureUserProfileMentalModel(
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
         "X-Bank-Id": bankId,
-        "mcp-session-id": sessionId,
+        ...sessionHeader,
       },
       body: JSON.stringify({
         jsonrpc: "2.0",
@@ -444,10 +450,16 @@ export async function createBank(
       return { ok: false, reason: `HTTP ${initResponse.status}` };
     }
 
+    // Hindsight MCP is stateless by design and does not issue an
+    // mcp-session-id; the MCP spec makes that header optional. Forward
+    // it only when a stateful server actually returns one. Hard-failing
+    // on its absence silently broke every scaffold memory-onboarding op
+    // (bank create / mission / mental model) fleet-wide against the
+    // stateless Hindsight server.
     const sessionId = initResponse.headers.get("mcp-session-id");
-    if (!sessionId) {
-      return { ok: false, reason: "No session ID returned" };
-    }
+    const sessionHeader: Record<string, string> = sessionId
+      ? { "mcp-session-id": sessionId }
+      : {};
 
     // Step 2: Call create_bank tool
     const timeout2 = setTimeout(() => controller.abort(), timeoutMs);
@@ -461,7 +473,7 @@ export async function createBank(
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
         "X-Bank-Id": bankId,
-        "mcp-session-id": sessionId,
+        ...sessionHeader,
       },
       body: JSON.stringify({
         jsonrpc: "2.0",
@@ -553,10 +565,16 @@ export async function updateBankMissions(
       return { ok: false, reason: `HTTP ${initResponse.status}` };
     }
 
+    // Hindsight MCP is stateless by design and does not issue an
+    // mcp-session-id; the MCP spec makes that header optional. Forward
+    // it only when a stateful server actually returns one. Hard-failing
+    // on its absence silently broke every scaffold memory-onboarding op
+    // (bank create / mission / mental model) fleet-wide against the
+    // stateless Hindsight server.
     const sessionId = initResponse.headers.get("mcp-session-id");
-    if (!sessionId) {
-      return { ok: false, reason: "No session ID returned" };
-    }
+    const sessionHeader: Record<string, string> = sessionId
+      ? { "mcp-session-id": sessionId }
+      : {};
 
     // Step 2: Call update_bank tool
     const timeout2 = setTimeout(() => controller.abort(), timeoutMs);
@@ -566,7 +584,7 @@ export async function updateBankMissions(
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
         "X-Bank-Id": bankId,
-        "mcp-session-id": sessionId,
+        ...sessionHeader,
       },
       body: JSON.stringify({
         jsonrpc: "2.0",
@@ -655,10 +673,16 @@ export async function addMemoryTag(
       return { ok: false, reason: `HTTP ${initResponse.status}` };
     }
 
+    // Hindsight MCP is stateless by design and does not issue an
+    // mcp-session-id; the MCP spec makes that header optional. Forward
+    // it only when a stateful server actually returns one. Hard-failing
+    // on its absence silently broke every scaffold memory-onboarding op
+    // (bank create / mission / mental model) fleet-wide against the
+    // stateless Hindsight server.
     const sessionId = initResponse.headers.get("mcp-session-id");
-    if (!sessionId) {
-      return { ok: false, reason: "No session ID returned" };
-    }
+    const sessionHeader: Record<string, string> = sessionId
+      ? { "mcp-session-id": sessionId }
+      : {};
 
     // Step 2: call update_memory with `add_tags` to append (rather than
     // replace) the tag. Hindsight's update_memory accepts an `add_tags`
@@ -673,7 +697,7 @@ export async function addMemoryTag(
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
         "X-Bank-Id": bankId,
-        "mcp-session-id": sessionId,
+        ...sessionHeader,
       },
       body: JSON.stringify({
         jsonrpc: "2.0",

--- a/tests/memory.add-memory-tag.test.ts
+++ b/tests/memory.add-memory-tag.test.ts
@@ -113,11 +113,15 @@ describe("addMemoryTag — error paths", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  it("returns error when initialize returns no session ID", async () => {
-    const mockFetch = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      headers: new Map(), // no mcp-session-id
-    } as any);
+  it("tolerates a stateless server (no mcp-session-id) and proceeds without the header", async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map(), // stateless: no mcp-session-id
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+      } as any);
     const result = await addMemoryTag(
       "http://test.local/mcp/",
       "clerk",
@@ -125,8 +129,10 @@ describe("addMemoryTag — error paths", () => {
       DEMOTE_FROM_RECALL_TAG,
       { fetchImpl: mockFetch as any },
     );
-    expect(result).toEqual({ ok: false, reason: "No session ID returned" });
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const toolHeaders = mockFetch.mock.calls[1][1].headers;
+    expect("mcp-session-id" in toolHeaders).toBe(false);
   });
 
   it("returns error when tools/call HTTP fails", async () => {

--- a/tests/memory.bank-missions.test.ts
+++ b/tests/memory.bank-missions.test.ts
@@ -155,11 +155,15 @@ describe("updateBankMissions", () => {
     expect(result.reason).toBe("Timeout");
   });
 
-  it("returns error when no session ID returned", async () => {
-    const mockFetch = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      headers: new Map(), // No session ID
-    } as any);
+  it("tolerates a stateless server (no mcp-session-id) and proceeds without the header", async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map(), // stateless: no mcp-session-id
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+      } as any);
 
     const result = await updateBankMissions(
       "http://test.local/mcp/",
@@ -168,7 +172,10 @@ describe("updateBankMissions", () => {
       { fetchImpl: mockFetch as any }
     );
 
-    expect(result).toEqual({ ok: false, reason: "No session ID returned" });
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const toolHeaders = mockFetch.mock.calls[1][1].headers;
+    expect("mcp-session-id" in toolHeaders).toBe(false);
   });
 
   it("returns error on network failure", async () => {

--- a/tests/memory.create-bank.test.ts
+++ b/tests/memory.create-bank.test.ts
@@ -184,11 +184,18 @@ describe("createBank", () => {
     expect(result).toEqual({ ok: false, reason: "Timeout" });
   });
 
-  it("returns error when no session ID returned", async () => {
-    const mockFetch = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      headers: new Map(), // no mcp-session-id
-    } as any);
+  it("tolerates a stateless server (no mcp-session-id) and proceeds without the header", async () => {
+    // Hindsight MCP is stateless by design — initialize returns no
+    // mcp-session-id. The client must NOT hard-fail; it should proceed
+    // and omit the header on the follow-up tool call.
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map(), // stateless: no mcp-session-id
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+      } as any);
 
     const result = await createBank(
       "http://test.local/mcp/",
@@ -196,6 +203,10 @@ describe("createBank", () => {
       { fetchImpl: mockFetch as any }
     );
 
-    expect(result).toEqual({ ok: false, reason: "No session ID returned" });
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const toolHeaders = mockFetch.mock.calls[1][1].headers;
+    expect("mcp-session-id" in toolHeaders).toBe(false);
+    expect(toolHeaders["X-Bank-Id"]).toBe("test-bank");
   });
 });


### PR DESCRIPTION
## Summary

Hindsight MCP runs **stateless by design** (verified live: `hindsight-mcp-server` v0.6.2 returns a valid `initialize` result but **no `mcp-session-id` header**; the MCP spec makes that header optional, and tool calls succeed statelessly). All four scaffold memory-onboarding paths in `src/memory/hindsight.ts` — `createBank`, `ensureUserProfileMentalModel`, `updateBankMissions`, `addMemoryTag` — hard-failed with `"No session ID returned"` whenever the header was absent.

Impact: **fleet-wide**. Every `switchroom apply` / `agent reconcile` against a stateless Hindsight deployment silently failed to create the per-agent bank, bank mission, and user-profile mental model (`⚠ Failed to create Hindsight bank for <agent>: No session ID returned` for all agents). Latent since the stateless Hindsight container came up.

## Change

- Forward `mcp-session-id` on follow-up requests **only when** a stateful server actually returns one; otherwise proceed without it. Never hard-fail on its absence.
- This keeps the **stateful** path working unchanged (header still forwarded when present) and makes the **stateless** path correct.
- Aligns with Hindsight's deliberate stateless design (do not flip it stateful — that would silently break `retain` fleet-wide on every MCP reconnect).

## Test plan

- [x] Rewrote the 3 regression tests that asserted the old hard-fail (`create-bank`, `bank-missions`, `add-memory-tag`) to assert stateless tolerance: proceeds, succeeds, and the follow-up tool call carries **no** `mcp-session-id` header.
- [x] Unchanged stateful happy-path tests still pass (header forwarded when the server provides one).
- [x] `npx vitest run tests/memory.*.test.ts` → **34/34 pass**.
- [x] Type-clean (`tsc`) for `src/memory` + memory tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)