### PR TITLE
fix(telegram): visible-answer-stream materialize-and-delete at turn-end so text-only turns ping

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -92,6 +92,22 @@ export interface AnswerStreamConfig {
       message_thread_id?: number
       link_preview_options?: { is_disabled: boolean }
       reply_parameters?: { message_id: number }
+      /**
+       * Distinguishes a streaming open (`'stream'` — silent edits-in-place
+       * preview, default) from the turn-end materialize (`'materialize'` —
+       * the user-facing final answer that should ping the device exactly
+       * once, matching beat-5 of the conversational-pacing contract).
+       *
+       * Used by the gateway wrapper in `gateway.ts` to set
+       * `disable_notification: true` for 'stream' purpose only —
+       * materialize lets the platform default (notify) through. Without
+       * this distinction, either every send pings (the original #1672
+       * bug, two device pings per multi-step turn — see
+       * `over-ping-safety-net.ts`) or none does (the over-correction
+       * where text-only short turns silently land and the user has no
+       * notification to know the answer arrived).
+       */
+      purpose?: 'stream' | 'materialize'
     },
   ) => Promise<{ message_id: number }>
   editMessageText: (
@@ -344,10 +360,14 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
         throw err
       }
     } else {
-      // First send — capture message_id; check generation for supersession
+      // First send — capture message_id; check generation for supersession.
+      // purpose: 'stream' tells the gateway wrapper this is the visible
+      // preview opener — silent (no device ping). The turn-end materialize
+      // path uses 'materialize' to allow the platform-default ping.
       const sendParams: Parameters<typeof sendMessage>[2] = {
         parse_mode: 'HTML',
         link_preview_options: { is_disabled: true },
+        purpose: 'stream',
       }
       if (threadId != null) sendParams.message_thread_id = threadId
       if (replyToMessageId != null) sendParams.reply_parameters = { message_id: replyToMessageId }
@@ -495,10 +515,16 @@ export function createAnswerStream(config: AnswerStreamConfig): AnswerStreamHand
         return undefined
       }
 
-      // Always send a fresh message for push notification
+      // Always send a fresh message for push notification.
+      // purpose: 'materialize' tells the gateway wrapper to allow the
+      // platform-default device ping through (vs the 'stream' opener
+      // which is forced silent). materialize() is the turn-end final-
+      // answer surface — beat 5 of the conversational-pacing contract
+      // — and MUST ping so the user knows the answer landed.
       const sendParams: Parameters<typeof sendMessage>[2] = {
         parse_mode: 'HTML',
         link_preview_options: { is_disabled: true },
+        purpose: 'materialize',
       }
       if (threadId != null) sendParams.message_thread_id = threadId
       // Don't quote-reply on materialize — the draft stream already established

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6956,73 +6956,73 @@ function handleSessionEvent(ev: SessionEvent): void {
           // overwrites `streamMsgId` internally with the new send's id;
           // without capturing here we'd lose the reference.
           const oldStreamedMsgId = streamedMsgId
-          // Fire-and-forget — turn_end must not block on the
-          // materialize promise. Errors are logged but never propagated;
-          // worst case the user sees the silent streamed preview (which
-          // already happened) without the ping (the failure case this
-          // branch was designed to fix), so we still need a record/dedup
-          // pass BEFORE awaiting to keep the bookkeeping accurate.
-          try {
-            outboundDedup.record(
-              turn.sessionChatId,
-              turn.sessionThreadId,
-              streamedFinalText,
-              Date.now(),
-              turn.registryKey ?? null,
-            )
-          } catch { /* best-effort */ }
-          if (HISTORY_ENABLED) {
-            try {
-              recordOutbound({
-                chat_id: turn.sessionChatId,
-                thread_id: turn.sessionThreadId ?? null,
-                message_ids: [streamedMsgId],
-                texts: [streamedFinalText],
-              })
-            } catch { /* best-effort */ }
-          }
-          // Now materialize-and-delete. Both calls fire-and-forget;
-          // materialize() is itself idempotent (`materialized` guard
-          // at the top of the function in answer-stream.ts) and
-          // dedup-aware (turn-flush already recorded above).
+          // Fire-and-forget materialize-and-delete sequence.
+          //
+          // Bookkeeping (dedup + history): handled inside
+          // `materialize()` itself — see `answer-stream.ts:~548-549`
+          // which calls the injected `recordDedup` + `recordOutbound`
+          // callbacks with the NEW (fresh-send) message_id only after a
+          // successful send. We deliberately do NOT pre-record here —
+          // doing so populates the same `outboundDedup` store that
+          // materialize's internal `checkDedup` consults at
+          // `answer-stream.ts:~510`, causing materialize to dedup-
+          // suppress its own send (return undefined, no ping fires) —
+          // the exact failure mode this PR exists to fix. Let
+          // materialize own the bookkeeping; gateway only sequences the
+          // operations.
+          //
+          // Delete gating: only run the cleanup `deleteMessage` if
+          // materialize actually sent (returned a numeric sentId). If
+          // it dedup-suppressed or threw, the streamed preview is the
+          // user's only copy of the answer and MUST be preserved.
           void (async () => {
+            let materializedId: number | undefined
             try {
-              await stream.materialize()
-              // Delete the silent streamed preview. The fresh
-              // materialized message lives at a NEW message_id; delete
-              // the OLD streamedMsgId so the chat doesn't show two
-              // messages with the same content. Best-effort; the catch
-              // below swallows any failure (already-deleted, permission,
-              // etc.) — wrapping in robustApiCall would retry-storm on
-              // permanent failures, and the worst case is a brief
-              // visible duplicate which is acceptable.
-              try {
-                // allow-raw-bot-api: cleanup delete of silent streamed preview
-                await bot.api.deleteMessage(turn.sessionChatId, oldStreamedMsgId)
-              } catch (delErr) {
-                // Best-effort — if the delete fails (already gone,
-                // permission denied, etc.) we accept the small
-                // visual duplicate rather than retry-storming.
-                process.stderr.write(
-                  `telegram gateway: answer-stream materialize-cleanup ` +
-                  `delete failed for msgId=${oldStreamedMsgId}: ${
-                    delErr instanceof Error ? delErr.message : String(delErr)
-                  }\n`,
-                )
-              }
+              materializedId = await stream.materialize()
             } catch (err) {
               process.stderr.write(
                 `telegram gateway: answer-stream materialize failed: ${
                   err instanceof Error ? err.message : String(err)
                 }\n`,
               )
+              return
             }
+            if (typeof materializedId !== 'number' || !Number.isFinite(materializedId)) {
+              // materialize() returned undefined — either pendingText
+              // was empty, the body was a silent marker (NO_REPLY /
+              // HEARTBEAT_OK), or `checkDedup` suppressed it. In every
+              // such case the streamed preview is the user's only copy
+              // of the content; don't delete it.
+              process.stderr.write(
+                `telegram gateway: answer-stream materialize returned no msgId ` +
+                `chat=${turn.sessionChatId} oldMsg=${oldStreamedMsgId} — ` +
+                `preserving silent preview as the user's only copy\n`,
+              )
+              return
+            }
+            // Materialize sent a fresh pinged message at materializedId.
+            // Delete the silent streamed preview so the chat shows one
+            // canonical message (the fresh pinged one) and not two with
+            // duplicate content. Best-effort; failures (already gone,
+            // permission denied) leave a brief visible duplicate which
+            // we accept rather than retry-storming.
+            try {
+              // allow-raw-bot-api: cleanup delete of silent streamed preview
+              await bot.api.deleteMessage(turn.sessionChatId, oldStreamedMsgId)
+            } catch (delErr) {
+              process.stderr.write(
+                `telegram gateway: answer-stream materialize-cleanup ` +
+                `delete failed for msgId=${oldStreamedMsgId}: ${
+                  delErr instanceof Error ? delErr.message : String(delErr)
+                }\n`,
+              )
+            }
+            process.stderr.write(
+              `telegram gateway: answer-stream materialized as answer ` +
+              `chat=${turn.sessionChatId} oldMsg=${oldStreamedMsgId} ` +
+              `newMsg=${materializedId} chars=${streamedFinalText.length}\n`,
+            )
           })()
-          process.stderr.write(
-            `telegram gateway: answer-stream materialized as answer ` +
-            `chat=${turn.sessionChatId} oldMsg=${oldStreamedMsgId} ` +
-            `chars=${streamedFinalText.length}\n`,
-          )
         } else {
           turn.answerStream = null
           void stream.retract().catch((err) => {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6680,27 +6680,38 @@ function handleSessionEvent(ev: SessionEvent): void {
             // forum topic. answer-stream's own try/catch already
             // tolerates undefined returns from editMessageText.
             //
-            // disable_notification: true UNCONDITIONALLY here (Bug A
-            // fix, 2026-05-25). The answer-stream lane sends a fresh
-            // sendMessage on the first text chunk to open the visible
-            // message. Without this flag the device pings — and then
-            // when the model later calls the reply MCP tool, that
-            // reply pings AGAIN (the over-ping safety net at
-            // gateway.ts:~4452 only sees executeReply paths, not this
-            // direct sendMessage). Result was two device pings per
-            // multi-step turn. Per the design contract — Telegram
-            // does not notify on edits anyway, and a stream-as-final-
-            // answer turn explicitly opts out of the device ping
-            // (see `reference/conversational-pacing.md` and the
-            // ANSWER_STREAM_VISIBLE_ENABLED comment above for the
-            // honest trade-off). Only the reply MCP tool ever pings.
+            // disable_notification gating by purpose (2026-05-25):
+            //
+            // - purpose='stream' (the live edit-in-place preview): SILENT.
+            //   Without disable_notification, the first text chunk that
+            //   opens the visible message device-pings, and then when the
+            //   model later calls the reply MCP tool, that reply pings
+            //   AGAIN (the over-ping safety net at gateway.ts:~4452 only
+            //   sees executeReply paths, not this direct sendMessage). Two
+            //   device pings per multi-step turn — the original Bug A.
+            //   Edits in place don't notify regardless (Telegram semantics).
+            //
+            // - purpose='materialize' (turn-end final-answer fresh send,
+            //   only fires for text-only turns where the stream IS the
+            //   answer): PING. The user reached for the agent and the
+            //   model produced an answer; per beat 5 of
+            //   `reference/conversational-pacing.md` the final answer MUST
+            //   ping the device exactly once. Without this carve-out, a
+            //   short text-only turn ("on it" being the whole response)
+            //   lands silently and the user has no notification to know
+            //   the answer arrived — the original over-correction.
+            //
+            // - purpose unset (defensive default): SILENT. Treat as
+            //   stream-purpose so we never accidentally fire a stray ping
+            //   from an unrecognised sendMessage callsite.
             sendMessage: async (chatId, text, params) => {
               const tid = params?.message_thread_id
+              const silent = params?.purpose !== 'materialize'
               const msg = await robustApiCall(
                 () =>
                   bot.api.sendMessage(chatId, text, {
                     parse_mode: params?.parse_mode,
-                    disable_notification: true,
+                    disable_notification: silent,
                     ...(tid != null ? { message_thread_id: tid } : {}),
                     ...(params?.link_preview_options != null
                       ? { link_preview_options: params.link_preview_options }
@@ -6711,7 +6722,7 @@ function handleSessionEvent(ev: SessionEvent): void {
                   }),
                 {
                   chat_id: chatId,
-                  verb: 'answer-stream.sendMessage',
+                  verb: `answer-stream.sendMessage(${params?.purpose ?? 'stream'})`,
                   ...(tid != null ? { threadId: tid } : {}),
                 },
               )
@@ -6902,13 +6913,30 @@ function handleSessionEvent(ev: SessionEvent): void {
       //
       // #869-Phase1 override: when `ANSWER_STREAM_VISIBLE_ENABLED` is
       // on, the stream is rendering a USER-VISIBLE message in the
-      // chat timeline. Retracting (delete) destroys content the user
-      // has been reading live — the worst possible UX flicker. So
-      // when the stream is the de-facto final answer (model never
-      // called reply, captured text is substantive) we instead call
-      // `stream.stop()` to freeze it as the final state, record the
-      // outbound for history + dedup, mark the turn answered, and
-      // suppress the turn-flush IIFE downstream.
+      // chat timeline. When the stream is the de-facto final answer
+      // (model never called reply, captured text is substantive), we
+      // need to:
+      //   1. Send a FRESH pinged message via `stream.materialize()`
+      //      so the user gets a device notification — beat 5 of the
+      //      conversational-pacing contract requires exactly one
+      //      ping per turn for the final answer. Without this,
+      //      text-only short turns ("on it" being the whole reply)
+      //      land silently and the user has no notification to know
+      //      the answer arrived (the failure caught by the
+      //      midturn-silent-dm UAT, 2026-05-25).
+      //   2. Delete the silent streamed preview message so the user
+      //      doesn't see a duplicate (the streamed message in place
+      //      + the fresh materialized ping). materialize() handles
+      //      the fresh send but leaves the old streamed message_id
+      //      orphaned by design — we delete it explicitly here.
+      //
+      // The previous behavior (just `stream.stop()` to freeze the
+      // streamed message in place) avoided the duplicate but also
+      // skipped the ping. Materialize-and-delete trades a brief
+      // visual "the streamed message is replaced by a fresh one"
+      // (often imperceptible for short turns where the streaming
+      // barely had time to register; mildly visible for longer
+      // turns) in exchange for an always-correct turn-end ping.
       let streamFinalizedAsAnswer = false
       if (turn?.answerStream != null) {
         const stream = turn.answerStream
@@ -6921,12 +6949,19 @@ function handleSessionEvent(ev: SessionEvent): void {
           && streamedFinalText.length > 0
         ) {
           turn.answerStream = null
-          stream.stop()
           streamFinalizedAsAnswer = true
           turn.finalAnswerDelivered = true
-          // Record as canonical outbound so retries dedup against it
-          // and the SQLite history can surface it. Mirrors the
-          // hooks turn-flush + reply both run.
+          // Capture the old streamed message_id BEFORE materialize so
+          // we can delete it after the fresh ping send. materialize()
+          // overwrites `streamMsgId` internally with the new send's id;
+          // without capturing here we'd lose the reference.
+          const oldStreamedMsgId = streamedMsgId
+          // Fire-and-forget — turn_end must not block on the
+          // materialize promise. Errors are logged but never propagated;
+          // worst case the user sees the silent streamed preview (which
+          // already happened) without the ping (the failure case this
+          // branch was designed to fix), so we still need a record/dedup
+          // pass BEFORE awaiting to keep the bookkeeping accurate.
           try {
             outboundDedup.record(
               turn.sessionChatId,
@@ -6946,9 +6981,46 @@ function handleSessionEvent(ev: SessionEvent): void {
               })
             } catch { /* best-effort */ }
           }
+          // Now materialize-and-delete. Both calls fire-and-forget;
+          // materialize() is itself idempotent (`materialized` guard
+          // at the top of the function in answer-stream.ts) and
+          // dedup-aware (turn-flush already recorded above).
+          void (async () => {
+            try {
+              await stream.materialize()
+              // Delete the silent streamed preview. The fresh
+              // materialized message lives at a NEW message_id; delete
+              // the OLD streamedMsgId so the chat doesn't show two
+              // messages with the same content. Best-effort; the catch
+              // below swallows any failure (already-deleted, permission,
+              // etc.) — wrapping in robustApiCall would retry-storm on
+              // permanent failures, and the worst case is a brief
+              // visible duplicate which is acceptable.
+              try {
+                // allow-raw-bot-api: cleanup delete of silent streamed preview
+                await bot.api.deleteMessage(turn.sessionChatId, oldStreamedMsgId)
+              } catch (delErr) {
+                // Best-effort — if the delete fails (already gone,
+                // permission denied, etc.) we accept the small
+                // visual duplicate rather than retry-storming.
+                process.stderr.write(
+                  `telegram gateway: answer-stream materialize-cleanup ` +
+                  `delete failed for msgId=${oldStreamedMsgId}: ${
+                    delErr instanceof Error ? delErr.message : String(delErr)
+                  }\n`,
+                )
+              }
+            } catch (err) {
+              process.stderr.write(
+                `telegram gateway: answer-stream materialize failed: ${
+                  err instanceof Error ? err.message : String(err)
+                }\n`,
+              )
+            }
+          })()
           process.stderr.write(
-            `telegram gateway: answer-stream finalized as answer ` +
-            `chat=${turn.sessionChatId} msg=${streamedMsgId} ` +
+            `telegram gateway: answer-stream materialized as answer ` +
+            `chat=${turn.sessionChatId} oldMsg=${oldStreamedMsgId} ` +
             `chars=${streamedFinalText.length}\n`,
           )
         } else {


### PR DESCRIPTION
## Summary

Follow-up to PR #1813 (visible-answer-stream default-on). Layer 1 of #1813 fixed the double-ping bug by forcing \`disable_notification: true\` on the answer-stream's sendMessage callback. UAT on test-harness 2026-05-25 caught the regression this over-correction introduced: text-only short turns now land silently with no device notification.

This PR adds a \`purpose: 'stream' | 'materialize'\` discriminator so the lane-opening send stays silent (preventing double-ping) but the turn-end materialize sends a proper pinged final-answer message.

## UAT result this fixes

\`telegram-plugin/uat/scenarios/midturn-silent-dm.test.ts\` ran twice on test-harness post-#1813, failed both times:

\`\`\`
final answer (message 0) was marked silent — the user won't get pinged when the turn finishes.
Trail: [0] silent=true text="on it": expected true to be false
\`\`\`

Model emitted "on it" via the answer-stream lane and stopped (single-message turn). With #1813's blanket \`disable_notification: true\`, the sole user-visible message landed silent — no ping → user has no notification to know the answer arrived.

## Fix shape

### Layer 1 — \`answer-stream.ts\`: \`purpose\` field on sendMessage params

Optional \`purpose: 'stream' | 'materialize'\` discriminator. Lane-opening fresh send passes 'stream'; turn-end materialize fresh send passes 'materialize'.

### Layer 2 — \`gateway.ts\`: honor purpose + materialize-and-delete at turn-end

The sendMessage wrapper sets \`disable_notification: params.purpose !== 'materialize'\`. Streaming opens stay silent; materialize fresh sends ping.

The turn-end IF-branch (stream is final answer, model never called reply, captured text substantive) previously called \`stream.stop()\` — froze the silent preview as final. Now it:
1. Calls \`stream.materialize()\` → fresh pinged message (purpose='materialize')
2. Deletes the old streamed preview via \`bot.api.deleteMessage\` so the user sees one message, not two

For SHORT turns (the dominant text-only case) the brief delete+resend at turn-end is barely perceptible — feels like "the message arrived with a ping." For LONG turns where the user has been reading the streamed content, the delete+resend is mildly visible — accepted UX trade-off in exchange for always-correct turn-end notification.

## What stays unchanged

- Multi-step turns (text + reply tool): reply pings normally. Over-ping cap unaffected. One ping per turn at the right moment.
- Edits in place during streaming: Telegram doesn't notify on edits regardless.
- Long visible-stream turns: stream silently while model thinks; at turn-end materialize-and-delete is the single notification.
- The else-branch (model DID call reply): unchanged. Reply pings; streamed preview is retracted.
- The companion #1813 PR's default-ON flip stays.

## Test plan

- [x] tsc + \`npm run lint\` clean (PII check, bot-api-wrapping with explicit \`allow-raw-bot-api\` marker for the cleanup delete, all others)
- [x] \`bun test telegram-plugin/tests/answer-stream*.test.ts\` → 47/47 pass
- [ ] **Full UAT re-sweep on test-harness** after merge — particular focus:
  - \`midturn-silent-dm\` (the failing test) — should now PASS, single-message turn pings at materialize
  - \`visible-answer-stream-dm\` (regression check) — multi-step rendering must still work; final reply still pings
  - \`silent-end-recovery-dm\` (headline 19% fix) — still passing
  - \`jtbd-fast-trivial-dm\` (TTFO regression)
  - \`jtbd-rapid-followup-dm\` (multi-turn)
  - \`jtbd-subagent-handback-dm\` (sub-agent flow)
- [ ] Post-merge canary on test-harness ~24h before fleet roll

## Risk

Low-medium. \`materialize()\` exists in \`answer-stream.ts\` since v0.12.x and is exercised by the flag-OFF path + tests. The materialize-and-delete combination is new here but each step is small + well-understood. \`deleteMessage\` is best-effort with a swallowing catch — failure (already-deleted, permission denied) at worst leaves a brief visible duplicate.

Roll-back: revert this PR; #1813 then resumes the silent-stream-as-final behavior — sub-optimal but not catastrophic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)