### PR TITLE
fix(handoff): --strict-mcp-config so the summarizer can't spawn a 2nd bridge

### DIFF
--- a/src/agents/handoff-summarizer.ts
+++ b/src/agents/handoff-summarizer.ts
@@ -278,9 +278,43 @@ export async function summarize(opts: SummarizeOpts): Promise<string> {
 }
 
 /**
+ * Build the `claude -p` argv for the handoff summarizer.
+ *
+ * `--strict-mcp-config` is load-bearing. Without it, this headless
+ * `claude -p` auto-discovers the agent's project `.mcp.json` and starts
+ * every MCP server in it — including `switchroom-telegram`. That spins
+ * up a *second* telegram bridge process which registers against the
+ * same gateway socket as the live agent's real bridge (it inherits
+ * `SWITCHROOM_AGENT_NAME`). The two collide under the gateway's
+ * register-race close, producing the per-turn "bridge reconnect race"
+ * flap (#1613 — the handoff Stop hook fires every turn, so does the
+ * flap). The summarizer is pure transcript-in / briefing-out: it needs
+ * no MCP tools. `--strict-mcp-config` with no `--mcp-config` loads
+ * zero servers. Exported for the args regression test.
+ */
+export function buildHandoffClaudeArgs(opts: {
+  model: string;
+  system: string;
+  user: string;
+}): string[] {
+  return [
+    "-p",
+    opts.user,
+    "--model",
+    opts.model,
+    "--append-system-prompt",
+    opts.system,
+    "--no-session-persistence",
+    // Do NOT inherit the agent's project .mcp.json — see doc above.
+    "--strict-mcp-config",
+  ];
+}
+
+/**
  * Spawns `claude -p <user> --append-system-prompt <system> --model
- * <model> --no-session-persistence`, collects stdout, enforces a
- * wall-clock timeout. Uses the caller's `$PATH` to locate `claude`.
+ * <model> --no-session-persistence --strict-mcp-config`, collects
+ * stdout, enforces a wall-clock timeout. Uses the caller's `$PATH` to
+ * locate `claude`.
  *
  * Post-RFC-H: claude reads its OAuth credentials from
  * `<agentDir>/.claude/credentials.json` directly. The auth-broker is
@@ -291,15 +325,7 @@ export async function summarize(opts: SummarizeOpts): Promise<string> {
 export const defaultClaudeCliRunner: ClaudeCliRunner = {
   async run({ model, system, user, timeoutMs }) {
     return await new Promise<string>((resolve, reject) => {
-      const args = [
-        "-p",
-        user,
-        "--model",
-        model,
-        "--append-system-prompt",
-        system,
-        "--no-session-persistence",
-      ];
+      const args = buildHandoffClaudeArgs({ model, system, user });
       const env: NodeJS.ProcessEnv = {
         ...process.env,
         FORCE_COLOR: "0",

--- a/tests/handoff-summarizer.test.ts
+++ b/tests/handoff-summarizer.test.ts
@@ -9,6 +9,7 @@ import {
   writeSidecarsAtomic,
   summarize,
   findLatestSessionJsonl,
+  buildHandoffClaudeArgs,
   TOPIC_MAX_CHARS,
   DEFAULT_SUMMARIZER_MODEL,
   type ClaudeCliRunner,
@@ -346,5 +347,36 @@ function failingRunner(err: Error): ClaudeCliRunner {
 describe("module constants", () => {
   it("exposes a stable default model id", () => {
     expect(DEFAULT_SUMMARIZER_MODEL).toMatch(/^claude-/);
+  });
+});
+
+describe("buildHandoffClaudeArgs", () => {
+  const args = buildHandoffClaudeArgs({
+    model: "claude-haiku-4-5-20251001",
+    system: "sys prompt",
+    user: "user prompt",
+  });
+
+  // Regression guard for the per-turn bridge-flap (#1613). Without
+  // --strict-mcp-config the headless summarizer auto-loads the agent's
+  // project .mcp.json, starts switchroom-telegram, and spawns a second
+  // bridge that collides with the live agent's bridge at the gateway.
+  it("passes --strict-mcp-config so it loads zero MCP servers", () => {
+    expect(args).toContain("--strict-mcp-config");
+  });
+
+  it("passes no --mcp-config — strict + empty means no servers at all", () => {
+    expect(args).not.toContain("--mcp-config");
+  });
+
+  it("runs headless print mode without session persistence", () => {
+    expect(args).toContain("-p");
+    expect(args).toContain("--no-session-persistence");
+  });
+
+  it("threads through model, system, and user", () => {
+    expect(args[args.indexOf("--model") + 1]).toBe("claude-haiku-4-5-20251001");
+    expect(args[args.indexOf("--append-system-prompt") + 1]).toBe("sys prompt");
+    expect(args[args.indexOf("-p") + 1]).toBe("user prompt");
   });
 });


### PR DESCRIPTION
## Summary

The **bridge-flap wedge class (#1613)** is root-caused and fixed. It is
**not** Claude Code's channel layer and **not** architectural.

The handoff-briefing summarizer (`src/agents/handoff-summarizer.ts`)
shells out to a headless `claude -p` once per turn, via the handoff Stop
hook. That `claude -p` ran **without `--strict-mcp-config`**, so it
auto-discovered the agent's project `.mcp.json` and started every MCP
server in it — including `switchroom-telegram`.

Starting `switchroom-telegram` spins up a **second telegram bridge
process**. It inherits `SWITCHROOM_AGENT_NAME`, registers against the
same gateway socket as the live agent's real persistent bridge, and the
two collide under the gateway's register-race close (#1585) — the ~2s
`bridge reconnect race` ping-pong, for the ~7-9s the `claude -p` lives.
The handoff hook fires every turn, so the flap recurs every turn.

## Why

Root-caused with process-ancestry instrumentation on a diag build.
**Every** flapping bridge traced to:

```
claude -p "Here is the recent session transcript…"
  → switchroom handoff → run-hook.sh hook:handoff → claude(agent)
```

— never to Claude Code's channel cycling. The persistent bridge was
never involved. This corrects #1613's diagnosis ("Claude cycles the
channel every ~7s / the flap is load-bearing / needs a gateway-managed
presence rearchitecture"): the competing bridge is **parasitic**, and
removing it removes the flap with zero effect on inbound delivery.
This also explains why the earlier `superseded`-handshake attempts
wedged — they could not tell the real bridge from the parasite (both
register as the same agent), so they sometimes stood down the real one.

JTBD: **Always-on** — eliminates the per-turn churn that stranded
inbounds and stranded progress-card reactions.

## Fix

The summarizer is pure transcript-in / briefing-out and needs no MCP
tools. Pass `--strict-mcp-config` (with no `--mcp-config`) so it loads
zero servers. Args extracted into `buildHandoffClaudeArgs` for a
regression test.

## Test plan

- [x] `vitest tests/handoff-summarizer.test.ts` — 25 pass (4 new:
  asserts `--strict-mcp-config` present, `--mcp-config` absent, args
  threaded through model/system/user)
- [x] `tsc --noEmit` clean
- [x] **Live canary** (test-harness, diag build, 6 driven turns):
  competing bridges 4-5/burst → **0**; `bridge reconnect race` → **0**;
  `bridgeDown`/`bridge_dead` → **0**; exactly **1** persistent bridge;
  **6/6** turns delivered. Pre-fix the same workload produced 4-5
  parasitic bridges and a reconnect-race burst per turn.

## Risk

Low. One flag added to a headless one-shot that used no MCP tools
before. No gateway / bridge / channel code touched.

## Follow-up

`src/web/webhook-dispatch.ts` spawns `claude -p` with the same gap
(`spawnAgentOneShot`, no `--strict-mcp-config`). Different feature,
lower frequency, and needs a decision on whether webhook-triggered
turns should deliver to Telegram — tracked separately, not in this PR.

Closes #1613.