### PR TITLE
fix(telegram): clearSilentEndState evicts pre-#1664 legacy-format files

### DIFF
--- a/telegram-plugin/silent-end.ts
+++ b/telegram-plugin/silent-end.ts
@@ -150,6 +150,18 @@ export function writeSilentEndState(
  * Called the moment a reply / stream_reply first-emit lands so the
  * Stop hook doesn't fire a stale block on the next stop.
  *
+ * Pre-#1664 (`commit f664cde8`) state files lacked a `turnKey` field
+ * entirely. The strict `prev.turnKey !== turnKey` check meant
+ * `undefined !== <anything>` was always true, so legacy files survived
+ * every clear path and remained readable by the Stop hook indefinitely.
+ * In production this stranded clerk with `retryCount=1` for ~hours
+ * across two container restarts, breaking the Stop hook's retry budget
+ * for every subsequent silent-end (the 2026-05-25 incident).
+ *
+ * Tolerance: treat a missing `prev.turnKey` as "stale unknown, unlink
+ * it" rather than "preserve". Strict comparison still applies when
+ * both sides are present, so the same-turn invariant is preserved.
+ *
  * Fail-silent: missing file, mismatched turnKey, or read/unlink errors
  * are all benign. The Stop hook itself defends against stale files via
  * the retryCount mechanism.
@@ -159,7 +171,7 @@ export function clearSilentEndState(turnKey: string, deps?: SilentEndDeps): void
   if (!existsSync(statePath)) return
   try {
     const prev = JSON.parse(readFileSync(statePath, 'utf8')) as Partial<SilentEndState>
-    if (prev.turnKey !== turnKey) return
+    if (prev.turnKey != null && prev.turnKey !== turnKey) return
     unlinkSync(statePath)
     emitLog(deps, `silent-end: cleared state file turnKey=${turnKey}\n`)
   } catch {

--- a/telegram-plugin/tests/silent-end.test.ts
+++ b/telegram-plugin/tests/silent-end.test.ts
@@ -106,6 +106,30 @@ describe('silent-end.ts — gateway state writer', () => {
     expect(() => clearSilentEndState('123:_')).not.toThrow()
   })
 
+  it('clearSilentEndState unlinks a pre-#1664 legacy-format file (no turnKey field)', () => {
+    // 2026-05-25 incident: clerk had a stale `{retryCount:1,timestamp:...}`
+    // file with NO `turnKey` field — written by a pre-#1664 build before
+    // the chatId/threadId/turnKey schema landed. The strict
+    // `prev.turnKey !== turnKey` check meant `undefined !== <anything>`
+    // returned true and every clear callsite no-op'd against it. The file
+    // survived two container restarts. When a new turn ended silently
+    // ~hours later, the Stop hook read the stale retryCount=1 and bailed
+    // without re-prompting, leaving the user with no reply for 5 minutes
+    // (until the framework's silence-poke fallback fired).
+    //
+    // Contract: any clearSilentEndState call must be able to evict a
+    // legacy file whose turnKey is missing. Strict matching still applies
+    // when both sides have a turnKey (the `clearSilentEndState leaves the
+    // file alone when turnKey does NOT match` test above pins that).
+    const path = join(stateDir, 'silent-end-pending.json')
+    writeFileSync(path, JSON.stringify({ retryCount: 1, timestamp: 1779692417907 }))
+    expect(existsSync(path)).toBe(true)
+
+    clearSilentEndState('any-turn-key-here')
+
+    expect(existsSync(path)).toBe(false)
+  })
+
   it('writeSilentEndState handles corrupt prior file by resetting retryCount', () => {
     const path = join(stateDir, 'silent-end-pending.json')
     writeFileSync(path, 'not valid json {{{')


### PR DESCRIPTION
## Summary

One-line widening at \`telegram-plugin/silent-end.ts:162\` so \`clearSilentEndState\` can actually evict pre-#1664 legacy-format silent-end state files. Without this, legacy files survive every clear path forever and break the Stop hook's retry budget on any subsequent silent-end for the affected agent.

## The incident this fixes

2026-05-25 around 17:15 Melbourne, clerk failed to deliver a reply to the user. Forensic trace:

- clerk's \`/state/agent/telegram/silent-end-pending.json\` contained \`{\"retryCount\":1,\"timestamp\":1779692417907}\` — no \`turnKey\` field, no \`chatId\` field. Pre-#1664 (\`commit f664cde8\`) legacy schema.
- File survived two container restarts (06:15 and 06:44 UTC).
- At 17:15 a fresh turn ended silently — model emitted \`type:\"text\"\` with \`stop_reason:\"end_turn\"\` instead of calling the reply tool.
- The Stop hook (\`telegram-plugin/hooks/silent-end-interrupt-stop.mjs\`) read \`retryCount=1 >= MAX_RETRIES=1\` and allowed stop without re-prompting.
- User got no reply until the gateway's silence-poke framework-fallback fired its canned 46-byte nudge ~5 min later.

## Root cause

\`silent-end.ts:162\` was:

\`\`\`ts
if (prev.turnKey !== turnKey) return
\`\`\`

Pre-#1664 files have no \`turnKey\` field. \`undefined !== <anything>\` is always true, so the function returned without unlinking. Every \`clearSilentEndState\` callsite (outbound reply at \`gateway.ts:4486\`, stream_reply at 5023, wedge resolution at 3266, exhaustion at \`silent-end.ts:236\`) silently no-op'd against the legacy file.

## Fix

\`\`\`ts
if (prev.turnKey != null && prev.turnKey !== turnKey) return
\`\`\`

Missing \`prev.turnKey\` is now treated as \"stale unknown — unlink it\" instead of \"preserve it\". Strict matching still applies when both sides have a turnKey, so current-format files are unaffected.

The next outbound reply (or any other clear callsite) naturally cleans up legacy files. No boot-clear or schema migration needed.

## Review history

Two rounds of fresh-process design review.

- **R1** mistakenly identified the bug as a shape mismatch between \`statusKey\` (chat:thread) and a turnKey supposedly stored as \`chat:thread:startTs\`. Proposed a four-callsite refactor.
- **R2** (fresh context, BLOCKED R1's plan) verified against live disk: finn's current-format file stores \`turnKey:\"8248703757:_\"\` — same \`chat:thread\` shape \`statusKey\` returns. The three \"broken\" callsites are NOT broken. The actual bug is that clerk's file is pre-#1664 legacy format with no \`turnKey\` at all.

R2 was correct; this PR ships the minimal one-line fix R2 recommended.

## What this does NOT fix

- The model still occasionally emits text+end_turn instead of calling the reply tool. That's the *trigger* condition the Stop hook exists to recover from. This PR restores the recovery path against legacy files; the model behavior itself is out of scope (visible-answer-stream territory, #1672).
- A separate companion PR addresses **Bug Y**: the current-format \`retryCount\` inherits across turns when \`prev.turnKey === args.turnKey\` (silent-end.ts:114) because turnKeys lack a per-instance suffix. finn hit this today (separate stuck file with retryCount=1). The companion PR adds a turn-start clear at \`gateway.ts:6228\`.

## Test plan

- [x] New regression: \`clearSilentEndState unlinks a pre-#1664 legacy-format file (no turnKey field)\` — writes a legacy \`{retryCount,timestamp}\` file, calls \`clearSilentEndState\` with any turnKey, asserts gone.
- [x] Pinned by existing test \`clearSilentEndState leaves the file alone when turnKey does NOT match\` (line 94 → now line 99 post-insertion): current-format mismatch still preserves.
- [x] \`vitest run telegram-plugin/tests/silent-end.test.ts\` → 39/39 pass (38 existing + 1 new).
- [x] \`npm run lint\` clean.
- [ ] Post-merge canary: after rollout, on the next outbound reply from clerk, the legacy state file should be unlinked. Verify via \`docker exec switchroom-clerk ls /state/agent/telegram/silent-end-pending.json\` — should be ENOENT.

## Risk

Trivial. Pure widening — current-format behavior is unchanged. Legacy-format files become evictable, which is the intended invariant (they should have been clearable from day one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)