### PR TITLE
fix(gateway): IPC agentIndex race — close the chronic bridge-flap class

### DIFF
--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -266,8 +266,24 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
 
   function removeClient(client: IpcClient & { _socket: ReturnType<typeof Bun.listen> extends infer S ? any : never }) {
     clients.delete(client);
-    if (client.agentName) agentIndex.delete(client.agentName);
-    if (client.topicId != null) topicIndex.delete(client.topicId);
+    // CRITICAL race fix (2026-05-20): only delete from agentIndex /
+    // topicIndex if the index still points to THIS client. A bridge
+    // that reconnects fast can have its NEW client overwrite
+    // agentIndex[name] (via handleRegister's replace-not-reject)
+    // BEFORE the OLD client's close+removeClient runs. Blindly
+    // deleting agentIndex[name] would remove the LIVE replacement
+    // client by accident → sendToAgent returns false → all subsequent
+    // inbound buffered until the bridge happens to reconnect in an
+    // ordering that works out. User-visible symptom was the chronic
+    // bridge-flap pattern (clerk + gymbro unresponsive 2026-05-20)
+    // where the gateway log showed "bridge registered" but messages
+    // were still getting buffered as if no bridge existed.
+    if (client.agentName && agentIndex.get(client.agentName) === client) {
+      agentIndex.delete(client.agentName);
+    }
+    if (client.topicId != null && topicIndex.get(client.topicId) === client) {
+      topicIndex.delete(client.topicId);
+    }
     loggedLegacyUpdatePlaceholder.delete(client.id);
     onClientDisconnected(client);
     log(`client disconnected: ${client.id} (agent=${client.agentName})`);
@@ -406,6 +422,28 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
 
     if (client.agentName) agentIndex.delete(client.agentName);
     if (client.topicId != null) topicIndex.delete(client.topicId);
+
+    // 2026-05-20 race fix: if a PRIOR client is registered as this
+    // agent name (a stale/zombie connection that hasn't been evicted
+    // yet), explicitly close it before installing this new client.
+    // Without this, the prior client remains in `clients` set, its
+    // heartbeat watchdog still ticks, and its eventual close+removeClient
+    // can confuse routing. The removeClient identity-check fix above
+    // means the index won't be wrongly deleted, but two concurrent
+    // clients claiming the same agent name is still a routing hazard
+    // — close the zombie cleanly here.
+    const existingClient = agentIndex.get(msg.agentName);
+    if (existingClient && existingClient !== client) {
+      log(
+        `register: closing prior client for agent=${msg.agentName} ` +
+        `(prior_id=${existingClient.id} new_id=${client.id}) — bridge reconnect race`,
+      );
+      try {
+        (existingClient as IpcClientImpl).close();
+      } catch {
+        /* nothing to do */
+      }
+    }
 
     client.agentName = msg.agentName;
     client.topicId = msg.topicId ?? null;


### PR DESCRIPTION
## TL;DR

**P0 fix for the chronic bridge-flap pattern.** Two concurrent races in the IPC server's agentIndex maintenance let a fast bridge reconnect orphan the LIVE client from routing, silently buffering inbound until the next reconnect happened to land in the right order. Symptom on 2026-05-20: clerk + gymbro unresponsive while gateway logs showed "bridge registered". Fleet-wide pattern, pre-existing, exposed by yesterday's shadow trace.

## Root cause (two bugs that compound)

**Bug 1 — `handleRegister` replace-not-reject** (ipc-server.ts:407):
- Sets `agentIndex[name] = client` unconditionally
- Comment line 509 admits this: *"handleRegister does replace-not-reject, so this is belt-and-suspenders"* — author knew but expected the watchdog to clean up

**Bug 2 — `removeClient` blind delete** (ipc-server.ts:269):
- `agentIndex.delete(client.agentName)` — no identity check
- If a NEW client has already overwritten that entry, this delete removes the LIVE client by accident

**Combined race:**
1. ClientA registered as "clerk"
2. ClientA's socket goes sluggish; bridge reconnects fast → ClientB
3. ClientB registers → agentIndex["clerk"] = B (A orphaned in `clients` set)
4. ClientA's close eventually propagates → removeClient(A) → `agentIndex.delete("clerk")` removes **B by accident**
5. ClientB is alive on socket but invisible to routing
6. `sendToAgent("clerk", msg)` returns false → message buffered indefinitely

Gateway log pattern: 3-4 "bridge registered" in a row, then 1 "bridge disconnected", routing dead the whole time.

## Fix (two parts)

**Part 1 — `removeClient` identity-check**: `agentIndex.delete(name)` only if `agentIndex.get(name) === client`. Same for topicIndex. Canonical race-safe pattern for concurrent-map cleanup.

**Part 2 — `handleRegister` explicit zombie-close**: when a new client registers as an agent already in agentIndex, explicitly close the prior client BEFORE installing the new one. Old removeClient runs cleanly (identity check skips the delete). Single canonical value at all times.

Together: agentIndex stays consistent with reality through all churn.

## Validation plan

- [x] `check-plugin-references` clean (strict tsc against plugin source)
- [ ] CI green
- [ ] Test-harness rollout FIRST: watch for new "register: closing prior client" lines, run fast-trivial + always-on UATs
- [ ] Stress test: rapid bridge restart cycle (5x `agent restart` in 30s) — UATs still pass
- [ ] After 1h test-harness bake: roll to fleet
- [ ] After 1h fleet bake: confirm bridge-flap pattern shrinks in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)