### PR TITLE
fix(uat): revise cross-turn UAT prompt to elicit natural ack

### DIFF
--- a/telegram-plugin/uat/scenarios/cross-turn-pending-progress-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/cross-turn-pending-progress-dm.test.ts
@@ -57,17 +57,19 @@ import type { ObservedMessage } from "../driver.js";
 
 const SLEEP_SECONDS = 350;
 
+// Engineered to elicit the natural production pattern: the model
+// sends a quick ack reply ("on it — background sleep running"),
+// dispatches the sleep as a background Bash, ends its turn, then
+// returns with "done" once the sleep completes. The framework
+// fix-under-test owns the in-between ambient.
 const PROMPT =
-  `This is an instrumented stress test of cross-turn pending-async ` +
-  `progress. Please run exactly this command via the Bash tool, and ` +
-  `ONLY this command, as a SINGLE call with run_in_background=true ` +
-  `(do not break it up, do not send any further reply until it ` +
-  `completes):\n\n` +
-  "```bash\n" +
-  `sleep ${SLEEP_SECONDS}\n` +
-  "```\n\n" +
-  `After the bash command returns, send exactly the single word ` +
-  `"done" as your final reply.`;
+  `Please run \`sleep ${SLEEP_SECONDS}\` in the background using the ` +
+  `Bash tool with \`run_in_background: true\` — this is a stress ` +
+  `test of the cross-turn ambient progress surface, so the sleep ` +
+  `duration matters. Send a brief one-line acknowledgement that ` +
+  `you've dispatched it (your natural beat-1 ack is fine), then ` +
+  `wait for it to complete. When it finishes, reply with exactly ` +
+  `the single word "done".`;
 
 const OVERALL_DEADLINE_MS = (SLEEP_SECONDS + 240) * 1000;
 


### PR DESCRIPTION
## Summary

Follow-up to PR #1669. The UAT scenario `cross-turn-pending-progress-dm.test.ts` had an over-prescriptive prompt — the model interpreted "do not send any further reply until it completes" as "send nothing at all," ended the turn with zero outbound, and the framework had no anchor to edit. The fix-under-test was blocked from activating by the test prompt itself.

## What

Revised the prompt to encourage the natural beat-1 ack (which is exactly the production pattern #1445 + #1669 are designed for).

## Verified live against test-harness on v0.13.14

```
+11.6s  fresh  silent=true   msg=73761  "dispatched — waiting on the 350s sleep"
+74.6s  edit   silent=true   msg=73761  "...— still working (1m)"
+134.6s edit   silent=true   msg=73761  "...— still working (2m)"
+152.4s fresh  silent=false  msg=73762  "done"
```

All four scenario assertions pass: in-place edits with the `— still working (Nm)` suffix landed, both edits were silent, both edits anchored to the same `messageId` as the initial reply, and the final fresh "done" pinged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)