### PR TITLE
fix(auth): tie Google Workspace OAuth scopes to the tier (#1663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## unreleased — Google Workspace OAuth scopes tied to the tier
+
+### fix(auth) — mint Slides/Docs/Sheets OAuth scopes so agents can edit Workspace files (#1663)
+
+Agents could read Drive and create plain Drive files but could not
+create or edit native Google **Slides / Docs / Sheets** — the
+auth-broker token only carried Drive scopes. Any Docs/Sheets/Slides API
+call 403'd, and the upstream Google Workspace MCP then fell back to its
+own browser OAuth on port 8000 (unrecoverable inside a container).
+
+- `switchroom auth google account add` now mints the Workspace API
+  scopes (`documents`, `spreadsheets`, and — at `extended`/`complete` —
+  `presentations`) alongside the Drive scopes. The scope set is **tied
+  to `google_workspace.tier`** so every tool a tier exposes can
+  authenticate. Calendar/Forms/Tasks/Chat/Gmail scopes are deliberately
+  out of scope (separate decision).
+- The `gdrive` MCP launcher runs a scope↔tier preflight at startup: a
+  token missing scopes the tier needs produces a loud, actionable
+  stderr warning naming the exact `account add --replace` recovery
+  command — instead of upstream's silent doomed port-8000 fallback.
+- The launcher also moves the upstream MCP's OAuth callback port off
+  8000 (`SWITCHROOM_GDRIVE_MCP_PORT`, default `8631`) so the fallback,
+  if ever triggered, no longer collides with whatever the host runs on
+  8000.
+- Changing the tier requires re-running `account add --replace` — OAuth
+  scopes are fixed at consent time. Documented in
+  `docs/google-workspace.md`.
+
 ## v0.13.12 — quieter turns: no duplicate wrap-up, no card-era worker pings
 
 Three production message-noise fixes plus the agent-image Playwright

--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -216,9 +216,45 @@ switchroom auth google account add you@gmail.com --replace --write
 files and edit files **they create**, but cannot edit your pre-existing
 unrelated Drive files (that would be the full `drive` scope, which
 switchroom deliberately does not request). It does **not** change
-behaviour for read-only accounts. The Workspace `tier` knob
-(`core`/`extended`/`complete`) controls which upstream MCP *tools* are
-exposed — it is independent of these OAuth scopes.
+behaviour for read-only accounts.
+
+#### Workspace API scopes are tied to the tier
+
+Creating or editing **native Google Docs / Sheets / Slides** needs
+product-specific OAuth scopes on top of the Drive scopes — `drive.file`
+alone authorizes a Drive *file object*, not a `documents.batchUpdate` /
+`spreadsheets.batchUpdate` / `presentations.batchUpdate` call. So
+`account add` mints those scopes alongside Drive, and **ties the set to
+the `tier`** in your `google_workspace:` block:
+
+| tier       | Workspace API scopes minted             |
+|------------|-----------------------------------------|
+| `core`     | `documents`, `spreadsheets`             |
+| `extended` | `documents`, `spreadsheets`, `presentations` |
+| `complete` | `documents`, `spreadsheets`, `presentations` |
+
+`presentations` (Slides) is added at `extended`/`complete` because
+Slides tools first appear at the `extended` tier. Calendar / Forms /
+Tasks / Chat / Gmail scopes are **not** minted — that is a separate,
+larger decision (Gmail in particular has an unresolved approval shape;
+see RFC G §5).
+
+**Changing the tier requires re-running `account add`.** OAuth scopes
+are fixed at consent time — raising `tier: core` → `tier: extended`
+does **not** retroactively widen an already-minted token. After a tier
+change, re-mint:
+
+```bash
+switchroom auth google account add you@gmail.com --replace [--write]
+```
+
+If you skip the re-mint, the `gdrive` MCP launcher prints a loud
+warning at startup naming the missing scopes and the exact recovery
+command — and the affected tools (Docs/Sheets/Slides create+edit) fail
+cleanly instead of triggering the upstream MCP's own browser OAuth
+(which binds a callback port that is unrecoverable inside a container).
+`switchroom auth google account list` shows each token's effective
+scopes.
 
 ### Removing an account
 

--- a/docs/google-workspace.md
+++ b/docs/google-workspace.md
@@ -256,6 +256,14 @@ cleanly instead of triggering the upstream MCP's own browser OAuth
 `switchroom auth google account list` shows each token's effective
 scopes.
 
+> **Port override.** That doomed upstream OAuth fallback binds a
+> callback server on a local port. The launcher moves it off the
+> upstream default (`8000`, commonly taken on a shared host) to
+> `8631`. If `8631` also collides, set `SWITCHROOM_GDRIVE_MCP_PORT`
+> in the agent's environment to a free port. This only affects the
+> never-meant-to-run fallback path — the seeded, browserless flow
+> doesn't bind a port at all.
+
 ### Removing an account
 
 ```bash

--- a/src/cli/auth-google.ts
+++ b/src/cli/auth-google.ts
@@ -607,7 +607,7 @@ function registerAccountAdd(accountParent: Command): void {
         // sizeable trees (Drive scaffolding, AES vault) that the
         // sibling enable/disable/list verbs don't need.
         const [
-          { runDriveOAuthFlow, selectDriveAccountScopes },
+          { runDriveOAuthFlow, selectGoogleWorkspaceScopes },
           { selectInitialTier },
           { brokerCall },
           { loadConfig, resolvePath },
@@ -733,7 +733,18 @@ function registerAccountAdd(accountParent: Command): void {
           );
         }
 
-        const accountScopes = selectDriveAccountScopes(opts.write ?? false);
+        // Tie the OAuth scope set to the configured Workspace tier
+        // (issue #1663). `gw.tier` defaults to `core` when unset — same
+        // default as GoogleWorkspaceTierSchema. core/extended/complete
+        // all mint Docs+Sheets scopes; extended/complete add Slides, so
+        // the token a tier mints can drive every tool that tier exposes
+        // (instead of advertising Slides/Docs/Sheets tools that 403 and
+        // trigger upstream's doomed port-8000 OAuth fallback).
+        const tier = gw.tier ?? "core";
+        const accountScopes = selectGoogleWorkspaceScopes({
+          write: opts.write ?? false,
+          tier,
+        });
         const oauthCfg = {
           client_id: clientIdRaw,
           client_secret: clientSecretRaw,
@@ -746,6 +757,21 @@ function registerAccountAdd(accountParent: Command): void {
             ),
           );
         }
+        console.log(
+          chalk.gray(
+            `  Workspace tier: ${tier} — requesting Docs + Sheets` +
+              (tier === "extended" || tier === "complete"
+                ? " + Slides"
+                : "") +
+              " API scopes so the tier's tools can authenticate.",
+          ),
+        );
+        console.log(
+          chalk.gray(
+            "  Changing the tier later requires re-running this command\n" +
+              "  (`--replace`) — OAuth scopes are fixed at consent time.",
+          ),
+        );
         // OAuthEnv is a shaped subset of process.env — picking the
         // fields the selector reads (rather than passing process.env
         // wholesale) keeps the call typed.

--- a/src/cli/drive-mcp-launcher.test.ts
+++ b/src/cli/drive-mcp-launcher.test.ts
@@ -326,11 +326,15 @@ describe("findMissingWorkspaceScopes — scope↔tier preflight (#1663)", () => 
 });
 
 describe("buildMissingScopeWarning — actionable re-mint guidance (#1663)", () => {
+  const DRIVE_FILE = "https://www.googleapis.com/auth/drive.file";
+  const PRESENTATIONS = "https://www.googleapis.com/auth/presentations";
+
   it("names the account, the tier, and the exact recovery command", () => {
     const msg = buildMissingScopeWarning(
-      ["https://www.googleapis.com/auth/presentations"],
+      [PRESENTATIONS],
       "extended",
       "you@example.com",
+      false,
     );
     expect(msg).toContain("you@example.com");
     expect(msg).toContain("extended");
@@ -340,13 +344,29 @@ describe("buildMissingScopeWarning — actionable re-mint guidance (#1663)", () 
     );
   });
 
-  it("appends --write when drive.file is among the missing scopes", () => {
-    const msg = buildMissingScopeWarning(
-      ["https://www.googleapis.com/auth/drive.file"],
-      "core",
-      "a@b.com",
-    );
+  it("appends --write when the EXISTING token already carries drive.file", () => {
+    // findMissingWorkspaceScopes never returns drive.file — the --write
+    // suffix must be driven by the existing token's scopes, not by the
+    // missing set. A write-capable token's recovery command MUST keep
+    // --write or running it verbatim silently downgrades to read-only.
+    const missing = findMissingWorkspaceScopes(DRIVE_FILE, "core");
+    expect(missing).toEqual([
+      "https://www.googleapis.com/auth/documents",
+      "https://www.googleapis.com/auth/spreadsheets",
+    ]);
+    expect(missing).not.toContain(DRIVE_FILE);
+    const msg = buildMissingScopeWarning(missing, "core", "a@b.com", true);
     expect(msg).toContain("--replace --write");
+  });
+
+  it("omits --write when the existing token has no drive.file scope", () => {
+    // A read-only token: the recovery command must NOT add --write, so
+    // the re-minted token stays read-only and capability isn't widened
+    // beyond what the operator originally consented to.
+    const missing = findMissingWorkspaceScopes("", "core");
+    const msg = buildMissingScopeWarning(missing, "core", "a@b.com", false);
+    expect(msg).toContain("--replace\n");
+    expect(msg).not.toContain("--write");
   });
 });
 

--- a/src/cli/drive-mcp-launcher.test.ts
+++ b/src/cli/drive-mcp-launcher.test.ts
@@ -14,13 +14,17 @@ import {
   AIOFILE_PIN,
   AIOFILE_PKG,
   buildChildEnv,
+  buildMissingScopeWarning,
   buildSeedCredentials,
   buildUvxArgs,
   encodeCredentialsFilename,
   classifyRootSchema,
+  findMissingWorkspaceScopes,
+  requiredWorkspaceScopesForTier,
   resolveCredentialsDir,
   sanitizeToolsListMessage,
 } from "./drive-mcp-launcher.js";
+import { workspaceScopesForTier } from "./drive.js";
 import { GOOGLE_WORKSPACE_MCP_PINNED_SHA } from "../memory/scaffold-integration.js";
 
 describe("buildSeedCredentials — exact upstream shape", () => {
@@ -244,6 +248,105 @@ describe("buildChildEnv — strips --single-user-incompatible knobs", () => {
     const base = { MCP_ENABLE_OAUTH21: "1" };
     buildChildEnv(base, "/tmp/c", "you@example.com");
     expect(base.MCP_ENABLE_OAUTH21).toBe("1");
+  });
+
+  it("moves WORKSPACE_MCP_PORT off 8000 to neutralize the doomed fallback (#1663)", () => {
+    const env = buildChildEnv({}, "/tmp/c", "you@example.com");
+    expect(env.WORKSPACE_MCP_PORT).toBe("8631");
+    expect(env.WORKSPACE_MCP_PORT).not.toBe("8000");
+  });
+
+  it("honours SWITCHROOM_GDRIVE_MCP_PORT override", () => {
+    const env = buildChildEnv(
+      { SWITCHROOM_GDRIVE_MCP_PORT: "9123" },
+      "/tmp/c",
+      "you@example.com",
+    );
+    expect(env.WORKSPACE_MCP_PORT).toBe("9123");
+  });
+
+  it("does not clobber an explicitly-set WORKSPACE_MCP_PORT", () => {
+    const env = buildChildEnv(
+      { WORKSPACE_MCP_PORT: "8042" },
+      "/tmp/c",
+      "you@example.com",
+    );
+    expect(env.WORKSPACE_MCP_PORT).toBe("8042");
+  });
+});
+
+describe("requiredWorkspaceScopesForTier — stays in sync with drive.ts (#1663)", () => {
+  it("matches workspaceScopesForTier for every tier", () => {
+    for (const tier of ["core", "extended", "complete"] as const) {
+      expect(requiredWorkspaceScopesForTier(tier)).toEqual(
+        workspaceScopesForTier(tier),
+      );
+    }
+  });
+
+  it("undefined tier behaves as core", () => {
+    expect(requiredWorkspaceScopesForTier(undefined)).toEqual(
+      workspaceScopesForTier("core"),
+    );
+  });
+});
+
+describe("findMissingWorkspaceScopes — scope↔tier preflight (#1663)", () => {
+  const DOCS = "https://www.googleapis.com/auth/documents";
+  const SHEETS = "https://www.googleapis.com/auth/spreadsheets";
+  const SLIDES = "https://www.googleapis.com/auth/presentations";
+
+  it("seed with all core scopes → nothing missing for core", () => {
+    const seed = `https://www.googleapis.com/auth/drive.readonly ${DOCS} ${SHEETS}`;
+    expect(findMissingWorkspaceScopes(seed, "core")).toEqual([]);
+  });
+
+  it("Drive-only seed (pre-#1663 token) → core flags Docs + Sheets missing", () => {
+    const seed = "https://www.googleapis.com/auth/drive.readonly";
+    expect(findMissingWorkspaceScopes(seed, "core")).toEqual([DOCS, SHEETS]);
+  });
+
+  it("core-scoped seed on an extended tier → flags Slides missing", () => {
+    const seed = `${DOCS} ${SHEETS}`;
+    expect(findMissingWorkspaceScopes(seed, "extended")).toEqual([SLIDES]);
+  });
+
+  it("full extended seed → nothing missing for extended", () => {
+    const seed = `${DOCS} ${SHEETS} ${SLIDES}`;
+    expect(findMissingWorkspaceScopes(seed, "extended")).toEqual([]);
+  });
+
+  it("empty seed scope string → all tier scopes missing", () => {
+    expect(findMissingWorkspaceScopes("", "extended")).toEqual([
+      DOCS,
+      SHEETS,
+      SLIDES,
+    ]);
+  });
+});
+
+describe("buildMissingScopeWarning — actionable re-mint guidance (#1663)", () => {
+  it("names the account, the tier, and the exact recovery command", () => {
+    const msg = buildMissingScopeWarning(
+      ["https://www.googleapis.com/auth/presentations"],
+      "extended",
+      "you@example.com",
+    );
+    expect(msg).toContain("you@example.com");
+    expect(msg).toContain("extended");
+    expect(msg).toContain("presentations");
+    expect(msg).toContain(
+      "switchroom auth google account add you@example.com --replace",
+    );
+  });
+
+  it("appends --write when drive.file is among the missing scopes", () => {
+    const msg = buildMissingScopeWarning(
+      ["https://www.googleapis.com/auth/drive.file"],
+      "core",
+      "a@b.com",
+    );
+    expect(msg).toContain("--replace --write");
   });
 });
 

--- a/src/cli/drive-mcp-launcher.ts
+++ b/src/cli/drive-mcp-launcher.ts
@@ -264,6 +264,9 @@ export function findMissingWorkspaceScopes(
   return requiredWorkspaceScopesForTier(tier).filter((s) => !have.has(s));
 }
 
+/** The Drive write scope minted by `auth google account add --write`. */
+const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file";
+
 /**
  * Build the operator-facing warning shown when the seed token is
  * missing scopes the requested tier needs (issue #1663). The launcher
@@ -271,11 +274,21 @@ export function findMissingWorkspaceScopes(
  * keep working — but the warning makes the partial-capability state
  * loud and tells the operator exactly how to fix it, instead of the
  * silent doomed port-8000 fallback.
+ *
+ * `hasWriteScope` MUST reflect the EXISTING token's scopes (whether the
+ * current credential already carries `drive.file`), NOT the `missing`
+ * set. `missing` only ever holds Docs/Sheets/Slides scopes — never
+ * `drive.file` — so deriving the recovery command's `--write` suffix
+ * from `missing` would always drop it, and an operator with a
+ * write-capable token who runs the printed command verbatim would
+ * silently downgrade to a read-only token and lose Drive file creation
+ * that previously worked. Carry the existing write capability forward.
  */
 export function buildMissingScopeWarning(
   missing: string[],
   tier: string | undefined,
   accountEmail: string,
+  hasWriteScope: boolean,
 ): string {
   const short = missing
     .map((s) => s.replace(/^https:\/\/www\.googleapis\.com\/auth\//, ""))
@@ -288,9 +301,10 @@ export function buildMissingScopeWarning(
     `to authenticate. OAuth scopes are fixed at consent time — re-run on the ` +
     `host to re-mint the token with the correct scopes:\n` +
     `    switchroom auth google account add ${accountEmail} --replace` +
-    `${missing.includes("https://www.googleapis.com/auth/drive.file") ? " --write" : ""}\n` +
+    `${hasWriteScope ? " --write" : ""}\n` +
     `  (scopes are derived from \`google_workspace.tier\` — set the tier ` +
-    `before re-running). Drive read/file tools are unaffected.\n`
+    `before re-running${hasWriteScope ? "; --write preserves the existing " +
+    "Drive write capability" : ""}). Drive read/file tools are unaffected.\n`
   );
 }
 
@@ -810,8 +824,22 @@ export async function runDriveMcpLauncher(opts: {
   // than refusing to start.
   const missingScopes = findMissingWorkspaceScopes(brokerCreds.scope, tier);
   if (missingScopes.length > 0) {
+    // Decide the recovery command's --write suffix from the EXISTING
+    // token's scopes — NOT from `missingScopes` (which never contains
+    // drive.file). A token that already carries drive.file was minted
+    // write-capable; the printed `account add --replace` must keep
+    // --write or the operator silently downgrades to read-only.
+    const hasWriteScope = brokerCreds.scope
+      .split(/\s+/)
+      .map((s) => s.trim())
+      .includes(DRIVE_FILE_SCOPE);
     process.stderr.write(
-      buildMissingScopeWarning(missingScopes, tier, brokerCreds.accountEmail),
+      buildMissingScopeWarning(
+        missingScopes,
+        tier,
+        brokerCreds.accountEmail,
+        hasWriteScope,
+      ),
     );
   }
 

--- a/src/cli/drive-mcp-launcher.ts
+++ b/src/cli/drive-mcp-launcher.ts
@@ -213,6 +213,87 @@ export const AIOFILE_PIN = "aiofile==3.10.2";
  */
 export const AIOFILE_PKG = AIOFILE_PIN.split("==")[0];
 
+// ─── Scope ↔ tier preflight (issue #1663) ─────────────────────────────────
+
+/**
+ * The Google Workspace API scopes a given `--tool-tier` needs in order
+ * for every tool it exposes to authenticate. Mirrors
+ * `workspaceScopesForTier` in src/cli/drive.ts — duplicated here (not
+ * imported) so the launcher's hot path stays free of the heavier
+ * drive.ts import tree. The two MUST stay in sync; a launcher unit test
+ * asserts equivalence against the drive.ts source of truth.
+ *
+ * `core` exposes Docs + Sheets tools; `extended`/`complete` add Slides.
+ * Drive scopes are not listed — the broker always mints those; the gap
+ * #1663 closes is the missing *Workspace* scopes.
+ */
+export function requiredWorkspaceScopesForTier(tier: string | undefined): string[] {
+  const docs = [
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/spreadsheets",
+  ];
+  if (tier === "extended" || tier === "complete") {
+    return [...docs, "https://www.googleapis.com/auth/presentations"];
+  }
+  // core (or unset — core is the documented default) → Docs + Sheets.
+  return docs;
+}
+
+/**
+ * Compare the scopes the broker's seed credentials actually carry
+ * against the scopes the requested tier needs. Returns the list of
+ * missing scopes (empty ⇒ the seed can drive every tool the tier
+ * exposes).
+ *
+ * Pure + exported so the preflight contract is unit-pinned. The result
+ * drives a loud, actionable stderr warning in {@link runDriveMcpLauncher}
+ * BEFORE upstream spawns — so a missing scope surfaces as a clear "re-run
+ * account add" message instead of upstream silently falling back to its
+ * own port-8000 browser OAuth (unrecoverable inside a container).
+ */
+export function findMissingWorkspaceScopes(
+  seedScope: string,
+  tier: string | undefined,
+): string[] {
+  const have = new Set(
+    seedScope
+      .split(/\s+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+  return requiredWorkspaceScopesForTier(tier).filter((s) => !have.has(s));
+}
+
+/**
+ * Build the operator-facing warning shown when the seed token is
+ * missing scopes the requested tier needs (issue #1663). The launcher
+ * still spawns upstream — Drive tools and any in-scope Workspace tools
+ * keep working — but the warning makes the partial-capability state
+ * loud and tells the operator exactly how to fix it, instead of the
+ * silent doomed port-8000 fallback.
+ */
+export function buildMissingScopeWarning(
+  missing: string[],
+  tier: string | undefined,
+  accountEmail: string,
+): string {
+  const short = missing
+    .map((s) => s.replace(/^https:\/\/www\.googleapis\.com\/auth\//, ""))
+    .join(", ");
+  return (
+    `drive-mcp-launcher: WARNING — the Google account '${accountEmail}' was ` +
+    `consented WITHOUT the scope(s) needed for tier '${tier ?? "core"}': ` +
+    `${short}.\n` +
+    `  The matching MCP tools (Docs / Sheets / Slides create+edit) will FAIL ` +
+    `to authenticate. OAuth scopes are fixed at consent time — re-run on the ` +
+    `host to re-mint the token with the correct scopes:\n` +
+    `    switchroom auth google account add ${accountEmail} --replace` +
+    `${missing.includes("https://www.googleapis.com/auth/drive.file") ? " --write" : ""}\n` +
+    `  (scopes are derived from \`google_workspace.tier\` — set the tier ` +
+    `before re-running). Drive read/file tools are unaffected.\n`
+  );
+}
+
 export function buildUvxArgs(tier?: string): string[] {
   const args = [
     "--from",
@@ -274,6 +355,25 @@ export function buildChildEnv(
   delete env.WORKSPACE_MCP_STATELESS_MODE;
   delete env.GOOGLE_APPLICATION_CREDENTIALS;
   delete env.WORKSPACE_MCP_SERVICE_ACCOUNT_FILE;
+  // Port-8000 fallback hardening (issue #1663). When a tool call needs a
+  // scope the seed token lacks, upstream falls back to its OWN browser
+  // OAuth flow, which binds a callback server on `WORKSPACE_MCP_PORT`
+  // (default 8000). On a shared host (Coolify et al.) 8000 is taken, so
+  // the fallback can never complete and the failure is opaque
+  // ("Port 8000 is already in use … Cannot start minimal OAuth server").
+  //
+  // The browserless launcher seeds credentials and is fed by the
+  // auth-broker — it should NEVER run upstream's own OAuth flow. We
+  // cannot disable the fallback outright (no upstream knob for that),
+  // but moving the port off 8000 to an operator-configurable,
+  // unlikely-to-collide default (`SWITCHROOM_GDRIVE_MCP_PORT`, default
+  // 8631) means the doomed bind at least fails on a private port
+  // instead of fighting whatever the operator runs on 8000 — and the
+  // scope-preflight warning above tells them the real fix. Operators
+  // who genuinely need a specific port can override.
+  if (!env.WORKSPACE_MCP_PORT) {
+    env.WORKSPACE_MCP_PORT = env.SWITCHROOM_GDRIVE_MCP_PORT ?? "8631";
+  }
   return env;
 }
 
@@ -697,6 +797,24 @@ export async function runDriveMcpLauncher(opts: {
   // Per-agent tier override (passed via --tier from the scaffold entry)
   // wins over the config top-level tier.
   const tier = opts.tier ?? configSecrets.tier;
+
+  // Scope ↔ tier preflight (issue #1663). The broker's seed token was
+  // minted by `auth google account add` at whatever tier was configured
+  // THEN. If the operator later raised the tier (e.g. core → extended
+  // for Slides) without re-running `account add`, the token lacks the
+  // Slides/Docs/Sheets scopes the new tier's tools need. Surface that as
+  // a loud, actionable stderr warning BEFORE upstream spawns — instead
+  // of upstream silently falling back to its doomed port-8000 OAuth on
+  // the first Docs/Sheets/Slides call. We warn (not exit): Drive tools
+  // and any in-scope Workspace tools still work, so degrading is better
+  // than refusing to start.
+  const missingScopes = findMissingWorkspaceScopes(brokerCreds.scope, tier);
+  if (missingScopes.length > 0) {
+    process.stderr.write(
+      buildMissingScopeWarning(missingScopes, tier, brokerCreds.accountEmail),
+    );
+  }
+
   const args = buildUvxArgs(tier);
   const env = buildChildEnv(
     process.env,

--- a/src/cli/drive.test.ts
+++ b/src/cli/drive.test.ts
@@ -39,8 +39,13 @@ vi.mock("../vault/vault.js", () => ({
 import {
   __test,
   selectDriveAccountScopes,
+  selectGoogleWorkspaceScopes,
+  workspaceScopesForTier,
   DRIVE_READONLY_SCOPES,
   DRIVE_WRITE_SCOPES,
+  GOOGLE_DOCS_SCOPE,
+  GOOGLE_SHEETS_SCOPE,
+  GOOGLE_SLIDES_SCOPE,
   type DriveCliDeps,
 } from "./drive.js";
 import type { WaitForApprovalResult } from "../vault/approvals/wait.js";
@@ -447,5 +452,68 @@ describe("selectDriveAccountScopes", () => {
     );
     // Least-privilege: NOT the full read/write `drive` scope.
     expect(s).not.toContain("https://www.googleapis.com/auth/drive");
+  });
+});
+
+describe("workspaceScopesForTier (issue #1663)", () => {
+  it("core → Docs + Sheets (core already exposes those tools)", () => {
+    const s = workspaceScopesForTier("core");
+    expect(s).toEqual([GOOGLE_DOCS_SCOPE, GOOGLE_SHEETS_SCOPE]);
+    expect(s).not.toContain(GOOGLE_SLIDES_SCOPE);
+  });
+
+  it("extended → adds Slides (first tier exposing Slides tools)", () => {
+    const s = workspaceScopesForTier("extended");
+    expect(s).toContain(GOOGLE_DOCS_SCOPE);
+    expect(s).toContain(GOOGLE_SHEETS_SCOPE);
+    expect(s).toContain(GOOGLE_SLIDES_SCOPE);
+  });
+
+  it("complete → also includes Slides", () => {
+    expect(workspaceScopesForTier("complete")).toContain(GOOGLE_SLIDES_SCOPE);
+  });
+
+  it("does NOT add calendar/gmail scopes (deferred per #1663)", () => {
+    for (const tier of ["core", "extended", "complete"] as const) {
+      const s = workspaceScopesForTier(tier);
+      expect(s.some((x) => x.includes("calendar"))).toBe(false);
+      expect(s.some((x) => x.includes("gmail"))).toBe(false);
+    }
+  });
+});
+
+describe("selectGoogleWorkspaceScopes (issue #1663)", () => {
+  it("core read-only: Drive read + Docs + Sheets, no Slides, no drive.file", () => {
+    const s = selectGoogleWorkspaceScopes({ write: false, tier: "core" });
+    expect(s).toContain("https://www.googleapis.com/auth/drive.readonly");
+    expect(s).toContain(GOOGLE_DOCS_SCOPE);
+    expect(s).toContain(GOOGLE_SHEETS_SCOPE);
+    expect(s).not.toContain(GOOGLE_SLIDES_SCOPE);
+    expect(s).not.toContain("https://www.googleapis.com/auth/drive.file");
+  });
+
+  it("extended write: Drive read + drive.file + Docs + Sheets + Slides", () => {
+    const s = selectGoogleWorkspaceScopes({ write: true, tier: "extended" });
+    expect(s).toContain("https://www.googleapis.com/auth/drive.file");
+    expect(s).toContain(GOOGLE_DOCS_SCOPE);
+    expect(s).toContain(GOOGLE_SHEETS_SCOPE);
+    expect(s).toContain(GOOGLE_SLIDES_SCOPE);
+  });
+
+  it("undefined tier defaults to core (matches schema default)", () => {
+    const s = selectGoogleWorkspaceScopes({ write: false });
+    expect(s).toEqual(selectGoogleWorkspaceScopes({ write: false, tier: "core" }));
+  });
+
+  it("produces no duplicate scopes", () => {
+    const s = selectGoogleWorkspaceScopes({ write: true, tier: "complete" });
+    expect(new Set(s).size).toBe(s.length);
+  });
+
+  it("never requests the full read/write `drive` scope (least-privilege)", () => {
+    for (const tier of ["core", "extended", "complete"] as const) {
+      const s = selectGoogleWorkspaceScopes({ write: true, tier });
+      expect(s).not.toContain("https://www.googleapis.com/auth/drive");
+    }
   });
 });

--- a/src/cli/drive.ts
+++ b/src/cli/drive.ts
@@ -94,14 +94,96 @@ export const DRIVE_WRITE_SCOPES = [
 ];
 const DEFAULT_SCOPES = DRIVE_READONLY_SCOPES;
 
+// ── Google Workspace API scopes (issue #1663) ────────────────────────────
+//
+// `drive.file` alone authorizes *Drive*-level create/edit (a Drive file
+// object), but native Google **Docs / Sheets / Slides** API calls
+// (`documents.batchUpdate`, `spreadsheets.batchUpdate`,
+// `presentations.batchUpdate`, and the matching `*.create` /
+// `*.get`) each require their own product-specific scope. Without them
+// the upstream Google Workspace MCP's Docs/Sheets/Slides tools 403 —
+// and upstream then falls back to its OWN browser OAuth on port 8000,
+// which is unrecoverable inside a container. These scopes are therefore
+// tied to the `--tier` so the token a tier mints can actually drive
+// every tool that tier exposes (see `selectGoogleWorkspaceScopes`).
+//
+// `documents` + `spreadsheets` cover the Docs/Sheets tools present at
+// EVERY tier (`core` already exposes them — see GoogleWorkspaceTierSchema
+// in src/config/schema.ts). `presentations` covers the Slides tools that
+// first appear at `extended`.
+//
+// Deliberately NOT added here: `calendar`, `gmail.*`, Forms/Tasks/Chat
+// scopes. The issue (#1663) scopes the fix to Slides/Docs/Sheets — the
+// surfaces explicitly broken today. Calendar/Forms/Tasks/Chat/Gmail are
+// a separate, larger scope-expansion decision (Gmail in particular has
+// an unresolved per-thread-approval shape — RFC G §5 out-of-scope).
+export const GOOGLE_DOCS_SCOPE = "https://www.googleapis.com/auth/documents";
+export const GOOGLE_SHEETS_SCOPE =
+  "https://www.googleapis.com/auth/spreadsheets";
+export const GOOGLE_SLIDES_SCOPE =
+  "https://www.googleapis.com/auth/presentations";
+
+/**
+ * The Google Workspace document scopes available at each tier. Tied to
+ * the tier→tool mapping in `GoogleWorkspaceTierSchema`:
+ *   - core / extended / complete  → Docs + Sheets (core already exposes
+ *     these tools)
+ *   - extended / complete         → + Slides (first exposed at extended)
+ *
+ * Pure + exported so the tier→scope contract is unit-pinned alongside
+ * the tier→tool contract.
+ */
+export function workspaceScopesForTier(
+  tier: "core" | "extended" | "complete",
+): string[] {
+  const docScopes = [GOOGLE_DOCS_SCOPE, GOOGLE_SHEETS_SCOPE];
+  if (tier === "extended" || tier === "complete") {
+    return [...docScopes, GOOGLE_SLIDES_SCOPE];
+  }
+  return docScopes;
+}
+
 /**
  * Pick the OAuth scope set for `auth google account add`. Default is
  * read-only; write is strictly opt-in (RFC D §12 — a read grant must
  * never silently authorize writes). Pure + exported so the
  * default-is-read invariant is unit-pinned.
+ *
+ * Back-compat shim: this is the pre-#1663 Drive-only selector. New
+ * callers should use {@link selectGoogleWorkspaceScopes}, which folds
+ * the tier-tied Docs/Sheets/Slides scopes in.
  */
 export function selectDriveAccountScopes(write: boolean): string[] {
   return write ? DRIVE_WRITE_SCOPES : DRIVE_READONLY_SCOPES;
+}
+
+/**
+ * Pick the full OAuth scope set for `auth google account add`, tying the
+ * Google Workspace API scopes (Docs / Sheets / Slides) to the `--tier`
+ * (issue #1663). The Drive base is always present (read, plus
+ * `drive.file` when `write`); the Workspace document scopes are added
+ * per {@link workspaceScopesForTier}.
+ *
+ * Why tie scopes to tier: a tier advertises a set of MCP *tools*, but
+ * before #1663 the minted token carried Drive scopes only — so
+ * `extended`/`complete` surfaced Slides/Docs/Sheets tools that could
+ * never authenticate. Minting the matching scope set means every tool a
+ * tier exposes can actually run.
+ *
+ * Pure + exported so the tier→scope contract is unit-pinned. Tier
+ * defaults to `core` (matching `GoogleWorkspaceTierSchema`'s documented
+ * default) when unset.
+ */
+export function selectGoogleWorkspaceScopes(opts: {
+  write: boolean;
+  tier?: "core" | "extended" | "complete";
+}): string[] {
+  const base = selectDriveAccountScopes(opts.write);
+  const workspace = workspaceScopesForTier(opts.tier ?? "core");
+  // De-dup defensively — base and workspace sets are disjoint today but
+  // a future scope move shouldn't silently produce a doubled scope
+  // string in the consent URL.
+  return [...new Set([...base, ...workspace])];
 }
 
 export interface DriveCliDeps {


### PR DESCRIPTION
## Summary

Closes #1663. Agents could read Drive and create plain Drive files but could **not** create or edit native Google **Slides / Docs / Sheets** — the auth-broker token only carried Drive scopes. Docs/Sheets/Slides API calls 403'd, and the upstream Google Workspace MCP then fell back to its own browser OAuth on port 8000, unrecoverable inside a container.

This PR mints the Google Workspace API scopes, ties them to the `--tier`, and hardens the launcher against the doomed fallback.

## Why

`drive.file` authorizes a Drive *file object*, not a `documents.batchUpdate` / `spreadsheets.batchUpdate` / `presentations.batchUpdate` call — each native Workspace product needs its own OAuth scope. Before this change `extended`/`complete` advertised Slides/Docs/Sheets MCP tools that could never authenticate.

JTBD: this serves the **multi-agent fleet** outcome (agents that actually do Workspace work) and `reference/`-equivalent RFC G. RFC G §6.3 already anticipated "Calendar/Sheets/Slides scopes adds rows, not commands."

## What changed

- **`src/cli/drive.ts`** — new Workspace scope constants (`documents`, `spreadsheets`, `presentations`) + tier-aware selector `selectGoogleWorkspaceScopes({ write, tier })`. `selectDriveAccountScopes` kept as a back-compat shim.
- **`src/cli/auth-google.ts`** — `account add` reads `google_workspace.tier` and mints the matching scope set; prints the tier + the "re-run to change scopes" note.
- **`src/cli/drive-mcp-launcher.ts`** — scope↔tier preflight: a token missing scopes its tier needs produces a loud, actionable stderr warning with the exact `account add --replace` recovery command, instead of the silent port-8000 fallback. Also moves the upstream MCP's OAuth callback port off 8000 (`SWITCHROOM_GDRIVE_MCP_PORT`, default `8631`).
- **`docs/google-workspace.md`** — tier→scope table + "changing the tier requires re-running account add" note.
- **`CHANGELOG.md`** — `## unreleased` entry.

### Tier → scope mapping chosen

| tier       | Workspace API scopes minted (on top of Drive) |
|------------|-----------------------------------------------|
| `core`     | `documents`, `spreadsheets`                   |
| `extended` | `documents`, `spreadsheets`, `presentations`  |
| `complete` | `documents`, `spreadsheets`, `presentations`  |

This mirrors the **existing tier→tool mapping** (`GoogleWorkspaceTierSchema`): `core` already exposes Docs/Sheets tools, so `core` mints those scopes (without them `core`'s own Docs/Sheets tools stay broken); Slides tools first appear at `extended`, so `presentations` is added there. Calendar/Forms/Tasks/Chat/Gmail scopes are deliberately **not** added — the issue scopes the fix to Slides/Docs/Sheets, and Gmail in particular has an unresolved per-thread-approval shape (RFC G §5).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run src/cli/` — 417 tests pass
- [x] New unit tests: `workspaceScopesForTier`, `selectGoogleWorkspaceScopes` (tier×write matrix, de-dup, least-privilege), launcher `findMissingWorkspaceScopes` preflight, `buildMissingScopeWarning`, `WORKSPACE_MCP_PORT` hardening, and a sync-check asserting `requiredWorkspaceScopesForTier` (launcher) matches `workspaceScopesForTier` (drive.ts)
- [ ] In-container UAT against a real Google account at `extended` tier — not run (no live Google client in this worktree); flagged for the canary step

## Risk

- **Low–medium.** Pure scope-string additions + a startup preflight that only *warns* (never refuses to spawn — Drive tools keep working). No behaviour change for accounts whose tier already matched their token.
- The launcher and drive.ts each have their own copy of the tier→scope list (drive.ts import tree is heavy for the launcher hot path); a unit test asserts they stay in sync.
- Existing tokens minted before this change keep working for Drive; the preflight warning prompts a one-time `account add --replace` re-mint to unlock Docs/Sheets/Slides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-up (REQUEST_CHANGES → addressed, commit 61badf78)

- **BLOCKER fixed.** `buildMissingScopeWarning` derived its `--write` recovery-command suffix from the `missing` scope set, which `findMissingWorkspaceScopes` never populates with `drive.file` — so `--write` was dead code and the printed `account add --replace` never carried it. A user with a pre-#1663 write-capable token would have silently downgraded to read-only by running the printed command. The suffix is now driven by a `hasWriteScope` boolean derived at the call site from the *existing* token's scopes (`brokerCreds.scope` contains `drive.file`). The dead-code test was rewritten to assert against `findMissingWorkspaceScopes`' real output and both `hasWriteScope` branches.
- **MINOR — port env var documented.** `SWITCHROOM_GDRIVE_MCP_PORT` (default `8631`) is now in `docs/google-workspace.md`.

## Known tracked follow-up (out of scope for #1663)

The `core` tier's schema exposes Calendar tools, but no Calendar OAuth scope is minted by this PR — Calendar tool calls at `core` will not authenticate. This is acceptably out of scope for #1663 (which scopes the fix to Docs/Sheets/Slides; Calendar/Forms/Tasks/Chat/Gmail scopes are a separate, larger decision — see RFC G §5). Tracked as a follow-up.
