### PR TITLE
fix(gateway): silence-poke fallback explicit outboundEmitted=false (PR 3b step 5)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1303,23 +1303,34 @@ function clearReactionState(key: string): void {
   }
 }
 
-function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
+function purgeReactionTracking(
+  key: string,
+  endingTurn?: CurrentTurn,
+  outboundEmittedOverride?: boolean,
+): void {
   // Phase 2b: turn end. The key was registered via setTurnStarted when
   // the inbound arrived; purge is the canonical turn-end signal.
   //
-  // outboundEmitted: read from the explicit `endingTurn` parameter when
-  // provided (canonical path via endCurrentTurnAtomic — module-scope
-  // currentTurn is already null by the time we get here), falling back
-  // to `currentTurn?.replyCalled` for the legacy callsites that haven't
-  // been threaded yet (sibling-key purges, restart-init cleanup).
-  // Without this explicit-turn handoff the shadow trace would report
-  // outboundEmitted=false on every replied turn (the dominant happy
-  // path), producing strictly worse data than the blind `true` it
-  // replaced. Invariant #5's `lastOutboundAt` correctness depends on
-  // this signal being accurate.
-  const outboundEmitted = endingTurn != null
-    ? endingTurn.replyCalled === true
-    : currentTurn?.replyCalled === true
+  // outboundEmitted derivation, in precedence order:
+  //   1. Explicit `outboundEmittedOverride` (e.g. silence-poke
+  //      framework fallback FORCES false because the 5-min fallback
+  //      firing proves visible delivery never happened — regardless of
+  //      whatever `replyCalled` the wedged turn object carries).
+  //   2. `endingTurn.replyCalled` when the canonical caller threads
+  //      the authoritative turn (endCurrentTurnAtomic path; module-scope
+  //      currentTurn is already null by the time we get here).
+  //   3. `currentTurn?.replyCalled` fallback for the (now-vanishing)
+  //      legacy callsites. Without the explicit-turn handoff the shadow
+  //      trace would report outboundEmitted=false on every replied
+  //      turn (the dominant happy path), producing strictly worse data
+  //      than the blind `true` it replaced. Invariant #5's
+  //      `lastOutboundAt` correctness depends on this signal being
+  //      accurate.
+  const outboundEmitted = outboundEmittedOverride !== undefined
+    ? outboundEmittedOverride
+    : endingTurn != null
+      ? endingTurn.replyCalled === true
+      : currentTurn?.replyCalled === true
   shadowEmit({ kind: 'turnEnd', key: key as _ChatKey, at: Date.now(), outboundEmitted })
   clearReactionState(key)
   activeTurnStartedAt.delete(key)
@@ -3124,7 +3135,15 @@ silencePoke.startTimer({
     // Drop silence-poke state and clear turn-active so the next inbound
     // for this chat starts a fresh turn instead of queueing forever.
     silencePoke.endTurn(fbKey)
-    purgeReactionTracking(fbKey)
+    // PR 3b step 5 (#1603 audit): force outboundEmitted=false. The
+    // framework fallback fires precisely because visible delivery
+    // didn't happen in 5 min — `wedgedTurn.replyCalled` may have been
+    // set during the turn (e.g. reply tool invoked but Telegram side
+    // never confirmed delivery), but from the user's perspective no
+    // outbound landed. The state machine's `noteOutbound` effect
+    // must NOT fire for this path. Pass `undefined` for endingTurn
+    // and `false` as the explicit override.
+    purgeReactionTracking(fbKey, undefined, false)
     // Defense-in-depth: the fallback's purgeReactionTracking above
     // clears the canonical statusKey(chatId, threadId) for fbKey
     // only. activeTurnStartedAt can hold sibling entries for the
@@ -3137,10 +3156,14 @@ silencePoke.startTimer({
     // purger. Multi-chat-safe — only touches keys for fbChatId, so
     // #1546's intentional cross-chat safety guard is preserved.
     // See turn-state-purge.ts.
+    //
+    // Same `outboundEmitted=false` rationale as the bare call above —
+    // wrap the purger so every sibling-key purge emits a fallback
+    // shadow turnEnd with the truthful "no visible delivery" signal.
     const fbExtraPurge = purgeStaleTurnsForChat(
       fbChatId,
       activeTurnStartedAt.keys(),
-      purgeReactionTracking,
+      (k) => purgeReactionTracking(k, undefined, false),
     )
     // Null `currentTurn` if it's still pointing at the wedged turn —
     // when claude eventually fires a late `turn_end` for this session


### PR DESCRIPTION
## Summary

Step 5 of the per-callsite migration plan from #1603 — the last bare `purgeReactionTracking(key)` callsite. The silence-poke framework fallback at `gateway.ts:3127` (and its sibling-key sweep at :3143) fires after 5 min of agent silence with no visible outbound. The shadow trace's `outboundEmitted` field must be **false** for this path regardless of `wedgedTurn.replyCalled` — the fallback firing is by definition "no visible delivery happened".

## Fix

Extend `purgeReactionTracking` signature with a third `outboundEmittedOverride?: boolean` parameter (highest precedence in the derivation):

```ts
function purgeReactionTracking(
  key: string,
  endingTurn?: CurrentTurn,
  outboundEmittedOverride?: boolean,
): void
```

Apply at both fallback sites:
- `gateway.ts:3127` — `purgeReactionTracking(fbKey, undefined, false)`
- `gateway.ts:3143` — wrap the iterator's purger as `(k) => purgeReactionTracking(k, undefined, false)`

## Why

`wedgedTurn.replyCalled` could be `true` (e.g. the reply tool was invoked but Telegram-side delivery never landed before the wedge), making the prior `currentTurn?.replyCalled` fallback fire `outboundEmitted=true` for a path where the user explicitly saw nothing arrive. Threading `wedgedTurn` would inherit the same bug. An explicit override is the only correct signal.

## Audit complete

This closes the seven-row audit from #1603. **All live callsites now emit `outboundEmitted` from an authoritative source:**

- `gateway.ts:1408` — canonical (via `endCurrentTurnAtomic`), threads `turn`
- `gateway.ts:3127` — silence-poke fallback, explicit `false` (this PR)
- `gateway.ts:3143` — sibling-key sweep, explicit `false` (this PR)
- `gateway.ts:6175` — turn-flush dedup branch, threads `turn` (step 3)
- `gateway.ts:6315` — turn-flush finally, threads `turn` (step 3)
- `gateway.ts:6412` — canonical happy-path tail, via `endCurrentTurnAtomic` threads `turn` (step 4 deleted the bare duplicate above it)

Unblocks step 7 (shadow→live cutover) once step 6's UAT lands and a 48h bake passes.

## Test plan

- [x] `vitest run telegram-plugin/` — 2739/2739 passing
- [x] `bun test` for gateway-bridge + inbound-delivery-machine + reaction-trigger* — 75/75 passing
- [x] `tsc --noEmit` clean
- [ ] CI green
- [ ] Fresh-process reviewer APPROVE

## Follow-ups

- Step 6: new UAT scenario (5 reply-tool calls in one turn → exactly one `turnEnd`)
- Step 7: 48h test-harness bake → flip `shadowEmit(turnEnd)` to live dispatch