### PR TITLE
fix(telegram): preserve parse_mode on pending-progress + clear draft on answer-stream terminal paths (#1698, #1704)

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -233,6 +233,34 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
     }
   }
 
+  /**
+   * Clear the in-progress sendMessageDraft (#1704). When the answer
+   * stream was using draft transport (DMs), Telegram leaves the draft
+   * sitting in the user's compose area until something replaces or
+   * clears it. On Telegram Desktop this blocks the user from typing —
+   * the compose field is occupied by the bot's draft preview.
+   *
+   * Every terminal path on the stream (materialize / stop / retract)
+   * must clear the draft. Best-effort: a failed clear is logged but
+   * not re-thrown — the worst case is a transient stale draft that
+   * Telegram's own 30 s draft expiry eventually mops up.
+   */
+  async function clearDraftBestEffort(): Promise<void> {
+    if (!usesDraftTransport || draftApi == null || draftId == null) return
+    try {
+      const params: { message_thread_id?: number } = {}
+      if (threadId != null) params.message_thread_id = threadId
+      await draftApi(
+        chatId,
+        draftId,
+        '',
+        Object.keys(params).length > 0 ? params : undefined,
+      )
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+
   async function sendDraft(text: string): Promise<boolean> {
     if (!draftApi || draftId == null) return false
     try {
@@ -406,20 +434,7 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       }
 
       // Clear draft so Telegram input area doesn't show stale text
-      if (usesDraftTransport && draftApi != null && draftId != null) {
-        try {
-          const clearParams: { message_thread_id?: number } = {}
-          if (threadId != null) clearParams.message_thread_id = threadId
-          await draftApi(
-            chatId,
-            draftId,
-            '',
-            Object.keys(clearParams).length > 0 ? clearParams : undefined,
-          )
-        } catch {
-          // Best-effort cleanup
-        }
-      }
+      await clearDraftBestEffort()
 
       // The text we want to materialize. Prefer pendingText (most recent
       // snapshot from the model) over lastSentText (what last reached the
@@ -528,6 +543,10 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
     stop(): void {
       stopped = true
       cancelScheduled()
+      // #1704: clear the compose-box draft. stop() is sync — fire and
+      // forget. A dropped clear falls back on Telegram's own 30 s
+      // draft expiry; the worst case is a transient stale preview.
+      void clearDraftBestEffort()
     },
 
     async retract(): Promise<void> {
@@ -539,6 +558,12 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       if (inFlight) {
         try { await inFlight } catch { /* ignore */ }
       }
+      // #1704: clear the compose-box draft when this stream was using
+      // draft transport. Without this, Telegram Desktop leaves the
+      // draft sitting in the user's input area and blocks them from
+      // typing until the 30 s draft expiry. Awaited so a follow-up
+      // sendMessage on the same chat doesn't race a stale draft edit.
+      await clearDraftBestEffort()
       // Delete the preliminary message if one was sent and deleteMessage
       // is wired. Best-effort: failures are logged but not re-thrown.
       const msgId = streamMsgId

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3303,12 +3303,19 @@ silencePoke.startTimer({
 // `SWITCHROOM_DISABLE_PENDING_PROGRESS=1`.
 pendingProgress.startTimer({
   editMessage: async (ctx) => {
+    // #1698: preserve the anchor's original parse_mode. Without this
+    // the edit goes out as plain text, and any <b>/<code>/<a> tag in
+    // anchorOriginalText (the model authored HTML via the reply tool,
+    // which defaults to format='html') re-renders as literal text the
+    // moment the first "still working (Nm)" tick fires.
+    const editOpts = ctx.parseMode != null ? { parse_mode: ctx.parseMode } : undefined
     await swallowingApiCall(
       () =>
         lockedBot.api.editMessageText(
           ctx.chatId,
           ctx.messageId,
           ctx.newText,
+          editOpts,
         ),
       {
         chat_id: ctx.chatId,
@@ -4567,6 +4574,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
           pendingProgress.noteOutbound(statusKey(chat_id, threadId), {
             messageId: decision.messageId,
             text: decision.mergedText,
+            parseMode,
           })
           if (HISTORY_ENABLED) {
             try {
@@ -4759,6 +4767,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       pendingProgress.noteOutbound(statusKey(chat_id, threadId), {
         messageId: anchorMsgId,
         text: chunks[chunks.length - 1],
+        parseMode,
       })
     }
   }
@@ -5138,9 +5147,21 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     // that follows. Capture it so if this turn ends with a pending
     // async dispatch, the framework edits THIS message in place at
     // intervals.
+    //
+    // #1698 — capture the parse_mode the stream-reply-handler used so
+    // the cross-turn edit tick reuses it. Mirrors the format→parseMode
+    // logic at stream-reply-handler.ts:355-368. Without this, the first
+    // "still working (Nm)" tick edits HTML content as plain text and
+    // <b>/<code>/<a> render as literal tags.
+    const streamFormat = (args.format as string | undefined) ?? (access.parseMode ?? 'html')
+    const streamParseMode: 'HTML' | 'MarkdownV2' | undefined =
+      streamFormat === 'html' ? 'HTML'
+      : streamFormat === 'markdownv2' ? 'MarkdownV2'
+      : undefined
     pendingProgress.noteOutbound(statusKey(sChatId, sThreadId), {
       messageId: result.messageId,
       text: args.text as string,
+      parseMode: streamParseMode,
     })
   }
   // #1664 — mark the turn's final answer as delivered. For stream_reply a

--- a/telegram-plugin/pending-work-progress.ts
+++ b/telegram-plugin/pending-work-progress.ts
@@ -45,10 +45,14 @@
  * interval is short (5s) but edits are spaced at EDIT_INTERVAL_MS so
  * the Telegram bot.api editMessageText rate stays well under limits.
  *
- * Edits are plain text (no parseMode). The suffix is appended to the
- * model's authored text; on subsequent edits the prior suffix is
- * stripped before re-appending so the message never accumulates
- * duplicate suffixes.
+ * Edits preserve the anchor's original `parse_mode` (issue #1698). The
+ * anchor was sent through the reply tool, which defaults to HTML; an
+ * earlier version of this module dropped parse_mode on edit, which made
+ * the next "still working (Nm)" tick re-render `<b>` / `<code>` tags as
+ * literal text. The suffix itself is plain text (no `<`/`>`/`&`) so it
+ * is safe under any parse_mode. On subsequent edits the prior suffix is
+ * stripped before re-appending so the message never accumulates duplicate
+ * suffixes.
  *
  * Kill switch: `SWITCHROOM_DISABLE_PENDING_PROGRESS=1` disables the
  * whole subsystem. The conversational-pacing prompt is unaffected.
@@ -76,6 +80,10 @@ export interface PendingProgressEditCtx {
   threadId: number | null
   messageId: number
   newText: string
+  /** Telegram parse_mode the original anchor was sent with (#1698).
+   *  The edit must use the same mode or pre-rendered HTML / MarkdownV2
+   *  tags in `anchorOriginalText` re-render as literal text. */
+  parseMode: 'HTML' | 'MarkdownV2' | undefined
 }
 
 /**
@@ -116,6 +124,11 @@ interface State {
   /** The captured anchor text — what the model wrote, *minus* any
    *  prior pending-progress suffix. Used as the base for every edit. */
   anchorOriginalText: string
+  /** parse_mode the anchor was originally sent with. Edits must
+   *  reuse this or the rendered HTML / MarkdownV2 tags in
+   *  anchorOriginalText render as literal text on the next tick
+   *  (issue #1698). */
+  anchorParseMode: 'HTML' | 'MarkdownV2' | undefined
   /** Wall-clock ms when the cross-turn ambient state was *activated*
    *  (at turn_end with pending+anchor). null before activation. */
   activatedAt: number | null
@@ -144,6 +157,7 @@ function ensure(key: string): State {
       pending: false,
       anchorMessageId: null,
       anchorOriginalText: '',
+      anchorParseMode: undefined,
       activatedAt: null,
       lastEditAt: null,
     }
@@ -181,6 +195,7 @@ export function startTurn(key: string): void {
   s.pending = false
   s.anchorMessageId = null
   s.anchorOriginalText = ''
+  s.anchorParseMode = undefined
 }
 
 /**
@@ -202,12 +217,24 @@ export function noteAsyncDispatch(key: string): void {
  */
 export function noteOutbound(
   key: string,
-  opts: { messageId: number; text: string },
+  opts: {
+    messageId: number
+    text: string
+    /** parse_mode the anchor was sent with. Captured so the
+     *  cross-turn edit tick can reuse it (#1698). Undefined or
+     *  omitted means the original send had no parse_mode (plain
+     *  text). Production callers MUST pass this — every reply path
+     *  knows its own parse_mode. Defaulted to undefined only so test
+     *  fixtures don't have to thread it through where they're
+     *  asserting other behaviour. */
+    parseMode?: 'HTML' | 'MarkdownV2' | undefined
+  },
 ): void {
   if (!enabled()) return
   const s = ensure(key)
   s.anchorMessageId = opts.messageId
   s.anchorOriginalText = opts.text.replace(SUFFIX_RE, '')
+  s.anchorParseMode = opts.parseMode
 }
 
 /**
@@ -331,6 +358,7 @@ function tick(now: number): void {
       threadId,
       messageId: s.anchorMessageId,
       newText,
+      parseMode: s.anchorParseMode,
     }
     // Fire-and-forget so a slow edit doesn't block the tick loop.
     // Errors are logged but never bubble (a 429 / "message not modified"

--- a/telegram-plugin/tests/answer-stream.test.ts
+++ b/telegram-plugin/tests/answer-stream.test.ts
@@ -417,6 +417,116 @@ describe('answer-stream — stop() cancels pending throttled edits', () => {
   })
 })
 
+// ─── #1704 regression — clear the sendMessageDraft on every terminal path ──
+//
+// In DMs the answer-stream uses sendMessageDraft, which renders inside the
+// user's compose box. Telegram Desktop blocks the user from typing while
+// the bot's draft is live — so stop() / retract() / materialize() must
+// all clear the draft. Without these tests the bug class slips back in
+// the next time someone tweaks the lifecycle.
+
+describe('answer-stream — clears sendMessageDraft on terminal paths (#1704)', () => {
+  it('stop() clears the draft when draft transport was in use', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    stream.update('mid-turn thought')
+    await flushMicrotasks()
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+
+    stream.stop()
+    // stop() is sync but the clear fires fire-and-forget — drain microtasks.
+    await flushMicrotasks()
+
+    // A second draft call must have landed with empty text, clearing the
+    // compose-box preview. The draft id matches the in-flight stream's.
+    const draftId = (sendMessageDraft.mock.calls[0] as unknown as [string, number, string, unknown])[1]
+    expect(sendMessageDraft).toHaveBeenCalledWith('chat1', draftId, '', undefined)
+  })
+
+  it('retract() clears the draft when draft transport was in use', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    stream.update('mid-turn thought')
+    await flushMicrotasks()
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+
+    await stream.retract()
+
+    const draftId = (sendMessageDraft.mock.calls[0] as unknown as [string, number, string, unknown])[1]
+    expect(sendMessageDraft).toHaveBeenCalledWith('chat1', draftId, '', undefined)
+  })
+
+  it('stop() is a no-op on the draft API when message transport was in use', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false, // forces message transport
+      minInitialChars: 0,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    stream.update('mid-turn thought')
+    await flushMicrotasks()
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(sendMessageDraft).not.toHaveBeenCalled()
+
+    stream.stop()
+    await flushMicrotasks()
+
+    // Never touched the draft API at all.
+    expect(sendMessageDraft).not.toHaveBeenCalled()
+  })
+
+  it('forwards message_thread_id to the draft-clear call', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: true,
+      threadId: 42,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    stream.update('mid-turn thought')
+    await flushMicrotasks()
+
+    await stream.retract()
+
+    const lastCall = sendMessageDraft.mock.calls[sendMessageDraft.mock.calls.length - 1] as unknown as [string, number, string, { message_thread_id?: number } | undefined]
+    expect(lastCall[2]).toBe('')
+    expect(lastCall[3]).toEqual({ message_thread_id: 42 })
+  })
+})
+
 describe('answer-stream — empty / whitespace-only text is a no-op', () => {
   it('update("") does not trigger any transport call', async () => {
     const sendMessage = makeSendMessage()

--- a/telegram-plugin/tests/pending-work-progress.test.ts
+++ b/telegram-plugin/tests/pending-work-progress.test.ts
@@ -318,6 +318,62 @@ describe('pending-work-progress', () => {
     expect(cap.edits).toHaveLength(0)
   })
 
+  // ─── #1698 regression — preserve parse_mode on the cross-turn edit ───
+  it("preserves the anchor's parse_mode on every edit (#1698)", async () => {
+    const cap = setup()
+    startTurn(KEY)
+    noteAsyncDispatch(KEY)
+    // Anchor was sent through the reply tool with format='html', so
+    // the captured text is already rendered Telegram HTML.
+    noteOutbound(KEY, {
+      messageId: 100,
+      text: '<b>Worker back.</b> Both blockers fixed.',
+      parseMode: 'HTML',
+    })
+    cap.now = 0
+    noteTurnEnd(KEY)
+    cap.now = EDIT_INTERVAL_MS
+    __tickForTests(cap.now)
+    await flush()
+    expect(cap.edits).toHaveLength(1)
+    expect(cap.edits[0].parseMode).toBe('HTML')
+    expect(cap.edits[0].newText).toBe(
+      '<b>Worker back.</b> Both blockers fixed.\n\n— still working (1m)',
+    )
+  })
+
+  it('passes undefined parseMode through when the anchor was plain text', async () => {
+    const cap = setup()
+    startTurn(KEY)
+    noteAsyncDispatch(KEY)
+    // format: 'text' path — anchor was sent without parse_mode.
+    noteOutbound(KEY, {
+      messageId: 100,
+      text: 'plain text reply',
+      parseMode: undefined,
+    })
+    noteTurnEnd(KEY)
+    cap.now = EDIT_INTERVAL_MS
+    __tickForTests(cap.now)
+    await flush()
+    expect(cap.edits[0].parseMode).toBeUndefined()
+  })
+
+  it('defaults parseMode to undefined when caller omits it (test ergonomics)', async () => {
+    const cap = setup()
+    startTurn(KEY)
+    noteAsyncDispatch(KEY)
+    // Callsite that hasn't been updated for the new field — must not
+    // typecheck-fail nor crash. The edit goes out parse_mode-less,
+    // matching the pre-#1698 behaviour for legacy callers.
+    noteOutbound(KEY, { messageId: 100, text: 'wd' })
+    noteTurnEnd(KEY)
+    cap.now = EDIT_INTERVAL_MS
+    __tickForTests(cap.now)
+    await flush()
+    expect(cap.edits[0].parseMode).toBeUndefined()
+  })
+
   it('multiple chats — independent state', async () => {
     const cap = setup()
     const KEY_A = 'A:_'


### PR DESCRIPTION
## Summary

Closes #1698 and resolves the user-blocking half of #1704 (part B —
the "•••" preview blocking the compose field). #1704 part A is
addressed at the diagnosis level: it's the deliberate
turn-flush-safety net, not a leak.

## Root causes

**#1698 — pending-progress drops parse_mode.**
`pending-work-progress.ts` edits the model's last reply in place every
60 s with a "still working (Nm)" suffix while async work is in flight.
The edit deliberately omitted `parse_mode` ("Edits are plain text",
per the docstring). But the anchor was sent through the `reply` MCP
tool, which defaults to `format: 'html'`. So the moment the first tick
fired, every `<b>` / `<code>` / `<a>` tag in the anchor re-rendered as
literal text — exactly the pattern in the three user repros today
(HTML tag at the start of a message that had pending async work
following it).

**#1704 part B — answer-stream leaks the draft.**
`answer-stream.ts` uses `sendMessageDraft` in DMs to preview model
text inside the user's compose area. `materialize()` cleared the
draft at end-of-turn, but `stop()` and `retract()` did not. So
whenever the turn ended without materialising (the common path when
the model goes on to call `reply` directly), the draft sat in the
compose box and Telegram Desktop blocked the user from typing until
the 30 s draft expiry.

**#1704 part A — diagnosed, not changed.**
The "stdout auto-forward" is `turn-flush-safety`, deliberately kept as
the ghost-reply safety net (see the file's own docstring at line 99
reverting a previous attempt to suppress it). Fixing part B removes
what the user likely perceived as part A in DMs — the stuck draft
preview that looked like a streaming marker. The turn-flush path is
unchanged.

## Changes

- `telegram-plugin/pending-work-progress.ts` — capture
  `anchorParseMode` in state + `noteOutbound`; thread through
  `PendingProgressEditCtx`. New field is optional in the public type so
  legacy test callers compile unchanged; production must pass it.
  Docstring updated to remove the now-wrong "plain text" claim.
- `telegram-plugin/gateway/gateway.ts` — pass `parseMode` to all three
  `noteOutbound` callsites (executeReply, silent-anchor merge,
  stream_reply done=true); reuse it on the edit-callback via
  `editMessageText(..., { parse_mode })`.
- `telegram-plugin/answer-stream.ts` — extract `clearDraftBestEffort()`
  helper; call from `stop()` (sync, fire-and-forget), `retract()`
  (awaited), and `materialize()` (replaces the inline copy).

## Tests

- `tests/pending-work-progress.test.ts` — +3 tests:
  - preserves HTML parse_mode on every edit (the #1698 regression)
  - passes undefined through for plain-text anchors
  - defaults parseMode to undefined for legacy / test callsites
- `tests/answer-stream.test.ts` — +4 tests:
  - `stop()` clears the draft when draft transport was in use
  - `retract()` clears the draft (awaited)
  - `stop()` is a no-op on the draft API for message transport
  - forwards `message_thread_id` to the draft-clear call

## Validation

- `vitest telegram-plugin/tests/` — 161 files / 2702 tests pass
- `bun test` on the two affected files — 48 pass, 0 fail
- `vitest tests/` (src/) — 308 files / 4965 tests pass
- `tsc --noEmit` clean
- `scripts/check-bot-api-wrapping.sh` clean (gateway.ts allowlist not drifted)
- `scripts/check-plugin-references.mjs` clean

## Test plan

- [x] Unit tests cover the fix paths and the legacy-caller compatibility
- [x] Full vitest + bun test green
- [x] tsc + plugin-refs + bot-api-allowlist guards green
- [ ] Post-merge: UAT scenario `jtbd-fast-trivial-dm` after fleet roll —
      confirm draft clears on turn end and pending-progress ticks
      preserve HTML

## Risk

Low. Both fixes are narrowly scoped to the documented terminal paths.
The pending-progress field is optional with a safe default; the
answer-stream draft-clear path is fire-and-forget with try/catch
swallowing failures (matches the existing `materialize` semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)