### PR TITLE
feat(telegram-plugin): MS-365 write approval hook (RFC #1873 PR 4/5)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -166,6 +166,12 @@ RUN chmod 0755 /opt/switchroom/autoaccept-poll.js
 COPY dist/cli/drive-write-pretool.mjs /opt/switchroom/hooks/drive-write-pretool.mjs
 RUN chmod 0755 /opt/switchroom/hooks/drive-write-pretool.mjs
 
+# MS-365 write PreToolUse hook (RFC #1873 §8 PR 4). Mirror of
+# drive-write-pretool — gates softeria's OneDrive/Mail/Calendar write
+# tools behind a Telegram approval card with weak-metadata payload.
+COPY dist/cli/ms-365-write-pretool.mjs /opt/switchroom/hooks/ms-365-write-pretool.mjs
+RUN chmod 0755 /opt/switchroom/hooks/ms-365-write-pretool.mjs
+
 # Advisory skill-shape linter (RFC native-by-default skill authoring,
 # Phase 1). Non-blocking — nudges the model toward a well-formed skill
 # when it writes under .claude/skills/; only the per-skill byte cap is
@@ -191,6 +197,7 @@ COPY docker/security-plugin/.claude-plugin /opt/switchroom/security-plugin/.clau
 COPY docker/security-plugin/hooks/hooks.json /opt/switchroom/security-plugin/hooks/hooks.json
 COPY telegram-plugin/hooks/secret-guard-pretool.mjs /opt/switchroom/security-plugin/hooks/secret-guard-pretool.mjs
 COPY dist/cli/drive-write-pretool.mjs /opt/switchroom/security-plugin/hooks/drive-write-pretool.mjs
+COPY dist/cli/ms-365-write-pretool.mjs /opt/switchroom/security-plugin/hooks/ms-365-write-pretool.mjs
 RUN chmod 0755 /opt/switchroom/security-plugin/hooks/*.mjs
 
 # switchroom CLI bundle: the in-container telegram-plugin gateway sidecar

--- a/docker/security-plugin/hooks/hooks.json
+++ b/docker/security-plugin/hooks/hooks.json
@@ -18,6 +18,15 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ms-365-write-pretool.mjs\"",
+            "timeout": 10
+          }
+        ]
       }
     ]
   }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -148,6 +148,21 @@ if (hookEscape.changed) {
   console.log(`[build] ASCII-escaped ${hookEscape.nonAsciiCount} non-ASCII code units in dist/cli/drive-write-pretool.mjs`);
 }
 
+// Bundle the ms-365-write-pretool hook — RFC #1873 §8 PR 4. Same
+// pattern as drive-write-pretool: self-contained .mjs the agent
+// container runs via node.
+console.log("[build] bundling src/cli/ms-365-write-pretool.ts -> dist/cli/ms-365-write-pretool.mjs");
+execSync(
+  `bun build ${JSON.stringify(resolve(root, "src/cli/ms-365-write-pretool.ts"))} --outfile ${JSON.stringify(resolve(outDir, "ms-365-write-pretool.mjs"))} --target node`,
+  { stdio: "inherit", cwd: root }
+);
+const ms365HookOutFile = resolve(outDir, "ms-365-write-pretool.mjs");
+chmodSync(ms365HookOutFile, 0o755);
+const ms365HookEscape = escapeBundleNonAscii(ms365HookOutFile);
+if (ms365HookEscape.changed) {
+  console.log(`[build] ASCII-escaped ${ms365HookEscape.nonAsciiCount} non-ASCII code units in dist/cli/ms-365-write-pretool.mjs`);
+}
+
 // Bundle the skill-validate-pretool hook — RFC native-by-default skill
 // authoring, Phase 1. Same pattern: standalone .mjs the agent container
 // runs via node. It imports the shared validators from src/cli/

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3368,6 +3368,26 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           ],
         },
         {
+          // RFC #1873 §8 — gates softeria write tools (OneDrive upload,
+          // mail/calendar mutations) behind a Telegram approval card.
+          // Mirror of the drive-write-pretool above. Matcher is scoped
+          // to the ms-365 MCP server key emitted by resolveMs365McpEntry
+          // in PR 3. The hook's GATED_MS365_WRITE_TOOLS set further
+          // filters to only write verbs (uploads + create/update/delete
+          // for calendar/mail) — read-only tools pass through unchanged.
+          matcher: "^mcp__ms-365__",
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:ms-365-write-pretool",
+                `node "${join(DOCKER_BUNDLED_HOOKS_PATH, "ms-365-write-pretool.mjs")}"`,
+              ),
+              timeout: 5 * 60 + 30,
+            },
+          ],
+        },
+        {
           // RFC native-by-default skill authoring, Phase 1 — advisory
           // skill-shape linter. Scoped to file-write tools; the hook
           // itself no-ops unless the target path is under

--- a/src/cli/ms-365-write-pretool.test.ts
+++ b/src/cli/ms-365-write-pretool.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for ms-365-write-pretool — RFC #1873 §8 PR 4.
+ *
+ * Pure-function tests for the testable surface. The async main() flow
+ * (stdin parse, gateway IPC, kernel poll) is not unit-tested here —
+ * it's tested in the gateway handler tests + UAT scenarios in PR 5.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  extractMs365Preview,
+  GATED_MS365_WRITE_TOOLS,
+  isGatedMs365Tool,
+} from "./ms-365-write-pretool.js";
+
+describe("isGatedMs365Tool", () => {
+  it("returns true for known gated tools", () => {
+    expect(isGatedMs365Tool("mcp__ms-365__upload-file-content")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__create-upload-session")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__create-event")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__update-event")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__delete-event")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__update-message")).toBe(true);
+    expect(isGatedMs365Tool("mcp__ms-365__delete-message")).toBe(true);
+  });
+
+  it("returns false for read tools (no gating overhead)", () => {
+    expect(isGatedMs365Tool("mcp__ms-365__list-files")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__get-drive-item")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__list-events")).toBe(false);
+  });
+
+  it("returns false for non-ms-365 tools (wrong prefix)", () => {
+    expect(isGatedMs365Tool("mcp__google-workspace__upload-file-content")).toBe(false);
+    expect(isGatedMs365Tool("Edit")).toBe(false);
+    expect(isGatedMs365Tool("Bash")).toBe(false);
+  });
+
+  it("returns false for empty / malformed input", () => {
+    expect(isGatedMs365Tool("")).toBe(false);
+    expect(isGatedMs365Tool("mcp__ms-365__")).toBe(false);
+  });
+
+  it("explicitly does NOT gate Mail.Send (RFC §4.3 — drafts only v1)", () => {
+    expect(isGatedMs365Tool("mcp__ms-365__send-mail")).toBe(false);
+    // Mail.Send is not in v1 scope; the agent shouldn't have access at
+    // all. If a future PR ever adds the scope, this test will need
+    // updating along with GATED_MS365_WRITE_TOOLS.
+  });
+});
+
+describe("GATED_MS365_WRITE_TOOLS — set integrity", () => {
+  it("does not include Mail.Send tools (v1 contract)", () => {
+    expect(GATED_MS365_WRITE_TOOLS.has("send-mail")).toBe(false);
+    expect(GATED_MS365_WRITE_TOOLS.has("send-message")).toBe(false);
+  });
+
+  it("includes all expected v1 write tools", () => {
+    const expected = [
+      "upload-file-content",
+      "create-upload-session",
+      "create-event",
+      "update-event",
+      "delete-event",
+      "update-message",
+      "delete-message",
+    ];
+    for (const t of expected) {
+      expect(GATED_MS365_WRITE_TOOLS.has(t)).toBe(true);
+    }
+  });
+});
+
+describe("extractMs365Preview", () => {
+  it("extracts itemId from common shape `itemId`", () => {
+    const r = extractMs365Preview("mcp__ms-365__upload-file-content", {
+      itemId: "01ABC",
+      fileName: "doc.docx",
+    });
+    expect(r.itemId).toBe("01ABC");
+    expect(r.itemDisplayName).toBe("doc.docx");
+  });
+
+  it("falls back through alternate id field names", () => {
+    expect(extractMs365Preview("mcp__ms-365__create-event", { eventId: "ev-1" }).itemId).toBe("ev-1");
+    expect(extractMs365Preview("mcp__ms-365__update-message", { messageId: "msg-1" }).itemId).toBe("msg-1");
+    expect(extractMs365Preview("mcp__ms-365__delete-event", { id: "x" }).itemId).toBe("x");
+  });
+
+  it('defaults itemId to "(new)" when no id field is present', () => {
+    expect(extractMs365Preview("mcp__ms-365__upload-file-content", {}).itemId).toBe("(new)");
+  });
+
+  it("extracts display name from common shapes", () => {
+    expect(extractMs365Preview("x", { name: "a" }).itemDisplayName).toBe("a");
+    expect(extractMs365Preview("x", { fileName: "b" }).itemDisplayName).toBe("b");
+    expect(extractMs365Preview("x", { subject: "Re: meeting" }).itemDisplayName).toBe("Re: meeting");
+    expect(extractMs365Preview("x", { title: "All-hands" }).itemDisplayName).toBe("All-hands");
+  });
+
+  it('defaults display name to "(unknown)"', () => {
+    expect(extractMs365Preview("x", {}).itemDisplayName).toBe("(unknown)");
+  });
+
+  it("extracts deep link from common url shapes", () => {
+    expect(extractMs365Preview("x", { webUrl: "https://x.com/y" }).deepLink).toBe("https://x.com/y");
+    expect(extractMs365Preview("x", { url: "http://abc" }).deepLink).toBe("http://abc");
+  });
+
+  it("rejects non-http deep links (best-effort filter for typo'd shapes)", () => {
+    expect(extractMs365Preview("x", { webUrl: "/relative" }).deepLink).toBeUndefined();
+    expect(extractMs365Preview("x", { webUrl: 42 }).deepLink).toBeUndefined();
+  });
+
+  it("extracts size from numeric fields", () => {
+    expect(extractMs365Preview("x", { contentSize: 1024 }).sizeBytesAfter).toBe(1024);
+    expect(extractMs365Preview("x", { fileSize: 2048 }).sizeBytesAfter).toBe(2048);
+  });
+
+  it("derives size from base64 content length when no numeric size field", () => {
+    const content = "A".repeat(100); // 100 base64 chars ≈ 75 bytes
+    const r = extractMs365Preview("x", { content });
+    expect(r.sizeBytesAfter).toBe(75);
+  });
+
+  it("handles missing / wrong-typed input defensively", () => {
+    expect(extractMs365Preview("x", null).itemId).toBe("(new)");
+    expect(extractMs365Preview("x", "not-an-object").itemId).toBe("(new)");
+    expect(extractMs365Preview("x", undefined).itemDisplayName).toBe("(unknown)");
+  });
+});

--- a/src/cli/ms-365-write-pretool.ts
+++ b/src/cli/ms-365-write-pretool.ts
@@ -1,0 +1,430 @@
+/**
+ * PreToolUse hook for softeria/ms-365-mcp-server write tools —
+ * RFC #1873 §8 PR 4.
+ *
+ * Bundled to `/opt/switchroom/hooks/ms-365-write-pretool.mjs` at build
+ * time so it runs inside the agent container with zero relative
+ * imports. Mirrors `drive-write-pretool.ts` shape with the weak-
+ * metadata simplification (RFC §8 v1).
+ *
+ * Claude Code PreToolUse contract:
+ *   Input:  JSON on stdin — { session_id, tool_name, tool_input, ... }
+ *   Output: exit 0 + empty stdout → allow.
+ *           exit 0 + JSON `{ decision: "block", reason: "..." }` → block.
+ *
+ * Flow:
+ *   1. Parse stdin. Skip (allow) if tool isn't a gated MS-365 write.
+ *   2. Best-effort extract item id + display name + size from tool_input.
+ *   3. (Optional) Check kernel for a standing grant at scope
+ *      `ms-365:write:<itemId>`. v1: always-prompt — no standing grants.
+ *      Skip this check; future PR can add a scope-key skip.
+ *   4. Send `request_ms365_approval` to gateway socket.
+ *   5. Poll `approval_lookup` until verdict (granted / denied / expired).
+ *   6. Granted → allow. Anything else → block.
+ *
+ * Fail-closed:
+ *   - Stdin parse fails → block (Claude Code protocol error — better
+ *     to fail closed than allow an unbounded operation)
+ *   - Gateway unreachable → block (operator can't see card)
+ *   - Kernel unreachable for verdict → block (no way to know decision)
+ *   - Timeout / no decision → block
+ *
+ * Fail-open ONLY when:
+ *   - Tool isn't in the gated set (unknown / non-write upstream tools)
+ *   - SWITCHROOM_AGENT_NAME missing (we don't know which agent we're gating)
+ */
+
+import { readFileSync } from "node:fs";
+import { createConnection } from "node:net";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+// ────────────────────────────────────────────────────────────────────────
+// Configuration
+// ────────────────────────────────────────────────────────────────────────
+
+const HOOK_TIMEOUT_MS = 5 * 60 * 1000;
+const KERNEL_POLL_INTERVAL_MS = 2000;
+const IPC_CONNECT_TIMEOUT_MS = 3000;
+const IPC_REPLY_TIMEOUT_MS = 10_000;
+const KERNEL_RPC_TIMEOUT_MS = 3000;
+
+const GATEWAY_SOCKET =
+  process.env.SWITCHROOM_GATEWAY_SOCKET ??
+  (process.env.TELEGRAM_STATE_DIR !== undefined
+    ? join(process.env.TELEGRAM_STATE_DIR, "gateway.sock")
+    : join(homedir(), ".claude", "channels", "telegram", "gateway.sock"));
+
+const KERNEL_SOCKET =
+  process.env.SWITCHROOM_KERNEL_SOCKET ?? "/run/switchroom/kernel/sock";
+
+const TOOL_PREFIX = "mcp__ms-365__";
+
+/**
+ * Gated softeria write tools — RFC §8.
+ *
+ * **OneDrive writes** — upload-file-content (≤4MB inline),
+ * create-upload-session (>4MB chunked).
+ *
+ * **Calendar writes** — create-event, update-event, delete-event.
+ *
+ * **Mail edits** — update-message, delete-message. Mail.Send is NOT in
+ * v1 scope (drafts only); the gated set doesn't include send tools to
+ * defend against scope creep.
+ *
+ * Tool-name conjecture: softeria's MCP server publishes tool names as
+ * `<verb>-<surface>` (e.g. `upload-file-content`). Claude Code
+ * namespaces them as `mcp__<server-key>__<tool-name>`. The exact
+ * tool-name list is verified at UAT time in PR 5.
+ */
+export const GATED_MS365_WRITE_TOOLS = new Set<string>([
+  "upload-file-content",
+  "create-upload-session",
+  "create-event",
+  "update-event",
+  "delete-event",
+  "update-message",
+  "delete-message",
+]);
+
+export function isGatedMs365Tool(toolName: string): boolean {
+  if (!toolName.startsWith(TOOL_PREFIX)) return false;
+  return GATED_MS365_WRITE_TOOLS.has(toolName.slice(TOOL_PREFIX.length));
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// stdin parse
+// ────────────────────────────────────────────────────────────────────────
+
+interface HookInput {
+  session_id?: string;
+  tool_name?: string;
+  tool_input?: unknown;
+}
+
+function readStdin(): string {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function parseHookInput(): HookInput | null {
+  const raw = readStdin();
+  if (!raw) return null;
+  try {
+    const obj = JSON.parse(raw) as HookInput;
+    return obj && typeof obj === "object" ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Preview extraction — best-effort from tool_input shape
+// ────────────────────────────────────────────────────────────────────────
+
+export interface Ms365PreviewExtract {
+  itemId: string;
+  itemDisplayName: string;
+  deepLink?: string;
+  sizeBytesAfter?: number;
+}
+
+/**
+ * Best-effort extract the preview-shape fields from softeria's
+ * tool_input. softeria's exact param names vary per tool — we look for
+ * the common shapes and fall through to "(unknown)" defaults.
+ *
+ * **This is pure heuristics**. UAT in PR 5 validates against actual
+ * tool_input shapes; if a tool's params don't match these patterns,
+ * the card shows "(unknown)" for the field — the operator can still
+ * make a decision based on tool name + agent rationale, just without
+ * the item-level context.
+ */
+export function extractMs365Preview(
+  toolName: string,
+  toolInput: unknown,
+): Ms365PreviewExtract {
+  const o = (toolInput && typeof toolInput === "object")
+    ? (toolInput as Record<string, unknown>)
+    : {};
+
+  // itemId common shapes: itemId, item_id, id, driveItemId, eventId, messageId
+  let itemId = "(new)";
+  for (const k of ["itemId", "item_id", "id", "driveItemId", "eventId", "messageId", "message_id"]) {
+    if (typeof o[k] === "string" && (o[k] as string).length > 0) {
+      itemId = o[k] as string;
+      break;
+    }
+  }
+
+  // Display name shapes: name, fileName, file_name, displayName, subject, title
+  let itemDisplayName = "(unknown)";
+  for (const k of ["name", "fileName", "file_name", "displayName", "subject", "title"]) {
+    if (typeof o[k] === "string" && (o[k] as string).length > 0) {
+      itemDisplayName = o[k] as string;
+      break;
+    }
+  }
+
+  // Deep link shapes: webUrl, web_url, url, link
+  let deepLink: string | undefined;
+  for (const k of ["webUrl", "web_url", "url", "link"]) {
+    if (typeof o[k] === "string" && (o[k] as string).startsWith("http")) {
+      deepLink = o[k] as string;
+      break;
+    }
+  }
+
+  // Size shapes: contentSize, content_size, fileSize, size (for upload tools)
+  let sizeBytesAfter: number | undefined;
+  for (const k of ["contentSize", "content_size", "fileSize", "size"]) {
+    if (typeof o[k] === "number" && Number.isFinite(o[k])) {
+      sizeBytesAfter = o[k] as number;
+      break;
+    }
+  }
+  // For inline base64-encoded content, derive size from the encoded string length
+  if (sizeBytesAfter === undefined && typeof o.content === "string") {
+    // base64 → bytes: roughly (length * 3) / 4 minus padding
+    const len = (o.content as string).length;
+    sizeBytesAfter = Math.floor((len * 3) / 4);
+  }
+
+  return { itemId, itemDisplayName, deepLink, sizeBytesAfter };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// IPC — gateway + kernel
+// ────────────────────────────────────────────────────────────────────────
+
+interface IpcOk { ok: true; value: unknown }
+interface IpcErr { ok: false; reason: string }
+type IpcResult = IpcOk | IpcErr;
+
+async function sendGatewayRequest(
+  socket: string,
+  payload: Record<string, unknown>,
+  matchType: string,
+  correlationId: string,
+): Promise<IpcResult> {
+  return new Promise((resolve) => {
+    const conn = createConnection(socket);
+    let buf = "";
+    const cleanup = () => {
+      try {
+        conn.destroy();
+      } catch {
+        /* ignore */
+      }
+    };
+    const replyTimer = setTimeout(() => {
+      cleanup();
+      resolve({ ok: false, reason: "gateway reply timeout" });
+    }, IPC_REPLY_TIMEOUT_MS);
+    const connectTimer = setTimeout(() => {
+      cleanup();
+      resolve({ ok: false, reason: "gateway connect timeout" });
+    }, IPC_CONNECT_TIMEOUT_MS);
+
+    conn.once("error", (err) => {
+      clearTimeout(replyTimer);
+      clearTimeout(connectTimer);
+      resolve({ ok: false, reason: `gateway: ${err.message}` });
+    });
+    conn.once("connect", () => {
+      clearTimeout(connectTimer);
+      conn.write(JSON.stringify(payload) + "\n");
+    });
+    conn.on("data", (chunk) => {
+      buf += chunk.toString("utf8");
+      const idx = buf.indexOf("\n");
+      while (true) {
+        const lineEnd = buf.indexOf("\n");
+        if (lineEnd === -1) break;
+        const line = buf.slice(0, lineEnd);
+        buf = buf.slice(lineEnd + 1);
+        try {
+          const parsed = JSON.parse(line) as {
+            type?: string;
+            correlationId?: string;
+          };
+          if (
+            parsed?.type === matchType &&
+            parsed?.correlationId === correlationId
+          ) {
+            clearTimeout(replyTimer);
+            cleanup();
+            resolve({ ok: true, value: parsed });
+            return;
+          }
+        } catch {
+          /* drop malformed line; keep reading */
+        }
+      }
+    });
+  });
+}
+
+async function rpcKernel(payload: Record<string, unknown>): Promise<IpcResult> {
+  return new Promise((resolve) => {
+    const conn = createConnection(KERNEL_SOCKET);
+    let buf = "";
+    const cleanup = () => {
+      try {
+        conn.destroy();
+      } catch {
+        /* ignore */
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve({ ok: false, reason: "kernel rpc timeout" });
+    }, KERNEL_RPC_TIMEOUT_MS);
+    conn.once("error", (err) => {
+      clearTimeout(timer);
+      resolve({ ok: false, reason: `kernel: ${err.message}` });
+    });
+    conn.once("connect", () => {
+      conn.write(JSON.stringify(payload) + "\n");
+    });
+    conn.on("data", (chunk) => {
+      buf += chunk.toString("utf8");
+      const lineEnd = buf.indexOf("\n");
+      if (lineEnd === -1) return;
+      const line = buf.slice(0, lineEnd);
+      clearTimeout(timer);
+      cleanup();
+      try {
+        resolve({ ok: true, value: JSON.parse(line) });
+      } catch (err) {
+        resolve({ ok: false, reason: `kernel parse: ${String(err)}` });
+      }
+    });
+  });
+}
+
+async function approvalLookup(
+  agentUnit: string,
+  scope: string,
+  approverSet: string[],
+): Promise<{ state?: string } | null> {
+  const res = await rpcKernel({
+    v: 1,
+    op: "approval_lookup",
+    agent_unit: agentUnit,
+    scope,
+    action: "write",
+    current_approver_set: approverSet,
+  });
+  if (!res.ok) return null;
+  return res.value as { state?: string };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Main
+// ────────────────────────────────────────────────────────────────────────
+
+function fail(reason: string): never {
+  process.stdout.write(
+    JSON.stringify({
+      decision: "block",
+      reason: `ms-365 write blocked: ${reason}`,
+    }),
+  );
+  process.exit(0);
+}
+
+function allow(): never {
+  process.exit(0);
+}
+
+async function main(): Promise<void> {
+  const input = parseHookInput();
+  if (!input) fail("malformed stdin");
+
+  const toolName = input.tool_name;
+  if (typeof toolName !== "string" || !isGatedMs365Tool(toolName)) {
+    // Not a gated tool — allow through.
+    allow();
+  }
+
+  const agentName = process.env.SWITCHROOM_AGENT_NAME;
+  if (!agentName) {
+    // No agent identity — can't gate. Fail open per the docstring
+    // contract (Claude Code protocol error, not our concern).
+    allow();
+  }
+
+  const accountEmail = process.env.SWITCHROOM_MICROSOFT_ACCOUNT ?? "(unknown)";
+
+  const extract = extractMs365Preview(toolName, input.tool_input);
+  const preview = {
+    agentName,
+    toolName,
+    itemId: extract.itemId,
+    itemDisplayName: extract.itemDisplayName,
+    accountEmail,
+    deepLink: extract.deepLink,
+    sizeBytesAfter: extract.sizeBytesAfter,
+    // No agentRationale yet — softeria doesn't pass one, and we
+    // don't have a sidecar channel for the agent to supply it.
+  };
+
+  const correlationId = randomBytes(16).toString("hex");
+  const requestResult = await sendGatewayRequest(
+    GATEWAY_SOCKET,
+    {
+      type: "request_ms365_approval",
+      correlationId,
+      agentName,
+      preview,
+      ttlMs: HOOK_TIMEOUT_MS,
+    },
+    "ms365_approval_posted",
+    correlationId,
+  );
+
+  if (!requestResult.ok) fail(requestResult.reason);
+  const response = requestResult.value as {
+    ok: boolean;
+    requestId?: string;
+    expiresAtMs?: number;
+    reason?: string;
+  };
+  if (!response.ok || !response.requestId) {
+    fail(response.reason ?? "gateway returned ok=false");
+  }
+
+  const deadline = response.expiresAtMs ?? Date.now() + HOOK_TIMEOUT_MS;
+  const scope = `ms-365:write:${preview.itemId}`;
+  // We don't know the approver_set in the hook — pass an empty list;
+  // the kernel uses the snapshot taken at register time.
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, KERNEL_POLL_INTERVAL_MS));
+    const lookup = await approvalLookup(agentName, scope, []);
+    if (!lookup) continue;
+    const state = lookup.state;
+    if (state === "granted") allow();
+    if (state === "denied" || state === "drift_revoked" || state === "expired") {
+      fail(`operator ${state}`);
+    }
+  }
+  fail("approval timed out");
+}
+
+// Only invoke main() when run as a script — not when imported by tests.
+// The hook is bundled by scripts/build.mjs into a standalone .mjs that
+// IS run as a script in the agent container; the gating below is
+// satisfied by bun's bundler exposing `import.meta.main` (true at
+// entrypoint, false on imports). At test-import time the predicate is
+// false so main() doesn't fire (and hang on readFileSync(0)).
+if ((import.meta as { main?: boolean }).main) {
+  main().catch((err) => {
+    const m = err instanceof Error ? err.message : String(err);
+    fail(`hook error: ${m}`);
+  });
+}

--- a/src/cli/ms-365-write-pretool.ts
+++ b/src/cli/ms-365-write-pretool.ts
@@ -187,9 +187,11 @@ export function extractMs365Preview(
       break;
     }
   }
-  // For inline base64-encoded content, derive size from the encoded string length
+  // For inline base64-encoded content, derive size from the encoded
+  // string length. Approximate (off by 0/1/2 bytes depending on `=`
+  // padding) — accurate enough for the operator's card. Surfaced as
+  // "approx N bytes" downstream if we ever care to be exact.
   if (sizeBytesAfter === undefined && typeof o.content === "string") {
-    // base64 → bytes: roughly (length * 3) / 4 minus padding
     const len = (o.content as string).length;
     sizeBytesAfter = Math.floor((len * 3) / 4);
   }
@@ -241,7 +243,6 @@ async function sendGatewayRequest(
     });
     conn.on("data", (chunk) => {
       buf += chunk.toString("utf8");
-      const idx = buf.indexOf("\n");
       while (true) {
         const lineEnd = buf.indexOf("\n");
         if (lineEnd === -1) break;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -265,6 +265,7 @@ import { shouldSweepChatAtBoot } from './boot-sweep-filter.js'
 
 import { createIpcServer, type IpcClient, type IpcServer } from './ipc-server.js'
 import { handleRequestDriveApproval } from './drive-write-approval.js'
+import { handleRequestMs365Approval } from './ms365-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
 import { createInboundSpool } from './inbound-spool.js'
@@ -4183,6 +4184,64 @@ const ipcServer: IpcServer = createIpcServer({
       buildCard: ({ preview, suggestRequestId }) =>
         buildDiffPreviewCard({ preview, suggestRequestId }),
       log: (m) => process.stderr.write(`telegram gateway: drive-approval — ${m}\n`),
+    })
+  },
+
+  /**
+   * RFC #1873 §8 — MS-365 write approval card. Mirrors
+   * onRequestDriveApproval but with the weak-metadata v1 preview shape
+   * (no diff-preview — just plain text card).
+   */
+  async onRequestMs365Approval(client: IpcClient, msg) {
+    await handleRequestMs365Approval(client, msg, {
+      agentName: getMyAgentName(),
+      loadAllowFrom: () => loadAccess().allowFrom,
+      loadTargetChat: () => {
+        const access = loadAccess()
+        const operator = access.allowFrom[0]
+        if (operator === undefined) return null
+        return { chatId: operator }
+      },
+      registerApproval: async (args) => {
+        const r = await kernelApprovalRequest({
+          agent_unit: args.agent_unit,
+          scope: args.scope,
+          action: args.action,
+          approver_set: args.approver_set,
+          why: args.why,
+          ttl_ms: args.ttl_ms,
+        })
+        if (r === null || r.state === 'rate_limited') return null
+        return {
+          request_id: r.request_id,
+          expires_at_ms: r.expires_at,
+        }
+      },
+      postCard: async (args) => {
+        try {
+          const sent = await robustApiCall(
+            () =>
+              bot.api.sendMessage(args.chatId, args.text, {
+                ...(args.threadId !== undefined
+                  ? { message_thread_id: args.threadId }
+                  : {}),
+                reply_markup: args.replyMarkup as never,
+              }),
+            {
+              chat_id: String(args.chatId),
+              verb: 'ms365-approval-card',
+              ...(args.threadId !== undefined ? { threadId: args.threadId } : {}),
+            },
+          )
+          return { messageId: (sent as { message_id: number }).message_id }
+        } catch (err) {
+          process.stderr.write(
+            `telegram gateway: ms365-approval postCard failed: ${(err as Error).message}\n`,
+          )
+          return null
+        }
+      },
+      log: (m) => process.stderr.write(`telegram gateway: ms365-approval — ${m}\n`),
     })
   },
 

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -127,6 +127,7 @@ export type GatewayToClient =
   | ToolCallResult
   | ScheduleRestartResult
   | DriveApprovalPostedEvent
+  | Ms365ApprovalPostedEvent
   | ConfigApprovalResolvedEvent;
 
 // === Bridge (Client) -> Gateway messages ===

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -307,6 +307,41 @@ export interface RequestDriveApprovalMessage {
 }
 
 /**
+ * RFC #1873 §8 — Microsoft 365 write approval (PR 4).
+ *
+ * Sent by the `ms-365-write-pretool` PreToolUse hook when softeria
+ * tries a gated write tool (OneDrive upload, calendar/mail mutations).
+ * Same shape as `request_drive_approval` but carries the weak-metadata
+ * v1 preview shape (file path / id / size delta / deep link / agent
+ * rationale) rather than Google's full DiffPreviewInput. Structural-
+ * diff preview is RFC §8 v1.5.
+ */
+export interface RequestMs365ApprovalMessage {
+  type: "request_ms365_approval";
+  correlationId: string;
+  agentName: string;
+  /**
+   * Weak-metadata payload — see Ms365WritePreview in
+   * `telegram-plugin/gateway/ms365-write-approval.ts`. Opaque on the
+   * wire; gateway validates via the handler.
+   */
+  preview: Record<string, unknown>;
+  ttlMs?: number;
+}
+
+/**
+ * Gateway → hook response after card is posted (or fails).
+ */
+export interface Ms365ApprovalPostedEvent {
+  type: "ms365_approval_posted";
+  correlationId: string;
+  ok: boolean;
+  requestId?: string;
+  expiresAtMs?: number;
+  reason?: string;
+}
+
+/**
  * hostd config-edit approval — sent by hostd to the caller agent's
  * gateway to render an approval card with the full unified diff in
  * the operator's primary chat. The gateway:
@@ -367,5 +402,6 @@ export type ClientToGateway =
   | UpdatePlaceholderMessage
   | InjectInboundMessage
   | RequestDriveApprovalMessage
+  | RequestMs365ApprovalMessage
   | RequestConfigApprovalMessage
   | RequestConfigFinalizeMessage;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -11,6 +11,7 @@ import type {
   RequestConfigApprovalMessage,
   RequestConfigFinalizeMessage,
   RequestDriveApprovalMessage,
+  RequestMs365ApprovalMessage,
   ScheduleRestartMessage,
   SessionEventForward,
   ToolCallMessage,
@@ -54,6 +55,15 @@ export interface IpcServerOptions {
   onRequestDriveApproval?: (
     client: IpcClient,
     msg: RequestDriveApprovalMessage,
+  ) => Promise<void>;
+  /**
+   * RFC #1873 §8 — Microsoft 365 write approval (PR 4). Same shape as
+   * onRequestDriveApproval but for softeria write tools. Optional;
+   * gateways without M365 integration ignore.
+   */
+  onRequestMs365Approval?: (
+    client: IpcClient,
+    msg: RequestMs365ApprovalMessage,
   ) => Promise<void>;
   /**
    * #1623 — hostd-initiated config-edit approval card. Handler posts
@@ -292,6 +302,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onPtyPartial,
     onInjectInbound,
     onRequestDriveApproval,
+    onRequestMs365Approval,
     onRequestConfigApproval,
     onRequestConfigFinalize,
     log = () => {},
@@ -430,6 +441,38 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
               correlationId: (msg as RequestDriveApprovalMessage).correlationId,
               ok: false,
               reason: "gateway not configured for Drive-write approval",
+            });
+          } catch {
+            /* best effort */
+          }
+        }
+        break;
+      case "request_ms365_approval":
+        if (onRequestMs365Approval) {
+          onRequestMs365Approval(client, msg as RequestMs365ApprovalMessage).catch(
+            (err) => {
+              log(
+                `request_ms365_approval handler threw (client=${client.id}): ${(err as Error).message}`,
+              );
+              try {
+                client.send({
+                  type: "ms365_approval_posted",
+                  correlationId: (msg as RequestMs365ApprovalMessage).correlationId,
+                  ok: false,
+                  reason: `gateway handler error: ${(err as Error).message}`,
+                });
+              } catch {
+                /* best effort */
+              }
+            },
+          );
+        } else {
+          try {
+            client.send({
+              type: "ms365_approval_posted",
+              correlationId: (msg as RequestMs365ApprovalMessage).correlationId,
+              ok: false,
+              reason: "gateway not configured for MS-365 write approval",
             });
           } catch {
             /* best effort */

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -283,6 +283,22 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
           || (m.ttlMs as number) < 0)) return false;
       return true;
     }
+    case "request_ms365_approval": {
+      // RFC #1873 §8 PR 4. Same wire-shape gate as Drive — gateway
+      // routes on the outer fields; the inner `preview` is opaque
+      // and re-validated by `validateMs365Preview()` downstream.
+      if (typeof m.correlationId !== "string"
+        || (m.correlationId as string).length === 0
+        || (m.correlationId as string).length > 64) return false;
+      if (typeof m.agentName !== "string"
+        || !AGENT_NAME_RE.test(m.agentName as string)) return false;
+      if (typeof m.preview !== "object" || m.preview === null) return false;
+      if (m.ttlMs !== undefined
+        && (typeof m.ttlMs !== "number"
+          || !Number.isFinite(m.ttlMs)
+          || (m.ttlMs as number) < 0)) return false;
+      return true;
+    }
     default:
       return false;
   }

--- a/telegram-plugin/gateway/ms365-write-approval.test.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.test.ts
@@ -300,13 +300,15 @@ describe("handleRequestMs365Approval", () => {
     expect(registerSpy.mock.calls[0][0].ttl_ms).toBe(5 * 60 * 1000);
   });
 
-  it("includes the inline-keyboard with ms365:<requestId>:approve|deny callback data", async () => {
+  it("emits apv:<requestId>:once|deny callback data (kernel-generic, NOT a ms365: dead-end)", async () => {
     const { deps, postCardSpy, client } = makeDeps();
     await handleRequestMs365Approval(client as unknown as IpcClient, makeMsg(), deps);
     const kb = postCardSpy.mock.calls[0][0].replyMarkup as {
       inline_keyboard: Array<Array<{ callback_data: string }>>;
     };
-    expect(kb.inline_keyboard[0][0].callback_data).toMatch(/^ms365:.+:approve$/);
-    expect(kb.inline_keyboard[0][1].callback_data).toMatch(/^ms365:.+:deny$/);
+    // MUST be `apv:` so the existing gateway dispatcher handles taps.
+    // Provider-namespaced `ms365:` would silently drop button taps.
+    expect(kb.inline_keyboard[0][0].callback_data).toMatch(/^apv:.+:once$/);
+    expect(kb.inline_keyboard[0][1].callback_data).toMatch(/^apv:.+:deny$/);
   });
 });

--- a/telegram-plugin/gateway/ms365-write-approval.test.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for ms365-write-approval handler — RFC #1873 §8 PR 4.
+ * Mirrors `drive-write-approval.test.ts` shape; DI-style — no live
+ * kernel / grammy / IPC needed.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildMs365CardText,
+  handleRequestMs365Approval,
+  validateMs365Preview,
+  type Ms365ApprovalHandlerDeps,
+  type Ms365WritePreview,
+} from "./ms365-write-approval.js";
+import type { IpcClient } from "./ipc-server.js";
+import type { RequestMs365ApprovalMessage } from "./ipc-protocol.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// validateMs365Preview
+// ────────────────────────────────────────────────────────────────────────
+
+describe("validateMs365Preview", () => {
+  const validPreview = {
+    agentName: "clerk",
+    toolName: "mcp__ms-365__upload-file-content",
+    itemId: "01ABCDEFG",
+    itemDisplayName: "Q3-Strategy.docx",
+    accountEmail: "ken@outlook.com",
+  };
+
+  it("accepts a minimal valid preview", () => {
+    const r = validateMs365Preview(validPreview);
+    expect(r).not.toBeNull();
+    expect(r!.agentName).toBe("clerk");
+    expect(r!.toolName).toBe("mcp__ms-365__upload-file-content");
+  });
+
+  it("accepts optional fields when typed correctly", () => {
+    const r = validateMs365Preview({
+      ...validPreview,
+      deepLink: "https://onedrive.live.com/x",
+      sizeBytesBefore: 1024,
+      sizeBytesAfter: 2048,
+      agentRationale: "Add Q3 meeting notes",
+    });
+    expect(r).not.toBeNull();
+    expect(r!.deepLink).toBe("https://onedrive.live.com/x");
+    expect(r!.sizeBytesBefore).toBe(1024);
+    expect(r!.sizeBytesAfter).toBe(2048);
+    expect(r!.agentRationale).toBe("Add Q3 meeting notes");
+  });
+
+  it("rejects null / non-object", () => {
+    expect(validateMs365Preview(null)).toBeNull();
+    expect(validateMs365Preview("string")).toBeNull();
+    expect(validateMs365Preview(42)).toBeNull();
+  });
+
+  it("rejects missing required fields", () => {
+    const cases = ["agentName", "toolName", "itemId", "itemDisplayName", "accountEmail"];
+    for (const field of cases) {
+      const copy: Record<string, unknown> = { ...validPreview };
+      delete copy[field];
+      expect(validateMs365Preview(copy)).toBeNull();
+    }
+  });
+
+  it("rejects empty-string required fields", () => {
+    const r = validateMs365Preview({ ...validPreview, agentName: "" });
+    expect(r).toBeNull();
+  });
+
+  it("ignores wrong-type optional fields gracefully (drops them, doesn't fail)", () => {
+    const r = validateMs365Preview({
+      ...validPreview,
+      deepLink: 42, // wrong type
+      sizeBytesAfter: "not-a-number",
+    });
+    expect(r).not.toBeNull();
+    expect(r!.deepLink).toBeUndefined();
+    expect(r!.sizeBytesAfter).toBeUndefined();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// buildMs365CardText
+// ────────────────────────────────────────────────────────────────────────
+
+describe("buildMs365CardText", () => {
+  const base: Ms365WritePreview = {
+    agentName: "clerk",
+    toolName: "mcp__ms-365__upload-file-content",
+    itemId: "01ABCDEFG",
+    itemDisplayName: "Q3-Strategy.docx",
+    accountEmail: "ken@outlook.com",
+  };
+
+  it("includes agent, tool, item, account", () => {
+    const text = buildMs365CardText(base);
+    expect(text).toContain("clerk");
+    expect(text).toContain("ms-365__upload-file-content");
+    expect(text).toContain("Q3-Strategy.docx");
+    expect(text).toContain("01ABCDEFG");
+    expect(text).toContain("ken@outlook.com");
+  });
+
+  it("omits ID line for new files", () => {
+    const text = buildMs365CardText({ ...base, itemId: "(new)" });
+    expect(text).not.toMatch(/^ID:/m);
+  });
+
+  it("shows size delta when before/after present", () => {
+    const text = buildMs365CardText({ ...base, sizeBytesBefore: 1024, sizeBytesAfter: 2048 });
+    expect(text).toMatch(/Size:.*1\.0KB.*2\.0KB.*\+1\.0KB/);
+  });
+
+  it("shows negative delta correctly", () => {
+    const text = buildMs365CardText({ ...base, sizeBytesBefore: 2048, sizeBytesAfter: 1024 });
+    expect(text).toMatch(/Size:.*-1\.0KB/);
+  });
+
+  it("includes deepLink when present", () => {
+    const text = buildMs365CardText({ ...base, deepLink: "https://onedrive.live.com/x" });
+    expect(text).toContain("https://onedrive.live.com/x");
+  });
+
+  it("includes agent rationale when present", () => {
+    const text = buildMs365CardText({ ...base, agentRationale: "Adding meeting notes" });
+    expect(text).toContain("💬 Adding meeting notes");
+  });
+
+  it("always shows weak-attestation warning", () => {
+    const text = buildMs365CardText(base);
+    expect(text).toContain("Weak attestation (RFC §8 v1)");
+  });
+
+  it("truncates over-long display names with ellipsis", () => {
+    const text = buildMs365CardText({ ...base, itemDisplayName: "x".repeat(500) });
+    expect(text).toContain("…");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// handleRequestMs365Approval — DI integration
+// ────────────────────────────────────────────────────────────────────────
+
+function makeDeps(): {
+  deps: Ms365ApprovalHandlerDeps;
+  registerSpy: ReturnType<typeof vi.fn>;
+  postCardSpy: ReturnType<typeof vi.fn>;
+  client: { send: ReturnType<typeof vi.fn> };
+} {
+  const registerSpy = vi.fn().mockResolvedValue({
+    request_id: "aabbccdd11223344aabbccdd11223344",
+    expires_at_ms: Date.now() + 5 * 60 * 1000,
+  });
+  const postCardSpy = vi.fn().mockResolvedValue({ messageId: 42 });
+  const sendSpy = vi.fn();
+  const deps: Ms365ApprovalHandlerDeps = {
+    agentName: "clerk",
+    loadAllowFrom: () => ["12345"],
+    loadTargetChat: () => ({ chatId: "12345" }),
+    registerApproval: registerSpy,
+    postCard: postCardSpy,
+    log: () => {},
+  };
+  return {
+    deps,
+    registerSpy,
+    postCardSpy,
+    client: { send: sendSpy },
+  };
+}
+
+function makeMsg(overrides: Partial<RequestMs365ApprovalMessage> = {}): RequestMs365ApprovalMessage {
+  return {
+    type: "request_ms365_approval",
+    correlationId: "corr-1",
+    agentName: "clerk",
+    preview: {
+      agentName: "clerk",
+      toolName: "mcp__ms-365__upload-file-content",
+      itemId: "01ABC",
+      itemDisplayName: "Strategy.docx",
+      accountEmail: "ken@outlook.com",
+    },
+    ttlMs: 5 * 60 * 1000,
+    ...overrides,
+  };
+}
+
+describe("handleRequestMs365Approval", () => {
+  it("happy path: registers kernel, posts card, sends ok=true response", async () => {
+    const { deps, registerSpy, postCardSpy, client } = makeDeps();
+    await handleRequestMs365Approval(client as unknown as IpcClient, makeMsg(), deps);
+    expect(registerSpy).toHaveBeenCalledOnce();
+    expect(postCardSpy).toHaveBeenCalledOnce();
+    expect(client.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "ms365_approval_posted",
+        correlationId: "corr-1",
+        ok: true,
+        requestId: "aabbccdd11223344aabbccdd11223344",
+      }),
+    );
+  });
+
+  it("uses correct kernel scope ms-365:write:<itemId>", async () => {
+    const { deps, registerSpy, client } = makeDeps();
+    await handleRequestMs365Approval(
+      client as unknown as IpcClient,
+      makeMsg({ preview: { ...makeMsg().preview, itemId: "01XYZ" } }),
+      deps,
+    );
+    expect(registerSpy.mock.calls[0][0].scope).toBe("ms-365:write:01XYZ");
+    expect(registerSpy.mock.calls[0][0].action).toBe("write");
+  });
+
+  it("rejects cross-agent requests", async () => {
+    const { deps, registerSpy, client } = makeDeps();
+    await handleRequestMs365Approval(
+      client as unknown as IpcClient,
+      makeMsg({ agentName: "other-agent" }),
+      deps,
+    );
+    expect(registerSpy).not.toHaveBeenCalled();
+    expect(client.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: false,
+        reason: expect.stringContaining("cross-agent"),
+      }),
+    );
+  });
+
+  it("rejects invalid preview", async () => {
+    const { deps, registerSpy, client } = makeDeps();
+    await handleRequestMs365Approval(
+      client as unknown as IpcClient,
+      makeMsg({ preview: { agentName: "clerk" } }),
+      deps,
+    );
+    expect(registerSpy).not.toHaveBeenCalled();
+    expect(client.send).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, reason: "invalid preview payload" }),
+    );
+  });
+
+  it("rejects when no allowFrom is configured", async () => {
+    const { deps, client } = makeDeps();
+    deps.loadAllowFrom = () => [];
+    await handleRequestMs365Approval(client as unknown as IpcClient, makeMsg(), deps);
+    expect(client.send).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, reason: expect.stringContaining("allowFrom") }),
+    );
+  });
+
+  it("rejects when no target chat resolved", async () => {
+    const { deps, client } = makeDeps();
+    deps.loadTargetChat = () => null;
+    await handleRequestMs365Approval(client as unknown as IpcClient, makeMsg(), deps);
+    expect(client.send).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, reason: expect.stringContaining("target chat") }),
+    );
+  });
+
+  it("fail-closes when kernel registration returns null", async () => {
+    const { deps, client } = makeDeps();
+    deps.registerApproval = async () => null;
+    await handleRequestMs365Approval(client as unknown as IpcClient, makeMsg(), deps);
+    expect(client.send).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, reason: expect.stringContaining("kernel") }),
+    );
+  });
+
+  it("fail-closes when card post returns null", async () => {
+    const { deps, client } = makeDeps();
+    deps.postCard = async () => null;
+    await handleRequestMs365Approval(client as unknown as IpcClient, makeMsg(), deps);
+    expect(client.send).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, reason: expect.stringContaining("card post") }),
+    );
+  });
+
+  it("clamps oversized TTL to maxTtlMs", async () => {
+    const { deps, registerSpy, client } = makeDeps();
+    await handleRequestMs365Approval(
+      client as unknown as IpcClient,
+      makeMsg({ ttlMs: 60 * 60 * 1000 }), // 1h, max is 30min
+      deps,
+    );
+    expect(registerSpy.mock.calls[0][0].ttl_ms).toBe(30 * 60 * 1000);
+  });
+
+  it("uses default TTL when none provided", async () => {
+    const { deps, registerSpy, client } = makeDeps();
+    const msg = makeMsg();
+    delete (msg as { ttlMs?: number }).ttlMs;
+    await handleRequestMs365Approval(client as unknown as IpcClient, msg, deps);
+    expect(registerSpy.mock.calls[0][0].ttl_ms).toBe(5 * 60 * 1000);
+  });
+
+  it("includes the inline-keyboard with ms365:<requestId>:approve|deny callback data", async () => {
+    const { deps, postCardSpy, client } = makeDeps();
+    await handleRequestMs365Approval(client as unknown as IpcClient, makeMsg(), deps);
+    const kb = postCardSpy.mock.calls[0][0].replyMarkup as {
+      inline_keyboard: Array<Array<{ callback_data: string }>>;
+    };
+    expect(kb.inline_keyboard[0][0].callback_data).toMatch(/^ms365:.+:approve$/);
+    expect(kb.inline_keyboard[0][1].callback_data).toMatch(/^ms365:.+:deny$/);
+  });
+});

--- a/telegram-plugin/gateway/ms365-write-approval.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.ts
@@ -236,7 +236,7 @@ export async function handleRequestMs365Approval(
       correlationId: msg.correlationId,
       ok,
       ...extra,
-    } as unknown as Parameters<IpcClient["send"]>[0]);
+    });
   };
 
   // Cross-agent guard

--- a/telegram-plugin/gateway/ms365-write-approval.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.ts
@@ -113,9 +113,15 @@ export interface Ms365ApprovalHandlerDeps {
     replyMarkup: unknown;
   }) => Promise<{ messageId: number } | null>;
   /**
-   * Build the inline keyboard. Defaults to a 2-button [✅ Approve]
-   * [🚫 Deny] using callback_data `ms365:<requestId>:approve|deny` —
-   * gateway's main button-handler will route these to the kernel.
+   * Build the inline keyboard. Defaults to 2-button [✅ Approve]
+   * [🚫 Deny] using callback_data `apv:<requestId>:once|deny` — the
+   * SAME shape Drive uses. The existing gateway `apv:` handler at
+   * `gateway.ts:handleApprovalCallback` consumes the kernel state
+   * machine generically (no provider awareness). Reused on purpose:
+   * provider-namespaced callback_data would silently drop button
+   * taps because there's no `ms365:` branch in the dispatcher.
+   * Reviewer of PR 4 caught this — the original `ms365:` prefix was
+   * an unwired dead end.
    */
   buildKeyboard?: (requestId: string) => unknown;
   log?: (msg: string) => void;
@@ -129,11 +135,17 @@ const MAX_TTL_MS = 30 * 60 * 1000;
 const MIN_TTL_MS = 30 * 1000;
 
 function defaultKeyboard(requestId: string): unknown {
+  // `apv:<requestId>:once` is the kernel-generic approval shape used
+  // by Drive's diff-preview cards. The existing `apv:` dispatch
+  // branch at gateway.ts:14149 routes the kernel consume + record
+  // for any provider. Mirroring `apv:` keeps the M365 cards wired
+  // through the same well-tested approval state machine instead of a
+  // new provider-namespaced one with its own bug surface.
   return {
     inline_keyboard: [
       [
-        { text: "✅ Approve", callback_data: `ms365:${requestId}:approve` },
-        { text: "🚫 Deny", callback_data: `ms365:${requestId}:deny` },
+        { text: "✅ Approve", callback_data: `apv:${requestId}:once` },
+        { text: "🚫 Deny", callback_data: `apv:${requestId}:deny` },
       ],
     ],
   };

--- a/telegram-plugin/gateway/ms365-write-approval.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.ts
@@ -1,0 +1,323 @@
+/**
+ * Microsoft 365 write approval handler — RFC #1873 §8 PR 4.
+ *
+ * Mirrors `drive-write-approval.ts` shape but with the weak-metadata
+ * v1 preview (file path / item ID / size delta / deep link / agent
+ * rationale) instead of Google's full DiffPreviewInput.
+ *
+ * Flow (called by the gateway's IPC dispatcher when the
+ * `ms-365-write-pretool` hook sends `request_ms365_approval`):
+ *   1. Validate the inbound preview payload (`validateMs365Preview`).
+ *   2. Verify the request is for this gateway's agent (cross-agent
+ *      requests rejected — defense in depth).
+ *   3. Register a kernel approval at scope `ms-365:write:<itemId>`,
+ *      action `write`, approver_set = operator allowFrom.
+ *   4. Build a plain-text Telegram card showing: tool, target file/
+ *      item, size delta, deep link, agent's rationale.
+ *   5. Post the card to operator chat.
+ *   6. Send `ms365_approval_posted { ok, requestId, expiresAtMs }` back
+ *      over IPC so the hook can poll `approval_lookup` for verdict.
+ *
+ * Fail closed: on any failure (preview malformed, kernel down, card
+ * post fails) we send `ok: false` so the hook fails closed and blocks
+ * the tool call.
+ *
+ * **Why weak metadata v1** — softeria upload calls are full-file
+ * replacements; computing a structural diff would require downloading
+ * the prior version and running the docx/xlsx/pptx skill in diff mode.
+ * That's RFC §8 v1.5 work; v1 ships the simpler "operator must trust
+ * the agent's rationale + click through to OneDrive to verify" shape.
+ */
+
+import type { IpcClient } from "./ipc-server.js";
+import type { RequestMs365ApprovalMessage } from "./ipc-protocol.js";
+
+// ────────────────────────────────────────────────────────────────────────
+// Wire shape — validates an inbound preview payload
+// ────────────────────────────────────────────────────────────────────────
+
+export interface Ms365WritePreview {
+  /** Agent slug — appears on the card title. */
+  agentName: string;
+  /** Tool name as Claude Code sees it: `mcp__ms-365__<fn>`. */
+  toolName: string;
+  /**
+   * Item identifier for the OneDrive item / mail message / calendar
+   * event the tool will mutate. Used as the kernel scope key:
+   * `ms-365:write:<itemId>`. May be "(new)" for create operations.
+   */
+  itemId: string;
+  /** Display name (file name / mail subject / event title). */
+  itemDisplayName: string;
+  /** Microsoft account email the agent is authenticated as. */
+  accountEmail: string;
+  /** Deep link to OneDrive / Outlook web — best-effort, may be empty. */
+  deepLink?: string;
+  /** Byte delta — present only for OneDrive uploads with known sizes. */
+  sizeBytesBefore?: number;
+  sizeBytesAfter?: number;
+  /** 1-line agent rationale — advisory; operator should not over-trust. */
+  agentRationale?: string;
+}
+
+/**
+ * Validate a wire payload into a typed Ms365WritePreview. Returns null
+ * on malformed input (defense in depth — the hook is trusted but the
+ * payload may be corrupted in transit / by future-version drift).
+ */
+export function validateMs365Preview(input: unknown): Ms365WritePreview | null {
+  if (!input || typeof input !== "object") return null;
+  const o = input as Record<string, unknown>;
+  if (typeof o.agentName !== "string" || o.agentName.length === 0) return null;
+  if (typeof o.toolName !== "string" || o.toolName.length === 0) return null;
+  if (typeof o.itemId !== "string" || o.itemId.length === 0) return null;
+  if (typeof o.itemDisplayName !== "string") return null;
+  if (typeof o.accountEmail !== "string") return null;
+  const out: Ms365WritePreview = {
+    agentName: o.agentName,
+    toolName: o.toolName,
+    itemId: o.itemId,
+    itemDisplayName: o.itemDisplayName,
+    accountEmail: o.accountEmail,
+  };
+  if (typeof o.deepLink === "string") out.deepLink = o.deepLink;
+  if (typeof o.sizeBytesBefore === "number") out.sizeBytesBefore = o.sizeBytesBefore;
+  if (typeof o.sizeBytesAfter === "number") out.sizeBytesAfter = o.sizeBytesAfter;
+  if (typeof o.agentRationale === "string") out.agentRationale = o.agentRationale;
+  return out;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Handler — DI shape mirrors DriveApprovalHandlerDeps
+// ────────────────────────────────────────────────────────────────────────
+
+export interface Ms365ApprovalHandlerDeps {
+  agentName: string;
+  loadAllowFrom: () => string[];
+  loadTargetChat: () => {
+    chatId: number | string;
+    threadId?: number;
+  } | null;
+  registerApproval: (args: {
+    agent_unit: string;
+    scope: string;
+    action: string;
+    approver_set: string[];
+    why: string;
+    ttl_ms: number;
+  }) => Promise<{ request_id: string; expires_at_ms: number } | null>;
+  postCard: (args: {
+    chatId: number | string;
+    threadId?: number;
+    text: string;
+    replyMarkup: unknown;
+  }) => Promise<{ messageId: number } | null>;
+  /**
+   * Build the inline keyboard. Defaults to a 2-button [✅ Approve]
+   * [🚫 Deny] using callback_data `ms365:<requestId>:approve|deny` —
+   * gateway's main button-handler will route these to the kernel.
+   */
+  buildKeyboard?: (requestId: string) => unknown;
+  log?: (msg: string) => void;
+  defaultTtlMs?: number;
+  maxTtlMs?: number;
+  minTtlMs?: number;
+}
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const MAX_TTL_MS = 30 * 60 * 1000;
+const MIN_TTL_MS = 30 * 1000;
+
+function defaultKeyboard(requestId: string): unknown {
+  return {
+    inline_keyboard: [
+      [
+        { text: "✅ Approve", callback_data: `ms365:${requestId}:approve` },
+        { text: "🚫 Deny", callback_data: `ms365:${requestId}:deny` },
+      ],
+    ],
+  };
+}
+
+/**
+ * Build the card body. Plain text (no Markdown) to keep escaping
+ * trivial. Truncates the rationale + display name to fit Telegram's
+ * 4096-char message limit with safety margin.
+ */
+export function buildMs365CardText(p: Ms365WritePreview): string {
+  const lines: string[] = [];
+  lines.push(`📄 Microsoft 365 write approval`);
+  lines.push("");
+  lines.push(`Agent: ${truncate(p.agentName, 64)}`);
+  lines.push(`Tool: ${truncate(p.toolName.replace(/^mcp__/, ""), 96)}`);
+  lines.push(`Item: ${truncate(p.itemDisplayName, 256)}`);
+  if (p.itemId !== "(new)") {
+    lines.push(`ID:   ${truncate(p.itemId, 96)}`);
+  }
+  lines.push(`Account: ${truncate(p.accountEmail, 96)}`);
+  if (
+    typeof p.sizeBytesBefore === "number" ||
+    typeof p.sizeBytesAfter === "number"
+  ) {
+    const before = p.sizeBytesBefore ?? 0;
+    const after = p.sizeBytesAfter ?? 0;
+    const delta = after - before;
+    const sign = delta >= 0 ? "+" : "";
+    lines.push(`Size: ${humanBytes(before)} → ${humanBytes(after)} (${sign}${humanBytes(delta)})`);
+  }
+  if (p.deepLink) {
+    lines.push(`Link: ${truncate(p.deepLink, 256)}`);
+  }
+  if (p.agentRationale) {
+    lines.push("");
+    lines.push(`💬 ${truncate(p.agentRationale, 512)}`);
+  }
+  lines.push("");
+  lines.push(
+    "⚠️ Weak attestation (RFC §8 v1): operator should click through to verify the actual change before approving. Structural diff coming v1.5.",
+  );
+  return lines.join("\n");
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1) + "…";
+}
+
+function humanBytes(bytes: number): string {
+  const abs = Math.abs(bytes);
+  if (abs < 1024) return `${bytes}B`;
+  if (abs < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  if (abs < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(2)}MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)}GB`;
+}
+
+function clampTtl(
+  requested: number | undefined,
+  def: number,
+  min: number,
+  max: number,
+): number {
+  if (typeof requested !== "number" || !Number.isFinite(requested)) return def;
+  return Math.max(min, Math.min(max, requested));
+}
+
+/**
+ * Main handler — wire the inbound IPC message to kernel + card post.
+ */
+export async function handleRequestMs365Approval(
+  client: IpcClient,
+  msg: RequestMs365ApprovalMessage,
+  deps: Ms365ApprovalHandlerDeps,
+): Promise<void> {
+  const log = deps.log ?? (() => {});
+  const sendResponse = (
+    ok: boolean,
+    extra: {
+      requestId?: string;
+      expiresAtMs?: number;
+      reason?: string;
+    } = {},
+  ): void => {
+    client.send({
+      type: "ms365_approval_posted",
+      correlationId: msg.correlationId,
+      ok,
+      ...extra,
+    } as unknown as Parameters<IpcClient["send"]>[0]);
+  };
+
+  // Cross-agent guard
+  if (msg.agentName !== deps.agentName) {
+    log(
+      `ms365-approval: cross-agent request rejected (msg=${msg.agentName} vs gateway=${deps.agentName})`,
+    );
+    sendResponse(false, { reason: "cross-agent request rejected" });
+    return;
+  }
+
+  const preview = validateMs365Preview(msg.preview);
+  if (!preview) {
+    log("ms365-approval: invalid preview payload");
+    sendResponse(false, { reason: "invalid preview payload" });
+    return;
+  }
+
+  const allowFrom = deps.loadAllowFrom();
+  if (allowFrom.length === 0) {
+    log("ms365-approval: no operator allowFrom configured");
+    sendResponse(false, { reason: "no operator allowFrom configured" });
+    return;
+  }
+
+  const targetChat = deps.loadTargetChat();
+  if (!targetChat) {
+    log("ms365-approval: no target chat resolved");
+    sendResponse(false, { reason: "no target chat resolved" });
+    return;
+  }
+
+  const ttlMs = clampTtl(
+    msg.ttlMs,
+    deps.defaultTtlMs ?? DEFAULT_TTL_MS,
+    deps.minTtlMs ?? MIN_TTL_MS,
+    deps.maxTtlMs ?? MAX_TTL_MS,
+  );
+
+  const scope = `ms-365:write:${preview.itemId}`;
+  const why =
+    preview.agentRationale ??
+    `${preview.toolName} on ${preview.itemDisplayName}`;
+
+  let registered;
+  try {
+    registered = await deps.registerApproval({
+      agent_unit: preview.agentName,
+      scope,
+      action: "write",
+      approver_set: allowFrom,
+      why,
+      ttl_ms: ttlMs,
+    });
+  } catch (err) {
+    const msg2 = err instanceof Error ? err.message : String(err);
+    log(`ms365-approval: kernel register failed — ${msg2}`);
+    sendResponse(false, { reason: `kernel register failed: ${msg2}` });
+    return;
+  }
+  if (!registered) {
+    sendResponse(false, { reason: "kernel returned no request_id" });
+    return;
+  }
+
+  const text = buildMs365CardText(preview);
+  const replyMarkup = (deps.buildKeyboard ?? defaultKeyboard)(registered.request_id);
+
+  let posted;
+  try {
+    posted = await deps.postCard({
+      chatId: targetChat.chatId,
+      threadId: targetChat.threadId,
+      text,
+      replyMarkup,
+    });
+  } catch (err) {
+    const m = err instanceof Error ? err.message : String(err);
+    log(`ms365-approval: card post threw — ${m}`);
+    sendResponse(false, { reason: `card post failed: ${m}` });
+    return;
+  }
+  if (!posted) {
+    sendResponse(false, { reason: "card post returned null" });
+    return;
+  }
+
+  log(
+    `ms365-approval: posted card msg=${posted.messageId} request=${registered.request_id} expires=${new Date(registered.expires_at_ms).toISOString()}`,
+  );
+
+  sendResponse(true, {
+    requestId: registered.request_id,
+    expiresAtMs: registered.expires_at_ms,
+  });
+}

--- a/telegram-plugin/tests/ipc-validator.test.ts
+++ b/telegram-plugin/tests/ipc-validator.test.ts
@@ -271,4 +271,65 @@ describe('validateClientMessage', () => {
       expect(validateClientMessage({ type: 'heartbeat' })).toBe(false)
     })
   })
+
+  describe('request_ms365_approval (RFC #1873 §8 PR 4)', () => {
+    const valid = {
+      type: 'request_ms365_approval',
+      correlationId: 'abc123',
+      agentName: 'clerk',
+      preview: { agentName: 'clerk', toolName: 'mcp__ms-365__upload-file-content' },
+      ttlMs: 300000,
+    }
+
+    it('accepts a valid request_ms365_approval', () => {
+      expect(validateClientMessage(valid)).toBe(true)
+    })
+
+    it('accepts when ttlMs is omitted (handler uses default)', () => {
+      const { ttlMs: _, ...without } = valid
+      expect(validateClientMessage(without)).toBe(true)
+    })
+
+    it('rejects missing correlationId', () => {
+      const { correlationId: _, ...m } = valid
+      expect(validateClientMessage(m)).toBe(false)
+    })
+
+    it('rejects empty correlationId', () => {
+      expect(validateClientMessage({ ...valid, correlationId: '' })).toBe(false)
+    })
+
+    it('rejects oversized correlationId (>64 chars)', () => {
+      expect(validateClientMessage({ ...valid, correlationId: 'x'.repeat(65) })).toBe(false)
+    })
+
+    it('rejects missing agentName', () => {
+      const { agentName: _, ...m } = valid
+      expect(validateClientMessage(m)).toBe(false)
+    })
+
+    it('rejects malformed agentName (caps, spaces)', () => {
+      expect(validateClientMessage({ ...valid, agentName: 'NOT-LOWER' })).toBe(false)
+      expect(validateClientMessage({ ...valid, agentName: 'has space' })).toBe(false)
+    })
+
+    it('rejects null / non-object preview', () => {
+      expect(validateClientMessage({ ...valid, preview: null })).toBe(false)
+      expect(validateClientMessage({ ...valid, preview: 'string' })).toBe(false)
+      expect(validateClientMessage({ ...valid, preview: 42 })).toBe(false)
+    })
+
+    it('rejects negative ttlMs', () => {
+      expect(validateClientMessage({ ...valid, ttlMs: -1 })).toBe(false)
+    })
+
+    it('rejects non-finite ttlMs', () => {
+      expect(validateClientMessage({ ...valid, ttlMs: Infinity })).toBe(false)
+      expect(validateClientMessage({ ...valid, ttlMs: NaN })).toBe(false)
+    })
+
+    it('rejects non-number ttlMs', () => {
+      expect(validateClientMessage({ ...valid, ttlMs: '300000' })).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

RFC #1873 PR 4 of 5. Gates softeria write tools (OneDrive uploads, mail/calendar mutations) behind a Telegram approval card before they reach Microsoft Graph.

**Tested**: 42 new tests (17 hook + 25 handler). Full suite 7782 passing. tsc clean. dist/ builds clean.

## What this adds

- **`src/cli/ms-365-write-pretool.ts`** — PreToolUse hook. Filters by `GATED_MS365_WRITE_TOOLS` set (upload, create/update/delete event, update/delete message — Mail.Send deliberately excluded per RFC §4.3). Best-effort preview extraction from tool_input (file id, display name, deep link, size). Gateway IPC + kernel polling. Fail-closed.
- **`telegram-plugin/gateway/ms365-write-approval.ts`** — gateway handler. Cross-agent guard, preview validation, kernel registration at scope `ms-365:write:<itemId>`, plain-text card build, telegram post.
- **`docker/Dockerfile.agent`** + **`docker/security-plugin/hooks/hooks.json`** — bake the bundled `.mjs` into both `/opt/switchroom/hooks/` AND the unstrippable security-plugin path (matching drive-write-pretool's two-mount shape).
- IPC protocol additions + dispatcher wiring + scaffold hook entry.

## Design — weak metadata v1 per RFC §8

Microsoft uploads are full-file replacements; a structural diff would require downloading the prior version and running the docx/xlsx/pptx skill in diff mode. That's v1.5. v1 ships a simple plain-text card:

```
📄 Microsoft 365 write approval

Agent: clerk
Tool: ms-365__upload-file-content
Item: Q3-Strategy.docx
ID:   01ABCDEFG
Account: ken@outlook.com
Size: 14.5KB → 16.2KB (+1.7KB)
Link: https://onedrive.live.com/...
💬 Adding the meeting notes from yesterday

⚠️ Weak attestation (RFC §8 v1): operator should click through to
verify the actual change before approving. Structural diff coming v1.5.

[✅ Approve]  [🚫 Deny]
```

Button callbacks use `ms365:<requestId>:approve|deny` callback_data — routed by the existing kernel-driven flow shared with drive-write.

## Reused infrastructure (no duplication)

The approval kernel, kernel approval state, Telegram button-tap routing, and approver_set semantics are shared with the Google Drive flow. PR 4 only adds the provider-specific bits: tool-name filter, scope key, card content. Same pattern Google followed for its provider-specific divergence from the generic kernel.

## Test coverage

- **`ms-365-write-pretool.test.ts`** (17 tests): `isGatedMs365Tool` (correct positives + read-tool false negatives + Mail.Send NOT gated + wrong-prefix rejections), `GATED_MS365_WRITE_TOOLS` set integrity, `extractMs365Preview` (id/displayName/deepLink/size extraction across common field-name shapes, base64-content size derivation, defensive defaults).
- **`ms365-write-approval.test.ts`** (25 tests): `validateMs365Preview` (valid + optional fields + rejection of null/non-object/missing required/empty-string), `buildMs365CardText` (all fields rendered, size delta formatting incl. negative, deep link / agent-rationale inclusion, weak-attestation warning always present, long-string truncation), `handleRequestMs365Approval` (happy path, cross-agent rejection, invalid-preview rejection, missing-allowFrom/target-chat handling, kernel-null fail-close, postCard-null fail-close, TTL clamping, keyboard callback_data format).

## Test plan

- [x] vitest run on hook tests (17 passed)
- [x] bun test on handler tests (25 passed)
- [x] full vitest suite (7782 passed; +45 vs PR 3 baseline)
- [x] tsc --noEmit clean
- [x] dist/ builds clean (incl. ms-365-write-pretool.mjs at 7.7KB)
- [ ] Reviewer agent verifies the hook fail-closed behavior under all error paths
- [ ] Reviewer checks the import.meta.main gating (tests would hang on stdin without it)
- [ ] Reviewer evaluates the weak-metadata card UX: is it enough info for personal-use operator decisions?

🤖 Generated with [Claude Code](https://claude.com/claude-code)