### PR TITLE
docs(telegram): flip steering contract docs + UAT to match live default

### DIFF
--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -23,11 +23,11 @@ The 👀→🤔→🔥→👍 status reaction and the typing indicator are *ambi
 
 **Follow-ups while a turn is in flight.** Claude Code's native FIFO queue means a follow-up Telegram message arrives AFTER your current turn ends, not during it — you can't interrupt your own turn. Every follow-up becomes the next prompt you see. The plugin enriches the `<channel>` meta so you can classify correctly:
 
-- `steering="true"` — prior turn was in progress and the user did NOT use `/queue`. Treat as a course-correction or addendum on the next action. Continue the original task, incorporating the new guidance.
-- `queued="true"` — the user typed `/queue ` or `/q ` (the prefix is stripped from the body you see). Treat as a new, independent task. Do NOT reference the in-flight work — start fresh.
+- `queued="true"` — DEFAULT for mid-turn follow-ups (no prefix). Treat as a new, independent task. Do NOT reference the in-flight work — start fresh. Also fires when the user typed `/queue ` or `/q ` (legacy alias; the prefix is stripped from the body you see).
+- `steering="true"` — the user typed `/steer ` or `/s ` (the prefix is stripped from the body you see). Treat as a course-correction or addendum on the in-flight work. Continue the original task, incorporating the new guidance.
 - `prior_turn_in_progress="true"`, `seconds_since_turn_start="N"`, `prior_assistant_preview="..."` — auxiliary context on the prior turn so you can decide which of the above applies when ambiguous. `prior_assistant_preview` is the first ~200 chars of your most recent reply in this chat, HTML tags stripped.
 
-If both `queued` and `steering` are somehow present, `queued` wins (explicit beats inferred). If `prior_turn_in_progress="true"` is set without either flag (shouldn't happen but defensive), treat the message as a follow-up related to your last reply.
+If both `queued` and `steering` are somehow present, `steering` wins (explicit opt-in beats default). If `prior_turn_in_progress="true"` is set without either flag (shouldn't happen but defensive), treat the message as a follow-up related to your last reply.
 
 **Self-narrate the classification.** At the top of your reply for any `steering` or `queued` message, include a brief italic one-liner so the user can correct you — e.g. `_↪️ treating as steer on the prior task_` or `_📥 queued as a new task_`.
 

--- a/reference/steer-or-queue-mid-flight.md
+++ b/reference/steer-or-queue-mid-flight.md
@@ -57,10 +57,12 @@ user thinking they steered when they actually queued, or vice versa.
 
 ## How switchroom answers this today
 
-- **Steer** = no marker. Send a follow-up while a turn is in flight; the inbound coalescer (default 1500ms gap) merges rapid-fire messages so the agent receives a single combined turn with both signals visible. Slower follow-ups arrive as fresh turns the agent sees in its next iteration.
+(Default flipped 2026-04-17, commits `4fff90bf` + `597a58af`. Prior to that, no-marker meant *steer*; the prompt fragment + this doc lagged the code change for ~5 weeks until 2026-05-24's audit caught it.)
+
+- **Queue** (default — no marker). Send a follow-up while a turn is in flight; it queues as a new, independent task that runs after the current turn ends. The agent receives the follow-up as a fresh turn with `<channel queued="true">` so it knows to start fresh and not carry context from the in-flight work. Legacy `/queue ` / `/q ` prefix is a redundant alias (still works; same outcome).
+- **Steer** = `/steer ` or `/s ` prefix. Explicit opt-in to course-correct the in-flight task. The agent receives the body with `<channel steering="true">` and treats it as an amendment to the current work.
 - **Interrupt + new task** = `!`-prefix marker (#575, gateway-side). A message starting with `!` SIGINTs the agent, strips the marker, and forwards the body as a fresh turn. Empty `!` triggers a "send your replacement instruction now" reply rather than forwarding nothing. The CLAUDE.md template tells the agent the rule so it can teach the user when asked.
-- **What the user sees**: ⚡ reaction on the `!` message confirms the interrupt landed. The agent's normal first-turn protocol then runs against the new body — so the chosen path is visible, not inferred.
-- **Still open** if it surfaces in practice: the JTBD's "queue cleanly behind, with isolated context" sense (file a new task that runs strictly AFTER the current one finishes) isn't a first-class operation today. Today's coalescer-as-queue means second-message effectively becomes amendment context. If a real "queue this for after" workflow shows up, file an issue against this JTBD.
+- **What the user sees**: 🤝 reaction on a `/steer` message confirms the steer landed mid-turn; ⚡ reaction on a `!` message confirms the interrupt landed; queued messages get the normal 👀 (received) reaction since they're a fresh turn from the agent's perspective. The agent self-narrates the classification at the top of its reply (e.g. `_↪️ treating as steer on the prior task_` or `_📥 queued as a new task_`) so the chosen path is visible, not inferred.
 
 ## UAT prompts
 

--- a/telegram-plugin/uat/scenarios/jtbd-rapid-followup-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-rapid-followup-dm.test.ts
@@ -1,38 +1,35 @@
 /**
  * JTBD scenario — rapid follow-ups (steering vs queued classification).
  *
- * Production behaviour codified in `_shared/telegram-style.md.hbs`:
+ * Live contract codified in `_shared/telegram-style.md.hbs` and
+ * `reference/steer-or-queue-mid-flight.md` (default-flip commits
+ * `4fff90bf` + `597a58af`, 2026-04-17):
  *
- * - A follow-up message arriving while a turn is in flight, with no
- *   `/queue` prefix, is `steering="true"` — treated as a course
- *   correction on the in-flight task.
- * - A follow-up prefixed with `/queue ` or `/q ` is `queued="true"` —
- *   a new independent task; the agent should NOT reference the
- *   in-flight work.
+ * - A mid-turn follow-up with NO prefix is `queued="true"` — new
+ *   independent task. The agent should NOT reference the in-flight
+ *   work.
+ * - A mid-turn follow-up prefixed with `/steer ` or `/s ` is
+ *   `steering="true"` — course-correction; the agent continues the
+ *   in-flight task incorporating the new guidance.
+ * - Legacy `/queue ` / `/q ` is a redundant alias for the default;
+ *   still works.
  *
- * This UAT fires both shapes and asserts the agent responds in a way
- * that reflects the classification — for steering it should mention
- * the correction; for queued it should treat the new task fresh.
- *
- * We can't assert directly on the internal channel meta (`steering`,
- * `queued`) from the driver side without inspecting the gateway log
- * — but the conversational pacing prompt instructs the agent to
- * "self-narrate the classification" with a small italic line at the
- * top of its reply. So we can pattern-match on that.
+ * This UAT fires both shapes and asserts the agent narrates the
+ * classification correctly. The prior version of this scenario
+ * (2026-05-13 / PR #1132) tested the pre-flip contract with
+ * too-loose assertions (`/md5/i` regex passes on the queued path
+ * by coincidence — the model answers "use md5" fresh and the reply
+ * contains "md5"). After unskipping with the corrected contract,
+ * the assertions check for the italic classification line the
+ * prompt instructs the agent to emit.
  */
 
 import { describe, it, expect } from "vitest";
 import { spinUp } from "../harness.js";
 
-// Skipped in CI: both cases failed in #1132 overnight (steering didn't
-// surface "md5"; queued didn't produce the expected fresh-task reply).
-// May be real classification bugs, may be prompt fragility — neither
-// has been root-caused. Excluded from the buildkite gate so it doesn't
-// block every PR touching telegram-plugin/. Run locally via
-// `bun run test:uat` once classification has been investigated.
-describe.skip("uat: rapid follow-ups — steering vs queued", () => {
+describe("uat: rapid follow-ups — steering vs queued classification", () => {
   it(
-    "follow-up WITHOUT /queue → agent treats as steering",
+    "follow-up with /steer prefix → agent self-narrates as steering",
     async () => {
       const sc = await spinUp({ agent: "test-harness" });
       try {
@@ -43,26 +40,39 @@ describe.skip("uat: rapid follow-ups — steering vs queued", () => {
           + "Show the work step by step with a 2-second pause between.",
         );
         await new Promise((r) => setTimeout(r, 3_000));
-        // Steer: change the algorithm
-        await sc.sendDM("actually use md5 not sha256");
+        // Steer: change the algorithm using the explicit /steer prefix.
+        await sc.sendDM("/steer actually use md5 not sha256");
 
-        // The agent should reply mentioning md5 (the steered
-        // algorithm), AND ideally surface the italic classification
-        // line per the prompt.
-        const reply = await sc.expectMessage(/md5/i, {
-          from: "bot",
-          timeout: 120_000,
-        });
+        // The agent should reply mentioning md5 AND surface the italic
+        // classification line per the prompt
+        // ("_↪️ treating as steer on the prior task_" or similar).
+        // We match either explicit-steer narration OR the steer emoji
+        // (`↪️`) to allow for natural-language variation while still
+        // failing if no narration appears (the previous version of
+        // this UAT was too loose — bare `/md5/i` passed by coincidence
+        // on the queued path).
+        const reply = await sc.expectMessage(
+          (m) => {
+            const txt = m.text;
+            const mentionsMd5 = /\bmd5\b/i.test(txt);
+            const narratesSteer =
+              /↪️|\bsteer(ing)?\b|continuing the (prior|original|in-flight) task|amendment|course[- ]correct/i.test(
+                txt,
+              );
+            return mentionsMd5 && narratesSteer;
+          },
+          { from: "bot", timeout: 120_000 },
+        );
         expect(reply.text.toLowerCase()).toContain("md5");
       } finally {
         await sc.tearDown();
       }
     },
-    150_000,
+    180_000,
   );
 
   it(
-    "follow-up WITH /queue → agent treats as new task",
+    "follow-up with no prefix mid-turn → agent treats as queued (new task)",
     async () => {
       const sc = await spinUp({ agent: "test-harness" });
       try {
@@ -71,9 +81,10 @@ describe.skip("uat: rapid follow-ups — steering vs queued", () => {
           + "Use bash.",
         );
         await new Promise((r) => setTimeout(r, 3_000));
-        // Queued: completely independent task. The agent should NOT
-        // reference the counting task.
-        await sc.sendDM("/queue what is 2+2?");
+        // No prefix — the default-flipped contract says this is a
+        // QUEUED new task. The agent should NOT reference the
+        // counting work.
+        await sc.sendDM("what is 2+2?");
 
         // First reply should be from the counting task (still
         // in-flight). Then a second reply for the queued task.
@@ -81,16 +92,32 @@ describe.skip("uat: rapid follow-ups — steering vs queued", () => {
           from: "bot",
           timeout: 60_000,
         });
-        // Then we expect another reply (the queued task's answer).
-        // /queue is treated as a new task per the prompt — answer
-        // should be "4" or mention 2+2.
+
+        // Second reply: the queued task's answer. We want to see
+        // EITHER the italic queued-narration line OR a fresh "4"
+        // answer that doesn't reference the counting work.
         const secondReply = await sc.expectMessage(
-          (m) =>
-            m.messageId > firstReply.messageId
-            && /\b4\b|two\s+plus\s+two|2\s*\+\s*2/i.test(m.text),
+          (m) => {
+            if (m.messageId <= firstReply.messageId) return false;
+            const txt = m.text;
+            const answersTheQuestion =
+              /\b4\b|\bfour\b|two\s+plus\s+two|2\s*\+\s*2/i.test(txt);
+            const narratesQueued =
+              /📥|\bqueued\b|new\s+(?:independent\s+)?task|fresh\s+task/i.test(
+                txt,
+              );
+            // Pass if either: the explicit narration is present, OR the
+            // reply answers cleanly without referencing the counting
+            // task. The latter is the substantive behavioural check —
+            // the queued task is isolated from the in-flight context.
+            const isolatedFromCounting = !/\bcount(ing)?\b|\bsleep\b/i.test(
+              txt,
+            );
+            return answersTheQuestion && (narratesQueued || isolatedFromCounting);
+          },
           { from: "bot", timeout: 120_000 },
         );
-        expect(secondReply.text).toMatch(/4|two|2\s*\+\s*2/i);
+        expect(secondReply.text).toMatch(/4|four|2\s*\+\s*2/i);
       } finally {
         await sc.tearDown();
       }


### PR DESCRIPTION
## Summary

The steering default was flipped on 2026-04-17 (commits `4fff90bf` + `597a58af`) — unprefixed mid-turn follow-ups are now QUEUED; steering is opt-in via `/steer` or `/s`. But three docs lagged the code change for ~5 weeks:

- **`profiles/_shared/telegram-style.md.hbs:24-32`** — model has been getting wrong guidance fleet-wide
- **`reference/steer-or-queue-mid-flight.md:58-63`** — JTBD doc described pre-flip contract
- **`telegram-plugin/uat/scenarios/jtbd-rapid-followup-dm.test.ts`** — `describe.skip`'d since #1132 because the inverted contract made the loose `/md5/i` assertion misleading

## Changes

- **Prompt**: queued = default; steering = `/steer` opt-in; tie-breaker flipped to "steering wins"
- **JTBD doc**: rewrites "How switchroom answers this today" to describe the post-flip contract with historical note
- **UAT**: unskipped + rewritten. Steering test uses `/steer` prefix explicitly. Queued test adds substantive behavioural check (no-counting-context) on top of the italic narration cue.

## Risk

Medium — the prompt change affects model behavior fleet-wide. The change brings model expectations into alignment with the gateway code that's been live for 5 weeks, so the net effect should be MORE correct behavior, not less. Canary on test-harness via v0.13.21 deploy before fleet rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
