### PR TITLE
fix(vault-broker): grant Drive-enabled agents the OAuth client credential (RFC G §4.4)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -110,8 +110,8 @@ import {
   getHindsightSettingsEntry,
   getBuiltinDefaultMcpEntries,
   getGdriveMcpSettingsEntry,
-  shouldEmitGdriveMcp,
 } from "../memory/scaffold-integration.js";
+import { shouldEmitGdriveMcp } from "../config/google-workspace-acl.js";
 import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
 import { applyTelegramProgressGuidance, applyCronTelegramGuidance } from "./sub-agent-telegram-prompt.js";
 import type { McpServerConfig } from "../memory/hindsight.js";

--- a/src/config/google-workspace-acl.test.ts
+++ b/src/config/google-workspace-acl.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Google Workspace / Drive ACL predicates.
+ *
+ * `shouldEmitGdriveMcp` is the shared scaffold↔broker gate (relocated
+ * here from scaffold-integration so the broker can share it without the
+ * hindsight layer). `isGoogleClientCredentialKeyForAgent` is the broker
+ * clause that completes RFC G §4.4: it grants a Drive-enabled agent
+ * read access to the OAuth client credential the config binds to it,
+ * which is otherwise broker-denied (the launcher can't spawn the gdrive
+ * MCP — the exact fleet-wide production failure this fixes).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { SwitchroomConfig } from "./schema.js";
+import {
+  shouldEmitGdriveMcp,
+  vaultRefKey,
+  isGoogleClientCredentialKeyForAgent,
+} from "./google-workspace-acl.js";
+
+describe("shouldEmitGdriveMcp — broker-ACL contract", () => {
+  // The same config that makes the scaffold emit the gdrive entry MUST
+  // be the config under which the broker would return a Google account.
+  // Broker logic (src/auth/broker/server.ts opGoogleGetCredentials):
+  //   account = agents.<name>.google_workspace.account  (must be set)
+  //   ACL     = google_accounts[account].enabled_for[].includes(name)
+  // shouldEmitGdriveMcp encodes exactly that — these cases pin both
+  // sides to one predicate.
+
+  it("emits when account set AND agent in enabled_for[] (broker would return creds)", () => {
+    expect(
+      shouldEmitGdriveMcp("carrie", "you@example.com", {
+        "you@example.com": { enabled_for: ["clerk", "carrie"] },
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT emit when agent has no google_workspace.account (broker → ACCOUNT_NOT_FOUND)", () => {
+    expect(
+      shouldEmitGdriveMcp("carrie", undefined, {
+        "you@example.com": { enabled_for: ["carrie"] },
+      }),
+    ).toBe(false);
+  });
+
+  it("does NOT emit when the referenced account isn't in google_accounts", () => {
+    expect(
+      shouldEmitGdriveMcp("carrie", "you@example.com", {
+        "other@gmail.com": { enabled_for: ["carrie"] },
+      }),
+    ).toBe(false);
+  });
+
+  it("does NOT emit when agent NOT in enabled_for[] (broker → FORBIDDEN)", () => {
+    expect(
+      shouldEmitGdriveMcp("carrie", "you@example.com", {
+        "you@example.com": { enabled_for: ["clerk"] },
+      }),
+    ).toBe(false);
+  });
+
+  it("does NOT emit when google_accounts is entirely absent", () => {
+    expect(shouldEmitGdriveMcp("carrie", "you@example.com", undefined)).toBe(
+      false,
+    );
+  });
+
+  it("normalizes account case/whitespace the same way the schema + broker do", () => {
+    // Schema lowercases+trims both the per-agent account and the
+    // google_accounts keys; the predicate must agree post-normalization.
+    expect(
+      shouldEmitGdriveMcp("carrie", "  You@Example.com  ", {
+        "you@example.com": { enabled_for: ["carrie"] },
+      }),
+    ).toBe(true);
+  });
+
+  it("treats an empty-string account as not configured", () => {
+    expect(
+      shouldEmitGdriveMcp("carrie", "   ", {
+        "you@example.com": { enabled_for: ["carrie"] },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("vaultRefKey — bare key extraction (mirrors the bot_token clause)", () => {
+  it("extracts the key from a plain vault: ref", () => {
+    expect(vaultRefKey("vault:google/client-secret")).toBe(
+      "google/client-secret",
+    );
+  });
+
+  it("strips a #scope suffix the same way the bot_token clause does", () => {
+    expect(vaultRefKey("vault:google/client-secret#read")).toBe(
+      "google/client-secret",
+    );
+  });
+
+  it("returns null for a literal (non-vault) value — no broker needed", () => {
+    expect(vaultRefKey("GOCSPX-literal-secret")).toBeNull();
+  });
+
+  it("returns null for an empty key (`vault:`)", () => {
+    expect(vaultRefKey("vault:")).toBeNull();
+    expect(vaultRefKey("vault:#scope")).toBeNull();
+  });
+
+  it("returns null for non-string / absent values", () => {
+    expect(vaultRefKey(undefined)).toBeNull();
+    expect(vaultRefKey(null)).toBeNull();
+    expect(vaultRefKey(42)).toBeNull();
+    expect(vaultRefKey("")).toBeNull();
+  });
+});
+
+/**
+ * Build a SwitchroomConfig with the Google Workspace surface populated.
+ * Mirrors the real shape: top-level `google_workspace` (client creds are
+ * top-level only per schema) + `google_accounts` (enabled_for[]) +
+ * per-agent `agents.<name>.google_workspace.account`.
+ */
+function gwConfig(opts: {
+  agentName: string;
+  account?: string;
+  enabledFor?: string[];
+  clientSecret?: string;
+  clientId?: string;
+  gdriveOptOut?: boolean;
+  includeAgent?: boolean;
+}): SwitchroomConfig {
+  const {
+    agentName,
+    account = "you@example.com",
+    enabledFor = [agentName],
+    clientSecret = "vault:google/client-secret",
+    clientId,
+    gdriveOptOut = false,
+    includeAgent = true,
+  } = opts;
+  return {
+    switchroom: { version: 1 },
+    telegram: { bot_token: "test", forum_chat_id: "123" },
+    google_accounts: { [account]: { enabled_for: enabledFor } },
+    google_workspace: {
+      google_client_id: clientId,
+      google_client_secret: clientSecret,
+    },
+    agents: includeAgent
+      ? {
+          [agentName]: {
+            topic_name: agentName,
+            google_workspace: { account },
+            ...(gdriveOptOut ? { mcp_servers: { gdrive: false } } : {}),
+          },
+        }
+      : {},
+  } as unknown as SwitchroomConfig;
+}
+
+describe("isGoogleClientCredentialKeyForAgent — RFC G §4.4 completion", () => {
+  it("grants a Drive-enabled agent the client-secret vault key even with NO schedule (the prod regression)", () => {
+    // klanker/ziggy in prod: enabled_for + account set, zero schedule
+    // entries → before this clause the launcher was broker-denied
+    // 'google/client-secret' and the gdrive MCP never spawned.
+    const cfg = gwConfig({ agentName: "klanker" });
+    expect(
+      isGoogleClientCredentialKeyForAgent(cfg, "klanker", "google/client-secret"),
+    ).toBe(true);
+  });
+
+  it("grants the client-id vault key too (symmetric with client-secret)", () => {
+    const cfg = gwConfig({
+      agentName: "klanker",
+      clientId: "vault:google/client-id",
+    });
+    expect(
+      isGoogleClientCredentialKeyForAgent(cfg, "klanker", "google/client-id"),
+    ).toBe(true);
+  });
+
+  it("honours a #scope suffix on the configured ref", () => {
+    const cfg = gwConfig({
+      agentName: "klanker",
+      clientSecret: "vault:google/client-secret#read",
+    });
+    expect(
+      isGoogleClientCredentialKeyForAgent(cfg, "klanker", "google/client-secret"),
+    ).toBe(true);
+  });
+
+  it("denies an agent NOT in enabled_for[] (same gate as the scaffold)", () => {
+    const cfg = gwConfig({ agentName: "klanker", enabledFor: ["clerk"] });
+    expect(
+      isGoogleClientCredentialKeyForAgent(cfg, "klanker", "google/client-secret"),
+    ).toBe(false);
+  });
+
+  it("denies when the agent has no google_workspace.account", () => {
+    const cfg = gwConfig({ agentName: "klanker" });
+    // Strip the per-agent account.
+    (cfg.agents as Record<string, { google_workspace?: unknown }>)[
+      "klanker"
+    ].google_workspace = undefined;
+    expect(
+      isGoogleClientCredentialKeyForAgent(cfg, "klanker", "google/client-secret"),
+    ).toBe(false);
+  });
+
+  it("denies an unrelated key (does not blanket-grant)", () => {
+    const cfg = gwConfig({ agentName: "klanker" });
+    expect(
+      isGoogleClientCredentialKeyForAgent(cfg, "klanker", "stripe/api-key"),
+    ).toBe(false);
+  });
+
+  it("does NOT grant when the client secret is a literal, not a vault: ref", () => {
+    // A literal is read straight from config by the launcher; the broker
+    // is never asked, so there is nothing to (and we must not) grant.
+    const cfg = gwConfig({
+      agentName: "klanker",
+      clientSecret: "GOCSPX-literal-value",
+    });
+    expect(
+      isGoogleClientCredentialKeyForAgent(
+        cfg,
+        "klanker",
+        "GOCSPX-literal-value",
+      ),
+    ).toBe(false);
+  });
+
+  it("respects the mcp_servers: { gdrive: false } hard opt-out", () => {
+    const cfg = gwConfig({ agentName: "klanker", gdriveOptOut: true });
+    expect(
+      isGoogleClientCredentialKeyForAgent(cfg, "klanker", "google/client-secret"),
+    ).toBe(false);
+  });
+
+  it("denies an unknown agent", () => {
+    const cfg = gwConfig({ agentName: "klanker", includeAgent: false });
+    expect(
+      isGoogleClientCredentialKeyForAgent(cfg, "klanker", "google/client-secret"),
+    ).toBe(false);
+  });
+
+  it("denies when google_workspace is entirely absent", () => {
+    const cfg = gwConfig({ agentName: "klanker" });
+    (cfg as { google_workspace?: unknown }).google_workspace = undefined;
+    expect(
+      isGoogleClientCredentialKeyForAgent(cfg, "klanker", "google/client-secret"),
+    ).toBe(false);
+  });
+});

--- a/src/config/google-workspace-acl.ts
+++ b/src/config/google-workspace-acl.ts
@@ -1,0 +1,144 @@
+/**
+ * Google Workspace / Drive ACL predicates — pure, zero-dependency.
+ *
+ * This module is imported by BOTH the agent scaffold
+ * (`src/agents/scaffold.ts` via `src/memory/scaffold-integration.ts`'s
+ * neighbours) AND the vault-broker ACL (`src/vault/broker/acl.ts`). The
+ * broker's `acl.ts` is deliberately pure (it only imports types) so its
+ * ACL logic can be unit-tested without standing up a broker; that is why
+ * these predicates live here and not in `scaffold-integration.ts` (which
+ * pulls in the hindsight memory layer). Keep this file dependency-free —
+ * type-only imports from the config schema, nothing else.
+ *
+ * The whole point of co-locating the gate predicate is that the scaffold
+ * (which decides whether to *emit* the `gdrive` MCP entry) and the broker
+ * (which decides whether to *serve* the OAuth client secret to that same
+ * agent) call the SAME function, so they can never disagree and leave an
+ * agent with a `gdrive` MCP whose launcher is broker-denied at spawn.
+ */
+
+import type { SwitchroomConfig } from "./schema.js";
+
+/**
+ * The shared gate predicate: should agent `<agentName>` receive the
+ * `gdrive` MCP entry (and, equivalently, be served the Google OAuth
+ * client credential by the vault-broker)?
+ *
+ * This MUST agree with the auth-broker's account-selection + ACL logic
+ * (`src/auth/broker/server.ts` opGoogleGetCredentials): the broker
+ * returns a Google account iff `agents.<name>.google_workspace.account`
+ * is set AND that account is a key in top-level `google_accounts` with
+ * `<name>` in its `enabled_for[]`. If the scaffold emitted the entry
+ * under looser conditions, the agent would get a `gdrive` MCP whose
+ * launcher fails at spawn (broker returns FORBIDDEN/ACCOUNT_NOT_FOUND) —
+ * a broken tool surface. So both sides call this one predicate.
+ *
+ * Hard opt-out (`mcp_servers: { gdrive: false }`) is handled by the
+ * caller (same shape as every other built-in default), NOT here — this
+ * predicate answers only "is this agent broker-authorized for Google".
+ *
+ * Account-name comparison is case-insensitive + trimmed because the
+ * config schema normalizes both the per-agent `google_workspace.account`
+ * and the `google_accounts` keys to lowercase; the broker compares the
+ * post-normalization strings. We re-normalize here defensively so a
+ * test or caller that hand-builds an un-normalized config still gets
+ * the same answer the broker would.
+ */
+export function shouldEmitGdriveMcp(
+  agentName: string,
+  agentGoogleAccount: string | undefined,
+  googleAccounts:
+    | Record<string, { enabled_for?: string[] } | undefined>
+    | undefined,
+): boolean {
+  if (!agentGoogleAccount) return false;
+  const account = agentGoogleAccount.trim().toLowerCase();
+  if (account.length === 0) return false;
+  const acctEntry = googleAccounts?.[account];
+  if (!acctEntry) return false;
+  const enabledFor = acctEntry.enabled_for ?? [];
+  return enabledFor.includes(agentName);
+}
+
+/**
+ * Extract the bare vault key from a config value that may be a `vault:`
+ * reference. Returns null when the value is absent, not a string, or not
+ * a `vault:` ref (i.e. a literal secret — no broker access is needed for
+ * a literal, the launcher reads it straight from config).
+ *
+ * Mirrors the bot_token clause in `acl.ts:checkAclByAgent` exactly,
+ * including the `#`-scope strip, so the key the broker authorizes can
+ * never diverge from the key the launcher actually requests.
+ */
+export function vaultRefKey(value: unknown): string | null {
+  if (typeof value !== "string" || !value.startsWith("vault:")) return null;
+  const key = value.slice("vault:".length).split("#")[0];
+  return key.length > 0 ? key : null;
+}
+
+/**
+ * Broker ACL predicate: may `<agentName>` read vault `<key>` because it
+ * is the Google OAuth client credential (`google_client_id` /
+ * `google_client_secret`) that the config assigns to this agent's Drive
+ * integration?
+ *
+ * This is identity-bound access to the single credential the config
+ * binds to THIS agent's `gdrive` MCP — NOT cross-agent secret access —
+ * exactly analogous to the per-agent bot_token clause in `acl.ts`. It
+ * deliberately bypasses the per-cron `schedule[].secrets[]` allowlist
+ * (which is cron-misconfiguration protection, not the auth boundary):
+ *
+ *   - RFC G §4.4 already gates the Google *account* slots
+ *     (`google:<account>:*`) by `google_accounts.<account>.enabled_for[]`
+ *     rather than schedule.secrets. The OAuth *client secret* is the one
+ *     remaining piece of the same Drive auth flow that was left out of
+ *     that model — without this, the `gdrive` MCP is dead on arrival on
+ *     every install that stores the client secret as a `vault:` ref
+ *     (the documented `switchroom auth google connect` shape), because
+ *     the launcher is broker-denied the secret before it can spawn.
+ *   - The grant is gated by `shouldEmitGdriveMcp` — the SAME predicate
+ *     the scaffold uses to decide whether to emit the entry at all — so
+ *     only agents that actually receive the `gdrive` MCP can read the
+ *     credential, and the two can never disagree.
+ *
+ * Honours the `mcp_servers: { gdrive: false }` hard opt-out so the grant
+ * stays exactly coextensive with the set of agents that get the MCP.
+ *
+ * Client id/secret are top-level-only per the config schema
+ * (`google_client_id/secret are not per-agent`), so we read them off
+ * `config.google_workspace`. The Drive-enabled gate uses the per-agent
+ * `google_workspace.account` + top-level `google_accounts`, mirroring
+ * `scaffold.ts:resolveGdriveMcpEntry`.
+ */
+export function isGoogleClientCredentialKeyForAgent(
+  config: SwitchroomConfig,
+  agentName: string,
+  key: string,
+): boolean {
+  if (!agentName || !key) return false;
+
+  const agentConfig = config.agents?.[agentName];
+  if (!agentConfig) return false;
+
+  // Hard opt-out: an agent with the gdrive MCP suppressed never spawns
+  // the launcher, so it must not be granted the credential either.
+  if (
+    (agentConfig.mcp_servers as Record<string, unknown> | undefined)?.[
+      "gdrive"
+    ] === false
+  ) {
+    return false;
+  }
+
+  const account = agentConfig.google_workspace?.account;
+  if (!shouldEmitGdriveMcp(agentName, account, config.google_accounts)) {
+    return false;
+  }
+
+  const gw = config.google_workspace;
+  if (!gw) return false;
+  for (const ref of [gw.google_client_id, gw.google_client_secret]) {
+    if (vaultRefKey(ref) === key) return true;
+  }
+  return false;
+}

--- a/src/memory/scaffold-integration.test.ts
+++ b/src/memory/scaffold-integration.test.ts
@@ -1,20 +1,20 @@
 /**
- * RFC G — `getGdriveMcpSettingsEntry()` launcher wiring + the shared
- * broker-ACL gate predicate (`shouldEmitGdriveMcp`).
+ * RFC G — `getGdriveMcpSettingsEntry()` launcher wiring.
  *
  * The entry used to be a bare `uvx` command with a dead
  * `GOOGLE_OAUTH_TOKEN_FROM_VAULT` env. It now points at the switchroom
  * CLI's hidden `drive-mcp-launcher` verb (the launcher seeds a
  * refresh-token credentials file and execs upstream `--single-user`).
- * These tests pin: the launcher command, no env block, the tier
- * pass-through, and the broker-ACL-contract agreement.
+ * These tests pin: the launcher command, no env block, and the tier
+ * pass-through. The shared broker-ACL gate predicate
+ * (`shouldEmitGdriveMcp`) moved to `config/google-workspace-acl.ts` —
+ * its contract tests live alongside it.
  */
 
 import { describe, expect, it } from "vitest";
 
 import {
   getGdriveMcpSettingsEntry,
-  shouldEmitGdriveMcp,
   type GdriveMcpTier,
 } from "./scaffold-integration.js";
 
@@ -57,70 +57,4 @@ describe("getGdriveMcpSettingsEntry — launcher command", () => {
       expect(flagIdx).toBeGreaterThan(args.indexOf("drive-mcp-launcher"));
     },
   );
-});
-
-describe("shouldEmitGdriveMcp — broker-ACL contract", () => {
-  // The same config that makes the scaffold emit the gdrive entry MUST
-  // be the config under which the broker would return a Google account.
-  // Broker logic (src/auth/broker/server.ts opGoogleGetCredentials):
-  //   account = agents.<name>.google_workspace.account  (must be set)
-  //   ACL     = google_accounts[account].enabled_for[].includes(name)
-  // shouldEmitGdriveMcp encodes exactly that — these cases pin both
-  // sides to one predicate.
-
-  it("emits when account set AND agent in enabled_for[] (broker would return creds)", () => {
-    expect(
-      shouldEmitGdriveMcp("carrie", "you@example.com", {
-        "you@example.com": { enabled_for: ["clerk", "carrie"] },
-      }),
-    ).toBe(true);
-  });
-
-  it("does NOT emit when agent has no google_workspace.account (broker → ACCOUNT_NOT_FOUND)", () => {
-    expect(
-      shouldEmitGdriveMcp("carrie", undefined, {
-        "you@example.com": { enabled_for: ["carrie"] },
-      }),
-    ).toBe(false);
-  });
-
-  it("does NOT emit when the referenced account isn't in google_accounts", () => {
-    expect(
-      shouldEmitGdriveMcp("carrie", "you@example.com", {
-        "other@gmail.com": { enabled_for: ["carrie"] },
-      }),
-    ).toBe(false);
-  });
-
-  it("does NOT emit when agent NOT in enabled_for[] (broker → FORBIDDEN)", () => {
-    expect(
-      shouldEmitGdriveMcp("carrie", "you@example.com", {
-        "you@example.com": { enabled_for: ["clerk"] },
-      }),
-    ).toBe(false);
-  });
-
-  it("does NOT emit when google_accounts is entirely absent", () => {
-    expect(
-      shouldEmitGdriveMcp("carrie", "you@example.com", undefined),
-    ).toBe(false);
-  });
-
-  it("normalizes account case/whitespace the same way the schema + broker do", () => {
-    // Schema lowercases+trims both the per-agent account and the
-    // google_accounts keys; the predicate must agree post-normalization.
-    expect(
-      shouldEmitGdriveMcp("carrie", "  You@Example.com  ", {
-        "you@example.com": { enabled_for: ["carrie"] },
-      }),
-    ).toBe(true);
-  });
-
-  it("treats an empty-string account as not configured", () => {
-    expect(
-      shouldEmitGdriveMcp("carrie", "   ", {
-        "you@example.com": { enabled_for: ["carrie"] },
-      }),
-    ).toBe(false);
-  });
 });

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -144,7 +144,8 @@ export interface GdriveMcpEntryOptions {
  * Default OFF for an agent — the scaffold only emits this entry when the
  * agent has `google_workspace.account` set AND that account lists the
  * agent in `google_accounts.<account>.enabled_for[]` (see
- * `shouldEmitGdriveMcp`). Agents can still hard opt-out with
+ * `shouldEmitGdriveMcp` in `config/google-workspace-acl.ts`). Agents can
+ * still hard opt-out with
  * `mcp_servers: { gdrive: false }`.
  *
  * @param switchroomCliPath  Absolute path to the in-container switchroom
@@ -168,46 +169,6 @@ export function getGdriveMcpSettingsEntry(
       args: ["drive-mcp-launcher", ...tierArgs],
     },
   };
-}
-
-/**
- * The shared gate predicate: should agent `<agentName>` receive the
- * `gdrive` MCP entry?
- *
- * This MUST agree with the auth-broker's account-selection + ACL logic
- * (`src/auth/broker/server.ts` opGoogleGetCredentials): the broker
- * returns a Google account iff `agents.<name>.google_workspace.account`
- * is set AND that account is a key in top-level `google_accounts` with
- * `<name>` in its `enabled_for[]`. If the scaffold emitted the entry
- * under looser conditions, the agent would get a `gdrive` MCP whose
- * launcher fails at spawn (broker returns FORBIDDEN/ACCOUNT_NOT_FOUND) —
- * a broken tool surface. So both sides call this one predicate.
- *
- * Hard opt-out (`mcp_servers: { gdrive: false }`) is handled by the
- * caller (same shape as every other built-in default), NOT here — this
- * predicate answers only "is this agent broker-authorized for Google".
- *
- * Account-name comparison is case-insensitive + trimmed because the
- * config schema normalizes both the per-agent `google_workspace.account`
- * and the `google_accounts` keys to lowercase; the broker compares the
- * post-normalization strings. We re-normalize here defensively so a
- * test or caller that hand-builds an un-normalized config still gets
- * the same answer the broker would.
- */
-export function shouldEmitGdriveMcp(
-  agentName: string,
-  agentGoogleAccount: string | undefined,
-  googleAccounts:
-    | Record<string, { enabled_for?: string[] } | undefined>
-    | undefined,
-): boolean {
-  if (!agentGoogleAccount) return false;
-  const account = agentGoogleAccount.trim().toLowerCase();
-  if (account.length === 0) return false;
-  const acctEntry = googleAccounts?.[account];
-  if (!acctEntry) return false;
-  const enabledFor = acctEntry.enabled_for ?? [];
-  return enabledFor.includes(agentName);
 }
 
 /**

--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -533,3 +533,62 @@ describe("ACL: an agent may read its OWN configured bot_token (install-validatio
     expect(checkAclByAgent(config, "admin", "random_key").allow).toBe(false);   // still gated
   });
 });
+
+describe("ACL: Google OAuth client credential (RFC G §4.4 completion)", () => {
+  // End-to-end through checkAclByAgent (the real broker entrypoint), not
+  // just the predicate. Pins that the clause is wired AND that it does
+  // not shadow the schedule.secrets gate for other keys.
+  function clientCredConfig(opts: {
+    enabledFor: string[];
+    clientSecret?: string;
+    schedule?: { cron: string; prompt: string; secrets?: string[] }[];
+  }): SwitchroomConfig {
+    return {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      google_accounts: {
+        "you@example.com": { enabled_for: opts.enabledFor },
+      },
+      google_workspace: {
+        google_client_secret: opts.clientSecret ?? "vault:google/client-secret",
+      },
+      agents: {
+        klanker: {
+          topic_name: "klanker",
+          google_workspace: { account: "you@example.com" },
+          schedule: (opts.schedule ?? []).map((s) => ({
+            cron: s.cron,
+            prompt: s.prompt,
+            secrets: s.secrets ?? [],
+          })),
+        },
+      },
+    } as unknown as SwitchroomConfig;
+  }
+
+  it("a Drive-enabled agent with ZERO schedule entries can read the client secret (the prod regression)", () => {
+    const config = clientCredConfig({ enabledFor: ["klanker"] });
+    const r = checkAclByAgent(config, "klanker", "google/client-secret");
+    expect(r.allow).toBe(true);
+  });
+
+  it("a non-enabled agent is still denied (falls through to the schedule.secrets gate)", () => {
+    const config = clientCredConfig({ enabledFor: ["clerk"] });
+    const r = checkAclByAgent(config, "klanker", "google/client-secret");
+    expect(r.allow).toBe(false);
+    if (!r.allow) expect(r.reason).toContain("no schedule entries");
+  });
+
+  it("does not shadow schedule.secrets — an unrelated key is still gated", () => {
+    // klanker gets the client-cred grant but must NOT thereby gain
+    // access to a key that isn't in any schedule.secrets[].
+    const config = clientCredConfig({
+      enabledFor: ["klanker"],
+      schedule: [{ cron: "* * * * *", prompt: "p", secrets: ["allowed_key"] }],
+    });
+    expect(checkAclByAgent(config, "klanker", "google/client-secret").allow).toBe(true);
+    expect(checkAclByAgent(config, "klanker", "allowed_key").allow).toBe(true);
+    expect(checkAclByAgent(config, "klanker", "stripe/api-key").allow).toBe(false);
+  });
+});

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -39,6 +39,7 @@
 import type { SwitchroomConfig } from "../../config/schema.js";
 import type { PeerInfo } from "./peercred.js";
 import type { VaultEntryScope } from "../vault.js";
+import { isGoogleClientCredentialKeyForAgent } from "../../config/google-workspace-acl.js";
 
 export interface AclAllow {
   allow: true;
@@ -219,6 +220,17 @@ export function checkAcl(
  *
  * Allowlist semantics — fail-closed:
  *   - If config.agents[agentName] is missing → deny.
+ *   - Config-derived identity-bound exceptions (checked BEFORE the
+ *     schedule.secrets allowlist, because they are auth-boundary access
+ *     to the single key the config binds to THIS agent, not cron-
+ *     misconfiguration protection):
+ *       · `google:<account>:*` account slots → gated by
+ *         `google_accounts.<account>.enabled_for[]` (RFC G §4.4).
+ *       · the Google OAuth client credential
+ *         (`google_workspace.google_client_{id,secret}` vault refs) →
+ *         gated by the same `shouldEmitGdriveMcp` predicate the scaffold
+ *         uses (config/google-workspace-acl.ts).
+ *       · the agent's own effective `bot_token` vault ref.
  *   - If the agent has no `schedule` array (or empty) → deny: there's no
  *     declared per-cron secrets[] to consult. Long-running agent-direct
  *     access is opted in only via populated `schedule[i].secrets`.
@@ -252,6 +264,27 @@ export function checkAclByAgent(
   const googleSlot = parseGoogleAccountSlotKey(key);
   if (googleSlot !== null) {
     return checkGoogleAccountAcl(config, agentName, googleSlot.account, key);
+  }
+
+  // RFC G §4.4, completed — the OAuth *client credential*.
+  // The google: account slots above bypass schedule.secrets because the
+  // Google account is the unit of trust (enabled_for[]), not a per-cron
+  // allowlist. The OAuth client_id/client_secret are the one remaining
+  // piece of the SAME Drive auth flow that the original RFC G ACL left
+  // out: they're referenced from config (`google_workspace.
+  // google_client_{id,secret}`), commonly as `vault:` refs (the
+  // documented `switchroom auth google connect` shape). Without this
+  // clause the `gdrive` MCP is dead on arrival fleet-wide — the launcher
+  // is broker-denied the client secret before it can spawn, even though
+  // every other layer (account slot, scaffold, MCP trust) is correctly
+  // wired. This is identity-bound access to the single credential the
+  // config binds to THIS agent's gdrive MCP — NOT cross-agent access —
+  // exactly analogous to the bot_token clause below, and gated by the
+  // SAME `shouldEmitGdriveMcp` predicate the scaffold uses to decide
+  // whether to emit the entry at all, so broker and scaffold can never
+  // disagree. See config/google-workspace-acl.ts.
+  if (isGoogleClientCredentialKeyForAgent(config, agentName, key)) {
+    return { allow: true };
   }
 
   // An agent legitimately needs to read its OWN configured bot token.


### PR DESCRIPTION
## Summary

The `gdrive` MCP is **dead on arrival fleet-wide**. `drive-mcp-launcher` resolves `google_workspace.google_client_secret` — a `vault:` ref in the documented `switchroom auth google connect` shape — through the vault-broker, but the broker's only standing read-ACL is per-agent `schedule[].secrets[]`. **Nothing in the Google/Drive onboarding flow wires that ACL**, so every Drive-enabled agent is broker-`DENIED` the client secret and the launcher refuses to spawn (`gdrive: ✗ Failed to connect`) — even though config, scaffold, MCP trust, and the OAuth refresh token are all correctly wired. Verified live on `klanker` and `ziggy`.

## Fix

RFC G §4.4 already exempts the Google *account* slots (`google:<account>:*`) from `schedule.secrets`, gating them on `google_accounts.<account>.enabled_for[]`. The OAuth client credential is the one remaining piece of the same Drive auth flow left out of that model. This adds the missing clause to `checkAclByAgent`, **exactly analogous to the existing per-agent `bot_token` exception**: identity-bound access to the single credential the config binds to THIS agent's gdrive MCP — *not* cross-agent access — gated by the **same `shouldEmitGdriveMcp` predicate the scaffold uses**, so broker and scaffold can never disagree. Honours the `mcp_servers: { gdrive: false }` hard opt-out.

`shouldEmitGdriveMcp` moves from `memory/scaffold-integration.ts` to a new **pure** `config/google-workspace-acl.ts` so the broker (whose `acl.ts` is deliberately dependency-free for standalone unit-testing) can share the exact predicate without pulling in the hindsight layer.

**No operator action** — no `schedule.secrets` hand-editing, no extra broker bounce. Works on fresh installs.

JTBD: *share-auth-across-the-fleet* — the Drive integration only delivers its outcome (agents can read your Drive) if the launcher can actually start.

## Test plan

- [x] `vitest` — new `config/google-workspace-acl.test.ts` (22 cases: relocated `shouldEmitGdriveMcp` contract + `vaultRefKey` + `isGoogleClientCredentialKeyForAgent` incl. non-enabled/opt-out/literal/unknown-agent negatives)
- [x] `vitest` — `acl.test.ts` +3 end-to-end cases through `checkAclByAgent` (zero-schedule grant; non-enabled fall-through; does-not-shadow-schedule.secrets)
- [x] `scaffold.test.ts` / `scaffold-gdrive-entry.test.ts` green (moved import, consumers unaffected)
- [x] `tsc --noEmit` clean across `src/` (the `@mtcute/node` plugin-references error is a pre-existing env gap, unrelated — file is identical on `origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)