### PR TITLE
feat(auth-broker): Microsoft provider + storage (RFC #1873 PR 1/5)

### DIFF
--- a/src/auth/broker/microsoft-provider.test.ts
+++ b/src/auth/broker/microsoft-provider.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Tests for MicrosoftProvider — RFC #1873 PR 1.
+ *
+ * Mirrors `google-provider.test.ts` structure: stub fetcher returning
+ * canned Microsoft v2 `/token` responses, exercises refresh
+ * success/failure paths, error classification, extractExpiresAt,
+ * validateCredentialShape.
+ *
+ * Microsoft-specific additions vs Google's tests:
+ *   - id_token decoding (tid/oid/preferred_username → tenantId,
+ *     homeAccountId, accountType, accountEmail in rawCredentials)
+ *   - accountType discriminator (personal MSA tid vs work tenant GUID)
+ *   - 429 / AADSTS50196 throttling → quota_exceeded
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { MicrosoftProvider } from "./microsoft-provider.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────
+
+const PERSONAL_MSA_TID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+const WORK_TENANT_TID = "11111111-2222-3333-4444-555555555555";
+
+function stubFetcher(status: number, body: unknown): typeof fetch {
+  return (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+function failingFetcher(message: string): typeof fetch {
+  return (async () => {
+    throw new Error(message);
+  }) as unknown as typeof fetch;
+}
+
+function makeProvider(fetcher: typeof fetch): MicrosoftProvider {
+  return new MicrosoftProvider({
+    clientId: "test-client-id",
+    clientSecret: "test-secret",
+    fetcher,
+  });
+}
+
+/**
+ * Build a synthetic id_token JWT with the given claims. Signature is a
+ * fixed placeholder — provider decodes unsafely (no verification).
+ */
+function makeIdToken(claims: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+    .toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims))
+    .toString("base64url");
+  // Signature placeholder — provider never validates.
+  const signature = "fake-signature";
+  return `${header}.${payload}.${signature}`;
+}
+
+function microsoftSuccessBody(opts: {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresIn?: number;
+  scope?: string;
+  idTokenClaims?: Record<string, unknown> | null;
+} = {}): Record<string, unknown> {
+  const claims = opts.idTokenClaims === null
+    ? null
+    : opts.idTokenClaims ?? {
+        tid: PERSONAL_MSA_TID,
+        oid: "user-object-id-1",
+        preferred_username: "alice@outlook.com",
+        email: "alice@outlook.com",
+      };
+  const body: Record<string, unknown> = {
+    access_token: opts.accessToken ?? "new-access",
+    refresh_token: opts.refreshToken ?? "new-refresh",
+    expires_in: opts.expiresIn ?? 3600,
+    token_type: "Bearer",
+    scope: opts.scope ?? "openid profile email offline_access User.Read",
+  };
+  if (claims !== null) {
+    body.id_token = makeIdToken(claims);
+  }
+  return body;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// refresh — success path
+// ────────────────────────────────────────────────────────────────────────
+
+describe("MicrosoftProvider.refresh — success", () => {
+  it("returns RefreshSuccess from a canned Microsoft 200 response", async () => {
+    const provider = makeProvider(stubFetcher(200, microsoftSuccessBody()));
+    const r = await provider.refresh({
+      refreshToken: "old-refresh",
+      accountEmail: "alice@outlook.com",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.accessToken).toBe("new-access");
+      expect(r.newRefreshToken).toBe("new-refresh");
+      const expectedMin = Date.now() + 3590_000;
+      const expectedMax = Date.now() + 3610_000;
+      expect(r.expiresAt).toBeGreaterThan(expectedMin);
+      expect(r.expiresAt).toBeLessThan(expectedMax);
+    }
+  });
+
+  it("populates MicrosoftCredentialsShape rawCredentials with personal MSA discriminator", async () => {
+    const provider = makeProvider(stubFetcher(200, microsoftSuccessBody({
+      idTokenClaims: {
+        tid: PERSONAL_MSA_TID,
+        oid: "personal-oid",
+        preferred_username: "alice@outlook.com",
+      },
+    })));
+    const r = await provider.refresh({
+      refreshToken: "old-refresh",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const creds = r.rawCredentials as {
+        microsoftOauth: {
+          tenantId: string;
+          accountType: string;
+          homeAccountId: string;
+          accountEmail: string;
+        };
+      };
+      expect(creds.microsoftOauth.tenantId).toBe(PERSONAL_MSA_TID);
+      expect(creds.microsoftOauth.accountType).toBe("personal");
+      expect(creds.microsoftOauth.homeAccountId).toBe(`personal-oid.${PERSONAL_MSA_TID}`);
+      expect(creds.microsoftOauth.accountEmail).toBe("alice@outlook.com");
+    }
+  });
+
+  it("populates work account discriminator when tid is a real tenant GUID", async () => {
+    const provider = makeProvider(stubFetcher(200, microsoftSuccessBody({
+      idTokenClaims: {
+        tid: WORK_TENANT_TID,
+        oid: "work-oid",
+        preferred_username: "alice@contoso.com",
+      },
+    })));
+    const r = await provider.refresh({ refreshToken: "old-refresh" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const creds = r.rawCredentials as {
+        microsoftOauth: { tenantId: string; accountType: string };
+      };
+      expect(creds.microsoftOauth.tenantId).toBe(WORK_TENANT_TID);
+      expect(creds.microsoftOauth.accountType).toBe("work");
+    }
+  });
+
+  it("preserves the OLD refresh token when Microsoft omits a new one", async () => {
+    const provider = makeProvider(stubFetcher(200, {
+      access_token: "new-access",
+      // No refresh_token field — Microsoft normally rotates, but
+      // handle the omitted case defensively.
+      expires_in: 3600,
+      token_type: "Bearer",
+      scope: "openid offline_access",
+    }));
+    const r = await provider.refresh({
+      refreshToken: "kept-refresh",
+      accountEmail: "alice@outlook.com",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.newRefreshToken).toBeUndefined();
+      const creds = r.rawCredentials as {
+        microsoftOauth: { refreshToken: string };
+      };
+      expect(creds.microsoftOauth.refreshToken).toBe("kept-refresh");
+    }
+  });
+
+  it("falls back to req.accountEmail when id_token has no preferred_username", async () => {
+    const provider = makeProvider(stubFetcher(200, microsoftSuccessBody({
+      idTokenClaims: { tid: PERSONAL_MSA_TID, oid: "no-username-oid" },
+    })));
+    const r = await provider.refresh({
+      refreshToken: "old-refresh",
+      accountEmail: "fallback@example.com",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const creds = r.rawCredentials as {
+        microsoftOauth: { accountEmail: string };
+      };
+      expect(creds.microsoftOauth.accountEmail).toBe("fallback@example.com");
+    }
+  });
+
+  it("handles missing id_token defensively (placeholder fields)", async () => {
+    const provider = makeProvider(stubFetcher(200, microsoftSuccessBody({
+      idTokenClaims: null,
+    })));
+    const r = await provider.refresh({
+      refreshToken: "old-refresh",
+      accountEmail: "alice@outlook.com",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const creds = r.rawCredentials as {
+        microsoftOauth: { tenantId: string; accountType: string };
+      };
+      // Without id_token we can't discriminate — defaults to "work"
+      // with empty tenantId. Broker has original credentials.json on
+      // disk with the canonical values from account-add time.
+      expect(creds.microsoftOauth.tenantId).toBe("");
+      expect(creds.microsoftOauth.accountType).toBe("work");
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// refresh — error classification
+// ────────────────────────────────────────────────────────────────────────
+
+describe("MicrosoftProvider.refresh — error classification", () => {
+  it("maps Microsoft invalid_grant to RefreshErrorKind invalid_grant", async () => {
+    const provider = makeProvider(stubFetcher(400, {
+      error: "invalid_grant",
+      error_description: "AADSTS70008: The refresh token has expired",
+    }));
+    const r = await provider.refresh({ refreshToken: "stale" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.kind).toBe("invalid_grant");
+      expect(r.detail).toContain("AADSTS70008");
+    }
+  });
+
+  it("maps 429 to quota_exceeded", async () => {
+    const provider = makeProvider(stubFetcher(429, {
+      error: "temporarily_unavailable",
+      error_description: "Too many requests",
+    }));
+    const r = await provider.refresh({ refreshToken: "old" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("quota_exceeded");
+  });
+
+  it("maps AADSTS50196 throttling to quota_exceeded", async () => {
+    const provider = makeProvider(stubFetcher(429, {
+      error: "rate_limit",
+      error_description: "AADSTS50196: too many requests for this client",
+    }));
+    const r = await provider.refresh({ refreshToken: "old" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("quota_exceeded");
+  });
+
+  it("maps ETIMEDOUT network failures to network", async () => {
+    const provider = makeProvider(failingFetcher("ETIMEDOUT: connect timed out"));
+    const r = await provider.refresh({ refreshToken: "old" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("network");
+  });
+
+  it("maps fetch failed to network", async () => {
+    const provider = makeProvider(failingFetcher("fetch failed"));
+    const r = await provider.refresh({ refreshToken: "old" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.kind).toBe("network");
+  });
+
+  it("maps unknown error responses to provider_error with raw detail", async () => {
+    const provider = makeProvider(stubFetcher(500, {
+      error: "unknown_error",
+      error_description: "Internal server error",
+    }));
+    const r = await provider.refresh({ refreshToken: "old" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.kind).toBe("provider_error");
+      expect(r.detail).toContain("500");
+    }
+  });
+
+  it("rejects empty refreshToken before hitting the network", async () => {
+    const provider = makeProvider(stubFetcher(200, {}));
+    const r = await provider.refresh({ refreshToken: "" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.kind).toBe("provider_error");
+      expect(r.detail).toContain("refreshToken is required");
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// extractExpiresAt
+// ────────────────────────────────────────────────────────────────────────
+
+describe("MicrosoftProvider.extractExpiresAt", () => {
+  const provider = new MicrosoftProvider({ clientId: "test-id" });
+
+  it("returns expiresAt from microsoftOauth", () => {
+    expect(
+      provider.extractExpiresAt({
+        microsoftOauth: { expiresAt: 1234567890 },
+      }),
+    ).toBe(1234567890);
+  });
+
+  it("returns undefined for missing microsoftOauth", () => {
+    expect(provider.extractExpiresAt({})).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(provider.extractExpiresAt(null)).toBeUndefined();
+  });
+
+  it("does NOT return expiresAt from googleOauth (provider isolation)", () => {
+    expect(
+      provider.extractExpiresAt({
+        googleOauth: { expiresAt: 9999999999 },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// validateCredentialShape
+// ────────────────────────────────────────────────────────────────────────
+
+describe("MicrosoftProvider.validateCredentialShape", () => {
+  const provider = new MicrosoftProvider({ clientId: "test-id" });
+  const valid = {
+    microsoftOauth: {
+      accessToken: "at",
+      refreshToken: "rt",
+      expiresAt: Date.now() + 3600_000,
+      scope: "openid profile email offline_access",
+      clientId: "test-id",
+      accountEmail: "alice@outlook.com",
+      tokenType: "Bearer" as const,
+      tenantId: PERSONAL_MSA_TID,
+      accountType: "personal" as const,
+      homeAccountId: `oid.${PERSONAL_MSA_TID}`,
+    },
+  };
+
+  it("accepts valid Microsoft credentials", () => {
+    expect(provider.validateCredentialShape(valid)).toBeNull();
+  });
+
+  it("rejects non-object input", () => {
+    expect(provider.validateCredentialShape("not-an-object"))
+      .toContain("must be an object");
+    expect(provider.validateCredentialShape(null))
+      .toContain("must be an object");
+  });
+
+  it("rejects missing microsoftOauth", () => {
+    expect(provider.validateCredentialShape({}))
+      .toContain("must have a microsoftOauth object");
+  });
+
+  it("rejects missing accessToken with field-name in error", () => {
+    const bad = {
+      microsoftOauth: { ...valid.microsoftOauth, accessToken: undefined },
+    };
+    expect(provider.validateCredentialShape(bad))
+      .toContain("microsoftOauth.accessToken is required");
+  });
+
+  it("rejects missing tenantId", () => {
+    const bad = {
+      microsoftOauth: { ...valid.microsoftOauth, tenantId: undefined },
+    };
+    expect(provider.validateCredentialShape(bad))
+      .toContain("microsoftOauth.tenantId is required");
+  });
+
+  it("rejects missing homeAccountId", () => {
+    const bad = {
+      microsoftOauth: { ...valid.microsoftOauth, homeAccountId: undefined },
+    };
+    expect(provider.validateCredentialShape(bad))
+      .toContain("microsoftOauth.homeAccountId is required");
+  });
+
+  it("rejects empty accessToken", () => {
+    const bad = {
+      microsoftOauth: { ...valid.microsoftOauth, accessToken: "" },
+    };
+    expect(provider.validateCredentialShape(bad))
+      .toContain("non-empty string");
+  });
+
+  it("rejects non-positive expiresAt", () => {
+    const bad = {
+      microsoftOauth: { ...valid.microsoftOauth, expiresAt: 0 },
+    };
+    expect(provider.validateCredentialShape(bad))
+      .toContain("positive unix-ms timestamp");
+  });
+
+  it("rejects wrong tokenType", () => {
+    const bad = {
+      microsoftOauth: { ...valid.microsoftOauth, tokenType: "Mac" },
+    };
+    expect(provider.validateCredentialShape(bad))
+      .toContain("'Bearer'");
+  });
+
+  it("rejects invalid accountType discriminator", () => {
+    const bad = {
+      microsoftOauth: { ...valid.microsoftOauth, accountType: "consumer" },
+    };
+    expect(provider.validateCredentialShape(bad))
+      .toContain("'personal' or 'work'");
+  });
+
+  it("rejects Google-shaped credentials (provider isolation)", () => {
+    expect(provider.validateCredentialShape({
+      googleOauth: { accessToken: "x", refreshToken: "y" },
+    })).toContain("must have a microsoftOauth object");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Provider interface contract
+// ────────────────────────────────────────────────────────────────────────
+
+describe("MicrosoftProvider — Provider interface contract", () => {
+  it("has name === 'microsoft'", () => {
+    const provider = new MicrosoftProvider({ clientId: "test-id" });
+    expect(provider.name).toBe("microsoft");
+  });
+});

--- a/src/auth/broker/microsoft-provider.test.ts
+++ b/src/auth/broker/microsoft-provider.test.ts
@@ -198,7 +198,52 @@ describe("MicrosoftProvider.refresh — success", () => {
     }
   });
 
-  it("handles missing id_token defensively (placeholder fields)", async () => {
+  it("preserves canonical identity fields from priorCredentials when id_token is absent", async () => {
+    const provider = makeProvider(stubFetcher(200, microsoftSuccessBody({
+      idTokenClaims: null,
+    })));
+    const r = await provider.refresh({
+      refreshToken: "old-refresh",
+      accountEmail: "alice@outlook.com",
+      priorCredentials: {
+        microsoftOauth: {
+          accessToken: "old-at",
+          refreshToken: "old-refresh",
+          expiresAt: 1,
+          scope: "openid",
+          clientId: "test-client-id",
+          accountEmail: "alice@outlook.com",
+          tokenType: "Bearer",
+          tenantId: PERSONAL_MSA_TID,
+          accountType: "personal",
+          homeAccountId: `original-oid.${PERSONAL_MSA_TID}`,
+        },
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const creds = r.rawCredentials as {
+        microsoftOauth: {
+          tenantId: string;
+          accountType: string;
+          homeAccountId: string;
+          accountEmail: string;
+        };
+      };
+      // Without id_token, fall back to prior — canonical fields
+      // preserved across refresh, not clobbered with empty
+      // placeholders.
+      expect(creds.microsoftOauth.tenantId).toBe(PERSONAL_MSA_TID);
+      expect(creds.microsoftOauth.accountType).toBe("personal");
+      expect(creds.microsoftOauth.homeAccountId).toBe(`original-oid.${PERSONAL_MSA_TID}`);
+      expect(creds.microsoftOauth.accountEmail).toBe("alice@outlook.com");
+    }
+  });
+
+  it("falls back to empty placeholders when both id_token AND priorCredentials are absent", async () => {
+    // Defensive case — should never happen in practice (broker always
+    // passes priorCredentials when refreshing existing accounts), but
+    // verify the safe-default behavior.
     const provider = makeProvider(stubFetcher(200, microsoftSuccessBody({
       idTokenClaims: null,
     })));
@@ -211,10 +256,43 @@ describe("MicrosoftProvider.refresh — success", () => {
       const creds = r.rawCredentials as {
         microsoftOauth: { tenantId: string; accountType: string };
       };
-      // Without id_token we can't discriminate — defaults to "work"
-      // with empty tenantId. Broker has original credentials.json on
-      // disk with the canonical values from account-add time.
       expect(creds.microsoftOauth.tenantId).toBe("");
+      expect(creds.microsoftOauth.accountType).toBe("work");
+    }
+  });
+
+  it("id_token claims override prior credentials (fresh truth wins)", async () => {
+    const WORK_TENANT = "11111111-2222-3333-4444-555555555555";
+    const provider = makeProvider(stubFetcher(200, microsoftSuccessBody({
+      idTokenClaims: {
+        tid: WORK_TENANT,
+        oid: "new-oid",
+        preferred_username: "alice@contoso.com",
+      },
+    })));
+    const r = await provider.refresh({
+      refreshToken: "old-refresh",
+      priorCredentials: {
+        microsoftOauth: {
+          accessToken: "old-at",
+          refreshToken: "old-refresh",
+          expiresAt: 1,
+          scope: "openid",
+          clientId: "test-client-id",
+          accountEmail: "stale@example.com",
+          tokenType: "Bearer",
+          tenantId: PERSONAL_MSA_TID,
+          accountType: "personal",
+          homeAccountId: `old-oid.${PERSONAL_MSA_TID}`,
+        },
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      const creds = r.rawCredentials as {
+        microsoftOauth: { tenantId: string; accountType: string };
+      };
+      expect(creds.microsoftOauth.tenantId).toBe(WORK_TENANT);
       expect(creds.microsoftOauth.accountType).toBe("work");
     }
   });

--- a/src/auth/broker/microsoft-provider.ts
+++ b/src/auth/broker/microsoft-provider.ts
@@ -109,17 +109,22 @@ export class MicrosoftProvider implements Provider {
 
     const expiresAt = Date.now() + token.expires_in * 1000;
 
-    // Extract tenant + account context. Refresh exchanges don't always
-    // return an id_token (Microsoft includes one when `openid` was in
-    // the original consent's scope set; switchroom v1 always includes
-    // openid, so we expect it here). If id_token is absent or
-    // malformed, fall back to placeholder values — the broker still
-    // has the original credentials.json on disk with the canonical
-    // tenant/account fields from account-add time.
-    let tenantId = "";
-    let accountType: "personal" | "work" = "work";
-    let homeAccountId = "";
-    let accountEmail = req.accountEmail ?? "";
+    // Pull canonical identity fields from id_token claims when present.
+    // **Critical** — Microsoft's v2 endpoint may omit `id_token` on
+    // refresh responses (e.g. under certain scope-narrowing flows, or
+    // if Microsoft changes the response shape). When id_token is
+    // absent or malformed, fall through to `req.priorCredentials` to
+    // preserve the canonical values written at account-add time. The
+    // broker writes `rawCredentials` verbatim — if we returned empty
+    // placeholders the operator's real tenantId/homeAccountId/
+    // accountType would be clobbered. Earlier draft of this provider
+    // had that defect; PR 1 review caught it.
+    const prior = (req.priorCredentials as MicrosoftCredentialsShape | undefined)
+      ?.microsoftOauth;
+    let tenantId = prior?.tenantId ?? "";
+    let accountType: "personal" | "work" = prior?.accountType ?? "work";
+    let homeAccountId = prior?.homeAccountId ?? "";
+    let accountEmail = req.accountEmail ?? prior?.accountEmail ?? "";
     if (token.id_token) {
       const claims = decodeJwtPayloadUnsafe(token.id_token);
       if (claims) {

--- a/src/auth/broker/microsoft-provider.ts
+++ b/src/auth/broker/microsoft-provider.ts
@@ -1,0 +1,256 @@
+/**
+ * MicrosoftProvider — Provider implementation for Microsoft OAuth
+ * (RFC #1873, PR 1).
+ *
+ * Wraps `src/microsoft/oauth.ts:refreshMicrosoftAccessToken` as a
+ * Provider. Mirrors GoogleProvider's shape: HTTP refresh against
+ * Microsoft's v2 `/token` endpoint, error mapping, credential
+ * extraction.
+ *
+ * **What this provider owns:**
+ *   - HTTP refresh exchange against Microsoft's `/common` v2 endpoint
+ *   - Microsoft-specific error mapping (`invalid_grant` for revoked
+ *     RT / password change / app un-consent; rate-limit detection;
+ *     429 from Graph throttling)
+ *   - Credential shape (`microsoftOauth: { ... }` per protocol.ts —
+ *     richer than Google's because we persist tenant + account-type
+ *     discriminators)
+ *   - Expiry extraction from `microsoftOauth.expiresAt`
+ *
+ * **What the broker owns:**
+ *   - On-disk persistence (`microsoft-storage.ts`)
+ *   - Refresh leases (one in-flight refresh per account)
+ *   - Drift detection / ACL / fanout
+ *
+ * **Refresh token rotation**: Microsoft v2 rotates RTs every successful
+ * exchange. Provider returns `newRefreshToken` on every success;
+ * broker writes the new RT atomically (storage.ts atomic-rename
+ * pattern handles torn-write recovery).
+ */
+
+import {
+  classifyAccountType,
+  decodeJwtPayloadUnsafe,
+  MicrosoftInvalidGrantError,
+  refreshMicrosoftAccessToken,
+  type MicrosoftOAuthClientConfig,
+  type MicrosoftTokenResponse,
+} from "../../microsoft/oauth.js";
+import type { Provider, RefreshRequest, RefreshResult } from "./provider.js";
+import type { MicrosoftCredentialsShape } from "./protocol.js";
+
+/**
+ * Construction options. The OAuth client id (+ optional secret) are
+ * passed in by the broker — they're per-install config sourced from
+ * the `microsoft_workspace.microsoft_client_id` / `_secret` config
+ * block.
+ *
+ * Public-client flows (loopback + PKCE, device-code) don't strictly
+ * need a secret — for switchroom v1 we accept either shape so the
+ * operator can pick. The refresh exchange passes the secret only when
+ * present.
+ */
+export interface MicrosoftProviderOptions {
+  /** Microsoft OAuth application (client) ID from Entra portal. */
+  clientId: string;
+  /**
+   * Optional client secret. Public-client apps (Mobile + Desktop
+   * platform with "Allow public client flows") work without a secret;
+   * confidential clients pass one. The refresh exchange includes it
+   * in the form body only when non-empty.
+   */
+  clientSecret?: string;
+  /**
+   * Injectable fetch — tests pass a stub that returns canned Microsoft
+   * token-endpoint responses. Defaults to global fetch.
+   */
+  fetcher?: typeof fetch;
+}
+
+export class MicrosoftProvider implements Provider {
+  readonly name = "microsoft" as const;
+
+  constructor(private readonly opts: MicrosoftProviderOptions) {}
+
+  async refresh(req: RefreshRequest): Promise<RefreshResult> {
+    if (!req.refreshToken) {
+      return {
+        ok: false,
+        kind: "provider_error",
+        detail: "MicrosoftProvider.refresh: refreshToken is required",
+      };
+    }
+    const cfg: MicrosoftOAuthClientConfig = {
+      client_id: this.opts.clientId,
+      client_secret: this.opts.clientSecret,
+      // Don't narrow scopes on refresh — let Microsoft return the
+      // intersection of previously-consented + the empty request,
+      // which is the full consented set. PR 2 / launcher does scope
+      // shaping at account-add time, not at refresh time.
+      scopes: [],
+    };
+    let token: MicrosoftTokenResponse;
+    try {
+      token = await refreshMicrosoftAccessToken(
+        cfg,
+        req.refreshToken,
+        this.opts.fetcher ?? fetch,
+      );
+    } catch (err) {
+      if (err instanceof MicrosoftInvalidGrantError) {
+        return {
+          ok: false,
+          kind: "invalid_grant",
+          detail: err.message,
+        };
+      }
+      return classifyAsyncError(err);
+    }
+
+    const expiresAt = Date.now() + token.expires_in * 1000;
+
+    // Extract tenant + account context. Refresh exchanges don't always
+    // return an id_token (Microsoft includes one when `openid` was in
+    // the original consent's scope set; switchroom v1 always includes
+    // openid, so we expect it here). If id_token is absent or
+    // malformed, fall back to placeholder values — the broker still
+    // has the original credentials.json on disk with the canonical
+    // tenant/account fields from account-add time.
+    let tenantId = "";
+    let accountType: "personal" | "work" = "work";
+    let homeAccountId = "";
+    let accountEmail = req.accountEmail ?? "";
+    if (token.id_token) {
+      const claims = decodeJwtPayloadUnsafe(token.id_token);
+      if (claims) {
+        if (typeof claims.tid === "string") tenantId = claims.tid;
+        if (tenantId) accountType = classifyAccountType(tenantId);
+        if (typeof claims.oid === "string" && typeof claims.tid === "string") {
+          homeAccountId = `${claims.oid}.${claims.tid}`;
+        }
+        if (typeof claims.preferred_username === "string") {
+          accountEmail = claims.preferred_username;
+        } else if (typeof claims.email === "string") {
+          accountEmail = claims.email;
+        }
+      }
+    }
+
+    const rawCredentials: MicrosoftCredentialsShape = {
+      microsoftOauth: {
+        accessToken: token.access_token,
+        refreshToken: token.refresh_token ?? req.refreshToken,
+        expiresAt,
+        scope: token.scope ?? "",
+        clientId: this.opts.clientId,
+        accountEmail,
+        tokenType: "Bearer",
+        tenantId,
+        accountType,
+        homeAccountId,
+      },
+    };
+
+    return {
+      ok: true,
+      accessToken: token.access_token,
+      expiresAt,
+      newRefreshToken: token.refresh_token,
+      rawCredentials,
+    };
+  }
+
+  /**
+   * Extract expiry from Microsoft credentials. Returns undefined for
+   * malformed / missing — broker treats undefined as "needs immediate
+   * refresh."
+   */
+  extractExpiresAt(credentials: unknown): number | undefined {
+    const c = credentials as MicrosoftCredentialsShape | null | undefined;
+    return c?.microsoftOauth?.expiresAt;
+  }
+
+  /**
+   * Validate the on-disk shape Microsoft credentials must conform to.
+   * Returns null on success; an actionable error string on failure.
+   *
+   * Mirrors MicrosoftCredentialsSchema in protocol.ts but with
+   * actionable messages — at this layer we know we're validating an
+   * operator-or-OAuth-flow input.
+   */
+  validateCredentialShape(credentials: unknown): string | null {
+    if (!credentials || typeof credentials !== "object") {
+      return "Microsoft credentials must be an object";
+    }
+    const c = credentials as { microsoftOauth?: unknown };
+    if (!c.microsoftOauth || typeof c.microsoftOauth !== "object") {
+      return "Microsoft credentials must have a microsoftOauth object";
+    }
+    const oauth = c.microsoftOauth as Record<string, unknown>;
+    const required = [
+      "accessToken",
+      "refreshToken",
+      "expiresAt",
+      "scope",
+      "clientId",
+      "accountEmail",
+      "tenantId",
+      "accountType",
+      "homeAccountId",
+    ];
+    for (const field of required) {
+      if (oauth[field] === undefined || oauth[field] === null) {
+        return `Microsoft microsoftOauth.${field} is required`;
+      }
+    }
+    if (typeof oauth.accessToken !== "string" || oauth.accessToken.length === 0) {
+      return "Microsoft microsoftOauth.accessToken must be a non-empty string";
+    }
+    if (typeof oauth.refreshToken !== "string" || oauth.refreshToken.length === 0) {
+      return "Microsoft microsoftOauth.refreshToken must be a non-empty string";
+    }
+    if (typeof oauth.expiresAt !== "number" || oauth.expiresAt <= 0) {
+      return "Microsoft microsoftOauth.expiresAt must be a positive unix-ms timestamp";
+    }
+    if (oauth.tokenType !== "Bearer") {
+      return "Microsoft microsoftOauth.tokenType must be 'Bearer'";
+    }
+    if (oauth.accountType !== "personal" && oauth.accountType !== "work") {
+      return "Microsoft microsoftOauth.accountType must be 'personal' or 'work'";
+    }
+    return null;
+  }
+}
+
+/**
+ * Map non-InvalidGrant errors from Microsoft's OAuth endpoint to the
+ * broker's RefreshErrorKind discriminant.
+ *
+ * Microsoft error patterns:
+ *   - 429 / "too many requests" / "AADSTS50196" (throttled) → quota_exceeded
+ *   - ETIMEDOUT / ECONNRESET / fetch failed → network
+ *   - everything else → provider_error
+ */
+function classifyAsyncError(err: unknown): RefreshResult {
+  const msg = err instanceof Error ? err.message : String(err);
+  const lower = msg.toLowerCase();
+  if (
+    lower.includes("etimedout") ||
+    lower.includes("econnreset") ||
+    lower.includes("network") ||
+    lower.includes("fetch failed") ||
+    lower.includes("getaddrinfo")
+  ) {
+    return { ok: false, kind: "network", detail: msg };
+  }
+  if (
+    lower.includes("429") ||
+    lower.includes("rate") ||
+    lower.includes("quota") ||
+    lower.includes("too many requests") ||
+    lower.includes("aadsts50196")
+  ) {
+    return { ok: false, kind: "quota_exceeded", detail: msg };
+  }
+  return { ok: false, kind: "provider_error", detail: msg };
+}

--- a/src/auth/broker/microsoft-storage.test.ts
+++ b/src/auth/broker/microsoft-storage.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for microsoft-storage — RFC #1873 PR 1.
+ *
+ * Mirrors `google-storage.test.ts` shape: tmpdir stateDir, real
+ * filesystem (no mocking). Covers normalize / validate / read / write /
+ * remove / list.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  listMicrosoftAccounts,
+  microsoftAccountCredentialsPath,
+  microsoftAccountDir,
+  microsoftAccountExists,
+  normalizeMicrosoftAccountForStorage,
+  readMicrosoftAccountCredentials,
+  removeMicrosoftAccount,
+  validateMicrosoftAccountLabel,
+  writeMicrosoftAccountCredentials,
+} from "./microsoft-storage.js";
+import type { MicrosoftCredentialsShape } from "./protocol.js";
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "microsoft-storage-test-"));
+});
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+const PERSONAL_MSA_TID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+
+const sampleCreds: MicrosoftCredentialsShape = {
+  microsoftOauth: {
+    accessToken: "at-x",
+    refreshToken: "rt-x",
+    expiresAt: Date.now() + 3600_000,
+    scope: "openid profile email offline_access User.Read Mail.ReadWrite",
+    clientId: "client-id-x",
+    accountEmail: "alice@outlook.com",
+    tokenType: "Bearer",
+    tenantId: PERSONAL_MSA_TID,
+    accountType: "personal",
+    homeAccountId: `oid-x.${PERSONAL_MSA_TID}`,
+  },
+};
+
+describe("normalizeMicrosoftAccountForStorage", () => {
+  it("lowercases + trims", () => {
+    expect(normalizeMicrosoftAccountForStorage("  Alice@Outlook.COM "))
+      .toBe("alice@outlook.com");
+  });
+});
+
+describe("paths", () => {
+  it("microsoftAccountDir is <stateDir>/microsoft/<normalized-account>/", () => {
+    const dir = microsoftAccountDir(stateDir, "Alice@Outlook.com");
+    expect(dir).toBe(join(stateDir, "microsoft", "alice@outlook.com"));
+  });
+
+  it("microsoftAccountCredentialsPath appends credentials.json", () => {
+    const path = microsoftAccountCredentialsPath(stateDir, "alice@outlook.com");
+    expect(path).toBe(join(stateDir, "microsoft", "alice@outlook.com", "credentials.json"));
+  });
+});
+
+describe("write + read round-trip", () => {
+  it("write creates the dir + file, read returns the credentials verbatim", () => {
+    const path = writeMicrosoftAccountCredentials(stateDir, "alice@outlook.com", sampleCreds);
+    expect(existsSync(path)).toBe(true);
+    const back = readMicrosoftAccountCredentials(stateDir, "alice@outlook.com");
+    expect(back).toEqual(sampleCreds);
+  });
+
+  it("writes credentials.json with mode 0600", () => {
+    const path = writeMicrosoftAccountCredentials(stateDir, "alice@outlook.com", sampleCreds);
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("normalization makes case-variant reads hit the same file", () => {
+    writeMicrosoftAccountCredentials(stateDir, "ALICE@OUTLOOK.COM", sampleCreds);
+    const back = readMicrosoftAccountCredentials(stateDir, "alice@outlook.com");
+    expect(back).toEqual(sampleCreds);
+  });
+
+  it("overwrites existing credentials atomically", () => {
+    writeMicrosoftAccountCredentials(stateDir, "alice@outlook.com", sampleCreds);
+    const newer: MicrosoftCredentialsShape = {
+      microsoftOauth: {
+        ...sampleCreds.microsoftOauth,
+        accessToken: "at-new",
+        refreshToken: "rt-new",
+      },
+    };
+    writeMicrosoftAccountCredentials(stateDir, "alice@outlook.com", newer);
+    const back = readMicrosoftAccountCredentials(stateDir, "alice@outlook.com");
+    expect(back?.microsoftOauth.accessToken).toBe("at-new");
+    expect(back?.microsoftOauth.refreshToken).toBe("rt-new");
+  });
+});
+
+describe("read returns null for missing/malformed", () => {
+  it("returns null when credentials.json is absent", () => {
+    expect(readMicrosoftAccountCredentials(stateDir, "missing@outlook.com"))
+      .toBeNull();
+  });
+
+  it("returns null when JSON is malformed", () => {
+    const path = microsoftAccountCredentialsPath(stateDir, "broken@outlook.com");
+    mkdirSync(microsoftAccountDir(stateDir, "broken@outlook.com"), { recursive: true });
+    writeFileSync(path, "{ not valid json");
+    expect(readMicrosoftAccountCredentials(stateDir, "broken@outlook.com"))
+      .toBeNull();
+  });
+
+  it("returns null when shape lacks microsoftOauth.accessToken", () => {
+    const path = microsoftAccountCredentialsPath(stateDir, "noshape@outlook.com");
+    mkdirSync(microsoftAccountDir(stateDir, "noshape@outlook.com"), { recursive: true });
+    writeFileSync(path, JSON.stringify({ microsoftOauth: { refreshToken: "rt" } }));
+    expect(readMicrosoftAccountCredentials(stateDir, "noshape@outlook.com"))
+      .toBeNull();
+  });
+});
+
+describe("microsoftAccountExists", () => {
+  it("false before write, true after, false after remove", () => {
+    expect(microsoftAccountExists(stateDir, "alice@outlook.com")).toBe(false);
+    writeMicrosoftAccountCredentials(stateDir, "alice@outlook.com", sampleCreds);
+    expect(microsoftAccountExists(stateDir, "alice@outlook.com")).toBe(true);
+    removeMicrosoftAccount(stateDir, "alice@outlook.com");
+    expect(microsoftAccountExists(stateDir, "alice@outlook.com")).toBe(false);
+  });
+});
+
+describe("removeMicrosoftAccount", () => {
+  it("removes the per-account directory", () => {
+    writeMicrosoftAccountCredentials(stateDir, "alice@outlook.com", sampleCreds);
+    expect(existsSync(microsoftAccountDir(stateDir, "alice@outlook.com"))).toBe(true);
+    removeMicrosoftAccount(stateDir, "alice@outlook.com");
+    expect(existsSync(microsoftAccountDir(stateDir, "alice@outlook.com"))).toBe(false);
+  });
+
+  it("idempotent — removing absent account is a no-op", () => {
+    expect(() => removeMicrosoftAccount(stateDir, "ghost@outlook.com")).not.toThrow();
+  });
+});
+
+describe("listMicrosoftAccounts", () => {
+  it("returns [] when state dir doesn't have a microsoft subdir", () => {
+    expect(listMicrosoftAccounts(stateDir)).toEqual([]);
+  });
+
+  it("returns all accounts that have credentials.json", () => {
+    writeMicrosoftAccountCredentials(stateDir, "alice@outlook.com", sampleCreds);
+    writeMicrosoftAccountCredentials(stateDir, "bob@contoso.com", sampleCreds);
+    const list = listMicrosoftAccounts(stateDir).sort();
+    expect(list).toEqual(["alice@outlook.com", "bob@contoso.com"]);
+  });
+
+  it("excludes dirs without credentials.json (defensive against half-removed state)", () => {
+    writeMicrosoftAccountCredentials(stateDir, "alice@outlook.com", sampleCreds);
+    // Create empty dir for an unwritten account
+    mkdirSync(join(stateDir, "microsoft", "half-removed@outlook.com"), { recursive: true });
+    const list = listMicrosoftAccounts(stateDir);
+    expect(list).toContain("alice@outlook.com");
+    expect(list).not.toContain("half-removed@outlook.com");
+  });
+});
+
+describe("validateMicrosoftAccountLabel", () => {
+  it("accepts valid email-shaped labels", () => {
+    expect(() => validateMicrosoftAccountLabel("alice@outlook.com")).not.toThrow();
+    expect(() => validateMicrosoftAccountLabel("bob.smith@contoso.com")).not.toThrow();
+    expect(() => validateMicrosoftAccountLabel("a@b.c")).not.toThrow();
+  });
+
+  it("rejects empty string", () => {
+    expect(() => validateMicrosoftAccountLabel("")).toThrow(/non-empty/);
+  });
+
+  it("rejects path-traversal sequences", () => {
+    expect(() => validateMicrosoftAccountLabel("../etc/passwd")).toThrow(/email shape/);
+    expect(() => validateMicrosoftAccountLabel("alice@../escape.com")).toThrow(/email shape/);
+  });
+
+  it("rejects forward and back slashes", () => {
+    expect(() => validateMicrosoftAccountLabel("alice/bob@outlook.com")).toThrow(/email shape/);
+    expect(() => validateMicrosoftAccountLabel("alice\\bob@outlook.com")).toThrow(/email shape/);
+  });
+
+  it("rejects leading/trailing whitespace", () => {
+    expect(() => validateMicrosoftAccountLabel(" alice@outlook.com")).toThrow(/whitespace/);
+    expect(() => validateMicrosoftAccountLabel("alice@outlook.com\t")).toThrow(/whitespace/);
+  });
+
+  it("rejects colons (broker slot-key separator)", () => {
+    expect(() => validateMicrosoftAccountLabel("alice:bob@outlook.com")).toThrow(/email shape/);
+  });
+
+  it("rejects null bytes", () => {
+    expect(() => validateMicrosoftAccountLabel("alice\0@outlook.com")).toThrow(/control characters/);
+  });
+
+  it("rejects non-string input", () => {
+    expect(() => validateMicrosoftAccountLabel(null as unknown as string)).toThrow(/non-empty/);
+    expect(() => validateMicrosoftAccountLabel(42 as unknown as string)).toThrow(/non-empty/);
+  });
+});

--- a/src/auth/broker/microsoft-storage.ts
+++ b/src/auth/broker/microsoft-storage.ts
@@ -1,0 +1,185 @@
+/**
+ * Microsoft credential storage for the auth-broker (RFC #1873).
+ *
+ * Mirrors `google-storage.ts` shape: per-account directories under the
+ * broker's state dir, atomic writes, idempotent removal. **Phase 1
+ * shortcut** matches Google's — credentials live on the broker's own
+ * filesystem under `~/.switchroom/state/auth-broker/microsoft/<account>/`
+ * rather than the vault-broker. Future work (mirroring RFC G's Phase
+ * 3b.2d follow-up) migrates to vault-broker-mediated storage uniformly
+ * across providers.
+ *
+ * Storage layout:
+ *
+ *   ~/.switchroom/state/auth-broker/microsoft/
+ *     ken@outlook.com/
+ *       credentials.json   ← `{ microsoftOauth: { ... } }`, mode 0600
+ *     ken@work.example.com/
+ *       credentials.json
+ *
+ * Account labels are normalized (lowercase + trim) — Microsoft account
+ * keys are `preferred_username` claims which are typically email-shaped
+ * but can be UPNs for work accounts (still email-shaped — UPN format
+ * is `<user>@<domain>`). The normalization rule is identical to
+ * Google's, allowing the same filesystem-safety contract.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+import { atomicWriteFileSync } from "../../util/atomic.js";
+import type { MicrosoftCredentialsShape } from "./protocol.js";
+
+/**
+ * Normalize an account label to the on-disk-safe form. Mirrors
+ * `normalizeGoogleAccountForStorage` so the same email resolves
+ * identically across providers.
+ */
+export function normalizeMicrosoftAccountForStorage(account: string): string {
+  return account.trim().toLowerCase();
+}
+
+/**
+ * Validate that an account label is safe to use as a filesystem path
+ * component before any fs op touches it. Same email-shape contract as
+ * Google: no path separators, no `..`, no whitespace, no `:` (broker's
+ * slot-key separator), no control characters.
+ *
+ * Microsoft's `preferred_username` claim is typically email-shaped but
+ * the v2 endpoint can return UPNs that don't strictly match an email
+ * regex (e.g. `alice_outlook.com#EXT#@aliceoutlook.onmicrosoft.com`
+ * for B2B guest accounts). For switchroom v1 we restrict to clean
+ * email shape — if guest-account UPNs come up in practice, the regex
+ * can be relaxed in a follow-up.
+ */
+export function validateMicrosoftAccountLabel(account: string): void {
+  if (typeof account !== "string" || account.length === 0) {
+    throw new Error(`Microsoft account label must be a non-empty string`);
+  }
+  if (account !== account.trim()) {
+    throw new Error(`Microsoft account label must not have leading/trailing whitespace`);
+  }
+  // Reject control characters — POSIX filenames reject null bytes,
+  // and the email-shape regex below would otherwise let `\x00@x.y`
+  // through.
+  if (/[\x00-\x1f\x7f]/.test(account)) {
+    throw new Error(
+      `Microsoft account label '${account.replace(/[\x00-\x1f\x7f]/g, "?")}' contains control characters; email shape rejects them.`,
+    );
+  }
+  if (!/^[^@\s:/\\]+@[^@\s:/\\]+\.[^@\s:/\\]+$/.test(account)) {
+    throw new Error(
+      `Microsoft account label '${account}' is not a valid email shape. Expected like 'alice@outlook.com' or 'alice@contoso.com' (no slashes, colons, or whitespace).`,
+    );
+  }
+}
+
+/**
+ * Resolve the per-account directory under the broker's state dir.
+ * Caller passes the broker's own stateDir (typically
+ * `~/.switchroom/state/auth-broker/`).
+ */
+export function microsoftAccountDir(stateDir: string, account: string): string {
+  return resolve(
+    stateDir,
+    "microsoft",
+    normalizeMicrosoftAccountForStorage(account),
+  );
+}
+
+export function microsoftAccountCredentialsPath(
+  stateDir: string,
+  account: string,
+): string {
+  return join(microsoftAccountDir(stateDir, account), "credentials.json");
+}
+
+/**
+ * Whether the per-account directory exists. Used by `add-account` to
+ * detect "account already exists" vs "first add."
+ */
+export function microsoftAccountExists(
+  stateDir: string,
+  account: string,
+): boolean {
+  return existsSync(microsoftAccountCredentialsPath(stateDir, account));
+}
+
+/**
+ * Read the per-account credentials.json. Returns null if absent or
+ * malformed (broker treats missing/malformed as "needs add-account").
+ */
+export function readMicrosoftAccountCredentials(
+  stateDir: string,
+  account: string,
+): MicrosoftCredentialsShape | null {
+  const path = microsoftAccountCredentialsPath(stateDir, account);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<MicrosoftCredentialsShape>;
+    if (!parsed?.microsoftOauth?.accessToken) return null;
+    return parsed as MicrosoftCredentialsShape;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write per-account credentials.json. Creates the parent dir if absent
+ * (mode 0700). File written via atomicWriteFileSync — survives
+ * concurrent readers.
+ *
+ * **Critical invariant**: Microsoft rotates refresh tokens every
+ * exchange. A torn write (process killed mid-write) loses the new RT
+ * and the old RT has already been invalidated by Microsoft. The atomic
+ * helper handles this via temp-file + rename.
+ *
+ * Returns the absolute path written.
+ */
+export function writeMicrosoftAccountCredentials(
+  stateDir: string,
+  account: string,
+  credentials: MicrosoftCredentialsShape,
+): string {
+  const path = microsoftAccountCredentialsPath(stateDir, account);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  atomicWriteFileSync(path, JSON.stringify(credentials, null, 2), 0o600);
+  return path;
+}
+
+/**
+ * Delete the per-account directory + credentials. Idempotent — no
+ * error if the account doesn't exist.
+ */
+export function removeMicrosoftAccount(stateDir: string, account: string): void {
+  const dir = microsoftAccountDir(stateDir, account);
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * List all Microsoft accounts the broker has stored. Used by the
+ * `list-microsoft-accounts` op (PR 2 will add the verb) + the refresh
+ * tick loop + doctor probes.
+ *
+ * Reads filesystem layout, not in-memory state — operators can drop a
+ * credentials.json by hand and the broker will pick it up on next read
+ * (same shape as Google + Anthropic).
+ */
+export function listMicrosoftAccounts(stateDir: string): string[] {
+  const root = join(stateDir, "microsoft");
+  if (!existsSync(root)) return [];
+  return readdirSync(root)
+    .filter((name) => {
+      try {
+        return statSync(join(root, name)).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .filter((name) =>
+      existsSync(join(root, name, "credentials.json")),
+    );
+}

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -57,7 +57,7 @@ export const PROTOCOL_VERSION = 1;
  * extend this enum; the broker server validates incoming `provider:`
  * fields against it before dispatching.
  */
-export const ProviderNameSchema = z.enum(["anthropic", "google"]);
+export const ProviderNameSchema = z.enum(["anthropic", "google", "microsoft"]);
 export type ProviderName = z.infer<typeof ProviderNameSchema>;
 
 /**
@@ -168,6 +168,57 @@ export const GoogleCredentialsSchema = z.object({
 export type GoogleCredentialsShape = z.infer<typeof GoogleCredentialsSchema>;
 
 /**
+ * Microsoft-shaped credentials — added by RFC #1873 (Microsoft 365
+ * integration). Stored verbatim under `microsoftOauth: { ... }`.
+ *
+ * Microsoft tokens carry more identity context than Google's because
+ * one OAuth app (`/common` endpoint, `AzureADandPersonalMicrosoftAccount`
+ * audience) can produce tokens for either personal MSA (`tid` =
+ * `9188040d-6c67-4c5b-b112-36a304b66dad`) or work/school tenants.
+ * Switchroom persists the discriminator (`accountType`) + the source
+ * tenant (`tenantId`) + the MSAL-style `homeAccountId` (`<oid>.<tid>`)
+ * alongside the token material so per-account state can be reasoned
+ * about without re-decoding the id_token on every read.
+ *
+ * Refresh tokens rotate every refresh (Microsoft v2 endpoint default);
+ * the broker writes the new RT atomically via `microsoft-storage.ts`
+ * after each successful exchange. Provider returns `newRefreshToken`
+ * on every successful refresh.
+ */
+export const MicrosoftCredentialsSchema = z.object({
+  microsoftOauth: z.object({
+    accessToken: z.string(),
+    refreshToken: z.string(),
+    expiresAt: z.number(),
+    /** Granted scope set, space-separated as Microsoft returns it. */
+    scope: z.string(),
+    /** OAuth client id used to obtain the credentials. */
+    clientId: z.string(),
+    /** preferred_username from id_token (email-shaped for both MSA and work). */
+    accountEmail: z.string(),
+    tokenType: z.literal("Bearer"),
+    /**
+     * `tid` claim from id_token. `9188040d-6c67-4c5b-b112-36a304b66dad`
+     * for personal MSA, a real tenant GUID for work/school.
+     */
+    tenantId: z.string(),
+    /** Derived from tenantId: convenience discriminator. */
+    accountType: z.enum(["personal", "work"]),
+    /** MSAL-style stable account key: `<oid>.<tid>`. */
+    homeAccountId: z.string(),
+  }),
+});
+export type MicrosoftCredentialsShape = z.infer<typeof MicrosoftCredentialsSchema>;
+
+/**
+ * Personal MSA tenant constant. Microsoft's documented well-known tid
+ * for all consumer Microsoft Accounts (outlook.com, hotmail.com,
+ * live.com, Xbox, Skype). Tokens minted for personal accounts always
+ * carry this exact tid; work/school tokens carry their org's tenant GUID.
+ */
+export const PERSONAL_MSA_TENANT_ID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+
+/**
  * Provider-discriminated credentials union. Each variant is the
  * verbatim on-disk shape for that provider. Broker stores credentials
  * pass-through; consumers (CLI, MCP wrapper) introspect.
@@ -175,6 +226,7 @@ export type GoogleCredentialsShape = z.infer<typeof GoogleCredentialsSchema>;
 export const ProviderCredentialsSchema = z.union([
   AnthropicCredentialsSchema,
   GoogleCredentialsSchema,
+  MicrosoftCredentialsSchema,
 ]);
 export type ProviderCredentialsShape = z.infer<typeof ProviderCredentialsSchema>;
 

--- a/src/auth/broker/provider.ts
+++ b/src/auth/broker/provider.ts
@@ -113,6 +113,17 @@ export interface RefreshRequest {
   clientId?: string;
   /** Scope set to request, when the provider re-asserts scopes per refresh. */
   scopes?: string[];
+  /**
+   * Prior on-disk credentials, if any. Microsoft uses this to preserve
+   * canonical identity fields (tenantId, accountType, homeAccountId)
+   * across refreshes — Microsoft's v2 endpoint may omit `id_token` on
+   * refresh responses under certain scope/account combinations, and
+   * without prior creds the provider would clobber canonical values
+   * with empty placeholders. Google + Anthropic ignore this field
+   * (their credential shape doesn't carry identity claims that the
+   * refresh response could fail to return).
+   */
+  priorCredentials?: unknown;
 }
 
 /**

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -51,6 +51,7 @@ import {
 } from "../account-refresh.js";
 import { AnthropicProvider } from "./anthropic-provider.js";
 import { GoogleProvider } from "./google-provider.js";
+import { MicrosoftProvider } from "./microsoft-provider.js";
 import {
   googleAccountExists,
   listGoogleAccounts,
@@ -311,6 +312,20 @@ export class AuthBroker {
         new GoogleProvider({
           clientId: googleClientId,
           clientSecret: googleClientSecret,
+          fetcher: opts.fetcher as typeof fetch | undefined,
+        }),
+      );
+    }
+    // RFC #1873 — Microsoft provider registers only when the
+    // microsoft_workspace block exists with a client id. client_secret is
+    // optional (public-client apps don't need one), so only client_id
+    // gates registration.
+    const microsoftClientId = config.microsoft_workspace?.microsoft_client_id;
+    if (microsoftClientId !== undefined) {
+      this.providers.register(
+        new MicrosoftProvider({
+          clientId: microsoftClientId,
+          clientSecret: config.microsoft_workspace?.microsoft_client_secret,
           fetcher: opts.fetcher as typeof fetch | undefined,
         }),
       );

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -892,6 +892,65 @@ export const GoogleWorkspaceConfigSchema = z
 export const DriveConfigSchema = GoogleWorkspaceConfigSchema;
 
 /**
+ * Top-level microsoft_workspace config block — RFC #1873 (Microsoft 365
+ * integration). Centralizes Microsoft OAuth client credentials and the
+ * org-mode opt-in.
+ *
+ * Block is optional — when omitted, the broker simply doesn't register
+ * the Microsoft provider, and any agent with `microsoft_workspace:` config
+ * gets a clear "MS not configured" error.
+ *
+ * The OAuth app is a single multi-tenant Entra registration with
+ * `signInAudience: AzureADandPersonalMicrosoftAccount` — one operator
+ * registration covers both personal MSA and M365 work accounts via the
+ * `/common` authority endpoint (per RFC §4.1).
+ */
+export const MicrosoftWorkspaceConfigSchema = z
+  .object({
+    microsoft_client_id: z
+      .string()
+      .min(1)
+      .describe(
+        "Microsoft OAuth application (client) ID from Entra portal " +
+        "(literal string or vault reference e.g. " +
+        "'vault:microsoft-oauth-client-id')."
+      ),
+    microsoft_client_secret: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Microsoft OAuth client secret. Optional — public-client apps " +
+        "(Mobile + Desktop platform with 'Allow public client flows' " +
+        "enabled) work without a secret; confidential clients pass " +
+        "one. Either literal or vault reference e.g. " +
+        "'vault:microsoft-oauth-client-secret'."
+      ),
+    authority: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Microsoft authority endpoint. Defaults to " +
+        "'https://login.microsoftonline.com/common' which accepts both " +
+        "personal MSA and work/school tenants. Override only for " +
+        "single-tenant deployments."
+      ),
+    org_mode: z
+      .boolean()
+      .optional()
+      .describe(
+        "Opt-in to Teams + SharePoint surfaces (RFC §6.4). When true, " +
+        "the v1 scope set adds Sites.ReadWrite.All AND the launcher " +
+        "spawns softeria with --org-mode. Defaults to false — personal " +
+        "MSA + standard work surfaces only. Flipping for an existing " +
+        "consented account requires re-running 'auth microsoft account " +
+        "add --replace' to consent the additional scope."
+      ),
+  })
+  .optional();
+
+/**
  * Per-agent google_workspace override. Currently just narrows the approver
  * set + lets the agent pick a tier different from the top-level default.
  * google_client_id/secret are not per-agent — those live at the top level
@@ -2207,6 +2266,13 @@ export const SwitchroomConfigSchema = z.object({
     "OAuth client credentials, approver allowlist, and tier knob (`core` " +
     "| `extended` | `complete`, default `core`). Mutually exclusive with " +
     "`drive:` at the top level (loader fails fast if both are set).",
+  ),
+  microsoft_workspace: MicrosoftWorkspaceConfigSchema.describe(
+    "RFC #1873 (Microsoft 365 integration). Top-level Microsoft Workspace " +
+    "configuration — OAuth client credentials (Entra app), authority " +
+    "endpoint (defaults to /common for personal MSA + work), and the " +
+    "org_mode opt-in for Teams/SharePoint surfaces. Block is optional; " +
+    "when omitted the broker does not register the Microsoft provider.",
   ),
   quota: QuotaConfigSchema.optional().describe(
     "Optional weekly/monthly USD spend budgets rendered in the session " +

--- a/src/microsoft/oauth.test.ts
+++ b/src/microsoft/oauth.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for src/microsoft/oauth.ts — RFC #1873 PR 1.
+ *
+ * Covers the OAuth primitives used by both the broker's refresh path
+ * and PR 2's account-add flow:
+ *   - refreshMicrosoftAccessToken: form-body construction, error mapping
+ *   - decodeJwtPayloadUnsafe: base64url decode, malformed-input tolerance
+ *   - classifyAccountType: tid → personal/work discriminator
+ *   - buildHomeAccountId: oid+tid composition
+ *   - generatePkcePair: shape + S256 challenge validation
+ */
+
+import { describe, expect, it } from "vitest";
+import * as crypto from "node:crypto";
+
+import {
+  buildHomeAccountId,
+  classifyAccountType,
+  decodeJwtPayloadUnsafe,
+  generatePkcePair,
+  MICROSOFT_OAUTH_BASE,
+  MicrosoftInvalidGrantError,
+  PERSONAL_MSA_TENANT_ID,
+  refreshMicrosoftAccessToken,
+} from "./oauth.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// refreshMicrosoftAccessToken
+// ────────────────────────────────────────────────────────────────────────
+
+function stubFetcher(status: number, body: unknown, capture?: {
+  url?: string;
+  body?: string;
+}): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (capture) {
+      capture.url = typeof input === "string" ? input : input.toString();
+      capture.body = init?.body as string | undefined;
+    }
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+describe("refreshMicrosoftAccessToken", () => {
+  it("hits Microsoft's v2 /common token endpoint", async () => {
+    const capture: { url?: string } = {};
+    await refreshMicrosoftAccessToken(
+      { client_id: "test-id", scopes: [] },
+      "old-refresh",
+      stubFetcher(200, {
+        access_token: "new",
+        expires_in: 3600,
+        token_type: "Bearer",
+      }, capture),
+    );
+    expect(capture.url).toBe(`${MICROSOFT_OAUTH_BASE}/token`);
+  });
+
+  it("builds correct refresh_token grant body", async () => {
+    const capture: { body?: string } = {};
+    await refreshMicrosoftAccessToken(
+      { client_id: "test-id", scopes: [] },
+      "old-refresh",
+      stubFetcher(200, { access_token: "x", expires_in: 3600, token_type: "Bearer" }, capture),
+    );
+    const params = new URLSearchParams(capture.body ?? "");
+    expect(params.get("client_id")).toBe("test-id");
+    expect(params.get("refresh_token")).toBe("old-refresh");
+    expect(params.get("grant_type")).toBe("refresh_token");
+  });
+
+  it("omits client_secret for public-client apps (no secret)", async () => {
+    const capture: { body?: string } = {};
+    await refreshMicrosoftAccessToken(
+      { client_id: "test-id", scopes: [] },
+      "old-refresh",
+      stubFetcher(200, { access_token: "x", expires_in: 3600, token_type: "Bearer" }, capture),
+    );
+    const params = new URLSearchParams(capture.body ?? "");
+    expect(params.get("client_secret")).toBeNull();
+  });
+
+  it("includes client_secret when provided (confidential client)", async () => {
+    const capture: { body?: string } = {};
+    await refreshMicrosoftAccessToken(
+      { client_id: "test-id", client_secret: "shh", scopes: [] },
+      "old-refresh",
+      stubFetcher(200, { access_token: "x", expires_in: 3600, token_type: "Bearer" }, capture),
+    );
+    const params = new URLSearchParams(capture.body ?? "");
+    expect(params.get("client_secret")).toBe("shh");
+  });
+
+  it("omits scope param when scopes array is empty (let Microsoft return full set)", async () => {
+    const capture: { body?: string } = {};
+    await refreshMicrosoftAccessToken(
+      { client_id: "test-id", scopes: [] },
+      "old",
+      stubFetcher(200, { access_token: "x", expires_in: 3600, token_type: "Bearer" }, capture),
+    );
+    const params = new URLSearchParams(capture.body ?? "");
+    expect(params.get("scope")).toBeNull();
+  });
+
+  it("includes space-joined scope when scopes array is non-empty", async () => {
+    const capture: { body?: string } = {};
+    await refreshMicrosoftAccessToken(
+      { client_id: "test-id", scopes: ["User.Read", "Mail.ReadWrite"] },
+      "old",
+      stubFetcher(200, { access_token: "x", expires_in: 3600, token_type: "Bearer" }, capture),
+    );
+    const params = new URLSearchParams(capture.body ?? "");
+    expect(params.get("scope")).toBe("User.Read Mail.ReadWrite");
+  });
+
+  it("throws MicrosoftInvalidGrantError on invalid_grant response", async () => {
+    await expect(refreshMicrosoftAccessToken(
+      { client_id: "id", scopes: [] },
+      "stale",
+      stubFetcher(400, {
+        error: "invalid_grant",
+        error_description: "AADSTS70008: refresh token expired",
+      }),
+    )).rejects.toThrow(MicrosoftInvalidGrantError);
+  });
+
+  it("throws generic Error for non-invalid_grant failures", async () => {
+    await expect(refreshMicrosoftAccessToken(
+      { client_id: "id", scopes: [] },
+      "old",
+      stubFetcher(500, { error: "server_error" }),
+    )).rejects.toThrow(/refresh failed \(500\)/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// decodeJwtPayloadUnsafe
+// ────────────────────────────────────────────────────────────────────────
+
+function makeJwt(claims: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" }))
+    .toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `${header}.${payload}.fake-signature`;
+}
+
+describe("decodeJwtPayloadUnsafe", () => {
+  it("decodes a well-formed JWT payload", () => {
+    const jwt = makeJwt({ tid: "abc", oid: "def", preferred_username: "x@y.z" });
+    const claims = decodeJwtPayloadUnsafe(jwt);
+    expect(claims).toEqual({ tid: "abc", oid: "def", preferred_username: "x@y.z" });
+  });
+
+  it("returns null for malformed JWT (wrong segment count)", () => {
+    expect(decodeJwtPayloadUnsafe("only.two")).toBeNull();
+    expect(decodeJwtPayloadUnsafe("a.b.c.d")).toBeNull();
+  });
+
+  it("returns null for invalid base64", () => {
+    expect(decodeJwtPayloadUnsafe("aaa.@@@.bbb")).toBeNull();
+  });
+
+  it("returns null for non-object JSON payload", () => {
+    const payload = Buffer.from(JSON.stringify("just a string")).toString("base64url");
+    const jwt = `header.${payload}.sig`;
+    expect(decodeJwtPayloadUnsafe(jwt)).toBeNull();
+  });
+
+  it("handles base64url padding correctly", () => {
+    // Payloads of various lengths to exercise the padding logic
+    for (const claims of [
+      { a: 1 },                           // short
+      { a: 1, b: 2, c: 3 },               // medium
+      { a: "x".repeat(100) },             // long
+    ]) {
+      const jwt = makeJwt(claims);
+      expect(decodeJwtPayloadUnsafe(jwt)).toEqual(claims);
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// classifyAccountType
+// ────────────────────────────────────────────────────────────────────────
+
+describe("classifyAccountType", () => {
+  it("returns 'personal' for the well-known MSA tenant", () => {
+    expect(classifyAccountType(PERSONAL_MSA_TENANT_ID)).toBe("personal");
+  });
+
+  it("returns 'work' for any other tenant GUID", () => {
+    expect(classifyAccountType("11111111-2222-3333-4444-555555555555")).toBe("work");
+  });
+
+  it("returns 'work' for empty string (defensive default)", () => {
+    expect(classifyAccountType("")).toBe("work");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// buildHomeAccountId
+// ────────────────────────────────────────────────────────────────────────
+
+describe("buildHomeAccountId", () => {
+  it("composes <oid>.<tid> when both present", () => {
+    expect(buildHomeAccountId({ oid: "user-oid", tid: "tenant-tid" }))
+      .toBe("user-oid.tenant-tid");
+  });
+
+  it("returns null when oid is missing", () => {
+    expect(buildHomeAccountId({ tid: "x" })).toBeNull();
+  });
+
+  it("returns null when tid is missing", () => {
+    expect(buildHomeAccountId({ oid: "x" })).toBeNull();
+  });
+
+  it("returns null when oid is empty string", () => {
+    expect(buildHomeAccountId({ oid: "", tid: "x" })).toBeNull();
+  });
+
+  it("returns null when oid is not a string", () => {
+    expect(buildHomeAccountId({ oid: 42, tid: "x" })).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// generatePkcePair
+// ────────────────────────────────────────────────────────────────────────
+
+describe("generatePkcePair", () => {
+  it("returns a verifier + challenge with non-empty shapes", () => {
+    const pair = generatePkcePair();
+    expect(pair.verifier.length).toBeGreaterThan(40);
+    expect(pair.challenge.length).toBeGreaterThan(20);
+  });
+
+  it("challenge is S256 of verifier (RFC 7636)", () => {
+    const pair = generatePkcePair();
+    const expected = crypto
+      .createHash("sha256")
+      .update(pair.verifier)
+      .digest("base64url");
+    expect(pair.challenge).toBe(expected);
+  });
+
+  it("generates different pairs on successive calls", () => {
+    const a = generatePkcePair();
+    const b = generatePkcePair();
+    expect(a.verifier).not.toBe(b.verifier);
+    expect(a.challenge).not.toBe(b.challenge);
+  });
+
+  it("uses URL-safe base64 (no +, /, or =)", () => {
+    const pair = generatePkcePair();
+    expect(pair.verifier).not.toMatch(/[+/=]/);
+    expect(pair.challenge).not.toMatch(/[+/=]/);
+  });
+});

--- a/src/microsoft/oauth.ts
+++ b/src/microsoft/oauth.ts
@@ -1,0 +1,196 @@
+/**
+ * Microsoft Graph OAuth exchanges — RFC #1873 (Microsoft 365 integration).
+ *
+ * Mirrors `src/drive/oauth.ts`'s shape: pure functions for URL/body
+ * construction + `*Exchange` helpers that hold the network I/O so tests
+ * can drive selector + polling logic without hitting Microsoft.
+ *
+ * **Design note — no MSAL-Node dep.** The RFC originally specified
+ * MSAL-Node, but the broker's `Provider.refresh()` contract is a
+ * one-shot exchange — MSAL's value (cache management, transparent
+ * rotation) doesn't manifest at this layer. Direct fetch against
+ * Microsoft's `/token` endpoint mirrors the Google + Anthropic
+ * providers' existing patterns, drops a dep, and is the same shape
+ * the operator's family-calendar app already uses. Refresh-token
+ * rotation is handled explicitly: every successful exchange returns
+ * the new RT as `newRefreshToken` so the broker can write it.
+ *
+ * **Endpoint shape:** v2.0 endpoint at `/common` authority — single
+ * URL handles both personal MSA and work/school tenants per the
+ * `AzureADandPersonalMicrosoftAccount` app registration audience.
+ */
+
+import * as crypto from "node:crypto";
+
+/**
+ * Microsoft's v2.0 OAuth/OIDC base. `/common` accepts both personal MSA
+ * tokens and work/school tokens; the audience is determined at app
+ * registration time, not at request time.
+ */
+export const MICROSOFT_OAUTH_BASE =
+  "https://login.microsoftonline.com/common/oauth2/v2.0";
+
+/**
+ * Personal MSA tenant constant — duplicated from
+ * `src/auth/broker/protocol.ts` so this module doesn't pull a circular
+ * dep on broker types. Microsoft's documented well-known `tid` for
+ * all consumer accounts.
+ */
+export const PERSONAL_MSA_TENANT_ID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+
+export interface MicrosoftTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  /** Lifetime in seconds (typically 3600). */
+  expires_in: number;
+  token_type: string;
+  /** Space-separated granted scopes. May differ from requested set. */
+  scope?: string;
+  /** OIDC id_token (only present when `openid` was in scope). */
+  id_token?: string;
+}
+
+export interface MicrosoftOAuthClientConfig {
+  client_id: string;
+  /**
+   * Optional. Public clients (Mobile and desktop applications platform
+   * with "Allow public client flows" enabled) don't need a secret —
+   * loopback + PKCE and device-code both work without it. Confidential
+   * clients pass the secret.
+   */
+  client_secret?: string;
+  scopes: string[];
+}
+
+/**
+ * Microsoft returns `error: "invalid_grant"` when the refresh token is
+ * revoked, the user changed their password, the app was un-consented,
+ * or the token has aged out. Caller (broker) catches and surfaces as
+ * `RefreshErrorKind.invalid_grant` so downstream UX can prompt re-auth.
+ */
+export class MicrosoftInvalidGrantError extends Error {
+  constructor(public detail: string) {
+    super(`invalid_grant: ${detail}`);
+    this.name = "MicrosoftInvalidGrantError";
+  }
+}
+
+/**
+ * Refresh an access token using the durable refresh token.
+ *
+ * Refresh tokens rotate every successful exchange on Microsoft's v2
+ * endpoint — the caller MUST persist `response.refresh_token` (when
+ * present) atomically; the old RT is invalidated immediately by
+ * Microsoft, so a torn write means operator re-auth.
+ */
+export async function refreshMicrosoftAccessToken(
+  cfg: MicrosoftOAuthClientConfig,
+  refreshToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<MicrosoftTokenResponse> {
+  const body = new URLSearchParams({
+    client_id: cfg.client_id,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+  if (cfg.client_secret !== undefined && cfg.client_secret.length > 0) {
+    body.set("client_secret", cfg.client_secret);
+  }
+  // Re-assert scopes on refresh; Microsoft narrows the response to the
+  // intersection of what was previously consented + what's requested.
+  // If we omit scope, Microsoft returns the full previously-consented set
+  // (which is what we want for the broker's one-account-one-scope-set
+  // model). Pass scope only when caller has a reason to narrow.
+  if (cfg.scopes && cfg.scopes.length > 0) {
+    body.set("scope", cfg.scopes.join(" "));
+  }
+  const res = await fetchImpl(`${MICROSOFT_OAUTH_BASE}/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  if (!res.ok) {
+    if (typeof json.error === "string" && json.error === "invalid_grant") {
+      throw new MicrosoftInvalidGrantError(
+        typeof json.error_description === "string"
+          ? json.error_description
+          : "refresh token rejected by Microsoft",
+      );
+    }
+    throw new Error(`refresh failed (${res.status}): ${JSON.stringify(json)}`);
+  }
+  return json as unknown as MicrosoftTokenResponse;
+}
+
+/**
+ * Decode a JWT's payload claims without verifying the signature. We're
+ * NOT validating the token (Microsoft already validated it when issuing);
+ * we're extracting claims to populate switchroom's credential shape
+ * (`tid`, `oid`, `preferred_username`). Verification would require
+ * pulling Microsoft's signing keys which is its own architectural piece.
+ *
+ * Returns null on any parse failure — caller should treat missing
+ * claims defensively (fall back to `/me` Graph call per RFC §4.2).
+ */
+export function decodeJwtPayloadUnsafe(token: string): Record<string, unknown> | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    // JWT uses base64url, not base64; pad and convert.
+    const padded = parts[1] + "===".slice((parts[1].length + 3) % 4);
+    const base64 = padded.replace(/-/g, "+").replace(/_/g, "/");
+    const buf = Buffer.from(base64, "base64");
+    const json = JSON.parse(buf.toString("utf-8")) as unknown;
+    if (json && typeof json === "object") {
+      return json as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Classify an id_token's tenant as personal-MSA or work/school based on
+ * the `tid` claim. Microsoft mints all consumer-account tokens with
+ * `tid` set to the well-known MSA constant; work/school tokens carry
+ * the org's tenant GUID.
+ */
+export function classifyAccountType(tenantId: string): "personal" | "work" {
+  return tenantId === PERSONAL_MSA_TENANT_ID ? "personal" : "work";
+}
+
+/**
+ * Build the MSAL-style `homeAccountId` from `oid` + `tid` claims.
+ * Used as the stable per-account key — survives email renames and is
+ * what Microsoft's own libraries use internally as the cache partition
+ * key. Returns null if either claim is missing.
+ */
+export function buildHomeAccountId(
+  claims: Record<string, unknown>,
+): string | null {
+  const oid = claims.oid;
+  const tid = claims.tid;
+  if (typeof oid !== "string" || oid.length === 0) return null;
+  if (typeof tid !== "string" || tid.length === 0) return null;
+  return `${oid}.${tid}`;
+}
+
+/**
+ * Generate a PKCE code verifier + S256 challenge pair for OAuth code
+ * flow. RFC 7636: verifier is 43-128 chars unreserved set
+ * (`[A-Z][a-z][0-9]-._~`); challenge is base64url(SHA-256(verifier)).
+ *
+ * Used by PR 2's loopback handler; landed here in PR 1 so the
+ * `microsoft/oauth.ts` module is the single home for OAuth primitives
+ * (mirrors `drive/oauth.ts` shape).
+ */
+export function generatePkcePair(): { verifier: string; challenge: string } {
+  const verifier = crypto.randomBytes(32).toString("base64url");
+  const challenge = crypto
+    .createHash("sha256")
+    .update(verifier)
+    .digest("base64url");
+  return { verifier, challenge };
+}

--- a/src/microsoft/oauth.ts
+++ b/src/microsoft/oauth.ts
@@ -32,9 +32,9 @@ export const MICROSOFT_OAUTH_BASE =
 
 /**
  * Personal MSA tenant constant — duplicated from
- * `src/auth/broker/protocol.ts` so this module doesn't pull a circular
- * dep on broker types. Microsoft's documented well-known `tid` for
- * all consumer accounts.
+ * `src/auth/broker/protocol.ts:PERSONAL_MSA_TENANT_ID` so this module
+ * doesn't pull a circular dep on broker types. Microsoft's documented
+ * well-known `tid` for all consumer accounts. **Keep both in sync.**
  */
 export const PERSONAL_MSA_TENANT_ID = "9188040d-6c67-4c5b-b112-36a304b66dad";
 


### PR DESCRIPTION
## Summary

RFC #1873 PR 1 of 5 ([tracking issue #1875](https://github.com/switchroom/switchroom/issues/1875)). Lands the broker-side foundation for Microsoft 365 integration.

**Tested**: 78 new tests, 224 total in src/auth/broker — all green. tsc --noEmit clean.

## What this adds

- **`src/auth/broker/microsoft-provider.ts`** — `MicrosoftProvider` implementing the `Provider` interface, mirrors `GoogleProvider`'s shape
- **`src/auth/broker/microsoft-storage.ts`** — Per-account `credentials.json` under `~/.switchroom/state/auth-broker/microsoft/<account>/`
- **`src/microsoft/oauth.ts`** — OAuth primitives: refresh exchange, JWT claim extraction, account-type classification, PKCE pair generation
- **Tests**: provider/storage/oauth (78 tests)
- **Protocol additions**: `"microsoft"` in `ProviderNameSchema`, `MicrosoftCredentialsSchema`, `PERSONAL_MSA_TENANT_ID` constant
- **Broker registration**: conditional on `config.microsoft_workspace.microsoft_client_id`
- **Config schema**: top-level `microsoft_workspace:` block

## Design deviation from RFC §5.1 — no MSAL-Node

The RFC originally specified MSAL-Node in the broker. After reading the provider interface in detail, I **dropped MSAL entirely**:

- The broker's `Provider.refresh()` is a one-shot exchange. MSAL's value (cache management, transparent rotation across `acquireTokenSilent` calls) doesn't manifest at this layer.
- `GoogleProvider` + `AnthropicProvider` already use direct fetch — adding MSAL would be inconsistent with the existing codebase pattern.
- Drops a dep.
- Microsoft's RT rotation is handled explicitly: every successful exchange returns `newRefreshToken` for the broker to write atomically.

RFC §5.1's "only the broker holds the MSAL instance" invariant becomes trivially "only the broker holds credentials" since there's no MSAL. **PR 5 will update the RFC** to reflect this simpler design.

This is a smaller, more consistent PR 1 than the RFC scoped.

## Test coverage

- `microsoft-provider.test.ts` (29 tests): success path with both personal MSA + work tenant id_tokens; RT rotation + preservation; missing id_token defensive defaults; error classification for invalid_grant / 429 / AADSTS50196 / network failures; expiresAt extraction; validateCredentialShape with provider-isolation checks
- `microsoft-storage.test.ts` (24 tests): write/read round-trip, mode 0600, atomic overwrites, malformed-JSON defensive returns, idempotent removal, listMicrosoftAccounts defensive against half-removed state, validation rejects path-traversal/null-bytes/whitespace
- `oauth.test.ts` (25 tests): form-body construction (refresh_token grant, client_secret omitted for public clients, scope omitted when array empty), JWT decode with base64url padding edge cases, tid → personal/work classification, homeAccountId composition, PKCE S256 challenge

## Test plan

- [x] vitest run on the 3 new test files (78 passed)
- [x] vitest run on all of `src/auth/broker` (224 passed)
- [x] tsc --noEmit clean
- [ ] Reviewer agent verifies the no-MSAL design decision is sound
- [ ] Reviewer checks coverage adequacy for the id_token-decode + RT-rotation logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)