### PR TITLE
fix(pacing): stop posting the model's turn wrap-up as a duplicate message

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1192,14 +1192,6 @@ type CurrentTurn = {
   gatewayReceiveAt: number
   replyCalled: boolean
   capturedText: string[]
-  // #1291: snapshot of capturedText.length at the moment of the most
-  // recent reply / stream_reply tool call. Used by decideTurnFlush to
-  // isolate the post-reply tail (e.g. a soft-commit reply followed by
-  // the real substantive answer in terminal text only) and flush it as
-  // a follow-up message. Pre-#1291 the existence of ANY reply call
-  // suppressed flush entirely — that lost long terminal-only answers
-  // after a "let me check" interim reply.
-  capturedTextLenAtLastReply: number
   orphanedReplyTimeoutId: ReturnType<typeof setTimeout> | null
   registryKey: string | null
   // Last assistant outbound message id for the current turn — populated
@@ -5706,7 +5698,6 @@ function handleSessionEvent(ev: SessionEvent): void {
           gatewayReceiveAt: startedAt,
           replyCalled: false,
           capturedText: [],
-          capturedTextLenAtLastReply: 0,
           orphanedReplyTimeoutId: null,
           registryKey: null,
           lastAssistantMsgId: null,
@@ -5807,12 +5798,6 @@ function handleSessionEvent(ev: SessionEvent): void {
       // placeholder-heartbeat label, which has been retired.
       if (isTelegramReplyTool(name)) {
         turn.replyCalled = true
-        // #1291: pin the captured-text index at the moment of this reply
-        // tool call. Anything pushed into capturedText after this point
-        // is the post-reply tail (e.g. the substantive answer composed
-        // in terminal text after a soft-commit "on it, back in a few").
-        // decideTurnFlush slices from this index to flush the tail.
-        turn.capturedTextLenAtLastReply = turn.capturedText.length
         if (turn.orphanedReplyTimeoutId != null) {
           clearTimeout(turn.orphanedReplyTimeoutId)
           turn.orphanedReplyTimeoutId = null
@@ -6072,20 +6057,8 @@ function handleSessionEvent(ev: SessionEvent): void {
         chatId: turn.sessionChatId,
         replyCalled: turn.replyCalled,
         capturedText: turn.capturedText,
-        capturedTextLenAtLastReply: turn.capturedTextLenAtLastReply,
         flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
       })
-      // #1291: when the model emitted a soft-commit reply followed by a
-      // substantive terminal-only answer, decideTurnFlush returns
-      // kind:'flush' with the post-reply tail. Log WARN so this case is
-      // auditable — the model SHOULD have called reply for the tail, but
-      // didn't, and the framework is covering for it.
-      if (flushDecision.kind === 'flush' && turn.replyCalled) {
-        process.stderr.write(
-          `telegram gateway: WARN post-reply-tail flush (#1291) — model emitted ${flushDecision.text.length} chars after a prior reply call without a follow-up reply tool` +
-          ` chat=${chatId} turnStartedAt=${turn.startedAt}\n`,
-        )
-      }
       if (flushDecision.kind === 'skip' && flushDecision.reason !== 'reply-called') {
         process.stderr.write(
           `telegram gateway: turn-flush skipped — reason=${flushDecision.reason}\n`,

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -138,112 +138,60 @@ describe('decideTurnFlush', () => {
     ).toEqual({ kind: 'skip', reason: 'reply-called' })
   })
 
-  // #1291 — when the model emits a soft-commit reply ("on it, back in a
-  // few") and then composes the real substantive answer in terminal text
-  // only, the pre-#1291 behaviour skipped flush entirely because
-  // replyCalled was true. The fix: track capturedTextLenAtLastReply and
-  // flush the post-reply tail when it meets the substantive threshold.
-  describe('#1291 — post-reply tail flush', () => {
-    it('flushes the post-reply tail when it meets the substantive threshold', () => {
+  // The turn-flush safety net covers exactly one failure mode: a turn that
+  // ended with the model never having said anything. Once the model has
+  // called reply / stream_reply the turn is served — any assistant text it
+  // emits afterwards is its own end-of-turn wrap-up (a closing summary,
+  // narration to itself), NOT a message it chose to send. The framework
+  // must never promote that terminal text into a second Telegram bubble.
+  //
+  // Regression guard for the redundant-follow-up-message fix: this reverts
+  // the #1291 post-reply-tail flush, which posted a duplicate recap on
+  // essentially every turn because the model habitually writes a closing
+  // summary after its final reply. See reference/conversational-pacing.md
+  // — "the framework owns the beat; the model authors the words".
+  describe('reply-called turns never flush trailing terminal text', () => {
+    it('skips even when a long substantive tail follows the reply', () => {
       const decision = decideTurnFlush({
         chatId: '700',
         replyCalled: true,
-        // Index 0 = the captured text BEFORE the reply tool was called
-        // (some thinking-as-text). Indices 1..2 are post-reply.
         capturedText: [
           'thinking out loud before the reply',
-          'Now here is the actual substantive answer the model composed ',
-          'in terminal text only after the interim reply call.',
+          'Answered the Playwright question and acked the calendar ' +
+            'diagnosis is still in flight. Will surface the root cause ' +
+            'when the worker returns.',
         ],
-        capturedTextLenAtLastReply: 1,
       })
-      expect(decision).toEqual({
-        kind: 'flush',
-        text:
-          'Now here is the actual substantive answer the model composed ' +
-          '\nin terminal text only after the interim reply call.',
-      })
+      expect(decision).toEqual({ kind: 'skip', reason: 'reply-called' })
     })
 
-    it('skips with reply-called-no-new-text when post-reply tail is below threshold', () => {
+    it('skips regardless of how many text blocks trail the reply', () => {
       const decision = decideTurnFlush({
         chatId: '701',
         replyCalled: true,
-        capturedText: ['the pre-reply scratch', 'ok.'], // tail = "ok." (3 chars)
-        capturedTextLenAtLastReply: 1,
+        capturedText: [
+          'a substantive paragraph the model wrote as terminal text',
+          'and another one, each well over any old length threshold',
+          'and a third closing summary block for good measure',
+        ],
       })
-      expect(decision).toEqual({
-        kind: 'skip',
-        reason: 'reply-called-no-new-text',
-      })
+      expect(decision).toEqual({ kind: 'skip', reason: 'reply-called' })
     })
 
-    it('skips with reply-called when there is no post-reply text at all', () => {
+    it('skips with reply-called when capturedText is empty', () => {
       const decision = decideTurnFlush({
         chatId: '702',
         replyCalled: true,
-        capturedText: ['everything-was-before-the-reply'],
-        capturedTextLenAtLastReply: 1, // tail slice is empty
+        capturedText: [],
       })
       expect(decision).toEqual({ kind: 'skip', reason: 'reply-called' })
     })
 
-    it('post-reply tail honors a silent marker (skip)', () => {
+    it('feature flag off still wins over a reply-called turn', () => {
       const decision = decideTurnFlush({
         chatId: '703',
         replyCalled: true,
-        capturedText: ['real answer pre-reply', 'NO_REPLY'],
-        capturedTextLenAtLastReply: 1,
-        replyCalledTailMinChars: 1, // force the marker check
-      })
-      expect(decision).toEqual({ kind: 'skip', reason: 'silent-marker' })
-    })
-
-    it('post-reply tail with null chatId still skips (no-inbound-chat)', () => {
-      const decision = decideTurnFlush({
-        chatId: null,
-        replyCalled: true,
-        capturedText: [
-          'pre',
-          'this tail would have been substantive enough to flush normally',
-        ],
-        capturedTextLenAtLastReply: 1,
-      })
-      expect(decision).toEqual({ kind: 'skip', reason: 'no-inbound-chat' })
-    })
-
-    it('preserves pre-#1291 behaviour when capturedTextLenAtLastReply is omitted', () => {
-      // Legacy caller doesn't track the marker — defaults to
-      // capturedText.length, so the tail slice is empty and we skip
-      // with reason 'reply-called' (the original behaviour).
-      const decision = decideTurnFlush({
-        chatId: '704',
-        replyCalled: true,
-        capturedText: ['some answer the model emitted'],
-      })
-      expect(decision).toEqual({ kind: 'skip', reason: 'reply-called' })
-    })
-
-    it('respects a custom replyCalledTailMinChars threshold', () => {
-      const decision = decideTurnFlush({
-        chatId: '705',
-        replyCalled: true,
-        capturedText: ['pre-reply', 'short but substantive in this test'],
-        capturedTextLenAtLastReply: 1,
-        replyCalledTailMinChars: 10,
-      })
-      expect(decision.kind).toBe('flush')
-    })
-
-    it('feature flag off still wins over post-reply tail flush', () => {
-      const decision = decideTurnFlush({
-        chatId: '706',
-        replyCalled: true,
-        capturedText: [
-          'pre',
-          'a long substantive post-reply tail that would otherwise flush',
-        ],
-        capturedTextLenAtLastReply: 1,
+        capturedText: ['a long substantive tail that pre-fix would flush'],
         flushEnabled: false,
       })
       expect(decision).toEqual({ kind: 'skip', reason: 'flag-disabled' })

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -57,7 +57,6 @@ export type FlushDecision =
 export type FlushSkipReason =
   | 'flag-disabled'
   | 'reply-called'
-  | 'reply-called-no-new-text'
   | 'no-inbound-chat'
   | 'empty-text'
   | 'silent-marker'
@@ -70,34 +69,13 @@ export interface FlushDecisionInput {
    * this turn. */
   replyCalled: boolean
   /** Raw text content blocks accumulated from assistant events across the
-   * turn. Joined + trimmed internally. */
+   * turn. Joined + trimmed internally. Only consulted when `replyCalled`
+   * is false — once the model has called reply / stream_reply the turn is
+   * served and trailing terminal text is dropped (see `decideTurnFlush`). */
   capturedText: string[]
-  /** Snapshot of `capturedText.length` at the moment of the most recent
-   * reply / stream_reply tool call in this turn. Indices `[capturedText
-   * length-at-last-reply, capturedText.length)` are the post-reply tail
-   * — substantive content the model emitted AFTER the reply (e.g. soft
-   * commit "on it, back in a few" followed by the real answer in
-   * terminal text only, the #1291 repro). When the tail meets
-   * `replyCalledTailMinChars` we flush it; otherwise we skip.
-   *
-   * Defaults to `capturedText.length` (treat all captured text as
-   * pre-reply, preserve the pre-#1291 behaviour where any reply tool
-   * call suppressed flush entirely) so callers that don't track the
-   * marker keep the old contract. */
-  capturedTextLenAtLastReply?: number
-  /** Minimum trimmed-tail length to qualify a post-reply tail flush.
-   * Defaults to `REPLY_CALLED_TAIL_MIN_CHARS` (40). Below this we skip
-   * with `reply-called-no-new-text` — typical for trailing markdown
-   * artifacts or a one-word afterthought. */
-  replyCalledTailMinChars?: number
   /** Feature flag — defaults to true. Pass `false` to force skip everywhere. */
   flushEnabled?: boolean
 }
-
-/** Default minimum trimmed length for the post-reply tail to be flushed
- * as a follow-up message. Below this we treat the tail as noise / artifact
- * and skip silently. */
-export const REPLY_CALLED_TAIL_MIN_CHARS = 40
 
 /**
  * Pure decision: should the gateway deterministically send the model's
@@ -107,39 +85,31 @@ export const REPLY_CALLED_TAIL_MIN_CHARS = 40
  * Ordering of checks is deliberate: cheapest/strongest first so logs
  * attribute a skip to the most specific cause.
  *
- * #1291 — when `replyCalled` is true we no longer suppress unconditionally.
- * The model may have emitted a soft-commit reply ("on it, back in a few")
- * followed by the real substantive answer in terminal text only. Using
- * `capturedTextLenAtLastReply` we isolate the post-reply tail and flush
- * it if it's substantive enough; otherwise we skip with
- * `reply-called-no-new-text` (logged) or `reply-called` (silent, no tail).
+ * The safety net has exactly one job: a turn that ended with the model
+ * having said *nothing* to the user. Once `replyCalled` is true the model
+ * has communicated through the proper channel and the decision is always
+ * `skip` — assistant text emitted after a reply is the model's own
+ * end-of-turn wrap-up (a closing summary, narration to itself), not a
+ * message it chose to send. Promoting that terminal text into a Telegram
+ * message second-guesses an explicit reply and posts a redundant duplicate
+ * on essentially every turn, because the model habitually writes a closing
+ * summary. The framework owns the *beat*; the model authors the *words*
+ * and emits them via reply (`reference/conversational-pacing.md`).
+ *
+ * (This reverts the #1291 post-reply-tail flush. Its intent — catch a
+ * soft-commit reply followed by the real answer in terminal text only —
+ * could not be told apart from the habitual wrap-up by length, so it
+ * misfired constantly. A model that soft-commits and never delivers is a
+ * pacing failure caught by the silence-poke ladder, not papered over here.)
  */
 export function decideTurnFlush(input: FlushDecisionInput): FlushDecision {
   const flushEnabled = input.flushEnabled !== false
   if (!flushEnabled) return { kind: 'skip', reason: 'flag-disabled' }
 
-  if (input.replyCalled) {
-    const tailIdx = input.capturedTextLenAtLastReply ?? input.capturedText.length
-    const tail = input.capturedText.slice(tailIdx).join('\n').trim()
-    const minChars = input.replyCalledTailMinChars ?? REPLY_CALLED_TAIL_MIN_CHARS
-    if (tail.length === 0) {
-      // The reply tool was called and nothing of substance came after —
-      // the turn is fully served by the reply. Skip silently (the gateway
-      // WARN gate excludes this reason from logs).
-      return { kind: 'skip', reason: 'reply-called' }
-    }
-    if (tail.length < minChars) {
-      // Post-reply tail exists but is below the substantive-content
-      // threshold — typically trailing markdown artifacts or a one-word
-      // afterthought. Skip but with a distinct reason so this case IS
-      // logged (auditable for #1291 regressions, vs the silent
-      // 'reply-called' which is the expected steady state).
-      return { kind: 'skip', reason: 'reply-called-no-new-text' }
-    }
-    if (input.chatId == null) return { kind: 'skip', reason: 'no-inbound-chat' }
-    if (isSilentFlushMarker(tail)) return { kind: 'skip', reason: 'silent-marker' }
-    return { kind: 'flush', text: tail }
-  }
+  // The model communicated through the proper channel — trust it. Any
+  // assistant text it emitted as terminal text afterwards is its own
+  // end-of-turn wrap-up, never a second Telegram message.
+  if (input.replyCalled) return { kind: 'skip', reason: 'reply-called' }
 
   if (input.chatId == null) return { kind: 'skip', reason: 'no-inbound-chat' }
   const joined = input.capturedText.join('\n').trim()


### PR DESCRIPTION
## Summary

Every agent turn that calls `reply` is followed by a **second, redundant Telegram message** — a third-person recap of what the turn did:

> [4:29 PM] Finn: Short version: the Playwright npm package…
> [4:29 PM] Finn: **Answered the Playwright question and acked the calendar diagnosis is still in flight. Will surface the calendar root cause when the worker returns.**

The model is *not* sending that second message. The gateway's turn-flush safety net scrapes the model's trailing terminal text and posts it.

## Why

Root cause is the **#1291 post-reply-tail flush**. `decideTurnFlush` was extended so that even when `reply` was called, any assistant text emitted after the last `reply` (≥40 chars) is flushed as a follow-up message — meant to catch a soft-commit reply followed by the real answer in terminal text only.

In practice the post-reply tail is almost never a forgotten answer. It's the model's **habitual end-of-turn summary** — Claude writes one on essentially every turn, and it's indistinguishable from a "real" answer by length. So #1291 misfired constantly; the gateway even logged each occurrence as a `WARN`.

This is also a direct violation of the pacing v2 design contract (`reference/conversational-pacing.md`): *"the framework owns the beat; the model authors the words."* Scraping terminal text into a message is the framework authoring a message.

## What changed

Deterministic contract: **a message reaches the user iff the model called `reply`/`stream_reply`.** Once `replyCalled` is true, `decideTurnFlush` always skips. The safety net keeps its one real job — a turn that ended with *zero* outbound (a genuine ghost-reply).

- `turn-flush-safety.ts` — `replyCalled` → always `skip:'reply-called'`; removed `capturedTextLenAtLastReply`, `replyCalledTailMinChars`, `REPLY_CALLED_TAIL_MIN_CHARS`, `reply-called-no-new-text`.
- `gateway.ts` — dropped the `capturedTextLenAtLastReply` turn-state field, its maintenance, and the now-dead #1291 `WARN` branch.
- `turn-flush-safety.test.ts` — replaced the #1291 suite with regression guards pinning skip-on-`replyCalled` for arbitrary trailing text.

No CLAUDE.md / prompt change — the behavior is controlled deterministically in the framework.

## Risk

Removing #1291 re-opens its target case: a model that soft-commits via `reply` then writes the real answer only as terminal text. That's a pacing failure already covered by the silence-poke ladder (it nudges the model to actually deliver), and the v2 design's stance is to fix the model's communication, not paper over it by promoting terminal text. The genuine zero-outbound ghost-reply backstop is untouched.

## Test plan

- [x] `vitest run telegram-plugin/tests/turn-flush-safety.test.ts` — 22 pass
- [x] `vitest run` gateway-disconnect-flush / turn-flush-dedup-controller / answer-stream-silent-markers — 14 pass
- [x] `tsc --noEmit` — clean
- [x] `scripts/check-bot-api-wrapping.sh` — clean
- [x] `scripts/check-plugin-references.mjs` — clean

JTBD: `know-what-my-agent-is-doing.md` — the chat is the artifact; a duplicate recap per turn is noise, not signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)