### PR TITLE
fix(gateway): permission verdicts survive reconnect + TTL auto-deny (PR-3/4)

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -89,7 +89,10 @@ ALLOWLIST=(
   # the +3-line builder-import block drifted the broadcast send to 2353
   # (just past the old 2350 ceiling). Widened end 2350 -> 2360; grep
   # confirms 2353 is the only raw call in 2351-2360.
-  "telegram-plugin/gateway/gateway.ts:2250-2360:operator-event broadcast; no thread_id in opts"
+  # Re-bumped 2026-05-19 for PR-3: import + TTL-sweep insertions drifted
+  # the broadcast send +19 to 2371 (past 2360). End 2360 -> 2380; next
+  # raw call is 2399 (outside), so no new un-allowlisted call enters.
+  "telegram-plugin/gateway/gateway.ts:2250-2380:operator-event broadcast; no thread_id in opts"
 
   # permission-request keyboard send. opts only has reply_markup. No thread_id.
   # Range bumped 2026-05-13 for stuck-turn-recovery v2 cleanup expansion
@@ -109,7 +112,11 @@ ALLOWLIST=(
   # End 3000 -> 3010: feat/hostd-deterministic-status inserted the
   # inFlightUpdate var + the silence-fallback update-status branch
   # above this block; the permission-keyboard raw send moved to 3002.
-  "telegram-plugin/gateway/gateway.ts:2695-3010:permission-request keyboard; no thread_id"
+  # Re-bumped 2026-05-19 for PR-3: the dispatchPermissionVerdict helper
+  # (+~49 after line 2745) drifted the permission-request keyboard send
+  # to 3069 (past 3010). End 3010 -> 3080; next raw call is 3209
+  # (outside), so no new un-allowlisted call enters the margin.
+  "telegram-plugin/gateway/gateway.ts:2695-3080:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
   # The caller dropped the thread; this raw sendMessage retries on the
@@ -133,7 +140,10 @@ ALLOWLIST=(
   # the retry/parse-mode policy that just rejected the payload.
   # End 3540 -> 3580: same insertion shifted the chunk-loop fallback
   # raw sends to 3545/3566.
-  "telegram-plugin/gateway/gateway.ts:3160-3580:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
+  # Re-bumped 2026-05-19 for PR-3: +~49 drift moved the reply chunk-loop
+  # raw sends to 3612/3633 (past 3580). End 3580 -> 3640; next raw call
+  # is 3689 (outside), so no new un-allowlisted call enters the margin.
+  "telegram-plugin/gateway/gateway.ts:3160-3640:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -182,7 +192,12 @@ ALLOWLIST=(
   # 10434/10457/10481 (10481 past the old 10480 ceiling). Widened end
   # 10480 -> 10490; grep confirms 10481 is the only raw call in
   # 10481-10540 — same already-.catch-swallowed wizard site, no new one.
-  "telegram-plugin/gateway/gateway.ts:9340-10490:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-19 for PR-3: +~49 drift moved the wizard
+  # editMessageText sites to 10498/10521/10545 (past 10490). End
+  # 10490 -> 10560; next raw call is 10698 (outside), so no new
+  # un-allowlisted call enters the margin — same already-.catch-
+  # swallowed wizard sites.
+  "telegram-plugin/gateway/gateway.ts:9340-10560:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -246,6 +246,7 @@ import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js
 import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer } from './pending-inbound-buffer.js'
+import { createPendingPermissionBuffer } from './pending-permission-decisions.js'
 import {
   buildVaultGrantApprovedInbound,
   buildVaultGrantDeniedInbound,
@@ -265,6 +266,7 @@ import type {
   PtyPartialForward,
   InboundMessage,
   InjectInboundMessage,
+  PermissionEvent,
 } from './ipc-protocol.js'
 import { DebounceBuffer, HourCap, buildReactionInboundMeta, buildReactionInboundText, evaluateTriggerCandidate, isGroupChat, resolveReactionsConfig, truncatePreview, type PendingReaction, type ReactionBatch, type ReactionsResolvedConfig } from './reaction-trigger.js'
 import { writePidFile, clearPidFile } from './pid-file.js'
@@ -2096,7 +2098,23 @@ const pendingStateReaper = setInterval(() => {
     if (now - v.startedAt > VAULT_INPUT_TTL_MS) pendingVaultOps.delete(k)
   }
   for (const [k, v] of pendingPermissions) {
-    if (now - v.startedAt > PERMISSION_TTL_MS) pendingPermissions.delete(k)
+    if (now - v.startedAt > PERMISSION_TTL_MS) {
+      // Don't just drop it: the claude turn is suspended INSIDE the MCP
+      // permission call waiting for a verdict. A silent delete left it
+      // wedged forever when the operator never tapped — permanent
+      // silence, the exact symptom this series fixes. Auto-deny so the
+      // call unblocks; claude then tells the user it couldn't get
+      // permission (or takes a fallback). Routed through
+      // dispatchPermissionVerdict so it's buffered+redelivered too if
+      // the bridge is also offline at sweep time.
+      dispatchPermissionVerdict({ type: 'permission', requestId: k, behavior: 'deny' })
+      process.stderr.write(
+        `telegram gateway: permission TTL expired — auto-deny request=${k} ` +
+        `tool=${v.tool_name} (no operator response in ` +
+        `${Math.round(PERMISSION_TTL_MS / 60000)}m)\n`,
+      )
+      pendingPermissions.delete(k)
+    }
   }
   for (const [k, v] of vaultPassphraseCache) {
     if (now > v.expiresAt) vaultPassphraseCache.delete(k)
@@ -2741,6 +2759,36 @@ silencePoke.startTimer({
 // would mint the grant but silently drop the `vault_grant_approved`
 // inbound, leaving the agent stuck waiting for a manual poke.
 const pendingInboundBuffer = createPendingInboundBuffer()
+const pendingPermissionBuffer = createPendingPermissionBuffer()
+
+/**
+ * Deliver a permission verdict to this agent's bridge, buffering on a
+ * miss so it's redelivered when the bridge reconnects. Replaces the
+ * bare `ipcServer.broadcast({type:'permission',...})` at every verdict
+ * site (and the TTL-sweep auto-deny). broadcast was fire-and-forget:
+ * a verdict produced while the bridge was mid-reconnect was dropped
+ * and the claude turn stayed suspended INSIDE the MCP permission call
+ * forever — the user tapped Approve/Deny and nothing happened, no
+ * further output, permanent silence. sendToAgent is registered-keyed
+ * and returns a real delivered bool; on a miss we buffer and
+ * onClientRegistered re-sends so the reconnecting bridge relays the
+ * verdict to the still-suspended call. A late verdict for a dead
+ * request_id is harmless — the bridge relays it and Claude Code
+ * ignores an unknown request_id. (Function declaration so the
+ * pre-2747 TTL sweep can reference it; ipcServer/pendingPermissionBuffer
+ * are resolved at call-time, after module init.)
+ */
+function dispatchPermissionVerdict(ev: PermissionEvent): void {
+  const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
+  const delivered = ipcServer.sendToAgent(selfAgent, ev)
+  if (!delivered) {
+    pendingPermissionBuffer.push(selfAgent, ev)
+    process.stderr.write(
+      `telegram gateway: permission verdict buffered (bridge offline) ` +
+      `request=${ev.requestId} behavior=${ev.behavior}\n`,
+    )
+  }
+}
 
 const ipcServer: IpcServer = createIpcServer({
   socketPath: SOCKET_PATH,
@@ -2765,6 +2813,22 @@ const ipcServer: IpcServer = createIpcServer({
           process.stderr.write(
             `telegram gateway: pending-inbound drain failed agent=${client.agentName} ` +
             `source=${msg.meta?.source ?? '-'}: ${(err as Error).message}\n`,
+          )
+        }
+      }
+      // PR-3: drain permission verdicts missed while the bridge was
+      // offline. A claude turn suspended inside the MCP permission call
+      // is unblocked the moment the reconnecting bridge relays the
+      // verdict; without this the verdict (incl. the TTL auto-deny) was
+      // lost and the turn stayed silent forever.
+      const pendingVerdicts = pendingPermissionBuffer.drain(client.agentName)
+      for (const ev of pendingVerdicts) {
+        try {
+          client.send(ev)
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: pending-permission drain failed agent=${client.agentName} ` +
+            `request=${ev.requestId} behavior=${ev.behavior}: ${(err as Error).message}\n`,
           )
         }
       }
@@ -6254,7 +6318,7 @@ async function handleInbound(
     // Forward permission reply to connected bridge
     const behavior = permMatch[1]!.toLowerCase().startsWith('y') ? 'allow' : 'deny'
     const request_id = permMatch[2]!.toLowerCase()
-    ipcServer.broadcast({
+    dispatchPermissionVerdict({
       type: 'permission',
       requestId: request_id,
       behavior,
@@ -8861,7 +8925,7 @@ async function handlePermissionSlash(ctx: Context, behavior: 'allow' | 'deny'): 
     return
   }
   // Forward to connected bridges — same IPC the button handler uses.
-  ipcServer.broadcast({ type: 'permission', requestId: request_id, behavior })
+  dispatchPermissionVerdict({ type: 'permission', requestId: request_id, behavior })
   pendingPermissions.delete(request_id)
   process.stderr.write(
     `[telegram gateway] slash-${behavior} request_id=${request_id} tool=${details.tool_name} by=${senderId}\n`,
@@ -12290,7 +12354,7 @@ bot.on('callback_query:data', async ctx => {
       // otherwise the rule may be unsafe to honour at scale and we
       // fall back to single-use allow.
       synthInbound: () => {
-        ipcServer.broadcast({
+        dispatchPermissionVerdict({
           type: 'permission',
           requestId: request_id,
           behavior: 'allow',
@@ -12328,7 +12392,7 @@ bot.on('callback_query:data', async ctx => {
     newText: baseText ? `${baseText}\n\n${label}` : label,
     parseMode: 'HTML',
     synthInbound: () => {
-      ipcServer.broadcast({
+      dispatchPermissionVerdict({
         type: 'permission',
         requestId: request_id,
         behavior: behavior as 'allow' | 'deny',

--- a/telegram-plugin/gateway/pending-permission-decisions.ts
+++ b/telegram-plugin/gateway/pending-permission-decisions.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-agent buffer for permission verdicts the gateway couldn't deliver
+ * because no live IPC client was registered for the agent at send-time.
+ *
+ * Background (PR-3 of the callback→model-continuation series): a
+ * tool/skill/MCP permission request suspends the claude turn *inside*
+ * the MCP permission call until the gateway relays the operator's
+ * Approve/Deny verdict back (`{type:'permission'}` → bridge
+ * `onPermission` → Claude Code). The verdict sites previously used
+ * `ipcServer.broadcast(...)`, which is fire-and-forget: if the bridge
+ * was mid-reconnect at the exact moment the operator tapped (every
+ * agent/gateway restart, claude session bounce), the verdict was
+ * dropped and the model stayed wedged forever — the user's tap did
+ * nothing and they were left silent.
+ *
+ * This is the permission-verdict analog of `pending-inbound-buffer.ts`:
+ * the verdict sites now `sendToAgent` (registered-keyed, real delivered
+ * bool) and on a miss `push()` here; `onClientRegistered` `drain()`s
+ * and re-sends so a reconnecting bridge relays the missed verdict to
+ * the still-suspended permission call.
+ *
+ * Contract mirrors pending-inbound-buffer:
+ *   - `push(agent, ev)` best-effort, synchronous, bounded.
+ *   - `drain(agent)` returns ALL pending verdicts in insertion order
+ *     and clears them; called from `onClientRegistered`.
+ *   - In-memory only; survives reconnect within one gateway lifetime,
+ *     not a gateway restart. A late-redelivered verdict for a
+ *     request_id claude no longer has is harmless — the bridge relays
+ *     it and Claude Code ignores an unknown request_id. The TTL-sweep
+ *     auto-deny is the independent backstop for "operator never tapped".
+ *
+ * Per-agent cap prevents a never-reconnecting bridge from leaking
+ * memory; on overflow the OLDEST verdict is dropped (freshest is most
+ * relevant) and logged.
+ */
+
+import type { PermissionEvent } from './ipc-protocol.js'
+
+/** Default cap per agent — a reasonable backlog of permission cards
+ *  stacked while the bridge is offline, no more. */
+export const DEFAULT_PENDING_PERMISSION_CAP = 32
+
+export interface PendingPermissionBuffer {
+  /** Append `ev` to `agent`'s queue. Returns true if accepted without
+   *  eviction, false if the cap forced dropping the oldest (the new
+   *  entry is STILL accepted). */
+  push: (agent: string, ev: PermissionEvent) => boolean
+  /** Pop and return all pending verdicts for `agent` (insertion order).
+   *  Empty array when none. Idempotent. */
+  drain: (agent: string) => PermissionEvent[]
+  /** Test-only: current depth for `agent`. */
+  depth: (agent: string) => number
+  /** Test-only: total depth across all agents. */
+  totalDepth: () => number
+}
+
+export interface PendingPermissionBufferOptions {
+  capPerAgent?: number
+  log?: (line: string) => void
+}
+
+export function createPendingPermissionBuffer(
+  opts: PendingPermissionBufferOptions = {},
+): PendingPermissionBuffer {
+  const cap = opts.capPerAgent ?? DEFAULT_PENDING_PERMISSION_CAP
+  const log = opts.log ?? ((line: string) => process.stderr.write(line))
+  const queues = new Map<string, PermissionEvent[]>()
+
+  return {
+    push(agent, ev) {
+      let q = queues.get(agent)
+      if (q == null) {
+        q = []
+        queues.set(agent, q)
+      }
+      let evicted = false
+      if (q.length >= cap) {
+        const dropped = q.shift()
+        evicted = true
+        log(
+          `pending-permission-buffer: agent=${agent} cap=${cap} reached — ` +
+          `dropped oldest verdict request=${dropped?.requestId ?? '-'} ` +
+          `behavior=${dropped?.behavior ?? '-'}\n`,
+        )
+      }
+      q.push(ev)
+      log(
+        `pending-permission-buffer: agent=${agent} buffered request=${ev.requestId} ` +
+        `behavior=${ev.behavior} depth_after=${q.length} evicted=${evicted}\n`,
+      )
+      return !evicted
+    },
+    drain(agent) {
+      const q = queues.get(agent)
+      if (q == null || q.length === 0) return []
+      queues.delete(agent)
+      log(
+        `pending-permission-buffer: drained agent=${agent} count=${q.length} ` +
+        `requests=[${q.map((e) => e.requestId).join(',')}]\n`,
+      )
+      return q
+    },
+    depth(agent) {
+      return queues.get(agent)?.length ?? 0
+    },
+    totalDepth() {
+      let n = 0
+      for (const q of queues.values()) n += q.length
+      return n
+    },
+  }
+}

--- a/telegram-plugin/tests/pending-permission-decisions.test.ts
+++ b/telegram-plugin/tests/pending-permission-decisions.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Pin the per-agent permission-verdict buffer (PR-3 of the callback→
+ * model-continuation series). A tool/skill/MCP permission request
+ * suspends the claude turn inside the MCP permission call until the
+ * operator's Approve/Deny verdict is relayed back. The verdict sites
+ * previously `broadcast(...)` fire-and-forget, so a verdict produced
+ * while the bridge was mid-reconnect was dropped and the model stayed
+ * wedged forever (user tapped, nothing happened, silence). This buffer
+ * — the permission analog of pending-inbound-buffer — holds the missed
+ * verdict and is drained on the next bridge register.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createPendingPermissionBuffer,
+  DEFAULT_PENDING_PERMISSION_CAP,
+} from '../gateway/pending-permission-decisions.js'
+import type { PermissionEvent } from '../gateway/ipc-protocol.js'
+
+function verdict(
+  requestId: string,
+  behavior: 'allow' | 'deny' = 'allow',
+  rule?: string,
+): PermissionEvent {
+  return { type: 'permission', requestId, behavior, ...(rule ? { rule } : {}) }
+}
+
+describe('pending-permission-decisions', () => {
+  it('push + drain — FIFO order per agent, idempotent drain', () => {
+    const buf = createPendingPermissionBuffer({ log: () => {} })
+    buf.push('a', verdict('r1', 'allow'))
+    buf.push('a', verdict('r2', 'deny'))
+    buf.push('b', verdict('r3', 'allow'))
+    const a = buf.drain('a')
+    expect(a.map((e) => e.requestId)).toEqual(['r1', 'r2'])
+    expect(a[1]!.behavior).toBe('deny')
+    expect(buf.drain('a')).toEqual([]) // idempotent
+    expect(buf.drain('b').map((e) => e.requestId)).toEqual(['r3'])
+    expect(buf.totalDepth()).toBe(0)
+  })
+
+  it('preserves the always-allow rule field through buffering', () => {
+    const buf = createPendingPermissionBuffer({ log: () => {} })
+    buf.push('a', verdict('r1', 'allow', 'Bash(ls:*)'))
+    const [ev] = buf.drain('a')
+    expect(ev!.rule).toBe('Bash(ls:*)')
+    expect(ev!.behavior).toBe('allow')
+  })
+
+  it('per-agent cap drops the OLDEST verdict and reports eviction', () => {
+    const buf = createPendingPermissionBuffer({ capPerAgent: 3, log: () => {} })
+    expect(buf.push('a', verdict('r1'))).toBe(true)
+    expect(buf.push('a', verdict('r2'))).toBe(true)
+    expect(buf.push('a', verdict('r3'))).toBe(true)
+    expect(buf.push('a', verdict('r4'))).toBe(false) // evicted oldest
+    const drained = buf.drain('a')
+    expect(drained.map((e) => e.requestId)).toEqual(['r2', 'r3', 'r4'])
+  })
+
+  it('depth/totalDepth track buffered verdicts', () => {
+    const buf = createPendingPermissionBuffer({ log: () => {} })
+    expect(buf.depth('a')).toBe(0)
+    buf.push('a', verdict('r1'))
+    buf.push('a', verdict('r2'))
+    buf.push('b', verdict('r3'))
+    expect(buf.depth('a')).toBe(2)
+    expect(buf.totalDepth()).toBe(3)
+  })
+
+  it('exports a sane default cap', () => {
+    expect(DEFAULT_PENDING_PERMISSION_CAP).toBeGreaterThanOrEqual(8)
+  })
+})


### PR DESCRIPTION
## Summary

PR-3 of the callback→model-continuation series — **the heart of the reported symptom** ("when it requests permissions for a skill/tool, it doesn't always continue; the user is left silent"). A permission request suspends the claude turn *inside* the MCP permission call until the gateway relays the Approve/Deny verdict back. Two ways it stayed wedged forever:

1. **Lost verdict.** All 4 verdict sites used fire-and-forget `ipcServer.broadcast({type:'permission',...})`. If the bridge was mid-reconnect at tap time (every agent/gateway restart, claude session bounce) the verdict was dropped — the suspended call never received it.
2. **Silent TTL.** The `pendingPermissions` sweep `delete()`d on 10-min expiry with no deny — when the operator never tapped, the suspended call hung forever.

## Fix (mirrors the proven `pending-inbound-buffer` pattern)
- New **`pending-permission-decisions.ts`** — per-agent bounded `PermissionEvent` buffer (the verdict analog of the inbound buffer), unit-tested.
- **`dispatchPermissionVerdict()`** replaces all 4 broadcast sites: `sendToAgent` (registered-keyed, real `delivered` bool) → buffer on miss → `onClientRegistered` drains + re-sends so a reconnecting bridge relays it to the still-suspended call.
- **TTL sweep** routes an explicit `behavior:'deny'` through the same helper (buffered too) instead of a silent delete → the call unblocks and claude itself tells the user (or takes a fallback) — never silent. (Chose model-speaks-on-deny over a gateway "expired" card: `pendingPermissions` has no `chat_id`; deny achieves the no-silence goal without auth-path chat plumbing — noted for the reviewer.)

## Test plan
- [x] New `pending-permission-decisions.test.ts` (FIFO/idempotent drain, rule-field preservation, cap-evict-oldest, depth) + `pending-inbound-buffer`/`ipc-server-client`/`finalize-callback`/`inline-keyboard` suites green (55, 0 fail)
- [x] Touched files tsc-clean; **full non-tsc lint clean** incl. `check-bot-api-wrapping` — required re-bump of **4** allowlist ranges for the +2/+19/+49 non-uniform line drift, each ceiling stopping before the next raw call (no new un-allowlisted call; same already-wrapped sites). **Reviewer: please run `bash scripts/check-bot-api-wrapping.sh`.**
- [ ] Full CI

> Series: PR-1 #1536 ✅ (vault_request_save wake-up), PR-2 #1537 ✅ (inbound+button buffered delivery), **PR-3 (this)**, PR-4 (kernel approval record-before-consume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)