### PR TITLE
fix(gateway): self-heal buffered inbound when silence-poke clears a wedge

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -116,7 +116,12 @@ ALLOWLIST=(
   # (+~49 after line 2745) drifted the permission-request keyboard send
   # to 3069 (past 3010). End 3010 -> 3080; next raw call is 3209
   # (outside), so no new un-allowlisted call enters the margin.
-  "telegram-plugin/gateway/gateway.ts:2695-3080:permission-request keyboard; no thread_id"
+  # Re-bumped 2026-05-19 for the silence-poke wedge-clear buffer
+  # self-heal (+14 lines in onFrameworkFallback ~2746) drifted the
+  # permission-request keyboard send 3072 -> 3086 (past 3080). End
+  # 3080 -> 3100; next raw call is 3650 (far outside), so no new
+  # un-allowlisted call enters the margin.
+  "telegram-plugin/gateway/gateway.ts:2695-3100:permission-request keyboard; no thread_id"
 
   # reply chunk-loop fallback after robustApiCall threw THREAD_NOT_FOUND.
   # The caller dropped the thread; this raw sendMessage retries on the
@@ -143,7 +148,11 @@ ALLOWLIST=(
   # Re-bumped 2026-05-19 for PR-3: +~49 drift moved the reply chunk-loop
   # raw sends to 3612/3633 (past 3580). End 3580 -> 3640; next raw call
   # is 3689 (outside), so no new un-allowlisted call enters the margin.
-  "telegram-plugin/gateway/gateway.ts:3160-3640:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
+  # Re-bumped 2026-05-19 for the silence-poke wedge-clear buffer
+  # self-heal (+14 lines ~2746) drifted the chunk-loop raw sends to
+  # ~3636/3650 (3650 past 3640). End 3640 -> 3660; next raw call is
+  # 10562 (far outside), so no new un-allowlisted call enters.
+  "telegram-plugin/gateway/gateway.ts:3160-3660:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -197,7 +206,12 @@ ALLOWLIST=(
   # 10490 -> 10560; next raw call is 10698 (outside), so no new
   # un-allowlisted call enters the margin — same already-.catch-
   # swallowed wizard sites.
-  "telegram-plugin/gateway/gateway.ts:9340-10560:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-19 for the silence-poke wedge-clear buffer
+  # self-heal (+14 lines ~2746) drifted the last wizard
+  # editMessageText site to 10562 (past 10560). End 10560 -> 10580;
+  # next raw call is 10698 (outside), so no new un-allowlisted call
+  # enters — same already-.catch-swallowed wizard site.
+  "telegram-plugin/gateway/gateway.ts:9340-10580:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -245,7 +245,7 @@ import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js'
 import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
-import { createPendingInboundBuffer } from './pending-inbound-buffer.js'
+import { createPendingInboundBuffer, redeliverBufferedInbound } from './pending-inbound-buffer.js'
 import { createPendingPermissionBuffer } from './pending-permission-decisions.js'
 import {
   buildVaultGrantApprovedInbound,
@@ -2743,10 +2743,27 @@ silencePoke.startTimer({
     try {
       clearSilentEndState(fbKey)
     } catch { /* best-effort */ }
+    // Self-heal the inbound buffer. pendingInboundBuffer otherwise
+    // drains ONLY on bridge re-register (onClientRegistered). After a
+    // network storm that settles with the bridge STILL connected, user
+    // messages buffered during the flap sit forever — until a manual
+    // restart forces a re-register (the fleet-update thundering-herd
+    // incident, 2026-05-19: agents "not responding", logs show
+    // pending-inbound-buffer depth>0 with no drain). Flushing on
+    // wedge-clear makes the agent self-heal. selfAgent-keyed; a miss
+    // re-buffers so nothing is lost if the bridge is genuinely offline.
+    const fbSelfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
+    const fbRedeliver = redeliverBufferedInbound(
+      pendingInboundBuffer,
+      fbSelfAgent,
+      (m) => ipcServer.sendToAgent(fbSelfAgent, m),
+    )
     process.stderr.write(
       `telegram gateway: silence-poke framework-fallback ended wedged turn ` +
       `chat=${fbChatId} thread=${ctx.threadId ?? '-'} silence_ms=${ctx.silenceMs} ` +
-      `currentTurn_nulled=${turnMatchesFallback}\n`,
+      `currentTurn_nulled=${turnMatchesFallback} ` +
+      `drained_buffered=${fbRedeliver.redelivered}/${fbRedeliver.drained}` +
+      `${fbRedeliver.rebuffered > 0 ? ` rebuffered=${fbRedeliver.rebuffered}` : ''}\n`,
     )
   },
 })

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -54,6 +54,45 @@ export interface PendingInboundBufferOptions {
   log?: (line: string) => void
 }
 
+/**
+ * Drain `agent`'s buffered inbound and re-deliver each via `send`. A
+ * `send` returning false (or throwing) means "not delivered" — the
+ * message is re-buffered so nothing is lost when the bridge is still
+ * offline. Returns counts for observability.
+ *
+ * This exists because `drain` is otherwise only called on bridge
+ * re-register (`onClientRegistered`). After a network storm that
+ * settles with the bridge STILL connected, messages buffered during
+ * the flap never drain — they sit until a manual restart forces a
+ * re-register. The silence-poke framework fallback calls this on
+ * wedge-clear so the agent self-heals (fleet-update thundering-herd
+ * incident, 2026-05-19).
+ */
+export function redeliverBufferedInbound(
+  buffer: PendingInboundBuffer,
+  agent: string,
+  send: (msg: InboundMessage) => boolean,
+): { drained: number; redelivered: number; rebuffered: number } {
+  const pending = buffer.drain(agent)
+  let redelivered = 0
+  let rebuffered = 0
+  for (const msg of pending) {
+    let delivered = false
+    try {
+      delivered = send(msg)
+    } catch {
+      delivered = false
+    }
+    if (delivered) {
+      redelivered++
+    } else {
+      buffer.push(agent, msg)
+      rebuffered++
+    }
+  }
+  return { drained: pending.length, redelivered, rebuffered }
+}
+
 export function createPendingInboundBuffer(
   opts: PendingInboundBufferOptions = {},
 ): PendingInboundBuffer {

--- a/telegram-plugin/tests/pending-inbound-buffer.test.ts
+++ b/telegram-plugin/tests/pending-inbound-buffer.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { createPendingInboundBuffer, DEFAULT_PENDING_INBOUND_CAP } from '../gateway/pending-inbound-buffer.js'
+import { createPendingInboundBuffer, redeliverBufferedInbound, DEFAULT_PENDING_INBOUND_CAP } from '../gateway/pending-inbound-buffer.js'
 import type { InboundMessage } from '../gateway/ipc-protocol.js'
 
 function inbound(source: string, ts = Date.now()): InboundMessage {
@@ -128,5 +128,75 @@ describe('pending-inbound-buffer', () => {
     expect(buf.totalDepth()).toBe(3)
     buf.drain('a')
     expect(buf.totalDepth()).toBe(1)
+  })
+})
+
+describe('redeliverBufferedInbound — wedge-clear self-heal (fleet-update incident 2026-05-19)', () => {
+  it('delivers every buffered message and empties the buffer when send succeeds', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('klanker', inbound('user', 1))
+    buf.push('klanker', inbound('user', 2))
+    const seen: number[] = []
+    const r = redeliverBufferedInbound(buf, 'klanker', (m) => {
+      seen.push(m.messageId as number)
+      return true
+    })
+    expect(r).toEqual({ drained: 2, redelivered: 2, rebuffered: 0 })
+    expect(seen).toEqual([1, 2]) // FIFO preserved
+    expect(buf.depth('klanker')).toBe(0)
+  })
+
+  it('re-buffers (loses nothing) when the bridge is still offline — send returns false', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('klanker', inbound('user', 1))
+    buf.push('klanker', inbound('cron', 2))
+    const r = redeliverBufferedInbound(buf, 'klanker', () => false)
+    expect(r).toEqual({ drained: 2, redelivered: 0, rebuffered: 2 })
+    expect(buf.depth('klanker')).toBe(2) // still there, nothing lost
+    expect(buf.drain('klanker').map((m) => m.meta?.source)).toEqual(['user', 'cron'])
+  })
+
+  it('treats a throwing send as not-delivered and re-buffers', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('klanker', inbound('user', 1))
+    const r = redeliverBufferedInbound(buf, 'klanker', () => {
+      throw new Error('bridge write failed')
+    })
+    expect(r).toEqual({ drained: 1, redelivered: 0, rebuffered: 1 })
+    expect(buf.depth('klanker')).toBe(1)
+  })
+
+  it('mixed: delivers what it can, re-buffers only the misses', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('klanker', inbound('a', 1))
+    buf.push('klanker', inbound('b', 2))
+    buf.push('klanker', inbound('c', 3))
+    let n = 0
+    const r = redeliverBufferedInbound(buf, 'klanker', () => {
+      n++
+      return n !== 2 // 2nd send fails
+    })
+    expect(r).toEqual({ drained: 3, redelivered: 2, rebuffered: 1 })
+    expect(buf.drain('klanker').map((m) => m.meta?.source)).toEqual(['b'])
+  })
+
+  it('is a no-op on an empty buffer (no send calls)', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    let calls = 0
+    const r = redeliverBufferedInbound(buf, 'klanker', () => {
+      calls++
+      return true
+    })
+    expect(r).toEqual({ drained: 0, redelivered: 0, rebuffered: 0 })
+    expect(calls).toBe(0)
+  })
+
+  it('only touches the named agent', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('klanker', inbound('user', 1))
+    buf.push('clerk', inbound('user', 2))
+    redeliverBufferedInbound(buf, 'klanker', () => true)
+    expect(buf.depth('klanker')).toBe(0)
+    expect(buf.depth('clerk')).toBe(1) // untouched
   })
 })


### PR DESCRIPTION
## Summary

Durable fix for the **2026-05-19 fleet-update thundering-herd incident** (clerk + klanker "not responding" after a `switchroom update`).

`pendingInboundBuffer` is drained **only** on bridge re-register (`onClientRegistered`). When `switchroom update` recreated all ~13 containers simultaneously, the concurrent gateway Telegram-startup overwhelmed `api.telegram.org` (`HttpError: getMe failed`, grammY `TimeoutError`) → a reconnect storm. The two agents that had an **in-flight turn** got a wedged turn; user messages arriving during the flap were correctly buffered (`pending-inbound-buffer depth_after=2`) — but with the bridge settling back **still connected** (no re-register), the buffer never drained. The agents looked dead despite healthy containers/tokens/polling; only a manual restart (which force-registers the bridge → drains) recovered them.

## Fix

The silence-poke framework fallback already ends the wedged turn. It now **also flushes the agent's inbound buffer** via a new pure `redeliverBufferedInbound(buffer, agent, send)` (drain → send → re-buffer on miss, so nothing is lost if the bridge is genuinely offline). The wedge-clear is itself the self-heal trigger — **no restart needed**. The fallback's summary log gains `drained_buffered=<redelivered>/<drained>` so this is visible in-log (it was invisible during the incident debug).

- `onClientRegistered`'s existing drain is **deliberately left untouched** (it works; minimal blast radius). The `currentTurn`-null guard is unchanged — the drain is independent of it (types confirm the guard is correct for the common case; making the buffer self-heal is the load-bearing fix).
- New logic extracted as a **pure exported helper** + unit-tested (idiomatic here — mirrors HEAD #1544's "extract pure seam + test").
- `check-bot-api-wrapping.sh`: the +14-line gateway.ts insertion drifted three pre-existing allowlisted raw sends past their range ends (permission keyboard 3086, chunk-loop 3650, vault wizard 10562); widened those three ranges per the documented same-PR protocol — verified no new un-allowlisted call enters the margins.

JTBD: *always-on* — an agent must self-recover from a transient network storm, not silently wedge until a human notices and restarts it.

## Test plan

- [x] `vitest telegram-plugin/tests/pending-inbound-buffer.test.ts` — 6 new cases: all-delivered empties buffer (FIFO preserved); send-false re-buffers (nothing lost); throwing send → re-buffer; mixed delivers-what-it-can; empty no-op; agent isolation
- [x] `vitest telegram-plugin/tests/silence-poke.test.ts` green (52) — fallback path unaffected
- [x] `tsc --noEmit` clean across `src/` + plugin (the `@mtcute/node` uat error is the known pre-existing env gap)
- [x] `check-bot-api-wrapping.sh` clean (drift absorbed); `check-bun-test-imports` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)