### PR TITLE
chore(config): remove orphaned summarizer_model + DispatchRule.model (#1630)

### DIFF
--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -556,7 +556,6 @@ function registerDispatchVerb(tg: Command, _program: Command): void {
           for (const line of rendered.split("\n")) {
             console.log(`    ${line}`);
           }
-          console.log(`  model: ${rule.model ?? "claude-sonnet-4-6"}`);
         }
 
         console.log();
@@ -566,7 +565,8 @@ function registerDispatchVerb(tg: Command, _program: Command): void {
           console.log(
             chalk.green(
               `${matchCount} rule(s) matched. ` +
-              `Run without --dry-run in production to spawn claude -p.`,
+              `The webhook turn injects into the agent's live session — ` +
+              `agent's configured model wins.`,
             ),
           );
         }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -358,8 +358,6 @@ export const SessionSchema = z
  *     start.sh skips all handoff logic.
  *   - show_handoff_line: if false, the plugin still gets the briefing in
  *     its system prompt but suppresses the user-visible continuity line.
- *   - summarizer_model: which Anthropic model produces the briefing.
- *     Haiku is the cost-sensitive default; swap for testing.
  *   - max_turns_in_briefing: hard cap on how many recent user/assistant
  *     turn pairs are fed to the summarizer. Bounds cost and latency.
  */
@@ -376,14 +374,6 @@ export const SessionContinuitySchema = z
         "Whether the telegram plugin prepends a visible '↩️ Picked up…' " +
         "line to the first assistant reply after a restart (default true).",
       ),
-    summarizer_model: z
-      .string()
-      .regex(
-        /^[a-zA-Z0-9][a-zA-Z0-9._\-/\[\]:]*$/,
-        "Model name must be alphanumeric with ._-/[]: only",
-      )
-      .optional()
-      .describe("Anthropic model used to produce the handoff briefing."),
     max_turns_in_briefing: z
       .number()
       .int()
@@ -663,7 +653,6 @@ export const TelegramChannelSchema = z
                   tz: z.string().optional(),
                 })
                 .optional(),
-              model: z.string().optional(),
             }),
           )
           .optional(),
@@ -671,8 +660,8 @@ export const TelegramChannelSchema = z
       .optional()
       .describe(
         "Auto-dispatch rules: when a verified webhook event matches a rule, " +
-        "spawn a one-shot `claude -p` turn for the agent with the rendered " +
-        "prompt. Supports cooldowns, quiet hours, and label/action matchers. " +
+        "inject the rendered prompt into the agent's live session (#1625). " +
+        "Supports cooldowns, quiet hours, and label/action matchers. " +
         "Off by default — opt in per agent. See src/web/webhook-dispatch.ts.",
       ),
     webhook_rate_limit: z

--- a/src/web/webhook-dispatch.ts
+++ b/src/web/webhook-dispatch.ts
@@ -80,13 +80,6 @@ export interface DispatchRule {
   /** Cooldown duration string: "5m", "1h", "30s". Defaults to "0" (no cooldown). */
   cooldown?: string
   quiet_hours?: QuietHours
-  /**
-   * Deprecated and ignored since #1620. A webhook turn now runs inside
-   * the agent's live interactive session, which uses the agent's own
-   * configured model — there is no per-turn model override. Retained
-   * as an optional field only so existing configs still parse.
-   */
-  model?: string
 }
 
 export interface WebhookDispatchConfig {


### PR DESCRIPTION
## Summary

Removes two config fields left parsed-but-ignored after the \`claude -p\` elimination (RFCs #1620 / #1625 / #1626):

- **\`session_continuity.summarizer_model\`** — handoff is now a deterministic transcript tail (#1626); there is no summarizer model. \`src/cli/handoff.ts\` no longer reads it; nothing outside the schema referenced it.
- **\`webhook_dispatch[].model\`** (\`DispatchRule.model\`) — webhook turns now run in the agent's live interactive session (#1625) and use the agent's own model. Only consumer was a dry-run print at \`src/cli/telegram.ts:559\` (\`switchroom telegram dispatch-test --dry-run\`); updated to match the new semantics.

Both were flagged in the #1625 / #1626 reviews as fast-follow cleanup. Removing now so the config surface has no knobs that do nothing — principle 3, \"one mind built this.\"

## Backward compatibility

Schema is non-strict — only \`ReleaseSchema\` uses \`.strict()\` (verified via \`grep -c '\.strict()' src/config/schema.ts\` → 1). So existing configs that still set either field will continue to parse; the value gets silently dropped instead of triggering a Zod error. This preserves the back-compat path explicitly called out in the #1625 / #1626 review threads.

## Out of scope

\`ScheduleEntrySchema.model\` (\`src/config/schema.ts:67\`) is also documented as \"DEPRECATED / IGNORED\" post cron-fold-in, but is still threaded through \`src/agents/scaffold.ts:2749 → buildCronScript\`. Whether that path is truly dead (and the field removable) needs its own audit — left for a follow-up.

## Test plan

- [x] \`tsc --noEmit\` clean.
- [x] \`webhook-dispatch.test.ts\` 36 tests pass.
- [x] Verified \`summarizer_model\` has zero non-schema readers via grep.

Closes #1630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)