### PR TITLE
feat(hostd,telegram): /doctor whole-fleet option for admin agents

### DIFF
--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -24,6 +24,12 @@
  * underlying `switchroom reconcile` CLI verb exists; `apply` covers
  * the intent.
  *
+ * Phase 3 (#1175 RFC §10) adds `agent_logs` / `agent_exec` (admin
+ * observability). Phase 3.1 (this PR) adds:
+ *   - `doctor`        (read-only host-side `switchroom doctor` →
+ *                       full-fleet health; same posture as
+ *                       `update_check`)
+ *
  * See docs/rfcs/host-control-daemon.md for the full verb table and
  * trust posture.
  */
@@ -202,6 +208,23 @@ export const AgentExecRequestSchema = z.object({
   }),
 });
 
+// ─── Phase 3.1 verb — read-only fleet doctor (this PR) ────────────────────
+//
+// `switchroom doctor` run host-side, where the docker socket is
+// present, so it produces the *full fleet* health view (containers,
+// singletons, image/CLI ages) instead of the degraded in-container
+// reading an agent gets when it shells `switchroom doctor` itself
+// (no docker socket in the agent container). Read-only — same trust
+// posture as `update_check`/`upgrade_status`: no fleet-mutation lock,
+// returns `completed` synchronously. Gateway only surfaces the
+// whole-fleet option on admin agents; the daemon is the audited
+// boundary regardless.
+export const DoctorRequestSchema = z.object({
+  ...RequestEnvelope,
+  op: z.literal("doctor"),
+  args: z.object({}).optional(),
+});
+
 export const RequestSchema = z.discriminatedUnion("op", [
   AgentRestartRequestSchema,
   UpgradeStatusRequestSchema,
@@ -213,6 +236,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   AgentStopRequestSchema,
   AgentLogsRequestSchema,
   AgentExecRequestSchema,
+  DoctorRequestSchema,
 ]);
 
 export type AgentRestartRequest = z.infer<typeof AgentRestartRequestSchema>;
@@ -225,6 +249,7 @@ export type AgentStartRequest = z.infer<typeof AgentStartRequestSchema>;
 export type AgentStopRequest = z.infer<typeof AgentStopRequestSchema>;
 export type AgentLogsRequest = z.infer<typeof AgentLogsRequestSchema>;
 export type AgentExecRequest = z.infer<typeof AgentExecRequestSchema>;
+export type DoctorRequest = z.infer<typeof DoctorRequestSchema>;
 export type HostdRequest = z.infer<typeof RequestSchema>;
 
 /** All verb names that pass discriminated-union validation. New verbs

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -519,6 +519,10 @@ export class HostdServer {
         case "agent_exec":
           resp = await this.handleAgentExec(req, started);
           break;
+        // ── Phase 3.1 read-only fleet doctor ─────────────────────
+        case "doctor":
+          resp = await this.handleDoctor(req, started);
+          break;
       }
     } catch (err) {
       resp = errorResponse(
@@ -610,6 +614,18 @@ export class HostdServer {
         return callerAdmin
           ? null
           : `${req.op} cross-agent requires admin: true on caller "${caller.name}"`;
+      case "doctor":
+        // Read-only, but whole-fleet: running `switchroom doctor`
+        // host-side enumerates every agent + singleton's health —
+        // broader exposure than update_check's version/plan view, so
+        // gate it to admin (no operator-attest / fleet-mutation lock;
+        // it changes nothing). The gateway only surfaces the
+        // whole-fleet option on admin agents, but the daemon is the
+        // enforced boundary. Operator (kind === "operator") already
+        // returned null at the top of this method.
+        return callerAdmin
+          ? null
+          : `doctor requires admin: true on caller "${caller.name}"`;
     }
   }
 
@@ -693,6 +709,37 @@ export class HostdServer {
       v: 1,
       request_id: req.request_id,
       result,
+      exit_code: res.exit_code,
+      duration_ms: Date.now() - started,
+      stdout_tail: tail(res.stdout),
+      stderr_tail: tail(res.stderr),
+    };
+  }
+
+  /**
+   * Read-only: `switchroom doctor` run host-side, where the docker
+   * socket is present, so it reports the FULL fleet (containers,
+   * singletons, image/CLI ages) instead of the degraded in-container
+   * view an agent gets when it shells `switchroom doctor` itself.
+   *
+   * Unlike update_check this is `completed` whenever the process ran,
+   * regardless of exit code: `switchroom doctor` exits 1 when it
+   * finds failing checks (a degraded fleet) — that's a *finding*, not
+   * a verb-dispatch failure, and the report on stdout is exactly what
+   * the operator wants surfaced. exit_code is carried through so the
+   * caller can still see "doctor found problems". A genuine spawn
+   * failure (CLI missing, OOM) throws and is caught upstream as
+   * `error`.
+   */
+  private async handleDoctor(
+    req: Extract<HostdRequest, { op: "doctor" }>,
+    started: number,
+  ): Promise<HostdResponse> {
+    const res = await this.runSwitchroom(["doctor"]);
+    return {
+      v: 1,
+      request_id: req.request_id,
+      result: "completed",
       exit_code: res.exit_code,
       duration_ms: Date.now() - started,
       stdout_tail: tail(res.stdout),

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -11652,16 +11652,81 @@ bot.command('usage', async ctx => {
   await switchroomReply(ctx, formatQuotaBlock(result.data), { html: true })
 })
 
+// Two-button scope picker shown to admin agents (when hostd is
+// reachable) so the operator can run doctor for the WHOLE FLEET
+// (host-side via hostd — has the docker socket) or just THIS agent
+// (in-container, degraded). callback_data is tiny (`dr:fleet` /
+// `dr:self`) — well within Telegram's 64-byte limit.
+function buildDoctorScopeKeyboard(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text('🩺 Whole fleet', 'dr:fleet')
+    .text('🩺 This agent', 'dr:self')
+}
+
+// Shared report prettifier: ANSI-strip + status-glyph swap + pre block.
+// Identical rendering for the in-container and the hostd fleet report.
+function formatDoctorReport(raw: string): string {
+  const trimmed = stripAnsi(raw).trim()
+  if (!trimmed) return 'doctor: no output'
+  const pretty = trimmed
+    .replace(/^( *)✓ /gm, '$1🟢 ')
+    .replace(/^( *)✗ /gm, '$1🔴 ')
+    .replace(/^( *)! /gm, '$1🟡 ')
+  return preBlock(formatSwitchroomOutput(pretty))
+}
+
+// In-container `switchroom doctor` — this agent's own (degraded: no
+// docker socket) view. The original /doctor behaviour, unchanged.
+async function renderSelfDoctor(ctx: Context): Promise<void> {
+  let output: string
+  try { output = switchroomExecCombined(['doctor'], 30000) }
+  catch (err: unknown) { output = (err as any).stdout ?? (err as any).message ?? 'doctor failed' }
+  await switchroomReply(ctx, formatDoctorReport(output), { html: true })
+}
+
+// Whole-fleet `switchroom doctor` via hostd: it runs host-side where
+// the docker socket exists, so it sees every container + singleton
+// instead of the degraded in-container reading. Read-only verb; the
+// daemon independently enforces the admin gate (path-as-identity), so
+// this is the audited boundary even though the gateway only offers
+// the button to admin agents.
+async function renderFleetDoctor(ctx: Context): Promise<void> {
+  const resp = await tryHostdDispatch(getMyAgentName(), {
+    v: 1,
+    op: 'doctor',
+    request_id: hostdRequestId('gw-doctor'),
+  })
+  if (resp === 'not-configured') {
+    await switchroomReply(ctx, '🩺 Whole-fleet doctor needs hostd, which isn’t configured here — showing this agent instead.', { html: true })
+    await renderSelfDoctor(ctx)
+    return
+  }
+  if (resp.result === 'denied') {
+    await switchroomReply(ctx, `🩺 <b>Whole-fleet doctor denied by hostd:</b>\n${preBlock(formatSwitchroomOutput(resp.error ?? 'admin required'))}`, { html: true })
+    return
+  }
+  // `completed` (including `switchroom doctor` exit 1 = "found
+  // problems", which the handler classifies as completed) or `error`:
+  // the report on stdout (or the error text) is exactly what the
+  // operator wants surfaced.
+  const body = resp.stdout_tail?.trim() || resp.error || '(no output from hostd doctor)'
+  await switchroomReply(ctx, formatDoctorReport(body), { html: true })
+}
+
 bot.command('doctor', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   try {
-    let output: string
-    try { output = switchroomExecCombined(['doctor'], 30000) }
-    catch (err: unknown) { output = (err as any).stdout ?? (err as any).message ?? 'doctor failed' }
-    const trimmed = stripAnsi(output).trim()
-    if (!trimmed) { await switchroomReply(ctx, 'doctor: no output'); return }
-    const pretty = trimmed.replace(/^( *)✓ /gm, '$1🟢 ').replace(/^( *)✗ /gm, '$1🔴 ').replace(/^( *)! /gm, '$1🟡 ')
-    await switchroomReply(ctx, preBlock(formatSwitchroomOutput(pretty)), { html: true })
+    // Admin agents with hostd reachable choose scope (one tap, no
+    // approval card — doctor is read-only). Everyone else keeps the
+    // original zero-extra-tap in-container behaviour.
+    if (AGENT_ADMIN && hostdWillBeUsed(getMyAgentName())) {
+      await switchroomReply(ctx, '🩺 <b>Doctor</b> — which scope?', {
+        html: true,
+        reply_markup: buildDoctorScopeKeyboard(),
+      })
+      return
+    }
+    await renderSelfDoctor(ctx)
   } catch (err: unknown) {
     await switchroomReply(ctx, `<b>doctor failed:</b>\n${preBlock(formatSwitchroomOutput((err as any).message ?? 'unknown error'))}`, { html: true })
   }
@@ -11817,6 +11882,30 @@ bot.on('callback_query:data', async ctx => {
   // Issue #44.
   if (data.startsWith('vd:')) {
     await handleVaultDeferCallback(ctx, data)
+    return
+  }
+
+  // dr:<scope> — /doctor scope picker (only shown to admin agents
+  // with hostd reachable). `dr:fleet` → host-side hostd `doctor`
+  // (full fleet); `dr:self` → in-container doctor. Read-only, no
+  // approval card. Same sender-auth as the /doctor command itself —
+  // every callback family must re-auth (the absence of this check
+  // was a past vulnerability class; see apv:/drvpick: notes above).
+  if (data.startsWith('dr:')) {
+    if (!isAuthorizedSender(ctx)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {})
+      return
+    }
+    const scope = data.slice(3)
+    await ctx.answerCallbackQuery({
+      text: scope === 'fleet' ? '🩺 Running fleet doctor…' : '🩺 Running doctor…',
+    }).catch(() => {})
+    try {
+      if (scope === 'fleet') await renderFleetDoctor(ctx)
+      else await renderSelfDoctor(ctx)
+    } catch (err: unknown) {
+      await switchroomReply(ctx, `<b>doctor failed:</b>\n${preBlock(formatSwitchroomOutput((err as any).message ?? 'unknown error'))}`, { html: true })
+    }
     return
   }
 

--- a/tests/host-control/protocol.test.ts
+++ b/tests/host-control/protocol.test.ts
@@ -36,6 +36,16 @@ describe("hostd protocol — framing & schema", () => {
     expect(decoded).toEqual(req);
   });
 
+  it("round-trips a doctor request without args", () => {
+    const req: HostdRequest = {
+      v: 1,
+      op: "doctor",
+      request_id: "doc-001",
+    };
+    const decoded = decodeRequest(encodeRequest(req).trimEnd());
+    expect(decoded).toEqual(req);
+  });
+
   it("round-trips a get_status request", () => {
     const req: HostdRequest = {
       v: 1,

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -441,6 +441,64 @@ describe("hostd server — Phase 2 read-only verbs", () => {
   });
 });
 
+describe("hostd server — doctor (read-only, admin-gated)", () => {
+  it("doctor: admin caller returns completed with the fleet report", async () => {
+    const sock = server
+      .getBoundPaths()
+      .find((p) => p.endsWith("/klanker/sock"))!; // klanker IS admin
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "doctor", request_id: "doc-ok" },
+    );
+    expect(resp.result).toBe("completed");
+    expect(resp.exit_code).toBe(0);
+    expect(resp.stdout_tail).toContain("stub: doctor");
+  });
+
+  it("doctor: denied for a non-admin caller (whole-fleet visibility is admin-only)", async () => {
+    const sock = server
+      .getBoundPaths()
+      .find((p) => p.endsWith("/bob/sock"))!; // bob is NOT admin
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "doctor", request_id: "doc-deny" },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/doctor requires admin/);
+  });
+
+  it("doctor: stays `completed` when `switchroom doctor` exits non-zero (findings ≠ dispatch failure)", async () => {
+    // `switchroom doctor` exits 1 when it finds failing checks — a
+    // *finding*, not a verb-dispatch failure. Unlike update_check
+    // (exit≠0 → error) the doctor verb must still return `completed`
+    // with the report + the real exit_code so the operator sees
+    // "doctor found problems" rather than an opaque error.
+    const failStub = join(tmp, "switchroom-doctorfail-stub.sh");
+    writeFileSync(failStub, `#!/bin/sh\necho "stub: $@"\necho "  2 ok · 1 warn · 1 fail"\nexit 1\n`);
+    chmodSync(failStub, 0o755);
+    await server.stop();
+    server = new (await import("../../src/host-control/server.js")).HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: failStub,
+      auditLogPath: join(tmp, "audit.log"),
+      allowNonLinux: true,
+    });
+    await server.start();
+    const sock = server
+      .getBoundPaths()
+      .find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "doctor", request_id: "doc-fail" },
+    );
+    expect(resp.result).toBe("completed");
+    expect(resp.exit_code).toBe(1);
+    expect(resp.stdout_tail).toContain("1 fail");
+  });
+});
+
 describe("hostd server — Phase 2 per-agent verbs", () => {
   it("agent_start: self-target allowed even for non-admin", async () => {
     const sock = server


### PR DESCRIPTION
## Summary

Operator ask: run `/doctor` from Telegram, and on **admin agents** offer a whole-fleet option.

Today `/doctor` shells `switchroom doctor` *inside the agent container* — which has no docker socket, so it's a degraded single-agent view.

- **New read-only hostd verb `doctor`** (`src/host-control/protocol.ts` + `server.ts`): runs `switchroom doctor` **host-side** (docker socket present) → full fleet (every container + singleton, image/CLI ages). Mirrors the `update_check` read-only proxy precedent. **Admin-gated at the daemon** — whole-fleet visibility is broader than `update_check`'s version/plan view; no fleet-mutation lock, no operator-attest (it mutates nothing). The gateway only offers the button to admin agents but the daemon is the enforced boundary (path-as-identity).
- **Classifies `completed` even when `switchroom doctor` exits 1** (it exits 1 on failing checks). That's a *finding*, not a verb-dispatch failure — the report must always be surfaced; exit_code is carried through. Deliberate, documented deviation from the strict `update_check` mirror.
- **Gateway `/doctor`** (`telegram-plugin/gateway/gateway.ts`): admin agent + hostd reachable → one-tap scope picker `[🩺 Whole fleet] [🩺 This agent]` (no approval card — read-only, per the operator's choice). Non-admin / no-hostd → original zero-extra-tap in-container behaviour, unchanged. New `dr:` callback family re-auths the sender (`isAuthorizedSender`) like every other callback family.

JTBD: *know-what-my-fleet-is-doing* — gives the operator a real fleet health view from chat without shelling into the host.

## Test plan

- [x] `tests/host-control/protocol.test.ts`: `doctor` request round-trips (no args).
- [x] `tests/host-control/server.test.ts`: admin caller → `completed` + report; non-admin caller → `denied` (`/doctor requires admin/`); stays `completed` with `exit_code:1` when doctor exits non-zero.
- [x] `npx vitest run tests/host-control/*.test.ts` → **53/53 pass**.
- [x] Type-clean (`tsc`) for changed files (only the unrelated pre-existing `@mtcute/node` UAT errors remain).
- [ ] CI green → reviewer APPROVE → auto-merge. (Deploy ships with the next release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)