### PR TITLE
fix(telegram): wedge fallback late-fire skip + disconnect dangling-turn sweep

### DIFF
--- a/telegram-plugin/gateway/disconnect-flush.ts
+++ b/telegram-plugin/gateway/disconnect-flush.ts
@@ -48,6 +48,18 @@ export interface DisconnectFlushDeps<Ctrl extends { setDone: () => void }, Strea
   /** Progress driver — disposed with `preservePending: true` for sub-agent JTBDs (#393). */
   disposeProgressDriver: () => void
 
+  /** Optional: called when the registered-agent disconnect found dangling
+   *  `activeTurnStartedAt` entries the controller loop did not clear (i.e.
+   *  `setDone()` already ran on the canonical reply path, leaving
+   *  `activeStatusReactions` empty but `activeTurnStartedAt` populated).
+   *  The gateway uses this to null its module-scope `currentTurn` — the
+   *  bridge that owned that turn just died. Without this, the next
+   *  inbound is "held mid-turn" against a ghost (the 2026-05-23 audit
+   *  found ~14 such events / 3 days / 9 agents).
+   *
+   *  No-op if no dangling keys are found. */
+  onDanglingTurnsSwept?: (purgedKeys: string[]) => void
+
   /** Logger — receives the one-line decision trace. */
   log: (msg: string) => void
 }
@@ -70,6 +82,7 @@ export function flushOnAgentDisconnect<
     activeDraftParseModes,
     clearActiveReactions,
     disposeProgressDriver,
+    onDanglingTurnsSwept,
     log,
   } = deps
 
@@ -90,6 +103,30 @@ export function flushOnAgentDisconnect<
     activeTurnStartedAt.delete(key)
   }
   clearActiveReactions()
+
+  // Defense-in-depth — sweep any `activeTurnStartedAt` keys the controller
+  // loop above did not touch. The bridge has crashed; any turn it owned is
+  // dead by definition, regardless of whether `activeStatusReactions`
+  // still tracks it. The race that motivates this: `setDone()` already
+  // fired on the canonical reply path (clearing the reaction controller)
+  // BUT the disconnect arrived BEFORE `purgeReactionTracking` ran the
+  // `activeTurnStartedAt.delete` line for that key. Without this sweep,
+  // the key orphans, and the next inbound is "held mid-turn" against
+  // a ghost — surfacing as the held-mid-turn / `currentTurn_nulled=true`
+  // wedge symptom documented in feedback_5min_restart_wedge memo and
+  // measured at ~14 events / 3 days / 9 agents (2026-05-23 audit).
+  const danglingKeys = [...activeTurnStartedAt.keys()]
+  if (danglingKeys.length > 0) {
+    for (const k of danglingKeys) {
+      activeTurnStartedAt.delete(k)
+      activeReactionMsgIds.delete(k)
+    }
+    log(
+      `telegram gateway: disconnect-flush swept ${danglingKeys.length} dangling turn key(s) ` +
+      `post-bridge-death (controller loop missed — setDone raced disconnect)`,
+    )
+    onDanglingTurnsSwept?.(danglingKeys)
+  }
 
   // Stop coalesce timers that could emit into a finalized draft stream, but
   // preserve chats with pendingCompletion=true — those have background

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3084,6 +3084,30 @@ silencePoke.startTimer({
     emitRuntimeMetric(event)
   },
   onFrameworkFallback: async (ctx) => {
+    // Late-fire short-circuit (2026-05-23 audit finding). The fallback
+    // can race a clean turn-end: the model's actual reply lands inside
+    // the silence window's final ~50ms, the canonical turn-end path
+    // clears `activeTurnStartedAt` and nulls `currentTurn`, and then
+    // this handler fires anyway. Without this check we emit a noisy
+    // "still working…" ping to the user (right after they got their
+    // real reply) AND a misleading "ended wedged turn ... currentTurn_
+    // nulled=false drained_buffered=0/0" log line. The 7-day audit
+    // showed this race accounts for ~90% of all framework_fallback log
+    // events (124 of 138 `currentTurn_nulled=false` cases). Distinct
+    // log line so observability still tracks the fact that the silence
+    // crossed threshold; the wedge counter is no longer polluted.
+    if (activeTurnStartedAt.get(ctx.key) == null && currentTurn == null) {
+      process.stderr.write(
+        `telegram gateway: silence-poke framework-fallback late-fire skipped — ` +
+        `turn ended cleanly during silence window ` +
+        `chat=${ctx.chatId} thread=${ctx.threadId ?? '-'} silence_ms=${ctx.silenceMs}\n`,
+      )
+      // Tell silence-poke this chat-thread is finished so the next
+      // arming doesn't carry stale state.
+      silencePoke.endTurn(ctx.key)
+      return
+    }
+
     // Deterministic in-flight update status (klanker incident). If this
     // gateway dispatched an update_apply that's still running, the
     // recurring framework fallback carries hostd's REAL phase + elapsed
@@ -3578,6 +3602,18 @@ const ipcServer: IpcServer = createIpcServer({
         // through both possibly-undefined hops. Caught by
         // scripts/check-plugin-references.mjs (TS2722).
         progressDriver?.dispose?.({ preservePending: true })
+      },
+      // When dangling activeTurnStartedAt keys were swept (setDone raced
+      // disconnect), the module-scope `currentTurn` may also point at the
+      // dead bridge's turn. Null it so the next inbound starts a fresh
+      // turn instead of inheriting a ghost.
+      onDanglingTurnsSwept: () => {
+        if (currentTurn != null) {
+          process.stderr.write(
+            `telegram gateway: disconnect-flush nulled currentTurn (bridge died with turn in flight)\n`,
+          )
+          currentTurn = null
+        }
       },
       log: (msg) => process.stderr.write(`${msg}\n`),
     })

--- a/telegram-plugin/tests/gateway-disconnect-flush.test.ts
+++ b/telegram-plugin/tests/gateway-disconnect-flush.test.ts
@@ -142,3 +142,117 @@ describe('flushOnAgentDisconnect — registered agent disconnects (existing beha
     expect(deps.activeDraftParseModes.size).toBe(0)
   })
 })
+
+describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)', () => {
+  // The race that motivates this: the canonical reply path fires
+  // `setDone()` on the StatusReactionController BEFORE purgeReactionTracking
+  // runs `activeTurnStartedAt.delete(key)`. If the bridge crashes between
+  // those two steps, the controller loop sees an EMPTY activeStatusReactions
+  // (already cleared by setDone) but activeTurnStartedAt still has the key.
+  // Without the sweep, that key orphans and the next inbound is "held mid-
+  // turn" against a ghost.
+
+  it('sweeps activeTurnStartedAt keys the controller loop missed', () => {
+    // Construct the exact race: activeStatusReactions is EMPTY (setDone
+    // already cleared it on the reply path) but activeTurnStartedAt still
+    // has an entry.
+    const onDanglingTurnsSwept = vi.fn()
+    const clearActiveReactions = vi.fn()
+    const disposeProgressDriver = vi.fn()
+    const log = vi.fn()
+    const deps = {
+      agentName: 'clerk',
+      activeStatusReactions: new Map<string, FakeCtrl>(),
+      activeReactionMsgIds: new Map<string, { chatId: string; messageId: number }>([
+        ['ghost:thr:msg', { chatId: 'ghost', messageId: 42 }],
+      ]),
+      activeTurnStartedAt: new Map<string, number>([['ghost:thr:msg', 100]]),
+      activeDraftStreams: new Map<string, FakeStream>(),
+      activeDraftParseModes: new Map<string, 'HTML' | 'MarkdownV2' | undefined>(),
+      clearActiveReactions,
+      disposeProgressDriver,
+      onDanglingTurnsSwept,
+      log,
+    }
+
+    flushOnAgentDisconnect(deps)
+
+    // The sweep fired and cleared the dangling entry.
+    expect(deps.activeTurnStartedAt.size).toBe(0)
+    expect(deps.activeReactionMsgIds.size).toBe(0)
+    expect(onDanglingTurnsSwept).toHaveBeenCalledTimes(1)
+    expect(onDanglingTurnsSwept.mock.calls[0][0]).toEqual(['ghost:thr:msg'])
+    // The log line names what happened so the operator can audit.
+    expect(
+      log.mock.calls.some((c: unknown[]) =>
+        typeof c[0] === 'string' && /swept .* dangling turn/.test(c[0]),
+      ),
+    ).toBe(true)
+  })
+
+  it('does not fire the sweep when the controller loop already cleaned up everything', () => {
+    // Normal-path disconnect: activeStatusReactions had entries, the
+    // controller loop ran setDone + delete on each, activeTurnStartedAt
+    // is already empty by the end of the loop. No dangling to sweep.
+    const { spies, deps } = makeDeps('clerk')
+    const onDanglingTurnsSwept = vi.fn()
+    const depsWithCallback = { ...deps, onDanglingTurnsSwept }
+
+    flushOnAgentDisconnect(depsWithCallback)
+
+    // Controller loop already cleaned both entries.
+    expect(deps.activeTurnStartedAt.size).toBe(0)
+    // Callback NOT fired — nothing left to sweep after the loop.
+    expect(onDanglingTurnsSwept).not.toHaveBeenCalled()
+    // Regression: the existing setDone path still works.
+    expect(spies.setDoneA).toHaveBeenCalledTimes(1)
+    expect(spies.setDoneB).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT sweep for anonymous disconnects (no agent registered)', () => {
+    // Critical regression guard: the sweep MUST be gated by the
+    // agentName-null early-return. Anonymous one-shot IPC clients
+    // (recall.py, etc.) disconnect constantly and must never touch
+    // turn state.
+    const onDanglingTurnsSwept = vi.fn()
+    const deps = {
+      agentName: null,
+      activeStatusReactions: new Map<string, FakeCtrl>(),
+      activeReactionMsgIds: new Map<string, { chatId: string; messageId: number }>(),
+      activeTurnStartedAt: new Map<string, number>([['real-turn:thr:msg', 100]]),
+      activeDraftStreams: new Map<string, FakeStream>(),
+      activeDraftParseModes: new Map<string, 'HTML' | 'MarkdownV2' | undefined>(),
+      clearActiveReactions: vi.fn(),
+      disposeProgressDriver: vi.fn(),
+      onDanglingTurnsSwept,
+      log: vi.fn(),
+    }
+
+    flushOnAgentDisconnect(deps)
+
+    // Anonymous disconnect: turn state preserved, sweep callback not fired.
+    expect(deps.activeTurnStartedAt.size).toBe(1)
+    expect(onDanglingTurnsSwept).not.toHaveBeenCalled()
+  })
+
+  it('omitting onDanglingTurnsSwept is safe (optional callback)', () => {
+    // Backward-compat guard — existing callers that don't pass the new
+    // callback still work without runtime error.
+    const deps = {
+      agentName: 'clerk',
+      activeStatusReactions: new Map<string, FakeCtrl>(),
+      activeReactionMsgIds: new Map<string, { chatId: string; messageId: number }>(),
+      activeTurnStartedAt: new Map<string, number>([['ghost:thr:msg', 100]]),
+      activeDraftStreams: new Map<string, FakeStream>(),
+      activeDraftParseModes: new Map<string, 'HTML' | 'MarkdownV2' | undefined>(),
+      clearActiveReactions: vi.fn(),
+      disposeProgressDriver: vi.fn(),
+      // onDanglingTurnsSwept intentionally omitted.
+      log: vi.fn(),
+    }
+
+    expect(() => flushOnAgentDisconnect(deps)).not.toThrow()
+    // The sweep still happens, just without the callback observation.
+    expect(deps.activeTurnStartedAt.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Two surgical fixes from a 7-day forensic audit of fleet framework-fallback events. The audit split 204 events / 3 days into:

- **~180 false-positive log artifacts** (late-fire race between model reply and 300s fallback)
- **~14 real user-impacting wedges** (bridge dies after setDone but before activeTurnStartedAt cleanup)

## Fix 1 — `gateway.ts` onFrameworkFallback early-return

Detects the clean-turn-end race at the top of the handler. When `activeTurnStartedAt.get(key) == null && currentTurn == null`, the turn ended in the silence window — skip the spurious user ping AND the misleading cleanup. Distinct log line preserved for observability.

## Fix 2 — `disconnect-flush.ts` dangling-turn sweep

After the `activeStatusReactions` controller loop, unconditionally sweep any `activeTurnStartedAt` / `activeReactionMsgIds` keys it missed. New optional `onDanglingTurnsSwept` callback lets the gateway null its `currentTurn` for the same reason.

## Test plan

- [x] 9 unit tests in `telegram-plugin/tests/gateway-disconnect-flush.test.ts` (4 new: exercises-the-race / no-spurious-sweep / anonymous-disconnect-gated / optional-callback-backward-compat).
- [x] Full lint suite green (tsc, plugin-references, bot-api-wrapping, bun-test-imports, no-pii-secrets, vault-hermeticity, no-broadcast-delivery).
- [ ] Post-deploy: re-measure fleet `framework-fallback ended wedged turn` rate. Expect ~90% reduction (Fix 1 removes false positives). Real wedge rate (`currentTurn_nulled=true` OR `rebuffered=N>0`) should drop toward zero (Fix 2 closes the leak).

## Risk

Low. Fix 1 is an early-return only when state is already clean — no semantic change to the genuine-wedge path. Fix 2 expands cleanup on bridge death, which is by-definition correct (the bridge cannot still be progressing a turn). The intentional `preservePending: true` progress-driver disposition is unchanged.

## Forensic context

Memory `feedback_5min_restart_wedge_violates_vision.md` will need an update after this lands — the `currentTurn_nulled=false` signature it treats as the smoking gun is actually the noise, not the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)