### PR TITLE
feat(gateway): route boot card via resolveOutboundTopic in supergroup mode (PR4b-boot)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -244,6 +244,7 @@ import { handleInjectCommand } from './inject-handler.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
 import { loadConfig as loadSwitchroomConfig } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
+import { resolveOutboundTopic as resolveOutboundTopicHelper, type TopicRouterConfig as _OutboundRouterConfig } from '../../src/telegram/topic-router.js'
 import { readTurnUsages } from '../../src/agents/perf.js'
 import { decideProactiveCompact, initialCompactState, type CompactState } from './proactive-compact.js'
 import { nextCompactNotify, idleCompactNotifyState, type CompactNotifyState } from './compact-notify.js'
@@ -9240,7 +9241,10 @@ function resolveBootChatId(
   marker: { chat_id: string; thread_id: number | null; ack_message_id: number | null; ts: number } | null,
   ageMs?: number,
 ): { chatId: string; threadId: number | undefined; ackMsgId: number | undefined } | null {
-  // 1. Restart marker
+  // 1. Restart marker — operator-initiated; honor where they typed
+  //    /restart. The marker carries the exact chat+thread context; no
+  //    routing override because the user expects to see the boot card
+  //    in the same lane where they invoked the restart.
   if (marker != null && (ageMs == null || ageMs < 5 * 60_000)) {
     return {
       chatId: marker.chat_id,
@@ -9248,9 +9252,19 @@ function resolveBootChatId(
       ackMsgId: marker.ack_message_id ?? undefined,
     }
   }
+
+  // For non-marker paths (spontaneous boot, crash recovery, env var,
+  // history fallback): supergroup-mode agents route the boot card to
+  // the `alerts` alias topic (or default_topic_id fallback) so the
+  // operator sees lifecycle events in a predictable lane instead of
+  // chat-root. For fleet-mode / DM agents the helper returns undefined
+  // → behavior unchanged (lands at chat-root as today). PR4b of
+  // supergroup-mode rollout (docs/rfcs/supergroup-mode.md).
+  const supergroupBootTopic = resolveBootCardTopic()
+
   // 2. Env var
   const envChat = process.env.SUBAGENT_OWNER_CHAT_ID
-  if (envChat) return { chatId: envChat, threadId: undefined, ackMsgId: undefined }
+  if (envChat) return { chatId: envChat, threadId: supergroupBootTopic, ackMsgId: undefined }
   // 3. Most-recent inbound from history
   if (HISTORY_ENABLED) {
     try {
@@ -9258,12 +9272,42 @@ function resolveBootChatId(
       const ownerChatId = access.allowFrom[0]
       if (ownerChatId) {
         const recent = queryHistory({ chat_id: ownerChatId, limit: 1 })
-        if (recent.length > 0) return { chatId: ownerChatId, threadId: undefined, ackMsgId: undefined }
+        if (recent.length > 0) return { chatId: ownerChatId, threadId: supergroupBootTopic, ackMsgId: undefined }
       }
     } catch {}
   }
   // 4. No known chat
   return null
+}
+
+/**
+ * Resolve the supergroup-mode topic for a boot-card outbound, or
+ * undefined when the agent isn't in supergroup-owned mode. Best-effort
+ * — any config-read failure returns undefined and we fall through to
+ * today's chat-root behavior. Called only at boot/reconnect (not per
+ * turn), so the cost of a fresh config-read is acceptable.
+ */
+function resolveBootCardTopic(): number | undefined {
+  const agentName = process.env.SWITCHROOM_AGENT_NAME
+  if (!agentName) return undefined
+  try {
+    const cfg = loadSwitchroomConfig()
+    const rawAgent = cfg.agents?.[agentName]
+    if (!rawAgent) return undefined
+    const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent)
+    const tg = resolved.channels?.telegram
+    if (!tg) return undefined
+    // The router treats the absence of default_topic_id as
+    // "fleet-mode" and returns undefined for `boot` (the caller's
+    // existing fallback). Only supergroup-owned agents (with
+    // default_topic_id set) get a routed value.
+    return resolveOutboundTopicHelper(
+      tg as _OutboundRouterConfig,
+      { kind: 'boot' },
+    )
+  } catch {
+    return undefined
+  }
 }
 
 /**


### PR DESCRIPTION
PR4b of the supergroup-mode rollout (first emitter wired). Small surgical change to \`resolveBootChatId\` that routes the boot card to the agent's \`alerts\` alias topic in supergroup-owned mode, with fleet/DM behavior unchanged.

## Summary

Adds \`resolveBootCardTopic()\` helper inside gateway.ts that loads the agent's resolved cascade config and calls \`resolveOutboundTopic({ kind: 'boot' })\` (the helper from PR1 #1868). Applied at the env-var / history-fallback paths of \`resolveBootChatId\`. The restart-marker path is explicitly NOT touched — the marker carries the exact chat+thread context where the operator typed \`/restart\`, and they expect to see the boot card in that lane.

For fleet-mode / DM agents (no \`default_topic_id\` set) the router returns \`undefined\` and the caller falls through to today's behavior. **Zero observable change** for the existing fleet.

For supergroup-owned agents (with \`channels.telegram.chat_id\` + \`default_topic_id\` set, per PR1 schema), spontaneous boots and crash recovery now land the boot card in the \`alerts\` alias topic instead of chat-root.

## Why

Per RFC \`docs/rfcs/supergroup-mode.md\`, two regressions were flagged for pull-forward: boot card single-destination routing + \`/restart\` marker collision. The marker collision is a separate fix (in flight for PR3b). This PR closes the boot-card half.

In supergroup mode the agent owns its own supergroup with named topics; lifecycle events (boot, compact, watchdog) belong in \`alerts\` so operators can mute/digest them separately from conversation lanes. Without this fix, a crashed agent's boot card could land in chat-root (General topic), which Telegram may bury under unread badge limits or which pollutes the conversational General lane.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] All 6 lint gates clean
- [x] 3,461 bun plugin tests green (no regressions)
- [x] PR1's 33 topic-router unit tests already pin the helper behavior for \`{ kind: 'boot' }\`: alerts alias → default_topic_id fallback → undefined when supergroup mode not configured. The added glue is straight config-load + helper-invocation.

## Risk

- **Very low.** Two-line change in the actual routing path; everything else is the new \`resolveBootCardTopic()\` helper which fails open (returns undefined → today's behavior).
- The config-load happens at boot/reconnect only (not per turn), well within budget.
- Restart marker path untouched — operators using \`/restart\` see the boot card in the same lane today and that doesn't change.

## Follow-ups

This is the FIRST emitter rewired. Sibling PRs follow for:
- Vault grant cards (turn-initiated vs background split per CPO #2)
- Permission cards (similar split)
- Hostd approval cards (operator-initiated → originating turn, fallback admin)
- Cron synthetic-inbound builder (per-entry \`topic:\` override)
- Compact card / watchdog (alerts alias)

These could ship together as PR4b-emitters or individually; will gauge scope after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)