### PR TITLE
test(telegram): unskip jtbd-interrupt-marker-dm after #1689 framework fix

### DIFF
--- a/telegram-plugin/uat/scenarios/jtbd-interrupt-marker-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-interrupt-marker-dm.test.ts
@@ -31,7 +31,7 @@ const INTERRUPT = "! actually just reply with the single word 'hello'";
 // a JTBD-floor invariant and shouldn't gate every PR that touches
 // telegram-plugin/. Unskip once the underlying behaviour has been
 // audited end-to-end via `bun run test:uat`.
-describe.skip("uat: ! interrupt marker", () => {
+describe("uat: ! interrupt marker", () => {
   it(
     "user fires !-interrupt mid-turn → agent picks up new task, drops old",
     async () => {


### PR DESCRIPTION
One-line follow-up to #1689. The framework fix landed but the UAT was left `describe.skip`-ed. Confirmed PASSING locally on v0.13.21 (25.2s, was a 60s timeout pre-fix). Unskipping so it gates CI going forward.