### PR TITLE
feat: phase 2 of structured error envelope (#1761)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## Unreleased
+
+### feat(#1761): error envelope Phase 2 — batch migration + denied-vs-error classification + negative-path tests
+
+Follow-ups on the Phase 1 wire protocol (#1759). Five tightenings:
+
+1. **Negative-path schema tests for `ErrorFixSchema` / `ErrorEnvelopeSchema`.**
+   Phase 1 only pinned the happy path. Phase 2 adds `safeParse` rejections
+   for: unknown `fix.kind`, missing required field per kind, non-URL
+   `docs`, malformed `code` (`e_lowercase`, bare `FOO`). The discriminator
+   is the integrity boundary for the unlock-card path — every silently-
+   accepted garbage shape becomes a load-bearing allowlist bypass on the
+   gateway side.
+
+2. **`err().docs(URL)` now throws `TypeError` at author-time** on a
+   non-URL string, matching `ErrorEnvelopeSchema`'s `z.string().url()`
+   receiver-side check. A new call site can no longer ship an envelope
+   that fails its own schema.
+
+3. **`E_CONFIG_EDIT_DISABLED` returns `result: "denied"`** instead of
+   `"error"` — it's a policy denial (feature flag off), not a server
+   fault. `asDenied()` swept across the other policy-denial codes
+   migrated in this PR (`E_DENIED`, `E_APPROVAL_TIMEOUT`).
+
+4. **Batch-migrated every remaining `errorResponse()` call site** in
+   `src/host-control/server.ts` to the `err()` builder with the
+   appropriate `fix` envelope:
+   - validation rejections (`E_PATCH_APPLY_FAILED` etc.) → `fix: bad_input`
+   - `E_NO_APPROVAL_GATEWAY` → `fix: operator_action` (infra)
+   - operator tap-deny `E_DENIED` → `fix: operator_action` (policy_denied), `result: "denied"`
+   - dispatch-failure `E_APPROVAL_DISPATCH_FAILED` → `fix: operator_action` (infra), `result: "error"`
+   - `E_APPROVAL_TIMEOUT` → `fix: operator_action` (policy_denied), `result: "denied"`
+   - rollback-path `E_RECONCILE_FAILED_ROLLED_BACK` → `fix: operator_action` (infra)
+   - top-level dispatch catch → `E_DISPATCH_FAILED` (no fix, internal)
+   - `get_status` invariant violation → `E_INTERNAL` (no fix)
+
+   Legacy `error: string` is preserved verbatim at every migrated site
+   so existing string-matching decoders (audit reader, telegram-plugin
+   gateway response handler, broker client) see no semantic regression.
+
+5. **MCP hostd surface — `content` length goes 1 → 2 on errors.** When
+   `error_envelope` is present, the MCP hostd tool response now appends
+   a second `content` text item carrying the envelope JSON (with a
+   leading `Structured error — fix.kind=…` discriminator hint). Tooling
+   that string-matches `content[0].text` is still safe; tooling that
+   parses the structured form should branch on `content.length === 2`.
+
 ## v0.13.35 — gateway crash-banner noise, error envelope, timezone hook
 
 Three reliability/UX fixes landed since v0.13.34.

--- a/src/host-control/error-builder.test.ts
+++ b/src/host-control/error-builder.test.ts
@@ -130,6 +130,22 @@ describe("error-builder — wire shape", () => {
     expect(props.has_docs).toBe(true);
   });
 
+  it("docs() throws at author-time on a non-URL (#1761)", () => {
+    expect(() => err("E_FOO", "bar").docs("not-a-url")).toThrow(TypeError);
+    expect(() => err("E_FOO", "bar").docs("/relative/path")).toThrow(TypeError);
+    // sanity: a real URL passes
+    expect(() =>
+      err("E_FOO", "bar").docs("https://switchroom.dev/docs/foo"),
+    ).not.toThrow();
+  });
+
+  it("asDenied() flips result from 'error' to 'denied' (#1761)", () => {
+    const resp = err("E_CONFIG_EDIT_DISABLED", "off")
+      .asDenied()
+      .build("r", 0);
+    expect(resp.result).toBe("denied");
+  });
+
   it("operator_steps content stays out of PostHog", () => {
     err("E_FOO", "human")
       .fixOperatorAction("policy_denied", ["PII-STEP-1", "PII-STEP-2"])

--- a/src/host-control/error-builder.ts
+++ b/src/host-control/error-builder.ts
@@ -90,7 +90,25 @@ export class ErrorBuilder {
     return this;
   }
 
+  /**
+   * Set the docs URL. Validated at author-time (fail loud) so a new
+   * call site can't ship an envelope that fails its own
+   * `ErrorEnvelopeSchema` (which enforces `z.string().url()`).
+   * Throws `TypeError` on a non-URL string — matches how the rest of
+   * the codebase treats author-mistake categories (e.g. zod schemas
+   * elsewhere parse-throw rather than silently coerce). Issue #1761.
+   */
   docs(url: string): this {
+    try {
+      // node's URL constructor is stricter than a regex and matches
+      // zod's `.url()` behavior. Author-time throw beats a runtime
+      // schema parse-failure at the receiver.
+      new URL(url);
+    } catch {
+      throw new TypeError(
+        `err().docs(): invalid URL: ${JSON.stringify(url)} — ErrorEnvelopeSchema requires a fully-qualified URL`,
+      );
+    }
     this._docs = url;
     return this;
   }

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -41,7 +41,6 @@ import {
   decodeRequest,
   encodeResponse,
   deniedResponse,
-  errorResponse,
   IDEMPOTENCY_WINDOW_MS,
   MAX_FRAME_BYTES,
   type HostdRequest,
@@ -661,12 +660,23 @@ export class HostdServer {
           resp = await this.handleConfigProposeEdit(req, caller, started);
           break;
       }
-    } catch (err) {
-      resp = errorResponse(
-        req.request_id,
-        `hostd dispatch failed: ${(err as Error).message}`,
-        Date.now() - started,
-      );
+    } catch (e) {
+      // #1761: top-level dispatch failure — no fix.kind applies
+      // (genuine server fault). Envelope still carries the code so
+      // agents can branch on `error_envelope.code` instead of regex.
+      const msg = (e as Error).message;
+      resp = err(
+        "E_DISPATCH_FAILED",
+        "hostd dispatch failed",
+      )
+        .why(msg)
+        .op(req.op)
+        .caller(caller.kind === "agent" ? "agent" : "operator")
+        .agentName(caller.kind === "agent" ? caller.name : undefined)
+        .build(req.request_id, Date.now() - started);
+      // Preserve the legacy error string for back-compat with existing
+      // string-matching decoders.
+      resp = { ...resp, error: `hostd dispatch failed: ${msg}` };
     }
     await this.writeAudit({ caller, req, resp });
     socket.write(encodeResponse(resp));
@@ -1246,6 +1256,9 @@ export class HostdServer {
   ): Promise<HostdResponse> {
     const enabled = this.opts.config.hostd?.config_edit_enabled === true;
     if (!enabled) {
+      // #1761: policy denial (feature flag off), not a server error.
+      // Flip to `denied` so callers branching on `result` see the
+      // right classification.
       return err("E_CONFIG_EDIT_DISABLED", "config_propose_edit is disabled")
         .why("operator opt-in per RFC §3.3")
         .fixFlipFlag("hostd.config_edit_enabled", true)
@@ -1253,6 +1266,7 @@ export class HostdServer {
         .op("config_propose_edit")
         .caller(caller.kind === "agent" ? "agent" : "operator")
         .agentName(caller.kind === "agent" ? caller.name : undefined)
+        .asDenied()
         .build(req.request_id, Date.now() - started);
     }
     const configPath =
@@ -1263,21 +1277,30 @@ export class HostdServer {
       unifiedDiff: req.args.unified_diff,
     });
     if (!verdict.ok) {
-      return errorResponse(
-        req.request_id,
-        `${verdict.code}: ${verdict.detail}`,
-        Date.now() - started,
-      );
+      // #1761: surface a structured envelope so the agent can render a
+      // targeted fix hint (the unified_diff is the only author-input).
+      return err(verdict.code, verdict.detail)
+        .fixBadInput("unified_diff")
+        .op("config_propose_edit")
+        .caller(caller.kind === "agent" ? "agent" : "operator")
+        .agentName(caller.kind === "agent" ? caller.name : undefined)
+        .build(req.request_id, Date.now() - started);
     }
     // ── Approval card ───────────────────────────────────────────────
     if (!this.opts.approvalGateway) {
-      return errorResponse(
-        req.request_id,
-        "E_NO_APPROVAL_GATEWAY: validation passed but hostd was " +
-          "started without an approval-gateway wiring; the operator " +
-          "build is missing the telegram-plugin link",
-        Date.now() - started,
-      );
+      // #1761: missing approval-gateway wiring is an operator/infra
+      // configuration gap — the agent cannot self-recover.
+      return err(
+        "E_NO_APPROVAL_GATEWAY",
+        "validation passed but hostd was started without an approval-gateway wiring; the operator build is missing the telegram-plugin link",
+      )
+        .fixOperatorAction("infra", [
+          "ensure hostd was launched with --approval-gateway / telegram-plugin link",
+        ])
+        .op("config_propose_edit")
+        .caller(caller.kind === "agent" ? "agent" : "operator")
+        .agentName(caller.kind === "agent" ? caller.name : undefined)
+        .build(req.request_id, Date.now() - started);
     }
     const callerName = caller.kind === "agent" ? caller.name : "operator";
     const approvalId = (this.opts.generateApprovalId ?? defaultApprovalId)();
@@ -1293,18 +1316,50 @@ export class HostdServer {
       // dispatch failure (card never reached the operator). Without
       // this, a Telegram sendMessage 400 surfaces as a misleading
       // "operator denied" — see ref #1758 structured-error work.
-      return errorResponse(
-        req.request_id,
-        formatConfigApprovalDenyError(approval, approvalId),
-        Date.now() - started,
-      );
+      // #1761: tap-deny is a POLICY DENIAL (result: "denied").
+      // Dispatch-failure is INFRA (result: "error").
+      const legacy = formatConfigApprovalDenyError(approval, approvalId);
+      const isDispatchFailure = approval.denySource === "dispatch_failure";
+      const code = isDispatchFailure
+        ? "E_APPROVAL_DISPATCH_FAILED"
+        : "E_DENIED";
+      const human = isDispatchFailure
+        ? "approval card dispatch failed before the operator could see it"
+        : "operator denied config_propose_edit";
+      const b = err(code, human)
+        .why(legacy)
+        .fixOperatorAction(
+          isDispatchFailure ? "infra" : "policy_denied",
+          isDispatchFailure
+            ? ["check telegram-plugin gateway connectivity"]
+            : undefined,
+        )
+        .op("config_propose_edit")
+        .caller(caller.kind === "agent" ? "agent" : "operator")
+        .agentName(caller.kind === "agent" ? caller.name : undefined);
+      if (!isDispatchFailure) b.asDenied();
+      const built = b.build(req.request_id, Date.now() - started);
+      // Preserve the verbatim legacy `error` string (tests + existing
+      // string-matching decoders depend on the exact format from
+      // `formatConfigApprovalDenyError`).
+      return { ...built, error: legacy };
     }
     if (approval.verdict === "timeout") {
-      return errorResponse(
-        req.request_id,
-        `E_APPROVAL_TIMEOUT: operator approval card expired without a tap (approval_id=${approvalId})`,
-        Date.now() - started,
-      );
+      // #1761: timeout is a policy-path denial (operator never acted),
+      // not a server failure.
+      const legacy = `E_APPROVAL_TIMEOUT: operator approval card expired without a tap (approval_id=${approvalId})`;
+      const built = err(
+        "E_APPROVAL_TIMEOUT",
+        "operator approval card expired without a tap",
+      )
+        .why(`approval_id=${approvalId}`)
+        .fixOperatorAction("policy_denied")
+        .op("config_propose_edit")
+        .caller(caller.kind === "agent" ? "agent" : "operator")
+        .agentName(caller.kind === "agent" ? caller.name : undefined)
+        .asDenied()
+        .build(req.request_id, Date.now() - started);
+      return { ...built, error: legacy };
     }
     // ── Apply path (mutex-serialized) ───────────────────────────────
     // Serialize concurrent config-edit applies through a single
@@ -1318,15 +1373,17 @@ export class HostdServer {
       let snapshot: string;
       try {
         snapshot = readFileSync(configPath, "utf-8");
-      } catch (err) {
+      } catch (e) {
         await approval.finalize({
           outcome: "reconcile_failed_rolled_back",
-          detail: `pre-write snapshot read failed: ${(err as Error).message}`,
+          detail: `pre-write snapshot read failed: ${(e as Error).message}`,
         });
-        return errorResponse(
-          req.request_id,
-          `E_RECONCILE_FAILED_ROLLED_BACK: snapshot read failed: ${(err as Error).message}`,
-          Date.now() - started,
+        // #1761: real infrastructure failure during rollback path.
+        return this.reconcileFailedRolledBack(
+          `snapshot read failed: ${(e as Error).message}`,
+          req,
+          caller,
+          started,
         );
       }
       const postApply = verdict.postApplyContent;
@@ -1335,18 +1392,19 @@ export class HostdServer {
       try {
         writeFileSync(tmp, postApply);
         renameSync(tmp, configPath);
-      } catch (err) {
+      } catch (e) {
         // Pre-write or rename failed — try to clean up tmp; live
         // file is untouched so no rollback needed.
         unlinkSyncBestEffort(tmp);
         await approval.finalize({
           outcome: "reconcile_failed_rolled_back",
-          detail: `atomic write failed: ${(err as Error).message}`,
+          detail: `atomic write failed: ${(e as Error).message}`,
         });
-        return errorResponse(
-          req.request_id,
-          `E_RECONCILE_FAILED_ROLLED_BACK: write failed: ${(err as Error).message}`,
-          Date.now() - started,
+        return this.reconcileFailedRolledBack(
+          `write failed: ${(e as Error).message}`,
+          req,
+          caller,
+          started,
         );
       }
       // Reconcile.
@@ -1371,16 +1429,17 @@ export class HostdServer {
       try {
         writeFileSync(tmp, snapshot);
         renameSync(tmp, configPath);
-      } catch (err) {
-        rollbackDetail = `snapshot restore failed: ${(err as Error).message}`;
+      } catch (e) {
+        rollbackDetail = `snapshot restore failed: ${(e as Error).message}`;
         await approval.finalize({
           outcome: "reconcile_failed_rolled_back",
           detail: rollbackDetail,
         });
-        return errorResponse(
-          req.request_id,
-          `E_RECONCILE_FAILED_ROLLED_BACK: ${rollbackDetail}`,
-          Date.now() - started,
+        return this.reconcileFailedRolledBack(
+          rollbackDetail,
+          req,
+          caller,
+          started,
         );
       }
       const recRes2 = await runner({ requestId: approvalId });
@@ -1392,14 +1451,45 @@ export class HostdServer {
         outcome: "reconcile_failed_rolled_back",
         detail: recoveryNote,
       });
-      return errorResponse(
-        req.request_id,
-        `E_RECONCILE_FAILED_ROLLED_BACK: reconcile exit ${recRes.exit_code}; ${recoveryNote}`,
-        Date.now() - started,
+      return this.reconcileFailedRolledBack(
+        `reconcile exit ${recRes.exit_code}; ${recoveryNote}`,
+        req,
+        caller,
+        started,
       );
     } finally {
       release();
     }
+  }
+
+  /**
+   * #1761: shared helper for the five sites that bail out of
+   * `handleConfigProposeEdit` with `E_RECONCILE_FAILED_ROLLED_BACK`.
+   * Carries a structured `operator_action`/`infra` envelope (the
+   * agent can't self-recover from a write/reconcile failure) while
+   * preserving the verbatim legacy `error` string so audit-reader /
+   * existing string-match decoders see no regression.
+   */
+  private reconcileFailedRolledBack(
+    detail: string,
+    req: Extract<HostdRequest, { op: "config_propose_edit" }>,
+    caller: SocketIdentity,
+    started: number,
+  ): HostdResponse {
+    const legacy = `E_RECONCILE_FAILED_ROLLED_BACK: ${detail}`;
+    const built = err(
+      "E_RECONCILE_FAILED_ROLLED_BACK",
+      "config write or reconcile failed; live file rolled back to snapshot",
+    )
+      .why(detail)
+      .fixOperatorAction("infra", [
+        "inspect hostd logs + switchroom apply output to identify the underlying failure",
+      ])
+      .op("config_propose_edit")
+      .caller(caller.kind === "agent" ? "agent" : "operator")
+      .agentName(caller.kind === "agent" ? caller.name : undefined)
+      .build(req.request_id, Date.now() - started);
+    return { ...built, error: legacy };
   }
 
   /** Serializes concurrent config_propose_edit apply phases. */
@@ -1683,11 +1773,12 @@ export class HostdServer {
     // checkGate already rejected unknown / cross-agent cases above.
     // If we got here `entry` must exist.
     if (!entry) {
-      return errorResponse(
-        req.request_id,
-        `get_status: internal: entry missing despite gate accept`,
-        Date.now() - started,
-      );
+      // #1761: internal invariant violation — no fix.kind applies.
+      const legacy = `get_status: internal: entry missing despite gate accept`;
+      const built = err("E_INTERNAL", "entry missing despite gate accept")
+        .op("get_status")
+        .build(req.request_id, Date.now() - started);
+      return { ...built, error: legacy };
     }
     return this.statusEntryToResponse(req.request_id, entry);
   }

--- a/tests/host-control/config-propose-edit.test.ts
+++ b/tests/host-control/config-propose-edit.test.ts
@@ -139,7 +139,8 @@ describe("hostd config_propose_edit — PR 1a gates (still live)", () => {
     server = makeServer({});
     await server.start();
     const resp = await send({ unified_diff: TINY_DIFF, request_id: "cpe-1" });
-    expect(resp.result).toBe("error");
+    // #1761: policy denial, not server error.
+    expect(resp.result).toBe("denied");
     expect(resp.error).toMatch(/^E_CONFIG_EDIT_DISABLED/);
     // #1758 Phase 1: yaml-path hint moved from legacy `error` string
     // into `error_envelope.fix.yaml_path`.
@@ -155,7 +156,8 @@ describe("hostd config_propose_edit — PR 1a gates (still live)", () => {
     server = makeServer({ configEditEnabled: false });
     await server.start();
     const resp = await send({ unified_diff: TINY_DIFF, request_id: "cpe-2" });
-    expect(resp.result).toBe("error");
+    // #1761: policy denial, not server error.
+    expect(resp.result).toBe("denied");
     expect(resp.error).toMatch(/^E_CONFIG_EDIT_DISABLED/);
   });
 
@@ -248,6 +250,14 @@ describe("hostd config_propose_edit — PR 1b stage 2 (clean apply)", () => {
     const resp = await send({ unified_diff: bad, request_id: "s2-1" });
     expect(resp.result).toBe("error");
     expect(resp.error).toMatch(/^E_PATCH_APPLY_FAILED/);
+    // #1761: validation rejections now carry a structured envelope
+    // (fix.kind: "bad_input") so the agent can render a targeted fix
+    // hint instead of regexing the legacy string.
+    expect(resp.error_envelope?.code).toBe("E_PATCH_APPLY_FAILED");
+    expect(resp.error_envelope?.fix).toEqual({
+      kind: "bad_input",
+      field: "unified_diff",
+    });
   });
 });
 
@@ -399,6 +409,9 @@ describe("hostd config_propose_edit — PR 1b happy path (no approval gateway wi
     const resp = await send({ unified_diff: good, request_id: "happy-1" });
     expect(resp.result).toBe("error");
     expect(resp.error).toMatch(/^E_NO_APPROVAL_GATEWAY/);
+    // #1761: structured envelope hints operator wiring is missing.
+    expect(resp.error_envelope?.code).toBe("E_NO_APPROVAL_GATEWAY");
+    expect(resp.error_envelope?.fix?.kind).toBe("operator_action");
   });
 });
 
@@ -465,8 +478,11 @@ describe("hostd config_propose_edit — apply path (#1623)", () => {
     await server.start();
     const before = readFile(configPath, "utf8");
     const resp = await send({ unified_diff: GOOD_DIFF, request_id: "ap-2" });
-    expect(resp.result).toBe("error");
+    // #1761: operator tap-deny is a policy denial, not server error.
+    expect(resp.result).toBe("denied");
     expect(resp.error).toMatch(/^E_DENIED/);
+    expect(resp.error_envelope?.code).toBe("E_DENIED");
+    expect(resp.error_envelope?.fix?.kind).toBe("operator_action");
     expect(finalizeCalls.length).toBe(0); // gateway already showed 'denied'
     expect(reconcileInvocations).toBe(0);
     // Live file untouched.
@@ -488,8 +504,11 @@ describe("hostd config_propose_edit — apply path (#1623)", () => {
     await server.start();
     const before = readFile(configPath, "utf8");
     const resp = await send({ unified_diff: GOOD_DIFF, request_id: "ap-3" });
-    expect(resp.result).toBe("error");
+    // #1761: approval-card timeout is a policy denial path.
+    expect(resp.result).toBe("denied");
     expect(resp.error).toMatch(/^E_APPROVAL_TIMEOUT/);
+    expect(resp.error_envelope?.code).toBe("E_APPROVAL_TIMEOUT");
+    expect(resp.error_envelope?.fix?.kind).toBe("operator_action");
     expect(reconcileInvocations).toBe(0);
     expect(readFile(configPath, "utf8")).toBe(before);
   });

--- a/tests/host-control/protocol.test.ts
+++ b/tests/host-control/protocol.test.ts
@@ -8,6 +8,8 @@ import {
   errorResponse,
   IDEMPOTENCY_WINDOW_MS,
   MAX_FRAME_BYTES,
+  ErrorFixSchema,
+  ErrorEnvelopeSchema,
   type HostdRequest,
   type HostdResponse,
 } from "../../src/host-control/protocol.js";
@@ -154,5 +156,128 @@ describe("error_envelope — #1758 Phase 1 round-trip", () => {
     };
     const decoded = decodeResponse(encodeResponse(resp).trimEnd());
     expect(decoded).toEqual(resp);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// #1761 Phase 2: negative-path schema tests. The discriminator is the
+// integrity boundary for the unlock-card path — every garbage shape it
+// silently accepts becomes a load-bearing allowlist bypass for the
+// gateway-side renderer. Pin the rejections.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("ErrorFixSchema — negative paths (#1761)", () => {
+  it("rejects an unknown fix.kind", () => {
+    const r = ErrorFixSchema.safeParse({ kind: "magic_unlock", token: "x" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects request_vault_grant without vault_key", () => {
+    const r = ErrorFixSchema.safeParse({ kind: "request_vault_grant" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects flip_yaml_flag without yaml_path", () => {
+    const r = ErrorFixSchema.safeParse({ kind: "flip_yaml_flag", to: true });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects operator_action with an unknown subkind", () => {
+    const r = ErrorFixSchema.safeParse({
+      kind: "operator_action",
+      subkind: "smells_bad",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects operator_action with an empty operator_steps array", () => {
+    const r = ErrorFixSchema.safeParse({
+      kind: "operator_action",
+      subkind: "policy_denied",
+      operator_steps: [],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects quota_exceeded missing limit", () => {
+    const r = ErrorFixSchema.safeParse({
+      kind: "quota_exceeded",
+      quota: "cron-entries",
+      current: 1,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects retry_after missing retry_at", () => {
+    const r = ErrorFixSchema.safeParse({ kind: "retry_after" });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts bad_input without field (field is optional)", () => {
+    const r = ErrorFixSchema.safeParse({ kind: "bad_input" });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("ErrorEnvelopeSchema — negative paths (#1761)", () => {
+  const base = {
+    v: 1 as const,
+    code: "E_OK",
+    human: "fine",
+    request_id: "r-1",
+  };
+
+  it("rejects a non-URL docs string", () => {
+    const r = ErrorEnvelopeSchema.safeParse({
+      ...base,
+      docs: "not-a-url-just-a-slug",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a fully-qualified docs URL", () => {
+    const r = ErrorEnvelopeSchema.safeParse({
+      ...base,
+      docs: "https://switchroom.dev/docs/foo",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a lowercase code (e_lowercase)", () => {
+    const r = ErrorEnvelopeSchema.safeParse({ ...base, code: "e_lowercase" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a bare-word code without the E_ / VAULT- prefix", () => {
+    const r = ErrorEnvelopeSchema.safeParse({ ...base, code: "FOO" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects an empty human string", () => {
+    const r = ErrorEnvelopeSchema.safeParse({ ...base, human: "" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a missing request_id", () => {
+    const { request_id: _omit, ...rest } = base;
+    void _omit;
+    const r = ErrorEnvelopeSchema.safeParse(rest);
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts the VAULT- prefix shape", () => {
+    const r = ErrorEnvelopeSchema.safeParse({
+      ...base,
+      code: "VAULT-BROKER-DENIED",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects an envelope whose nested fix fails the discriminator", () => {
+    const r = ErrorEnvelopeSchema.safeParse({
+      ...base,
+      fix: { kind: "magic_unlock" },
+    });
+    expect(r.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 follow-ups for the structured error envelope (#1758, Phase 1 in #1759).

- **Negative-path schema tests** pin `ErrorFixSchema` / `ErrorEnvelopeSchema` rejections (unknown `fix.kind`, missing required fields, non-URL `docs`, malformed `code` regex) — the discriminator is the integrity boundary for the unlock-card path.
- **`err().docs(URL)` validates at author-time** — throws `TypeError` on a non-URL, matching the receiver-side `z.string().url()` check. New call sites can no longer ship an envelope that fails its own schema.
- **`E_CONFIG_EDIT_DISABLED` returns `result: "denied"`** instead of `"error"` (policy denial, not server fault). `asDenied()` also applied to other policy-denial codes swept in the batch migration (`E_DENIED`, `E_APPROVAL_TIMEOUT`).
- **Batch-migrated every remaining `errorResponse()` call site** in `src/host-control/server.ts` to `err()` with the appropriate `fix` envelope. Legacy `error: string` preserved verbatim at every migrated site for back-compat with existing string-matching decoders.
- **CHANGELOG note** on the MCP hostd `content.length` going 1 -> 2 on errors when `error_envelope` is present.

## Migration map (server.ts)

| Site | Code | Fix kind | Result |
|---|---|---|---|
| flag-off | `E_CONFIG_EDIT_DISABLED` | `flip_yaml_flag` | `denied` |
| validation reject | `E_PATCH_APPLY_FAILED` etc. | `bad_input` (field=unified_diff) | `error` |
| no gateway | `E_NO_APPROVAL_GATEWAY` | `operator_action` (infra) | `error` |
| operator tap-deny | `E_DENIED` | `operator_action` (policy_denied) | `denied` |
| dispatch-failure deny | `E_APPROVAL_DISPATCH_FAILED` | `operator_action` (infra) | `error` |
| approval timeout | `E_APPROVAL_TIMEOUT` | `operator_action` (policy_denied) | `denied` |
| write/reconcile fail | `E_RECONCILE_FAILED_ROLLED_BACK` | `operator_action` (infra) | `error` |
| top-level catch | `E_DISPATCH_FAILED` | none | `error` |
| get_status invariant | `E_INTERNAL` | none | `error` |

## Test plan

- [x] `tsc --noEmit` clean
- [x] `src/host-control/error-builder.test.ts` — 7 tests pass (added `docs()` URL-throw and `asDenied()` flip tests)
- [x] `tests/host-control/protocol.test.ts` — 36 tests pass (added 16 negative-path `safeParse` rejections for `ErrorFixSchema` + `ErrorEnvelopeSchema`)
- [x] `tests/host-control/config-propose-edit.test.ts` — 21 tests pass (updated `E_CONFIG_EDIT_DISABLED` / `E_DENIED` / `E_APPROVAL_TIMEOUT` to expect `result: "denied"`; added envelope assertions on validation + no-gateway paths)
- [x] `src/host-control/approval-gateway.test.ts` — 9 tests pass (unchanged; `formatConfigApprovalDenyError` helper untouched)

Refs: #1758, #1759

Generated with [Claude Code](https://claude.com/claude-code)