### PR TITLE
feat(#1720): deterministic progress-pacing envelopes for background sub-agents

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -288,6 +288,10 @@ import {
   buildVaultSaveDiscardedInbound,
 } from './vault-grant-inbound-builders.js'
 import { decideSubagentHandback } from './subagent-handback-inbound-builder.js'
+import {
+  decideSubagentProgress,
+  DEFAULT_PROGRESS_INTERVAL_MS,
+} from './subagent-progress-inbound-builder.js'
 import { createPollHealthCheck, type PollHealthCheckHandle } from './poll-health.js'
 import type {
   ToolCallMessage,
@@ -15857,6 +15861,28 @@ void (async () => {
                   return
                 }
 
+                // #1720: when the handback is queued, sweep any still-
+                // live progress envelopes for the SAME sub-agent out of
+                // the spool. Without this a progress envelope queued
+                // moments before the worker finished could land on top
+                // of the handback turn, producing a duplicated /
+                // contradictory "still running" line. Prefix match on
+                // `s:progress:<jsonl_agent_id>:` — see `inbound-spool.ts`
+                // spoolId branch.
+                try {
+                  const progressPrefix = `s:progress:${agentId}:`
+                  const dropped = inboundSpool?.dropMatching((id) => id.startsWith(progressPrefix)) ?? 0
+                  if (dropped > 0) {
+                    process.stderr.write(
+                      `telegram gateway: subagent-handback ${agentId} swept ${dropped} live progress envelope(s) from spool\n`,
+                    )
+                  }
+                } catch (err) {
+                  process.stderr.write(
+                    `telegram gateway: subagent-handback ${agentId} progress-sweep error: ${(err as Error).message}\n`,
+                  )
+                }
+
                 // Deliver via pendingInboundBuffer + the idle-drain tick.
                 // The drain only releases at an idle prompt (no active
                 // turn), so the handback always lands as a clean fresh
@@ -15864,6 +15890,60 @@ void (async () => {
                 pendingInboundBuffer.push(process.env.SWITCHROOM_AGENT_NAME ?? '', decision.inbound)
                 process.stderr.write(
                   `telegram gateway: subagent-handback queued agent=${agentId} outcome=${outcome} chat=${decision.chatId} resultChars=${resultText.length}\n`,
+                )
+              },
+              // conversational-pacing beat 3 — mid-flight progress for
+              // background workers (#1720). Fires on every
+              // `sub_agent_text` event; the pure `decideSubagentProgress`
+              // gates on (a) background flag, (b) bucket-not-yet-fired
+              // (deterministic `floor(elapsed / interval)`), (c) chat
+              // resolves. Envelope spoolId is
+              // `s:progress:<jsonl_agent_id>:<bucketIdx>` so a re-fire
+              // within the same bucket — or across a gateway restart —
+              // collapses to one live entry. TTL on `meta.expiresAt`
+              // suppresses stale-after-restart delivery (a 4-h-old
+              // "still working (5m)" would be a lie). Sweep on handback
+              // lives in the `onFinish` block just above.
+              onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx }) => {
+                let fleetChatId = ''
+                let isBackground = false
+                try {
+                  const fleets = progressDriver?.peekAllFleets() ?? []
+                  for (const f of fleets) {
+                    if (f.fleet.has(agentId)) {
+                      fleetChatId = f.chatId ?? ''
+                      break
+                    }
+                  }
+                } catch { /* peek failures non-fatal */ }
+                if (turnsDb != null) {
+                  try {
+                    const row = turnsDb
+                      .prepare('SELECT background FROM subagents WHERE jsonl_agent_id = ?')
+                      .get(agentId) as { background: number } | undefined
+                    if (row != null) isBackground = row.background === 1
+                  } catch { /* best-effort */ }
+                }
+                if (!isBackground) return // skip overhead for foreground
+
+                const decision = decideSubagentProgress({
+                  disableEnvValue: process.env.SWITCHROOM_DISABLE_SUBAGENT_PROGRESS,
+                  isBackground,
+                  fleetChatId,
+                  ownerChatId: loadAccess().allowFrom[0] ?? '',
+                  subagentJsonlId: agentId,
+                  taskDescription: description,
+                  latestSummary,
+                  elapsedMs,
+                  progressIntervalMs: DEFAULT_PROGRESS_INTERVAL_MS,
+                  lastBucketIdx: prevBucketIdx,
+                })
+                if (!decision.deliver) return
+
+                setBucketIdx(decision.bucketIdx)
+                pendingInboundBuffer.push(process.env.SWITCHROOM_AGENT_NAME ?? '', decision.inbound)
+                process.stderr.write(
+                  `telegram gateway: subagent-progress queued agent=${agentId} bucket=${decision.bucketIdx} elapsed_ms=${elapsedMs} chat=${decision.chatId}\n`,
                 )
               },
             })

--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -63,6 +63,22 @@ export function spoolId(msg: InboundMessage): string {
   ) {
     return `s:handback:${msg.meta.subagent_jsonl_id}`
   }
+  // Subagent progress envelopes (#1720): deterministic per (jsonl id,
+  // bucket idx) — every elapsed bucket collapses to one live entry, so
+  // a re-fire within the same bucket window (or after a gateway
+  // restart) is a structural no-op. The bucket idx is computed by the
+  // gateway from `floor(elapsedMs / progressIntervalMs)` so a worker
+  // that emits narrative lines every 30s only produces one envelope
+  // per bucket. Mirrors the #1719 handback-spoolId pattern.
+  if (
+    msg.meta?.source === 'subagent_progress' &&
+    typeof msg.meta?.subagent_jsonl_id === 'string' &&
+    msg.meta.subagent_jsonl_id.length > 0 &&
+    typeof msg.meta?.bucket_idx === 'string' &&
+    msg.meta.bucket_idx.length > 0
+  ) {
+    return `s:progress:${msg.meta.subagent_jsonl_id}:${msg.meta.bucket_idx}`
+  }
   if (typeof msg.messageId === 'number' && msg.messageId > 0) {
     return `m:${msg.chatId}:${msg.messageId}`
   }
@@ -118,8 +134,22 @@ export interface InboundSpool {
    *  registered bridge. Idempotent. */
   ack: (msg: InboundMessage) => void
   /** Live (un-acked) entries, oldest first. Used at boot to re-push
-   *  into the in-memory buffer. Pure read — does not mutate. */
+   *  into the in-memory buffer. Pure read — does not mutate.
+   *
+   *  TTL (#1720): an entry whose `msg.meta.expiresAt` is a numeric ms
+   *  epoch in the past is OMITTED from the result. Progress envelopes
+   *  carry a TTL because stale progress lies ("still working (5m)"
+   *  delivered 4h after the worker finished is worse than no progress);
+   *  handback envelopes never set `expiresAt` so this is a no-op for
+   *  them. */
   liveEntries: () => ReplayEntry[]
+  /** Drop every live entry whose spool id matches the predicate. Used
+   *  by the handback path (#1720) to sweep stale progress envelopes
+   *  for the same sub-agent at the moment the handback is queued —
+   *  otherwise a progress envelope queued moments before the worker
+   *  finished could land on top of the handback turn. Tombstones the
+   *  dropped entries durably. */
+  dropMatching: (predicate: (id: string) => boolean) => number
   /** Escalate+drop entries older than `escalateAfterMs`. Calls
    *  `onEscalate` once per dropped entry (post the "couldn't deliver"
    *  card there). Returns the count escalated. Safe to call on a timer. */
@@ -257,7 +287,30 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
     },
     liveEntries() {
       // Insertion order = Map iteration order = oldest first.
-      return [...live.values()].map((e) => ({ agent: e.agent, msg: e.msg }))
+      // TTL filter (#1720): skip entries whose meta.expiresAt is in the
+      // past. The on-disk log keeps them (cheap); compaction sweeps.
+      const cutoff = now()
+      const out: ReplayEntry[] = []
+      for (const e of live.values()) {
+        const expRaw = e.msg.meta?.expiresAt
+        if (typeof expRaw === 'string' && expRaw.length > 0) {
+          const exp = Number(expRaw)
+          if (Number.isFinite(exp) && exp <= cutoff) continue
+        }
+        out.push({ agent: e.agent, msg: e.msg })
+      }
+      return out
+    },
+    dropMatching(predicate) {
+      let n = 0
+      for (const [id, _e] of [...live.entries()]) {
+        if (!predicate(id)) continue
+        live.delete(id)
+        appendRecord({ t: 'ack', id })
+        n++
+      }
+      if (n > 0) maybeCompact()
+      return n
     },
     sweepEscalations(onEscalate) {
       const cutoff = now() - escalateAfterMs

--- a/telegram-plugin/gateway/subagent-progress-inbound-builder.ts
+++ b/telegram-plugin/gateway/subagent-progress-inbound-builder.ts
@@ -1,0 +1,238 @@
+/**
+ * Pure builder for the synthetic `subagent_progress` inbound the
+ * gateway injects when a *background* sub-agent emits a narrative line
+ * (`sub_agent_text`) past a bucket boundary while still running.
+ *
+ * Why this exists (conversational-pacing beat 3 — mid-flight progress
+ * for background workers):
+ *
+ *   - Foreground sub-agents stream their narrative into the parent's
+ *     turn natively; the parent can surface progress in its own voice
+ *     as the work unfolds.
+ *   - Background sub-agents are decoupled from any turn boundary. The
+ *     parent is typically idle while the worker runs. Without a wake,
+ *     the user sees nothing between dispatch and the eventual handback
+ *     (beat 4, #1719). The cross-turn ambient ticker in
+ *     `pending-work-progress.ts` keeps the parent's last reply alive
+ *     ("— still working (Nm)") but says NOTHING about *what's
+ *     happening* — it's liveness, not content.
+ *
+ * The watcher already captures `lastResultText` on every
+ * `sub_agent_text` emission (`subagent-watcher.ts:607-622`). We
+ * piggyback on that event stream: every `progressIntervalMs` worth of
+ * elapsed time, the next narrative line minted by the worker becomes
+ * a synthetic `<channel source="subagent_progress">` inbound. The
+ * parent wakes, sees the cue, and surfaces one user-facing line of
+ * progress in its own voice. No timer-driven polling, no TaskOutput
+ * sampling, no `expected_duration` parameter.
+ *
+ * Two divergences from the #1719 handback envelope:
+ *
+ *   1. Determinism by BUCKET, not by jsonl id alone. The spool dedup
+ *      id is `s:progress:<jsonl_agent_id>:<bucketIdx>` where
+ *      `bucketIdx = floor(elapsedMs / progressIntervalMs)`. A worker
+ *      that emits 10 narrative lines inside a single bucket window
+ *      still produces exactly one envelope; the next bucket gets its
+ *      own envelope. Monotonic, idempotent across restarts.
+ *
+ *   2. TTL — every progress envelope sets `meta.expiresAt` to
+ *      `nowMs + 2 × progressIntervalMs`. A 4-hour-stale
+ *      "still working (5m)" delivered after a long downtime would be a
+ *      lie; handback envelopes don't have this asymmetry (they're
+ *      "deliver-eventually OK"). The spool's `liveEntries()` skips
+ *      expired entries — see `inbound-spool.ts`.
+ *
+ * Shape contract mirrors `subagent-handback-inbound-builder.ts`: the
+ * `meta.source` string is load-bearing for the channel wrapper.
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+
+/** Cap on the latest-summary text carried in the inbound. The model
+ *  synthesises a one-line update from it; the full transcript is never
+ *  needed and an unbounded paste bloats the parent's context. */
+export const PROGRESS_RESULT_MAX = 800
+/** Cap on the dispatch-time task description echoed back for context. */
+export const PROGRESS_DESC_MAX = 200
+/** Default bucket size — how often a fresh progress envelope may fire
+ *  for a given sub-agent. 5 min is well past the conversational-pacing
+ *  beat 2/3 boundary and matches the refined RFC. */
+export const DEFAULT_PROGRESS_INTERVAL_MS = 5 * 60 * 1000
+
+export interface SubagentProgressContext {
+  /** Telegram chat the work was dispatched from. */
+  chatId: string
+  /** JSONL-derived sub-agent id (stable per Claude Code spawn). Pinned
+   *  into the spool id so envelopes for the same worker dedup across
+   *  buckets cleanly and survive gateway restarts. */
+  subagentJsonlId: string
+  /** Dispatch-time task description (the sub-agent's `description`). */
+  taskDescription: string
+  /** Worker's most recent narrative line — the cue payload. May be
+   *  empty when the worker emits a tool-use without prose; the
+   *  envelope is still useful (it tells the parent "still alive"). */
+  latestSummary: string
+  /** ms elapsed since the worker was dispatched. */
+  elapsedMs: number
+  /** Bucket index = floor(elapsedMs / progressIntervalMs). The
+   *  determinism axis. */
+  bucketIdx: number
+  /** Window size (ms) used to compute `bucketIdx`. The envelope's TTL
+   *  is `2 × progressIntervalMs` past `nowMs`. */
+  progressIntervalMs: number
+}
+
+function truncate(s: string, max: number): string {
+  const t = s.trim()
+  return t.length > max ? t.slice(0, max) + '…' : t
+}
+
+function formatElapsed(ms: number): string {
+  const totalMin = Math.floor(ms / 60_000)
+  if (totalMin < 60) return `${Math.max(1, totalMin)}m`
+  const h = Math.floor(totalMin / 60)
+  const m = totalMin % 60
+  return m === 0 ? `${h}h` : `${h}h${m}m`
+}
+
+/**
+ * Build the synthetic InboundMessage for a mid-flight background
+ * sub-agent. Deterministic under a fixed `nowMs` for tests.
+ */
+export function buildSubagentProgressInbound(opts: {
+  ctx: SubagentProgressContext
+  nowMs?: number
+}): InboundMessage {
+  const ts = opts.nowMs ?? Date.now()
+  const desc = truncate(opts.ctx.taskDescription, PROGRESS_DESC_MAX) || '(no description)'
+  const summary = truncate(opts.ctx.latestSummary, PROGRESS_RESULT_MAX)
+  const elapsed = formatElapsed(opts.ctx.elapsedMs)
+  const expiresAt = ts + 2 * opts.ctx.progressIntervalMs
+
+  const text =
+    `🔄 A background worker you dispatched is still running.\n\n` +
+    `Task: ${desc}\n` +
+    `Elapsed: ${elapsed}\n\n` +
+    (summary
+      ? `Latest activity:\n${summary}\n\n`
+      : `(no narrative line yet — worker has been tool-only)\n\n`) +
+    `This is beat 3 — mid-flight progress. Surface ONE short line to ` +
+    `the user in your own voice about what the worker is up to. Do ` +
+    `NOT paste this raw, do NOT repeat the elapsed time verbatim, do ` +
+    `NOT promise completion. The handback (beat 4) will come ` +
+    `separately when the worker finishes.`
+
+  return {
+    type: 'inbound',
+    chatId: opts.ctx.chatId,
+    messageId: ts, // synthetic — no Telegram message id exists
+    user: 'subagent-watcher',
+    userId: 0,
+    ts,
+    text,
+    meta: {
+      source: 'subagent_progress',
+      subagent_jsonl_id: opts.ctx.subagentJsonlId,
+      bucket_idx: String(opts.ctx.bucketIdx),
+      expiresAt: String(expiresAt),
+      elapsed_ms: String(opts.ctx.elapsedMs),
+    },
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Progress decision (pure — unit-testable gate for the gateway onProgress path)
+// ───────────────────────────────────────────────────────────────────────────
+
+export interface SubagentProgressDecisionInput {
+  /** `SWITCHROOM_DISABLE_SUBAGENT_PROGRESS` env var value (any non-empty
+   *  value other than '0' disables progress envelopes entirely). */
+  disableEnvValue: string | undefined
+  /** Whether the sub-agent was a background dispatch. Foreground
+   *  sub-agents already surface narrative inside the parent's turn. */
+  isBackground: boolean
+  /** Chat id from the progress-driver fleet entry; '' if not found. */
+  fleetChatId: string
+  /** Owner chat fallback (access.json allowFrom[0]); '' if none. */
+  ownerChatId: string
+  subagentJsonlId: string
+  taskDescription: string
+  latestSummary: string
+  elapsedMs: number
+  /** Window size (ms). */
+  progressIntervalMs: number
+  /** Last bucket idx already emitted for this sub-agent — null if no
+   *  envelope has fired yet. The gateway tracks this per-agent and
+   *  passes it in; the decision returns the new bucket idx on
+   *  `deliver: true` so the caller can update its tracker. */
+  lastBucketIdx: number | null
+  /** Deterministic clock for tests. */
+  nowMs?: number
+}
+
+export type SubagentProgressSkipReason =
+  | 'env-disabled'
+  | 'foreground'
+  | 'no-chat'
+  | 'bucket-already-fired'
+  | 'first-bucket-suppressed'
+  | 'missing-jsonl-id'
+
+export type SubagentProgressDecision =
+  | { deliver: false; reason: SubagentProgressSkipReason }
+  | { deliver: true; chatId: string; bucketIdx: number; inbound: InboundMessage }
+
+/**
+ * Decide whether to deliver a mid-flight progress envelope. Pure — all
+ * IO (registry lookup, fleet peek, access.json read) is the caller's
+ * job.
+ *
+ * Gates, in order:
+ *   1. kill-switch — `SWITCHROOM_DISABLE_SUBAGENT_PROGRESS=1` disables.
+ *   2. foreground — foreground sub-agents stream natively.
+ *   3. no-chat    — nowhere to deliver.
+ *   4. missing-jsonl-id — the dedup key. Without it we'd lose
+ *      deterministic bucketing across restarts; refuse rather than
+ *      degrade silently.
+ *   5. first-bucket-suppressed — bucket 0 covers the first
+ *      `progressIntervalMs` window when ambient liveness is plenty.
+ *      The earliest envelope is bucket 1 (≥ one full window in).
+ *   6. bucket-already-fired — same bucket → same spoolId → no-op.
+ */
+export function decideSubagentProgress(
+  input: SubagentProgressDecisionInput,
+): SubagentProgressDecision {
+  if (input.disableEnvValue != null && input.disableEnvValue !== '' && input.disableEnvValue !== '0') {
+    return { deliver: false, reason: 'env-disabled' }
+  }
+  if (!input.isBackground) {
+    return { deliver: false, reason: 'foreground' }
+  }
+  const chatId = input.fleetChatId || input.ownerChatId
+  if (!chatId) {
+    return { deliver: false, reason: 'no-chat' }
+  }
+  if (!input.subagentJsonlId) {
+    return { deliver: false, reason: 'missing-jsonl-id' }
+  }
+  const bucketIdx = Math.floor(input.elapsedMs / input.progressIntervalMs)
+  if (bucketIdx < 1) {
+    return { deliver: false, reason: 'first-bucket-suppressed' }
+  }
+  if (input.lastBucketIdx != null && bucketIdx <= input.lastBucketIdx) {
+    return { deliver: false, reason: 'bucket-already-fired' }
+  }
+  const inbound = buildSubagentProgressInbound({
+    ctx: {
+      chatId,
+      subagentJsonlId: input.subagentJsonlId,
+      taskDescription: input.taskDescription,
+      latestSummary: input.latestSummary,
+      elapsedMs: input.elapsedMs,
+      bucketIdx,
+      progressIntervalMs: input.progressIntervalMs,
+    },
+    ...(input.nowMs !== undefined ? { nowMs: input.nowMs } : {}),
+  })
+  return { deliver: true, chatId, bucketIdx, inbound }
+}

--- a/telegram-plugin/pending-work-progress.ts
+++ b/telegram-plugin/pending-work-progress.ts
@@ -267,12 +267,16 @@ export function noteTurnEnd(key: string): void {
  * Clear pending-progress for a chat — reasons:
  *   'inbound'   — user sent a new message, they're re-engaged
  *   'handback'  — switchroom injected a subagent_handback channel turn
+ *   'progress'  — switchroom injected a subagent_progress channel turn
+ *                 (#1720) — the model is about to compose an explicit
+ *                 in-voice reply about the worker's status, so the
+ *                 ambient "— still working (Nm)" edit should yield
  *   'timeout'   — exceeded MAX_LIFETIME_MS
  *   'manual'    — test / debug
  */
 export function clearPending(
   key: string,
-  reason: 'inbound' | 'handback' | 'timeout' | 'manual',
+  reason: 'inbound' | 'handback' | 'progress' | 'timeout' | 'manual',
 ): void {
   if (!stateByKey.has(key)) return
   const s = stateByKey.get(key)!

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -115,6 +115,14 @@ export interface WorkerEntry {
    */
   lastResultText: string
   /**
+   * Last bucket index for which an `onProgress` callback was fired for
+   * this sub-agent (#1720). Null until the first envelope. The gateway
+   * owns the actual decision via `decideSubagentProgress`; this field
+   * persists the cursor across `sub_agent_text` events on the same
+   * entry so the watcher doesn't re-fire within the same bucket window.
+   */
+  lastProgressBucketIdx: number | null
+  /**
    * Most recent tool call observed on this sub-agent's JSONL tail —
    * tool name + sanitised arg for fleet-row display (P0 of #662). Null
    * before any `sub_agent_tool_use` event has been seen. Replace-on-write;
@@ -280,6 +288,23 @@ export interface SubagentWatcherConfig {
      *  no `sub_agent_text` line was ever observed. Feeds the
      *  `subagent_handback` inbound. */
     resultText: string
+  }) => void
+  /**
+   * #1720: fires on every `sub_agent_text` event for a running
+   * sub-agent. The gateway decides whether to materialise a
+   * `subagent_progress` envelope via `decideSubagentProgress` (pure,
+   * bucket-deterministic); the watcher just surfaces the cue.
+   * `setBucketIdx` writes back the per-entry cursor so a same-bucket
+   * re-fire is suppressed. Foreground vs background classification is
+   * the gateway's call.
+   */
+  onProgress?: (args: {
+    agentId: string
+    description: string
+    latestSummary: string
+    elapsedMs: number
+    prevBucketIdx: number | null
+    setBucketIdx: (b: number) => void
   }) => void
   /** `Date.now` override for tests. */
   now?: () => number
@@ -483,6 +508,21 @@ export function readSubTail(
    *  the clerk agent logged 540k ENOENT lines in 3 days (30/sec
    *  sustained) AND leaked one fs.watch FD per stranded entry. */
   onFileVanished?: (agentId: string, code: 'ENOENT' | 'EACCES') => void,
+  /** Fires on every `sub_agent_text` event for a running sub-agent
+   *  (#1720). The gateway decides whether to materialise a progress
+   *  envelope via `decideSubagentProgress` — pure decision, watcher
+   *  just surfaces the cue. `latestSummary` is the narrative text;
+   *  `elapsedMs` is `now - entry.dispatchedAt`; `prevBucketIdx` is
+   *  `entry.lastProgressBucketIdx` (gateway calls `setBucketIdx` on a
+   *  successful deliver so a same-bucket re-fire is suppressed). */
+  onProgress?: (args: {
+    agentId: string
+    description: string
+    latestSummary: string
+    elapsedMs: number
+    prevBucketIdx: number | null
+    setBucketIdx: (b: number) => void
+  }) => void,
 ): void {
   try {
     const stat = fs.statSync(entry.filePath)
@@ -620,6 +660,26 @@ export function readSubTail(
           // args or file content — consistent with the watcher's
           // "descriptions only" privacy posture.
           entry.lastResultText = ev.text.trim().slice(0, SUBAGENT_RESULT_TEXT_MAX)
+          // #1720: surface a progress cue for the gateway. Only fire
+          // while the entry is still running and not historical — a
+          // terminal entry's last narrative line is the handback
+          // payload, not a mid-flight progress nudge.
+          if (onProgress != null && entry.state === 'running' && !entry.historical) {
+            try {
+              onProgress({
+                agentId: entry.agentId,
+                description: entry.description,
+                latestSummary: entry.lastResultText,
+                elapsedMs: now - entry.dispatchedAt,
+                prevBucketIdx: entry.lastProgressBucketIdx,
+                setBucketIdx: (b: number) => {
+                  entry.lastProgressBucketIdx = b
+                },
+              })
+            } catch (cbErr) {
+              log?.(`subagent-watcher: onProgress callback error ${entry.agentId}: ${(cbErr as Error).message}`)
+            }
+          }
         } else if (ev.kind === 'sub_agent_turn_end') {
           if (entry.state === 'running') {
             entry.state = 'done'
@@ -802,6 +862,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       stallTerminalSynthesised: false,
       lastSummaryLine: '',
       lastResultText: '',
+      lastProgressBucketIdx: null,
       lastTool: null,
       historical: isHistorical,
     }
@@ -832,7 +893,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     // Initial read
     readSubTail(entry, tail, n, (desc) => {
       log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-    }, fs, log, db, parentStateDir, config.onUnstall)
+    }, fs, log, db, parentStateDir, config.onUnstall, undefined, config.onProgress)
 
     // If the JSONL already contained a turn_end at registration time
     // (file written-then-watched), fire the state-transition + completion
@@ -863,7 +924,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
         if (!entry || !t) return
         readSubTail(entry, t, nowFn(), (desc) => {
           log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-        }, fs, log, db, parentStateDir, config.onUnstall, cleanupTerminalAgent)
+        }, fs, log, db, parentStateDir, config.onUnstall, cleanupTerminalAgent, config.onProgress)
         maybySendStateTransition(agentId)
       })
     } catch (err) {
@@ -1201,7 +1262,7 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
       if (!tail) continue
       readSubTail(entry, tail, n, (desc) => {
         log?.(`subagent-watcher: description updated for ${agentId}: ${desc}`)
-      }, fs, log, db, parentStateDir, config.onUnstall, cleanupTerminalAgent)
+      }, fs, log, db, parentStateDir, config.onUnstall, cleanupTerminalAgent, config.onProgress)
       maybySendStateTransition(agentId)
     }
 

--- a/telegram-plugin/tests/inbound-spool-progress.test.ts
+++ b/telegram-plugin/tests/inbound-spool-progress.test.ts
@@ -1,0 +1,213 @@
+/**
+ * #1720 — extensions to inbound-spool for the progress envelope.
+ *
+ * Three behaviours pinned here that the existing spool tests don't
+ * cover:
+ *
+ *   1. spoolId for `subagent_progress` is bucket-deterministic — two
+ *      envelopes for the same (jsonl id, bucket idx) collapse to ONE
+ *      live entry regardless of ts.
+ *   2. `liveEntries()` skips entries whose `meta.expiresAt` has
+ *      passed (stale progress is worse than no progress).
+ *   3. `dropMatching(predicate)` tombstones live entries by spool id
+ *      prefix — the handback path uses this to sweep stale progress
+ *      envelopes for a sub-agent at the moment its handback is queued.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createInboundSpool,
+  spoolId,
+  type InboundSpoolFsSeam,
+} from '../gateway/inbound-spool.js'
+import type { InboundMessage } from '../gateway/ipc-protocol.js'
+
+function progressMsg(over: {
+  jsonlId: string
+  bucketIdx: number
+  ts?: number
+  chatId?: string
+  expiresAt?: number
+}): InboundMessage {
+  const ts = over.ts ?? 1_000_000
+  const meta: Record<string, string> = {
+    source: 'subagent_progress',
+    subagent_jsonl_id: over.jsonlId,
+    bucket_idx: String(over.bucketIdx),
+  }
+  if (over.expiresAt != null) meta.expiresAt = String(over.expiresAt)
+  return {
+    type: 'inbound',
+    chatId: over.chatId ?? 'c1',
+    messageId: ts,
+    user: 'subagent-watcher',
+    userId: 0,
+    ts,
+    text: 'progress envelope',
+    meta,
+  }
+}
+
+function fakeFs(): InboundSpoolFsSeam {
+  const files = new Map<string, string>()
+  return {
+    appendFileSync: (p, d) => files.set(p, (files.get(p) ?? '') + d),
+    readFileSync: (p) => files.get(p) ?? '',
+    writeFileSync: (p, d) => files.set(p, d),
+    renameSync: (from, to) => {
+      files.set(to, files.get(from) ?? '')
+      files.delete(from)
+    },
+    existsSync: (p) => files.has(p),
+    statSizeSync: (p) => Buffer.byteLength(files.get(p) ?? ''),
+  }
+}
+
+const PATH = '/state/agent/telegram/inbound-spool.jsonl'
+
+describe('spoolId — subagent_progress branch (#1720)', () => {
+  it('two progress envelopes for the same (jsonl id, bucket idx) have IDENTICAL ids', () => {
+    const a = spoolId(progressMsg({ jsonlId: 'j1', bucketIdx: 2, ts: 1000 }))
+    const b = spoolId(progressMsg({ jsonlId: 'j1', bucketIdx: 2, ts: 9999 }))
+    expect(a).toBe('s:progress:j1:2')
+    expect(a).toBe(b)
+  })
+
+  it('different bucket idx → different id', () => {
+    expect(
+      spoolId(progressMsg({ jsonlId: 'j1', bucketIdx: 1 })),
+    ).not.toBe(spoolId(progressMsg({ jsonlId: 'j1', bucketIdx: 2 })))
+  })
+
+  it('different jsonl id → different id', () => {
+    expect(
+      spoolId(progressMsg({ jsonlId: 'j1', bucketIdx: 1 })),
+    ).not.toBe(spoolId(progressMsg({ jsonlId: 'j2', bucketIdx: 1 })))
+  })
+})
+
+describe('inbound-spool — progress envelopes coalesce by bucket', () => {
+  it('three puts for the same (jsonl id, bucket idx) yield ONE live entry', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs })
+    expect(s.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 1, ts: 1000 }))).toBe(true)
+    expect(s.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 1, ts: 2000 }))).toBe(false)
+    expect(s.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 1, ts: 3000 }))).toBe(false)
+    expect(s.liveCount()).toBe(1)
+  })
+
+  it('a fresh spool over the same file still sees ONE live entry (restart-safe coalesce)', () => {
+    const fs = fakeFs()
+    const s1 = createInboundSpool({ path: PATH, fs })
+    s1.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 1, ts: 1000 }))
+    s1.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 1, ts: 2000 }))
+    const s2 = createInboundSpool({ path: PATH, fs })
+    expect(s2.liveCount()).toBe(1)
+    expect(s2.liveEntries()[0].msg.meta.subagent_jsonl_id).toBe('j1')
+  })
+
+  it('successive buckets DO NOT collapse', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs })
+    s.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 1 }))
+    s.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 2 }))
+    s.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 3 }))
+    expect(s.liveCount()).toBe(3)
+  })
+})
+
+describe('inbound-spool — TTL filter on liveEntries (#1720)', () => {
+  it('an entry whose expiresAt is in the past is OMITTED from liveEntries', () => {
+    const fs = fakeFs()
+    let t = 1_000_000
+    const s = createInboundSpool({ path: PATH, fs, now: () => t })
+    // expiresAt = 1_002_000 — within window at put-time
+    s.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 1, ts: t, expiresAt: 1_002_000 }))
+    expect(s.liveEntries()).toHaveLength(1)
+    expect(s.liveCount()).toBe(1) // raw count includes it
+    // Advance clock past expiry
+    t = 1_010_000
+    expect(s.liveEntries()).toHaveLength(0)
+    // liveCount is the raw map size — TTL is a read-time filter.
+    expect(s.liveCount()).toBe(1)
+  })
+
+  it('entries without expiresAt are not affected (handback envelopes stay live)', () => {
+    const fs = fakeFs()
+    let t = 1_000_000
+    const s = createInboundSpool({ path: PATH, fs, now: () => t })
+    s.put('worker', {
+      type: 'inbound',
+      chatId: 'c1',
+      messageId: 999,
+      user: 'x',
+      userId: 0,
+      ts: t,
+      text: 'handback',
+      meta: { source: 'subagent_handback' },
+    })
+    t = 9_000_000_000
+    expect(s.liveEntries()).toHaveLength(1)
+  })
+
+  it('a non-numeric or empty expiresAt is treated as "no expiry"', () => {
+    const fs = fakeFs()
+    let t = 1_000_000
+    const s = createInboundSpool({ path: PATH, fs, now: () => t })
+    s.put('worker', {
+      type: 'inbound',
+      chatId: 'c1',
+      messageId: 1,
+      user: 'x',
+      userId: 0,
+      ts: t,
+      text: 'x',
+      meta: { source: 'subagent_progress', subagent_jsonl_id: 'j1', bucket_idx: '1', expiresAt: '' },
+    })
+    s.put('worker', {
+      type: 'inbound',
+      chatId: 'c1',
+      messageId: 2,
+      user: 'x',
+      userId: 0,
+      ts: t,
+      text: 'x',
+      meta: { source: 'subagent_progress', subagent_jsonl_id: 'j2', bucket_idx: '1', expiresAt: 'not-a-number' },
+    })
+    t = 9_000_000_000
+    expect(s.liveEntries()).toHaveLength(2)
+  })
+})
+
+describe('inbound-spool — dropMatching (#1720 handback sweep)', () => {
+  it('drops every live entry whose id matches the predicate', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs })
+    s.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 1 }))
+    s.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 2 }))
+    s.put('worker', progressMsg({ jsonlId: 'j2', bucketIdx: 1 }))
+    expect(s.liveCount()).toBe(3)
+    const dropped = s.dropMatching((id) => id.startsWith('s:progress:j1:'))
+    expect(dropped).toBe(2)
+    expect(s.liveCount()).toBe(1)
+    expect(s.liveEntries()[0].msg.meta.subagent_jsonl_id).toBe('j2')
+  })
+
+  it('a drop survives across a restart (tombstoned in the log)', () => {
+    const fs = fakeFs()
+    const s1 = createInboundSpool({ path: PATH, fs })
+    s1.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 1 }))
+    s1.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 2 }))
+    expect(s1.dropMatching((id) => id.startsWith('s:progress:j1:'))).toBe(2)
+    const s2 = createInboundSpool({ path: PATH, fs })
+    expect(s2.liveCount()).toBe(0)
+  })
+
+  it('an empty match set is a no-op (returns 0)', () => {
+    const fs = fakeFs()
+    const s = createInboundSpool({ path: PATH, fs })
+    s.put('worker', progressMsg({ jsonlId: 'j1', bucketIdx: 1 }))
+    expect(s.dropMatching((id) => id.startsWith('s:progress:nope:'))).toBe(0)
+    expect(s.liveCount()).toBe(1)
+  })
+})

--- a/telegram-plugin/tests/subagent-progress-inbound-builder.test.ts
+++ b/telegram-plugin/tests/subagent-progress-inbound-builder.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Pin the InboundMessage shape and decision logic for the synthetic
+ * `subagent_progress` envelope (#1720 — mid-flight progress beat).
+ *
+ * Three load-bearing guarantees:
+ *
+ *   1. The `meta.source` string is `subagent_progress`. The MCP
+ *      channel notification wraps it as
+ *      `<channel source="subagent_progress">`; the parent agent's
+ *      beat-3 hook keys on exactly that tag.
+ *   2. `meta.expiresAt` is set on every envelope (`nowMs + 2 × interval`).
+ *      Stale progress is a lie, so the spool's TTL filter MUST have a
+ *      live numeric value to gate on.
+ *   3. The spool dedup id derived via `meta.subagent_jsonl_id` +
+ *      `meta.bucket_idx` is deterministic — same (jsonl id, bucket idx)
+ *      always collapses to the same `s:progress:...` id, so a re-fire
+ *      within the same window is structurally a no-op.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildSubagentProgressInbound,
+  decideSubagentProgress,
+  DEFAULT_PROGRESS_INTERVAL_MS,
+  PROGRESS_DESC_MAX,
+  PROGRESS_RESULT_MAX,
+} from '../gateway/subagent-progress-inbound-builder.js'
+import { spoolId } from '../gateway/inbound-spool.js'
+
+const FIXED_NOW = 1_700_000_000_000
+const INTERVAL_MS = DEFAULT_PROGRESS_INTERVAL_MS
+
+describe('buildSubagentProgressInbound', () => {
+  it('builds an envelope with the load-bearing meta.source and TTL', () => {
+    const inbound = buildSubagentProgressInbound({
+      ctx: {
+        chatId: '12345',
+        subagentJsonlId: 'jsonl-abc',
+        taskDescription: 'Crawl the repo for dead code',
+        latestSummary: 'scanning packages/server — 14 files in so far',
+        elapsedMs: 7 * 60 * 1000,
+        bucketIdx: 1,
+        progressIntervalMs: INTERVAL_MS,
+      },
+      nowMs: FIXED_NOW,
+    })
+    expect(inbound.type).toBe('inbound')
+    expect(inbound.chatId).toBe('12345')
+    expect(inbound.user).toBe('subagent-watcher')
+    expect(inbound.ts).toBe(FIXED_NOW)
+    expect(inbound.messageId).toBe(FIXED_NOW)
+    expect(inbound.meta.source).toBe('subagent_progress')
+    expect(inbound.meta.subagent_jsonl_id).toBe('jsonl-abc')
+    expect(inbound.meta.bucket_idx).toBe('1')
+    // TTL: nowMs + 2 × interval. Numeric, parseable, > now.
+    expect(inbound.meta.expiresAt).toBeDefined()
+    const exp = Number(inbound.meta.expiresAt)
+    expect(Number.isFinite(exp)).toBe(true)
+    expect(exp).toBe(FIXED_NOW + 2 * INTERVAL_MS)
+    // Body content
+    expect(inbound.text).toContain('Crawl the repo for dead code')
+    expect(inbound.text).toContain('scanning packages/server')
+    expect(inbound.text).toMatch(/beat 3/)
+  })
+
+  it('handles an empty latest summary (tool-only worker) without breaking shape', () => {
+    const inbound = buildSubagentProgressInbound({
+      ctx: {
+        chatId: '99',
+        subagentJsonlId: 'jsonl-xyz',
+        taskDescription: 'Run the suite',
+        latestSummary: '',
+        elapsedMs: 6 * 60 * 1000,
+        bucketIdx: 1,
+        progressIntervalMs: INTERVAL_MS,
+      },
+      nowMs: FIXED_NOW,
+    })
+    expect(inbound.meta.source).toBe('subagent_progress')
+    expect(inbound.text).toContain('tool-only')
+  })
+
+  it('caps an over-long latest summary and description', () => {
+    const inbound = buildSubagentProgressInbound({
+      ctx: {
+        chatId: '99',
+        subagentJsonlId: 'jsonl-xyz',
+        taskDescription: 'D'.repeat(PROGRESS_DESC_MAX + 500),
+        latestSummary: 'L'.repeat(PROGRESS_RESULT_MAX + 5000),
+        elapsedMs: 5 * 60 * 1000,
+        bucketIdx: 1,
+        progressIntervalMs: INTERVAL_MS,
+      },
+      nowMs: FIXED_NOW,
+    })
+    expect(inbound.text.length).toBeLessThan(
+      PROGRESS_RESULT_MAX + PROGRESS_DESC_MAX + 800,
+    )
+    expect(inbound.text).toContain('…')
+  })
+
+  // Deterministic spoolId per bucket — the core #1720 guarantee.
+  it('two envelopes with the same (jsonl id, bucket idx) yield IDENTICAL spoolIds', () => {
+    const a = buildSubagentProgressInbound({
+      ctx: {
+        chatId: '12345',
+        subagentJsonlId: 'jsonl-abc',
+        taskDescription: 'x',
+        latestSummary: 'first line',
+        elapsedMs: 7 * 60 * 1000,
+        bucketIdx: 1,
+        progressIntervalMs: INTERVAL_MS,
+      },
+      nowMs: FIXED_NOW,
+    })
+    const b = buildSubagentProgressInbound({
+      ctx: {
+        chatId: '12345',
+        subagentJsonlId: 'jsonl-abc',
+        taskDescription: 'x',
+        latestSummary: 'a DIFFERENT line, also in bucket 1',
+        elapsedMs: 8 * 60 * 1000, // still bucket 1 (8 < 10)
+        bucketIdx: 1,
+        progressIntervalMs: INTERVAL_MS,
+      },
+      // Different nowMs — proves dedup is content-keyed, not ts-keyed.
+      nowMs: FIXED_NOW + 60_000,
+    })
+    expect(spoolId(a)).toBe(spoolId(b))
+    expect(spoolId(a)).toBe('s:progress:jsonl-abc:1')
+  })
+
+  it('different bucket idx → different spoolId (envelopes do NOT collapse)', () => {
+    const bucket1 = buildSubagentProgressInbound({
+      ctx: {
+        chatId: '12345',
+        subagentJsonlId: 'jsonl-abc',
+        taskDescription: 'x',
+        latestSummary: 'b1',
+        elapsedMs: 7 * 60 * 1000,
+        bucketIdx: 1,
+        progressIntervalMs: INTERVAL_MS,
+      },
+      nowMs: FIXED_NOW,
+    })
+    const bucket2 = buildSubagentProgressInbound({
+      ctx: {
+        chatId: '12345',
+        subagentJsonlId: 'jsonl-abc',
+        taskDescription: 'x',
+        latestSummary: 'b2',
+        elapsedMs: 12 * 60 * 1000,
+        bucketIdx: 2,
+        progressIntervalMs: INTERVAL_MS,
+      },
+      nowMs: FIXED_NOW + 5 * 60 * 1000,
+    })
+    expect(spoolId(bucket1)).not.toBe(spoolId(bucket2))
+  })
+})
+
+describe('decideSubagentProgress', () => {
+  function baseInput(over: Partial<Parameters<typeof decideSubagentProgress>[0]> = {}) {
+    return {
+      disableEnvValue: undefined,
+      isBackground: true,
+      fleetChatId: '12345',
+      ownerChatId: '999',
+      subagentJsonlId: 'jsonl-abc',
+      taskDescription: 'x',
+      latestSummary: 'hi',
+      elapsedMs: 7 * 60 * 1000,
+      progressIntervalMs: INTERVAL_MS,
+      lastBucketIdx: null,
+      nowMs: FIXED_NOW,
+      ...over,
+    } as const
+  }
+
+  it('delivers when all gates pass; bucketIdx is floor(elapsed/interval)', () => {
+    const d = decideSubagentProgress(baseInput())
+    expect(d.deliver).toBe(true)
+    if (d.deliver) {
+      expect(d.bucketIdx).toBe(1)
+      expect(d.chatId).toBe('12345')
+      expect(d.inbound.meta.source).toBe('subagent_progress')
+    }
+  })
+
+  it('kill-switch (SWITCHROOM_DISABLE_SUBAGENT_PROGRESS=1) skips delivery', () => {
+    const d = decideSubagentProgress(baseInput({ disableEnvValue: '1' }))
+    expect(d.deliver).toBe(false)
+    if (!d.deliver) expect(d.reason).toBe('env-disabled')
+  })
+
+  it('foreground sub-agents skip (parent already sees the narrative)', () => {
+    const d = decideSubagentProgress(baseInput({ isBackground: false }))
+    expect(d.deliver).toBe(false)
+    if (!d.deliver) expect(d.reason).toBe('foreground')
+  })
+
+  it('falls back to owner chat when fleet chat is empty', () => {
+    const d = decideSubagentProgress(baseInput({ fleetChatId: '' }))
+    expect(d.deliver).toBe(true)
+    if (d.deliver) expect(d.chatId).toBe('999')
+  })
+
+  it('no-chat when neither fleet nor owner resolves', () => {
+    const d = decideSubagentProgress(baseInput({ fleetChatId: '', ownerChatId: '' }))
+    expect(d.deliver).toBe(false)
+    if (!d.deliver) expect(d.reason).toBe('no-chat')
+  })
+
+  it('first bucket (idx 0) is suppressed — ambient liveness is plenty for the opening window', () => {
+    const d = decideSubagentProgress(baseInput({ elapsedMs: 60_000 }))
+    expect(d.deliver).toBe(false)
+    if (!d.deliver) expect(d.reason).toBe('first-bucket-suppressed')
+  })
+
+  it('same bucket as last fired is a no-op (dedup at the decision layer)', () => {
+    const d = decideSubagentProgress(baseInput({ lastBucketIdx: 1 }))
+    expect(d.deliver).toBe(false)
+    if (!d.deliver) expect(d.reason).toBe('bucket-already-fired')
+  })
+
+  it('next bucket fires even when prior bucket already fired', () => {
+    const d = decideSubagentProgress(baseInput({
+      elapsedMs: 12 * 60 * 1000,
+      lastBucketIdx: 1,
+    }))
+    expect(d.deliver).toBe(true)
+    if (d.deliver) expect(d.bucketIdx).toBe(2)
+  })
+
+  it('missing-jsonl-id refuses to mint a non-deterministic envelope', () => {
+    const d = decideSubagentProgress(baseInput({ subagentJsonlId: '' }))
+    expect(d.deliver).toBe(false)
+    if (!d.deliver) expect(d.reason).toBe('missing-jsonl-id')
+  })
+})


### PR DESCRIPTION
## Problem

The conversational-pacing **beat-3 gap** for *background* sub-agents: between dispatch and the eventual handback (beat 4, #1719), the user sees nothing about WHAT the worker is doing. The cross-turn ambient ticker in `pending-work-progress.ts` keeps the parent's last reply alive (`— still working (Nm)`) but that's liveness, not content. The model is silent until the worker finishes.

## Design (event-driven, one primitive)

- `subagent-watcher.ts` already captures `lastResultText` on every `sub_agent_text` emission (lines 607-622). Add an `onProgress` callback fired from that same branch — no new tail loop, no TaskOutput sampling, no `expected_duration` parameter.
- Gateway resolves background-vs-foreground + chat from the existing fleet/DB and delegates the gating to the pure `decideSubagentProgress`. Foreground sub-agents short-circuit before any decision-layer work.
- Envelope spool id is `s:progress:<jsonl_agent_id>:<bucketIdx>` with `bucketIdx = floor(elapsedMs / progressIntervalMs)`. A worker emitting 10 narrative lines within one bucket window collapses to **one** live entry; the next bucket gets its own envelope. Same dedup trick as the #1719 handback envelope, just with bucket replacing jsonl id.

## Determinism guarantees

- **Spool id**: `s:progress:<jsonl_agent_id>:<bucketIdx>` — deterministic per (worker, bucket). Re-fire within the same bucket window collapses; survives gateway/container restart.
- **TTL**: every envelope sets `meta.expiresAt = nowMs + 2 × interval`. Stale progress is a lie (`still working (5m)` delivered 4h post-restart). `InboundSpool.liveEntries()` filters out expired entries — the single divergence from the handback shape, which is "deliver-eventually OK".
- **Handback sweep**: when the gateway queues a `subagent_handback` for a given sub-agent, it calls the new `InboundSpool.dropMatching` with the `s:progress:<jsonl_agent_id>:` prefix so a still-live progress envelope from the same worker can't land on top of the handback turn.

## What was rejected (and why)

- `expected_duration` — agents are bad estimators; a wrong ETA either spams or under-fires. And it would require monkey-patching the `Agent` tool we don't own.
- TaskOutput tail-sampling — `lastResultText` already captures the same content through the same JSONL door.
- Stop-hook scanner backstop — fires once per parent turn; misses the long-idle case the silent-stall path (`subagent-watcher.ts:1059-1087`, from #1719) already covers.

## Kill switch

`SWITCHROOM_DISABLE_SUBAGENT_PROGRESS=1`.

## Scope

~150 LOC + 2 new test files (24 test cases). No DB migration, no schema change. Branched independently from main (not stacked on #1719).

## Test plan

- [x] `bun x tsc --noEmit` clean
- [x] New tests pass (24/24)
- [x] All `subagent-*`, `inbound-*`, `pending-*`, `fleet-state-watcher` tests still pass — 122/122 across 11 files in the related-test set, 104/104 in the broader inbound suite
- [ ] Watch live behaviour in a switchroom agent: dispatch a background worker that runs >10 min and emits narrative lines; verify exactly one beat-3 reply per 5-min bucket; verify handback still lands cleanly afterwards

Closes #1720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)