### PR TITLE
fix: clarify extractCronIntervalMin returns smallest gap, not worst-case interval (#1779)

### DIFF
--- a/src/cli/agent-config-write.test.ts
+++ b/src/cli/agent-config-write.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { scheduleAdd, scheduleRemove } from "./agent-config-write.js";
+import { scheduleAdd, scheduleRemove, extractCronSmallestGapMin } from "./agent-config-write.js";
 import { cronUnitHash } from "../agents/cron-unit-name.js";
 
 let root: string;
@@ -252,5 +252,35 @@ describe("scheduleAdd — cross-agent denial", () => {
     expect(() => {
       scheduleAdd({ agent: "other-agent", cronExpr: "0 9 * * *", prompt: "p", root });
     }).toThrow(/cross-agent/);
+  });
+});
+
+// #1779 — extractCronSmallestGapMin returns the *smallest gap* between
+// consecutive fires, used as the rejection signal for the 5-min floor.
+// Explicitly NOT the worst-case wait (see fn docstring). For
+// `0,1,2 * * * *` the worst-case wait is ~58 min, but the rejection
+// signal — and what this fn returns — is the smallest gap (1 min).
+describe("extractCronSmallestGapMin (#1779)", () => {
+  it("CSV `0,1,2` → 1 (smallest gap is the rejection signal, not 58)", () => {
+    expect(extractCronSmallestGapMin("0,1,2 * * * *")).toBe(1);
+  });
+  it("CSV `0,30` → 30", () => {
+    expect(extractCronSmallestGapMin("0,30 * * * *")).toBe(30);
+  });
+  it("CSV `0,15,30,45` → 15", () => {
+    expect(extractCronSmallestGapMin("0,15,30,45 * * * *")).toBe(15);
+  });
+  it("stepped `*/5` → 5 (== floor, accepted)", () => {
+    expect(extractCronSmallestGapMin("*/5 * * * *")).toBe(5);
+  });
+  it("stepped `*/4` → 4 (< floor, rejected)", () => {
+    expect(extractCronSmallestGapMin("*/4 * * * *")).toBe(4);
+  });
+  it("`*` → 1 (every minute)", () => {
+    expect(extractCronSmallestGapMin("* * * * *")).toBe(1);
+  });
+  it("range / unknown forms → 0", () => {
+    expect(extractCronSmallestGapMin("0-30 * * * *")).toBe(0);
+    expect(extractCronSmallestGapMin("bogus")).toBe(0);
   });
 });

--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -69,14 +69,28 @@ const MAX_ENTRIES_PER_AGENT = 20;
 const MIN_CRON_INTERVAL_MIN = 5;
 
 /**
- * Best-effort interval extraction for the `current` field of the
- * envelope's `quota_exceeded` fix. Parses the minutes column of a
- * 5-field cron expr; returns 1 for `*`, the step for a stepped value, the count
- * for a CSV list, or 0 when we can't tell (e.g. complex range exprs).
- * Used purely as structured metadata — the user-facing message is
- * still the canonical truth.
+ * Returns the **smallest gap (in minutes)** between consecutive fires
+ * implied by the minutes column of a 5-field cron expr. This is the
+ * rejection signal used by the min-interval floor: if the smallest
+ * gap is below `MIN_CRON_INTERVAL_MIN`, the schedule fires too fast
+ * and is refused.
+ *
+ * Semantics by minute-field shape:
+ *   - `*`        → 1  (fires every minute)
+ *   - `*\/N`     → N  (stepped cadence)
+ *   - CSV list   → smallest pairwise gap between sorted values
+ *                  (e.g. `0,1,2` → 1, `0,30` → 30, `0,15,30,45` → 15)
+ *   - anything else (ranges, mixed) → 0 (unknown)
+ *
+ * NOTE: this is **not** the worst-case wait between fires. For CSV
+ * lists clustered at the top of the hour like `0,1,2 * * * *`, the
+ * worst-case wait is ~58 min (minute 2 → next hour's minute 0), but
+ * the *smallest* gap is 1 — which is what the floor cares about.
+ * Surfaced as `requested_interval_min` in the error envelope's
+ * `quota_exceeded.current` field; receivers should read it as "the
+ * tightest cadence the schedule implies", not "the user's wait time".
  */
-function extractCronIntervalMin(expr: string): number {
+export function extractCronSmallestGapMin(expr: string): number {
   const fields = expr.trim().split(/\s+/);
   if (fields.length < 5) return 0;
   const min = fields[0];
@@ -86,7 +100,6 @@ function extractCronIntervalMin(expr: string): number {
   if (min.includes(",")) {
     const parts = min.split(",").map((s) => Number(s)).filter((n) => Number.isFinite(n));
     if (parts.length >= 2) {
-      // Approximate cadence: smallest gap between sorted entries.
       const sorted = [...parts].sort((a, b) => a - b);
       let smallest = Infinity;
       for (let i = 1; i < sorted.length; i++) {
@@ -373,7 +386,7 @@ export function scheduleAdd(opts: AddOpts): ScheduleAddResult | ScheduleErrorRes
       code: "E_CRON_TOO_FREQUENT",
       message: "cron interval is tighter than the minimum (5 minutes)",
       exit: 9,
-      meta: { requested_interval_min: extractCronIntervalMin(opts.cronExpr) },
+      meta: { requested_interval_min: extractCronSmallestGapMin(opts.cronExpr) },
     };
   }
 


### PR DESCRIPTION
## Summary
- Rename `extractCronIntervalMin` → `extractCronSmallestGapMin` in `src/cli/agent-config-write.ts` and rewrite the docstring to spell out what the CSV branch actually returns: the smallest pairwise gap between sorted minute-field entries, used as the rejection signal for the 5-min floor — NOT the worst-case wait between fires.
- Wire shape preserved. `meta.requested_interval_min` and the envelope's `quota_exceeded.current` field still carry the same number; only the source name and comments change.
- Adds 7 direct unit tests for the helper covering CSV, stepped, star, and unknown forms.

## Why
For `0,1,2 * * * *` the helper returns `1` (smallest gap). The old name and "Approximate cadence" comment implied this was the interval the user would see between fires, but the true worst-case wait is ~58 min (minute 2 wrap-around to minute 0). The rejection logic (smallest-gap < floor) is correct and unchanged — the field name and docstring were the lie.

## Scope
Contained to `src/cli/agent-config-write.ts` + its test file. No schema, envelope, or behaviour change. Refs #1776.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/cli/agent-config-write.test.ts` — 23/23 pass (16 existing + 7 new)

Closes #1779