### PR TITLE
feat(telegram): silent-reply auto-edit — multi-step turns render as one growing anchor + final ping

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -75,6 +75,7 @@ import {
 } from '../analytics-posthog.js'
 import { emitRuntimeMetric } from '../runtime-metrics.js'
 import { decideOverPing } from '../over-ping-safety-net.js'
+import { decideSilentReplyAnchor } from '../silent-reply-anchor.js'
 import { classifyInbound } from '../inbound-classifier.js'
 import * as silencePoke from '../silence-poke.js'
 import * as pendingProgress from '../pending-work-progress.js'
@@ -1218,6 +1219,16 @@ type CurrentTurn = {
   // the framework. Null until the first ping lands. Reset on every
   // fresh-turn enqueue.
   firstPingAt: number | null
+  // #1677 silent-reply auto-edit. The first silent reply of a turn
+  // captures `silentAnchorMessageId` + `silentAnchorText`; subsequent
+  // silent replies in the SAME turn editMessageText that anchor
+  // (appending with paragraph-break separator). Net visual: one
+  // growing silent bubble instead of N stacked silent bubbles.
+  // Cleared by turn-atom replacement on enqueue. See
+  // `telegram-plugin/silent-reply-anchor.ts` for the pure
+  // `decideSilentReplyAnchor` predicate.
+  silentAnchorMessageId: number | null
+  silentAnchorText: string
   capturedText: string[]
   orphanedReplyTimeoutId: ReturnType<typeof setTimeout> | null
   registryKey: string | null
@@ -4417,6 +4428,91 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
 
   startTypingLoop(chat_id)
 
+  // #1677 silent-reply auto-edit. Consecutive silent replies within
+  // a turn edit a single anchor message instead of stacking new
+  // bubbles. We branch BEFORE the chunk loop so the single-chunk
+  // common case takes an editMessageText path; everything else
+  // (multi-chunk, ping, files, buttons) falls through to fresh send
+  // and either captures a new anchor or doesn't, per the predicate.
+  let silentAnchorEditDone = false
+  {
+    const turn = currentTurn
+    if (turn != null && chunks.length === 1) {
+      const decision = decideSilentReplyAnchor({
+        effectivelySilent: disableNotification,
+        anchorMessageId: turn.silentAnchorMessageId,
+        anchorText: turn.silentAnchorText,
+        newReplyText: effectiveText,
+        hasFiles: files.length > 0,
+        hasButtons: replyMarkup != null,
+      })
+      if (decision.kind === 'edit-anchor') {
+        const editParams: {
+          parse_mode?: 'HTML' | 'MarkdownV2'
+          message_thread_id?: number
+          link_preview_options?: { is_disabled: boolean }
+        } = {
+          link_preview_options: { is_disabled: disableLinkPreview },
+        }
+        if (parseMode != null) editParams.parse_mode = parseMode
+        if (threadId != null) editParams.message_thread_id = threadId
+        try {
+          await robustApiCall(
+            () =>
+              lockedBot.api.editMessageText(
+                chat_id,
+                decision.messageId,
+                decision.mergedText,
+                editParams,
+              ),
+            {
+              chat_id,
+              verb: 'reply.silent-anchor-edit',
+              ...(threadId != null ? { threadId } : {}),
+            },
+          )
+          turn.silentAnchorText = decision.mergedText
+          sentIds.push(decision.messageId)
+          logOutbound(
+            'edit',
+            chat_id,
+            decision.messageId,
+            decision.mergedText.length,
+            'silent-anchor-merge',
+          )
+          process.stderr.write(
+            `telegram gateway: silent-reply auto-edit — ` +
+            `chat=${chat_id} anchor=${decision.messageId} ` +
+            `merged_len=${decision.mergedText.length}\n`,
+          )
+          silentAnchorEditDone = true
+        } catch (err) {
+          // Edit failed (e.g. message deleted, rate limit exhausted,
+          // parse error). Fall through to fresh-send below — the
+          // anchor will be overwritten by whatever lands.
+          process.stderr.write(
+            `telegram gateway: silent-reply auto-edit failed, ` +
+            `falling back to fresh send: ${err instanceof Error ? err.message : String(err)}\n`,
+          )
+        }
+      }
+    }
+  }
+
+  if (silentAnchorEditDone) {
+    // Skip the chunk loop entirely — the anchor edit IS the send.
+    // Match the normal exit path: stop typing, then return.
+    stopTypingLoop(chat_id)
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `edited (id: ${sentIds[0]})`,
+        },
+      ],
+    }
+  }
+
   try {
     for (let i = 0; i < chunks.length; i++) {
       const shouldReplyTo =
@@ -4549,6 +4645,27 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         messageId: anchorMsgId,
         text: chunks[chunks.length - 1],
       })
+    }
+  }
+
+  // #1677 silent-reply auto-edit — anchor capture for the FIRST
+  // silent reply of a turn (or the silent reply that replaced the
+  // anchor on overflow). Only captures for the single-chunk,
+  // silent, no-files, no-buttons happy path; the edit-anchor path
+  // earlier in this function handles SUBSEQUENT silent replies by
+  // editing. The next silent reply this turn will see the captured
+  // anchor and edit it in place.
+  if (
+    chunks.length === 1
+    && disableNotification
+    && files.length === 0
+    && replyMarkup == null
+    && sentIds.length === 1
+  ) {
+    const turn = currentTurn
+    if (turn != null) {
+      turn.silentAnchorMessageId = sentIds[0]!
+      turn.silentAnchorText = effectiveText
     }
   }
 
@@ -5941,6 +6058,8 @@ function handleSessionEvent(ev: SessionEvent): void {
           replyCalled: false,
           finalAnswerDelivered: false,
           firstPingAt: null,
+          silentAnchorMessageId: null,
+          silentAnchorText: '',
           capturedText: [],
           orphanedReplyTimeoutId: null,
           registryKey: null,

--- a/telegram-plugin/silent-reply-anchor.ts
+++ b/telegram-plugin/silent-reply-anchor.ts
@@ -1,0 +1,142 @@
+/**
+ * silent-reply-anchor.ts — pure decision predicate for the
+ * "consecutive silent replies edit one growing message" UX fix.
+ *
+ * Background. Modern Claude 2.1.x on this fleet implements
+ * conversational pacing (`reference/conversational-pacing.md` beats
+ * 1 + 3 + 5) by calling the `reply` MCP tool multiple times in a
+ * turn — a silent ack, silent per-step updates, and one pinged
+ * final answer. The over-ping safety net (#1674) caps the
+ * notifications at one. But the user still SEES N separate chat
+ * bubbles for the silent replies, which reads as visual spam even
+ * when no device pings. The operator's original complaint was
+ * exactly this shape:
+ *
+ *   "I would like more regular process updates, where it edits a
+ *    status message in place vs spamming multiple messages."
+ *
+ * Fix: consecutive silent replies within a turn EDIT a single
+ * anchor message instead of each sending a fresh bubble. The
+ * model's intent (silent mid-turn updates) is honoured; the
+ * framework controls the visual placement (one growing bubble,
+ * not many). Final pinged reply lands as a separate fresh bubble
+ * (it's the final answer; the silent anchor is the preamble).
+ *
+ * Net visual for a multi-step turn:
+ *   pre-fix:  4 bubbles (silent ack + 2 silent steps + 1 pinged final)
+ *   post-fix: 2 bubbles (1 silent anchor with all 3 thoughts + 1 pinged final)
+ *
+ * Pinged replies always fresh-send. Reply-tool calls with files
+ * or button keyboards bypass the anchor (fresh send) because the
+ * edit path can't merge those cleanly.
+ *
+ * Accumulation format: `${anchorText}\n\n${newReplyText}` —
+ * blank-line paragraph separator. Reads naturally as the model
+ * "thinking out loud" with paragraph breaks per thought.
+ *
+ * Kill switch: `SWITCHROOM_DISABLE_SILENT_REPLY_AUTOEDIT=1` — turns
+ * the safety net off; reverts to per-reply fresh send.
+ */
+
+/** Telegram caption / text limit. The accumulator stays under this. */
+export const TELEGRAM_MSG_CAP = 4000
+
+export interface SilentReplyAnchorDecisionInput {
+  /** True when the model passed `disable_notification: true` for
+   *  this reply (i.e. the model intends this to be silent — a
+   *  beat 1/3 update). The over-ping safety net coerces other
+   *  pings to silent; this predicate sees the EFFECTIVE flag, not
+   *  the raw model intent. */
+  effectivelySilent: boolean
+  /** Wall-clock ms of the current anchor's existence, or null when
+   *  no silent anchor has been set this turn. */
+  anchorMessageId: number | null
+  /** Text content of the current anchor (accumulated). Empty when
+   *  no anchor exists. */
+  anchorText: string
+  /** Text content of the incoming reply, BEFORE any anchor merge. */
+  newReplyText: string
+  /** True if the incoming reply has attached files (photos,
+   *  documents, etc). Anchor merge bypassed when true — edits
+   *  can't add media to an existing text message. */
+  hasFiles: boolean
+  /** True if the incoming reply has an inline keyboard. Anchor
+   *  merge bypassed when true — keyboard semantics across edits
+   *  are too easy to get wrong, and the markup is rare enough
+   *  that fresh-send is the safer default. */
+  hasButtons: boolean
+}
+
+/**
+ * What the caller should do with this reply.
+ *
+ *   - `kind: 'fresh'` — send a normal new message; if it should
+ *     become the next anchor (silent + no attachments), the caller
+ *     captures its message_id after send and sets the anchor.
+ *
+ *   - `kind: 'edit-anchor'` — DO NOT send; edit the existing
+ *     anchor message with `mergedText` as the new content. The
+ *     caller updates `anchor.text = mergedText` after a successful
+ *     edit. messageId is the anchor's existing id.
+ */
+export type SilentReplyAnchorDecision =
+  | { kind: 'fresh'; becomesAnchor: boolean }
+  | { kind: 'edit-anchor'; messageId: number; mergedText: string }
+
+function enabled(): boolean {
+  const v = process.env.SWITCHROOM_DISABLE_SILENT_REPLY_AUTOEDIT
+  return !(v === '1' || v === 'true')
+}
+
+/**
+ * Decide whether to merge this reply into an existing silent
+ * anchor or fresh-send. Pure: no IO, no mutation, kill-switch
+ * checked per call.
+ */
+export function decideSilentReplyAnchor(
+  input: SilentReplyAnchorDecisionInput,
+): SilentReplyAnchorDecision {
+  // Kill switch disengages the whole mechanism — every reply
+  // falls through to fresh-send with no anchor capture.
+  if (!enabled()) {
+    return { kind: 'fresh', becomesAnchor: false }
+  }
+
+  // Pinged replies never merge — they're the final answer bubble,
+  // semantically distinct from the silent preamble.
+  if (!input.effectivelySilent) {
+    return { kind: 'fresh', becomesAnchor: false }
+  }
+
+  // Files / buttons bypass the anchor — edit-text can't merge
+  // media, and keyboards across edits are a foot-gun.
+  if (input.hasFiles || input.hasButtons) {
+    return { kind: 'fresh', becomesAnchor: false }
+  }
+
+  // Empty body — let the caller's existing validation handle it.
+  // We treat as fresh-but-don't-anchor so a downstream "drop empty"
+  // doesn't leave a stale anchor pointer.
+  if (input.newReplyText.trim().length === 0) {
+    return { kind: 'fresh', becomesAnchor: false }
+  }
+
+  // No anchor yet this turn → this reply BECOMES the anchor.
+  if (input.anchorMessageId == null) {
+    return { kind: 'fresh', becomesAnchor: true }
+  }
+
+  // Anchor exists → try to merge. The merge format is paragraph-
+  // break separation. If the merged result would exceed the
+  // Telegram text cap, give up on the anchor and start fresh —
+  // the new reply becomes a new anchor.
+  const merged = `${input.anchorText}\n\n${input.newReplyText}`
+  if (merged.length > TELEGRAM_MSG_CAP) {
+    return { kind: 'fresh', becomesAnchor: true }
+  }
+  return {
+    kind: 'edit-anchor',
+    messageId: input.anchorMessageId,
+    mergedText: merged,
+  }
+}

--- a/telegram-plugin/tests/silent-reply-anchor.test.ts
+++ b/telegram-plugin/tests/silent-reply-anchor.test.ts
@@ -34,7 +34,7 @@ describe('decideSilentReplyAnchor — silent replies edit a single growing ancho
       effectivelySilent: true,
       anchorMessageId: 12345,
       anchorText: 'on it — checking the calendar',
-      newReplyText: 'Step 1: hostname is pixsoul-ubuntu',
+      newReplyText: 'Step 1: hostname is example-host',
       hasFiles: false,
       hasButtons: false,
     })
@@ -42,7 +42,7 @@ describe('decideSilentReplyAnchor — silent replies edit a single growing ancho
       kind: 'edit-anchor',
       messageId: 12345,
       mergedText:
-        'on it — checking the calendar\n\nStep 1: hostname is pixsoul-ubuntu',
+        'on it — checking the calendar\n\nStep 1: hostname is example-host',
     })
   })
 

--- a/telegram-plugin/tests/silent-reply-anchor.test.ts
+++ b/telegram-plugin/tests/silent-reply-anchor.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit suite for #1677 silent-reply auto-edit predicate.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  TELEGRAM_MSG_CAP,
+  decideSilentReplyAnchor,
+} from '../silent-reply-anchor.js'
+
+describe('decideSilentReplyAnchor — silent replies edit a single growing anchor', () => {
+  beforeEach(() => {
+    delete process.env.SWITCHROOM_DISABLE_SILENT_REPLY_AUTOEDIT
+  })
+  afterEach(() => {
+    delete process.env.SWITCHROOM_DISABLE_SILENT_REPLY_AUTOEDIT
+  })
+
+  it('first silent reply this turn becomes the anchor (fresh send + capture)', () => {
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: true,
+      anchorMessageId: null,
+      anchorText: '',
+      newReplyText: 'on it — checking the calendar',
+      hasFiles: false,
+      hasButtons: false,
+    })
+    expect(d).toEqual({ kind: 'fresh', becomesAnchor: true })
+  })
+
+  it('subsequent silent reply edits the anchor with paragraph-break merge', () => {
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: true,
+      anchorMessageId: 12345,
+      anchorText: 'on it — checking the calendar',
+      newReplyText: 'Step 1: hostname is pixsoul-ubuntu',
+      hasFiles: false,
+      hasButtons: false,
+    })
+    expect(d).toEqual({
+      kind: 'edit-anchor',
+      messageId: 12345,
+      mergedText:
+        'on it — checking the calendar\n\nStep 1: hostname is pixsoul-ubuntu',
+    })
+  })
+
+  it('third and beyond silent replies keep accumulating onto the same anchor', () => {
+    // Simulate the multi-step pattern: ack → step1 → step2 → step3.
+    // After two prior accumulations the anchor reads as three paragraphs.
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: true,
+      anchorMessageId: 12345,
+      anchorText: 'on it\n\nStep 1: hostname\n\nStep 2: OS family',
+      newReplyText: 'Step 3: CPU',
+      hasFiles: false,
+      hasButtons: false,
+    })
+    expect(d.kind).toBe('edit-anchor')
+    if (d.kind === 'edit-anchor') {
+      expect(d.mergedText).toBe(
+        'on it\n\nStep 1: hostname\n\nStep 2: OS family\n\nStep 3: CPU',
+      )
+    }
+  })
+
+  it('pinged (effectivelySilent=false) reply NEVER merges — fresh send', () => {
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: false,
+      anchorMessageId: 12345,
+      anchorText: 'on it\n\nSteps done',
+      newReplyText: 'Final answer here',
+      hasFiles: false,
+      hasButtons: false,
+    })
+    expect(d).toEqual({ kind: 'fresh', becomesAnchor: false })
+  })
+
+  it('files attached → fresh send (anchor cannot absorb media)', () => {
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: true,
+      anchorMessageId: 12345,
+      anchorText: 'on it',
+      newReplyText: 'here is the chart',
+      hasFiles: true,
+      hasButtons: false,
+    })
+    expect(d).toEqual({ kind: 'fresh', becomesAnchor: false })
+  })
+
+  it('button keyboard → fresh send (keyboard semantics across edits is a foot-gun)', () => {
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: true,
+      anchorMessageId: 12345,
+      anchorText: 'on it',
+      newReplyText: 'choose one:',
+      hasFiles: false,
+      hasButtons: true,
+    })
+    expect(d).toEqual({ kind: 'fresh', becomesAnchor: false })
+  })
+
+  it('empty reply body → fresh send + DO NOT become anchor', () => {
+    // The caller has its own empty-text validation; we just avoid
+    // leaving a dangling anchor pointer if the empty reply
+    // accidentally goes through.
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: true,
+      anchorMessageId: null,
+      anchorText: '',
+      newReplyText: '   ',
+      hasFiles: false,
+      hasButtons: false,
+    })
+    expect(d).toEqual({ kind: 'fresh', becomesAnchor: false })
+  })
+
+  it('overflow: merged text > TELEGRAM_MSG_CAP → fresh send + start new anchor', () => {
+    const huge = 'x'.repeat(TELEGRAM_MSG_CAP - 10)
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: true,
+      anchorMessageId: 12345,
+      anchorText: huge,
+      newReplyText: 'short tail',
+      hasFiles: false,
+      hasButtons: false,
+    })
+    // Merged would be huge + "\n\n" + "short tail" → exceeds cap.
+    expect(d).toEqual({ kind: 'fresh', becomesAnchor: true })
+  })
+
+  it('kill switch — `SWITCHROOM_DISABLE_SILENT_REPLY_AUTOEDIT=1` short-circuits to fresh send for every reply', () => {
+    process.env.SWITCHROOM_DISABLE_SILENT_REPLY_AUTOEDIT = '1'
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: true,
+      anchorMessageId: 12345,
+      anchorText: 'on it',
+      newReplyText: 'Step 1',
+      hasFiles: false,
+      hasButtons: false,
+    })
+    expect(d).toEqual({ kind: 'fresh', becomesAnchor: false })
+  })
+
+  it('kill switch accepts string "true" too', () => {
+    process.env.SWITCHROOM_DISABLE_SILENT_REPLY_AUTOEDIT = 'true'
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: true,
+      anchorMessageId: null,
+      anchorText: '',
+      newReplyText: 'on it',
+      hasFiles: false,
+      hasButtons: false,
+    })
+    expect(d).toEqual({ kind: 'fresh', becomesAnchor: false })
+  })
+
+  it('borderline merge — exactly at the cap is accepted (boundary inclusive)', () => {
+    // Aim merged.length === TELEGRAM_MSG_CAP exactly.
+    // separator is "\n\n" (2 chars). anchor + separator + new === cap.
+    const newReplyText = 'tail'
+    const anchorLen = TELEGRAM_MSG_CAP - newReplyText.length - 2
+    const anchor = 'a'.repeat(anchorLen)
+    const d = decideSilentReplyAnchor({
+      effectivelySilent: true,
+      anchorMessageId: 12345,
+      anchorText: anchor,
+      newReplyText,
+      hasFiles: false,
+      hasButtons: false,
+    })
+    expect(d.kind).toBe('edit-anchor')
+    if (d.kind === 'edit-anchor') {
+      expect(d.mergedText.length).toBe(TELEGRAM_MSG_CAP)
+    }
+  })
+})


### PR DESCRIPTION
Closes the visual half of the spam complaint the over-ping cap (#1674) only half-fixed. Pre-fix: multi-step turn = 4 stacked bubbles. Post-fix: 2 bubbles (silent growing preamble + pinged final).

Pure-predicate design (`telegram-plugin/silent-reply-anchor.ts`, 11 unit tests). Default-on, kill switch `SWITCHROOM_DISABLE_SILENT_REPLY_AUTOEDIT=1`.

See commit body for full rationale + test plan + risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)