### PR TITLE
feat(skill): observability for personal-skills adoption (60-day Phase 2 decision)

### DIFF
--- a/docs/personal-skills-adoption-observability.md
+++ b/docs/personal-skills-adoption-observability.md
@@ -1,0 +1,95 @@
+# Personal-skills adoption observability
+
+> **Why this doc exists.** RFC v3 (#1819) deferred Phase 2 — operator-
+> approval-gated edits to the **shared** skill pool — until 60+ days of
+> personal-skill usage data is in. This doc says how to read that data.
+
+## What's instrumented
+
+After v0.13.45 + the audit-instrumentation follow-up, every **mutating**
+personal-skill op writes one JSONL row to
+`~/.switchroom/audit/<agent>/agent-config.jsonl`:
+
+| cmd                    | When                                                  |
+|------------------------|-------------------------------------------------------|
+| `skill.init_personal`  | New personal skill written (success path only)        |
+| `skill.edit_personal`  | Existing personal skill overwritten (success only)    |
+| `skill.remove_personal`| Personal skill moved to trash (success only)          |
+
+`skill.list_personal` and `skill.search` are read-only and **not**
+audited — they fire too often to be useful signal. Disk state at
+`~/.switchroom/agents/<agent>/.claude/skills/personal-*/` is the ground
+truth for "what skills currently exist."
+
+Failure paths exit via `fail()` before the audit call. That's deliberate:
+we want adoption signal, not error rate (the existing structured CLI
+errors already cover the failure case).
+
+## Reading the data
+
+```bash
+node scripts/observe-personal-skills.mjs            # text report
+node scripts/observe-personal-skills.mjs --json     # machine-readable
+node scripts/observe-personal-skills.mjs --since 7d # last week only
+```
+
+The script reads:
+
+1. **Disk state** — every `~/.switchroom/agents/<agent>/.claude/skills/personal-<name>/`
+   dir. Reports name, file count, size, mtime. This is the authoritative
+   "is anyone using this?" signal.
+2. **Trash state** — `~/.switchroom/agents/<agent>/.claude/skills-trash/`.
+   Recently-removed skills, recoverable for 24h. Helps separate
+   experimentation from durable adoption.
+3. **Audit log** — `~/.switchroom/audit/<agent>/agent-config.jsonl`,
+   filtered to `skill.*_personal`. Gives the time series — when did the
+   workflow start being used, what's the cadence per agent.
+
+## Phase-2 decision criteria (60-day checkpoint, ~2026-07-25)
+
+Re-run the script after the 60-day window. The Phase 2 RFC body should
+cite the actual numbers, not assumptions.
+
+**Strong signal for Phase 2 priority (proceed with the design):**
+
+- ≥ 50% of fleet agents have authored at least one personal skill
+- Total `skill.init_personal` count > 10× total `skill.remove_personal`
+  (means skills are sticking, not just being tried+abandoned)
+- Operator has been asked to copy a personal skill into the shared pool
+  at least 3 times (the Workflow-3 demand signal — proves the gap that
+  Phase 2 would close)
+
+**Weak signal (defer Phase 2 further):**
+
+- < 20% of agents have used the workflow at all
+- Most `init_personal` events have a matching `remove_personal` (test
+  drives, not adoption)
+- No operator request to promote a personal skill to shared
+
+**No signal (the deferred-tracker #1821 stays closed):**
+
+- Zero personal skills authored across the fleet
+- Indicates the workflow either isn't discovered (skill_search itself
+  needs better surfacing) or isn't needed. Either way, Phase 2 is the
+  wrong fix.
+
+## What this doesn't measure
+
+- **Skill quality** — usage count says nothing about whether the skills
+  agents author are useful. Spot-check the actual `SKILL.md` files.
+- **Operator-side burden** — Phase 2's whole reason for existing is
+  reducing operator taps on the approval card. If operators are happy
+  with the current `switchroom skill apply` CLI as the shared-pool path,
+  Phase 2 buys nothing regardless of personal-skill volume.
+- **Cross-agent capability spread** — `skill_search` could surface a
+  shared skill to other agents; we don't currently log opt-ins, so this
+  blind spot remains. If it matters, add audit rows to `skill_install`
+  in a follow-up.
+
+## Operating note
+
+The audit log is best-effort: `appendAudit` swallows write errors silently
+to avoid blocking the action. If the `~/.switchroom/audit/<agent>/` dir
+is read-only, you'll see disk state but no audit rows for that agent.
+Same defensive pattern as the existing `config.get` / `cron.list`
+auditing.

--- a/scripts/observe-personal-skills.mjs
+++ b/scripts/observe-personal-skills.mjs
@@ -27,7 +27,7 @@
  * existing src/cli/skill-search.ts helpers).
  */
 
-import { readdirSync, statSync, readFileSync, existsSync } from "node:fs";
+import { readdirSync, statSync, lstatSync, readFileSync, existsSync } from "node:fs";
 import { join, basename } from "node:path";
 import { homedir } from "node:os";
 
@@ -69,6 +69,14 @@ function safeStat(p) {
   }
 }
 
+function safeLstat(p) {
+  try {
+    return lstatSync(p);
+  } catch {
+    return null;
+  }
+}
+
 function dirSize(dir) {
   let bytes = 0;
   let files = 0;
@@ -77,8 +85,12 @@ function dirSize(dir) {
     const cur = stack.pop();
     for (const ent of safeReaddir(cur)) {
       const sub = join(cur, ent);
-      const st = safeStat(sub);
+      // lstat NOT stat — never follow a symlink out of the skill tree.
+      // A malicious `personal-foo → /etc` would otherwise have us
+      // walking arbitrary host dirs (metadata only, but still wrong).
+      const st = safeLstat(sub);
       if (!st) continue;
+      if (st.isSymbolicLink()) continue;
       if (st.isDirectory()) stack.push(sub);
       else if (st.isFile()) {
         bytes += st.size;

--- a/scripts/observe-personal-skills.mjs
+++ b/scripts/observe-personal-skills.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * observe-personal-skills.mjs
+ *
+ * Read-only observability for the #1819 agent-managed personal-skills
+ * workflow. Run on the host (not in-container) to get a fleet-wide
+ * snapshot:
+ *
+ *   - which agents have authored personal skills (and how many)
+ *   - per-skill: name, file count, size, mtime
+ *   - trash-dir contents (recently removed)
+ *   - agent-config audit-log rows for skill.* commands, if any
+ *
+ * Purpose: feed the 60-day Phase 2 / shared-pool decision with real data.
+ * If after 60 days no agent has authored a personal skill, the demand
+ * for Phase 2 propose-publish-to-shared is presumably also low. If most
+ * agents are authoring, Phase 2 becomes the priority.
+ *
+ * Usage:
+ *
+ *   node scripts/observe-personal-skills.mjs                # text report
+ *   node scripts/observe-personal-skills.mjs --json         # machine-readable
+ *   node scripts/observe-personal-skills.mjs --since 7d     # filter audit by age
+ *
+ * No writes. Safe to run any time, by any user (rows from dirs they
+ * can't stat are silently skipped — same defensive pattern as the
+ * existing src/cli/skill-search.ts helpers).
+ */
+
+import { readdirSync, statSync, readFileSync, existsSync } from "node:fs";
+import { join, basename } from "node:path";
+import { homedir } from "node:os";
+
+const PERSONAL_PREFIX = "personal-";
+const TRASH_DIRNAME = "skills-trash";
+const args = process.argv.slice(2);
+const wantJson = args.includes("--json");
+const sinceIdx = args.indexOf("--since");
+const sinceFilter = sinceIdx >= 0 ? args[sinceIdx + 1] : undefined;
+
+const sinceMs = parseSinceArg(sinceFilter);
+
+function parseSinceArg(s) {
+  if (!s) return 0;
+  const m = /^(\d+)([smhd])$/.exec(s);
+  if (!m) {
+    process.stderr.write(`error: --since must be like 7d, 24h, 30m (got ${s})\n`);
+    process.exit(2);
+  }
+  const n = Number(m[1]);
+  const unit = m[2];
+  const factor = unit === "s" ? 1e3 : unit === "m" ? 60e3 : unit === "h" ? 3600e3 : 86400e3;
+  return Date.now() - n * factor;
+}
+
+function safeReaddir(p) {
+  try {
+    return readdirSync(p);
+  } catch {
+    return [];
+  }
+}
+
+function safeStat(p) {
+  try {
+    return statSync(p);
+  } catch {
+    return null;
+  }
+}
+
+function dirSize(dir) {
+  let bytes = 0;
+  let files = 0;
+  const stack = [dir];
+  while (stack.length) {
+    const cur = stack.pop();
+    for (const ent of safeReaddir(cur)) {
+      const sub = join(cur, ent);
+      const st = safeStat(sub);
+      if (!st) continue;
+      if (st.isDirectory()) stack.push(sub);
+      else if (st.isFile()) {
+        bytes += st.size;
+        files += 1;
+      }
+    }
+  }
+  return { files, bytes };
+}
+
+function enumerateAgent(agentDir) {
+  const skillsDir = join(agentDir, ".claude", "skills");
+  const trashDir = join(agentDir, ".claude", TRASH_DIRNAME);
+  const personal = [];
+  for (const ent of safeReaddir(skillsDir)) {
+    if (!ent.startsWith(PERSONAL_PREFIX)) continue;
+    const p = join(skillsDir, ent);
+    const st = safeStat(p);
+    if (!st?.isDirectory()) continue;
+    const { files, bytes } = dirSize(p);
+    personal.push({
+      name: ent.slice(PERSONAL_PREFIX.length),
+      path: p,
+      files,
+      bytes,
+      mtime: st.mtime.toISOString(),
+    });
+  }
+  const trash = [];
+  for (const ent of safeReaddir(trashDir)) {
+    const p = join(trashDir, ent);
+    const st = safeStat(p);
+    if (!st?.isDirectory()) continue;
+    // Trash dirname: <name>-<unix-ts>
+    const m = /^(.+)-(\d+)$/.exec(ent);
+    const removedAt = m ? new Date(Number(m[2])).toISOString() : null;
+    trash.push({
+      name: m ? m[1] : ent,
+      path: p,
+      removed_at: removedAt,
+    });
+  }
+  return { personal, trash };
+}
+
+function enumerateAuditLog(agent) {
+  const audit = join(homedir(), ".switchroom", "audit", agent, "agent-config.jsonl");
+  if (!existsSync(audit)) return [];
+  let raw;
+  try {
+    raw = readFileSync(audit, "utf8");
+  } catch {
+    return [];
+  }
+  const rows = [];
+  for (const line of raw.split("\n")) {
+    if (!line) continue;
+    try {
+      const row = JSON.parse(line);
+      if (!row.cmd?.startsWith("skill.")) continue;
+      const ts = Date.parse(row.ts);
+      if (sinceMs && ts < sinceMs) continue;
+      rows.push(row);
+    } catch {
+      // ignore malformed lines
+    }
+  }
+  return rows;
+}
+
+const agentsRoot = join(homedir(), ".switchroom", "agents");
+const fleet = safeReaddir(agentsRoot)
+  .map((name) => ({ name, dir: join(agentsRoot, name) }))
+  .filter((a) => safeStat(a.dir)?.isDirectory());
+
+const report = fleet.map(({ name, dir }) => {
+  const { personal, trash } = enumerateAgent(dir);
+  const audit = enumerateAuditLog(name);
+  return { agent: name, personal, trash, audit };
+});
+
+const summary = {
+  generated_at: new Date().toISOString(),
+  host_agents_root: agentsRoot,
+  filter_since: sinceFilter ?? null,
+  totals: {
+    agents: report.length,
+    agents_with_personal: report.filter((r) => r.personal.length > 0).length,
+    personal_skills: report.reduce((n, r) => n + r.personal.length, 0),
+    trash_entries: report.reduce((n, r) => n + r.trash.length, 0),
+    audit_rows_skill_star: report.reduce((n, r) => n + r.audit.length, 0),
+  },
+  per_agent: report,
+};
+
+if (wantJson) {
+  process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
+  process.exit(0);
+}
+
+// Text report (operator-readable).
+const { totals } = summary;
+console.log(`# Personal-skills observability (${summary.generated_at})`);
+console.log(``);
+console.log(`Agents on host        : ${totals.agents}`);
+console.log(`Agents with personals : ${totals.agents_with_personal}`);
+console.log(`Personal skills total : ${totals.personal_skills}`);
+console.log(`Trashed (recoverable) : ${totals.trash_entries}`);
+console.log(`Audit rows (skill.*)  : ${totals.audit_rows_skill_star}${sinceFilter ? ` (since ${sinceFilter})` : ""}`);
+console.log(``);
+
+for (const r of report) {
+  if (r.personal.length === 0 && r.trash.length === 0 && r.audit.length === 0) continue;
+  console.log(`── ${r.agent} ──`);
+  if (r.personal.length > 0) {
+    console.log(`  personal skills:`);
+    for (const p of r.personal) {
+      console.log(`    ${p.name.padEnd(28)} files=${String(p.files).padStart(3)}  bytes=${String(p.bytes).padStart(7)}  mtime=${p.mtime}`);
+    }
+  }
+  if (r.trash.length > 0) {
+    console.log(`  trash (recoverable, 24h sweep):`);
+    for (const t of r.trash) {
+      console.log(`    ${t.name.padEnd(28)} removed_at=${t.removed_at ?? "<unknown>"}`);
+    }
+  }
+  if (r.audit.length > 0) {
+    const byCmd = new Map();
+    for (const row of r.audit) byCmd.set(row.cmd, (byCmd.get(row.cmd) ?? 0) + 1);
+    console.log(`  audit rows by cmd:`);
+    for (const [cmd, n] of [...byCmd.entries()].sort()) {
+      console.log(`    ${cmd.padEnd(28)} count=${n}`);
+    }
+  }
+  console.log(``);
+}
+
+console.log(`(no-personal agents omitted from per-agent breakdown)`);

--- a/src/cli/skill-personal.ts
+++ b/src/cli/skill-personal.ts
@@ -59,6 +59,7 @@ import {
   validateSkillBundle,
 } from "./skill-common.js";
 import { withConfigError } from "./helpers.js";
+import { appendAudit } from "./agent-config.js";
 import chalk from "chalk";
 
 // ─── Constants ─────────────────────────────────────────────────────
@@ -455,6 +456,9 @@ export function initPersonalAction(name: string, opts: InitEditOpts): void {
   const agentsRoot = resolveAgentsRoot(opts);
   const files = loadFiles(opts);
   loadValidateWrite(agentsRoot, agent, name, files, /*ensureNew=*/ true);
+  // Audit row on success only (failure paths exit via fail() before this).
+  // Used by scripts/observe-personal-skills.mjs for adoption telemetry.
+  appendAudit(agent, "skill.init_personal", { name, files: Object.keys(files).length }, 0);
 }
 
 export function editPersonalAction(name: string, opts: InitEditOpts): void {
@@ -462,6 +466,7 @@ export function editPersonalAction(name: string, opts: InitEditOpts): void {
   const agentsRoot = resolveAgentsRoot(opts);
   const files = loadFiles(opts);
   loadValidateWrite(agentsRoot, agent, name, files, /*ensureNew=*/ false);
+  appendAudit(agent, "skill.edit_personal", { name, files: Object.keys(files).length }, 0);
 }
 
 export function removePersonalAction(name: string, opts: RemoveOpts): void {
@@ -510,6 +515,7 @@ export function removePersonalAction(name: string, opts: RemoveOpts): void {
       recoverable_until: new Date(ts + TRASH_TTL_MS).toISOString(),
     }),
   );
+  appendAudit(agent, "skill.remove_personal", { name }, 0);
 }
 
 export function listPersonalAction(opts: ListOpts): void {


### PR DESCRIPTION
## Summary

Two pieces of telemetry for the **60-day Phase 2 decision** (RFC #1819
defers operator-approval-gated edits to the shared pool until usage
data exists):

1. **Audit instrumentation in \`skill-personal.ts\`.** Three mutating ops
   now emit one JSONL row each to \`~/.switchroom/audit/<agent>/agent-config.jsonl\`
   on success: \`skill.init_personal\`, \`skill.edit_personal\`,
   \`skill.remove_personal\`. Same shape as existing \`config.get\` / \`cron.list\`
   rows. Read-only ops (\`list_personal\`, \`search\`) are deliberately NOT
   audited — they fire too often to be useful signal; disk state is the
   ground truth for "what skills exist."

2. **\`scripts/observe-personal-skills.mjs\`.** Host-side read-only fleet
   scan. For each agent: lists current personal skills (disk state),
   trash (recently removed, 24h recoverable), and audit rows. Supports
   \`--json\` and \`--since 7d\`.

3. **\`docs/personal-skills-adoption-observability.md\`.** Decision rubric
   for the 60-day checkpoint (~2026-07-25): three signal tiers with
   explicit thresholds for strong / weak / no Phase 2 demand.

## Why these instead of PostHog / Grafana

- \`appendAudit\` is the **existing** instrumentation primitive the
  agent-config commands already use. Adding three callsites costs ~3
  lines and zero new dependencies.
- PostHog \`cli_command_invoked\` already fires for the top-level
  \`switchroom\` command but is too coarse (doesn't distinguish
  \`init_personal\` from \`list_personal\`). Adding per-subcommand
  PostHog events would be a separate, more invasive PR.
- Disk-state inspection answers the dominant question ("did anyone
  author?") without any telemetry at all — it's the safety net.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] All 71 \`src/cli/skill*\` tests still pass — audit calls are
  silently no-op when test dir is unwritable (existing \`appendAudit\`
  behaviour)
- [x] Live script run against the host fleet — currently shows
  35 agents on host, 0 with personal skills, 2 trash entries (from
  v0.13.45 UAT smoke tests)

## Risk

- **\`appendAudit\` is best-effort** — it catches and swallows all I/O
  errors so a full or read-only audit dir can never block a write op.
  Same defensive pattern as the existing callsites in agent-config.ts.
- **No behaviour change** on the happy path beyond one extra
  \`appendFileSync\` call per mutating op.
- **Failure paths exit before the audit call** — by design. We want
  adoption signal, not error rate (errors are tracked via the
  structured CLI error surface already).

## Next checkpoint

Re-run the script around **2026-07-25** (60 days after v0.13.45 ship)
and consult the decision rubric in
\`docs/personal-skills-adoption-observability.md\`. Three outcomes:
proceed with Phase 2 RFC, defer further, or close #1821 entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)