### PR TITLE
fix(broker): a test-injected broker must not auto-unlock the real vault

### DIFF
--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -318,7 +318,18 @@ export class VaultBroker {
     // default mechanism, opt-in via vault.broker.autoUnlock=true), then
     // falls back to $CREDENTIALS_DIRECTORY for power users running the
     // broker as a system unit with systemd LoadCredentialEncrypted=.
-    this._tryAutoUnlock();
+    //
+    // SKIP when _testSecrets was injected: those ARE the authoritative
+    // unlocked vault for this (test-only) broker. Without this guard a
+    // test broker started on a real deployment host auto-unlocks from
+    // the host's ~/.switchroom/vault-auto-unlock blob and silently
+    // replaces the 3 injected fixtures with the real ~90-key fleet
+    // vault — making the broker server tests pass in clean CI but FAIL
+    // on any host where switchroom is actually deployed (a hermeticity
+    // bug), and pulling the real fleet vault into a test process.
+    if (this.testOpts._testSecrets === undefined) {
+      this._tryAutoUnlock();
+    }
 
     if (process.platform !== "linux") {
       // Reachable only when SWITCHROOM_BROKER_ALLOW_NON_LINUX=1 was set


### PR DESCRIPTION
## Summary

`VaultBroker.start()` called `_tryAutoUnlock()` **unconditionally**. When the broker is constructed with `_testSecrets` (the test-only injection path, guarded by `BrokerTestOpts`) **and** started on a host where switchroom is actually deployed, it auto-unlocked from the host's real `~/.switchroom/vault-auto-unlock` blob and **silently replaced the injected fixtures with the real ~90-key fleet vault**.

- **Hermeticity bug:** the broker server tests passed in clean CI (no blob) but **failed deterministically on any real deployment host** — `status`/`list`/`get`/`audit` asserting `keyCount === 3` received `90`, etc. (5 tests in `server.test.ts`). A suite that's green in CI but red on every real host is the "tests don't reflect reality" trap.
- **Mild safety issue:** a test-mode broker process pulled the real fleet vault into memory.

**Fix:** skip machine-bound / systemd auto-unlock when `_testSecrets` is injected — those *are* the authoritative unlocked vault for that broker; ambient host auto-unlock has no business overriding an explicit test injection. Strictly correct (the `_test*` path is test-only and `BrokerTestOpts`-guarded) and makes the broker server suite hermetic on every host.

## Test plan

- [x] On this deployment host: `bun test src/vault/broker/server.test.ts` → **24 pass/5 fail → 29 pass/0 fail**.
- [x] `tsc` clean (only the 3 pre-existing unrelated `@mtcute/node` errors).
- [x] No behaviour change in production: `_testSecrets` is test-only; real brokers (no `_testSecrets`) still auto-unlock exactly as before.
- [x] One-line guard; no broker security/ACL/grant logic touched.

Out of scope (separately filed): 2 `client-token.test.ts` grant-rejection tests still fail on this host only — pre-existing, identical on clean `upstream/main`, CI-green, and **verified NOT** auto-unlock/HOME related; needs dedicated repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)