### PR TITLE
fix(timezone-hook): include weekday + AM/PM to prevent LLM time-of-week drift

### DIFF
--- a/bin/timezone-hook.sh
+++ b/bin/timezone-hook.sh
@@ -45,7 +45,7 @@ fi
 # `-d "@<unix>"` is required (Linux-only, fine for switchroom production).
 NOW_UNIX=$(date +%s)
 ROUNDED=$(( NOW_UNIX - (NOW_UNIX % 900) ))
-NOW=$(TZ="$TZ_VAL" date -d "@$ROUNDED" '+%Y-%m-%d %H:%M %Z (UTC%:z)')
+NOW=$(TZ="$TZ_VAL" date -d "@$ROUNDED" '+%A %Y-%m-%d %I:%M %p %Z (UTC%:z)')
 
 if [ "$TZ_UNSET" = "1" ]; then
   MSG="Current local time: $NOW ($TZ_VAL — WARNING: SWITCHROOM_TIMEZONE unset; compose env may be stale, run \`switchroom apply && switchroom agent restart <agent>\` to refresh)"

--- a/tests/timezone-hook.test.ts
+++ b/tests/timezone-hook.test.ts
@@ -89,8 +89,9 @@ describe("timezone-hook.sh", () => {
     const { json } = runHook({ SWITCHROOM_TIMEZONE: "UTC" });
     const ctx = (json as { hookSpecificOutput: { additionalContext: string } })
       .hookSpecificOutput.additionalContext;
-    // Match "YYYY-MM-DD HH:MM " — the literal minute token after the colon.
-    const m = ctx.match(/\d{4}-\d{2}-\d{2} \d{2}:(\d{2}) /);
+    // Match "Weekday YYYY-MM-DD HH:MM AM/PM " — the literal minute token after the colon.
+    // Format is now '%A %Y-%m-%d %I:%M %p %Z (UTC%:z)' e.g. "Monday 2026-05-25 10:00 AM AEST (UTC+10:00)"
+    const m = ctx.match(/\w+ \d{4}-\d{2}-\d{2} \d{2}:(\d{2}) [AP]M /);
     expect(m).not.toBeNull();
     const mins = parseInt(m![1], 10);
     expect(mins % 15).toBe(0);


### PR DESCRIPTION
## Problem

`bin/timezone-hook.sh` injects current local time into every agent turn via `additionalContext`. The format was:

```
2026-05-25 10:00 AEST (UTC+10:00)
```

Without an explicit **weekday** or **AM/PM**, LLMs must derive both from the raw values:
- 24-hour `10:00` gives no AM/PM signal on its own
- Day-of-week must be computed from the ISO date — a step models get wrong under context pressure

This causes observable UX bugs: agents saying "tonight" at 10am, scheduling things on the wrong weekday, and generally drifting on time-of-day descriptors in conversation.

## Fix

Change the `date` format string (line 48) from:

```bash
'+%Y-%m-%d %H:%M %Z (UTC%:z)'
```

to:

```bash
'+%A %Y-%m-%d %I:%M %p %Z (UTC%:z)'
```

**Before:** `2026-05-25 10:00 AEST (UTC+10:00)`
**After:** `Monday 2026-05-25 10:00 AM AEST (UTC+10:00)`

`%A` = full weekday name, `%I` = 12-hour hour, `%p` = AM/PM.

## Test changes

`tests/timezone-hook.test.ts` — the 15-minute bucket assertion regex updated from:
```ts
/\d{4}-\d{2}-\d{2} \d{2}:(\d{2}) /
```
to:
```ts
/\w+ \d{4}-\d{2}-\d{2} \d{2}:(\d{2}) [AP]M /
```

All other tests pass unchanged (they match on `Current local time:`, `Australia/Melbourne`, `WARNING`, etc. — none tied to the format string).

## Follow-up (not in this PR)

The gateway's `currentDate` system-reminder block (injected as `"Today's date is YYYY-MM-DD"`) hits sub-agents that don't receive the timezone hook context. The same fix should be applied there — append `, <Weekday>` — but the injection site is in gateway TypeScript source that wasn't straightforward to locate in this pass. Noted here for a follow-up issue/PR.

## Checklist
- [x] `bin/timezone-hook.sh` format string updated
- [x] `tests/timezone-hook.test.ts` regex updated
- [ ] Gateway `currentDate` block — follow-up