### PR TITLE
fix(scaffold): user-declared mcp_servers reach .mcp.json (both writers)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2423,9 +2423,29 @@ export function scaffoldAgent(
       }
     }
 
-    // .mcp.json is purely template-driven. writeIfChanged so a stale
-    // file from a pre-v0.7.6 release (different plugin path resolution)
-    // is rewritten on the next `switchroom apply`.
+    // User-declared mcp_servers from switchroom.yaml (`defaults.mcp_servers`
+    // and per-agent `agents.<name>.mcp_servers`, already merged by the
+    // config cascade). Spread AFTER the framework set so user-declared
+    // entries can override on key collision — matching the
+    // settings.json precedence at line ~2255 where built-in defaults
+    // only land when `!settings.mcpServers[entry.key]`. `false`
+    // opt-outs are stripped by `filterMcpServers`. Without this spread
+    // (the pre-fix state since v0.7.6) the only MCPs Claude could see
+    // were the framework set — perplexity, notion, and any other
+    // operator-declared entries were silently dropped.
+    if (agentConfig.mcp_servers) {
+      const filtered = filterMcpServers(agentConfig.mcp_servers);
+      if (filtered) {
+        for (const [key, value] of Object.entries(filtered)) {
+          mcpServers[key] = value as McpServerConfig;
+        }
+      }
+    }
+
+    // .mcp.json contents: framework MCPs + user-declared MCPs from
+    // switchroom.yaml. writeIfChanged so a stale file from a pre-v0.7.6
+    // release (different plugin path resolution) is rewritten on the
+    // next `switchroom apply`.
     writeIfChanged(
       mcpJsonPath,
       () => JSON.stringify({ mcpServers }, null, 2) + "\n",
@@ -4369,6 +4389,23 @@ Don't wait for a slash command. Don't ask permission. Memory work is table stake
       const gdrive = resolveGdriveMcpEntry(name, agentConfig, switchroomConfig);
       if (gdrive) {
         mcpServers[gdrive.key] = gdrive.value;
+      }
+    }
+
+    // User-declared mcp_servers from switchroom.yaml. Mirrors the
+    // scaffoldAgent path: spread AFTER the framework set with user
+    // winning on key collision. `false` opt-outs stripped by
+    // filterMcpServers. Without this spread the entire user MCP
+    // surface in switchroom.yaml is silently dropped from .mcp.json
+    // (the surface Claude Code actually loads), regression class
+    // since v0.7.6's docker cutover — see the in-block comment at
+    // the scaffoldAgent writer for the full story.
+    if (agentConfig.mcp_servers) {
+      const filtered = filterMcpServers(agentConfig.mcp_servers);
+      if (filtered) {
+        for (const [key, value] of Object.entries(filtered)) {
+          mcpServers[key] = value as McpServerConfig;
+        }
       }
     }
 

--- a/tests/scaffold.mcp-json-user-declared.test.ts
+++ b/tests/scaffold.mcp-json-user-declared.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent, reconcileAgent } from "../src/agents/scaffold.js";
+import type {
+  AgentConfig,
+  SwitchroomConfig,
+  TelegramConfig,
+} from "../src/config/schema.js";
+
+/**
+ * Regression test for the user-declared mcp_servers → .mcp.json gap
+ * (audit 2026-05-25).
+ *
+ * Pre-fix the .mcp.json writers in scaffold.ts (both scaffoldAgent and
+ * reconcileAgent) were template-driven and emitted only the hardcoded
+ * framework set (switchroom-telegram, agent-config, hostd-if-admin,
+ * hindsight, gdrive). User-declared `mcp_servers` in switchroom.yaml
+ * — either at `defaults.mcp_servers` or per-agent
+ * `agents.<name>.mcp_servers` — were silently dropped from .mcp.json
+ * even though they landed in settings.json (which Claude Code doesn't
+ * load under the `--dangerously-load-development-channels` flag the
+ * agent actually uses).
+ *
+ * Net effect from PR #875 (v0.7.6 docker cutover) until the fix: every
+ * operator-declared MCP server on the fleet — perplexity (declared
+ * under defaults.mcp_servers) and carrie's notion (declared under her
+ * per-agent block) — was effectively dead. `claude mcp list` from
+ * inside any agent container returned only the framework set.
+ *
+ * This test pins both writers so the regression cannot recur.
+ */
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+describe("scaffold/reconcile: user-declared mcp_servers reach .mcp.json", () => {
+  let agentsDir: string;
+
+  beforeEach(() => {
+    agentsDir = mkdtempSync(join(tmpdir(), "switchroom-mcp-user-"));
+  });
+
+  afterEach(() => {
+    rmSync(agentsDir, { recursive: true, force: true });
+  });
+
+  it("emits a user-declared command-based MCP into .mcp.json (scaffoldAgent)", () => {
+    const name = "test-agent";
+    const agentConfig = makeAgentConfig({
+      mcp_servers: {
+        perplexity: {
+          command: "/home/test/launchers/perplexity-mcp.sh",
+        },
+      },
+    } as Partial<AgentConfig>);
+    const switchroomConfig = {
+      switchroom: {
+        version: 1,
+        agents_dir: "~/.switchroom/agents",
+        skills_dir: "~/.switchroom/skills",
+      },
+      telegram: telegramConfig,
+      agents: { [name]: agentConfig },
+    } as unknown as SwitchroomConfig;
+
+    const res = scaffoldAgent(
+      name,
+      agentConfig,
+      agentsDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+
+    const mcpJson = JSON.parse(readFileSync(join(res.agentDir, ".mcp.json"), "utf-8"));
+    expect(mcpJson.mcpServers).toHaveProperty("perplexity");
+    expect(mcpJson.mcpServers.perplexity).toEqual({
+      command: "/home/test/launchers/perplexity-mcp.sh",
+    });
+    // Framework MCPs preserved.
+    expect(mcpJson.mcpServers).toHaveProperty("switchroom-telegram");
+    expect(mcpJson.mcpServers).toHaveProperty("agent-config");
+  });
+
+  it("emits a user-declared HTTP MCP (e.g. notion) into .mcp.json (scaffoldAgent)", () => {
+    const name = "carrie-like";
+    const agentConfig = makeAgentConfig({
+      mcp_servers: {
+        notion: {
+          type: "http",
+          url: "https://mcp.notion.com/mcp",
+        },
+      },
+    } as Partial<AgentConfig>);
+    const switchroomConfig = {
+      switchroom: {
+        version: 1,
+        agents_dir: "~/.switchroom/agents",
+        skills_dir: "~/.switchroom/skills",
+      },
+      telegram: telegramConfig,
+      agents: { [name]: agentConfig },
+    } as unknown as SwitchroomConfig;
+
+    const res = scaffoldAgent(
+      name,
+      agentConfig,
+      agentsDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+
+    const mcpJson = JSON.parse(readFileSync(join(res.agentDir, ".mcp.json"), "utf-8"));
+    expect(mcpJson.mcpServers.notion).toEqual({
+      type: "http",
+      url: "https://mcp.notion.com/mcp",
+    });
+  });
+
+  it("honours the `false` opt-out sentinel (scaffoldAgent)", () => {
+    // A user-declared `gdrive: false` must NOT clobber the framework
+    // gdrive entry into the map as `false` — filterMcpServers strips
+    // `false` values before the spread. (The gdrive-specific opt-out
+    // pathway is exercised by separate tests; this assertion just
+    // confirms `false` doesn't leak into the rendered output.)
+    const name = "optout-agent";
+    const agentConfig = makeAgentConfig({
+      mcp_servers: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        gdrive: false as any,
+        my_real: { command: "/bin/true" },
+      },
+    } as Partial<AgentConfig>);
+    const switchroomConfig = {
+      switchroom: {
+        version: 1,
+        agents_dir: "~/.switchroom/agents",
+        skills_dir: "~/.switchroom/skills",
+      },
+      telegram: telegramConfig,
+      agents: { [name]: agentConfig },
+    } as unknown as SwitchroomConfig;
+
+    const res = scaffoldAgent(
+      name,
+      agentConfig,
+      agentsDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+
+    const mcpJson = JSON.parse(readFileSync(join(res.agentDir, ".mcp.json"), "utf-8"));
+    // The legit user-declared entry lands.
+    expect(mcpJson.mcpServers).toHaveProperty("my_real");
+    // The `false` sentinel is NOT a stored entry.
+    expect(mcpJson.mcpServers.gdrive).not.toBe(false);
+  });
+
+  it("user-declared key collides with framework — user wins (matches settings.json semantics)", () => {
+    // Operator deliberately overrides a framework MCP (e.g. swapping
+    // hindsight's URL). settings.json adds framework entries only when
+    // `!settings.mcpServers[entry.key]` — user wins there too. .mcp.json
+    // must match that precedence so the two views can't disagree on
+    // which definition is live.
+    const name = "override-agent";
+    const customHindsight = {
+      type: "http",
+      url: "http://127.0.0.1:99999/custom-hindsight/",
+    };
+    const agentConfig = makeAgentConfig({
+      mcp_servers: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        hindsight: customHindsight as any,
+      },
+    } as Partial<AgentConfig>);
+    const switchroomConfig = {
+      switchroom: {
+        version: 1,
+        agents_dir: "~/.switchroom/agents",
+        skills_dir: "~/.switchroom/skills",
+      },
+      telegram: telegramConfig,
+      agents: { [name]: agentConfig },
+    } as unknown as SwitchroomConfig;
+
+    const res = scaffoldAgent(
+      name,
+      agentConfig,
+      agentsDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+
+    const mcpJson = JSON.parse(readFileSync(join(res.agentDir, ".mcp.json"), "utf-8"));
+    expect(mcpJson.mcpServers.hindsight).toEqual(customHindsight);
+  });
+
+  it("reconcileAgent emits the same user-declared MCPs as scaffoldAgent", () => {
+    // Mirrors the parity test (scaffold.mcp-json-builder-parity.test.ts)
+    // but with user-declared mcp_servers to guard against one builder
+    // picking up the spread but the other forgetting it.
+    const name = "reconcile-parity";
+    const agentConfig = makeAgentConfig({
+      mcp_servers: {
+        custom_one: { command: "/bin/echo", args: ["one"] },
+        custom_two: { type: "http", url: "https://example.test/mcp" },
+      },
+    } as Partial<AgentConfig>);
+    const switchroomConfig = {
+      switchroom: {
+        version: 1,
+        agents_dir: "~/.switchroom/agents",
+        skills_dir: "~/.switchroom/skills",
+      },
+      telegram: telegramConfig,
+      agents: { [name]: agentConfig },
+    } as unknown as SwitchroomConfig;
+
+    const res = scaffoldAgent(
+      name,
+      agentConfig,
+      agentsDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+    const mcpPath = join(res.agentDir, ".mcp.json");
+    const afterScaffold = readFileSync(mcpPath, "utf-8");
+
+    // Sanity: both user-declared entries landed.
+    const scaffoldParsed = JSON.parse(afterScaffold);
+    expect(scaffoldParsed.mcpServers).toHaveProperty("custom_one");
+    expect(scaffoldParsed.mcpServers).toHaveProperty("custom_two");
+
+    reconcileAgent(
+      name,
+      agentConfig,
+      agentsDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+    const afterReconcile = readFileSync(mcpPath, "utf-8");
+
+    expect(afterReconcile).toBe(afterScaffold);
+  });
+});


### PR DESCRIPTION
## Summary

Both `.mcp.json` writers in `src/agents/scaffold.ts` were template-driven and silently dropped user-declared `mcp_servers` from `switchroom.yaml` on every scaffold + reconcile. This fix spreads `agentConfig.mcp_servers` into the rendered `.mcp.json` after the framework set, with user-declared entries winning on key collision (matches `settings.json` precedence).

## What was broken

Pre-fix runtime state from the live fleet (`docker exec -w /state/agent switchroom-<any> claude mcp list`): exactly the framework set is connected. `defaults.mcp_servers.perplexity` (declared at `switchroom.yaml:130`) and `agents.carrie.mcp_servers.notion` (per-agent) were both absent — the operator declared them, the cascade merged them, settings.json received them, but Claude Code never loaded them.

**Root cause:** PR #875 (v0.7.6, May 2026 docker cutover) introduced project-`.mcp.json` discovery as the only MCP-loader path that wins under the agent's `exec claude … --dangerously-load-development-channels server:switchroom-telegram` invocation (no `--mcp-config` flag). At inception the writer carried only `switchroom-telegram`. Subsequent PRs added each framework MCP one at a time (`agent-config`, then `hindsight`/`hostd`, then `gdrive` via PR #1358 after Drive silently failed for exactly this reason). **The general spread of `agentConfig.mcp_servers` was never wired** — checked via `git log -G \"agentConfig\\.mcp_servers\" -- src/agents/scaffold.ts`, references appear only as opt-out gates and as the settings.json template plumbing.

settings.json.mcpServers was populated correctly via `profiles/_base/settings.json.hbs:28` but Claude Code doesn't read it under the agent invocation actually used — it's dead text for the switchroom-telegram-plugin path.

## What changed

`src/agents/scaffold.ts` — two writer regions:
- `scaffoldAgent` at ~line 2369: after the framework set is assembled (telegram, agent-config, hostd-if-admin, hindsight, gdrive), spread `agentConfig.mcp_servers` filtered through `filterMcpServers` (strips `false` opt-out sentinels). User-declared keys win on collision.
- `reconcileAgent` at ~line 4314: identical spread, identical precedence — matches the byte-parity invariant the existing `scaffold.mcp-json-builder-parity.test.ts` enforces.

The trust pass `ensureMcpServersTrusted` automatically picks up the new entries because it iterates `Object.keys(mcpServers)`.

## Test plan

- [x] New `tests/scaffold.mcp-json-user-declared.test.ts` — 5 cases:
  - command-based user MCP (perplexity shape) reaches .mcp.json
  - HTTP user MCP (notion shape) reaches .mcp.json
  - `false` opt-out sentinel is stripped, not stored
  - user-key wins on collision with a framework MCP
  - scaffold and reconcile emit byte-identical output (mirrors the gdrive parity test)
- [x] All 228 scaffold tests pass.
- [x] tsc --noEmit clean.

## Not in this PR (filed as separate work)

- **Launcher-path-in-container:** user MCPs declared with `command: /host/path/launcher.sh` will now appear in `.mcp.json` but fail at spawn with ENOENT — the host path isn't bind-mounted into the agent container. Separate PR adds a `mcp-launchers/` bind-mount in compose + relocates the operator's `perplexity-mcp.sh`. Pure-HTTP MCPs (carrie's notion) work as soon as this PR lands.
- **Doctor probe:** \"user-declared MCPs configured but not delivered\" — regression guard, separate PR.

## Risk

Behavior change is opt-in by config — only operators who have already declared `mcp_servers` in their yaml see new entries appear in `.mcp.json`. The fleet has two such entries today (perplexity, notion); both are expected to work after fleet reconcile (notion immediately, perplexity after the launcher-mount PR lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)