### PR TITLE
fix(status): tolerate stateless hindsight in agent-status probe

### DIFF
--- a/src/agents/status.ts
+++ b/src/agents/status.ts
@@ -661,10 +661,20 @@ export async function probeHindsight(
     if (!initResp.ok) {
       return { reachable: false, bankExists: false, reason: `HTTP ${initResp.status}` };
     }
+    // Hindsight runs STATELESS by design (HINDSIGHT_API_MCP_STATELESS=true) —
+    // a stateless server returns 200 OK on `initialize` but emits NO
+    // `mcp-session-id` header (there is no session to track; every request
+    // is self-contained). The old hard-fail here ("no session id" →
+    // reachable:false) was a false negative: it drove `overall: fail` and
+    // surfaced `hindsight: fail unreachable (no session id)` on every
+    // agent even though the daemon was up and healthy. `initResp.ok`
+    // already proves reachability. Forward the session header only when a
+    // stateful server actually issued one — same fix as #1515 in
+    // src/memory/hindsight.ts.
     const sessionId = initResp.headers.get("mcp-session-id");
-    if (!sessionId) {
-      return { reachable: false, bankExists: false, reason: "no session id" };
-    }
+    const sessionHeader: Record<string, string> = sessionId
+      ? { "mcp-session-id": sessionId }
+      : {};
 
     // list_banks → look for bankId
     const timeout2 = setTimeout(() => controller.abort(), timeoutMs);
@@ -674,7 +684,7 @@ export async function probeHindsight(
         "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream",
         "X-Bank-Id": bankId,
-        "mcp-session-id": sessionId,
+        ...sessionHeader,
       },
       body: JSON.stringify({
         jsonrpc: "2.0",

--- a/tests/agent.status.probe-hindsight.test.ts
+++ b/tests/agent.status.probe-hindsight.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression coverage for the `hindsight: fail unreachable (no session
+ * id)` false-negative.
+ *
+ * `src/agents/status.ts` carries its OWN `probeHindsight` (used by
+ * `switchroom agent status`), distinct from the one in
+ * `src/memory/hindsight.ts` that doctor uses. #1515 made the
+ * memory/hindsight.ts copy tolerate a stateless server (no
+ * `mcp-session-id`) but MISSED this status.ts copy — so every
+ * `agent status` against a (correctly) stateless hindsight reported
+ * `reachable: false, reason: "no session id"`, driving `overall: fail`
+ * on a healthy daemon (observed live: lawgpt, 2026-05-19).
+ *
+ * Hindsight runs stateless by design (HINDSIGHT_API_MCP_STATELESS=true):
+ * `initialize` returns 200 OK with NO `mcp-session-id` header. A 200 on
+ * init already proves reachability; the session header must be
+ * forwarded only when a stateful server actually issued one.
+ */
+import { describe, it, expect } from "vitest";
+
+import { probeHindsight } from "../src/agents/status.js";
+
+type Init = { headers: Record<string, string> };
+
+/** Minimal Response-like stub matching what probeHindsight consumes. */
+function makeFetch(opts: {
+  initStatus?: number;
+  initHeaders?: Record<string, string>;
+  listStatus?: number;
+  listBody?: string;
+}): { fetchImpl: typeof fetch; calls: Init[] } {
+  const calls: Init[] = [];
+  let n = 0;
+  const fetchImpl = (async (_url: string, init: RequestInit) => {
+    n += 1;
+    calls.push({ headers: (init.headers ?? {}) as Record<string, string> });
+    if (n === 1) {
+      const status = opts.initStatus ?? 200;
+      const h = new Map(Object.entries(opts.initHeaders ?? {}));
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        headers: { get: (k: string) => h.get(k.toLowerCase()) ?? h.get(k) ?? null },
+        text: async () => "",
+      };
+    }
+    const status = opts.listStatus ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: { get: () => null },
+      text: async () => opts.listBody ?? "",
+    };
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+const BANK = "user-profile-lawgpt";
+const listBodyWithBank = `data: ${JSON.stringify({
+  result: { content: [{ text: BANK }] },
+})}`;
+
+describe("probeHindsight — stateless tolerance (the lawgpt false-negative)", () => {
+  it("reports reachable when a STATELESS server omits mcp-session-id", async () => {
+    // Pre-fix this returned { reachable:false, reason:"no session id" }.
+    const { fetchImpl } = makeFetch({
+      initHeaders: {}, // stateless: NO mcp-session-id
+      listBody: listBodyWithBank,
+    });
+    const r = await probeHindsight("http://h:18888/mcp", BANK, { fetchImpl });
+    expect(r.reachable).toBe(true);
+    expect(r.bankExists).toBe(true);
+  });
+
+  it("does NOT forward a session header when the server is stateless", async () => {
+    const { fetchImpl, calls } = makeFetch({
+      initHeaders: {},
+      listBody: listBodyWithBank,
+    });
+    await probeHindsight("http://h:18888/mcp", BANK, { fetchImpl });
+    expect("mcp-session-id" in calls[1]!.headers).toBe(false);
+  });
+
+  it("still forwards the session header when a STATEFUL server issues one", async () => {
+    const { fetchImpl, calls } = makeFetch({
+      initHeaders: { "mcp-session-id": "sess-abc" },
+      listBody: listBodyWithBank,
+    });
+    const r = await probeHindsight("http://h:18888/mcp", BANK, { fetchImpl });
+    expect(r.reachable).toBe(true);
+    expect(r.bankExists).toBe(true);
+    expect((calls[1]!.headers as Record<string, string>)["mcp-session-id"]).toBe(
+      "sess-abc",
+    );
+  });
+
+  it("stateless + bank absent → reachable but bankExists:false (NOT a false 'unreachable')", async () => {
+    const { fetchImpl } = makeFetch({
+      initHeaders: {},
+      listBody: `data: ${JSON.stringify({ result: { content: [{ text: "some-other-bank" }] } })}`,
+    });
+    const r = await probeHindsight("http://h:18888/mcp", BANK, { fetchImpl });
+    expect(r.reachable).toBe(true);
+    expect(r.bankExists).toBe(false);
+  });
+
+  it("genuine unreachable still reported (init non-2xx) — fix didn't mask real failures", async () => {
+    const { fetchImpl } = makeFetch({ initStatus: 503 });
+    const r = await probeHindsight("http://h:18888/mcp", BANK, { fetchImpl });
+    expect(r.reachable).toBe(false);
+    expect(r.reason).toContain("503");
+  });
+});


### PR DESCRIPTION
## Summary

`switchroom agent status <agent>` reported `hindsight: fail unreachable (no session id)` on every agent against a **healthy** daemon, driving `overall: fail`. Observed live on `lawgpt` (2026-05-19).

Hindsight runs **stateless by design** (`HINDSIGHT_API_MCP_STATELESS=true`): `initialize` returns 200 OK with **no** `mcp-session-id` header. `src/agents/status.ts`'s `probeHindsight` hard-failed on the missing header (`reachable:false, reason:"no session id"`) even though the 200 on init already proves reachability.

**#1515 fixed exactly this false assumption — but only in `src/memory/hindsight.ts`** (the copy `doctor` uses). `src/agents/status.ts` carries its **own** `probeHindsight` (used by `agent status`) and was missed. This applies the same fix there: forward `mcp-session-id` only when a stateful server issued one; otherwise proceed (a stateless `list_banks` is self-contained). Genuine unreachability — non-2xx init, timeout, ECONNREFUSED — is unchanged.

## JTBD

**Always-on** observability honesty: `agent status` / `doctor` must not red-flag a healthy fleet.

## Test plan

- [x] New direct regression test `tests/agent.status.probe-hindsight.test.ts` (stateless→reachable; header omitted when stateless; still forwarded when stateful; bank-absent still distinguished from unreachable; genuine non-2xx still fails)
- [x] Existing `tests/agent.status.test.ts` (38) + `src/agents/status-runtime.test.ts` (6) green — no regression
- [x] `npm run lint` clean
- [ ] CI green + fresh-process reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)