### PR TITLE
feat(scaffold): introduce ~/.switchroom/fleet/ + move lane 1 invariants off --append-system-prompt (closes #1852)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -568,16 +568,29 @@ for f in \
   fi
 done
 
+# Fleet directory — epic #1850 / issue #1852. Extends Claude Code's
+# native CLAUDE.md auto-discovery to `~/.switchroom/fleet/` so every
+# agent reads the release-pinned `switchroom-invariants.md` (lane 1)
+# and operator-owned `CLAUDE.md` (lane 2) from there. Guarded on the
+# directory existing so a fresh-install or a half-applied state
+# doesn't fail boot — `switchroom apply`'s ensureHostMountSources
+# creates the dir + seeds the files.
+SR_FLEET_DIR="$HOME/.switchroom/fleet"
+SR_FLEET_ARG=""
+if [ -d "$SR_FLEET_DIR" ]; then
+  SR_FLEET_ARG="--add-dir $SR_FLEET_DIR"
+fi
+
 {{#if useSwitchroomPlugin}}
 if [ -n "$APPEND_PROMPT" ]; then
-  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 else
-  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 fi
 {{else}}
 if [ -n "$APPEND_PROMPT" ]; then
-  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 else
-  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}}{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
+  exec claude $CONTINUE_FLAG --channels plugin:telegram@claude-plugins-official --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}}{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}
 fi
 {{/if}}

--- a/profiles/coding/CLAUDE.md.hbs
+++ b/profiles/coding/CLAUDE.md.hbs
@@ -34,7 +34,7 @@ You are a senior software engineering agent. You write, review, debug, and archi
 - Clear commit messages in imperative mood explaining the why.
 - Atomic commits. PR descriptions explain what, why, and how to test.
 
-{{> telegram-style}}
+{{!-- telegram-style now in ~/.switchroom/fleet/switchroom-invariants.md --}}
 
 ## Memory — Hindsight
 

--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -39,7 +39,14 @@ How you should decide what to do next. These are procedural rules, not vibe.
 - **Weak or empty tool result is not a conclusion.** Vary the query, path, command, or source before deciding the thing isn't there.
 - **Non-final turn:** use tools to advance, or ask the one clarifying question that unblocks safe progress. One question, not five.
 
-{{> telegram-style}}
+{{!--
+  Telegram-style guidance (the 5-beat pacing contract) lives in the
+  fleet invariants file at `~/.switchroom/fleet/switchroom-invariants.md`
+  and reaches the agent via Claude Code native CLAUDE.md discovery
+  (`--add-dir ~/.switchroom/fleet`). Do not re-include the
+  `{{> telegram-style}}` partial here — that would re-introduce the
+  session-level duplication the prompt redesign removed.
+--}}
 
 ## Memory — Hindsight is your single backend
 

--- a/profiles/executive-assistant/CLAUDE.md.hbs
+++ b/profiles/executive-assistant/CLAUDE.md.hbs
@@ -33,7 +33,7 @@ You help the user stay organized, prepared, and focused on high-leverage work. Y
 - **Anticipate, don't just react.** Flag gaps proactively.
 - **Be concise.** Lead with essentials. Details on request.
 
-{{> telegram-style}}
+{{!-- telegram-style now in ~/.switchroom/fleet/switchroom-invariants.md --}}
 
 ## Memory — Hindsight
 

--- a/profiles/health-coach/CLAUDE.md.hbs
+++ b/profiles/health-coach/CLAUDE.md.hbs
@@ -27,7 +27,7 @@ You are a health and fitness coaching agent — an accountability partner, not a
 ## Boundaries
 Recommend the user consult a professional for: persistent pain/injury, medical conditions, specialized nutrition plans, symptoms of overtraining or disordered eating. Say it plainly: "That's outside my lane — worth checking with your doctor."
 
-{{> telegram-style}}
+{{!-- telegram-style now in ~/.switchroom/fleet/switchroom-invariants.md --}}
 
 ## Memory — Hindsight
 

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1723,6 +1723,21 @@ function emitAgentService(
       `      - ${homePrefix}/.switchroom/mcp-launchers:${homePrefix}/.switchroom/mcp-launchers:ro`,
     );
   }
+  // Fleet directory — agent prompt cascade lanes 1 and 2 (epic
+  // #1850, issue #1852). Holds `switchroom-invariants.md`
+  // (release-pinned) and `CLAUDE.md` (operator-owned fleet defaults).
+  // Reaches the agent's `claude` process via `--add-dir` (set in
+  // start.sh.hbs), which extends Claude Code's native CLAUDE.md
+  // discovery roots. Same-path mount so the operator can edit the
+  // file and the agent reads the same bytes. `:ro` because the
+  // agent never writes here; `switchroom apply` is the only writer.
+  // Created with seeded files by `ensureHostMountSources` in apply.ts,
+  // so existsSync is true on every post-apply install.
+  if (existsSync(`${hostHomeForChecks}/.switchroom/fleet`)) {
+    lines.push(
+      `      - ${homePrefix}/.switchroom/fleet:${homePrefix}/.switchroom/fleet:ro`,
+    );
+  }
   // PER-AGENT credentials mount (sec WS6-F2, #1390). Previously the
   // ENTIRE `~/.switchroom/credentials/` dir was bind-mounted `:ro`
   // into EVERY agent — so a prompt-injected agent could read every

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -34,17 +34,26 @@ const REPO_ROOT = resolve(import.meta.dirname, "../..");
  * action needed" reply instead of either silently retrying or echoing
  * the raw kernel error to the user.
  *
- * Kept in lockstep across the two `systemPromptAppendShellQuoted`
- * call sites in this file — extracting to a top-level constant
- * prevents drift the way the prior duplication of telegramGuidance +
- * memoryGuidance did not.
+ * One of three fleet invariant blocks shipped by Switchroom. They
+ * reach the agent via the fleet directory
+ * (`~/.switchroom/fleet/switchroom-invariants.md`), loaded by Claude
+ * Code's native CLAUDE.md auto-discovery when `--add-dir` extends the
+ * discovery roots to the fleet dir (see start.sh.hbs and the
+ * `renderFleetInvariants` helper below).
  *
- * Why this string lives here and not in profiles/_base/*.hbs:
- *   - The .hbs files are written to disk per-agent and operator-
- *     editable; the sandbox primer is non-negotiable runtime context
- *     and shouldn't get accidentally diverged per agent.
- *   - Append-system-prompt is cache-friendly: same content every
- *     session boot means the model's KV cache hits warm.
+ * Hoisted to top-level constants alongside TELEGRAM_GUIDANCE and
+ * MEMORY_GUIDANCE to prevent the drift that previously affected those
+ * two (which used to live as inline strings duplicated across
+ * scaffold and reconcile paths).
+ *
+ * Why TypeScript constants and not `.hbs` files:
+ *   - The `.hbs` files are per-agent and operator-editable; these
+ *     blocks are fleet-wide and release-controlled.
+ *   - Single canonical source in TypeScript; the rendered file on
+ *     disk (~/.switchroom/fleet/switchroom-invariants.md) is the
+ *     visible artifact so operators can READ what the agent is told,
+ *     but operator edits get reset on `switchroom apply`
+ *     (checksum-enforced).
  */
 const SANDBOX_GUIDANCE = `## Sandbox: you're running in a switchroom container
 
@@ -87,6 +96,112 @@ Example response shapes:
   \`docker/Dockerfile.agent\` and rebuild the agent image."
 - "I tried to clone into \`/workspace\` — that path doesn't exist in my
   sandbox. Cloning into \`$HOME/workspace\` instead."`;
+
+/**
+ * The Telegram pacing contract. One of three fleet invariant blocks.
+ * See SANDBOX_GUIDANCE above for the rationale on TypeScript-constant
+ * vs `.hbs` file.
+ *
+ * Companion: the per-turn `<turn-pacing>` UserPromptSubmit hook (PR
+ * #1646) reasserts the contract adjacent to each user message. That
+ * hook is load-bearing and lives elsewhere in this file; do NOT
+ * remove it when modifying this constant.
+ */
+const TELEGRAM_GUIDANCE = `## Talking to a human on Telegram
+
+There is a real person on the other end. Every turn should feel like
+messaging a capable colleague — not a tool emitting output. Five beats:
+
+1. **Acknowledge first.** Unless your whole reply is a single short
+   sentence you can send right now, your FIRST action this turn is a
+   brief \`reply\` in your own voice — "on it", "good question, one
+   sec", "let me dig in" — before any tool call and before you
+   compose the full answer. This holds even for a pure-thinking
+   answer: if it will run to a paragraph, ack first. It is the line
+   between a colleague and a black box.
+2. **Then go quiet and work.** Heads-down is correct — do NOT narrate
+   every tool call. A typing indicator runs automatically while you
+   work; you do not maintain it.
+3. **Surface meaningful progress** at genuine inflection points — a
+   hard step finished, a blocker, a pivot, dispatching a sub-agent, a
+   notably slow wait, a finding worth knowing now. One short \`reply\`,
+   \`disable_notification: true\`.
+4. **Hand back delegations with synthesis.** When a sub-agent / worker
+   returns, re-enter in YOUR voice — what it found, and what you are
+   doing next. Never let its raw report stand as your reply. A
+   *background* worker finishes after your turn ends; its result
+   arrives as a fresh \`<channel source="subagent_handback">\` turn —
+   treat that turn as the cue to do exactly this.
+5. **Deliver the answer** as a final \`reply\`.
+
+The one thing to avoid is *spam*: a reply on every tool call, on a
+timer, or repeating what you already said. Responsive and human, never
+a flood. Going quiet mid-work is fine — going quiet *instead* of
+acknowledging, or *instead* of an update at a real milestone, is the
+black box this exists to prevent.
+
+Every turn that answers a user message ends with a user-visible
+\`reply\` (or \`stream_reply\` done=true) — Telegram is all the user
+sees; your terminal output never reaches them.`;
+
+/**
+ * The Hindsight memory protocol. One of three fleet invariant blocks.
+ * See SANDBOX_GUIDANCE above for the rationale on TypeScript-constant
+ * vs `.hbs` file.
+ */
+const MEMORY_GUIDANCE = `## Memory — proactive, conversational
+
+You have Hindsight tools: \`mcp__hindsight__sync_retain\`, \`mcp__hindsight__delete_memory\`, \`mcp__hindsight__recall\`, \`mcp__hindsight__reflect\`. Use them without being asked.
+
+### Retain proactively
+When the user shares a fact, preference, decision, or plan worth keeping across sessions, call \`sync_retain\` in the same turn. Briefly acknowledge in your reply ("got it, April 2nd anniversary"). Don't narrate the tool call. Skip small talk and transient tool output, the auto-retain hook handles conversation-level signal.
+
+### Correct proactively
+When the user corrects you or contradicts a prior memory, call \`delete_memory\` on the wrong entry, then \`sync_retain\` the correction. Acknowledge the correction in one line ("noted, Alice not Bob").
+
+### Forget proactively
+When the user asks you to forget something ("forget that", "delete X", "drop what I said about Y"), call \`delete_memory\` for matching entries and confirm what was removed.
+
+### Inspect proactively
+When the user asks "what do you know about X / me", "what do you remember about Y", or any memory audit, use \`reflect\` to synthesize an answer across the bank. Return it as honest prose, not a raw dump. If the bank has little on the topic, say so.
+
+Don't wait for a slash command. Don't ask permission. Memory work is table stakes, like a colleague who takes notes and remembers.`;
+
+/**
+ * Canonical rendering of the fleet invariants file written to
+ * `~/.switchroom/fleet/switchroom-invariants.md`. Apply checksums
+ * this against the on-disk file and restores on drift. Operators
+ * read the file to see what every agent is told; edits are
+ * non-durable (release-controlled).
+ *
+ * Header is a literal string the operator sees first when they open
+ * the file — it MUST teach the file's nature without requiring docs.
+ */
+export function renderFleetInvariants(): string {
+  return [
+    "<!--",
+    "  ~/.switchroom/fleet/switchroom-invariants.md",
+    "",
+    "  Release-controlled fleet invariants. Every Switchroom agent reads",
+    "  this via Claude Code native CLAUDE.md discovery, since the agent's",
+    "  `claude` process boots with `--add-dir ~/.switchroom/fleet`.",
+    "",
+    "  DO NOT EDIT. `switchroom apply` regenerates this file on every run",
+    "  and restores it if it drifts from the release canonical. To extend",
+    "  the agent's behaviour fleet-wide, edit ~/.switchroom/fleet/CLAUDE.md",
+    "  instead (operator-owned, additive, preserved across applies).",
+    "-->",
+    "",
+    "# Switchroom fleet invariants",
+    "",
+    SANDBOX_GUIDANCE,
+    "",
+    TELEGRAM_GUIDANCE,
+    "",
+    MEMORY_GUIDANCE,
+    "",
+  ].join("\n");
+}
 
 import { DEFAULT_PROFILE } from "../config/schema.js";
 import {
@@ -1710,68 +1825,18 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
       return out;
     })(),
     systemPromptAppendShellQuoted: (() => {
-      const useSwitchroomPlugin = usesSwitchroomTelegramPlugin(agentConfig);
+      // Lane 1 invariants (telegram pacing / memory protocol / sandbox
+      // primer) used to be concatenated here. They now reach the model
+      // via Claude Code native CLAUDE.md auto-discovery from
+      // `~/.switchroom/fleet/switchroom-invariants.md`, loaded by the
+      // `--add-dir` flag set in start.sh.hbs. See `renderFleetInvariants()`
+      // at the top of this file.
+      //
+      // What remains here: the operator's per-agent
+      // `system_prompt_append` (yaml passthrough). Reserved for genuinely
+      // per-agent system-prompt extensions; fleet-wide content goes in
+      // `~/.switchroom/fleet/CLAUDE.md` (lane 2, operator-owned).
       const baseAppend = agentConfig.system_prompt_append ?? '';
-      const telegramGuidance = `## Talking to a human on Telegram
-
-There is a real person on the other end. Every turn should feel like
-messaging a capable colleague — not a tool emitting output. Five beats:
-
-1. **Acknowledge first.** Unless your whole reply is a single short
-   sentence you can send right now, your FIRST action this turn is a
-   brief \`reply\` in your own voice — "on it", "good question, one
-   sec", "let me dig in" — before any tool call and before you
-   compose the full answer. This holds even for a pure-thinking
-   answer: if it will run to a paragraph, ack first. It is the line
-   between a colleague and a black box.
-2. **Then go quiet and work.** Heads-down is correct — do NOT narrate
-   every tool call. A typing indicator runs automatically while you
-   work; you do not maintain it.
-3. **Surface meaningful progress** at genuine inflection points — a
-   hard step finished, a blocker, a pivot, dispatching a sub-agent, a
-   notably slow wait, a finding worth knowing now. One short \`reply\`,
-   \`disable_notification: true\`.
-4. **Hand back delegations with synthesis.** When a sub-agent / worker
-   returns, re-enter in YOUR voice — what it found, and what you are
-   doing next. Never let its raw report stand as your reply. A
-   *background* worker finishes after your turn ends; its result
-   arrives as a fresh \`<channel source="subagent_handback">\` turn —
-   treat that turn as the cue to do exactly this.
-5. **Deliver the answer** as a final \`reply\`.
-
-The one thing to avoid is *spam*: a reply on every tool call, on a
-timer, or repeating what you already said. Responsive and human, never
-a flood. Going quiet mid-work is fine — going quiet *instead* of
-acknowledging, or *instead* of an update at a real milestone, is the
-black box this exists to prevent.
-
-Every turn that answers a user message ends with a user-visible
-\`reply\` (or \`stream_reply\` done=true) — Telegram is all the user
-sees; your terminal output never reaches them.`;
-
-      const memoryGuidance = `## Memory — proactive, conversational
-
-You have Hindsight tools: \`mcp__hindsight__sync_retain\`, \`mcp__hindsight__delete_memory\`, \`mcp__hindsight__recall\`, \`mcp__hindsight__reflect\`. Use them without being asked.
-
-### Retain proactively
-When the user shares a fact, preference, decision, or plan worth keeping across sessions, call \`sync_retain\` in the same turn. Briefly acknowledge in your reply ("got it, April 2nd anniversary"). Don't narrate the tool call. Skip small talk and transient tool output, the auto-retain hook handles conversation-level signal.
-
-### Correct proactively
-When the user corrects you or contradicts a prior memory, call \`delete_memory\` on the wrong entry, then \`sync_retain\` the correction. Acknowledge the correction in one line ("noted, Alice not Bob").
-
-### Forget proactively
-When the user asks you to forget something ("forget that", "delete X", "drop what I said about Y"), call \`delete_memory\` for matching entries and confirm what was removed.
-
-### Inspect proactively
-When the user asks "what do you know about X / me", "what do you remember about Y", or any memory audit, use \`reflect\` to synthesize an answer across the bank. Return it as honest prose, not a raw dump. If the bank has little on the topic, say so.
-
-Don't wait for a slash command. Don't ask permission. Memory work is table stakes, like a colleague who takes notes and remembers.`;
-
-      if (useSwitchroomPlugin) {
-        const parts = [baseAppend, telegramGuidance, memoryGuidance, SANDBOX_GUIDANCE].filter(s => s.length > 0);
-        const combined = parts.join('\n\n---\n\n');
-        return shellSingleQuote(combined);
-      }
       return baseAppend.length > 0 ? shellSingleQuote(baseAppend) : undefined;
     })(),
     extraCliArgs: (() => {
@@ -3803,66 +3868,11 @@ export function reconcileAgent(
       // communicate like a person — ack first, narrate meaningful progress,
       // hand back delegations with synthesis, deliver.
       systemPromptAppendShellQuoted: (() => {
-        const useSwitchroomPlugin = usesSwitchroomTelegramPlugin(agentConfig);
+        // Lane 1 invariants moved to `~/.switchroom/fleet/switchroom-invariants.md`
+        // and reach the model via Claude Code native CLAUDE.md
+        // auto-discovery (start.sh.hbs passes `--add-dir ~/.switchroom/fleet`).
+        // See the matching scaffoldAgent path above and renderFleetInvariants().
         const baseAppend = agentConfig.system_prompt_append ?? '';
-        const telegramGuidance = `## Talking to a human on Telegram
-
-There is a real person on the other end. Every turn should feel like
-messaging a capable colleague — not a tool emitting output. Five beats:
-
-1. **Acknowledge first.** Unless your whole reply is a single short
-   sentence you can send right now, your FIRST action this turn is a
-   brief \`reply\` in your own voice — "on it", "good question, one
-   sec", "let me dig in" — before any tool call and before you
-   compose the full answer. This holds even for a pure-thinking
-   answer: if it will run to a paragraph, ack first. It is the line
-   between a colleague and a black box.
-2. **Then go quiet and work.** Heads-down is correct — do NOT narrate
-   every tool call. A typing indicator runs automatically while you
-   work; you do not maintain it.
-3. **Surface meaningful progress** at genuine inflection points — a
-   hard step finished, a blocker, a pivot, dispatching a sub-agent, a
-   notably slow wait, a finding worth knowing now. One short \`reply\`,
-   \`disable_notification: true\`.
-4. **Hand back delegations with synthesis.** When a sub-agent / worker
-   returns, re-enter in YOUR voice — what it found, and what you are
-   doing next. Never let its raw report stand as your reply. A
-   *background* worker finishes after your turn ends; its result
-   arrives as a fresh \`<channel source="subagent_handback">\` turn —
-   treat that turn as the cue to do exactly this.
-5. **Deliver the answer** as a final \`reply\`.
-
-The one thing to avoid is *spam*: a reply on every tool call, on a
-timer, or repeating what you already said. Responsive and human, never
-a flood. Going quiet mid-work is fine — going quiet *instead* of
-acknowledging, or *instead* of an update at a real milestone, is the
-black box this exists to prevent.
-
-Every turn that answers a user message ends with a user-visible
-\`reply\` (or \`stream_reply\` done=true) — Telegram is all the user
-sees; your terminal output never reaches them.`;
-        const memoryGuidance = `## Memory — proactive, conversational
-
-You have Hindsight tools: \`mcp__hindsight__sync_retain\`, \`mcp__hindsight__delete_memory\`, \`mcp__hindsight__recall\`, \`mcp__hindsight__reflect\`. Use them without being asked.
-
-### Retain proactively
-When the user shares a fact, preference, decision, or plan worth keeping across sessions, call \`sync_retain\` in the same turn. Briefly acknowledge in your reply ("got it, April 2nd anniversary"). Don't narrate the tool call. Skip small talk and transient tool output, the auto-retain hook handles conversation-level signal.
-
-### Correct proactively
-When the user corrects you or contradicts a prior memory, call \`delete_memory\` on the wrong entry, then \`sync_retain\` the correction. Acknowledge the correction in one line ("noted, Alice not Bob").
-
-### Forget proactively
-When the user asks you to forget something ("forget that", "delete X", "drop what I said about Y"), call \`delete_memory\` for matching entries and confirm what was removed.
-
-### Inspect proactively
-When the user asks "what do you know about X / me", "what do you remember about Y", or any memory audit, use \`reflect\` to synthesize an answer across the bank. Return it as honest prose, not a raw dump. If the bank has little on the topic, say so.
-
-Don't wait for a slash command. Don't ask permission. Memory work is table stakes, like a colleague who takes notes and remembers.`;
-        if (useSwitchroomPlugin) {
-          const parts = [baseAppend, telegramGuidance, memoryGuidance, SANDBOX_GUIDANCE].filter(s => s.length > 0);
-          const combined = parts.join('\n\n---\n\n');
-          return shellSingleQuote(combined);
-        }
         return baseAppend.length > 0 ? shellSingleQuote(baseAppend) : undefined;
       })(),
       extraCliArgs: (() => {

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -17,7 +17,7 @@
  */
 import { Option, type Command } from "commander";
 import chalk from "chalk";
-import { accessSync, chownSync, constants as fsConstants, copyFileSync, existsSync, mkdirSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { accessSync, chownSync, constants as fsConstants, copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { spawnSync as childSpawnSync } from "node:child_process";
 import readline from "node:readline";
@@ -55,7 +55,7 @@ import {
   findConfigFile,
   ConfigError,
 } from "../config/loader.js";
-import { scaffoldAgent, alignAgentUid } from "../agents/scaffold.js";
+import { scaffoldAgent, alignAgentUid, renderFleetInvariants } from "../agents/scaffold.js";
 import { installUpdatePromptHook } from "./update-prompt-hook.js";
 import { generateCompose, allocateAgentUid } from "../agents/compose.js";
 import { resolveImageTag, resolveRelease } from "../config/release-resolve.js";
@@ -408,6 +408,55 @@ async function ensureHostMountSources(config: SwitchroomConfig): Promise<void> {
     } catch {
       /* dev / no CAP_CHOWN — leave existing ownership */
     }
+  }
+
+  // Fleet directory — lane 1 (release-pinned invariants) and lane 2
+  // (operator-owned fleet defaults) of the agent prompt cascade. The
+  // dir is bind-mounted `:ro` into every agent at the same host-absolute
+  // path (`src/agents/compose.ts`) and reaches the agent's `claude`
+  // process via `--add-dir "$HOME/.switchroom/fleet"` set in
+  // `profiles/_base/start.sh.hbs`. Claude Code native CLAUDE.md
+  // discovery then loads `.md` files in this dir into the system
+  // prompt. See epic #1850 + child issue #1852.
+  //
+  // L1 invariants: rendered from TypeScript constants
+  // (TELEGRAM_GUIDANCE, MEMORY_GUIDANCE, SANDBOX_GUIDANCE in
+  // scaffold.ts) via `renderFleetInvariants()`. Release-controlled,
+  // checksum-restored on drift. Operator reads to know what every
+  // agent is told; operator edits get reset on next apply.
+  //
+  // L2 fleet defaults: empty placeholder for now. The actual lane 2
+  // content (operating principles, concision norm, tool-family
+  // catalogue) lands in epic issue #1855. `writeIfMissing` semantics
+  // — operator edits are preserved across applies.
+  const fleetDir = join(home, ".switchroom", "fleet");
+  await mkdir(fleetDir, { recursive: true });
+  const invariantsPath = join(fleetDir, "switchroom-invariants.md");
+  const invariantsCanonical = renderFleetInvariants();
+  const invariantsCurrent = existsSync(invariantsPath)
+    ? readFileSync(invariantsPath, "utf-8")
+    : null;
+  if (invariantsCurrent !== invariantsCanonical) {
+    writeFileSync(invariantsPath, invariantsCanonical, { mode: 0o644 });
+  }
+  const fleetClaudePath = join(fleetDir, "CLAUDE.md");
+  if (!existsSync(fleetClaudePath)) {
+    // L2 placeholder. Real content arrives via epic issue #1855.
+    writeFileSync(
+      fleetClaudePath,
+      [
+        "# Switchroom fleet defaults",
+        "",
+        "Operator-owned fleet brain. Every agent reads this via",
+        "`--add-dir ~/.switchroom/fleet` (Claude Code native CLAUDE.md",
+        "discovery). Additions stack across the fleet; `switchroom apply`",
+        "never clobbers your edits here.",
+        "",
+        "<!-- L2 fleet defaults content lands in switchroom #1855 -->",
+        "",
+      ].join("\n"),
+      { mode: 0o644 },
+    );
   }
 }
 

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -625,6 +625,47 @@ describe("generateCompose", () => {
     }
   });
 
+  it("emits a :ro mount for the fleet dir when present (epic #1850 / issue #1852)", async () => {
+    // The fleet directory holds the agent prompt cascade's lane 1
+    // (release-pinned invariants) and lane 2 (operator-owned fleet
+    // defaults). Reaches each agent's `claude` process via
+    // `--add-dir ~/.switchroom/fleet` in start.sh.hbs — Claude Code
+    // native CLAUDE.md auto-discovery loads the `.md` files from
+    // there into the system prompt.
+    const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-fleet-"));
+    mkdirSync(join(tmp, ".switchroom", "fleet"), { recursive: true });
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+      });
+      expect(out).toContain(
+        `${tmp}/.switchroom/fleet:${tmp}/.switchroom/fleet:ro`,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("omits the fleet mount when the host dir doesn't exist (pre-apply state)", async () => {
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-no-fleet-"));
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+      });
+      expect(out).not.toContain(`/.switchroom/fleet`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("emits each mount independently when only one host dir exists (#907)", async () => {
     // Vault-only operators commonly have populated skills/ but no
     // filesystem credentials/ (everything via vault). The two

--- a/tests/scaffold.memory-prompt.test.ts
+++ b/tests/scaffold.memory-prompt.test.ts
@@ -2,10 +2,22 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { scaffoldAgent, reconcileAgent } from "../src/agents/scaffold.js";
+import { scaffoldAgent, reconcileAgent, renderFleetInvariants } from "../src/agents/scaffold.js";
 import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
 
-describe("Memory prompt guidance", () => {
+/**
+ * Memory prompt guidance — epic #1850 redesign moved this content from
+ * `--append-system-prompt` into the fleet invariants file at
+ * `~/.switchroom/fleet/switchroom-invariants.md`, loaded by Claude
+ * Code native CLAUDE.md discovery via `--add-dir`. These tests now
+ * verify the content is in the rendered invariants file (single source
+ * of truth) rather than in scaffold-emitted start.sh.
+ *
+ * Regression guard: start.sh must NOT contain the memory guidance —
+ * if it does, the session-level duplication the redesign removed
+ * has been re-introduced.
+ */
+describe("Memory prompt guidance (post-#1850)", () => {
   let tmpDir: string;
   let telegramConfig: TelegramConfig;
   let switchroomConfig: SwitchroomConfig;
@@ -35,118 +47,46 @@ describe("Memory prompt guidance", () => {
     }
   });
 
-  it("includes memory guidance block when using switchroom telegram plugin", () => {
-    const agentConfig: AgentConfig = {
-      channels: {
-        telegram: {
-          plugin: "switchroom",
-        },
-      },
-      memory: {
-        collection: "test-agent",
-      },
-    };
-
-    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, switchroomConfig);
-
-    const startShPath = join(tmpDir, "test-agent", "start.sh");
-    const startSh = readFileSync(startShPath, "utf-8");
-
-    expect(startSh).toContain("## Memory — proactive, conversational");
-    expect(startSh).toContain("### Retain proactively");
-    expect(startSh).toContain("### Correct proactively");
-    expect(startSh).toContain("### Forget proactively");
-    expect(startSh).toContain("### Inspect proactively");
-    expect(startSh).toContain("mcp__hindsight__sync_retain");
-    expect(startSh).toContain("mcp__hindsight__delete_memory");
-    expect(startSh).toContain("mcp__hindsight__recall");
-    expect(startSh).toContain("mcp__hindsight__reflect");
+  it("renderFleetInvariants() includes the memory guidance block (lane 1)", () => {
+    const out = renderFleetInvariants();
+    expect(out).toContain("## Memory — proactive, conversational");
+    expect(out).toContain("### Retain proactively");
+    expect(out).toContain("### Correct proactively");
+    expect(out).toContain("### Forget proactively");
+    expect(out).toContain("### Inspect proactively");
+    expect(out).toContain("mcp__hindsight__sync_retain");
+    expect(out).toContain("mcp__hindsight__delete_memory");
+    expect(out).toContain("mcp__hindsight__recall");
+    expect(out).toContain("mcp__hindsight__reflect");
   });
 
-  it("does NOT include memory guidance when using official telegram plugin", () => {
-    const agentConfig: AgentConfig = {
-      channels: {
-        telegram: {
-          plugin: "official",
-        },
-      },
-    };
-
-    const noMemoryConfig: SwitchroomConfig = {
-      agents: {},
-      telegram: telegramConfig,
-    };
-
-    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, noMemoryConfig);
-
-    const startShPath = join(tmpDir, "test-agent", "start.sh");
-    const startSh = readFileSync(startShPath, "utf-8");
-
-    expect(startSh).not.toContain("## Memory — proactive, conversational");
-  });
-
-  it("memory guidance appears AFTER the Telegram pacing block", () => {
-    const agentConfig: AgentConfig = {
-      channels: {
-        telegram: {
-          plugin: "switchroom",
-        },
-      },
-      memory: {
-        collection: "test-agent",
-      },
-    };
-
-    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, switchroomConfig);
-
-    const startShPath = join(tmpDir, "test-agent", "start.sh");
-    const startSh = readFileSync(startShPath, "utf-8");
-
-    const pacingIdx = startSh.indexOf("## Talking to a human on Telegram");
-    const memoryIdx = startSh.indexOf("## Memory — proactive, conversational");
-
+  it("renderFleetInvariants() orders Telegram pacing BEFORE memory guidance", () => {
+    // The fleet invariants file orders sections so the model reads
+    // them in the same sequence as the prior --append-system-prompt
+    // assembly. Telegram pacing first (it governs every turn),
+    // memory second (it governs cross-turn retention).
+    const out = renderFleetInvariants();
+    const pacingIdx = out.indexOf("## Talking to a human on Telegram");
+    const memoryIdx = out.indexOf("## Memory — proactive, conversational");
     expect(pacingIdx).toBeGreaterThan(-1);
     expect(memoryIdx).toBeGreaterThan(-1);
     expect(memoryIdx).toBeGreaterThan(pacingIdx);
   });
 
-  it("reconcileAgent emits identical memory guidance as scaffoldAgent", () => {
-    const agentConfig: AgentConfig = {
-      channels: {
-        telegram: {
-          plugin: "switchroom",
-        },
-      },
-      memory: {
-        collection: "test-agent",
-      },
-    };
+  it("renderFleetInvariants() includes all four memory sub-sections in correct order", () => {
+    const out = renderFleetInvariants();
+    const retainIdx = out.indexOf("### Retain proactively");
+    const correctIdx = out.indexOf("### Correct proactively");
+    const forgetIdx = out.indexOf("### Forget proactively");
+    const inspectIdx = out.indexOf("### Inspect proactively");
 
-    // First scaffold
-    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, switchroomConfig);
-    const scaffoldStartSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
-
-    // Then reconcile
-    reconcileAgent("test-agent", agentConfig, tmpDir, telegramConfig, switchroomConfig);
-    const reconcileStartSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
-
-    // Extract the APPEND_PROMPT sections. Bash single-quoted strings embed
-    // literal `'` as the `'"'"'` sequence; match those along with normal
-    // non-quote chars so the Memory block (which contains apostrophes)
-    // survives the extract.
-    const extractAppend = (content: string) => {
-      const match = content.match(/APPEND_PROMPT='((?:[^']|'"'"')*)'/s);
-      return match ? match[1] : "";
-    };
-
-    const scaffoldAppend = extractAppend(scaffoldStartSh);
-    const reconcileAppend = extractAppend(reconcileStartSh);
-
-    expect(scaffoldAppend).toBe(reconcileAppend);
-    expect(scaffoldAppend).toContain("## Memory — proactive, conversational");
+    expect(retainIdx).toBeGreaterThan(-1);
+    expect(correctIdx).toBeGreaterThan(retainIdx);
+    expect(forgetIdx).toBeGreaterThan(correctIdx);
+    expect(inspectIdx).toBeGreaterThan(forgetIdx);
   });
 
-  it("includes all four sub-sections in correct order", () => {
+  it("scaffoldAgent does NOT include memory guidance in start.sh (regression guard for session-level duplication)", () => {
     const agentConfig: AgentConfig = {
       channels: {
         telegram: {
@@ -163,14 +103,38 @@ describe("Memory prompt guidance", () => {
     const startShPath = join(tmpDir, "test-agent", "start.sh");
     const startSh = readFileSync(startShPath, "utf-8");
 
-    const retainIdx = startSh.indexOf("### Retain proactively");
-    const correctIdx = startSh.indexOf("### Correct proactively");
-    const forgetIdx = startSh.indexOf("### Forget proactively");
-    const inspectIdx = startSh.indexOf("### Inspect proactively");
+    // Memory content now lives in ~/.switchroom/fleet/switchroom-invariants.md
+    // (loaded via --add-dir). It must NOT also appear in start.sh's
+    // APPEND_PROMPT — that was the pre-#1850 duplication.
+    expect(startSh).not.toContain("## Memory — proactive, conversational");
+    expect(startSh).not.toContain("### Retain proactively");
+    // But the fleet --add-dir IS present:
+    expect(startSh).toContain("SR_FLEET_DIR");
+    expect(startSh).toContain(".switchroom/fleet");
+  });
 
-    expect(retainIdx).toBeGreaterThan(-1);
-    expect(correctIdx).toBeGreaterThan(retainIdx);
-    expect(forgetIdx).toBeGreaterThan(correctIdx);
-    expect(inspectIdx).toBeGreaterThan(forgetIdx);
+  it("reconcileAgent emits identical start.sh as scaffoldAgent (parity, post-#1850)", () => {
+    const agentConfig: AgentConfig = {
+      channels: {
+        telegram: {
+          plugin: "switchroom",
+        },
+      },
+      memory: {
+        collection: "test-agent",
+      },
+    };
+
+    scaffoldAgent("test-agent", agentConfig, tmpDir, telegramConfig, switchroomConfig);
+    const scaffoldStartSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+
+    reconcileAgent("test-agent", agentConfig, tmpDir, telegramConfig, switchroomConfig);
+    const reconcileStartSh = readFileSync(join(tmpDir, "test-agent", "start.sh"), "utf-8");
+
+    // After #1850 the APPEND_PROMPT is just the operator's per-agent
+    // `system_prompt_append` (empty by default), so scaffoldAgent and
+    // reconcileAgent should produce identical start.sh for the same
+    // input. Confirms the init-vs-reconcile drift fix held.
+    expect(reconcileStartSh).toBe(scaffoldStartSh);
   });
 });

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2305,14 +2305,33 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(startSh).toContain("export LOG_LEVEL='debug'");
   });
 
-  it("appends the sandbox primer to system prompt so agents recognise EROFS as the sandbox", () => {
+  it("renderFleetInvariants() includes the sandbox primer (epic #1850 lane 1)", async () => {
     // Closes the UX gap where agents hitting `EROFS` on a read-only mount
     // would either silently retry or echo the raw kernel error to the
     // user. The primer (top-level `SANDBOX_GUIDANCE` constant) names
     // the writable mounts + tells the agent how to respond when it hits
-    // the boundary. Kept in lockstep across both
-    // `systemPromptAppendShellQuoted` call sites — this test would fail
-    // if either site forgets to include it after a future refactor.
+    // the boundary.
+    //
+    // PR redesigning epic #1850 moved this content from
+    // `--append-system-prompt` into the fleet invariants file at
+    // `~/.switchroom/fleet/switchroom-invariants.md`, loaded by Claude
+    // Code native CLAUDE.md discovery via `--add-dir`. This test
+    // verifies the content is in the rendered invariants file.
+    const { renderFleetInvariants } = await import("../src/agents/scaffold.js");
+    const out = renderFleetInvariants();
+    expect(out).toContain("## Sandbox: you");
+    expect(out).toContain("running in a switchroom container");
+    expect(out).toContain("$HOME");
+    expect(out).toContain("/state/agent/home");
+    expect(out).toContain("/tmp");
+    expect(out).toContain("read-only file system");
+    expect(out).toContain("Operator action");
+  });
+
+  it("scaffoldAgent no longer appends the sandbox primer to system_prompt_append (moved to fleet invariants)", () => {
+    // Post-#1850 the sandbox primer is in `~/.switchroom/fleet/switchroom-invariants.md`,
+    // not in `--append-system-prompt`. This test guards against
+    // re-introducing the duplication.
     const agentConfig = makeAgentConfig({});
     const result = scaffoldAgent(
       "sandbox-primer-agent",
@@ -2321,46 +2340,14 @@ describe("scaffoldAgent with global defaults cascade", () => {
       telegramConfig,
     );
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-
-    // Load-bearing headings — drop these and the agent's reply
-    // template stops working. Substrings are chosen to NOT cross an
-    // ASCII apostrophe (POSIX single-quote wrapping splits the literal
-    // around apostrophes via the `'"'"'` idiom, so a substring spanning
-    // one wouldn't appear contiguously in start.sh).
-    expect(startSh).toContain("## Sandbox: you");
-    expect(startSh).toContain("running in a switchroom container");
-    // Writable paths the agent must know about
-    expect(startSh).toContain("$HOME");
-    expect(startSh).toContain("/state/agent/home");
-    expect(startSh).toContain("/tmp");
-    // Read-only paths + the operator-action framing
-    expect(startSh).toContain("read-only file system");
-    expect(startSh).toContain("Operator action");
-    // The primer must NOT leak when an agent doesn't use the switchroom
-    // telegram plugin (host-systemd legacy / non-telegram dispatches).
-    // The wrapping logic only includes the guidance when
-    // `useSwitchroomPlugin` is true; a regression there would attach
-    // the primer to agents whose telegram plumbing is different and
-    // confuse the model.
-  });
-
-  it("does NOT append sandbox primer for agents without the switchroom telegram plugin", () => {
-    const agentConfig = makeAgentConfig({
-      channels: {
-        telegram: {
-          plugin: "official",
-        },
-      },
-    });
-    const result = scaffoldAgent(
-      "sandbox-primer-skip-agent",
-      agentConfig,
-      tmpDir,
-      telegramConfig,
-    );
-    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    // start.sh should NOT inline the sandbox primer. The agent reads
+    // it via `--add-dir ~/.switchroom/fleet` instead.
     expect(startSh).not.toContain("## Sandbox: you");
     expect(startSh).not.toContain("running in a switchroom container");
+    // start.sh DOES carry the --add-dir flag pointing at the fleet dir,
+    // unconditionally for every plugin path.
+    expect(startSh).toContain("SR_FLEET_DIR");
+    expect(startSh).toContain(".switchroom/fleet");
   });
 
   it("escapes system_prompt_append via POSIX single-quote wrapping", () => {
@@ -2513,7 +2500,14 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(startSh).toContain("--allowedTools 'Edit'");
   });
 
-  it("agents with no add_dirs/allowed_tools/disallowed_tools render no flags (#199)", () => {
+  it("agents with no add_dirs/allowed_tools/disallowed_tools render no per-agent flags (#199)", () => {
+    // Pre-#1850: this test asserted start.sh had no `--add-dir` flag
+    // when the agent didn't configure any add_dirs. Post-#1850 the
+    // fleet directory mount adds an unconditional `--add-dir
+    // $SR_FLEET_DIR` (guarded by directory existence), so the
+    // "no add-dir flags" assertion shifted from "no occurrences" to
+    // "no per-agent occurrences" — i.e. no add-dir tied to a yaml
+    // `add_dirs:` entry.
     const agentConfig = makeAgentConfig();
     const result = scaffoldAgent(
       "bare-agent",
@@ -2522,7 +2516,16 @@ describe("scaffoldAgent with global defaults cascade", () => {
       telegramConfig,
     );
     const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
-    expect(startSh).not.toContain("--add-dir");
+    // The fleet add-dir is expected and conditional on the directory
+    // existing at runtime; it's emitted via the SR_FLEET_ARG shell var.
+    expect(startSh).toContain("SR_FLEET_DIR");
+    expect(startSh).toContain("SR_FLEET_ARG");
+    // No per-agent add-dirs from yaml `add_dirs:` (since none configured).
+    // Per-agent add-dirs render as literal `--add-dir '<path>'` tokens
+    // inside extraCliArgs; the fleet add-dir uses an unquoted shell
+    // variable `$SR_FLEET_ARG`. Distinguish by looking for literal
+    // quoted `--add-dir '` which only per-agent emissions produce.
+    expect(startSh).not.toContain("--add-dir '");
     expect(startSh).not.toContain("--allowedTools");
     expect(startSh).not.toContain("--disallowedTools");
   });


### PR DESCRIPTION
First PR of epic #1850 (agent prompt redesign). Closes #1852.

## Summary

Three coordinated mechanical changes. Behaviour-equivalent at the model level — the same content reaches the model, just from disk instead of baked-in-string, and from one path instead of two.

1. **Hoist `TELEGRAM_GUIDANCE` + `MEMORY_GUIDANCE` to top-level constants** alongside the already-hoisted `SANDBOX_GUIDANCE`. Removes the init-vs-reconcile drift hazard.
2. **Introduce `~/.switchroom/fleet/`** directory mechanism with `--add-dir` wiring + compose bind-mount + `apply`-time seeding.
3. **Move L1 invariants content off `--append-system-prompt`** into `~/.switchroom/fleet/switchroom-invariants.md`. Remove the `{{> telegram-style}}` partial inclusion from all four profile templates to eliminate the session-level duplication.

The per-turn `<turn-pacing>` UserPromptSubmit hook from PR #1646 is **untouched**. It's load-bearing.

## Why

Per the ground-truth audit + Opus review in the epic thread:

- The 5-beats content used to reach the model TWICE at session-prompt time: once via the `{{> telegram-style}}` partial rendered into `<agentDir>/CLAUDE.md` (native auto-discovery), once via the scaffold-baked `telegramGuidance` constant in `--append-system-prompt`. After this PR, once from L1.
- `scaffold.ts` had `telegramGuidance` + `memoryGuidance` duplicated verbatim between the initial-scaffold path (`:1715-1768` old) and the reconcile path (`:3808-3861` old). Only one fired per invocation but the drift hazard was real. Hoisted to top-level constants matching `SANDBOX_GUIDANCE`.
- L1 invariants were operator-invisible (compiled into `dist/cli/switchroom.js` only). Now visible on disk at `~/.switchroom/fleet/switchroom-invariants.md` with a \"DO NOT EDIT, release-controlled\" header; doctor probe (in follow-up #1858) will checksum-pin them.

## What changed

| File | Change |
|---|---|
| `src/agents/scaffold.ts` | Hoist `TELEGRAM_GUIDANCE` + `MEMORY_GUIDANCE` to top-level constants. New exported `renderFleetInvariants()` helper. Remove inline duplicates from both `systemPromptAppendShellQuoted` IIFEs. |
| `src/cli/apply.ts` | `ensureHostMountSources` creates `~/.switchroom/fleet/`, renders `switchroom-invariants.md` (release-pinned, rewritten on every apply), and `writeIfMissing` seeds `CLAUDE.md` (L2 placeholder). |
| `src/agents/compose.ts` | Bind-mount `~/.switchroom/fleet:~/.switchroom/fleet:ro` per agent (existsSync-guarded; same pattern as `skills/` and `mcp-launchers/`). |
| `profiles/_base/start.sh.hbs` | Add `--add-dir \"\$HOME/.switchroom/fleet\"` to all four `exec claude` branches via a shared shell var, guarded by directory existence. |
| `profiles/{default,coding,executive-assistant,health-coach}/CLAUDE.md.hbs` | Remove `{{> telegram-style}}` partial inclusion. The 5-beats now lives in L1 invariants only. |
| `tests/scaffold.memory-prompt.test.ts` | Rewritten to assert content via `renderFleetInvariants()` instead of via the (now-removed) `--append-system-prompt` injection. Adds regression guard: start.sh must NOT contain memory guidance. |
| `tests/scaffold.test.ts` | Updates the sandbox-primer + no-flags tests for the new shape. |
| `tests/docker/compose-generator.test.ts` | 2 new tests: fleet mount present when host dir exists; mount omitted when absent. |

## Test plan

- [x] 226/226 scaffold tests pass.
- [x] 150/150 compose-generator tests pass (2 new fleet tests added).
- [x] `tsc --noEmit` clean.
- [x] `check-bot-api-wrapping.sh` clean.

Live-verify (manual, after merge): on a fleet apply, confirm `~/.switchroom/fleet/switchroom-invariants.md` exists with the expected three sections, `~/.switchroom/fleet/CLAUDE.md` exists with the placeholder, and an agent's `claude` invocation carries `--add-dir $HOME/.switchroom/fleet`.

## Risk

Migration is forward-only and behaviour-equivalent. Existing operators' first apply post-merge:
1. Creates `~/.switchroom/fleet/` (no existing operator has it).
2. Seeds both files with current content.
3. Compose bind-mount picks up on next reconcile (which happens automatically on apply).
4. Agent `start.sh` regenerates with `--add-dir` flag.
5. Agent's next session boot loads the L1 file via native auto-discovery.

Same content reaches the model as before, just from disk. The two scaffold.ts duplicates + the `{{> telegram-style}}` partial are removed in the same PR so the model isn't temporarily double-loaded.

## Out of scope (epic follow-ups)

- Two-section per-agent `<agentDir>/CLAUDE.md` marker (#1857)
- Lane 2 fleet defaults content (#1855)
- Soul schema widening (#1856)
- Workspace/* fold into L3 (#1865)
- Doctor probes for the new cascade (#1858)
- `switchroom apply --refresh-fleet-defaults` (#1859)
- Per-turn `<turn-pacing>` hook (deliberately untouched, #1646)

🤖 Generated with [Claude Code](https://claude.com/claude-code)