### PR TITLE
feat(#1758): error envelope Phase 1 — wire protocol + builder + E_CONFIG_EDIT_DISABLED migration + unlock card

### DIFF
--- a/src/analytics/error-friction.ts
+++ b/src/analytics/error-friction.ts
@@ -1,0 +1,56 @@
+/**
+ * PostHog wrapper for `switchroom_error_friction` events (#1758).
+ *
+ * One event per structured error envelope emission, fired from
+ * `error-builder.ts`'s `.build()` as an intentionally-unawaited
+ * side-effect. Reuses the existing `captureEvent` client in
+ * `src/analytics/posthog.ts` — no new client, no new env var.
+ *
+ * PII discipline (issue spec):
+ *   - NEVER send `human`, `why`, `docs` body, `yaml_path.to` value,
+ *     raw `vault_key`, stdout/stderr tails, or `operator_steps` content.
+ *   - `vault_key` → sha256, first 16 hex chars only.
+ *   - `yaml_path` is allowed (structural, not secret —
+ *     e.g. `hostd.config_edit_enabled`).
+ *   - `request_id` verified PII-safe (caller-supplied opaque token).
+ */
+
+import { createHash } from "node:crypto";
+import { captureEvent } from "./posthog.js";
+import type { ErrorEnvelope } from "../host-control/protocol.js";
+
+export interface ErrorFrictionContext {
+  /** Verb / operation name (e.g. `config_propose_edit`). */
+  op: string;
+  /** Who hit the error — drives the friction-by-caller breakdown. */
+  caller_kind: "agent" | "operator" | "unknown";
+  /** Agent name if `caller_kind === "agent"`. */
+  agent_name?: string;
+}
+
+function sha256Hex16(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex").slice(0, 16);
+}
+
+export function recordErrorFriction(
+  env: ErrorEnvelope,
+  ctx: ErrorFrictionContext,
+): void {
+  // Intentional fire-and-forget — `captureEvent` is async but its
+  // internal try/catch swallows errors, and we never want telemetry
+  // to block (or worse, fail) an error response.
+  void captureEvent("switchroom_error_friction", {
+    code: env.code,
+    op: ctx.op,
+    caller_kind: ctx.caller_kind,
+    agent_name: ctx.agent_name ?? null,
+    fix_kind: env.fix?.kind ?? null,
+    has_docs: Boolean(env.docs),
+    request_id: env.request_id,
+    vault_key_hash:
+      env.fix?.kind === "request_vault_grant"
+        ? sha256Hex16(env.fix.vault_key)
+        : null,
+    quota_name: env.fix?.kind === "quota_exceeded" ? env.fix.quota : null,
+  });
+}

--- a/src/host-control/config-edit-validator.ts
+++ b/src/host-control/config-edit-validator.ts
@@ -75,6 +75,24 @@ export type ValidationResult = ValidationOk | ValidationFailure;
 /** Hard cap on raw unified-diff bytes. RFC §3.2 step 1. */
 export const MAX_PATCH_BYTES = 1024 * 1024;
 
+/**
+ * Allowlist of operator-flippable yaml paths the Telegram bridge is
+ * permitted to render a one-tap unlock card for (#1758 Phase 1).
+ *
+ * Scoped narrowly on purpose: a malformed / hostile `error_envelope`
+ * from any backend could otherwise nudge the operator into approving
+ * an arbitrary yaml flag flip. The list grows only when the operator
+ * UX explicitly wants one-tap unlock for a new flag.
+ */
+export const UNLOCK_CARD_YAML_ALLOWLIST = new Set<string>([
+  "hostd.config_edit_enabled",
+]);
+
+/** True iff `path` is in {@link UNLOCK_CARD_YAML_ALLOWLIST}. */
+export function isAllowlistedYamlPath(path: string): boolean {
+  return UNLOCK_CARD_YAML_ALLOWLIST.has(path);
+}
+
 export interface ValidatorOptions {
   /** Live config file the patch is applied against (read fresh each call). */
   configPath: string;

--- a/src/host-control/error-builder.test.ts
+++ b/src/host-control/error-builder.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the structured error builder (#1758 Phase 1).
+ *
+ * Verifies:
+ *   - builder produces both legacy `error: string` AND `error_envelope`
+ *   - legacy string format stable across every `fix.kind` variant
+ *   - fire-and-forget recordErrorFriction never throws / blocks
+ *   - PostHog never sees PII (human/why/docs/raw vault_key/operator_steps)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the analytics layer BEFORE importing the builder so the builder
+// picks up the mocked captureEvent.
+const captureEventMock = vi.fn();
+vi.mock("../analytics/posthog.js", () => ({
+  captureEvent: (...args: unknown[]) => captureEventMock(...args),
+  getDistinctId: () => "test-distinct-id",
+}));
+
+import { err } from "./error-builder.js";
+
+describe("error-builder — wire shape", () => {
+  beforeEach(() => {
+    captureEventMock.mockReset();
+  });
+
+  it("produces both legacy `error` and `error_envelope`", () => {
+    const resp = err("E_CONFIG_EDIT_DISABLED", "config_propose_edit is disabled")
+      .why("operator opt-in per RFC §3.3")
+      .fixFlipFlag("hostd.config_edit_enabled", true)
+      .docs("https://switchroom.dev/docs/config-edit#opt-in")
+      .op("config_propose_edit")
+      .caller("agent")
+      .agentName("klanker")
+      .build("req-1", 42);
+
+    expect(resp.result).toBe("error");
+    expect(resp.exit_code).toBeNull();
+    expect(resp.duration_ms).toBe(42);
+    expect(resp.error).toBe(
+      "E_CONFIG_EDIT_DISABLED: config_propose_edit is disabled — operator opt-in per RFC §3.3",
+    );
+    expect(resp.error_envelope).toEqual({
+      v: 1,
+      code: "E_CONFIG_EDIT_DISABLED",
+      human: "config_propose_edit is disabled",
+      why: "operator opt-in per RFC §3.3",
+      fix: {
+        kind: "flip_yaml_flag",
+        yaml_path: "hostd.config_edit_enabled",
+        to: true,
+      },
+      docs: "https://switchroom.dev/docs/config-edit#opt-in",
+      request_id: "req-1",
+    });
+  });
+
+  it("legacy `error` string format stable across fix.kind variants", () => {
+    const cases: Array<{ name: string; build: () => string | undefined }> = [
+      {
+        name: "no fix",
+        build: () => err("E_FOO", "bar").build("r", 0).error,
+      },
+      {
+        name: "flip_yaml_flag",
+        build: () => err("E_FOO", "bar").fixFlipFlag("a.b", 1).build("r", 0).error,
+      },
+      {
+        name: "request_vault_grant",
+        build: () => err("E_FOO", "bar").fixVaultGrant("foo/bar").build("r", 0).error,
+      },
+      {
+        name: "operator_action",
+        build: () => err("E_FOO", "bar").fixOperatorAction("policy_denied", ["step1"]).build("r", 0).error,
+      },
+      {
+        name: "retry_after",
+        build: () => err("E_FOO", "bar").fixRetryAfter("2026-01-01T00:00:00Z").build("r", 0).error,
+      },
+      {
+        name: "quota_exceeded",
+        build: () => err("E_FOO", "bar").fixQuotaExceeded("q", 1, 2).build("r", 0).error,
+      },
+      {
+        name: "bad_input",
+        build: () => err("E_FOO", "bar").fixBadInput("field").build("r", 0).error,
+      },
+    ];
+    for (const c of cases) {
+      const s = c.build();
+      expect(s, c.name).toBe("E_FOO: bar"); // why undefined → no suffix
+    }
+    // Sanity check with .why()
+    const withWhy = err("E_FOO", "bar").why("reason").build("r", 0).error;
+    expect(withWhy).toBe("E_FOO: bar — reason");
+  });
+
+  it(".build() never throws even if telemetry blows up", () => {
+    captureEventMock.mockImplementationOnce(() => {
+      throw new Error("posthog gone wrong");
+    });
+    expect(() =>
+      err("E_FOO", "bar").build("r", 0),
+    ).not.toThrow();
+  });
+
+  it("PII discipline — captureEvent never sees human/why/docs/raw vault_key/operator_steps", () => {
+    err("VAULT-BROKER-DENIED", "PII-SENSITIVE-HUMAN")
+      .why("PII-SENSITIVE-WHY")
+      .fixVaultGrant("openai/api-key-VERY-SECRET")
+      .docs("https://docs.example.com/PII-SENSITIVE-DOCS")
+      .op("vault_request_access")
+      .caller("agent")
+      .agentName("klanker")
+      .build("req-vault", 0);
+
+    expect(captureEventMock).toHaveBeenCalledTimes(1);
+    const [event, props] = captureEventMock.mock.calls[0]!;
+    expect(event).toBe("switchroom_error_friction");
+    const json = JSON.stringify(props);
+    expect(json).not.toContain("PII-SENSITIVE-HUMAN");
+    expect(json).not.toContain("PII-SENSITIVE-WHY");
+    expect(json).not.toContain("PII-SENSITIVE-DOCS");
+    expect(json).not.toContain("openai/api-key-VERY-SECRET");
+    // sha256 first 16 hex chars
+    expect(props.vault_key_hash).toMatch(/^[0-9a-f]{16}$/);
+    expect(props.code).toBe("VAULT-BROKER-DENIED");
+    expect(props.fix_kind).toBe("request_vault_grant");
+    expect(props.has_docs).toBe(true);
+  });
+
+  it("operator_steps content stays out of PostHog", () => {
+    err("E_FOO", "human")
+      .fixOperatorAction("policy_denied", ["PII-STEP-1", "PII-STEP-2"])
+      .op("foo")
+      .caller("agent")
+      .build("r", 0);
+    const [, props] = captureEventMock.mock.calls[0]!;
+    const json = JSON.stringify(props);
+    expect(json).not.toContain("PII-STEP-1");
+    expect(json).not.toContain("PII-STEP-2");
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/src/host-control/error-builder.ts
+++ b/src/host-control/error-builder.ts
@@ -1,0 +1,165 @@
+/**
+ * Structured error builder (#1758 Phase 1).
+ *
+ * Fluent API used at hostd error-emission sites to replace bare
+ * `errorResponse(req.request_id, "E_FOO: human")` calls. Produces a
+ * `HostdResponse` that carries BOTH the legacy `error: string` (for
+ * one release cycle of backwards-compat) AND a structured
+ * `error_envelope` agents read `fix.kind` from directly.
+ *
+ *   return err("E_CONFIG_EDIT_DISABLED", "config_propose_edit is disabled")
+ *     .why("operator opt-in per RFC §3.3")
+ *     .fixFlipFlag("hostd.config_edit_enabled", true)
+ *     .docs("https://switchroom.dev/docs/config-edit#opt-in")
+ *     .op("config_propose_edit")
+ *     .caller("agent")
+ *     .agentName(callerName)
+ *     .build(req.request_id, Date.now() - started);
+ *
+ * `.build()` also fires `recordErrorFriction(envelope, ctx)` as an
+ * intentionally-unawaited side-effect. Any synchronous throw from
+ * the recorder is swallowed defensively — telemetry must never block
+ * an error response.
+ */
+
+import type {
+  ErrorEnvelope,
+  ErrorFix,
+  HostdResponse,
+} from "./protocol.js";
+import {
+  recordErrorFriction,
+  type ErrorFrictionContext,
+} from "../analytics/error-friction.js";
+
+export class ErrorBuilder {
+  private _code: string;
+  private _human: string;
+  private _why?: string;
+  private _fix?: ErrorFix;
+  private _docs?: string;
+  private _op = "unknown";
+  private _caller: "agent" | "operator" | "unknown" = "unknown";
+  private _agentName?: string;
+  private _result: "denied" | "error" = "error";
+
+  constructor(code: string, human: string) {
+    this._code = code;
+    this._human = human;
+  }
+
+  why(reason: string): this {
+    this._why = reason;
+    return this;
+  }
+
+  fixFlipFlag(yamlPath: string, to: unknown): this {
+    this._fix = { kind: "flip_yaml_flag", yaml_path: yamlPath, to };
+    return this;
+  }
+
+  fixVaultGrant(vaultKey: string): this {
+    this._fix = { kind: "request_vault_grant", vault_key: vaultKey };
+    return this;
+  }
+
+  fixOperatorAction(
+    subkind: "policy_denied" | "infra" | "out_of_scope",
+    steps?: string[],
+  ): this {
+    this._fix = {
+      kind: "operator_action",
+      subkind,
+      ...(steps && steps.length > 0 ? { operator_steps: steps } : {}),
+    };
+    return this;
+  }
+
+  fixRetryAfter(retryAt: string): this {
+    this._fix = { kind: "retry_after", retry_at: retryAt };
+    return this;
+  }
+
+  fixQuotaExceeded(quota: string, current: number, limit: number): this {
+    this._fix = { kind: "quota_exceeded", quota, current, limit };
+    return this;
+  }
+
+  fixBadInput(field?: string): this {
+    this._fix = { kind: "bad_input", ...(field ? { field } : {}) };
+    return this;
+  }
+
+  docs(url: string): this {
+    this._docs = url;
+    return this;
+  }
+
+  op(name: string): this {
+    this._op = name;
+    return this;
+  }
+
+  caller(kind: "agent" | "operator" | "unknown"): this {
+    this._caller = kind;
+    return this;
+  }
+
+  agentName(name?: string): this {
+    this._agentName = name;
+    return this;
+  }
+
+  /** Mark this builder as a `denied` (not `error`) result. Default is `error`. */
+  asDenied(): this {
+    this._result = "denied";
+    return this;
+  }
+
+  build(requestId: string, durationMs: number): HostdResponse {
+    const envelope: ErrorEnvelope = {
+      v: 1,
+      code: this._code,
+      human: this._human,
+      ...(this._why !== undefined ? { why: this._why } : {}),
+      ...(this._fix !== undefined ? { fix: this._fix } : {}),
+      ...(this._docs !== undefined ? { docs: this._docs } : {}),
+      request_id: requestId,
+    };
+    // Synthesise the legacy `error` string so existing string-matching
+    // decoders (audit reader, vault-broker client, telegram-plugin
+    // gateway response handler) see no semantic regression.
+    const legacy =
+      `${this._code}: ${this._human}` +
+      (this._why ? ` — ${this._why}` : "");
+
+    const ctx: ErrorFrictionContext = {
+      op: this._op,
+      caller_kind: this._caller,
+      ...(this._agentName ? { agent_name: this._agentName } : {}),
+    };
+    // Intentional fire-and-forget. If the recorder itself throws
+    // synchronously (it shouldn't — captureEvent already has internal
+    // try/catch), swallow it: telemetry must never break the error
+    // response.
+    try {
+      recordErrorFriction(envelope, ctx);
+    } catch {
+      // swallow
+    }
+
+    return {
+      v: 1,
+      request_id: requestId,
+      result: this._result,
+      exit_code: null,
+      duration_ms: durationMs,
+      error: legacy,
+      error_envelope: envelope,
+    };
+  }
+}
+
+export function err(code: string, human: string): ErrorBuilder {
+  return new ErrorBuilder(code, human);
+}

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -372,6 +372,60 @@ export type HostdVerb = HostdRequest["op"];
 export const ResultSchema = z.enum(["started", "completed", "denied", "error"]);
 export type Result = z.infer<typeof ResultSchema>;
 
+// ─── Error envelope (issue #1758 Phase 1) ─────────────────────────────────
+//
+// Structured error envelope carried alongside the legacy `error: string`
+// field on a `denied` / `error` response. Agents read `fix.kind` directly
+// instead of regexing the human string; the Telegram bridge can render
+// one-tap unlock / grant cards for safe `fix.kind`s (allowlist-gated).
+//
+// `error: string` is preserved for one release cycle so existing decoders
+// continue to work — the builder synthesises a stable legacy string from
+// `code` + `human` + `why`.
+
+export const ErrorFixSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("flip_yaml_flag"),
+    yaml_path: z.string(),
+    to: z.unknown(),
+  }),
+  z.object({
+    kind: z.literal("request_vault_grant"),
+    vault_key: z.string(),
+  }),
+  z.object({
+    kind: z.literal("operator_action"),
+    subkind: z.enum(["policy_denied", "infra", "out_of_scope"]),
+    operator_steps: z.array(z.string()).min(1).optional(),
+  }),
+  z.object({
+    kind: z.literal("retry_after"),
+    retry_at: z.string(),
+  }),
+  z.object({
+    kind: z.literal("quota_exceeded"),
+    quota: z.string(),
+    current: z.number(),
+    limit: z.number(),
+  }),
+  z.object({
+    kind: z.literal("bad_input"),
+    field: z.string().optional(),
+  }),
+]);
+export type ErrorFix = z.infer<typeof ErrorFixSchema>;
+
+export const ErrorEnvelopeSchema = z.object({
+  v: z.literal(1),
+  code: z.string().regex(/^(E_[A-Z0-9_]+|VAULT-[A-Z-]+)$/),
+  human: z.string().min(1),
+  why: z.string().optional(),
+  fix: ErrorFixSchema.optional(),
+  docs: z.string().url().optional(),
+  request_id: z.string().min(1),
+});
+export type ErrorEnvelope = z.infer<typeof ErrorEnvelopeSchema>;
+
 const ResponseEnvelope = {
   v: z.literal(1),
   request_id: z.string().min(1).max(128),
@@ -388,6 +442,9 @@ const ResponseEnvelope = {
   stderr_tail: z.string().optional(),
   /** Operator-visible error message for `denied` / `error`. */
   error: z.string().optional(),
+  /** Structured error envelope (#1758 Phase 1). Sibling of `error`;
+   *  agents read `fix.kind` directly to know the next move. */
+  error_envelope: ErrorEnvelopeSchema.optional(),
 };
 
 export const ResponseSchema = z.object(ResponseEnvelope);

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -48,6 +48,7 @@ import {
   type HostdResponse,
   type Result,
 } from "./protocol.js";
+import { err } from "./error-builder.js";
 import { chainRow, seedChain, type ChainState } from "../util/audit-hashchain.js";
 import { socketPathToIdentity, type SocketIdentity } from "./peercred.js";
 import { redact } from "../secret-detect/redact.js";
@@ -1217,13 +1218,14 @@ export class HostdServer {
   ): Promise<HostdResponse> {
     const enabled = this.opts.config.hostd?.config_edit_enabled === true;
     if (!enabled) {
-      return errorResponse(
-        req.request_id,
-        "E_CONFIG_EDIT_DISABLED: config_propose_edit is disabled; " +
-          "operator must set hostd.config_edit_enabled=true in " +
-          "switchroom.yaml to opt in",
-        Date.now() - started,
-      );
+      return err("E_CONFIG_EDIT_DISABLED", "config_propose_edit is disabled")
+        .why("operator opt-in per RFC §3.3")
+        .fixFlipFlag("hostd.config_edit_enabled", true)
+        .docs("https://switchroom.dev/docs/config-edit#opt-in")
+        .op("config_propose_edit")
+        .caller(caller.kind === "agent" ? "agent" : "operator")
+        .agentName(caller.kind === "agent" ? caller.name : undefined)
+        .build(req.request_id, Date.now() - started);
     }
     const configPath =
       this.opts.configPath ?? req.args.target_path;

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -507,10 +507,23 @@ export async function dispatchTool(
   // denied/error: tool-error so the model can see it failed but also
   // sees the full daemon response (including the daemon's error
   // message) without raising an exception.
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(resp) }],
-    isError: true,
-  };
+  const content: { type: "text"; text: string }[] = [
+    { type: "text", text: JSON.stringify(resp) },
+  ];
+  // #1758 Phase 1: when a structured error envelope is present, surface
+  // it as a second content item with a leading discriminator hint so
+  // the agent can branch on `fix.kind` without re-parsing the legacy
+  // `error` string.
+  if (resp.error_envelope) {
+    const env = resp.error_envelope;
+    content.push({
+      type: "text",
+      text:
+        `Structured error — fix.kind=${env.fix?.kind ?? "none"}\n` +
+        JSON.stringify(env, null, 2),
+    });
+  }
+  return { content, isError: true };
 }
 
 /**

--- a/telegram-plugin/gateway/error-envelope-card.ts
+++ b/telegram-plugin/gateway/error-envelope-card.ts
@@ -1,0 +1,64 @@
+/**
+ * Render a one-tap unlock card for hostd error_envelopes that carry a
+ * `flip_yaml_flag` fix (#1758 Phase 1).
+ *
+ * CRITICAL safety: the `yaml_path` MUST be on the
+ * `UNLOCK_CARD_YAML_ALLOWLIST` exported from
+ * `src/host-control/config-edit-validator.ts`. A malformed or hostile
+ * envelope from any backend could otherwise nudge the operator into
+ * one-tap-approving an arbitrary flag flip. Non-allowlisted paths fall
+ * back to plain-text rendering (the caller surfaces `resp.error` as
+ * today).
+ *
+ * Phase 1 scope: ONLY `flip_yaml_flag`. `request_vault_grant` is
+ * explicitly deferred to a later phase (still plain-text rendered).
+ */
+
+import type { HostdResponse } from "../../src/host-control/protocol.js";
+import { isAllowlistedYamlPath } from "../../src/host-control/config-edit-validator.js";
+import {
+  buildApprovalCard,
+  type BuiltApprovalCard,
+} from "./approval-card.js";
+
+export type UnlockCardOutcome =
+  | { kind: "card"; card: BuiltApprovalCard; yaml_path: string; to: unknown }
+  | { kind: "plain-text" };
+
+/**
+ * Decide whether to render a one-tap unlock card for the given
+ * response. Returns `{kind: "plain-text"}` whenever the envelope
+ * lacks a `flip_yaml_flag` fix OR the path isn't on the allowlist.
+ *
+ * `approvalRequestId` is the 32-hex nonce minted by the approval
+ * kernel; caller is responsible for binding the card to that nonce
+ * and recording the apply-on-tap intent.
+ */
+export function renderErrorEnvelopeCard(
+  resp: HostdResponse,
+  agentName: string,
+  approvalRequestId: string,
+): UnlockCardOutcome {
+  const env = resp.error_envelope;
+  if (!env || !env.fix) return { kind: "plain-text" };
+  if (env.fix.kind !== "flip_yaml_flag") {
+    // request_vault_grant is Phase-2 work; everything else has no
+    // unlock-card UX. Caller falls back to plain-text rendering.
+    return { kind: "plain-text" };
+  }
+  const { yaml_path, to } = env.fix;
+  if (!isAllowlistedYamlPath(yaml_path)) {
+    // Defense-in-depth: never render a one-tap card for a path the
+    // operator hasn't explicitly opted into.
+    return { kind: "plain-text" };
+  }
+  const card = buildApprovalCard({
+    request_id: approvalRequestId,
+    agent: agentName,
+    scope_humanized: `flip ${yaml_path} → ${JSON.stringify(to)}`,
+    why: env.human + (env.why ? ` — ${env.why}` : ""),
+    offer_always: false,
+    offer_ttl: false,
+  });
+  return { kind: "card", card, yaml_path, to };
+}

--- a/telegram-plugin/tests/error-envelope-unlock-card.test.ts
+++ b/telegram-plugin/tests/error-envelope-unlock-card.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Telegram bridge unlock-card safety (#1758 Phase 1).
+ *
+ * The bridge MUST validate `flip_yaml_flag.yaml_path` against the
+ * config-edit-validator allowlist before rendering a one-tap approval
+ * card. A malformed or hostile envelope from any backend could
+ * otherwise nudge the operator into approving an arbitrary flag flip.
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderErrorEnvelopeCard } from "../gateway/error-envelope-card.js";
+import type { HostdResponse } from "../../src/host-control/protocol.js";
+
+function mkResp(fix: HostdResponse["error_envelope"]["fix"]): HostdResponse {
+  return {
+    v: 1,
+    request_id: "r-1",
+    result: "error",
+    exit_code: null,
+    duration_ms: 0,
+    error: "E_FOO: foo",
+    error_envelope: {
+      v: 1,
+      code: "E_FOO",
+      human: "foo",
+      fix,
+      request_id: "r-1",
+    },
+  } as HostdResponse;
+}
+
+describe("renderErrorEnvelopeCard — allowlist guard", () => {
+  it("renders an approval card for an allowlisted yaml_path", () => {
+    const resp = mkResp({
+      kind: "flip_yaml_flag",
+      yaml_path: "hostd.config_edit_enabled",
+      to: true,
+    });
+    const out = renderErrorEnvelopeCard(resp, "klanker", "a".repeat(32));
+    expect(out.kind).toBe("card");
+    if (out.kind === "card") {
+      expect(out.yaml_path).toBe("hostd.config_edit_enabled");
+      expect(out.to).toBe(true);
+      expect(out.card.text).toContain("klanker");
+    }
+  });
+
+  it("falls back to plain-text for a NON-allowlisted yaml_path", () => {
+    const resp = mkResp({
+      kind: "flip_yaml_flag",
+      yaml_path: "hostd.evil_backdoor_flag",
+      to: true,
+    });
+    const out = renderErrorEnvelopeCard(resp, "klanker", "a".repeat(32));
+    expect(out).toEqual({ kind: "plain-text" });
+  });
+
+  it("falls back to plain-text for request_vault_grant (Phase 2 scope)", () => {
+    const resp = mkResp({
+      kind: "request_vault_grant",
+      vault_key: "openai/api-key",
+    });
+    const out = renderErrorEnvelopeCard(resp, "klanker", "a".repeat(32));
+    expect(out).toEqual({ kind: "plain-text" });
+  });
+
+  it("falls back to plain-text when no envelope is present", () => {
+    const resp: HostdResponse = {
+      v: 1,
+      request_id: "r-1",
+      result: "error",
+      exit_code: null,
+      duration_ms: 0,
+      error: "legacy string",
+    };
+    const out = renderErrorEnvelopeCard(resp, "klanker", "a".repeat(32));
+    expect(out).toEqual({ kind: "plain-text" });
+  });
+});

--- a/tests/host-control/config-propose-edit.test.ts
+++ b/tests/host-control/config-propose-edit.test.ts
@@ -141,7 +141,14 @@ describe("hostd config_propose_edit — PR 1a gates (still live)", () => {
     const resp = await send({ unified_diff: TINY_DIFF, request_id: "cpe-1" });
     expect(resp.result).toBe("error");
     expect(resp.error).toMatch(/^E_CONFIG_EDIT_DISABLED/);
-    expect(resp.error).toMatch(/hostd\.config_edit_enabled=true/);
+    // #1758 Phase 1: yaml-path hint moved from legacy `error` string
+    // into `error_envelope.fix.yaml_path`.
+    expect(resp.error_envelope?.code).toBe("E_CONFIG_EDIT_DISABLED");
+    expect(resp.error_envelope?.fix).toEqual({
+      kind: "flip_yaml_flag",
+      yaml_path: "hostd.config_edit_enabled",
+      to: true,
+    });
   });
 
   it("returns E_CONFIG_EDIT_DISABLED when the flag is explicitly false", async () => {

--- a/tests/host-control/protocol.test.ts
+++ b/tests/host-control/protocol.test.ts
@@ -110,3 +110,49 @@ describe("hostd protocol — framing & schema", () => {
     expect(IDEMPOTENCY_WINDOW_MS).toBe(15_000);
   });
 });
+
+describe("error_envelope — #1758 Phase 1 round-trip", () => {
+  const variants: Array<{ name: string; fix: unknown }> = [
+    { name: "flip_yaml_flag", fix: { kind: "flip_yaml_flag", yaml_path: "hostd.config_edit_enabled", to: true } },
+    { name: "request_vault_grant", fix: { kind: "request_vault_grant", vault_key: "openai/api-key" } },
+    { name: "operator_action no steps", fix: { kind: "operator_action", subkind: "policy_denied" } },
+    { name: "operator_action with steps", fix: { kind: "operator_action", subkind: "infra", operator_steps: ["restart gateway"] } },
+    { name: "retry_after", fix: { kind: "retry_after", retry_at: "2026-01-01T00:00:00Z" } },
+    { name: "quota_exceeded", fix: { kind: "quota_exceeded", quota: "cron-entries", current: 20, limit: 20 } },
+    { name: "bad_input", fix: { kind: "bad_input", field: "agent_name" } },
+    { name: "bad_input no field", fix: { kind: "bad_input" } },
+  ];
+  for (const v of variants) {
+    it(`survives encode/decode round-trip — ${v.name}`, () => {
+      const resp: HostdResponse = {
+        v: 1,
+        request_id: "rt-1",
+        result: "error",
+        exit_code: null,
+        duration_ms: 0,
+        error: "E_FOO: human",
+        error_envelope: {
+          v: 1,
+          code: "E_FOO",
+          human: "human",
+          fix: v.fix as never,
+          request_id: "rt-1",
+        },
+      };
+      const decoded = decodeResponse(encodeResponse(resp).trimEnd());
+      expect(decoded).toEqual(resp);
+    });
+  }
+
+  it("ResponseSchema accepts a response WITHOUT error_envelope (backwards-compat)", () => {
+    const resp: HostdResponse = {
+      v: 1,
+      request_id: "rt-bc",
+      result: "completed",
+      exit_code: 0,
+      duration_ms: 0,
+    };
+    const decoded = decodeResponse(encodeResponse(resp).trimEnd());
+    expect(decoded).toEqual(resp);
+  });
+});


### PR DESCRIPTION
Closes part of #1758 (Phase 1 only).

## Summary

Adds the structured `error_envelope` sibling to hostd's `ResponseEnvelope`, the fluent `err()` builder that produces both legacy string + envelope, the PostHog `switchroom_error_friction` wrapper (PII-disciplined), and migrates the first call site (`E_CONFIG_EDIT_DISABLED`). The Telegram bridge gains a one-tap unlock-card renderer gated by a yaml-path allowlist.

## What ships (Phase 1)

- `ErrorFixSchema` + `ErrorEnvelopeSchema` in `src/host-control/protocol.ts`
- `err()` builder in `src/host-control/error-builder.ts` with `.why()`, `.fixFlipFlag()`, `.fixVaultGrant()`, `.fixOperatorAction()`, `.fixRetryAfter()`, `.fixQuotaExceeded()`, `.fixBadInput()`, `.docs()`, `.op()`, `.caller()`, `.agentName()`, `.build()`
- `recordErrorFriction()` in `src/analytics/error-friction.ts` — reuses existing `captureEvent`, never sends `human`/`why`/`docs`/raw `vault_key`/`operator_steps`; vault keys hashed to first-16-hex-chars-of-sha256
- First migration: `E_CONFIG_EDIT_DISABLED` in `handleConfigProposeEdit` (highest-friction unlock-card path)
- MCP hostd shim surfaces the envelope as a second `text` content item with a `fix.kind=…` discriminator hint
- `isAllowlistedYamlPath()` + `UNLOCK_CARD_YAML_ALLOWLIST` in `config-edit-validator.ts` (pins `hostd.config_edit_enabled` only — grows by operator decision)
- `telegram-plugin/gateway/error-envelope-card.ts` renders the one-tap card iff the path is allowlisted; non-allowlisted paths fall back to plain-text (defense against hostile envelopes from any backend)

## Out of scope (deferred to later phases per #1758)

- Migrating call sites 2–10 (Phase 2)
- agent-config broker errors (Phase 3)
- ESLint AST ratchet banning bare `E_*` literals (Phase 3)
- Vault-broker `envelope` field addition (Phase 2)
- PostHog dashboard for friction ranking (Phase 4)

Legacy `error: string` is preserved (synthesised by `.build()` as `\${code}: \${human}\${why ? " — " + why : ""}`) so existing decoders see no semantic regression.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `src/host-control/error-builder.test.ts` — 5 tests passing (builder shape, legacy-string stability across all `fix.kind` variants, fire-and-forget safety, PII discipline including `operator_steps` content)
- [x] `tests/host-control/protocol.test.ts` — 8 new round-trip tests, one per `fix.kind`, plus backwards-compat with envelope absent
- [x] `tests/host-control/config-propose-edit.test.ts` — updated existing `E_CONFIG_EDIT_DISABLED` test to assert `error_envelope.fix === {kind:"flip_yaml_flag", yaml_path:"hostd.config_edit_enabled", to:true}`
- [x] `telegram-plugin/tests/error-envelope-unlock-card.test.ts` — allowlisted path renders card; non-allowlisted falls back to plain-text; `request_vault_grant` falls back to plain-text (Phase 2 scope); missing envelope falls back to plain-text

Pre-existing failures in `tests/host-control/server.test.ts` (22 tests, all `'error' to be 'completed'` due to missing `switchroom` CLI binary in the test environment) verified to be unchanged from `origin/main` baseline — not caused by this PR.