### PR TITLE
fix(skill-clone): skip non-allowlisted source files (closes #1847)

### DIFF
--- a/src/cli/skill-personal.test.ts
+++ b/src/cli/skill-personal.test.ts
@@ -768,3 +768,102 @@ describe("config-repo mirror (versioned personal skills)", () => {
     }
   });
 });
+
+describe("clone-to-personal skips non-allowlisted source files (#1847)", () => {
+  let agentsRoot: string;
+  let sharedRoot: string;
+
+  beforeEach(() => {
+    agentsRoot = tmpAgentsRoot();
+    sharedRoot = mkdtempSync(join(tmpdir(), "clone-skip-shared-"));
+  });
+
+  afterEach(() => {
+    try { rmSync(agentsRoot, { recursive: true, force: true }); } catch { /**/ }
+    try { rmSync(sharedRoot, { recursive: true, force: true }); } catch { /**/ }
+  });
+
+  it("clones a source dir with LICENSE/VENDORED.md/non-allowlisted extras, dropping them", () => {
+    const src = join(sharedRoot, "vendored");
+    mkdirSync(join(src, "scripts"), { recursive: true });
+    writeFileSync(join(src, "SKILL.md"), validSkillMd("vendored"));
+    writeFileSync(join(src, "LICENSE"), "MIT License\n");
+    writeFileSync(join(src, "VENDORED.md"), "vendored from upstream\n");
+    writeFileSync(join(src, "reference.md"), "ad-hoc reference doc\n"); // not allowlisted at root
+    writeFileSync(join(src, "scripts/run.sh"), "#!/bin/bash\necho ok\n");
+
+    const origStderr = process.stderr.write.bind(process.stderr);
+    let stderrText = "";
+    process.stderr.write = ((c: unknown) => {
+      stderrText += typeof c === "string" ? c : (c as Buffer).toString("utf-8");
+      return true;
+    }) as typeof process.stderr.write;
+
+    let stdout = "";
+    try {
+      stdout = captureStdout(() => {
+        clonePersonalAction("shared:vendored", {
+          agent: AGENT,
+          root: agentsRoot,
+          sharedRoot,
+        });
+      });
+    } finally {
+      process.stderr.write = origStderr;
+    }
+
+    // SKILL.md + scripts/run.sh land; the rest do NOT.
+    const dest = join(agentsRoot, AGENT, ".claude/skills/personal-vendored");
+    expect(existsSync(join(dest, "SKILL.md"))).toBe(true);
+    expect(existsSync(join(dest, "scripts/run.sh"))).toBe(true);
+    expect(existsSync(join(dest, "LICENSE"))).toBe(false);
+    expect(existsSync(join(dest, "VENDORED.md"))).toBe(false);
+    expect(existsSync(join(dest, "reference.md"))).toBe(false);
+
+    // Stderr notes the skip + names the offenders.
+    expect(stderrText).toMatch(/skipped 3 non-allowlisted/);
+    expect(stderrText).toMatch(/LICENSE/);
+    expect(stderrText).toMatch(/VENDORED\.md/);
+
+    // JSON success surface lists them.
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.action).toBe("clone_to_personal");
+    expect(parsed.files).toBe(2); // SKILL.md + scripts/run.sh
+    expect(parsed.skipped).toHaveLength(3);
+    expect(parsed.skipped).toEqual(
+      expect.arrayContaining(["LICENSE", "VENDORED.md", "reference.md"]),
+    );
+  });
+
+  it("emits skipped:[] (empty) when source is shape-clean — distinguishable from silent drop", () => {
+    const src = join(sharedRoot, "clean");
+    mkdirSync(src, { recursive: true });
+    writeFileSync(join(src, "SKILL.md"), validSkillMd("clean"));
+
+    const out = captureStdout(() => {
+      clonePersonalAction("shared:clean", {
+        agent: AGENT,
+        root: agentsRoot,
+        sharedRoot,
+      });
+    });
+    const parsed = JSON.parse(out);
+    expect(parsed.skipped).toEqual([]);
+  });
+
+  it("still refuses if SKILL.md itself is missing (even after skipping extras)", () => {
+    const src = join(sharedRoot, "no-md");
+    mkdirSync(src, { recursive: true });
+    writeFileSync(join(src, "LICENSE"), "MIT\n");
+    writeFileSync(join(src, "README"), "no skill here\n"); // README (no .md) is not allowlisted
+
+    expectExitCode(() => {
+      clonePersonalAction("shared:no-md", {
+        agent: AGENT,
+        root: agentsRoot,
+        sharedRoot,
+      });
+    }, 2);
+  });
+});

--- a/src/cli/skill-personal.ts
+++ b/src/cli/skill-personal.ts
@@ -56,6 +56,7 @@ import {
   SH_SCRIPT_RE,
   SKILL_SLUG_RE,
   type SkillFileMap,
+  validateRelPath,
   validateSkillBundle,
 } from "./skill-common.js";
 import { withConfigError } from "./helpers.js";
@@ -702,8 +703,16 @@ function resolveCloneSource(
  * declining to read them upfront avoids OOM on a pathological source.
  */
 const CLONE_MAX_FILE_BYTES = 1024 * 1024;
-function readSourceFiles(dir: string): SkillFileMap {
+
+interface CloneReadResult {
+  files: SkillFileMap;
+  /** Paths that existed in the source but didn't pass the allowlist. */
+  skipped: string[];
+}
+
+function readSourceFiles(dir: string): CloneReadResult {
   const files: SkillFileMap = {};
+  const skipped: string[] = [];
   const walk = (sub: string): void => {
     for (const ent of readdirSync(sub, { withFileTypes: true })) {
       const full = join(sub, ent.name);
@@ -718,6 +727,17 @@ function readSourceFiles(dir: string): SkillFileMap {
       }
       if (ent.isFile()) {
         const rel = relative(dir, full).replace(/\\/g, "/");
+        // Allowlist gate (closes #1847): bundled skills ship with
+        // operator-relevant files at root (LICENSE, VENDORED.md,
+        // reference.md, scripts/requirements.txt, etc.) that aren't
+        // in the agent-authored-skill path allowlist. Skipping them
+        // here keeps the personal fork shape-clean and the publish-
+        // side validator strict — the agent never sees these files
+        // in their workspace, which is correct.
+        if (!validateRelPath(rel)) {
+          skipped.push(rel);
+          continue;
+        }
         // Pre-flight size check via lstat (no need to open).
         try {
           const st = lstatSync(full);
@@ -736,7 +756,7 @@ function readSourceFiles(dir: string): SkillFileMap {
     }
   };
   walk(dir);
-  return files;
+  return { files, skipped };
 }
 
 /**
@@ -773,12 +793,23 @@ export function clonePersonalAction(source: string, opts: CloneOpts): void {
   // Read source files, rewrite SKILL.md name to match the new slug so
   // the personal-tier validator (which enforces name == slug) accepts
   // the bundle.
-  const files = readSourceFiles(src.dir);
+  const { files, skipped } = readSourceFiles(src.dir);
   if (!files["SKILL.md"]) {
     fail(`source ${JSON.stringify(source)} has no SKILL.md at ${src.dir}`);
   }
   if (newName !== src.slug) {
     files["SKILL.md"] = rewriteSkillMdName(files["SKILL.md"]!, newName);
+  }
+
+  // Surface skipped paths to the operator/agent on stderr so the fork
+  // is honest about what landed (LICENSE, VENDORED.md, README, etc.
+  // — see #1847). Single line, not per-file noise.
+  if (skipped.length > 0) {
+    process.stderr.write(
+      chalk.yellow(
+        `note: skipped ${skipped.length} non-allowlisted path${skipped.length === 1 ? "" : "s"} from source: ${skipped.join(", ")}\n`,
+      ),
+    );
   }
 
   // Same validate+write pipeline as init_personal: ensureNew=true so a
@@ -798,6 +829,10 @@ export function clonePersonalAction(source: string, opts: CloneOpts): void {
       name: newName,
       path: skillDir,
       files: Object.keys(files).length,
+      // Empty array when nothing was skipped — explicit so MCP callers
+      // can distinguish "shape-clean source" from "we silently dropped
+      // something you might care about".
+      skipped,
     }),
   );
   appendAudit(
@@ -809,6 +844,7 @@ export function clonePersonalAction(source: string, opts: CloneOpts): void {
       source_slug: src.slug,
       name: newName,
       files: Object.keys(files).length,
+      skipped_count: skipped.length,
     },
     0,
   );


### PR DESCRIPTION
## Summary

Closes #1847. Six of nine bundled skills currently fail
\`skill clone-to-personal bundled:<name>\` because they ship with
operator-relevant files (LICENSE, VENDORED.md, reference.md,
scripts/requirements.txt) that aren't in the agent-authored-skill
path allowlist. JTBD currently broken for the dominant clone case.

## Fix (Option A per issue body)

\`readSourceFiles\` filters source files through \`validateRelPath\`.
Skipped paths land in the JSON output's new \`skipped[]\` field +
single-line stderr note. Publish-side validator stays strict (correct
threat model: agents shouldn't be publishing arbitrary file shapes
into shared pool).

## Test plan

- [x] 3 new tests in \`skill-personal.test.ts\`
- [x] All 37 tests pass; tsc clean
- [x] Opus reviewer ranked this 1st in the post-v0.13.50 follow-up triage (smallest, unblocks UAT)

## Risk

Filter is bounded by the existing \`validateRelPath\` allowlist. Worst
case: agent's fork doesn't include an upstream file the operator
expected (LICENSE.txt etc.). The fork is the agent's runtime surface;
LICENSE.txt isn't operative there. Documented via the explicit
\`skipped[]\` array so the caller knows what dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)