### PR TITLE
feat(scheduler): wire per-cron topic field via resolveOutboundTopic (PR4b-cron)

### DIFF
--- a/src/agent-scheduler/index.test.ts
+++ b/src/agent-scheduler/index.test.ts
@@ -19,6 +19,7 @@ import type {
 import {
   registerAgentSchedule,
   resolveChannelTarget,
+  resolveEntryThreadId,
   type CronLib,
 } from "./index.js";
 
@@ -233,5 +234,105 @@ describe("resolveChannelTarget", () => {
       agents: {},
     } as unknown as Parameters<typeof resolveChannelTarget>[0];
     expect(resolveChannelTarget(config, "ghost")).toEqual({ chatId: "-100" });
+  });
+
+  // ─── PR4b-cron: supergroup-mode override paths ──────────────────────────
+  it("uses the per-agent supergroup chat_id when set (overrides fleet forum_chat_id)", () => {
+    const config = {
+      telegram: { forum_chat_id: "-1001111111111" },  // fleet, ignored
+      agents: {
+        klanker: {
+          channels: {
+            telegram: {
+              chat_id: "-1002222222222",
+              default_topic_id: 1,
+              topic_aliases: { planning: 17, admin: 31 },
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof resolveChannelTarget>[0];
+    const target = resolveChannelTarget(config, "klanker");
+    expect(target).not.toBeNull();
+    expect(target!.chatId).toBe("-1002222222222");
+    expect(target!.threadId).toBe(1);
+    expect(target!.routerConfig).toEqual({
+      default_topic_id: 1,
+      topic_aliases: { planning: 17, admin: 31 },
+    });
+  });
+
+  it("falls back to fleet forum_chat_id when channels.telegram.chat_id is absent", () => {
+    const config = {
+      telegram: { forum_chat_id: "-1001111111111" },
+      agents: {
+        klanker: {
+          topic_id: 42,
+          channels: { telegram: { /* no chat_id */ } },
+        },
+      },
+    } as unknown as Parameters<typeof resolveChannelTarget>[0];
+    const target = resolveChannelTarget(config, "klanker");
+    expect(target).toEqual({
+      chatId: "-1001111111111",
+      threadId: 42,
+    });
+    expect("routerConfig" in target!).toBe(false);
+  });
+});
+
+describe("resolveEntryThreadId", () => {
+  function makeEntry(topic?: string | number) {
+    return {
+      agent: "klanker",
+      scheduleIndex: 0,
+      cron: "0 8 * * *",
+      prompt: "test",
+      promptKey: "abc",
+      ...(topic !== undefined ? { topic } : {}),
+    };
+  }
+  const SG_CHANNEL = {
+    chatId: "-1002222222222",
+    threadId: 1,
+    routerConfig: {
+      default_topic_id: 1,
+      topic_aliases: { planning: 17, admin: 31 },
+    },
+  };
+  const FLEET_CHANNEL = {
+    chatId: "-1001111111111",
+    threadId: 42,
+  };
+
+  it("resolves a string alias against routerConfig.topic_aliases", () => {
+    expect(resolveEntryThreadId(makeEntry("planning"), SG_CHANNEL)).toBe(17);
+    expect(resolveEntryThreadId(makeEntry("admin"), SG_CHANNEL)).toBe(31);
+  });
+
+  it("passes through a numeric topic ID unchanged", () => {
+    expect(resolveEntryThreadId(makeEntry(99), SG_CHANNEL)).toBe(99);
+  });
+
+  it("falls back to default_topic_id when entry has no topic (supergroup mode)", () => {
+    expect(resolveEntryThreadId(makeEntry(), SG_CHANNEL)).toBe(1);
+  });
+
+  it("falls back to default_topic_id when alias is unknown (supergroup mode)", () => {
+    // Defensive fallback — loader-time validation should reject
+    // unknown aliases, but the helper handles config drift.
+    expect(resolveEntryThreadId(makeEntry("nonexistent"), SG_CHANNEL)).toBe(1);
+  });
+
+  it("returns fleet channel.threadId when no routerConfig (fleet mode)", () => {
+    expect(resolveEntryThreadId(makeEntry(), FLEET_CHANNEL)).toBe(42);
+    // Even with a per-entry topic set, fleet agents have no aliases
+    // to resolve against — return the fleet threadId unchanged.
+    expect(resolveEntryThreadId(makeEntry("planning"), FLEET_CHANNEL)).toBe(42);
+  });
+
+  it("returns undefined when no routerConfig AND no channel threadId (DM agent)", () => {
+    const dmChannel = { chatId: "12345" };
+    expect(resolveEntryThreadId(makeEntry(), dmChannel)).toBeUndefined();
   });
 });

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -28,6 +28,8 @@
 
 import { resolve, join } from "node:path";
 import { loadConfig } from "../config/loader.js";
+import { resolveAgentConfig } from "../config/merge.js";
+import { resolveOutboundTopic } from "../telegram/topic-router.js";
 import {
   collectScheduleEntries,
   dispatchAsInbound,
@@ -63,11 +65,18 @@ export interface CronLib {
 /**
  * The fields the in-agent scheduler knows about its target chat at
  * registration time. The forum_chat_id is global (one per fleet);
- * threadId is the agent's own topic in that forum.
+ * threadId is the agent's own topic in that forum (fleet mode) or
+ * the supergroup-owned default fallback.
+ *
+ * `routerConfig` (PR4b-cron of supergroup-mode rollout): when the
+ * agent is in supergroup-owned mode, each per-entry `topic` field
+ * resolves through `resolveOutboundTopic({ kind: 'cron', entryTopic })`.
+ * Unset / undefined for fleet-mode and DM agents — behavior unchanged.
  */
 export interface AgentChannelTarget {
   chatId: string;
   threadId?: number;
+  routerConfig?: { default_topic_id?: number; topic_aliases?: Record<string, number> };
 }
 
 export interface RegisterOptions {
@@ -102,9 +111,10 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
       let delivered = false;
       let summary = "";
       try {
+        const threadId = resolveEntryThreadId(entry, opts.channel);
         const result = dispatchAsInbound(
           entry,
-          { chatId: opts.channel.chatId, threadId: opts.channel.threadId, now },
+          { chatId: opts.channel.chatId, threadId, now },
           opts.dispatcher,
         );
         delivered = result.delivered;
@@ -173,14 +183,70 @@ export function resolveChannelTarget(
   config: ReturnType<typeof loadConfig>,
   agentName: string,
 ): AgentChannelTarget | null {
+  const agent = config.agents?.[agentName];
+
+  // Resolve through the cascade only when the agent exists, so a
+  // supergroup-owned override at the per-agent
+  // `channels.telegram.chat_id` level takes precedence over the
+  // fleet `telegram.forum_chat_id`. Missing-agent fall-through to
+  // the fleet-chat lookup preserves the prior leniency contract.
+  const tgChannel = agent
+    ? resolveAgentConfig(config.defaults, config.profiles, agent).channels?.telegram
+    : undefined;
+  const supergroupChatId = tgChannel?.chat_id;
+  const supergroupDefaultTopic = tgChannel?.default_topic_id;
+
+  if (typeof supergroupChatId === "string" && supergroupChatId.length > 0) {
+    // Supergroup-owned mode: agent owns its own supergroup. The
+    // router config carries default_topic_id + topic_aliases so
+    // per-entry `topic` resolves at dispatch time (PR4b-cron).
+    return {
+      chatId: supergroupChatId,
+      ...(typeof supergroupDefaultTopic === "number" ? { threadId: supergroupDefaultTopic } : {}),
+      routerConfig: {
+        ...(typeof supergroupDefaultTopic === "number" ? { default_topic_id: supergroupDefaultTopic } : {}),
+        ...(tgChannel?.topic_aliases ? { topic_aliases: tgChannel.topic_aliases } : {}),
+      },
+    };
+  }
+
+  // Fleet mode (the existing default): one shared forum_chat_id, each
+  // agent assigned a per-agent topic_id.
   const forumChatId = config.telegram?.forum_chat_id;
   if (typeof forumChatId !== "string" || forumChatId.length === 0) return null;
-  const agent = config.agents?.[agentName];
   const threadId = agent?.topic_id;
   return {
     chatId: forumChatId,
     ...(typeof threadId === "number" ? { threadId } : {}),
   };
+}
+
+/**
+ * Resolve the Telegram thread_id to dispatch a synthetic-inbound on.
+ *
+ * - Supergroup-owned agents: the per-entry `topic` field (alias name
+ *   or numeric ID) flows through `resolveOutboundTopic({ kind: 'cron',
+ *   entryTopic })`. Unknown aliases / missing topic field fall back to
+ *   the agent's `default_topic_id` (carried as `channel.threadId`).
+ * - Fleet / DM agents: returns the channel's threadId unchanged
+ *   (the agent's home topic_id in the shared supergroup, or undefined
+ *   for DMs).
+ *
+ * Pure — no I/O. Tested via the topic-router suite plus a small
+ * integration row in this module's tests.
+ */
+export function resolveEntryThreadId(
+  entry: SchedulerEntry,
+  channel: AgentChannelTarget,
+): number | undefined {
+  if (channel.routerConfig) {
+    const routed = resolveOutboundTopic(channel.routerConfig, {
+      kind: "cron",
+      entryTopic: entry.topic,
+    });
+    if (routed !== undefined) return routed;
+  }
+  return channel.threadId;
 }
 
 export async function main(): Promise<void> {
@@ -323,9 +389,10 @@ export async function main(): Promise<void> {
         );
         for (const m of missed) {
           const startedAt = Date.now();
+          const threadId = resolveEntryThreadId(m.entry, channel);
           const result = dispatchAsInbound(
             m.entry,
-            { chatId: channel.chatId, threadId: channel.threadId },
+            { chatId: channel.chatId, threadId },
             dispatcher,
           );
           sink.recordFire({
@@ -368,9 +435,10 @@ export async function main(): Promise<void> {
           promptKey: "skip-notice",
         };
         const startedAt = Date.now();
+        const threadId = resolveEntryThreadId(noticeEntry, channel);
         const result = dispatchAsInbound(
           noticeEntry,
-          { chatId: channel.chatId, threadId: channel.threadId },
+          { chatId: channel.chatId, threadId },
           dispatcher,
         );
         sink.recordFire({

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -29,6 +29,16 @@ export interface SchedulerEntry {
   prompt: string;
   /** SHA-256 prefix of prompt — stable, non-reversible audit key. */
   promptKey: string;
+  /**
+   * Per-entry Telegram topic override (PR4b of supergroup-mode rollout).
+   * Either a string alias defined in the agent's
+   * `channels.telegram.topic_aliases` (e.g. "planning"), or a numeric
+   * thread_id. Consumed by the in-agent scheduler's dispatch path via
+   * `resolveOutboundTopic({ kind: 'cron', entryTopic })`. Undefined for
+   * fleet-mode / DM agents and for supergroup-mode entries that want
+   * the default_topic_id.
+   */
+  topic?: string | number;
 }
 
 /**
@@ -65,6 +75,9 @@ export function collectScheduleEntries(
         cron: entry.cron,
         prompt: entry.prompt,
         promptKey: createHash("sha256").update(entry.prompt).digest("hex").slice(0, 12),
+        // Propagate the per-entry topic override (PR1 schema field).
+        // Resolved at dispatch time via resolveOutboundTopic().
+        ...(entry.topic !== undefined ? { topic: entry.topic } : {}),
       });
     }
   }


### PR DESCRIPTION
PR4b-cron of the supergroup-mode rollout. Wires the per-entry \`schedule[].topic\` field (added in PR1 schema #1868) through the in-agent cron synthesizer.

## Summary

Three load-bearing changes:

1. **\`SchedulerEntry\` gains optional \`topic\`** (string alias or numeric ID) — propagated by \`collectScheduleEntries\` from the cascade-resolved entry.
2. **\`AgentChannelTarget\` gains optional \`routerConfig\`** — carries \`default_topic_id\` + \`topic_aliases\` for supergroup-owned agents. Populated by \`resolveChannelTarget\` when the agent's \`channels.telegram.chat_id\` is set.
3. **\`resolveEntryThreadId()\` new helper** called from all three \`dispatchAsInbound\` callsites (live fires, missed-fire replay, stale-skip notice). Resolves per-entry topic via \`resolveOutboundTopic({ kind: 'cron', entryTopic })\` in supergroup mode; falls through to \`channel.threadId\` otherwise.

\`resolveChannelTarget\` upgraded to a cascade-aware resolver: picks the per-agent supergroup \`chat_id\` when set, else falls back to fleet \`forum_chat_id\` (today's behavior). Missing-agent leniency contract preserved.

## Why

In supergroup-owned mode, a cron entry like:

\`\`\`yaml
schedule:
  - cron: \"0 8 * * 1-5\"
    prompt: \"Morning digest…\"
    topic: planning      # ← resolves against channels.telegram.topic_aliases
\`\`\`

…now correctly delivers the synthetic-inbound into the \`planning\` topic instead of the agent's default. For fleet/DM agents (no \`channels.telegram.chat_id\` set) behavior is **identical** to today.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] All 6 lint gates clean
- [x] 8 new \`index.test.ts\` rows passing:
  - 2 \`resolveChannelTarget\` rows: supergroup-mode active path + fallback when \`channels.telegram.chat_id\` absent.
  - 6 \`resolveEntryThreadId\` rows: alias resolution, numeric passthrough, default_topic_id fallback, unknown-alias defensive fallback, fleet-mode channel passthrough, DM-mode undefined.
- [x] 279 tests across \`src/scheduler/\`, \`src/agent-scheduler/\`, \`src/telegram/\`, \`src/config/\` green
- [x] Existing \`resolveChannelTarget\` 4-row test set unchanged (backward compat verified at the test level)

## Risk

- **Low.** Pure additive at the data layer (new optional field on SchedulerEntry and AgentChannelTarget). The dispatch helper falls through to today's behavior when routerConfig is absent.
- The cascade resolution in \`resolveChannelTarget\` now calls \`resolveAgentConfig\` per call — adds a O(profile chain depth) cost per registration. Today there's 1 call per agent at startup, so cost is bounded and trivial.
- New routing only fires when:
  - Agent has \`channels.telegram.chat_id\` set (no fleet agents today)
  - Cron entry has \`topic:\` set (no entries today)
  - Both: lookup applies. Single point of failure means the helper covers it.

## Follow-ups

Sibling emitter PRs (all small, all use the same \`resolveOutboundTopic\` helper):
- Vault grant cards (turn-vs-background split per CPO #2)
- Permission cards (similar split)
- Hostd approval cards
- Compact card / watchdog

Plus the load-bearing **PR3b** \`currentTurn\` refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)