### PR TITLE
feat(doctor): add `skip` status — stop warn-fatigue from by-design noise

### DIFF
--- a/src/cli/doctor-audit-integrity.ts
+++ b/src/cli/doctor-audit-integrity.ts
@@ -31,7 +31,7 @@ import { join } from "node:path";
 
 import { verifyAuditLog } from "../util/audit-hashchain.js";
 
-export type CheckStatus = "ok" | "warn" | "fail";
+import type { CheckStatus } from "./doctor-status.js";
 
 export interface CheckResult {
   name: string;

--- a/src/cli/doctor-auth-broker.ts
+++ b/src/cli/doctor-auth-broker.ts
@@ -35,7 +35,7 @@ import { accountCredentialsPath, accountDir } from "../auth/account-store.js";
 import { resolveStatePath } from "../config/paths.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
-export type CheckStatus = "ok" | "warn" | "fail";
+import type { CheckStatus } from "./doctor-status.js";
 
 export interface CheckResult {
   name: string;
@@ -366,6 +366,7 @@ export function runAuthBrokerChecks(
     checkAuthBrokerThresholdViolations(deps),
     checkAuthBrokerActiveAccount(config, deps),
   ];
-  const rank: Record<CheckStatus, number> = { fail: 0, warn: 1, ok: 2 };
+  // skip ranks after ok — it's "not checked from here", least urgent.
+  const rank: Record<CheckStatus, number> = { fail: 0, warn: 1, ok: 2, skip: 3 };
   return [...results].sort((a, b) => rank[a.status] - rank[b.status]);
 }

--- a/src/cli/doctor-credentials-migration.ts
+++ b/src/cli/doctor-credentials-migration.ts
@@ -28,7 +28,7 @@ import { join } from "node:path";
 
 import type { SwitchroomConfig } from "../config/schema.js";
 
-export type CheckStatus = "ok" | "warn" | "fail";
+import type { CheckStatus } from "./doctor-status.js";
 export interface CheckResult {
   name: string;
   status: CheckStatus;

--- a/src/cli/doctor-docker.ts
+++ b/src/cli/doctor-docker.ts
@@ -26,7 +26,7 @@ import { readFileSync } from "node:fs";
 import { allocateAgentUid, describeAgents } from "../agents/compose.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
-export type CheckStatus = "ok" | "warn" | "fail";
+import type { CheckStatus } from "./doctor-status.js";
 
 export interface CheckResult {
   name: string;

--- a/src/cli/doctor-drive.test.ts
+++ b/src/cli/doctor-drive.test.ts
@@ -206,7 +206,7 @@ describe("runDriveChecks — deployed scaffold wiring (bug-8 / bug-9)", () => {
   // single honest "unverifiable from host" WARN, never a `fail`
   // (the original code mislabeled EACCES as ".mcp.json is unparseable"
   // and failed all 9 agents on a perfectly healthy fleet).
-  it("WARNS (not fail) when scaffold files are host-unreadable (EACCES)", () => {
+  it("SKIPS (not warn/fail) when scaffold files are host-unreadable (EACCES)", () => {
     const rs = runDriveChecks(base, {
       agentsDir: "/agents",
       existsSync: (p) =>
@@ -220,7 +220,7 @@ describe("runDriveChecks — deployed scaffold wiring (bug-8 / bug-9)", () => {
       },
     });
     const w = rs.find((r) => r.name === "drive: carrie scaffold");
-    expect(w?.status).toBe("warn");
+    expect(w?.status).toBe("skip");
     expect(w?.detail).toContain("unverifiable from the host");
     // Crucially: nothing in the section is a `fail` purely because the
     // host can't read agent-UID-owned files.

--- a/src/cli/doctor-drive.ts
+++ b/src/cli/doctor-drive.ts
@@ -47,7 +47,7 @@ import { join, resolve } from "node:path";
 import { resolveAgentsDir } from "../config/loader.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
-export type CheckStatus = "ok" | "warn" | "fail";
+import type { CheckStatus } from "./doctor-status.js";
 
 export interface CheckResult {
   name: string;
@@ -262,7 +262,7 @@ function checkScaffoldWiring(
     if (mcpRead.kind === "unreadable" || trustRead.kind === "unreadable") {
       results.push({
         name: `drive: ${name} scaffold`,
-        status: "warn",
+        status: "skip",
         detail:
           "scaffold files are agent-UID-owned (mode 0600) — unverifiable from the host operator; the agent process reads them fine. Verify in-container if needed: `docker exec switchroom-" +
           name +

--- a/src/cli/doctor-hostd.ts
+++ b/src/cli/doctor-hostd.ts
@@ -27,7 +27,7 @@ import { spawnSync } from "node:child_process";
 
 import type { SwitchroomConfig } from "../config/schema.js";
 
-export type CheckStatus = "ok" | "warn" | "fail";
+import type { CheckStatus } from "./doctor-status.js";
 
 export interface CheckResult {
   name: string;

--- a/src/cli/doctor-inlined-secrets.ts
+++ b/src/cli/doctor-inlined-secrets.ts
@@ -26,7 +26,7 @@ import { parse as parseYaml } from "yaml";
 
 import type { SwitchroomConfig } from "../config/schema.js";
 
-export type CheckStatus = "ok" | "warn" | "fail";
+import type { CheckStatus } from "./doctor-status.js";
 
 export interface CheckResult {
   name: string;

--- a/src/cli/doctor-secret-access.ts
+++ b/src/cli/doctor-secret-access.ts
@@ -43,7 +43,7 @@ import { openVault, type VaultEntry } from "../vault/vault.js";
 import { checkAclByAgent, checkEntryScope } from "../vault/broker/acl.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
-export type CheckStatus = "ok" | "warn" | "fail";
+import type { CheckStatus } from "./doctor-status.js";
 
 export interface CheckResult {
   name: string;
@@ -182,7 +182,7 @@ export function runSecretAccessChecks(
   if (!passphrase) {
     results.push({
       name: "agent secret access",
-      status: "warn",
+      status: "skip",
       detail:
         "SWITCHROOM_VAULT_PASSPHRASE not set — cannot enumerate vault keys/ACLs " +
         "to verify per-agent secret access",

--- a/src/cli/doctor-status.test.ts
+++ b/src/cli/doctor-status.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { statusGlyph, type CheckStatus } from "./doctor-status.js";
+import { printSection, type CheckResult } from "./doctor.js";
+
+describe("statusGlyph", () => {
+  it("returns a distinct non-empty glyph for every status (exhaustive)", () => {
+    const statuses: CheckStatus[] = ["ok", "warn", "fail", "skip"];
+    const glyphs = statuses.map(statusGlyph);
+    for (const g of glyphs) expect(g.length).toBeGreaterThan(0);
+    // All four visually distinct — skip must NOT look like warn.
+    expect(new Set(glyphs).size).toBe(4);
+    expect(statusGlyph("skip")).not.toBe(statusGlyph("warn"));
+  });
+});
+
+describe("printSection — skip accounting", () => {
+  it("counts skip separately and never folds it into warn/fail", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const results: CheckResult[] = [
+        { name: "a", status: "ok" },
+        { name: "b", status: "warn", fix: "do x" },
+        { name: "c", status: "fail" },
+        { name: "d", status: "skip", fix: "verify in-agent" },
+        { name: "e", status: "skip" },
+      ];
+      const counts = printSection("T", results);
+      expect(counts).toEqual({ oks: 1, warns: 1, fails: 1, skips: 2 });
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("still prints the how-to-verify line for a skip (honest, not hidden)", () => {
+    const lines: string[] = [];
+    const logSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation((...a: unknown[]) => {
+        lines.push(a.join(" "));
+      });
+    try {
+      printSection("T", [
+        { name: "d", status: "skip", fix: "run X to verify" },
+      ]);
+      expect(lines.some((l) => l.includes("run X to verify"))).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/src/cli/doctor-status.ts
+++ b/src/cli/doctor-status.ts
@@ -1,0 +1,42 @@
+/**
+ * Canonical health-check status + glyph for `switchroom doctor`.
+ *
+ * Pure leaf module: imports only `chalk`, never any `doctor*.ts`
+ * sibling. Every doctor check module imports `CheckStatus` from here
+ * (the type used to be copy-pasted into 9 files).
+ *
+ * - `ok`   — verified good.
+ * - `warn` — verified, and something the operator should look at.
+ * - `fail` — verified bad; sets a non-zero exit.
+ * - `skip` — NOT a problem and NOT verified from here: the check
+ *   can't run from the operator's vantage point by design — e.g. the
+ *   host operator UID cannot read an agent-private 0600 file (WS6-F2),
+ *   or a required input like `SWITCHROOM_VAULT_PASSPHRASE` isn't set.
+ *
+ *   `skip` is deliberately distinct from `warn` so that `warn` keeps
+ *   meaning "look at this" and the operator never learns to ignore
+ *   the column (the "cosmetic summary the user learns to distrust"
+ *   anti-pattern in reference/restart-and-know-what-im-running.md).
+ *   It never affects the exit code, and it STILL prints its
+ *   how-to-verify line — honest, not hidden (avoids "lying by
+ *   omission").
+ */
+
+import chalk from "chalk";
+
+export type CheckStatus = "ok" | "warn" | "fail" | "skip";
+
+export function statusGlyph(status: CheckStatus): string {
+  switch (status) {
+    case "ok":
+      return chalk.green("✓");
+    case "warn":
+      return chalk.yellow("!");
+    case "fail":
+      return chalk.red("✗");
+    case "skip":
+      // en-dash, dim: "not checked from here" — visually quiet so it
+      // doesn't read as a problem.
+      return chalk.gray("–");
+  }
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,5 +1,7 @@
 import type { Command } from "commander";
 import chalk from "chalk";
+
+import { type CheckStatus, statusGlyph } from "./doctor-status.js";
 import { execSync, spawnSync } from "node:child_process";
 import {
   accessSync,
@@ -35,25 +37,14 @@ import { runAuditIntegrityChecks } from "./doctor-audit-integrity.js";
 
 /**
  * Result of a single doctor check.
+ * `CheckStatus` + `statusGlyph` live in ./doctor-status.ts (imported
+ * above) so the 9 doctor modules share one definition.
  */
-export type CheckStatus = "ok" | "warn" | "fail";
-
 export interface CheckResult {
   name: string;
   status: CheckStatus;
   detail?: string;
   fix?: string;
-}
-
-function statusGlyph(status: CheckStatus): string {
-  switch (status) {
-    case "ok":
-      return chalk.green("\u2713");
-    case "warn":
-      return chalk.yellow("!");
-    case "fail":
-      return chalk.red("\u2717");
-  }
 }
 
 /**
@@ -555,7 +546,7 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
       },
       {
         name: "vault unlock",
-        status: "warn",
+        status: "skip",
         detail: "SWITCHROOM_VAULT_PASSPHRASE not set; cannot verify decrypt",
         fix: "Export SWITCHROOM_VAULT_PASSPHRASE to verify the vault unlocks",
       },
@@ -1038,8 +1029,9 @@ export async function checkTelegram(config: SwitchroomConfig): Promise<CheckResu
       // deploy doctor across all 8 agents).
       results.push({
         name: `${name}: bot token`,
-        status: "warn",
+        status: "skip",
         detail: `unreadable from host (${read.error}) — agent reads it fine; cannot verify TELEGRAM_BOT_TOKEN from operator UID`,
+        fix: `Verify in-agent (PR2 hostd agent_smoke), or: docker exec switchroom-${name} sh -lc 'test -s "$TELEGRAM_BOT_TOKEN_FILE" || grep -q TELEGRAM_BOT_TOKEN /state/agent/telegram/.env && echo ok'`,
       });
       continue;
     }
@@ -1118,10 +1110,14 @@ export function checkStartShStale(
   try {
     content = readFileSync(startShPath, "utf-8");
   } catch (err) {
+    // start.sh is mode 0700 owned by the per-agent UID; the host
+    // operator can't read it. By-design unverifiable from here — not
+    // a problem (the agent runs it fine). PR2 verifies in-agent.
     return {
       name: label,
-      status: "warn",
-      detail: `unreadable: ${(err as Error).message}`,
+      status: "skip",
+      detail: `unreadable from host (${(err as Error).message}) — agent-UID-owned; the scheduler block can't be checked from the operator UID`,
+      fix: `Verify in-agent (PR2 hostd agent_smoke), or: docker exec switchroom-${agentName} grep -q _switchroom_supervise.*agent-scheduler /state/agent/start.sh && echo ok`,
     };
   }
   // Match on the actual supervisor invocation, not the bare token —
@@ -1418,8 +1414,9 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
         // post-deploy doctor across the full fleet (2026-05-10).
         results.push({
           name: `${name}: auth`,
-          status: "warn",
+          status: "skip",
           detail: "auth state owned by agent UID — unverifiable from host (agent reads it fine)",
+          fix: `Verify in-agent (PR2 hostd agent_smoke runs a real auth liveness check)`,
         });
       } else {
         results.push({
@@ -1557,22 +1554,28 @@ export function printSection(title: string, results: CheckResult[]): {
   oks: number;
   warns: number;
   fails: number;
+  skips: number;
 } {
   console.log(chalk.bold(`\n${title}`));
   let oks = 0;
   let warns = 0;
   let fails = 0;
+  let skips = 0;
   for (const r of results) {
     if (r.status === "ok") oks++;
     if (r.status === "warn") warns++;
     if (r.status === "fail") fails++;
+    if (r.status === "skip") skips++;
     const detail = r.detail ? chalk.gray(`  (${r.detail})`) : "";
     console.log(`  ${statusGlyph(r.status)} ${r.name}${detail}`);
+    // Show the how-to-verify line for skip too: it's not a problem,
+    // but the operator should be able to verify it on demand. Honest,
+    // not hidden (the "lying by omission" anti-pattern).
     if (r.fix && r.status !== "ok") {
       console.log(chalk.gray(`      \u2192 ${r.fix}`));
     }
   }
-  return { oks, warns, fails };
+  return { oks, warns, fails, skips };
 }
 
 // ---------------------------------------------------------------------------
@@ -1647,7 +1650,7 @@ export function checkMffVaultKeyPresent(
   if (!passphrase) {
     return {
       name: "mff: vault key present",
-      status: "warn",
+      status: "skip",
       detail: "SWITCHROOM_VAULT_PASSPHRASE not set — skipping vault checks",
       fix: "Export SWITCHROOM_VAULT_PASSPHRASE to enable MFF vault probes",
     };
@@ -1823,7 +1826,7 @@ export async function checkMffApiReachable(
   if (state !== "readable") {
     return {
       name: "mff: API reachable",
-      status: "warn",
+      status: "skip",
       detail:
         state === "agent-private"
           ? "skipped — MFF creds are per-agent/agent-private since WS6-F2; deep probe must run in-agent"
@@ -1891,7 +1894,7 @@ export async function checkMffAuthFlow(
   if (state !== "readable") {
     return {
       name: "mff: auth flow",
-      status: "warn",
+      status: "skip",
       detail:
         state === "agent-private"
           ? "skipped — MFF creds are per-agent/agent-private since WS6-F2; deep probe must run in-agent"
@@ -2013,7 +2016,7 @@ export async function checkMffCloudflareUa(
   if (state !== "readable") {
     return {
       name: "mff: Cloudflare UA bypass",
-      status: "warn",
+      status: "skip",
       detail:
         state === "agent-private"
           ? "skipped — MFF creds are per-agent/agent-private since WS6-F2; deep probe must run in-agent"
@@ -2355,16 +2358,24 @@ export function registerDoctorCommand(program: Command): void {
         let totalOk = 0;
         let totalWarn = 0;
         let totalFail = 0;
+        let totalSkip = 0;
         for (const { title, results } of sections) {
           if (results.length === 0) continue;
-          const { oks, warns, fails } = printSection(title, results);
+          const { oks, warns, fails, skips } = printSection(title, results);
           totalOk += oks;
           totalWarn += warns;
           totalFail += fails;
+          totalSkip += skips;
         }
 
         console.log();
-        const summary = `${chalk.green(`${totalOk} ok`)} · ${chalk.yellow(`${totalWarn} warn`)} · ${chalk.red(`${totalFail} fail`)}`;
+        // `skip` is appended last and never affects the exit code —
+        // it means "not checked from here by design", not a problem.
+        // Keeping the ok/warn/fail order stable preserves operator
+        // muscle-memory and any loose output readers.
+        const summary =
+          `${chalk.green(`${totalOk} ok`)} · ${chalk.yellow(`${totalWarn} warn`)} · ${chalk.red(`${totalFail} fail`)}` +
+          ` · ${chalk.gray(`${totalSkip} skip`)}`;
         console.log(`  ${summary}`);
         console.log();
 

--- a/tests/doctor-secret-access.test.ts
+++ b/tests/doctor-secret-access.test.ts
@@ -82,7 +82,7 @@ describe("runSecretAccessChecks — Check A (operator readable)", () => {
 });
 
 describe("runSecretAccessChecks — Check B (per-agent access)", () => {
-  it("warns (cannot verify) when the passphrase is unset", () => {
+  it("skips (cannot verify) when the passphrase is unset", () => {
     const saved = process.env.SWITCHROOM_VAULT_PASSPHRASE;
     delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
     try {
@@ -91,7 +91,7 @@ describe("runSecretAccessChecks — Check B (per-agent access)", () => {
         deps({ passphrase: undefined }),
       );
       const b = get(r, "agent secret access");
-      expect(b?.status).toBe("warn");
+      expect(b?.status).toBe("skip");
       expect(b?.detail).toContain("SWITCHROOM_VAULT_PASSPHRASE not set");
     } finally {
       if (saved !== undefined) process.env.SWITCHROOM_VAULT_PASSPHRASE = saved;

--- a/tests/doctor.mff.test.ts
+++ b/tests/doctor.mff.test.ts
@@ -129,10 +129,10 @@ describe("checkMffVaultKeyPresent", () => {
   beforeEach(() => { tempDir = makeTempDir(); });
   afterEach(() => { rmSync(tempDir, { recursive: true, force: true }); });
 
-  it("returns warn when passphrase is not set", () => {
+  it("returns skip when passphrase is not set", () => {
     const vaultPath = join(tempDir, "vault.enc");
     const result = checkMffVaultKeyPresent(undefined, vaultPath);
-    expect(result.status).toBe("warn");
+    expect(result.status).toBe("skip");
     expect(result.detail).toContain("SWITCHROOM_VAULT_PASSPHRASE");
   });
 
@@ -641,20 +641,20 @@ describe("WS6-F2 agent-private behaviour", () => {
   );
 
   it.skipIf(isRoot)(
-    "deep probes skip (warn) on an agent-private .env — no host read of agent secrets",
+    "deep probes skip (status=skip) on an agent-private .env — no host read of agent secrets",
     async () => {
       const p = join(tempDir, ".env");
       writeFileSync(p, "MFF_API_URL=https://x\n");
       chmodSync(p, 0o000);
       const api = await checkMffApiReachable(p);
-      expect(api.status).toBe("warn");
+      expect(api.status).toBe("skip");
       expect(api.detail).toContain("agent-private");
     },
   );
 
-  it("deep probes skip (warn) when the .env is absent", async () => {
+  it("deep probes skip (status=skip) when the .env is absent", async () => {
     const api = await checkMffApiReachable(join(tempDir, "nope.env"));
-    expect(api.status).toBe("warn");
+    expect(api.status).toBe("skip");
     expect(api.detail).toContain("not found");
   });
 });

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -312,7 +312,7 @@ describe("checkTelegram", () => {
   });
 
   it.skipIf(process.getuid?.() === 0)(
-    "reports warn (not fail) when .env exists but is unreadable from host UID (EACCES)",
+    "reports skip (not warn/fail) when .env exists but is unreadable from host UID (EACCES)",
     async () => {
     // Per-agent state files are mode 0600 owned by the agent UID
     // (compose.ts allocates 10001-10999); when `switchroom doctor`
@@ -335,7 +335,7 @@ describe("checkTelegram", () => {
         makeConfig({ assistant: { plugin: "switchroom" } }),
       );
       expect(results).toHaveLength(1);
-      expect(results[0].status).toBe("warn");
+      expect(results[0].status).toBe("skip");
       expect(results[0].detail).toContain("unreadable from host");
       expect(results[0].detail).toContain("agent reads it fine");
       // Crucially: the row must NOT claim TELEGRAM_BOT_TOKEN is "missing".


### PR DESCRIPTION
## Summary

`switchroom doctor` printed `66 ok · 52 warn · 0 fail`. **~45 of the 52 `warn`s are permanent, expected, by-design lines** — "the host operator UID can't read this agent-private 0600 file" (WS6-F2) or "SWITCHROOM_VAULT_PASSPHRASE unset, can't verify". They never clear → the operator learns to ignore the `warn` column → a *real* warn gets missed. The product's own design contract (`reference/restart-and-know-what-im-running.md`) names this exact anti-pattern: *"Cosmetic summaries that always look the same regardless of the actual config. The user learns to distrust it."* and *"Lying by omission."*

**This is PR 1 of 2** (split per plan-review). Tier A — the standalone, low-risk *semantic* fix. **PR 2** will add a read-only admin-gated **hostd `agent_smoke`** verb (privileged in-agent liveness battery — auth/MCP/vault/scheduler) that *upgrades* skips to real ✓/✗, with `skip` as its already-shipped fallback. (Routing privileged checks through the audited hostd boundary — per operator request — is strictly better than the doctor CLI doing its own `docker exec`: keeps WS6-F2 intact, doctor stays unprivileged.)

## Changes

- New **pure-leaf** `src/cli/doctor-status.ts` owns `CheckStatus` (`ok|warn|fail|skip`) + `statusGlyph` — replaces the type copy-pasted into **9** doctor modules (consistency principle; imports only `chalk`, never a sibling → no cycle). The expanded union also caught a real missing `Record<CheckStatus,number>` key in `doctor-auth-broker`.
- `skip` threaded through `printSection`/summary/aggregation: counted separately, **never affects the exit code** (still `fail`-only), **appended last** in the summary (`… · N skip`; ok/warn/fail order preserved for any loose readers / operator muscle-memory), and **still prints its how-to-verify line** (honest, not hidden).
- Reclassified genuinely-host-impossible checks `warn`→`skip`: passphrase-unset (vault unlock, agent secret access, MFF vault key), EACCES by-design branches (telegram bot token, start.sh scheduler, agent auth, drive scaffold), WS6-F2 agent-private MFF deep probes. **Real-problem branches stay `warn`/`fail`** (missing scaffold, genuine auth fail, corrupt mcp.json, manifest drift).

## Test plan

- [x] **Live-verified on the host**: `66 ok · 11 warn · 0 fail · 42 skip` (was `66 · 52 · 0`). A real `manifest drift: claude CLI (declared 2.1.140, installed 2.1.143)` warn that was buried in the 52 is now visible.
- [x] 220 doctor tests pass — 5 updated to assert `skip` (intent preserved/strengthened: by-design ≠ problem), 3 new skip-semantics tests (`statusGlyph` exhaustive+distinct; `printSection` counts skip separately, not as warn; skip still prints its verify line).
- [x] `tsc` clean for all changed files (only the 3 pre-existing unrelated `@mtcute/node` UAT errors remain).
- [x] Exit/`--json`: `process.exit(1)` still `fail`-only (skip can't change it); `--json` `status` enum gains `"skip"` (additive — the only consumer, #1518 hostd `doctor` verb, is text-passthrough, not a JSON parser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)