### PR TITLE
feat(draft-stream): 429 + non-true fallback robustness (PR D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## unreleased — feat(draft-stream): 429 + non-true fallback robustness
+
+PR D of the sendMessageDraft alignment sequence. Closes the durability
+hole when Telegram rate-limits `sendMessageDraft` or returns a soft
+failure.
+
+Two new failure paths handled in `draft-stream.ts:sendViaDraft`:
+
+1. **429 from `sendMessageDraft`**. Extract `retry_after` via the new
+   `extractDraft429RetryAfterSecs()` helper (shared with
+   `issues-card.ts`), fall back to message transport for the rest of
+   this stream, AND push `lastSentAt` forward by `retry_after * 1000`
+   so the fallback's next send doesn't immediately re-429 (Telegram's
+   per-chat rate cap is shared across methods). The 429 detection is
+   gated on `isDraft429()` — duck-typed on grammY's `GrammyError`
+   shape (`error_code` + `parameters.retry_after` + `method` /
+   `description` carrying `sendMessageDraft`).
+
+2. **Non-true return from `sendMessageDraft`**. Per docs the method
+   returns `true` on success. An explicit `false` or `null` return
+   means the call was accepted but the draft didn't land — fall back
+   to message transport. `undefined` is treated as success because
+   grammY's typed wrapper sometimes strips the bool; we must not
+   false-positive on that.
+
+Both fallbacks bump `fallbackFires` so the `gw-trace stream-end`
+counter reflects the path the stream took.
+
+13 new tests: 9 unit tests for the two new helpers
+(`extractDraft429RetryAfterSecs`, `isDraft429`) and 4 end-to-end
+draft-stream tests (429 → fallback no further drafts;
+`false` return → fallback; `undefined` return → continued drafts;
+429 → fallbacks counter visible in stream-end). 81/81 vitest +
+52/52 bun-test.
+
 ## unreleased — feat(draft-stream): 30s persist-then-continue chain
 
 PR C of the sendMessageDraft alignment sequence. Telegram's

--- a/telegram-plugin/draft-stream.ts
+++ b/telegram-plugin/draft-stream.ts
@@ -32,6 +32,8 @@
 import {
   shouldFallbackFromDraftTransport,
   allocateDraftId,
+  isDraft429,
+  extractDraft429RetryAfterSecs,
 } from './draft-transport.js'
 
 const TELEGRAM_MAX_CHARS = 4096
@@ -350,7 +352,27 @@ export function createDraftStream(
       return true
     }
     try {
-      await draftApi(chatId, draftId, draftText)
+      const result = await draftApi(chatId, draftId, draftText)
+      // PR D: sendMessageDraft is documented to return `true` on success.
+      // A non-true (or missing) return is a soft failure — Telegram
+      // accepted the call but the draft didn't land. Fall back to
+      // message transport for the rest of this stream so the user still
+      // sees the content. This catches API surface changes + edge cases
+      // not covered by `shouldFallbackFromDraftTransport`'s regex.
+      if (result !== true && result !== undefined) {
+        // Some grammY wrappers strip the bool and return undefined on
+        // success; treat ONLY explicitly-falsy returns as failure to
+        // avoid false-positive fallback. true / undefined → success.
+        if (result === false || result === null) {
+          warn?.(
+            `draft-stream: sendMessageDraft returned non-true (${JSON.stringify(result)}) — falling back to message transport`,
+          )
+          fallbackFires++
+          usesDraftTransport = false
+          draftId = undefined
+          return false
+        }
+      }
       if (firstFireAtMs == null) firstFireAtMs = Date.now() - streamStartedAt
       // Mark the start of THIS chunk's persist window on first fire of
       // each chunk (after the previous persist boundary).
@@ -359,6 +381,30 @@ export function createDraftStream(
       log?.(`stream → draft (id: ${draftId}, ${draftText.length} chars tail)`)
       return true
     } catch (err) {
+      // PR D: dedicated 429 path. Telegram rate-limits sendMessageDraft
+      // independently from sendMessage/editMessageText. On 429:
+      //   - extract `retry_after`
+      //   - fall back to message transport for the rest of this stream
+      //   - bump `lastSentAt` so the throttle window absorbs the
+      //     retry_after delay — prevents the message-transport
+      //     fallback from immediately firing and getting 429'd too
+      //     (Telegram's per-chat rate cap is shared across methods).
+      const retryAfterSecs = extractDraft429RetryAfterSecs(err)
+      if (retryAfterSecs != null && isDraft429(err)) {
+        warn?.(
+          `draft-stream: sendMessageDraft 429 (retry_after=${retryAfterSecs}s) — falling back to message transport + backoff`,
+        )
+        fallbackFires++
+        usesDraftTransport = false
+        draftId = undefined
+        // Push lastSentAt forward so the NEXT flush waits at least
+        // `retry_after` seconds before the message-transport send.
+        // The throttle math at update() / schedule() compares
+        // `Date.now() - lastSentAt >= throttleMs`, so by moving
+        // lastSentAt forward we delay the next fire.
+        lastSentAt = Date.now() + retryAfterSecs * 1000 - throttleMs
+        return false
+      }
       if (shouldFallbackFromDraftTransport(err)) {
         const msg = err instanceof Error ? err.message : String(err)
         warn?.(`draft-stream: sendMessageDraft rejected — falling back to sendMessage/editMessageText (${msg})`)

--- a/telegram-plugin/draft-transport.ts
+++ b/telegram-plugin/draft-transport.ts
@@ -35,6 +35,56 @@ export function shouldFallbackFromDraftTransport(err: unknown): boolean {
 }
 
 /**
+ * PR D — extract the `retry_after` seconds from a grammY 429 error.
+ * Returns null when the error isn't a 429 (or has no retry_after).
+ *
+ * Shared with `issues-card.ts:extractRetryAfterSecs`. Duck-typed on the
+ * documented grammY `GrammyError` shape to keep this module
+ * test-friendly without importing `GrammyError` directly.
+ */
+export function extractDraft429RetryAfterSecs(err: unknown): number | null {
+  if (err == null || typeof err !== 'object') return null
+  const e = err as { error_code?: unknown; parameters?: { retry_after?: unknown } }
+  if (e.error_code !== 429) return null
+  const ra = e.parameters?.retry_after
+  if (typeof ra === 'number' && Number.isFinite(ra) && ra > 0) return ra
+  return null
+}
+
+/**
+ * PR D — was this a 429 from `sendMessageDraft` specifically? Used by
+ * draft-stream to differentiate "draft is rate-limited" (transient,
+ * just back off this stream) from a non-429 send error (handled
+ * separately by `shouldFallbackFromDraftTransport`).
+ *
+ * Both cases trigger fallback to message transport for the rest of
+ * the stream, but the 429 case ALSO bumps the throttle window to
+ * honor Telegram's `retry_after` — so the message-transport fallback
+ * doesn't immediately fire a fresh send before Telegram's cooldown
+ * elapses and re-429s.
+ */
+export function isDraft429(err: unknown): boolean {
+  if (extractDraft429RetryAfterSecs(err) == null) return false
+  // grammY GrammyError carries the method name in its `method` field.
+  // Best-effort: match either the structured method or the error text.
+  if (typeof err === 'object' && err != null && 'method' in err) {
+    const m = (err as { method?: unknown }).method
+    if (typeof m === 'string' && /sendMessageDraft/i.test(m)) return true
+  }
+  const text =
+    typeof err === 'string'
+      ? err
+      : err instanceof Error
+        ? err.message
+        : typeof err === 'object' && err != null && 'description' in err
+          ? typeof (err as { description: unknown }).description === 'string'
+            ? (err as { description: string }).description
+            : ''
+          : ''
+  return /sendMessageDraft/i.test(text)
+}
+
+/**
  * Symbol-keyed shared counter for draft-id allocation across concurrent
  * streams (mirrors openclaw's getDraftStreamState). Using Symbol.for ensures
  * the same counter is shared even if this module is loaded multiple times

--- a/telegram-plugin/tests/draft-stream.test.ts
+++ b/telegram-plugin/tests/draft-stream.test.ts
@@ -1075,4 +1075,131 @@ describe('createDraftStream — draft transport', () => {
     })
   })
 
+  // ─── PR D: 429 + non-true return fallback robustness ──────────────────
+  describe('429 + non-true fallback (PR D)', () => {
+    it('429 on draft falls back to message transport (no further draft fires)', async () => {
+      const m = makeMock()
+      let draftCalls = 0
+      const sendMessageDraft = vi.fn(async () => {
+        draftCalls++
+        const err = new Error('sendMessageDraft: Too Many Requests: retry after 3') as Error & {
+          error_code?: number
+          method?: string
+          parameters?: { retry_after?: number }
+        }
+        err.error_code = 429
+        err.method = 'sendMessageDraft'
+        err.parameters = { retry_after: 3 }
+        throw err
+      })
+      const stream = createDraftStream(m.send, m.edit, {
+        throttleMs: 50,
+        previewTransport: 'draft',
+        sendMessageDraft,
+        chatId: 'chat-429',
+      })
+
+      void stream.update('hello')
+      await microtaskFlush(20)
+      expect(draftCalls).toBe(1)
+      await microtaskFlush(20)
+      vi.advanceTimersByTime(3500)
+      await microtaskFlush(20)
+      await stream.finalize()
+      expect(m.sendCalls.length).toBeGreaterThanOrEqual(1)
+      // sendMessageDraft was NOT called again after the 429.
+      expect(draftCalls).toBe(1)
+    })
+
+    it('non-true (false) return from sendMessageDraft triggers fallback', async () => {
+      const m = makeMock()
+      let draftCalls = 0
+      const sendMessageDraft = vi.fn(async () => {
+        draftCalls++
+        return false
+      })
+      const stream = createDraftStream(m.send, m.edit, {
+        throttleMs: 50,
+        previewTransport: 'draft',
+        sendMessageDraft,
+        chatId: 'chat-nonbool',
+      })
+      void stream.update('content')
+      await microtaskFlush(20)
+      expect(draftCalls).toBe(1)
+      await microtaskFlush(20)
+      vi.advanceTimersByTime(100)
+      await microtaskFlush(20)
+      await stream.finalize()
+      // Subsequent updates / finalize do NOT re-invoke sendMessageDraft.
+      expect(draftCalls).toBe(1)
+      expect(m.sendCalls.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('undefined return is treated as success (does not trigger fallback)', async () => {
+      // grammY's typed wrapper sometimes returns void/undefined on
+      // success. We must not false-positive fallback on those.
+      const m = makeMock()
+      let draftCalls = 0
+      const sendMessageDraft = vi.fn(async () => {
+        draftCalls++
+        return undefined
+      })
+      const stream = createDraftStream(m.send, m.edit, {
+        throttleMs: 50,
+        previewTransport: 'draft',
+        sendMessageDraft,
+        chatId: 'chat-undef',
+      })
+      void stream.update('first')
+      await microtaskFlush(20)
+      vi.advanceTimersByTime(100)
+      void stream.update('second')
+      await microtaskFlush(20)
+      vi.advanceTimersByTime(100)
+      await microtaskFlush(20)
+      await stream.finalize()
+      expect(draftCalls).toBeGreaterThan(1)
+    })
+
+    it('429 path increments fallbacks counter (visible in stream-end trace)', async () => {
+      const captured: string[] = []
+      const originalWrite = process.stderr.write
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        const text = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8')
+        captured.push(text)
+        return true
+      }) as typeof process.stderr.write
+      try {
+        const m = makeMock()
+        const sendMessageDraft = vi.fn(async () => {
+          const err = new Error('429') as Error & {
+            error_code?: number
+            method?: string
+            parameters?: { retry_after?: number }
+          }
+          err.error_code = 429
+          err.method = 'sendMessageDraft'
+          err.parameters = { retry_after: 2 }
+          throw err
+        })
+        const stream = createDraftStream(m.send, m.edit, {
+          throttleMs: 50,
+          previewTransport: 'draft',
+          sendMessageDraft,
+          chatId: 'chat-429-trace',
+        })
+        void stream.update('text')
+        await microtaskFlush(20)
+        vi.advanceTimersByTime(3000)
+        await stream.finalize()
+        const endLine = captured.find((c) => c.includes('gw-trace stream-end'))
+        expect(endLine).toBeDefined()
+        expect(endLine).toMatch(/fallbacks=[1-9]/)
+      } finally {
+        process.stderr.write = originalWrite
+      }
+    })
+  })
+
 })

--- a/telegram-plugin/tests/draft-transport.test.ts
+++ b/telegram-plugin/tests/draft-transport.test.ts
@@ -9,6 +9,8 @@ import {
   shouldFallbackFromDraftTransport,
   allocateDraftId,
   __resetDraftIdForTests,
+  extractDraft429RetryAfterSecs,
+  isDraft429,
 } from '../draft-transport.js'
 
 describe('DRAFT_METHOD_UNAVAILABLE_RE', () => {
@@ -137,5 +139,73 @@ describe('allocateDraftId', () => {
     expect(allocateDraftId()).toBe(2_147_483_647)
     // Next should wrap
     expect(allocateDraftId()).toBe(1)
+  })
+})
+
+// ─── PR D: 429 + non-True helpers ──────────────────────────────────────
+
+describe('extractDraft429RetryAfterSecs (PR D)', () => {
+  it('returns retry_after on a grammY 429', () => {
+    const err = { error_code: 429, parameters: { retry_after: 7 } }
+    expect(extractDraft429RetryAfterSecs(err)).toBe(7)
+  })
+
+  it('returns null on non-429 error_code', () => {
+    const err = { error_code: 400, parameters: { retry_after: 7 } }
+    expect(extractDraft429RetryAfterSecs(err)).toBeNull()
+  })
+
+  it('returns null when retry_after is missing', () => {
+    const err = { error_code: 429 }
+    expect(extractDraft429RetryAfterSecs(err)).toBeNull()
+  })
+
+  it('returns null when retry_after is non-positive', () => {
+    expect(extractDraft429RetryAfterSecs({ error_code: 429, parameters: { retry_after: 0 } })).toBeNull()
+    expect(extractDraft429RetryAfterSecs({ error_code: 429, parameters: { retry_after: -1 } })).toBeNull()
+  })
+
+  it('returns null on primitive errors', () => {
+    expect(extractDraft429RetryAfterSecs(null)).toBeNull()
+    expect(extractDraft429RetryAfterSecs(undefined)).toBeNull()
+    expect(extractDraft429RetryAfterSecs('boom')).toBeNull()
+    expect(extractDraft429RetryAfterSecs(42)).toBeNull()
+  })
+})
+
+describe('isDraft429 (PR D)', () => {
+  it('returns true when 429 carries method=sendMessageDraft', () => {
+    const err = {
+      error_code: 429,
+      parameters: { retry_after: 5 },
+      method: 'sendMessageDraft',
+    }
+    expect(isDraft429(err)).toBe(true)
+  })
+
+  it('returns true when 429 description mentions sendMessageDraft', () => {
+    const err = {
+      error_code: 429,
+      parameters: { retry_after: 5 },
+      description: 'sendMessageDraft: Too Many Requests: retry after 5',
+    }
+    expect(isDraft429(err)).toBe(true)
+  })
+
+  it('returns false on 429 from a different method', () => {
+    const err = {
+      error_code: 429,
+      parameters: { retry_after: 5 },
+      method: 'sendMessage',
+    }
+    expect(isDraft429(err)).toBe(false)
+  })
+
+  it('returns false on non-429 errors even when mentioning sendMessageDraft', () => {
+    const err = {
+      error_code: 400,
+      description: 'sendMessageDraft: bad request',
+    }
+    expect(isDraft429(err)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
Final PR of the sendMessageDraft alignment epic. Closes the durability hole when Telegram rate-limits \`sendMessageDraft\` or returns a soft failure.

## What
Two new failure paths in \`draft-stream.ts:sendViaDraft\`:

**1. 429 (rate-limited):**
- Extract \`retry_after\` via new \`extractDraft429RetryAfterSecs()\` helper (shared with \`issues-card.ts\`).
- Fall back to message transport for the rest of the stream.
- Bump \`lastSentAt\` forward by \`retry_after * 1000\` so the message-transport fallback doesn't immediately re-429 (Telegram's per-chat rate cap is shared across methods).
- 429 gated on \`isDraft429()\` — matches the method name or description carrying \`sendMessageDraft\`.

**2. Non-true return:**
- Per Telegram docs sendMessageDraft returns \`true\` on success.
- \`false\` / \`null\` → fall back to message transport.
- \`undefined\` → treated as success (grammY's typed wrapper strips the bool; we must not false-positive).

Both bump \`fallbackFires\` for the \`gw-trace stream-end\` counter.

## Test plan
- [x] 13 new tests (9 unit for the helpers + 4 end-to-end for draft-stream behavior)
- [x] 81/81 vitest passes
- [x] 52/52 bun-test passes
- [x] tsc clean
- [ ] Validate live: trigger 429 on test-harness (synthetic or natural) — observe \`gw-trace stream-end ... fallbacks=N\`

Closes the alignment epic (A: traces #1596, B: throttle #1597, C: persist-chain #1598, D: this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)