### PR TITLE
sec(WS3): validate agent slug on broker requests with path-component use (#1448)

### DIFF
--- a/src/vault/broker/protocol.test.ts
+++ b/src/vault/broker/protocol.test.ts
@@ -151,3 +151,97 @@ describe("malformed JSON rejection", () => {
     ).toThrow();
   });
 });
+
+// ─── Agent-name validation (#1448) ─────────────────────────────────────────
+//
+// Pre-fix the broker accepted any non-empty `agent` string on mint_grant
+// (and friends) and joined it directly into a filesystem path
+// (`~/.switchroom/agents/<agent>/.vault-token`). A peer with broker-IPC
+// access could escape the agents tree with `agent: "../foo"`. The
+// validation now happens at the schema layer so the bad request is
+// rejected before any filesystem call is reached.
+
+describe("agent-name validation on broker requests (#1448)", () => {
+  // Minimum-viable mint_grant body — the test mutates only `agent`.
+  function mintGrantBody(agent: unknown) {
+    return JSON.stringify({
+      v: 1,
+      op: "mint_grant",
+      agent,
+      keys: ["some_key"],
+      ttl_seconds: 60,
+      passphrase: "doesn't-matter-rejected-before-broker-runs",
+    });
+  }
+
+  it("accepts a kebab-case agent slug (regression)", () => {
+    // Common-case agent names must continue to validate cleanly.
+    for (const ok of ["klanker", "gymbro", "lawgpt", "carrie", "finn", "a1", "z9", "agent-1", "a_b_c"]) {
+      expect(() => decodeRequest(mintGrantBody(ok))).not.toThrow();
+    }
+  });
+
+  it("rejects path-traversal agent names", () => {
+    expect(() => decodeRequest(mintGrantBody("../escape"))).toThrow();
+    expect(() => decodeRequest(mintGrantBody("foo/../bar"))).toThrow();
+    expect(() => decodeRequest(mintGrantBody(".."))).toThrow();
+  });
+
+  it("rejects absolute-path agent names", () => {
+    expect(() => decodeRequest(mintGrantBody("/etc/passwd"))).toThrow();
+    expect(() => decodeRequest(mintGrantBody("/abs"))).toThrow();
+  });
+
+  it("rejects names with separators or shell metacharacters", () => {
+    expect(() => decodeRequest(mintGrantBody("foo/bar"))).toThrow();
+    expect(() => decodeRequest(mintGrantBody("foo bar"))).toThrow();
+    expect(() => decodeRequest(mintGrantBody("foo;bar"))).toThrow();
+    expect(() => decodeRequest(mintGrantBody("foo\nbar"))).toThrow();
+    expect(() => decodeRequest(mintGrantBody("foo\\bar"))).toThrow();
+  });
+
+  it("rejects names starting with non-alnum (dot, hyphen, underscore)", () => {
+    // Leading `-` or `_` would collide with CLI flag parsing in audit
+    // contexts; leading `.` is the dotfile escape.
+    expect(() => decodeRequest(mintGrantBody(".hidden"))).toThrow();
+    expect(() => decodeRequest(mintGrantBody("-flag"))).toThrow();
+    expect(() => decodeRequest(mintGrantBody("_under"))).toThrow();
+  });
+
+  it("rejects reserved identity names (operator)", () => {
+    // `operator` resolves to the operator identity in peercred; allowing
+    // it as an agent slug lets a malicious peer mis-route mint_grant.
+    expect(() => decodeRequest(mintGrantBody("operator"))).toThrow();
+  });
+
+  it("rejects empty and overlong names", () => {
+    expect(() => decodeRequest(mintGrantBody(""))).toThrow();
+    expect(() => decodeRequest(mintGrantBody("a".repeat(65)))).toThrow();
+    // Exactly 64 is at the boundary and should pass.
+    expect(() => decodeRequest(mintGrantBody("a".repeat(64)))).not.toThrow();
+  });
+
+  it("applies the same validation to list_grants (when agent is set)", () => {
+    const body = JSON.stringify({
+      v: 1,
+      op: "list_grants",
+      agent: "../escape",
+    });
+    expect(() => decodeRequest(body)).toThrow();
+  });
+
+  it("list_grants accepts omitted agent (back-compat)", () => {
+    const body = JSON.stringify({ v: 1, op: "list_grants" });
+    expect(() => decodeRequest(body)).not.toThrow();
+  });
+
+  it("applies the same validation to preflight_access", () => {
+    const body = JSON.stringify({
+      v: 1,
+      op: "preflight_access",
+      agent: "foo/../bar",
+      keys: ["k"],
+    });
+    expect(() => decodeRequest(body)).toThrow();
+  });
+});

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -19,10 +19,37 @@
 
 import { z } from "zod";
 import type { VaultEntry } from "../vault.js";
+import { isReservedAgentName } from "./peercred.js";
 
 // ─── Constants ─────────────────────────────────────────────────────────────
 
 export const MAX_FRAME_BYTES = 64 * 1024; // 64 KiB
+
+/**
+ * Agent-name validator (#1448). Any broker request that interpolates a
+ * wire-supplied `agent` value into a filesystem path MUST validate
+ * through this schema before use. Pre-fix `mint_grant` accepted any
+ * non-empty string and joined it directly into
+ * `~/.switchroom/agents/<agent>/.vault-token` — a malicious peer with
+ * broker-IPC access could `agent: "../foo"` to escape the agents tree.
+ *
+ * Charclass + cap mirror `src/host-control/protocol.ts` AgentNameSchema
+ * (kebab-case ASCII, first char alnum, 64-byte cap), which matches the
+ * shape `allocateAgentUid` already implicitly requires. Reserved names
+ * (e.g. `operator`) are rejected at the schema layer so the broker
+ * can't be tricked into routing through an alternate identity.
+ */
+export const AgentNameSchema = z
+  .string()
+  .min(1)
+  .max(64, "agent name max 64 chars")
+  .regex(
+    /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/,
+    "agent name must be kebab-case ASCII (alnum + _- only, first char alnum)",
+  )
+  .refine((s) => !isReservedAgentName(s), {
+    message: "agent name is reserved",
+  });
 
 // ─── Request schemas ────────────────────────────────────────────────────────
 
@@ -114,7 +141,7 @@ export const ListRequestSchema = z.object({
 export const MintGrantRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("mint_grant"),
-  agent: z.string().min(1),
+  agent: AgentNameSchema,
   /** Keys this grant authorizes for READ. May be empty when `write_keys`
    * is non-empty (write-only grant). */
   keys: z.array(z.string().min(1)),
@@ -165,7 +192,7 @@ export const MintGrantRequestSchema = z.object({
 export const ListGrantsRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("list_grants"),
-  agent: z.string().optional(),
+  agent: AgentNameSchema.optional(),
   /**
    * Optional operator-passphrase attestation (#1051). Same trust
    * posture as the mint_grant attestation field (#1012 Phase 2).
@@ -226,7 +253,7 @@ export const LockRequestSchema = z.object({
 export const PreflightAccessRequestSchema = z.object({
   v: z.literal(1),
   op: z.literal("preflight_access"),
-  agent: z.string().min(1),
+  agent: AgentNameSchema,
   keys: z.array(z.string().min(1)).min(1).max(128),
 });
 


### PR DESCRIPTION
## Summary

Closes #1448. Adds a shared `AgentNameSchema` Zod validator in `src/vault/broker/protocol.ts` and applies it to every broker request field whose value reaches a filesystem path component. Validation happens at schema layer (`decodeRequest`), so a malicious or malformed `agent` is rejected before any `mkdirSync` / `writeFileSync` runs.

## Threat

`mint_grant` previously accepted any non-empty string and joined it directly into the path tree:

```ts
const tokenDir = path.join(os.homedir(), \".switchroom\", \"agents\", agent);
mkdirSync(tokenDir, { recursive: true });
writeFileSync(tokenPath, mintResult.token, { mode: 0o600 });
```

A peer with broker-IPC access could pass `agent: \"../foo\"`, `agent: \"/etc/passwd\"`, or `agent: \"operator\"` to escape the agents tree, write outside the intended dir, or shadow another identity.

## What changed

- New `AgentNameSchema` constant — kebab-case ASCII, first char alnum, 64-char cap, refined to reject `isReservedAgentName` matches (so `operator` and friends are out).
- Applied to:
  - `MintGrantRequestSchema.agent`
  - `ListGrantsRequestSchema.agent` (optional — validates only when set; \"list everything\" path unaffected)
  - `PreflightAccessRequestSchema.agent`

Charclass + cap match `src/host-control/protocol.ts`'s existing `AgentNameSchema`, which is what `allocateAgentUid` and the broader scaffold already implicitly require. Codifies what the rest of the codebase assumes.

## Out of scope

- `revoke_grant` reads slugs from the grants DB (not the wire) so it's not on the wire-validation path. Stored bad slugs from pre-fix grants could still round-trip — a one-shot defensive validation on read is worth a follow-up but doesn't gate this PR.
- `ScheduleEntrySchema.secrets[]` key regex (`^[a-zA-Z0-9_\\-/]+\$`) is permissive but operates on key names (vault keyspace), not path components — separate concern.

## Test plan

- [x] 10 new validation cases in `protocol.test.ts`:
  - Positive: `klanker`, `gymbro`, `lawgpt`, `agent-1`, `a_b_c`, 1-char names, exactly 64-char names.
  - Negative: `../escape`, `foo/../bar`, `..`, `/abs`, `/etc/passwd`, `foo/bar`, `foo bar`, `foo;bar`, `foo\\nbar`, `foo\\\\bar`, `.hidden`, `-flag`, `_under`, `operator` (reserved), empty, 65-char.
  - Cascade: same rule applies to `list_grants` (when set) and `preflight_access`. `list_grants` without `agent` still accepted.
- [x] 39/39 `protocol.test.ts` tests pass (29 existing + 10 new).
- [x] 19/19 existing mint-grant bun tests pass unchanged (passphrase-attest + posture-attest suites).
- [x] tsc --noEmit clean.

## Risk

- Existing fleets use slugs that already conform to the new regex (the scaffold's `allocateAgentUid` already implicitly requires kebab-case ASCII). No production deployment will break.
- Tests/fixtures using non-conforming agent names in `mint_grant` calls would now fail at the schema layer — grep across the suite shows none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)