### PR TITLE
chore: release v0.12.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## v0.12.19 — feat: "your message is queued" now survives a restart (durable inbound spool)
+
+Headline: the gateway's "⏳ your message is queued and will be
+processed when it reconnects" promise was backed by an in-memory
+buffer — a gateway/container restart silently lost the message (the
+user had to resend; hit twice, finn + carrie). This release makes the
+promise deterministic with a crash-tolerant on-disk spool on the
+persistent per-agent volume: every queued inbound is durably
+recorded, boot-replayed if undelivered, acked only on confirmed
+delivery, and — if still undeliverable past a bound — the promise is
+explicitly retracted with a "couldn't deliver, resend" card rather
+than vanishing. Also closes the mid-turn composer wedge and a
+stateless-hindsight false-fail in the status probe.
+
+### Changes
+
+#### Features
+
+- **feat(gateway):** durable inbound spool. The "message is queued"
+  promise is now crash-survivable: a JSONL spool on
+  `STATE_DIR=/state/agent/telegram` (survives container recreate),
+  composed into the in-memory buffer at a single chokepoint (all push
+  sites). Boot-replays un-acked inbound; acks only on confirmed
+  delivery to a live registered bridge; dedups by a stable id; and a
+  bounded-escalation sweep posts an explicit "couldn't deliver —
+  resend" card so a queued message is ALWAYS resolved (delivered or
+  visibly retracted), never silently lost across a restart.
+  Compaction is atomic (tmp+rename). v1 ack = "delivered to a live
+  bridge"; a true claude→gateway consumption-ack is a documented
+  follow-up. (#1558)
+
+#### Fixes
+
+- **fix(gateway):** turn-gate inbound delivery to end the composer
+  wedge — a non-steering Telegram message arriving mid-turn was typed
+  into claude's TUI composer and its auto-submit raced
+  turn-completion, stranding the message (the lawgpt wedge). Such
+  inbound is now buffered until claude goes idle, where it submits
+  cleanly as a fresh turn; steering messages stay exempt. (#1555)
+- **fix(status):** the agent-status probe tolerates a stateless
+  hindsight backend instead of false-failing the status check when
+  hindsight is configured stateless. (#1556)
+
 ## v0.12.18 — feat: tell the user when proactive compaction runs
 
 Headline: v0.12.17 added opt-in proactive `/compact`, but it ran

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.12.18",
+  "version": "0.12.19",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release **v0.12.19** — 3 commits since v0.12.18 (`ed814298`).

**Headliner (#1558):** the gateway's "⏳ your message is queued and will be processed when it reconnects" promise is now **deterministic across a restart**. Was an in-memory buffer → a container/gateway restart silently lost the message (finn + carrie, users had to resend). Now: crash-tolerant JSONL spool on the persistent per-agent volume, single-chokepoint into the buffer, boot-replay of un-acked, ack only on confirmed delivery, dedup, atomic compaction, and a bounded-escalation "couldn't deliver — resend" card so the promise is always resolved (delivered or visibly retracted), never silently lost. (v1 ack = delivered-to-live-bridge; claude-consumption-ack is a documented v2 follow-up.)

Also: **#1555** turn-gates mid-turn inbound (ends the lawgpt composer wedge), **#1556** tolerates stateless hindsight in the status probe.

Two-file release commit (`package.json` 0.12.18→0.12.19 + `CHANGELOG.md`, full triage of all 3).

## Test plan

- [x] CHANGELOG triaged against `ed814298..upstream/main` (exactly #1555, #1556, #1558)
- [x] Two-file release-commit shape
- [ ] CI green → auto-merge
- [ ] Post-merge: npm publish + registry verify; **wait for the v0.12.19 image build before the staggered rollout** (avoid the :latest pull-race); then the determinism proof — buffer a message, deliberately restart the agent, confirm it's delivered post-restart. Git tag skipped (matches practice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)