### PR TITLE
fix(memory): override hindsight retainEveryNTurns=1 — close the moat JTBD

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1503,6 +1503,24 @@ export function installHindsightPlugin(
   }
   copyDirRecursive(sourcePath, destPath);
 
+  // Apply switchroom-specific overrides on top of the vendored plugin's
+  // default settings.json. Vendor stays untouched; overrides are applied
+  // after every copy so they survive reconcile/restart.
+  //
+  // `retainEveryNTurns: 1` (override from vendor default `10`): the
+  // vendor's default throttles auto-retention to every 10 turns. For
+  // switchroom's "always-on specialist exec-assistant" vision, that
+  // throttle is wrong — users expect "please remember this" or even a
+  // single fact-sharing turn to survive a restart. The jtbd-memory-
+  // survives-restart UAT exposed the gap (2026-05-20): a 2-turn
+  // session NEVER hit the retention threshold, so the token was lost
+  // on restart. Setting retainEveryNTurns=1 makes every Stop hook
+  // trigger retention. Cost: more frequent hindsight API calls
+  // (cheap — async POST to a local container). Memory is the moat
+  // (reference/remember-across-sessions.md); paying for it on every
+  // turn is correct.
+  applyHindsightSettingsOverrides(destPath);
+
   // Resolve the agent's bank/collection name and the Hindsight REST URL.
   // The plugin's hooks expect HINDSIGHT_API_URL (the REST base), not the
   // /mcp/ MCP endpoint URL — strip the suffix.
@@ -1512,6 +1530,40 @@ export function installHindsightPlugin(
   const apiBaseUrl = mcpUrl.replace(/\/mcp\/?$/, "").replace(/\/$/, "");
 
   return { pluginDir: destPath, apiBaseUrl, bankId };
+}
+
+/**
+ * Merge switchroom-specific overrides into the vendored hindsight
+ * plugin's `settings.json`. Idempotent — runs after every plugin
+ * copy on every scaffold/reconcile/restart.
+ *
+ * Currently overrides:
+ *   - `retainEveryNTurns`: 10 → 1 (capture every turn, not every 10th)
+ *
+ * Future overrides go here, NOT in the vendor file. The vendor is
+ * third-party code and must remain untouched for clean upstream
+ * updates. This function is the single point of switchroom-specific
+ * memory tuning.
+ */
+function applyHindsightSettingsOverrides(pluginDestPath: string): void {
+  const settingsPath = join(pluginDestPath, "settings.json");
+  if (!existsSync(settingsPath)) return; // vendor structure changed; bail safely
+  let raw: string;
+  try {
+    raw = readFileSync(settingsPath, "utf-8");
+  } catch {
+    return;
+  }
+  let settings: Record<string, unknown>;
+  try {
+    settings = JSON.parse(raw);
+  } catch {
+    return; // vendor's settings.json malformed; don't make it worse
+  }
+  // Override: every turn retains (no throttle). See the rationale in
+  // installHindsightPlugin() above.
+  settings.retainEveryNTurns = 1;
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
 }
 
 /**

--- a/telegram-plugin/uat/scenarios/jtbd-memory-survives-restart-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-memory-survives-restart-dm.test.ts
@@ -81,28 +81,30 @@ function restartAgent(name: string): void {
   );
 }
 
-// Retained for when this test is unskipped — gates on the same
-// sudo-availability prerequisite as jtbd-always-on-after-restart.
 const sudoOk = canShellSudo();
-void sudoOk;
 
-// KNOWN VISION GAP — captured 2026-05-20. The first live run of this
-// UAT against test-harness FAILED: after capture → restart → recall,
-// the agent replied "I don't have that token — no SWITCHROOM_UAT_MEM_*
-// value was ever shared with me to remember." The
-// `remember-across-sessions` JTBD is NOT being met in production for
-// content captured within a single turn.
+// UNSKIPPED 2026-05-20 after root-cause + fix.
 //
-// Critically: this is distinct from claude-code session resume.
-// The wake-audit-content UAT (jtbd-wake-audit-content-dm.test.ts)
-// run immediately after this one observed the agent REFERENCE the
-// SWITCHROOM_UAT_MEM_ token in its post-restart status summary
-// ("Token recall — SWITCHROOM_UAT_MEM_ missing from memory") — so
-// session resume DID surface the prior turn's conversation in
-// claude's context. What's missing is hindsight LONG-TERM memory
-// capture. The session-JSONL replay carries forward the immediate
-// conversation; hindsight is the structured memory that's supposed
-// to outlast individual sessions and surface cross-session.
+// Original failure: the first live run on 2026-05-20 FAILED — after
+// capture → restart → recall, the agent replied "I don't have that
+// token — no SWITCHROOM_UAT_MEM_* value was ever shared with me to
+// remember." Documented at the time as a known vision gap.
+//
+// Root cause: the vendored hindsight-memory plugin's default
+// `retainEveryNTurns: 10` throttled auto-retention to every 10
+// turns. A 2-turn UAT session (capture turn → restart) NEVER reached
+// the threshold, so the Stop hook's retain.py skipped (`turn_count %
+// retain_every_n != 0`) and the token never persisted. The recall
+// query at the new boot found nothing.
+//
+// Fix: switchroom's scaffold (src/agents/scaffold.ts) now applies a
+// post-copy override that sets `retainEveryNTurns: 1` in the
+// per-agent settings.json. Every turn end retains. Vendor file
+// stays untouched. See project_hindsight_memory_gap_root_cause.md.
+//
+// Live re-run after the fix: capture TTFO=22.7s, recall TTFO=14.1s,
+// token round-tripped successfully. The remember-across-sessions
+// JTBD is now met for single-turn explicit-memory prompts.
 //
 // Likely root causes (any/all):
 //   - Hindsight capture is opportunistic — the model decides when to
@@ -121,8 +123,8 @@ void sudoOk;
 //
 // (Memory is the moat — see comment block above. Shipping the test
 // as a known-failing skip is more honest than not shipping it at all.)
-describe.skip(
-  "uat: memory survives across restart (remember-across-sessions JTBD) — SKIPPED: known vision gap, see comment above",
+(sudoOk ? describe : describe.skip)(
+  "uat: memory survives across restart (remember-across-sessions JTBD)",
   () => {
     it(
       "agent remembers a unique token after capture → restart → recall",


### PR DESCRIPTION
## Summary

The moat-defining JTBD `reference/remember-across-sessions.md` was silently failing in production: single-turn "please remember this" prompts never persisted, the agent forgot across every restart, the relationship never compounded.

Caught by the `jtbd-memory-survives-restart` UAT (#1577) on 2026-05-20. Root-caused to the vendored hindsight plugin's default `retainEveryNTurns: 10` throttling Stop-hook retention away from short sessions. Fix is a scaffold-layer override; vendor untouched.

## Validation (live)

After applying override on test-harness + restart:

```
[memory-survives] capture phase: TTFO=22709ms, reply length=144
[memory-survives] recall TTFO=14068ms — within vision target.
                  Token round-tripped successfully.
```

UAT unskipped in this PR. **The executable spec is now the regression gate.**

## Why this fix shape

- Vendor `vendor/hindsight-memory/settings.json` is third-party code per project CLAUDE.md — must not be touched.
- The override lives in `src/agents/scaffold.ts:installHindsightPlugin()` after the plugin tree copy. Idempotent across reconcile/restart. Future switchroom-specific memory tuning lands in the same helper.

## Cost

Every Stop hook now POSTs to hindsight (was: every 10th). Local container, async on hindsight side. test-harness's hindsight bank already shows 237 completed operations with no failures — handles the volume fine.

## Test plan

- [x] Live UAT against test-harness PASSED (capture 22.7s, recall 14.1s, token round-tripped)
- [x] `check-plugin-references` clean
- [x] Vendor file untouched
- [ ] CI green
- [ ] After merge: fleet rollout (all 9 agents need `switchroom apply` to pick up the new override)
- [ ] Re-run memory UAT post-rollout to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)