### PR TITLE
fix(telegram): voice scrub wired into stream_reply + turn-flush paths

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4932,6 +4932,31 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   if (!args.chat_id) throw new Error('stream_reply: chat_id is required')
   if (args.text == null || args.text === '') throw new Error('stream_reply: text is required and cannot be empty')
 
+  // Voice scrub (PR #1683 follow-up). Modern Claude on the fleet
+  // uses the answer-stream / draft-stream path for multi-paragraph
+  // replies — the model emits via stream_reply and the original
+  // PR #1683 scrub site (executeReply) never sees the text. klanker's
+  // 2026-05-24 log showed model output with em-dashes routed via
+  // stream_reply done=true, materializing as sendMessage with no
+  // scrub. Mirror the executeReply pattern here: scrub BEFORE the
+  // outbound-dedup check (so retries see the scrubbed key) and
+  // mutate args.text so all downstream consumers (the stream-
+  // controller, dedup record, history record) see the scrubbed
+  // version. Kill switch: SWITCHROOM_DISABLE_VOICE_SCRUB.
+  {
+    const scrub = scrubVoice(args.text as string)
+    if (scrub.replaced > 0) {
+      args.text = scrub.scrubbed
+      emitRuntimeMetric({
+        kind: 'voice_scrub_applied',
+        chatKey: statusKey(args.chat_id as string, args.message_thread_id != null
+          ? Number(args.message_thread_id) : undefined),
+        replaced: scrub.replaced,
+        site: 'stream_reply',
+      })
+    }
+  }
+
   // #546 dedup check: stream_reply done=true is the most-common
   // retry shape — claude-code re-emits the final-text call when
   // the previous bridge missed the ack. If turn-flush already sent
@@ -6751,10 +6776,30 @@ function handleSessionEvent(ev: SessionEvent): void {
       }
 
       if (flushDecision.kind === 'flush') {
-        const capturedText = flushDecision.text
+        let capturedText = flushDecision.text
         const backstopChatId = chatId
         const backstopThreadId = threadId
         const backstopCtrl = ctrl
+
+        // Voice scrub (PR #1683 follow-up). Turn-flush is the path
+        // that fires when the model emits raw transcript text WITHOUT
+        // calling reply / stream_reply. That captured text bypasses
+        // PR #1683's executeReply scrub site entirely and is delivered
+        // via sendMessage / editMessageText directly. Scrub the
+        // capturedText before markdownToHtml so em-dashes never reach
+        // the wire. Kill switch: SWITCHROOM_DISABLE_VOICE_SCRUB.
+        {
+          const scrub = scrubVoice(capturedText)
+          if (scrub.replaced > 0) {
+            capturedText = scrub.scrubbed
+            emitRuntimeMetric({
+              kind: 'voice_scrub_applied',
+              chatKey: statusKey(backstopChatId, backstopThreadId),
+              replaced: scrub.replaced,
+              site: 'turn_flush',
+            })
+          }
+        }
 
         // #1664 — turn-flush only fires when !replyCalled (decideTurnFlush
         // returns 'reply-called' otherwise). It legitimately delivers the

--- a/telegram-plugin/runtime-metrics.ts
+++ b/telegram-plugin/runtime-metrics.ts
@@ -158,7 +158,11 @@ export type RuntimeMetricEvent =
       kind: 'voice_scrub_applied'
       chatKey: string
       replaced: number
-      site: 'reply' | 'edit_message' | 'progress_update' | 'answer_stream'
+      // `stream_reply` and `turn_flush` added in v0.13.21 — modern
+      // Claude routes most multi-paragraph replies through the
+      // answer-stream / draft-stream path, bypassing the v0.13.20
+      // executeReply scrub site. The two new sites close that gap.
+      site: 'reply' | 'edit_message' | 'progress_update' | 'answer_stream' | 'stream_reply' | 'turn_flush'
     }
 
 /**


### PR DESCRIPTION
## Summary

PR #1683 wired the voice scrub into `executeReply` + `executeEditMessage` only. Modern Claude routes multi-paragraph replies through the answer-stream / draft-stream path, materializing via `stream_reply done=true` or via the turn-flush `capturedText` path — both bypass the v0.13.20 scrub.

## The wire-in gaps closed

1. **`executeStreamReply`** (`gateway.ts:4929`): scrub `args.text` at top of function before the outbound-dedup check. Mutate `args.text` so downstream sees the scrubbed version. New metric site `'stream_reply'`.
2. **Turn-flush** (`gateway.ts:6779`): scrub `capturedText` before `markdownToHtml` renders it for chunked sendMessage. New metric site `'turn_flush'`.

## Test plan

- [x] Full lint green (tsc, plugin-references, bot-api, bun-test-imports, pii, vault-hermeticity, no-broadcast)
- [x] No new tests needed — scrubber correctness is pinned by existing `text-voice-scrub.test.ts` (19 tests); the new wire-in sites use the same `scrubVoice` call
- [ ] Post-deploy: re-measure em-dash density on klanker (was 81% pre-fix). Expect significant drop now that the dominant stream_reply path is wired.

## Risk

Low. Both sites mirror the existing `executeReply` pattern. Kill switch (`SWITCHROOM_DISABLE_VOICE_SCRUB`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
