### PR TITLE
chore: release v0.12.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.12.11 — hostd operator socket; honest doctor, part 3 (verified liveness goes live)
+
+Completes the honest-doctor arc. Part 1 (v0.12.9) made the
+host-unverifiable rows an honest `skip`; part 2 (v0.12.10) built the
+verified `agent_smoke` probe; deploying part 2 surfaced that hostd
+had **no operator socket**, so the host CLI couldn't consume it and
+the "Agent liveness" section degraded to a single `skip`. Part 3
+gives the host operator the transport.
+
+### Changes
+
+#### Features
+
+- **feat(hostd):** hostd now binds an **operator socket**
+  (`~/.switchroom/hostd/operator/sock`, mode 0600, chowned to
+  `SWITCHROOM_HOSTD_OPERATOR_UID`) alongside the per-agent sockets.
+  `peercred` maps it to `kind:"operator"` and `checkGate` leaves it
+  ungated (the operator is root-equivalent on its own host). The
+  hostd compose template passes the operator UID (SUDO-aware). No-op
+  when the env is unset/invalid — fail-closed, same posture as the
+  vault-broker. With this, `switchroom doctor`'s "Agent liveness
+  (in-agent via hostd)" section flips from a degraded `skip` to real
+  per-agent verified `ok`/`✗`. (#1527)
+
 ## v0.12.10 — verified in-agent liveness (`agent_smoke`); honest doctor, part 2
 
 Part 2 of the `switchroom doctor` signal-to-noise work (part 1, the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Delta vs v0.12.10 = the already-reviewed+merged **#1527** (hostd operator socket — completes the honest-doctor arc, part 3). `package.json` 0.12.10 → 0.12.11 (0.12.10 published — no collision) + CHANGELOG only; no code in this PR.

## Test plan
- [x] #1527 independently reviewer-APPROVE'd (security-critical: trust boundary + path-as-identity verified) + merged green.
- [x] Versioning verified: canonical/npm/host all 0.12.10 → next is 0.12.11.
- [ ] CI green → auto-merge → build (real node_modules, verify exit) → publish → verify tarball has dist/ → `switchroom update` → **live-verify "Agent liveness" flips skip→verified**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)