### PR TITLE
docs: codify the Claude-native / subscription-funded constraint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,37 @@ around claude (the vision's "no Docker-as-runtime" line in
 
 See `README.md` for the user-facing description.
 
+## Hard constraint — Claude-native, subscription-funded (a core pillar)
+
+This is **non-negotiable** and load-bearing for the entire product —
+it is `reference/vision.md` pillar 3 ("subscription-honest") restated
+as an engineering gate. A change that violates it is out of scope by
+construction, however useful it seems.
+
+- **Every agent runs the unmodified `claude` CLI**, authenticated with
+  the operator's **Pro/Max OAuth** credentials. No `ANTHROPIC_API_KEY`,
+  no API keys of any kind, no Claude Agent SDK, no raw Anthropic API,
+  no protocol interception, no custom inference runtime. switchroom is
+  scaffolding and lifecycle management *around* the CLI — never a
+  harness *over* it.
+- **The reason is Anthropic policy compliance**, not merely cost. Using
+  the native CLI on the subscription is what keeps switchroom inside
+  Anthropic's third-party policy. Treat it as a compliance boundary,
+  not a preference.
+- **`claude -p` (headless/print mode)** is the same CLI + OAuth, but
+  as of the **2026-06-15** policy it is *programmatic usage* — a
+  separate credit, off subscription limits. Adding a new `claude -p`
+  callsite is a constraint violation: route the work through the
+  interactive agent session as a synthesized turn instead. The
+  existing callsites are being removed — see
+  `docs/rfcs/eliminate-claude-p.md`. A CI guard
+  (`tests/bridge-flap-regression-guard.test.ts`) already enforces
+  `--strict-mcp-config` on any headless `claude` spawn.
+- **Before adding any code path that calls a model:** it MUST be the
+  interactive `claude` session, or a synthesized turn injected into it
+  (the cron / `inject_inbound` pattern). If you reach for the SDK or
+  the API, stop — that is not switchroom.
+
 ## v0.7+ runtime architecture (read this before touching docker/compose/broker code)
 
 ```

--- a/reference/vision.md
+++ b/reference/vision.md
@@ -78,10 +78,20 @@ specialist without leaving the topic.
 Switchroom is scaffolding and lifecycle management. It creates
 directories, stands up a long-running service per agent, manages
 OAuth, routes Telegram messages, and gets out of the way. Each agent
-runs the unmodified `claude` binary, authenticated directly with
-Anthropic. No Agent SDK, no API-key routing, no credential
-interception. Fully compliant with Anthropic's April 2026 third-party
-policy.
+runs the **unmodified `claude` binary**, authenticated directly with
+Anthropic through the **Pro/Max OAuth** flow. No Agent SDK, no
+API-key routing, no `ANTHROPIC_API_KEY`, no credential interception,
+no custom inference runtime.
+
+This is a **hard constraint, not a preference** — it is what keeps
+switchroom compliant with Anthropic's third-party policy. The native
+CLI on the subscription is the compliance boundary: the moment a
+feature reaches for the Agent SDK or the raw API, it has left
+switchroom. Every model call is the interactive `claude` session, or
+a synthesized turn injected into it. (`claude -p` headless mode is the
+same CLI, but as of the 2026-06-15 policy it counts as *programmatic*
+usage — off the subscription — so switchroom routes that work back
+through the interactive session instead.)
 
 One bill. The one you already pay.
 


### PR DESCRIPTION
## Summary

Makes switchroom's core pillar — **run the unmodified `claude` CLI on
the Pro/Max subscription, for Anthropic policy compliance** — an
explicit engineering constraint, not just positioning prose.

The 2026-06-15 Anthropic policy change (`claude -p` + Agent SDK
reclassified as *programmatic* usage, off subscription limits) makes it
worth stating clearly so future work can't drift into the Agent SDK,
the raw API, or heavy `claude -p`.

## Changes

- **CLAUDE.md** — new section *"Hard constraint — Claude-native,
  subscription-funded (a core pillar)"*. An engineering gate: unmodified
  `claude` CLI + Pro/Max OAuth only; no SDK / no API key / no custom
  runtime; the reason is **policy compliance**, not cost; a new
  `claude -p` callsite is a constraint violation (route through the
  interactive session); cross-references `docs/rfcs/eliminate-claude-p.md`
  and the CI guard.
- **reference/vision.md** — pillar 3 sharpened from positioning prose
  to an explicit *"hard constraint, not a preference"* compliance
  boundary; notes the `claude -p` / programmatic-usage nuance and the
  2026-06-15 policy.

Docs only — no code.