### PR TITLE
feat(session): proactive /compact at session.max_context_tokens

### DIFF
--- a/docs/session-optimization.md
+++ b/docs/session-optimization.md
@@ -66,11 +66,31 @@ The main agent (Opus) handles planning and review. `@worker` (Sonnet) handles im
 
 ## Compaction
 
-Claude Code auto-compacts at ~83.5% of the context window (~835k tokens on the 1M Opus model). This is handled transparently:
+Claude Code auto-compacts late in the context window (roughly 80–85% full — on the 1M Opus model that is well past 800k tokens). This is handled transparently:
 
 - **Micro-compaction** selectively summarizes old tool results.
 - **Full compaction** produces a structured summary of intent, changes, and pending work.
 - **CLAUDE.md is sacred** — never compacted, always in the system prompt.
 - **Hindsight is the safety net** — anything compaction loses can be recalled from the memory bank.
 
-With the 1M context window on Opus 4.6, most conversations won't hit compaction in a single session.
+On the 1M context window (Opus 4.7), most conversations never reach native auto-compaction in a single session.
+
+### Proactive compaction (`session.max_context_tokens`)
+
+Native auto-compaction firing only near the very top of a 1M window means an agent can spend a long time operating with a very large, mostly-stale context — slower, costlier per turn, and lower-signal than a lean window. To hold a **deliberately small working context** on a large-window model, set a token cap:
+
+```yaml
+defaults:
+  session:
+    max_context_tokens: 190000   # /compact when occupancy reaches ~190k
+```
+
+Behavior:
+
+- **Opt-in.** Unset (the default) → unchanged: rely on Claude Code's native auto-compaction. A fresh `switchroom setup` is unaffected.
+- **What's measured.** Occupancy = the latest assistant turn's `input + cache-read + cache-creation` tokens — the prefix the model actually re-read this turn, i.e. the live window fill. Not cumulative across the session.
+- **When it fires.** Only at a turn boundary while the model is idle (never mid-generation). It runs the same `/compact` the model would, just earlier and on your schedule.
+- **Anti-flap.** After a compaction it disarms and re-arms only once occupancy falls back below ~60% of the cap, with an additional few-turn floor — so a borderline post-compact turn can't trigger a second compaction.
+- **Cascade.** Standard `session.*` per-field merge: set fleet-wide under `defaults.session` or override per agent/profile. Orthogonal to `session.max_idle` / `session.max_turns` (fresh-session rotation) and `session_continuity.resume_mode`.
+
+This is the recommended setting for an always-on fleet on the 1M Opus model where lean, fast, high-signal turns matter more than maximum single-session memory (Hindsight remains the cross-session safety net).

--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -92,7 +92,11 @@ ALLOWLIST=(
   # Re-bumped 2026-05-19 for PR-3: import + TTL-sweep insertions drifted
   # the broadcast send +19 to 2371 (past 2360). End 2360 -> 2380; next
   # raw call is 2399 (outside), so no new un-allowlisted call enters.
-  "telegram-plugin/gateway/gateway.ts:2250-2380:operator-event broadcast; no thread_id in opts"
+  # Re-bumped 2026-05-19 for proactive context-compaction: +107 net
+  # lines higher in the file drifted the broadcast send to 2475 (past
+  # 2380). End 2380 -> 2520; check flags only 2475 in 2381-2694 (next
+  # allowlist entry starts 2695), so no new un-allowlisted call enters.
+  "telegram-plugin/gateway/gateway.ts:2250-2520:operator-event broadcast; no thread_id in opts"
 
   # permission-request keyboard send. opts only has reply_markup. No thread_id.
   # Range bumped 2026-05-13 for stuck-turn-recovery v2 cleanup expansion
@@ -157,7 +161,12 @@ ALLOWLIST=(
   # drifted the chunk-loop raw send to 3692 (past 3660). End
   # 3660 -> 3700; next raw call is 10604 (far outside), so no new
   # un-allowlisted call enters the margin.
-  "telegram-plugin/gateway/gateway.ts:3160-3700:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
+  # Re-bumped 2026-05-19 for proactive context-compaction: +107 net
+  # lines higher in the file drifted the chunk-loop raw sends to
+  # 3778/3799 (past 3700). End 3700 -> 3860; check flags only
+  # 3778/3799 before the next allowlist entry (8100), so no new
+  # un-allowlisted call enters the margin.
+  "telegram-plugin/gateway/gateway.ts:3160-3860:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -221,7 +230,13 @@ ALLOWLIST=(
   # editMessageText site to 10604 (past 10580). End 10580 -> 10620;
   # next raw call is 10698 (outside), so no new un-allowlisted call
   # enters — same already-.catch-swallowed wizard site.
-  "telegram-plugin/gateway/gateway.ts:9340-10620:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-19 for proactive context-compaction: +107 net
+  # lines (perf import, maybeProactiveCompact + module state, onSession
+  # event activeFile capture) drifted the three already-.catch-swallowed
+  # wizard editMessageText sites to 10664/10687/10711 (past 10620). End
+  # 10620 -> 10760; the next raw ctx.api call is 12579 (ctx.api.getFile,
+  # far outside), so no new un-allowlisted call enters.
+  "telegram-plugin/gateway/gateway.ts:9340-10760:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -330,6 +330,19 @@ export const SessionSchema = z
         "turns than this. Useful for preventing context bloat on " +
         "long-running agents.",
       ),
+    max_context_tokens: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        "Proactively run /compact when the live context window " +
+        "occupancy (latest assistant turn input + cache-read + " +
+        "cache-creation tokens) reaches this many tokens. Opt-in: " +
+        "unset means rely on Claude Code's native auto-compaction. " +
+        "Useful on large-window models (e.g. 1M Opus) to hold a " +
+        "deliberately lean working context.",
+      ),
   })
   .optional();
 

--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -616,11 +616,18 @@ function forwardSessionEvent(ev: SessionEvent): void {
     chatId = ev.chatId ?? ''
     threadId = ev.threadId != null ? Number(ev.threadId) : undefined
   }
+  // Forward the tailer's already-attached file (its tracked
+  // currentFile) so the gateway's proactive-compaction check reads
+  // occupancy from the exact session JSONL the tailer is on, never an
+  // independent findActiveSessionFile re-scan (which can transiently
+  // resolve a sub-agent transcript or a stale rotated file).
+  const activeFile = sessionTailHandle?.getActiveFile() ?? null
   ipc.sendSessionEvent({
     type: 'session_event',
     event: ev as unknown as Record<string, unknown>,
     chatId,
     ...(threadId != null ? { threadId } : {}),
+    ...(activeFile ? { activeFile } : {}),
   })
 }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -228,6 +228,8 @@ import { handleInjectCommand } from './inject-handler.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
 import { loadConfig as loadSwitchroomConfig } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
+import { readTurnUsages } from '../../src/agents/perf.js'
+import { decideProactiveCompact, initialCompactState, type CompactState } from './proactive-compact.js'
 import {
   tryHostdDispatch,
   hostdRequestId,
@@ -1062,6 +1064,28 @@ const chatAvailableReactions = new Map<string, Set<string> | null>()
 const chatProbesInFlight = new Set<string>()
 const activeTurnStartedAt = new Map<string, number>()
 const pendingRestarts = new Map<string, number>()  // agentName -> timestamp when restart was requested
+
+// ─── Proactive context compaction (session.max_context_tokens) ──────────
+//
+// Opt-in: when the resolved agent config sets session.max_context_tokens,
+// we fire `/compact` once the live context-window occupancy of the latest
+// assistant turn reaches that many tokens. Evaluated ONLY at the
+// model-idle gate inside purgeReactionTracking (activeTurnStartedAt.size
+// === 0) — never mid-turn — mirroring the pendingRestarts drain. The
+// `/compact` verb is allowlisted in src/agents/inject.ts and runs via the
+// tmux send-keys path (the only path that actually executes the slash
+// command; inject_inbound would deliver it as literal text).
+//
+// `lastSessionActiveFile` is the session-tail's tracked currentFile,
+// forwarded by the bridge on every session_event — we read occupancy from
+// exactly that file (never an independent findActiveSessionFile re-scan).
+let lastSessionActiveFile: string | null = null
+// Anti-spam state machine lives in ./proactive-compact (pure, unit
+// tested). `compactDispatching` is a synchronous re-entrancy guard for
+// the async tmux send — purgeReactionTracking can run several times per
+// turn and we must not double-dispatch before the first send settles.
+let compactState: CompactState = initialCompactState()
+let compactDispatching = false
 const activeDraftStreams = new Map<string, DraftStreamHandle>()
 const activeDraftParseModes = new Map<string, 'HTML' | 'MarkdownV2' | undefined>()
 const suppressPtyPreview = new Set<string>()
@@ -1233,12 +1257,92 @@ function purgeReactionTracking(key: string): void {
   // survives us getting killed by our own restart. Fire-and-forget;
   // response to the client was already sent when the restart was
   // scheduled, so nobody is waiting on this.
-  if (activeTurnStartedAt.size === 0 && pendingRestarts.size > 0) {
-    for (const [agentName, _timestamp] of pendingRestarts.entries()) {
-      triggerSelfRestart(agentName, 'turn-complete-pending-restart');
-      pendingRestarts.delete(agentName);
+  if (activeTurnStartedAt.size === 0) {
+    if (pendingRestarts.size > 0) {
+      for (const [agentName, _timestamp] of pendingRestarts.entries()) {
+        triggerSelfRestart(agentName, 'turn-complete-pending-restart');
+        pendingRestarts.delete(agentName);
+      }
+    } else {
+      // Strictly lower priority than a pending restart: if we just
+      // kicked a restart the process is going away and compacting is
+      // moot, so only evaluate when no restart drained this pass.
+      maybeProactiveCompact();
     }
   }
+}
+
+/**
+ * Model-idle proactive-compaction check. Called ONLY from the
+ * activeTurnStartedAt.size === 0 gate above (never mid-turn). Opt-in via
+ * the resolved agent config's session.max_context_tokens; a no-op when
+ * unset, so a fresh `switchroom setup` is unchanged.
+ *
+ * Occupancy = the latest usage-bearing assistant turn's
+ * input + cache_read + cache_creation tokens (the prefix the model
+ * actually re-read this turn ≈ current window fill). readTurnUsages(_,1)
+ * returns exactly that single turn and skips tool-only / usage-less
+ * lines, so we never under-count off a sub-line.
+ *
+ * Note (accepted, benign): there is a check-to-send race — a new inbound
+ * could set activeTurnStartedAt between this idle check and the async
+ * tmux send. A `/compact` that lands as a new turn starts is queued in
+ * claude's prompt buffer and runs at the next idle prompt (see the
+ * FUTURE-GAP note in src/agents/inject.ts); it is not a mid-generation
+ * injection. We do not claim size===0 is atomic.
+ */
+function maybeProactiveCompact(): void {
+  if (compactDispatching) return;
+
+  const agentName = process.env.SWITCHROOM_AGENT_NAME;
+  if (!agentName) return;
+
+  let cap: number | undefined;
+  try {
+    const cfg = loadSwitchroomConfig();
+    // Resolve through the cascade so a fleet-wide
+    // `defaults.session.max_context_tokens` applies even when the agent
+    // has no explicit per-agent session block (rawAgent → {}).
+    const rawAgent = cfg.agents?.[agentName] ?? {};
+    const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent);
+    cap = resolved.session?.max_context_tokens;
+  } catch {
+    // Best-effort — config may be unreadable in odd boot states; a
+    // failed read just means "no proactive compaction this pass".
+    return;
+  }
+  if (cap == null || cap <= 0) return; // opt-in: unset → native compaction only
+
+  const file = lastSessionActiveFile;
+  if (!file) return;
+
+  const turns = readTurnUsages(file, 1);
+  if (turns.length === 0) return;
+  const t = turns[0];
+  const occupancy = t.input + t.cacheRead + t.cacheCreate;
+
+  const decision = decideProactiveCompact(compactState, occupancy, cap);
+  compactState = decision.state;
+  if (!decision.fire) return;
+
+  // Set the re-entrancy guard synchronously BEFORE the await so a
+  // re-entrant purge pass can't double-dispatch (the decider already
+  // disarmed + armed the cooldown in decision.state).
+  compactDispatching = true;
+  process.stderr.write(
+    `telegram gateway: proactive /compact for ${agentName} ` +
+      `(occupancy=${occupancy} >= cap=${cap})\n`,
+  );
+  void injectSlashCommandImpl(agentName, '/compact')
+    .catch((err: unknown) => {
+      process.stderr.write(
+        `telegram gateway: proactive /compact inject failed for ` +
+          `${agentName}: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    })
+    .finally(() => {
+      compactDispatching = false;
+    });
 }
 
 function endStatusReaction(chatId: string, threadId: number | undefined, outcome: 'done' | 'error'): void {
@@ -2997,6 +3101,9 @@ const ipcServer: IpcServer = createIpcServer({
   },
 
   onSessionEvent(_client: IpcClient, msg: SessionEventForward) {
+    // Track the session-tail's attached file for the proactive-
+    // compaction occupancy read (see maybeProactiveCompact).
+    if (msg.activeFile) lastSessionActiveFile = msg.activeFile
     const ev = msg.event as unknown as SessionEvent
     // Pass the envelope's chatId so non-enqueue events can route to the
     // correct card even when the driver's currentChatId is stale.

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -121,6 +121,15 @@ export interface SessionEventForward {
   event: Record<string, unknown>;
   chatId: string;
   threadId?: number;
+  /**
+   * The session-tail's currently-attached JSONL path (its tracked
+   * `currentFile`, not an independent re-scan). Forwarded so the
+   * gateway's proactive-compaction check reads occupancy from the
+   * exact file the tailer is on — avoids the sub-agent-mtime /
+   * stale-rotation wrong-file hazard. Absent until the tailer has
+   * attached a file.
+   */
+  activeFile?: string;
 }
 
 export interface PermissionRequestForward {

--- a/telegram-plugin/gateway/proactive-compact.ts
+++ b/telegram-plugin/gateway/proactive-compact.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure decision core for proactive context compaction
+ * (`session.max_context_tokens`). Kept side-effect-free so the
+ * anti-spam state machine — the part most prone to livelock /
+ * double-fire — is unit-testable in isolation. The impure shell
+ * (config load, session-file read, tmux `/compact` inject) lives in
+ * gateway.ts and calls `decideProactiveCompact` at the model-idle gate.
+ *
+ * Occupancy fed in by the caller = the latest usage-bearing assistant
+ * turn's `input + cache_read + cache_creation` tokens (the prefix the
+ * model re-read this turn ≈ live context-window fill). Not cumulative.
+ */
+
+/** Hysteresis lower band: re-arm only once occupancy < fraction × cap. */
+export const COMPACT_REARM_FRACTION = 0.6;
+
+/**
+ * Turn-count re-fire floor: after a fire, skip this many idle
+ * evaluations regardless of occupancy. Guards against a slow
+ * post-`/compact` JSONL rotation still reading the pre-compact turn and
+ * triggering an immediate second compaction.
+ */
+export const COMPACT_COOLDOWN_TURNS = 3;
+
+export interface CompactState {
+  /** False after a fire; re-armed only below the hysteresis band. */
+  armed: boolean;
+  /** Idle evaluations remaining before re-fire is even considered. */
+  cooldownTurns: number;
+}
+
+export interface CompactDecision {
+  fire: boolean;
+  /** Next state — caller must persist this verbatim. */
+  state: CompactState;
+}
+
+export function initialCompactState(): CompactState {
+  return { armed: true, cooldownTurns: 0 };
+}
+
+/**
+ * Decide whether to fire `/compact` this idle evaluation, given the
+ * current state, the measured occupancy, and the configured cap.
+ *
+ * Precedence (each returns early):
+ *  1. Cooldown floor — burn one turn, never fire.
+ *  2. Disarmed — re-arm iff occupancy < REARM_FRACTION × cap; never
+ *     fire on the arming pass (so we can't arm and fire together).
+ *  3. Below cap — hold.
+ *  4. Armed and at/above cap — fire, disarm, start the cooldown.
+ *
+ * Livelock safety: once disarmed, step 2 is the ONLY path back to
+ * armed, and it requires occupancy to actually drop below the lower
+ * band. If a compaction fails to shrink context, the cap stays
+ * exceeded, occupancy never drops below 0.6×cap, and we stay disarmed
+ * — i.e. we degrade to "don't fire" rather than firing every turn.
+ */
+export function decideProactiveCompact(
+  state: CompactState,
+  occupancy: number,
+  cap: number,
+): CompactDecision {
+  if (state.cooldownTurns > 0) {
+    return {
+      fire: false,
+      state: { armed: state.armed, cooldownTurns: state.cooldownTurns - 1 },
+    };
+  }
+
+  if (!state.armed) {
+    const armed = occupancy < cap * COMPACT_REARM_FRACTION;
+    return { fire: false, state: { armed, cooldownTurns: 0 } };
+  }
+
+  if (occupancy < cap) {
+    return { fire: false, state };
+  }
+
+  return {
+    fire: true,
+    state: { armed: false, cooldownTurns: COMPACT_COOLDOWN_TURNS },
+  };
+}

--- a/telegram-plugin/tests/proactive-compact.test.ts
+++ b/telegram-plugin/tests/proactive-compact.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decideProactiveCompact,
+  initialCompactState,
+  COMPACT_COOLDOWN_TURNS,
+  COMPACT_REARM_FRACTION,
+  type CompactState,
+} from '../gateway/proactive-compact.js'
+
+const CAP = 190_000
+
+// Drive the state machine over a sequence of occupancy readings,
+// returning the index of every evaluation that fired.
+function run(occ: number[], start: CompactState = initialCompactState()) {
+  let state = start
+  const fires: number[] = []
+  occ.forEach((o, i) => {
+    const d = decideProactiveCompact(state, o, CAP)
+    state = d.state
+    if (d.fire) fires.push(i)
+  })
+  return { state, fires }
+}
+
+describe('decideProactiveCompact', () => {
+  it('does not fire below the cap', () => {
+    const { fires } = run([0, 50_000, 150_000, CAP - 1])
+    expect(fires).toEqual([])
+  })
+
+  it('fires exactly once when occupancy reaches the cap, then disarms', () => {
+    // Stays high after the fire (compaction has not landed yet).
+    const { fires } = run([CAP, CAP, CAP])
+    expect(fires).toEqual([0])
+  })
+
+  it('fires at occupancy strictly above the cap too', () => {
+    const { fires } = run([CAP + 25_000])
+    expect(fires).toEqual([0])
+  })
+
+  it('burns exactly COMPACT_COOLDOWN_TURNS idle evals after a fire before re-considering', () => {
+    // Fire at 0, then occupancy stays pegged high. The cooldown must
+    // swallow the next COMPACT_COOLDOWN_TURNS evals with no fire, and
+    // because it is still above the re-arm band it never re-arms ->
+    // never fires again. (Livelock guard.)
+    const seq = new Array(1 + COMPACT_COOLDOWN_TURNS + 5).fill(CAP)
+    const { fires } = run(seq)
+    expect(fires).toEqual([0])
+  })
+
+  it('re-arms only after occupancy falls below REARM_FRACTION × cap, never on the arming pass', () => {
+    const lowBand = CAP * COMPACT_REARM_FRACTION
+    // fire(0) -> cooldown(1..3) -> still high(4) stays disarmed ->
+    // drop just below band(5): arms but does NOT fire same pass ->
+    // climb back to cap(6): fires again.
+    const seq = [
+      CAP, // 0 fire
+      CAP, // 1 cooldown
+      CAP, // 2 cooldown
+      CAP, // 3 cooldown
+      CAP, // 4 disarmed, above band -> hold
+      lowBand - 1, // 5 re-arm, must NOT fire here
+      CAP, // 6 armed + at cap -> fire
+    ]
+    const { fires } = run(seq)
+    expect(fires).toEqual([0, 6])
+  })
+
+  it('does not re-arm if occupancy only drops to the band but not below it', () => {
+    const lowBand = CAP * COMPACT_REARM_FRACTION
+    // After cooldown, occupancy sits exactly at the band (not strictly
+    // below) forever -> never re-arms -> only the first fire.
+    const seq = [CAP, CAP, CAP, CAP, lowBand, lowBand, lowBand, CAP, CAP]
+    const { fires } = run(seq)
+    expect(fires).toEqual([0])
+  })
+
+  it('full healthy cycle: fire, compaction shrinks context, climbs again, fires again', () => {
+    const seq = [
+      120_000, // below cap
+      CAP, // fire (idx 1)
+      30_000, // cooldown 1 (post-compact, small)
+      35_000, // cooldown 2
+      40_000, // cooldown 3
+      45_000, // disarmed, below band -> re-arm (no fire)
+      90_000, // armed, below cap -> hold
+      CAP + 5_000, // fire again (idx 7)
+    ]
+    const { fires } = run(seq)
+    expect(fires).toEqual([1, 7])
+  })
+
+  it('never fires twice in immediate succession even with no cooldown left if still disarmed', () => {
+    // Construct a state that is past cooldown but disarmed, occupancy
+    // pegged at cap: must hold (not fire) until it drops below band.
+    const stuck: CompactState = { armed: false, cooldownTurns: 0 }
+    const { fires } = run([CAP, CAP, CAP, CAP], stuck)
+    expect(fires).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Opt-in token cap that runs Claude Code's `/compact` once live context occupancy reaches a configured threshold, so an always-on fleet on the 1M Opus window holds a deliberately lean working context instead of waiting for native auto-compaction near the top of the window.

- New `session.max_context_tokens` (opt-in, **no schema default** → fresh `switchroom setup` unchanged). Standard per-field `session` cascade, agent-wins; intended fleet-wide via `defaults.session`.
- Occupancy = latest assistant turn `input + cache_read + cache_creation` (the prefix re-read this turn ≈ live window fill) via existing `perf.ts` `readTurnUsages` — never cumulative, skips tool-only/usage-less lines.
- Reads the **session-tail's already-attached file** (forwarded by the bridge on `session_event`), never an independent `findActiveSessionFile` re-scan that could resolve a sub-agent transcript or a stale post-compact rotation.
- Fires only at the **model-idle gate** in `purgeReactionTracking` (`activeTurnStartedAt.size === 0`), strictly lower priority than a pending restart; never mid-turn. Uses the allowlisted tmux `injectSlashCommand` path (the only path that executes the verb; `inject_inbound` would deliver literal text).
- Anti-spam state machine extracted to a **pure, unit-tested** module (`proactive-compact.ts`): disarm-on-fire + occupancy hysteresis (re-arm `< 0.6×cap`) + turn-count cooldown floor; degrades to "don't fire" rather than livelock if a compaction fails to shrink context.
- `docs/session-optimization.md`: documents the opt-in, reverses the "let native handle it" stance for large-window fleets, fixes stale Opus 4.6 / hard-coded 83.5% figures.

Pre-implementation independent design review: REQUEST_CHANGES → all required changes folded in (session-tail file plumbing, `readTurnUsages` instead of the non-exported `extractTurnUsage`, turn-count floor, documented benign check-to-send race, doc number fix).

**JTBD / Outcome:** vision Outcome 4 (Always-on) — lean, fast, high-signal turns on a 24/7 fleet; Hindsight remains the cross-session safety net. Within design contract; no RFC amendment.

## Test plan

- [x] `tsc --noEmit` clean; full build clean
- [x] bot-api-wrapping / bun-test-imports / no-pii-secrets gates clean (allowlist line-drift ranges re-bumped with dated rationale)
- [x] New `proactive-compact.test.ts` — 8 tests: fires at/above cap, disarms, cooldown floor, hysteresis re-arm (never arm+fire same pass), livelock guard, full healthy cycle
- [x] Regression green: perf (11), config (10), session-tail (43), gateway/bridge (57)
- [ ] Fleet deploy via `switchroom update` after merge; set `defaults.session.max_context_tokens` in private config

🤖 Generated with [Claude Code](https://claude.com/claude-code)