### PR TITLE
test: unit-cover warnLegacyStateOnce + checkLegacyState (#1375)

### DIFF
--- a/tests/legacy-state-helpers.test.ts
+++ b/tests/legacy-state-helpers.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the legacy-state deprecation safety rails (#1373 / #1375):
+ *
+ * 1. src/config/paths.ts `warnLegacyStateOnce`:
+ *    - Writes exactly one stderr line per process across multiple legacy hits.
+ *    - Writes zero lines when only the canonical `~/.switchroom` tree exists.
+ *
+ * 2. src/cli/doctor.ts `checkLegacyState()`:
+ *    - Returns `status: "ok"` on a clean (migrated) host.
+ *    - Returns `status: "warn"` for the `~/.clerk` dir and the v0.6
+ *      `~/.switchroom/vault-broker.sock` (including a DANGLING symlink,
+ *      since detection uses lstatSync).
+ *    - Never returns `status: "fail"` — doctor exit code is unaffected.
+ *
+ * These are the safety rails that have to keep working right up to the
+ * v0.13.0 removal of the `.clerk` dual-read shim. The dual-read is the
+ * only silent-catastrophic deprecation in the tree — deleting it while
+ * a host is still on `~/.clerk` makes vault/agents/auth read as absent
+ * with no error. Coverage here gives the removal PR a green floor.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  symlinkSync,
+  mkdtempSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+describe("warnLegacyStateOnce (src/config/paths.ts)", () => {
+  let tmp: string;
+  let origHome: string | undefined;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tmp = mkdtempSync(join(tmpdir(), "switchroom-legacy-state-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tmp;
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    // Reset module state so `_legacyStateWarned` starts fresh per test.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    if (origHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = origHome;
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("emits zero stderr lines when only the canonical ~/.switchroom tree exists", async () => {
+    mkdirSync(join(tmp, ".switchroom", "agents"), { recursive: true });
+    const { resolveStatePath } = await import("../src/config/paths.js");
+
+    const got = resolveStatePath("agents");
+    expect(got).toBe(join(tmp, ".switchroom", "agents"));
+
+    const deprecationCalls = stderrSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("DEPRECATED: reading legacy state"),
+    );
+    expect(deprecationCalls).toHaveLength(0);
+  });
+
+  it("emits exactly one stderr line per process across multiple legacy hits", async () => {
+    // Only ~/.clerk/<frag> exists → resolveStatePath falls back to legacy and
+    // warns. Two consecutive calls must produce a single deprecation line.
+    mkdirSync(join(tmp, ".clerk", "agents"), { recursive: true });
+    mkdirSync(join(tmp, ".clerk", "vault.enc.d"), { recursive: true });
+    const { resolveStatePath } = await import("../src/config/paths.js");
+
+    const a = resolveStatePath("agents");
+    const b = resolveStatePath("vault.enc.d");
+    expect(a).toBe(join(tmp, ".clerk", "agents"));
+    expect(b).toBe(join(tmp, ".clerk", "vault.enc.d"));
+
+    const deprecationCalls = stderrSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("DEPRECATED: reading legacy state"),
+    );
+    expect(deprecationCalls).toHaveLength(1);
+    // Sanity-check the message body — the removal-version pointer is the
+    // load-bearing part for the operator.
+    expect(String(deprecationCalls[0][0])).toMatch(/REMOVED in v0\.13\.0/);
+  });
+
+  it("the resolveDualPath callsite also dedups against resolveStatePath", async () => {
+    // Both helpers funnel through the same module-level _legacyStateWarned
+    // flag. Hitting both should still produce exactly one stderr line.
+    mkdirSync(join(tmp, ".clerk", "vault.enc.d"), { recursive: true });
+    mkdirSync(join(tmp, ".clerk", "agents", "x"), { recursive: true });
+    const { resolveStatePath, resolveDualPath } = await import("../src/config/paths.js");
+
+    resolveStatePath("vault.enc.d");
+    resolveDualPath("~/.switchroom/agents/x");
+
+    const deprecationCalls = stderrSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("DEPRECATED: reading legacy state"),
+    );
+    expect(deprecationCalls).toHaveLength(1);
+  });
+});
+
+describe("checkLegacyState (src/cli/doctor.ts)", () => {
+  let tmp: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "switchroom-doctor-legacy-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tmp;
+  });
+
+  afterEach(() => {
+    if (origHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = origHome;
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns status=ok for both probes when neither legacy artifact exists", async () => {
+    const { checkLegacyState } = await import("../src/cli/doctor.js");
+    const results = checkLegacyState();
+
+    expect(results).toHaveLength(1); // only the clerk-dir probe runs when no socket
+    for (const r of results) {
+      expect(r.status).toBe("ok");
+      expect(r.status).not.toBe("fail");
+    }
+  });
+
+  it("returns status=warn (never fail) when ~/.clerk is present", async () => {
+    mkdirSync(join(tmp, ".clerk"), { recursive: true });
+    const { checkLegacyState } = await import("../src/cli/doctor.js");
+
+    const results = checkLegacyState();
+    const clerk = results.find((r) => r.name.includes("legacy ~/.clerk"));
+    expect(clerk).toBeDefined();
+    expect(clerk?.status).toBe("warn");
+    expect(clerk?.status).not.toBe("fail");
+    expect(clerk?.detail).toContain(join(tmp, ".clerk"));
+    expect(clerk?.fix).toMatch(/mv ~\/\.clerk ~\/\.switchroom/);
+  });
+
+  it("returns status=warn for the v0.6 broker socket when it exists as a real file", async () => {
+    mkdirSync(join(tmp, ".switchroom"), { recursive: true });
+    writeFileSync(join(tmp, ".switchroom", "vault-broker.sock"), "");
+    const { checkLegacyState } = await import("../src/cli/doctor.js");
+
+    const results = checkLegacyState();
+    const sock = results.find((r) => r.name.includes("legacy v0.6 broker socket"));
+    expect(sock).toBeDefined();
+    expect(sock?.status).toBe("warn");
+    expect(sock?.status).not.toBe("fail");
+    expect(sock?.fix).toMatch(/LEGACY_SOCKET_PATH/);
+  });
+
+  it("returns status=warn for a DANGLING symlink at the broker-socket path (lstatSync detection)", async () => {
+    // Detection uses lstatSync, not statSync, so a dangling symlink still
+    // surfaces. Pre-#1373 the probe missed this case and let the operator
+    // hit the silent-fallback failure mode on a v0.13.0 upgrade.
+    mkdirSync(join(tmp, ".switchroom"), { recursive: true });
+    symlinkSync(
+      join(tmp, "nonexistent-target"),
+      join(tmp, ".switchroom", "vault-broker.sock"),
+    );
+    const { checkLegacyState } = await import("../src/cli/doctor.js");
+
+    const results = checkLegacyState();
+    const sock = results.find((r) => r.name.includes("legacy v0.6 broker socket"));
+    expect(sock).toBeDefined();
+    expect(sock?.status).toBe("warn");
+    expect(sock?.detail).toContain("symlink");
+  });
+
+  it("never returns status=fail under any combination — doctor exit code stays 0", async () => {
+    // Both legacy artifacts present at once.
+    mkdirSync(join(tmp, ".clerk"), { recursive: true });
+    mkdirSync(join(tmp, ".switchroom"), { recursive: true });
+    writeFileSync(join(tmp, ".switchroom", "vault-broker.sock"), "");
+    const { checkLegacyState } = await import("../src/cli/doctor.js");
+
+    const results = checkLegacyState();
+    for (const r of results) {
+      expect(r.status).not.toBe("fail");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up from #1373 (legacy-state deprecation notice). Pins the v0.12.x safety rails so the v0.13.0 shim-removal PR lands with green coverage. Pure test addition — no behaviour change.

## Coverage added

### `warnLegacyStateOnce` (\`src/config/paths.ts\`)

- Zero stderr lines when only the canonical \`~/.switchroom\` tree exists (migrated hosts pay no warn-noise cost).
- Exactly one stderr line per process across multiple legacy hits via \`resolveStatePath\` (the module-level \`_legacyStateWarned\` dedup).
- The dedup also holds across the two callsites — \`resolveStatePath\` and \`resolveDualPath\` both funnel through the same flag.

### \`checkLegacyState\` (\`src/cli/doctor.ts\`)

- \`status: \"ok\"\` for both probes on a clean migrated host.
- \`status: \"warn\"\` (never \"fail\", so doctor exit stays 0) when:
  - \`~/.clerk\` exists.
  - The v0.6 \`~/.switchroom/vault-broker.sock\` exists as a real file.
  - It exists as a **dangling symlink** (lstatSync detection — the case statSync would miss).

## Isolation

Tests use \`mkdtempSync\` + \`process.env.HOME\` override (matching the pattern in \`tests/doctor.repo-hygiene.test.ts\`). \`vi.resetModules()\` per test so the module-level \`_legacyStateWarned\` dedup flag starts fresh.

## Why it matters

The \`.clerk\` dual-read is the only **silent-catastrophic** deprecation shim in the tree — deleting it while a host is still on \`~/.clerk\` makes vault/agents/auth read as absent with no error. The warn + doctor check are what give operators a chance to migrate before v0.13.0. This PR pins their behaviour so the removal commit has a green floor.

## Test plan

- [x] \`vitest run tests/legacy-state-helpers.test.ts\` — 8/8 pass.
- [x] \`tsc --noEmit\` clean.

Closes #1375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)