### PR TITLE
chore: release v0.12.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased — feat(gateway): prefix-cache warmup turn (Phase 1, opt-in)
+## v0.12.29 — feat(gateway): prefix-cache warmup (Phase 1, opt-in) + outboundEmitted refinement
 
 Per cold-start TTFO RFC (#1589) Option A. On every bridge-up after
 restart, the gateway synthesizes a `__WARMUP_PING__` inbound and
@@ -30,7 +30,7 @@ Phase 1 is deliberately minimal:
 shape (`meta.source="warmup"`, synthetic messageId=0), boot-target
 fallback, send-error handling.
 
-## unreleased — fix(gateway): refine turnEnd outboundEmitted to track replyCalled
+### turnEnd outboundEmitted refinement (PR 3b precondition)
 
 Phase 2b PR 3b precondition. The shadow emit at `gateway.ts:1287`
 previously sent `outboundEmitted: true` blindly on every turnEnd —

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.12.28",
+  "version": "0.12.29",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- feat(gateway): prefix-cache warmup (Phase 1, opt-in) (#1594)
- fix(gateway): refine turnEnd outboundEmitted to track replyCalled (#1593)

## Test plan
- [x] Build verified
- [ ] Canary on test-harness with SWITCHROOM_PREFIX_WARMUP=1
- [ ] Measure TTFO delta vs baseline
- [ ] Document Phase 2 (UX suppression) as follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)