### PR TITLE
docs(drift-audit): refresh historical onboarding-gap referrers in workspace-files.md

### DIFF
--- a/docs/workspace-files.md
+++ b/docs/workspace-files.md
@@ -56,9 +56,7 @@ Use this mechanism for: identity, persona, operating rules, safety
 directives, tool docs — anything that doesn't change mid-session.
 
 **The list is currently hardcoded in the switchroom binary.** Adding a
-new stable file requires a code change + release. This is tracked for
-convergence (see [gap analysis](../reference/onboarding-gap-analysis.md)
-gap 4 and gap 8).
+new stable file requires a code change + release.
 
 ### 2. Dynamic UserPromptSubmit hook
 
@@ -200,5 +198,4 @@ rename across the boundary without updating both sides.
 
 - `src/agents/workspace.ts` — loader implementation
 - `src/agents/bootstrap-budget.ts` — budget enforcement
-- `reference/onboarding-gap-analysis.md` — fixes planned for the
-  mechanism-convergence gap
+- `reference/onboarding-gap-analysis.md` — historical motivation for the workspace loader convergence design (point-in-time, 2026-04-25; not a live roadmap)


### PR DESCRIPTION
## Summary

- Removed a dead link to `reference/onboarding-gap-analysis.md` from the stable system-prompt render section of `docs/workspace-files.md` (finding c3: the gap analysis is a historical snapshot, not a live tracker).
- Updated the Related section entry for `reference/onboarding-gap-analysis.md` to accurately describe it as a historical point-in-time document rather than an active roadmap for planned fixes (finding c4).

## Why

Audit run `audit/2026-05-26/` found two places in `docs/workspace-files.md` that directed readers to `reference/onboarding-gap-analysis.md` as if it were a live tracking document. That file carries an explicit disclaimer that it is a historical snapshot (2026-04-25) and does not track closure. Readers following these links expected current tracking and found a stale dead-end.

## Findings addressed

### Finding 1 — historical-onboarding-gap-analysis:c3

- **File:** `docs/workspace-files.md` L58-61
- **Verdict:** archive-leaks
- **Action:** fix-referrer — removed "(see gap analysis gap 4 and gap 8)" link from the hardcoded stable-list note. The gap is real but the tracker is dead.

### Finding 2 — historical-onboarding-gap-analysis:c4

- **File:** `docs/workspace-files.md` L199-204 (Related section)
- **Verdict:** archive-leaks
- **Action:** fix-referrer — replaced "fixes planned for the mechanism-convergence gap" with "historical motivation for the workspace loader convergence design (point-in-time, 2026-04-25; not a live roadmap)".

Batch file: `audit/2026-05-26/fix-batches/docs-onboarding-referrer-fix.md`

## Out of scope

- Edits to `reference/README.md` L60 (different description of the same file) — in `reference-readme-index-corrections` batch.
- Edits to `reference/onboarding-gap-analysis.md` itself — the file carries an accurate disclaimer; no changes needed there.

## Verification

- [x] tsc clean (N/A — doc-only batch)
- [x] No file edited by this PR is edited by any sibling drift-audit PR (only `docs/workspace-files.md` touched)
- [ ] Reviewer agent APPROVE pending

Generated with [Claude Code](https://claude.com/claude-code)