### PR TITLE
chore: release v0.12.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## v0.12.20 — fix: held-mid-turn wedge closed at both source and recovery; vault-broker operator-unlock + backups
+
+Two headlines. (a) Gateway: the gymbro/klanker "agent receives the
+message, acknowledges with a reaction, then never replies" wedge is
+fully closed — the silence-poke framework fallback now sweeps sibling
+`activeTurnStartedAt` entries for the firing chat (recovery), AND
+every site that nulls `currentTurn` now atomically purges the turn's
+statusKey (source). #1556's turn-gate can no longer stay stuck on a
+dangling sibling key while claude is idle. (b) Vault: the broker's
+operator-unlock path now bypasses peercred (closes the RFC-J Phase-3
+gap surfaced during the vault-forensics window), and a new
+`switchroom vault backup` verb writes dated, encrypted, versioned
+snapshots so a vault rewrite is no longer single-copy-fatal.
+
+### Changes
+
+#### Features
+
+- **feat(vault):** `switchroom vault backup` — operator-run command
+  that writes dated, encrypted, versioned snapshots of the vault to a
+  configurable destination, so a single-copy loss (rewrite, accidental
+  reinit) is no longer fatal to vault state. (#1562)
+
+#### Fixes
+
+- **fix(gateway):** held-mid-turn wedge closed at both layers.
+  (a) The silence-poke framework fallback now sweeps any
+  `activeTurnStartedAt` sibling key for the firing chat (new pure
+  `purgeStaleTurnsForChat` helper) — catches any dangling state from
+  whichever path leaked it. Multi-chat safe: only touches keys for
+  `fbChatId`, preserving #1546's cross-chat guard. (b) All four
+  turn-end paths (context-exhaust / silent-marker / turn-flush /
+  `turn_end`) now call a new `endCurrentTurnAtomic(turn)` helper that
+  pairs `currentTurn = null` with
+  `purgeReactionTracking(statusKey(turn.sessionChatId,
+  turn.sessionThreadId))` — null and purge are inseparable at the
+  source, so siblings can't leak through to begin with. The fallback's
+  multi-chat-safe null guard is untouched. Symptom (gymbro/klanker
+  2026-05-20): `currentTurn_nulled=false drained_buffered=0/N
+  rebuffered=N` followed by every subsequent inbound stuck in `inbound
+  held mid-turn`. (#1564)
+- **fix(vault-broker):** bypass peercred on the operator-unlock path —
+  closes a Phase-3 gap from RFC-J where an unlock invoked via the
+  operator socket could fail the peercred check that's only meaningful
+  for per-agent sockets. (#1561)
+- **fix(test-hermeticity):** regression-proof gate against the
+  `os.homedir()` trap so vault-related tests can no longer leak into
+  the real `~/.switchroom` instead of a tmpdir. (#1560)
+- **test:** de-flake `timezone-hook.test.ts` (CI shard timeout under
+  load). (#1563)
+
 ## v0.12.19 — feat: "your message is queued" now survives a restart (durable inbound spool)
 
 Headline: the gateway's "⏳ your message is queued and will be

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.12.19",
+  "version": "0.12.20",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release **v0.12.20** — 5 commits since v0.12.19 (`5f6810ed`).

**Headliners:**
- **(gateway)** **gymbro/klanker held-mid-turn wedge closed at BOTH source and recovery** (#1564). Two layers: atomic `endCurrentTurnAtomic(turn)` at every turn-end site so `currentTurn = null` and `purgeReactionTracking(statusKey)` are inseparable (source); silence-poke fallback now sweeps sibling `activeTurnStartedAt` keys for the firing chat (recovery). Multi-chat safety preserved at both layers.
- **(vault)** broker operator-unlock peercred bypass (#1561 — closes RFC-J Phase-3 gap surfaced by the vault-forensics window) + new `switchroom vault backup` verb for dated/encrypted/versioned snapshots so a single-copy loss is no longer fatal (#1562).

Plus #1560 (test-hermeticity gate against the `os.homedir()` trap) and #1563 (timezone-hook flake fix).

Two-file release commit (`package.json` 0.12.19→0.12.20 + `CHANGELOG.md`, full triage of all 5).

## Test plan

- [x] CHANGELOG triaged against `5f6810ed..upstream/main` (exactly #1560, #1561, #1562, #1563, #1564)
- [x] Two-file release-commit shape
- [ ] CI green → auto-merge
- [ ] Post-merge: npm publish (+ tarball verify) + wait for v0.12.20 image before staggered rollout (avoid `:latest` pull-race); verify held-mid-turn fix live on the previously-stuck agents (`drained_buffered=0/N rebuffered=N` should now also show `extra_keys_purged=N` when it happens at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)