### PR TITLE
fix(#1767): drive-write approval card oversize-body overflow

### DIFF
--- a/telegram-plugin/gateway/config-approval-handler.test.ts
+++ b/telegram-plugin/gateway/config-approval-handler.test.ts
@@ -67,7 +67,7 @@ afterEach(() => {
 
 describe("buildConfigApprovalCardBody", () => {
   it("HTML-escapes the diff body so `<` / `&` can't break out of the <pre> block", () => {
-    const body = buildConfigApprovalCardBody({
+    const { body } = buildConfigApprovalCardBody({
       agentName: "klanker",
       reason: "<script>",
       unifiedDiff: "a & b <c>",
@@ -80,7 +80,7 @@ describe("buildConfigApprovalCardBody", () => {
     // 3000 `&` chars escape to 15000 `&amp;` chars — far past 4096.
     // The post-escape cap MUST kick in and truncate the rendered body.
     const evilDiff = "&".repeat(3000);
-    const body = buildConfigApprovalCardBody({
+    const { body } = buildConfigApprovalCardBody({
       agentName: "klanker",
       reason: "test",
       unifiedDiff: evilDiff,
@@ -91,7 +91,7 @@ describe("buildConfigApprovalCardBody", () => {
 
   it("rendered body stays under 4096 when raw diff is all `<` (5x escape)", () => {
     const evilDiff = "<".repeat(3000);
-    const body = buildConfigApprovalCardBody({
+    const { body } = buildConfigApprovalCardBody({
       agentName: "klanker",
       reason: "test",
       unifiedDiff: evilDiff,
@@ -102,7 +102,7 @@ describe("buildConfigApprovalCardBody", () => {
 
   it("clips an unbounded operator-supplied `reason` to ~500 chars with ellipsis", () => {
     const longReason = "x".repeat(2000);
-    const body = buildConfigApprovalCardBody({
+    const { body } = buildConfigApprovalCardBody({
       agentName: "klanker",
       reason: longReason,
       unifiedDiff: "small",
@@ -116,10 +116,50 @@ describe("buildConfigApprovalCardBody", () => {
     expect(reasonLine.endsWith("…")).toBe(true);
   });
 
+  it("returns truncated:false when the rendered body fits without trimming", () => {
+    const { body, truncated } = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: "small",
+      unifiedDiff: "-a\n+b\n",
+    });
+    expect(truncated).toBe(false);
+    expect(body).toContain("<pre>-a\n+b\n</pre>");
+  });
+
+  it("returns truncated:true and appends the sentinel when the body has to shrink", () => {
+    const { body, truncated } = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: "test",
+      unifiedDiff: "&".repeat(3000),
+    });
+    expect(truncated).toBe(true);
+    expect(body).toContain("diff continues, see attached file");
+  });
+
+  it("handles a single unbroken line (no `\\n` to snap to) by char-truncation fallback", () => {
+    // 8000 `x` chars on a single line. After HTML escape (no inflation
+    // for `x`) the diff body alone is 8000 chars + framing — way past
+    // the cap. There's no newline to snap to, so the helper must fall
+    // through to char-truncation rather than returning empty.
+    const oneLongLine = "x".repeat(8000);
+    const { body, truncated } = buildConfigApprovalCardBody({
+      agentName: "klanker",
+      reason: "test",
+      unifiedDiff: oneLongLine,
+    });
+    expect(truncated).toBe(true);
+    expect(body.length).toBeLessThanOrEqual(4096);
+    // Should still contain SOME of the line content — the helper
+    // shouldn't degenerate to "framing + sentinel only" when char-
+    // truncation is available.
+    expect(body).toMatch(/x{100,}/);
+    expect(body).toContain("diff continues, see attached file");
+  });
+
   it("rendered body stays under 4096 even when reason is also adversarial", () => {
     const evilDiff = "&".repeat(3000);
     const evilReason = "&".repeat(2000);
-    const body = buildConfigApprovalCardBody({
+    const { body } = buildConfigApprovalCardBody({
       agentName: "klanker",
       reason: evilReason,
       unifiedDiff: evilDiff,

--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -7,6 +7,7 @@ import type {
   RequestConfigApprovalMessage,
   RequestConfigFinalizeMessage,
 } from "./ipc-protocol.js";
+import { truncateRawToFit } from "./oversize-card-body.js";
 
 /** Pending approval state — in-memory only (no SQLite per RFC §3.4). */
 interface PendingConfigApproval {
@@ -119,7 +120,14 @@ const RENDERED_BODY_CAP = 3900;
 /** Operator-supplied `reason` is unbounded at the wire — clip it. */
 const REASON_MAX_CHARS = 500;
 const REASON_ELLIPSIS = "…";
-const DIFF_SENTINEL = "\n[… diff continues, see attached file]";
+/**
+ * Sentinel appended to a truncated diff in the inline card body when
+ * the full diff ships separately as a `.patch` attachment. Exported
+ * so the dispatcher can key oversize detection off the
+ * `{truncated}` flag returned by `buildConfigApprovalCardBody`
+ * instead of substring-matching this string.
+ */
+export const DIFF_SENTINEL = "\n[… diff continues, see attached file]";
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -150,7 +158,7 @@ export function buildConfigApprovalCardBody(args: {
   agentName: string;
   reason: string;
   unifiedDiff: string;
-}): string {
+}): { body: string; truncated: boolean } {
   const safeReason = clipReason(args.reason);
   const render = (diff: string): string =>
     `🛠 <b>Config edit proposed</b>\n` +
@@ -158,42 +166,13 @@ export function buildConfigApprovalCardBody(args: {
     `Reason: ${escapeHtml(safeReason)}\n\n` +
     `<pre>${escapeHtml(diff)}</pre>`;
 
-  let body = render(args.unifiedDiff);
-  if (body.length <= RENDERED_BODY_CAP) return body;
-
-  // Rendered body too big — escaping inflated the diff past our cap.
-  // Binary-search the raw-diff slice that fits, snapping to a line
-  // boundary where possible and appending the truncation sentinel.
-  let lo = 0;
-  let hi = args.unifiedDiff.length;
-  let bestDiff = "";
-  while (lo <= hi) {
-    const mid = (lo + hi) >>> 1;
-    const slice = args.unifiedDiff.slice(0, mid);
-    const candidate = slice + DIFF_SENTINEL;
-    if (render(candidate).length <= RENDERED_BODY_CAP) {
-      bestDiff = candidate;
-      lo = mid + 1;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  // Snap to last newline so we don't cut mid-line. The sentinel is
-  // suffixed AFTER the snap so the trailing line stays intact.
-  const rawCap = bestDiff.length - DIFF_SENTINEL.length;
-  if (rawCap > 0) {
-    const rawSlice = args.unifiedDiff.slice(0, rawCap);
-    const lastNl = rawSlice.lastIndexOf("\n");
-    if (lastNl > 0) bestDiff = rawSlice.slice(0, lastNl) + DIFF_SENTINEL;
-  }
-  body = render(bestDiff);
-  // Defensive: if the framing alone (with empty diff + sentinel) still
-  // overflowed (e.g. reason clip somehow failed), hard-cut the rendered
-  // body and append a plain-text marker. Should be unreachable.
-  if (body.length > TELEGRAM_SENDMESSAGE_LIMIT) {
-    body = body.slice(0, TELEGRAM_SENDMESSAGE_LIMIT - 1);
-  }
-  return body;
+  return truncateRawToFit({
+    raw: args.unifiedDiff,
+    render,
+    cap: RENDERED_BODY_CAP,
+    sentinel: DIFF_SENTINEL,
+    hardLimit: TELEGRAM_SENDMESSAGE_LIMIT,
+  });
 }
 
 /**
@@ -252,13 +231,17 @@ export async function handleRequestConfigApproval(
   // ship the full diff as a `.patch` attachment whenever truncation
   // happens in either layer.
   const prelim = truncateDiffForCard(msg.unifiedDiff);
-  const body = buildConfigApprovalCardBody({
+  const built = buildConfigApprovalCardBody({
     agentName: msg.agentName,
     reason: msg.reason,
     unifiedDiff: prelim,
   });
-  const oversize =
-    prelim !== msg.unifiedDiff || body.includes("diff continues, see attached file");
+  const body = built.body;
+  // Oversize iff EITHER the cheap raw fast-path trimmed lines OR the
+  // post-escape rendered cap had to re-truncate. Keyed off the
+  // builder's structured `truncated` flag instead of substring-
+  // matching the sentinel string (#1767 nit).
+  const oversize = prelim !== msg.unifiedDiff || built.truncated;
   const replyMarkup = deps.buildKeyboard(msg.requestId);
 
   const posted = await deps.postCard({

--- a/telegram-plugin/gateway/drive-write-approval.test.ts
+++ b/telegram-plugin/gateway/drive-write-approval.test.ts
@@ -280,6 +280,76 @@ describe("handleRequestDriveApproval — TTL clamping", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────
+// Oversize-body fit (#1767)
+// ────────────────────────────────────────────────────────────────────────
+
+describe("handleRequestDriveApproval — oversize card body fit (#1767)", () => {
+  it("truncates the rendered text under 4096 chars before posting", async () => {
+    const spy = makeSpy();
+    // buildCard returns a body well past Telegram's 4096-char limit
+    // (simulates a docTitle / anchor / summary whose HTML-escape
+    // inflated past the limit). Handler must shrink it before postCard.
+    const giantText =
+      "<b>Title</b>\n" +
+      Array.from({ length: 200 }, (_, i) => `line-${i}-${"x".repeat(40)}`).join(
+        "\n",
+      );
+    expect(giantText.length).toBeGreaterThan(4096);
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({
+        spy,
+        buildCard: () => ({ text: giantText, reply_markup: { stub: true } }),
+      }),
+    );
+    expect(spy.posted).toHaveLength(1);
+    expect(spy.posted[0]!.text.length).toBeLessThanOrEqual(4096);
+    expect(spy.posted[0]!.text).toContain("preview truncated");
+    // Card was successfully posted → ok:true response went back.
+    expect(spy.sent[0]?.ok).toBe(true);
+    // The log line surfaces the truncation event.
+    expect(
+      spy.logs.some((l) => l.includes("oversize-truncated")),
+    ).toBe(true);
+  });
+
+  it("does not touch the body when it already fits", async () => {
+    const spy = makeSpy();
+    const small = "<b>Small</b>\nline 1\nline 2";
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({
+        spy,
+        buildCard: () => ({ text: small, reply_markup: { stub: true } }),
+      }),
+    );
+    expect(spy.posted[0]!.text).toBe(small);
+    expect(
+      spy.logs.some((l) => l.includes("oversize-truncated")),
+    ).toBe(false);
+  });
+
+  it("post failure after truncation surfaces a structured reason", async () => {
+    const spy = makeSpy();
+    const giantText =
+      "<b>Title</b>\n" + "x".repeat(8000);
+    await handleRequestDriveApproval(
+      clientFor(spy),
+      msgFor(),
+      deps({
+        spy,
+        buildCard: () => ({ text: giantText, reply_markup: { stub: true } }),
+        postCard: async () => null,
+      }),
+    );
+    expect(spy.sent[0]?.ok).toBe(false);
+    expect(spy.sent[0]?.reason).toMatch(/oversize-body truncation/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
 // Always responds (no path drops the response)
 // ────────────────────────────────────────────────────────────────────────
 

--- a/telegram-plugin/gateway/drive-write-approval.ts
+++ b/telegram-plugin/gateway/drive-write-approval.ts
@@ -30,6 +30,7 @@ import type {
   DriveApprovalPostedEvent,
   RequestDriveApprovalMessage,
 } from "./ipc-protocol.js";
+import { truncateRawToFit } from "./oversize-card-body.js";
 
 // ────────────────────────────────────────────────────────────────────────
 // Injected deps — caller (gateway.ts) wires these from the existing
@@ -99,6 +100,18 @@ export interface DriveApprovalHandlerDeps {
 const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const MIN_TTL_MS = 30 * 1000; // 30 seconds
+
+/**
+ * Telegram `sendMessage` hard limit. `buildDiffPreviewCard` HTML-
+ * escapes the docTitle + every body line with no upstream length
+ * cap, so an adversarial or just-unusually-long docTitle / anchor
+ * displayName / agent-supplied summary can render past 4096 once
+ * `&` / `<` / `>` inflate up to 5x. We rebuild a truncated body
+ * keyed off the wrapper-attested fields when that happens. (#1767)
+ */
+const TELEGRAM_SENDMESSAGE_LIMIT = 4096;
+const RENDERED_BODY_CAP = 3900;
+const OVERSIZE_SENTINEL = "\n[… preview truncated; open in Drive for full context]";
 
 /**
  * Top-level handler called by ipc-server's onRequestDriveApproval.
@@ -204,19 +217,55 @@ export async function handleRequestDriveApproval(
     });
     return;
   }
+  // Oversize guard (#1767). buildDiffPreviewCard renders title +
+  // every body line HTML-escaped with no length cap. Worst-case `&`
+  // / `<` / `>` inflate 5x — a long docTitle or anchor displayName
+  // pushes past Telegram's 4096-char sendMessage limit and the API
+  // returns a generic 400 that surfaces as a silent E_DENIED. Cap
+  // the rendered body BEFORE posting.
+  let cardText = card.text;
+  let truncatedForFit = false;
+  if (cardText.length > RENDERED_BODY_CAP) {
+    const fit = truncateRawToFit({
+      raw: card.text,
+      // The "raw" here is the already-escaped card text — we don't
+      // have access to pre-escape source at this layer because
+      // buildDiffPreviewCard owns escaping. Line-snap is the safe
+      // granularity: HTML entities like `&amp;` never span `\n`, so
+      // truncating at a newline boundary can't bisect an entity.
+      // The defensive single-long-line fallback may char-cut into an
+      // entity, but the drive-preview lines are short (anchor name,
+      // metrics, capped 200-char summary) so this is unreachable
+      // unless a multi-KB docTitle slipped through Drive itself.
+      render: (slice) => slice,
+      cap: RENDERED_BODY_CAP,
+      sentinel: OVERSIZE_SENTINEL,
+      hardLimit: TELEGRAM_SENDMESSAGE_LIMIT,
+    });
+    cardText = fit.body;
+    truncatedForFit = fit.truncated;
+  }
+
   const posted = await deps.postCard({
     chatId: target.chatId,
     ...(target.threadId !== undefined ? { threadId: target.threadId } : {}),
-    text: card.text,
+    text: cardText,
     replyMarkup: card.reply_markup,
   });
   if (posted === null) {
     reply({
       correlationId: msg.correlationId,
       ok: false,
-      reason: "Telegram sendMessage failed",
+      reason: truncatedForFit
+        ? "Telegram sendMessage failed even after oversize-body truncation"
+        : "Telegram sendMessage failed",
     });
     return;
+  }
+  if (truncatedForFit) {
+    deps.log?.(
+      `drive_approval_posted oversize-truncated correlation=${msg.correlationId} original_len=${card.text.length} rendered_len=${cardText.length}`,
+    );
   }
 
   deps.log?.(

--- a/telegram-plugin/gateway/oversize-card-body.test.ts
+++ b/telegram-plugin/gateway/oversize-card-body.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the shared truncateRawToFit helper (#1767).
+ *
+ * Covers:
+ *   - No-op when the rendered body already fits.
+ *   - Binary-search shrinks the raw slice; result fits under `cap`.
+ *   - Line-snap when newlines exist; sentinel appended.
+ *   - Char-truncation fallback when a single unbroken line exceeds
+ *     the budget (no `\n` to snap to).
+ *   - Defensive hard-cut when even the framing-alone overflows.
+ */
+
+import { describe, it, expect } from "vitest";
+import { truncateRawToFit } from "./oversize-card-body.js";
+
+const SENTINEL = "\n[… truncated]";
+
+function frame(escapeMultiplier: number) {
+  // Render closure that mimics a `<pre>`-wrapped HTML-escaped body
+  // where every `&` inflates `escapeMultiplier`-fold.
+  return (raw: string) => {
+    const inflated = raw.replace(/&/g, "&".repeat(escapeMultiplier));
+    return `<b>Hdr</b>\n<pre>${inflated}</pre>`;
+  };
+}
+
+describe("truncateRawToFit", () => {
+  it("returns the full body unchanged when it fits under cap", () => {
+    const raw = "small content";
+    const { body, truncated } = truncateRawToFit({
+      raw,
+      render: (s) => `<pre>${s}</pre>`,
+      cap: 100,
+      sentinel: SENTINEL,
+    });
+    expect(truncated).toBe(false);
+    expect(body).toBe("<pre>small content</pre>");
+  });
+
+  it("shrinks raw via binary-search until the rendered body fits the cap (5x escape inflation)", () => {
+    const raw = "&".repeat(2000); // 2000 chars raw, 10000 after 5x inflate
+    const { body, truncated } = truncateRawToFit({
+      raw,
+      render: frame(5),
+      cap: 1000,
+      sentinel: SENTINEL,
+    });
+    expect(truncated).toBe(true);
+    expect(body.length).toBeLessThanOrEqual(1000);
+    expect(body).toContain("truncated");
+  });
+
+  it("snaps to the last newline within the chosen raw prefix (no mid-line cut)", () => {
+    const raw = ["line-a", "line-b", "line-c", "line-d", "line-e"]
+      .map((l) => l.repeat(50))
+      .join("\n");
+    const { body, truncated } = truncateRawToFit({
+      raw,
+      render: (s) => `<pre>${s}</pre>`,
+      cap: 600,
+      sentinel: SENTINEL,
+    });
+    expect(truncated).toBe(true);
+    // The portion before the sentinel must end at a complete line —
+    // no partial `line-?` suffix mid-word.
+    const beforeSentinel = body.slice(
+      0,
+      body.length - SENTINEL.length - "</pre>".length,
+    );
+    // Every line in the source repeated its label 50x — assert the
+    // tail of the kept content ends with a full repeated block, not
+    // a chopped one. Easiest check: the body must not end mid-word
+    // like `line-` (the dash followed by no letter).
+    expect(beforeSentinel).not.toMatch(/line-$/);
+  });
+
+  it("falls through to char-truncation when a single unbroken line exceeds cap", () => {
+    const raw = "x".repeat(5000); // no newlines at all
+    const { body, truncated } = truncateRawToFit({
+      raw,
+      render: (s) => `<pre>${s}</pre>`,
+      cap: 500,
+      sentinel: SENTINEL,
+    });
+    expect(truncated).toBe(true);
+    expect(body.length).toBeLessThanOrEqual(500);
+    // Some of the line content survives — the helper shouldn't
+    // collapse to "<pre>" + sentinel only.
+    expect(body).toMatch(/x{100,}/);
+    expect(body).toContain("truncated");
+  });
+
+  it("hard-cuts at hardLimit when framing alone overflows (defensive)", () => {
+    // Framing-alone is 5000 chars (way past cap), and the renderer
+    // ignores its input — so no slice of raw can ever fit. The
+    // helper should hard-cut to hardLimit rather than loop forever.
+    const huge = "Z".repeat(5000);
+    const { body, truncated } = truncateRawToFit({
+      raw: "ignored",
+      render: () => huge,
+      cap: 1000,
+      sentinel: SENTINEL,
+      hardLimit: 1100,
+    });
+    expect(truncated).toBe(true);
+    expect(body.length).toBeLessThanOrEqual(1100);
+  });
+});

--- a/telegram-plugin/gateway/oversize-card-body.ts
+++ b/telegram-plugin/gateway/oversize-card-body.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared "render-and-fit" helper for approval cards that wrap
+ * user-supplied content in HTML framing. (#1762 / #1767)
+ *
+ * Telegram's `sendMessage` caps the body at 4096 chars and we render
+ * with `parse_mode=HTML`. Worst-case escape inflates raw content up
+ * to 5x (`&` → `&amp;`), so a naive raw-input cap is unsafe — the
+ * post-escape body can blow past the limit and `sendMessage` then
+ * returns a generic 400 that surfaces upstream as a silent
+ * `E_DENIED`.
+ *
+ * This helper binary-searches the largest prefix of the RAW content
+ * whose rendered body still fits under `cap`, snaps to the last
+ * newline so we don't cut mid-line (and never cut mid-entity like
+ * `&am|p;` — raw doesn't contain entities yet), and appends a
+ * sentinel pointing at the attached full content (if any).
+ *
+ * Callers own the framing: pass a `render(slice)` closure that
+ * embeds the slice in whatever escaped envelope they want, and the
+ * helper guarantees the returned `body` fits.
+ *
+ * Both `config-approval-handler.ts` (config-edit diffs) and
+ * `drive-write-approval.ts` (Drive write preview cards) use this.
+ */
+
+export interface TruncateRawToFitInput {
+  /** Raw, un-escaped content to slice. */
+  raw: string;
+  /**
+   * Build the full rendered card body from a (possibly truncated)
+   * raw slice. The closure owns HTML escaping + all framing. Called
+   * O(log n) times during the binary search; keep it cheap.
+   */
+  render: (rawSlice: string) => string;
+  /**
+   * Maximum rendered length (chars). Should be set below Telegram's
+   * 4096 hard limit to leave margin for invisible framing wobble.
+   */
+  cap: number;
+  /**
+   * Marker appended to the truncated slice before re-rendering — e.g.
+   * `"\n[… diff continues, see attached file]"`. The render closure
+   * receives `rawSlice + sentinel` so the marker is visible inside
+   * the same envelope (code block etc.).
+   */
+  sentinel: string;
+  /** Absolute hard cap for the defensive last-resort raw cut. Default `cap + 196`. */
+  hardLimit?: number;
+}
+
+export interface TruncateRawToFitResult {
+  /** Rendered body, guaranteed to fit within `cap` (best-effort) or `hardLimit` (defensive). */
+  body: string;
+  /** True iff the helper had to truncate (raw was sliced or hard-cut). */
+  truncated: boolean;
+}
+
+/**
+ * Try the full content first; if it fits, return as-is. Otherwise
+ * binary-search the largest raw prefix whose rendered body fits,
+ * snap to the last newline boundary, append the sentinel, re-render
+ * and return.
+ *
+ * Defensive last resort: if even the empty-slice + sentinel render
+ * overflows (means the framing alone exceeds `cap` — caller bug or
+ * adversarial reason field that slipped past clipping), we hard-cut
+ * the rendered body to `hardLimit` chars. Should be unreachable in
+ * production but cheaper than crashing.
+ */
+export function truncateRawToFit(
+  input: TruncateRawToFitInput,
+): TruncateRawToFitResult {
+  const { raw, render, cap, sentinel } = input;
+  const hardLimit = input.hardLimit ?? cap + 196;
+
+  const fullBody = render(raw);
+  if (fullBody.length <= cap) {
+    return { body: fullBody, truncated: false };
+  }
+
+  // Binary-search the largest raw prefix length whose rendered body
+  // fits (with sentinel suffixed before render). We track the best
+  // slice rather than just the length so we can snap after the loop.
+  let lo = 0;
+  let hi = raw.length;
+  let bestSliceLen = 0;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const candidate = raw.slice(0, mid) + sentinel;
+    if (render(candidate).length <= cap) {
+      bestSliceLen = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  // Snap to the last newline within the chosen raw prefix so we
+  // never cut a line in half. If a single unbroken line exceeds
+  // the budget, fall through with the char-truncated slice — the
+  // caller's framing (e.g. `<pre>`) handles the visual gracefully.
+  let chosenRaw = raw.slice(0, bestSliceLen);
+  const lastNl = chosenRaw.lastIndexOf("\n");
+  if (lastNl > 0) chosenRaw = chosenRaw.slice(0, lastNl);
+
+  let body = render(chosenRaw + sentinel);
+
+  // Defensive: framing-alone overflow. Hard-cut to hardLimit so the
+  // outbound sendMessage at least has a chance of succeeding.
+  if (body.length > hardLimit) {
+    body = body.slice(0, hardLimit - 1);
+  }
+  return { body, truncated: true };
+}


### PR DESCRIPTION
## Summary

Follow-up to #1766. Drive-write approval cards had the same latent overflow pattern that bit `config_propose_edit` in #1762: `buildDiffPreviewCard` HTML-escapes `docTitle` + every body line with no upstream length cap, so a long Drive doc title, anchor `displayName`, or agent-supplied summary can render past Telegram's 4096-char `sendMessage` limit once `&` / `<` / `>` inflate up to 5x. Telegram then returns a generic 400 that surfaces as a silent `E_DENIED` from the agent's perspective.

- Extract the rendered-body cap + line-snap binary-search helper into a new shared module `telegram-plugin/gateway/oversize-card-body.ts` exposing `truncateRawToFit({raw, render, cap, sentinel, hardLimit?})`.
- `config-approval-handler.ts` now uses the helper; `buildConfigApprovalCardBody` returns `{body, truncated}` and the dispatcher keys oversize detection off the boolean instead of substring-matching the sentinel.
- `drive-write-approval.ts` runs `card.text` through the helper between `buildCard` and `postCard`; on truncation, logs the event. If `postCard` still fails after shrinking, surfaces a structured deny reason (`"Telegram sendMessage failed even after oversize-body truncation"`).
- Rolls in the three #1766 review nits while in the file: exported `DIFF_SENTINEL` constant; removed the unreachable `bestDiff=""` edge case (helper guards it); added a test for a single unbroken line exceeding the cap (no `\n` to snap to) to lock in the char-truncation fallback.

Closes #1767.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run telegram-plugin/gateway/{config-approval-handler,drive-write-approval,oversize-card-body,diff-preview-card}.test.ts` — 56/56 pass
- [x] New shared-helper tests cover no-op-when-fits, binary-search-shrink (5x inflate), line-snap (no mid-line cut), char-truncation fallback (single long line), defensive hard-cut (framing-alone overflow)
- [x] New drive-write oversize tests cover truncation-before-post, no-op-when-fits, structured-deny-reason on post-failure-after-truncation
- [x] All pre-existing config-approval / drive-write / diff-preview-card tests still pass against the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)