### PR TITLE
feat(cli): switchroom telegram topics <chat_id> — discover forum thread IDs (PR7)

### DIFF
--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -13,6 +13,7 @@
 import type { Command } from "commander";
 import chalk from "chalk";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   matchesRule,
   buildGithubContext,
@@ -25,12 +26,17 @@ import { resolvePath, loadConfig } from "../config/loader.js";
 import { createVault, setStringSecret } from "../vault/vault.js";
 import { getConfig, getConfigPath, withConfigError } from "./helpers.js";
 import { resolveAgentConfig } from "../config/merge.js";
+import { resolveStatePath } from "../config/paths.js";
 import {
   setTelegramFeature,
   removeTelegramFeature,
   addWebhookSource,
   removeWebhookSource,
 } from "./telegram-yaml.js";
+import {
+  formatTopicsTable,
+  type TopicRow,
+} from "../telegram/topics-discover.js";
 
 export function registerTelegramCommand(program: Command): void {
   const tg = program
@@ -43,6 +49,172 @@ export function registerTelegramCommand(program: Command): void {
   registerEnableVerb(tg, program);
   registerDisableVerb(tg, program);
   registerDispatchVerb(tg, program);
+  registerTopicsVerb(tg, program);
+}
+
+// ─── topics (PR7 of supergroup-mode) ────────────────────────────────────────
+
+/**
+ * `switchroom telegram topics <chat_id>` — discover which forum topic IDs
+ * the agent has observed inbound messages from in a given chat. Reads the
+ * local SQLite history buffer (`<agentDir>/telegram/history.db`).
+ *
+ * Onboarding ergonomics for supergroup-mode (docs/rfcs/supergroup-mode.md):
+ * after enabling a forum supergroup, the operator sends one message in
+ * each topic, runs this command, and gets back the numeric thread IDs to
+ * paste under `channels.telegram.topic_aliases`. The command also prints
+ * a copy-paste-ready YAML snippet for the aliases block.
+ */
+function registerTopicsVerb(tg: Command, program: Command): void {
+  tg.command("topics <chat_id>")
+    .description(
+      "Discover forum topic IDs seen in <chat_id> by reading the agent's local SQLite history buffer. Useful for naming aliases when configuring supergroup-mode (channels.telegram.topic_aliases).",
+    )
+    .option("--agent <name>", "Read history from this agent's state dir (required if multiple agents)")
+    .option("--limit <n>", "Max distinct topics to show", "50")
+    .action(
+      withConfigError(async (chatId: string, opts: TopicsDiscoverOpts) => {
+        await runTopicsDiscover(program, chatId, opts);
+      }),
+    );
+}
+
+interface TopicsDiscoverOpts {
+  agent?: string;
+  limit?: string;
+}
+
+async function runTopicsDiscover(
+  program: Command,
+  chatId: string,
+  opts: TopicsDiscoverOpts,
+): Promise<void> {
+  const config = getConfig(program);
+  const agents = Object.keys(config.agents);
+
+  // Resolve agent. With one agent in the config, default to it; otherwise
+  // require --agent so the operator doesn't accidentally read the wrong
+  // history.
+  let agentName = opts.agent;
+  if (!agentName) {
+    if (agents.length === 1) {
+      agentName = agents[0];
+    } else if (agents.length === 0) {
+      fail("No agents in switchroom.yaml. Add at least one to use this command.");
+    } else {
+      fail(
+        `Multiple agents in switchroom.yaml — pass --agent <name> to choose.\n` +
+          `  Options: ${agents.join(", ")}`,
+      );
+    }
+  }
+  if (!config.agents[agentName!]) {
+    fail(`Unknown agent '${agentName}'. Check switchroom.yaml.`);
+  }
+
+  const agentsDir = process.env.SWITCHROOM_AGENTS_DIR ?? resolveStatePath("agents");
+  const dbPath = join(agentsDir, agentName!, "telegram", "history.db");
+  if (!existsSync(dbPath)) {
+    fail(
+      `No history DB at ${dbPath}.\n` +
+        `  The agent may not have received any Telegram messages yet, or it may be offline.\n` +
+        `  Tip: send one message in each topic of the supergroup, then re-run this command.`,
+    );
+  }
+
+  const limit = Number(opts.limit ?? "50");
+  if (!Number.isFinite(limit) || limit <= 0) {
+    fail(`--limit must be a positive integer (got ${opts.limit})`);
+  }
+
+  const rows = readTopicsFromHistory(dbPath, chatId, Math.floor(limit));
+
+  if (rows.length === 0) {
+    console.log(
+      chalk.yellow(
+        `No messages found for chat ${chatId} in agent '${agentName}'s history.\n` +
+          `  Send one message in each topic, then re-run.`,
+      ),
+    );
+    return;
+  }
+
+  console.log(formatTopicsTable(rows, chatId, agentName!));
+}
+
+/**
+ * Read distinct (thread_id, first_message) tuples from the local
+ * SQLite history buffer for the given chat. Bun-only — uses
+ * `import.meta.require('bun:sqlite')` to dodge the vitest test loader
+ * (same pattern as `telegram-plugin/history.ts`).
+ */
+function readTopicsFromHistory(
+  dbPath: string,
+  chatId: string,
+  limit: number,
+): TopicRow[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const metaRequire = (import.meta as any).require;
+  if (typeof metaRequire !== "function") {
+    fail(
+      "`switchroom telegram topics` requires the Bun runtime (history DB uses bun:sqlite). " +
+        "Run via `bun run dev` or via the installed `switchroom` CLI (bun-bundled).",
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { Database } = metaRequire("bun:sqlite") as { Database: new (path: string, opts?: { create?: boolean }) => any };
+  const db = new Database(dbPath, { create: false });
+  try {
+    // Per-topic aggregate: msg count, first/last seen, plus the FIRST
+    // message text (joined via a correlated subquery so we don't fire
+    // an extra query per row).
+    const aggregateRows = db
+      .prepare(
+        `
+        SELECT
+          thread_id,
+          COUNT(*) AS msg_count,
+          MIN(ts) AS first_ts,
+          MAX(ts) AS last_ts
+        FROM messages
+        WHERE chat_id = ?
+        GROUP BY thread_id
+        ORDER BY first_ts ASC
+        LIMIT ?
+        `,
+      )
+      .all(chatId, limit) as Array<{
+      thread_id: number | null;
+      msg_count: number;
+      first_ts: number;
+      last_ts: number;
+    }>;
+
+    // Fetch the first-message text per (chat, thread, ts). SQLite's
+    // `thread_id IS NULL` distinguishes the null row from numeric ids.
+    const firstStmt = db.prepare(
+      `SELECT text, role FROM messages
+       WHERE chat_id = ? AND ts = ?
+       AND (thread_id IS NULL AND ? IS NULL OR thread_id = ?)
+       ORDER BY message_id ASC LIMIT 1`,
+    );
+
+    return aggregateRows.map((r) => {
+      const first = firstStmt.get(chatId, r.first_ts, r.thread_id, r.thread_id) as
+        | { text: string; role: string }
+        | undefined;
+      return {
+        thread_id: r.thread_id,
+        msg_count: r.msg_count,
+        first_ts: r.first_ts,
+        last_ts: r.last_ts,
+        first_text: first?.text ?? null,
+        first_role: first?.role ?? null,
+      };
+    });
+  } finally {
+    db.close();
+  }
 }
 
 // ─── status ──────────────────────────────────────────────────────────────────

--- a/src/telegram/topics-discover.test.ts
+++ b/src/telegram/topics-discover.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for the pure formatter half of `switchroom telegram topics`.
+ *
+ * The SQLite-fetching half lives in src/cli/telegram.ts and requires
+ * bun:sqlite — exercised by integration / smoke tests run under bun,
+ * not here. These vitest specs cover the formatter, the truncate
+ * helper, and the relative-time formatter.
+ */
+
+import { describe, expect, it } from "vitest";
+import { formatTopicsTable, truncate, formatAgo, type TopicRow } from "./topics-discover.js";
+
+// Strip ANSI color codes — chalk is enabled in tests, but assertions
+// are easier to write against plain strings.
+function plain(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+describe("truncate", () => {
+  it("returns short strings unchanged", () => {
+    expect(truncate("hi", 60)).toBe("hi");
+  });
+
+  it("appends an ellipsis past max length", () => {
+    const long = "x".repeat(100);
+    const out = truncate(long, 60);
+    expect(out).toHaveLength(60);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("collapses newlines to single spaces", () => {
+    expect(truncate("hello\nworld\n\nfoo", 60)).toBe("hello world foo");
+  });
+
+  it("trims leading/trailing whitespace before truncating", () => {
+    expect(truncate("   hello   ", 60)).toBe("hello");
+  });
+});
+
+describe("formatAgo", () => {
+  const NOW = 1_700_000_000;
+
+  it("renders 'just now' for <60s", () => {
+    expect(formatAgo(NOW - 30, NOW)).toBe("just now");
+    expect(formatAgo(NOW - 59, NOW)).toBe("just now");
+  });
+
+  it("renders minutes for <60m", () => {
+    expect(formatAgo(NOW - 90, NOW)).toBe("1m ago");
+    expect(formatAgo(NOW - 1800, NOW)).toBe("30m ago");
+  });
+
+  it("renders hours for <24h", () => {
+    expect(formatAgo(NOW - 3600, NOW)).toBe("1h ago");
+    expect(formatAgo(NOW - 12 * 3600, NOW)).toBe("12h ago");
+  });
+
+  it("renders days for <30d", () => {
+    expect(formatAgo(NOW - 86400, NOW)).toBe("1d ago");
+    expect(formatAgo(NOW - 7 * 86400, NOW)).toBe("7d ago");
+  });
+
+  it("renders an ISO date past 30 days", () => {
+    const old = NOW - 60 * 86400;
+    const out = formatAgo(old, NOW);
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("clamps negative deltas (future ts) to 'just now'", () => {
+    expect(formatAgo(NOW + 100, NOW)).toBe("just now");
+  });
+});
+
+describe("formatTopicsTable", () => {
+  const ROW_BASE = {
+    msg_count: 5,
+    first_ts: Math.floor(Date.now() / 1000) - 3600,
+    last_ts: Math.floor(Date.now() / 1000),
+    first_role: "user",
+  };
+
+  it("renders a row per topic with thread_id, msg count, and preview", () => {
+    const rows: TopicRow[] = [
+      { ...ROW_BASE, thread_id: 17, first_text: "hi from planning" },
+      { ...ROW_BASE, thread_id: 23, first_text: "cron digest goes here" },
+    ];
+    const out = plain(formatTopicsTable(rows, "-1001234567890", "klanker"));
+    expect(out).toContain("Topics observed in chat -1001234567890");
+    expect(out).toContain("(agent: klanker)");
+    expect(out).toContain("17");
+    expect(out).toContain("23");
+    expect(out).toContain("hi from planning");
+    expect(out).toContain("cron digest goes here");
+    expect(out).toContain("user:");
+  });
+
+  it("flags thread_id=1 as General (the Bot-API quirk reminder)", () => {
+    const rows: TopicRow[] = [
+      { ...ROW_BASE, thread_id: 1, first_text: "hello general" },
+    ];
+    const out = plain(formatTopicsTable(rows, "-1001234567890", "klanker"));
+    expect(out).toContain("(General)");
+  });
+
+  it("renders chat-root rows distinctly (thread_id=null)", () => {
+    const rows: TopicRow[] = [
+      { ...ROW_BASE, thread_id: null, first_text: "DM message" },
+    ];
+    const out = plain(formatTopicsTable(rows, "12345", "carrie"));
+    expect(out).toContain("chat-root");
+  });
+
+  it("emits a copy-paste topic_aliases YAML snippet for numeric threads", () => {
+    const rows: TopicRow[] = [
+      { ...ROW_BASE, thread_id: 17, first_text: "x" },
+      { ...ROW_BASE, thread_id: 23, first_text: "y" },
+    ];
+    const out = plain(formatTopicsTable(rows, "-1001234567890", "klanker"));
+    expect(out).toContain("topic_aliases:");
+    expect(out).toContain("topic_17: 17");
+    expect(out).toContain("topic_23: 23");
+  });
+
+  it("aliases General as 'general' in the YAML snippet", () => {
+    const rows: TopicRow[] = [
+      { ...ROW_BASE, thread_id: 1, first_text: "x" },
+    ];
+    const out = plain(formatTopicsTable(rows, "-1001234567890", "klanker"));
+    expect(out).toContain("general: 1");
+  });
+
+  it("omits chat-root rows from the YAML snippet (can't alias chat-root)", () => {
+    const rows: TopicRow[] = [
+      { ...ROW_BASE, thread_id: null, first_text: "x" },
+      { ...ROW_BASE, thread_id: 17, first_text: "y" },
+    ];
+    const out = plain(formatTopicsTable(rows, "-1001234567890", "klanker"));
+    expect(out).toContain("topic_17: 17");
+    // chat-root shouldn't appear as an alias entry
+    expect(out).not.toMatch(/^\s*chat-root:/m);
+  });
+
+  it("skips the snippet entirely when no numeric threads observed", () => {
+    const rows: TopicRow[] = [
+      { ...ROW_BASE, thread_id: null, first_text: "x" },
+    ];
+    const out = plain(formatTopicsTable(rows, "12345", "carrie"));
+    expect(out).not.toContain("topic_aliases:");
+  });
+
+  it("renders '(no message)' when first_text is null", () => {
+    const rows: TopicRow[] = [
+      { ...ROW_BASE, thread_id: 17, first_text: null, first_role: null },
+    ];
+    const out = plain(formatTopicsTable(rows, "-1001234567890", "klanker"));
+    expect(out).toContain("(no message)");
+  });
+
+  it("singularizes 'msg' for count=1", () => {
+    const rows: TopicRow[] = [
+      { ...ROW_BASE, msg_count: 1, thread_id: 17, first_text: "x" },
+      { ...ROW_BASE, msg_count: 2, thread_id: 18, first_text: "y" },
+    ];
+    const out = plain(formatTopicsTable(rows, "-1001234567890", "klanker"));
+    expect(out).toContain("1 msg,");
+    expect(out).toContain("2 msgs,");
+  });
+});

--- a/src/telegram/topics-discover.ts
+++ b/src/telegram/topics-discover.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure formatter for `switchroom telegram topics <chat_id>` output.
+ *
+ * The DB-fetching half lives in `src/cli/telegram.ts` because it needs
+ * `bun:sqlite` (runtime-bound) and can't be exercised from vitest. This
+ * module is pure-data-in, string-out so the formatting is unit-testable.
+ *
+ * Part of PR7 of the supergroup-mode rollout (docs/rfcs/supergroup-mode.md).
+ */
+
+import chalk from "chalk";
+
+export interface TopicRow {
+  /** Telegram thread ID; `null` means chat-root (no forum thread). */
+  thread_id: number | null;
+  /** Count of messages observed in this (chat, thread). */
+  msg_count: number;
+  /** Earliest message timestamp (epoch seconds). */
+  first_ts: number;
+  /** Latest message timestamp (epoch seconds). */
+  last_ts: number;
+  /** Text of the FIRST observed message in this thread (truncated by caller). */
+  first_text: string | null;
+  /** Role of the first message ('user' / 'assistant') for context. */
+  first_role: string | null;
+}
+
+const PREVIEW_MAX = 60;
+
+/**
+ * Render the discovery output as a multi-line string. Caller prints it.
+ *
+ * Sections:
+ *   - One block per observed topic: thread ID + msg count + first-seen
+ *     age + first-message preview.
+ *   - A copy-paste-ready `topic_aliases:` snippet at the end.
+ *
+ * The General-topic note (`thread_id === 1`) is flagged inline because
+ * id=1 is the Telegram General topic at MTProto but the Bot API rejects
+ * it on send (see chat-lock.ts strip-1 logic) — operators benefit from
+ * the reminder when choosing whether to alias it.
+ */
+export function formatTopicsTable(
+  rows: TopicRow[],
+  chatId: string,
+  agentName: string,
+): string {
+  const lines: string[] = [];
+  lines.push(
+    chalk.bold(`Topics observed in chat ${chatId}`) +
+      chalk.gray(` (agent: ${agentName})`),
+  );
+  lines.push("");
+
+  for (const row of rows) {
+    const threadLabel =
+      row.thread_id == null
+        ? chalk.bold("chat-root")
+        : chalk.bold(String(row.thread_id));
+    const generalNote = row.thread_id === 1 ? chalk.yellow(" (General)") : "";
+    const firstAgo = formatAgo(row.first_ts);
+    const meta = chalk.gray(
+      `(${row.msg_count} msg${row.msg_count === 1 ? "" : "s"}, first seen ${firstAgo})`,
+    );
+    lines.push(`  ${threadLabel}${generalNote}  ${meta}`);
+
+    const preview = row.first_text ? truncate(row.first_text, PREVIEW_MAX) : "(no message)";
+    const role = row.first_role ?? "?";
+    lines.push(`    ${chalk.dim(`${role}: ${preview}`)}`);
+  }
+
+  // Copy-paste-ready YAML snippet for the operator. Only includes
+  // numeric thread_ids (chat-root isn't a forum topic — can't alias).
+  const aliasable = rows.filter((r) => r.thread_id != null);
+  if (aliasable.length > 0) {
+    lines.push("");
+    lines.push(chalk.dim("To use in switchroom.yaml under channels.telegram.topic_aliases:"));
+    lines.push(chalk.dim("  topic_aliases:"));
+    for (const row of aliasable) {
+      const placeholder =
+        row.thread_id === 1
+          ? "general"
+          : `topic_${row.thread_id}`;
+      lines.push(chalk.dim(`    ${placeholder}: ${row.thread_id}`));
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Truncate a string to `max` chars, appending `…` if cut. Collapses
+ * embedded newlines to spaces so the preview stays single-line.
+ */
+export function truncate(s: string, max: number): string {
+  const oneLine = s.replace(/\s+/g, " ").trim();
+  if (oneLine.length <= max) return oneLine;
+  return oneLine.slice(0, max - 1) + "…";
+}
+
+/**
+ * Render an epoch-seconds timestamp as a human "age" string.
+ * - <60s: "just now"
+ * - <60m: "Nm ago"
+ * - <24h: "Nh ago"
+ * - <30d: "Nd ago"
+ * - otherwise: ISO date
+ *
+ * Pure (takes the current time as `now`) so tests can fix the clock.
+ */
+export function formatAgo(ts: number, now: number = Math.floor(Date.now() / 1000)): string {
+  const delta = Math.max(0, now - ts);
+  if (delta < 60) return "just now";
+  if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
+  if (delta < 86400) return `${Math.floor(delta / 3600)}h ago`;
+  if (delta < 86400 * 30) return `${Math.floor(delta / 86400)}d ago`;
+  return new Date(ts * 1000).toISOString().slice(0, 10);
+}


### PR DESCRIPTION
PR7 of the supergroup-mode rollout. Small operator-ergonomics verb that closes the discovery loop for supergroup-mode onboarding.

## Summary

After enabling a forum supergroup and sending one message in each topic, the operator runs:

\`\`\`
switchroom telegram topics -1001234567890 --agent klanker
\`\`\`

…to read the agent's local SQLite history buffer (\`<agentDir>/telegram/history.db\`) and surface the numeric thread IDs needed for \`channels.telegram.topic_aliases\` (the schema added in PR1 #1868).

Output:

\`\`\`
Topics observed in chat -1001234567890 (agent: klanker)

  1 (General)  (3 msgs, first seen 2h ago)
    user: hi from general
  17  (8 msgs, first seen 1h ago)
    user: planning kickoff
  23  (1 msg, first seen 12m ago)
    user: cron output goes here

To use in switchroom.yaml under channels.telegram.topic_aliases:
  topic_aliases:
    general: 1
    topic_17: 17
    topic_23: 23
\`\`\`

The General-topic note (\`thread_id === 1\`) is flagged inline because id=1 is the Bot-API quirk handled in PR4a (#1871) — the YAML snippet auto-suggests \`general\` as the alias name there.

## Split

- \`src/cli/telegram.ts\` — verb registration + the SQLite-fetching half (bun:sqlite via \`import.meta.require\`, same pattern as \`telegram-plugin/history.ts\` to dodge the vitest loader).
- \`src/telegram/topics-discover.ts\` — pure formatter + helpers (\`formatTopicsTable\`, \`truncate\`, \`formatAgo\`). Unit-testable from vitest.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] All 6 lint gates clean
- [x] 19 new \`topics-discover.test.ts\` rows passing:
  - \`truncate\` (4): passthrough / ellipsis / newline collapse / trim
  - \`formatAgo\` (6): under-60s / minutes / hours / days / >30d ISO / negative-delta clamp
  - \`formatTopicsTable\` (9): row rendering / General flag / chat-root / YAML snippet emission + omission cases / msg-vs-msgs / null first_text
- [x] 793 tests across \`src/cli/\`, \`src/telegram/\`, \`src/config/\` all green

## Risk

- **Very low.** Pure new verb, no existing behavior touched.
- Bun-runtime gate fails fast with a clear error if invoked from plain node (\`switchroom telegram topics requires the Bun runtime...\`) so it can't silently misbehave.
- Read-only access to the SQLite DB; \`{ create: false }\` ensures we don't accidentally create an empty DB on a typo.

## Follow-ups

- **PR3b**: \`currentTurn\` singleton → \`Map<ChatKey, Turn>\` + per-topic gate (the load-bearing architectural piece).
- **PR4b**: wire \`resolveOutboundTopic()\` (from PR1) into emitters (boot card, vault/permission cards, hostd, cron, compact, watchdog).
- **PR5**: slash-command smart split per CPO #4.
- **PR6**: Hindsight memory topic-metadata tagging per CPO #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)