### PR TITLE
feat(approval): atomic approval_consume_record — close the consume↔record gap (PR-6)

### DIFF
--- a/docs/rfcs/approval-kernel.md
+++ b/docs/rfcs/approval-kernel.md
@@ -151,7 +151,7 @@ apv:<8-hex request id>:<action>[:<param>]
 ```
 
 - 8-hex request id matches `generateAskId` convention.
-- Single-use enforced by an atomic `UPDATE approval_nonces SET consumed_at = ? WHERE request_id = ? AND consumed_at IS NULL` with a rowcount check. Only on rowcount=1 does the kernel proceed to insert/update the corresponding `approval_decisions` row. A re-tap of an already-consumed callback returns a brief "this prompt expired" toast via `answerCallbackQuery`.
+- Single-use enforced by an atomic `UPDATE approval_nonces SET consumed_at = ? WHERE request_id = ? AND consumed_at IS NULL` with a rowcount check. Only on rowcount=1 does the kernel proceed to insert/update the corresponding `approval_decisions` row. A re-tap of an already-consumed callback returns a brief "this prompt expired" toast via `answerCallbackQuery`. *(PR-6: the Telegram `apv:` card path realizes this "only on rowcount=1 do we proceed to the decision row" as a single atomic `approval_consume_record` op — `consumeNonce` + `recordDecision` in one `db.transaction()` — rather than two RPC round-trips, so a broker death between consume and record can no longer burn the nonce without a decision. See `src/vault/approvals/MIGRATION.md`.)*
 - Examples: `apv:a3f1b9c2:allow`, `apv:a3f1b9c2:ttl:1h`, `apv:a3f1b9c2:deny`.
 
 Full scope and humanized title are stored server-side keyed by request id.

--- a/src/vault/approvals/MIGRATION.md
+++ b/src/vault/approvals/MIGRATION.md
@@ -136,3 +136,16 @@ the gateway by writing directly to the broker's grants DB through a
 side channel (or by adding `approval_record` later). The kernel's
 internal `recordDecision` function is exported so a future
 `approval_record` RPC handler can call it without code duplication.
+
+> **PR-6 update.** Both anticipated steps shipped: `approval_record`
+> landed, then the two-RPC split (`approval_consume` → `approval_record`)
+> was fused into a single atomic `approval_consume_record` op for the
+> Telegram `apv:` card path. It composes the same exported `consumeNonce`
+> + `recordDecision` primitives inside ONE `db.transaction()`, closing
+> the consume↔record gap (a broker/gateway death between the two legacy
+> ops burned the nonce with no decision → wedged turn). This realizes
+> RFC §6.1's "only on rowcount=1 does the kernel proceed to insert the
+> decision row" as one atomic step instead of two round-trips.
+> `approval_consume` / `approval_record` remain for their other callers
+> (deferred-secret + `/vault grant` dual-dispatch, `/folders`); only the
+> `apv:` card migrated.

--- a/src/vault/approvals/client.ts
+++ b/src/vault/approvals/client.ts
@@ -145,6 +145,18 @@ export interface ApprovalConsumeResult {
   why?: string | null;
 }
 
+/** Result of the atomic consume+record op (PR-6). Superset of
+ *  ApprovalConsumeResult — `decision_id` is present only on the
+ *  consumed-and-recorded path; `consumed:false` ⇒ no decision written. */
+export interface ApprovalConsumeRecordResult {
+  consumed: boolean;
+  decision_id?: string;
+  agent_unit?: string;
+  scope?: string;
+  action?: string;
+  why?: string | null;
+}
+
 export async function approvalRequest(
   args: ApprovalRequestArgs,
   opts?: ApprovalKernelClientOpts,
@@ -268,7 +280,74 @@ export async function approvalRecord(
   );
   if (r.kind !== "response" || !r.resp.ok) return null;
   if (!("decision_id" in r.resp)) return null;
-  return r.resp.decision_id;
+  // `decision_id` is required on OkApprovalRecord but optional on the
+  // structurally-similar OkApprovalConsumeRecord (the response union is
+  // a plain z.union, not discriminated), so the narrowed type is
+  // string|undefined — coalesce to satisfy the string|null contract.
+  return r.resp.decision_id ?? null;
+}
+
+/**
+ * Atomic consume+record (PR-6). One round-trip; the kernel burns the
+ * single-use nonce AND writes the decision in one SQLite transaction.
+ * Returns `null` on kernel-unreachable / `!ok` / malformed (caller
+ * treats as "kernel unreachable"); `{consumed:false}` ⇒ nonce already
+ * burned/expired/unknown ("this prompt expired", no decision);
+ * `{consumed:true, decision_id, scope, …}` ⇒ recorded. Mirrors the
+ * approvalConsume/approvalRecord wrappers; both of those are kept for
+ * their other callers (deferred-secret + /vault-grant dual-dispatch,
+ * /folders). On a mixed-version rollout an old kernel rejects the
+ * unknown op → `null` → the gateway shows "kernel unreachable" and the
+ * shipped permission-TTL auto-deny backstops; switchroom update
+ * recreates containers together so the window is seconds.
+ */
+export async function approvalConsumeRecord(
+  args: {
+    request_id: string;
+    decision: ApprovalDecisionMode;
+    approver_set: string[];
+    granted_by_user_id: number;
+    ttl_ms?: number | null;
+  },
+  opts?: ApprovalKernelClientOpts,
+): Promise<ApprovalConsumeRecordResult | null> {
+  const r = await rpcRaw(
+    {
+      v: 1,
+      op: "approval_consume_record",
+      request_id: args.request_id,
+      decision: args.decision,
+      approver_set: args.approver_set,
+      granted_by_user_id: args.granted_by_user_id,
+      ttl_ms: args.ttl_ms ?? null,
+    },
+    withKernelOpts(opts),
+  );
+  if (r.kind !== "response" || !r.resp.ok) return null;
+  if (!("consumed" in r.resp)) return null;
+  // The response union is a plain z.union and OkApprovalConsumeResponse
+  // is structurally a prefix of OkApprovalConsumeRecordResponse, so the
+  // `"consumed" in` narrowing keeps both and TS can't see `decision_id`.
+  // The kernel only ever returns the consume_record shape for this op
+  // and the payload is already zod-validated at the wire boundary —
+  // read the fields through a narrow structural view (same trust level
+  // as the sibling approvalConsume wrapper).
+  const resp = r.resp as {
+    consumed: boolean;
+    decision_id?: string;
+    agent_unit?: string;
+    scope?: string;
+    action?: string;
+    why?: string | null;
+  };
+  return {
+    consumed: resp.consumed,
+    decision_id: resp.decision_id,
+    agent_unit: resp.agent_unit,
+    scope: resp.scope,
+    action: resp.action,
+    why: resp.why ?? null,
+  };
 }
 
 export async function approvalList(

--- a/src/vault/approvals/kernel-listener-acl.test.ts
+++ b/src/vault/approvals/kernel-listener-acl.test.ts
@@ -200,4 +200,55 @@ describe("kernel listener-identity ACL on mutating ops (#1399)", () => {
     expect(ok.ok).toBe(true);
     expect(ok.revoked).toBe(true);
   });
+
+  // PR-6: the atomic approval_consume_record op must enforce the SAME
+  // listener-identity ACL as approval_consume (it burns + records).
+  it("denies cross-agent approval_consume_record, nonce intact, no decision, no oracle", async () => {
+    const rid = await aliceRequest();
+
+    // bob tries to atomically burn+record alice's nonce.
+    const denied = await rpc(bobSock, {
+      v: 1,
+      op: "approval_consume_record",
+      request_id: rid,
+      decision: "allow_always",
+      approver_set: ["op1"],
+      granted_by_user_id: 1,
+    });
+    expect(denied.ok).toBe(false);
+    expect(denied.code).toBe("DENIED");
+    expect(String(denied.msg)).not.toContain("alice"); // no owner oracle
+
+    // bob's attempt was a no-op: alice can still atomically
+    // consume+record her own nonce.
+    const okay = await rpc(aliceSock, {
+      v: 1,
+      op: "approval_consume_record",
+      request_id: rid,
+      decision: "allow_once",
+      approver_set: ["op1"],
+      granted_by_user_id: 1,
+    });
+    expect(okay.ok).toBe(true);
+    expect(okay.consumed).toBe(true);
+    expect(okay.decision_id).toBeTruthy();
+    expect(okay.agent_unit).toBe("alice");
+  });
+
+  it("second approval_consume_record is non-committal {consumed:false} (single-use)", async () => {
+    const rid = await aliceRequest();
+    const first = await rpc(aliceSock, {
+      v: 1, op: "approval_consume_record", request_id: rid,
+      decision: "allow_once", approver_set: ["op1"], granted_by_user_id: 1,
+    });
+    expect(first.ok).toBe(true);
+    expect(first.consumed).toBe(true);
+    const second = await rpc(aliceSock, {
+      v: 1, op: "approval_consume_record", request_id: rid,
+      decision: "allow_always", approver_set: ["op1"], granted_by_user_id: 1,
+    });
+    expect(second.ok).toBe(true);
+    expect(second.consumed).toBe(false);
+    expect(second.decision_id).toBeUndefined();
+  });
 });

--- a/src/vault/approvals/kernel-operator-acl.test.ts
+++ b/src/vault/approvals/kernel-operator-acl.test.ts
@@ -139,6 +139,21 @@ describe("kernel operator socket — deny-by-default ACL", () => {
         granted_by_user_id: 1,
       },
     ],
+    [
+      // PR-6 R1: the atomic consume+record op BURNS a nonce AND records
+      // a decision — it must never be reachable on the operator socket.
+      // Pinned so a future OPERATOR_ALLOWED_OPS edit can't silently
+      // expose it.
+      "approval_consume_record",
+      {
+        v: 1,
+        op: "approval_consume_record",
+        request_id: "0badf00d0badf00d0badf00d0badf00d",
+        decision: "allow_always",
+        approver_set: ["u1"],
+        granted_by_user_id: 1,
+      },
+    ],
   ];
 
   for (const [op, req] of forbidden) {

--- a/src/vault/approvals/kernel-server.ts
+++ b/src/vault/approvals/kernel-server.ts
@@ -50,6 +50,7 @@ import {
   requestApproval,
   lookupDecision,
   consumeNonce,
+  consumeAndRecord,
   revokeDecision,
   listDecisions,
   recordDecision,
@@ -484,6 +485,45 @@ function handleRequest(
       ttl_ms: req.ttl_ms ?? undefined,
     });
     socket.write(encodeResponse({ ok: true, decision_id }));
+    return;
+  }
+  if (req.op === "approval_consume_record") {
+    // Atomic consume+record (PR-6). ACL EXACTLY mirrors approval_consume
+    // (not approval_record): this op BURNS the nonce, so a null peek
+    // must fall through to the non-committal {consumed:false} rather
+    // than approval_record's BAD_REQUEST "unknown request_id" — the
+    // latter would be a cross-agent existence oracle on a burning op
+    // (regresses kernel-listener-acl). Listener identity is bind-time
+    // (`agent`), never from the wire. Operator socket can't reach this:
+    // OPERATOR_ALLOWED_OPS is deny-by-default and gates earlier.
+    const peek = getNonce(db, req.request_id);
+    if (peek !== null) {
+      const acl = checkApprovalAclByAgent(agent, peek.agent_unit);
+      if (!acl.allow) {
+        socket.write(encodeResponse(errorResponse("DENIED", "approval_consume_record denied: nonce does not belong to the calling agent")));
+        return;
+      }
+    }
+    const res = consumeAndRecord(db, {
+      request_id: req.request_id,
+      decision: req.decision,
+      approver_set: req.approver_set,
+      granted_by_user_id: req.granted_by_user_id,
+      ttl_ms: req.ttl_ms ?? undefined,
+    });
+    if (!res.consumed) {
+      socket.write(encodeResponse({ ok: true, consumed: false }));
+      return;
+    }
+    socket.write(encodeResponse({
+      ok: true,
+      consumed: true,
+      decision_id: res.decision_id,
+      agent_unit: res.nonce.agent_unit,
+      scope: res.nonce.scope,
+      action: res.nonce.action,
+      why: res.nonce.why,
+    }));
     return;
   }
   if (req.op === "approval_list") {

--- a/src/vault/approvals/kernel.test.ts
+++ b/src/vault/approvals/kernel.test.ts
@@ -10,6 +10,7 @@ import { migrateApprovalSchema, DEFAULT_MAX_TTL_LIFETIME_MS } from "./schema.js"
 import {
   requestApproval,
   consumeNonce,
+  consumeAndRecord,
   recordDecision,
   lookupDecision,
   revokeDecision,
@@ -379,5 +380,94 @@ describe("approval kernel — RFC §10 rate caps", () => {
   it("constants align with RFC §10", () => {
     expect(MAX_PENDING_PER_AGENT).toBe(2);
     expect(MAX_PENDING_GLOBAL).toBe(32);
+  });
+});
+
+describe("approval kernel — consumeAndRecord atomic op (PR-6)", () => {
+  let db: Database;
+  beforeEach(() => { db = newDb(); });
+
+  function freshNonce(): string {
+    return requestApproval(db, {
+      agent_unit: "switchroom-klanker.service",
+      scope: "secret:OPENAI_API_KEY",
+      action: "read",
+      approver_set: ["123"],
+      why: "needs key",
+    }).request_id;
+  }
+
+  it("consumes the nonce AND records the decision atomically", () => {
+    const rid = freshNonce();
+    const res = consumeAndRecord(db, {
+      request_id: rid,
+      decision: "allow_once",
+      approver_set: ["123"],
+      granted_by_user_id: 123,
+    });
+    expect(res.consumed).toBe(true);
+    if (!res.consumed) throw new Error("unreachable");
+    expect(res.decision_id).toBeTruthy();
+    // Nonce burned + linked to the decision; exactly one decision row.
+    const nonce = getNonce(db, rid)!;
+    expect(nonce.consumed_at).not.toBeNull();
+    expect(nonce.decision_id).toBe(res.decision_id);
+    expect(
+      db.query<{ n: number }, []>(`SELECT COUNT(*) n FROM approval_decisions`).get()!.n,
+    ).toBe(1);
+    // The decision is visible to a subsequent lookup → grant flow works.
+    expect(
+      lookupDecision(db, {
+        agent_unit: "switchroom-klanker.service",
+        scope: "secret:OPENAI_API_KEY",
+        action: "read",
+        current_approver_set: ["123"],
+      }).state,
+    ).toBe("granted");
+  });
+
+  it("second call is non-committal {consumed:false} — single-use, exactly one decision", () => {
+    const rid = freshNonce();
+    expect(consumeAndRecord(db, { request_id: rid, decision: "allow_once", approver_set: ["123"], granted_by_user_id: 1 }).consumed).toBe(true);
+    const second = consumeAndRecord(db, { request_id: rid, decision: "allow_always", approver_set: ["123"], granted_by_user_id: 1 });
+    expect(second.consumed).toBe(false);
+    expect(
+      db.query<{ n: number }, []>(`SELECT COUNT(*) n FROM approval_decisions`).get()!.n,
+    ).toBe(1);
+  });
+
+  it("unknown request_id → {consumed:false}, no decision (non-committal, mirrors approval_consume)", () => {
+    const res = consumeAndRecord(db, {
+      request_id: "0badf00d0badf00d0badf00d0badf00d",
+      decision: "allow_once",
+      approver_set: ["123"],
+      granted_by_user_id: 1,
+    });
+    expect(res.consumed).toBe(false);
+    expect(
+      db.query<{ n: number }, []>(`SELECT COUNT(*) n FROM approval_decisions`).get()!.n,
+    ).toBe(0);
+  });
+
+  it("rollback-on-throw: a throw inside the consume txn reverts the burn (PR-6 is the repo's first db.transaction use)", () => {
+    // Directly exercises the bun:sqlite db.transaction rollback
+    // semantics consumeAndRecord relies on: consume the nonce, then
+    // throw — the consumed_at burn AND any decision row must roll back.
+    const rid = freshNonce();
+    expect(() =>
+      db.transaction(() => {
+        const n = consumeNonce(db, rid);
+        expect(n).not.toBeNull();
+        recordDecision(db, { nonce: n!, decision: "allow_once", approver_set: ["123"], granted_by_user_id: 1 });
+        throw new Error("boom — simulate a failure after the burn+record");
+      })(),
+    ).toThrow("boom");
+    // Burn reverted (nonce reusable) and NO decision persisted.
+    expect(getNonce(db, rid)!.consumed_at).toBeNull();
+    expect(
+      db.query<{ n: number }, []>(`SELECT COUNT(*) n FROM approval_decisions`).get()!.n,
+    ).toBe(0);
+    // And consumeAndRecord can still succeed afterward (proves reusable).
+    expect(consumeAndRecord(db, { request_id: rid, decision: "allow_once", approver_set: ["123"], granted_by_user_id: 1 }).consumed).toBe(true);
   });
 });

--- a/src/vault/approvals/kernel.ts
+++ b/src/vault/approvals/kernel.ts
@@ -501,6 +501,59 @@ export function recordDecision(
 }
 
 /**
+ * Atomically consume the single-use nonce AND record the decision in
+ * ONE SQLite transaction (PR-6). Composes the existing primitives — no
+ * new SQL. If `recordDecision` throws (or anything else in the body),
+ * bun:sqlite rolls back the `consumed_at` burn too, so the nonce stays
+ * reusable rather than being burned with no decision (the exact gap
+ * that wedged the agent's turn when the broker died between the two
+ * legacy ops — RFC §6.1 always specified this as one atomic
+ * rowcount-gated step; the two-RPC split was a Phase-1 expedient, see
+ * MIGRATION.md).
+ *
+ * `{ consumed: false }` ⇒ already-consumed / expired / unknown (race or
+ * re-tap): NO decision row is written, identical to a standalone
+ * `consumeNonce` returning null. Audit rows (`consume` + `grant|deny`,
+ * or just `expire`) are emitted by the composed primitives and commit
+ * atomically with the state — `approval_audit` is unchained
+ * (schema.ts), so a rolled-back+retried call cannot corrupt any chain.
+ *
+ * NOTE: first explicit `db.transaction()` use in the repo — covered by
+ * an explicit rollback-on-throw test.
+ */
+export function consumeAndRecord(
+  db: Database,
+  input: {
+    request_id: string;
+    decision: ApprovalDecisionMode;
+    approver_set: string[];
+    granted_by_user_id: number;
+    ttl_ms?: number;
+  },
+  now: number = Date.now(),
+): { consumed: false } | { consumed: true; decision_id: string; nonce: NonceRow } {
+  const run = db.transaction(():
+    | { consumed: false }
+    | { consumed: true; decision_id: string; nonce: NonceRow } => {
+    const nonce = consumeNonce(db, input.request_id, now);
+    if (nonce === null) return { consumed: false };
+    const decision_id = recordDecision(
+      db,
+      {
+        nonce,
+        decision: input.decision,
+        approver_set: input.approver_set,
+        granted_by_user_id: input.granted_by_user_id,
+        ttl_ms: input.ttl_ms,
+      },
+      now,
+    );
+    return { consumed: true, decision_id, nonce };
+  });
+  return run();
+}
+
+/**
  * Revoke a decision by id. Idempotent (revoking a revoked row is a no-op).
  * `reason` is persisted into approval_decisions.revoke_reason.
  */

--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -28,8 +28,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { chainRow, seedChain, type ChainState } from "../../util/audit-hashchain.js";
 
-/** Operations the broker can perform. */
-export type AuditOp = "get" | "put" | "set" | "delete" | "list" | "unlock" | "lock" | "mint_grant" | "list_grants" | "revoke_grant" | "preflight_access";
+/** Operations the broker can perform. (PR-6: `approval_consume_record`
+ *  is an additive member of the shared broker/kernel request union, so
+ *  the broker's grant-mgmt `writeAudit({ op: req.op })` callsites now
+ *  see it in `req.op`'s static type even though the broker never
+ *  dispatches it — including it here keeps the audit-op vocabulary a
+ *  superset of the wire ops and satisfies tsc with no runtime change.) */
+export type AuditOp = "get" | "put" | "set" | "delete" | "list" | "unlock" | "lock" | "mint_grant" | "list_grants" | "revoke_grant" | "preflight_access" | "approval_consume_record";
 
 /**
  * One audit log entry.

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -311,6 +311,23 @@ export const ApprovalRecordRequestSchema = z.object({
   ttl_ms: z.number().int().positive().nullable().optional(),
 });
 
+// Atomic consume+record (PR-6). Identical payload to approval_record;
+// the kernel burns the single-use nonce AND writes the decision inside
+// ONE SQLite transaction, eliminating the consume↔record IPC gap that
+// wedged the agent's turn if the broker/gateway died between the two
+// legacy ops. Additive: approval_consume / approval_record stay intact
+// for their other callers (deferred-secret + /vault-grant dual-dispatch,
+// /folders picker, tests) — only the apv: card path migrates.
+export const ApprovalConsumeRecordRequestSchema = z.object({
+  v: z.literal(1),
+  op: z.literal("approval_consume_record"),
+  request_id: z.string().regex(/^[0-9a-f]{32}$/),
+  decision: ApprovalDecisionModeSchema,
+  approver_set: z.array(z.string()),
+  granted_by_user_id: z.number().int(),
+  ttl_ms: z.number().int().positive().nullable().optional(),
+});
+
 export const RequestSchema = z.discriminatedUnion("op", [
   GetRequestSchema,
   PutRequestSchema,
@@ -327,6 +344,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   ApprovalRevokeRequestSchema,
   ApprovalListRequestSchema,
   ApprovalRecordRequestSchema,
+  ApprovalConsumeRecordRequestSchema,
 ]);
 
 export type GetRequest = z.infer<typeof GetRequestSchema>;
@@ -522,6 +540,20 @@ export const OkApprovalRecordResponseSchema = z.object({
   decision_id: z.string(),
 });
 
+// Reuses OkApprovalConsumeResponseSchema's exact field shape (so the
+// gateway's consumed.scope Drive-button path needs no adaptation) plus
+// an optional decision_id present only on the consumed+recorded path.
+// consumed:false ⇒ nonce already burned/expired/unknown, no decision.
+export const OkApprovalConsumeRecordResponseSchema = z.object({
+  ok: z.literal(true),
+  consumed: z.boolean(),
+  decision_id: z.string().optional(),
+  agent_unit: z.string().optional(),
+  scope: z.string().optional(),
+  action: z.string().optional(),
+  why: z.string().nullable().optional(),
+});
+
 export const ErrorResponseSchema = z.object({
   ok: z.literal(false),
   code: ErrorCode,
@@ -544,6 +576,7 @@ export const ResponseSchema = z.union([
   OkApprovalRevokeResponseSchema,
   OkApprovalListResponseSchema,
   OkApprovalRecordResponseSchema,
+  OkApprovalConsumeRecordResponseSchema,
   ErrorResponseSchema,
 ]);
 

--- a/src/vault/broker/server-approvals.test.ts
+++ b/src/vault/broker/server-approvals.test.ts
@@ -137,7 +137,13 @@ describe("VaultBroker: approval-kernel ops", () => {
       approver_set: ["U1"], granted_by_user_id: 42,
     });
     if (!(recRes.ok && "decision_id" in recRes)) throw new Error("bad");
+    // approval_record always returns a string decision_id. The response
+    // union is a plain z.union and (since PR-6) two variants carry
+    // `decision_id` — one optional — so the `in` narrowing yields
+    // string|undefined. Assert it's a string: strengthens the test and
+    // gives the later approval_revoke a `string` decision_id.
     const id = recRes.decision_id;
+    if (typeof id !== "string") throw new Error("expected a string decision_id");
 
     const list = await rpc(socketPath, { v: 1, op: "approval_list" });
     expect(list.ok).toBe(true);

--- a/telegram-plugin/gateway/approval-callback.ts
+++ b/telegram-plugin/gateway/approval-callback.ts
@@ -27,10 +27,7 @@ import {
   ttlMsFromToken,
   type ApprovalChoice,
 } from "./approval-card.js";
-import {
-  approvalConsume,
-  approvalRecord,
-} from "../../src/vault/approvals/client.js";
+import { approvalConsumeRecord } from "../../src/vault/approvals/client.js";
 import type { ApprovalDecisionMode } from "../../src/vault/approvals/schema.js";
 import { scopeToOpenInDriveButton } from "../../src/drive/deep-links.js";
 
@@ -120,18 +117,6 @@ export async function handleApprovalCallback(
   }
   const { decision, granted, ttl_ms, displayMode } = resolved;
 
-  const consumed = await approvalConsume(parsed.request_id);
-  if (consumed === null) {
-    await ctx.answerCallbackQuery({ text: "approval kernel unreachable" });
-    return;
-  }
-  if (!consumed.consumed) {
-    // Single-use enforcement: someone already tapped, or the nonce
-    // expired/unknown. Match the RFC §8.1 wording.
-    await ctx.answerCallbackQuery({ text: "this prompt expired" });
-    return;
-  }
-
   const granted_by_user_id = ctx.from?.id ?? 0;
   // Approver set at decision time = the chat that received the card. We
   // store the singleton for now; the gateway-side approver-set lookup
@@ -139,18 +124,37 @@ export async function handleApprovalCallback(
   // when each surface migrates and starts passing access.allowFrom.
   const approver_set = [String(granted_by_user_id)];
 
-  const decision_id = await approvalRecord({
+  // PR-6: atomic consume+record — ONE round-trip; the kernel burns the
+  // single-use nonce AND writes the decision in one SQLite transaction.
+  // If the record fails the burn rolls back, so `null` genuinely means
+  // "nothing happened, safe to retry" — there is no burned-nonce /
+  // no-decision wedge any more (the residual the shipped permission-TTL
+  // auto-deny used to backstop). resolveApprovalDecision already
+  // validated the ttl above, so no fallible step precedes this call.
+  const result = await approvalConsumeRecord({
     request_id: parsed.request_id,
     decision,
     approver_set,
     granted_by_user_id,
     ttl_ms,
   });
-
-  if (decision_id === null) {
+  if (result === null) {
+    await ctx.answerCallbackQuery({ text: "approval kernel unreachable" });
+    return;
+  }
+  if (!result.consumed) {
+    // Already tapped / expired / unknown — single-use is enforced
+    // kernel-side and NO decision was written. RFC §8.1 wording.
+    await ctx.answerCallbackQuery({ text: "this prompt expired" });
+    return;
+  }
+  if (!result.decision_id) {
+    // Defensive: consumed:true must carry a decision_id. Kept distinct
+    // from the unreachable message for operator triage.
     await ctx.answerCallbackQuery({ text: "kernel record failed" });
     return;
   }
+  const decision_id: string = result.decision_id;
 
   // Edit the original card to its post-tap state. Drop the original
   // action keyboard either way; on a successful grant for a Drive
@@ -163,8 +167,8 @@ export async function handleApprovalCallback(
       ? ` · /approvals revoke <code>${decision_id}</code>`
       : "");
 
-  const postTapKeyboard = granted && consumed.scope
-    ? buildGrantedKeyboard(consumed.scope)
+  const postTapKeyboard = granted && result.scope
+    ? buildGrantedKeyboard(result.scope)
     : undefined;
 
   try {


### PR DESCRIPTION
## Summary

Closes the last residual of the callback→model-continuation series. The Telegram `apv:` approval-card path did **two** kernel RPCs — `approval_consume` (atomic single-use burn) then `approval_record`. A broker/gateway death in the ~1-RPC gap burned the nonce with **no decision** → the agent's `approval_lookup` poll never saw a verdict → wedged turn (previously only bounded to ≤10 min by the shipped `PERMISSION_TTL` auto-deny).

**Independently design-reviewed before any code** (verdict: APPROVE, no required changes; 2 non-blocking tightening recs folded in).

New **additive** `approval_consume_record` op: kernel `consumeAndRecord()` composes the **existing** `consumeNonce` + `recordDecision` primitives in **one `db.transaction()`** (the repo's first explicit SQLite txn — explicit rollback-on-throw test added). Record failure rolls back the burn → nonce reusable, no wedge. Realizes RFC §6.1's "only on rowcount=1 do we proceed to the decision row" as one atomic step (`MIGRATION.md` anticipated exactly this).

## Integrity preserved (the high-stakes part)
- kernel-server handler **mirrors `approval_consume`'s #1399 listener-identity ACL exactly** (`getNonce` peek → `checkApprovalAclByAgent` → generic DENIED, no agent-name oracle; null-peek = non-committal `{consumed:false}`, **not** `approval_record`'s BAD_REQUEST — a *burning* op must not be a cross-agent existence oracle).
- single-use unchanged (same `consumed_at`-guarded UPDATE rowcount).
- `approval_audit` is unchained (`schema.ts`) → rollback/retry cannot corrupt any audit chain.
- operator socket deny-by-default → new op auto-denied, **pinned** by the parametrized operator-acl test (rec R1).
- shared broker/kernel zod union: purely additive, `v` stays 1, no existing op/shape touched; `approval_consume`/`approval_record` kept for their other callers (deferred-secret + `/vault grant` dual-dispatch, `/folders`) — only the `apv:` card migrated.
- mixed-version rollout: old kernel zod-rejects → client `null` → "kernel unreachable" → `PERMISSION_TTL` backstop; containers recreate together (seconds). No legacy fallback added (over-engineering for a seconds-long, backstopped window).

## Test plan
- [x] `kernel.test.ts`: happy / double-call(single-use, 1 decision) / unknown(non-committal) / **rollback-on-throw** (burn reverts, no decision, reusable)
- [x] `kernel-listener-acl.test.ts`: cross-agent `approval_consume_record` DENIED + no owner-name oracle + single-use, over real bound sockets
- [x] `kernel-operator-acl.test.ts`: operator-socket DENIED (rec R1, parametrized)
- [x] `protocol.test.ts` + `client.test.ts` + `approval-callback.test.ts` green (vitest 50, bun 38) — shared-protocol back-compat intact
- [x] touched files tsc-clean; full **non-tsc lint** clean (`check-bot-api-wrapping`/`bun-test-imports`/`no-pii`) — not `gateway.ts`, no allowlist drift
- [ ] Full CI

Docs: `MIGRATION.md` update + RFC §6.1 cross-ref.

> **Reviewer — heightened BLOCK criteria** (auth-integrity + shared protocol): (1) #1399 ACL non-regression on the new op (incl. null-peek = non-committal, no agent-name oracle); (2) atomicity — `db.transaction` rollback-on-throw actually reverts the burn, no nested-txn hazard; (3) shared-protocol back-compat — no existing op/shape changed, broker server safely ignores the new op; (4) operator-socket deny pinned. Please run `bun test src/vault/approvals/kernel*.test.ts` and `bash scripts/check-bot-api-wrapping.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)