### PR TITLE
chore: release v0.12.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## v0.12.15 — fix: agents self-heal a post-network-storm wedge (no manual restart)
+
+Headline: an agent that had a turn in flight when the network flapped
+(e.g. every gateway hitting `api.telegram.org` at once during a
+fleet-wide `switchroom update` recreate) could end up silently "not
+responding" — the inbound buffer drained ONLY on a bridge re-register,
+so once connectivity returned with the bridge still connected the
+buffered user messages sat forever until a manual per-agent restart.
+The silence-poke framework fallback now flushes that buffer when it
+clears the wedged turn, so the agent self-recovers within the
+silence-poke window with no operator action. Also: the approval kernel
+closes its consume↔record gap (atomic), and `switchroom doctor` now
+actively probes Drive OAuth-client broker-reachability instead of only
+checking config presence.
+
+### Changes
+
+#### Features
+
+- **feat(approval):** `approval_consume_record` is now atomic — the
+  single-use nonce consume and the audit-record write can no longer
+  tear apart on a crash/race between the two, closing the
+  consume↔record gap (PR-6). (#1545)
+
+#### Fixes
+
+- **fix(gateway):** agents self-heal a wedged turn after a network
+  storm. `pendingInboundBuffer` previously drained only on bridge
+  re-register (`onClientRegistered`); after a storm that settled with
+  the bridge still connected, messages buffered during the flap never
+  drained and the agent looked dead until a manual restart. The
+  silence-poke framework fallback now flushes the buffer (new pure
+  `redeliverBufferedInbound` — drain → send → re-buffer on miss so
+  nothing is lost) when it clears the wedge. The fallback log gains
+  `drained_buffered=<n>/<n>` for visibility. Root-caused from the
+  2026-05-19 fleet-update thundering-herd incident. (#1546)
+- **fix(doctor):** the Google Drive section now actively probes that
+  the vault-broker will actually *serve* the configured OAuth client
+  credential to each Drive-enabled agent (operator-socket
+  `preflight_access` → full `checkAclByAgent`), instead of only
+  checking the value is present in config. Closes the blind spot that
+  let the v0.12.14 client-secret broker-ACL bug ship silently; broker
+  locked/unreachable maps to `skip`, never a false fail. (#1543)
+
+#### Internal
+
+- **refactor(approval):** extracted a pure `resolveApprovalDecision`
+  and unit-tested the bad-TTL seam, de-risking the approval-decision
+  path ahead of the atomic-consume change. (#1544)
+
 ## v0.12.14 — fix: Google Drive MCP works fleet-wide (RFC G §4.4) + gateway/approval delivery reliability
 
 Headline: the Google Drive MCP was dead on arrival on every install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.12.14",
+  "version": "0.12.15",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release **v0.12.15** — 4 commits since v0.12.14 (`db6d87d6`).

**Headliner:** agents now self-heal a post-network-storm wedge (#1546). `pendingInboundBuffer` previously drained only on bridge re-register; after a storm that settled with the bridge still connected (the 2026-05-19 fleet-update thundering-herd incident), buffered user messages sat until a manual restart. The silence-poke framework fallback now flushes the buffer on wedge-clear — no operator action.

Also: approval-kernel atomic consume↔record (#1545), the `switchroom doctor` Drive broker-reachability probe (#1543, closes the blind spot that let the v0.12.14 client-secret bug ship silently), and the approval-decision pure-seam refactor that de-risked #1545 (#1544).

Two-file release commit per convention (`package.json` 0.12.14 → 0.12.15 + `CHANGELOG.md`, full triage of all 4 commits — none omitted).

## Test plan

- [x] CHANGELOG triaged against `db6d87d6..upstream/main` (4 commits: #1543, #1544, #1545, #1546)
- [x] Only `package.json` + `CHANGELOG.md` changed (matches the v0.12.14 release-commit shape)
- [ ] CI green (10 required checks) → auto-merge
- [ ] Post-merge: `npm publish --ignore-scripts`; verify tarball has `dist/cli/switchroom.js`; verify registry `@latest`. Git tag intentionally skipped (matches current practice — v0.12.10–14 untagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)