### PR TITLE
feat(webhook): deliver via inject_inbound, not claude -p (#1617)

### DIFF
--- a/src/web/webhook-dispatch.test.ts
+++ b/src/web/webhook-dispatch.test.ts
@@ -22,6 +22,7 @@ import {
   type DispatchMatcher,
   type DispatchRule,
   type WebhookDispatchConfig,
+  type EvaluateDispatchDeps,
   type TemplateContext,
   type QuietHours,
 } from './webhook-dispatch.js'
@@ -274,6 +275,8 @@ describe('evaluateDispatch', () => {
     }
   }
 
+  const FORUM_CHAT = '-1001234567890'
+
   const baseRule: DispatchRule = {
     match: {
       event: 'pull_request',
@@ -282,12 +285,37 @@ describe('evaluateDispatch', () => {
       exclude_authors: ['dependabot[bot]'],
     },
     prompt: 'Review PR #{{number}}: {{title}}\n{{html_url}}',
-    model: 'claude-sonnet-4-6',
   }
 
-  it('fires spawn when rule matches', () => {
+  interface CapturedInject {
+    socketPath: string
+    agentName: string
+    inbound: Record<string, unknown>
+  }
+
+  /** Capture every inject_inbound the evaluator delivers (in place of
+   *  a real gateway socket connection). */
+  function captureInject(): {
+    injected: CapturedInject[]
+    injectFn: NonNullable<EvaluateDispatchDeps['injectFn']>
+  } {
+    const injected: CapturedInject[] = []
+    return {
+      injected,
+      injectFn: async (socketPath, agentName, inbound) => {
+        injected.push({
+          socketPath,
+          agentName,
+          inbound: inbound as unknown as Record<string, unknown>,
+        })
+        return true
+      },
+    }
+  }
+
+  it('injects an inbound turn when a rule matches — no claude -p spawn', () => {
     const resolveAgentDir = makeTmpResolveAgentDir()
-    const spawned: Array<{ cmd: string; args: string[] }> = []
+    const { injected, injectFn } = captureInject()
     const config: WebhookDispatchConfig = { github: [baseRule] }
 
     const count = evaluateDispatch(
@@ -297,29 +325,53 @@ describe('evaluateDispatch', () => {
         eventType: 'pull_request',
         payload: prOpened,
         dispatchConfig: config,
+        chatId: FORUM_CHAT,
+        threadId: 7,
       },
-      {
-        resolveAgentDir,
-        now: () => 1_000_000,
-        log: () => {},
-        spawnFn: (cmd, args) => {
-          spawned.push({ cmd, args })
-          return { on: () => {}, pid: 9999 }
-        },
-      },
+      { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn },
     )
 
     expect(count).toBe(1)
-    expect(spawned).toHaveLength(1)
-    expect(spawned[0].cmd).toBe('claude')
-    expect(spawned[0].args[0]).toBe('-p')
-    expect(spawned[0].args[1]).toContain('#42')
-    expect(spawned[0].args[1]).toContain('Add dark mode support')
+    expect(injected).toHaveLength(1)
+    expect(injected[0].agentName).toBe('reggie')
+
+    const inbound = injected[0].inbound
+    expect(inbound.type).toBe('inbound')
+    expect(inbound.chatId).toBe(FORUM_CHAT)
+    expect(inbound.threadId).toBe(7)
+    expect(inbound.user).toBe('webhook')
+    expect((inbound.meta as Record<string, string>).source).toBe('webhook')
+    expect((inbound.meta as Record<string, string>).event).toBe('pull_request')
+    expect(inbound.text).toContain('#42')
+    expect(inbound.text).toContain('Add dark mode support')
+  })
+
+  it('routes to the agent gateway socket under the resolved agent dir', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const { injected, injectFn } = captureInject()
+    const config: WebhookDispatchConfig = { github: [baseRule] }
+
+    evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'github',
+        eventType: 'pull_request',
+        payload: prOpened,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
+      { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn },
+    )
+
+    expect(injected).toHaveLength(1)
+    expect(injected[0].socketPath).toBe(
+      join(resolveAgentDir('reggie'), 'telegram', 'gateway.sock'),
+    )
   })
 
   it('skips dependabot PR', () => {
     const resolveAgentDir = makeTmpResolveAgentDir()
-    const spawned: Array<unknown> = []
+    const { injected, injectFn } = captureInject()
     const config: WebhookDispatchConfig = { github: [baseRule] }
 
     const count = evaluateDispatch(
@@ -329,17 +381,13 @@ describe('evaluateDispatch', () => {
         eventType: 'pull_request',
         payload: prDependabot,
         dispatchConfig: config,
+        chatId: FORUM_CHAT,
       },
-      {
-        resolveAgentDir,
-        now: () => 1_000_000,
-        log: () => {},
-        spawnFn: (_, args) => { spawned.push(args); return { on: () => {} } },
-      },
+      { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn },
     )
 
     expect(count).toBe(0)
-    expect(spawned).toHaveLength(0)
+    expect(injected).toHaveLength(0)
   })
 
   it('returns 0 for non-github source', () => {
@@ -352,6 +400,7 @@ describe('evaluateDispatch', () => {
         eventType: 'push',
         payload: pushPayload,
         dispatchConfig: config,
+        chatId: FORUM_CHAT,
       },
       { resolveAgentDir, log: () => {} },
     )
@@ -360,7 +409,7 @@ describe('evaluateDispatch', () => {
 
   it('skips during quiet hours', () => {
     const resolveAgentDir = makeTmpResolveAgentDir()
-    const spawned: Array<unknown> = []
+    const { injected, injectFn } = captureInject()
     const ruleWithQH: DispatchRule = {
       ...baseRule,
       quiet_hours: { start: 0, end: 23, tz: 'UTC' }, // always quiet
@@ -374,49 +423,59 @@ describe('evaluateDispatch', () => {
         eventType: 'pull_request',
         payload: prOpened,
         dispatchConfig: config,
+        chatId: FORUM_CHAT,
       },
       {
         resolveAgentDir,
         nowDate: () => new Date('2026-05-06T10:00:00Z'),
         now: () => 1_000_000,
         log: () => {},
-        spawnFn: (_, args) => { spawned.push(args); return { on: () => {} } },
+        injectFn,
       },
     )
 
     expect(count).toBe(0)
-    expect(spawned).toHaveLength(0)
+    expect(injected).toHaveLength(0)
   })
 
   it('respects cooldown — second fire within window is skipped', () => {
     const resolveAgentDir = makeTmpResolveAgentDir()
-    const spawned: Array<unknown> = []
+    const { injected, injectFn } = captureInject()
     const ruleWithCooldown: DispatchRule = { ...baseRule, cooldown: '5m' }
     const config: WebhookDispatchConfig = { github: [ruleWithCooldown] }
 
-    const deps = {
-      resolveAgentDir,
-      now: () => 1_000_000,
-      log: () => {},
-      spawnFn: (_cmd: string, args: string[]) => { spawned.push(args); return { on: () => {} } },
-    }
+    const deps = { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn }
 
     evaluateDispatch(
-      { agent: 'reggie', source: 'github', eventType: 'pull_request', payload: prOpened, dispatchConfig: config },
+      {
+        agent: 'reggie',
+        source: 'github',
+        eventType: 'pull_request',
+        payload: prOpened,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
       deps,
     )
     const count2 = evaluateDispatch(
-      { agent: 'reggie', source: 'github', eventType: 'pull_request', payload: prOpened, dispatchConfig: config },
+      {
+        agent: 'reggie',
+        source: 'github',
+        eventType: 'pull_request',
+        payload: prOpened,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
       { ...deps, now: () => 1_060_000 }, // 1 minute later, still in cooldown
     )
 
-    expect(spawned).toHaveLength(1)
+    expect(injected).toHaveLength(1)
     expect(count2).toBe(0)
   })
 
   it('fires multiple matching rules', () => {
     const resolveAgentDir = makeTmpResolveAgentDir()
-    const spawned: Array<unknown> = []
+    const { injected, injectFn } = captureInject()
     const rule2: DispatchRule = {
       match: { event: 'pull_request', labels_any: ['enhancement'] },
       prompt: 'Enhancement PR opened: {{title}}',
@@ -424,16 +483,19 @@ describe('evaluateDispatch', () => {
     const config: WebhookDispatchConfig = { github: [baseRule, rule2] }
 
     const count = evaluateDispatch(
-      { agent: 'reggie', source: 'github', eventType: 'pull_request', payload: prOpened, dispatchConfig: config },
       {
-        resolveAgentDir,
-        now: () => 1_000_000,
-        log: () => {},
-        spawnFn: (_, args) => { spawned.push(args); return { on: () => {} } },
+        agent: 'reggie',
+        source: 'github',
+        eventType: 'pull_request',
+        payload: prOpened,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
       },
+      { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn },
     )
 
     expect(count).toBe(2)
-    expect(spawned).toHaveLength(2)
+    expect(injected).toHaveLength(2)
+    expect((injected[1].inbound.meta as Record<string, string>).rule_index).toBe('1')
   })
 })

--- a/src/web/webhook-dispatch.ts
+++ b/src/web/webhook-dispatch.ts
@@ -1,8 +1,8 @@
 /**
  * Webhook dispatch (#715). After an event is verified and recorded by
  * `webhook-handler.ts`, this module evaluates per-rule matchers and, for
- * each match, spawns a fresh `claude -p` invocation against the agent so
- * it can react to the event via Telegram.
+ * each match, delivers a synthesized turn to the agent so it can react
+ * to the event via Telegram.
  *
  * Design principles:
  *   - **Static matcher** (no CEL/expression parser). Fields: `event`,
@@ -14,8 +14,14 @@
  *     coalesces. State stored per-agent on disk.
  *   - **Quiet hours**: skip dispatch entirely when the wall clock is
  *     inside the configured window (events still in JSONL).
- *   - **Spawn pattern**: same shape as cron one-shots — `claude -p`
- *     with `--no-session-persistence`, env vars matching `buildCronScript`.
+ *   - **Delivery (since #1620)**: a match synthesizes an
+ *     `InboundMessage` tagged `meta.source="webhook"` and delivers it
+ *     via `inject_inbound` to the agent's gateway socket — the same
+ *     path cron uses. The webhook turn runs inside the agent's live
+ *     interactive `claude` session. No `claude -p`: a headless
+ *     `claude -p` is *programmatic* usage under Anthropic's 2026-06-15
+ *     policy (off the subscription) and would spawn a parasitic second
+ *     telegram bridge (#1617). See `docs/rfcs/eliminate-claude-p.md`.
  *
  * Configuration (in switchroom.yaml under agents.<name>.channels.telegram):
  *
@@ -33,88 +39,14 @@
  *         {{html_url}}
  *       cooldown: 5m
  *       quiet_hours: { start: 22, end: 8, tz: Australia/Melbourne }
- *       model: claude-opus-4-7
  * ```
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
-import { spawn } from 'child_process'
-
-/**
- * When the parent process (typically the systemd-launched switchroom-web)
- * was started without nvm in PATH, `node` won't resolve for spawned
- * children — so any agent hook that uses `node /path/to/hook.mjs` exits
- * 127 and the agent's issue sink lights up. This is invisible to the
- * operator until the first webhook fires.
- *
- * Detect an nvm install (in priority order: `NVM_DIR`, `~/.nvm`) and
- * resolve a node bin directory by reading `alias/default` first, then
- * falling back to the lexicographically newest version directory. Returns
- * undefined when no usable nvm install is found, in which case the caller
- * leaves PATH untouched.
- *
- * Exported for tests.
- */
-export function resolveNvmNodeBin(env: NodeJS.ProcessEnv): string | undefined {
-  const nvmDir = env.NVM_DIR ?? join(env.HOME ?? homedir(), '.nvm')
-  if (!existsSync(nvmDir)) return undefined
-
-  const versionsDir = join(nvmDir, 'versions', 'node')
-  if (!existsSync(versionsDir)) return undefined
-
-  const tryVersion = (v: string): string | undefined => {
-    const bin = join(versionsDir, v, 'bin')
-    return existsSync(join(bin, 'node')) ? bin : undefined
-  }
-
-  // Prefer the user's default alias if set.
-  const defaultAliasPath = join(nvmDir, 'alias', 'default')
-  try {
-    if (existsSync(defaultAliasPath)) {
-      const aliased = readFileSync(defaultAliasPath, 'utf-8').trim()
-      if (aliased) {
-        const bin = tryVersion(aliased.startsWith('v') ? aliased : `v${aliased}`)
-        if (bin) return bin
-      }
-    }
-  } catch {
-    // Fall through to dir scan
-  }
-
-  // Otherwise: lexicographic max across installed versions.
-  try {
-    const versions = readdirSync(versionsDir).filter((v) => v.startsWith('v')).sort()
-    for (let i = versions.length - 1; i >= 0; i--) {
-      const bin = tryVersion(versions[i])
-      if (bin) return bin
-    }
-  } catch {
-    return undefined
-  }
-
-  return undefined
-}
-
-/**
- * Returns a copy of `env` with `node` guaranteed to be on PATH where
- * possible. No-op when `node` already resolves via the inherited PATH or
- * when no nvm install is present.
- *
- * Exported for tests.
- */
-export function ensureNodeOnPath(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const path = env.PATH ?? ''
-  // Cheap pre-check: if any PATH entry already contains a node binary, no-op.
-  const existing = path.split(':').some((dir) => dir && existsSync(join(dir, 'node')))
-  if (existing) return env
-
-  const nvmBin = resolveNvmNodeBin(env)
-  if (!nvmBin) return env
-
-  return { ...env, PATH: path ? `${nvmBin}:${path}` : nvmBin }
-}
+import { createInjectIpcClient, type InjectIpcClient } from '../agent-scheduler/ipc-client.js'
+import type { InboundMessageWire } from '../scheduler/dispatch.js'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -143,12 +75,17 @@ export interface QuietHours {
 export interface DispatchRule {
   description?: string
   match: DispatchMatcher
-  /** Handlebars-style `{{field}}` template for the claude -p prompt. */
+  /** Handlebars-style `{{field}}` template for the synthesized turn's prompt. */
   prompt: string
   /** Cooldown duration string: "5m", "1h", "30s". Defaults to "0" (no cooldown). */
   cooldown?: string
   quiet_hours?: QuietHours
-  /** Model override. Defaults to claude-sonnet-4-6. */
+  /**
+   * Deprecated and ignored since #1620. A webhook turn now runs inside
+   * the agent's live interactive session, which uses the agent's own
+   * configured model — there is no per-turn model override. Retained
+   * as an optional field only so existing configs still parse.
+   */
   model?: string
 }
 
@@ -398,19 +335,21 @@ export function isQuietHour(qh: QuietHours, now: Date): boolean {
   }
 }
 
-// ─── Spawner ──────────────────────────────────────────────────────────────────
+// ─── Inbound injection ────────────────────────────────────────────────────────
 
-export interface SpawnAgentOneShotDeps {
-  /** Override to capture spawn args in tests. */
-  spawnFn?: (
-    cmd: string,
-    args: string[],
-    opts: { env: NodeJS.ProcessEnv; stdio: [string, string, string] },
-  ) => { on: (event: string, cb: (code: number | null) => void) => void; pid?: number }
+export interface InjectWebhookInboundDeps {
+  /**
+   * Test seam — replace the gateway delivery. Default connects to the
+   * agent's gateway UDS socket and writes one `inject_inbound` envelope.
+   * Resolves true when the bytes were accepted by the socket.
+   */
+  injectFn?: (
+    socketPath: string,
+    agentName: string,
+    inbound: InboundMessageWire,
+  ) => Promise<boolean>
   /** Override agent dir resolver for tests. */
   resolveAgentDir?: (agent: string) => string
-  /** Injectable cooldown store for tests. */
-  cooldownStore?: CooldownStore
   /** Clock override for tests. */
   now?: () => number
   /** Log sink. */
@@ -418,77 +357,86 @@ export interface SpawnAgentOneShotDeps {
 }
 
 /**
- * Spawn a fresh `claude -p` process for the given agent and prompt.
- * Env setup:
- *   - CLAUDE_CONFIG_DIR → <agentDir>/.claude
- *   - SWITCHROOM_AGENT_NAME → <agentName>
- *   - TELEGRAM_STATE_DIR → <agentDir>/telegram
- *   - ANTHROPIC_API_KEY unset to force OAuth
- *
- * Post-RFC-H: claude reads its OAuth token directly from
- * `<CLAUDE_CONFIG_DIR>/credentials.json`. The auth-broker writes that
- * file atomically and refreshes ahead of claude's own window —
- * `CLAUDE_CODE_OAUTH_TOKEN` env injection has been removed everywhere
- * (one mechanism, not two).
+ * Default delivery: connect to the agent's gateway socket, write one
+ * `inject_inbound` envelope, close. The webhook process is host-side;
+ * the agent's gateway socket lives at a host-visible bind-mounted path
+ * inside the agent's telegram state dir.
  */
-export function spawnAgentOneShot(
+async function defaultInject(
+  socketPath: string,
+  agentName: string,
+  inbound: InboundMessageWire,
+): Promise<boolean> {
+  const client = createInjectIpcClient({ socketPath })
+  try {
+    const connected = await client.waitForConnect(5_000)
+    if (!connected) return false
+    return client.sendInjectInbound({
+      type: 'inject_inbound',
+      agentName,
+      // InboundMessageWire is a structural mirror of telegram-plugin's
+      // InboundMessage — the cast is a no-op at runtime. Same pattern
+      // as the scheduler's `ipcDispatcher` (agent-scheduler/index.ts).
+      inbound: inbound as unknown as Parameters<
+        InjectIpcClient['sendInjectInbound']
+      >[0]['inbound'],
+    })
+  } finally {
+    client.close()
+  }
+}
+
+/**
+ * Synthesize an `InboundMessage` for a matched webhook rule and deliver
+ * it to the agent's gateway as an `inject_inbound` envelope. The turn
+ * runs in the agent's live interactive `claude` session — the same
+ * path cron fires take.
+ *
+ * Fire-and-forget: the synthesized turn is delivered asynchronously and
+ * the result is logged; the caller's match-evaluation loop does not
+ * block on gateway round-trips.
+ */
+export function injectWebhookInbound(
   agent: string,
   prompt: string,
-  model: string,
-  deps: SpawnAgentOneShotDeps = {},
+  ctx: { chatId: string; threadId?: number; eventType: string; ruleIndex: number },
+  deps: InjectWebhookInboundDeps = {},
 ): void {
   const log = deps.log ?? ((s) => process.stderr.write(s))
   const resolveAgentDir =
     deps.resolveAgentDir ?? ((a) => join(homedir(), '.switchroom', 'agents', a))
-  const agentDir = resolveAgentDir(agent)
-  const claudeConfigDir = join(agentDir, '.claude')
-  const telegramStateDir = join(agentDir, 'telegram')
+  const now = (deps.now ?? Date.now)()
+  const socketPath = join(resolveAgentDir(agent), 'telegram', 'gateway.sock')
 
-  const env: NodeJS.ProcessEnv = ensureNodeOnPath({
-    ...process.env,
-    FORCE_COLOR: '0',
-    NO_COLOR: '1',
-    CLAUDE_CONFIG_DIR: claudeConfigDir,
-    SWITCHROOM_AGENT_NAME: agent,
-    TELEGRAM_STATE_DIR: telegramStateDir,
-  })
-
-  // Unset ANTHROPIC_API_KEY to force OAuth auth (mirrors cron script pattern).
-  delete env.ANTHROPIC_API_KEY
-  // Defence in depth: scrub any inherited CLAUDE_CODE_OAUTH_TOKEN so a
-  // legacy operator-shell export can't shadow the broker-managed
-  // credentials.json. (RFC H §7.4)
-  delete env.CLAUDE_CODE_OAUTH_TOKEN
-
-  const spawnFn = deps.spawnFn ?? (
-    (cmd: string, args: string[], opts: { env: NodeJS.ProcessEnv; stdio: [string, string, string] }) =>
-      spawn(cmd, args, { ...opts, stdio: opts.stdio as ['ignore', 'ignore', 'pipe'] })
-  )
-
-  const child = spawnFn('claude', ['-p', prompt, '--model', model, '--no-session-persistence'], {
-    env,
-    stdio: ['ignore', 'ignore', 'pipe'],
-  })
-
-  log(`webhook-dispatch: agent='${agent}' model='${model}' pid=${child.pid ?? '?'} spawned\n`)
-
-  // Drain stderr to prevent the OS pipe buffer (~64KB) from blocking
-  // the child process. We log the last few lines on failure so operators
-  // can debug a broken dispatch without attaching a PTY.
-  let stderrTail = ''
-  const stderrStream = (child as unknown as { stderr?: { on: (e: string, cb: (d: Buffer) => void) => void } }).stderr
-  if (stderrStream) {
-    stderrStream.on('data', (d: Buffer) => {
-      stderrTail = (stderrTail + d.toString('utf-8')).slice(-2048)
-    })
+  const inbound: InboundMessageWire = {
+    type: 'inbound',
+    chatId: ctx.chatId,
+    ...(ctx.threadId !== undefined ? { threadId: ctx.threadId } : {}),
+    // Synthetic id — webhook fires have no Telegram message_id. The
+    // bridge only uses messageId for reply-context, a no-op here.
+    messageId: now,
+    user: 'webhook',
+    userId: 0,
+    ts: now,
+    text: prompt,
+    meta: {
+      source: 'webhook',
+      event: ctx.eventType,
+      rule_index: String(ctx.ruleIndex),
+    },
   }
 
-  child.on('close', (code) => {
-    if (code !== 0) {
-      const tail = stderrTail.trim().split('\n').slice(-3).join(' | ')
-      log(`webhook-dispatch: agent='${agent}' claude -p exited with code ${code}${tail ? `: ${tail}` : ''}\n`)
-    }
-  })
+  const injectFn = deps.injectFn ?? defaultInject
+  injectFn(socketPath, agent, inbound)
+    .then((ok) =>
+      log(
+        `webhook-dispatch: agent='${agent}' inject_inbound ` +
+          `${ok ? 'delivered to gateway' : 'not delivered (gateway not connected)'}\n`,
+      ),
+    )
+    .catch((err: unknown) =>
+      log(`webhook-dispatch: agent='${agent}' inject failed: ${String(err)}\n`),
+    )
 }
 
 // ─── Main dispatch evaluator ──────────────────────────────────────────────────
@@ -499,17 +447,26 @@ export interface EvaluateDispatchArgs {
   eventType: string
   payload: Record<string, unknown>
   dispatchConfig: WebhookDispatchConfig
+  /**
+   * Chat the synthesized webhook turn belongs to — the fleet forum
+   * chat. The caller resolves this from `telegram.forum_chat_id`.
+   */
+  chatId: string
+  /** The agent's forum topic id, when the forum chat has topics. */
+  threadId?: number
 }
 
-export interface EvaluateDispatchDeps extends SpawnAgentOneShotDeps {
+export interface EvaluateDispatchDeps extends InjectWebhookInboundDeps {
   /** Overridable Date for quiet-hours evaluation. */
   nowDate?: () => Date
+  /** Injectable cooldown store for tests. */
+  cooldownStore?: CooldownStore
 }
 
 /**
  * Evaluate all dispatch rules for the incoming event. For each matching
- * rule that is not in cooldown and not in quiet hours, spawn a fresh
- * `claude -p` process.
+ * rule that is not in cooldown and not in quiet hours, deliver a
+ * synthesized `inject_inbound` turn to the agent.
  *
  * Returns the number of dispatches fired (0 if nothing matched).
  */
@@ -560,17 +517,22 @@ export function evaluateDispatch(
     }
 
     const prompt = renderTemplate(rule.prompt, ctx)
-    const model = rule.model ?? 'claude-sonnet-4-6'
 
     log(
       `webhook-dispatch: agent='${args.agent}' rule=${i} matched event='${args.eventType}' action='${ctx.action}' firing\n`,
     )
 
-    spawnAgentOneShot(args.agent, prompt, model, {
-      ...deps,
-      resolveAgentDir,
-      cooldownStore,
-    })
+    injectWebhookInbound(
+      args.agent,
+      prompt,
+      {
+        chatId: args.chatId,
+        ...(args.threadId !== undefined ? { threadId: args.threadId } : {}),
+        eventType: args.eventType,
+        ruleIndex: i,
+      },
+      { ...deps, resolveAgentDir },
+    )
 
     fired++
   }

--- a/tests/bridge-flap-regression-guard.test.ts
+++ b/tests/bridge-flap-regression-guard.test.ts
@@ -34,11 +34,13 @@ const ROOTS = ["src", "telegram-plugin"];
  * Every entry MUST cite a tracking issue. This list may only ever
  * shrink — when the gap is fixed the entry must be deleted, and the
  * "no stale entries" test below enforces that.
+ *
+ * Currently empty: webhook-dispatch.ts (the last entry, #1617) was
+ * migrated off `claude -p` to the `inject_inbound` path — every
+ * headless-`claude` callsite now passes `--strict-mcp-config`, or
+ * spawns no `claude` at all.
  */
-const KNOWN_GAPS: Record<string, string> = {
-  "src/web/webhook-dispatch.ts":
-    "#1617 — migrating to inject_inbound (RFC docs/rfcs/eliminate-claude-p.md, Workstream A)",
-};
+const KNOWN_GAPS: Record<string, string> = {};
 
 /** Matches `spawn("claude"`, `spawnSync('claude'`, `execFile("claude"`, etc. */
 const SPAWN_CLAUDE =


### PR DESCRIPTION
## Summary

RFC #1620 **Workstream A**. Converts `webhook-dispatch` off `claude -p`.

`spawnAgentOneShot` shelled out to a headless `claude -p`. Under
Anthropic's **2026-06-15** policy that is *programmatic* usage — off
the subscription — which violates switchroom's Claude-native /
subscription-funded constraint (`reference/vision.md` pillar 3); and
that `claude -p` auto-loads the agent's `.mcp.json` and spawns a
parasitic second telegram bridge (**#1617**, same class as the #1613
flap).

## Change

A matched rule now synthesizes an `InboundMessage` tagged
`meta.source="webhook"` and delivers it via `inject_inbound` to the
agent's gateway socket — the **Phase-4 cron pattern**. The webhook turn
runs inside the agent's **live interactive `claude` session**. No
`claude -p`, no second bridge, 100% subscription-funded.

- `spawnAgentOneShot` → `injectWebhookInbound`.
- `EvaluateDispatchArgs` gains `chatId` / `threadId`.
- Removed the now-dead `resolveNvmNodeBin` / `ensureNodeOnPath` helpers.
- `DispatchRule.model` kept but documented deprecated/ignored.
- `KNOWN_GAPS` in the bridge-flap regression guard is now **empty** —
  webhook-dispatch was its last entry; the guard's self-cleaning check
  drove the removal.

## Scope note

`webhook_dispatch` (#715) is **not wired** into the live ingest path —
`webhook-handler.ts` records events but never calls `evaluateDispatch`.
This PR converts the dispatch *mechanism* so the feature, whenever it
is wired, runs on the compliant path. Wiring it is separate scope.

## Test plan

- [x] `vitest src/web/webhook-dispatch.test.ts` — 36 pass (rewritten to
      assert the `inject_inbound` envelope + `meta`, no claude spawn)
- [x] `vitest tests/bridge-flap-regression-guard.test.ts` — 3 pass, `KNOWN_GAPS` empty
- [x] `tsc --noEmit` clean

## Risk

Low. The feature is unwired, so no live behaviour changes; the
conversion is mechanism-only and fully unit-covered.

Closes #1617.