### PR TITLE
fix(gateway): refine turnEnd outboundEmitted to track replyCalled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## unreleased — fix(gateway): refine turnEnd outboundEmitted to track replyCalled
+
+Phase 2b PR 3b precondition. The shadow emit at `gateway.ts:1287`
+previously sent `outboundEmitted: true` blindly on every turnEnd —
+flagged in the PR 3a CHANGELOG (gateway.ts:1277-1281 doc comment) as a
+known approximation that would corrupt invariant #5's `lastOutboundAt`
+data once dispatched live.
+
+Now reads from `endingTurn?.replyCalled` (threaded explicitly from
+`endCurrentTurnAtomic`) with a fallback to module-scope
+`currentTurn?.replyCalled` for legacy sibling-purge / restart-init
+callsites. NO_REPLY / HEARTBEAT_OK / wedged turns now correctly emit
+`outboundEmitted: false` — so a subsequent silence-poke fallback fire
+won't get over-suppressed by stale `lastOutboundAt` data when the state
+machine's tick effects are eventually wired live (PR 3b2).
+
+Pure data-quality change for the shadow trace; no behavior delta until
+the turnEnd cutover (PR 3b2) executes the dispatcher's `noteOutbound`
+effect.
+
 ## v0.12.28 — fix(npm): ship vendor/ in published tarball + per-line log timestamps
 
 The `vendor/` directory (containing the hindsight-memory plugin tree)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ callsites. NO_REPLY / HEARTBEAT_OK / wedged turns now correctly emit
 won't get over-suppressed by stale `lastOutboundAt` data when the state
 machine's tick effects are eventually wired live (PR 3b2).
 
+Implementation note: `endCurrentTurnAtomic` nulls `currentTurn` BEFORE
+calling `purgeReactionTracking`, so reading module-scope `currentTurn`
+inside the helper would always see `null` on the happy path (every
+replied turn). Fixed by threading the ending turn explicitly through
+the new optional second parameter `endingTurn?: CurrentTurn`. Legacy
+sibling-purge / restart-init callsites still pass undefined and fall
+back to module-scope — `false` is correct there since those paths
+aren't ending the current turn.
+
 Pure data-quality change for the shadow trace; no behavior delta until
 the turnEnd cutover (PR 3b2) executes the dispatcher's `noteOutbound`
 effect.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1278,13 +1278,20 @@ function streamKey(chatId: string, threadId?: number | null): string {
 }
 
 function purgeReactionTracking(key: string): void {
-  // Phase 2b shadow: turn end. The key was registered via setTurnStarted
-  // when the inbound arrived; purge is the canonical turn-end signal.
-  // outboundEmitted is approximated `true` here — refined in PR 3 to read
-  // from the per-turn `replyCalled` flag on `currentTurn`. Conservative
-  // shadow approximation is safe (only affects machine's lastOutboundAt
-  // tracking; can't drive incorrect behavior in shadow mode).
-  shadowEmit({ kind: 'turnEnd', key: key as _ChatKey, at: Date.now(), outboundEmitted: true })
+  // Phase 2b: turn end. The key was registered via setTurnStarted when
+  // the inbound arrived; purge is the canonical turn-end signal.
+  //
+  // outboundEmitted: read from `currentTurn?.replyCalled` — the gateway's
+  // authoritative signal for whether the model called the reply tool
+  // during this turn. Without this refinement (PR 3a era was blindly
+  // `true`), invariant #5's `lastOutboundAt` data would write on every
+  // turn-end regardless of model behavior, over-suppressing the
+  // silence-poke fallback for silent (NO_REPLY) turns that genuinely
+  // ARE stuck. `currentTurn` is null on cleanup paths where the turn
+  // has already been nulled (sibling-key sweep, restart-init); `false`
+  // is the safe default there too.
+  const outboundEmitted = currentTurn?.replyCalled === true
+  shadowEmit({ kind: 'turnEnd', key: key as _ChatKey, at: Date.now(), outboundEmitted })
   const msgInfo = activeReactionMsgIds.get(key)
   activeStatusReactions.delete(key)
   activeReactionMsgIds.delete(key)

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1277,20 +1277,23 @@ function streamKey(chatId: string, threadId?: number | null): string {
   return chatKey(chatId, threadId)
 }
 
-function purgeReactionTracking(key: string): void {
+function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
   // Phase 2b: turn end. The key was registered via setTurnStarted when
   // the inbound arrived; purge is the canonical turn-end signal.
   //
-  // outboundEmitted: read from `currentTurn?.replyCalled` — the gateway's
-  // authoritative signal for whether the model called the reply tool
-  // during this turn. Without this refinement (PR 3a era was blindly
-  // `true`), invariant #5's `lastOutboundAt` data would write on every
-  // turn-end regardless of model behavior, over-suppressing the
-  // silence-poke fallback for silent (NO_REPLY) turns that genuinely
-  // ARE stuck. `currentTurn` is null on cleanup paths where the turn
-  // has already been nulled (sibling-key sweep, restart-init); `false`
-  // is the safe default there too.
-  const outboundEmitted = currentTurn?.replyCalled === true
+  // outboundEmitted: read from the explicit `endingTurn` parameter when
+  // provided (canonical path via endCurrentTurnAtomic — module-scope
+  // currentTurn is already null by the time we get here), falling back
+  // to `currentTurn?.replyCalled` for the legacy callsites that haven't
+  // been threaded yet (sibling-key purges, restart-init cleanup).
+  // Without this explicit-turn handoff the shadow trace would report
+  // outboundEmitted=false on every replied turn (the dominant happy
+  // path), producing strictly worse data than the blind `true` it
+  // replaced. Invariant #5's `lastOutboundAt` correctness depends on
+  // this signal being accurate.
+  const outboundEmitted = endingTurn != null
+    ? endingTurn.replyCalled === true
+    : currentTurn?.replyCalled === true
   shadowEmit({ kind: 'turnEnd', key: key as _ChatKey, at: Date.now(), outboundEmitted })
   const msgInfo = activeReactionMsgIds.get(key)
   activeStatusReactions.delete(key)
@@ -1377,7 +1380,12 @@ function purgeReactionTracking(key: string): void {
 function endCurrentTurnAtomic(turn: CurrentTurn): void {
   if (currentTurn !== turn) return
   currentTurn = null
-  purgeReactionTracking(statusKey(turn.sessionChatId, turn.sessionThreadId))
+  // Pass `turn` so purgeReactionTracking sees the authoritative
+  // replyCalled flag even though we just nulled module-scope
+  // currentTurn. Without this, the shadow trace's outboundEmitted
+  // would be false on every replied turn (the dominant happy path),
+  // producing strictly worse data than the blind `true` it replaced.
+  purgeReactionTracking(statusKey(turn.sessionChatId, turn.sessionThreadId), turn)
 }
 
 /**


### PR DESCRIPTION
## Summary
Phase 2b PR 3b precondition. The shadow emit at \`gateway.ts:1287\` previously sent \`outboundEmitted: true\` blindly. Now reads from \`currentTurn?.replyCalled === true\` — the gateway's authoritative reply-emitted signal.

## Why this gates the next cutover
PR 3b2 will wire the dispatcher's \`noteOutbound\` effect to actually write \`lastOutboundAt\` into the state machine's perKey state. With blind \`true\`, every NO_REPLY/HEARTBEAT_OK/wedged turn would write a recent-outbound timestamp, over-suppressing silence-poke fallback fires.

## Behavior delta
None this PR (shadow mode only). The dispatcher logs \`noteOutbound\` as \`not-yet-cutover\` and the imperative \`silencePoke.noteOutbound\` path is unchanged. Pure data-quality fix.

## Risk
Tiny. \`currentTurn\` is module-scope and accessible from \`purgeReactionTracking\`. Null defaults to \`false\` on cleanup paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)