### PR TITLE
sec(WS1-F1): chown account-level credentials.json + meta.json to operator UID post-write (#1447)

### DIFF
--- a/src/auth/account-store.ts
+++ b/src/auth/account-store.ts
@@ -28,6 +28,7 @@
  */
 
 import {
+  chownSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -269,6 +270,35 @@ export function writeAccountCredentials(
   validateAccountLabel(label);
   mkdirSync(accountDir(label, home), { recursive: true });
   atomicWriteJson(accountCredentialsPath(label, home), enrichClaudeCreds(value));
+}
+
+/**
+ * Chown the account dir + credentials.json + meta.json to (uid, uid).
+ * No-op for files that don't exist (so it's safe to call before either
+ * artifact has landed). Throws on EPERM — callers running under the
+ * auth-broker should catch and route through `warnCapChownMissing` so
+ * dev hosts without CAP_CHOWN stay quiet after the first warning.
+ *
+ * Threat addressed by #1447 (WS1-F1): when the auth-broker runs as
+ * root and writes account-level files, the artifacts land root:root.
+ * The operator runs Switchroom commands as a non-root UID, so a
+ * subsequent `switchroom auth list` (or any tool that reads
+ * `~/.switchroom/accounts/`) hits EACCES until manual recovery.
+ * Chowning back to the operator UID after every write makes the
+ * fix durable instead of relying on the apply-time sweep.
+ */
+export function chownAccountFiles(
+  label: string,
+  uid: number,
+  home: string = homedir(),
+): void {
+  validateAccountLabel(label);
+  const dir = accountDir(label, home);
+  if (existsSync(dir)) chownSync(dir, uid, uid);
+  const creds = accountCredentialsPath(label, home);
+  if (existsSync(creds)) chownSync(creds, uid, uid);
+  const meta = accountMetaPath(label, home);
+  if (existsSync(meta)) chownSync(meta, uid, uid);
 }
 
 /* ── Meta read/write ─────────────────────────────────────────────────── */

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -66,6 +66,7 @@ import {
   accountDir,
   accountExists,
   accountsRoot,
+  chownAccountFiles,
   enrichClaudeCreds,
   listAccounts,
   patchAccountMeta,
@@ -1102,6 +1103,11 @@ export class AuthBroker {
       socket.write(encodeError(id, "INTERNAL", (err as Error).message));
       return;
     }
+    // #1447 (WS1-F1): broker runs as root in production (auth-broker
+    // container) and the writes above leave the dir + files root:root.
+    // The operator's CLI then can't read them — chown back to the
+    // operator UID. Swallow EPERM on dev hosts that lack CAP_CHOWN.
+    this.chownAccountFilesIfRoot(label);
     // Re-index sha so a subsequent boot doesn't trip drift detection on the new file.
     const contents = readFileSync(accountCredentialsPath(label, this.home), "utf-8");
     this.shaIndex[label] = sha256Hex(contents);
@@ -1530,6 +1536,10 @@ export class AuthBroker {
       };
       const outcome = await refreshAccountIfNeeded(label, opts);
       if (outcome.kind === "refreshed") {
+        // #1447 (WS1-F1): refreshAccountIfNeeded wrote credentials.json
+        // + meta.json under the broker's UID (root in production); chown
+        // back to the operator UID so the operator CLI keeps working.
+        this.chownAccountFilesIfRoot(label);
         const creds = readAccountCredentials(label, this.home);
         const newExpiresAt = creds?.claudeAiOauth?.expiresAt ?? outcome.newExpiresAt;
         this.lastWrittenExpiresAt.set(label, newExpiresAt);
@@ -1935,6 +1945,22 @@ export class AuthBroker {
       `Per-agent mirror written but ownership not flipped. ` +
       `Suppressing further chown warnings for this process.`,
     );
+  }
+
+  /**
+   * Chown the account dir + credentials.json + meta.json to the
+   * operator UID after a broker write (#1447). No-op when operatorUid
+   * is undefined (dev path where broker runs under the operator UID
+   * already) and silently swallows EPERM on hosts without CAP_CHOWN
+   * via the same warn helper the per-agent mirror chown uses.
+   */
+  private chownAccountFilesIfRoot(label: string): void {
+    if (this.operatorUid === undefined) return;
+    try {
+      chownAccountFiles(label, this.operatorUid, this.home);
+    } catch (err) {
+      this.warnCapChownMissing(err);
+    }
   }
 
   /* ─── Config validation ─────────────────────────────────────── */

--- a/tests/auth-account-store.test.ts
+++ b/tests/auth-account-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync, writeFileSync, readdirSync } from "node:fs";
+import { mkdirSync, rmSync, statSync, writeFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -9,6 +9,7 @@ import {
   accountHealth,
   accountMetaPath,
   accountsRoot,
+  chownAccountFiles,
   getAccountInfos,
   listAccounts,
   patchAccountMeta,
@@ -465,5 +466,59 @@ describe("renameAccount", () => {
     writeAccountCredentials("legit", { claudeAiOauth: { accessToken: "x" } }, home);
     expect(() => renameAccount("../etc", "legit", home)).toThrow();
     expect(() => renameAccount("legit", "foo bar", home)).toThrow();
+  });
+});
+
+describe("chownAccountFiles (#1447)", () => {
+  it("validates the label before touching the filesystem", () => {
+    // Path-traversal labels must be rejected at the gate — never reach
+    // the chownSync calls, since accountDir(label) would otherwise
+    // interpolate the bad label.
+    expect(() => chownAccountFiles("../etc", process.getuid!(), home)).toThrow();
+    expect(() => chownAccountFiles("foo/bar", process.getuid!(), home)).toThrow();
+  });
+
+  it("is a no-op when the account dir doesn't exist", () => {
+    // Safe to call before writeAccountCredentials has landed: just
+    // returns without throwing if there's nothing to chown.
+    expect(() => chownAccountFiles("nonexistent", process.getuid!(), home)).not.toThrow();
+  });
+
+  it("chowns dir + credentials.json + meta.json to the target uid", () => {
+    // The test user owns the tmpdir, so chowning to their own UID is
+    // a permitted no-op. We verify by stat that uid matches after the
+    // call — guarding against a future refactor that forgets one of
+    // the three artifacts.
+    const me = process.getuid!();
+    writeAccountCredentials("myaccount", { claudeAiOauth: { accessToken: "x" } }, home);
+    patchAccountMeta("myaccount", { lastRefreshedAt: 1700000000000 }, home);
+
+    chownAccountFiles("myaccount", me, home);
+
+    expect(statSync(accountDir("myaccount", home)).uid).toBe(me);
+    expect(statSync(accountCredentialsPath("myaccount", home)).uid).toBe(me);
+    expect(statSync(accountMetaPath("myaccount", home)).uid).toBe(me);
+  });
+
+  it("tolerates missing meta.json (chowns dir + creds, skips meta)", () => {
+    // patchAccountMeta hasn't been called — only credentials.json exists.
+    // The function must not throw on the absent meta path.
+    const me = process.getuid!();
+    writeAccountCredentials("creds-only", { claudeAiOauth: { accessToken: "x" } }, home);
+
+    expect(() => chownAccountFiles("creds-only", me, home)).not.toThrow();
+    expect(statSync(accountDir("creds-only", home)).uid).toBe(me);
+    expect(statSync(accountCredentialsPath("creds-only", home)).uid).toBe(me);
+  });
+
+  it("throws EPERM when chown to a different uid is attempted under a non-root user (back-pressure for warnCapChownMissing)", () => {
+    // Skip if running as root — the call would actually succeed.
+    if (process.getuid!() === 0) return;
+    writeAccountCredentials("other-uid", { claudeAiOauth: { accessToken: "x" } }, home);
+    // Pick a uid that's almost certainly not the test user. nobody is
+    // commonly 65534 on Linux; if that happens to be the test user (very
+    // rare), substitute 0 (root) which the test user definitely isn't.
+    const otherUid = process.getuid!() === 65534 ? 0 : 65534;
+    expect(() => chownAccountFiles("other-uid", otherUid, home)).toThrow(/EPERM|operation not permitted/i);
   });
 });


### PR DESCRIPTION
## Summary

Closes #1447. The auth-broker runs as root in production. After it writes account-level OAuth state (`~/.switchroom/accounts/<label>/{credentials.json,meta.json}`), the artifacts land root:root and the operator's CLI hits EACCES on subsequent reads. The apply-time sweep papers over this on the next reconcile, but the durable fix is to chown at the write site.

## What changed

1. **New `chownAccountFiles(label, uid, home)` helper** in `src/auth/account-store.ts` — chowns the account dir + `credentials.json` + `meta.json` to (uid, uid). Validates the label first (so a malicious caller can't path-traverse through). Safe to call before any artifact has landed; no-op for files that don't exist. Throws on EPERM so callers can route through their own warn helper for dev hosts without CAP_CHOWN.

2. **New `chownAccountFilesIfRoot(label)`** private method on `AuthBrokerServer` — no-op when `operatorUid` is undefined (dev path, broker is the operator UID already); otherwise calls the helper and swallows EPERM via the existing one-shot `warnCapChownMissing` pattern that already covers the per-agent mirror chown.

3. **Wired into both write callsites:**
   - `opAddAccount` (`server.ts:1099`) — after `writeAccountCredentials` + `patchAccountMeta`.
   - `runRefreshTick` (`server.ts:1531`) — after the refresh helper reports `kind: \"refreshed\"`.

The dir gets chowned too (`mkdirSync({recursive: true})` inside `writeAccountCredentials` creates it root-owned when the broker is root, and the operator needs `+r` on the dir).

## Why no `writeAccountCredentials(label, uid)` extension instead

Considered adding an optional `chownUid` arg to the write helpers. Rejected: chown belongs at the broker layer because the EPERM-swallow + one-shot warn is broker-context behaviour (`logErr`, `capChownWarned` flag). Keeping the store as a passive read/write layer matches its module docstring (\"passive storage layer: validation, paths, atomic read/write\").

## Test plan

- [x] 5 new tests in `tests/auth-account-store.test.ts`:
  - Label validation rejects path-traversal before touching the FS.
  - No-op when the account dir doesn't exist.
  - Full triple-chown success path (dir + creds + meta) — verified via `statSync.uid`.
  - Missing-meta tolerance (chowns dir + creds, skips meta).
  - EPERM bubble-up for non-root callers chowning to a foreign uid (back-pressure for the broker's `warnCapChownMissing` path).
- [x] 41/41 `tests/auth-account-store.test.ts` pass.
- [x] 53/53 existing auth-broker server tests pass (the new chown is no-op when `operatorUid` is undefined, which is the test-fixture pattern).
- [x] tsc --noEmit clean.

## Risk

- Existing apply-time sweep (`restoreOperatorOwnership`) still runs and stays correct; this PR adds a parallel durable fix, doesn't remove the safety net.
- Dev hosts without CAP_CHOWN: `warnCapChownMissing` already prints one log line and suppresses further warnings, matching the existing per-agent mirror pattern.

## Pre-existing flake (not caused by this PR)

`tests/auth-heal-cli.test.ts` failed in my worktree because it requires a built `dist/cli/switchroom.js` which fresh worktrees lack. The same test passes on the main checkout where dist is present. Not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)