### PR TITLE
fix(docker): provision the Python Playwright binding in the agent image

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -62,26 +62,38 @@ RUN mkdir -p /tmp/tmux-shared
 COPY --from=ghcr.io/astral-sh/uv:0.7.13 /uv /uvx /usr/local/bin/
 
 # Playwright — pre-baked for skills that use browser automation
-# (calendar / scrape / UI-test). Pre-this-bake, agents called
-# `npx playwright` which triggered an on-demand download of the
-# browser binaries into `~/.cache/ms-playwright/` per agent on
-# first call (~30s latency, plus N copies of ~150MB browsers across
-# the fleet). Baking it in:
+# (calendar / scrape / UI-test) and the `@playwright/mcp` default MCP.
+# Pre-this-bake, agents called `npx playwright` which triggered an
+# on-demand download of the browser binaries into `~/.cache/ms-playwright/`
+# per agent on first call (~30s latency, plus N copies of ~150MB
+# browsers across the fleet). Baking it in:
 #
 #   - First call latency ~0s
 #   - One shared browser cache in image layer, not N per-agent caches
 #   - Version pin via image build, no per-agent npm @latest drift
 #
-# Major-version pin: the npm install resolves to the latest 1.x at
-# image build time; CI re-builds the image when a new patch lands.
-# Bumping the major requires CI to re-run `playwright install
-# --with-deps` in case browser-binary versions changed.
+# TWO bindings, ONE pinned version. The `@playwright/mcp` default MCP
+# server needs the JS binding; the bundled `webapp-testing` skill is
+# Python (`from playwright.sync_api import sync_playwright`) and needs
+# the Python binding. Both bindings share the browser binaries under
+# $PLAYWRIGHT_BROWSERS_PATH — which is ONLY safe when they are the
+# SAME Playwright version: Playwright pins an exact browser revision
+# per version, so a JS/Python version skew surfaces as "browser not
+# found" at runtime. PLAYWRIGHT_VERSION below is the single source of
+# truth for both installs — bump it in one place, never let them drift.
+# (tests/docker/dockerfile-agent-bakes.test.ts pins that invariant.)
 #
-# `--with-deps chromium` installs the apt packages chromium needs
-# at runtime (libnss3, libatk1.0-0, libcups2 etc.). Firefox / Webkit
-# can be added per-agent via `npx playwright install <browser>`
-# without re-baking; chromium is the default because most skills
-# use it.
+# Pre-this-bake the Python binding was absent entirely: `webapp-testing`
+# shipped as a default skill whose one hard dependency (`import
+# playwright`) was never provisioned, so the skill failed with
+# ModuleNotFoundError on every agent.
+#
+# `--with-deps chromium` installs the apt packages chromium needs at
+# runtime (libnss3, libatk1.0-0, libcups2 etc.) at build time as root,
+# baked into the image layer — the non-root agent never runs apt.
+# Firefox / Webkit can be added per-agent via `npx playwright install
+# <browser>` without re-baking; chromium is the default because most
+# skills use it.
 #
 # Browser binaries land at $PLAYWRIGHT_BROWSERS_PATH (image layer,
 # OS-independent) instead of $HOME/.cache/.
@@ -89,10 +101,24 @@ COPY --from=ghcr.io/astral-sh/uv:0.7.13 /uv /uvx /usr/local/bin/
 # Placed here — well above the `COPY dist/**` block — so a typical
 # src-only PR rebuilds 3-4 small COPY layers instead of triggering
 # this ~150MB layer (which would also pay ~20s of `playwright install`).
+ARG PLAYWRIGHT_VERSION=1.60.0
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright/browsers
+
+# JS binding + chromium browser + system libs.
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
-    npm install -g playwright@^1.49.0 \
+    npm install -g playwright@${PLAYWRIGHT_VERSION} \
  && npx playwright install --with-deps chromium
+
+# Python binding — same pinned version, so it resolves the SAME
+# chromium revision already baked above (no second ~150MB download).
+# `--break-system-packages`: Debian bookworm's python3 is PEP 668
+# externally-managed; the container IS the environment, so a global
+# install is correct here. The follow-up `playwright install chromium`
+# is idempotent — a no-op when the revision already matches the JS
+# bake, a safety net if a future bump ever desyncs the revision.
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    pip3 install --break-system-packages "playwright==${PLAYWRIGHT_VERSION}" \
+ && python3 -m playwright install chromium
 
 # Phase 2 cron-fold-in: the in-agent scheduler's node-cron runtime dep.
 # Bundle is built by scripts/build.mjs with --external node-cron, so the

--- a/tests/docker/dockerfile-agent-bakes.test.ts
+++ b/tests/docker/dockerfile-agent-bakes.test.ts
@@ -48,3 +48,51 @@ describe("Dockerfile.agent bakes", () => {
     );
   });
 });
+
+/**
+ * Playwright is delivered through TWO bindings — the JS binding for the
+ * `@playwright/mcp` default MCP, and the Python binding for the bundled
+ * `webapp-testing` skill (`from playwright.sync_api import ...`). Both
+ * share the browser binaries under $PLAYWRIGHT_BROWSERS_PATH, which is
+ * only safe when the two bindings are the SAME version: Playwright pins
+ * an exact browser revision per version, so a JS/Python skew surfaces
+ * as "browser not found" at runtime. These tests pin the single-source-
+ * of-truth invariant so a future bump can't silently desync the pair.
+ */
+describe("Dockerfile.agent Playwright provisioning", () => {
+  it("declares a single PLAYWRIGHT_VERSION build arg with a pinned value", () => {
+    const args = dockerfile.match(/ARG\s+PLAYWRIGHT_VERSION=/g) ?? [];
+    expect(args).toHaveLength(1);
+    // Exact pin (X.Y.Z) — no caret/tilde range, so the browser revision
+    // is deterministic across image rebuilds.
+    expect(dockerfile).toMatch(/ARG\s+PLAYWRIGHT_VERSION=\d+\.\d+\.\d+\s*$/m);
+  });
+
+  it("installs the JS binding at the pinned version", () => {
+    expect(dockerfile).toMatch(
+      /npm\s+install\s+-g\s+playwright@\$\{PLAYWRIGHT_VERSION\}/,
+    );
+  });
+
+  it("installs the Python binding at the SAME pinned version", () => {
+    expect(dockerfile).toMatch(
+      /pip3?\s+install\s+[^\n]*playwright==\$\{PLAYWRIGHT_VERSION\}/,
+    );
+  });
+
+  it("installs chromium + system deps for the JS binding", () => {
+    expect(dockerfile).toMatch(/playwright\s+install\s+--with-deps\s+chromium/);
+  });
+
+  it("ensures the Python binding's chromium is resolved", () => {
+    expect(dockerfile).toMatch(
+      /python3\s+-m\s+playwright\s+install\s+chromium/,
+    );
+  });
+
+  it("does not pin the JS binding to a floating npm range", () => {
+    // `playwright@^…` / `playwright@~…` would let the JS binding drift
+    // away from the exact-pinned Python binding on the next rebuild.
+    expect(dockerfile).not.toMatch(/playwright@[\^~]/);
+  });
+});


### PR DESCRIPTION
## Summary

The bundled **`webapp-testing`** skill ships enabled on every agent and is **Python-only** — every example and all SKILL.md guidance is `from playwright.sync_api import sync_playwright`. But the agent image baked **only the JS Playwright binding**, so the skill fails with `ModuleNotFoundError: No module named 'playwright'` on every agent.

Confirmed live inside a `v0.13.11` agent container:
```
$ python3 -c "import playwright"
ModuleNotFoundError: No module named 'playwright'
```
(The JS side is fine — `playwright` 1.60.0 + chromium-1223 baked, system libs resolve, `LAUNCH OK`.)

This bakes the **Python binding** into `docker/Dockerfile.agent`, pinned to the same version as the JS binding.

## Why

A "default skill" is only a symlink + settings entry — nothing in the reconcile path provisions a skill's runtime dependencies. `webapp-testing` ships no `requirements.txt`, so the lazy per-skill venv path (`switchroom deps`) can't provision it either. The **image bake is the right layer** — same as the JS binding.

The JS binding (for the `@playwright/mcp` default MCP) and the Python binding (for `webapp-testing`) **share the browser binaries** under `$PLAYWRIGHT_BROWSERS_PATH`. That is only safe when both bindings are the **same Playwright version** — Playwright pins an exact browser revision per version, so a JS/Python skew surfaces as "browser not found" at runtime.

This PR therefore:
- Adds a single `ARG PLAYWRIGHT_VERSION=1.60.0` (the version the old floating `^1.49.0` already resolved to) as the **single source of truth** for both installs.
- De-floats the JS install from `playwright@^1.49.0` → exact `${PLAYWRIGHT_VERSION}`, so the bindings cannot drift apart on a future rebuild.
- Installs `playwright==${PLAYWRIGHT_VERSION}` via pip (`--break-system-packages`; the container is the environment) + `python3 -m playwright install chromium` (idempotent — reuses the chromium-1223 layer from the JS bake, no second ~150MB download).

## Test plan

- [x] `tests/docker/dockerfile-agent-bakes.test.ts` — 6 new assertions pinning the single-source-of-truth invariant (one `ARG`, both installs reference it, exact pin / no caret/tilde, chromium `--with-deps` for JS, `python3 -m playwright install chromium` for Python).
- [x] `vitest run tests/docker/dockerfile-agent-bakes.test.ts` → 11 pass.
- [x] `tsc --noEmit` → clean.

## Risk

Low. Dockerfile-only + test. Adds one image layer (~50MB Python package; browsers shared with the existing JS layer). Lands on the next agent-image rebuild + fleet rollout.

JTBD: **always-on** — a default-enabled skill that `ModuleNotFoundError`s on first use fails the "works on a fresh setup with zero config" defaults test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)