### PR TITLE
fix(telegram): reset silent-end retry budget at turn-start

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6503,6 +6503,23 @@ function handleSessionEvent(ev: SessionEvent): void {
         currentTurn = next
         // #549 fix — fresh turn, reset preamble-suppression state.
         preambleSuppressor.reset()
+        // Reset the silent-end retry budget for this chat. The stored
+        // turnKey is `chat:thread` shape (no per-instance suffix), so
+        // without an explicit per-turn clear, `writeSilentEndState`
+        // (silent-end.ts:114) inherits `retryCount` across turns
+        // whenever a prior turn for the same chat hit retryCount=1.
+        // The Stop hook then sees `retryCount >= MAX_RETRIES=1` on the
+        // very first silent-end of every subsequent turn and bails
+        // without re-prompting. finn hit this on 2026-05-25 with a
+        // stuck retryCount=1 file. A new turn invalidates any prior
+        // turn's retry budget by definition; clear it eagerly here.
+        // ev.threadId is `string | null` (Telegram's wire shape);
+        // statusKey wants `number | null` — same conversion as the
+        // registry-key branch a few lines down.
+        clearSilentEndState(statusKey(
+          ev.chatId,
+          ev.threadId != null ? Number(ev.threadId) : null,
+        ))
         // Stage 3b: stamp turn-start in the registry. turn_key is
         // chat:thread:startTs — unique per turn, distinct from the
         // progress-card-driver's per-chat sequence number (these are two

--- a/telegram-plugin/tests/silent-end.test.ts
+++ b/telegram-plugin/tests/silent-end.test.ts
@@ -62,6 +62,38 @@ describe('silent-end.ts — gateway state writer', () => {
     expect(state!.retryCount).toBe(0)
   })
 
+  it('turn-start clear pattern resets retryCount for a new turn on the same chat', () => {
+    // 2026-05-25 finn incident: the stored turnKey is `chat:thread`
+    // shape (no per-instance startedAt suffix). When a prior turn for
+    // a chat left the silent-end-pending.json at retryCount=1 (Stop
+    // hook had incremented but no successful reply cleared it),
+    // writeSilentEndState on the next silent-end for the SAME chat
+    // matches `prev.turnKey === args.turnKey` and inherits
+    // retryCount=1 — so the Stop hook bails on the very first
+    // silent-end of the new turn without re-prompting.
+    //
+    // The gateway's fix (gateway.ts:6503) calls
+    // clearSilentEndState(statusKey(chatId, threadId)) at turn-start.
+    // This test pins the contract: clear-then-write yields
+    // retryCount=0, not the inherited 1.
+    const path = join(stateDir, 'silent-end-pending.json')
+    // Prior turn left retryCount=1 stuck on this chat.
+    writeFileSync(path, JSON.stringify({
+      chatId: '12345', threadId: null, turnKey: '12345:_',
+      retryCount: 1, timestamp: 0,
+    }))
+
+    // Gateway turn-start hook fires for a NEW turn on the same chat.
+    clearSilentEndState('12345:_')
+    expect(existsSync(path)).toBe(false)
+
+    // The new turn later ends silent → writeSilentEndState writes
+    // fresh state. Without the turn-start clear above, retryCount
+    // would have inherited as 1 (per the test at line 42 above).
+    writeSilentEndState({ chatId: '12345', threadId: null, turnKey: '12345:_' })
+    expect(readSilentEndState()!.retryCount).toBe(0)
+  })
+
   it('writeSilentEndState falls back to ~/.claude/channels/telegram when TELEGRAM_STATE_DIR is unset', () => {
     // Updated 2026-05-13 UAT overnight: discovered the writer used to
     // silently no-op when the env var was unset, while the Stop hook


### PR DESCRIPTION
## Summary

One-line addition at \`telegram-plugin/gateway/gateway.ts:6503\` (the turn-start point, immediately after \`currentTurn = next\`): call \`clearSilentEndState(statusKey(ev.chatId, ev.threadId))\` so the Stop hook's retry budget resets to zero on every new turn instead of inheriting from prior turns.

## The bug being fixed

\`writeSilentEndState\` (\`telegram-plugin/silent-end.ts:114\`) inherits \`retryCount\` when \`prev.turnKey === args.turnKey\`. The stored turnKey is \`chat:thread\` shape (no per-instance startedAt suffix — verified: finn's live file stores \`turnKey:\"<chat>:_\"\`), so every turn for the same chat shares the same turnKey and inherits its prior retry counter.

Failure mode: once any turn ends silent and the Stop hook bumps retryCount to 1 (the MAX_RETRIES=1 ceiling), every subsequent silent-end on that chat is stuck at the ceiling. The hook bails on the very first silent-end of the new turn without re-prompting.

## Live evidence

finn's stuck state file (mtime 2026-05-25 17:44 Melbourne):

\`\`\`json
{\"retryCount\":1,\"timestamp\":...,\"turnKey\":\"<chat>:_\",\"chatId\":\"<chat>\"}
\`\`\`

Gateway log on finn shows **32** \`silence-poke framework-fallback ended wedged turn\` events. Each one is a turn the Stop hook should have re-prompted but didn't — fixed only by the gateway's 5-minute silence-poke framework-fallback firing its canned 46-byte nudge.

## Fix

\`\`\`ts
currentTurn = next
preambleSuppressor.reset()
clearSilentEndState(statusKey(
  ev.chatId,
  ev.threadId != null ? Number(ev.threadId) : null,
))
\`\`\`

A new turn invalidates any prior turn's retry budget by definition. The next silent-end starts fresh at retryCount=0 and gets its full Stop-hook re-prompt.

Threading detail: \`ev.threadId\` is \`string | null\` (Telegram wire shape); \`statusKey\` wants \`number | null\`, so we apply the same conversion the existing registry-key branch uses a few lines down (\`evThreadIdNum\`).

## Why not change the turnKey shape

Adding \`:startedAt\` to the turnKey would also fix the inheritance, but it'd ripple through every reader (Stop hook, recordSilentTurnEnd, writeSilentEndState's inherit check, the gateway's three other clear callsites). One-line eager clear is strictly smaller blast radius.

## Relationship to PR #1804 (Bug X — legacy-format files)

Companion PR #1804 fixes a separate bug: pre-#1664 legacy-format files with no \`turnKey\` field at all (clerk's case). Both PRs are independent; can land in either order.

Neither PR fixes the underlying model behavior of emitting \`type:\"text\"\` + \`stop_reason:\"end_turn\"\` instead of calling the reply tool. That's the trigger condition the Stop hook exists to recover from; PRs #1804 + this PR together restore the recovery path to working order, but the trigger itself is out of scope (visible-answer-stream territory, #1672, currently shelved).

## Test plan

- [x] New regression at \`telegram-plugin/tests/silent-end.test.ts\`: \`turn-start clear pattern resets retryCount for a new turn on the same chat\` — pins the contract that clear-then-write yields \`retryCount=0\`, not the inherited 1.
- [x] Three-part contract pinned across silent-end.test.ts:
  - Inherits when same turnKey (line 42, unchanged)
  - Resets when different turnKey (line 53, unchanged)
  - Resets when explicitly cleared between turns (line 64, new)
- [x] \`vitest run telegram-plugin/tests/silent-end.test.ts\` → 39/39 pass
- [x] \`npm run lint\` clean (no PII, no bot-api allowlist drift — gateway insert verified clean per \`feedback_gateway_bot_api_allowlist_drift\`)
- [ ] Post-merge canary: after rollout, finn's stuck file should clear at the next inbound. Verify by sending a test DM and checking \`docker exec switchroom-finn cat /state/agent/telegram/silent-end-pending.json\` — should be ENOENT until the turn ends silent (if it does).

## Risk

Low. Pure additive call at a well-defined state-machine transition (turn-start). Cannot lose data that a prior turn legitimately needed — the only thing erased is the retry counter, which by definition belongs to a turn that has already ended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)