### PR TITLE
refactor(gateway): chat-lock + inbound-coalesce per-(chat,thread) keying (PR2)

### DIFF
--- a/telegram-plugin/chat-lock.ts
+++ b/telegram-plugin/chat-lock.ts
@@ -1,5 +1,5 @@
 /**
- * Per-chat FIFO serialization for outbound Telegram API calls.
+ * Per-(chat, thread) FIFO serialization for outbound Telegram API calls.
  *
  * Without this, concurrent MCP tool handlers (reply, stream_reply, react,
  * edit_message, delete_message, pin_message, forward_message) all call
@@ -8,32 +8,56 @@
  * `stream_reply` edit, or a `react` can resolve before the `reply` it
  * reacts to.
  *
- * The fix is a per-chat promise chain: every handler acquires the lock
- * for its `chat_id`, dispatches its API call, then releases. Granularity
- * is `chat_id` (not chat+thread) — different chats run concurrently.
+ * The fix is a per-key promise chain: every handler acquires the lock
+ * for its `(chat_id, message_thread_id)` pair, dispatches its API call,
+ * then releases. Granularity moved from `chat_id` to `(chat, thread)`
+ * in PR2 of the supergroup-mode rollout (CPO ratified 2026-05-27,
+ * decision #8=B): for a supergroup agent owning many topics, the old
+ * per-chat lock artificially serialized cross-topic sends (an
+ * `#alerts` digest queueing behind eight `#planning` stream edits).
+ * Now different threads in the same chat dispatch concurrently;
+ * per-thread ordering is still preserved (`sendMessage` then
+ * `editMessageText` on the returned message_id can't race).
+ *
+ * Methods without `message_thread_id` in their options (edits,
+ * deletes, reactions, pins — Telegram infers thread from message_id)
+ * key by `chat_id` alone via the canonical `chatKey(chat, null)`
+ * collapse — same behavior as before for those callsites.
+ *
+ * Telegram's per-chat rate ceiling is still respected via grammY's
+ * autoRetry transformer; if two topics in the same chat both burst
+ * past the limit, grammY backs off per the Retry-After header — same
+ * worst-case behavior as the old per-chat lock, just hit differently.
+ * See docs/rfcs/supergroup-mode.md and the
+ * `tests/outbound-ordering.test.ts` 429-isolation row.
  */
 
+import { chatKey } from './gateway/chat-key.js'
+
 export interface ChatLock {
-  /** Run `fn` serialized against other work on the same `chatId`. */
-  run<T>(chatId: string, fn: () => Promise<T>): Promise<T>
-  /** Wrap a bot.api-shaped object so every method auto-locks on its first arg. */
+  /** Run `fn` serialized against other work on the same `key`. */
+  run<T>(key: string, fn: () => Promise<T>): Promise<T>
+  /**
+   * Wrap a bot.api-shaped object so every method auto-locks by
+   * `(chat_id, message_thread_id)` pair extracted from its arguments.
+   */
   wrapBot<B extends { api: Record<string, unknown> }>(bot: B): B
 }
 
 export function createChatLock(): ChatLock {
   const chains = new Map<string, Promise<unknown>>()
 
-  function run<T>(chatId: string, fn: () => Promise<T>): Promise<T> {
-    const prior = chains.get(chatId) ?? Promise.resolve()
+  function run<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prior = chains.get(key) ?? Promise.resolve()
     // Swallow the prior result/error for the chain we're about to build on,
-    // so one failure doesn't poison the whole chat's queue.
+    // so one failure doesn't poison the whole queue.
     const next = prior.then(fn, fn)
     // Keep the chain alive only while work is pending. When this call is
     // the tail, clear the map entry to avoid unbounded growth.
     const tracked = next.finally(() => {
-      if (chains.get(chatId) === tracked) chains.delete(chatId)
+      if (chains.get(key) === tracked) chains.delete(key)
     })
-    chains.set(chatId, tracked)
+    chains.set(key, tracked)
     return next
   }
 
@@ -45,14 +69,31 @@ export function createChatLock(): ChatLock {
         return function (this: unknown, ...args: unknown[]) {
           // By Telegram Bot API convention, the first positional arg of
           // every chat-scoped method is `chat_id`. Methods without one
-          // (getMe, getFile, setMyCommands) fall through as a string of
-          // their own — which is fine; they don't need per-chat ordering.
+          // (getMe, getFile, setMyCommands) fall through to a global
+          // lane — they have no per-chat ordering constraint.
           const first = args[0]
-          const key =
-            typeof first === 'string' || typeof first === 'number'
-              ? String(first)
-              : '__global__'
-          return run(key, () =>
+          if (typeof first !== 'string' && typeof first !== 'number') {
+            return run('__global__', () =>
+              (orig as (...a: unknown[]) => Promise<unknown>).apply(target, args),
+            )
+          }
+          const chatId = String(first)
+          // Try to extract `message_thread_id` from the LAST arg if it's
+          // a plain options object. Telegram API convention: options bag
+          // is the last positional. Arrays (e.g. `setMessageReaction`'s
+          // reactions list) are explicitly excluded — only plain objects
+          // can carry message_thread_id. Edits / deletes / reactions /
+          // pins infer thread from message_id; they fall through with
+          // `null` thread and serialize per-chat as before.
+          const last = args[args.length - 1]
+          const threadFromOpts =
+            last != null &&
+            typeof last === 'object' &&
+            !Array.isArray(last)
+              ? (last as Record<string, unknown>).message_thread_id
+              : undefined
+          const tid = typeof threadFromOpts === 'number' ? threadFromOpts : null
+          return run(chatKey(chatId, tid), () =>
             (orig as (...a: unknown[]) => Promise<unknown>).apply(target, args),
           )
         }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -7870,7 +7870,11 @@ async function handleInboundCoalesced(
   //     defensive against future routers that might call this without one).
   maybeEarlyAckReaction(ctx, from)
 
-  const key = inboundCoalesceKey(String(ctx.chat!.id), String(from.id))
+  const key = inboundCoalesceKey(
+    String(ctx.chat!.id),
+    ctx.message?.message_thread_id,
+    String(from.id),
+  )
   const result = inboundCoalescer.enqueue(key, { text, ctx, downloadImage, attachment })
   if (result.bypass) return handleInbound(ctx, text, undefined, undefined)
 }

--- a/telegram-plugin/gateway/inbound-coalesce.ts
+++ b/telegram-plugin/gateway/inbound-coalesce.ts
@@ -137,11 +137,24 @@ export function createInboundCoalescer<T>(opts: InboundCoalescerOptions<T>): Inb
 }
 
 /**
- * Build a coalesce key from `(chatId, userId)`. Identity-stable across
- * messages from the same sender in the same chat, distinct across
- * different senders so a user-driven reply isn't merged with a sibling
- * message from someone else in a group chat.
+ * Build a coalesce key from `(chatId, threadId, userId)`. Identity-stable
+ * across messages from the same sender in the same chat and topic,
+ * distinct across:
+ *   - different senders (so one user's typing isn't merged with another's)
+ *   - different topics (so a user typing in #planning isn't merged with
+ *     the same user's message in #admin — supergroup-mode invariant,
+ *     CPO decision #9 ratified 2026-05-27)
+ *
+ * `threadId` collapses `null`/`undefined`/`0` to `_` via the same
+ * convention as `chatKey()`. The 1.5s coalesce window is per-topic
+ * intent ("user sends 3 sentences as one thought") — applying it
+ * cross-topic merges genuinely separate conversations.
  */
-export function inboundCoalesceKey(chatId: string, userId: string): string {
-  return `${chatId}:${userId}`
+export function inboundCoalesceKey(
+  chatId: string,
+  threadId: number | null | undefined,
+  userId: string,
+): string {
+  const t = threadId == null || threadId === 0 ? '_' : String(threadId)
+  return `${chatId}:${t}:${userId}`
 }

--- a/telegram-plugin/stream-reply-handler.ts
+++ b/telegram-plugin/stream-reply-handler.ts
@@ -23,6 +23,7 @@ import {
   type RetryPolicy,
 } from './stream-controller.js'
 import { sanitizeTelegramHtml } from './html-sanitize.js'
+import { chatKey, chatKeyWithSuffix } from './gateway/chat-key.js'
 
 /**
  * Builds the inline status-accent header line for `reply` / `stream_reply`.
@@ -311,14 +312,15 @@ function streamKey(
   lane?: string,
   turnKey?: string,
 ): string {
-  // Canonical chat-key derivation lives in gateway/chat-key.ts — keep this
-  // expression in lockstep with that helper (treats 0/null/undefined the
-  // same), but inline here so this file doesn't introduce a cross-package
-  // import for one expression. See #1564 for the sibling-key bug class.
-  const t = threadId == null || threadId === 0 ? '_' : String(threadId)
-  const base = `${chatId}:${t}`
-  const withLane = lane != null && lane.length > 0 ? `${base}:${lane}` : base
-  return turnKey != null && turnKey.length > 0 ? `${withLane}:${turnKey}` : withLane
+  // Adopt the canonical chatKey() / chatKeyWithSuffix() primitives from
+  // gateway/chat-key.ts (PR2 of supergroup mode — kills the previously
+  // inlined copy of the key expression). The brand erases to string at
+  // runtime, so callers using `streamKey` as a `Map<string, T>` key
+  // continue to work unchanged.
+  const base = lane != null && lane.length > 0
+    ? chatKeyWithSuffix(chatId, threadId ?? null, lane)
+    : chatKey(chatId, threadId ?? null)
+  return turnKey != null && turnKey.length > 0 ? `${base}:${turnKey}` : base
 }
 
 export async function handleStreamReply(

--- a/telegram-plugin/tests/inbound-coalesce.test.ts
+++ b/telegram-plugin/tests/inbound-coalesce.test.ts
@@ -21,10 +21,26 @@ beforeEach(() => { vi.useFakeTimers() })
 afterEach(() => { vi.useRealTimers() })
 
 describe('inboundCoalesceKey', () => {
-  it('combines chatId and userId so distinct senders never collide', () => {
-    expect(inboundCoalesceKey('c1', 'u1')).not.toBe(inboundCoalesceKey('c1', 'u2'))
-    expect(inboundCoalesceKey('c1', 'u1')).not.toBe(inboundCoalesceKey('c2', 'u1'))
-    expect(inboundCoalesceKey('c1', 'u1')).toBe(inboundCoalesceKey('c1', 'u1'))
+  it('combines chatId, threadId, and userId so distinct senders never collide', () => {
+    expect(inboundCoalesceKey('c1', null, 'u1')).not.toBe(inboundCoalesceKey('c1', null, 'u2'))
+    expect(inboundCoalesceKey('c1', null, 'u1')).not.toBe(inboundCoalesceKey('c2', null, 'u1'))
+    expect(inboundCoalesceKey('c1', null, 'u1')).toBe(inboundCoalesceKey('c1', null, 'u1'))
+  })
+
+  it('keeps the same user\'s messages in DIFFERENT topics in distinct buckets (supergroup-mode)', () => {
+    // CPO decision #9 ratified 2026-05-27: per-topic coalesce intent.
+    // The 1.5s window is "user sends 3 sentences as one thought" —
+    // applying it cross-topic merges genuinely separate conversations.
+    expect(inboundCoalesceKey('c1', 17, 'u1')).not.toBe(inboundCoalesceKey('c1', 23, 'u1'))
+    expect(inboundCoalesceKey('c1', 17, 'u1')).not.toBe(inboundCoalesceKey('c1', null, 'u1'))
+  })
+
+  it('collapses null / undefined / 0 thread IDs to the same key (chatKey convention)', () => {
+    const k1 = inboundCoalesceKey('c1', null, 'u1')
+    const k2 = inboundCoalesceKey('c1', undefined, 'u1')
+    const k3 = inboundCoalesceKey('c1', 0, 'u1')
+    expect(k1).toBe(k2)
+    expect(k1).toBe(k3)
   })
 })
 

--- a/telegram-plugin/tests/outbound-ordering.test.ts
+++ b/telegram-plugin/tests/outbound-ordering.test.ts
@@ -170,6 +170,113 @@ describe('wrapBot — bot.api.* calls auto-lock by first-arg chat id', () => {
     expect(rb.message_id).toBe(20)
   })
 
+  it('SAME chat + DIFFERENT thread sendMessage calls dispatch concurrently (supergroup-mode unblock)', async () => {
+    // PR2 of supergroup-mode: chat-lock moved from chatId-only keying
+    // to (chat, thread) keying. Two topics in the same supergroup must
+    // not artificially serialize at the bot.api layer.
+    const lock = createChatLock()
+    const bot = createMockBot()
+    const wrapped = lock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+
+    const dTopicA = deferred<{ message_id: number }>()
+    const dTopicB = deferred<{ message_id: number }>()
+    const started: string[] = []
+    bot.api.sendMessage.mockImplementationOnce(async (_c: string, t: string) => {
+      started.push(`A:${t}`)
+      return dTopicA.promise
+    })
+    bot.api.sendMessage.mockImplementationOnce(async (_c: string, t: string) => {
+      started.push(`B:${t}`)
+      return dTopicB.promise
+    })
+
+    // Same chatId "supergrp" but different message_thread_id.
+    const pA = wrapped.api.sendMessage('supergrp', 'planning msg', { message_thread_id: 17 })
+    const pB = wrapped.api.sendMessage('supergrp', 'cron digest', { message_thread_id: 23 })
+    await Promise.resolve(); await Promise.resolve()
+    // BOTH should have started — supergroup-mode parallelism guarantee.
+    expect(started).toEqual(['A:planning msg', 'B:cron digest'])
+
+    // Resolve B first; A's resolution must not delay B's return.
+    dTopicB.resolve({ message_id: 200 })
+    const rB = await pB
+    expect(rB.message_id).toBe(200)
+
+    dTopicA.resolve({ message_id: 100 })
+    const rA = await pA
+    expect(rA.message_id).toBe(100)
+  })
+
+  it('SAME chat + SAME thread sendMessage calls STILL serialize (per-topic ordering preserved)', async () => {
+    // Per-topic message order matters (a reply tied to a message_id
+    // must see that message exist first). The lock must still serialize
+    // within a topic.
+    const lock = createChatLock()
+    const bot = createMockBot()
+    const wrapped = lock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+
+    const dSlow = deferred<{ message_id: number }>()
+    const startOrder: string[] = []
+    bot.api.sendMessage.mockImplementationOnce(async (_c: string, t: string) => {
+      startOrder.push(`first:${t}`)
+      const r = await dSlow.promise
+      startOrder.push(`first:end:${t}`)
+      return r
+    })
+    bot.api.sendMessage.mockImplementationOnce(async (_c: string, t: string) => {
+      startOrder.push(`second:${t}`)
+      return { message_id: 2 }
+    })
+
+    const p1 = wrapped.api.sendMessage('supergrp', 'first', { message_thread_id: 17 })
+    const p2 = wrapped.api.sendMessage('supergrp', 'second', { message_thread_id: 17 })
+
+    await Promise.resolve(); await Promise.resolve()
+    // Same thread → second waits for first.
+    expect(startOrder).toEqual(['first:first'])
+
+    dSlow.resolve({ message_id: 1 })
+    await Promise.all([p1, p2])
+    expect(startOrder).toEqual(['first:first', 'first:end:first', 'second:second'])
+  })
+
+  it('a 429 from one topic does NOT stall sends to a different topic in the same chat', async () => {
+    // CPO #8=B guardrail: when grammY's autoRetry transformer backs off
+    // on a 429 in topic A, topic B's sends must keep flowing. This test
+    // pins the contract by simulating a slow/rejecting first call (proxy
+    // for a 429+backoff path) on topic A and asserting topic B doesn't
+    // wait on it.
+    const lock = createChatLock()
+    const bot = createMockBot()
+    const wrapped = lock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+
+    // Topic A's send hangs (proxy for an in-flight 429-backoff path);
+    // topic B's send must NOT wait on it.
+    const dTopicA = deferred<{ message_id: number }>()
+    const started: string[] = []
+    bot.api.sendMessage.mockImplementationOnce(async () => {
+      started.push('topicA:start')
+      return dTopicA.promise
+    })
+    bot.api.sendMessage.mockImplementationOnce(async () => {
+      started.push('topicB:start')
+      return { message_id: 2 }
+    })
+
+    const pA = wrapped.api.sendMessage('supergrp', 'overloaded', { message_thread_id: 17 })
+    const pB = wrapped.api.sendMessage('supergrp', 'unaffected', { message_thread_id: 23 })
+
+    // Topic B should complete WITHOUT waiting on topic A's hang.
+    const rB = await pB
+    expect(rB.message_id).toBe(2)
+    expect(started).toContain('topicB:start')
+
+    // Resolve A so the lock chain drains cleanly.
+    dTopicA.resolve({ message_id: 1 })
+    const rA = await pA
+    expect(rA.message_id).toBe(1)
+  })
+
   it('react (setMessageReaction) queues behind an in-flight reply (sendMessage) to the same chat', async () => {
     const lock = createChatLock()
     const bot = createMockBot()


### PR DESCRIPTION
PR2 of the **supergroup-owned mode** rollout (RFC: [`docs/rfcs/supergroup-mode.md`](docs/rfcs/supergroup-mode.md), PR1 #1868 merged). Three focused composite-key refactors, all at the API-call layer. **No behavior change for fleet-shared or DM agents** — existing tests stay green; only supergroup-mode parallelism is unblocked.

## Summary

**chat-lock per-(chat,thread)** — CPO decision #8=B ratified 2026-05-27:
- \`wrapBot\` proxy now extracts \`message_thread_id\` from the options bag and locks by \`chatKey(chat, thread)\`.
- Methods without thread in opts (\`editMessageText\`, \`setMessageReaction\`, \`deleteMessage\`, pin/unpin) fall through to \`chatKey(chat, null)\` — same per-chat serialization as before, no regression.
- Same-chat-different-topic \`sendMessage\` calls now dispatch concurrently — fixes the "cron digest queues behind 8 planning stream edits" artificial latency under supergroup mode.
- 429 from one topic doesn't queue another — guardrail per CPO #8 nit.

**inbound-coalesce per-(chat,thread,user)** — CPO decision #9 ratified:
- \`inboundCoalesceKey\` gains a \`threadId\` parameter (now \`chatId × threadId × userId\`).
- Same sender in two topics in the same chat no longer has their messages merged into one turn — each topic gets its own 1.5s sliding window.

**\`stream-reply-handler.ts\` adopts canonical \`chatKey()\`**:
- Killed the inline copy of the chat-key expression at \`stream-reply-handler.ts:308\` (warned about drift risk in the comment since PR #1564).
- Imports \`chatKey\` / \`chatKeyWithSuffix\` from \`gateway/chat-key.js\`.

## Why

These three are at the API-call/wire layer, independent of the bigger \`currentTurn\` refactor in PR3. They're shippable now and unblock the supergroup-mode parallelism guarantees we need without touching the turn-lifecycle code.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] All 6 lint gates clean (\`check-plugin-references\`, \`check-bot-api-wrapping\`, etc.)
- [x] 3 new outbound-ordering rows passing: per-thread concurrency unblock, per-thread ordering preserved, 429-isolation guardrail.
- [x] 2 new inbound-coalesce rows passing: topic isolation, null/undefined/0 thread collapse.
- [x] All 3,451 bun plugin tests green; 180 vitest src/config + src/telegram green.
- [x] Backward-compat verified: tests for the existing per-chat ordering / same-chat-no-thread serialization still pass without modification — the fall-through path is identical.

## Risk

- **Low.** Pure refactor at well-tested seams. The change is observable only when:
  - Two callsites target the same chat with **different** \`message_thread_id\` (chat-lock change) — today's fleet has one topic per agent, so this rarely fires.
  - Two messages arrive from the **same user** to the **same chat** in **different topics** within ~1.5s (coalesce change) — same rarity.
- Telegram's per-chat rate ceiling is still respected via grammY's autoRetry transformer (worst case: 429 → backoff per \`Retry-After\`, same as today's worst case).
- No persistent state changes, no schema changes, no config changes.

## Follow-ups

- **PR2b** (next): gateway state re-keys — composite-key \`typingIntervals\`/\`turnTypingIntervals\`, \`pendingReauthFlows\`. These fix concrete user-felt bugs (typing indicator clobbering, cross-topic OAuth code mis-attribution) and were originally part of PR2 in the RFC — splitting to keep this PR focused and reviewable.
- **PR3**: \`currentTurn\` → \`Map<ChatKey, Turn>\` + per-topic gate (the gated parallel-turns refactor).
- **PR4**: wire \`resolveOutboundTopic()\` into emitters; General-topic strip-1 wrapper at the same \`chatLock.wrapBot\` proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)