### PR TITLE
fix(broker): bind-mount per-agent .vault-token files into vault-broker so mint_grant lands

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -977,6 +977,30 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // ownership doesn't gate the write path. (Same pattern as
   // vault-audit.log above and host-control-audit.log on hostd.)
   lines.push(`      - ${homePrefix}/.switchroom/vault-grants.db:/root/.switchroom/vault-grants.db`);
+  // Per-agent vault-grant token files. The broker's mint_grant
+  // handler (server.ts ~2222) writes the minted token at
+  // `os.homedir() + .switchroom/agents/<agent>/.vault-token`.
+  // Inside the broker container `os.homedir()` is `/root`, so the
+  // unmounted default would write to `/root/.switchroom/agents/<agent>/.vault-token`
+  // — ephemeral, invisible to both the operator host and the
+  // agent containers that need to read the token to authenticate
+  // back to the broker. Pre-fix every fresh mint stranded.
+  //
+  // Bind each per-agent token file at the same path the broker
+  // computes, so writes land on the operator's host fs and the
+  // agent's per-agent dir mount surfaces them inside the agent
+  // container too. Source files are pre-created (mode 0600,
+  // owned by the agent UID) by `ensureHostMountSources` in
+  // apply.ts so docker doesn't auto-create a root-owned directory
+  // here. Broker writes via root with CAP_DAC_OVERRIDE; a
+  // post-write chownSync (server.ts mint_grant) restores agent-UID
+  // ownership after every mint so the agent keeps being able to
+  // read the file from its own peercred identity.
+  for (const a of describeAgents(config)) {
+    lines.push(
+      `      - ${homePrefix}/.switchroom/agents/${a.name}/.vault-token:/root/.switchroom/agents/${a.name}/.vault-token`,
+    );
+  }
   // /etc/machine-id passthrough — required so the broker can derive
   // the same machine-bound key the host's `enable-auto-unlock` used
   // to seal the auto-unlock blob. The agent base image (node:22-bookworm-slim)

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -17,7 +17,7 @@
  */
 import { Option, type Command } from "commander";
 import chalk from "chalk";
-import { accessSync, constants as fsConstants, copyFileSync, existsSync, mkdirSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { accessSync, chownSync, constants as fsConstants, copyFileSync, existsSync, mkdirSync, readdirSync, renameSync, writeFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { spawnSync as childSpawnSync } from "node:child_process";
 import readline from "node:readline";
@@ -356,6 +356,45 @@ async function ensureHostMountSources(config: SwitchroomConfig): Promise<void> {
   const hostdAuditLogPath = join(home, ".switchroom", "host-control-audit.log");
   if (!existsSync(hostdAuditLogPath)) {
     writeFileSync(hostdAuditLogPath, "", { mode: 0o644 });
+  }
+
+  // Per-agent vault-grant token file (`<agentDir>/.vault-token`,
+  // mode 0600). The broker's mint_grant handler (server.ts ~2222)
+  // writes the token at `os.homedir() + .switchroom/agents/<agent>/.vault-token`
+  // — inside the broker container that path is `/root/.switchroom/...`
+  // and was never bind-mounted out, so fresh mints stranded in the
+  // broker's ephemeral filesystem. Operator-side `.vault-token` files
+  // either didn't exist or were stale, and `claude mcp list` shows
+  // "Failed to connect" for any user-declared MCP that relies on
+  // `switchroom vault get <key>` to fetch its API key (e.g. perplexity).
+  // Surfaced 2026-05-25 after the v0.13.37 launcher relocation +
+  // a fleet-wide `vault grant` cycle showed every minted token
+  // missing on the operator side.
+  //
+  // Fix: pre-create the file (so docker compose `up` doesn't
+  // auto-create a directory at this path on a fresh install) and
+  // chown to the agent UID so the agent inside the container can
+  // read it under its own peercred identity. The broker writes via
+  // CAP_DAC_OVERRIDE so its writes succeed regardless of ownership;
+  // a follow-up chownSync in mint_grant restores the agent UID after
+  // every write so subsequent reads from the agent keep working.
+  for (const name of Object.keys(config.agents)) {
+    const tokenPath = join(home, ".switchroom", "agents", name, ".vault-token");
+    if (!existsSync(tokenPath)) {
+      writeFileSync(tokenPath, "", { mode: 0o600 });
+    }
+    // Best-effort chown to the agent UID. allocateAgentUid is the
+    // deterministic UID derivation used by every other per-agent
+    // file (scaffold, broker chown-after-mint). Swallow EPERM on
+    // dev hosts that don't have the permissions — the operator
+    // running apply may not be root, and the existing .vault-token
+    // is already correctly owned in that case.
+    try {
+      const uid = allocateAgentUid(name);
+      chownSync(tokenPath, uid, uid);
+    } catch {
+      /* dev / no CAP_CHOWN — leave existing ownership */
+    }
   }
 }
 

--- a/src/vault/broker/server.ts
+++ b/src/vault/broker/server.ts
@@ -2265,6 +2265,26 @@ export class VaultBroker {
         const tmpPath = `${tokenPath}.tmp.${process.pid}`;
         writeFileSync(tmpPath, mintResult.token, { mode: 0o600 });
         renameSync(tmpPath, tokenPath);
+        // Chown to the agent UID. Without this the file lands root:root
+        // (broker runs as root) — the agent's in-container
+        // `switchroom vault get` would then fall back to the peercred
+        // ACL with no token attached, hitting VAULT-BROKER-DENIED on
+        // every call. Pre-fix this gap was masked because the per-
+        // agent token files weren't bind-mounted into the broker at
+        // all and the write stranded inside the broker's ephemeral
+        // /root/.switchroom. CAP_CHOWN is granted to the broker (see
+        // compose.ts cap_add). Swallow EPERM on dev hosts without
+        // it — the broker still returns the token in the IPC
+        // response, just the on-disk mirror is owner-wrong.
+        try {
+          const uid = allocateAgentUid(agent);
+          chownSync(tokenPath, uid, uid);
+        } catch (chownErr) {
+          process.stderr.write(
+            `[vault-broker] mint_grant: token written but chown failed for agent ${agent}: ` +
+            `${(chownErr as Error).message} (CAP_CHOWN missing?)\n`
+          );
+        }
       } catch (err) {
         // Non-fatal: the token is still returned. File write is best-effort.
         process.stderr.write(

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -810,6 +810,34 @@ describe("generateCompose", () => {
     );
   });
 
+  it("broker bind-mounts each per-agent .vault-token file at /root/.switchroom/agents/<name>/.vault-token", () => {
+    // fails when: mint_grant writes the new token to
+    // `os.homedir() + .switchroom/agents/<agent>/.vault-token` —
+    // inside the broker container that path is `/root/.switchroom/...`,
+    // ephemeral, and invisible to both the operator host and the agent
+    // container. The agent's in-container `switchroom vault get` then
+    // can't read the freshly-minted token, so the broker falls back to
+    // the peercred ACL path and denies any user-declared MCP that
+    // relies on standing grants (e.g. perplexity).
+    //
+    // Surfaced 2026-05-25 after a fleet-wide `switchroom vault grant`
+    // cycle for perplexity/api-key produced grants in the DB (visible
+    // via `vault grants`) but stale on-host token files — every agent
+    // hit VAULT-BROKER-DENIED on perplexity launcher startup.
+    //
+    // Mount is RW (broker writes the token on every mint); pre-created
+    // by `ensureHostMountSources()` in apply.ts so docker doesn't
+    // auto-create a root-owned directory at the mount path.
+    const out = generateCompose({ config: makeConfig({ a: {}, b: {} }) });
+    const block = /vault-broker:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";
+    expect(block).toMatch(
+      /-\s+\$\{HOME\}\/\.switchroom\/agents\/a\/\.vault-token:\/root\/\.switchroom\/agents\/a\/\.vault-token(?!:ro)/,
+    );
+    expect(block).toMatch(
+      /-\s+\$\{HOME\}\/\.switchroom\/agents\/b\/\.vault-token:\/root\/\.switchroom\/agents\/b\/\.vault-token(?!:ro)/,
+    );
+  });
+
   it("kernel keeps CHOWN + FOWNER (mirrors broker socket-ownership flow)", () => {
     const out = generateCompose({ config: makeConfig({ a: {} }) });
     const block = /approval-kernel:[\s\S]*?(?=\n  [a-z])/.exec(out)?.[0] ?? "";


### PR DESCRIPTION
## Summary

Closes a deployment-shape bug surfaced during the 2026-05-25 fleet-wide `vault grant` cycle for perplexity. `mint_grant` writes the freshly-minted capability token at `os.homedir() + .switchroom/agents/<agent>/.vault-token`. Inside the broker container `os.homedir()` is `/root` (broker runs as root) and the broker compose stanza never bind-mounted per-agent dirs — so writes stranded in `/root/.switchroom/agents/<agent>/.vault-token` inside the broker's ephemeral filesystem, invisible to both the operator host and the agent container that needs to read the token.

The grants DB persists (#1737 mount), so `vault grants` shows the grant exists. But the token string never reaches the agent — `switchroom vault get` falls through to the peercred ACL with no token attached, hits `checkAclByAgent`, returns `VAULT-BROKER-DENIED`.

## What changed

Three coordinated changes:

1. **`src/agents/compose.ts`** — one bind-mount per agent in the broker volumes block:
   ```
   - ${HOME}/.switchroom/agents/<name>/.vault-token:/root/.switchroom/agents/<name>/.vault-token
   ```
   Same RW pattern as the existing `vault-audit.log` and `vault-grants.db` mounts.

2. **`src/cli/apply.ts`** (`ensureHostMountSources`) — pre-create each agent's `.vault-token` source file (mode 0600, chown to agent UID via the deterministic `allocateAgentUid`). Docker compose `up` would otherwise auto-create a root-owned directory at the mount path. Mirrors the existing `vault-grants.db` and `host-control-audit.log` pre-create pattern.

3. **`src/vault/broker/server.ts`** mint_grant — `chownSync` the freshly-written token to the agent UID. Without this, broker writes the token root:root (broker is root with CAP_DAC_OVERRIDE) and the agent inside its container can't read it under its peercred identity. CAP_CHOWN is already in the broker's `cap_add`. Swallow EPERM on dev hosts without it — the broker still returns the token in the IPC response, only the on-disk mirror is owner-wrong.

## Test plan

- [x] New `tests/docker/compose-generator.test.ts` case asserts the per-agent token bind-mount is emitted for every configured agent in the broker block. 146/146 compose tests pass.
- [x] 19/19 existing mint-grant bun tests pass (chown emits a one-line warn on EPERM but assertion paths unchanged).
- [x] tsc --noEmit clean.

## Live verification path (after release)

1. `switchroom update` rolls the new compose stanza + apply pre-create + broker image.
2. `switchroom vault grant <agent> --keys <some-key>` mints a grant.
3. `ls -la ~/.switchroom/agents/<agent>/.vault-token` shows the new token, owned by the agent UID.
4. `docker exec switchroom-<agent> sh -lc 'switchroom vault get <some-key>'` returns the value (no DENIED).

## Risk

- Existing operators with stale `.vault-token` files: the pre-create only runs if the file is missing, so existing ones are preserved. Operators who need to re-mint can `vault revoke <id>` + `vault grant <agent> --keys ...` — the new chown ensures the re-minted token lands readable.
- Operators on dev hosts without CAP_CHOWN: the broker swallows the chown EPERM with one stderr line; mints still succeed in the IPC response. The on-disk mirror is owner-wrong (root) but the IPC-bearer agent can pass the token via its own response path — unchanged from today's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)