### PR TITLE
fix(#1741): silent-end ack reply no longer clears state

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4594,12 +4594,21 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // #1122 KPI: a `reply` always produces a fresh user-visible outbound
   // message — count it for the outbound-gap / TTFO KPI AND reset the
   // silence-poke clock so the next poke is measured from this send.
-  // Also clear any silent-end state file so the Stop hook doesn't fire
-  // a stale block when the session ends (deterministic restore of the
-  // detection PR3 inadvertently removed).
   signalTracker.noteOutbound(statusKey(chat_id, threadId), Date.now())
   silencePoke.noteOutbound(statusKey(chat_id, threadId), Date.now())
-  clearSilentEndState(statusKey(chat_id, threadId))
+  // #1741 — only clear silent-end state on a plausibly-final reply.
+  // An interim ack (disable_notification:true, short text, no done)
+  // must NOT clear the state file; otherwise a turn that ends with
+  // ack-only + answer-as-transcript leaves no state for the Stop
+  // hook to act on if `turn_end` never lands (the `turn_duration`
+  // system event is unreliable for trivial-prompt turns — see the
+  // executeReply finalize comments). Final-answer replies still
+  // clear; the main turn-end path also re-writes the state when
+  // finalAnswerDelivered=false, so this is a belt-and-braces gate
+  // for the turn_end-missing case (#1741).
+  if (isFinalAnswerReply({ text: rawText, disableNotification })) {
+    clearSilentEndState(statusKey(chat_id, threadId))
+  }
 
   if (previewMessageId != null && reply_to != null && replyMode !== 'off') {
     await deleteStalePreview(previewMessageId)
@@ -5170,7 +5179,19 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       const sKey = statusKey(streamChatId, streamThreadId)
       signalTracker.noteOutbound(sKey, Date.now())
       silencePoke.noteOutbound(sKey, Date.now())
-      clearSilentEndState(sKey)
+      // #1741 — see executeReply for the rationale: only a plausibly-
+      // final stream_reply clears the silent-end state. An interim
+      // ack via stream_reply must NOT clear; the Stop hook needs
+      // the state to persist if turn_end fails to land.
+      if (
+        isFinalAnswerReply({
+          text: (args.text as string | undefined) ?? '',
+          disableNotification: args.disable_notification === true,
+          done: args.done === true,
+        })
+      ) {
+        clearSilentEndState(sKey)
+      }
     }
   }
 

--- a/telegram-plugin/tests/silent-end.test.ts
+++ b/telegram-plugin/tests/silent-end.test.ts
@@ -301,6 +301,111 @@ describe('recordUndeliveredTurnEnd — #1664 extended trigger', () => {
   })
 })
 
+describe('#1741 — ack reply must not clear silent-end state', () => {
+  // The gateway gates `clearSilentEndState` at the reply send-site on
+  // `isFinalAnswerReply`. These tests reproduce that gate as a unit:
+  // simulate a turn's reply sequence by calling the same predicate the
+  // gateway uses, and assert state-file persistence matches the contract.
+  //
+  // Why this matters: if `turn_end` never lands (Claude Code's
+  // `turn_duration` system event is unreliable for trivial-prompt
+  // turns), the only line of defence between an undelivered turn and
+  // the Stop hook is the persistence of `silent-end-pending.json`.
+  // Pre-fix, an ack reply cleared the file unconditionally — so the
+  // Stop hook found no state and allowed the stop on every ack-then-
+  // tool-then-silent shape. Post-fix, only a plausibly-final reply
+  // clears it.
+
+  function simulateReplyAtGateway(
+    reply: { text: string; disableNotification: boolean; done?: boolean },
+    turnKey: string,
+  ): void {
+    // The gateway calls clearSilentEndState ONLY when isFinalAnswerReply
+    // is true. Mirror that gate exactly.
+    if (isFinalAnswerReply(reply)) {
+      clearSilentEndState(turnKey)
+    }
+  }
+
+  it('ack reply (disable_notification, short, no done) does NOT clear pending state', () => {
+    // A prior turn-end already wrote state (or a re-prompt round wrote it).
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey: 'c:_' })
+    // Agent sends an interim ack.
+    simulateReplyAtGateway(
+      { text: 'On it', disableNotification: true },
+      'c:_',
+    )
+    // State must persist — the Stop hook still needs to be able to
+    // catch a subsequent silent end.
+    expect(readSilentEndState()).not.toBeNull()
+    expect(readSilentEndState()!.turnKey).toBe('c:_')
+  })
+
+  it('final-answer reply (disable_notification=false) clears the state', () => {
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey: 'c:_' })
+    simulateReplyAtGateway(
+      { text: "Done — here's the result.", disableNotification: false },
+      'c:_',
+    )
+    expect(readSilentEndState()).toBeNull()
+  })
+
+  it('stream_reply done=true clears the state even with disable_notification=true', () => {
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey: 'c:_' })
+    simulateReplyAtGateway(
+      { text: 'ok', disableNotification: true, done: true },
+      'c:_',
+    )
+    expect(readSilentEndState()).toBeNull()
+  })
+
+  it('long ack-shaped reply (>=200 chars) is treated as final and clears the state', () => {
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey: 'c:_' })
+    simulateReplyAtGateway(
+      { text: 'x'.repeat(250), disableNotification: true },
+      'c:_',
+    )
+    expect(readSilentEndState()).toBeNull()
+  })
+
+  it('ack-then-silent end-to-end: ack does not clear, Stop hook still blocks', () => {
+    // 1. The previous undelivered turn-end wrote state, OR the turn
+    //    starts fresh and only the Stop hook will see this state file
+    //    once the gateway re-writes it. Simulate the gateway's writer
+    //    firing at turn-end with finalAnswerDelivered=false (no
+    //    qualifying reply happened this turn).
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey: 'c:_' })
+    // 2. Mid-turn ack reply lands. Pre-fix this would unlink the
+    //    state file; post-fix it must persist.
+    simulateReplyAtGateway(
+      { text: 'On it, working on it…', disableNotification: true },
+      'c:_',
+    )
+    // 3. Stop hook fires (separately tested below): it must still
+    //    find the state file and decide to block. Verify the file is
+    //    intact at the path the hook reads.
+    const state = readSilentEndState()
+    expect(state).not.toBeNull()
+    expect(state!.turnKey).toBe('c:_')
+  })
+
+  it('ack-then-final: ack does not clear, final clears', () => {
+    writeSilentEndState({ chatId: 'c', threadId: null, turnKey: 'c:_' })
+    // Interim ack — state persists.
+    simulateReplyAtGateway(
+      { text: 'On it', disableNotification: true },
+      'c:_',
+    )
+    expect(readSilentEndState()).not.toBeNull()
+    // Final answer — state cleared.
+    simulateReplyAtGateway(
+      { text: 'Done — the answer is 42.', disableNotification: false },
+      'c:_',
+    )
+    expect(readSilentEndState()).toBeNull()
+  })
+})
+
 describe('silent-end-interrupt-stop hook — integration', () => {
   const hookPath = join(__dirname, '..', 'hooks', 'silent-end-interrupt-stop.mjs')
 


### PR DESCRIPTION
## Summary

- Gate `clearSilentEndState` at the reply send-sites in `executeReply` and `executeStreamReply` on the existing `isFinalAnswerReply` predicate.
- An interim ack reply (`disable_notification:true`, short text, no `done`) was unconditionally clearing the silent-end state file. When `turn_end` later failed to land (Claude Code's `turn_duration` system event is unreliable for trivial-prompt turns), the Stop hook found no state file and allowed the stop, so silent-end recovery never engaged for the ack-then-tool-then-silent shape.
- The main turn-end path already gates the writer on `turn.finalAnswerDelivered` (#1664) and remains the primary writer; this is the belt-and-braces fix for the `turn_end`-missing case.

## Test plan

- [x] `vitest run telegram-plugin/tests/silent-end.test.ts` — 36 tests pass (30 existing + 6 new under "#1741 — ack reply must not clear silent-end state").
- [x] `vitest run telegram-plugin/tests/final-answer-detect.test.ts` — 8 tests pass (predicate unchanged).
- [x] `node telegram-plugin/scripts/build.mjs` — gateway bundles cleanly.
- [x] `tsc --noEmit` — no new type errors in gateway.ts.

Closes #1741

🤖 Generated with [Claude Code](https://claude.com/claude-code)