### PR TITLE
fix(scaffold): register repo-context-pretool in settings.json (v0.13.48 hotfix)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3268,6 +3268,37 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
             },
           ],
         },
+        {
+          // PR #1811 / v0.13.48 — repo-context auto-injection.
+          // When the agent's tool call touches a file under a code repo
+          // OUTSIDE its workspace, walk up from the target to find the
+          // nearest CLAUDE.md / AGENTS.md / AGENT.md, read it, and
+          // inject as additionalContext via hookSpecificOutput. Dedups
+          // per session via /tmp/switchroom-repo-context-<session_id>/.
+          // Closes the "non-coder user asks agent to work on ~/code/foo
+          // and the agent forgets the repo's CLAUDE.md" gap.
+          //
+          // Scaffold-side registration MUST mirror what's in
+          // telegram-plugin/hooks/hooks.json — that JSON is the
+          // plugin-system view (loaded when an agent uses
+          // --plugin-dir), but Claude Code reads PreToolUse hooks
+          // from settings.json at session start, which the scaffold
+          // writes from this list. Both must agree or the hook
+          // silently doesn't fire (#1811 UAT caught this on v0.13.48
+          // — settings.json was missing the entry, so Claude Code
+          // never invoked the hook in production).
+          matcher: "^(Read|Edit|Write|MultiEdit|NotebookEdit|Bash)$",
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:repo-context-pretool",
+                `node "${join(DOCKER_HOOKS_PATH, "repo-context-pretool.mjs")}"`,
+              ),
+              timeout: 5,
+            },
+          ],
+        },
       ]
     : [];
 

--- a/tests/reconcile-hooks-drift.test.ts
+++ b/tests/reconcile-hooks-drift.test.ts
@@ -76,6 +76,17 @@ describe("buildSettingsHooksBlock", () => {
       e.hooks.some(h => h.command.includes("subagent-tracker-posttool.mjs")),
     );
     expect(subagentPostEntry?.matcher).toBe("^(Agent|Task)$");
+
+    // PR #1811 / v0.13.48: repo-context-pretool must be registered AND
+    // matched to the file-touching + Bash tools. Drift between the
+    // scaffold list (here) and telegram-plugin/hooks/hooks.json silently
+    // skips the hook — the live UAT for #1811 caught exactly this gap on
+    // v0.13.48 before the v0.13.49 hotfix landed.
+    expect(preCmds.some(c => c.includes("repo-context-pretool.mjs"))).toBe(true);
+    const repoContextEntry = preHooks.find(e =>
+      e.hooks.some(h => h.command.includes("repo-context-pretool.mjs")),
+    );
+    expect(repoContextEntry?.matcher).toBe("^(Read|Edit|Write|MultiEdit|NotebookEdit|Bash)$");
   });
 
   it("with user hooks declared merges them with switchroom-owned hooks", () => {


### PR DESCRIPTION
## Problem

PR #1811 / v0.13.48 added the repo-context PreToolUse hook to \`telegram-plugin/hooks/hooks.json\` (the plugin-system view, loaded when an agent uses \`--plugin-dir\`). But the scaffold writes the agent's \`settings.json\` PreToolUse list from a separate hand-coded array in \`src/agents/scaffold.ts:3184+\`. That list was missed in the original PR, so Claude Code (which reads PreToolUse from settings.json at session start) never invoked the hook in production.

Caught by the live UAT against v0.13.48: agent navigated into \`/state/agent/home/uat-repo/\` with a CLAUDE.md containing \`UAT-1811-MARKER-CONFIRMED\` and the agent replied \`NO MARKER OBSERVED\` — the hook didn't fire. Direct invocation of the hook on the same envelope produces the correct additionalContext (confirmed via \`docker exec ... node /opt/.../repo-context-pretool.mjs < envelope.json\`), so the hook itself is fine — it just wasn't being called.

## Fix

Add the matching entry to scaffold.ts's \`switchroomPreToolUse\` array. Extends the existing \`reconcile-hooks-drift.test.ts\` to pin the registration so a future refactor can't silently regress it.

## Test plan

- [x] \`vitest run tests/reconcile-hooks-drift.test.ts\` — 10 pass (one new assertion)
- [x] \`tsc --noEmit\` clean
- [ ] Post-merge: hotfix release v0.13.49, fleet roll, re-run the UAT scenario and verify the agent's reply now contains \`UAT-1811-MARKER-CONFIRMED\`

## Risk

Low. Pure additive change to a hand-coded list; matches what was already in \`hooks.json\` for the plugin-system path; mirrors how the other 5 hooks are registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)