### PR TITLE
chore: release v0.13.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## v0.13.38 — approval-card collapsed view shows what + why without expanding
+
+### fix(telegram): approval-card collapsed view (#1790, PR #1794)
+
+Skill / MCP / generic-tool permission cards rendered as a single line
+`🔐 Permission: <title>` with the agent's stated rationale and the
+input preview hidden behind "See more". Operators couldn't tell why
+they were being asked to approve. The vault `vault_request_access`
+card already had a multi-line layout — it was the gold standard. This
+release converges all three approval surfaces on the vault layout:
+
+```
+🔐 <agent> · <tool summary>
+why: <description-or-"not provided">
+```
+
+Specifics:
+
+- **`telegram-plugin/permission-title.ts`** — new
+  `formatPermissionCardBody({toolName, inputPreview, description,
+  agentName})` pure function builds the multi-line HTML-escaped body.
+  Always renders the why-line: when the agent omitted `description`,
+  renders `why: <i>not provided</i>` so a missing rationale is visible
+  as an agent-side failure rather than a card-template choice.
+- **Skill summarizer** no longer returns bare `Skill` when no
+  skill-name key matches. Falls through `command` → first scalar arg
+  hint before giving up. Closes the regression that produced
+  "🔐 Permission: Skill" with zero context.
+- **MCP summarizer** appends `(key: value)` for the first scalar arg
+  of any uncurated MCP tool (skips routing-only keys like `chat_id` /
+  `message_thread_id` / `request_id`). Operators see context on
+  third-party / new MCP tools without an expand tap.
+- **`onPermissionRequest`** (`telegram-plugin/gateway/gateway.ts`)
+  switched to the new body builder. Send call now carries
+  `parse_mode: 'HTML'`. Passes `_client.agentName` so the operator
+  sees which agent is asking.
+- **`renderVaultRequestAccessCard`** always renders the why-line —
+  `why: <i>not provided</i>` when reason is missing.
+- **`bridge.ts`** vault tool description nudges agents to supply
+  `reason`; explains that omission will render as "not provided"
+  which operators will usually take as a Deny signal.
+
+UAT on test-harness (bind-mounted dist) triggered the vault card and
+observed clean rendering: `🔐 test-harness wants vault access / key:
+pr1790-uat-fake / scope: read · duration: 30d / why: PR #1790 card
+layout UAT` — no literal HTML tags, parse_mode=HTML honoured.
+
+Out of scope: the expanded "See more" view stays as-is — collapsed-
+view fix only. No bridge / IPC protocol changes (`description` was
+already on the wire from Claude Code's `PermissionRequest` payload).
+
 ## v0.13.37 — user-declared mcp_servers reach .mcp.json (regression class fix)
 
 Audit-driven release closing a class regression that shipped silently

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.13.37",
+  "version": "0.13.38",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Single-fix release: approval-card collapsed view (#1790, PR #1794).

## Test plan

- [x] PR #1794 merged with green CI + APPROVE from fresh reviewer
- [x] Live UAT on test-harness (bind-mounted dist): vault card renders with parse_mode=HTML correctly
- [ ] Post-release: rebuild + verify tarball, npm publish, install local CLI
- [ ] Post-release: wait for docker-images workflow, fleet roll, canary UAT, close #1790

🤖 Generated with [Claude Code](https://claude.com/claude-code)