### PR TITLE
fix(telegram): replace em-dash with comma in handoff-line template

### DIFF
--- a/telegram-plugin/handoff-continuity.ts
+++ b/telegram-plugin/handoff-continuity.ts
@@ -5,7 +5,7 @@
  * (written by the summarizer Stop hook). On the FIRST assistant reply
  * of the new session the plugin prepends a subtle one-liner:
  *
- *   ↩️ Picked up where we left off — <topic>
+ *   ↩️ Picked up where we left off, <topic>
  *
  * The sidecar is consumed (read + deleted) so the line only fires once.
  * All helpers here are filesystem-only or env-only — no Telegram side
@@ -175,7 +175,13 @@ export function formatHandoffLine(
   topic: string,
   format: HandoffFormat,
 ): string {
-  const prefix = "↩️ Picked up where we left off — ";
+  // Comma instead of em-dash: the framework-emitted prefix is
+  // concatenated AFTER scrubVoice runs on the model body (gateway.ts
+  // executeReply), so any em-dash here bypasses the v0.13.20 voice
+  // scrub. Replacing at the template source is one mechanical change
+  // that closes the dominant residual em-dash leak (16 of 17 dashed
+  // messages on test-harness were this template per 2026-05-24 audit).
+  const prefix = "↩️ Picked up where we left off, ";
   if (format === "html") {
     return `<i>${prefix}${escapeHtml(topic)}</i>\n\n`;
   }

--- a/telegram-plugin/tests/handoff-continuity.test.ts
+++ b/telegram-plugin/tests/handoff-continuity.test.ts
@@ -219,7 +219,7 @@ describe("shouldShowHandoffLine", () => {
 describe("formatHandoffLine", () => {
   it("wraps the topic in italic HTML with the return emoji", () => {
     const line = formatHandoffLine("fixing the bug", "html");
-    expect(line).toBe("<i>↩️ Picked up where we left off — fixing the bug</i>\n\n");
+    expect(line).toBe("<i>↩️ Picked up where we left off, fixing the bug</i>\n\n");
   });
 
   it("escapes HTML-unsafe chars in the topic", () => {
@@ -238,12 +238,25 @@ describe("formatHandoffLine", () => {
 
   it("produces plain text for 'text' format", () => {
     const line = formatHandoffLine("simple", "text");
-    expect(line).toBe("↩️ Picked up where we left off — simple\n\n");
+    expect(line).toBe("↩️ Picked up where we left off, simple\n\n");
   });
 
   it("always ends with a blank-line separator", () => {
     for (const fmt of ["html", "markdownv2", "text"] as const) {
       expect(formatHandoffLine("t", fmt).endsWith("\n\n")).toBe(true);
+    }
+  });
+
+  // Regression guard: the handoff prefix was an em-dash bypass for the
+  // v0.13.20 voice scrubber (the framework prefix is concatenated AFTER
+  // scrubVoice runs in executeReply). Replacing the em-dash with a
+  // comma at the template source closes that leak. Pin it so a future
+  // operator who "fixes typography" doesn't re-introduce the dash.
+  it("does NOT contain an em-dash or en-dash in any format (voice-scrub guard)", () => {
+    for (const fmt of ["html", "markdownv2", "text"] as const) {
+      const line = formatHandoffLine("anything goes here", fmt);
+      expect(line).not.toContain("—");
+      expect(line).not.toContain("–");
     }
   });
 });


### PR DESCRIPTION
## Summary

PR #1683 voice scrubber runs BEFORE `takeHandoffPrefix` concatenates the framework-emitted prefix in `executeReply`. So a literal em-dash in the prefix template bypasses the scrub.

2026-05-24 audit found this is the dominant residual: 16 of 17 dashed messages on test-harness post-v0.13.20 were this prefix.

## Fix

`handoff-continuity.ts:178` — replace `"↩️ Picked up where we left off — "` with `"↩️ Picked up where we left off, "`. One mechanical character change at the template source.

## Test plan

- [x] 30 existing tests still pass
- [x] 1 new regression guard: `formatHandoffLine` output contains no `—` or `–` in any format (html/markdownv2/text)
- [x] Full lint green

## Risk

Low. Pure text template change at source. The prefix is framework-emitted (the user never sees the literal `—` choice as a quote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
