### PR TITLE
fix(approval): compute decision before burning the single-use nonce (PR-4/4)

### DIFF
--- a/telegram-plugin/gateway/approval-callback.ts
+++ b/telegram-plugin/gateway/approval-callback.ts
@@ -57,19 +57,18 @@ export async function handleApprovalCallback(
     return;
   }
 
-  const consumed = await approvalConsume(parsed.request_id);
-  if (consumed === null) {
-    await ctx.answerCallbackQuery({ text: "approval kernel unreachable" });
-    return;
-  }
-  if (!consumed.consumed) {
-    // Single-use enforcement: someone already tapped, or the nonce
-    // expired/unknown. Match the RFC §8.1 wording.
-    await ctx.answerCallbackQuery({ text: "this prompt expired" });
-    return;
-  }
-
-  // Compute decision + ttl from the choice variant.
+  // Compute decision + ttl from the choice variant BEFORE burning the
+  // single-use nonce. This block has a fallible early-return (the
+  // `bad ttl token` path). Pre-fix it ran AFTER approvalConsume(), so a
+  // malformed ttl token burned the nonce but recorded no decision — the
+  // agent's approval_lookup poll never saw a verdict and the turn
+  // wedged (pre-PR-3: forever; now bounded by PR-3's PERMISSION_TTL
+  // auto-deny). approvalConsume stays the atomic single-use guard; it
+  // simply doesn't fire until we have a valid decision to record
+  // immediately after. There is now NO fallible step between
+  // consume→record; the only residual gap is the inherent 1-RPC
+  // consume/record non-atomicity (backstopped by PR-3's TTL auto-deny;
+  // a fully atomic kernel consume+record is a tracked follow-up).
   let decision: ApprovalDecisionMode;
   let granted: boolean;
   let ttl_ms: number | null = null;
@@ -105,6 +104,18 @@ export async function handleApprovalCallback(
       displayMode = `granted for ${parsed.choice.param}`;
       break;
     }
+  }
+
+  const consumed = await approvalConsume(parsed.request_id);
+  if (consumed === null) {
+    await ctx.answerCallbackQuery({ text: "approval kernel unreachable" });
+    return;
+  }
+  if (!consumed.consumed) {
+    // Single-use enforcement: someone already tapped, or the nonce
+    // expired/unknown. Match the RFC §8.1 wording.
+    await ctx.answerCallbackQuery({ text: "this prompt expired" });
+    return;
   }
 
   const granted_by_user_id = ctx.from?.id ?? 0;


### PR DESCRIPTION
## Summary

Final PR (4/4) of the callback→model-continuation reliability series.

`handleApprovalCallback` (the `apv:` approval-kernel path — the human-in-the-loop gate for **every dangerous tool call + every Drive write**) called `approvalConsume()` (the atomic single-use nonce burn) **before** computing the decision from the tapped choice. The decision `switch` has a fallible early-return (`bad ttl token`). So a malformed ttl token **burned the nonce but recorded no decision** → the agent's `approval_lookup` poll never saw a verdict → the turn wedged (pre-PR-3: forever; now bounded by PR-3's `PERMISSION_TTL` auto-deny), and a re-tap showed "this prompt expired".

**Fix:** move the pure decision-compute `switch` *above* `approvalConsume()`. `approvalConsume` stays the atomic single-use guard — unchanged concurrency semantics (still the first touch of kernel state; two concurrent taps still race there, one wins) — it just doesn't fire until a valid decision is guaranteed to be recorded immediately after. There is now **no fallible step between consume→record**.

Residual: the inherent 1-RPC consume/record non-atomicity (broker crash / `approval_record` null after consume) — far narrower, and already backstopped by PR-3's TTL auto-deny so it can't wedge silently forever. A fully atomic kernel `consume+record` op is the complete fix, left as a **tracked follow-up** (kernel-protocol change, deliberately out of scope for this hot-path series).

## Test plan
- [x] Pure statement reorder — no logic/payload change; the `switch` references no `consumed`, and the later `consumed.scope` use still runs before record
- [x] `approval-callback.ts` tsc-clean; full **non-tsc lint clean** (`check-bot-api-wrapping` clean — different file, no gateway.ts line drift; `check-bun-test-imports`; `check-no-pii-secrets`)
- [x] `approval-callback.test.ts` + `src/vault/approvals/{kernel,wait,client}.test.ts` + approval-pattern bun suites green — no regression
- [ ] Full CI

## Series recap (all merged)
PR-1 #1536 `vault_request_save` wake-up · PR-2 #1537 inbound+button buffered delivery · PR-3 #1539 permission verdict redelivery + TTL auto-deny · **PR-4 (this)** approval nonce-before-decision. Net: a user selection/approval can no longer leave the model wedged + the user silent — on tap-loss (reconnect), no-tap (TTL), or kernel-state ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)