### PR TITLE
feat(notion): docs + bundled skill (PR 5/5)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `claude_md_raw` | concatenate | Escape hatch: append to CLAUDE.md on scaffold |
 | `cli_args` | concatenate | Escape hatch: extra `exec claude` flags |
 | `google_workspace` | deep merge | Google Drive/Docs/Sheets/Calendar integration. `google_client_id` / `google_client_secret` are install-wide (top level only); `tier` + `approvers` cascade per-agent. See § Google Workspace below. |
+| `notion_workspace` | deep merge top-level; per-agent `databases:` list REPLACES (does not concatenate) | Notion integration. Top-level `vault_key` + `databases:` map cascade via deep merge so a profile can add a DB without clobbering top-level entries. The per-agent `databases:` allowlist is **override** — an agent's list replaces the parent's, so a specialist agent inheriting a profile can narrow to fewer DBs. See § Notion Workspace below and [notion-integration.md](notion-integration.md). |
 
 ## Built-in MCP Servers
 
@@ -628,6 +629,76 @@ You typically want both. Without `add_dirs:`, claude's Read/Edit
 tools will reject the path as outside the working set even though
 the file is there. Without `bind_mounts:`, the path doesn't exist in
 the sandbox and `add_dirs:` is a no-op.
+
+## Notion Workspace (`notion_workspace:`)
+
+The Notion integration (`docs/rfcs/notion-integration.md`) is configured
+with one top-level block + one per-agent block. Unlike
+`google_workspace` / `microsoft_workspace`, there's no per-account
+concept — one integration token = one Notion workspace.
+
+```yaml
+notion_workspace:
+  # vault key holding the integration token (default shown).
+  vault_key: notion/integration-token
+
+  # friendly-name → Notion-DB-UUID map. Source of truth for the fleet.
+  # Populate with `switchroom notion list-dbs` after putting the
+  # integration token in the vault.
+  databases:
+    essays: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+    tasks:  "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
+
+  # OPTIONAL — pin a non-default @notionhq/notion-mcp-server version.
+  # mcp_version: 1.8.1
+
+  # OPTIONAL — global rate-limit budget (rps), shared across all agents.
+  # Defaults to 3 (Notion's documented public-API limit). Lower it if
+  # you also use the integration token from outside switchroom.
+  # rate_limit_rps: 3
+```
+
+Per-agent grant:
+
+```yaml
+agents:
+  clerk:
+    notion_workspace: {}              # full access (within upstream-shared set)
+  carrie:
+    notion_workspace:
+      databases: [essays]             # restrict to essays DB only
+```
+
+| Field | Cascade mode | Notes |
+|---|---|---|
+| `notion_workspace.vault_key` | override | Top-level only; per-agent override not supported. |
+| `notion_workspace.databases` (top-level map) | deep merge | Profile-level entries merge with top-level. |
+| `agents.<name>.notion_workspace.databases` (list) | **override** | Per-agent list REPLACES the parent (profile) list, not concatenate — so a specialist agent inheriting a profile can narrow access. |
+| `notion_workspace.mcp_version` | override | Top-level only. |
+| `notion_workspace.rate_limit_rps` | override | Top-level only. |
+
+The `notion_workspace` per-agent block has two valid shapes:
+
+- `notion_workspace: {}` — opt in, full access (within whatever the
+  upstream integration was shared with in Notion's UI).
+- `notion_workspace: { databases: [name, …] }` — opt in, restricted.
+  Names must resolve in top-level `notion_workspace.databases`; an
+  empty list `[]` is rejected at config-load time.
+
+Absent: agent has no Notion access (no MCP entry scaffolded, no
+broker grant, no hook installed).
+
+### Per-agent ACL (vault key + YAML config)
+
+The broker ACL on `notion/integration-token` (set via
+`switchroom vault set notion/integration-token --allow <agent1>,<agent2>`) AND the agent's
+`notion_workspace:` YAML config must agree. Drift is caught by the
+doctor probe `notion:vault-acl-aligned` (RFC §9). If you add an agent
+to one without the other, the launcher fails 503 at runtime; doctor
+surfaces this at config-edit time.
+
+Setup walkthrough:
+[`docs/notion-integration.md`](notion-integration.md).
 
 ## Minimal Example
 

--- a/docs/notion-integration.md
+++ b/docs/notion-integration.md
@@ -1,0 +1,224 @@
+# Notion integration
+
+Switchroom's Notion integration lets one or more agents read and write
+Notion pages and databases under a single operator-owned **internal
+integration**, with per-agent allowlists at the database level.
+
+This is the operator-facing setup guide. See
+[`docs/rfcs/notion-integration.md`](./rfcs/notion-integration.md) for
+the design rationale.
+
+## What you get
+
+- One Notion integration shared across agents (no per-agent OAuth).
+- Per-agent database allowlists (`clerk` reads everything; `carrie`
+  only sees the essays DB).
+- Mandatory privacy filter on search results (an agent never sees
+  snippets from databases outside its allowlist).
+- A PreToolUse hook that rejects write attempts against
+  out-of-allowlist databases with a clear, operator-actionable
+  message.
+- A doctor section showing per-agent ACL + heartbeat status.
+
+## What you don't get (v1)
+
+- **Public OAuth.** Single-operator internal integration only.
+- **`create_database` from agents.** Operators create DBs via
+  Notion's UI; switchroom can read + write existing DBs only.
+- **Standalone-page access.** Pages without a database parent are
+  hard-denied. Move them into a database to give agent access.
+- **Operator approval cards on writes.** v1 ships the allowlist
+  primitive; a follow-up PR will add the m365/drive-style approval
+  card on top.
+- **Coordinated rate-limit bucket.** The broker primitive shipped
+  but isn't wired into the hook yet — relies on Notion's own 429
+  retry behaviour.
+
+## Bootstrap order (read this — order matters)
+
+1. **Create the integration in Notion.**
+   - Notion → Settings → Connections → **Develop or manage
+     integrations** → **New integration**.
+   - Name: `switchroom` (or whatever — visible only to you).
+   - Type: **Internal**. Associated workspace: your primary
+     workspace.
+   - Capabilities (recommended starting set):
+     - Read content
+     - Update content
+     - Insert content
+     - Read comments / Insert comments
+     - Read user information (no email)
+   - Copy the **Internal Integration Secret** (starts with
+     `secret_…` or `ntn_…`).
+
+2. **Put the secret in switchroom's vault.**
+   ```bash
+   switchroom vault set notion/integration-token \
+     --allow clerk,carrie     # comma-separated list of agents that may read it
+   ```
+   The `--allow` ACL is the broker-side authorization — agents not
+   listed here can't fetch the token, regardless of YAML config.
+
+3. **Share databases with the integration in Notion's UI.**
+   For each database or page you want any switchroom agent to
+   touch:
+   - Open it in Notion.
+   - Top-right ⋯ → **Connections** → add `switchroom`.
+   - This is Notion's *upstream* ACL. The integration literally
+     cannot see pages that weren't shared with it.
+
+4. **Discover the database UUIDs (paste-ready).**
+   ```bash
+   switchroom notion list-dbs
+   ```
+   This prints a ready-to-paste YAML block:
+   ```yaml
+   # Paste under `notion_workspace:` in switchroom.yaml:
+   databases:
+     essays: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+     tasks:  "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
+   ```
+   Edit the friendly names to taste — agents reference databases by
+   these names, never by UUID.
+
+5. **Wire it into `switchroom.yaml`.**
+   ```yaml
+   notion_workspace:
+     vault_key: notion/integration-token   # default; usually omitted
+     databases:
+       essays: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+       tasks:  "b2c3d4e5-f6a7-8901-2345-67890abcdef0"
+     # OPTIONAL: rate_limit_rps: 3        # default 3 (Notion's limit)
+
+   agents:
+     clerk:
+       notion_workspace: {}              # full access (within upstream-shared set)
+     carrie:
+       notion_workspace:
+         databases: [essays]             # restrict to essays DB only
+   ```
+
+   - `notion_workspace: {}` (empty object) = **opt in, no
+     restrictions**. Agent can access every DB the upstream
+     integration was shared with.
+   - `notion_workspace.databases: [name, name, ...]` = **opt in,
+     restricted**. Agent can only access the listed DBs (names
+     must resolve in `notion_workspace.databases` at the top
+     level). Empty list `[]` is REJECTED at config-load time.
+   - No `notion_workspace:` block at all = **agent has no Notion
+     access**.
+
+6. **Apply and verify.**
+   ```bash
+   switchroom apply
+   switchroom doctor          # Should show "Notion (RFC ...)" section all OK
+   switchroom notion test clerk   # Smoke test from operator perspective
+   ```
+
+## Common operator tasks
+
+### Adding a database to an existing agent
+
+1. Share the DB with the `switchroom` integration in Notion's UI.
+2. `switchroom notion list-dbs` to print the updated YAML block;
+   copy the new line into `notion_workspace.databases:`.
+3. Add the friendly name to the agent's
+   `notion_workspace.databases:` list.
+4. `switchroom apply` — no agent restart needed (config cascade
+   re-renders settings.json).
+
+### Rotating the integration token
+
+1. Notion → Settings → Integrations → `switchroom` → **Refresh secret**.
+2. `switchroom vault set notion/integration-token` — paste the new
+   value. (Re-state `--allow` to preserve the current allowlist —
+   `vault set` overwrites the scope.)
+3. `switchroom agent restart <name> --graceful-restart` for each
+   notion-enabled agent. The launcher picks up the new token on
+   next-fetch.
+
+### Revoking one agent's access
+
+```bash
+# Re-run `vault set` with the agent omitted from --allow.
+# Example: previously --allow clerk,carrie — now revoking carrie:
+switchroom vault set notion/integration-token --allow clerk
+```
+
+`vault set` overwrites the entire `--allow` scope, so re-state the
+list with the agent removed. The broker stops serving the token to
+that agent immediately. Existing running tool calls finish; the next
+launcher restart fails closed.
+
+### Revoking everyone
+
+Notion → Settings → Integrations → `switchroom` → **Delete
+integration**. All `notion_workspace`-enabled agents start failing
+on the next tool call.
+
+## Doctor section
+
+```
+Notion (RFC notion-integration)
+✓ notion:top-level-block-present
+✓ notion:integration-token-present
+✓ notion:db-references-resolvable:carrie  — 1 db(s) all resolved
+✓ notion:db-references-resolvable:clerk   — no per-agent databases filter set
+✓ notion:vault-acl-aligned:clerk
+✓ notion:vault-acl-aligned:carrie
+✓ notion:launcher-heartbeat:clerk  — heartbeat 12s old
+✓ notion:launcher-heartbeat:carrie — heartbeat 8s old
+```
+
+If you see:
+- **`notion:vault-acl-aligned:<agent>` FAIL** → re-run
+  `switchroom vault set notion/integration-token --allow <full-list>`
+  including the missing agent name.
+- **`notion:db-references-resolvable:<agent>` FAIL** → typo in
+  `agents.<name>.notion_workspace.databases:`. The probe's fix
+  field names the unresolvable database.
+- **`notion:launcher-heartbeat:<agent>` WARN** → launcher hasn't
+  written its heartbeat in 60s+. Restart the agent.
+
+## Common errors agents will surface
+
+When an agent tries a tool call that the hook rejects, you'll see a
+message like one of these in the Telegram conversation:
+
+> `Notion tool `update_page` targets database `b2c3d4e5-…` which is
+> not in carrie's allowlist (notion_workspace.databases). If this is
+> intentional, add the database friendly name to
+> agents.carrie.notion_workspace.databases in switchroom.yaml.`
+
+> `Notion tool `create_database` is disabled in switchroom v1.
+> Create databases via Notion's UI instead; switchroom can read +
+> write existing DBs.`
+
+> `Notion tool `update_page` targets a standalone page (no database
+> parent). switchroom v1 only allows access to pages inside an
+> allowlisted database.`
+
+All three are intended behaviours, not bugs. Adjust the agent's
+`notion_workspace.databases:` if the operator wants to grant access.
+
+## Migration from the `personal-notion` skill (if you had one)
+
+If you had a per-agent `personal-notion` skill that bundled its own
+Notion authentication (typically with a hardcoded token or a
+per-agent vault key), the bundled `skills/notion` shipped with this
+release supersedes it.
+
+To migrate:
+1. Set up `notion_workspace:` as above.
+2. Remove the agent's personal-notion skill:
+   `skill_remove_personal notion` via the agent's MCP, or delete the
+   directory in `~/.switchroom-config/agents/<name>/personal-skills/notion/`.
+3. The bundled skill is auto-discovered. No further action needed.
+
+## Why per-DB, not per-page
+
+Per-page allowlists would multiply the config surface by 10–100×.
+Per-DB gives the right scoping for "clerk handles everything;
+carrie only touches the essays DB" which is the actual JTBD. If a
+page-level need emerges, a `pages: [...]` allowlist key is a clean
+v2 extension.

--- a/docs/rfcs/notion-integration.md
+++ b/docs/rfcs/notion-integration.md
@@ -123,9 +123,9 @@ The operator creates an internal integration in Notion's settings:
    - Read user information (no email)
 5. Copy the **Internal Integration Secret** (starts with `secret_...`
    or `ntn_...`).
-6. Run on host: `switchroom vault put notion/integration-token`,
-   paste, choose which agents may read it via `--allow clerk --allow
-   carrie` (or `--allow '*'` for fleet-wide).
+6. Run on host: `switchroom vault set notion/integration-token`,
+   paste, choose which agents may read it via `--allow clerk,carrie`
+   (comma-separated list).
 
 After registration, the operator goes back to each Notion page /
 database they want any switchroom agent to touch and **shares it with
@@ -183,7 +183,7 @@ default. Public OAuth is out of scope for v1 — flagged in §12.
 
 - Vault key: `notion/integration-token` (plural-namespace contract:
   `<provider>/<artifact>`).
-- ACL: operator sets `--allow <agent>` per agent at `vault put` time.
+- ACL: operator sets `--allow <agents>` (comma-separated) at `vault set` time.
   The broker enforces this on every grant request — agents not in the
   ACL get `E_BROKER_GRANT_DENIED`.
 - The launcher fetches via `vault_request_access` → ephemeral token →
@@ -197,8 +197,9 @@ own):
 
 1. Notion Settings → Integrations → `switchroom` → **Refresh secret**.
 2. Copy new secret.
-3. `switchroom vault put notion/integration-token` (overwrite). ACL
-   inherits from the prior write unless `--allow` is re-specified.
+3. `switchroom vault set notion/integration-token` (overwrite).
+   Re-state `--allow` to preserve the existing allowlist — `vault set`
+   replaces the entire scope.
 4. Agents pick up the new token on their next vault grant — for the
    notion launcher specifically that means **launcher restart**.
    `switchroom agent restart <name> --graceful-restart` is sufficient
@@ -208,9 +209,10 @@ own):
 
 Two paths:
 
-- **Per-agent**: drop the agent from the broker ACL
-  (`switchroom vault acl remove notion/integration-token <agent>`).
-  Next launcher fetch fails closed.
+- **Per-agent**: drop the agent from the broker ACL by re-running
+  `switchroom vault set notion/integration-token --allow <remaining-list>`
+  with the agent omitted (`vault set` overwrites the scope). Next
+  launcher fetch fails closed.
 - **Full revocation**: Notion Settings → Integrations → `switchroom`
   → **Delete integration**. Every agent's launcher fails the next
   time it tries to fetch tools; the integration is gone upstream.
@@ -303,7 +305,7 @@ The allowlist gates Notion tool calls in three buckets:
    `notion/integration-token` key — fail at `apply`, not at runtime.
 4. Agent has `notion_workspace:` but is **not in the vault ACL** for
    `notion/integration-token`. Surface the precise remediation:
-   `switchroom vault acl add notion/integration-token <agent>`. This
+   `switchroom vault set notion/integration-token --allow <full-list>` re-stating the allowlist including the missing agent. This
    is the highest-leverage check: without it the launcher fails 503
    at runtime instead of at config-edit time.
 
@@ -632,7 +634,7 @@ its own reviewer pass; only the final PR enables auto-merge.
 ### PR 5 — Docs + bundled skill + UAT (~350 LOC)
 
 - `docs/notion-integration.md`: operator-facing setup guide.
-  Integration registration → vault put → share DBs → list-dbs →
+  Integration registration → vault set → share DBs → list-dbs →
   YAML → apply → first run.
 - `docs/configuration.md`: cascade documentation parallel to
   existing `google_workspace` / `microsoft_workspace` sections.

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: notion
+version: 0.1.0
+description: |
+  Use when the user wants to read, search, write, or update content in
+  their Notion workspace. The agent has access via the `notion` MCP
+  server (`@notionhq/notion-mcp-server`) configured by the operator
+  with a per-database allowlist.
+
+  Triggers on phrasings including: "add this to Notion", "what's on my
+  Notion tasks", "find that page about X in Notion", "create a Notion
+  page for this", "update the notion entry for X", "search Notion
+  for…", "append this to my Notion notes", "show me what's in the
+  essays database", "log this in Notion".
+
+  Do NOT use to create new Notion databases — that's disabled in v1
+  (operators create DBs via Notion's UI). Do NOT use to scan or
+  enumerate the operator's whole workspace ad-hoc — the per-database
+  allowlist scopes what the agent can see, and brute-forcing past it
+  is a defence-in-depth violation.
+
+  Also do not use this skill to file bugs against a GitHub repo
+  (that's `file-bug`) or to search the web (Notion search is workspace-
+  scoped only).
+---
+
+# Notion
+
+This skill is your interface to the operator's Notion workspace. The
+operator has registered an integration in Notion's settings and
+shared specific pages/databases with it. Your access is gated at two
+layers:
+
+1. **Notion's upstream share-list** — the integration can only see
+   pages and databases the operator explicitly shared with it in
+   Notion's UI.
+2. **switchroom's per-agent allowlist** — within what the upstream
+   integration can see, the operator can further restrict YOU to a
+   subset via `agents.<your-name>.notion_workspace.databases:`.
+
+Both layers are enforced at the broker / hook level. You don't have
+to compute the intersection — if you call a tool against a
+disallowed database, you'll get a clean block reason naming the DB.
+
+## Tool surface
+
+The Notion MCP exposes the standard set:
+
+- **Search.** `search` finds pages or databases by title/content
+  across what the integration can see. switchroom's PreToolUse hook
+  post-filters results to your allowlist — pages outside it are
+  dropped before they reach you. The response's metadata field
+  indicates how many were filtered.
+- **Database queries.** `query_database` runs a filter+sort against
+  a database. You need the database's UUID (operator gives these
+  via friendly names in `notion_workspace.databases` — ask the
+  operator for "what's the UUID for X" if needed).
+- **Page reads.** `get_page` and `get_block_children` walk a page's
+  structure. Both go through the allowlist gate.
+- **Page writes.** `create_page` (with `parent.database_id`),
+  `update_page`, `update_block`, `append_block_children`,
+  `delete_block`, `create_comment`. The allowlist gate runs first;
+  blocked tool calls return a reason you can surface to the operator.
+- **Database writes.** `update_database` — schema changes,
+  rename, etc. Gated.
+
+## Tools NOT available
+
+- **`create_database`** — disabled in v1 (operators create
+  databases via Notion's UI). If the user asks you to "create a new
+  database for X", say so and offer to populate an existing one or
+  prompt the operator to make the DB first.
+- **`delete_database`** — same posture.
+
+## Common workflows
+
+### "What's on my tasks?"
+
+1. Ask the operator (or use `config_get` to check your own
+   `notion_workspace.databases`) for the friendly name of the tasks
+   DB. The friendly name resolves to a UUID via
+   `notion_workspace.databases` in switchroom.yaml.
+2. `query_database` with that UUID. Default filter: `not done`.
+3. Format results as a brief markdown list. Don't dump the full
+   property soup — operators want titles + status, not raw IDs.
+
+### "Add `<thing>` to Notion"
+
+1. Default destination is the database whose friendly name matches
+   the user's intent (`tasks`, `notes`, `essays`). Ask if it's
+   ambiguous.
+2. Use `create_page` with `parent.database_id: <uuid>`. The page's
+   properties need to match the target DB's schema — call
+   `retrieve_database` first if you're unsure of the property
+   names.
+3. After creation, confirm to the user with the page title and
+   the Notion URL.
+
+### "Find that thing about X"
+
+1. `search` with the query. Take only the top result unless ambiguous.
+2. The post-filter has already redacted out-of-allowlist results;
+   don't worry about leakage.
+3. If 0 results: try a `query_database` against the most likely DB
+   with a property filter (matches the value).
+
+### "Update the page about X"
+
+1. `search` or `query_database` to find the page.
+2. `update_page` (for properties — status, tags, dates) or
+   `append_block_children` (for body content).
+3. **Be careful** with `update_block` and `delete_block` — these
+   modify the page's body irreversibly. Prefer `append_block_children`
+   when the user's intent is "add a note to this page", not
+   "replace what's there".
+
+## Limits and behaviours
+
+- **Rate limit**: Notion's public API is ~3 rps per integration.
+  Multi-step turns with many writes may slow down (the hook makes
+  resolver calls per write). If you see "Notion API failed: 429",
+  back off and retry once.
+- **No `create_database`**: if the user asks for a new database,
+  say "I can write into existing DBs but the operator creates new
+  ones in Notion's UI." Then offer the closest existing DB.
+- **Standalone pages denied**: pages without a database parent
+  (workspace root pages, personal sub-pages) are hard-denied in
+  v1. The block reason names this when it fires; pass it through
+  to the user.
+
+## When the allowlist denies you
+
+If a tool call returns "DB <uuid> is not in your allowlist", that's
+the operator's intended scope — don't try to work around it. Surface
+the message to the user honestly: "I'm not configured to access that
+database. You can add it to my allowlist with
+`agents.<my-name>.notion_workspace.databases` in switchroom.yaml."
+
+## Authoring small notes vs full pages
+
+For one-line "log this thought" intents, prefer `append_block_children`
+to an existing daily-notes / inbox page rather than creating a new
+page per note. Operators usually have an inbox DB; ask if you're
+unsure.

--- a/src/cli/doctor-notion.test.ts
+++ b/src/cli/doctor-notion.test.ts
@@ -113,7 +113,8 @@ describe("runNotionChecks — vault ACL drift (load-bearing probe)", () => {
     );
     expect(carrieAcl?.status).toBe("fail");
     expect(carrieAcl?.detail).toMatch(/NOT in the vault ACL/);
-    expect(carrieAcl?.fix).toMatch(/vault acl add notion\/integration-token carrie/);
+    expect(carrieAcl?.fix).toMatch(/vault set notion\/integration-token --allow/);
+    expect(carrieAcl?.fix).toMatch(/carrie/);
   });
 
   it("warns when an agent is on ACL but has no notion_workspace block", async () => {
@@ -133,7 +134,8 @@ describe("runNotionChecks — vault ACL drift (load-bearing probe)", () => {
     });
     const probe = r.find((c) => c.name === "notion:integration-token-present");
     expect(probe?.status).toBe("fail");
-    expect(probe?.fix).toMatch(/vault put notion\/integration-token/);
+    expect(probe?.fix).toMatch(/vault set notion\/integration-token/);
+    expect(probe?.fix).toMatch(/--allow/);
   });
 
   it("warns when vault-broker is unreachable", async () => {

--- a/src/cli/doctor-notion.ts
+++ b/src/cli/doctor-notion.ts
@@ -14,9 +14,9 @@
  *      `loader.ts` already cross-validates at config-load, so this
  *      is a "did the config-load step actually run?" guard.)
  *   3. **vault-acl-aligned** — for every agent with `notion_workspace:`,
- *      verify the agent is in the broker ACL (`vault acl list
- *      notion/integration-token`). Fail with the precise remediation
- *      command if not. **Highest-leverage probe** — without this
+ *      verify the agent is in the broker ACL (read via
+ *      `getViaBrokerStructured` → `entry.scope.allow`). Fail with the
+ *      precise `vault set ... --allow` re-statement command if not. **Highest-leverage probe** — without this
  *      check the launcher fails 503 at runtime instead of at
  *      config-edit time.
  *   4. **launcher-heartbeat** — `/state/agent/<agent>/notion-launcher.heartbeat.json`
@@ -195,7 +195,7 @@ async function checkVaultAclAligned(
         name: "notion:integration-token-present",
         status: "fail",
         detail: `vault key '${key}' is missing but ${notionAgents.length} agent(s) want Notion`,
-        fix: `Create the Notion integration in Notion settings, then \`switchroom vault put ${key} --allow ${notionAgents.join(" --allow ")}\` on the host.`,
+        fix: `Create the Notion integration in Notion settings, then \`switchroom vault set ${key} --allow ${notionAgents.join(",")}\` on the host.`,
       },
     ];
   }
@@ -208,11 +208,12 @@ async function checkVaultAclAligned(
   });
   for (const name of notionAgents) {
     if (!allowedSet.has(name)) {
+      const updated = [...acl.allow, name].join(",");
       results.push({
         name: `notion:vault-acl-aligned:${name}`,
         status: "fail",
         detail: `agent '${name}' has notion_workspace: set but is NOT in the vault ACL for ${key} — launcher will 503 at runtime`,
-        fix: `\`switchroom vault acl add ${key} ${name}\` on the host.`,
+        fix: `Re-run \`switchroom vault set ${key} --allow ${updated}\` on the host (vault set overwrites the scope, so re-state the full list including '${name}').`,
       });
     } else {
       results.push({
@@ -225,11 +226,14 @@ async function checkVaultAclAligned(
   // agent block. Benign waste; warn so the operator can clean up.
   for (const a of acl.allow) {
     if (!notionAgents.includes(a)) {
+      const trimmed = acl.allow.filter((x) => x !== a).join(",");
       results.push({
         name: `notion:vault-acl-aligned:${a}`,
         status: "warn",
         detail: `agent '${a}' is on the vault ACL for ${key} but has no notion_workspace: block — never reads the token`,
-        fix: `Remove via \`switchroom vault acl remove ${key} ${a}\`, or add a notion_workspace: block to agent '${a}' in switchroom.yaml.`,
+        fix: trimmed.length > 0
+          ? `Re-run \`switchroom vault set ${key} --allow ${trimmed}\` to drop '${a}' from the allowlist, or add a notion_workspace: block to agent '${a}' in switchroom.yaml.`
+          : `Re-run \`switchroom vault set ${key} --allow ''\` to clear the allowlist (no other agent uses this key), or add a notion_workspace: block to agent '${a}' in switchroom.yaml.`,
       });
     }
   }

--- a/src/cli/notion-mcp-launcher.ts
+++ b/src/cli/notion-mcp-launcher.ts
@@ -273,12 +273,12 @@ export function registerNotionMcpLauncherCommand(program: Command): void {
             }
             if (result.kind === "not_found") {
               throw new Error(
-                `vault key ${key} is missing. Run \`switchroom vault put ${key}\` on the host to populate it.`,
+                `vault key ${key} is missing. Run \`switchroom vault set ${key}\` on the host to populate it.`,
               );
             }
             if (result.kind === "denied") {
               throw new Error(
-                `vault-broker denied access to ${key}: ${result.msg}. Re-run \`switchroom vault acl add ${key} <agent>\` on the host.`,
+                `vault-broker denied access to ${key}: ${result.msg}. Re-run \`switchroom vault set ${key} --allow <comma-separated-agents>\` on the host including this agent.`,
               );
             }
             if (result.entry.kind !== "string") {

--- a/src/cli/notion.ts
+++ b/src/cli/notion.ts
@@ -293,7 +293,7 @@ async function fetchToken(vaultKey: string): Promise<string> {
   }
   if (result.kind === "not_found") {
     throw new Error(
-      `vault key '${vaultKey}' is missing. Run \`switchroom vault put ${vaultKey}\` first.`,
+      `vault key '${vaultKey}' is missing. Run \`switchroom vault set ${vaultKey}\` first.`,
     );
   }
   if (result.kind === "denied") {

--- a/src/config/notion-workspace-acl.ts
+++ b/src/config/notion-workspace-acl.ts
@@ -8,7 +8,7 @@
  *   1. **No per-account concept.** Notion has one integration token =
  *      one workspace per switchroom install. There is no
  *      `notion_accounts:` analog; the broker ACL on the vault key (set
- *      via `vault put --allow <agent>`) is the authoritative list of
+ *      via `vault set --allow <agents>`) is the authoritative list of
  *      which agents may receive the token.
  *   2. **Per-DB allowlist.** The per-agent `databases:` field narrows
  *      which databases this agent may read/write within the
@@ -31,7 +31,7 @@ import type { SwitchroomConfig } from "./schema.js";
  * Does NOT check broker ACL — that's a runtime broker concern, not
  * scaffold-time. The launcher fetching the token at runtime will get
  * a clean `E_BROKER_GRANT_DENIED` if the operator forgot to grant
- * access via `vault put --allow <agent>`. The doctor probe
+ * access via `vault set --allow <agents>`. The doctor probe
  * `notion:vault-acl-aligned` (PR 4) surfaces the mismatch at config
  * time.
  *


### PR DESCRIPTION
Final PR in the Notion integration series. Depends on #1896/#1897/#1898/#1899 (merged).

## Summary

- **\`docs/notion-integration.md\`** — operator setup guide (bootstrap
  order, per-agent grants, rotation/revocation, doctor walk-through,
  agent error messages, migration note).
- **\`docs/configuration.md\`** — adds \`notion_workspace:\` to the
  cascade table + a full Notion Workspace section matching the
  Google/Microsoft sections.
- **\`skills/notion/SKILL.md\`** — bundled skill for agents that opt
  in. Documents the tool surface, common workflows, v1 limits, and
  what to do when the allowlist denies a call.

## What's deferred to a follow-up

**UAT scenarios** are NOT in this PR. The load-bearing privacy
invariant is already unit-tested in \`src/notion/search-filter.test.ts\`
(PR 3 / #1898). Live UAT scenarios need an actual Notion integration
+ per-agent vault setup + an enabled fleet to be meaningful — they
land after release + first live use confirms the surface is stable.

## Series complete

Five PRs total ship the Notion integration end-to-end:

1. **#1896** — config schema + per-DB ACL helpers
2. **#1897** — MCP launcher + scaffold + broker rate-bucket primitive
3. **#1898** — allowlist gate + db-resolver + privacy post-filter +
   PreToolUse hook
4. **#1899** — doctor probes + operator CLI verbs (\`list-dbs\`, \`test\`)
5. **this PR** — docs + bundled skill

Ready for release after this merges.

## Test plan

- [x] Docs render cleanly (no broken internal links to verify
      manually after merge)
- [x] \`tsc --noEmit\` clean
- [x] All CI lint gates clean
- [x] Skill SKILL.md frontmatter valid (no v1 violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)