### PR TITLE
fix(#1760): tear down still-working ticker on every reply finalize

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3434,6 +3434,14 @@ pendingProgress.startTimer({
     )
   },
   emitMetric: (event) => emitRuntimeMetric(event),
+  // #1760 defense-in-depth: if a newer turn for this chat is active at
+  // tick time, the prior turn's pending-progress is stale (the
+  // canonical teardown was missed). Drop the ticker instead of editing
+  // the old anchor — see pending-work-progress.ts's docblock.
+  isActiveTurnNewerThan: (key, activatedAt) => {
+    const turnStartedAt = activeTurnStartedAt.get(key)
+    return turnStartedAt != null && turnStartedAt > activatedAt
+  },
 })
 
 // Per-agent buffer for synthetic inbounds the gateway couldn't deliver
@@ -4689,6 +4697,10 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
           //   - #1664 silent-end re-prompt fires even when the
           //     accumulated silent content qualifies as substantive;
           //   - retries within the dedup window may double-send.
+          // #1760 primary fix — clear any stale prior-turn ticker
+          // before re-anchoring on this silent-reply edit. See the
+          // matching comment at the executeReply finalize site below.
+          pendingProgress.clearPending(statusKey(chat_id, threadId), 'reply_finalize')
           pendingProgress.noteOutbound(statusKey(chat_id, threadId), {
             messageId: decision.messageId,
             text: decision.mergedText,
@@ -4882,6 +4894,14 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   if (sentIds.length === chunks.length && chunks.length > 0) {
     const anchorMsgId = sentIds[chunks.length - 1]
     if (typeof anchorMsgId === 'number') {
+      // #1760 primary fix — clear any stale prior-turn ticker BEFORE
+      // re-anchoring. The canonical teardown wires (turn_end,
+      // subagent_handback, inbound) can be missed (e.g. SDK turn_end
+      // event dropped, as in the #1760 live evidence). Tearing down on
+      // every reply-finalize is idempotent and resilient: it's a no-op
+      // when nothing is active, and drops a stale ambient before the
+      // new turn captures its anchor.
+      pendingProgress.clearPending(statusKey(chat_id, threadId), 'reply_finalize')
       pendingProgress.noteOutbound(statusKey(chat_id, threadId), {
         messageId: anchorMsgId,
         text: chunks[chunks.length - 1],
@@ -5319,6 +5339,10 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       streamFormat === 'html' ? 'HTML'
       : streamFormat === 'markdownv2' ? 'MarkdownV2'
       : undefined
+    // #1760 primary fix — clear any stale prior-turn ticker before
+    // re-anchoring on stream_reply done. See the matching comment at
+    // the executeReply finalize site.
+    pendingProgress.clearPending(statusKey(sChatId, sThreadId), 'reply_finalize')
     pendingProgress.noteOutbound(statusKey(sChatId, sThreadId), {
       messageId: result.messageId,
       text: args.text as string,

--- a/telegram-plugin/pending-work-progress.ts
+++ b/telegram-plugin/pending-work-progress.ts
@@ -112,6 +112,20 @@ export interface PendingProgressDeps {
   nowMs?: () => number
   /** Optional poll interval override for tests. */
   pollIntervalMs?: number
+  /**
+   * Defense-in-depth (#1760). When provided, returns the gateway's
+   * `activeTurnStartedAt` epoch ms for this chat key, or undefined if no
+   * turn is currently active. The ticker uses this on every fire to detect
+   * a stale ambient: if a NEWER turn has started (epoch > our activatedAt)
+   * the prior turn's cross-turn pending-progress is by definition orphaned
+   * (the turn_end teardown was missed, e.g. SDK event dropped) and the
+   * ticker self-terminates instead of editing a stale anchor. Converts the
+   * #1760 failure mode from "stuck forever" to "at most one stale tick."
+   *
+   * Defaults to undefined — preserves prior behaviour for tests that
+   * exercise the ticker without a gateway.
+   */
+  isActiveTurnNewerThan?: (key: string, activatedAt: number) => boolean
 }
 
 interface State {
@@ -276,7 +290,14 @@ export function noteTurnEnd(key: string): void {
  */
 export function clearPending(
   key: string,
-  reason: 'inbound' | 'handback' | 'progress' | 'timeout' | 'manual',
+  reason:
+    | 'inbound'
+    | 'handback'
+    | 'progress'
+    | 'timeout'
+    | 'manual'
+    | 'reply_finalize'
+    | 'stale_turn',
 ): void {
   if (!stateByKey.has(key)) return
   const s = stateByKey.get(key)!
@@ -334,6 +355,21 @@ function tick(now: number): void {
     const elapsed = now - s.activatedAt
     if (elapsed >= MAX_LIFETIME_MS) {
       clearPending(key, 'timeout')
+      continue
+    }
+
+    // #1760 defense-in-depth: if a newer turn is currently active for
+    // this chat, the prior turn's cross-turn pending-progress is stale
+    // (the canonical teardown — turn_end or the next turn's reply-
+    // finalize — was missed). Drop the timer instead of editing the
+    // old anchor; the new turn will manage its own anchor via the
+    // regular noteOutbound / noteTurnEnd path. Converts "stuck forever"
+    // (the live #1760 evidence) into "at most one stale tick."
+    if (
+      activeDeps.isActiveTurnNewerThan != null
+      && activeDeps.isActiveTurnNewerThan(key, s.activatedAt)
+    ) {
+      clearPending(key, 'stale_turn')
       continue
     }
 

--- a/telegram-plugin/tests/pending-work-progress.test.ts
+++ b/telegram-plugin/tests/pending-work-progress.test.ts
@@ -407,4 +407,138 @@ describe('pending-work-progress', () => {
     expect(cap.edits.filter((e) => e.messageId === 10)).toHaveLength(1)
     expect(cap.edits.filter((e) => e.messageId === 20)).toHaveLength(2)
   })
+
+  // ─── #1760 regression tests ───────────────────────────────────────────
+  //
+  // The "— still working (Nm)" ticker can get stuck forever editing an
+  // old outbound message if the gateway misses the SDK `turn_end` event.
+  // Two layers of defence:
+  //
+  //   1. PRIMARY: the gateway tears down on every `reply: finalized`
+  //      chokepoint via `clearPending(key, 'reply_finalize')` BEFORE
+  //      `noteOutbound` on the next turn's first reply. Verified here by
+  //      simulating a missed-turn_end scenario: the prior turn's ticker
+  //      is activated, then the gateway processes a fresh reply on a NEW
+  //      turn without ever calling `noteTurnEnd` for the prior one. The
+  //      explicit `clearPending('reply_finalize')` call must wipe the
+  //      stale ambient.
+  //
+  //   2. DEFENSE-IN-DEPTH: at tick time, if `isActiveTurnNewerThan`
+  //      returns true (gateway reports a newer turn is active for this
+  //      chat), the ticker self-terminates instead of editing. Bug
+  //      becomes "at most one stale tick" rather than "stuck forever."
+
+  it('#1760 primary: reply_finalize teardown wipes a stale activated ticker', async () => {
+    const cap = setup()
+
+    // Turn 1: dispatch async work, capture an anchor, end the turn.
+    // Ticker activates and fires one edit at +60s.
+    startTurn(KEY)
+    noteAsyncDispatch(KEY)
+    noteOutbound(KEY, { messageId: 100, text: 'kicking off worker' })
+    noteTurnEnd(KEY)
+    cap.now = EDIT_INTERVAL_MS
+    __tickForTests(cap.now)
+    await flush()
+    expect(cap.edits).toHaveLength(1)
+    expect(cap.edits[0]?.messageId).toBe(100)
+
+    // Turn 2 begins WITHOUT a prior `noteTurnEnd` clear (simulating the
+    // #1760 missed-turn_end SDK-event-drop). The gateway's reply-
+    // finalize chokepoint MUST call clearPending('reply_finalize')
+    // BEFORE noteOutbound on the new anchor. After that, the prior
+    // ticker is gone and further ticks (even before any new
+    // noteTurnEnd) edit nothing.
+    clearPending(KEY, 'reply_finalize')
+    noteOutbound(KEY, { messageId: 200, text: 'turn 2 reply' })
+
+    cap.now = EDIT_INTERVAL_MS * 5
+    __tickForTests(cap.now)
+    await flush()
+    // No additional edits — the stale ticker is dead. Note that the new
+    // turn's ticker has not been activated yet (noteTurnEnd not called),
+    // so nothing should fire here either.
+    expect(cap.edits).toHaveLength(1)
+
+    // The 'reply_finalize' clear must surface as a metric so operators
+    // can observe the backstop firing in production.
+    const reasons = cap.metrics
+      .filter((m): m is Extract<PendingProgressMetric, { kind: 'pending_progress_cleared' }> =>
+        m.kind === 'pending_progress_cleared')
+      .map((m) => m.reason)
+    expect(reasons).toContain('reply_finalize')
+  })
+
+  it('#1760 defense-in-depth: ticker self-terminates when isActiveTurnNewerThan is true', async () => {
+    const cap: Capture = { edits: [], metrics: [], now: 0 }
+    __resetAllForTests()
+    // The activatedAt epoch captured by the ticker:
+    const TURN_1_ACTIVATED_AT = 1_000
+    // A NEWER turn starts later, simulating turn-2 racing past the
+    // missed teardown:
+    const TURN_2_STARTED_AT = TURN_1_ACTIVATED_AT + 30_000
+
+    __setDepsForTests({
+      editMessage: async (ctx) => {
+        cap.edits.push(ctx)
+      },
+      emitMetric: (e) => {
+        cap.metrics.push(e)
+      },
+      nowMs: () => cap.now,
+      // Reports a newer turn always-on for this test.
+      isActiveTurnNewerThan: (_key, activatedAt) =>
+        TURN_2_STARTED_AT > activatedAt,
+    })
+
+    // Bootstrap a "prior turn" ticker at TURN_1_ACTIVATED_AT.
+    cap.now = TURN_1_ACTIVATED_AT
+    startTurn(KEY)
+    noteAsyncDispatch(KEY)
+    noteOutbound(KEY, { messageId: 100, text: 'kicking off worker' })
+    noteTurnEnd(KEY)
+    expect(__getStateForTests(KEY)?.activatedAt).toBe(TURN_1_ACTIVATED_AT)
+
+    // Advance past EDIT_INTERVAL_MS so the tick would otherwise fire.
+    cap.now = TURN_1_ACTIVATED_AT + EDIT_INTERVAL_MS + 1_000
+    __tickForTests(cap.now)
+    await flush()
+
+    // No edit fired — the predicate detected a newer active turn and
+    // dropped the ticker.
+    expect(cap.edits).toHaveLength(0)
+    expect(__getStateForTests(KEY)).toBeUndefined()
+
+    const cleared = cap.metrics.find(
+      (m): m is Extract<PendingProgressMetric, { kind: 'pending_progress_cleared' }> =>
+        m.kind === 'pending_progress_cleared',
+    )
+    expect(cleared?.reason).toBe('stale_turn')
+  })
+
+  it('#1760 defense-in-depth: predicate returning false leaves ticker alone', async () => {
+    const cap: Capture = { edits: [], metrics: [], now: 0 }
+    __resetAllForTests()
+    __setDepsForTests({
+      editMessage: async (ctx) => {
+        cap.edits.push(ctx)
+      },
+      emitMetric: (e) => {
+        cap.metrics.push(e)
+      },
+      nowMs: () => cap.now,
+      // No newer turn — the legitimate cross-turn ambient case.
+      isActiveTurnNewerThan: () => false,
+    })
+
+    startTurn(KEY)
+    noteAsyncDispatch(KEY)
+    noteOutbound(KEY, { messageId: 100, text: 'kicking off worker' })
+    noteTurnEnd(KEY)
+
+    cap.now = EDIT_INTERVAL_MS
+    __tickForTests(cap.now)
+    await flush()
+    expect(cap.edits).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
Fixes #1760.

## Summary

The "— still working (Nm)" cross-turn suffix ticker (`pending-work-progress.ts`) could get stuck forever editing an old outbound message when the gateway missed the SDK `turn_end` event. Live evidence in the issue: msg 2443 finalized at 00:09:48, ticker fired every minute for the next ~50 min while subsequent turns ran in between without clearing it.

## Fix — two layers

**Primary.** The gateway now calls `clearPending(key, 'reply_finalize')` immediately before every `noteOutbound` chokepoint:
- `executeReply` final-chunk anchor capture
- the silent-reply edit-anchor branch
- `executeStreamReply` done=true anchor capture

Idempotent (no-op when nothing is active) and resilient to missing or late SDK events. Any stale prior-turn ambient is wiped before the new turn's anchor is captured. The legitimate cross-turn flow's `handback`/`inbound` clears still fire first; the new clear is a backstop.

**Defense-in-depth.** `pending-work-progress` now accepts an optional `isActiveTurnNewerThan(key, activatedAt)` dep. The gateway wires it to `activeTurnStartedAt.get(key) > activatedAt`. If a tick fires while a NEWER turn is active for the same chat, the prior turn's ambient is by definition orphaned and the ticker self-terminates with reason `'stale_turn'`. Converts the failure mode from "stuck forever" to "at most one stale tick" — matching the issue's recommendation verbatim.

## Tests

Added to `telegram-plugin/tests/pending-work-progress.test.ts`:

- `#1760 primary` — replicates the missed-turn_end scenario. Activates a ticker, fires one edit, then a new turn's `clearPending('reply_finalize')` + `noteOutbound` runs without ever calling `noteTurnEnd` on the prior turn. Asserts no further edits and a `reason: 'reply_finalize'` metric is emitted.
- `#1760 defense-in-depth (active)` — with `isActiveTurnNewerThan: () => true`, a tick after activation drops the timer instead of editing and emits `reason: 'stale_turn'`.
- `#1760 defense-in-depth (inactive)` — with `isActiveTurnNewerThan: () => false`, the legitimate cross-turn ambient still fires its edit normally (regression guard).

## Verification

- `pending-work-progress.test.ts` — 20/20 pass (17 prior + 3 new)
- `silence-poke.test.ts` — 59/59 pass unchanged
- `silent-end.test.ts` — 36/36 pass unchanged
- `tsc --noEmit` clean
- `npm run lint` clean

## Test plan

- [ ] Run `npm test` in CI — all telegram-plugin suites green
- [ ] Manual: deploy to a non-prod agent, trigger a turn that ends without `turn_end` arriving (e.g. via a contrived sub-agent-watcher exit path or by killing the SDK mid-turn) and confirm the next inbound's reply does NOT show the stale "— still working (Nm)" suffix being re-edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)