### PR TITLE
fix(doctor): probe OAuth client-credential broker-reachability for Drive

### DIFF
--- a/src/cli/doctor-drive.test.ts
+++ b/src/cli/doctor-drive.test.ts
@@ -12,7 +12,11 @@
 
 import { describe, expect, it } from "vitest";
 
-import { runDriveChecks, type DriveProbeDeps } from "./doctor-drive.js";
+import {
+  runDriveChecks,
+  runDriveBrokerReachabilityChecks,
+  type DriveProbeDeps,
+} from "./doctor-drive.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 function cfg(partial: Partial<SwitchroomConfig>): SwitchroomConfig {
@@ -246,5 +250,135 @@ describe("runDriveChecks — deployed scaffold wiring (bug-8 / bug-9)", () => {
     const w = rs.find((r) => r.name === "drive: carrie scaffold");
     expect(w?.status).toBe("fail");
     expect(w?.detail).toContain("corrupt");
+  });
+});
+
+describe("runDriveBrokerReachabilityChecks — the silent-failure blind spot", () => {
+  // This is the check that would have caught #1538 loud: config /
+  // scaffold / MCP-trust all green, but the broker DENIES the agent the
+  // OAuth client secret, so the gdrive MCP never spawns.
+  const DRIVE_CFG = (
+    clientSecret: string,
+    clientId?: string,
+  ): SwitchroomConfig =>
+    cfg({
+      agents: {
+        carrie: { google_workspace: { account: "you@x.com" } } as never,
+      },
+      google_accounts: { "you@x.com": { enabled_for: ["carrie"] } } as never,
+      google_workspace: {
+        ...(clientId ? { google_client_id: clientId } : {}),
+        google_client_secret: clientSecret,
+      } as never,
+    });
+
+  it("returns [] when Drive is unused (no drive agents)", async () => {
+    expect(
+      await runDriveBrokerReachabilityChecks(cfg({ agents: {} as never })),
+    ).toEqual([]);
+  });
+
+  it("reports ok (no broker needed) when the client secret is a literal", async () => {
+    let called = false;
+    const rs = await runDriveBrokerReachabilityChecks(
+      DRIVE_CFG("GOCSPX-literal"),
+      { preflight: async () => { called = true; return { kind: "locked" }; } },
+    );
+    expect(called).toBe(false);
+    expect(rs).toHaveLength(1);
+    expect(rs[0].status).toBe("ok");
+    expect(rs[0].detail).toContain("literal");
+  });
+
+  it("OK when the broker will serve the vault: client secret to the agent", async () => {
+    const rs = await runDriveBrokerReachabilityChecks(
+      DRIVE_CFG("vault:google/client-secret"),
+      {
+        preflight: async (_a, keys) => ({
+          kind: "ok",
+          results: keys.map((key) => ({
+            key,
+            exists: true,
+            acl_ok: true,
+            scope_ok: true,
+          })),
+        }),
+      },
+    );
+    expect(rs).toHaveLength(1);
+    expect(rs[0].status).toBe("ok");
+    expect(rs[0].name).toBe("drive: carrie client-cred broker-reachable");
+  });
+
+  it("FAILS loud when the broker DENIES the client secret (the #1538 regression)", async () => {
+    const rs = await runDriveBrokerReachabilityChecks(
+      DRIVE_CFG("vault:google/client-secret"),
+      {
+        preflight: async (_a, keys) => ({
+          kind: "ok",
+          results: keys.map((key) => ({
+            key,
+            exists: true,
+            acl_ok: false,
+            acl_reason:
+              "agent 'carrie' has no schedule entries declaring 'secrets'; nothing is broker-accessible",
+            scope_ok: true,
+          })),
+        }),
+      },
+    );
+    expect(rs).toHaveLength(1);
+    expect(rs[0].status).toBe("fail");
+    expect(rs[0].detail).toContain("DENIES");
+    expect(rs[0].detail).toContain("google/client-secret");
+    expect(rs[0].detail).toContain("silently never works");
+    expect(rs[0].fix).toContain("enabled_for[]");
+  });
+
+  it("SKIPS (never false-fails) when the broker is locked", async () => {
+    const rs = await runDriveBrokerReachabilityChecks(
+      DRIVE_CFG("vault:google/client-secret"),
+      { preflight: async () => ({ kind: "locked" }) },
+    );
+    expect(rs[0].status).toBe("skip");
+    expect(rs[0].detail).toContain("locked");
+  });
+
+  it("SKIPS (never false-fails) when the broker operator socket is unreachable", async () => {
+    const rs = await runDriveBrokerReachabilityChecks(
+      DRIVE_CFG("vault:google/client-secret"),
+      {
+        preflight: async () => ({
+          kind: "unreachable",
+          msg: "ENOENT operator sock",
+        }),
+      },
+    );
+    expect(rs[0].status).toBe("skip");
+    expect(rs[0].detail).toContain("unreachable");
+  });
+
+  it("probes BOTH client_id and client_secret when both are vault: refs", async () => {
+    let seen: string[] = [];
+    await runDriveBrokerReachabilityChecks(
+      DRIVE_CFG("vault:google/client-secret", "vault:google/client-id"),
+      {
+        preflight: async (_a, keys) => {
+          seen = keys;
+          return {
+            kind: "ok",
+            results: keys.map((key) => ({
+              key,
+              exists: true,
+              acl_ok: true,
+              scope_ok: true,
+            })),
+          };
+        },
+      },
+    );
+    expect(seen.sort()).toEqual(
+      ["google/client-id", "google/client-secret"].sort(),
+    );
   });
 });

--- a/src/cli/doctor-drive.ts
+++ b/src/cli/doctor-drive.ts
@@ -43,11 +43,14 @@ import {
   readFileSync as realReadFileSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
+import { homedir } from "node:os";
 
 import { resolveAgentsDir } from "../config/loader.js";
 import type { SwitchroomConfig } from "../config/schema.js";
+import { vaultRefKey } from "../config/google-workspace-acl.js";
 
 import type { CheckStatus } from "./doctor-status.js";
+import { defaultPreflight, type PreflightOutcome } from "./doctor-secret-access.js";
 
 export interface CheckResult {
   name: string;
@@ -62,6 +65,15 @@ export interface DriveProbeDeps {
   agentsDir?: string;
   existsSync?: (p: string) => boolean;
   readFileSync?: (p: string) => string;
+  /**
+   * Operator-socket preflight RPC, used only by
+   * `runDriveBrokerReachabilityChecks`. Defaults to the shared
+   * `defaultPreflight` over `~/.switchroom/broker-operator/sock` (same
+   * client `runSecretAccessChecks` uses). Injectable for tests.
+   */
+  preflight?: (agent: string, keys: string[]) => Promise<PreflightOutcome>;
+  /** Override the broker operator socket path (tests). */
+  brokerOperatorSocket?: string;
 }
 
 interface ResolvedDeps {
@@ -378,9 +390,26 @@ export function runDriveChecks(
   const matrix = checkConfigMatrix(config);
   results.push(...matrix);
 
-  // An agent is "Drive-enabled" only when BOTH sides of the matrix
-  // agree — that's exactly the set the launcher will succeed for.
-  const driveAgents = Object.keys(config.agents ?? {}).filter((name) => {
+  const driveAgents = computeDriveAgents(config);
+
+  results.push(...checkOAuthClient(config, driveAgents.length > 0));
+  results.push(...checkScaffoldWiring(config, driveAgents, d));
+
+  return results;
+}
+
+/**
+ * The "Drive-enabled" set: agents where BOTH sides of the matrix agree
+ * (per-agent `google_workspace.account` set AND that account lists the
+ * agent in `google_accounts.<acct>.enabled_for[]`). Exactly the set the
+ * launcher succeeds for — and the set the broker now grants the OAuth
+ * client credential (RFC G §4.4, v0.12.14). Shared by the sync
+ * config/scaffold checks and the async broker-reachability check so the
+ * two can never disagree about which agents to probe.
+ */
+function computeDriveAgents(config: SwitchroomConfig): string[] {
+  const accounts = config.google_accounts;
+  return Object.keys(config.agents ?? {}).filter((name) => {
     const acct = agentAccount(config, name);
     return (
       !!acct &&
@@ -388,9 +417,101 @@ export function runDriveChecks(
       (accounts[acct].enabled_for ?? []).includes(name)
     );
   });
+}
 
-  results.push(...checkOAuthClient(config, driveAgents.length > 0));
-  results.push(...checkScaffoldWiring(config, driveAgents, d));
+/**
+ * Check 4 — does the broker actually SERVE the OAuth client credential?
+ *
+ * `checkOAuthClient` only proves the value is *present in config*. When
+ * it's a `vault:` ref (the documented `switchroom auth google connect`
+ * shape) the launcher resolves it through the vault-broker — and before
+ * v0.12.14 the broker denied it fleet-wide (the client cred was the one
+ * piece of the Drive auth flow outside both `schedule.secrets` and the
+ * RFC G §4.4 account-slot grant), so the `gdrive` MCP silently never
+ * spawned while every config/scaffold/trust check stayed green. THIS is
+ * the blind spot that let that ship. We ask the broker the same
+ * question it answers at runtime (`preflight_access` → full
+ * `checkAclByAgent`, which includes the v0.12.14 client-cred clause),
+ * using the SAME key-extraction (`vaultRefKey`) the broker authorizes
+ * against, so the verdict matches enforcement exactly.
+ *
+ * Literal (non-`vault:`) creds need no broker — reported ok. Broker
+ * locked / unreachable → `skip` (never a false fail; a static miss does
+ * not prove the agent lacks access — mirrors runSecretAccessChecks).
+ *
+ * Async + separate from `runDriveChecks` (which stays sync) so the
+ * broker RPC doesn't change that function's signature or its tests;
+ * `doctor.ts` composes both into the one "Google Drive" section, the
+ * same shape it already uses for the async `runSecretAccessChecks`.
+ */
+export async function runDriveBrokerReachabilityChecks(
+  config: SwitchroomConfig,
+  deps: DriveProbeDeps = {},
+): Promise<CheckResult[]> {
+  const driveAgents = computeDriveAgents(config);
+  if (driveAgents.length === 0) return [];
 
+  const gw = config.google_workspace;
+  const idKey = vaultRefKey(gw?.google_client_id);
+  const secretKey = vaultRefKey(gw?.google_client_secret);
+  const vaultKeys = [idKey, secretKey].filter((k): k is string => k !== null);
+
+  if (vaultKeys.length === 0) {
+    // Both creds are literals (or unset — checkOAuthClient fails that
+    // case separately). A literal is read straight from config by the
+    // launcher; the broker is never consulted, so nothing to verify.
+    return [
+      {
+        name: "drive: OAuth client broker-reachable",
+        status: "ok",
+        detail:
+          "client credential is a literal (not a vault: ref) — the launcher reads it from config; no broker grant needed",
+      },
+    ];
+  }
+
+  const sock =
+    deps.brokerOperatorSocket ??
+    join(homedir(), ".switchroom", "broker-operator", "sock");
+  const preflight =
+    deps.preflight ?? ((a: string, k: string[]) => defaultPreflight(sock, a, k));
+
+  const results: CheckResult[] = [];
+  for (const agent of driveAgents) {
+    const outcome = await preflight(agent, vaultKeys);
+    if (outcome.kind === "locked") {
+      results.push({
+        name: `drive: ${agent} client-cred broker-reachable`,
+        status: "skip",
+        detail:
+          "vault-broker is locked — cannot verify; the fleet's launchers/crons are dead while locked anyway (not a Drive-specific fault)",
+      });
+      continue;
+    }
+    if (outcome.kind === "unreachable") {
+      results.push({
+        name: `drive: ${agent} client-cred broker-reachable`,
+        status: "skip",
+        detail: `broker operator socket unreachable (${outcome.msg}) — cannot verify; not a false fail`,
+      });
+      continue;
+    }
+    const denied = outcome.results.filter((r) => !r.acl_ok);
+    if (denied.length === 0) {
+      results.push({
+        name: `drive: ${agent} client-cred broker-reachable`,
+        status: "ok",
+        detail: `vault-broker will serve the OAuth client credential (${vaultKeys.join(", ")}) to '${agent}'`,
+      });
+      continue;
+    }
+    const d0 = denied[0];
+    results.push({
+      name: `drive: ${agent} client-cred broker-reachable`,
+      status: "fail",
+      detail: `vault-broker DENIES '${agent}' the OAuth client key '${d0.key}' (${d0.acl_reason ?? "no ACL grant"}) — the gdrive MCP launcher exits before spawning and Drive silently never works for this agent`,
+      fix: `confirm '${agent}' is in google_accounts[<account>].enabled_for[] and has agents.${agent}.google_workspace.account set (v0.12.14+ broker grants the client credential off that gate automatically); then ensure the broker is running the v0.12.14+ image`,
+    });
+  }
   return results;
 }

--- a/src/cli/doctor-secret-access.ts
+++ b/src/cli/doctor-secret-access.ts
@@ -204,8 +204,10 @@ function keyGap(
 }
 
 /** Default preflight: one operator-socket RPC per agent. No
- *  passphrase needed — the broker answers from its unlocked vault. */
-async function defaultPreflight(
+ *  passphrase needed — the broker answers from its unlocked vault.
+ *  Exported so the Drive doctor reuses the exact RPC + LOCKED/
+ *  unreachable mapping (one source → byte-identical verdicts). */
+export async function defaultPreflight(
   socketPath: string,
   agent: string,
   keys: string[],

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -29,7 +29,7 @@ import { probeHindsight, isHindsightEnabled } from "../memory/hindsight.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runHostdChecks } from "./doctor-hostd.js";
-import { runDriveChecks } from "./doctor-drive.js";
+import { runDriveChecks, runDriveBrokerReachabilityChecks } from "./doctor-drive.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
 import { runSecretAccessChecks } from "./doctor-secret-access.js";
 import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
@@ -2333,7 +2333,13 @@ export function registerDoctorCommand(program: Command): void {
             title: "Agent liveness (in-agent via hostd)",
             results: await runAgentSmokeChecks(config, { fast: opts.fast }),
           },
-          { title: "Google Drive", results: runDriveChecks(config) },
+          {
+            title: "Google Drive",
+            results: [
+              ...runDriveChecks(config),
+              ...(await runDriveBrokerReachabilityChecks(config)),
+            ],
+          },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath, config) },
         ];
 


### PR DESCRIPTION
## Summary

Closes the `doctor-drive` blind spot that let #1538 ship silently. `checkOAuthClient` only verified the client credential is *present in config* (`clientValuePresent`) — never that the vault-broker would actually **serve** it. So a `vault:` client secret broker-DENIED to every Drive-enabled agent showed all-green in `switchroom doctor` while the `gdrive` MCP never spawned fleet-wide.

Adds an async `runDriveBrokerReachabilityChecks`:
- For `vault:` client creds, asks the broker the same question it answers at runtime — `preflight_access` → full `checkAclByAgent` (incl. the v0.12.14 client-cred clause from #1538) — per Drive-enabled agent, using the shared `vaultRefKey` so the probed key is exactly what the broker authorizes against.
- Broker **DENIES** → loud `fail` with the broker's own reason + an actionable fix.
- Literal (non-`vault:`) creds → `ok` (launcher reads from config; no broker needed).
- Broker **locked / unreachable** → `skip` (never a false fail — mirrors `runSecretAccessChecks`'s philosophy).

**Why #1533 doesn't already cover this:** `doctor-secret-access`'s `collectVaultRefs` runs on the *resolved per-agent* config (top-level `google_workspace.google_client_{id,secret}` aren't in it), and `keyGap` only applies the ACL check to **cron** keys. Verified by reading the code, not assumed.

Design notes:
- Kept **separate** from the sync `runDriveChecks` (signature + all its tests untouched); `doctor.ts` composes both into the one "Google Drive" section — the same shape it already uses for the async `runSecretAccessChecks`.
- `defaultPreflight` exported for reuse (one source → byte-identical verdicts with the vault-access section).
- The "Drive-enabled agent" set is now a shared helper, so the sync and async checks can never disagree about which agents to probe.

JTBD: *share-auth-across-the-fleet* — doctor must surface, loudly, when the Drive auth chain is broker-broken instead of greenlighting a dead integration.

## Test plan

- [x] `vitest src/cli/doctor-drive.test.ts` — 7 new cases: no-drive→[]; literal→ok (preflight not called); broker-serves→ok; **broker-DENIES→fail with reason+fix (the #1538 regression-catcher)**; locked→skip; unreachable→skip; both id+secret vault refs probed
- [x] `tests/doctor-secret-access.test.ts` green (the `defaultPreflight` export change is non-breaking)
- [x] `tsc --noEmit` clean across `src/` (the `@mtcute/node` plugin-references error is the known pre-existing env gap, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)