### PR TITLE
fix(gateway): stop logging anonymous IPC disconnects as bridge flaps

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3438,11 +3438,15 @@ const ipcServer: IpcServer = createIpcServer({
   },
 
   onClientDisconnected(client: IpcClient) {
-    process.stderr.write(`telegram gateway: bridge disconnected — agent=${client.agentName}\n`)
-    // Phase 2b shadow: ONLY emit bridgeDown for the REAL bridge sidecar
-    // (matching the bridgeUp gate above). Anonymous IPC clients
-    // disconnect frequently — those are not bridge flaps.
+    // ONLY log "bridge disconnected" + emit bridgeDown for the REAL
+    // bridge sidecar (matching the bridgeUp gate above). Anonymous IPC
+    // clients — e.g. recall.py's one-shot legacy update_placeholder
+    // handshake — connect and disconnect constantly with agentName=null;
+    // logging those as "bridge disconnected — agent=null" reads as a
+    // bridge flap in the supervisor log when nothing flapped. The
+    // anonymous disconnect is still traced by disconnect-flush.ts.
     if (client.agentName != null) {
+      process.stderr.write(`telegram gateway: bridge disconnected — agent=${client.agentName}\n`)
       shadowEmit({ kind: 'bridgeDown', at: Date.now() })
     }
 


### PR DESCRIPTION
## Summary

`onClientDisconnected` logged `telegram gateway: bridge disconnected — agent=<name>` for **every** client disconnect. Anonymous IPC clients — `recall.py`'s one-shot legacy `update_placeholder` handshake and similar short-lived connections — disconnect constantly with `agentName=null`, producing a stream of `bridge disconnected — agent=null` lines (twice per turn in normal operation). In the supervisor log it reads as a bridge flap when nothing flapped.

## Why

Surfaced while triaging a v0.13.9 fleet UAT: the gateway log looked like it was flapping on every turn. It wasn't — turns completed cleanly; the lines were anonymous one-shot IPC clients. Misleading noise that masks real flaps.

The `bridgeDown` shadow emit immediately below this log line **already** gated on `client.agentName != null` for exactly this reason ("ONLY emit bridgeDown for the REAL bridge sidecar"). The log line just didn't share the gate.

## Fix

Move the `bridge disconnected` log inside the existing `if (client.agentName != null)` block. It now fires only for the real bridge sidecar. Anonymous disconnects stay traceable via `disconnect-flush.ts`'s `anonymous client disconnect` line.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `check-plugin-references.mjs` — clean
- [x] `check-bot-api-wrapping.sh` — clean (no allowlist drift from the line shift)

No new test: the change is log-output-only, and the gate condition is identical to the already-tested `bridgeDown` emit gate — there is no extractable unit to assert against without an integration harness disproportionate to a one-line log gate.

## Risk

Minimal — log output only, no control-flow or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)