### PR TITLE
chore: release v0.13.2 — revert PR 3b steps 1-5 (canary regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v0.13.2 — revert PR 3b steps 1-5 (canary regression)
+
+The v0.13.1 canary on test-harness surfaced a regression: the
+canonical shadow `turnEnd` event no longer fires on the dominant
+happy-path turn-end. The audit's premise — that
+`endCurrentTurnAtomic(turn)` at gateway.ts:~6444 would emit the
+single authoritative event after the bare-purge deletions — turned
+out to be empirically wrong for the trivial-reply path. The
+v0.13.0 trace shows one `turnEnd outbound=false` per trivial UAT;
+the v0.13.1 trace shows zero.
+
+No user-visible impact (no fleet rolled to v0.13.1; test-harness
+rolled back to v0.13.0 within minutes of the canary). The shadow
+trace correctness fixes that PR 3b was meant to deliver are
+strictly worse off — fewer correct emits, not more.
+
+Reverts the gateway.ts changes from PRs #1604, #1605, #1606,
+#1607, #1608. The #1603 RFC addendum remains in place as
+documentation; it accurately describes the audit's findings, only
+the implementation order needs revisiting (per-step empirical
+bisection required, not pure code-review).
+
+v0.13.2 = v0.13.0 + the #1602 sends-counter fix (already shipped
+in v0.13.1) + no other changes to gateway.ts.
+
+The audit work (the per-callsite mapping) remains valuable. The
+re-implementation will:
+- Bisect each step on test-harness before committing.
+- Assert the trivial-UAT shadow `turnEnd` count BEFORE AND AFTER
+  each individual change.
+- Treat any drop in emit count as a blocker, not progress.
+
 ## v0.13.1 — sends counter fix + shadow `turnEnd` correctness audit (PR 3b)
 
 Two themes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1278,62 +1278,32 @@ function streamKey(chatId: string, threadId?: number | null): string {
   return chatKey(chatId, threadId)
 }
 
-/**
- * Reaction-state cleanup — controller + msg-id maps + active-reaction
- * file removal. PURE reaction-cleanup, no turn-end semantics:
- *   - does NOT emit shadow `turnEnd`
- *   - does NOT clear `activeTurnStartedAt` (turn-active marker)
- *   - does NOT fire the model-idle restart/flush gate
- *
- * Called from mid-turn signals like `endStatusReaction` (post-reply-tool,
- * post-stream-reply-finalize) where the 👍 transition fires but the
- * turn is still active. Per #1603 audit step 2: the reply tool was
- * previously calling `purgeReactionTracking` here, which fired premature
- * shadow `turnEnd` events and cleared `activeTurnStartedAt` mid-turn —
- * the latter would trigger the model-idle restart probe and
- * pendingInbound flush as if claude had gone idle.
- */
-function clearReactionState(key: string): void {
+function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
+  // Phase 2b: turn end. The key was registered via setTurnStarted when
+  // the inbound arrived; purge is the canonical turn-end signal.
+  //
+  // outboundEmitted: read from the explicit `endingTurn` parameter when
+  // provided (canonical path via endCurrentTurnAtomic — module-scope
+  // currentTurn is already null by the time we get here), falling back
+  // to `currentTurn?.replyCalled` for the legacy callsites that haven't
+  // been threaded yet (sibling-key purges, restart-init cleanup).
+  // Without this explicit-turn handoff the shadow trace would report
+  // outboundEmitted=false on every replied turn (the dominant happy
+  // path), producing strictly worse data than the blind `true` it
+  // replaced. Invariant #5's `lastOutboundAt` correctness depends on
+  // this signal being accurate.
+  const outboundEmitted = endingTurn != null
+    ? endingTurn.replyCalled === true
+    : currentTurn?.replyCalled === true
+  shadowEmit({ kind: 'turnEnd', key: key as _ChatKey, at: Date.now(), outboundEmitted })
   const msgInfo = activeReactionMsgIds.get(key)
   activeStatusReactions.delete(key)
   activeReactionMsgIds.delete(key)
+  activeTurnStartedAt.delete(key)
   if (msgInfo) {
     const agentDir = resolveAgentDirFromEnv()
     if (agentDir != null) removeActiveReaction(agentDir, msgInfo.chatId, msgInfo.messageId)
   }
-}
-
-function purgeReactionTracking(
-  key: string,
-  endingTurn?: CurrentTurn,
-  outboundEmittedOverride?: boolean,
-): void {
-  // Phase 2b: turn end. The key was registered via setTurnStarted when
-  // the inbound arrived; purge is the canonical turn-end signal.
-  //
-  // outboundEmitted derivation, in precedence order:
-  //   1. Explicit `outboundEmittedOverride` (e.g. silence-poke
-  //      framework fallback FORCES false because the 5-min fallback
-  //      firing proves visible delivery never happened — regardless of
-  //      whatever `replyCalled` the wedged turn object carries).
-  //   2. `endingTurn.replyCalled` when the canonical caller threads
-  //      the authoritative turn (endCurrentTurnAtomic path; module-scope
-  //      currentTurn is already null by the time we get here).
-  //   3. `currentTurn?.replyCalled` fallback for the (now-vanishing)
-  //      legacy callsites. Without the explicit-turn handoff the shadow
-  //      trace would report outboundEmitted=false on every replied
-  //      turn (the dominant happy path), producing strictly worse data
-  //      than the blind `true` it replaced. Invariant #5's
-  //      `lastOutboundAt` correctness depends on this signal being
-  //      accurate.
-  const outboundEmitted = outboundEmittedOverride !== undefined
-    ? outboundEmittedOverride
-    : endingTurn != null
-      ? endingTurn.replyCalled === true
-      : currentTurn?.replyCalled === true
-  shadowEmit({ kind: 'turnEnd', key: key as _ChatKey, at: Date.now(), outboundEmitted })
-  clearReactionState(key)
-  activeTurnStartedAt.delete(key)
 
   // If no more active turns and a restart is pending, perform it now.
   //
@@ -1623,24 +1593,12 @@ async function resolveCompactCard(
 }
 
 function endStatusReaction(chatId: string, threadId: number | undefined, outcome: 'done' | 'error'): void {
-  // Mid-turn signal: the reply tool fired, or stream_reply finalized,
-  // and the status-reaction needs to transition to its terminal emoji
-  // (👍 / ⚠️). The turn itself is still active — the canonical turn-end
-  // signal is `endCurrentTurnAtomic(turn)`, which runs later via the
-  // turn_end handler / context-exhaust path / silent-marker path.
-  //
-  // Pre-#1603 audit step 2 (this commit), this called
-  // `purgeReactionTracking(key)` directly, which would fire shadow
-  // `turnEnd` and clear the turn-active marker mid-turn — the latter
-  // triggering the model-idle restart probe + pendingInbound flush as
-  // if claude had gone idle. Use `clearReactionState` to only do the
-  // reaction-cleanup work.
   const key = statusKey(chatId, threadId)
   const ctrl = activeStatusReactions.get(key)
   if (!ctrl) return
   if (outcome === 'done') ctrl.setDone()
   else ctrl.setError()
-  clearReactionState(key)
+  purgeReactionTracking(key)
 }
 
 function resolveThreadId(chat_id: string, explicit?: string | number | null): number | undefined {
@@ -3135,15 +3093,7 @@ silencePoke.startTimer({
     // Drop silence-poke state and clear turn-active so the next inbound
     // for this chat starts a fresh turn instead of queueing forever.
     silencePoke.endTurn(fbKey)
-    // PR 3b step 5 (#1603 audit): force outboundEmitted=false. The
-    // framework fallback fires precisely because visible delivery
-    // didn't happen in 5 min — `wedgedTurn.replyCalled` may have been
-    // set during the turn (e.g. reply tool invoked but Telegram side
-    // never confirmed delivery), but from the user's perspective no
-    // outbound landed. The state machine's `noteOutbound` effect
-    // must NOT fire for this path. Pass `undefined` for endingTurn
-    // and `false` as the explicit override.
-    purgeReactionTracking(fbKey, undefined, false)
+    purgeReactionTracking(fbKey)
     // Defense-in-depth: the fallback's purgeReactionTracking above
     // clears the canonical statusKey(chatId, threadId) for fbKey
     // only. activeTurnStartedAt can hold sibling entries for the
@@ -3156,14 +3106,10 @@ silencePoke.startTimer({
     // purger. Multi-chat-safe — only touches keys for fbChatId, so
     // #1546's intentional cross-chat safety guard is preserved.
     // See turn-state-purge.ts.
-    //
-    // Same `outboundEmitted=false` rationale as the bare call above —
-    // wrap the purger so every sibling-key purge emits a fallback
-    // shadow turnEnd with the truthful "no visible delivery" signal.
     const fbExtraPurge = purgeStaleTurnsForChat(
       fbChatId,
       activeTurnStartedAt.keys(),
-      (k) => purgeReactionTracking(k, undefined, false),
+      purgeReactionTracking,
     )
     // Null `currentTurn` if it's still pointing at the wedged turn —
     // when claude eventually fires a late `turn_end` for this session
@@ -5882,10 +5828,7 @@ function handleSessionEvent(ev: SessionEvent): void {
         const ceKey = statusKey(chatId, threadId)
         const ctrl = activeStatusReactions.get(ceKey)
         if (ctrl) ctrl.setError()
-        // Duplicate-emit removed (#1603 audit, step 1): the canonical
-        // endCurrentTurnAtomic(turn) call at line ~5851 below already
-        // invokes purgeReactionTracking on the same ceKey. The bare
-        // call here was firing a second shadow `turnEnd` per traversal.
+        purgeReactionTracking(ceKey)
         // Surfaced during CC-5 investigation (`docs/status-ask-cause-classes.md`):
         // the context-exhaust bail path teardown was missing
         // `silencePoke.endTurn(key)`. Without it, the silence-poke state for
@@ -6043,10 +5986,7 @@ function handleSessionEvent(ev: SessionEvent): void {
         // Fall through to normal state cleanup (ctrl.setDone, purge, etc.)
         // but skip the regular closeProgressLane so we don't re-finalize.
         if (ctrl) ctrl.setDone()
-        // Duplicate-emit removed (#1603 audit, step 1): endCurrentTurnAtomic(turn)
-        // at line ~6049 below invokes purgeReactionTracking on the same key
-        // (statusKey(chatId, threadId)). The bare call here was firing a
-        // second shadow `turnEnd` per silent-marker traversal.
+        purgeReactionTracking(statusKey(chatId, threadId))
         // Match the normal turn_end path's telemetry so silent-marker turns
         // still appear in turn-duration graphs.
         {
@@ -6187,15 +6127,7 @@ function handleSessionEvent(ev: SessionEvent): void {
                 // mirroring this contract — so reply-only turns transition
                 // to terminal 👍 in their own success path rather than
                 // relying on this dedup heuristic.
-                //
-                // PR 3b step 3 (#1603 audit): thread the captured `turn`
-                // explicitly. `endCurrentTurnAtomic(turn)` ran at line ~6120
-                // before this IIFE started, so `currentTurn === null` by
-                // now — without an explicit endingTurn argument, the shadow
-                // trace would read `outboundEmitted=false` for this dedup
-                // path even though `recentCount > 0` proves the reply tool
-                // did fire (turn.replyCalled === true).
-                purgeReactionTracking(statusKey(backstopChatId, backstopThreadId), turn)
+                purgeReactionTracking(statusKey(backstopChatId, backstopThreadId))
                 return
               }
             } catch {}
@@ -6323,35 +6255,14 @@ function handleSessionEvent(ev: SessionEvent): void {
             process.stderr.write(`telegram gateway: turn-flush send failed: ${(err as Error).message}\n`)
             if (backstopCtrl) backstopCtrl.setError()
           } finally {
-            // PR 3b step 3 (#1603 audit): thread the captured `turn`
-            // explicitly. The turn-flush backstop runs inside this IIFE
-            // after `endCurrentTurnAtomic(turn)` already nulled
-            // `currentTurn` at line ~6120. Without threading, the shadow
-            // trace would read `outboundEmitted=currentTurn?.replyCalled
-            // === undefined` → false. For the turn-flush path
-            // `turn.replyCalled` is `false` regardless (the model didn't
-            // call the reply tool — the gateway backstop did the work),
-            // so the threaded value matches the existing fallback here.
-            // But pinning the source via the captured turn matches the
-            // canonical pattern and survives any future change to how
-            // `currentTurn` is sequenced.
-            purgeReactionTracking(statusKey(backstopChatId, backstopThreadId), turn)
+            purgeReactionTracking(statusKey(backstopChatId, backstopThreadId))
           }
         })()
         return
       }
 
       if (ctrl) ctrl.setDone()
-      // Duplicate-emit removed (#1603 audit, step 4 — the audit's
-      // original "route through endCurrentTurnAtomic" recommendation
-      // missed that this same code path already calls
-      // `endCurrentTurnAtomic(turn)` ~90 lines below at line ~6412
-      // on the same key — `chatId === turn.sessionChatId` and
-      // `threadId === turn.sessionThreadId` per the bindings at
-      // ~5946-5947. Removing this bare call closes the last duplicate
-      // shadow-`turnEnd` emit on the dominant happy-path turn-end
-      // tail; the canonical primitive below still fires the single
-      // authoritative turnEnd with the threaded turn).
+      purgeReactionTracking(statusKey(chatId, threadId))
       {
         const sKey = streamKey(chatId, threadId)
         const turnDurationMs = turn.startedAt > 0 ? Date.now() - turn.startedAt : 0


### PR DESCRIPTION
## Summary

**P0 finding from v0.13.1 canary** — the canonical shadow `turnEnd` event stopped firing on the dominant happy-path turn-end after PR 3b's five-step refactor. Reverting gateway.ts to its v0.13.0 state.

## Evidence

Same trivial UAT (`jtbd-fast-trivial-dm.test.ts`, "Reply with just the number: what is 2 + 2?") on the same test-harness agent:

**v0.13.0** (after fast-trivial UAT):
```
gw-trace shadow event=inbound key=8248703757:_ msg=1090 ... perKeySize=1
gw-trace shadow event=turnEnd key=8248703757:_ outbound=false effects=[clearTurnStarted,drainBuffer,logTrace] perKeySize=0
```

**v0.13.1** (after fast-trivial UAT):
```
gw-trace shadow event=inbound key=8248703757:_ msg=1086 ... perKeySize=1
[no turnEnd ever]
```

`perKeySize=0` (turn cleared) vs `perKeySize=1` (turn still tracked as active in the shadow state machine).

## Root cause hypothesis

The audit's premise was that `endCurrentTurnAtomic(turn)` at gateway.ts:~6444 would emit the single authoritative shadow `turnEnd` after the bare-purge deletions in steps 1, 2, and 4. Empirically this is wrong — some unidentified upstream code path nulls `currentTurn` before 6444 fires, so its `currentTurn === turn` guard short-circuits silently. The reviewers (also fresh-process) didn't catch this because the property-test suite + 165 vitest files don't exercise the integration path.

Lesson: every step of this work needs an **empirical** bisect on test-harness with a shadow-trace-count assertion before committing. The audit's findings are valuable; the implementation order needs revisiting.

## Production state

- **Fleet:** never rolled to v0.13.1 (all 8 fleet agents on v0.13.0).
- **Test-harness:** v0.13.1 canary detected the regression; rolled back to v0.13.0 immediately.
- **npm:** v0.13.1 published but unused.
- **No user-visible impact.**

## What this PR does

Restores `telegram-plugin/gateway/gateway.ts` to its v0.13.0 state. Reverts the gateway.ts changes from:

- #1604 step 1 (delete duplicate emits at 5831/5989)
- #1605 step 2 (split purge → clearReactionState)
- #1606 step 3 (thread turn at IIFE sites)
- #1607 step 4 (delete duplicate at 6322)
- #1608 step 5 (explicit outboundEmittedOverride)

The #1603 RFC addendum stays. The audit's findings are still valuable; only the implementation order needs re-doing with empirical bisection.

v0.13.2 = v0.13.0 + #1602 (sends-counter, already shipped in v0.13.1) + nothing else.

## Test plan

- [x] vitest 2739/2739
- [x] bun test 31/31 (gateway-bridge + inbound-delivery-machine)
- [x] tsc --noEmit clean
- [ ] CI green
- [ ] After merge: tag v0.13.2, publish to npm, wait for docker-images, canary on test-harness, verify trivial-UAT shadow turnEnd resumes firing, then roll fleet