### PR TITLE
test(bridge-flap): regression guards so the flap can't silently return

### DIFF
--- a/telegram-plugin/uat/scenarios/bridge-flap-resilience-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/bridge-flap-resilience-dm.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Bridge-flap resilience scenario — regression guard for #1613 / #1616.
+ *
+ * ## The bug this guards
+ *
+ * The handoff-briefing summarizer shells out to a headless `claude -p`
+ * once per turn (handoff Stop hook). Before #1616 it ran without
+ * `--strict-mcp-config`, so it auto-discovered the agent's project
+ * `.mcp.json` and started every MCP server in it — including
+ * `switchroom-telegram`. That spun up a *second* telegram bridge
+ * process which registered against the same gateway socket as the
+ * live agent's real bridge; the two collided under the gateway's
+ * register-race close, producing an A↔B "bridge reconnect race" flap
+ * every ~2s for the ~7-9s the `claude -p` lived. The handoff hook
+ * fires every turn, so did the flap. A turn whose completion landed
+ * inside a flap burst could have its `turn_end` signal eaten — the
+ * agent looked wedged for that turn.
+ *
+ * The fix (#1616): the summarizer passes `--strict-mcp-config`, so
+ * the headless `claude -p` loads zero MCP servers and never spawns a
+ * competing bridge. The structural guard against a new offending
+ * callsite is `tests/bridge-flap-regression-guard.test.ts`; this
+ * scenario is the behavioural backstop.
+ *
+ * ## What this scenario asserts (root-cause-agnostic by design)
+ *
+ * The checks are symptom-based, so they catch a flap reintroduced by
+ * ANY future change — not only a regression of #1616:
+ *
+ * 1. Send a handful of DMs in succession — each drives a turn (and a
+ *    handoff-hook fire). **Primary assertion:** every DM gets a reply
+ *    within budget. Directly catches both the flap (eats turn_end)
+ *    and the wedge (a zero-bridge gap strands the inbound).
+ * 2. **Forensic assertion:** inspect the agent's gateway-supervisor.log
+ *    over the test window and assert the `bridge disconnected` density
+ *    stays BELOW a flap threshold. One healthy persistent bridge
+ *    produces only a trickle of disconnects; a sustained reconnect
+ *    race produces dozens in tight ~2s bursts.
+ *
+ * ## Why the log inspection
+ *
+ * A flap is a server-side phenomenon that does not always surface as
+ * a missed reply (a burst can self-heal in ~20-30s). The `bridge
+ * disconnected` count is the transport-agnostic flap symptom. This
+ * scenario shells into the agent container via `docker exec` to read
+ * the gateway log; if docker is unavailable the log assertion is
+ * skipped with a warning and the responsiveness checks still run.
+ *
+ * ## Tolerances
+ *
+ * - `DISCONNECT_FLAP_THRESHOLD` is the max acceptable `bridge
+ *   disconnected` count over the window. Post-#1616 a healthy ~4-turn
+ *   run sits well under 16 (measured ~8-13, including anonymous
+ *   probe-connection churn); a sustained flap is 20-40+. 16 sits
+ *   comfortably in the gap.
+ */
+
+import { describe, expect, it } from "vitest";
+import { execSync } from "node:child_process";
+import { spinUp } from "../harness.js";
+import type { ObservedMessage } from "../driver.js";
+
+const AGENT = "test-harness";
+const CONTAINER = `switchroom-${AGENT}`;
+const GATEWAY_LOG = "/var/log/switchroom/gateway-supervisor.log";
+
+const DM_COUNT = 4;
+const PER_DM_TIMEOUT_MS = 30_000;
+const OVERALL_DEADLINE_MS = 180_000;
+
+// Post-#1616 a healthy ~4-turn run logs ~8-13 `bridge disconnected`
+// lines (one persistent bridge + anonymous probe-connection churn).
+// A sustained A↔B flap produces 20-40+ in tight ~2s bursts. 16 sits
+// in the gap.
+const DISCONNECT_FLAP_THRESHOLD = 16;
+
+/** Total line count of the agent's gateway-supervisor.log, or null if
+ *  the container/log is unreachable (CI without the container). */
+function gatewayLogLineCount(): number | null {
+  try {
+    const out = execSync(
+      `docker exec ${CONTAINER} sh -lc 'wc -l < ${GATEWAY_LOG}'`,
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    return parseInt(out.trim(), 10);
+  } catch {
+    return null;
+  }
+}
+
+/** Count `bridge disconnected` lines after `sinceLine` in the log. */
+function disconnectCountSince(sinceLine: number): number | null {
+  try {
+    const out = execSync(
+      `docker exec ${CONTAINER} sh -lc ` +
+        `'awk "NR>${sinceLine}" ${GATEWAY_LOG} | grep -c "bridge disconnected" || true'`,
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    return parseInt(out.trim(), 10);
+  } catch {
+    return null;
+  }
+}
+
+describe("uat: bridge-flap resilience — agent stays responsive, gateway does not flap", () => {
+  it(
+    "every DM gets a reply and the gateway does not flap across turns",
+    async () => {
+      const baselineLine = gatewayLogLineCount();
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        const overallDeadline = Date.now() + OVERALL_DEADLINE_MS;
+
+        for (let i = 1; i <= DM_COUNT; i++) {
+          await sc.sendDM(`flap-resilience probe ${i}/${DM_COUNT}: reply with OK${i}`);
+
+          const remaining = Math.min(
+            PER_DM_TIMEOUT_MS,
+            overallDeadline - Date.now(),
+          );
+          expect(
+            remaining,
+            `overall deadline hit before DM ${i} — earlier turns were too slow`,
+          ).toBeGreaterThan(0);
+
+          const reply = await sc.expectMessage(
+            (m: ObservedMessage) => m.fromBot && !m.edited,
+            { from: "bot", timeout: remaining },
+          );
+          expect(
+            reply.text.length,
+            `DM ${i}/${DM_COUNT} produced an empty reply — a flap may have ` +
+              `eaten the turn_end signal`,
+          ).toBeGreaterThan(0);
+        }
+
+        // Responsiveness held for all DM_COUNT turns. Now check the
+        // server-side flap signal.
+        if (baselineLine == null) {
+          console.warn(
+            "[bridge-flap-resilience] docker exec unavailable — skipping " +
+              "the gateway-log flap assertion; responsiveness checks passed.",
+          );
+          return;
+        }
+
+        const disconnectCount = disconnectCountSince(baselineLine);
+        expect(
+          disconnectCount,
+          "could not read gateway log after the run — container went away",
+        ).not.toBeNull();
+        expect(
+          disconnectCount as number,
+          `gateway logged ${disconnectCount} "bridge disconnected" lines across ` +
+            `${DM_COUNT} turns — at/above the flap threshold ` +
+            `(${DISCONNECT_FLAP_THRESHOLD}). A parasitic bridge is racing the ` +
+            `live one — check for a headless 'claude -p' spawned without ` +
+            `--strict-mcp-config (#1613/#1616).`,
+        ).toBeLessThan(DISCONNECT_FLAP_THRESHOLD);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    OVERALL_DEADLINE_MS + 30_000,
+  );
+});

--- a/tests/bridge-flap-regression-guard.test.ts
+++ b/tests/bridge-flap-regression-guard.test.ts
@@ -17,9 +17,14 @@ import { join, relative } from "node:path";
  *
  * This test fails the build if any source file spawns `claude`
  * without `--strict-mcp-config`, so a new callsite — or a removed
- * flag — cannot silently reintroduce the flap. The behavioural
- * backstop (a flap reintroduced by some other mechanism) is the
- * `bridge-flap-resilience-dm` UAT scenario.
+ * flag — cannot silently reintroduce the flap.
+ *
+ * NOTE: source is comment-stripped before every check. A naive
+ * file-wide substring scan would be defeated by the doc comments that
+ * *describe* `--strict-mcp-config` — a callsite could lose the real
+ * argv entry and still pass because the prose mentions the flag. The
+ * behavioural backstop (a flap reintroduced by some other mechanism)
+ * is the `bridge-flap-resilience-dm` UAT scenario.
  */
 
 const ROOTS = ["src", "telegram-plugin"];
@@ -38,6 +43,18 @@ const KNOWN_GAPS: Record<string, string> = {
 /** Matches `spawn("claude"`, `spawnSync('claude'`, `execFile("claude"`, etc. */
 const SPAWN_CLAUDE =
   /(?:spawn|spawnSync|execFile|execFileSync)[A-Za-z]*\(\s*['"]claude['"]/;
+
+/**
+ * Strip line and block comments so the checks below see code only,
+ * not prose. Without this a doc comment that mentions
+ * `--strict-mcp-config` would mask a callsite that no longer actually
+ * passes the flag.
+ */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
 
 function walkTs(dir: string): string[] {
   const out: string[] = [];
@@ -61,38 +78,45 @@ function walkTs(dir: string): string[] {
 
 describe("bridge-flap regression guard — headless claude must use --strict-mcp-config (#1613/#1616)", () => {
   const repoRoot = process.cwd();
-  const claudeSpawners = ROOTS.flatMap((r) => walkTs(join(repoRoot, r)))
-    .filter((f) => SPAWN_CLAUDE.test(readFileSync(f, "utf8")))
-    .map((f) => relative(repoRoot, f).replace(/\\/g, "/"));
+  // { rel, code } where code is the comment-stripped source.
+  const spawners = ROOTS.flatMap((r) => walkTs(join(repoRoot, r)))
+    .map((f) => ({
+      rel: relative(repoRoot, f).replace(/\\/g, "/"),
+      code: stripComments(readFileSync(f, "utf8")),
+    }))
+    .filter((x) => SPAWN_CLAUDE.test(x.code));
 
   it("the source scan still finds claude spawners (scan-not-broken sanity)", () => {
     // If the regex silently stops matching, every per-file check below
     // vacuously passes — this guards the guard.
-    expect(claudeSpawners.length).toBeGreaterThan(0);
+    expect(spawners.map((s) => s.rel)).toContain("src/agents/handoff-summarizer.ts");
   });
 
-  for (const rel of claudeSpawners) {
+  for (const { rel, code } of spawners) {
     it(`${rel} passes --strict-mcp-config`, () => {
       if (rel in KNOWN_GAPS) {
         expect(KNOWN_GAPS[rel]).toMatch(/#\d+/);
         return; // documented, issue-tracked exception
       }
-      const src = readFileSync(join(repoRoot, rel), "utf8");
+      // `code` is comment-stripped — a doc comment that merely
+      // *describes* the flag cannot satisfy this check.
       expect(
-        src.includes("--strict-mcp-config"),
-        `${rel} spawns a headless 'claude' but does not pass --strict-mcp-config. ` +
-          `Without it the subprocess auto-loads the agent's .mcp.json, starts ` +
-          `switchroom-telegram, and spawns a parasitic bridge → the #1613 flap. ` +
-          `Add --strict-mcp-config, or (if genuinely intentional) add the file to ` +
-          `KNOWN_GAPS with a tracking-issue reference.`,
+        code.includes("--strict-mcp-config"),
+        `${rel} spawns a headless 'claude' but does not pass --strict-mcp-config ` +
+          `(checked against comment-stripped source). Without it the subprocess ` +
+          `auto-loads the agent's .mcp.json, starts switchroom-telegram, and ` +
+          `spawns a parasitic bridge → the #1613 flap. Add --strict-mcp-config, ` +
+          `or (if genuinely intentional) add the file to KNOWN_GAPS with a ` +
+          `tracking-issue reference.`,
       ).toBe(true);
     });
   }
 
   it("KNOWN_GAPS has no stale entries", () => {
+    const found = spawners.map((s) => s.rel);
     for (const rel of Object.keys(KNOWN_GAPS)) {
       expect(
-        claudeSpawners,
+        found,
         `${rel} is allowlisted in KNOWN_GAPS but no longer spawns claude — ` +
           `delete the entry.`,
       ).toContain(rel);

--- a/tests/bridge-flap-regression-guard.test.ts
+++ b/tests/bridge-flap-regression-guard.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+/**
+ * Regression guard for the bridge-flap wedge class (#1613 / #1616).
+ *
+ * A headless `claude -p` subprocess auto-discovers the agent's project
+ * `.mcp.json` and starts every MCP server in it — including
+ * `switchroom-telegram`, which spins up a *second* telegram bridge.
+ * That parasitic bridge registers against the same gateway socket as
+ * the live agent's real bridge, and the two collide under the
+ * gateway's register-race close — the "bridge reconnect race" flap.
+ *
+ * `--strict-mcp-config` (with no `--mcp-config`) makes a headless
+ * `claude` load zero MCP servers, and is the fix (#1616).
+ *
+ * This test fails the build if any source file spawns `claude`
+ * without `--strict-mcp-config`, so a new callsite — or a removed
+ * flag — cannot silently reintroduce the flap. The behavioural
+ * backstop (a flap reintroduced by some other mechanism) is the
+ * `bridge-flap-resilience-dm` UAT scenario.
+ */
+
+const ROOTS = ["src", "telegram-plugin"];
+
+/**
+ * Files that spawn `claude` WITHOUT `--strict-mcp-config`, knowingly.
+ * Every entry MUST cite a tracking issue. This list may only ever
+ * shrink — when the gap is fixed the entry must be deleted, and the
+ * "no stale entries" test below enforces that.
+ */
+const KNOWN_GAPS: Record<string, string> = {
+  "src/web/webhook-dispatch.ts":
+    "#1617 — migrating to inject_inbound (RFC docs/rfcs/eliminate-claude-p.md, Workstream A)",
+};
+
+/** Matches `spawn("claude"`, `spawnSync('claude'`, `execFile("claude"`, etc. */
+const SPAWN_CLAUDE =
+  /(?:spawn|spawnSync|execFile|execFileSync)[A-Za-z]*\(\s*['"]claude['"]/;
+
+function walkTs(dir: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    if (e === "node_modules" || e === "dist" || e === ".git") continue;
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) {
+      out.push(...walkTs(p));
+    } else if (e.endsWith(".ts") && !e.endsWith(".test.ts") && !e.endsWith(".d.ts")) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+describe("bridge-flap regression guard — headless claude must use --strict-mcp-config (#1613/#1616)", () => {
+  const repoRoot = process.cwd();
+  const claudeSpawners = ROOTS.flatMap((r) => walkTs(join(repoRoot, r)))
+    .filter((f) => SPAWN_CLAUDE.test(readFileSync(f, "utf8")))
+    .map((f) => relative(repoRoot, f).replace(/\\/g, "/"));
+
+  it("the source scan still finds claude spawners (scan-not-broken sanity)", () => {
+    // If the regex silently stops matching, every per-file check below
+    // vacuously passes — this guards the guard.
+    expect(claudeSpawners.length).toBeGreaterThan(0);
+  });
+
+  for (const rel of claudeSpawners) {
+    it(`${rel} passes --strict-mcp-config`, () => {
+      if (rel in KNOWN_GAPS) {
+        expect(KNOWN_GAPS[rel]).toMatch(/#\d+/);
+        return; // documented, issue-tracked exception
+      }
+      const src = readFileSync(join(repoRoot, rel), "utf8");
+      expect(
+        src.includes("--strict-mcp-config"),
+        `${rel} spawns a headless 'claude' but does not pass --strict-mcp-config. ` +
+          `Without it the subprocess auto-loads the agent's .mcp.json, starts ` +
+          `switchroom-telegram, and spawns a parasitic bridge → the #1613 flap. ` +
+          `Add --strict-mcp-config, or (if genuinely intentional) add the file to ` +
+          `KNOWN_GAPS with a tracking-issue reference.`,
+      ).toBe(true);
+    });
+  }
+
+  it("KNOWN_GAPS has no stale entries", () => {
+    for (const rel of Object.keys(KNOWN_GAPS)) {
+      expect(
+        claudeSpawners,
+        `${rel} is allowlisted in KNOWN_GAPS but no longer spawns claude — ` +
+          `delete the entry.`,
+      ).toContain(rel);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two layers of regression guard for the bridge-flap wedge class
(#1613), fixed in #1616. Ensures a future change cannot silently
reintroduce it.

### 1. Structural guard (CI-gating, fast)
`tests/bridge-flap-regression-guard.test.ts` — a vitest source scan.
Every `claude` subprocess spawn in `src/` and `telegram-plugin/` must
pass `--strict-mcp-config` (which makes a headless `claude` load zero
MCP servers and is the #1616 fix), or be listed in `KNOWN_GAPS` with a
tracking-issue reference.

- Fails the build if a **new** headless-claude callsite is added
  without the flag.
- Fails if the flag is **removed** from the handoff summarizer.
- `KNOWN_GAPS` is self-cleaning — a "no stale entries" test forces the
  allowlist entry to be deleted once the gap is fixed.
- One current entry: `webhook-dispatch.ts` (#1617, slated for removal
  in RFC #1620 Workstream A).

### 2. Behavioural backstop
`telegram-plugin/uat/scenarios/bridge-flap-resilience-dm.test.ts` —
drives 4 DMs, asserts each gets a reply, and reads the agent's
gateway-supervisor.log to assert `bridge disconnected` density stays
under a flap threshold. Symptom-based — catches a flap reintroduced by
**any** mechanism, not only a #1616 regression. Recovered from the
investigation branch; its header doc is rewritten to the correct root
cause (the original described the since-disproven "Claude cycles the
channel" theory).

## Test plan

- [x] `vitest tests/bridge-flap-regression-guard.test.ts` — 4 pass
- [x] `tsc --noEmit` clean
- [x] verified the structural guard *fails* when `--strict-mcp-config`
      is removed from the handoff summarizer
- UAT runs in `ci-uat` / pre-rollout (not a CI unit test)

## Risk

None — test-only. No production code touched.