### PR TITLE
fix(gateway): delete duplicate turnEnd shadow emits (PR 3b step 1)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5828,7 +5828,10 @@ function handleSessionEvent(ev: SessionEvent): void {
         const ceKey = statusKey(chatId, threadId)
         const ctrl = activeStatusReactions.get(ceKey)
         if (ctrl) ctrl.setError()
-        purgeReactionTracking(ceKey)
+        // Duplicate-emit removed (#1603 audit, step 1): the canonical
+        // endCurrentTurnAtomic(turn) call at line ~5851 below already
+        // invokes purgeReactionTracking on the same ceKey. The bare
+        // call here was firing a second shadow `turnEnd` per traversal.
         // Surfaced during CC-5 investigation (`docs/status-ask-cause-classes.md`):
         // the context-exhaust bail path teardown was missing
         // `silencePoke.endTurn(key)`. Without it, the silence-poke state for
@@ -5986,7 +5989,10 @@ function handleSessionEvent(ev: SessionEvent): void {
         // Fall through to normal state cleanup (ctrl.setDone, purge, etc.)
         // but skip the regular closeProgressLane so we don't re-finalize.
         if (ctrl) ctrl.setDone()
-        purgeReactionTracking(statusKey(chatId, threadId))
+        // Duplicate-emit removed (#1603 audit, step 1): endCurrentTurnAtomic(turn)
+        // at line ~6049 below invokes purgeReactionTracking on the same key
+        // (statusKey(chatId, threadId)). The bare call here was firing a
+        // second shadow `turnEnd` per silent-marker traversal.
         // Match the normal turn_end path's telemetry so silent-marker turns
         // still appear in turn-duration graphs.
         {


### PR DESCRIPTION
## Summary

First implementation step from the per-callsite migration plan landed in #1603. Mechanical deletion of two bare `purgeReactionTracking(key)` callsites that were firing a duplicate shadow `turnEnd` event:

- `telegram-plugin/gateway/gateway.ts:5831` — context-exhaust bail path. Line 5851 already calls `endCurrentTurnAtomic(turn)` on the same `ceKey`.
- `telegram-plugin/gateway/gateway.ts:5989` — silent-marker turn finalize. Line 6049 already calls `endCurrentTurnAtomic(turn)` on the same `statusKey`.

## Why

The shadow trace's `turnEnd` events are the source of truth for the PR 3b shadow→live cutover. With these duplicate emits in place, every context-exhaust or silent-marker traversal produces 2 events for one logical turn, which would break the state machine's per-turn invariants (RFC §4 "exactly one `turnEnd` per logical turn"). Removing them is a prerequisite for the cutover.

## What changes

- 2 `purgeReactionTracking(key)` lines deleted.
- Each replaced with an inline comment pointing at the canonical `endCurrentTurnAtomic(turn)` call that does the work, citing #1603 audit step 1, so a future reader doesn't reintroduce them.

## No runtime behaviour change

The user-visible turn lifecycle is owned by `endCurrentTurnAtomic` which is still called (unchanged) at lines 5851 and 6049 immediately after. The deleted bare-purge calls were redundant — both invoke `purgeReactionTracking` on the identical key.

## Test plan

- [x] `vitest run` — 2739/2739 passing
- [x] `bun test gateway-bridge.test.ts inbound-delivery-machine.test.ts` — 31/31 passing
- [x] `tsc --noEmit` clean
- [ ] CI green
- [ ] Fresh-process reviewer APPROVE

## Follow-ups

Per #1603 audit, remaining PR 3b steps:
- Step 2: fix gateway.ts:1601 premature emit
- Step 3: thread `turn` at 6130, 6258
- Step 4: route 6265 through `endCurrentTurnAtomic`
- Step 5: refactor 3096 with explicit `outboundEmitted=false`
- Step 6: new UAT scenario (5 reply-tool calls → exactly one `turnEnd`)
- Step 7: 48h test-harness bake, then shadow→live cutover