### PR TITLE
fix(gateway): vault_request_save routes through attest_via_posture under telegram-id

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -332,7 +332,7 @@ import {
 import { runPipeline } from '../secret-detect/pipeline.js'
 import { StagingMap } from '../secret-detect/staging.js'
 import { maskToken } from '../secret-detect/mask.js'
-import { defaultVaultWrite, defaultVaultList } from '../secret-detect/vault-write.js'
+import { defaultVaultWrite, defaultVaultList, defaultVaultWritePosture } from '../secret-detect/vault-write.js'
 import { parseVaultCliError, renderVaultCliError } from '../secret-detect/vault-error.js'
 import { recentDenialsFromAuditLog, type RecentDenial } from './recent-denials.js'
 import { detectSecrets } from '../secret-detect/index.js'
@@ -11774,46 +11774,49 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
     // stale "spinning" state on the button while we run the write.
     await ctx.answerCallbackQuery({ text: '⏳ Saving…' }).catch(() => {})
 
-    // #1115 follow-up: telegram-id mode silent-save was withdrawn. The
-    // original PR shortcut routed the save through an in-memory
-    // passphrase the gateway held under telegram-id; the reviewer
-    // flagged that as a bypass surface (claude in the same container
-    // could exfiltrate the passphrase). The access-approve flow now
-    // attests via the broker (`attest_via_posture: true` on
-    // mint_grant) so the passphrase never leaves the broker. The
-    // save-approve flow uses `defaultVaultWrite` which shells to the
-    // CLI — routing it through broker-IPC attest_via_posture is a
-    // tracked follow-up. Until then, vault_request_save under
-    // telegram-id falls through to the standard passphrase-cache
-    // path: the operator must have unlocked the vault in this chat
-    // (`/vault unlock` or any /vault command) so the cache is
-    // populated. Same UX as passphrase mode.
-
-    // Fetch the cached passphrase for this chat. If the gateway hasn't
-    // seen the user unlock the vault yet, we can't attest the write —
-    // surface the unlock card via the same path the deferred-secret
-    // flow uses (issue #44).
-    const cached = vaultPassphraseCache.get(pending.chat_id)
-    if (!cached || cached.expiresAt <= Date.now()) {
-      if (pending.card_message_id != null) {
-        await ctx.api
-          .editMessageText(
-            pending.chat_id,
-            pending.card_message_id,
-            `🔒 <b>Vault is locked.</b> Run <code>/vault unlock</code> (or any /vault command) to cache the passphrase, then tap Save again on the next card.`,
-            { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
-          )
-          .catch(() => {})
+    // #1115 follow-up: the save-approve flow now mirrors the access-
+    // approve flow under telegram-id mode — broker `put` accepts
+    // `attest_via_posture: true` (server.ts:1448-1500), so the
+    // gateway can attest the write without a cached passphrase.
+    // Closes the UX gap where tapping Save surfaced a misleading
+    // "🔒 Vault is locked" message even when the broker had been
+    // auto-unlocked at boot.
+    //
+    // Branch: under telegram-id mode use the posture-attested put;
+    // under passphrase mode keep the existing cached-passphrase +
+    // shell-to-CLI path (operator must `/vault unlock` once per
+    // chat session to populate `vaultPassphraseCache`).
+    let write: { ok: boolean; output: string }
+    if (VAULT_APPROVAL_AUTH_MODE === 'telegram-id') {
+      // Posture-attested broker put. No passphrase needed. The broker
+      // verifies (a) telegram-id mode, (b) per-agent peer, (c) broker
+      // unlocked — see server.ts:1448-1500.
+      write = await defaultVaultWritePosture(pending.key, pending.value)
+    } else {
+      // Passphrase mode — fetch the cached passphrase for this chat.
+      // If the gateway hasn't seen the user unlock the vault yet, we
+      // can't attest the write — surface the unlock prompt.
+      const cached = vaultPassphraseCache.get(pending.chat_id)
+      if (!cached || cached.expiresAt <= Date.now()) {
+        if (pending.card_message_id != null) {
+          await ctx.api
+            .editMessageText(
+              pending.chat_id,
+              pending.card_message_id,
+              `🔒 <b>Passphrase not cached for this chat.</b> Run <code>/vault unlock</code> (or any /vault command) to cache it, then tap Save again on the next card.`,
+              { parse_mode: 'HTML', reply_markup: { inline_keyboard: [] } },
+            )
+            .catch(() => {})
+        }
+        pendingVaultRequestSaves.delete(stageId)
+        return
       }
-      pendingVaultRequestSaves.delete(stageId)
-      return
+      // defaultVaultWrite spawns `switchroom vault set <key>` with the
+      // passphrase env set; the CLI forwards the passphrase to the
+      // broker put as operator-attestation (#969 P1a), which authorizes
+      // new-key creation.
+      write = defaultVaultWrite(pending.key, pending.value, cached.passphrase)
     }
-
-    // Run the write. defaultVaultWrite spawns `switchroom vault set
-    // <key>` with the passphrase env set; the CLI in turn forwards the
-    // passphrase to the broker put as operator-attestation (#969 P1a),
-    // which authorizes new-key creation.
-    const write = defaultVaultWrite(pending.key, pending.value, cached.passphrase)
 
     if (!write.ok) {
       // Route through the structured-error renderer from #969 P0b so

--- a/telegram-plugin/secret-detect/vault-write.ts
+++ b/telegram-plugin/secret-detect/vault-write.ts
@@ -53,14 +53,34 @@ export type VaultWriteFn = (
  * gateway's existing parseVaultCliError / renderVaultCliError path
  * still works.
  */
+/**
+ * Test-injection seam for `defaultVaultWritePosture`. Production
+ * callers omit and get the live broker client; tests pass mock
+ * functions to avoid `vi.mock` / `mock.module` (which don't
+ * cross-runtime cleanly — vitest's `vi.mock` and bun:test's
+ * `mock.module` need separate wiring and shadow other tests' module
+ * imports if not carefully isolated).
+ */
+export interface VaultWritePostureDeps {
+  putViaBroker?: typeof putViaBroker
+  resolveBrokerSocketPath?: typeof resolveBrokerSocketPath
+}
+
 export type VaultWritePostureFn = (
   slug: string,
   value: string,
+  deps?: VaultWritePostureDeps,
 ) => Promise<VaultWriteResult>
 
-export const defaultVaultWritePosture: VaultWritePostureFn = async (slug, value) => {
-  const socket = resolveBrokerSocketPath()
-  const result = await putViaBroker(
+export const defaultVaultWritePosture: VaultWritePostureFn = async (
+  slug,
+  value,
+  deps,
+) => {
+  const put = deps?.putViaBroker ?? putViaBroker
+  const resolveSocket = deps?.resolveBrokerSocketPath ?? resolveBrokerSocketPath
+  const socket = resolveSocket()
+  const result = await put(
     slug,
     { kind: 'string', value },
     { socket, attest_via_posture: true, timeoutMs: 10000 },

--- a/telegram-plugin/secret-detect/vault-write.ts
+++ b/telegram-plugin/secret-detect/vault-write.ts
@@ -1,15 +1,31 @@
 /**
  * Programmatic vault write from the Telegram plugin path.
  *
- * Reuses the existing `runVaultCli`-style approach (spawn `switchroom vault
- * set` with SWITCHROOM_VAULT_PASSPHRASE in env and the secret piped on
- * stdin) so we don't have to import and open the vault directly from this
- * subprocess.
+ * Two flavors:
  *
- * Exposed as a pure function for testability: callers inject the spawn
- * helper in tests to avoid needing a real vault on disk.
+ *   1. `defaultVaultWrite(slug, value, passphrase)` — shell-out to
+ *      `switchroom vault set`. The CLI forwards the passphrase to the
+ *      broker as operator-attestation (#969 P1a). Used by passphrase-
+ *      mode approval flows where the gateway cached the operator's
+ *      passphrase via /vault unlock.
+ *
+ *   2. `defaultVaultWritePosture(slug, value)` — direct broker call via
+ *      `putViaBroker(..., attest_via_posture: true)`. Used by
+ *      telegram-id-mode approval flows where the broker auto-unlocked
+ *      at boot and the gateway never needs the passphrase
+ *      (`vault.broker.approvalAuth: telegram-id` in switchroom.yaml).
+ *      Closes the UX gap where tapping Save on a `vault_request_save`
+ *      card surfaced a misleading "🔒 Vault is locked" message when
+ *      the operator hadn't run /vault unlock in that chat — even
+ *      though the broker had been unlocked for hours. The tracked
+ *      follow-up of #1115; broker side has supported the flag since
+ *      PR #1115 follow-up rev 3.
+ *
+ * Exposed as pure functions for testability: callers inject the spawn /
+ * broker helper in tests to avoid needing a real vault on disk.
  */
 import { execFileSync } from 'node:child_process'
+import { putViaBroker, resolveBrokerSocketPath } from '../../src/vault/broker/client.js'
 
 export interface VaultWriteResult {
   ok: boolean
@@ -21,6 +37,48 @@ export type VaultWriteFn = (
   value: string,
   passphrase: string,
 ) => VaultWriteResult
+
+/**
+ * Posture-attested vault write — no passphrase required. Returns the
+ * same `VaultWriteResult` shape as `defaultVaultWrite` for drop-in
+ * substitution at the gateway save / defer / auto-save callsites.
+ *
+ * Caller MUST verify `vault.broker.approvalAuth === 'telegram-id'` in
+ * config before invoking — the broker will reject `attest_via_posture`
+ * under passphrase mode with `attest_via_posture requires
+ * vault.broker.approvalAuth: telegram-id` (server.ts:1500). The
+ * gateway's `VAULT_APPROVAL_AUTH_MODE` flag is the canonical signal.
+ *
+ * Returns `{ ok: false, output: ... }` on any broker error so the
+ * gateway's existing parseVaultCliError / renderVaultCliError path
+ * still works.
+ */
+export type VaultWritePostureFn = (
+  slug: string,
+  value: string,
+) => Promise<VaultWriteResult>
+
+export const defaultVaultWritePosture: VaultWritePostureFn = async (slug, value) => {
+  const socket = resolveBrokerSocketPath()
+  const result = await putViaBroker(
+    slug,
+    { kind: 'string', value },
+    { socket, attest_via_posture: true, timeoutMs: 10000 },
+  )
+  if (result.kind === 'ok') {
+    return { ok: true, output: `sent (key: ${slug})` }
+  }
+  // Mirror the CLI's error format so the existing parseVaultCliError
+  // / renderVaultCliError stack handles broker-mediated failures
+  // without a special branch.
+  const prefix =
+    result.kind === 'unreachable'
+      ? 'VAULT-BROKER-UNREACHABLE'
+      : result.kind === 'denied'
+        ? `VAULT-BROKER-DENIED (${result.code})`
+        : `VAULT-BROKER-${result.code}`
+  return { ok: false, output: `${prefix}: ${result.msg}` }
+}
 
 export type VaultListFn = (passphrase: string) => { ok: boolean; keys: string[] }
 

--- a/telegram-plugin/tests/vault-approval-posture.test.ts
+++ b/telegram-plugin/tests/vault-approval-posture.test.ts
@@ -121,20 +121,34 @@ describe('performVaultAccessApproval — broker-mediated attestation', () => {
   })
 })
 
-describe('handleVaultRequestSaveCallback — telegram-id silent path withdrawn', () => {
-  it('NO LONGER reads an in-memory passphrase for telegram-id; falls through to cached-passphrase path', () => {
+describe('handleVaultRequestSaveCallback — posture-attested broker put (#1115 follow-up)', () => {
+  it('NO in-memory passphrase under telegram-id; routes the save through the broker via attest_via_posture', () => {
     const fnBlock =
       gatewaySrc
         .split('async function handleVaultRequestSaveCallback')[1]
         ?.split('async function handleVaultDeferCallback')[0] ?? ''
-    // Regression guard: the original PR added a
-    // `VAULT_APPROVAL_AUTH_MODE === 'telegram-id'` shortcut that
-    // pulled an in-memory passphrase. That was a bypass surface.
-    // The save handler must NOT branch on the posture for an
-    // in-memory passphrase any more.
+    // Regression guard (original #1115 first-cut withdrawal): the
+    // handler must NOT pull a long-lived in-memory passphrase under
+    // telegram-id. That was a bypass surface — claude in the same
+    // container could exfiltrate it. The follow-up replaces it with
+    // a broker-IPC `attest_via_posture` call so the passphrase
+    // never leaves the broker process.
     expect(fnBlock).not.toMatch(/AUTO_UNLOCK_PASSPHRASE/)
-    // Standard cache lookup still present.
+    // The #1115 follow-up wiring: under telegram-id the handler
+    // calls `defaultVaultWritePosture` (posture-attested broker put,
+    // no passphrase). Under passphrase mode it keeps the legacy
+    // cached-passphrase + shell-out path.
+    expect(fnBlock).toMatch(/VAULT_APPROVAL_AUTH_MODE === 'telegram-id'/)
+    expect(fnBlock).toMatch(/defaultVaultWritePosture\(/)
+    // Passphrase-mode branch still present.
     expect(fnBlock).toMatch(/vaultPassphraseCache\.get\(pending\.chat_id\)/)
+    expect(fnBlock).toMatch(/defaultVaultWrite\(pending\.key, pending\.value, cached\.passphrase\)/)
+    // The misleading pre-fix card text ("Vault is locked") must be
+    // rephrased — the broker IS unlocked under telegram-id; only
+    // the chat's passphrase cache needs warming up under passphrase
+    // mode. Pin the corrected wording so the wedge UX can't
+    // silently regress.
+    expect(fnBlock).toMatch(/Passphrase not cached for this chat/)
   })
 })
 

--- a/telegram-plugin/tests/vault-write-posture.test.ts
+++ b/telegram-plugin/tests/vault-write-posture.test.ts
@@ -14,64 +14,75 @@
  *   - Forwards `kind: 'string'` entry shape verbatim (only kind the
  *     `vault_request_save` MCP tool emits).
  *
- * We mock `putViaBroker` so the unit test never hits a real socket /
- * a real vault.
+ * Test seam: the helper accepts an optional `deps` param so tests
+ * inject mock fns directly (no `vi.mock` / `mock.module`). This
+ * keeps the test runnable under both vitest AND bun:test without
+ * the module-cache cross-pollination that broke an earlier rev.
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { defaultVaultWritePosture } from '../secret-detect/vault-write.js'
+import type { PutResult } from '../../src/vault/broker/client.js'
 
-vi.mock('../../src/vault/broker/client.js', () => ({
-  putViaBroker: vi.fn(),
-  resolveBrokerSocketPath: vi.fn(() => '/run/switchroom/broker/sock'),
-}))
+type PutCall = {
+  slug: string
+  entry: { kind: 'string'; value: string } | { kind: 'binary'; value: string }
+  opts: { socket?: string; attest_via_posture?: boolean; timeoutMs?: number }
+}
 
-const { defaultVaultWritePosture } = await import('../secret-detect/vault-write.js')
-const brokerClient = await import('../../src/vault/broker/client.js')
-const putMock = brokerClient.putViaBroker as ReturnType<typeof vi.fn>
+function makeDeps(putResult: PutResult, socket = '/run/switchroom/broker/sock'): {
+  deps: { putViaBroker: (...args: never[]) => Promise<PutResult>; resolveBrokerSocketPath: () => string }
+  calls: PutCall[]
+} {
+  const calls: PutCall[] = []
+  const deps = {
+    putViaBroker: async (...args: never[]): Promise<PutResult> => {
+      const [slug, entry, opts] = args as unknown as [PutCall['slug'], PutCall['entry'], PutCall['opts']]
+      calls.push({ slug, entry, opts })
+      return putResult
+    },
+    resolveBrokerSocketPath: () => socket,
+  }
+  return { deps, calls }
+}
 
 describe('defaultVaultWritePosture', () => {
-  beforeEach(() => {
-    putMock.mockReset()
-  })
-
   it('returns { ok: true } on broker `kind: ok`', async () => {
-    putMock.mockResolvedValueOnce({ kind: 'ok' })
-    const r = await defaultVaultWritePosture('forward-email/api-key', 'sk-value')
+    const { deps } = makeDeps({ kind: 'ok' })
+    const r = await defaultVaultWritePosture('forward-email/api-key', 'sk-value', deps)
     expect(r.ok).toBe(true)
     expect(r.output).toContain('forward-email/api-key')
   })
 
   it('forwards attest_via_posture: true on the put RPC', async () => {
-    putMock.mockResolvedValueOnce({ kind: 'ok' })
-    await defaultVaultWritePosture('ha/access-token', 'jwt-value')
-    expect(putMock).toHaveBeenCalledTimes(1)
-    const [, , opts] = putMock.mock.calls[0]
-    expect(opts).toMatchObject({ attest_via_posture: true })
+    const { deps, calls } = makeDeps({ kind: 'ok' })
+    await defaultVaultWritePosture('ha/access-token', 'jwt-value', deps)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].opts.attest_via_posture).toBe(true)
   })
 
   it('forwards kind: string entry verbatim', async () => {
-    putMock.mockResolvedValueOnce({ kind: 'ok' })
-    await defaultVaultWritePosture('some-key', 'some-value')
-    const [keyArg, entryArg] = putMock.mock.calls[0]
-    expect(keyArg).toBe('some-key')
-    expect(entryArg).toEqual({ kind: 'string', value: 'some-value' })
+    const { deps, calls } = makeDeps({ kind: 'ok' })
+    await defaultVaultWritePosture('some-key', 'some-value', deps)
+    expect(calls[0].slug).toBe('some-key')
+    expect(calls[0].entry).toEqual({ kind: 'string', value: 'some-value' })
   })
 
   it('returns ok:false with VAULT-BROKER-UNREACHABLE prefix on unreachable', async () => {
-    putMock.mockResolvedValueOnce({ kind: 'unreachable', msg: 'connect ENOENT' })
-    const r = await defaultVaultWritePosture('k', 'v')
+    const { deps } = makeDeps({ kind: 'unreachable', msg: 'connect ENOENT' })
+    const r = await defaultVaultWritePosture('k', 'v', deps)
     expect(r.ok).toBe(false)
     expect(r.output).toContain('VAULT-BROKER-UNREACHABLE')
     expect(r.output).toContain('connect ENOENT')
   })
 
   it('returns ok:false with VAULT-BROKER-DENIED prefix on denied', async () => {
-    putMock.mockResolvedValueOnce({
+    const { deps } = makeDeps({
       kind: 'denied',
       code: 'DENIED',
       msg: 'attest_via_posture requires telegram-id',
     })
-    const r = await defaultVaultWritePosture('k', 'v')
+    const r = await defaultVaultWritePosture('k', 'v', deps)
     expect(r.ok).toBe(false)
     expect(r.output).toContain('VAULT-BROKER-DENIED')
     expect(r.output).toContain('DENIED')
@@ -79,22 +90,19 @@ describe('defaultVaultWritePosture', () => {
   })
 
   it('returns ok:false with VAULT-BROKER-UNKNOWN_KEY prefix on not_found', async () => {
-    putMock.mockResolvedValueOnce({
+    const { deps } = makeDeps({
       kind: 'not_found',
       code: 'UNKNOWN_KEY',
       msg: 'no such key',
     })
-    const r = await defaultVaultWritePosture('k', 'v')
+    const r = await defaultVaultWritePosture('k', 'v', deps)
     expect(r.ok).toBe(false)
     expect(r.output).toContain('VAULT-BROKER-UNKNOWN_KEY')
   })
 
-  it('resolves the broker socket via resolveBrokerSocketPath()', async () => {
-    const resolveMock = brokerClient.resolveBrokerSocketPath as ReturnType<typeof vi.fn>
-    resolveMock.mockReturnValueOnce('/tmp/test-socket')
-    putMock.mockResolvedValueOnce({ kind: 'ok' })
-    await defaultVaultWritePosture('k', 'v')
-    const [, , opts] = putMock.mock.calls[0]
-    expect(opts).toMatchObject({ socket: '/tmp/test-socket' })
+  it('resolves the broker socket via the injected resolveBrokerSocketPath', async () => {
+    const { deps, calls } = makeDeps({ kind: 'ok' }, '/tmp/test-socket')
+    await defaultVaultWritePosture('k', 'v', deps)
+    expect(calls[0].opts.socket).toBe('/tmp/test-socket')
   })
 })

--- a/telegram-plugin/tests/vault-write-posture.test.ts
+++ b/telegram-plugin/tests/vault-write-posture.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for `defaultVaultWritePosture` — the posture-attested
+ * vault write helper introduced by the #1115 follow-up.
+ *
+ * Contract pinned here:
+ *   - Returns `{ ok: true, output }` on broker `kind: 'ok'`.
+ *   - Returns `{ ok: false, output: <marker>: <msg> }` on each broker
+ *     failure shape (unreachable / denied / not_found), with markers
+ *     that the gateway's `parseVaultCliError` / `renderVaultCliError`
+ *     stack can recognize (so failures still render the actionable
+ *     host hint instead of a raw blob).
+ *   - Forwards `attest_via_posture: true` on the put — the load-
+ *     bearing flag the broker server (server.ts:1448-1500) gates on.
+ *   - Forwards `kind: 'string'` entry shape verbatim (only kind the
+ *     `vault_request_save` MCP tool emits).
+ *
+ * We mock `putViaBroker` so the unit test never hits a real socket /
+ * a real vault.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('../../src/vault/broker/client.js', () => ({
+  putViaBroker: vi.fn(),
+  resolveBrokerSocketPath: vi.fn(() => '/run/switchroom/broker/sock'),
+}))
+
+const { defaultVaultWritePosture } = await import('../secret-detect/vault-write.js')
+const brokerClient = await import('../../src/vault/broker/client.js')
+const putMock = brokerClient.putViaBroker as ReturnType<typeof vi.fn>
+
+describe('defaultVaultWritePosture', () => {
+  beforeEach(() => {
+    putMock.mockReset()
+  })
+
+  it('returns { ok: true } on broker `kind: ok`', async () => {
+    putMock.mockResolvedValueOnce({ kind: 'ok' })
+    const r = await defaultVaultWritePosture('forward-email/api-key', 'sk-value')
+    expect(r.ok).toBe(true)
+    expect(r.output).toContain('forward-email/api-key')
+  })
+
+  it('forwards attest_via_posture: true on the put RPC', async () => {
+    putMock.mockResolvedValueOnce({ kind: 'ok' })
+    await defaultVaultWritePosture('ha/access-token', 'jwt-value')
+    expect(putMock).toHaveBeenCalledTimes(1)
+    const [, , opts] = putMock.mock.calls[0]
+    expect(opts).toMatchObject({ attest_via_posture: true })
+  })
+
+  it('forwards kind: string entry verbatim', async () => {
+    putMock.mockResolvedValueOnce({ kind: 'ok' })
+    await defaultVaultWritePosture('some-key', 'some-value')
+    const [keyArg, entryArg] = putMock.mock.calls[0]
+    expect(keyArg).toBe('some-key')
+    expect(entryArg).toEqual({ kind: 'string', value: 'some-value' })
+  })
+
+  it('returns ok:false with VAULT-BROKER-UNREACHABLE prefix on unreachable', async () => {
+    putMock.mockResolvedValueOnce({ kind: 'unreachable', msg: 'connect ENOENT' })
+    const r = await defaultVaultWritePosture('k', 'v')
+    expect(r.ok).toBe(false)
+    expect(r.output).toContain('VAULT-BROKER-UNREACHABLE')
+    expect(r.output).toContain('connect ENOENT')
+  })
+
+  it('returns ok:false with VAULT-BROKER-DENIED prefix on denied', async () => {
+    putMock.mockResolvedValueOnce({
+      kind: 'denied',
+      code: 'DENIED',
+      msg: 'attest_via_posture requires telegram-id',
+    })
+    const r = await defaultVaultWritePosture('k', 'v')
+    expect(r.ok).toBe(false)
+    expect(r.output).toContain('VAULT-BROKER-DENIED')
+    expect(r.output).toContain('DENIED')
+    expect(r.output).toContain('telegram-id')
+  })
+
+  it('returns ok:false with VAULT-BROKER-UNKNOWN_KEY prefix on not_found', async () => {
+    putMock.mockResolvedValueOnce({
+      kind: 'not_found',
+      code: 'UNKNOWN_KEY',
+      msg: 'no such key',
+    })
+    const r = await defaultVaultWritePosture('k', 'v')
+    expect(r.ok).toBe(false)
+    expect(r.output).toContain('VAULT-BROKER-UNKNOWN_KEY')
+  })
+
+  it('resolves the broker socket via resolveBrokerSocketPath()', async () => {
+    const resolveMock = brokerClient.resolveBrokerSocketPath as ReturnType<typeof vi.fn>
+    resolveMock.mockReturnValueOnce('/tmp/test-socket')
+    putMock.mockResolvedValueOnce({ kind: 'ok' })
+    await defaultVaultWritePosture('k', 'v')
+    const [, , opts] = putMock.mock.calls[0]
+    expect(opts).toMatchObject({ socket: '/tmp/test-socket' })
+  })
+})


### PR DESCRIPTION
## Summary

Closes the UX gap where tapping Save on a `vault_request_save` card surfaced a misleading "🔒 Vault is locked" message even when the broker had been auto-unlocked for hours.

#1115 follow-up. The save handler now uses `attest_via_posture: true` under `telegram-id` mode (just like `mint_grant` does since #1115). Closes the tracked follow-up named in the existing `gateway.ts:11784` comment.

## Surfaced 2026-05-24

Clerk asked for `forward-email/api-key` via `vault_request_save`. Operator tapped Save. Gateway responded with "🔒 Vault is locked, run `/vault unlock`". The broker was unlocked at the time (uptime 1h, 78 keys, all per-agent socket pairs ok). The misleading text was the gateway's **per-chat passphrase cache** being empty — not the broker. Audit log confirmed zero `op:put` lines for the requested key — every save attempt short-circuited on the empty cache.

## Root cause

The #1115 first-cut added a telegram-id silent-save shortcut that pulled an in-memory passphrase. The reviewer flagged it as a bypass surface (claude in the same container could exfiltrate). The follow-up withdrew the shortcut but left telegram-id mode falling through to the standard passphrase-cache path. **Telegram-id installs never run `/vault unlock`** (auto-unlock at boot), so the cache stays empty forever and every `vault_request_save` card wedges.

The original PR comment (`telegram-plugin/gateway/gateway.ts:11784`) named the proper resolution as a tracked follow-up: *"routing it through broker-IPC attest_via_posture is a tracked follow-up."*

## Architecture

Already in place:
- Broker server supports `put` with `attest_via_posture: true` (`src/vault/broker/server.ts:1448-1500`) — added by #1115 follow-up rev 3.
- Broker client `putViaBroker` accepts the flag (`src/vault/broker/client.ts:557-600`).

Gap: the CLI shell-out (`defaultVaultWrite`) didn't expose the flag.

## Fix

- New `defaultVaultWritePosture(slug, value)` helper calls `putViaBroker` directly with `attest_via_posture: true`. Returns the same `VaultWriteResult` shape as `defaultVaultWrite` for drop-in substitution. Wraps broker error shapes in `VAULT-BROKER-*` prefixes so the existing `parseVaultCliError` / `renderVaultCliError` stack still surfaces actionable host hints on failure.
- `handleVaultRequestSaveCallback` branches on `VAULT_APPROVAL_AUTH_MODE`:

| Mode | Path | Passphrase needed |
|---|---|---|
| `telegram-id` | `defaultVaultWritePosture` (new) | No |
| `passphrase` | cached-passphrase + `defaultVaultWrite` (legacy) | Yes |

- Card text corrected from "🔒 Vault is locked" to "🔒 Passphrase not cached for this chat" — the broker is independent of the chat's passphrase cache; the old text conflated them.

## Scope

Only `handleVaultRequestSaveCallback`. The other two save-ish callsites (`handleVaultDeferCallback`, stash-command auto-save) keep their existing cached-passphrase paths — they're operator-initiated chat commands where `/vault unlock` is a natural prerequisite, not agent-initiated approval cards. Tracked follow-up if the same UX wedge surfaces there.

## Test plan

- [x] `vitest run telegram-plugin/tests/` — 2745/2745 pass
- [x] `bun test telegram-plugin/tests/` — 3331/3331 pass
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean
- [x] `check-vault-test-hermeticity.mjs` clean
- [x] New `vault-write-posture.test.ts` (7 cases) pins the helper's contract
- [x] Existing `vault-approval-posture.test.ts` updated with new pins; invariant #3 preserved
- [ ] **Live canary after release**: on clerk's chat, ask the agent to retry `vault_request_save` for `forward-email/api-key`; tap Save; verify the secret lands (audit log shows `op:put, key:forward-email/api-key, result:allowed`) without any `/vault unlock` first

## Risk

Low. The change is gated on `VAULT_APPROVAL_AUTH_MODE === 'telegram-id'` so passphrase-mode installs see zero diff. The new `attest_via_posture` flag has been broker-side since #1115 follow-up rev 3 (in production via the `mint_grant` path). The handler keeps the same outcome shape (success / failure / wake-agent) so downstream code is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)