### PR TITLE
feat(broker,doctor): preflight_access — default doctor verifies cron secrets

### DIFF
--- a/src/cli/doctor-secret-access.ts
+++ b/src/cli/doctor-secret-access.ts
@@ -35,12 +35,14 @@ import {
   realpathSync,
   statSync,
 } from "node:fs";
-import { userInfo } from "node:os";
+import { userInfo, homedir } from "node:os";
+import { join } from "node:path";
 
 import { resolveStatePath } from "../config/paths.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { openVault, type VaultEntry } from "../vault/vault.js";
 import { checkAclByAgent, checkEntryScope } from "../vault/broker/acl.js";
+import { rpcRaw } from "../vault/broker/client.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 import type { CheckStatus } from "./doctor-status.js";
@@ -74,7 +76,30 @@ export interface SecretAccessDeps {
   selfUid?: number;
   /** Current operator username (default os.userInfo().username). */
   selfUser?: string;
+  /**
+   * Operator-socket preflight RPC. Default: `rpcRaw(preflight_access)`
+   * over `~/.switchroom/broker-operator/sock`. Lets default `doctor`
+   * (no SWITCHROOM_VAULT_PASSPHRASE) verify cron-secret existence+ACL
+   * via the broker's already-unlocked vault. Injectable for tests.
+   */
+  preflight?: (agent: string, keys: string[]) => Promise<PreflightOutcome>;
+  /** Override the broker operator socket path (tests). */
+  brokerOperatorSocket?: string;
 }
+
+export interface PreflightKeyResult {
+  key: string;
+  exists: boolean;
+  acl_ok: boolean;
+  acl_reason?: string;
+  scope_ok: boolean;
+  scope_reason?: string;
+}
+
+export type PreflightOutcome =
+  | { kind: "ok"; results: PreflightKeyResult[] }
+  | { kind: "locked" }
+  | { kind: "unreachable"; msg: string };
 
 function resolveVaultPath(config: SwitchroomConfig): string {
   return config.vault?.path
@@ -133,10 +158,84 @@ function collectVaultRefs(value: unknown, out: Set<string>): void {
   }
 }
 
-export function runSecretAccessChecks(
+/** Per-agent declared secret needs: cron `schedule[].secrets[]`
+ *  (broker-served → checkAclByAgent gates) + every `vault:` config
+ *  ref (resolved operator-side; scope still applies). */
+function collectNeeds(resolved: unknown): {
+  needed: Set<string>;
+  cronKeys: Set<string>;
+} {
+  const cronKeys = new Set<string>();
+  for (const entry of (resolved as { schedule?: Array<{ secrets?: string[] }> })
+    .schedule ?? []) {
+    for (const s of entry.secrets ?? []) cronKeys.add(s);
+  }
+  const refKeys = new Set<string>();
+  collectVaultRefs(resolved, refKeys);
+  return { needed: new Set<string>([...cronKeys, ...refKeys]), cronKeys };
+}
+
+/**
+ * The ONE per-key gap rule, shared by the local-passphrase and the
+ * broker paths so they produce byte-identical verdicts. Returns a gap
+ * string or null. `google:` slots are auth-broker slots — existence
+ * is governed by google_accounts, not the vault blob, so skip the
+ * existence check for them. Cron keys get the static ACL check; the
+ * "no *static* ACL" wording is deliberate — a runtime capability/
+ * token grant the static check can't see may still cover it (do not
+ * regress this caveat).
+ */
+function keyGap(
+  key: string,
+  isCron: boolean,
+  exists: boolean,
+  acl: { allow: boolean; reason?: string },
+  scope: { allow: boolean; reason?: string },
+): string | null {
+  const isGoogleSlot = key.startsWith("google:");
+  if (!isGoogleSlot && !exists) return `'${key}' missing from the vault`;
+  if (isCron && !acl.allow) {
+    return `'${key}' (cron) — no static ACL grants read (${acl.reason})`;
+  }
+  if (!scope.allow) {
+    return `'${key}' — per-key scope denies read (${scope.reason})`;
+  }
+  return null;
+}
+
+/** Default preflight: one operator-socket RPC per agent. No
+ *  passphrase needed — the broker answers from its unlocked vault. */
+async function defaultPreflight(
+  socketPath: string,
+  agent: string,
+  keys: string[],
+): Promise<PreflightOutcome> {
+  const r = await rpcRaw(
+    { v: 1, op: "preflight_access", agent, keys },
+    { socket: socketPath, timeoutMs: 5000 },
+  );
+  if (r.kind === "unreachable") return { kind: "unreachable", msg: r.msg };
+  const resp = r.resp;
+  if (resp.ok === true && (resp as { op?: string }).op === "preflight_access") {
+    return {
+      kind: "ok",
+      results: (resp as unknown as { results: PreflightKeyResult[] }).results,
+    };
+  }
+  if (resp.ok === false && resp.code === "LOCKED") return { kind: "locked" };
+  return {
+    kind: "unreachable",
+    msg:
+      resp.ok === false
+        ? `broker error ${resp.code}: ${resp.msg}`
+        : "unexpected broker response",
+  };
+}
+
+export async function runSecretAccessChecks(
   config: SwitchroomConfig,
   deps: SecretAccessDeps = {},
-): CheckResult[] {
+): Promise<CheckResult[]> {
   const results: CheckResult[] = [];
   const vaultPath = deps.vaultPath ?? resolveVaultPath(config);
   const statVault = deps.statVault ?? defaultStatVault;
@@ -178,16 +277,91 @@ export function runSecretAccessChecks(
   }
 
   // ---- Check B: per-agent secret existence + ACL --------------------
+  const pushAgentResult = (
+    name: string,
+    total: number,
+    gaps: string[],
+  ): void => {
+    results.push(
+      gaps.length === 0
+        ? {
+            name: `secret access: ${name}`,
+            status: "ok",
+            detail: `${total} secret(s): all present + ACL ok`,
+          }
+        : {
+            name: `secret access: ${name}`,
+            status: "fail",
+            detail: `${gaps.length}/${total} unreachable — ${gaps.join("; ")}`,
+            fix:
+              "`switchroom vault set <key>` for missing keys; " +
+              "`switchroom vault set <key> --allow " +
+              name +
+              "` to grant this agent read access",
+          },
+    );
+  };
+
   const passphrase = deps.passphrase ?? process.env.SWITCHROOM_VAULT_PASSPHRASE;
   if (!passphrase) {
-    results.push({
-      name: "agent secret access",
-      status: "skip",
-      detail:
-        "SWITCHROOM_VAULT_PASSPHRASE not set — cannot enumerate vault keys/ACLs " +
-        "to verify per-agent secret access",
-      fix: "Export SWITCHROOM_VAULT_PASSPHRASE and re-run `switchroom doctor`",
-    });
+    // Default path — NO passphrase. Ask the vault-broker (which holds
+    // the vault unlocked in memory) over its operator socket, using
+    // the broker's OWN enforcement predicates. Turns the old
+    // passphrase-gated `skip` into a real verified verdict.
+    const sock =
+      deps.brokerOperatorSocket ??
+      join(homedir(), ".switchroom", "broker-operator", "sock");
+    const preflight =
+      deps.preflight ?? ((a: string, k: string[]) => defaultPreflight(sock, a, k));
+    for (const name of Object.keys(config.agents ?? {})) {
+      const resolved = resolveAgentConfig(
+        config.defaults,
+        config.profiles,
+        config.agents[name],
+      );
+      const { needed, cronKeys } = collectNeeds(resolved);
+      if (needed.size === 0) {
+        results.push({
+          name: `secret access: ${name}`,
+          status: "ok",
+          detail: "no declared vault secrets",
+        });
+        continue;
+      }
+      const out = await preflight(name, [...needed].sort());
+      if (out.kind === "unreachable" || out.kind === "locked") {
+        // Global condition (one broker) → a single honest skip, stop.
+        // Mirrors the historical single-skip shape; never a false fail.
+        results.push({
+          name: "agent secret access",
+          status: "skip",
+          detail:
+            out.kind === "locked"
+              ? "vault-broker is locked — cron-secret existence/ACL unverified (re-run after it unlocks; it auto-unlocks on boot)"
+              : `vault-broker operator socket unreachable (${out.msg}) and SWITCHROOM_VAULT_PASSPHRASE unset — cron-secret existence/ACL unverified`,
+          fix: "Ensure the broker operator socket (~/.switchroom/broker-operator/sock) is bound, or export SWITCHROOM_VAULT_PASSPHRASE and re-run `switchroom doctor`",
+        });
+        return results;
+      }
+      const byKey = new Map(out.results.map((r) => [r.key, r]));
+      const gaps: string[] = [];
+      for (const key of [...needed].sort()) {
+        const r = byKey.get(key);
+        if (r === undefined) {
+          gaps.push(`'${key}' — broker returned no result`);
+          continue;
+        }
+        const g = keyGap(
+          key,
+          cronKeys.has(key),
+          r.exists,
+          { allow: r.acl_ok, reason: r.acl_reason },
+          { allow: r.scope_ok, reason: r.scope_reason },
+        );
+        if (g) gaps.push(g);
+      }
+      pushAgentResult(name, needed.size, gaps);
+    }
     return results;
   }
 
@@ -206,31 +380,20 @@ export function runSecretAccessChecks(
     return results;
   }
 
-  const agents = Object.keys(config.agents ?? {});
-  for (const name of agents) {
+  // Passphrase IS set → local path (operator decrypts the vault
+  // themselves). Behaviour-identical to before; shares the SAME
+  // collectNeeds + keyGap rule as the broker path so the two can't
+  // drift. (Provenance: cron `schedule[].secrets[]` are broker-served
+  // → checkAclByAgent gates; plain `vault:` config refs are resolved
+  // operator-side and only the per-key scope applies — keyGap encodes
+  // exactly this.)
+  for (const name of Object.keys(config.agents ?? {})) {
     const resolved = resolveAgentConfig(
       config.defaults,
       config.profiles,
       config.agents[name],
     );
-
-    // Provenance matters. Cron `schedule[].secrets[]` are served at
-    // runtime BY THE BROKER, so the broker's cron allowlist
-    // (checkAclByAgent) AND the per-key scope (checkEntryScope) both
-    // gate them. Plain `vault:` config refs (bot_token, env, mcp, …)
-    // are resolved operator-side at scaffold time via openVault — they
-    // do NOT pass through checkAclByAgent (applying it here would
-    // falsely FAIL the canonical `bot_token: "vault:…"` config on any
-    // agent without a cron schedule). Per-key scope still applies to
-    // them wherever the broker serves them.
-    const cronKeys = new Set<string>();
-    for (const entry of (resolved as { schedule?: Array<{ secrets?: string[] }> }).schedule ?? []) {
-      for (const s of entry.secrets ?? []) cronKeys.add(s);
-    }
-    const refKeys = new Set<string>();
-    collectVaultRefs(resolved, refKeys);
-    const needed = new Set<string>([...cronKeys, ...refKeys]);
-
+    const { needed, cronKeys } = collectNeeds(resolved);
     if (needed.size === 0) {
       results.push({
         name: `secret access: ${name}`,
@@ -239,49 +402,18 @@ export function runSecretAccessChecks(
       });
       continue;
     }
-
     const gaps: string[] = [];
     for (const key of [...needed].sort()) {
-      // google:<acct>:* are auth-broker slots, not literal vault keys —
-      // existence is governed by google_accounts, not the vault blob;
-      // the ACL predicate already routes them, so check ACL only.
-      const isGoogleSlot = key.startsWith("google:");
-      if (!isGoogleSlot && !(key in entries)) {
-        gaps.push(`'${key}' missing from the vault`);
-        continue;
-      }
-      const byScope = checkEntryScope(entries[key]?.scope, name);
-      if (cronKeys.has(key)) {
-        // broker-served cron secret → full broker predicate
-        const byAgent = checkAclByAgent(config, name, key);
-        if (!byAgent.allow) {
-          gaps.push(`'${key}' (cron) — no static ACL grants read (${byAgent.reason})`);
-          continue;
-        }
-      }
-      if (!byScope.allow) {
-        gaps.push(`'${key}' — per-key scope denies read (${byScope.reason})`);
-      }
+      const g = keyGap(
+        key,
+        cronKeys.has(key),
+        key in entries,
+        checkAclByAgent(config, name, key),
+        checkEntryScope(entries[key]?.scope, name),
+      );
+      if (g) gaps.push(g);
     }
-
-    if (gaps.length === 0) {
-      results.push({
-        name: `secret access: ${name}`,
-        status: "ok",
-        detail: `${needed.size} secret(s): all present + ACL ok`,
-      });
-    } else {
-      results.push({
-        name: `secret access: ${name}`,
-        status: "fail",
-        detail: `${gaps.length}/${needed.size} unreachable — ${gaps.join("; ")}`,
-        fix:
-          "`switchroom vault set <key>` for missing keys; " +
-          "`switchroom vault set <key> --allow " +
-          name +
-          "` to grant this agent read access",
-      });
-    }
+    pushAgentResult(name, needed.size, gaps);
   }
 
   return results;

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2320,7 +2320,7 @@ export function registerDoctorCommand(program: Command): void {
           },
           { title: "Legacy State", results: checkLegacyState() },
           { title: "Vault", results: checkVault(config) },
-          { title: "Vault access", results: runSecretAccessChecks(config) },
+          { title: "Vault access", results: await runSecretAccessChecks(config) },
           { title: "Memory (Hindsight)", results: await checkHindsight(config) },
           { title: "Telegram", results: await checkTelegram(config) },
           { title: "Agents", results: checkAgents(config, configPath) },

--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -29,7 +29,7 @@ import * as path from "node:path";
 import { chainRow, seedChain, type ChainState } from "../../util/audit-hashchain.js";
 
 /** Operations the broker can perform. */
-export type AuditOp = "get" | "put" | "set" | "delete" | "list" | "unlock" | "lock" | "mint_grant" | "list_grants" | "revoke_grant";
+export type AuditOp = "get" | "put" | "set" | "delete" | "list" | "unlock" | "lock" | "mint_grant" | "list_grants" | "revoke_grant" | "preflight_access";
 
 /**
  * One audit log entry.

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -206,6 +206,49 @@ export const LockRequestSchema = z.object({
   op: z.literal("lock"),
 });
 
+/**
+ * Read-only OPERATOR-ONLY introspection: "for agent <agent>, what is
+ * the static existence + ACL/scope status of these keys?" Answered
+ * from the broker's already-unlocked in-memory vault using the SAME
+ * predicates the real `get` path composes — so the caller (doctor)
+ * gets the verified truth WITHOUT holding SWITCHROOM_VAULT_PASSPHRASE.
+ * NEVER returns secret values. Agent (per-agent socket) callers are
+ * rejected — this is an operator tool, and the key list is a key-
+ * existence oracle that only the operator (same trust root as the
+ * vault file) may use. `acl`/`scope` mirror what doctor-secret-
+ * access.ts already computes locally; the caller decides per
+ * provenance which to apply (cron keys → acl; scope always; google:
+ * slots → existence n/a). Caveat preserved on the consumer side:
+ * a missing static ACL does NOT prove no access (a runtime
+ * capability/token grant the static check can't see may still cover
+ * it) — same "no *static* ACL" wording as the local path.
+ */
+export const PreflightAccessRequestSchema = z.object({
+  v: z.literal(1),
+  op: z.literal("preflight_access"),
+  agent: z.string().min(1),
+  keys: z.array(z.string().min(1)).min(1).max(128),
+});
+
+export const OkPreflightAccessResponseSchema = z.object({
+  ok: z.literal(true),
+  op: z.literal("preflight_access"),
+  results: z.array(
+    z.object({
+      key: z.string(),
+      /** Key present in the unlocked vault map. */
+      exists: z.boolean(),
+      /** checkAclByAgent(config, agent, key).allow — the static-ACL
+       *  signal the agent `get` path uses. NEVER a value. */
+      acl_ok: z.boolean(),
+      acl_reason: z.string().optional(),
+      /** checkEntryScope(entry.scope, agent).allow */
+      scope_ok: z.boolean(),
+      scope_reason: z.string().optional(),
+    }),
+  ),
+});
+
 
 // ─── Approval kernel (RFC B) ────────────────────────────────────────────────
 
@@ -274,6 +317,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   ListRequestSchema,
   StatusRequestSchema,
   LockRequestSchema,
+  PreflightAccessRequestSchema,
   MintGrantRequestSchema,
   ListGrantsRequestSchema,
   RevokeGrantRequestSchema,
@@ -290,6 +334,8 @@ export type PutRequest = z.infer<typeof PutRequestSchema>;
 export type ListRequest = z.infer<typeof ListRequestSchema>;
 export type StatusRequest = z.infer<typeof StatusRequestSchema>;
 export type LockRequest = z.infer<typeof LockRequestSchema>;
+export type PreflightAccessRequest = z.infer<typeof PreflightAccessRequestSchema>;
+export type OkPreflightAccessResponse = z.infer<typeof OkPreflightAccessResponseSchema>;
 export type MintGrantRequest = z.infer<typeof MintGrantRequestSchema>;
 export type ListGrantsRequest = z.infer<typeof ListGrantsRequestSchema>;
 export type RevokeGrantRequest = z.infer<typeof RevokeGrantRequestSchema>;
@@ -487,6 +533,7 @@ export const ResponseSchema = z.union([
   OkKeysResponseSchema,
   OkStatusResponseSchema,
   OkLockResponseSchema,
+  OkPreflightAccessResponseSchema,
   OkPutResponseSchema,
   OkMintGrantResponseSchema,
   OkListGrantsResponseSchema,

--- a/src/vault/broker/server.test.ts
+++ b/src/vault/broker/server.test.ts
@@ -842,4 +842,32 @@ describe("VaultBroker server: audit log emission (denied identity)", () => {
       expect(entry.result).toMatch(/^denied:/);
     },
   );
+
+  // ── preflight_access: operator-only gate ────────────────────────────────
+  // The operator-ALLOWED path needs a real /run/switchroom/broker/
+  // operator socket (peercred's SOCKET_PATH regexes are hard-anchored
+  // there — that path-shape IS the security root, so a unit test can't
+  // bind one; no broker test does). The GATE — a non-operator
+  // (per-agent/default) caller is refused — is the new security-
+  // critical behaviour and is fully testable here. The operator-
+  // allowed computation is covered by composition: checkAclByAgent/
+  // checkEntryScope (acl.test.ts) + the consumer mapping incl.
+  // locked→skip (doctor-secret-access.test.ts, injected preflight).
+  it("preflight_access: DENIED on a non-operator socket, and audited without secret material", async () => {
+    const resp = await rpc(socketPath, {
+      v: 1,
+      op: "preflight_access",
+      agent: "anyone",
+      keys: ["foo", "baz"],
+    });
+    expect(resp.ok).toBe(false);
+    if (!resp.ok) expect(resp.code).toBe("DENIED");
+    const row = readAuditLines(auditLogPath).find(
+      (e) => e.op === "preflight_access",
+    );
+    expect(row).toBeDefined();
+    expect(row!.result).toMatch(/^denied:operator-only/);
+    // Never carries a secret value.
+    expect(JSON.stringify(row)).not.toContain("bar-value");
+  });
 });

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -856,6 +856,78 @@ export class VaultBroker {
       return;
     }
 
+    if (req.op === "preflight_access") {
+      // OPERATOR-ONLY. The {key→exists} answer is a key-existence
+      // oracle; only the operator (same trust root as the vault
+      // file — the operator socket is 0600 + chowned to the operator
+      // UID) may use it. An agent must never probe another agent's
+      // (or arbitrary) keys/ACL. `isOperator` is set ONLY by the
+      // canonical operator-socket bind (peercred), never by a
+      // per-agent socket, so this gate is airtight.
+      if (!isOperator) {
+        writeAudit({
+          ts: new Date().toISOString(),
+          op: "preflight_access",
+          caller: auditCaller,
+          pid: auditPid,
+          cgroup: auditCgroup,
+          result: "denied:operator-only",
+        });
+        socket.write(
+          encodeResponse(
+            errorResponse("DENIED", "preflight_access is operator-only"),
+          ),
+        );
+        return;
+      }
+      if (this.secrets === null) {
+        // Locked → the caller (doctor) maps LOCKED to `skip`, never a
+        // false fail. The broker is only locked pre-first-unlock or
+        // post-auth-failure, when the fleet's crons are dead anyway.
+        socket.write(
+          encodeResponse(errorResponse("LOCKED", "Vault is locked")),
+        );
+        return;
+      }
+      const pfSecrets = this.secrets;
+      const pfConfig = this.config;
+      const results = req.keys.map((key) => {
+        const exists = Object.prototype.hasOwnProperty.call(pfSecrets, key);
+        // The SAME predicates the real `get` path composes, so the
+        // verdict matches enforcement. NO secret value is ever read
+        // or returned — only existence + the boolean ACL/scope
+        // predicates. (The caller decides per provenance which to
+        // apply, and preserves the "no *static* ACL — a runtime
+        // grant may still cover this" caveat: a static miss here
+        // does NOT prove the agent lacks access.)
+        const acl =
+          pfConfig !== null
+            ? checkAclByAgent(pfConfig, req.agent, key)
+            : { allow: false as const, reason: "broker has no config loaded" };
+        const scope = checkEntryScope(pfSecrets[key]?.scope, req.agent);
+        return {
+          key,
+          exists,
+          acl_ok: acl.allow,
+          ...(acl.allow ? {} : { acl_reason: acl.reason }),
+          scope_ok: scope.allow,
+          ...(scope.allow ? {} : { scope_reason: scope.reason }),
+        };
+      });
+      writeAudit({
+        ts: new Date().toISOString(),
+        op: "preflight_access",
+        caller: auditCaller,
+        pid: auditPid,
+        cgroup: auditCgroup,
+        result: `allowed:agent=${req.agent},keys=${req.keys.length}`,
+      });
+      socket.write(
+        encodeResponse({ ok: true, op: "preflight_access", results }),
+      );
+      return;
+    }
+
     if (req.op === "list") {
       if (this.secrets === null) {
         socket.write(encodeResponse(errorResponse("LOCKED", "Vault is locked")));

--- a/tests/doctor-secret-access.test.ts
+++ b/tests/doctor-secret-access.test.ts
@@ -4,6 +4,7 @@ import {
   runSecretAccessChecks,
   type VaultFileStat,
   type SecretAccessDeps,
+  type PreflightOutcome,
 } from "../src/cli/doctor-secret-access.js";
 import type { VaultEntry } from "../src/vault/vault.js";
 import type { SwitchroomConfig } from "../src/config/schema.js";
@@ -20,6 +21,7 @@ const READABLE: VaultFileStat = {
   realPath: "/home/op/.switchroom/vault/vault.enc",
 };
 
+// Default deps: passphrase SET → exercises the (preserved) LOCAL path.
 function deps(over: Partial<SecretAccessDeps> = {}): SecretAccessDeps {
   return {
     vaultPath: "/v",
@@ -32,12 +34,28 @@ function deps(over: Partial<SecretAccessDeps> = {}): SecretAccessDeps {
   };
 }
 
-const get = (r: ReturnType<typeof runSecretAccessChecks>, name: string) =>
-  r.find((x) => x.name === name);
+// Broker-path deps: NO passphrase, inject a fake preflight RPC.
+function brokerDeps(
+  preflight: (a: string, k: string[]) => Promise<PreflightOutcome>,
+  over: Partial<SecretAccessDeps> = {},
+): SecretAccessDeps {
+  return {
+    vaultPath: "/v",
+    selfUid: 1000,
+    selfUser: "op",
+    statVault: () => READABLE,
+    passphrase: undefined,
+    preflight,
+    ...over,
+  };
+}
+
+type R = Awaited<ReturnType<typeof runSecretAccessChecks>>;
+const get = (r: R, name: string) => r.find((x) => x.name === name);
 
 describe("runSecretAccessChecks — Check A (operator readable)", () => {
-  it("ok when the vault file is absent (defers to Vault section)", () => {
-    const r = runSecretAccessChecks(
+  it("ok when the vault file is absent (defers to Vault section)", async () => {
+    const r = await runSecretAccessChecks(
       cfg({}),
       deps({
         statVault: () => ({
@@ -54,8 +72,8 @@ describe("runSecretAccessChecks — Check A (operator readable)", () => {
     expect(a?.detail).toContain("not present");
   });
 
-  it("FAILs with a chown fix when the file is root-locked", () => {
-    const r = runSecretAccessChecks(
+  it("FAILs with a chown fix when the file is root-locked", async () => {
+    const r = await runSecretAccessChecks(
       cfg({}),
       deps({
         statVault: () => ({
@@ -70,36 +88,18 @@ describe("runSecretAccessChecks — Check A (operator readable)", () => {
     const a = get(r, "vault: operator readable");
     expect(a?.status).toBe("fail");
     expect(a?.detail).toContain("uid 0");
-    expect(a?.fix).toBe(
-      "sudo chown op:op /home/op/.switchroom/vault/vault.enc",
-    );
+    expect(a?.fix).toBe("sudo chown op:op /home/op/.switchroom/vault/vault.enc");
   });
 
-  it("ok when the operator can read it", () => {
-    const r = runSecretAccessChecks(cfg({}), deps());
+  it("ok when the operator can read it", async () => {
+    const r = await runSecretAccessChecks(cfg({}), deps());
     expect(get(r, "vault: operator readable")?.status).toBe("ok");
   });
 });
 
-describe("runSecretAccessChecks — Check B (per-agent access)", () => {
-  it("skips (cannot verify) when the passphrase is unset", () => {
-    const saved = process.env.SWITCHROOM_VAULT_PASSPHRASE;
-    delete process.env.SWITCHROOM_VAULT_PASSPHRASE;
-    try {
-      const r = runSecretAccessChecks(
-        cfg({ a: {} }),
-        deps({ passphrase: undefined }),
-      );
-      const b = get(r, "agent secret access");
-      expect(b?.status).toBe("skip");
-      expect(b?.detail).toContain("SWITCHROOM_VAULT_PASSPHRASE not set");
-    } finally {
-      if (saved !== undefined) process.env.SWITCHROOM_VAULT_PASSPHRASE = saved;
-    }
-  });
-
-  it("fails 'agent secret access' when the vault won't open and the file IS readable", () => {
-    const r = runSecretAccessChecks(
+describe("runSecretAccessChecks — Check B local path (passphrase set)", () => {
+  it("fails when the vault won't open and the file IS readable", async () => {
+    const r = await runSecretAccessChecks(
       cfg({ a: {} }),
       deps({
         openVault: () => {
@@ -112,7 +112,7 @@ describe("runSecretAccessChecks — Check B (per-agent access)", () => {
     expect(b?.detail).toContain("bad passphrase");
   });
 
-  it("ok per agent when declared cron secrets exist and ACL allows", () => {
+  it("ok per agent when declared cron secrets exist and ACL allows", async () => {
     const config = cfg({
       scout: {
         schedule: [{ cron: "0 8 * * *", prompt: "x", secrets: ["api-key"] }],
@@ -122,97 +122,138 @@ describe("runSecretAccessChecks — Check B (per-agent access)", () => {
     const entries: Record<string, VaultEntry> = {
       "api-key": { kind: "string", value: "v" },
     };
-    const r = runSecretAccessChecks(config, deps({ openVault: () => entries }));
+    const r = await runSecretAccessChecks(
+      config,
+      deps({ openVault: () => entries }),
+    );
     expect(get(r, "secret access: scout")?.status).toBe("ok");
     expect(get(r, "secret access: scout")?.detail).toContain("all present");
-    expect(get(r, "secret access: bare")?.status).toBe("ok");
     expect(get(r, "secret access: bare")?.detail).toContain(
       "no declared vault secrets",
     );
   });
 
-  it("FAILs when a declared cron secret is missing from the vault", () => {
+  it("FAILs when a declared cron secret is missing from the vault", async () => {
     const config = cfg({
       scout: {
         schedule: [{ cron: "0 8 * * *", prompt: "x", secrets: ["api-key"] }],
       },
     });
-    const r = runSecretAccessChecks(config, deps({ openVault: () => ({}) }));
+    const r = await runSecretAccessChecks(
+      config,
+      deps({ openVault: () => ({}) }),
+    );
     const s = get(r, "secret access: scout");
     expect(s?.status).toBe("fail");
     expect(s?.detail).toContain("'api-key' missing from the vault");
     expect(s?.fix).toContain("--allow scout");
   });
 
-  it("FAILs when the per-key scope denies the agent", () => {
+  it("config vault: ref is per-key-scope checked but NOT run through checkAclByAgent", async () => {
+    const config = cfg({
+      tgbot: { channels: { telegram: { bot_token: "vault:tok" } } },
+    });
+    const okEntries: Record<string, VaultEntry> = {
+      tok: { kind: "string", value: "123:ABC" },
+    };
+    const okR = await runSecretAccessChecks(
+      config,
+      deps({ openVault: () => okEntries }),
+    );
+    expect(get(okR, "secret access: tgbot")?.status).toBe("ok");
+
+    const denyEntries: Record<string, VaultEntry> = {
+      tok: { kind: "string", value: "v", scope: { deny: ["tgbot"] } },
+    };
+    const denyR = await runSecretAccessChecks(
+      config,
+      deps({ openVault: () => denyEntries }),
+    );
+    const s = get(denyR, "secret access: tgbot");
+    expect(s?.status).toBe("fail");
+    expect(s?.detail).toContain("per-key scope denies");
+    expect(s?.detail).not.toContain("no static ACL");
+  });
+});
+
+describe("runSecretAccessChecks — Check B broker path (no passphrase)", () => {
+  it("ok per agent when the broker reports all keys present + ACL ok", async () => {
     const config = cfg({
       scout: {
         schedule: [{ cron: "0 8 * * *", prompt: "x", secrets: ["api-key"] }],
       },
+      bare: {},
     });
-    const entries: Record<string, VaultEntry> = {
-      "api-key": { kind: "string", value: "v", scope: { deny: ["scout"] } },
-    };
-    const r = runSecretAccessChecks(config, deps({ openVault: () => entries }));
-    const s = get(r, "secret access: scout");
-    expect(s?.status).toBe("fail");
-    expect(s?.detail).toContain("per-key scope denies");
+    const r = await runSecretAccessChecks(
+      config,
+      brokerDeps(async (_agent, keys) => ({
+        kind: "ok",
+        results: keys.map((key) => ({
+          key,
+          exists: true,
+          acl_ok: true,
+          scope_ok: true,
+        })),
+      })),
+    );
+    expect(get(r, "secret access: scout")?.status).toBe("ok");
+    expect(get(r, "secret access: scout")?.detail).toContain("all present");
+    expect(get(r, "secret access: bare")?.detail).toContain(
+      "no declared vault secrets",
+    );
   });
 
-  it("picks up `vault:` refs from config (not just cron) and flags missing", () => {
+  it("FAILs with the SAME gap strings as the local path (missing / cron-ACL / scope)", async () => {
     const config = cfg({
-      tgbot: { channels: { telegram: { bot_token: "vault:bot#x" } } },
-    });
-    const r = runSecretAccessChecks(config, deps({ openVault: () => ({}) }));
-    const s = get(r, "secret access: tgbot");
-    expect(s?.status).toBe("fail");
-    expect(s?.detail).toContain("'bot' missing from the vault");
-  });
-
-  it("OK for the canonical bot_token vault: ref with no cron schedule (no false ACL fail)", () => {
-    // Regression for the BLOCK: bot_token is resolved operator-side at
-    // scaffold time, NOT via the broker cron allowlist. An agent with
-    // no schedule[] must NOT be failed by checkAclByAgent.
-    const config = cfg({
-      tgbot: { channels: { telegram: { bot_token: "vault:tok" } } },
-    });
-    const entries: Record<string, VaultEntry> = {
-      tok: { kind: "string", value: "123:ABC" }, // exists, default (open) scope
-    };
-    const r = runSecretAccessChecks(config, deps({ openVault: () => entries }));
-    const s = get(r, "secret access: tgbot");
-    expect(s?.status).toBe("ok");
-    expect(s?.detail).toContain("all present");
-  });
-
-  it("config vault: ref is still per-key-scope checked (deny ⇒ fail)", () => {
-    const config = cfg({
-      tgbot: { channels: { telegram: { bot_token: "vault:tok" } } },
-    });
-    const entries: Record<string, VaultEntry> = {
-      tok: { kind: "string", value: "v", scope: { deny: ["tgbot"] } },
-    };
-    const r = runSecretAccessChecks(config, deps({ openVault: () => entries }));
-    const s = get(r, "secret access: tgbot");
-    expect(s?.status).toBe("fail");
-    expect(s?.detail).toContain("per-key scope denies");
-    expect(s?.detail).not.toContain("no static ACL"); // not run through checkAclByAgent
-  });
-
-  it("does not false-'missing' a google:<acct> slot ref (existence skipped)", () => {
-    const config = cfg({
-      g: {
+      scout: {
         schedule: [
-          { cron: "0 8 * * *", prompt: "x", secrets: ["google:a@x:drive"] },
+          { cron: "0 8 * * *", prompt: "x", secrets: ["missing", "noacl"] },
         ],
       },
     });
-    // not in the vault blob, but isGoogleSlot ⇒ existence skipped; ACL
-    // is evaluated via checkAclByAgent (no google_accounts ⇒ denied).
-    const r = runSecretAccessChecks(config, deps({ openVault: () => ({}) }));
-    const s = get(r, "secret access: g");
+    const r = await runSecretAccessChecks(
+      config,
+      brokerDeps(async (_a, _k) => ({
+        kind: "ok",
+        results: [
+          { key: "missing", exists: false, acl_ok: true, scope_ok: true },
+          {
+            key: "noacl",
+            exists: true,
+            acl_ok: false,
+            acl_reason: "no allow grant",
+            scope_ok: true,
+          },
+        ],
+      })),
+    );
+    const s = get(r, "secret access: scout");
     expect(s?.status).toBe("fail");
-    expect(s?.detail).not.toContain("missing from the vault");
-    expect(s?.detail).toContain("no static ACL");
+    expect(s?.detail).toContain("'missing' missing from the vault");
+    expect(s?.detail).toContain(
+      "'noacl' (cron) — no static ACL grants read (no allow grant)",
+    );
+  });
+
+  it("broker LOCKED → single honest skip (never a false fail)", async () => {
+    const r = await runSecretAccessChecks(
+      cfg({ a: { schedule: [{ cron: "* * * * *", prompt: "p", secrets: ["k"] }] } }),
+      brokerDeps(async () => ({ kind: "locked" })),
+    );
+    const b = get(r, "agent secret access");
+    expect(b?.status).toBe("skip");
+    expect(b?.detail).toContain("locked");
+    expect(r.some((x) => x.status === "fail")).toBe(false);
+  });
+
+  it("broker unreachable → single honest skip (never a false fail)", async () => {
+    const r = await runSecretAccessChecks(
+      cfg({ a: { schedule: [{ cron: "* * * * *", prompt: "p", secrets: ["k"] }] } }),
+      brokerDeps(async () => ({ kind: "unreachable", msg: "ENOENT" })),
+    );
+    const b = get(r, "agent secret access");
+    expect(b?.status).toBe("skip");
+    expect(b?.detail).toContain("unreachable");
+    expect(r.some((x) => x.status === "fail")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`switchroom doctor`'s "Vault access" check verifies, per agent, that the secrets its cron `schedule[].secrets[]` + `vault:` refs declare **(a)** exist and **(b)** the agent has ACL — using the broker's own predicates. But it opened the vault file *locally*, needing `SWITCHROOM_VAULT_PASSPHRASE`, so on a **normal run it `skip`ped**. Net: a cron could silently fail at fire time on a missing key/ACL and default `doctor` never caught it.

New read-only **operator-only** broker op **`preflight_access{agent, keys}`** → per-key `{exists, acl_ok, scope_ok, reasons}`, answered from the broker's *already-unlocked in-memory vault* using the **same** predicates the real `get` path composes (`checkAclByAgent`/`checkEntryScope`). **Never returns secret values.** A per-agent (non-operator) socket is refused — the `{key→exists}` answer is an operator-only oracle and the gate is airtight (`isOperator` is set only by the canonical operator-socket bind; peercred path-regexes are hard-anchored). Locked → `LOCKED` (consumer maps → `skip`, never a false fail).

`doctor-secret-access`: no passphrase → ask the broker over its operator socket; broker unreachable/locked → **one honest `skip`** (never false); passphrase set → **unchanged** local path. Both paths share **one** `collectNeeds` + `keyGap` rule so they can't drift, **preserving the "no *static* ACL — a runtime grant may still cover this" caveat** (matches what `get` actually enforces for agents).

Independently **plan-reviewed** (verdict REVISE → all findings adopted: mirror the existing cron/scope split, *not* a flat-AND that would false-fail agents with runtime grants; `LOCKED` as the explicit skip discriminator; doctor passes the declared needed-set).

## Test plan

- [x] Broker: `preflight_access` on a non-operator socket → `DENIED`, audited `denied:operator-only`, response/audit carry **no** secret material.
- [x] Consumer (injected preflight): broker `ok` → per-agent ok / **same gap strings** as the local path (missing / cron-no-static-ACL / scope-deny); `locked` → single skip; `unreachable` → single skip; local path (passphrase set) preserved.
- [x] 40 vitest green (consumer + protocol); `tsc` clean.
- [x] **5 broker-server *bun* failures are pre-existing + environment-dependent** (non-Linux peercred) — *identical on upstream/main*, CI-green — not introduced by this PR.
- [ ] CI green → reviewer APPROVE → auto-merge → release → `switchroom update` → **verify default `doctor` "Vault access" shows real per-agent cron-secret `ok`/`✗` instead of the passphrase `skip`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)