### PR TITLE
chore: release v0.13.51 — closes agent-managed-skills JTBD end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## v0.13.51 — closes the agent-managed-skills JTBD end-to-end
+
+Two PRs that complete what v0.13.50 started: the durability story is
+now true for the dominant in-container caller, and bundled skills are
+finally cloneable.
+
+UAT of v0.13.50 surfaced two gaps the principled triage (fresh-process
+Opus reviewer, aligned to vision + principles) ranked as load-bearing:
+
+### fix(skill-clone): skip non-allowlisted source files (PR #1848, closes #1847)
+
+Six of nine bundled skills (\`docx\`, \`mcp-builder\`, \`humanizer\`,
+\`pdf\`, \`pptx\`, \`skill-creator\`) ship with operator-relevant files
+at root (LICENSE, VENDORED.md, reference.md, scripts/requirements.txt)
+that aren't in the agent-authored-skill path allowlist. \`skill clone-
+to-personal bundled:<name>\` was failing the dominant case.
+
+\`readSourceFiles\` now filters source files through \`validateRelPath\`.
+Skipped paths surface as a single-line yellow stderr note + an explicit
+\`skipped[]\` array in the JSON output (empty when source was shape-
+clean — distinguishable from "we silently dropped something you might
+care about"). Publish-side validator stays strict.
+
+### feat(compose): bind-mount config-repo personal-skills per-agent (PR #1849, closes #1846)
+
+The load-bearing JTBD fix. v0.13.50 (#1844) auto-mirrored personal-
+skill writes to \`~/.switchroom-config/agents/<agent>/personal-skills/\`
+for durability. But the agent runs **inside** a container where
+\`~/.switchroom-config/\` didn't exist → \`resolveConfigSkillsDir\`
+returned null → mirror silently no-op'd for the dominant caller.
+
+Four coordinated changes (all four layers of the audit-dir precedent):
+
+1. **\`compose.ts\`** — per-agent \`rw\` bind mount of the operator's
+   slice (\`~/.switchroom-config/agents/<a>/personal-skills/\`) when
+   the operator has opted into versioned skills (\`~/.switchroom-config\`
+   exists on host)
+2. **\`profiles/_base/start.sh.hbs\`** — sibling \`ln -sfn\` so the
+   in-container CLI's \`homedir()\` call resolves to the bind-mounted
+   host path (matches the existing \`~/.switchroom\` symlink at #910)
+3. **\`scaffold.ts:alignAgentUid\`** — chown the mirror dir to the
+   agent UID so the in-container write doesn't EACCES
+4. **\`apply.ts:ensureHostMountSources\`** — pre-create the per-agent
+   dir at pass-1 so the chown sweep finds it on first apply
+
+Fresh-process Opus reviewer caught the missing fourth layer (#3
+symlink) during initial review. The four-layer pattern is now
+documented for future bind-mounts of operator state.
+
 ## v0.13.50 — agents fix their own skills (clone-to-personal + versioned mirror)
 
 Two PRs that close the biggest gap surfaced by v0.13.47 UAT — agents

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.13.50",
+  "version": "0.13.51",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

v0.13.51 bundles the two principled-triage follow-ups from the v0.13.50 UAT, both ranked as load-bearing by a fresh-process Opus reviewer:

- **#1848** — clone-to-personal skips non-allowlisted source files (six of nine bundled skills now cloneable, closes #1847)
- **#1849** — per-agent bind-mount of config-repo personal-skills slice (closes the durability story for in-container callers, closes #1846)

See the v0.13.51 CHANGELOG section for design rationale + the four-layer audit-dir precedent.

## Net effect

The JTBD from the gymbro screenshot finally works end-to-end with **zero human in the loop**:

\`\`\`
agent: skill_clone_to_personal bundled:mcp-builder
→ skipped: ["LICENSE.txt", "VENDORED.md"], cloned 11 allowlisted files
→ live fork at <agentDir>/.claude/skills/personal-mcp-builder/
→ mirror at ~/.switchroom-config/agents/<agent>/personal-skills/mcp-builder/
→ operator commits at their own cadence
→ host rebuild safe
\`\`\`

## Rollout

1. Wait for \`docker-images\` workflow (~5 min)
2. \`npm publish --ignore-scripts\` from verified tarball
3. UAT canary: clerk (non-admin) clones \`bundled:humanizer\` (previously failed); verify both live + mirror land + git status shows new dir
4. Sequential fleet rollout with \`--version\` assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)