### PR TITLE
refactor(approval): pure resolveApprovalDecision + unit-test the bad-ttl seam (PR-5)

### DIFF
--- a/telegram-plugin/gateway/approval-callback.test.ts
+++ b/telegram-plugin/gateway/approval-callback.test.ts
@@ -12,7 +12,10 @@
 
 import { describe, expect, it } from "vitest";
 import { InlineKeyboard } from "grammy";
-import { buildGrantedKeyboard } from "./approval-callback.js";
+import {
+  buildGrantedKeyboard,
+  resolveApprovalDecision,
+} from "./approval-callback.js";
 
 /**
  * Helper — pull the `[{text, url}]` rows out of a grammy InlineKeyboard
@@ -100,5 +103,50 @@ describe("buildGrantedKeyboard — no button cases", () => {
     // edit MUST NOT render a URL button derived from such a string.
     expect(buildGrantedKeyboard("doc:gdrive:folder/abc/def/**")).toBeUndefined();
     expect(buildGrantedKeyboard("doc:gdrive:write:abc?evil=1")).toBeUndefined();
+  });
+});
+
+describe("resolveApprovalDecision — pure decision resolution (PR-5)", () => {
+  it("deny → deny / not granted", () => {
+    expect(resolveApprovalDecision({ kind: "deny" })).toEqual({
+      ok: true, decision: "deny", granted: false, ttl_ms: null, displayMode: "denied",
+    });
+  });
+
+  it("once → allow_once, no ttl", () => {
+    expect(resolveApprovalDecision({ kind: "once" })).toEqual({
+      ok: true, decision: "allow_once", granted: true, ttl_ms: null, displayMode: "granted once",
+    });
+  });
+
+  it("always → allow_always, no ttl", () => {
+    expect(resolveApprovalDecision({ kind: "always" })).toEqual({
+      ok: true, decision: "allow_always", granted: true, ttl_ms: null, displayMode: "granted always",
+    });
+  });
+
+  it("ttl with a valid token → allow_ttl with computed ms", () => {
+    expect(resolveApprovalDecision({ kind: "ttl", param: "24h" })).toEqual({
+      ok: true,
+      decision: "allow_ttl",
+      granted: true,
+      ttl_ms: 24 * 60 * 60 * 1000,
+      displayMode: "granted for 24h",
+    });
+    expect(resolveApprovalDecision({ kind: "ttl", param: "7d" })).toMatchObject({
+      ok: true, decision: "allow_ttl", ttl_ms: 7 * 24 * 60 * 60 * 1000,
+    });
+  });
+
+  it("ttl with a bad token → { ok: false } so the caller does NOT consume the nonce", () => {
+    // This is the load-bearing case: pre-PR-4 this branch ran after
+    // approvalConsume() burned the single-use nonce, wedging the agent.
+    // It must report failure WITHOUT side effects (pure fn → caller
+    // returns before approvalConsume).
+    for (const param of ["bogus", "0h", "1w", "", "h", "12"]) {
+      expect(resolveApprovalDecision({ kind: "ttl", param })).toEqual({
+        ok: false, error: "bad ttl token",
+      });
+    }
   });
 });

--- a/telegram-plugin/gateway/approval-callback.ts
+++ b/telegram-plugin/gateway/approval-callback.ts
@@ -22,13 +22,60 @@
  */
 
 import { type Context, InlineKeyboard } from "grammy";
-import { parseApprovalCallback, ttlMsFromToken } from "./approval-card.js";
+import {
+  parseApprovalCallback,
+  ttlMsFromToken,
+  type ApprovalChoice,
+} from "./approval-card.js";
 import {
   approvalConsume,
   approvalRecord,
 } from "../../src/vault/approvals/client.js";
 import type { ApprovalDecisionMode } from "../../src/vault/approvals/schema.js";
 import { scopeToOpenInDriveButton } from "../../src/drive/deep-links.js";
+
+/**
+ * Resolve a tapped approval choice to its decision tuple — PURE, no
+ * kernel I/O, so the `bad ttl token` branch (the only fallible path in
+ * the old inline switch) is unit-testable without mocking grammy.
+ *
+ * Extracted (PR-5) from `handleApprovalCallback` so PR-4's invariant —
+ * "compute + validate the decision BEFORE burning the single-use
+ * nonce" — is now structural, not a comment: the handler calls this
+ * first and only proceeds to `approvalConsume` on `ok: true`. A
+ * malformed ttl token returns `{ ok: false }` and the nonce is never
+ * touched (operator can re-tap a valid choice).
+ */
+export type ResolvedApprovalDecision =
+  | {
+      ok: true;
+      decision: ApprovalDecisionMode;
+      granted: boolean;
+      ttl_ms: number | null;
+      displayMode: string;
+    }
+  | { ok: false; error: string };
+
+export function resolveApprovalDecision(
+  choice: ApprovalChoice,
+): ResolvedApprovalDecision {
+  switch (choice.kind) {
+    case "deny":
+      return { ok: true, decision: "deny", granted: false, ttl_ms: null, displayMode: "denied" };
+    case "once":
+      // No expiry — recorded as a one-shot grant; the agent calls
+      // approval_lookup at most once, then proceeds. /approvals revoke
+      // can still target the row by id.
+      return { ok: true, decision: "allow_once", granted: true, ttl_ms: null, displayMode: "granted once" };
+    case "always":
+      return { ok: true, decision: "allow_always", granted: true, ttl_ms: null, displayMode: "granted always" };
+    case "ttl": {
+      const ms = ttlMsFromToken(choice.param);
+      if (ms === null) return { ok: false, error: "bad ttl token" };
+      return { ok: true, decision: "allow_ttl", granted: true, ttl_ms: ms, displayMode: `granted for ${choice.param}` };
+    }
+  }
+}
 
 /**
  * Build the post-tap keyboard for a granted decision. Today this is
@@ -57,54 +104,21 @@ export async function handleApprovalCallback(
     return;
   }
 
-  // Compute decision + ttl from the choice variant BEFORE burning the
-  // single-use nonce. This block has a fallible early-return (the
-  // `bad ttl token` path). Pre-fix it ran AFTER approvalConsume(), so a
-  // malformed ttl token burned the nonce but recorded no decision — the
-  // agent's approval_lookup poll never saw a verdict and the turn
-  // wedged (pre-PR-3: forever; now bounded by PR-3's PERMISSION_TTL
-  // auto-deny). approvalConsume stays the atomic single-use guard; it
-  // simply doesn't fire until we have a valid decision to record
-  // immediately after. There is now NO fallible step between
-  // consume→record; the only residual gap is the inherent 1-RPC
-  // consume/record non-atomicity (backstopped by PR-3's TTL auto-deny;
-  // a fully atomic kernel consume+record is a tracked follow-up).
-  let decision: ApprovalDecisionMode;
-  let granted: boolean;
-  let ttl_ms: number | null = null;
-  let displayMode: string;
-  switch (parsed.choice.kind) {
-    case "deny":
-      decision = "deny";
-      granted = false;
-      displayMode = "denied";
-      break;
-    case "once":
-      decision = "allow_once";
-      granted = true;
-      // No expiry — recorded as a one-shot grant; the agent calls
-      // approval_lookup at most once, then proceeds. /approvals revoke
-      // can still target the row by id.
-      displayMode = "granted once";
-      break;
-    case "always":
-      decision = "allow_always";
-      granted = true;
-      displayMode = "granted always";
-      break;
-    case "ttl": {
-      decision = "allow_ttl";
-      granted = true;
-      const ms = ttlMsFromToken(parsed.choice.param);
-      if (ms === null) {
-        await ctx.answerCallbackQuery({ text: "bad ttl token" });
-        return;
-      }
-      ttl_ms = ms;
-      displayMode = `granted for ${parsed.choice.param}`;
-      break;
-    }
+  // Resolve + validate the decision BEFORE burning the single-use
+  // nonce (PR-4 invariant, now structural via the pure
+  // resolveApprovalDecision — see its doc). A malformed ttl token
+  // returns { ok: false } here and the nonce is never touched, so the
+  // operator can re-tap a valid choice; pre-fix this validation ran
+  // AFTER approvalConsume(), burning the nonce with no decision
+  // recorded → the agent's approval_lookup poll never saw a verdict
+  // and the turn wedged. There is now NO fallible step between the
+  // consume→record below.
+  const resolved = resolveApprovalDecision(parsed.choice);
+  if (!resolved.ok) {
+    await ctx.answerCallbackQuery({ text: resolved.error });
+    return;
   }
+  const { decision, granted, ttl_ms, displayMode } = resolved;
 
   const consumed = await approvalConsume(parsed.request_id);
   if (consumed === null) {


### PR DESCRIPTION
## Summary

Follow-up **#2** from the callback→continuation reviews. PR-4 (#1541) made *"validate the decision before burning the single-use nonce"* true by statement ordering; this makes it **structural and tested**:

- Extract the decision `switch` into a pure, exported **`resolveApprovalDecision(choice) → {ok:true,decision,granted,ttl_ms,displayMode} | {ok:false,error}`**.
- `handleApprovalCallback` calls it first and only reaches `approvalConsume` on `ok:true` — a malformed ttl token now structurally cannot burn the nonce (the exact pre-PR-4 wedge on this dangerous-tool gate).
- Unit-test the previously-untested fallible branch: deny / once / always / valid-ttl (`24h`,`7d`) / invalid-ttl (`bogus`,`0h`,`1w`,``,`h`,`12`).

Pure refactor — **no behavior change** (byte-equivalent decision outputs; same `answerCallbackQuery("bad ttl token")`+return), no kernel/protocol change. 2 files.

## Scope honesty — follow-up #1 deliberately NOT bundled

Grounding revealed #1 ("atomic kernel consume+record") is **not** the quick additive cleanup I first sized: it changes the **shared broker+approval-kernel Zod wire protocol** (`src/vault/broker/protocol.ts`, also used by the vault broker) **and** must exactly replicate the **#1399 listener-identity ACL** (skipping it = an approval-integrity bypass). That's a wire-protocol + approval-integrity change deserving its own dedicated, separately-reviewed PR — re-sized and surfaced rather than slipped into a "cleanup". The residual it would close (the ~1-RPC consume↔record window) is already bounded by PR-3's TTL auto-deny, so deferring it is safe, not a regression.

## Test plan
- [x] `approval-callback{,.test}.ts` tsc-clean; full non-tsc lint clean (`check-bot-api-wrapping` clean — not `gateway.ts`, no line drift; `check-bun-test-imports`; `check-no-pii-secrets`)
- [x] `approval-callback.test.ts` 12 green (5 new `resolveApprovalDecision` + 7 existing `buildGrantedKeyboard`); `kernel`/`wait` suites no-regression
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)