### PR TITLE
fix(vault-broker): pair per-agent unlock socket with each data socket

### DIFF
--- a/src/vault/broker/server-per-agent-unlock.test.ts
+++ b/src/vault/broker/server-per-agent-unlock.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Regression guard for the per-agent unlock socket.
+ *
+ * Before this fix, `bindAgentSocket` bound only the *data* socket for each
+ * per-agent listener — never a paired unlock socket. The client side
+ * (`unlockViaBroker` + `unlockSocketFor`) derives the unlock path from the
+ * data socket as `<dir>/unlock`, so an in-container `vault unlock` from an
+ * agent (the Telegram `/vault unlock` flow) failed with
+ * `ENOENT /run/switchroom/broker/unlock` even though the broker was up and
+ * the data socket was reachable.
+ *
+ * `bindOperatorListener` already pairs the sockets correctly; this test
+ * pins the equivalent contract on `bindAgentSocket`.
+ *
+ * NOTE: This file uses `bun:sqlite` transitively (via VaultBroker →
+ * grants-db.ts → bun:sqlite). It must NOT be run by vitest (excluded in
+ * vitest.config.ts) and is run via `bun test` instead (see test:bun in
+ * package.json).
+ *
+ * The canonical socket path regex in `peercred.ts` requires
+ * `/run/switchroom/broker/<name>/sock`, which we can't write to from a
+ * tmpdir-scoped test. We use `mock.module` to override `socketPathToAgent`
+ * so the test can drive `bindAgentSocket` against a tmpdir path while
+ * keeping the real `unlockSocketFor` (operates on any `/sock`-suffixed
+ * path).
+ */
+
+import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { Database } from "bun:sqlite";
+
+// Pre-import + override peercred BEFORE importing server.ts so the broker
+// picks up the patched `socketPathToAgent`. `unlockSocketFor` keeps its real
+// implementation.
+const peercredReal = await import("./peercred.js");
+mock.module("./peercred.js", () => ({
+  ...peercredReal,
+  socketPathToAgent: (socketPath: string): string | null => {
+    const m = socketPath.match(/\/([a-zA-Z0-9][a-zA-Z0-9_-]*)\/sock$/);
+    return m ? m[1] : null;
+  },
+}));
+
+const { VaultBroker } = await import("./server.js");
+const { unlockSocketFor } = await import("./peercred.js");
+const { createAuditLogger } = await import("./audit-log.js");
+const { migrateGrantsSchema } = await import("../grants.js");
+const { createVault } = await import("../vault.js");
+
+function makeInMemoryGrantsDb(): Database {
+  const db = new Database(":memory:");
+  migrateGrantsSchema(db);
+  return db;
+}
+
+function makeMinimalConfig(vaultPath: string) {
+  return {
+    switchroom: { version: 1 },
+    telegram: { bot_token: "test", forum_chat_id: "123" },
+    vault: {
+      path: vaultPath,
+      broker: { socket: "~/.switchroom/vault-broker.sock", enabled: true },
+    },
+    agents: {},
+  } as any;
+}
+
+const CORRECT_PASSPHRASE = "correct-horse-battery-staple";
+
+describe("VaultBroker bindAgentSocket: pairs data + unlock socket", () => {
+  let broker: InstanceType<typeof VaultBroker>;
+  let tmpDir: string;
+  let agentDir: string;
+  let dataSock: string;
+  let unlockSock: string;
+  let legacySock: string;
+  let vaultPath: string;
+  let auditLogPath: string;
+  let prevNonLinuxFlag: string | undefined;
+
+  beforeEach(async () => {
+    prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-pair-test-"));
+    agentDir = path.join(tmpDir, "test-agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    dataSock = path.join(agentDir, "sock");
+    unlockSock = unlockSocketFor(dataSock);
+    legacySock = path.join(tmpDir, "legacy.sock");
+    vaultPath = path.join(tmpDir, "vault.enc");
+    auditLogPath = path.join(tmpDir, "vault-audit.log");
+
+    createVault(CORRECT_PASSPHRASE, vaultPath);
+
+    broker = new VaultBroker({
+      _testConfig: makeMinimalConfig(vaultPath),
+      _testAuditLogger: createAuditLogger({ path: auditLogPath }),
+      _testGrantsDb: makeInMemoryGrantsDb(),
+      _testIdentify: () => ({
+        uid: process.getuid?.() ?? 1000,
+        pid: process.pid,
+        exe: process.execPath,
+        systemdUnit: null,
+      }),
+    });
+    await broker.start(legacySock, undefined, vaultPath);
+  });
+
+  afterEach(() => {
+    try { broker.stop(); } catch { /* ignore */ }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (prevNonLinuxFlag === undefined) {
+      delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
+    } else {
+      process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+    }
+  });
+
+  it("binds both <agent>/sock AND <agent>/unlock after bindAgentSocket", async () => {
+    const agentName = await broker.bindAgentSocket(dataSock);
+    expect(agentName).toBe("test-agent");
+
+    expect(fs.existsSync(dataSock)).toBe(true);
+    expect(fs.statSync(dataSock).isSocket()).toBe(true);
+
+    // The regression we're guarding: without the fix, this fails (ENOENT)
+    // and the documented Telegram `/vault unlock` flow stays broken.
+    expect(fs.existsSync(unlockSock)).toBe(true);
+    expect(fs.statSync(unlockSock).isSocket()).toBe(true);
+  });
+
+  it("the paired unlock socket accepts a connection (no ENOENT)", async () => {
+    await broker.bindAgentSocket(dataSock);
+
+    // Precise symptom path: agent CLI dials `unlockSocketFor(dataSock)`.
+    // Pre-fix this errored with ENOENT before any bytes flowed.
+    await new Promise<void>((resolveP, rejectP) => {
+      const c = net.createConnection({ path: unlockSock });
+      const timeout = setTimeout(() => {
+        c.destroy();
+        rejectP(new Error("timed out connecting to per-agent unlock socket"));
+      }, 2000);
+      c.on("connect", () => {
+        clearTimeout(timeout);
+        c.destroy();
+        resolveP();
+      });
+      c.on("error", (err) => {
+        clearTimeout(timeout);
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          rejectP(new Error(
+            `per-agent unlock socket missing (ENOENT) at ${unlockSock} — ` +
+            `pre-fix regression`,
+          ));
+          return;
+        }
+        rejectP(err);
+      });
+    });
+  });
+
+  it("stop() cleans up the per-agent unlock socket", async () => {
+    await broker.bindAgentSocket(dataSock);
+    expect(fs.existsSync(unlockSock)).toBe(true);
+
+    broker.stop();
+    expect(fs.existsSync(unlockSock)).toBe(false);
+    expect(fs.existsSync(dataSock)).toBe(false);
+  });
+});

--- a/src/vault/broker/server-per-agent-unlock.test.ts
+++ b/src/vault/broker/server-per-agent-unlock.test.ts
@@ -80,12 +80,19 @@ describe("VaultBroker bindAgentSocket: pairs data + unlock socket", () => {
   let vaultPath: string;
   let auditLogPath: string;
   let prevNonLinuxFlag: string | undefined;
+  let prevHome: string | undefined;
 
   beforeEach(async () => {
     prevNonLinuxFlag = process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
     process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = "1";
 
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "broker-pair-test-"));
+    // Hermeticity: redirect HOME to the tmpdir BEFORE any broker code path
+    // resolves `~/.switchroom/...`. See CLAUDE.md "Vault & shared-state
+    // test discipline" — without this the test corrupts the operator's
+    // live vault on a production-treated host.
+    prevHome = process.env.HOME;
+    process.env.HOME = tmpDir;
     agentDir = path.join(tmpDir, "test-agent");
     fs.mkdirSync(agentDir, { recursive: true });
     dataSock = path.join(agentDir, "sock");
@@ -117,6 +124,11 @@ describe("VaultBroker bindAgentSocket: pairs data + unlock socket", () => {
       delete process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX;
     } else {
       process.env.SWITCHROOM_BROKER_ALLOW_NON_LINUX = prevNonLinuxFlag;
+    }
+    if (prevHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = prevHome;
     }
   });
 

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -565,19 +565,54 @@ export class VaultBroker {
         // (still-root-owned) parent dir to create the socket node.
         // Errors swallowed for non-docker dev/test runs where CAP_CHOWN
         // isn't held (callers run as the same UID as agents).
+        let agentUid: number | null = null;
         try {
-          const uid = allocateAgentUid(agentName);
-          try { chownSync(abs, uid, uid); } catch { /* see above */ }
+          agentUid = allocateAgentUid(agentName);
+          try { chownSync(abs, agentUid, agentUid); } catch { /* see above */ }
           if (abs.endsWith("/sock")) {
             const dir = abs.slice(0, -"/sock".length);
-            try { chownSync(dir, uid, uid); } catch { /* see above */ }
+            try { chownSync(dir, agentUid, agentUid); } catch { /* see above */ }
           }
         } catch {
           // allocateAgentUid is deterministic and pure; swallow only to
           // protect the listen() callback from any unexpected throw.
         }
         this.agentServers.set(abs, { server, agentName });
-        resolveP(agentName);
+
+        // Pair an unlock listener at the canonical sibling path
+        // (`<dir>/unlock` for subdir shape, `<name>.unlock.sock` for
+        // flat shape — `unlockSocketFor` is the single source of truth
+        // shared with the client). Without this, an in-container
+        // `vault unlock` from the agent (e.g. Telegram `/vault unlock`)
+        // gets ENOENT: the client derives the unlock path from the
+        // data socket but the broker would never have bound it. The
+        // operator listener (`bindOperatorListener`) already pairs the
+        // sockets this way; we mirror that here for per-agent peers.
+        // peercred stays ON (the operator-only carve-out from #1561
+        // does not apply — agents must still verify).
+        const unlockAbs = unlockSocketFor(abs);
+        if (existsSync(unlockAbs)) {
+          try { unlinkSync(unlockAbs); } catch { /* tolerate */ }
+        }
+        const unlockServer = net.createServer((sock) => {
+          this._handleUnlockConnection(sock, false);
+        });
+        unlockServer.on("error", (err) => {
+          // Tear down the data listener so the broker doesn't drift
+          // into a half-bound state (data up, unlock down) where the
+          // documented `/vault unlock` flow keeps failing silently.
+          try { server.close(); } catch { /* ignore */ }
+          this.agentServers.delete(abs);
+          rejectP(err);
+        });
+        unlockServer.listen(unlockAbs, () => {
+          try { chmodSync(unlockAbs, 0o660); } catch { /* ignore */ }
+          if (agentUid !== null) {
+            try { chownSync(unlockAbs, agentUid, agentUid); } catch { /* dev/no CAP_CHOWN */ }
+          }
+          this.agentServers.set(unlockAbs, { server: unlockServer, agentName });
+          resolveP(agentName);
+        });
       });
     });
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -104,6 +104,7 @@ export default defineConfig({
       "**/src/vault/broker/server-mint-grant-posture-attest.test.ts",
       "**/src/vault/broker/client-token.test.ts",
       "**/src/vault/broker/server-unlock.test.ts",
+      "**/src/vault/broker/server-per-agent-unlock.test.ts",
       "**/src/vault/broker/auto-unlock.test.ts",
       // RFC E drive disconnect tests use bun's `mock()` primitive — run
       // via test:bun. The other Phase 1a/1b/1c drive tests use no bun-


### PR DESCRIPTION
## Summary

`bindAgentSocket()` bound only the per-agent **data** socket. The client (`unlockViaBroker` → `unlockSocketFor(dataSocketPath)`) derives the unlock path as `<dir>/unlock`, but the broker never created a listener there — so an in-container `vault unlock` from any agent (the Telegram `/vault unlock` flow documented in CLAUDE.md) failed with `ENOENT /run/switchroom/broker/unlock` even when the broker was up and the data socket was reachable.

`bindOperatorListener` already pairs the sockets correctly. Mirror that pattern in `bindAgentSocket`.

## Why

The documented `/vault unlock` flow from any agent's Telegram chat has been **structurally non-functional since v0.7** — every per-agent peer that tried it hit ENOENT, and only the host-shell route (`switchroom vault broker unlock` against the operator socket pair) and the auto-unlock blob actually worked. Surfaced today (2026-05-24) when the operator hit it from klanker.

## What

`src/vault/broker/server.ts`
- After binding the per-agent data socket and chowning to the agent UID, bind a paired unlock listener at `unlockSocketFor(abs)`, chown the same way, and register both entries in `agentServers` so `stop()` cleans them up.
- Peercred stays ON for agent unlock — the operator-only peercred bypass added in #1561 does not apply.
- On bind failure for the unlock pair, tear down the data listener too so the broker can't drift into a half-bound state.

`src/vault/broker/server-per-agent-unlock.test.ts` (new, bun:test)
- Drives `bindAgentSocket` against a tmpdir path via `mock.module` of `socketPathToAgent` (the canonical regex requires `/run/switchroom/broker/...`).
- Asserts both sockets exist + are sockets.
- Asserts connection to the unlock socket no longer ENOENTs (the precise pre-fix symptom).
- Asserts `stop()` unlinks both files.

`vitest.config.ts`
- Excludes the new bun:test file from the vitest pass (transitive `bun:sqlite` via grants-db).

## Test plan

- [x] `bun test src/vault/broker/server-per-agent-unlock.test.ts` — 3 pass
- [x] `bun test src/vault/broker/server.test.ts src/vault/broker/server-unlock.test.ts` — 40 pass (no regression)
- [x] `./node_modules/.bin/vitest run src/vault/broker/` — 161 pass
- [x] `./node_modules/.bin/tsc --noEmit` — clean
- [x] `bash scripts/check-bot-api-wrapping.sh` — clean
- [ ] After merge + image publish: recreate `switchroom-vault-broker` on the test-harness host, run UAT `jtbd-*` suite, manually `/vault unlock` from a Telegram DM against a fresh-locked broker

## Risk

Low. The new bind logic mirrors `bindOperatorListener` (well-trodden, #1561). The unlock handler (`_handleUnlockConnection(sock, false)`) is the same path the legacy single-socket unlock has always used. The shutdown path already walks `agentServers` so new entries are cleaned up automatically.

**Rollout:** vault-broker container needs to recreate to re-run `bindAgentSocket` per agent. Agent containers do NOT need to restart — they'll dial the new socket on next attempt.

## Workaround until rollout

`switchroom vault broker unlock` from the host shell hits the operator unlock pair, which has always been correctly bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)