### PR TITLE
fix(#1719): deterministic spoolId for subagent_handback envelopes

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -15796,6 +15796,10 @@ void (async () => {
                   ownerChatId: loadAccess().allowFrom[0] ?? '',
                   taskDescription: description,
                   resultText,
+                  // Plumb the JSONL agent id so the spool can mint a
+                  // deterministic dedup key — closes the #1719
+                  // re-fire-on-restart class.
+                  jsonlAgentId: agentId,
                 })
                 if (!decision.deliver) {
                   if (decision.reason === 'no-chat') {

--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -49,6 +49,20 @@ import type { InboundMessage } from './ipc-protocol.js'
  *  synthetics of the SAME logical event dedup, but distinct events
  *  (different ts) do not collapse. */
 export function spoolId(msg: InboundMessage): string {
+  // Subagent handbacks (#1719): the JSONL agent id is unique per
+  // Claude Code spawn, so use it as the dedup key. This makes the id
+  // stable across the watcher's onFinish race AND across a
+  // gateway/container restart — so a re-built handback envelope for
+  // the same finished sub-agent collapses against the live spool
+  // entry (or its tombstone) instead of minting a fresh ts-derived
+  // id and re-firing the turn. See issue #1719.
+  if (
+    msg.meta?.source === 'subagent_handback' &&
+    typeof msg.meta?.subagent_jsonl_id === 'string' &&
+    msg.meta.subagent_jsonl_id.length > 0
+  ) {
+    return `s:handback:${msg.meta.subagent_jsonl_id}`
+  }
   if (typeof msg.messageId === 'number' && msg.messageId > 0) {
     return `m:${msg.chatId}:${msg.messageId}`
   }

--- a/telegram-plugin/gateway/subagent-handback-inbound-builder.ts
+++ b/telegram-plugin/gateway/subagent-handback-inbound-builder.ts
@@ -48,6 +48,14 @@ export interface SubagentHandbackContext {
   resultText: string
   /** Terminal outcome as classified by the watcher. */
   outcome: 'completed' | 'failed'
+  /** JSONL filename stem for this Claude Code spawn — unique per
+   *  sub-agent run. Plumbed into `meta.subagent_jsonl_id` so the
+   *  spool can mint a deterministic dedup id (`s:handback:<id>`),
+   *  closing the #1719 re-fire-on-restart class. Optional only for
+   *  back-compat with older builder callers — when present the
+   *  spoolId branch fires, when absent the spool falls back to the
+   *  legacy ts-based id (status-quo behaviour). */
+  jsonlAgentId?: string
 }
 
 function truncate(s: string, max: number): string {
@@ -98,6 +106,7 @@ export function buildSubagentHandbackInbound(opts: {
     meta: {
       source: 'subagent_handback',
       outcome: opts.ctx.outcome,
+      ...(opts.ctx.jsonlAgentId ? { subagent_jsonl_id: opts.ctx.jsonlAgentId } : {}),
     },
   }
 }
@@ -128,6 +137,10 @@ export interface SubagentHandbackDecisionInput {
   ownerChatId: string
   taskDescription: string
   resultText: string
+  /** JSONL filename stem for this Claude Code spawn — forwarded into
+   *  the built inbound's `meta.subagent_jsonl_id`. See
+   *  `SubagentHandbackContext.jsonlAgentId` for the dedup rationale. */
+  jsonlAgentId?: string
   /** Deterministic clock for tests. */
   nowMs?: number
 }
@@ -178,6 +191,7 @@ export function decideSubagentHandback(
       taskDescription: input.taskDescription,
       resultText: input.resultText,
       outcome: input.outcome,
+      ...(input.jsonlAgentId ? { jsonlAgentId: input.jsonlAgentId } : {}),
     },
     ...(input.nowMs !== undefined ? { nowMs: input.nowMs } : {}),
   })

--- a/telegram-plugin/tests/inbound-spool.test.ts
+++ b/telegram-plugin/tests/inbound-spool.test.ts
@@ -67,6 +67,68 @@ describe('spoolId — stable dedup key', () => {
     const b = spoolId(msg({ messageId: 0, meta: { source: 'cron' }, ts: 100 }))
     expect(a).toBe(b)
   })
+  // #1719: a subagent_handback envelope carries the JSONL agent id, and
+  // spoolId() keys on it — so a re-built envelope for the same finished
+  // sub-agent (different Date.now()-derived ts/messageId across a
+  // restart or the onFinish race) collapses to one spool entry instead
+  // of re-firing the handback turn.
+  it('subagent_handback → s:handback:<jsonl_agent_id>, stable across ts', () => {
+    const a = spoolId(
+      msg({
+        messageId: 1700_000_000_000,
+        ts: 1700_000_000_000,
+        meta: { source: 'subagent_handback', subagent_jsonl_id: 'abc-123' },
+      }),
+    )
+    const b = spoolId(
+      msg({
+        messageId: 1700_000_999_999,
+        ts: 1700_000_999_999,
+        meta: { source: 'subagent_handback', subagent_jsonl_id: 'abc-123' },
+      }),
+    )
+    expect(a).toBe('s:handback:abc-123')
+    expect(b).toBe(a) // stable across Date.now() drift / restart re-build
+  })
+  it('subagent_handback for distinct sub-agents stays distinct', () => {
+    const a = spoolId(
+      msg({ messageId: 0, meta: { source: 'subagent_handback', subagent_jsonl_id: 'a' } }),
+    )
+    const b = spoolId(
+      msg({ messageId: 0, meta: { source: 'subagent_handback', subagent_jsonl_id: 'b' } }),
+    )
+    expect(a).not.toBe(b)
+  })
+  it('subagent_handback without jsonl id falls back to legacy id (back-compat)', () => {
+    const a = spoolId(
+      msg({ messageId: 555, meta: { source: 'subagent_handback' }, ts: 100 }),
+    )
+    // messageId > 0 → legacy m:<chat>:<msgId> still wins.
+    expect(a).toBe('m:c1:555')
+  })
+})
+
+describe('inbound-spool — subagent_handback dedup across restart re-build (#1719)', () => {
+  it('two handback envelopes for the same jsonl id collapse to one live entry', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs })
+    const first = msg({
+      messageId: 1700_000_000_000,
+      ts: 1700_000_000_000,
+      meta: { source: 'subagent_handback', subagent_jsonl_id: 'jsonl-xyz' },
+    })
+    // Simulates a second onFinish (or boot-replay re-build) for the
+    // same sub-agent. Different ts / messageId — same jsonl id.
+    const second = msg({
+      messageId: 1700_000_999_999,
+      ts: 1700_000_999_999,
+      meta: { source: 'subagent_handback', subagent_jsonl_id: 'jsonl-xyz' },
+    })
+    expect(s.put('worker', first)).toBe(true)
+    expect(s.put('worker', second)).toBe(false) // deduped, no re-fire
+    expect(s.liveCount()).toBe(1)
+    expect(s.liveEntries()).toHaveLength(1)
+  })
 })
 
 describe('inbound-spool — put / ack / dedup', () => {

--- a/telegram-plugin/tests/subagent-handback-inbound-builder.test.ts
+++ b/telegram-plugin/tests/subagent-handback-inbound-builder.test.ts
@@ -95,6 +95,28 @@ describe('buildSubagentHandbackInbound', () => {
     expect(inbound.text).toContain('…')
   })
 
+  it('carries meta.subagent_jsonl_id when jsonlAgentId is provided (#1719 dedup key)', () => {
+    const inbound = buildSubagentHandbackInbound({
+      ctx: {
+        chatId: '12345',
+        taskDescription: 'x',
+        resultText: 'y',
+        outcome: 'completed',
+        jsonlAgentId: 'jsonl-xyz',
+      },
+      nowMs: FIXED_NOW,
+    })
+    expect(inbound.meta.subagent_jsonl_id).toBe('jsonl-xyz')
+  })
+
+  it('omits meta.subagent_jsonl_id when jsonlAgentId is not provided (back-compat)', () => {
+    const inbound = buildSubagentHandbackInbound({
+      ctx: { chatId: '12345', taskDescription: 'x', resultText: 'y', outcome: 'completed' },
+      nowMs: FIXED_NOW,
+    })
+    expect(inbound.meta.subagent_jsonl_id).toBeUndefined()
+  })
+
   it('falls back to a placeholder when the description is blank', () => {
     const inbound = buildSubagentHandbackInbound({
       ctx: { chatId: '99', taskDescription: '   ', resultText: 'x', outcome: 'completed' },


### PR DESCRIPTION
## Summary

- **Root cause:** the synthetic `subagent_handback` inbound was built with `messageId: Date.now()`, so `spoolId()` minted a fresh id every call (real `m:<chat>:<msgId>` or synthetic fallback `s:<chat>:source:ts`). A re-built envelope for the same finished sub-agent — whether from the `onFinish` race in `subagent-watcher.ts` or a gateway/container restart re-running the watcher path — produced a NEW spoolId. `InboundSpool.put`'s idempotency-by-id could not collapse the duplicate, and the handback turn re-fired.
- **Fix (one layer, no DB ledger, no schema change):** plumb the JSONL agent id (unique per Claude Code spawn) through `SubagentHandbackContext.jsonlAgentId` → `meta.subagent_jsonl_id` on the built inbound. Branch `spoolId()` to return `s:handback:<jsonl_agent_id>` for `subagent_handback` envelopes carrying that meta key. Falls through to legacy logic otherwise (back-compat for any in-flight pre-fix envelopes).
- **Scope:** ~32 LOC of production change across `subagent-handback-inbound-builder.ts`, `inbound-spool.ts`, `gateway.ts`. Foreground sub-agents are untouched (gated upstream by `decideSubagentHandback` returning `foreground` skip).

Architectural rationale matches the refinement comment on #1719: the spool is the durable boundary; making the id deterministic by the natural per-spawn key closes the re-fire class without a second dedup layer racing the spool.

## Test plan

- [x] \`bun x tsc --noEmit\` clean
- [x] 37/37 pass: \`inbound-spool.test.ts\`, \`subagent-handback-inbound-builder.test.ts\`, \`subagent-handback-decision.test.ts\`
- [x] New cases in \`inbound-spool.test.ts\`: spoolId stable for same \`jsonl_agent_id\` across different \`ts\`/\`messageId\`; distinct sub-agents stay distinct; legacy back-compat fallback when \`subagent_jsonl_id\` absent; full \`put\`+\`put\` dedup proving two envelopes for the same jsonl id collapse to one live entry.
- [x] New cases in \`subagent-handback-inbound-builder.test.ts\`: built envelope carries \`meta.subagent_jsonl_id\` when provided, omits it when not.

Closes #1719

🤖 Generated with [Claude Code](https://claude.com/claude-code)