### PR TITLE
fix(hostd): agent_smoke auth probe checks the real cred path

### DIFF
--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1177,7 +1177,14 @@ export class HostdServer {
     const PROBES: { name: string; cmd: string }[] = [
       {
         name: "auth",
-        cmd: 'test -s "$CLAUDE_CONFIG_DIR/.credentials.json" || test -s "$HOME/.claude/.credentials.json"',
+        // The agent's claude state dir is /state/agent/.claude — NOT
+        // $HOME/.claude (HOME=/state/agent/home) and CLAUDE_CONFIG_DIR
+        // is unset in-container. Verified live: the OAuth credential
+        // is /state/agent/.claude/.credentials.json. Probing the
+        // $HOME/$CLAUDE_CONFIG_DIR paths gave a false "auth FAIL" for
+        // every (healthy, Telegram-serving) agent. Match the other
+        // probes, which already key off /state/agent.
+        cmd: "test -s /state/agent/.claude/.credentials.json",
       },
       {
         name: "scheduler",

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -542,6 +542,34 @@ describe("hostd server — agent_smoke (read-only in-agent battery)", () => {
     expect(body.probes.every((p: { state: string }) => p.state === "ok")).toBe(true);
   });
 
+  it("probe commands target the real in-agent paths (regression: auth path)", async () => {
+    // Pin the probe command STRINGS. Live-verify caught the auth probe
+    // checking $CLAUDE_CONFIG_DIR/$HOME (both wrong/empty in-agent) →
+    // false "auth FAIL" fleet-wide; the real cred is
+    // /state/agent/.claude/.credentials.json. Stub-only tests can't
+    // exercise real paths, so assert the literal cmds here.
+    const argsLog = join(tmp, `smoke-args-${Math.random().toString(36).slice(2)}.log`);
+    await withDocker(
+      `#!/bin/sh\ncase "$1" in\n  inspect) echo "true"; exit 0 ;;\n  exec) echo "$@" >> ${argsLog}; exit 0 ;;\nesac\nexit 0\n`,
+    );
+    const sock = server.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+    await hostdRequest(
+      { socketPath: sock },
+      { v: 1, op: "agent_smoke", request_id: "sm-paths", args: { name: "klanker" } },
+    );
+    const { readFileSync } = await import("node:fs");
+    const seen = readFileSync(argsLog, "utf8");
+    // auth probe must use the verified real path…
+    expect(seen).toContain("/state/agent/.claude/.credentials.json");
+    // …and must NOT use the old wrong locations.
+    expect(seen).not.toContain("CLAUDE_CONFIG_DIR");
+    expect(seen).not.toContain("$HOME/.claude/.credentials.json");
+    // other probes still key off /state/agent
+    expect(seen).toContain("/state/agent/start.sh");
+    expect(seen).toContain("/state/agent/.mcp.json");
+    expect(seen).toContain("/state/agent/telegram/.env");
+  });
+
   it("cross-agent denied for a non-admin caller", async () => {
     await withDocker('#!/bin/sh\nexit 0\n');
     const sock = server.getBoundPaths().find((p) => p.endsWith("/bob/sock"))!;


### PR DESCRIPTION
## Summary

Last fix in the honest-doctor arc. After the docker-exec `--` hotfix (#1529/v0.12.12), the `agent_smoke` battery's other 4 probes (scheduler/mcp/bot_token/state) went **green in-agent** — but `auth` still failed (now `exit 1`, not 127), keeping the "Agent liveness" section at 9 fail.

Root cause: the auth probe tested `$CLAUDE_CONFIG_DIR/.credentials.json || $HOME/.claude/.credentials.json`. **In an agent container `CLAUDE_CONFIG_DIR` is unset and `HOME=/state/agent/home`** — the claude state dir is `/state/agent/.claude` (the known non-$HOME agent-config location). So the probe checked nothing and false-failed for every healthy (Telegram-serving) agent.

**Verified live in-container:** the OAuth credential is `/state/agent/.claude/.credentials.json`. The probe now points there (consistent with the other probes, which already key off `/state/agent`).

Added a server test that captures the docker argv and **pins every probe's command string** — stub tests can't exercise real in-agent paths, so this is the structural regression guard for probe-path correctness (the gap that let this and the `--` bug through).

## Test plan
- [x] 58 hostd/doctor tests green; `tsc` clean.
- [x] Real cred path confirmed via `docker exec` into a live agent.
- [ ] CI green → reviewer APPROVE → auto-merge → release **0.12.13** → `switchroom update` → **FINAL verify: all 5 probes `ok`, "Agent liveness" flips to per-agent `ok`, the 9 fail clears**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)