### PR TITLE
feat(telegram): visible answer-stream — openclaw-pattern TTFO fix (#869 Phase 1)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2855,6 +2855,42 @@ const STREAM_THROTTLE_MS_OVERRIDE: number | undefined = (() => {
   return Number.isFinite(n) && n >= 0 ? n : undefined
 })()
 const TURN_FLUSH_SAFETY_ENABLED = isTurnFlushSafetyEnabled()
+
+// #869-Phase1 / openclaw-pattern. When SET, the answer-lane stream
+// (telegram-plugin/answer-stream.ts) renders the model's transcript
+// text as a USER-VISIBLE edit-in-place message instead of writing to
+// Telegram's invisible compose-box draft (which is the default and
+// supports the #1664 "retract + re-prompt" contract). With this flag
+// on:
+//   1. createAnswerStream is instantiated without `sendMessageDraft`,
+//      so it falls back to `sendMessage` + `editMessageText` for a
+//      real chat-timeline message (`answer-stream.ts:212-214`).
+//   2. minInitialChars is set to 1 — the first text chunk pushes a
+//      visible message immediately (TTFO under 5s for short turns).
+//   3. At turn_end, if the model never called reply / stream_reply
+//      AND the streamed message has substantive captured text, the
+//      gateway DOES NOT retract (which would delete a user-visible
+//      message the user has been reading live); it calls
+//      `stream.stop()` to freeze the current text as the final
+//      answer, records the message in dedup + history, and marks
+//      `turn.finalAnswerDelivered = true` so the #1664 silent-end
+//      re-prompt does not fire. Turn-flush is suppressed for this
+//      branch — its job (deliver captured text) is structurally
+//      already done by the visible stream.
+//   4. The reply-tool / stream_reply path is unchanged — when the
+//      model uses an explicit reply tool the prior streamed message
+//      is retracted (delete) and the reply takes over as before.
+// Trade-off: a stream-as-final-answer turn does NOT push a device
+// notification (Telegram does not notify on edits, and we choose
+// not to send a duplicate fresh message for the ping). For short
+// turns where the user is actively watching, this is the right
+// shape — they see the answer materialise live. For longer waits,
+// the cross-turn pending-progress system (#1445/#1669) is the
+// canonical surface and DOES ping at the appropriate boundaries.
+// Default OFF; flip per-agent via env to canary the new behaviour.
+const ANSWER_STREAM_VISIBLE_ENABLED =
+  process.env.SWITCHROOM_VISIBLE_ANSWER_STREAM === '1'
+  || process.env.SWITCHROOM_VISIBLE_ANSWER_STREAM === 'true'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const progressDriver: any = null
 const unpinProgressCardForChat: ((chatId: string, threadId: number | undefined) => void) | null = null
@@ -5986,7 +6022,13 @@ function handleSessionEvent(ev: SessionEvent): void {
             chatId: turn.sessionChatId,
             isPrivateChat: turn.isDm,
             threadId: turn.sessionThreadId,
-            sendMessageDraft: sendMessageDraftFn,
+            // #869-Phase1 visible-answer-stream: omit the draft API so
+            // the lane uses the real sendMessage / editMessageText path
+            // and edits a user-visible chat-timeline message instead
+            // of the invisible compose-box draft.
+            ...(ANSWER_STREAM_VISIBLE_ENABLED
+              ? { minInitialChars: 1 }
+              : { sendMessageDraft: sendMessageDraftFn }),
             // #1075: route through robustApiCall so flood-wait,
             // benign-400, and THREAD_NOT_FOUND are handled uniformly
             // instead of crashing the answer-stream loop on a deleted
@@ -6189,20 +6231,71 @@ function handleSessionEvent(ev: SessionEvent): void {
       // (regression for short no-tool replies). Order matters here: this
       // call must come before the retract/null block.
       preambleSuppressor.flushNow()
-      // #656: always retract the answer-lane stream at turn_end. Turn-flush
-      // (gateway.ts ~3475) is the sole canonical emitter for no-reply turns —
-      // it runs markdownToHtml and records to outboundDedup. Materializing
-      // here would race turn-flush and post raw model text (no HTML conv).
+      // #656: by default we ALWAYS retract the answer-lane stream at
+      // turn_end. Turn-flush is the canonical emitter for no-reply
+      // turns; materialising here would race it and post raw model
+      // text (no HTML conv).
+      //
+      // #869-Phase1 override: when `ANSWER_STREAM_VISIBLE_ENABLED` is
+      // on, the stream is rendering a USER-VISIBLE message in the
+      // chat timeline. Retracting (delete) destroys content the user
+      // has been reading live — the worst possible UX flicker. So
+      // when the stream is the de-facto final answer (model never
+      // called reply, captured text is substantive) we instead call
+      // `stream.stop()` to freeze it as the final state, record the
+      // outbound for history + dedup, mark the turn answered, and
+      // suppress the turn-flush IIFE downstream.
+      let streamFinalizedAsAnswer = false
       if (turn?.answerStream != null) {
         const stream = turn.answerStream
-        turn.answerStream = null
-        void stream.retract().catch((err) => {
+        const streamedMsgId = stream.messageId()
+        const streamedFinalText = turn.capturedText.join('').trim()
+        if (
+          ANSWER_STREAM_VISIBLE_ENABLED
+          && !turn.replyCalled
+          && streamedMsgId != null
+          && streamedFinalText.length > 0
+        ) {
+          turn.answerStream = null
+          stream.stop()
+          streamFinalizedAsAnswer = true
+          turn.finalAnswerDelivered = true
+          // Record as canonical outbound so retries dedup against it
+          // and the SQLite history can surface it. Mirrors the
+          // hooks turn-flush + reply both run.
+          try {
+            outboundDedup.record(
+              turn.sessionChatId,
+              turn.sessionThreadId,
+              streamedFinalText,
+              Date.now(),
+            )
+          } catch { /* best-effort */ }
+          if (HISTORY_ENABLED) {
+            try {
+              recordOutbound({
+                chat_id: turn.sessionChatId,
+                thread_id: turn.sessionThreadId ?? null,
+                message_ids: [streamedMsgId],
+                texts: [streamedFinalText],
+              })
+            } catch { /* best-effort */ }
+          }
           process.stderr.write(
-            `telegram gateway: answer-stream retract failed: ${
-              err instanceof Error ? err.message : String(err)
-            }\n`,
+            `telegram gateway: answer-stream finalized as answer ` +
+            `chat=${turn.sessionChatId} msg=${streamedMsgId} ` +
+            `chars=${streamedFinalText.length}\n`,
           )
-        })
+        } else {
+          turn.answerStream = null
+          void stream.retract().catch((err) => {
+            process.stderr.write(
+              `telegram gateway: answer-stream retract failed: ${
+                err instanceof Error ? err.message : String(err)
+              }\n`,
+            )
+          })
+        }
       }
       if (turn == null) return
       const chatId = turn.sessionChatId
@@ -6214,12 +6307,19 @@ function handleSessionEvent(ev: SessionEvent): void {
       // surface to recover from. The decideTurnFlush 'empty-text'
       // path now relies on capturedText alone.
 
-      const flushDecision = decideTurnFlush({
-        chatId: turn.sessionChatId,
-        replyCalled: turn.replyCalled,
-        capturedText: turn.capturedText,
-        flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
-      })
+      // #869-Phase1: when the answer-stream finalised as the answer
+      // above, skip the turn-flush IIFE entirely — its job (deliver
+      // captured text) is already done by the visible stream, and
+      // running it would race a duplicate fresh-sendMessage against
+      // the user-visible edited message.
+      const flushDecision = streamFinalizedAsAnswer
+        ? ({ kind: 'skip', reason: 'reply-called' } as ReturnType<typeof decideTurnFlush>)
+        : decideTurnFlush({
+            chatId: turn.sessionChatId,
+            replyCalled: turn.replyCalled,
+            capturedText: turn.capturedText,
+            flushEnabled: TURN_FLUSH_SAFETY_ENABLED,
+          })
       if (flushDecision.kind === 'skip' && flushDecision.reason !== 'reply-called') {
         process.stderr.write(
           `telegram gateway: turn-flush skipped — reason=${flushDecision.reason}\n`,

--- a/telegram-plugin/uat/scenarios/visible-answer-stream-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/visible-answer-stream-dm.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Visible answer-stream — UAT for the openclaw-pattern TTFO fix
+ * (#869 Phase 1 narrow scope).
+ *
+ * Validates that when `SWITCHROOM_VISIBLE_ANSWER_STREAM=1` is set on
+ * the target agent, the framework auto-renders the model's transcript
+ * text as a user-visible edit-in-place message starting within ~5s of
+ * inbound — instead of writing to Telegram's invisible compose-box
+ * draft (the default #1664 behaviour).
+ *
+ * ## Required setup
+ *
+ * The target agent (default `test-harness`) MUST have
+ * `SWITCHROOM_VISIBLE_ANSWER_STREAM=1` in its container environment.
+ * Without that env var the scenario will (correctly) fail — the
+ * default behaviour writes to a draft the mtcute driver cannot see.
+ *
+ * ## What this asserts
+ *
+ *   1. The first user-visible bot output (fresh `sendMessage`) lands
+ *      within `VISIBLE_TTFO_BUDGET_MS` (default 8 s) of the inbound.
+ *      Today's median TTFO across the fleet is 17–69 s; the visible
+ *      lane should drop it well under 10 s for any reply long enough
+ *      to emit a text chunk.
+ *   2. The initial fresh message is silent (the answer-stream emits
+ *      with `disable_notification: true` so mid-turn edits never ping).
+ *   3. Subsequent edits land on the SAME message_id — single in-place
+ *      surface, not a chain of pinged sends.
+ *   4. At least one edit growth event happens between first send and
+ *      turn-end (the streaming property — TTFO is fast, then content
+ *      grows live).
+ *
+ * The captured trail is dumped to console for forensic inspection
+ * regardless of pass/fail.
+ *
+ * Wall-clock budget: ~90 s.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+import type { ObservedMessage } from "../driver.js";
+
+const VISIBLE_TTFO_BUDGET_MS = 8_000;
+const OVERALL_DEADLINE_MS = 90_000;
+const QUIESCENCE_MS = 8_000;
+
+// Prompt engineered to make the model emit a multi-sentence answer
+// over a few seconds — long enough that the streaming behaviour
+// is observable, short enough that turn-flush isn't tempted to fire.
+// Deliberately does NOT instruct the model to call `reply` — we want
+// to exercise the transcript-only path that the visible-answer-stream
+// covers.
+const PROMPT =
+  `Please give a four-sentence overview of how Linux page-cache ` +
+  `interacts with mmap on a typical x86_64 server. Reply in a single ` +
+  `message, with substantive prose. No code blocks.`;
+
+interface TrailEntry {
+  relMs: number;
+  kind: "fresh" | "edit";
+  silent: boolean;
+  messageId: number;
+  textPreview: string;
+  textLength: number;
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + " ".repeat(n - s.length);
+}
+
+describe("uat: visible answer-stream — model transcript renders live (#869 Phase 1)", () => {
+  it(
+    "first fresh message lands within VISIBLE_TTFO_BUDGET_MS; subsequent edits grow it in place",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        const startedAt = Date.now();
+        await sc.sendDM(PROMPT);
+        console.log(`[visible-answer-stream] t=0 prompt sent`);
+
+        const trail: TrailEntry[] = [];
+        let firstAnchorMsgId: number | null = null;
+        let quiescenceDeadline = startedAt + 30_000;
+        const overallDeadline = startedAt + OVERALL_DEADLINE_MS;
+
+        while (Date.now() < overallDeadline) {
+          const remaining = Math.min(
+            quiescenceDeadline - Date.now(),
+            overallDeadline - Date.now(),
+          );
+          if (remaining <= 0) break;
+          try {
+            const msg = await sc.expectMessage(
+              (m: ObservedMessage) => m.fromBot,
+              { from: "bot", timeout: remaining },
+            );
+            const rel = Date.now() - startedAt;
+            const entry: TrailEntry = {
+              relMs: rel,
+              kind: msg.edited ? "edit" : "fresh",
+              silent: msg.silent,
+              messageId: msg.messageId,
+              textPreview: msg.text
+                .slice(0, 120)
+                .replace(/\n/g, " ⏎ "),
+              textLength: msg.text.length,
+            };
+            trail.push(entry);
+            if (firstAnchorMsgId == null && entry.kind === "fresh") {
+              firstAnchorMsgId = entry.messageId;
+            }
+            console.log(
+              `[visible-answer-stream] +${(rel / 1000).toFixed(1)}s ` +
+                `${entry.kind.toUpperCase()} msg=${entry.messageId} ` +
+                `silent=${entry.silent} len=${entry.textLength} ` +
+                `text=${JSON.stringify(entry.textPreview)}`,
+            );
+            quiescenceDeadline = Date.now() + QUIESCENCE_MS;
+          } catch {
+            break;
+          }
+        }
+
+        console.log("\n========== VISIBLE-ANSWER-STREAM TRAIL ==========");
+        console.log(`total bot messages observed: ${trail.length}`);
+        console.log(`first anchor messageId: ${firstAnchorMsgId}`);
+        console.log("");
+        console.log("  rel(s)   kind   silent  msg          len   text");
+        console.log("  -------  -----  ------  -----------  ----  ----");
+        for (const e of trail) {
+          console.log(
+            `  ${pad((e.relMs / 1000).toFixed(1) + "s", 8)} ` +
+              `${pad(e.kind, 6)} ${pad(String(e.silent), 7)} ` +
+              `${pad(String(e.messageId), 12)} ${pad(String(e.textLength), 5)} ` +
+              `${e.textPreview}`,
+          );
+        }
+        console.log("=================================================\n");
+
+        // ── Regression assertions ─────────────────────────────────
+
+        const fresh = trail.filter((e) => e.kind === "fresh");
+        const edits = trail.filter((e) => e.kind === "edit");
+
+        // (1) at least one fresh message landed
+        expect(
+          fresh.length,
+          `no fresh bot replies observed — either the agent isn't ` +
+            `responding OR the visible-answer-stream flag is OFF ` +
+            `(SWITCHROOM_VISIBLE_ANSWER_STREAM not set on the target ` +
+            `agent's container env). Re-check the agent's compose ` +
+            `environment.`,
+        ).toBeGreaterThanOrEqual(1);
+
+        // (2) first fresh landed within the TTFO budget
+        const ttfoMs = fresh[0].relMs;
+        expect(
+          ttfoMs,
+          `TTFO ${ttfoMs}ms exceeded the visible-answer-stream ` +
+            `budget of ${VISIBLE_TTFO_BUDGET_MS}ms. Either the model ` +
+            `was unusually slow to emit its first text chunk, OR the ` +
+            `visible answer-stream is not active. Default behaviour ` +
+            `(invisible draft) would never have surfaced a fresh ` +
+            `message at all, so the most likely cause is model latency.`,
+        ).toBeLessThanOrEqual(VISIBLE_TTFO_BUDGET_MS);
+
+        // (3) first fresh message was silent (mid-turn edits don't ping)
+        expect(
+          fresh[0].silent,
+          `the first fresh message pinged the user — answer-stream ` +
+            `should send silently (disable_notification:true). A ping ` +
+            `here means an explicit \`reply\` tool may have fired instead.`,
+        ).toBe(true);
+
+        // (4) at least one in-place EDIT landed on the same messageId
+        // (this is the "live streaming" assertion — TTFO is fast AND
+        // content grows on the same surface, not a chain of new sends).
+        const sameAnchorEdits = edits.filter(
+          (e) => e.messageId === firstAnchorMsgId,
+        );
+        expect(
+          sameAnchorEdits.length,
+          `no in-place edits to the anchor message landed — the model ` +
+            `either replied in a single shot (very short answer) or ` +
+            `the streaming path isn't running. Edits observed: ` +
+            `${edits.length}, on anchor: ${sameAnchorEdits.length}.`,
+        ).toBeGreaterThanOrEqual(1);
+
+        // (5) every edit is silent (Telegram edits don't push, but
+        // we double-check via mtcute's flag in case the framework
+        // ever swaps to a fresh-send pattern by accident)
+        const loudEdits = edits.filter((e) => !e.silent);
+        expect(
+          loudEdits.length,
+          `${loudEdits.length} edit(s) pinged the device.`,
+        ).toBe(0);
+
+        // (6) text length grows monotonically on the anchor (streaming
+        // by construction — once content is on the anchor, it only
+        // accumulates)
+        const anchorTrail = trail.filter(
+          (e) => e.messageId === firstAnchorMsgId,
+        );
+        for (let i = 1; i < anchorTrail.length; i++) {
+          expect(
+            anchorTrail[i].textLength,
+            `anchor message #${firstAnchorMsgId} text shrank between ` +
+              `events ${i - 1} (len=${anchorTrail[i - 1].textLength}) ` +
+              `and ${i} (len=${anchorTrail[i].textLength}) — ` +
+              `streaming text should only grow.`,
+          ).toBeGreaterThanOrEqual(anchorTrail[i - 1].textLength);
+        }
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    OVERALL_DEADLINE_MS + 30_000,
+  );
+});


### PR DESCRIPTION
## Summary

Closes the dominant common-case UX failure: TTFO median 69s on the busiest fleet agent for what should be 20-second exchanges. The user sees a typing indicator + reaction but **zero words** for a full minute. This PR makes the existing answer-lane (`answer-stream.ts`, which already reads model `text` events and edits a draft) write to a **user-visible** chat-timeline message instead of Telegram's invisible compose-box draft.

Flag-gated (`SWITCHROOM_VISIBLE_ANSWER_STREAM=1`), default OFF — canaries on test-harness before fleet flip.

## Behaviour matrix

| flag | turn ends with reply | turn ends without reply (transcript-only) |
|---|---|---|
| **OFF (default)** | answer-lane writes invisible draft → retracted; reply is visible | invisible draft → retracted; #1664 re-prompt → model fires reply → reply is visible |
| **ON** | answer-lane writes visible message; on reply, retracts (delete); reply takes over | answer-lane writes visible message; at turn_end, **freezes as final answer** (no retract, no turn-flush, marks `finalAnswerDelivered=true`) |

## Test plan

- [x] tsc + lint gates green
- [x] vitest `telegram-plugin/`: 170 files / 2818 tests pass (zero change in default mode)
- [ ] UAT `visible-answer-stream-dm.test.ts` — runs post-release on test-harness with the env flag set; asserts TTFO < 8s, first fresh message silent, anchor edits land on same `messageId`, text grows monotonically

## Risk

Low. Default OFF = pure addition, gated. With flag ON:
- streamed text doesn't ping (Telegram limitation on edits) — acceptable for short turns; cross-turn ambient (#1669) handles longer
- raw model text rendered as HTML may have unbalanced tags — existing answer-stream HTML-fallback handles parse rejections

Per the prior reviewer pattern: detailed `file:line` rationale lives in the commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)