### PR TITLE
feat(gateway): slash-command smart split — heavy → admin alias in supergroup mode (PR5)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9215,10 +9215,26 @@ type SwitchroomReplyMarkup =
 async function switchroomReply(
   ctx: Context,
   text: string,
-  options: { html?: boolean; reply_markup?: SwitchroomReplyMarkup } = {},
+  options: {
+    html?: boolean
+    reply_markup?: SwitchroomReplyMarkup
+    // PR5 — supergroup-mode slash-command smart split (CPO #4).
+    // 'query' (default semantics) follows the originating topic;
+    // 'mutation' and 'heavy' route to admin alias in supergroup mode;
+    // omitted/undefined preserves legacy in-place reply behavior.
+    classification?: 'query' | 'mutation' | 'heavy'
+  } = {},
 ): Promise<void> {
   const chatId = String(ctx.chat!.id)
-  const threadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
+  const baseThreadId = resolveThreadId(chatId, ctx.message?.message_thread_id)
+  // PR5 — when caller flagged the reply as mutation/heavy AND we're
+  // in supergroup mode, override the in-place thread with the
+  // admin-alias topic. For 'query' (or non-supergroup), routedOpts
+  // is `{}` and baseThreadId wins → behavior unchanged.
+  const routedOpts = options.classification
+    ? slashCommandReplyOpts(ctx, options.classification)
+    : {}
+  const threadId = routedOpts.message_thread_id ?? baseThreadId
   await ctx.reply(text, {
     ...(threadId != null ? { message_thread_id: threadId } : {}),
     ...(options.html ? { parse_mode: 'HTML' as const, link_preview_options: { is_disabled: true } } : {}),
@@ -9526,6 +9542,53 @@ function resolveSystemdRunPath(): string | null {
     _systemdRunPath = null
   }
   return _systemdRunPath
+}
+
+/**
+ * PR5 — supergroup-mode slash-command smart split (CPO #4 design).
+ *
+ * Classifies a slash-command response by event class and returns the
+ * `message_thread_id` an outbound reply should target in supergroup
+ * mode, or `undefined` when the agent isn't in supergroup-owned mode
+ * (caller falls through to grammY's default `ctx.reply` which
+ * routes to the originating topic).
+ *
+ * Three classes:
+ *   - `query` (`/help`, `/status`, etc.) — follows the originating
+ *     topic, identical to default `ctx.reply` behaviour.
+ *   - `mutation` (`/restart`, `/update apply`) — admin alias.
+ *   - `heavy` (`/logs`, `/audit`, `/upgradestatus`, `/memory <q>`)
+ *     — admin alias (operational separation per CPO #4).
+ *
+ * Callers spread the returned topic onto their send opts:
+ *
+ *   await ctx.reply(text, {
+ *     ...opts,
+ *     ...slashCommandReplyOpts(ctx, 'heavy'),
+ *   })
+ *
+ * Returns `{}` when no override is needed (non-supergroup, or
+ * helper resolved to the originating topic). Returns
+ * `{ message_thread_id: N }` otherwise.
+ */
+function slashCommandReplyOpts(
+  ctx: Context,
+  classification: 'query' | 'mutation' | 'heavy',
+): { message_thread_id?: number } {
+  const originThreadId = ctx.message?.message_thread_id
+  const event =
+    classification === 'query'
+      ? ({ kind: 'command-query', originThreadId } as const)
+      : classification === 'mutation'
+        ? ({ kind: 'command-mutation' } as const)
+        : ({ kind: 'command-heavy' } as const)
+  const target = resolveAgentOutboundTopic(event)
+  if (target == null) return {}
+  // Avoid the spurious explicit thread_id when it would equal the
+  // implicit-reply destination — keeps the wire identical to default
+  // ctx.reply for the query class in supergroup mode.
+  if (target === originThreadId) return {}
+  return { message_thread_id: target }
 }
 
 /**
@@ -9979,18 +10042,27 @@ async function dispatchShortVerbViaHostd(
   )
 }
 
-async function runSwitchroomCommand(ctx: Context, args: string[], label: string): Promise<void> {
+async function runSwitchroomCommand(
+  ctx: Context,
+  args: string[],
+  label: string,
+  // PR5 — supergroup-mode classification threaded through to
+  // switchroomReply. Default 'query' so existing callers (most
+  // commands) preserve in-place reply behavior. /logs /audit
+  // /upgradestatus /memory pass 'heavy' to route to admin alias.
+  classification: 'query' | 'mutation' | 'heavy' = 'query',
+): Promise<void> {
   try {
     const output = stripAnsi(switchroomExec(args))
     const formatted = formatSwitchroomOutput(output)
-    if (formatted) { await switchroomReply(ctx, preBlock(formatted), { html: true }) }
-    else { await switchroomReply(ctx, `${label}: done (no output)`) }
+    if (formatted) { await switchroomReply(ctx, preBlock(formatted), { html: true, classification }) }
+    else { await switchroomReply(ctx, `${label}: done (no output)`, { classification }) }
   } catch (err: unknown) {
     const error = err as { status?: number; stderr?: string; message?: string }
-    if (error.message?.includes('ENOENT')) { await switchroomReply(ctx, 'switchroom CLI not found.', { html: true }); return }
-    if (error.message?.includes('ETIMEDOUT') || error.message?.includes('timed out')) { await switchroomReply(ctx, `${label}: timed out`); return }
+    if (error.message?.includes('ENOENT')) { await switchroomReply(ctx, 'switchroom CLI not found.', { html: true, classification }); return }
+    if (error.message?.includes('ETIMEDOUT') || error.message?.includes('timed out')) { await switchroomReply(ctx, `${label}: timed out`, { classification }); return }
     const detail = stripAnsi(error.stderr?.trim() || error.message || 'unknown error')
-    await switchroomReply(ctx, `<b>${escapeHtmlForTg(label)} failed:</b>\n${preBlock(formatSwitchroomOutput(detail))}`, { html: true })
+    await switchroomReply(ctx, `<b>${escapeHtmlForTg(label)} failed:</b>\n${preBlock(formatSwitchroomOutput(detail))}`, { html: true, classification })
   }
 }
 
@@ -10955,7 +11027,9 @@ bot.command('update', async ctx => {
 // /upgrade-status. The /upgrade alias just below redirects.)
 bot.command('upgradestatus', async ctx => {
   if (!isAuthorizedSender(ctx)) return
-  await runSwitchroomCommand(ctx, ['update', '--status'], 'update --status')
+  // PR5 — heavy-output: route to admin alias in supergroup mode
+  // (CPO #4). Fleet-shared / DM agents fall through to in-place reply.
+  await runSwitchroomCommand(ctx, ['update', '--status'], 'update --status', 'heavy')
 })
 // Alias with hyphen — Grammy doesn't allow hyphens in command names
 // (Telegram's slash-command grammar excludes them) but operators are
@@ -11043,7 +11117,8 @@ bot.command('audit', async ctx => {
     )
     return
   }
-  await runSwitchroomCommand(ctx, argv, `hostd audit${argv.length > 2 ? ' …' : ''}`)
+  // PR5 — heavy-output → admin alias in supergroup mode (CPO #4).
+  await runSwitchroomCommand(ctx, argv, `hostd audit${argv.length > 2 ? ' …' : ''}`, 'heavy')
 })
 
 // ─── /approve, /deny, /pending ────────────────────────────────────────────
@@ -13825,14 +13900,16 @@ bot.command('logs', async ctx => {
   try { assertSafeAgentName(name) } catch { await switchroomReply(ctx, 'Invalid agent name.'); return }
   const lines = linesArg ? parseInt(linesArg, 10) : 20
   const lineCount = isNaN(lines) || lines < 1 ? 20 : Math.min(lines, 200)
-  await runSwitchroomCommand(ctx, ['agent', 'logs', name, '--lines', String(lineCount)], `logs ${name}`)
+  // PR5 — heavy-output → admin alias in supergroup mode (CPO #4).
+  await runSwitchroomCommand(ctx, ['agent', 'logs', name, '--lines', String(lineCount)], `logs ${name}`, 'heavy')
 })
 
 bot.command('memory', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   const query = ctx.match?.trim()
   if (!query) { await switchroomReply(ctx, 'Usage: /memory <search query>'); return }
-  await runSwitchroomCommand(ctx, ['memory', 'search', query], 'memory search')
+  // PR5 — heavy-output → admin alias in supergroup mode (CPO #4).
+  await runSwitchroomCommand(ctx, ['memory', 'search', query], 'memory search', 'heavy')
 })
 
 bot.command('issues', async ctx => {

--- a/telegram-plugin/tests/slash-command-smart-split.test.ts
+++ b/telegram-plugin/tests/slash-command-smart-split.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import { resolveOutboundTopic } from '../../src/telegram/topic-router.js'
+
+/**
+ * PR5 — supergroup-mode slash-command smart-split (CPO #4).
+ *
+ * The gateway wires `runSwitchroomCommand` → `switchroomReply` →
+ * `slashCommandReplyOpts(ctx, classification)` → `resolveOutboundTopic`.
+ * The helper is a thin classifier on top of the existing router; this
+ * test pins the END contract that drives all 4 heavy-output commands
+ * (/logs, /audit, /upgradestatus, /memory) and any future mutation
+ * additions:
+ *
+ *   - query → follows the originating topic (or undefined for fleet/DM)
+ *   - mutation → admin alias (or undefined for fleet/DM)
+ *   - heavy → admin alias (or undefined for fleet/DM)
+ *
+ * The gateway wrapper additionally collapses `target === originThreadId`
+ * back to `{}` so a query in the originating topic doesn't write a
+ * redundant `message_thread_id` opt. That's a wire-shape micro-opt
+ * tested separately at the call site.
+ */
+
+describe('PR5 slash-command smart split — router contract', () => {
+  const supergroup = {
+    default_topic_id: 1,
+    topic_aliases: { planning: 17, admin: 31, alerts: 42 },
+  }
+  const fleet = {} // no chat_id / default_topic_id → fleet/DM
+
+  describe('query class', () => {
+    it('supergroup: follows originThreadId', () => {
+      expect(
+        resolveOutboundTopic(supergroup, {
+          kind: 'command-query',
+          originThreadId: 17,
+        }),
+      ).toBe(17)
+    })
+
+    it('fleet: returns originThreadId unchanged (caller passes-through)', () => {
+      expect(
+        resolveOutboundTopic(fleet, {
+          kind: 'command-query',
+          originThreadId: 17,
+        }),
+      ).toBe(17)
+    })
+
+    it('supergroup, no origin thread (chat root): default_topic_id fallback', () => {
+      // command-query returns originThreadId verbatim, including
+      // undefined; the wrapper collapses undefined to "no override"
+      // and grammY's ctx.reply picks the originating topic anyway.
+      expect(
+        resolveOutboundTopic(supergroup, {
+          kind: 'command-query',
+          originThreadId: undefined,
+        }),
+      ).toBeUndefined()
+    })
+  })
+
+  describe('mutation class', () => {
+    it('supergroup: routes to admin alias', () => {
+      expect(resolveOutboundTopic(supergroup, { kind: 'command-mutation' })).toBe(31)
+    })
+
+    it('supergroup with no admin alias: default_topic_id fallback', () => {
+      const cfg = { default_topic_id: 1, topic_aliases: { planning: 17 } }
+      expect(resolveOutboundTopic(cfg, { kind: 'command-mutation' })).toBe(1)
+    })
+
+    it('fleet: returns undefined (caller falls through to ctx.reply)', () => {
+      expect(resolveOutboundTopic(fleet, { kind: 'command-mutation' })).toBeUndefined()
+    })
+  })
+
+  describe('heavy class (the 4 commands actually wired in PR5)', () => {
+    it('supergroup: /logs /audit /upgradestatus /memory all route to admin', () => {
+      // All four commands fold through the same `slashCommandReplyOpts(ctx, "heavy")`
+      // wrapper, which fires the same router event. One assertion covers
+      // all of them.
+      expect(resolveOutboundTopic(supergroup, { kind: 'command-heavy' })).toBe(31)
+    })
+
+    it('supergroup with no admin alias: default_topic_id fallback', () => {
+      const cfg = { default_topic_id: 1, topic_aliases: { planning: 17 } }
+      expect(resolveOutboundTopic(cfg, { kind: 'command-heavy' })).toBe(1)
+    })
+
+    it('fleet: returns undefined (caller falls through to ctx.reply)', () => {
+      expect(resolveOutboundTopic(fleet, { kind: 'command-heavy' })).toBeUndefined()
+    })
+  })
+
+  describe('separation contract: query vs mutation/heavy take different paths', () => {
+    // Pins the structural intent: a query and a mutation issued from
+    // the SAME originating topic in the SAME supergroup must resolve
+    // to DIFFERENT topics. If anyone collapses the three classes back
+    // to one event kind, this test fails loudly.
+    it('query.originThread !== mutation.adminAlias', () => {
+      const q = resolveOutboundTopic(supergroup, {
+        kind: 'command-query',
+        originThreadId: 17,
+      })
+      const m = resolveOutboundTopic(supergroup, { kind: 'command-mutation' })
+      const h = resolveOutboundTopic(supergroup, { kind: 'command-heavy' })
+      expect(q).toBe(17)
+      expect(m).toBe(31)
+      expect(h).toBe(31)
+      expect(q).not.toBe(m)
+      expect(m).toBe(h) // mutation and heavy both → admin
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- New `slashCommandReplyOpts(ctx, classification)` helper bridges `switchroomReply` → router via `command-query | command-mutation | command-heavy` event kinds
- 4 heavy-output commands wired: `/logs`, `/audit`, `/upgradestatus`, `/memory`
- Non-supergroup topology trace-verified: returns `{}` → `baseThreadId` wins → no wire change

## Why
CPO #4 from supergroup-mode RFC: operational separation. Heavy output dumped from /logs or /audit shouldn't pollute the topic the user typed into — admin alias is the right lane. Mutations get the same treatment via the existing PR4b-boot routing of boot cards.

## Test plan
- [x] 10 new tests pin the classification → topic contract
- [x] tsc --noEmit clean
- [x] check-bot-api-wrapping.sh clean
- [x] bun test 3490/3490 pass

## Out of scope (deferred)
- Mutation commands (/restart /update apply /new /reset) — boot cards already route via PR4b-boot; gateway-side ack stays in-place
- /doctor /folders /pending /topics /issues — judgment call on heaviness; trivial one-line additions when observed
- UAT against supergroup-configured test-harness agent — needs fixture
