### PR TITLE
fix: diff-preview-card error message says '8 hex' but regex is 32 (#1772)

### DIFF
--- a/telegram-plugin/gateway/diff-preview-card.test.ts
+++ b/telegram-plugin/gateway/diff-preview-card.test.ts
@@ -111,7 +111,7 @@ describe("buildDiffPreviewCard — input validation", () => {
     const preview = buildDiffPreview(baseInput());
     expect(() =>
       buildDiffPreviewCard({ preview, suggestRequestId: "not-hex" }),
-    ).toThrow(/8 hex chars/);
+    ).toThrow(/32 hex chars/);
   });
 
   it("throws on a malformed writeRequestId", () => {
@@ -122,7 +122,7 @@ describe("buildDiffPreviewCard — input validation", () => {
         suggestRequestId: "aabbccddaabbccddaabbccddaabbccdd",
         writeRequestId: "ABCDEF01", // wrong case
       }),
-    ).toThrow(/8 hex chars/);
+    ).toThrow(/32 hex chars/);
   });
 });
 

--- a/telegram-plugin/gateway/diff-preview-card.ts
+++ b/telegram-plugin/gateway/diff-preview-card.ts
@@ -73,12 +73,12 @@ export function buildDiffPreviewCard(
 ): BuiltDiffPreviewCard {
   if (!REQUEST_ID_RE.test(input.suggestRequestId)) {
     throw new Error(
-      `buildDiffPreviewCard: suggestRequestId must be 8 hex chars (got '${input.suggestRequestId}')`,
+      `buildDiffPreviewCard: suggestRequestId must be 32 hex chars (got '${input.suggestRequestId}')`,
     );
   }
   if (input.writeRequestId !== undefined && !REQUEST_ID_RE.test(input.writeRequestId)) {
     throw new Error(
-      `buildDiffPreviewCard: writeRequestId must be 8 hex chars (got '${input.writeRequestId}')`,
+      `buildDiffPreviewCard: writeRequestId must be 32 hex chars (got '${input.writeRequestId}')`,
     );
   }
 


### PR DESCRIPTION
## Summary
- `REQUEST_ID_RE` is `/^[0-9a-f]{32}$/` but the thrown error message read "must be 8 hex chars" — drift from an earlier ID-length change.
- Updated both error messages (`suggestRequestId` and `writeRequestId`) plus the matching `.toThrow(/8 hex chars/)` test expectations to "32 hex chars".

Fixes #1772.

## Test plan
- [x] `bun test telegram-plugin/gateway/diff-preview-card.test.ts` — 9 pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)