### PR TITLE
feat(config): fail-fast on unknown cron `topic:` aliases at load time

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -225,3 +225,170 @@ describe("resolveAgentsDir: SWITCHROOM_AGENTS_DIR env var override", () => {
     expect(resolveAgentsDir(cfg)).toBe(yamlAgentsDir);
   });
 });
+
+// ─── PR4b-cron follow-up: cron topic alias validation ────────────────────
+describe("loadConfig: cron `topic:` alias validation", () => {
+  it("accepts schedule entries with aliases that resolve in topic_aliases", () => {
+    const path = writeTempConfig(`
+switchroom:
+  version: 1
+telegram:
+  bot_token: "x"
+  forum_chat_id: "-1001111111111"
+agents:
+  klanker:
+    topic_name: planning
+    channels:
+      telegram:
+        chat_id: "-1002222222222"
+        default_topic_id: 1
+        topic_aliases:
+          planning: 17
+          cron: 23
+    schedule:
+      - cron: "0 8 * * 1-5"
+        prompt: "Morning digest"
+        topic: planning
+      - cron: "30 9 * * *"
+        prompt: "Another check"
+        topic: cron
+`);
+    expect(() => loadConfig(path)).not.toThrow();
+  });
+
+  it("accepts numeric topic IDs without consulting topic_aliases", () => {
+    const path = writeTempConfig(`
+switchroom:
+  version: 1
+telegram:
+  bot_token: "x"
+  forum_chat_id: "-1001111111111"
+agents:
+  klanker:
+    topic_name: planning
+    channels:
+      telegram:
+        chat_id: "-1002222222222"
+        default_topic_id: 1
+    schedule:
+      - cron: "0 8 * * 1-5"
+        prompt: "Send to thread 99"
+        topic: 99
+`);
+    expect(() => loadConfig(path)).not.toThrow();
+  });
+
+  it("accepts schedule entries without a topic field (default fallback)", () => {
+    const path = writeTempConfig(`
+switchroom:
+  version: 1
+telegram:
+  bot_token: "x"
+  forum_chat_id: "-1001111111111"
+agents:
+  klanker:
+    topic_name: planning
+    schedule:
+      - cron: "0 8 * * *"
+        prompt: "Daily — no topic override"
+`);
+    expect(() => loadConfig(path)).not.toThrow();
+  });
+
+  it("rejects an unknown alias with a clear, agent-and-cron-cited error", () => {
+    const path = writeTempConfig(`
+switchroom:
+  version: 1
+telegram:
+  bot_token: "x"
+  forum_chat_id: "-1001111111111"
+agents:
+  klanker:
+    topic_name: planning
+    channels:
+      telegram:
+        chat_id: "-1002222222222"
+        default_topic_id: 1
+        topic_aliases:
+          planning: 17
+    schedule:
+      - cron: "0 8 * * 1-5"
+        prompt: "Typo here"
+        topic: plannign
+`);
+    let caught: Error | null = null;
+    try { loadConfig(path); } catch (e) { caught = e as Error; }
+    expect(caught).toBeInstanceOf(ConfigError);
+    const ce = caught as ConfigError;
+    expect(ce.message).toContain("Cron \`topic:\` alias references unknown");
+    expect(ce.details?.join("\n")).toContain("klanker");
+    expect(ce.details?.join("\n")).toContain("plannign");
+    expect(ce.details?.join("\n")).toContain("0 8 * * 1-5");
+  });
+
+  it("rejects string aliases when fleet-mode agents have no topic_aliases at all", () => {
+    // Fleet/DM agents: silent dispatch to undefined / chat-root would be
+    // worse than failing fast — definitely not what the operator meant.
+    const path = writeTempConfig(`
+switchroom:
+  version: 1
+telegram:
+  bot_token: "x"
+  forum_chat_id: "-1001111111111"
+agents:
+  klanker:
+    topic_name: planning
+    topic_id: 42
+    schedule:
+      - cron: "0 8 * * *"
+        prompt: "Where does this go?"
+        topic: planning
+`);
+    let caught: Error | null = null;
+    try { loadConfig(path); } catch (e) { caught = e as Error; }
+    expect(caught).toBeInstanceOf(ConfigError);
+  });
+
+  it("aggregates multiple violations from multiple agents in a single error", () => {
+    const path = writeTempConfig(`
+switchroom:
+  version: 1
+telegram:
+  bot_token: "x"
+  forum_chat_id: "-1001111111111"
+agents:
+  klanker:
+    topic_name: planning
+    channels:
+      telegram:
+        chat_id: "-1002222222222"
+        default_topic_id: 1
+        topic_aliases:
+          planning: 17
+    schedule:
+      - cron: "0 8 * * *"
+        prompt: "Typo 1"
+        topic: plannign
+  ziggy:
+    topic_name: cron
+    channels:
+      telegram:
+        chat_id: "-1003333333333"
+        default_topic_id: 1
+        topic_aliases:
+          admin: 31
+    schedule:
+      - cron: "30 8 * * *"
+        prompt: "Typo 2"
+        topic: alerst
+`);
+    let caught: Error | null = null;
+    try { loadConfig(path); } catch (e) { caught = e as Error; }
+    expect(caught).toBeInstanceOf(ConfigError);
+    const ce = caught as ConfigError;
+    expect(ce.details?.length).toBe(2);
+    const joined = ce.details?.join("\n") ?? "";
+    expect(joined).toContain("plannign");
+    expect(joined).toContain("alerst");
+  });
+});

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -6,6 +6,7 @@ import { ZodError } from "zod";
 import { SwitchroomConfigSchema, type SwitchroomConfig } from "./schema.js";
 import { resolveDualPath } from "./paths.js";
 import { applyAgentOverlays } from "./overlay-loader.js";
+import { resolveAgentConfig } from "./merge.js";
 
 export class ConfigError extends Error {
   constructor(
@@ -199,7 +200,59 @@ export function loadConfig(configPath?: string): SwitchroomConfig {
   // per-file isolated and surfaced as warnings — they never fail the load.
   applyAgentOverlays(config);
 
+  // PR4b-cron follow-up: validate that every per-cron `topic:` alias
+  // resolves against the agent's channels.telegram.topic_aliases. This
+  // is a cross-field check that needs the resolved cascade, so it lives
+  // here in the loader rather than the zod schema. A typo'd alias would
+  // otherwise silently fall back to default_topic_id at dispatch time —
+  // far worse UX than failing fast at config-load.
+  validateAllCronTopicAliases(config, filePath);
+
   return config;
+}
+
+/**
+ * Walk every agent's resolved schedule and reject any per-cron `topic:`
+ * alias that doesn't exist in the agent's `channels.telegram.topic_aliases`.
+ *
+ * Fleet-mode and DM agents have no aliases — a string `topic:` there is
+ * also rejected (resolveOutboundTopic would silently fall through to
+ * undefined and the cron fire would land at chat-root, definitely not
+ * what the operator intended). Numeric `topic:` IDs are always accepted.
+ *
+ * Throws a `ConfigError` aggregating all violations across the fleet so
+ * a yaml with multiple typos surfaces them all in one pass.
+ */
+function validateAllCronTopicAliases(
+  config: SwitchroomConfig,
+  filePath: string,
+): void {
+  const issues: string[] = [];
+  for (const [agentName, agentRaw] of Object.entries(config.agents)) {
+    if (!agentRaw) continue;
+    const resolved = resolveAgentConfig(config.defaults, config.profiles, agentRaw);
+    const schedule = resolved.schedule ?? [];
+    if (schedule.length === 0) continue;
+    const tg = resolved.channels?.telegram;
+    const aliases = new Set(Object.keys(tg?.topic_aliases ?? {}));
+    for (const entry of schedule) {
+      if (entry.topic == null) continue;
+      if (typeof entry.topic === "number") continue;
+      if (!aliases.has(entry.topic)) {
+        issues.push(
+          `  agents.${agentName}.schedule cron \`${entry.cron}\`: ` +
+          `topic alias "${entry.topic}" is not defined in ` +
+          `channels.telegram.topic_aliases.`,
+        );
+      }
+    }
+  }
+  if (issues.length > 0) {
+    throw new ConfigError(
+      `Cron \`topic:\` alias references unknown topic_aliases in ${filePath}`,
+      issues,
+    );
+  }
 }
 
 export function resolveAgentsDir(config: SwitchroomConfig): string {


### PR DESCRIPTION
Follow-up to PR4b-cron #1876. Closes the loader-side TODO the reviewer flagged: an unknown cron \`topic:\` alias today silently falls back to \`default_topic_id\` at dispatch (defensive runtime behavior). This PR adds loader-time validation so a yaml typo surfaces at config-load with a clear error instead of misrouting cron fires.

## Summary

New private \`validateAllCronTopicAliases()\` in \`src/config/loader.ts\`:
- Walks every agent's cascade-resolved schedule.
- Rejects any string \`topic:\` that isn't in \`channels.telegram.topic_aliases\`. Numeric topic IDs always accepted.
- Aggregates ALL violations across the fleet into a single \`ConfigError\` so multiple typos surface in one pass.
- Cites agent name + cron expression + alias name in each detail line.

The cross-field nature (entry-level \`topic\` ↔ agent-level \`topic_aliases\`) is why this lives in the loader and not the zod schema — schema can't see across that boundary cleanly.

## Why

Without this, an operator writes:

\`\`\`yaml
schedule:
  - cron: \"0 8 * * 1-5\"
    prompt: \"Morning digest\"
    topic: plannign         # ← typo
\`\`\`

…and the dispatcher silently routes the fire to \`default_topic_id\` (the agent's General/fallback topic) every weekday at 8am, forever, with no error anywhere. The runtime fallback is correct as a defense-in-depth, but the operator should hear about the typo loudly at \`switchroom apply\` time.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] All 6 lint gates clean
- [x] 6 new \`loader.test.ts\` rows: aliases-that-resolve / numeric-IDs / no-topic-field / unknown-alias-clear-error / fleet-no-aliases-rejected / multi-violation-aggregation
- [x] 190 \`src/config/\` tests green

## Risk

- **Low.** Pure additive validation at config-load. Existing valid configs pass through unchanged; only configs with cron \`topic:\` typos (a brand-new field shipped in PR1) start failing — and they were going to misroute silently anyway, so failing fast is strictly better.
- A small backward-compat consideration: if any (currently impossible) yaml in the wild relied on a string-typed \`topic:\` falling back to default, that yaml will now fail at load. Mitigation: the \`topic:\` field landed in PR1 #1868 just hours ago — nobody is depending on the silent-fallback behavior yet.

## Follow-ups

Sibling emitter PRs (vault / permission / hostd) — each uses the same \`resolveAgentOutboundTopic\` helper generalized in PR4b-compact #1877. Plus PR3b (currentTurn refactor) and PR5 (slash command smart split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)