### PR TITLE
feat(session): notify Telegram on proactive-compaction start + finish

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -96,7 +96,11 @@ ALLOWLIST=(
   # lines higher in the file drifted the broadcast send to 2475 (past
   # 2380). End 2380 -> 2520; check flags only 2475 in 2381-2694 (next
   # allowlist entry starts 2695), so no new un-allowlisted call enters.
-  "telegram-plugin/gateway/gateway.ts:2250-2520:operator-event broadcast; no thread_id in opts"
+  # Re-bumped 2026-05-19 for proactive-compaction notification: +150 net
+  # lines higher drifted the broadcast send to 2625 (past 2520). End
+  # 2520 -> 2680; check flags only 2625 in 2521-2694 (next allowlist
+  # entry starts 2695), so no new un-allowlisted call enters.
+  "telegram-plugin/gateway/gateway.ts:2250-2680:operator-event broadcast; no thread_id in opts"
 
   # permission-request keyboard send. opts only has reply_markup. No thread_id.
   # Range bumped 2026-05-13 for stuck-turn-recovery v2 cleanup expansion
@@ -166,7 +170,11 @@ ALLOWLIST=(
   # 3778/3799 (past 3700). End 3700 -> 3860; check flags only
   # 3778/3799 before the next allowlist entry (8100), so no new
   # un-allowlisted call enters the margin.
-  "telegram-plugin/gateway/gateway.ts:3160-3860:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
+  # Re-bumped 2026-05-19 for proactive-compaction notification: +150 net
+  # lines drifted the chunk-loop raw sends to 3928/3949 (past 3860). End
+  # 3860 -> 4000; check flags only 3928/3949 before the next allowlist
+  # entry (8100), so no new un-allowlisted call enters the margin.
+  "telegram-plugin/gateway/gateway.ts:3160-4000:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -236,7 +244,12 @@ ALLOWLIST=(
   # wizard editMessageText sites to 10664/10687/10711 (past 10620). End
   # 10620 -> 10760; the next raw ctx.api call is 12579 (ctx.api.getFile,
   # far outside), so no new un-allowlisted call enters.
-  "telegram-plugin/gateway/gateway.ts:9340-10760:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-19 for proactive-compaction notification: +150 net
+  # lines drifted the three wizard editMessageText sites to
+  # 10814/10837/10861 (past 10760). End 10760 -> 10920; next raw
+  # ctx.api call is still far outside (~12700+), so no new
+  # un-allowlisted call enters.
+  "telegram-plugin/gateway/gateway.ts:9340-10920:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/compact-notify.ts
+++ b/telegram-plugin/gateway/compact-notify.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure transition selector for the proactive-compaction user
+ * notification (a single Telegram card edited START → FINISH). Kept
+ * side-effect-free so the lifecycle — the part prone to double-post /
+ * stale-edit / spurious-finish — is unit-testable in isolation. The
+ * impure shell (send/editMessageText, the wall-clock timeout) lives in
+ * gateway.ts.
+ *
+ * The "finished" signal is the proactive-compaction state machine's
+ * re-arm edge (`armed: false → true`, which the decider only produces
+ * when post-`/compact` occupancy drops below 0.6×cap — i.e. context
+ * verifiably shrank). This module does NOT own the wall-clock timeout
+ * (an idle agent produces no evaluations, so a dangling card must be
+ * resolved by a real timer in the shell, independent of this loop).
+ *
+ * Session reset/rotation (`session.max_idle` / `max_turns`) is
+ * deliberately silent and is not represented here.
+ */
+
+export interface CompactNotifyState {
+  phase: "idle" | "awaiting";
+  /**
+   * The active session file when START was posted. FINISH is only
+   * accepted if the re-arm edge is observed against this SAME file —
+   * a sub-agent transcript briefly leading session-tail's currentFile
+   * can read a small occupancy and spuriously satisfy the re-arm
+   * condition; gating on the start-file rejects that false positive.
+   */
+  fileAtStart: string | null;
+}
+
+/**
+ * - `none`              — no card action this evaluation.
+ * - `start`             — post a fresh START card.
+ * - `start-superseding` — a prior card is still outstanding; mark it
+ *                         superseded, then post a fresh START card.
+ * - `finish`            — edit the outstanding card to FINISHED.
+ */
+export type CompactNotifyAction =
+  | "none"
+  | "start"
+  | "start-superseding"
+  | "finish";
+
+export interface CompactNotifyEvent {
+  /** The proactive-compaction decider fired `/compact` this eval. */
+  fired: boolean;
+  /** Decider re-arm edge this eval (wasArmed=false → state.armed=true). */
+  rearmed: boolean;
+  /** session-tail's active file used for the occupancy read this eval. */
+  activeFile: string | null;
+}
+
+export function idleCompactNotifyState(): CompactNotifyState {
+  return { phase: "idle", fileAtStart: null };
+}
+
+/**
+ * Select the card action for this idle evaluation and the next state.
+ * Pure: same inputs → same outputs, no I/O.
+ *
+ * Precedence:
+ *  1. A fire always (re)starts a card. If one was still outstanding,
+ *     supersede it first (single-outstanding-card invariant).
+ *  2. While awaiting, a re-arm edge ON THE SAME start-file → FINISH.
+ *  3. Otherwise hold (the shell's wall-clock timeout resolves a card
+ *     that never gets a re-arm — e.g. a compaction that didn't shrink
+ *     context, or an agent that went idle right after START).
+ */
+export function nextCompactNotify(
+  state: CompactNotifyState,
+  ev: CompactNotifyEvent,
+): { state: CompactNotifyState; action: CompactNotifyAction } {
+  if (ev.fired) {
+    const superseding = state.phase === "awaiting";
+    return {
+      state: { phase: "awaiting", fileAtStart: ev.activeFile },
+      action: superseding ? "start-superseding" : "start",
+    };
+  }
+
+  if (state.phase === "awaiting") {
+    if (
+      ev.rearmed &&
+      ev.activeFile != null &&
+      ev.activeFile === state.fileAtStart
+    ) {
+      return { state: idleCompactNotifyState(), action: "finish" };
+    }
+    return { state, action: "none" };
+  }
+
+  return { state, action: "none" };
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -230,6 +230,7 @@ import { refreshBanner } from '../slot-banner-driver.js'
 import { loadConfig as loadSwitchroomConfig } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
 import { readTurnUsages } from '../../src/agents/perf.js'
 import { decideProactiveCompact, initialCompactState, type CompactState } from './proactive-compact.js'
+import { nextCompactNotify, idleCompactNotifyState, type CompactNotifyState } from './compact-notify.js'
 import {
   tryHostdDispatch,
   hostdRequestId,
@@ -1086,6 +1087,25 @@ let lastSessionActiveFile: string | null = null
 // turn and we must not double-dispatch before the first send settles.
 let compactState: CompactState = initialCompactState()
 let compactDispatching = false
+
+// User-facing proactive-compaction notification (single Telegram card
+// edited START → FINISH; transition selection is pure in
+// ./compact-notify). Session reset/rotation stays silent — not here.
+// The wall-clock timer is owned HERE (not the pure helper): an idle
+// agent produces no idle evaluations, so a card that never gets a
+// re-arm edge must be resolved by a real timer, independent of the
+// eval loop, or it would dangle forever.
+const COMPACT_CARD_TIMEOUT_MS = 15 * 60 * 1000
+interface OutstandingCompactCard {
+  chatId: string
+  threadId: number | undefined
+  messageId: number
+  occAtStart: number
+  capAtStart: number
+  timer: ReturnType<typeof setTimeout>
+}
+let compactNotifyState: CompactNotifyState = idleCompactNotifyState()
+let outstandingCompactCard: OutstandingCompactCard | null = null
 const activeDraftStreams = new Map<string, DraftStreamHandle>()
 const activeDraftParseModes = new Map<string, 'HTML' | 'MarkdownV2' | undefined>()
 const suppressPtyPreview = new Set<string>()
@@ -1321,8 +1341,35 @@ function maybeProactiveCompact(): void {
   const t = turns[0];
   const occupancy = t.input + t.cacheRead + t.cacheCreate;
 
+  const wasArmed = compactState.armed;
   const decision = decideProactiveCompact(compactState, occupancy, cap);
   compactState = decision.state;
+  // Re-arm edge: the decider only flips disarmed→armed when post-
+  // /compact occupancy fell below 0.6×cap — i.e. context verifiably
+  // shrank. That edge is the honest "compaction finished" signal.
+  const rearmed = !wasArmed && decision.state.armed;
+
+  // User-facing notification transitions (pure). Resolved synchronously
+  // here — before any await and before the !fire return — so a
+  // re-entrant purge pass can't double-post (compactState was already
+  // persisted/disarmed above). All card I/O is reached only past the
+  // `cap == null` opt-in return earlier in this function, so a fleet
+  // with the feature off never posts anything (Defaults preserved).
+  const nt = nextCompactNotify(compactNotifyState, {
+    fired: decision.fire,
+    rearmed,
+    activeFile: file,
+  });
+  compactNotifyState = nt.state;
+  if (nt.action === 'finish') {
+    void resolveCompactCard('finished', occupancy);
+  } else if (nt.action === 'start' || nt.action === 'start-superseding') {
+    if (nt.action === 'start-superseding') {
+      void resolveCompactCard('superseded', occupancy);
+    }
+    void postCompactCard(occupancy, cap);
+  }
+
   if (!decision.fire) return;
 
   // Set the re-entrancy guard synchronously BEFORE the await so a
@@ -1343,6 +1390,109 @@ function maybeProactiveCompact(): void {
     .finally(() => {
       compactDispatching = false;
     });
+}
+
+/**
+ * Post the START card for a proactive compaction. Best-effort: a failed
+ * send just means no card (the compaction itself still happens). The
+ * outstanding record + a wall-clock timeout are armed so the card can
+ * never dangle if the re-arm edge never arrives (failed/idle case).
+ */
+async function postCompactCard(occ: number, cap: number): Promise<void> {
+  try {
+    const chatId = loadAccess().allowFrom[0];
+    if (!chatId) return;
+    const threadId = chatThreadMap.get(chatId);
+    const text =
+      `🗜️ <b>Context compaction</b>\n` +
+      `Working context hit ~${occ.toLocaleString()} tokens ` +
+      `(cap ${cap.toLocaleString()}) — running <code>/compact</code>. ` +
+      `Older detail moves to Hindsight; I'll confirm here once the ` +
+      `context has shrunk (may take a turn or two).`;
+    const sent = await swallowingApiCall(
+      () =>
+        bot.api.sendMessage(chatId, text, {
+          parse_mode: 'HTML',
+          ...(threadId != null ? { message_thread_id: threadId } : {}),
+        }),
+      { chat_id: chatId, verb: 'proactiveCompact.start' },
+    );
+    const messageId = (sent as { message_id?: number } | undefined)
+      ?.message_id;
+    if (typeof messageId !== 'number') return;
+    const timer = setTimeout(() => {
+      void resolveCompactCard('timeout', null);
+    }, COMPACT_CARD_TIMEOUT_MS);
+    timer.unref?.();
+    outstandingCompactCard = {
+      chatId,
+      threadId,
+      messageId,
+      occAtStart: occ,
+      capAtStart: cap,
+      timer,
+    };
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: proactive-compact start card failed: ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+/**
+ * Resolve the outstanding START card to a terminal state by editing it
+ * in place. `finished` is driven by the decider re-arm edge (context
+ * verifiably shrank), `superseded` when a newer compaction starts first,
+ * `timeout` by the wall-clock timer (re-arm never arrived). The
+ * outstanding record + timer are cleared synchronously BEFORE the await
+ * so a stale message_id can never be edited twice and the timer can't
+ * double-fire. On `timeout` the pure notify state is also reset so a
+ * future compaction starts a clean lifecycle.
+ */
+async function resolveCompactCard(
+  kind: 'finished' | 'superseded' | 'timeout',
+  occNow: number | null,
+): Promise<void> {
+  const card = outstandingCompactCard;
+  if (!card) return;
+  outstandingCompactCard = null;
+  clearTimeout(card.timer);
+  if (kind === 'timeout') compactNotifyState = idleCompactNotifyState();
+  let text: string;
+  if (kind === 'finished') {
+    text =
+      `✅ <b>Context compacted</b>\n` +
+      `Working context reduced` +
+      (occNow != null
+        ? ` (~${card.occAtStart.toLocaleString()} → ` +
+          `~${occNow.toLocaleString()} tokens)`
+        : '') +
+      `. Hindsight retains the detail.`;
+  } else if (kind === 'superseded') {
+    text =
+      `↩️ <b>Context compaction superseded</b>\n` +
+      `A newer compaction started before this one confirmed.`;
+  } else {
+    text =
+      `⚠️ <b>Compaction issued</b>\n` +
+      `<code>/compact</code> was requested but the context isn't ` +
+      `confirmed reduced yet. Native compaction and Hindsight still apply.`;
+  }
+  try {
+    await swallowingApiCall(
+      () =>
+        bot.api.editMessageText(card.chatId, card.messageId, text, {
+          parse_mode: 'HTML',
+        }),
+      { chat_id: card.chatId, verb: `proactiveCompact.${kind}` },
+    );
+  } catch (err) {
+    process.stderr.write(
+      `telegram gateway: proactive-compact ${kind} card edit failed: ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
 }
 
 function endStatusReaction(chatId: string, threadId: number | undefined, outcome: 'done' | 'error'): void {

--- a/telegram-plugin/tests/compact-notify.test.ts
+++ b/telegram-plugin/tests/compact-notify.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import {
+  nextCompactNotify,
+  idleCompactNotifyState,
+  type CompactNotifyState,
+} from '../gateway/compact-notify.js'
+
+const FILE_A = '/state/.../sess-a.jsonl'
+const FILE_B = '/state/.../sess-b.jsonl'
+
+describe('nextCompactNotify', () => {
+  it('idle + fired → start, awaiting with fileAtStart', () => {
+    const r = nextCompactNotify(idleCompactNotifyState(), {
+      fired: true,
+      rearmed: false,
+      activeFile: FILE_A,
+    })
+    expect(r.action).toBe('start')
+    expect(r.state).toEqual({ phase: 'awaiting', fileAtStart: FILE_A })
+  })
+
+  it('idle + nothing → none', () => {
+    const r = nextCompactNotify(idleCompactNotifyState(), {
+      fired: false,
+      rearmed: false,
+      activeFile: FILE_A,
+    })
+    expect(r.action).toBe('none')
+    expect(r.state.phase).toBe('idle')
+  })
+
+  it('idle + spurious rearm (no card outstanding) → none', () => {
+    const r = nextCompactNotify(idleCompactNotifyState(), {
+      fired: false,
+      rearmed: true,
+      activeFile: FILE_A,
+    })
+    expect(r.action).toBe('none')
+    expect(r.state.phase).toBe('idle')
+  })
+
+  it('awaiting + rearm on SAME file → finish, back to idle', () => {
+    const awaiting: CompactNotifyState = { phase: 'awaiting', fileAtStart: FILE_A }
+    const r = nextCompactNotify(awaiting, {
+      fired: false,
+      rearmed: true,
+      activeFile: FILE_A,
+    })
+    expect(r.action).toBe('finish')
+    expect(r.state).toEqual(idleCompactNotifyState())
+  })
+
+  it('awaiting + rearm on DIFFERENT file → none (sub-agent false-positive guard)', () => {
+    const awaiting: CompactNotifyState = { phase: 'awaiting', fileAtStart: FILE_A }
+    const r = nextCompactNotify(awaiting, {
+      fired: false,
+      rearmed: true,
+      activeFile: FILE_B,
+    })
+    expect(r.action).toBe('none')
+    expect(r.state).toBe(awaiting) // unchanged, still awaiting
+  })
+
+  it('awaiting + rearm but activeFile null → none', () => {
+    const awaiting: CompactNotifyState = { phase: 'awaiting', fileAtStart: FILE_A }
+    const r = nextCompactNotify(awaiting, {
+      fired: false,
+      rearmed: true,
+      activeFile: null,
+    })
+    expect(r.action).toBe('none')
+    expect(r.state.phase).toBe('awaiting')
+  })
+
+  it('awaiting + no rearm → none, stays awaiting (shell timeout owns dangling)', () => {
+    const awaiting: CompactNotifyState = { phase: 'awaiting', fileAtStart: FILE_A }
+    const r = nextCompactNotify(awaiting, {
+      fired: false,
+      rearmed: false,
+      activeFile: FILE_A,
+    })
+    expect(r.action).toBe('none')
+    expect(r.state.phase).toBe('awaiting')
+  })
+
+  it('awaiting + fired again → start-superseding, awaiting with NEW fileAtStart', () => {
+    const awaiting: CompactNotifyState = { phase: 'awaiting', fileAtStart: FILE_A }
+    const r = nextCompactNotify(awaiting, {
+      fired: true,
+      rearmed: false,
+      activeFile: FILE_B,
+    })
+    expect(r.action).toBe('start-superseding')
+    expect(r.state).toEqual({ phase: 'awaiting', fileAtStart: FILE_B })
+  })
+
+  it('full healthy cycle: fire → hold → rearm(same file) → idle', () => {
+    let s = idleCompactNotifyState()
+    const fires: string[] = []
+    const seq = [
+      { fired: true, rearmed: false, activeFile: FILE_A }, // START
+      { fired: false, rearmed: false, activeFile: FILE_A }, // cooldown/hold
+      { fired: false, rearmed: false, activeFile: FILE_A }, // hold
+      { fired: false, rearmed: true, activeFile: FILE_A }, // FINISH
+      { fired: false, rearmed: false, activeFile: FILE_A }, // idle, nothing
+    ]
+    for (const ev of seq) {
+      const r = nextCompactNotify(s, ev)
+      s = r.state
+      fires.push(r.action)
+    }
+    expect(fires).toEqual(['start', 'none', 'none', 'finish', 'none'])
+    expect(s).toEqual(idleCompactNotifyState())
+  })
+
+  it('rearm that arrives only after a file flip never finishes the wrong card', () => {
+    // START on FILE_A; a sub-agent (FILE_B) leads and "rearms" → ignored;
+    // later the real drop is observed back on FILE_A → finish.
+    let s = nextCompactNotify(idleCompactNotifyState(), {
+      fired: true,
+      rearmed: false,
+      activeFile: FILE_A,
+    }).state
+    const mid = nextCompactNotify(s, {
+      fired: false,
+      rearmed: true,
+      activeFile: FILE_B,
+    })
+    expect(mid.action).toBe('none')
+    s = mid.state
+    const fin = nextCompactNotify(s, {
+      fired: false,
+      rearmed: true,
+      activeFile: FILE_A,
+    })
+    expect(fin.action).toBe('finish')
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #1551/v0.12.17 (proactive `/compact`). Owner ask: **when proactive compaction starts and finishes, tell the Telegram user; session reset/rotation stays silent.**

- A single Telegram card, posted on `/compact` fire ("running /compact…") and **edited in place** to "✅ context compacted (~X → ~Y tokens)" — boot-card-style, matching the card-consistency principle.
- **Finish signal = the v0.12.17 decider's re-arm edge** (`armed:false→true`, which the decider only produces when post-`/compact` occupancy fell below 0.6×cap = context verifiably shrank). Zero new IPC, no new SessionEvent — reuses the shipped state machine + the bridge's already-forwarded active-file.
- **Same-file guard**: FINISH only accepted if the re-arm is observed against the SAME session file active at START (rejects a sub-agent transcript briefly leading session-tail's `currentFile` → no spurious/pre-completion finish).
- **Wall-clock 15-min timeout** (real timer in the gateway shell, NOT the eval loop — an idle agent produces no evals) edits a never-confirmed card to a neutral terminal state so it can never dangle.
- **Single-outstanding-card** invariant + atomic clear (timer + record cleared before the await → no stale message_id double-edit; a new fire supersedes the prior card).
- START decision synchronous (before any await, after the `cap==null` opt-in return) → no double-post on re-entrant purge; feature-off fleet posts nothing (**Defaults preserved**).
- Transition selection extracted to a **pure, unit-tested** module (`compact-notify.ts`, 10 tests covering same-file guard, supersede, timeout-handoff, full cycle); `proactive-compact.ts` unchanged. New Telegram calls `swallowingApiCall`-wrapped; bot-api allowlist line-ranges re-bumped same-PR.

Pre-implementation independent design review: REQUEST_CHANGES → all 6 required changes folded in (wall-clock timeout, same-file guard, synchronous START + post-opt-in placement, single-outstanding/atomic-clear, honest START copy + pure helper, same-PR allowlist re-bump).

**JTBD / Outcome:** Vision Outcome 1 (Visibility) — a silent ~600k+ context drop becomes a visible event in the operator's chat. Session reset stays silent by explicit owner direction.

## Test plan

- [x] `tsc --noEmit` clean; build clean
- [x] bot-api-wrapping / bun-test-imports / no-pii-secrets clean (allowlist re-bumped w/ dated rationale)
- [x] New `compact-notify.test.ts` (10): start/finish/supersede/same-file-guard/null-file/idle-rearm/full-cycle/file-flip
- [x] Regression green: proactive-compact (8), perf (11), config (10), gateway/bridge/session-tail (85)
- [ ] Release v0.12.18 → GHCR `:latest` → `switchroom update` → verify a real compaction posts+edits a card

🤖 Generated with [Claude Code](https://claude.com/claude-code)