### PR TITLE
feat(draft-stream): sub-second draft throttle + configurable knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## unreleased — feat(draft-stream): sub-second draft throttle + configurable knob
+
+PR B of the sendMessageDraft alignment sequence. Replaces the single
+hardcoded `DEFAULT_THROTTLE_MS = 1000` with a transport-aware default:
+
+- **Draft transport** (DMs with sendMessageDraft available): **300 ms**.
+  Drafts are ephemeral and don't share `editMessageText`'s per-message
+  rate cap, so faster refresh feels live without bandwidth cost.
+- **Message transport** (groups / forums / draft API absent): **1000 ms**
+  preserved — respects Telegram's ~1 edit/sec/message practical ceiling.
+
+Both defaults are overridable via `channels.telegram.stream_throttle_ms`
+in agent yaml (wired through `SWITCHROOM_TG_STREAM_THROTTLE_MS` env).
+Explicit caller `throttleMs` still wins. Floor stays at 250 ms.
+
+Two prior `throttleMs: 600` callsites in `gateway.ts` and the
+`?? 600` default in `stream-reply-handler.ts` are removed — they were
+a legacy compromise that fought both ceilings.
+
+6 new tests pin: draft default 300, message default 1000, auto+DM→
+draft default, auto+non-DM→message default, explicit-override-wins,
+MIN_THROTTLE_MS floor. 93/93 tests total.
+
 ## unreleased — feat(draft-stream): gw-trace stream-start/stream-end observability
 
 PR A of the sendMessageDraft alignment sequence. Adds two always-on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,17 @@ Both defaults are overridable via `channels.telegram.stream_throttle_ms`
 in agent yaml (wired through `SWITCHROOM_TG_STREAM_THROTTLE_MS` env).
 Explicit caller `throttleMs` still wins. Floor stays at 250 ms.
 
-Two prior `throttleMs: 600` callsites in `gateway.ts` and the
-`?? 600` default in `stream-reply-handler.ts` are removed — they were
-a legacy compromise that fought both ceilings.
+One prior `throttleMs: 600` callsite in `gateway.ts`'s
+`executeStreamReply` is removed and the `?? 600` default in
+`stream-reply-handler.ts` is replaced with passthrough — they were a
+legacy compromise that fought both ceilings on the LLM stream_reply
+path.
+
+The PTY-activity streaming path (`gateway.ts:6438` and
+`pty-partial-handler.ts:159`) DELIBERATELY keeps its `throttleMs: 600`
+— PTY drives many tiny partials as TUIs re-render and has different
+flicker characteristics from LLM token cadence. The transport-aware
+defaults do not apply there.
 
 6 new tests pin: draft default 300, message default 1000, auto+DM→
 draft default, auto+non-DM→message default, explicit-override-wins,

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1044,6 +1044,9 @@ function channelsToEnv(agent: AgentConfig): Record<string, string> {
   if (tg.stream_mode !== undefined) {
     out.SWITCHROOM_TG_STREAM_MODE = tg.stream_mode;
   }
+  if (tg.stream_throttle_ms !== undefined) {
+    out.SWITCHROOM_TG_STREAM_THROTTLE_MS = String(tg.stream_throttle_ms);
+  }
   // Progress-card driver thresholds — only effective when stream_mode=checklist.
   if (tg.orphan_promotion_ms !== undefined) {
     out.SWITCHROOM_TG_ORPHAN_PROMOTION_MS = String(tg.orphan_promotion_ms);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -474,6 +474,19 @@ export const TelegramChannelSchema = z
         "a structured progress card from session-tail events — stable " +
         "order, per-tool status emojis, fires only on semantic transitions."
       ),
+    stream_throttle_ms: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        "Throttle window in ms between successive stream edits (or " +
+        "sendMessageDraft tics) during a turn. Lower = more responsive " +
+        "stream, higher = fewer API calls. Floored at 250 by draft-stream " +
+        "itself. Default 300 for draft transport (DMs) and 1000 for " +
+        "message transport (groups/forums). Override per-agent if a " +
+        "particular agent needs snappier or quieter streaming."
+      ),
     hotReloadStable: z
       .boolean()
       .optional()

--- a/telegram-plugin/draft-stream.ts
+++ b/telegram-plugin/draft-stream.ts
@@ -35,7 +35,17 @@ import {
 } from './draft-transport.js'
 
 const TELEGRAM_MAX_CHARS = 4096
-const DEFAULT_THROTTLE_MS = 1000
+// PR B: transport-aware defaults.
+//   Draft transport (DMs): 300 ms — drafts are ephemeral and don't share
+//     editMessageText's per-message rate cap, so we can refresh much faster.
+//     300 ms feels live without burning bandwidth.
+//   Message transport (groups / forums / draft API absent): 1000 ms — must
+//     respect Telegram's "1 edit/sec/message" practical ceiling.
+// Both defaults can be overridden per-stream via `config.throttleMs` (which
+// is itself wired from `channels.telegram.stream_throttle_ms` in the agent
+// yaml, via the SWITCHROOM_TG_STREAM_THROTTLE_MS env var the gateway reads).
+const DEFAULT_DRAFT_THROTTLE_MS = 300
+const DEFAULT_MESSAGE_THROTTLE_MS = 1000
 const MIN_THROTTLE_MS = 250
 
 /**
@@ -169,7 +179,16 @@ export function createDraftStream(
   edit: StreamEditFn,
   config: DraftStreamConfig = {},
 ): DraftStreamHandle {
-  const throttleMs = Math.max(MIN_THROTTLE_MS, config.throttleMs ?? DEFAULT_THROTTLE_MS)
+  // Transport-aware default — the actual transport resolves a few lines
+  // below, so we replicate the prefersDraft check here. An explicit
+  // `config.throttleMs` (from the operator yaml or the caller) wins.
+  const _willPreferDraft =
+    (config.previewTransport ?? 'auto') === 'draft' ||
+    ((config.previewTransport ?? 'auto') === 'auto' && config.isPrivateChat === true)
+  const _defaultForTransport = _willPreferDraft && config.sendMessageDraft != null
+    ? DEFAULT_DRAFT_THROTTLE_MS
+    : DEFAULT_MESSAGE_THROTTLE_MS
+  const throttleMs = Math.max(MIN_THROTTLE_MS, config.throttleMs ?? _defaultForTransport)
   const maxChars = config.maxChars ?? TELEGRAM_MAX_CHARS
   const idleMs = Math.max(0, config.idleMs ?? 0)
   const log = config.log

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2786,6 +2786,17 @@ function postLegacyBanner(
 // short-circuit to no-ops at runtime. `progressDriver` is typed `any`
 // so TS doesn't resolve `progressDriver?.X` to `never`.
 const streamMode = process.env.SWITCHROOM_TG_STREAM_MODE ?? 'checklist'
+// PR B: per-agent stream throttle override via channels.telegram.stream_throttle_ms.
+// When unset, draft-stream.ts applies transport-aware defaults (300 ms draft,
+// 1000 ms message). Parsed once at boot; sub-zero / NaN values fall back to
+// undefined so the per-transport default wins. See `src/agents/scaffold.ts`
+// `channelsToEnv()` for the yaml → env wiring.
+const STREAM_THROTTLE_MS_OVERRIDE: number | undefined = (() => {
+  const raw = process.env.SWITCHROOM_TG_STREAM_THROTTLE_MS
+  if (raw == null || raw === '') return undefined
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) && n >= 0 ? n : undefined
+})()
 const TURN_FLUSH_SAFETY_ENABLED = isTurnFlushSafetyEnabled()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const progressDriver: any = null
@@ -4471,7 +4482,13 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       recordOutbound,
       ...(HISTORY_ENABLED ? { getLatestInboundMessageId } : {}),
       writeError: (line) => process.stderr.write(line),
-      throttleMs: 600,
+      // PR B: drop the legacy 600 ms compromise. When the operator sets
+      // `channels.telegram.stream_throttle_ms` in yaml, the env override
+      // wins; otherwise draft-stream's transport-aware default fires
+      // (300 ms draft / 1000 ms message). `throttleMs: undefined` is a
+      // signal — handlers downgrade to `?? undefined`, which then
+      // passes through to draft-stream where the default applies.
+      ...(STREAM_THROTTLE_MS_OVERRIDE != null ? { throttleMs: STREAM_THROTTLE_MS_OVERRIDE } : {}),
       progressCardActive: streamMode === 'checklist',
     },
   )

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6435,6 +6435,14 @@ function handlePtyActivity(text: string): void {
       historyEnabled: false,
       recordOutbound,
       writeError: (line) => process.stderr.write(line),
+      // PR B note: this is the PTY-activity stream, NOT the LLM
+      // stream_reply path. PTY drives many tiny partials as a TUI
+      // re-renders; 600 ms is a deliberate compromise tuned for the
+      // PTY flicker characteristics, not LLM token cadence. The
+      // transport-aware defaults (300/1000) deliberately do NOT
+      // apply here. If you change this, also check
+      // telegram-plugin/pty-partial-handler.ts:159 which has the
+      // same value for the same reason.
       throttleMs: 600,
     },
   ).catch((err) => {

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -514,7 +514,9 @@ export async function handleStreamReply(
       threadId,
       parseMode,
       disableLinkPreview: deps.disableLinkPreview,
-      throttleMs: deps.throttleMs ?? 600,
+      // PR B: pass undefined when caller didn't override, so draft-stream's
+      // transport-aware default (300 ms draft / 1000 ms message) wins.
+      ...(deps.throttleMs != null ? { throttleMs: deps.throttleMs } : {}),
       retry: deps.retry,
       ...(replyToMessageId != null ? { replyToMessageId } : {}),
       ...(args.quote_text != null && replyToMessageId != null ? { quoteText: args.quote_text } : {}),

--- a/telegram-plugin/tests/draft-stream.test.ts
+++ b/telegram-plugin/tests/draft-stream.test.ts
@@ -836,4 +836,95 @@ describe('createDraftStream — draft transport', () => {
     })
   })
 
+  // ─── PR B: transport-aware throttle defaults ──────────────────────────
+  describe('transport-aware throttle defaults (PR B)', () => {
+    let captured: string[] = []
+    let originalWrite: typeof process.stderr.write
+
+    beforeEach(() => {
+      captured = []
+      originalWrite = process.stderr.write
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        const text = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8')
+        captured.push(text)
+        return true
+      }) as typeof process.stderr.write
+    })
+    afterEach(() => {
+      process.stderr.write = originalWrite
+    })
+
+    it('draft transport defaults to 300ms throttle (sub-second)', () => {
+      const m = makeMock()
+      const draftApi = vi.fn(async () => ({ ok: true }))
+      createDraftStream(m.send, m.edit, {
+        previewTransport: 'draft',
+        sendMessageDraft: draftApi,
+        chatId: 'c1',
+      })
+      const trace = captured.find((c) => c.includes('gw-trace stream-start'))
+      expect(trace).toBeDefined()
+      expect(trace).toContain('throttleMs=300')
+    })
+
+    it('message transport defaults to 1000ms throttle', () => {
+      const m = makeMock()
+      createDraftStream(m.send, m.edit, {
+        previewTransport: 'message',
+      })
+      const trace = captured.find((c) => c.includes('gw-trace stream-start'))
+      expect(trace).toBeDefined()
+      expect(trace).toContain('throttleMs=1000')
+    })
+
+    it('auto + DM + draftApi resolves to draft default (300ms)', () => {
+      const m = makeMock()
+      const draftApi = vi.fn(async () => ({ ok: true }))
+      createDraftStream(m.send, m.edit, {
+        previewTransport: 'auto',
+        isPrivateChat: true,
+        sendMessageDraft: draftApi,
+        chatId: 'c1',
+      })
+      const trace = captured.find((c) => c.includes('gw-trace stream-start'))
+      expect(trace).toContain('throttleMs=300')
+    })
+
+    it('auto + non-DM resolves to message default (1000ms)', () => {
+      const m = makeMock()
+      const draftApi = vi.fn(async () => ({ ok: true }))
+      createDraftStream(m.send, m.edit, {
+        previewTransport: 'auto',
+        isPrivateChat: false,
+        sendMessageDraft: draftApi,
+        chatId: 'c1',
+      })
+      const trace = captured.find((c) => c.includes('gw-trace stream-start'))
+      expect(trace).toContain('throttleMs=1000')
+    })
+
+    it('explicit config.throttleMs wins over transport default', () => {
+      const m = makeMock()
+      const draftApi = vi.fn(async () => ({ ok: true }))
+      createDraftStream(m.send, m.edit, {
+        previewTransport: 'draft',
+        sendMessageDraft: draftApi,
+        chatId: 'c1',
+        throttleMs: 500,
+      })
+      const trace = captured.find((c) => c.includes('gw-trace stream-start'))
+      expect(trace).toContain('throttleMs=500')
+    })
+
+    it('explicit override below MIN_THROTTLE_MS is floored at 250', () => {
+      const m = makeMock()
+      createDraftStream(m.send, m.edit, {
+        previewTransport: 'message',
+        throttleMs: 100,
+      })
+      const trace = captured.find((c) => c.includes('gw-trace stream-start'))
+      expect(trace).toContain('throttleMs=250')
+    })
+  })
+
 })


### PR DESCRIPTION
## Summary
PR B of the sendMessageDraft alignment sequence. Transport-aware throttle defaults: **300 ms draft / 1000 ms message**. Configurable per agent via \`channels.telegram.stream_throttle_ms\`.

## Why
The old hardcoded \`throttleMs: 600\` (gateway) and \`?? 600\` (handler) fought both ceilings — too slow for ephemeral drafts, too fast for editMessageText's 1/sec/message practical cap. Now each transport runs at its natural pace.

## Behavior
- DM streams (draft transport): refresh every 300 ms — feels live.
- Group/forum streams (message transport): preserved 1000 ms.
- Yaml override: \`channels.telegram.stream_throttle_ms: 250\` (or whatever) per agent.
- Floor: 250 ms.
- Caller-explicit \`throttleMs\` still wins.

## Test plan
- [x] 93/93 tests pass (6 new for transport-aware defaults + override + floor)
- [x] tsc clean
- [ ] Deploy: observe \`gw-trace stream-start ... throttleMs=300\` lines on DM streams; \`throttleMs=1000\` on group streams

Builds on PR #1596 (observability traces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)