### PR TITLE
feat(pacing): per-turn ack directive via UserPromptSubmit hook (v2 PR β)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3338,6 +3338,20 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
 
   // --- Switchroom-owned UserPromptSubmit hooks ---
   const useHotReloadStable = agentConfig.channels?.telegram?.hotReloadStable === true;
+  // Per-turn pacing directive (conversational-pacing v2). Injected
+  // adjacent to the user's message every turn so "acknowledge first"
+  // is salient AT TURN TIME — not one buried sub-bullet in a 32KB
+  // CLAUDE.md the model has to recall. This is the load-bearing fix:
+  // a UserPromptSubmit hook's stdout lands right next to the prompt.
+  const turnPacingDirective =
+    '<turn-pacing>You are messaging a human. First action this turn: if ' +
+    'answering needs any tool call (a file read, a search, a command), ' +
+    'send a SHORT acknowledgement via the reply tool with ' +
+    'disable_notification true BEFORE the first tool call. Then work; ' +
+    'surface meaningful progress in human prose at real milestones; hand ' +
+    'back any sub-agent findings in your own voice; deliver the answer. ' +
+    'Skip the opening ack only for a one-sentence answer you can give ' +
+    'immediately.</turn-pacing>';
   const switchroomUserPromptSubmit: Array<Record<string, unknown>> = [
     ...(useHotReloadStable
       ? [
@@ -3374,6 +3388,21 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           command: wrap(
             "hook:timezone",
             `bash "${join(DOCKER_BIN_PATH, "timezone-hook.sh")}"`,
+          ),
+          timeout: 3,
+        },
+      ],
+    },
+    {
+      hooks: [
+        {
+          type: "command",
+          // Emits the per-turn pacing directive (above) — its stdout is
+          // injected adjacent to the user's message. Static string; an
+          // inline `printf` avoids a baked-in hook script.
+          command: wrap(
+            "hook:turn-pacing",
+            `printf '%s\\n' ${shellSingleQuote(turnPacingDirective)}`,
           ),
           timeout: 3,
         },

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2130,9 +2130,11 @@ describe("scaffoldAgent with global defaults cascade", () => {
     );
 
     // Native Claude Code nested shape. User's UserPromptSubmit hook +
-    // switchroom-owned workspace-dynamic and timezone hooks (always
-    // injected; the dynamic injects per-turn workspace files, the
-    // timezone hook emits a one-line local-time additionalContext).
+    // switchroom-owned workspace-dynamic, timezone, and turn-pacing
+    // hooks (always injected; the dynamic injects per-turn workspace
+    // files, the timezone hook emits a one-line local-time
+    // additionalContext, the turn-pacing hook emits the per-turn
+    // conversational-pacing directive).
     expect(settings.hooks.UserPromptSubmit).toEqual([
       {
         hooks: [
@@ -2153,6 +2155,15 @@ describe("scaffoldAgent with global defaults cascade", () => {
           {
             type: "command",
             command: expect.stringContaining("timezone-hook.sh"),
+            timeout: 3,
+          },
+        ],
+      },
+      {
+        hooks: [
+          {
+            type: "command",
+            command: expect.stringContaining("turn-pacing"),
             timeout: 3,
           },
         ],


### PR DESCRIPTION
## Summary

PR β of **conversational-pacing v2**. PR α (#1645, merged) re-founded the contract and removed the card-era contradictions. This PR makes the "acknowledge first" instruction **salient at turn time**.

## Why

The root-cause trace found the ack rule was one sub-bullet inside a 32KB `CLAUDE.md` — far from the actual user turn, with nothing reasserting it when the model acts. Removing the contradiction (α) is necessary but not sufficient: the model still has to *recall* a buried instruction.

## What changed

A new switchroom-owned **UserPromptSubmit hook** emits a short `<turn-pacing>` directive whose stdout lands **adjacent to every user message**: acknowledge first (a short `reply` before the first tool call), narrate meaningful progress in human prose, hand back sub-agent findings in your own voice, deliver.

- `scaffold.ts` — adds the hook (a `turnPacingDirective` const + a fourth `UserPromptSubmit` entry, alongside workspace-dynamic / timezone). Static directive, inline `printf` — no baked-in hook script, no Dockerfile change.
- `scaffold.test.ts` — the hook-array test updated for the new entry.

## Deliberately deferred

The silence-poke ack-rung deliverability fix (today the poke can only ride a tool result → dead on fast turns) needs key-aware `consumeArmedPoke` surgery and is a *backstop*. The fuzzy UAT on test-harness will show whether the hook + the v2 prompt already carry the ack reliably; the poke is built only if the data says it's needed. Data-driven, and avoids rushing risky silence-poke surgery.

## Test plan

- [x] `tsc --noEmit` clean; 176 scaffold tests pass.
- [ ] Fuzzy UAT on test-harness (the `jtbd-fast-ack-dm` 8-shape scenario) — measure the ack rate vs the 0/8 baseline.

## Risk

Low — additive. A new UserPromptSubmit hook emitting a static string; no existing code path changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)