### PR TITLE
docs(vision): re-anchor on the standing-team thesis

### DIFF
--- a/reference/vision.md
+++ b/reference/vision.md
@@ -4,7 +4,7 @@ source: switchroom.ai (canonical), README.md, reference/*.md JTBDs
 audience: anyone deciding whether a feature, PR, or release belongs in switchroom
 ---
 
-# Switchroom — product vision
+# Switchroom: product vision
 
 > **A switchboard for your Pro or Max.**
 > Your standing team. Specialists who remember you, own their patch,
@@ -58,7 +58,7 @@ use case worth loving, made to work the way it should.
 Every feature should serve one of these. If it doesn't, it doesn't
 belong.
 
-### 1. A standing team that knows you — *specialists, not one generalist*
+### 1. A standing team that knows you: *specialists, not one generalist*
 
 The headline. One bot per specialist, each a real `claude` session
 with its own SOUL.md (who it is), CLAUDE.md (what it does), memory,
@@ -76,7 +76,7 @@ point.* Switchroom gives each specialist its own semantic memory bank
 and keeps it from fighting Claude's native memory. That is a sound
 fit, not a differentiator.
 
-### 2. You hold the leash — *controlled, purposeful, never roaming*
+### 2. You hold the leash: *controlled, purposeful, never roaming*
 
 The substantive one. Agents act, but only with what you gave them. An
 approval kernel and per-agent ACLs mean a specialist sees only the
@@ -89,7 +89,7 @@ And you are never in the dark, the state is always legible in plain
 words, and you can steer or stop a turn mid-flight. Awareness and
 control, not a tool-call log to supervise.
 
-### 3. Subscription-honest and predictable — *the plan is the ceiling*
+### 3. Subscription-honest and predictable: *the plan is the ceiling*
 
 Each agent runs the unmodified `claude` binary, authenticated directly
 with Anthropic over the same OAuth as the desktop app. No Agent SDK,
@@ -99,7 +99,7 @@ you chose, not a meter you can't forecast. Need more capacity, pool
 several accounts with automatic failover. One bill. The one you
 already pay.
 
-### 4. Always available, in Telegram, done properly — *there when you want it*
+### 4. Always available, in Telegram, done properly: *there when you want it*
 
 Each specialist is a long-running service. It survives reboots,
 network drops, and your laptop closing. It does its regular scheduled
@@ -114,12 +114,12 @@ multi-channel bridge.
 
 Two different people, do not conflate them:
 
-- **The principal** — the person the team serves. Could be you in
+- **The principal.** The person the team serves. Could be you in
   non-coding mode, could be someone non-technical in your house. They
   never see a server. They text an assistant that knows them, gets
   things done, and checks before anything that matters. The bar: one
   even a non-technical partner likes working with.
-- **The operator** — the person who stands it up. Comfortable with a
+- **The operator.** The person who stands it up. Comfortable with a
   Linux box, YAML, and an OAuth flow. Runs it once, then mostly lives
   as a principal too.
 
@@ -162,9 +162,9 @@ messages, the status the principal sees, the setup wizard.
 This document is the *what* and *why*. Two sibling documents turn it
 into a verdict on any specific PR or design:
 
-- **`reference/principles.md`** — the three load-bearing standards
+- **`reference/principles.md`** carries the three load-bearing standards
   (docs / defaults / consistency) every change is checked against.
-- **`reference/*.md` JTBDs** — outcome-focused jobs the product must
+- **`reference/*.md` JTBDs** are the outcome-focused jobs the product must
   do. Each maps to one of the four outcomes above.
 
 A feature lands when it (a) advances one of the four outcomes,

--- a/reference/vision.md
+++ b/reference/vision.md
@@ -7,19 +7,22 @@ audience: anyone deciding whether a feature, PR, or release belongs in switchroo
 # Switchroom — product vision
 
 > **A switchboard for your Pro or Max.**
-> Opinionated Telegram UX for Claude Code, on the subscription you
-> already pay for.
+> Your standing team. Specialists who remember you, own their patch,
+> and act, while you get on with life.
 
-Switchroom turns your Claude Pro or Max subscription into a fleet of
-always-on specialist agents you talk to from Telegram. One box you
-already own, one Telegram forum, one bot per agent, every session
-officially authenticated through the same OAuth flow you use on the
-desktop. No API keys. No harness. No second invoice.
+Switchroom turns your Claude Pro or Max subscription into a small team
+of always-on specialist assistants you talk to from Telegram. One box
+you already own, one Telegram forum, one bot per specialist. Each is a
+real person to you: it has a name, a job it owns, a memory of you that
+builds over time, and the tools and skills to actually do the work. You
+text it like you would text a competent assistant. It does the thing,
+and it asks you first on anything that matters.
 
-It is **not** a general-purpose LLM orchestrator, **not** a multi-channel
-bridge, **not** a hosted service, **not** multi-tenant. It does one
-thing: makes Telegram the best possible interaction surface for Claude
-Code. Unashamedly.
+It is **not** a general-purpose LLM orchestrator, **not** a
+multi-channel bridge, **not** a hosted service, **not** multi-tenant,
+and **not** an autonomous agent that roams on its own. It is the
+opinionated version of one idea, done properly: a personal team that
+lives in Telegram and stays on your leash.
 
 ---
 
@@ -28,17 +31,25 @@ Code. Unashamedly.
 > *"I loved OpenClaw + Telegram. I wanted my Claude subscription. And
 > the UX done properly. So I built this."*
 
-Two existing options, two failures:
+The use case came from OpenClaw. Always-on assistants you talk to in a
+chat app, each with a personality and a job, was a genuinely good idea
+and OpenClaw is where it clicked. Three things kept it from being the
+thing actually needed, and nothing else had fixed them:
 
-- **OpenClaw + Telegram** — great UX, but it pings the Anthropic API on
-  your own key. You signed up for "use your subscription," not "buy
-  API credits on top of your subscription."
-- **Claude Code's built-in Telegram channel** — uses the subscription
-  correctly, but it's an MVP black box. Send a message, wait, eventually
-  something comes back. What did the agent actually do? No idea.
+- **Run it on the subscription, properly.** It should use the Claude
+  Pro or Max plan already paid for, the same OAuth as the desktop app,
+  compliant with Anthropic's third-party policy, and cost a predictable
+  amount. Not an API meter. Not a second invoice.
+- **Stay on the leash.** Assistants given broad standing access will,
+  trying to be helpful, eventually do something expensive or
+  irreversible. Access to credentials, tools, and skills has to be
+  granted deliberately and approved by a human, with no way for the
+  agent to route around it.
+- **Telegram, done properly.** Not a bridge spread thin across Slack,
+  Discord, WhatsApp, and Teams. One channel, opinionated, excellent.
 
-Switchroom is the third option: subscription-honest *and* the UX done
-properly.
+So this got built. It is not pitched as a moat. It is the version of a
+use case worth loving, made to work the way it should.
 
 ---
 
@@ -47,69 +58,73 @@ properly.
 Every feature should serve one of these. If it doesn't, it doesn't
 belong.
 
-### 1. Visibility — *see every step, pinned to the chat*
+### 1. A standing team that knows you — *specialists, not one generalist*
 
-The headline UX. Every time an agent starts work, a **progress card**
-pins into its Telegram topic and updates in place as tools execute.
-Each Read, Bash, Edit, Grep is visible as it happens, with elapsed
-time so you can tell if something's stuck. Sub-agent work surfaces in
-the same card. When the agent finishes, the card flips to Done and
-unpins.
+The headline. One bot per specialist, each a real `claude` session
+with its own SOUL.md (who it is), CLAUDE.md (what it does), memory,
+skills, tools, and credentials. `clerk`, the canonical example, is a
+chief of staff: it handles the calendar, watches the health data,
+fields the household requests, and answers in one voice because it
+knows you across all of it. A coding specialist is the same thesis,
+not an exception: it remembers why the product made the choices it
+did, so its pushback on a half-formed idea from the train is
+load-bearing, not just syntactically valid. You add a specialist by
+editing ten lines of YAML, not by forking the product.
 
-No silent gaps. No ghosts. No squinting into a black box.
+*Memory is an implementation detail in service of this, not a selling
+point.* Switchroom gives each specialist its own semantic memory bank
+and keeps it from fighting Claude's native memory. That is a sound
+fit, not a differentiator.
 
-### 2. Multi-agent fleet — *specialists, not one generalist*
+### 2. You hold the leash — *controlled, purposeful, never roaming*
 
-One bot per agent. Each agent is a real `claude --channels` session
-with its own SOUL.md (who it is), CLAUDE.md (what it does), memory
-collection, skills, tools, and OAuth credentials. A health coach is
-not the same process as an executive assistant is not the same process
-as a coding agent. You add a new specialist by editing ten lines of
-YAML, not by forking the product.
+The substantive one. Agents act, but only with what you gave them. An
+approval kernel and per-agent ACLs mean a specialist sees only the
+credentials and tools you granted it. It can ask for more when more
+would help, you get an Allow or Deny card in Telegram, and only your
+tap grants it. It cannot self-elevate or work around you. There are
+deliberately **no heartbeats**: agents are at beck and call and run
+the explicit scheduled tasks you set, they do not loop autonomously.
+And you are never in the dark, the state is always legible in plain
+words, and you can steer or stop a turn mid-flight. Awareness and
+control, not a tool-call log to supervise.
 
-Sub-agents (Opus plans, Sonnet implements) compose inside each
-specialist without leaving the topic.
+### 3. Subscription-honest and predictable — *the plan is the ceiling*
 
-### 3. Subscription-honest — *your Pro or Max is the ceiling*
+Each agent runs the unmodified `claude` binary, authenticated directly
+with Anthropic over the same OAuth as the desktop app. No Agent SDK,
+no API-key routing, no credential interception, compliant with
+Anthropic's April 2026 third-party policy. Cost is the subscription
+you chose, not a meter you can't forecast. Need more capacity, pool
+several accounts with automatic failover. One bill. The one you
+already pay.
 
-> *"Not a harness. Doesn't patch the CLI, doesn't intercept the
-> protocol, doesn't forge tokens."*
+### 4. Always available, in Telegram, done properly — *there when you want it*
 
-Switchroom is scaffolding and lifecycle management. It creates
-directories, stands up a long-running service per agent, manages
-OAuth, routes Telegram messages, and gets out of the way. Each agent
-runs the unmodified `claude` binary, authenticated directly with
-Anthropic. No Agent SDK, no API-key routing, no credential
-interception. Fully compliant with Anthropic's April 2026 third-party
-policy.
-
-One bill. The one you already pay.
-
-### 4. Always-on — *runs while you sleep or work offline*
-
-Each agent is a long-running service. They survive reboots, network
-drops, and your laptop closing. Scheduled tasks fire across reboots.
-Token refresh runs unattended for weeks. Crashed agents auto-recover
-with an audit trail. The fleet comes back on its own after a cold
-boot.
-
-Telegram IS the mobile interface. Anywhere your phone has signal, your
-fleet is reachable.
+Each specialist is a long-running service. It survives reboots,
+network drops, and your laptop closing. It does its regular scheduled
+work and is there the moment you reach for it, from anywhere your
+phone has signal. Available and punctual, not autonomous. Telegram is
+the interface, opinionated and singular on purpose, not one tab of a
+multi-channel bridge.
 
 ---
 
 ## Who it's for
 
-- **Solo developers** who want Claude in Telegram across devices,
-  without giving up their subscription.
-- **Home-lab operators** comfortable with YAML and a box they already
-  own.
-- **Founder-operators** running a personal fleet of specialists —
-  health coach, executive assistant, coding agent, research agent —
-  each with its own persona and persistent memory.
+Two different people, do not conflate them:
 
-Built for people who already run things themselves. Configuration over
-code. Transparency over abstraction.
+- **The principal** — the person the team serves. Could be you in
+  non-coding mode, could be someone non-technical in your house. They
+  never see a server. They text an assistant that knows them, gets
+  things done, and checks before anything that matters. The bar: one
+  even a non-technical partner likes working with.
+- **The operator** — the person who stands it up. Comfortable with a
+  Linux box, YAML, and an OAuth flow. Runs it once, then mostly lives
+  as a principal too.
+
+Technical to stand up. Human to live with. Both halves stay honest;
+neither is hidden behind the other.
 
 ---
 
@@ -120,23 +135,25 @@ code. Transparency over abstraction.
 | A harness or wrapper | Switchroom never intercepts auth or inference. The `claude` CLI is the runtime. |
 | A multi-provider orchestrator | We don't care about OpenAI, Gemini, Llama, or model swapping. |
 | A multi-channel bridge | Not Slack, not Discord, not Teams. Telegram, done properly. |
+| An autonomous agent | No heartbeats. Beck-and-call plus explicit schedules, on your leash. |
 | Multi-tenant | Single-operator by design. |
 | A hosted service | Self-hosted only. Your box, your tokens, your data. |
-| A mobile app | Telegram IS the mobile app. |
+| A mobile app | Telegram is the mobile app. |
 
 ---
 
 ## Voice and tone
 
-Technical, direct, opinionated. Speaks to builders with agency.
-Casual punctuation, assumes infrastructure literacy. Emphasises what
-the product *doesn't* do as much as what it does — because the
-absences (no harness, no API key, no fork) are the differentiation.
+Plain, direct, opinionated. It should read like one person built it,
+because one person did, not like a committee shipped a kit. Lead with
+what it feels like to have the team, not with the machinery. Keep the
+operator and trust details honest and present, never buried, never
+dressed up. No corporate filler, no hype, no em dashes. Emphasise what
+the product deliberately does *not* do, no API key, no harness, no
+heartbeat, no second channel, because the restraint is the point.
 
-This voice carries into the product surface: CLI output, error
-messages, progress cards, setup wizard. Switchroom should sound like
-one person built it (because one person did) — not like a committee
-shipped a kit.
+This voice carries into every product surface: CLI output, error
+messages, the status the principal sees, the setup wizard.
 
 ---
 
@@ -148,9 +165,7 @@ into a verdict on any specific PR or design:
 - **`reference/principles.md`** — the three load-bearing standards
   (docs / defaults / consistency) every change is checked against.
 - **`reference/*.md` JTBDs** — outcome-focused jobs the product must
-  do (e.g. `know-what-my-agent-is-doing`, `survive-reboots-and-real-life`,
-  `keep-my-subscription-honest`). Each maps to one of the four
-  outcomes above.
+  do. Each maps to one of the four outcomes above.
 
 A feature lands when it (a) advances one of the four outcomes,
 (b) satisfies its JTBD, and (c) passes all three principle checks.

--- a/reference/vision.md
+++ b/reference/vision.md
@@ -10,19 +10,16 @@ audience: anyone deciding whether a feature, PR, or release belongs in switchroo
 > Your standing team. Specialists who remember you, own their patch,
 > and act, while you get on with life.
 
-Switchroom turns your Claude Pro or Max subscription into a small team
-of always-on specialist assistants you talk to from Telegram. One box
-you already own, one Telegram forum, one bot per specialist. Each is a
-real person to you: it has a name, a job it owns, a memory of you that
-builds over time, and the tools and skills to actually do the work. You
-text it like you would text a competent assistant. It does the thing,
-and it asks you first on anything that matters.
+Your Claude subscription becomes a small team of always-on assistants
+you text from Telegram. One box you own. One bot per specialist. Each
+has a name, a job it owns, a memory of you, and the tools to do the
+work. You text it like you'd text a good assistant. It does the thing.
+It asks first on anything that matters.
 
-It is **not** a general-purpose LLM orchestrator, **not** a
-multi-channel bridge, **not** a hosted service, **not** multi-tenant,
-and **not** an autonomous agent that roams on its own. It is the
-opinionated version of one idea, done properly: a personal team that
-lives in Telegram and stays on your leash.
+Not a general-purpose orchestrator. Not a multi-channel bridge. Not a
+hosted service. Not multi-tenant. Not an agent that roams on its own.
+One idea, done properly: a personal team that lives in Telegram and
+stays on your leash.
 
 ---
 
@@ -31,100 +28,83 @@ lives in Telegram and stays on your leash.
 > *"I loved OpenClaw + Telegram. I wanted my Claude subscription. And
 > the UX done properly. So I built this."*
 
-The use case came from OpenClaw. Always-on assistants you talk to in a
-chat app, each with a personality and a job, was a genuinely good idea
-and OpenClaw is where it clicked. Three things kept it from being the
-thing actually needed, and nothing else had fixed them:
+The use case came from OpenClaw. Always-on assistants in a chat app,
+each with a personality and a job. Good idea. Three things stopped it
+being the one I needed, and nothing else fixed them:
 
-- **Run it on the subscription, properly.** It should use the Claude
-  Pro or Max plan already paid for, the same OAuth as the desktop app,
-  compliant with Anthropic's third-party policy, and cost a predictable
-  amount. Not an API meter. Not a second invoice.
-- **Stay on the leash.** Assistants given broad standing access will,
-  trying to be helpful, eventually do something expensive or
-  irreversible. Access to credentials, tools, and skills has to be
-  granted deliberately and approved by a human, with no way for the
-  agent to route around it.
+- **On the subscription, properly.** The Claude plan I already pay for,
+  the same OAuth as the desktop. Compliant. Predictable cost. Not an
+  API meter. Not a second invoice.
+- **On the leash.** Give an assistant broad standing access and one day
+  it helpfully does something irreversible. Credentials, tools, skills:
+  granted deliberately, approved by a human, no way around it.
 - **Telegram, done properly.** Not a bridge spread thin across Slack,
-  Discord, WhatsApp, and Teams. One channel, opinionated, excellent.
+  Discord, Teams. One channel. Opinionated. Excellent.
 
-So this got built. It is not pitched as a moat. It is the version of a
-use case worth loving, made to work the way it should.
+So I built it.
 
 ---
 
 ## The four outcomes
 
-Every feature should serve one of these. If it doesn't, it doesn't
-belong.
+Every feature serves one of these. If it doesn't, it doesn't belong.
 
 ### 1. A standing team that knows you: *specialists, not one generalist*
 
-The headline. One bot per specialist, each a real `claude` session
-with its own SOUL.md (who it is), CLAUDE.md (what it does), memory,
-skills, tools, and credentials. `clerk`, the canonical example, is a
-chief of staff: it handles the calendar, watches the health data,
-fields the household requests, and answers in one voice because it
-knows you across all of it. A coding specialist is the same thesis,
-not an exception: it remembers why the product made the choices it
-did, so its pushback on a half-formed idea from the train is
-load-bearing, not just syntactically valid. You add a specialist by
-editing ten lines of YAML, not by forking the product.
+The headline. One bot per specialist. Each its own persona, memory,
+skills, tools, credentials. `clerk` is the canonical one: a chief of
+staff that runs the calendar, watches the health data, fields the
+household asks, all in one voice, because it knows you across all of
+it. The coding specialist is the same thesis, not an exception. It
+remembers why the product is the way it is, so its pushback on a
+half-formed idea from the train is worth something. Add a specialist
+in ten lines of YAML. You don't fork the product.
 
-*Memory is an implementation detail in service of this, not a selling
-point.* Switchroom gives each specialist its own semantic memory bank
-and keeps it from fighting Claude's native memory. That is a sound
-fit, not a differentiator.
+Memory serves this. It isn't the pitch.
 
 ### 2. You hold the leash: *controlled, purposeful, never roaming*
 
-The substantive one. Agents act, but only with what you gave them. An
-approval kernel and per-agent ACLs mean a specialist sees only the
-credentials and tools you granted it. It can ask for more when more
-would help, you get an Allow or Deny card in Telegram, and only your
-tap grants it. It cannot self-elevate or work around you. There are
-deliberately **no heartbeats**: agents are at beck and call and run
-the explicit scheduled tasks you set, they do not loop autonomously.
-And you are never in the dark, the state is always legible in plain
-words, and you can steer or stop a turn mid-flight. Awareness and
-control, not a tool-call log to supervise.
+The substantive one. Agents act, but only with what you gave them. A
+specialist sees only the credentials and tools you granted it. It can
+ask for more. You get an Allow or Deny card in Telegram. Only your tap
+grants it. It can't self-elevate or route around you. No heartbeats:
+beck-and-call plus the explicit schedules you set, never a loop of its
+own. You're never in the dark, the state reads in plain words, and you
+can steer or stop a turn mid-flight. Awareness and control. Not a
+tool-call log to babysit.
 
 ### 3. Subscription-honest and predictable: *the plan is the ceiling*
 
-Each agent runs the unmodified `claude` binary, authenticated directly
-with Anthropic over the same OAuth as the desktop app. No Agent SDK,
-no API-key routing, no credential interception, compliant with
-Anthropic's April 2026 third-party policy. Cost is the subscription
-you chose, not a meter you can't forecast. Need more capacity, pool
-several accounts with automatic failover. One bill. The one you
-already pay.
+Every agent runs the unmodified `claude` binary, OAuth straight to
+Anthropic, the same flow as the desktop. No Agent SDK. No API-key
+routing. No credential interception. Compliant with Anthropic's April
+2026 third-party policy. Cost is the subscription you chose, not a
+meter you can't forecast. Need more throughput, pool accounts with
+automatic failover. One bill. The one you already pay.
 
 ### 4. Always available, in Telegram, done properly: *there when you want it*
 
 Each specialist is a long-running service. It survives reboots,
-network drops, and your laptop closing. It does its regular scheduled
-work and is there the moment you reach for it, from anywhere your
-phone has signal. Available and punctual, not autonomous. Telegram is
-the interface, opinionated and singular on purpose, not one tab of a
-multi-channel bridge.
+network drops, your laptop closing. It runs its scheduled work and
+it's there the second you reach for it, anywhere your phone has
+signal. Available and punctual. Not autonomous. Telegram is the
+interface, singular on purpose, not one tab of a bridge.
 
 ---
 
 ## Who it's for
 
-Two different people, do not conflate them:
+Two people. Don't conflate them.
 
-- **The principal.** The person the team serves. Could be you in
-  non-coding mode, could be someone non-technical in your house. They
-  never see a server. They text an assistant that knows them, gets
-  things done, and checks before anything that matters. The bar: one
-  even a non-technical partner likes working with.
-- **The operator.** The person who stands it up. Comfortable with a
-  Linux box, YAML, and an OAuth flow. Runs it once, then mostly lives
-  as a principal too.
+- **The principal.** The person the team serves. You in non-coding
+  mode, or someone non-technical in your house. Never sees a server.
+  Texts an assistant that knows them and checks before anything that
+  matters. The bar: one even a non-technical partner likes.
+- **The operator.** Stands it up. Fine with a Linux box, YAML, an
+  OAuth flow. Runs it once, then mostly lives as a principal too.
 
-Technical to stand up. Human to live with. Both halves stay honest;
-neither is hidden behind the other.
+Technical to stand up. Human to live with. Both halves honest. Neither
+hidden.
 
 ---
 
@@ -133,7 +113,7 @@ neither is hidden behind the other.
 | Not… | Because… |
 |---|---|
 | A harness or wrapper | Switchroom never intercepts auth or inference. The `claude` CLI is the runtime. |
-| A multi-provider orchestrator | We don't care about OpenAI, Gemini, Llama, or model swapping. |
+| A multi-provider orchestrator | No OpenAI, Gemini, Llama, model swapping. |
 | A multi-channel bridge | Not Slack, not Discord, not Teams. Telegram, done properly. |
 | An autonomous agent | No heartbeats. Beck-and-call plus explicit schedules, on your leash. |
 | Multi-tenant | Single-operator by design. |
@@ -144,29 +124,28 @@ neither is hidden behind the other.
 
 ## Voice and tone
 
-Plain, direct, opinionated. It should read like one person built it,
-because one person did, not like a committee shipped a kit. Lead with
-what it feels like to have the team, not with the machinery. Keep the
-operator and trust details honest and present, never buried, never
-dressed up. No corporate filler, no hype, no em dashes. Emphasise what
-the product deliberately does *not* do, no API key, no harness, no
-heartbeat, no second channel, because the restraint is the point.
+Plain, direct, opinionated. Reads like one person built it, because
+one did. Lead with what it feels like to have the team, not the
+machinery. Operator and trust details stay honest and present, never
+buried, never dressed up. No filler. No hype. No em dashes. Say what
+it deliberately doesn't do, no API key, no harness, no heartbeat, no
+second channel. The restraint is the point.
 
-This voice carries into every product surface: CLI output, error
-messages, the status the principal sees, the setup wizard.
+Carries into every surface: CLI output, errors, the status the
+principal sees, the setup wizard.
 
 ---
 
 ## How vision becomes verdict
 
-This document is the *what* and *why*. Two sibling documents turn it
-into a verdict on any specific PR or design:
+The *what* and *why*. Two sibling docs turn it into a verdict on a
+specific PR or design:
 
-- **`reference/principles.md`** carries the three load-bearing standards
-  (docs / defaults / consistency) every change is checked against.
-- **`reference/*.md` JTBDs** are the outcome-focused jobs the product must
-  do. Each maps to one of the four outcomes above.
+- **`reference/principles.md`** carries the three standards (docs /
+  defaults / consistency) every change is checked against.
+- **`reference/*.md` JTBDs** are the outcome-focused jobs. Each maps
+  to one of the four outcomes above.
 
 A feature lands when it (a) advances one of the four outcomes,
-(b) satisfies its JTBD, and (c) passes all three principle checks.
+(b) satisfies its JTBD, (c) passes all three principle checks.
 Anything else is out of scope, however clever.


### PR DESCRIPTION
## Summary

Re-anchors `reference/vision.md` per the 2026-05-19/20 product steer.

- **Spine:** *"Your standing team. Specialists who remember you, own their patch, and act, while you get on with life."*
- **Why it exists:** OpenClaw is the inspiration, not the villain. Honest three-driver origin: subscription/compliance, you-hold-the-leash (kernel + ACL), Telegram done properly. No moat language.
- **Four outcomes re-pointed** (same count, verdict rule intact): 1) a standing team that knows you, 2) you hold the leash (kernel + ACL, no heartbeats, awareness not a tool-call log), 3) subscription-honest and predictable, 4) always available in Telegram done properly. Pinned-progress-card "Visibility" framing retired; memory demoted to implementation detail.
- **`clerk`** = canonical cross-domain example; the coding personality is the same thesis, not a carve-out.
- **Who it's for** split into principal vs operator (technical to stand up, human to live with).
- **Voice section** rewritten off "speaks to builders with infra literacy".
- Tightened ~30% on a second pass. Zero em dashes.

## Open follow-ups (deliberately not in this PR)

1. **Cascade consistency relabel.** `reference/README.md` JTBD group headings (`### Visibility`, `### Multi-agent fleet`, `### Always-on`) and `CLAUDE.md`'s "four outcomes" verdict-rule wording still cite the old outcome names. They need a matching relabel pass to stay consistent with this vision; the JTBDs themselves map 1:1 to the new four.
2. **`ken-voice` skill pass.** The current draft has NOT been through `~/.switchroom-config/skills/ken-voice/references/{patterns.md,evals.md}` (50+ patterns / 11-check scoring guide with "would Ken actually say this aloud?" as the killshot). One more rigorous voice pass is warranted before merge.
3. **README + diagrams cascade.** Hero, "See it work" example, headline diagram, and the FAQ in the merged README (PR #1540) currently reflect the *old* visibility-as-headline framing. They will need a follow-up pass to match this vision once it lands.

Context for the next agent: full re-anchor history + corrections (including the moat-hunting Ken explicitly called off, and the corrected honest read of Hindsight as implementation not differentiator) are captured in memory at `~/.claude/projects/-home-kenthompson-code-switchroom/memory/project_vision_reanchor_human_assistants.md`.

## Test plan

- [ ] Read on GitHub; verify the voice and structure.
- [ ] Run draft through `ken-voice` scoring guide (10/11 threshold; aloud test).
- [ ] Decide if the cascade relabel lands in this PR or a sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)