### PR TITLE
fix(broker): bind-mount vault-grants.db so grants survive container recreate

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -951,6 +951,32 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // because broker appends; broker runs as root with CAP_DAC_OVERRIDE
   // so file ownership/mode doesn't gate the write path. See #1025.
   lines.push(`      - ${homePrefix}/.switchroom/vault-audit.log:/root/.switchroom/vault-audit.log`);
+  // Capability grants DB — bind-mount the host SQLite file into the
+  // broker so grants survive container recreate. Without this mount
+  // the broker writes to `/root/.switchroom/vault-grants.db` inside
+  // the container (which evaporates on every recreate). The token
+  // files on disk (`~/.switchroom/agents/<agent>/.vault-token`)
+  // persist via the per-agent bind mounts and reference a grant ID
+  // that no longer exists in the fresh broker DB — the broker's
+  // #1496 fall-through routes the call to the standing schedule.
+  // secrets ACL, which usually denies because the granted key
+  // isn't in the agent's static config (the whole reason a grant
+  // was minted in the first place). Surfaces as
+  // `VAULT-BROKER-DENIED [DENIED]: key 'X' not in ACL for agent
+  // 'Y'` on every `switchroom vault get` from inside the agent
+  // container after a broker recreate.
+  //
+  // Surfaced 2026-05-24 after the v0.13.31 broker recreate wiped
+  // every grant minted earlier the same day (clerk's vg_5e1991 for
+  // `ha/access-token`). The doctor probe doesn't catch this — it
+  // only inspects path-as-identity ACL, not grant-based access.
+  //
+  // Pre-created mode 0600 by `ensureHostMountSources()` (apply.ts)
+  // so docker doesn't auto-create a directory at the source path.
+  // Broker writes via root with CAP_DAC_OVERRIDE so file
+  // ownership doesn't gate the write path. (Same pattern as
+  // vault-audit.log above and host-control-audit.log on hostd.)
+  lines.push(`      - ${homePrefix}/.switchroom/vault-grants.db:/root/.switchroom/vault-grants.db`);
   // /etc/machine-id passthrough — required so the broker can derive
   // the same machine-bound key the host's `enable-auto-unlock` used
   // to seal the auto-unlock blob. The agent base image (node:22-bookworm-slim)

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -328,6 +328,25 @@ async function ensureHostMountSources(config: SwitchroomConfig): Promise<void> {
     writeFileSync(auditLogPath, "", { mode: 0o644 });
   }
 
+  // vault-grants.db: capability-token grants persisted to a SQLite
+  // file. Same dir-vs-file race as vault-audit.log — if the source
+  // path doesn't exist, docker auto-creates it as a root-owned
+  // DIRECTORY and the broker can't write. Pre-create as a 0-byte
+  // file owned by the operator (mode 0600 — secrets material, no
+  // group/other access). The broker's `openGrantsDb` runs the SQL
+  // migration on first open and turns the empty file into a valid
+  // schema, so the broker boots cleanly on either a fresh empty
+  // file OR an existing populated DB.
+  //
+  // Without this bind mount + pre-create, broker recreates wipe
+  // every capability grant — the orphaned `.vault-token` files
+  // on disk then fail every `vault get` from inside agent
+  // containers. Surfaced 2026-05-24 after the v0.13.31 rollout.
+  const grantsDbPath = join(home, ".switchroom", "vault-grants.db");
+  if (!existsSync(grantsDbPath)) {
+    writeFileSync(grantsDbPath, "", { mode: 0o600 });
+  }
+
   // host-control-audit.log: same pattern as vault-audit.log — hostd
   // is the writer (from inside its own container at /host-home),
   // admin agents bind-mount it :ro so `/audit hostd` (#1328) can

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -737,6 +737,34 @@ describe("generateCompose", () => {
     );
   });
 
+  it("broker bind-mounts the host vault-grants.db onto /root/.switchroom/vault-grants.db (#1737 wedge)", () => {
+    // fails when: the broker writes the capability-grants SQLite to a
+    // container-local path that evaporates on recreate. Token files on
+    // disk (~/.switchroom/agents/<agent>/.vault-token) persist via the
+    // per-agent bind mounts and reference grant IDs that no longer
+    // exist in the fresh broker DB — every `switchroom vault get` from
+    // inside an agent container returns
+    // `VAULT-BROKER-DENIED [DENIED]: key 'X' not in ACL for agent 'Y'`
+    // because the #1496 fall-through routes the unusable token to the
+    // standing schedule.secrets ACL, which usually denies (the whole
+    // reason a grant was minted in the first place).
+    //
+    // Surfaced 2026-05-24 when clerk's vg_5e1991 grant for
+    // `ha/access-token` disappeared after the v0.13.31 broker recreate.
+    // The doctor probe doesn't catch it — doctor only inspects path-
+    // as-identity ACL, not grant-based access.
+    //
+    // Mount is RW (not :ro) because the broker writes new rows on every
+    // mint_grant call; `ensureHostMountSources()` in apply.ts pre-
+    // creates the source file mode 0600 (secrets material) so docker
+    // doesn't auto-create a directory at the mount path.
+    const out = generateCompose({ config: makeConfig({ a: {} }) });
+    const block = /vault-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toMatch(
+      /-\s+\$\{HOME\}\/\.switchroom\/vault-grants\.db:\/root\/\.switchroom\/vault-grants\.db(?!:ro)/,
+    );
+  });
+
   it("kernel keeps CHOWN + FOWNER (mirrors broker socket-ownership flow)", () => {
     const out = generateCompose({ config: makeConfig({ a: {} }) });
     const block = /approval-kernel:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";


### PR DESCRIPTION
## Summary

Capability grants minted via Telegram approval cards (the access-approve flow #1051/#1115) live in a SQLite DB the broker writes to `/root/.switchroom/vault-grants.db` — which evaporates on every container recreate. Token files on disk persist (orphaned). Result: every `switchroom vault get` from inside an agent container returns `VAULT-BROKER-DENIED [DENIED]: key 'X' not in ACL for agent 'Y'` after a broker recreate, even though the agent legitimately has a token file with the right grant ID.

## Surfaced 2026-05-24

Diagnosing the clerk save-card chain end-to-end revealed the wedge. Clerk's `vg_5e1991` grant for `ha/access-token` was minted via Telegram approval at 11:25 today and worked fine until the v0.13.31 broker recreate at 13:21. Audit log shows the broker now has `4096 bytes` (essentially empty) in `/root/.switchroom/vault-grants.db`; the host has the older `57344 bytes` file from May 22 that the broker is NOT bind-mounting. Token file on clerk side is at the right path, mode 0600, content matches `vg_5e1991` — but the broker can't validate it because the grant row is gone.

## Root cause

Broker compose mounts vault.enc + vault-audit.log + machine-id but skips vault-grants.db. Doctor doesn't catch it — only inspects path-as-identity ACL.

## Fix

Mirror the vault-audit.log pattern for vault-grants.db:

- `src/agents/compose.ts` — bind-mount `${HOME}/.switchroom/vault-grants.db:/root/.switchroom/vault-grants.db` in the broker service (RW).
- `src/cli/apply.ts:ensureHostMountSources` — pre-create the host file as 0-byte mode 0600 so docker doesn't auto-create a directory at the source path on greenfield installs.

## Tests

- `tests/docker/compose-generator.test.ts` — new pin asserts the RW bind mount is in the broker block.
- Full suite green: vitest 7156/7156 + bun:test 3336/3336. Lints clean.

## Rollout

After this lands and the broker container recreates:
- The host file (May 22 snapshot, 57344 bytes) becomes the broker's live DB.
- Any grants minted between May 22 and the rollout (in the ephemeral container DB) are lost. Currently no active grants on the broker so this is a clean slate.
- Operator will need to re-approve any active vault_request_access flows via Telegram. (For Ken: clerk's `ha/access-token` grant needs re-mint.)
- Going forward, all grants survive broker recreates.

## Risk

Low. The change mirrors a well-trodden bind-mount pattern. Boot path is clean on either empty new file OR existing populated DB (`openGrantsDb` runs the migration idempotently). Verified by the existing `src/vault/grants-db.ts` migration logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)