### PR TITLE
feat(doctor): probe user-declared MCPs against rendered .mcp.json (#1786 follow-up)

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -17,13 +17,14 @@ import { dirname, join, resolve } from "node:path";
 import { createPublicKey, createPrivateKey } from "node:crypto";
 import { listSecrets, getStringSecret } from "../vault/vault.js";
 import { resolveAgentsDir, resolvePath } from "../config/loader.js";
+import { resolveAgentConfig } from "../config/merge.js";
 import { resolveStatePath, LEGACY_STATE_DIR } from "../config/paths.js";
 import { getConfig, getConfigPath, withConfigError } from "./helpers.js";
 import { getAllAgentStatuses } from "../agents/lifecycle.js";
 import { readQuarantineMarkerForAgent } from "../agents/quarantine.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
 import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
-import type { SwitchroomConfig } from "../config/schema.js";
+import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
 import { probeHindsight, isHindsightEnabled } from "../memory/hindsight.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
@@ -439,6 +440,64 @@ export function checkConfig(config: SwitchroomConfig, configPath: string): Check
   });
 
   return results;
+}
+
+/**
+ * Cross-reference user-declared `mcp_servers` (cascade-merged from
+ * `defaults.mcp_servers` + per-agent `agents.<name>.mcp_servers`)
+ * against the keys actually present in the rendered `.mcp.json`. Warns
+ * when an operator declared an MCP server in switchroom.yaml that
+ * never made it into `.mcp.json` — the runtime regression class that
+ * silently shipped from PR #875 (v0.7.6 docker cutover) until PR #1786
+ * (scaffold writer fix).
+ *
+ * `false` opt-out sentinels in the declared map are intentional
+ * suppressions, not missing entries — filtered out before the diff.
+ *
+ * Returns ONE CheckResult per agent (skip when no user-declared
+ * entries; ok when all declared keys are present; warn with the
+ * missing-keys list otherwise).
+ */
+export function checkUserDeclaredMcps(
+  name: string,
+  agentConfig: AgentConfig,
+  config: SwitchroomConfig,
+  renderedMcpServers: Record<string, unknown>,
+): CheckResult {
+  const resolved = resolveAgentConfig(
+    config.defaults,
+    config.profiles,
+    agentConfig,
+  );
+  const declaredMcp = resolved.mcp_servers ?? {};
+  const declaredKeys = Object.entries(declaredMcp)
+    .filter(([, v]) => v !== false)
+    .map(([k]) => k);
+  const renderedKeys = Object.keys(renderedMcpServers);
+  const missing = declaredKeys.filter((k) => !renderedKeys.includes(k));
+
+  if (declaredKeys.length === 0) {
+    return {
+      name: `${name}: user-declared MCPs`,
+      status: "skip",
+      detail: "no user-declared mcp_servers in switchroom.yaml",
+    };
+  }
+  if (missing.length === 0) {
+    return {
+      name: `${name}: user-declared MCPs`,
+      status: "ok",
+      detail:
+        `${declaredKeys.length} declared, all in .mcp.json (${declaredKeys.join(", ")})`,
+    };
+  }
+  return {
+    name: `${name}: user-declared MCPs`,
+    status: "warn",
+    detail:
+      `${missing.length}/${declaredKeys.length} declared but missing from .mcp.json: ${missing.join(", ")}`,
+    fix: `Run \`switchroom agent reconcile ${name} --restart\`. If the entry still doesn't appear, check switchroom.yaml shape (defaults.mcp_servers.<key> or agents.${name}.mcp_servers.<key>).`,
+  };
 }
 
 /**
@@ -1694,6 +1753,19 @@ export function checkAgents(config: SwitchroomConfig, configPath: string): Check
               detail: memoryEnabled ? "switchroom-telegram + hindsight" : "switchroom-telegram",
             });
           }
+
+          // User-declared MCPs configured-vs-delivered check (#1786
+          // follow-up). The cascade-resolved `mcp_servers` (defaults
+          // + per-agent merge) is the operator's contract; the
+          // rendered .mcp.json is what Claude Code actually loads.
+          // Pre-fix (PR #1786) the writer was template-driven and
+          // silently dropped every user-declared entry — perplexity,
+          // notion, etc. all absent from the live fleet despite being
+          // in yaml. This probe surfaces any future regression of the
+          // same class loudly instead of silently.
+          results.push(
+            checkUserDeclaredMcps(name, agentConfig, config, mcp.mcpServers ?? {}),
+          );
         } catch (err) {
           results.push({
             name: `${name}: .mcp.json`,

--- a/tests/doctor.user-declared-mcps.test.ts
+++ b/tests/doctor.user-declared-mcps.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { checkUserDeclaredMcps } from "../src/cli/doctor.js";
+import type {
+  AgentConfig,
+  SwitchroomConfig,
+} from "../src/config/schema.js";
+
+/**
+ * Regression-guard probe for the user-declared-mcp_servers gap
+ * (#1786 follow-up). Tests the cross-reference between cascade-
+ * resolved `mcp_servers` (the operator's contract in switchroom.yaml)
+ * and the rendered `.mcp.json.mcpServers` keys (what Claude Code
+ * actually loads). Pre-fix the writer silently dropped every user-
+ * declared entry; this probe surfaces any recurrence loudly.
+ */
+
+const baseTelegram = {
+  bot_token: "123:abc",
+  forum_chat_id: "-100",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "T",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeConfig(
+  agentName: string,
+  agentConfig: AgentConfig,
+  defaultsMcp?: Record<string, unknown>,
+): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: "~/.switchroom/agents" },
+    telegram: baseTelegram,
+    defaults: defaultsMcp ? { mcp_servers: defaultsMcp } : undefined,
+    agents: { [agentName]: agentConfig },
+  } as unknown as SwitchroomConfig;
+}
+
+describe("checkUserDeclaredMcps (#1786 follow-up)", () => {
+  it("returns skip when no user-declared mcp_servers exist anywhere", () => {
+    const agent = makeAgentConfig();
+    const config = makeConfig("a", agent);
+    // Rendered .mcp.json carries only the framework set.
+    const rendered = {
+      "switchroom-telegram": {},
+      "agent-config": {},
+      hindsight: {},
+    };
+    const r = checkUserDeclaredMcps("a", agent, config, rendered);
+    expect(r.status).toBe("skip");
+    expect(r.detail).toMatch(/no user-declared/);
+  });
+
+  it("returns ok when defaults.mcp_servers.perplexity is in rendered .mcp.json", () => {
+    const agent = makeAgentConfig();
+    const config = makeConfig("a", agent, {
+      perplexity: { command: "/home/op/.switchroom/mcp-launchers/perplexity-mcp.sh" },
+    });
+    const rendered = {
+      "switchroom-telegram": {},
+      perplexity: { command: "/home/op/.switchroom/mcp-launchers/perplexity-mcp.sh" },
+    };
+    const r = checkUserDeclaredMcps("a", agent, config, rendered);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("perplexity");
+  });
+
+  it("returns warn when defaults.mcp_servers.perplexity is missing from rendered .mcp.json (the live fleet pre-#1786 case)", () => {
+    const agent = makeAgentConfig();
+    const config = makeConfig("a", agent, {
+      perplexity: { command: "/home/op/.switchroom/mcp-launchers/perplexity-mcp.sh" },
+    });
+    // Rendered .mcp.json missing perplexity — the bug.
+    const rendered = {
+      "switchroom-telegram": {},
+      "agent-config": {},
+    };
+    const r = checkUserDeclaredMcps("a", agent, config, rendered);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toMatch(/1\/1 declared but missing.*perplexity/);
+    expect(r.fix).toMatch(/switchroom agent reconcile/);
+  });
+
+  it("respects per-agent mcp_servers (carrie's notion shape)", () => {
+    // No defaults, but carrie declares notion at the per-agent level.
+    const agent = makeAgentConfig({
+      mcp_servers: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        notion: { type: "http", url: "https://mcp.notion.com/mcp" } as any,
+      },
+    } as Partial<AgentConfig>);
+    const config = makeConfig("carrie", agent);
+    const renderedMissing = { "switchroom-telegram": {} };
+    expect(checkUserDeclaredMcps("carrie", agent, config, renderedMissing).status).toBe(
+      "warn",
+    );
+    const renderedPresent = {
+      "switchroom-telegram": {},
+      notion: { type: "http", url: "https://mcp.notion.com/mcp" },
+    };
+    expect(checkUserDeclaredMcps("carrie", agent, config, renderedPresent).status).toBe(
+      "ok",
+    );
+  });
+
+  it("merges defaults + per-agent, both must be present in rendered output", () => {
+    const agent = makeAgentConfig({
+      mcp_servers: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        notion: { type: "http", url: "https://mcp.notion.com/mcp" } as any,
+      },
+    } as Partial<AgentConfig>);
+    const config = makeConfig("a", agent, {
+      perplexity: { command: "/launchers/p.sh" },
+    });
+    // Rendered has perplexity but not notion.
+    const rendered = {
+      "switchroom-telegram": {},
+      perplexity: { command: "/launchers/p.sh" },
+    };
+    const r = checkUserDeclaredMcps("a", agent, config, rendered);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toMatch(/notion/);
+    expect(r.detail).not.toMatch(/perplexity.*missing/);
+  });
+
+  it("filters `false` opt-out sentinels from the declared set (not flagged as missing)", () => {
+    // `mcp_servers: { gdrive: false }` is an intentional suppression
+    // of the framework gdrive entry — not a missing user-declared
+    // entry. The probe must not warn on it.
+    const agent = makeAgentConfig({
+      mcp_servers: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        gdrive: false as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        notion: { type: "http", url: "https://mcp.notion.com/mcp" } as any,
+      },
+    } as Partial<AgentConfig>);
+    const config = makeConfig("a", agent);
+    const rendered = {
+      "switchroom-telegram": {},
+      notion: { type: "http", url: "https://mcp.notion.com/mcp" },
+      // gdrive correctly absent because of the opt-out.
+    };
+    const r = checkUserDeclaredMcps("a", agent, config, rendered);
+    expect(r.status).toBe("ok");
+    // The "declared count" should be 1, not 2 (gdrive: false stripped).
+    expect(r.detail).toContain("1 declared");
+    expect(r.detail).not.toMatch(/gdrive/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `switchroom doctor` probe that cross-references the operator's cascade-resolved `mcp_servers` (from switchroom.yaml's `defaults.mcp_servers` + per-agent `agents.<name>.mcp_servers`) against the keys actually present in each agent's rendered `.mcp.json`. The regression-guard that would have caught the bug class fixed in PR #1786 within one `switchroom doctor` invocation.

## Three outcomes per agent

- **skip** — no user-declared `mcp_servers`; nothing to verify.
- **ok** — every declared key is present in `.mcp.json`.
- **warn** — declared but missing keys named explicitly, with `switchroom agent reconcile <name> --restart` as the fix-up.

`false` opt-out sentinels are filtered out before the diff — those are intentional suppressions of framework defaults, not missing entries.

## Why a separate probe rather than expanding the existing `.mcp.json` check

The existing per-agent `.mcp.json` check at `src/cli/doctor.ts:1657-1706` only validates the framework set (`switchroom-telegram` presence, `hindsight` when memory enabled). User-declared entries are a separate concern — different remediation (operator-yaml-side vs reconcile-side), different failure semantics (warn vs fail). Splitting keeps each probe focused on one operator-actionable diagnosis.

## What changed

`src/cli/doctor.ts`:
- New exported `checkUserDeclaredMcps(name, agentConfig, config, renderedMcpServers)` helper that returns ONE `CheckResult`. Cascade-resolves via the existing `resolveAgentConfig` helper so the probe correctly merges `defaults` and per-agent shape.
- Called from the per-agent `.mcp.json` block in `runAgentChecks` after the existing switchroom-telegram/hindsight check.

## Test plan

- [x] 6 new tests in `tests/doctor.user-declared-mcps.test.ts`:
  - skip when no user-declared MCPs anywhere
  - ok when `defaults.mcp_servers.perplexity` is in rendered output
  - warn when it's missing (the live-fleet pre-#1786 case)
  - per-agent `mcp_servers` (carrie's notion shape) — warn + ok cases
  - defaults + per-agent merge — both required in rendered output
  - `false` opt-out sentinels filtered, not flagged
- [x] 162/162 existing doctor tests pass.
- [x] tsc --noEmit clean.

## Risk

Read-only probe. No state change, no remediation triggered automatically. The warn message guides the operator to `switchroom agent reconcile <name> --restart` which is the standard re-scaffold path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)