### PR TITLE
feat(gateway): InboundDeliveryStateMachine SHADOW mode (Phase 2b PR 2)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -254,6 +254,13 @@ import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
 import { createPendingPermissionBuffer } from './pending-permission-decisions.js'
 import { chatKey, chatKeyWithSuffix } from './chat-key.js'
+// Phase 2b PR 2 — shadow mode. Each event-site below calls shadowEmit()
+// to record what the InboundDeliveryStateMachine PREDICTS the gateway
+// should do. Behavior unchanged in this PR — the imperative code below
+// still runs everything. PR 3 will cut over to executing the machine's
+// effects.
+import { shadowEmit } from './inbound-delivery-machine-shadow.js'
+import type { ChatKey as _ChatKey } from './inbound-delivery-machine.js'
 import {
   buildVaultGrantApprovedInbound,
   buildVaultGrantDeniedInbound,
@@ -1265,6 +1272,13 @@ function streamKey(chatId: string, threadId?: number | null): string {
 }
 
 function purgeReactionTracking(key: string): void {
+  // Phase 2b shadow: turn end. The key was registered via setTurnStarted
+  // when the inbound arrived; purge is the canonical turn-end signal.
+  // outboundEmitted is approximated `true` here — refined in PR 3 to read
+  // from the per-turn `replyCalled` flag on `currentTurn`. Conservative
+  // shadow approximation is safe (only affects machine's lastOutboundAt
+  // tracking; can't drive incorrect behavior in shadow mode).
+  shadowEmit({ kind: 'turnEnd', key: key as _ChatKey, at: Date.now(), outboundEmitted: true })
   const msgInfo = activeReactionMsgIds.get(key)
   activeStatusReactions.delete(key)
   activeReactionMsgIds.delete(key)
@@ -3182,6 +3196,8 @@ const ipcServer: IpcServer = createIpcServer({
 
   onClientRegistered(client: IpcClient) {
     process.stderr.write(`telegram gateway: bridge registered — agent=${client.agentName}\n`)
+    // Phase 2b shadow: bridge up.
+    shadowEmit({ kind: 'bridgeUp', at: Date.now() })
     client.send({ type: 'status', status: 'agent_connected' })
 
     // #1150: drain any synthetic inbounds queued for this agent while
@@ -3307,6 +3323,8 @@ const ipcServer: IpcServer = createIpcServer({
 
   onClientDisconnected(client: IpcClient) {
     process.stderr.write(`telegram gateway: bridge disconnected — agent=${client.agentName}\n`)
+    // Phase 2b shadow: bridge down.
+    shadowEmit({ kind: 'bridgeDown', at: Date.now() })
 
     // Scope the flush to clients that actually registered as an agent.
     // Anonymous one-shot connections (e.g. recall.py's legacy
@@ -6636,6 +6654,23 @@ async function handleInbound(
   // ambient-signal alerting (the dominant variance is reasoning time, not
   // network RTT) but not a user-perceived end-to-end measurement.
   const inboundReceivedAt = Date.now()
+
+  // Phase 2b shadow: inbound arrival. Emit BEFORE the snapshot/gate
+  // logic so the machine sees the event at the same point in time the
+  // imperative code would. The machine internally handles fresh-turn
+  // vs mid-turn — its decision will be visible in the gw-trace shadow
+  // line emitted to stderr.
+  const _shadowKey = statusKey(ctx.chat?.id != null ? String(ctx.chat.id) : '0', ctx.message?.message_thread_id) as _ChatKey
+  shadowEmit({
+    kind: 'inbound',
+    key: _shadowKey,
+    msg: {
+      msgId: ctx.message?.message_id ?? 0,
+      isSteering: false, // refined in PR 3 — for now shadow conservatively classifies as non-steering
+      payload: null,
+    },
+    at: Date.now(),
+  })
 
   // #1556 self-blocking fix (v0.12.22): snapshot the live turn-state
   // BEFORE the fresh-turn branch (line ~7357) sets activeTurnStartedAt

--- a/telegram-plugin/gateway/inbound-delivery-machine-shadow.ts
+++ b/telegram-plugin/gateway/inbound-delivery-machine-shadow.ts
@@ -1,0 +1,117 @@
+/**
+ * InboundDeliveryStateMachine — SHADOW MODE wiring (Phase 2b PR 2).
+ *
+ * Per RFC `docs/rfcs/inbound-delivery-state-machine.md` Phase 2b PR 2:
+ * the state machine runs ALONGSIDE the existing imperative gateway
+ * code, recording predicted effects to a structured trace. Behavior
+ * is unchanged — every existing code path still executes the actual
+ * I/O. This module's job:
+ *
+ *   1. Own the module-scope machine state.
+ *   2. Expose `shadowEmit(event)` that runs `transition()` + logs the
+ *      predicted effects via `gw-trace shadow ...` stderr lines.
+ *   3. Provide test hooks for resetting + inspecting state.
+ *
+ * After PR 2 bakes on the fleet for 24+ hours, PR 3 will wire the
+ * effects to drive ACTUAL behavior (the cutover), at which point the
+ * imperative paths get deleted in PR 4.
+ *
+ * Telemetry approach: each `shadowEmit` writes a single stderr line
+ * with the event kind + emitted effect kinds. Operators can then:
+ *
+ *   docker exec switchroom-<agent> sh -lc 'grep "gw-trace shadow" \
+ *     /var/log/switchroom/gateway-supervisor.log | tail -50'
+ *
+ * to see what the state machine PREDICTS the gateway should do for
+ * each event. Comparing against the actual log lines (`pending-inbound-
+ * buffer: agent=X buffered ...` etc.) is the validation that the
+ * machine is bit-identical with reality.
+ *
+ * Toggle off via `SWITCHROOM_DELIVERY_MACHINE_SHADOW=0` — a kill
+ * switch for the case where the shadow emits prove problematic
+ * (e.g., trace volume too high). The default is ON.
+ */
+
+import {
+  type Effect,
+  type Event,
+  type State,
+  initialState,
+  transition,
+} from './inbound-delivery-machine.js'
+
+let state: State = initialState()
+const enabled = process.env.SWITCHROOM_DELIVERY_MACHINE_SHADOW !== '0'
+
+/**
+ * Run an event through the state machine in shadow mode. The machine
+ * state advances, the predicted effects are LOGGED, but no I/O fires.
+ *
+ * Returns the effects for callers that want to inspect them inline
+ * (e.g., the eventual PR 3 cutover will replace the return-and-ignore
+ * pattern here with return-and-execute).
+ */
+export function shadowEmit(event: Event): readonly Effect[] {
+  if (!enabled) return []
+  // Shadow mode MUST NEVER break the gateway. The state machine is
+  // pure (no I/O, no async) and property-tested over 5000 schedules,
+  // so transition() won't throw on well-formed input. But event
+  // construction at the call site could mis-shape inputs; the
+  // try/catch is belt-and-braces so a shadow bug never wedges a real
+  // turn. The catch logs and bails — the imperative gateway code
+  // below the emit point still runs.
+  try {
+    const result = transition(state, event)
+    state = result.state
+
+    // Single structured stderr line per event — grep-friendly and
+    // low volume (one line per gateway event, not per effect). The
+    // format matches gateway.ts's existing `tg-post method=...` shape
+    // so log aggregation can pick it up without a new parser.
+    const effectKinds = result.effects.map((e) => e.kind).join(',')
+    const eventDetail = formatEventDetail(event)
+    process.stderr.write(
+      `gw-trace shadow event=${event.kind}${eventDetail} effects=[${effectKinds}] global=${state.global.kind} perKeySize=${state.perKey.size}\n`,
+    )
+    return result.effects
+  } catch (err) {
+    process.stderr.write(
+      `gw-trace shadow ERROR event=${event.kind} err=${err instanceof Error ? err.message : String(err)}\n`,
+    )
+    return []
+  }
+}
+
+/** Compact event detail for the trace line — keeps the line one-line. */
+function formatEventDetail(event: Event): string {
+  switch (event.kind) {
+    case 'inbound':
+      return ` key=${event.key} msg=${event.msg.msgId} steer=${event.msg.isSteering}`
+    case 'turnStart':
+    case 'turnEnd':
+      return ` key=${event.key}${event.kind === 'turnEnd' ? ` outbound=${event.outboundEmitted}` : ''}`
+    case 'permVerdict':
+      return ` req=${event.verdict.requestId} behavior=${event.verdict.behavior}`
+    case 'modelOutbound':
+      return ` key=${event.key}`
+    case 'bridgeUp':
+    case 'bridgeDown':
+    case 'tick':
+      return ''
+  }
+}
+
+/** Test hook: reset state to the initial empty machine. */
+export function __shadowResetForTests(): void {
+  state = initialState()
+}
+
+/** Test hook: read the current shadow state. */
+export function __shadowGetStateForTests(): State {
+  return state
+}
+
+/** Test hook: check if shadow mode is enabled (mirrors the env-var). */
+export function __shadowEnabledForTests(): boolean {
+  return enabled
+}


### PR DESCRIPTION
## Summary

PR 2 of 4 from the Phase 2b RFC (#1576). Wires the pure state machine (PR 1, #1578) into the gateway in **SHADOW mode** — every event-site records predicted effects to `gw-trace shadow ...` stderr, but the imperative code below still runs everything.

**Zero behavior change in this PR.** Operator-observable: a new structured trace line per event, low volume, grep-friendly.

## Wired event sites

| Site | Shadow event |
|---|---|
| `onClientRegistered` | `bridgeUp` |
| `onClientDisconnected` | `bridgeDown` |
| `handleInbound` (entry) | `inbound` |
| `purgeReactionTracking` (turn-end gate) | `turnEnd` |

`modelOutbound` + `tick` deferred to PR 3 — high volume, only needed for invariant #5 (spurious fallback suppression) which kicks in at cutover.

## Validation (local smoke)

```
gw-trace shadow event=bridgeUp effects=[redeliverPersistedPermVerdicts,drainBuffer,logTrace]
gw-trace shadow event=inbound key=c1:_ msg=100 steer=false effects=[setTurnStarted,deliverToBridge,logTrace]
gw-trace shadow event=turnEnd key=c1:_ outbound=true effects=[clearTurnStarted,noteOutbound,drainBuffer,logTrace]
```

**The boot-wedge case correctly produces `deliverToBridge` (not `bufferInbound`).** A future regression of v0.12.22's fix would appear instantly in this trace.

## Kill switch

`SWITCHROOM_DELIVERY_MACHINE_SHADOW=0` disables emit entirely. Default ON.

## Safety

`shadowEmit` wraps `transition()` in try/catch. State machine is pure + property-tested over 5,000 random schedules (PR 1) so it shouldn't throw; catch is belt-and-braces — a shadow bug logs an error line and returns, never wedges a real turn.

## What unblocks once this bakes

After ~24 hours of fleet runtime with `gw-trace shadow` lines visible alongside the actual production logs, PR 3 cuts over the gateway to **execute** the machine's effects (replacing the corresponding imperative paths). The shadow trace becomes the ground-truth comparison: every effect the machine predicted should match an actual gateway action.

## Test plan

- [x] `check-plugin-references` clean (strict tsc against plugin source)
- [x] Local bun smoke test of shadowEmit chain (bridgeUp → inbound → turnEnd) — produces correct effects, no throws
- [ ] CI green
- [ ] Roll to test-harness FIRST, observe gw-trace lines, run fast-trivial + always-on UAT (validate no behavior regression)
- [ ] Then roll to fleet
- [ ] Bake 24h, file PR 3 (cutover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)