### PR TITLE
refactor: extract buildEnvelope() + make request_id optional (#1778)

### DIFF
--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -60,8 +60,7 @@ import {
   type PendingReasonCode,
 } from "./agent-config-pending.js";
 import { existsSync, readFileSync } from "node:fs";
-import { randomUUID } from "node:crypto";
-import type { ErrorEnvelope } from "../host-control/protocol.js";
+import { buildEnvelope, type ErrorEnvelope } from "../host-control/protocol.js";
 
 const MAX_ENTRIES_PER_AGENT = 20;
 
@@ -182,42 +181,29 @@ function buildEnvelopeForCode(
   message: string,
   extra: Record<string, unknown>,
 ): ErrorEnvelope | undefined {
-  // request_id is required by ErrorEnvelopeSchema; CLI emit sites have
-  // no caller-supplied id, so synthesize one. Receivers correlate via
-  // audit_id when needed; this id exists purely to satisfy the schema.
-  const request_id = `agent-config-${randomUUID()}`;
+  // #1778 — request_id is now optional on ErrorEnvelopeSchema. CLI
+  // emit sites no longer fabricate a placeholder; receivers correlate
+  // via audit_id / surrounding context.
   if (code === "E_CRON_TOO_FREQUENT") {
-    return {
-      v: 1,
-      code,
-      human: message,
-      fix: {
-        kind: "quota_exceeded",
-        quota: "cron_min_interval_minutes",
-        current: typeof extra.requested_interval_min === "number"
-          ? (extra.requested_interval_min as number)
-          : 0,
-        limit: MIN_CRON_INTERVAL_MIN,
-      },
-      request_id,
-    };
+    return buildEnvelope(code, message, {
+      kind: "quota_exceeded",
+      quota: "cron_min_interval_minutes",
+      current: typeof extra.requested_interval_min === "number"
+        ? (extra.requested_interval_min as number)
+        : 0,
+      limit: MIN_CRON_INTERVAL_MIN,
+    });
   }
   if (code === "E_QUOTA_EXCEEDED") {
     const current = typeof extra.current === "number"
       ? (extra.current as number)
       : MAX_ENTRIES_PER_AGENT;
-    return {
-      v: 1,
-      code,
-      human: message,
-      fix: {
-        kind: "quota_exceeded",
-        quota: "schedule_entries_per_agent",
-        current,
-        limit: MAX_ENTRIES_PER_AGENT,
-      },
-      request_id,
-    };
+    return buildEnvelope(code, message, {
+      kind: "quota_exceeded",
+      quota: "schedule_entries_per_agent",
+      current,
+      limit: MAX_ENTRIES_PER_AGENT,
+    });
   }
   return undefined;
 }

--- a/src/cli/vault-denied-envelope.test.ts
+++ b/src/cli/vault-denied-envelope.test.ts
@@ -67,7 +67,7 @@ describe("writeVaultDeniedEnvelope — envelope shape", () => {
     });
     expect(parsed.human).toContain("DENIED");
     expect(parsed.human).toContain("no grant");
-    expect(typeof parsed.request_id).toBe("string");
-    expect(parsed.request_id.length).toBeGreaterThan(0);
+    // #1778 — request_id is optional; CLI sites no longer fabricate one.
+    expect(parsed.request_id).toBeUndefined();
   });
 });

--- a/src/cli/vault-denied-envelope.ts
+++ b/src/cli/vault-denied-envelope.ts
@@ -29,6 +29,8 @@
  * Split out of `vault.ts` so unit tests don't pull in the broker
  * client / sqlite-backed grants store via transitive imports.
  */
+import { buildEnvelope } from "../host-control/protocol.js";
+
 /**
  * Stderr line prefix for structured error envelopes. Canonical across
  * all envelope-emitting CLIs — chosen to NOT share a prefix with any
@@ -42,16 +44,11 @@ export function writeVaultDeniedEnvelope(
   brokerCode: string,
   human: string,
 ): void {
-  const envelope = {
-    v: 1 as const,
-    code: "VAULT-BROKER-DENIED",
-    human: `${brokerCode}: ${human}`,
-    fix: {
-      kind: "request_vault_grant" as const,
-      vault_key: vaultKey,
-    },
-    request_id: `vault-cli-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
-  };
+  const envelope = buildEnvelope(
+    "VAULT-BROKER-DENIED",
+    `${brokerCode}: ${human}`,
+    { kind: "request_vault_grant", vault_key: vaultKey },
+  );
   process.stderr.write(
     `${ENVELOPE_SENTINEL} ${JSON.stringify(envelope)}\n`,
   );

--- a/src/host-control/error-builder.ts
+++ b/src/host-control/error-builder.ts
@@ -27,6 +27,7 @@ import type {
   ErrorFix,
   HostdResponse,
 } from "./protocol.js";
+import { buildEnvelope } from "./protocol.js";
 import {
   recordErrorFriction,
   type ErrorFrictionContext,
@@ -135,15 +136,11 @@ export class ErrorBuilder {
   }
 
   build(requestId: string, durationMs: number): HostdResponse {
-    const envelope: ErrorEnvelope = {
-      v: 1,
-      code: this._code,
-      human: this._human,
-      ...(this._why !== undefined ? { why: this._why } : {}),
-      ...(this._fix !== undefined ? { fix: this._fix } : {}),
-      ...(this._docs !== undefined ? { docs: this._docs } : {}),
+    const envelope: ErrorEnvelope = buildEnvelope(this._code, this._human, this._fix, {
+      why: this._why,
+      docs: this._docs,
       request_id: requestId,
-    };
+    });
     // Synthesise the legacy `error` string so existing string-matching
     // decoders (audit reader, vault-broker client, telegram-plugin
     // gateway response handler) see no semantic regression.

--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -422,9 +422,57 @@ export const ErrorEnvelopeSchema = z.object({
   why: z.string().optional(),
   fix: ErrorFixSchema.optional(),
   docs: z.string().url().optional(),
-  request_id: z.string().min(1),
+  /**
+   * Optional. The hostd dispatcher path threads the real RPC
+   * `request_id` through; CLI emit sites (vault-broker denial line,
+   * agent-config sibling JSON key) have no caller-supplied id and
+   * omit the field — receivers correlate via `audit_id` or the
+   * surrounding context. Relaxed from `.min(1)` to `.optional()`
+   * in #1778 to stop fabricated `<service>-<uuid>` placeholders.
+   */
+  request_id: z.string().min(1).optional(),
 });
 export type ErrorEnvelope = z.infer<typeof ErrorEnvelopeSchema>;
+
+/**
+ * Pure envelope constructor (#1778) — single source of truth for the
+ * `ErrorEnvelope` wire shape. Used by the hostd `ErrorBuilder` (which
+ * adds `request_id` + `why`/`docs` and wraps in `HostdResponse`) and
+ * directly by CLI emit sites (`writeVaultDeniedEnvelope`,
+ * `agent-config-write.ts`) that don't have an RPC request_id to thread.
+ *
+ * `fix` is passed through verbatim — validation that the discriminator
+ * + required fields line up is `ErrorEnvelopeSchema`'s job, not this
+ * function's. Callers that want author-time validation should pipe the
+ * result through `ErrorEnvelopeSchema.parse`.
+ *
+ * Per-code `fix.kind` selection is the CALLER's responsibility — this
+ * function does not mint a default `fix` for any code. Unknown / un-
+ * migrated codes pass `undefined` and the field elides from the
+ * envelope, matching `ErrorEnvelopeSchema`'s `fix.optional()`.
+ */
+export interface BuildEnvelopeOptions {
+  why?: string;
+  docs?: string;
+  request_id?: string;
+}
+
+export function buildEnvelope(
+  code: string,
+  human: string,
+  fix?: ErrorFix,
+  opts: BuildEnvelopeOptions = {},
+): ErrorEnvelope {
+  return {
+    v: 1,
+    code,
+    human,
+    ...(opts.why !== undefined ? { why: opts.why } : {}),
+    ...(fix !== undefined ? { fix } : {}),
+    ...(opts.docs !== undefined ? { docs: opts.docs } : {}),
+    ...(opts.request_id !== undefined ? { request_id: opts.request_id } : {}),
+  };
+}
 
 const ResponseEnvelope = {
   v: z.literal(1),

--- a/tests/host-control/protocol.test.ts
+++ b/tests/host-control/protocol.test.ts
@@ -6,6 +6,7 @@ import {
   decodeResponse,
   deniedResponse,
   errorResponse,
+  buildEnvelope,
   IDEMPOTENCY_WINDOW_MS,
   MAX_FRAME_BYTES,
   ErrorFixSchema,
@@ -258,11 +259,24 @@ describe("ErrorEnvelopeSchema — negative paths (#1761)", () => {
     expect(r.success).toBe(false);
   });
 
-  it("rejects a missing request_id", () => {
+  // #1778 — request_id is optional. CLI emit sites (vault denial,
+  // agent-config sibling JSON key) no longer fabricate placeholders;
+  // hostd-path responses still thread the real RPC id through.
+  it("accepts an envelope without request_id (now optional, #1778)", () => {
     const { request_id: _omit, ...rest } = base;
     void _omit;
     const r = ErrorEnvelopeSchema.safeParse(rest);
-    expect(r.success).toBe(false);
+    expect(r.success).toBe(true);
+  });
+
+  it("round-trips an envelope without request_id through safeParse", () => {
+    const noId = { v: 1 as const, code: "VAULT-BROKER-DENIED", human: "denied" };
+    const r = ErrorEnvelopeSchema.safeParse(noId);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.request_id).toBeUndefined();
+      expect(r.data).toEqual(noId);
+    }
   });
 
   it("accepts the VAULT- prefix shape", () => {
@@ -279,5 +293,73 @@ describe("ErrorEnvelopeSchema — negative paths (#1761)", () => {
       fix: { kind: "magic_unlock" },
     });
     expect(r.success).toBe(false);
+  });
+});
+
+describe("buildEnvelope — pure constructor (#1778)", () => {
+  it("produces a minimal envelope (no fix, no opts)", () => {
+    const env = buildEnvelope("E_FOO", "broken");
+    expect(env).toEqual({ v: 1, code: "E_FOO", human: "broken" });
+    expect(env.fix).toBeUndefined();
+    expect(env.request_id).toBeUndefined();
+    expect(ErrorEnvelopeSchema.safeParse(env).success).toBe(true);
+  });
+
+  it("threads request_id, why, docs through opts", () => {
+    const env = buildEnvelope("E_FOO", "broken", undefined, {
+      why: "because",
+      docs: "https://example.com/x",
+      request_id: "req-9",
+    });
+    expect(env).toEqual({
+      v: 1,
+      code: "E_FOO",
+      human: "broken",
+      why: "because",
+      docs: "https://example.com/x",
+      request_id: "req-9",
+    });
+    expect(ErrorEnvelopeSchema.safeParse(env).success).toBe(true);
+  });
+
+  it("passes each fix.kind variant through verbatim", () => {
+    const cases = [
+      { kind: "flip_yaml_flag", yaml_path: "hostd.x", to: true } as const,
+      { kind: "request_vault_grant", vault_key: "svc/key" } as const,
+      { kind: "operator_action", subkind: "policy_denied", operator_steps: ["s1"] } as const,
+      { kind: "operator_action", subkind: "infra" } as const,
+      { kind: "retry_after", retry_at: "2026-01-01T00:00:00Z" } as const,
+      { kind: "quota_exceeded", quota: "q", current: 1, limit: 2 } as const,
+      { kind: "bad_input", field: "f" } as const,
+      { kind: "bad_input" } as const,
+    ];
+    for (const fix of cases) {
+      const env = buildEnvelope("E_FOO", "h", fix);
+      expect(env.fix).toEqual(fix);
+      expect(ErrorEnvelopeSchema.safeParse(env).success).toBe(true);
+    }
+  });
+
+  it("does not synthesize a fix for an unknown code (caller's job)", () => {
+    const env = buildEnvelope("E_NEVER_SEEN_BEFORE", "huh");
+    expect(env.fix).toBeUndefined();
+  });
+
+  it("does not validate fix payloads itself — schema is the gate", () => {
+    // Missing required fields for the kind: buildEnvelope passes
+    // through as-is. ErrorEnvelopeSchema.safeParse is what catches it.
+    const env = buildEnvelope("E_FOO", "h", {
+      // @ts-expect-error — intentionally malformed for the test
+      kind: "quota_exceeded",
+    });
+    expect(env.fix).toEqual({ kind: "quota_exceeded" });
+    expect(ErrorEnvelopeSchema.safeParse(env).success).toBe(false);
+  });
+
+  it("omits why / docs / request_id when undefined (no nullish keys leak in)", () => {
+    const env = buildEnvelope("E_FOO", "h", undefined, { why: undefined });
+    expect("why" in env).toBe(false);
+    expect("docs" in env).toBe(false);
+    expect("request_id" in env).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Two cleanups for the #1758 error-envelope rollout:

- **Extract `buildEnvelope(code, human, fix?, opts?)`** in `src/host-control/protocol.ts` as the single source of truth for the `ErrorEnvelope` wire shape. The hostd `ErrorBuilder.build()` now delegates envelope assembly; `writeVaultDeniedEnvelope` and `agent-config-write.ts`'s `buildEnvelopeForCode` call it directly instead of hand-spreading the same conditional shape. Per-code → `fix.kind` selection stays at each call site (that's domain logic) — what's deduplicated is the assembly + optional-field elision.
- **Relax `request_id` on `ErrorEnvelopeSchema` to `optional()`.** Both CLI emit sites previously fabricated placeholder ids (`agent-config-${randomUUID()}`, `` `vault-cli-${Date.now()}-…` ``) purely to satisfy the receiver-side schema. They now omit the field; receivers correlate via `audit_id` / surrounding context. The hostd dispatch path still threads the real RPC `request_id`.

Refs #1758, #1759, #1769, #1770, #1776, #1777.

## Coordination with #1777

#1777 is in flight on the same file (`src/cli/vault-denied-envelope.ts`, changing the sentinel prefix). The diffs are orthogonal — that PR changes the emission format string, this PR changes the envelope construction — but a small merge conflict on the import / `buildEnvelope` call site is possible. Easily resolved either way.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` on the four touched test files: `tests/host-control/protocol.test.ts` (43 tests), `src/host-control/error-builder.test.ts` (7), `src/cli/vault-denied-envelope.test.ts` (3), `src/cli/agent-config-write.test.ts` (16) — all green
- [x] New unit tests for `buildEnvelope` cover: all 6 `fix.kind` variants pass-through, opts pass-through, unknown code → no `fix`, malformed `fix` → caught by schema not by builder, undefined opt keys don't leak in
- [x] New schema test confirms `request_id` is optional and an envelope without it round-trips through `ErrorEnvelopeSchema.safeParse`
- [x] Existing `vault-denied-envelope.test.ts` updated to assert `request_id` is absent (was asserting non-empty presence)
- [x] Existing `error-builder.test.ts` unchanged — hostd path still threads `request_id` through

Pre-existing test failures on `main` (auth-heal, boot-self-test, cli.issues, token-helpers, autoaccept-poll-bundled) are unrelated — they need a built `dist/` or shell-helper deps; confirmed they fail on `origin/main` without this PR's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)