### PR TITLE
feat(config): notion_workspace schema + per-DB ACL helpers (PR 1/5)

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -7,6 +7,7 @@ import { SwitchroomConfigSchema, type SwitchroomConfig } from "./schema.js";
 import { resolveDualPath } from "./paths.js";
 import { applyAgentOverlays } from "./overlay-loader.js";
 import { resolveAgentConfig } from "./merge.js";
+import { validateNotionWorkspaceConfig } from "./notion-workspace-acl.js";
 
 export class ConfigError extends Error {
   constructor(
@@ -207,6 +208,19 @@ export function loadConfig(configPath?: string): SwitchroomConfig {
   // otherwise silently fall back to default_topic_id at dispatch time —
   // far worse UX than failing fast at config-load.
   validateAllCronTopicAliases(config, filePath);
+
+  // RFC docs/rfcs/notion-integration.md PR 1: cross-validate per-agent
+  // notion_workspace.databases references against the top-level
+  // notion_workspace.databases friendly-name map. Same rationale as the
+  // cron-topic-alias check above — silent fall-through at runtime is
+  // strictly worse than failing fast at config-load.
+  const notionIssues = validateNotionWorkspaceConfig(config);
+  if (notionIssues.length > 0) {
+    throw new ConfigError(
+      `Invalid notion_workspace configuration in ${filePath}`,
+      notionIssues,
+    );
+  }
 
   return config;
 }

--- a/src/config/notion-validation.test.ts
+++ b/src/config/notion-validation.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Loader-level test for notion_workspace cross-validation —
+ * RFC docs/rfcs/notion-integration.md PR 1.
+ *
+ * Confirms that the loader hookup (loader.ts → validateNotionWorkspaceConfig)
+ * fails fast at config-load time on invalid notion_workspace cross-refs.
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { ConfigError, loadConfig } from "./loader.js";
+
+function writeYaml(yaml: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "switchroom-notion-validation-"));
+  const path = join(dir, "switchroom.yaml");
+  writeFileSync(path, yaml, "utf-8");
+  return path;
+}
+
+describe("loader: notion_workspace cross-validation", () => {
+  it("loads a valid notion_workspace config without complaint", () => {
+    const path = writeYaml(`
+switchroom:
+  version: 1
+  agents_dir: "/tmp/agents"
+telegram:
+  bot_token: "x"
+  forum_chat_id: "1"
+agents:
+  clerk:
+    topic_name: "clerk-topic"
+    notion_workspace: {}
+  carrie:
+    topic_name: "carrie-topic"
+    notion_workspace:
+      databases: [essays]
+notion_workspace:
+  databases:
+    essays: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+    tasks: "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
+`);
+    const config = loadConfig(path);
+    expect(config.notion_workspace?.databases?.essays).toMatch(/^a1b2c3d4/);
+    expect(config.agents.carrie?.notion_workspace?.databases).toEqual(["essays"]);
+  });
+
+  it("rejects a per-agent DB reference that's not in the top-level map", () => {
+    const path = writeYaml(`
+switchroom:
+  version: 1
+  agents_dir: "/tmp/agents"
+telegram:
+  bot_token: "x"
+  forum_chat_id: "1"
+agents:
+  carrie:
+    topic_name: "carrie-topic"
+    notion_workspace:
+      databases: [nonexistent]
+notion_workspace:
+  databases:
+    essays: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+`);
+    expect(() => loadConfig(path)).toThrowError(ConfigError);
+    try {
+      loadConfig(path);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError);
+      const ce = err as ConfigError;
+      expect(ce.message).toMatch(/Invalid notion_workspace/);
+      expect(ce.details?.[0]).toMatch(/nonexistent/);
+      expect(ce.details?.[0]).toMatch(/list-dbs/);
+    }
+  });
+
+  it("rejects per-agent notion_workspace when top-level block is missing", () => {
+    const path = writeYaml(`
+switchroom:
+  version: 1
+  agents_dir: "/tmp/agents"
+telegram:
+  bot_token: "x"
+  forum_chat_id: "1"
+agents:
+  carrie:
+    topic_name: "carrie-topic"
+    notion_workspace:
+      databases: [essays]
+`);
+    expect(() => loadConfig(path)).toThrow(ConfigError);
+    try {
+      loadConfig(path);
+    } catch (err) {
+      const ce = err as ConfigError;
+      expect(ce.details?.[0]).toMatch(/top-level notion_workspace block is missing/);
+    }
+  });
+
+  it("rejects empty databases list at the zod schema layer", () => {
+    const path = writeYaml(`
+switchroom:
+  version: 1
+  agents_dir: "/tmp/agents"
+telegram:
+  bot_token: "x"
+  forum_chat_id: "1"
+agents:
+  carrie:
+    topic_name: "carrie-topic"
+    notion_workspace:
+      databases: []
+notion_workspace:
+  databases:
+    essays: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+`);
+    // The zod schema's .min(1) catches this before the cross-validator
+    // gets a chance; the error surface is "Invalid switchroom.yaml
+    // configuration" with the zod path included.
+    expect(() => loadConfig(path)).toThrow();
+    try {
+      loadConfig(path);
+    } catch (err) {
+      const ce = err as ConfigError;
+      // Either error surface is acceptable — both fail fast at load.
+      const msg = `${ce.message} ${(ce.details ?? []).join(" ")}`;
+      expect(msg).toMatch(/notion_workspace|databases|at least one/);
+    }
+  });
+
+  it("rejects malformed UUIDs in the top-level databases map", () => {
+    const path = writeYaml(`
+switchroom:
+  version: 1
+  agents_dir: "/tmp/agents"
+telegram:
+  bot_token: "x"
+  forum_chat_id: "1"
+agents:
+  clerk:
+    topic_name: "clerk-topic"
+    notion_workspace: {}
+notion_workspace:
+  databases:
+    essays: "not-a-uuid"
+`);
+    expect(() => loadConfig(path)).toThrow();
+  });
+
+  it("rejects out-of-range rate_limit_rps", () => {
+    const path = writeYaml(`
+switchroom:
+  version: 1
+  agents_dir: "/tmp/agents"
+telegram:
+  bot_token: "x"
+  forum_chat_id: "1"
+agents:
+  clerk:
+    topic_name: "clerk-topic"
+    notion_workspace: {}
+notion_workspace:
+  rate_limit_rps: 100
+  databases:
+    essays: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+`);
+    expect(() => loadConfig(path)).toThrow();
+  });
+
+  it("ignores agents without notion_workspace", () => {
+    const path = writeYaml(`
+switchroom:
+  version: 1
+  agents_dir: "/tmp/agents"
+telegram:
+  bot_token: "x"
+  forum_chat_id: "1"
+agents:
+  clerk:
+    topic_name: "clerk-topic"
+    notion_workspace: {}
+  finn:
+    topic_name: "finn-topic"
+notion_workspace:
+  databases:
+    essays: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+`);
+    // Should load cleanly — finn has no notion config, isn't validated
+    // against the friendly-name map.
+    const config = loadConfig(path);
+    expect(config.agents.finn?.notion_workspace).toBeUndefined();
+  });
+});

--- a/src/config/notion-workspace-acl.test.ts
+++ b/src/config/notion-workspace-acl.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for notion-workspace-acl — RFC docs/rfcs/notion-integration.md PR 1.
+ * Mirrors `microsoft-workspace-acl.test.ts` shape where the model fits.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  agentCanAccessNotionDB,
+  isNotionIntegrationTokenKeyForAgent,
+  normalizeNotionUuid,
+  resolveDbNameFromUuid,
+  shouldEmitNotionMcp,
+  validateNotionWorkspaceConfig,
+} from "./notion-workspace-acl.js";
+import type { SwitchroomConfig } from "./schema.js";
+
+const DB_ESSAYS_DASHED = "a1b2c3d4-e5f6-7890-1234-567890abcdef";
+// Undashed form of DB_ESSAYS_DASHED — verified by stripping dashes.
+const DB_ESSAYS_UNDASHED = "a1b2c3d4e5f678901234567890abcdef";
+const DB_TASKS_DASHED = "b2c3d4e5-f6a7-8901-2345-67890abcdef0";
+
+// Build a baseline config with the top-level notion_workspace block
+// and a single agent with full access. Callers override slices via a
+// loose Record so they don't have to satisfy the full nested agent
+// shape (schedule, topic_name, ...). Same pattern m365's test uses to
+// sidestep deep-type strictness.
+const baseConfig = (overrides: Record<string, unknown> = {}): SwitchroomConfig =>
+  ({
+    agents: {
+      clerk: {
+        notion_workspace: {},
+      },
+    },
+    notion_workspace: {
+      vault_key: "notion/integration-token",
+      databases: {
+        essays: DB_ESSAYS_DASHED,
+        tasks: DB_TASKS_DASHED,
+      },
+    },
+    ...overrides,
+  }) as unknown as SwitchroomConfig;
+
+describe("normalizeNotionUuid", () => {
+  it("normalizes dashed UUID to undashed lowercase", () => {
+    expect(normalizeNotionUuid("A1B2C3D4-E5F6-7890-1234-567890ABCDEF")).toBe(
+      "a1b2c3d4e5f678901234567890abcdef",
+    );
+  });
+
+  it("accepts undashed UUID", () => {
+    expect(normalizeNotionUuid("a1b2c3d4e5f678901234567890abcdef")).toBe(
+      "a1b2c3d4e5f678901234567890abcdef",
+    );
+  });
+
+  it("returns null for malformed UUIDs", () => {
+    expect(normalizeNotionUuid("not-a-uuid")).toBeNull();
+    expect(normalizeNotionUuid("a1b2c3")).toBeNull();
+    expect(normalizeNotionUuid("")).toBeNull();
+    expect(normalizeNotionUuid(undefined)).toBeNull();
+    expect(normalizeNotionUuid(null)).toBeNull();
+  });
+
+  it("rejects non-hex characters", () => {
+    expect(normalizeNotionUuid("g1b2c3d4-e5f6-7890-1234-567890abcdef")).toBeNull();
+  });
+});
+
+describe("shouldEmitNotionMcp", () => {
+  it("returns false when agentName is empty", () => {
+    expect(shouldEmitNotionMcp("", baseConfig())).toBe(false);
+  });
+
+  it("returns false when top-level notion_workspace is missing", () => {
+    const cfg = baseConfig();
+    delete (cfg as { notion_workspace?: unknown }).notion_workspace;
+    expect(shouldEmitNotionMcp("clerk", cfg)).toBe(false);
+  });
+
+  it("returns false when agent has no notion_workspace block", () => {
+    const cfg = baseConfig({
+      agents: { clerk: {} },
+    });
+    expect(shouldEmitNotionMcp("clerk", cfg)).toBe(false);
+  });
+
+  it("returns true for an agent with notion_workspace: {}", () => {
+    expect(shouldEmitNotionMcp("clerk", baseConfig())).toBe(true);
+  });
+
+  it("returns true for an agent with notion_workspace.databases set", () => {
+    const cfg = baseConfig({
+      agents: {
+        carrie: { notion_workspace: { databases: ["essays"] } },
+      },
+    });
+    expect(shouldEmitNotionMcp("carrie", cfg)).toBe(true);
+  });
+
+  it("returns false for an agent not present in config.agents", () => {
+    expect(shouldEmitNotionMcp("ghost", baseConfig())).toBe(false);
+  });
+});
+
+describe("isNotionIntegrationTokenKeyForAgent", () => {
+  it("returns true for the default vault key on an enabled agent", () => {
+    expect(
+      isNotionIntegrationTokenKeyForAgent(
+        baseConfig(),
+        "clerk",
+        "notion/integration-token",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for an unrelated vault key", () => {
+    expect(
+      isNotionIntegrationTokenKeyForAgent(
+        baseConfig(),
+        "clerk",
+        "google/refresh-token",
+      ),
+    ).toBe(false);
+  });
+
+  it("honours the operator's vault_key override", () => {
+    const cfg = baseConfig({
+      notion_workspace: {
+        vault_key: "custom/notion-token",
+        databases: { essays: DB_ESSAYS_DASHED },
+      },
+    });
+    expect(
+      isNotionIntegrationTokenKeyForAgent(cfg, "clerk", "custom/notion-token"),
+    ).toBe(true);
+    expect(
+      isNotionIntegrationTokenKeyForAgent(cfg, "clerk", "notion/integration-token"),
+    ).toBe(false);
+  });
+
+  it("returns false when agent has mcp_servers.notion = false (hard opt-out)", () => {
+    const cfg = baseConfig();
+    cfg.agents.clerk = {
+      ...cfg.agents.clerk,
+      mcp_servers: { notion: false } as unknown as Record<string, unknown>,
+    };
+    expect(
+      isNotionIntegrationTokenKeyForAgent(
+        cfg,
+        "clerk",
+        "notion/integration-token",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for agents without notion_workspace", () => {
+    const cfg = baseConfig({ agents: { ghost: {} } });
+    expect(
+      isNotionIntegrationTokenKeyForAgent(
+        cfg,
+        "ghost",
+        "notion/integration-token",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when key is empty", () => {
+    expect(
+      isNotionIntegrationTokenKeyForAgent(baseConfig(), "clerk", ""),
+    ).toBe(false);
+  });
+});
+
+describe("agentCanAccessNotionDB", () => {
+  it("allows everything for an agent with no databases filter", () => {
+    expect(
+      agentCanAccessNotionDB(baseConfig(), "clerk", DB_ESSAYS_DASHED),
+    ).toBe(true);
+    expect(
+      agentCanAccessNotionDB(baseConfig(), "clerk", DB_TASKS_DASHED),
+    ).toBe(true);
+  });
+
+  it("allows a DB inside the filter list", () => {
+    const cfg = baseConfig({
+      agents: {
+        carrie: { notion_workspace: { databases: ["essays"] } },
+      },
+    });
+    expect(
+      agentCanAccessNotionDB(cfg, "carrie", DB_ESSAYS_DASHED),
+    ).toBe(true);
+  });
+
+  it("denies a DB outside the filter list", () => {
+    const cfg = baseConfig({
+      agents: {
+        carrie: { notion_workspace: { databases: ["essays"] } },
+      },
+    });
+    expect(
+      agentCanAccessNotionDB(cfg, "carrie", DB_TASKS_DASHED),
+    ).toBe(false);
+  });
+
+  it("denies access for an agent without a notion_workspace block", () => {
+    const cfg = baseConfig({ agents: { ghost: {} } });
+    expect(
+      agentCanAccessNotionDB(cfg, "ghost", DB_ESSAYS_DASHED),
+    ).toBe(false);
+  });
+
+  it("compares UUIDs after normalizing dashes (mixed forms allowed)", () => {
+    const cfg = baseConfig({
+      agents: {
+        carrie: { notion_workspace: { databases: ["essays"] } },
+      },
+    });
+    expect(
+      agentCanAccessNotionDB(cfg, "carrie", DB_ESSAYS_UNDASHED),
+    ).toBe(true);
+  });
+
+  it("rejects an unknown friendly name in the filter (silent deny — apply catches this)", () => {
+    const cfg = baseConfig({
+      agents: {
+        carrie: {
+          notion_workspace: { databases: ["nonexistent"] },
+        },
+      },
+    });
+    // No DB resolves; nothing in the filter list maps to a real UUID,
+    // so every access is denied. (The loader's
+    // validateNotionWorkspaceConfig catches this case at config load
+    // and emits a clear error — this predicate is just defence in
+    // depth.)
+    expect(
+      agentCanAccessNotionDB(cfg, "carrie", DB_ESSAYS_DASHED),
+    ).toBe(false);
+  });
+
+  it("returns false for a malformed UUID input", () => {
+    expect(
+      agentCanAccessNotionDB(baseConfig(), "clerk", "not-a-uuid"),
+    ).toBe(false);
+  });
+});
+
+describe("resolveDbNameFromUuid", () => {
+  it("returns the friendly name for a known UUID", () => {
+    expect(resolveDbNameFromUuid(baseConfig(), DB_ESSAYS_DASHED)).toBe(
+      "essays",
+    );
+  });
+
+  it("works with un-dashed UUID input", () => {
+    expect(resolveDbNameFromUuid(baseConfig(), DB_ESSAYS_UNDASHED)).toBe(
+      "essays",
+    );
+  });
+
+  it("returns null for an unknown UUID", () => {
+    expect(
+      resolveDbNameFromUuid(
+        baseConfig(),
+        "ffffffff-ffff-ffff-ffff-ffffffffffff",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when the top-level DB map is empty", () => {
+    const cfg = baseConfig({
+      notion_workspace: {
+        databases: {},
+      } as unknown as SwitchroomConfig["notion_workspace"],
+    });
+    expect(resolveDbNameFromUuid(cfg, DB_ESSAYS_DASHED)).toBeNull();
+  });
+
+  it("returns null for malformed input", () => {
+    expect(resolveDbNameFromUuid(baseConfig(), "not-a-uuid")).toBeNull();
+  });
+});
+
+describe("validateNotionWorkspaceConfig", () => {
+  it("returns no issues for a valid config", () => {
+    expect(validateNotionWorkspaceConfig(baseConfig())).toEqual([]);
+  });
+
+  it("returns no issues when no agent uses notion_workspace", () => {
+    const cfg = baseConfig({ agents: { other: {} } });
+    delete (cfg as { notion_workspace?: unknown }).notion_workspace;
+    expect(validateNotionWorkspaceConfig(cfg)).toEqual([]);
+  });
+
+  it("rejects a per-agent DB reference not present in the top-level map", () => {
+    const cfg = baseConfig({
+      agents: {
+        carrie: {
+          notion_workspace: { databases: ["nonexistent"] },
+        },
+      },
+    });
+    const issues = validateNotionWorkspaceConfig(cfg);
+    expect(issues.length).toBe(1);
+    expect(issues[0]).toMatch(/agents\.carrie\.notion_workspace\.databases/);
+    expect(issues[0]).toMatch(/nonexistent/);
+    expect(issues[0]).toMatch(/list-dbs/);
+  });
+
+  it("rejects per-agent notion_workspace when top-level is missing", () => {
+    const cfg = baseConfig({
+      agents: {
+        carrie: { notion_workspace: { databases: ["essays"] } },
+      },
+    });
+    delete (cfg as { notion_workspace?: unknown }).notion_workspace;
+    const issues = validateNotionWorkspaceConfig(cfg);
+    expect(issues.length).toBe(1);
+    expect(issues[0]).toMatch(/top-level notion_workspace block is missing/);
+  });
+
+  it("aggregates errors across multiple agents", () => {
+    const cfg = baseConfig({
+      agents: {
+        carrie: { notion_workspace: { databases: ["nonexistent"] } },
+        finn: { notion_workspace: { databases: ["also-missing"] } },
+      },
+    });
+    const issues = validateNotionWorkspaceConfig(cfg);
+    expect(issues.length).toBe(2);
+    expect(issues.some((i) => i.includes("carrie"))).toBe(true);
+    expect(issues.some((i) => i.includes("finn"))).toBe(true);
+  });
+
+  it("ignores agents without notion_workspace", () => {
+    const cfg = baseConfig({
+      agents: {
+        clerk: { notion_workspace: {} },
+        nointegration: {},
+      },
+    });
+    expect(validateNotionWorkspaceConfig(cfg)).toEqual([]);
+  });
+
+  it("flags empty databases list (defensive — schema also rejects)", () => {
+    const cfg = baseConfig({
+      agents: {
+        carrie: {
+          notion_workspace: {
+            databases: [],
+          } as unknown as Record<string, unknown>,
+        },
+      },
+    });
+    const issues = validateNotionWorkspaceConfig(cfg);
+    expect(issues.length).toBe(1);
+    expect(issues[0]).toMatch(/empty list/);
+  });
+});

--- a/src/config/notion-workspace-acl.ts
+++ b/src/config/notion-workspace-acl.ts
@@ -1,0 +1,235 @@
+/**
+ * Notion Workspace ACL predicates + load-time cross-validation —
+ * RFC docs/rfcs/notion-integration.md.
+ *
+ * Mirrors `microsoft-workspace-acl.ts` shape where the model fits, with
+ * two material differences:
+ *
+ *   1. **No per-account concept.** Notion has one integration token =
+ *      one workspace per switchroom install. There is no
+ *      `notion_accounts:` analog; the broker ACL on the vault key (set
+ *      via `vault put --allow <agent>`) is the authoritative list of
+ *      which agents may receive the token.
+ *   2. **Per-DB allowlist.** The per-agent `databases:` field narrows
+ *      which databases this agent may read/write within the
+ *      integration's upstream-shared set. Enforced at the PreToolUse
+ *      hook (PR 3) using `agentCanAccessNotionDB`.
+ *
+ * Pure module — no I/O, no side effects. Safe to import from anywhere.
+ */
+
+import type { SwitchroomConfig } from "./schema.js";
+
+/**
+ * Should agent `<agentName>` receive the Notion MCP entry in its
+ * scaffolded `.mcp.json`?
+ *
+ * Two conditions: (1) the top-level `notion_workspace:` block exists,
+ * (2) the agent has a `notion_workspace:` block (presence = opt-in;
+ * absence = no Notion).
+ *
+ * Does NOT check broker ACL — that's a runtime broker concern, not
+ * scaffold-time. The launcher fetching the token at runtime will get
+ * a clean `E_BROKER_GRANT_DENIED` if the operator forgot to grant
+ * access via `vault put --allow <agent>`. The doctor probe
+ * `notion:vault-acl-aligned` (PR 4) surfaces the mismatch at config
+ * time.
+ *
+ * Hard opt-out (`mcp_servers: { notion: false }`) handled by the
+ * caller, not here.
+ */
+export function shouldEmitNotionMcp(
+  agentName: string,
+  config: SwitchroomConfig,
+): boolean {
+  if (!agentName) return false;
+  if (!config.notion_workspace) return false;
+  const agentConfig = config.agents?.[agentName];
+  if (!agentConfig) return false;
+  if (agentConfig.notion_workspace === undefined) return false;
+  return true;
+}
+
+/**
+ * Broker ACL predicate: would `<agentName>` be served the Notion
+ * integration token vault key?
+ *
+ * Mirrors `isMicrosoftClientCredentialKeyForAgent` shape. Gated on
+ * `shouldEmitNotionMcp` so the grant is coextensive with the set of
+ * agents that get the MCP — the two predicates can never disagree.
+ *
+ * The vault key compared is the bare key string (no `vault:` prefix).
+ * The default is `notion/integration-token`; the operator can override
+ * via `notion_workspace.vault_key`.
+ */
+export function isNotionIntegrationTokenKeyForAgent(
+  config: SwitchroomConfig,
+  agentName: string,
+  key: string,
+): boolean {
+  if (!agentName || !key) return false;
+  if (!shouldEmitNotionMcp(agentName, config)) return false;
+
+  const agentConfig = config.agents?.[agentName];
+  if (
+    (agentConfig?.mcp_servers as Record<string, unknown> | undefined)?.[
+      "notion"
+    ] === false
+  ) {
+    return false;
+  }
+
+  const configuredKey =
+    config.notion_workspace?.vault_key ?? "notion/integration-token";
+  return key === configuredKey;
+}
+
+/**
+ * Normalize a Notion UUID to its undashed (32-hex) canonical form for
+ * comparison. Notion accepts both dashed and undashed forms on
+ * requests, but compares them after normalizing — so a tool call with
+ * `parent.database_id: "a1b2c3d4e5f67890..."` and a config entry
+ * `essays: "a1b2c3d4-e5f6-7890-..."` must compare equal.
+ *
+ * Returns null if the input isn't a syntactically valid UUID.
+ */
+export function normalizeNotionUuid(uuid: string | undefined | null): string | null {
+  if (typeof uuid !== "string") return null;
+  const stripped = uuid.replace(/-/g, "").toLowerCase();
+  if (!/^[0-9a-f]{32}$/.test(stripped)) return null;
+  return stripped;
+}
+
+/**
+ * PreToolUse hook predicate (PR 3): may agent `<agentName>` access
+ * the Notion database identified by `<dbUuid>`?
+ *
+ * Decision tree:
+ *   - Agent has no `notion_workspace:` block → DENY.
+ *   - Agent has `notion_workspace: {}` (no `databases:` filter) → ALLOW
+ *     anything the upstream integration can see.
+ *   - Agent has `notion_workspace.databases: [...]` → ALLOW only if
+ *     `<dbUuid>` matches a resolved UUID in that list.
+ *
+ * UUIDs are compared after normalizing dashes (Notion's response
+ * format is dashed; operators often paste un-dashed).
+ */
+export function agentCanAccessNotionDB(
+  config: SwitchroomConfig,
+  agentName: string,
+  dbUuid: string,
+): boolean {
+  if (!shouldEmitNotionMcp(agentName, config)) return false;
+
+  const targetNorm = normalizeNotionUuid(dbUuid);
+  if (targetNorm === null) return false;
+
+  const agentConfig = config.agents?.[agentName];
+  const allowedNames = agentConfig?.notion_workspace?.databases;
+  if (allowedNames === undefined || allowedNames.length === 0) {
+    // No databases filter = full access (within upstream-shared set).
+    // The `length === 0` branch is defensive — schema rejects empty
+    // lists at load time, but defending against a partially-validated
+    // SwitchroomConfig shape is cheap.
+    return true;
+  }
+
+  const dbMap = config.notion_workspace?.databases ?? {};
+  for (const name of allowedNames) {
+    const uuid = dbMap[name];
+    if (!uuid) continue;
+    if (normalizeNotionUuid(uuid) === targetNorm) return true;
+  }
+  return false;
+}
+
+/**
+ * Reverse lookup: given a UUID, return its operator-assigned friendly
+ * name if present in the top-level DB map. Used by the approval card
+ * UI (PR 3) to surface "tasks" instead of a UUID in the operator-
+ * facing approval message.
+ *
+ * Returns null when the UUID doesn't appear in the map — the caller
+ * should fall back to displaying the bare UUID.
+ */
+export function resolveDbNameFromUuid(
+  config: SwitchroomConfig,
+  dbUuid: string,
+): string | null {
+  const targetNorm = normalizeNotionUuid(dbUuid);
+  if (targetNorm === null) return null;
+
+  const dbMap = config.notion_workspace?.databases ?? {};
+  for (const [name, uuid] of Object.entries(dbMap)) {
+    if (normalizeNotionUuid(uuid) === targetNorm) return name;
+  }
+  return null;
+}
+
+/**
+ * Load-time cross-validation — called from `loader.ts` after the zod
+ * schema accepts the YAML. Catches typos the schema can't (it doesn't
+ * see across keys).
+ *
+ * Currently catches one class of error:
+ *   - Per-agent `notion_workspace.databases: [<name>]` references a
+ *     friendly name not present in top-level
+ *     `notion_workspace.databases`.
+ *
+ * Returns the list of error strings (formatted ready for ConfigError
+ * inclusion). Empty array = config is valid.
+ *
+ * Runtime-state checks (vault key present, broker ACL alignment) are
+ * deliberately deferred to the doctor probes (PR 4) — they need
+ * broker-daemon state, not just YAML.
+ */
+export function validateNotionWorkspaceConfig(
+  config: SwitchroomConfig,
+): string[] {
+  const issues: string[] = [];
+  const dbMap = config.notion_workspace?.databases ?? {};
+  const known = new Set(Object.keys(dbMap));
+
+  for (const [agentName, agentRaw] of Object.entries(config.agents ?? {})) {
+    if (!agentRaw) continue;
+    const dbFilter = agentRaw.notion_workspace?.databases;
+    if (dbFilter === undefined) continue;
+
+    // Schema already rejects empty lists, but we defend against a
+    // partially-validated shape (e.g. cascade-resolved configs in
+    // tests). An empty list reaching here is a programming error,
+    // not a YAML one.
+    if (dbFilter.length === 0) {
+      issues.push(
+        `  agents.${agentName}.notion_workspace.databases is an empty ` +
+        `list. Delete the entire notion_workspace block to remove Notion ` +
+        `access, or list at least one database friendly name.`,
+      );
+      continue;
+    }
+
+    if (config.notion_workspace === undefined) {
+      issues.push(
+        `  agents.${agentName}.notion_workspace is set but the top-level ` +
+        `notion_workspace block is missing. Configure the integration ` +
+        `globally first (vault_key + databases map), then grant per-agent ` +
+        `access.`,
+      );
+      continue;
+    }
+
+    for (const name of dbFilter) {
+      if (!known.has(name)) {
+        issues.push(
+          `  agents.${agentName}.notion_workspace.databases references ` +
+          `unknown database "${name}". Add it to top-level ` +
+          `notion_workspace.databases (run \`switchroom notion list-dbs\` ` +
+          `to see the UUIDs the integration can read), or remove the ` +
+          `reference.`,
+        );
+      }
+    }
+  }
+
+  return issues;
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -964,6 +964,90 @@ export const MicrosoftWorkspaceConfigSchema = z
   .optional();
 
 /**
+ * Top-level notion_workspace config block — RFC docs/rfcs/notion-integration.md.
+ *
+ * Centralizes the Notion internal-integration token, the friendly-name →
+ * database UUID map, and the global rate-limit bucket size. Block is
+ * optional — when omitted, no agent gets a notion MCP entry regardless of
+ * per-agent config (the per-agent block is meaningless without the
+ * top-level one).
+ *
+ * Unlike google_workspace/microsoft_workspace which use OAuth-flow
+ * accounts, Notion uses a single long-lived integration token. There is
+ * no per-account concept; there is no `notion_accounts:` analog. The
+ * twin-key ACL is (1) broker ACL on the vault key, (2) per-agent
+ * `databases:` filter in AgentNotionWorkspaceConfigSchema.
+ *
+ * UUID regex is lenient (32 hex with optional dashes) — Notion's wire
+ * format always normalizes to the dashed form on responses but accepts
+ * either on requests, and the operator may paste either.
+ */
+export const NotionWorkspaceConfigSchema = z
+  .object({
+    vault_key: z
+      .string()
+      .min(1)
+      .default("notion/integration-token")
+      .describe(
+        "Vault key holding the Notion internal-integration token. Default " +
+        "`notion/integration-token`. Override only for non-standard vault " +
+        "layouts. The broker's --allow ACL on this key is the authoritative " +
+        "list of which agents may receive the token."
+      ),
+    databases: z
+      .record(
+        z.string().regex(/^[a-z0-9][a-z0-9_-]{0,62}$/, {
+          message:
+            "notion_workspace.databases friendly names must match " +
+            "/^[a-z0-9][a-z0-9_-]{0,62}$/ — lowercase letters, digits, " +
+            "hyphens, underscores. Got: '%s'.",
+        }),
+        z.string().regex(
+          /^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}$/,
+          {
+            message:
+              "notion_workspace.databases values must be Notion database " +
+              "UUIDs (32 hex characters, optional dashes).",
+          }
+        ),
+      )
+      .default({})
+      .describe(
+        "Friendly-name → Notion database UUID map. Operator-managed; agents " +
+        "reference databases by friendly name only — they never see or type " +
+        "UUIDs. Populate via `switchroom notion list-dbs` (PR 4) after " +
+        "vault-putting the integration token and sharing DBs with the " +
+        "integration in Notion's UI."
+      ),
+    mcp_version: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Optional pin for the upstream `@notionhq/notion-mcp-server` npm " +
+        "package version. Default is the build-time `NOTION_MCP_PINNED_VERSION` " +
+        "constant. Override only when reproducing operator-specific bugs."
+      ),
+    rate_limit_rps: z
+      .number()
+      .int()
+      .positive()
+      .max(10)
+      .optional()
+      .describe(
+        "Optional global rate-limit budget in requests per second across all " +
+        "switchroom agents sharing this integration token. Defaults to 3 " +
+        "(Notion's documented public-API limit). Lower it if you also use " +
+        "the integration token from outside switchroom and need to share " +
+        "budget. Higher than 10 is rejected — if you think you need it, " +
+        "your usage probably needs a workspace-tier upgrade with Notion."
+      ),
+  })
+  .optional();
+
+export type NotionWorkspaceConfig = z.infer<typeof NotionWorkspaceConfigSchema>;
+
+/**
  * Per-agent google_workspace override. Currently just narrows the approver
  * set + lets the agent pick a tier different from the top-level default.
  * google_client_id/secret are not per-agent — those live at the top level
@@ -1040,6 +1124,56 @@ export const AgentMicrosoftWorkspaceConfigSchema = z
       ),
   })
   .optional();
+
+/**
+ * Per-agent notion_workspace override — RFC docs/rfcs/notion-integration.md.
+ *
+ * Presence of the block opts the agent IN to Notion access (the launcher
+ * is scaffolded, the `.mcp.json` entry is emitted, the broker grants the
+ * integration token). Absence opts out.
+ *
+ * The optional `databases:` filter narrows which DBs this agent may
+ * read/write. Names must resolve in the top-level
+ * `notion_workspace.databases` map (cross-validated at load time by
+ * `validateNotionWorkspaceConfig`). Empty list `[]` is rejected — same as
+ * "no notion_workspace at all", and the operator's intent is ambiguous;
+ * fail loudly instead of silently denying every tool call.
+ *
+ * Cascade: per-agent `databases` list REPLACES the parent (profile)
+ * list, never concatenates — see RFC §6.5.
+ */
+export const AgentNotionWorkspaceConfigSchema = z
+  .object({
+    databases: z
+      .array(
+        z.string().regex(/^[a-z0-9][a-z0-9_-]{0,62}$/, {
+          message:
+            "notion_workspace.databases entries must be friendly names " +
+            "matching /^[a-z0-9][a-z0-9_-]{0,62}$/ — these must appear as " +
+            "keys in top-level notion_workspace.databases.",
+        }),
+      )
+      .min(1, {
+        message:
+          "notion_workspace.databases must list at least one friendly " +
+          "name. An empty list rejects every Notion tool call — if you " +
+          "want to remove this agent's Notion access, delete the entire " +
+          "notion_workspace block instead.",
+      })
+      .optional()
+      .describe(
+        "Optional per-agent allowlist of database friendly names this " +
+        "agent may read/write. Each name must exist as a key in top-level " +
+        "notion_workspace.databases. Omit the field (or leave it undefined) " +
+        "to grant access to every DB the upstream integration can see — " +
+        "appropriate for an admin/orchestrator agent. Set the list to " +
+        "narrow access for specialist agents."
+      ),
+  })
+  .optional();
+
+export type AgentNotionWorkspaceConfig =
+  z.infer<typeof AgentNotionWorkspaceConfigSchema>;
 
 /**
  * Legacy alias for back-compat with RFC D shipped config. Identical shape
@@ -1780,6 +1914,13 @@ export const AgentSchema = z.object({
     "this agent in its `enabled_for[]`) and optionally overrides org_mode. " +
     "microsoft_client_id/secret are not per-agent.",
   ),
+  notion_workspace: AgentNotionWorkspaceConfigSchema.describe(
+    "RFC docs/rfcs/notion-integration.md. Per-agent Notion access. " +
+    "Presence opts the agent IN (launcher scaffolded, MCP entry emitted, " +
+    "broker grants the integration token). Optional `databases:` filter " +
+    "narrows which DBs this agent may read/write — names must resolve in " +
+    "top-level notion_workspace.databases. Absence opts the agent OUT.",
+  ),
   repos: z
     .record(
       z.string().regex(
@@ -2330,6 +2471,14 @@ export const SwitchroomConfigSchema = z.object({
     "endpoint (defaults to /common for personal MSA + work), and the " +
     "org_mode opt-in for Teams/SharePoint surfaces. Block is optional; " +
     "when omitted the broker does not register the Microsoft provider.",
+  ),
+  notion_workspace: NotionWorkspaceConfigSchema.describe(
+    "RFC docs/rfcs/notion-integration.md. Top-level Notion integration " +
+    "config — vault key for the integration token, friendly-name → " +
+    "database UUID map, optional MCP-package version pin, and optional " +
+    "global rate-limit override (default 3 rps, Notion's documented " +
+    "public-API limit). Block is optional; when omitted no agent gets a " +
+    "Notion MCP entry regardless of per-agent config.",
   ),
   quota: QuotaConfigSchema.optional().describe(
     "Optional weekly/monthly USD spend budgets rendered in the session " +


### PR DESCRIPTION
First PR in the Notion integration series (5 PRs total). RFC at #1895
(\`docs/rfcs/notion-integration.md\`).

## Summary

- Adds \`notion_workspace:\` top-level config block (vault_key,
  friendly-name → DB UUID map, optional mcp_version, optional
  rate_limit_rps).
- Adds per-agent \`notion_workspace:\` block (optional \`databases:\`
  allowlist).
- Adds \`src/config/notion-workspace-acl.ts\` with pure predicates used
  by the broker (PR 2) and the PreToolUse hook (PR 3): emission gate,
  vault-key match, per-DB access check (UUID-normalized), friendly-
  name reverse lookup, and load-time cross-validator.
- Wires the cross-validator into the loader so typos in per-agent
  \`databases:\` references fail fast at config-load instead of silently
  denying every tool call at runtime.

No runtime behaviour change yet — schema only. The launcher in PR 2
will read these fields; the hook in PR 3 will enforce the per-DB ACL.

## Why this shape

- Mirrors \`microsoft-workspace-acl.ts\` byte-for-byte where the model
  fits (predicate names, vault-ref helper, mcp_servers hard opt-out
  honoured at the same place).
- Diverges from m365 on the two pieces that genuinely differ for
  Notion: no per-account concept (one integration token per
  workspace), per-DB allowlist (the integration's upstream-shared set
  is the outer boundary; switchroom's \`databases:\` is the inner).
- Runtime-state checks (vault key present, broker ACL alignment)
  deferred to doctor probes in PR 4 — they need broker-daemon state,
  not YAML.

## Test plan

- [x] \`./node_modules/.bin/vitest run src/config/\` — 252/252 passing
      (was 210; +42 new cases)
- [x] \`./node_modules/.bin/tsc --noEmit\` clean
- [x] \`node scripts/check-plugin-references.mjs\` clean
- [x] \`node scripts/check-bun-test-imports.mjs\` clean

## Risk

Very low. Schema-only addition; existing code paths untouched. The
loader hook is a single \`if (issues.length > 0) throw\` block that only
fires when both \`notion_workspace:\` blocks are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)