### PR TITLE
chore: release v0.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.13.7 — auto-failover detects the new Claude usage-limit shape
+
+### fix(auth) — quota-exhaustion detection for Claude v2.1.x (#1642)
+
+Account auto-failover was dead fleet-wide: an agent that hit its Claude
+subscription quota surfaced *"You've hit your limit · resets …"* and
+stopped — never rotating to a healthy account, even with others
+available in `fallback_order`. Claude Code v2.1.x records a usage-limit
+hit as a *synthetic assistant message* (`isApiErrorMessage: true`,
+`apiErrorStatus: 429`), not the `api_error` line shape the detector
+recognised — so the exhaustion signal never reached the fleet
+auto-fallback path and `fireFleetAutoFallback` was never called. The
+detector now catches the new shape and classifies a 429 in it as
+quota-exhausted; the model-unavailable text signals learn the new
+"hit your limit" wording. Regression tests are pinned to the exact
+on-disk line shape so the next Claude format drift fails loud.
+
 ## v0.13.6 — a typing indicator for the whole turn
 
 Headline: the agent now shows `typing…` for the *entire* turn, not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release **v0.13.7** — auto-failover detects the new Claude usage-limit shape.

The convergence release: brings the **continuous typing indicator** (v0.13.6, #1638) *and* the **auto-failover fix** (#1642) to the fleet in one staggered rollout. The fleet is currently on v0.13.4.

## Contents (since v0.13.4)

- **fix(auth)** — quota-exhaustion detection for Claude v2.1.x (#1642). Auto-failover was dead fleet-wide; the detector now catches the synthetic-assistant-message usage-limit shape.
- **feat(telegram)** — continuous `typing…` indicator for the whole turn (#1638).
- **hostd** — `config_propose_edit` skeleton, flag-gated, no behaviour change (#1637, #1640).

## Test plan

- [x] CI required checks.
- [ ] Tag → docker-images.
- [ ] Staggered fleet rollout, test-harness first.

Constituent PRs reviewed + merged independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)