### PR TITLE
fix(gateway): opportunistic idle-drain closes the bridge-flap orphan gap

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -152,7 +152,12 @@ ALLOWLIST=(
   # self-heal (+14 lines ~2746) drifted the chunk-loop raw sends to
   # ~3636/3650 (3650 past 3640). End 3640 -> 3660; next raw call is
   # 10562 (far outside), so no new un-allowlisted call enters.
-  "telegram-plugin/gateway/gateway.ts:3160-3660:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
+  # Re-bumped 2026-05-19 for the idle-drain fix: the +~30-line
+  # opportunistic idle-drain block (~line 3274, inside this range)
+  # drifted the chunk-loop raw send to 3692 (past 3660). End
+  # 3660 -> 3700; next raw call is 10604 (far outside), so no new
+  # un-allowlisted call enters the margin.
+  "telegram-plugin/gateway/gateway.ts:3160-3700:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -211,7 +216,12 @@ ALLOWLIST=(
   # editMessageText site to 10562 (past 10560). End 10560 -> 10580;
   # next raw call is 10698 (outside), so no new un-allowlisted call
   # enters — same already-.catch-swallowed wizard site.
-  "telegram-plugin/gateway/gateway.ts:9340-10580:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-19 for the idle-drain fix: the +~30-line
+  # opportunistic idle-drain block (~3274) drifted the last wizard
+  # editMessageText site to 10604 (past 10580). End 10580 -> 10620;
+  # next raw call is 10698 (outside), so no new un-allowlisted call
+  # enters — same already-.catch-swallowed wizard site.
+  "telegram-plugin/gateway/gateway.ts:9340-10620:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -245,7 +245,7 @@ import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js'
 import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
-import { createPendingInboundBuffer, redeliverBufferedInbound } from './pending-inbound-buffer.js'
+import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
 import { createPendingPermissionBuffer } from './pending-permission-decisions.js'
 import {
   buildVaultGrantApprovedInbound,
@@ -3271,6 +3271,48 @@ const ipcServer: IpcServer = createIpcServer({
 
   log: (msg) => process.stderr.write(`telegram gateway: ipc — ${msg}\n`),
 })
+
+// ─── Opportunistic idle-drain of pendingInboundBuffer ─────────────────────
+// pendingInboundBuffer otherwise drains only on (a) bridge re-register
+// (onClientRegistered) or (b) the silence-poke framework fallback
+// clearing a wedged turn (#1546). NEITHER fires when a message is
+// buffered during a bridge-IPC flap that then settles with no
+// subsequent clean re-register AND claude is idle (no active turn →
+// silence-poke never arms). The message orphans until a manual restart
+// (finn, 2026-05-19 — buffered "verify with mff-query.py cashflow"
+// while idle; last `bridge registered` predated the buffer push, so
+// onClientRegistered's drain never ran for it).
+//
+// This is the third drain trigger. It's gated to be zero-cost and
+// zero-churn: skip entirely when nothing is buffered (one Map.get, no
+// log) or when the bridge isn't alive (exactly sendToAgent's own
+// guard — so we never drain into a dead bridge and re-buffer/log-spin).
+// Only when there IS a buffered message AND a live bridge do we reuse
+// the #1546 `redeliverBufferedInbound` (lossless: re-buffers any
+// per-message miss). A message delivered while a turn is active is
+// queued normally by the bridge — same as a live arrival, not lost.
+const IDLE_DRAIN_INTERVAL_MS = 5000
+if (!STATIC) {
+  setInterval(() => {
+    const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
+    const r = idleDrainTick(
+      pendingInboundBuffer,
+      selfAgent,
+      () => {
+        const c = ipcServer.getClient(selfAgent)
+        return c != null && c.isAlive()
+      },
+      (m) => ipcServer.sendToAgent(selfAgent, m),
+    )
+    if (r != null && r.redelivered > 0) {
+      process.stderr.write(
+        `telegram gateway: idle-drain flushed ${r.redelivered}/${r.drained} ` +
+        `buffered inbound for ${selfAgent}` +
+        `${r.rebuffered > 0 ? ` (${r.rebuffered} re-buffered)` : ''}\n`,
+      )
+    }
+  }, IDLE_DRAIN_INTERVAL_MS).unref()
+}
 
 // ─── Tool execution ──────────────────────────────────────────────────────
 

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -93,6 +93,38 @@ export function redeliverBufferedInbound(
   return { drained: pending.length, redelivered, rebuffered }
 }
 
+/**
+ * One opportunistic idle-drain tick. The third drain trigger, beside
+ * `onClientRegistered` (bridge re-register) and the silence-poke
+ * wedge-clear (#1546). Closes the orphan gap those two miss: a message
+ * buffered during a bridge-IPC flap that settles with no subsequent
+ * clean re-register while claude is idle (no turn → no silence-poke)
+ * — it would otherwise sit until a manual restart (finn, 2026-05-19).
+ *
+ * Gated to be zero-cost / zero-churn so it can run on a short timer:
+ *   - empty buffer → return null (one Map.get, NO drain, NO log)
+ *   - bridge not alive → return null (never drain into a dead bridge,
+ *     which would re-buffer+log-spin every tick; onClientRegistered
+ *     will drain on the eventual reconnect instead)
+ *   - otherwise → `redeliverBufferedInbound` (lossless: re-buffers any
+ *     per-message miss). A message delivered mid-turn is queued
+ *     normally by the bridge, same as a live arrival — not lost.
+ *
+ * Returns the redeliver counts only when it actually ran, else null
+ * (so the caller logs only on a real flush).
+ */
+export function idleDrainTick(
+  buffer: PendingInboundBuffer,
+  agent: string,
+  isBridgeAlive: () => boolean,
+  send: (msg: InboundMessage) => boolean,
+): { drained: number; redelivered: number; rebuffered: number } | null {
+  if (!agent) return null
+  if (buffer.depth(agent) === 0) return null
+  if (!isBridgeAlive()) return null
+  return redeliverBufferedInbound(buffer, agent, send)
+}
+
 export function createPendingInboundBuffer(
   opts: PendingInboundBufferOptions = {},
 ): PendingInboundBuffer {

--- a/telegram-plugin/tests/pending-inbound-buffer.test.ts
+++ b/telegram-plugin/tests/pending-inbound-buffer.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { createPendingInboundBuffer, redeliverBufferedInbound, DEFAULT_PENDING_INBOUND_CAP } from '../gateway/pending-inbound-buffer.js'
+import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick, DEFAULT_PENDING_INBOUND_CAP } from '../gateway/pending-inbound-buffer.js'
 import type { InboundMessage } from '../gateway/ipc-protocol.js'
 
 function inbound(source: string, ts = Date.now()): InboundMessage {
@@ -198,5 +198,52 @@ describe('redeliverBufferedInbound — wedge-clear self-heal (fleet-update incid
     redeliverBufferedInbound(buf, 'klanker', () => true)
     expect(buf.depth('klanker')).toBe(0)
     expect(buf.depth('clerk')).toBe(1) // untouched
+  })
+})
+
+describe('idleDrainTick — the 3rd drain trigger (finn orphan gap, 2026-05-19)', () => {
+  it('no-op (returns null, no send) when the buffer is empty', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    let sent = 0
+    const r = idleDrainTick(buf, 'finn', () => true, () => { sent++; return true })
+    expect(r).toBeNull()
+    expect(sent).toBe(0)
+  })
+
+  it('no-op (returns null) when bridge is NOT alive — never drains into a dead bridge', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('finn', inbound('user', 1))
+    let sent = 0
+    const r = idleDrainTick(buf, 'finn', () => false, () => { sent++; return true })
+    expect(r).toBeNull()
+    expect(sent).toBe(0)
+    expect(buf.depth('finn')).toBe(1) // untouched — onClientRegistered will get it on reconnect
+  })
+
+  it('flushes the buffer when bridge is alive AND something is buffered (the finn fix)', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('finn', inbound('user', 2013)) // the orphaned "verify with mff-query.py" class
+    const seen: number[] = []
+    const r = idleDrainTick(buf, 'finn', () => true, (m) => { seen.push(m.messageId as number); return true })
+    expect(r).toEqual({ drained: 1, redelivered: 1, rebuffered: 0 })
+    expect(seen).toEqual([2013])
+    expect(buf.depth('finn')).toBe(0)
+  })
+
+  it('is lossless — a delivery miss re-buffers, returns null on empty agent', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('finn', inbound('user', 1))
+    const r = idleDrainTick(buf, 'finn', () => true, () => false)
+    expect(r).toEqual({ drained: 1, redelivered: 0, rebuffered: 1 })
+    expect(buf.depth('finn')).toBe(1) // nothing lost
+    expect(idleDrainTick(buf, '', () => true, () => true)).toBeNull() // empty agent guard
+  })
+
+  it('checks depth BEFORE isBridgeAlive — empty buffer never probes the bridge', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    let probed = false
+    const r = idleDrainTick(buf, 'finn', () => { probed = true; return true }, () => true)
+    expect(r).toBeNull()
+    expect(probed).toBe(false) // cheap path: Map.get only, no bridge probe, no log
   })
 })


### PR DESCRIPTION
## Summary

Closes the residual gap that #1546 did **not** cover — surfaced as **finn "not responding", 2026-05-19**.

`pendingInboundBuffer` drained only via (a) `onClientRegistered` (bridge re-register edge) or (b) #1546's silence-poke fallback on a **wedged-turn** clear. finn's case fit neither: a user message ("verify with mff-query.py cashflow") was buffered during a **bridge-IPC flap**; the flap settled with the last `bridge registered` event *predating* the buffer push (so `onClientRegistered`'s drain never ran for it), and claude was **idle** (no active turn → silence-poke never arms → #1546 can't fire). The message orphaned until a manual restart.

## Fix

A **third drain trigger**: a 5s `.unref()` timer (sibling of the existing `checkApprovals` interval) calling the new pure `idleDrainTick`. Gated to be **zero-cost / zero-churn**:
- buffer empty → `null` immediately (one `Map.get`, no log, no bridge probe)
- bridge not alive → `null` (never drain into a dead bridge → no re-buffer/log-spin; `onClientRegistered` still handles the eventual reconnect)
- non-empty buffer **and** live bridge → reuse the #1546-tested `redeliverBufferedInbound` (lossless: re-buffers any per-message miss; a delivery mid-turn is queued normally by the bridge, same as a live arrival)

`idleDrainTick` is an **extracted pure seam** (mirrors #1544/#1546) — unit-tested independent of the gateway monolith. No new `IpcServer` API: the connected-gate reuses the existing `getClient()` + `isAlive()` that `sendToAgent` itself uses. `onClientRegistered`'s drain and the #1546 path are **unchanged** (purely additive).

JTBD: *always-on* — an agent must self-recover from a transient bridge flap, not silently swallow a message until a human notices.

## Test plan

- [x] `vitest pending-inbound-buffer.test.ts` — 5 new `idleDrainTick` cases: empty→null (no send/probe), bridge-dead→null+buffer-untouched, alive+buffered→flush (FIFO), miss→re-buffer (lossless) + empty-agent guard, depth-checked-before-bridge-probe
- [x] `vitest silence-poke.test.ts` green (52) — #1546 path unaffected
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping` clean (the +~30-line insert drifted 2 pre-existing allowlisted raw sends; widened those 2 ranges per the documented protocol — no new un-allowlisted call in the margins) + `check-bun-test-imports` clean
- [ ] Post-merge: staggered rollout; confirm `idle-drain flushed` log token appears when a buffered+idle agent self-heals

🤖 Generated with [Claude Code](https://claude.com/claude-code)