### PR TITLE
chore: release v0.13.47 — audit-log unblocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## v0.13.47 — audit-log unblocking (closes the silent-audit class)
+
+Two narrow fixes that resolve UAT findings from v0.13.46. The
+headline is that **the agent-config audit log was silently empty on
+every host since the audit feature shipped** — `~/.switchroom/audit/<agent>/`
+was created root-owned by `apply` running under sudo, so every
+`appendAudit` from the in-container agent UID returned EACCES which
+`appendAudit` swallows silently by design. v0.13.46's observability
+work depended on those rows; v0.13.47 actually makes them land.
+
+### fix(scaffold): chown audit dir to agent UID (PR #1833, closes #1831)
+
+`alignAgentUid` now includes `~/.switchroom/audit/<name>/` in its
+chown sweep alongside the existing agent state dir and per-agent log
+dir. Same shape as the #880 log-dir chown; same idempotent sudo
+fallback. `ensureHostMountSources` pre-creates the dir under
+operator umask BEFORE the chown pass so a fresh install lands
+agent-owned in one apply cycle (reviewer caught this — without the
+pre-create, the dir doesn't exist on first apply and the chown is a
+no-op).
+
+Security implication: with audit writes restored, the agent-config
+audit log (config-read denials, cron-list deny-by-default,
+skill.*_personal mutations) is **usable for the first time** on
+freshly-applied hosts. Existing hosts get the fix on next
+`switchroom update` — the manual chown workaround applied during
+v0.13.46 UAT is no longer required.
+
+### fix(observe-personal-skills): surface EACCES (PR #1834, closes #1832)
+
+`scripts/observe-personal-skills.mjs` used to report `files=0 bytes=0`
+for unreadable 0700 personal-skill dirs — silent and misleading. Now
+distinguishes "unreadable" from "empty": per-entry shows `<opaque
+(need sudo)>`, a top-of-report `Unreadable (0700 dirs): N` line
+points at the sudo workaround, and the JSON output carries an
+`unreadable: true` flag plus a `totals.unreadable_personals` rollup.
+
+The dir COUNT — the load-bearing signal for the 60-day Phase 2
+decision rubric — is unchanged. This is observability honesty, not
+a load-bearing fix.
+
 ## v0.13.46 — agent-managed skills follow-ups (UX + observability)
 
 Two small follow-ups to v0.13.45, both surfaced during that release's UAT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.13.46",
+  "version": "0.13.47",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v0.13.47 ships two narrow fixes that resolve UAT findings from v0.13.46:

- **#1833** — \`alignAgentUid\` includes \`~/.switchroom/audit/<name>/\` in
  the chown sweep + \`ensureHostMountSources\` pre-creates the dir under
  operator umask so a fresh install lands agent-owned in one apply
  cycle. (Closes #1831.)
- **#1834** — \`observe-personal-skills.mjs\` surfaces EACCES (\`<opaque
  (need sudo)>\`) instead of silent 0/0. (Closes #1832.)

See the v0.13.47 CHANGELOG section for the per-PR breakdown + the
security framing.

## Headline

The agent-config audit log was silently empty on every host since the
audit feature shipped (\`~/.switchroom/audit/<agent>/\` was created
root-owned by sudo-elevated \`apply\`; in-container agent UID couldn't
write; \`appendAudit\` swallows EACCES). v0.13.47 actually makes the
rows land. v0.13.46's observability instrumentation was correct;
just the storage substrate was broken.

## Test plan

- [x] Each constituent PR reviewed by fresh-process reviewer (#1833 went through one REQUEST_CHANGES + same-PR fix cycle)
- [x] \`node scripts/build.mjs\` exits 0; CLI loads (\`bun dist/cli/switchroom.js --version\` → 0.13.47)
- [x] CHANGELOG entry for v0.13.47

## Rollout

1. Wait for \`docker-images\` workflow (~5 min)
2. \`npm publish --ignore-scripts\` from verified tarball
3. UAT: fresh \`switchroom update\` (without manual chown) → audit dirs land agent-owned → \`skill init-personal\` writes a row that the observability script reads
4. Sequential fleet rollout with \`--version\` assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)