### PR TITLE
feat(web): surface quota reset times under the 5h/7d % cells

### DIFF
--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -774,16 +774,24 @@
       // usage % cell: live 5h/7d utilization from the last cached
       // probe (cost-gated — see refreshQuota). null → "—" + a per-
       // account ↻ that force-probes. quotaStale → value shown muted
-      // with ↻ to refresh.
-      const pctCell = (pct, label, stale) => {
+      // with ↻ to refresh. When `resetAt` is provided we append a
+      // muted "resets in Xh" line so the operator can see WHEN the
+      // window rolls over without hovering for a tooltip — matches
+      // anthropic-ratelimit-unified-{5h,7d}-reset headers exposed by
+      // the broker probe (src/auth/quota.ts:97-98).
+      const pctCell = (pct, label, stale, resetAt) => {
         if (pct == null) return '<span style="color:var(--text-dim)">—</span>';
         let cls = 'quota-pct';
         if (pct >= 90) cls += ' high';
         else if (pct >= 70) cls += ' mid';
         const v = `${Math.round(pct)}%`;
-        return stale
+        const reset = resetAt
+          ? `<div style="font-size:.72rem;color:var(--text-dim);font-weight:normal;margin-top:.1rem">resets ${formatTimestamp(resetAt)}</div>`
+          : '';
+        const pctSpan = stale
           ? `<span class="${cls}" title="stale — click ↻" style="opacity:.55">${v}</span>`
           : `<span class="${cls}">${v}</span>`;
+        return reset ? `<div>${pctSpan}${reset}</div>` : pctSpan;
       };
       const enriched = accounts.map(a => {
         const q = a.quota || null;
@@ -792,9 +800,8 @@
         return {
           a,
           usedBy: a.usedBy || [],
-          fiveH: pctCell(u ? u.fiveHourPct : null, '5h', a.quotaStale),
-          sevenD: pctCell(u ? u.sevenDayPct : null, '7d', a.quotaStale),
-          fiveReset: u && u.fiveHourResetAt ? formatTimestamp(u.fiveHourResetAt) : '<span style="color:var(--text-dim)">—</span>',
+          fiveH: pctCell(u ? u.fiveHourPct : null, '5h', a.quotaStale, u ? u.fiveHourResetAt : null),
+          sevenD: pctCell(u ? u.sevenDayPct : null, '7d', a.quotaStale, u ? u.sevenDayResetAt : null),
           captured: u && u.capturedAt
             ? formatTimestamp(u.capturedAt)
             : '<span style="color:var(--text-dim)">never</span>',


### PR DESCRIPTION
## Summary

Adds reset-time labels under the 5h/7d % cells on the web portal's Accounts tab. Operators can now see at a glance WHEN an exhausted account will recover, without hovering or clicking through.

## Why

The broker's quota probe (`src/auth/quota.ts:97-98`) already captures `fiveHourResetAt` and `sevenDayResetAt` from the `anthropic-ratelimit-unified-{5h,7d}-reset` response headers. The dashboard API forwards both fields verbatim on `AccountQuotaUsage` (`src/web/api.ts:228-236`, populated at `:361-368`). The Accounts tab rendered the percentages but never surfaced the reset times.

Pre-fix the UI even computed `fiveReset: formatTimestamp(...)` into the enriched row object (`index.html:797`) but never destructured or rendered it anywhere — dead code from a partially-shipped attempt.

## What changed

`src/web/ui/index.html`:
- Extended `pctCell(pct, label, stale, resetAt)` to optionally append a muted `resets in Xh / Yd` line under the percentage when a reset timestamp is available.
- Removed the orphan `fiveReset` field.

Renders inline so no new column is added — table width unchanged. Card view (same `fiveH` / `sevenD` HTML strings) picks it up automatically.

`formatTimestamp` already handles relative future times correctly (`in 3h`, `in 2d 4h`); same helper used by `exhausted_until` and the account expires column.

## Visual

Before:
```
LABEL  HEALTH  USED BY  5H %  7D %  PROBED  ...
ken    healthy ...      2%    91%   0m ago  ...
```

After:
```
LABEL  HEALTH  USED BY  5H %     7D %         PROBED  ...
ken    healthy ...      2%       91%          0m ago  ...
                        resets   resets
                        in 3h    in 2d 4h
```

## Test plan

- [x] tsc --noEmit clean.
- [x] Manual: visited live portal — reset lines now render under the percentages where the broker has them (operators who haven't run a probe yet still see just "—", same as before).

## Risk

Pure presentation. No API change, no schema change. Existing fields that are already populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)