### PR TITLE
fix(#1799 follow-up): apply-side cleanup of stale cron-*.sh + doc sweep

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -265,8 +265,9 @@ per-agent slot model that's no longer needed).
 ## Ephemeral consumers (hindsight et al.)
 
 A non-agent container that needs OAuth credentials (e.g. a
-hindsight instance running `claude -p`) is declared in
-`switchroom.yaml`:
+hindsight instance using the `claude-code` LLM provider — it calls
+the Anthropic API under the consumer's OAuth identity for its own
+summarization / recall) is declared in `switchroom.yaml`:
 
 ```yaml
 auth:

--- a/src/agents/cron-unit-name.ts
+++ b/src/agents/cron-unit-name.ts
@@ -1,41 +1,20 @@
 /**
- * Cron-unit content-hash naming (switchroom #1163, Phase D).
+ * Cron-unit content-hash naming — RETIRED, kept for cleanup only.
  *
- * Pre-Phase-D, each schedule entry materialised as
- * `telegram/cron-<index>.sh` — filename derived purely from declaration
- * order. Two failure modes:
+ * Originally introduced by #1163 (Phase D) to stabilise the filenames
+ * of per-agent `telegram/cron-<sha12>.sh` scripts so an edit
+ * deterministically renamed the on-disk file. Phase 4 cron-fold-in
+ * (#890-#893) retired the `.sh`-generation path entirely — cron now
+ * fires through the in-container `agent-scheduler` sibling via
+ * `inject_inbound` IPC into the live session.
  *
- *   1. Renames/reorders in `switchroom.yaml` shuffle the index → the
- *      file at `cron-0.sh` is now a different task. The Phase F
- *      hot-cron reloader sees that as content drift on a still-named
- *      file and can't tell "task replaced" from "prompt edited".
- *
- *   2. Index-based names give no source-of-origin signal. Phase B
- *      stamps overlay-loaded entries with the `OVERLAY_SOURCE`
- *      symbol, but downstream consumers (reconciler, audit) couldn't
- *      tell main-config from overlay once the script hit disk.
- *
- * Phase D switches to a content hash:
- * `cron-<sha256(cron + prompt)[:12]>.sh`. Scripts live under
- * `<agentDir>/telegram/`, already namespaced by filesystem, so the
- * agent name is intentionally NOT part of the hash input — two agents
- * with identical (cron, prompt) tuples produce the same basename in
- * their own dirs without collision.
- *
- * The hash is:
- *
- *   - deterministic — same inputs always produce the same filename;
- *   - collision-resistant — 48 bits across at most a few dozen entries
- *     per agent is overkill for the use case;
- *   - rename-safe — editing a prompt or cron expression deterministically
- *     renames the on-disk file, so F's reconciler sees "old file gone,
- *     new file appeared" instead of "file X drifted".
- *
- * Migration: `switchroom migrate cron-unit-names` performs a hard-cut
- * rename of any legacy `cron-<digits>.sh` files an agent dir still
- * carries. Idempotent — re-runs are no-ops once the rename has landed.
- * No systemd units are involved: switchroom cron runs as in-container
- * node-cron, so the migration is `.sh`-only.
+ * This file survives only to provide the regexes (`CRON_SCRIPT_
+ * BASENAME_RE` / `LEGACY_CRON_SCRIPT_BASENAME_RE`) the cleanup pass
+ * in `scaffold.ts` uses to identify and delete stale on-disk
+ * artifacts from prior installs. The hash helpers
+ * (`cronUnitHash`/`cronUnitName`/`cronScriptFilename`) are still
+ * exported because the test-suite uses them to compute expected
+ * stale-file paths before asserting deletion.
  */
 import { createHash } from "node:crypto";
 

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -750,18 +750,17 @@ export function getAgentLogs(name: string, follow: boolean): void {
  * agent container.
  *
  * The categories intentionally collapse together:
- *   - "cron"     — `telegram/cron-*.sh` script regeneration (a legacy
- *                  artifact). The Phase-4 in-container agent-scheduler
- *                  (`src/agent-scheduler/`) reads its schedule entries
- *                  from the cascade-resolved config at boot and closes
- *                  over each entry's cron+prompt at registration time —
- *                  it does NOT exec these scripts, nor re-read config
- *                  per fire. So a cron change is observed only after the
- *                  scheduler re-reads config (next container/scheduler
- *                  restart), not "on the next fire". We tag it "cron"
- *                  only so the caller can skip a destructive bounce on a
- *                  prompt tweak (see applyCronChangesHot) — the change
- *                  still waits for the next natural restart.
+ *   - "cron"     — stale `telegram/cron-*.sh` artifacts being swept
+ *                  (post-#1799 cleanup). The Phase-4 in-container
+ *                  agent-scheduler (`src/agent-scheduler/`) reads its
+ *                  schedule entries from the cascade-resolved config at
+ *                  boot and closes over each entry's cron+prompt at
+ *                  registration time — there are no .sh scripts to exec
+ *                  per fire. A schedule edit in the yaml is observed
+ *                  only after the scheduler re-reads config (next
+ *                  container restart). We still tag the .sh-deletion
+ *                  change as "cron" so the caller can skip a destructive
+ *                  bounce when the only change is the cleanup pass.
  *   - "skill"    — `.claude/skills/` symlinks / payload. Phase C will
  *                  build hot-reload for these; for now they still need
  *                  a restart, but we tag them so #1163's Phase C can
@@ -814,14 +813,15 @@ export interface ApplyCronChangesHotResult {
 
 /**
  * Apply cron-only reconcile changes without restarting the agent
- * container. `reconcileAgent` has already rewritten the bind-mounted
- * agent dir (config + legacy `telegram/cron-<i>.sh` scripts). This
- * helper deliberately performs NO restart — so a prompt tweak doesn't
- * kill the running session — but note it also does NOT make the change
- * live: the in-container scheduler snapshots its entries at boot, so
- * the new schedule is observed only on the scheduler's next
- * boot/restart (image pull, OOM bounce, host reboot, or an explicit
- * `switchroom agent restart`).
+ * container. `reconcileAgent` may have swept stale `telegram/cron-*.sh`
+ * artifacts (post-#1799 cleanup) from the bind-mounted agent dir; that
+ * doesn't require a restart because the agent-scheduler never read
+ * those files. This helper deliberately performs NO restart — so a
+ * schedule edit in the yaml doesn't kill the running session — but note
+ * it also does NOT make the change live: the in-container scheduler
+ * snapshots its entries at boot, so the new schedule is observed only
+ * on the scheduler's next boot/restart (image pull, OOM bounce, host
+ * reboot, or an explicit `switchroom agent restart`).
  *
  * This helper exists as a named seam so:
  *   1. Phase F's decision in `reconcileAndRestartAgent` has a single

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2679,9 +2679,29 @@ export function scaffoldAgent(
   // the in-container `agent-scheduler` sibling, which delivers each
   // fire as a synthesized `meta.source="cron"` inbound via
   // `inject_inbound` IPC — there are no more per-agent cron .sh
-  // scripts. See `src/scheduler/dispatch.ts`. The `reconcileAgentDir`
-  // path below removes any stale `cron-*.sh` + `.source` sidecars
-  // left on disk from prior installs.
+  // scripts. See `src/scheduler/dispatch.ts`.
+  //
+  // Sweep any stale `cron-*.sh` + `.source` sidecars from prior
+  // installs. This MUST run from the scaffold path (not just
+  // `reconcileAgentDir`) because `switchroom apply` calls
+  // `scaffoldAgent` — not reconcile — for agents it considers
+  // "up to date". Without this sweep, files left over from the
+  // pre-retirement code path persist across applies until a
+  // separate `switchroom agent reconcile` is run. Idempotent: no-op
+  // when nothing matches.
+  {
+    const telegramDir = join(agentDir, "telegram");
+    if (existsSync(telegramDir)) {
+      for (const file of readdirSync(telegramDir)) {
+        const isCronScript = CRON_SCRIPT_BASENAME_RE.test(file) || LEGACY_CRON_SCRIPT_BASENAME_RE.test(file);
+        if (isCronScript) {
+          unlinkSync(join(telegramDir, file));
+          const sidecar = join(telegramDir, file.replace(/\.sh$/, ".source"));
+          if (existsSync(sidecar)) unlinkSync(sidecar);
+        }
+      }
+    }
+  }
 
   // --- Copy skill files from profile ---
   // Profile-bundled skills land in .claude/skills/ so Claude Code discovers

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -593,12 +593,13 @@ export async function reconcileAndRestartAgent(
   }
 
   // ── Phase F (switchroom#1163): cron-only hot reload ──────────────────────
-  // A `cron:` block edit in switchroom.yaml regenerates
-  // `telegram/cron-<i>.sh` on the host bind-mount. The script content is
-  // live in-container without any docker touch — `docker compose up -d
-  // --force-recreate --no-deps` would needlessly kill any in-flight
-  // Claude session for what's effectively a file edit. So: when every
-  // change in this reconcile is cron-tagged, take the hot path.
+  // Post-#1799 there are no `telegram/cron-*.sh` scripts on disk — cron
+  // fires through the in-container agent-scheduler via inject_inbound
+  // IPC. The "cron" change tag now signals stale-script cleanup (a
+  // file deletion that the agent-scheduler doesn't read, so no restart
+  // is needed) rather than script regeneration. When every change in
+  // this reconcile is cron-tagged, take the hot path — no docker bounce
+  // for what's effectively a tidy-up.
   //
   // Most-restrictive wins: any single non-cron change in `allChanges`
   // falls through to the bot-token preflight + restart path below.

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -3111,6 +3111,35 @@ describe("scheduled task: cron-*.sh retirement (Phase 4 cron-fold-in)", () => {
     expect(existsSync(join(result.agentDir, "telegram", `${stem0}.source`))).toBe(false);
   });
 
+  it("scaffoldAgent ALSO deletes stale cron-*.sh + .source from prior installs", () => {
+    // Regression for the apply-side gap: `switchroom apply` calls
+    // `scaffoldAgent` (not `reconcileAgentDir`) for agents it considers
+    // "up to date". Without a sweep here, stale `cron-*.sh` files from
+    // pre-#1799 installs persist across applies. This test pins the
+    // sweep into the scaffold path.
+    const agentConfig = makeAgentConfig({
+      schedule: [{ cron: "0 6 * * *", prompt: "irrelevant" }],
+    });
+    // Pre-create a stale .sh + .source pair (simulating a v0.13.39-or-
+    // older agent dir that still has the dormant `claude -p` cron
+    // script on disk).
+    const telegramDir = join(tmpDir, "scaffold-cleanup", "telegram");
+    mkdirSync(telegramDir, { recursive: true });
+    const staleStem = cronUnitName("0 6 * * *", "irrelevant");
+    const staleScriptPath = join(telegramDir, `${staleStem}.sh`);
+    const staleSourcePath = join(telegramDir, `${staleStem}.source`);
+    writeFileSync(staleScriptPath, "#!/bin/bash\nclaude -p 'stale'\n", { mode: 0o700 });
+    writeFileSync(staleSourcePath, "main\n");
+    expect(existsSync(staleScriptPath)).toBe(true);
+    expect(existsSync(staleSourcePath)).toBe(true);
+
+    // Run scaffoldAgent — it should sweep the stale files even though
+    // it never had any reason to write a fresh one (and never will).
+    scaffoldAgent("scaffold-cleanup", agentConfig, tmpDir, telegramConfig);
+    expect(existsSync(staleScriptPath)).toBe(false);
+    expect(existsSync(staleSourcePath)).toBe(false);
+  });
+
   it("reconcileAgentDir deletes stale cron-*.sh + .source from prior installs", () => {
     const agentConfig = makeAgentConfig({
       schedule: [{ cron: "0 6 * * *", prompt: "irrelevant" }],


### PR DESCRIPTION
## Why

Rolling v0.13.40 to the live fleet caught two follow-ups for the #1799 retirement:

### 1. Apply-side cleanup gap

PR #1799 added the stale-script sweep to `reconcileAgentDir`, but `switchroom apply` calls `scaffoldAgent` (not reconcile) for agents it considers \"up to date\". On the live host's first apply after rolling v0.13.40, agents **with** `schedule:` entries (clerk, gymbro, finn) still had their dormant `cron-*.sh` + `.source` files on disk because the scaffold path had no sweep.

This PR moves the sweep into `scaffoldAgent` so apply sweeps regardless of which code path it takes per agent. Idempotent: no-op when nothing matches.

### 2. Stale docs/comments

Several modules' headers and inline comments still described the cron-script generation as live / regenerated. Updated:

- `src/agents/cron-unit-name.ts` header
- `src/agents/lifecycle.ts:753-810` (change-kind classification)
- `src/cli/agent.ts:597` (Phase F hot-reload note)
- `docs/auth.md:268` (\"hindsight instance running `claude -p`\" — was always inaccurate; hindsight uses the `claude-code` LLM provider over the Anthropic API)

## Test plan

- [x] tsc clean
- [x] New `scaffoldAgent ALSO deletes stale cron-*.sh + .source` test
- [x] 173 scaffold tests pass
- [x] Live host: manual cleanup already swept the residual files
- [ ] CI green
- [ ] After next `switchroom apply`, no `cron-*.sh` in any agent's `telegram/` dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)