### PR TITLE
fix(#1762): config_propose_edit silent E_DENIED on oversize diff

### DIFF
--- a/src/host-control/approval-gateway.test.ts
+++ b/src/host-control/approval-gateway.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for SocketApprovalGateway (#1762).
+ *
+ * Focus areas (added with #1762):
+ *   - `reason` surfaces from gateway → ApprovalResult on
+ *     config_approval_resolved
+ *   - `denySource: "dispatch_failure"` propagates when the gateway
+ *     reports a card-dispatch failure
+ *   - `denySource: "operator"` defaults on a bare deny (no denySource
+ *     field on the wire) so the caller's discriminant is always
+ *     populated when verdict==="deny"
+ *   - resolveGatewaySocket returning null → deny with
+ *     denySource: "dispatch_failure"
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createServer, type Server, type Socket } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SocketApprovalGateway } from "./approval-gateway.js";
+import { formatConfigApprovalDenyError } from "./server.js";
+
+interface FakeGateway {
+  server: Server;
+  socketPath: string;
+  /** Set by the test to control how the gateway responds to incoming requests. */
+  respond: (write: (line: string) => void, requestId: string) => void;
+  /** All client sockets — force-destroyed by afterEach to unblock server.close. */
+  clients: Socket[];
+}
+
+function startFakeGateway(): FakeGateway {
+  const dir = mkdtempSync(join(tmpdir(), "sr-1762-"));
+  const socketPath = join(dir, "gw.sock");
+  const handle: Partial<FakeGateway> = { clients: [] };
+  const server = createServer((sock: Socket) => {
+    handle.clients?.push(sock);
+    let buf = "";
+    sock.on("data", (chunk) => {
+      buf += chunk.toString("utf8");
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        const obj = JSON.parse(line) as { type: string; requestId: string };
+        if (obj.type === "request_config_approval") {
+          handle.respond?.(
+            (out: string) => sock.write(out + "\n"),
+            obj.requestId,
+          );
+        }
+      }
+    });
+  });
+  server.listen(socketPath);
+  handle.server = server;
+  handle.socketPath = socketPath;
+  // default respond — overridden per-test
+  handle.respond = () => {};
+  // cleanup attached to the returned object via close handler
+  server.on("close", () => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+  return handle as FakeGateway;
+}
+
+const baseReq = {
+  requestId: "req-fake",
+  agentName: "klanker",
+  reason: "test",
+  unifiedDiff: "--- a\n+++ b\n",
+  timeoutMs: 5_000,
+};
+
+describe("SocketApprovalGateway — dispatch_failure plumbing (#1762)", () => {
+  let fake: FakeGateway;
+
+  beforeEach(() => {
+    fake = startFakeGateway();
+  });
+  afterEach(async () => {
+    // SocketApprovalGateway keeps the client socket open after the
+    // verdict resolves (so finalize() can reuse it). The fake server
+    // can't fully close until every connection is gone, so destroy
+    // them explicitly here.
+    for (const c of fake.clients) c.destroy();
+    await new Promise<void>((resolve) => fake.server.close(() => resolve()));
+  });
+
+  it("propagates reason + denySource='dispatch_failure' from the gateway", async () => {
+    fake.respond = (write, requestId) => {
+      write(
+        JSON.stringify({
+          type: "config_approval_resolved",
+          requestId,
+          verdict: "deny",
+          reason: "Telegram sendMessage failed (4097 > 4096 chars)",
+          denySource: "dispatch_failure",
+        }),
+      );
+    };
+    const gw = new SocketApprovalGateway({
+      resolveGatewaySocket: () => fake.socketPath,
+    });
+    const result = await gw.requestApproval(baseReq);
+    expect(result.verdict).toBe("deny");
+    expect(result.reason).toBe(
+      "Telegram sendMessage failed (4097 > 4096 chars)",
+    );
+    expect(result.denySource).toBe("dispatch_failure");
+  });
+
+  it("defaults denySource='operator' on a bare deny with no denySource field", async () => {
+    fake.respond = (write, requestId) => {
+      write(
+        JSON.stringify({
+          type: "config_approval_resolved",
+          requestId,
+          verdict: "deny",
+        }),
+      );
+    };
+    const gw = new SocketApprovalGateway({
+      resolveGatewaySocket: () => fake.socketPath,
+    });
+    const result = await gw.requestApproval(baseReq);
+    expect(result.verdict).toBe("deny");
+    expect(result.denySource).toBe("operator");
+    expect(result.reason).toBeUndefined();
+  });
+
+  it("denySource is undefined on non-deny verdicts (approve)", async () => {
+    fake.respond = (write, requestId) => {
+      write(
+        JSON.stringify({
+          type: "config_approval_resolved",
+          requestId,
+          verdict: "approve",
+        }),
+      );
+    };
+    const gw = new SocketApprovalGateway({
+      resolveGatewaySocket: () => fake.socketPath,
+    });
+    const result = await gw.requestApproval(baseReq);
+    expect(result.verdict).toBe("approve");
+    expect(result.denySource).toBeUndefined();
+  });
+
+  it("resolveGatewaySocket=null → deny with denySource='dispatch_failure'", async () => {
+    const gw = new SocketApprovalGateway({
+      resolveGatewaySocket: () => null,
+    });
+    const result = await gw.requestApproval(baseReq);
+    expect(result.verdict).toBe("deny");
+    expect(result.denySource).toBe("dispatch_failure");
+    expect(result.reason).toMatch(/no reachable telegram gateway/);
+  });
+
+  it("server-side mapping: denySource='dispatch_failure' → E_APPROVAL_DISPATCH_FAILED with the gateway reason", () => {
+    const msg = formatConfigApprovalDenyError(
+      {
+        
+        reason: "Telegram sendMessage failed (4097 > 4096 chars)",
+        denySource: "dispatch_failure",
+      },
+      "abc12345",
+    );
+    expect(msg).toContain("E_APPROVAL_DISPATCH_FAILED");
+    expect(msg).toContain("Telegram sendMessage failed");
+    expect(msg).toContain("approval_id=abc12345");
+    expect(msg).not.toContain("operator denied");
+  });
+
+  it("server-side mapping: denySource='operator' → E_DENIED with reason appended", () => {
+    const msg = formatConfigApprovalDenyError(
+      {
+        
+        denySource: "operator",
+        reason: "operator tapped deny",
+      },
+      "abc12345",
+    );
+    expect(msg).toMatch(/^E_DENIED:/);
+    expect(msg).toContain("operator denied config_propose_edit");
+    expect(msg).toContain("operator tapped deny");
+  });
+
+  it("server-side mapping: no reason → bare E_DENIED message", () => {
+    const msg = formatConfigApprovalDenyError(
+      { denySource: "operator" },
+      "abc12345",
+    );
+    expect(msg).toBe(
+      "E_DENIED: operator denied config_propose_edit (approval_id=abc12345)",
+    );
+  });
+
+  it("server-side mapping: dispatch_failure with no reason → generic fallback string", () => {
+    const msg = formatConfigApprovalDenyError(
+      { denySource: "dispatch_failure" },
+      "abc12345",
+    );
+    expect(msg).toContain("E_APPROVAL_DISPATCH_FAILED");
+    expect(msg).toContain("card dispatch failed");
+  });
+
+  it("gateway socket closes before verdict → deny with denySource='dispatch_failure'", async () => {
+    fake.respond = (_write, _requestId) => {
+      // Drop the connection without responding — simulates gateway
+      // crash mid-request. Destroying every server-side client socket
+      // surfaces as a 'close' event on the SocketApprovalGateway client.
+      for (const c of fake.clients) c.destroy();
+    };
+    const gw = new SocketApprovalGateway({
+      resolveGatewaySocket: () => fake.socketPath,
+    });
+    const result = await gw.requestApproval(baseReq);
+    expect(result.verdict).toBe("deny");
+    expect(result.denySource).toBe("dispatch_failure");
+    expect(result.reason).toBeDefined();
+  });
+});

--- a/src/host-control/approval-gateway.ts
+++ b/src/host-control/approval-gateway.ts
@@ -15,6 +15,21 @@ export interface ApprovalRequest {
 
 export interface ApprovalResult {
   verdict: ApprovalVerdict;
+  /**
+   * Diagnostic detail from the gateway when present. On a
+   * dispatch-failure deny this carries the underlying cause (e.g.
+   * "Telegram sendMessage failed") so the caller can surface a
+   * descriptive error instead of an opaque `E_DENIED`. Issue #1762.
+   */
+  reason?: string;
+  /**
+   * On `verdict: "deny"`, distinguishes an actual operator tap
+   * (`"operator"`) from a gateway-side dispatch failure that
+   * auto-denied because the card never reached the operator
+   * (`"dispatch_failure"`). Undefined when verdict is not "deny".
+   * Issue #1762.
+   */
+  denySource?: "operator" | "dispatch_failure";
   /** Update the approval card with the apply outcome. */
   finalize: (outcome: {
     outcome: "applied" | "reconcile_failed_rolled_back";
@@ -43,6 +58,8 @@ export class SocketApprovalGateway implements ApprovalGateway {
       // No reachable gateway — fail closed.
       return {
         verdict: "deny",
+        reason: "no reachable telegram gateway socket for this agent",
+        denySource: "dispatch_failure",
         finalize: async () => {},
       };
     }
@@ -95,7 +112,12 @@ export class SocketApprovalGateway implements ApprovalGateway {
           log(
             `request_config_approval write failed (requestId=${req.requestId}): ${(err as Error).message}`,
           );
-          resolve({ verdict: "deny", finalize: async () => {} });
+          resolve({
+            verdict: "deny",
+            reason: `request_config_approval write failed: ${(err as Error).message}`,
+            denySource: "dispatch_failure",
+            finalize: async () => {},
+          });
         }
       });
 
@@ -122,8 +144,23 @@ export class SocketApprovalGateway implements ApprovalGateway {
             !resolved
           ) {
             resolved = true;
+            const verdict = obj.verdict as ApprovalVerdict;
+            const reasonField =
+              typeof obj.reason === "string" ? obj.reason : undefined;
+            // denySource is only meaningful on deny verdicts. Gateway
+            // omits the field on operator-tap denies — default to
+            // "operator" in that case so the caller can rely on the
+            // discriminant being present whenever verdict==="deny".
+            const denySource: "operator" | "dispatch_failure" | undefined =
+              verdict === "deny"
+                ? obj.denySource === "dispatch_failure"
+                  ? "dispatch_failure"
+                  : "operator"
+                : undefined;
             resolve({
-              verdict: obj.verdict as ApprovalVerdict,
+              verdict,
+              ...(reasonField !== undefined ? { reason: reasonField } : {}),
+              ...(denySource !== undefined ? { denySource } : {}),
               finalize,
             });
             // Note: we keep `client` open so finalize can reuse it.
@@ -137,13 +174,23 @@ export class SocketApprovalGateway implements ApprovalGateway {
         log(
           `gateway socket error (requestId=${req.requestId}): ${err.message}`,
         );
-        resolve({ verdict: "deny", finalize: async () => {} });
+        resolve({
+          verdict: "deny",
+          reason: `gateway socket error: ${err.message}`,
+          denySource: "dispatch_failure",
+          finalize: async () => {},
+        });
       });
 
       client.on("close", () => {
         if (resolved) return;
         resolved = true;
-        resolve({ verdict: "deny", finalize: async () => {} });
+        resolve({
+          verdict: "deny",
+          reason: "gateway socket closed before verdict",
+          denySource: "dispatch_failure",
+          finalize: async () => {},
+        });
       });
     });
   }

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -280,6 +280,34 @@ function defaultApprovalId(): string {
   return randomBytes(4).toString("hex");
 }
 
+/**
+ * Map a deny `ApprovalResult` to the appropriate error string for
+ * the config_propose_edit response. (#1762)
+ *
+ *   - `denySource === "dispatch_failure"` → `E_APPROVAL_DISPATCH_FAILED`
+ *     (Telegram card never reached the operator — opaque
+ *     "operator denied" would be a lie)
+ *   - operator tap deny → `E_DENIED` with the reason (when present)
+ *     appended for diagnostic value
+ *
+ * Exported only for unit testing — the production caller is
+ * `handleConfigProposeEdit` in this file.
+ */
+export function formatConfigApprovalDenyError(
+  approval: {
+    reason?: string;
+    denySource?: "operator" | "dispatch_failure";
+  },
+  approvalId: string,
+): string {
+  if (approval.denySource === "dispatch_failure") {
+    const detail = approval.reason ?? "card dispatch failed";
+    return `E_APPROVAL_DISPATCH_FAILED: ${detail} (approval_id=${approvalId})`;
+  }
+  const suffix = approval.reason ? `: ${approval.reason}` : "";
+  return `E_DENIED: operator denied config_propose_edit${suffix} (approval_id=${approvalId})`;
+}
+
 /** Best-effort tmp-file cleanup — swallowed errors. */
 function unlinkSyncBestEffort(path: string): void {
   try {
@@ -1261,9 +1289,13 @@ export class HostdServer {
       timeoutMs: CONFIG_APPROVAL_TIMEOUT_MS,
     });
     if (approval.verdict === "deny") {
+      // #1762: distinguish operator-tap deny from gateway-side
+      // dispatch failure (card never reached the operator). Without
+      // this, a Telegram sendMessage 400 surfaces as a misleading
+      // "operator denied" — see ref #1758 structured-error work.
       return errorResponse(
         req.request_id,
-        `E_DENIED: operator denied config_propose_edit (approval_id=${approvalId})`,
+        formatConfigApprovalDenyError(approval, approvalId),
         Date.now() - started,
       );
     }

--- a/telegram-plugin/gateway/config-approval-handler.test.ts
+++ b/telegram-plugin/gateway/config-approval-handler.test.ts
@@ -75,6 +75,57 @@ describe("buildConfigApprovalCardBody", () => {
     expect(body).toContain("&lt;script&gt;");
     expect(body).toContain("a &amp; b &lt;c&gt;");
   });
+
+  it("rendered body stays under Telegram's 4096-char limit when raw diff is all `&` (worst-case 5x escape inflation)", () => {
+    // 3000 `&` chars escape to 15000 `&amp;` chars — far past 4096.
+    // The post-escape cap MUST kick in and truncate the rendered body.
+    const evilDiff = "&".repeat(3000);
+    const body = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: "test",
+      unifiedDiff: evilDiff,
+    });
+    expect(body.length).toBeLessThanOrEqual(4096);
+    expect(body).toContain("diff continues, see attached file");
+  });
+
+  it("rendered body stays under 4096 when raw diff is all `<` (5x escape)", () => {
+    const evilDiff = "<".repeat(3000);
+    const body = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: "test",
+      unifiedDiff: evilDiff,
+    });
+    expect(body.length).toBeLessThanOrEqual(4096);
+    expect(body).toContain("&lt;");
+  });
+
+  it("clips an unbounded operator-supplied `reason` to ~500 chars with ellipsis", () => {
+    const longReason = "x".repeat(2000);
+    const body = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: longReason,
+      unifiedDiff: "small",
+    });
+    // The escaped reason should appear, but capped.
+    const reasonLine = body
+      .split("\n")
+      .find((l) => l.startsWith("Reason: "))!;
+    // "Reason: " prefix (8) + clipped reason.
+    expect(reasonLine.length).toBeLessThanOrEqual(8 + 500);
+    expect(reasonLine.endsWith("…")).toBe(true);
+  });
+
+  it("rendered body stays under 4096 even when reason is also adversarial", () => {
+    const evilDiff = "&".repeat(3000);
+    const evilReason = "&".repeat(2000);
+    const body = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: evilReason,
+      unifiedDiff: evilDiff,
+    });
+    expect(body.length).toBeLessThanOrEqual(4096);
+  });
 });
 
 describe("handleRequestConfigApproval", () => {

--- a/telegram-plugin/gateway/config-approval-handler.test.ts
+++ b/telegram-plugin/gateway/config-approval-handler.test.ts
@@ -17,6 +17,7 @@ import {
   handleRequestConfigFinalize,
   parseConfigApprovalCallback,
   resolvePendingConfigApproval,
+  truncateDiffForCard,
   _resetPendingConfigApprovalsForTest,
   _peekPendingConfigApprovalForTest,
 } from "./config-approval-handler.js";
@@ -100,6 +101,7 @@ describe("handleRequestConfigApproval", () => {
         requestId: "req-1",
         verdict: "deny",
         reason: expect.stringContaining("gateway serves 'klanker'"),
+        denySource: "dispatch_failure",
       },
     ]);
   });
@@ -222,6 +224,100 @@ describe("handleRequestConfigFinalize", () => {
       deps,
     );
     expect(editCalls.length).toBe(0);
+  });
+});
+
+describe("oversize diff → attachment fallback (#1762)", () => {
+  function bigDiff(lines: number): string {
+    // Each line ~80 chars → 200 lines ≈ 16 KB, comfortably > 4096.
+    const row =
+      "-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    return Array.from({ length: lines }, (_, i) => `${row}${i}`).join("\n");
+  }
+
+  it("truncateDiffForCard caps the diff and appends a sentinel", () => {
+    const truncated = truncateDiffForCard(bigDiff(200), 50, 3000);
+    expect(truncated.length).toBeLessThanOrEqual(3050);
+    expect(truncated.endsWith("[… diff continues, see attached file]")).toBe(
+      true,
+    );
+  });
+
+  it("returns the original diff unchanged when below the line cap", () => {
+    const small = "--- a\n+++ b\n@@\n-x\n+y\n";
+    expect(truncateDiffForCard(small, 50)).toBe(small);
+  });
+
+  it("oversize body still posts a card with buttons AND fires postAttachment", async () => {
+    const huge = bigDiff(200);
+    const attachmentCalls: Array<{
+      chatId: number | string;
+      filename: string;
+      content: string;
+    }> = [];
+    const { client, sent, deps } = fakeDeps({
+      postAttachment: async (a: {
+        chatId: number | string;
+        filename: string;
+        content: string;
+      }) => {
+        attachmentCalls.push({
+          chatId: a.chatId,
+          filename: a.filename,
+          content: a.content,
+        });
+      },
+    });
+    await handleRequestConfigApproval(
+      client,
+      { ...baseMsg, unifiedDiff: huge },
+      deps,
+    );
+
+    // Card was posted exactly once, with buttons, and within Telegram's limit.
+    expect(deps.postCard).toHaveBeenCalledTimes(1);
+    const postArgs = (deps.postCard as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { text: string; replyMarkup: unknown };
+    expect(postArgs.text.length).toBeLessThanOrEqual(4096);
+    expect(postArgs.text).toMatch(/diff continues, see attached file/);
+    expect(postArgs.replyMarkup).toBeDefined();
+
+    // Attachment carries the FULL diff, named .patch, keyed by requestId.
+    expect(attachmentCalls.length).toBe(1);
+    expect(attachmentCalls[0]!.filename).toBe("config-edit-req-1.patch");
+    expect(attachmentCalls[0]!.content).toBe(huge);
+
+    // The pending entry is registered — handler hasn't auto-denied.
+    expect(_peekPendingConfigApprovalForTest("req-1")).toBeDefined();
+    // No verdict has crossed the wire yet (still pending operator tap).
+    expect(sent.filter((s) => s.type === "config_approval_resolved")).toEqual(
+      [],
+    );
+  });
+
+  it("oversize but no postAttachment dep → card still posts, missing-attachment is logged", async () => {
+    const huge = bigDiff(200);
+    const logs: string[] = [];
+    const { client, deps } = fakeDeps({ log: (m: string) => logs.push(m) });
+    await handleRequestConfigApproval(
+      client,
+      { ...baseMsg, unifiedDiff: huge },
+      deps,
+    );
+    expect(deps.postCard).toHaveBeenCalledTimes(1);
+    expect(
+      logs.some((l) => l.includes("no postAttachment dep wired")),
+    ).toBe(true);
+    expect(_peekPendingConfigApprovalForTest("req-1")).toBeDefined();
+  });
+
+  it("postCard failure → deny carries denySource='dispatch_failure'", async () => {
+    const { client, sent, deps } = fakeDeps({
+      postCard: vi.fn(async () => null),
+    });
+    await handleRequestConfigApproval(client, baseMsg, deps);
+    expect(sent[0]!.verdict).toBe("deny");
+    expect(sent[0]!.denySource).toBe("dispatch_failure");
   });
 });
 

--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -74,13 +74,16 @@ export interface ConfigApprovalHandlerDeps {
 /**
  * Truncate a unified diff for inline display in the card body when
  * the full diff would exceed Telegram's 4096-char sendMessage limit.
- * Caps at `maxLines` lines AND at `maxChars` characters (whichever
- * trips first), then appends a sentinel pointing to the attached
- * `.patch` document. (#1762)
+ * Caps at `maxLines` lines AND at `maxChars` *raw* characters
+ * (whichever trips first), then appends a sentinel pointing to the
+ * attached `.patch` document. (#1762)
  *
- * The char cap is the load-bearing one — long single lines can still
- * overflow a 50-line slice. We leave ~600 chars of headroom under the
- * 4096 cap for the framing (header lines, `<pre>` tags, HTML escapes).
+ * NOTE: This is a *raw-input* cap. HTML escaping happens downstream
+ * and can inflate by up to 5x per char (`&` → `&amp;`). The
+ * load-bearing post-escape cap lives in `buildConfigApprovalCardBody`
+ * (rendered-body cap), which re-truncates the raw diff if escaping
+ * blew past Telegram's 4096 sendMessage limit. This function is the
+ * cheap fast-path for the common case.
  */
 export function truncateDiffForCard(
   unifiedDiff: string,
@@ -105,19 +108,92 @@ export function truncateDiffForCard(
   return out === unifiedDiff ? out : out + sentinel;
 }
 
+/**
+ * Telegram `sendMessage` hard limit. We render with `parse_mode=HTML`,
+ * so the limit applies to the rendered (escaped) body, NOT the raw
+ * pre-escape source. Worst-case escape is `&` → `&amp;` (5x).
+ */
+const TELEGRAM_SENDMESSAGE_LIMIT = 4096;
+/** Safety margin under the hard limit for invisible framing wobble. */
+const RENDERED_BODY_CAP = 3900;
+/** Operator-supplied `reason` is unbounded at the wire — clip it. */
+const REASON_MAX_CHARS = 500;
+const REASON_ELLIPSIS = "…";
+const DIFF_SENTINEL = "\n[… diff continues, see attached file]";
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function clipReason(reason: string): string {
+  if (reason.length <= REASON_MAX_CHARS) return reason;
+  return reason.slice(0, REASON_MAX_CHARS - REASON_ELLIPSIS.length) +
+    REASON_ELLIPSIS;
+}
+
+/**
+ * Render the card body, guaranteeing the result fits under Telegram's
+ * 4096-char sendMessage limit even when HTML escaping inflates the
+ * raw diff up to 5x (worst case: all `&`). Strategy:
+ *
+ *   1. Clip `reason` (user-supplied, unbounded) to REASON_MAX_CHARS.
+ *   2. Render with the (already line/char-capped) diff.
+ *   3. If the rendered body still exceeds RENDERED_BODY_CAP, binary-
+ *      shrink the raw diff and re-render until it fits. Truncation
+ *      happens on the RAW diff (then re-escaped), so we never cut
+ *      mid-entity like `&am|p;`.
+ *
+ * The full diff still ships as a `.patch` attachment — this cap only
+ * shrinks the inline preview.
+ */
 export function buildConfigApprovalCardBody(args: {
   agentName: string;
   reason: string;
   unifiedDiff: string;
 }): string {
-  const esc = (s: string) =>
-    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-  return (
+  const safeReason = clipReason(args.reason);
+  const render = (diff: string): string =>
     `🛠 <b>Config edit proposed</b>\n` +
-    `Agent: <code>${esc(args.agentName)}</code>\n` +
-    `Reason: ${esc(args.reason)}\n\n` +
-    `<pre>${esc(args.unifiedDiff)}</pre>`
-  );
+    `Agent: <code>${escapeHtml(args.agentName)}</code>\n` +
+    `Reason: ${escapeHtml(safeReason)}\n\n` +
+    `<pre>${escapeHtml(diff)}</pre>`;
+
+  let body = render(args.unifiedDiff);
+  if (body.length <= RENDERED_BODY_CAP) return body;
+
+  // Rendered body too big — escaping inflated the diff past our cap.
+  // Binary-search the raw-diff slice that fits, snapping to a line
+  // boundary where possible and appending the truncation sentinel.
+  let lo = 0;
+  let hi = args.unifiedDiff.length;
+  let bestDiff = "";
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const slice = args.unifiedDiff.slice(0, mid);
+    const candidate = slice + DIFF_SENTINEL;
+    if (render(candidate).length <= RENDERED_BODY_CAP) {
+      bestDiff = candidate;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  // Snap to last newline so we don't cut mid-line. The sentinel is
+  // suffixed AFTER the snap so the trailing line stays intact.
+  const rawCap = bestDiff.length - DIFF_SENTINEL.length;
+  if (rawCap > 0) {
+    const rawSlice = args.unifiedDiff.slice(0, rawCap);
+    const lastNl = rawSlice.lastIndexOf("\n");
+    if (lastNl > 0) bestDiff = rawSlice.slice(0, lastNl) + DIFF_SENTINEL;
+  }
+  body = render(bestDiff);
+  // Defensive: if the framing alone (with empty diff + sentinel) still
+  // overflowed (e.g. reason clip somehow failed), hard-cut the rendered
+  // body and append a plain-text marker. Should be unreachable.
+  if (body.length > TELEGRAM_SENDMESSAGE_LIMIT) {
+    body = body.slice(0, TELEGRAM_SENDMESSAGE_LIMIT - 1);
+  }
+  return body;
 }
 
 /**
@@ -167,23 +243,22 @@ export async function handleRequestConfigApproval(
     return;
   }
 
-  // Pre-flight oversize check (#1762). Telegram caps sendMessage at
-  // 4096 chars; rendered HTML adds escaping + framing so we threshold
-  // the raw diff conservatively. When oversize, we truncate the diff
-  // in the card body and ship the full diff as a `.patch` attachment.
-  const fullBody = buildConfigApprovalCardBody({
+  // Pre-flight oversize handling (#1762). Telegram caps sendMessage
+  // at 4096 chars and we render with parse_mode=HTML, so the limit
+  // applies to the rendered (escaped) body — worst-case `&` → `&amp;`
+  // inflates 5x. Fast-path with a cheap raw-input cap, then let
+  // buildConfigApprovalCardBody enforce the post-escape rendered cap
+  // (which re-truncates the diff if escaping blew past the limit). We
+  // ship the full diff as a `.patch` attachment whenever truncation
+  // happens in either layer.
+  const prelim = truncateDiffForCard(msg.unifiedDiff);
+  const body = buildConfigApprovalCardBody({
     agentName: msg.agentName,
     reason: msg.reason,
-    unifiedDiff: msg.unifiedDiff,
+    unifiedDiff: prelim,
   });
-  const oversize = fullBody.length > 3500;
-  const body = oversize
-    ? buildConfigApprovalCardBody({
-        agentName: msg.agentName,
-        reason: msg.reason,
-        unifiedDiff: truncateDiffForCard(msg.unifiedDiff),
-      })
-    : fullBody;
+  const oversize =
+    prelim !== msg.unifiedDiff || body.includes("diff continues, see attached file");
   const replyMarkup = deps.buildKeyboard(msg.requestId);
 
   const posted = await deps.postCard({
@@ -314,10 +389,6 @@ export async function handleRequestConfigFinalize(
       `config finalize card edit failed (requestId=${msg.requestId}): ${(err as Error).message}`,
     );
   }
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 /**

--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -50,6 +50,18 @@ export interface ConfigApprovalHandlerDeps {
     messageId: number;
     text: string;
   }) => Promise<void>;
+  /**
+   * Send the full diff as a `.patch` document attachment when the
+   * card body exceeds Telegram's 4096-char sendMessage limit
+   * (#1762). Best-effort — failures are logged and do NOT block the
+   * approval flow (the truncated card is still actionable).
+   */
+  postAttachment?: (args: {
+    chatId: number | string;
+    threadId?: number;
+    filename: string;
+    content: string;
+  }) => Promise<void>;
   log?: (msg: string) => void;
 }
 
@@ -59,6 +71,40 @@ export interface ConfigApprovalHandlerDeps {
  * diffs may be truncated by the API; the validator already caps
  * unified_diff at ~63 KiB so practical fleet edits fit comfortably.
  */
+/**
+ * Truncate a unified diff for inline display in the card body when
+ * the full diff would exceed Telegram's 4096-char sendMessage limit.
+ * Caps at `maxLines` lines AND at `maxChars` characters (whichever
+ * trips first), then appends a sentinel pointing to the attached
+ * `.patch` document. (#1762)
+ *
+ * The char cap is the load-bearing one — long single lines can still
+ * overflow a 50-line slice. We leave ~600 chars of headroom under the
+ * 4096 cap for the framing (header lines, `<pre>` tags, HTML escapes).
+ */
+export function truncateDiffForCard(
+  unifiedDiff: string,
+  maxLines = 50,
+  maxChars = 3000,
+): string {
+  const sentinel = "\n[… diff continues, see attached file]";
+  const lines = unifiedDiff.split("\n");
+  let out: string;
+  if (lines.length <= maxLines) {
+    out = unifiedDiff;
+  } else {
+    out = lines.slice(0, maxLines).join("\n");
+  }
+  if (out.length > maxChars) {
+    // Snap to the last complete line within the cap, falling back to
+    // a hard char cut if a single line exceeds maxChars.
+    const cap = out.slice(0, maxChars);
+    const lastNl = cap.lastIndexOf("\n");
+    out = lastNl > 0 ? cap.slice(0, lastNl) : cap;
+  }
+  return out === unifiedDiff ? out : out + sentinel;
+}
+
 export function buildConfigApprovalCardBody(args: {
   agentName: string;
   reason: string;
@@ -85,6 +131,7 @@ export async function handleRequestConfigApproval(
   const reply = (
     verdict: "approve" | "deny" | "timeout",
     reason?: string,
+    denySource?: "operator" | "dispatch_failure",
   ) => {
     try {
       client.send({
@@ -92,6 +139,7 @@ export async function handleRequestConfigApproval(
         requestId: msg.requestId,
         verdict,
         ...(reason ? { reason } : {}),
+        ...(denySource ? { denySource } : {}),
       });
     } catch (err) {
       deps.log?.(
@@ -101,21 +149,41 @@ export async function handleRequestConfigApproval(
   };
 
   if (msg.agentName !== deps.agentName) {
-    reply("deny", `gateway serves '${deps.agentName}', not '${msg.agentName}'`);
+    reply(
+      "deny",
+      `gateway serves '${deps.agentName}', not '${msg.agentName}'`,
+      "dispatch_failure",
+    );
     return;
   }
 
   const target = deps.loadTargetChat();
   if (target === null) {
-    reply("deny", "no target chat available — operator not paired?");
+    reply(
+      "deny",
+      "no target chat available — operator not paired?",
+      "dispatch_failure",
+    );
     return;
   }
 
-  const body = buildConfigApprovalCardBody({
+  // Pre-flight oversize check (#1762). Telegram caps sendMessage at
+  // 4096 chars; rendered HTML adds escaping + framing so we threshold
+  // the raw diff conservatively. When oversize, we truncate the diff
+  // in the card body and ship the full diff as a `.patch` attachment.
+  const fullBody = buildConfigApprovalCardBody({
     agentName: msg.agentName,
     reason: msg.reason,
     unifiedDiff: msg.unifiedDiff,
   });
+  const oversize = fullBody.length > 3500;
+  const body = oversize
+    ? buildConfigApprovalCardBody({
+        agentName: msg.agentName,
+        reason: msg.reason,
+        unifiedDiff: truncateDiffForCard(msg.unifiedDiff),
+      })
+    : fullBody;
   const replyMarkup = deps.buildKeyboard(msg.requestId);
 
   const posted = await deps.postCard({
@@ -125,8 +193,11 @@ export async function handleRequestConfigApproval(
     replyMarkup,
   });
   if (posted === null) {
-    reply("deny", "Telegram sendMessage failed");
+    reply("deny", "Telegram sendMessage failed", "dispatch_failure");
     return;
+  }
+  if (oversize) {
+    await maybePostAttachment(deps, target, msg);
   }
 
   const entry: PendingConfigApproval = {
@@ -247,6 +318,36 @@ export async function handleRequestConfigFinalize(
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * Best-effort attachment of the full diff as a `.patch` document.
+ * Logged-and-swallowed on failure — the truncated card body remains
+ * actionable even without the attachment. (#1762)
+ */
+async function maybePostAttachment(
+  deps: ConfigApprovalHandlerDeps,
+  target: { chatId: number | string; threadId?: number },
+  msg: RequestConfigApprovalMessage,
+): Promise<void> {
+  if (deps.postAttachment === undefined) {
+    deps.log?.(
+      `oversize config approval card but no postAttachment dep wired (requestId=${msg.requestId})`,
+    );
+    return;
+  }
+  try {
+    await deps.postAttachment({
+      chatId: target.chatId,
+      ...(target.threadId !== undefined ? { threadId: target.threadId } : {}),
+      filename: `config-edit-${msg.requestId}.patch`,
+      content: msg.unifiedDiff,
+    });
+  } catch (err) {
+    deps.log?.(
+      `config approval attachment failed (requestId=${msg.requestId}): ${(err as Error).message}`,
+    );
+  }
 }
 
 // Test-only: clear the in-memory pending map between cases.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4109,6 +4109,24 @@ const ipcServer: IpcServer = createIpcServer({
           )
         }
       },
+      // #1762: send the full diff as a `.patch` attachment when the
+      // card body would exceed Telegram's 4096-char sendMessage limit.
+      postAttachment: async (args) => {
+        const input = new InputFile(Buffer.from(args.content, 'utf8'), args.filename)
+        await robustApiCall(
+          () =>
+            bot.api.sendDocument(args.chatId, input, {
+              ...(args.threadId !== undefined
+                ? { message_thread_id: args.threadId }
+                : {}),
+            }),
+          {
+            chat_id: String(args.chatId),
+            verb: 'config-approval-attachment',
+            ...(args.threadId !== undefined ? { threadId: args.threadId } : {}),
+          },
+        )
+      },
       log: (m) =>
         process.stderr.write(`telegram gateway: config-approval — ${m}\n`),
     })

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -107,8 +107,17 @@ export interface ConfigApprovalResolvedEvent {
   /** Echoes the requestId from the originating request_config_approval. */
   requestId: string;
   verdict: "approve" | "deny" | "timeout";
-  /** Diagnostic detail when present (currently unused; reserved). */
+  /** Diagnostic detail when present. */
   reason?: string;
+  /**
+   * Distinguishes an actual operator tap-deny (`"operator"`) from a
+   * gateway-side dispatch failure that auto-denied because the card
+   * never reached the operator (`"dispatch_failure"`). Only set on
+   * `verdict: "deny"` events. Caller (hostd) maps `dispatch_failure`
+   * to a distinct error code so the failure isn't misattributed to
+   * the operator. Issue #1762.
+   */
+  denySource?: "operator" | "dispatch_failure";
 }
 
 export type GatewayToClient =


### PR DESCRIPTION
## Summary

Fixes #1762. Two bugs in the `config_propose_edit` approval path that conspired to swallow Telegram's 4096-char `sendMessage` limit as an opaque `E_DENIED: operator denied …` — even though the operator never saw a card.

- **Card body overflow** — `buildConfigApprovalCardBody` inlined the full unified diff into a single `<pre>` block. Diffs > ~4 KB 400'd at the Bot API; the handler caught the null return and auto-replied `verdict: "deny"`. Now: truncate inline to ~3000 chars with a sentinel, and ship the full diff as a `.patch` document attachment on the same card. Approve/Deny buttons preserved.
- **Discarded reason (higher leverage)** — `approval-gateway` dropped the gateway-side `reason` field and the server rendered every deny as a misleading "operator denied". Plumbed `reason` + a new `denySource: "operator" | "dispatch_failure"` discriminant through `ApprovalResult`. Server maps `dispatch_failure` denies to a distinct `E_APPROVAL_DISPATCH_FAILED` error code.

Related: #1758 — this is the same opaque-failure class the structured error envelope work is addressing.

## Files

- `telegram-plugin/gateway/config-approval-handler.ts` — pre-flight oversize check, `truncateDiffForCard`, optional `postAttachment` dep, `denySource` on dispatch-failure denies.
- `telegram-plugin/gateway/ipc-protocol.ts` — extend `ConfigApprovalResolvedEvent` with `denySource`.
- `telegram-plugin/gateway/gateway.ts` — wire `postAttachment` against `bot.api.sendDocument` for `.patch` upload.
- `src/host-control/approval-gateway.ts` — propagate `reason` + `denySource` from the wire to `ApprovalResult`; tag every internal fail-closed branch with `denySource: "dispatch_failure"`.
- `src/host-control/server.ts` — new exported `formatConfigApprovalDenyError` helper; `handleConfigProposeEdit` emits `E_APPROVAL_DISPATCH_FAILED` when `denySource === "dispatch_failure"`, otherwise `E_DENIED: … : <reason>`.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean (one pre-existing `@mtcute/node` plugin-references error baseline-on-main, unrelated to this change)
- [x] New + relevant existing tests pass (27/27 in scope):
  - [x] `config-approval-handler.test.ts`: oversize body (~16 KB diff) → card stays under 4096 chars, sentinel present, buttons preserved, `postAttachment` fires with `config-edit-<requestId>.patch` carrying the full diff; missing `postAttachment` dep → card still posts and missing-attachment is logged; `postCard` null → deny carries `denySource: "dispatch_failure"`.
  - [x] `approval-gateway.test.ts` (new): wire-level `reason` + `denySource` propagation; bare deny defaults `denySource: "operator"`; `denySource` undefined on approve; null socket path → `denySource: "dispatch_failure"`; socket close mid-request → `denySource: "dispatch_failure"`.
  - [x] `formatConfigApprovalDenyError` unit: `dispatch_failure` → `E_APPROVAL_DISPATCH_FAILED` with reason; `operator` → `E_DENIED` with reason; no-reason / no-source fallbacks.
- [ ] Operator review (Ken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)