### PR TITLE
fix(gateway): buffer Telegram-inbound + button-tap delivery (PR-2/4)

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -176,7 +176,13 @@ ALLOWLIST=(
   # inside). Widened end 10430 -> 10480; grep confirms only
   # 10423/10446/10470 are raw calls in 10431-10480 — all the same
   # already-.catch-swallowed wizard editMessageText sites, no new one.
-  "telegram-plugin/gateway/gateway.ts:9340-10480:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-19 for PR-2 of the callback-continuation series:
+  # the ~+11-line normal-inbound sendToAgent+buffer rewrite (~line
+  # 6987) drifted the wizard editMessageText callsites to
+  # 10434/10457/10481 (10481 past the old 10480 ceiling). Widened end
+  # 10480 -> 10490; grep confirms 10481 is the only raw call in
+  # 10481-10540 — same already-.catch-swallowed wizard site, no new one.
+  "telegram-plugin/gateway/gateway.ts:9340-10490:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6984,17 +6984,28 @@ async function handleInbound(
     },
   }
 
-  // Try to send to a connected bridge. If no bridge connected, tell the user.
-  ipcServer.broadcast(inboundMsg)
-  const delivered = ipcServer.clientCount() > 0
-
+  // Deliver to THIS agent's registered bridge, buffering on miss.
+  // broadcast()/clientCount() were the wrong primitives: broadcast is
+  // not registered-keyed (writes to any alive socket incl. an
+  // unregistered pre-handshake one) and yields no delivered signal,
+  // and clientCount() counts unregistered sockets — so a bridge
+  // mid-reconnect made clientCount()>0, the message was broadcast into
+  // a non-registered socket, the "restarting" notice was suppressed,
+  // and the user's message was silently lost. The old "queued either
+  // way" comment was false: broadcast does not queue. sendToAgent is
+  // registered-keyed + returns a real delivered bool; on a miss we
+  // push to pendingInboundBuffer, which onClientRegistered drains on
+  // the next bridge register — so the notice below is now truthful.
+  const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
+  const delivered = ipcServer.sendToAgent(selfAgent, inboundMsg)
   if (!delivered) {
+    pendingInboundBuffer.push(selfAgent, inboundMsg)
     const threadOpts = messageThreadId != null ? { message_thread_id: messageThreadId } : {}
     // #1075: thread-id-bearing — swallow via robustApiCall so a deleted
-    // topic doesn't crash the gateway. Fire-and-forget; the user-visible
-    // hint is non-critical (the inbound is queued either way).
+    // topic doesn't crash the gateway. Fire-and-forget; the inbound is
+    // genuinely buffered now, so the hint is accurate, not a guess.
     void swallowingApiCall(
-      () => bot.api.sendMessage(chat_id, '⏳ Agent is restarting, please wait…', { ...threadOpts }),
+      () => bot.api.sendMessage(chat_id, '⏳ Agent is restarting — your message is queued and will be processed when it reconnects.', { ...threadOpts }),
       {
         chat_id,
         verb: 'agent-restarting-notice',
@@ -12132,16 +12143,25 @@ bot.on('callback_query:data', async ctx => {
     process.stderr.write(
       `telegram gateway: button_callback chatId=${cbChatId} user=${ctx.from.id} data=${JSON.stringify(agentCb.raw)} btnText=${JSON.stringify(buttonText ?? null)}\n`,
     )
-    ipcServer.broadcast(inboundMsg)
-    if (ipcServer.clientCount() === 0) {
-      // No bridge connected — the agent's gone. Tell the user so they
-      // don't think the button silently swallowed their tap.
+    // Registered-keyed delivery + buffer-on-miss (same fix as the
+    // normal-inbound path above): broadcast()/clientCount() lost the
+    // tap whenever the bridge was mid-reconnect (clientCount() counts
+    // unregistered sockets, so the notice was suppressed AND nothing
+    // was actually queued). sendToAgent → pendingInboundBuffer (drained
+    // by onClientRegistered) makes the "queued" promise real.
+    const selfAgentBtn = process.env.SWITCHROOM_AGENT_NAME ?? ''
+    const btnDelivered = ipcServer.sendToAgent(selfAgentBtn, inboundMsg)
+    if (!btnDelivered) {
+      pendingInboundBuffer.push(selfAgentBtn, inboundMsg)
+      // No registered bridge — the agent's mid-restart. Tell the user
+      // so they don't think the button silently swallowed their tap;
+      // the tap is genuinely buffered now and replays on reconnect.
       // #1075: thread-id-bearing — swallow on THREAD_NOT_FOUND.
       void swallowingApiCall(
         () =>
           bot.api.sendMessage(
             cbChatId,
-            '⏳ Agent is restarting — your button tap was queued but won\'t be processed until it comes back.',
+            '⏳ Agent is restarting — your button tap is queued and will be processed when it comes back.',
             cbThreadId != null ? { message_thread_id: cbThreadId } : {},
           ),
         {


### PR DESCRIPTION
## Summary

PR-2 of the callback→model-continuation reliability series. **This is the owner's core symptom** — a user sends a message or taps a button and the model never proceeds / they're left silent.

Both inbound-delivery callsites in `gateway.ts` used `ipcServer.broadcast(inboundMsg)` guarded by `ipcServer.clientCount()`:
- the **normal Telegram-text → agent** path (~line 6987)
- the **agent button (`agent:` callback)** path (~line 12146)

`broadcast()` is not registered-keyed and gives no delivered signal; `clientCount()` counts *unregistered* pre-handshake sockets. So whenever the bridge was mid-reconnect (every agent/gateway restart, claude session bounce), the guard read "connected", the message/tap was written into a non-registered socket and **lost**, and the "agent restarting" notice was **suppressed** — silent loss. The normal-path comment literally claimed "the inbound is queued either way" — false; `broadcast` does not queue.

Fix: both sites now use the proven cron/vault/PR-1 idiom — `ipcServer.sendToAgent(SWITCHROOM_AGENT_NAME, inboundMsg)` (registered-keyed, real `delivered` bool) → on miss `pendingInboundBuffer.push(...)`, drained by the existing `onClientRegistered` hook on the next bridge register. The "queued, will process when it reconnects" notice is now truthful.

## Test plan
- [x] Touched `gateway.ts` tsc-clean; full **non-tsc** lint clean (`check-bot-api-wrapping` — incl. the required line-drift allowlist re-bump 10480→10490, the PR-1 lesson; `check-bun-test-imports`; `check-no-pii-secrets`)
- [x] Existing `pending-inbound-buffer` / `ipc-server-client` / `ipc-server-race` / `finalize-callback` / `inline-keyboard-callbacks` / `gateway-bridge` suites green (80 tests, 0 fail) — no regression to the primitives this wires
- [x] Wiring is a faithful mirror of the already-tested `sendToAgent + pendingInboundBuffer + onClientRegistered-drain` pattern (cron #890s / vault #1052 / PR-1 #1536); the 13k-line monolith has no isolated unit seam without a risky refactor — testing posture matches PR-1 (reviewer verifies the wiring)
- [ ] Full CI

**Reviewer please also run `bash scripts/check-bot-api-wrapping.sh`** (PR-1's reviewer missed that the line-drift broke this CI check) and confirm both callsites mirror the proven idiom.

> Re-scope note: permission-verdict redelivery moved to **PR-3** — `pendingPermissions` has no agent name and is architecturally a single-bridge broadcast; its fix is a `pendingPermissions`-lifecycle change that coheres with PR-3's TTL-sweep work, not this InboundMessage-path change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)