### PR TITLE
fix(scaffold): pin TELEGRAM_STATE_DIR to in-container view (closes #1892)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2476,12 +2476,23 @@ export function scaffoldAgent(
     const switchroomCliPath = "/usr/local/bin/switchroom";
     const resolvedConfigPath = DOCKER_CONFIG_PATH;
 
+    // TELEGRAM_STATE_DIR MUST be the in-container view, not derived from
+    // `agentDir` (which is HOME-dependent and differs between host CLI and
+    // in-container CLI). Both writers target the same on-disk .mcp.json via
+    // bind-mount; the file is consumed by the in-container Claude, so the
+    // value must always be the in-container path regardless of where the
+    // writer runs. Pre-fix: host apply wrote `/home/<user>/...`, in-container
+    // reconcile wrote `/state/agent/home/...`, each invocation flipped the
+    // file and the broker's cron-only reconcile saw drift on every
+    // `schedule_add`. See switchroom#1892.
+    const telegramStateDir = `${DOCKER_AGENT_HOME}/.switchroom/agents/${name}/telegram`;
+
     const mcpServers: Record<string, McpServerConfig> = {
       "switchroom-telegram": {
         command: "bun",
         args: ["run", "--cwd", pluginDir, "--shell=bun", "--silent", "start"],
         env: {
-          TELEGRAM_STATE_DIR: join(agentDir, "telegram"),
+          TELEGRAM_STATE_DIR: telegramStateDir,
           SWITCHROOM_CONFIG: resolvedConfigPath,
           SWITCHROOM_CLI_PATH: switchroomCliPath,
         },
@@ -4427,12 +4438,18 @@ export function reconcileAgent(
     const switchroomCliPath = "/usr/local/bin/switchroom";
     const resolvedConfigPath = DOCKER_CONFIG_PATH;
 
+    // See companion comment + telegramStateDir derivation in scaffoldAgent
+    // (~line 2479). Must match byte-for-byte across both writers or every
+    // cron-only reconcile reports drift on the writer's own output.
+    // switchroom#1892.
+    const telegramStateDir = `${DOCKER_AGENT_HOME}/.switchroom/agents/${name}/telegram`;
+
     const mcpServers: Record<string, McpServerConfig> = {
       "switchroom-telegram": {
         command: "bun",
         args: ["run", "--cwd", pluginDir, "--shell=bun", "--silent", "start"],
         env: {
-          TELEGRAM_STATE_DIR: join(agentDir, "telegram"),
+          TELEGRAM_STATE_DIR: telegramStateDir,
           SWITCHROOM_CONFIG: resolvedConfigPath,
           SWITCHROOM_CLI_PATH: switchroomCliPath,
         },

--- a/tests/scaffold.mcp-json-telegram-state-dir.test.ts
+++ b/tests/scaffold.mcp-json-telegram-state-dir.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  scaffoldAgent,
+  reconcileAgent,
+  DOCKER_AGENT_HOME,
+} from "../src/agents/scaffold.js";
+import type {
+  AgentConfig,
+  SwitchroomConfig,
+  TelegramConfig,
+} from "../src/config/schema.js";
+
+/**
+ * switchroom#1892 regression guard. The `.mcp.json` file is bind-mounted
+ * into the agent container and consumed by the in-container Claude. Its
+ * `TELEGRAM_STATE_DIR` value MUST therefore be the in-container path,
+ * regardless of where the writer (host CLI or in-container CLI) is running.
+ *
+ * Pre-fix, both writers derived it from `agentDir` (HOME-dependent), so
+ * host `switchroom apply` wrote `/home/<user>/...` and in-container
+ * reconcile wrote `/state/agent/home/...` for the same logical agent.
+ * Each invocation flipped the file; every `schedule_add` triggered a
+ * broker reconcile that detected drift on its own write and failed with
+ * `E_RECONCILE_FAILED`.
+ */
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  } as unknown as SwitchroomConfig;
+}
+
+describe("scaffold/reconcile .mcp.json TELEGRAM_STATE_DIR is environment-independent (#1892)", () => {
+  let agentsDir: string;
+
+  beforeEach(() => {
+    agentsDir = mkdtempSync(join(tmpdir(), "switchroom-tg-state-dir-"));
+  });
+
+  afterEach(() => {
+    rmSync(agentsDir, { recursive: true, force: true });
+  });
+
+  it("scaffoldAgent writes the in-container TELEGRAM_STATE_DIR even when agentDir is a host-side path", () => {
+    const name = "test-agent";
+    const agentConfig = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig(name, agentConfig);
+
+    const res = scaffoldAgent(name, agentConfig, agentsDir, telegramConfig, switchroomConfig);
+    const mcp = JSON.parse(readFileSync(join(res.agentDir, ".mcp.json"), "utf-8"));
+    const tsd = mcp.mcpServers["switchroom-telegram"].env.TELEGRAM_STATE_DIR;
+
+    expect(tsd).toBe(`${DOCKER_AGENT_HOME}/.switchroom/agents/${name}/telegram`);
+    // Belt-and-braces: the host tmpdir path must NOT leak into the value.
+    expect(tsd.startsWith(agentsDir)).toBe(false);
+  });
+
+  it("reconcileAgent writes the in-container TELEGRAM_STATE_DIR even when agentDir is a host-side path", () => {
+    const name = "test-agent-2";
+    const agentConfig = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig(name, agentConfig);
+
+    scaffoldAgent(name, agentConfig, agentsDir, telegramConfig, switchroomConfig);
+    reconcileAgent(name, agentConfig, agentsDir, telegramConfig, switchroomConfig);
+
+    const mcp = JSON.parse(readFileSync(join(agentsDir, name, ".mcp.json"), "utf-8"));
+    const tsd = mcp.mcpServers["switchroom-telegram"].env.TELEGRAM_STATE_DIR;
+
+    expect(tsd).toBe(`${DOCKER_AGENT_HOME}/.switchroom/agents/${name}/telegram`);
+    expect(tsd.startsWith(agentsDir)).toBe(false);
+  });
+});

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -558,8 +558,10 @@ describe("scaffoldAgent", () => {
     expect(mcpJson.mcpServers).toBeDefined();
     expect(mcpJson.mcpServers["switchroom-telegram"]).toBeDefined();
     expect(mcpJson.mcpServers["switchroom-telegram"].command).toBe("bun");
+    // #1892: TELEGRAM_STATE_DIR is hardcoded to the in-container view so
+    // host CLI and in-container CLI writes don't flip the on-disk file.
     expect(mcpJson.mcpServers["switchroom-telegram"].env.TELEGRAM_STATE_DIR).toBe(
-      join(result.agentDir, "telegram"),
+      "/state/agent/home/.switchroom/agents/fork-agent/telegram",
     );
     expect(mcpJson.mcpServers["switchroom-telegram"].env.SWITCHROOM_CONFIG).toBe(
       "/state/config/switchroom.yaml",


### PR DESCRIPTION
## Summary

- Closes #1892. Pin `TELEGRAM_STATE_DIR` in `.mcp.json` to the in-container path in both `scaffoldAgent` and `reconcileAgent`, so host CLI and in-container CLI writes don't flip the on-disk file and trigger drift on every `schedule_add`.
- New regression test asserting both writers emit the canonical `${DOCKER_AGENT_HOME}/.switchroom/agents/<name>/telegram` value regardless of runtime `agentDir`.
- Updated one existing assertion in `tests/scaffold.test.ts` that encoded the bug (`join(result.agentDir, "telegram")`).

## Why

`agentDir` is HOME-dependent. In-container `HOME=/state/agent/home` so `agentDir` resolves to `/state/agent/home/.switchroom/agents/<name>`; host CLI sees `/home/<user>/.switchroom/agents/<name>`. Both writers target the same on-disk file via bind-mount and were each writing their environment's path. Every cron `schedule_add` triggered a broker reconcile that detected drift on its own write → `E_RECONCILE_FAILED` → overlay rolled back. Clerk and any docker-mode agent could not manage scheduled tasks.

Every other path in the framework MCP set was already environment-independent (`DOCKER_TELEGRAM_PLUGIN_PATH`, `DOCKER_CONFIG_PATH`, hardcoded `/usr/local/bin/switchroom`). `TELEGRAM_STATE_DIR` was the lone outlier.

`.mcp.json` is consumed only by the in-container Claude, so the value must always be the in-container view.

See #1892 for full root-cause analysis (with reproducible probes against clerk's real config showing zero-byte diff post-fix).

## Test plan

- [x] `vitest run tests/scaffold src/agents/scaffold` — 252 / 252 pass
- [x] `tsc --noEmit` — clean
- [x] New `tests/scaffold.mcp-json-telegram-state-dir.test.ts` pins both writers
- [x] Existing parity test `tests/scaffold.mcp-json-builder-parity.test.ts` still green
- [x] Live validation: probe against clerk's real config shows byte-identical `.mcp.json` between in-container and host writers post-fix; pre-fix the `TELEGRAM_STATE_DIR` line diverged

## Risk

Low. `DOCKER_AGENT_HOME` is the same constant compose already uses for the container's HOME (scaffold.ts:2055, 2100). The change unifies existing in-container behaviour with host-CLI behaviour. No new code paths, no new flags. Latent since v0.7.x docker cutover; visible whenever a host `switchroom apply` runs between in-container reconciles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)