### PR TITLE
chore: release v0.12.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.12.13 — fix: agent_smoke auth probe checked the wrong path
+
+### Changes
+
+#### Fixes
+
+- **fix(hostd):** the `agent_smoke` `auth` probe tested
+  `$CLAUDE_CONFIG_DIR`/`$HOME/.claude/.credentials.json`, but
+  in-agent `CLAUDE_CONFIG_DIR` is unset and `HOME=/state/agent/home`
+  while the real OAuth credential is `/state/agent/.claude/.credentials.json`
+  — so it false-failed "auth" for every healthy agent (the only
+  probe still red after the v0.12.12 `--` fix). Probe now targets the
+  verified path, consistent with the other probes. Completes the
+  honest-doctor arc (v0.12.9 `skip` → v0.12.10 `agent_smoke` →
+  v0.12.11 operator socket → v0.12.12 `--` → this): the "Agent
+  liveness" section now reports real per-agent `ok`. A new server
+  test pins every probe's command string so a wrong-path probe
+  can't regress unseen. (#1531)
+
 ## v0.12.12 — fix: docker-exec `--` broke agent_exec & agent_smoke in production
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.12.12",
+  "version": "0.12.13",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Delta vs v0.12.12 = the reviewed+merged **#1531** (agent_smoke auth probe → real cred path; completes the honest-doctor arc). package.json 0.12.12→0.12.13 + CHANGELOG only. Versioning verified: canonical/npm/host all 0.12.12 → next 0.12.13. After merge: build (real nm, verify exit) → publish → verify tarball → switchroom update → **FINAL verify all 5 probes ok, Agent liveness flips to ok**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)