### PR TITLE
fix(gateway): silence-poke fallback sweeps sibling activeTurnStartedAt keys

### DIFF
--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -179,7 +179,11 @@ ALLOWLIST=(
   # chunk-loop raw sends to 4026/4047 (past 4000). End 4000 -> 4060;
   # check flags only 4026/4047 before the next entry (8100), so no new
   # un-allowlisted call enters the margin.
-  "telegram-plugin/gateway/gateway.ts:3160-4060:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
+  # Re-bumped 2026-05-20 for the silence-poke turn-state purge fix:
+  # the ~17-line purgeStaleTurnsForChat insertion (~3014) drifted the
+  # chunk-loop raw send to 4067 (past 4060). End 4060 -> 4080; next
+  # raw call is 11002 (far outside), no new un-allowlisted call enters.
+  "telegram-plugin/gateway/gateway.ts:3160-4080:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -260,7 +264,12 @@ ALLOWLIST=(
   # 10920). End 10920 -> 11000; next raw call is well outside, so no
   # new un-allowlisted call enters — same already-.catch-swallowed
   # wizard sites.
-  "telegram-plugin/gateway/gateway.ts:9340-11000:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-20 for the silence-poke turn-state purge fix:
+  # the ~17-line purgeStaleTurnsForChat insertion (~3014) drifted the
+  # last wizard editMessageText site to 11002 (past 11000). End
+  # 11000 -> 11020; next raw call is well outside — same already-
+  # .catch-swallowed wizard site, no new un-allowlisted call enters.
+  "telegram-plugin/gateway/gateway.ts:9340-11020:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/scripts/check-bot-api-wrapping.sh
+++ b/scripts/check-bot-api-wrapping.sh
@@ -183,7 +183,11 @@ ALLOWLIST=(
   # the ~17-line purgeStaleTurnsForChat insertion (~3014) drifted the
   # chunk-loop raw send to 4067 (past 4060). End 4060 -> 4080; next
   # raw call is 11002 (far outside), no new un-allowlisted call enters.
-  "telegram-plugin/gateway/gateway.ts:3160-4080:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
+  # Re-bumped 2026-05-20 (same-PR follow-up): the +~26-line
+  # endCurrentTurnAtomic helper insertion (~1320) drifted the
+  # chunk-loop raw send 4067 -> 4093 (past 4080). End 4080 -> 4100;
+  # next raw call is 11028 (far outside), no new un-allowlisted call.
+  "telegram-plugin/gateway/gateway.ts:3160-4100:reply chunk-loop THREAD_NOT_FOUND + plaintext-fallback raw sends (intentional)"
 
   # credit-watch notification. No thread_id (DM).
   # Range bumped 2026-05-13 for stuck-turn-recovery (#1136) v2 cleanup
@@ -269,7 +273,12 @@ ALLOWLIST=(
   # last wizard editMessageText site to 11002 (past 11000). End
   # 11000 -> 11020; next raw call is well outside — same already-
   # .catch-swallowed wizard site, no new un-allowlisted call enters.
-  "telegram-plugin/gateway/gateway.ts:9340-11020:vault grant wizard ctx.api.editMessageText already has .catch swallow"
+  # Re-bumped 2026-05-20 (same-PR follow-up): the +~26-line
+  # endCurrentTurnAtomic helper insertion (~1320) drifted the last
+  # wizard editMessageText site 11002 -> 11028 (past 11020). End
+  # 11020 -> 11040; same already-.catch-swallowed wizard site, no
+  # new un-allowlisted call enters.
+  "telegram-plugin/gateway/gateway.ts:9340-11040:vault grant wizard ctx.api.editMessageText already has .catch swallow"
 
   # boot-card.ts and issues-card.ts: these MODULES receive a bot adapter
   # via DI. The gateway wires those adapters through robustApiCall (see

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -250,6 +250,7 @@ import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
 import { createInboundSpool } from './inbound-spool.js'
+import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
 import { createPendingPermissionBuffer } from './pending-permission-decisions.js'
 import {
@@ -3011,6 +3012,23 @@ silencePoke.startTimer({
     // for this chat starts a fresh turn instead of queueing forever.
     silencePoke.endTurn(fbKey)
     purgeReactionTracking(fbKey)
+    // Defense-in-depth: the fallback's purgeReactionTracking above
+    // clears the canonical statusKey(chatId, threadId) for fbKey
+    // only. activeTurnStartedAt can hold sibling entries for the
+    // SAME chat (different threads, or a `null` vs `undefined`-thread
+    // variant left over from a normal turn-end path that nulled
+    // currentTurn without invoking purgeReactionTracking — the
+    // gymbro/klanker held-mid-turn symptom, 2026-05-20). Any sibling
+    // for fbChatId is by definition stale when THIS fallback fires
+    // (the chat has been silent ≥5 min); sweep them via the same
+    // purger. Multi-chat-safe — only touches keys for fbChatId, so
+    // #1546's intentional cross-chat safety guard is preserved.
+    // See turn-state-purge.ts.
+    const fbExtraPurge = purgeStaleTurnsForChat(
+      fbChatId,
+      activeTurnStartedAt.keys(),
+      purgeReactionTracking,
+    )
     // Null `currentTurn` if it's still pointing at the wedged turn —
     // when claude eventually fires a late `turn_end` for this session
     // (or never does), the handler's `const turn = currentTurn` snapshot
@@ -3044,7 +3062,8 @@ silencePoke.startTimer({
       `chat=${fbChatId} thread=${ctx.threadId ?? '-'} silence_ms=${ctx.silenceMs} ` +
       `currentTurn_nulled=${turnMatchesFallback} ` +
       `drained_buffered=${fbRedeliver.redelivered}/${fbRedeliver.drained}` +
-      `${fbRedeliver.rebuffered > 0 ? ` rebuffered=${fbRedeliver.rebuffered}` : ''}\n`,
+      `${fbRedeliver.rebuffered > 0 ? ` rebuffered=${fbRedeliver.rebuffered}` : ''}` +
+      `${fbExtraPurge.purged.length > 0 ? ` extra_keys_purged=${fbExtraPurge.purged.length}` : ''}\n`,
     )
   },
 })

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1320,6 +1320,32 @@ function purgeReactionTracking(key: string): void {
 }
 
 /**
+ * Atomic null-and-purge for a wedged turn. Every site that ends a
+ * turn by nulling `currentTurn` MUST also clear the turn's statusKey
+ * from `activeTurnStartedAt` — else a dangling entry survives and
+ * `#1556`'s turn-gate holds every new inbound mid-turn forever
+ * (gymbro / klanker held-mid-turn symptom, 2026-05-20).
+ *
+ * Pre-this, three turn-end paths (silent-marker / turn-flush /
+ * `turn_end`) nulled `currentTurn` on code-paths whose
+ * `purgeReactionTracking` calls weren't reached on every branch,
+ * leaving sibling entries under the turn's statusKey that the
+ * silence-poke framework-fallback's `purgeReactionTracking(fbKey)`
+ * couldn't catch (different key shape). The fallback now also sweeps
+ * siblings for `fbChatId` (`turn-state-purge.ts`) as defense-in-depth,
+ * but THIS helper closes the leak at origin: null and purge are
+ * inseparable at every call site.
+ *
+ * Idempotent: a second purge is a no-op `.delete()` on a key already
+ * gone — handlers that already purge elsewhere are unharmed.
+ */
+function endCurrentTurnAtomic(turn: CurrentTurn): void {
+  if (currentTurn !== turn) return
+  currentTurn = null
+  purgeReactionTracking(statusKey(turn.sessionChatId, turn.sessionThreadId))
+}
+
+/**
  * Model-idle proactive-compaction check. Called ONLY from the
  * activeTurnStartedAt.size === 0 gate above (never mid-turn). Opt-in via
  * the resolved agent config's session.max_context_tokens; a no-op when
@@ -5705,7 +5731,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           turn.answerStream = null
         }
         // Null the atom — this turn is being abandoned.
-        if (currentTurn === turn) currentTurn = null
+        endCurrentTurnAtomic(turn)
         // #549 fix — context-exhaustion teardown also resets preamble state.
         preambleSuppressor.reset()
       }
@@ -5903,7 +5929,7 @@ function handleSessionEvent(ev: SessionEvent): void {
         // returns early at handler entry. A new `enqueue` swaps in a
         // fresh atom; the silent-turn teardown doesn't need to preserve
         // any of the prior turn's state.
-        if (currentTurn === turn) currentTurn = null
+        endCurrentTurnAtomic(turn)
         // #549 fix — silent-marker teardown drops any pending preamble.
         preambleSuppressor.dropNow()
         return
@@ -5937,7 +5963,7 @@ function handleSessionEvent(ev: SessionEvent): void {
         // sendMessage await for this turn will see currentTurn == null
         // and bail; a new enqueue will swap in a fresh atom. The
         // `backstop*` locals above hold everything the IIFE needs.
-        if (currentTurn === turn) currentTurn = null
+        endCurrentTurnAtomic(turn)
         // #549 fix — turn-flush takes ownership of the captured-text
         // backup; reset the preamble buffer (its content is already in
         // the captured `capturedText`, which turn-flush is about to send).
@@ -6209,7 +6235,7 @@ function handleSessionEvent(ev: SessionEvent): void {
       // #1067: null the atom in one assignment, replacing the seven
       // field clears the pre-refactor version did. Any late-arriving
       // event for this turn will see currentTurn == null and bail.
-      if (currentTurn === turn) currentTurn = null
+      endCurrentTurnAtomic(turn)
       // #549 fix — preamble flush already happened at the TOP of this
       // turn_end handler (before turn.answerStream is nulled). See
       // comment near line 3431.

--- a/telegram-plugin/gateway/turn-state-purge.ts
+++ b/telegram-plugin/gateway/turn-state-purge.ts
@@ -1,0 +1,71 @@
+/**
+ * turn-state-purge.ts — defense-in-depth cleanup for the silence-poke
+ * framework-fallback (gateway.ts).
+ *
+ * The fallback's `purgeReactionTracking(fbKey)` clears the canonical
+ * `statusKey(chatId, threadId)` for the exact chat+thread that armed
+ * the silence-poke. But `activeTurnStartedAt` (and its siblings) can
+ * legitimately hold MORE than one entry for the same chat — e.g.:
+ *
+ *   - a normal turn-end handler null'd `currentTurn` but skipped
+ *     `purgeReactionTracking` on a code-path that didn't reach it
+ *     (gateway.ts:5887/5921/6193 — purgeReactionTracking calls in
+ *     those handlers are conditional/not on every branch), so
+ *     `activeTurnStartedAt[oldKey]` is dangling when the fallback
+ *     fires for a NEW key
+ *   - a multi-thread chat (topic-based group, or a `null` vs
+ *     `undefined` thread variant) has entries under different keys of
+ *     the SAME chat
+ *
+ * In either case, the fallback purges `fbKey` but a sibling key for
+ * the same chat remains → `activeTurnStartedAt.size > 0` persists →
+ * `#1556`'s turn-gate holds every new inbound forever → user sees
+ * "not responding" while claude is actually idle (gymbro + klanker,
+ * 2026-05-20).
+ *
+ * This helper sweeps any sibling keys for the firing chat after the
+ * canonical `purgeReactionTracking(fbKey)`, via the same purger.
+ * Multi-chat safe: it only touches keys whose chatId matches — other
+ * chats' active turns are untouched, preserving the deliberate
+ * multi-chat safety #1546 kept.
+ *
+ * Key shape: `statusKey(chatId, threadId)` emits
+ * `${chatId}:${threadId ?? '_'}`. Chat ids are numeric strings (no
+ * `:` inside), so `indexOf(':')` is a safe prefix delimiter. A
+ * "prefix-without-separator" false positive (e.g. chatId `123` vs key
+ * `1234:_`) is structurally impossible because the helper splits on
+ * `:` and equates the prefix, NOT a string-startsWith.
+ *
+ * Pure / dependency-free so the multi-chat-safety and key-shape logic
+ * are unit-testable without standing up a gateway — mirrors the
+ * `#1544 / #1546 / #1549 / #1558` pure-seam idiom.
+ */
+
+export interface PurgeStaleTurnsResult {
+  /** Keys for `chatId` that the helper purged via the callback. */
+  purged: string[]
+}
+
+export function purgeStaleTurnsForChat(
+  chatId: string,
+  keys: Iterable<string>,
+  purger: (key: string) => void,
+): PurgeStaleTurnsResult {
+  if (!chatId) return { purged: [] }
+  const purged: string[] = []
+  // Snapshot first — `purger` typically deletes from the same Map the
+  // caller is iterating; mutating during iteration is correct on JS
+  // Maps but a snapshot makes the contract explicit and lets the
+  // helper accept any iterable.
+  const snapshot: string[] = []
+  for (const k of keys) snapshot.push(k)
+  for (const key of snapshot) {
+    const sep = key.indexOf(':')
+    if (sep < 0) continue // malformed / non-statusKey shape — skip
+    const keyChat = key.slice(0, sep)
+    if (keyChat !== chatId) continue
+    purger(key)
+    purged.push(key)
+  }
+  return { purged }
+}

--- a/telegram-plugin/tests/turn-state-purge.test.ts
+++ b/telegram-plugin/tests/turn-state-purge.test.ts
@@ -29,12 +29,12 @@ describe('purgeStaleTurnsForChat', () => {
   it('purges the canonical DM key for the firing chat (typical case)', () => {
     const purged: string[] = []
     const r = purgeStaleTurnsForChat(
-      '8248703757',
-      [statusKey('8248703757')],
+      '12345',
+      [statusKey('12345')],
       (k) => purged.push(k),
     )
-    expect(r.purged).toEqual(['8248703757:_'])
-    expect(purged).toEqual(['8248703757:_'])
+    expect(r.purged).toEqual(['12345:_'])
+    expect(purged).toEqual(['12345:_'])
   })
 
   it('purges every sibling key for the same chat (multi-thread / dangling)', () => {
@@ -43,31 +43,31 @@ describe('purgeStaleTurnsForChat', () => {
     // canonical purgeReactionTracking(fbKey).
     const purged: string[] = []
     const r = purgeStaleTurnsForChat(
-      '8248703757',
+      '12345',
       [
-        statusKey('8248703757'),       // DM, no thread
-        statusKey('8248703757', 42),    // thread 42
-        statusKey('8248703757', 99),    // thread 99
+        statusKey('12345'),       // DM, no thread
+        statusKey('12345', 42),    // thread 42
+        statusKey('12345', 99),    // thread 99
       ],
       (k) => purged.push(k),
     )
-    expect(r.purged.sort()).toEqual(['8248703757:42', '8248703757:99', '8248703757:_'])
+    expect(r.purged.sort()).toEqual(['12345:42', '12345:99', '12345:_'])
     expect(purged).toHaveLength(3)
   })
 
   it('NEVER touches keys for OTHER chats (multi-chat safety — the #1546 guard)', () => {
     const purged: string[] = []
     const r = purgeStaleTurnsForChat(
-      '8248703757',
+      '12345',
       [
-        statusKey('8248703757'),       // target chat — purge
-        statusKey('9999999999'),       // different chat — must NOT touch
-        statusKey('9999999999', 7),    // different chat thread — must NOT touch
+        statusKey('12345'),       // target chat — purge
+        statusKey('-1001234567890'),       // different chat — must NOT touch
+        statusKey('-1001234567890', 7),    // different chat thread — must NOT touch
       ],
       (k) => purged.push(k),
     )
-    expect(r.purged).toEqual(['8248703757:_'])
-    expect(purged).toEqual(['8248703757:_']) // ONLY the target chat
+    expect(r.purged).toEqual(['12345:_'])
+    expect(purged).toEqual(['12345:_']) // ONLY the target chat
   })
 
   it('does not false-match on a chatId-prefix superstring (e.g. 123 vs 1234)', () => {

--- a/telegram-plugin/tests/turn-state-purge.test.ts
+++ b/telegram-plugin/tests/turn-state-purge.test.ts
@@ -1,0 +1,109 @@
+/**
+ * turn-state-purge — the silence-poke fallback's defense-in-depth
+ * cleanup. Pins the multi-chat safety + key-shape correctness that
+ * the gymbro/klanker held-mid-turn fix (2026-05-20) depends on.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { purgeStaleTurnsForChat } from '../gateway/turn-state-purge.js'
+
+function statusKey(chatId: string, threadId?: number): string {
+  return `${chatId}:${threadId ?? '_'}`
+}
+
+describe('purgeStaleTurnsForChat', () => {
+  it('returns [] and calls nothing when keys is empty', () => {
+    let calls = 0
+    const r = purgeStaleTurnsForChat('123', [], () => calls++)
+    expect(r.purged).toEqual([])
+    expect(calls).toBe(0)
+  })
+
+  it('returns [] and calls nothing when chatId is empty (guard)', () => {
+    let calls = 0
+    const r = purgeStaleTurnsForChat('', [statusKey('123')], () => calls++)
+    expect(r.purged).toEqual([])
+    expect(calls).toBe(0)
+  })
+
+  it('purges the canonical DM key for the firing chat (typical case)', () => {
+    const purged: string[] = []
+    const r = purgeStaleTurnsForChat(
+      '8248703757',
+      [statusKey('8248703757')],
+      (k) => purged.push(k),
+    )
+    expect(r.purged).toEqual(['8248703757:_'])
+    expect(purged).toEqual(['8248703757:_'])
+  })
+
+  it('purges every sibling key for the same chat (multi-thread / dangling)', () => {
+    // This is the gymbro/klanker symptom: a stale activeTurnStartedAt
+    // entry under a different thread of the same chat survives the
+    // canonical purgeReactionTracking(fbKey).
+    const purged: string[] = []
+    const r = purgeStaleTurnsForChat(
+      '8248703757',
+      [
+        statusKey('8248703757'),       // DM, no thread
+        statusKey('8248703757', 42),    // thread 42
+        statusKey('8248703757', 99),    // thread 99
+      ],
+      (k) => purged.push(k),
+    )
+    expect(r.purged.sort()).toEqual(['8248703757:42', '8248703757:99', '8248703757:_'])
+    expect(purged).toHaveLength(3)
+  })
+
+  it('NEVER touches keys for OTHER chats (multi-chat safety — the #1546 guard)', () => {
+    const purged: string[] = []
+    const r = purgeStaleTurnsForChat(
+      '8248703757',
+      [
+        statusKey('8248703757'),       // target chat — purge
+        statusKey('9999999999'),       // different chat — must NOT touch
+        statusKey('9999999999', 7),    // different chat thread — must NOT touch
+      ],
+      (k) => purged.push(k),
+    )
+    expect(r.purged).toEqual(['8248703757:_'])
+    expect(purged).toEqual(['8248703757:_']) // ONLY the target chat
+  })
+
+  it('does not false-match on a chatId-prefix superstring (e.g. 123 vs 1234)', () => {
+    // If we used a naive startsWith on the WHOLE key, chatId "123"
+    // would falsely match key "1234:_". The helper splits on `:` and
+    // equates the chatId slice, which prevents that.
+    const purged: string[] = []
+    const r = purgeStaleTurnsForChat(
+      '123',
+      [statusKey('123'), statusKey('1234'), statusKey('12')],
+      (k) => purged.push(k),
+    )
+    expect(r.purged).toEqual(['123:_']) // ONLY the exact match
+  })
+
+  it('skips malformed keys (no `:`)', () => {
+    let calls = 0
+    const r = purgeStaleTurnsForChat(
+      '123',
+      ['malformed', '', 'no-colon-here', statusKey('123')],
+      () => calls++,
+    )
+    expect(r.purged).toEqual(['123:_'])
+    expect(calls).toBe(1)
+  })
+
+  it('accepts any iterable (snapshots before iteration — purger may delete)', () => {
+    // The real call site iterates `activeTurnStartedAt.keys()` and
+    // the purger deletes from that same Map. Snapshotting in the
+    // helper prevents iterator skew.
+    const map = new Map<string, number>()
+    map.set('123:_', 1)
+    map.set('123:7', 2)
+    map.set('999:_', 3)
+    const r = purgeStaleTurnsForChat('123', map.keys(), (k) => map.delete(k))
+    expect(r.purged.sort()).toEqual(['123:7', '123:_'])
+    expect([...map.keys()]).toEqual(['999:_']) // multi-chat safety preserved
+  })
+})


### PR DESCRIPTION
## Symptom (live on gymbro + klanker, 2026-05-20)

Every user message stuck in #1556's mid-turn hold forever, claude actually idle. Gateway log:

```
silence-poke framework-fallback ended wedged turn ...
  currentTurn_nulled=false drained_buffered=0/2 rebuffered=2
...
inbound held mid-turn agent=gymbro chat=8248703757 msg=2001 — will flush on turn-complete
```

The fallback ran, but `activeTurnStartedAt.size > 0` persisted afterwards → #1556's turn-gate kept buffering. (#1558's bounded escalation IS firing — the 15-min "couldn't deliver — resend" card lands — but the underlying wedge stayed stuck.)

## Root cause

The fallback's `purgeReactionTracking(fbKey)` clears **exactly one** `statusKey(chatId, threadId)` entry. `activeTurnStartedAt` can hold *sibling* entries for the same chat under a different statusKey:

- A normal turn-end handler (gateway.ts:5887/5921/6193) nulled `currentTurn` on a code-path that didn't reach its `purgeReactionTracking` call → dangling entry under the prior key.
- `null` vs `undefined` thread variant, or a multi-thread chat, keys to a different statusKey than the fallback's fbKey.

Either way: the sibling survives, `activeTurnStartedAt.size > 0` persists, the wedge looks permanent. #1546's `redeliverBufferedInbound` runs but `send` returns false because the gateway's turn-state view is still wedged.

## Fix

Defense-in-depth — after `purgeReactionTracking(fbKey)`, sweep `activeTurnStartedAt.keys()` for any key whose chatId matches `fbChatId` and purge those via the same callback. Any sibling for fbChat is by definition stale when this fallback fires (≥5 min silent). **Multi-chat-safe**: only touches keys for `fbChatId` — #1546's intentional cross-chat safety guard for other agents/chats is preserved verbatim. Log gains `extra_keys_purged=<n>` so this case is visible in prod.

Extracted as the pure helper `purgeStaleTurnsForChat` (mirrors #1544 / #1546 / #1549 / #1558 idiom). The currentTurn-null tuple-match guard is **left intentionally untouched** — it's #1546's deliberate cross-chat safety; relaxing it isn't needed to fix this symptom (the gate is `activeTurnStartedAt.size`, not `currentTurn !== null`).

JTBD: *always-on* — "not responding while claude is idle" is the worst-of-both UX.

## Test plan

- [x] `vitest turn-state-purge.test.ts` — 8 cases: empty / empty-chatId / canonical DM / multi-thread same chat / **multi-chat safety (other chats untouched, the #1546 invariant)** / **chatId-prefix-superstring safety (`123` vs `1234` does NOT false-match)** / malformed-key skip / snapshot-during-mutation
- [x] `vitest silence-poke.test.ts` green (52) — unchanged path
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping` clean (2 ranges widened per protocol)
- [ ] Post-merge: NO release/rollout yet — vault is locked on this fleet, deploys are blocked until vault is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)