### PR TITLE
feat(draft-stream): gw-trace stream-start/stream-end observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## unreleased — feat(draft-stream): gw-trace stream-start/stream-end observability
+
+PR A of the sendMessageDraft alignment sequence. Adds two always-on
+structured stderr traces from `telegram-plugin/draft-stream.ts`:
+
+- `gw-trace stream-start transport=<draft|message> reason=<…> req=<auto|draft|message> dm=<bool|undef> api=<available|absent> throttleMs=<n> [draftId=<n>] chatId=<…>` — emitted at stream creation, captures WHY the transport was chosen (draft API available + DM, draft requested but no API, explicit message, auto fell back to message because non-DM, etc.).
+- `gw-trace stream-end transport=<…> drafts=<n> sends=<n> edits=<n> fallbacks=<n> firstFireMs=<n> durationMs=<n> chars=<n> chatId=<…>` — emitted on `finalize()`, captures per-stream fire counts (so the aggregator can see "stream used 80% draft + 20% edit fallback" vs "all edits, draft never fired") + per-stream first-fire latency.
+
+Kill switch: `SWITCHROOM_STREAM_TRACES=0` (default ON).
+
+Gates the rest of the sendMessageDraft alignment PR sequence (B/C/D)
+which optimise throttle, handle the 30s expiry, and harden fallback —
+without these traces every claim of "draft is the primary path" would
+be unverifiable. Pairs with the existing per-method `tg-post` lines
+(which the supervisor log already captures) by adding the
+PER-STREAM resolution context the tg-post lines lack.
+
+4 new tests in `telegram-plugin/tests/draft-stream.test.ts` (37/37
+total) pin: stream-start with draft + DM, stream-start with auto +
+non-DM falls back to message, stream-end fire-count shape,
+kill-switch.
+
 ## v0.12.29 — feat(gateway): prefix-cache warmup (Phase 1, opt-in) + outboundEmitted refinement
 
 Per cold-start TTFO RFC (#1589) Option A. On every bridge-up after

--- a/telegram-plugin/draft-stream.ts
+++ b/telegram-plugin/draft-stream.ts
@@ -207,11 +207,49 @@ export function createDraftStream(
     warn?.('draft-stream: sendMessageDraft unavailable; falling back to sendMessage/editMessageText')
   }
 
+  // Stream-start trace — always-on, structured for grep + aggregation.
+  // Resolves WHY the chosen transport landed (req=auto|draft|message;
+  // dm=true|false|undef; api=available|absent). Gates the rest of the
+  // sendMessageDraft alignment PR sequence: without this we can't tell
+  // a draft-routing regression from a config-toggle change.
+  // Kill switch: SWITCHROOM_STREAM_TRACES=0.
+  if (process.env.SWITCHROOM_STREAM_TRACES !== '0') {
+    const reason = usesDraftTransport
+      ? 'draft'
+      : requestedTransport === 'message'
+        ? 'explicit-message'
+        : requestedTransport === 'draft' && draftApi == null
+          ? 'draft-requested-but-no-api'
+          : !prefersDraft
+            ? 'auto-non-dm'
+            : 'fallback'
+    const draftIdPart = draftId != null ? ` draftId=${draftId}` : ''
+    process.stderr.write(
+      `gw-trace stream-start transport=${usesDraftTransport ? 'draft' : 'message'} ` +
+        `reason=${reason} req=${requestedTransport} ` +
+        `dm=${config.isPrivateChat === undefined ? 'undef' : String(config.isPrivateChat)} ` +
+        `api=${draftApi != null ? 'available' : 'absent'} ` +
+        `throttleMs=${throttleMs}${draftIdPart} ` +
+        `chatId=${chatId || '-'}\n`,
+    )
+  }
+
   let messageId: number | null = config.initialMessageId ?? null
   let pendingText: string | null = null
   let lastSentText: string | null = null
   let lastSentAt = 0
   let inFlight: Promise<void> | null = null
+  // PR A observability — per-stream fire counters for the stream-end
+  // trace. draftFires/editFires/sendFires let the aggregator distinguish
+  // "stream used 80% draft + 20% edit fallback" vs "all edits, draft
+  // never fired". `firstFireAtMs` is the latency from stream-start to
+  // first wire send (matches TTFO sub-component for a single stream).
+  const streamStartedAt = Date.now()
+  let firstFireAtMs: number | null = null
+  let draftFires = 0
+  let editFires = 0
+  let sendFires = 0
+  let fallbackFires = 0
   let scheduledTimer: ReturnType<typeof setTimeout> | null = null
   let final = false
   let stopped = false
@@ -232,12 +270,15 @@ export function createDraftStream(
     if (!draftApi || draftId == null) return false
     try {
       await draftApi(chatId, draftId, textToSend)
+      if (firstFireAtMs == null) firstFireAtMs = Date.now() - streamStartedAt
+      draftFires++
       log?.(`stream → draft (id: ${draftId}, ${textToSend.length} chars)`)
       return true
     } catch (err) {
       if (shouldFallbackFromDraftTransport(err)) {
         const msg = err instanceof Error ? err.message : String(err)
         warn?.(`draft-stream: sendMessageDraft rejected — falling back to sendMessage/editMessageText (${msg})`)
+        fallbackFires++
         usesDraftTransport = false
         draftId = undefined
         return false
@@ -309,9 +350,13 @@ export function createDraftStream(
   async function sendViaMessage(textToSend: string): Promise<void> {
     if (messageId == null) {
       messageId = await send(textToSend)
+      if (firstFireAtMs == null) firstFireAtMs = Date.now() - streamStartedAt
+      sendFires++
       log?.(`stream → sent (id: ${messageId}, ${textToSend.length} chars)`)
     } else {
       await edit(messageId, textToSend)
+      if (firstFireAtMs == null) firstFireAtMs = Date.now() - streamStartedAt
+      editFires++
       log?.(`stream → edited (id: ${messageId}, ${textToSend.length} chars)`)
     }
   }
@@ -429,6 +474,22 @@ export function createDraftStream(
       }
 
       log?.(`stream finalized (id: ${messageId})`)
+
+      // Stream-end trace — pairs with stream-start. `drafts`/`edits`/
+      // `sends` lets the aggregator see the transport ratio per stream;
+      // `firstFireMs` is the per-stream send latency component of TTFO;
+      // `chars` is the final committed text length.
+      if (process.env.SWITCHROOM_STREAM_TRACES !== '0') {
+        const durationMs = Date.now() - streamStartedAt
+        process.stderr.write(
+          `gw-trace stream-end transport=${usesDraftTransport ? 'draft' : 'message'} ` +
+            `drafts=${draftFires} sends=${sendFires} edits=${editFires} ` +
+            `fallbacks=${fallbackFires} ` +
+            `firstFireMs=${firstFireAtMs ?? -1} durationMs=${durationMs} ` +
+            `chars=${(lastSentText ?? '').length} ` +
+            `chatId=${chatId || '-'}\n`,
+        )
+      }
     },
 
     getMessageId(): number | null {

--- a/telegram-plugin/tests/draft-stream.test.ts
+++ b/telegram-plugin/tests/draft-stream.test.ts
@@ -749,4 +749,91 @@ describe('createDraftStream — draft transport', () => {
     expect(callCount).toBeGreaterThan(1) // draft update + failed clear attempt
   })
 
+  // ─── PR A observability: gw-trace stream-start / stream-end ───────────
+  describe('gw-trace stream-start / stream-end', () => {
+    let captured: string[] = []
+    let originalWrite: typeof process.stderr.write
+
+    beforeEach(() => {
+      captured = []
+      originalWrite = process.stderr.write
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        const text = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8')
+        captured.push(text)
+        return true
+      }) as typeof process.stderr.write
+    })
+    afterEach(() => {
+      process.stderr.write = originalWrite
+    })
+
+    it('emits stream-start with resolved transport=draft on dm + draftApi', async () => {
+      const m = makeMock()
+      const draftApi = vi.fn(async () => ({ ok: true }))
+      const stream = createDraftStream(m.send, m.edit, {
+        throttleMs: 1000,
+        previewTransport: 'draft',
+        sendMessageDraft: draftApi,
+        chatId: 'chat-X',
+      })
+      const trace = captured.find((c) => c.includes('gw-trace stream-start'))
+      expect(trace).toBeDefined()
+      expect(trace).toContain('transport=draft')
+      expect(trace).toContain('reason=draft')
+      expect(trace).toContain('api=available')
+      expect(trace).toContain('chatId=chat-X')
+      await stream.finalize()
+    })
+
+    it('emits stream-start with reason=auto-non-dm when isPrivateChat is false', async () => {
+      const m = makeMock()
+      const draftApi = vi.fn(async () => ({ ok: true }))
+      createDraftStream(m.send, m.edit, {
+        throttleMs: 1000,
+        previewTransport: 'auto',
+        isPrivateChat: false,
+        sendMessageDraft: draftApi,
+        chatId: 'chat-Y',
+      })
+      const trace = captured.find((c) => c.includes('gw-trace stream-start'))
+      expect(trace).toBeDefined()
+      expect(trace).toContain('transport=message')
+      expect(trace).toContain('reason=auto-non-dm')
+    })
+
+    it('emits stream-end with fire counts on finalize', async () => {
+      const m = makeMock()
+      const stream = createDraftStream(m.send, m.edit, {
+        throttleMs: 50,
+        previewTransport: 'message',
+      })
+      void stream.update('first')
+      await microtaskFlush()
+      await stream.finalize()
+      const trace = captured.find((c) => c.includes('gw-trace stream-end'))
+      expect(trace).toBeDefined()
+      expect(trace).toContain('transport=message')
+      expect(trace).toMatch(/sends=[1-9]/)
+      expect(trace).toContain('firstFireMs=')
+      expect(trace).toContain('durationMs=')
+    })
+
+    it('SWITCHROOM_STREAM_TRACES=0 suppresses both traces', async () => {
+      const prev = process.env.SWITCHROOM_STREAM_TRACES
+      process.env.SWITCHROOM_STREAM_TRACES = '0'
+      try {
+        const m = makeMock()
+        const stream = createDraftStream(m.send, m.edit, {
+          throttleMs: 50,
+          previewTransport: 'message',
+        })
+        await stream.finalize()
+        expect(captured.find((c) => c.includes('gw-trace stream-'))).toBeUndefined()
+      } finally {
+        if (prev === undefined) delete process.env.SWITCHROOM_STREAM_TRACES
+        else process.env.SWITCHROOM_STREAM_TRACES = prev
+      }
+    })
+  })
+
 })


### PR DESCRIPTION
## Summary
PR A of the sendMessageDraft alignment sequence (cold-start TTFO RFC #1589 follow-on). Adds always-on structured traces from \`draft-stream.ts\`:

- \`gw-trace stream-start ...\` at stream creation — transport resolution + WHY (api-absent / non-dm / explicit / etc.) + throttleMs + draftId.
- \`gw-trace stream-end ...\` at \`finalize()\` — per-stream fire counts (drafts/sends/edits/fallbacks) + firstFireMs (per-stream TTFO) + durationMs.

Kill switch: \`SWITCHROOM_STREAM_TRACES=0\`. Default ON.

## Why this first
Existing \`tg-post\` lines count per-call but lack per-stream context. Production fleet (v0.12.29) shows mixed draft/message ratios but we can't tell WHY any individual stream chose its transport. These traces close that gap.

Gates PRs B (sub-second throttle + configurable), C (23-30s persist-then-continue chain), D (fallback robustness).

## Test plan
- [x] 37/37 tests pass (4 new for trace shape + kill-switch)
- [x] tsc clean
- [ ] Deploy to test-harness, observe \`gw-trace stream-start transport=draft\` lines on DM streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)