### PR TITLE
hostd: config_propose_edit apply path (minimal — approval card + atomic write + reconcile)

### DIFF
--- a/src/host-control/approval-gateway.ts
+++ b/src/host-control/approval-gateway.ts
@@ -1,22 +1,5 @@
-/**
- * hostd ApprovalGateway — RFC §3.3 / #1623.
- *
- * Abstracts the "ask the operator to approve a config diff" surface
- * so the apply path in `HostdServer.handleConfigProposeEdit` is
- * testable without spinning up a real Telegram gateway. Production
- * code wires `SocketApprovalGateway` (below), which connects to the
- * caller agent's gateway IPC socket and exchanges the new
- * `request_config_approval` / `config_approval_resolved` /
- * `request_config_finalize` messages defined in
- * `telegram-plugin/gateway/ipc-protocol.ts`.
- *
- * The single-method contract keeps the server's apply path narrow:
- * one round-trip yields a verdict, and the returned `finalize`
- * callback is invoked once after the apply attempt completes to
- * flip the card body to the terminal outcome. The interface is
- * intentionally identical to what the in-process tests need — no
- * gateway, no sockets, just `{verdict, finalize}`.
- */
+// hostd ApprovalGateway (#1623): abstracts the operator-approval surface
+// so HostdServer.handleConfigProposeEdit's apply path is testable.
 
 import { connect, type Socket } from "node:net";
 
@@ -32,8 +15,7 @@ export interface ApprovalRequest {
 
 export interface ApprovalResult {
   verdict: ApprovalVerdict;
-  /** Update the operator-visible card with the apply outcome. Idempotent
-   *  best-effort — failures inside the gateway are logged, not thrown. */
+  /** Update the approval card with the apply outcome. */
   finalize: (outcome: {
     outcome: "applied" | "reconcile_failed_rolled_back";
     detail?: string;
@@ -44,20 +26,10 @@ export interface ApprovalGateway {
   requestApproval(req: ApprovalRequest): Promise<ApprovalResult>;
 }
 
-// ────────────────────────────────────────────────────────────────────────
-// SocketApprovalGateway — production wiring against the per-agent
-// gateway IPC socket at `<agentDir>/telegram/gateway.sock`.
-// ────────────────────────────────────────────────────────────────────────
+// SocketApprovalGateway — production wiring against `<agentDir>/telegram/gateway.sock`.
 
 export interface SocketApprovalGatewayOptions {
-  /**
-   * Resolve a per-agent gateway IPC socket path. Hostd invokes this
-   * once per request with the caller agent's name (RFC §3.3: the
-   * card lands in the calling admin agent's chat, which is the
-   * operator's primary surface for that agent). Returns null when
-   * no gateway socket is reachable — the caller treats this as a
-   * deny + diagnostic error.
-   */
+  /** Resolve gateway IPC socket path; null → deny. */
   resolveGatewaySocket: (agentName: string) => string | null;
   log?: (msg: string) => void;
 }
@@ -74,63 +46,35 @@ export class SocketApprovalGateway implements ApprovalGateway {
         finalize: async () => {},
       };
     }
-    // Single TCP-like connection holds both the request and the
-    // eventual resolved event. We keep it open until either the
-    // verdict arrives, our local timeout fires, or the connection
-    // drops — whichever first.
+    // Single connection holds both the request and the resolved event.
+    // Gateway is the source of truth for the timeout; socket error/close → deny.
     return await new Promise<ApprovalResult>((resolve) => {
       const client: Socket = connect({ path: sockPath });
       let buffer = "";
       let resolved = false;
       const log = this.opts.log ?? (() => {});
 
-      // Hostd-side hard deadline. The gateway also runs a timer and
-      // SHOULD beat us to it; this is defense-in-depth in case the
-      // gateway is silent (process gone, socket hung).
-      const localTimeout = setTimeout(() => {
-        if (resolved) return;
-        resolved = true;
-        try { client.end(); } catch { /* noop */ }
-        resolve({
-          verdict: "timeout",
-          finalize: async () => {},
-        });
-      }, req.timeoutMs + 5_000); // grace window so gateway-side timer wins
-
       const finalize = async (outcome: {
         outcome: "applied" | "reconcile_failed_rolled_back";
         detail?: string;
       }): Promise<void> => {
-        // Best-effort second message on the same connection; if it
-        // dropped after the verdict we open a fresh one.
-        const send = (sock: Socket) => {
-          try {
-            sock.write(
-              JSON.stringify({
-                type: "request_config_finalize",
-                requestId: req.requestId,
-                outcome: outcome.outcome,
-                ...(outcome.detail ? { detail: outcome.detail } : {}),
-              }) + "\n",
-            );
-            sock.end();
-          } catch (err) {
-            log(
-              `finalize write failed (requestId=${req.requestId}): ${(err as Error).message}`,
-            );
-          }
-        };
-        if (!client.destroyed) {
-          send(client);
-          return;
-        }
-        const sock2 = connect({ path: sockPath });
-        sock2.on("connect", () => send(sock2));
-        sock2.on("error", (err) => {
-          log(
-            `finalize reconnect failed (requestId=${req.requestId}): ${err.message}`,
+        // Best-effort single-shot write on the existing connection.
+        if (client.destroyed) return;
+        try {
+          client.write(
+            JSON.stringify({
+              type: "request_config_finalize",
+              requestId: req.requestId,
+              outcome: outcome.outcome,
+              ...(outcome.detail ? { detail: outcome.detail } : {}),
+            }) + "\n",
           );
-        });
+          client.end();
+        } catch (err) {
+          log(
+            `finalize write failed (requestId=${req.requestId}): ${(err as Error).message}`,
+          );
+        }
       };
 
       client.on("connect", () => {
@@ -148,7 +92,6 @@ export class SocketApprovalGateway implements ApprovalGateway {
         } catch (err) {
           if (resolved) return;
           resolved = true;
-          clearTimeout(localTimeout);
           log(
             `request_config_approval write failed (requestId=${req.requestId}): ${(err as Error).message}`,
           );
@@ -179,7 +122,6 @@ export class SocketApprovalGateway implements ApprovalGateway {
             !resolved
           ) {
             resolved = true;
-            clearTimeout(localTimeout);
             resolve({
               verdict: obj.verdict as ApprovalVerdict,
               finalize,
@@ -192,7 +134,6 @@ export class SocketApprovalGateway implements ApprovalGateway {
       client.on("error", (err) => {
         if (resolved) return;
         resolved = true;
-        clearTimeout(localTimeout);
         log(
           `gateway socket error (requestId=${req.requestId}): ${err.message}`,
         );
@@ -202,7 +143,6 @@ export class SocketApprovalGateway implements ApprovalGateway {
       client.on("close", () => {
         if (resolved) return;
         resolved = true;
-        clearTimeout(localTimeout);
         resolve({ verdict: "deny", finalize: async () => {} });
       });
     });

--- a/src/host-control/approval-gateway.ts
+++ b/src/host-control/approval-gateway.ts
@@ -1,0 +1,210 @@
+/**
+ * hostd ApprovalGateway — RFC §3.3 / #1623.
+ *
+ * Abstracts the "ask the operator to approve a config diff" surface
+ * so the apply path in `HostdServer.handleConfigProposeEdit` is
+ * testable without spinning up a real Telegram gateway. Production
+ * code wires `SocketApprovalGateway` (below), which connects to the
+ * caller agent's gateway IPC socket and exchanges the new
+ * `request_config_approval` / `config_approval_resolved` /
+ * `request_config_finalize` messages defined in
+ * `telegram-plugin/gateway/ipc-protocol.ts`.
+ *
+ * The single-method contract keeps the server's apply path narrow:
+ * one round-trip yields a verdict, and the returned `finalize`
+ * callback is invoked once after the apply attempt completes to
+ * flip the card body to the terminal outcome. The interface is
+ * intentionally identical to what the in-process tests need — no
+ * gateway, no sockets, just `{verdict, finalize}`.
+ */
+
+import { connect, type Socket } from "node:net";
+
+export type ApprovalVerdict = "approve" | "deny" | "timeout";
+
+export interface ApprovalRequest {
+  requestId: string;
+  agentName: string;
+  reason: string;
+  unifiedDiff: string;
+  timeoutMs: number;
+}
+
+export interface ApprovalResult {
+  verdict: ApprovalVerdict;
+  /** Update the operator-visible card with the apply outcome. Idempotent
+   *  best-effort — failures inside the gateway are logged, not thrown. */
+  finalize: (outcome: {
+    outcome: "applied" | "reconcile_failed_rolled_back";
+    detail?: string;
+  }) => Promise<void>;
+}
+
+export interface ApprovalGateway {
+  requestApproval(req: ApprovalRequest): Promise<ApprovalResult>;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// SocketApprovalGateway — production wiring against the per-agent
+// gateway IPC socket at `<agentDir>/telegram/gateway.sock`.
+// ────────────────────────────────────────────────────────────────────────
+
+export interface SocketApprovalGatewayOptions {
+  /**
+   * Resolve a per-agent gateway IPC socket path. Hostd invokes this
+   * once per request with the caller agent's name (RFC §3.3: the
+   * card lands in the calling admin agent's chat, which is the
+   * operator's primary surface for that agent). Returns null when
+   * no gateway socket is reachable — the caller treats this as a
+   * deny + diagnostic error.
+   */
+  resolveGatewaySocket: (agentName: string) => string | null;
+  log?: (msg: string) => void;
+}
+
+export class SocketApprovalGateway implements ApprovalGateway {
+  constructor(private opts: SocketApprovalGatewayOptions) {}
+
+  async requestApproval(req: ApprovalRequest): Promise<ApprovalResult> {
+    const sockPath = this.opts.resolveGatewaySocket(req.agentName);
+    if (sockPath === null) {
+      // No reachable gateway — fail closed.
+      return {
+        verdict: "deny",
+        finalize: async () => {},
+      };
+    }
+    // Single TCP-like connection holds both the request and the
+    // eventual resolved event. We keep it open until either the
+    // verdict arrives, our local timeout fires, or the connection
+    // drops — whichever first.
+    return await new Promise<ApprovalResult>((resolve) => {
+      const client: Socket = connect({ path: sockPath });
+      let buffer = "";
+      let resolved = false;
+      const log = this.opts.log ?? (() => {});
+
+      // Hostd-side hard deadline. The gateway also runs a timer and
+      // SHOULD beat us to it; this is defense-in-depth in case the
+      // gateway is silent (process gone, socket hung).
+      const localTimeout = setTimeout(() => {
+        if (resolved) return;
+        resolved = true;
+        try { client.end(); } catch { /* noop */ }
+        resolve({
+          verdict: "timeout",
+          finalize: async () => {},
+        });
+      }, req.timeoutMs + 5_000); // grace window so gateway-side timer wins
+
+      const finalize = async (outcome: {
+        outcome: "applied" | "reconcile_failed_rolled_back";
+        detail?: string;
+      }): Promise<void> => {
+        // Best-effort second message on the same connection; if it
+        // dropped after the verdict we open a fresh one.
+        const send = (sock: Socket) => {
+          try {
+            sock.write(
+              JSON.stringify({
+                type: "request_config_finalize",
+                requestId: req.requestId,
+                outcome: outcome.outcome,
+                ...(outcome.detail ? { detail: outcome.detail } : {}),
+              }) + "\n",
+            );
+            sock.end();
+          } catch (err) {
+            log(
+              `finalize write failed (requestId=${req.requestId}): ${(err as Error).message}`,
+            );
+          }
+        };
+        if (!client.destroyed) {
+          send(client);
+          return;
+        }
+        const sock2 = connect({ path: sockPath });
+        sock2.on("connect", () => send(sock2));
+        sock2.on("error", (err) => {
+          log(
+            `finalize reconnect failed (requestId=${req.requestId}): ${err.message}`,
+          );
+        });
+      };
+
+      client.on("connect", () => {
+        try {
+          client.write(
+            JSON.stringify({
+              type: "request_config_approval",
+              requestId: req.requestId,
+              agentName: req.agentName,
+              reason: req.reason,
+              unifiedDiff: req.unifiedDiff,
+              timeoutMs: req.timeoutMs,
+            }) + "\n",
+          );
+        } catch (err) {
+          if (resolved) return;
+          resolved = true;
+          clearTimeout(localTimeout);
+          log(
+            `request_config_approval write failed (requestId=${req.requestId}): ${(err as Error).message}`,
+          );
+          resolve({ verdict: "deny", finalize: async () => {} });
+        }
+      });
+
+      client.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(line);
+          } catch {
+            log(`bad JSON from gateway: ${line.slice(0, 200)}`);
+            continue;
+          }
+          const obj = parsed as Record<string, unknown>;
+          if (
+            obj.type === "config_approval_resolved" &&
+            obj.requestId === req.requestId &&
+            (obj.verdict === "approve" ||
+              obj.verdict === "deny" ||
+              obj.verdict === "timeout") &&
+            !resolved
+          ) {
+            resolved = true;
+            clearTimeout(localTimeout);
+            resolve({
+              verdict: obj.verdict as ApprovalVerdict,
+              finalize,
+            });
+            // Note: we keep `client` open so finalize can reuse it.
+          }
+        }
+      });
+
+      client.on("error", (err) => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(localTimeout);
+        log(
+          `gateway socket error (requestId=${req.requestId}): ${err.message}`,
+        );
+        resolve({ verdict: "deny", finalize: async () => {} });
+      });
+
+      client.on("close", () => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(localTimeout);
+        resolve({ verdict: "deny", finalize: async () => {} });
+      });
+    });
+  }
+}

--- a/src/host-control/config-edit-validator.ts
+++ b/src/host-control/config-edit-validator.ts
@@ -53,7 +53,13 @@ import {
 } from "yaml";
 import { SwitchroomConfigSchema } from "../config/schema.js";
 
-export type ValidationOk = { ok: true };
+/**
+ * Successful validation. `postApplyContent` carries the post-patch
+ * file bytes so the caller (#1623 apply path) can write them directly
+ * without re-applying the diff — the validator already paid the cost
+ * of running `git apply` against the live file.
+ */
+export type ValidationOk = { ok: true; postApplyContent: string };
 export type ValidationFailure = {
   ok: false;
   code:
@@ -454,5 +460,5 @@ export function validateConfigEdit(
   }
   const leakErr = secretLeakGuard(beforeData, parsedAfter.data);
   if (leakErr) return leakErr;
-  return { ok: true };
+  return { ok: true, postApplyContent: applied.after };
 }

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -21,9 +21,12 @@
  */
 
 import { homedir } from "node:os";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { loadConfig } from "../config/loader.js";
 import { allocateAgentUid } from "../agents/compose.js";
 import { HostdServer } from "./server.js";
+import { SocketApprovalGateway } from "./approval-gateway.js";
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -48,6 +51,22 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  // #1623 — wire the SocketApprovalGateway so config_propose_edit can
+  // round-trip an operator approval card through the caller agent's
+  // gateway IPC socket. Socket location mirrors
+  // `src/agents/lifecycle.ts:gracefulRestartAgent` —
+  // `<agentsDir>/<agentName>/telegram/gateway.sock`.
+  const agentsDir =
+    process.env.SWITCHROOM_AGENTS_DIR ??
+    join(homedir(), ".switchroom", "agents");
+  const approvalGateway = new SocketApprovalGateway({
+    resolveGatewaySocket: (agentName) => {
+      const sock = resolve(agentsDir, agentName, "telegram", "gateway.sock");
+      return existsSync(sock) ? sock : null;
+    },
+    log: (m) => process.stderr.write(`hostd: approval-gateway — ${m}\n`),
+  });
+
   const server = new HostdServer({
     homeDir: homedir(),
     agentUids,
@@ -55,7 +74,17 @@ async function main(): Promise<void> {
       agents: Object.fromEntries(
         Object.entries(config.agents).map(([n, a]) => [n, { admin: a.admin === true }]),
       ),
+      ...(config.hostd
+        ? {
+            hostd: {
+              ...(config.hostd.config_edit_enabled !== undefined
+                ? { config_edit_enabled: config.hostd.config_edit_enabled }
+                : {}),
+            },
+          }
+        : {}),
     },
+    approvalGateway,
   });
   await server.start();
 

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -305,10 +305,6 @@ export const CONFIG_PROPOSE_EDIT_ERROR_CODES = [
   "E_YAML_UNSAFE_CONSTRUCT", // stage 3a: `!!`-tag, `&`-anchor, `*`-alias, `<<:` merge
   "E_SCHEMA_INVALID", // stage 3b: post-apply yaml fails zod
   "E_SECRET_LEAK_DETECTED", // stage 4: literal secret / un-vaulted-ref regression
-  // PR 1b sentinel — validation passed but apply path is still gated
-  // behind PR 1c. Returned in the success case so callers can tell
-  // "validation worked" apart from "validation rejected".
-  "E_NOT_IMPLEMENTED_APPLY_PATH",
   "E_VALIDATION_REJECTED",
   "E_SCHEMA_REJECTED",
   "E_APPLY_REJECTED",

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -316,6 +316,10 @@ export const CONFIG_PROPOSE_EDIT_ERROR_CODES = [
   "E_RECONCILE_FAILED",
   "E_DENIED",
   "E_EXPIRED",
+  // #1623 apply path (this PR).
+  "E_NO_APPROVAL_GATEWAY",
+  "E_APPROVAL_TIMEOUT",
+  "E_RECONCILE_FAILED_ROLLED_BACK",
 ] as const;
 export type ConfigProposeEditErrorCode =
   (typeof CONFIG_PROPOSE_EDIT_ERROR_CODES)[number];

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -128,31 +128,11 @@ export interface ServerOptions {
    * touching real fleet config.
    */
   configPath?: string;
-  /**
-   * RFC §3.3 / #1623 — surface that renders the operator approval
-   * card and awaits the verdict. Production wiring uses
-   * `SocketApprovalGateway` (per-agent gateway IPC socket); tests
-   * inject an in-process mock. Optional: when unset, the apply path
-   * returns `E_NO_APPROVAL_GATEWAY` rather than skipping the
-   * approval step. Operator opts in by setting
-   * `hostd.config_edit_enabled: true` AND deploying a hostd build
-   * with the gateway wired — both signals required.
-   */
+  /** RFC §3.3 / #1623 — operator-approval surface; unset → `E_NO_APPROVAL_GATEWAY`. */
   approvalGateway?: ApprovalGateway;
-  /**
-   * Test seam: override the random hex id generator. Default is
-   * `crypto.randomBytes(4).toString('hex')`. Tests pin a deterministic
-   * id so assertions on the audit row + finalize payload stay stable.
-   */
+  /** Test seam: override the random hex id generator. */
   generateApprovalId?: () => string;
-  /**
-   * Test seam: override the `switchroom apply` subprocess invocation
-   * used after a successful atomic write. Default shells out to the
-   * `switchroomBin` with `apply` argv (mirrors the Phase-2 `apply`
-   * verb). Tests inject a function that simulates success/failure
-   * without touching docker or the host filesystem beyond the
-   * scratch config file.
-   */
+  /** Test seam: override the `switchroom apply` subprocess invocation. */
   runReconcile?: (args: {
     requestId: string;
   }) => Promise<{ exit_code: number; stdout: string; stderr: string }>;
@@ -1220,40 +1200,7 @@ export class HostdServer {
    * makes NO model call.
    */
   /**
-   * `config_propose_edit` — PR 1a stub.
-   *
-   * The full RFC (`docs/rfcs/admin-agent-config-edit.md`) sequences
-   * three PRs: 1a wires schema + dispatcher (this method), 1b adds
-   * the validation pipeline (§3.2), 1c adds the approval card + apply
-   * path (§3.3, §3.4). Until 1c lands the verb has no live effect on
-   * disk — it surfaces a flag-aware error so admin agents can
-   * discover the feature and operators can opt in incrementally.
-   *
-   * Error-code convention (`CONFIG_PROPOSE_EDIT_ERROR_CODES` in
-   * protocol.ts): the audit row and the `resp.error` string both
-   * carry the code so MCP callers and the audit reader can branch on
-   * it without parsing free text. Format: `<CODE>: <human message>`.
-   */
-  /**
    * `config_propose_edit` — full apply path (#1623 / RFC §3.3-3.4).
-   *
-   * Sequence:
-   *   1. Flag gate (operator opted in via `hostd.config_edit_enabled`).
-   *   2. Validation pipeline (PR 1b — `validateConfigEdit`).
-   *   3. Approval card via `approvalGateway.requestApproval` (RFC §3.3).
-   *      Verdict ∈ {approve, deny, timeout}. Deny / timeout return
-   *      `E_DENIED` / `E_APPROVAL_TIMEOUT` and finalize is a no-op.
-   *   4. On approve: serialize on `configApplyLock` (single-process
-   *      mutex — RFC §3.4 explicitly walks back the belt-and-braces
-   *      flock for single-host single-operator land), take a snapshot
-   *      of the live config, atomically write the new content
-   *      (`<path>.tmp` → rename), invoke `switchroom apply`.
-   *   5. If reconcile fails: restore from snapshot atomically, re-run
-   *      reconcile (basic rollback), finalize the card to
-   *      "reconcile failed; rolled back", return
-   *      `E_RECONCILE_FAILED_ROLLED_BACK`.
-   *   6. On success: finalize the card to "applied", return result
-   *      `completed`.
    *
    * Deliberately OUT of scope per operator decision (single-operator
    * single-host posture, see PR description): rate limiter,
@@ -1348,10 +1295,6 @@ export class HostdServer {
           Date.now() - started,
         );
       }
-      // The validator already produced the post-apply text (it runs
-      // `git apply` against the live file). We re-derive it here by
-      // applying the patch a second time to obtain the post-patch
-      // bytes — the validator returns its own copy on success.
       const postApply = verdict.postApplyContent;
       // Atomic write: `<path>.tmp` → rename.
       const tmp = configPath + ".tmp";
@@ -1361,7 +1304,7 @@ export class HostdServer {
       } catch (err) {
         // Pre-write or rename failed — try to clean up tmp; live
         // file is untouched so no rollback needed.
-        try { unlinkSyncBestEffort(tmp); } catch { /* noop */ }
+        unlinkSyncBestEffort(tmp);
         await approval.finalize({
           outcome: "reconcile_failed_rolled_back",
           detail: `atomic write failed: ${(err as Error).message}`,

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -33,9 +33,10 @@ import {
   writeFileSync,
   renameSync,
   mkdirSync,
+  unlinkSync,
 } from "node:fs";
 import { join, dirname, resolve } from "node:path";
-import { randomUUID } from "node:crypto";
+import { randomUUID, randomBytes } from "node:crypto";
 import {
   decodeRequest,
   encodeResponse,
@@ -52,6 +53,7 @@ import { socketPathToIdentity, type SocketIdentity } from "./peercred.js";
 import { redact } from "../secret-detect/redact.js";
 import { detectInstallType, type InstallType } from "../cli/install-detect.js";
 import { validateConfigEdit } from "./config-edit-validator.js";
+import type { ApprovalGateway } from "./approval-gateway.js";
 
 /** Subset of switchroom.yaml the daemon reads. */
 export interface ServerConfig {
@@ -126,6 +128,34 @@ export interface ServerOptions {
    * touching real fleet config.
    */
   configPath?: string;
+  /**
+   * RFC §3.3 / #1623 — surface that renders the operator approval
+   * card and awaits the verdict. Production wiring uses
+   * `SocketApprovalGateway` (per-agent gateway IPC socket); tests
+   * inject an in-process mock. Optional: when unset, the apply path
+   * returns `E_NO_APPROVAL_GATEWAY` rather than skipping the
+   * approval step. Operator opts in by setting
+   * `hostd.config_edit_enabled: true` AND deploying a hostd build
+   * with the gateway wired — both signals required.
+   */
+  approvalGateway?: ApprovalGateway;
+  /**
+   * Test seam: override the random hex id generator. Default is
+   * `crypto.randomBytes(4).toString('hex')`. Tests pin a deterministic
+   * id so assertions on the audit row + finalize payload stay stable.
+   */
+  generateApprovalId?: () => string;
+  /**
+   * Test seam: override the `switchroom apply` subprocess invocation
+   * used after a successful atomic write. Default shells out to the
+   * `switchroomBin` with `apply` argv (mirrors the Phase-2 `apply`
+   * verb). Tests inject a function that simulates success/failure
+   * without touching docker or the host filesystem beyond the
+   * scratch config file.
+   */
+  runReconcile?: (args: {
+    requestId: string;
+  }) => Promise<{ exit_code: number; stdout: string; stderr: string }>;
 }
 
 /**
@@ -259,6 +289,23 @@ export function readCachedInstallType(bindRoot: string): {
     // detected value without caching. Best-effort by contract.
   }
   return payload;
+}
+
+/** RFC §3.3 — operator approval card lifespan. */
+const CONFIG_APPROVAL_TIMEOUT_MS = 10 * 60 * 1000;
+
+/** 8-hex random id for an in-flight config_propose_edit approval. */
+function defaultApprovalId(): string {
+  return randomBytes(4).toString("hex");
+}
+
+/** Best-effort tmp-file cleanup — swallowed errors. */
+function unlinkSyncBestEffort(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch {
+    /* noop */
+  }
 }
 
 const STATUS_RETENTION_MS = 10 * 60 * 1000; // 10 min
@@ -602,7 +649,7 @@ export class HostdServer {
         // not-implemented marker. PR 1b adds validation; PR 1c adds
         // the approval card + apply path.
         case "config_propose_edit":
-          resp = this.handleConfigProposeEdit(req, started);
+          resp = await this.handleConfigProposeEdit(req, caller, started);
           break;
       }
     } catch (err) {
@@ -1187,10 +1234,40 @@ export class HostdServer {
    * carry the code so MCP callers and the audit reader can branch on
    * it without parsing free text. Format: `<CODE>: <human message>`.
    */
-  private handleConfigProposeEdit(
+  /**
+   * `config_propose_edit` — full apply path (#1623 / RFC §3.3-3.4).
+   *
+   * Sequence:
+   *   1. Flag gate (operator opted in via `hostd.config_edit_enabled`).
+   *   2. Validation pipeline (PR 1b — `validateConfigEdit`).
+   *   3. Approval card via `approvalGateway.requestApproval` (RFC §3.3).
+   *      Verdict ∈ {approve, deny, timeout}. Deny / timeout return
+   *      `E_DENIED` / `E_APPROVAL_TIMEOUT` and finalize is a no-op.
+   *   4. On approve: serialize on `configApplyLock` (single-process
+   *      mutex — RFC §3.4 explicitly walks back the belt-and-braces
+   *      flock for single-host single-operator land), take a snapshot
+   *      of the live config, atomically write the new content
+   *      (`<path>.tmp` → rename), invoke `switchroom apply`.
+   *   5. If reconcile fails: restore from snapshot atomically, re-run
+   *      reconcile (basic rollback), finalize the card to
+   *      "reconcile failed; rolled back", return
+   *      `E_RECONCILE_FAILED_ROLLED_BACK`.
+   *   6. On success: finalize the card to "applied", return result
+   *      `completed`.
+   *
+   * Deliberately OUT of scope per operator decision (single-operator
+   * single-host posture, see PR description): rate limiter,
+   * crash-recovery journal, Prometheus metrics, TOCTOU re-validation,
+   * literal `flock` on the config file (the in-process mutex is
+   * sufficient — hostd is the only writer), attachment fallback for
+   * very large diffs, 5s safety-delay button swap, privilege-
+   * escalation detection.
+   */
+  private async handleConfigProposeEdit(
     req: Extract<HostdRequest, { op: "config_propose_edit" }>,
+    caller: SocketIdentity,
     started: number,
-  ): HostdResponse {
+  ): Promise<HostdResponse> {
     const enabled = this.opts.config.hostd?.config_edit_enabled === true;
     if (!enabled) {
       return errorResponse(
@@ -1201,10 +1278,6 @@ export class HostdServer {
         Date.now() - started,
       );
     }
-    // PR 1b — run the validation pipeline (RFC §4). On any rejection
-    // we surface the stage-specific error code; on success we still
-    // return a sentinel (E_NOT_IMPLEMENTED_APPLY_PATH) because the
-    // approval card + flock + atomic-write path lands in PR 1c.
     const configPath =
       this.opts.configPath ?? req.args.target_path;
     const verdict = validateConfigEdit({
@@ -1219,12 +1292,148 @@ export class HostdServer {
         Date.now() - started,
       );
     }
-    return errorResponse(
-      req.request_id,
-      "E_NOT_IMPLEMENTED_APPLY_PATH: validation passed (apply path " +
-        "not yet implemented — pending PR 1c)",
-      Date.now() - started,
-    );
+    // ── Approval card ───────────────────────────────────────────────
+    if (!this.opts.approvalGateway) {
+      return errorResponse(
+        req.request_id,
+        "E_NO_APPROVAL_GATEWAY: validation passed but hostd was " +
+          "started without an approval-gateway wiring; the operator " +
+          "build is missing the telegram-plugin link",
+        Date.now() - started,
+      );
+    }
+    const callerName = caller.kind === "agent" ? caller.name : "operator";
+    const approvalId = (this.opts.generateApprovalId ?? defaultApprovalId)();
+    const approval = await this.opts.approvalGateway.requestApproval({
+      requestId: approvalId,
+      agentName: callerName,
+      reason: req.args.reason,
+      unifiedDiff: req.args.unified_diff,
+      timeoutMs: CONFIG_APPROVAL_TIMEOUT_MS,
+    });
+    if (approval.verdict === "deny") {
+      return errorResponse(
+        req.request_id,
+        `E_DENIED: operator denied config_propose_edit (approval_id=${approvalId})`,
+        Date.now() - started,
+      );
+    }
+    if (approval.verdict === "timeout") {
+      return errorResponse(
+        req.request_id,
+        `E_APPROVAL_TIMEOUT: operator approval card expired without a tap (approval_id=${approvalId})`,
+        Date.now() - started,
+      );
+    }
+    // ── Apply path (mutex-serialized) ───────────────────────────────
+    // Serialize concurrent config-edit applies through a single
+    // in-process promise chain. Hostd is the only writer of
+    // switchroom.yaml; no cross-process flock is needed.
+    const release = await this.acquireConfigApplyLock();
+    try {
+      // Snapshot the live config so we can rollback if reconcile
+      // fails. Read synchronously — the lock is held, no one else
+      // is touching the file.
+      let snapshot: string;
+      try {
+        snapshot = readFileSync(configPath, "utf-8");
+      } catch (err) {
+        await approval.finalize({
+          outcome: "reconcile_failed_rolled_back",
+          detail: `pre-write snapshot read failed: ${(err as Error).message}`,
+        });
+        return errorResponse(
+          req.request_id,
+          `E_RECONCILE_FAILED_ROLLED_BACK: snapshot read failed: ${(err as Error).message}`,
+          Date.now() - started,
+        );
+      }
+      // The validator already produced the post-apply text (it runs
+      // `git apply` against the live file). We re-derive it here by
+      // applying the patch a second time to obtain the post-patch
+      // bytes — the validator returns its own copy on success.
+      const postApply = verdict.postApplyContent;
+      // Atomic write: `<path>.tmp` → rename.
+      const tmp = configPath + ".tmp";
+      try {
+        writeFileSync(tmp, postApply);
+        renameSync(tmp, configPath);
+      } catch (err) {
+        // Pre-write or rename failed — try to clean up tmp; live
+        // file is untouched so no rollback needed.
+        try { unlinkSyncBestEffort(tmp); } catch { /* noop */ }
+        await approval.finalize({
+          outcome: "reconcile_failed_rolled_back",
+          detail: `atomic write failed: ${(err as Error).message}`,
+        });
+        return errorResponse(
+          req.request_id,
+          `E_RECONCILE_FAILED_ROLLED_BACK: write failed: ${(err as Error).message}`,
+          Date.now() - started,
+        );
+      }
+      // Reconcile.
+      const runner =
+        this.opts.runReconcile ??
+        (async () => this.runSwitchroom(["apply"]));
+      const recRes = await runner({ requestId: approvalId });
+      if (recRes.exit_code === 0) {
+        await approval.finalize({ outcome: "applied" });
+        return {
+          v: 1,
+          request_id: req.request_id,
+          result: "completed",
+          exit_code: 0,
+          duration_ms: Date.now() - started,
+          stdout_tail: tail(recRes.stdout),
+          stderr_tail: tail(recRes.stderr),
+        };
+      }
+      // ── Reconcile failed → rollback to snapshot, re-run reconcile.
+      let rollbackDetail = "";
+      try {
+        writeFileSync(tmp, snapshot);
+        renameSync(tmp, configPath);
+      } catch (err) {
+        rollbackDetail = `snapshot restore failed: ${(err as Error).message}`;
+        await approval.finalize({
+          outcome: "reconcile_failed_rolled_back",
+          detail: rollbackDetail,
+        });
+        return errorResponse(
+          req.request_id,
+          `E_RECONCILE_FAILED_ROLLED_BACK: ${rollbackDetail}`,
+          Date.now() - started,
+        );
+      }
+      const recRes2 = await runner({ requestId: approvalId });
+      const recoveryNote =
+        recRes2.exit_code === 0
+          ? "rolled back successfully"
+          : `rolled back but recovery reconcile also failed (exit ${recRes2.exit_code})`;
+      await approval.finalize({
+        outcome: "reconcile_failed_rolled_back",
+        detail: recoveryNote,
+      });
+      return errorResponse(
+        req.request_id,
+        `E_RECONCILE_FAILED_ROLLED_BACK: reconcile exit ${recRes.exit_code}; ${recoveryNote}`,
+        Date.now() - started,
+      );
+    } finally {
+      release();
+    }
+  }
+
+  /** Serializes concurrent config_propose_edit apply phases. */
+  private configApplyLock: Promise<void> = Promise.resolve();
+  private async acquireConfigApplyLock(): Promise<() => void> {
+    let release!: () => void;
+    const next = new Promise<void>((r) => { release = r; });
+    const prior = this.configApplyLock;
+    this.configApplyLock = prior.then(() => next);
+    await prior;
+    return release;
   }
 
   private async handleAgentSmoke(

--- a/telegram-plugin/gateway/config-approval-handler.test.ts
+++ b/telegram-plugin/gateway/config-approval-handler.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Gateway-side `request_config_approval` handler tests (#1623).
+ *
+ * Focuses on the load-bearing transitions, not exhaustive plumbing:
+ *   - Happy path: card posted, callback resolved, finalize edits.
+ *   - Cross-agent rejection.
+ *   - Double-tap is a no-op (second `resolvePendingConfigApproval`
+ *     returns false and does not send a second verdict).
+ *   - Timeout fires `verdict: "timeout"` automatically.
+ *   - parseConfigApprovalCallback parses + rejects malformed input.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  buildConfigApprovalCardBody,
+  handleRequestConfigApproval,
+  handleRequestConfigFinalize,
+  parseConfigApprovalCallback,
+  resolvePendingConfigApproval,
+  _resetPendingConfigApprovalsForTest,
+  _peekPendingConfigApprovalForTest,
+} from "./config-approval-handler.js";
+import type { RequestConfigApprovalMessage } from "./ipc-protocol.js";
+
+const baseMsg: RequestConfigApprovalMessage = {
+  type: "request_config_approval",
+  requestId: "req-1",
+  agentName: "klanker",
+  reason: "tighten doctor schedule",
+  unifiedDiff: "--- a/x\n+++ b/x\n@@\n-a\n+b\n",
+  timeoutMs: 60_000,
+};
+
+function fakeDeps(overrides: Partial<Parameters<typeof handleRequestConfigApproval>[2]> = {}) {
+  const sent: Array<{ type: string; [k: string]: unknown }> = [];
+  const client = {
+    send: (m: { type: string; [k: string]: unknown }) => {
+      sent.push(m);
+    },
+  };
+  const editCalls: Array<{
+    chatId: number | string;
+    messageId: number;
+    text: string;
+  }> = [];
+  const deps = {
+    agentName: "klanker",
+    loadTargetChat: () => ({ chatId: 42 }),
+    postCard: vi.fn(async () => ({ messageId: 1001 })),
+    buildKeyboard: () => ({ inline_keyboard: [] }),
+    editCard: async (a: { chatId: number | string; messageId: number; text: string }) => {
+      editCalls.push(a);
+    },
+    log: () => {},
+    ...overrides,
+  };
+  return { client, sent, deps, editCalls };
+}
+
+beforeEach(() => {
+  _resetPendingConfigApprovalsForTest();
+});
+afterEach(() => {
+  _resetPendingConfigApprovalsForTest();
+});
+
+describe("buildConfigApprovalCardBody", () => {
+  it("HTML-escapes the diff body so `<` / `&` can't break out of the <pre> block", () => {
+    const body = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: "<script>",
+      unifiedDiff: "a & b <c>",
+    });
+    expect(body).toContain("&lt;script&gt;");
+    expect(body).toContain("a &amp; b &lt;c&gt;");
+  });
+});
+
+describe("handleRequestConfigApproval", () => {
+  it("posts the card, registers a pending entry, and stays open until resolved", async () => {
+    const { client, deps } = fakeDeps();
+    await handleRequestConfigApproval(client, baseMsg, deps);
+    expect(deps.postCard).toHaveBeenCalledTimes(1);
+    const pending = _peekPendingConfigApprovalForTest("req-1");
+    expect(pending).toBeDefined();
+    expect(pending!.messageId).toBe(1001);
+  });
+
+  it("rejects a cross-agent request without posting a card", async () => {
+    const { client, sent, deps } = fakeDeps();
+    await handleRequestConfigApproval(
+      client,
+      { ...baseMsg, agentName: "evilpeer" },
+      deps,
+    );
+    expect(deps.postCard).not.toHaveBeenCalled();
+    expect(sent).toEqual([
+      {
+        type: "config_approval_resolved",
+        requestId: "req-1",
+        verdict: "deny",
+        reason: expect.stringContaining("gateway serves 'klanker'"),
+      },
+    ]);
+  });
+
+  it("rejects when no target chat is paired", async () => {
+    const { client, sent, deps } = fakeDeps({ loadTargetChat: () => null });
+    await handleRequestConfigApproval(client, baseMsg, deps);
+    expect(sent[0]!.verdict).toBe("deny");
+    expect(sent[0]!.reason).toMatch(/not paired/);
+  });
+
+  it("rejects when postCard fails (Telegram down)", async () => {
+    const { client, sent, deps } = fakeDeps({
+      postCard: vi.fn(async () => null),
+    });
+    await handleRequestConfigApproval(client, baseMsg, deps);
+    expect(sent[0]!.verdict).toBe("deny");
+    expect(sent[0]!.reason).toMatch(/sendMessage failed/);
+  });
+});
+
+describe("resolvePendingConfigApproval — double-tap and verdict propagation", () => {
+  it("first tap resolves; second tap is a no-op", async () => {
+    const { client, sent, deps, editCalls } = fakeDeps();
+    await handleRequestConfigApproval(client, baseMsg, deps);
+    const first = await resolvePendingConfigApproval("req-1", "approve", deps);
+    expect(first).toBe(true);
+    const second = await resolvePendingConfigApproval("req-1", "deny", deps);
+    expect(second).toBe(false);
+    // Only one verdict crossed the wire to hostd.
+    const verdicts = sent.filter((s) => s.type === "config_approval_resolved");
+    expect(verdicts.length).toBe(1);
+    expect(verdicts[0]!.verdict).toBe("approve");
+    // Card edited once to the interim 'Applying' state.
+    expect(editCalls.length).toBe(1);
+    expect(editCalls[0]!.text).toMatch(/Applying/);
+  });
+
+  it("returns false when no entry exists (unknown requestId)", async () => {
+    const { deps } = fakeDeps();
+    const r = await resolvePendingConfigApproval("unknown", "approve", deps);
+    expect(r).toBe(false);
+  });
+});
+
+describe("timeout path", () => {
+  it("auto-fires verdict 'timeout' after timeoutMs and edits card to '⏱ Expired'", async () => {
+    vi.useFakeTimers();
+    try {
+      const { client, sent, deps, editCalls } = fakeDeps();
+      await handleRequestConfigApproval(
+        client,
+        { ...baseMsg, timeoutMs: 1000 },
+        deps,
+      );
+      vi.advanceTimersByTime(1500);
+      // Allow microtasks scheduled inside the timer to flush.
+      await vi.runAllTimersAsync();
+      const verdicts = sent.filter((s) => s.type === "config_approval_resolved");
+      expect(verdicts.length).toBe(1);
+      expect(verdicts[0]!.verdict).toBe("timeout");
+      expect(editCalls[0]!.text).toMatch(/Expired/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("handleRequestConfigFinalize", () => {
+  it("edits the card to '✅ Applied' on success", async () => {
+    const { client, deps, editCalls } = fakeDeps();
+    await handleRequestConfigApproval(client, baseMsg, deps);
+    await resolvePendingConfigApproval("req-1", "approve", deps);
+    await handleRequestConfigFinalize(
+      client,
+      {
+        type: "request_config_finalize",
+        requestId: "req-1",
+        outcome: "applied",
+      },
+      deps,
+    );
+    const last = editCalls[editCalls.length - 1]!;
+    expect(last.text).toMatch(/Applied/);
+  });
+
+  it("edits to '⚠️ Reconcile failed; rolled back' with detail", async () => {
+    const { client, deps, editCalls } = fakeDeps();
+    await handleRequestConfigApproval(client, baseMsg, deps);
+    await resolvePendingConfigApproval("req-1", "approve", deps);
+    await handleRequestConfigFinalize(
+      client,
+      {
+        type: "request_config_finalize",
+        requestId: "req-1",
+        outcome: "reconcile_failed_rolled_back",
+        detail: "rolled back successfully",
+      },
+      deps,
+    );
+    const last = editCalls[editCalls.length - 1]!;
+    expect(last.text).toMatch(/Reconcile failed/);
+    expect(last.text).toMatch(/rolled back successfully/);
+  });
+
+  it("is a no-op when no pending entry exists for the requestId", async () => {
+    const { client, deps, editCalls } = fakeDeps();
+    await handleRequestConfigFinalize(
+      client,
+      {
+        type: "request_config_finalize",
+        requestId: "missing",
+        outcome: "applied",
+      },
+      deps,
+    );
+    expect(editCalls.length).toBe(0);
+  });
+});
+
+describe("parseConfigApprovalCallback", () => {
+  it("parses well-formed callbacks", () => {
+    expect(parseConfigApprovalCallback("cfg:abc:approve")).toEqual({
+      requestId: "abc",
+      choice: "approve",
+    });
+    expect(parseConfigApprovalCallback("cfg:deadbeef:deny")).toEqual({
+      requestId: "deadbeef",
+      choice: "deny",
+    });
+  });
+
+  it("rejects malformed input", () => {
+    expect(parseConfigApprovalCallback("apv:abc:once")).toBeNull();
+    expect(parseConfigApprovalCallback("cfg:")).toBeNull();
+    expect(parseConfigApprovalCallback("cfg:abc:bogus")).toBeNull();
+    expect(parseConfigApprovalCallback("cfg::approve")).toBeNull();
+  });
+});

--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -1,37 +1,6 @@
-/**
- * hostd config-edit approval handler — #1623 / RFC §3.3.
- *
- * Called by the gateway IPC dispatcher when hostd sends a
- * `request_config_approval` message. The handler:
- *
- *   1. Posts a Telegram card with the agent name, reason, and full
- *      unified diff in a fenced code block + two inline buttons:
- *      [✅ Approve] [🚫 Deny] (callback_data `cfg:<id>:approve` /
- *      `cfg:<id>:deny`).
- *   2. Registers the pending request in an in-memory map keyed by
- *      `requestId`. A single-shot timer fires `verdict: "timeout"`
- *      after `timeoutMs` and edits the card to "⏱ expired".
- *   3. On the first tap (Approve / Deny), the `cfg:` callback handler
- *      calls `resolvePendingConfigApproval(requestId, verdict)` which
- *      cancels the timer, sends `config_approval_resolved` back to
- *      hostd over the same client connection, and edits the card to
- *      an interim "👀 applying…" / "🚫 denied" state. Subsequent taps
- *      on the same id are no-ops (double-tap safe).
- *   4. After hostd's apply path completes, it sends
- *      `request_config_finalize` to flip the card body to the
- *      terminal state ("✅ applied" or
- *      "⚠️ reconcile failed; rolled back"). The finalize handler
- *      runs even after the pending entry has been cleared from the
- *      map — it edits by `chatId`+`messageId` recorded on the
- *      pending entry at post time.
- *
- * Trust model: same as the Drive-write approval handler — the
- * gateway socket is reachable only from inside the agent container
- * (or hostd via the bind-mounted state dir), so the requesting
- * client is treated as trusted. Operator-side authorization is
- * still re-checked on the callback tap against `access.allowFrom`
- * (mirrors the `apv:` / `drvpick:` / `op:` handlers in gateway.ts).
- */
+// hostd config-edit approval handler (#1623 / RFC §3.3): posts an approval
+// card, resolves the verdict back to hostd over IPC, and flips the card to
+// a terminal state on finalize.
 
 import type { IpcClient } from "./ipc-server.js";
 import type {
@@ -55,11 +24,7 @@ interface PendingConfigApproval {
 
 const pending = new Map<string, PendingConfigApproval>();
 
-// ────────────────────────────────────────────────────────────────────────
 // Injected deps — gateway.ts wires these from the existing surface.
-// Same shape pattern as drive-write-approval to keep the unit tests
-// free of grammy + telegram.
-// ────────────────────────────────────────────────────────────────────────
 
 export interface ConfigApprovalHandlerDeps {
   /** This gateway's agent name — cross-agent requests rejected. */
@@ -137,13 +102,6 @@ export async function handleRequestConfigApproval(
 
   if (msg.agentName !== deps.agentName) {
     reply("deny", `gateway serves '${deps.agentName}', not '${msg.agentName}'`);
-    return;
-  }
-
-  if (pending.has(msg.requestId)) {
-    // Defensive — hostd should never reuse a requestId, but if it
-    // does, fail closed rather than overwrite the live entry.
-    reply("deny", `duplicate requestId '${msg.requestId}'`);
     return;
   }
 
@@ -254,14 +212,7 @@ export async function resolvePendingConfigApproval(
   return true;
 }
 
-/**
- * Called by the IPC dispatcher on `request_config_finalize` — edits
- * the card body to the terminal apply outcome. Idempotent — if the
- * pending entry has already been removed (e.g. by an earlier timeout
- * + cleanup), we still attempt the edit using a chat-id we don't
- * have, so this path requires the pending entry to still exist;
- * otherwise it's a best-effort no-op.
- */
+/** IPC `request_config_finalize` handler — edits the card to the terminal outcome. */
 export async function handleRequestConfigFinalize(
   _client: Pick<IpcClient, "send">,
   msg: RequestConfigFinalizeMessage,

--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -1,0 +1,333 @@
+/**
+ * hostd config-edit approval handler — #1623 / RFC §3.3.
+ *
+ * Called by the gateway IPC dispatcher when hostd sends a
+ * `request_config_approval` message. The handler:
+ *
+ *   1. Posts a Telegram card with the agent name, reason, and full
+ *      unified diff in a fenced code block + two inline buttons:
+ *      [✅ Approve] [🚫 Deny] (callback_data `cfg:<id>:approve` /
+ *      `cfg:<id>:deny`).
+ *   2. Registers the pending request in an in-memory map keyed by
+ *      `requestId`. A single-shot timer fires `verdict: "timeout"`
+ *      after `timeoutMs` and edits the card to "⏱ expired".
+ *   3. On the first tap (Approve / Deny), the `cfg:` callback handler
+ *      calls `resolvePendingConfigApproval(requestId, verdict)` which
+ *      cancels the timer, sends `config_approval_resolved` back to
+ *      hostd over the same client connection, and edits the card to
+ *      an interim "👀 applying…" / "🚫 denied" state. Subsequent taps
+ *      on the same id are no-ops (double-tap safe).
+ *   4. After hostd's apply path completes, it sends
+ *      `request_config_finalize` to flip the card body to the
+ *      terminal state ("✅ applied" or
+ *      "⚠️ reconcile failed; rolled back"). The finalize handler
+ *      runs even after the pending entry has been cleared from the
+ *      map — it edits by `chatId`+`messageId` recorded on the
+ *      pending entry at post time.
+ *
+ * Trust model: same as the Drive-write approval handler — the
+ * gateway socket is reachable only from inside the agent container
+ * (or hostd via the bind-mounted state dir), so the requesting
+ * client is treated as trusted. Operator-side authorization is
+ * still re-checked on the callback tap against `access.allowFrom`
+ * (mirrors the `apv:` / `drvpick:` / `op:` handlers in gateway.ts).
+ */
+
+import type { IpcClient } from "./ipc-server.js";
+import type {
+  RequestConfigApprovalMessage,
+  RequestConfigFinalizeMessage,
+} from "./ipc-protocol.js";
+
+/** Pending approval state — in-memory only (no SQLite per RFC §3.4). */
+interface PendingConfigApproval {
+  requestId: string;
+  client: Pick<IpcClient, "send">;
+  chatId: number | string;
+  threadId?: number;
+  messageId: number;
+  /** node:Timeout — set when the timer is armed; cleared once the
+   *  request resolves (approve/deny/timeout) to make resolve idempotent. */
+  timer: ReturnType<typeof setTimeout> | null;
+  /** Has a verdict already been sent? Guards against double-tap. */
+  resolved: boolean;
+}
+
+const pending = new Map<string, PendingConfigApproval>();
+
+// ────────────────────────────────────────────────────────────────────────
+// Injected deps — gateway.ts wires these from the existing surface.
+// Same shape pattern as drive-write-approval to keep the unit tests
+// free of grammy + telegram.
+// ────────────────────────────────────────────────────────────────────────
+
+export interface ConfigApprovalHandlerDeps {
+  /** This gateway's agent name — cross-agent requests rejected. */
+  agentName: string;
+  /** Operator's primary chat for the card. Returns null if not paired. */
+  loadTargetChat: () => {
+    chatId: number | string;
+    threadId?: number;
+  } | null;
+  /** Post the Telegram card. Returns the posted message id on success. */
+  postCard: (args: {
+    chatId: number | string;
+    threadId?: number;
+    text: string;
+    /** grammy InlineKeyboard, passed through verbatim. */
+    replyMarkup: unknown;
+  }) => Promise<{ messageId: number } | null>;
+  /** Build the inline keyboard with [✅ Approve] [🚫 Deny] buttons. */
+  buildKeyboard: (requestId: string) => unknown;
+  /** Edit a posted card to a new body. Best-effort — failures logged. */
+  editCard: (args: {
+    chatId: number | string;
+    messageId: number;
+    text: string;
+  }) => Promise<void>;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Build the card body (HTML). Renders the full diff in a `<pre>`
+ * code block — Telegram caps messages at 4096 chars, so very large
+ * diffs may be truncated by the API; the validator already caps
+ * unified_diff at ~63 KiB so practical fleet edits fit comfortably.
+ */
+export function buildConfigApprovalCardBody(args: {
+  agentName: string;
+  reason: string;
+  unifiedDiff: string;
+}): string {
+  const esc = (s: string) =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return (
+    `🛠 <b>Config edit proposed</b>\n` +
+    `Agent: <code>${esc(args.agentName)}</code>\n` +
+    `Reason: ${esc(args.reason)}\n\n` +
+    `<pre>${esc(args.unifiedDiff)}</pre>`
+  );
+}
+
+/**
+ * Top-level handler — called by the IPC dispatcher.
+ */
+export async function handleRequestConfigApproval(
+  client: Pick<IpcClient, "send">,
+  msg: RequestConfigApprovalMessage,
+  deps: ConfigApprovalHandlerDeps,
+): Promise<void> {
+  const reply = (
+    verdict: "approve" | "deny" | "timeout",
+    reason?: string,
+  ) => {
+    try {
+      client.send({
+        type: "config_approval_resolved",
+        requestId: msg.requestId,
+        verdict,
+        ...(reason ? { reason } : {}),
+      });
+    } catch (err) {
+      deps.log?.(
+        `config_approval_resolved send failed (requestId=${msg.requestId}): ${(err as Error).message}`,
+      );
+    }
+  };
+
+  if (msg.agentName !== deps.agentName) {
+    reply("deny", `gateway serves '${deps.agentName}', not '${msg.agentName}'`);
+    return;
+  }
+
+  if (pending.has(msg.requestId)) {
+    // Defensive — hostd should never reuse a requestId, but if it
+    // does, fail closed rather than overwrite the live entry.
+    reply("deny", `duplicate requestId '${msg.requestId}'`);
+    return;
+  }
+
+  const target = deps.loadTargetChat();
+  if (target === null) {
+    reply("deny", "no target chat available — operator not paired?");
+    return;
+  }
+
+  const body = buildConfigApprovalCardBody({
+    agentName: msg.agentName,
+    reason: msg.reason,
+    unifiedDiff: msg.unifiedDiff,
+  });
+  const replyMarkup = deps.buildKeyboard(msg.requestId);
+
+  const posted = await deps.postCard({
+    chatId: target.chatId,
+    ...(target.threadId !== undefined ? { threadId: target.threadId } : {}),
+    text: body,
+    replyMarkup,
+  });
+  if (posted === null) {
+    reply("deny", "Telegram sendMessage failed");
+    return;
+  }
+
+  const entry: PendingConfigApproval = {
+    requestId: msg.requestId,
+    client,
+    chatId: target.chatId,
+    ...(target.threadId !== undefined ? { threadId: target.threadId } : {}),
+    messageId: posted.messageId,
+    timer: null,
+    resolved: false,
+  };
+  entry.timer = setTimeout(() => {
+    void resolvePendingConfigApproval(msg.requestId, "timeout", deps).catch(
+      (err) =>
+        deps.log?.(
+          `config approval timeout handler threw (requestId=${msg.requestId}): ${(err as Error).message}`,
+        ),
+    );
+  }, msg.timeoutMs);
+  pending.set(msg.requestId, entry);
+
+  deps.log?.(
+    `config_approval_posted requestId=${msg.requestId} agent=${msg.agentName} messageId=${posted.messageId}`,
+  );
+}
+
+/**
+ * Called by the `cfg:` callback dispatcher in gateway.ts on an
+ * operator tap, by the per-request timer on expiry, OR by the
+ * finalize path defensively before edit. Sends a single
+ * `config_approval_resolved` reply over the original client
+ * connection and edits the card to the interim state. Double-tap
+ * safe — subsequent calls for the same requestId are no-ops.
+ *
+ * Returns true if THIS call resolved the request (first call wins),
+ * false if it was already resolved.
+ */
+export async function resolvePendingConfigApproval(
+  requestId: string,
+  verdict: "approve" | "deny" | "timeout",
+  deps: Pick<ConfigApprovalHandlerDeps, "editCard" | "log">,
+): Promise<boolean> {
+  const entry = pending.get(requestId);
+  if (!entry || entry.resolved) return false;
+  entry.resolved = true;
+  if (entry.timer !== null) {
+    clearTimeout(entry.timer);
+    entry.timer = null;
+  }
+
+  // Send the verdict back to hostd. Best effort — if the IPC
+  // connection has dropped, hostd's own timeout will fire.
+  try {
+    entry.client.send({
+      type: "config_approval_resolved",
+      requestId,
+      verdict,
+    });
+  } catch (err) {
+    deps.log?.(
+      `config_approval_resolved send failed (requestId=${requestId}): ${(err as Error).message}`,
+    );
+  }
+
+  // Edit the card to an interim/terminal state.
+  const interim =
+    verdict === "approve"
+      ? "👀 <b>Applying…</b>"
+      : verdict === "deny"
+        ? "🚫 <b>Denied</b>"
+        : "⏱ <b>Expired</b>";
+  try {
+    await deps.editCard({
+      chatId: entry.chatId,
+      messageId: entry.messageId,
+      text: interim,
+    });
+  } catch (err) {
+    deps.log?.(
+      `config approval card edit failed (requestId=${requestId}): ${(err as Error).message}`,
+    );
+  }
+  return true;
+}
+
+/**
+ * Called by the IPC dispatcher on `request_config_finalize` — edits
+ * the card body to the terminal apply outcome. Idempotent — if the
+ * pending entry has already been removed (e.g. by an earlier timeout
+ * + cleanup), we still attempt the edit using a chat-id we don't
+ * have, so this path requires the pending entry to still exist;
+ * otherwise it's a best-effort no-op.
+ */
+export async function handleRequestConfigFinalize(
+  _client: Pick<IpcClient, "send">,
+  msg: RequestConfigFinalizeMessage,
+  deps: Pick<ConfigApprovalHandlerDeps, "editCard" | "log">,
+): Promise<void> {
+  const entry = pending.get(msg.requestId);
+  if (!entry) {
+    deps.log?.(
+      `config_finalize: no pending entry for requestId=${msg.requestId} (likely already cleaned up)`,
+    );
+    return;
+  }
+  // Clean up the pending entry — finalize is the terminal transition.
+  pending.delete(msg.requestId);
+
+  const body =
+    msg.outcome === "applied"
+      ? `✅ <b>Applied</b>${msg.detail ? `\n${escapeHtml(msg.detail)}` : ""}`
+      : `⚠️ <b>Reconcile failed; rolled back</b>${msg.detail ? `\n${escapeHtml(msg.detail)}` : ""}`;
+  try {
+    await deps.editCard({
+      chatId: entry.chatId,
+      messageId: entry.messageId,
+      text: body,
+    });
+  } catch (err) {
+    deps.log?.(
+      `config finalize card edit failed (requestId=${msg.requestId}): ${(err as Error).message}`,
+    );
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// Test-only: clear the in-memory pending map between cases.
+export function _resetPendingConfigApprovalsForTest(): void {
+  for (const entry of pending.values()) {
+    if (entry.timer !== null) clearTimeout(entry.timer);
+  }
+  pending.clear();
+}
+
+// Test-only: peek at a pending entry.
+export function _peekPendingConfigApprovalForTest(
+  requestId: string,
+): Readonly<PendingConfigApproval> | undefined {
+  return pending.get(requestId);
+}
+
+/**
+ * Parse `cfg:<requestId>:<choice>` callback data. Returns null on
+ * malformed input. The callback handler in gateway.ts uses this +
+ * resolvePendingConfigApproval to drive the tap → resolve flow.
+ */
+export function parseConfigApprovalCallback(
+  data: string,
+): { requestId: string; choice: "approve" | "deny" } | null {
+  if (!data.startsWith("cfg:")) return null;
+  const rest = data.slice(4);
+  const colon = rest.lastIndexOf(":");
+  if (colon < 0) return null;
+  const requestId = rest.slice(0, colon);
+  const choice = rest.slice(colon + 1);
+  if (requestId.length === 0 || requestId.length > 64) return null;
+  if (choice !== "approve" && choice !== "deny") return null;
+  return { requestId, choice };
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3768,6 +3768,102 @@ const ipcServer: IpcServer = createIpcServer({
     })
   },
 
+  /**
+   * #1623 — hostd-initiated config-edit approval card. hostd posts a
+   * `request_config_approval` message; we render the card via
+   * `handleRequestConfigApproval`, awaiting the operator tap (or
+   * timeout) before sending `config_approval_resolved` back. After
+   * hostd's apply attempt completes it posts
+   * `request_config_finalize` to flip the card to the terminal
+   * outcome.
+   */
+  async onRequestConfigApproval(client: IpcClient, msg) {
+    const { handleRequestConfigApproval } = await import(
+      './config-approval-handler.js'
+    )
+    const { InlineKeyboard } = await import('grammy')
+    await handleRequestConfigApproval(client, msg, {
+      agentName: getMyAgentName(),
+      loadTargetChat: () => {
+        const access = loadAccess()
+        const operator = access.allowFrom[0]
+        if (operator === undefined) return null
+        return { chatId: operator }
+      },
+      buildKeyboard: (requestId) =>
+        new InlineKeyboard()
+          .text('✅ Approve', `cfg:${requestId}:approve`)
+          .text('🚫 Deny', `cfg:${requestId}:deny`),
+      postCard: async (args) => {
+        try {
+          const sent = await robustApiCall(
+            () =>
+              bot.api.sendMessage(args.chatId, args.text, {
+                parse_mode: 'HTML',
+                ...(args.threadId !== undefined
+                  ? { message_thread_id: args.threadId }
+                  : {}),
+                reply_markup: args.replyMarkup as never,
+              }),
+            {
+              chat_id: String(args.chatId),
+              verb: 'config-approval-card',
+              ...(args.threadId !== undefined ? { threadId: args.threadId } : {}),
+            },
+          )
+          return { messageId: (sent as { message_id: number }).message_id }
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: config-approval postCard failed: ${(err as Error).message}\n`,
+          )
+          return null
+        }
+      },
+      editCard: async (args) => {
+        try {
+          await robustApiCall(
+            () =>
+              bot.api.editMessageText(args.chatId, args.messageId, args.text, {
+                parse_mode: 'HTML',
+              }),
+            { chat_id: String(args.chatId), verb: 'config-approval-edit' },
+          )
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: config-approval editCard failed: ${(err as Error).message}\n`,
+          )
+        }
+      },
+      log: (m) =>
+        process.stderr.write(`telegram gateway: config-approval — ${m}\n`),
+    })
+  },
+
+  async onRequestConfigFinalize(client: IpcClient, msg) {
+    const { handleRequestConfigFinalize } = await import(
+      './config-approval-handler.js'
+    )
+    await handleRequestConfigFinalize(client, msg, {
+      editCard: async (args) => {
+        try {
+          await robustApiCall(
+            () =>
+              bot.api.editMessageText(args.chatId, args.messageId, args.text, {
+                parse_mode: 'HTML',
+              }),
+            { chat_id: String(args.chatId), verb: 'config-approval-finalize' },
+          )
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: config-finalize editCard failed: ${(err as Error).message}\n`,
+          )
+        }
+      },
+      log: (m) =>
+        process.stderr.write(`telegram gateway: config-finalize — ${m}\n`),
+    })
+  },
+
   onInjectInbound(_client: IpcClient, msg: InjectInboundMessage) {
     const promptKey = typeof msg.inbound.meta?.prompt_key === 'string'
       ? msg.inbound.meta.prompt_key
@@ -12713,6 +12809,53 @@ bot.on('callback_query:data', async ctx => {
     }
     const { handleApprovalCallback } = await import('./approval-callback.js')
     await handleApprovalCallback(ctx, data)
+    return
+  }
+
+  // #1623: cfg:<requestId>:<approve|deny> — hostd config-edit
+  // approval card. Resolves the pending approval (gateway-side
+  // in-memory map), sends `config_approval_resolved` back to hostd
+  // over the original IPC connection, and edits the card to the
+  // interim "Applying…" / "Denied" state. Same operator-allowlist
+  // gate as every other callback family.
+  if (data.startsWith('cfg:')) {
+    const access = loadAccess()
+    const senderId = String(ctx.from?.id ?? '')
+    if (!access.allowFrom.includes(senderId)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' })
+      return
+    }
+    const { parseConfigApprovalCallback, resolvePendingConfigApproval } =
+      await import('./config-approval-handler.js')
+    const parsed = parseConfigApprovalCallback(data)
+    if (parsed === null) {
+      await ctx.answerCallbackQuery({ text: 'Malformed callback.' })
+      return
+    }
+    const resolved = await resolvePendingConfigApproval(
+      parsed.requestId,
+      parsed.choice,
+      {
+        editCard: async (args) => {
+          try {
+            await bot.api.editMessageText(args.chatId, args.messageId, args.text, {
+              parse_mode: 'HTML',
+            })
+          } catch {
+            /* best effort */
+          }
+        },
+        log: (m) =>
+          process.stderr.write(`telegram gateway: config-approval cb — ${m}\n`),
+      },
+    )
+    await ctx.answerCallbackQuery({
+      text: resolved
+        ? parsed.choice === 'approve'
+          ? 'Approving…'
+          : 'Denied'
+        : 'Already resolved.',
+    })
     return
   }
 

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -93,13 +93,32 @@ export interface DriveApprovalPostedEvent {
   reason?: string;
 }
 
+/**
+ * hostd config-edit approval — sent by the gateway back to hostd
+ * after the operator taps Approve/Deny on a `request_config_approval`
+ * card (or the 10-minute timeout elapses).
+ *
+ * The gateway is the source of truth for the verdict; hostd treats
+ * this as a one-shot reply per `requestId`. Subsequent taps on the
+ * same card are ignored at the callback dispatcher (#1623, RFC §3.4).
+ */
+export interface ConfigApprovalResolvedEvent {
+  type: "config_approval_resolved";
+  /** Echoes the requestId from the originating request_config_approval. */
+  requestId: string;
+  verdict: "approve" | "deny" | "timeout";
+  /** Diagnostic detail when present (currently unused; reserved). */
+  reason?: string;
+}
+
 export type GatewayToClient =
   | InboundMessage
   | PermissionEvent
   | StatusEvent
   | ToolCallResult
   | ScheduleRestartResult
-  | DriveApprovalPostedEvent;
+  | DriveApprovalPostedEvent
+  | ConfigApprovalResolvedEvent;
 
 // === Bridge (Client) -> Gateway messages ===
 
@@ -278,6 +297,55 @@ export interface RequestDriveApprovalMessage {
   ttlMs?: number;
 }
 
+/**
+ * hostd config-edit approval — sent by hostd to the caller agent's
+ * gateway to render an approval card with the full unified diff in
+ * the operator's primary chat. The gateway:
+ *
+ *   1. Posts a Telegram card with [✅ Approve] [🚫 Deny] buttons
+ *      using callback_data `cfg:<requestId>:approve` / `:deny`.
+ *   2. Tracks the pending request in-memory (no SQLite).
+ *   3. On button tap (or 10-minute timeout) sends a single
+ *      `config_approval_resolved` event back over the same
+ *      connection.
+ *   4. After hostd reports the apply outcome via
+ *      `request_config_finalize`, edits the card body to the final
+ *      state ("✅ applied" / "⚠️ reconcile failed; rolled back" /
+ *      "🚫 denied" / "⏱ expired").
+ *
+ * Trust model: same as request_drive_approval — the gateway socket
+ * lives inside the agent container, only that-UID processes can
+ * connect. hostd reaches it via the per-agent state-dir bind mount
+ * (`<state-dir>/gateway.sock`).
+ */
+export interface RequestConfigApprovalMessage {
+  type: "request_config_approval";
+  /** Hostd-generated stable id (8-hex). Echoed in resolved/finalize. */
+  requestId: string;
+  /** Name of the admin agent that called config_propose_edit. */
+  agentName: string;
+  /** Operator-visible justification (≤500 chars). */
+  reason: string;
+  /** Full unified diff to render in a code block on the card. */
+  unifiedDiff: string;
+  /** Card timeout in milliseconds (gateway-enforced). */
+  timeoutMs: number;
+}
+
+/**
+ * Sent by hostd after the apply attempt completes (success OR
+ * rollback) so the gateway can edit the approval card body to a
+ * terminal state. Idempotent: if the card was already edited (e.g.
+ * by the timeout path), the second edit is a best-effort no-op.
+ */
+export interface RequestConfigFinalizeMessage {
+  type: "request_config_finalize";
+  requestId: string;
+  outcome: "applied" | "reconcile_failed_rolled_back";
+  /** Optional short diagnostic appended to the card body. */
+  detail?: string;
+}
+
 export type ClientToGateway =
   | RegisterMessage
   | ToolCallMessage
@@ -289,4 +357,6 @@ export type ClientToGateway =
   | PtyPartialForward
   | UpdatePlaceholderMessage
   | InjectInboundMessage
-  | RequestDriveApprovalMessage;
+  | RequestDriveApprovalMessage
+  | RequestConfigApprovalMessage
+  | RequestConfigFinalizeMessage;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -8,6 +8,8 @@ import type {
   PermissionRequestForward,
   PtyPartialForward,
   RegisterMessage,
+  RequestConfigApprovalMessage,
+  RequestConfigFinalizeMessage,
   RequestDriveApprovalMessage,
   ScheduleRestartMessage,
   SessionEventForward,
@@ -52,6 +54,26 @@ export interface IpcServerOptions {
   onRequestDriveApproval?: (
     client: IpcClient,
     msg: RequestDriveApprovalMessage,
+  ) => Promise<void>;
+  /**
+   * #1623 — hostd-initiated config-edit approval card. Handler posts
+   * a Telegram card with [✅ Approve] [🚫 Deny] buttons, tracks the
+   * pending request in-memory, and sends `config_approval_resolved`
+   * back over the same connection when the operator taps or the
+   * timeout fires. Optional: gateways without the hostd integration
+   * configured ignore these messages.
+   */
+  onRequestConfigApproval?: (
+    client: IpcClient,
+    msg: RequestConfigApprovalMessage,
+  ) => Promise<void>;
+  /**
+   * #1623 — hostd-initiated terminal card edit after apply completed
+   * (success OR rolled-back). Best-effort; no reply expected.
+   */
+  onRequestConfigFinalize?: (
+    client: IpcClient,
+    msg: RequestConfigFinalizeMessage,
   ) => Promise<void>;
   log?: (msg: string) => void;
   /**
@@ -205,6 +227,35 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
         && typeof inb.meta === "object"
         && inb.meta !== null;
     }
+    case "request_config_approval": {
+      // #1623 — hostd-initiated config-edit approval card. Wire shape
+      // only; the handler module validates the diff content.
+      if (typeof m.requestId !== "string"
+        || (m.requestId as string).length === 0
+        || (m.requestId as string).length > 64) return false;
+      if (typeof m.agentName !== "string"
+        || !AGENT_NAME_RE.test(m.agentName as string)) return false;
+      if (typeof m.reason !== "string"
+        || (m.reason as string).length === 0
+        || (m.reason as string).length > 500) return false;
+      if (typeof m.unifiedDiff !== "string"
+        || (m.unifiedDiff as string).length === 0) return false;
+      if (typeof m.timeoutMs !== "number"
+        || !Number.isFinite(m.timeoutMs)
+        || (m.timeoutMs as number) <= 0) return false;
+      return true;
+    }
+    case "request_config_finalize": {
+      if (typeof m.requestId !== "string"
+        || (m.requestId as string).length === 0
+        || (m.requestId as string).length > 64) return false;
+      if (m.outcome !== "applied"
+        && m.outcome !== "reconcile_failed_rolled_back") return false;
+      if (m.detail !== undefined
+        && (typeof m.detail !== "string"
+          || (m.detail as string).length > 500)) return false;
+      return true;
+    }
     case "request_drive_approval": {
       // RFC E §4.2 Cut 2. Validate the wire-shaped fields the
       // gateway will route on; the inner `preview` is treated as
@@ -241,6 +292,8 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onPtyPartial,
     onInjectInbound,
     onRequestDriveApproval,
+    onRequestConfigApproval,
+    onRequestConfigFinalize,
     log = () => {},
     heartbeatTimeoutMs = 30_000,
   } = options;
@@ -382,6 +435,54 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
             /* best effort */
           }
         }
+        break;
+      case "request_config_approval":
+        if (onRequestConfigApproval) {
+          onRequestConfigApproval(
+            client,
+            msg as RequestConfigApprovalMessage,
+          ).catch((err) => {
+            log(
+              `request_config_approval handler threw (client=${client.id}): ${(err as Error).message}`,
+            );
+            try {
+              client.send({
+                type: "config_approval_resolved",
+                requestId: (msg as RequestConfigApprovalMessage).requestId,
+                verdict: "deny",
+                reason: `gateway handler error: ${(err as Error).message}`,
+              });
+            } catch {
+              /* best effort */
+            }
+          });
+        } else {
+          // Fail closed — hostd treats this as deny so the apply path
+          // never runs without an operator-attested approval card.
+          try {
+            client.send({
+              type: "config_approval_resolved",
+              requestId: (msg as RequestConfigApprovalMessage).requestId,
+              verdict: "deny",
+              reason: "gateway not configured for config-edit approval",
+            });
+          } catch {
+            /* best effort */
+          }
+        }
+        break;
+      case "request_config_finalize":
+        if (onRequestConfigFinalize) {
+          onRequestConfigFinalize(
+            client,
+            msg as RequestConfigFinalizeMessage,
+          ).catch((err) => {
+            log(
+              `request_config_finalize handler threw (client=${client.id}): ${(err as Error).message}`,
+            );
+          });
+        }
+        // No reply expected.
         break;
       case "update_placeholder":
         // Legacy recall.py IPC — placeholder UX was removed in #553 PR 5.

--- a/tests/host-control/config-propose-edit.test.ts
+++ b/tests/host-control/config-propose-edit.test.ts
@@ -19,6 +19,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HostdServer } from "../../src/host-control/server.js";
 import { hostdRequest } from "../../src/host-control/client.js";
+import type {
+  ApprovalGateway,
+  ApprovalRequest,
+  ApprovalResult,
+} from "../../src/host-control/approval-gateway.js";
 
 let tmp: string;
 let server: HostdServer;
@@ -36,6 +41,13 @@ const VALID_BASE_YAML =
 function makeServer(opts: {
   configEditEnabled?: boolean;
   configPath?: string;
+  approvalGateway?: ApprovalGateway;
+  generateApprovalId?: () => string;
+  runReconcile?: (args: { requestId: string }) => Promise<{
+    exit_code: number;
+    stdout: string;
+    stderr: string;
+  }>;
 }) {
   return new HostdServer({
     homeDir: tmp,
@@ -50,7 +62,31 @@ function makeServer(opts: {
     auditLogPath: join(tmp, "audit.log"),
     allowNonLinux: true,
     configPath: opts.configPath,
+    approvalGateway: opts.approvalGateway,
+    generateApprovalId: opts.generateApprovalId,
+    runReconcile: opts.runReconcile,
   });
+}
+
+/** Build a stub ApprovalGateway with a pre-canned verdict + finalize spy. */
+function stubGateway(verdict: "approve" | "deny" | "timeout") {
+  const finalizeCalls: Array<{
+    outcome: "applied" | "reconcile_failed_rolled_back";
+    detail?: string;
+  }> = [];
+  const requests: ApprovalRequest[] = [];
+  const gw: ApprovalGateway = {
+    async requestApproval(req): Promise<ApprovalResult> {
+      requests.push(req);
+      return {
+        verdict,
+        finalize: async (out) => {
+          finalizeCalls.push(out);
+        },
+      };
+    },
+  };
+  return { gw, finalizeCalls, requests };
 }
 
 beforeEach(async () => {
@@ -341,8 +377,8 @@ describe("hostd config_propose_edit — PR 1b stage 4 (secret-leak guard)", () =
   });
 });
 
-describe("hostd config_propose_edit — PR 1b happy path", () => {
-  it("returns E_NOT_IMPLEMENTED_APPLY_PATH on a valid diff (apply still pending PR 1c)", async () => {
+describe("hostd config_propose_edit — PR 1b happy path (no approval gateway wired)", () => {
+  it("returns E_NO_APPROVAL_GATEWAY when validation passes but no gateway is configured", async () => {
     server = makeServer({ configEditEnabled: true, configPath });
     await server.start();
     const good =
@@ -355,7 +391,149 @@ describe("hostd config_propose_edit — PR 1b happy path", () => {
       " telegram:\n";
     const resp = await send({ unified_diff: good, request_id: "happy-1" });
     expect(resp.result).toBe("error");
-    expect(resp.error).toMatch(/^E_NOT_IMPLEMENTED_APPLY_PATH/);
-    expect(resp.error).toMatch(/PR 1c/);
+    expect(resp.error).toMatch(/^E_NO_APPROVAL_GATEWAY/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// #1623 PR 1c — full apply path (approval card + atomic write +
+// reconcile + rollback). All four transitions covered with a stub
+// ApprovalGateway and a stub reconcile runner — no docker / no real
+// gateway socket.
+// ─────────────────────────────────────────────────────────────────────
+
+import { readFileSync as readFile } from "node:fs";
+
+const GOOD_DIFF =
+  "--- a/switchroom.yaml\n" +
+  "+++ b/switchroom.yaml\n" +
+  "@@ -1,3 +1,4 @@\n" +
+  "+# touched by apply-path test\n" +
+  " switchroom:\n" +
+  "   version: 1\n" +
+  " telegram:\n";
+
+describe("hostd config_propose_edit — apply path (#1623)", () => {
+  it("approves → writes the new content + invokes reconcile + finalizes 'applied'", async () => {
+    const { gw, finalizeCalls, requests } = stubGateway("approve");
+    let reconcileInvocations = 0;
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      generateApprovalId: () => "deadbeef",
+      runReconcile: async () => {
+        reconcileInvocations += 1;
+        return { exit_code: 0, stdout: "applied ok", stderr: "" };
+      },
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "ap-1" });
+    expect(resp.result).toBe("completed");
+    expect(resp.exit_code).toBe(0);
+    // Card was rendered with the right payload + finalized to 'applied'.
+    expect(requests.length).toBe(1);
+    expect(requests[0]!.requestId).toBe("deadbeef");
+    expect(requests[0]!.agentName).toBe("klanker");
+    expect(requests[0]!.unifiedDiff).toBe(GOOD_DIFF);
+    expect(finalizeCalls).toEqual([{ outcome: "applied" }]);
+    // Live file actually contains the post-patch content.
+    const live = readFile(configPath, "utf8");
+    expect(live).toContain("# touched by apply-path test");
+    expect(reconcileInvocations).toBe(1);
+  });
+
+  it("deny tap → returns E_DENIED, no write, no reconcile", async () => {
+    const { gw, finalizeCalls } = stubGateway("deny");
+    let reconcileInvocations = 0;
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async () => {
+        reconcileInvocations += 1;
+        return { exit_code: 0, stdout: "", stderr: "" };
+      },
+    });
+    await server.start();
+    const before = readFile(configPath, "utf8");
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "ap-2" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_DENIED/);
+    expect(finalizeCalls.length).toBe(0); // gateway already showed 'denied'
+    expect(reconcileInvocations).toBe(0);
+    // Live file untouched.
+    expect(readFile(configPath, "utf8")).toBe(before);
+  });
+
+  it("timeout → returns E_APPROVAL_TIMEOUT, no write, no reconcile", async () => {
+    const { gw } = stubGateway("timeout");
+    let reconcileInvocations = 0;
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async () => {
+        reconcileInvocations += 1;
+        return { exit_code: 0, stdout: "", stderr: "" };
+      },
+    });
+    await server.start();
+    const before = readFile(configPath, "utf8");
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "ap-3" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_APPROVAL_TIMEOUT/);
+    expect(reconcileInvocations).toBe(0);
+    expect(readFile(configPath, "utf8")).toBe(before);
+  });
+
+  it("reconcile failure → rolls back to snapshot + re-runs reconcile + finalizes 'rolled back'", async () => {
+    const { gw, finalizeCalls } = stubGateway("approve");
+    const snapshotBefore = readFile(configPath, "utf8");
+    const reconcileExitCodes = [1, 0]; // first fails, recovery succeeds
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async () => {
+        const ec = reconcileExitCodes.shift() ?? 0;
+        return {
+          exit_code: ec,
+          stdout: ec === 0 ? "ok" : "",
+          stderr: ec === 0 ? "" : "reconcile boom",
+        };
+      },
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "ap-4" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_RECONCILE_FAILED_ROLLED_BACK/);
+    expect(resp.error).toMatch(/rolled back successfully/);
+    // Snapshot restored — live file matches the pre-write content.
+    expect(readFile(configPath, "utf8")).toBe(snapshotBefore);
+    // Card finalized to the failure state.
+    expect(finalizeCalls.length).toBe(1);
+    expect(finalizeCalls[0]!.outcome).toBe("reconcile_failed_rolled_back");
+    expect(finalizeCalls[0]!.detail).toMatch(/rolled back successfully/);
+  });
+
+  it("double-tap protection happens gateway-side (server only sees one verdict)", async () => {
+    // Simulate the contract: even if the operator double-taps, the
+    // gateway dedups and we receive exactly one resolution. We assert
+    // the server does NOT call requestApproval again on retries
+    // within the same in-process call — i.e. a single approve verdict
+    // produces a single apply + finalize pair.
+    const { gw, finalizeCalls, requests } = stubGateway("approve");
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async () => ({ exit_code: 0, stdout: "", stderr: "" }),
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "ap-5" });
+    expect(resp.result).toBe("completed");
+    expect(requests.length).toBe(1);
+    expect(finalizeCalls.length).toBe(1);
   });
 });


### PR DESCRIPTION
Closes the remaining PR for `config_propose_edit` (#1623). Builds on the skeleton (#1637) and the 4-stage validation pipeline (#1640). Replaces the dispatcher's `E_NOT_IMPLEMENTED_APPLY_PATH` stub with the full apply path.

## What's in (4 transitions + rollback)

1. **Approval card via hostd→gateway IPC.** New `request_config_approval` / `config_approval_resolved` / `request_config_finalize` message types on the gateway IPC surface, with a per-agent in-memory pending map (no SQLite per §3.4) and a new `cfg:` callback prefix wired into gateway.ts's `bot.on('callback_query:data')` dispatcher.
2. **Hostd-side `ApprovalGateway` interface.** Single-method abstraction the apply path consumes; production wiring is `SocketApprovalGateway` (connects to `<agentsDir>/<agent>/telegram/gateway.sock` — same pattern as `src/agents/lifecycle.ts:gracefulRestartAgent`); tests inject an in-process mock.
3. **Apply path.** Mutex-serialized snapshot → atomic write (`<path>.tmp` → `rename`) → `switchroom apply` → on failure, restore from snapshot atomically and re-run reconcile. Card is finalized via `request_config_finalize` to the terminal state ("✅ applied" / "⚠️ reconcile failed; rolled back").
4. **All four transitions covered by tests.**
   - Approve → apply → finalize 'applied' → `result: "completed"`
   - Deny → no write → `E_DENIED`
   - Timeout → no write → `E_APPROVAL_TIMEOUT`
   - Reconcile failure → snapshot restored → re-reconciled → card finalized to 'rolled back' → `E_RECONCILE_FAILED_ROLLED_BACK`
   - Plus a double-tap-protection assertion (gateway dedups; server sees a single verdict).
5. **Gateway handler unit tests** cover the cross-agent rejection, no-target-chat rejection, postCard failure, single-shot resolution (double-tap = no-op), timeout firing 'timeout' verdict, finalize editing to applied/failed, and callback parsing.

## What's deliberately out (per operator decision — single-operator single-host posture)

- Rate limiter
- Crash-recovery journal
- Prometheus metrics
- TOCTOU re-validation (validator already runs once)
- Literal `flock` on the config file (in-process mutex is sufficient — hostd is the only writer)
- Attachment fallback for very large diffs
- 5s safety-delay button swap
- Privilege-escalation detection
- Secrets-deref guard (validator's stage-4 secret-leak check is considered sufficient)

## Operator opt-in

The default flag stays off. Operator opts in by setting `hostd.config_edit_enabled: true` in `switchroom.yaml`.

## LOC

The diff lands at ~1.5k lines (counting tests + ~50% comment-to-code ratio in the new modules). Above the ~400-700-LOC target Ken sketched. The IPC surface (new message types + handler + validator additions + main.ts wiring + tests for both hostd-side and gateway-side) was the bulk of the unavoidable new code. Happy to prune docstrings if the comment density feels heavy on review.

## Test coverage

```
✓ telegram-plugin/gateway/config-approval-handler.test.ts (13 tests)
✓ tests/host-control/protocol.test.ts                     (11 tests)
✓ tests/host-control/config-edit-validator.test.ts        ( 2 tests)
✓ tests/host-control/config-propose-edit.test.ts          (21 tests)
```

`npx tsc --noEmit` is clean. The full vitest run has 22 pre-existing failures in `tests/host-control/server.test.ts` and 1 in `tests/install/static-binary.test.ts` — all confirmed present on `main` (sandbox/env-dependent, unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)