### PR TITLE
fix(pacing): re-prompt when a turn ends with the answer left as a draft (#1664)

### DIFF
--- a/telegram-plugin/final-answer-detect.ts
+++ b/telegram-plugin/final-answer-detect.ts
@@ -1,0 +1,83 @@
+/**
+ * final-answer-detect.ts — #1664 "did this reply deliver the final answer?"
+ *
+ * Background. An agent often ends a turn with its real answer as plain
+ * assistant transcript text instead of a `reply` / `stream_reply` tool
+ * call. The gateway renders that transcript as a live Telegram draft
+ * (`sendMessageDraft`) and, at turn_end, retracts the draft — so the
+ * answer is never finalized and the user watches it vanish (#1664).
+ *
+ * The gateway's `replyCalled` flag flips on the FIRST reply / stream_reply
+ * tool use and stays true for the rest of the turn. It cannot distinguish
+ * "the model sent an interim ack" from "the model sent its real answer" —
+ * both set `replyCalled`. The silent-end re-prompt safety net needs a
+ * finer signal: it must engage when a turn ended with only an interim
+ * ack and the real answer left as transcript text.
+ *
+ * This module is that finer signal — a pure predicate the gateway calls
+ * for each reply that lands. A turn whose every reply was classified
+ * "interim" ends with `CurrentTurn.finalAnswerDelivered === false`, which
+ * triggers the re-prompt; a turn with at least one "final" reply does not.
+ *
+ * Keeping the policy in one unit-testable function is the point — the
+ * gateway is a multi-thousand-line module that's expensive to import in a
+ * test. See `telegram-plugin/tests/final-answer-detect.test.ts`.
+ *
+ * The fix re-prompts the model; it never materializes the draft into a
+ * message (`reference/principles.md`: the model communicates, the
+ * framework is the safety net). So a false "interim" classification is
+ * cheap (one extra re-prompt) and a false "final" classification is the
+ * dangerous one (a real answer left undelivered) — the length backstop
+ * exists to make the dangerous miss rare.
+ */
+
+/**
+ * Length backstop for the final-answer classification. The pacing
+ * contract (`docs/telegram-style.md`) says interim updates pass
+ * `disable_notification: true` and the final answer omits it — so a
+ * notification-bearing reply is the primary "final answer" signal. But a
+ * model that mis-marks a genuinely substantive reply as interim
+ * (`disable_notification: true` on what is really the answer) would
+ * otherwise leave the turn looking undelivered. Any reply at or above
+ * this many characters therefore ALSO counts as the final answer,
+ * regardless of the notification flag. 200 chars is comfortably longer
+ * than a typical interim ack ("on it", "looking into that…", "give me a
+ * sec") and short enough that a real answer almost always clears it.
+ */
+export const FINAL_ANSWER_MIN_CHARS = 200
+
+export interface FinalAnswerReplyInput {
+  /** The reply text the model sent (the model's own answer text, before
+   * any HTML conversion or Telegraph-link substitution). */
+  text: string
+  /** The `disable_notification` argument the reply tool was called with.
+   * `true` is the pacing contract's "interim update" marker; the final
+   * answer omits it (effectively `false`). */
+  disableNotification: boolean
+  /** For `stream_reply` only: whether this call carried `done: true`. A
+   * `done: true` call explicitly closes the stream and IS the final
+   * answer by definition. Pass `false` for the plain `reply` tool. */
+  done?: boolean
+}
+
+/**
+ * Pure predicate: did this reply deliver the turn's final answer (as
+ * opposed to an interim ack)? `true` if ANY of:
+ *
+ *   - `done === true` — a `stream_reply` terminal call; the model
+ *     explicitly closed the stream, so this is the final answer.
+ *   - `disableNotification === false` — the pacing contract's explicit
+ *     "final answer" signal (interim updates set it `true`).
+ *   - `text.length >= FINAL_ANSWER_MIN_CHARS` — the length backstop for
+ *     a substantive answer mis-marked as interim.
+ *
+ * The gateway ORs this across every reply in a turn; once one reply
+ * qualifies, `CurrentTurn.finalAnswerDelivered` latches true and the
+ * silent-end re-prompt will not engage for that turn.
+ */
+export function isFinalAnswerReply(input: FinalAnswerReplyInput): boolean {
+  if (input.done === true) return true
+  if (!input.disableNotification) return true
+  if (input.text.length >= FINAL_ANSWER_MIN_CHARS) return true
+  return false
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4080,6 +4080,13 @@ async function executeUpdateChecklist(args: Record<string, unknown>): Promise<{ 
 }
 
 async function executeReply(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
+  // #1664 — pin the turn this reply belongs to at entry. The
+  // finalAnswerDelivered write near the end of this function runs after
+  // several awaits; turn-pinning (the #1067 pattern used across the
+  // gateway) keeps the write attributed to THIS turn rather than reading
+  // module-scope currentTurn, which a future refactor could let roll over
+  // mid-call.
+  const turn = currentTurn
   const chat_id = args.chat_id as string
   if (!chat_id) throw new Error('reply: chat_id is required')
   const rawText = args.text as string | undefined
@@ -4510,15 +4517,10 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     // "delivered" because replyCalled is true — and the silent-end
     // re-prompt would never engage. `rawText` is the model's own answer
     // text, measured before HTML conversion / Telegraph-link
-    // substitution. Reading the module-scope currentTurn is safe here:
-    // executeReply is invoked synchronously off an IPC dispatch within
-    // the in-flight turn; if the turn already rolled over, the stale
-    // write is harmless (the new turn re-inits the flag to false).
-    if (
-      isFinalAnswerReply({ text: rawText, disableNotification }) &&
-      currentTurn != null
-    ) {
-      currentTurn.finalAnswerDelivered = true
+    // substitution. Writes `turn` (pinned at executeReply entry) so the
+    // flag always lands on the turn this reply belongs to.
+    if (turn != null && isFinalAnswerReply({ text: rawText, disableNotification })) {
+      turn.finalAnswerDelivered = true
     }
   }
 
@@ -4533,6 +4535,8 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
 }
 
 async function executeStreamReply(args: Record<string, unknown>): Promise<unknown> {
+  // #1664 — pin the turn at entry; see executeReply for the rationale.
+  const turn = currentTurn
   if (!args.chat_id) throw new Error('stream_reply: chat_id is required')
   if (args.text == null || args.text === '') throw new Error('stream_reply: text is required and cannot be empty')
 
@@ -4720,14 +4724,14 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   // executeReply uses. See the CurrentTurn.finalAnswerDelivered doc-comment
   // for why replyCalled is not a sufficient signal here.
   if (
+    turn != null &&
     isFinalAnswerReply({
       text: (args.text as string | undefined) ?? '',
       disableNotification: args.disable_notification === true,
       done: args.done === true,
-    }) &&
-    currentTurn != null
+    })
   ) {
-    currentTurn.finalAnswerDelivered = true
+    turn.finalAnswerDelivered = true
   }
   return { content: [{ type: 'text', text: `${result.status} (id: ${result.messageId ?? 'pending'})` }] }
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -76,7 +76,8 @@ import {
 import { emitRuntimeMetric } from '../runtime-metrics.js'
 import { classifyInbound } from '../inbound-classifier.js'
 import * as silencePoke from '../silence-poke.js'
-import { writeSilentEndState, clearSilentEndState, recordSilentTurnEnd } from '../silent-end.js'
+import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd } from '../silent-end.js'
+import { isFinalAnswerReply } from '../final-answer-detect.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
 import { type SessionEvent } from '../session-tail.js'
 import {
@@ -1191,6 +1192,19 @@ type CurrentTurn = {
   startedAt: number
   gatewayReceiveAt: number
   replyCalled: boolean
+  // #1664 — whether the model has delivered its *final answer* this turn
+  // (as opposed to only an interim ack). `replyCalled` flips on the first
+  // reply / stream_reply tool_use and stays true for the rest of the turn,
+  // so it cannot tell "ack only" from "ack + real answer". This flag is the
+  // finer signal the silent-end re-prompt needs: it is set only when a reply
+  // actually lands AND `isFinalAnswerReply` (final-answer-detect.ts)
+  // classifies it as the final answer — notification-bearing, or long
+  // enough to be substantive, or a stream_reply done=true — OR when the
+  // turn-flush safety net legitimately emits the model's terminal text. A
+  // turn that ends with this still `false` triggers the silent-end re-prompt
+  // even though `replyCalled` is true — the #1664 case where the real answer
+  // ended up as plain transcript text rendered into an ephemeral draft.
+  finalAnswerDelivered: boolean
   capturedText: string[]
   orphanedReplyTimeoutId: ReturnType<typeof setTimeout> | null
   registryKey: string | null
@@ -4488,6 +4502,24 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     } catch (err) {
       process.stderr.write(`telegram gateway: reply: endStatusReaction hook threw: ${err}\n`)
     }
+    // #1664 — mark the turn's final answer as delivered when this reply
+    // looks like the real answer rather than an interim ack. The
+    // classification (notification-bearing OR substantive length) lives
+    // in `isFinalAnswerReply`. Without this, a turn that ack'd then ended
+    // with the real answer as plain transcript text (#1664) would look
+    // "delivered" because replyCalled is true — and the silent-end
+    // re-prompt would never engage. `rawText` is the model's own answer
+    // text, measured before HTML conversion / Telegraph-link
+    // substitution. Reading the module-scope currentTurn is safe here:
+    // executeReply is invoked synchronously off an IPC dispatch within
+    // the in-flight turn; if the turn already rolled over, the stale
+    // write is harmless (the new turn re-inits the flag to false).
+    if (
+      isFinalAnswerReply({ text: rawText, disableNotification }) &&
+      currentTurn != null
+    ) {
+      currentTurn.finalAnswerDelivered = true
+    }
   }
 
   process.stderr.write(`telegram channel: reply: finalized chatId=${chat_id} messageIds=[${sentIds.join(',')}] chunks=${chunks.length}\n`)
@@ -4679,6 +4711,23 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     const sChatId = args.chat_id as string
     const sThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
     outboundDedup.record(sChatId, sThreadId, args.text as string, Date.now())
+  }
+  // #1664 — mark the turn's final answer as delivered. For stream_reply a
+  // call with done=true IS the final answer by definition (the model
+  // explicitly closed the stream). A non-terminal stream_reply chunk also
+  // counts when it carries the final-answer signals — notification-bearing
+  // OR substantive length — via the same `isFinalAnswerReply` predicate
+  // executeReply uses. See the CurrentTurn.finalAnswerDelivered doc-comment
+  // for why replyCalled is not a sufficient signal here.
+  if (
+    isFinalAnswerReply({
+      text: (args.text as string | undefined) ?? '',
+      disableNotification: args.disable_notification === true,
+      done: args.done === true,
+    }) &&
+    currentTurn != null
+  ) {
+    currentTurn.finalAnswerDelivered = true
   }
   return { content: [{ type: 'text', text: `${result.status} (id: ${result.messageId ?? 'pending'})` }] }
 }
@@ -5697,6 +5746,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           startedAt,
           gatewayReceiveAt: startedAt,
           replyCalled: false,
+          finalAnswerDelivered: false,
           capturedText: [],
           orphanedReplyTimeoutId: null,
           registryKey: null,
@@ -5815,6 +5865,22 @@ function handleSessionEvent(ev: SessionEvent): void {
       // #1067: snapshot at entry. The answer-stream creation closures
       // below also read `turn` instead of currentTurn so they pin to
       // this turn's chat for the stream's lifetime.
+      //
+      // #1664 ordering note: a `text` event can arrive AFTER turn_end has
+      // nulled currentTurn (the issue observed `answer_lane_update
+      // transport:"draft"` firing post-turn_end). Such a late event is
+      // dropped here by the `turn != null` guard — it is NOT folded back
+      // into the just-ended turn. That is deliberate and safe: by the
+      // time this fires, the turn atom has been handed to
+      // endCurrentTurnAtomic and turn_end has already run its flush /
+      // silent-end decision; re-opening a closed turn (re-creating an
+      // answer stream, re-evaluating decideTurnFlush) would be a large,
+      // race-prone change. The #1664 safety net does not depend on
+      // catching the late text: a turn whose real answer lost the race
+      // ends with finalAnswerDelivered=false, so recordUndeliveredTurnEnd
+      // engages the Stop-hook re-prompt and the model re-delivers the
+      // answer through the reply tool. The dropped draft text is
+      // recovered by re-prompt, not by post-hoc materialization.
       const turn = currentTurn
       if (turn != null) {
         turn.capturedText.push(ev.text)
@@ -6181,6 +6247,18 @@ function handleSessionEvent(ev: SessionEvent): void {
         const backstopThreadId = threadId
         const backstopCtrl = ctrl
 
+        // #1664 — turn-flush only fires when !replyCalled (decideTurnFlush
+        // returns 'reply-called' otherwise). It legitimately delivers the
+        // model's terminal text as the answer, so the turn IS answered.
+        // Mark it now so the early-return below skips the silent-end
+        // re-prompt for a turn whose answer is genuinely on its way out.
+        // (The IIFE that actually sends runs after this branch's `return`;
+        // since the silent-end block is on the sibling reply-called path
+        // that this branch never reaches, this set is belt-and-braces —
+        // it keeps the captured `turn` atom internally consistent for any
+        // future reader.)
+        turn.finalAnswerDelivered = true
+
         // #654 deterministic double-message fix. Hand off the pinned
         // progress card BEFORE state reset so the driver doesn't keep
         // editing it while turn-flush is rewriting it with the answer.
@@ -6413,17 +6491,31 @@ function handleSessionEvent(ev: SessionEvent): void {
           longest_silent_gap_ms: outboundMetrics.longestOutboundGapMs,
           ended_via: outboundMetrics.outboundCount > 0 ? 'reply' : 'silent',
         })
-        // #1122 PR4 / #1161: deterministic silent-end handling (see the
-        // silent-marker path above for the rationale).
-        //   - first silent-end → recordSilentTurnEnd writes the state
-        //     file so the Stop hook (silent-end-interrupt-stop.mjs)
-        //     blocks the session-end and re-prompts the agent to reply.
+        // #1122 PR4 / #1161 / #1664: deterministic undelivered-turn
+        // handling (see the silent-marker path above for the rationale).
+        //   - first undelivered turn-end → recordSilentTurnEnd writes the
+        //     state file so the Stop hook (silent-end-interrupt-stop.mjs)
+        //     blocks the session-end and re-prompts the agent to deliver.
         //   - the Stop-hook re-prompt is already spent and the agent is
-        //     STILL silent → recordSilentTurnEnd returns exhausted:true;
-        //     deliver a user-facing fallback so the turn never just
-        //     vanishes (the user otherwise only sees the card disappear).
-        if (outboundMetrics.outboundCount === 0) {
-          const silentEnd = recordSilentTurnEnd({
+        //     STILL undelivered → recordSilentTurnEnd returns
+        //     exhausted:true; deliver a user-facing fallback so the turn
+        //     never just vanishes (the user otherwise only sees the card
+        //     disappear).
+        //
+        // #1664 — the trigger is "no final answer delivered", not "zero
+        // outbound". `outboundCount === 0` is now just the special case
+        // where nothing landed at all. The added case: the model sent an
+        // interim ack via reply/stream_reply (outboundCount > 0,
+        // replyCalled = true) but ended the turn with its real answer as
+        // plain transcript text — rendered into an ephemeral answer-lane
+        // draft and retracted at turn_end, never finalized. finalAnswer-
+        // Delivered stays false there, so the re-prompt engages and the
+        // model re-delivers the answer through the reply tool. NO_REPLY /
+        // HEARTBEAT_OK silent-marker turns return earlier and never reach
+        // this path. The turn-flush 'flush' branch also returns earlier
+        // (and sets finalAnswerDelivered=true defensively).
+        if (turn.finalAnswerDelivered === false) {
+          const silentEnd = recordUndeliveredTurnEnd({
             chatId,
             threadId: threadId ?? null,
             turnKey: tKey,

--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -117,7 +117,7 @@ function main() {
         'cannot see it — only text sent through the reply tool is delivered. ' +
         'Send your final answer now by calling mcp__switchroom-telegram__reply ' +
         '(or mcp__switchroom-telegram__stream_reply with done=true). ' +
-        'If you already delivered your answer via the reply tool, or you ' +
+        'If your final answer has already reached the user, or you ' +
         'intentionally have nothing to add, reply with exactly NO_REPLY.',
     }),
   )

--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -2,11 +2,19 @@
 /**
  * Stop hook — auto-interrupt for silent-end turns.
  *
- * When a Claude Code session ends without the agent having called reply or
- * stream_reply (a "silent-end"), the Telegram gateway writes a state file at
+ * When a Claude Code session ends without the agent delivering a final
+ * answer to the user, the Telegram gateway writes a state file at
  * $TELEGRAM_STATE_DIR/silent-end-pending.json. This hook reads that file and,
  * if a first-time silent-end is detected (retryCount === 0), returns a
  * decision:block to re-prompt the agent instead of letting the session close.
+ *
+ * #1664 — "no final answer delivered" covers two cases: (a) the turn ended
+ * with zero outbound (the original case), and (b) the model sent only an
+ * interim ack via reply/stream_reply but left its real answer as plain
+ * transcript text, which the gateway renders into an ephemeral draft and
+ * never finalizes. The re-prompt below tells the model to send its answer
+ * through the reply tool, or reply NO_REPLY if it genuinely has nothing to
+ * add / already delivered.
  *
  * On the second silent-end (retryCount >= MAX_RETRIES), the hook allows the
  * stop. The gateway's turn-end path (recordSilentTurnEnd in silent-end.ts)
@@ -104,9 +112,13 @@ function main() {
     JSON.stringify({
       decision: 'block',
       reason:
-        'You ran tools but never sent a reply to the user. ' +
-        'Call mcp__switchroom-telegram__reply or mcp__switchroom-telegram__stream_reply (with done=true) ' +
-        'to send your final answer now.',
+        'This turn is ending without your final answer reaching the user. ' +
+        'If you wrote an answer as plain text (not via a tool), the user ' +
+        'cannot see it — only text sent through the reply tool is delivered. ' +
+        'Send your final answer now by calling mcp__switchroom-telegram__reply ' +
+        '(or mcp__switchroom-telegram__stream_reply with done=true). ' +
+        'If you already delivered your answer via the reply tool, or you ' +
+        'intentionally have nothing to add, reply with exactly NO_REPLY.',
     }),
   )
   process.exit(0)

--- a/telegram-plugin/silent-end.ts
+++ b/telegram-plugin/silent-end.ts
@@ -182,22 +182,39 @@ export function readSilentEndState(deps?: SilentEndDeps): SilentEndState | null 
 }
 
 /**
- * Record a user-message turn that ended with zero outbound messages and
- * report whether the deterministic re-prompt has been exhausted. This is
- * the gateway's single entry point for the main turn-end path.
+ * Record a user-message turn that ended WITHOUT the model delivering a
+ * final answer, and report whether the deterministic re-prompt has been
+ * exhausted. This is the gateway's single entry point for the main
+ * turn-end path.
  *
- *   - First silent-end of a turn (no prior state, or prior `retryCount`
+ * #1664 — the trigger generalized from "zero outbound" to "no final
+ * answer delivered". Two cases reach here now:
+ *   1. Zero outbound — the turn ended with nothing sent at all (the
+ *      original #1122/#1161 silent-end case).
+ *   2. Interim-ack only — the model sent an ack via reply/stream_reply
+ *      but ended the turn with its real answer as plain transcript text
+ *      (rendered into an ephemeral answer-lane draft that gets retracted
+ *      at turn_end, never finalized). The gateway tracks this via
+ *      `CurrentTurn.finalAnswerDelivered`; case 1 is just the subset
+ *      where that flag is false because nothing landed.
+ * In both cases the model still owes the user an answer, so the same
+ * re-prompt safety net applies — the framework re-prompts; the model
+ * re-delivers via the reply tool (never the framework materializing a
+ * message from the draft — see `reference/principles.md`).
+ *
+ *   - First undelivered turn-end (no prior state, or prior `retryCount`
  *     still below `SILENT_END_MAX_RETRIES`) → writes the state file via
  *     `writeSilentEndState`, so `silent-end-interrupt-stop.mjs` blocks
  *     the stop and re-prompts the agent. Returns `{ exhausted: false }`.
  *
- *   - A silent-end where the prior state for the SAME turn already shows
- *     `retryCount >= SILENT_END_MAX_RETRIES` → the Stop hook already
- *     spent its re-prompt and the agent is STILL silent. Recovery has
- *     failed. Clears the state file (so the Stop hook on this final turn
- *     finds nothing pending and allows the stop cleanly) and returns
- *     `{ exhausted: true }` — the caller MUST then deliver a user-facing
- *     fallback so the turn never just vanishes (#1161).
+ *   - An undelivered turn-end where the prior state for the SAME turn
+ *     already shows `retryCount >= SILENT_END_MAX_RETRIES` → the Stop
+ *     hook already spent its re-prompt and the agent is STILL
+ *     undelivered. Recovery has failed. Clears the state file (so the
+ *     Stop hook on this final turn finds nothing pending and allows the
+ *     stop cleanly) and returns `{ exhausted: true }` — the caller MUST
+ *     then deliver a user-facing fallback so the turn never just
+ *     vanishes (#1161).
  *
  * Chat-less autonomous wakeup turns never reach here: the gateway only
  * creates a `currentTurn` (and therefore only runs a turn-end handler)
@@ -228,3 +245,12 @@ export function recordSilentTurnEnd(
   writeSilentEndState(args, deps)
   return { exhausted: false }
 }
+
+/**
+ * #1664 — semantic alias for `recordSilentTurnEnd`. The trigger is now
+ * "no final answer delivered", of which "zero outbound" is one case; new
+ * callsites should prefer this name so the intent reads correctly. The
+ * behaviour, retry semantics, and `{exhausted}` contract are identical —
+ * `recordSilentTurnEnd` is kept for the existing callers and tests.
+ */
+export const recordUndeliveredTurnEnd = recordSilentTurnEnd

--- a/telegram-plugin/tests/final-answer-detect.test.ts
+++ b/telegram-plugin/tests/final-answer-detect.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit coverage for the #1664 final-answer detection predicate.
+ *
+ * `isFinalAnswerReply` is the finer signal the silent-end re-prompt needs:
+ * the gateway's `replyCalled` flag flips on the first reply / stream_reply
+ * tool use and cannot tell an interim ack from the real answer. This
+ * predicate classifies each reply so a turn whose every reply was "interim"
+ * (and whose real answer ended up as plain transcript text) ends with
+ * `finalAnswerDelivered === false` and triggers the re-prompt — the #1664
+ * bug (streamed answers rendered to a draft, retracted at turn_end, lost).
+ *
+ * These tests pin the pure predicate. The gateway wires it into
+ * executeReply / executeStreamReply (covered by the gateway integration
+ * surface); pinning the policy here keeps it auditable without importing
+ * the multi-thousand-line gateway module.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { isFinalAnswerReply, FINAL_ANSWER_MIN_CHARS } from '../final-answer-detect.js'
+
+describe('isFinalAnswerReply — #1664 final-answer classification', () => {
+  it('classifies a notification-bearing reply as the final answer', () => {
+    // disable_notification:false is the pacing contract's "final answer"
+    // signal — interim updates pass disable_notification:true.
+    expect(
+      isFinalAnswerReply({ text: 'short answer', disableNotification: false }),
+    ).toBe(true)
+  })
+
+  it('classifies a short interim ack (disable_notification:true) as NOT final', () => {
+    expect(
+      isFinalAnswerReply({ text: 'on it…', disableNotification: true }),
+    ).toBe(false)
+  })
+
+  it('length backstop: a long reply mis-marked interim still counts as final', () => {
+    const longText = 'x'.repeat(FINAL_ANSWER_MIN_CHARS)
+    expect(
+      isFinalAnswerReply({ text: longText, disableNotification: true }),
+    ).toBe(true)
+  })
+
+  it('length backstop is inclusive at exactly FINAL_ANSWER_MIN_CHARS', () => {
+    expect(
+      isFinalAnswerReply({
+        text: 'x'.repeat(FINAL_ANSWER_MIN_CHARS),
+        disableNotification: true,
+      }),
+    ).toBe(true)
+    // One char under the threshold and marked interim → still interim.
+    expect(
+      isFinalAnswerReply({
+        text: 'x'.repeat(FINAL_ANSWER_MIN_CHARS - 1),
+        disableNotification: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('stream_reply done=true is always the final answer, even short + interim', () => {
+    // A done=true call explicitly closes the stream — it IS the answer,
+    // regardless of length or the notification flag.
+    expect(
+      isFinalAnswerReply({ text: 'ok', disableNotification: true, done: true }),
+    ).toBe(true)
+  })
+
+  it('a non-terminal stream_reply chunk (done=false) is classified like a plain reply', () => {
+    // Short interim chunk → not final.
+    expect(
+      isFinalAnswerReply({ text: 'thinking…', disableNotification: true, done: false }),
+    ).toBe(false)
+    // Notification-bearing chunk → final.
+    expect(
+      isFinalAnswerReply({ text: 'here it is', disableNotification: false, done: false }),
+    ).toBe(true)
+  })
+
+  it('an empty reply marked interim is NOT the final answer', () => {
+    expect(
+      isFinalAnswerReply({ text: '', disableNotification: true }),
+    ).toBe(false)
+  })
+
+  it('FINAL_ANSWER_MIN_CHARS is the documented 200-char backstop', () => {
+    // Guards the constant against silent drift — the value is referenced
+    // in the CurrentTurn doc-comment and the Stop-hook rationale.
+    expect(FINAL_ANSWER_MIN_CHARS).toBe(200)
+  })
+})

--- a/telegram-plugin/tests/silent-end.test.ts
+++ b/telegram-plugin/tests/silent-end.test.ts
@@ -8,8 +8,10 @@ import {
   clearSilentEndState,
   readSilentEndState,
   recordSilentTurnEnd,
+  recordUndeliveredTurnEnd,
   SILENT_END_MAX_RETRIES,
 } from '../silent-end.js'
+import { isFinalAnswerReply } from '../final-answer-detect.js'
 
 let stateDir: string
 const ORIG_ENV = process.env.TELEGRAM_STATE_DIR
@@ -187,6 +189,118 @@ describe('recordSilentTurnEnd — #1161 exhaustion detection', () => {
   })
 })
 
+describe('recordUndeliveredTurnEnd — #1664 extended trigger', () => {
+  it('is the same function as recordSilentTurnEnd (semantic alias)', () => {
+    expect(recordUndeliveredTurnEnd).toBe(recordSilentTurnEnd)
+  })
+
+  // The gateway computes `finalAnswerDelivered` by OR-ing isFinalAnswerReply
+  // across every reply landed this turn, then engages the re-prompt iff the
+  // flag is still false at turn_end. These tests reproduce that exact
+  // decision: classify the turn's replies, then call recordUndeliveredTurnEnd
+  // only when no reply qualified.
+  function simulateTurnEnd(
+    replies: Array<{ text: string; disableNotification: boolean; done?: boolean }>,
+    turnKey: string,
+  ): { finalAnswerDelivered: boolean; rePromptEngaged: boolean } {
+    const finalAnswerDelivered = replies.some((r) =>
+      isFinalAnswerReply(r),
+    )
+    let rePromptEngaged = false
+    if (finalAnswerDelivered === false) {
+      recordUndeliveredTurnEnd({ chatId: 'c', threadId: null, turnKey })
+      rePromptEngaged = true
+    }
+    return { finalAnswerDelivered, rePromptEngaged }
+  }
+
+  it('#1664 regression: ack reply + answer-as-transcript → re-prompt fires', () => {
+    // The exact #1664 shape: the model sent a short interim ack via the
+    // reply tool (disable_notification:true), then ended the turn with its
+    // real answer as plain transcript text — which the gateway renders into
+    // an ephemeral draft and retracts at turn_end, never finalized. No
+    // reply qualified as the final answer, so the turn is undelivered.
+    const r = simulateTurnEnd(
+      [{ text: 'On it — give me a moment.', disableNotification: true }],
+      'c:1664',
+    )
+    expect(r.finalAnswerDelivered).toBe(false)
+    expect(r.rePromptEngaged).toBe(true)
+    // State file written so silent-end-interrupt-stop.mjs blocks the stop.
+    expect(readSilentEndState()).toMatchObject({ turnKey: 'c:1664', retryCount: 0 })
+  })
+
+  it('a turn with a final-answer reply (notification-bearing) → re-prompt NOT engaged', () => {
+    const r = simulateTurnEnd(
+      [{ text: 'Here is the answer.', disableNotification: false }],
+      'c:final',
+    )
+    expect(r.finalAnswerDelivered).toBe(true)
+    expect(r.rePromptEngaged).toBe(false)
+    expect(readSilentEndState()).toBeNull()
+  })
+
+  it('a long reply mis-marked interim → re-prompt NOT engaged (length backstop)', () => {
+    const r = simulateTurnEnd(
+      [{ text: 'x'.repeat(500), disableNotification: true }],
+      'c:long',
+    )
+    expect(r.finalAnswerDelivered).toBe(true)
+    expect(r.rePromptEngaged).toBe(false)
+    expect(readSilentEndState()).toBeNull()
+  })
+
+  it('zero-outbound turn → re-prompt still engaged (regression of the original case)', () => {
+    // No replies at all — the original #1122 silent-end case is now just
+    // the subset of "no final answer delivered" where nothing landed.
+    const r = simulateTurnEnd([], 'c:zero')
+    expect(r.finalAnswerDelivered).toBe(false)
+    expect(r.rePromptEngaged).toBe(true)
+    expect(readSilentEndState()).toMatchObject({ turnKey: 'c:zero', retryCount: 0 })
+  })
+
+  it('interim ack followed by a final-answer reply in the same turn → NOT engaged', () => {
+    // The model ack'd first then properly delivered — finalAnswerDelivered
+    // latches true on the second reply; the turn is answered.
+    const r = simulateTurnEnd(
+      [
+        { text: 'Looking into it…', disableNotification: true },
+        { text: 'Done — the result is 42.', disableNotification: false },
+      ],
+      'c:ack-then-final',
+    )
+    expect(r.finalAnswerDelivered).toBe(true)
+    expect(r.rePromptEngaged).toBe(false)
+    expect(readSilentEndState()).toBeNull()
+  })
+
+  it('stream_reply done=true counts as the final answer → NOT engaged', () => {
+    const r = simulateTurnEnd(
+      [{ text: 'ok', disableNotification: true, done: true }],
+      'c:stream-done',
+    )
+    expect(r.finalAnswerDelivered).toBe(true)
+    expect(r.rePromptEngaged).toBe(false)
+    expect(readSilentEndState()).toBeNull()
+  })
+
+  it('exhaustion still applies on the #1664 path after the Stop-hook re-prompt', () => {
+    // First undelivered turn-end writes state.
+    expect(simulateTurnEnd(
+      [{ text: 'one sec', disableNotification: true }],
+      'c:exhaust',
+    ).rePromptEngaged).toBe(true)
+    // Stop hook blocks once and bumps retryCount (simulated).
+    const path = join(stateDir, 'silent-end-pending.json')
+    const s = readSilentEndState()!
+    writeFileSync(path, JSON.stringify({ ...s, retryCount: s.retryCount + 1 }))
+    // Re-prompted turn STILL ends with only an interim ack → exhausted.
+    const second = recordUndeliveredTurnEnd({ chatId: 'c', threadId: null, turnKey: 'c:exhaust' })
+    expect(second.exhausted).toBe(true)
+    expect(readSilentEndState()).toBeNull()
+  })
+})
+
 describe('silent-end-interrupt-stop hook — integration', () => {
   const hookPath = join(__dirname, '..', 'hooks', 'silent-end-interrupt-stop.mjs')
 
@@ -222,6 +336,10 @@ describe('silent-end-interrupt-stop hook — integration', () => {
     const out = JSON.parse(r.stdout.trim())
     expect(out.decision).toBe('block')
     expect(out.reason).toContain('reply')
+    // #1664 — the re-prompt must offer the NO_REPLY escape hatch so a
+    // model that already delivered (or intentionally has nothing to add)
+    // can end the turn cleanly instead of being forced to re-send.
+    expect(out.reason).toContain('NO_REPLY')
     // retryCount must have been incremented to 1
     expect(readSilentEndState()!.retryCount).toBe(1)
   })


### PR DESCRIPTION
## Summary

Fixes #1664 — streamed final answers delivered via `sendMessageDraft` were never finalized into a permanent `sendMessage`. The draft showed transiently then got retracted at `turn_end`; from the user's side, replies *appeared and then vanished*, and were absent from history.

The fix extends the existing **silent-end re-prompt safety net** so it engages whenever a real user-message turn ends without a *final answer* delivered — not just on zero outbound. The model re-delivers via the `reply` tool; the framework never materializes the draft.

## Why

An agent often ends a turn with its real answer as plain assistant **transcript text** instead of a `reply`/`stream_reply` tool call. The gateway's answer-stream renders that transcript as a live Telegram **draft**; at `turn_end` the gateway retracts the draft and the answer is lost.

The framework genuinely cannot classify transcript-after-a-reply by inspection: sometimes it's the real answer (#1664 — must not lose), sometimes a redundant wrap-up (#1657 — must not duplicate). Only the model knows its intent. Per `reference/principles.md` ("build the model to communicate; framework is the safety net, not the headline"), the fix **re-prompts the model** rather than faking a message from the draft.

**Relationship to #1657:** complementary, not a revert. #1657 made `decideTurnFlush` skip when `replyCalled` — that stays exactly as-is. #1657 stops the *duplicate* wrap-up; this PR handles the *un-delivered answer*. The two cases are indistinguishable to turn-flush, which is why the model (not the framework) resolves it via the re-prompt.

## What changed

**Part 1 — track "final answer delivered" per turn**
- New `finalAnswerDelivered: boolean` on `CurrentTurn`, init `false`.
- New pure module `telegram-plugin/final-answer-detect.ts` — `isFinalAnswerReply(...)`: a reply is the final answer if notification-bearing (`disable_notification` falsy — the pacing contract's explicit "final answer" signal), OR `>= FINAL_ANSWER_MIN_CHARS` (200 — a length backstop for an answer mis-marked interim), OR a `stream_reply` with `done: true`.
- `executeReply` / `executeStreamReply` set `currentTurn.finalAnswerDelivered = true` via that predicate when a reply lands. The turn-flush `flush` branch sets it too.

**Part 2 — extend the turn_end trigger**
- The gateway now engages the re-prompt when `turn.finalAnswerDelivered === false` (subsumes the old `outboundCount === 0` case; adds ack-reply + answer-as-transcript). NO_REPLY/HEARTBEAT_OK silent-marker turns return earlier and never reach this path.
- `recordSilentTurnEnd` is unchanged; re-exported as `recordUndeliveredTurnEnd` for the clearer name. Retry/exhaustion/`{exhausted}`/#1161-fallback semantics preserved.

**Part 3 — Stop-hook re-prompt wording**
- `silent-end-interrupt-stop.mjs` re-prompt now covers the #1664 case: send the answer via the `reply` tool now, OR reply `NO_REPLY` if already delivered / intentionally nothing to add.

**Part 4 — ordering race**
- Investigated. A late `text` event after `currentTurn` is nulled is dropped by the existing `turn != null` guard; folding it back into a closed turn (re-creating the answer stream, re-running `decideTurnFlush`) is large and race-prone. It is **not correctness-critical**: a turn whose answer lost the race ends `finalAnswerDelivered=false`, so Parts 1-3 recover it via the re-prompt. Left a clear code comment on the `text` event guard explaining this rather than destabilizing `turn_end`.

## Test plan

- [x] `telegram-plugin/tests/final-answer-detect.test.ts` — new, pins the predicate (notification flag, length backstop incl. boundary, `done:true`, empty text).
- [x] `telegram-plugin/tests/silent-end.test.ts` — new `#1664 extended trigger` block: ack reply + answer-as-transcript → re-prompt fires; final-answer reply / long mis-marked reply / `stream done` → not engaged; zero-outbound → still engaged (regression); ack-then-final → not engaged; exhaustion still applies on the #1664 path. Hook test now also asserts the `NO_REPLY` escape hatch.
- [x] Full `telegram-plugin/` suite green under both vitest (2627) and `bun test` (3207).
- [x] `tsc --noEmit`, `check-bot-api-wrapping.sh`, `check-plugin-references.mjs` all clean.

## Risk

Low. The new module is pure and fully tested. The behavior change is strictly *additive* to an existing safety net — a turn that previously would NOT re-prompt (ack + transcript answer) now does; the worst case of a false "interim" classification is one extra re-prompt (the model replies `NO_REPLY`). The `#1657` turn-flush behavior is untouched. The dangerous direction (a real answer falsely classified "final" and left undelivered) is guarded by the 200-char length backstop.