### PR TITLE
ci(docker-images): tolerate a missing :sha-<short> in promote-to-dev

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -360,4 +360,24 @@ jobs:
         run: |
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image }}"
-          docker buildx imagetools create -t "${IMAGE}:dev" "${IMAGE}:sha-${SHA_SHORT}"
+          # An image whose build context is unchanged for this commit is
+          # a 100% buildx cache hit and pushes NOTHING — so its per-commit
+          # `:sha-<short>` tag never gets created. This is the norm for
+          # `hindsight` (it extends upstream `vectorize-io/hindsight`, not
+          # `switchroom-base`, so most main commits don't touch its
+          # context). Hard-failing the retag here turned that into a
+          # whole-run red on `docker-images` for every hindsight-untouched
+          # release (e.g. v0.12.15 / dc508a9), even though the fleet is
+          # fine: `:latest` is pushed inline by the build jobs, and the
+          # existing `:dev` already points at the last good build. So:
+          # promote when the source tag exists; otherwise no-op (the
+          # unchanged image needs no re-promotion). buildx imagetools
+          # inspect is the existence probe — it resolves OCI indexes /
+          # provenance-attested manifests the same way `create` consumes
+          # them, so the probe can't disagree with the retag.
+          if docker buildx imagetools inspect "${IMAGE}:sha-${SHA_SHORT}" >/dev/null 2>&1; then
+            docker buildx imagetools create -t "${IMAGE}:dev" "${IMAGE}:sha-${SHA_SHORT}"
+            echo "promoted ${IMAGE}:sha-${SHA_SHORT} -> ${IMAGE}:dev"
+          else
+            echo "::notice title=promote-to-dev skipped::${IMAGE}:sha-${SHA_SHORT} absent (build context unchanged this commit — buildx cache hit, nothing pushed). Existing ${IMAGE}:dev retained; nothing to re-promote."
+          fi

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -338,7 +338,17 @@ jobs:
   # PR C: promote :sha-<7> → :dev for every image when smoke passes.
   # Matrix-fanout retag using buildx imagetools so we don't rebuild.
   promote-to-dev:
-    needs: [smoke-test]
+    # `build-hindsight` is intentionally decoupled from the base→
+    # build-dependents→smoke-test chain (it extends upstream, builds in
+    # parallel). But promote-to-dev's `hindsight` matrix leg retags
+    # hindsight's `:sha-<short>`, so it MUST gate on build-hindsight
+    # succeeding — otherwise a genuine hindsight build/push failure
+    # (job green path not taken) could be misread by the retag step as
+    # a benign "image unchanged" skip. With build-hindsight in `needs`,
+    # a missing `:sha-<short>` at promote time provably means
+    # "build succeeded but context unchanged → buildx cache hit, nothing
+    # pushed", never "build failed".
+    needs: [smoke-test, build-hindsight]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
@@ -358,8 +368,10 @@ jobs:
 
       - name: Retag :sha-<7> as :dev (no rebuild)
         run: |
+          set -euo pipefail
           SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
           IMAGE="${REGISTRY}/${IMAGE_NAMESPACE}/switchroom-${{ matrix.image }}"
+          SRC="${IMAGE}:sha-${SHA_SHORT}"
           # An image whose build context is unchanged for this commit is
           # a 100% buildx cache hit and pushes NOTHING — so its per-commit
           # `:sha-<short>` tag never gets created. This is the norm for
@@ -369,15 +381,26 @@ jobs:
           # whole-run red on `docker-images` for every hindsight-untouched
           # release (e.g. v0.12.15 / dc508a9), even though the fleet is
           # fine: `:latest` is pushed inline by the build jobs, and the
-          # existing `:dev` already points at the last good build. So:
-          # promote when the source tag exists; otherwise no-op (the
-          # unchanged image needs no re-promotion). buildx imagetools
-          # inspect is the existence probe — it resolves OCI indexes /
-          # provenance-attested manifests the same way `create` consumes
-          # them, so the probe can't disagree with the retag.
-          if docker buildx imagetools inspect "${IMAGE}:sha-${SHA_SHORT}" >/dev/null 2>&1; then
-            docker buildx imagetools create -t "${IMAGE}:dev" "${IMAGE}:sha-${SHA_SHORT}"
-            echo "promoted ${IMAGE}:sha-${SHA_SHORT} -> ${IMAGE}:dev"
+          # existing `:dev` already points at the last good build.
+          #
+          # promote-to-dev `needs: [smoke-test, build-hindsight]`, so by
+          # the time this runs EVERY image's build job has SUCCEEDED — a
+          # missing `:sha-<short>` therefore provably means "cache hit,
+          # nothing pushed", never "build failed". In that case the
+          # existing `:dev` is already the last good build → skip.
+          #
+          # CRITICAL: only skip on a genuine NOT-FOUND. A transient
+          # registry/auth/network error from `imagetools inspect` must
+          # NOT be misread as "absent" — that would silently stop `:dev`
+          # advancing for a CHANGED image (e.g. agent/kernel on a code
+          # release). Any non-absence error fails the step loudly.
+          if out=$(docker buildx imagetools inspect "$SRC" 2>&1); then
+            docker buildx imagetools create -t "${IMAGE}:dev" "$SRC"
+            echo "promoted $SRC -> ${IMAGE}:dev"
+          elif printf '%s' "$out" | grep -qiE 'manifest unknown|not found|404|no such manifest|MANIFEST_UNKNOWN'; then
+            echo "::notice title=promote-to-dev skipped::$SRC absent (build context unchanged this commit — buildx cache hit, nothing pushed). Existing ${IMAGE}:dev retained; nothing to re-promote."
           else
-            echo "::notice title=promote-to-dev skipped::${IMAGE}:sha-${SHA_SHORT} absent (build context unchanged this commit — buildx cache hit, nothing pushed). Existing ${IMAGE}:dev retained; nothing to re-promote."
+            echo "::error title=promote-to-dev failed::inspecting $SRC failed with a non-absence error (registry/auth/network?) — NOT masking a possibly-real promotion."
+            printf '%s\n' "$out"
+            exit 1
           fi


### PR DESCRIPTION
## Summary

`docker-images` has been showing **false-red on `main` for every release that doesn't touch hindsight** (most of them — e.g. v0.12.15 / `dc508a9`). Root cause:

- `promote-to-dev` retags each image's per-commit `:sha-<short>` → `:dev` via `docker buildx imagetools create`.
- An image whose build context is unchanged for a commit is a **100% buildx cache hit and pushes nothing**, so `:sha-<short>` is never created. `hindsight` extends upstream `vectorize-io/hindsight:latest` (not `switchroom-base`), so most main commits don't touch its context.
- `imagetools create` then hard-fails `manifest unknown`. With `fail-fast: false` the other matrix legs go green, but the hindsight leg reds the **whole `docker-images` run**.

**Impact was cosmetic-but-loud:** the fleet is unaffected — `:latest` is pushed inline by the build jobs, and the existing `:dev` already points at the last good hindsight build. But it made main CI red after `chore: release` commits and masked real signal.

## Fix

Promote when the per-commit source tag exists; otherwise emit a `::notice::` and **no-op** (an image unchanged this commit needs no re-promotion — its `:dev` is already current). `buildx imagetools inspect` is the existence probe — it resolves OCI indexes / provenance-attested manifests exactly as `create` consumes them, so the probe can't disagree with the retag it guards.

Workflow-only. `promote-to-dev` is `if: github.event_name == 'push' && refs/heads/main` so this exercises post-merge on the next main push, not on this PR.

## Test plan

- [x] `python3 yaml.safe_load` parses the workflow
- [x] `bash -n` on the new retag snippet (syntax OK)
- [x] Logic review: cache-hit/no-`:sha` legs (hindsight on a code-only release) → notice + success; changed-image legs → unchanged behavior (`create` runs). Verified against the dc508a9 failure (`switchroom-hindsight:sha-dc508a9: not found`, all other legs green).
- [ ] Post-merge: next `docker-images` run on main is green; a hindsight-untouched commit logs the skip notice instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)