### PR TITLE
fix(telegram): subagent-watcher deregisters on ENOENT/EACCES

### DIFF
--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -459,7 +459,10 @@ function backfillJsonlAgentId(
   log?.(`subagent-watcher: backfill linked ${agentId} → ${candidate.id}`)
 }
 
-function readSubTail(
+// Exported for unit-testing the ENOENT/EACCES deregister path
+// (telegram-plugin/tests/subagent-watcher-enoent-deregister.test.ts).
+// Not intended for consumption by other modules.
+export function readSubTail(
   entry: WorkerEntry,
   tail: SubTail,
   now: number,
@@ -472,6 +475,14 @@ function readSubTail(
    *  previously-stalled entry. Closes the resume edge the schema doc
    *  has always promised. */
   onUnstall?: (agentId: string, description: string) => void,
+  /** Fires when the JSONL file is no longer accessible (ENOENT — file
+   *  reaped by Claude Code when the parent session ends; EACCES —
+   *  permission change mid-poll). The caller deregisters the entry so
+   *  the 1s poll loop stops re-statting a dead path. Without this
+   *  callback, every poll re-emits the error log line — on 2026-05-23
+   *  the clerk agent logged 540k ENOENT lines in 3 days (30/sec
+   *  sustained) AND leaked one fs.watch FD per stranded entry. */
+  onFileVanished?: (agentId: string, code: 'ENOENT' | 'EACCES') => void,
 ): void {
   try {
     const stat = fs.statSync(entry.filePath)
@@ -639,6 +650,17 @@ function readSubTail(
     }
     tail.hasEmittedStart = startState.hasEmittedStart
   } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'EACCES') {
+      // JSONL is gone (Claude Code reaped the parent session's
+      // subagents/ dir) or permission flipped under us. Deregister the
+      // entry so the periodic poll stops re-emitting this same line
+      // forever. Logged ONCE per agent — operators can still audit
+      // which entries got reaped without 30 lines/sec of noise.
+      log?.(`subagent-watcher: JSONL vanished for ${entry.agentId} (${code}) — deregistering`)
+      onFileVanished?.(entry.agentId, code)
+      return
+    }
     log?.(`subagent-watcher: read error ${entry.agentId}: ${(err as Error).message}`)
   }
 }
@@ -841,7 +863,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
         if (!entry || !t) return
         readSubTail(entry, t, nowFn(), (desc) => {
           log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-        }, fs, log, db, parentStateDir, config.onUnstall)
+        }, fs, log, db, parentStateDir, config.onUnstall, cleanupTerminalAgent)
         maybySendStateTransition(agentId)
       })
     } catch (err) {
@@ -1179,7 +1201,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       if (!tail) continue
       readSubTail(entry, tail, n, (desc) => {
         log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-      }, fs, log, db, parentStateDir, config.onUnstall)
+      }, fs, log, db, parentStateDir, config.onUnstall, cleanupTerminalAgent)
       maybySendStateTransition(agentId)
     }
 

--- a/telegram-plugin/tests/subagent-watcher-enoent-deregister.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-enoent-deregister.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the readSubTail ENOENT/EACCES deregister path.
+ *
+ * Production symptom: clerk agent's gateway-supervisor.log was growing
+ * at ~30 ENOENT lines/sec sustained (540k+ in 3 days) because the
+ * watcher's poll loop kept statx-ing JSONL files Claude Code had
+ * already reaped along with the parent session's `subagents/` dir.
+ * Same shape on klanker with EACCES (635 events) — likely a perm
+ * flip during cleanup.
+ *
+ * Fix shape: when readSubTail's statSync throws ENOENT or EACCES,
+ * log ONE line + invoke the onFileVanished callback so the watcher
+ * factory can call cleanupTerminalAgent and stop polling. Other
+ * errors (parse, malformed JSONL) keep the legacy per-poll log line.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { readSubTail } from '../subagent-watcher.js'
+import type { WorkerEntry } from '../subagent-watcher.js'
+
+function fakeFsThrowingFromStat(code: 'ENOENT' | 'EACCES' | 'EOTHER') {
+  const err = new Error(`fake ${code}`) as NodeJS.ErrnoException
+  err.code = code
+  return {
+    existsSync: () => true,
+    readdirSync: () => [],
+    statSync: () => { throw err },
+    openSync: () => -1,
+    closeSync: () => {},
+    readSync: () => 0,
+    watch: () => ({ close: () => {} } as ReturnType<typeof require>),
+  } as unknown as Parameters<typeof readSubTail>[4]
+}
+
+function makeEntry(): WorkerEntry {
+  return {
+    agentId: 'a1234567890abcdef',
+    filePath: '/tmp/fake/agent-a1234567890abcdef.jsonl',
+    dispatchedAt: 0,
+    lastActivityAt: 0,
+    toolCount: 0,
+    state: 'running',
+    completionNotified: false,
+    stallNotified: false,
+    historical: false,
+    description: '',
+    lastSummaryLine: '',
+    lastResultText: '',
+  }
+}
+
+function makeTail() {
+  return {
+    cursor: 0,
+    pendingPartial: '',
+    hasEmittedStart: false,
+    watcher: null,
+  }
+}
+
+describe('readSubTail — ENOENT/EACCES deregister', () => {
+  it('fires onFileVanished and logs ONCE on ENOENT', () => {
+    const onFileVanished = vi.fn()
+    const log = vi.fn()
+    const entry = makeEntry()
+
+    readSubTail(
+      entry,
+      makeTail(),
+      0,
+      vi.fn(),
+      fakeFsThrowingFromStat('ENOENT'),
+      log,
+      null,
+      null,
+      undefined,
+      onFileVanished,
+    )
+
+    expect(onFileVanished).toHaveBeenCalledTimes(1)
+    expect(onFileVanished).toHaveBeenCalledWith('a1234567890abcdef', 'ENOENT')
+    expect(log).toHaveBeenCalledTimes(1)
+    expect(log.mock.calls[0][0]).toMatch(/JSONL vanished for a1234567890abcdef \(ENOENT\) — deregistering/)
+    expect(log.mock.calls[0][0]).not.toMatch(/read error/)
+  })
+
+  it('fires onFileVanished and logs ONCE on EACCES (klanker pattern)', () => {
+    const onFileVanished = vi.fn()
+    const log = vi.fn()
+
+    readSubTail(
+      makeEntry(),
+      makeTail(),
+      0,
+      vi.fn(),
+      fakeFsThrowingFromStat('EACCES'),
+      log,
+      null,
+      null,
+      undefined,
+      onFileVanished,
+    )
+
+    expect(onFileVanished).toHaveBeenCalledTimes(1)
+    expect(onFileVanished).toHaveBeenCalledWith('a1234567890abcdef', 'EACCES')
+    expect(log).toHaveBeenCalledTimes(1)
+    expect(log.mock.calls[0][0]).toMatch(/EACCES/)
+  })
+
+  it('still logs the legacy "read error" for unexpected error codes', () => {
+    // Regression guard: parse errors, EIO, EBUSY, etc. must still
+    // surface their detail. Only file-vanished codes are deregistered.
+    const onFileVanished = vi.fn()
+    const log = vi.fn()
+
+    readSubTail(
+      makeEntry(),
+      makeTail(),
+      0,
+      vi.fn(),
+      fakeFsThrowingFromStat('EOTHER'),
+      log,
+      null,
+      null,
+      undefined,
+      onFileVanished,
+    )
+
+    expect(onFileVanished).not.toHaveBeenCalled()
+    expect(log).toHaveBeenCalledTimes(1)
+    expect(log.mock.calls[0][0]).toMatch(/read error a1234567890abcdef/)
+  })
+
+  it('omitting onFileVanished is safe (optional callback)', () => {
+    const log = vi.fn()
+
+    expect(() =>
+      readSubTail(
+        makeEntry(),
+        makeTail(),
+        0,
+        vi.fn(),
+        fakeFsThrowingFromStat('ENOENT'),
+        log,
+        null,
+        null,
+        undefined,
+      ),
+    ).not.toThrow()
+    expect(log).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Clerk agent was logging ~30 ENOENT lines/sec sustained (540k+/3d) from readSubTail statx-ing JSONL files Claude Code had reaped. Klanker same shape with EACCES.

## Fix

In readSubTail catch, detect err.code ENOENT/EACCES. Log once and invoke new optional onFileVanished callback. Factory wires it to cleanupTerminalAgent (closes FSWatcher, drops from registry/tails/knownFiles, adds to terminatedAgentIds).

## Test plan

- [x] 4 unit tests: ENOENT, EACCES, legacy errors still log, optional callback omitted
- [x] Full lint green
- [ ] Post-deploy: re-measure clerk log volume. Expect 99%+ reduction

## Risk

Low. Only deregisters when file is by-definition unreachable. Other read errors keep legacy logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
