### PR TITLE
fix(skill-search): default --agent to $SWITCHROOM_AGENT_NAME (closes #1827)

### DIFF
--- a/src/cli/skill-search.test.ts
+++ b/src/cli/skill-search.test.ts
@@ -12,8 +12,24 @@ import {
   listPersonalSkills,
   listSharedSkills,
   readSkillFrontmatter,
+  searchAction,
   searchSkills,
 } from "./skill-search.js";
+
+function captureStdout(fn: () => void): string {
+  const orig = console.log;
+  let captured = "";
+  console.log = (...args: unknown[]): void => {
+    captured +=
+      args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ") + "\n";
+  };
+  try {
+    fn();
+  } finally {
+    console.log = orig;
+  }
+  return captured;
+}
 
 const AGENT = "test-agent";
 
@@ -338,5 +354,88 @@ describe("searchSkills", () => {
       bundledRoot,
     });
     expect(rBig.length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe("searchAction — env-default --agent (#1827)", () => {
+  let agentsRoot: string;
+  let sharedRoot: string;
+  let bundledRoot: string;
+  const ENV = "SWITCHROOM_AGENT_NAME";
+  const SAVED = process.env[ENV];
+
+  beforeEach(() => {
+    agentsRoot = mkdtempSync(join(tmpdir(), "skill-search-envdefault-a-"));
+    sharedRoot = mkdtempSync(join(tmpdir(), "skill-search-envdefault-s-"));
+    bundledRoot = mkdtempSync(join(tmpdir(), "skill-search-envdefault-b-"));
+    // Personal skill under the env-set agent.
+    writeSkillDir(
+      join(agentsRoot, AGENT, ".claude/skills/personal-mine"),
+      "mine",
+    );
+    // Shared skill (always visible regardless of agent).
+    writeSkillDir(join(sharedRoot, "common"), "common");
+  });
+
+  afterEach(() => {
+    if (SAVED === undefined) delete process.env[ENV];
+    else process.env[ENV] = SAVED;
+    rmSync(agentsRoot, { recursive: true, force: true });
+    rmSync(sharedRoot, { recursive: true, force: true });
+    rmSync(bundledRoot, { recursive: true, force: true });
+  });
+
+  it("uses $SWITCHROOM_AGENT_NAME when --agent is omitted (personal tier visible)", () => {
+    process.env[ENV] = AGENT;
+    const out = captureStdout(() => {
+      searchAction({
+        // no `agent` — exercise the env-default
+        root: agentsRoot,
+        sharedRoot,
+        bundledRoot,
+      });
+    });
+    const results = JSON.parse(out);
+    const names = results.map((r: { name: string }) => r.name).sort();
+    expect(names).toEqual(["common", "mine"]);
+    const personal = results.find(
+      (r: { tier: string }) => r.tier === "personal",
+    );
+    expect(personal?.name).toBe("mine");
+    expect(personal?.agent).toBe(AGENT);
+  });
+
+  it("explicit --agent overrides the env default", () => {
+    process.env[ENV] = "different-agent";
+    const out = captureStdout(() => {
+      searchAction({
+        agent: AGENT,
+        root: agentsRoot,
+        sharedRoot,
+        bundledRoot,
+      });
+    });
+    const results = JSON.parse(out);
+    const personal = results.find(
+      (r: { tier: string }) => r.tier === "personal",
+    );
+    expect(personal?.agent).toBe(AGENT);
+  });
+
+  it("with no --agent and no env, personal tier yields zero (shared/bundled still searched)", () => {
+    delete process.env[ENV];
+    const out = captureStdout(() => {
+      searchAction({
+        root: agentsRoot,
+        sharedRoot,
+        bundledRoot,
+      });
+    });
+    const results = JSON.parse(out);
+    expect(results.find((r: { tier: string }) => r.tier === "personal")).toBeUndefined();
+    // Shared still visible.
+    expect(results.find((r: { tier: string }) => r.tier === "shared")?.name).toBe(
+      "common",
+    );
   });
 });

--- a/src/cli/skill-search.ts
+++ b/src/cli/skill-search.ts
@@ -368,8 +368,16 @@ export function searchAction(opts: CliOpts): void {
     limit = Math.floor(n);
   }
 
+  // Default --agent to $SWITCHROOM_AGENT_NAME so an in-container agent
+  // sees its own personal tier without having to pass --agent explicitly.
+  // Mirrors the resolveAgent() helper in skill-personal.ts — but stays
+  // optional here (no agent → personal tier yields zero, caller still gets
+  // shared + bundled results). Closes #1827.
+  const resolvedAgent =
+    opts.agent ?? process.env.SWITCHROOM_AGENT_NAME ?? undefined;
+
   const results = searchSkills({
-    agent: opts.agent,
+    agent: resolvedAgent,
     query: opts.query,
     tier,
     limit,


### PR DESCRIPTION
## Summary

Closes #1827, surfaced during v0.13.45 UAT.

\`skill search\` did not default \`--agent\` from the env, even though the
four sibling personal-skill ops (init/edit/remove/list) do. Agents
invoking \`skill_search\` from inside their own container had to pass
\`--agent\` explicitly to see their personal tier — otherwise personal
results were silently omitted.

## Fix

Read \`process.env.SWITCHROOM_AGENT_NAME\` as the fallback when
\`--agent\` is omitted, in \`searchAction\` (\`src/cli/skill-search.ts\`).
Mirrors \`resolveAgent\` from \`skill-personal.ts\` but keeps \`agent\`
OPTIONAL here — no agent context (env unset AND no flag) still works
for shared/bundled-only searches, just with personal tier skipped.

## Test plan

3 new regression tests in \`src/cli/skill-search.test.ts\`:

- [x] \`\$SWITCHROOM_AGENT_NAME\` populates the personal tier when
  \`--agent\` omitted
- [x] Explicit \`--agent\` overrides the env default
- [x] Neither set → personal tier yields zero, shared/bundled still searched

All 26 tests in the file pass; tsc clean.

## Risk

Read-only fallback. Worst case: an env-unset operator running the host
CLI gets the existing behaviour. No security implication — the slug regex
still gates the value before any filesystem join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)