### PR TITLE
feat(gateway): strip message_thread_id=1 on send (General-topic quirk) (PR4a)

### DIFF
--- a/telegram-plugin/chat-lock.ts
+++ b/telegram-plugin/chat-lock.ts
@@ -24,6 +24,19 @@
  * key by `chat_id` alone via the canonical `chatKey(chat, null)`
  * collapse — same behavior as before for those callsites.
  *
+ * **General-topic strip (PR4a of supergroup-mode):** Telegram's General
+ * topic has `id=1` at the MTProto layer, but the Bot API's send-side
+ * REJECTS `message_thread_id=1` with HTTP 400 "message thread not
+ * found" (see tdlib/telegram-bot-api#447). The wrapper detects an
+ * incoming `message_thread_id: 1`, strips it from the options bag
+ * before the underlying API call, AND normalizes the lock key as if
+ * the thread were null — since semantically id=1 IS the chat root
+ * for the Bot API send-side, treating it as a distinct lane would
+ * mean two General-topic sends in the same chat would race past
+ * each other. (`editMessageText` etc. don't accept `message_thread_id`
+ * at all, so this only fires for sends like `sendMessage` and
+ * `sendChatAction`.)
+ *
  * Telegram's per-chat rate ceiling is still respected via grammY's
  * autoRetry transformer; if two topics in the same chat both burst
  * past the limit, grammY backs off per the Retry-After header — same
@@ -86,13 +99,27 @@ export function createChatLock(): ChatLock {
           // pins infer thread from message_id; they fall through with
           // `null` thread and serialize per-chat as before.
           const last = args[args.length - 1]
-          const threadFromOpts =
+          const lastIsOpts =
             last != null &&
             typeof last === 'object' &&
             !Array.isArray(last)
-              ? (last as Record<string, unknown>).message_thread_id
-              : undefined
-          const tid = typeof threadFromOpts === 'number' ? threadFromOpts : null
+          const threadFromOpts = lastIsOpts
+            ? (last as Record<string, unknown>).message_thread_id
+            : undefined
+          let tid = typeof threadFromOpts === 'number' ? threadFromOpts : null
+          // General-topic strip: id=1 is rejected by the Bot API on send.
+          // Strip from opts AND normalize the lock key as if thread were
+          // null (semantically id=1 IS chat-root for the send-side). See
+          // the file-header comment + RFC for the full rationale.
+          if (tid === 1) {
+            tid = null
+            // Rebuild args with a copy of opts that drops message_thread_id,
+            // so the underlying bot.api call won't receive the rejected
+            // value. Don't mutate the caller's opts object.
+            const cleanedOpts: Record<string, unknown> = { ...(last as Record<string, unknown>) }
+            delete cleanedOpts.message_thread_id
+            args = args.slice(0, -1).concat([cleanedOpts])
+          }
           return run(chatKey(chatId, tid), () =>
             (orig as (...a: unknown[]) => Promise<unknown>).apply(target, args),
           )

--- a/telegram-plugin/tests/outbound-ordering.test.ts
+++ b/telegram-plugin/tests/outbound-ordering.test.ts
@@ -277,6 +277,127 @@ describe('wrapBot — bot.api.* calls auto-lock by first-arg chat id', () => {
     expect(rA.message_id).toBe(1)
   })
 
+  it('strips message_thread_id=1 from sendMessage opts (General-topic Bot API quirk)', async () => {
+    // Telegram's General topic has id=1 at MTProto but the Bot API
+    // REJECTS message_thread_id=1 on send with HTTP 400 "message thread
+    // not found" (tdlib/telegram-bot-api#447). The wrapper strips id=1
+    // from the opts bag before the underlying API call.
+    const lock = createChatLock()
+    const bot = createMockBot()
+    const wrapped = lock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+
+    bot.api.sendMessage.mockImplementationOnce(async () => ({ message_id: 1 }))
+
+    await wrapped.api.sendMessage('supergrp', 'hello General', { message_thread_id: 1 })
+
+    const callOpts = bot.api.sendMessage.mock.calls[0]![2]
+    expect(callOpts).toBeDefined()
+    expect((callOpts as Record<string, unknown>).message_thread_id).toBeUndefined()
+  })
+
+  it('preserves other opts when stripping message_thread_id=1', async () => {
+    const lock = createChatLock()
+    const bot = createMockBot()
+    const wrapped = lock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+    bot.api.sendMessage.mockImplementationOnce(async () => ({ message_id: 1 }))
+
+    await wrapped.api.sendMessage('supergrp', 'hello', {
+      message_thread_id: 1,
+      parse_mode: 'HTML',
+      reply_to_message_id: 42,
+    })
+
+    const callOpts = bot.api.sendMessage.mock.calls[0]![2] as Record<string, unknown>
+    expect(callOpts.message_thread_id).toBeUndefined()
+    expect(callOpts.parse_mode).toBe('HTML')
+    expect(callOpts.reply_to_message_id).toBe(42)
+  })
+
+  it('does NOT mutate the caller\'s opts object (strip uses a copy)', async () => {
+    const lock = createChatLock()
+    const bot = createMockBot()
+    const wrapped = lock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+    bot.api.sendMessage.mockImplementationOnce(async () => ({ message_id: 1 }))
+
+    const callerOpts = { message_thread_id: 1, parse_mode: 'HTML' as const }
+    await wrapped.api.sendMessage('supergrp', 'hello', callerOpts)
+
+    expect(callerOpts.message_thread_id).toBe(1)  // caller's object untouched
+  })
+
+  it('does NOT strip non-1 thread IDs', async () => {
+    const lock = createChatLock()
+    const bot = createMockBot()
+    const wrapped = lock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+    bot.api.sendMessage.mockImplementationOnce(async () => ({ message_id: 1 }))
+
+    await wrapped.api.sendMessage('supergrp', 'planning msg', { message_thread_id: 17 })
+
+    const callOpts = bot.api.sendMessage.mock.calls[0]![2] as Record<string, unknown>
+    expect(callOpts.message_thread_id).toBe(17)  // non-General threads untouched
+  })
+
+  it('two SAME-chat General-topic sends still serialize (id=1 normalized to chat-root lane)', async () => {
+    // After stripping id=1, the lock key normalizes to chatKey(chatId, null)
+    // = `chatId:_`. Two General-topic sends queue through the same
+    // chat-root lane preserving order (Telegram per-chat order matters).
+    const lock = createChatLock()
+    const bot = createMockBot()
+    const wrapped = lock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+
+    const dSlow = deferred<{ message_id: number }>()
+    const order: string[] = []
+    bot.api.sendMessage.mockImplementationOnce(async (_c: string, t: string) => {
+      order.push(`first:${t}`)
+      const r = await dSlow.promise
+      order.push(`first:end:${t}`)
+      return r
+    })
+    bot.api.sendMessage.mockImplementationOnce(async (_c: string, t: string) => {
+      order.push(`second:${t}`)
+      return { message_id: 2 }
+    })
+
+    const p1 = wrapped.api.sendMessage('supergrp', 'general msg 1', { message_thread_id: 1 })
+    const p2 = wrapped.api.sendMessage('supergrp', 'general msg 2', { message_thread_id: 1 })
+
+    await Promise.resolve(); await Promise.resolve()
+    expect(order).toEqual(['first:general msg 1'])  // second waits
+
+    dSlow.resolve({ message_id: 1 })
+    await Promise.all([p1, p2])
+    expect(order).toEqual(['first:general msg 1', 'first:end:general msg 1', 'second:general msg 2'])
+  })
+
+  it('General-topic strip does NOT serialize against non-General sends in the same chat', async () => {
+    // id=1 → chat-root lane. id=17 → its own lane. Independent dispatch.
+    const lock = createChatLock()
+    const bot = createMockBot()
+    const wrapped = lock.wrapBot({ api: bot.api as unknown as Record<string, unknown> }) as unknown as typeof bot
+
+    const dGeneral = deferred<{ message_id: number }>()
+    const dPlanning = deferred<{ message_id: number }>()
+    const started: string[] = []
+    bot.api.sendMessage.mockImplementationOnce(async () => {
+      started.push('general')
+      return dGeneral.promise
+    })
+    bot.api.sendMessage.mockImplementationOnce(async () => {
+      started.push('planning')
+      return dPlanning.promise
+    })
+
+    const pGeneral = wrapped.api.sendMessage('supergrp', 'g', { message_thread_id: 1 })
+    const pPlanning = wrapped.api.sendMessage('supergrp', 'p', { message_thread_id: 17 })
+
+    await Promise.resolve(); await Promise.resolve()
+    expect(started).toEqual(['general', 'planning'])  // both started concurrently
+
+    dPlanning.resolve({ message_id: 17 })
+    dGeneral.resolve({ message_id: 1 })
+    await Promise.all([pGeneral, pPlanning])
+  })
+
   it('react (setMessageReaction) queues behind an in-flight reply (sendMessage) to the same chat', async () => {
     const lock = createChatLock()
     const bot = createMockBot()


### PR DESCRIPTION
PR4a of supergroup-mode rollout. Tiny, focused, independent of PR3b (the architectural \`currentTurn\` refactor). Addresses a real Telegram Bot API quirk that would otherwise crash supergroup-mode replies to General.

## Summary

Telegram's General topic has \`id=1\` at the MTProto layer but the Bot API REJECTS \`message_thread_id=1\` on \`sendMessage\` / \`sendChatAction\` / sibling sends with HTTP 400 \"message thread not found\" (see [tdlib/telegram-bot-api#447](https://github.com/tdlib/telegram-bot-api/issues/447)). Inbound updates from General correctly carry \`message_thread_id=1\`, so the naive \"echo thread back on reply\" pattern fails.

Fix at the \`chatLock.wrapBot\` Proxy chokepoint (single layer, not the ~150 send-site callsites):
- If the options bag has \`message_thread_id === 1\`, strip it from a COPY of opts (don't mutate caller's object).
- Normalize the lock key to \`chatKey(chatId, null)\` so semantically-chat-root sends share one lane (Telegram per-chat ordering still matters within General).

\`editMessageText\` / \`editMessageReplyMarkup\` / \`setMessageReaction\` don't take \`message_thread_id\` at all (Telegram infers thread from message_id), so they're naturally unaffected.

## Why

Without this, the first reply to a General-topic message in a supergroup-mode agent fails. Every fleet rollout post-supergroup needs this to work. Shipping ahead of PR4 (full emitter rewiring) so the strip is in place when emitters start producing General-targeted outbounds.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] All 6 lint gates clean
- [x] 6 new \`outbound-ordering.test.ts\` rows passing:
  - id=1 stripped from sendMessage opts
  - Other opts preserved (parse_mode, reply_to_message_id) when stripping
  - Caller's opts object NOT mutated (defensive copy)
  - Non-1 thread IDs untouched (id=17 passes through unchanged)
  - Two id=1 sends to same chat still serialize (chat-root lane)
  - id=1 send + id=17 send to same chat dispatch concurrently (no artificial cross-topic serialization)
- [x] All 3,462 bun plugin tests green

## Risk

- **Very low.** Surgical change at a single Proxy chokepoint. Existing chat-lock tests still pass (no behavior change for non-id=1 callers). The strip only fires when a caller explicitly passes \`message_thread_id: 1\` — today no callsite does this intentionally (fleet agents in named topics pass their \`topic_id\`, DMs pass nothing).
- The lock-key normalization (id=1 → chat-root lane) is correct per Telegram's semantics: id=1 IS the chat-root for the send-side. Treating it as a distinct lane would let two General-topic sends race past each other, which Telegram's per-chat ordering forbids.

## Sources

- [core.telegram.org/api/forum](https://core.telegram.org/api/forum) — \"Every forum has a non-deletable 'General' topic, with id=1\"
- [tdlib/telegram-bot-api#447](https://github.com/tdlib/telegram-bot-api/issues/447) — canonical reproduction
- Bot API changelog 6.3 + 6.4 (forum support introduction)

## Follow-ups

- **PR3b**: \`currentTurn\` singleton → \`Map<ChatKey, Turn>\` + per-topic gate (the load-bearing architectural piece).
- **PR4b**: wire \`resolveOutboundTopic()\` into emitters (boot/vault/hostd/cron/compact/watchdog).
- **PR5/6/7**: slash-command smart split, hindsight memory tagging, topics discovery CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)