### PR TITLE
fix(gateway): release buffer gate on every reply finalize (v0.13.30 wedge follow-up)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1413,6 +1413,78 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
 }
 
 /**
+ * Narrow buffer-gate release. Clears the per-key
+ * `activeTurnStartedAt` entry and triggers the held-inbound flush
+ * if the fleet went idle, WITHOUT touching the reaction
+ * controller, the active-reaction message-id, or the typing loop.
+ *
+ * Why split from `purgeReactionTracking`. #1718's contract keeps
+ * `activeStatusReactions[key]` alive across the turn so the
+ * working-state ladder can re-paint on every tool/thinking event
+ * (and the steer-vs-queue logic at the inbound handler reads the
+ * controller — gateway.ts:8322-8323 — to classify mid-turn
+ * messages). Wiping the controller mid-turn would either collapse
+ * the ladder to 👍 prematurely (#1713 regression) or break the
+ * steer detection.
+ *
+ * The BUFFER gate (`activeTurnStartedAt`) is a separate concern:
+ * it gates `shouldBufferInbound` (gateway.ts:8603) and the
+ * "claude is idle" flush at `purgeReactionTracking`'s tail. The
+ * #1728/#1729 fix released both halves together by gating on
+ * `isFinalAnswerReply`, but a trivial-prompt reply that sets
+ * `disable_notification: true` and is < 200 chars (e.g. the model
+ * mis-classifies "4" as an interim ack) returns false from
+ * `isFinalAnswerReply`, so neither half releases and the gate
+ * wedges (v0.13.30 UAT regression — every subsequent inbound logs
+ * `held mid-turn ... will flush on turn-complete` forever).
+ *
+ * `releaseTurnBufferGate` is called from `executeReply` on EVERY
+ * successful reply finalize — regardless of `isFinalAnswerReply` —
+ * so the buffer gate releases independently of the reaction
+ * state. The reaction controller stays for #1713's bidirectional
+ * ladder + steer detection; only the gate flips.
+ *
+ * Idempotent: a second release is a no-op `.delete()` on an
+ * already-empty key.
+ *
+ * @internal exported only via the `gateway.ts` module — used by
+ * `executeReply`'s post-send block and by tests via source-level
+ * pinning in `vault-approval-posture.test.ts` / wedge-guard suites.
+ */
+function releaseTurnBufferGate(key: string): void {
+  if (!activeTurnStartedAt.has(key)) return
+  activeTurnStartedAt.delete(key)
+  // Shadow trace so the structural turn-end metric still records.
+  // outboundEmitted=true is correct here — we only reach this from
+  // executeReply AFTER an outbound landed.
+  shadowEmit({ kind: 'turnEnd', key: key as _ChatKey, at: Date.now(), outboundEmitted: true })
+
+  // Mirror the deterministic-delivery flush from
+  // `purgeReactionTracking` (gateway.ts:1376-1399). When the fleet
+  // hits zero-active-turns, drain any held inbound. This is the
+  // load-bearing wedge fix: the gate that pinned msg 1874+ in
+  // test-harness's 13:02 UAT now opens after the reply.
+  if (activeTurnStartedAt.size === 0) {
+    const selfAgentForFlush = process.env.SWITCHROOM_AGENT_NAME ?? ''
+    if (pendingInboundBuffer.depth(selfAgentForFlush) > 0) {
+      const fr = redeliverBufferedInbound(
+        pendingInboundBuffer,
+        selfAgentForFlush,
+        (m) => ipcServer.sendToAgent(selfAgentForFlush, m),
+        inboundSpool,
+      )
+      if (fr.redelivered > 0) {
+        process.stderr.write(
+          `telegram gateway: reply-released-gate flushed ${fr.redelivered}/${fr.drained} ` +
+          `held inbound for ${selfAgentForFlush}` +
+          `${fr.rebuffered > 0 ? ` (${fr.rebuffered} re-buffered)` : ''}\n`,
+        )
+      }
+    }
+  }
+}
+
+/**
  * Atomic null-and-purge for a wedged turn. Every site that ends a
  * turn by nulling `currentTurn` MUST also clear the turn's statusKey
  * from `activeTurnStartedAt` — else a dangling entry survives and
@@ -4975,6 +5047,24 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       // observable side effects that #1718 deferred unconditionally.
       finalizeStatusReaction(chat_id, threadId, 'done')
     }
+    // v0.13.30 follow-up — release the buffer gate on EVERY reply
+    // finalize, not just on `isFinalAnswerReply`. The narrow
+    // `finalizeStatusReaction` path above misses short replies that
+    // set `disable_notification: true` (the model mis-classifies a
+    // genuine answer as an interim ack — e.g. "4" for "what's
+    // 2+2"). Pre-fix the gate stayed set forever and every later
+    // inbound logged `held mid-turn ... will flush on turn-
+    // complete` — but turn-complete never came because Claude
+    // Code's `turn_duration` system event doesn't reliably land
+    // for trivial-prompt turns. v0.13.30 UAT showed the regression
+    // (msg 1873 reply at 13:02:46, msg 1874 held at 13:03:04, gate
+    // never released).
+    //
+    // The reaction controller stays alive (preserves #1713
+    // bidirectional ladder + the steer-vs-queue logic at
+    // gateway.ts:8322 which reads `activeStatusReactions`). Only
+    // the buffer gate flips.
+    releaseTurnBufferGate(statusKey(chat_id, threadId))
   }
 
   process.stderr.write(`telegram channel: reply: finalized chatId=${chat_id} messageIds=[${sentIds.join(',')}] chunks=${chunks.length}\n`)
@@ -5230,6 +5320,17 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     })
   ) {
     turn.finalAnswerDelivered = true
+  }
+  // v0.13.30 follow-up — release the buffer gate on every successful
+  // stream_reply too. Same rationale as executeReply: short replies
+  // with `disable_notification: true` would otherwise wedge the gate
+  // forever. `result.status` is always 'updated' | 'finalized'
+  // (stream-reply-handler.ts:305) at this point — earlier failures
+  // throw or return before reaching here.
+  {
+    const sChat = args.chat_id as string
+    const sThread = resolveThreadId(sChat, args.message_thread_id as string | undefined)
+    releaseTurnBufferGate(statusKey(sChat, sThread))
   }
   return { content: [{ type: 'text', text: `${result.status} (id: ${result.messageId ?? 'pending'})` }] }
 }

--- a/telegram-plugin/tests/buffer-gate-broadened.test.ts
+++ b/telegram-plugin/tests/buffer-gate-broadened.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression guard for the v0.13.30→v0.13.31 wedge fix: the buffer
+ * gate (`activeTurnStartedAt`) must release on EVERY successful
+ * reply / stream_reply finalize — not just on `isFinalAnswerReply`.
+ *
+ * Surfaced 2026-05-24 via the v0.13.30 UAT canary:
+ *   13:02:46 reply finalized for msg 1873 (charCount=67)
+ *   13:03:04 msg 1874 — held mid-turn  (gate STILL open)
+ *   13:03:40 msg 1875 — held mid-turn  (depth=2)
+ *   13:04:19 msg 1876 — held mid-turn  (depth=3)
+ *
+ * Root cause: the trivial-prompt reply used `disable_notification:
+ * true` and was < 200 chars (the model classified "4" as an interim
+ * ack), so `isFinalAnswerReply` returned false, the
+ * `finalizeStatusReaction` gate in `executeReply` short-circuited,
+ * and the buffer gate stayed set. Pre-#1718 the gate released on
+ * every reply (via `endStatusReaction → purgeReactionTracking`);
+ * #1718 deferred everything to `turn_end`, then #1729 partially
+ * restored via `isFinalAnswerReply`-gated finalize. This fix
+ * decouples the buffer-gate release from the reaction-state
+ * finalize: every successful reply releases the gate, the reaction
+ * controller stays alive (preserves #1713 bidirectional ladder +
+ * the steer-vs-queue logic).
+ *
+ * The gateway IIFE is too entangled to instantiate in-process; we
+ * do source-level assertions like `reply-terminal-reaction.test.ts`
+ * does. If a future commit regresses the contract (re-narrows the
+ * gate release, or removes the helper), these assertions trip.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+describe('buffer-gate release decoupled from final-answer classification', () => {
+  // Extract the helper's docstring (everything between the matching
+  // `/**` block above `function releaseTurnBufferGate` and the
+  // function declaration). The body slice (used by other tests) is
+  // separate — see fnBody().
+  function fnDocstring(): string {
+    const beforeFn = gatewaySrc.split('function releaseTurnBufferGate')[0] ?? ''
+    const lastBlockOpen = beforeFn.lastIndexOf('/**')
+    if (lastBlockOpen < 0) return ''
+    return beforeFn.slice(lastBlockOpen)
+  }
+  function fnBody(): string {
+    // The function body — everything between `function
+    // releaseTurnBufferGate(...): void {` and its matching `}`. Use
+    // a simple brace-balance over the slice from open-brace onward.
+    const afterDecl = gatewaySrc.split('function releaseTurnBufferGate')[1] ?? ''
+    const openIdx = afterDecl.indexOf('{')
+    if (openIdx < 0) return ''
+    let depth = 0
+    for (let i = openIdx; i < afterDecl.length; i++) {
+      const ch = afterDecl[i]
+      if (ch === '{') depth++
+      else if (ch === '}') {
+        depth--
+        if (depth === 0) return afterDecl.slice(openIdx, i + 1)
+      }
+    }
+    return afterDecl.slice(openIdx)
+  }
+
+  it('declares a narrow `releaseTurnBufferGate` helper (not the full purgeReactionTracking)', () => {
+    expect(gatewaySrc).toMatch(/function releaseTurnBufferGate\(key: string\): void/)
+    // The helper docstring must explain WHY split from
+    // purgeReactionTracking — future readers need to know.
+    const doc = fnDocstring()
+    expect(doc).toMatch(/#1713/)
+    expect(doc).toMatch(/steer-vs-queue/)
+  })
+
+  it('releaseTurnBufferGate ONLY clears activeTurnStartedAt + flushes; does NOT touch activeStatusReactions', () => {
+    const body = fnBody()
+    expect(body).toMatch(/activeTurnStartedAt\.delete\(key\)/)
+    expect(body).toMatch(/pendingInboundBuffer/)
+    // Critical regression guard: the helper must NOT touch the
+    // reaction controller, else #1713's bidirectional ladder
+    // collapses to 👍 mid-turn.
+    expect(body).not.toMatch(/activeStatusReactions\.delete/)
+    expect(body).not.toMatch(/activeReactionMsgIds\.delete/)
+    // Also must NOT call finalizeStatusReaction or
+    // purgeReactionTracking (both would clear the controller).
+    expect(body).not.toMatch(/finalizeStatusReaction\(/)
+    expect(body).not.toMatch(/purgeReactionTracking\(/)
+  })
+
+  it('executeReply calls releaseTurnBufferGate OUTSIDE the isFinalAnswerReply branch', () => {
+    // Slice the executeReply post-send block (between the anchor
+    // comments and the next exported function).
+    const post = gatewaySrc.split("fresh sendMessage from reply tool is a user-visible")[1] ?? ''
+    const slice = post.split('\nasync function ')[0] ?? ''
+    // The narrow `isFinalAnswerReply`-gated finalize MUST stay (it
+    // emits the 👍 reaction on the final-answer happy path).
+    expect(slice).toMatch(/isFinalAnswerReply\(/)
+    expect(slice).toMatch(/finalizeStatusReaction\(/)
+    // The new unconditional buffer-gate release must ALSO be
+    // present and must be OUTSIDE the isFinalAnswerReply branch
+    // (so trivial-prompt non-notification replies still release
+    // the gate).
+    expect(slice).toMatch(/releaseTurnBufferGate\(statusKey\(chat_id, threadId\)\)/)
+    // Structural check: the release must appear AFTER the
+    // isFinalAnswerReply block's closing brace but BEFORE the
+    // post-send block ends. Easiest pin: it must NOT be inside the
+    // `if (turn != null && isFinalAnswerReply(...))` block.
+    const gateBlockOpen = slice.indexOf('if (turn != null && isFinalAnswerReply(')
+    const gateBlockClose = slice.indexOf('}', gateBlockOpen)
+    const releaseIdx = slice.indexOf('releaseTurnBufferGate(')
+    expect(gateBlockOpen).toBeGreaterThan(-1)
+    expect(gateBlockClose).toBeGreaterThan(gateBlockOpen)
+    expect(releaseIdx).toBeGreaterThan(gateBlockClose)
+  })
+
+  it('executeStreamReply calls releaseTurnBufferGate before its final return', () => {
+    const post =
+      gatewaySrc.split('async function executeStreamReply')[1]
+        ?.split('\nasync function ')[0] ?? ''
+    expect(post).toMatch(/releaseTurnBufferGate\(statusKey\(/)
+  })
+
+  it('the helper is invoked from executeReply / executeStreamReply only — not from new mid-turn paths', () => {
+    // Sanity: nothing else should call releaseTurnBufferGate. The
+    // helper is narrow on purpose. If future code adds new
+    // callsites that aren't reply-finalize, the steer-vs-queue
+    // semantics could drift.
+    const callMatches = gatewaySrc.match(/releaseTurnBufferGate\(/g) ?? []
+    // Definition + 2 callsites (executeReply, executeStreamReply) = 3.
+    // If this count grows the test catches it; reviewer must justify
+    // any new callsite.
+    expect(callMatches.length).toBe(3)
+  })
+})


### PR DESCRIPTION
## Summary

#1728/#1729 follow-up. Closes the trivial-prompt wedge where short non-notification replies (e.g. the model sends "4" as `disable_notification: true` for "what's 2+2?") fail `isFinalAnswerReply`, the #1729 `finalizeStatusReaction` short-circuits, and `activeTurnStartedAt` never releases.

Surfaced on v0.13.30 UAT canary 2026-05-24:
```
13:02:46 reply finalized for msg 1873 (charCount=67)
13:03:04 msg 1874 — held mid-turn
13:03:40 msg 1875 — held mid-turn (depth=2)
13:04:19 msg 1876 — held mid-turn (depth=3)
```

The wedge has been latent since v0.13.28 (where #1729 first landed). v0.13.28 passed UAT once by cache-warm luck; the structural issue stayed. v0.13.30 didn't regress anything — gateway diff between v0.13.28 and v0.13.30 doesn't touch `executeReply`, `finalizeStatusReaction`, or `activeTurnStartedAt`. Just exposed the latent wedge on a different cache state.

## Fix

Decouple buffer-gate cleanup from reaction-state finalize.

New narrow `releaseTurnBufferGate(key)` helper at `telegram-plugin/gateway/gateway.ts:~1415`:
- Clears `activeTurnStartedAt[key]` (the buffer gate)
- Triggers the deterministic-delivery flush on `size === 0`
- Emits the `turnEnd` shadow trace

Does NOT touch:
- `activeStatusReactions` — preserves #1713's bidirectional ladder AND the steer-vs-queue logic at `gateway.ts:8322` (which reads the controller to classify mid-turn inbounds)
- `activeReactionMsgIds`
- The typing loop

Called unconditionally from `executeReply` and `executeStreamReply` on successful finalize, regardless of `isFinalAnswerReply`. The narrow #1729 `finalizeStatusReaction` call stays (still fires the 👍 reaction on the final-answer happy path); only the buffer-gate cleanup is broadened.

## Net contract

| Reply shape | 👍 (debounced) | Buffer gate | currentTurn |
|---|---|---|---|
| Final-answer (notification-bearing OR ≥200 chars OR done) | fires | released | stays (turn_end cleans) |
| Short non-notification (interim-ack-style) | unchanged (no 👍 mid-turn) | **NEW: released** | stays |
| `turn_end` event | fires (idempotent) | released (idempotent) | nulled |
| Steer / queued mid-turn detection | unchanged (reads `activeStatusReactions`) | n/a | n/a |

## Tests

- New `telegram-plugin/tests/buffer-gate-broadened.test.ts` — 5 cases pin the narrow contract structurally. Critical guards: helper does NOT call `activeStatusReactions.delete` / `finalizeStatusReaction` / `purgeReactionTracking`; release call is OUTSIDE the `isFinalAnswerReply` branch in `executeReply`; callsite count locked to 3 (definition + 2 usages).
- Full plugin suite: vitest 2750/2750 + bun:test 3336/3336.
- Lint guards: `check-bot-api-wrapping.sh` clean, `check-vault-test-hermeticity.mjs` clean.

## Live canary plan

After release v0.13.31:
1. Roll fleet: `switchroom update --pin v0.13.31`
2. Run `bun run --cwd telegram-plugin test:uat jtbd-fast-trivial-dm` (the v0.13.30 failure mode) — expect TTFO < 12s.
3. Grep test-harness `gateway-supervisor.log` for `held mid-turn` since rollout time. Expect ZERO new entries.
4. Repeat the trivial-prompt UAT 3-5 times to confirm not a flake.
5. If green: clean up, done.

## Risk

Low. The reaction state and steer-vs-queue logic are unchanged (the controller stays alive). The buffer-gate release on every reply mirrors pre-#1718 behavior (which worked structurally — #1718's design intent was to keep the controller alive across the turn for the ladder, not to keep the buffer gate set). Tests pin the narrow contract so regression is structurally caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)