### PR TITLE
feat(doctor): probe per-agent vault-broker socket pair (#1721 follow-on)

### DIFF
--- a/src/cli/doctor-vault-broker-pairs.test.ts
+++ b/src/cli/doctor-vault-broker-pairs.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for `checkVaultBrokerSocketPairs` — the operational regression
+ * guard for the per-agent unlock socket pair (PR #1721 follow-on).
+ *
+ * The original bug class: `bindAgentSocket()` bound only the data
+ * socket, never the paired unlock socket — so the documented
+ * Telegram `/vault unlock` flow failed `ENOENT` on every agent.
+ * PR #1721 fixed `bindAgentSocket()`; this probe catches it again
+ * if the volume-mount layout, the broker image, or `switchroom apply`
+ * ever drifts a half-bound state back into the fleet.
+ *
+ * We inject the per-agent probe so the test exercises only the
+ * aggregation + verdict shape — the real `probeVaultBrokerSocketPair`
+ * is exercised by the live broker container, not in unit tests.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  checkVaultBrokerSocketPairs,
+  type PerAgentSocketPairState,
+} from "./doctor.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+function cfg(agentNames: string[]): SwitchroomConfig {
+  const agents: Record<string, unknown> = {};
+  for (const n of agentNames) agents[n] = {};
+  return { agents } as unknown as SwitchroomConfig;
+}
+
+function probeFrom(
+  states: Record<string, PerAgentSocketPairState>,
+): (name: string) => PerAgentSocketPairState {
+  return (name: string) => states[name] ?? "unreachable";
+}
+
+describe("checkVaultBrokerSocketPairs", () => {
+  it("ok: all agents have both sockets bound", () => {
+    const r = checkVaultBrokerSocketPairs(cfg(["clerk", "ziggy", "carrie"]), {
+      probe: probeFrom({ clerk: "ok", ziggy: "ok", carrie: "ok" }),
+    });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("3/3");
+  });
+
+  it("fail: one agent missing unlock half — the precise pre-fix bug class", () => {
+    const r = checkVaultBrokerSocketPairs(cfg(["clerk", "ziggy"]), {
+      probe: probeFrom({ clerk: "ok", ziggy: "missing-unlock" }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("1/2");
+    expect(r.detail).toContain("unlock missing: ziggy");
+    // Operator-facing diagnostic must name the symptom they'll see.
+    expect(r.detail).toContain("ENOENT");
+    expect(r.fix).toContain("#1721");
+  });
+
+  it("fail: missing unlock on multiple agents — names listed in stable order", () => {
+    const r = checkVaultBrokerSocketPairs(cfg(["zeta", "alpha", "mike"]), {
+      probe: probeFrom({
+        zeta: "missing-unlock",
+        alpha: "missing-unlock",
+        mike: "ok",
+      }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("unlock missing: alpha, zeta");
+  });
+
+  it("fail: missing data half (different bug class — broker bound nothing)", () => {
+    const r = checkVaultBrokerSocketPairs(cfg(["clerk"]), {
+      probe: probeFrom({ clerk: "missing-data" }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("data missing: clerk");
+  });
+
+  it("fail: missing both — compose mount not present at all", () => {
+    const r = checkVaultBrokerSocketPairs(cfg(["clerk"]), {
+      probe: probeFrom({ clerk: "missing-both" }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("both missing: clerk");
+  });
+
+  it("skip: all agents unreachable — broker container itself is down", () => {
+    const r = checkVaultBrokerSocketPairs(cfg(["clerk", "ziggy"]), {
+      probe: probeFrom({ clerk: "unreachable", ziggy: "unreachable" }),
+    });
+    // Don't N-row spam an operator when the broker is just down.
+    expect(r.status).toBe("skip");
+    expect(r.detail).toContain("unreachable");
+  });
+
+  it("fail: partial unreachable (mid-restart) does NOT collapse to skip", () => {
+    // If only some agents probe as unreachable while others are healthy,
+    // that's a real divergence the operator needs to see — not the
+    // "broker is down" blanket skip.
+    const r = checkVaultBrokerSocketPairs(cfg(["clerk", "ziggy"]), {
+      probe: probeFrom({ clerk: "ok", ziggy: "unreachable" }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("unreachable: ziggy");
+  });
+
+  it("ok: empty fleet (no agents declared)", () => {
+    const r = checkVaultBrokerSocketPairs(cfg([]), { probe: () => "ok" });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("no agents configured");
+  });
+
+  it("groups the diagnostic so each bug class is surfaced once", () => {
+    const r = checkVaultBrokerSocketPairs(
+      cfg(["a", "b", "c", "d", "e"]),
+      {
+        probe: probeFrom({
+          a: "ok",
+          b: "missing-unlock",
+          c: "missing-data",
+          d: "missing-both",
+          e: "missing-unlock",
+        }),
+      },
+    );
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("1/5");
+    expect(r.detail).toContain("unlock missing: b, e");
+    expect(r.detail).toContain("data missing: c");
+    expect(r.detail).toContain("both missing: d");
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -493,6 +493,158 @@ export function checkLegacyState(): CheckResult[] {
   return results;
 }
 
+/**
+ * Probe the vault-broker container for the per-agent socket *pair* —
+ * both `<dir>/sock` (data) AND `<dir>/unlock`. Mirrors
+ * `probeAuthBrokerSocket` for the sibling auth-broker.
+ *
+ * The unlock half historically went unbound by `bindAgentSocket()` —
+ * the documented Telegram `/vault unlock` flow returned
+ * `ENOENT /run/switchroom/broker/unlock` because the broker only paired
+ * data + unlock for the *operator* listener, never for per-agent
+ * peers. PR #1721 fixed `bindAgentSocket` itself; this probe is the
+ * operational regression guard. Volume-mount config drift, an out-of-
+ * date broker image, or an `apply` that didn't reconcile would all
+ * surface as a missing unlock half without this probe.
+ *
+ * Return values per agent:
+ *   - "ok"             — both sock + unlock are bound
+ *   - "missing-unlock" — data present, unlock absent (the original bug)
+ *   - "missing-data"   — data absent (agent never bound)
+ *   - "missing-both"   — neither bound (compose mount missing)
+ *   - "unreachable"    — broker container not running / docker unavailable
+ *
+ * @internal exported for testing
+ */
+export type PerAgentSocketPairState =
+  | "ok"
+  | "missing-unlock"
+  | "missing-data"
+  | "missing-both"
+  | "unreachable";
+
+export function probeVaultBrokerSocketPair(
+  agentName: string,
+): PerAgentSocketPairState {
+  const dataPath = `/run/switchroom/broker/${agentName}/sock`;
+  const unlockPath = `/run/switchroom/broker/${agentName}/unlock`;
+  // Single `docker exec` that prints `D=<0|1> U=<0|1>` so we avoid the
+  // 4× docker exec cost (~300ms each) per agent. `test -S` exits 0 when
+  // the path is a socket, non-zero otherwise.
+  const script =
+    `D=0; U=0; ` +
+    `test -S '${dataPath}' && D=1; ` +
+    `test -S '${unlockPath}' && U=1; ` +
+    `echo "D=$D U=$U"`;
+  const r = spawnSync(
+    "docker",
+    ["exec", "switchroom-vault-broker", "sh", "-c", script],
+    { stdio: "pipe", timeout: 3000 },
+  );
+  if (r.error || r.status === null) return "unreachable";
+  if (r.status !== 0) {
+    // Non-zero from `sh -c` itself (vs the inner `test`s) → docker
+    // couldn't reach the container (no such container, daemon down, etc).
+    if (r.status >= 125) return "unreachable";
+    // Unknown shell failure — treat conservatively as unreachable so we
+    // don't false-alarm the operator with a "missing" verdict.
+    return "unreachable";
+  }
+  const out = r.stdout.toString();
+  const dOk = /D=1/.test(out);
+  const uOk = /U=1/.test(out);
+  if (dOk && uOk) return "ok";
+  if (dOk && !uOk) return "missing-unlock";
+  if (!dOk && uOk) return "missing-data";
+  return "missing-both";
+}
+
+/**
+ * Aggregate per-agent socket-pair states into a single doctor row.
+ *
+ * Fleet-scale rationale: agents typically come in 5-15 per host. One
+ * row per agent would clobber doctor output. Group the verdict and
+ * point the operator at the specific agents that are off.
+ *
+ * @internal exported for testing
+ */
+export function checkVaultBrokerSocketPairs(
+  config: SwitchroomConfig,
+  opts?: { probe?: (agentName: string) => PerAgentSocketPairState },
+): CheckResult {
+  const agentNames = Object.keys(config.agents ?? {}).sort();
+  if (agentNames.length === 0) {
+    return {
+      name: "vault-broker per-agent socket pairs",
+      status: "ok",
+      detail: "no agents configured",
+    };
+  }
+  const probe = opts?.probe ?? probeVaultBrokerSocketPair;
+  const states = new Map<string, PerAgentSocketPairState>();
+  for (const name of agentNames) {
+    states.set(name, probe(name));
+  }
+  // All unreachable → broker container not running. One honest skip row,
+  // not N "missing" rows.
+  const allUnreachable = [...states.values()].every((s) => s === "unreachable");
+  if (allUnreachable) {
+    return {
+      name: "vault-broker per-agent socket pairs",
+      status: "skip",
+      detail:
+        "vault-broker container unreachable — couldn't probe per-agent socket pairs",
+      fix: "Check the vault-broker service health row above; `switchroom update` brings it back",
+    };
+  }
+  const groups: Record<Exclude<PerAgentSocketPairState, "ok">, string[]> = {
+    "missing-unlock": [],
+    "missing-data": [],
+    "missing-both": [],
+    "unreachable": [],
+  };
+  let okCount = 0;
+  for (const [name, state] of states) {
+    if (state === "ok") {
+      okCount++;
+    } else {
+      groups[state].push(name);
+    }
+  }
+  if (okCount === agentNames.length) {
+    return {
+      name: "vault-broker per-agent socket pairs",
+      status: "ok",
+      detail: `${okCount}/${agentNames.length} agents: data + unlock sockets bound`,
+    };
+  }
+  const parts: string[] = [];
+  if (groups["missing-unlock"].length > 0) {
+    parts.push(
+      `unlock missing: ${groups["missing-unlock"].join(", ")} ` +
+      `(the documented Telegram /vault unlock flow fails ENOENT for these)`,
+    );
+  }
+  if (groups["missing-data"].length > 0) {
+    parts.push(`data missing: ${groups["missing-data"].join(", ")}`);
+  }
+  if (groups["missing-both"].length > 0) {
+    parts.push(`both missing: ${groups["missing-both"].join(", ")}`);
+  }
+  if (groups["unreachable"].length > 0) {
+    parts.push(`unreachable: ${groups["unreachable"].join(", ")}`);
+  }
+  return {
+    name: "vault-broker per-agent socket pairs",
+    status: "fail",
+    detail: `${okCount}/${agentNames.length} ok — ${parts.join("; ")}`,
+    fix:
+      "Run `switchroom update` (or `switchroom apply` then recreate the " +
+      "vault-broker container). If only the unlock half is missing, the " +
+      "broker image predates PR #1721 — pull the latest image.",
+  };
+}
+
 function checkVault(config: SwitchroomConfig): CheckResult[] {
   const vaultPath = config.vault?.path
     ? config.vault.path.replace(/^~/, process.env.HOME ?? "")
@@ -524,6 +676,8 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
           detail: "Approval auth: passphrase (two-factor)",
         };
 
+  const pairsResult = checkVaultBrokerSocketPairs(config);
+
   if (!existsSync(vaultPath)) {
     return [
       postureResult,
@@ -533,6 +687,7 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
         detail: `${vaultPath} not found`,
         fix: "Run `switchroom vault init` if you plan to store secrets in the vault",
       },
+      pairsResult,
     ];
   }
 
@@ -551,6 +706,7 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
         detail: "SWITCHROOM_VAULT_PASSPHRASE not set; cannot verify decrypt",
         fix: "Export SWITCHROOM_VAULT_PASSPHRASE to verify the vault unlocks",
       },
+      pairsResult,
     ];
   }
 
@@ -563,6 +719,7 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
         status: "ok",
         detail: `${keys.length} secret(s)`,
       },
+      pairsResult,
     ];
   } catch (err) {
     return [
@@ -573,6 +730,7 @@ function checkVault(config: SwitchroomConfig): CheckResult[] {
         detail: (err as Error).message,
         fix: "SWITCHROOM_VAULT_PASSPHRASE is wrong, or the vault file is corrupted",
       },
+      pairsResult,
     ];
   }
 }


### PR DESCRIPTION
## Summary

Operational regression guard for the per-agent unlock socket pair shipped in #1721. The unit test in that PR pins `bindAgentSocket()` itself; this doctor row catches the **deployment** regression class — broker image rolled back, compose volume mounts drifted, `apply` skipped the reconcile — that the unit test can't see.

Originally landed alongside #1721 but auto-merge fired on CI-green before this commit was pushed (the `feedback_automerge_after_review` pattern); cherry-picked onto a fresh branch.

## Why

Symptom from the live host on 2026-05-24: `vault unlock failed: Broker unreachable: connect ENOENT /run/switchroom/broker/unlock` from inside the klanker container. Root cause was the per-agent unlock socket never being bound (fixed by #1721). Doctor had no probe for it — so the half-bound state was invisible until an operator tried `/vault unlock` and got ENOENT.

## What

- `src/cli/doctor.ts` adds two exports:
  - `probeVaultBrokerSocketPair(agentName)` — single `docker exec switchroom-vault-broker sh -c "test -S <sock> && test -S <unlock>"`; returns `ok | missing-unlock | missing-data | missing-both | unreachable`. Mirrors `probeAuthBrokerSocket` for the sibling auth-broker.
  - `checkVaultBrokerSocketPairs(config, opts?)` — aggregates per-agent verdicts into one CheckResult. Wired into `checkVault()` so it surfaces in the "Vault" doctor section. Single row for a fleet of 9+ agents (no N-row spam).
- `src/cli/doctor-vault-broker-pairs.test.ts` — 9 vitest cases pinning each verdict shape with an injected probe.

Verdict shapes:
- `ok` — all agents have both halves bound
- `fail (unlock)` — the precise pre-#1721 bug class; detail includes "ENOENT" so the operator pattern-matches the symptom they'd see
- `fail (data/both)` — different bug classes
- `skip` — broker container unreachable; one honest skip instead of N "missing" rows
- partial-unreachable correctly stays in `fail` (mid-restart visibility)

## Test plan

- [x] `vitest run src/cli/doctor-vault-broker-pairs.test.ts` — 9/9 pass
- [x] `vitest run src/cli/doctor*` — 57/57 pass (no regression in sibling doctor tests)
- [x] `tsc --noEmit` — clean
- [x] `check-vault-test-hermeticity` — clean
- [x] `check-bot-api-wrapping.sh` — clean

## Risk

Low. New code path on the read-only doctor probe surface. `checkVault()` now adds N docker-exec probes (3s timeout each), so a worst-case unreachable broker = ~27s of blocking on a 9-agent fleet — bounded by the per-agent timeout. Matches the established `probeAuthBrokerSocket` shape.

## Forward-looking nit (out of scope, prior reviewer flagged)

Could collapse to a single fleet-wide `docker exec ... ls` instead of N per-agent execs. Current shape mirrors the auth-broker sibling for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)