### PR TITLE
chore: release v0.13.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased — Google Workspace OAuth scopes tied to the tier
+## v0.13.13 — create Workspace files; streamed answers stop vanishing
 
 ### fix(auth) — mint Slides/Docs/Sheets OAuth scopes so agents can edit Workspace files (#1663)
 
@@ -27,6 +27,26 @@ own browser OAuth on port 8000 (unrecoverable inside a container).
 - Changing the tier requires re-running `account add --replace` — OAuth
   scopes are fixed at consent time. Documented in
   `docs/google-workspace.md`.
+
+### fix(pacing) — streamed answers no longer vanish from the chat (#1664)
+
+An agent often ends a turn with its real answer as plain assistant
+transcript text instead of a `reply` tool call. The gateway rendered
+that transcript as a live Telegram draft and then **deleted it at
+turn-end** — the user watched the answer stream in, then it vanished,
+and it never reached history either.
+
+The framework can't classify transcript-after-a-`reply` (sometimes the
+real answer, sometimes a redundant wrap-up — only the model knows), so
+per `reference/principles.md` ("the model communicates; the framework
+is the safety net") the fix re-prompts the model rather than faking the
+message. It extends the silent-end safety net: each turn tracks whether
+a real **final-answer beat** landed — a notification-bearing `reply`, a
+≥200-char reply, a `stream_reply` with `done=true`, or a legitimate
+turn-flush. If a turn ends without one, the Stop hook blocks turn-end
+and re-prompts the agent to send its answer via `reply` (or `NO_REPLY`
+if it already did). No duplicate, no data loss; complements the #1657
+turn-flush fix without weakening it.
 
 ## v0.13.12 — quieter turns: no duplicate wrap-up, no card-era worker pings
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release **v0.13.13** — *create Workspace files; streamed answers stop vanishing.*

Diff is `CHANGELOG.md` + `package.json` only. Both constituent PRs merged + reviewed since v0.13.12:

| PR | Issue | |
|---|---|---|
| #1665 | #1663 | fix(auth): Google Workspace OAuth scopes tied to the `--tier` — agents can create/edit Slides/Docs/Sheets |
| #1666 | #1664 | fix(pacing): re-prompt when a turn ends with the answer left as a draft — streamed answers no longer vanish |

## Test plan
- [x] `node scripts/build.mjs` → clean, `dist/cli/switchroom.js` 2.8MB
- [x] Both constituent PRs independently reviewed (fresh-process) + CI-green before merge

## Risk
Low for release metadata itself. #1666 changes turn-end behaviour — a UAT canary pass (pacing scenarios) gates the fleet rollout after this merges + images build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)