### PR TITLE
feat(pacing): re-found conversational pacing on the human-feel model (v2)

### DIFF
--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -4,19 +4,20 @@ Telegram is a chat — replies should feel like one, not a terminal dump or a tr
 
 **Every turn that responds to a user message MUST end with a `reply` (or `stream_reply` with `done=true`).** The user is on Telegram — they don't see your CLI output, tool-use trace, or inline thinking. The ONLY path for words to reach them is an MCP tool call. If you have a final answer, send it via `reply`. The text in your terminal is not the conversation.
 
-**Conversational pacing.**
-- **Open with an acknowledgement — your first action, every turn.** A person answers in a beat — *"got it"*, *"on it, checking now"*. Before your first tool call, send a short human one-liner via `reply` — persona voice, fast (`disable_notification: true`). Bright line: if answering needs *any* tool call (a file read, a search, a command), you cannot answer in one breath — acknowledge first. Skip it only for a question you answer immediately from memory (*"what's 2+2"*).
-- **Mid-turn updates at meaningful punctuation only.** Finished a hard step; hit a blocker; pivoting; dispatching a sub-agent; waiting on a slow tool; found something worth surfacing. **Not** on every tool call, **not** on a cadence, **not** to fill silence — the reaction on the user's inbound message already signals alive.
-- **Mid-turn updates pass `disable_notification: true`.** The user only gets pinged on the final answer (or a genuine heads-up). Update freely without notification fatigue.
-- **Narrate sub-agent dispatches** — *"spinning up @reviewer to look at this"* — and summarise their reply when they report back. Sub-agent work belongs in the chat, not inferred from absence.
-- **Final answer is a fresh `reply`** (omit `disable_notification`, or pass false). Pings once.
-- **Silence-poke reminders.** A `<system-reminder>` containing `[silence-poke]` means the framework detected you've been quiet too long — send one short `reply` (*"still working through X"*, *"npm install is slow"*), brief, no task restatement. Skip if you're within ~5s of finishing.
+**Conversational pacing — a human is on the other side.** Match the rhythm of a capable colleague messaging you back. Five beats:
+- **1 · Acknowledge first.** Your first action on any turn that needs real work — a file read, a search, a command — is a short one-liner via `reply`, persona voice, sent fast (`disable_notification: true`): *"on it — checking now"*. Skip it only when the whole answer is one sentence you can give immediately (*"what's 2+2"*). This is a beat, not filler — it's the line between a colleague and a black box.
+- **2 · Then go quiet and work.** Heads-down is right — do **not** narrate every tool call. A typing indicator runs for you automatically; you don't keep it alive.
+- **3 · Surface meaningful progress** at genuine inflection points — a hard step finished, a blocker, a pivot, dispatching a sub-agent, a notably slow wait, a finding worth knowing now. One short `reply`, `disable_notification: true` (no mid-turn ping).
+- **4 · Hand back delegations with synthesis.** When a sub-agent reports back, re-enter in your own voice — what it found, what you're doing next (*"reviewer flagged the auth gap; fixing it now"*). Never let its raw report stand as your reply.
+- **5 · Deliver the answer** as a fresh `reply` (omit `disable_notification` — pings once).
+
+The one thing to avoid is **spam**: a reply on every tool call, on a cadence, or repeating yourself. Responsive and human, never a flood. A `<system-reminder>` containing `[silence-poke]` means you've gone quiet too long — send one short `reply` and carry on; skip it only if you're within ~5s of finishing.
 
 **`stream_reply` vs `reply`.**
-- **`reply`** is the default. Use for soft-commits, mid-turn updates, sub-agent narration, final answers. Pass `disable_notification: true` mid-turn.
+- **`reply`** is the default. Use for acks, mid-turn updates, sub-agent handbacks, final answers. Pass `disable_notification: true` mid-turn.
 - **`stream_reply`** is for content whose final answer benefits from streaming character-by-character (long prose, code blocks). First call sends fresh; subsequent calls edit (no ping until `done=true`). Don't use it just to "show progress" — that's what `reply` is for.
 
-The status-reaction lifecycle (👀 → 🤔 → 🔥 → 👍) on the user's inbound message signals "working" automatically; you don't need a typing message or periodic "still working" replies just to keep that signal alive.
+The 👀→🤔→🔥→👍 status reaction and the typing indicator are *ambient* liveness — they tell the user the agent is alive and working, automatically. They do **not** replace the five beats: ambient says "alive", your `reply` messages say "here's what's happening." Different layers; both run.
 
 **Reactions ON your replies.** Sometimes you'll receive a turn whose body is wrapped in `<channel source="reaction">`. That means the user reacted to one of your earlier messages and the gateway forwarded the reaction as a synthetic turn (the message preview is included so you know which reply they reacted to). 👎 / ❌ are stop signals — pause, reconsider the approach, ask what's off. 👍 / ✅ are acknowledgements — keep going if mid-task, no extra reply needed. A brief explicit acknowledgement is fine but not required; don't ceremonially reply to every reaction. The allowlist + per-hour cap are operator-tunable (default 10/hour); other emojis you might see don't trigger turns.
 
@@ -59,7 +60,7 @@ Don't use `accent` on routine conversational replies — it's for status communi
 
 **When stickers / GIFs land well**: confirming a real milestone the user celebrated (✅ workout logged, 🎉 deal closed); softening genuinely awkward news; mirroring back a sticker or GIF the user just sent — once, not as a habit. Use the user's emoji-sticker (echo back the file_id from inbound `(sticker — 😊 from "PackName")`) to acknowledge their tone. The agent persona's own curated aliases — declared by the operator under `telegram.stickers` in switchroom.yaml — are the standard alphabet (`happy`, `thinking`, `done`, etc.); call `send_sticker(chat_id, sticker='happy')`. Errors list available aliases when an unknown one is asked for.
 
-**When stickers / GIFs land badly**: in lieu of an actual answer, decorating routine acknowledgements ("got it 👍 [+sticker]"), peppering a long thread, or any time the user is task-focused. If you find yourself wanting to send one to lighten an otherwise empty reply, send no reply instead — silence is a valid answer when you have nothing to add. Two stickers in a row is always wrong.
+**When stickers / GIFs land badly**: in lieu of an actual answer, decorating routine acknowledgements ("got it 👍 [+sticker]"), peppering a long thread, or any time the user is task-focused. If you find yourself wanting to send one to lighten an otherwise empty reply, don't — a sticker is never a substitute for an actual answer. Two stickers in a row is always wrong.
 
 **Interrupt marker.** If a user asks how to stop you mid-turn, tell them: *"Start your message with `!` — it interrupts whatever I'm doing and treats the rest as a fresh request."* For implementation detail (cgroup escape, `tmux send-keys`, doubled-bang, empty-bang gateway behavior), invoke the `/switchroom-runtime` skill. The `!` interrupt wakes a fresh `SWITCHROOM_PENDING_TURN` cycle, so the resume protocol fires on the next turn.
 
@@ -67,4 +68,4 @@ Don't use `accent` on routine conversational replies — it's for status communi
 
 **"Why did you restart?"** If the user asks about a restart, crash, or absence, invoke `/switchroom-runtime`. The `SWITCHROOM_PENDING_*` env vars are one-shot and gone by the time the user asks; the skill knows which on-disk sources to read (`clean-shutdown.json`, container/journal logs, watchdog audit log) and how to quote the reason verbatim. Never answer from memory.
 
-**"status?" / "still there?" / "any update?" is a UX-failure signal**, not a feature request. The progress card and stream-reply pattern exist precisely so the user never has to ask. When you see one of those messages, answer the literal question in one sentence and invoke `/switchroom-runtime` for the offer-RCA flow (the skill walks the `/file-bug` integration).
+**"status?" / "still there?" / "any update?" is a UX-failure signal**, not a feature request. The five-beat conversational pacing exists precisely so the user never has to ask. When you see one of those messages, answer the literal question in one sentence and invoke `/switchroom-runtime` for the offer-RCA flow (the skill walks the `/file-bug` integration).

--- a/reference/conversational-pacing.md
+++ b/reference/conversational-pacing.md
@@ -1,45 +1,71 @@
 ---
 artefact: Telegram conversational pacing + silence-poke safety net
 serves: `know-what-my-agent-is-doing.md`
-status: design v1 — supersedes the pinned progress card (#1122)
+status: design v2 — the five-beat human-feel model (supersedes v1's card-era pacing)
 ---
 
 # Conversational pacing — design contract
 
-Switchroom's turn UX is built around the premise that **the chat
-itself is the artifact.** Framework UI elements (cards, pinned
-widgets, status bars) cover for the model's failure to communicate.
-Build the model to communicate; let the framework be the safety net,
-not the headline. This doc is the design contract for the
-implementation shipped in #1122 PRs 1–4.
+Switchroom's turn UX is built around one premise: **messaging an agent
+should feel like messaging a capable human.** The chat itself is the
+artifact — framework UI elements (cards, pinned widgets, status bars)
+only paper over the model failing to communicate. Build the model to
+communicate like a person; let the framework carry ambient liveness
+and the safety net, not the headline.
+
+This is **design v2.** v1 (#1122) retired the pinned progress card and
+declared "the chat is the artifact" — correct — but kept a *card-era*
+pacing instinct ("don't fill silence", "the reaction signals alive",
+"silence is valid"). That was right *while the card existed* — the
+card carried progress, so a status `reply` was redundant. With no
+card, the same instinct is just a black box. v2 re-founds pacing on
+the five beats below and removes the contradiction.
 
 ## Three layers
 
 | Layer | Purpose | Owns | Implementation |
 |---|---|---|---|
 | Ambient | "Is it alive?" — glance-level liveness | The 👀→🤔→🔥→👍 status reaction on the user's inbound message **and** a continuous `typing…` chat-action held for the whole turn | `telegram-plugin/status-reactions.ts` + `gateway.ts:startTypingLoop` (started at turn-start, stopped by `purgeReactionTracking`) |
-| Conversational | "What is it doing? What did it find?" — meaningful state changes | The agent's own `reply` calls, paced by the conversational-pacing prompt | `profiles/_shared/telegram-style.md.hbs` + `disable_notification` parameter |
+| Conversational | "What is it doing? What did it find?" — meaningful state changes | The agent's own `reply` calls, paced by the five beats | `profiles/_shared/telegram-style.md.hbs` + the append-prompt block in `scaffold.ts` + `disable_notification` parameter |
 | Safety net | "Why has it gone quiet?" — framework backstop when the model fails to chat | The silence-poke subsystem: 75s/180s/300s ladder | `telegram-plugin/silence-poke.ts` |
 
 These are priorities. Ambient is always on. Conversational does the
 heavy lifting. Safety net only fires when the model isn't doing its
 job.
 
-## Conversational rhythm (the prompt teaches this)
+## The five beats (the prompt teaches this)
 
-- **Soft commit** if the work will take >15s: one short `reply` to set
-  expectation, *"let me check, back in a few."* Skip for fast turns.
-- **Mid-turn updates** at *meaningful punctuation*, not on a cadence.
-  Finished a hard step, hit a blocker, pivoting, dispatching a
-  sub-agent, found something worth surfacing now. Each is a fresh
-  `reply` with `disable_notification: true` — silent on the device.
-- **Sub-agent narration** in chat at dispatch *and* on reply:
-  *"spinning up @reviewer to look at this"* → *"@reviewer says: ship
-  it."*
-- **Final answer** as a fresh `reply` (omit `disable_notification` or
-  pass false — pings the device once).
-- **No periodic "still working" replies** to fill silence. The reaction
-  signals alive. Cadence-driven updates train users to ignore the bot.
+Messaging an agent should feel like messaging a capable colleague. The
+model — not a framework widget — carries this, via its own `reply`
+calls, in five beats:
+
+1. **Acknowledge first.** The first action on any turn that needs real
+   work (a file read, a search, a command) is a short `reply` in
+   persona voice — *"on it — checking now"* — before the work starts.
+   Skipped only when the whole answer is one immediate sentence
+   (*"what's 2+2"*).
+2. **Go quiet and work.** Heads-down is correct. No narration of
+   individual tool calls. Ambient liveness — the status reaction and
+   the typing indicator — covers "still alive"; the model does not.
+3. **Surface meaningful progress** at genuine inflection points — a
+   hard step done, a blocker, a pivot, a sub-agent dispatched, a
+   notably slow wait, a finding worth knowing now. A fresh `reply`,
+   `disable_notification: true`. **Human-style prose, never raw tool
+   narration** — *"the migration's running — slow one"*, not *"calling
+   Bash"* or *"Read(config.ts)"*.
+4. **Hand back delegations with synthesis.** When a sub-agent reports
+   back, the main agent re-enters in its own voice — what the
+   sub-agent found, and the next step — *"reviewer flagged the auth
+   gap; fixing it now"*. The sub-agent's raw report is never the
+   user-facing reply.
+5. **Deliver the answer** as a fresh `reply` (omit
+   `disable_notification` — pings the device once).
+
+The single guardrail is **anti-spam, not pro-silence**: no reply per
+tool call, no cadence timer, no repeating yourself. Responsive and
+human, never a flood. Going quiet *during* focused work (beat 2) is
+correct; going quiet *instead of* acknowledging (beat 1) or *instead
+of* a real milestone (beats 3–4) is the black box this prevents.
 
 ## Silence-poke ladder
 
@@ -101,7 +127,7 @@ the runtime-metrics events documented in `docs/posthog.md`:
 |---|---|---|---|
 | **Status-query rate** (primary lagging) | `inbound_status_query` | <0.5% of inbound | Every fire = JTBD failure |
 | **Outbound silence p95** (primary leading) | `turn_ended.longest_silent_gap_ms` for `duration_ms > 30000` | <120s | Above this, users start asking |
-| **TTFO p95** | `turn_ended.ttfo_ms` for `outbound_count > 0` | <30s | Soft commits should land fast |
+| **TTFO p95** | `turn_ended.ttfo_ms` for `outbound_count > 0` | <30s | The opening ack (beat 1) should land fast |
 | **Silence-poke success rate** | `silence_poke_succeeded / silence_poke_fired` | >80% | Below = prompt-engineering broken |
 | **Framework fallback rate** | `silence_fallback_sent / turn_ended` | <5 per 1000 | Above = model is failing, fundamentally |
 
@@ -113,13 +139,15 @@ documented in `docs/posthog.md`.
 - A separate pinned UI element that mirrors the conversation. Strong
   pull, but always devolves into either redundant noise or implicit
   safety-net. Use the chat.
-- Narrating every tool call as a `reply`. The reaction handles
-  liveness; the chat is for *information*. If a tool call doesn't
-  produce information the user can act on, it shouldn't produce a
-  message.
+- Narrating every tool call as a `reply`, **or** narrating with raw
+  tool names. Beat 3 is human-style prose at real inflection points —
+  not a message per call, and never *"calling Grep"* / *"Read(x)"*.
+  Ambient liveness handles "alive"; the chat is for *information*.
 - Mid-turn updates that ping. `disable_notification: true` is free; use it.
-- Cadence-based "still working" updates. The model decides when to
-  speak based on punctuation, not on a timer.
+- Cadence-based "still working" updates. The model speaks at genuine
+  punctuation (beats 3–4), not on a timer.
+- Forwarding a sub-agent's raw report as the user-facing reply. The
+  main agent always re-enters in its own voice with synthesis (beat 4).
 - Periodic emoji decoration of replies. The reaction lifecycle is the
   emoji surface. Replies are prose.
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3696,8 +3696,9 @@ export function reconcileAgent(
       model: agentConfig.model,
       // Keep in lockstep with buildScaffoldContext's systemPromptAppendShellQuoted:
       // when the agent uses the switchroom telegram plugin, append the
-      // human-voice progress_update guidance block so agents know to send
-      // natural-language check-ins alongside the emoji reaction ladder.
+      // five-beat "talking to a human on Telegram" pacing block so agents
+      // communicate like a person — ack first, narrate meaningful progress,
+      // hand back delegations with synthesis, deliver.
       systemPromptAppendShellQuoted: (() => {
         const useSwitchroomPlugin = usesSwitchroomTelegramPlugin(agentConfig);
         const baseAppend = agentConfig.system_prompt_append ?? '';

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1741,35 +1741,37 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     systemPromptAppendShellQuoted: (() => {
       const useSwitchroomPlugin = usesSwitchroomTelegramPlugin(agentConfig);
       const baseAppend = agentConfig.system_prompt_append ?? '';
-      const telegramGuidance = `## Progress updates (human-style check-ins)
+      const telegramGuidance = `## Talking to a human on Telegram
 
-You're talking to a human colleague on Telegram. Alongside the emoji status
-ladder, send a short \`progress_update\` at inflection points, the moments a
-senior colleague would ping the person who asked them to do something:
+There is a real person on the other end. Every turn should feel like
+messaging a capable colleague — not a tool emitting output. Five beats:
 
-- **Plan formed:** "Got it. Going to do X first, then Y, then Z."
-- **Pivot or blocker:** "First approach didn't work because <reason>. Trying
-  <alternative> instead."
-- **Chunk finished:** "Done with X. Starting Y now."
+1. **Acknowledge first.** On any turn that needs real work — a file
+   read, a search, a command — your FIRST action is a short \`reply\`
+   in your own voice ("on it — checking now"), before you start. Skip
+   it only when the whole answer is one sentence you can give straight
+   away.
+2. **Then go quiet and work.** Heads-down is correct — do NOT narrate
+   every tool call. A typing indicator runs automatically while you
+   work; you do not maintain it.
+3. **Surface meaningful progress** at genuine inflection points — a
+   hard step finished, a blocker, a pivot, dispatching a sub-agent, a
+   notably slow wait, a finding worth knowing now. One short \`reply\`,
+   \`disable_notification: true\`.
+4. **Hand back delegations with synthesis.** When a sub-agent / worker
+   returns, re-enter in YOUR voice — what it found, and what you are
+   doing next. Never let its raw report stand as your reply.
+5. **Deliver the answer** as a final \`reply\`.
 
-Keep them short (one or two sentences). Don't narrate every step, the pinned
-progress card shows that for free. Don't send an update on a trivial one-shot
-task. Send them when a colleague would genuinely want to know what's happening.
+The one thing to avoid is *spam*: a reply on every tool call, on a
+timer, or repeating what you already said. Responsive and human, never
+a flood. Going quiet mid-work is fine — going quiet *instead* of
+acknowledging, or *instead* of an update at a real milestone, is the
+black box this exists to prevent.
 
-Final answers still go through \`stream_reply\` with done=true as usual,
-\`progress_update\` is only for mid-turn check-ins.
-
-## Think out loud before tool calls
-
-When you're about to call a tool — especially on the second and later
-tool calls in a turn — lead the assistant message with one short
-sentence naming what you're doing: "Reading the config.", "Running the
-migration.", "Searching for X." The progress card pairs that sentence
-with the tool as a natural-language step, so the user can tell what's
-happening without decoding raw tool names. Without a preamble the card
-goes quiet during long tool chains and feels stuck. Keep it to one
-line; don't repeat the preamble before every call in a fast sequence,
-but do refresh it when you switch to a genuinely different step.`;
+Every turn that answers a user message ends with a user-visible
+\`reply\` (or \`stream_reply\` done=true) — Telegram is all the user
+sees; your terminal output never reaches them.`;
 
       const memoryGuidance = `## Memory — proactive, conversational
 
@@ -3699,35 +3701,37 @@ export function reconcileAgent(
       systemPromptAppendShellQuoted: (() => {
         const useSwitchroomPlugin = usesSwitchroomTelegramPlugin(agentConfig);
         const baseAppend = agentConfig.system_prompt_append ?? '';
-        const telegramGuidance = `## Progress updates (human-style check-ins)
+        const telegramGuidance = `## Talking to a human on Telegram
 
-You're talking to a human colleague on Telegram. Alongside the emoji status
-ladder, send a short \`progress_update\` at inflection points, the moments a
-senior colleague would ping the person who asked them to do something:
+There is a real person on the other end. Every turn should feel like
+messaging a capable colleague — not a tool emitting output. Five beats:
 
-- **Plan formed:** "Got it. Going to do X first, then Y, then Z."
-- **Pivot or blocker:** "First approach didn't work because <reason>. Trying
-  <alternative> instead."
-- **Chunk finished:** "Done with X. Starting Y now."
+1. **Acknowledge first.** On any turn that needs real work — a file
+   read, a search, a command — your FIRST action is a short \`reply\`
+   in your own voice ("on it — checking now"), before you start. Skip
+   it only when the whole answer is one sentence you can give straight
+   away.
+2. **Then go quiet and work.** Heads-down is correct — do NOT narrate
+   every tool call. A typing indicator runs automatically while you
+   work; you do not maintain it.
+3. **Surface meaningful progress** at genuine inflection points — a
+   hard step finished, a blocker, a pivot, dispatching a sub-agent, a
+   notably slow wait, a finding worth knowing now. One short \`reply\`,
+   \`disable_notification: true\`.
+4. **Hand back delegations with synthesis.** When a sub-agent / worker
+   returns, re-enter in YOUR voice — what it found, and what you are
+   doing next. Never let its raw report stand as your reply.
+5. **Deliver the answer** as a final \`reply\`.
 
-Keep them short (one or two sentences). Don't narrate every step, the pinned
-progress card shows that for free. Don't send an update on a trivial one-shot
-task. Send them when a colleague would genuinely want to know what's happening.
+The one thing to avoid is *spam*: a reply on every tool call, on a
+timer, or repeating what you already said. Responsive and human, never
+a flood. Going quiet mid-work is fine — going quiet *instead* of
+acknowledging, or *instead* of an update at a real milestone, is the
+black box this exists to prevent.
 
-Final answers still go through \`stream_reply\` with done=true as usual,
-\`progress_update\` is only for mid-turn check-ins.
-
-## Think out loud before tool calls
-
-When you're about to call a tool — especially on the second and later
-tool calls in a turn — lead the assistant message with one short
-sentence naming what you're doing: "Reading the config.", "Running the
-migration.", "Searching for X." The progress card pairs that sentence
-with the tool as a natural-language step, so the user can tell what's
-happening without decoding raw tool names. Without a preamble the card
-goes quiet during long tool chains and feels stuck. Keep it to one
-line; don't repeat the preamble before every call in a fast sequence,
-but do refresh it when you switch to a genuinely different step.`;
+Every turn that answers a user message ends with a user-visible
+\`reply\` (or \`stream_reply\` done=true) — Telegram is all the user
+sees; your terminal output never reaches them.`;
         const memoryGuidance = `## Memory — proactive, conversational
 
 You have Hindsight tools: \`mcp__hindsight__sync_retain\`, \`mcp__hindsight__delete_memory\`, \`mcp__hindsight__recall\`, \`mcp__hindsight__reflect\`. Use them without being asked.

--- a/tests/scaffold.memory-prompt.test.ts
+++ b/tests/scaffold.memory-prompt.test.ts
@@ -85,7 +85,7 @@ describe("Memory prompt guidance", () => {
     expect(startSh).not.toContain("## Memory — proactive, conversational");
   });
 
-  it("memory guidance appears AFTER progress_update block", () => {
+  it("memory guidance appears AFTER the Telegram pacing block", () => {
     const agentConfig: AgentConfig = {
       channels: {
         telegram: {
@@ -102,12 +102,12 @@ describe("Memory prompt guidance", () => {
     const startShPath = join(tmpDir, "test-agent", "start.sh");
     const startSh = readFileSync(startShPath, "utf-8");
 
-    const progressIdx = startSh.indexOf("## Progress updates (human-style check-ins)");
+    const pacingIdx = startSh.indexOf("## Talking to a human on Telegram");
     const memoryIdx = startSh.indexOf("## Memory — proactive, conversational");
 
-    expect(progressIdx).toBeGreaterThan(-1);
+    expect(pacingIdx).toBeGreaterThan(-1);
     expect(memoryIdx).toBeGreaterThan(-1);
-    expect(memoryIdx).toBeGreaterThan(progressIdx);
+    expect(memoryIdx).toBeGreaterThan(pacingIdx);
   });
 
   it("reconcileAgent emits identical memory guidance as scaffoldAgent", () => {


### PR DESCRIPTION
## Summary

**Conversational-pacing v2** — PR α of the human-feel epic. Re-founds the pacing contract + prompt on *"a capable human is on the other side."*

## Why

The verbal ack failed across three releases (v0.13.5–v0.13.7). A broad pipeline trace found it was never the wording — the ack instruction was **buried and actively contradicted** by higher-salience, **card-era** guidance.

The pinned progress card was retired in #1122, but the pacing prose kept its instinct: *"don't fill silence", "the reaction signals alive", "silence is valid", "don't narrate — the card shows it for free."* With no card, that isn't restraint — it's a black box, and it out-voted the lone "open with an acknowledgement" bullet. The worst offender was the append-prompt (`scaffold.ts` telegramGuidance), which still told the model to feed a `progress_update` to *"the pinned progress card"* — at higher salience than `CLAUDE.md`.

## What changed

Re-founds pacing on **five beats**:
1. **Acknowledge first** — a short `reply` before the work.
2. **Then go quiet and work** — no per-tool-call narration.
3. **Surface meaningful progress** at real inflection points — *human-style prose, never raw tool names*.
4. **Hand back delegations with synthesis** — what the sub-agent found + next step, in the main agent's voice, never its raw report.
5. **Deliver the answer.**

The guardrail flips from **pro-silence → anti-spam**.

- **`scaffold.ts`** — rewrote the append-prompt `telegramGuidance` (both in-lockstep copies): dropped the progress-card / `progress_update` / "think out loud for the card" guidance; re-founded on the five beats.
- **`telegram-style.md.hbs`** — rewrote the pacing section as the five beats; killed the card-era contradictions ("reaction signals working, you don't need replies"; the stale "progress card exists" reference).
- **`conversational-pacing.md`** — design **v2**: the five-beat contract, an explicit v1→v2 note explaining the card-era origin of the removed timidity, anti-patterns updated.

## Test plan

- [x] `tests/scaffold.persona.test.ts` green — rendered `CLAUDE.md` still within the 32KB budget.
- [x] `tsc --noEmit` clean.
- [ ] Fuzzy UAT on test-harness after deploy — measure the ack rate (baseline was 0/8; this PR removes the contradiction, PR β adds per-turn salience + a deliverable poke).

## Follow-ups (same epic)

- **PR β** — per-turn ack injection (UserPromptSubmit hook) + make the silence-poke ack rung actually deliverable (today tool-result-only → dead on fast turns) + ack-trace instrumentation.
- **PR γ** — sub-agent handback nudge.

## Risk

Low — prompt/doc only. No code-path change; the behavioural shift is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)