### PR TITLE
chore: release v0.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.12.8 — operator vault CLI fix, whole-fleet /doctor, audit tamper-evidence correctness
+
+Three fixes from a `switchroom doctor` audit pass.
+
+### Changes
+
+#### Fixes
+
+- **fix(vault-broker):** the broker runs as root, so its only vault write path (`saveVault` → atomic rename) left `~/.switchroom/vault/vault.enc` `root:root 0600`. The broker keeps reading it (CAP_DAC_READ_SEARCH) which masked the breakage, but the operator's `switchroom vault …` CLI failed `EACCES` on its own vault — and it silently re-broke on every persist (token rotation, `/vault put`, auto-unlock, every broker bounce). doctor's lone hard fail. Broker now chowns `vault.enc` back to the operator UID after persist, mirroring its existing socket-chown pattern. (#1519)
+- **fix(doctor):** audit tamper-evidence (`doctor-audit-integrity`) was a false-negative on every long-lived host: it inspected only the first log row, so an append-only log's permanent pre-#1433 legacy preamble made it report "tamper-evidence inactive, run `switchroom update`" forever AND never verify the chained region (a forensically-rewritten row was undetectable — the exact WS10-F2 attack the check exists for). New `verifyAuditLog()` is segment-aware: the broker/hostd re-anchor the chain on every restart (multi-segment is normal — the live host has 6 segments / 5 restarts), so pass/fail is per-row self-consistency (`_hash == sha256(_prev∥_seq∥body)`), which never false-alarms on restarts yet still catches an in-place edit. (#1520)
+
+#### Features
+
+- **feat(hostd,telegram):** `/doctor` from Telegram now offers admin agents a one-tap scope picker — **🩺 Whole fleet** (host-side via the new read-only, admin-gated hostd `doctor` verb, so it sees every container + singleton) or **🩺 This agent** (the prior in-container view). Non-admin / no-hostd agents keep the original behaviour unchanged. No approval card — `doctor` is read-only. (#1518)
+
 ## v0.12.7 — republish of v0.12.6 (broken artifact had no dist/)
 
 `switchroom@0.12.6` was published with **no `dist/`** — the build had failed silently (the publish command piped the build through `tail`, which masked its non-zero exit) so the tarball shipped without the CLI bundle and is unusable. **Use v0.12.7.** v0.12.6 is deprecated on npm. The *code* content of v0.12.7 is identical to the intended v0.12.6 — the only delta is a correctly built artifact (verified post-publish that the tarball contains `dist/cli/switchroom.js` with the fix). No source changes vs v0.12.6.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Delta vs v0.12.7 = exactly 3 already-reviewed+merged PRs (a `switchroom doctor` audit pass):

- **#1519** fix(vault-broker): chown `vault.enc` back to operator after persist (doctor's lone hard fail — operator vault CLI was EACCES).
- **#1520** fix(doctor): segment-aware audit tamper-evidence (restored WS10-F2 detection; no false-alarm on broker restarts).
- **#1518** feat(hostd,telegram): `/doctor` whole-fleet option for admin agents.

package.json 0.12.7→0.12.8 + CHANGELOG only; no code changes in this PR.

## Test plan

- [x] All 3 PRs independently reviewer-APPROVE'd + merged with green CI.
- [x] Release delta verified: `git log v0.12.7..upstream/main` == only those 3.
- [ ] CI green → auto-merge → build (real node_modules, verify exit) → publish → **verify published tarball has dist/** → deploy via `switchroom update` (rolls broker/hostd images so the vault-chown + audit fixes go live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)