### PR TITLE
docs: add Vault & shared-state test discipline (HARD RULES)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,45 @@ These rules are permanent guidance for every phase of the docker migration, not 
 - Project-scoped compose teardown is also fine: `docker compose -p <project> down -v --remove-orphans`. Scope is the compose project name — won't touch anything outside it.
 - If you find yourself wanting to "just clean everything up", STOP and ask.
 
+## Vault & shared-state test discipline (HARD RULES)
+
+Same principle as the Docker rules above: tests run on the **live
+operator host**. `~/.switchroom/` is the production state tree — the
+real encrypted vault, audit log, grants DB, and per-agent scaffolds. A
+test that writes there corrupts a running fleet.
+
+**On 2026-05-22 a vault/broker test did exactly this:** it created its
+fixture vault at the *default* path and truncated the production
+`~/.switchroom/vault/vault.enc` from 77 keys to a 414-byte test vault,
+and forked the `vault-audit.log` hash chain. The fleet survived only
+because the broker re-persists the whole vault on the next `put` and a
+token rotation happened to heal the disk before any broker restart. Do
+not rely on that luck.
+
+- Any test that constructs a `VaultBroker`, opens/saves a vault
+  (`openVault` / `saveVault` / `createVault`), or writes the audit log
+  MUST point every path at an isolated tmpdir
+  (`mkdtempSync(join(tmpdir(), "…"))`). Never `~/.switchroom/`.
+- **The dangerous defaults** — each resolves to *production* when you
+  omit an override:
+  - `new VaultBroker(...)` with no `vaultPath` arg and no
+    `config.vault.path` → `~/.switchroom/vault.enc`.
+  - `createAuditLogger()` with no path → `~/.switchroom/vault-audit.log`.
+  - `openVault` / `saveVault` / `getVaultPath()` fall back to
+    `~/.switchroom/vault.enc`.
+  In tests, construct the broker via the `_testVaultPath` +
+  `_testAuditLogger` hooks on the constructor's test-options arg (see
+  `src/vault/broker/server.ts`), or pass an explicit tmp `vaultPath`.
+  `tests/integration/vault-broker-e2e.test.ts` is the canonical
+  isolated pattern (`mkdtempSync` → tmp vault + tmp socket) — copy it.
+- The same applies to the grants DB (`vault-grants.db`), per-agent
+  `.vault-token` files, and anything else under `~/.switchroom/`.
+- A test that needs the *real* broker (a true e2e) still gets an
+  isolated `SWITCHROOM_VAULT_PATH` / config + its own tmp socket — it
+  never shares the operator's vault.
+- If you're about to run a vault/broker test and can't point to where
+  its tmpdir is, STOP — assume it will hit production.
+
 ## Design contract
 
 `reference/` is the design contract for any non-trivial change. Three

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,8 +249,10 @@ not rely on that luck.
   - `new VaultBroker(...)` with no `vaultPath` arg and no
     `config.vault.path` → `~/.switchroom/vault.enc`.
   - `createAuditLogger()` with no path → `~/.switchroom/vault-audit.log`.
-  - `openVault` / `saveVault` / `getVaultPath()` fall back to
-    `~/.switchroom/vault.enc`.
+  - `openVault` / `saveVault` take a *required* `vaultPath` — but
+    `getVaultPath()` (`src/cli/vault.ts`) falls back to
+    `~/.switchroom/vault.enc`, so a test that derives its path from
+    `getVaultPath()` hits production.
   In tests, construct the broker via the `_testVaultPath` +
   `_testAuditLogger` hooks on the constructor's test-options arg (see
   `src/vault/broker/server.ts`), or pass an explicit tmp `vaultPath`.


### PR DESCRIPTION
## Summary

Adds a **"Vault & shared-state test discipline (HARD RULES)"** section to `CLAUDE.md` — a sibling of the existing "Docker test discipline" section.

## Why

On **2026-05-22** a vault/broker test running on the live operator host created its fixture vault at the *default* path and **truncated the production `~/.switchroom/vault/vault.enc` from 77 keys to a 414-byte test vault**, and forked the `vault-audit.log` hash chain.

The fleet survived only by luck: the broker re-persists the entire vault to disk on every `put` (`server.ts:1533`), and a routine OAuth-token rotation did a `put` that healed the disk file ~2 minutes before any broker restart. The broker does **not** persist on SIGTERM (`server.ts:2685`), so a restart in the corruption window would have permanently lost 77 secrets.

Root cause: nothing tells contributors (human or agent) that the broker's default paths **are production**:
- `new VaultBroker(...)` with no `vaultPath` / `config.vault.path` → `~/.switchroom/vault.enc`
- `createAuditLogger()` with no path → `~/.switchroom/vault-audit.log`
- `openVault` / `saveVault` / `getVaultPath()` → fall back to `~/.switchroom/vault.enc`

A test that omits the `_testVaultPath` / `_testAuditLogger` hooks silently clobbers a live fleet.

## What this PR does

Documents the hard rule: vault/broker/audit-log tests MUST use an isolated tmpdir; names the dangerous defaults explicitly; cites `tests/integration/vault-broker-e2e.test.ts` as the canonical isolated pattern to copy.

## Follow-up (recommended, separate PR)

A **structural guard** that makes the default vault/audit-log path resolution *throw* when running under the test runner — so a mis-isolated test fails loudly instead of corrupting production. This doc is the guidance; the guard is the enforcement. Candidate offending tests to audit when that lands: `src/vault/broker/server-grants.test.ts`, `client-token.test.ts`, `scope.test.ts`, `server.test.ts` (all use `myagent` / `foo` fixtures matching the incident's audit-log signature).

## Test plan

- [x] Docs-only change. `AGENTS.md` / `AGENT.md` are symlinks to `CLAUDE.md` — edited the canonical file.

## Risk

None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)