### PR TITLE
fix(auth): a transient overload is not quota exhaustion (honest escalation)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2712,8 +2712,14 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     // Card text branches on the AND. wouldFireFleetAutoFallback is a
     // pure read of the dedup state; calling fireFleetAutoFallback only
     // when both are true keeps the card honest.
-    const isAutoKind =
-      modelUnavailable.kind === 'quota_exhausted' || modelUnavailable.kind === 'overload'
+    // Only a genuine quota / usage-limit hit is addressable by fleet
+    // auto-fallback (swap to an account that still has runway). An
+    // `overload` is transient Anthropic SERVER-side capacity pressure —
+    // every account is equally affected, so failing over does nothing;
+    // it just produces a self-cancelling "probed healthy / Stale event?"
+    // loop on every 529. Overload is handled by Claude Code's own
+    // internal retry, not by switching accounts.
+    const isAutoKind = modelUnavailable.kind === 'quota_exhausted'
     const willActuallyFire = isAutoKind && wouldFireFleetAutoFallback()
     process.stderr.write(
       `telegram gateway: operator-event suppressing-raw-stderr-for-model-unavailable agent=${agent} kind=${kind} detected=${modelUnavailable.kind} autoKind=${isAutoKind} willFire=${willActuallyFire}\n`,

--- a/telegram-plugin/model-unavailable.ts
+++ b/telegram-plugin/model-unavailable.ts
@@ -326,7 +326,17 @@ export function resolveModelUnavailableFromOperatorEvent(
     return detectModelUnavailable(detail) ?? { kind: 'quota_exhausted', raw: detail }
   }
   if (ev.kind === 'rate-limited') {
-    return detectModelUnavailable(detail) ?? { kind: 'overload', raw: detail }
+    // A rate-limited / transient overload is NOT "model unavailable" —
+    // it is retryable and Claude Code retries it internally. Escalate
+    // to the model-unavailable card ONLY if the detail carries a
+    // genuine quota signal (a 4xx that slipped past the classifier
+    // with usage-limit wording in its body). A bare overload /
+    // rate-limit returns null → the caller renders the calm
+    // `rate-limited` card, never the scary "⚠️ Model unavailable" one.
+    // Returning `{kind:'overload'}` here is what fired a false
+    // model-unavailable card on every transient 529.
+    const detected = detectModelUnavailable(detail)
+    return detected?.kind === 'quota_exhausted' ? detected : null
   }
   if (ev.kind === 'unknown-5xx') {
     return detectModelUnavailable(detail) ?? { kind: 'overload', raw: detail }

--- a/telegram-plugin/operator-events.fixtures.json
+++ b/telegram-plugin/operator-events.fixtures.json
@@ -1,6 +1,5 @@
 {
   "_comment": "Captured error shapes per OperatorEventKind. Real API keys/IDs have been scrubbed.",
-
   "credentials-expired": [
     {
       "_source": "Anthropic API — 401 with authentication_error + expired hint",
@@ -16,7 +15,6 @@
       "message": "OAuth token expired, please re-authenticate to continue"
     }
   ],
-
   "credentials-invalid": [
     {
       "_source": "Anthropic API — 401 with invalid_api_key",
@@ -40,7 +38,6 @@
       "message": "Invalid API key"
     }
   ],
-
   "credit-exhausted": [
     {
       "_source": "Anthropic API — 402 credit_balance_too_low",
@@ -56,23 +53,7 @@
       "message": "credit balance insufficient"
     }
   ],
-
-  "quota-exhausted": [
-    {
-      "_source": "Anthropic API — 529 overloaded_error (Claude Code converts to quota-exhausted)",
-      "status": 529,
-      "error": {
-        "type": "overloaded_error",
-        "message": "Overloaded"
-      }
-    },
-    {
-      "_source": "Synthetic — set by session-tail after repeated 429 + slot exhaustion",
-      "type": "overloaded_error",
-      "message": "Service overloaded, usage limits reached"
-    }
-  ],
-
+  "quota-exhausted": [],
   "rate-limited": [
     {
       "_source": "Anthropic API — 429 rate_limit_error",
@@ -86,9 +67,21 @@
       "_source": "Top-level rate_limit_error",
       "type": "rate_limit_error",
       "message": "rate limit exceeded"
+    },
+    {
+      "_source": "Anthropic API — 529 overloaded_error (transient server capacity → rate-limited, NOT quota)",
+      "status": 529,
+      "error": {
+        "type": "overloaded_error",
+        "message": "Overloaded"
+      }
+    },
+    {
+      "_source": "Synthetic — overloaded_error from session-tail (transient → rate-limited, NOT quota)",
+      "type": "overloaded_error",
+      "message": "Service overloaded, usage limits reached"
     }
   ],
-
   "agent-crashed": [
     {
       "_source": "Synthetic — emitted by IPC bridge when Claude child exits nonzero",
@@ -101,7 +94,6 @@
       "message": "IPC socket disconnected unexpectedly"
     }
   ],
-
   "agent-restarted-unexpectedly": [
     {
       "_source": "Synthetic — emitted by gateway boot-banner diff when uptime drops unexpectedly",
@@ -114,7 +106,6 @@
       "message": "systemd unit restarted outside of operator request"
     }
   ],
-
   "unknown-4xx": [
     {
       "_source": "Novel 4xx not matching any known Anthropic error type",
@@ -142,7 +133,6 @@
       "_value": "something went wrong"
     }
   ],
-
   "unknown-5xx": [
     {
       "_source": "500 with no recognised type",

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -139,8 +139,17 @@ function classifyInner(raw: unknown): OperatorEventKind {
     message.toLowerCase().includes('overloaded_error') ||
     message.toLowerCase().includes('overloaded')
   ) {
-    // Anthropic overloaded = quota exhausted / service rate-limiting
-    return 'quota-exhausted'
+    // Anthropic "overloaded" (HTTP 529) is transient SERVER-side
+    // capacity pressure — orthogonal to account quota. It is retryable
+    // (`x-should-retry: true`) and Claude Code retries it internally.
+    // Classifying it `quota-exhausted` fired a false "Model
+    // unavailable — quota exhausted" card AND a self-cancelling fleet
+    // auto-fallback on every 529 (the active account always probes
+    // healthy — nothing is actually exhausted — so the fallback no-ops
+    // with "probed healthy / Stale event?"). It is a rate-limit-family
+    // transient; failing over to another account does nothing because
+    // every account is equally affected.
+    return 'rate-limited'
   }
 
   // Synthetic kinds (non-Anthropic — set by session-tail or IPC bridge)

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -409,9 +409,37 @@ export function projectSubagentLine(
  * Returns null when no actionable error is detected (routine lines).
  * Never throws — delegates to classifyClaudeError's own safety guarantee.
  */
+/**
+ * Extract Claude Code's retry-state annotations from a transcript line.
+ * Claude Code writes top-level `retryAttempt` / `maxRetries` on a
+ * retried API error (e.g. a 529 it is internally retrying). Used to
+ * tell an in-flight retry from an exhausted (terminal) one. Both
+ * optional — non-retried errors and older Claude Code versions omit
+ * them.
+ */
+function extractRetryState(obj: Record<string, unknown>): {
+  retryAttempt: number | null
+  maxRetries: number | null
+} {
+  return {
+    retryAttempt: typeof obj.retryAttempt === 'number' ? obj.retryAttempt : null,
+    maxRetries: typeof obj.maxRetries === 'number' ? obj.maxRetries : null,
+  }
+}
+
 export function detectErrorInTranscriptLine(
   line: string,
-): { kind: OperatorEventKind; raw: unknown; detail: string } | null {
+): {
+  kind: OperatorEventKind
+  raw: unknown
+  detail: string
+  /** True for the rate-limit / transient-overload family. */
+  transient: boolean
+  /** True when the error is final — NOT an in-flight retry. A transient
+   *  error mid-retry is `transient:true, terminal:false`; the caller
+   *  suppresses it (no operator card until the failure is terminal). */
+  terminal: boolean
+} | null {
   if (!line || line.length > 2 * 1024 * 1024) return null
   let obj: Record<string, unknown>
   try {
@@ -447,7 +475,16 @@ export function detectErrorInTranscriptLine(
       status === 429
         ? 'quota-exhausted'
         : classifyClaudeError({ type: errStr, status, message: text })
-    return { kind, raw: obj, detail: text || errStr || 'api error' }
+    // An `isApiErrorMessage` line is Claude surfacing the failure to the
+    // user — terminal by construction (Claude writes this shape only
+    // after its own internal retries are exhausted).
+    return {
+      kind,
+      raw: obj,
+      detail: text || errStr || 'api error',
+      transient: kind === 'rate-limited',
+      terminal: true,
+    }
   }
 
   // Explicit error line types from Claude Code JSONL
@@ -472,7 +509,23 @@ export function detectErrorInTranscriptLine(
     extractDetailMessage(obj) ??
     String(type ?? '')
 
-  return { kind, raw, detail }
+  // Transient = the rate-limit / overload family. For a transient,
+  // decide `terminal` from Claude Code's retry annotations: below the
+  // cap → still retrying (in-flight); at/above → exhausted. With no
+  // retry state, an explicit `type:"api_error"`/`"error"` LINE means
+  // Claude surfaced the failure (terminal); an embedded-error object
+  // with no retry state is ambiguous → treat as in-flight and suppress
+  // (the silence-poke covers a genuinely stuck turn; a false card is
+  // the bug we are fixing, a missed ambiguous card costs nothing).
+  const transient = kind === 'rate-limited'
+  const retry = extractRetryState(obj)
+  const terminal = !transient
+    ? true
+    : retry.retryAttempt != null && retry.maxRetries != null
+      ? retry.retryAttempt >= retry.maxRetries
+      : isErrorLine
+
+  return { kind, raw, detail, transient, terminal }
 }
 
 function extractDetailMessage(obj: Record<string, unknown> | null): string | null {
@@ -514,6 +567,10 @@ export interface TailOperatorEvent {
   kind: OperatorEventKind
   detail: string
   raw: unknown
+  /** True for the rate-limit / transient-overload family. */
+  transient: boolean
+  /** True when the failure is final, not an in-flight retry. */
+  terminal: boolean
 }
 
 export interface SessionTailConfig {
@@ -665,7 +722,17 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
           try {
             const errEvent = detectErrorInTranscriptLine(line)
             if (errEvent) {
-              onOperatorEvent(errEvent)
+              // Honest escalation: a transient overload Claude is still
+              // retrying (transient && !terminal) posts NO operator
+              // card — it almost always resolves on the next retry.
+              // Escalate only terminal failures + non-transient errors.
+              if (errEvent.terminal || !errEvent.transient) {
+                onOperatorEvent(errEvent)
+              } else {
+                log?.(
+                  `session-tail: transient overload suppressed (in-flight retry) kind=${errEvent.kind}`,
+                )
+              }
             }
           } catch (err) {
             log?.(`session-tail: onOperatorEvent threw: ${(err as Error).message}`)

--- a/telegram-plugin/tests/model-unavailable.test.ts
+++ b/telegram-plugin/tests/model-unavailable.test.ts
@@ -247,9 +247,22 @@ describe('resolveModelUnavailableFromOperatorEvent — kind-driven mapping', () 
     expect(d?.kind).toBe('quota_exhausted')
   })
 
-  it('always treats kind=rate-limited as overload', () => {
+  it('treats a bare kind=rate-limited as NOT model-unavailable (transient → calm card)', () => {
+    // A transient overload / rate-limit is retryable — Claude Code
+    // retries it internally. resolveModelUnavailableFromOperatorEvent
+    // returns null so the gateway renders the calm `rate-limited` card,
+    // never the scary "⚠️ Model unavailable" one. Returning
+    // `{kind:'overload'}` here is what fired a false card on every 529.
     const d = resolveModelUnavailableFromOperatorEvent({ kind: 'rate-limited', detail: '' })
-    expect(d?.kind).toBe('overload')
+    expect(d).toBeNull()
+  })
+
+  it('escalates a kind=rate-limited that carries a genuine quota signal', () => {
+    const d = resolveModelUnavailableFromOperatorEvent({
+      kind: 'rate-limited',
+      detail: "You've hit your limit · resets 8:50am",
+    })
+    expect(d?.kind).toBe('quota_exhausted')
   })
 
   it('always treats kind=unknown-5xx as overload', () => {

--- a/telegram-plugin/tests/operator-events-session-tail.test.ts
+++ b/telegram-plugin/tests/operator-events-session-tail.test.ts
@@ -56,13 +56,64 @@ describe('detectErrorInTranscriptLine — error detection', () => {
     expect(result!.kind).toBe('credit-exhausted')
   })
 
-  it('classifies overloaded_error as quota-exhausted', () => {
+  it('classifies overloaded_error as rate-limited (transient), NOT quota-exhausted', () => {
+    // A 529 "overloaded" is transient Anthropic server-capacity
+    // pressure — orthogonal to account quota. Classifying it
+    // quota-exhausted fired a false "Model unavailable" card + a
+    // self-cancelling fleet auto-fallback on every 529.
     const line = JSON.stringify({
       type: 'api_error',
       error: { type: 'overloaded_error', message: 'Overloaded' },
     })
     const result = detectErrorInTranscriptLine(line)
-    expect(result!.kind).toBe('quota-exhausted')
+    expect(result!.kind).toBe('rate-limited')
+    expect(result!.transient).toBe(true)
+    // An explicit `type:"api_error"` line (no retry state) = Claude
+    // surfaced the failure → terminal.
+    expect(result!.terminal).toBe(true)
+  })
+
+  it('marks an in-flight 529 retry transient + NOT terminal (suppressed)', () => {
+    // Real on-disk shape: a 529 Claude Code is internally retrying,
+    // annotated with retryAttempt < maxRetries.
+    const line = JSON.stringify({
+      type: 'system',
+      subtype: 'api_error',
+      error: { status: 529, type: 'overloaded_error', message: 'Overloaded' },
+      retryAttempt: 9,
+      maxRetries: 10,
+      retryInMs: 34479,
+    })
+    const result = detectErrorInTranscriptLine(line)
+    expect(result!.kind).toBe('rate-limited')
+    expect(result!.transient).toBe(true)
+    // 9 < 10 — still retrying → in-flight → the caller suppresses it.
+    expect(result!.terminal).toBe(false)
+  })
+
+  it('marks an exhausted 529 retry terminal (escalates)', () => {
+    const line = JSON.stringify({
+      type: 'system',
+      subtype: 'api_error',
+      error: { status: 529, type: 'overloaded_error', message: 'Overloaded' },
+      retryAttempt: 10,
+      maxRetries: 10,
+    })
+    const result = detectErrorInTranscriptLine(line)
+    expect(result!.kind).toBe('rate-limited')
+    expect(result!.transient).toBe(true)
+    // retries exhausted → terminal → escalates.
+    expect(result!.terminal).toBe(true)
+  })
+
+  it('marks non-transient errors terminal (always escalate)', () => {
+    const line = JSON.stringify({
+      type: 'api_error',
+      error: { type: 'authentication_error', message: 'expired' },
+    })
+    const result = detectErrorInTranscriptLine(line)
+    expect(result!.transient).toBe(false)
+    expect(result!.terminal).toBe(true)
   })
 
   it('returns null for lines without error field', () => {

--- a/telegram-plugin/tests/operator-events.test.ts
+++ b/telegram-plugin/tests/operator-events.test.ts
@@ -57,13 +57,20 @@ describe('classifyClaudeError — credit-exhausted fixtures', () => {
   }
 })
 
-describe('classifyClaudeError — quota-exhausted fixtures', () => {
-  for (const fixture of fixtures['quota-exhausted']) {
-    it(`classifies: ${fixture._source}`, () => {
-      const input = '_value' in fixture ? fixture._value : fixture
-      expect(classifyClaudeError(input)).toBe('quota-exhausted')
-    })
-  }
+describe('classifyClaudeError — quota-exhausted', () => {
+  // classifyClaudeError is type/code/status-based and intentionally
+  // does NOT self-classify quota-exhausted: a genuine subscription
+  // usage-limit hit has no reliable Anthropic error TYPE — it is
+  // detected from the response TEXT. session-tail's `isApiErrorMessage`
+  // 429 branch + the `detectModelUnavailable` text path own quota
+  // detection. (`overloaded_error` used to be mapped here — wrongly;
+  // a 529 overload is transient server capacity, now `rate-limited`.)
+  it('no error TYPE maps to quota-exhausted (the text path owns it)', () => {
+    expect(fixtures['quota-exhausted']).toHaveLength(0)
+    expect(
+      classifyClaudeError({ type: 'overloaded_error', message: 'Overloaded' }),
+    ).not.toBe('quota-exhausted')
+  })
 })
 
 describe('classifyClaudeError — rate-limited fixtures', () => {


### PR DESCRIPTION
## The incident

Operator screenshot: `clerk` and `klanker` showing **"⚠️ Model unavailable — Reason: quota exhausted / Auto-failover in progress"** → **"Auto-fallback skipped: me@kenthompson.com.au probed healthy (1% / 0%). Stale event?"** — looping on every transient HTTP 529.

A fresh-process investigation confirmed: the accounts were **never exhausted** (1%/0% used). Auto-fallback *correctly* declined — there was nothing to fall back from. The bug is entirely upstream: a transient error wearing a quota label.

## Root cause

A transient Anthropic **HTTP 529 `overloaded_error`** (server capacity; `x-should-retry:true`; Claude Code was on retry 9/10 internally) was classified `quota-exhausted`. The comment in `operator-events.ts` literally said *"Anthropic overloaded = quota exhausted"* — factually wrong. That one mislabel fired both a false **card** and a self-cancelling fleet **auto-fallback** on every 529.

## Fixes — classification

- **`operator-events.ts`** `classifyClaudeError`: `overloaded_error` / HTTP 529 → `rate-limited`, not `quota-exhausted`. Overload is rate-limit-family transient; orthogonal to account quota.
- **`gateway.ts`** `emitGatewayOperatorEvent`: fleet auto-fallback now triggers **only** on `quota_exhausted`, never `overload` — failing over does nothing when every account is equally hit by Anthropic server load.
- **`model-unavailable.ts`** `resolveModelUnavailableFromOperatorEvent`: a bare `rate-limited` returns `null` → the gateway renders the **calm** `rate-limited` card, not the scary "⚠️ Model unavailable" one. Escalates to the model-unavailable card only if the detail carries a genuine quota signal. (Returning `{kind:'overload'}` here was the still-live false-card path the planner caught.)

## Fixes — honest escalation

- **`session-tail.ts`** `detectErrorInTranscriptLine` now extracts Claude Code's retry annotations (`retryAttempt`/`maxRetries`) and returns `transient` + `terminal`. A transient overload Claude is **still retrying** (`transient && !terminal`) posts **no operator card** — it almost always resolves on the next retry. Only a terminal failure (retries exhausted, or the user-surfaced `isApiErrorMessage` shape) or a non-transient error escalates.
- `classifyClaudeError` no longer self-classifies `quota-exhausted` — a genuine usage-limit has no reliable error *type*; it is detected from the response *text* (session-tail's `isApiErrorMessage` 429 branch + `detectModelUnavailable`). The two `overloaded_error` fixtures moved `quota-exhausted` → `rate-limited`.

## Design-contract alignment

- **`survive-reboots-and-real-life`** — "absorb transient failures, resume work; tell the user when something went wrong." A 529 mid-retry is *not* something gone wrong worth a card. Don't cry wolf.
- **`track-plan-quota-live`** — a quota alarm must mean quota. A false "quota exhausted" erodes the exact trust the job exists to protect.
- **principles / docs test** — the old card said "quota exhausted" when quota was fine: a card that isn't true fails the docs test.

## Test plan

- [x] `vitest` — 125 pass: new session-tail transient/terminal cases (in-flight 529 → suppressed; exhausted 529 → escalates; non-transient → escalates); `model-unavailable` rate-limited contract; fixtures moved
- [x] `tsc --noEmit` — clean
- [x] `check-bot-api-wrapping`, `check-plugin-references`, `check-no-pii-secrets`, `check-bun-test-imports` — clean

## Deferred (noted, not in this PR)

The overload-specific *long-running* honest surface ("⏳ Claude's servers are busy, retrying") on a turn stuck retrying for minutes — the existing silence-poke already fires a generic "still working" fallback, so this is wording polish, tracked as a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)