### PR TITLE
fix(vault): vault set --file preserves binary bytes via kind="binary" (#1090)

### DIFF
--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -7,6 +7,7 @@ import { resolvePath } from "../config/loader.js";
 import {
   createVault,
   setStringSecret,
+  setBinarySecret,
   getSecret,
   listSecrets,
   removeSecret,
@@ -522,10 +523,33 @@ export function registerVaultCommand(program: Command): void {
         const passphrase = await getPassphrase();
 
         let value: string;
+        // Set to true when --file reads a file whose bytes don't survive
+        // a UTF-8 round-trip — e.g. a tarball, sealed archive, or raw
+        // key material containing non-UTF-8 bytes. We store these as
+        // kind="binary" (base64) so the bytes are preserved verbatim
+        // instead of getting silently mangled to U+FFFD (#1090).
+        let isBinaryFile = false;
         if (opts.file) {
           // --file flag: read value from a file verbatim.
           try {
-            value = readFileSync(resolvePath(opts.file), "utf8");
+            const buf = readFileSync(resolvePath(opts.file));
+            const asUtf8 = buf.toString("utf8");
+            // Lossless-UTF-8 detection: if the bytes survive a decode +
+            // re-encode round-trip, treat as text (existing behaviour).
+            // Otherwise the file is binary and we must base64-encode it
+            // before storage to preserve bytes.
+            if (Buffer.compare(buf, Buffer.from(asUtf8, "utf8")) === 0) {
+              value = asUtf8;
+            } else {
+              value = buf.toString("base64");
+              isBinaryFile = true;
+              console.error(
+                chalk.yellow(
+                  `note: file contains non-UTF-8 bytes; storing as kind="binary" ` +
+                  `(base64-encoded). Retrieve with: switchroom vault get ${key} | base64 -d`,
+                ),
+              );
+            }
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             console.error(chalk.red(`Error reading file: ${msg}`));
@@ -547,7 +571,14 @@ export function registerVaultCommand(program: Command): void {
         }
 
         // Validate the value against the declared format hint.
-        if (formatHint) {
+        // Skip for binary --file content: the stored value is base64,
+        // not the original bytes, so a format hint like "json" or "pem"
+        // would never match — the operator's intent was a hint about
+        // the underlying bytes. Validating those would require decoding
+        // base64 here, which is fine but premature: callers who want
+        // format-hinted binary should pipe through a text encoding
+        // before --file.
+        if (formatHint && !isBinaryFile) {
           const validationError = validateFormatHint(value, formatHint);
           if (validationError) {
             console.error(
@@ -606,7 +637,11 @@ export function registerVaultCommand(program: Command): void {
           }
         }
 
-        setStringSecret(passphrase, vaultPath, key, value, formatHint, scope);
+        if (isBinaryFile) {
+          setBinarySecret(passphrase, vaultPath, key, value, formatHint, scope);
+        } else {
+          setStringSecret(passphrase, vaultPath, key, value, formatHint, scope);
+        }
         if (formatHint && scope) {
           const scopeDesc = [
             scope.allow?.length ? `allow: ${scope.allow.join(", ")}` : "",

--- a/src/vault/vault.ts
+++ b/src/vault/vault.ts
@@ -526,6 +526,28 @@ export function setStringSecret(
   setSecret(passphrase, vaultPath, key, entry);
 }
 
+/**
+ * Store a binary secret. `value` is expected to be a base64 string —
+ * callers convert their bytes (e.g. `buf.toString("base64")`) before
+ * passing them in. Retrievers know to `base64 -d` the returned value.
+ */
+export function setBinarySecret(
+  passphrase: string,
+  vaultPath: string,
+  key: string,
+  value: string,
+  format?: VaultFormatHint,
+  scope?: VaultEntryScope,
+): void {
+  const entry: VaultEntry = format
+    ? { kind: "binary", value, format }
+    : { kind: "binary", value };
+  if (scope !== undefined) {
+    (entry as { kind: "binary"; value: string; format?: VaultFormatHint; scope?: VaultEntryScope }).scope = scope;
+  }
+  setSecret(passphrase, vaultPath, key, entry);
+}
+
 export function getStringSecret(
   passphrase: string,
   vaultPath: string,

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -327,6 +327,27 @@ describe("vault set CLI — multi-line values", () => {
 
     expect(getStringSecret(passphrase, vaultPath, "cfg")).toBe(json);
   });
+
+  it("preserves binary --file bytes via base64 + kind=\"binary\" (#1090)", () => {
+    // 0xff in the lead position is the canonical case from the issue —
+    // the prior utf8-readFileSync silently replaced it with U+FFFD
+    // (EF BF BD), losing the original byte.
+    const bytes = Buffer.from([0xff, 0xfe, 0x00, 0x42, 0x69, 0x6e]);
+    const filePath = join(tmpDir, "blob.bin");
+    writeFileSync(filePath, bytes);
+
+    const result = runCli(["set", "test/blob", "--file", filePath]);
+    expect(result.status).toBe(0);
+    // Friendly hint pointing at base64 -d for retrieval.
+    expect(result.stderr).toContain("kind=\"binary\"");
+    expect(result.stderr).toContain("base64 -d");
+
+    const entry = getSecret(passphrase, vaultPath, "test/blob");
+    expect(entry?.kind).toBe("binary");
+    if (entry?.kind === "binary") {
+      expect(Buffer.from(entry.value, "base64")).toEqual(bytes);
+    }
+  });
 }, 30_000);
 
 describe("vault resolver", () => {


### PR DESCRIPTION
## Summary

`switchroom vault set <key> --file <path>` previously called `readFileSync(path, \"utf8\")`, which silently replaces non-UTF-8 byte sequences with the U+FFFD replacement character (3 bytes: EF BF BD). Binary inputs — tarballs, sealed archives, raw key material — would store the corrupted form, and the `vault list` post-write check only verifies key presence so the corruption was invisible.

## Approach

1. Drop the `\"utf8\"` arg from `readFileSync` to get a `Buffer`.
2. **Lossless-UTF-8 round-trip detection:** `Buffer.compare(buf, Buffer.from(buf.toString(\"utf8\"), \"utf8\")) === 0` is the test. If text-clean → store as `kind=\"string\"` (existing behaviour preserved for PEM, JSON, configs, etc.).
3. If lossy → base64-encode the bytes and store as `kind=\"binary\"`, with a clear stderr note pointing at `switchroom vault get <key> | base64 -d` for retrieval.
4. Adds `setBinarySecret` helper as the binary parallel to `setStringSecret`.
5. Skips format-hint validation for binary `--file` inputs (the stored value is base64, not the original bytes — format-hint validation would need to decode first; out of scope).

## Why round-trip detection vs. always-binary

Always-binary would break operators who currently `vault set --file mykey.pem` and consume `vault get mykey` as raw text. Round-trip detection preserves the existing text-file workflow byte-for-byte while fixing the binary corruption silently. Non-UTF-8 inputs (the broken case) now surface a clear hint at write time about the base64-decode retrieval path.

## Test plan

- [x] New test at `tests/vault.test.ts` writes a Buffer starting with 0xff (the canonical case from the issue), confirms `kind=\"binary\"`, confirms base64 round-trips back to the original bytes, confirms the stderr hint mentions `base64 -d`.
- [x] All 62 vault tests pass.
- [x] tsc --noEmit clean.
- [x] Existing text-file workflows unchanged (verified via the existing `--file flag` test in the same suite).

## Risk

Behaviour change is restricted to inputs that were previously silently corrupted. Operators currently relying on `vault get <key>` returning text for `--file` writes are unaffected (round-trip-clean inputs continue to store as `kind=\"string\"`). The migration-script workaround referenced in the issue (#1084's hand-rolled base64 + sha256 verify) can remain in place; it doesn't conflict.

Closes #1090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)