### PR TITLE
fix(broker): mcp_servers.secrets[] ACL consults defaults too (#1806 cascade follow-up)

### DIFF
--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -737,6 +737,96 @@ describe("ACL: user-declared MCP-server secrets", () => {
     ).toBe(false);
   });
 
+  // ─── #1806 follow-up: defaults-cascade ─────────────────────────────
+  // The broker loads raw yaml; cascade was open-coded inline in the
+  // ACL clause. Pre-this-fix the read was per-agent-only, so an MCP
+  // declared in defaults (the documented common case for perplexity)
+  // was never seen by the ACL — every agent that inherited it via
+  // cascade hit VAULT-BROKER-DENIED. Discovered live 2026-05-25 on
+  // clerk against v0.13.42.
+
+  it("allows a key declared under defaults.mcp_servers (cascade)", () => {
+    const config = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      defaults: {
+        mcp_servers: {
+          perplexity: {
+            command: "/path/to/perplexity-mcp.sh",
+            secrets: ["perplexity/api-key"],
+          },
+        },
+      },
+      agents: {
+        clerk: { topic_name: "clerk" },
+      },
+    } as unknown as SwitchroomConfig;
+    expect(checkAclByAgent(config, "clerk", "perplexity/api-key").allow).toBe(true);
+  });
+
+  it("per-agent override of a defaults MCP entry wins (replaces secrets too)", () => {
+    // Per `src/config/merge.ts:391-397` the cascade is per-key shallow:
+    // an agent's mcp_servers.perplexity FULLY replaces the defaults
+    // entry rather than partial-merging. So if the agent re-declares
+    // perplexity, only its own `secrets:` apply.
+    const config = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      defaults: {
+        mcp_servers: {
+          perplexity: {
+            command: "/default/launcher.sh",
+            secrets: ["perplexity/api-key"],
+          },
+        },
+      },
+      agents: {
+        clerk: {
+          topic_name: "clerk",
+          mcp_servers: {
+            perplexity: {
+              command: "/clerk-custom-launcher.sh",
+              secrets: ["perplexity/api-key", "perplexity/extra-key"],
+            },
+          },
+        },
+      },
+    } as unknown as SwitchroomConfig;
+    // Both the inherited key and the per-agent-only key are accessible
+    // because the agent's full override re-declares both.
+    expect(checkAclByAgent(config, "clerk", "perplexity/api-key").allow).toBe(true);
+    expect(checkAclByAgent(config, "clerk", "perplexity/extra-key").allow).toBe(true);
+  });
+
+  it("per-agent `false` opt-out drops the inherited MCP's grant (cascade)", () => {
+    // The shallow merge applies `false` over the defaults entry; the
+    // typeof guard then skips it.
+    const config = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      defaults: {
+        mcp_servers: {
+          perplexity: {
+            command: "/path/to/launcher.sh",
+            secrets: ["perplexity/api-key"],
+          },
+        },
+      },
+      agents: {
+        clerk: {
+          topic_name: "clerk",
+          mcp_servers: { perplexity: false },
+        },
+      },
+    } as unknown as SwitchroomConfig;
+    expect(
+      checkAclByAgent(config, "clerk", "perplexity/api-key").allow,
+    ).toBe(false);
+  });
+
   it("does not cross agents — one agent's MCP secret stays on that agent", () => {
     const config = {
       switchroom: { version: 1 },

--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -827,6 +827,119 @@ describe("ACL: user-declared MCP-server secrets", () => {
     ).toBe(false);
   });
 
+  // ─── #1810 follow-up: profile-layer cascade ──────────────────────────
+  // Per `src/config/merge.ts:resolveAgentConfig` the canonical cascade
+  // is 3-layer: defaults → profiles.<agent.extends> → agent.
+  // ProfileSchema accepts `mcp_servers` by design, so an operator can
+  // declare an MCP under a custom profile and expect every agent
+  // extending that profile to inherit it. Pin the profile layer.
+
+  it("allows a key declared under profiles.<extends>.mcp_servers (cascade)", () => {
+    const config = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      profiles: {
+        coding: {
+          mcp_servers: {
+            github: {
+              command: "/path/to/github-mcp.sh",
+              secrets: ["github/api-token"],
+            },
+          },
+        },
+      },
+      agents: {
+        clerk: { topic_name: "clerk", extends: "coding" },
+      },
+    } as unknown as SwitchroomConfig;
+    expect(checkAclByAgent(config, "clerk", "github/api-token").allow).toBe(true);
+  });
+
+  it("agent without extends does NOT inherit a profile's mcp_servers", () => {
+    const config = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      profiles: {
+        coding: {
+          mcp_servers: {
+            github: {
+              command: "/path/to/github-mcp.sh",
+              secrets: ["github/api-token"],
+            },
+          },
+        },
+      },
+      agents: {
+        clerk: { topic_name: "clerk" }, // no extends
+      },
+    } as unknown as SwitchroomConfig;
+    expect(checkAclByAgent(config, "clerk", "github/api-token").allow).toBe(false);
+  });
+
+  it("per-agent override beats the profile's MCP entry", () => {
+    // Layer order: defaults → profile → agent. The agent's per-key
+    // entry fully replaces the profile's.
+    const config = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      profiles: {
+        coding: {
+          mcp_servers: {
+            github: {
+              command: "/profile/github.sh",
+              secrets: ["github/api-token"],
+            },
+          },
+        },
+      },
+      agents: {
+        clerk: {
+          topic_name: "clerk",
+          extends: "coding",
+          mcp_servers: {
+            github: {
+              command: "/clerk/custom-github.sh",
+              secrets: ["github/api-token", "github/extra-scope"],
+            },
+          },
+        },
+      },
+    } as unknown as SwitchroomConfig;
+    expect(checkAclByAgent(config, "clerk", "github/api-token").allow).toBe(true);
+    expect(checkAclByAgent(config, "clerk", "github/extra-scope").allow).toBe(true);
+  });
+
+  it("per-agent `false` over a profile MCP drops the grant", () => {
+    const config = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      profiles: {
+        coding: {
+          mcp_servers: {
+            github: {
+              command: "/path/to/github-mcp.sh",
+              secrets: ["github/api-token"],
+            },
+          },
+        },
+      },
+      agents: {
+        clerk: {
+          topic_name: "clerk",
+          extends: "coding",
+          mcp_servers: { github: false },
+        },
+      },
+    } as unknown as SwitchroomConfig;
+    expect(
+      checkAclByAgent(config, "clerk", "github/api-token").allow,
+    ).toBe(false);
+  });
+
   it("does not cross agents — one agent's MCP secret stays on that agent", () => {
     const config = {
       switchroom: { version: 1 },

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -332,19 +332,31 @@ export function checkAclByAgent(
   //         command: /path/to/perplexity-mcp.sh
   //         secrets: [ perplexity/api-key ]
   //
-  // The cascade resolves `mcp_servers.perplexity` onto every agent
-  // that inherits defaults; the declared `secrets` array becomes
-  // broker-accessible to that agent under its own peercred identity.
+  // The check consults the EFFECTIVE (post-cascade) mcp_servers map —
+  // per-key shallow merge of defaults + per-agent overrides, mirroring
+  // `src/config/merge.ts:391-397`. The broker loads raw yaml without
+  // running the full cascade pipeline (that lives in resolveAgentConfig
+  // / mergeAgentConfig and is too expensive per ACL request), so the
+  // mcp_servers cascade is open-coded here. Defaults-only MCPs (the
+  // common case — perplexity declared once in defaults, inherited by
+  // every agent) are correctly granted; per-agent additions still win
+  // on key conflict; per-agent `false` opt-outs drop the grant
+  // because the typeof guard below skips non-object entries.
+  //
+  // #1806 (v0.13.42) shipped the per-agent-only read; the
+  // defaults-cascade was missed and only surfaced when an operator
+  // tried to wire perplexity for an agent that inherited the MCP
+  // from defaults rather than declaring it per-agent. Fixed here.
   //
   // Checked BEFORE the no-schedule early-deny below so an MCP-only
   // agent (no cron schedule) can still serve user-declared MCPs.
-  // The check tolerates `false` opt-outs (the `mcp_servers: { gdrive:
-  // false }` shape used to disable an inherited MCP) because
-  // Object.entries skips them naturally — a `false` entry has no
-  // `secrets[]` to consult.
-  const mcpServers = (agentConfig as { mcp_servers?: Record<string, unknown> })
-    .mcp_servers ?? {};
-  for (const mcpEntry of Object.values(mcpServers)) {
+  const effectiveMcp: Record<string, unknown> = {
+    ...((config as { defaults?: { mcp_servers?: Record<string, unknown> } })
+      .defaults?.mcp_servers ?? {}),
+    ...((agentConfig as { mcp_servers?: Record<string, unknown> })
+      .mcp_servers ?? {}),
+  };
+  for (const mcpEntry of Object.values(effectiveMcp)) {
     if (!mcpEntry || typeof mcpEntry !== "object") continue;
     const declared = (mcpEntry as { secrets?: unknown }).secrets;
     if (Array.isArray(declared) && declared.includes(key)) {

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -333,26 +333,42 @@ export function checkAclByAgent(
   //         secrets: [ perplexity/api-key ]
   //
   // The check consults the EFFECTIVE (post-cascade) mcp_servers map —
-  // per-key shallow merge of defaults + per-agent overrides, mirroring
-  // `src/config/merge.ts:391-397`. The broker loads raw yaml without
-  // running the full cascade pipeline (that lives in resolveAgentConfig
-  // / mergeAgentConfig and is too expensive per ACL request), so the
-  // mcp_servers cascade is open-coded here. Defaults-only MCPs (the
-  // common case — perplexity declared once in defaults, inherited by
-  // every agent) are correctly granted; per-agent additions still win
-  // on key conflict; per-agent `false` opt-outs drop the grant
-  // because the typeof guard below skips non-object entries.
+  // per-key shallow merge of defaults + extends-profile + per-agent
+  // overrides, mirroring `src/config/merge.ts:resolveAgentConfig` (the
+  // 3-layer pipeline at lines 168-211) and the field-level merge at
+  // lines 391-397. The broker loads raw yaml without running the full
+  // cascade pipeline (it pulls in env merges, deprecation-warn side
+  // effects, and is too expensive per ACL request), so the
+  // mcp_servers-only cascade is open-coded here.
   //
-  // #1806 (v0.13.42) shipped the per-agent-only read; the
-  // defaults-cascade was missed and only surfaced when an operator
-  // tried to wire perplexity for an agent that inherited the MCP
-  // from defaults rather than declaring it per-agent. Fixed here.
+  // Layer order matches the canonical cascade:
+  //   1. defaults.mcp_servers
+  //   2. profiles.<agent.extends>.mcp_servers   (if extends is set)
+  //   3. agents.<name>.mcp_servers
+  //
+  // Per-key shallow merge — a later layer's entry FULLY REPLACES an
+  // earlier layer's entry at that key. `false` opt-outs survive the
+  // merge as the literal value and are then skipped by the typeof
+  // guard below.
+  //
+  // History:
+  //   #1806 (v0.13.42) shipped per-agent-only read — defaults invisible.
+  //   #1810 (this fix) added the defaults + profile cascade.
   //
   // Checked BEFORE the no-schedule early-deny below so an MCP-only
   // agent (no cron schedule) can still serve user-declared MCPs.
+  const cfgWithProfiles = config as {
+    defaults?: { mcp_servers?: Record<string, unknown> };
+    profiles?: Record<string, { mcp_servers?: Record<string, unknown> }>;
+  };
+  const profileName = (agentConfig as { extends?: string }).extends;
+  const profileMcp =
+    profileName != null && profileName.length > 0
+      ? (cfgWithProfiles.profiles?.[profileName]?.mcp_servers ?? {})
+      : {};
   const effectiveMcp: Record<string, unknown> = {
-    ...((config as { defaults?: { mcp_servers?: Record<string, unknown> } })
-      .defaults?.mcp_servers ?? {}),
+    ...(cfgWithProfiles.defaults?.mcp_servers ?? {}),
+    ...profileMcp,
     ...((agentConfig as { mcp_servers?: Record<string, unknown> })
       .mcp_servers ?? {}),
   };


### PR DESCRIPTION
## Problem

PR #1806 (v0.13.42) added the \`mcp_servers.<name>.secrets[]\` ACL clause but only read \`agentConfig.mcp_servers\`. The broker loads raw yaml via \`loadConfig\` — no cascade — so an MCP declared once in \`defaults.mcp_servers\` (the documented common case for perplexity / notion / etc.) was never visible to the ACL. Agents that inherited the entry through the cascade still hit \`VAULT-BROKER-DENIED\`.

Live repro (clerk on v0.13.42 just now):

\`\`\`yaml
# ~/.switchroom/switchroom.yaml
defaults:
  mcp_servers:
    perplexity:
      command: /home/kenthompson/.switchroom/mcp-launchers/perplexity-mcp.sh
      secrets: [ perplexity/api-key ]
\`\`\`

\`\`\`
$ docker exec switchroom-clerk sh -lc 'switchroom vault get perplexity/api-key'
VAULT-BROKER-DENIED [DENIED]: key 'perplexity/api-key' not in ACL for agent 'clerk'
\`\`\`

## Fix

Open-code the per-key shallow merge in the ACL — mirrors \`src/config/merge.ts:391-397\`. Full cascade pipeline (\`resolveAgentConfig\` / \`mergeAgentConfig\`) would be too expensive per ACL request and pull in deeper machinery (extends: profiles, env merges, etc.); the ACL only needs to know "which mcp_servers entries are effectively live for this agent".

\`\`\`ts
const effectiveMcp: Record<string, unknown> = {
  ...(config.defaults?.mcp_servers ?? {}),
  ...(agentConfig.mcp_servers ?? {}),
};
\`\`\`

\`false\` opt-outs still drop the grant because the shallow merge applies \`false\` over the defaults entry and the typeof guard skips non-object values.

## Tests

3 new ACL cases (49 total in file):

- defaults-only MCP entry → allow (the regressed path)
- per-agent override re-declares secrets → both inherited and new keys accessible
- per-agent \`false\` opt-out over a defaults entry → denied

## Risk

Low. Additive — can only grant more, never deny existing accesses. The shallow merge matches the documented mcp_servers cascade semantics. Existing schedule.secrets, gdrive, bot-token, google-slot paths untouched.

## Test plan

- [x] 49 ACL unit tests pass
- [x] tsc clean
- [ ] Post-merge: release v0.13.43, fleet roll, verify clerk \`switchroom vault get perplexity/api-key\` succeeds, verify perplexity MCP connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)