### PR TITLE
test(telegram): unit coverage + runtime-metric for #1674 over-ping safety net

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -74,6 +74,7 @@ import {
   shutdownAnalytics,
 } from '../analytics-posthog.js'
 import { emitRuntimeMetric } from '../runtime-metrics.js'
+import { decideOverPing } from '../over-ping-safety-net.js'
 import { classifyInbound } from '../inbound-classifier.js'
 import * as silencePoke from '../silence-poke.js'
 import * as pendingProgress from '../pending-work-progress.js'
@@ -4242,17 +4243,32 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // send — races concurrent reply calls).
   {
     const turn = currentTurn
-    if (turn != null && !disableNotification) {
-      if (turn.firstPingAt != null) {
+    if (turn != null) {
+      const now = Date.now()
+      const decision = decideOverPing({
+        modelRequestedPing: !disableNotification,
+        firstPingAt: turn.firstPingAt,
+        nowMs: now,
+      })
+      if (decision.suppress) {
         process.stderr.write(
           `telegram gateway: reply over-ping safety net — ` +
           `downgrading disable_notification:false → true ` +
           `(chat=${chat_id} thread=${args.message_thread_id ?? '-'} ` +
-          `firstPingAt=${turn.firstPingAt} sinceFirstPing_ms=${Date.now() - turn.firstPingAt})\n`,
+          `firstPingAt=${turn.firstPingAt} sinceFirstPing_ms=${decision.sinceFirstPingMs})\n`,
         )
+        // Observability: surface to the unified runtime-metrics
+        // fan-out so the cadence dashboard can track fleet-wide
+        // over-ping rate (leading indicator of model pacing drift).
+        emitRuntimeMetric({
+          kind: 'over_ping_suppressed',
+          key: statusKey(chat_id, args.message_thread_id != null
+            ? Number(args.message_thread_id) : undefined),
+          sinceFirstPingMs: decision.sinceFirstPingMs ?? 0,
+        })
         disableNotification = true
-      } else {
-        turn.firstPingAt = Date.now()
+      } else if (decision.claimSlot) {
+        turn.firstPingAt = now
       }
     }
   }

--- a/telegram-plugin/over-ping-safety-net.ts
+++ b/telegram-plugin/over-ping-safety-net.ts
@@ -1,0 +1,80 @@
+/**
+ * over-ping-safety-net.ts — pure decision predicate for #1674's
+ * "at-most-one device-ping per turn" framework safety net.
+ *
+ * Background. `reference/conversational-pacing.md` beat 5 is
+ * explicit: the model should deliver the answer as a fresh `reply`
+ * omitting `disable_notification` (i.e. pinging the device once).
+ * EXACTLY ONE ping per turn. The model occasionally violates this
+ * — fleet UAT 2026-05-23 reproduced a substantive Step 3 answer
+ * pinged + a wrap-up "Delivered all three steps with a wrap-up
+ * summary." ALSO pinged, two device beeps for a turn that should
+ * have produced one.
+ *
+ * This module is the framework safety net. The IO live in the
+ * gateway's `executeReply` (mutate `turn.firstPingAt`, emit log +
+ * runtime-metric, override `disableNotification`); keeping the
+ * *decision* pure makes the predicate unit-testable without
+ * standing up a gateway.
+ *
+ * Contract:
+ *   - When the model requested a ping (`!disable_notification`) AND
+ *     the current turn already had a ping land (`firstPingAt != null`),
+ *     the decision says SUPPRESS — the caller downgrades to silent.
+ *   - When the model requested a ping AND no prior ping this turn,
+ *     the decision says CLAIM the slot — caller sets `firstPingAt`.
+ *   - When the model requested silent, this module is a no-op.
+ *
+ * The slot is claimed BEFORE the actual send (caller responsibility).
+ * Trade-off documented inline in `gateway.ts:executeReply`.
+ */
+
+export interface OverPingDecisionInput {
+  /** True iff the model requested a device ping
+   *  (`disable_notification:false` or omitted, since the default is to
+   *  ping per Telegram Bot API). The caller computes this from the
+   *  inbound `args.disable_notification === true` check. */
+  modelRequestedPing: boolean
+  /** Wall-clock ms of the FIRST ping this turn, or null if no ping
+   *  has landed yet. Caller threads this through from
+   *  `CurrentTurn.firstPingAt`. */
+  firstPingAt: number | null
+  /** Deterministic clock for tests; defaults to Date.now() in callers. */
+  nowMs: number
+}
+
+export interface OverPingDecision {
+  /** True iff the caller should override `disableNotification` to
+   *  `true` (i.e. send this reply silently). Implies a contract
+   *  violation by the model — caller should log + emit a metric. */
+  suppress: boolean
+  /** True iff the caller should claim the slot —
+   *  `turn.firstPingAt = nowMs`. Mutually exclusive with `suppress`. */
+  claimSlot: boolean
+  /** When `suppress` is true, how long the first ping has been
+   *  "active" (ms since `firstPingAt`). Caller surfaces this in the
+   *  log + metric for forensic analysis (e.g. tight rapid double-pings
+   *  vs delayed wrap-ups). Null otherwise. */
+  sinceFirstPingMs: number | null
+}
+
+/**
+ * Pure decision: should the framework suppress this reply's ping?
+ * No mutation, no IO, deterministic under a fixed `nowMs`.
+ */
+export function decideOverPing(input: OverPingDecisionInput): OverPingDecision {
+  if (!input.modelRequestedPing) {
+    // Model already chose silent — nothing for the safety net to do.
+    return { suppress: false, claimSlot: false, sinceFirstPingMs: null }
+  }
+  if (input.firstPingAt != null) {
+    // Slot already claimed by an earlier ping this turn — suppress.
+    return {
+      suppress: true,
+      claimSlot: false,
+      sinceFirstPingMs: input.nowMs - input.firstPingAt,
+    }
+  }
+  // First ping this turn — let it through and claim the slot.
+  return { suppress: false, claimSlot: true, sinceFirstPingMs: null }
+}

--- a/telegram-plugin/runtime-metrics.ts
+++ b/telegram-plugin/runtime-metrics.ts
@@ -124,6 +124,24 @@ export type RuntimeMetricEvent =
       elapsedMs?: number
       reason?: string
     }
+  /**
+   * #1674 over-ping safety net engaged. Fires when a `reply` call
+   * arrived with `disable_notification: false` AND the current turn
+   * already had a pinged reply land — the framework downgraded this
+   * call to silent to honour beat 5's "EXACTLY ONE ping per turn"
+   * contract. Each event is a model contract violation the safety
+   * net caught. A high rate per agent means the model is
+   * systematically over-pinging — prompt drift or training
+   * regression worth investigating.
+   *
+   *   key                 → `<chatId>:<threadIdOrEmpty>` (the statusKey shape)
+   *   sinceFirstPingMs    → time since the FIRST ping landed this turn
+   */
+  | {
+      kind: 'over_ping_suppressed'
+      key: string
+      sinceFirstPingMs: number
+    }
 
 /**
  * The JSONL sink lives under the runtime state dir so it's per-agent

--- a/telegram-plugin/tests/over-ping-safety-net.test.ts
+++ b/telegram-plugin/tests/over-ping-safety-net.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit suite for #1674's over-ping safety net predicate.
+ * Pins the decision logic in isolation from the gateway's
+ * `executeReply` IO so a future refactor can't silently regress.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { decideOverPing } from '../over-ping-safety-net.js'
+
+describe('decideOverPing — at-most-one-ping-per-turn safety net', () => {
+  it('lets the FIRST ping through and tells caller to claim the slot', () => {
+    const d = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: null,
+      nowMs: 1_000,
+    })
+    expect(d.suppress).toBe(false)
+    expect(d.claimSlot).toBe(true)
+    expect(d.sinceFirstPingMs).toBeNull()
+  })
+
+  it('SUPPRESSES subsequent ping in the same turn and reports elapsed', () => {
+    const d = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: 1_000,
+      nowMs: 4_500,
+    })
+    expect(d.suppress).toBe(true)
+    expect(d.claimSlot).toBe(false)
+    expect(d.sinceFirstPingMs).toBe(3_500)
+  })
+
+  it('is a no-op when the model already requested silent (regardless of slot state)', () => {
+    // No prior ping
+    const d1 = decideOverPing({
+      modelRequestedPing: false,
+      firstPingAt: null,
+      nowMs: 1_000,
+    })
+    expect(d1).toEqual({ suppress: false, claimSlot: false, sinceFirstPingMs: null })
+
+    // Prior ping already landed — silent reply still no-op, NOT claimed
+    const d2 = decideOverPing({
+      modelRequestedPing: false,
+      firstPingAt: 1_000,
+      nowMs: 5_000,
+    })
+    expect(d2).toEqual({ suppress: false, claimSlot: false, sinceFirstPingMs: null })
+  })
+
+  it('handles the edge case where firstPingAt equals nowMs (instant double-call)', () => {
+    // Same-tick double-fire: the second call comes in with firstPingAt
+    // exactly at nowMs. Elapsed is 0; suppress fires.
+    const d = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: 1_000,
+      nowMs: 1_000,
+    })
+    expect(d.suppress).toBe(true)
+    expect(d.claimSlot).toBe(false)
+    expect(d.sinceFirstPingMs).toBe(0)
+  })
+
+  it('reports large elapsed deltas honestly (late wrap-up after long work)', () => {
+    // Real-world reproducer pattern: substantive answer pings at +30s,
+    // wrap-up "Delivered all three steps…" pings at +36s. The safety
+    // net catches the second; sinceFirstPingMs reflects the 6s gap.
+    const d = decideOverPing({
+      modelRequestedPing: true,
+      firstPingAt: 30_000,
+      nowMs: 36_000,
+    })
+    expect(d.suppress).toBe(true)
+    expect(d.sinceFirstPingMs).toBe(6_000)
+  })
+
+  it('claim-vs-suppress is mutually exclusive', () => {
+    // Defensive invariant — no caller path should ever see both flags
+    // true at once.
+    const cases: Array<{
+      modelRequestedPing: boolean
+      firstPingAt: number | null
+      nowMs: number
+    }> = [
+      { modelRequestedPing: true, firstPingAt: null, nowMs: 100 },
+      { modelRequestedPing: true, firstPingAt: 50, nowMs: 100 },
+      { modelRequestedPing: false, firstPingAt: null, nowMs: 100 },
+      { modelRequestedPing: false, firstPingAt: 50, nowMs: 100 },
+    ]
+    for (const c of cases) {
+      const d = decideOverPing(c)
+      expect(d.suppress && d.claimSlot).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
Non-blocking follow-ups from the #1674 reviewer pass:

- Extract over-ping decision to pure `decideOverPing` predicate (`telegram-plugin/over-ping-safety-net.ts`) with 6-test unit suite.
- Emit `over_ping_suppressed` runtime-metric on each suppression for fleet-wide observability (was stderr-only before).

Pure refactor + additive metric. No behaviour change.

See commit body for rationale + test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)