### PR TITLE
fix(telegram): scope outbound dedup by turnKey to stop swallowing cross-turn replies

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4263,7 +4263,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // late-replies with different content sail through.
   {
     const replyThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
-    const dup = outboundDedup.check(chat_id, replyThreadId, text, Date.now())
+    const dup = outboundDedup.check(chat_id, replyThreadId, text, Date.now(), currentTurn?.registryKey ?? null)
     if (dup != null) {
       process.stderr.write(
         `telegram gateway: reply: deduped (#546) chatId=${chat_id} ` +
@@ -4597,6 +4597,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
             threadId,
             decision.mergedText,
             Date.now(),
+            turn?.registryKey ?? null,
           )
 
           silentAnchorEditDone = true
@@ -4921,7 +4922,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // calls with this same content within DEFAULT_DEDUP_TTL_MS will
   // be suppressed.
   if (sentIds.length > 0) {
-    outboundDedup.record(chat_id, threadId, text, Date.now())
+    outboundDedup.record(chat_id, threadId, text, Date.now(), currentTurn?.registryKey ?? null)
   }
   return { content: [{ type: 'text', text: result }] }
 }
@@ -4942,7 +4943,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     const sChatId = args.chat_id as string
     const sThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
     const sText = args.text as string
-    const dup = outboundDedup.check(sChatId, sThreadId, sText, Date.now())
+    const dup = outboundDedup.check(sChatId, sThreadId, sText, Date.now(), currentTurn?.registryKey ?? null)
     if (dup != null) {
       process.stderr.write(
         `telegram gateway: stream_reply: deduped (#546) chatId=${sChatId} ` +
@@ -5106,7 +5107,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   if (args.done === true && result.messageId != null) {
     const sChatId = args.chat_id as string
     const sThreadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
-    outboundDedup.record(sChatId, sThreadId, args.text as string, Date.now())
+    outboundDedup.record(sChatId, sThreadId, args.text as string, Date.now(), currentTurn?.registryKey ?? null)
     // #1445 cross-turn pending-async ambient. The terminal stream_reply
     // (done=true) is the user-visible anchor for any cross-turn wait
     // that follows. Capture it so if this turn ends with a pending
@@ -6418,10 +6419,10 @@ function handleSessionEvent(ev: SessionEvent): void {
             // threadId come from the captured `turn` snapshot, stable for
             // the lifetime of the stream.
             checkDedup: (text: string) => {
-              return outboundDedup.check(turn.sessionChatId, turn.sessionThreadId, text, Date.now()) != null
+              return outboundDedup.check(turn.sessionChatId, turn.sessionThreadId, text, Date.now(), turn.registryKey ?? null) != null
             },
             recordDedup: (text: string) => {
-              outboundDedup.record(turn.sessionChatId, turn.sessionThreadId, text, Date.now())
+              outboundDedup.record(turn.sessionChatId, turn.sessionThreadId, text, Date.now(), turn.registryKey ?? null)
             },
             // #648 — write answer-stream materializations into the SQLite
             // history buffer so get_recent_messages can surface them. Guard
@@ -6582,6 +6583,7 @@ function handleSessionEvent(ev: SessionEvent): void {
               turn.sessionThreadId,
               streamedFinalText,
               Date.now(),
+              turn.registryKey ?? null,
             )
           } catch { /* best-effort */ }
           if (HISTORY_ENABLED) {
@@ -6947,6 +6949,7 @@ function handleSessionEvent(ev: SessionEvent): void {
               backstopThreadId,
               capturedText,
               Date.now(),
+              currentTurn?.registryKey ?? null,
             )
             if (backstopCtrl) backstopCtrl.setDone()
             // Unpin the card. completeTurn cleans up pinMgr's per-turn

--- a/telegram-plugin/recent-outbound-dedup.ts
+++ b/telegram-plugin/recent-outbound-dedup.ts
@@ -57,6 +57,16 @@ interface DedupEntry {
   /** First 80 chars of the original (un-normalized) text — for
    *  operator-facing log lines that show what got deduped. */
   preview: string
+  /** The `currentTurn.registryKey` at record time, or `null` if the
+   *  recording site had no turn context. Threaded through so check()
+   *  can distinguish within-turn retries (#546 bug class — keep
+   *  protecting) from cross-turn coincidences (2026-05-23 audit found
+   *  identical mid-turn + final replies across two turns ~30s apart
+   *  silently swallowing the second turn's answer; the user gets
+   *  no response to their second question). Null on either side
+   *  matches as before, preserving the boot-time / edge-case behaviour
+   *  the original tests pin. */
+  turnKey: string | null
 }
 
 /**
@@ -75,8 +85,21 @@ export class OutboundDedupCache {
   /** Record an outbound message. Caller should invoke this after a
    *  successful send, regardless of which path sent it (turn-flush,
    *  executeReply, executeStreamReply, etc.). Short content is not
-   *  recorded — see DEDUP_MIN_CONTENT_LEN. */
-  record(chatId: string, threadId: number | undefined, text: string, now: number): void {
+   *  recorded — see DEDUP_MIN_CONTENT_LEN.
+   *
+   *  `turnKey` lets check() tell within-turn retries (the #546 race
+   *  this module exists to catch) apart from cross-turn coincidences
+   *  (a user asking similar questions in different turns). Pass
+   *  `null` if the recording site has no turn context — that matches
+   *  legacy behaviour and is what the early-boot / fallback callers
+   *  pass. */
+  record(
+    chatId: string,
+    threadId: number | undefined,
+    text: string,
+    now: number,
+    turnKey: string | null = null,
+  ): void {
     if (text.length < DEDUP_MIN_CONTENT_LEN) return
     const key = makeKey(chatId, threadId)
     const list = this.entries.get(key) ?? []
@@ -85,6 +108,7 @@ export class OutboundDedupCache {
       hash: normalizeForDedup(text),
       ts: now,
       preview: text.slice(0, 80),
+      turnKey,
     })
     this.entries.set(key, list)
   }
@@ -92,12 +116,24 @@ export class OutboundDedupCache {
   /** Check whether the given text was already sent recently to the
    *  same chat. Returns the matched entry's preview + age on hit, or
    *  null on miss. Caller decides what to do with the answer
-   *  (skip-send, log, etc.). */
+   *  (skip-send, log, etc.).
+   *
+   *  Cross-turn carve-out (2026-05-23 fix): when both sides of a hash
+   *  match carry non-null `turnKey` AND those keys differ, treat as
+   *  miss. The duplicate-reply race this module was built for (#546)
+   *  is strictly within-turn (the same turn's buffered text replays
+   *  via a stream_reply retry), so within-turn retries continue to
+   *  hit. A user typing two similar prompts back-to-back used to lose
+   *  the second turn's reply because the hashes collided across
+   *  turns; that no longer happens. Null on EITHER side (legacy /
+   *  no-turn-context callers) still matches — preserves backward
+   *  compatibility with the original test suite + early-boot paths. */
   check(
     chatId: string,
     threadId: number | undefined,
     text: string,
     now: number,
+    turnKey: string | null = null,
   ): { matched: true; preview: string; ageMs: number } | null {
     if (text.length < DEDUP_MIN_CONTENT_LEN) return null
     const key = makeKey(chatId, threadId)
@@ -106,9 +142,19 @@ export class OutboundDedupCache {
     this.evict(list, now)
     const candidateHash = normalizeForDedup(text)
     for (const entry of list) {
-      if (entry.hash === candidateHash) {
-        return { matched: true, preview: entry.preview, ageMs: now - entry.ts }
+      if (entry.hash !== candidateHash) continue
+      // Cross-turn carve-out: distinct, non-null turnKeys on both
+      // sides ⇒ different turns ⇒ not a #546 retry. Skip past this
+      // entry and keep scanning (a same-turn match later in the list
+      // should still hit).
+      if (
+        turnKey != null
+        && entry.turnKey != null
+        && entry.turnKey !== turnKey
+      ) {
+        continue
       }
+      return { matched: true, preview: entry.preview, ageMs: now - entry.ts }
     }
     return null
   }

--- a/telegram-plugin/tests/recent-outbound-dedup.test.ts
+++ b/telegram-plugin/tests/recent-outbound-dedup.test.ts
@@ -190,3 +190,75 @@ describe('OutboundDedupCache — multiple entries per chat', () => {
     expect(cache.check('chat', undefined, LONG_HTML, 6000)).not.toBeNull()
   })
 })
+
+// ─── turnKey carve-out (2026-05-23 cross-turn-swallow fix) ───────────────────
+// Without turnKey awareness, the 60s TTL eats the SECOND turn's reply when a
+// user asks similar questions back-to-back (forensic audit on midturn-silent
+// UAT). The carve-out: both sides non-null + distinct ⇒ treat as miss.
+// Within-turn (#546 retry race) protection unchanged: same turnKey on both
+// sides ⇒ legacy hit. Null on either side ⇒ legacy hit.
+
+const LONG_TEXT = 'long enough text to count as content for the dedup floor'
+
+describe('OutboundDedupCache — turnKey carve-out', () => {
+  it('cross-turn identical content with distinct non-null turnKeys MISSES', () => {
+    // The headline bug: dedup was eating user replies across turns.
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, LONG_TEXT, 1000, 'turn-A')
+    expect(
+      cache.check('chat', undefined, LONG_TEXT, 5000, 'turn-B'),
+    ).toBeNull()
+  })
+
+  it('within-turn duplicates (same turnKey) STILL HIT — preserves #546 protection', () => {
+    // Same-turn retry race the module was built for.
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, LONG_TEXT, 1000, 'turn-A')
+    expect(
+      cache.check('chat', undefined, LONG_TEXT, 10_000, 'turn-A'),
+    ).not.toBeNull()
+  })
+
+  it('record-null + check-non-null → legacy hit', () => {
+    // Boot-time / silent-marker callers pass null on record; later
+    // executeReply checks with a turnKey. Legacy match must persist
+    // for the #546 protection to cover these cross-context cases.
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, LONG_TEXT, 1000, null)
+    expect(
+      cache.check('chat', undefined, LONG_TEXT, 5000, 'turn-A'),
+    ).not.toBeNull()
+  })
+
+  it('record-non-null + check-null → legacy hit', () => {
+    // Symmetric direction: turn-flush records with turnKey, a later
+    // null-context probe (rare but possible) still matches.
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, LONG_TEXT, 1000, 'turn-A')
+    expect(
+      cache.check('chat', undefined, LONG_TEXT, 5000, null),
+    ).not.toBeNull()
+  })
+
+  it('cross-turn entry does NOT shadow a same-turn match later in the list', () => {
+    // Edge case the predicate must handle: when the scan hits a stale
+    // cross-turn entry whose hash matches, it must keep scanning past
+    // it to find a real same-turn match. (The carve-out is implemented
+    // as `continue`, not `return null`.)
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, LONG_TEXT, 1000, 'turn-A') // older, cross-turn
+    cache.record('chat', undefined, LONG_TEXT, 3000, 'turn-B') // newer, same turn as query
+    expect(
+      cache.check('chat', undefined, LONG_TEXT, 5000, 'turn-B'),
+    ).not.toBeNull()
+  })
+
+  it('legacy 4-arg API still compiles + matches (default turnKey=null)', () => {
+    // Backward-compat smoke test — older callers that haven't been
+    // updated to pass turnKey continue to behave as the original test
+    // suite pins.
+    const cache = new OutboundDedupCache()
+    cache.record('chat', undefined, LONG_TEXT, 1000)
+    expect(cache.check('chat', undefined, LONG_TEXT, 5000)).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Forensic audit of midturn-silent UAT failures found that `recent-outbound-dedup` was silently dropping cross-turn identical replies. A user asking similar questions within 60s would lose the second turn's answer.

## The bug

`recent-outbound-dedup.ts` has a 60s TTL keyed only by `(chatId, threadId)`. The module exists for the #546 within-turn retry race (9-11s apart). But without turn awareness, cross-turn identical content false-positives:

Run 3 of midturn-silent-dm UAT (2026-05-23):
```
12:31:48.730  reply: deduped (#546) ageMs=30708 "Host pixsoul-ubuntu IS running …"
```
Final answer dropped. User got no response.

## The fix

5th optional argument `turnKey` on `record()` + `check()`. When BOTH sides have non-null turnKeys AND they differ → treat as miss. Either side null → legacy match preserved.

Threaded through all 9 callsites with `currentTurn?.registryKey ?? null`.

## Why this preserves #546 protection

The within-turn retry race the module was built for fires at 9-11s within the same `currentTurn.registryKey`. Within-turn dedup still hits (same key). Only cross-turn collisions (distinct non-null keys) now miss.

## Test plan

- [x] 5 new tests in `recent-outbound-dedup.test.ts` (23 total): cross-turn miss, within-turn hit, either-null legacy match, cross-turn entry doesn't shadow within-turn match, 3-arg legacy API.
- [x] `bun test` clean (23/23).
- [x] Full `npm run lint` green.

## Risk

Medium. Dedup is a load-bearing safety net. The carve-out only fires when both sides have non-null turnKeys AND they differ — narrow condition that within-turn retries cannot satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)