### PR TITLE
test(pacing): extract + cover the sub-agent handback decision gate

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -281,7 +281,7 @@ import {
   buildVaultSaveFailedInbound,
   buildVaultSaveDiscardedInbound,
 } from './vault-grant-inbound-builders.js'
-import { buildSubagentHandbackInbound } from './subagent-handback-inbound-builder.js'
+import { decideSubagentHandback } from './subagent-handback-inbound-builder.js'
 import { createPollHealthCheck, type PollHealthCheckHandle } from './poll-health.js'
 import type {
   ToolCallMessage,
@@ -15063,22 +15063,24 @@ void (async () => {
               // need nothing here, and 'orphan' is a stale historical-at-
               // boot row, not a fresh completion the user is waiting on.
               onFinish: ({ agentId, outcome, description, resultText }) => {
-                if (process.env.SWITCHROOM_SUBAGENT_HANDBACK === '0') return
-                if (outcome !== 'completed' && outcome !== 'failed') return
-
-                let chatId = ''
+                // IO: resolve the fleet chat id and the background flag.
+                // The DECISION (gating + inbound build) is delegated to
+                // the pure `decideSubagentHandback` so it is unit-tested
+                // independent of the gateway — see
+                // `subagent-handback-decision.test.ts`.
+                let fleetChatId = ''
                 let isBackground = false
                 try {
                   const fleets = progressDriver?.peekAllFleets() ?? []
                   for (const f of fleets) {
                     if (f.fleet.has(agentId)) {
-                      chatId = f.chatId ?? ''
+                      fleetChatId = f.chatId ?? ''
                       break
                     }
                   }
                 } catch {
                   // peek failures are non-fatal — fall through to the
-                  // owner-chat fallback below.
+                  // owner-chat fallback inside decideSubagentHandback.
                 }
                 if (turnsDb != null) {
                   try {
@@ -15088,36 +15090,36 @@ void (async () => {
                     if (row != null) isBackground = row.background === 1
                   } catch { /* best-effort */ }
                 }
-                if (!isBackground) return
 
-                // chatId fallback: if the progress-driver fleet entry was
-                // already cleaned up by the time onFinish fires, route to
-                // the owner chat. Every switchroom fleet agent is
-                // DM-shaped, so allowFrom[0] is the conversation that
-                // dispatched the work.
-                const handbackChatId = chatId || (loadAccess().allowFrom[0] ?? '')
-                if (!handbackChatId) {
-                  process.stderr.write(
-                    `telegram gateway: subagent-handback ${agentId} — no chat to deliver to; skipped\n`,
-                  )
+                const decision = decideSubagentHandback({
+                  handbackEnvValue: process.env.SWITCHROOM_SUBAGENT_HANDBACK,
+                  outcome,
+                  isBackground,
+                  fleetChatId,
+                  // Owner-chat fallback: if the progress-driver fleet
+                  // entry was already cleaned up, route to the owner
+                  // chat. Every switchroom fleet agent is DM-shaped, so
+                  // allowFrom[0] is the conversation that dispatched.
+                  ownerChatId: loadAccess().allowFrom[0] ?? '',
+                  taskDescription: description,
+                  resultText,
+                })
+                if (!decision.deliver) {
+                  if (decision.reason === 'no-chat') {
+                    process.stderr.write(
+                      `telegram gateway: subagent-handback ${agentId} — no chat to deliver to; skipped\n`,
+                    )
+                  }
                   return
                 }
 
-                const inbound = buildSubagentHandbackInbound({
-                  ctx: {
-                    chatId: String(handbackChatId),
-                    taskDescription: description,
-                    resultText,
-                    outcome,
-                  },
-                })
                 // Deliver via pendingInboundBuffer + the idle-drain tick.
                 // The drain only releases at an idle prompt (no active
                 // turn), so the handback always lands as a clean fresh
                 // turn and never races a turn-in-flight composer (#1556).
-                pendingInboundBuffer.push(process.env.SWITCHROOM_AGENT_NAME ?? '', inbound)
+                pendingInboundBuffer.push(process.env.SWITCHROOM_AGENT_NAME ?? '', decision.inbound)
                 process.stderr.write(
-                  `telegram gateway: subagent-handback queued agent=${agentId} outcome=${outcome} chat=${handbackChatId} resultChars=${resultText.length}\n`,
+                  `telegram gateway: subagent-handback queued agent=${agentId} outcome=${outcome} chat=${decision.chatId} resultChars=${resultText.length}\n`,
                 )
               },
             })

--- a/telegram-plugin/gateway/subagent-handback-inbound-builder.ts
+++ b/telegram-plugin/gateway/subagent-handback-inbound-builder.ts
@@ -101,3 +101,85 @@ export function buildSubagentHandbackInbound(opts: {
     },
   }
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// Handback decision (pure — unit-testable gate for the gateway onFinish path)
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Inputs to the handback decision. The gateway's `subagent-watcher`
+ * `onFinish` callback does the IO — resolves `isBackground` from the
+ * registry DB, `fleetChatId` from the progress-driver fleet, and
+ * `ownerChatId` from access.json — then hands the resolved values here.
+ * Keeping the *decision* pure makes the gate (which injects turns)
+ * testable without standing up a gateway.
+ */
+export interface SubagentHandbackDecisionInput {
+  /** `SWITCHROOM_SUBAGENT_HANDBACK` env var value (any non-'0' = enabled). */
+  handbackEnvValue: string | undefined
+  /** Terminal outcome the watcher reported. */
+  outcome: 'completed' | 'failed' | 'orphan'
+  /** Whether the sub-agent was a background dispatch (registry DB flag).
+   *  Foreground sub-agents hand back natively in the parent's turn. */
+  isBackground: boolean
+  /** Chat id from the progress-driver fleet entry; '' if not found. */
+  fleetChatId: string
+  /** Owner chat fallback (access.json allowFrom[0]); '' if none. */
+  ownerChatId: string
+  taskDescription: string
+  resultText: string
+  /** Deterministic clock for tests. */
+  nowMs?: number
+}
+
+/** Why a handback was NOT delivered — one of these, or `delivered`. */
+export type SubagentHandbackSkipReason =
+  | 'env-disabled'
+  | 'outcome-not-terminal'
+  | 'foreground'
+  | 'no-chat'
+
+export type SubagentHandbackDecision =
+  | { deliver: false; reason: SubagentHandbackSkipReason }
+  | { deliver: true; chatId: string; inbound: InboundMessage }
+
+/**
+ * Decide whether a finished sub-agent warrants a handback turn, and if
+ * so build the inbound. Pure: all IO is the caller's job.
+ *
+ * Gates, in order:
+ *   1. kill-switch — `SWITCHROOM_SUBAGENT_HANDBACK=0` disables entirely.
+ *   2. outcome — only `completed`/`failed` hand back; `orphan` is a
+ *      stale historical-at-boot row, not a fresh completion.
+ *   3. foreground — a foreground sub-agent already handed its result
+ *      back as the Task tool result in the parent's own turn.
+ *   4. no-chat — neither the fleet entry nor the owner chat resolved,
+ *      so there is nowhere to deliver.
+ */
+export function decideSubagentHandback(
+  input: SubagentHandbackDecisionInput,
+): SubagentHandbackDecision {
+  if (input.handbackEnvValue === '0') {
+    return { deliver: false, reason: 'env-disabled' }
+  }
+  if (input.outcome !== 'completed' && input.outcome !== 'failed') {
+    return { deliver: false, reason: 'outcome-not-terminal' }
+  }
+  if (!input.isBackground) {
+    return { deliver: false, reason: 'foreground' }
+  }
+  const chatId = input.fleetChatId || input.ownerChatId
+  if (!chatId) {
+    return { deliver: false, reason: 'no-chat' }
+  }
+  const inbound = buildSubagentHandbackInbound({
+    ctx: {
+      chatId,
+      taskDescription: input.taskDescription,
+      resultText: input.resultText,
+      outcome: input.outcome,
+    },
+    ...(input.nowMs !== undefined ? { nowMs: input.nowMs } : {}),
+  })
+  return { deliver: true, chatId, inbound }
+}

--- a/telegram-plugin/tests/subagent-handback-decision.test.ts
+++ b/telegram-plugin/tests/subagent-handback-decision.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression coverage for `decideSubagentHandback` — the gate the
+ * gateway's subagent-watcher `onFinish` callback runs to decide whether
+ * a finished sub-agent gets a handback turn injected.
+ *
+ * This is the highest-risk surface of the handback feature (#1650): it
+ * injects a fresh turn. Before this suite the decision lived inline in
+ * the gateway's `onFinish` closure with no automated test — a refactor
+ * that broke the `isBackground` gate would have fired handbacks for
+ * foreground sub-agents (double messages) with nothing to catch it.
+ * The decision is now a pure function; these cases pin every gate.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { decideSubagentHandback } from '../gateway/subagent-handback-inbound-builder.js'
+
+const FIXED_NOW = 1_700_000_000_000
+
+const base = {
+  handbackEnvValue: undefined as string | undefined,
+  outcome: 'completed' as 'completed' | 'failed' | 'orphan',
+  isBackground: true,
+  fleetChatId: '777',
+  ownerChatId: '999',
+  taskDescription: 'Do the thing',
+  resultText: 'Done.',
+  nowMs: FIXED_NOW,
+}
+
+describe('decideSubagentHandback', () => {
+  it('delivers for a background completed sub-agent', () => {
+    const d = decideSubagentHandback({ ...base })
+    expect(d.deliver).toBe(true)
+    if (d.deliver) {
+      expect(d.chatId).toBe('777')
+      expect(d.inbound.meta.source).toBe('subagent_handback')
+      expect(d.inbound.chatId).toBe('777')
+    }
+  })
+
+  it('delivers for a background FAILED sub-agent', () => {
+    const d = decideSubagentHandback({ ...base, outcome: 'failed' })
+    expect(d.deliver).toBe(true)
+    if (d.deliver) expect(d.inbound.meta.outcome).toBe('failed')
+  })
+
+  it('skips a foreground sub-agent (handed back natively in-turn)', () => {
+    const d = decideSubagentHandback({ ...base, isBackground: false })
+    expect(d).toEqual({ deliver: false, reason: 'foreground' })
+  })
+
+  it("skips an 'orphan' outcome (stale historical-at-boot row)", () => {
+    const d = decideSubagentHandback({ ...base, outcome: 'orphan' })
+    expect(d).toEqual({ deliver: false, reason: 'outcome-not-terminal' })
+  })
+
+  it('skips when the kill-switch is set (SWITCHROOM_SUBAGENT_HANDBACK=0)', () => {
+    const d = decideSubagentHandback({ ...base, handbackEnvValue: '0' })
+    expect(d).toEqual({ deliver: false, reason: 'env-disabled' })
+  })
+
+  it('treats any non-"0" env value (incl. undefined) as enabled', () => {
+    expect(decideSubagentHandback({ ...base, handbackEnvValue: undefined }).deliver).toBe(true)
+    expect(decideSubagentHandback({ ...base, handbackEnvValue: '1' }).deliver).toBe(true)
+    expect(decideSubagentHandback({ ...base, handbackEnvValue: '' }).deliver).toBe(true)
+  })
+
+  it('falls back to the owner chat when the fleet entry is gone', () => {
+    const d = decideSubagentHandback({ ...base, fleetChatId: '' })
+    expect(d.deliver).toBe(true)
+    if (d.deliver) {
+      expect(d.chatId).toBe('999')
+      expect(d.inbound.chatId).toBe('999')
+    }
+  })
+
+  it('prefers the fleet chat id over the owner chat when both are present', () => {
+    const d = decideSubagentHandback({ ...base, fleetChatId: '777', ownerChatId: '999' })
+    expect(d.deliver).toBe(true)
+    if (d.deliver) expect(d.chatId).toBe('777')
+  })
+
+  it('skips when no chat resolves at all', () => {
+    const d = decideSubagentHandback({ ...base, fleetChatId: '', ownerChatId: '' })
+    expect(d).toEqual({ deliver: false, reason: 'no-chat' })
+  })
+
+  it('gate order: kill-switch wins over every other condition', () => {
+    // env-disabled even though it is a deliverable background completion.
+    const d = decideSubagentHandback({ ...base, handbackEnvValue: '0', isBackground: true })
+    expect(d).toEqual({ deliver: false, reason: 'env-disabled' })
+  })
+
+  it('gate order: outcome filter applies before the foreground check', () => {
+    // orphan + foreground — outcome filter is checked first.
+    const d = decideSubagentHandback({ ...base, outcome: 'orphan', isBackground: false })
+    expect(d).toEqual({ deliver: false, reason: 'outcome-not-terminal' })
+  })
+
+  it('carries the task description and result text into the inbound', () => {
+    const d = decideSubagentHandback({
+      ...base,
+      taskDescription: 'Migrate the DB',
+      resultText: 'Applied 3 migrations, 0 rows dropped.',
+    })
+    expect(d.deliver).toBe(true)
+    if (d.deliver) {
+      expect(d.inbound.text).toContain('Migrate the DB')
+      expect(d.inbound.text).toContain('Applied 3 migrations')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Closes the regression-coverage gap the #1650 review flagged as a follow-up. The sub-agent handback feature shipped with the gateway `onFinish` handler's **gating logic inline in a closure — untested.** That is the feature's highest-risk surface: it injects a fresh turn. A refactor breaking the `isBackground` gate would fire handbacks for *foreground* sub-agents (double messages) with no automated guard — the only end-to-end check is a UAT, which does not run in CI.

## What this does

- Extracts the decision into a **pure** `decideSubagentHandback(input) → { deliver:false, reason } | { deliver:true, chatId, inbound }`.
- The gateway `onFinish` keeps the IO (`peekAllFleets`, the registry-DB `background` query, `loadAccess`) and delegates the gate.
- New `subagent-handback-decision.test.ts` — 12 cases pinning every gate:
  - background completed / failed → deliver
  - foreground → skip `foreground`
  - orphan outcome → skip `outcome-not-terminal`
  - kill-switch (`SWITCHROOM_SUBAGENT_HANDBACK=0`) → skip `env-disabled`
  - non-`0` env values (incl. undefined/empty) → enabled
  - owner-chat fallback when the fleet entry is gone
  - fleet-chat precedence over owner-chat
  - gate ordering (kill-switch first; outcome filter before foreground check)
  - description + result text carried into the inbound

## No behaviour change

Pure refactor + coverage. The gate conditions and their order are byte-identical to the previous inline logic.

## Test plan

- [x] `vitest` — `subagent-handback-decision.test.ts` 12/12, builder suite 5/5
- [x] `tsc --noEmit` — clean
- [x] `check-bot-api-wrapping`, `check-plugin-references`, `check-no-pii-secrets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)