### PR TITLE
docs(vision): re-anchor on the standing-team thesis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,10 +233,14 @@ docs, three questions:
 **Vision — `reference/vision.md`** — *should we build this?*
 Every feature serves one of four outcomes:
 
-1. **Visibility** — see every step, pinned to the chat (progress card)
-2. **Multi-agent fleet** — specialists, not one generalist
-3. **Subscription-honest** — Pro/Max is the ceiling, no API-key routing
-4. **Always-on** — runs while you sleep or work offline
+1. **A standing team that knows you** — specialists with persona +
+   memory, not one generalist
+2. **You hold the leash** — controlled, purposeful, never roaming;
+   awareness + control, not a tool-call log to babysit
+3. **Subscription-honest and predictable** — the plan is the ceiling;
+   the unmodified `claude` CLI on the subscription, no API/SDK
+4. **Always available** — there in Telegram the second you reach for
+   it; survives reboots, runs its schedules
 
 **Principles — `reference/principles.md`** — *did we build it well?*
 Three checks. A "no" on any one is a redesign, not a follow-up:

--- a/reference/README.md
+++ b/reference/README.md
@@ -29,26 +29,26 @@ that touches the job.
 
 ## JTBD index — grouped by vision outcome
 
-### Visibility — *see every step, pinned to the chat*
-
-- [`know-what-my-agent-is-doing.md`](know-what-my-agent-is-doing.md) — know what my agent is actually doing
-- [`restart-and-know-what-im-running.md`](restart-and-know-what-im-running.md) — know what I'm running after a restart, without asking
-- [`track-plan-quota-live.md`](track-plan-quota-live.md) — track my plan quota live, without a dashboard
-- [`steer-or-queue-mid-flight.md`](steer-or-queue-mid-flight.md) — steer or queue while the agent is mid-flight
-
-### Multi-agent fleet — *specialists, not one generalist*
+### A standing team that knows you — *specialists, not one generalist*
 
 - [`run-a-fleet-of-specialists.md`](run-a-fleet-of-specialists.md) — run a fleet of specialists, not one generalist
 - [`give-each-agent-its-own-workspace.md`](give-each-agent-its-own-workspace.md) — give each agent its own working copy of the code
 - [`remember-across-sessions.md`](remember-across-sessions.md) — remember across sessions without being re-told
 - [`extend-without-forking.md`](extend-without-forking.md) — extend the product without forking it
 
-### Subscription-honest — *your Pro or Max is the ceiling*
+### You hold the leash — *controlled, purposeful, never roaming*
+
+- [`know-what-my-agent-is-doing.md`](know-what-my-agent-is-doing.md) — know what my agent is actually doing
+- [`restart-and-know-what-im-running.md`](restart-and-know-what-im-running.md) — know what I'm running after a restart, without asking
+- [`track-plan-quota-live.md`](track-plan-quota-live.md) — track my plan quota live, without a dashboard
+- [`steer-or-queue-mid-flight.md`](steer-or-queue-mid-flight.md) — steer or queue while the agent is mid-flight
+
+### Subscription-honest and predictable — *the plan is the ceiling*
 
 - [`keep-my-subscription-honest.md`](keep-my-subscription-honest.md) — keep my subscription the only thing I'm paying for
 - [`share-auth-across-the-fleet.md`](share-auth-across-the-fleet.md) — log into Anthropic once per account, not once per agent
 
-### Always-on — *runs while you sleep or work offline*
+### Always available — *there when you want it*
 
 - [`survive-reboots-and-real-life.md`](survive-reboots-and-real-life.md) — survive reboots and real life
 - [`idempotent-update-and-restart.md`](idempotent-update-and-restart.md) — update switchroom and trust everything's running the new version

--- a/reference/vision.md
+++ b/reference/vision.md
@@ -4,22 +4,22 @@ source: switchroom.ai (canonical), README.md, reference/*.md JTBDs
 audience: anyone deciding whether a feature, PR, or release belongs in switchroom
 ---
 
-# Switchroom — product vision
+# Switchroom: product vision
 
 > **A switchboard for your Pro or Max.**
-> Opinionated Telegram UX for Claude Code, on the subscription you
-> already pay for.
+> Your standing team. Specialists who remember you, own their patch,
+> and act, while you get on with life.
 
-Switchroom turns your Claude Pro or Max subscription into a fleet of
-always-on specialist agents you talk to from Telegram. One box you
-already own, one Telegram forum, one bot per agent, every session
-officially authenticated through the same OAuth flow you use on the
-desktop. No API keys. No harness. No second invoice.
+Your Claude subscription becomes a small team of always-on assistants
+you text from Telegram. One box you own. One bot per specialist. Each
+has a name, a job it owns, a memory of you, and the tools to do the
+work. You text it like you'd text a good assistant. It does the thing.
+It asks first on anything that matters.
 
-It is **not** a general-purpose LLM orchestrator, **not** a multi-channel
-bridge, **not** a hosted service, **not** multi-tenant. It does one
-thing: makes Telegram the best possible interaction surface for Claude
-Code. Unashamedly.
+Not a general-purpose orchestrator. Not a multi-channel bridge. Not a
+hosted service. Not multi-tenant. Not an agent that roams on its own.
+One idea, done properly: a personal team that lives in Telegram and
+stays on your leash.
 
 ---
 
@@ -28,98 +28,94 @@ Code. Unashamedly.
 > *"I loved OpenClaw + Telegram. I wanted my Claude subscription. And
 > the UX done properly. So I built this."*
 
-Two existing options, two failures:
+The use case came from OpenClaw. Always-on assistants in a chat app,
+each with a personality and a job. Good idea. Three things stopped it
+being the one I needed, and nothing else fixed them:
 
-- **OpenClaw + Telegram** — great UX, but it pings the Anthropic API on
-  your own key. You signed up for "use your subscription," not "buy
-  API credits on top of your subscription."
-- **Claude Code's built-in Telegram channel** — uses the subscription
-  correctly, but it's an MVP black box. Send a message, wait, eventually
-  something comes back. What did the agent actually do? No idea.
+- **On the subscription, properly.** The Claude plan I already pay for,
+  the same OAuth as the desktop. Compliant. Predictable cost. Not an
+  API meter. Not a second invoice.
+- **On the leash.** Give an assistant broad standing access and one day
+  it helpfully does something irreversible. Credentials, tools, skills:
+  granted deliberately, approved by a human, no way around it.
+- **Telegram, done properly.** Not a bridge spread thin across Slack,
+  Discord, Teams. One channel. Opinionated. Excellent.
 
-Switchroom is the third option: subscription-honest *and* the UX done
-properly.
+So I built it.
 
 ---
 
 ## The four outcomes
 
-Every feature should serve one of these. If it doesn't, it doesn't
-belong.
+Every feature serves one of these. If it doesn't, it doesn't belong.
 
-### 1. Visibility — *see every step, pinned to the chat*
+### 1. A standing team that knows you: *specialists, not one generalist*
 
-The headline UX. Every time an agent starts work, a **progress card**
-pins into its Telegram topic and updates in place as tools execute.
-Each Read, Bash, Edit, Grep is visible as it happens, with elapsed
-time so you can tell if something's stuck. Sub-agent work surfaces in
-the same card. When the agent finishes, the card flips to Done and
-unpins.
+The headline. One bot per specialist. Each its own persona, memory,
+skills, tools, credentials. `clerk` is the canonical one: a chief of
+staff that runs the calendar, watches the health data, fields the
+household asks, all in one voice, because it knows you across all of
+it. The coding specialist is the same thesis, not an exception. It
+remembers why the product is the way it is, so its pushback on a
+half-formed idea from the train is worth something. Add a specialist
+in ten lines of YAML. You don't fork the product.
 
-No silent gaps. No ghosts. No squinting into a black box.
+Memory serves this. It isn't the pitch.
 
-### 2. Multi-agent fleet — *specialists, not one generalist*
+### 2. You hold the leash: *controlled, purposeful, never roaming*
 
-One bot per agent. Each agent is a real `claude --channels` session
-with its own SOUL.md (who it is), CLAUDE.md (what it does), memory
-collection, skills, tools, and OAuth credentials. A health coach is
-not the same process as an executive assistant is not the same process
-as a coding agent. You add a new specialist by editing ten lines of
-YAML, not by forking the product.
+The substantive one. Agents act, but only with what you gave them. A
+specialist sees only the credentials and tools you granted it. It can
+ask for more. You get an Allow or Deny card in Telegram. Only your tap
+grants it. It can't self-elevate or route around you. No heartbeats:
+beck-and-call plus the explicit schedules you set, never a loop of its
+own. You're never in the dark, the state reads in plain words, and you
+can steer or stop a turn mid-flight. Awareness and control. Not a
+tool-call log to babysit.
 
-Sub-agents (Opus plans, Sonnet implements) compose inside each
-specialist without leaving the topic.
+### 3. Subscription-honest and predictable: *the plan is the ceiling*
 
-### 3. Subscription-honest — *your Pro or Max is the ceiling*
+Every agent runs the unmodified `claude` binary, OAuth straight to
+Anthropic, the same flow as the desktop. No Agent SDK. No API-key
+routing. No raw API. No credential interception. This is a hard
+constraint, not a preference: running the native CLI on the
+subscription is what keeps switchroom inside Anthropic's third-party
+policy. The moment a feature reaches for the SDK or the API, it has
+left switchroom.
 
-> *"Not a harness. Doesn't patch the CLI, doesn't intercept the
-> protocol, doesn't forge tokens."*
+Every model call is the interactive `claude` session, or a turn
+synthesized into it. Headless `claude -p` is the same CLI, but as of
+the 2026-06-15 policy it counts as programmatic usage, off the
+subscription, so switchroom keeps that work in the interactive session
+too.
 
-Switchroom is scaffolding and lifecycle management. It creates
-directories, stands up a long-running service per agent, manages
-OAuth, routes Telegram messages, and gets out of the way. Each agent
-runs the **unmodified `claude` binary**, authenticated directly with
-Anthropic through the **Pro/Max OAuth** flow. No Agent SDK, no
-API-key routing, no `ANTHROPIC_API_KEY`, no credential interception,
-no custom inference runtime.
+Cost is the subscription you chose, not a meter you can't forecast.
+Need more throughput, pool accounts with automatic failover. One bill.
+The one you already pay.
 
-This is a **hard constraint, not a preference** — it is what keeps
-switchroom compliant with Anthropic's third-party policy. The native
-CLI on the subscription is the compliance boundary: the moment a
-feature reaches for the Agent SDK or the raw API, it has left
-switchroom. Every model call is the interactive `claude` session, or
-a synthesized turn injected into it. (`claude -p` headless mode is the
-same CLI, but as of the 2026-06-15 policy it counts as *programmatic*
-usage — off the subscription — so switchroom routes that work back
-through the interactive session instead.)
+### 4. Always available, in Telegram, done properly: *there when you want it*
 
-One bill. The one you already pay.
-
-### 4. Always-on — *runs while you sleep or work offline*
-
-Each agent is a long-running service. They survive reboots, network
-drops, and your laptop closing. Scheduled tasks fire across reboots.
-Token refresh runs unattended for weeks. Crashed agents auto-recover
-with an audit trail. The fleet comes back on its own after a cold
-boot.
-
-Telegram IS the mobile interface. Anywhere your phone has signal, your
-fleet is reachable.
+Each specialist is a long-running service. It survives reboots,
+network drops, your laptop closing. It runs its scheduled work and
+it's there the second you reach for it, anywhere your phone has
+signal. Available and punctual. Not autonomous. Telegram is the
+interface, singular on purpose, not one tab of a bridge.
 
 ---
 
 ## Who it's for
 
-- **Solo developers** who want Claude in Telegram across devices,
-  without giving up their subscription.
-- **Home-lab operators** comfortable with YAML and a box they already
-  own.
-- **Founder-operators** running a personal fleet of specialists —
-  health coach, executive assistant, coding agent, research agent —
-  each with its own persona and persistent memory.
+Two people. Don't conflate them.
 
-Built for people who already run things themselves. Configuration over
-code. Transparency over abstraction.
+- **The principal.** The person the team serves. You in non-coding
+  mode, or someone non-technical in your house. Never sees a server.
+  Texts an assistant that knows them and checks before anything that
+  matters. The bar: one even a non-technical partner likes.
+- **The operator.** Stands it up. Fine with a Linux box, YAML, an
+  OAuth flow. Runs it once, then mostly lives as a principal too.
+
+Technical to stand up. Human to live with. Both halves honest. Neither
+hidden.
 
 ---
 
@@ -128,40 +124,39 @@ code. Transparency over abstraction.
 | Not… | Because… |
 |---|---|
 | A harness or wrapper | Switchroom never intercepts auth or inference. The `claude` CLI is the runtime. |
-| A multi-provider orchestrator | We don't care about OpenAI, Gemini, Llama, or model swapping. |
+| A multi-provider orchestrator | No OpenAI, Gemini, Llama, model swapping. |
 | A multi-channel bridge | Not Slack, not Discord, not Teams. Telegram, done properly. |
+| An autonomous agent | No heartbeats. Beck-and-call plus explicit schedules, on your leash. |
 | Multi-tenant | Single-operator by design. |
 | A hosted service | Self-hosted only. Your box, your tokens, your data. |
-| A mobile app | Telegram IS the mobile app. |
+| A mobile app | Telegram is the mobile app. |
 
 ---
 
 ## Voice and tone
 
-Technical, direct, opinionated. Speaks to builders with agency.
-Casual punctuation, assumes infrastructure literacy. Emphasises what
-the product *doesn't* do as much as what it does — because the
-absences (no harness, no API key, no fork) are the differentiation.
+Plain, direct, opinionated. Reads like one person built it, because
+one did. Lead with what it feels like to have the team, not the
+machinery. Operator and trust details stay honest and present, never
+buried, never dressed up. No filler. No hype. No em dashes. Say what
+it deliberately doesn't do, no API key, no harness, no heartbeat, no
+second channel. The restraint is the point.
 
-This voice carries into the product surface: CLI output, error
-messages, progress cards, setup wizard. Switchroom should sound like
-one person built it (because one person did) — not like a committee
-shipped a kit.
+Carries into every surface: CLI output, errors, the status the
+principal sees, the setup wizard.
 
 ---
 
 ## How vision becomes verdict
 
-This document is the *what* and *why*. Two sibling documents turn it
-into a verdict on any specific PR or design:
+The *what* and *why*. Two sibling docs turn it into a verdict on a
+specific PR or design:
 
-- **`reference/principles.md`** — the three load-bearing standards
-  (docs / defaults / consistency) every change is checked against.
-- **`reference/*.md` JTBDs** — outcome-focused jobs the product must
-  do (e.g. `know-what-my-agent-is-doing`, `survive-reboots-and-real-life`,
-  `keep-my-subscription-honest`). Each maps to one of the four
-  outcomes above.
+- **`reference/principles.md`** carries the three standards (docs /
+  defaults / consistency) every change is checked against.
+- **`reference/*.md` JTBDs** are the outcome-focused jobs. Each maps
+  to one of the four outcomes above.
 
 A feature lands when it (a) advances one of the four outcomes,
-(b) satisfies its JTBD, and (c) passes all three principle checks.
+(b) satisfies its JTBD, (c) passes all three principle checks.
 Anything else is out of scope, however clever.


### PR DESCRIPTION
## Summary

Executes the **2026-05-19 product steer**: lead the vision with the
always-on specialist assistants (persona, memory, focus); demote
tool-call visibility from "the headline UX" to one facet of a control
outcome. `reference/vision.md` still opened on the progress card.

## The four outcomes, re-anchored

| Was | Now |
|---|---|
| 1. Visibility | 1. **A standing team that knows you** — specialists with persona + memory; the headline |
| 2. Multi-agent fleet | 2. **You hold the leash** — controlled, never roaming; awareness + control (visibility folded in as one facet) |
| 3. Subscription-honest | 3. **Subscription-honest and predictable** |
| 4. Always-on | 4. **Always available** |

Still **four** outcomes — `principles.md` and the verdict rule are
unaffected.

## Changes (docs only, 3 files)

- **`reference/vision.md`** — the re-anchored vision. Outcome #3
  reconciled with #1624 (the Claude-native hard constraint) + the
  2026-06-15 `claude -p`/programmatic-usage nuance, kept em-dash-free
  per the doc's own voice rule.
- **`CLAUDE.md`** — the "Design contract" section's four-outcomes
  enumeration updated to match.
- **`reference/README.md`** — the JTBD index regrouped: same 13 jobs,
  new outcome headings, new order.

## Provenance

The vision.md prose is recovered from earlier re-anchor work on the
`docs/vision-reanchor` branch (which had drifted onto pre-history-
rewrite commits, 148-file drift — unmergeable). The re-anchor diff was
a single file; it's replayed here onto current `main`, with outcome #3
reconciled against #1624 which merged in the interim.

Note: a reviewer can check craft, internal consistency, and factual
accuracy — the product-narrative call itself is the operator's.