### PR TITLE
fix(telegram): interrupt body bypasses the buffer-until-idle gate

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8491,6 +8491,15 @@ async function handleInbound(
     decideInboundDelivery({
       turnInFlight: turnInFlightAtReceipt,
       isSteering,
+      // Interrupt-marker carve-out (2026-05-24): the `!`-prefixed body
+      // must bypass the "buffer-until-turn-complete" gate because the
+      // SIGINT'd turn often doesn't emit turn_complete, leaving the
+      // body stranded in pendingInboundBuffer indefinitely. The
+      // `interrupt` const is computed at the start of handleInbound
+      // (line ~7606) and remains in scope here. When the user fires
+      // `!`-with-body, this delivers the body as a fresh inbound to
+      // the freshly-killed bridge.
+      isInterrupt: interrupt.isInterrupt,
     }) === 'buffer-until-idle'
   ) {
     pendingInboundBuffer.push(selfAgent, inboundMsg)

--- a/telegram-plugin/gateway/inbound-delivery-gate.ts
+++ b/telegram-plugin/gateway/inbound-delivery-gate.ts
@@ -53,6 +53,27 @@
  * mid-turn — that is the whole point of the steering feature (redirect
  * the agent while it works). Steering messages keep immediate delivery.
  * The wedge only ever affected the queued-mid-turn default path.
+ *
+ * ## Interrupt-marker is also exempt (2026-05-24 fix)
+ *
+ * An inbound prefixed with `!` invokes the interrupt path
+ * (`gateway.ts:handleInbound` parse + `tmux send-keys C-c` to the
+ * bridge). The SIGINT kills the in-flight turn at the SDK level — but
+ * the killed turn does NOT always emit `turn_complete`. Without that
+ * event, the turn-complete buffer-flush never fires, and the
+ * post-SIGINT inbound body (the `!` replacement instruction) rots in
+ * `pendingInboundBuffer` indefinitely.
+ *
+ * 2026-05-24 live UAT trace: user fires `! actually reply hello`,
+ * SIGINT delivered, killed turn never emits `turn_complete`, buffer
+ * stays full, user sees no response. The Phase-3 audit had this UAT
+ * `describe.skip`'d as "real interrupt-marker wedge or prompt-shape
+ * issue" — confirmed real.
+ *
+ * Resolution: bypass the gate for interrupt inbounds. The interrupt
+ * carve-out is a peer of `isSteering` — both are "intentional
+ * mid-turn delivery" cases. Caller passes the interrupt flag from the
+ * inbound parse; the gate returns `'deliver'` immediately.
  */
 
 export interface InboundDeliveryGateInput {
@@ -63,6 +84,14 @@ export interface InboundDeliveryGateInput {
   /** This inbound carried an explicit `/steer` (`/s`) prefix and is an
    *  intentional mid-turn redirect. */
   isSteering: boolean
+  /** This inbound was parsed by `parseInterruptMarker` as a `!`-prefixed
+   *  interrupt request. The gateway has already (or is about to) deliver
+   *  the SIGINT to claude via tmux send-keys; the body of the message
+   *  (post-`!`) is the user's replacement instruction. Without this
+   *  carve-out, the body rots in pendingInboundBuffer because the
+   *  SIGINT'd turn doesn't reliably emit turn_complete to drain the
+   *  buffer. Optional + defaults false for backward compat. */
+  isInterrupt?: boolean
 }
 
 export type InboundDeliveryDecision =
@@ -73,13 +102,17 @@ export type InboundDeliveryDecision =
   | 'buffer-until-idle'
 
 /**
- * Pure. The ONLY condition that defers delivery is "a turn is in flight
- * AND this is not a steering message". Everything else delivers
- * immediately (idle → submits at once; steering → intentional mid-turn).
+ * Pure. Defers delivery ONLY when a turn is in flight AND this inbound
+ * is neither steering nor an interrupt. Idle → deliver. Steering → deliver
+ * (intentional mid-turn redirect). Interrupt → deliver (the `!`
+ * carve-out — see header doc; the killed turn may never drain the
+ * buffer, so we must not buffer in the first place).
  */
 export function decideInboundDelivery(
   input: InboundDeliveryGateInput,
 ): InboundDeliveryDecision {
-  if (input.turnInFlight && !input.isSteering) return 'buffer-until-idle'
+  if (input.isSteering) return 'deliver'
+  if (input.isInterrupt === true) return 'deliver'
+  if (input.turnInFlight) return 'buffer-until-idle'
   return 'deliver'
 }

--- a/telegram-plugin/tests/inbound-delivery-gate.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-gate.test.ts
@@ -41,13 +41,86 @@ describe('decideInboundDelivery', () => {
     ).toBe('deliver')
   })
 
-  it('is total: the ONLY deferral path is mid-turn AND not steering', () => {
+  it('is total: the ONLY deferral path is mid-turn AND not steering AND not interrupt', () => {
     for (const turnInFlight of [true, false]) {
       for (const isSteering of [true, false]) {
-        const decision = decideInboundDelivery({ turnInFlight, isSteering })
-        const expectBuffer = turnInFlight && !isSteering
-        expect(decision).toBe(expectBuffer ? 'buffer-until-idle' : 'deliver')
+        for (const isInterrupt of [true, false]) {
+          const decision = decideInboundDelivery({ turnInFlight, isSteering, isInterrupt })
+          const expectBuffer = turnInFlight && !isSteering && !isInterrupt
+          expect(decision).toBe(expectBuffer ? 'buffer-until-idle' : 'deliver')
+        }
       }
     }
+  })
+
+  // ─── Interrupt-marker carve-out (2026-05-24 fix for the stranded-body bug) ──
+  // Live UAT trace: user fires `! actually do X` mid-turn. SIGINT delivered
+  // to claude via tmux send-keys. The killed turn does NOT emit
+  // turn_complete in many cases (mid-tool-call kill, in-flight subagent),
+  // so the post-`!` body sits in pendingInboundBuffer forever — the
+  // turn-complete drain trigger never fires. The user never gets a reply
+  // to their replacement instruction.
+  //
+  // The carve-out is a peer of isSteering: an interrupt body is by
+  // definition an intentional mid-turn delivery — the user explicitly
+  // asked for "stop and do this instead".
+  describe('interrupt-marker carve-out', () => {
+    it('delivers a `!`-interrupt body mid-turn (does NOT buffer)', () => {
+      // The headline regression fix. Without the carve-out the killed turn
+      // strands the body indefinitely.
+      expect(
+        decideInboundDelivery({
+          turnInFlight: true,
+          isSteering: false,
+          isInterrupt: true,
+        }),
+      ).toBe('deliver')
+    })
+
+    it('delivers a `!`-interrupt body even when claude is idle (no harm)', () => {
+      expect(
+        decideInboundDelivery({
+          turnInFlight: false,
+          isSteering: false,
+          isInterrupt: true,
+        }),
+      ).toBe('deliver')
+    })
+
+    it('isInterrupt is optional — omitting it preserves legacy behavior', () => {
+      // Backward-compat for callers that haven't been updated yet. Mirrors
+      // the optional-default pattern used in other gateway predicates this
+      // session (silent-reply-anchor wasOverPingSuppressed, recent-outbound-
+      // dedup turnKey).
+      expect(
+        decideInboundDelivery({ turnInFlight: true, isSteering: false }),
+      ).toBe('buffer-until-idle')
+      expect(
+        decideInboundDelivery({ turnInFlight: false, isSteering: false }),
+      ).toBe('deliver')
+    })
+
+    it('explicit isInterrupt:false is identical to omitting it', () => {
+      expect(
+        decideInboundDelivery({
+          turnInFlight: true,
+          isSteering: false,
+          isInterrupt: false,
+        }),
+      ).toBe('buffer-until-idle')
+    })
+
+    it('interrupt + steering combination delivers (both are exempt paths)', () => {
+      // Pathological prompt: `! /steer change tactics`. parseInterruptMarker
+      // strips the `!`, then steering parse sees `/steer`. Either flag
+      // alone delivers; both together still deliver. No regression.
+      expect(
+        decideInboundDelivery({
+          turnInFlight: true,
+          isSteering: true,
+          isInterrupt: true,
+        }),
+      ).toBe('deliver')
+    })
   })
 })


### PR DESCRIPTION
## Summary

User fires `!` interrupt mid-turn → SIGINT lands → killed turn does NOT emit turn_complete → post-`!` body sits in `pendingInboundBuffer` forever → user gets no response.

Live UAT trace (jtbd-interrupt-marker-dm, was `describe.skip`'d since #1132):

```
21:26:58.992  msg=1709 interrupt-marker received body_len=48
21:26:58.995  SIGINT delivered via tmux send-keys
21:26:58.998  pending-inbound-buffer: buffered depth_after=1
21:26:58.998  inbound held mid-turn, will flush on turn-complete
21:27:01..21:28:25  90s with no turn-complete, no flush, no reply
```

## Fix

Add `isInterrupt: boolean` to `InboundDeliveryGateInput`. Peer of `isSteering` — both are intentional mid-turn delivery cases. Thread `interrupt.isInterrupt` (parsed at `gateway.ts:7606`) through to the gate call at line ~8491.

## Test plan

- [x] 10 unit tests (5 new): interrupt mid-turn delivers, interrupt idle delivers, optional/false legacy behavior, interrupt+steering combo
- [x] Existing 5 cases widened to 3D matrix (8 combinations)
- [x] Full lint green

## Risk

Low. Additive carve-out shaped exactly like the existing `isSteering` exemption. No behavior change when `isInterrupt` is omitted or false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
