### PR TITLE
fix(#1728): release buffer gate on final-answer reply (v0.13.27 wedge)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4931,26 +4931,49 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     } catch { /* best-effort signal */ }
     // #203: fresh sendMessage from reply tool is a user-visible signal.
     signalTracker.noteSignal(statusKey(chat_id, threadId), Date.now())
-    // #1713: the reply tool is a NON-EVENT for the status reaction.
-    // The reaction reflects current turn activity, not delivery state —
-    // only the `turn_end` IPC handler finalizes (👍). A plain `reply`
-    // mid-turn or as the final answer does not change the emoji on the
-    // user's inbound message; the next turn_end does. This is a
-    // deliberate revert of the PR #602 follow-up that wired delivery-
-    // confirmation into the terminal path (see #1713 issue body for
-    // the rationale: "delivery confirmation ≠ turn end").
-    // #1664 — mark the turn's final answer as delivered when this reply
-    // looks like the real answer rather than an interim ack. The
-    // classification (notification-bearing OR substantive length) lives
-    // in `isFinalAnswerReply`. Without this, a turn that ack'd then ended
-    // with the real answer as plain transcript text (#1664) would look
-    // "delivered" because replyCalled is true — and the silent-end
-    // re-prompt would never engage. `rawText` is the model's own answer
-    // text, measured before HTML conversion / Telegraph-link
-    // substitution. Writes `turn` (pinned at executeReply entry) so the
-    // flag always lands on the turn this reply belongs to.
+    // #1713: the reply tool is a NON-EVENT for the status reaction
+    // WHEN IT'S AN INTERIM ACK. The reaction reflects current turn
+    // activity, not delivery state — interim acks must not collapse
+    // the working-state ladder to 👍.
+    //
+    // #1728 carve-out (2026-05-24): when this reply IS the final
+    // answer (`isFinalAnswerReply` returns true — same classifier
+    // #1664 uses for silent-end re-prompt gating), it IS effectively
+    // turn-end and we MUST finalize here. Rationale: Claude Code's
+    // `turn_duration` system event is unreliable for the trivial-
+    // prompt happy path (driver sends "what's 2+2", model replies
+    // "4", no `turn_duration` ever lands in the JSONL session tail).
+    // Pre-#1718 this wedge was masked by the legacy
+    // `endStatusReaction` shim running unconditionally on every
+    // reply (outcome='done'); #1718 removed that call site
+    // intending `turn_end` to be the sole terminal trigger. The
+    // contract was right in spirit but `turn_end` doesn't fire 100%
+    // of the time, so the buffer gate (activeTurnStartedAt) stays
+    // set forever and every subsequent inbound gets `held mid-turn`
+    // and never delivered. v0.13.27 shipped + reverted on this
+    // failure mode (#1728).
+    //
+    // Net contract:
+    //   - interim ack reply (isFinalAnswerReply === false)
+    //         → non-event, no reaction finalize, buffer gate stays
+    //   - final-answer reply (isFinalAnswerReply === true)
+    //         → finalize reaction (debounced 👍) + release buffer
+    //           gate via purgeReactionTracking (called inside
+    //           finalizeStatusReaction). currentTurn stays alive so
+    //           a subsequent `turn_end` still cleans up its share
+    //           idempotently.
+    //
+    // #1664 — `turn.finalAnswerDelivered = true` keeps the silent-
+    // end re-prompt from spuriously firing on a delivered final.
     if (turn != null && isFinalAnswerReply({ text: rawText, disableNotification })) {
       turn.finalAnswerDelivered = true
+      // #1728: release the buffer gate + emit terminal 👍. Mid-turn
+      // acks bypass this branch and remain non-events for the
+      // reaction (preserves #1713). The full turn-state teardown
+      // (nulling `currentTurn`, the per-turn cleanup) still runs in
+      // the `turn_end` handler when it lands; this only fires the
+      // observable side effects that #1718 deferred unconditionally.
+      finalizeStatusReaction(chat_id, threadId, 'done')
     }
   }
 

--- a/telegram-plugin/tests/reply-terminal-reaction.test.ts
+++ b/telegram-plugin/tests/reply-terminal-reaction.test.ts
@@ -1,39 +1,44 @@
 /**
- * #1713 — plain `reply` tool is a NON-EVENT for the status reaction.
+ * #1713 + #1728 — interim-ack `reply` tool is a non-event for the
+ * status reaction; final-answer `reply` finalizes.
  *
- * History. PR #602 follow-up wired `executeReply` to fire the terminal
- * 👍 after at least one chunk landed, mirroring the (now-also-removed)
- * stream_reply Bug Z behaviour. #1713 reverts both: the status reaction
- * reflects current turn activity, not delivery state. Only the
- * gateway's `turn_end` IPC handler finalizes the reaction. Mid-turn
- * replies — ack or final — must not change the emoji.
+ * History.
+ *   - PR #602 follow-up wired `executeReply` to fire the terminal 👍
+ *     after at least one chunk landed.
+ *   - #1713 (#1718) reverted that: reaction reflects current turn
+ *     activity, not delivery state. Made `turn_end` the sole terminal
+ *     trigger so mid-turn ACK replies don't collapse the working-state
+ *     ladder to 👍.
+ *   - #1728 (this fix) carve-out: Claude Code's `turn_duration` system
+ *     event is unreliable for the trivial-prompt happy path, leaving
+ *     `activeTurnStartedAt` set forever and every subsequent inbound
+ *     stuck "held mid-turn" (the v0.13.27 wedge). When the reply IS
+ *     the final answer (`isFinalAnswerReply` returns true), executeReply
+ *     calls `finalizeStatusReaction` to release the buffer gate and
+ *     emit the (debounced 3500ms) terminal 👍. Interim acks bypass this
+ *     branch and remain non-events for the reaction.
  *
- * This file pins the new invariant: there is no `endStatusReaction`
- * call inside the executeReply post-send block. The post-send block
- * now records signal-tracker / outbound-dedup / final-answer state
- * only — reaction state is owned by turn_end.
+ * Net contract pinned here:
+ *   - executeReply post-send block must NOT call the legacy
+ *     `endStatusReaction('done')` (the pre-#1713 bug class).
+ *   - executeReply MUST call `finalizeStatusReaction` gated on
+ *     `isFinalAnswerReply` so the buffer gate releases on final answer.
  *
  * The gateway IIFE / executeReply body are too entangled to import
- * directly, so we model the post-#1713 contract here. If executeReply
- * regresses (re-adds a terminal-reaction call), the inline review
- * comment guarding `if (sentIds.length > 0)` and this test should both
- * catch it.
+ * directly, so we do source-level assertions.
  */
 import { describe, it, expect, vi } from 'vitest'
 
-describe('#1713 — plain reply tool is a non-event for the reaction', () => {
-  it('executeReply post-send block does NOT call endStatusReaction', () => {
-    // Read the source to assert the contract — there should be no
-    // `endStatusReaction(... 'done')` call inside the post-send
-    // `if (sentIds.length > 0)` block in executeReply.
+describe('#1713 + #1728 — reply tool reaction contract', () => {
+  it('executeReply post-send block does NOT call legacy endStatusReaction', () => {
+    // The pre-#1713 bug class was `endStatusReaction(chat_id, threadId,
+    // 'done')` firing 👍 unconditionally on every reply (including
+    // mid-turn acks). That call must stay removed.
     //
     // We do a coarse-grained source-level check rather than a unit
     // test of a copied helper. If/when the executeReply body is
     // extracted into its own function this can become a proper unit
     // test; until then the source-level guard is the safest pin.
-    //
-    // The intent: a future commit that re-adds the call (regressing
-    // #1713) will trip this assertion.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const fs = require('node:fs') as typeof import('node:fs')
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -51,6 +56,44 @@ describe('#1713 — plain reply tool is a non-event for the reaction', () => {
     // contained `endStatusReaction(chat_id, threadId, 'done')`.
     const slice = src.slice(anchor, anchor + 3000)
     expect(slice).not.toMatch(/endStatusReaction\([^)]*'done'\)/)
+  })
+
+  it('executeReply post-send block DOES call finalizeStatusReaction gated on isFinalAnswerReply (#1728 wedge fix)', () => {
+    // #1728 — the v0.13.27 wedge: `turn_duration` system events from
+    // Claude Code don't reliably land for trivial-prompt turns, so
+    // activeTurnStartedAt never clears and every subsequent inbound
+    // gets held mid-turn. The fix: when executeReply detects a final-
+    // answer reply (the same `isFinalAnswerReply` classifier #1664
+    // uses for silent-end re-prompt gating), trigger
+    // `finalizeStatusReaction` to release the buffer gate. Interim
+    // acks (isFinalAnswerReply === false) MUST bypass this branch and
+    // remain non-events for the reaction (preserves #1713).
+    //
+    // If a future commit removes the finalizeStatusReaction call or
+    // un-gates it from isFinalAnswerReply, the wedge returns.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('node:fs') as typeof import('node:fs')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('node:path') as typeof import('node:path')
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../gateway/gateway.ts'),
+      'utf8',
+    )
+    const anchor = src.indexOf("fresh sendMessage from reply tool is a user-visible")
+    expect(anchor).toBeGreaterThan(-1)
+    const slice = src.slice(anchor, anchor + 3000)
+    // The finalize MUST appear in the post-send block.
+    expect(slice).toMatch(/finalizeStatusReaction\(/)
+    // It MUST be gated by isFinalAnswerReply (the classifier prevents
+    // interim acks from firing 👍, which would regress #1713).
+    expect(slice).toMatch(/isFinalAnswerReply\(/)
+    // Sanity: the finalize MUST appear AFTER the isFinalAnswerReply
+    // check (i.e. inside the gated branch), not as a sibling that
+    // fires unconditionally.
+    const gateIdx = slice.indexOf('isFinalAnswerReply(')
+    const finalizeIdx = slice.indexOf('finalizeStatusReaction(')
+    expect(gateIdx).toBeGreaterThan(-1)
+    expect(finalizeIdx).toBeGreaterThan(gateIdx)
   })
 
   it('reply tool deps no longer wire a status-reaction terminal callback', () => {


### PR DESCRIPTION
Closes #1728.

## Summary

v0.13.27 wedged every agent on `inbound held mid-turn — will flush on turn-complete` with the gate never opening. Root cause: #1718's contract change made `turn_end` the sole terminal trigger for both the 👍 reaction AND the per-turn buffer gate. Claude Code's `turn_duration` system event doesn't reliably land for the trivial-prompt happy path, so the buffer gate stayed set forever.

## Why

Pre-#1718, `executeReply` synchronously called `endStatusReaction('done')` → `purgeReactionTracking` which cleared `activeTurnStartedAt[key]` on every reply. Removing that call deferred the cleanup to `turn_end` — which doesn't fire 100% of the time. The pre-existing 300s `silence-poke framework-fallback` masked it as an occasional wedge pre-v0.13.27; #1718 made it happen on every trivial-prompt turn.

I checked production logs going back to 2026-05-21: `silence-poke framework-fallback ended wedged turn ... currentTurn_nulled=false` fires regularly even on v0.13.26. So this wedge class existed pre-#1718; #1718 just promoted it from tail-case to common case.

## Fix

In `executeReply`, when `isFinalAnswerReply` returns true (same classifier #1664 uses for silent-end re-prompt gating), call `finalizeStatusReaction(chat_id, threadId, 'done')`. That:
- Fires the debounced 👍 (3500ms) per the #1713 spec
- Calls `purgeReactionTracking` which releases the buffer gate AND triggers the held-inbound flush
- Leaves `currentTurn` alive; a subsequent `turn_end` event still cleans up its share idempotently

Interim acks (`isFinalAnswerReply === false`) bypass this branch entirely and remain non-events for the reaction — the working-state ladder still works for ack-mid-turn flows (preserves #1713).

## Net contract

| Path | Reaction | Buffer gate | currentTurn |
|---|---|---|---|
| interim ack reply | non-event | stays | stays |
| **final-answer reply** | **finalize (debounced 👍)** | **released** | **stays (cleaned by `turn_end`)** |
| `turn_end` event | finalize (idempotent) | release (idempotent) | nulled |

## Tests

- `telegram-plugin/tests/reply-terminal-reaction.test.ts` updated. Retains the legacy `endStatusReaction('done')` regression guard; adds a new case pinning that `finalizeStatusReaction` IS called AND is gated on `isFinalAnswerReply` (regression catch for both halves of the contract).
- Full plugin suite green: vitest 2738/2738 + bun 3324/3324.

## Test plan

- [x] vitest + bun-test
- [x] `tsc --noEmit`
- [x] `check-bot-api-wrapping.sh`
- [x] `check-vault-test-hermeticity.mjs`
- [ ] After merge + release v0.13.28: roll to test-harness, verify `jtbd-fast-trivial-dm` passes (was the v0.13.27 failure mode), monitor for `held mid-turn` log entries via `docker logs switchroom-test-harness | grep "held mid-turn"`

## Risk

Low. The change is a single 3-line addition in a well-trodden code path, gated on the same `isFinalAnswerReply` classifier that already had a production track record (#1664 silent-end re-prompt). The new test pin makes the contract explicit so future contributors can't accidentally regress either half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)