### PR TITLE
hostd: config_propose_edit validation pipeline (PR 1b)

### DIFF
--- a/src/host-control/config-edit-validator.ts
+++ b/src/host-control/config-edit-validator.ts
@@ -1,0 +1,458 @@
+/**
+ * config_propose_edit — PR 1b validation pipeline.
+ *
+ * Implements RFC §4 (`docs/rfcs/admin-agent-config-edit.md`). Pure
+ * functions: no daemon state, no flock, no audit-log writes, no
+ * approval card. The dispatcher (`server.ts`) calls
+ * `validateConfigEdit()` and turns the verdict into a `HostdResponse`
+ * + audit row.
+ *
+ * Pipeline (each stage rejects with a stable error code; stages run
+ * in order and short-circuit on first failure):
+ *
+ *   1. Patch shape — single-file unified diff against the configured
+ *      target path; ≤1 MB raw bytes; no path traversal or absolute
+ *      paths other than the literal target; multi-hunk OK.
+ *      → E_PATCH_INVALID_SHAPE
+ *   2. Clean apply — `git apply --check` against a scratch copy of
+ *      the live config. Catches context drift / operator hand-edits.
+ *      → E_PATCH_APPLY_FAILED
+ *   3a. YAML failsafe parse of the post-apply content; rejects `!!`
+ *      tags, `&` anchors, `*` aliases, `<<:` merge keys BEFORE zod
+ *      runs (those are code-execution / hidden-mutation primitives
+ *      zod cannot defend against — RFC §4.3 is explicit on this).
+ *      → E_YAML_UNSAFE_CONSTRUCT
+ *   3b. Zod parse against the existing SwitchroomConfigSchema.
+ *      → E_SCHEMA_INVALID
+ *   4. Secrets-deref do-not-regress guard: any field that was a
+ *      `vault:<key>` reference in the BEFORE config MUST still be a
+ *      vault reference in the AFTER config (no inlining). No newly-
+ *      introduced literal string matches a secret-shape heuristic
+ *      (sk-/ghp_/xoxb-/AIza prefixes; long base64 in credential-
+ *      named fields). Vault references themselves are fine — they
+ *      are the entire point of the indirection.
+ *      → E_SECRET_LEAK_DETECTED
+ *
+ * Success returns `{ ok: true }`; PR 1c will swap that for the
+ * approval-card dispatch.
+ */
+
+import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, isAbsolute, normalize } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  parseDocument,
+  isAlias,
+  isScalar,
+  isPair,
+  isNode,
+  visit,
+  type Document,
+  type Node,
+} from "yaml";
+import { SwitchroomConfigSchema } from "../config/schema.js";
+
+export type ValidationOk = { ok: true };
+export type ValidationFailure = {
+  ok: false;
+  code:
+    | "E_PATCH_INVALID_SHAPE"
+    | "E_PATCH_APPLY_FAILED"
+    | "E_YAML_UNSAFE_CONSTRUCT"
+    | "E_SCHEMA_INVALID"
+    | "E_SECRET_LEAK_DETECTED";
+  detail: string;
+};
+export type ValidationResult = ValidationOk | ValidationFailure;
+
+/** Hard cap on raw unified-diff bytes. RFC §3.2 step 1. */
+export const MAX_PATCH_BYTES = 1024 * 1024;
+
+export interface ValidatorOptions {
+  /** Live config file the patch is applied against (read fresh each call). */
+  configPath: string;
+  /** Canonical target path the diff is allowed to touch. Must equal
+   *  what the wire schema pins — the validator double-checks. */
+  targetPath: string;
+  /** Raw unified diff body. LF-only is enforced. */
+  unifiedDiff: string;
+  /** Path to `git` binary; defaults to `git` on PATH. Test seam. */
+  gitBin?: string;
+}
+
+function isTargetPathHeader(headerPath: string, targetBasename: string): boolean {
+  if (headerPath === "/dev/null") return false;
+  let p = headerPath;
+  if (p.startsWith("a/") || p.startsWith("b/")) p = p.slice(2);
+  if (isAbsolute(p)) return false;
+  if (p.includes("..")) return false;
+  const norm = normalize(p);
+  if (norm.includes("..") || isAbsolute(norm)) return false;
+  return norm === targetBasename;
+}
+
+/** Stage 1 — RFC §4.1. */
+function validateShape(
+  unifiedDiff: string,
+  targetPath: string,
+): ValidationFailure | null {
+  const byteLen = Buffer.byteLength(unifiedDiff, "utf8");
+  if (byteLen > MAX_PATCH_BYTES) {
+    return {
+      ok: false,
+      code: "E_PATCH_INVALID_SHAPE",
+      detail: `patch exceeds ${MAX_PATCH_BYTES}-byte cap (${byteLen} bytes)`,
+    };
+  }
+  if (unifiedDiff.includes("\r")) {
+    return {
+      ok: false,
+      code: "E_PATCH_INVALID_SHAPE",
+      detail: "patch must be LF-only (no CRLF / CR)",
+    };
+  }
+  const lines = unifiedDiff.split("\n");
+  const minusHeaders: string[] = [];
+  const plusHeaders: string[] = [];
+  let hunkCount = 0;
+  for (const ln of lines) {
+    if (ln.startsWith("--- ")) minusHeaders.push(ln.slice(4).trim());
+    else if (ln.startsWith("+++ ")) plusHeaders.push(ln.slice(4).trim());
+    else if (ln.startsWith("@@")) hunkCount++;
+  }
+  if (minusHeaders.length === 0 || plusHeaders.length === 0) {
+    return {
+      ok: false,
+      code: "E_PATCH_INVALID_SHAPE",
+      detail: "patch missing `---`/`+++` headers",
+    };
+  }
+  if (hunkCount === 0) {
+    return {
+      ok: false,
+      code: "E_PATCH_INVALID_SHAPE",
+      detail: "patch contains no hunks",
+    };
+  }
+  if (minusHeaders.length > 1 || plusHeaders.length > 1) {
+    return {
+      ok: false,
+      code: "E_PATCH_INVALID_SHAPE",
+      detail: "multi-file diff not allowed; single-file only",
+    };
+  }
+  const targetBasename = targetPath.split("/").pop() ?? targetPath;
+  for (const h of [...minusHeaders, ...plusHeaders]) {
+    const path = h.split("\t")[0]!.trim();
+    if (!isTargetPathHeader(path, targetBasename)) {
+      return {
+        ok: false,
+        code: "E_PATCH_INVALID_SHAPE",
+        detail: `header path "${path}" does not match target "${targetBasename}"`,
+      };
+    }
+  }
+  return null;
+}
+
+/** Stage 2 — RFC §4.2. */
+function applyPatch(
+  unifiedDiff: string,
+  configPath: string,
+  gitBin: string | undefined,
+): { ok: true; after: string } | ValidationFailure {
+  if (!existsSync(configPath)) {
+    return {
+      ok: false,
+      code: "E_PATCH_APPLY_FAILED",
+      detail: `target config not found at ${configPath}`,
+    };
+  }
+  const liveContent = readFileSync(configPath, "utf8");
+  const scratchDir = mkdtempSync(join(tmpdir(), "config-propose-edit-"));
+  try {
+    const basename = configPath.split("/").pop() ?? "switchroom.yaml";
+    const scratchFile = join(scratchDir, basename);
+    writeFileSync(scratchFile, liveContent);
+    const patchFile = join(scratchDir, "proposal.patch");
+    writeFileSync(patchFile, unifiedDiff);
+
+    const bin = gitBin ?? "git";
+    const baseArgs = [
+      "apply",
+      "--whitespace=nowarn",
+      "--recount",
+      "--unidiff-zero",
+    ];
+    const checkP1 = spawnSync(
+      bin,
+      [...baseArgs.slice(0, 1), "--check", ...baseArgs.slice(1), "-p1", patchFile],
+      { cwd: scratchDir, encoding: "utf8", timeout: 10_000 },
+    );
+    let pStrip = "-p1";
+    if (checkP1.status !== 0) {
+      const checkP0 = spawnSync(
+        bin,
+        [...baseArgs.slice(0, 1), "--check", ...baseArgs.slice(1), "-p0", patchFile],
+        { cwd: scratchDir, encoding: "utf8", timeout: 10_000 },
+      );
+      if (checkP0.status !== 0) {
+        const stderr = (checkP1.stderr || "") + (checkP0.stderr || "");
+        return {
+          ok: false,
+          code: "E_PATCH_APPLY_FAILED",
+          detail: `git apply --check failed: ${stderr.trim().slice(0, 500)}`,
+        };
+      }
+      pStrip = "-p0";
+    }
+    const real = spawnSync(
+      bin,
+      [...baseArgs, pStrip, patchFile],
+      { cwd: scratchDir, encoding: "utf8", timeout: 10_000 },
+    );
+    if (real.status !== 0) {
+      return {
+        ok: false,
+        code: "E_PATCH_APPLY_FAILED",
+        detail: `git apply failed: ${(real.stderr || "").trim().slice(0, 500)}`,
+      };
+    }
+    const after = readFileSync(scratchFile, "utf8");
+    return { ok: true, after };
+  } finally {
+    rmSync(scratchDir, { recursive: true, force: true });
+  }
+}
+
+/** Stage 3a — failsafe-style YAML walk that rejects dangerous constructs. */
+function failsafeParse(
+  source: string,
+): { ok: true; doc: Document.Parsed; data: unknown } | ValidationFailure {
+  let doc: Document.Parsed;
+  try {
+    doc = parseDocument(source, { merge: false, strict: true });
+  } catch (err) {
+    return {
+      ok: false,
+      code: "E_YAML_UNSAFE_CONSTRUCT",
+      detail: `YAML parse error: ${(err as Error).message}`,
+    };
+  }
+  if (doc.errors && doc.errors.length > 0) {
+    return {
+      ok: false,
+      code: "E_YAML_UNSAFE_CONSTRUCT",
+      detail: `YAML parse error: ${doc.errors[0]!.message}`,
+    };
+  }
+  let rejection: ValidationFailure | null = null;
+  visit(doc, (_key, node, _path) => {
+    if (rejection) return visit.BREAK;
+    if (isAlias(node)) {
+      rejection = {
+        ok: false,
+        code: "E_YAML_UNSAFE_CONSTRUCT",
+        detail: "YAML aliases (`*name`) are not allowed",
+      };
+      return visit.BREAK;
+    }
+    if (isNode(node)) {
+      if ((node as Node).anchor) {
+        rejection = {
+          ok: false,
+          code: "E_YAML_UNSAFE_CONSTRUCT",
+          detail: `YAML anchors (\`&${(node as Node).anchor}\`) are not allowed`,
+        };
+        return visit.BREAK;
+      }
+      const tag = (node as Node).tag;
+      if (typeof tag === "string" && tag.startsWith("!")) {
+        rejection = {
+          ok: false,
+          code: "E_YAML_UNSAFE_CONSTRUCT",
+          detail: `YAML explicit tags (\`${tag}\`) are not allowed`,
+        };
+        return visit.BREAK;
+      }
+    }
+    if (isPair(node)) {
+      const k = node.key;
+      if (isScalar(k) && k.value === "<<") {
+        rejection = {
+          ok: false,
+          code: "E_YAML_UNSAFE_CONSTRUCT",
+          detail: "YAML merge keys (`<<:`) are not allowed",
+        };
+        return visit.BREAK;
+      }
+    }
+    return undefined;
+  });
+  if (rejection) return rejection;
+  // Defense-in-depth: textual scan in case the yaml package's
+  // failsafe normalisation hid these constructs from the AST walk.
+  if (/(^|\n)\s*<<\s*:/.test(source)) {
+    return {
+      ok: false,
+      code: "E_YAML_UNSAFE_CONSTRUCT",
+      detail: "YAML merge keys (`<<:`) are not allowed",
+    };
+  }
+  const tagMatch = source.match(/(^|\s)!![A-Za-z_][\w/.\-:]*/);
+  if (tagMatch) {
+    return {
+      ok: false,
+      code: "E_YAML_UNSAFE_CONSTRUCT",
+      detail: `YAML explicit tags (\`${tagMatch[0].trim()}\`) are not allowed`,
+    };
+  }
+  return { ok: true, doc, data: doc.toJS() };
+}
+
+/** Stage 3b — zod against the existing schema. */
+function schemaValidate(data: unknown): ValidationFailure | null {
+  const result = SwitchroomConfigSchema.safeParse(data);
+  if (result.success) return null;
+  const issue = result.error.issues[0];
+  const where = issue?.path.join(".") || "(root)";
+  return {
+    ok: false,
+    code: "E_SCHEMA_INVALID",
+    detail: `schema validation failed at ${where}: ${issue?.message ?? "unknown"}`,
+  };
+}
+
+function collectStrings(
+  root: unknown,
+  out: Map<string, string>,
+  prefix = "",
+): void {
+  if (root === null || root === undefined) return;
+  if (typeof root === "string") {
+    out.set(prefix || "(root)", root);
+    return;
+  }
+  if (Array.isArray(root)) {
+    for (let i = 0; i < root.length; i++) {
+      collectStrings(root[i], out, `${prefix}[${i}]`);
+    }
+    return;
+  }
+  if (typeof root === "object") {
+    for (const [k, v] of Object.entries(root as Record<string, unknown>)) {
+      const p = prefix ? `${prefix}.${k}` : k;
+      collectStrings(v, out, p);
+    }
+  }
+}
+
+const SECRET_PREFIX_PATTERNS: { name: string; re: RegExp }[] = [
+  { name: "openai-key", re: /^sk-[A-Za-z0-9_\-]{20,}$/ },
+  { name: "anthropic-key", re: /^sk-ant-[A-Za-z0-9_\-]{20,}$/ },
+  { name: "github-pat", re: /^ghp_[A-Za-z0-9]{20,}$/ },
+  { name: "github-fine-grained", re: /^github_pat_[A-Za-z0-9_]{20,}$/ },
+  { name: "slack-bot", re: /^xoxb-[A-Za-z0-9\-]{10,}$/ },
+  { name: "slack-user", re: /^xoxp-[A-Za-z0-9\-]{10,}$/ },
+  { name: "google-api", re: /^AIza[A-Za-z0-9_\-]{30,}$/ },
+  { name: "aws-access-key", re: /^AKIA[A-Z0-9]{16,}$/ },
+];
+
+const CREDENTIAL_FIELD_RE =
+  /(^|[._\-])(secret|token|password|api[_\-]?key|bot[_\-]?token|client[_\-]?secret|credential)s?($|[._\-])/i;
+
+const VAULT_REF_RE = /^vault:[A-Za-z0-9_\-]+(\/[A-Za-z0-9_\-]+)*$/;
+
+function masked(s: string): string {
+  if (s.length <= 8) return "***";
+  return `${s.slice(0, 3)}...${s.slice(-3)}`;
+}
+
+/** Stage 4 — RFC §4.4 secret-leak / vault-ref-regression guard. */
+function secretLeakGuard(
+  before: unknown,
+  after: unknown,
+): ValidationFailure | null {
+  const beforeStrings = new Map<string, string>();
+  const afterStrings = new Map<string, string>();
+  collectStrings(before, beforeStrings);
+  collectStrings(after, afterStrings);
+
+  for (const [path, val] of beforeStrings) {
+    if (!VAULT_REF_RE.test(val)) continue;
+    if (!afterStrings.has(path)) continue;
+    const newVal = afterStrings.get(path)!;
+    if (!VAULT_REF_RE.test(newVal)) {
+      return {
+        ok: false,
+        code: "E_SECRET_LEAK_DETECTED",
+        detail:
+          `field "${path}" was a vault reference (${val}) but the ` +
+          `proposed change replaces it with a literal value ` +
+          `(${masked(newVal)}); inlining a secret is not allowed`,
+      };
+    }
+  }
+
+  for (const [path, val] of afterStrings) {
+    if (VAULT_REF_RE.test(val)) continue;
+    if (beforeStrings.get(path) === val) continue;
+    for (const { name, re } of SECRET_PREFIX_PATTERNS) {
+      if (re.test(val)) {
+        return {
+          ok: false,
+          code: "E_SECRET_LEAK_DETECTED",
+          detail:
+            `field "${path}" contains a literal ${name}-shaped value ` +
+            `(${masked(val)}); use a vault:<key> reference instead`,
+        };
+      }
+    }
+    if (CREDENTIAL_FIELD_RE.test(path)) {
+      if (val.length >= 40 && /^[A-Za-z0-9+/=_\-]+$/.test(val)) {
+        return {
+          ok: false,
+          code: "E_SECRET_LEAK_DETECTED",
+          detail:
+            `field "${path}" is credential-named and the proposed ` +
+            `value (${masked(val)}) looks like a literal secret; ` +
+            `use a vault:<key> reference instead`,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/** Run the full PR 1b pipeline. Pure: no side effects on the live config. */
+export function validateConfigEdit(
+  opts: ValidatorOptions,
+): ValidationResult {
+  const shapeErr = validateShape(opts.unifiedDiff, opts.targetPath);
+  if (shapeErr) return shapeErr;
+  const applied = applyPatch(opts.unifiedDiff, opts.configPath, opts.gitBin);
+  if (!("ok" in applied) || applied.ok !== true) {
+    return applied as ValidationFailure;
+  }
+  const parsedAfter = failsafeParse(applied.after);
+  if (!("ok" in parsedAfter) || parsedAfter.ok !== true) {
+    return parsedAfter as ValidationFailure;
+  }
+  const schemaErr = schemaValidate(parsedAfter.data);
+  if (schemaErr) return schemaErr;
+  let beforeData: unknown = {};
+  try {
+    const beforeRaw = existsSync(opts.configPath)
+      ? readFileSync(opts.configPath, "utf8")
+      : "";
+    const beforeDoc = parseDocument(beforeRaw, { merge: false, strict: false });
+    beforeData = beforeDoc.toJS();
+  } catch {
+    beforeData = {};
+  }
+  const leakErr = secretLeakGuard(beforeData, parsedAfter.data);
+  if (leakErr) return leakErr;
+  return { ok: true };
+}

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -297,6 +297,18 @@ export const ConfigProposeEditRequestSchema = z.object({
 export const CONFIG_PROPOSE_EDIT_ERROR_CODES = [
   "E_CONFIG_EDIT_DISABLED",
   "E_NOT_IMPLEMENTED",
+  // PR 1b — validation pipeline (RFC §4). The four stages each get a
+  // distinct code so callers can render targeted user-facing errors
+  // and the audit reader can branch without parsing free text.
+  "E_PATCH_INVALID_SHAPE", // stage 1: shape / size / path-traversal
+  "E_PATCH_APPLY_FAILED", // stage 2: `git apply --check` rejected
+  "E_YAML_UNSAFE_CONSTRUCT", // stage 3a: `!!`-tag, `&`-anchor, `*`-alias, `<<:` merge
+  "E_SCHEMA_INVALID", // stage 3b: post-apply yaml fails zod
+  "E_SECRET_LEAK_DETECTED", // stage 4: literal secret / un-vaulted-ref regression
+  // PR 1b sentinel — validation passed but apply path is still gated
+  // behind PR 1c. Returned in the success case so callers can tell
+  // "validation worked" apart from "validation rejected".
+  "E_NOT_IMPLEMENTED_APPLY_PATH",
   "E_VALIDATION_REJECTED",
   "E_SCHEMA_REJECTED",
   "E_APPLY_REJECTED",

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -51,6 +51,7 @@ import { chainRow, seedChain, type ChainState } from "../util/audit-hashchain.js
 import { socketPathToIdentity, type SocketIdentity } from "./peercred.js";
 import { redact } from "../secret-detect/redact.js";
 import { detectInstallType, type InstallType } from "../cli/install-detect.js";
+import { validateConfigEdit } from "./config-edit-validator.js";
 
 /** Subset of switchroom.yaml the daemon reads. */
 export interface ServerConfig {
@@ -113,6 +114,18 @@ export interface ServerOptions {
    * to enumerate refs from the operator's compose file.
    */
   imageRefsForDigests?: () => string[];
+  /**
+   * Path to the live `switchroom.yaml` the config-edit validator (PR 1b)
+   * reads when checking that a proposed unified diff applies cleanly
+   * and the post-apply YAML survives schema + secret-leak validation.
+   *
+   * Defaults to `/state/config/switchroom.yaml` — the canonical path
+   * the wire schema (`ConfigProposeEditRequestSchema.args.target_path`)
+   * pins. Tests override this to point at a scratch file under `tmp/`
+   * so the validation pipeline can be exercised end-to-end without
+   * touching real fleet config.
+   */
+  configPath?: string;
 }
 
 /**
@@ -1188,9 +1201,28 @@ export class HostdServer {
         Date.now() - started,
       );
     }
+    // PR 1b — run the validation pipeline (RFC §4). On any rejection
+    // we surface the stage-specific error code; on success we still
+    // return a sentinel (E_NOT_IMPLEMENTED_APPLY_PATH) because the
+    // approval card + flock + atomic-write path lands in PR 1c.
+    const configPath =
+      this.opts.configPath ?? req.args.target_path;
+    const verdict = validateConfigEdit({
+      configPath,
+      targetPath: req.args.target_path,
+      unifiedDiff: req.args.unified_diff,
+    });
+    if (!verdict.ok) {
+      return errorResponse(
+        req.request_id,
+        `${verdict.code}: ${verdict.detail}`,
+        Date.now() - started,
+      );
+    }
     return errorResponse(
       req.request_id,
-      "E_NOT_IMPLEMENTED: validation pipeline pending (PR 1b)",
+      "E_NOT_IMPLEMENTED_APPLY_PATH: validation passed (apply path " +
+        "not yet implemented — pending PR 1c)",
       Date.now() - started,
     );
   }

--- a/tests/host-control/config-edit-validator.test.ts
+++ b/tests/host-control/config-edit-validator.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for `validateConfigEdit` — exercise paths the wire-layer
+ * frame cap (64 KB) makes unreachable from the integration test in
+ * `config-propose-edit.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  validateConfigEdit,
+  MAX_PATCH_BYTES,
+} from "../../src/host-control/config-edit-validator.js";
+
+let tmp: string;
+let configPath: string;
+
+const VALID_BASE_YAML =
+  "switchroom:\n" +
+  "  version: 1\n" +
+  "telegram:\n" +
+  '  bot_token: "x"\n' +
+  '  forum_chat_id: "1"\n' +
+  "agents: {}\n";
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "validator-unit-"));
+  configPath = join(tmp, "switchroom.yaml");
+  writeFileSync(configPath, VALID_BASE_YAML);
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("validateConfigEdit — oversize cap (defense-in-depth)", () => {
+  it("rejects a patch over MAX_PATCH_BYTES with E_PATCH_INVALID_SHAPE", () => {
+    // Wire layer caps at 64 KB, but the validator independently
+    // enforces 1 MB per RFC §3.2 step 1 in case a future caller
+    // bypasses the wire (e.g. an in-process invocation from PR 1c's
+    // approval-card handler).
+    const big = "x".repeat(MAX_PATCH_BYTES + 100);
+    const result = validateConfigEdit({
+      configPath,
+      targetPath: "/state/config/switchroom.yaml",
+      unifiedDiff:
+        "--- a/switchroom.yaml\n+++ b/switchroom.yaml\n@@ -1 +1 @@\n-a\n+b\n" +
+        big,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("E_PATCH_INVALID_SHAPE");
+      expect(result.detail).toMatch(/cap/);
+    }
+  });
+
+  it("rejects a CRLF patch with E_PATCH_INVALID_SHAPE", () => {
+    const crlf =
+      "--- a/switchroom.yaml\r\n+++ b/switchroom.yaml\r\n@@ -1 +1 @@\r\n-a\r\n+b\r\n";
+    const result = validateConfigEdit({
+      configPath,
+      targetPath: "/state/config/switchroom.yaml",
+      unifiedDiff: crlf,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("E_PATCH_INVALID_SHAPE");
+      expect(result.detail).toMatch(/LF-only/);
+    }
+  });
+});

--- a/tests/host-control/config-propose-edit.test.ts
+++ b/tests/host-control/config-propose-edit.test.ts
@@ -1,16 +1,16 @@
 /**
- * hostd server tests — `config_propose_edit` (PR 1a skeleton).
+ * hostd server tests — `config_propose_edit` (PR 1a wire + PR 1b
+ * validation pipeline).
  *
- * Scope: this PR ships the wire shape + dispatcher stub only. Tests
- * cover what is actually live today:
- *   - flag-off  → result=error, error string carries E_CONFIG_EDIT_DISABLED
- *   - flag-on   → result=error, error string carries E_NOT_IMPLEMENTED
- *   - admin gate: non-admin caller is denied BEFORE the flag is read
- *     (so an un-admin'd peer can't probe the toggle state)
- *   - target_path mismatch is rejected at wire decode (literal type)
+ * Coverage map:
+ *   - PR 1a (still live): flag-off, admin gate.
+ *   - PR 1b: the four validation stages (RFC §4) — each rejection
+ *     path AND the happy path that produces E_NOT_IMPLEMENTED_APPLY_PATH
+ *     (validation passed; apply still gated behind PR 1c).
  *
- * Validation pipeline, approval card, and apply path land in PR 1b/1c
- * and gain their own tests there.
+ * The flag-on path is tested with a real on-disk scratch config file
+ * (`configPath` opt) so the validator's `git apply --check` runs
+ * against something real.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
@@ -23,8 +23,20 @@ import { hostdRequest } from "../../src/host-control/client.js";
 let tmp: string;
 let server: HostdServer;
 let stubBin: string;
+let configPath: string;
 
-function makeServer(opts: { configEditEnabled?: boolean }) {
+const VALID_BASE_YAML =
+  "switchroom:\n" +
+  "  version: 1\n" +
+  "telegram:\n" +
+  '  bot_token: "x"\n' +
+  '  forum_chat_id: "1"\n' +
+  "agents: {}\n";
+
+function makeServer(opts: {
+  configEditEnabled?: boolean;
+  configPath?: string;
+}) {
   return new HostdServer({
     homeDir: tmp,
     agentUids: { klanker: 10001, bob: 10002 },
@@ -37,6 +49,7 @@ function makeServer(opts: { configEditEnabled?: boolean }) {
     switchroomBin: stubBin,
     auditLogPath: join(tmp, "audit.log"),
     allowNonLinux: true,
+    configPath: opts.configPath,
   });
 }
 
@@ -45,6 +58,8 @@ beforeEach(async () => {
   stubBin = join(tmp, "switchroom-stub.sh");
   writeFileSync(stubBin, `#!/bin/sh\necho "stub: $@"\nexit 0\n`);
   chmodSync(stubBin, 0o755);
+  configPath = join(tmp, "switchroom.yaml");
+  writeFileSync(configPath, VALID_BASE_YAML);
 });
 
 afterEach(async () => {
@@ -61,26 +76,33 @@ const TINY_DIFF =
   "+  version: 1  # touched\n" +
   " agents: {}\n";
 
-describe("hostd server — config_propose_edit (PR 1a stub)", () => {
+async function send(args: {
+  sockOwner?: string;
+  unified_diff: string;
+  request_id: string;
+}) {
+  const owner = args.sockOwner ?? "klanker";
+  const sock = server.getBoundPaths().find((p) => p.endsWith(`/${owner}/sock`))!;
+  return hostdRequest(
+    { socketPath: sock },
+    {
+      v: 1,
+      op: "config_propose_edit",
+      request_id: args.request_id,
+      args: {
+        unified_diff: args.unified_diff,
+        reason: "test",
+        target_path: "/state/config/switchroom.yaml",
+      },
+    },
+  );
+}
+
+describe("hostd config_propose_edit — PR 1a gates (still live)", () => {
   it("returns E_CONFIG_EDIT_DISABLED when the flag is omitted (default off)", async () => {
     server = makeServer({});
     await server.start();
-    const sock = server
-      .getBoundPaths()
-      .find((p) => p.endsWith("/klanker/sock"))!;
-    const resp = await hostdRequest(
-      { socketPath: sock },
-      {
-        v: 1,
-        op: "config_propose_edit",
-        request_id: "cpe-1",
-        args: {
-          unified_diff: TINY_DIFF,
-          reason: "smoke test",
-          target_path: "/state/config/switchroom.yaml",
-        },
-      },
-    );
+    const resp = await send({ unified_diff: TINY_DIFF, request_id: "cpe-1" });
     expect(resp.result).toBe("error");
     expect(resp.error).toMatch(/^E_CONFIG_EDIT_DISABLED/);
     expect(resp.error).toMatch(/hostd\.config_edit_enabled=true/);
@@ -89,72 +111,251 @@ describe("hostd server — config_propose_edit (PR 1a stub)", () => {
   it("returns E_CONFIG_EDIT_DISABLED when the flag is explicitly false", async () => {
     server = makeServer({ configEditEnabled: false });
     await server.start();
-    const sock = server
-      .getBoundPaths()
-      .find((p) => p.endsWith("/klanker/sock"))!;
-    const resp = await hostdRequest(
-      { socketPath: sock },
-      {
-        v: 1,
-        op: "config_propose_edit",
-        request_id: "cpe-2",
-        args: {
-          unified_diff: TINY_DIFF,
-          reason: "smoke",
-          target_path: "/state/config/switchroom.yaml",
-        },
-      },
-    );
+    const resp = await send({ unified_diff: TINY_DIFF, request_id: "cpe-2" });
     expect(resp.result).toBe("error");
     expect(resp.error).toMatch(/^E_CONFIG_EDIT_DISABLED/);
   });
 
-  it("returns E_NOT_IMPLEMENTED when the flag is true (PR 1b not shipped)", async () => {
-    server = makeServer({ configEditEnabled: true });
-    await server.start();
-    const sock = server
-      .getBoundPaths()
-      .find((p) => p.endsWith("/klanker/sock"))!;
-    const resp = await hostdRequest(
-      { socketPath: sock },
-      {
-        v: 1,
-        op: "config_propose_edit",
-        request_id: "cpe-3",
-        args: {
-          unified_diff: TINY_DIFF,
-          reason: "smoke",
-          target_path: "/state/config/switchroom.yaml",
-        },
-      },
-    );
-    expect(resp.result).toBe("error");
-    expect(resp.error).toMatch(/^E_NOT_IMPLEMENTED/);
-    expect(resp.error).toMatch(/PR 1b/);
-  });
-
   it("denies non-admin callers before reading the flag", async () => {
-    // Flag ON to prove the gate fires before the handler runs — a
-    // non-admin caller must NOT learn whether the feature is enabled.
-    server = makeServer({ configEditEnabled: true });
+    server = makeServer({ configEditEnabled: true, configPath });
     await server.start();
-    const sock = server
-      .getBoundPaths()
-      .find((p) => p.endsWith("/bob/sock"))!;
-    const resp = await hostdRequest(
-      { socketPath: sock },
-      {
-        v: 1,
-        op: "config_propose_edit",
-        request_id: "cpe-4",
-        args: {
-          unified_diff: TINY_DIFF,
-          reason: "smoke",
-          target_path: "/state/config/switchroom.yaml",
-        },
-      },
-    );
+    const resp = await send({
+      sockOwner: "bob",
+      unified_diff: TINY_DIFF,
+      request_id: "cpe-3",
+    });
     expect(resp.result).toBe("denied");
     expect(resp.error).toMatch(/requires admin: true/);
+  });
+});
+
+describe("hostd config_propose_edit — PR 1b stage 1 (patch shape)", () => {
+  beforeEach(async () => {
+    server = makeServer({ configEditEnabled: true, configPath });
+    await server.start();
+  });
+
+  // Note: the wire layer caps every request at MAX_FRAME_BYTES
+  // (64 KB), so the >1 MB validator cap is defense-in-depth and is
+  // tested directly against `validateConfigEdit` rather than over the
+  // socket. See `config-edit-validator.test.ts` for that unit test.
+
+  it("rejects a multi-file diff with E_PATCH_INVALID_SHAPE", async () => {
+    const multi =
+      TINY_DIFF +
+      "--- a/other.yaml\n" +
+      "+++ b/other.yaml\n" +
+      "@@ -1 +1 @@\n" +
+      "-a\n+b\n";
+    const resp = await send({ unified_diff: multi, request_id: "s1-2" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_PATCH_INVALID_SHAPE/);
+    expect(resp.error).toMatch(/multi-file/);
+  });
+
+  it("rejects a path-traversal header with E_PATCH_INVALID_SHAPE", async () => {
+    const evil =
+      "--- a/../../etc/passwd\n" +
+      "+++ b/../../etc/passwd\n" +
+      "@@ -1 +1 @@\n" +
+      "-a\n+b\n";
+    const resp = await send({ unified_diff: evil, request_id: "s1-3" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_PATCH_INVALID_SHAPE/);
+  });
+
+  it("rejects a diff targeting a non-config file with E_PATCH_INVALID_SHAPE", async () => {
+    const wrong =
+      "--- a/something-else.yaml\n" +
+      "+++ b/something-else.yaml\n" +
+      "@@ -1 +1 @@\n" +
+      "-a\n+b\n";
+    const resp = await send({ unified_diff: wrong, request_id: "s1-4" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_PATCH_INVALID_SHAPE/);
+  });
+
+  it("rejects an absolute-path header with E_PATCH_INVALID_SHAPE", async () => {
+    const abs =
+      "--- a/switchroom.yaml\n" +
+      "+++ /etc/passwd\n" +
+      "@@ -1 +1 @@\n" +
+      "-a\n+b\n";
+    const resp = await send({ unified_diff: abs, request_id: "s1-5" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_PATCH_INVALID_SHAPE/);
+  });
+});
+
+describe("hostd config_propose_edit — PR 1b stage 2 (clean apply)", () => {
+  beforeEach(async () => {
+    server = makeServer({ configEditEnabled: true, configPath });
+    await server.start();
+  });
+
+  it("rejects a context-mismatched patch with E_PATCH_APPLY_FAILED", async () => {
+    const bad =
+      "--- a/switchroom.yaml\n" +
+      "+++ b/switchroom.yaml\n" +
+      "@@ -1,3 +1,3 @@\n" +
+      " switchroom:\n" +
+      "-  nonexistent: true\n" +
+      "+  nonexistent: false\n" +
+      " agents: {}\n";
+    const resp = await send({ unified_diff: bad, request_id: "s2-1" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_PATCH_APPLY_FAILED/);
+  });
+});
+
+describe("hostd config_propose_edit — PR 1b stage 3 (yaml + schema)", () => {
+  beforeEach(async () => {
+    server = makeServer({ configEditEnabled: true, configPath });
+    await server.start();
+  });
+
+  it("rejects a patch that introduces a `!!`-tag with E_YAML_UNSAFE_CONSTRUCT", async () => {
+    const bad =
+      "--- a/switchroom.yaml\n" +
+      "+++ b/switchroom.yaml\n" +
+      "@@ -4,3 +4,4 @@\n" +
+      '   bot_token: "x"\n' +
+      '   forum_chat_id: "1"\n' +
+      " agents: {}\n" +
+      "+evil: !!str danger\n";
+    const resp = await send({ unified_diff: bad, request_id: "s3-1" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_YAML_UNSAFE_CONSTRUCT/);
+  });
+
+  it("rejects a patch that introduces an `&` anchor with E_YAML_UNSAFE_CONSTRUCT", async () => {
+    const bad =
+      "--- a/switchroom.yaml\n" +
+      "+++ b/switchroom.yaml\n" +
+      "@@ -1,5 +1,6 @@\n" +
+      " switchroom:\n" +
+      "   version: 1\n" +
+      "+anchored: &myref hello\n" +
+      " telegram:\n" +
+      '   bot_token: "x"\n' +
+      '   forum_chat_id: "1"\n';
+    const resp = await send({ unified_diff: bad, request_id: "s3-2" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_YAML_UNSAFE_CONSTRUCT/);
+  });
+
+  it("rejects a patch that introduces a `<<:` merge key with E_YAML_UNSAFE_CONSTRUCT", async () => {
+    const bad =
+      "--- a/switchroom.yaml\n" +
+      "+++ b/switchroom.yaml\n" +
+      "@@ -4,3 +4,5 @@\n" +
+      '   bot_token: "x"\n' +
+      '   forum_chat_id: "1"\n' +
+      " agents: {}\n" +
+      "+merged:\n" +
+      "+  <<: {a: 1}\n";
+    const resp = await send({ unified_diff: bad, request_id: "s3-3" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_YAML_UNSAFE_CONSTRUCT/);
+  });
+
+  it("rejects schema-invalid post-apply yaml with E_SCHEMA_INVALID", async () => {
+    const bad =
+      "--- a/switchroom.yaml\n" +
+      "+++ b/switchroom.yaml\n" +
+      "@@ -1,5 +1,5 @@\n" +
+      " switchroom:\n" +
+      "-  version: 1\n" +
+      "+  version: 2\n" +
+      " telegram:\n" +
+      '   bot_token: "x"\n' +
+      '   forum_chat_id: "1"\n';
+    const resp = await send({ unified_diff: bad, request_id: "s3-4" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_SCHEMA_INVALID/);
+  });
+});
+
+describe("hostd config_propose_edit — PR 1b stage 4 (secret-leak guard)", () => {
+  it("rejects in-lining of a previously-vaulted secret with E_SECRET_LEAK_DETECTED", async () => {
+    writeFileSync(
+      configPath,
+      "switchroom:\n" +
+        "  version: 1\n" +
+        "telegram:\n" +
+        '  bot_token: "vault:telegram/bot_token"\n' +
+        '  forum_chat_id: "1"\n' +
+        "agents: {}\n",
+    );
+    server = makeServer({ configEditEnabled: true, configPath });
+    await server.start();
+    const bad =
+      "--- a/switchroom.yaml\n" +
+      "+++ b/switchroom.yaml\n" +
+      "@@ -1,6 +1,6 @@\n" +
+      " switchroom:\n" +
+      "   version: 1\n" +
+      " telegram:\n" +
+      '-  bot_token: "vault:telegram/bot_token"\n' +
+      '+  bot_token: "1234567890:AAEhBOOLBOOLBOOLBOOLBOOLBOOLBOOLB"\n' +
+      '   forum_chat_id: "1"\n' +
+      " agents: {}\n";
+    const resp = await send({ unified_diff: bad, request_id: "s4-1" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_SECRET_LEAK_DETECTED/);
+    expect(resp.error).toMatch(/vault reference/);
+  });
+
+  it("rejects a literal `sk-...` value with E_SECRET_LEAK_DETECTED", async () => {
+    server = makeServer({ configEditEnabled: true, configPath });
+    await server.start();
+    const bad =
+      "--- a/switchroom.yaml\n" +
+      "+++ b/switchroom.yaml\n" +
+      "@@ -4,3 +4,4 @@\n" +
+      '   bot_token: "x"\n' +
+      '   forum_chat_id: "1"\n' +
+      " agents: {}\n" +
+      '+openai_token: "sk-abcdefghijklmnopqrstuvwxyz0123456789"\n';
+    const resp = await send({ unified_diff: bad, request_id: "s4-2" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_SECRET_LEAK_DETECTED/);
+    expect(resp.error).toMatch(/openai-key|literal/);
+  });
+
+  it("rejects a literal `ghp_...` value with E_SECRET_LEAK_DETECTED", async () => {
+    server = makeServer({ configEditEnabled: true, configPath });
+    await server.start();
+    const bad =
+      "--- a/switchroom.yaml\n" +
+      "+++ b/switchroom.yaml\n" +
+      "@@ -4,3 +4,4 @@\n" +
+      '   bot_token: "x"\n' +
+      '   forum_chat_id: "1"\n' +
+      " agents: {}\n" +
+      '+github_token: "ghp_abcdefghijklmnopqrstuvwxyz0123456789"\n';
+    const resp = await send({ unified_diff: bad, request_id: "s4-3" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_SECRET_LEAK_DETECTED/);
+    expect(resp.error).toMatch(/github-pat|literal/);
+  });
+});
+
+describe("hostd config_propose_edit — PR 1b happy path", () => {
+  it("returns E_NOT_IMPLEMENTED_APPLY_PATH on a valid diff (apply still pending PR 1c)", async () => {
+    server = makeServer({ configEditEnabled: true, configPath });
+    await server.start();
+    const good =
+      "--- a/switchroom.yaml\n" +
+      "+++ b/switchroom.yaml\n" +
+      "@@ -1,3 +1,4 @@\n" +
+      "+# touched by config_propose_edit happy-path test\n" +
+      " switchroom:\n" +
+      "   version: 1\n" +
+      " telegram:\n";
+    const resp = await send({ unified_diff: good, request_id: "happy-1" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_NOT_IMPLEMENTED_APPLY_PATH/);
+    expect(resp.error).toMatch(/PR 1c/);
   });
 });


### PR DESCRIPTION
## Summary

Implements **PR 1b** of the `config_propose_edit` rollout per
[RFC §4](../blob/main/docs/rfcs/admin-agent-config-edit.md), building on
the PR 1a skeleton from #1637 (RFC #1623).

Replaces the `E_NOT_IMPLEMENTED` stub in
`HostdServer.handleConfigProposeEdit` with the four-stage validation
pipeline. The verb now returns a structured verdict when the
`hostd.config_edit_enabled` flag is on — but still NO approval card,
NO apply, NO rollback (those land in PR 1c). The default flag remains
`false`.

## The four stages

| Stage | Code | What it does |
|---|---|---|
| **1. Patch shape** | `E_PATCH_INVALID_SHAPE` | Single-file unified diff; ≤1 MB raw bytes; LF-only; no path traversal (`..`); no absolute paths; no multi-file diffs; headers must resolve to the canonical target. |
| **2. Clean apply** | `E_PATCH_APPLY_FAILED` | `git apply --check` against a scratch copy of the live config. Tries `-p1` then `-p0`. |
| **3a. Failsafe YAML** | `E_YAML_UNSAFE_CONSTRUCT` | `parseDocument` + AST walk rejecting `!!`-tags, `&` anchors, `*` aliases, `<<:` merge keys. Plus defense-in-depth textual scans. |
| **3b. Schema** | `E_SCHEMA_INVALID` | Existing `SwitchroomConfigSchema` zod parse of the post-apply YAML. |
| **4. Secret-leak guard** | `E_SECRET_LEAK_DETECTED` | Vault-ref do-not-regress (`vault:foo/bar` field cannot become a literal); known-credential-prefix patterns (`sk-`, `sk-ant-`, `ghp_`, `github_pat_`, `xoxb-`, `xoxp-`, `AIza`, `AKIA`) rejected; credential-named fields with long base64-shaped literals rejected. |

On success the dispatcher returns a new sentinel
`E_NOT_IMPLEMENTED_APPLY_PATH` so callers can distinguish
"validation worked, apply pending" from "validation rejected".

## Tests added

`tests/host-control/config-propose-edit.test.ts` — 16 tests covering:

- Stage 1: multi-file, path-traversal, non-target-path, absolute-path
- Stage 2: context-mismatched patch
- Stage 3: `!!`-tag, `&` anchor, `<<:` merge, schema-invalid (`version: 2`)
- Stage 4: vault-ref in-lining, `sk-...` literal, `ghp_...` literal
- Happy path: schema-neutral comment-line addition lands on `E_NOT_IMPLEMENTED_APPLY_PATH`
- PR 1a gates still pass (flag-off, non-admin denial)

`tests/host-control/config-edit-validator.test.ts` — pure unit tests
for paths the 64 KB wire-frame cap makes unreachable over the socket:
the >1 MB defense-in-depth cap and the LF-only enforcement.

## RFC ambiguities resolved

- **"Failsafe loader"** — interpreted as "reject the dangerous
  constructs", not "discard all type info". Using yaml's
  `parseDocument` + AST walk keeps `version: 1` as an `int` so the
  downstream zod parse works, while anchor/tag/alias/merge nodes are
  rejected before zod runs.
- **"Secret-shape heuristic"** — chose a conservative known-prefix
  set (OpenAI / Anthropic / GitHub PAT / Slack / Google API / AWS
  access key) plus a credential-named-field base64 fallback. Erring
  toward more false-positives — operators can rephrase a rejected
  diff.

## What's still gated behind PR 1c

- `flock(2)` serialisation
- Approval-card render + operator tap
- Snapshot to `~/.switchroom/config-backups/`
- Atomic `rename(2)` write
- `switchroom apply` reconcile
- Rollback on reconcile failure
- Rate limiting + sqlite token bucket
- Crash-recovery journal

## Test plan

- [x] `npx vitest run tests/host-control/config-propose-edit.test.ts tests/host-control/config-edit-validator.test.ts` — 18/18 green
- [x] `npx tsc --noEmit` — clean
- [x] No regressions in host-control test suite vs baseline (`server.test.ts` carries 22 pre-existing failures on `main` unrelated to this change — environmental subprocess flake)
- [ ] Operator sanity-check the rendered diff in CI logs once a real proposal lands

Builds on: #1637 (PR 1a — skeleton)
RFC: #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)