### PR TITLE
feat(cli): switchroom status — fleet + accounts + MCPs snapshot (#1837)

### DIFF
--- a/skills/switchroom-status/SKILL.md
+++ b/skills/switchroom-status/SKILL.md
@@ -32,23 +32,25 @@ description: >
 
 When the user asks about agent status, what's running, uptime, or wants to see agent info, answer by running (or telling them to run) `switchroom agent list` — this is the canonical command for showing running agents, their uptime, and current state.
 
-## Step 1 — Always mention `switchroom agent list` in your response
+## Step 1 — Always mention `switchroom status` in your response
 
-The answer to "what agents are running", "show me agent info", "list all switchroom agents", or any uptime question is the `switchroom agent list` command. Your response MUST include the literal command string `switchroom agent list` so the user can copy it. If you have Bash tool access, run it and include the output. If you do not have Bash access, or the command fails in the current environment, still tell the user explicitly:
+The answer to "what agents are running", "show me agent info", "list all switchroom agents", or any uptime question is the `switchroom status` command (since v0.13.51). Your response MUST include the literal command string `switchroom status` so the user can copy it. If you have Bash tool access, run it and include the output. If you do not have Bash access, or the command fails in the current environment, still tell the user explicitly:
 
-> Run `switchroom agent list` from your switchroom project directory to see running agents, their uptime, and status.
+> Run `switchroom status` from your switchroom project directory to see running agents (uptime + scheduler), known auth accounts, and per-agent MCP connection state.
 
-Do not respond with a PATH-not-found bailout or a "no config found" diagnosis without first giving the user the command — the eval environment may not have a config on cwd, but on the user's actual machine `switchroom agent list` is the right command.
+Do not respond with a PATH-not-found bailout or a "no config found" diagnosis without first giving the user the command — the eval environment may not have a config on cwd, but on the user's actual machine `switchroom status` is the right command. (Pre-v0.13.51 the canonical command was `switchroom agent list` — that still works but only shows the Fleet section.)
 
 ## Step 2 — Try to run it
 
 If you have Bash tool access, run:
 
 ```bash
-switchroom agent list --json 2>/dev/null || switchroom agent list
+switchroom status --json 2>/dev/null || switchroom status
 ```
 
-If that succeeds, parse the output and present the running agent list with full uptime, status, and model details (see Step 3). If it fails (e.g. command not found, no config in cwd), still include the `switchroom agent list` command and the word "uptime" in your text response — the user needs those as actionable information.
+`switchroom status` returns three sections: **Fleet** (per-agent uptime + scheduler), **Accounts** (broker-known auth accounts with active marker), and **MCPs** (per-agent MCP connection state). If you want to skip the MCP probe (slower because it does a docker exec per agent), pass `--no-mcp`.
+
+If `switchroom status` fails (e.g. command not found, no config in cwd), fall back to `switchroom agent list` (older command, Fleet-only). Still include the `switchroom status` command and the word "uptime" in your text response — the user needs those as actionable information.
 
 ## Step 3 — For each agent, report running state and uptime
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { VERSION } from "../build-info.js";
 import { registerAgentCommand } from "./agent.js";
+import { registerStatusCommand } from "./status.js";
 import { registerTopicsCommand } from "./topics.js";
 import { registerAuthCommand } from "./auth.js";
 import { registerVaultCommand } from "./vault.js";
@@ -65,6 +66,7 @@ registerRestartCommand(program);
 registerVersionCommand(program);
 registerVersionsCommand(program);
 registerAgentCommand(program);
+registerStatusCommand(program);
 registerTopicsCommand(program);
 registerAuthCommand(program);
 registerVaultCommand(program);

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for `switchroom status` — focused on the pure helpers
+ * (parser + uptime formatter). Integration coverage (docker exec
+ * + broker round-trip) lives in the e2e test that needs a running
+ * fleet — kept out of the per-PR critical path.
+ */
+import { describe, it, expect } from "vitest";
+import { parseClaudeMcpList, formatUptimeShort } from "./status.js";
+
+describe("parseClaudeMcpList", () => {
+  const SAMPLE_HAPPY = `Checking MCP server health…
+
+switchroom-telegram: bun run --cwd /opt/switchroom/telegram-plugin --shell=bun --silent start - ✓ Connected
+agent-config: /usr/local/bin/switchroom mcp agent-config - ✓ Connected
+hindsight: http://127.0.0.1:18888/mcp/ (HTTP) - ✓ Connected
+gdrive: /usr/local/bin/switchroom drive-mcp-launcher --tier extended - ✓ Connected
+perplexity: /home/kenthompson/.switchroom/mcp-launchers/perplexity-mcp.sh  - ✓ Connected
+`;
+
+  it("parses all-connected output cleanly", () => {
+    const out = parseClaudeMcpList(SAMPLE_HAPPY);
+    expect(out.map((s) => s.name)).toEqual([
+      "switchroom-telegram",
+      "agent-config",
+      "hindsight",
+      "gdrive",
+      "perplexity",
+    ]);
+    expect(out.every((s) => s.connected)).toBe(true);
+  });
+
+  it("flags failed servers", () => {
+    const out = parseClaudeMcpList(`Checking MCP server health…
+
+switchroom-telegram: bun run ... - ✓ Connected
+perplexity: /home/foo/perplexity.sh - ✗ Failed to connect
+`);
+    expect(out).toHaveLength(2);
+    expect(out[0].connected).toBe(true);
+    expect(out[1].connected).toBe(false);
+    expect(out[1].status).toContain("Failed");
+  });
+
+  it("ignores the header banner and any blank lines", () => {
+    const out = parseClaudeMcpList(`
+
+Checking MCP server health…
+
+
+switchroom-telegram: cmd - ✓ Connected
+
+`);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("switchroom-telegram");
+  });
+
+  it("ignores lines without the ` - ` discriminator", () => {
+    const out = parseClaudeMcpList(`Some random preamble: not an MCP line
+switchroom-telegram: cmd - ✓ Connected
+Trailing chatter without a dash
+`);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("switchroom-telegram");
+  });
+
+  it("treats `Connected` not adjacent to `Failed` as connected", () => {
+    // Defensive — a server named "Connected" or status with weird
+    // wording shouldn't trip the heuristic.
+    const out = parseClaudeMcpList(`my-mcp: cmd - ✓ Connected (HTTP)\n`);
+    expect(out[0].connected).toBe(true);
+  });
+
+  it("treats any non-Connected status as failure with verbatim text preserved", () => {
+    const out = parseClaudeMcpList(`stuck-mcp: cmd - Connecting…\n`);
+    expect(out[0].connected).toBe(false);
+    expect(out[0].status).toBe("Connecting…");
+  });
+
+  it("returns empty on empty input", () => {
+    expect(parseClaudeMcpList("")).toEqual([]);
+  });
+
+  it("returns empty when no line has the discriminator", () => {
+    expect(parseClaudeMcpList("No MCP servers configured.\n")).toEqual([]);
+  });
+
+  it("handles single-line probe failure output (claude not installed)", () => {
+    // When claude isn't on PATH, the docker exec returns stderr —
+    // parser sees no MCP lines and returns empty (probe-level wrapper
+    // handles the error separately).
+    expect(parseClaudeMcpList("/bin/sh: claude: command not found\n")).toEqual([]);
+  });
+});
+
+describe("formatUptimeShort", () => {
+  it("returns em-dash for null / malformed / future timestamps", () => {
+    expect(formatUptimeShort(null)).toBe("—");
+    expect(formatUptimeShort("not-an-iso-date")).toBe("—");
+    // A timestamp in the future yields a negative delta → em-dash.
+    const future = new Date(Date.now() + 60_000).toISOString();
+    expect(formatUptimeShort(future)).toBe("—");
+  });
+
+  it("renders minutes for short uptimes", () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();
+    expect(formatUptimeShort(fiveMinAgo)).toBe("5m");
+  });
+
+  it("renders hours + minutes for medium uptimes", () => {
+    const twoHrThirtyAgo = new Date(Date.now() - (2 * 3600 + 30 * 60) * 1000).toISOString();
+    expect(formatUptimeShort(twoHrThirtyAgo)).toBe("2h 30m");
+  });
+
+  it("renders days + hours for long uptimes", () => {
+    const threeDaysFiveHrsAgo = new Date(
+      Date.now() - (3 * 86400 + 5 * 3600) * 1000,
+    ).toISOString();
+    expect(formatUptimeShort(threeDaysFiveHrsAgo)).toBe("3d 5h");
+  });
+});

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -14,7 +14,7 @@ switchroom-telegram: bun run --cwd /opt/switchroom/telegram-plugin --shell=bun -
 agent-config: /usr/local/bin/switchroom mcp agent-config - ✓ Connected
 hindsight: http://127.0.0.1:18888/mcp/ (HTTP) - ✓ Connected
 gdrive: /usr/local/bin/switchroom drive-mcp-launcher --tier extended - ✓ Connected
-perplexity: /home/kenthompson/.switchroom/mcp-launchers/perplexity-mcp.sh  - ✓ Connected
+perplexity: ~/.switchroom/mcp-launchers/perplexity-mcp.sh  - ✓ Connected
 `;
 
   it("parses all-connected output cleanly", () => {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -205,7 +205,13 @@ export function registerStatusCommand(program: Command): void {
     .option(
       "--mcp-timeout <ms>",
       `MCP probe per-agent timeout in ms (default ${MCP_PROBE_TIMEOUT_MS})`,
-      (v) => Number.parseInt(v, 10),
+      (v) => {
+        // Fall back to the default on NaN / non-positive values so a
+        // typo like `--mcp-timeout abc` doesn't silently disable the
+        // timeout (Node's execFile treats `timeout: NaN` as no timeout).
+        const n = Number.parseInt(v, 10);
+        return Number.isFinite(n) && n > 0 ? n : MCP_PROBE_TIMEOUT_MS;
+      },
       MCP_PROBE_TIMEOUT_MS,
     )
     .action(

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,0 +1,347 @@
+/**
+ * `switchroom status` — one-shot fleet snapshot.
+ *
+ * Closes the gap from #1837: the existing `switchroom agent list`
+ * shows uptime/template/scheduler but nothing about MCP connection
+ * state or active-account quota. Operators (and the Telegram
+ * `/status` skill that wraps this) want a single command that
+ * surfaces:
+ *
+ *   1. Fleet — per-agent uptime + scheduler state (reuses the
+ *      existing agent-list data).
+ *   2. Accounts — known auth accounts + active + fallback order
+ *      (reuses the existing auth-list broker call).
+ *   3. MCPs — per-agent MCP connection state, fetched in parallel
+ *      via `docker exec <agent> claude mcp list`. Reports
+ *      "connected" / "Failed to connect" per server.
+ *
+ * Future iterations (#1837 follow-up):
+ *   - Live quota probe per account (5h % + reset time, 7d % + reset).
+ *   - Hindsight detailed bank stats (obs count, last retain/recall).
+ *   - Per-agent recent message count from SQLite history.
+ *
+ * `--json` flag emits structured output for the Telegram skill to
+ * re-render, and for any operator scripting.
+ *
+ * Time budget: targets <3s on a 9-agent fleet. The MCP probe is the
+ * dominant cost (~500ms-1s per agent), so it runs in parallel.
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { getAllAgentStatuses } from "../agents/lifecycle.js";
+import { getSchedulerState, formatSchedulerState } from "../agents/scheduler-state.js";
+import { withConfigError, getConfig } from "./helpers.js";
+import { brokerCall } from "./broker-call.js";
+
+const execFileP = promisify(execFile);
+
+// Per-agent `claude mcp list` probe timeout. The probe does a real
+// handshake against every MCP server the agent has wired (typically 5-6
+// servers @ ~1s each), so a single agent's probe takes 6-10s. Under
+// fleet-wide parallelism (9 concurrent docker exec calls) the per-
+// probe time roughly doubles due to docker daemon + auth-broker
+// contention. 20s buys headroom while keeping the worst-case status
+// runtime <25s on a 9-agent fleet.
+const MCP_PROBE_TIMEOUT_MS = 20_000;
+
+export interface McpServerState {
+  name: string;
+  connected: boolean;
+  /** Verbatim status string from `claude mcp list` (e.g. "✓ Connected"
+   *  or "✗ Failed to connect"). Null when the probe itself failed
+   *  (docker exec error, agent not running, etc.). */
+  status: string | null;
+}
+
+export interface PerAgentMcpProbe {
+  agent: string;
+  /** True iff the docker exec + parse round-trip succeeded. */
+  ok: boolean;
+  /** Reason the probe failed when ok === false. Examples: "agent
+   *  container not running", "claude mcp list exited 1", "probe
+   *  timed out after 8s". */
+  reason?: string;
+  servers: McpServerState[];
+}
+
+/**
+ * Probe `claude mcp list` inside an agent's container and return
+ * the parsed connection state. Fails open: any error path returns
+ * `{ok: false, reason}` rather than throwing.
+ *
+ * `claude mcp list` outputs (when run from the agent's cwd):
+ *   Checking MCP server health…
+ *
+ *   switchroom-telegram: bun run ... - ✓ Connected
+ *   agent-config: /usr/local/bin/... - ✓ Connected
+ *   gdrive: /usr/local/bin/... - ✓ Connected
+ *   perplexity: /home/.../perplexity-mcp.sh - ✗ Failed to connect
+ *
+ * Parser is forgiving — any line matching `<name>: <command> - <status>`
+ * counts; `✓ Connected` is the success marker, anything else is treated
+ * as a failure with the verbatim status preserved.
+ */
+export async function probeAgentMcps(
+  agentName: string,
+  opts: { execImpl?: typeof execFile; timeoutMs?: number } = {},
+): Promise<PerAgentMcpProbe> {
+  const timeoutMs = opts.timeoutMs ?? MCP_PROBE_TIMEOUT_MS;
+  const exec = opts.execImpl
+    ? promisify(opts.execImpl)
+    : execFileP;
+  try {
+    const { stdout } = await exec(
+      "docker",
+      [
+        "exec",
+        `switchroom-${agentName}`,
+        "sh",
+        "-lc",
+        "cd /state/agent && claude mcp list 2>&1",
+      ],
+      { timeout: timeoutMs, maxBuffer: 1024 * 1024 },
+    );
+    const servers = parseClaudeMcpList(stdout);
+    return { agent: agentName, ok: true, servers };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Distinguish "container not running" (no such container, exit 1
+    // from docker) from a real claude error.
+    const reason =
+      msg.includes("No such container") || msg.includes("is not running")
+        ? "agent container not running"
+        : msg.includes("ETIMEDOUT") || msg.includes("timed out")
+          ? `probe timed out after ${timeoutMs}ms`
+          : `mcp list failed: ${msg.split("\n")[0].slice(0, 120)}`;
+    return { agent: agentName, ok: false, reason, servers: [] };
+  }
+}
+
+/** Parse `claude mcp list` stdout into per-server state. Exported for tests. */
+export function parseClaudeMcpList(stdout: string): McpServerState[] {
+  // Each interesting line looks like:
+  //   <name>: <command-or-url> - ✓ Connected
+  //   <name>: <command-or-url> - ✗ Failed to connect
+  // The dash + status is the discriminator.
+  const out: McpServerState[] = [];
+  for (const rawLine of stdout.split("\n")) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+    // Skip the header banner and any pre-amble. The data lines all
+    // contain " - " between the command/url and the status.
+    const dashIdx = line.lastIndexOf(" - ");
+    if (dashIdx < 0) continue;
+    const colonIdx = line.indexOf(":");
+    if (colonIdx < 0 || colonIdx > dashIdx) continue;
+    const name = line.slice(0, colonIdx).trim();
+    const status = line.slice(dashIdx + 3).trim();
+    if (name.length === 0) continue;
+    const connected = status.includes("Connected") && !status.includes("Failed");
+    out.push({ name, connected, status });
+  }
+  return out;
+}
+
+interface AccountSnapshot {
+  label: string;
+  active: boolean;
+  available: boolean;
+  exhausted: boolean;
+  /** Seconds until the OAuth credentials expire. */
+  expiresInSec?: number | null;
+  /** Live quota reset time if the broker has probed recently. */
+  quotaResetAt?: string | null;
+}
+
+/**
+ * Fetch the broker's account state. Returns null when the broker is
+ * unreachable (uncommon in production but a common dev state).
+ */
+async function fetchAccounts(): Promise<{ active: string | null; accounts: AccountSnapshot[] } | null> {
+  try {
+    const state = await brokerCall((client) => client.listState()) as {
+      active?: string;
+      accounts?: Array<{
+        label: string;
+        exhausted?: boolean;
+        expiresInSec?: number | null;
+        quotaResetAt?: string | null;
+      }>;
+    };
+    const active = state.active ?? null;
+    const accounts = (state.accounts ?? []).map((a) => ({
+      label: a.label,
+      active: a.label === active,
+      available: !a.exhausted,
+      exhausted: a.exhausted ?? false,
+      expiresInSec: a.expiresInSec ?? null,
+      quotaResetAt: a.quotaResetAt ?? null,
+    }));
+    return { active, accounts };
+  } catch {
+    return null;
+  }
+}
+
+export function registerStatusCommand(program: Command): void {
+  program
+    .command("status")
+    .description(
+      "One-shot fleet snapshot — per-agent uptime + scheduler, " +
+      "auth accounts, MCP connection state. Wrapped by the Telegram " +
+      "`/status` skill. Use `--json` for programmatic output.",
+    )
+    .option("--json", "Output JSON")
+    .option(
+      "--no-mcp",
+      "Skip the per-agent MCP probe (faster — avoids the docker exec round-trip)",
+    )
+    .option(
+      "--mcp-timeout <ms>",
+      `MCP probe per-agent timeout in ms (default ${MCP_PROBE_TIMEOUT_MS})`,
+      (v) => Number.parseInt(v, 10),
+      MCP_PROBE_TIMEOUT_MS,
+    )
+    .action(
+      withConfigError(async (opts: { json?: boolean; mcp?: boolean; mcpTimeout?: number }) => {
+        const config = getConfig(program);
+        const agentNames = Object.keys(config.agents ?? {}).sort();
+
+        // ── Fleet section: reuse the existing agent-list data ──────────
+        const statuses = getAllAgentStatuses(config);
+        const logsDir = join(homedir(), ".switchroom", "logs");
+        const schedulerStates = Object.fromEntries(
+          agentNames.map((n) => [n, getSchedulerState(n, logsDir)] as const),
+        );
+
+        // ── Accounts section: broker.listState ─────────────────────────
+        const accountsP = fetchAccounts();
+
+        // ── MCPs section: parallel docker exec ─────────────────────────
+        const mcpEnabled = opts.mcp !== false;
+        const mcpTimeoutMs = opts.mcpTimeout ?? MCP_PROBE_TIMEOUT_MS;
+        const mcpsP = mcpEnabled
+          ? Promise.all(
+              agentNames.map((n) => probeAgentMcps(n, { timeoutMs: mcpTimeoutMs })),
+            )
+          : Promise.resolve<PerAgentMcpProbe[]>([]);
+
+        const [accounts, mcps] = await Promise.all([accountsP, mcpsP]);
+
+        if (opts.json) {
+          const data = {
+            fleet: agentNames.map((name) => {
+              const agentConfig = config.agents?.[name];
+              const status = statuses[name];
+              const sched = schedulerStates[name];
+              return {
+                name,
+                status: status?.active ?? "unknown",
+                // ISO-timestamp of container start (matches
+                // AgentStatus.uptime shape); consumers compute the
+                // delta themselves.
+                started_at: status?.uptime ?? null,
+                topic: agentConfig?.topic_name ?? null,
+                scheduler: sched,
+              };
+            }),
+            accounts: accounts ?? { active: null, accounts: [] },
+            mcps: mcpEnabled ? mcps : { skipped: true },
+          };
+          console.log(JSON.stringify(data, null, 2));
+          return;
+        }
+
+        // ── Human-readable rendering ───────────────────────────────────
+        console.log();
+        console.log(chalk.bold("Fleet"));
+        for (const name of agentNames) {
+          const status = statuses[name];
+          const sched = schedulerStates[name];
+          const isUp = status?.active === "active";
+          const dot = isUp ? chalk.green("●") : chalk.gray("○");
+          const uptime = formatUptimeShort(status?.uptime ?? null);
+          const schedStr = sched ? formatSchedulerState(sched) : "?";
+          console.log(
+            `  ${dot} ${name.padEnd(16)} ${chalk.dim(uptime.padEnd(8))} ${chalk.dim(schedStr)}`,
+          );
+        }
+
+        console.log();
+        console.log(chalk.bold("Accounts"));
+        if (accounts == null) {
+          console.log(chalk.gray("  (broker unreachable — run `switchroom auth list` for details)"));
+        } else if (accounts.accounts.length === 0) {
+          console.log(chalk.gray("  (no accounts configured)"));
+        } else {
+          for (const acc of accounts.accounts) {
+            const marker = acc.active
+              ? chalk.green("●")
+              : acc.exhausted
+                ? chalk.red("✗")
+                : chalk.gray("○");
+            const tag = acc.active
+              ? chalk.green("active")
+              : acc.exhausted
+                ? chalk.red("exhausted")
+                : chalk.gray("available");
+            const reset = acc.quotaResetAt ? `  reset=${acc.quotaResetAt}` : "";
+            console.log(`  ${marker} ${acc.label.padEnd(35)} ${tag}${reset}`);
+          }
+        }
+
+        if (mcpEnabled) {
+          console.log();
+          console.log(chalk.bold("MCPs"));
+          for (const probe of mcps) {
+            if (!probe.ok) {
+              console.log(
+                `  ${chalk.red("✗")} ${probe.agent.padEnd(16)} ${chalk.dim(probe.reason ?? "probe failed")}`,
+              );
+              continue;
+            }
+            if (probe.servers.length === 0) {
+              console.log(
+                `  ${chalk.gray("○")} ${probe.agent.padEnd(16)} ${chalk.dim("no MCPs configured")}`,
+              );
+              continue;
+            }
+            const parts = probe.servers.map((s) =>
+              s.connected
+                ? chalk.green(`✓ ${s.name}`)
+                : chalk.red(`✗ ${s.name}`),
+            );
+            console.log(`  ${probe.agent.padEnd(16)} ${parts.join("  ")}`);
+          }
+        }
+        console.log();
+      }),
+    );
+}
+
+/**
+ * Compact uptime from an ISO timestamp (the shape `AgentStatus.uptime`
+ * carries — container-start time). Returns "44m", "2h 3m", "5d 2h", or
+ * "—" for null / malformed / non-positive. Mirrors the format used by
+ * `switchroom agent list` (intentionally identical so the two outputs
+ * align side-by-side).
+ */
+export function formatUptimeShort(timestamp: string | null): string {
+  if (!timestamp) return "—";
+  const start = new Date(timestamp).getTime();
+  if (Number.isNaN(start)) return "—";
+  const seconds = Math.floor((Date.now() - start) / 1000);
+  if (seconds <= 0) return "—";
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}


### PR DESCRIPTION
Closes #1837 (v1 scope — quota/hindsight detail filed as follow-ups in the issue).

## Why

Operator request 2026-05-26: \`switchroom agent list\` shows uptime/template/scheduler but nothing about MCP connection state or active-account quota. The Telegram \`/status\` skill (which wrapped \`switchroom agent list\`) inherited the same gap. This new top-level command is the answer.

## Demo (live against the v0.13.49 fleet)

\`\`\`
$ switchroom status

Fleet
  ● carrie           22m      idle
  ● clerk            22m      5 tasks
  ● finn             22m      1 task
  ● gymbro           22m      6 tasks
  ● klanker          22m      idle
  ● lawgpt           22m      idle
  ● reggie           22m      idle
  ● test-harness     22m      idle
  ● ziggy            22m      idle

Accounts
  ● ken.thompson@outlook.com.au         active
  ○ me@kenthompson.com.au               available
  ○ pixsoul@gmail.com                   available

MCPs
  carrie           ✓ switchroom-telegram  ✓ agent-config  ✓ hostd  ✓ hindsight  ✓ gdrive  ✓ perplexity  ✗ notion
  clerk            ✓ switchroom-telegram  ✓ agent-config  ✓ hindsight  ✓ gdrive  ✓ perplexity
  ...
\`\`\`

Smoke run caught carrie/notion as ✗ — real prod state, file as follow-up.

## What this ships

- **Fleet** — uptime + scheduler (reuses existing data; cheap).
- **Accounts** — active marker + exhausted marker (reuses brokerCall; cheap).
- **MCPs** — per-agent connection state via parallel \`docker exec ... claude mcp list\`. Pass \`--no-mcp\` to skip.
- \`--json\` for programmatic use.
- \`skills/switchroom-status/SKILL.md\` updated to invoke \`switchroom status\` instead of \`switchroom agent list\` — the Telegram \`/status\` response now gets all three sections.

## Out of scope (v2 follow-ups)

- Live quota probe per account (5h % + reset, 7d % + reset)
- Hindsight detailed bank stats
- Per-agent recent message count from history.db

## Test plan

- [x] 13 unit tests cover parser + formatter
- [x] tsc / no-pii / plugin-refs / bot-api-allowlist clean
- [x] End-to-end smoke against the live fleet — output matches expectation
- [ ] Post-merge: release v0.13.51, fleet roll, run Telegram /status on a real agent to confirm the skill consumes the new output cleanly

## Risk

Low. Pure additive new command; doesn't touch existing surfaces. Broker-unreachable / per-agent-probe-fail paths degrade gracefully (em-dash / ✗ marker, other sections unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)