### PR TITLE
feat(gateway): durable inbound spool — "message is queued" survives restart

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -174,7 +174,12 @@ ALLOWLIST=(
   # lines drifted the chunk-loop raw sends to 3928/3949 (past 3860). End
   # 3860 -> 4000; check flags only 3928/3949 before the next allowlist
   # entry (8100), so no new un-allowlisted call enters the margin.
-  "telegram-plugin/gateway/gateway.ts:3160-4000:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
+  # Re-bumped 2026-05-19 for the durable-inbound-spool feature: the
+  # ~40-line spool construct + boot-replay block (~3057) drifted the
+  # chunk-loop raw sends to 4026/4047 (past 4000). End 4000 -> 4060;
+  # check flags only 4026/4047 before the next entry (8100), so no new
+  # un-allowlisted call enters the margin.
+  "telegram-plugin/gateway/gateway.ts:3160-4060:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -249,7 +254,13 @@ ALLOWLIST=(
   # 10814/10837/10861 (past 10760). End 10760 -> 10920; next raw
   # ctx.api call is still far outside (~12700+), so no new
   # un-allowlisted call enters.
-  "telegram-plugin/gateway/gateway.ts:9340-10920:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-19 for the durable-inbound-spool feature: the
+  # ~40-line spool construct + boot-replay block (~3057) drifted the
+  # vault-wizard editMessageText sites to 10935/10958/10982 (past
+  # 10920). End 10920 -> 11000; next raw call is well outside, so no
+  # new un-allowlisted call enters — same already-.catch-swallowed
+  # wizard sites.
+  "telegram-plugin/gateway/gateway.ts:9340-11000:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3070,6 +3070,7 @@ const inboundSpool = STATIC
         appendFileSync: (p, d) => appendFileSync(p, d),
         readFileSync: (p) => readFileSync(p, 'utf8'),
         writeFileSync: (p, d) => writeFileSync(p, d),
+        renameSync: (a, b) => renameSync(a, b),
         existsSync: (p) => existsSync(p),
         statSizeSync: (p) => statSync(p).size,
       },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -17,7 +17,7 @@ import { execFileSync, execSync, spawn } from 'child_process'
 import {
   readFileSync, writeFileSync, mkdirSync, readdirSync, rmSync,
   statSync, renameSync, realpathSync, chmodSync, openSync, closeSync,
-  existsSync, unlinkSync,
+  existsSync, unlinkSync, appendFileSync,
 } from 'fs'
 import { homedir } from 'os'
 import { join, extname, sep, basename } from 'path'
@@ -249,6 +249,7 @@ import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js
 import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
+import { createInboundSpool } from './inbound-spool.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
 import { createPendingPermissionBuffer } from './pending-permission-decisions.js'
 import {
@@ -1292,6 +1293,7 @@ function purgeReactionTracking(key: string): void {
         pendingInboundBuffer,
         selfAgentForFlush,
         (m) => ipcServer.sendToAgent(selfAgentForFlush, m),
+        inboundSpool,
       )
       if (fr.redelivered > 0) {
         process.stderr.write(
@@ -3035,6 +3037,7 @@ silencePoke.startTimer({
       pendingInboundBuffer,
       fbSelfAgent,
       (m) => ipcServer.sendToAgent(fbSelfAgent, m),
+      inboundSpool,
     )
     process.stderr.write(
       `telegram gateway: silence-poke framework-fallback ended wedged turn ` +
@@ -3053,7 +3056,41 @@ silencePoke.startTimer({
 // vault_request_access card during the 100ms bridge-reconnect window
 // would mint the grant but silently drop the `vault_grant_approved`
 // inbound, leaving the agent stuck waiting for a manual poke.
-const pendingInboundBuffer = createPendingInboundBuffer()
+// Durable inbound spool on the persistent per-agent volume
+// (STATE_DIR = /state/agent/telegram in prod — survives container
+// recreate). Makes the "⏳ your message is queued and will be
+// processed when it reconnects" promise deterministic across a
+// gateway/container restart (finn/carrie lost-on-restart incident,
+// 2026-05-19). STATIC mode has no runtime/bridge, so no spool.
+const inboundSpool = STATIC
+  ? undefined
+  : createInboundSpool({
+      path: join(STATE_DIR, 'inbound-spool.jsonl'),
+      fs: {
+        appendFileSync: (p, d) => appendFileSync(p, d),
+        readFileSync: (p) => readFileSync(p, 'utf8'),
+        writeFileSync: (p, d) => writeFileSync(p, d),
+        existsSync: (p) => existsSync(p),
+        statSizeSync: (p) => statSync(p).size,
+      },
+    })
+const pendingInboundBuffer = createPendingInboundBuffer({ spool: inboundSpool })
+// Boot-replay: re-queue every un-acked spooled inbound into the
+// in-memory buffer so the existing drain triggers (onClientRegistered
+// / silence-poke #1546 / idle-drain #1549) deliver them. push →
+// spool.put dedups on the already-live id, so this re-push does NOT
+// double-append. This is what makes a queued message survive a
+// restart instead of being silently lost.
+if (inboundSpool != null) {
+  const replay = inboundSpool.liveEntries()
+  for (const e of replay) pendingInboundBuffer.push(e.agent, e.msg)
+  if (replay.length > 0) {
+    process.stderr.write(
+      `telegram gateway: inbound-spool boot-replay re-queued ${replay.length} ` +
+      `un-acked inbound (durable-queue, survives restart)\n`,
+    )
+  }
+}
 const pendingPermissionBuffer = createPendingPermissionBuffer()
 
 /**
@@ -3104,6 +3141,12 @@ const ipcServer: IpcServer = createIpcServer({
       for (const msg of pending) {
         try {
           client.send(msg)
+          // Confirmed delivery to the just-registered live bridge →
+          // tombstone the durable spool entry so it isn't boot-replayed
+          // again. A throw below leaves it spooled (un-acked) so the
+          // idle-drain / escalation path still recovers it — strictly
+          // safer than the old log-and-drop.
+          inboundSpool?.ack(msg)
         } catch (err) {
           process.stderr.write(
             `telegram gateway: pending-inbound drain failed agent=${client.agentName} ` +
@@ -3592,6 +3635,7 @@ if (!STATIC) {
         return c != null && c.isAlive()
       },
       (m) => ipcServer.sendToAgent(selfAgent, m),
+      inboundSpool,
     )
     if (r != null && r.redelivered > 0) {
       process.stderr.write(
@@ -3600,6 +3644,28 @@ if (!STATIC) {
         `${r.rebuffered > 0 ? ` (${r.rebuffered} re-buffered)` : ''}\n`,
       )
     }
+    // Bounded escalation: a spooled inbound still un-acked past its
+    // bound (default 15 min — well past the 5-min silence-poke ladder)
+    // is undeliverable in practice. Retract the "will be processed"
+    // promise EXPLICITLY (honest failure) instead of letting it sit
+    // forever. This is what makes the guarantee deterministic: every
+    // queued message ends either delivered or visibly retracted.
+    inboundSpool?.sweepEscalations((e) => {
+      const chat = e.msg.chatId
+      const threadOpts =
+        typeof e.msg.meta?.threadId === 'string' && e.msg.meta.threadId
+          ? { message_thread_id: Number(e.msg.meta.threadId) }
+          : {}
+      void swallowingApiCall(
+        () =>
+          bot.api.sendMessage(
+            chat,
+            "⚠️ I couldn't deliver an earlier message to the agent after repeated retries (it survived restarts but the agent never picked it up). Please resend it.",
+            { ...threadOpts },
+          ),
+        { chat_id: chat, verb: 'inbound-spool-escalation' },
+      )
+    })
   }, IDLE_DRAIN_INTERVAL_MS).unref()
 }
 

--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -1,0 +1,262 @@
+/**
+ * inbound-spool.ts — durable, crash-tolerant spool for buffered inbound.
+ *
+ * Why this exists: `pending-inbound-buffer.ts` is in-memory only. A
+ * gateway/container restart (switchroom update, agent restart, a
+ * self-restart, an OOM) destroys it — so the user-facing promise
+ * "⏳ your message is queued and will be processed when it reconnects"
+ * (gateway.ts) is a lie across a restart. Proven twice: finn and
+ * carrie (2026-05-19) lost the user's message on restart and the user
+ * had to resend. #1546/#1549 only shrank the in-memory delivery
+ * window; they cannot survive process death.
+ *
+ * This module makes the promise DETERMINISTIC: every buffered inbound
+ * is also appended to a JSONL spool on the persistent per-agent volume
+ * (`/state/agent/telegram/…`, survives container recreate). On boot the
+ * gateway replays un-acked entries back into the in-memory buffer, so
+ * the existing drain machinery delivers them. An entry is acked (and
+ * tombstoned) ONLY on confirmed delivery to a live registered bridge.
+ * Un-acked entries older than `escalateAfterMs` are surfaced to the
+ * user via an explicit "couldn't deliver — resend?" callback and then
+ * dropped: the promise is then ALWAYS resolved — kept, or visibly
+ * retracted — never silently lost.
+ *
+ * Scope (v1): the ack is "delivered to a live registered bridge", not
+ * "claude consumed it". A true claude→gateway consumption-ack needs a
+ * new bidirectional bridge protocol (high blast radius) and is a
+ * documented follow-up. v1 already eliminates the silent-loss-on-
+ * restart class — the actual incident class.
+ *
+ * Crash-consistency: append-only JSONL, one self-contained JSON object
+ * per line, written with a trailing newline in a single `appendFileSync`
+ * (atomic for small writes on local fs). A torn final line on a crash
+ * mid-write is tolerated: replay skips any line that does not
+ * round-trip `JSON.parse` + shape-check. Acks are themselves appended
+ * as tombstone lines (`{t:"ack",id}`) rather than rewriting the file;
+ * a bounded `compact()` rewrites the file dropping acked/escalated ids
+ * when it grows past `compactAtBytes`.
+ *
+ * This module is PURE w.r.t. its injected fs + clock seams so the
+ * crash/dedup/replay/escalation logic is unit-tested without a real
+ * gateway (mirrors the #1544/#1546/#1549 pure-seam idiom).
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+
+/** Stable dedup id for an inbound. Real Telegram messages have a
+ *  unique (chatId, messageId). Synthetic/cron inbounds use messageId
+ *  0 — fall back to a deterministic id from source+ts so retried
+ *  synthetics of the SAME logical event dedup, but distinct events
+ *  (different ts) do not collapse. */
+export function spoolId(msg: InboundMessage): string {
+  if (typeof msg.messageId === 'number' && msg.messageId > 0) {
+    return `m:${msg.chatId}:${msg.messageId}`
+  }
+  const src = msg.meta?.source ?? '-'
+  return `s:${msg.chatId}:${src}:${msg.ts}`
+}
+
+interface SpoolRecord {
+  t: 'put' | 'ack'
+  id: string
+  /** Present only on `put`. The full inbound to replay. */
+  msg?: InboundMessage
+  /** Present only on `put`. Owning agent (replay re-pushes per agent). */
+  agent?: string
+  /** Present only on `put`. ms epoch first-spooled — drives escalation. */
+  firstAt?: number
+}
+
+export interface InboundSpoolFsSeam {
+  appendFileSync: (path: string, data: string) => void
+  readFileSync: (path: string) => string
+  writeFileSync: (path: string, data: string) => void
+  existsSync: (path: string) => boolean
+  statSizeSync: (path: string) => number
+}
+
+export interface InboundSpoolOptions {
+  path: string
+  fs: InboundSpoolFsSeam
+  now?: () => number
+  log?: (line: string) => void
+  /** Un-acked entries older than this are escalated then dropped.
+   *  Default 15 min — comfortably past the 5-min silence-poke ladder
+   *  so self-heal gets every chance before we retract the promise. */
+  escalateAfterMs?: number
+  /** Rewrite-compact the JSONL once it exceeds this. Default 256 KiB. */
+  compactAtBytes?: number
+}
+
+export interface ReplayEntry {
+  agent: string
+  msg: InboundMessage
+}
+
+export interface InboundSpool {
+  /** Durably record `msg` for `agent`. Idempotent by spoolId: a
+   *  re-spool of an already-live id is a no-op (returns false). */
+  put: (agent: string, msg: InboundMessage) => boolean
+  /** Tombstone `id` — call ONLY on confirmed delivery to a live
+   *  registered bridge. Idempotent. */
+  ack: (msg: InboundMessage) => void
+  /** Live (un-acked) entries, oldest first. Used at boot to re-push
+   *  into the in-memory buffer. Pure read — does not mutate. */
+  liveEntries: () => ReplayEntry[]
+  /** Escalate+drop entries older than `escalateAfterMs`. Calls
+   *  `onEscalate` once per dropped entry (post the "couldn't deliver"
+   *  card there). Returns the count escalated. Safe to call on a timer. */
+  sweepEscalations: (onEscalate: (e: ReplayEntry) => void) => number
+  /** Test/observability: count of live (un-acked) ids. */
+  liveCount: () => number
+}
+
+export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
+  const { path, fs } = opts
+  const now = opts.now ?? Date.now
+  const log = opts.log ?? ((l: string) => process.stderr.write(l))
+  const escalateAfterMs = opts.escalateAfterMs ?? 15 * 60 * 1000
+  const compactAtBytes = opts.compactAtBytes ?? 256 * 1024
+
+  // In-memory projection of the on-disk log, rebuilt from the file at
+  // construction. `live` maps spoolId → the put record (insertion order
+  // preserved via the Map). An `ack` deletes from `live`.
+  const live = new Map<string, { agent: string; msg: InboundMessage; firstAt: number }>()
+
+  function parseLine(line: string): SpoolRecord | null {
+    const s = line.trim()
+    if (!s) return null
+    let rec: unknown
+    try {
+      rec = JSON.parse(s)
+    } catch {
+      return null // torn / partial line from a crash mid-append — skip
+    }
+    if (rec == null || typeof rec !== 'object') return null
+    const r = rec as Record<string, unknown>
+    if (r.t !== 'put' && r.t !== 'ack') return null
+    if (typeof r.id !== 'string' || r.id.length === 0) return null
+    if (r.t === 'put') {
+      if (r.msg == null || typeof r.msg !== 'object') return null
+      if (typeof r.agent !== 'string' || r.agent.length === 0) return null
+      if (typeof r.firstAt !== 'number') return null
+    }
+    return r as unknown as SpoolRecord
+  }
+
+  // Rebuild `live` from the file. Tolerates a torn last line.
+  function hydrate(): void {
+    live.clear()
+    if (!fs.existsSync(path)) return
+    let raw = ''
+    try {
+      raw = fs.readFileSync(path)
+    } catch {
+      return
+    }
+    for (const line of raw.split('\n')) {
+      const rec = parseLine(line)
+      if (rec == null) continue
+      if (rec.t === 'put') {
+        // Last put for an id wins; an ack later removes it.
+        live.set(rec.id, {
+          agent: rec.agent as string,
+          msg: rec.msg as InboundMessage,
+          firstAt: rec.firstAt as number,
+        })
+      } else {
+        live.delete(rec.id)
+      }
+    }
+  }
+
+  function appendRecord(rec: SpoolRecord): void {
+    try {
+      fs.appendFileSync(path, JSON.stringify(rec) + '\n')
+    } catch (err) {
+      // Durability is best-effort relative to fs availability; a spool
+      // write failure must NOT break live delivery. Log loudly — a
+      // persistently failing spool means we're back to in-memory-only
+      // semantics and the operator should know.
+      log(
+        `inbound-spool: append FAILED path=${path} id=${rec.id} t=${rec.t}: ` +
+        `${(err as Error).message} — durability degraded to in-memory\n`,
+      )
+    }
+  }
+
+  function maybeCompact(): void {
+    let size = 0
+    try {
+      size = fs.existsSync(path) ? fs.statSizeSync(path) : 0
+    } catch {
+      return
+    }
+    if (size <= compactAtBytes) return
+    // Rewrite the file as exactly the current live set (one put per
+    // live id, no acks). Crash-safe enough for a spool: a crash mid-
+    // rewrite loses at worst the compaction (the pre-compaction file
+    // is replaced in a single writeFileSync); replay still works off
+    // whatever landed because every surviving line is self-contained.
+    const lines: string[] = []
+    for (const [id, e] of live) {
+      lines.push(
+        JSON.stringify({ t: 'put', id, agent: e.agent, msg: e.msg, firstAt: e.firstAt } satisfies SpoolRecord),
+      )
+    }
+    try {
+      fs.writeFileSync(path, lines.length ? lines.join('\n') + '\n' : '')
+      log(`inbound-spool: compacted path=${path} live=${live.size}\n`)
+    } catch (err) {
+      log(`inbound-spool: compact FAILED path=${path}: ${(err as Error).message}\n`)
+    }
+  }
+
+  hydrate()
+
+  return {
+    put(agent, msg) {
+      const id = spoolId(msg)
+      if (live.has(id)) return false // dedup: already spooled & un-acked
+      const firstAt = now()
+      live.set(id, { agent, msg, firstAt })
+      appendRecord({ t: 'put', id, agent, msg, firstAt })
+      maybeCompact()
+      return true
+    },
+    ack(msg) {
+      const id = spoolId(msg)
+      if (!live.has(id)) return // idempotent / unknown id
+      live.delete(id)
+      appendRecord({ t: 'ack', id })
+      maybeCompact()
+    },
+    liveEntries() {
+      // Insertion order = Map iteration order = oldest first.
+      return [...live.values()].map((e) => ({ agent: e.agent, msg: e.msg }))
+    },
+    sweepEscalations(onEscalate) {
+      const cutoff = now() - escalateAfterMs
+      let n = 0
+      for (const [id, e] of [...live.entries()]) {
+        if (e.firstAt > cutoff) continue
+        live.delete(id)
+        appendRecord({ t: 'ack', id }) // tombstone — promise retracted
+        try {
+          onEscalate({ agent: e.agent, msg: e.msg })
+        } catch (err) {
+          log(`inbound-spool: onEscalate threw id=${id}: ${(err as Error).message}\n`)
+        }
+        n++
+      }
+      if (n > 0) {
+        log(`inbound-spool: escalated+dropped ${n} undelivered entr${n === 1 ? 'y' : 'ies'} (older than ${escalateAfterMs}ms)\n`)
+        maybeCompact()
+      }
+      return n
+    },
+    liveCount() {
+      return live.size
+    },
+  }
+}

--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -71,6 +71,9 @@ export interface InboundSpoolFsSeam {
   appendFileSync: (path: string, data: string) => void
   readFileSync: (path: string) => string
   writeFileSync: (path: string, data: string) => void
+  /** Atomic same-dir replace (POSIX rename). Used so compaction can't
+   *  lose entries to a crash mid-rewrite. */
+  renameSync: (from: string, to: string) => void
   existsSync: (path: string) => boolean
   statSizeSync: (path: string) => number
 }
@@ -194,20 +197,27 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
     }
     if (size <= compactAtBytes) return
     // Rewrite the file as exactly the current live set (one put per
-    // live id, no acks). Crash-safe enough for a spool: a crash mid-
-    // rewrite loses at worst the compaction (the pre-compaction file
-    // is replaced in a single writeFileSync); replay still works off
-    // whatever landed because every surviving line is self-contained.
+    // live id, no acks). ATOMIC: write a sibling tmp then rename over
+    // the real path. rename(2) is atomic within a filesystem, so a
+    // crash at any point leaves EITHER the full pre-compaction log OR
+    // the full compacted log on disk — never a truncated/torn file
+    // that loses live entries after the tear. (Plain writeFileSync is
+    // not atomic; a crash mid-write of a >256 KiB rewrite could drop
+    // entries past the tear — the residual the reviewer flagged.)
     const lines: string[] = []
     for (const [id, e] of live) {
       lines.push(
         JSON.stringify({ t: 'put', id, agent: e.agent, msg: e.msg, firstAt: e.firstAt } satisfies SpoolRecord),
       )
     }
+    const tmp = path + '.compact.tmp'
     try {
-      fs.writeFileSync(path, lines.length ? lines.join('\n') + '\n' : '')
+      fs.writeFileSync(tmp, lines.length ? lines.join('\n') + '\n' : '')
+      fs.renameSync(tmp, path)
       log(`inbound-spool: compacted path=${path} live=${live.size}\n`)
     } catch (err) {
+      // Compaction is opportunistic — a failure keeps the (larger but
+      // correct) append-only log; never lose data trying to shrink it.
       log(`inbound-spool: compact FAILED path=${path}: ${(err as Error).message}\n`)
     }
   }

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -30,6 +30,7 @@
  */
 
 import type { InboundMessage } from './ipc-protocol.js'
+import type { InboundSpool } from './inbound-spool.js'
 
 /** Default cap per agent. Tuned for `should fit a reasonable backlog of
  *  approval cards stacked while bridge is offline` but no more. */
@@ -52,6 +53,19 @@ export interface PendingInboundBuffer {
 export interface PendingInboundBufferOptions {
   capPerAgent?: number
   log?: (line: string) => void
+  /**
+   * Durable spool. When set, every `push` is also recorded on the
+   * persistent per-agent volume so a gateway/container restart cannot
+   * silently lose the message (the finn/carrie incident class). The
+   * in-memory queue stays the hot path + cap; the spool is the
+   * crash-survivable record, acked only on confirmed delivery (by
+   * `redeliverBufferedInbound`/`idleDrainTick`), boot-replayed by the
+   * gateway, and escalated-then-dropped if undeliverable past its
+   * bound. The in-memory cap eviction does NOT touch the spool — an
+   * evicted-from-memory entry survives in the spool (strictly safer
+   * than the old silent in-memory drop).
+   */
+  spool?: InboundSpool
 }
 
 /**
@@ -72,6 +86,7 @@ export function redeliverBufferedInbound(
   buffer: PendingInboundBuffer,
   agent: string,
   send: (msg: InboundMessage) => boolean,
+  spool?: InboundSpool,
 ): { drained: number; redelivered: number; rebuffered: number } {
   const pending = buffer.drain(agent)
   let redelivered = 0
@@ -85,6 +100,11 @@ export function redeliverBufferedInbound(
     }
     if (delivered) {
       redelivered++
+      // Confirmed delivery to a live registered bridge → the durable
+      // promise is kept; tombstone the spool entry so it is NOT
+      // boot-replayed again. A miss leaves it spooled (re-pushed below
+      // AND still live in the spool) for the next drain / escalation.
+      spool?.ack(msg)
     } else {
       buffer.push(agent, msg)
       rebuffered++
@@ -129,11 +149,12 @@ export function idleDrainTick(
   agent: string,
   isBridgeAlive: () => boolean,
   send: (msg: InboundMessage) => boolean,
+  spool?: InboundSpool,
 ): { drained: number; redelivered: number; rebuffered: number } | null {
   if (!agent) return null
   if (buffer.depth(agent) === 0) return null
   if (!isBridgeAlive()) return null
-  return redeliverBufferedInbound(buffer, agent, send)
+  return redeliverBufferedInbound(buffer, agent, send, spool)
 }
 
 export function createPendingInboundBuffer(
@@ -141,6 +162,7 @@ export function createPendingInboundBuffer(
 ): PendingInboundBuffer {
   const cap = opts.capPerAgent ?? DEFAULT_PENDING_INBOUND_CAP
   const log = opts.log ?? ((line: string) => process.stderr.write(line))
+  const spool = opts.spool
   const queues = new Map<string, InboundMessage[]>()
 
   return {
@@ -160,6 +182,12 @@ export function createPendingInboundBuffer(
         )
       }
       q.push(msg)
+      // Durable record FIRST-class to the in-memory queue: spool BEFORE
+      // returning, regardless of the cap eviction above — an entry the
+      // in-memory cap drops still survives in the spool (boot-replayed /
+      // escalated), which is the whole point. spool.put dedups by
+      // spoolId so a boot-replay re-push is a no-op here.
+      spool?.put(agent, msg)
       log(
         `pending-inbound-buffer: agent=${agent} buffered source=${msg.meta?.source ?? '-'} ` +
         `depth_after=${q.length} evicted=${evicted}\n`,

--- a/telegram-plugin/tests/inbound-spool.test.ts
+++ b/telegram-plugin/tests/inbound-spool.test.ts
@@ -32,23 +32,21 @@ function msg(over: Partial<InboundMessage> = {}): InboundMessage {
   } as InboundMessage
 }
 
-/** In-memory fake fs. Models append-only + full rewrite. */
-function fakeFs(): InboundSpoolFsSeam & { dump(): string } {
-  let store = ''
-  let exists = false
+/** In-memory fake fs keyed by path. Models append, full rewrite, and
+ *  atomic rename (so the tmp→rename compaction path is exercised). */
+function fakeFs(): InboundSpoolFsSeam & { dump(p?: string): string } {
+  const files = new Map<string, string>()
   return {
-    appendFileSync: (_p, d) => {
-      store += d
-      exists = true
+    appendFileSync: (p, d) => files.set(p, (files.get(p) ?? '') + d),
+    readFileSync: (p) => files.get(p) ?? '',
+    writeFileSync: (p, d) => files.set(p, d),
+    renameSync: (from, to) => {
+      files.set(to, files.get(from) ?? '')
+      files.delete(from)
     },
-    readFileSync: () => store,
-    writeFileSync: (_p, d) => {
-      store = d
-      exists = true
-    },
-    existsSync: () => exists,
-    statSizeSync: () => Buffer.byteLength(store),
-    dump: () => store,
+    existsSync: (p) => files.has(p),
+    statSizeSync: (p) => Buffer.byteLength(files.get(p) ?? ''),
+    dump: (p = PATH) => files.get(p) ?? '',
   }
 }
 
@@ -207,5 +205,25 @@ describe('inbound-spool — robustness', () => {
     expect(s2.liveCount()).toBe(1)
     expect(s2.liveEntries()[0].msg.messageId).toBe(999)
     expect(fs.dump().split('\n').filter(Boolean).length).toBeLessThan(5)
+  })
+
+  it('atomic compaction: a rename crash leaves the ORIGINAL log intact (no loss)', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs, compactAtBytes: 200 })
+    for (let i = 1; i <= 10; i++) {
+      s.put('a', msg({ messageId: i, text: 'y'.repeat(50) }))
+    }
+    // Simulate a crash AFTER the tmp write but BEFORE/at the rename.
+    fs.renameSync = () => {
+      throw new Error('crash mid-compact')
+    }
+    s.put('a', msg({ messageId: 11, text: 'y'.repeat(50) })) // triggers maybeCompact → rename throws
+    // Original append-only log must still hold every live entry — the
+    // failed compaction is a no-op, never a truncation.
+    const s2 = createInboundSpool({ path: PATH, fs })
+    expect(s2.liveCount()).toBe(11)
+    expect(s2.liveEntries().map((e) => e.msg.messageId)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+    ])
   })
 })

--- a/telegram-plugin/tests/inbound-spool.test.ts
+++ b/telegram-plugin/tests/inbound-spool.test.ts
@@ -1,0 +1,211 @@
+/**
+ * inbound-spool — durable, crash-tolerant inbound spool.
+ *
+ * Pins the determinism guarantee: a buffered inbound survives a
+ * gateway/container restart (it's on the persistent volume), is
+ * replayed un-acked, acked only on confirmed delivery, deduped by a
+ * stable id, and escalated-then-dropped if undeliverable past its
+ * bound — so the "your message is queued" promise is ALWAYS resolved
+ * (delivered or visibly retracted), never silently lost (the
+ * finn/carrie lost-on-restart incident class, 2026-05-19).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createInboundSpool,
+  spoolId,
+  type InboundSpoolFsSeam,
+} from '../gateway/inbound-spool.js'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
+
+function msg(over: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    type: 'inbound',
+    chatId: 'c1',
+    messageId: 1001,
+    user: 'ken',
+    userId: 42,
+    ts: 1000,
+    text: 'hello',
+    meta: {},
+    ...over,
+  } as InboundMessage
+}
+
+/** In-memory fake fs. Models append-only + full rewrite. */
+function fakeFs(): InboundSpoolFsSeam & { dump(): string } {
+  let store = ''
+  let exists = false
+  return {
+    appendFileSync: (_p, d) => {
+      store += d
+      exists = true
+    },
+    readFileSync: () => store,
+    writeFileSync: (_p, d) => {
+      store = d
+      exists = true
+    },
+    existsSync: () => exists,
+    statSizeSync: () => Buffer.byteLength(store),
+    dump: () => store,
+  }
+}
+
+const PATH = '/state/agent/telegram/inbound-spool.jsonl'
+
+describe('spoolId — stable dedup key', () => {
+  it('real Telegram message → m:chat:msgId', () => {
+    expect(spoolId(msg({ chatId: 'c9', messageId: 55 }))).toBe('m:c9:55')
+  })
+  it('synthetic (messageId 0) → s:chat:source:ts (distinct events do not collapse)', () => {
+    const a = spoolId(msg({ messageId: 0, meta: { source: 'cron' }, ts: 100 }))
+    const b = spoolId(msg({ messageId: 0, meta: { source: 'cron' }, ts: 200 }))
+    expect(a).toBe('s:c1:cron:100')
+    expect(a).not.toBe(b) // different ts = different logical event
+  })
+  it('same logical synthetic retried (same ts) dedups to the same id', () => {
+    const a = spoolId(msg({ messageId: 0, meta: { source: 'cron' }, ts: 100 }))
+    const b = spoolId(msg({ messageId: 0, meta: { source: 'cron' }, ts: 100 }))
+    expect(a).toBe(b)
+  })
+})
+
+describe('inbound-spool — put / ack / dedup', () => {
+  it('put records a live entry; dedups a re-put of the same id', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs })
+    expect(s.put('carrie', msg({ messageId: 7 }))).toBe(true)
+    expect(s.put('carrie', msg({ messageId: 7 }))).toBe(false) // dedup
+    expect(s.liveCount()).toBe(1)
+    expect(s.liveEntries()).toHaveLength(1)
+    expect(s.liveEntries()[0].agent).toBe('carrie')
+  })
+
+  it('ack tombstones the entry; ack is idempotent / unknown-id safe', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs })
+    const m = msg({ messageId: 7 })
+    s.put('carrie', m)
+    s.ack(m)
+    expect(s.liveCount()).toBe(0)
+    s.ack(m) // idempotent
+    s.ack(msg({ messageId: 999 })) // unknown id, no throw
+    expect(s.liveCount()).toBe(0)
+  })
+
+  it('liveEntries is oldest-first (replay order)', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs })
+    s.put('a', msg({ messageId: 1 }))
+    s.put('a', msg({ messageId: 2 }))
+    s.put('a', msg({ messageId: 3 }))
+    expect(s.liveEntries().map((e) => e.msg.messageId)).toEqual([1, 2, 3])
+  })
+})
+
+describe('inbound-spool — crash-survivable replay (the core guarantee)', () => {
+  it('a fresh spool over an existing file rebuilds live state (survives restart)', () => {
+    const fs = fakeFs()
+    const s1 = createInboundSpool({ path: PATH, fs })
+    s1.put('carrie', msg({ messageId: 7, text: 'the craft message' }))
+    s1.put('carrie', msg({ messageId: 8 }))
+    s1.ack(msg({ messageId: 8 })) // 8 delivered before the "crash"
+    // Simulate gateway/container restart: brand-new spool, SAME file.
+    const s2 = createInboundSpool({ path: PATH, fs })
+    expect(s2.liveCount()).toBe(1)
+    const live = s2.liveEntries()
+    expect(live[0].msg.messageId).toBe(7)
+    expect(live[0].msg.text).toBe('the craft message') // full payload survived
+    expect(live[0].agent).toBe('carrie')
+  })
+
+  it('tolerates a torn final line (crash mid-append) — skips it, keeps the rest', () => {
+    const fs = fakeFs()
+    const s1 = createInboundSpool({ path: PATH, fs })
+    s1.put('carrie', msg({ messageId: 7 }))
+    // Append a half-written record (no newline, invalid JSON tail).
+    fs.appendFileSync(PATH, '{"t":"put","id":"m:c1:8","agen')
+    const s2 = createInboundSpool({ path: PATH, fs })
+    expect(s2.liveCount()).toBe(1) // the torn line is ignored, 7 survives
+    expect(s2.liveEntries()[0].msg.messageId).toBe(7)
+  })
+
+  it('ignores any line that does not pass the shape check', () => {
+    const fs = fakeFs()
+    fs.appendFileSync(PATH, 'not json\n')
+    fs.appendFileSync(PATH, '{"t":"put"}\n') // missing id/msg/agent
+    fs.appendFileSync(PATH, '{"t":"weird","id":"x"}\n')
+    fs.appendFileSync(
+      PATH,
+      JSON.stringify({ t: 'put', id: 'm:c1:7', agent: 'a', firstAt: 1, msg: msg({ messageId: 7 }) }) + '\n',
+    )
+    const s = createInboundSpool({ path: PATH, fs })
+    expect(s.liveCount()).toBe(1)
+    expect(s.liveEntries()[0].msg.messageId).toBe(7)
+  })
+})
+
+describe('inbound-spool — bounded escalation (promise always resolved)', () => {
+  it('escalates+drops only entries older than the bound; younger untouched', () => {
+    const fs = fakeFs()
+    let t = 1_000_000
+    const s = createInboundSpool({
+      path: PATH,
+      fs,
+      now: () => t,
+      escalateAfterMs: 10_000,
+    })
+    s.put('carrie', msg({ messageId: 1 })) // firstAt = 1_000_000
+    t = 1_005_000
+    s.put('carrie', msg({ messageId: 2 })) // firstAt = 1_005_000
+    t = 1_012_000 // msg1 is 12s old (>10s bound), msg2 is 7s old
+    const escalated: number[] = []
+    const n = s.sweepEscalations((e) => escalated.push(e.msg.messageId as number))
+    expect(n).toBe(1)
+    expect(escalated).toEqual([1])
+    expect(s.liveCount()).toBe(1) // msg2 still live
+    expect(s.liveEntries()[0].msg.messageId).toBe(2)
+  })
+
+  it('an escalated id stays dropped across a restart (tombstoned, not replayed)', () => {
+    const fs = fakeFs()
+    let t = 0
+    const s1 = createInboundSpool({ path: PATH, fs, now: () => t, escalateAfterMs: 100 })
+    s1.put('a', msg({ messageId: 1 }))
+    t = 1000
+    expect(s1.sweepEscalations(() => {})).toBe(1)
+    const s2 = createInboundSpool({ path: PATH, fs })
+    expect(s2.liveCount()).toBe(0) // not resurrected on replay
+  })
+})
+
+describe('inbound-spool — robustness', () => {
+  it('a failing appendFileSync does not throw and keeps in-memory live state', () => {
+    const fs = fakeFs()
+    fs.appendFileSync = () => {
+      throw new Error('ENOSPC')
+    }
+    const logs: string[] = []
+    const s = createInboundSpool({ path: PATH, fs, log: (l) => logs.push(l) })
+    expect(() => s.put('a', msg({ messageId: 1 }))).not.toThrow()
+    expect(s.liveCount()).toBe(1) // live delivery still works (degraded durability)
+    expect(logs.join('')).toContain('durability degraded')
+  })
+
+  it('compacts once past the size bound, dropping acked ids', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs, compactAtBytes: 200 })
+    for (let i = 1; i <= 20; i++) {
+      s.put('a', msg({ messageId: i, text: 'x'.repeat(50) }))
+      s.ack(msg({ messageId: i }))
+    }
+    s.put('a', msg({ messageId: 999 }))
+    // After compaction the file holds only the one live id, not the
+    // 20 acked put+ack pairs.
+    const s2 = createInboundSpool({ path: PATH, fs })
+    expect(s2.liveCount()).toBe(1)
+    expect(s2.liveEntries()[0].msg.messageId).toBe(999)
+    expect(fs.dump().split('\n').filter(Boolean).length).toBeLessThan(5)
+  })
+})

--- a/telegram-plugin/tests/pending-inbound-buffer.test.ts
+++ b/telegram-plugin/tests/pending-inbound-buffer.test.ts
@@ -247,3 +247,69 @@ describe('idleDrainTick — the 3rd drain trigger (finn orphan gap, 2026-05-19)'
     expect(probed).toBe(false) // cheap path: Map.get only, no bridge probe, no log
   })
 })
+
+describe('durable-spool integration (finn/carrie lost-on-restart fix)', () => {
+  function spySpool() {
+    const puts: string[] = []
+    const acks: string[] = []
+    return {
+      puts,
+      acks,
+      spool: {
+        put: (_a: string, m: InboundMessage) => {
+          puts.push(String(m.messageId))
+          return true
+        },
+        ack: (m: InboundMessage) => {
+          acks.push(String(m.messageId))
+        },
+        liveEntries: () => [],
+        sweepEscalations: () => 0,
+        liveCount: () => 0,
+      },
+    }
+  }
+
+  it('every push is durably spooled (chokepoint for all ~10 push sites)', () => {
+    const sp = spySpool()
+    const buf = createPendingInboundBuffer({ log: () => {}, spool: sp.spool as never })
+    buf.push('carrie', inbound('user', 7))
+    buf.push('carrie', inbound('user', 8))
+    expect(sp.puts).toEqual(['7', '8'])
+  })
+
+  it('a CONFIRMED delivery acks the spool; a miss does NOT (stays durable)', () => {
+    const sp = spySpool()
+    const buf = createPendingInboundBuffer({ log: () => {}, spool: sp.spool as never })
+    buf.push('carrie', inbound('user', 7))
+    // delivery succeeds → spool acked
+    redeliverBufferedInbound(buf, 'carrie', () => true, sp.spool as never)
+    expect(sp.acks).toEqual(['7'])
+
+    // delivery misses → NOT acked, re-buffered + still spooled
+    const sp2 = spySpool()
+    const buf2 = createPendingInboundBuffer({ log: () => {}, spool: sp2.spool as never })
+    buf2.push('carrie', inbound('user', 9))
+    redeliverBufferedInbound(buf2, 'carrie', () => false, sp2.spool as never)
+    expect(sp2.acks).toEqual([]) // never acked on a miss → survives for retry/escalation
+    expect(buf2.depth('carrie')).toBe(1) // re-buffered in memory too
+  })
+
+  it('idleDrainTick threads the spool through (ack only on delivered)', () => {
+    const sp = spySpool()
+    const buf = createPendingInboundBuffer({ log: () => {}, spool: sp.spool as never })
+    buf.push('carrie', inbound('user', 7))
+    idleDrainTick(buf, 'carrie', () => true, () => true, sp.spool as never)
+    expect(sp.acks).toEqual(['7'])
+  })
+
+  it('works with no spool (back-compat: undefined spool is a no-op)', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('carrie', inbound('user', 7))
+    expect(redeliverBufferedInbound(buf, 'carrie', () => true)).toEqual({
+      drained: 1,
+      redelivered: 1,
+      rebuffered: 0,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Makes the **"⏳ your message is queued and will be processed when it reconnects"** promise *deterministic*. Today it's backed by an **in-memory** buffer (`pending-inbound-buffer`); a gateway/container restart (`switchroom update`, `agent restart`, self-restart, OOM) destroys it and the message is **silently lost**. Proven twice on 2026-05-19 — finn and carrie both lost the user's message on restart and the user had to resend. #1546/#1549 only shrank the in-memory window; they cannot survive process death.

## Design

New crash-tolerant append-only JSONL spool (`inbound-spool.ts`) on the **persistent per-agent volume** (`STATE_DIR=/state/agent/telegram`, survives container recreate), composed **into** `createPendingInboundBuffer` so all ~10 `push` call sites get durability at **one chokepoint**:

- **push → spool.put** — dedup by a stable `spoolId` (`m:chat:msgId` real, `s:chat:src:ts` synthetic). In-memory cap eviction no longer means loss — the entry survives spooled.
- **boot → replay** — `liveEntries()` re-queued into the in-memory buffer so the *existing* drain triggers (`onClientRegistered` / #1546 / #1549) deliver them. This is what survives a restart.
- **delivered → spool.ack** — tombstoned **only** on confirmed delivery to a live registered bridge (threaded through `redeliverBufferedInbound` / `idleDrainTick` / `onClientRegistered`). A miss stays spooled for retry.
- **escalation** — `sweepEscalations` on the idle-drain timer: an entry un-acked past the bound (15 min, well past the 5-min silence-poke ladder) posts an explicit *"couldn't deliver — resend"* card and is dropped.

**Net: every queued message ends either delivered or visibly retracted — never silently lost across a restart.**

**Scope (v1):** the ack is *"delivered to a live registered bridge"*, not *"claude consumed it"*. A true claude→gateway consumption-ack needs a new bidirectional bridge protocol (high blast radius) and is a **documented follow-up** — v1 already eliminates the silent-loss-on-restart class, the actual incident.

`inbound-spool.ts` is pure w.r.t. injected fs/clock seams (mirrors the #1544/#1546/#1549 idiom). `onClientRegistered`'s drain + #1546/#1549 are otherwise unchanged (additive). The undefined-spool path is preserved (back-compat / `STATIC`).

JTBD: *always-on* — a message the system told the user it accepted must not vanish because a container recycled.

## Test plan

- [x] `vitest inbound-spool.test.ts` (13) — dedup, **crash-tolerant replay** (torn last line / bad-shape lines skipped), **ack-survives-restart**, oldest-first replay order, **bounded escalation** + tombstone-survives-restart, append-failure → degrade-not-throw, compaction drops acked ids
- [x] `vitest pending-inbound-buffer.test.ts` (26, +5 new) — spool-on-push chokepoint, **ack only on confirmed delivery (miss stays durable)**, idleDrainTick threads spool, undefined-spool back-compat
- [x] `vitest silence-poke.test.ts` (52) green — #1546 path unaffected
- [x] `tsc --noEmit` clean; `check-bot-api-wrapping` clean (2 ranges widened per protocol — no new un-allowlisted call); `check-bun-test-imports` clean
- [ ] Post-merge: staggered rollout; **verify a queued message survives a deliberate agent restart** (the determinism proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)