### PR TITLE
feat(compose): mount ~/.switchroom/mcp-launchers/ for user-declared command-based MCPs

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1682,6 +1682,23 @@ function emitAgentService(
   if (existsSync(`${hostHomeForChecks}/.switchroom/skills`)) {
     lines.push(`      - ${homePrefix}/.switchroom/skills:${homePrefix}/.switchroom/skills:ro`);
   }
+  // Operator-declared MCP launcher dir (#1786 follow-up). Operators who
+  // declare a user-level MCP server with a `command:` host path (e.g.
+  // `defaults.mcp_servers.perplexity.command:
+  // /home/<op>/.switchroom/mcp-launchers/perplexity-mcp.sh`) need that
+  // launcher to resolve INSIDE the agent container too — otherwise the
+  // .mcp.json entry lands (per the scaffold fix) but the launcher
+  // ENOENTs at spawn. Mount the operator's `~/.switchroom/mcp-launchers/`
+  // at the same host-absolute path so the operator's yaml `command:`
+  // value just works in-container. Same-path :ro mount mirrors the
+  // skills/ pattern above; existsSync-guarded so dev installs without
+  // a launcher dir don't hard-fail compose `up`. Pure-URL MCPs (e.g.
+  // notion `type: http`) don't need this mount.
+  if (existsSync(`${hostHomeForChecks}/.switchroom/mcp-launchers`)) {
+    lines.push(
+      `      - ${homePrefix}/.switchroom/mcp-launchers:${homePrefix}/.switchroom/mcp-launchers:ro`,
+    );
+  }
   // PER-AGENT credentials mount (sec WS6-F2, #1390). Previously the
   // ENTIRE `~/.switchroom/credentials/` dir was bind-mounted `:ro`
   // into EVERY agent — so a prompt-injected agent could read every

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -524,6 +524,51 @@ describe("generateCompose", () => {
     }
   });
 
+  it("emits a :ro mount for the operator's mcp-launchers/ dir when present (#1786 follow-up)", async () => {
+    // Operators who declare user-level MCP servers with a host `command:`
+    // path (e.g. defaults.mcp_servers.perplexity.command:
+    // /home/<op>/.switchroom/mcp-launchers/perplexity-mcp.sh) need that
+    // path to resolve INSIDE the agent container too — otherwise the
+    // .mcp.json entry lands but the launcher ENOENTs at spawn. Same-
+    // path :ro mount makes the operator's yaml command Just Work.
+    const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-mcp-launchers-"));
+    mkdirSync(join(tmp, ".switchroom", "mcp-launchers"), { recursive: true });
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+      });
+      expect(out).toContain(
+        `${tmp}/.switchroom/mcp-launchers:${tmp}/.switchroom/mcp-launchers:ro`,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("omits the mcp-launchers mount when the host dir doesn't exist", async () => {
+    // Same `:ro` source absent guard as skills/credentials — docker
+    // compose `up` hard-fails on a missing source. Operators without
+    // any user-declared command-based MCPs simply have no
+    // ~/.switchroom/mcp-launchers/ dir; the mount must be omitted.
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-no-launchers-"));
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+      });
+      expect(out).not.toContain(`/.switchroom/mcp-launchers`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("emits each mount independently when only one host dir exists (#907)", async () => {
     // Vault-only operators commonly have populated skills/ but no
     // filesystem credentials/ (everything via vault). The two


### PR DESCRIPTION
## Summary

Follow-up to PR #1786 (scaffold .mcp.json user-declared MCPs). PR #1786 fixes the writer so user-declared `mcp_servers` from `switchroom.yaml` land in `.mcp.json`. For pure-URL MCPs (e.g. carrie's notion with `type: http`) that's the complete fix. For **command-based** MCPs the launcher path must ALSO resolve inside the agent container — otherwise the entry lands but `spawn` ENOENTs.

This PR adds a `~/.switchroom/mcp-launchers/:~/.switchroom/mcp-launchers/:ro` bind-mount to every agent, mirroring the existing `skills/` mount pattern.

## Why a new convention directory

Pre-fix, the only operator-`~/.switchroom`-prefixed mounts in the agent container were:
- Per-agent subdirs (`agents/<name>`, `audit/<name>`, `credentials/<name>`, `logs/<name>`)
- The operator-shared `skills/` directory and `switchroom.yaml` file

Launchers at arbitrary host paths under `~/.switchroom/` were unreachable from inside the agent. Options considered:

1. **Mount the operator's entire `~/.switchroom/` :ro** — too broad, exposes vault socket / accounts / agents-of-other-names. Rejected.
2. **Bind-mount individual launcher files** — requires scaffold-time path inspection + per-launcher mount emission. Brittle.
3. **Convention directory `~/.switchroom/mcp-launchers/`** — operator drops launchers there, same-path mount makes the yaml `command:` value work in-container. Same pattern as `skills/`. ✅ Chosen.

## What changed

`src/agents/compose.ts` — one new `:ro` mount right after the `skills/` mount, same `existsSync`-guarded pattern:

```typescript
if (existsSync(`${hostHomeForChecks}/.switchroom/mcp-launchers`)) {
  lines.push(
    `      - ${homePrefix}/.switchroom/mcp-launchers:${homePrefix}/.switchroom/mcp-launchers:ro`,
  );
}
```

## Test plan

- [x] 2 new tests in `tests/docker/compose-generator.test.ts`:
  - mcp-launchers dir present → same-path `:ro` mount emitted.
  - dir absent → mount omitted (docker compose `up` hard-fails on a missing `:ro` source — same guard as skills/credentials mounts use).
- [x] 145/145 compose-generator tests pass.
- [x] tsc --noEmit clean.

## Operator-side migration (separate)

The current operator config has `defaults.mcp_servers.perplexity.command: /home/<op>/.switchroom/perplexity-mcp.sh` (host path at the root of `~/.switchroom/`, not under a launchers/ subdir). After this PR lands, the launcher needs to move to `~/.switchroom/mcp-launchers/perplexity-mcp.sh` and the yaml path updated. That's a one-line change in the private `~/.switchroom-config/` repo, tracked separately.

## Risk

`existsSync`-guarded: operators without any user-declared command-based MCPs have no `mcp-launchers/` dir and the mount is silently omitted. No behavior change for any agent until an operator opts in by creating the directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)