### PR TITLE
fix(vault-broker): chown vault.enc back to operator after persist

### DIFF
--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -603,6 +603,30 @@ export class VaultBroker {
    * model as per-agent sockets). Mode 0600 + chown keeps anyone but
    * the host operator UID from connecting in the first place.
    */
+  /**
+   * Re-own vault.enc to the host operator UID after a broker write.
+   * The broker container is root, so saveVault → atomicWriteFileSync
+   * renames a root-owned tmp into place; without this the operator's
+   * `switchroom vault …` CLI fails EACCES on its own vault (the
+   * broker keeps working via CAP_DAC_READ_SEARCH, masking it). Same
+   * UID source + best-effort posture as the operator-socket chowns:
+   * no-op when SWITCHROOM_BROKER_OPERATOR_UID is unset (legacy/tests)
+   * or chown isn't permitted (non-docker dev / no CAP_CHOWN).
+   * `chownSync` follows the v0.7.12+ `vault.enc -> vault/vault.enc`
+   * symlink, so the underlying file is what gets re-owned.
+   */
+  private chownVaultToOperator(): void {
+    const uidStr = process.env.SWITCHROOM_BROKER_OPERATOR_UID;
+    if (uidStr === undefined) return;
+    const uid = parseInt(uidStr, 10);
+    if (!Number.isFinite(uid) || uid <= 0) return;
+    try {
+      if (existsSync(this.vaultPath)) chownSync(this.vaultPath, uid, uid);
+    } catch {
+      /* non-docker dev / no CAP_CHOWN — same posture as socket chowns */
+    }
+  }
+
   bindOperatorListener(socketPath: string, operatorUid: number): Promise<void> {
     const abs = resolve(socketPath);
     const identity = socketPathToIdentity(abs);
@@ -1582,6 +1606,16 @@ export class VaultBroker {
         );
         return;
       }
+      // Hand vault.enc back to the host operator UID. The broker runs
+      // as root, so the saveVault → atomicWriteFileSync rename above
+      // left the file root:root 0600. The broker still reads it
+      // (CAP_DAC_READ_SEARCH) which masks the breakage, but the
+      // operator's `switchroom vault …` CLI then fails EACCES — and it
+      // silently re-broke on every persist (token rotation, /vault
+      // put, auto-unlock re-persist) before this. Mirrors the
+      // socket-chown pattern; no-op on legacy/test (env unset) or
+      // non-docker dev (no CAP_CHOWN).
+      this.chownVaultToOperator();
       // Successful put — log only the key, NEVER the value. Surface the
       // auth method so audit downstream can trace which path authorized
       // the write: passphrase (operator-attested via gateway), grant


### PR DESCRIPTION
## Summary

`switchroom doctor` reported one hard **fail**: `vault: operator readable` — `~/.switchroom/vault/vault.enc` was `root:root 0600`, so the operator's `switchroom vault …` CLI failed `EACCES` on its own vault.

**Root cause (confirmed in source):** the vault-broker container runs as **root**. Its sole vault write path — `server.ts` `op:put` → `saveVault()` → `atomicWriteFileSync()` (`src/vault/vault.ts`) — writes a tmp file and `renameSync`s it into place with mode `0600` but **never chowns it**. So the persisted `vault.enc` is owned by root. The broker keeps working (it has `CAP_DAC_READ_SEARCH`), which **masks** the breakage; meanwhile the operator CLI is dead and it **silently re-broke on every persist** (OAuth token rotation, `/vault put`, auto-unlock re-persist, every broker bounce — the file's mtime tracked the last broker restart exactly). The broker already meticulously chowns its *sockets* to operator/agent UIDs (`server.ts` bind paths) — only the vault **data-file** write path was missing the equivalent.

## Fix

A `chownVaultToOperator()` helper called on the `op:put` success path: hands `vault.enc` back to `SWITCHROOM_BROKER_OPERATOR_UID` after a successful `saveVault`. Mirrors the existing operator/agent socket-chown pattern in the same file — best-effort + guarded: no-op when the UID env is unset (legacy/tests) or chown isn't permitted (non-docker dev / no `CAP_CHOWN`). `chownSync` follows the v0.7.12+ `vault.enc -> vault/vault.enc` symlink so the underlying file is re-owned.

The host was also one-time-remediated (`chown` back to operator) so the CLI works now; this fix prevents recurrence.

## Test plan

- [x] `tsc` clean for `src/vault/broker/server.ts`.
- [x] Existing vault/broker suite green (114 tests) — the new call is a guarded no-op when `SWITCHROOM_BROKER_OPERATOR_UID` is unset (the test env), so no behaviour change there.
- **Deliberately no new unit test** (calling out for reviewer scrutiny): the fix mirrors ~6 sibling best-effort `try{chownSync}catch{}` calls in this same file that are themselves untested by project convention — they no-op outside docker/root and the only observable assertion needs root or heavy `fs` mocking at the systemd-gated e2e seam. Adding bespoke fs-mock machinery here would be disproportionate and inconsistent with the file's established pattern. Flagging explicitly — if the reviewer wants coverage I'll add it.
- [ ] CI green → reviewer APPROVE → auto-merge → ships next release (broker image rebuild; live via `switchroom update`'s refresh step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)