### PR TITLE
fix(scaffold): chown audit dir to agent UID (closes #1831)

### DIFF
--- a/src/agents/scaffold.test.ts
+++ b/src/agents/scaffold.test.ts
@@ -64,6 +64,10 @@ describe("alignAgentUid", () => {
   // log redirects (`>> /var/log/switchroom/...`) hit the bind-mounted
   // root-owned dir as a non-root agent UID.
   const expectedLogsDir = join(homedir(), ".switchroom", "logs", "agent");
+  // Added 2026-05-26 (#1831): the per-agent audit dir lives at
+  // ~/.switchroom/audit/<name>/ and is chowned alongside state + logs
+  // so the agent-config audit JSONL is writable from inside the container.
+  const expectedAuditDir = join(homedir(), ".switchroom", "audit", "agent");
 
   it("still runs recursive chown even when the top-level dir is already owned (subtree may be stale)", () => {
     // The previous behaviour was a fast-path no-op when statSync said the
@@ -79,11 +83,21 @@ describe("alignAgentUid", () => {
     });
 
     expect(res.chowned).toBe(true);
-    expect(res.paths).toEqual(["/fake/state/agent", expectedLogsDir]);
+    expect(res.paths).toEqual([
+      "/fake/state/agent",
+      expectedLogsDir,
+      expectedAuditDir,
+    ]);
     expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
     const [bin, args] = mockedExecFileSync.mock.calls[0];
     expect(bin).toBe("chown");
-    expect(args).toEqual(["-R", "10042:10042", "/fake/state/agent", expectedLogsDir]);
+    expect(args).toEqual([
+      "-R",
+      "10042:10042",
+      "/fake/state/agent",
+      expectedLogsDir,
+      expectedAuditDir,
+    ]);
   });
 
   it("tries unprivileged chown first, returns success when it works", () => {
@@ -99,7 +113,13 @@ describe("alignAgentUid", () => {
     expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
     const [bin, args] = mockedExecFileSync.mock.calls[0];
     expect(bin).toBe("chown");
-    expect(args).toEqual(["-R", "10042:10042", "/fake/state/agent", expectedLogsDir]);
+    expect(args).toEqual([
+      "-R",
+      "10042:10042",
+      "/fake/state/agent",
+      expectedLogsDir,
+      expectedAuditDir,
+    ]);
   });
 
   it("falls back to `sudo chown` when unprivileged chown fails (EPERM)", () => {
@@ -128,6 +148,7 @@ describe("alignAgentUid", () => {
       "10042:10042",
       "/fake/state/agent",
       expectedLogsDir,
+      expectedAuditDir,
     ]);
   });
 
@@ -173,9 +194,11 @@ describe("alignAgentUid", () => {
   });
 
   it("still chowns when only the logs dir exists (legacy state-only paths absent)", () => {
-    // existsSync returns true for /fake/state/agent (the call argument
-    // sequence in alignAgentUid is agentDir then logsDir).
-    mockedExistsSync.mockImplementation((p) => p !== "/fake/state/agent");
+    // existsSync returns true for everything EXCEPT /fake/state/agent
+    // and the audit dir, isolating the logs-dir-only path.
+    mockedExistsSync.mockImplementation(
+      (p) => p !== "/fake/state/agent" && p !== expectedAuditDir,
+    );
     mockedStatSync.mockReturnValue({ uid: 1000, gid: 1000 } as never);
     mockedExecFileSync.mockImplementationOnce(() => Buffer.from(""));
 
@@ -191,6 +214,40 @@ describe("alignAgentUid", () => {
     expect(args).toEqual(["-R", "10042:10042", expectedLogsDir]);
   });
 
+  // #1831 — the audit dir must be chowned alongside state + logs.
+  // Without this, every appendAudit() call in agent-config.ts is a
+  // silent no-op (write to root-owned dir from agent UID).
+  it("includes the per-agent audit dir in the chown sweep (#1831)", () => {
+    mockedStatSync.mockReturnValue({ uid: 0, gid: 0 } as never);
+    mockedExecFileSync.mockImplementationOnce(() => Buffer.from(""));
+
+    const res = alignAgentUid("agent", "/fake/state/agent", 10042, {
+      writeOut: () => {},
+      confirm: false,
+    });
+
+    expect(res.chowned).toBe(true);
+    expect(res.paths).toContain(expectedAuditDir);
+    const [bin, args] = mockedExecFileSync.mock.calls[0];
+    expect(bin).toBe("chown");
+    expect(args).toContain(expectedAuditDir);
+    expect(args).toContain("10042:10042");
+  });
+
+  it("skips the audit dir if it doesn't exist yet (resilient to fresh installs)", () => {
+    mockedExistsSync.mockImplementation((p) => p !== expectedAuditDir);
+    mockedStatSync.mockReturnValue({ uid: 0, gid: 0 } as never);
+    mockedExecFileSync.mockImplementationOnce(() => Buffer.from(""));
+
+    const res = alignAgentUid("agent", "/fake/state/agent", 10042, {
+      writeOut: () => {},
+      confirm: false,
+    });
+
+    expect(res.chowned).toBe(true);
+    expect(res.paths).not.toContain(expectedAuditDir);
+  });
+
   // PR-D1 / v0.7 coverage gap #4 — when alignAgentUid actually shells
   // chown, it must record the prior owner of every top-level path to
   // ~/.switchroom/.uid-alignment.log so a future rollback can restore
@@ -204,8 +261,9 @@ describe("alignAgentUid", () => {
       confirm: false,
     });
 
-    // Two paths chowned (state dir + logs dir), so two audit lines.
-    expect(mockedAppendFileSync).toHaveBeenCalledTimes(2);
+    // Three paths chowned (state dir + logs dir + audit dir), so
+    // three audit lines.
+    expect(mockedAppendFileSync).toHaveBeenCalledTimes(3);
     for (const call of mockedAppendFileSync.mock.calls) {
       const [logPath, line] = call;
       expect(logPath).toBe(join(homedir(), ".switchroom", ".uid-alignment.log"));

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -194,9 +194,17 @@ export function alignAgentUid(
   // boot and the agent comes up without autoaccept or the gateway daemon.
   // See #880.
   const logsDir = join(homedir(), ".switchroom", "logs", name);
+  // ~/.switchroom/audit/<name>/ holds the agent-config audit JSONL
+  // (appendAudit in src/cli/agent-config.ts). Compose generator pre-
+  // creates the dir at compose.ts:~1750; under `apply`'s sudo self-
+  // elevation that mkdir runs as root → root-owned dir → agent UID
+  // can't appendFileSync → every audit row silently swallowed (#1831).
+  // Include here so the chown sweep aligns ownership.
+  const auditDir = join(homedir(), ".switchroom", "audit", name);
   const paths: string[] = [];
   if (existsSync(agentDir)) paths.push(agentDir);
   if (existsSync(logsDir)) paths.push(logsDir);
+  if (existsSync(auditDir)) paths.push(auditDir);
   if (paths.length === 0) return { chowned: false, paths: [] };
 
   // No fast-path: a previous `apply` may have aligned the top-level dirs

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -291,6 +291,11 @@ async function ensureHostMountSources(config: SwitchroomConfig): Promise<void> {
     dirs.push(join(home, ".switchroom", "agents", name));
     dirs.push(join(home, ".switchroom", "logs", name));
     dirs.push(join(home, ".claude", "projects", name));
+    // Pre-create the per-agent audit dir so alignAgentUid's second pass
+    // can chown it to the agent UID BEFORE compose mounts it (otherwise
+    // generateCompose's mkdirSync would create it as root mid-apply,
+    // leaving the audit log unwritable on fresh installs — #1831).
+    dirs.push(join(home, ".switchroom", "audit", name));
   }
   for (const dir of dirs) {
     await mkdir(dir, { recursive: true });


### PR DESCRIPTION
## Summary

\`~/.switchroom/audit/<agent>/\` is pre-created by the compose generator
under \`apply\`'s sudo self-elevation, making it root-owned. Agent runs
in-container under its allocated UID (10001-10999) → can't
\`appendFileSync\` → every \`appendAudit\` callsite is a silent no-op.

This affected **every** audit row ever shipped, including pre-existing
\`config.get\` / \`cron.list\` / \`skill.list\` denial and success rows
(audit trail was empty on freshly-applied hosts) and the new
\`skill.{init,edit,remove}_personal\` rows from #1829.

## Discovery

v0.13.46 UAT (clerk + test-harness) — audit log empty even after a
successful \`skill.init_personal\`. Manual \`chown -R <uid>:<uid>\` on
each agent's audit dir restored writes. Next \`switchroom apply\` will
now do this automatically.

## Fix

Include \`~/.switchroom/audit/<name>/\` in \`alignAgentUid\`'s chown
sweep (\`src/agents/scaffold.ts\`) alongside the existing state-dir +
logs-dir entries. Same pattern as the #880 log-dir chown.

## Test plan

- [x] 2 new tests in \`scaffold.test.ts\`:
  - audit dir included in chown sweep (paths + args verified)
  - audit dir skipped gracefully when not yet existing (fresh install)
- [x] 4 existing tests updated (chown args went 2 paths → 3)
- [x] All 12 \`scaffold.test.ts\` tests pass
- [x] \`tsc --noEmit\` clean

## Risk

- **Behaviour change is additive** — chown only runs if the dir
  already exists (\`existsSync\` guard), idempotent.
- **Sudo prompt** is unchanged: the existing chown sweep already
  prompts; we're just widening its targets by one dir.
- On hosts with the existing audit-empty bug, the next \`apply\` /
  \`update\` will retroactively fix the bug — no manual ops needed.

## Security implication

With audit writes restored, the agent-config audit log (config-read
denials, cron-list deny-by-default, etc.) is **usable for the first
time** on freshly-applied hosts. The empty-audit-log bug had been
silently masking the security trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)