### PR TITLE
chore: release v0.12.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased — feat(gateway): Phase 2b PR 3a — bridgeUp dispatcher cutover
+## v0.12.27 — feat(gateway): Phase 2b PR 3a — bridgeUp dispatcher cutover
 
 First real cutover of the `InboundDeliveryStateMachine` (RFC
 `docs/rfcs/inbound-delivery-state-machine.md`). The `bridgeUp` event

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.12.26",
+  "version": "0.12.27",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Phase 2b PR 3a — bridgeUp dispatcher cutover (#1587)

## Test plan
- [x] Build green (`node scripts/build.mjs` → `dist/cli/switchroom.js` 2.79MB)
- [x] CI on #1587 green before merge
- [ ] Roll to test-harness, bake 48h, then fleet (separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)