### PR TITLE
fix: PR #1706 follow-ups — entity decode + draft-id rotation + UAT promotion (#1791, #1792, #1793)

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -244,15 +244,22 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
    * must clear the draft. Best-effort: a failed clear is logged but
    * not re-thrown — the worst case is a transient stale draft that
    * Telegram's own 30 s draft expiry eventually mops up.
+   *
+   * #1792 — accepts an explicit `targetDraftId` so `forceNewMessage`
+   * can clear the OLD id before bumping the closure's `draftId`. The
+   * default reads the live closure, which is what stop() / retract()
+   * want — clear whatever's current at the time the call lands.
    */
-  async function clearDraftBestEffort(): Promise<void> {
-    if (!usesDraftTransport || draftApi == null || draftId == null) return
+  async function clearDraftBestEffort(
+    targetDraftId: number | undefined = draftId,
+  ): Promise<void> {
+    if (!usesDraftTransport || draftApi == null || targetDraftId == null) return
     try {
       const params: { message_thread_id?: number } = {}
       if (threadId != null) params.message_thread_id = threadId
       await draftApi(
         chatId,
-        draftId,
+        targetDraftId,
         '',
         Object.keys(params).length > 0 ? params : undefined,
       )
@@ -531,6 +538,18 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       stopped = false
       materialized = false
       if (usesDraftTransport) {
+        // #1792: clear the OLD draftId BEFORE rotating. Otherwise the
+        // stale content stays in the user's compose box until the 30 s
+        // Telegram draft expiry — the typical caller (gateway.ts mid-
+        // turn rapid-steer path: `forceNewMessage(); stop();`) cleans
+        // up the prior turn's stream, so the prior draft's content is
+        // semantically retracted. Fire-and-forget — forceNewMessage is
+        // sync; the worst-case failure mode is the same 30 s expiry
+        // we'd have had without the call.
+        const staleDraftId = draftId
+        if (staleDraftId != null) {
+          void clearDraftBestEffort(staleDraftId)
+        }
         draftId = allocateDraftId()
       }
       log?.(`answer-stream: forceNewMessage (gen=${generation})`)
@@ -546,6 +565,10 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       // #1704: clear the compose-box draft. stop() is sync — fire and
       // forget. A dropped clear falls back on Telegram's own 30 s
       // draft expiry; the worst case is a transient stale preview.
+      // (#1792: the stale-id-after-rotation hazard is owned by
+      // forceNewMessage itself now — it clears its own draftId before
+      // rotating. stop() just clears whatever's current; clearing an
+      // already-cleared or never-used id is a harmless no-op.)
       void clearDraftBestEffort()
     },
 
@@ -563,6 +586,8 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
       // draft sitting in the user's input area and blocks them from
       // typing until the 30 s draft expiry. Awaited so a follow-up
       // sendMessage on the same chat doesn't race a stale draft edit.
+      // (See #1792 note in stop() — forceNewMessage owns its own stale
+      // id cleanup; retract just clears whatever's current.)
       await clearDraftBestEffort()
       // Delete the preliminary message if one was sent and deleteMessage
       // is wired. Best-effort: failures are logged but not re-thrown.

--- a/telegram-plugin/steering.ts
+++ b/telegram-plugin/steering.ts
@@ -74,21 +74,52 @@ export function escapeXmlAttribute(s: string): string {
 }
 
 /**
+ * Decode the small set of HTML / XML entities switchroom emits when it
+ * renders model output as Telegram HTML. Pre-#1791 this function did
+ * not decode and `formatPriorAssistantPreview` then re-escaped the
+ * already-encoded entities, so a turn containing inline `<code>` would
+ * surface to the model on the next inbound as `&amp;amp;lt;…&amp;amp;gt;`
+ * (triple-encoded). The model had to mentally decode three layers to
+ * recover the original characters it wrote — measurably hostile to
+ * comprehension on turns with placeholders, JSX, XML, generics, etc.
+ *
+ * Decoding before re-escape closes that loop: the attribute boundary
+ * stays safe because `escapeXmlAttribute` runs unchanged at the tail.
+ *
+ * Limited to the canonical six entities — there's no general HTML
+ * entity table here, which keeps the surface predictable.
+ */
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    // `&amp;` last so we don't accidentally re-decode `&amp;lt;` → `<` on
+    // a single pass — the order above relies on `&amp;` still being
+    // intact during the prior replaces.
+    .replace(/&amp;/g, '&')
+}
+
+/**
  * Produce a short, safe preview of the last assistant turn for injection
  * as an XML attribute. Strips HTML tags (so `<b>foo</b>` becomes `foo`),
- * collapses all whitespace runs into single spaces, truncates to
- * `maxChars` visible characters, then XML-escapes.
- *
- * We do NOT decode HTML entities — a literal `&amp;` in the source
- * survives as `&amp;amp;` after escape, which is fine: the attribute is
- * for the model's situational awareness, not faithful rendering.
+ * decodes the canonical six XML entities so the model sees the original
+ * characters (not triple-encoded `&amp;amp;lt;` — see #1791), collapses
+ * all whitespace runs into single spaces, truncates to `maxChars` visible
+ * characters, then XML-escapes for safe attribute injection.
  */
 export function formatPriorAssistantPreview(text: string, maxChars = 200): string {
   // Strip HTML tags. Anything angle-bracketed between < and > goes away;
   // this is deliberately liberal (no tag-name whitelist) because the
   // preview is for the model's eyes only.
   const stripped = text.replace(/<[^>]*>/g, '')
-  const collapsed = stripped.replace(/\s+/g, ' ').trim()
+  // #1791: decode entities BEFORE collapse/truncate/re-escape so the
+  // model sees the prose it actually wrote. The re-escape at the tail
+  // preserves attribute-injection safety.
+  const decoded = decodeXmlEntities(stripped)
+  const collapsed = decoded.replace(/\s+/g, ' ').trim()
   const truncated = collapsed.length > maxChars ? collapsed.slice(0, maxChars) : collapsed
   return escapeXmlAttribute(truncated)
 }

--- a/telegram-plugin/tests/answer-stream.test.ts
+++ b/telegram-plugin/tests/answer-stream.test.ts
@@ -527,6 +527,92 @@ describe('answer-stream — clears sendMessageDraft on terminal paths (#1704)', 
   })
 })
 
+// ─── #1792 — forceNewMessage clears the stale draftId before rotating ───
+//
+// Background: `forceNewMessage()` rotates `draftId` to a fresh allocation
+// so the stream can be re-used for a new turn (typical caller: gateway
+// rapid-steer path in `handleSessionEvent` enqueue branch — calls
+// `forceNewMessage(); stop()` on the prior turn's stream before opening
+// the new turn). Pre-#1792, the rotation orphaned the prior turn's
+// draft content in the user's compose box until Telegram's 30 s draft
+// expiry — `stop()`'s fire-and-forget clear closed over the (now-new)
+// `draftId`, so the clear targeted the unused id, not the stale one.
+//
+// Post-fix: `forceNewMessage` itself clears the stale draftId BEFORE
+// rotating. `stop()` continues to clear whatever draftId is current
+// at the time it runs (defensive, also fine: clearing an unused id
+// is a harmless no-op for the user).
+
+describe('answer-stream — forceNewMessage clears the stale draft before rotating (#1792)', () => {
+  it('clears the pre-rotation draftId when forceNewMessage rotates', async () => {
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    // Open the stream — this allocates draftId N and fires sendDraft(N).
+    stream.update('first turn thought')
+    await flushMicrotasks()
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+    const staleDraftId = (sendMessageDraft.mock.calls[0] as unknown as [string, number, string, unknown])[1]
+    sendMessageDraft.mockClear()
+
+    // Rotate. forceNewMessage must enqueue a clear against the OLD
+    // draftId before bumping to the new allocation — pre-fix the
+    // stale content stayed in the compose box for 30 s.
+    stream.forceNewMessage()
+    await flushMicrotasks()
+
+    expect(sendMessageDraft).toHaveBeenCalledTimes(1)
+    const clearedId = (sendMessageDraft.mock.calls[0] as unknown as [string, number, string, unknown])[1]
+    const clearedText = (sendMessageDraft.mock.calls[0] as unknown as [string, number, string, unknown])[2]
+    expect(clearedId).toBe(staleDraftId)
+    expect(clearedText).toBe('')
+  })
+
+  it('the gateway sequence forceNewMessage(); stop() clears the stale draftId', async () => {
+    // Mirrors the only production caller — telegram-plugin/gateway/
+    // gateway.ts:6476-6477 cleans up the prior turn's answer-stream
+    // before opening a new turn (rapid steer / queue path).
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const sendMessageDraft = makeSendMessageDraft()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: true,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      sendMessageDraft,
+    })
+
+    stream.update('prior turn thought')
+    await flushMicrotasks()
+    const staleDraftId = (sendMessageDraft.mock.calls[0] as unknown as [string, number, string, unknown])[1]
+    sendMessageDraft.mockClear()
+
+    stream.forceNewMessage()
+    stream.stop()
+    await flushMicrotasks()
+
+    // The stale id must have been cleared by ONE of the two calls
+    // (forceNewMessage in this design); the new unused id may also
+    // be cleared by stop() — harmless. The load-bearing invariant
+    // is "the stale id reaches sendMessageDraft('') somewhere".
+    const clearedIds = (sendMessageDraft.mock.calls as unknown as Array<[string, number, string, unknown]>)
+      .filter(c => c[2] === '')
+      .map(c => c[1])
+    expect(clearedIds).toContain(staleDraftId)
+  })
+})
+
 describe('answer-stream — empty / whitespace-only text is a no-op', () => {
   it('update("") does not trigger any transport call', async () => {
     const sendMessage = makeSendMessage()

--- a/telegram-plugin/tests/steering.test.ts
+++ b/telegram-plugin/tests/steering.test.ts
@@ -138,10 +138,43 @@ describe('formatPriorAssistantPreview', () => {
     expect(formatPriorAssistantPreview('a & b < c')).toBe('a &amp; b &lt; c')
   })
 
-  test('does NOT decode HTML entities (documented)', () => {
-    // Entities like &amp; survive as literal "&amp;" through strip and then
-    // get re-escaped to &amp;amp;. Acceptable for a model-facing preview.
-    expect(formatPriorAssistantPreview('a &amp; b')).toBe('a &amp;amp; b')
+  // ─── #1791 — decode entities before re-escape ───────────────────────────
+  // Pre-fix this function did NOT decode, so an already-encoded source
+  // (e.g. the rendered HTML stored in history) was re-escaped on top of
+  // its own encoding. The model saw `&amp;amp;lt;bar&amp;amp;gt;` (triple
+  // encoded) instead of `<bar>`. Decoding before the trim/re-escape pass
+  // closes that loop; the attribute boundary stays safe because
+  // escapeXmlAttribute runs unchanged at the tail.
+
+  test('decodes &amp; before re-escape (single-pass, not triple) — #1791', () => {
+    // Source stored in history as escaped HTML: `a &amp; b`.
+    // Pre-fix output: `a &amp;amp; b`. Post-fix: `a &amp; b` (single).
+    expect(formatPriorAssistantPreview('a &amp; b')).toBe('a &amp; b')
+  })
+
+  test('decodes &lt; / &gt; inside stripped tags — #1791', () => {
+    // The classic #1120 case: model wrote `Path: \`/tmp/foo-<bar>/\``,
+    // markdownToHtml stored it as `<code>/tmp/foo-&lt;bar&gt;/</code>`,
+    // strip removes the <code> tags, decode brings back the angle
+    // brackets, escape re-encodes safely for the attribute.
+    expect(formatPriorAssistantPreview('<code>/tmp/foo-&lt;bar&gt;/</code>'))
+      .toBe('/tmp/foo-&lt;bar&gt;/')
+  })
+
+  test('decodes &quot; / &apos; / &nbsp; — #1791', () => {
+    expect(formatPriorAssistantPreview('say &quot;hi&quot;')).toBe('say &quot;hi&quot;')
+    expect(formatPriorAssistantPreview('it&apos;s here')).toBe("it&apos;s here")
+    expect(formatPriorAssistantPreview('a&nbsp;b')).toBe('a b')
+  })
+
+  test('does not over-decode: bare `&amp;lt;` decodes to `&lt;`, not `<` — #1791', () => {
+    // The decode order (&lt; / &gt; / &quot; / &apos; / &nbsp; first, then
+    // &amp;) ensures a single pass doesn't strip two layers of escape.
+    // A literal `&amp;lt;` in source (i.e. someone deliberately encoded
+    // the word "&lt;") becomes `&lt;` after one decode pass, and then
+    // re-escapes back to `&amp;lt;`. Pin this so the order isn't accidentally
+    // flipped to a re-decode loop.
+    expect(formatPriorAssistantPreview('&amp;lt;')).toBe('&amp;lt;')
   })
 
   test('empty string returns empty', () => {

--- a/telegram-plugin/uat/scenarios/jtbd-pending-progress-html-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-pending-progress-html-dm.test.ts
@@ -1,0 +1,124 @@
+/**
+ * UAT — pending-progress edit preserves HTML formatting (#1698 regression gate).
+ *
+ * Promoted from the one-off `pr1706-pending-progress-html-dm.test.ts`
+ * verification scenario per #1793. The pending-progress / silent-anchor
+ * / answer-stream code family in `telegram-plugin/` all touch the
+ * parse_mode contract on cross-turn edits; the existing UAT suite
+ * (`cross-turn-pending-progress-dm.test.ts`, `jtbd-fast-trivial-dm.test.ts`,
+ * `jtbd-soft-commit-dm.test.ts`) covers cadence / round-trip / pacing
+ * but does NOT pin the parse_mode contract. #1698 shipped to prod and
+ * the existing suite went green throughout — this scenario closes that
+ * blind spot.
+ *
+ * Method:
+ *   1. Ask the agent to send ONE reply with both <b> and <code> via
+ *      the reply tool (default html format).
+ *   2. Dispatch a background bash so the turn ends with pending async.
+ *   3. End turn. Pending-progress activates.
+ *   4. After ~60-90s, observe the first edit. Assert text reads back
+ *      WITHOUT literal `<b>` / `<code>` substrings (Telegram parsed
+ *      under HTML, formatting moved to entities, mtcute Message.text
+ *      returns plain prose). Pre-fix, parse_mode was dropped on the
+ *      edit and the tags would render as literal characters.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spinUp, type ObservedMessage } from "../harness.js";
+
+const SLEEP_SECONDS = 90;
+const OVERALL_DEADLINE_MS = 4 * 60_000;
+
+const PROMPT =
+  `Please run \`sleep ${SLEEP_SECONDS}\` in the background using the ` +
+  `Bash tool with \`run_in_background: true\`. Send exactly ONE reply, ` +
+  `using the reply tool with default html format, containing this text ` +
+  `VERBATIM:\n\n` +
+  `<b>Worker dispatched.</b> Running <code>sleep ${SLEEP_SECONDS}</code> ` +
+  `in background.\n\n` +
+  `Do NOT send any other reply until the sleep finishes. Just dispatch ` +
+  `the bash, send that one HTML reply, end your turn. When it finishes ` +
+  `much later, reply with the single word "done".`;
+
+const SUFFIX_RE = /\n\n— still working \(\d+m\)$/;
+
+describe("uat: pending-progress edit preserves HTML formatting (#1698 regression gate)", () => {
+  it(
+    "first pending-progress edit reads back WITHOUT literal HTML tags",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        const startedAt = Date.now();
+        await sc.sendDM(PROMPT);
+
+        let anchorMsgId: number | null = null;
+        let editText: string | null = null;
+        const deadline = startedAt + OVERALL_DEADLINE_MS;
+
+        while (Date.now() < deadline) {
+          try {
+            const msg = await sc.expectMessage(
+              (m: ObservedMessage) => m.fromBot,
+              { from: "bot", timeout: deadline - Date.now() },
+            );
+            const rel = Date.now() - startedAt;
+            console.log(
+              `[jtbd-pending-progress-html] +${(rel / 1000).toFixed(1)}s ` +
+                `${msg.edited ? "EDIT" : "FRESH"} msg=${msg.messageId} ` +
+                `${JSON.stringify(msg.text.slice(0, 120))}`,
+            );
+            if (!msg.edited && anchorMsgId == null) {
+              anchorMsgId = msg.messageId;
+              continue;
+            }
+            if (
+              msg.edited &&
+              anchorMsgId === msg.messageId &&
+              SUFFIX_RE.test(msg.text)
+            ) {
+              editText = msg.text;
+              break;
+            }
+          } catch {
+            break;
+          }
+        }
+
+        expect(
+          anchorMsgId,
+          "agent never sent its initial HTML reply — UAT env issue",
+        ).not.toBeNull();
+        expect(
+          editText,
+          `no pending-progress edit observed within ${OVERALL_DEADLINE_MS / 1000}s — ` +
+            `model may not have dispatched async, or pending-progress is disabled`,
+        ).not.toBeNull();
+
+        // ── THE #1698 REGRESSION GATE ─────────────────────────────────
+        // mtcute's Message.text returns the parsed text — formatting
+        // lives in `entities`. So a working parse_mode=HTML edit shows
+        // clean prose with no literal "<b>" / "<code>" substrings.
+        // Pre-fix the gateway dropped parse_mode on the cross-turn
+        // edit and Telegram stored the tags as plain characters.
+        expect(
+          editText,
+          `#1698 regression: pending-progress edit text contains literal "<b>" — ` +
+            `parse_mode was dropped and Telegram is storing the original HTML tags as plain.`,
+        ).not.toContain("<b>");
+        expect(editText).not.toContain("</b>");
+        expect(editText).not.toContain("<code>");
+        expect(editText).not.toContain("</code>");
+
+        // Sanity — the model's prose is still visible (without tags).
+        expect(editText).toContain("Worker dispatched");
+
+        // Belt-and-braces — the suffix landed (proves the edit was
+        // pending-progress and not some other path).
+        expect(editText).toMatch(SUFFIX_RE);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    OVERALL_DEADLINE_MS + 30_000,
+  );
+});


### PR DESCRIPTION
Three follow-ups from PR #1706's review pass, batched. Each commit is independent.

## Commits

### \`f716b3e8\` — #1791: decode entities before re-escape in \`formatPriorAssistantPreview\`

\`steering.ts:formatPriorAssistantPreview\` stripped HTML tags and then XML-escaped *without* decoding entities first. So a turn containing inline \`<code>\` (stored in history as \`<code>&lt;…&gt;</code>\`) surfaced to the model on the next inbound's \`prior_assistant_preview\` attribute as \`&amp;amp;lt;…&amp;amp;gt;\` — triple-encoded. The model had to decode three layers to recover the original characters it wrote one turn ago. Fix: decode the canonical six entities (\`&lt;\` / \`&gt;\` / \`&quot;\` / \`&apos;\` / \`&nbsp;\` / \`&amp;\`) after strip and before re-escape. Attribute boundary stays safe because \`escapeXmlAttribute\` runs unchanged at the tail.

### \`a5bf3522\` — #1792: \`forceNewMessage\` clears stale draftId before rotating

PR #1706 added \`clearDraftBestEffort\` to stop() and retract(). Reviewer flagged a race: the only production caller (\`gateway.ts:6476\`) calls \`forceNewMessage(); stop();\`. \`forceNewMessage\` synchronously rotates \`draftId\` to a fresh allocation; stop's fire-and-forget clear then read the NEW (unused) id, leaving the prior turn's stale draft in the compose box until Telegram's 30 s expiry. Fix: \`forceNewMessage\` clears its own draftId BEFORE rotating. \`stop\` and \`retract\` continue to clear whatever's current — defensive, since clearing an unused id is a no-op.

### \`79a935f1\` — #1793: promote pending-progress-html UAT to permanent

The PR #1706 verification scenario (parse_mode-preserved on cross-turn edits) becomes \`jtbd-pending-progress-html-dm.test.ts\`. The pending-progress / silent-anchor / answer-stream family all touch parse_mode on edits; existing UAT pins cadence / round-trip / pacing but not parse_mode. #1698 shipped to prod with the suite green throughout — this closes that blind spot. ~80-90s runtime, part of \`bun run test:uat\`.

## Test plan

- [x] 33 + 50 unit tests added/extended across steering / answer-stream
- [x] 170 telegram-plugin test files / 2825 tests green
- [x] \`bun test\` clean on touched files (83 tests)
- [x] \`tsc --noEmit\` clean
- [x] \`check-bot-api-wrapping.sh\` clean
- [x] \`check-plugin-references.mjs\` clean
- [x] \`check-no-pii-secrets.mjs\` clean
- [ ] Post-merge: release v0.13.39, fleet roll, run the new \`jtbd-pending-progress-html-dm\` UAT against the released image

## Risk

Low. Three independent, narrowly-scoped changes; each has unit-test pinning. The #1791 entity decode is a behaviour change visible to the model — but the prior triple-encoded form was clearly hostile to comprehension, and the fix preserves attribute-injection safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)