### PR TITLE
feat(cli): switchroom auth microsoft verbs + OAuth flow (RFC #1873 PR 2/5)

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -266,10 +266,31 @@ export interface GoogleAddAccountCredentials {
   };
 }
 
+/**
+ * Microsoft-shaped credentials payload for `addAccount`. RFC #1873 PR 2
+ * — client-side TS type matching protocol's `MicrosoftCredentialsSchema`.
+ * Richer than Google's shape: persists tenant + account-type discriminators.
+ */
+export interface MicrosoftAddAccountCredentials {
+  microsoftOauth: {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+    scope: string;
+    clientId: string;
+    accountEmail: string;
+    tokenType: "Bearer";
+    tenantId: string;
+    accountType: "personal" | "work";
+    homeAccountId: string;
+  };
+}
+
 /** Discriminated union of credentials shapes for `addAccount`. */
 export type AddAccountCredentials =
   | AnthropicAddAccountCredentials
-  | GoogleAddAccountCredentials;
+  | GoogleAddAccountCredentials
+  | MicrosoftAddAccountCredentials;
 
 // ─── Client ───────────────────────────────────────────────────────────────
 

--- a/src/cli/auth-microsoft.ts
+++ b/src/cli/auth-microsoft.ts
@@ -498,45 +498,57 @@ function registerAccountAdd(accountParent: Command): void {
 }
 
 function registerAccountRemove(accountParent: Command): void {
-  accountParent
+  // .alias("rm") to match Google's verb shape.
+  const cmd = accountParent
     .command("remove <account>")
+    .alias("rm")
     .description(
-      "Remove a Microsoft account from the auth-broker. Refused if any agent still enabled — run `auth microsoft disable <account> all` first.",
-    )
-    .action(
-      withConfigError(async (account: string) => {
-        const normalizedAccount = validateAndNormalizeAccountEmail(account);
-        const { brokerCall } = await import("./broker-call.js");
+      "Remove a Microsoft account from the auth-broker AND prune the YAML entry. Refused if any agent still enabled — run `auth microsoft disable <account> all` first.",
+    );
+  cmd.action(
+    withConfigError(async (account: string, _opts: unknown, command) => {
+      const normalizedAccount = validateAndNormalizeAccountEmail(account);
+      const { brokerCall } = await import("./broker-call.js");
 
-        // Refuse if any agent still enabled in YAML
-        const yamlPath = process.env.SWITCHROOM_CONFIG ?? "~/.switchroom/switchroom.yaml";
-        try {
-          const yaml = readFileSync(yamlPath.replace(/^~/, process.env.HOME ?? ""), "utf-8");
-          const enabled = getEnabledAgentsForMicrosoftAccount(yaml, normalizedAccount);
-          if (enabled && enabled.length > 0) {
-            throw new Error(
-              `Account ${normalizedAccount} is still enabled on agents: ${enabled.join(", ")}. ` +
-              `Run 'switchroom auth microsoft disable ${normalizedAccount} all' first.`,
-            );
-          }
-        } catch (e) {
-          if (e instanceof Error && e.message.includes("still enabled")) throw e;
-          // YAML read failure — proceed (broker remove is independent)
-        }
+      // Resolve YAML path via the program (honors --config flag) rather
+      // than hand-rolling ~ expansion. The action callback's `command`
+      // arg is the leaf subcommand; walk up to the top-level program.
+      const program = command.parent?.parent?.parent ?? command;
+      const yamlPath = getConfigPath(program);
+      const before = readFileSync(yamlPath, "utf-8");
+      const enabled = getEnabledAgentsForMicrosoftAccount(before, normalizedAccount);
+      if (enabled && enabled.length > 0) {
+        throw new Error(
+          `Account ${normalizedAccount} is still enabled on agents: ${enabled.join(", ")}. ` +
+          `Run 'switchroom auth microsoft disable ${normalizedAccount} all' first.`,
+        );
+      }
 
-        await brokerCall(async (client) => {
-          await client.rmAccount(normalizedAccount, "microsoft");
-        });
+      await brokerCall(async (client) => {
+        await client.rmAccount(normalizedAccount, "microsoft");
+      });
 
-        console.log();
+      // Prune the dormant YAML entry now that the broker creds are gone.
+      // Idempotent — if the entry was already absent, returns input verbatim.
+      const after = removeMicrosoftAccountEntry(before, normalizedAccount);
+      if (after !== before) writeFileSync(yamlPath, after);
+
+      console.log();
+      console.log(
+        chalk.green(
+          `  ✓ Removed Microsoft account ${chalk.bold(normalizedAccount)} from auth-broker.`,
+        ),
+      );
+      if (after !== before) {
         console.log(
-          chalk.green(
-            `  ✓ Removed Microsoft account ${chalk.bold(normalizedAccount)} from auth-broker.`,
+          chalk.gray(
+            `    pruned dormant entry from microsoft_accounts: in switchroom.yaml`,
           ),
         );
-        console.log();
-      }),
-    );
+      }
+      console.log();
+    }),
+  );
 }
 
 function registerAccountList(accountParent: Command): void {
@@ -652,6 +664,25 @@ function buildMicrosoftCredentials(opts: {
     }
   }
 
+  // Catch typo'd account args: if Microsoft authenticated a different
+  // email than what the operator passed, warn loudly. Easy to miss
+  // otherwise — broker indexes by the passed arg, credentials.json says
+  // the real email, and `enable` on the typo would still "work" but
+  // route to the wrong account. Reviewer ask.
+  if (resolvedEmail.toLowerCase() !== accountEmail.toLowerCase()) {
+    console.warn();
+    console.warn(
+      `  ⚠ Account argument was '${accountEmail}' but Microsoft authenticated as '${resolvedEmail}'.`,
+    );
+    console.warn(
+      `    The broker will index by '${accountEmail}' (what you typed). If this isn't what`,
+    );
+    console.warn(
+      `    you intended (e.g. a typo), 'switchroom auth microsoft account remove ${accountEmail}' to undo.`,
+    );
+    console.warn();
+  }
+
   return {
     microsoftOauth: {
       accessToken: tokens.access_token,
@@ -669,23 +700,39 @@ function buildMicrosoftCredentials(opts: {
 }
 
 /**
- * Read a single visible line — for non-secret prompts. Hidden input
- * version (`readHiddenLine`) lives below.
+ * Read a single hidden line of input (no echo) — for secret prompts
+ * like the vault passphrase. On non-TTY input (CI, piped stdin) falls
+ * back to readline.question for sensible behavior.
  */
 async function readHiddenLine(prompt: string): Promise<string> {
   const readline = await import("node:readline");
+  const stdin = process.stdin as unknown as {
+    isTTY?: boolean;
+    setRawMode?: (raw: boolean) => void;
+  };
+  // Non-TTY: use readline.question — manual data listener + readline
+  // interface fight each other on piped stdin. Matches Google's
+  // auth-google.ts:1063 shape.
+  if (!stdin.isTTY) {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    return new Promise<string>((resolve) => {
+      rl.question(prompt, (answer) => {
+        rl.close();
+        resolve(answer);
+      });
+    });
+  }
   return new Promise((resolve, reject) => {
     const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,
     });
     const stdout = process.stdout as unknown as { write: (s: string) => void };
-    const stdin = process.stdin as unknown as {
-      isTTY?: boolean;
-      setRawMode?: (raw: boolean) => void;
-    };
     stdout.write(prompt);
-    if (stdin.isTTY && stdin.setRawMode) {
+    if (stdin.setRawMode) {
       stdin.setRawMode(true);
     }
     let line = "";
@@ -743,7 +790,11 @@ export function microsoftClientSetupGuidance(reason: string): string {
     "    switchroom vault set microsoft-oauth-client-id",
     "    switchroom vault set microsoft-oauth-client-secret  # optional",
     "",
-    "  8. Add to ~/.switchroom/switchroom.yaml (top level):",
+    "  8. If your work tenant requires admin consent, your IT admin must",
+    "     grant the requested Graph scopes (Files.ReadWrite.All etc.) at",
+    "     first sign-in. Personal MSA accounts (outlook.com / hotmail.com)",
+    "     don't need this step.",
+    "  9. Add to ~/.switchroom/switchroom.yaml (top level):",
     "",
     "    microsoft_workspace:",
     '      microsoft_client_id: "vault:microsoft-oauth-client-id"',

--- a/src/cli/auth-microsoft.ts
+++ b/src/cli/auth-microsoft.ts
@@ -1,0 +1,761 @@
+/**
+ * `switchroom auth microsoft ...` — RFC #1873 PR 2 CLI verbs.
+ *
+ * Mirrors `auth-google.ts` shape, swapping Google OAuth client + broker
+ * provider for Microsoft. Two-tier ladder (loopback + device-code) where
+ * Google needed three for Drive scope rejections — Microsoft's device-code
+ * works fine on personal MSA + work for the v1 scope set.
+ *
+ *   switchroom auth microsoft enable <account> <agents...>
+ *   switchroom auth microsoft disable <account> <agents...>
+ *   switchroom auth microsoft list
+ *   switchroom auth microsoft account add <account> [--replace] [--org-mode]
+ *   switchroom auth microsoft account remove <account>
+ *   switchroom auth microsoft account list
+ *
+ * `connect` wizard deferred to a follow-up — operators bootstrap by
+ * registering an Entra app + vaulting credentials + writing the YAML
+ * block manually. `account add` prints actionable guidance when the
+ * block is missing.
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { readFileSync, writeFileSync } from "node:fs";
+
+import {
+  disableAgentsOnMicrosoftAccount,
+  enableAgentsOnMicrosoftAccount,
+  getEnabledAgentsForMicrosoftAccount,
+  listMicrosoftAccounts,
+  removeMicrosoftAccountEntry,
+} from "./microsoft-accounts-yaml.js";
+import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+export function registerAuthMicrosoftSubcommands(
+  program: Command,
+  authParent: Command,
+): void {
+  const microsoft = authParent
+    .command("microsoft")
+    .description(
+      "Manage Microsoft 365 accounts shared across agents (RFC #1873 — see docs/rfcs/microsoft-workspace.md)",
+    );
+
+  registerEnable(microsoft, program);
+  registerDisable(microsoft, program);
+  registerList(microsoft, program);
+
+  const account = microsoft
+    .command("account")
+    .description(
+      "Manage Microsoft account credentials in the auth-broker (add / remove / list).",
+    );
+  registerAccountAdd(account);
+  registerAccountRemove(account);
+  registerAccountList(account);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// enable / disable / list — YAML-side operations
+// ────────────────────────────────────────────────────────────────────────
+
+function registerEnable(microsoftParent: Command, program: Command): void {
+  microsoftParent
+    .command("enable <account> <agents...>")
+    .description(
+      "Enable a Microsoft account on one or more agents. Use `all` to enable on every declared agent. Appends to microsoft_accounts.<account>.enabled_for[] — does NOT mint the broker credentials (use `auth microsoft account add` for that).",
+    )
+    .action(
+      withConfigError(async (account: string, agents: string[]) => {
+        const normalizedAccount = validateAndNormalizeAccountEmail(account);
+        const config = getConfig(program);
+        agents = expandAllAgents(agents, config);
+        validateAgentSlugs(agents, config);
+        const yamlPath = getConfigPath(program);
+        const before = readFileSync(yamlPath, "utf-8");
+        const enabledBefore = getEnabledAgentsBefore(before, normalizedAccount);
+
+        const after = enableAgentsOnMicrosoftAccount(before, normalizedAccount, agents);
+        if (after !== before) writeFileSync(yamlPath, after);
+
+        const enabledAfter = getEnabledAgentsForMicrosoftAccount(after, normalizedAccount) ?? [];
+        const newlyEnabled = enabledAfter.filter((a) => !enabledBefore.includes(a));
+
+        console.log();
+        if (newlyEnabled.length === 0) {
+          console.log(
+            `No change — all of ${agents.join(", ")} already enabled on ${chalk.bold(normalizedAccount)}.`,
+          );
+        } else {
+          console.log(
+            `${chalk.green("✓")} Enabled ${chalk.bold(normalizedAccount)} on: ${newlyEnabled.join(", ")}`,
+          );
+        }
+        if (enabledAfter.length > 0 && enabledAfter.length !== newlyEnabled.length) {
+          const alreadyEnabled = enabledAfter.filter((a) => !newlyEnabled.includes(a));
+          console.log(
+            `  ${chalk.gray("already enabled on:")} ${alreadyEnabled.join(", ")}`,
+          );
+        }
+        console.log();
+        if (newlyEnabled.length > 0) {
+          console.log(
+            `Next: ${chalk.bold(`switchroom agent restart ${newlyEnabled.join(" ")}`)} so the wrapper picks up the new ACL.`,
+          );
+          console.log();
+        }
+      }),
+    );
+}
+
+function registerDisable(microsoftParent: Command, program: Command): void {
+  microsoftParent
+    .command("disable <account> <agents...>")
+    .description(
+      "Disable a Microsoft account on one or more agents. Use `all` to disable on every declared agent. Leaves the account in microsoft_accounts: with an empty enabled_for[] (dormant — matches shipped Google behavior per RFC §6.1).",
+    )
+    .action(
+      withConfigError(async (account: string, agents: string[]) => {
+        const normalizedAccount = validateAndNormalizeAccountEmail(account);
+        const config = getConfig(program);
+        agents = expandAllAgents(agents, config);
+        const yamlPath = getConfigPath(program);
+        const before = readFileSync(yamlPath, "utf-8");
+        const enabledBefore = getEnabledAgentsBefore(before, normalizedAccount);
+
+        if (enabledBefore.length === 0) {
+          console.log();
+          console.log(
+            chalk.yellow(`Account ${chalk.bold(normalizedAccount)} is not currently enabled on any agent — nothing to do.`),
+          );
+          console.log();
+          return;
+        }
+
+        const after = disableAgentsOnMicrosoftAccount(before, normalizedAccount, agents);
+        if (after !== before) writeFileSync(yamlPath, after);
+
+        const enabledAfter = getEnabledAgentsForMicrosoftAccount(after, normalizedAccount) ?? [];
+        const removed = enabledBefore.filter((a) => !enabledAfter.includes(a));
+
+        console.log();
+        if (removed.length === 0) {
+          console.log(
+            `No change — none of ${agents.join(", ")} were enabled on ${chalk.bold(normalizedAccount)}.`,
+          );
+        } else {
+          console.log(
+            `${chalk.green("✓")} Disabled ${chalk.bold(normalizedAccount)} from: ${removed.join(", ")}`,
+          );
+        }
+        if (enabledAfter.length === 0) {
+          console.log(
+            `  ${chalk.gray("account is now")} ${chalk.bold("dormant")} ${chalk.gray("(empty enabled_for[])")}`,
+          );
+        } else {
+          console.log(
+            `  ${chalk.gray("still enabled on:")} ${enabledAfter.join(", ")}`,
+          );
+        }
+        console.log();
+        if (removed.length > 0) {
+          console.log(
+            `Next: ${chalk.bold(`switchroom agent restart ${removed.join(" ")}`)} so the wrapper drops its access.`,
+          );
+          console.log();
+        }
+      }),
+    );
+}
+
+function registerList(microsoftParent: Command, program: Command): void {
+  microsoftParent
+    .command("list")
+    .description(
+      "List every Microsoft account configured in switchroom.yaml with its enabled_for[] agents.",
+    )
+    .option("--json", "Emit raw JSON instead of a table")
+    .action(
+      withConfigError(async (opts: { json?: boolean }) => {
+        const yamlPath = getConfigPath(program);
+        const yaml = readFileSync(yamlPath, "utf-8");
+        const accounts = listMicrosoftAccounts(yaml);
+
+        if (opts.json) {
+          console.log(JSON.stringify(accounts, null, 2));
+          return;
+        }
+
+        console.log();
+        if (accounts.length === 0) {
+          console.log(chalk.gray("No Microsoft accounts configured."));
+          console.log(
+            `Add one: ${chalk.bold("switchroom auth microsoft account add <email>")}`,
+          );
+          console.log(
+            `Then enable on agents: ${chalk.bold("switchroom auth microsoft enable <email> <agent>...")}`,
+          );
+          console.log();
+          return;
+        }
+
+        const accountColWidth = Math.max(
+          ...accounts.map((a) => a.account.length),
+          "ACCOUNT".length,
+        );
+        console.log(`${pad("ACCOUNT", accountColWidth)}  AGENTS`);
+        console.log(`${pad("-".repeat(7), accountColWidth)}  ${"-".repeat(6)}`);
+        for (const { account, enabled_for } of accounts) {
+          const agentList =
+            enabled_for.length === 0
+              ? chalk.gray("(dormant — empty enabled_for)")
+              : enabled_for.join(", ");
+          console.log(`${pad(account, accountColWidth)}  ${agentList}`);
+        }
+        console.log();
+      }),
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// account add / remove / list — broker thin clients
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * v1 scope sets — RFC §4.3. `org_mode: false` (default) covers personal
+ * MSA + standard work surfaces. `org_mode: true` opts in to SharePoint
+ * (and softeria's --org-mode for Teams tools at PR 3 time).
+ */
+const SCOPE_SET_DEFAULT = [
+  "openid",
+  "profile",
+  "email",
+  "offline_access",
+  "User.Read",
+  "Mail.ReadWrite",
+  "Calendars.ReadWrite",
+  "Files.ReadWrite.All",
+];
+
+const SCOPE_SET_ORG_MODE = [
+  ...SCOPE_SET_DEFAULT,
+  "Sites.ReadWrite.All",
+];
+
+function selectMicrosoftScopes(orgMode: boolean): string[] {
+  return orgMode ? SCOPE_SET_ORG_MODE : SCOPE_SET_DEFAULT;
+}
+
+function registerAccountAdd(accountParent: Command): void {
+  accountParent
+    .command("add <account>")
+    .description(
+      "Mint a Microsoft OAuth refresh token for <account> and register with the auth-broker. Uses desktop-loopback by default (or device-code on headless hosts); both work for personal MSA and work/school. --org-mode also requests Sites.ReadWrite.All (SharePoint).",
+    )
+    .option(
+      "--replace",
+      "Overwrite existing credentials for <account> (default refuses if account already registered)",
+      false,
+    )
+    .option(
+      "--org-mode",
+      "Request the SharePoint scope (Sites.ReadWrite.All) in addition to the default set. Useful for work accounts with SharePoint document libraries. Default is OneDrive-only.",
+      false,
+    )
+    .action(
+      withConfigError(
+        async (account: string, opts: { replace?: boolean; "orgMode"?: boolean }) => {
+          const normalizedAccount = validateAndNormalizeAccountEmail(account);
+
+          const [
+            { selectInitialTier, runLoopbackOAuth, requestDeviceCode, pollDeviceToken },
+            { brokerCall },
+            { loadConfig, resolvePath },
+            { getSecret },
+            { isVaultReference, parseVaultReference },
+            { getViaBrokerStructured, statusViaBroker, resolveBrokerSocketPath },
+          ] = await Promise.all([
+            import("../microsoft/oauth.js"),
+            import("./broker-call.js"),
+            import("../config/loader.js"),
+            import("../vault/vault.js"),
+            import("../vault/resolver.js"),
+            import("../vault/broker/client.js"),
+          ]);
+
+          const config = loadConfig();
+          const mw = config.microsoft_workspace;
+          if (!mw) {
+            throw new Error(
+              microsoftClientSetupGuidance(
+                "switchroom.yaml has no `microsoft_workspace:` block, so there is no Microsoft OAuth app to connect accounts against.",
+              ),
+            );
+          }
+
+          let clientIdRaw =
+            process.env.SWITCHROOM_MICROSOFT_CLIENT_ID ?? mw.microsoft_client_id;
+          let clientSecretRaw =
+            process.env.SWITCHROOM_MICROSOFT_CLIENT_SECRET ??
+            mw.microsoft_client_secret;
+          if (!clientIdRaw) {
+            throw new Error(
+              microsoftClientSetupGuidance(
+                "The `microsoft_workspace:` block is present but `microsoft_client_id` is empty.",
+              ),
+            );
+          }
+          // client_secret optional — public-client apps don't need one.
+
+          const needsVault =
+            isVaultReference(clientIdRaw) ||
+            (clientSecretRaw !== undefined && isVaultReference(clientSecretRaw));
+
+          if (needsVault) {
+            let brokerSocket: string | undefined;
+            try {
+              brokerSocket = resolveBrokerSocketPath({
+                vaultBrokerSocket: config.vault?.broker?.socket
+                  ? resolvePath(config.vault.broker.socket)
+                  : undefined,
+              });
+            } catch {
+              brokerSocket = resolveBrokerSocketPath();
+            }
+            const status = await statusViaBroker({ socket: brokerSocket });
+            const viaBroker = status !== null && status.unlocked;
+
+            let directVaultPath: string | undefined;
+            let directPassphrase: string | undefined;
+            const resolveRef = async (
+              raw: string,
+              label: string,
+            ): Promise<string> => {
+              if (!isVaultReference(raw)) return raw;
+              const key = parseVaultReference(raw);
+
+              if (viaBroker) {
+                const result = await getViaBrokerStructured(key, {
+                  socket: brokerSocket,
+                });
+                if (result.kind === "ok") {
+                  if (result.entry.kind !== "string") {
+                    throw new Error(
+                      `${label} vault entry '${key}' is not a string (kind=${result.entry.kind}).`,
+                    );
+                  }
+                  return result.entry.value;
+                }
+                if (result.kind !== "unreachable") {
+                  throw new Error(
+                    `${label} references vault key '${key}': broker ${result.kind} [${(result as { code?: string }).code ?? "?"}] ${(result as { msg?: string }).msg ?? ""}`,
+                  );
+                }
+                console.error(
+                  chalk.yellow(
+                    `  vault-broker became unreachable — falling back to direct vault read for '${key}'.`,
+                  ),
+                );
+              }
+
+              directVaultPath ??= resolvePath(
+                config.vault?.path ?? "~/.switchroom/vault.enc",
+              );
+              directPassphrase ??=
+                process.env.SWITCHROOM_VAULT_PASSPHRASE ??
+                (await readHiddenLine("Vault passphrase: "));
+              const entry = getSecret(directPassphrase, directVaultPath, key);
+              if (!entry) {
+                throw new Error(
+                  `${label} references vault key '${key}' but no such secret in vault.`,
+                );
+              }
+              if (entry.kind !== "string") {
+                throw new Error(
+                  `${label} vault entry '${key}' is not a string (kind=${entry.kind}).`,
+                );
+              }
+              return entry.value;
+            };
+            clientIdRaw = await resolveRef(clientIdRaw, "microsoft_client_id");
+            if (clientSecretRaw !== undefined) {
+              clientSecretRaw = await resolveRef(clientSecretRaw, "microsoft_client_secret");
+            }
+          }
+
+          const orgMode = opts["orgMode"] ?? mw.org_mode ?? false;
+          const scopes = selectMicrosoftScopes(orgMode);
+          const oauthCfg = {
+            client_id: clientIdRaw,
+            client_secret: clientSecretRaw,
+            scopes,
+          };
+
+          if (orgMode) {
+            console.log(
+              chalk.yellow(
+                "  Requesting SharePoint scope (Sites.ReadWrite.All) — grants read/write to every SharePoint site this account can access. Per RFC §4.3, opt-in for work accounts with SharePoint document libraries.",
+              ),
+            );
+          }
+          console.log(
+            chalk.gray(
+              `  Scopes: ${scopes.join(" ")}`,
+            ),
+          );
+
+          const oauthEnv = {
+            DISPLAY: process.env.DISPLAY,
+            WAYLAND_DISPLAY: process.env.WAYLAND_DISPLAY,
+            SSH_CONNECTION: process.env.SSH_CONNECTION,
+            SSH_TTY: process.env.SSH_TTY,
+            SWITCHROOM_MICROSOFT_OAUTH_TIER:
+              process.env.SWITCHROOM_MICROSOFT_OAUTH_TIER,
+          };
+          const initialTier = selectInitialTier(oauthEnv);
+
+          console.log();
+          console.log(
+            chalk.bold(
+              `Connecting Microsoft account ${chalk.cyan(normalizedAccount)} to switchroom auth-broker.`,
+            ),
+          );
+          console.log(
+            chalk.gray(`  OAuth tier: ${initialTier}`),
+          );
+          console.log();
+
+          let tokens;
+          if (initialTier === "desktop_loopback") {
+            tokens = await runLoopbackOAuth(oauthCfg, {
+              onAuthUrl: (url: string, opened: boolean) => {
+                if (opened) {
+                  console.log(chalk.gray("  Browser opened — complete consent at:"));
+                } else {
+                  console.log(chalk.yellow("  Open this URL in any browser:"));
+                }
+                console.log(`    ${url}`);
+                console.log();
+              },
+            });
+          } else {
+            const device = await requestDeviceCode(oauthCfg);
+            console.log(chalk.bold("  Open this URL on any device + paste the code:"));
+            console.log(`    ${chalk.cyan(device.verification_uri)}`);
+            console.log(`    code: ${chalk.bold.yellow(device.user_code)}`);
+            console.log(chalk.gray(`  (expires in ${Math.round(device.expires_in / 60)}min)`));
+            console.log();
+            tokens = await pollDeviceToken(oauthCfg, device);
+          }
+
+          if (!tokens.refresh_token) {
+            throw new Error(
+              "Microsoft did not return a refresh_token — ensure `offline_access` is in the consented scope set and try again.",
+            );
+          }
+
+          const microsoftCreds = buildMicrosoftCredentials({
+            tokens,
+            clientId: clientIdRaw,
+            accountEmail: normalizedAccount,
+            fallbackScope: scopes.join(" "),
+          });
+
+          await brokerCall(async (client) => {
+            await client.addAccount(
+              normalizedAccount,
+              microsoftCreds,
+              opts.replace ?? false,
+              "microsoft",
+            );
+          });
+
+          console.log();
+          console.log(
+            chalk.green(
+              `  ✓ Registered Microsoft account ${chalk.bold(normalizedAccount)} with auth-broker.`,
+            ),
+          );
+          const accountType = microsoftCreds.microsoftOauth.accountType;
+          console.log(
+            chalk.gray(
+              `  Account type: ${accountType} ${accountType === "personal" ? "(MSA — outlook.com / hotmail.com)" : `(work/school — tenant ${microsoftCreds.microsoftOauth.tenantId})`}`,
+            ),
+          );
+          console.log();
+          console.log(`  Next: enable on one or more agents:`);
+          console.log(
+            chalk.cyan(
+              `    switchroom auth microsoft enable ${normalizedAccount} <agent> [...]`,
+            ),
+          );
+          console.log();
+        },
+      ),
+    );
+}
+
+function registerAccountRemove(accountParent: Command): void {
+  accountParent
+    .command("remove <account>")
+    .description(
+      "Remove a Microsoft account from the auth-broker. Refused if any agent still enabled — run `auth microsoft disable <account> all` first.",
+    )
+    .action(
+      withConfigError(async (account: string) => {
+        const normalizedAccount = validateAndNormalizeAccountEmail(account);
+        const { brokerCall } = await import("./broker-call.js");
+
+        // Refuse if any agent still enabled in YAML
+        const yamlPath = process.env.SWITCHROOM_CONFIG ?? "~/.switchroom/switchroom.yaml";
+        try {
+          const yaml = readFileSync(yamlPath.replace(/^~/, process.env.HOME ?? ""), "utf-8");
+          const enabled = getEnabledAgentsForMicrosoftAccount(yaml, normalizedAccount);
+          if (enabled && enabled.length > 0) {
+            throw new Error(
+              `Account ${normalizedAccount} is still enabled on agents: ${enabled.join(", ")}. ` +
+              `Run 'switchroom auth microsoft disable ${normalizedAccount} all' first.`,
+            );
+          }
+        } catch (e) {
+          if (e instanceof Error && e.message.includes("still enabled")) throw e;
+          // YAML read failure — proceed (broker remove is independent)
+        }
+
+        await brokerCall(async (client) => {
+          await client.rmAccount(normalizedAccount, "microsoft");
+        });
+
+        console.log();
+        console.log(
+          chalk.green(
+            `  ✓ Removed Microsoft account ${chalk.bold(normalizedAccount)} from auth-broker.`,
+          ),
+        );
+        console.log();
+      }),
+    );
+}
+
+function registerAccountList(accountParent: Command): void {
+  accountParent
+    .command("list")
+    .description(
+      "List Microsoft accounts the broker holds credentials for. Distinct from `auth microsoft list` (YAML ACL matrix).",
+    )
+    .option("--json", "Emit raw JSON")
+    .action(
+      withConfigError(async (_opts: { json?: boolean }) => {
+        // Phase 2 follow-up — needs a `list-microsoft-accounts` broker op
+        // (mirror of `list-google-accounts`). For now, fall back to
+        // pointing at the YAML view.
+        console.log();
+        console.log(
+          chalk.yellow(
+            "  Broker-side listing for Microsoft accounts is a follow-up (needs a list-microsoft-accounts wire op).",
+          ),
+        );
+        console.log(
+          `  For now, see the YAML matrix: ${chalk.bold("switchroom auth microsoft list")}`,
+        );
+        console.log();
+      }),
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// helpers
+// ────────────────────────────────────────────────────────────────────────
+
+function validateAndNormalizeAccountEmail(account: string): string {
+  const normalized = account.trim().toLowerCase();
+  if (!/^[^@\s:]+@[^@\s:]+\.[^@\s:]+$/.test(normalized)) {
+    throw new Error(
+      `'${account}' is not a valid Microsoft account email. Expected format like 'alice@outlook.com' or 'alice@contoso.com' (colons not allowed).`,
+    );
+  }
+  return normalized;
+}
+
+function getEnabledAgentsBefore(yamlText: string, account: string): string[] {
+  return getEnabledAgentsForMicrosoftAccount(yamlText, account) ?? [];
+}
+
+function expandAllAgents(agents: string[], config: SwitchroomConfig): string[] {
+  if (!agents.includes("all")) return agents;
+  const allNames = Object.keys(config.agents);
+  if (allNames.length === 0) {
+    throw new Error(
+      "switchroom.yaml has no agents declared — `all` matches nothing.",
+    );
+  }
+  return allNames;
+}
+
+function validateAgentSlugs(agents: string[], config: SwitchroomConfig): void {
+  const known = new Set(Object.keys(config.agents));
+  const unknown = agents.filter((a) => !known.has(a));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown agent(s) in switchroom.yaml: ${unknown.join(", ")}. ` +
+      `Known agents: ${[...known].join(", ")}`,
+    );
+  }
+}
+
+function pad(s: string, width: number): string {
+  return s.length >= width ? s : s + " ".repeat(width - s.length);
+}
+
+/**
+ * Build the Microsoft broker credentials shape from a token response.
+ * Decodes the id_token (if present) to populate canonical identity
+ * fields (tenantId, accountType, homeAccountId, accountEmail).
+ *
+ * The broker's MicrosoftProvider also does this on refresh; here we do
+ * it at account-add time to seed the on-disk credentials.json with
+ * canonical values.
+ */
+function buildMicrosoftCredentials(opts: {
+  tokens: import("../microsoft/oauth.js").MicrosoftTokenResponse;
+  clientId: string;
+  accountEmail: string;
+  fallbackScope: string;
+}): import("../auth/broker/protocol.js").MicrosoftCredentialsShape {
+  const { tokens, clientId, accountEmail, fallbackScope } = opts;
+
+  // Lazy module-level import to keep CLI startup snappy.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { decodeJwtPayloadUnsafe, classifyAccountType, buildHomeAccountId } =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("../microsoft/oauth.js") as typeof import("../microsoft/oauth.js");
+
+  let tenantId = "";
+  let accountType: "personal" | "work" = "work";
+  let homeAccountId = "";
+  let resolvedEmail = accountEmail;
+
+  if (tokens.id_token) {
+    const claims = decodeJwtPayloadUnsafe(tokens.id_token);
+    if (claims) {
+      if (typeof claims.tid === "string") tenantId = claims.tid;
+      if (tenantId) accountType = classifyAccountType(tenantId);
+      const home = buildHomeAccountId(claims);
+      if (home) homeAccountId = home;
+      if (typeof claims.preferred_username === "string") {
+        resolvedEmail = claims.preferred_username.toLowerCase();
+      } else if (typeof claims.email === "string") {
+        resolvedEmail = claims.email.toLowerCase();
+      }
+    }
+  }
+
+  return {
+    microsoftOauth: {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token ?? "",
+      expiresAt: Date.now() + tokens.expires_in * 1000,
+      scope: tokens.scope ?? fallbackScope,
+      clientId,
+      accountEmail: resolvedEmail,
+      tokenType: "Bearer",
+      tenantId,
+      accountType,
+      homeAccountId,
+    },
+  };
+}
+
+/**
+ * Read a single visible line — for non-secret prompts. Hidden input
+ * version (`readHiddenLine`) lives below.
+ */
+async function readHiddenLine(prompt: string): Promise<string> {
+  const readline = await import("node:readline");
+  return new Promise((resolve, reject) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    const stdout = process.stdout as unknown as { write: (s: string) => void };
+    const stdin = process.stdin as unknown as {
+      isTTY?: boolean;
+      setRawMode?: (raw: boolean) => void;
+    };
+    stdout.write(prompt);
+    if (stdin.isTTY && stdin.setRawMode) {
+      stdin.setRawMode(true);
+    }
+    let line = "";
+    const onData = (chunk: Buffer) => {
+      const s = chunk.toString("utf8");
+      for (const ch of s) {
+        if (ch === "\n" || ch === "\r") {
+          if (stdin.isTTY && stdin.setRawMode) stdin.setRawMode(false);
+          process.stdin.off("data", onData);
+          rl.close();
+          stdout.write("\n");
+          resolve(line);
+          return;
+        }
+        if (ch === "\x7f" || ch === "\b") {
+          line = line.slice(0, -1);
+          continue;
+        }
+        if (ch === "\x03") {
+          // Ctrl-C
+          if (stdin.isTTY && stdin.setRawMode) stdin.setRawMode(false);
+          process.stdin.off("data", onData);
+          rl.close();
+          reject(new Error("aborted"));
+          return;
+        }
+        line += ch;
+      }
+    };
+    process.stdin.on("data", onData);
+  });
+}
+
+export function microsoftClientSetupGuidance(reason: string): string {
+  return [
+    reason,
+    "",
+    "Switchroom ships no shared Microsoft OAuth app — register your own.",
+    "One-time per install:",
+    "",
+    "  1. Go to https://entra.microsoft.com → App registrations → New",
+    "     registration",
+    "  2. Supported account types: 'Accounts in any organizational",
+    "     directory AND personal Microsoft accounts' (multi-tenant + MSA)",
+    "  3. Redirect URI: platform 'Mobile and desktop applications',",
+    "     value `http://localhost` (port-agnostic; Microsoft ignores port",
+    "     for loopback URIs)",
+    "  4. Authentication → Advanced settings → 'Allow public client",
+    "     flows': Yes (enables device-code on personal MSA)",
+    "  5. Copy the Application (client) ID from the Overview page",
+    "  6. Optional: create a client secret in 'Certificates & secrets'",
+    "     (skip if using public-client flow only)",
+    "  7. Vault the credentials:",
+    "",
+    "    switchroom vault set microsoft-oauth-client-id",
+    "    switchroom vault set microsoft-oauth-client-secret  # optional",
+    "",
+    "  8. Add to ~/.switchroom/switchroom.yaml (top level):",
+    "",
+    "    microsoft_workspace:",
+    '      microsoft_client_id: "vault:microsoft-oauth-client-id"',
+    '      microsoft_client_secret: "vault:microsoft-oauth-client-secret"  # omit if public-client',
+    "      authority: https://login.microsoftonline.com/common",
+    "      org_mode: false",
+    "",
+    "Env vars SWITCHROOM_MICROSOFT_CLIENT_ID / _SECRET override the block",
+    "for one-off debugging.",
+    "",
+    "Full walkthrough: docs/microsoft-workspace.md (PR 5 will land this).",
+    "Don't reuse an existing Entra app — see RFC §4.1 (signInAudience",
+    "mismatch + token-version drift make app sharing brittle).",
+  ].join("\n");
+}

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -51,6 +51,7 @@ import {
 } from "../auth/manager.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import { registerAuthGoogleSubcommands } from "./auth-google.js";
+import { registerAuthMicrosoftSubcommands } from "./auth-microsoft.js";
 import { setAuthActive } from "./auth-active-yaml.js";
 import { atomicWriteFileSync } from "../util/atomic.js";
 import { statSync } from "node:fs";
@@ -468,6 +469,7 @@ export function registerAuthCommand(program: Command): void {
     .description("Manage OAuth authentication via switchroom-auth-broker (RFC H)");
 
   registerAuthGoogleSubcommands(program, auth);
+  registerAuthMicrosoftSubcommands(program, auth);
 
   // ── auth heal <agent> --json --config-dir <dir> ────────────────────────
   // Minimal surface kept for boot-self-test.sh's structural diagnoser

--- a/src/cli/microsoft-accounts-yaml.test.ts
+++ b/src/cli/microsoft-accounts-yaml.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for microsoft-accounts-yaml — RFC #1873 PR 2.
+ *
+ * Mirrors `google-accounts-yaml.test.ts` structure: string-in / string-out
+ * pure-module test. Validates dormant-on-empty per RFC #1873 §6.1.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  disableAgentsOnMicrosoftAccount,
+  enableAgentsOnMicrosoftAccount,
+  getEnabledAgentsForMicrosoftAccount,
+  listMicrosoftAccounts,
+  removeMicrosoftAccountEntry,
+} from "./microsoft-accounts-yaml.js";
+
+const STARTER = `version: "v1"
+auth:
+  active: ken
+agents:
+  clerk: {}
+`;
+
+describe("enableAgentsOnMicrosoftAccount", () => {
+  it("adds agents to a fresh entry, creating the parent map", () => {
+    const out = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    expect(out).toContain("microsoft_accounts:");
+    expect(out).toContain("ken@outlook.com:");
+    expect(out).toContain("enabled_for:");
+    expect(out).toContain("- clerk");
+  });
+
+  it("is idempotent (adding the same agent twice is a no-op)", () => {
+    const once = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    const twice = enableAgentsOnMicrosoftAccount(once, "ken@outlook.com", ["clerk"]);
+    expect(twice).toBe(once);
+  });
+
+  it("returns the input verbatim when no agents would be added", () => {
+    const once = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    const verbatim = enableAgentsOnMicrosoftAccount(once, "ken@outlook.com", []);
+    expect(verbatim).toBe(once);
+  });
+
+  it("appends new agents preserving existing order", () => {
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk", "lawgpt"]);
+    yaml = enableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["finn"]);
+    const agents = getEnabledAgentsForMicrosoftAccount(yaml, "ken@outlook.com");
+    expect(agents).toEqual(["clerk", "lawgpt", "finn"]);
+  });
+
+  it("preserves comments in unrelated parts of the file", () => {
+    const yaml = `# top-level comment
+version: "v1"
+agents:
+  # clerk is the exec assistant
+  clerk: {}
+`;
+    const out = enableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["clerk"]);
+    expect(out).toContain("# top-level comment");
+    expect(out).toContain("# clerk is the exec assistant");
+  });
+});
+
+describe("disableAgentsOnMicrosoftAccount", () => {
+  it("removes named agents, keeps others", () => {
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk", "lawgpt"]);
+    yaml = disableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["clerk"]);
+    const agents = getEnabledAgentsForMicrosoftAccount(yaml, "ken@outlook.com");
+    expect(agents).toEqual(["lawgpt"]);
+  });
+
+  it("leaves enabled_for as empty array (dormant) when all agents removed", () => {
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    yaml = disableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["clerk"]);
+    // Dormant — entry stays per RFC #1873 §6.1
+    const agents = getEnabledAgentsForMicrosoftAccount(yaml, "ken@outlook.com");
+    expect(agents).toEqual([]);
+  });
+
+  it("returns input verbatim when account not present", () => {
+    const out = disableAgentsOnMicrosoftAccount(STARTER, "ghost@outlook.com", ["clerk"]);
+    expect(out).toBe(STARTER);
+  });
+
+  it("returns input verbatim when no named agents are in the list", () => {
+    const yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    const out = disableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["nonexistent"]);
+    expect(out).toBe(yaml);
+  });
+});
+
+describe("getEnabledAgentsForMicrosoftAccount", () => {
+  it("returns null when account is absent (vs empty array = dormant)", () => {
+    expect(getEnabledAgentsForMicrosoftAccount(STARTER, "ken@outlook.com")).toBeNull();
+  });
+
+  it("returns [] when entry exists with empty enabled_for (dormant)", () => {
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    yaml = disableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["clerk"]);
+    expect(getEnabledAgentsForMicrosoftAccount(yaml, "ken@outlook.com")).toEqual([]);
+  });
+});
+
+describe("listMicrosoftAccounts", () => {
+  it("returns [] when no microsoft_accounts block exists", () => {
+    expect(listMicrosoftAccounts(STARTER)).toEqual([]);
+  });
+
+  it("lists all accounts in source order", () => {
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    yaml = enableAgentsOnMicrosoftAccount(yaml, "ken@contoso.com", ["lawgpt"]);
+    const list = listMicrosoftAccounts(yaml);
+    expect(list).toEqual([
+      { account: "ken@outlook.com", enabled_for: ["clerk"] },
+      { account: "ken@contoso.com", enabled_for: ["lawgpt"] },
+    ]);
+  });
+
+  it("includes dormant accounts (empty enabled_for) in the list", () => {
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    yaml = disableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["clerk"]);
+    expect(listMicrosoftAccounts(yaml)).toEqual([
+      { account: "ken@outlook.com", enabled_for: [] },
+    ]);
+  });
+});
+
+describe("removeMicrosoftAccountEntry", () => {
+  it("removes a configured account", () => {
+    const yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    const out = removeMicrosoftAccountEntry(yaml, "ken@outlook.com");
+    expect(out).not.toContain("ken@outlook.com");
+    expect(out).not.toContain("microsoft_accounts:");
+  });
+
+  it("prunes the empty parent map when removing the last entry", () => {
+    const yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    const out = removeMicrosoftAccountEntry(yaml, "ken@outlook.com");
+    expect(out).not.toContain("microsoft_accounts");
+  });
+
+  it("keeps the parent map when other accounts remain", () => {
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    yaml = enableAgentsOnMicrosoftAccount(yaml, "ken@contoso.com", ["lawgpt"]);
+    const out = removeMicrosoftAccountEntry(yaml, "ken@outlook.com");
+    expect(out).toContain("microsoft_accounts");
+    expect(out).toContain("ken@contoso.com");
+    expect(out).not.toContain("ken@outlook.com");
+  });
+
+  it("returns input verbatim when account is absent", () => {
+    expect(removeMicrosoftAccountEntry(STARTER, "ghost@outlook.com")).toBe(STARTER);
+  });
+});

--- a/src/cli/microsoft-accounts-yaml.ts
+++ b/src/cli/microsoft-accounts-yaml.ts
@@ -1,0 +1,163 @@
+/**
+ * YAML editor for `switchroom auth microsoft enable/disable` — RFC #1873.
+ *
+ * Edits the top-level `microsoft_accounts.<email>.enabled_for: [agents...]`
+ * map while preserving comments and formatting elsewhere in the file.
+ * Mirrors `google-accounts-yaml.ts` byte-for-byte (s/google/microsoft/) —
+ * the shape is identical, the key name differs.
+ *
+ * Per RFC #1873 §6.1, dormant-on-empty (empty `enabled_for[]` stays as
+ * an empty array, not pruned) — matches shipped Google behavior.
+ */
+
+import {
+  parseDocument,
+  type Document,
+  isMap,
+  isSeq,
+  type YAMLMap,
+  type YAMLSeq,
+} from "yaml";
+
+/**
+ * Append agents to `microsoft_accounts.<account>.enabled_for`. Idempotent.
+ * Pass-through (verbatim byte-equality preserved) if no agents would be added.
+ */
+export function enableAgentsOnMicrosoftAccount(
+  yamlText: string,
+  account: string,
+  agentsToEnable: string[],
+): string {
+  const doc = parseDocument(yamlText);
+  ensureMicrosoftAccountEntry(doc, account);
+  const existing = doc.getIn(["microsoft_accounts", account, "enabled_for"]);
+  const currentAgents = readEnabledFor(existing);
+  const additions = agentsToEnable.filter((a) => !currentAgents.includes(a));
+  if (additions.length === 0) return yamlText;
+  if (isSeq(existing)) {
+    const seq = existing as YAMLSeq;
+    for (const a of additions) seq.add(a);
+  } else {
+    doc.setIn(
+      ["microsoft_accounts", account, "enabled_for"],
+      [...currentAgents, ...additions],
+    );
+  }
+  return String(doc);
+}
+
+/**
+ * Remove agents from `microsoft_accounts.<account>.enabled_for`. No-op
+ * if none of the named agents are present. When `enabled_for` becomes
+ * empty, it stays as an empty array (NOT pruned) — empty-but-present
+ * is the "dormant account" state per RFC #1873 §6.1, mirroring shipped
+ * Google behavior.
+ */
+export function disableAgentsOnMicrosoftAccount(
+  yamlText: string,
+  account: string,
+  agentsToDisable: string[],
+): string {
+  const doc = parseDocument(yamlText);
+  if (!hasMicrosoftAccountEntry(doc, account)) return yamlText;
+  const existing = doc.getIn(["microsoft_accounts", account, "enabled_for"]);
+  if (!isSeq(existing)) return yamlText;
+  const seq = existing as YAMLSeq;
+  const beforeLen = seq.items.length;
+  for (let i = seq.items.length - 1; i >= 0; i--) {
+    const item = seq.items[i];
+    const v = (item as { value?: unknown })?.value ?? item;
+    if (typeof v === "string" && agentsToDisable.includes(v)) {
+      seq.delete(i);
+    }
+  }
+  if (seq.items.length === beforeLen) return yamlText;
+  return String(doc);
+}
+
+/**
+ * Read `microsoft_accounts.<account>.enabled_for` without mutating.
+ * Returns `null` if the account isn't in the YAML at all
+ * (distinguished from `[]` which means dormant).
+ */
+export function getEnabledAgentsForMicrosoftAccount(
+  yamlText: string,
+  account: string,
+): string[] | null {
+  const doc = parseDocument(yamlText);
+  if (!hasMicrosoftAccountEntry(doc, account)) return null;
+  const existing = doc.getIn(["microsoft_accounts", account, "enabled_for"]);
+  return readEnabledFor(existing);
+}
+
+/**
+ * List every Microsoft account configured in the YAML. Returns entries
+ * in YAML-source order so the CLI output matches what the operator
+ * sees in the file.
+ */
+export function listMicrosoftAccounts(
+  yamlText: string,
+): Array<{ account: string; enabled_for: string[] }> {
+  const doc = parseDocument(yamlText);
+  const accounts = doc.get("microsoft_accounts");
+  if (!isMap(accounts)) return [];
+  const out: Array<{ account: string; enabled_for: string[] }> = [];
+  for (const item of (accounts as YAMLMap).items) {
+    const account = String((item.key as { value?: unknown }).value ?? item.key);
+    const enabled = doc.getIn([
+      "microsoft_accounts",
+      account,
+      "enabled_for",
+    ]);
+    out.push({ account, enabled_for: readEnabledFor(enabled) });
+  }
+  return out;
+}
+
+/**
+ * Remove the entire `microsoft_accounts.<account>` entry from the YAML.
+ * Used by `auth microsoft account remove`. CLI verb is responsible for
+ * checking `enabled_for` is empty first (so we don't strand any
+ * agents whose tools depended on the account).
+ */
+export function removeMicrosoftAccountEntry(
+  yamlText: string,
+  account: string,
+): string {
+  const doc = parseDocument(yamlText);
+  if (!hasMicrosoftAccountEntry(doc, account)) return yamlText;
+  doc.deleteIn(["microsoft_accounts", account]);
+  pruneEmptyMap(doc, ["microsoft_accounts"]);
+  return String(doc);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// internals
+// ────────────────────────────────────────────────────────────────────────
+
+function readEnabledFor(node: unknown): string[] {
+  if (!isSeq(node)) return [];
+  const seq = node as YAMLSeq;
+  return seq.items
+    .map((item) => (item as { value?: unknown }).value ?? item)
+    .filter((v): v is string => typeof v === "string");
+}
+
+function ensureMicrosoftAccountEntry(doc: Document, account: string): void {
+  if (!hasMicrosoftAccountEntry(doc, account)) {
+    doc.setIn(["microsoft_accounts", account, "enabled_for"], []);
+  }
+}
+
+function hasMicrosoftAccountEntry(doc: Document, account: string): boolean {
+  const accounts = doc.get("microsoft_accounts");
+  if (!isMap(accounts)) return false;
+  return (accounts as YAMLMap).has(account);
+}
+
+function pruneEmptyMap(doc: Document, path: string[]): void {
+  const node = doc.getIn(path);
+  if (isMap(node) && (node as YAMLMap).items.length === 0) {
+    doc.deleteIn(path);
+  }
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -992,6 +992,43 @@ export const AgentGoogleWorkspaceConfigSchema = z
   .optional();
 
 /**
+ * Per-agent microsoft_workspace override — RFC #1873.
+ * Pins which Microsoft account this agent uses for the M365 MCP surface.
+ * `microsoft_client_id/secret` are not per-agent (one app reg per
+ * switchroom install).
+ */
+export const AgentMicrosoftWorkspaceConfigSchema = z
+  .object({
+    account: z
+      .string()
+      .regex(/^[^@\s:]+@[^@\s:]+\.[^@\s:]+$/, {
+        message:
+          "microsoft_workspace.account must be a Microsoft account email like " +
+          "'alice@outlook.com' or 'alice@contoso.com' (colons not allowed)",
+      })
+      .transform((v) => v.trim().toLowerCase())
+      .optional()
+      .describe(
+        "RFC #1873: the Microsoft account this agent uses for the M365 MCP. " +
+        "Must be a key in top-level `microsoft_accounts:` with this agent " +
+        "listed in its `enabled_for[]`. Read by the auth-broker " +
+        "(get-credentials, provider=microsoft) and by the scaffold to " +
+        "decide whether to emit the `ms-365` MCP entry. Normalized to " +
+        "lowercase so it matches the microsoft_accounts key (which is " +
+        "also normalized)."
+      ),
+    org_mode: z
+      .boolean()
+      .optional()
+      .describe(
+        "Per-agent org_mode override (RFC #1873 §6.4). When set, replaces " +
+        "the top-level microsoft_workspace.org_mode for this agent. " +
+        "Defaults to top-level value (which defaults to false)."
+      ),
+  })
+  .optional();
+
+/**
  * Legacy alias for back-compat with RFC D shipped config. Identical shape
  * (tier added is fully optional). New code should prefer
  * `AgentGoogleWorkspaceConfigSchema`.
@@ -1723,6 +1760,13 @@ export const AgentSchema = z.object({
     "Mutually exclusive with `drive:` on the same agent (loader fails fast " +
     "if both are set).",
   ),
+  microsoft_workspace: AgentMicrosoftWorkspaceConfigSchema.describe(
+    "RFC #1873 (Microsoft 365 integration). Per-agent Microsoft Workspace " +
+    "override — pins the Microsoft account this agent reads via the " +
+    "auth-broker (must be a key in top-level `microsoft_accounts:` with " +
+    "this agent in its `enabled_for[]`) and optionally overrides org_mode. " +
+    "microsoft_client_id/secret are not per-agent.",
+  ),
   repos: z
     .record(
       z.string().regex(
@@ -2334,6 +2378,33 @@ export const SwitchroomConfigSchema = z.object({
       "auth google enable|disable` (Phase 3); read by the broker on " +
       "every Google slot access. Replaces RFC D's per-agent vault slot " +
       "scope (which can't express 'two agents share one Google account')."
+    ),
+  microsoft_accounts: z
+    .record(
+      z.string()
+        .regex(/^[^@\s:]+@[^@\s:]+\.[^@\s:]+$/, {
+          message: "Account key must be a Microsoft account email like 'alice@outlook.com' or 'alice@contoso.com' (colons not allowed)",
+        })
+        .transform((v) => v.trim().toLowerCase()),
+      z.object({
+        enabled_for: z
+          .array(z.string().regex(/^[a-z0-9][a-z0-9_-]{0,50}$/, {
+            message: "Agent name must match the standard agent-name pattern",
+          }))
+          .describe(
+            "Agent slugs that may read this Microsoft account's broker " +
+            "credentials. Per-agent ACL enforced at the broker; agents " +
+            "still authenticate via socket-path-as-identity, broker just " +
+            "gates the cross-agent token share. Mirrors google_accounts."
+          ),
+      }),
+    )
+    .optional()
+    .describe(
+      "RFC #1873: per-Microsoft-account ACL. Maps account email → list of " +
+      "agents permitted to use that account's broker credentials. Written " +
+      "by `switchroom auth microsoft enable|disable`; read by the broker " +
+      "on get-credentials with provider=microsoft."
     ),
   defaults: AgentDefaultsSchema.describe(
     "Implicit bottom-of-cascade profile applied to every agent before " +

--- a/src/microsoft/oauth.test.ts
+++ b/src/microsoft/oauth.test.ts
@@ -228,6 +228,247 @@ describe("buildHomeAccountId", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────
+// PR 2 additions — loopback + device-code + tier selection
+// ────────────────────────────────────────────────────────────────────────
+
+describe("selectInitialTier", () => {
+  it("forces tier from SWITCHROOM_MICROSOFT_OAUTH_TIER override", async () => {
+    const { selectInitialTier } = await import("./oauth.js");
+    expect(selectInitialTier({ SWITCHROOM_MICROSOFT_OAUTH_TIER: "device_code" }))
+      .toBe("device_code");
+    expect(selectInitialTier({ SWITCHROOM_MICROSOFT_OAUTH_TIER: "desktop_loopback" }))
+      .toBe("desktop_loopback");
+  });
+
+  it("returns device_code on headless host (SSH, no DISPLAY)", async () => {
+    const { selectInitialTier } = await import("./oauth.js");
+    expect(selectInitialTier({
+      SSH_CONNECTION: "1.2.3.4 4242 5.6.7.8 22",
+    })).toBe("device_code");
+  });
+
+  it("returns desktop_loopback when DISPLAY set + browser available", async () => {
+    const { selectInitialTier } = await import("./oauth.js");
+    expect(selectInitialTier({
+      DISPLAY: ":0",
+      ["SWITCHROOM_MICROSOFT_HAS_BROWSER_OPENER"]: "1",
+    } as Record<string, string>)).toBe("desktop_loopback");
+  });
+
+  it("falls back to device_code when DISPLAY set but no browser opener", async () => {
+    const { selectInitialTier } = await import("./oauth.js");
+    expect(selectInitialTier({
+      DISPLAY: ":0",
+      ["SWITCHROOM_MICROSOFT_HAS_BROWSER_OPENER"]: "0",
+    } as Record<string, string>)).toBe("device_code");
+  });
+});
+
+describe("detectHeadless", () => {
+  it("headless when SSH and no DISPLAY", async () => {
+    const { detectHeadless } = await import("./oauth.js");
+    expect(detectHeadless({ SSH_CONNECTION: "x" })).toBe(true);
+  });
+
+  it("not headless when DISPLAY and no SSH", async () => {
+    const { detectHeadless } = await import("./oauth.js");
+    expect(detectHeadless({ DISPLAY: ":0" })).toBe(false);
+  });
+
+  it("headless when SSH set even with DISPLAY (X-forwarding case)", async () => {
+    const { detectHeadless } = await import("./oauth.js");
+    expect(detectHeadless({ SSH_CONNECTION: "x", DISPLAY: ":0" })).toBe(true);
+  });
+});
+
+describe("buildLoopbackAuthUrl", () => {
+  it("constructs URL with PKCE challenge + state", async () => {
+    const { buildLoopbackAuthUrl } = await import("./oauth.js");
+    const url = buildLoopbackAuthUrl(
+      { client_id: "test-id", scopes: ["User.Read", "Mail.ReadWrite"] },
+      "http://127.0.0.1:8080",
+      "state-xyz",
+      "challenge-abc",
+    );
+    const u = new URL(url);
+    expect(u.hostname).toBe("login.microsoftonline.com");
+    expect(u.pathname).toBe("/common/oauth2/v2.0/authorize");
+    expect(u.searchParams.get("client_id")).toBe("test-id");
+    expect(u.searchParams.get("redirect_uri")).toBe("http://127.0.0.1:8080");
+    expect(u.searchParams.get("response_type")).toBe("code");
+    expect(u.searchParams.get("scope")).toBe("User.Read Mail.ReadWrite");
+    expect(u.searchParams.get("state")).toBe("state-xyz");
+    expect(u.searchParams.get("code_challenge")).toBe("challenge-abc");
+    expect(u.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(u.searchParams.get("prompt")).toBe("select_account");
+  });
+});
+
+describe("exchangeAuthCode", () => {
+  it("posts code + code_verifier to token endpoint", async () => {
+    const { exchangeAuthCode } = await import("./oauth.js");
+    const capture: { body?: string } = {};
+    const fetcher = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capture.body = init?.body as string;
+      return new Response(JSON.stringify({
+        access_token: "at",
+        refresh_token: "rt",
+        expires_in: 3600,
+        token_type: "Bearer",
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+    await exchangeAuthCode(
+      { client_id: "test-id", scopes: [] },
+      "auth-code-xyz",
+      "http://127.0.0.1:8080",
+      "verifier-xyz",
+      fetcher,
+    );
+    const params = new URLSearchParams(capture.body ?? "");
+    expect(params.get("client_id")).toBe("test-id");
+    expect(params.get("code")).toBe("auth-code-xyz");
+    expect(params.get("grant_type")).toBe("authorization_code");
+    expect(params.get("redirect_uri")).toBe("http://127.0.0.1:8080");
+    expect(params.get("code_verifier")).toBe("verifier-xyz");
+  });
+
+  it("throws on non-2xx response", async () => {
+    const { exchangeAuthCode } = await import("./oauth.js");
+    const fetcher = (async () =>
+      new Response(JSON.stringify({ error: "invalid_grant" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    await expect(exchangeAuthCode(
+      { client_id: "id", scopes: [] },
+      "bad", "http://x", "v", fetcher,
+    )).rejects.toThrow(/token exchange failed \(400\)/);
+  });
+});
+
+describe("requestDeviceCode", () => {
+  it("hits Microsoft's /devicecode endpoint", async () => {
+    const { requestDeviceCode } = await import("./oauth.js");
+    const capture: { url?: string; body?: string } = {};
+    const fetcher = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      capture.url = typeof input === "string" ? input : input.toString();
+      capture.body = init?.body as string;
+      return new Response(JSON.stringify({
+        device_code: "dc",
+        user_code: "ABCD-1234",
+        verification_uri: "https://microsoft.com/devicelogin",
+        expires_in: 900,
+        interval: 5,
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+    const resp = await requestDeviceCode(
+      { client_id: "test-id", scopes: ["User.Read"] },
+      fetcher,
+    );
+    expect(capture.url).toContain("/devicecode");
+    const params = new URLSearchParams(capture.body ?? "");
+    expect(params.get("client_id")).toBe("test-id");
+    expect(params.get("scope")).toBe("User.Read");
+    expect(resp.user_code).toBe("ABCD-1234");
+  });
+});
+
+describe("pollDeviceToken", () => {
+  it("returns token on success", async () => {
+    const { pollDeviceToken } = await import("./oauth.js");
+    const fetcher = (async () =>
+      new Response(JSON.stringify({
+        access_token: "at",
+        refresh_token: "rt",
+        expires_in: 3600,
+        token_type: "Bearer",
+      }), { status: 200, headers: { "content-type": "application/json" } })
+    ) as unknown as typeof fetch;
+    const sleepMs = async () => {};
+    const result = await pollDeviceToken(
+      { client_id: "id", scopes: [] },
+      { device_code: "dc", user_code: "AB-12", verification_uri: "x", expires_in: 60, interval: 1 },
+      { fetchImpl: fetcher, sleepMs },
+    );
+    expect(result.access_token).toBe("at");
+  });
+
+  it("retries on authorization_pending", async () => {
+    const { pollDeviceToken } = await import("./oauth.js");
+    let callCount = 0;
+    const fetcher = (async () => {
+      callCount++;
+      if (callCount < 3) {
+        return new Response(JSON.stringify({ error: "authorization_pending" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({
+        access_token: "at",
+        expires_in: 3600,
+        token_type: "Bearer",
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+    const sleepMs = async () => {};
+    const result = await pollDeviceToken(
+      { client_id: "id", scopes: [] },
+      { device_code: "dc", user_code: "AB", verification_uri: "x", expires_in: 60, interval: 1 },
+      { fetchImpl: fetcher, sleepMs },
+    );
+    expect(callCount).toBe(3);
+    expect(result.access_token).toBe("at");
+  });
+
+  it("throws on authorization_declined", async () => {
+    const { pollDeviceToken } = await import("./oauth.js");
+    const fetcher = (async () =>
+      new Response(JSON.stringify({ error: "authorization_declined" }), {
+        status: 400, headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    const sleepMs = async () => {};
+    await expect(pollDeviceToken(
+      { client_id: "id", scopes: [] },
+      { device_code: "dc", user_code: "x", verification_uri: "x", expires_in: 60, interval: 1 },
+      { fetchImpl: fetcher, sleepMs },
+    )).rejects.toThrow(/User denied/);
+  });
+
+  it("throws on expired_token", async () => {
+    const { pollDeviceToken } = await import("./oauth.js");
+    const fetcher = (async () =>
+      new Response(JSON.stringify({ error: "expired_token" }), {
+        status: 400, headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    const sleepMs = async () => {};
+    await expect(pollDeviceToken(
+      { client_id: "id", scopes: [] },
+      { device_code: "dc", user_code: "x", verification_uri: "x", expires_in: 60, interval: 1 },
+      { fetchImpl: fetcher, sleepMs },
+    )).rejects.toThrow(/Device code expired/);
+  });
+
+  it("times out if deadline passes", async () => {
+    const { pollDeviceToken } = await import("./oauth.js");
+    const fetcher = (async () =>
+      new Response(JSON.stringify({ error: "authorization_pending" }), {
+        status: 400, headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+    const sleepMs = async () => {};
+    let nowVal = 1_000_000;
+    const now = () => {
+      nowVal += 30_000;
+      return nowVal;
+    };
+    await expect(pollDeviceToken(
+      { client_id: "id", scopes: [] },
+      { device_code: "dc", user_code: "x", verification_uri: "x", expires_in: 1, interval: 1 },
+      { fetchImpl: fetcher, sleepMs, now },
+    )).rejects.toThrow(/timed out/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
 // generatePkcePair
 // ────────────────────────────────────────────────────────────────────────
 

--- a/src/microsoft/oauth.test.ts
+++ b/src/microsoft/oauth.test.ts
@@ -472,6 +472,138 @@ describe("pollDeviceToken", () => {
 // generatePkcePair
 // ────────────────────────────────────────────────────────────────────────
 
+// ────────────────────────────────────────────────────────────────────────
+// runLoopbackOAuth — full flow integration (ported from drive/oauth.test.ts
+// state-mismatch + happy-path patterns)
+// ────────────────────────────────────────────────────────────────────────
+
+describe("runLoopbackOAuth", () => {
+  it("happy path: opens server, completes consent, exchanges code", async () => {
+    const { runLoopbackOAuth } = await import("./oauth.js");
+    let authUrl = "";
+    const fetcher = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const params = new URLSearchParams(init?.body as string);
+      // Verify code_verifier was forwarded
+      expect(params.get("code_verifier")).toBeTruthy();
+      expect(params.get("code")).toBe("real-auth-code");
+      return new Response(JSON.stringify({
+        access_token: "at",
+        refresh_token: "rt",
+        expires_in: 3600,
+        token_type: "Bearer",
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+
+    const openImpl = async (url: string): Promise<boolean> => {
+      authUrl = url;
+      // Simulate Microsoft redirecting back to the loopback after consent.
+      const parsed = new URL(url);
+      const state = parsed.searchParams.get("state")!;
+      const redirectUri = parsed.searchParams.get("redirect_uri")!;
+      const callback = new URL(redirectUri);
+      callback.searchParams.set("code", "real-auth-code");
+      callback.searchParams.set("state", state);
+      // Microsoft's actual redirect — let it land asynchronously after listen.
+      setTimeout(() => {
+        // Use Node's http.get to hit the loopback callback.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const http = require("node:http") as typeof import("node:http");
+        const req = http.get(callback.toString());
+        req.on("error", () => { /* ignore */ });
+      }, 10);
+      return true;
+    };
+
+    const tokens = await runLoopbackOAuth(
+      { client_id: "test-id", scopes: ["User.Read"] },
+      { fetchImpl: fetcher, openImpl, timeoutMs: 10_000 },
+    );
+    expect(tokens.access_token).toBe("at");
+    expect(tokens.refresh_token).toBe("rt");
+    expect(authUrl).toContain("login.microsoftonline.com");
+  }, 20_000);
+
+  it("rejects state mismatch (CSRF guard)", async () => {
+    const { runLoopbackOAuth } = await import("./oauth.js");
+    const fetcher = (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch;
+    const openImpl = async (url: string): Promise<boolean> => {
+      const parsed = new URL(url);
+      const redirectUri = parsed.searchParams.get("redirect_uri")!;
+      const callback = new URL(redirectUri);
+      callback.searchParams.set("code", "code");
+      callback.searchParams.set("state", "wrong-state");
+      setTimeout(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const http = require("node:http") as typeof import("node:http");
+        const req = http.get(callback.toString());
+        req.on("error", () => { /* ignore */ });
+      }, 10);
+      return true;
+    };
+    await expect(runLoopbackOAuth(
+      { client_id: "test-id", scopes: ["User.Read"] },
+      { fetchImpl: fetcher, openImpl, timeoutMs: 10_000 },
+    )).rejects.toThrow(/state parameter mismatch/);
+  }, 20_000);
+
+  it("rejects callback with no code parameter", async () => {
+    const { runLoopbackOAuth } = await import("./oauth.js");
+    const fetcher = (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch;
+    const openImpl = async (url: string): Promise<boolean> => {
+      const parsed = new URL(url);
+      const redirectUri = parsed.searchParams.get("redirect_uri")!;
+      const state = parsed.searchParams.get("state")!;
+      const callback = new URL(redirectUri);
+      callback.searchParams.set("state", state);
+      // No code param
+      setTimeout(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const http = require("node:http") as typeof import("node:http");
+        const req = http.get(callback.toString());
+        req.on("error", () => { /* ignore */ });
+      }, 10);
+      return true;
+    };
+    await expect(runLoopbackOAuth(
+      { client_id: "test-id", scopes: ["User.Read"] },
+      { fetchImpl: fetcher, openImpl, timeoutMs: 10_000 },
+    )).rejects.toThrow(/missing 'code'/);
+  }, 20_000);
+
+  it("propagates Microsoft error response from callback", async () => {
+    const { runLoopbackOAuth } = await import("./oauth.js");
+    const fetcher = (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch;
+    const openImpl = async (url: string): Promise<boolean> => {
+      const parsed = new URL(url);
+      const redirectUri = parsed.searchParams.get("redirect_uri")!;
+      const callback = new URL(redirectUri);
+      callback.searchParams.set("error", "access_denied");
+      callback.searchParams.set("error_description", "User denied consent");
+      setTimeout(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const http = require("node:http") as typeof import("node:http");
+        const req = http.get(callback.toString());
+        req.on("error", () => { /* ignore */ });
+      }, 10);
+      return true;
+    };
+    await expect(runLoopbackOAuth(
+      { client_id: "test-id", scopes: ["User.Read"] },
+      { fetchImpl: fetcher, openImpl, timeoutMs: 10_000 },
+    )).rejects.toThrow(/access_denied/);
+  }, 20_000);
+
+  it("times out if no callback ever arrives", async () => {
+    const { runLoopbackOAuth } = await import("./oauth.js");
+    const fetcher = (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch;
+    const openImpl = async () => true; // Don't actually call back
+    await expect(runLoopbackOAuth(
+      { client_id: "test-id", scopes: ["User.Read"] },
+      { fetchImpl: fetcher, openImpl, timeoutMs: 200 },
+    )).rejects.toThrow(/timed out/);
+  });
+});
+
 describe("generatePkcePair", () => {
   it("returns a verifier + challenge with non-empty shapes", () => {
     const pair = generatePkcePair();

--- a/src/microsoft/oauth.ts
+++ b/src/microsoft/oauth.ts
@@ -21,6 +21,8 @@
  */
 
 import * as crypto from "node:crypto";
+import * as http from "node:http";
+import { spawn } from "node:child_process";
 
 /**
  * Microsoft's v2.0 OAuth/OIDC base. `/common` accepts both personal MSA
@@ -193,4 +195,446 @@ export function generatePkcePair(): { verifier: string; challenge: string } {
     .update(verifier)
     .digest("base64url");
   return { verifier, challenge };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Tier selection — mirrors src/drive/oauth.ts shape
+// ────────────────────────────────────────────────────────────────────────
+
+export type MicrosoftOAuthTier = "device_code" | "desktop_loopback";
+
+export interface MicrosoftOAuthEnv {
+  DISPLAY?: string;
+  WAYLAND_DISPLAY?: string;
+  SSH_CONNECTION?: string;
+  SSH_TTY?: string;
+  /** Test/operator override: force a tier regardless of env. */
+  SWITCHROOM_MICROSOFT_OAUTH_TIER?: string;
+}
+
+/**
+ * Decide whether the host is headless. Same heuristic as drive/oauth.ts:
+ * no graphical display server AND inside an SSH session.
+ */
+export function detectHeadless(env: MicrosoftOAuthEnv): boolean {
+  const hasDisplay = Boolean(
+    (env.DISPLAY && env.DISPLAY.trim() !== "") ||
+    (env.WAYLAND_DISPLAY && env.WAYLAND_DISPLAY.trim() !== ""),
+  );
+  const inSsh = Boolean(
+    (env.SSH_CONNECTION && env.SSH_CONNECTION.trim() !== "") ||
+    (env.SSH_TTY && env.SSH_TTY.trim() !== ""),
+  );
+  if (hasDisplay && !inSsh) return false;
+  return true;
+}
+
+/**
+ * Pick the preferred OAuth tier. Unlike Google (which has 3 tiers
+ * because device-code fails for Drive scopes), Microsoft's device-code
+ * works fine for the v1 scope set on personal MSA + work — so we have
+ * a clean two-tier ladder. Headless hosts default to device-code;
+ * desktops with a browser default to loopback.
+ */
+export function selectInitialTier(env: MicrosoftOAuthEnv): MicrosoftOAuthTier {
+  const override = env.SWITCHROOM_MICROSOFT_OAUTH_TIER;
+  if (override === "device_code" || override === "desktop_loopback") {
+    return override;
+  }
+  if (detectHeadless(env)) return "device_code";
+  if (hasBrowserOpener(env)) return "desktop_loopback";
+  return "device_code";
+}
+
+/**
+ * Detect whether a browser-opener is available on the host. Tests can
+ * short-circuit by setting `SWITCHROOM_MICROSOFT_HAS_BROWSER_OPENER`.
+ */
+export function hasBrowserOpener(
+  env: MicrosoftOAuthEnv & {
+    SWITCHROOM_MICROSOFT_HAS_BROWSER_OPENER?: string;
+    PATH?: string;
+  } = {},
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const override = env.SWITCHROOM_MICROSOFT_HAS_BROWSER_OPENER;
+  if (override === "1") return true;
+  if (override === "0") return false;
+
+  if ((platform as string) === "win32") return true;
+  const candidate = platform === "darwin" ? "open" : "xdg-open";
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require("node:fs") as typeof import("node:fs");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require("node:path") as typeof import("node:path");
+    const pathEnv = env.PATH ?? process.env.PATH ?? "";
+    const sep = (platform as string) === "win32" ? ";" : ":";
+    for (const dir of pathEnv.split(sep)) {
+      if (!dir) continue;
+      try {
+        const full = path.join(dir, candidate);
+        fs.accessSync(full, fs.constants.X_OK);
+        return true;
+      } catch {
+        /* not here */
+      }
+    }
+  } catch {
+    /* fall through */
+  }
+  return false;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Auth-code exchange (PKCE) — used by loopback flow
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Exchange an authorization code for tokens. Includes PKCE
+ * `code_verifier`. Used by the loopback flow after the browser callback.
+ */
+export async function exchangeAuthCode(
+  cfg: MicrosoftOAuthClientConfig,
+  code: string,
+  redirectUri: string,
+  codeVerifier: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<MicrosoftTokenResponse> {
+  const body = new URLSearchParams({
+    client_id: cfg.client_id,
+    code,
+    grant_type: "authorization_code",
+    redirect_uri: redirectUri,
+    code_verifier: codeVerifier,
+  });
+  if (cfg.client_secret !== undefined && cfg.client_secret.length > 0) {
+    body.set("client_secret", cfg.client_secret);
+  }
+  if (cfg.scopes && cfg.scopes.length > 0) {
+    body.set("scope", cfg.scopes.join(" "));
+  }
+  const res = await fetchImpl(`${MICROSOFT_OAUTH_BASE}/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`token exchange failed (${res.status}): ${text}`);
+  }
+  return (await res.json()) as MicrosoftTokenResponse;
+}
+
+/**
+ * Build the loopback consent URL targeting an ephemeral local
+ * redirect_uri with PKCE `code_challenge`.
+ *
+ * Microsoft's v2 `/authorize` endpoint. `prompt=select_account`
+ * always shows the account picker (better for multi-account users).
+ */
+export function buildLoopbackAuthUrl(
+  cfg: MicrosoftOAuthClientConfig,
+  redirectUri: string,
+  state: string,
+  codeChallenge: string,
+): string {
+  const u = new URL(`${MICROSOFT_OAUTH_BASE}/authorize`);
+  u.searchParams.set("client_id", cfg.client_id);
+  u.searchParams.set("redirect_uri", redirectUri);
+  u.searchParams.set("response_type", "code");
+  u.searchParams.set("scope", cfg.scopes.join(" "));
+  u.searchParams.set("response_mode", "query");
+  u.searchParams.set("prompt", "select_account");
+  u.searchParams.set("state", state);
+  u.searchParams.set("code_challenge", codeChallenge);
+  u.searchParams.set("code_challenge_method", "S256");
+  return u.toString();
+}
+
+/**
+ * Best-effort browser open. Returns true on successful spawn.
+ */
+export async function openBrowser(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+  spawnImpl: typeof spawn = spawn,
+): Promise<boolean> {
+  let cmd: string;
+  let args: string[];
+  if (platform === "darwin") {
+    cmd = "open";
+    args = [url];
+  } else if ((platform as string) === "win32") {
+    cmd = "cmd";
+    args = ["/c", "start", "", url];
+  } else {
+    cmd = "xdg-open";
+    args = [url];
+  }
+  return new Promise<boolean>((resolve) => {
+    try {
+      const p = spawnImpl(cmd, args, { stdio: "ignore", detached: true });
+      p.once("error", () => resolve(false));
+      p.once("spawn", () => {
+        try {
+          p.unref();
+        } catch {
+          /* noop */
+        }
+        resolve(true);
+      });
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+export interface MicrosoftLoopbackOptions {
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+  openImpl?: (url: string) => Promise<boolean>;
+  onAuthUrl?: (url: string, opened: boolean) => void;
+  host?: string;
+}
+
+/**
+ * Run the desktop-loopback OAuth flow against Microsoft v2:
+ *   1. Generate PKCE pair + CSRF state
+ *   2. Bind 127.0.0.1:0
+ *   3. Open Microsoft consent URL (or print it)
+ *   4. Wait for Microsoft to redirect back with ?code=...&state=...
+ *   5. Validate state, exchange code at /token with code_verifier
+ *
+ * Always closes the ephemeral server before returning.
+ */
+export async function runLoopbackOAuth(
+  cfg: MicrosoftOAuthClientConfig,
+  opts: MicrosoftLoopbackOptions = {},
+): Promise<MicrosoftTokenResponse> {
+  const timeoutMs = opts.timeoutMs ?? 5 * 60 * 1000;
+  const host = opts.host ?? "127.0.0.1";
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const openImpl = opts.openImpl ?? openBrowser;
+  const state = crypto.randomBytes(16).toString("hex");
+  const { verifier, challenge } = generatePkcePair();
+
+  let server: http.Server | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const closeServer = (): Promise<void> =>
+    new Promise((resolve) => {
+      if (!server) return resolve();
+      const s = server;
+      server = null;
+      s.close(() => resolve());
+      try {
+        s.unref();
+      } catch {
+        /* noop */
+      }
+    });
+
+  try {
+    const { code, redirectUri } = await new Promise<{
+      code: string;
+      redirectUri: string;
+    }>((resolve, reject) => {
+      server = http.createServer((req, res) => {
+        try {
+          const url = new URL(req.url ?? "/", `http://${host}`);
+          if (url.pathname !== "/") {
+            res.writeHead(404, { "content-type": "text/plain" });
+            res.end("Not found");
+            return;
+          }
+          const gotState = url.searchParams.get("state");
+          const gotCode = url.searchParams.get("code");
+          const gotErr = url.searchParams.get("error");
+          const gotErrDesc = url.searchParams.get("error_description");
+
+          if (gotErr) {
+            renderHtml(
+              res,
+              400,
+              "Authorization failed",
+              `Microsoft returned: ${escapeHtml(gotErr)}. ${escapeHtml(gotErrDesc ?? "")} You can close this tab.`,
+            );
+            reject(new Error(`OAuth error from Microsoft: ${gotErr} ${gotErrDesc ?? ""}`));
+            return;
+          }
+          if (!gotState || gotState !== state) {
+            renderHtml(res, 400, "Authorization failed", "State parameter mismatch — refusing this callback. You can close this tab.");
+            reject(new Error("OAuth state parameter mismatch (possible CSRF)."));
+            return;
+          }
+          if (!gotCode) {
+            renderHtml(res, 400, "Authorization failed", "No authorization code present. You can close this tab.");
+            reject(new Error("OAuth callback missing 'code' parameter."));
+            return;
+          }
+          renderHtml(res, 200, "Microsoft authorization complete", "You can close this tab and return to the terminal.");
+          const hostHeader = req.headers.host ?? `${host}:?`;
+          resolve({
+            code: gotCode,
+            redirectUri: `http://${hostHeader}`,
+          });
+        } catch (e) {
+          reject(e instanceof Error ? e : new Error(String(e)));
+        }
+      });
+
+      server.on("error", (e) => reject(e));
+
+      server.listen(0, host, () => {
+        const addr = server!.address();
+        if (!addr || typeof addr === "string") {
+          reject(new Error("Failed to determine ephemeral port for loopback OAuth."));
+          return;
+        }
+        const redirectUri = `http://${host}:${addr.port}`;
+        const authUrl = buildLoopbackAuthUrl(cfg, redirectUri, state, challenge);
+        openImpl(authUrl)
+          .then((opened) => opts.onAuthUrl?.(authUrl, opened))
+          .catch(() => opts.onAuthUrl?.(authUrl, false));
+      });
+
+      timer = setTimeout(() => {
+        reject(
+          new Error(
+            `Loopback OAuth timed out after ${Math.round(timeoutMs / 1000)}s waiting for browser callback.`,
+          ),
+        );
+      }, timeoutMs);
+    });
+
+    if (timer) clearTimeout(timer);
+    await closeServer();
+    return await exchangeAuthCode(cfg, code, redirectUri, verifier, fetchImpl);
+  } finally {
+    if (timer) clearTimeout(timer);
+    await closeServer();
+  }
+}
+
+function renderHtml(
+  res: http.ServerResponse,
+  status: number,
+  title: string,
+  body: string,
+): void {
+  const html = `<!doctype html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title><style>body{font-family:system-ui,sans-serif;max-width:480px;margin:4em auto;padding:0 1em;color:#222}h1{font-size:1.25em}</style></head><body><h1>${escapeHtml(title)}</h1><p>${body}</p></body></html>`;
+  res.writeHead(status, { "content-type": "text/html; charset=utf-8" });
+  res.end(html);
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Device-code flow (RFC 8628) — Microsoft v2
+// ────────────────────────────────────────────────────────────────────────
+
+export interface MicrosoftDeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  /** Some Microsoft responses include this; not in RFC 8628. Optional. */
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval: number;
+  message?: string;
+}
+
+/**
+ * RFC 8628 device-authorization request against Microsoft v2 `/devicecode`.
+ * Note: Microsoft's older docs (since corrected in MSAL.NET 4.5+ release
+ * notes) claimed device-code didn't work on /common — it does. See RFC
+ * §4.2 "stale-doc trap".
+ */
+export async function requestDeviceCode(
+  cfg: MicrosoftOAuthClientConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<MicrosoftDeviceCodeResponse> {
+  const body = new URLSearchParams({
+    client_id: cfg.client_id,
+    scope: cfg.scopes.join(" "),
+  });
+  const res = await fetchImpl(
+    `https://login.microsoftonline.com/common/oauth2/v2.0/devicecode`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`device_code request failed (${res.status}): ${text}`);
+  }
+  return (await res.json()) as MicrosoftDeviceCodeResponse;
+}
+
+/**
+ * Poll the token endpoint until the user completes consent or we time out.
+ * Implements RFC 8628 §3.5: respect `interval`, back off on `slow_down`,
+ * terminate on `authorization_declined` / `expired_token`.
+ */
+export async function pollDeviceToken(
+  cfg: MicrosoftOAuthClientConfig,
+  device: MicrosoftDeviceCodeResponse,
+  opts: {
+    fetchImpl?: typeof fetch;
+    sleepMs?: (ms: number) => Promise<void>;
+    now?: () => number;
+  } = {},
+): Promise<MicrosoftTokenResponse> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const sleepMs = opts.sleepMs ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const now = opts.now ?? Date.now;
+
+  let interval = device.interval > 0 ? device.interval : 5;
+  const deadline = now() + device.expires_in * 1000;
+
+  while (now() < deadline) {
+    await sleepMs(interval * 1000);
+    const body = new URLSearchParams({
+      client_id: cfg.client_id,
+      device_code: device.device_code,
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    });
+    if (cfg.client_secret !== undefined && cfg.client_secret.length > 0) {
+      body.set("client_secret", cfg.client_secret);
+    }
+    const res = await fetchImpl(`${MICROSOFT_OAUTH_BASE}/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    if (res.ok && typeof json.access_token === "string") {
+      return json as unknown as MicrosoftTokenResponse;
+    }
+    const err = json.error;
+    if (err === "authorization_pending") continue;
+    if (err === "slow_down") {
+      interval += 5;
+      continue;
+    }
+    if (err === "authorization_declined" || err === "access_denied") {
+      throw new Error("User denied the consent request.");
+    }
+    if (err === "expired_token" || err === "code_expired") {
+      throw new Error("Device code expired before consent.");
+    }
+    throw new Error(`Token poll failed: ${JSON.stringify(json)}`);
+  }
+  throw new Error("Device-code consent timed out.");
 }


### PR DESCRIPTION
## Summary

RFC #1873 PR 2 of 5 ([tracking issue #1875](https://github.com/switchroom/switchroom/issues/1875)). Lands the operator-facing CLI verbs for Microsoft 365 account management.

**Tested**: 59 new tests (18 YAML helpers + 41 oauth primitives + extensions). Full suite 7692 passing. tsc --noEmit clean. dist/ builds clean.

## What this adds

**CLI verbs** (mirror `switchroom auth google ...`):
- `enable <account> <agents...>` — adds agents to `microsoft_accounts.<email>.enabled_for[]`
- `disable <account> <agents...>` — removes from ACL; dormant-on-empty per RFC §6.1
- `list` — accounts × agents matrix
- `account add <account> [--replace] [--org-mode]` — OAuth loopback OR device-code, decode id_token, register with broker
- `account remove <account>` — refused while any agent enabled
- `account list` — stub awaiting list-microsoft-accounts broker op

**OAuth ladder** — two-tier (vs Google's three): Microsoft device-code works fine for v1 scopes on personal MSA + work, so we have a clean `desktop_loopback` (auto-detected when DISPLAY+browser) / `device_code` (auto on headless) split. Operator override via `SWITCHROOM_MICROSOFT_OAUTH_TIER`.

**Schema additions:**
- Top-level `microsoft_accounts:` block (per-account ACL)
- Per-agent `microsoft_workspace:` override (account selector + org_mode)
- `MicrosoftAddAccountCredentials` in the broker client union

**OAuth primitives** in `src/microsoft/oauth.ts`:
- `selectInitialTier` / `detectHeadless` / `hasBrowserOpener`
- `exchangeAuthCode` (PKCE) + `buildLoopbackAuthUrl` + `runLoopbackOAuth` (full HTTP server + PKCE + CSRF + token exchange)
- `requestDeviceCode` + `pollDeviceToken` (RFC 8628 §3.5 polling)

## Notable design decisions

- **`connect` wizard deferred**. The Entra portal walkthrough is 8 steps with screenshots that don't translate to a terminal wizard cleanly. The `account add` verb prints a complete walkthrough as the error when `microsoft_workspace:` is missing — passes the docs test (`reference/principles.md` §1: usable without opening docs/).
- **Public-client apps default** — `microsoft_client_secret` is optional. Loopback uses PKCE; refresh forwards client_id only when secret is absent. This matches Microsoft's recommendation for desktop apps + family-calendar app's pattern.
- **Scope set hardcoded** — v1 (per RFC §4.3): `openid profile email offline_access User.Read Mail.ReadWrite Calendars.ReadWrite Files.ReadWrite.All`. `--org-mode` adds `Sites.ReadWrite.All` (SharePoint).
- **`list-microsoft-accounts` broker op deferred** — stub in `account list`. Mirrors RFC G's list-google-accounts follow-up. Operators get the YAML matrix view via `auth microsoft list` for now.

## Test coverage

- **microsoft-accounts-yaml.test.ts** (18 tests): enable/disable/list/remove with YAML round-trips, comment preservation, dormant-on-empty, source-order preservation
- **microsoft/oauth.test.ts** (+16 new tests): selectInitialTier (override + headless detection), detectHeadless (SSH/DISPLAY combinations), buildLoopbackAuthUrl (PKCE + state + prompt=select_account), exchangeAuthCode (form-body shape), requestDeviceCode + pollDeviceToken (success + slow_down + authorization_declined + expired_token + timeout)

## Test plan

- [x] vitest run on new test files (59 passed)
- [x] full vitest suite (7692 passed)
- [x] bun test telegram-plugin/tests (3466 passed; UAT failures pre-existing — need live Telegram)
- [x] tsc --noEmit clean
- [x] dist/ builds clean
- [ ] Reviewer agent verifies the no-connect-wizard tradeoff is acceptable
- [ ] Reviewer checks the OAuth flow corner cases (PKCE + state CSRF + token expiry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)