### PR TITLE
fix(broker): ACL grants user-declared mcp_servers.*.secrets[] keys

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,6 +157,69 @@ defaults:
     playwright: false   # opt-out: no agent gets the browser MCP unless they explicitly enable it
 ```
 
+### Wiring an MCP server that needs vault secrets
+
+The common pattern for adding a third-party MCP server is:
+
+1. **Drop a launcher script** into `~/.switchroom/mcp-launchers/`. The directory is bind-mounted into every agent container at the same path (since v0.13.36 / PR #1787) so any executable there is reachable from inside an agent without rebuilding the image.
+2. **Store the API key** in the vault: `switchroom vault set <service>/api-key`.
+3. **Have the launcher fetch the key at spawn** via `switchroom vault get <service>/api-key` (this asks the vault-broker, no operator prompt needed).
+4. **Declare the MCP server + its vault dependency** in `switchroom.yaml`:
+
+```yaml
+defaults:
+  mcp_servers:
+    perplexity:
+      command: /home/<operator>/.switchroom/mcp-launchers/perplexity-mcp.sh
+      # Vault keys the launcher will fetch via `switchroom vault get`.
+      # The broker grants these to every agent that inherits this MCP
+      # entry through the cascade. Without this declaration, the
+      # launcher will hit VAULT-BROKER-DENIED at spawn time.
+      secrets: [ perplexity/api-key ]
+```
+
+The `secrets:` array is the **broker-ACL declaration**: it tells the vault-broker which keys an agent running this MCP is allowed to fetch under its own peercred identity. No per-agent `vault grant` ceremony required.
+
+Example launcher (`~/.switchroom/mcp-launchers/perplexity-mcp.sh`):
+
+```bash
+#!/bin/bash
+set -euo pipefail
+export PERPLEXITY_API_KEY="$(switchroom vault get perplexity/api-key)"
+exec npx -y @perplexity-ai/mcp-server "$@"
+```
+
+**Opt-out per agent** works as usual:
+
+```yaml
+agents:
+  some-agent:
+    mcp_servers:
+      perplexity: false   # this agent doesn't get perplexity (or its vault grant)
+```
+
+The `false` opt-out drops the ACL grant too — the broker won't serve `perplexity/api-key` to an agent that disabled the MCP.
+
+**Multiple secrets per server** are supported — list them all:
+
+```yaml
+defaults:
+  mcp_servers:
+    notion:
+      command: /home/operator/.switchroom/mcp-launchers/notion-mcp.sh
+      secrets: [ notion/api-key, notion/workspace-id ]
+```
+
+**Special cases that don't need this declaration:**
+
+- **gdrive** — wired through `google_workspace.google_client_secret` + `google_accounts.<email>.enabled_for[]` (RFC G §4.4). The broker's ACL has a dedicated clause for the Google OAuth client credential and per-account token slots; `mcp_servers.gdrive.secrets:` is not required. See [google-workspace.md](google-workspace.md) for the full setup.
+- **switchroom-telegram** — agent's effective `bot_token` is granted to that agent via a dedicated ACL clause (the per-agent `bot_token` override or the global `telegram.bot_token`).
+- **hindsight** — runs as an HTTP server on the host; no vault keys at launcher spawn.
+
+If you're wiring **any other** third-party MCP that needs a vault key, use the `secrets:` field above. The fault-mode for a missing declaration is silent: `claude mcp list` will report the server as "Failed to connect" because the launcher hits `VAULT-BROKER-DENIED` and the upstream MCP rejects on missing env.
+
+The `switchroom doctor` health check confirms the broker is reachable; an MCP-specific reachability probe is on the follow-up list.
+
 ## Progress-Card Tunable Thresholds
 
 When `channels.telegram.stream_mode` is `checklist` (the default), the progress-card driver manages an edit-in-place Telegram message that tracks tool calls and sub-agent activity during a turn. The five knobs below control how it handles edge cases — timeouts, JSONL gaps, and Telegram API rate limits.

--- a/docs/vault-broker.md
+++ b/docs/vault-broker.md
@@ -31,9 +31,21 @@ arbitrary scripts.
 | Caller context | Broker access |
 |---|---|
 | Scheduled run for `agent-<name>` (via that agent's bound socket) | Allowed if the requested key is in `schedule[N].secrets` |
+| MCP-server launcher for `agent-<name>` (via that agent's bound socket) | Allowed if the requested key is in any of the agent's effective `mcp_servers.<name>.secrets` |
 | Interactive shell (`switchroom vault get`) | **Denied** — use `--no-broker` |
 | Claude Code / agent session | **Denied** — use `--no-broker` |
 | Any other caller | **Denied** |
+
+### Identity-bound ACL exceptions
+
+The broker grants four classes of identity-bound keys to an agent under its own peercred (path-as-identity), in addition to the schedule.secrets allowlist:
+
+1. **Agent's own `bot_token`** — the gateway reads `agents.<name>.bot_token` (per-agent override) or falls back to `telegram.bot_token` (global). The ACL grants exactly that resolved key to the owning agent.
+2. **Google OAuth client credential** — `google_workspace.google_client_secret` (and `_id`) when the agent has `gdrive` MCP enabled. Gated by the same `shouldEmitGdriveMcp` predicate the scaffold uses, so the broker and scaffold can't disagree. See [google-workspace.md](google-workspace.md).
+3. **Google account slot tokens** — `google:<account>:<field>` keys, gated by `google_accounts.<account>.enabled_for[]` per RFC G §4.4.
+4. **User-declared MCP-server secrets** — any key listed in the agent's effective `mcp_servers.<name>.secrets[]` (post-cascade). Generalises the gdrive special-case to every operator-declared MCP launcher. See [configuration.md § Wiring an MCP server that needs vault secrets](configuration.md#wiring-an-mcp-server-that-needs-vault-secrets) for the operator-facing how-to. Added in v0.13.42.
+
+These four exceptions are checked **before** the schedule.secrets allowlist; an MCP-only agent (no cron schedule) still serves its MCP secrets correctly because the exceptions short-circuit the "no schedule → deny all" early return.
 
 Identity is **path-as-identity**: compose binds one socket per agent at
 `/run/switchroom/broker/<agent>/sock`, chowned to that agent's UID at

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1061,7 +1061,20 @@ function filterMcpServers(
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(servers)) {
     if (value === false) continue; // opt-out: skip this server
-    out[key] = value;
+    if (value != null && typeof value === "object" && !Array.isArray(value)) {
+      // Strip switchroom-internal fields before they reach .mcp.json
+      // (#1806). Currently just `secrets:` — the broker-ACL declaration
+      // for vault keys the launcher will fetch (see vault-broker.md).
+      // Claude Code ignores unknown fields, but leaking the field
+      // (a) clutters .mcp.json which agents may read directly, and
+      // (b) discloses which vault keys an MCP needs to anything that
+      // can read the file. Discloses key NAMES only (not values), but
+      // there's no upside to keeping it.
+      const { secrets: _secrets, ...rest } = value as Record<string, unknown>;
+      out[key] = rest;
+    } else {
+      out[key] = value;
+    }
   }
   return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -592,3 +592,174 @@ describe("ACL: Google OAuth client credential (RFC G §4.4 completion)", () => {
     expect(checkAclByAgent(config, "klanker", "stripe/api-key").allow).toBe(false);
   });
 });
+
+// ─── User-declared MCP-server secrets (PR #1799 follow-up) ────────────
+//
+// Operators wire MCP servers via `defaults.mcp_servers.<name>` in
+// switchroom.yaml; the cascade merges the entry onto every agent that
+// inherits defaults. Pre-fix the ACL only honored `schedule.secrets[]`,
+// so an MCP server whose launcher fetched its API key from the vault
+// (e.g. perplexity, notion) was broker-denied at spawn and silently
+// failed to connect. The new clause grants any key declared in the
+// agent's effective `mcp_servers.<name>.secrets[]`, generalising the
+// gdrive client-secret special-case to every user-declared MCP.
+
+describe("ACL: user-declared MCP-server secrets", () => {
+  // Helper — builds a config with one MCP server entry on the agent's
+  // post-cascade `mcp_servers` map (callers can assume cascade already
+  // ran). The ACL is index-blind to where the entry came from.
+  function mcpConfig(opts: {
+    agent: string;
+    mcpEntries?: Record<string, unknown>;
+    schedule?: Array<{ cron: string; prompt: string; secrets?: string[] }>;
+  }): SwitchroomConfig {
+    return {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      agents: {
+        [opts.agent]: {
+          topic_name: opts.agent,
+          ...(opts.mcpEntries ? { mcp_servers: opts.mcpEntries } : {}),
+          schedule: (opts.schedule ?? []).map((s) => ({
+            cron: s.cron,
+            prompt: s.prompt,
+            secrets: s.secrets ?? [],
+          })),
+        },
+      },
+    } as unknown as SwitchroomConfig;
+  }
+
+  it("allows a key declared under an effective mcp_servers entry", () => {
+    const config = mcpConfig({
+      agent: "clerk",
+      mcpEntries: {
+        perplexity: {
+          command: "/path/to/perplexity-mcp.sh",
+          secrets: ["perplexity/api-key"],
+        },
+      },
+    });
+    expect(checkAclByAgent(config, "clerk", "perplexity/api-key").allow).toBe(true);
+  });
+
+  it("allows even when the agent has zero schedule entries (MCP-only agent)", () => {
+    // The MCP-secret clause must short-circuit BEFORE the no-schedule
+    // early-deny — otherwise a long-running agent that uses MCPs but
+    // declares no cron would never see any broker-accessible keys.
+    const config = mcpConfig({
+      agent: "ziggy",
+      mcpEntries: {
+        notion: {
+          command: "/path/to/notion-mcp.sh",
+          secrets: ["notion/api-key"],
+        },
+      },
+      // intentionally no schedule
+    });
+    expect(checkAclByAgent(config, "ziggy", "notion/api-key").allow).toBe(true);
+  });
+
+  it("falls through to schedule.secrets for keys not in any mcp_servers entry", () => {
+    const config = mcpConfig({
+      agent: "clerk",
+      mcpEntries: {
+        perplexity: {
+          command: "/path/to/perplexity-mcp.sh",
+          secrets: ["perplexity/api-key"],
+        },
+      },
+      schedule: [
+        { cron: "0 * * * *", prompt: "p", secrets: ["microsoft/ken-tokens"] },
+      ],
+    });
+    expect(checkAclByAgent(config, "clerk", "microsoft/ken-tokens").allow).toBe(true);
+  });
+
+  it("denies a key not declared in MCP-secrets or schedule.secrets", () => {
+    const config = mcpConfig({
+      agent: "clerk",
+      mcpEntries: {
+        perplexity: {
+          command: "/path/to/perplexity-mcp.sh",
+          secrets: ["perplexity/api-key"],
+        },
+      },
+    });
+    const r = checkAclByAgent(config, "clerk", "stripe/api-key");
+    expect(r.allow).toBe(false);
+    if (!r.allow) {
+      expect(r.reason).toContain("stripe/api-key");
+    }
+  });
+
+  it("ignores `false` MCP entries (the per-agent opt-out shape)", () => {
+    // An agent that opts out of an inherited MCP (`mcp_servers:
+    // { perplexity: false }`) must NOT keep ACL access to its secrets.
+    // `false` is not an object, so Object.values + the typeof guard
+    // naturally skips it.
+    const config = mcpConfig({
+      agent: "carrie",
+      mcpEntries: { perplexity: false },
+    });
+    expect(
+      checkAclByAgent(config, "carrie", "perplexity/api-key").allow,
+    ).toBe(false);
+  });
+
+  it("ignores entries with no `secrets` array — declaring an MCP doesn't auto-grant keys", () => {
+    // The grant is opt-in per-MCP — an entry without `secrets:` gets
+    // nothing. Operators have to declare what their launcher will
+    // actually read.
+    const config = mcpConfig({
+      agent: "clerk",
+      mcpEntries: { perplexity: { command: "/path/to/perplexity-mcp.sh" } },
+    });
+    expect(
+      checkAclByAgent(config, "clerk", "perplexity/api-key").allow,
+    ).toBe(false);
+  });
+
+  it("ignores non-array `secrets` values (defensive against bad yaml)", () => {
+    const config = mcpConfig({
+      agent: "clerk",
+      mcpEntries: {
+        perplexity: {
+          command: "/path/to/perplexity-mcp.sh",
+          // operator typo — string instead of array
+          secrets: "perplexity/api-key" as unknown as string[],
+        },
+      },
+    });
+    expect(
+      checkAclByAgent(config, "clerk", "perplexity/api-key").allow,
+    ).toBe(false);
+  });
+
+  it("does not cross agents — one agent's MCP secret stays on that agent", () => {
+    const config = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      agents: {
+        clerk: {
+          topic_name: "clerk",
+          mcp_servers: {
+            perplexity: {
+              command: "/path/to/perplexity-mcp.sh",
+              secrets: ["perplexity/api-key"],
+            },
+          },
+        },
+        gymbro: {
+          topic_name: "gymbro",
+          // gymbro has perplexity DISABLED — must not get the key
+          mcp_servers: { perplexity: false },
+        },
+      },
+    } as unknown as SwitchroomConfig;
+    expect(checkAclByAgent(config, "clerk", "perplexity/api-key").allow).toBe(true);
+    expect(checkAclByAgent(config, "gymbro", "perplexity/api-key").allow).toBe(false);
+  });
+});

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -231,9 +231,14 @@ export function checkAcl(
  *         gated by the same `shouldEmitGdriveMcp` predicate the scaffold
  *         uses (config/google-workspace-acl.ts).
  *       · the agent's own effective `bot_token` vault ref.
- *   - If the agent has no `schedule` array (or empty) → deny: there's no
- *     declared per-cron secrets[] to consult. Long-running agent-direct
- *     access is opted in only via populated `schedule[i].secrets`.
+ *       · user-declared MCP-server secrets — any key listed under
+ *         `mcp_servers.<name>.secrets[]` in the effective (post-cascade)
+ *         config for this agent. Generalises the gdrive special-case
+ *         above so operator-declared MCPs (perplexity, notion, etc.)
+ *         can fetch their API keys at launcher spawn time without
+ *         per-agent `vault grant` ceremony.
+ *   - If the agent has no `schedule` array (or empty) AND no MCP-secret
+ *     match above → deny: nothing is broker-accessible.
  *   - If `key` appears in ANY schedule entry's secrets[] → allow. We
  *     deliberately do not require the caller to identify which schedule
  *     index they are; the broker container has no way to know that, and
@@ -317,11 +322,41 @@ export function checkAclByAgent(
     }
   }
 
+  // User-declared MCP-server secrets (#1790 follow-up — generalises
+  // the gdrive `google/client-secret` special-case above). Operators
+  // declare an MCP server's vault dependencies inline:
+  //
+  //   defaults:
+  //     mcp_servers:
+  //       perplexity:
+  //         command: /path/to/perplexity-mcp.sh
+  //         secrets: [ perplexity/api-key ]
+  //
+  // The cascade resolves `mcp_servers.perplexity` onto every agent
+  // that inherits defaults; the declared `secrets` array becomes
+  // broker-accessible to that agent under its own peercred identity.
+  //
+  // Checked BEFORE the no-schedule early-deny below so an MCP-only
+  // agent (no cron schedule) can still serve user-declared MCPs.
+  // The check tolerates `false` opt-outs (the `mcp_servers: { gdrive:
+  // false }` shape used to disable an inherited MCP) because
+  // Object.entries skips them naturally — a `false` entry has no
+  // `secrets[]` to consult.
+  const mcpServers = (agentConfig as { mcp_servers?: Record<string, unknown> })
+    .mcp_servers ?? {};
+  for (const mcpEntry of Object.values(mcpServers)) {
+    if (!mcpEntry || typeof mcpEntry !== "object") continue;
+    const declared = (mcpEntry as { secrets?: unknown }).secrets;
+    if (Array.isArray(declared) && declared.includes(key)) {
+      return { allow: true };
+    }
+  }
+
   const schedule = agentConfig.schedule ?? [];
   if (schedule.length === 0) {
     return {
       allow: false,
-      reason: `agent '${agentName}' has no schedule entries declaring 'secrets'; nothing is broker-accessible`,
+      reason: `agent '${agentName}' has no schedule entries declaring 'secrets' and no mcp_servers.*.secrets[] declaring '${key}'; nothing is broker-accessible`,
     };
   }
 

--- a/tests/scaffold.mcp-json-user-declared.test.ts
+++ b/tests/scaffold.mcp-json-user-declared.test.ts
@@ -254,4 +254,44 @@ describe("scaffold/reconcile: user-declared mcp_servers reach .mcp.json", () => 
 
     expect(afterReconcile).toBe(afterScaffold);
   });
+
+  // ─── #1806 — switchroom-internal `secrets:` field is stripped from
+  // .mcp.json so vault key names aren't leaked to the in-container
+  // Claude session.
+  it("strips the `secrets:` field from rendered .mcp.json (#1806)", () => {
+    const name = "perplexity-agent";
+    const agentConfig = makeAgentConfig({
+      mcp_servers: {
+        perplexity: {
+          command: "/home/test/launchers/perplexity-mcp.sh",
+          // switchroom-internal: declares which vault keys the broker
+          // will serve to this agent. Must not reach .mcp.json.
+          secrets: ["perplexity/api-key"],
+        },
+      },
+    } as Partial<AgentConfig>);
+    const switchroomConfig = {
+      switchroom: {
+        version: 1,
+        agents_dir: "~/.switchroom/agents",
+        skills_dir: "~/.switchroom/skills",
+      },
+      telegram: telegramConfig,
+      agents: { [name]: agentConfig },
+    } as unknown as SwitchroomConfig;
+
+    const res = scaffoldAgent(
+      name,
+      agentConfig,
+      agentsDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+
+    const mcpJson = JSON.parse(readFileSync(join(res.agentDir, ".mcp.json"), "utf-8"));
+    expect(mcpJson.mcpServers.perplexity).toEqual({
+      command: "/home/test/launchers/perplexity-mcp.sh",
+    });
+    expect(mcpJson.mcpServers.perplexity).not.toHaveProperty("secrets");
+  });
 });


### PR DESCRIPTION
## Problem

User-declared MCP servers in switchroom.yaml (perplexity, notion, any operator-added entry) whose launcher fetches its API key from the vault via \`switchroom vault get <key>\` were broker-denied at spawn time. The vault-broker ACL (\`src/vault/broker/acl.ts:checkAclByAgent\`) only special-cased three identity-bound exceptions — Google account slots, gdrive's \`google/client-secret\`, per-agent \`telegram-bot-token\` — plus the union of \`schedule[].secrets[]\`. Any launcher-time vault fetch outside those clauses hit \`VAULT-BROKER-DENIED\`, the launcher exported an empty env var, and the upstream MCP server hard-rejected on missing key.

Live repro 2026-05-25 (clerk): \`mcp__switchroom-telegram\` / \`agent-config\` / \`hindsight\` / \`gdrive\` connected fine; \`perplexity\` reported "Failed to connect". Launcher trace:

\`\`\`
$ docker exec switchroom-clerk sh -lc '/home/kenthompson/.switchroom/mcp-launchers/perplexity-mcp.sh </dev/null'
VAULT-BROKER-DENIED [DENIED]: key 'perplexity/api-key' not in ACL for agent 'clerk'
Error: PERPLEXITY_API_KEY environment variable is required
\`\`\`

The path was wired through recently — PR #1786 (scaffold writes user-declared MCPs), #1787 (compose mounts the launcher dir), #1798 (broker mint_grant persists tokens) — but the ACL plumbing was the missing piece.

## Fix

Generalise the gdrive \`google/client-secret\` special-case into a per-MCP \`secrets:\` declaration on each \`mcp_servers.<name>\` entry. Operators opt in inline:

\`\`\`yaml
defaults:
  mcp_servers:
    perplexity:
      command: /home/kenthompson/.switchroom/mcp-launchers/perplexity-mcp.sh
      secrets: [ perplexity/api-key ]
\`\`\`

The cascade resolves \`mcp_servers.perplexity\` onto every agent that inherits defaults; the declared \`secrets[]\` array is then broker-accessible to that agent under its peercred identity. No per-agent \`vault grant\` ceremony required.

- Checked BEFORE the no-schedule early-deny so an MCP-only agent (no cron) still works.
- \`false\` opt-outs (\`mcp_servers: { perplexity: false }\` per-agent) are respected — \`Object.values\` + \`typeof\` guard skips them naturally.
- Opt-in per-MCP — an entry without \`secrets:\` gets nothing. Operators have to declare what their launcher will actually read; this preserves the gdrive-style auth-boundary discipline rather than auto-granting from launcher introspection.
- Schema needs no change — \`mcp_servers\` is \`z.record(z.string(), z.unknown())\`, so the new field is just data.

## Tests

8 new ACL unit tests + 38 existing pass (46 total):
- cascade-resolved entry → allow
- MCP-only agent (no schedule) → allow
- fall-through to schedule.secrets for unrelated keys → allow
- unlisted key → deny
- \`false\` opt-out → drops ACL access
- missing \`secrets:\` field → deny (opt-in per-MCP)
- defensive against non-array \`secrets\` values → deny
- cross-agent isolation — clerk's perplexity grant doesn't reach gymbro

## Operator follow-up

After merge + release: operator config (\`~/.switchroom-config/switchroom.yaml\`) adds \`secrets: [perplexity/api-key]\` under \`defaults.mcp_servers.perplexity\`. \`switchroom apply\` then propagates the ACL to every agent via the cascade.

## Test plan

- [x] 46 ACL unit tests pass (vitest + bun)
- [x] Full src/vault + tests/ suite green (5443 tests pass)
- [x] tsc / check-bot-api-wrapping / check-plugin-references / check-no-pii-secrets all clean
- [ ] Post-merge: release v0.13.42, fleet roll, operator config commit, verify clerk perplexity round-trip

## Risk

Low. Additive ACL clause — can only allow more, never deny existing accesses. Schema field is optional. The existing schedule.secrets, gdrive, bot-token, google-slot paths are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)