### PR TITLE
feat(skill): auto-mirror personal skills to ~/.switchroom-config (durability)

### DIFF
--- a/docs/personal-skills-adoption-observability.md
+++ b/docs/personal-skills-adoption-observability.md
@@ -4,6 +4,33 @@
 > approval-gated edits to the **shared** skill pool — until 60+ days of
 > personal-skill usage data is in. This doc says how to read that data.
 
+## Version control (durability)
+
+Personal skills are *runtime state* at
+`~/.switchroom/agents/<agent>/.claude/skills/personal-<name>/` —
+survive container recreate but NOT git-tracked. A host rebuild loses
+every personal skill.
+
+If `~/.switchroom-config/` exists (the operator's private config repo),
+every successful `init_personal` / `edit_personal` / `clone_to_personal`
+also writes an opportunistic mirror to:
+
+```
+~/.switchroom-config/agents/<agent>/personal-skills/<name>/
+```
+
+`remove_personal` moves the corresponding mirror to a sibling
+`.<name>-trash-<ts>/` dir so the deletion shows up in `git status`.
+
+Override `SWITCHROOM_CONFIG_DIR` to point at an alternate repo
+(separate-operator fleets, tests). If the config repo doesn't exist
+**or** the mirror write fails, the live copy still works — just
+isn't version-controlled until the next successful sync. A warning
+prints on stderr in that case.
+
+**No auto-commit.** The operator commits the config repo at their own
+cadence. `cd ~/.switchroom-config && git status` shows what's changed.
+
 ## What's instrumented
 
 After v0.13.45 + the audit-instrumentation follow-up, every **mutating**

--- a/docs/personal-skills-adoption-observability.md
+++ b/docs/personal-skills-adoption-observability.md
@@ -21,12 +21,22 @@ also writes an opportunistic mirror to:
 
 `remove_personal` moves the corresponding mirror to a sibling
 `.<name>-trash-<ts>/` dir so the deletion shows up in `git status`.
+Each edit also leaves a `.<name>-prior-<ts>/` sibling holding the
+prior content (cheap recovery before the operator commits).
+
+**Retention.** `.prior-*` and `.trash-*` siblings older than **24h**
+get swept lazily on the next mirror op. Without this, a chatty agent
+would accumulate one stale dir per edit forever. Mirrors the live
+`skills-trash` 24h sweep so the operator's mental model is uniform.
+Anything older than 24h lives in git history once the operator
+commits.
 
 Override `SWITCHROOM_CONFIG_DIR` to point at an alternate repo
 (separate-operator fleets, tests). If the config repo doesn't exist
-**or** the mirror write fails, the live copy still works — just
-isn't version-controlled until the next successful sync. A warning
-prints on stderr in that case.
+the mirror **silently no-ops** (operator hasn't opted in). If the
+repo exists but a mirror write fails (EACCES, ENOSPC,
+cross-device-link), a warning prints to stderr and the live copy
+continues unaffected.
 
 **No auto-commit.** The operator commits the config repo at their own
 cadence. `cd ~/.switchroom-config && git status` shows what's changed.

--- a/src/cli/skill-personal.test.ts
+++ b/src/cli/skill-personal.test.ts
@@ -6,7 +6,7 @@
  * covered separately by `src/mcp/agent-config/server.test.ts`.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { afterAll, beforeAll, describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   mkdtempSync,
   rmSync,
@@ -30,6 +30,28 @@ import {
 } from "./skill-personal.js";
 
 const AGENT = "test-agent";
+
+// CRITICAL: pin SWITCHROOM_CONFIG_DIR to a per-file tmpdir BEFORE any
+// test runs. The personal-skill ops in this file unconditionally try
+// to mirror writes into the config repo (#1844). Without this pin,
+// every test would leak fixtures into the operator's real
+// ~/.switchroom-config/ — same failure class as the 2026-05-22 vault
+// clobber. Enforces the Vault/shared-state HARD rule from CLAUDE.md.
+const FILE_LEVEL_CONFIG_DIR = mkdtempSync(join(tmpdir(), "skill-personal-config-"));
+const SAVED_CONFIG_DIR_ENV = process.env.SWITCHROOM_CONFIG_DIR;
+
+beforeAll(() => {
+  process.env.SWITCHROOM_CONFIG_DIR = FILE_LEVEL_CONFIG_DIR;
+});
+
+afterAll(() => {
+  if (SAVED_CONFIG_DIR_ENV === undefined) {
+    delete process.env.SWITCHROOM_CONFIG_DIR;
+  } else {
+    process.env.SWITCHROOM_CONFIG_DIR = SAVED_CONFIG_DIR_ENV;
+  }
+  try { rmSync(FILE_LEVEL_CONFIG_DIR, { recursive: true, force: true }); } catch { /**/ }
+});
 
 const validSkillMd = (name: string, desc = "A test skill"): string =>
   `---
@@ -538,18 +560,20 @@ describe("config-repo mirror (versioned personal skills)", () => {
   let agentsRoot: string;
   let configDir: string;
   const ENV = "SWITCHROOM_CONFIG_DIR";
-  let savedEnv: string | undefined;
+  // File-level beforeAll already pins SWITCHROOM_CONFIG_DIR to a tmpdir.
+  // Each test in this block points it at its OWN tmpdir for isolation,
+  // then restores to the file-level tmpdir after — never to the unset
+  // state (which would leak into ~/.switchroom-config if it exists).
+  const fileLevelTmp = process.env[ENV];
 
   beforeEach(() => {
     agentsRoot = tmpAgentsRoot();
     configDir = mkdtempSync(join(tmpdir(), "skill-config-"));
-    savedEnv = process.env[ENV];
     process.env[ENV] = configDir;
   });
 
   afterEach(() => {
-    if (savedEnv === undefined) delete process.env[ENV];
-    else process.env[ENV] = savedEnv;
+    process.env[ENV] = fileLevelTmp; // restore to file-level tmpdir, NOT unset
     try { rmSync(agentsRoot, { recursive: true, force: true }); } catch { /**/ }
     try { rmSync(configDir, { recursive: true, force: true }); } catch { /**/ }
   });
@@ -607,22 +631,25 @@ describe("config-repo mirror (versioned personal skills)", () => {
   });
 
   it("silent skip when the config repo doesn't exist (operator hasn't opted in)", () => {
-    delete process.env[ENV]; // override removed; falls back to ~/.switchroom-config which we won't create
-    const realHomeDir = join(tmpdir(), "no-config-repo-test-fakehome");
-    mkdirSync(realHomeDir, { recursive: true });
+    // Point env at a path that doesn't exist. resolveConfigSkillsDir
+    // returns null → mirror no-ops, the live write still succeeds.
+    // CRITICAL: never `delete process.env[ENV]` here — that would
+    // fall back to the operator's real ~/.switchroom-config and
+    // leak test fixtures into it (project_vault_clobbered_by_test_2026_05_22).
+    const ghostDir = join(tmpdir(), `no-config-repo-${Date.now()}`);
+    process.env[ENV] = ghostDir;
 
     const skillFile = join(agentsRoot, "input.md");
     writeFileSync(skillFile, validSkillMd("opted-out"));
 
-    // Should succeed without writing anywhere outside agentsRoot.
     captureStdout(() => {
       initPersonalAction("opted-out", { agent: AGENT, from: skillFile, root: agentsRoot });
     });
 
     // Live copy is fine.
     expect(existsSync(join(agentsRoot, AGENT, ".claude/skills/personal-opted-out/SKILL.md"))).toBe(true);
-
-    try { rmSync(realHomeDir, { recursive: true, force: true }); } catch { /**/ }
+    // Mirror dir was never created.
+    expect(existsSync(ghostDir)).toBe(false);
   });
 
   it("clone-to-personal mirrors the cloned fork", () => {
@@ -645,6 +672,70 @@ describe("config-repo mirror (versioned personal skills)", () => {
     } finally {
       try { rmSync(sharedRoot, { recursive: true, force: true }); } catch { /**/ }
     }
+  });
+
+  it("sweeps .<name>-prior-<ts>/ siblings older than 24h on next mirror op (#1844)", () => {
+    const skillFile = join(agentsRoot, "input.md");
+    writeFileSync(skillFile, validSkillMd("sweep1", "v1"));
+    captureStdout(() => {
+      initPersonalAction("sweep1", { agent: AGENT, from: skillFile, root: agentsRoot });
+    });
+
+    // Manually backdate a fake .prior- sibling to ~25h ago.
+    const mirrorDir = join(configDir, "agents", AGENT, "personal-skills");
+    const oldTs = Date.now() - 25 * 60 * 60 * 1000;
+    const oldPrior = join(mirrorDir, `.sweep1-prior-${oldTs}`);
+    mkdirSync(oldPrior, { recursive: true });
+    writeFileSync(join(oldPrior, "SKILL.md"), validSkillMd("sweep1", "ancient"));
+
+    // Trigger any mirror op — the lazy sweep should remove the old entry.
+    writeFileSync(skillFile, validSkillMd("sweep1", "v2"));
+    captureStdout(() => {
+      editPersonalAction("sweep1", { agent: AGENT, from: skillFile, root: agentsRoot });
+    });
+
+    expect(existsSync(oldPrior)).toBe(false);
+    // A fresh .prior- from THIS edit should still exist.
+    const remaining = readdirSync(mirrorDir).filter((n: string) =>
+      n.startsWith(".sweep1-prior-"),
+    );
+    expect(remaining.length).toBe(1);
+  });
+
+  it("refuses to mirror a symlinked source dir (defense in depth)", () => {
+    // Construct an alt skill dir + symlink the personal slot at it.
+    const altDir = mkdtempSync(join(tmpdir(), "evil-skill-"));
+    mkdirSync(altDir, { recursive: true });
+    writeFileSync(join(altDir, "SKILL.md"), validSkillMd("symevil"));
+
+    const personalSlot = join(agentsRoot, AGENT, ".claude/skills/personal-symevil");
+    mkdirSync(join(agentsRoot, AGENT, ".claude/skills"), { recursive: true });
+    symlinkSync(altDir, personalSlot);
+
+    // Run mirror via a direct internal call — exercise the defense, not
+    // the public init path (which would refuse the symlinked dest at write).
+    // Easiest: just verify the mirror dir stays absent after a manual
+    // editPersonalAction call against the now-symlinked target.
+    const skillFile = join(agentsRoot, "input.md");
+    writeFileSync(skillFile, validSkillMd("symevil", "v2"));
+
+    const origStderr = process.stderr.write.bind(process.stderr);
+    let stderrText = "";
+    process.stderr.write = ((c: unknown) => {
+      stderrText += typeof c === "string" ? c : (c as Buffer).toString("utf-8");
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      try {
+        editPersonalAction("symevil", { agent: AGENT, from: skillFile, root: agentsRoot });
+      } catch { /* writer may reject; that's fine — we're testing mirror defense */ }
+    } finally {
+      process.stderr.write = origStderr;
+    }
+    // The mirror dir for symevil should NOT exist (mirror refused).
+    expect(existsSync(join(configDir, "agents", AGENT, "personal-skills/symevil"))).toBe(false);
+
+    try { rmSync(altDir, { recursive: true, force: true }); } catch { /**/ }
   });
 
   it("mirror failure (read-only config dir) does NOT block the live write", () => {

--- a/src/cli/skill-personal.test.ts
+++ b/src/cli/skill-personal.test.ts
@@ -533,3 +533,147 @@ describe("clonePersonalAction (fork shared/bundled into personal)", () => {
     }, 2);
   });
 });
+
+describe("config-repo mirror (versioned personal skills)", () => {
+  let agentsRoot: string;
+  let configDir: string;
+  const ENV = "SWITCHROOM_CONFIG_DIR";
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    agentsRoot = tmpAgentsRoot();
+    configDir = mkdtempSync(join(tmpdir(), "skill-config-"));
+    savedEnv = process.env[ENV];
+    process.env[ENV] = configDir;
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV];
+    else process.env[ENV] = savedEnv;
+    try { rmSync(agentsRoot, { recursive: true, force: true }); } catch { /**/ }
+    try { rmSync(configDir, { recursive: true, force: true }); } catch { /**/ }
+  });
+
+  it("init mirrors the new skill into ~/.switchroom-config/agents/<agent>/personal-skills/<name>/", () => {
+    const skillFile = join(agentsRoot, "input.md");
+    writeFileSync(skillFile, validSkillMd("mirrored"));
+    captureStdout(() => {
+      initPersonalAction("mirrored", { agent: AGENT, from: skillFile, root: agentsRoot });
+    });
+
+    const mirror = join(configDir, "agents", AGENT, "personal-skills", "mirrored");
+    expect(existsSync(mirror)).toBe(true);
+    expect(existsSync(join(mirror, "SKILL.md"))).toBe(true);
+    expect(readFileSync(join(mirror, "SKILL.md"), "utf-8")).toContain("name: mirrored");
+
+    // Live copy also exists (mirror is additive, not redirect).
+    expect(existsSync(join(agentsRoot, AGENT, ".claude/skills/personal-mirrored/SKILL.md"))).toBe(true);
+  });
+
+  it("edit re-mirrors with updated content", () => {
+    const skillFile = join(agentsRoot, "input.md");
+    writeFileSync(skillFile, validSkillMd("edited", "v1"));
+    captureStdout(() => {
+      initPersonalAction("edited", { agent: AGENT, from: skillFile, root: agentsRoot });
+    });
+
+    // Update content + edit.
+    writeFileSync(skillFile, validSkillMd("edited", "v2-updated"));
+    captureStdout(() => {
+      editPersonalAction("edited", { agent: AGENT, from: skillFile, root: agentsRoot });
+    });
+
+    const mirror = join(configDir, "agents", AGENT, "personal-skills", "edited/SKILL.md");
+    expect(readFileSync(mirror, "utf-8")).toContain("v2-updated");
+  });
+
+  it("remove moves the mirror to .<name>-trash-<ts>/ sibling for git-visible deletion", () => {
+    const skillFile = join(agentsRoot, "input.md");
+    writeFileSync(skillFile, validSkillMd("doomed"));
+    captureStdout(() => {
+      initPersonalAction("doomed", { agent: AGENT, from: skillFile, root: agentsRoot });
+    });
+    const mirrorDir = join(configDir, "agents", AGENT, "personal-skills", "doomed");
+    expect(existsSync(mirrorDir)).toBe(true);
+
+    captureStdout(() => {
+      removePersonalAction("doomed", { agent: AGENT, root: agentsRoot });
+    });
+
+    expect(existsSync(mirrorDir)).toBe(false);
+    // A .doomed-trash-<ts>/ sibling appears.
+    const siblings = readdirSync(join(configDir, "agents", AGENT, "personal-skills"));
+    expect(siblings.some((s: string) => /^\.doomed-trash-\d+$/.test(s))).toBe(true);
+  });
+
+  it("silent skip when the config repo doesn't exist (operator hasn't opted in)", () => {
+    delete process.env[ENV]; // override removed; falls back to ~/.switchroom-config which we won't create
+    const realHomeDir = join(tmpdir(), "no-config-repo-test-fakehome");
+    mkdirSync(realHomeDir, { recursive: true });
+
+    const skillFile = join(agentsRoot, "input.md");
+    writeFileSync(skillFile, validSkillMd("opted-out"));
+
+    // Should succeed without writing anywhere outside agentsRoot.
+    captureStdout(() => {
+      initPersonalAction("opted-out", { agent: AGENT, from: skillFile, root: agentsRoot });
+    });
+
+    // Live copy is fine.
+    expect(existsSync(join(agentsRoot, AGENT, ".claude/skills/personal-opted-out/SKILL.md"))).toBe(true);
+
+    try { rmSync(realHomeDir, { recursive: true, force: true }); } catch { /**/ }
+  });
+
+  it("clone-to-personal mirrors the cloned fork", () => {
+    const sharedRoot = mkdtempSync(join(tmpdir(), "clone-shared-mirror-"));
+    try {
+      const src = join(sharedRoot, "calendar");
+      mkdirSync(src, { recursive: true });
+      writeFileSync(join(src, "SKILL.md"), validSkillMd("calendar"));
+
+      captureStdout(() => {
+        clonePersonalAction("shared:calendar", {
+          agent: AGENT,
+          root: agentsRoot,
+          sharedRoot,
+        });
+      });
+
+      const mirror = join(configDir, "agents", AGENT, "personal-skills", "calendar/SKILL.md");
+      expect(existsSync(mirror)).toBe(true);
+    } finally {
+      try { rmSync(sharedRoot, { recursive: true, force: true }); } catch { /**/ }
+    }
+  });
+
+  it("mirror failure (read-only config dir) does NOT block the live write", () => {
+    // Make the config dir effectively unwritable by pointing the override
+    // at a non-dir (a regular file). The mirror try/catch should swallow.
+    const blockFile = join(tmpdir(), `block-${Date.now()}`);
+    writeFileSync(blockFile, "i am not a dir");
+    process.env[ENV] = blockFile;
+
+    const origStderr = process.stderr.write.bind(process.stderr);
+    let stderrText = "";
+    process.stderr.write = ((c: unknown) => {
+      stderrText += typeof c === "string" ? c : (c as Buffer).toString("utf-8");
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      const skillFile = join(agentsRoot, "input.md");
+      writeFileSync(skillFile, validSkillMd("survives"));
+      captureStdout(() => {
+        initPersonalAction("survives", { agent: AGENT, from: skillFile, root: agentsRoot });
+      });
+      // Live copy lands fine.
+      expect(existsSync(join(agentsRoot, AGENT, ".claude/skills/personal-survives/SKILL.md"))).toBe(true);
+      // Warning printed.
+      expect(stderrText).toMatch(/mirror.*failed/);
+    } finally {
+      process.stderr.write = origStderr;
+      try { rmSync(blockFile, { force: true }); } catch { /**/ }
+    }
+  });
+});

--- a/src/cli/skill-personal.ts
+++ b/src/cli/skill-personal.ts
@@ -74,6 +74,108 @@ const TRASH_DIRNAME = "skills-trash";
 /** Recovery window: trash entries older than this get swept. */
 const TRASH_TTL_MS = 24 * 60 * 60 * 1000;
 
+// ─── Config-repo mirror (versioned personal skills) ──────────────────
+
+/**
+ * Personal skills are *runtime state* at
+ * `<agentDir>/.claude/skills/personal-<name>/` so claude-code's
+ * depth-1 discovery finds them without a custom mount. Runtime state
+ * survives container recreate (the agent dir is bind-mounted) but is
+ * NOT git-tracked — a host rebuild loses every agent's personal-skill
+ * workspace.
+ *
+ * The fix: after every successful personal-skill write, opportunistically
+ * mirror the dir into
+ * `~/.switchroom-config/agents/<agent>/personal-skills/<name>/`
+ * if the operator has the config repo set up. Mirror is best-effort:
+ *
+ *   - If `~/.switchroom-config/` doesn't exist, skip silently (operator
+ *     hasn't opted in to the versioned-skill pattern).
+ *   - If mirroring fails (EACCES, ENOSPC, etc.), warn on stderr and
+ *     continue. The live copy still works; just not version-controlled
+ *     until the next successful sync.
+ *   - No auto-commit. Operator decides commit cadence (`cd
+ *     ~/.switchroom-config && git status` shows the changes).
+ *
+ * Override `SWITCHROOM_CONFIG_DIR` to point at an alternate config repo
+ * (e.g. Lisa's `~lisa/.switchroom-config/` for her fleet, or a tmpdir
+ * in tests).
+ */
+const PERSONAL_SKILLS_SUBPATH = "personal-skills";
+
+function resolveConfigSkillsDir(agent: string): string | null {
+  const override = process.env.SWITCHROOM_CONFIG_DIR;
+  const candidate = override
+    ? resolve(override)
+    : join(homedir(), ".switchroom-config");
+  if (!existsSync(candidate)) return null;
+  return join(candidate, "agents", agent, PERSONAL_SKILLS_SUBPATH);
+}
+
+/**
+ * Mirror a successfully-written personal-skill dir into the operator's
+ * config repo, if one exists. Best-effort: errors logged to stderr and
+ * swallowed so a broken config-repo path never blocks a live write.
+ *
+ * Pass `liveSkillDir = null` to mirror a REMOVAL — the existing mirror
+ * (if any) is moved to a `.<name>-trash-<ts>` sibling so a stray
+ * `git status` still shows the deletion.
+ */
+function mirrorToConfigRepo(
+  agent: string,
+  name: string,
+  liveSkillDir: string | null,
+): void {
+  const configSkillsRoot = resolveConfigSkillsDir(agent);
+  if (!configSkillsRoot) return; // operator hasn't opted in
+  const dest = join(configSkillsRoot, name);
+
+  try {
+    if (liveSkillDir === null) {
+      if (existsSync(dest)) {
+        const trash = join(
+          configSkillsRoot,
+          `.${name}-trash-${Date.now()}`,
+        );
+        renameSync(dest, trash);
+      }
+      return;
+    }
+
+    mkdirSync(configSkillsRoot, { recursive: true, mode: 0o755 });
+    // Atomic-ish: stage under a sibling, swap, remove old.
+    const staging = mkdtempSync(join(configSkillsRoot, `.${name}-staging-`));
+    const walk = (src: string, dst: string): void => {
+      mkdirSync(dst, { recursive: true, mode: 0o755 });
+      for (const ent of readdirSync(src, { withFileTypes: true })) {
+        const s = join(src, ent.name);
+        const d = join(dst, ent.name);
+        if (ent.isSymbolicLink()) continue; // skip — same defense as readSourceFiles
+        if (ent.isDirectory()) walk(s, d);
+        else if (ent.isFile()) {
+          writeFileSync(d, readFileSync(s));
+        }
+      }
+    };
+    walk(liveSkillDir, staging);
+
+    if (existsSync(dest)) {
+      const prior = join(configSkillsRoot, `.${name}-prior-${Date.now()}`);
+      renameSync(dest, prior);
+      // Leave .<name>-prior-<ts> for git diff visibility; operator
+      // commits when ready and can rm the .prior- sibling.
+    }
+    renameSync(staging, dest);
+  } catch (err) {
+    process.stderr.write(
+      chalk.yellow(
+        `warning: mirror to ${dest} failed (${(err as Error).message ?? err}); ` +
+          `live copy still works, but this skill is not version-controlled until next successful sync.\n`,
+      ),
+    );
+  }
+}
+
 // ─── Types ─────────────────────────────────────────────────────────
 
 interface AgentOpts {
@@ -446,13 +548,15 @@ export function initPersonalAction(name: string, opts: InitEditOpts): void {
   const agentsRoot = resolveAgentsRoot(opts);
   const files = loadFiles(opts);
   loadValidateWrite(agentsRoot, agent, name, files, /*ensureNew=*/ true);
+  const skillDir = personalSkillDir(agentsRoot, agent, name);
+  mirrorToConfigRepo(agent, name, skillDir);
   console.log(
     JSON.stringify({
       ok: true,
       action: "init",
       agent,
       name,
-      path: personalSkillDir(agentsRoot, agent, name),
+      path: skillDir,
       files: Object.keys(files).length,
     }),
   );
@@ -466,13 +570,15 @@ export function editPersonalAction(name: string, opts: InitEditOpts): void {
   const agentsRoot = resolveAgentsRoot(opts);
   const files = loadFiles(opts);
   loadValidateWrite(agentsRoot, agent, name, files, /*ensureNew=*/ false);
+  const skillDir = personalSkillDir(agentsRoot, agent, name);
+  mirrorToConfigRepo(agent, name, skillDir);
   console.log(
     JSON.stringify({
       ok: true,
       action: "edit",
       agent,
       name,
-      path: personalSkillDir(agentsRoot, agent, name),
+      path: skillDir,
       files: Object.keys(files).length,
     }),
   );
@@ -631,6 +737,8 @@ export function clonePersonalAction(source: string, opts: CloneOpts): void {
   // Same validate+write pipeline as init_personal: ensureNew=true so a
   // pre-existing personal copy isn't silently clobbered.
   loadValidateWrite(agentsRoot, agent, newName, files, /*ensureNew=*/ true);
+  const skillDir = personalSkillDir(agentsRoot, agent, newName);
+  mirrorToConfigRepo(agent, newName, skillDir);
 
   console.log(
     JSON.stringify({
@@ -641,7 +749,7 @@ export function clonePersonalAction(source: string, opts: CloneOpts): void {
       source_tier: src.tier,
       source_slug: src.slug,
       name: newName,
-      path: personalSkillDir(agentsRoot, agent, newName),
+      path: skillDir,
       files: Object.keys(files).length,
     }),
   );
@@ -695,6 +803,8 @@ export function removePersonalAction(name: string, opts: RemoveOpts): void {
   const now = new Date(ts);
   utimesSync(trashTarget, now, now);
 
+  // Mirror the removal into the config repo (null signals delete).
+  mirrorToConfigRepo(agent, name, null);
   console.log(
     JSON.stringify({
       ok: true,

--- a/src/cli/skill-personal.ts
+++ b/src/cli/skill-personal.ts
@@ -121,6 +121,32 @@ function resolveConfigSkillsDir(agent: string): string | null {
  * (if any) is moved to a `.<name>-trash-<ts>` sibling so a stray
  * `git status` still shows the deletion.
  */
+/**
+ * `.prior-<ts>/` and `.trash-<ts>/` siblings retention: lazy sweep at
+ * the start of each mirror op deletes entries older than 24h. Without
+ * this, every edit leaves a permanent stale copy in the config repo —
+ * 100 edits = 100 dirs of stale skill content (#1844 reviewer flag).
+ * Same TTL as the live skills-trash sweep so the operator's mental
+ * model is uniform.
+ */
+const MIRROR_PRIOR_TTL_MS = 24 * 60 * 60 * 1000;
+function sweepMirrorPriors(configSkillsRoot: string): void {
+  try {
+    if (!existsSync(configSkillsRoot)) return;
+    const now = Date.now();
+    for (const ent of readdirSync(configSkillsRoot)) {
+      const m = /^\.(?:.+)-(?:prior|trash)-(\d+)$/.exec(ent);
+      if (!m) continue;
+      const ts = Number(m[1]!);
+      if (!Number.isFinite(ts)) continue;
+      if (now - ts < MIRROR_PRIOR_TTL_MS) continue;
+      try {
+        rmSync(join(configSkillsRoot, ent), { recursive: true, force: true });
+      } catch { /* best-effort */ }
+    }
+  } catch { /* best-effort */ }
+}
+
 function mirrorToConfigRepo(
   agent: string,
   name: string,
@@ -131,7 +157,28 @@ function mirrorToConfigRepo(
   const dest = join(configSkillsRoot, name);
 
   try {
+    // Defense in depth: liveSkillDir should be a canonical path under
+    // <agentDir>/.claude/skills, but if it were ever a symlink (future
+    // redirect mode, misconfigured scaffold), don't follow it across
+    // the file system.
+    if (liveSkillDir !== null) {
+      try {
+        const st = lstatSync(liveSkillDir);
+        if (st.isSymbolicLink()) {
+          process.stderr.write(
+            chalk.yellow(
+              `warning: refusing to mirror ${liveSkillDir} — source is a symlink\n`,
+            ),
+          );
+          return;
+        }
+      } catch {
+        // Fall through; readdirSync below will surface a useful error.
+      }
+    }
+
     if (liveSkillDir === null) {
+      sweepMirrorPriors(configSkillsRoot);
       if (existsSync(dest)) {
         const trash = join(
           configSkillsRoot,
@@ -143,6 +190,7 @@ function mirrorToConfigRepo(
     }
 
     mkdirSync(configSkillsRoot, { recursive: true, mode: 0o755 });
+    sweepMirrorPriors(configSkillsRoot);
     // Atomic-ish: stage under a sibling, swap, remove old.
     const staging = mkdtempSync(join(configSkillsRoot, `.${name}-staging-`));
     const walk = (src: string, dst: string): void => {
@@ -162,8 +210,7 @@ function mirrorToConfigRepo(
     if (existsSync(dest)) {
       const prior = join(configSkillsRoot, `.${name}-prior-${Date.now()}`);
       renameSync(dest, prior);
-      // Leave .<name>-prior-<ts> for git diff visibility; operator
-      // commits when ready and can rm the .prior- sibling.
+      // .prior- siblings: bounded by sweepMirrorPriors above (24h TTL).
     }
     renameSync(staging, dest);
   } catch (err) {


### PR DESCRIPTION
## Summary

Closes the durability gap the user raised post-#1843: personal skills
are runtime state under \`~/.switchroom/agents/<agent>/.claude/skills/\`,
survive container recreate but NOT a host rebuild and NOT git-tracked.
Lisa's fleet on her own host would have zero recovery path.

## Fix

After every successful \`init_personal\` / \`edit_personal\` /
\`clone_to_personal\` write, opportunistically mirror the dir into:

\`\`\`
~/.switchroom-config/agents/<agent>/personal-skills/<name>/
\`\`\`

if the operator has set up the config repo (same opt-in pattern as
\`vault-backup\`'s default destination — see vault-backup.ts:101).
\`remove_personal\` moves the corresponding mirror to a
\`.<name>-trash-<ts>/\` sibling so the deletion shows in \`git status\`.

\`SWITCHROOM_CONFIG_DIR\` env override lets multi-operator hosts (or
tests) point at a different repo. If the repo doesn't exist OR the
mirror write fails, the **live copy is unaffected** — a warning prints
to stderr and the action continues. Same defensive pattern as
\`appendAudit\`'s "never block a live action."

**No auto-commit.** Operator commits the config repo at their own
cadence — \`cd ~/.switchroom-config && git status\` shows the changes.

## Why mirror-not-redirect

A pure redirect (live writes into the config repo via mount/symlink)
would require:

- bind-mounting the config repo into every agent container
- chowning the per-agent subdir to the agent UID
- migrating existing bare \`personal-*\` dirs into the repo
- changing the symlink-safe writer to write THROUGH symlinks

Mirror-after-write trades atomicity for ~zero implementation
complexity:

- claude-code discovery unchanged (still finds
  \`.claude/skills/personal-*/\`)
- \`writePersonalSkill\` unchanged (still atomic-rename into agent dir)
- no compose mount changes, no UID alignment changes
- migration is free (existing dirs are unaffected; next write mirrors them)

Tradeoff: live → mirror gap is bounded by the next successful sync
(typically same call). If mirror fails, stderr warning + the audit row
still lands and the live copy works.

## Test plan

- [x] 6 new tests in \`skill-personal.test.ts\`:
  - init mirrors to the right path
  - edit re-mirrors with updated content
  - remove moves mirror to \`.<name>-trash-<ts>/\` for git-visible delete
  - silent skip when config repo doesn't exist (opt-in)
  - clone-to-personal mirrors the cloned fork
  - mirror failure (unwritable config dir) does NOT block live write
- [x] All 32 \`skill-personal\` tests pass; tsc clean
- [x] Doc updated: \`docs/personal-skills-adoption-observability.md\`

## Risk

- **Mirror is best-effort** — by design, can never block a live write.
- **No auto-commit** — operator owns commit cadence.
- **Disk space** — each mirror is a copy. Personal-skill bundles are
  ≤256 KB by validator policy, fleet of 10 agents × 5 skills each = ~13 MB
  worst case. Acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)