### PR TITLE
chore: release v0.12.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased — fix(npm): ship vendor/ in published tarball
+## v0.12.28 — fix(npm): ship vendor/ in published tarball + per-line log timestamps
 
 The `vendor/` directory (containing the hindsight-memory plugin tree)
 was missing from `package.json`'s `files` array. Effect: every npm-
@@ -15,7 +15,7 @@ rollout).
 Fix: add `"vendor"` to the `files` array. Also: the silent-null path
 now logs to stderr so a future regression of the same shape is loud.
 
-## unreleased — feat(gateway): per-line ISO timestamps on supervisor log
+### Per-line ISO timestamps on supervisor log
 
 Per cold-start TTFO RFC (#1589) rec #1. The gateway's stderr is captured
 to `/var/log/switchroom/gateway-supervisor.log` but had no per-line

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.12.27",
+  "version": "0.12.28",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- fix(npm): ship vendor/ in published tarball (#1591)
- feat(gateway): per-line ISO timestamps on supervisor log (#1590)

## Test plan
- [x] Build verified — `dist/cli/switchroom.js` present (2.79MB)
- [ ] Roll to test-harness, confirm: (a) log lines have `[ISO]` prefix; (b) `<agentDir>/.claude/plugins/hindsight-memory/` files have fresh mtime
- [ ] If green: roll to fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)