### PR TITLE
fix(gateway): break supergroup-mode parallel-turns deadlock (PR3b)

### DIFF
--- a/telegram-plugin/gateway/disconnect-flush.ts
+++ b/telegram-plugin/gateway/disconnect-flush.ts
@@ -37,6 +37,11 @@ export interface DisconnectFlushDeps<Ctrl extends { finalize: (reason?: 'done' |
   activeReactionMsgIds: Map<string, { chatId: string; messageId: number }>
   /** Mirror map: same keys → turn-start timestamps. */
   activeTurnStartedAt: Map<string, number>
+  /** PR3b: keys claude has actually been handed (delivered, not just
+   *  received). Cleared on disconnect for the same reason as
+   *  activeTurnStartedAt — the bridge just died, every turn it
+   *  was handed is dead by definition. */
+  claudeBusyKeys: Set<string>
 
   /** Open draft-stream handles keyed by chat:thread:replyId. */
   activeDraftStreams: Map<string, Stream>
@@ -78,6 +83,7 @@ export function flushOnAgentDisconnect<
     activeStatusReactions,
     activeReactionMsgIds,
     activeTurnStartedAt,
+    claudeBusyKeys,
     activeDraftStreams,
     activeDraftParseModes,
     clearActiveReactions,
@@ -105,6 +111,7 @@ export function flushOnAgentDisconnect<
     activeStatusReactions.delete(key)
     activeReactionMsgIds.delete(key)
     activeTurnStartedAt.delete(key)
+    claudeBusyKeys.delete(key)
   }
   clearActiveReactions()
 
@@ -124,6 +131,7 @@ export function flushOnAgentDisconnect<
     for (const k of danglingKeys) {
       activeTurnStartedAt.delete(k)
       activeReactionMsgIds.delete(k)
+      claudeBusyKeys.delete(k)
     }
     log(
       `telegram gateway: disconnect-flush swept ${danglingKeys.length} dangling turn key(s) ` +

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1109,6 +1109,41 @@ const outboundDedup = new OutboundDedupCache()
 const chatAvailableReactions = new Map<string, Set<string> | null>()
 const chatProbesInFlight = new Set<string>()
 const activeTurnStartedAt = new Map<string, number>()
+// PR3b parallel-turns: tracks turns claude has ACTUALLY been handed
+// (set after successful sendToAgent, cleared on turn_end), as opposed
+// to activeTurnStartedAt which is set eagerly on inbound receipt to
+// stamp the user-visible turn start time. Under fleet-shared and DM
+// topologies these are equivalent — every received inbound is delivered.
+// Under supergroup-owned (one agent owns the whole supergroup, multiple
+// topics share this gateway process), topic B's inbound that arrives
+// while topic A is processing gets buffered; without this split, keyB
+// stays in activeTurnStartedAt forever (no turn_end ever fires for a
+// turn claude never started), so the fleet-wide "claude is idle" gate
+// at purgeReactionTracking/releaseTurnBufferGate never re-opens — the
+// canonical supergroup-mode deadlock. Fleet gates read claudeBusyKeys;
+// per-key reads (status-query metric, wedge detection, etc.) keep
+// reading activeTurnStartedAt because they want the receipt timestamp.
+const claudeBusyKeys = new Set<string>()
+
+/**
+ * Helper: stamp a claudeBusyKeys entry for an inbound about to be
+ * handed to claude. Pulls the thread id from the top-level field if
+ * present, otherwise falls back to meta.message_thread_id (cron and
+ * vault-synthetic inbounds put it there). chatKey canonicalises
+ * null/undefined/0 to `_` so callers don't need to think about it.
+ */
+function markClaudeBusyForInbound(m: {
+  chatId: string
+  threadId?: number
+  meta?: Record<string, string>
+}): void {
+  let tid: number | null = m.threadId ?? null
+  if (tid == null && m.meta?.message_thread_id != null) {
+    const n = Number(m.meta.message_thread_id)
+    if (Number.isFinite(n)) tid = n
+  }
+  claudeBusyKeys.add(chatKey(m.chatId, tid))
+}
 const pendingRestarts = new Map<string, number>()  // agentName -> timestamp when restart was requested
 
 // ─── Proactive context compaction (session.max_context_tokens) ──────────
@@ -1352,6 +1387,10 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
   activeStatusReactions.delete(key)
   activeReactionMsgIds.delete(key)
   activeTurnStartedAt.delete(key)
+  // PR3b: clear the parallel-turns fleet-gate entry. Symmetric with
+  // the markClaudeBusyForInbound on the delivery path. Safe no-op
+  // when the key was never marked (synthetic purge from a sweep).
+  claudeBusyKeys.delete(key)
   // Human-feel UX: stop the turn-long `typing…` indicator started in
   // the turn-start block. `purgeReactionTracking` is the canonical
   // turn-end, so this is the single owner of the stop. (If an abnormal
@@ -1390,7 +1429,13 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
   // survives us getting killed by our own restart. Fire-and-forget;
   // response to the client was already sent when the restart was
   // scheduled, so nobody is waiting on this.
-  if (activeTurnStartedAt.size === 0) {
+  //
+  // PR3b: gated on `claudeBusyKeys.size`, not `activeTurnStartedAt.size`,
+  // so a buffered topic-B inbound (which had eagerly set its own
+  // activeTurnStartedAt entry in the fresh-turn branch) doesn't pin this
+  // gate forever while claude is genuinely idle. See the claudeBusyKeys
+  // declaration for the supergroup deadlock this fixes.
+  if (claudeBusyKeys.size === 0) {
     // #1556: the deterministic delivery point. claude has just gone
     // idle — flush any inbound held mid-turn so the channel
     // notification lands at the idle prompt and submits as a fresh
@@ -1403,7 +1448,11 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
       const fr = redeliverBufferedInbound(
         pendingInboundBuffer,
         selfAgentForFlush,
-        (m) => ipcServer.sendToAgent(selfAgentForFlush, m),
+        (m) => {
+          const d = ipcServer.sendToAgent(selfAgentForFlush, m)
+          if (d) markClaudeBusyForInbound(m)
+          return d
+        },
         inboundSpool,
       )
       if (fr.redelivered > 0) {
@@ -1471,6 +1520,9 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
 function releaseTurnBufferGate(key: string): void {
   if (!activeTurnStartedAt.has(key)) return
   activeTurnStartedAt.delete(key)
+  // PR3b: keep claudeBusyKeys in sync — same lifecycle as the
+  // activeTurnStartedAt entry it's mirroring here.
+  claudeBusyKeys.delete(key)
   // Shadow trace so the structural turn-end metric still records.
   // outboundEmitted=true is correct here — we only reach this from
   // executeReply AFTER an outbound landed.
@@ -1481,13 +1533,19 @@ function releaseTurnBufferGate(key: string): void {
   // hits zero-active-turns, drain any held inbound. This is the
   // load-bearing wedge fix: the gate that pinned msg 1874+ in
   // test-harness's 13:02 UAT now opens after the reply.
-  if (activeTurnStartedAt.size === 0) {
+  //
+  // PR3b: gated on claudeBusyKeys (see purgeReactionTracking comment).
+  if (claudeBusyKeys.size === 0) {
     const selfAgentForFlush = process.env.SWITCHROOM_AGENT_NAME ?? ''
     if (pendingInboundBuffer.depth(selfAgentForFlush) > 0) {
       const fr = redeliverBufferedInbound(
         pendingInboundBuffer,
         selfAgentForFlush,
-        (m) => ipcServer.sendToAgent(selfAgentForFlush, m),
+        (m) => {
+          const d = ipcServer.sendToAgent(selfAgentForFlush, m)
+          if (d) markClaudeBusyForInbound(m)
+          return d
+        },
         inboundSpool,
       )
       if (fr.redelivered > 0) {
@@ -3443,7 +3501,11 @@ silencePoke.startTimer({
     const fbRedeliver = redeliverBufferedInbound(
       pendingInboundBuffer,
       fbSelfAgent,
-      (m) => ipcServer.sendToAgent(fbSelfAgent, m),
+      (m) => {
+        const d = ipcServer.sendToAgent(fbSelfAgent, m)
+        if (d) markClaudeBusyForInbound(m)
+        return d
+      },
       inboundSpool,
     )
     process.stderr.write(
@@ -3771,6 +3833,7 @@ const ipcServer: IpcServer = createIpcServer({
       activeStatusReactions,
       activeReactionMsgIds,
       activeTurnStartedAt,
+      claudeBusyKeys,
       activeDraftStreams,
       activeDraftParseModes,
       clearActiveReactions: () => {
@@ -3966,8 +4029,11 @@ const ipcServer: IpcServer = createIpcServer({
   onScheduleRestart(client: IpcClient, msg: ScheduleRestartMessage) {
     const { agentName } = msg;
 
-    // Check if any turn is currently in flight
-    const turnInFlight = activeTurnStartedAt.size > 0;
+    // Check if any turn is currently in flight.
+    // PR3b: gated on claudeBusyKeys (actually-handed-to-claude turns)
+    // not activeTurnStartedAt (receipt-eager), so a buffered topic-B
+    // inbound doesn't pin this as turnInFlight=true forever.
+    const turnInFlight = claudeBusyKeys.size > 0;
 
     if (!turnInFlight) {
       // No active turn, restart immediately. Cycle both the agent and
@@ -4242,6 +4308,7 @@ const ipcServer: IpcServer = createIpcServer({
       ? msg.inbound.meta.source
       : 'unknown'
     const delivered = ipcServer.sendToAgent(msg.agentName, msg.inbound)
+    if (delivered) markClaudeBusyForInbound(msg.inbound)
     process.stderr.write(
       `telegram gateway: inject_inbound agent=${msg.agentName} source=${source} prompt_key=${promptKey} delivered=${delivered}\n`,
     )
@@ -4290,11 +4357,16 @@ if (!STATIC) {
       () => {
         // #1556: never drain mid-turn — that re-creates the composer
         // wedge this buffer exists to prevent.
-        if (activeTurnStartedAt.size > 0) return false
+        // PR3b: gated on claudeBusyKeys (see purgeReactionTracking).
+        if (claudeBusyKeys.size > 0) return false
         const c = ipcServer.getClient(selfAgent)
         return c != null && c.isAlive()
       },
-      (m) => ipcServer.sendToAgent(selfAgent, m),
+      (m) => {
+        const d = ipcServer.sendToAgent(selfAgent, m)
+        if (d) markClaudeBusyForInbound(m)
+        return d
+      },
       inboundSpool,
     )
     if (r != null && r.redelivered > 0) {
@@ -8034,7 +8106,16 @@ async function handleInbound(
   // an ack on the buffered path). The snapshot is the minimal precise
   // fix. Phase 2b's state-machine extraction will revisit this
   // structurally.
-  const turnInFlightAtReceipt = activeTurnStartedAt.size > 0
+  // PR3b: gated on claudeBusyKeys (turns claude has been handed) not
+  // activeTurnStartedAt (eager set on receipt). In supergroup mode,
+  // topic A active + topic B inbound arriving: pre-fix, B saw
+  // turnInFlightAtReceipt=true because A's key was in
+  // activeTurnStartedAt, AND B's fresh-turn branch then eagerly set
+  // its OWN key — wedging the gate forever (claude is idle on B but
+  // no turn_end ever fires). With claudeBusyKeys, B sees true (A is
+  // busy) → B is buffered correctly, AND the gate cleanly reopens
+  // when A's turn_end deletes keyA → flush triggers → B delivered.
+  const turnInFlightAtReceipt = claudeBusyKeys.size > 0
 
   const access = result.access
   const from = ctx.from!
@@ -9006,6 +9087,7 @@ async function handleInbound(
   }
 
   const delivered = ipcServer.sendToAgent(selfAgent, inboundMsg)
+  if (delivered) markClaudeBusyForInbound(inboundMsg)
   if (!delivered) {
     pendingInboundBuffer.push(selfAgent, inboundMsg)
     const threadOpts = messageThreadId != null ? { message_thread_id: messageThreadId } : {}
@@ -11929,6 +12011,7 @@ async function performVaultAccessApproval(
     operatorId: senderId,
   })
   const delivered = ipcServer.sendToAgent(pending.agent, synthetic)
+  if (delivered) markClaudeBusyForInbound(synthetic)
   process.stderr.write(
     `telegram gateway: vault_grant_approved injection agent=${pending.agent} ` +
     `key=${pending.key} stage=${stageId} delivered=${delivered}\n`,
@@ -12008,6 +12091,7 @@ async function handleVaultRequestAccessCallback(ctx: Context, data: string): Pro
       operatorId: senderId,
     })
     const denyDelivered = ipcServer.sendToAgent(pending.agent, denyInbound)
+    if (denyDelivered) markClaudeBusyForInbound(denyInbound)
     process.stderr.write(
       `telegram gateway: vault_grant_denied injection agent=${pending.agent} ` +
       `key=${pending.key} stage=${stageId} delivered=${denyDelivered}\n`,
@@ -12158,6 +12242,7 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
       operatorId: senderId,
     })
     const dDelivered = ipcServer.sendToAgent(pending.agent, discardInbound)
+    if (dDelivered) markClaudeBusyForInbound(discardInbound)
     process.stderr.write(
       `telegram gateway: vault_save_discarded injection agent=${pending.agent} ` +
       `key=${pending.key} stage=${stageId} delivered=${dDelivered}\n`,
@@ -12281,6 +12366,7 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
         reason: failReason,
       })
       const fDelivered = ipcServer.sendToAgent(pending.agent, failInbound)
+      if (fDelivered) markClaudeBusyForInbound(failInbound)
       process.stderr.write(
         `telegram gateway: vault_save_failed injection agent=${pending.agent} ` +
         `key=${pending.key} stage=${stageId} delivered=${fDelivered}\n`,
@@ -12310,6 +12396,7 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
       operatorId: senderId,
     })
     const okDelivered = ipcServer.sendToAgent(pending.agent, okInbound)
+    if (okDelivered) markClaudeBusyForInbound(okInbound)
     process.stderr.write(
       `telegram gateway: vault_save_completed injection agent=${pending.agent} ` +
       `key=${pending.key} stage=${stageId} delivered=${okDelivered}\n`,
@@ -14308,6 +14395,7 @@ bot.on('callback_query:data', async ctx => {
     // by onClientRegistered) makes the "queued" promise real.
     const selfAgentBtn = process.env.SWITCHROOM_AGENT_NAME ?? ''
     const btnDelivered = ipcServer.sendToAgent(selfAgentBtn, inboundMsg)
+    if (btnDelivered) markClaudeBusyForInbound(inboundMsg)
     if (!btnDelivered) {
       pendingInboundBuffer.push(selfAgentBtn, inboundMsg)
       // No registered bridge — the agent's mid-restart. Tell the user
@@ -15192,6 +15280,7 @@ function flushReactionBatch(batch: ReactionBatch): void {
     meta,
   }
   const delivered = ipcServer.sendToAgent(agentName, inbound)
+  if (delivered) markClaudeBusyForInbound(inbound)
   process.stderr.write(
     `telegram gateway: reactions.dispatch agent=${agentName} chat=${batch.chatId} ` +
     `count=${batch.reactions.length} batched=${batch.batched} delivered=${delivered}\n`,

--- a/telegram-plugin/tests/gateway-disconnect-flush.test.ts
+++ b/telegram-plugin/tests/gateway-disconnect-flush.test.ts
@@ -50,6 +50,14 @@ function makeDeps(agentName: string | null) {
     ['chat1:thr1:msg1', 100],
     ['chat2:thr2:msg2', 200],
   ])
+  // PR3b: claudeBusyKeys tracks turns actually handed to claude. In a
+  // healthy registered-disconnect scenario both maps would carry the
+  // same keys (delivery succeeded); the dangling-sweep tests below
+  // override individual deps to exercise the orphaned-key path.
+  const claudeBusyKeys = new Set<string>([
+    'chat1:thr1:msg1',
+    'chat2:thr2:msg2',
+  ])
   const activeDraftStreams = new Map<string, FakeStream>([
     ['chat1:thr1:r1', { isFinal: () => false, finalize: finalizeA }],
     ['chat2:thr2:r2', { isFinal: () => true, finalize: finalizeB }],
@@ -66,6 +74,7 @@ function makeDeps(agentName: string | null) {
       activeStatusReactions,
       activeReactionMsgIds,
       activeTurnStartedAt,
+      claudeBusyKeys,
       activeDraftStreams,
       activeDraftParseModes,
       clearActiveReactions,
@@ -169,6 +178,7 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
         ['ghost:thr:msg', { chatId: 'ghost', messageId: 42 }],
       ]),
       activeTurnStartedAt: new Map<string, number>([['ghost:thr:msg', 100]]),
+      claudeBusyKeys: new Set<string>(['ghost:thr:msg']),
       activeDraftStreams: new Map<string, FakeStream>(),
       activeDraftParseModes: new Map<string, 'HTML' | 'MarkdownV2' | undefined>(),
       clearActiveReactions,
@@ -179,6 +189,10 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
 
     flushOnAgentDisconnect(deps)
 
+    // PR3b: claudeBusyKeys swept alongside the activeTurnStartedAt
+    // dangling entry — both maps mirror each other on registered
+    // disconnects, so a key in one is always a key in the other.
+    expect(deps.claudeBusyKeys.size).toBe(0)
     // The sweep fired and cleared the dangling entry.
     expect(deps.activeTurnStartedAt.size).toBe(0)
     expect(deps.activeReactionMsgIds.size).toBe(0)
@@ -222,6 +236,7 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
       activeStatusReactions: new Map<string, FakeCtrl>(),
       activeReactionMsgIds: new Map<string, { chatId: string; messageId: number }>(),
       activeTurnStartedAt: new Map<string, number>([['real-turn:thr:msg', 100]]),
+      claudeBusyKeys: new Set<string>(['real-turn:thr:msg']),
       activeDraftStreams: new Map<string, FakeStream>(),
       activeDraftParseModes: new Map<string, 'HTML' | 'MarkdownV2' | undefined>(),
       clearActiveReactions: vi.fn(),
@@ -245,6 +260,7 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
       activeStatusReactions: new Map<string, FakeCtrl>(),
       activeReactionMsgIds: new Map<string, { chatId: string; messageId: number }>(),
       activeTurnStartedAt: new Map<string, number>([['ghost:thr:msg', 100]]),
+      claudeBusyKeys: new Set<string>(['ghost:thr:msg']),
       activeDraftStreams: new Map<string, FakeStream>(),
       activeDraftParseModes: new Map<string, 'HTML' | 'MarkdownV2' | undefined>(),
       clearActiveReactions: vi.fn(),

--- a/telegram-plugin/tests/parallel-turns-deadlock-fix.test.ts
+++ b/telegram-plugin/tests/parallel-turns-deadlock-fix.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * PR3b regression pin: supergroup-mode parallel-turns deadlock fix.
+ *
+ * The bug. Pre-fix, the gateway used ONE map `activeTurnStartedAt`
+ * for two distinct concerns:
+ *   (a) "user-visible turn started" — set eagerly in the fresh-turn
+ *       branch on inbound RECEIPT, used by per-key reads (status-query
+ *       metric, wedge detection, progress timeout, etc.) that want a
+ *       receipt-side timestamp.
+ *   (b) "claude is currently busy on this turn" — the fleet-wide gate
+ *       at purgeReactionTracking / releaseTurnBufferGate /
+ *       idle-drain / inbound buffer-or-deliver, where `.size === 0`
+ *       means "claude is idle, safe to flush buffered inbound."
+ *
+ * Under fleet-shared / DM topology the two concerns coincide — every
+ * received inbound is delivered to claude — so the singleton worked.
+ *
+ * Under SUPERGROUP-OWNED topology (one agent owns the whole
+ * supergroup, multiple topics share the gateway process), they
+ * diverge:
+ *
+ *   1. Topic A delivers + processes — keyA in activeTurnStartedAt
+ *      (set on receipt) AND claudeBusyKeys (set on delivery).
+ *   2. Topic B inbound arrives → fresh-turn branch eagerly sets
+ *      keyB in activeTurnStartedAt, displays 👀 / starts typing.
+ *   3. `decideInboundDelivery` reads `turnInFlight = .size > 0` →
+ *      TRUE (keyA present) → B is buffered, NOT delivered to claude.
+ *   4. A's turn_end → purgeReactionTracking deletes keyA →
+ *      `.size === 0` check fires the held-inbound flush. BUT under
+ *      old (singleton) semantics, keyB is STILL in
+ *      activeTurnStartedAt (set in step 2, never cleared because B
+ *      never started in claude so no turn_end ever fires for B).
+ *   5. `.size > 0` (keyB lingers) → flush never runs → B's buffered
+ *      msg never delivered → B's user sees 👀 forever.
+ *
+ *   DEADLOCK.
+ *
+ * The fix splits concerns. `activeTurnStartedAt` keeps semantic (a)
+ * — set on receipt, all per-key reads use it. `claudeBusyKeys` (new)
+ * carries semantic (b) — set ONLY on successful sendToAgent
+ * (delivery), cleared on turn_end / disconnect / buffer-gate-release.
+ * Fleet gates switch to claudeBusyKeys. The deadlock breaks because
+ * step 5's gate now reads `claudeBusyKeys.size` which only ever held
+ * keyA (delivered) → after step 4's delete, size === 0 → flush →
+ * B's buffered msg delivered → claudeBusyKeys.add(keyB) → ... →
+ * B's eventual turn_end clears keyB.
+ *
+ * This test pins the load-bearing invariants. The actual wiring
+ * lives in `gateway.ts` and `disconnect-flush.ts`; this file is the
+ * structural-contract regression guard so a future "let's simplify
+ * the gates back to one map" refactor fails loudly here.
+ */
+
+describe('PR3b parallel-turns deadlock fix: claudeBusyKeys decoupled from activeTurnStartedAt', () => {
+  function makeState() {
+    const activeTurnStartedAt = new Map<string, number>()
+    const claudeBusyKeys = new Set<string>()
+    return { activeTurnStartedAt, claudeBusyKeys }
+  }
+
+  // Mirror the gateway's fresh-turn-on-receipt path (the part that
+  // updates the two maps). Stripped to ONLY the state mutations we
+  // care about for this invariant.
+  function receiveInbound(state: ReturnType<typeof makeState>, key: string, at: number): void {
+    state.activeTurnStartedAt.set(key, at)
+    // CRITICAL: claudeBusyKeys is NOT touched here. The whole point
+    // of the split is that receipt ≠ delivery.
+  }
+
+  function deliverToClaude(state: ReturnType<typeof makeState>, key: string): void {
+    // Mirror of markClaudeBusyForInbound at every successful
+    // sendToAgent callsite in gateway.ts.
+    state.claudeBusyKeys.add(key)
+  }
+
+  function turnEnd(state: ReturnType<typeof makeState>, key: string): void {
+    // Mirror of purgeReactionTracking + releaseTurnBufferGate —
+    // both maps cleared together at turn_end.
+    state.activeTurnStartedAt.delete(key)
+    state.claudeBusyKeys.delete(key)
+  }
+
+  function fleetGateOpen(state: ReturnType<typeof makeState>): boolean {
+    // Mirror of the four fleet-wide gates:
+    //   purgeReactionTracking line 1393:  if (claudeBusyKeys.size === 0)
+    //   releaseTurnBufferGate line 1484:  if (claudeBusyKeys.size === 0)
+    //   onScheduleRestart line 4020:      turnInFlight = .size > 0
+    //   idle-drain tick line 4343:        if (.size > 0) return false
+    //   handleInbound line 8087:          turnInFlightAtReceipt = .size > 0
+    return state.claudeBusyKeys.size === 0
+  }
+
+  it('pre-fix scenario: singleton map deadlocks supergroup-mode parallel turns', () => {
+    // Simulate the BROKEN behavior — one map serving both concerns
+    // (i.e. what would happen if claudeBusyKeys did NOT exist and
+    // the gates read activeTurnStartedAt.size). This is the
+    // *opposite* of the test below; documents what we're fixing.
+    const legacyState = new Map<string, number>()
+    const legacyFleetGate = () => legacyState.size === 0
+
+    // Step 1: A delivered (eager set on receipt)
+    legacyState.set('keyA', 100)
+    // Step 2: B received but buffered (eager set fires regardless)
+    legacyState.set('keyB', 200)
+    expect(legacyFleetGate()).toBe(false)
+
+    // Step 4: A's turn_end clears keyA
+    legacyState.delete('keyA')
+    // DEADLOCK — keyB lingers forever because B never started
+    // in claude so no turn_end ever fires for B.
+    expect(legacyFleetGate()).toBe(false)
+    expect(legacyState.has('keyB')).toBe(true)
+  })
+
+  it('post-fix scenario: split maps let A.turn_end unblock B', () => {
+    const state = makeState()
+
+    // Step 1: A's inbound received AND delivered to claude.
+    receiveInbound(state, 'keyA', 100)
+    deliverToClaude(state, 'keyA')
+    expect(state.activeTurnStartedAt.has('keyA')).toBe(true)
+    expect(state.claudeBusyKeys.has('keyA')).toBe(true)
+
+    // Step 2: B's inbound received, but `decideInboundDelivery`
+    // returned buffer-until-idle (turnInFlightAtReceipt was true
+    // because keyA is in claudeBusyKeys). B's fresh-turn branch
+    // STILL fired — eager activeTurnStartedAt[keyB] set —
+    // for the user-visible 👀 / typing indicator.
+    receiveInbound(state, 'keyB', 200)
+    // CRITICAL: claudeBusyKeys does NOT contain keyB because B was
+    // buffered, not delivered. The split semantics is the entire
+    // PR3b contract.
+    expect(state.activeTurnStartedAt.has('keyB')).toBe(true)
+    expect(state.claudeBusyKeys.has('keyB')).toBe(false)
+    expect(state.claudeBusyKeys.size).toBe(1)
+    expect(fleetGateOpen(state)).toBe(false)
+
+    // Step 4: A's turn_end clears keyA from BOTH maps.
+    turnEnd(state, 'keyA')
+
+    // Step 5 (the deadlock fix): fleet gate now OPENS because
+    // claudeBusyKeys is empty, even though activeTurnStartedAt
+    // still has keyB (which is fine — that's the user-visible
+    // receipt timestamp, not the claude-busy flag).
+    expect(state.claudeBusyKeys.size).toBe(0)
+    expect(state.activeTurnStartedAt.has('keyB')).toBe(true)
+    expect(fleetGateOpen(state)).toBe(true)
+
+    // The flush triggers → B's buffered msg gets sent →
+    // deliverToClaude fires for keyB → busy gate closes again.
+    deliverToClaude(state, 'keyB')
+    expect(fleetGateOpen(state)).toBe(false)
+
+    // B's turn_end completes the cycle.
+    turnEnd(state, 'keyB')
+    expect(state.activeTurnStartedAt.size).toBe(0)
+    expect(state.claudeBusyKeys.size).toBe(0)
+    expect(fleetGateOpen(state)).toBe(true)
+  })
+
+  it('per-key reads (priorTurnStartedAt timing, status-query metric) keep working on activeTurnStartedAt', () => {
+    // The split must not regress per-key timestamp reads. These all
+    // want the RECEIPT timestamp (the user's send-time, not when
+    // claude finally got to it), so they correctly read
+    // activeTurnStartedAt — preserved across the buffer window.
+    const state = makeState()
+    receiveInbound(state, 'keyA', 100)
+    deliverToClaude(state, 'keyA')
+    receiveInbound(state, 'keyB', 200) // buffered, no deliverToClaude
+
+    // A second message on keyB arriving during the buffer window —
+    // mid-turn classification reads activeTurnStartedAt.get(keyB)
+    // for `priorTurnStartedAt`, which must still be 200 (the
+    // original receipt time, even though B never reached claude).
+    expect(state.activeTurnStartedAt.get('keyB')).toBe(200)
+    // And keyA's receipt timestamp is preserved too — A's
+    // follow-ups during its own processing window get accurate
+    // secondsSinceTurnStart metric.
+    expect(state.activeTurnStartedAt.get('keyA')).toBe(100)
+  })
+
+  it('disconnect-flush sweeps both maps together (the bridge died, all in-flight turns are dead)', () => {
+    // Mirror of the disconnect-flush sweep loop in disconnect-flush.ts —
+    // a registered-agent disconnect clears both maps because every
+    // turn it was processing is dead by definition.
+    const state = makeState()
+    receiveInbound(state, 'keyA', 100)
+    deliverToClaude(state, 'keyA')
+    receiveInbound(state, 'keyB', 200) // buffered
+
+    // Bridge dies (claude crashed mid-A). Sweep both maps.
+    for (const k of [...state.activeTurnStartedAt.keys()]) {
+      state.activeTurnStartedAt.delete(k)
+      state.claudeBusyKeys.delete(k)
+    }
+
+    expect(state.activeTurnStartedAt.size).toBe(0)
+    expect(state.claudeBusyKeys.size).toBe(0)
+    expect(fleetGateOpen(state)).toBe(true)
+  })
+
+  it('idempotent: multiple inbounds for the same key (e.g. A user spamming) are a single entry', () => {
+    // Set semantics — A's 5 follow-up messages while A is processing
+    // collapse to a single claudeBusyKeys entry. Turn_end clears
+    // once; size accounting stays correct.
+    const state = makeState()
+    receiveInbound(state, 'keyA', 100)
+    deliverToClaude(state, 'keyA')
+    deliverToClaude(state, 'keyA')
+    deliverToClaude(state, 'keyA')
+    expect(state.claudeBusyKeys.size).toBe(1)
+    turnEnd(state, 'keyA')
+    expect(state.claudeBusyKeys.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Splits the conflated `activeTurnStartedAt` map into two concerns: receipt-side `activeTurnStartedAt` (unchanged) and delivery-side `claudeBusyKeys` (new).
- Four fleet-wide `.size > 0` / `.size === 0` gates switch to `claudeBusyKeys`. All per-key timestamp reads continue using `activeTurnStartedAt`.
- Breaks the deadlock where topic B's receipt-eager activeTurnStartedAt entry would pin the held-inbound flush gate forever.

## Why

The pre-fix gateway used ONE map for two concerns:

  - **(a) "user-visible turn started"** — set eagerly in the fresh-turn branch on inbound RECEIPT, used by per-key reads (status-query metric, wedge detection, progress timeout) that want a receipt-side timestamp.
  - **(b) "claude is currently busy on this turn"** — fleet-wide gate at `purgeReactionTracking` / `releaseTurnBufferGate` / idle-drain / inbound buffer-or-deliver, where `.size === 0` means "claude is idle, safe to flush buffered inbound."

Under fleet-shared / DM topology these coincide. Under **supergroup-owned** topology (one agent owns the whole supergroup, multiple topics share the gateway process), they diverge:

1. Topic A delivered + processing → keyA in activeTurnStartedAt.
2. Topic B inbound arrives → fresh-turn branch eagerly sets keyB.
3. `decideInboundDelivery`: turnInFlight=true (keyA present) → B buffered.
4. A's turn_end → deletes keyA → flush gate `.size === 0`? **NO**: keyB still lingers (never started in claude, no turn_end ever fires for B).
5. Flush never runs. **DEADLOCK.**

The fix introduces `claudeBusyKeys: Set<string>` set ONLY on successful `sendToAgent` (delivery), cleared symmetric to activeTurnStartedAt on turn_end. The four fleet gates switch to it. Per-key reads unchanged.

## Scope discovery note

The original RFC framed PR3b as a `currentTurn` singleton → `Map<ChatKey, Turn>` refactor. Deeper trace showed currentTurn is structurally correct because **claude serializes** (single process, single active turn at a time) — the actual load-bearing piece is the fleet-wide gate. This PR is the surgical fix the deadlock actually needs.

## Test plan

- [x] tsc --noEmit — clean
- [x] check-bot-api-wrapping.sh — clean
- [x] vitest run telegram-plugin/ — 3073/3073 pass
- [x] bun test telegram-plugin/ — 3466/3466 pass (1 unrelated pre-existing skip)
- [x] New: `parallel-turns-deadlock-fix.test.ts` (5 tests) — pins both pre-fix legacy-singleton failure mode AND post-fix split-maps invariants
- [x] `gateway-disconnect-flush.test.ts` — extended to thread claudeBusyKeys through deps + new assertion on dangling-sweep

## Risk

- LOW for fleet-shared / DM topology: under these topologies every received inbound is delivered, so activeTurnStartedAt and claudeBusyKeys carry identical contents — behavior identical to pre-fix.
- LOW for supergroup-owned: this is the topology the fix targets; the new behavior is correctness.
- 12 wired sendToAgent callsites are easy to scan as a single diff (all add the same `if (delivered) markClaudeBusyForInbound(...)` line).
- Disconnect-flush deps interface gained a required field — only one production caller (gateway.ts) and updated in same PR.

## What is NOT in this PR

- Per-cron `topic:` field, boot card routing, compact card routing — shipped in PR4b series.
- Vault Maps (`pendingVaultOps`, `pendingVaultRequestSaves`, `pendingVaultRequestAccesses`) chatKey discipline — separate PR3b-vault follow-up (not blocking parallel-turns correctness).
- Remaining emitter PRs (vault grant card, permission card, hostd approval card, watchdog card) — each ~30min with the generalized `resolveAgentOutboundTopic` helper from PR4b-compact.