### PR TITLE
fix(gateway): turn-gate inbound delivery to end the composer wedge

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -249,6 +249,7 @@ import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js
 import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
+import { decideInboundDelivery } from './inbound-delivery-gate.js'
 import { createPendingPermissionBuffer } from './pending-permission-decisions.js'
 import {
   buildVaultGrantApprovedInbound,
@@ -1278,6 +1279,29 @@ function purgeReactionTracking(key: string): void {
   // response to the client was already sent when the restart was
   // scheduled, so nobody is waiting on this.
   if (activeTurnStartedAt.size === 0) {
+    // #1556: the deterministic delivery point. claude has just gone
+    // idle — flush any inbound held mid-turn so the channel
+    // notification lands at the idle prompt and submits as a fresh
+    // turn (instead of stranding in the composer, the lawgpt wedge).
+    // Zero-churn: depth check first, no work on the common empty path.
+    // Lossless: redeliver re-buffers any per-message miss (bridge
+    // mid-reconnect), which onClientRegistered then drains.
+    const selfAgentForFlush = process.env.SWITCHROOM_AGENT_NAME ?? ''
+    if (pendingInboundBuffer.depth(selfAgentForFlush) > 0) {
+      const fr = redeliverBufferedInbound(
+        pendingInboundBuffer,
+        selfAgentForFlush,
+        (m) => ipcServer.sendToAgent(selfAgentForFlush, m),
+      )
+      if (fr.redelivered > 0) {
+        process.stderr.write(
+          `telegram gateway: turn-complete flushed ${fr.redelivered}/${fr.drained} ` +
+          `held inbound for ${selfAgentForFlush}` +
+          `${fr.rebuffered > 0 ? ` (${fr.rebuffered} re-buffered)` : ''}\n`,
+        )
+      }
+    }
+
     if (pendingRestarts.size > 0) {
       for (const [agentName, _timestamp] of pendingRestarts.entries()) {
         triggerSelfRestart(agentName, 'turn-complete-pending-restart');
@@ -3542,12 +3566,17 @@ const ipcServer: IpcServer = createIpcServer({
 //
 // This is the third drain trigger. It's gated to be zero-cost and
 // zero-churn: skip entirely when nothing is buffered (one Map.get, no
-// log) or when the bridge isn't alive (exactly sendToAgent's own
-// guard — so we never drain into a dead bridge and re-buffer/log-spin).
-// Only when there IS a buffered message AND a live bridge do we reuse
-// the #1546 `redeliverBufferedInbound` (lossless: re-buffers any
-// per-message miss). A message delivered while a turn is active is
-// queued normally by the bridge — same as a live arrival, not lost.
+// log), when the bridge isn't alive (exactly sendToAgent's own guard —
+// so we never drain into a dead bridge and re-buffer/log-spin), OR
+// when a turn is in flight. The turn gate is #1556: a message
+// delivered while a turn is active is NOT safely queued by the bridge
+// — claude types it into its TUI composer and the auto-submit races
+// turn-completion, stranding it (the lawgpt wedge). Draining only at
+// `activeTurnStartedAt.size === 0` guarantees the channel notification
+// lands at an idle prompt and submits as a fresh turn. Only when there
+// IS a buffered message AND a live bridge AND no active turn do we
+// reuse the #1546 `redeliverBufferedInbound` (lossless: re-buffers any
+// per-message miss).
 const IDLE_DRAIN_INTERVAL_MS = 5000
 if (!STATIC) {
   setInterval(() => {
@@ -3556,6 +3585,9 @@ if (!STATIC) {
       pendingInboundBuffer,
       selfAgent,
       () => {
+        // #1556: never drain mid-turn — that re-creates the composer
+        // wedge this buffer exists to prevent.
+        if (activeTurnStartedAt.size > 0) return false
         const c = ipcServer.getClient(selfAgent)
         return c != null && c.isAlive()
       },
@@ -7377,6 +7409,29 @@ async function handleInbound(
   // push to pendingInboundBuffer, which onClientRegistered drains on
   // the next bridge register — so the notice below is now truthful.
   const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
+
+  // #1556: turn-gated delivery. A non-steering inbound that arrives
+  // mid-turn must NOT be sent to the bridge now — claude would type it
+  // into its TUI composer and the auto-submit races turn-completion,
+  // stranding the message (the lawgpt wedge, 2026-05-19). Buffer it;
+  // `purgeReactionTracking`'s turn-complete hook and the turn-gated
+  // idle-drain flush it the instant claude goes idle, where the channel
+  // notification submits cleanly as a fresh turn. Steering messages are
+  // exempt — reaching claude mid-turn is the whole point of /steer.
+  if (
+    decideInboundDelivery({
+      turnInFlight: activeTurnStartedAt.size > 0,
+      isSteering,
+    }) === 'buffer-until-idle'
+  ) {
+    pendingInboundBuffer.push(selfAgent, inboundMsg)
+    process.stderr.write(
+      `telegram gateway: inbound held mid-turn agent=${selfAgent} ` +
+      `chat=${chat_id} msg=${msgId ?? '-'} — will flush on turn-complete\n`,
+    )
+    return
+  }
+
   const delivered = ipcServer.sendToAgent(selfAgent, inboundMsg)
   if (!delivered) {
     pendingInboundBuffer.push(selfAgent, inboundMsg)

--- a/telegram-plugin/gateway/inbound-delivery-gate.ts
+++ b/telegram-plugin/gateway/inbound-delivery-gate.ts
@@ -1,0 +1,77 @@
+/**
+ * Inbound delivery gate (#1556 — the lawgpt composer-wedge).
+ *
+ * Pure decision: given the live turn state, should a freshly-received
+ * Telegram inbound be delivered to the bridge *now*, or held in the
+ * pending-inbound buffer until claude is idle?
+ *
+ * ## Why this exists
+ *
+ * The gateway used to `ipcServer.sendToAgent(inbound)` unconditionally,
+ * buffering ONLY when the bridge was offline. The load-bearing (and
+ * false) assumption — stated verbatim in three places before this fix
+ * (`pending-inbound-buffer.ts`, the idle-drain comment, and the
+ * implicit unconditional send) — was:
+ *
+ *   "a message delivered while a turn is active is queued normally by
+ *    the bridge, same as a live arrival, not lost."
+ *
+ * It is not. The bridge converts an inbound into an MCP
+ * `notifications/claude/channel` notification (`bridge.ts:onInbound`).
+ * When claude receives that notification mid-turn, the unmodified CLI
+ * types the text into its TUI composer and relies on an auto-submit
+ * once the turn ends. That submit races turn-completion and frequently
+ * does not fire — the message strands in the composer, claude sits at
+ * an idle prompt with the user's instruction un-actioned, and nothing
+ * self-heals it (the turn-active watchdog only catches *in-turn* hangs;
+ * this is *between-turns*-with-undelivered-input, which reads as
+ * healthy idle). Observed live: agent `lawgpt`, 2026-05-19 — a
+ * follow-up message sat unsubmitted indefinitely; only a restart
+ * cleared it, and the restart *lost* the message.
+ *
+ * ## The deterministic guarantee
+ *
+ * A non-steering inbound is delivered to the bridge ONLY when no turn
+ * is in flight. The channel notification therefore always lands at an
+ * idle claude prompt, where it submits cleanly as a fresh turn. It can
+ * be *delayed* (until the current turn completes) but can never strand
+ * in the composer. The turn-complete hook
+ * (`purgeReactionTracking`) and the turn-gated idle-drain timer flush
+ * the buffer the instant `activeTurnStartedAt.size === 0`.
+ *
+ * ## Steering is deliberately exempt
+ *
+ * An explicit `/steer` (`/s`) message is *meant* to reach claude
+ * mid-turn — that is the whole point of the steering feature (redirect
+ * the agent while it works). Steering messages keep immediate delivery.
+ * The wedge only ever affected the queued-mid-turn default path.
+ */
+
+export interface InboundDeliveryGateInput {
+  /** A turn is in flight RIGHT NOW (live: `activeTurnStartedAt.size > 0`),
+   *  evaluated at delivery time — not a receipt-time snapshot, so a turn
+   *  that completed between receipt and here correctly reads as idle. */
+  turnInFlight: boolean
+  /** This inbound carried an explicit `/steer` (`/s`) prefix and is an
+   *  intentional mid-turn redirect. */
+  isSteering: boolean
+}
+
+export type InboundDeliveryDecision =
+  /** Send to the bridge now (idle prompt, or an intentional steer). */
+  | 'deliver'
+  /** Hold in the pending-inbound buffer; the turn-complete hook /
+   *  turn-gated idle-drain flushes it when claude goes idle. */
+  | 'buffer-until-idle'
+
+/**
+ * Pure. The ONLY condition that defers delivery is "a turn is in flight
+ * AND this is not a steering message". Everything else delivers
+ * immediately (idle → submits at once; steering → intentional mid-turn).
+ */
+export function decideInboundDelivery(
+  input: InboundDeliveryGateInput,
+): InboundDeliveryDecision {
+  if (input.turnInFlight && !input.isSteering) return 'buffer-until-idle'
+  return 'deliver'
+}

--- a/telegram-plugin/gateway/inbound-delivery-gate.ts
+++ b/telegram-plugin/gateway/inbound-delivery-gate.ts
@@ -31,13 +31,21 @@
  *
  * ## The deterministic guarantee
  *
- * A non-steering inbound is delivered to the bridge ONLY when no turn
- * is in flight. The channel notification therefore always lands at an
- * idle claude prompt, where it submits cleanly as a fresh turn. It can
- * be *delayed* (until the current turn completes) but can never strand
- * in the composer. The turn-complete hook
- * (`purgeReactionTracking`) and the turn-gated idle-drain timer flush
- * the buffer the instant `activeTurnStartedAt.size === 0`.
+ * A non-steering inbound on the Telegram `handleInbound` path is
+ * delivered to the bridge ONLY when no turn is in flight. The channel
+ * notification therefore always lands at an idle claude prompt, where
+ * it submits cleanly as a fresh turn. It can be *delayed* (until the
+ * current turn completes) but can never strand in the composer. The
+ * turn-complete hook (`purgeReactionTracking`) and the turn-gated
+ * idle-drain timer flush the buffer the instant
+ * `activeTurnStartedAt.size === 0`.
+ *
+ * Scope: this gates the Telegram `handleInbound` path only — the one
+ * the lawgpt wedge hit. The `inject_inbound` IPC path (cron / synthetic
+ * operator wakeups) reaches the bridge directly and is deliberately
+ * NOT gated here: cron fires carry at-least-once replay semantics and
+ * their delivery contract is a separate product decision, out of scope
+ * for this bug.
  *
  * ## Steering is deliberately exempt
  *

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -107,8 +107,16 @@ export function redeliverBufferedInbound(
  *     which would re-buffer+log-spin every tick; onClientRegistered
  *     will drain on the eventual reconnect instead)
  *   - otherwise → `redeliverBufferedInbound` (lossless: re-buffers any
- *     per-message miss). A message delivered mid-turn is queued
- *     normally by the bridge, same as a live arrival — not lost.
+ *     per-message miss).
+ *
+ * NOTE (#1556): a message delivered mid-turn is NOT safely queued by
+ * the bridge — the prior "queued normally, same as a live arrival"
+ * claim here was the false assumption behind the lawgpt composer
+ * wedge. claude types a mid-turn channel notification into its TUI
+ * composer and the auto-submit races turn-completion, stranding it.
+ * The `idleDrainTick` caller therefore also gates on
+ * `activeTurnStartedAt.size === 0`, so this function is never invoked
+ * mid-turn. Delivery is turn-gated end to end (gateway.ts).
  *
  * Returns the redeliver counts only when it actually ran, else null
  * (so the caller logs only on a real flush).

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -116,7 +116,10 @@ export function redeliverBufferedInbound(
  * composer and the auto-submit races turn-completion, stranding it.
  * The `idleDrainTick` caller therefore also gates on
  * `activeTurnStartedAt.size === 0`, so this function is never invoked
- * mid-turn. Delivery is turn-gated end to end (gateway.ts).
+ * mid-turn. The Telegram `handleInbound` delivery path is turn-gated
+ * (gateway.ts); the `inject_inbound` cron/synthetic path is a separate
+ * delivery contract and deliberately not gated — see
+ * `inbound-delivery-gate.ts`.
  *
  * Returns the redeliver counts only when it actually ran, else null
  * (so the caller logs only on a real flush).

--- a/telegram-plugin/tests/inbound-delivery-gate.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-gate.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { decideInboundDelivery } from '../gateway/inbound-delivery-gate.js'
+
+/**
+ * Regression coverage for #1556 — the lawgpt composer wedge.
+ *
+ * Before this gate, the gateway sent every inbound to the bridge
+ * immediately, buffering only when the bridge was offline. A
+ * non-steering message that arrived mid-turn was typed into claude's
+ * TUI composer and stranded when the auto-submit raced
+ * turn-completion. The deterministic invariant the gate enforces:
+ *
+ *   a non-steering inbound is delivered ONLY when no turn is in flight.
+ *
+ * Steering (/steer, /s) is the sole exemption — reaching claude
+ * mid-turn is the entire point of that feature.
+ */
+describe('decideInboundDelivery', () => {
+  it('delivers immediately when claude is idle (no turn in flight)', () => {
+    expect(
+      decideInboundDelivery({ turnInFlight: false, isSteering: false }),
+    ).toBe('deliver')
+  })
+
+  it('BUFFERS a non-steering message that arrives mid-turn (the wedge fix)', () => {
+    expect(
+      decideInboundDelivery({ turnInFlight: true, isSteering: false }),
+    ).toBe('buffer-until-idle')
+  })
+
+  it('delivers a steering message mid-turn (steering is intentionally exempt)', () => {
+    expect(
+      decideInboundDelivery({ turnInFlight: true, isSteering: true }),
+    ).toBe('deliver')
+  })
+
+  it('delivers a steering message when idle (steer with no active turn)', () => {
+    expect(
+      decideInboundDelivery({ turnInFlight: false, isSteering: true }),
+    ).toBe('deliver')
+  })
+
+  it('is total: the ONLY deferral path is mid-turn AND not steering', () => {
+    for (const turnInFlight of [true, false]) {
+      for (const isSteering of [true, false]) {
+        const decision = decideInboundDelivery({ turnInFlight, isSteering })
+        const expectBuffer = turnInFlight && !isSteering
+        expect(decision).toBe(expectBuffer ? 'buffer-until-idle' : 'deliver')
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Deterministic fix for the **composer wedge** observed live on agent `lawgpt` (2026-05-19): a non-steering Telegram message that arrived **mid-turn** was sent to the bridge immediately, typed into claude's TUI composer, and stranded forever when the auto-submit raced turn-completion. The agent sat at an idle prompt with the user's instruction un-actioned — invisible to every watchdog (the turn-active marker only catches *in-turn* hangs; this is *between-turns-with-undelivered-input*, which reads as healthy idle). Only a restart cleared it, and the restart **lost the message**.

Root cause was a false assumption stated verbatim in three places: *"a message delivered mid-turn is queued normally by the bridge, same as a live arrival — not lost."* It is not — claude strands it in the composer.

## The fix (deterministic)

A non-steering inbound on the Telegram `handleInbound` path reaches the bridge **only when no turn is in flight**, so the channel notification always lands at an idle prompt and submits as a fresh turn:

1. **Delivery gate** (`gateway.ts` `handleInbound`): mid-turn + `!steering` → buffer in the existing `pendingInboundBuffer` instead of `sendToAgent` (no false "agent restarting" notice — the bridge is alive, just busy).
2. **Turn-complete flush** (`purgeReactionTracking`): flush the held buffer the instant `activeTurnStartedAt.size === 0` (mirrors the existing `pendingRestarts` drain; zero-churn depth check; lossless `redeliverBufferedInbound`).
3. **Idle-drain timer**: also gated on `!turnInFlight` so the 5s tick can never re-flush into a mid-turn bridge.

Steering (`/steer`, `/s`) is deliberately exempt — mid-turn delivery is the entire point of that feature. The `inject_inbound` cron/synthetic path is a separate delivery contract, deliberately out of scope.

Decision extracted to a pure, unit-tested helper (`inbound-delivery-gate.ts`, mirroring `dm-command-gate.ts`). False-assumption comments corrected.

**Out of scope (follow-up):** in-memory buffer persistence across a gateway restart. The wedge elimination makes restart-to-recover unnecessary, so it is no longer load-bearing.

## JTBD

Serves **Always-on** + **Talk from anywhere**: an agent must never silently drop a message the user sent while it was working.

## Test plan

- [x] New pure-helper regression test `telegram-plugin/tests/inbound-delivery-gate.test.ts` (5 cases incl. exhaustive truth table)
- [x] Adjacent regressions green: `pending-inbound-buffer` (22), `dm-command-gate` (14), `gateway-disconnect-flush` (5), `inbound-coalesce` (7), `inbound-message-types` (39), `gateway-bridge`+`ipc-server-race` (29)
- [x] Full `npm run lint` clean (incl. `check-bot-api-wrapping` — no allowlist drift)
- [x] Independent fresh-process reviewer: APPROVE
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)