### PR TITLE
test(uat): fuzzy UAT for the guaranteed fast acknowledgement

### DIFF
--- a/telegram-plugin/uat/scenarios/jtbd-fast-ack-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-fast-ack-dm.test.ts
@@ -69,8 +69,8 @@ const AGENT = "test-harness";
 // for a model that leans on the ack-poke nudge instead of self-acking.
 const ACK_HARD_MS = 20_000;
 
-// Vision target: the model self-acknowledges in a beat, well before
-// the framework has to step in.
+// Vision target: the model self-acknowledges in a beat, fast enough
+// that the ack-poke nudge never has to come into it.
 const ACK_VISION_MS = 8_000;
 
 // A first outbound at or under this length reads as an acknowledgement
@@ -166,8 +166,9 @@ describe("uat: guaranteed fast acknowledgement — fuzzy prompt shapes", () => {
           // Invariant: the outbound is a real, non-empty message.
           expect(len).toBeGreaterThan(0);
 
-          // Hard contract: a sign of life FAST, deterministically
-          // backstopped by the framework ack poke.
+          // Hard contract: a sign of life FAST. A latency target, not
+          // a framework guarantee (see header doc) — but a failure
+          // here is a real pacing defect, so it fails the build.
           if (ttfo >= ACK_HARD_MS) {
             throw new Error(
               `[ack] ${tc.name}: TTFO=${ttfo}ms exceeds the hard `
@@ -180,7 +181,7 @@ describe("uat: guaranteed fast acknowledgement — fuzzy prompt shapes", () => {
           expect(ttfo).toBeLessThan(ACK_HARD_MS);
 
           // Forensic, soft: did the model self-acknowledge in a beat,
-          // or did the framework have to drag it over the line?
+          // or did it only get there with the ack-poke nudge?
           const looksLikeAck = len <= ACK_LEN_CEILING;
           if (ttfo < ACK_VISION_MS && looksLikeAck) {
             console.log(
@@ -197,14 +198,13 @@ describe("uat: guaranteed fast acknowledgement — fuzzy prompt shapes", () => {
             );
           } else {
             // Passed the hard contract but slower than the vision
-            // target — the canary for the model leaning on the
-            // framework backstop instead of self-acking.
+            // target — the canary for the model needing the ack-poke
+            // nudge instead of acknowledging promptly on its own.
             console.warn(
               `[ack] ${tc.name}: TTFO=${ttfo}ms (vision target `
               + `<${ACK_VISION_MS}ms), ${len} chars`
               + `${looksLikeAck ? "" : " — and long, not an ack one-liner"}`
-              + `. The model leaned on the framework ack poke rather `
-              + `than acknowledging on its own.`,
+              + `. The model did not acknowledge promptly on its own.`,
             );
           }
         } finally {

--- a/telegram-plugin/uat/scenarios/jtbd-fast-ack-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-fast-ack-dm.test.ts
@@ -23,21 +23,24 @@
  *
  * ## Targets
  *
- *   - **Hard contract (deterministic):** the first outbound lands
- *     within `ACK_HARD_MS` for every prompt. This is backstopped by
- *     the framework ack poke (~10s) — even a non-compliant model is
- *     nudged and sends *something* well inside the budget, so the
- *     assertion does not depend on model goodwill. Pre-#1633 a slow
- *     prompt's first outbound was the full answer, often 30-60s out —
- *     this bound cleanly separates the fixed behaviour from a
- *     regression.
+ *   - **Hard contract:** the first outbound lands within `ACK_HARD_MS`
+ *     for every prompt. This is a tight *latency target*, not a
+ *     framework guarantee. The silence-poke ack rung is a *nudge*
+ *     piggybacked on the model's next tool result (`consumeArmedPoke`
+ *     drained at the gateway tool-result chokepoint) — not a
+ *     framework-composed send. It helps the model along, but a
+ *     pure-reasoning prompt that issues no tool call never drains the
+ *     nudge, so the bound ultimately depends on model latency. It
+ *     still has teeth: pre-#1633 a slow prompt's first outbound was
+ *     the full answer, often 30-60s out, so 20s cleanly separates the
+ *     fixed behaviour from a regression. A failure here means the
+ *     agent left the user on a silent chat — a real pacing defect.
  *   - **Vision target (soft, per-case forensic):** the first outbound
  *     lands within `ACK_VISION_MS` and is short — a genuine
  *     acknowledgement, not a full-answer dump. The model self-acking
- *     (rather than waiting for the framework backstop) is what makes
- *     it *feel* human. Logged, not failed: real model runs vary, and
- *     the prompt explicitly lets a turn skip the ack when the answer
- *     itself arrives in the first couple of seconds.
+ *     quickly is what makes it *feel* human. Logged, not failed: real
+ *     model runs vary, and the prompt explicitly lets a turn skip the
+ *     ack when the answer itself arrives in the first couple seconds.
  *
  * ## Relationship to adjacent UATs
  *
@@ -59,9 +62,11 @@ import { spinUp } from "../harness.js";
 const AGENT = "test-harness";
 
 // Hard contract: a sign of life within this budget, every prompt.
-// Sized to comfortably cover the framework-backstop path — the ~10s
-// ack poke, plus the nudge piggybacking the next tool result, plus
-// the model emitting the reply, plus mtcute polling jitter.
+// A tight latency target — well above a healthy self-ack (~3-8s on a
+// warm agent) and well below the pre-#1633 silent-then-dump regression
+// (30-60s). Model-dependent, not a framework guarantee (see header
+// doc), so it carries generous headroom for mtcute polling jitter and
+// for a model that leans on the ack-poke nudge instead of self-acking.
 const ACK_HARD_MS = 20_000;
 
 // Vision target: the model self-acknowledges in a beat, well before
@@ -167,8 +172,8 @@ describe("uat: guaranteed fast acknowledgement — fuzzy prompt shapes", () => {
             throw new Error(
               `[ack] ${tc.name}: TTFO=${ttfo}ms exceeds the hard `
               + `contract ${ACK_HARD_MS}ms — the user sat on a silent `
-              + `chat. The guaranteed-ack path (prompt + ~10s ack `
-              + `poke) is not delivering. First outbound: `
+              + `chat. The fast-ack path (pacing prompt + ack-poke `
+              + `nudge) is not delivering. First outbound: `
               + `${JSON.stringify(firstOutbound.text.slice(0, 200))}`,
             );
           }

--- a/telegram-plugin/uat/scenarios/jtbd-fast-ack-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-fast-ack-dm.test.ts
@@ -1,0 +1,212 @@
+/**
+ * JTBD scenario — guaranteed fast acknowledgement (human-feel UX epic).
+ *
+ * Serves: `reference/conversational-pacing.md` and the JTBD
+ * "talking to my agent feels like talking to a capable person".
+ *
+ * A person you message answers in a beat — "got it", "on it, checking
+ * now" — before the work is done. PR #1633 made that opening
+ * acknowledgement a *guarantee*, split across two layers:
+ *
+ *   - the conversational-pacing prompt teaches the model to open with
+ *     a short human one-liner unless the real answer lands in a second
+ *     or two;
+ *   - the silence-poke subsystem *enforces* it — a ~10s ack-budget
+ *     poke fires when nothing at all has been sent this turn, nudging
+ *     the model to acknowledge before it does more work.
+ *
+ * This UAT drives a FUZZY set of non-trivial prompt shapes — research,
+ * multi-step compute, open-ended advice, code, reflective asks. Every
+ * one needs real work, so a turn that goes silent for tens of seconds
+ * is a black box. The invariant under test: the user sees a sign of
+ * life FAST, every time, across every prompt shape.
+ *
+ * ## Targets
+ *
+ *   - **Hard contract (deterministic):** the first outbound lands
+ *     within `ACK_HARD_MS` for every prompt. This is backstopped by
+ *     the framework ack poke (~10s) — even a non-compliant model is
+ *     nudged and sends *something* well inside the budget, so the
+ *     assertion does not depend on model goodwill. Pre-#1633 a slow
+ *     prompt's first outbound was the full answer, often 30-60s out —
+ *     this bound cleanly separates the fixed behaviour from a
+ *     regression.
+ *   - **Vision target (soft, per-case forensic):** the first outbound
+ *     lands within `ACK_VISION_MS` and is short — a genuine
+ *     acknowledgement, not a full-answer dump. The model self-acking
+ *     (rather than waiting for the framework backstop) is what makes
+ *     it *feel* human. Logged, not failed: real model runs vary, and
+ *     the prompt explicitly lets a turn skip the ack when the answer
+ *     itself arrives in the first couple of seconds.
+ *
+ * ## Relationship to adjacent UATs
+ *
+ *   - `jtbd-fast-trivial-dm.test.ts` — TRIVIAL prompts: the answer
+ *     itself should land fast, no ack ceremony. This file is the
+ *     non-trivial inverse: real work, but a fast *acknowledgement*.
+ *   - `jtbd-soft-commit-dm.test.ts` — the predecessor: a single slow
+ *     prompt, a looser "first reply within 30s" floor. This file is
+ *     the stronger, fuzzed successor of that contract.
+ *
+ * Each case is a single inbound; cases run sequentially. As with the
+ * other fuzz files, a prior turn may still be finishing in the
+ * background when the next case starts — an accepted, noted risk.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+
+// Hard contract: a sign of life within this budget, every prompt.
+// Sized to comfortably cover the framework-backstop path — the ~10s
+// ack poke, plus the nudge piggybacking the next tool result, plus
+// the model emitting the reply, plus mtcute polling jitter.
+const ACK_HARD_MS = 20_000;
+
+// Vision target: the model self-acknowledges in a beat, well before
+// the framework has to step in.
+const ACK_VISION_MS = 8_000;
+
+// A first outbound at or under this length reads as an acknowledgement
+// one-liner rather than a full-answer dump. Mirrors the >200-char
+// "long answer" heuristic in jtbd-soft-commit-dm, with headroom for a
+// persona-voiced ack ("on it — pulling the os-release and hostname now").
+const ACK_LEN_CEILING = 320;
+
+interface AckCase {
+  name: string;
+  /** A prompt that genuinely needs more than a second or two of work,
+   *  so an instant full answer is not a legitimate ack-skip. */
+  prompt: string;
+}
+
+const ACK_CASES: readonly AckCase[] = [
+  // ─── Research / multi-source read ─────────────────────────────
+  {
+    name: "machine-summary research",
+    prompt:
+      "Read /etc/os-release and /etc/hostname, then tell me in one "
+      + "sentence what kind of machine this is.",
+  },
+  // ─── Multi-step compute ───────────────────────────────────────
+  {
+    name: "compound date math",
+    prompt:
+      "Work out what day of the week it is today, then tell me how "
+      + "many days are left until the end of this month.",
+  },
+  // ─── Open-ended advice ("take your time") ─────────────────────
+  {
+    name: "open-ended prioritisation",
+    prompt:
+      "I've got a free afternoon and three half-finished side "
+      + "projects. Help me decide what to focus on. Take your time.",
+  },
+  // ─── Summarise / explain ──────────────────────────────────────
+  {
+    name: "plain-language summary",
+    prompt:
+      "Give me a 3-bullet summary of what a Linux container actually "
+      + "is, in plain language.",
+  },
+  // ─── Code task ────────────────────────────────────────────────
+  {
+    name: "bash one-liner with explanation",
+    prompt:
+      "Write me a small bash one-liner that counts the total number "
+      + "of lines across all .ts files under the current directory, "
+      + "and explain how it works.",
+  },
+  // ─── Reflective / vague-but-real ──────────────────────────────
+  {
+    name: "reflective open ask",
+    prompt:
+      "Something feels off with how I'm spending my mornings lately. "
+      + "Help me think through it.",
+  },
+  // ─── Comparison / judgement ───────────────────────────────────
+  {
+    name: "tech comparison",
+    prompt:
+      "Compare REST and GraphQL for a small side project — which "
+      + "would you pick and why?",
+  },
+  // ─── Investigate the box ──────────────────────────────────────
+  {
+    name: "disk-usage investigation",
+    prompt:
+      "Have a look at what's taking up the most space under /var/log "
+      + "and summarise what you find.",
+  },
+];
+
+describe("uat: guaranteed fast acknowledgement — fuzzy prompt shapes", () => {
+  for (const tc of ACK_CASES) {
+    it(
+      `[ack] ${tc.name} — sign of life within ${ACK_HARD_MS / 1000}s`,
+      async () => {
+        const sc = await spinUp({ agent: AGENT });
+        try {
+          const sendStart = Date.now();
+          await sc.sendDM(tc.prompt);
+
+          const firstOutbound = await sc.expectMessage(/\S/, {
+            from: "bot",
+            timeout: ACK_HARD_MS + 6_000,
+          });
+          const ttfo = Date.now() - sendStart;
+          const len = firstOutbound.text.trim().length;
+
+          // Invariant: the outbound is a real, non-empty message.
+          expect(len).toBeGreaterThan(0);
+
+          // Hard contract: a sign of life FAST, deterministically
+          // backstopped by the framework ack poke.
+          if (ttfo >= ACK_HARD_MS) {
+            throw new Error(
+              `[ack] ${tc.name}: TTFO=${ttfo}ms exceeds the hard `
+              + `contract ${ACK_HARD_MS}ms — the user sat on a silent `
+              + `chat. The guaranteed-ack path (prompt + ~10s ack `
+              + `poke) is not delivering. First outbound: `
+              + `${JSON.stringify(firstOutbound.text.slice(0, 200))}`,
+            );
+          }
+          expect(ttfo).toBeLessThan(ACK_HARD_MS);
+
+          // Forensic, soft: did the model self-acknowledge in a beat,
+          // or did the framework have to drag it over the line?
+          const looksLikeAck = len <= ACK_LEN_CEILING;
+          if (ttfo < ACK_VISION_MS && looksLikeAck) {
+            console.log(
+              `[ack] ${tc.name}: TTFO=${ttfo}ms, ${len} chars — fast `
+              + `short acknowledgement. Feels human.`,
+            );
+          } else if (ttfo < ACK_VISION_MS && !looksLikeAck) {
+            // Fast but long: the answer itself arrived quickly. The
+            // pacing prompt explicitly sanctions skipping the ack when
+            // the answer lands in the first couple of seconds.
+            console.log(
+              `[ack] ${tc.name}: TTFO=${ttfo}ms, ${len} chars — fast `
+              + `full answer (legitimate ack-skip).`,
+            );
+          } else {
+            // Passed the hard contract but slower than the vision
+            // target — the canary for the model leaning on the
+            // framework backstop instead of self-acking.
+            console.warn(
+              `[ack] ${tc.name}: TTFO=${ttfo}ms (vision target `
+              + `<${ACK_VISION_MS}ms), ${len} chars`
+              + `${looksLikeAck ? "" : " — and long, not an ack one-liner"}`
+              + `. The model leaned on the framework ack poke rather `
+              + `than acknowledging on its own.`,
+            );
+          }
+        } finally {
+          await sc.tearDown();
+        }
+      },
+      ACK_HARD_MS + 45_000,
+    );
+  }
+});

--- a/telegram-plugin/uat/scenarios/jtbd-soft-commit-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-soft-commit-dm.test.ts
@@ -30,7 +30,7 @@ const SLOW_PROMPT = (
 
 describe("uat: soft-commit pacing", () => {
   it(
-    "user asks slow question → first reply lands within 20s",
+    "user asks slow question → first reply lands within 30s",
     async () => {
       const sc = await spinUp({ agent: "test-harness" });
       try {

--- a/telegram-plugin/uat/scenarios/jtbd-soft-commit-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-soft-commit-dm.test.ts
@@ -1,16 +1,20 @@
 /**
- * JTBD scenario — soft-commit for slow turns.
+ * JTBD scenario — first sign of life on a slow turn.
  *
- * The new conversational-pacing prompt (#1122) instructs the agent
- * to send a one-liner "let me check, back in a few" before slow
- * work. This UAT exercises that behaviour: send a prompt that
- * obviously needs >15s, expect the FIRST outbound to be a short
- * soft-commit message, with the final answer landing later.
+ * The conversational-pacing prompt instructs the agent to open with
+ * an acknowledgement before slow work. (The original ">15s soft
+ * commit" bullet this file was named for was superseded by the
+ * guaranteed "Open with an acknowledgement" bullet in PR #1633 —
+ * acknowledge every turn unless the answer lands in a second or two.)
  *
- * Not strict — the agent's allowed to skip the soft-commit if it
- * judges the work is fast enough. The assertion is "the user does
- * NOT see a long silent gap before the first sign of life": either
- * a soft-commit OR the actual reply lands within 20s.
+ * This UAT exercises a single slow prompt and asserts the loose
+ * floor: the user does NOT see a long silent gap before the first
+ * sign of life — a reply lands within 30s.
+ *
+ * The stronger, fuzzed successor of this contract is
+ * `jtbd-fast-ack-dm.test.ts` — varied prompt shapes, a tight 20s
+ * hard budget backstopped by the framework ack poke. This file is
+ * retained as a minimal single-prompt floor.
  */
 
 import { describe, it, expect } from "vitest";

--- a/telegram-plugin/uat/scenarios/jtbd-soft-commit-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-soft-commit-dm.test.ts
@@ -13,8 +13,9 @@
  *
  * The stronger, fuzzed successor of this contract is
  * `jtbd-fast-ack-dm.test.ts` — varied prompt shapes, a tight 20s
- * hard budget backstopped by the framework ack poke. This file is
- * retained as a minimal single-prompt floor.
+ * hard latency target (a tight target, not a framework guarantee —
+ * see that file's header). This file is retained as a minimal
+ * single-prompt floor.
  */
 
 import { describe, it, expect } from "vitest";


### PR DESCRIPTION
## Summary

PR2 of the **human-feel Telegram UX** epic — the deterministic validation harness for [#1633](https://github.com/switchroom/switchroom/pull/1633) (guaranteed fast ack).

The epic's directive is to validate with the UAT harness using **fuzzy, varied test cases — not one-shot**. This adds `jtbd-fast-ack-dm.test.ts`, which drives 8 non-trivial prompt shapes and asserts the user sees a sign of life **fast, every time**.

## Why

JTBD *"talking to my agent feels like talking to a capable person"* / vision outcome **you hold the leash**. #1633 made the opening acknowledgement a guarantee; this PR makes that guarantee *measurable* and *regression-proof*.

## What changed

**New — `telegram-plugin/uat/scenarios/jtbd-fast-ack-dm.test.ts`** — 8 fuzzy non-trivial prompt shapes (research, multi-step compute, open-ended advice, code, reflective, comparison, investigation), each genuinely needing real work. Per case:

- **Hard contract:** first outbound within **20s**. A tight *latency target* — not a framework guarantee: the silence-poke ack rung is a nudge piggybacked on the model's next tool result, so a pure-reasoning prompt that issues no tool call never drains it and the bound depends on model latency. It still has teeth — pre-#1633 a slow prompt's first outbound was the full answer, often 30-60s out, so 20s cleanly catches the silent-black-box regression.
- **Vision target (soft, forensic):** first outbound within **8s** and short — a genuine acknowledgement, not a full-answer dump. Logged, not failed (real model runs vary; the prompt sanctions skipping the ack when the answer lands in a second or two).

**Refreshed — `jtbd-soft-commit-dm.test.ts`** — doc-comment refresh (the ">15s soft commit" bullet it was named for was superseded by the guaranteed "Open with an acknowledgement" bullet in #1633), plus a pre-existing-drift fix to the `it()` title (said 20s, asserts 30s). Retained as a minimal single-prompt floor; the new file is its fuzzed successor. No behaviour change to that scenario.

## Test plan

- [x] All 8 cases collect cleanly under the UAT vitest config (`vitest list --config vitest.uat.config.ts`).
- [ ] Runs for real against test-harness in the v0.13.5 canary (the scenario's purpose).

## Risk

None to production — this PR is test-only (two files, both under `telegram-plugin/uat/scenarios/`). UAT scenarios are not in the CI gate; they run on-demand via `test:uat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)