### PR TITLE
fix(gateway): thread turn at post-null IIFE turn-flush sites (PR 3b step 3)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6164,7 +6164,15 @@ function handleSessionEvent(ev: SessionEvent): void {
                 // mirroring this contract — so reply-only turns transition
                 // to terminal 👍 in their own success path rather than
                 // relying on this dedup heuristic.
-                purgeReactionTracking(statusKey(backstopChatId, backstopThreadId))
+                //
+                // PR 3b step 3 (#1603 audit): thread the captured `turn`
+                // explicitly. `endCurrentTurnAtomic(turn)` ran at line ~6120
+                // before this IIFE started, so `currentTurn === null` by
+                // now — without an explicit endingTurn argument, the shadow
+                // trace would read `outboundEmitted=false` for this dedup
+                // path even though `recentCount > 0` proves the reply tool
+                // did fire (turn.replyCalled === true).
+                purgeReactionTracking(statusKey(backstopChatId, backstopThreadId), turn)
                 return
               }
             } catch {}
@@ -6292,7 +6300,19 @@ function handleSessionEvent(ev: SessionEvent): void {
             process.stderr.write(`telegram gateway: turn-flush send failed: ${(err as Error).message}\n`)
             if (backstopCtrl) backstopCtrl.setError()
           } finally {
-            purgeReactionTracking(statusKey(backstopChatId, backstopThreadId))
+            // PR 3b step 3 (#1603 audit): thread the captured `turn`
+            // explicitly. The turn-flush backstop runs inside this IIFE
+            // after `endCurrentTurnAtomic(turn)` already nulled
+            // `currentTurn` at line ~6120. Without threading, the shadow
+            // trace would read `outboundEmitted=currentTurn?.replyCalled
+            // === undefined` → false. For the turn-flush path
+            // `turn.replyCalled` is `false` regardless (the model didn't
+            // call the reply tool — the gateway backstop did the work),
+            // so the threaded value matches the existing fallback here.
+            // But pinning the source via the captured turn matches the
+            // canonical pattern and survives any future change to how
+            // `currentTurn` is sequenced.
+            purgeReactionTracking(statusKey(backstopChatId, backstopThreadId), turn)
           }
         })()
         return


### PR DESCRIPTION
## Summary

Step 3 of the per-callsite migration plan from #1603. Threads the captured `turn` closure variable into `purgeReactionTracking` at the two sites that live inside the turn-flush backstop IIFE (`gateway.ts:6141-6297`). The IIFE runs AFTER `endCurrentTurnAtomic(turn)` at line ~6120 nulls `currentTurn`, so without threading, the shadow trace's `outboundEmitted` would read undefined → false on both:

- **gateway.ts:6167 — dedup branch.** Fires when `recentCount > 0` proves the reply tool DID land messages, so `turn.replyCalled === true` is the authoritative signal. Pre-fix shadow data was incorrect (reported `outboundEmitted=false` for a path that's literally the "the reply tool sent messages" branch).
- **gateway.ts:6295 — turn-flush finally.** The backstop did the work, not the model's reply tool, so `turn.replyCalled === false` matches the prior fallback value. The fix is canonical-pattern alignment.

## Why

Two of the seven bare-purge callsites identified in #1603's audit, both inside the IIFE that post-dates `currentTurn` nulling. Routing through `endCurrentTurnAtomic` would no-op via its `currentTurn === turn` guard — so explicit-turn threading is the right migration here per the audit's row-by-row recommendation.

## Test plan

- [x] `vitest run telegram-plugin/` — 2739/2739 passing
- [x] `bun test` for gateway-bridge + inbound-delivery-machine + reaction-trigger* — 75/75 passing
- [x] `tsc --noEmit` clean
- [ ] CI green
- [ ] Fresh-process reviewer APPROVE

## Follow-ups

- Step 4: route gateway.ts:6302 through `endCurrentTurnAtomic` (dominant happy-path turn-end tail, bit-identical refactor)
- Step 5: refactor gateway.ts:3127 silence-poke fallback with explicit `outboundEmitted=false`
- Step 6: new UAT scenario (5 reply-tool calls → exactly one `turnEnd`)
- Step 7: 48h test-harness bake → shadow→live cutover