### PR TITLE
fix(gateway): canonicalize chat-key derivation to close #1564 sibling-key class

### DIFF
--- a/telegram-plugin/gateway/chat-key.ts
+++ b/telegram-plugin/gateway/chat-key.ts
@@ -1,0 +1,67 @@
+/**
+ * Canonical chat-key construction with branded type.
+ *
+ * The gateway tracks per-chat state (active turn, draft stream, status
+ * reactions, progress throttle, etc.) in `Map<string, ...>` instances
+ * keyed by a string derived from `(chatId, threadId | null)`. Multiple
+ * callsites historically constructed those keys inline as
+ * `` `${chatId}:${threadId ?? '_'}` ``. That worked until PR #1564 hit
+ * the silence-poke wedge: an `activeTurnStartedAt` entry survived a
+ * turn-end because the entry was set under one rendering of the key
+ * (`null` thread → `_`) and the cleanup ran against another
+ * (`undefined` thread → `_`, but also `0` thread → `0`, which doesn't
+ * coalesce). The fallback's `purgeReactionTracking` cleared one
+ * statusKey at a time; sibling keys for the same chat persisted, so
+ * `activeTurnStartedAt.size > 0` stayed true forever and every
+ * subsequent inbound was held mid-turn.
+ *
+ * This module makes the bug class hard to reintroduce:
+ *
+ *   1. `chatKey()` is the canonical constructor for "this chat+thread"
+ *      keys. It collapses `null`, `undefined`, and `0` thread IDs
+ *      into the same token (`_`). All sites in `gateway.ts`,
+ *      `stream-reply-handler.ts`, and `pty-partial-handler.ts` route
+ *      through it (or mirror its expression inline).
+ *   2. The returned `ChatKey` is a branded string — a documentation
+ *      marker for human readers. `telegram-plugin/` is bun-bundled
+ *      and NOT in `tsconfig.json`'s `include`; `lint:plugin-references`
+ *      filters tsc output to reference-class errors only (TS2304/2552/
+ *      2722/2561). A future opt-in `Map<ChatKey, T>` migration could
+ *      provide enforcement teeth, but that requires either bringing
+ *      `telegram-plugin/` into the strict tsc check or rewriting the
+ *      lint to fail on TS2345 type-mismatch. Today the brand is a
+ *      nudge, not a fence.
+ *
+ * `chatKeyWithSuffix()` extends a ChatKey with a lane suffix
+ * (`activity`, `progress`, etc.) — same documentation brand.
+ *
+ * Non-ChatKey keyspaces (chat:message, chat:user, chat:sender:reason)
+ * are deliberately NOT branded — they have different shape and
+ * different invariants, see `deferredKey` / `inboundCoalesceKey` /
+ * the gate-dedup helper in `gateway.ts`.
+ */
+
+export type ChatKey = string & { readonly __brand: 'ChatKey' }
+
+export function chatKey(chatId: string, threadId?: number | null): ChatKey {
+  const t = threadId == null || threadId === 0 ? '_' : String(threadId)
+  return `${chatId}:${t}` as ChatKey
+}
+
+export function chatKeyWithSuffix(
+  chatId: string,
+  threadId: number | null | undefined,
+  suffix: string,
+): ChatKey {
+  return `${chatKey(chatId, threadId)}:${suffix}` as ChatKey
+}
+
+/**
+ * Extract the chatId portion of a ChatKey. Used by sibling-key sweeps
+ * (PR #1564's `purgeStaleTurnsForChat`) that need to enumerate every
+ * thread under a single chat.
+ */
+export function chatIdOfChatKey(key: ChatKey): string {
+  const idx = key.indexOf(':')
+  return idx === -1 ? key : key.slice(0, idx)
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -253,6 +253,7 @@ import { createInboundSpool } from './inbound-spool.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
 import { createPendingPermissionBuffer } from './pending-permission-decisions.js'
+import { chatKey, chatKeyWithSuffix } from './chat-key.js'
 import {
   buildVaultGrantApprovedInbound,
   buildVaultGrantDeniedInbound,
@@ -1249,12 +1250,18 @@ let lastContextExhaustionWarningAt = 0
 
 let pendingPtyPartial: string | null = null
 
-function statusKey(chatId: string, threadId?: number): string {
-  return `${chatId}:${threadId ?? '_'}`
+// statusKey + streamKey are thin re-exports of the canonical chatKey()
+// constructor (see telegram-plugin/gateway/chat-key.ts). chatKey()
+// collapses 0/null/undefined thread IDs to the same token (`_`),
+// closing the sibling-key class behind #1564 (where one site set the
+// entry under `null → _` and another cleared under `0 → 0`, leaving
+// activeTurnStartedAt non-empty forever).
+function statusKey(chatId: string, threadId?: number | null): string {
+  return chatKey(chatId, threadId)
 }
 
-function streamKey(chatId: string, threadId?: number): string {
-  return `${chatId}:${threadId ?? '_'}`
+function streamKey(chatId: string, threadId?: number | null): string {
+  return chatKey(chatId, threadId)
 }
 
 function purgeReactionTracking(key: string): void {
@@ -5397,7 +5404,7 @@ function resetOrphanedReplyTimeout(): void {
 }
 
 function closeActivityLane(chatId: string, threadId: number | undefined): void {
-  const key = `${chatId}:${threadId ?? '_'}:activity`
+  const key = chatKeyWithSuffix(chatId, threadId, 'activity')
   const stream = activeDraftStreams.get(key)
   if (stream == null) return
   activeDraftStreams.delete(key)
@@ -5409,7 +5416,7 @@ function closeProgressLane(chatId: string, threadId: number | undefined): void {
   // Progress-card streams include a turnKey suffix in their key
   // (e.g. "chatId:_:progress:chatId:1"). Iterate and match by prefix
   // so the backstop actually finds the stream.
-  const prefix = `${chatId}:${threadId ?? '_'}:progress`
+  const prefix = chatKeyWithSuffix(chatId, threadId, 'progress')
   for (const [key, stream] of activeDraftStreams) {
     if (key.startsWith(prefix)) {
       activeDraftStreams.delete(key)
@@ -5465,7 +5472,11 @@ function handleSessionEvent(ev: SessionEvent): void {
         // progress-card-driver's per-chat sequence number (these are two
         // independent identifier schemes and don't need to align).
         if (turnsDb != null) {
-          const turnKey = `${ev.chatId}:${ev.threadId ?? '_'}:${startedAt}`
+          // ev.threadId is `string | null` (Telegram emits as string); convert
+          // to number for chatKeyWithSuffix. Number(null) = 0 which canonicalizes
+          // to '_' — same as the explicit `null` branch below.
+          const evThreadIdNum = ev.threadId != null ? Number(ev.threadId) : null
+          const turnKey = chatKeyWithSuffix(ev.chatId, evThreadIdNum, String(startedAt))
           next.registryKey = turnKey
           // Phase 1 of #332: capture first ~200 chars of the user's message.
           const userPromptPreview = extractUserPromptPreview(ev.rawContent)
@@ -5862,7 +5873,7 @@ function handleSessionEvent(ev: SessionEvent): void {
         // Drop progress-card streams without finalising — the normal
         // closeProgressLane call below would call stream.finalize() which
         // sends a final "Done" edit to Telegram. Skip that for silent turns.
-        const suppressPrefix = `${chatId}:${threadId ?? '_'}:progress`
+        const suppressPrefix = chatKeyWithSuffix(chatId, threadId, 'progress')
         for (const [key] of activeDraftStreams) {
           if (key.startsWith(suppressPrefix)) {
             activeDraftStreams.delete(key)

--- a/telegram-plugin/pty-partial-handler.ts
+++ b/telegram-plugin/pty-partial-handler.ts
@@ -94,7 +94,10 @@ export interface PtyHandlerDeps {
 }
 
 function streamKey(chatId: string, threadId?: number): string {
-  return `${chatId}:${threadId ?? '_'}`
+  // Canonical chat-key derivation lives in gateway/chat-key.ts — keep this
+  // expression in lockstep (treats 0/null/undefined the same). See #1564.
+  const t = threadId == null || threadId === 0 ? '_' : String(threadId)
+  return `${chatId}:${t}`
 }
 
 /**

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -313,7 +313,12 @@ function streamKey(
   lane?: string,
   turnKey?: string,
 ): string {
-  const base = `${chatId}:${threadId ?? '_'}`
+  // Canonical chat-key derivation lives in gateway/chat-key.ts — keep this
+  // expression in lockstep with that helper (treats 0/null/undefined the
+  // same), but inline here so this file doesn't introduce a cross-package
+  // import for one expression. See #1564 for the sibling-key bug class.
+  const t = threadId == null || threadId === 0 ? '_' : String(threadId)
+  const base = `${chatId}:${t}`
   const withLane = lane != null && lane.length > 0 ? `${base}:${lane}` : base
   return turnKey != null && turnKey.length > 0 ? `${withLane}:${turnKey}` : withLane
 }

--- a/telegram-plugin/tests/e2e.test.ts
+++ b/telegram-plugin/tests/e2e.test.ts
@@ -50,7 +50,11 @@ function statusKey(chatId: string, threadId?: number): string {
 }
 
 function streamKey(chatId: string, threadId?: number): string {
-  return `${chatId}:${threadId ?? 'default'}`
+  // Mirrors production's canonical chat-key derivation (gateway/chat-key.ts):
+  // 0/null/undefined thread IDs all collapse to '_'. Diverging sentinels
+  // here would let the harness pass with a key shape production rejects.
+  const t = threadId == null || threadId === 0 ? '_' : String(threadId)
+  return `${chatId}:${t}`
 }
 
 interface PluginState {

--- a/telegram-plugin/tests/races.test.ts
+++ b/telegram-plugin/tests/races.test.ts
@@ -29,7 +29,11 @@ function statusKey(chatId: string, threadId?: number): string {
   return `${chatId}:${threadId ?? '_'}`
 }
 function streamKey(chatId: string, threadId?: number): string {
-  return `${chatId}:${threadId ?? 'default'}`
+  // Mirrors production's canonical chat-key derivation (gateway/chat-key.ts):
+  // 0/null/undefined thread IDs all collapse to '_'. Diverging sentinels
+  // here would let the harness pass with a key shape production rejects.
+  const t = threadId == null || threadId === 0 ? '_' : String(threadId)
+  return `${chatId}:${t}`
 }
 
 interface PluginState {


### PR DESCRIPTION
## Summary

- New `telegram-plugin/gateway/chat-key.ts` — single canonical constructor `chatKey(chatId, threadId)` that collapses 0/null/undefined `threadId` to the same token (`_`). Returns branded `ChatKey` (documentation).
- `gateway.ts` `statusKey`/`streamKey` route through it. 4 ad-hoc literal sites in `closeActivityLane`, `closeProgressLane`, `turnKey` construction, and the silent-turn `suppressPrefix` swap to `chatKeyWithSuffix()`.
- `stream-reply-handler.ts` and `pty-partial-handler.ts` mirror the canonical form inline (no cross-package import for a 2-line expression).
- `tests/e2e.test.ts` and `tests/races.test.ts` local-harness `streamKey` swapped from divergent `${threadId ?? 'default'}` to the canonical `_` form.

## Why

PR #1564 fixed `activeTurnStartedAt.size > 0` staying true forever post-`turnEnd` with a chatId-prefix sibling-key sweep. The bug class behind it: `${chatId}:${threadId ?? '_'}` lets `0` (a valid Telegram thread id) survive `??` coalescing — `0` renders as `"0"`, sibling keys for the same chat+thread accumulate, and the wedge-detection's per-key purge leaves them stranded.

This PR closes the class upstream — the canonical helper makes the divergence unrepresentable.

## Migration

| File | Change |
|---|---|
| `telegram-plugin/gateway/chat-key.ts` | new module |
| `telegram-plugin/gateway/gateway.ts` | import + `statusKey`/`streamKey` reroute + 4 ad-hoc literals |
| `telegram-plugin/stream-reply-handler.ts` | local `streamKey` aligned |
| `telegram-plugin/pty-partial-handler.ts` | local `streamKey` aligned |
| `telegram-plugin/tests/e2e.test.ts` | harness `streamKey` aligned (was `'default'` → `_`) |
| `telegram-plugin/tests/races.test.ts` | same |

## Why not brand the Maps

`telegram-plugin/` is bun-bundled, not in `tsconfig.json`'s `include`. `lint:plugin-references` only catches reference-class errors (TS2304/2552/2722/2561), not type-mismatch. Propagating `Map<ChatKey, T>` through 15+ files would be documentation-only — no CI enforcement teeth. The canonical-helper migration is the load-bearing fix; the brand stays as a return-type marker for human readers.

## Not migrated (different keyspaces, document-and-skip)

- `deferredKey` (`${chat_id}:${message_id}`)
- `inboundCoalesceKey` (`${chatId}:${userId}`)
- `agentButtonMeta` keys (`${chatId}:${messageId}`)
- gate-deny dedup (`${chatId}:${senderId}:${reason}`)

## Test plan

- [x] `tsc --noEmit` clean
- [x] All 6 individual lints pass (`check-bot-api-wrapping`, `check-bun-test-imports`, `check-no-pii-secrets`, `check-vault-test-hermeticity`, `check-no-broadcast-delivery`, `check-plugin-references`)
- [x] Diff stat: +95 −12 across 6 files
- [ ] CI green
- [ ] Existing gateway tests (`races.test.ts`, `e2e.test.ts`, etc.) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)