### PR TITLE
feat(vault): switchroom vault backup — dated, encrypted, versioned snapshots

### DIFF
--- a/src/cli/vault-backup.ts
+++ b/src/cli/vault-backup.ts
@@ -1,0 +1,141 @@
+/**
+ * CLI: `switchroom vault backup`
+ *
+ * Writes a dated, encrypted copy of `~/.switchroom/vault/vault.enc` to a
+ * configured destination directory, with rotation + a manifest. Companion
+ * to the proven manual recovery flow (`cp <bak> vault/vault.enc + docker
+ * restart switchroom-vault-broker`), turning the lucky `vault.enc.divergent.bak`
+ * survival from the 2026-05-20 incident into a deliberate operator capability.
+ *
+ * v1 scope (this CLI verb): backup only. `vault restore` is a separate v2
+ * design+PR — the reviewer raised genuine restore-safety questions (broker
+ * quiesce mid-mint, force-flag semantics, pre-restore-bak rotation) that
+ * deserve their own pass. Manual `cp + restart` recovery remains the
+ * intermediate path and was proven on the incident host.
+ *
+ * Trust model: the file copied is the AES-256-GCM-encrypted vault envelope
+ * — the operator's passphrase is the gate, not "is the file on this host".
+ * Storing it in a private GitHub repo (the operator's existing
+ * `~/.switchroom-config/` pattern) extends durability without weakening
+ * encryption, IFF the auto-unlock blob is never co-located. The
+ * `findAutoUnlockSibling` defense-in-depth check in
+ * `src/vault/backup.ts` refuses to write a backup into any directory
+ * that already contains an `*auto-unlock*` sibling — closing the foot-gun.
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { loadConfig, resolvePath } from "../config/loader.js";
+import {
+  backupVault,
+  DEFAULT_RETAIN,
+  defaultHome,
+  resolveBackupDestination,
+} from "../vault/backup.js";
+
+interface BackupOptions {
+  to?: string;
+  retain?: string; // commander gives us a string; parsed below
+}
+
+/** Resolve where the live vault file lives. Matches the precedence used
+ *  by the other `vault` subcommands (config → default), so a custom
+ *  `vault.path` in switchroom.yaml is honoured. */
+function getLiveVaultPath(configPath: string | undefined): string {
+  try {
+    const cfg = loadConfig(configPath);
+    if (cfg.vault?.path) return resolvePath(cfg.vault.path);
+  } catch {
+    /* fall through to default */
+  }
+  // Default per src/vault/vault.ts: ~/.switchroom/vault/vault.enc (post-migration).
+  // We deliberately do NOT use the legacy `~/.switchroom/vault.enc` symlink
+  // path because newer installs follow the migrated subdir shape and
+  // `resolvePath` doesn't expand `~` here — caller passes already-resolved.
+  return resolvePath("~/.switchroom/vault/vault.enc");
+}
+
+export function registerVaultBackupCommand(vault: Command, program: Command): void {
+  vault
+    .command("backup")
+    .description(
+      "Write a dated, encrypted backup of the vault to a configured directory. " +
+      "Default destination: ~/.switchroom-config/vault-backups/ if that operator " +
+      "config repo exists, else ~/.switchroom/vault-backups/. Rotated to the last " +
+      "30 backups by default."
+    )
+    .option(
+      "--to <path>",
+      "Destination directory for the backup. Overrides config and default. " +
+      "MUST NOT be ~/.switchroom/vault/ (the broker's bind-mounted dir, " +
+      "validated by `switchroom apply` against an allowlist). Created with mode 0700.",
+    )
+    .option(
+      "--retain <n>",
+      `Keep only the N most recent backups in the destination dir (default ${DEFAULT_RETAIN}). ` +
+      `Older ones are pruned after the new backup is written.`,
+    )
+    .action(async (opts: BackupOptions) => {
+      try {
+        const parentOpts = program.opts();
+        const vaultPath = getLiveVaultPath(parentOpts.config);
+
+        // Read config (optional) to honour `vault.backup.destination` if set.
+        let configDestination: string | undefined;
+        try {
+          const cfg = loadConfig(parentOpts.config);
+          // The schema entry is added under vault.backup; consume it
+          // defensively so older configs without the block continue to work.
+          const backupCfg = (cfg.vault as { backup?: { destination?: string } } | undefined)?.backup;
+          if (backupCfg?.destination) {
+            configDestination = resolvePath(backupCfg.destination);
+          }
+        } catch {
+          /* tolerate missing/malformed config */
+        }
+
+        const home = defaultHome();
+        const hasSwitchroomConfigRepo = existsSync(join(home, ".switchroom-config"));
+
+        const destDir = resolveBackupDestination({
+          cliToFlag: opts.to ? resolvePath(opts.to) : undefined,
+          configDestination,
+          home,
+          hasSwitchroomConfigRepo,
+        });
+
+        // Parse --retain (commander gives string; we want a number). Reject
+        // anything not a non-negative integer at the CLI boundary.
+        let retain = DEFAULT_RETAIN;
+        if (opts.retain !== undefined) {
+          const n = Number(opts.retain);
+          if (!Number.isInteger(n) || n < 0) {
+            console.error(chalk.red(
+              `Error: --retain must be a non-negative integer (got ${JSON.stringify(opts.retain)})`,
+            ));
+            process.exit(1);
+          }
+          retain = n;
+        }
+
+        const result = backupVault({ vaultPath, destDir, retain });
+
+        // Operator-facing summary. Never prints any vault content;
+        // the sha256 + size are properties of the encrypted ciphertext.
+        console.log(`${chalk.green("✓")} vault backup written`);
+        console.log(`  ${chalk.dim("path:")}   ${result.fullPath}`);
+        console.log(`  ${chalk.dim("size:")}   ${result.bytes} bytes`);
+        console.log(`  ${chalk.dim("sha256:")} ${result.sha256}`);
+        if (result.pruned.length > 0) {
+          console.log(`  ${chalk.dim("pruned:")} ${result.pruned.length} older backup(s)`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(chalk.red(`Error: ${msg}`));
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -30,6 +30,7 @@ import { registerVaultBrokerCommand } from "./vault-broker.js";
 import { registerVaultDoctorCommand } from "./vault-doctor.js";
 import { registerVaultAuditCommand } from "./vault-audit.js";
 import { registerVaultGrantCommands } from "./vault-grant.js";
+import { registerVaultBackupCommand } from "./vault-backup.js";
 
 /**
  * Sandbox-context detection.
@@ -1006,4 +1007,10 @@ export function registerVaultCommand(program: Command): void {
 
   // `vault grant` / `vault grants` / `vault revoke` — capability token management.
   registerVaultGrantCommands(vault, program);
+
+  // `vault backup` — dated encrypted snapshots of vault.enc to a
+  // configured destination (operator's private config repo by default).
+  // Companion to the proven manual `cp + restart broker` recovery flow;
+  // see src/cli/vault-backup.ts for the trust-model + design discussion.
+  registerVaultBackupCommand(vault, program);
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1790,6 +1790,41 @@ export const VaultConfigSchema = z.object({
       "in memory and serves secrets to cron scripts via a Unix socket, so the " +
       "vault passphrase is entered once at startup rather than per-cron invocation.",
     ),
+  backup: z
+    .object({
+      destination: z
+        .string()
+        .optional()
+        .describe(
+          "Destination directory for `switchroom vault backup`. " +
+          "When unset, the CLI defaults to " +
+          "`~/.switchroom-config/vault-backups/` if that operator config " +
+          "repo exists, else `~/.switchroom/vault-backups/`. " +
+          "Path is tilde-expanded at read time. " +
+          "MUST NOT be `~/.switchroom/vault/` (the broker bind-mount dir, " +
+          "validated by `switchroom apply` against an artifact allowlist)."
+        ),
+      retain: z
+        .number()
+        .int()
+        .nonnegative()
+        .default(30)
+        .describe(
+          "How many of the most-recent backups to keep in the destination dir. " +
+          "Older ones are pruned after each new backup is written. Default 30 " +
+          "= roughly a month at daily cadence."
+        ),
+    })
+    .optional()
+    .describe(
+      "Configuration for `switchroom vault backup`. Optional — the CLI works " +
+      "with built-in defaults if this block is absent. The backed-up file is " +
+      "the AES-256-GCM-encrypted vault envelope; the operator passphrase " +
+      "remains the gate, so committing backups to a private git repo extends " +
+      "durability without weakening encryption (provided the auto-unlock " +
+      "blob is NEVER co-located — `vault backup` refuses to write into a " +
+      "directory that contains an auto-unlock-shaped sibling)."
+    ),
 });
 
 /**

--- a/src/vault/backup.test.ts
+++ b/src/vault/backup.test.ts
@@ -305,6 +305,22 @@ describe("backupVault (IO orchestrator)", () => {
     backupVault({ vaultPath, destDir });
     expect(statSync(destDir).mode & 0o777).toBe(0o700);
   });
+
+  it("refuses sub-second collision instead of silently overwriting (code-review finding F3)", () => {
+    // Same `now` → same computed filename → second call must refuse.
+    const t = new Date(Date.UTC(2026, 4, 20, 8, 9, 4));
+    const r1 = backupVault({ vaultPath, destDir, now: t });
+    expect(existsSync(r1.fullPath)).toBe(true);
+    expect(() => backupVault({ vaultPath, destDir, now: t })).toThrow(/sub-second collision/);
+    // The pre-existing backup file is unchanged
+    expect(readFileSync(r1.fullPath, "utf8")).toBe(VALID_VAULT_JSON);
+    // The manifest still has exactly one row for this filename
+    const rows = readManifest(destDir);
+    expect(rows.filter((r) => r.file === r1.filename)).toHaveLength(1);
+    // The tmp file from the second (refused) attempt was cleaned up
+    const dirEntries = readdirSync(destDir);
+    expect(dirEntries.filter((n) => n.startsWith(".tmp."))).toEqual([]);
+  });
 });
 
 describe("defaultHome", () => {

--- a/src/vault/backup.test.ts
+++ b/src/vault/backup.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Unit tests for vault backup helpers (#1562).
+ *
+ * Hermetic per the gate at #1561: every IO test uses a tmpdir and sets
+ * `process.env.HOME = tmpDir` BEFORE invoking any backup function, so
+ * `os.homedir()`-derived paths resolve into the tmpdir.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  backupVault,
+  computeBackupFilename,
+  defaultHome,
+  findAutoUnlockSibling,
+  LATEST_SYMLINK,
+  listBackupFiles,
+  MANIFEST_FILE,
+  parseBackupFilename,
+  readManifest,
+  resolveBackupDestination,
+  selectBackupsToPrune,
+  validateVaultEnvelopeFile,
+} from "./backup.js";
+
+const VALID_VAULT_JSON = JSON.stringify({
+  salt: "0123456789abcdef0123456789abcdef",
+  iv: "0123456789ab0123456789ab",
+  data: "deadbeefcafe1234",
+  tag: "fedcba9876543210fedcba9876543210",
+  kdf: { N: 32768, r: 8, p: 1 },
+});
+
+describe("computeBackupFilename", () => {
+  it("renders UTC date+time, lex-sortable", () => {
+    // Use UTC explicitly so the test is timezone-independent
+    const t = new Date(Date.UTC(2026, 4, 20, 8, 9, 4));
+    expect(computeBackupFilename(t)).toBe("vault.enc.20260520-080904.bak");
+  });
+
+  it("pads single-digit components", () => {
+    const t = new Date(Date.UTC(2026, 0, 1, 0, 0, 0));
+    expect(computeBackupFilename(t)).toBe("vault.enc.20260101-000000.bak");
+  });
+});
+
+describe("parseBackupFilename", () => {
+  it("accepts the canonical shape", () => {
+    expect(parseBackupFilename("vault.enc.20260520-080904.bak")).toBe("20260520-080904");
+  });
+  it("rejects the manifest, symlink, and unrelated files", () => {
+    expect(parseBackupFilename("manifest.jsonl")).toBe(null);
+    expect(parseBackupFilename("vault.enc.latest.bak")).toBe(null);
+    expect(parseBackupFilename("vault.enc.divergent.bak")).toBe(null); // migration's bak, not ours
+    expect(parseBackupFilename("README.md")).toBe(null);
+  });
+  it("rejects malformed dates", () => {
+    expect(parseBackupFilename("vault.enc.notadate.bak")).toBe(null);
+    expect(parseBackupFilename("vault.enc.2026-05-20-080904.bak")).toBe(null); // wrong separator
+  });
+});
+
+describe("validateVaultEnvelopeFile", () => {
+  let dir: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vault-backup-validate-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = dir;
+  });
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("accepts a well-formed envelope", () => {
+    const p = join(dir, "v.enc");
+    writeFileSync(p, VALID_VAULT_JSON);
+    expect(validateVaultEnvelopeFile(p)).toBe(null);
+  });
+
+  it("rejects an empty file", () => {
+    const p = join(dir, "v.enc");
+    writeFileSync(p, "");
+    expect(validateVaultEnvelopeFile(p)).toMatch(/empty/i);
+  });
+
+  it("rejects non-JSON", () => {
+    const p = join(dir, "v.enc");
+    writeFileSync(p, "garbage");
+    expect(validateVaultEnvelopeFile(p)).toMatch(/JSON/);
+  });
+
+  it("rejects JSON missing required fields", () => {
+    const p = join(dir, "v.enc");
+    writeFileSync(p, JSON.stringify({ salt: "x", iv: "y" })); // no data/tag
+    expect(validateVaultEnvelopeFile(p)).toMatch(/missing or empty required field/);
+  });
+
+  it("rejects a malformed kdf field", () => {
+    const p = join(dir, "v.enc");
+    writeFileSync(p, JSON.stringify({
+      salt: "x", iv: "y", data: "z", tag: "t", kdf: { N: "not-a-number", r: 8, p: 1 },
+    }));
+    expect(validateVaultEnvelopeFile(p)).toMatch(/malformed kdf/);
+  });
+
+  it("rejects nonexistent file with the underlying error", () => {
+    expect(validateVaultEnvelopeFile(join(dir, "nope"))).toMatch(/cannot read/);
+  });
+});
+
+describe("resolveBackupDestination (pure)", () => {
+  it("--to flag wins absolutely", () => {
+    expect(resolveBackupDestination({
+      cliToFlag: "/explicit/path",
+      configDestination: "/cfg",
+      home: "/h",
+      hasSwitchroomConfigRepo: true,
+    })).toBe("/explicit/path");
+  });
+
+  it("config destination wins over defaults when no --to", () => {
+    expect(resolveBackupDestination({
+      configDestination: "/cfg/place",
+      home: "/h",
+      hasSwitchroomConfigRepo: true,
+    })).toBe("/cfg/place");
+  });
+
+  it("falls back to ~/.switchroom-config/vault-backups/ when that repo exists", () => {
+    expect(resolveBackupDestination({
+      home: "/home/op",
+      hasSwitchroomConfigRepo: true,
+    })).toBe("/home/op/.switchroom-config/vault-backups");
+  });
+
+  it("falls back to ~/.switchroom/vault-backups/ when no config repo", () => {
+    expect(resolveBackupDestination({
+      home: "/home/op",
+      hasSwitchroomConfigRepo: false,
+    })).toBe("/home/op/.switchroom/vault-backups");
+  });
+});
+
+describe("findAutoUnlockSibling (defense-in-depth)", () => {
+  it("returns null on an empty dir listing", () => {
+    expect(findAutoUnlockSibling([])).toBe(null);
+  });
+
+  it("returns null on only backup files + known artifacts", () => {
+    expect(findAutoUnlockSibling([
+      "vault.enc.20260520-080904.bak",
+      "vault.enc.20260520-093000.bak",
+      "manifest.jsonl",
+      "vault.enc.latest.bak",
+      "README.md",
+      ".git",
+      ".gitignore",
+    ])).toBe(null);
+  });
+
+  it("flags a vault-auto-unlock file", () => {
+    expect(findAutoUnlockSibling(["vault-auto-unlock"])).toBe("vault-auto-unlock");
+  });
+
+  it("flags any 'auto-unlock' substring (case-insensitive)", () => {
+    expect(findAutoUnlockSibling(["Auto-Unlock.bin"])).toBe("Auto-Unlock.bin");
+    expect(findAutoUnlockSibling(["fleet.auto-unlock.creds"])).toBe("fleet.auto-unlock.creds");
+  });
+
+  it("flags a dotfile auto-unlock variant", () => {
+    expect(findAutoUnlockSibling([".vault-auto"])).toBe(".vault-auto");
+  });
+});
+
+describe("selectBackupsToPrune", () => {
+  it("returns nothing when count <= retain", () => {
+    expect(selectBackupsToPrune(["a", "b"], 30)).toEqual([]);
+    expect(selectBackupsToPrune(["a", "b"], 2)).toEqual([]);
+  });
+  it("prunes the oldest beyond retain (input is newest-first)", () => {
+    const xs = ["new3", "new2", "new1", "old3", "old2", "old1"];
+    expect(selectBackupsToPrune(xs, 3)).toEqual(["old3", "old2", "old1"]);
+  });
+  it("retain=0 prunes everything", () => {
+    expect(selectBackupsToPrune(["a", "b", "c"], 0)).toEqual(["a", "b", "c"]);
+  });
+  it("throws on negative retain", () => {
+    expect(() => selectBackupsToPrune([], -1)).toThrow();
+  });
+});
+
+describe("backupVault (IO orchestrator)", () => {
+  let dir: string;
+  let vaultPath: string;
+  let destDir: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vault-backup-io-"));
+    prevHome = process.env.HOME;
+    process.env.HOME = dir; // hermetic per #1561
+
+    // Lay out a fake ~/.switchroom/vault/vault.enc + a backup dest dir.
+    const switchroomDir = join(dir, ".switchroom");
+    mkdirSync(join(switchroomDir, "vault"), { recursive: true, mode: 0o700 });
+    vaultPath = join(switchroomDir, "vault", "vault.enc");
+    writeFileSync(vaultPath, VALID_VAULT_JSON, { mode: 0o600 });
+
+    destDir = join(dir, "backups");
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes a dated backup + symlink + manifest row", () => {
+    const fixedNow = new Date(Date.UTC(2026, 4, 20, 8, 9, 4));
+    const r = backupVault({ vaultPath, destDir, now: fixedNow });
+
+    expect(r.filename).toBe("vault.enc.20260520-080904.bak");
+    expect(existsSync(r.fullPath)).toBe(true);
+    expect(readFileSync(r.fullPath, "utf8")).toBe(VALID_VAULT_JSON);
+
+    // Manifest row
+    const rows = readManifest(destDir);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].file).toBe(r.filename);
+    expect(rows[0].size_bytes).toBe(statSync(r.fullPath).size);
+    expect(rows[0].sha256).toMatch(/^[0-9a-f]{64}$/);
+
+    // Symlink
+    expect(existsSync(join(destDir, LATEST_SYMLINK))).toBe(true);
+  });
+
+  it("refuses if source is not a valid envelope", () => {
+    writeFileSync(vaultPath, "not json");
+    expect(() => backupVault({ vaultPath, destDir })).toThrow(/not a valid vault envelope/);
+    // and didn't create the dest dir on a refusal? — actually we DO mkdir the
+    // dest first (idempotent), so just assert no .bak landed:
+    expect(listBackupFiles(destDir)).toEqual([]);
+  });
+
+  it("refuses if destination contains an auto-unlock sibling", () => {
+    mkdirSync(destDir, { recursive: true, mode: 0o700 });
+    writeFileSync(join(destDir, "vault-auto-unlock"), "machine-bound-blob-here");
+    expect(() => backupVault({ vaultPath, destDir })).toThrow(/auto-unlock credential/);
+    expect(listBackupFiles(destDir)).toEqual([]); // no backup written
+  });
+
+  it("rotates beyond retain budget (oldest pruned)", () => {
+    // Lay 5 backups; retain=2.
+    for (let h = 0; h < 5; h++) {
+      const t = new Date(Date.UTC(2026, 4, 20, h, 0, 0));
+      backupVault({ vaultPath, destDir, now: t, retain: 99 });
+    }
+    expect(listBackupFiles(destDir)).toHaveLength(5);
+
+    // Now do one more with retain=2 → keep 2 newest, prune 4 older.
+    const r = backupVault({
+      vaultPath, destDir,
+      now: new Date(Date.UTC(2026, 4, 20, 10, 0, 0)),
+      retain: 2,
+    });
+    const remaining = listBackupFiles(destDir);
+    expect(remaining).toHaveLength(2);
+    // newest-first: the just-written one + the previous-newest
+    expect(remaining[0]).toBe(r.filename);
+    expect(r.pruned.length).toBeGreaterThan(0);
+  });
+
+  it("manifest accumulates across multiple backups", () => {
+    backupVault({ vaultPath, destDir, now: new Date(Date.UTC(2026, 4, 20, 1, 0, 0)) });
+    backupVault({ vaultPath, destDir, now: new Date(Date.UTC(2026, 4, 20, 2, 0, 0)) });
+    backupVault({ vaultPath, destDir, now: new Date(Date.UTC(2026, 4, 20, 3, 0, 0)) });
+    const rows = readManifest(destDir);
+    expect(rows).toHaveLength(3);
+  });
+
+  it("atomic tmp file does NOT live inside ~/.switchroom/vault/ (apply.ts safety)", () => {
+    // After a backup, the broker bind-mount dir must contain ONLY
+    // vault.enc + nothing else. The atomic tmp lives in destDir.
+    backupVault({ vaultPath, destDir });
+    const vaultDirEntries = readdirSync(join(dir, ".switchroom", "vault"));
+    expect(vaultDirEntries).toEqual(["vault.enc"]);
+  });
+
+  it("destination dir gets mode 0700 on creation", () => {
+    backupVault({ vaultPath, destDir });
+    expect(statSync(destDir).mode & 0o777).toBe(0o700);
+  });
+});
+
+describe("defaultHome", () => {
+  // The function returns process.env.HOME (if set) or os.homedir().
+  // This test just pins that contract — used by the CLI to construct
+  // ResolveDestinationInput without re-reaching for the env each time.
+  it("returns process.env.HOME when set", () => {
+    const prev = process.env.HOME;
+    process.env.HOME = "/tmp/forced-home";
+    try {
+      expect(defaultHome()).toBe("/tmp/forced-home");
+    } finally {
+      if (prev === undefined) delete process.env.HOME;
+      else process.env.HOME = prev;
+    }
+  });
+});

--- a/src/vault/backup.ts
+++ b/src/vault/backup.ts
@@ -330,6 +330,22 @@ export function backupVault(opts: {
   } finally {
     closeSync(fd);
   }
+
+  // Refuse on sub-second collision: two backups in the same UTC second
+  // would otherwise silently overwrite each other (renameSync replaces
+  // an existing target with no warning) while the manifest appends two
+  // rows pointing at the same filename with different sha256s — confusing
+  // and a silent data-loss path. Operator-facing error tells them to
+  // retry in 1s. Sub-second backup invocations only happen with concurrent
+  // operator scripts; daily-cron usage never hits this.
+  if (existsSync(fullPath)) {
+    try { unlinkSync(tmpPath); } catch { /* tolerate cleanup failure */ }
+    throw new Error(
+      `vault backup refused: '${fullPath}' already exists ` +
+      `(sub-second collision with another backup). Retry in 1 second, ` +
+      `or check for a concurrent backup process.`,
+    );
+  }
   renameSync(tmpPath, fullPath);
   const stat = statSync(fullPath);
   const sha256 = sha256OfFile(fullPath);
@@ -348,11 +364,37 @@ export function backupVault(opts: {
   try { unlinkSync(latestPath); } catch { /* not present */ }
   try { symlinkSync(filename, latestPath); } catch { /* best-effort */ }
 
-  // 7. Rotate.
+  // 7. Durability: fsync the destination directory so the new dirent
+  //    (the backup file, the manifest entry update, the new symlink) is
+  //    persisted to stable storage. WITHOUT this, POSIX permits the
+  //    kernel to defer the directory-entry write — a host crash
+  //    post-rename can lose the backup file even though renameSync
+  //    returned. For a feature whose raison d'être is "don't lose the
+  //    vault on incident", this is load-bearing. One fsync at the end
+  //    is sufficient: it makes ALL changes-to-this-dir-since-last-fsync
+  //    durable atomically.
+  try {
+    const dirFd = openSync(opts.destDir, "r");
+    try { fsyncSync(dirFd); } finally { closeSync(dirFd); }
+  } catch {
+    // Best-effort: some filesystems (FAT, tmpfs in some configs) refuse
+    // fsync on directories. Don't fail the backup if the fs doesn't
+    // support it — the file is still written; durability is degraded
+    // but not catastrophically lost.
+  }
+
+  // 8. Rotate.
   const sorted = listBackupFiles(opts.destDir);
   const pruneNames = selectBackupsToPrune(sorted, retain);
   for (const old of pruneNames) {
     try { unlinkSync(join(opts.destDir, old)); } catch { /* tolerate */ }
+  }
+  // Fsync again after pruning so the unlinks are durable. Same best-effort.
+  if (pruneNames.length > 0) {
+    try {
+      const dirFd = openSync(opts.destDir, "r");
+      try { fsyncSync(dirFd); } finally { closeSync(dirFd); }
+    } catch { /* best-effort */ }
   }
 
   return {

--- a/src/vault/backup.ts
+++ b/src/vault/backup.ts
@@ -1,0 +1,391 @@
+/**
+ * Vault backup helpers (#1562 — vault backup/restore for future-proofing).
+ *
+ * Motivation (incident 2026-05-20): a non-hermetic broker test (now
+ * fixed by #1560) corrupted the operator's live `~/.switchroom/vault/
+ * vault.enc` on a shared production-treated host. Recovery worked only
+ * because the May-11 vault-layout migration had preserved a
+ * `vault.enc.divergent.bak` on disk — luck, not design. This module
+ * makes that backup deliberate, dated, rotatable, and trackable in the
+ * operator's existing private config repo.
+ *
+ * v1 scope (this file + the matching `switchroom vault backup` CLI verb):
+ *   - Copy `~/.switchroom/vault/vault.enc` to a configured destination.
+ *   - Dated filename `vault.enc.YYYYMMDD-HHMMSS.bak` (UTC, lex-sortable).
+ *   - Rotation: keep last N (default 30).
+ *   - Manifest: one JSONL row per backup with sha256 of the ciphertext
+ *     (integrity-check without decrypt; encrypted blob, so safe to track
+ *     in git or sync to private repo).
+ *
+ * v2 (separate design review) will add `vault restore` — deliberately
+ * scoped out here because the reviewer raised three genuine
+ * restore-safety questions (broker-quiesce mid-mint, force-flag
+ * semantics, pre-restore-bak rotation) that deserve their own design
+ * pass. Proven manual recovery (`cp <bak> vault/vault.enc + docker
+ * restart broker`) still works today.
+ *
+ * Hard rules:
+ *   - NEVER copies `~/.switchroom/vault-auto-unlock` (machine-bound; if
+ *     leaked, gives the passphrase — and is useless off-host anyway).
+ *   - NEVER copies `vault-grants.db` (per-agent grant tokens; different
+ *     threat model).
+ *   - REFUSES to write backups into a directory that already contains an
+ *     `auto-unlock`-shaped sibling — defense-in-depth against an operator
+ *     one day pointing `--to ~/.switchroom/` and bulk-syncing the
+ *     whole dir.
+ *   - Atomic tmp file lives INSIDE the destination dir (not inside
+ *     `~/.switchroom/vault/`, which is the broker bind-mount validated
+ *     by `apply.ts` against `KNOWN_VAULT_ARTIFACT_NAMES`).
+ *
+ * All path-resolution is a pure function of (config, env, fs-existence)
+ * — testable without touching real `$HOME` (per the hermeticity lint
+ * gate, #1561).
+ */
+
+import {
+  createHash,
+  randomBytes,
+} from "node:crypto";
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+
+/** Sentinel filename written next to every backup; pruning skips it. */
+export const LATEST_SYMLINK = "vault.enc.latest.bak";
+
+/** Manifest filename. */
+export const MANIFEST_FILE = "manifest.jsonl";
+
+/** Default rotation depth. */
+export const DEFAULT_RETAIN = 30;
+
+/** Filename prefix used by `computeBackupFilename` AND `listBackupFiles`. */
+const FILENAME_PREFIX = "vault.enc.";
+const FILENAME_SUFFIX = ".bak";
+
+/** Filenames inside the destination dir that look like an auto-unlock blob.
+ *  ANY match here causes `backup` to refuse, per the design-reviewer's
+ *  defense-in-depth ask: never let an operator one-day point `--to` at a
+ *  dir that also holds the machine-bound passphrase blob. */
+const AUTO_UNLOCK_FILENAME_PATTERNS = [
+  /auto-unlock/i,
+  /^\.?vault-auto/i,
+];
+
+/** Whitelisted artifact names that may live next to a backup file in
+ *  the destination dir without tripping the auto-unlock-sibling check.
+ *  Symlink + manifest are produced by THIS module; pre-existing backup
+ *  files are obviously fine. */
+const KNOWN_BACKUP_DIR_ARTIFACTS: ReadonlySet<string> = new Set([
+  LATEST_SYMLINK,
+  MANIFEST_FILE,
+  ".git",
+  ".gitignore",
+  "README.md",
+]);
+
+/** A single manifest row. JSONL: one row appended per `backup()`. */
+export interface ManifestRow {
+  /** ISO-8601 UTC. */
+  ts: string;
+  /** Basename only (no dir). */
+  file: string;
+  /** Byte size of the file. */
+  size_bytes: number;
+  /** Hex sha256 of the encrypted-vault file (= the .enc ciphertext as
+   *  written — integrity check without decrypt). */
+  sha256: string;
+}
+
+/** Result of a successful backup. */
+export interface BackupResult {
+  destDir: string;
+  filename: string;
+  fullPath: string;
+  bytes: number;
+  sha256: string;
+  pruned: string[];
+}
+
+/** Compute the dated backup filename from a Date (UTC).
+ *  Lex-sortable, distinct per second. */
+export function computeBackupFilename(now: Date): string {
+  const Y = now.getUTCFullYear().toString().padStart(4, "0");
+  const M = (now.getUTCMonth() + 1).toString().padStart(2, "0");
+  const D = now.getUTCDate().toString().padStart(2, "0");
+  const h = now.getUTCHours().toString().padStart(2, "0");
+  const m = now.getUTCMinutes().toString().padStart(2, "0");
+  const s = now.getUTCSeconds().toString().padStart(2, "0");
+  return `${FILENAME_PREFIX}${Y}${M}${D}-${h}${m}${s}${FILENAME_SUFFIX}`;
+}
+
+/** Match a backup filename and extract its timestamp segment (for sort).
+ *  Returns null on non-matching names so callers can skip the symlink,
+ *  manifest, README, etc., when listing backups for rotation. */
+export function parseBackupFilename(name: string): string | null {
+  if (!name.startsWith(FILENAME_PREFIX)) return null;
+  if (!name.endsWith(FILENAME_SUFFIX)) return null;
+  const inner = name.slice(FILENAME_PREFIX.length, -FILENAME_SUFFIX.length);
+  if (!/^\d{8}-\d{6}$/.test(inner)) return null;
+  return inner;
+}
+
+/** Validate that the file at `path` is a syntactically well-formed
+ *  switchroom vault envelope (no decrypt — that needs the passphrase).
+ *  Returns null on success, an explanation string on failure.
+ *
+ *  Same shape as `VaultFile` at src/vault/vault.ts:176-183 — kept
+ *  duplicated here intentionally to avoid pulling in vault.ts's crypto
+ *  dependencies, and because the validation surface for backup is
+ *  intentionally narrower (we never re-encrypt, only memcpy). */
+export function validateVaultEnvelopeFile(path: string): string | null {
+  let buf: Buffer;
+  try {
+    buf = readFileSync(path);
+  } catch (err) {
+    return `cannot read ${path}: ${(err as Error).message}`;
+  }
+  if (buf.length === 0) {
+    return `${path} is empty`;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(buf.toString("utf8"));
+  } catch {
+    return `${path} is not valid JSON (vault envelope is JSON)`;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return `${path} is not a JSON object`;
+  }
+  const obj = parsed as Record<string, unknown>;
+  for (const required of ["salt", "iv", "data", "tag"] as const) {
+    if (typeof obj[required] !== "string" || (obj[required] as string).length === 0) {
+      return `${path} is missing or empty required field '${required}'`;
+    }
+  }
+  // kdf is optional (legacy vaults omit), but if present must shape-match.
+  if (obj.kdf !== undefined) {
+    const k = obj.kdf as Record<string, unknown>;
+    if (typeof k.N !== "number" || typeof k.r !== "number" || typeof k.p !== "number") {
+      return `${path} has malformed kdf field`;
+    }
+  }
+  return null;
+}
+
+/** Inputs to `resolveBackupDestination`. Pure: caller provides everything,
+ *  no real-fs / real-$HOME assumptions. Tests can construct any state. */
+export interface ResolveDestinationInput {
+  /** Result of the operator-supplied `--to` arg (highest precedence). */
+  cliToFlag?: string;
+  /** Result of `switchroom.yaml`'s `vault.backup.destination` setting. */
+  configDestination?: string;
+  /** Operator HOME (defaults to `os.homedir()`); injectable for tests. */
+  home: string;
+  /** Whether `<home>/.switchroom-config/` exists (= operator uses the
+   *  private-config-repo pattern). Caller pre-resolves to keep this
+   *  function pure. */
+  hasSwitchroomConfigRepo: boolean;
+}
+
+/** Pick the backup destination directory.
+ *
+ *  Precedence (highest first):
+ *    1. `--to` CLI flag
+ *    2. `vault.backup.destination` config setting
+ *    3. `<home>/.switchroom-config/vault-backups/` if that config repo
+ *       exists (operator's existing private-repo pattern)
+ *    4. `<home>/.switchroom/vault-backups/` fallback
+ *
+ *  Path is resolved (no `~` expansion needed — caller passes `home`).
+ *  Pure: returns the chosen path; does NOT create the directory. */
+export function resolveBackupDestination(input: ResolveDestinationInput): string {
+  if (input.cliToFlag) return resolvePath(input.cliToFlag);
+  if (input.configDestination) return resolvePath(input.configDestination);
+  if (input.hasSwitchroomConfigRepo) {
+    return join(input.home, ".switchroom-config", "vault-backups");
+  }
+  return join(input.home, ".switchroom", "vault-backups");
+}
+
+/** Defense-in-depth: refuse to write into a dir that contains an
+ *  auto-unlock-shaped sibling. Pure: takes a list of filenames (caller
+ *  reads the directory), returns null on safe or an offending name on
+ *  unsafe. The check considers only direct children, not subdirs. */
+export function findAutoUnlockSibling(
+  entries: string[],
+): string | null {
+  for (const name of entries) {
+    if (KNOWN_BACKUP_DIR_ARTIFACTS.has(name)) continue;
+    if (AUTO_UNLOCK_FILENAME_PATTERNS.some((re) => re.test(name))) {
+      return name;
+    }
+  }
+  return null;
+}
+
+/** Compute the list of pruning victims given a sorted-newest-first list
+ *  of backup filenames and a retain budget. Pure. */
+export function selectBackupsToPrune(
+  sortedNewestFirst: string[],
+  retain: number,
+): string[] {
+  if (retain < 0) throw new Error("retain must be >= 0");
+  return sortedNewestFirst.slice(retain);
+}
+
+/** List backup files in `dir`, sorted newest-first. Tolerates a
+ *  non-existent dir (returns []). */
+export function listBackupFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((n) => parseBackupFilename(n) !== null)
+    .sort((a, b) => {
+      const ka = parseBackupFilename(a)!;
+      const kb = parseBackupFilename(b)!;
+      return kb.localeCompare(ka);
+    });
+}
+
+/** SHA-256 of a file's contents. Streaming would be lower-memory but
+ *  vault.enc is ~40 KB; a single read is simpler and the API is sync. */
+export function sha256OfFile(path: string): string {
+  const h = createHash("sha256");
+  h.update(readFileSync(path));
+  return h.digest("hex");
+}
+
+/** Perform the backup. IO orchestrator over the pure helpers above. */
+export function backupVault(opts: {
+  vaultPath: string;
+  destDir: string;
+  retain?: number;
+  now?: Date;
+}): BackupResult {
+  const now = opts.now ?? new Date();
+  const retain = opts.retain ?? DEFAULT_RETAIN;
+
+  // 1. Validate the source is a real vault envelope before we copy
+  //    anything — better to fail fast than write a corrupt backup.
+  const validationError = validateVaultEnvelopeFile(opts.vaultPath);
+  if (validationError) {
+    throw new Error(
+      `vault backup refused: source is not a valid vault envelope: ${validationError}`,
+    );
+  }
+
+  // 2. Ensure destination dir exists with strict perms (0700).
+  mkdirSync(opts.destDir, { recursive: true, mode: 0o700 });
+
+  // 3. Defense-in-depth: scan dir for an auto-unlock-shaped sibling.
+  //    If any non-whitelisted, non-backup file matches the pattern,
+  //    refuse — the operator is about to commit the machine-bound
+  //    passphrase blob into version control.
+  const dirEntries = readdirSync(opts.destDir);
+  const offender = findAutoUnlockSibling(dirEntries);
+  if (offender) {
+    throw new Error(
+      `vault backup refused: destination '${opts.destDir}' contains a file ` +
+      `that looks like an auto-unlock credential ('${offender}'). The ` +
+      `machine-bound auto-unlock blob MUST NOT be co-located with the ` +
+      `encrypted vault — if they're together in version control, the ` +
+      `passphrase gate is bypassed. Move/remove that file and retry.`,
+    );
+  }
+
+  // 4. Atomic write into the destination dir (tmp source MUST be in the
+  //    dest dir, NOT in ~/.switchroom/vault/ — that's the broker
+  //    bind-mount validated by `apply.ts` against KNOWN_VAULT_ARTIFACT_NAMES).
+  const filename = computeBackupFilename(now);
+  const fullPath = join(opts.destDir, filename);
+  const tmpName = `.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
+  const tmpPath = join(opts.destDir, tmpName);
+
+  // Copy + fsync + rename. Read source, write atomic tmp, fsync, rename.
+  const src = readFileSync(opts.vaultPath);
+  const fd = openSync(tmpPath, "wx", 0o600);
+  try {
+    writeSync(fd, src);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(tmpPath, fullPath);
+  const stat = statSync(fullPath);
+  const sha256 = sha256OfFile(fullPath);
+
+  // 5. Manifest row.
+  const row: ManifestRow = {
+    ts: now.toISOString(),
+    file: filename,
+    size_bytes: stat.size,
+    sha256,
+  };
+  appendFileSync(join(opts.destDir, MANIFEST_FILE), JSON.stringify(row) + "\n", { mode: 0o600 });
+
+  // 6. Update the "latest" symlink for convenience.
+  const latestPath = join(opts.destDir, LATEST_SYMLINK);
+  try { unlinkSync(latestPath); } catch { /* not present */ }
+  try { symlinkSync(filename, latestPath); } catch { /* best-effort */ }
+
+  // 7. Rotate.
+  const sorted = listBackupFiles(opts.destDir);
+  const pruneNames = selectBackupsToPrune(sorted, retain);
+  for (const old of pruneNames) {
+    try { unlinkSync(join(opts.destDir, old)); } catch { /* tolerate */ }
+  }
+
+  return {
+    destDir: opts.destDir,
+    filename,
+    fullPath,
+    bytes: stat.size,
+    sha256,
+    pruned: pruneNames,
+  };
+}
+
+/** Convenience: read manifest as an array (for `vault backup list` UI
+ *  in v2, and for tests). Returns rows in append-order. */
+export function readManifest(destDir: string): ManifestRow[] {
+  const p = join(destDir, MANIFEST_FILE);
+  if (!existsSync(p)) return [];
+  const lines = readFileSync(p, "utf8").split("\n").filter((l) => l.length > 0);
+  const out: ManifestRow[] = [];
+  for (const line of lines) {
+    try {
+      out.push(JSON.parse(line) as ManifestRow);
+    } catch {
+      // tolerate a corrupt line — best-effort; the file is operator-readable
+      // and a corrupt row is recoverable by hand.
+    }
+  }
+  return out;
+}
+
+/** Default `home` resolution for non-test callers — extracted so tests
+ *  can construct `ResolveDestinationInput` without touching real $HOME. */
+export function defaultHome(): string {
+  return process.env.HOME ?? homedir();
+}
+


### PR DESCRIPTION
## Summary

Companion to the proven manual recovery flow (`cp <bak> vault/vault.enc && docker restart switchroom-vault-broker`) — turns the lucky survival of `vault.enc.divergent.bak` from the **2026-05-20 incident** into a deliberate operator capability. v1 is **backup only**; `vault restore` is a separate v2 design+PR because the design reviewer raised three genuine restore-safety questions (broker quiesce mid-mint, force-flag semantics, pre-restore-bak rotation) that deserve their own pass.

## CLI

```
switchroom vault backup [--to <path>] [--retain <n>]
```

- Default `--to`: `~/.switchroom-config/vault-backups/` if that operator config repo exists (the existing private-repo pattern), else `~/.switchroom/vault-backups/`. Honors `vault.backup.destination` in `switchroom.yaml`.
- Filename: `vault.enc.YYYYMMDD-HHMMSS.bak` (UTC, lex-sortable).
- Atomic write: tmp inside the **destination** dir (never inside `~/.switchroom/vault/`, which is the broker bind-mount `switchroom apply` validates against `KNOWN_VAULT_ARTIFACT_NAMES`). fsync + rename. Mode 0600. Dest dir mode 0700.
- Symlink `vault.enc.latest.bak` → newest.
- Rotation: keep last N (default 30). Older pruned post-write.
- Manifest: one JSONL row per backup at `<dest>/manifest.jsonl` — `{ts, file, size_bytes, sha256}`. SHA-256 of the **ciphertext** — integrity check without decrypt.

## Trust model

The copied file IS the AES-256-GCM-encrypted vault envelope. Passphrase remains the gate; "encrypted blob lives in private git" doesn't weaken encryption. The auto-unlock blob is **never** copied (machine-bound + leaking it bypasses the passphrase). As defense-in-depth, `findAutoUnlockSibling` aborts the backup if the destination dir contains ANY file matching `*auto-unlock*` — closes the foot-gun if an operator one day points `--to ~/.switchroom/` and bulk-syncs the whole dir.

## Design was reviewed BEFORE implementation

The design reviewer raised 5 issues:
- **#1 (restore-only):** `--force` semantics — deferred with restore.
- **#2:** atomic-write tmp file must NOT live inside `~/.switchroom/vault/` — **addressed** (tmp lives in destDir; explicit test pins this).
- **#3 (restore-only):** broker quiesce — deferred with restore.
- **#4:** path-picker must be a pure function for testable HOME isolation — **addressed** (`resolveBackupDestination` is pure; tests construct any env state).
- **#5:** refuse if dest contains an auto-unlock sibling — **addressed** (`findAutoUnlockSibling` + an end-to-end refusal test).

Issues 1 + 3 only apply to `restore`, which is correctly scoped out of v1.

## Test plan

- [x] 32 unit tests pass (`src/vault/backup.test.ts`) — hermetic per #1561 (`process.env.HOME = tmpDir`).
- [x] `npm run lint` clean.
- [x] End-to-end CLI smoke (bun runtime, tmpdir HOME): `vault backup --to <tmp>` writes the dated `.bak` + manifest row + `vault.enc.latest.bak` symlink; real `~/.switchroom/vault/` untouched.

## Out of scope (tracked follow-ups)

- `switchroom vault restore <path>` — v2, separate design review.
- Built-in scheduling — operator wires to crontab or `~/.switchroom-config/sync.sh` for v1.
- Off-host backup (S3, etc.) — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)