### PR TITLE
refactor(gateway): typing indicators + auth-intercept maps per-(chat,thread) (PR3)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1357,7 +1357,19 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
   // abort skips purge, the stray loop self-heals: the next turn on this
   // chat calls `startTurnTypingLoop`, which stops the old interval
   // first.)
-  stopTurnTypingLoop(chatIdOfChatKey(key as _ChatKey))
+  // PR3 supergroup-mode: stop the per-(chat,thread) typing loop, not
+  // the whole chat's. Prefer the ending-turn's session ids (the
+  // canonical turn ownership); fall back to parsing the chatKey
+  // for sibling-purge / restart-cleanup callers that don't have a
+  // Turn handle.
+  if (endingTurn != null) {
+    stopTurnTypingLoop(endingTurn.sessionChatId, endingTurn.sessionThreadId ?? null)
+  } else {
+    const chatId = chatIdOfChatKey(key as _ChatKey)
+    const threadPart = (key as string).slice(chatId.length + 1)
+    const threadId = threadPart === '_' || threadPart === '' ? null : Number(threadPart)
+    stopTurnTypingLoop(chatId, Number.isFinite(threadId) ? threadId : null)
+  }
   if (msgInfo) {
     const agentDir = resolveAgentDirFromEnv()
     if (agentDir != null) removeActiveReaction(agentDir, msgInfo.chatId, msgInfo.messageId)
@@ -1875,6 +1887,13 @@ function escapeMarkdownV2(text: string): string {
 }
 
 // ─── Typing indicator ─────────────────────────────────────────────────────
+// All four state maps re-keyed from `chat_id` to `chatKey(chat, thread)`
+// in PR3 of the supergroup-mode rollout. In supergroup mode one agent
+// owns many topics in one chat; chatId-only keying meant topic A's
+// typing indicator died when topic B's tool call ended (last-stop-wins
+// on a shared key). Per-(chat,thread) keying preserves independent
+// typing loops across topics. Callers without thread context pass
+// `null` and behave exactly as before (chatKey collapses null→`_`).
 const typingIntervals = new Map<string, ReturnType<typeof setInterval>>()
 // Track pending backoff-retry timers so shutdown and stop can cancel them.
 const typingRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
@@ -1903,34 +1922,41 @@ const CHAT_ACTION_WHITELIST = new Set([
 ] as const)
 type ChatAction = typeof CHAT_ACTION_WHITELIST extends Set<infer T> ? T : never
 
-function startTypingLoop(chat_id: string, action: ChatAction = 'typing'): void {
-  stopTypingLoop(chat_id)
+function startTypingLoop(
+  chat_id: string,
+  thread_id: number | null = null,
+  action: ChatAction = 'typing',
+): void {
+  stopTypingLoop(chat_id, thread_id)
+  const key = chatKey(chat_id, thread_id) as string
+  const sendOpts = thread_id != null ? { message_thread_id: thread_id } : undefined
   const send = () => {
-    bot.api.sendChatAction(chat_id, action).then(
+    bot.api.sendChatAction(chat_id, action, sendOpts).then(
       () => { typingBackoffMs = 0 },
       (err) => {
         const msg = err instanceof Error ? err.message : String(err)
         if (msg.includes('401') || msg.includes('Unauthorized')) {
           typingBackoffMs = Math.min(Math.max(typingBackoffMs * 2 || 1000, 1000), TYPING_BACKOFF_MAX)
-          stopTypingLoop(chat_id)
+          stopTypingLoop(chat_id, thread_id)
           const retry = setTimeout(() => {
-            typingRetryTimers.delete(chat_id)
-            startTypingLoop(chat_id, action)
+            typingRetryTimers.delete(key)
+            startTypingLoop(chat_id, thread_id, action)
           }, typingBackoffMs)
-          typingRetryTimers.set(chat_id, retry)
+          typingRetryTimers.set(key, retry)
         }
       },
     )
   }
   send()
-  typingIntervals.set(chat_id, setInterval(send, 4000))
+  typingIntervals.set(key, setInterval(send, 4000))
 }
 
-function stopTypingLoop(chat_id: string): void {
-  const iv = typingIntervals.get(chat_id)
-  if (iv) { clearInterval(iv); typingIntervals.delete(chat_id) }
-  const retry = typingRetryTimers.get(chat_id)
-  if (retry) { clearTimeout(retry); typingRetryTimers.delete(chat_id) }
+function stopTypingLoop(chat_id: string, thread_id: number | null = null): void {
+  const key = chatKey(chat_id, thread_id) as string
+  const iv = typingIntervals.get(key)
+  if (iv) { clearInterval(iv); typingIntervals.delete(key) }
+  const retry = typingRetryTimers.get(key)
+  if (retry) { clearTimeout(retry); typingRetryTimers.delete(key) }
 }
 
 // Turn-level `typing…` indicator. Deliberately a SEPARATE interval map
@@ -1945,18 +1971,21 @@ function stopTypingLoop(chat_id: string): void {
 // sendChatAction is cheap.
 const turnTypingIntervals = new Map<string, ReturnType<typeof setInterval>>()
 
-function startTurnTypingLoop(chat_id: string): void {
-  stopTurnTypingLoop(chat_id)
+function startTurnTypingLoop(chat_id: string, thread_id: number | null = null): void {
+  stopTurnTypingLoop(chat_id, thread_id)
+  const key = chatKey(chat_id, thread_id) as string
+  const sendOpts = thread_id != null ? { message_thread_id: thread_id } : undefined
   const send = () => {
-    void bot.api.sendChatAction(chat_id, 'typing').catch(() => {})
+    void bot.api.sendChatAction(chat_id, 'typing', sendOpts).catch(() => {})
   }
   send()
-  turnTypingIntervals.set(chat_id, setInterval(send, 4000))
+  turnTypingIntervals.set(key, setInterval(send, 4000))
 }
 
-function stopTurnTypingLoop(chat_id: string): void {
-  const iv = turnTypingIntervals.get(chat_id)
-  if (iv) { clearInterval(iv); turnTypingIntervals.delete(chat_id) }
+function stopTurnTypingLoop(chat_id: string, thread_id: number | null = null): void {
+  const key = chatKey(chat_id, thread_id) as string
+  const iv = turnTypingIntervals.get(key)
+  if (iv) { clearInterval(iv); turnTypingIntervals.delete(key) }
 }
 
 const typingWrapper = createTypingWrapper({
@@ -4672,7 +4701,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     previewMessageId = null
   }
 
-  startTypingLoop(chat_id)
+  startTypingLoop(chat_id, threadId ?? null)
 
   // #1677 silent-reply auto-edit. Consecutive silent replies within
   // a turn edit a single anchor message instead of stacking new
@@ -4804,7 +4833,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   if (silentAnchorEditDone) {
     // Skip the chunk loop entirely — the anchor edit IS the send.
     // Match the normal exit path: stop typing, then return.
-    stopTypingLoop(chat_id)
+    stopTypingLoop(chat_id, threadId ?? null)
     return {
       content: [
         {
@@ -4921,7 +4950,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     const msg = err instanceof Error ? err.message : String(err)
     throw new Error(`reply failed after ${sentIds.length} of ${chunks.length} chunk(s) sent: ${msg}`)
   } finally {
-    stopTypingLoop(chat_id)
+    stopTypingLoop(chat_id, threadId ?? null)
   }
 
   // #710: remember per-button agent meta (ack_text / single_use) keyed
@@ -6281,8 +6310,12 @@ async function executeSendTyping(args: Record<string, unknown>): Promise<unknown
     }
     action = rawAction as ChatAction
   }
-  startTypingLoop(stChatId, action)
-  setTimeout(() => stopTypingLoop(stChatId), 30000)
+  // PR3 supergroup-mode: resolve thread from args or fall back to the
+  // last-seen thread for this chat so the indicator lands in the topic
+  // the agent is working in (rather than the chat root).
+  const stThreadId = resolveThreadId(stChatId, args.message_thread_id as string | number | undefined) ?? null
+  startTypingLoop(stChatId, stThreadId, action)
+  setTimeout(() => stopTypingLoop(stChatId, stThreadId), 30000)
   for (const [key, ctrl] of activeStatusReactions.entries()) {
     if (key.startsWith(`${stChatId}:`)) ctrl.setTool()
   }
@@ -6632,7 +6665,7 @@ function handleSessionEvent(ev: SessionEvent): void {
       if (isTelegramSurfaceTool(name)) return
       ctrl.setTool(name)
       if (ev.toolUseId) {
-        typingWrapper.onToolUse(ev.toolUseId, turn.sessionChatId, name)
+        typingWrapper.onToolUse(ev.toolUseId, turn.sessionChatId, name, turn.sessionThreadId ?? null)
       }
       return
     }
@@ -6875,7 +6908,7 @@ function handleSessionEvent(ev: SessionEvent): void {
       const turn = currentTurn
       if (turn == null) return
       if (!ev.toolUseId) return
-      typingWrapper.onToolUse(ev.toolUseId, turn.sessionChatId, ev.toolName)
+      typingWrapper.onToolUse(ev.toolUseId, turn.sessionChatId, ev.toolName, turn.sessionThreadId ?? null)
       return
     }
     case 'sub_agent_tool_result': {
@@ -8744,7 +8777,10 @@ async function handleInbound(
         // turn-end (`purgeReactionTracking → stopTurnTypingLoop`).
         // Deterministic, framework-owned, no prose — the mechanical
         // ambient layer of the pacing contract.
-        startTurnTypingLoop(chat_id)
+        // PR3 supergroup-mode: pass thread so the indicator lands in
+        // this turn's topic (otherwise topic A's turn-end would kill
+        // topic B's typing indicator on shared chat_id keying).
+        startTurnTypingLoop(chat_id, messageThreadId ?? null)
         // #1122 KPI: emit turn_started so dashboards can compute funnel
         // start counts + correlate to turn_ended for duration / TTFO.
         emitRuntimeMetric({

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8204,11 +8204,17 @@ async function handleInbound(
   // hygiene). The add-flow intercept comes first because /auth add
   // creates fresh credentials at the broker layer, vs /reauth which
   // mutates an existing agent's slot — different success paths.
-  const pendingAdd = pendingAuthAddFlows.get(chat_id)
+  //
+  // PR3 supergroup-mode: keyed by chatKey(chat, thread) so an OAuth
+  // code pasted into topic A isn't intercepted when topic B has a
+  // separate /auth add flow pending (security: prevents cross-topic
+  // credential mis-attribution).
+  const interceptKey = chatKey(chat_id, messageThreadId) as string
+  const pendingAdd = pendingAuthAddFlows.get(interceptKey)
   if (pendingAdd && looksLikeAuthCode(text)) {
     const elapsed = Date.now() - pendingAdd.startedAt
     if (elapsed < REAUTH_INTERCEPT_TTL_MS) {
-      pendingAuthAddFlows.delete(chat_id)
+      pendingAuthAddFlows.delete(interceptKey)
       try {
         const credentials = await submitAccountAuthCode(pendingAdd, text.trim())
         try {
@@ -8249,15 +8255,15 @@ async function handleInbound(
     // Stale — drop the pending entry but let the message fall through
     // to other intercepts (defensively wipe scratch).
     cancelAccountAuthSession(pendingAdd)
-    pendingAuthAddFlows.delete(chat_id)
+    pendingAuthAddFlows.delete(interceptKey)
   }
 
   // Auth-code intercept
-  const pendingReauth = pendingReauthFlows.get(chat_id)
+  const pendingReauth = pendingReauthFlows.get(interceptKey)
   if (pendingReauth && looksLikeAuthCode(text)) {
     const elapsed = Date.now() - pendingReauth.startedAt
     if (elapsed < REAUTH_INTERCEPT_TTL_MS) {
-      pendingReauthFlows.delete(chat_id)
+      pendingReauthFlows.delete(interceptKey)
       const { result, errorText } = execAuthCode(pendingReauth.agent, text.trim())
       if (errorText) {
         await switchroomReply(ctx, `<b>auth code failed:</b>\n${preBlock(formatSwitchroomOutput(errorText))}`, { html: true })
@@ -8279,7 +8285,7 @@ async function handleInbound(
       redactAuthCodeMessage(bot.api as never, chat_id, msgId ?? null, line => process.stderr.write(line))
       return
     }
-    pendingReauthFlows.delete(chat_id)
+    pendingReauthFlows.delete(interceptKey)
   }
 
   // Vault intercept
@@ -11282,19 +11288,24 @@ bot.command("auth", async ctx => {
       )
       return
     }
+    // PR3 supergroup-mode: key auth-add flows by (chat, thread) so
+    // separate flows in two topics of one supergroup can't collide.
+    // In DM chats message_thread_id is undefined → key collapses to
+    // `chatId:_`, identical to today's behavior.
+    const authAddKey = chatKey(chatId, ctx.message?.message_thread_id ?? null) as string
     if (parsed.kind === 'cancel') {
-      const existing = pendingAuthAddFlows.get(chatId)
+      const existing = pendingAuthAddFlows.get(authAddKey)
       if (!existing) {
         await switchroomReply(ctx, "<i>No pending <code>/auth add</code> flow in this chat.</i>", { html: true })
         return
       }
       cancelAccountAuthSession(existing)
-      pendingAuthAddFlows.delete(chatId)
+      pendingAuthAddFlows.delete(authAddKey)
       await switchroomReply(ctx, "Cancelled.", { html: true })
       return
     }
     // parsed.kind === 'add'
-    if (pendingAuthAddFlows.has(chatId)) {
+    if (pendingAuthAddFlows.has(authAddKey)) {
       await switchroomReply(
         ctx,
         "<i>An <code>/auth add</code> flow is already in progress for this chat. " +
@@ -11305,7 +11316,7 @@ bot.command("auth", async ctx => {
     }
     try {
       const { loginUrl, scratchDir, child } = await startAccountAuthSession(parsed.label)
-      pendingAuthAddFlows.set(chatId, {
+      pendingAuthAddFlows.set(authAddKey, {
         label: parsed.label,
         scratchDir,
         child,
@@ -13069,7 +13080,14 @@ async function handleOperatorEventCallback(ctx: Context, data: string): Promise<
         parseMode: 'HTML',
         synthInbound: async () => {
           await runSwitchroomAuthCommand(ctx, ['auth', 'reauth', agent], `auth reauth ${agent}`)
-          pendingReauthFlows.set(String(ctx.chat!.id), { agent, startedAt: Date.now() })
+          // PR3 supergroup-mode: key by (chat, thread) so an OAuth code
+          // pasted into a different topic isn't mistakenly intercepted
+          // as this flow's reauth code.
+          const reauthThreadId = ctx.callbackQuery?.message?.message_thread_id
+          pendingReauthFlows.set(
+            chatKey(String(ctx.chat!.id), reauthThreadId ?? null) as string,
+            { agent, startedAt: Date.now() },
+          )
         },
       })
       return

--- a/telegram-plugin/tests/typing-wrap.test.ts
+++ b/telegram-plugin/tests/typing-wrap.test.ts
@@ -2,8 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTypingWrapper } from '../typing-wrap.js'
 
 function makeDeps(overrides: { isSurfaceTool?: (name: string) => boolean } = {}) {
-  const startTypingLoop = vi.fn<(chatId: string) => void>()
-  const stopTypingLoop = vi.fn<(chatId: string) => void>()
+  // PR3 supergroup-mode: start/stop now take (chatId, threadId?). The
+  // existing tests cover the chatId-only case (threadId omitted → null);
+  // new tests below pin the per-thread isolation.
+  const startTypingLoop = vi.fn<(chatId: string, threadId?: number | null) => void>()
+  const stopTypingLoop = vi.fn<(chatId: string, threadId?: number | null) => void>()
   const isSurfaceTool =
     overrides.isSurfaceTool ??
     ((name: string) =>
@@ -28,7 +31,7 @@ describe('createTypingWrapper', () => {
     w.onToolUse('t1', 'chat-A', 'Bash')
     // First tool on a fresh chat fires immediately — no timer wait required.
     expect(deps.startTypingLoop).toHaveBeenCalledTimes(1)
-    expect(deps.startTypingLoop).toHaveBeenCalledWith('chat-A')
+    expect(deps.startTypingLoop).toHaveBeenCalledWith('chat-A', null)
   })
 
   it('a parallel second tool on the same chat uses the debounce', () => {
@@ -69,7 +72,7 @@ describe('createTypingWrapper', () => {
     expect(deps.startTypingLoop).toHaveBeenCalledTimes(1)
     w.onToolResult('t1')
     expect(deps.stopTypingLoop).toHaveBeenCalledTimes(1)
-    expect(deps.stopTypingLoop).toHaveBeenCalledWith('chat-A')
+    expect(deps.stopTypingLoop).toHaveBeenCalledWith('chat-A', null)
   })
 
   it('skips surface tools (reply/stream_reply/edit_message/react)', () => {
@@ -93,16 +96,16 @@ describe('createTypingWrapper', () => {
     w.onToolUse('t1', 'chat-A', 'Bash')
     w.onToolUse('t2', 'chat-B', 'Grep')
     expect(deps.startTypingLoop).toHaveBeenCalledTimes(2)
-    expect(deps.startTypingLoop).toHaveBeenNthCalledWith(1, 'chat-A')
-    expect(deps.startTypingLoop).toHaveBeenNthCalledWith(2, 'chat-B')
+    expect(deps.startTypingLoop).toHaveBeenNthCalledWith(1, 'chat-A', null)
+    expect(deps.startTypingLoop).toHaveBeenNthCalledWith(2, 'chat-B', null)
 
     w.onToolResult('t1')
     expect(deps.stopTypingLoop).toHaveBeenCalledTimes(1)
-    expect(deps.stopTypingLoop).toHaveBeenLastCalledWith('chat-A')
+    expect(deps.stopTypingLoop).toHaveBeenLastCalledWith('chat-A', null)
 
     w.onToolResult('t2')
     expect(deps.stopTypingLoop).toHaveBeenCalledTimes(2)
-    expect(deps.stopTypingLoop).toHaveBeenLastCalledWith('chat-B')
+    expect(deps.stopTypingLoop).toHaveBeenLastCalledWith('chat-B', null)
   })
 
   it('drainAll clears pending entries and stops any started loops', () => {
@@ -137,5 +140,59 @@ describe('createTypingWrapper', () => {
     expect(deps.startTypingLoop).toHaveBeenCalledTimes(1)
     vi.advanceTimersByTime(2)
     expect(deps.startTypingLoop).toHaveBeenCalledTimes(2)
+  })
+
+  // ─── PR3 supergroup-mode: per-(chat,thread) lane isolation ────────────
+  it('SAME chat + DIFFERENT threads each get their own immediate-fire lane', () => {
+    const deps = makeDeps()
+    const w = createTypingWrapper(deps)
+    // Both are "first tool on lane" — both fire immediately, not debounced.
+    w.onToolUse('t1', 'chat-A', 'Bash', 17)
+    w.onToolUse('t2', 'chat-A', 'Read', 23)
+    expect(deps.startTypingLoop).toHaveBeenCalledTimes(2)
+    expect(deps.startTypingLoop).toHaveBeenNthCalledWith(1, 'chat-A', 17)
+    expect(deps.startTypingLoop).toHaveBeenNthCalledWith(2, 'chat-A', 23)
+  })
+
+  it('SAME chat + SAME thread STILL uses debounce on the second tool', () => {
+    const deps = makeDeps()
+    const w = createTypingWrapper(deps)
+    w.onToolUse('t1', 'chat-A', 'Bash', 17)
+    w.onToolUse('t2', 'chat-A', 'Read', 17)
+    expect(deps.startTypingLoop).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(500)
+    expect(deps.startTypingLoop).toHaveBeenCalledTimes(2)
+  })
+
+  it('stopping topic A does NOT clear topic B\'s lane (the headline bug fix)', () => {
+    // The bug: chatId-only keying meant `activeChats.delete(chatId)`
+    // when topic A's tool ended ALSO marked topic B's lane as inactive,
+    // so topic B's next tool would re-fire immediately (wrong — it's
+    // already typing) and a subsequent stop could mismatch.
+    // Per-(chat,thread) lane keying preserves independence.
+    const deps = makeDeps()
+    const w = createTypingWrapper(deps)
+    w.onToolUse('t1', 'chat-A', 'Bash', 17)   // topic A lane: active
+    w.onToolUse('t2', 'chat-A', 'Read', 23)   // topic B lane: active (independent)
+    expect(deps.startTypingLoop).toHaveBeenCalledTimes(2)
+
+    w.onToolResult('t1')  // topic A done
+    expect(deps.stopTypingLoop).toHaveBeenLastCalledWith('chat-A', 17)
+    // Topic B is still active — a third tool on topic B should DEBOUNCE
+    // (lane is still active), not fire immediately.
+    w.onToolUse('t3', 'chat-A', 'Edit', 23)
+    expect(deps.startTypingLoop).toHaveBeenCalledTimes(2)  // no immediate fire
+    vi.advanceTimersByTime(500)
+    expect(deps.startTypingLoop).toHaveBeenCalledTimes(3)
+    expect(deps.startTypingLoop).toHaveBeenLastCalledWith('chat-A', 23)
+  })
+
+  it('treats undefined / null threadId as the same lane (chatKey null/0 collapse)', () => {
+    const deps = makeDeps()
+    const w = createTypingWrapper(deps)
+    w.onToolUse('t1', 'chat-A', 'Bash')           // undefined thread
+    w.onToolUse('t2', 'chat-A', 'Read', null)     // null thread — same lane
+    expect(deps.startTypingLoop).toHaveBeenCalledTimes(1)  // only first fires immediately
+    expect(deps.startTypingLoop).toHaveBeenLastCalledWith('chat-A', null)
   })
 })

--- a/telegram-plugin/typing-wrap.ts
+++ b/telegram-plugin/typing-wrap.ts
@@ -1,26 +1,43 @@
 // Auto-wrap tool dispatch with a Telegram typing-indicator loop so the user
 // sees a live "agent is working" signal during the 3–30s gap where the
 // progress card is deliberately suppressed (its initialDelayMs is 3s).
-// The first tool call on a given chat fires the typing loop immediately so
-// there's no silent dead window before the progress card appears. Subsequent
-// calls on the same chat honour the debounce to avoid churn.
-// Surface tools own their own loop — see isSurfaceTool.
+// The first tool call on a given (chat, thread) fires the typing loop
+// immediately so there's no silent dead window before the progress card
+// appears. Subsequent calls on the same lane honour the debounce to avoid
+// churn. Surface tools own their own loop — see isSurfaceTool.
+//
+// Keying changed from `chatId` to `(chatId, threadId)` in PR3 of the
+// supergroup-mode rollout. In supergroup mode one agent owns many topics
+// in one chat; chatId-only keying made topic A's typing indicator die when
+// topic B's tool-call ended (last-stop-wins on a shared key). Per-thread
+// keying preserves independent typing loops across topics — matches the
+// per-(chat,thread) state model the rest of the gateway already uses.
+// Callers that don't yet carry a thread context pass `undefined` and
+// behave exactly as before (null thread collapses to `_` per chatKey()).
+
+import { chatKey } from './gateway/chat-key.js'
 
 export interface TypingWrapperDeps {
-  startTypingLoop: (chatId: string) => void
-  stopTypingLoop: (chatId: string) => void
+  startTypingLoop: (chatId: string, threadId?: number | null) => void
+  stopTypingLoop: (chatId: string, threadId?: number | null) => void
   isSurfaceTool: (toolName: string) => boolean
   debounceMs?: number
 }
 
 export interface TypingWrapper {
-  onToolUse: (toolUseId: string, chatId: string, toolName: string) => void
+  onToolUse: (
+    toolUseId: string,
+    chatId: string,
+    toolName: string,
+    threadId?: number | null,
+  ) => void
   onToolResult: (toolUseId: string) => void
   drainAll: () => void
 }
 
 interface Entry {
   chatId: string
+  threadId: number | null
   timer: ReturnType<typeof setTimeout>
   started: boolean
 }
@@ -28,29 +45,33 @@ interface Entry {
 export function createTypingWrapper(deps: TypingWrapperDeps): TypingWrapper {
   const debounceMs = deps.debounceMs ?? 500
   const pending = new Map<string, Entry>()
-  // Track chats that already have an active typing loop so the first
-  // tool call fires immediately while subsequent calls use the debounce.
-  const activeChats = new Set<string>()
+  // Track per-(chat,thread) lanes that already have an active typing loop
+  // so the first tool call on a lane fires immediately while subsequent
+  // calls on the same lane use the debounce.
+  const activeLanes = new Set<string>()
 
   return {
-    onToolUse(toolUseId, chatId, toolName) {
+    onToolUse(toolUseId, chatId, toolName, threadId) {
       if (!toolUseId) return
       if (deps.isSurfaceTool(toolName)) return
+      const tid = threadId ?? null
+      const lane = chatKey(chatId, tid) as string
       // Replace any pre-existing entry for the same id defensively.
       const prior = pending.get(toolUseId)
       if (prior) {
         clearTimeout(prior.timer)
-        if (prior.started) deps.stopTypingLoop(prior.chatId)
+        if (prior.started) deps.stopTypingLoop(prior.chatId, prior.threadId)
         pending.delete(toolUseId)
       }
-      // First tool on this chat: fire immediately rather than waiting for
+      // First tool on this lane: fire immediately rather than waiting for
       // the debounce — this closes the silent dead window before the first
       // progress card appears.
-      if (!activeChats.has(chatId)) {
-        deps.startTypingLoop(chatId)
-        activeChats.add(chatId)
+      if (!activeLanes.has(lane)) {
+        deps.startTypingLoop(chatId, tid)
+        activeLanes.add(lane)
         const entry: Entry = {
           chatId,
+          threadId: tid,
           started: true,
           timer: setTimeout(() => {}, 0), // no-op sentinel
         }
@@ -59,9 +80,10 @@ export function createTypingWrapper(deps: TypingWrapperDeps): TypingWrapper {
       }
       const entry: Entry = {
         chatId,
+        threadId: tid,
         started: false,
         timer: setTimeout(() => {
-          deps.startTypingLoop(chatId)
+          deps.startTypingLoop(chatId, tid)
           entry.started = true
         }, debounceMs),
       }
@@ -74,8 +96,8 @@ export function createTypingWrapper(deps: TypingWrapperDeps): TypingWrapper {
       if (!entry) return
       clearTimeout(entry.timer)
       if (entry.started) {
-        deps.stopTypingLoop(entry.chatId)
-        activeChats.delete(entry.chatId)
+        deps.stopTypingLoop(entry.chatId, entry.threadId)
+        activeLanes.delete(chatKey(entry.chatId, entry.threadId) as string)
       }
       pending.delete(toolUseId)
     },
@@ -83,10 +105,10 @@ export function createTypingWrapper(deps: TypingWrapperDeps): TypingWrapper {
     drainAll() {
       for (const entry of pending.values()) {
         clearTimeout(entry.timer)
-        if (entry.started) deps.stopTypingLoop(entry.chatId)
+        if (entry.started) deps.stopTypingLoop(entry.chatId, entry.threadId)
       }
       pending.clear()
-      activeChats.clear()
+      activeLanes.clear()
     },
   }
 }


### PR DESCRIPTION
PR3 of the supergroup-mode rollout. **All gateway-state surgery needed for the currentTurn architectural refactor that follows** — committed separately as PR3b so this one stays reviewable. RFC: [\`docs/rfcs/supergroup-mode.md\`](docs/rfcs/supergroup-mode.md).

## Summary

Two distinct re-keys, both moving chatId-keyed state to per-(chat,thread) keys. Same bug class: in supergroup mode one agent owns many topics in one chat; the old chatId-only keying caused cross-topic state collisions invisible in today's fleet model (where each agent has its own bot + own topic), but immediately user-felt the moment supergroup mode lands.

**Typing indicators** (commit 1):
- \`typingIntervals\` / \`turnTypingIntervals\` / \`typingRetryTimers\` re-keyed to \`chatKey(chat, thread)\`. Bug fixed: topic A's turn-end no longer kills topic B's in-flight typing loop.
- \`typing-wrap.ts\` \`activeChats\` → \`activeLanes\` (chatKey-keyed). Per-thread debounce vs first-fire decision is correct across lanes.
- \`sendChatAction\` now passes \`message_thread_id\` so Telegram renders the indicator in the right topic (was chat-root only before).
- \`onToolUse\` / \`startTypingLoop\` / \`stopTypingLoop\` / \`startTurnTypingLoop\` / \`stopTurnTypingLoop\` signatures gain optional \`threadId\` param. All gateway callsites updated to pass \`turn.sessionThreadId\` / \`messageThreadId\` / args-resolved thread.

**Pending auth-intercept maps** (commit 2):
- \`pendingAuthAddFlows\` + \`pendingReauthFlows\` re-keyed via \`chatKey()\`. Security bug fixed: an \`sk-ant-…\`-shaped paste in topic A could otherwise be intercepted as topic B's pending OAuth code → cross-topic credential mis-attribution.
- handleInbound, \`/auth\` command handler, and callback-button reauth-set all updated.

## Why

- **Typing**: typing indicator dying mid-turn when a sibling topic ends would be the first felt regression operators see. This must land before PR4 wires supergroup-mode emitters.
- **Auth intercept**: silent credential mis-attribution is a security concern, not just UX. Even if a user only types OAuth codes in DM today, hardening the key shape now prevents a class of bugs that would otherwise surface during PR3b's parallel-turns rollout.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] All 6 lint gates clean (\`check-plugin-references\`, \`check-bot-api-wrapping\`, \`check-no-pii-secrets\`, etc.)
- [x] 4 new \`typing-wrap.test.ts\` rows passing:
  - SAME chat + DIFFERENT thread → each gets own immediate-fire lane
  - SAME chat + SAME thread → still uses debounce
  - **Stopping topic A does NOT clear topic B's lane** (the headline bug)
  - undefined / null threadId → same lane (chatKey collapse)
- [x] All 8 existing typing-wrap tests updated to assert \`(chatId, null)\` signature where threadId wasn't previously passed — preserves backward-compat intent.
- [x] All 3,455 bun plugin tests green; no test changes for pending-intercept paths (exercised indirectly via reauth/add scenarios).

## Risk

- **Low.** Pure state-key refactor at well-tested seams. Backward-compat verified by chatKey collapse:
  - DM agents and fleet-shared agents pass undefined/null threadId → key collapses to \`chatId:_\` → behavior identical to today.
  - Bug fix matters only when one agent owns multiple topics in one chat (supergroup mode, not yet shipped).
- \`sendChatAction\` now passes \`message_thread_id\` opts — this means the typing indicator renders in the topic instead of chat-root. For fleet-mode agents in a single topic this is the same observable result; for DM agents \`message_thread_id\` is undefined so no opts → no change.

## Follow-ups

- **PR3b** (the architectural one): \`currentTurn\` singleton → \`Map<ChatKey, Turn>\` + per-topic \`activeTurnStartedAt\` gate. The load-bearing parallel-turns refactor. Will need a new \`jtbd-parallel-turns-supergroup\` UAT scenario plus 3× \`jtbd-fast-trivial-dm\` regression. Coming next session.
- **PR4**: wire \`resolveOutboundTopic()\` (from PR1) into emitters; General-topic strip-1 wrapper.
- **PR5+6+7**: slash-command smart split, hindsight memory tagging, topics discovery CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)