### PR TITLE
docs(jtbd): refresh subscription-honest + quota JTBDs for the 2026-06-15 policy

### DIFF
--- a/reference/keep-my-subscription-honest.md
+++ b/reference/keep-my-subscription-honest.md
@@ -21,6 +21,26 @@ Transparency beats cleverness here. If there's any ambiguity about what
 the agent is using, the user should be able to find out in seconds, and
 the answer should match what Anthropic's terms permit.
 
+## Interactive, not programmatic (the 2026-06-15 line)
+
+As of **2026-06-15** Anthropic splits subscription usage in two:
+*interactive* Claude Code draws the subscription; *programmatic* usage
+— the Agent SDK and headless `claude -p` — draws a separate Agent-SDK
+credit, off the subscription. "Mixing billing models" stopped being a
+hypothetical and became a line in the policy.
+
+Switchroom's rule: **every model call is the interactive `claude`
+session.** Cron fires, webhook triggers, and session handoffs are all
+delivered *into* that one session as synthesized turns — never a
+headless `claude -p`, never the SDK, never the raw API. There is no
+programmatic surface, so there is nothing that quietly draws a
+different pool. (RFC #1620 removed the last `claude -p`; a CI guard
+keeps it at zero. The constraint is stated in `reference/vision.md`
+pillar 3 and enforced as an engineering gate in `CLAUDE.md`.)
+
+This is why the job still holds after the policy split: "the
+subscription is the only thing I'm paying for" stays literally true.
+
 ## Signs it's working
 
 - The user can state in one sentence what they're paying for and what
@@ -41,6 +61,10 @@ the answer should match what Anthropic's terms permit.
 ## Anti-patterns: don't build this
 
 - Silent fallback to API billing when the subscription is rate-limited.
+- A headless `claude -p` or an Agent SDK call anywhere in a code path.
+  Since 2026-06-15 both are *programmatic* usage — they draw the
+  separate Agent-SDK credit, not the subscription, and silently split
+  the billing model. Route the work through the interactive session.
 - Asking the user for an API key as "optional" when core features need
   it. Either the subscription supports the feature, or it doesn't.
 - Proxying subscription auth through the product in a way that bends

--- a/reference/track-plan-quota-live.md
+++ b/reference/track-plan-quota-live.md
@@ -22,6 +22,18 @@ Accuracy matters too. If the displayed number lags reality by an hour,
 the user plans around a phantom. Whatever the product shows, it needs
 to be current enough to act on.
 
+## One pool, not two
+
+The 2026-06-15 Anthropic policy split created a second usage pool — a
+separate Agent-SDK / `claude -p` credit alongside the interactive
+subscription limits. Switchroom deliberately has **no programmatic
+surface**: every model call is the interactive `claude` session (see
+`keep-my-subscription-honest`). So there is exactly *one* pool to
+track — the interactive subscription window — and quota tracking
+stays a single-signal problem. If a future feature ever introduced
+programmatic usage, this job would fork into two legible-but-separate
+signals; that split is itself a reason not to.
+
 ## Signs it's working
 
 - The user can answer "am I close to my limit?" without stopping what


### PR DESCRIPTION
## Summary

RFC #1620 **P2** — the design-contract refresh. Updates the two JTBDs
the 2026-06-15 Anthropic policy directly touches.

The policy split subscription usage into **interactive** (Claude Code,
on the subscription) and **programmatic** (Agent SDK + headless
`claude -p`, on a separate credit). switchroom's response — already
shipped as code in #1625 / #1626 — is **zero programmatic surface**:
every model call is the interactive `claude` session.

## Changes

- **`keep-my-subscription-honest`** — new *"Interactive, not
  programmatic (the 2026-06-15 line)"* section: names the policy split
  and states switchroom's rule. New anti-pattern: a headless
  `claude -p` / Agent SDK call anywhere in a code path.
- **`track-plan-quota-live`** — new *"One pool, not two"* section:
  because there is no programmatic surface, there is one usage pool to
  track, so quota tracking stays a single-signal problem.

Companion to #1624 (vision pillar 3 + CLAUDE.md hard constraint). Docs
only — no code.

## Context

`reference/vision.md` pillar 3 and `CLAUDE.md` already carry the
engineering constraint (#1624). This PR brings the outcome-focused
JTBD layer in line.