### PR TITLE
feat(#1743): release-triggered fleet restart — pull-based detection + graceful apply

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -42,6 +42,25 @@ This same surface is exposed over the **agent-config MCP broker**, so an agent c
 
 Either way, a schedule change takes effect once the in-container scheduler re-registers — on the next `switchroom agent restart <name>` (or any container restart). There is no hot-reload; the scheduler reads config at boot.
 
+### Release-triggered fleet restart (opt-in, #1743)
+
+Plugin / gateway fixes that ship via a `:latest` retag don't change the agent container's image digest, so `docker compose up -d --remove-orphans` is a no-op and the running `bun` process keeps the pre-fix code in memory until an unrelated restart cycles it. To close that lag, the hostd daemon can poll the remote release tag and roll the fleet automatically.
+
+Enable in `switchroom.yaml`:
+
+```yaml
+host_control:
+  auto_release_check:
+    enabled: true
+    interval_minutes: 5            # floor 5, ceiling 1440
+    apply_on_detect: true          # false → log-only (dogfood mode)
+    image_ref: ghcr.io/switchroom/switchroom-agent:latest
+```
+
+When `enabled: true`, hostd polls `docker manifest inspect <image_ref>` every `interval_minutes`. If the remote digest diverges from the local image's `RepoDigests`, it runs `switchroom update` then `switchroom restart all` (graceful — drains in-flight Telegram turns via the existing `decideRestart` path). Events land at `~/.switchroom/release-watcher-events.jsonl` (`release_detected` → `apply_started/succeeded/failed` → `restart_started` → `fleet_caught_up`), with `duration_ms` on `fleet_caught_up` giving the AC's `time_from_release_to_fleet_caught_up_seconds` counter. Failures log and drop the tick — no retry-storm.
+
+Default is `enabled: false` so existing deployments don't suddenly self-roll. Pair with `apply_on_detect: false` to dogfood the detector without rolling the fleet.
+
 ## Guardrails on agent-authored entries
 
 Operator-authored entries in `switchroom.yaml` are trusted. Entries written through the `schedule add` / MCP path are gated (structured error code → exit code):

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1860,6 +1860,51 @@ export const QuotaConfigSchema = z.object({
  * bind mounts for admin agents so the daemon can dispatch a closed
  * set of operator verbs reached from inside the containers.
  */
+/**
+ * Pull-based release-triggered fleet restart (#1743).
+ *
+ * Closes the deployment-lag gap: hostd polls the remote image tag on
+ * a fixed interval, and when the remote digest diverges from the
+ * deployed digest it runs `switchroom update` then `switchroom
+ * restart all` (graceful — drains in-flight turns).
+ */
+export const AutoReleaseCheckSchema = z.object({
+  enabled: z
+    .boolean()
+    .default(false)
+    .describe(
+      "When true, hostd polls the remote release tag every " +
+      "`interval_minutes` and applies + restarts the fleet when a new " +
+      "release is detected. Default false — opt-in.",
+    ),
+  interval_minutes: z
+    .number()
+    .int()
+    .min(5)
+    .max(1440)
+    .default(5)
+    .describe(
+      "Poll interval in minutes. Floor of 5m matches the agent-config " +
+      "cron rate limit; ceiling of 1440m (24h) is a sanity cap.",
+    ),
+  apply_on_detect: z
+    .boolean()
+    .default(true)
+    .describe(
+      "When false, hostd logs `release_detected` but does NOT call " +
+      "update_apply / restart all. Useful for dogfooding the detector " +
+      "without rolling the fleet.",
+    ),
+  image_ref: z
+    .string()
+    .default("ghcr.io/switchroom/switchroom-agent:latest")
+    .describe(
+      "Image reference whose remote digest is compared to the local " +
+      "image digest. Defaults to the agent image's :latest tag, which " +
+      "is the canonical signal that a release has been promoted.",
+    ),
+});
+
 export const HostControlConfigSchema = z.object({
   enabled: z
     .boolean()
@@ -1881,6 +1926,12 @@ export const HostControlConfigSchema = z.object({
       "still rely on the in-container `spawnSwitchroomDetached` " +
       "shellout (removal is tracked as RFC C Phase 3).",
     ),
+  auto_release_check: AutoReleaseCheckSchema.default({}).describe(
+    "Pull-based release-triggered fleet restart (#1743). hostd polls " +
+    "the remote release tag on a fixed interval and applies + " +
+    "restarts the fleet (graceful) when a new release is detected. " +
+    "Opt-in: default enabled=false.",
+  ),
 });
 
 /**
@@ -2158,6 +2209,7 @@ export type AgentDriveConfig = z.infer<typeof AgentDriveConfigSchema>;
 export type VaultBrokerConfig = z.infer<typeof VaultConfigSchema>["broker"];
 export type QuotaConfig = z.infer<typeof QuotaConfigSchema>;
 export type HostControlConfig = z.infer<typeof HostControlConfigSchema>;
+export type AutoReleaseCheck = z.infer<typeof AutoReleaseCheckSchema>;
 export type HostdConfig = z.infer<typeof HostdConfigSchema>;
 export type AuthConfig = NonNullable<z.infer<typeof SwitchroomConfigSchema>["auth"]>;
 export type AuthConsumer = NonNullable<AuthConfig["consumers"]>[number];

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -27,6 +27,13 @@ import { loadConfig } from "../config/loader.js";
 import { allocateAgentUid } from "../agents/compose.js";
 import { HostdServer } from "./server.js";
 import { SocketApprovalGateway } from "./approval-gateway.js";
+import { ReleaseWatcher } from "./release-watcher.js";
+import {
+  makeReleaseCheck,
+  makeApply,
+  makeRestart,
+} from "./release-watcher-shellouts.js";
+import { appendFile } from "node:fs/promises";
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -93,6 +100,45 @@ async function main(): Promise<void> {
     `hostd: ready — bound ${paths.length} agent socket(s): ${paths.join(", ")}\n`,
   );
 
+  // #1743 — pull-based release-triggered fleet restart. Opt-in via
+  // `host_control.auto_release_check.enabled: true`. The watcher
+  // lives inside hostd because it's already the long-running host
+  // daemon with docker socket access + the `switchroom` CLI on PATH
+  // (RFC C §5.1).
+  let releaseWatcher: ReleaseWatcher | null = null;
+  const autoRel = config.host_control?.auto_release_check;
+  if (autoRel?.enabled === true) {
+    const eventsLog = join(
+      homedir(),
+      ".switchroom",
+      "release-watcher-events.jsonl",
+    );
+    releaseWatcher = new ReleaseWatcher({
+      intervalMs: autoRel.interval_minutes * 60_000,
+      checkFn: makeReleaseCheck({
+        imageRef: autoRel.image_ref,
+        log: (m) => process.stderr.write(`hostd: ${m}\n`),
+      }),
+      applyFn: makeApply("switchroom"),
+      restartFn: makeRestart("switchroom"),
+      applyOnDetect: autoRel.apply_on_detect,
+      log: (m) => process.stderr.write(`hostd: ${m}\n`),
+      onEvent: (e) => {
+        // Telemetry sink — JSONL append. The
+        // `time_from_release_to_fleet_caught_up_seconds` AC counter
+        // is the `duration_ms` field of the `fleet_caught_up` row
+        // (delta from the matching `release_detected` row).
+        void appendFile(eventsLog, JSON.stringify(e) + "\n").catch(() => {});
+      },
+    });
+    releaseWatcher.start();
+    process.stderr.write(
+      `hostd: release-watcher started — polling ${autoRel.image_ref} ` +
+        `every ${autoRel.interval_minutes}m ` +
+        `(apply_on_detect=${autoRel.apply_on_detect})\n`,
+    );
+  }
+
   // Wait for SIGTERM / SIGINT. `docker stop` sends SIGTERM after
   // tini relays it; Ctrl-C in dev sends SIGINT. Both shut down
   // gracefully.
@@ -101,6 +147,7 @@ async function main(): Promise<void> {
     if (stopping) return;
     stopping = true;
     process.stderr.write(`hostd: shutting down (${reason})\n`);
+    if (releaseWatcher) releaseWatcher.stop();
     await server.stop();
     process.exit(0);
   }

--- a/src/host-control/release-watcher-shellouts.ts
+++ b/src/host-control/release-watcher-shellouts.ts
@@ -1,0 +1,179 @@
+/**
+ * Real-world dependency wiring for the release watcher (#1743).
+ *
+ * The watcher itself (`release-watcher.ts`) is dependency-injected and
+ * has no docker / CLI knowledge. This module supplies the concrete
+ * implementations used by the daemon in production.
+ *
+ * Detection strategy:
+ *   1. `docker manifest inspect <image_ref>` → remote digest of the
+ *      release tag (network round-trip to GHCR).
+ *   2. `docker image inspect <image_ref>` → local image's RepoDigest.
+ *   3. If remote != local → release available.
+ *
+ * Both probes are bounded by spawn timeouts; any error (network, auth,
+ * registry rate-limit) surfaces as a `check_failed` event and the
+ * tick is dropped (no retry-storm — the next interval will retry).
+ */
+
+import { spawn } from "node:child_process";
+
+export interface ProbeResult {
+  /** "sha256:..." digest, or null if the probe failed. */
+  digest: string | null;
+  /** stderr tail for diagnostics. */
+  error?: string;
+}
+
+/** Run a process to completion, return stdout / stderr / exit. */
+async function run(
+  cmd: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((res) => {
+    const p = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    const to = setTimeout(() => {
+      try { p.kill("SIGKILL"); } catch { /* nothing to do */ }
+    }, timeoutMs);
+    p.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+    p.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+    p.on("close", (code: number | null) => {
+      clearTimeout(to);
+      res({ stdout, stderr, code });
+    });
+    p.on("error", () => {
+      clearTimeout(to);
+      res({ stdout, stderr, code: -1 });
+    });
+  });
+}
+
+/** Resolve remote digest via `docker manifest inspect`. */
+export async function probeRemoteDigest(
+  imageRef: string,
+  dockerBin = "docker",
+): Promise<ProbeResult> {
+  const r = await run(
+    dockerBin,
+    ["manifest", "inspect", "--verbose", imageRef],
+    30_000,
+  );
+  if (r.code !== 0) {
+    return {
+      digest: null,
+      error: r.stderr.trim().split("\n").slice(-3).join(" | "),
+    };
+  }
+  try {
+    const parsed = JSON.parse(r.stdout);
+    if (Array.isArray(parsed)) {
+      // Manifest list — `docker pull` of the tag resolves to the
+      // platform-matched entry; use the first entry's Descriptor as
+      // the comparator. (Docker doesn't expose the list-digest via
+      // this command, but the per-platform digest is stable and
+      // matches what `RepoDigests` records locally after a pull.)
+      const first = parsed[0];
+      if (first?.Descriptor?.digest) return { digest: first.Descriptor.digest };
+      return { digest: null, error: "manifest list missing Descriptor.digest" };
+    }
+    if (parsed?.Descriptor?.digest) return { digest: parsed.Descriptor.digest };
+    return { digest: null, error: "manifest response missing Descriptor.digest" };
+  } catch (e) {
+    return { digest: null, error: (e as Error).message };
+  }
+}
+
+/** Resolve local digest via `docker image inspect`. */
+export async function probeLocalDigest(
+  imageRef: string,
+  dockerBin = "docker",
+): Promise<ProbeResult> {
+  const r = await run(
+    dockerBin,
+    ["image", "inspect", "--format", "{{json .RepoDigests}}|{{.Id}}", imageRef],
+    10_000,
+  );
+  if (r.code !== 0) {
+    return {
+      digest: null,
+      error: r.stderr.trim().split("\n").slice(-3).join(" | "),
+    };
+  }
+  const out = r.stdout.trim();
+  const sep = out.indexOf("|");
+  const repoDigestsJson = sep >= 0 ? out.slice(0, sep) : "";
+  const id = sep >= 0 ? out.slice(sep + 1) : out;
+  try {
+    const repoDigests = repoDigestsJson
+      ? (JSON.parse(repoDigestsJson) as string[] | null)
+      : null;
+    if (repoDigests && repoDigests.length > 0) {
+      // `repo@sha256:<hex>` — keep the digest half so we can compare
+      // against the remote manifest digest directly.
+      const at = repoDigests[0].lastIndexOf("@");
+      if (at >= 0) return { digest: repoDigests[0].slice(at + 1) };
+    }
+    if (id) return { digest: id };
+    return { digest: null, error: "no RepoDigests or Id" };
+  } catch (e) {
+    return { digest: null, error: (e as Error).message };
+  }
+}
+
+/** Build a release `checkFn` that compares remote vs local digest. */
+export function makeReleaseCheck(opts: {
+  imageRef: string;
+  dockerBin?: string;
+  log?: (m: string) => void;
+}) {
+  return async () => {
+    const [remote, local] = await Promise.all([
+      probeRemoteDigest(opts.imageRef, opts.dockerBin),
+      probeLocalDigest(opts.imageRef, opts.dockerBin),
+    ]);
+    if (!remote.digest) {
+      throw new Error(`remote digest probe failed: ${remote.error ?? "unknown"}`);
+    }
+    if (!local.digest) {
+      // Local image absent: treat as "available" so the watcher pulls
+      // for the first time. Operators who don't want this behaviour
+      // can set apply_on_detect=false to gate on operator review.
+      if (opts.log)
+        opts.log(
+          `local image absent for ${opts.imageRef} — treating as release available`,
+        );
+      return { available: true, version: remote.digest };
+    }
+    return {
+      available: remote.digest !== local.digest,
+      version: remote.digest,
+    };
+  };
+}
+
+/** Build an `applyFn` that runs `switchroom update`. */
+export function makeApply(switchroomBin: string) {
+  return async () => {
+    const r = await run(switchroomBin, ["update"], 30 * 60_000); // 30m ceiling
+    if (r.code !== 0) {
+      throw new Error(
+        `switchroom update failed (exit ${r.code}): ${r.stderr.trim().slice(-500)}`,
+      );
+    }
+  };
+}
+
+/** Build a `restartFn` that runs `switchroom restart all` (graceful). */
+export function makeRestart(switchroomBin: string) {
+  return async () => {
+    const r = await run(switchroomBin, ["restart", "all"], 5 * 60_000); // 5m ceiling
+    if (r.code !== 0) {
+      throw new Error(
+        `switchroom restart all failed (exit ${r.code}): ${r.stderr.trim().slice(-500)}`,
+      );
+    }
+  };
+}

--- a/src/host-control/release-watcher.ts
+++ b/src/host-control/release-watcher.ts
@@ -1,0 +1,219 @@
+/**
+ * Release watcher — pull-based release-triggered fleet restart (#1743).
+ *
+ * Runs inside the long-lived hostd process. On a fixed interval it
+ * asks `checkFn()` whether a new release is available; when one is
+ * detected it runs `applyFn()` (the equivalent of `switchroom update`)
+ * then `restartFn()` (`switchroom restart all` — graceful by default).
+ *
+ * The design choice is **pull, not push**: GitHub Actions has no
+ * inbound webhook surface into hostd's UDS, and exposing one publicly
+ * would require new infra. A 5-minute poll meets the issue's P95 ≤5 m
+ * acceptance criterion without any new public network surface.
+ *
+ * Single in-flight guard prevents overlapping cycles (a slow apply
+ * outlasting the next tick); failures log + drop the tick rather than
+ * retry-storming.
+ *
+ * The module is dependency-injection-shaped on purpose: the real
+ * docker / switchroom shellouts are wired in `main.ts`, but tests
+ * exercise the state machine with stub functions.
+ */
+
+export interface ReleaseCheckResult {
+  /** True if remote release differs from currently-running fleet. */
+  available: boolean;
+  /** Opaque version / digest identifier — printed in logs and emitted
+   *  in the audit row so operators can correlate a rollout. */
+  version?: string;
+}
+
+export interface ReleaseWatcherEvent {
+  /** ms since epoch */
+  at: number;
+  /** event kind. */
+  kind:
+    | "release_detected"
+    | "apply_started"
+    | "apply_succeeded"
+    | "apply_failed"
+    | "restart_started"
+    | "fleet_caught_up"
+    | "restart_failed"
+    | "check_failed";
+  version?: string;
+  error?: string;
+  duration_ms?: number;
+}
+
+export interface ReleaseWatcherOptions {
+  /** Poll interval in milliseconds. */
+  intervalMs: number;
+  /** Probe for a new release. Returns `available: true` when the
+   *  remote tag's digest no longer matches the deployed digest. */
+  checkFn: () => Promise<ReleaseCheckResult>;
+  /** Run the equivalent of `switchroom update` end-to-end. Resolves
+   *  when the apply completes (or rejects on failure). */
+  applyFn: () => Promise<void>;
+  /** Run the equivalent of `switchroom restart all` (graceful by
+   *  default — drains in-flight turns). Resolves when scheduling
+   *  completes; the per-agent drain happens asynchronously. */
+  restartFn: () => Promise<void>;
+  /** If false, the watcher will log a "release detected" event and
+   *  stop short of calling applyFn / restartFn. Use to dogfood the
+   *  check loop without auto-rolling the fleet. */
+  applyOnDetect: boolean;
+  /** Receives one event per state transition for telemetry / audit. */
+  onEvent?: (e: ReleaseWatcherEvent) => void;
+  /** Diagnostic log sink. */
+  log?: (m: string) => void;
+  /** Test seam — wall clock. */
+  now?: () => number;
+}
+
+export class ReleaseWatcher {
+  private timer: NodeJS.Timeout | null = null;
+  private inFlight = false;
+  private stopped = false;
+
+  constructor(private readonly opts: ReleaseWatcherOptions) {}
+
+  start(): void {
+    if (this.timer) return;
+    this.stopped = false;
+    // Schedule with setInterval — first tick fires after `intervalMs`,
+    // not immediately. Deliberate: on hostd boot the fleet was just
+    // started from the operator's most-recent update, so the boot-time
+    // tick would near-certainly be a no-op and we'd rather not double-
+    // check during startup churn.
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.opts.intervalMs);
+    if (typeof this.timer.unref === "function") this.timer.unref();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Run one check-and-maybe-roll cycle. Exposed for testing. */
+  async tick(): Promise<void> {
+    if (this.stopped) return;
+    if (this.inFlight) {
+      this.log("skip tick: previous cycle still in flight");
+      return;
+    }
+    this.inFlight = true;
+    try {
+      let check: ReleaseCheckResult;
+      try {
+        check = await this.opts.checkFn();
+      } catch (err) {
+        this.emit({
+          at: this.now(),
+          kind: "check_failed",
+          error: errMsg(err),
+        });
+        this.log(`check_failed: ${errMsg(err)}`);
+        return;
+      }
+      if (!check.available) return;
+
+      const detectedAt = this.now();
+      this.emit({
+        at: detectedAt,
+        kind: "release_detected",
+        ...(check.version ? { version: check.version } : {}),
+      });
+      this.log(
+        `release detected${check.version ? `: ${check.version}` : ""}` +
+          (this.opts.applyOnDetect
+            ? ", auto-applying"
+            : " (apply_on_detect=false; not rolling)"),
+      );
+      if (!this.opts.applyOnDetect) return;
+
+      const applyStarted = this.now();
+      this.emit({
+        at: applyStarted,
+        kind: "apply_started",
+        ...(check.version ? { version: check.version } : {}),
+      });
+      try {
+        await this.opts.applyFn();
+      } catch (err) {
+        this.emit({
+          at: this.now(),
+          kind: "apply_failed",
+          error: errMsg(err),
+          duration_ms: this.now() - applyStarted,
+        });
+        this.log(`apply_failed: ${errMsg(err)}`);
+        return;
+      }
+      this.emit({
+        at: this.now(),
+        kind: "apply_succeeded",
+        duration_ms: this.now() - applyStarted,
+      });
+
+      const restartStarted = this.now();
+      this.emit({
+        at: restartStarted,
+        kind: "restart_started",
+        ...(check.version ? { version: check.version } : {}),
+      });
+      try {
+        await this.opts.restartFn();
+      } catch (err) {
+        this.emit({
+          at: this.now(),
+          kind: "restart_failed",
+          error: errMsg(err),
+          duration_ms: this.now() - restartStarted,
+        });
+        this.log(`restart_failed: ${errMsg(err)}`);
+        return;
+      }
+      const caughtUpAt = this.now();
+      this.emit({
+        at: caughtUpAt,
+        kind: "fleet_caught_up",
+        ...(check.version ? { version: check.version } : {}),
+        duration_ms: caughtUpAt - detectedAt,
+      });
+      this.log(
+        `fleet caught up in ${caughtUpAt - detectedAt}ms` +
+          (check.version ? ` (version ${check.version})` : ""),
+      );
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  private emit(e: ReleaseWatcherEvent): void {
+    if (this.opts.onEvent) {
+      try {
+        this.opts.onEvent(e);
+      } catch {
+        // never let a telemetry sink failure break the watcher
+      }
+    }
+  }
+
+  private log(m: string): void {
+    if (this.opts.log) this.opts.log(`release-watcher: ${m}`);
+  }
+
+  private now(): number {
+    return this.opts.now ? this.opts.now() : Date.now();
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/tests/host-control/release-watcher.test.ts
+++ b/tests/host-control/release-watcher.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Release watcher unit tests (#1743).
+ *
+ * Exercises the pull-based release detection state machine with
+ * stubbed check / apply / restart functions — no docker, no
+ * switchroom CLI, no network.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { ReleaseWatcher, type ReleaseWatcherEvent } from "../../src/host-control/release-watcher.js";
+
+function collect() {
+  const events: ReleaseWatcherEvent[] = [];
+  return {
+    events,
+    onEvent: (e: ReleaseWatcherEvent) => { events.push(e); },
+  };
+}
+
+describe("ReleaseWatcher", () => {
+  it("does nothing when no release is available", async () => {
+    const applyFn = vi.fn().mockResolvedValue(undefined);
+    const restartFn = vi.fn().mockResolvedValue(undefined);
+    const sink = collect();
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: false }),
+      applyFn,
+      restartFn,
+      applyOnDetect: true,
+      onEvent: sink.onEvent,
+    });
+    await w.tick();
+    expect(applyFn).not.toHaveBeenCalled();
+    expect(restartFn).not.toHaveBeenCalled();
+    expect(sink.events).toEqual([]);
+  });
+
+  it("on detect: emits release_detected → apply_* → restart_* → fleet_caught_up", async () => {
+    const applyFn = vi.fn().mockResolvedValue(undefined);
+    const restartFn = vi.fn().mockResolvedValue(undefined);
+    const sink = collect();
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: true, version: "sha256:abc" }),
+      applyFn,
+      restartFn,
+      applyOnDetect: true,
+      onEvent: sink.onEvent,
+    });
+    await w.tick();
+    expect(applyFn).toHaveBeenCalledOnce();
+    expect(restartFn).toHaveBeenCalledOnce();
+    const kinds = sink.events.map((e) => e.kind);
+    expect(kinds).toEqual([
+      "release_detected",
+      "apply_started",
+      "apply_succeeded",
+      "restart_started",
+      "fleet_caught_up",
+    ]);
+    const caughtUp = sink.events.find((e) => e.kind === "fleet_caught_up")!;
+    expect(caughtUp.version).toBe("sha256:abc");
+    expect(typeof caughtUp.duration_ms).toBe("number");
+  });
+
+  it("apply_on_detect=false: emits release_detected, stops there", async () => {
+    const applyFn = vi.fn();
+    const restartFn = vi.fn();
+    const sink = collect();
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: true, version: "sha256:abc" }),
+      applyFn,
+      restartFn,
+      applyOnDetect: false,
+      onEvent: sink.onEvent,
+    });
+    await w.tick();
+    expect(applyFn).not.toHaveBeenCalled();
+    expect(restartFn).not.toHaveBeenCalled();
+    expect(sink.events.map((e) => e.kind)).toEqual(["release_detected"]);
+  });
+
+  it("apply failure: emits apply_failed, does NOT call restart, does NOT retry within the tick", async () => {
+    const applyFn = vi.fn().mockRejectedValue(new Error("pull denied"));
+    const restartFn = vi.fn();
+    const sink = collect();
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: true }),
+      applyFn,
+      restartFn,
+      applyOnDetect: true,
+      onEvent: sink.onEvent,
+    });
+    await w.tick();
+    expect(applyFn).toHaveBeenCalledOnce();
+    expect(restartFn).not.toHaveBeenCalled();
+    const failed = sink.events.find((e) => e.kind === "apply_failed")!;
+    expect(failed).toBeDefined();
+    expect(failed.error).toContain("pull denied");
+  });
+
+  it("check failure: emits check_failed, does NOT call apply / restart", async () => {
+    const applyFn = vi.fn();
+    const restartFn = vi.fn();
+    const sink = collect();
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => { throw new Error("network unreachable"); },
+      applyFn,
+      restartFn,
+      applyOnDetect: true,
+      onEvent: sink.onEvent,
+    });
+    await w.tick();
+    expect(applyFn).not.toHaveBeenCalled();
+    expect(restartFn).not.toHaveBeenCalled();
+    expect(sink.events.map((e) => e.kind)).toEqual(["check_failed"]);
+  });
+
+  it("overlapping ticks: second tick is dropped while the first is in flight", async () => {
+    let resolveApply: (() => void) | null = null;
+    const applyFn = vi.fn(() => new Promise<void>((res) => { resolveApply = res; }));
+    const restartFn = vi.fn().mockResolvedValue(undefined);
+    const sink = collect();
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: true }),
+      applyFn,
+      restartFn,
+      applyOnDetect: true,
+      onEvent: sink.onEvent,
+    });
+    const first = w.tick();
+    // While first is hung in applyFn, fire a second tick
+    await w.tick();
+    // The second tick should have returned early — applyFn must
+    // still have been called exactly once.
+    expect(applyFn).toHaveBeenCalledTimes(1);
+    // Release the first apply so the test can complete
+    resolveApply!();
+    await first;
+    expect(restartFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("stop() prevents further work", async () => {
+    const applyFn = vi.fn().mockResolvedValue(undefined);
+    const restartFn = vi.fn().mockResolvedValue(undefined);
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn: async () => ({ available: true }),
+      applyFn,
+      restartFn,
+      applyOnDetect: true,
+    });
+    w.start();
+    w.stop();
+    await w.tick();
+    expect(applyFn).not.toHaveBeenCalled();
+    expect(restartFn).not.toHaveBeenCalled();
+  });
+
+  it("start() before stop() does NOT spawn an immediate tick (setInterval semantics)", () => {
+    const applyFn = vi.fn();
+    const restartFn = vi.fn();
+    const checkFn = vi.fn().mockResolvedValue({ available: false });
+    const w = new ReleaseWatcher({
+      intervalMs: 1_000_000,
+      checkFn,
+      applyFn,
+      restartFn,
+      applyOnDetect: true,
+    });
+    w.start();
+    // No tick yet (interval is 1000s out)
+    expect(checkFn).not.toHaveBeenCalled();
+    w.stop();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the deployment-lag gap (#1743). Today a plugin/gateway fix ships via `:dev → :latest` retag but doesn't reach running agents until an unrelated restart picks it up — the Clerk agent demonstrated the exact bug PR #1718 fixed 6 hours after release because its `bun` process hadn't cycled.

This adds a **pull-based** release watcher inside the long-running hostd daemon. It polls the remote image tag every 5 minutes (configurable), and on a digest-change it runs `switchroom update` → `switchroom restart all` (graceful — drains in-flight Telegram turns via the existing `decideRestart` path).

- Opt-in via `host_control.auto_release_check.enabled: true` (default `false`).
- `apply_on_detect: false` runs the detector in log-only mode for dogfooding.
- Events written to `~/.switchroom/release-watcher-events.jsonl`. AC's `time_from_release_to_fleet_caught_up_seconds` counter is the `duration_ms` field on `fleet_caught_up` rows.
- Failure → log + drop the tick. Single in-flight guard prevents overlap.

## Design choice — pull vs push

The issue called out two mechanically distinct triggers. I picked **pull**:

1. No new public infra. Hostd's UDS isn't internet-reachable; exposing a webhook endpoint would require an ingress / relay.
2. Re-uses existing CLI verbs (`switchroom update`, `switchroom restart`).
3. Self-contained on the host — no `.github/workflows/promote.yml` changes needed for v1.
4. 5-minute worst-case lag meets the AC ("P95 within 5 min").

Push remains viable as a future enhancement when an internet-reachable hostd surface lands.

## Test plan

- [x] `npx vitest run tests/host-control/release-watcher.test.ts` — 8 new unit tests, all green (available, unavailable, apply_on_detect=false, apply-fail no-restart, check-fail, overlap-skip, stop()).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [ ] Operator-level integration test: flip `enabled: true`, retag `:latest`, observe `fleet_caught_up` JSONL row within `interval_minutes`.

## Files

- `src/config/schema.ts` — `AutoReleaseCheckSchema` + `host_control.auto_release_check` field
- `src/host-control/release-watcher.ts` — DI-shaped state machine (no docker / CLI knowledge)
- `src/host-control/release-watcher-shellouts.ts` — real-world `docker manifest inspect` + `docker image inspect` probes; `switchroom update` / `restart all` wrappers
- `src/host-control/main.ts` — wires the watcher into the hostd entrypoint
- `tests/host-control/release-watcher.test.ts` — unit tests
- `docs/scheduling.md` — operator-facing docs section

Closes #1743

🤖 Generated with [Claude Code](https://claude.com/claude-code)