### PR TITLE
fix(telegram): over-ping-suppressed finals bypass silent-anchor merge

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,1 @@
-~/code/switchroom/node_modules
+/home/kenthompson/code/switchroom-sec-1417/node_modules

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4252,6 +4252,12 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // and subsequent pings would be silenced. Acceptable trade-off (a
   // failed first ping is an edge case; the alternative — claim after
   // send — races concurrent reply calls).
+  // Tracks whether the over-ping safety net coerced this reply
+  // from ping→silent. Threaded into the silent-anchor predicate
+  // below: a demoted final-answer reply must NOT merge into the
+  // silent preamble bubble; it lands as a fresh silent bubble so
+  // the user can still find it (see #1674 / silent-anchor follow-up).
+  let wasOverPingSuppressed = false
   {
     const turn = currentTurn
     if (turn != null) {
@@ -4278,6 +4284,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
           sinceFirstPingMs: decision.sinceFirstPingMs ?? 0,
         })
         disableNotification = true
+        wasOverPingSuppressed = true
       } else if (decision.claimSlot) {
         turn.firstPingAt = now
       }
@@ -4445,6 +4452,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
         newReplyText: effectiveText,
         hasFiles: files.length > 0,
         hasButtons: replyMarkup != null,
+        wasOverPingSuppressed,
       })
       if (decision.kind === 'edit-anchor') {
         const editParams: {

--- a/telegram-plugin/silent-reply-anchor.ts
+++ b/telegram-plugin/silent-reply-anchor.ts
@@ -65,6 +65,15 @@ export interface SilentReplyAnchorDecisionInput {
    *  are too easy to get wrong, and the markup is rare enough
    *  that fresh-send is the safer default. */
   hasButtons: boolean
+  /** True iff this reply was an intended-ping (model requested
+   *  `disable_notification:false`) that the over-ping safety net
+   *  (#1674) coerced to silent. Anchor merge MUST bypass when true:
+   *  semantically the model intended this as a distinct/final
+   *  delivery, and merging it into the existing silent preamble
+   *  would bury the content (the user already stopped looking at
+   *  the anchor bubble because earlier ticks edited it silently).
+   *  Optional — defaults to false for non-gateway callers. */
+  wasOverPingSuppressed?: boolean
 }
 
 /**
@@ -105,6 +114,19 @@ export function decideSilentReplyAnchor(
   // Pinged replies never merge — they're the final answer bubble,
   // semantically distinct from the silent preamble.
   if (!input.effectivelySilent) {
+    return { kind: 'fresh', becomesAnchor: false }
+  }
+
+  // Over-ping-suppressed replies bypass the anchor. The model
+  // intended a ping (almost always: a final/distinct reply); the
+  // safety net demoted to silent so the user isn't double-beeped.
+  // Merging the demoted reply into the existing silent anchor
+  // hides it — the user has already disengaged from the bubble
+  // that's been edited silently for the rest of the turn. Land
+  // as a fresh silent bubble instead, preserving discoverability.
+  // Don't capture as next anchor either: this reply is the
+  // *answer*, not more preamble.
+  if (input.wasOverPingSuppressed === true) {
     return { kind: 'fresh', becomesAnchor: false }
   }
 

--- a/telegram-plugin/tests/silent-reply-anchor.test.ts
+++ b/telegram-plugin/tests/silent-reply-anchor.test.ts
@@ -175,4 +175,73 @@ describe('decideSilentReplyAnchor — silent replies edit a single growing ancho
       expect(d.mergedText.length).toBe(TELEGRAM_MSG_CAP)
     }
   })
+
+  // Follow-up to #1679 — when the over-ping safety net coerces a
+  // model-intended ping to silent, the demoted reply must NOT be
+  // merged into the existing silent anchor. The anchor has been
+  // edited silently for the whole turn; the user has long since
+  // disengaged. Merging the (semantically final) demoted reply
+  // there would hide the answer entirely.
+  describe('over-ping-suppressed messages bypass anchor merge', () => {
+    it('demoted reply with an active anchor lands as a fresh silent (not edit, not next-anchor)', () => {
+      const d = decideSilentReplyAnchor({
+        effectivelySilent: true,
+        anchorMessageId: 12345,
+        anchorText: 'on it — gathering facts',
+        newReplyText: 'Delivered all three steps with a wrap-up summary.',
+        hasFiles: false,
+        hasButtons: false,
+        wasOverPingSuppressed: true,
+      })
+      expect(d).toEqual({ kind: 'fresh', becomesAnchor: false })
+    })
+
+    it('demoted reply with no anchor yet also fresh-sends without capturing the anchor', () => {
+      // The model fired a stray ping before any silent ack; the
+      // safety-net demoted that ping. A demoted message is never
+      // anchor material — it's an answer, not preamble.
+      const d = decideSilentReplyAnchor({
+        effectivelySilent: true,
+        anchorMessageId: null,
+        anchorText: '',
+        newReplyText: 'Delivered all three steps with a wrap-up summary.',
+        hasFiles: false,
+        hasButtons: false,
+        wasOverPingSuppressed: true,
+      })
+      expect(d).toEqual({ kind: 'fresh', becomesAnchor: false })
+    })
+
+    it('genuinely silent reply (not over-ping-suppressed) still merges normally', () => {
+      // Regression guard: the new bypass must not over-fire on
+      // legitimate beat-3 silent ticks.
+      const d = decideSilentReplyAnchor({
+        effectivelySilent: true,
+        anchorMessageId: 12345,
+        anchorText: 'on it — gathering facts',
+        newReplyText: 'Step 1: hostname is example-host',
+        hasFiles: false,
+        hasButtons: false,
+        wasOverPingSuppressed: false,
+      })
+      expect(d).toEqual({
+        kind: 'edit-anchor',
+        messageId: 12345,
+        mergedText:
+          'on it — gathering facts\n\nStep 1: hostname is example-host',
+      })
+    })
+
+    it('omitting wasOverPingSuppressed defaults to false (backward compat)', () => {
+      const d = decideSilentReplyAnchor({
+        effectivelySilent: true,
+        anchorMessageId: 12345,
+        anchorText: 'on it',
+        newReplyText: 'next thought',
+        hasFiles: false,
+        hasButtons: false,
+      })
+      expect(d.kind).toBe('edit-anchor')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes the load-bearing follow-up from #1679's documented residuals. When a turn produces multiple silent updates (anchored into one growing bubble via #1677) AND ends with a model-intended-pinged final reply that the over-ping safety net (#1674) demotes to silent, the demoted final reply would *merge into the silent anchor*. The user has long since disengaged from the silently-edited bubble (no ping, no scroll change), so the actual answer is buried.

## Why this is the right fix

The over-ping safety net's job is to suppress *device notifications*, not to relocate content. The silent-anchor predicate's job is to combat *visual spam* from chatty silent updates. They compose correctly for most cases, but the case where they fight is: an over-ping-suppressed reply (semantically the final answer) being treated as 'just another silent tick' by the anchor predicate.

The fix is a single bypass clause: `wasOverPingSuppressed: true` ⇒ fresh-send-silent, no anchor capture. Discoverability preserved (user sees a new bubble); ping contract preserved (no second beep). Model intent ('distinct delivery') honored visually.

## Test plan

- [x] 4 new unit tests in `silent-reply-anchor.test.ts` (active anchor + demoted, no anchor + demoted, regular silent still merges, omitted input defaults to false).
- [x] Existing 11 silent-anchor + 6 over-ping + 14 pending-progress unit tests all green.
- [x] `npm run lint` clean (tsc, plugin-references, bot-api-wrapping, bun-test-imports, no-pii-secrets, vault-hermeticity, no-broadcast-delivery).

## Risk

Low. Predicate-level change with explicit kill-switch (`SWITCHROOM_DISABLE_SILENT_REPLY_AUTOEDIT=1`) inherited from #1677. The bypass only fires when both the safety net AND the anchor mechanism are active — a narrow intersection. Default-false on the new input means non-gateway callers and unit tests pin behavior unchanged.

## Related

- #1674 — over-ping safety net (cap 1 ping/turn)
- #1677 — silent-reply auto-edit (anchor mechanism)
- #1679 — side-effect parity in edit branch (documented this gap as follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)