### PR TITLE
fix(hostd): drop docker-exec `--` — it broke agent_exec/agent_smoke in prod

### DIFF
--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1138,8 +1138,9 @@ export class HostdServer {
     req: Extract<HostdRequest, { op: "agent_smoke" }>,
     started: number,
   ): Promise<HostdResponse> {
-    // req.args.name is AgentNameSchema-validated at decode; passed as
-    // its own argv element (+ `--`) so it can't be a docker flag.
+    // req.args.name is AgentNameSchema-validated at decode and passed
+    // as its own argv element; docker exec stops parsing its options
+    // at CONTAINER so nothing after it is read as a docker flag.
     const container = `switchroom-${req.args.name}`;
     type Probe = { name: string; state: "ok" | "fail" | "skip"; detail: string };
     const respond = (

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1097,10 +1097,18 @@ export class HostdServer {
       );
     }
     const container = `switchroom-${req.args.name}`;
-    // #1401: `--` terminates docker's own option parsing, so no
-    // user-supplied argv element can be reinterpreted as a `docker
-    // exec` flag (-e / -u / -w / --privileged / --entrypoint, …).
-    const res = await this.runDocker(["exec", container, "--", ...req.args.argv]);
+    // No `--`. Unlike `docker run`, `docker exec` stops parsing its
+    // OWN options at CONTAINER: every token after the container name
+    // is the command/args. Verified against real docker —
+    // `docker exec C -e X cmd` execs a program literally named "-e"
+    // (it is NOT read as --env). So the #1401 concern (argv[0]
+    // reinterpreted as a docker flag) cannot occur for `docker exec`;
+    // and a literal `--` is actively harmful — docker exec tries to
+    // exec a binary named "--" → "executable file not found" / exit
+    // 127. The prior `--` silently broke EVERY real agent_exec; it
+    // was only ever exercised against a docker STUB in tests, which
+    // didn't model real docker's post-CONTAINER argv handling.
+    const res = await this.runDocker(["exec", container, ...req.args.argv]);
     return {
       v: 1,
       request_id: req.request_id,
@@ -1207,10 +1215,12 @@ export class HostdServer {
     const probes: Probe[] = await Promise.all(
       PROBES.map(async (p): Promise<Probe> => {
         try {
+          // No `--`: docker exec stops option-parsing at CONTAINER
+          // (see handleAgentExec) — a literal `--` is exec'd as the
+          // command → exit 127. p.cmd is a fixed literal anyway.
           const r = await this.runDocker([
             "exec",
             container,
-            "--",
             "sh",
             "-lc",
             p.cmd,

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -520,7 +520,12 @@ describe("hostd server — agent_smoke (read-only in-agent battery)", () => {
 
   it("running container, all probes pass → completed, exit 0, every probe ok", async () => {
     await withDocker(
-      '#!/bin/sh\ncase "$1" in\n  inspect) echo "true"; exit 0 ;;\n  exec) exit 0 ;;\nesac\nexit 0\n',
+      // exec) models real docker: a literal `--` as the command
+      // position (docker exec C -- ...) is exec'd as a binary named
+      // "--" → 127. Guards against re-introducing the cargo-culted
+      // `docker run`-style `--` (the bug that broke prod, masked
+      // because the old stub ignored argv past $1).
+      '#!/bin/sh\ncase "$1" in\n  inspect) echo "true"; exit 0 ;;\n  exec) [ "$3" = "--" ] && { echo \'exec: "--": not found\' >&2; exit 127; }; exit 0 ;;\nesac\nexit 0\n',
     );
     const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
     const resp = await hostdRequest(
@@ -550,7 +555,12 @@ describe("hostd server — agent_smoke (read-only in-agent battery)", () => {
 
   it("self-target allowed for a non-admin caller", async () => {
     await withDocker(
-      '#!/bin/sh\ncase "$1" in\n  inspect) echo "true"; exit 0 ;;\n  exec) exit 0 ;;\nesac\nexit 0\n',
+      // exec) models real docker: a literal `--` as the command
+      // position (docker exec C -- ...) is exec'd as a binary named
+      // "--" → 127. Guards against re-introducing the cargo-culted
+      // `docker run`-style `--` (the bug that broke prod, masked
+      // because the old stub ignored argv past $1).
+      '#!/bin/sh\ncase "$1" in\n  inspect) echo "true"; exit 0 ;;\n  exec) [ "$3" = "--" ] && { echo \'exec: "--": not found\' >&2; exit 127; }; exit 0 ;;\nesac\nexit 0\n',
     );
     const sock = server.getBoundPaths().find((p) => p.endsWith("/bob/sock"))!;
     const resp = await hostdRequest(
@@ -581,7 +591,7 @@ describe("hostd server — agent_smoke (read-only in-agent battery)", () => {
     // exec echoes a fake secret then exits 1 — the handler must never
     // surface stdout (probes are exit-code only).
     await withDocker(
-      '#!/bin/sh\ncase "$1" in\n  inspect) echo "true"; exit 0 ;;\n  exec) echo "FAKE-SECRET-LEAK-XYZ"; exit 1 ;;\nesac\nexit 0\n',
+      '#!/bin/sh\ncase "$1" in\n  inspect) echo "true"; exit 0 ;;\n  exec) [ "$3" = "--" ] && { echo \'exec: "--": not found\' >&2; exit 127; }; echo "FAKE-SECRET-LEAK-XYZ"; exit 1 ;;\nesac\nexit 0\n',
     );
     const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
     const resp = await hostdRequest(
@@ -1059,12 +1069,17 @@ describe("hostd server — Phase 2 fleet mutations + lock", () => {
       },
     );
     expect(resp.result).toBe("completed");
-    // #1401: `--` separates the fixed `docker exec <container>` prefix
-    // from caller-supplied argv so no element can be reparsed as a
-    // docker flag.
+    // NO `--`: `docker exec` stops parsing its own options at
+    // CONTAINER, so caller argv after the container name can't be
+    // reparsed as a docker flag (the #1401 concern doesn't apply to
+    // `docker exec`). A literal `--` would be exec'd as a binary
+    // named "--" → 127, which silently broke every real agent_exec
+    // until this fix (the old stub ignored argv past $1 so tests
+    // never caught it). This pins the corrected invocation.
     expect(resp.stdout_tail).toContain(
-      "docker: exec switchroom-bob -- ls -la /state",
+      "docker: exec switchroom-bob ls -la /state",
     );
+    expect(resp.stdout_tail).not.toContain(" -- ");
   });
 
   it("agent_exec: argv element with a newline/NUL/CR is denied (#1401)", async () => {


### PR DESCRIPTION
## Summary

**Production-breaking bug, found by live-verification.** `docker exec` — unlike `docker run` — stops parsing its **own** options at `CONTAINER`; every token after the container name is the command. Verified against real docker: `docker exec C -e X cmd` execs a program literally named `-e` (it is **not** read as `--env`). So #1401's concern (caller `argv[0]` reparsed as a docker flag) **cannot occur for `docker exec`**, and the literal `--` added for it is actively harmful — `docker exec C -- sh …` makes docker try to exec a binary named `"--"` → `executable file not found` → **exit 127**.

**Impact:** every real `agent_exec` (#1208/#1401) **and** `agent_smoke` (#1525) was broken in production — every call 127'd. Invisible because the hostd server tests use a docker **stub shell script** that ignored argv past `$1`, so `--` was never exercised against real docker. Surfaced by live-verifying the `agent_smoke` doctor section right after deploying 0.12.11: all 5 probes × all 9 agents = `exit 127`.

## Changes

- `server.ts`: remove `--` from both `runDocker(["exec", container, …])` sites (`handleAgentExec`, `handleAgentSmoke`); replace the incorrect #1401 comment with the verified rationale.
- `server.test.ts`: the docker **stub now models real docker** — a `--` in the command position exits 127 — so reintroducing the `--` fails the `agent_smoke` "all probes ok" test (closes the stub-masking gap that hid this). Updated the `agent_exec` argv assertion to pin the corrected (no-`--`) invocation and assert ` -- ` is absent.

## Test plan

- [x] 79 hostd/doctor tests green; `tsc` clean (only the 3 pre-existing unrelated `@mtcute/node` UAT errors).
- [x] Verified directly against the live fleet: `docker exec switchroom-clerk -- sh …` → exit 127; `docker exec switchroom-clerk sh …` → exit 0.
- [ ] CI green → reviewer APPROVE → auto-merge → release **0.12.12** → `switchroom update` → **re-verify the "Agent liveness" section flips from all-127-FAIL to real per-agent `ok`/`✗`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)