### PR TITLE
chore: untrack node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+node_modules
 node_modules/
 dist/
 *.log

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/kenthompson/code/switchroom-sec-1417/node_modules


### PR DESCRIPTION
## Summary

Removes the tracked `node_modules` symlink from the repo and widens `.gitignore` so it doesn't keep coming back.

## Why

The repo currently tracks `node_modules` as a symlink pointing at `/home/kenthompson/code/switchroom-sec-1417/node_modules` — a checkout-local path. Anyone who clones the repo gets a broken symlink, and the path leaks operator-specific info into upstream.

`.gitignore` already had `node_modules/` but the trailing slash means "directory only", so it didn't match the existing symlink — which is why multiple prior "untrack" PRs (e.g. `ddda584b`, `b04a97d2`) haven't stuck. Widening to `node_modules` matches both shapes.

This is the recurring landmine pinned in `feedback_history_rewrite_landmines`.

## Test plan

- [x] `git check-ignore -v node_modules` now returns hit on the new rule
- [x] Local node_modules symlink survives the change (untracked, ignored)
- [ ] CI: lint / vitest / bun-test (no source-code changes — should be green)

## Risk

Low. No runtime, source, or test changes. Local developers may need to recreate their own `node_modules` symlink after pulling (the established pattern from `feedback_worktree_node_modules_symlink`); nothing was depending on the tracked symlink being a tracked symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)