### PR TITLE
fix(auth): detect Claude v2.1.x usage-limit shape so auto-failover fires

### DIFF
--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -80,6 +80,10 @@ export function detectModelUnavailable(
     'quota_exhausted',
     'plan limit',
     'subscription limit',
+    // Claude Code v2.1.x usage-limit wording: "You've hit your limit ·
+    // resets 8:50am (Australia/Melbourne)".
+    'hit your limit',
+    'hit the limit',
   ]
   if (quotaSignals.some(s => lower.includes(s))) {
     const resetAt = parseResetTime(sample)

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -423,6 +423,33 @@ export function detectErrorInTranscriptLine(
 
   const type = obj.type as string | undefined
 
+  // Claude Code (v2.1.x) records a usage-limit / API error as a
+  // SYNTHETIC ASSISTANT MESSAGE, not an api_error / error line:
+  //   { type: "assistant",
+  //     message: { role: "assistant",
+  //       content: [{ type: "text", text: "You've hit your limit · resets …" }] },
+  //     error: "rate_limit", isApiErrorMessage: true, apiErrorStatus: 429 }
+  // It has no `api_error`/`error` top-type and no nested error OBJECT
+  // (`error` is a bare string), so the structured checks below miss it
+  // entirely. That silent miss is what kept fleet auto-fallback from
+  // ever firing on a quota hit — the exhaustion signal never reached
+  // the operator-event path. Detect this shape explicitly.
+  if (obj.isApiErrorMessage === true) {
+    const status =
+      typeof obj.apiErrorStatus === 'number' ? obj.apiErrorStatus : null
+    const errStr = typeof obj.error === 'string' ? obj.error : ''
+    const text = extractAssistantText(obj)
+    // A 429 in this shape is a subscription usage-limit hit (it carries
+    // a reset time) — classify it quota-exhausted so the operator event
+    // resolves to an auto-fallback-eligible kind. Other statuses fall
+    // through to the shared classifier.
+    const kind: OperatorEventKind =
+      status === 429
+        ? 'quota-exhausted'
+        : classifyClaudeError({ type: errStr, status, message: text })
+    return { kind, raw: obj, detail: text || errStr || 'api error' }
+  }
+
   // Explicit error line types from Claude Code JSONL
   const isErrorLine = type === 'api_error' || type === 'error'
 
@@ -452,6 +479,32 @@ function extractDetailMessage(obj: Record<string, unknown> | null): string | nul
   if (!obj) return null
   const msg = obj.message
   return typeof msg === 'string' && msg.length > 0 ? msg : null
+}
+
+/**
+ * Pull the human-readable text out of a synthetic assistant message
+ * (`message.content[].text`, joined). Used for the v2.1.x
+ * `isApiErrorMessage` shape, where the user-facing error string lives
+ * inside the assistant message rather than in an `error` object.
+ * Returns '' for any non-conforming shape — never throws.
+ */
+function extractAssistantText(obj: Record<string, unknown>): string {
+  const message = obj.message
+  if (typeof message !== 'object' || message == null) return ''
+  const content = (message as Record<string, unknown>).content
+  if (!Array.isArray(content)) return ''
+  const parts: string[] = []
+  for (const block of content) {
+    if (
+      typeof block === 'object'
+      && block != null
+      && (block as Record<string, unknown>).type === 'text'
+    ) {
+      const t = (block as Record<string, unknown>).text
+      if (typeof t === 'string') parts.push(t)
+    }
+  }
+  return parts.join(' ').trim()
 }
 
 // ─── The tail watcher ─────────────────────────────────────────────────────

--- a/telegram-plugin/tests/model-unavailable.test.ts
+++ b/telegram-plugin/tests/model-unavailable.test.ts
@@ -42,6 +42,15 @@ describe('detectModelUnavailable — quota / billing strings', () => {
   it('classifies "quota exhausted" verbatim', () => {
     expect(detectModelUnavailable('quota exhausted on slot main')?.kind).toBe('quota_exhausted')
   })
+
+  it("classifies Claude Code v2.1.x 'You've hit your limit' wording", () => {
+    // The exact text claude writes inside the synthetic
+    // isApiErrorMessage assistant message on a subscription quota hit.
+    const d = detectModelUnavailable(
+      "You've hit your limit · resets 8:50am (Australia/Melbourne)",
+    )
+    expect(d?.kind).toBe('quota_exhausted')
+  })
 })
 
 describe('detectModelUnavailable — overload / 429 / 5xx strings', () => {

--- a/telegram-plugin/tests/operator-events-session-tail.test.ts
+++ b/telegram-plugin/tests/operator-events-session-tail.test.ts
@@ -70,6 +70,49 @@ describe('detectErrorInTranscriptLine — error detection', () => {
     expect(detectErrorInTranscriptLine(line)).toBeNull()
   })
 
+  // Regression — the fleet-auto-failover dead-zone. Claude Code v2.1.x
+  // records a usage-limit hit as a synthetic assistant message with
+  // isApiErrorMessage:true (no api_error type, no nested error OBJECT).
+  // Pre-fix, detectErrorInTranscriptLine missed it entirely → the
+  // operator-event path never ran → fleet auto-fallback never fired.
+  it('detects the v2.1.x synthetic-assistant-message usage-limit shape', () => {
+    // The exact on-disk line shape, verbatim from a real quota hit.
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        model: '<synthetic>',
+        content: [
+          {
+            type: 'text',
+            text: "You've hit your limit · resets 8:50am (Australia/Melbourne)",
+          },
+        ],
+      },
+      error: 'rate_limit',
+      isApiErrorMessage: true,
+      apiErrorStatus: 429,
+    })
+    const result = detectErrorInTranscriptLine(line)
+    expect(result).not.toBeNull()
+    // A 429 in this shape is a subscription usage-limit hit → must
+    // classify quota-exhausted so the operator event resolves to an
+    // auto-fallback-eligible kind.
+    expect(result!.kind).toBe('quota-exhausted')
+    // The user-facing text must survive into `detail` (the model-
+    // unavailable card + the text-pattern path both rely on it).
+    expect(result!.detail).toContain('hit your limit')
+  })
+
+  it('still returns null for a normal (non-error) assistant message', () => {
+    // No isApiErrorMessage flag → must NOT be treated as an error.
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Done.' }] },
+    })
+    expect(detectErrorInTranscriptLine(line)).toBeNull()
+  })
+
   it('returns null for lines with null error field', () => {
     const line = JSON.stringify({ type: 'assistant', error: null })
     expect(detectErrorInTranscriptLine(line)).toBeNull()


### PR DESCRIPTION
## Summary

**Fleet-wide P1.** Account auto-failover is completely dead. An agent that hits its Claude subscription quota surfaces *"You've hit your limit · resets …"* and stops — it never rotates to a healthy account, even with two available in `fallback_order`. Surfaced live: the operator's `clerk` agent hit the wall and just kept reporting the limit; `switchroom auth list` showed all three accounts healthy (`QUOTA-RESET: —`) because the exhaustion signal never reached the auth pool.

## Root cause — a JSONL-shape drift

Claude Code v2.1.x records a usage-limit hit as a **synthetic assistant message**, not an error line:

```json
{ "type": "assistant",
  "message": { "role": "assistant",
    "content": [{ "type": "text", "text": "You've hit your limit · resets 8:50am (Australia/Melbourne)" }] },
  "error": "rate_limit", "isApiErrorMessage": true, "apiErrorStatus": 429 }
```

`detectErrorInTranscriptLine` only recognised `type:"api_error"` / `type:"error"` lines or a nested error **object**. This shape has neither — `error` is a bare string — so detection returned `null`. The operator-event path never ran, `fireFleetAutoFallback` was never reached. The fallback machinery is fine; it just never got the signal. Same bug class as the `docker exec --` drift.

It's **fleet-wide** — no agent on the current Claude version auto-fails-over on a usage-limit hit.

## Fix

- **`session-tail.ts`** — `detectErrorInTranscriptLine` now detects the `isApiErrorMessage:true` shape, pulls the user-facing text from `message.content[].text`, and classifies a 429 in this shape as `quota-exhausted` (a subscription usage-limit hit carries a reset time) — so `resolveModelUnavailableFromOperatorEvent` resolves it to an auto-fallback-eligible kind and `fireFleetAutoFallback` runs.
- **`model-unavailable.ts`** — adds `"hit your limit"` / `"hit the limit"` to the quota text signals, so the model-unavailable card + the text-pattern path classify the new wording as `quota_exhausted`.
- **Regression tests** pinned to the exact on-disk line shape (and the new wording), so the next Claude format drift fails loud at test time.

## Why

Vision outcome **subscription-honest and predictable** — auto-failover across the Max-account pool is the mechanism that keeps the fleet running on the subscription when one account hits a window limit. With it dead, a quota hit takes an agent down until manual intervention.

## Test plan

- [x] `operator-events-session-tail.test.ts` + `model-unavailable.test.ts` — 52 pass, incl. 3 new tests pinning the v2.1.x shape.
- [x] `node scripts/build.mjs` clean.
- [ ] Canary: confirm a real quota hit triggers fleet auto-fallback.

## Risk

Low. Additive detection — a new branch for a shape that currently falls through to `null`; the existing `api_error`/`error`/nested-object paths are untouched (regression test confirms a normal assistant message still returns `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)