### PR TITLE
feat(hostd,doctor): agent_smoke verb — verified in-agent liveness

### DIFF
--- a/src/cli/doctor-agent-smoke.test.ts
+++ b/src/cli/doctor-agent-smoke.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+
+import { runAgentSmokeChecks } from "./doctor-agent-smoke.js";
+import type { HostdResponse } from "../host-control/protocol.js";
+
+const cfg = { agents: { klanker: {}, gymbro: {} } };
+
+function resp(body: unknown, over: Partial<HostdResponse> = {}): HostdResponse {
+  return {
+    v: 1,
+    request_id: "x",
+    result: "completed",
+    exit_code: 0,
+    duration_ms: 1,
+    stdout_tail: JSON.stringify(body),
+    ...over,
+  };
+}
+
+describe("runAgentSmokeChecks", () => {
+  it("--fast omits the section entirely", async () => {
+    const r = await runAgentSmokeChecks(cfg, {
+      fast: true,
+      hostdRequestImpl: async () => resp({}),
+    });
+    expect(r).toEqual([]);
+  });
+
+  it("operator socket absent → one honest skip row (no per-agent noise)", async () => {
+    const r = await runAgentSmokeChecks(cfg, {
+      operatorSockPath: "/definitely/not/here.sock",
+    });
+    expect(r).toHaveLength(1);
+    expect(r[0]).toMatchObject({ name: "agent liveness", status: "skip" });
+    expect(r[0].detail).toMatch(/operator socket not found/);
+  });
+
+  it("all probes ok → one `ok` row per agent with a compact summary", async () => {
+    const r = await runAgentSmokeChecks(cfg, {
+      hostdRequestImpl: async (_s, name) =>
+        resp({
+          container: "running",
+          probes: [
+            { name: "auth", state: "ok", detail: "ok" },
+            { name: "scheduler", state: "ok", detail: "ok" },
+          ],
+        }),
+    });
+    expect(r.map((c) => c.name)).toEqual(["klanker: liveness", "gymbro: liveness"]);
+    expect(r.every((c) => c.status === "ok")).toBe(true);
+    expect(r[0].detail).toBe("auth:ok scheduler:ok");
+  });
+
+  it("a failing probe → `fail` row naming the failed probe in the fix", async () => {
+    const r = await runAgentSmokeChecks(
+      { agents: { klanker: {} } },
+      {
+        hostdRequestImpl: async () =>
+          resp({
+            container: "running",
+            probes: [
+              { name: "auth", state: "fail", detail: "exit 1" },
+              { name: "state", state: "ok", detail: "ok" },
+            ],
+          }),
+      },
+    );
+    expect(r[0].status).toBe("fail");
+    expect(r[0].detail).toBe("auth:FAIL state:ok");
+    expect(r[0].fix).toMatch(/auth/);
+  });
+
+  it("container absent → skip (never fail — agent-down is not a defect this acts on)", async () => {
+    const r = await runAgentSmokeChecks(
+      { agents: { klanker: {} } },
+      {
+        hostdRequestImpl: async () =>
+          resp({ container: "absent", probes: [{ name: "auth", state: "skip", detail: "" }] }),
+      },
+    );
+    expect(r[0].status).toBe("skip");
+    expect(r[0].detail).toMatch(/not running/);
+  });
+
+  it("hostd denied → skip (not fail)", async () => {
+    const r = await runAgentSmokeChecks(
+      { agents: { klanker: {} } },
+      {
+        hostdRequestImpl: async () =>
+          resp({}, { result: "denied", error: "agent_smoke cross-agent requires admin" }),
+      },
+    );
+    expect(r[0].status).toBe("skip");
+    expect(r[0].detail).toMatch(/denied/);
+  });
+
+  it("hostd unreachable (throws) → skip (infra, not an agent defect)", async () => {
+    const r = await runAgentSmokeChecks(
+      { agents: { klanker: {} } },
+      {
+        hostdRequestImpl: async () => {
+          throw new Error("ECONNREFUSED");
+        },
+      },
+    );
+    expect(r[0].status).toBe("skip");
+    expect(r[0].detail).toMatch(/unreachable/);
+  });
+});

--- a/src/cli/doctor-agent-smoke.ts
+++ b/src/cli/doctor-agent-smoke.ts
@@ -1,0 +1,152 @@
+/**
+ * doctor section: in-agent liveness via the hostd `agent_smoke` verb.
+ *
+ * The host operator cannot read agent-private 0600 state (WS6-F2), so
+ * the rest of doctor honestly reports those rows as `skip`. This
+ * section gets the VERIFIED truth by asking hostd — the one audited,
+ * admin-gated component that holds the docker socket — to run a fixed
+ * read-only probe battery INSIDE each agent and report back.
+ *
+ * Degrade-not-fail: hostd unreachable / host_control off / a down
+ * agent → `skip`, never `fail` (infra or agent-down is not a health
+ * defect this probe can act on; `agent_start` is the lever). Exactly
+ * ONE compact row per agent — this section exists to ADD verified
+ * signal, not to re-noise the summary the `skip` work just cleaned.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import type { CheckStatus } from "./doctor-status.js";
+import { hostdRequest } from "../host-control/client.js";
+import type { HostdResponse } from "../host-control/protocol.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+interface SmokeProbe {
+  name: string;
+  state: "ok" | "fail" | "skip";
+  detail: string;
+}
+
+export interface AgentSmokeDeps {
+  homeDir?: string;
+  /** --fast / offline: omit the section entirely. */
+  fast?: boolean;
+  /** Injected for tests; defaults to the real UDS client. */
+  hostdRequestImpl?: (sock: string, name: string) => Promise<HostdResponse>;
+  /** Override the operator socket path (tests). */
+  operatorSockPath?: string;
+}
+
+/** Be gentle on hostd: a handful of agents probed at a time. */
+const CONCURRENCY = 4;
+
+export async function runAgentSmokeChecks(
+  config: { agents?: Record<string, unknown> },
+  deps: AgentSmokeDeps = {},
+): Promise<CheckResult[]> {
+  if (deps.fast) return [];
+
+  const home = deps.homeDir ?? homedir();
+  const sock =
+    deps.operatorSockPath ??
+    join(home, ".switchroom", "hostd", "operator", "sock");
+
+  if (!deps.hostdRequestImpl && !existsSync(sock)) {
+    return [
+      {
+        name: "agent liveness",
+        status: "skip",
+        detail:
+          "hostd operator socket not found — in-agent probes skipped (host_control disabled, or hostd not running)",
+        fix: "Enable host_control + `switchroom update` for real in-agent liveness; or `switchroom doctor --fast` to silence.",
+      },
+    ];
+  }
+
+  const call =
+    deps.hostdRequestImpl ??
+    ((s: string, name: string) =>
+      hostdRequest(
+        { socketPath: s, timeoutMs: 8000 },
+        {
+          v: 1,
+          request_id: `doctor-smoke-${randomUUID()}`,
+          op: "agent_smoke",
+          args: { name },
+        },
+      ));
+
+  const names = Object.keys(config.agents ?? {});
+  const results: CheckResult[] = [];
+
+  for (let i = 0; i < names.length; i += CONCURRENCY) {
+    const settled = await Promise.all(
+      names.slice(i, i + CONCURRENCY).map(
+        async (name): Promise<CheckResult> => {
+          const label = `${name}: liveness`;
+          try {
+            const resp = await call(sock, name);
+            if (resp.result === "denied") {
+              return {
+                name: label,
+                status: "skip",
+                detail: `hostd denied agent_smoke (${resp.error ?? "admin required"})`,
+              };
+            }
+            let parsed: { container?: string; probes?: SmokeProbe[] };
+            try {
+              parsed = JSON.parse(resp.stdout_tail ?? "{}");
+            } catch {
+              return {
+                name: label,
+                status: "skip",
+                detail: "hostd returned an unparseable agent_smoke payload",
+              };
+            }
+            const probes = parsed.probes ?? [];
+            if (parsed.container === "absent") {
+              return {
+                name: label,
+                status: "skip",
+                detail: `container not running — ${probes.length} probe(s) skipped`,
+              };
+            }
+            const fails = probes.filter((p) => p.state === "fail");
+            const summary = probes
+              .map(
+                (p) =>
+                  `${p.name}:${p.state === "ok" ? "ok" : p.state === "fail" ? "FAIL" : "skip"}`,
+              )
+              .join(" ");
+            if (fails.length > 0) {
+              return {
+                name: label,
+                status: "fail",
+                detail: summary,
+                fix: `Investigate ${fails.map((f) => f.name).join(", ")} in switchroom-${name}.`,
+              };
+            }
+            return { name: label, status: "ok", detail: summary };
+          } catch (err) {
+            return {
+              name: label,
+              status: "skip",
+              detail: `hostd unreachable: ${(err as Error).message}`,
+            };
+          }
+        },
+      ),
+    );
+    results.push(...settled);
+  }
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -34,6 +34,7 @@ import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js
 import { runSecretAccessChecks } from "./doctor-secret-access.js";
 import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
 import { runAuditIntegrityChecks } from "./doctor-audit-integrity.js";
+import { runAgentSmokeChecks } from "./doctor-agent-smoke.js";
 
 /**
  * Result of a single doctor check.
@@ -2219,8 +2220,12 @@ export function registerDoctorCommand(program: Command): void {
     .description("Diagnose Switchroom's setup: deps, vault, memory, agents, MCP wireup")
     .option("--json", "Output as JSON")
     .option("--skill <name>", "Run probes for a specific skill only (e.g. mff)")
+    .option(
+      "--fast",
+      "Skip in-agent (hostd) liveness probes — offline/quick; the host-unverifiable rows stay `skip`",
+    )
     .action(
-      withConfigError(async (opts: { json?: boolean; skill?: string }) => {
+      withConfigError(async (opts: { json?: boolean; skill?: string; fast?: boolean }) => {
         // Pre-config-load short-circuit: if no switchroom.yaml exists yet
         // (e.g. fresh install before `switchroom setup`), running doctor
         // should still be useful — that's exactly when an operator wants
@@ -2324,6 +2329,10 @@ export function registerDoctorCommand(program: Command): void {
           { title: "Docker (Phase 1a)", results: runDockerSection(config) },
           { title: "Auth Broker", results: runAuthBrokerChecks(config) },
           { title: "Host control (hostd)", results: runHostdChecks(config) },
+          {
+            title: "Agent liveness (in-agent via hostd)",
+            results: await runAgentSmokeChecks(config, { fast: opts.fast }),
+          },
           { title: "Google Drive", results: runDriveChecks(config) },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath, config) },
         ];

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -225,6 +225,28 @@ export const DoctorRequestSchema = z.object({
   args: z.object({}).optional(),
 });
 
+/**
+ * Read-only in-agent liveness battery. hostd `docker exec`s a FIXED
+ * set of presence/validity probes inside the target agent container
+ * (auth creds present, scheduler block + sidecar, .mcp.json /
+ * .claude.json valid, bot-token present, /state writable). Every
+ * probe returns only a boolean/state — NEVER a secret value. `deep`
+ * opts into a real, quota-costing `claude -p` auth smoke; the default
+ * makes NO model call (subscription-honest). Self-target is allowed;
+ * cross-agent requires admin (mirrors agent_logs/agent_exec). The
+ * doctor CLI (operator socket) + Telegram /doctor consume this to
+ * upgrade the WS6-F2 host-unverifiable `skip` rows to real ok/fail;
+ * a down container / unreachable hostd degrades to skip, never fail.
+ */
+export const AgentSmokeRequestSchema = z.object({
+  ...RequestEnvelope,
+  op: z.literal("agent_smoke"),
+  args: z.object({
+    name: AgentNameSchema,
+    deep: z.boolean().optional(),
+  }),
+});
+
 export const RequestSchema = z.discriminatedUnion("op", [
   AgentRestartRequestSchema,
   UpgradeStatusRequestSchema,
@@ -237,6 +259,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   AgentLogsRequestSchema,
   AgentExecRequestSchema,
   DoctorRequestSchema,
+  AgentSmokeRequestSchema,
 ]);
 
 export type AgentRestartRequest = z.infer<typeof AgentRestartRequestSchema>;
@@ -250,6 +273,7 @@ export type AgentStopRequest = z.infer<typeof AgentStopRequestSchema>;
 export type AgentLogsRequest = z.infer<typeof AgentLogsRequestSchema>;
 export type AgentExecRequest = z.infer<typeof AgentExecRequestSchema>;
 export type DoctorRequest = z.infer<typeof DoctorRequestSchema>;
+export type AgentSmokeRequest = z.infer<typeof AgentSmokeRequestSchema>;
 export type HostdRequest = z.infer<typeof RequestSchema>;
 
 /** All verb names that pass discriminated-union validation. New verbs

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -523,6 +523,10 @@ export class HostdServer {
         case "doctor":
           resp = await this.handleDoctor(req, started);
           break;
+        // ── Phase 3.2 read-only in-agent liveness battery ────────
+        case "agent_smoke":
+          resp = await this.handleAgentSmoke(req, started);
+          break;
       }
     } catch (err) {
       resp = errorResponse(
@@ -604,12 +608,15 @@ export class HostdServer {
           : `${req.op} cross-agent requires admin: true on caller "${caller.name}"`;
       case "agent_logs":
       case "agent_exec":
+      case "agent_smoke":
         // Phase 3 admin-observability verbs. Self-target is allowed
         // (an agent reading its own logs / inspecting its own
         // container is harmless and useful for self-debugging);
         // cross-agent requires admin. agent_exec additionally enforces
         // a read-only argv allowlist at dispatch time — see
-        // isAllowlistedReadOnlyArgv.
+        // isAllowlistedReadOnlyArgv. agent_smoke runs a FIXED
+        // read-only probe battery (no caller-supplied argv at all),
+        // so it's strictly safer than agent_exec under the same gate.
         if (req.args.name === caller.name) return null;
         return callerAdmin
           ? null
@@ -735,7 +742,14 @@ export class HostdServer {
     req: Extract<HostdRequest, { op: "doctor" }>,
     started: number,
   ): Promise<HostdResponse> {
-    const res = await this.runSwitchroom(["doctor"]);
+    // `--fast`: the whole-fleet doctor reached via this verb (the
+    // Telegram /doctor surface, #1518) must stay STRUCTURAL only. The
+    // in-agent liveness section makes a hostd round-trip per agent;
+    // running it here would risk the gateway's 30s shell-out timeout
+    // and re-enter hostd recursively. Operators get in-agent liveness
+    // by running `switchroom doctor` directly on the host (no 30s
+    // budget), or via the standalone `agent_smoke` verb per agent.
+    const res = await this.runSwitchroom(["doctor", "--fast"]);
     return {
       v: 1,
       request_id: req.request_id,
@@ -1047,6 +1061,130 @@ export class HostdServer {
       stdout_tail: tail(res.stdout),
       stderr_tail: tail(res.stderr),
     };
+  }
+
+  /**
+   * Read-only in-agent liveness battery (Phase 3.2). hostd is the one
+   * audited, admin-gated component with the docker socket, so the
+   * privileged in-container probing lives HERE, not in an
+   * unprivileged caller. Every probe is a FIXED literal command (no
+   * caller argv) returning only a boolean/state — NEVER a secret
+   * value (the bot-token probe uses `grep -q`, which emits nothing).
+   * A down container or a docker failure degrades every probe to
+   * `skip`; the verb itself is always `completed` when it ran (a
+   * failing probe is a *finding* the caller renders, not a
+   * verb-dispatch failure — same posture as the doctor verb). `deep`
+   * adds a real, quota-costing `claude -p` auth smoke; the default
+   * makes NO model call.
+   */
+  private async handleAgentSmoke(
+    req: Extract<HostdRequest, { op: "agent_smoke" }>,
+    started: number,
+  ): Promise<HostdResponse> {
+    // req.args.name is AgentNameSchema-validated at decode; passed as
+    // its own argv element (+ `--`) so it can't be a docker flag.
+    const container = `switchroom-${req.args.name}`;
+    type Probe = { name: string; state: "ok" | "fail" | "skip"; detail: string };
+    const respond = (
+      containerState: "running" | "absent",
+      probes: Probe[],
+    ): HostdResponse => ({
+      v: 1,
+      request_id: req.request_id,
+      result: "completed",
+      exit_code: probes.some((p) => p.state === "fail") ? 1 : 0,
+      duration_ms: Date.now() - started,
+      stdout_tail: tail(
+        JSON.stringify({
+          container: containerState,
+          deep: !!req.args.deep,
+          probes,
+        }),
+      ),
+    });
+
+    let running = false;
+    try {
+      const insp = await this.runDocker([
+        "inspect",
+        "-f",
+        "{{.State.Running}}",
+        container,
+      ]);
+      running = insp.exit_code === 0 && insp.stdout.trim() === "true";
+    } catch {
+      running = false;
+    }
+
+    const PROBES: { name: string; cmd: string }[] = [
+      {
+        name: "auth",
+        cmd: 'test -s "$CLAUDE_CONFIG_DIR/.credentials.json" || test -s "$HOME/.claude/.credentials.json"',
+      },
+      {
+        name: "scheduler",
+        cmd: "grep -q '_switchroom_supervise.*agent-scheduler' /state/agent/start.sh && pgrep -f agent-scheduler >/dev/null",
+      },
+      {
+        name: "mcp",
+        cmd: "python3 -m json.tool /state/agent/.mcp.json >/dev/null 2>&1",
+      },
+      {
+        // grep -q emits NOTHING on stdout — only an exit code, so the
+        // token value never leaves the container.
+        name: "bot_token",
+        cmd: "test -f /state/agent/telegram/.env && grep -qE '^TELEGRAM_BOT_TOKEN=[0-9]+:' /state/agent/telegram/.env",
+      },
+      { name: "state", cmd: "test -w /state/agent" },
+    ];
+    if (req.args.deep) {
+      PROBES.push({
+        name: "auth_live",
+        cmd: "timeout 25 claude -p ok >/dev/null 2>&1",
+      });
+    }
+
+    if (!running) {
+      return respond(
+        "absent",
+        PROBES.map((p) => ({
+          name: p.name,
+          state: "skip" as const,
+          detail: `container ${container} is not running — use agent_start`,
+        })),
+      );
+    }
+
+    const probes: Probe[] = await Promise.all(
+      PROBES.map(async (p): Promise<Probe> => {
+        try {
+          const r = await this.runDocker([
+            "exec",
+            container,
+            "--",
+            "sh",
+            "-lc",
+            p.cmd,
+          ]);
+          return {
+            name: p.name,
+            state: r.exit_code === 0 ? "ok" : "fail",
+            // NEVER include r.stdout: probes are exit-code only so a
+            // secret can't leak into the operator/audit surface.
+            detail: r.exit_code === 0 ? "ok" : `exit ${r.exit_code}`,
+          };
+        } catch (err) {
+          // docker binary missing / exec spawn error → not a health
+          // signal about the agent. Skip, never fail.
+          return {
+            name: p.name,
+            state: "skip",
+            detail: `probe could not run: ${(err as Error).message}`,
+          };
+        }
+      }),
+    );
+    return respond("running", probes);
   }
 
   /** Spawn the host `docker` CLI and capture stdout/stderr. Symmetric

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -499,6 +499,104 @@ describe("hostd server — doctor (read-only, admin-gated)", () => {
   });
 });
 
+describe("hostd server — agent_smoke (read-only in-agent battery)", () => {
+  async function withDocker(stubBody: string): Promise<string> {
+    const dockerStub = join(tmp, `docker-smoke-${Math.random().toString(36).slice(2)}.sh`);
+    writeFileSync(dockerStub, stubBody);
+    chmodSync(dockerStub, 0o755);
+    await server.stop();
+    server = new (await import("../../src/host-control/server.js")).HostdServer({
+      homeDir: tmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: stubBin,
+      dockerBin: dockerStub,
+      auditLogPath: join(tmp, "audit.log"),
+      allowNonLinux: true,
+    });
+    await server.start();
+    return dockerStub;
+  }
+
+  it("running container, all probes pass → completed, exit 0, every probe ok", async () => {
+    await withDocker(
+      '#!/bin/sh\ncase "$1" in\n  inspect) echo "true"; exit 0 ;;\n  exec) exit 0 ;;\nesac\nexit 0\n',
+    );
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "agent_smoke", request_id: "sm-ok", args: { name: "klanker" } },
+    );
+    expect(resp.result).toBe("completed");
+    expect(resp.exit_code).toBe(0);
+    const body = JSON.parse(resp.stdout_tail!);
+    expect(body.container).toBe("running");
+    expect(body.probes.map((p: { name: string }) => p.name).sort()).toEqual(
+      ["auth", "bot_token", "mcp", "scheduler", "state"],
+    );
+    expect(body.probes.every((p: { state: string }) => p.state === "ok")).toBe(true);
+  });
+
+  it("cross-agent denied for a non-admin caller", async () => {
+    await withDocker('#!/bin/sh\nexit 0\n');
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/bob/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "agent_smoke", request_id: "sm-deny", args: { name: "klanker" } },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/cross-agent requires admin/);
+  });
+
+  it("self-target allowed for a non-admin caller", async () => {
+    await withDocker(
+      '#!/bin/sh\ncase "$1" in\n  inspect) echo "true"; exit 0 ;;\n  exec) exit 0 ;;\nesac\nexit 0\n',
+    );
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/bob/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "agent_smoke", request_id: "sm-self", args: { name: "bob" } },
+    );
+    expect(resp.result).toBe("completed");
+    expect(JSON.parse(resp.stdout_tail!).container).toBe("running");
+  });
+
+  it("down container → completed, exit 0, every probe skip (never fail)", async () => {
+    await withDocker(
+      '#!/bin/sh\ncase "$1" in\n  inspect) echo "false"; exit 0 ;;\nesac\nexit 0\n',
+    );
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "agent_smoke", request_id: "sm-down", args: { name: "klanker" } },
+    );
+    expect(resp.result).toBe("completed");
+    expect(resp.exit_code).toBe(0);
+    const body = JSON.parse(resp.stdout_tail!);
+    expect(body.container).toBe("absent");
+    expect(body.probes.every((p: { state: string }) => p.state === "skip")).toBe(true);
+  });
+
+  it("a failing probe → completed (NOT error), exit 1, and NO probe stdout leaks", async () => {
+    // exec echoes a fake secret then exits 1 — the handler must never
+    // surface stdout (probes are exit-code only).
+    await withDocker(
+      '#!/bin/sh\ncase "$1" in\n  inspect) echo "true"; exit 0 ;;\n  exec) echo "FAKE-SECRET-LEAK-XYZ"; exit 1 ;;\nesac\nexit 0\n',
+    );
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    const resp = await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "agent_smoke", request_id: "sm-fail", args: { name: "klanker" } },
+    );
+    expect(resp.result).toBe("completed"); // a finding, not a dispatch error
+    expect(resp.exit_code).toBe(1);
+    expect(resp.stdout_tail).not.toContain("FAKE-SECRET-LEAK-XYZ");
+    const body = JSON.parse(resp.stdout_tail!);
+    expect(body.probes.every((p: { state: string }) => p.state === "fail")).toBe(true);
+    expect(body.probes.every((p: { detail: string }) => /^exit \d+$/.test(p.detail))).toBe(true);
+  });
+});
+
 describe("hostd server — Phase 2 per-agent verbs", () => {
   it("agent_start: self-target allowed even for non-admin", async () => {
     const sock = server


### PR DESCRIPTION
## Summary

**PR 2 of the honest-doctor work** (PR 1 = the `skip` status, already shipped in 0.12.9). PR 1 made the ~45 host-unverifiable rows an honest `skip`; this adds the **verified truth** — but routes the privileged in-agent probing through **hostd** (the one audited, admin-gated component that holds the docker socket), *not* the unprivileged doctor CLI shelling `docker exec` itself. That keeps the WS6-F2 boundary intact and the doctor CLI unprivileged (per operator request + the plan-review guidance).

- **New read-only `agent_smoke` hostd verb** — protocol schema + dispatch + gate mirroring `agent_logs`/`agent_exec` (self-target allowed, cross-agent admin-gated, operator socket ungated). Runs a **fixed** probe battery inside the target container via `docker exec … --` (agent name is `AgentNameSchema`-validated and passed as its own argv element — no injection): auth-creds present, scheduler block+sidecar, `.mcp.json` valid, bot-token present, `/state` writable. Opt-in `--deep` adds a bounded real `claude -p` auth smoke; the **default makes NO model call** (subscription-honest). **Probes are exit-code only — stdout is never surfaced** (the bot-token probe is `grep -q`, emits nothing; a test asserts a fake secret echoed by a probe never reaches the response).
- **Degrade-not-fail**: a down container / docker failure → every probe `skip`; the verb is always `completed` when it ran (a failing probe is a *finding*, not a dispatch error — same posture as the #1518 doctor verb).
- **New doctor section "Agent liveness (in-agent via hostd)"** — exactly one compact row per agent (adds signal without re-noising the summary PR 1 just cleaned). hostd unreachable / `host_control` off / agent down → `skip`, never fail. `--fast` omits it (offline/quick).
- **Protects #1518**: `handleDoctor` now runs `switchroom doctor --fast`, so the Telegram whole-fleet `/doctor` stays structural and can't blow the gateway's 30 s shell-out budget or recurse into hostd. In-agent liveness is for the host operator CLI + the standalone verb.

## Test plan

- [x] hostd server tests: gate (admin/self ok, cross-agent non-admin denied), running→all ok (completed/exit 0), **down container → all skip (never fail)**, **failing probe → completed (NOT error) + exit 1 + asserts a probe's stdout never leaks into the response**.
- [x] doctor consumer tests (injected hostd client): `--fast`→omitted, socket-absent→one honest skip, ok→compact row, fail→`fail`+fix names the probe, container-absent→skip, denied→skip, hostd-unreachable→skip.
- [x] 182 doctor+hostd tests green; `tsc` clean (only the 3 pre-existing unrelated `@mtcute/node` UAT errors).
- [ ] CI green → reviewer APPROVE → auto-merge → release **0.12.10** (0.12.9 is taken) → `switchroom update` → live-verify the new section + probes against the real fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)