### PR TITLE
docker: bump agent /tmp tmpfs to 1GB default (keep noexec)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1318,7 +1318,7 @@ function emitAgentService(
   // RAM-backed and capped so a runaway can't fill the host disk.
   lines.push(`    read_only: true`);
   lines.push(`    tmpfs:`);
-  lines.push(`      - /tmp:size=256m,mode=1777`);
+  lines.push(`      - /tmp:size=1g,mode=1777`);
   lines.push(`    depends_on:`);
   lines.push(`      vault-broker:`);
   lines.push(`        condition: service_started`);

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -657,7 +657,7 @@ describe("generateCompose", () => {
       expect(block, `agent-${name} security_opt`).toContain('no-new-privileges:true');
       expect(block, `agent-${name} cap_drop`).toMatch(/cap_drop:\s*\n\s*-\s*"ALL"/);
       expect(block, `agent-${name} read_only`).toContain("read_only: true");
-      expect(block, `agent-${name} tmpfs`).toContain("/tmp:size=256m");
+      expect(block, `agent-${name} tmpfs`).toContain("/tmp:size=1g");
     }
   });
 


### PR DESCRIPTION
## Summary

Bumps the default tmpfs size for switchroom agent containers from 256MB to 1GB. Long worker sessions on the 256MB cap were filling `/tmp` during sub-agent dispatches (caught live while running this PR's own test suite — `df /tmp` reported 255M/256M used, ENOSPC across 444 test files).

`noexec` is intentionally NOT changed — it stays as deliberate sandbox hardening. Tests or tools that need an executable scratch dir should set `TMPDIR=/state/agent/tmp` or use a repo-local scratch path instead.

## Changes

- `src/agents/compose.ts`: `/tmp:size=256m,mode=1777` → `/tmp:size=1g,mode=1777`
- `tests/docker/compose-generator.test.ts`: assertion updated to match

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `tests/docker/compose-generator.test.ts` + `tests/memory.test.ts` green (161 passed)
- [ ] Pre-existing test failures unrelated to this change (missing `dist/cli/switchroom.js` — needs `npm run build` first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)