### PR TITLE
fix(gateway): snapshot turnInFlight at receipt to close the 5-min restart wedge (P0 vision)

### DIFF
--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -97,3 +97,23 @@ jobs:
         # scenario file, but only fuzz scenarios are PR-gate-stable.
         working-directory: telegram-plugin
         run: bun run test:uat fuzz-
+
+      - name: UAT JTBD vision scenarios (operator-host only — self-skips without sudo)
+        if: steps.secrets.outputs.ok == 'true'
+        # The jtbd-* scenarios encode vision/JTBD contracts that require
+        # a live switchroom host (NOPASSWD sudo + the switchroom CLI on
+        # PATH + a running test-harness agent) to run. On CI runners
+        # without that setup, each scenario self-skips via a
+        # `canShellSudo()` guard — the step still completes, so CI stays
+        # green, but a regression on the operator's harness host fails
+        # the gate as soon as they run UAT.
+        #
+        # Why this is gated separately from the fuzz scenarios: the
+        # vision UAT shells out to `switchroom agent restart`, which is
+        # mutating + side-effecting. It's the right tool for catching
+        # post-restart wedges (the #1556 self-blocking gate that
+        # produced the 5-min blank on every restart pre-v0.12.22) but
+        # mixing it with the fuzz pool would let one flake stall the
+        # gate. Keep them separate; operators run both during UAT.
+        working-directory: telegram-plugin
+        run: bun run test:uat jtbd-always-on-after-restart

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6637,6 +6637,39 @@ async function handleInbound(
   // network RTT) but not a user-perceived end-to-end measurement.
   const inboundReceivedAt = Date.now()
 
+  // #1556 self-blocking fix (v0.12.22): snapshot the live turn-state
+  // BEFORE the fresh-turn branch (line ~7357) sets activeTurnStartedAt
+  // for THIS inbound. The #1556 delivery gate further down asks "is a
+  // turn ALREADY in flight" — but if we read activeTurnStartedAt.size
+  // at the gate, we see the entry this handler just wrote, and buffer
+  // the very message that just started the turn. Symptom: every first
+  // post-restart message in each thread was held 5 minutes until the
+  // silence-poke fallback drained the buffer; the "5-min blank after
+  // restart" wedge documented in
+  // feedback_5min_restart_wedge_violates_vision.md.
+  //
+  // Why ONLY first-after-restart, not every steady-state message: the
+  // fresh-turn branch fires only when `priorActive = activeStatusReactions.get(key)`
+  // returns null (no controller currently running for this chat+thread).
+  // In a live conversation, the controller from the previous turn
+  // typically hasn't been cleared yet when the user's follow-up
+  // arrives (or follow-ups arrive mid-turn, taking the queued path) —
+  // so the else branch at ~7313 is skipped and the .set never fires.
+  // A fresh container after restart has EMPTY `activeStatusReactions`,
+  // so the very first message in each thread is guaranteed to enter
+  // the fresh-turn branch and trigger the self-block.
+  //
+  // Why snapshot, not move-the-set(): the .set() at ~7357 is embedded
+  // in a coupled init bundle (controller, msgIds, signalTracker.reset,
+  // silencePoke.startTurn, the 👀 reaction emit). Moving only the .set
+  // splits the bundle in ways future maintainers will drift; moving
+  // the WHOLE bundle past the gate changes user-visible ack timing
+  // (👀 wouldn't land until after the gate decides to deliver, hiding
+  // an ack on the buffered path). The snapshot is the minimal precise
+  // fix. Phase 2b's state-machine extraction will revisit this
+  // structurally.
+  const turnInFlightAtReceipt = activeTurnStartedAt.size > 0
+
   const access = result.access
   const from = ctx.from!
   const chat_id = String(ctx.chat!.id)
@@ -7546,9 +7579,15 @@ async function handleInbound(
   // idle-drain flush it the instant claude goes idle, where the channel
   // notification submits cleanly as a fresh turn. Steering messages are
   // exempt — reaching claude mid-turn is the whole point of /steer.
+  //
+  // CRITICAL: turnInFlight reads the snapshot taken at receipt above,
+  // not `activeTurnStartedAt.size > 0` live. The fresh-turn branch at
+  // line ~7357 already populated the Map for THIS inbound's turn;
+  // reading the live size here would self-block (see the comment on
+  // turnInFlightAtReceipt for the wedge symptom this fixes).
   if (
     decideInboundDelivery({
-      turnInFlight: activeTurnStartedAt.size > 0,
+      turnInFlight: turnInFlightAtReceipt,
       isSteering,
     }) === 'buffer-until-idle'
   ) {

--- a/telegram-plugin/uat/scenarios/jtbd-always-on-after-restart-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-always-on-after-restart-dm.test.ts
@@ -1,0 +1,157 @@
+/**
+ * JTBD scenario — always-on vision: first message after restart replies
+ * quickly, NOT 5 minutes later via silence-poke fallback.
+ *
+ * Vision (`reference/vision.md`, see [[project_vision_reanchor_human_assistants]]):
+ * agents are always-on specialist exec-assistants. A 5-min blank
+ * window on the first message after restart is what BROKEN feels
+ * like to a user trying to use their assistant.
+ *
+ * ## The wedge this guards against
+ *
+ * Pre-v0.12.22, every agent restart produced ~5 min blank on the
+ * first user message in each thread:
+ *
+ *   1. User sends msg → handleInbound runs the fresh-turn branch
+ *      → activeTurnStartedAt.set(key, now) at gateway.ts:7357
+ *   2. The #1556 delivery gate further down (~7551) checks
+ *      activeTurnStartedAt.size > 0 to decide if a turn is "already
+ *      in flight" — sees the entry it just wrote → buffer-until-idle
+ *   3. Inbound stuck in pendingInboundBuffer. Bridge never sees it.
+ *      Claude never replies. activeTurnStartedAt[key] stays set.
+ *   4. ~300s later silence-poke framework-fallback fires, drains
+ *      the buffer, the reply finally lands — five minutes late.
+ *
+ * Documented in `feedback_5min_restart_wedge_violates_vision.md`.
+ * Fix is a one-line snapshot of the live size at receipt-time before
+ * the fresh-turn branch mutates the Map.
+ *
+ * ## What this UAT asserts
+ *
+ * After a deliberate restart, the FIRST message in a fresh thread
+ * gets a reply within a budget that excludes the silence-poke
+ * fallback floor (300s). Concretely we assert < 120s, which is
+ * generous for slow LLM replies but well below the wedge symptom.
+ *
+ * The test also makes a stricter observation log so a future
+ * regression that lands BETWEEN "wedge fixed" (~LLM latency) and
+ * "wedge present" (~5 min) is visible — e.g. some slow startup
+ * path that takes 60-90s would pass the contract but bear
+ * investigation.
+ *
+ * ## Why this scenario specifically
+ *
+ * - `smoke-dm-reply.test.ts` covers steady-state inbound→reply but
+ *   does NOT restart the agent first, so the wedge surfaces as a
+ *   "first message is slow" pattern that the smoke test would
+ *   silently absorb on warm runs.
+ * - `silent-end-recovery-dm.test.ts` covers mid-turn silent-end →
+ *   no-reply, but at 6 min budget — too generous to catch the
+ *   5-min wedge as a regression.
+ * - This is the FIRST UAT to explicitly tie the assertion to the
+ *   "always-on" vision and measure first-after-restart TTFO.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { execSync } from "node:child_process";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+
+// Budget for the marker-safe restart itself (per
+// feedback_agent_restart_needs_sudo_when_running.md, restart blocks
+// ~30s as the gateway's bridge reattaches).
+const RESTART_BUDGET_MS = 90_000;
+
+// Hard contract: first-after-restart reply must land in under 2 min.
+// This is generous for slow LLM replies but well below the 5-min
+// silence-poke fallback floor — a regression of the #1556 wedge
+// would trip on TTFO ≥ 300s and fail the test.
+const HARD_REPLY_BUDGET_MS = 120_000;
+
+// Vision-aligned target: real expectation is well under 30s on a
+// healthy fleet. A pass between 30-120s is yellow — covered by the
+// contract but worth logging for forensic visibility.
+const VISION_REPLY_BUDGET_MS = 30_000;
+
+function canShellSudo(): boolean {
+  try {
+    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function restartAgent(name: string): void {
+  // Marker-safe restart per memory feedback_compose_rollout.md +
+  // feedback_agent_restart_needs_sudo_when_running.md. Apply step
+  // self-elevates internally; restart needs the wrapper. We don't
+  // call apply here — the agent scaffolds are already current; only
+  // the in-memory state needs to reset.
+  execSync(
+    `sudo -n env PATH=$PATH HOME=$HOME switchroom agent restart ${name} --force`,
+    { stdio: ["ignore", "pipe", "pipe"], timeout: RESTART_BUDGET_MS },
+  );
+}
+
+// This scenario requires NOPASSWD sudo + the switchroom CLI on PATH on
+// the harness host. Skip on CI runners that don't expose those.
+const sudoOk = canShellSudo();
+
+(sudoOk ? describe : describe.skip)(
+  "uat: always-on after restart",
+  () => {
+    beforeAll(() => {
+      restartAgent(AGENT);
+      // Brief settle so the bridge sidecar finishes its reattach
+      // before we send the first inbound. The bridge-register log
+      // line is the earliest the agent can accept inbound.
+      return new Promise((r) => setTimeout(r, 5_000));
+    }, RESTART_BUDGET_MS + 10_000);
+
+    it(
+      "first message after fresh restart → reply within 2 min (NOT the 5-min wedge)",
+      async () => {
+        const sc = await spinUp({ agent: AGENT });
+        try {
+          const sendStart = Date.now();
+          await sc.sendDM("ping — JTBD always-on UAT");
+
+          const firstReply = await sc.expectMessage(/\S/, {
+            from: "bot",
+            timeout: HARD_REPLY_BUDGET_MS,
+          });
+          const ttfo = Date.now() - sendStart;
+
+          expect(firstReply.text.length).toBeGreaterThan(0);
+
+          // HARD CONTRACT: the wedge symptom is 300s+ TTFO. Anything
+          // ≥ HARD_REPLY_BUDGET_MS (120s) flags a regression of the
+          // #1556 self-blocking gate.
+          if (ttfo >= HARD_REPLY_BUDGET_MS) {
+            throw new Error(
+              `[always-on] first-post-restart reply took ${ttfo}ms — ` +
+              `matches the #1556 wedge symptom (5-min silence-poke fallback). ` +
+              `Vision broken; see feedback_5min_restart_wedge_violates_vision.md`,
+            );
+          }
+          expect(ttfo).toBeLessThan(HARD_REPLY_BUDGET_MS);
+
+          // Yellow-band log: passes the contract but degraded from the
+          // vision target. Worth investigating if this fires regularly.
+          if (ttfo >= VISION_REPLY_BUDGET_MS) {
+            console.warn(
+              `[always-on] first-post-restart TTFO=${ttfo}ms — passed ` +
+              `contract (${HARD_REPLY_BUDGET_MS}ms) but slower than the ` +
+              `vision target (${VISION_REPLY_BUDGET_MS}ms). Forensic flag.`,
+            );
+          }
+        } finally {
+          await sc.tearDown();
+        }
+      },
+      HARD_REPLY_BUDGET_MS + 10_000,
+    );
+  },
+);


### PR DESCRIPTION
## TL;DR

Every agent restart produced ~5 minutes of "blank" for the first user message in each thread. **This violates the "always-on specialist exec-assistants" vision** and was the dominant user-perceived failure mode during the v0.12.21 fleet rollout. Two-line fix; mtcute UAT regression guard. Ship as v0.12.22.

## Root cause

`gateway.ts:7357` (inside the fresh-turn branch of `handleInbound`) does `activeTurnStartedAt.set(key, Date.now())` BEFORE the #1556 delivery gate at `gateway.ts:7551` reads `activeTurnStartedAt.size > 0`. The gate sees the entry it just produced, decides `buffer-until-idle`, and strands the turn-starting message in `pendingInboundBuffer`. Claude never receives it. Claude never replies. `activeTurnStartedAt[key]` stays set. 5 minutes later the silence-poke framework-fallback fires, drains the buffer, the reply finally lands — five minutes late.

PR #1555 / #1556 introduced this gate on 2026-05-19 (the lawgpt composer-wedge fix). The intent was correct — buffer inbound that arrives DURING an existing turn — but the implementation reads the live Map after this handler has already mutated it for the inbound itself.

## Fix

Two-line change: snapshot `activeTurnStartedAt.size > 0` ONCE at receipt time (after `gate()` pair/drop early-exits, before any side effects), pass the snapshot to `decideInboundDelivery`.

```typescript
// Snapshot before any mutation in this handler.
const turnInFlightAtReceipt = activeTurnStartedAt.size > 0
// ... existing fresh-turn branch sets activeTurnStartedAt[key] ...
if (decideInboundDelivery({ turnInFlight: turnInFlightAtReceipt, isSteering }) === 'buffer-until-idle') {
  ...
}
```

The snapshot captures "was a turn already in flight WHEN this inbound arrived" — the actual semantic #1556 wanted, not "is anything in the Map RIGHT NOW (including the turn we just started)."

## Vision UAT — mtcute JTBD regression guard

Per the user's explicit ask ("add UAT in MTCute for this kind of behaviour too ensure we honour vision JTBD etc"), adds `telegram-plugin/uat/scenarios/jtbd-always-on-after-restart-dm.test.ts`:

- Shells out to `switchroom agent restart test-harness --force` (marker-safe path)
- Sends a fresh inbound via the mtcute driver session
- Asserts reply lands within **120s** (hard contract — wedge symptom was 300s+)
- Logs forensic warning at 30s threshold (vision target is "few seconds")
- Skipped on hosts without NOPASSWD sudo (mtcute UAT prerequisite)

This is the FIRST UAT explicitly tied to the always-on vision per memory `feedback_5min_restart_wedge_violates_vision.md`. Future regressions of the wedge — by any mechanism, not just this specific gate — fail the test.

## Why this is P0

Per memory `project_vision_reanchor_human_assistants.md`: switchroom's product position is "always-on specialist exec-assistants." A 5-min blank window on the first message after restart is what *broken* feels like to a user trying to use their assistant. Saying "it'll auto-recover in 5 min" is the bug, not the fix.

The Phase 2 structural work (`InboundDeliveryStateMachine` extraction + property test in `feat/restart-wedge-2b`) is still the right long-term move, but it's multi-day. This hotfix ships the user-facing fix now.

## Test plan

- [x] All 6 structural lints clean (`check-bot-api-wrapping`, `check-bun-test-imports`, `check-no-pii-secrets`, `check-vault-test-hermeticity`, `check-no-broadcast-delivery`, `check-plugin-references`)
- [x] `check-plugin-references` (strict tsc against plugin source) passes — catches the type errors the broader `lint:tsc` missed in A2
- [ ] CI green on this PR
- [ ] Post-merge: cut v0.12.22, fleet rollout, verify mtcute UAT passes against a freshly-restarted test-harness agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)