### PR TITLE
feat(telegram): visible-answer-stream default ON + over-ping fix (#1672 follow-up)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3024,10 +3024,24 @@ const TURN_FLUSH_SAFETY_ENABLED = isTurnFlushSafetyEnabled()
 // shape — they see the answer materialise live. For longer waits,
 // the cross-turn pending-progress system (#1445/#1669) is the
 // canonical surface and DOES ping at the appropriate boundaries.
-// Default OFF; flip per-agent via env to canary the new behaviour.
-const ANSWER_STREAM_VISIBLE_ENABLED =
-  process.env.SWITCHROOM_VISIBLE_ANSWER_STREAM === '1'
-  || process.env.SWITCHROOM_VISIBLE_ANSWER_STREAM === 'true'
+//
+// 2026-05-25: default flipped ON after fleet-log audit showed
+// framework-fallback rate at ~19% of inbounds (target per
+// `reference/conversational-pacing.md`: <0.5%). Streaming the
+// model's text events live into the chat closes the
+// catastrophic-UX failure mode at the lane-of-first-defense level.
+// Aligned with the "chat IS the artifact" sub-principle (the user
+// sees a normal chat message that grows — no chrome, no parallel
+// widget). Override with SWITCHROOM_VISIBLE_ANSWER_STREAM=0 to
+// disable, e.g. for an agent that needs the legacy draft-only
+// behaviour during debugging.
+const ANSWER_STREAM_VISIBLE_ENABLED = (() => {
+  const raw = process.env.SWITCHROOM_VISIBLE_ANSWER_STREAM
+  if (raw == null) return true
+  const v = raw.trim().toLowerCase()
+  if (v === '0' || v === 'false' || v === 'off' || v === 'no') return false
+  return true
+})()
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const progressDriver: any = null
 const unpinProgressCardForChat: ((chatId: string, threadId: number | undefined) => void) | null = null
@@ -6665,12 +6679,28 @@ function handleSessionEvent(ev: SessionEvent): void {
             // instead of crashing the answer-stream loop on a deleted
             // forum topic. answer-stream's own try/catch already
             // tolerates undefined returns from editMessageText.
+            //
+            // disable_notification: true UNCONDITIONALLY here (Bug A
+            // fix, 2026-05-25). The answer-stream lane sends a fresh
+            // sendMessage on the first text chunk to open the visible
+            // message. Without this flag the device pings — and then
+            // when the model later calls the reply MCP tool, that
+            // reply pings AGAIN (the over-ping safety net at
+            // gateway.ts:~4452 only sees executeReply paths, not this
+            // direct sendMessage). Result was two device pings per
+            // multi-step turn. Per the design contract — Telegram
+            // does not notify on edits anyway, and a stream-as-final-
+            // answer turn explicitly opts out of the device ping
+            // (see `reference/conversational-pacing.md` and the
+            // ANSWER_STREAM_VISIBLE_ENABLED comment above for the
+            // honest trade-off). Only the reply MCP tool ever pings.
             sendMessage: async (chatId, text, params) => {
               const tid = params?.message_thread_id
               const msg = await robustApiCall(
                 () =>
                   bot.api.sendMessage(chatId, text, {
                     parse_mode: params?.parse_mode,
+                    disable_notification: true,
                     ...(tid != null ? { message_thread_id: tid } : {}),
                     ...(params?.link_preview_options != null
                       ? { link_preview_options: params.link_preview_options }


### PR DESCRIPTION
## Summary

Flips \`SWITCHROOM_VISIBLE_ANSWER_STREAM\` default from OFF to ON across the fleet + fixes Bug A from the shelve memo (visible-mode sendMessage now passes \`disable_notification: true\`).

## Why now

Fleet log audit 2026-05-25 — \`silence-poke framework-fallback ended wedged turn\` events / total inbounds across all 9 agents:

| Agent | inbound | framework-fallback | rate |
|---|---|---|---|
| clerk | 319 | 24 | 7.5% |
| klanker | 243 | 53 | 21.8% |
| finn | 102 | 32 | 31.4% |
| gymbro | 50 | 29 | 58% |
| test-harness | 349 | 30 | 8.6% |
| **Fleet** | **1142** | **218** | **~19%** |

\`reference/conversational-pacing.md\` target: **<0.5%** (\"<5 per 1000\"). Current fleet is **~38× the design target**. The shelved flag-default-OFF was based on a 4× underestimate of the actual trigger rate ("revisit if answer_lane_update fires on >5% of turns"). The empirical case for shipping is conclusive.

## Why principle-aligned (this is the question that took the longest to resolve)

\`reference/principles.md\` § 3 sub-principle: *"The chat IS the artifact. Framework UI elements that mirror the conversation (cards, pinned widgets, status bars) cover for the model's failure to communicate naturally."*

The retired progress card (#1122) was **chrome** — a pinned widget separate from the chat. **Visible-answer-stream is not chrome.** It is a regular Telegram chat message that grows as the model emits text. The user perceives it identically to "the model is typing live" — same shape as any other chat message. No parallel widget, no card, no separate UI surface. The chat is still the artifact; the artifact just shows the model's actual thought process surfacing live.

Reading the sub-principle as a *literal rule about who writes the bytes* leads to the wrong conclusion; reading it as a *UX rule about chrome vs. coherent chat* gives the right answer. A doc clarification belongs in a follow-up PR; this one stays narrowly-scoped.

## User-visible experience change

**Before (flag OFF):** Type "do you have perplexity?" → typing indicator → ~30s+ → silence-poke fallback message *"still working… no update from agent in 5 min"* → user re-asks → eventually the answer arrives, or not.

**After (flag ON):** Type same prompt → typing indicator → seconds later a message appears in the chat and grows in place as the model thinks → answer materialises. Silent (no extra device ping; only the reply MCP tool rings the device when used). UX matches ChatGPT, Claude.ai, every modern AI chat.

## Code changes

Two changes in \`telegram-plugin/gateway/gateway.ts\`:

### 1. Default flag flip

\`ANSWER_STREAM_VISIBLE_ENABLED\` defaults to true. Operators can disable per-agent via env: \`SWITCHROOM_VISIBLE_ANSWER_STREAM=0\` (also accepts \`false\` / \`off\` / \`no\`). Same precedent pattern as \`isTurnFlushSafetyEnabled\` (\`telegram-plugin/turn-flush-safety.ts:125\`).

### 2. Bug A fix — \`disable_notification: true\` on visible-mode sendMessage

The shelve memo's Bug A is verified against current code at \`gateway.ts:6651-6671\`. The sendMessage callback passed to \`createAnswerStream\` forwards \`parse_mode\`, \`message_thread_id\`, \`link_preview_options\`, \`reply_parameters\` — but NOT \`disable_notification\`. So the first text chunk that opens the visible message pings the device. Then when the model later calls reply, executeReply pings AGAIN (the over-ping safety net at gateway.ts:~4452 only observes executeReply, not the direct answer-stream sendMessage).

Fix: pass \`disable_notification: true\` unconditionally on the visible-mode sendMessage. Telegram doesn't notify on edits, so the answer-stream lane is silent end-to-end. Only the reply MCP tool ever rings the device. This matches the explicit trade-off already documented in the existing block comment: *\"a stream-as-final-answer turn does NOT push a device notification.\"*

## Bug B (flash-then-delete) — deferred

The shelve memo cited a second bug: when the model emits preamble text + then calls reply, the preamble bubble retracts at turn-end. The user briefly sees streaming preamble before it vanishes. This is a UX quirk in the happy-path minority case, not catastrophic — the canonical answer still reaches via reply. For initial ship the current retract behavior stays. Follow-up PR can polish if production observation shows it matters.

## Companion work

Silent-end / conversational-pacing improvement sequence:
- #1804 — silent-end legacy-format eviction (merged)
- #1805 — turn-start retry budget reset (merged)
- #1812 — MAX_RETRIES 1→2 (open)
- **This PR** — visible-answer-stream default-on + Bug A fix

The first three fixed the recovery ladder. This one shifts the solution to the lane-of-first-defense: the user sees the answer streaming live, so the recovery ladder rarely needs to fire at all.

## Test plan

- [x] tsc + full \`npm run lint\` clean
- [ ] **Thorough canary UAT on test-harness** before merge:
  - \`visible-answer-stream-dm.test.ts\` — pre-existing UAT added by #1672 but never run pre-release
  - \`silent-end-recovery-dm.test.ts\` — verify the dominant failure mode now resolves via the visible lane
  - \`jtbd-fast-trivial-dm.test.ts\` — TTFO regression check
  - \`jtbd-rapid-followup-dm.test.ts\` — multi-turn behavior
  - \`jtbd-subagent-handback-dm.test.ts\` — sub-agent flow
  - \`midturn-silent-dm.test.ts\` — silence handling
- [ ] Watch for spurious second pings + unexpected retract events for ~24h post-canary before fleet roll

## Risk

Medium. The flag itself has been in production code since v0.13.15 (#1672); this PR just flips the default + fixes the documented over-ping bug. Roll-back is a single env-var override (\`SWITCHROOM_VISIBLE_ANSWER_STREAM=0\`) deployable per-agent.

Known carve-outs deferred:
- Bug B (flash-then-delete preamble) — UX quirk
- Telegram edit rate limits under high text-event frequency — answer-stream's existing throttle should cover; not stress-tested
- silent-anchor / over-ping interactions — verified independent per-message tracking; no cross-talk in code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)