### PR TITLE
fix(telegram): stop subagent-watcher posting card-era "✓ Worker done"

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -14956,26 +14956,11 @@ void (async () => {
               // inside the sub-agent. Belt-and-braces with PR #557's
               // multi-signal progress gate.
               parentStateDir: STATE_DIR,
-              sendNotification: (text: string) => {
-                const ownerChatId = loadAccess().allowFrom[0]
-                if (!ownerChatId) return
-                // #1075: thread-id-bearing — route through swallowingApiCall
-                // so a deleted TOPIC_ID forum thread doesn't crash the
-                // gateway. Notifications are best-effort.
-                void swallowingApiCall(
-                  () =>
-                    lockedBot.api.sendMessage(ownerChatId, text, {
-                      parse_mode: 'HTML',
-                      link_preview_options: { is_disabled: true },
-                      ...(TOPIC_ID != null ? { message_thread_id: TOPIC_ID } : {}),
-                    }),
-                  {
-                    chat_id: ownerChatId,
-                    verb: 'subagent-watcher-notification',
-                    ...(TOPIC_ID != null ? { threadId: TOPIC_ID } : {}),
-                  },
-                )
-              },
+              // No user-facing notification callback: the card-era
+              // "✓ Worker done" message was retired with the progress
+              // card (#1122). Sub-agent completion reaches the user as
+              // the model's own beat-4 handback reply; the watcher's
+              // role here is registry liveness + the `onFinish` cue.
               log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
               // Option C (#393): route stall detections into the progress-card
               // driver so the pinned card re-renders with a ⚠️ indicator even

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -147,11 +147,6 @@ export interface SubagentWatcherConfig {
    */
   agentCwd?: string
   /**
-   * Send a fresh (non-edit) Telegram message. For stall / completion
-   * state-transition notifications.
-   */
-  sendNotification: (text: string) => void
-  /**
    * How often to re-scan for new subagent dirs (ms). Default 1000.
    */
   rescanMs?: number
@@ -862,21 +857,19 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
 
     if (entry.state === 'done' && !entry.completionNotified) {
       entry.completionNotified = true
-      const desc = escapeHtml(truncate(entry.description, 80))
-      const summary = entry.lastSummaryLine
-        ? ` — ${escapeHtml(truncate(entry.lastSummaryLine, 120))}`
-        : ''
-      const tools = entry.toolCount > 0 ? ` (${entry.toolCount} tools)` : ''
-      try {
-        config.sendNotification(`✓ Worker done: ${desc}${tools}${summary}`)
-      } catch (err) {
-        log?.(`subagent-watcher: completion notification error: ${(err as Error).message}`)
-      }
-      // Symmetric `sub_agent_finished` surface (#card-audit-log). Emit
-      // before the deferred cleanup runs so the callback always sees a
-      // live registry entry. Historical entries that already-completed at
-      // boot get their `completionNotified=true` shortcut in registerAgent
-      // and skip this path entirely — only post-boot transitions fire.
+      // Card retired (#1122): the watcher no longer sends a user-facing
+      // "✓ Worker done" message. A framework-authored status line is a
+      // conversational-pacing anti-pattern, and the heuristic that drove
+      // it (silent-stall synthesis) fired on a worker mid-`Bash` as
+      // readily as on a finished one. The user-facing handback is the
+      // model's own beat-4 reply, woken by Claude Code's native
+      // background-task notification. Completion is surfaced here only
+      // via the structured `onFinish` callback — emitted before the
+      // deferred cleanup runs so the callback always sees a live
+      // registry entry. Historical entries that already-completed at
+      // boot get their `completionNotified=true` shortcut in
+      // registerAgent and skip this path — only post-boot transitions
+      // fire.
       if (config.onFinish) {
         try {
           config.onFinish({

--- a/telegram-plugin/tests/fleet-state-watcher.test.ts
+++ b/telegram-plugin/tests/fleet-state-watcher.test.ts
@@ -50,7 +50,6 @@ describe('subagent-watcher: WorkerEntry.lastTool', () => {
     const intervals: Array<{ fn: () => void }> = []
     const w = startSubagentWatcher({
       agentDir,
-      sendNotification: () => {},
       stallThresholdMs: 60_000,
       rescanMs: 500,
       now: () => Date.now(),

--- a/telegram-plugin/tests/subagent-registry-bugs.test.ts
+++ b/telegram-plugin/tests/subagent-registry-bugs.test.ts
@@ -148,7 +148,6 @@ function makeHarnessWithDb(opts: {
   } = opts
 
   let currentTime = 10_000
-  const notifications: string[] = []
   const logs: string[] = []
 
   const fileContents: Map<string, Buffer> = new Map()
@@ -217,7 +216,6 @@ function makeHarnessWithDb(opts: {
 
   const watcher = startSubagentWatcher({
     agentDir,
-    sendNotification: (text) => notifications.push(text),
     stallThresholdMs,
     // Mirror the active-loop threshold for fixtures with toolCount=0;
     // tests that need the silent-synthesis vs active-loop distinction
@@ -257,7 +255,7 @@ function makeHarnessWithDb(opts: {
     if (pollInterval) pollInterval.fn()
   }
 
-  return { notifications, logs, advance, poll, watcher, now: () => currentTime, mockFs, fileContents }
+  return { logs, advance, poll, watcher, now: () => currentTime, mockFs, fileContents }
 }
 
 // ─── Bug 1 — ID mismatch: watcher never bumps last_activity_at ───────────────

--- a/telegram-plugin/tests/subagent-watcher-env-thresholds.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-env-thresholds.test.ts
@@ -84,7 +84,6 @@ function makeHarness(opts: {
     silentSynthesisStallThresholdMs: configStallThresholdMs,
     silentStallTerminalMs: configSilentStallTerminalMs,
     rescanMs: 500,
-    sendNotification: () => {},
     onStall: (_id, idleMs) => stallCalls.push({ idleMs }),
     onStallTerminal: (id) => stallTerminalCalls.push({ agentId: id }),
     onFinish: ({ outcome }) => finishCalls.push({ outcome }),

--- a/telegram-plugin/tests/subagent-watcher-parent-marker.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-parent-marker.test.ts
@@ -86,7 +86,6 @@ describe('subagent-watcher: parent turn-active marker refresh (#501)', () => {
     let nextRef = 1
     const watcher = startSubagentWatcher({
       agentDir: opts.agentDir,
-      sendNotification: () => { /* noop */ },
       stallThresholdMs: 60_000,
       rescanMs: 500,
       now: () => Date.now(),

--- a/telegram-plugin/tests/subagent-watcher-stall-notification.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-stall-notification.test.ts
@@ -26,7 +26,6 @@ function subAgentUserMsg(promptText: string) {
 // ─── Harness (mirrors subagent-watcher.test.ts pattern) ──────────────────────
 
 interface StallHarness {
-  notifications: string[]
   stallCalls: Array<{ agentId: string; idleMs: number; description: string }>
   unstallCalls: Array<{ agentId: string; description: string }>
   logs: string[]
@@ -55,7 +54,6 @@ function makeStallHarness(opts: {
   } = opts
 
   let currentTime = 1000
-  const notifications: string[] = []
   const stallCalls: Array<{ agentId: string; idleMs: number; description: string }> = []
   const unstallCalls: Array<{ agentId: string; description: string }> = []
   const logs: string[] = []
@@ -139,7 +137,6 @@ function makeStallHarness(opts: {
     // silent-synthesis vs active-loop split.
     silentSynthesisStallThresholdMs: silentSynthesisStallThresholdMs ?? stallThresholdMs,
     rescanMs,
-    sendNotification: (text) => notifications.push(text),
     onStall: (id, idle, desc) => stallCalls.push({ agentId: id, idleMs: idle, description: desc }),
     onUnstall: (id, desc) => unstallCalls.push({ agentId: id, description: desc }),
     now: () => currentTime,
@@ -168,7 +165,7 @@ function makeStallHarness(opts: {
     }
   }
 
-  return { notifications, stallCalls, unstallCalls, logs, advance, watcher, now: () => currentTime, fileContents, jsonlPath }
+  return { stallCalls, unstallCalls, logs, advance, watcher, now: () => currentTime, fileContents, jsonlPath }
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/telegram-plugin/tests/subagent-watcher-stall-terminal.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-stall-terminal.test.ts
@@ -127,7 +127,6 @@ function makeHarness(opts: {
     silentSynthesisStallThresholdMs: stallThresholdMs,
     silentStallTerminalMs,
     rescanMs,
-    sendNotification: () => {},
     onStall: (id, idleMs) => stallCalls.push({ agentId: id, idleMs }),
     onUnstall: (id) => unstallCalls.push({ agentId: id }),
     onStallTerminal: (id, desc) => stallTerminalCalls.push({ agentId: id, description: desc }),

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -198,7 +198,10 @@ function makeHarness(opts: {
 
   const watcher = startSubagentWatcher({
     agentDir,
-    sendNotification: (text) => notifications.push(text),
+    // Card retired (#1122): completion surfaces via onFinish, not a
+    // user-facing message. Capture it so the completion assertions still
+    // verify the terminal-transition + de-dup behaviour.
+    onFinish: (info) => notifications.push(`✓ Worker done: ${info.description}`),
     stallThresholdMs,
     // Mirror the active-loop threshold so existing fixtures (which have
     // toolCount=0 and use the simple "advance past N" model) keep
@@ -382,8 +385,13 @@ describe('startSubagentWatcher', () => {
       let nextRef = 1
       const watcher = startSubagentWatcher({
         agentDir: opts.agentDir,
-        sendNotification: (text) => notifications.push(text),
-        ...(opts.onFinish ? { onFinish: opts.onFinish } : {}),
+        // Card retired (#1122): completion surfaces via onFinish. Capture
+        // it for the completion assertions and still delegate to any
+        // test-supplied onFinish.
+        onFinish: (info) => {
+          notifications.push(`✓ Worker done: ${info.description}`)
+          opts.onFinish?.(info)
+        },
         stallThresholdMs: 60_000,
         rescanMs: 500,
         now: () => Date.now(),
@@ -994,7 +1002,8 @@ describe('startSubagentWatcher', () => {
       const watcher = startSubagentWatcher({
         agentDir: opts.agentDir,
         ...(opts.agentCwd !== undefined ? { agentCwd: opts.agentCwd } : {}),
-        sendNotification: (text) => notifications.push(text),
+        // Card retired (#1122): completion surfaces via onFinish.
+        onFinish: (info) => notifications.push(`✓ Worker done: ${info.description}`),
         stallThresholdMs: 60_000,
         rescanMs: 500,
         now: () => Date.now(),
@@ -1133,7 +1142,8 @@ describe('startSubagentWatcher', () => {
       let nextRef = 1
       const watcher = startSubagentWatcher({
         agentDir,
-        sendNotification: (text) => notifications.push(text),
+        // Card retired (#1122): completion surfaces via onFinish.
+        onFinish: (info) => notifications.push(`✓ Worker done: ${info.description}`),
         stallThresholdMs: 60_000,
         rescanMs: 500,
         now: () => Date.now(),


### PR DESCRIPTION
## Summary

The gateway wired the `subagent-watcher`'s `sendNotification` callback to a real Telegram `sendMessage`. When the progress card was retired (#1122) that wiring was never updated — so the watcher kept posting a framework-authored `✓ Worker done: sub-agent (N tools) — …` message straight into the user's chat.

This PR removes the `sendNotification` callback entirely: the config field, the gateway binding, and the call site. Sub-agent completion is still surfaced through the structured `onFinish` callback (unchanged) — which the #1650 background-handback path already consumes.

## Why

Observed in production (agent `finn`, 2026-05-22). The user dispatched a background worker; 4 minutes later they saw `✓ Worker done: sub-agent (13 tools) — I have enough. The root cause is clear…` and assumed the agent had finished and would answer — then silence. The real answer arrived 6 minutes later.

Two defects, both fixed by this removal:

1. **Wrong timing.** The message fires from the watcher's *silent-stall terminal-synthesis* path — a heuristic that declares a worker "done" after ~6 min of JSONL silence. A worker mid-`Bash` (a build, a Coolify deploy) is silent because it is *busy*, not finished. In the incident it fired ~6 min early on a worker still deploying, and separately surfaced a 6-min-stale ghost of an already-answered task.
2. **Wrong author.** A framework-authored status line is a conversational-pacing anti-pattern (`reference/conversational-pacing.md` — *"framework UI elements only paper over the model failing to communicate"*). Post-card, the user-facing handback is the model's own **beat 4** reply, woken by Claude Code's native background-task notification — which already delivers it reliably (the `<task-notification>` mechanism appears hundreds of times across transcript history; switchroom's own `subagent_handback` reconstruction, twice).

The watcher's role is now registry liveness + the `onFinish` cue — never a user-facing message.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `check-bot-api-wrapping.sh` + `check-plugin-references.mjs` — clean
- [x] `vitest telegram-plugin/` — 168 files, 2788 tests pass
- [x] The `Worker done` completion tests in `subagent-watcher.test.ts` now capture `onFinish` (the surviving completion signal) instead of `sendNotification`; de-dup / not-at-boot / not-for-historical coverage is preserved

## Risk

Low — pure removal of a user-facing surface. No change to completion detection, the registry, stall detection, or the #1650 handback. A finished sub-agent whose JSONL lacks a `turn_end` line is unaffected: Claude Code's native `<task-notification>` still delivers the answer.

## Follow-ups (not in this PR)

- The *silent-stall terminal synthesis* still exists and still feeds `onFinish` → it can fire the #1650 handback on a false (mid-`Bash`) stall. Rare today (#1650's `background` flag misdetects the current `Agent` dispatch shape, so the handback seldom delivers). Worth a separate look at retiring the card-era synthesis and/or re-grounding #1650 on the harness `<task-notification>`.

JTBD: `know-what-my-agent-is-doing` — the chat must not lie about whether a delegated job is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)