### PR TITLE
fix(gateway): sweep claudeBusyKeys orphans on bridge disconnect (PR3b follow-up)

### DIFF
--- a/telegram-plugin/gateway/disconnect-flush.ts
+++ b/telegram-plugin/gateway/disconnect-flush.ts
@@ -140,6 +140,30 @@ export function flushOnAgentDisconnect<
     onDanglingTurnsSwept?.(danglingKeys)
   }
 
+  // PR3b orphan-sweep (#1880 follow-up): claudeBusyKeys can hold keys
+  // that activeTurnStartedAt does NOT — specifically when a synthetic
+  // inbound (cron via onInjectInbound, reaction dispatch, vault
+  // grant-approved / -denied / save-discarded / -failed / -completed,
+  // button-callback) was delivered. Those paths bypass handleInbound's
+  // fresh-turn branch (which is what would set activeTurnStartedAt),
+  // so the sweep loop above wouldn't notice them. Pre-PR3b this was
+  // invisible because the fleet gate read activeTurnStartedAt.size —
+  // synthetic-only turns never registered. PR3b's claudeBusyKeys.add
+  // is the more-accurate "claude is busy on this" gate, which means
+  // a synthetic-delivered turn that dies WITHOUT turn_end leaves an
+  // orphan that the activeTurnStartedAt-keyed sweep can't see.
+  // Cure: clear any leftover busy keys here. Bridge died → every
+  // busy key is dead by definition. Same justification as the
+  // dangling-sweep above for activeTurnStartedAt.
+  if (claudeBusyKeys.size > 0) {
+    const orphanCount = claudeBusyKeys.size
+    claudeBusyKeys.clear()
+    log(
+      `telegram gateway: disconnect-flush cleared ${orphanCount} orphan claudeBusyKeys ` +
+      `entr${orphanCount === 1 ? 'y' : 'ies'} (synthetic-inbound deliveries that never turn_ended)`,
+    )
+  }
+
   // Stop coalesce timers that could emit into a finalized draft stream, but
   // preserve chats with pendingCompletion=true — those have background
   // sub-agents that legitimately outlive the parent bridge disconnect. The

--- a/telegram-plugin/tests/gateway-disconnect-flush.test.ts
+++ b/telegram-plugin/tests/gateway-disconnect-flush.test.ts
@@ -252,6 +252,106 @@ describe('flushOnAgentDisconnect — dangling-turn sweep (2026-05-23 wedge fix)'
     expect(onDanglingTurnsSwept).not.toHaveBeenCalled()
   })
 
+  // PR3b orphan-sweep regression: synthetic-inbound deliveries
+  // (cron, reactions, vault, button-callback) bypass handleInbound's
+  // fresh-turn branch and so never stamp activeTurnStartedAt. They
+  // DO mark claudeBusyKeys. If their turn dies without turn_end, the
+  // activeTurnStartedAt-keyed dangling sweep misses them — orphan
+  // persists in claudeBusyKeys → fleet gate wedges. This test pins
+  // the post-sweep claudeBusyKeys.clear() fix.
+  it('sweeps claudeBusyKeys orphans that have NO activeTurnStartedAt entry (PR3b follow-up)', () => {
+    const onDanglingTurnsSwept = vi.fn()
+    const log = vi.fn()
+    const deps = {
+      agentName: 'clerk',
+      activeStatusReactions: new Map<string, FakeCtrl>(),
+      activeReactionMsgIds: new Map<string, { chatId: string; messageId: number }>(),
+      activeTurnStartedAt: new Map<string, number>(),
+      // The orphan scenario: claude was handed a turn (e.g. cron
+      // synthetic delivered), so claudeBusyKeys has it, but
+      // activeTurnStartedAt was never set because cron bypasses
+      // handleInbound's fresh-turn branch.
+      claudeBusyKeys: new Set<string>(['cron-only-key:_']),
+      activeDraftStreams: new Map<string, FakeStream>(),
+      activeDraftParseModes: new Map<string, 'HTML' | 'MarkdownV2' | undefined>(),
+      clearActiveReactions: vi.fn(),
+      disposeProgressDriver: vi.fn(),
+      onDanglingTurnsSwept,
+      log,
+    }
+
+    flushOnAgentDisconnect(deps)
+
+    // The orphan is cleared even though it never had an
+    // activeTurnStartedAt entry.
+    expect(deps.claudeBusyKeys.size).toBe(0)
+    // The activeTurnStartedAt-keyed sweep wasn't fired (nothing in
+    // that map to sweep) — so onDanglingTurnsSwept shouldn't fire
+    // either. The orphan sweep is a separate observation.
+    expect(onDanglingTurnsSwept).not.toHaveBeenCalled()
+    // But it logs the orphan-clear so operators can see it.
+    expect(
+      log.mock.calls.some((c: unknown[]) =>
+        typeof c[0] === 'string' && /orphan claudeBusyKeys/.test(c[0]),
+      ),
+    ).toBe(true)
+  })
+
+  it('orphan-sweep singular vs plural log message agrees with count', () => {
+    // Tiny grammar regression: "1 entry" vs "2 entries".
+    const log = vi.fn()
+    const baseDeps = {
+      agentName: 'clerk',
+      activeStatusReactions: new Map<string, FakeCtrl>(),
+      activeReactionMsgIds: new Map<string, { chatId: string; messageId: number }>(),
+      activeTurnStartedAt: new Map<string, number>(),
+      activeDraftStreams: new Map<string, FakeStream>(),
+      activeDraftParseModes: new Map<string, 'HTML' | 'MarkdownV2' | undefined>(),
+      clearActiveReactions: vi.fn(),
+      disposeProgressDriver: vi.fn(),
+    }
+    // Singular form.
+    flushOnAgentDisconnect({
+      ...baseDeps,
+      claudeBusyKeys: new Set<string>(['k1:_']),
+      log,
+    })
+    expect(log.mock.calls.some((c: unknown[]) =>
+      typeof c[0] === 'string' && / 1 orphan claudeBusyKeys entry /.test(c[0]),
+    )).toBe(true)
+    // Plural form.
+    log.mockClear()
+    flushOnAgentDisconnect({
+      ...baseDeps,
+      claudeBusyKeys: new Set<string>(['k1:_', 'k2:1']),
+      log,
+    })
+    expect(log.mock.calls.some((c: unknown[]) =>
+      typeof c[0] === 'string' && / 2 orphan claudeBusyKeys entries /.test(c[0]),
+    )).toBe(true)
+  })
+
+  it('does NOT fire orphan-sweep log when claudeBusyKeys is empty', () => {
+    // Zero-noise discipline: every disconnect for a healthy idle
+    // agent shouldn't produce a "0 orphan claudeBusyKeys" line.
+    const log = vi.fn()
+    flushOnAgentDisconnect({
+      agentName: 'clerk',
+      activeStatusReactions: new Map<string, FakeCtrl>(),
+      activeReactionMsgIds: new Map<string, { chatId: string; messageId: number }>(),
+      activeTurnStartedAt: new Map<string, number>(),
+      claudeBusyKeys: new Set<string>(),
+      activeDraftStreams: new Map<string, FakeStream>(),
+      activeDraftParseModes: new Map<string, 'HTML' | 'MarkdownV2' | undefined>(),
+      clearActiveReactions: vi.fn(),
+      disposeProgressDriver: vi.fn(),
+      log,
+    })
+    expect(log.mock.calls.some((c: unknown[]) =>
+      typeof c[0] === 'string' && /orphan claudeBusyKeys/.test(c[0]),
+    )).toBe(false)
+  })
+
   it('omitting onDanglingTurnsSwept is safe (optional callback)', () => {
     // Backward-compat guard — existing callers that don't pass the new
     // callback still work without runtime error.


### PR DESCRIPTION
## Summary

Closes a strictly-new latent leak introduced by PR3b (#1880): \`claudeBusyKeys\` can hold keys that \`activeTurnStartedAt\` does NOT — synthetic-inbound deliveries (cron / reactions / vault / button-callback) bypass handleInbound's fresh-turn branch (the only path that sets activeTurnStartedAt), but they DO mark claudeBusyKeys.

If such a synthetic-delivered turn dies without turn_end, the existing recovery sweeps (disconnect-flush iterating activeTurnStartedAt.keys(), silence-poke framework-fallback keyed off activeTurnStartedAt entries) can't see it → orphan persists → fleet flush gate wedges forever.

## The fix

One \`claudeBusyKeys.clear()\` appended to \`flushOnAgentDisconnect\`. Same justification as the existing dangling-sweep block immediately above it: bridge died, every busy key is dead by definition.

## Test plan

- [x] vitest run telegram-plugin/ — 12/12 disconnect-flush tests pass (9 existing + 3 new)
- [x] tsc --noEmit clean
- [x] Three new tests pin: orphan-with-no-activeTurnStartedAt-entry / singular-vs-plural grammar / zero-noise-when-empty

## Why this folds into v0.13.53

Release PR #1883 merged but not yet tagged. Landing this fix before tagging means the leak never ships to a release.

## Discovery

Edge-case audit subagent caught this while validating PR3b for parallel-turns correctness — flagged as GAP-6 + GAP-9 (same root cause). Two unrelated symptoms reduce to one orphan-class with one line fix.