### PR TITLE
treat sub-agent inaccessible-service reports as missing vault grants

### DIFF
--- a/profiles/_shared/vault-protocol.md.hbs
+++ b/profiles/_shared/vault-protocol.md.hbs
@@ -61,6 +61,18 @@ there's an operator in the loop:
   scrub hooks will redact it, and you've leaked it to chat history
   along the way. Always use the `vault_request_access` flow.
 
+### When a sub-agent or tool reports a service/API/credential as "inaccessible"
+
+Treat this as the same signal as `VAULT-BROKER-DENIED` from your own tools. A sub-agent saying "Coolify API not accessible" or "cannot reach the database" almost always means no vault grant exists for that key — the sub-agent hit the broker wall and surfaced it as prose.
+
+Don't escalate to the operator to paste credentials or open a dashboard. Instead:
+
+1. Infer the likely key name (`<service>/<key>` convention — e.g. `coolify/api-token`, `github/token`, `<repo>/DATABASE_URL`).
+2. Call `vault_request_access` with that key, `scope='read'`, and a one-line reason (same flow as a direct `VAULT-BROKER-DENIED`).
+3. End your turn cleanly and resume when the grant is approved.
+
+Only escalate to the operator if the grant is explicitly denied, or if you cannot infer a plausible key name.
+
 ### Hint: the deny stderr tells you the exact recovery
 
 The CLI emits a marker + actionable hint on every vault failure. Read

--- a/src/agents/sub-agent-telegram-prompt.ts
+++ b/src/agents/sub-agent-telegram-prompt.ts
@@ -56,6 +56,10 @@ When you call \`mcp__switchroom-telegram__progress_update\` from inside this sub
 One short line per call. Skip for trivial one-shot tasks. Don't narrate every tool call — the parent card already shows your tool ring buffer.
 
 Pass \`chat_id\` = \`${args.defaultChatId}\` unless the parent is handling a different chat in this turn, in which case use whatever chat_id the parent saw on its inbound message.
+
+## Vault / credential access
+
+If you cannot reach a service or API because a credential is missing or denied, **do not tell the parent to ask the operator manually**. Instead, return the exact vault key name you need (use the \`<service>/<key>\` convention, e.g. \`coolify/api-token\`) and the verbatim error. Your parent agent can call \`vault_request_access\` to get the grant — that is the correct recovery path, not an escalation to the operator.
 `
 }
 

--- a/tests/scaffold.persona.test.ts
+++ b/tests/scaffold.persona.test.ts
@@ -145,6 +145,6 @@ describe("scaffoldAgent — persona (Phase 2)", () => {
     // future fragments, so we step back up to a comparable point.
     // Each block is load-bearing. Future bumps should justify themselves
     // similarly.
-    expect(claudeMd.length).toBeLessThan(32000); // post-self-sufficiency epic; identity + peers + admin posture
+    expect(claudeMd.length).toBeLessThan(33500); // +vault sub-agent fallback guidance (PR #1632)
   });
 });


### PR DESCRIPTION
## Incident context

2026-05-21 AEST: during a prod outage rollback, a worker sub-agent reported "Coolify API not accessible". The parent agent (finn) escalated to the operator and asked him to open Coolify, instead of recognising this as a missing-vault-grant pattern and calling \`vault_request_access\`. The operator pointed out the vault flow should have fired.

Root cause: \`vault-protocol.md.hbs\` only covers the case where the agent itself gets \`VAULT-BROKER-DENIED\` from a direct \`switchroom vault get\` call. Sub-agents often surface the same failure as prose ("not accessible", "cannot reach", "API unavailable"), and nothing told the parent to treat that as the same signal.

## Changes

**Change 1 — \`profiles/_shared/vault-protocol.md.hbs\`**

Adds a new section "When a sub-agent or tool reports a service/API/credential as inaccessible" directly before the existing "Hint" section. Tells the parent agent to:
- Infer the vault key using the `<service>/<key>` convention
- Call `vault_request_access` (same flow as a direct VAULT-BROKER-DENIED)
- Only escalate if the grant is denied or the key is unknown

**Change 2 — \`src/agents/sub-agent-telegram-prompt.ts\`**

Adds a "Vault / credential access" block to `buildTelegramProgressGuidance`, which is appended to every sub-agent's prompt when the parent runs on Telegram. Tells sub-agents to return the exact key name + verbatim error, not to tell the parent to ask the operator manually.

## How to test

Both changes are prompt/docs — no logic change. CI green is the test. Manual smoke test: spawn a sub-agent against a service with no vault grant and verify it returns the key name rather than "ask the operator".

🤖 Generated with [Claude Code](https://claude.com/claude-code)