### PR TITLE
fix(telegram): bump SILENT_END_MAX_RETRIES 1 → 2

### DIFF
--- a/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
+++ b/telegram-plugin/hooks/silent-end-interrupt-stop.mjs
@@ -62,7 +62,8 @@ import { scanTurnForFinalReply } from './silent-end-scan.mjs'
 
 // MUST stay in sync with SILENT_END_MAX_RETRIES in telegram-plugin/silent-end.ts
 // (this hook is a standalone .mjs and can't import the TS module).
-const MAX_RETRIES = 1
+// Bumped 1 → 2 on 2026-05-25 — see the matching doc-comment in silent-end.ts.
+const MAX_RETRIES = 2
 
 function readStdin() {
   try {

--- a/telegram-plugin/silent-end.ts
+++ b/telegram-plugin/silent-end.ts
@@ -56,8 +56,18 @@ export interface SilentEndDeps {
  * gives up. MUST stay in sync with `MAX_RETRIES` in the Stop hook
  * (`telegram-plugin/hooks/silent-end-interrupt-stop.mjs`) — the hook is a
  * standalone `.mjs` and can't import this module.
+ *
+ * 2026-05-25 bump from 1 → 2. With the original budget of 1, a model
+ * that stubbornly emitted `type:"text"` + `stop_reason:"end_turn"` twice
+ * in a row (instead of calling the reply tool) fell through to the
+ * gateway's 5-minute silence-poke framework-fallback. Second-retry
+ * cases now get a chance before the user-visible nudge fires. Memory:
+ * the Stop hook prompt itself is explicit ("only text sent through the
+ * reply tool is delivered. Send your final answer now"), so a second
+ * nudge isn't redundant — it's giving a different sample from the
+ * model under the same prompt.
  */
-export const SILENT_END_MAX_RETRIES = 1
+export const SILENT_END_MAX_RETRIES = 2
 
 function resolveStateDir(deps?: SilentEndDeps): string {
   if (deps?.stateDir != null) return deps.stateDir

--- a/telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts
+++ b/telegram-plugin/tests/silent-end-interrupt-stop-integration.test.ts
@@ -18,6 +18,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { spawnSync } from 'node:child_process'
+import { SILENT_END_MAX_RETRIES } from '../silent-end.js'
 import {
   mkdtempSync,
   mkdirSync,
@@ -172,7 +173,10 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
       reply('ack', { disable_notification: true }),
     ])
     const statePath = join(stateDir, 'silent-end-pending.json')
-    writeFileSync(statePath, JSON.stringify({ retryCount: 1, chatId: '111' }), 'utf8')
+    // Use the canonical ceiling so this test stays accurate as MAX_RETRIES evolves.
+    writeFileSync(statePath, JSON.stringify({
+      retryCount: SILENT_END_MAX_RETRIES, chatId: '111',
+    }), 'utf8')
 
     const r = runHook({
       event: { session_id: 's1', transcript_path: transcript },
@@ -183,7 +187,7 @@ describe('silent-end-interrupt-stop.mjs — integration', () => {
     expect(r.stderr).toMatch(/retry exhausted/)
     // State unchanged.
     const state = JSON.parse(readFileSync(statePath, 'utf8'))
-    expect(state.retryCount).toBe(1)
+    expect(state.retryCount).toBe(SILENT_END_MAX_RETRIES)
   })
 
   it('NO_REPLY in transcript → allow stop, no state file written', () => {

--- a/telegram-plugin/tests/silent-end.test.ts
+++ b/telegram-plugin/tests/silent-end.test.ts
@@ -226,10 +226,11 @@ describe('recordSilentTurnEnd — #1161 exhaustion detection', () => {
   it('full lifecycle: silent → re-prompt → still silent → exhausted', () => {
     // 1. Turn ends silent — first record.
     expect(recordSilentTurnEnd({ chatId: 'c', threadId: null, turnKey: 'c:_' }).exhausted).toBe(false)
-    // 2. Stop hook blocks and increments retryCount (simulated).
+    // 2. Stop hook blocks and bumps retryCount up to the ceiling
+    //    (simulated; the hook does retryCount+1 each block until MAX).
     const path = join(stateDir, 'silent-end-pending.json')
     const s = readSilentEndState()!
-    writeFileSync(path, JSON.stringify({ ...s, retryCount: s.retryCount + 1 }))
+    writeFileSync(path, JSON.stringify({ ...s, retryCount: SILENT_END_MAX_RETRIES }))
     // 3. Re-prompted turn ends silent again — recovery exhausted.
     expect(recordSilentTurnEnd({ chatId: 'c', threadId: null, turnKey: 'c:_' }).exhausted).toBe(true)
     expect(readSilentEndState()).toBeNull()
@@ -346,10 +347,11 @@ describe('recordUndeliveredTurnEnd — #1664 extended trigger', () => {
       [{ text: 'one sec', disableNotification: true }],
       'c:exhaust',
     ).rePromptEngaged).toBe(true)
-    // Stop hook blocks once and bumps retryCount (simulated).
+    // Stop hook blocks until retryCount hits the ceiling (simulated;
+    // the hook does retryCount+1 each block until SILENT_END_MAX_RETRIES).
     const path = join(stateDir, 'silent-end-pending.json')
     const s = readSilentEndState()!
-    writeFileSync(path, JSON.stringify({ ...s, retryCount: s.retryCount + 1 }))
+    writeFileSync(path, JSON.stringify({ ...s, retryCount: SILENT_END_MAX_RETRIES }))
     // Re-prompted turn STILL ends with only an interim ack → exhausted.
     const second = recordUndeliveredTurnEnd({ chatId: 'c', threadId: null, turnKey: 'c:exhaust' })
     expect(second.exhausted).toBe(true)
@@ -538,13 +540,14 @@ describe('silent-end-interrupt-stop hook — integration (#1775: transcript-scan
     expect(readSilentEndState()!.retryCount).toBe(1)
   })
 
-  it('allows the stop when retryCount >= MAX_RETRIES (1), even if transcript still shows no reply', () => {
-    // Retry already spent — gateway will post the user-facing
+  it('allows the stop when retryCount >= MAX_RETRIES, even if transcript still shows no reply', () => {
+    // Retry budget already spent — gateway will post the user-facing
     // fallback so the user isn't left silent.
     const path = join(stateDir, 'silent-end-pending.json')
     mkdirSync(stateDir, { recursive: true })
     writeFileSync(path, JSON.stringify({
-      chatId: 'c', threadId: null, turnKey: 'c:_', retryCount: 1, timestamp: 0,
+      chatId: 'c', threadId: null, turnKey: 'c:_',
+      retryCount: SILENT_END_MAX_RETRIES, timestamp: 0,
     }))
     const transcript = writeTranscript([
       ENQUEUE,


### PR DESCRIPTION
## Summary

Bumps the Stop hook's retry budget from 1 to 2. With the budget at 1, a model that stubbornly emits \`text\` + \`stop_reason: \"end_turn\"\` twice falls through to the gateway's 5-minute silence-poke framework-fallback (the user-visible \"no update from agent in N min\" canned nudge). Bumping to 2 gives the model a second nudge before the user-visible failure fires.

## Empirical context

Fleet log audit 2026-05-25, all-history rates:

| Agent | inbound | framework-fallback | rate |
|---|---|---|---|
| clerk | 319 | 24 | 7.5% |
| klanker | 243 | 53 | 21.8% |
| finn | 102 | 32 | 31.4% |
| gymbro | 50 | 29 | 58% |
| test-harness | 349 | 30 | 8.6% |
| **Fleet** | **1142** | **218** | **~19%** |

Target per \`reference/conversational-pacing.md\` KPI table: **<0.5%** (\"<5 per 1000\"). Current fleet is **38×** the design target.

The #1804 + #1805 fixes shipped today restored per-turn retry-budget freshness (stale state was making the budget invisible). With those fixes the Stop hook re-prompt finally works as intended. This PR widens the ladder by one rung.

## Why principle-aligned

\`reference/conversational-pacing.md\` design v2 contract: \"framework owns the beat + enforces, model authors every word.\" Bumping MAX_RETRIES makes the framework enforce harder (more retry chances). The model still authors all delivered content. This is the safety-net layer doing exactly what v2 prescribes.

## Trade-off

Each retry costs ~5-30s wall time plus inference budget. Worst-case time-to-framework-fallback grows from ~30s + 300s to ~60s + 300s. Mitigated by:

1. The retry only fires if the model actually silent-ended (rare in absolute terms)
2. The 300s window is unchanged — total wall budget grows slightly
3. The trade is "one extra nudge round" vs \"user-visible 'no update from agent' canned message\" — the latter is much worse UX

## Companion work

Part of the silent-end / conversational-pacing improvement sequence:

- #1804 — silent-end legacy-format file eviction (merged)
- #1805 — turn-start retry budget reset (merged)
- **This PR** — widen retry budget 1→2
- Forthcoming — #1672 fix + flag-on (visible-answer-stream) — addresses the failure mode at the lane-of-first-defense level

## Changes

- \`telegram-plugin/silent-end.ts:60\`: SILENT_END_MAX_RETRIES = 2
- \`telegram-plugin/hooks/silent-end-interrupt-stop.mjs:65\`: MAX_RETRIES = 2 (must stay in sync; the in-sync regression test at \`silent-end.test.ts:238\` regex-extracts the hook value and asserts equality)

## Test changes

Three lifecycle tests that simulated the retry-then-exhaust cycle hardcoded \`retryCount: 1\` to mean \"exhausted\". Updated to reference \`SILENT_END_MAX_RETRIES\` so they stay correct as the ceiling evolves. Test description \"(1)\" → \"(MAX_RETRIES)\". The integration test imports the constant and uses it. **49/49 silent-end + integration tests pass.**

## Lint

\`npm run lint\` clean (tsc, plugin-refs, bot-api-wrapping, bun-test-imports, no-pii, vault-hermeticity, no-broadcast).

## Risk

Low. Single constant bump. No new code paths. Stop hook re-prompt mechanism unchanged; just one more allowed iteration. Rollback = revert the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)