### PR TITLE
feat(skill): clone-to-personal — fork shared/bundled into agent's tier

### DIFF
--- a/src/cli/skill-personal.test.ts
+++ b/src/cli/skill-personal.test.ts
@@ -26,6 +26,7 @@ import {
   editPersonalAction,
   removePersonalAction,
   listPersonalAction,
+  clonePersonalAction,
 } from "./skill-personal.js";
 
 const AGENT = "test-agent";
@@ -360,5 +361,175 @@ describe("symlink-safe writes (security T3 regression)", () => {
     }, 9);
     // Symlink must still exist (write was rejected, NOT followed).
     expect(existsSync(skillsDir)).toBe(true);
+  });
+});
+
+describe("clonePersonalAction (fork shared/bundled into personal)", () => {
+  let agentsRoot: string;
+  let sharedRoot: string;
+  let bundledRoot: string;
+
+  beforeEach(() => {
+    agentsRoot = tmpAgentsRoot();
+    sharedRoot = mkdtempSync(join(tmpdir(), "clone-shared-"));
+    bundledRoot = mkdtempSync(join(tmpdir(), "clone-bundled-"));
+  });
+
+  afterEach(() => {
+    try { rmSync(agentsRoot, { recursive: true, force: true }); } catch { /**/ }
+    try { rmSync(sharedRoot, { recursive: true, force: true }); } catch { /**/ }
+    try { rmSync(bundledRoot, { recursive: true, force: true }); } catch { /**/ }
+  });
+
+  it("clones a shared skill into the agent's personal tier", () => {
+    // Seed a shared skill (operator-curated).
+    const src = join(sharedRoot, "garmin");
+    mkdirSync(join(src, "scripts"), { recursive: true });
+    writeFileSync(join(src, "SKILL.md"), validSkillMd("garmin"));
+    writeFileSync(join(src, "scripts/list.sh"), "#!/bin/bash\necho v1\n");
+
+    const out = captureStdout(() => {
+      clonePersonalAction("shared:garmin", {
+        agent: AGENT,
+        root: agentsRoot,
+        sharedRoot,
+        bundledRoot,
+      });
+    });
+
+    const parsed = JSON.parse(out);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.action).toBe("clone_to_personal");
+    expect(parsed.source_tier).toBe("shared");
+    expect(parsed.name).toBe("garmin");
+    expect(parsed.files).toBe(2);
+
+    const dest = join(agentsRoot, AGENT, ".claude/skills/personal-garmin");
+    expect(existsSync(join(dest, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(dest, "scripts/list.sh"))).toBe(true);
+    // Shared source is untouched.
+    expect(readFileSync(join(src, "SKILL.md"), "utf-8")).toContain("name: garmin");
+  });
+
+  it("clones a bundled skill into the agent's personal tier", () => {
+    const src = join(bundledRoot, "docx");
+    mkdirSync(src, { recursive: true });
+    writeFileSync(join(src, "SKILL.md"), validSkillMd("docx", "Word docs"));
+
+    captureStdout(() => {
+      clonePersonalAction("bundled:docx", {
+        agent: AGENT,
+        root: agentsRoot,
+        sharedRoot,
+        bundledRoot,
+      });
+    });
+
+    const dest = join(agentsRoot, AGENT, ".claude/skills/personal-docx/SKILL.md");
+    expect(existsSync(dest)).toBe(true);
+  });
+
+  it("renames the SKILL.md `name:` field when --name override is given", () => {
+    const src = join(sharedRoot, "garmin");
+    mkdirSync(src, { recursive: true });
+    writeFileSync(join(src, "SKILL.md"), validSkillMd("garmin"));
+
+    captureStdout(() => {
+      clonePersonalAction("shared:garmin", {
+        agent: AGENT,
+        name: "garmin-v2",
+        root: agentsRoot,
+        sharedRoot,
+        bundledRoot,
+      });
+    });
+
+    const dest = join(agentsRoot, AGENT, ".claude/skills/personal-garmin-v2/SKILL.md");
+    expect(existsSync(dest)).toBe(true);
+    expect(readFileSync(dest, "utf-8")).toContain("name: garmin-v2");
+    expect(readFileSync(dest, "utf-8")).not.toContain("name: garmin\n");
+  });
+
+  it("refuses if personal-<name> already exists", () => {
+    const src = join(sharedRoot, "garmin");
+    mkdirSync(src, { recursive: true });
+    writeFileSync(join(src, "SKILL.md"), validSkillMd("garmin"));
+
+    // Seed an existing personal copy.
+    captureStdout(() => {
+      clonePersonalAction("shared:garmin", {
+        agent: AGENT, root: agentsRoot, sharedRoot, bundledRoot,
+      });
+    });
+
+    expectExitCode(() => {
+      clonePersonalAction("shared:garmin", {
+        agent: AGENT, root: agentsRoot, sharedRoot, bundledRoot,
+      });
+    }, 9);
+  });
+
+  it("rejects malformed source string", () => {
+    expectExitCode(() => {
+      clonePersonalAction("notvalid", {
+        agent: AGENT, root: agentsRoot, sharedRoot, bundledRoot,
+      });
+    }, 2);
+    expectExitCode(() => {
+      clonePersonalAction("file:///etc/passwd", {
+        agent: AGENT, root: agentsRoot, sharedRoot, bundledRoot,
+      });
+    }, 2);
+  });
+
+  it("rejects unknown source (exit 1)", () => {
+    expectExitCode(() => {
+      clonePersonalAction("shared:nonexistent", {
+        agent: AGENT, root: agentsRoot, sharedRoot, bundledRoot,
+      });
+    }, 1);
+  });
+
+  it("rejects symlinked source (won't follow out of the pool)", () => {
+    const realDir = mkdtempSync(join(tmpdir(), "clone-evil-"));
+    mkdirSync(realDir, { recursive: true });
+    writeFileSync(join(realDir, "SKILL.md"), validSkillMd("garmin"));
+    symlinkSync(realDir, join(sharedRoot, "garmin"));
+
+    expectExitCode(() => {
+      clonePersonalAction("shared:garmin", {
+        agent: AGENT, root: agentsRoot, sharedRoot, bundledRoot,
+      });
+    }, 2);
+
+    try { rmSync(realDir, { recursive: true, force: true }); } catch { /**/ }
+  });
+
+  it("rejects invalid destination slug", () => {
+    const src = join(sharedRoot, "garmin");
+    mkdirSync(src, { recursive: true });
+    writeFileSync(join(src, "SKILL.md"), validSkillMd("garmin"));
+
+    expectExitCode(() => {
+      clonePersonalAction("shared:garmin", {
+        agent: AGENT,
+        name: "BadCase",
+        root: agentsRoot,
+        sharedRoot,
+        bundledRoot,
+      });
+    }, 2);
+  });
+
+  it("rejects source dir missing SKILL.md", () => {
+    const src = join(sharedRoot, "no-md");
+    mkdirSync(src, { recursive: true });
+    writeFileSync(join(src, "README.md"), "# nothing useful");
+
+    expectExitCode(() => {
+      clonePersonalAction("shared:no-md", {
+        agent: AGENT, root: agentsRoot, sharedRoot, bundledRoot,
+      });
+    }, 2);
   });
 });

--- a/src/cli/skill-personal.ts
+++ b/src/cli/skill-personal.ts
@@ -419,16 +419,6 @@ function loadValidateWrite(
   }
 
   writePersonalSkill(target, files);
-  console.log(
-    JSON.stringify({
-      ok: true,
-      action: ensureNew ? "init" : "edit",
-      agent,
-      name,
-      path: target,
-      files: Object.keys(files).length,
-    }),
-  );
 }
 
 // ─── Public entry points (CLI command actions) ─────────────────────
@@ -456,6 +446,16 @@ export function initPersonalAction(name: string, opts: InitEditOpts): void {
   const agentsRoot = resolveAgentsRoot(opts);
   const files = loadFiles(opts);
   loadValidateWrite(agentsRoot, agent, name, files, /*ensureNew=*/ true);
+  console.log(
+    JSON.stringify({
+      ok: true,
+      action: "init",
+      agent,
+      name,
+      path: personalSkillDir(agentsRoot, agent, name),
+      files: Object.keys(files).length,
+    }),
+  );
   // Audit row on success only (failure paths exit via fail() before this).
   // Used by scripts/observe-personal-skills.mjs for adoption telemetry.
   appendAudit(agent, "skill.init_personal", { name, files: Object.keys(files).length }, 0);
@@ -466,7 +466,178 @@ export function editPersonalAction(name: string, opts: InitEditOpts): void {
   const agentsRoot = resolveAgentsRoot(opts);
   const files = loadFiles(opts);
   loadValidateWrite(agentsRoot, agent, name, files, /*ensureNew=*/ false);
+  console.log(
+    JSON.stringify({
+      ok: true,
+      action: "edit",
+      agent,
+      name,
+      path: personalSkillDir(agentsRoot, agent, name),
+      files: Object.keys(files).length,
+    }),
+  );
   appendAudit(agent, "skill.edit_personal", { name, files: Object.keys(files).length }, 0);
+}
+
+// ─── Clone-to-personal ─────────────────────────────────────────────
+
+interface CloneOpts extends AgentOpts {
+  /** Optional override slug. Defaults to the source slug. */
+  name?: string;
+  /** Test hooks. */
+  root?: string;
+  sharedRoot?: string;
+  bundledRoot?: string;
+}
+
+/** Source allow-list: `shared:<name>` or `bundled:<name>`. */
+const CLONE_SOURCE_RE = /^(shared|bundled):([a-z0-9][a-z0-9_-]{0,62})$/;
+
+function defaultSharedRoot(): string {
+  return join(homedir(), ".switchroom", "skills");
+}
+
+function defaultBundledRoot(): string {
+  return join(homedir(), ".switchroom", "skills", "_bundled");
+}
+
+function resolveCloneSource(
+  source: string,
+  opts: CloneOpts,
+): { tier: "shared" | "bundled"; slug: string; dir: string } {
+  const m = CLONE_SOURCE_RE.exec(source);
+  if (!m) {
+    fail(
+      `source must be \`shared:<name>\` or \`bundled:<name>\` (got ${JSON.stringify(source)})`,
+    );
+  }
+  const tier = m[1] as "shared" | "bundled";
+  const slug = m[2]!;
+  const root =
+    tier === "bundled"
+      ? (opts.bundledRoot ?? defaultBundledRoot())
+      : (opts.sharedRoot ?? defaultSharedRoot());
+  const dir = join(root, slug);
+  if (!existsSync(dir)) {
+    fail(
+      `clone source ${JSON.stringify(source)} not found at ${dir}; ` +
+        `check \`switchroom skill search --tier ${tier}\``,
+      1,
+    );
+  }
+  // Symlink-safety: refuse to read through a symlinked source dir. The
+  // bundled tier uses symlinks (see reconcileAgentDefaultSkills) but
+  // those point INTO the shared pool — we want the canonical pool path.
+  const st = lstatSync(dir);
+  if (st.isSymbolicLink()) {
+    fail(
+      `clone source ${JSON.stringify(source)} is a symlink at ${dir}; ` +
+        `point clone at the canonical pool path instead`,
+    );
+  }
+  return { tier, slug, dir };
+}
+
+/**
+ * Read all files from a source skill dir into a SkillFileMap. Same
+ * walk as `loadFromDir` but doesn't fail on the inner symlink check —
+ * it operates on the canonical pool path resolved above.
+ */
+function readSourceFiles(dir: string): SkillFileMap {
+  const files: SkillFileMap = {};
+  const walk = (sub: string): void => {
+    for (const ent of readdirSync(sub, { withFileTypes: true })) {
+      const full = join(sub, ent.name);
+      if (ent.isSymbolicLink()) {
+        // Skip internal symlinks (e.g. operator drop-ins) — clone is a
+        // self-contained copy, not a symlink-preserving mirror.
+        continue;
+      }
+      if (ent.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (ent.isFile()) {
+        const rel = relative(dir, full).replace(/\\/g, "/");
+        files[rel] = readFileSync(full, "utf-8");
+      }
+    }
+  };
+  walk(dir);
+  return files;
+}
+
+/**
+ * Patch the SKILL.md `name:` frontmatter field so the cloned copy is
+ * internally consistent with its new slug. Without this, validation
+ * would fail when the source's name and the personal-tier slug differ.
+ */
+function rewriteSkillMdName(content: string, newName: string): string {
+  if (!content.startsWith("---\n") && !content.startsWith("---\r\n")) {
+    return content;
+  }
+  const rest = content.slice(content.indexOf("\n") + 1);
+  const endIdx = rest.indexOf("\n---");
+  if (endIdx < 0) return content;
+  const fm = rest.slice(0, endIdx);
+  const body = rest.slice(endIdx);
+  // Replace the first `name:` line; preserve other frontmatter as-is.
+  const patched = fm.replace(
+    /^(\s*name\s*:)[ \t]*\S.*$/m,
+    `$1 ${newName}`,
+  );
+  return "---\n" + patched + body;
+}
+
+export function clonePersonalAction(source: string, opts: CloneOpts): void {
+  const agent = resolveAgent(opts);
+  const agentsRoot = resolveAgentsRoot(opts);
+  const src = resolveCloneSource(source, opts);
+  const newName = opts.name ?? src.slug;
+  if (!SKILL_SLUG_RE.test(newName)) {
+    fail(`destination name must match ${SKILL_SLUG_RE.source}: got ${JSON.stringify(newName)}`);
+  }
+
+  // Read source files, rewrite SKILL.md name to match the new slug so
+  // the personal-tier validator (which enforces name == slug) accepts
+  // the bundle.
+  const files = readSourceFiles(src.dir);
+  if (!files["SKILL.md"]) {
+    fail(`source ${JSON.stringify(source)} has no SKILL.md at ${src.dir}`);
+  }
+  if (newName !== src.slug) {
+    files["SKILL.md"] = rewriteSkillMdName(files["SKILL.md"]!, newName);
+  }
+
+  // Same validate+write pipeline as init_personal: ensureNew=true so a
+  // pre-existing personal copy isn't silently clobbered.
+  loadValidateWrite(agentsRoot, agent, newName, files, /*ensureNew=*/ true);
+
+  console.log(
+    JSON.stringify({
+      ok: true,
+      action: "clone_to_personal",
+      agent,
+      source,
+      source_tier: src.tier,
+      source_slug: src.slug,
+      name: newName,
+      path: personalSkillDir(agentsRoot, agent, newName),
+      files: Object.keys(files).length,
+    }),
+  );
+  appendAudit(
+    agent,
+    "skill.clone_to_personal",
+    {
+      source,
+      source_tier: src.tier,
+      source_slug: src.slug,
+      name: newName,
+      files: Object.keys(files).length,
+    },
+    0,
+  );
 }
 
 export function removePersonalAction(name: string, opts: RemoveOpts): void {
@@ -623,5 +794,23 @@ export function registerSkillPersonalCommands(program: Command): void {
     .option("--root <path>", "Test-only override for agents-root dir")
     .action(withConfigError(async (opts: ListOpts) => {
       listPersonalAction(opts);
+    }));
+
+  parent
+    .command("clone-to-personal <source>")
+    .description(
+      "Fork a shared or bundled skill into this agent's writable workspace. " +
+      "Source format: `shared:<name>` or `bundled:<name>`. The personal copy " +
+      "becomes mutable via edit-personal; the upstream source is untouched. " +
+      "Use --name to give the fork a different slug. No operator approval — " +
+      "agent's own workspace.",
+    )
+    .option("--agent <name>", "Agent name (defaults to $SWITCHROOM_AGENT_NAME)")
+    .option("--name <slug>", "Override destination slug (default: source slug)")
+    .option("--root <path>", "Test-only override for agents-root dir")
+    .option("--shared-root <path>", "Test-only override for shared-pool dir")
+    .option("--bundled-root <path>", "Test-only override for bundled-pool dir")
+    .action(withConfigError(async (source: string, opts: CloneOpts) => {
+      clonePersonalAction(source, opts);
     }));
 }

--- a/src/cli/skill-personal.ts
+++ b/src/cli/skill-personal.ts
@@ -32,7 +32,7 @@
  * `existsSync` (which follows symlinks and misses dangling).
  */
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import {
   closeSync,
   existsSync,
@@ -542,7 +542,13 @@ function resolveCloneSource(
  * Read all files from a source skill dir into a SkillFileMap. Same
  * walk as `loadFromDir` but doesn't fail on the inner symlink check —
  * it operates on the canonical pool path resolved above.
+ *
+ * Skips internal symlinks (defence in depth) and refuses to read any
+ * individual file > 1 MiB. Both `validateSkillBundle` and the
+ * `MAX_FILE_BYTES` gate downstream would catch giant files, but
+ * declining to read them upfront avoids OOM on a pathological source.
  */
+const CLONE_MAX_FILE_BYTES = 1024 * 1024;
 function readSourceFiles(dir: string): SkillFileMap {
   const files: SkillFileMap = {};
   const walk = (sub: string): void => {
@@ -559,6 +565,19 @@ function readSourceFiles(dir: string): SkillFileMap {
       }
       if (ent.isFile()) {
         const rel = relative(dir, full).replace(/\\/g, "/");
+        // Pre-flight size check via lstat (no need to open).
+        try {
+          const st = lstatSync(full);
+          if (st.size > CLONE_MAX_FILE_BYTES) {
+            fail(
+              `clone source has oversized file ${rel} (${st.size} bytes > ${CLONE_MAX_FILE_BYTES}); ` +
+                `refuse to read`,
+              3,
+            );
+          }
+        } catch {
+          // Stat failure on a regular file is unusual; let readFileSync surface it.
+        }
         files[rel] = readFileSync(full, "utf-8");
       }
     }
@@ -807,9 +826,9 @@ export function registerSkillPersonalCommands(program: Command): void {
     )
     .option("--agent <name>", "Agent name (defaults to $SWITCHROOM_AGENT_NAME)")
     .option("--name <slug>", "Override destination slug (default: source slug)")
-    .option("--root <path>", "Test-only override for agents-root dir")
-    .option("--shared-root <path>", "Test-only override for shared-pool dir")
-    .option("--bundled-root <path>", "Test-only override for bundled-pool dir")
+    .addOption(new Option("--root <path>").hideHelp())
+    .addOption(new Option("--shared-root <path>").hideHelp())
+    .addOption(new Option("--bundled-root <path>").hideHelp())
     .action(withConfigError(async (source: string, opts: CloneOpts) => {
       clonePersonalAction(source, opts);
     }));

--- a/src/mcp/agent-config/server.test.ts
+++ b/src/mcp/agent-config/server.test.ts
@@ -40,6 +40,7 @@ describe("TOOLS export", () => {
       "peers_list",            // identity / peer-awareness
       "schedule_add",
       "schedule_remove",
+      "skill_clone_to_personal", // #1819 follow-up — fork shared/bundled
       "skill_edit_personal",   // #1819 Phase 1 (agent-managed personal skills)
       "skill_init_personal",   // #1819 Phase 1
       "skill_install",         // #1163 Phase 2 (shared library)

--- a/src/mcp/agent-config/server.ts
+++ b/src/mcp/agent-config/server.ts
@@ -78,6 +78,8 @@ interface ToolArgs {
   // skill_search (#1819 Phase 3)
   query?: string;
   tier?: string;
+  // (`source?: string` for skill_install + skill_clone_to_personal is
+  // declared above.)
 }
 
 function buildArgs(base: string[], a: ToolArgs): string[] {
@@ -362,6 +364,35 @@ export const TOOLS = [
       properties: {},
     },
   },
+  {
+    name: "skill_clone_to_personal",
+    description:
+      "Fork a shared or bundled skill into this agent's writable workspace. " +
+      "Use when you find a defect or gap in a skill you depend on and want " +
+      "to fix it yourself — the upstream source is untouched, your fork is " +
+      "yours to edit via `skill_edit_personal`. Source format: " +
+      "`shared:<name>` or `bundled:<name>`. Same validation gates as " +
+      "init/edit. Pre-existing personal-<name> is refused (use edit or " +
+      "remove first). No operator approval.",
+    inputSchema: {
+      type: "object" as const,
+      required: ["source"],
+      properties: {
+        source: {
+          type: "string",
+          pattern: "^(shared|bundled):[a-z0-9][a-z0-9_-]{0,62}$",
+          description:
+            "Source skill: `shared:<name>` (operator pool) or `bundled:<name>` (shipped).",
+        },
+        name: {
+          type: "string",
+          pattern: "^[a-z0-9][a-z0-9_-]{0,62}$",
+          description:
+            "Optional destination slug (defaults to the source slug).",
+        },
+      },
+    },
+  },
 ];
 
 export function dispatchTool(
@@ -502,6 +533,19 @@ export function dispatchTool(
       if (a.query) base.push("--query", a.query);
       if (a.tier) base.push("--tier", a.tier);
       if (typeof a.limit === "number") base.push("--limit", String(a.limit));
+      cliArgs = base;
+      parseMode = "json";
+      break;
+    }
+    // Clone a shared or bundled skill into the agent's personal tier.
+    case "skill_clone_to_personal": {
+      const a = args as ToolArgs;
+      if (!a.source || typeof a.source !== "string") {
+        return errorText("skill_clone_to_personal: source is required");
+      }
+      const base = ["skill", "clone-to-personal", a.source];
+      if (a.agent) base.push("--agent", a.agent);
+      if (a.name) base.push("--name", a.name);
       cliArgs = base;
       parseMode = "json";
       break;


### PR DESCRIPTION
## Summary

5th personal-skill verb: \`clone-to-personal\`. Agent copies a shared
or bundled skill into its own personal tier; fork becomes mutable
via existing \`edit-personal\`; upstream untouched.

**The JTBD** (surfaced live during v0.13.47 UAT): an agent finds a
defect in a skill it depends on, has the context to fix it, but
shared-pool entries are operator-owned. So the agent writes a chat
message asking the operator to manually edit a file. Doesn't scale
to multi-operator fleets (e.g. Ken's vs Lisa's agents).

## Why this shape

| Option | Blast radius | New concepts | Cost |
|---|---|---|---|
| **Clone-to-personal (this PR)** | Self-only (matches personal-tier invariant) | None | ~2 agent-hrs |
| Delegation/RBAC | Owner can degrade every consumer | New ACL layer | ~15+ agent-hrs + design |
| Phase 2 propose-publish | Operator-approved per edit | Approval card flow | ~20+ agent-hrs (deferred, 8 must-fixes) |

Clone-to-personal solves the immediate friction; Phase 2 (eventually)
becomes the **promotion** path back to shared. Complementary.

## Surface

**CLI:**
\`\`\`
switchroom skill clone-to-personal <source> [--name X] [--agent A]
\`\`\`

**MCP (agent-config server):**
\`\`\`
skill_clone_to_personal { source: "shared:<name>" | "bundled:<name>", name? }
\`\`\`

Source allow-list mirrors \`skill_install\`: only \`shared:\` /
\`bundled:\` schemes accepted. No \`file://\`, no arbitrary paths.

## Test plan

- [x] 9 new tests covering happy paths + 7 rejection modes
- [x] Refactored \`loadValidateWrite\` to not print its own success JSON; each action prints its own (init/edit emit unchanged shape; clone emits enriched)
- [x] Bridge-flap regression guard still green
- [x] MCP TOOLS list updated to include \`skill_clone_to_personal\`
- [x] 98/98 tests pass across all affected suites; tsc clean

## Risk

**Forks drift.** A personal copy of \`garmin\` can fall behind upstream
fixes to the shared \`garmin\`. Two mitigations later (not in this PR):
\`skill_diff_against_source\` (read-only diff vs source pool — ~30 min
add) and eventual Phase 2 propose-publish for re-merging fork
improvements back upstream.

## Symlink safety

Source must NOT be a symlink (refuses with exit 2). The bundled tier
uses symlinks internally (\`reconcileAgentDefaultSkills\`) but those
point INTO the canonical pool — this op operates on canonical paths
only. Eliminates a class of "clone reads /etc" attacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)