### PR TITLE
fix(npm): ship vendor/ in published tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## unreleased — fix(npm): ship vendor/ in published tarball
+
+The `vendor/` directory (containing the hindsight-memory plugin tree)
+was missing from `package.json`'s `files` array. Effect: every npm-
+installed switchroom CLI ran `switchroom apply` with
+`resolveHindsightVendorPath()` pointing at a non-existent path. The
+guard at `scaffold.ts:1493` silently returned null, so the
+hindsight plugin tree was NEVER copied into existing agents on apply.
+Workaround was manual `sed` across all 9 fleet agents whenever a
+hindsight setting changed (e.g., the v0.12.23 `retainEveryNTurns=1`
+rollout).
+
+Fix: add `"vendor"` to the `files` array. Also: the silent-null path
+now logs to stderr so a future regression of the same shape is loud.
+
 ## unreleased — feat(gateway): per-line ISO timestamps on supervisor log
 
 Per cold-start TTFO RFC (#1589) rec #1. The gateway's stderr is captured

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "profiles",
     "skills",
     "telegram-plugin",
+    "vendor",
     "bin",
     "README.md",
     "LICENSE"

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1491,6 +1491,17 @@ export function installHindsightPlugin(
 
   const sourcePath = resolveHindsightVendorPath();
   if (!existsSync(sourcePath)) {
+    // Loud about it: a missing vendor dir means the npm tarball was
+    // packed without the `vendor/` entry (regression of the bug fixed
+    // in this PR — `files` array in package.json must include
+    // `vendor`). Silent-null left a fleet on v0.12.27 with `apply`
+    // never refreshing the hindsight plugin tree on existing agents,
+    // forcing manual sed workarounds across 9 agents.
+    process.stderr.write(
+      `installHindsightPlugin: vendor source missing at ${sourcePath} ` +
+        `— hindsight plugin NOT installed for ${agentName}. ` +
+        `Likely a packaging regression: check the npm tarball's files array.\n`,
+    );
     return null;
   }
 


### PR DESCRIPTION
## Summary
Closes task #32. The `vendor/` dir (hindsight-memory plugin tree) was missing from `package.json`'s `files` array. Every npm-installed switchroom CLI ran `switchroom apply` with `resolveHindsightVendorPath()` pointing at a non-existent path; the silent-null guard at `scaffold.ts:1493` meant the hindsight plugin tree was NEVER refreshed on existing agents during apply.

## Symptom
Manual `sed` workaround across all 9 fleet agents was the only way to roll a hindsight setting change (e.g., v0.12.23 `retainEveryNTurns=1`).

## Fix
- Add `\"vendor\"` to `package.json` files array. Verified via `npm pack --dry-run` — vendor/hindsight-memory/ contents now appear in the tarball.
- Convert the silent-null path in `installHindsightPlugin` to log to stderr so the next regression of this shape is loud (per-agent diagnostic during apply).

## Test plan
- [x] `npm pack --dry-run` shows vendor/hindsight-memory/{.claude-plugin,hooks,scripts,LICENSE,README.md,CHANGELOG.md}
- [x] tsc clean
- [ ] After release: `switchroom apply` on test-harness refreshes \`<agentDir>/.claude/plugins/hindsight-memory/\` files to fresh mtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)