### PR TITLE
sec(WS3 follow-up): defend revoke_grant token-unlink against pre-fix stored slugs

### DIFF
--- a/src/vault/broker/protocol.test.ts
+++ b/src/vault/broker/protocol.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  AgentNameSchema,
   encodeRequest,
   decodeRequest,
   encodeResponse,
@@ -243,5 +244,32 @@ describe("agent-name validation on broker requests (#1448)", () => {
       keys: ["k"],
     });
     expect(() => decodeRequest(body)).toThrow();
+  });
+});
+
+// ─── AgentNameSchema direct use (#1448 follow-up) ──────────────────────────
+//
+// The schema is also used on the READ path in the revoke_grant handler
+// (defense-in-depth against pre-fix stored grants whose agent_slug
+// predates wire validation). Tests below pin the safeParse semantics
+// the handler relies on.
+
+describe("AgentNameSchema safeParse (read-path use)", () => {
+  it("returns success for canonical fleet agent names", () => {
+    for (const ok of ["klanker", "gymbro", "ziggy", "lawgpt", "carrie", "finn", "reggie", "clerk"]) {
+      expect(AgentNameSchema.safeParse(ok).success).toBe(true);
+    }
+  });
+
+  it("returns failure for path-traversal slugs (pre-fix DB rows)", () => {
+    expect(AgentNameSchema.safeParse("../escape").success).toBe(false);
+    expect(AgentNameSchema.safeParse("foo/../bar").success).toBe(false);
+    expect(AgentNameSchema.safeParse("/abs").success).toBe(false);
+    expect(AgentNameSchema.safeParse("").success).toBe(false);
+  });
+
+  it("returns failure for reserved identity names", () => {
+    expect(AgentNameSchema.safeParse("operator").success).toBe(false);
+    expect(AgentNameSchema.safeParse("hostd").success).toBe(false);
   });
 });

--- a/src/vault/broker/protocol.ts
+++ b/src/vault/broker/protocol.ts
@@ -36,8 +36,9 @@ export const MAX_FRAME_BYTES = 64 * 1024; // 64 KiB
  * Charclass + cap mirror `src/host-control/protocol.ts` AgentNameSchema
  * (kebab-case ASCII, first char alnum, 64-byte cap), which matches the
  * shape `allocateAgentUid` already implicitly requires. Reserved names
- * (e.g. `operator`) are rejected at the schema layer so the broker
- * can't be tricked into routing through an alternate identity.
+ * (`operator`, `hostd` — see RESERVED_AGENT_NAMES in peercred.ts) are
+ * rejected at the schema layer so the broker can't be tricked into
+ * routing through an alternate identity.
  */
 export const AgentNameSchema = z
   .string()

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -43,6 +43,7 @@ import {
 import { identify, socketPathToAgent, socketPathToIdentity, unlockSocketFor, type PeerInfo } from "./peercred.js";
 import { checkAcl, checkAclByAgent, checkEntryScope, agentSlugFromPeer, parseCronUnit } from "./acl.js";
 import {
+  AgentNameSchema,
   decodeRequest,
   encodeResponse,
   errorResponse,
@@ -2295,13 +2296,20 @@ export class VaultBroker {
       // Best-effort: find and remove any token file for this grant ID.
       // We don't know which agent it belonged to without querying — query the
       // revoked row (revoked_at is now set) to get the agent slug.
+      //
+      // Defense-in-depth (#1448 follow-up): re-validate the stored
+      // agent_slug against AgentNameSchema before joining it into a
+      // filesystem path. Wire validation now rejects bad slugs at write
+      // time, but the grants DB could carry pre-fix rows with
+      // path-traversal slugs. A bad row here would otherwise let an
+      // unlink escape the agents tree.
       try {
         const row = this.grantsDb
           .query<{ agent_slug: string }, [string]>(
             "SELECT agent_slug FROM vault_grants WHERE id = ?",
           )
           .get(id);
-        if (row) {
+        if (row && AgentNameSchema.safeParse(row.agent_slug).success) {
           const tokenPath = path.join(
             os.homedir(),
             ".switchroom",


### PR DESCRIPTION
## Summary

Follow-up to #1714 (mint_grant slug validation) addressing the two non-blocking items from the reviewer:

1. **Defense-in-depth on `revoke_grant` token-unlink** — re-validate the DB-stored `agent_slug` against `AgentNameSchema` before joining it into a filesystem path, so a pre-#1714 grant row carrying a path-traversal slug can't escape the agents tree on revoke.
2. **JSDoc nit** at `src/vault/broker/protocol.ts:34` — example list of reserved names now includes `hostd` alongside `operator` (both are in `RESERVED_AGENT_NAMES`).

## Why

#1714 closed the wire-validation gap, but the grants DB can still carry rows whose `agent_slug` was stored before that fix. The revoke handler joins that stored value into `~/.switchroom/agents/<agent_slug>/.vault-token` and `unlinkSync`s it. Pre-fix the slug could be anything — `../etc/passwd-shaped` → unlink resolves outside the agents tree.

Risk is small in practice:
- Outer try/catch swallows the unlink error.
- The operation is unlink-only (no write/exec escape).
- The same actor who minted the bad row had broker-IPC access to start with — and that's the threat model #1714 already mitigated for new rows.

But defense-in-depth is cheap: `AgentNameSchema.safeParse(row.agent_slug).success` gates the path-join. Poisoned rows just skip the unlink — the grant itself is still revoked at the DB level (`revokeGrant(this.grantsDb, id)` ran earlier and is unconditional). Operationally: a stale token file might remain on disk for poisoned rows, but the capability is gone.

## Test plan

- [x] 3 new tests in `protocol.test.ts` pinning `AgentNameSchema.safeParse` semantics on (a) canonical fleet names (pass), (b) path-traversal slugs (fail), (c) reserved identity names `operator` + `hostd` (fail).
- [x] 42/42 protocol tests pass.
- [x] 161/161 broker unit tests pass.
- [x] tsc --noEmit clean.

## Risk

Behaviour change is restricted to revoke calls where the stored slug is malformed — exactly the pre-fix poisoned-row case. Healthy rows pass `safeParse` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)