### PR TITLE
chore: release v0.12.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.12.9 — restore the Telegram reauth flow (auth reauth/code/cancel)
+
+One fix: the per-agent OAuth reauth flow was dead fleet-wide.
+
+### Changes
+
+#### Fixes
+
+- **fix(auth):** restore the `auth reauth` / `auth code` / `auth cancel` CLI verbs. RFC-H (#1254) removed their registrations from `src/cli/auth.ts` when it restructured auth around the broker, but left the engine (`src/auth/manager.ts` — `startAuthSession`/`submitAuthCode`/`cancelAuthSession`), every caller (the Telegram gateway `op:reauth` + `/auth reauth`, `welcome-text`, `operator-events`) and the tests all still expecting them. Net effect: any agent's 🔐 Reauth button ran `switchroom auth reauth <agent>` → "unknown command" → the operator saw **"Command failed"** (surfaced on `gymbro` after a transient 4xx). Re-registered as thin, agent-scoped wrappers over the existing, tested engine (`--slot`/`--force`, `auth code … --json` pinned to the gateway's parser); the credential write path is unchanged, so RFC-H's single-*writer* broker plane is untouched. (#1522)
+
 ## v0.12.8 — operator vault CLI fix, whole-fleet /doctor, audit tamper-evidence correctness
 
 Three fixes from a `switchroom doctor` audit pass.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release **v0.12.9**. Single change since v0.12.8: restores the Telegram reauth flow (`auth reauth`/`code`/`cancel` verbs orphaned by RFC-H #1254 — see #1522, merged as `6c1ecd1b`).

- `package.json`: 0.12.8 → 0.12.9
- `CHANGELOG.md`: new `## v0.12.9` section (the #1522 fix)

Scope is exactly these two files. Triage per the release convention is `v0.12.8..HEAD` = only #1522.

## Post-merge (release mechanics, done after squash-merge)
- Tag `v0.12.9` on the squashed merge commit on `main`, push to canonical
- `npm run build` then `npm publish --ignore-scripts` (prepublishOnly is skipped intentionally — local lint hits the pre-existing `@mtcute` env-gap; CI lint is the authoritative gate and is green). Verify the tarball contains `dist/cli/switchroom.js` (the v0.12.7 lesson)
- Confirm GHCR builds a `v0.12.9`/`sha-`tagged image; create the `v0.12.9` GitHub Release

## Out of scope (pre-existing debt, flagged separately)
- No 0.12.x GitHub *Release* objects exist (max is v0.11.1) — automation tags+npm-publishes only
- `src/build-info.ts` is tracked-stale (0.11.1) by design (refreshed at build, not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)