### PR TITLE
fix(vault): redirect mis-isolated broker tests away from the live vault

### DIFF
--- a/src/vault/broker/audit-log.ts
+++ b/src/vault/broker/audit-log.ts
@@ -27,6 +27,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { chainRow, seedChain, type ChainState } from "../../util/audit-hashchain.js";
+import { safeAuditLogPath } from "./test-isolation-guard.js";
 
 /** Operations the broker can perform. (PR-6: `approval_consume_record`
  *  is an additive member of the shared broker/kernel request union, so
@@ -149,7 +150,11 @@ export function callerFromPeer(peer: {
  * Linux for a low-volume audit channel.
  */
 export function createAuditLogger(opts: AuditLoggerOptions = {}): AuditLogger {
-  const logPath = opts.path ?? defaultAuditLogPath();
+  // test-isolation guard: under the test runner, a would-be-production
+  // path (a broker built without an explicit _testAuditLogger) is
+  // redirected to a tmp file so tests can't pollute the operator's real
+  // vault-audit.log. No-op in production. See test-isolation-guard.ts.
+  const logPath = safeAuditLogPath(opts.path ?? defaultAuditLogPath());
   // sec WS10-F2 / #1417: per-row hash chain for tamper-evidence.
   // Seeded once from the existing log tail at broker startup; advanced
   // in-process per write (single-writer-process contract — see

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -51,6 +51,7 @@ import {
   type BrokerStatus,
 } from "./protocol.js";
 import { createAuditLogger, callerFromPeer, type AuditLogger } from "./audit-log.js";
+import { safeVaultPath } from "./test-isolation-guard.js";
 import { Database } from "bun:sqlite";
 import { mintGrant, validateGrant, validateGrantForWrite, revokeGrant, listGrants, migrateGrantsSchema } from "../grants.js";
 import { openGrantsDb } from "../grants-db.js";
@@ -198,7 +199,9 @@ export class VaultBroker {
       );
     }
     if (testOpts._testVaultPath !== undefined) {
-      this.vaultPath = testOpts._testVaultPath;
+      // test-isolation guard: redirect a _testVaultPath that points
+      // into the real ~/.switchroom tree to an isolated tmpdir.
+      this.vaultPath = safeVaultPath(testOpts._testVaultPath);
     }
 
     // Use the injected logger for tests; create the real one for production.
@@ -268,6 +271,11 @@ export class VaultBroker {
     } else {
       this.vaultPath = resolvePath(this.config.vault?.path ?? "~/.switchroom/vault.enc");
     }
+    // test-isolation guard: under the test runner, redirect a vault
+    // path that resolved into the real ~/.switchroom tree to an
+    // isolated tmpdir, so a mis-isolated test can neither read nor
+    // clobber the operator's live vault. No-op in production.
+    this.vaultPath = safeVaultPath(this.vaultPath);
 
     // Pre-load secrets if test opts provided
     if (this.testOpts._testSecrets !== undefined) {

--- a/src/vault/broker/test-isolation-guard.test.ts
+++ b/src/vault/broker/test-isolation-guard.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the vault/broker test-isolation guard.
+ *
+ * These run under vitest, so `isTestRuntime()` is true throughout — the
+ * redirect behaviour is exercised directly.
+ */
+import { describe, it, expect } from "vitest";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  isTestRuntime,
+  isUnderRealSwitchroomHome,
+  safeVaultPath,
+  safeAuditLogPath,
+} from "./test-isolation-guard.js";
+
+const realHome = resolve(homedir(), ".switchroom");
+const realTmp = resolve(tmpdir());
+
+describe("test-isolation-guard", () => {
+  it("isTestRuntime() is true under the test runner", () => {
+    expect(isTestRuntime()).toBe(true);
+  });
+
+  describe("isUnderRealSwitchroomHome", () => {
+    it("is true for the ~/.switchroom dir itself and paths inside it", () => {
+      expect(isUnderRealSwitchroomHome(realHome)).toBe(true);
+      expect(isUnderRealSwitchroomHome(join(realHome, "vault", "vault.enc"))).toBe(true);
+      expect(isUnderRealSwitchroomHome(join(realHome, "vault-audit.log"))).toBe(true);
+    });
+
+    it("is false for an isolated tmpdir path", () => {
+      expect(isUnderRealSwitchroomHome(join(realTmp, "x", "vault.enc"))).toBe(false);
+    });
+
+    it("is not fooled by a sibling prefix (~/.switchroom-config)", () => {
+      // `${home}.switchroom-config` shares the `.switchroom` prefix but
+      // is NOT inside the `.switchroom/` dir — the sep check guards this.
+      expect(isUnderRealSwitchroomHome(realHome + "-config/x")).toBe(false);
+    });
+  });
+
+  describe("safeVaultPath", () => {
+    it("redirects a production vault path to an isolated tmpdir", () => {
+      const prod = join(realHome, "vault", "vault.enc");
+      const safe = safeVaultPath(prod);
+      expect(safe).not.toBe(prod);
+      expect(isUnderRealSwitchroomHome(safe)).toBe(false);
+      expect(safe.startsWith(realTmp)).toBe(true);
+      expect(safe.endsWith("vault.enc")).toBe(true);
+    });
+
+    it("returns an already-isolated tmp path unchanged", () => {
+      const isolated = join(realTmp, "sw-test-xyz", "vault.enc");
+      expect(safeVaultPath(isolated)).toBe(isolated);
+    });
+
+    it("hands out a FRESH dir per call so two brokers never collide", () => {
+      const prod = join(realHome, "vault.enc");
+      expect(safeVaultPath(prod)).not.toBe(safeVaultPath(prod));
+    });
+
+    it("honours the SWITCHROOM_ALLOW_PROD_VAULT_IN_TEST escape hatch", () => {
+      const prod = join(realHome, "vault.enc");
+      const prev = process.env.SWITCHROOM_ALLOW_PROD_VAULT_IN_TEST;
+      process.env.SWITCHROOM_ALLOW_PROD_VAULT_IN_TEST = "1";
+      try {
+        expect(safeVaultPath(prod)).toBe(prod);
+      } finally {
+        if (prev === undefined) delete process.env.SWITCHROOM_ALLOW_PROD_VAULT_IN_TEST;
+        else process.env.SWITCHROOM_ALLOW_PROD_VAULT_IN_TEST = prev;
+      }
+    });
+  });
+
+  describe("safeAuditLogPath", () => {
+    it("redirects a production audit-log path to an isolated tmp file", () => {
+      const prod = join(realHome, "vault-audit.log");
+      const safe = safeAuditLogPath(prod);
+      expect(safe).not.toBe(prod);
+      expect(isUnderRealSwitchroomHome(safe)).toBe(false);
+      expect(safe.startsWith(realTmp)).toBe(true);
+    });
+
+    it("returns an already-isolated tmp path unchanged", () => {
+      const isolated = join(realTmp, "sw-test-audit-xyz", "vault-audit.log");
+      expect(safeAuditLogPath(isolated)).toBe(isolated);
+    });
+
+    it("reuses one shared tmp file per process (append-only telemetry)", () => {
+      const prod = join(realHome, "vault-audit.log");
+      expect(safeAuditLogPath(prod)).toBe(safeAuditLogPath(prod));
+    });
+  });
+});

--- a/src/vault/broker/test-isolation-guard.test.ts
+++ b/src/vault/broker/test-isolation-guard.test.ts
@@ -3,6 +3,12 @@
  *
  * These run under vitest, so `isTestRuntime()` is true throughout — the
  * redirect behaviour is exercised directly.
+ *
+ * SWITCHROOM_HERMETICITY_LINT: allow-real-home — this test is the
+ * proof-of-redirect for the guard itself, so it MUST compute the real
+ * `~/.switchroom` path via `homedir()` to assert that the guard
+ * rewrites it away. The redirect is what makes referencing real-home
+ * safe here; the lint exemption is the documented escape hatch.
  */
 import { describe, it, expect } from "vitest";
 import { homedir, tmpdir } from "node:os";

--- a/src/vault/broker/test-isolation-guard.ts
+++ b/src/vault/broker/test-isolation-guard.ts
@@ -1,0 +1,116 @@
+/**
+ * test-isolation-guard — keeps a vault/broker test from touching the
+ * operator's PRODUCTION state tree (`~/.switchroom/`).
+ *
+ * Background: on 2026-05-22 a broker test running on the live host
+ * resolved its vault path to the default `~/.switchroom/vault/vault.enc`
+ * and a `put` re-encrypted the whole 414-byte fixture vault over the
+ * operator's real 77-key vault. See "Vault & shared-state test
+ * discipline" in CLAUDE.md.
+ *
+ * Policy: **redirect, don't throw.** Under the test runner, a vault or
+ * audit-log path that resolves into the real `~/.switchroom` tree is
+ * silently redirected to an isolated tmpdir (with a one-time stderr
+ * warning). A throw would fail dozens of pre-existing mis-isolated
+ * broker tests for no safety gain — redirection makes mis-isolation
+ * *harmless* instead of *catastrophic*, which is the actual goal. The
+ * CLAUDE.md directive remains the human-facing teaching; this module is
+ * the safety net.
+ *
+ * Every check is a no-op outside the test runner — production is
+ * untouched. `SWITCHROOM_ALLOW_PROD_VAULT_IN_TEST=1` disables it for
+ * the rare test that genuinely must use the real tree.
+ */
+import { mkdtempSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
+
+/** True when running under vitest (`VITEST`) or any `NODE_ENV=test` runner. */
+export function isTestRuntime(): boolean {
+  return process.env.NODE_ENV === "test" || process.env.VITEST !== undefined;
+}
+
+/** Escape hatch for the rare test that genuinely must use the real tree. */
+function escapeHatchSet(): boolean {
+  return process.env.SWITCHROOM_ALLOW_PROD_VAULT_IN_TEST === "1";
+}
+
+/**
+ * Absolute path to the operator's real `~/.switchroom` dir, resolved
+ * from `os.homedir()` at call time — so a test that overrides `$HOME`
+ * to a tmpdir is correctly seen as already isolated.
+ */
+function realSwitchroomHome(): string {
+  return resolve(homedir(), ".switchroom");
+}
+
+/** True if `p` is the real `~/.switchroom` dir or a path inside it. */
+export function isUnderRealSwitchroomHome(p: string): boolean {
+  const home = realSwitchroomHome();
+  const r = resolve(p);
+  return r === home || r.startsWith(home + sep);
+}
+
+let warnedVault = false;
+
+/**
+ * Given the vault path a broker resolved, return a safe one. Outside
+ * the test runner — or for a path already outside `~/.switchroom` — the
+ * path is returned unchanged. Under the test runner a path inside the
+ * real `~/.switchroom` tree is redirected to a FRESH per-call tmpdir,
+ * so a mis-isolated broker can neither read nor clobber the operator's
+ * live vault. A fresh dir per call keeps two brokers in two tests from
+ * colliding on one file.
+ */
+export function safeVaultPath(requestedPath: string): string {
+  if (!isTestRuntime() || escapeHatchSet()) return requestedPath;
+  if (!isUnderRealSwitchroomHome(requestedPath)) return requestedPath;
+  const redirected = join(
+    mkdtempSync(join(tmpdir(), "sw-test-vault-")),
+    "vault.enc",
+  );
+  if (!warnedVault) {
+    warnedVault = true;
+    process.stderr.write(
+      `[test-isolation guard] vault path redirected away from the ` +
+        `production tree to an isolated tmpdir — a vault/broker test ` +
+        `resolved its vault path inside ~/.switchroom. See CLAUDE.md ` +
+        `"Vault & shared-state test discipline".\n`,
+    );
+  }
+  return redirected;
+}
+
+let warnedAudit = false;
+let cachedTmpAuditLog: string | undefined;
+
+/**
+ * Given the audit-log path a caller wants, return a safe one. Outside
+ * the test runner — or for a path already outside `~/.switchroom` — the
+ * path is returned unchanged. Under the test runner a would-be-
+ * production path is redirected to a per-process tmp file, so a broker
+ * constructed without an explicit `_testAuditLogger` cannot pollute the
+ * operator's real `vault-audit.log` (or desync its tamper-evident hash
+ * chain). One shared file per process is fine here — the audit log is
+ * append-only telemetry, not per-test state.
+ */
+export function safeAuditLogPath(requestedPath: string): string {
+  if (!isTestRuntime() || escapeHatchSet()) return requestedPath;
+  if (!isUnderRealSwitchroomHome(requestedPath)) return requestedPath;
+  if (!cachedTmpAuditLog) {
+    cachedTmpAuditLog = join(
+      mkdtempSync(join(tmpdir(), "sw-test-audit-")),
+      "vault-audit.log",
+    );
+  }
+  if (!warnedAudit) {
+    warnedAudit = true;
+    process.stderr.write(
+      `[test-isolation guard] audit log redirected away from the ` +
+        `production path to ${cachedTmpAuditLog} — a broker was ` +
+        `constructed without _testAuditLogger. See CLAUDE.md ` +
+        `"Vault & shared-state test discipline".\n`,
+    );
+  }
+  return cachedTmpAuditLog;
+}


### PR DESCRIPTION
## Summary

Structural enforcement for the **"Vault & shared-state test discipline"** directive added in #1660. The directive is the human-facing teaching; this is the safety net that makes the failure mode impossible.

## Background

On **2026-05-22** a broker test running on the live operator host resolved its vault path to the default `~/.switchroom/vault/vault.enc` and a `put` re-encrypted a 414-byte fixture vault over the operator's real **77-key vault**. The fleet survived only by luck (the broker re-persists on the next `put`, and a token rotation healed the disk before any broker restart).

## What this PR does

New `src/vault/broker/test-isolation-guard.ts` — under the test runner only (`VITEST` / `NODE_ENV=test`), a path that resolves inside the real `~/.switchroom` tree is redirected to an isolated tmpdir:

- **`safeVaultPath()`** — wired into `VaultBroker` vault-path resolution (`start()` + the `_testVaultPath` hook). Fresh tmpdir per call, so two brokers never collide.
- **`safeAuditLogPath()`** — wired into `createAuditLogger()`. One shared tmp file per process (the audit log is append-only telemetry).

**Policy: redirect, not throw.** A throw would fail dozens of pre-existing mis-isolated broker tests for no safety gain. Redirection makes mis-isolation *harmless* instead of *catastrophic* — the actual goal — with a one-time stderr warning so it stays visible. `SWITCHROOM_ALLOW_PROD_VAULT_IN_TEST=1` is the escape hatch. Every check is a **no-op outside the test runner**, so production path resolution is byte-for-byte unchanged.

## Measured impact

Running the broker `bun test` suite on a host with a populated `~/.switchroom`:
- **Before:** 83 test cases resolved their vault path to the production tree.
- **After:** 81 are isolated automatically. The remaining 2 (`client-token.test.ts` grant-expired/revoked) **fail identically on `upstream/main` without this change** — verified by reverting the guard — they are a separate pre-existing host-state dependency (the `.vault-token` / standing-ACL fall-through path), out of scope here and noted as a follow-up.

CI runs on a clean `~/.switchroom`, so `bun-test` was and remains green; this guard makes the **dev-host** runs safe.

## Test plan

- [x] `src/vault/broker/test-isolation-guard.test.ts` — 11 new vitest cases (redirect of prod paths, passthrough of tmp paths, fresh-dir-per-call, shared audit file, sibling-prefix `~/.switchroom-config` safety, escape hatch).
- [x] `vitest run src/vault/` → 256 pass, 0 fail.
- [x] broker `bun test` (15 files) → 160 pass, 2 pre-existing fail (above).
- [x] `tsc --noEmit` → clean.

## Risk

Low. Test-runtime-only behaviour; production resolution is unchanged (`isTestRuntime()` false → guard returns input verbatim).

## Follow-up

The 2 `client-token.test.ts` failures + the `.vault-token` agents-dir mis-isolation are a separate, pre-existing fix — same disease, different path, worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)