### PR TITLE
fix(gateway): delete duplicate turnEnd at happy-path tail (PR 3b step 4)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6319,7 +6319,16 @@ function handleSessionEvent(ev: SessionEvent): void {
       }
 
       if (ctrl) ctrl.setDone()
-      purgeReactionTracking(statusKey(chatId, threadId))
+      // Duplicate-emit removed (#1603 audit, step 4 — the audit's
+      // original "route through endCurrentTurnAtomic" recommendation
+      // missed that this same code path already calls
+      // `endCurrentTurnAtomic(turn)` ~90 lines below at line ~6412
+      // on the same key — `chatId === turn.sessionChatId` and
+      // `threadId === turn.sessionThreadId` per the bindings at
+      // ~5946-5947. Removing this bare call closes the last duplicate
+      // shadow-`turnEnd` emit on the dominant happy-path turn-end
+      // tail; the canonical primitive below still fires the single
+      // authoritative turnEnd with the threaded turn).
       {
         const sKey = streamKey(chatId, threadId)
         const turnDurationMs = turn.startedAt > 0 ? Date.now() - turn.startedAt : 0


### PR DESCRIPTION
## Summary

Step 4 of the per-callsite migration plan from #1603. The audit's original recommendation for this site (gateway.ts:6322, formerly :6265) was "route through `endCurrentTurnAtomic` — the dominant happy-path turn-end, bit-identical refactor." On closer inspection, the same code path already invokes `endCurrentTurnAtomic(turn)` ~90 lines below (line 6412) on the **same key**:

- gateway.ts:5946-5947 binds `chatId = turn.sessionChatId` and `threadId = turn.sessionThreadId`.
- The deleted line 6322 was `purgeReactionTracking(statusKey(chatId, threadId))`.
- The surviving line 6412 is `endCurrentTurnAtomic(turn)` → `purgeReactionTracking(statusKey(turn.sessionChatId, turn.sessionThreadId), turn)`.

Identical keys. This is the same **duplicate-emit class** as steps 1's deletions at 5831/5989, just spread further apart in the code (telemetry + DB recording + marker cleanup live between them). Fix is the same shape: delete the bare call.

## Side benefit

The idle-gate at lines 1340-1378 (pendingInbound flush, restart trigger, `maybeProactiveCompact`) now fires once — at the natural point after all turn-end telemetry / DB recording / marker cleanup — rather than twice.

## Test plan

- [x] `vitest run telegram-plugin/` — 2739/2739 passing
- [x] `bun test` for gateway-bridge + inbound-delivery-machine + reaction-trigger* — 75/75 passing
- [x] `tsc --noEmit` clean
- [ ] CI green
- [ ] Fresh-process reviewer APPROVE

## Audit table update

The RFC's PR 3b table should be amended in a follow-up to reclassify 6322 from "bit-identical refactor target" to "duplicate-emit, delete the bare call" (matching 5831/5989). Not gating this PR — the implementation here is the authoritative record.

## Follow-ups

- Step 5: refactor gateway.ts:3127 silence-poke fallback with explicit `outboundEmitted=false`
- Step 6: new UAT scenario (5 reply-tool calls → exactly one `turnEnd`)
- Step 7: 48h test-harness bake → shadow→live cutover