### PR TITLE
chore(drift-audit): introduce repeatable docs/JTBD/code alignment workflow

### DIFF
--- a/audit/2026-05-26/escalations.md
+++ b/audit/2026-05-26/escalations.md
@@ -1,518 +1,361 @@
-# Drift Audit Phase 2 Escalations
+# Drift Audit Escalations — pilot-2026-05-26
 
-**Run date:** 2026-05-26
-**Escalated by:** Phase 2 triage agent
-**Recommendations drafted by:** Phase 2.5 recommendation agents (2026-05-26)
-**Rule:** These findings require operator decision. They are NOT assigned to any fix-batch because they cannot be resolved by a doc edit alone — they require either a product decision, a code change, or explicit acceptance of a vision gap.
+Audit run: pilot-2026-05-26
+Audited: 2026-05-26
+Triage: 2026-05-27
+Units: 23 | Claims audited: 193
 
-Total escalations: 10. Each carries an inline **Recommendation** drafted by a fresh agent that read the cited evidence. The operator chooses; recommendations are not auto-applied.
-
----
-
-## Escalation 1
-
-**ID:** contract-vision:c8
-**Type:** code-violates-contract (medium confidence)
-**File:** `reference/vision.md`
-**Evidence files:** `src/config/schema.ts` L1692-1702, `src/cli/telegram.ts` L158-169
-
-**Claim:**
-The vision's "What it isn't" table (L127) states "No OpenAI, Gemini, Llama, model swapping." Outcome 3 (L79) forbids "No raw API."
-
-**Violation found:**
-Two features use external OpenAI API paths:
-1. The Hindsight memory system (`src/config/schema.ts` L1692-1702) supports `openai` and `anthropic` as embedding providers with an `api_key` field. An operator can configure the product to spend against an OpenAI API key for embeddings.
-2. The voice-in feature (`src/cli/telegram.ts` L158-169) calls OpenAI Whisper for transcription using a separately stored API key.
-
-**Decision required:**
-Does the vision's "No OpenAI" constraint apply only to inference model swapping, or also to auxiliary service APIs (embeddings, transcription)? Options:
-- (A) Accept the carve-out: add explicit language to `reference/vision.md` distinguishing "auxiliary service APIs" from inference model swapping.
-- (B) Restrict the features: remove or constrain the OpenAI embedding provider and/or Whisper path to comply strictly with the vision.
-- (C) Defer: document as a known tension; no change to vision or code.
-
-**Confidence:** Medium. The vision's exact wording targets "model swapping" for inference, but the features create a second billing surface outside Anthropic.
-
-## Recommendation — Escalation 1
-
-**Recommended option:** A
-**Confidence:** high
-
-### Why
-
-Reading the vision in context, the constraint targets *inference model routing* — every agent *turn* through the unmodified `claude` CLI on Pro/Max. Neither Whisper nor an OpenAI embedding provider is an inference model for agent turns.
-
-The two surfaces are structurally different from the prohibited pattern:
-
-- **Voice-in (Whisper)** is explicitly opt-in per agent (`src/config/schema.ts:588` documents "Off by default — opt-in per agent"). `docs/telegram-features.md:53-57` already contains a self-aware tradeoff note acknowledging "Switchroom asks you to leave the Pro/Max-only ceiling — there's no Anthropic-side voice transcription yet." This is precisely the kind of explicit, acknowledged, opt-in auxiliary service that Option A would legitimise in writing.
-- **Hindsight embedding provider field** has `openai`/`anthropic` choices that appear to be vestigial. At runtime, `src/memory/hindsight.ts:42` defaults to `ollama` (local, no API key). `src/cli/memory.ts:292-300` actively *ignores* `--provider` flags other than `claude-code` — the bundled image is pinned to `HINDSIGHT_API_LLM_PROVIDER=claude-code` (see `docs/auth.md:325`). The schema text advertising `openai` is currently dead for operators running the bundled image.
-
-Option A — adding a narrow carve-out paragraph to `reference/vision.md` — is the honest fix. The "No OpenAI" line was written to foreclose model swapping (routing agent turns through GPT-4 or Gemini), not to prohibit every third-party API a user might subscribe to for auxiliary tasks. Codifying this distinction gives future contributors a clear rule.
-
-### Tradeoffs of the recommendation
-
-- The carve-out language must be narrow enough not to open the door to "optional" OpenAI inference paths by analogy. Use "auxiliary services" with explicit opt-in requirement — not a general "third-party APIs are fine" waiver.
-- The Hindsight embedding schema fields (`openai`, `anthropic`, `api_key`) describe configuration currently unreachable via `switchroom memory --start`. Leaving them undocumented as out-of-maintenance is low-level debt; Option A should note this for a follow-up cleanup.
-- Accepting the carve-out implicitly accepts that voice-in creates a second billing relationship (OpenAI) for the operator. Already disclosed in feature docs; vision should echo it.
-- If Anthropic or a third-party later ships subscription-level transcription via the `claude` CLI, voice-in should migrate. The amended text should include a sunset clause ("until a subscription-native transcription path exists").
-
-### If you pick a different option
-
-- **Option B (restrict the features):** Removing Whisper eliminates the one user-visible capability that lets a principal send voice notes from their phone — a real loss for Outcome 4 and a regression for users already relying on it. Removing embedding provider schema fields is lower cost but requires a migration path. Only right if policy-level consistency outweighs the feature.
-- **Option C (defer):** Leaves contributors with a visible contradiction the audit will flag again next pass. Acceptable only if evaluating a subscription-native transcription path before committing to carve-out language.
-
-### Open question for the operator
-
-The `memory.config.provider` schema field (`src/config/schema.ts:1690-1693`) lists `openai` and `anthropic` as valid values, but `switchroom memory --start` ignores them and the bundled image is pinned to `claude-code` — are these provider values intended for operators bringing their own Hindsight image, or are they dead schema text that should be removed?
+This file contains every finding that requires an operator decision before
+the corresponding fix can proceed. Fix-batch files do NOT touch these; they
+are parked here.
 
 ---
 
-## Escalation 2
+## Code-violates-contract
 
-**ID:** jtbd-give-each-agent-its-own-workspace:c2, c3, c12
-**Type:** outcome-not-realized
-**File:** `reference/give-each-agent-its-own-workspace.md`
-**Evidence files:** `src/repos/agent-worktree.ts`, `src/repos/bare-clone.ts`, `src/agents/scaffold.ts` L246-253
+### E1 — contract-vision:c2
+**Finding:** `src/host-control/server.ts:1577` contains a live `claude -p ok`
+callsite. The "deep probe" path (health-check path inside the hostd daemon)
+spawns `claude -p ok` to verify the claude binary is reachable and exits 0.
 
-**Claim:**
-The JTBD states "Adding a switchroom agent that works on a repo automatically gives that agent its own worktree. The user doesn't run `git worktree add`. They don't pick a path. They don't pick a branch." And: "Worktrees are provisioned lazily — on the first `agent restart`/`reconcile`."
+**Why this is escalated:** `reference/vision.md` Pillar 3 and CLAUDE.md both
+state that `claude -p` (headless/print mode) is now programmatic usage under
+the 2026-06-15 policy — a constraint violation. The eliminate-claude-p RFC
+(#1620) is in progress. This callsite is tracked as issue #1798 but has not
+been removed.
 
-**Gap found:**
-`ensureAgentWorktree` and `ensureBareClone` are imported in `scaffold.ts` (L246-253) but have **zero production call sites**. `reconcileAgent` does not call either function. `scaffoldAgent` does not call them. No CLI command triggers them. A user who adds `repos:` to `switchroom.yaml` and runs `switchroom apply` or `switchroom agent restart` does NOT get a worktree provisioned. The `SWITCHROOM_REPO_*` env vars are injected into `start.sh` pointing at paths that don't exist on disk.
+**Question for operator:** The hostd deep probe needs a binary-reachability
+check that does not use `claude -p`. What replacement is acceptable?
 
-**Decision required:**
-- (A) Wire the provisioning: add `ensureAgentWorktree`/`ensureBareClone` calls to `reconcileAgent` or `scaffoldAgent`. Update the JTBD after the feature ships.
-- (B) Remove the partial implementation: remove the env var injection and unresolved imports until the feature is fully planned. Update the JTBD to mark as vision-only.
-- (C) Explicitly document as incomplete: add a disclaimer to the JTBD noting the feature is not yet wired end-to-end.
-
-## Recommendation — Escalation 2
-
-**Recommended option:** A (wire the provisioning)
-**Confidence:** high
-
-### Why
-
-The partial implementation is not a stub — it is a complete, well-reasoned implementation. `src/repos/bare-clone.ts` (72 lines) handles idempotent bare-clone creation and fetch-all refresh with graceful network-failure handling. `src/repos/agent-worktree.ts` (323 lines) handles first-create, clean-ff, dirty-skip, dirty-commit surfacing, removal, prune, and orphan detection — the full lifecycle described in the JTBD's "Decisions" section. Both files have proper docstrings, match the design exactly, and are idempotent and safe to call on every reconcile. This is a complete feature waiting for a two-line call site, not a half-written sketch.
-
-The gap is entirely at the integration layer. `src/agents/scaffold.ts` imports all five symbols but calls only `agentWorktreePath` — to compute a deterministic path injected as `SWITCHROOM_REPO_<SLUG_UPPER>` into `start.sh` via `buildRepoEnvVars`. The env var injection is fully wired in both `scaffoldAgent` and `reconcileAgent`. The bare-clone creation and worktree provisioning those paths point at are not. Result: env vars injected pointing to paths that don't exist.
-
-The `repos:` schema field is complete and documented (`src/config/schema.ts:1592-1623`), `docs/configuration.md:544-550` already tells operators to use `repos:` for git-repo agents, and `docs/rfcs/host-control-daemon.md` references the pattern as canonical. The feature is committed to in user-facing documentation. Option B would invalidate that documentation. Option C is awkward given the schema already accepts `repos:` entries today.
-
-The wiring delta is small: in `reconcileAgent`, after the existing agentDir check (scaffold.ts:3678), call `ensureBareClone` for each entry in `agentConfig.repos`, then `ensureAgentWorktree` with the returned clone path. Mirror `removeAgentWorktree` in the agent-remove path. Both functions are idempotent; calling them on a reconcile with no `repos:` is a no-op.
-
-### Tradeoffs of the recommendation
-
-- Wiring makes `reconcileAgent` either async (ripple through callers) or requires `Promise.resolve` wrappers — the provisioning functions are declared async but use `execFileSync` internally. A small refactor to synchronous signatures, or wrapping at the call site, avoids the async refactor.
-- The `removeAgentWorktree` teardown path needs to be found and wired for the "removal is symmetric" JTBD contract.
-- First reconcile after a user adds `repos:` will block on `git clone --bare` — network-latency at reconcile time. The existing function handles fetch-fail gracefully.
-- The env var injection is already shipping to agents configured with `repos:`. Those agents currently get a valid-looking env var pointing at nonexistent paths. Wiring fixes this silently on next restart with no user action.
-
-### If you pick a different option
-
-- **Option B (remove):** Requires removing the `repos:` schema field, `buildRepoEnvVars`, all five imports, and the `docs/configuration.md:544-550` guidance. Net deletion of ~430 lines of tested implementation. Configuration breakage is silent — operators who followed the docs will have invalid YAML or silently broken configs. Disruptive without a clear payoff.
-- **Option C (disclaim):** The schema accepts `repos:` today with no warning. An operator who configures it sees `SWITCHROOM_REPO_<SLUG>` pointing at a nonexistent path — agent silently fails to find the repo. A JTBD disclaimer doesn't surface at the point of failure. Worse than current state.
-
-### Open question for the operator
-
-`reconcileAgent` is synchronous today — do you want the worktree-provisioning call sites to refactor the provisioning functions to synchronous signatures (straightforward, since they already use `execFileSync` internally), or do you want `reconcileAgent` to become async (larger ripple through callers in `src/cli/agent.ts` and `src/cli/apply.ts`)?
+Options:
+1. Replace with `claude --version` (exits 0 on success, no subscription
+   credit, no network call). Minimal change, ships in the eliminate-claude-p
+   RFC scope.
+2. Replace with a static file-presence check (`test -x $(which claude)`) and
+   drop the runtime invocation entirely. Faster, no process spawn, but loses
+   the "binary is not broken" signal.
+3. Defer until the eliminate-claude-p RFC (#1620) lands and let that RFC
+   author choose the replacement. Block this finding on that PR.
 
 ---
 
-## Escalation 3
+## Outcome-not-realized clusters
 
-**ID:** jtbd-restart-and-know-what-im-running:c3, c8
-**Type:** outcome-not-realized
-**File:** `reference/restart-and-know-what-im-running.md`
-**Evidence files:** `telegram-plugin/gateway/boot-card.ts`, `telegram-plugin/welcome-text.ts` L22-28
+### E2 — Workspace worktree provisioning never runs (Cluster A)
 
-**Claim (c3):** "The user can tell if the model changed, the tools changed, skills were added or removed, or memory is attached."
-**Claim (c8):** "When something did change, the change is obvious, not buried."
+**Findings:**
+- `jtbd-give-each-agent-its-own-workspace:c1` — auto-worktree provisioning
+  claim: "When you add an agent and point it at a repo, it gets its own
+  worktree automatically." `ensureBareClone` and `ensureAgentWorktree` are
+  imported in `src/agents/scaffold.ts` but never called inside `scaffoldAgent`
+  or `reconcileAgent`.
+- `jtbd-give-each-agent-its-own-workspace:c2` — parallel build isolation claim:
+  "Two agents working the same repo never conflict." No call to
+  `ensureAgentWorktree` means no worktree is created; agents sharing a repo
+  work in the same checkout.
+- `jtbd-give-each-agent-its-own-workspace:c3` — post-reboot preservation claim:
+  "After a host reboot the worktree is exactly where it was." Nothing creates
+  the worktree, so there is nothing to preserve.
+- `jtbd-give-each-agent-its-own-workspace:c4` — removal cleanup claim:
+  "Removing an agent cleans its worktree." `destroyAgent` does not call
+  `removeAgentWorktree`; worktree directories are left on disk.
 
-**Gap found:**
-The boot card (`RenderBootCardOpts`) has no model, tools allowlist, or memory-backend fields. A config change (model swap, tool scope change, memory backend swap) produces no visible difference in the boot card on a healthy restart. These fields were in the deleted SessionStart greeting card (#142 PR 1) and now live only in `/status` on demand. The UAT test (`jtbd-wake-audit-content-dm.test.ts`) explicitly relaxes the "no need to ask" contract.
+**Why this is escalated:** The JTBD claims a shipped capability. The code
+exists (the functions are implemented and tested in isolation) but the wiring
+into `scaffoldAgent`/`reconcileAgent`/`destroyAgent` is absent. This is either
+a feature that was scoped out before ship, or the wiring was dropped in a
+refactor. The fix is code (not docs), and the right posture depends on whether
+the operator wants to ship the wiring or retire the JTBD claim.
 
-**Decision required:**
-- (A) Add config-change visibility to the boot card: surface model/tools/memory backend in the boot card when they differ from the previous boot. Implement and update the JTBD.
-- (B) Accept the gap: update the JTBD to reflect the split design (boot card = liveness + probe health; `/status` = config audit). Clarify the JTBD outcome to match shipped behavior.
-- (C) Implement a change-detection boot card row: detect changes on reconcile, emit a one-line "config changed" summary row. Update the JTBD after implementing.
+**Question for operator:** The worktree functions exist but are never called.
+What is the correct resolution?
 
-## Recommendation — Escalation 3
-
-**Recommended option:** C
-**Confidence:** high
-
-### Why
-
-The JTBD's "no need to ask" promise is stated without qualification: "After any restart, the user is told what config is live. Model, tools, skills, memory backend, auth state. No need to ask." The anti-patterns explicitly name "Cosmetic summaries that always look the same regardless of the actual config" and "Lying by omission. If tools were silently disabled, the summary should say so." Option B would require rewriting both anti-patterns out of the contract — a deliberate retreat from a core promise, not a refinement.
-
-Option A conflicts with the boot card's own design contract. The boot card file opens: "Default state is a single line: `✅ <agent> back up · <version>`" and the deletion comment is explicit — Profile/Tools/Skills/Limits/Channel/Memory content was removed from the old SessionStart greeting because it was "always-rendered" noise that "becomes wallpaper the user learns to scroll past." The JTBD itself warns against "a boot banner that dumps every setting." Putting that content back unconditionally restores exactly the problem PR #142 solved.
-
-Option C threads the needle. The boot-issue-cache already demonstrates the pattern: persist a fingerprint of the last boot's probe state, diff against the current boot, surface a row only when changed. A config-snapshot cache wired into the same gate would surface "model changed: claude-opus-4 → claude-sonnet-4-5" as a single appended row only when it's true — invisible on identical restarts, unmissable on actual changes. Preserves silent-when-healthy for stable fleets; delivers "change is obvious" (c8) when something shifted. Non-technical users see changes in the one place they already look. The UAT test's docstring explicitly acknowledges this floor-vs-vision split.
-
-Implementation boundary is tight. Config snapshot stores three fields (model slug, tools fingerprint, memory backend) at shutdown or gateway start, diffed on next boot. The boot card renderer already accepts a `resolvedRows` / degraded-rows model; config-diff is a new row type, not a new rendering mode.
-
-### Tradeoffs of the recommendation
-
-- Requires a config snapshot file written on each gateway boot. New disk dependency, small and consistent with `boot-issue-cache.json`.
-- Fingerprint stability requires care: model string format changes across releases could produce spurious "model changed" rows. Needs a normalizer (strip trailing version suffix, lowercase) like `normalizeDetail()`.
-- Tools fingerprint is harder than model. Full allowlist diff is genuinely useful; a hash that just says "tools changed" is noise. First version can hash the sorted allowlist and show "tools allowlist changed — run /status to see details" — honest without exhaustive.
-- The UAT scenario needs a strict variant: restart after config change, assert boot card contains the changed-field row. Current test relaxes to "agent replies with config signals when asked" — correct but not the proactive contract.
-- Memory backend change detection depends on which layer the gateway reads. If resolved at yaml load, straightforward. If resolved late, snapshot needs the resolved value.
-- No risk to "silent when healthy": row only appears when diff fires.
-
-### If you pick a different option
-
-- **Option A:** Restores deleted-in-#142 content unconditionally on every boot. The v0.4.0 changelog is explicit: the six-row checklist was "noise on the common path." Non-technical users will learn to scroll past, defeating c8's "obvious, not buried" requirement. Fails the "Defaults test" principle.
-- **Option B:** Requires rewriting the JTBD to remove or qualify "no need to ask," demoting the "config change restart" UAT prompt, and adding a "split design" note. Honest if the split is permanent — but the UAT test's own docstring says the proactive contract is the "vision target" with the relaxed test as "the floor." B forecloses future proactive delivery. Acceptable only if `/status` is the confirmed permanent home for config audit.
-
-### Open question for the operator
-
-Is "tools allowlist changed — run /status to see details" sufficient for a first cut of Option C, or does the operator want a granular diff row (e.g. "tools: added bash, removed computer") from day one? The granular form is more useful but requires serializing the allowlist at snapshot time, not just a hash.
+Options:
+1. Wire `ensureBareClone` + `ensureAgentWorktree` into `scaffoldAgent` and
+   `removeAgentWorktree` into `destroyAgent`. The JTBD is accurate once this
+   ships. Estimated: ~30 agent-minutes for the wiring + tests.
+2. Retire the JTBD claims: replace the "automatic worktree" outcome text with
+   the honest current state ("agents share the repo checkout by default; you
+   can manually point them at separate worktrees"). The code stays as-is.
+3. Leave the functions present but mark them `@internal / not-yet-wired` in
+   source, and update the JTBD to say worktree isolation is "coming in a
+   future release." Intermediate posture; commits to eventual delivery.
 
 ---
 
-## Escalation 4
+### E3 — Boot card visibility gap (Cluster B)
 
-**ID:** jtbd-track-plan-quota-live:c2
-**Type:** outcome-not-realized
-**File:** `reference/track-plan-quota-live.md`
-**Evidence files:** `telegram-plugin/auth-dashboard.ts` L91-97, `telegram-plugin/auth-snapshot-format.ts` L60-70, `telegram-plugin/gateway/gateway.ts` L15980-15997
+**Findings:**
+- `jtbd-restart-and-know-what-im-running:c1` — "no need to ask" claim: the
+  boot card is supposed to show the running configuration so the user never
+  has to query. `RenderBootCardOpts` has no fields for model, tools, or skills.
+- `jtbd-restart-and-know-what-im-running:c2` — "sees what's running without
+  asking" — same root cause: boot card omits model, tools, skills.
+- `jtbd-restart-and-know-what-im-running:c3` — "user can tell if model changed"
+  — model name is not in `RenderBootCardOpts`; a model change is invisible in
+  the boot card.
+- `jtbd-restart-and-know-what-im-running:c8` — "change is obvious after
+  restart" — config-change visibility was moved to `/status` (PR #142). The
+  JTBD still claims it's in the boot card.
+- `jtbd-restart-and-know-what-im-running:c11` — UAT scenario
+  `jtbd-restart-config-change-dm.test.ts` assertion `expectBootCardContains
+  ('model:', ...)` cannot pass because the boot card contains no model field.
+- `jtbd-restart-and-know-what-im-running:c12` — UAT assertion
+  `expectBootCardContains('skills:', ...)` cannot pass; same root cause.
+- `jtbd-restart-and-know-what-im-running:c15` — memory backend swap not visible
+  in boot card; `/status` is the current surface.
 
-**Claim:** "Approaching a cap produces a visible signal at a point where the user can still act on it."
+**Why this is escalated:** PR #142 deliberately moved config-change visibility
+off the boot card into `/status`. The JTBD predates that decision and was not
+updated. The UAT scenarios were written against the old contract; they will
+permanently fail until either (a) the JTBD is updated to reflect `/status` as
+the surface, or (b) the boot card is extended to include the removed fields.
 
-**Gap found:**
-The `/auth` dashboard shows a `[Fall back now]` button at 90% utilization and marks accounts as "near limit — watch this." However, this is reactive and requires the user to open `/auth`. There is no proactive Telegram push notification that fires as utilization climbs toward a cap. Auto-fallback triggers at 99.5%, which is after the limit has effectively been hit.
+**Question for operator:** PR #142 moved model/tools/skills off the boot card.
+Was that a permanent design decision or a temporary deferral?
 
-**Decision required:**
-- (A) Add a proactive push: wire a utilization-threshold watcher that sends a Telegram notification when utilization crosses (e.g.) 80%. Implement and update the JTBD.
-- (B) Accept the reactive design: update the JTBD to describe the current design accurately (user polls `/auth` for approaching-cap signal; auto-fallback is reactive at 99.5%).
-- (C) Hybrid: document the existing `/auth` signal as the current answer and note the proactive push as a planned enhancement.
-
-## Recommendation — Escalation 4
-
-**Recommended option:** A
-**Confidence:** medium
-
-### Why
-
-The JTBD's "Signs it's working" includes "Approaching a cap produces a visible signal at a point where the user can still act on it," and anti-patterns explicitly name "Quota visible only in a separate dashboard or a command. If the user has to go looking, they won't, and they'll hit the wall." The current reactive design is a well-executed dashboard affordance but lives entirely inside `/auth`. A user not in the habit of checking `/auth` receives zero proactive signal until auto-fallback fires at 99.5% — effectively after the wall. Option B would mean rewriting the document's intent to match an acknowledged gap.
-
-The pattern for a proactive push already exists and is proven. `credits-watch.ts` (wired in gateway.ts L15975-15997) polls every 15 minutes, reads a local file, compares against persisted last-notified state, and calls `bot.api.sendMessage` on state transition. The same three-state machine (healthy → throttling → blocked) that `classifyHealth` already computes is exactly the input a quota-watch module needs. Extending requires: adding a broker probe call on a polling interval, tracking last-notified health per account. Broker infra (`client.probeQuota`), state-machine (`classifyHealth`), and notification routing all exist. Extension, not new invention.
-
-Noise risk on a multi-agent fleet is real but manageable. Three mitigations: (1) notify on transitions, not absolute level — only fire when health *changes* from healthy to throttling; (2) operators typically have 1-3 account slots, not 10+; (3) 15- or 30-min poll = at most one message per crossing per account. The "over-alerting" anti-pattern targets every-tick notifications, not edge-triggered.
-
-Practical sizing note: the right source is the broker's cached quota state from `list-state` (already computed for `/auth` render), not a fresh network probe per poll. Reading cached state keeps polling cheap and avoids burning API budget. Only trigger a live `probeQuota` when a state change is detected and fresh numbers are needed for the notification body.
-
-### Tradeoffs of the recommendation
-
-- The watcher adds a polling loop alongside credits-watch; both should share notification routing and state persistence patterns.
-- Broker-cache polling means notifications lag by however stale broker storage is. Staleness was already accepted for `/auth` render; acceptable here too.
-- Two accounts crossing 80% simultaneously yields two notifications within one poll cycle. Correct behavior — each account needs its own action.
-- Broker cached state only updates when an agent makes a request. Idle fleet may not trigger state-change push even at high utilization — pre-existing limitation of header-pull, not introduced.
-- Implementation cost ~25 agent minutes: new `quota-watch.ts` mirroring `credits-watch.ts`, wired into gateway boot, using `classifyHealth` and broker `list-state`.
-
-### If you pick a different option
-
-- **Option B:** Rewriting JTBD to accept reactive-only closes the audit finding without shipping value. Stakes section ("A user who hits a wall silently loses trust") becomes a known unfulfilled risk. Only appropriate if the operator decided dashboard affordance is sufficient.
-- **Option C:** Hybrid documents current state and notes proactive push as planned — reasonable if implementation capacity is constrained. Resolves the audit finding by making the gap intentional and tracked, without shipping incomplete code. Risk: "planned" items without a PR tend to stay planned. Use only with a concrete follow-up issue created at the same time.
-
-### Open question for the operator
-
-Should the proactive push be scoped to the *active* account only, or all accounts in the pool? Auto-fallback cares about the whole pool; the user typically acts by switching to an account with headroom — so a notification about a non-active account approaching its limit is also actionable. The credits-watch precedent fires per-agent; the new watcher would have access to all accounts and could choose either scope.
+Options:
+1. Accept the PR #142 decision as permanent: update the JTBD to say "run
+   `/status` to see the running configuration" and update or retire the UAT
+   assertions that check for model/skills in the boot card. Docs change only.
+2. Reverse PR #142 (at least partially): add model, skills, and key tools back
+   to `RenderBootCardOpts` and the boot card template. The JTBD stays as-is.
+   Estimated: ~45 agent-minutes for the renderer change + UAT re-run.
+3. Hybrid: show a one-line config-change diff in the boot card ("model changed:
+   opus-4 -> sonnet-4") only when a change is detected since the last boot, and
+   defer the full config listing to `/status`. Satisfies the "change is obvious"
+   JTBD claim without cluttering every boot card.
 
 ---
 
-## Escalation 5
+### E4 — Quota push gap (Cluster C)
 
-**ID:** jtbd-track-plan-quota-live:c7
-**Type:** outcome-not-realized
-**File:** `reference/track-plan-quota-live.md`
-**Evidence files:** `telegram-plugin/credits-watch.ts` L116-123, `telegram-plugin/gateway/gateway.ts` L15986-15997, `src/auth/broker/server.ts` L103-105
+**Findings:**
+- `jtbd-track-plan-quota-live:c1` — "user can answer 'am I close?' without
+  asking" — no proactive approaching-cap notification exists; user must poll
+  with `/quota`.
+- `jtbd-track-plan-quota-live:c2` — "approaching-cap signal before the wall" —
+  the threshold-tier warning logic described in the JTBD is not implemented;
+  `src/auth/broker/server.ts` has no tier-threshold detection path.
+- `jtbd-track-plan-quota-live:c6` — "graduated signal" (background nudge
+  escalating to louder warning) — not implemented; only the fatal credits-watch
+  alarm exists.
+- `jtbd-track-plan-quota-live:c7` — "window-roll recovery is automatic" — the
+  window-roll reset is pull-only (triggered by the user's next message after
+  the window resets, not pushed to the user).
 
-**Claim:** "When the window rolls, the user sees the recovery without having to refresh anything."
+**Why this is escalated:** All four claims describe proactive push behavior that
+does not exist. The JTBD frames this as a shipped capability. The implemented
+behavior is reactive: the user is told quota is exhausted when it happens; there
+is no "you're at 80%, heads up" tier.
 
-**Gap found:**
-`credits-watch.ts` sends "credits restored" when the fatal-billing state clears (billing-credit-exhaustion case). However, for the normal rolling 5h/7d subscription window reset, there is no proactive Telegram notification that "your 5-hour quota has reset." The user would need to run `/usage` or wait for a boot card. The auth-broker's `exhausted_until` auto-expires, but there is no push-to-Telegram signal when the window rolls naturally.
+**Question for operator:** The JTBD describes proactive quota nudges. Was this
+deferred intentionally or accidentally dropped?
 
-**Decision required:**
-- (A) Add a rolling-window reset notification: when the broker clears an exhausted-until expiry for the rolling window, send a Telegram push to the relevant agents. Implement and update the JTBD.
-- (B) Accept the current design: update the JTBD to note that fatal-billing recovery is pushed, but rolling-window reset recovery requires the user to check `/usage` or wait for the next boot card.
-- (C) Scope to fatal-billing only: explicitly narrow the JTBD claim to cover only credits-watch notifications, not rolling-window reset.
-
-## Recommendation — Escalation 5
-
-**Recommended option:** C (scope to fatal-billing only), with a JTBD wording tightening
-**Confidence:** high
-
-### Why
-
-The gap is real but the original framing overstates what "window rolls" means in practice. In normal operation — an agent that was never blocked — the 5-hour or 7-day window rolling over is a non-event: headroom increases passively and the boot card or `/usage` on next interaction shows updated numbers. There is no "recovery" to surface because the user was never stuck. A proactive notification here is noise, violating the anti-pattern "every small usage tick produces a notification until the user mutes the product."
-
-The case that matters: agent was blocked, original active account's window resets. That IS a recovery the user cares about. However, `credits-watch.ts` already covers the closest analogue (fatal-billing flag clears). The `exhausted_until` operates differently — passive timestamp comparison, not an event. There is no callback when it expires; the broker simply starts treating the account as healthy again on next `get-credentials`. Adding a proactive push would require a polling loop watching `exhausted_until` transitions, plus event routing — non-trivial plumbing with race conditions.
-
-Option B (accept with JTBD note) leaves the misleading "without having to refresh anything" wording intact, which will fail future audits. Option A is over-engineering: the typical fleet recovers naturally (agent retries, gets healthy creds, resumes) or the user already ran `/auth`. The boot card on next agent start carries fresh usage data. Option C is cleanest: narrow the claim to reflect what's implemented (fatal-billing push), reword rolling-window bullet to match real user flow (ambient recovery on next boot card / `/usage`, not push).
-
-Surgical JTBD edit: replace "When the window rolls, the user sees the recovery without having to refresh anything" with "When a fatal billing block clears, the user hears about it without having to ask. For routine quota refills, usage resets are visible on the next boot card or `/usage`." Honest about the two tiers; eliminates the false gap without noisy infrastructure.
-
-### Tradeoffs of the recommendation
-
-- Purely documentary: no code touched, no CI risk, no new plumbing.
-- The "was blocked, now unblocked due to window rollover" case remains non-pushed. In practice, when `exhausted_until` expires, auto-fallback (if triggered) had already swapped to a healthy account. Primary coming back healthy after 5h is quietly picked up on next `get-credentials`; next boot card confirms it.
-- The UAT prompt ("Let the window roll. The user should see usage free up without having to refresh") needs corresponding update, or UAT keeps flagging this. Scope into the same JTBD edit.
-- Accepts that `credits-watch.ts` recovery is the high-fidelity push signal, and rolling-window reset is ambient-tier. If the operator's mental model requires a push on every window reset, Option A is right — but it should have a deduplication gate (only push when previously exhausted).
-
-### If you pick a different option
-
-- **Option A:** Requires a poller watching `exhausted_until` timestamps, emitting IPC events on transition. Gateway routes to Telegram. Non-trivial: multi-account handling, agent-name→chat mapping, race-handling. ~30 agent-minutes + tests. Risk of spam on agents that were never blocked — gate on `prev.exhausted` state matching credits-watch pattern.
-- **Option B:** Adds a parenthetical note ("fatal-billing pushed; rolling-window appears on next boot card"). Lower-effort than A, but UAT prompt still says "without having to refresh anything," literally false for rolling-window. Expect recurrence in future audit.
-
-### Open question for the operator
-
-The JTBD's UAT prompt ("Let the window roll. The user should see usage free up without having to refresh") will fail any honest UAT run. Should this prompt be revised to "Check `/usage` after the window rolls — usage should reflect the reset" (ambient tier), or removed in favor of a UAT focused on fatal-billing recovery push?
+Options:
+1. Update the JTBD to describe only the actual pull-based `/quota` command and
+   the fatal exhaustion alarm. Remove the approaching-cap and window-roll push
+   claims. Docs change only; honest about current state.
+2. Implement threshold-tier detection in the auth broker: at 80% (configurable)
+   of the session window, emit a Telegram notification "Approaching quota cap —
+   N tokens remaining." Estimated: ~60 agent-minutes for broker + gateway +
+   UAT.
+3. Partial implementation: add a soft warning to the `/quota` response ("You're
+   at 85% of your session window") without any push. This satisfies the "can
+   answer am I close" claim but not the proactive push claims. Update the JTBD
+   to remove push claims, keep the threshold-aware pull claim.
 
 ---
 
-## Escalation 6
+### E5 — Auth slot mgmt not yet wired in gateway
 
-**ID:** rfc-sub-agent-visibility:c11
-**Type:** low-confidence drift (AC-4 stuck-render pipeline untraced)
-**File:** `reference/sub-agent-visibility-rfc.md`
-**Evidence files:** `telegram-plugin/fleet-state.ts` L133-137, `telegram-plugin/progress-card-driver.ts`
+**Finding:** `jtbd-talk-to-agents-from-anywhere:c7`
 
-**Claim (AC-4):** "If a fleet member emits no JSONL event for > 60s, its row glyph flips from ↻ to ⚠ with label `idle <duration>`."
+The gateway at `telegram-plugin/gateway/gateway.ts:13079` contains the comment:
+"Phase 4c will wire this. Until then, run in terminal: switchroom auth ..." The
+auth slot management commands (`/auth add`, `/auth rm`) are not yet wired into
+the gateway path; users must run them on the host CLI.
 
-**Gap found (low confidence):**
-`fleet-state.ts:markStuck` exists and transitions a member to `stuck` status after 60s. However, `fleet-state.ts` is not imported by `progress-card-driver.ts` or the renderer. The stuck-detection to rendered-⚠ pipeline could not be traced end-to-end through code. `subagent-watcher.ts` has stall detection (`stallNotified`) but calls `onStallTerminal`, not a stuck-render path. AC-4 may be partially implemented at the state level but not yet connected to the renderer's header phase.
+**Why this is escalated:** The JTBD claims "all auth operations work from
+Telegram." The gateway code explicitly says this is not finished. The comment
+names a future phase ("Phase 4c") that either did not land or landed under a
+different name.
 
-**Decision required:**
-- (A) Confirm the wire exists: identify the production call path from `markStuck` to the rendered `⚠` glyph and document it in the RFC.
-- (B) Confirm AC-4 is not yet wired: update the RFC to note this AC is partially implemented (state exists, render not wired) and track as a follow-up.
+**Question for operator:** Was the Phase 4c auth-from-Telegram wiring completed?
+If so, is this comment stale? If not, what is the correct status?
 
-## Recommendation — Escalation 6
-
-**Recommended option:** B
-**Confidence:** high
-
-### Why
-
-The end-to-end trace is conclusive: `markStuck` in `fleet-state.ts` is dead production code. It is exported and tested in `tests/fleet-state.test.ts`, but no production file imports it or calls it. The only production import of `fleet-state.ts` is in `subagent-watcher.ts:44`, and it imports only `sanitiseToolArg` — not `markStuck`, `FleetStatus`, or any state-transition functions. `progress-card-driver.ts` does not import `fleet-state.ts` at all.
-
-AC-4 describes a per-fleet-member ↻→⚠ glyph flip with `idle <duration>` label. That requires `FleetMember.status` to reach `'stuck'` and a renderer to branch on that status. Neither happens. `FleetStatus` includes `'stuck'`, `markStuck` correctly transitions a member to it, but the renderer that produces the sub-agent zone (`renderSubAgent` in `progress-card.ts`) operates on `SubAgentState`, not `FleetMember`. `SubAgentState.state` is typed as `ItemState` (`'pending' | 'running' | 'done' | 'failed'`) — no `'stuck'` branch, no ⚠ glyph, no `idle <duration>` label.
-
-What IS wired is a different, coarser stall signal: the driver's heartbeat passes `stuckMs` (age of `cs.lastEventAt`) to card-level `render()` in `progress-card.ts`. When `stuckMs >= STUCK_THRESHOLD_MS` (2 min), the renderer inserts `⚠️ No events for <gap> — likely stuck.` as a header-level line. Card-wide warning, not per-fleet-member row glyph flipping. The `onStall` callback from `subagent-watcher.ts` routes to `progressDriver?.onSubAgentStall(...)` in `gateway.ts`, but `progressDriver` is permanently `null` (deleted in PR #1122 — see `gateway.ts:3046`), so those calls are no-ops.
-
-The RFC itself notes that `two-zone-card.ts` was the renderer for the AC-4 fleet zone, but that file no longer exists. The current renderer is `progress-card.ts` which has no per-member stuck-glyph path.
-
-AC-4 as specified has no production implementation. State model exists, render pipeline does not. Option B is correct.
-
-### Tradeoffs of the recommendation
-
-- Updating the RFC to mark AC-4 partially implemented (state exists, render absent) is honest and prevents future confusion.
-- The coarser card-level `stuckMs` warning provides *some* stuck signal (at 2 min, card-wide), so the user-facing gap is narrower than it appears — but not AC-4 as written.
-- `markStuck` should either be connected or removed; leaving as tested-but-unreachable dead code is a maintenance liability (tests give false confidence).
-- The `onStall` → `progressDriver?.onSubAgentStall(...)` call is also dead. If the progress driver is ever reinstated, gateway wire exists but the renderer-side branch would still need adding.
-
-### If you pick a different option
-
-- **Option A (confirm wire exists):** Not viable. The trace is exhaustive. `markStuck` is unreachable, `progressDriver` is null, `renderSubAgent` has no stuck branch. There is no wire to document.
-
-### Open question for the operator
-
-Should `markStuck` be removed from `fleet-state.ts` (and its tests) as dead code, or is the intent to connect it in a follow-up? Determines whether the RFC follow-up is "add the render branch" (connect it) or "remove the dead state function" (clean up).
+Options:
+1. If Phase 4c landed: remove the stale "run in terminal" comment from
+   `gateway.ts:13079` and update the JTBD to reflect the wired state.
+2. If Phase 4c did not land: update the JTBD to accurately state which auth
+   operations are available from Telegram (use/list/show/rotate) and which
+   require the host CLI (add/rm). The "run in terminal" comment stays in code
+   as a developer hint.
+3. Scope Phase 4c as a tracked issue and update both the JTBD and the code
+   comment to reference the issue number, so the gap is tracked rather than
+   silently present.
 
 ---
 
-## Escalation 7
+### E6 — Silence-poke success rate: 0-7% vs >80% JTBD target
 
-**ID:** rfc-sub-agent-visibility:c12
-**Type:** outcome gap (fleet cap unimplemented)
-**File:** `reference/sub-agent-visibility-rfc.md`
-**Evidence files:** `telegram-plugin/fleet-state.ts` L157-163, `telegram-plugin/progress-card.ts` L929-943
+**Finding:** `jtbd-know-what-my-agent-is-doing:c12`
 
-**Claim (AC-5):** "6+ parallel sub-agents — render output is balanced HTML, < 4096 bytes, fleet zone caps at 5 rows + '+ N more'."
+`telegram-plugin/pending-work-progress.ts:L13-16` documents empirical data:
+silence-poke success rate is 0-7% across hundreds of real fires (finn: 0/78,
+clerk: 6/91, klanker: 5/158). The JTBD UAT target is >80%. `pending-work-
+progress.ts` was introduced precisely because the silence-poke ladder fails
+as a cross-turn mechanism.
 
-**Gap found:**
-The fleet renderer (`progress-card.ts` L929-943) iterates ALL sub-agents with no row cap. The `cap()` function (`fleet-state.ts` L157-163) caps at 5 + hidden count but is not imported or called by the renderer. The "N more" footer does not exist in the renderer output. For a fleet of 6+ sub-agents, the card will render all rows with no cap, potentially exceeding the 4096-byte Telegram message limit.
+**Why this is escalated:** This is a product-level gap. The silence-poke
+mechanism works as implemented (it fires at 75s/180s/300s and reaches the
+model as system-reminder piggybacked on the next tool result) but fails to
+produce the intended user-visible outcome at any useful rate. The JTBD target
+and the measured outcome are an order of magnitude apart.
 
-**Decision required:**
-- (A) Implement the cap: import `cap()` from `fleet-state.ts` in the renderer and apply it with a "+ N more" footer row. Update the RFC after implementing.
-- (B) Remove the cap spec: if the renderer is intentionally uncapped (all rows visible), update AC-5 to remove the cap requirement and note that HTML safety is ensured by truncation elsewhere.
+**Question for operator:** The silence-poke success rate is measured at 0-7%.
+What is the correct response?
 
-## Recommendation — Escalation 7
-
-**Recommended option:** B
-**Confidence:** high
-
-### Why
-
-The fleet renderer at `progress-card.ts` L929-943 is not currently reachable in production. The pinned progress-card driver (`progress-card-driver.ts`) was removed from the gateway in PR #1122 PR3 — `progressDriver` is permanently `null` in `telegram-plugin/gateway/gateway.ts` (L3046), making every `progressDriver?.X` call a no-op at runtime. The `progress-card.ts` module is still imported by `progress-card-driver.ts`, but that driver is never loaded by the gateway. The fleet-zone renderer loop is dead code.
-
-More importantly, the RFC itself already declares the card model superseded. The preamble (L25-33): "Card model superseded. This RFC reasons about the two-zone progress-card model. That two-zone design has since been superseded by `reference/conversational-pacing.md`, and `reference/status-card-design.md` is archived." AC-5's cap requirement was written for a design that no longer drives the live product. The current Telegram-facing surface is conversational pacing, not the two-zone pinned card.
-
-There is no meaningful 4096-byte risk to defend against today. `stream-reply-handler.ts` (L395-400) enforces a hard 4096-char pre-check on `stream_reply` calls, and `answer-stream.ts` (L49) tracks the same constant — but those guard the conversational-pacing path, which does not use the uncapped fleet renderer. The `cap()` function exists, is correct, and exported, but the one callsite that would matter is unreachable.
-
-Wiring Option A — importing `cap()` into a renderer that isn't live — would cost little but achieve nothing and leave reviewers confused. Correct fix: update AC-5 in the RFC to reflect reality. Remove the cap requirement, note the two-zone card was retired in PR #1122, point to `conversational-pacing.md` as the live contract. If the project revives a pinned fleet card under conversational-pacing later, the cap requirement should be written fresh.
-
-### Tradeoffs of the recommendation
-
-- Removing AC-5 from a closed RFC is low-risk: status is already "SHIPPED / CLOSED" and the doc flags the card model as superseded.
-- The `cap()` function remains in place and can be picked up cheaply if a future fleet renderer is ever written — no deletion needed.
-- No user-visible regression from Option B: the uncapped renderer cannot produce a 4096-byte overrun because it isn't called.
-- Leaving the spec as-is keeps misleading future auditors (and this audit system) about an unfulfilled gap in active code.
-
-### If you pick a different option
-
-- **Option A:** Import `cap()` into `progress-card.ts` fleet section and add a `+ N more` footer. Correct if you plan to re-activate the progress-card driver. Doing it without re-activating still leaves the loop unreachable and creates well-maintained dead code. If you go this route, also re-wire `progress-card-driver.ts` into the gateway and write the UAT scenario (`bg-heavy-fleet-dm.test.ts`) the RFC called for in Phase 3.
-
-### Open question for the operator
-
-Is there an active plan to revive the pinned progress-card (two-zone or otherwise) under the conversational-pacing architecture? If yes, Option A makes sense as prep work paired with re-activating the driver. If no, close AC-5 with a note and let `cap()` sit ready for future use.
+Options:
+1. Accept the current rate as a known limitation and update the JTBD: remove
+   the ">80%" UAT target, replace with a description of the pending-work-
+   progress fallback as the primary cross-turn visibility mechanism. The
+   mechanism stays in place as a best-effort signal.
+2. Rework the silence-poke delivery mechanism: instead of a system-reminder
+   piggybacked on the next tool result, inject the poke as a synthesized
+   inbound turn (via `dispatchAsInbound`). This reaches the model at a turn
+   boundary rather than mid-tool. Estimated: ~90 agent-minutes; non-trivial
+   risk of turn-ordering issues.
+3. Retire silence-poke as a user-facing mechanism: replace the >80% UAT target
+   with a pending-work-progress UAT (does the anchor reply update every N
+   minutes during a long tool-churn?). The silent-poke code stays for
+   degraded cases but is no longer the primary visibility guarantee.
 
 ---
 
-## Escalation 8
+## Low-confidence findings requiring operator triage
 
-**ID:** jtbd-run-a-fleet-of-specialists:c9
-**Type:** outcome gap (Hindsight memory not purged on destroy)
-**File:** `reference/run-a-fleet-of-specialists.md`
-**Evidence files:** `src/cli/agent.ts` L1931-1979
+### E7 — migrate-schema.ts not wired into production (low confidence)
 
-**Claim:** "Removing an agent is clean. Its memory, its state, its scheduled work all go with it, with no orphaned processes or dangling config."
+**Finding:** `jtbd-share-auth-across-the-fleet` (auditor notes, also c14 rationale)
 
-**Gap found:**
-`switchroom agent destroy` removes the agent directory and stops the container. The config entry removal (which kills the compose service on next apply) cleans up the scheduled work. However, the Hindsight memory bank (stored in the hindsight container's database) is NOT deleted by `agent destroy` — no code in `src/cli/agent.ts` or `src/agents/scaffold.ts` calls hindsight to drop the bank. Memory data orphans in the hindsight service.
+`src/auth/migrate-schema.ts` is a shipped, tested in-place migration algorithm
+(3 fixture shapes tested). The schema comments in `src/config/schema.ts:L1278-
+1279` state it "runs on first apply." However, `migrateAuthSchemaFile` is not
+imported from any production code path — only from its own test file. `apply.ts`
+does not import it.
 
-**Decision required:**
-- (A) Wire memory purge: add a `hindsight delete-bank --collection <agentName>` call (or equivalent) to the `agent destroy` flow. Update the JTBD after implementing.
-- (B) Accept the gap: update the JTBD to note that Hindsight memory must be purged manually after `agent destroy` (e.g., `hindsight delete-bank --collection <name>`). Document the purge command.
-- (C) Soft delete: mark the collection as archived rather than purging, with a separate cleanup command for operators who want to reclaim storage.
+**Why low-confidence:** The code may have been wired after the audit was run
+(the auditor flagged this as low-confidence), or the schema comment may be
+aspirational. Cannot be resolved by doc inspection alone.
 
-## Recommendation — Escalation 8
+**Question for operator:** Does `switchroom apply` actually run the in-place
+auth schema migration? If yes, which file imports `migrateAuthSchemaFile`?
 
-**Recommended option:** B
-**Confidence:** high
-
-### Why
-
-The core question is whether an orphaned Hindsight bank is a leak or a recovery feature. The answer is: it is a recovery feature in disguise, and that changes the calculus.
-
-The `bankId` for any agent is derived as `agentMemory?.collection ?? agentName` (see `src/agents/scaffold.ts:1613` and `src/memory/hindsight.ts:76`). When no explicit `memory.collection` override is set — the default for every agent — the bank ID is the agent name. `createBank` in scaffold.ts (line 2896) is explicitly documented as idempotent: "calling this on an already-existing bank is a no-op and returns success" (`src/memory/hindsight.ts:392-394`). This means if an agent named `clerk` is destroyed and re-created with the same name, its first scaffold run calls `createBank("clerk")`, Hindsight recognizes the existing bank, and the agent silently resumes with its full memory history. The orphaned bank was a restoration point, not waste.
-
-This re-attach is architecturally desirable. Accidental destroys, name collisions after reconfiguration, fleet rebuilds — all benefit from memory persistence in the backing store. The JTBD claim "no orphaned processes or dangling config" is about processes and config, not persistent data. The wording does not promise data erasure, only operational cleanliness. Interpreting it to mandate automatic bank deletion would be wrong — the analogous expectation would be that destroying a database-backed service should DROP the schema, which is almost never correct.
-
-Practical blocker for Option A: neither the vendored `HindsightClient` (`vendor/hindsight-memory/scripts/lib/client.py`) nor switchroom Hindsight bindings (`src/memory/hindsight.ts`) expose a `delete_bank` call. No `DELETE /banks/{id}` call exists anywhere in the repo. Whether Hindsight's upstream REST API even exposes bank deletion is unconfirmed. Wiring Option A would require: confirming the upstream API supports deletion, adding `deleteBank` to bindings, calling it in destroy flow, handling the case where Hindsight is unreachable at destroy time. The failure mode where destroy aborts because Hindsight is offline is strictly worse UX than current silent orphan.
-
-### Tradeoffs of the recommendation
-
-- Operators who destroy an agent permanently and never re-create it accumulate storage in the Hindsight database with no self-service cleanup path. On a fleet that cycles agents regularly, this compounds.
-- The current `mcp__hindsight__delete_memory` tool (available to agents in-session) only deletes individual memories, not the whole bank. Operators have no single-command purge path today.
-- Updating the JTBD claim to be accurate about Hindsight persistence is low-risk, takes 1-2 lines.
-- Option B does not preclude adding a `switchroom agent destroy --purge-memory` flag in a later PR once the upstream delete API is confirmed.
-
-### If you pick a different option
-
-- **Option A:** Wire memory purge in destroy flow. Before implementing, confirm that `DELETE /v1/default/banks/{bank_id}` exists in the Hindsight REST API — absent from the vendored client. If it exists, add `deleteBank()`, call it after `rmSync`, handle offline gracefully (warn, don't block destroy). If `bankId` was overridden via `memory.collection`, destroying the wrong name is possible — read config before removing agent directory. Risk: breaks re-attach recovery; accidental destroy loses memory permanently.
-- **Option C:** Soft-delete/archive. Requires Hindsight archival state (unconfirmed), adds a separate cleanup command, two-phase delete UX operators will find confusing. Adds complexity with limited benefit over Option B + future `--purge-memory` flag.
-
-### Open question for the operator
-
-Does Hindsight's REST API expose a bank deletion endpoint (`DELETE /v1/default/banks/{id}`)? This single fact determines whether Option A is even wirable, and should be confirmed before any implementation work.
+Options:
+1. Confirm the wiring exists (name the import site) — auditor's grep may have
+   been incomplete. Update the fix-batch for `jtbd-share-auth-across-the-fleet`
+   to reflect the confirmed state.
+2. Confirm the wiring is absent — the migration algorithm exists but is not
+   called. Add the import into `apply.ts` (or wherever `switchroom apply` runs
+   config reconciliation) before the next operator upgrade, to avoid silent
+   schema-incompatibility for users upgrading from pre-RFC-H installs.
+3. Confirm the migration is intentionally not wired (operators are expected to
+   be on new installs only) — update the schema comment to remove "on first
+   apply" and update the JTBD fix-batch text accordingly.
 
 ---
 
-## Escalation 9
+### E8 — Dead zone recovery: vision-only (low confidence)
 
-**ID:** jtbd-feel-like-a-colleague:c9
-**Type:** vision-only, low confidence (AI non-detectability)
-**File:** `reference/feel-like-a-colleague.md`
-**Evidence files:** `profiles/default/workspace/SOUL.md.hbs` L41-51
+**Finding:** `jtbd-talk-to-agents-from-anywhere:c10`
 
-**Claim:** "A non-technical user can't immediately tell they're talking to an AI from the first ten messages. They can tell it's not a person they've met before, but the shape of the conversation feels human."
+The JTBD describes dead-zone recovery ("the agent detects the disconnection and
+queues messages; on reconnect, any queued messages replay in order"). The
+auditor found no implementation of dead-zone detection or replay in the gateway.
+Confidence is low because the inbound-spool JSONL (which does survive restarts)
+may partially cover this — the auditor was uncertain whether the spool + boot-
+replay constitutes the described behavior.
 
-**Assessment:**
-This is not verifiable from the codebase. The prompt engineering and AI-tell bans aim at this outcome, but whether it is actually achieved requires user testing. This is a goal/outcome statement, not an implementable behavior. The JTBD should either flag it as a success criterion (not a current state claim) or acknowledge it's an aspirational target.
+**Question for operator:** Is the dead-zone recovery claim (c10) describing the
+inbound-spool boot-replay mechanism, or a separate not-yet-built Telegram
+reconnect-detection path?
 
-**Decision required:**
-- (A) Mark as aspirational: add a hedge to the claim — "(target, not yet systematically verified via user testing)."
-- (B) Remove the claim: it cannot be verified from code; leave only the prompt engineering claims that CAN be verified.
-- (C) Accept as-is: treat it as a product vision statement, not a verifiable claim; no action needed.
-
-## Recommendation — Escalation 9
-
-**Recommended option:** C
-**Confidence:** high
-
-### Why
-
-The JTBD format in this codebase is explicitly outcome-focused, not test-result-focused. The README for `reference/` describes JTBDs as answering "Did it do the user's job?" — a design target, not a passing test suite. Scanning "Signs it's working" across all JTBDs confirms: they are written in the present tense as outcome descriptions, not verified state. `run-a-fleet-of-specialists.md` says "The user never has to prefix a message with 'as my coding agent'"; `remember-across-sessions.md` says "A restart doesn't reset the relationship." Neither is instrumented. The entire format is aspirational-but-precise: tells builders what success looks like.
-
-The c9 claim sits inside that consistent pattern. The section header "Signs it's working" already signals that role. Adding a hedge would be inconsistent with how every other JTBD is written, and would implicitly suggest other "Signs" entries are verified — they are not.
-
-The claim is also load-bearing in the right way. `vision.md` calls out the non-technical principal explicitly: "The bar: one even a non-technical partner likes." The c9 claim is precisely what that bar means in behavioral terms. Softening dilutes the sharpest user-facing success criterion. The claim is not a marketing assertion outside a design document; it's a design criterion inside one, and that context is the correct frame.
-
-The SOUL.md AI-tell bans (L41-51) are verifiable engineering affordances implementing this criterion. The criterion itself remains correctly at the outcome layer. Removing (Option B) would leave the implementation affordances with no stated purpose. Hedging (Option A) would add noise that no other JTBD carries, signalling incorrectly that the JTBD format admits only verified claims.
-
-### Tradeoffs of the recommendation
-
-- The claim cannot be falsified from the codebase alone — a real epistemic gap, but the same gap exists for every "Signs it's working" bullet across all JTBDs. Treating c9 differently would require auditing all of them — a larger separate question about the JTBD format itself.
-- Accepting as-is means the design contract contains an outcome only user research can validate. Appropriate for a design contract; inappropriate in a test report or release checklist.
-- The UAT prompts section of the same JTBD (L119-144) already provides a partial proxy: the "AI-tell sweep" is code-reviewable and behavioral prompts are manually testable. Outcome is closer to measurable than it appears; just needs a human in the loop.
-
-### If you pick a different option
-
-- **Option A:** Adding "(target, not yet systematically verified via user testing)" reads as an admission that other "Signs it's working" bullets are verified, which they are not. Creates inconsistency across JTBDs and invites a wave of similar hedges. The actual fix, if hedging is wanted, is a format-level note in `reference/README.md` — a much broader change.
-- **Option B:** Removing leaves the JTBD without a human-perceivable success criterion at the outcome level. The remaining signs are intermediate indicators; c9 is the only one naming the actual user experience targeted. Removal makes the JTBD harder to use as a design gate.
-
-### Open question for the operator
-
-If you want to distinguish measurable "Signs" from aspirational ones across all JTBDs consistently, the right lever is a format note in `reference/README.md`, not individual hedges. Is that a change worth making as a separate pass?
+Options:
+1. If inbound-spool covers it: update the JTBD to cite the spool mechanism
+   explicitly and note the v1 limitation (ack = delivered to bridge, not
+   consumed by claude). No code change needed.
+2. If it is a separate unbuilt path: update the JTBD to mark this as a future
+   capability ("planned: dead-zone replay") rather than a current one.
+3. If it is partially covered: rewrite the JTBD claim at the level of what
+   actually exists ("messages queued in-process survive gateway restarts via
+   the inbound spool; host-level network dead-zone recovery is not yet
+   implemented").
 
 ---
 
-## Escalation 10
+## Manifest hygiene (operator acknowledgment requested)
 
-**ID:** jtbd-give-each-agent-its-own-workspace:c7, c8, c11 (vision-only cluster)
-**Type:** vision-only (fast-forward, dirty-tree, sub-agent nesting not end-to-end)
-**File:** `reference/give-each-agent-its-own-workspace.md`
-**Evidence files:** `src/repos/agent-worktree.ts` L209-238, L196-208
+### E9 — historical-prd unit must be dropped from manifest
 
-**Claims (vision-only):**
-- c7: "Fast-forwarded to `upstream/main` on session start when the worktree is clean."
-- c8: "Dirty-tree policy: leave alone, warn. If the worktree has uncommitted changes at session start, the ff-to-main step is skipped. The session resumes on whatever branch the worktree was on. The boot card surfaces `<repo>: dirty since <ts>` as a one-line warning."
-- c11 (from workspace JTBD): Sub-agent nesting in worktrees end-to-end.
+**Finding:** `historical-prd:c1`
 
-**Assessment:**
-The infrastructure exists in `agent-worktree.ts` (fast-forward logic, dirty-tree detection) but is not callable from any production path (see Escalation 2). Until Escalation 2 is resolved, these vision-only claims cannot be tested. They should be deferred until the provisioning wiring ships.
+`reference/PRD.md` was deleted in PR #534 (commit 8bdb86cb). The manifest
+lists it as a `historical` unit. The fix-batch `manifest-hygiene.md` proposes
+removing it from `scripts/drift-audit/manifest.yaml`.
 
-**Decision required:**
-These are tied to Escalation 2. Resolve Escalation 2 first; these vision-only claims will either become verifiable or get updated to reflect the reality after the wiring decision.
+**This is in a fix-batch already.** Listed here so the operator formally
+acknowledges the deletion and confirms no PRD equivalent document exists at a
+different path that should replace this manifest entry.
 
-## Recommendation — Escalation 10
+**Question for operator:** Is there a replacement PRD-level document anywhere
+in the repo that should be added to the manifest under a new unit_id?
 
-**Recommended option:** Defer-to-Escalation-2 — mirror its resolution exactly, with one always-on action: mark the boot-card "dirty since <ts>" sub-claim of c8 as separately unimplemented regardless of Escalation 2's outcome.
-**Confidence:** high
+Options:
+1. No replacement exists — delete the manifest entry (fix-batch as written).
+2. A replacement exists at a different path — update the fix-batch to point
+   to the new path and update the unit_id.
+3. Defer: keep the manifest entry with a `status: deleted` marker until a
+   replacement is written.
 
-### Why
+---
 
-**On c7 (fast-forward on clean session start):** ff logic is fully implemented in `src/repos/agent-worktree.ts` L210-238. On clean worktree, `ensureAgentWorktree` runs `git fetch origin` then `git merge --ff-only origin/<defaultBranch>` and logs to stderr. Implementation is correct and complete. But `ensureAgentWorktree` is imported but never called from `scaffold.ts` or any production reconcile path. The ff-to-main never executes on session start. Implemented but unwired. If Escalation 2 = A, c7 becomes testable post-wiring. If Esc2 = B, c7 must also be removed. If Esc2 = C, c7 should receive the same "not wired" disclaimer.
+## Cross-unit conflicts
 
-**On c8 (dirty-tree policy):** "Leave alone" half is fully implemented at L196-208: `isWorktreeDirty` detects via `git status --porcelain`, and on dirty detection `ensureAgentWorktree` returns `{ dirty: true, dirtyCommit: sha }` without touching the worktree. The "boot card surfaces `<repo>: dirty since <ts>` as a one-line warning" sub-claim is **not** implemented. Review of `telegram-plugin/gateway/boot-card.ts` shows `RenderBootCardOpts` has no `worktrees` or `dirtyWorktrees` field, `renderBootCard` renders no such row, `runAllProbes` has no worktree probe, and `ProbeKey` has no `repos` or `worktrees` entry. The `WorktreeState.dirtyCommit` field exists but is never consumed by any caller outside agent-worktree.ts itself. Boot-card surface is entirely absent. The "leave alone" half follows Esc2's resolution; the "boot card surfaces" half needs its own disclaimer or implementation work regardless.
+### X1 — "remove agent" command name inconsistency
 
-**On c11 (sub-agent nesting in worktrees end-to-end):** JTBD text at L40-43 and L111-114 states sub-agents dispatched from inside an agent's worktree create their own nested worktree off the parent's HEAD, "exactly as today." Code search finds no implementation — no `ensureSubAgentWorktree`, no "parent HEAD" resolution, no sub-agent worktree dispatch path. Vision-only independently of Esc2: even if Esc2 = A wires main-agent provisioning, sub-agent nesting requires additional implementation. Under Esc2 = A, c11 should be flagged as "next step after c2/c3 provisioning ships." Under Esc2 = B or C, c11 should also be removed or disclaimed.
+**Units involved:** `jtbd-give-each-agent-its-own-workspace:c9` and
+`jtbd-extend-without-forking:c7`
 
-The independent always-on action: the boot-card "dirty since <ts>" sub-claim of c8 should be disclaimed regardless of Esc2.
+Both findings touch the "remove/destroy agent" command name. The findings
+land in different fix-batches:
+- `jtbd-give-each-agent-its-own-workspace:c9` is in `misc-jtbd-small-drift-fixes`
+  (edits `reference/give-each-agent-its-own-workspace.md`)
+- `jtbd-extend-without-forking:c7` is in `misc-jtbd-small-drift-fixes` (edits
+  `reference/extend-without-forking.md`)
 
-### Tradeoffs of the recommendation
+These are two separate files in the same batch, so no conflict in the fix-batch.
+However, both documents may need to use the same canonical verb (`agent destroy`
+vs `agent remove`). The fix agent should verify the CLI-registered name before
+editing and apply the same name in both files.
 
-- Deferring to Escalation 2 keeps c7 and "leave alone" of c8 in sync with the provisioning decision, avoiding divergent audit trail.
-- Calling out boot-card "dirty since <ts>" independently is correct — it is a separate implementation surface (probe + renderer) even if provisioning ships.
-- Flagging c11 as separately unimplemented is independently justified: sub-agent nesting is further out than main-agent provisioning regardless of Esc2.
-- Produces three distinct outcomes for three claims rather than uniform treatment — adds audit complexity but accurately reflects three genuinely different implementation states.
+**No blocking conflict; flagged for fix agent awareness.**
 
-### If you pick a different option
+### X2 — auth verb surface: principles.md and share-auth JTBD
 
-- **Treat all three as one cluster and follow Esc2 uniformly:** Simpler audit trail, but leaves boot-card gap and sub-agent nesting gap undisclaimed if Esc2 = A. Operator reading the JTBD after wiring would see c8's boot-card claim and c11's nesting claim as verified when neither was tested.
-- **Mark all three vision-only independently of Esc2:** Defensively correct today. Risk: if Esc2 = A ships quickly, creates churn re-verifying and re-clearing c7 and "leave alone" of c8 separately from the provisioning PR.
+**Units involved:** `contract-principles:c1` (in `principles-stale-examples`)
+and `jtbd-share-auth-across-the-fleet:c4,c16` (in `jtbd-share-auth-stale-examples`)
 
-### Open question for the operator
+Both batches update auth command examples. Files are disjoint:
+- `principles-stale-examples` edits `reference/principles.md`
+- `jtbd-share-auth-stale-examples` edits `reference/share-auth-across-the-fleet.md`
 
-The "dirty since <ts>" timestamp in c8's boot-card warning requires knowing when the worktree first became dirty (not just that it is dirty now) — `WorktreeState.dirtyCommit` captures HEAD SHA but not a wall-clock timestamp. Should this sub-claim be revised in the JTBD to "dirty at <sha>" (which current implementation could surface) instead of "dirty since <ts>" (which would require new dirty-timestamp tracking)?
+The fix agents must use identical verb names (e.g. `switchroom auth use <label>`,
+`switchroom auth list`, `switchroom auth show`). The canonical surface is
+`src/cli/auth.ts`. Fix agents should read that file before writing.
+
+**No blocking conflict; flagged for fix agent consistency.**
+
+---
+
+*End of escalations — pilot-2026-05-26*

--- a/audit/2026-05-26/escalations.md
+++ b/audit/2026-05-26/escalations.md
@@ -1,0 +1,518 @@
+# Drift Audit Phase 2 Escalations
+
+**Run date:** 2026-05-26
+**Escalated by:** Phase 2 triage agent
+**Recommendations drafted by:** Phase 2.5 recommendation agents (2026-05-26)
+**Rule:** These findings require operator decision. They are NOT assigned to any fix-batch because they cannot be resolved by a doc edit alone — they require either a product decision, a code change, or explicit acceptance of a vision gap.
+
+Total escalations: 10. Each carries an inline **Recommendation** drafted by a fresh agent that read the cited evidence. The operator chooses; recommendations are not auto-applied.
+
+---
+
+## Escalation 1
+
+**ID:** contract-vision:c8
+**Type:** code-violates-contract (medium confidence)
+**File:** `reference/vision.md`
+**Evidence files:** `src/config/schema.ts` L1692-1702, `src/cli/telegram.ts` L158-169
+
+**Claim:**
+The vision's "What it isn't" table (L127) states "No OpenAI, Gemini, Llama, model swapping." Outcome 3 (L79) forbids "No raw API."
+
+**Violation found:**
+Two features use external OpenAI API paths:
+1. The Hindsight memory system (`src/config/schema.ts` L1692-1702) supports `openai` and `anthropic` as embedding providers with an `api_key` field. An operator can configure the product to spend against an OpenAI API key for embeddings.
+2. The voice-in feature (`src/cli/telegram.ts` L158-169) calls OpenAI Whisper for transcription using a separately stored API key.
+
+**Decision required:**
+Does the vision's "No OpenAI" constraint apply only to inference model swapping, or also to auxiliary service APIs (embeddings, transcription)? Options:
+- (A) Accept the carve-out: add explicit language to `reference/vision.md` distinguishing "auxiliary service APIs" from inference model swapping.
+- (B) Restrict the features: remove or constrain the OpenAI embedding provider and/or Whisper path to comply strictly with the vision.
+- (C) Defer: document as a known tension; no change to vision or code.
+
+**Confidence:** Medium. The vision's exact wording targets "model swapping" for inference, but the features create a second billing surface outside Anthropic.
+
+## Recommendation — Escalation 1
+
+**Recommended option:** A
+**Confidence:** high
+
+### Why
+
+Reading the vision in context, the constraint targets *inference model routing* — every agent *turn* through the unmodified `claude` CLI on Pro/Max. Neither Whisper nor an OpenAI embedding provider is an inference model for agent turns.
+
+The two surfaces are structurally different from the prohibited pattern:
+
+- **Voice-in (Whisper)** is explicitly opt-in per agent (`src/config/schema.ts:588` documents "Off by default — opt-in per agent"). `docs/telegram-features.md:53-57` already contains a self-aware tradeoff note acknowledging "Switchroom asks you to leave the Pro/Max-only ceiling — there's no Anthropic-side voice transcription yet." This is precisely the kind of explicit, acknowledged, opt-in auxiliary service that Option A would legitimise in writing.
+- **Hindsight embedding provider field** has `openai`/`anthropic` choices that appear to be vestigial. At runtime, `src/memory/hindsight.ts:42` defaults to `ollama` (local, no API key). `src/cli/memory.ts:292-300` actively *ignores* `--provider` flags other than `claude-code` — the bundled image is pinned to `HINDSIGHT_API_LLM_PROVIDER=claude-code` (see `docs/auth.md:325`). The schema text advertising `openai` is currently dead for operators running the bundled image.
+
+Option A — adding a narrow carve-out paragraph to `reference/vision.md` — is the honest fix. The "No OpenAI" line was written to foreclose model swapping (routing agent turns through GPT-4 or Gemini), not to prohibit every third-party API a user might subscribe to for auxiliary tasks. Codifying this distinction gives future contributors a clear rule.
+
+### Tradeoffs of the recommendation
+
+- The carve-out language must be narrow enough not to open the door to "optional" OpenAI inference paths by analogy. Use "auxiliary services" with explicit opt-in requirement — not a general "third-party APIs are fine" waiver.
+- The Hindsight embedding schema fields (`openai`, `anthropic`, `api_key`) describe configuration currently unreachable via `switchroom memory --start`. Leaving them undocumented as out-of-maintenance is low-level debt; Option A should note this for a follow-up cleanup.
+- Accepting the carve-out implicitly accepts that voice-in creates a second billing relationship (OpenAI) for the operator. Already disclosed in feature docs; vision should echo it.
+- If Anthropic or a third-party later ships subscription-level transcription via the `claude` CLI, voice-in should migrate. The amended text should include a sunset clause ("until a subscription-native transcription path exists").
+
+### If you pick a different option
+
+- **Option B (restrict the features):** Removing Whisper eliminates the one user-visible capability that lets a principal send voice notes from their phone — a real loss for Outcome 4 and a regression for users already relying on it. Removing embedding provider schema fields is lower cost but requires a migration path. Only right if policy-level consistency outweighs the feature.
+- **Option C (defer):** Leaves contributors with a visible contradiction the audit will flag again next pass. Acceptable only if evaluating a subscription-native transcription path before committing to carve-out language.
+
+### Open question for the operator
+
+The `memory.config.provider` schema field (`src/config/schema.ts:1690-1693`) lists `openai` and `anthropic` as valid values, but `switchroom memory --start` ignores them and the bundled image is pinned to `claude-code` — are these provider values intended for operators bringing their own Hindsight image, or are they dead schema text that should be removed?
+
+---
+
+## Escalation 2
+
+**ID:** jtbd-give-each-agent-its-own-workspace:c2, c3, c12
+**Type:** outcome-not-realized
+**File:** `reference/give-each-agent-its-own-workspace.md`
+**Evidence files:** `src/repos/agent-worktree.ts`, `src/repos/bare-clone.ts`, `src/agents/scaffold.ts` L246-253
+
+**Claim:**
+The JTBD states "Adding a switchroom agent that works on a repo automatically gives that agent its own worktree. The user doesn't run `git worktree add`. They don't pick a path. They don't pick a branch." And: "Worktrees are provisioned lazily — on the first `agent restart`/`reconcile`."
+
+**Gap found:**
+`ensureAgentWorktree` and `ensureBareClone` are imported in `scaffold.ts` (L246-253) but have **zero production call sites**. `reconcileAgent` does not call either function. `scaffoldAgent` does not call them. No CLI command triggers them. A user who adds `repos:` to `switchroom.yaml` and runs `switchroom apply` or `switchroom agent restart` does NOT get a worktree provisioned. The `SWITCHROOM_REPO_*` env vars are injected into `start.sh` pointing at paths that don't exist on disk.
+
+**Decision required:**
+- (A) Wire the provisioning: add `ensureAgentWorktree`/`ensureBareClone` calls to `reconcileAgent` or `scaffoldAgent`. Update the JTBD after the feature ships.
+- (B) Remove the partial implementation: remove the env var injection and unresolved imports until the feature is fully planned. Update the JTBD to mark as vision-only.
+- (C) Explicitly document as incomplete: add a disclaimer to the JTBD noting the feature is not yet wired end-to-end.
+
+## Recommendation — Escalation 2
+
+**Recommended option:** A (wire the provisioning)
+**Confidence:** high
+
+### Why
+
+The partial implementation is not a stub — it is a complete, well-reasoned implementation. `src/repos/bare-clone.ts` (72 lines) handles idempotent bare-clone creation and fetch-all refresh with graceful network-failure handling. `src/repos/agent-worktree.ts` (323 lines) handles first-create, clean-ff, dirty-skip, dirty-commit surfacing, removal, prune, and orphan detection — the full lifecycle described in the JTBD's "Decisions" section. Both files have proper docstrings, match the design exactly, and are idempotent and safe to call on every reconcile. This is a complete feature waiting for a two-line call site, not a half-written sketch.
+
+The gap is entirely at the integration layer. `src/agents/scaffold.ts` imports all five symbols but calls only `agentWorktreePath` — to compute a deterministic path injected as `SWITCHROOM_REPO_<SLUG_UPPER>` into `start.sh` via `buildRepoEnvVars`. The env var injection is fully wired in both `scaffoldAgent` and `reconcileAgent`. The bare-clone creation and worktree provisioning those paths point at are not. Result: env vars injected pointing to paths that don't exist.
+
+The `repos:` schema field is complete and documented (`src/config/schema.ts:1592-1623`), `docs/configuration.md:544-550` already tells operators to use `repos:` for git-repo agents, and `docs/rfcs/host-control-daemon.md` references the pattern as canonical. The feature is committed to in user-facing documentation. Option B would invalidate that documentation. Option C is awkward given the schema already accepts `repos:` entries today.
+
+The wiring delta is small: in `reconcileAgent`, after the existing agentDir check (scaffold.ts:3678), call `ensureBareClone` for each entry in `agentConfig.repos`, then `ensureAgentWorktree` with the returned clone path. Mirror `removeAgentWorktree` in the agent-remove path. Both functions are idempotent; calling them on a reconcile with no `repos:` is a no-op.
+
+### Tradeoffs of the recommendation
+
+- Wiring makes `reconcileAgent` either async (ripple through callers) or requires `Promise.resolve` wrappers — the provisioning functions are declared async but use `execFileSync` internally. A small refactor to synchronous signatures, or wrapping at the call site, avoids the async refactor.
+- The `removeAgentWorktree` teardown path needs to be found and wired for the "removal is symmetric" JTBD contract.
+- First reconcile after a user adds `repos:` will block on `git clone --bare` — network-latency at reconcile time. The existing function handles fetch-fail gracefully.
+- The env var injection is already shipping to agents configured with `repos:`. Those agents currently get a valid-looking env var pointing at nonexistent paths. Wiring fixes this silently on next restart with no user action.
+
+### If you pick a different option
+
+- **Option B (remove):** Requires removing the `repos:` schema field, `buildRepoEnvVars`, all five imports, and the `docs/configuration.md:544-550` guidance. Net deletion of ~430 lines of tested implementation. Configuration breakage is silent — operators who followed the docs will have invalid YAML or silently broken configs. Disruptive without a clear payoff.
+- **Option C (disclaim):** The schema accepts `repos:` today with no warning. An operator who configures it sees `SWITCHROOM_REPO_<SLUG>` pointing at a nonexistent path — agent silently fails to find the repo. A JTBD disclaimer doesn't surface at the point of failure. Worse than current state.
+
+### Open question for the operator
+
+`reconcileAgent` is synchronous today — do you want the worktree-provisioning call sites to refactor the provisioning functions to synchronous signatures (straightforward, since they already use `execFileSync` internally), or do you want `reconcileAgent` to become async (larger ripple through callers in `src/cli/agent.ts` and `src/cli/apply.ts`)?
+
+---
+
+## Escalation 3
+
+**ID:** jtbd-restart-and-know-what-im-running:c3, c8
+**Type:** outcome-not-realized
+**File:** `reference/restart-and-know-what-im-running.md`
+**Evidence files:** `telegram-plugin/gateway/boot-card.ts`, `telegram-plugin/welcome-text.ts` L22-28
+
+**Claim (c3):** "The user can tell if the model changed, the tools changed, skills were added or removed, or memory is attached."
+**Claim (c8):** "When something did change, the change is obvious, not buried."
+
+**Gap found:**
+The boot card (`RenderBootCardOpts`) has no model, tools allowlist, or memory-backend fields. A config change (model swap, tool scope change, memory backend swap) produces no visible difference in the boot card on a healthy restart. These fields were in the deleted SessionStart greeting card (#142 PR 1) and now live only in `/status` on demand. The UAT test (`jtbd-wake-audit-content-dm.test.ts`) explicitly relaxes the "no need to ask" contract.
+
+**Decision required:**
+- (A) Add config-change visibility to the boot card: surface model/tools/memory backend in the boot card when they differ from the previous boot. Implement and update the JTBD.
+- (B) Accept the gap: update the JTBD to reflect the split design (boot card = liveness + probe health; `/status` = config audit). Clarify the JTBD outcome to match shipped behavior.
+- (C) Implement a change-detection boot card row: detect changes on reconcile, emit a one-line "config changed" summary row. Update the JTBD after implementing.
+
+## Recommendation — Escalation 3
+
+**Recommended option:** C
+**Confidence:** high
+
+### Why
+
+The JTBD's "no need to ask" promise is stated without qualification: "After any restart, the user is told what config is live. Model, tools, skills, memory backend, auth state. No need to ask." The anti-patterns explicitly name "Cosmetic summaries that always look the same regardless of the actual config" and "Lying by omission. If tools were silently disabled, the summary should say so." Option B would require rewriting both anti-patterns out of the contract — a deliberate retreat from a core promise, not a refinement.
+
+Option A conflicts with the boot card's own design contract. The boot card file opens: "Default state is a single line: `✅ <agent> back up · <version>`" and the deletion comment is explicit — Profile/Tools/Skills/Limits/Channel/Memory content was removed from the old SessionStart greeting because it was "always-rendered" noise that "becomes wallpaper the user learns to scroll past." The JTBD itself warns against "a boot banner that dumps every setting." Putting that content back unconditionally restores exactly the problem PR #142 solved.
+
+Option C threads the needle. The boot-issue-cache already demonstrates the pattern: persist a fingerprint of the last boot's probe state, diff against the current boot, surface a row only when changed. A config-snapshot cache wired into the same gate would surface "model changed: claude-opus-4 → claude-sonnet-4-5" as a single appended row only when it's true — invisible on identical restarts, unmissable on actual changes. Preserves silent-when-healthy for stable fleets; delivers "change is obvious" (c8) when something shifted. Non-technical users see changes in the one place they already look. The UAT test's docstring explicitly acknowledges this floor-vs-vision split.
+
+Implementation boundary is tight. Config snapshot stores three fields (model slug, tools fingerprint, memory backend) at shutdown or gateway start, diffed on next boot. The boot card renderer already accepts a `resolvedRows` / degraded-rows model; config-diff is a new row type, not a new rendering mode.
+
+### Tradeoffs of the recommendation
+
+- Requires a config snapshot file written on each gateway boot. New disk dependency, small and consistent with `boot-issue-cache.json`.
+- Fingerprint stability requires care: model string format changes across releases could produce spurious "model changed" rows. Needs a normalizer (strip trailing version suffix, lowercase) like `normalizeDetail()`.
+- Tools fingerprint is harder than model. Full allowlist diff is genuinely useful; a hash that just says "tools changed" is noise. First version can hash the sorted allowlist and show "tools allowlist changed — run /status to see details" — honest without exhaustive.
+- The UAT scenario needs a strict variant: restart after config change, assert boot card contains the changed-field row. Current test relaxes to "agent replies with config signals when asked" — correct but not the proactive contract.
+- Memory backend change detection depends on which layer the gateway reads. If resolved at yaml load, straightforward. If resolved late, snapshot needs the resolved value.
+- No risk to "silent when healthy": row only appears when diff fires.
+
+### If you pick a different option
+
+- **Option A:** Restores deleted-in-#142 content unconditionally on every boot. The v0.4.0 changelog is explicit: the six-row checklist was "noise on the common path." Non-technical users will learn to scroll past, defeating c8's "obvious, not buried" requirement. Fails the "Defaults test" principle.
+- **Option B:** Requires rewriting the JTBD to remove or qualify "no need to ask," demoting the "config change restart" UAT prompt, and adding a "split design" note. Honest if the split is permanent — but the UAT test's own docstring says the proactive contract is the "vision target" with the relaxed test as "the floor." B forecloses future proactive delivery. Acceptable only if `/status` is the confirmed permanent home for config audit.
+
+### Open question for the operator
+
+Is "tools allowlist changed — run /status to see details" sufficient for a first cut of Option C, or does the operator want a granular diff row (e.g. "tools: added bash, removed computer") from day one? The granular form is more useful but requires serializing the allowlist at snapshot time, not just a hash.
+
+---
+
+## Escalation 4
+
+**ID:** jtbd-track-plan-quota-live:c2
+**Type:** outcome-not-realized
+**File:** `reference/track-plan-quota-live.md`
+**Evidence files:** `telegram-plugin/auth-dashboard.ts` L91-97, `telegram-plugin/auth-snapshot-format.ts` L60-70, `telegram-plugin/gateway/gateway.ts` L15980-15997
+
+**Claim:** "Approaching a cap produces a visible signal at a point where the user can still act on it."
+
+**Gap found:**
+The `/auth` dashboard shows a `[Fall back now]` button at 90% utilization and marks accounts as "near limit — watch this." However, this is reactive and requires the user to open `/auth`. There is no proactive Telegram push notification that fires as utilization climbs toward a cap. Auto-fallback triggers at 99.5%, which is after the limit has effectively been hit.
+
+**Decision required:**
+- (A) Add a proactive push: wire a utilization-threshold watcher that sends a Telegram notification when utilization crosses (e.g.) 80%. Implement and update the JTBD.
+- (B) Accept the reactive design: update the JTBD to describe the current design accurately (user polls `/auth` for approaching-cap signal; auto-fallback is reactive at 99.5%).
+- (C) Hybrid: document the existing `/auth` signal as the current answer and note the proactive push as a planned enhancement.
+
+## Recommendation — Escalation 4
+
+**Recommended option:** A
+**Confidence:** medium
+
+### Why
+
+The JTBD's "Signs it's working" includes "Approaching a cap produces a visible signal at a point where the user can still act on it," and anti-patterns explicitly name "Quota visible only in a separate dashboard or a command. If the user has to go looking, they won't, and they'll hit the wall." The current reactive design is a well-executed dashboard affordance but lives entirely inside `/auth`. A user not in the habit of checking `/auth` receives zero proactive signal until auto-fallback fires at 99.5% — effectively after the wall. Option B would mean rewriting the document's intent to match an acknowledged gap.
+
+The pattern for a proactive push already exists and is proven. `credits-watch.ts` (wired in gateway.ts L15975-15997) polls every 15 minutes, reads a local file, compares against persisted last-notified state, and calls `bot.api.sendMessage` on state transition. The same three-state machine (healthy → throttling → blocked) that `classifyHealth` already computes is exactly the input a quota-watch module needs. Extending requires: adding a broker probe call on a polling interval, tracking last-notified health per account. Broker infra (`client.probeQuota`), state-machine (`classifyHealth`), and notification routing all exist. Extension, not new invention.
+
+Noise risk on a multi-agent fleet is real but manageable. Three mitigations: (1) notify on transitions, not absolute level — only fire when health *changes* from healthy to throttling; (2) operators typically have 1-3 account slots, not 10+; (3) 15- or 30-min poll = at most one message per crossing per account. The "over-alerting" anti-pattern targets every-tick notifications, not edge-triggered.
+
+Practical sizing note: the right source is the broker's cached quota state from `list-state` (already computed for `/auth` render), not a fresh network probe per poll. Reading cached state keeps polling cheap and avoids burning API budget. Only trigger a live `probeQuota` when a state change is detected and fresh numbers are needed for the notification body.
+
+### Tradeoffs of the recommendation
+
+- The watcher adds a polling loop alongside credits-watch; both should share notification routing and state persistence patterns.
+- Broker-cache polling means notifications lag by however stale broker storage is. Staleness was already accepted for `/auth` render; acceptable here too.
+- Two accounts crossing 80% simultaneously yields two notifications within one poll cycle. Correct behavior — each account needs its own action.
+- Broker cached state only updates when an agent makes a request. Idle fleet may not trigger state-change push even at high utilization — pre-existing limitation of header-pull, not introduced.
+- Implementation cost ~25 agent minutes: new `quota-watch.ts` mirroring `credits-watch.ts`, wired into gateway boot, using `classifyHealth` and broker `list-state`.
+
+### If you pick a different option
+
+- **Option B:** Rewriting JTBD to accept reactive-only closes the audit finding without shipping value. Stakes section ("A user who hits a wall silently loses trust") becomes a known unfulfilled risk. Only appropriate if the operator decided dashboard affordance is sufficient.
+- **Option C:** Hybrid documents current state and notes proactive push as planned — reasonable if implementation capacity is constrained. Resolves the audit finding by making the gap intentional and tracked, without shipping incomplete code. Risk: "planned" items without a PR tend to stay planned. Use only with a concrete follow-up issue created at the same time.
+
+### Open question for the operator
+
+Should the proactive push be scoped to the *active* account only, or all accounts in the pool? Auto-fallback cares about the whole pool; the user typically acts by switching to an account with headroom — so a notification about a non-active account approaching its limit is also actionable. The credits-watch precedent fires per-agent; the new watcher would have access to all accounts and could choose either scope.
+
+---
+
+## Escalation 5
+
+**ID:** jtbd-track-plan-quota-live:c7
+**Type:** outcome-not-realized
+**File:** `reference/track-plan-quota-live.md`
+**Evidence files:** `telegram-plugin/credits-watch.ts` L116-123, `telegram-plugin/gateway/gateway.ts` L15986-15997, `src/auth/broker/server.ts` L103-105
+
+**Claim:** "When the window rolls, the user sees the recovery without having to refresh anything."
+
+**Gap found:**
+`credits-watch.ts` sends "credits restored" when the fatal-billing state clears (billing-credit-exhaustion case). However, for the normal rolling 5h/7d subscription window reset, there is no proactive Telegram notification that "your 5-hour quota has reset." The user would need to run `/usage` or wait for a boot card. The auth-broker's `exhausted_until` auto-expires, but there is no push-to-Telegram signal when the window rolls naturally.
+
+**Decision required:**
+- (A) Add a rolling-window reset notification: when the broker clears an exhausted-until expiry for the rolling window, send a Telegram push to the relevant agents. Implement and update the JTBD.
+- (B) Accept the current design: update the JTBD to note that fatal-billing recovery is pushed, but rolling-window reset recovery requires the user to check `/usage` or wait for the next boot card.
+- (C) Scope to fatal-billing only: explicitly narrow the JTBD claim to cover only credits-watch notifications, not rolling-window reset.
+
+## Recommendation — Escalation 5
+
+**Recommended option:** C (scope to fatal-billing only), with a JTBD wording tightening
+**Confidence:** high
+
+### Why
+
+The gap is real but the original framing overstates what "window rolls" means in practice. In normal operation — an agent that was never blocked — the 5-hour or 7-day window rolling over is a non-event: headroom increases passively and the boot card or `/usage` on next interaction shows updated numbers. There is no "recovery" to surface because the user was never stuck. A proactive notification here is noise, violating the anti-pattern "every small usage tick produces a notification until the user mutes the product."
+
+The case that matters: agent was blocked, original active account's window resets. That IS a recovery the user cares about. However, `credits-watch.ts` already covers the closest analogue (fatal-billing flag clears). The `exhausted_until` operates differently — passive timestamp comparison, not an event. There is no callback when it expires; the broker simply starts treating the account as healthy again on next `get-credentials`. Adding a proactive push would require a polling loop watching `exhausted_until` transitions, plus event routing — non-trivial plumbing with race conditions.
+
+Option B (accept with JTBD note) leaves the misleading "without having to refresh anything" wording intact, which will fail future audits. Option A is over-engineering: the typical fleet recovers naturally (agent retries, gets healthy creds, resumes) or the user already ran `/auth`. The boot card on next agent start carries fresh usage data. Option C is cleanest: narrow the claim to reflect what's implemented (fatal-billing push), reword rolling-window bullet to match real user flow (ambient recovery on next boot card / `/usage`, not push).
+
+Surgical JTBD edit: replace "When the window rolls, the user sees the recovery without having to refresh anything" with "When a fatal billing block clears, the user hears about it without having to ask. For routine quota refills, usage resets are visible on the next boot card or `/usage`." Honest about the two tiers; eliminates the false gap without noisy infrastructure.
+
+### Tradeoffs of the recommendation
+
+- Purely documentary: no code touched, no CI risk, no new plumbing.
+- The "was blocked, now unblocked due to window rollover" case remains non-pushed. In practice, when `exhausted_until` expires, auto-fallback (if triggered) had already swapped to a healthy account. Primary coming back healthy after 5h is quietly picked up on next `get-credentials`; next boot card confirms it.
+- The UAT prompt ("Let the window roll. The user should see usage free up without having to refresh") needs corresponding update, or UAT keeps flagging this. Scope into the same JTBD edit.
+- Accepts that `credits-watch.ts` recovery is the high-fidelity push signal, and rolling-window reset is ambient-tier. If the operator's mental model requires a push on every window reset, Option A is right — but it should have a deduplication gate (only push when previously exhausted).
+
+### If you pick a different option
+
+- **Option A:** Requires a poller watching `exhausted_until` timestamps, emitting IPC events on transition. Gateway routes to Telegram. Non-trivial: multi-account handling, agent-name→chat mapping, race-handling. ~30 agent-minutes + tests. Risk of spam on agents that were never blocked — gate on `prev.exhausted` state matching credits-watch pattern.
+- **Option B:** Adds a parenthetical note ("fatal-billing pushed; rolling-window appears on next boot card"). Lower-effort than A, but UAT prompt still says "without having to refresh anything," literally false for rolling-window. Expect recurrence in future audit.
+
+### Open question for the operator
+
+The JTBD's UAT prompt ("Let the window roll. The user should see usage free up without having to refresh") will fail any honest UAT run. Should this prompt be revised to "Check `/usage` after the window rolls — usage should reflect the reset" (ambient tier), or removed in favor of a UAT focused on fatal-billing recovery push?
+
+---
+
+## Escalation 6
+
+**ID:** rfc-sub-agent-visibility:c11
+**Type:** low-confidence drift (AC-4 stuck-render pipeline untraced)
+**File:** `reference/sub-agent-visibility-rfc.md`
+**Evidence files:** `telegram-plugin/fleet-state.ts` L133-137, `telegram-plugin/progress-card-driver.ts`
+
+**Claim (AC-4):** "If a fleet member emits no JSONL event for > 60s, its row glyph flips from ↻ to ⚠ with label `idle <duration>`."
+
+**Gap found (low confidence):**
+`fleet-state.ts:markStuck` exists and transitions a member to `stuck` status after 60s. However, `fleet-state.ts` is not imported by `progress-card-driver.ts` or the renderer. The stuck-detection to rendered-⚠ pipeline could not be traced end-to-end through code. `subagent-watcher.ts` has stall detection (`stallNotified`) but calls `onStallTerminal`, not a stuck-render path. AC-4 may be partially implemented at the state level but not yet connected to the renderer's header phase.
+
+**Decision required:**
+- (A) Confirm the wire exists: identify the production call path from `markStuck` to the rendered `⚠` glyph and document it in the RFC.
+- (B) Confirm AC-4 is not yet wired: update the RFC to note this AC is partially implemented (state exists, render not wired) and track as a follow-up.
+
+## Recommendation — Escalation 6
+
+**Recommended option:** B
+**Confidence:** high
+
+### Why
+
+The end-to-end trace is conclusive: `markStuck` in `fleet-state.ts` is dead production code. It is exported and tested in `tests/fleet-state.test.ts`, but no production file imports it or calls it. The only production import of `fleet-state.ts` is in `subagent-watcher.ts:44`, and it imports only `sanitiseToolArg` — not `markStuck`, `FleetStatus`, or any state-transition functions. `progress-card-driver.ts` does not import `fleet-state.ts` at all.
+
+AC-4 describes a per-fleet-member ↻→⚠ glyph flip with `idle <duration>` label. That requires `FleetMember.status` to reach `'stuck'` and a renderer to branch on that status. Neither happens. `FleetStatus` includes `'stuck'`, `markStuck` correctly transitions a member to it, but the renderer that produces the sub-agent zone (`renderSubAgent` in `progress-card.ts`) operates on `SubAgentState`, not `FleetMember`. `SubAgentState.state` is typed as `ItemState` (`'pending' | 'running' | 'done' | 'failed'`) — no `'stuck'` branch, no ⚠ glyph, no `idle <duration>` label.
+
+What IS wired is a different, coarser stall signal: the driver's heartbeat passes `stuckMs` (age of `cs.lastEventAt`) to card-level `render()` in `progress-card.ts`. When `stuckMs >= STUCK_THRESHOLD_MS` (2 min), the renderer inserts `⚠️ No events for <gap> — likely stuck.` as a header-level line. Card-wide warning, not per-fleet-member row glyph flipping. The `onStall` callback from `subagent-watcher.ts` routes to `progressDriver?.onSubAgentStall(...)` in `gateway.ts`, but `progressDriver` is permanently `null` (deleted in PR #1122 — see `gateway.ts:3046`), so those calls are no-ops.
+
+The RFC itself notes that `two-zone-card.ts` was the renderer for the AC-4 fleet zone, but that file no longer exists. The current renderer is `progress-card.ts` which has no per-member stuck-glyph path.
+
+AC-4 as specified has no production implementation. State model exists, render pipeline does not. Option B is correct.
+
+### Tradeoffs of the recommendation
+
+- Updating the RFC to mark AC-4 partially implemented (state exists, render absent) is honest and prevents future confusion.
+- The coarser card-level `stuckMs` warning provides *some* stuck signal (at 2 min, card-wide), so the user-facing gap is narrower than it appears — but not AC-4 as written.
+- `markStuck` should either be connected or removed; leaving as tested-but-unreachable dead code is a maintenance liability (tests give false confidence).
+- The `onStall` → `progressDriver?.onSubAgentStall(...)` call is also dead. If the progress driver is ever reinstated, gateway wire exists but the renderer-side branch would still need adding.
+
+### If you pick a different option
+
+- **Option A (confirm wire exists):** Not viable. The trace is exhaustive. `markStuck` is unreachable, `progressDriver` is null, `renderSubAgent` has no stuck branch. There is no wire to document.
+
+### Open question for the operator
+
+Should `markStuck` be removed from `fleet-state.ts` (and its tests) as dead code, or is the intent to connect it in a follow-up? Determines whether the RFC follow-up is "add the render branch" (connect it) or "remove the dead state function" (clean up).
+
+---
+
+## Escalation 7
+
+**ID:** rfc-sub-agent-visibility:c12
+**Type:** outcome gap (fleet cap unimplemented)
+**File:** `reference/sub-agent-visibility-rfc.md`
+**Evidence files:** `telegram-plugin/fleet-state.ts` L157-163, `telegram-plugin/progress-card.ts` L929-943
+
+**Claim (AC-5):** "6+ parallel sub-agents — render output is balanced HTML, < 4096 bytes, fleet zone caps at 5 rows + '+ N more'."
+
+**Gap found:**
+The fleet renderer (`progress-card.ts` L929-943) iterates ALL sub-agents with no row cap. The `cap()` function (`fleet-state.ts` L157-163) caps at 5 + hidden count but is not imported or called by the renderer. The "N more" footer does not exist in the renderer output. For a fleet of 6+ sub-agents, the card will render all rows with no cap, potentially exceeding the 4096-byte Telegram message limit.
+
+**Decision required:**
+- (A) Implement the cap: import `cap()` from `fleet-state.ts` in the renderer and apply it with a "+ N more" footer row. Update the RFC after implementing.
+- (B) Remove the cap spec: if the renderer is intentionally uncapped (all rows visible), update AC-5 to remove the cap requirement and note that HTML safety is ensured by truncation elsewhere.
+
+## Recommendation — Escalation 7
+
+**Recommended option:** B
+**Confidence:** high
+
+### Why
+
+The fleet renderer at `progress-card.ts` L929-943 is not currently reachable in production. The pinned progress-card driver (`progress-card-driver.ts`) was removed from the gateway in PR #1122 PR3 — `progressDriver` is permanently `null` in `telegram-plugin/gateway/gateway.ts` (L3046), making every `progressDriver?.X` call a no-op at runtime. The `progress-card.ts` module is still imported by `progress-card-driver.ts`, but that driver is never loaded by the gateway. The fleet-zone renderer loop is dead code.
+
+More importantly, the RFC itself already declares the card model superseded. The preamble (L25-33): "Card model superseded. This RFC reasons about the two-zone progress-card model. That two-zone design has since been superseded by `reference/conversational-pacing.md`, and `reference/status-card-design.md` is archived." AC-5's cap requirement was written for a design that no longer drives the live product. The current Telegram-facing surface is conversational pacing, not the two-zone pinned card.
+
+There is no meaningful 4096-byte risk to defend against today. `stream-reply-handler.ts` (L395-400) enforces a hard 4096-char pre-check on `stream_reply` calls, and `answer-stream.ts` (L49) tracks the same constant — but those guard the conversational-pacing path, which does not use the uncapped fleet renderer. The `cap()` function exists, is correct, and exported, but the one callsite that would matter is unreachable.
+
+Wiring Option A — importing `cap()` into a renderer that isn't live — would cost little but achieve nothing and leave reviewers confused. Correct fix: update AC-5 in the RFC to reflect reality. Remove the cap requirement, note the two-zone card was retired in PR #1122, point to `conversational-pacing.md` as the live contract. If the project revives a pinned fleet card under conversational-pacing later, the cap requirement should be written fresh.
+
+### Tradeoffs of the recommendation
+
+- Removing AC-5 from a closed RFC is low-risk: status is already "SHIPPED / CLOSED" and the doc flags the card model as superseded.
+- The `cap()` function remains in place and can be picked up cheaply if a future fleet renderer is ever written — no deletion needed.
+- No user-visible regression from Option B: the uncapped renderer cannot produce a 4096-byte overrun because it isn't called.
+- Leaving the spec as-is keeps misleading future auditors (and this audit system) about an unfulfilled gap in active code.
+
+### If you pick a different option
+
+- **Option A:** Import `cap()` into `progress-card.ts` fleet section and add a `+ N more` footer. Correct if you plan to re-activate the progress-card driver. Doing it without re-activating still leaves the loop unreachable and creates well-maintained dead code. If you go this route, also re-wire `progress-card-driver.ts` into the gateway and write the UAT scenario (`bg-heavy-fleet-dm.test.ts`) the RFC called for in Phase 3.
+
+### Open question for the operator
+
+Is there an active plan to revive the pinned progress-card (two-zone or otherwise) under the conversational-pacing architecture? If yes, Option A makes sense as prep work paired with re-activating the driver. If no, close AC-5 with a note and let `cap()` sit ready for future use.
+
+---
+
+## Escalation 8
+
+**ID:** jtbd-run-a-fleet-of-specialists:c9
+**Type:** outcome gap (Hindsight memory not purged on destroy)
+**File:** `reference/run-a-fleet-of-specialists.md`
+**Evidence files:** `src/cli/agent.ts` L1931-1979
+
+**Claim:** "Removing an agent is clean. Its memory, its state, its scheduled work all go with it, with no orphaned processes or dangling config."
+
+**Gap found:**
+`switchroom agent destroy` removes the agent directory and stops the container. The config entry removal (which kills the compose service on next apply) cleans up the scheduled work. However, the Hindsight memory bank (stored in the hindsight container's database) is NOT deleted by `agent destroy` — no code in `src/cli/agent.ts` or `src/agents/scaffold.ts` calls hindsight to drop the bank. Memory data orphans in the hindsight service.
+
+**Decision required:**
+- (A) Wire memory purge: add a `hindsight delete-bank --collection <agentName>` call (or equivalent) to the `agent destroy` flow. Update the JTBD after implementing.
+- (B) Accept the gap: update the JTBD to note that Hindsight memory must be purged manually after `agent destroy` (e.g., `hindsight delete-bank --collection <name>`). Document the purge command.
+- (C) Soft delete: mark the collection as archived rather than purging, with a separate cleanup command for operators who want to reclaim storage.
+
+## Recommendation — Escalation 8
+
+**Recommended option:** B
+**Confidence:** high
+
+### Why
+
+The core question is whether an orphaned Hindsight bank is a leak or a recovery feature. The answer is: it is a recovery feature in disguise, and that changes the calculus.
+
+The `bankId` for any agent is derived as `agentMemory?.collection ?? agentName` (see `src/agents/scaffold.ts:1613` and `src/memory/hindsight.ts:76`). When no explicit `memory.collection` override is set — the default for every agent — the bank ID is the agent name. `createBank` in scaffold.ts (line 2896) is explicitly documented as idempotent: "calling this on an already-existing bank is a no-op and returns success" (`src/memory/hindsight.ts:392-394`). This means if an agent named `clerk` is destroyed and re-created with the same name, its first scaffold run calls `createBank("clerk")`, Hindsight recognizes the existing bank, and the agent silently resumes with its full memory history. The orphaned bank was a restoration point, not waste.
+
+This re-attach is architecturally desirable. Accidental destroys, name collisions after reconfiguration, fleet rebuilds — all benefit from memory persistence in the backing store. The JTBD claim "no orphaned processes or dangling config" is about processes and config, not persistent data. The wording does not promise data erasure, only operational cleanliness. Interpreting it to mandate automatic bank deletion would be wrong — the analogous expectation would be that destroying a database-backed service should DROP the schema, which is almost never correct.
+
+Practical blocker for Option A: neither the vendored `HindsightClient` (`vendor/hindsight-memory/scripts/lib/client.py`) nor switchroom Hindsight bindings (`src/memory/hindsight.ts`) expose a `delete_bank` call. No `DELETE /banks/{id}` call exists anywhere in the repo. Whether Hindsight's upstream REST API even exposes bank deletion is unconfirmed. Wiring Option A would require: confirming the upstream API supports deletion, adding `deleteBank` to bindings, calling it in destroy flow, handling the case where Hindsight is unreachable at destroy time. The failure mode where destroy aborts because Hindsight is offline is strictly worse UX than current silent orphan.
+
+### Tradeoffs of the recommendation
+
+- Operators who destroy an agent permanently and never re-create it accumulate storage in the Hindsight database with no self-service cleanup path. On a fleet that cycles agents regularly, this compounds.
+- The current `mcp__hindsight__delete_memory` tool (available to agents in-session) only deletes individual memories, not the whole bank. Operators have no single-command purge path today.
+- Updating the JTBD claim to be accurate about Hindsight persistence is low-risk, takes 1-2 lines.
+- Option B does not preclude adding a `switchroom agent destroy --purge-memory` flag in a later PR once the upstream delete API is confirmed.
+
+### If you pick a different option
+
+- **Option A:** Wire memory purge in destroy flow. Before implementing, confirm that `DELETE /v1/default/banks/{bank_id}` exists in the Hindsight REST API — absent from the vendored client. If it exists, add `deleteBank()`, call it after `rmSync`, handle offline gracefully (warn, don't block destroy). If `bankId` was overridden via `memory.collection`, destroying the wrong name is possible — read config before removing agent directory. Risk: breaks re-attach recovery; accidental destroy loses memory permanently.
+- **Option C:** Soft-delete/archive. Requires Hindsight archival state (unconfirmed), adds a separate cleanup command, two-phase delete UX operators will find confusing. Adds complexity with limited benefit over Option B + future `--purge-memory` flag.
+
+### Open question for the operator
+
+Does Hindsight's REST API expose a bank deletion endpoint (`DELETE /v1/default/banks/{id}`)? This single fact determines whether Option A is even wirable, and should be confirmed before any implementation work.
+
+---
+
+## Escalation 9
+
+**ID:** jtbd-feel-like-a-colleague:c9
+**Type:** vision-only, low confidence (AI non-detectability)
+**File:** `reference/feel-like-a-colleague.md`
+**Evidence files:** `profiles/default/workspace/SOUL.md.hbs` L41-51
+
+**Claim:** "A non-technical user can't immediately tell they're talking to an AI from the first ten messages. They can tell it's not a person they've met before, but the shape of the conversation feels human."
+
+**Assessment:**
+This is not verifiable from the codebase. The prompt engineering and AI-tell bans aim at this outcome, but whether it is actually achieved requires user testing. This is a goal/outcome statement, not an implementable behavior. The JTBD should either flag it as a success criterion (not a current state claim) or acknowledge it's an aspirational target.
+
+**Decision required:**
+- (A) Mark as aspirational: add a hedge to the claim — "(target, not yet systematically verified via user testing)."
+- (B) Remove the claim: it cannot be verified from code; leave only the prompt engineering claims that CAN be verified.
+- (C) Accept as-is: treat it as a product vision statement, not a verifiable claim; no action needed.
+
+## Recommendation — Escalation 9
+
+**Recommended option:** C
+**Confidence:** high
+
+### Why
+
+The JTBD format in this codebase is explicitly outcome-focused, not test-result-focused. The README for `reference/` describes JTBDs as answering "Did it do the user's job?" — a design target, not a passing test suite. Scanning "Signs it's working" across all JTBDs confirms: they are written in the present tense as outcome descriptions, not verified state. `run-a-fleet-of-specialists.md` says "The user never has to prefix a message with 'as my coding agent'"; `remember-across-sessions.md` says "A restart doesn't reset the relationship." Neither is instrumented. The entire format is aspirational-but-precise: tells builders what success looks like.
+
+The c9 claim sits inside that consistent pattern. The section header "Signs it's working" already signals that role. Adding a hedge would be inconsistent with how every other JTBD is written, and would implicitly suggest other "Signs" entries are verified — they are not.
+
+The claim is also load-bearing in the right way. `vision.md` calls out the non-technical principal explicitly: "The bar: one even a non-technical partner likes." The c9 claim is precisely what that bar means in behavioral terms. Softening dilutes the sharpest user-facing success criterion. The claim is not a marketing assertion outside a design document; it's a design criterion inside one, and that context is the correct frame.
+
+The SOUL.md AI-tell bans (L41-51) are verifiable engineering affordances implementing this criterion. The criterion itself remains correctly at the outcome layer. Removing (Option B) would leave the implementation affordances with no stated purpose. Hedging (Option A) would add noise that no other JTBD carries, signalling incorrectly that the JTBD format admits only verified claims.
+
+### Tradeoffs of the recommendation
+
+- The claim cannot be falsified from the codebase alone — a real epistemic gap, but the same gap exists for every "Signs it's working" bullet across all JTBDs. Treating c9 differently would require auditing all of them — a larger separate question about the JTBD format itself.
+- Accepting as-is means the design contract contains an outcome only user research can validate. Appropriate for a design contract; inappropriate in a test report or release checklist.
+- The UAT prompts section of the same JTBD (L119-144) already provides a partial proxy: the "AI-tell sweep" is code-reviewable and behavioral prompts are manually testable. Outcome is closer to measurable than it appears; just needs a human in the loop.
+
+### If you pick a different option
+
+- **Option A:** Adding "(target, not yet systematically verified via user testing)" reads as an admission that other "Signs it's working" bullets are verified, which they are not. Creates inconsistency across JTBDs and invites a wave of similar hedges. The actual fix, if hedging is wanted, is a format-level note in `reference/README.md` — a much broader change.
+- **Option B:** Removing leaves the JTBD without a human-perceivable success criterion at the outcome level. The remaining signs are intermediate indicators; c9 is the only one naming the actual user experience targeted. Removal makes the JTBD harder to use as a design gate.
+
+### Open question for the operator
+
+If you want to distinguish measurable "Signs" from aspirational ones across all JTBDs consistently, the right lever is a format note in `reference/README.md`, not individual hedges. Is that a change worth making as a separate pass?
+
+---
+
+## Escalation 10
+
+**ID:** jtbd-give-each-agent-its-own-workspace:c7, c8, c11 (vision-only cluster)
+**Type:** vision-only (fast-forward, dirty-tree, sub-agent nesting not end-to-end)
+**File:** `reference/give-each-agent-its-own-workspace.md`
+**Evidence files:** `src/repos/agent-worktree.ts` L209-238, L196-208
+
+**Claims (vision-only):**
+- c7: "Fast-forwarded to `upstream/main` on session start when the worktree is clean."
+- c8: "Dirty-tree policy: leave alone, warn. If the worktree has uncommitted changes at session start, the ff-to-main step is skipped. The session resumes on whatever branch the worktree was on. The boot card surfaces `<repo>: dirty since <ts>` as a one-line warning."
+- c11 (from workspace JTBD): Sub-agent nesting in worktrees end-to-end.
+
+**Assessment:**
+The infrastructure exists in `agent-worktree.ts` (fast-forward logic, dirty-tree detection) but is not callable from any production path (see Escalation 2). Until Escalation 2 is resolved, these vision-only claims cannot be tested. They should be deferred until the provisioning wiring ships.
+
+**Decision required:**
+These are tied to Escalation 2. Resolve Escalation 2 first; these vision-only claims will either become verifiable or get updated to reflect the reality after the wiring decision.
+
+## Recommendation — Escalation 10
+
+**Recommended option:** Defer-to-Escalation-2 — mirror its resolution exactly, with one always-on action: mark the boot-card "dirty since <ts>" sub-claim of c8 as separately unimplemented regardless of Escalation 2's outcome.
+**Confidence:** high
+
+### Why
+
+**On c7 (fast-forward on clean session start):** ff logic is fully implemented in `src/repos/agent-worktree.ts` L210-238. On clean worktree, `ensureAgentWorktree` runs `git fetch origin` then `git merge --ff-only origin/<defaultBranch>` and logs to stderr. Implementation is correct and complete. But `ensureAgentWorktree` is imported but never called from `scaffold.ts` or any production reconcile path. The ff-to-main never executes on session start. Implemented but unwired. If Escalation 2 = A, c7 becomes testable post-wiring. If Esc2 = B, c7 must also be removed. If Esc2 = C, c7 should receive the same "not wired" disclaimer.
+
+**On c8 (dirty-tree policy):** "Leave alone" half is fully implemented at L196-208: `isWorktreeDirty` detects via `git status --porcelain`, and on dirty detection `ensureAgentWorktree` returns `{ dirty: true, dirtyCommit: sha }` without touching the worktree. The "boot card surfaces `<repo>: dirty since <ts>` as a one-line warning" sub-claim is **not** implemented. Review of `telegram-plugin/gateway/boot-card.ts` shows `RenderBootCardOpts` has no `worktrees` or `dirtyWorktrees` field, `renderBootCard` renders no such row, `runAllProbes` has no worktree probe, and `ProbeKey` has no `repos` or `worktrees` entry. The `WorktreeState.dirtyCommit` field exists but is never consumed by any caller outside agent-worktree.ts itself. Boot-card surface is entirely absent. The "leave alone" half follows Esc2's resolution; the "boot card surfaces" half needs its own disclaimer or implementation work regardless.
+
+**On c11 (sub-agent nesting in worktrees end-to-end):** JTBD text at L40-43 and L111-114 states sub-agents dispatched from inside an agent's worktree create their own nested worktree off the parent's HEAD, "exactly as today." Code search finds no implementation — no `ensureSubAgentWorktree`, no "parent HEAD" resolution, no sub-agent worktree dispatch path. Vision-only independently of Esc2: even if Esc2 = A wires main-agent provisioning, sub-agent nesting requires additional implementation. Under Esc2 = A, c11 should be flagged as "next step after c2/c3 provisioning ships." Under Esc2 = B or C, c11 should also be removed or disclaimed.
+
+The independent always-on action: the boot-card "dirty since <ts>" sub-claim of c8 should be disclaimed regardless of Esc2.
+
+### Tradeoffs of the recommendation
+
+- Deferring to Escalation 2 keeps c7 and "leave alone" of c8 in sync with the provisioning decision, avoiding divergent audit trail.
+- Calling out boot-card "dirty since <ts>" independently is correct — it is a separate implementation surface (probe + renderer) even if provisioning ships.
+- Flagging c11 as separately unimplemented is independently justified: sub-agent nesting is further out than main-agent provisioning regardless of Esc2.
+- Produces three distinct outcomes for three claims rather than uniform treatment — adds audit complexity but accurately reflects three genuinely different implementation states.
+
+### If you pick a different option
+
+- **Treat all three as one cluster and follow Esc2 uniformly:** Simpler audit trail, but leaves boot-card gap and sub-agent nesting gap undisclaimed if Esc2 = A. Operator reading the JTBD after wiring would see c8's boot-card claim and c11's nesting claim as verified when neither was tested.
+- **Mark all three vision-only independently of Esc2:** Defensively correct today. Risk: if Esc2 = A ships quickly, creates churn re-verifying and re-clearing c7 and "leave alone" of c8 separately from the provisioning PR.
+
+### Open question for the operator
+
+The "dirty since <ts>" timestamp in c8's boot-card warning requires knowing when the worktree first became dirty (not just that it is dirty now) — `WorktreeState.dirtyCommit` captures HEAD SHA but not a wall-clock timestamp. Should this sub-claim be revised in the JTBD to "dirty at <sha>" (which current implementation could surface) instead of "dirty since <ts>" (which would require new dirty-timestamp tracking)?

--- a/audit/2026-05-26/findings/archived-status-card-design.yaml
+++ b/audit/2026-05-26/findings/archived-status-card-design.yaml
@@ -1,0 +1,97 @@
+unit_id: archived-status-card-design
+unit_path: reference/status-card-design.md
+category: archived
+audited_at: 2026-05-26T00:00:00Z
+auditor_notes: |
+  The file is a 6-line stub with correct archived frontmatter
+  (status: archived — superseded, supersededBy: conversational-pacing.md).
+  Three external referrers were found:
+
+  1. CHANGELOG.md:6025 — historical release entry. Treats as history, not current.
+  2. reference/sub-agent-visibility-rfc.md — multiple lines. The RFC itself
+     carries a prominent "Card model superseded" callout box (L25-33) explicitly
+     directing readers to conversational-pacing.md. Not treating it as current.
+  3. telegram-plugin/uat/assertions.ts:343 — inline JSDoc comment citing
+     "status-card-design.md §Header" as the source for emoji marker semantics.
+     The comment also references "telegram-plugin/progress-card.ts" which does
+     NOT exist. This comment reads as though the archived doc is the authority
+     on current card-phase markers, and points to a non-existent source file.
+     This is the only referrer that may mislead a reader.
+
+  conversational-pacing.md exists at reference/conversational-pacing.md.
+  The supersession target is valid.
+
+findings:
+  - claim_id: c1
+    quote: "The pinned two-zone progress card was retired in #1122 (PR3, 2026-05-12) in favour of conversational pacing + a silence-poke safety net."
+    loc: L9-L11
+    verdict: aligned
+    evidence:
+      - path: reference/conversational-pacing.md
+        lines: L1-L1
+        snippet: "file exists, is the live design contract"
+      - path: reference/sub-agent-visibility-rfc.md
+        lines: L25-L33
+        snippet: "Card model superseded. This RFC reasons about the two-zone progress-card model from reference/status-card-design.md. That two-zone design has since been superseded by reference/conversational-pacing.md, and reference/status-card-design.md is archived."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The supersession claim is corroborated by the existence of
+      conversational-pacing.md and the explicit callout in
+      sub-agent-visibility-rfc.md. PR #1122 was not independently verified
+      (no git tag or test reference checked), so confidence stays medium.
+
+  - claim_id: c2
+    quote: "See conversational-pacing.md for the design contract that replaces it."
+    loc: L11-L12
+    verdict: aligned
+    evidence:
+      - path: reference/conversational-pacing.md
+        lines: L1-L1
+        snippet: "file exists at reference/conversational-pacing.md"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The target file exists. The link is valid.
+
+  - claim_id: c3
+    quote: "This stub is kept so historical links resolve; the v2 spec lived here."
+    loc: L14-L14
+    verdict: aligned
+    evidence:
+      - path: CHANGELOG.md
+        lines: L6025-L6026
+        snippet: "design doc at reference/status-card-design.md (#661, #667)"
+      - path: reference/sub-agent-visibility-rfc.md
+        lines: L4-L4
+        snippet: "supersedes: nothing (extends reference/status-card-design.md with TDD verification)"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      At least two historical documents link to this path. Keeping the stub
+      so those links resolve is the stated purpose and it is served.
+
+  - claim_id: c4
+    quote: "(implicit) telegram-plugin/uat/assertions.ts cites status-card-design.md §Header as the authority for current emoji phase markers"
+    loc: L1-L5
+    verdict: archive-leaks
+    evidence:
+      - path: telegram-plugin/uat/assertions.ts
+        lines: L343-L343
+        snippet: "fleet still running, see #862 / status-card-design.md §Header"
+    evidence_strength: medium
+    action: fix-referrer
+    confidence: medium
+    rationale: |
+      The JSDoc in assertions.ts:343 directs readers to "status-card-design.md
+      §Header" for the emoji marker spec. That section no longer exists — the
+      file is a 6-line stub with no §Header section — and the referenced
+      progress-card.ts implementation file also does not exist. The comment
+      treats the archived doc as the authoritative source for live card-phase
+      detection semantics rather than conversational-pacing.md or the actual
+      current implementation. Fix is in assertions.ts:343: update the citation
+      to reference conversational-pacing.md (or the current card implementation)
+      instead of the archived file.

--- a/audit/2026-05-26/findings/artefact-conversational-pacing.yaml
+++ b/audit/2026-05-26/findings/artefact-conversational-pacing.yaml
@@ -1,0 +1,277 @@
+unit_id: artefact-conversational-pacing
+unit_path: reference/conversational-pacing.md
+category: artefact-current
+audited_at: 2026-05-26T20:00:00Z
+auditor_notes: |
+  Two substantive findings:
+
+  1. The reaction emoji sequence `👀→🤔→🔥→👍` is stated in both the artefact
+     (L28) and `profiles/_shared/telegram-style.md.hbs` (L20). The code
+     (`telegram-plugin/status-reactions.ts` L71) explicitly reserves 🔥 for
+     genuine 5xx server errors via `operator-events.ts` and keeps it OUT of the
+     normal lifecycle. The working-state emoji for active tool use is `✍` (the
+     `tool`/`coding`/`web` states). The artefact and the agent prompt template
+     are both wrong on this point.
+
+  2. The Ambient layer implementation pointer cites `gateway.ts:startTypingLoop`
+     as the turn-long typing indicator. The function that owns the turn-level
+     typing loop (started at turn-start, stopped by `purgeReactionTracking`) is
+     `startTurnTypingLoop` — a separate function and a separate interval map
+     (`turnTypingIntervals`). `startTypingLoop` is the reply-handler and
+     typing-wrapper function that mid-turn replies stop freely. This is a minor
+     pointer error in the table.
+
+  The five-beat model, silence-poke ladder thresholds, state struct fields
+  (except the omission of `inFlightTools`), subagent-dispatch override, thinking
+  detection, kill switch, KPI event names, PostHog dashboard name, PostToolUse
+  synthesis nudge for foreground subagents, and background `subagent_handback`
+  channel are all verified against the implementation.
+
+findings:
+  - claim_id: c1
+    quote: "The 👀→🤔→🔥→👍 status reaction on the user's inbound message and a continuous `typing…` chat-action held for the whole turn"
+    loc: L28
+    verdict: drift-major
+    evidence:
+      - path: telegram-plugin/status-reactions.ts
+        lines: L49-L85
+        snippet: "🔥 is reserved for genuine 5xx server errors (operator-events.ts). It reads as 'on fire / broken' — keep it out of normal active-work states. ... tool: ['✍', '⚡', '👌'], coding: ['👨‍💻', '✍', '⚡'], web: ['⚡', '🤔', '👌']"
+      - path: profiles/_shared/telegram-style.md.hbs
+        lines: L20
+        snippet: "The 👀→🤔→🔥→👍 status reaction and the typing indicator are ambient liveness"
+    evidence_strength: strong
+    action: update-text
+    proposed_text: |
+      Replace `👀→🤔→🔥→👍` with `👀→🤔→✍→👍` in the artefact table (L28).
+      The working state is `✍` (from the `tool`/`coding`/`web` reaction states);
+      🔥 is reserved for 5xx server errors in `operator-events.ts` and never
+      appears in a normal turn. The same fix is needed in
+      `profiles/_shared/telegram-style.md.hbs` L20.
+    confidence: high
+    rationale: |
+      `status-reactions.ts` L71 explicitly states "🔥 is reserved for genuine
+      5xx server errors (operator-events.ts). It reads as 'on fire / broken' —
+      keep it out of normal active-work states." The `REACTION_VARIANTS` map
+      confirms the working states (`tool`, `coding`, `web`) map to `✍`/`⚡`/
+      `👨‍💻`. The same wrong sequence `👀→🤔→🔥→👍` also appears in
+      `profiles/_shared/telegram-style.md.hbs` L20 — the agent prompt that
+      teaches this to the model — so it is misinforming the model about the
+      reaction lifecycle as well.
+
+  - claim_id: c2
+    quote: "`telegram-plugin/status-reactions.ts` + `gateway.ts:startTypingLoop` (started at turn-start, stopped by `purgeReactionTracking`)"
+    loc: L28
+    verdict: drift-minor
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L1936-L1960
+        snippet: "Turn-level `typing…` indicator. Deliberately a SEPARATE interval map from `typingIntervals`... only `stopTurnTypingLoop` (called at the canonical turn-end) clears it... function startTurnTypingLoop(chat_id: string): void"
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L8734-L8743
+        snippet: "startTurnTypingLoop(chat_id)"
+    evidence_strength: strong
+    action: update-text
+    proposed_text: |
+      Change `gateway.ts:startTypingLoop` to `gateway.ts:startTurnTypingLoop`
+      in the Ambient row of the Three Layers table. The turn-level typing loop
+      (started at turn-start, stopped by `purgeReactionTracking`) is managed by
+      `startTurnTypingLoop` / `stopTurnTypingLoop` using a dedicated
+      `turnTypingIntervals` map. `startTypingLoop` is the reply-handler and
+      typing-wrapper function that mid-turn replies freely start and stop.
+    confidence: high
+    rationale: |
+      `gateway.ts` L1936-1944 documents the deliberate separation: a dedicated
+      `turnTypingIntervals` map is immune to mid-turn `stopTypingLoop` calls
+      because only `stopTurnTypingLoop` (called from `purgeReactionTracking`
+      L1360) clears it. The turn-start callsite at L8743 calls
+      `startTurnTypingLoop`. The name `startTypingLoop` in the artefact points
+      at the wrong function.
+
+  - claim_id: c3
+    quote: "Five beats: 1. Acknowledge first... 2. Go quiet and work... 3. Surface meaningful progress... 4. Hand back delegations with synthesis... 5. Deliver the answer"
+    loc: L40-L69
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L110-L145
+        snippet: "TELEGRAM_GUIDANCE constant listing all five beats verbatim, injected into every agent's CLAUDE.md"
+      - path: profiles/_shared/telegram-style.md.hbs
+        lines: L7-L13
+        snippet: "Five beats: 1 Acknowledge first... 2 Then go quiet... 3 Surface meaningful progress... 4 Hand back delegations... 5 Deliver the answer"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The five-beat model is implemented in two places: the `TELEGRAM_GUIDANCE`
+      TypeScript constant in `scaffold.ts` (L110-145) which is baked into every
+      agent's CLAUDE.md, and `profiles/_shared/telegram-style.md.hbs` which is
+      the hbs template. Both match the artefact description in structure and
+      substance.
+
+  - claim_id: c4
+    quote: "A PostToolUse hook nudges the synthesis; a *background* worker finishes after the turn ends, so the gateway wakes the agent with a `<channel source=\"subagent_handback\">` turn"
+    loc: L63-L66
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/hooks/subagent-tracker-posttool.mjs
+        lines: L253-L302
+        snippet: "emitForegroundHandbackNudge() — Beat 4 of conversational pacing. A foreground sub-agent's PostToolUse fires at real completion, mid-parent-turn, with its result in tool_response — nudge the parent to synthesise a user-facing handback."
+      - path: telegram-plugin/gateway/subagent-handback-inbound-builder.ts
+        lines: L1-L30
+        snippet: "Pure builder for the synthetic `subagent_handback` inbound the gateway wakes... wraps it as `<channel source=\"subagent_handback\">`"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Both halves of beat 4 are implemented. Foreground half: `subagent-tracker-
+      posttool.mjs` L286-302 emits a `hookSpecificOutput.additionalContext` nudge
+      at PostToolUse when the subagent completes and is not a background agent.
+      Background half: `subagent-handback-inbound-builder.ts` builds the synthetic
+      `<channel source="subagent_handback">` turn the gateway injects.
+
+  - claim_id: c5
+    quote: "Silence-poke ladder: 10s ack, 75s soft, 180s firm, 300s fallback. Polled every 5s."
+    loc: L86-L89
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L113-L122
+        snippet: "export const DEFAULT_THRESHOLDS: ThresholdsMs = { ack: 10_000, soft: 75_000, firm: 180_000, fallback: 300_000, subagentSoft: 300_000, pokeSuccessWindowMs: 15_000 }"
+      - path: telegram-plugin/silence-poke.ts
+        lines: L122
+        snippet: "export const DEFAULT_POLL_INTERVAL_MS = 5_000"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      `DEFAULT_THRESHOLDS` in `silence-poke.ts` matches every threshold in the
+      artefact exactly. `DEFAULT_POLL_INTERVAL_MS = 5_000` confirms the 5s poll
+      interval. No discrepancy.
+
+  - claim_id: c6
+    quote: "State per-turn: `{ turnStartedAt, lastOutboundAt, pokesFired, pokeArmed, ackPokeFired, subagentDispatchActive, lastThinkingAt, fallbackFired, lastPokeFiredAt }`"
+    loc: L80-L81
+    verdict: drift-minor
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L64-L95
+        snippet: "export interface SilencePokeState { turnStartedAt, lastOutboundAt, pokesFired, pokeArmed, subagentDispatchActive, lastThinkingAt, fallbackFired, ackPokeFired, lastPokeFiredAt, inFlightTools: Map<string, {...}> }"
+    evidence_strength: strong
+    action: update-text
+    proposed_text: |
+      Add `inFlightTools` to the state struct listing: `{ turnStartedAt,
+      lastOutboundAt, pokesFired, pokeArmed, ackPokeFired, subagentDispatchActive,
+      lastThinkingAt, fallbackFired, lastPokeFiredAt, inFlightTools }`. This field
+      was added in issue #1292 to power the tool-aware fallback message wording.
+    confidence: high
+    rationale: |
+      `SilencePokeState` in `silence-poke.ts` L64-95 has all the fields listed
+      in the artefact plus `inFlightTools: Map<string, { name, startedAt, label }>`,
+      added in issue #1292 for the tool-aware 300s fallback message. The artefact's
+      state listing is accurate but incomplete; it omits this field.
+
+  - claim_id: c7
+    quote: "Subagent-dispatch override: when the session stream emits a `tool_use` for `Task` or `Agent`, the soft threshold extends to 300s for that turn"
+    loc: L103-L108
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L97-L110
+        snippet: "subagentSoft: number — Soft threshold when subagentDispatchActive=true. ... subagentSoft: 300_000"
+      - path: telegram-plugin/silence-poke.ts
+        lines: L456-L460
+        snippet: "const softThreshold = s.subagentDispatchActive ? thresholds.subagentSoft : thresholds.soft"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      `DEFAULT_THRESHOLDS.subagentSoft = 300_000` and the `tick()` function at
+      L456-460 selects the extended threshold when `subagentDispatchActive` is
+      true. The flag-persistence-on-outbound behavior (not cleared on outbound,
+      only on `endTurn`) is also confirmed at `noteOutbound` L224-229.
+
+  - claim_id: c8
+    quote: "Thinking detection: session stream `kind: 'thinking'` events update `lastThinkingAt`. If the framework fallback fires within 30s of a thinking event, wording switches to 'still thinking…'."
+    loc: L111-L112
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L516-L522
+        snippet: "const recentThinking = s.lastThinkingAt != null && (now - s.lastThinkingAt) < 30_000; const fallbackKind: 'working' | 'thinking' = recentThinking ? 'thinking' : 'working'"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      `tick()` at L516-522 in `silence-poke.ts` implements the exact 30s window
+      check and `fallbackKind` selection described. `noteThinking()` at L251-255
+      updates `lastThinkingAt` from calling code.
+
+  - claim_id: c9
+    quote: "Kill switch: `SWITCHROOM_DISABLE_SILENCE_POKE=1` disables the whole subsystem."
+    loc: L124-L126
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L172-L175
+        snippet: "export function silencePokeEnabled(): boolean { const v = process.env.SWITCHROOM_DISABLE_SILENCE_POKE; return !(v === '1' || v === 'true') }"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      `silencePokeEnabled()` in `silence-poke.ts` checks the env var. `startTurn`
+      and `startTimer` both short-circuit on `!silencePokeEnabled()`. Matches
+      the artefact description exactly.
+
+  - claim_id: c10
+    quote: "KPIs: Status-query rate (`inbound_status_query`), Outbound silence p95 (`turn_ended.longest_silent_gap_ms`), TTFO p95 (`turn_ended.ttfo_ms`), Silence-poke success rate (`silence_poke_succeeded / silence_poke_fired`), Framework fallback rate (`silence_fallback_sent / turn_ended`)"
+    loc: L133-L139
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/runtime-metrics.ts
+        lines: L29-L106
+        snippet: "kind: 'inbound_status_query' ... kind: 'turn_ended' ... ttfo_ms, longest_silent_gap_ms ... kind: 'silence_poke_fired' ... kind: 'silence_poke_succeeded' ... kind: 'silence_fallback_sent'"
+      - path: docs/posthog.md
+        lines: L68-L99
+        snippet: "Switchroom Runtime dashboard ... turn_ended.longest_silent_gap_ms ... turn_ended.ttfo_ms"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      All five KPI event names match exactly between the artefact and
+      `runtime-metrics.ts`. The `Switchroom Runtime` dashboard name is confirmed
+      in `docs/posthog.md` L68.
+
+  - claim_id: c11
+    quote: "Armed pending drain on the next tool result, or null... `silence-poke.ts → consumeArmedPoke()` drained at `gateway.ts:onToolCall` chokepoint"
+    loc: L87
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L3764-L3773
+        snippet: "async onToolCall(client: IpcClient, msg: ToolCallMessage): Promise<ToolCallResult> { ... const reminder = silencePoke.consumeArmedPoke()"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      `gateway.ts` L3764 defines `onToolCall` and L3773 calls
+      `silencePoke.consumeArmedPoke()`. This is the correct chokepoint. Matches
+      the artefact's description of the drain mechanism.
+
+  - claim_id: c12
+    quote: "Wording is load-bearing. Exact strings live in `silence-poke.ts:formatPokeText`."
+    loc: L114-L115
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L354-L380
+        snippet: "export function formatPokeText(level: PokeLevel): string { if (level === 'ack') { ... } if (level === 'soft') { ... } return ..."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      `formatPokeText` exists at L354-380 with the three level branches (ack,
+      soft, firm). The wording in the artefact description matches the
+      implementation's two stated principles: the "skip if finishing soon"
+      language is present in the `soft` branch, and the `formatFrameworkFallbackText`
+      function at L398-426 implements the `(no update from agent in N min)`
+      parenthetical where N is derived from `silenceMs`.

--- a/audit/2026-05-26/findings/contract-principles.yaml
+++ b/audit/2026-05-26/findings/contract-principles.yaml
@@ -1,0 +1,425 @@
+unit_id: contract-principles
+unit_path: reference/principles.md
+category: contract
+audited_at: 2026-05-26T12:00:00Z
+auditor_notes: |
+  Five concrete examples in the file reference shipped behavior that has
+  since changed: (1) "auth login <agent>" verb removed by RFC H and
+  replaced with "auth add / auth reauth"; (2) "executive" profile renamed
+  to "executive-assistant"; (3) the 3-command upgrade flow superseded by
+  "switchroom update"; (4) "defaults.skills_auto" config field referenced
+  in the Principle 2 skills example does not exist in the config schema;
+  (5) "vault set" success message does not tell the user to reference the
+  key as "vault:<key>" in switchroom.yaml.
+
+  All other principle prose, check-questions, and examples checked out
+  either as aligned or as aspirational standards (vision-only). The
+  "chat IS the artifact" sub-principle is accurate — the pinned progress
+  card was genuinely retired in #1122 and replaced by in-chat streaming.
+
+findings:
+  - claim_id: c1
+    quote: "`switchroom auth login coach` prints the OAuth URL inline, says \"open
+      this in any browser — tokens save to this agent's CLAUDE_CONFIG_DIR, no other
+      agent is affected,\" and watches for completion."
+    loc: L38-L41
+    verdict: contract-example-stale
+    evidence:
+      - path: src/cli/auth.ts
+        lines: L1-L26
+        snippet: "The fleet-wide model collapses what used to be a per-agent verb tree
+          (`auth login / reauth / heal / promote / enable / disable / share /
+          refresh-accounts / status / account add / account list / account rm`)
+          into a small accounts-and-fleet surface: auth add <label> / auth reauth <agent>"
+      - path: src/cli/auth.ts
+        lines: L815-L820
+        snippet: "auth .command(\"reauth <agent>\") .description(\"Start/resume an
+          OAuth re-auth session for an agent; prints the login URL\")"
+    evidence_strength: strong
+    action: update-text
+    proposed_text: "Replace the example verb from `switchroom auth login coach` to
+      `switchroom auth add default --via-claude` (first-time) or `switchroom auth
+      reauth coach` (refresh). Drop the CLAUDE_CONFIG_DIR detail — the fleet model
+      no longer uses per-agent credential dirs as the primary framing."
+    confidence: high
+    rationale: |
+      RFC H removed `auth login` entirely; the registered verbs in auth.ts
+      are now `add`, `list`, `use`, `rotate`, `rm`, `show`, `refresh`, `agent
+      override`, and `reauth`. A grep for `.command("login")` in auth.ts returns
+      nothing. The CLAUDE_CONFIG_DIR framing also predates the fleet/broker
+      architecture. This is a stale CLI example, not a principle violation.
+
+  - claim_id: c2
+    quote: "`switchroom setup` detects that the bot's privacy mode is still on and
+      tells the user \"@CoachBot has Privacy Mode enabled — it won't see group messages.
+      Disable it in @BotFather → Bot Settings → Group Privacy → Turn off, then
+      re-run this step.\""
+    loc: L45-L50
+    verdict: contract-example-stale
+    evidence:
+      - path: src/cli/setup.ts
+        lines: L293-L301
+        snippet: "console.log(chalk.gray(\"  Tip: Create bots via @BotFather — one per agent.\"));\n
+          \"  IMPORTANT: Disable privacy mode on each bot BEFORE adding it to the group.\"\n
+          \"  In BotFather: /mybots -> select bot -> Bot Settings -> Group Privacy -> Turn off\""
+      - path: src/setup/botfather-walkthrough.ts
+        lines: L198-L198
+        snippet: "log(\"  Step 4. (Optional) /setprivacy → Disable, so the bot can read group\");"
+    evidence_strength: medium
+    action: update-text
+    proposed_text: "Replace the dynamic-detection example with what the setup wizard
+      actually does: setup prints a static upfront instruction to disable privacy mode
+      before adding the bot to a group, not a post-join detection message. The good
+      example should reflect the upfront-guidance pattern rather than an
+      error-detection pattern that doesn't exist."
+    confidence: high
+    rationale: |
+      The setup wizard (src/cli/setup.ts L293-L301) prints a static advisory to
+      disable privacy mode before proceeding. The BotFather walkthrough
+      (src/setup/botfather-walkthrough.ts L198) similarly offers a static optional
+      step note. Neither file contains logic to detect that privacy mode is currently
+      on and surface the quoted error message. The good example describes a
+      detect-and-report behavior that is not shipped.
+
+  - claim_id: c3
+    quote: "A failing skill on an agent shows up as a real `reply` with `accent: 'issue'`:
+      \"skill `weekly-review` failed: missing `hindsight` MCP. Run `switchroom agent
+      reconcile coach` to repair.\""
+    loc: L52-L56
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/tests/status-accent.test.ts
+        lines: L111-L116
+        snippet: "it(\"accent='issue' prepends the warning header before the body\", ...\n
+          { chat_id: '1', text: 'Blocked on X.', accent: 'issue' }"
+      - path: src/cli/doctor.ts
+        lines: L1267-L1267
+        snippet: "fix: `Run \\`switchroom agent reconcile ${name}\\` and ensure the vault
+          contains telegram_bot_token`"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The `accent: 'issue'` mechanism is alive (tested in
+      telegram-plugin/tests/status-accent.test.ts). The `switchroom agent reconcile`
+      suggestion pattern exists throughout src/cli/ for agent repair guidance. The
+      specific "missing hindsight MCP" text is illustrative rather than a literal
+      message claim, and the principle it demonstrates — error messages with next-step
+      instructions — is correctly implemented. Confidence medium because the exact
+      weekly-review failure text was not traced end-to-end.
+
+  - claim_id: c4
+    quote: "`switchroom vault set telegram-bot-token` prompts for the value, masks
+      input, confirms encryption, and tells the user \"now reference this in
+      switchroom.yaml as `vault:telegram-bot-token`.\""
+    loc: L58-L62
+    verdict: contract-example-stale
+    evidence:
+      - path: src/cli/vault.ts
+        lines: L665-L668
+        snippet: "console.log(chalk.green(`✓ Secret '${key}' saved`));"
+    evidence_strength: strong
+    action: update-text
+    proposed_text: "Update the success-message portion of the example to match what
+      vault set actually prints: `✓ Secret 'telegram-bot-token' saved`. If the
+      principle intent is that vault set should tell the user about the vault: syntax,
+      that is a missing-UX gap — either add the hint to the vault set output or update
+      the example to show what currently ships."
+    confidence: high
+    rationale: |
+      src/cli/vault.ts L665-L668 shows the success output is `✓ Secret '${key}'
+      saved` with no mention of the vault: reference syntax. The principle example
+      claims the command tells the user "now reference this in switchroom.yaml as
+      `vault:telegram-bot-token`" — that instruction is not emitted. The masking
+      and prompting behaviors are accurate (L572: `promptLine("Secret value: ", true)`),
+      but the success-message portion is stale.
+
+  - claim_id: c5
+    quote: "`switchroom setup` produces a complete `switchroom.yaml` with the `default`
+      profile, a working bot, working memory, and the first agent already responding
+      in Telegram before the user reads anything."
+    loc: L87-L90
+    verdict: aligned
+    evidence:
+      - path: src/cli/setup.ts
+        lines: L293-L301
+        snippet: "setup.ts drives BotFather walkthrough, writes switchroom.yaml with default profile"
+      - path: src/agents/add-orchestrator.ts
+        lines: L207-L243
+        snippet: "runAddAgent orchestrates BotFather walkthrough + agent creation in one flow"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The setup wizard in src/cli/setup.ts and src/agents/add-orchestrator.ts drives
+      the full BotFather walkthrough, creates a working agent configuration with the
+      default profile, and validates the bot token before completing. The claimed
+      outcome — first agent responding in Telegram — is the design intent realized
+      by the orchestrator. Confidence medium as the full interactive path was not
+      run live.
+
+  - claim_id: c6
+    quote: "Playwright MCP is wired by default; opt out with `mcp_servers: { playwright:
+      false }`. The conversational-pacing prompt + silence-poke safety net are on
+      for every agent with tuned thresholds."
+    loc: L95-L99
+    verdict: aligned
+    evidence:
+      - path: src/agents/reconcile-default-mcps.test.ts
+        lines: L26-L136
+        snippet: "FIXTURE_DEFAULTS[0] = { key: 'playwright', value: { command: 'npx',
+          args: ['-y', '@playwright/mcp@0.0.71', '--snapshot'] }, optOutKey: 'playwright' }\n
+          it('(c) honours per-agent opt-out (mcp_servers: { playwright: false })'...)"
+      - path: telegram-plugin/silence-poke.ts
+        lines: L1-L15
+        snippet: "silence-poke.ts — framework safety net for 'model is silent to the user'"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The Playwright MCP default and opt-out are pinned by a dedicated test suite
+      (reconcile-default-mcps.test.ts). The silence-poke safety net module is live
+      in telegram-plugin/silence-poke.ts and is referenced throughout the streaming
+      pipeline. Both behaviors described are directly implemented.
+
+  - claim_id: c7
+    quote: "`switchroom agent create exec --profile executive` inherits everything
+      from the executive profile and only writes the two-line agent stanza."
+    loc: L102-L105
+    verdict: contract-example-stale
+    evidence:
+      - path: profiles/
+        lines: L1-L1
+        snippet: "Profiles directory contains: _base, _shared, coding, default,
+          executive-assistant, health-coach. No 'executive' profile."
+      - path: docs/cli-reference.md
+        lines: L43-L43
+        snippet: "--profile: `coding`, `default`, `executive-assistant`,"
+    evidence_strength: strong
+    action: update-text
+    proposed_text: "Update the example from `--profile executive` to
+      `--profile executive-assistant`. The profile was named `executive-assistant`
+      from the start (not renamed); this is a typo or shorthand in the example."
+    confidence: high
+    rationale: |
+      The profiles/ directory contains `executive-assistant` but not `executive`.
+      The docs/cli-reference.md L43 confirms `executive-assistant` is the correct
+      profile slug. A grep for bare `executive` (excluding `executive-assistant`)
+      across src/ returns no results. The example in principles.md uses a profile
+      name that does not exist.
+
+  - claim_id: c8
+    quote: "The upgrade flow — `switchroom apply` to reconcile, `docker compose pull`
+      to fetch new images, `docker compose up -d --remove-orphans` to roll the
+      fleet — is three lines, idempotent, and the same on every host."
+    loc: L108-L111
+    verdict: contract-example-stale
+    evidence:
+      - path: src/cli/update.ts
+        lines: L1-L24
+        snippet: "`switchroom update` — bundle the host-update flow into one verb (#918).
+          Pre-#918 the operator was told to invoke five commands across two privilege
+          levels... `update` runs them in order, with idempotent skip-if-fresh checks."
+    evidence_strength: strong
+    action: update-text
+    proposed_text: "Replace the three-command example with the current single-command
+      idiom: `switchroom update` runs pull-images, apply, docker compose up, and
+      doctor in one step. The three individual commands described were the pre-#918
+      pattern. The good example should read: `switchroom update` — one command,
+      idempotent, same on every host."
+    confidence: high
+    rationale: |
+      src/cli/update.ts L1-L24 explicitly documents that `switchroom update` was
+      introduced in #918 to replace the five-command (three for source checkout, more
+      for docker) flow. CLAUDE.md also lists `switchroom update` as the standard
+      operator command. The good example in principles.md still describes the
+      replaced multi-command pattern, making it stale relative to shipped behavior.
+
+  - claim_id: c9
+    quote: "Sensible default skills on each profile (health-coach ships with `check-in`
+      and `weekly-review`); operator skills (`humanizer`, `buildkite-*`) stay opt-in
+      via `defaults.skills_auto`."
+    loc: L115-L118
+    verdict: contract-example-stale
+    evidence:
+      - path: profiles/health-coach/skills/
+        lines: L1-L1
+        snippet: "health-coach profile contains check-in/ and weekly-review/ skill directories"
+      - path: src/config/schema.ts
+        lines: L1-L1
+        snippet: "Schema contains humanizer_voice_file field but no skills_auto field"
+      - path: docs/skills.md
+        lines: L125-L126
+        snippet: "| `humanizer` | developer (opt-in) | Strips AI-writing patterns from
+          replies; opt in via `defaults.skills`"
+    evidence_strength: strong
+    action: update-text
+    proposed_text: "Replace `defaults.skills_auto` with the actual config field. Per
+      docs/skills.md, humanizer is opt-in via `defaults.skills` (not `defaults.skills_auto`).
+      The first half of the example (health-coach ships with check-in and weekly-review)
+      is accurate. Remove `buildkite-*` skills reference — no such skills exist in
+      the skills/ directory."
+    confidence: high
+    rationale: |
+      `defaults.skills_auto` does not appear anywhere in src/config/schema.ts or
+      anywhere else in the codebase. docs/skills.md L125 confirms humanizer is
+      opt-in via `defaults.skills`. The health-coach profile does contain both
+      check-in and weekly-review skill directories, so that half is accurate.
+      No `buildkite-*` skills were found in the skills/ directory; only humanizer,
+      humanizer-calibrate, and switchroom-* skills are present.
+
+  - claim_id: c10
+    quote: "Every top-level CLI verb is `switchroom <noun> <verb>` — `agent start`,
+      `vault set`, `topics sync`, `auth login`. One shape. One file per noun in
+      `src/cli/`."
+    loc: L143-L145
+    verdict: contract-example-stale
+    evidence:
+      - path: src/cli/auth.ts
+        lines: L9-L16
+        snippet: "auth add <label> --from-agent | --from-credentials | --from-oauth |
+          --via-claude; auth list; auth use <label>; auth rotate; auth rm <label>"
+    evidence_strength: strong
+    action: update-text
+    proposed_text: "Replace `auth login` in the example list with `auth add` or
+      `auth reauth` — `auth login` was removed by RFC H. The structural claim
+      (noun-verb shape, one file per noun) remains accurate and should be kept."
+    confidence: high
+    rationale: |
+      The broader principle (noun-verb shape, one file per noun) is well-supported
+      by the repo structure. However the specific example `auth login` no longer
+      exists as a registered command. Minor stale example in an otherwise accurate
+      structural claim — keeping the principle, updating just the example verb.
+
+  - claim_id: c11
+    quote: "Every long-running operation — interactive reply, scheduled task, sub-agent
+      delegation — uses the same conversational pacing rhythm. Soft-commit, mid-turn
+      updates at meaningful punctuation, final answer pings once."
+    loc: L149-L153
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L1-L15
+        snippet: "silence-poke module implements the framework safety net for silent
+          turns; pings once at turn-end via materialize()"
+      - path: telegram-plugin/answer-stream.ts
+        lines: L29-L40
+        snippet: "Turn-end materializes as a fresh sendMessage (push notification) NOT
+          an edit-finalize — mirrors OpenClaw's materialize() pattern."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The conversational pacing rhythm is implemented in the gateway via
+      answer-stream.ts (materialize-at-turn-end) and silence-poke.ts (silence
+      safety net). The pattern described — soft-commit during turn, single final
+      push notification — matches the shipped architecture. Confidence medium
+      because "scheduled task" pacing was not fully traced.
+
+  - claim_id: c12
+    quote: "Every config field has a documented cascade mode (union / override /
+      per-key merge / concat / deep-merge) and behaves the same way across
+      `defaults`, profiles, and agents. See `src/config/merge.ts` and
+      `docs/configuration.md`."
+    loc: L159-L163
+    verdict: aligned
+    evidence:
+      - path: src/config/merge.ts
+        lines: L24-L640
+        snippet: "schedule: concatenated (defaults entries first). hooks: per-event
+          concat. env: per-key merge. settings_raw: deep merge. cli_args: concat."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      src/config/merge.ts exists and documents specific cascade modes per field
+      (concat, per-key merge, deep-merge, etc.) inline in the implementation.
+      The file path cited in principles.md is correct. The claim is accurate.
+
+  - claim_id: c13
+    quote: "Secrets are referenced uniformly as `vault:<key>` anywhere in
+      `switchroom.yaml`. The vault CLI, the cascade resolver, and the bootstrap
+      layer all know that prefix."
+    loc: L167-L170
+    verdict: aligned
+    evidence:
+      - path: src/cli/setup.ts
+        lines: L327-L381
+        snippet: "if (rawToken.startsWith(\"vault:\")) { ... key = rawToken.replace(\"vault:\", \"\")"
+      - path: src/cli/doctor-inlined-secrets.ts
+        lines: L79-L79
+        snippet: "if (v.startsWith(\"vault:\")) return false; // the sanctioned form"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The `vault:` prefix is consistently checked across setup.ts, the doctor,
+      config loaders, and the Google workspace integration. All layers understand
+      and resolve this prefix. The claim is accurate.
+
+  - claim_id: c14
+    quote: "`switchroom agent restart` always reconciles first (regenerates the
+      runtime config if changed), so a restart is also a mini-deploy."
+    loc: L174-L177
+    verdict: aligned
+    evidence:
+      - path: src/cli/agent.ts
+        lines: L497-L512
+        snippet: "this so we can unit-test 'restart always reconciles first, and skips
+          restart if reconcile fails' without booting commander. Why reconcile before
+          every restart? Restart was historically a pure ... If reconcile fails, we
+          do NOT proceed to restart"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      src/cli/agent.ts L497-L512 explicitly documents the reconcile-first-before-restart
+      invariant and its rationale. CLAUDE.md also states "Since PR #59, `agent restart`
+      always runs reconcile first." The claim is accurate and load-bearing.
+
+  - claim_id: c15
+    quote: "Same Telegram UX surface for every agent — same `/auth` router, same
+      reaction lifecycle, same conversational pacing, same silence-poke safety net,
+      regardless of profile."
+    loc: L181-L184
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway.ts
+        lines: L1-L1
+        snippet: "single gateway.ts implements auth routing, reaction lifecycle,
+          and silence-poke for all agents"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The telegram-plugin ships a single gateway that all agent containers run.
+      The same gateway code handles auth routing, reactions, pacing, and silence-poke
+      regardless of which profile the agent uses. Confidence medium as cross-profile
+      invariance was not tested end-to-end.
+
+  - claim_id: c16
+    quote: "We've been here once already (the pinned progress card, retired in #1122).
+      Build the model to communicate; let the framework be the safety net, not the
+      headline. Single source of truth for 'what is the agent doing': the chat itself."
+    loc: L191-L197
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/session-tail.ts
+        lines: L37-L41
+        snippet: "#1122 PR3: inlined from the deleted progress-card.ts. Kill switch
+          for the sub-agent transcript watcher (PROGRESS_CARD_MULTI_AGENT=0 disables it)."
+      - path: CHANGELOG.md
+        lines: L451-L457
+        snippet: "The 'chat IS the artifact' principle clarification: the retired
+          progress card (#1122) was chrome — a pinned widget separate from the chat.
+          Visible-answer-stream is not chrome."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The CHANGELOG confirms the pinned progress card was retired in #1122, and that
+      the current in-chat streaming is explicitly NOT chrome per the product decision.
+      session-tail.ts references the deleted progress-card.ts from PR3 of #1122. The
+      principle accurately describes the historical event and the current design intent.
+      The slot-banner (auth banner) still pins but is a distinct feature from the
+      progress card and is not a counterexample to this principle.

--- a/audit/2026-05-26/findings/contract-reference-readme.yaml
+++ b/audit/2026-05-26/findings/contract-reference-readme.yaml
@@ -1,0 +1,252 @@
+unit_id: contract-reference-readme
+unit_path: reference/README.md
+category: contract
+audited_at: 2026-05-26T10:00:00Z
+auditor_notes: |
+  Audited all verifiable claims in reference/README.md.
+
+  Key findings summary:
+  1. JTBD count discrepancy: README lists 14 JTBDs; CLAUDE.md states "13 outcome-focused jobs".
+     All 14 files exist on disk. CLAUDE.md is wrong by one.
+  2. All 14 JTBD files exist, have correct job:/outcome:/stakes: frontmatter within the first
+     5 lines, and are grouped under the correct outcome heading. No dead pointers.
+  3. The head -5 reference/*.md trick works for all 14 JTBD files, but the reference/ dir
+     now contains 22 .md files (8 non-JTBD: README, vision, principles, conversational-pacing,
+     onboarding-gap-analysis, rfc-docker-multi-container, status-card-design, sub-agent-visibility-rfc).
+     The command still surfaces all JTBD frontmatter correctly; non-JTBD files simply produce
+     noise headers. The README's "Survey every job in one read" comment is slightly misleading
+     but functionally adequate.
+  4. onboarding-gap-analysis.md README description says "tracks gaps as they close" but the
+     file's own header says "no longer tracks closure" and "is stale". Minor description drift.
+  5. Outcome 4 label: README uses "Always available" (shortened); vision.md uses "Always
+     available, in Telegram, done properly". Minor drift, vision is authoritative.
+  6. idempotent-update-and-restart.md is missing the "Anti-patterns" and "UAT prompts" sections
+     that every other JTBD file has. The README claims all JTBDs have these sections.
+  7. idempotent-update-and-restart.md link description in README is truncated vs the file's job:
+     field (omits "that" and "no manual checks"). Minor wording drift.
+
+findings:
+  - claim_id: c1
+    quote: "Three documents, three questions. Read in this order."
+    loc: L3
+    verdict: aligned
+    evidence:
+      - path: reference/vision.md
+        lines: L1
+        snippet: "# Switchroom: product vision"
+      - path: reference/principles.md
+        lines: L1
+        snippet: "# Switchroom product principles"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Both vision.md and principles.md exist at the stated paths. The table at L5-L9
+      correctly links both and describes their purpose. All three columns (vision, principles,
+      JTBDs) are present and accurate.
+
+  - claim_id: c2
+    quote: "The verdict rule lives in CLAUDE.md (\"Design contract\" section): a change ships only when it advances one of the four outcomes, satisfies its JTBD, and passes all three principle checks."
+    loc: L11-L13
+    verdict: aligned
+    evidence:
+      - path: CLAUDE.md
+        lines: L260-L264
+        snippet: "### Verdict rule\n\nA change ships when it (a) advances one of the four outcomes,\n(b) satisfies its JTBD, and (c) passes all three principle checks."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      CLAUDE.md has a "## Design contract" section (L224) with a "### Verdict rule" subsection
+      (L260) containing exactly this rule. The README's description matches.
+
+  - claim_id: c3
+    quote: "Each JTBD has a three-line frontmatter — job: / outcome: / stakes: — that captures 80% of the doc."
+    loc: L17-L18
+    verdict: aligned
+    evidence:
+      - path: reference/run-a-fleet-of-specialists.md
+        lines: L1-L5
+        snippet: "---\njob: run a fleet of specialists...\noutcome: ...\nstakes: ..."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      All 14 JTBD files confirmed to have job:, outcome:, stakes: fields within the first
+      5 lines. The frontmatter is a three-line YAML block in every case.
+
+  - claim_id: c4
+    quote: "# Survey every job in one read:\nhead -5 reference/*.md"
+    loc: L21-L22
+    verdict: drift-minor
+    evidence:
+      - path: reference/
+        lines: L1
+        snippet: "22 .md files total in reference/; 8 are non-JTBD files without job:/outcome:/stakes: frontmatter"
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    proposed_text: |
+      Change the comment to: "# Survey every JTBD in one read (also prints headers for non-JTBD docs):"
+      Or alternatively: "head -5 reference/*.md | grep -E '^(==>|job:|outcome:|stakes:)'"
+      to filter out the noise from the 8 non-JTBD .md files also present in the directory.
+    rationale: |
+      The command works — all 14 JTBD frontmatter fields are surfaced. However, reference/
+      now contains 22 .md files, of which 8 (README.md, vision.md, principles.md,
+      conversational-pacing.md, onboarding-gap-analysis.md, rfc-docker-multi-container.md,
+      status-card-design.md, sub-agent-visibility-rfc.md) do not have JTBD frontmatter.
+      The comment "Survey every job" implies all output lines are JTBD jobs, which is slightly
+      misleading. The behavior is still useful but produces noise headers for the 8 non-JTBD files.
+
+  - claim_id: c5
+    quote: "The body's Signs it's working, Anti-patterns, and UAT prompts sections are where the design teeth are"
+    loc: L25-L28
+    verdict: drift-minor
+    evidence:
+      - path: reference/idempotent-update-and-restart.md
+        lines: L30-L141
+        snippet: "## Signs it's working\n...\n## Signs it's not\n...\n## What the user needs from the surface\n...\n## Worked examples"
+    evidence_strength: medium
+    action: update-text
+    confidence: high
+    proposed_text: |
+      Change "The body's Signs it's working, Anti-patterns, and UAT prompts sections" to
+      "Most JTBD bodies have Signs it's working, Anti-patterns, and UAT prompts sections" —
+      or add Anti-patterns and UAT prompts sections to idempotent-update-and-restart.md to
+      bring it into structural conformance with the other 13 JTBDs.
+    rationale: |
+      13 of 14 JTBD files have all three sections (Signs it's working, Anti-patterns, UAT prompts).
+      idempotent-update-and-restart.md has "Signs it's working" and "Signs it's not" but no
+      "Anti-patterns" or "UAT prompts" sections. The README's claim about "the body's ... sections"
+      implies all JTBDs have this structure. The file uses a different structural template.
+
+  - claim_id: c6
+    quote: "outcome-focused jobs, one per file"
+    loc: L9
+    verdict: aligned
+    evidence:
+      - path: reference/
+        lines: L1
+        snippet: "14 JTBD .md files, each containing exactly one job: field"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      All 14 JTBD files each contain a single job: field. The "one per file" claim is accurate.
+
+  - claim_id: c7
+    quote: "run-a-fleet-of-specialists.md — run a fleet of specialists, not one generalist ... (14 files listed in grouped JTBD index)"
+    loc: L34-L56
+    verdict: aligned
+    evidence:
+      - path: reference/run-a-fleet-of-specialists.md
+        lines: L2
+        snippet: "job: run a fleet of specialists, not one generalist"
+      - path: reference/talk-to-agents-from-anywhere.md
+        lines: L2
+        snippet: "job: talk to my agents from anywhere"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      All 14 JTBD files listed in the README index exist on disk. The link descriptions
+      match the job: field in each file (the one minor truncation in idempotent-update-and-restart
+      is addressed in c10). The groupings under the four outcome headings are correct and
+      consistent with vision.md.
+
+  - claim_id: c8
+    quote: "### A standing team that knows you — *specialists, not one generalist* (5 JTBDs) / ### You hold the leash — *controlled, purposeful, never roaming* (4 JTBDs) / ### Subscription-honest and predictable — *the plan is the ceiling* (2 JTBDs) / ### Always available — *there when you want it* (3 JTBDs)"
+    loc: L32-L56
+    verdict: aligned
+    evidence:
+      - path: reference/vision.md
+        lines: L52-L103
+        snippet: "### 1. A standing team that knows you: *specialists, not one generalist*\n### 2. You hold the leash: *controlled, purposeful, never roaming*\n### 3. Subscription-honest and predictable: *the plan is the ceiling*\n### 4. Always available, in Telegram, done properly: *there when you want it*"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The four outcome groupings and their JTBD membership are correct. All 14 JTBD files
+      are assigned to the right outcome group. The group headings match vision.md's four
+      outcomes (with the minor Outcome 4 label shortening addressed in c9).
+
+  - claim_id: c9
+    quote: "### Always available — *there when you want it*"
+    loc: L52
+    verdict: drift-minor
+    evidence:
+      - path: reference/vision.md
+        lines: L96
+        snippet: "### 4. Always available, in Telegram, done properly: *there when you want it*"
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    proposed_text: |
+      "### Always available, in Telegram, done properly — *there when you want it*"
+      to match vision.md exactly. Or leave abbreviated — this is a low-priority cosmetic fix.
+    rationale: |
+      vision.md's outcome 4 header includes "in Telegram, done properly" which the README
+      omits. Since vision.md is authoritative for contract documents, the README's heading
+      is a minor truncation. CLAUDE.md also uses the shortened form (L238), suggesting the
+      shortening is intentional across the codebase, but vision.md remains the source of truth.
+
+  - claim_id: c10
+    quote: "idempotent-update-and-restart.md — update switchroom and trust everything's running the new version"
+    loc: L55
+    verdict: drift-minor
+    evidence:
+      - path: reference/idempotent-update-and-restart.md
+        lines: L2
+        snippet: "job: update switchroom and trust that everything is actually running the new version, no manual checks"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    proposed_text: |
+      "idempotent-update-and-restart.md — update switchroom and trust everything is actually running the new version, no manual checks"
+    rationale: |
+      The README index description truncates the JTBD job: field. The actual job: value is
+      "update switchroom and trust that everything is actually running the new version, no manual checks".
+      The README omits "that", changes "is actually" to just "s", and drops "no manual checks".
+      This is minor wording drift in the index description.
+
+  - claim_id: c11
+    quote: "13 outcome-focused jobs grouped by outcome in reference/README.md" (from CLAUDE.md L249, which README L9 implicitly represents as its own count via the index)"
+    loc: L34-L56
+    verdict: drift-major
+    evidence:
+      - path: reference/README.md
+        lines: L34-L56
+        snippet: "14 JTBD entries across the four outcome groups (5+4+2+3=14)"
+      - path: CLAUDE.md
+        lines: L249
+        snippet: "13 outcome-focused jobs grouped by outcome in reference/README.md."
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    proposed_text: |
+      In CLAUDE.md L249: change "13 outcome-focused jobs" to "14 outcome-focused jobs".
+      The fix is in CLAUDE.md, not in reference/README.md, which is the authoritative source.
+    rationale: |
+      reference/README.md lists exactly 14 JTBD entries (5 under outcome 1, 4 under outcome 2,
+      2 under outcome 3, 3 under outcome 4). All 14 corresponding .md files exist on disk.
+      CLAUDE.md at L249 states "13 outcome-focused jobs" which is wrong by one. The README is
+      the authoritative index; CLAUDE.md references it and gets the count wrong.
+
+  - claim_id: c12
+    quote: "onboarding-gap-analysis.md — phased fix plan from a real onboarding session; tracks gaps as they close, not a durable JTBD."
+    loc: L60
+    verdict: drift-minor
+    evidence:
+      - path: reference/onboarding-gap-analysis.md
+        lines: L3-L8
+        snippet: "## Status — historical (last updated 2026-04-25); no longer tracks closure\n\nThis document is a point-in-time analysis, not a live tracker. Despite being indexed as \"tracks gaps as they close,\" it does not track closure and is stale."
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    proposed_text: |
+      "onboarding-gap-analysis.md — point-in-time onboarding gap snapshot (2026-04-25); historical, no longer updated. Not a durable JTBD."
+    rationale: |
+      The README describes this file as "tracks gaps as they close" but the file itself declares
+      in its own Status header (L3) that it "no longer tracks closure" and is "stale." The file
+      even notes it was "indexed as 'tracks gaps as they close'" but that description is wrong.
+      The README index description should be updated to match the file's own self-description.

--- a/audit/2026-05-26/findings/contract-vision.yaml
+++ b/audit/2026-05-26/findings/contract-vision.yaml
@@ -1,0 +1,324 @@
+unit_id: contract-vision
+unit_path: reference/vision.md
+category: contract
+audited_at: 2026-05-26T12:00:00Z
+auditor_notes: |
+  Audited all four outcomes plus the "What it isn't" table.
+  One active code-violates-contract finding: src/host-control/server.ts
+  line 1577 contains a live `claude -p ok` callsite inside the `deep`
+  probe path of the agent_health verb. It is already in the
+  KNOWN_TEMPLATE_GAPS allowlist of tests/bridge-flap-regression-guard.test.ts
+  under tracking issue #1798. The vision is unambiguous that every model
+  call must be the interactive session or an injected turn; the `deep`
+  probe is a direct violation. Escalation is appropriate.
+
+  The OpenAI Whisper usage in telegram-plugin/voice-transcribe.ts is
+  noted separately. The "What it isn't" table row says "A multi-provider
+  orchestrator | No OpenAI, Gemini, Llama, model swapping." The
+  surrounding text ("model swapping") indicates inference orchestration
+  is the constraint, not auxiliary services. Whisper is a transcription
+  helper, not an inference provider replacing Claude. The wording is
+  ambiguous enough to merit a minor text clarification rather than a
+  contract violation.
+
+  Account pooling / auto-failover (vision L93-95: "pool accounts with
+  automatic failover") is implemented via the fleet-wide auto-fallback
+  path (telegram-plugin/fleet-fallback-gate.ts, session-tail.ts) which
+  rotates OAuth slots on quota exhaustion. Claim is aligned.
+
+findings:
+  - claim_id: c1
+    quote: "Every agent runs the unmodified `claude` binary, OAuth straight to Anthropic, the same flow as the desktop. No Agent SDK. No API-key routing. No raw API."
+    loc: L77-L80
+    verdict: aligned
+    evidence:
+      - path: CLAUDE.md
+        lines: L37-L66
+        snippet: "Every agent runs the unmodified `claude` CLI, authenticated with the operator's Pro/Max OAuth credentials. No `ANTHROPIC_API_KEY`, no API keys of any kind, no Claude Agent SDK, no raw Anthropic API..."
+      - path: tests/bridge-flap-regression-guard.test.ts
+        lines: L1-L30
+        snippet: "As of RFC #1620 the codebase has *zero* headless-`claude` spawners at all (the handoff builder and webhook dispatch were both moved off `claude -p`)"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      CLAUDE.md encodes this as a hard constraint with CI enforcement via
+      tests/bridge-flap-regression-guard.test.ts. The scan confirms no
+      source file spawns `claude` without `--strict-mcp-config`, and the
+      SDK/API import scan found no `@anthropic-ai/sdk` or raw API usage in
+      src/ or telegram-plugin/. The constraint is architecturally upheld.
+
+  - claim_id: c2
+    quote: "Every model call is the interactive `claude` session, or a turn synthesized into it. Headless `claude -p` is the same CLI, but as of the 2026-06-15 policy it counts as programmatic usage, off the subscription."
+    loc: L86-L90
+    verdict: code-violates-contract
+    evidence:
+      - path: src/host-control/server.ts
+        lines: L1574-L1578
+        snippet: "if (req.args.deep) { PROBES.push({ name: \"auth_live\", cmd: \"timeout 25 claude -p ok >/dev/null 2>&1\", }); }"
+      - path: tests/bridge-flap-regression-guard.test.ts
+        lines: L168-L175
+        snippet: "KNOWN_TEMPLATE_GAPS: { \"src/host-control/server.ts\": \"#1798\" }"
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      src/host-control/server.ts line 1577 contains an active `claude -p ok`
+      callsite in the `deep` branch of the agent_health probe. The vision
+      (L86-L90) and CLAUDE.md hard constraint both forbid any `claude -p`
+      callsite as programmatic usage under the 2026-06-15 policy. The code
+      is already acknowledged in KNOWN_TEMPLATE_GAPS with tracking issue
+      #1798 but remains unfixed. Vision is authoritative for contract units;
+      verdict is code-violates-contract. Operator must decide whether to
+      retire the deep probe entirely, replace it with a token-introspect
+      liveness check via the auth-broker, or accept the policy exception.
+
+  - claim_id: c3
+    quote: "No Agent SDK. No API-key routing. No raw API. No credential interception."
+    loc: L78-L81
+    verdict: aligned
+    evidence:
+      - path: src/auth/via-claude.ts
+        lines: L1-L25
+        snippet: "spawn `claude` in a clean tmux pane, dispatch the well-known OAuth flow..."
+      - path: src/auth/accounts.ts
+        lines: L254-L291
+        snippet: "token (e.g. when planning the slot pool)..."
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      No `@anthropic-ai/sdk` imports found anywhere in src/ or
+      telegram-plugin/. Auth flows go through the claude CLI's OAuth path,
+      not a raw API key. The auth broker manages token rotation but never
+      calls the Anthropic API directly. Credential interception would mean
+      proxying the claude CLI's network traffic, which is not present in the
+      codebase.
+
+  - claim_id: c4
+    quote: "A standing team that knows you: specialists, not one generalist. One bot per specialist. Each its own persona, memory, skills, tools, credentials."
+    loc: L52-L63
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L793-L800
+        snippet: "per-agent scaffold dir...SOUL.md per agent...per-agent skills..."
+      - path: src/config/schema.ts
+        lines: L1494-L1510
+        snippet: "per-agent config fields for skills, persona, credentials..."
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The scaffold system generates per-agent SOUL.md (persona), per-agent
+      memory, per-agent credential slots, and per-agent skills. CLAUDE.md's
+      repo layout section confirms profiles/ and skills/ directories plus
+      per-agent config cascade. The multi-agent architecture is thoroughly
+      implemented.
+
+  - claim_id: c5
+    quote: "You hold the leash: controlled, purposeful, never roaming. A specialist sees only the credentials and tools you granted it. It can ask for more. You get an Allow or Deny card in Telegram. Only your tap grants it."
+    loc: L65-L74
+    verdict: aligned
+    evidence:
+      - path: src/vault/approvals/
+        lines: L1-L1
+        snippet: "approval-kernel — per-agent UDS for approval/grant flows"
+      - path: CLAUDE.md
+        lines: L68-L85
+        snippet: "approval-kernel (root, mirror of broker socket model)...per-agent sockets at /run/switchroom/kernel/<agent>/sock"
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The approval-kernel service provides the Allow/Deny flow. Vault
+      per-agent socket model ensures a specialist only accesses credentials
+      bound to its socket path (path-as-identity invariant in
+      src/vault/broker/peercred.ts). The architecture enforces the leash
+      constraint structurally.
+
+  - claim_id: c6
+    quote: "No heartbeats. Beck-and-call plus the explicit schedules you set, never a loop of its own."
+    loc: L72-L73
+    verdict: aligned
+    evidence:
+      - path: src/agent-scheduler/index.ts
+        lines: L1-L15
+        snippet: "fires via inject_inbound...cron-driven...no autonomous loop"
+      - path: src/agent-scheduler/index.ts
+        lines: L247-L247
+        snippet: "setInterval(() => { /* idle */ }, 1 << 30);"
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The agent-scheduler uses node-cron to fire at operator-defined
+      schedules only, dispatching via inject_inbound to the interactive
+      session. The agent itself has no polling loop — the `setInterval`
+      at line 247 is an idle keep-alive, not a work loop. The "no
+      heartbeats" claim is architecturally correct.
+
+  - claim_id: c7
+    quote: "Always available, in Telegram, done properly: there when you want it. Each specialist is a long-running service. It survives reboots, network drops, your laptop closing."
+    loc: L96-L104
+    verdict: aligned
+    evidence:
+      - path: CLAUDE.md
+        lines: L68-L80
+        snippet: "tini (PID 1) -> start.sh -> tmux server+client -> claude; agent containers use network_mode: host"
+      - path: profiles/_base/start.sh.hbs
+        lines: L1-L1
+        snippet: "start.sh.hbs — the agent entry script template (includes the docker-mode tmux preamble)"
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      Docker containers with tini as PID 1 provide service durability. The
+      tmux layer ensures the claude session persists across network drops.
+      Compose restart policies keep agents alive across reboots. The
+      always-available architecture is implemented.
+
+  - claim_id: c8
+    quote: "Switchroom never intercepts auth or inference. The `claude` CLI is the runtime."
+    loc: L126-L126
+    verdict: aligned
+    evidence:
+      - path: src/auth/via-claude.ts
+        lines: L1-L30
+        snippet: "spawn `claude` in a clean tmux pane, dispatch the well-known OAuth flow"
+      - path: CLAUDE.md
+        lines: L44-L52
+        snippet: "Every agent runs the unmodified `claude` CLI...Docker is for distribution and isolation, not a custom runtime around claude"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The claude CLI runs unmodified inside each agent container. Auth
+      flows use the CLI's own OAuth mechanism (the auth broker manages
+      token rotation but does not proxy inference). No inference
+      interception layer exists in the codebase.
+
+  - claim_id: c9
+    quote: "A multi-provider orchestrator | No OpenAI, Gemini, Llama, model swapping."
+    loc: L127-L127
+    verdict: drift-minor
+    evidence:
+      - path: telegram-plugin/voice-transcribe.ts
+        lines: L1-L22
+        snippet: "Voice-message transcription via OpenAI Whisper (#578 spike)...POSTs them to OpenAI's Whisper API."
+      - path: src/config/schema.ts
+        lines: L588-L588
+        snippet: "API key read from ~/.switchroom/openai-api-key (mode 0600). Off by..."
+    evidence_strength: medium
+    action: update-text
+    proposed_text: |
+      "A multi-provider orchestrator | No OpenAI, Gemini, Llama, or model
+      swapping for inference. Auxiliary services (e.g. voice transcription
+      via Whisper) are opt-in helpers, not Claude replacements."
+    confidence: medium
+    rationale: |
+      The voice-transcribe.ts module calls the OpenAI Whisper API for
+      audio transcription (opt-in, off by default). This is not inference
+      orchestration — it does not replace or augment Claude's reasoning.
+      However the "What it isn't" table row reads "No OpenAI, Gemini,
+      Llama, model swapping" which is ambiguous: a reader could reasonably
+      interpret it as a blanket ban on any OpenAI dependency. The
+      surrounding column text "model swapping" signals the constraint is
+      about inference providers, but the left-column label alone is
+      misleading. Minor text clarification is warranted to preserve the
+      intent (no inference orchestration) without misrepresenting the
+      shipped voice-in feature.
+
+  - claim_id: c10
+    quote: "Not Slack, not Discord, not Teams. Telegram, done properly."
+    loc: L128-L128
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L1-L10
+        snippet: "Telegram bot gateway — sole inbound channel"
+      - path: src/cli/telegram.ts
+        lines: L1-L10
+        snippet: "Telegram plugin configuration commands only"
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The telegram-plugin is the sole inbound channel implementation. No
+      Slack, Discord, or Teams adapters exist in the codebase. The web/
+      directory provides a local REST API and webhook handler (inbound from
+      external services to the agent), not a chat channel bridge — it routes
+      into the same inject_inbound path.
+
+  - claim_id: c11
+    quote: "Multi-tenant | Single-operator by design."
+    loc: L130-L130
+    verdict: aligned
+    evidence:
+      - path: src/host-control/server.ts
+        lines: L1244-L1244
+        snippet: "Deliberately OUT of scope per operator decision (single-operator single-host posture)"
+      - path: CLAUDE.md
+        lines: L1-L10
+        snippet: "Users run Claude Code agents 24/7 on a Linux box...single-operator by design"
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The operator model is single-user by construction: a single
+      ~/.switchroom/ state tree, a single switchroom.yaml, and no
+      multi-tenant auth layer. The host-control server comment explicitly
+      cites "single-operator single-host posture."
+
+  - claim_id: c12
+    quote: "A hosted service | Self-hosted only. Your box, your tokens, your data."
+    loc: L131-L131
+    verdict: aligned
+    evidence:
+      - path: docs/install.md
+        lines: L1-L5
+        snippet: "install on your own Linux host"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      No hosted service, SaaS offering, or cloud-hosted instance exists
+      in the codebase or published infrastructure. The install path
+      is always to an operator-owned Linux box via docker compose.
+
+  - claim_id: c13
+    quote: "Need more throughput, pool accounts with automatic failover. One bill."
+    loc: L93-L95
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/fleet-fallback-gate.ts
+        lines: L1-L5
+        snippet: "Re-entry guard + dedup window for fleet-wide auto-fallback."
+      - path: telegram-plugin/session-tail.ts
+        lines: L462-L475
+        snippet: "fleet auto-fallback...quota hit...exhaustion signal...auto-fallback-eligible"
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The fleet-wide auto-fallback path (PR #1329) rotates OAuth slots on
+      quota exhaustion. The auth accounts slot pool (src/auth/accounts.ts)
+      supports multiple accounts per agent. The claim accurately describes
+      the shipped capability.
+
+  - claim_id: c14
+    quote: "The moment a feature reaches for the SDK or the API, it has left switchroom."
+    loc: L83-L84
+    verdict: aligned
+    evidence:
+      - path: CLAUDE.md
+        lines: L37-L66
+        snippet: "Before adding any code path that calls a model: it MUST be the interactive claude session...If you reach for the SDK or the API, stop."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      No `@anthropic-ai/sdk` imports exist in src/ or telegram-plugin/.
+      The bridge-flap regression guard and skill validator both scan for
+      prohibited patterns. CLAUDE.md encodes the constraint with explicit
+      CI enforcement. The code does not reach for the SDK.

--- a/audit/2026-05-26/findings/historical-onboarding-gap-analysis.yaml
+++ b/audit/2026-05-26/findings/historical-onboarding-gap-analysis.yaml
@@ -1,0 +1,176 @@
+unit_id: historical-onboarding-gap-analysis
+unit_path: reference/onboarding-gap-analysis.md
+category: historical
+audited_at: 2026-05-26T14:00:00Z
+auditor_notes: |
+  The document carries a correct historical disclaimer at the top (L1-L13),
+  explicitly stating it is a point-in-time snapshot and should not be read
+  as current state. The disclaimer is accurate.
+
+  The main hygiene concern is four referrers that point at this document
+  without surfacing the historical caveat to the reader:
+
+  1. reference/README.md L60 — describes it as "tracks gaps as they close"
+     which contradicts the disclaimer inside the document itself ("does not
+     track closure").
+  2. docs/workspace-files.md L60-L61 — links it as the active tracker for
+     a gap that has not yet shipped ("this is tracked for convergence").
+  3. docs/workspace-files.md L203 — calls it "fixes planned for the
+     mechanism-convergence gap" — present-tense, implies current roadmap.
+  4. src/agents/status.ts L16 — uses it as a rationale comment in shipped
+     code ("the gap this closes"), which is fine — it is a historical
+     citation and the gap is closed; no reader confusion expected here.
+  5. src/agents/scaffold.ts L2887 — same pattern, historical citation in
+     a comment next to the fix; gap 1 is closed; low-confusion risk.
+
+  Gaps shipped so far (from code evidence): gap 1 (auto-create bank —
+  scaffold.ts:2887+), gap 3 (switchroom agent status — status.ts). Gaps
+  4/8 (workspace loader convergence) are still open — the two file lists
+  remain hardcoded in workspace.ts (L94, L108). Gap 6 (Telegram pairing),
+  gap 5 (corpus bootstrap), gap 2 (readiness gate), gap 7 (empty
+  templates), B2 (per-agent dynamic list), C1, C2 — not confirmed as
+  shipped from code review; treated as open or unknown.
+
+  The document itself does not need editing (the disclaimer is honest and
+  the content is read-only historical). The action required is in the three
+  referrers that treat it as a live tracker.
+
+findings:
+  - claim_id: c1
+    quote: "This document is a point-in-time analysis, not a live tracker. Despite being indexed as 'tracks gaps as they close,' it does not track closure and is stale."
+    loc: L4-L13
+    verdict: aligned
+    evidence:
+      - path: reference/onboarding-gap-analysis.md
+        lines: L1-L13
+        snippet: "## Status — historical (last updated 2026-04-25); no longer tracks closure"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The disclaimer at the top of the document accurately describes its
+      status. It is appropriately labelled historical and explicitly
+      instructs readers not to use it as current state. No change needed
+      to the document itself.
+
+  - claim_id: c2
+    quote: "tracks gaps as they close, not a durable JTBD"
+    loc: L60
+    verdict: archive-leaks
+    evidence:
+      - path: reference/README.md
+        lines: L60
+        snippet: "onboarding-gap-analysis.md — phased fix plan from a real onboarding session; tracks gaps as they close, not a durable JTBD."
+    evidence_strength: strong
+    action: fix-referrer
+    referrer:
+      path: reference/README.md
+      lines: L60
+    confidence: high
+    rationale: |
+      reference/README.md describes the document as "tracks gaps as they
+      close" — but the document's own disclaimer (L4-L8) explicitly states
+      it does NOT track closure and is stale. The referrer description
+      contradicts the disclaimer, leading a reader to expect current status
+      that is not there. The description should be updated to signal the
+      historical nature, e.g. "historical point-in-time gap analysis from
+      2026-04-25 onboarding session; some gaps have since shipped."
+    proposed_text: |
+      `onboarding-gap-analysis.md` — historical point-in-time gap analysis
+      from a 2026-04-25 onboarding session; not a live tracker. Several
+      gaps have shipped; read as motivation context, not current roadmap.
+
+  - claim_id: c3
+    quote: "The list is currently hardcoded in the switchroom binary. Adding a new stable file requires a code change + release. This is tracked for convergence (see gap analysis gap 4 and gap 8)."
+    loc: L58-L61
+    verdict: archive-leaks
+    evidence:
+      - path: docs/workspace-files.md
+        lines: L58-L61
+        snippet: "This is tracked for convergence (see [gap analysis](../reference/onboarding-gap-analysis.md) gap 4 and gap 8)."
+      - path: src/agents/workspace.ts
+        lines: L94-L108
+        snippet: "STABLE_BOOTSTRAP_FILENAMES ... DYNAMIC_BOOTSTRAP_FILENAMES (still hardcoded arrays)"
+    evidence_strength: medium
+    action: fix-referrer
+    referrer:
+      path: docs/workspace-files.md
+      lines: L58-L61
+    confidence: medium
+    rationale: |
+      docs/workspace-files.md links the gap analysis as the active
+      tracking location for the workspace loader convergence work. The
+      hardcoded list issue is real and unshipped (workspace.ts L94, L108
+      still shows hardcoded arrays), but the gap-analysis document is not
+      a tracker — it is historical. The link gives the reader a dead-end.
+      The referrer should either remove the link or note it as historical
+      motivation, and if the gap is still open, point to an active issue
+      or RFC instead.
+    proposed_text: |
+      Remove the "(see gap analysis ...)" link. If an active tracking
+      location exists (issue or RFC), link that instead. The gap analysis
+      is historical and does not track closure.
+
+  - claim_id: c4
+    quote: "reference/onboarding-gap-analysis.md — fixes planned for the mechanism-convergence gap"
+    loc: L203
+    verdict: archive-leaks
+    evidence:
+      - path: docs/workspace-files.md
+        lines: L199-L204
+        snippet: "- reference/onboarding-gap-analysis.md — fixes planned for the mechanism-convergence gap"
+    evidence_strength: strong
+    action: fix-referrer
+    referrer:
+      path: docs/workspace-files.md
+      lines: L203
+    confidence: high
+    rationale: |
+      The "Related" section of docs/workspace-files.md describes the gap
+      analysis as "fixes planned for the mechanism-convergence gap" —
+      present tense, implying active roadmap. The document carries a
+      disclaimer saying it is not a live tracker. A reader following this
+      link expecting planned fixes will find a stale snapshot. Either
+      remove the entry or replace with a note that it is historical
+      context ("historical motivation for the convergence design").
+    proposed_text: |
+      `reference/onboarding-gap-analysis.md` — historical motivation for
+      the workspace loader convergence design (point-in-time, 2026-04-25;
+      not a live roadmap).
+
+  - claim_id: c5
+    quote: "See reference/onboarding-gap-analysis.md §3 for the gap this closes."
+    loc: L16
+    verdict: aligned
+    evidence:
+      - path: src/agents/status.ts
+        lines: L14-L17
+        snippet: "See reference/onboarding-gap-analysis.md §3 for the gap this closes."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      This is a JSDoc comment in src/agents/status.ts citing the gap
+      analysis as retrospective motivation for a gap that has been closed
+      (status.ts implements gap 3 — "switchroom agent status"). The comment
+      uses past tense ("the gap this closes") and is accurate as a
+      historical citation. No reader confusion is expected; the comment is
+      an explanation, not a navigation pointer to a live tracker.
+
+  - claim_id: c6
+    quote: "See reference/onboarding-gap-analysis.md §1 ... create_bank is a no-op if the bank already exists."
+    loc: L2887
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L2885-L2891
+        snippet: "(see reference/onboarding-gap-analysis.md §1). create_bank is a no-op if the bank already exists."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      src/agents/scaffold.ts cites the gap analysis as historical
+      motivation for the auto-create bank logic. Gap 1 (auto-create
+      Hindsight bank on agent create) is confirmed shipped by this code.
+      The comment is a correct retrospective citation, not a forward
+      pointer. No action needed.

--- a/audit/2026-05-26/findings/historical-prd.yaml
+++ b/audit/2026-05-26/findings/historical-prd.yaml
@@ -1,0 +1,46 @@
+unit_id: historical-prd
+unit_path: reference/PRD.md
+category: historical
+audited_at: 2026-05-26T08:00:00Z
+auditor_notes: |
+  reference/PRD.md does not exist on disk. It was deliberately deleted
+  in commit 8bdb86cb (PR #534, "docs(design-contract): vision + principles
+  + JTBD index, scrap PRD") — 446 lines removed. The commit message notes:
+  "PRD removed — partially-dated already, and everything load-bearing
+  replaced by the four-doc design contract."
+
+  Because the file is absent, no disclaimer accuracy check is possible
+  and no body claims can be verified. The only actionable findings are
+  the two audit-infrastructure files that still name it as a unit to audit.
+  Neither treats PRD.md as current spec; both are drift-audit tooling that
+  was written before the deletion was noticed.
+
+  No other files in src/, telegram-plugin/, profiles/, skills/, docker/,
+  docs/, or tests/ reference PRD.md.
+
+findings:
+  - claim_id: c1
+    quote: "path: reference/PRD.md"
+    loc: L229
+    verdict: dead-pointer
+    evidence:
+      - path: scripts/drift-audit/manifest.yaml
+        lines: L228-L230
+        snippet: |
+          - id: historical-prd
+            path: reference/PRD.md
+            category: historical
+      - path: scripts/drift-audit/README.md
+        lines: L94
+        snippet: |
+          | `historical` | `reference/PRD.md`, `reference/onboarding-gap-analysis.md` | ...
+    evidence_strength: strong
+    action: delete
+    confidence: high
+    rationale: |
+      reference/PRD.md was deleted in PR #534 (commit 8bdb86cb). Git history
+      confirms: "reference/PRD.md | 446 -------". The manifest entry and the
+      README example row both name a file that no longer exists. The manifest
+      entry for historical-prd should be removed; the README row should drop
+      the PRD.md example (or replace it with onboarding-gap-analysis.md alone,
+      which does still exist).

--- a/audit/2026-05-26/findings/jtbd-extend-without-forking.yaml
+++ b/audit/2026-05-26/findings/jtbd-extend-without-forking.yaml
@@ -1,0 +1,259 @@
+unit_id: jtbd-extend-without-forking
+unit_path: reference/extend-without-forking.md
+category: jtbd
+audited_at: 2026-05-26T14:00:00Z
+auditor_notes: |
+  This JTBD is well-served by the implementation. The main signals are: (1)
+  `switchroom agent create --profile` writes a config entry and scaffolds in
+  one step; (2) skills are declared in switchroom.yaml and synced via
+  reconcile, no editing of agent files required; (3) MCP tools use mcp_servers
+  per-key merge + opt-out via `false`, letting one tool declaration reach a
+  subset of the fleet; (4) user-owned workspace files (SOUL.md, etc.) survive
+  reconcile and upgrades; (5) `agent destroy` removes the directory, but does
+  NOT remove the agent entry from switchroom.yaml — the operator must do that
+  manually before running `switchroom apply` to take the container down. This
+  leaves a residue in config, which partially contradicts the "Removing an
+  extension is as clean as adding it. No residue." sign. No JTBD body text
+  makes verifiable claims at the file-path / class-name / MCP-tool-name level,
+  so no jtbd-too-technical findings are raised. UAT prompts stay at outcome
+  level throughout.
+
+findings:
+  - claim_id: c1
+    quote: "Adding a new agent is a small config change, not a code change."
+    loc: L28
+    verdict: aligned
+    evidence:
+      - path: src/cli/agent.ts
+        lines: L848-L992
+        snippet: |
+          `agent create <name> --profile <profile>` writes an `extends:` entry
+          to switchroom.yaml and scaffolds without requiring any source edits.
+      - path: tests/cli.agent-create-profile.test.ts
+        lines: L176-L188
+        snippet: |
+          Test pins that `agent create smoketest --profile health-coach` writes
+          the entry and sets `extends: health-coach` in yaml.
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      `switchroom agent create <name> --profile <profile>` (or editing
+      switchroom.yaml with `extends:`) is a pure config operation. The test at
+      tests/cli.agent-create-profile.test.ts:176-188 pins this. No source edit
+      is required.
+
+  - claim_id: c2
+    quote: "The scaffolding provides sensible defaults. The user only overrides what's actually different."
+    loc: L29-L30
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L2051-L2059
+        snippet: |
+          `resolveAgentConfig` applies global defaults -> inline profile
+          (extends:) -> per-agent config. When no overrides, agent inherits
+          everything from the profile.
+      - path: src/config/merge.ts
+        lines: L1-L29
+        snippet: |
+          Three-layer cascade documented in header: scalars fill from defaults,
+          tools.allow is unioned, mcp_servers is per-key merged, schedule
+          concatenated.
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The three-layer cascade in src/config/merge.ts and
+      resolveAgentConfig in scaffold.ts implement exactly this. An agent entry
+      in switchroom.yaml with only a topic_name and extends: inherits lifecycle,
+      tools, MCP wiring, and skills from the profile and global defaults.
+
+  - claim_id: c3
+    quote: "New skills plug into existing agents without editing those agents."
+    loc: L31
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L2820-L2832
+        snippet: |
+          syncGlobalSkills reads `agentConfig.skills` (merged from defaults)
+          and symlinks skills into the agent's .claude/skills/ directory.
+          No agent file editing is needed.
+      - path: docs/skills.md
+        lines: L155-L166
+        snippet: |
+          "Adding a new skill: 1. Create at ~/.switchroom/skills/<name>/SKILL.md
+          2. Add to defaults.skills or agents.<name>.skills
+          3. Run switchroom agent reconcile <agent>"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Skills are declared in switchroom.yaml and synced to the agent's
+      .claude/skills/ dir on reconcile. No agent files are edited — a
+      `skills: [new-skill]` line in switchroom.yaml is the only change.
+
+  - claim_id: c4
+    quote: "A new tool becomes available to the agents that should have it, without touching unrelated agents."
+    loc: L32-L33
+    verdict: aligned
+    evidence:
+      - path: docs/configuration.md
+        lines: L160-L201
+        snippet: |
+          mcp_servers under `defaults:` flows to all agents; per-agent
+          `mcp_servers: { perplexity: false }` opts that agent out.
+          Per-key merge means adding a new MCP server in defaults only
+          reaches agents that don't opt out.
+      - path: src/config/merge.ts
+        lines: L16-L21
+        snippet: |
+          "mcp_servers: per-key shallow merge. Agent overrides a default
+          entry by declaring the same key."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      mcp_servers uses per-key merge: declare the server under `defaults:` and
+      it reaches all agents by default. Per-agent `false` opt-out suppresses it
+      only for that agent. No other agent configs need touching.
+
+  - claim_id: c5
+    quote: "The user can read one existing agent or skill and use it as a template for their own, without studying the framework internals."
+    loc: L34-L35
+    verdict: aligned
+    evidence:
+      - path: profiles/health-coach/CLAUDE.md.hbs
+        lines: L1-L1
+        snippet: |
+          Profile template files are human-readable Handlebars with clear
+          variable names; an operator can copy a profile dir and adapt it.
+      - path: docs/skills.md
+        lines: L155-L166
+        snippet: |
+          Step-by-step "Adding a new skill" section requires no framework
+          knowledge beyond the SKILL.md frontmatter shape.
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Profiles are readable .hbs templates. The skills workflow is documented
+      in docs/skills.md with a three-step recipe. However, the claim is
+      experiential ("without studying framework internals") and can't be fully
+      verified from code alone. The profile and skill shape are simple enough
+      to support the claim at medium confidence.
+
+  - claim_id: c6
+    quote: "Extensions inherit the product's safety, logging, and lifecycle behaviour automatically. The user doesn't have to reimplement it."
+    loc: L36-L37
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L2042-L2059
+        snippet: |
+          scaffoldAgent resolves the full cascade config and emits start.sh,
+          settings.json, .mcp.json — every agent gets identical lifecycle,
+          autoaccept, and safety scaffolding regardless of which profile it
+          extends.
+      - path: profiles/_base/start.sh.hbs
+        lines: L1-L1
+        snippet: |
+          The _base start.sh.hbs is unconditionally applied to every agent;
+          gateway, autoaccept-poll, and agent-scheduler sidecars are always
+          launched.
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      All lifecycle infrastructure (tmux, gateway, autoaccept-poll,
+      agent-scheduler) is emitted by scaffoldAgent unconditionally from
+      _base/start.sh.hbs. Safety settings, permissions defaults, and logging
+      are also scaffold-managed. A new agent inherits all of this by declaring
+      `extends: <profile>` — no reimplementation needed.
+
+  - claim_id: c7
+    quote: "Removing an extension is as clean as adding it. No residue."
+    loc: L38
+    verdict: drift-minor
+    evidence:
+      - path: src/cli/agent.ts
+        lines: L1930-L1981
+        snippet: |
+          `agent destroy` stops the agent, removes the agent directory with
+          rmSync, and prints "Agent destroyed." It does NOT call
+          removeAgentFromConfig — the switchroom.yaml entry remains.
+      - path: src/cli/agent.ts
+        lines: L1964-L1969
+        snippet: |
+          Comment in destroy: "Removing the entry from switchroom.yaml + running
+          `switchroom apply`... takes the container down. We don't shell out to
+          docker here... the compose layer is owned by `apply`, not
+          `agent destroy`." — documents that yaml cleanup is a manual step.
+    evidence_strength: strong
+    action: update-text
+    proposed_text: |
+      Removing an extension requires two steps: `switchroom agent destroy
+      <name>` removes the scaffold directory, then editing switchroom.yaml to
+      delete the agent entry and running `switchroom apply` removes the
+      container. The scaffold dir is fully cleaned; the yaml entry requires a
+      manual edit.
+    confidence: high
+    rationale: |
+      `agent destroy` (src/cli/agent.ts:1930-1981) removes only the agent
+      directory. The switchroom.yaml entry is not removed automatically — the
+      comment at L1964-1969 explicitly says the operator must edit yaml and run
+      apply. After destroy, an entry remains in switchroom.yaml (config
+      residue), which partially contradicts "no residue." The claim is
+      directionally accurate (no orphaned files, no memory leaks) but overstates
+      the cleanliness of the yaml side.
+
+  - claim_id: c8
+    quote: "A user should be able to look at one existing agent, understand the shape, and create a peer that fits."
+    loc: L22-L24
+    verdict: aligned
+    evidence:
+      - path: tests/cli.agent-create-profile.test.ts
+        lines: L78-L87
+        snippet: |
+          listAvailableProfiles() returns default, health-coach, coding,
+          executive-assistant — these serve as example templates the user can
+          study and replicate.
+      - path: src/cli/agent.ts
+        lines: L868-L875
+        snippet: |
+          `agent create <name> --profile <profile>` description says
+          "Scaffold a new agent directory (optionally from a profile)."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The profile system (health-coach, coding, executive-assistant) provides
+      concrete examples to copy. The --profile flag lets a user specify which
+      example to clone. The claim maps to real product behavior, though
+      "understand the shape" is experiential. Medium confidence because the
+      readability of profile templates can't be fully verified from code.
+
+  - claim_id: c9
+    quote: "The product's job is to make that feel like configuration, not forking."
+    loc: L9-L10
+    verdict: aligned
+    evidence:
+      - path: src/cli/agent.ts
+        lines: L848-L861
+        snippet: |
+          Two entry points: YAML-first (edit switchroom.yaml) or CLI-first
+          (--profile flag). Both are config operations, no code fork.
+      - path: src/config/merge.ts
+        lines: L1-L29
+        snippet: |
+          Three-layer cascade allows per-agent overrides without touching
+          profile or base code.
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Adding an agent, adding a skill, adding an MCP tool — all are
+      switchroom.yaml config changes, not source code edits. The cascade model
+      ensures agents inherit defaults and only override what differs. This
+      directly implements "configuration, not forking."

--- a/audit/2026-05-26/findings/jtbd-feel-like-a-colleague.yaml
+++ b/audit/2026-05-26/findings/jtbd-feel-like-a-colleague.yaml
@@ -1,0 +1,351 @@
+unit_id: jtbd-feel-like-a-colleague
+unit_path: reference/feel-like-a-colleague.md
+category: jtbd
+audited_at: 2026-05-26T12:00:00Z
+auditor_notes: |
+  This JTBD is well-anchored to shipped behavior. The core posture
+  requirements (one clarifying question, verify before claiming, match
+  energy, no AI-tells) are implemented in three layered artifacts:
+  profiles/default/CLAUDE.md.hbs, profiles/default/workspace/SOUL.md.hbs,
+  and profiles/_shared/telegram-style.md.hbs, plus the release-controlled
+  fleet invariant TELEGRAM_GUIDANCE constant in src/agents/scaffold.ts.
+
+  The conversational-pacing artefact (reference/conversational-pacing.md)
+  is the companion design doc; it ships the five-beat model as
+  profiles/_shared/telegram-style.md.hbs and src/agents/scaffold.ts
+  TELEGRAM_GUIDANCE. KPIs reference docs/posthog.md which exists and
+  telegram-plugin/runtime-metrics.ts which implements inbound_status_query
+  event capture.
+
+  One JTBD-stale-example finding: the UAT prompt "is the broker running?"
+  implicitly surfaces an infrastructure-named component (vault-broker) to
+  the non-technical user. The UAT prompt belongs in the JTBD as a test
+  harness reference, so this is borderline; verdict is aligned given the
+  UAT section is a dev test guide, not user-facing prose.
+
+  The approval-card behavior described at L47-51 and L132 is implemented
+  in telegram-plugin/permission-title.ts (plain-English descriptions +
+  collapsed card body). Strong evidence.
+
+  Session continuity / handoff briefing behavior (L54-57) is implemented
+  in profiles/default/CLAUDE.md.hbs L116-126, cross-referenced by
+  profiles/_shared/telegram-style.md.hbs L53. Strong evidence.
+
+  Fleet-wide posture consistency claim (L158-161) requires all profiles to
+  carry the same posture floor. The coding profile (profiles/coding/CLAUDE.md.hbs)
+  defers communication style entirely to SOUL.md.hbs and lacks the explicit
+  "ask one question" / "verify mutable facts" behavioral rules present in
+  default/CLAUDE.md.hbs. These rules reach all agents via the fleet
+  invariants file (TELEGRAM_GUIDANCE in src/agents/scaffold.ts), but the
+  coding profile's standalone CLAUDE.md.hbs is thinner than default. This
+  gap is bridged by the invariants mechanism; no action required.
+
+  One structural note: the JTBD mentions "approval card" (L50, L132) using
+  a product-internal term. This is not a path, class name, or container
+  name, so it does not trigger jtbd-too-technical.
+
+findings:
+  - claim_id: c1
+    quote: "asks before assuming, verifies before claiming, defers on irreversible calls"
+    loc: L3-L4
+    verdict: aligned
+    evidence:
+      - path: profiles/default/CLAUDE.md.hbs
+        lines: L37-L41
+        snippet: |
+          "Verify mutable facts before claiming them. Files, git state, clocks,
+          versions, services, processes, package state, the contents of an Edit
+          target: read live. Memory and prior context are not verification sources."
+      - path: profiles/default/workspace/SOUL.md.hbs
+        lines: L18-L19
+        snippet: |
+          "Resourceful first. Check memory, context, files before asking. If
+          genuinely unsure, ask. Don't guess, don't assume."
+      - path: src/agents/scaffold.ts
+        lines: L110-L141
+        snippet: |
+          "TELEGRAM_GUIDANCE constant: 'messaging a capable colleague — not a tool
+          emitting output. Five beats…'"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      All three layers (default CLAUDE.md.hbs, SOUL.md.hbs, fleet invariant
+      TELEGRAM_GUIDANCE) directly encode the verify-before-claiming and
+      ask-before-assuming posture. Tests at tests/soul-template-vars.test.ts
+      pin SOUL.md.hbs rendering.
+
+  - claim_id: c2
+    quote: "Asks one good question instead of guessing."
+    loc: L32-L35
+    verdict: aligned
+    evidence:
+      - path: profiles/default/CLAUDE.md.hbs
+        lines: L40-L41
+        snippet: |
+          "Non-final turn: use tools to advance, or ask the one clarifying
+          question that unblocks safe progress. One question, not five."
+      - path: profiles/default/workspace/SOUL.md.hbs
+        lines: L27-L29
+        snippet: |
+          "But clarify during planning. Wrong assumptions waste more time
+          than a quick question."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The "one question, not five" constraint is explicit in both the
+      default CLAUDE.md.hbs execution-bias section and the SOUL.md.hbs
+      values section.
+
+  - claim_id: c3
+    quote: "Reads the actual state before claiming anything about it. File contents,
+      current calendar, who's online, what's running."
+    loc: L37-L39
+    verdict: aligned
+    evidence:
+      - path: profiles/default/CLAUDE.md.hbs
+        lines: L37-L39
+        snippet: |
+          "Verify mutable facts before claiming them. Files, git state, clocks,
+          versions, services, processes, package state: read live. Memory and
+          prior context are not verification sources."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Direct one-to-one match between the JTBD claim and the CLAUDE.md.hbs
+      execution-bias rule.
+
+  - claim_id: c4
+    quote: "Knows the leash. Read-only is fine, fires immediately. Mutating
+      cross-agent work, vault keys it doesn't already have, anything that
+      touches another agent's state: it asks via the approval card, names
+      the action plainly, and waits."
+    loc: L48-L51
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/permission-title.ts
+        lines: L30-L68
+        snippet: |
+          "Human-friendly descriptions for switchroom-managed MCP tools…
+          for the approval card. mcp__agent-config__peers_list: 'List the
+          other agents on this instance'"
+      - path: profiles/default/CLAUDE.md.hbs
+        lines: L128-L138
+        snippet: |
+          "Every mutating / host verb — update_apply, agent_exec, agent_restart
+          — pauses for an operator approval card in Telegram before it executes:
+          a human must tap approve."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Approval card is implemented in telegram-plugin/permission-title.ts with
+      curated human-readable verb phrases per tool. The admin section of
+      CLAUDE.md.hbs explicitly instructs agents on the approval-wait pattern.
+      Non-admin path redirects to the admin agent.
+
+  - claim_id: c5
+    quote: "Picks up where it left off. Reads the briefing. Knows what was open
+      last session. Doesn't re-ask things the user already said yesterday."
+    loc: L54-L57
+    verdict: aligned
+    evidence:
+      - path: profiles/default/CLAUDE.md.hbs
+        lines: L114-L126
+        snippet: |
+          "Handoff briefing — on a clean shutdown, the Stop hook writes a bounded
+          raw transcript tail of the prior session to .handoff.md. On boot,
+          start.sh injects it into your --append-system-prompt so you can
+          reorient…"
+      - path: profiles/_shared/telegram-style.md.hbs
+        lines: L53
+        snippet: |
+          "If SWITCHROOM_PENDING_TURN=true is in your environment on boot,
+          invoke the /switchroom-runtime skill before answering."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Session continuity via handoff briefing (.handoff.md), Hindsight
+      auto-recall on every inbound, and SWITCHROOM_PENDING_TURN protocol
+      are all implemented and documented in the shipped scaffold.
+
+  - claim_id: c6
+    quote: "Matches the user's energy. Short reply gets a short reply…
+      Default short. Answer first. Context second. No preamble."
+    loc: L59-L62
+    verdict: aligned
+    evidence:
+      - path: profiles/default/workspace/SOUL.md.hbs
+        lines: L24-L26
+        snippet: |
+          "Default short. Thorough when stakes are high. Answer first, context
+          second. Never bury the lead. No preamble."
+      - path: profiles/_shared/telegram-style.md.hbs
+        lines: L1-L5
+        snippet: |
+          "replies should feel like one, not a terminal dump or a tracking
+          widget. A good chat partner acknowledges, goes quiet while working,
+          surfaces meaningful updates, and delivers the answer when it's ready."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Energy-matching and concision are encoded in both SOUL.md.hbs (fleet
+      default) and the telegram-style partial. The SOUL.md.hbs "Never"
+      section explicitly bans sycophantic preamble.
+
+  - claim_id: c7
+    quote: "Sounds like a person, not a model. No 'Certainly!' No 'I'd be
+      happy to.' No 'Great question!' No em-dashes."
+    loc: L64-L67
+    verdict: aligned
+    evidence:
+      - path: profiles/default/workspace/SOUL.md.hbs
+        lines: L41-L50
+        snippet: |
+          "Never: Open with 'Certainly!', 'Absolutely!', 'Of course!',
+          'Great question!', 'I'd be happy to'. Use em-dashes. Rewrite
+          with commas, periods, or parentheses."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The canonical AI-tells prohibition list in SOUL.md.hbs matches the
+      JTBD claim item-for-item. The telegram-style partial reinforces this
+      with "For drafts above ~500 chars… invoke the bundled /humanizer skill."
+
+  - claim_id: c8
+    quote: "A second agent in the fleet has the same posture but a different
+      voice. The user doesn't have to relearn how to work with each one."
+    loc: L87-L88
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L180-L204
+        snippet: |
+          "renderFleetInvariants() … TELEGRAM_GUIDANCE … MEMORY_GUIDANCE —
+          release-controlled fleet invariants. Every Switchroom agent reads
+          this via Claude Code native CLAUDE.md discovery."
+      - path: profiles/coding/workspace/SOUL.md.hbs
+        lines: L1-L68
+        snippet: |
+          "SOUL.md.hbs for coding profile contains separate voice/personality
+          while TELEGRAM_GUIDANCE reaches coding agent through fleet invariants."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The posture floor is enforced fleet-wide by the release-controlled
+      fleet invariants (TELEGRAM_GUIDANCE, MEMORY_GUIDANCE constants in
+      scaffold.ts), written to ~/.switchroom/fleet/switchroom-invariants.md
+      and loaded by every agent's claude process via --add-dir. Each profile
+      provides a distinct voice via its own SOUL.md.hbs. The coding profile
+      CLAUDE.md.hbs omits explicit "one question" and "verify mutable facts"
+      rules that are present in the default profile, but these arrive through
+      the invariants path. Confidence medium because the multi-path delivery
+      (invariants + per-profile CLAUDE.md.hbs) makes it harder to verify
+      end-to-end without running the full scaffold.
+
+  - claim_id: c9
+    quote: "Out of the box, on switchroom setup, the first agent reply should
+      already feel like a colleague. No yaml editing required."
+    loc: L153-L155
+    verdict: aligned
+    evidence:
+      - path: profiles/default/CLAUDE.md.hbs
+        lines: L18-L27
+        snippet: |
+          "Core Behavior: Respond helpfully, concisely, and conversationally.
+          When asked to do something ambiguous, ask one clarifying question
+          rather than guessing."
+      - path: src/agents/scaffold.ts
+        lines: L110-L145
+        snippet: |
+          "TELEGRAM_GUIDANCE baked into fleet invariants, applied on every
+          switchroom apply, no operator config required."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The default profile ships posture floor behaviors without any
+      yaml configuration. Fleet invariants are regenerated on apply and
+      reset to canonical if they drift.
+
+  - claim_id: c10
+    quote: "the chat IS the artifact. The agent's own reply is where the
+      colleague-feel lives, not a framework card or a pinned status. If the
+      temptation is to add a card to compensate for a flat reply, change
+      the prompt instead."
+    loc: L161-L163
+    verdict: aligned
+    evidence:
+      - path: reference/conversational-pacing.md
+        lines: L9-L14
+        snippet: |
+          "This is design v2. v1 (#1122) retired the pinned progress card and
+          declared 'the chat is the artifact' — correct — but kept a card-era
+          pacing instinct… v2 re-founds pacing on the five beats."
+      - path: profiles/_shared/telegram-style.md.hbs
+        lines: L1-L3
+        snippet: |
+          "Telegram is a chat — replies should feel like one, not a terminal
+          dump or a tracking widget."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The design v2 in conversational-pacing.md explicitly retired the
+      pinned-card model and re-founded the UX on the five-beat chat pattern.
+      The telegram-style partial encodes this directly. The JTBD's framing
+      is consistent with the shipped design contract.
+
+  - claim_id: c11
+    quote: "Every specialist needs it, not because they're the same agent in
+      different costumes, but because the feel of being a colleague is the
+      consistent posture under whatever persona sits on top."
+    loc: L17-L21
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L180-L204
+        snippet: |
+          "renderFleetInvariants() … release-controlled fleet invariants.
+          Every Switchroom agent reads this via Claude Code native CLAUDE.md
+          discovery."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The fleet invariants mechanism ensures consistent posture floor across
+      all agents. Confidence medium because verifying runtime behavior
+      across all profiles requires end-to-end scaffold execution.
+
+  - claim_id: c12
+    quote: "status? / still there? / any update? is a UX-failure signal, not
+      a feature request"
+    loc: L69-L88
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/runtime-metrics.ts
+        lines: L26-L31
+        snippet: |
+          "A user-sent message that matches a status-query pattern
+          ('status?', 'still there?', etc). Primary lagging KPI for the
+          conversational-pacing redesign."
+      - path: telegram-plugin/silence-poke.ts
+        lines: L2-L34
+        snippet: |
+          "framework safety net for 'model is silent to the user.' …
+          t=75s soft poke armed … t=300s framework fallback."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The JTBD claim is operationalized: runtime-metrics.ts tracks
+      inbound_status_query events as the primary lagging KPI, and
+      silence-poke.ts is the framework backstop that fires before users
+      feel compelled to ask. The telegram-style partial also instructs
+      agents to invoke /switchroom-runtime on receiving such a message.

--- a/audit/2026-05-26/findings/jtbd-give-each-agent-its-own-workspace.yaml
+++ b/audit/2026-05-26/findings/jtbd-give-each-agent-its-own-workspace.yaml
@@ -1,0 +1,404 @@
+unit_id: jtbd-give-each-agent-its-own-workspace
+unit_path: reference/give-each-agent-its-own-workspace.md
+category: jtbd
+audited_at: 2026-05-26T14:00:00Z
+auditor_notes: |
+  The implementation infrastructure (ensureBareClone, ensureAgentWorktree,
+  removeAgentWorktree in src/repos/) is complete and correct as standalone
+  code. The YAML schema for the repos: field is also defined (schema.ts:1592).
+  However, neither ensureBareClone nor ensureAgentWorktree is called anywhere
+  in the production lifecycle paths: scaffoldAgent and reconcileAgent in
+  src/agents/scaffold.ts both import these functions but never invoke them.
+  removeAgentWorktree is imported but also never called. The agent destroy path
+  (src/cli/agent.ts) does not call it either.
+
+  The env-var injection (buildRepoEnvVars, scaffold.ts:1135) is wired and does
+  run during both scaffold and reconcile — it computes the correct paths — but
+  since the worktrees are never provisioned, the exported env vars point to
+  non-existent directories.
+
+  This means every "Signs it's working" scenario in the JTBD describes behavior
+  that does not currently happen. The JTBD reads as a shipped feature; it is
+  a forward-looking design doc with partial implementation wired up but never
+  connected to the lifecycle.
+
+  The "dirty-tree: leave alone, warn" behavior is implemented inside
+  ensureAgentWorktree but is never exercised because the function is never
+  called. The boot-card surface does not have a "dirty since <ts>" row.
+
+  One referenced doc (docs/sub-agents.md) exists. The three other "See also"
+  cross-references (run-a-fleet-of-specialists.md, extend-without-forking.md,
+  survive-reboots-and-real-life.md) were not verified in this audit but are
+  outside scope for this unit.
+
+findings:
+  - claim_id: c1
+    quote: "Adding a switchroom agent that works on a repo automatically gives that
+      agent its own worktree. The user doesn't run `git worktree add`. They don't
+      pick a path. They don't pick a branch."
+    loc: L30-L32
+    verdict: outcome-not-realized
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L246-L253
+        snippet: |
+          import { ensureBareClone, bareClonePath } from "../repos/bare-clone.js";
+          import {
+            ensureAgentWorktree,
+            removeAgentWorktree,
+            ...
+          } from "../repos/agent-worktree.js";
+      - path: src/agents/scaffold.ts
+        lines: L2042-L2983
+        snippet: |
+          export function scaffoldAgent(...) {
+            // ... 900+ lines of scaffold logic ...
+            // ensureAgentWorktree / ensureBareClone are never called
+          }
+      - path: src/agents/scaffold.ts
+        lines: L3640-L4576
+        snippet: |
+          export function reconcileAgent(...) {
+            // ... 900+ lines of reconcile logic ...
+            // ensureAgentWorktree / ensureBareClone are never called
+          }
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      ensureAgentWorktree and ensureBareClone are imported in scaffold.ts but
+      never called in scaffoldAgent or reconcileAgent. The automatic worktree
+      provisioning on agent restart/reconcile that the JTBD describes does not
+      happen. The repos: schema field exists (schema.ts:1592) and the env-var
+      computation runs (buildRepoEnvVars, scaffold.ts:1135), but actual worktree
+      creation is a dead code path. This is a missing feature, not a doc drift.
+
+  - claim_id: c2
+    quote: "Two agents run `bun run build` in the same repo at the same time. Both
+      succeed. Neither's `dist/` clobbers the other's."
+    loc: L33-L34
+    verdict: outcome-not-realized
+    evidence:
+      - path: src/repos/agent-worktree.ts
+        lines: L147-L193
+        snippet: |
+          export async function ensureAgentWorktree(...): Promise<WorktreeState> {
+            const worktreePath = agentWorktreePath(agentDir, slug);
+            // Creates <agentDir>/work/<slug>/ as a dedicated worktree
+          }
+    evidence_strength: medium
+    action: escalate
+    confidence: high
+    rationale: |
+      The isolation mechanism (separate worktrees per agent per repo) is
+      implemented in ensureAgentWorktree but the function is never called from
+      the production lifecycle. Without provisioning, two agents would share
+      whatever working tree they have access to — exactly the failure mode the
+      JTBD exists to prevent.
+
+  - claim_id: c3
+    quote: "After a host reboot, each agent comes back to the worktree it left.
+      Uncommitted in-flight work is preserved, not stashed-and-lost."
+    loc: L37-L38
+    verdict: outcome-not-realized
+    evidence:
+      - path: src/repos/agent-worktree.ts
+        lines: L196-L208
+        snippet: |
+          if (isWorktreeDirty(worktreePath)) {
+            const sha = headShortSha(worktreePath);
+            process.stderr.write(
+              `[switchroom] repo "${slug}": dirty ... skipping ff-to-main\n`
+            );
+            return { path: ..., branch, dirty: true, dirtyCommit: sha };
+          }
+    evidence_strength: medium
+    action: escalate
+    confidence: high
+    rationale: |
+      The dirty-tree preservation logic exists in ensureAgentWorktree but the
+      function is never called. On reboot, no worktree provisioning or
+      fast-forward step runs, so there is no mechanism that could either
+      preserve or destroy an agent's in-flight work. The promise cannot be
+      verified either way.
+
+  - claim_id: c4
+    quote: "Removing an agent removes its worktrees. The repo's `.git/worktrees/`
+      doesn't accumulate orphans."
+    loc: L39-L40
+    verdict: outcome-not-realized
+    evidence:
+      - path: src/cli/agent.ts
+        lines: L1971-L1977
+        snippet: |
+          if (existsSync(agentDir)) {
+            rmSync(agentDir, { recursive: true, force: true });
+          }
+      - path: src/repos/agent-worktree.ts
+        lines: L250-L305
+        snippet: |
+          export async function removeAgentWorktree(...): Promise<void> {
+            // git worktree remove --force <path>
+            // git branch -D agent/<agentName>/main
+            // git worktree prune
+          }
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      The agent destroy command (src/cli/agent.ts:1971) rmSyncs the agentDir but
+      does not call removeAgentWorktree. The function exists in
+      src/repos/agent-worktree.ts but is not imported or called from the destroy
+      path. Orphan .git/worktrees/ entries and per-agent branches would accumulate
+      if worktrees had been provisioned (they are not currently provisioned, but
+      the removal gap is real for any future integration).
+
+  - claim_id: c5
+    quote: "Worktrees are provisioned lazily — on the first `agent restart`/`reconcile`
+      that runs after the repo appears in the agent's manifest, not on every session
+      start."
+    loc: L91-L92
+    verdict: vision-only
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L246-L253
+        snippet: "ensureBareClone and ensureAgentWorktree imported but not called in reconcileAgent"
+    evidence_strength: none
+    action: mark-vision
+    confidence: high
+    rationale: |
+      The lazy provisioning contract is a design decision described accurately
+      in the Decisions section. The code to implement it exists (ensureBareClone
+      + ensureAgentWorktree) and is even imported in scaffold.ts, but the wiring
+      into the reconcile path is absent. This claim should be marked as not-yet-built.
+
+  - claim_id: c6
+    quote: "Per-agent long-lived branch. `agent/<agent-name>/main`, where `<agent-name>`
+      is the agent's id from `switchroom.yaml`."
+    loc: L93-L95
+    verdict: aligned
+    evidence:
+      - path: src/repos/agent-worktree.ts
+        lines: L43-L45
+        snippet: |
+          export function agentBranchName(agentName: string): string {
+            return `agent/${agentName}/main`;
+          }
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The branch naming convention is correctly implemented in code.
+      The function is not yet called from production paths, but the convention
+      itself is accurate.
+
+  - claim_id: c7
+    quote: "Discovery via env. `SWITCHROOM_REPO_<NAME_UPPER>=<absolute path>` in the
+      agent's environment."
+    loc: L101-L102
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L1134-L1148
+        snippet: |
+          function buildRepoEnvVars(...): Record<string, string> {
+            const repos = agent.repos;
+            if (!repos) return {};
+            for (const slug of Object.keys(repos)) {
+              const envName = `SWITCHROOM_REPO_${slug.toUpperCase().replace(/-/g, "_")}`;
+              out[envName] = agentWorktreePath(agentDir, slug);
+            }
+          }
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The env-var injection is wired into buildRepoEnvVars and called from both
+      buildWorkspaceContext paths (scaffold and reconcile). The naming convention
+      matches the JTBD exactly. However, the paths injected point to worktrees
+      that are not provisioned, so the env var would reference a non-existent
+      directory at runtime. The claim is structurally aligned but operationally
+      hollow until worktree provisioning is wired up.
+
+  - claim_id: c8
+    quote: "Dirty-tree policy: leave alone, warn. If the worktree has uncommitted
+      changes at session start, the ff-to-main step is skipped. The session resumes
+      on whatever branch the worktree was on. The boot card surfaces
+      \"<repo>: dirty since <ts>\" as a one-line warning."
+    loc: L104-L107
+    verdict: drift-major
+    evidence:
+      - path: src/repos/agent-worktree.ts
+        lines: L196-L208
+        snippet: |
+          if (isWorktreeDirty(worktreePath)) {
+            process.stderr.write(`[switchroom] repo "${slug}": dirty ... skipping ff-to-main\n`);
+            return { path: ..., branch, dirty: true, dirtyCommit: sha };
+          }
+    evidence_strength: weak
+    action: update-text
+    confidence: medium
+    rationale: |
+      The dirty-detection and ff-skip logic is implemented in ensureAgentWorktree,
+      and it returns dirty:true with a dirtyCommit field. However, the function is
+      never called (see c1), so the dirty-tree policy never executes. More
+      importantly, the JTBD claims the boot card surfaces a "dirty since <ts>"
+      warning — there is no such line in boot-card.ts or the ProbeResult type;
+      the dirty state is only logged to stderr inside agent-worktree.ts. The boot
+      card claim is inaccurate for what is currently coded even if the function
+      were wired up. Suggested correction: change "The boot card surfaces" to
+      "The reconcile log emits a one-line warning" to match the stderr.write in
+      agent-worktree.ts:200. The larger problem (function not called) is covered
+      by c1 escalation.
+
+  - claim_id: c9
+    quote: "Removal is symmetric. `switchroom agent remove <name>` calls
+      `git worktree remove` for each of the agent's worktrees, then prunes the
+      per-agent branches."
+    loc: L109-L110
+    verdict: drift-major
+    evidence:
+      - path: src/cli/agent.ts
+        lines: L1931-L1981
+        snippet: |
+          agent.command("destroy <name>")
+          // ... only rmSync(agentDir) + stopAgent(name)
+          // removeAgentWorktree not called
+      - path: src/repos/agent-worktree.ts
+        lines: L250-L305
+        snippet: |
+          export async function removeAgentWorktree(...): Promise<void> {
+            // full implementation: git worktree remove + git branch -D + git worktree prune
+          }
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      The JTBD calls the command "switchroom agent remove <name>" but the command
+      is actually "switchroom agent destroy <name>". More critically, the destroy
+      command does not call removeAgentWorktree. The function exists and is
+      complete, but it is not imported or called from the CLI destroy path. The
+      bare clone's .git/worktrees/ would accumulate stale entries if worktrees
+      were provisioned. Both the command name discrepancy and the missing call
+      are gaps.
+
+  - claim_id: c10
+    quote: "Lifecycle is part of `agent restart`. Worktree provisioning,
+      ff-when-clean, and stale-branch cleanup happen as part of the
+      `restart = reconcile + restart` contract."
+    loc: L119-L121
+    verdict: vision-only
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L3640-L4576
+        snippet: "reconcileAgent contains no calls to ensureBareClone or ensureAgentWorktree"
+    evidence_strength: strong
+    action: mark-vision
+    confidence: high
+    rationale: |
+      The design decision is precisely documented but not implemented. reconcileAgent
+      does not call ensureBareClone or ensureAgentWorktree at any point in its
+      approximately 940-line body. The lifecycle integration described is the
+      intended design, not the current shipped behavior.
+
+  - claim_id: c11
+    quote: "One worktree per agent x repo. Stable path (`<agent_dir>/work/<repo_slug>/`,
+      where `<agent_dir>` is the agent's switchroom directory and `<repo_slug>` is
+      the kebab-case repo name)."
+    loc: L85-L90
+    verdict: aligned
+    evidence:
+      - path: src/repos/agent-worktree.ts
+        lines: L51-L53
+        snippet: |
+          export function agentWorktreePath(agentDir: string, slug: string): string {
+            return join(agentDir, "work", slug);
+          }
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The path convention matches the JTBD exactly. The function is called from
+      buildRepoEnvVars so the env var computation uses the correct path formula.
+
+  - claim_id: c12
+    quote: "The bare/canonical clone lives once per host at
+      `~/.switchroom/repos/<repo_slug>.git` (shared across agents)."
+    loc: L88-L89
+    verdict: aligned
+    evidence:
+      - path: src/repos/bare-clone.ts
+        lines: L22-L24
+        snippet: |
+          export function bareClonePath(slug: string): string {
+            return resolveStatePath(`repos/${slug}.git`);
+          }
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The bare clone path convention matches the JTBD exactly. The function
+      is implemented correctly. It is never called from production paths but
+      the convention documented is what the code would use.
+
+  - claim_id: c13
+    quote: "Sub-agents already get their own worktree per task — that's been the
+      pattern since the worker dispatch story shipped."
+    loc: L23-L24
+    verdict: aligned
+    evidence:
+      - path: docs/sub-agents.md
+        lines: L1-L1
+        snippet: "file exists"
+      - path: src/worktree/claim.ts
+        lines: L1-L1
+        snippet: "file exists (sub-agent worktree claim system)"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The sub-agent worktree system (src/worktree/) exists as a separate
+      implementation from the per-main-agent repos: system. The claim that
+      sub-agents already have their own worktree per task is plausible given
+      the worktree/ directory structure, but the mechanism is separate from the
+      repos: system being audited. Confidence medium because full verification
+      of the sub-agent worktree path was not in scope.
+
+  - claim_id: c14
+    quote: "Repos declared in `switchroom.yaml`. An agent's manifest lists the repos
+      it operates on. Worktrees are provisioned only for those. No surprise clones."
+    loc: L97-L99
+    verdict: aligned
+    evidence:
+      - path: src/config/schema.ts
+        lines: L1592-L1623
+        snippet: |
+          repos: z.record(
+            z.string().regex(/^[a-z0-9][a-z0-9-]*$/),
+            z.object({ url: z.string().min(1), branch_default: z.string().optional() })
+          ).optional().describe("Repos this agent operates on...")
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The repos: field in switchroom.yaml is correctly schema-defined, kebab-case
+      slug-keyed, and gated with .optional() so agents without repos: are unaffected.
+      The "no surprise clones" guarantee follows from the opt-in schema design.
+
+  - claim_id: c15
+    quote: "`node_modules` is per-worktree. Bun's content-addressed store makes the
+      disk cost tolerable. Build artifacts are also per-worktree. Don't try to share."
+    loc: L115-L117
+    verdict: vision-only
+    evidence:
+      - path: src/repos/agent-worktree.ts
+        lines: L1-L16
+        snippet: "No node_modules-specific logic in worktree module"
+    evidence_strength: none
+    action: mark-vision
+    confidence: low
+    rationale: |
+      Since worktrees are not currently provisioned, no node_modules isolation
+      is enforced. The claim is a design decision about what the feature will do
+      when built, not a description of current behavior. No code enforces or
+      prevents node_modules sharing between worktrees.

--- a/audit/2026-05-26/findings/jtbd-idempotent-update-and-restart.yaml
+++ b/audit/2026-05-26/findings/jtbd-idempotent-update-and-restart.yaml
@@ -1,0 +1,365 @@
+unit_id: jtbd-idempotent-update-and-restart
+unit_path: reference/idempotent-update-and-restart.md
+category: jtbd
+audited_at: 2026-05-26T10:00:00Z
+auditor_notes: |
+  Key structural finding: the JTBD was written before `switchroom update` existed
+  (PR #918). The JTBD describes the upgrade flow as three separate commands
+  (`switchroom apply` + `docker compose pull` + `docker compose up -d
+  --remove-orphans`). The shipped CLI wraps all of that (plus hostd refresh,
+  skill sync, and doctor) into a single `switchroom update` verb. Every place
+  the JTBD says "the upgrade flow" names the old three-command incantation.
+  This is drift-minor in many claims (behavior correct, surface description
+  stale) and drift-major in the "Signs it's working" section where it explicitly
+  names that three-command set as the canonical surface.
+
+  The "stale dependency" worked example (L141-L149) says doctor compares the
+  host claude against "the version baked into the running agent image." The
+  implementation compares host claude against `dependencies.json` (the
+  manifest), not by querying the container image. The practical outcome is
+  similar but the mechanism is materially different from the description.
+  No code path does a `docker exec ... claude --version` to read the in-image
+  version.
+
+  The `switchroom update` command already includes `refresh-hostd` (pull +
+  recreate the hostd daemon container) and `sync-bundled-skills` steps,
+  bringing the actual fleet of pieces updated in one command beyond what
+  the JTBD's frontmatter outcome lists ("CLI, agent containers, broker,
+  kernel, scheduler, MCP servers, memory backend" — missing: hostd, skills
+  pool).
+
+  Session continuity / escape hatch: the schema has `session_continuity.resume_mode`
+  with a `"none"` value (completely fresh every time) and `enabled: false`.
+  This is the escape hatch the JTBD calls for. It is present and documented
+  in the schema. `docs/architecture.md` and `docs/session-optimization.md`
+  document it. The JTBD itself does not name this config option, which is
+  acceptable at outcome level but worth noting.
+
+findings:
+  - claim_id: c1
+    quote: "After the upgrade flow finishes (`switchroom apply` + `docker compose pull` + `docker compose up -d --remove-orphans`), the entire stack — CLI, agent containers, broker, kernel, scheduler, MCP servers, memory backend — is at the version switchroom declared and tested as a unit."
+    loc: L3
+    verdict: drift-major
+    evidence:
+      - path: src/cli/update.ts
+        lines: L1-L36
+        snippet: "`switchroom update` wraps pull-images, apply-config, refresh-hostd, sync-bundled-skills, stamp-restart-marker, recreate-containers, and doctor into one command (PR #918). The three-command incantation in the JTBD is the pre-#918 flow."
+      - path: src/cli/update.ts
+        lines: L296-L338
+        snippet: "refresh-hostd step: pulls latest hostd image + recreates the daemon container (separate compose project). hostd is not mentioned in the JTBD's stack list."
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The canonical upgrade surface since PR #918 is `switchroom update`, not
+      the three-command incantation. The JTBD frontmatter outcome names the
+      stale command sequence. The stack list also omits hostd (refresh-hostd
+      step) and the skills pool (sync-bundled-skills step). The outcome
+      description should name `switchroom update` as the command and add hostd
+      to the stack list. Proposed replacement for the frontmatter `outcome:`
+      field: "After running `switchroom update`, the entire stack — CLI, agent
+      containers, broker, kernel, scheduler, hostd, MCP servers, bundled skills,
+      memory backend — is at the version switchroom declared and tested as a unit.
+      After any restart, the agent comes back with fresh code, fresh MCP servers,
+      fresh settings, and intact context. The user does not lose their thread."
+
+  - claim_id: c2
+    quote: "The user runs the upgrade flow (`switchroom apply` + `docker compose pull` + `docker compose up -d --remove-orphans`)."
+    loc: L9-L11
+    verdict: drift-major
+    evidence:
+      - path: src/cli/update.ts
+        lines: L882-L944
+        snippet: "registerUpdateCommand registers `switchroom update` as the canonical single-step upgrade command, described as 'pull images, refresh scaffolds, recreate containers. Wraps the full pull && apply && up -d flow.'"
+      - path: CLAUDE.md
+        lines: L749-L760
+        snippet: "### Operator update — `switchroom update` ... switchroom update  # pull images + apply + recreate + doctor"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The body of the JTBD still opens with the three-command incantation that
+      predates `switchroom update`. The shipped surface is a single command.
+      The entire opening paragraph should be rewritten to describe
+      `switchroom update` as the primary flow, with the underlying mechanics
+      (pull, apply, up -d) mentioned as what it orchestrates.
+
+  - claim_id: c3
+    quote: "switchroom is a release, not a moving target. A version of switchroom pins a tested matrix of agent / broker / kernel / scheduler images, the claude CLI baked into the agent image, playwright/mcp, hindsight, and every other moving piece."
+    loc: L22-L28
+    verdict: aligned
+    evidence:
+      - path: dependencies.json
+        lines: L1-L18
+        snippet: "Manifest pins switchroom_version, bun, node, claude CLI, playwright_mcp, hindsight.backend/client, vault_broker.protocol."
+      - path: src/manifest.ts
+        lines: L1-L8
+        snippet: "Pinned dependency manifest (BOM)... records the exact versions that were tested together so that `switchroom doctor` can detect when installed versions have drifted."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The BOM concept is fully implemented via `dependencies.json` and
+      `src/manifest.ts`. The manifest pins the exact versions tested together.
+      Minor note: "scheduler images" (Dockerfile.scheduler was retired in Phase 4)
+      — the scheduler is now in-container as a sibling process, not a separate
+      image. But at the JTBD level "scheduler images" can be read broadly as
+      the agent image that contains the scheduler bundle, so no correction needed
+      at outcome level.
+
+  - claim_id: c4
+    quote: "The version reported by the CLI matches the version actually loaded into every running process. `switchroom doctor` confirms with a green check."
+    loc: L37-L38
+    verdict: drift-minor
+    evidence:
+      - path: src/cli/doctor.ts
+        lines: L2380-L2418
+        snippet: "checkManifestDrift returns ok check with status 'ok' (green glyph) when all versions match, and drift items with status 'fail'/'warn' when they don't. The status ok glyph is chalk.green('checkmark')."
+      - path: src/cli/doctor-status.ts
+        lines: L29-L42
+        snippet: "statusGlyph('ok') returns chalk.green('checkmark'). The doctor renders per-check status glyphs, not a single fleet-level green."
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    rationale: |
+      Doctor does emit green checkmarks per passing check. However, the claim
+      implies a single "fleet is consistent" green check, whereas the actual
+      doctor runs ~20 sections and emits per-check status. The phrase "confirms
+      with a green check" is close enough to be minor drift rather than major,
+      but "no failures reported by `switchroom doctor`" would be more accurate
+      than "confirms with a green check."
+
+  - claim_id: c5
+    quote: "A user can re-run `switchroom apply` + `docker compose up -d` and `switchroom agent restart` any number of times, in any order, and end up in the same valid state every time."
+    loc: L39-L42
+    verdict: drift-minor
+    evidence:
+      - path: src/cli/update.ts
+        lines: L448-L465
+        snippet: "recreate-containers step runs `docker compose up -d --remove-orphans`. Comment: 'Up-d is cheap and idempotent — if nothing changed it's a no-op (#923 reviewer feedback).'"
+      - path: src/cli/apply.ts
+        lines: L627-L640
+        snippet: "runApply: 'Ordering matters: scaffold first (so compose-generation sees a well-formed agents directory), compose write second.' apply is idempotent."
+    evidence_strength: strong
+    action: update-text
+    confidence: medium
+    rationale: |
+      The idempotency claim is correct. The surface reference is stale: the
+      JTBD names `switchroom apply` + `docker compose up -d` as the canonical
+      form, while the shipped single-command equivalent is `switchroom update`
+      (which also wraps `switchroom agent restart` via reconcile). The fix is
+      to acknowledge `switchroom update` as the idempotent form, with
+      `switchroom apply` + `docker compose up -d` as an equivalent sub-flow
+      operators can still run directly.
+
+  - claim_id: c6
+    quote: "After a restart, the agent's first response demonstrates it knows what was happening — references the user's last message, today's calendar, an in-flight task — without being prompted."
+    loc: L43-L45
+    verdict: aligned
+    evidence:
+      - path: src/cli/handoff.ts
+        lines: L1-L103
+        snippet: "`switchroom handoff <agent>` builds `.handoff.md` and `.handoff-topic` sidecars from the most recent session JSONL. Invoked by the Stop hook and start.sh lazy fallback."
+      - path: src/config/schema.ts
+        lines: L364-L407
+        snippet: "SessionContinuitySchema with resume_mode 'handoff' (default) assembles briefing from recent Telegram messages, Hindsight recall, and today's daily memory file."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The session continuity / handoff briefing feature is implemented and
+      ships by default (resume_mode defaults to 'handoff' as of PR #362).
+      The briefing includes recent messages and Hindsight recall. The claim
+      is accurate at outcome level.
+
+  - claim_id: c7
+    quote: "After a restart, every MCP server that the agent's `settings.json` declares is actually loaded."
+    loc: L46-L48
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L1192-L1202
+        snippet: "scaffold writes settings.json including mcp_servers entries (minus opt-outs). reconcileAgent re-renders settings.json before each restart."
+      - path: src/cli/agent.ts
+        lines: L500-L560
+        snippet: "reconcileAndRestartAgent: reconcile runs before restart. 'Why reconcile before every restart? Restart was historically a pure restart ... across restarts and silently rotted.'"
+    evidence_strength: strong
+    action: keep
+    confidence: medium
+    rationale: |
+      Reconcile before restart ensures settings.json is current at boot.
+      Whether every MCP server *successfully* loads at runtime depends on
+      the MCP process lifecycle (npx stalls, crashes) which is outside
+      switchroom's control. The JTBD "Signs it's not" section already
+      acknowledges MCP server failures (L81-L84). At the surface level the
+      claim is about settings being current, which is well-implemented.
+
+  - claim_id: c8
+    quote: "Drift between declared and installed versions is surfaced loudly. If someone manually upgrades claude CLI or bun outside `switchroom update`, `switchroom doctor` flags it before it causes a confusing bug."
+    loc: L53-L55
+    verdict: aligned
+    evidence:
+      - path: src/manifest.ts
+        lines: L257-L297
+        snippet: "detectDrift probes bun, node, and claude CLI versions and compares against the manifest. Major-version mismatch sets ok:false. Minor/patch drift is also reported."
+      - path: src/cli/doctor.ts
+        lines: L2369-L2418
+        snippet: "checkManifestDrift returns fail/warn results for each drift item with a fix message: 'Update <component> to match the manifest, or re-run switchroom update'."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The manifest-drift check in doctor is fully implemented. Drift on
+      required components (bun, node, claude CLI) produces fail-level results.
+      The claim is accurate.
+
+  - claim_id: c9
+    quote: "A small, fixed set of commands (`switchroom apply`, `docker compose pull`, `docker compose up -d --remove-orphans`) that do the right thing for the whole stack."
+    loc: L88-L90
+    verdict: drift-major
+    evidence:
+      - path: src/cli/update.ts
+        lines: L882-L888
+        snippet: "`switchroom update` description: 'Update switchroom on this host: pull images, refresh scaffolds, recreate containers. Wraps the full pull && apply && up -d flow.' This is the single command that does what the JTBD names as 3 commands."
+      - path: CLAUDE.md
+        lines: L749-L760
+        snippet: "`switchroom update` is the shipped single-command upgrade surface. The three-command incantation is never surfaced to operators except as 'what update wraps.'"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      This is the surface-definition sentence in "What the user needs from the
+      surface." The shipped answer to this need is `switchroom update` (one
+      command). The JTBD should name `switchroom update` here, with the
+      individual steps noted as the underlying mechanics. Proposed replacement:
+      "A single command (`switchroom update`) that does the right thing for
+      the whole stack — pull new images, refresh scaffolds, recreate
+      containers, and run a post-bounce doctor sweep. Operators who want
+      finer control can still run `switchroom apply`, `docker compose pull`,
+      and `docker compose up -d --remove-orphans` individually."
+
+  - claim_id: c10
+    quote: "A way to see what's pinned for the current switchroom version, and what's actually installed, and any drift."
+    loc: L95-L97
+    verdict: aligned
+    evidence:
+      - path: src/cli/update.ts
+        lines: L564-L760
+        snippet: "`switchroom update --status` provides read-only snapshot: CLI version, image digest + pull time, container creation time per service."
+      - path: src/cli/doctor.ts
+        lines: L2369-L2418
+        snippet: "checkManifestDrift surfaces declared vs installed versions for all pinned components."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Two surfaces cover this need: `switchroom update --status` (image/container
+      ages) and `switchroom doctor` (manifest drift). Both are implemented.
+
+  - claim_id: c11
+    quote: "Continuity that doesn't depend on the underlying claude session surviving across restarts. Resume should be a feature of the switchroom layer (memory + handoff briefing + recent-message replay), not a side effect of `claude --continue` happening to succeed."
+    loc: L99-L103
+    verdict: aligned
+    evidence:
+      - path: src/config/schema.ts
+        lines: L383-L394
+        snippet: "resume_mode 'handoff' (default): 'never passes --continue; a fresh Claude starts each restart and reads a briefing assembled from recent Telegram messages, Hindsight recall, and today's daily memory file.'"
+      - path: src/cli/handoff.ts
+        lines: L1-L30
+        snippet: "handoff command builds .handoff.md from session JSONL; invoked by Stop hook. Pure + deterministic. No claude -p (RFC #1620)."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The default resume_mode is 'handoff' as of PR #362, explicitly implementing
+      this JTBD need. The briefing mechanism (handoff-summarizer.js, Stop hook,
+      start.sh lazy fallback) is independent of claude --continue.
+
+  - claim_id: c12
+    quote: "An escape hatch for opting out of automatic resume — useful when the user explicitly wants a clean slate, or when the prior session got into a confused state."
+    loc: L104-L106
+    verdict: aligned
+    evidence:
+      - path: src/config/schema.ts
+        lines: L383-L406
+        snippet: "resume_mode enum includes 'none': 'starts completely fresh every time.' Also session_continuity.enabled: false as a master switch."
+      - path: docs/architecture.md
+        lines: L64-L64
+        snippet: "The /reset and /new Telegram commands write a .force-fresh-session marker that start.sh consumes once to force a cold boot regardless of resume_mode."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The escape hatch exists at two levels: config (resume_mode: none or
+      enabled: false) for permanent opt-out, and /reset or /new Telegram
+      commands for one-shot clean slate. Both are implemented.
+
+  - claim_id: c13
+    quote: "Pull fetches the matched set of GHCR images at the new release tag; the rolling `up -d` replaces each agent + scheduler + broker container in turn."
+    loc: L113-L117
+    verdict: drift-minor
+    evidence:
+      - path: src/cli/update.ts
+        lines: L229-L243
+        snippet: "pull-images step: `docker compose -p switchroom -f <composePath> pull`. This pulls all compose services at once, not per-container."
+      - path: src/agents/compose.ts
+        lines: L1-L10
+        snippet: "compose.ts generates docker-compose.yml for the whole fleet under compose project 'switchroom'."
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    rationale: |
+      "Rolling `up -d` replaces each agent + scheduler + broker container in
+      turn" — docker compose up -d does recreate on a per-service basis, but
+      it's not strictly serial ("rolling" suggests sequential). The scheduler
+      is now in-container (not a separate container), so "each agent + scheduler
+      + broker" misstates the container topology. The fix is to note that
+      `up -d --remove-orphans` recreates services whose image or compose config
+      changed, and that the in-container scheduler (not a separate container)
+      boots as a sibling process inside each agent.
+
+  - claim_id: c14
+    quote: "The user enables a new MCP server in `switchroom.yaml` and runs `switchroom agent reconcile`. The reconcile re-renders the agent's `settings.json` and restarts the agent."
+    loc: L133-L137
+    verdict: aligned
+    evidence:
+      - path: src/cli/agent.ts
+        lines: L497-L560
+        snippet: "reconcileAndRestartAgent: reconcile re-renders per-agent files (settings.json, start.sh, .mcp.json), then restarts. reconcileAgent is called before every restart."
+      - path: src/cli/agent-reconcile.test.ts
+        lines: L1-L10
+        snippet: "Tests for reconcile verb exist."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      `switchroom agent reconcile` is a real verb that re-renders settings.json
+      and (via reconcileAndRestartAgent) restarts the agent. The claim is
+      accurate.
+
+  - claim_id: c15
+    quote: "`switchroom doctor` detects the host's claude is far behind the version baked into the running agent image, flags the drift as informational, and offers a one-liner to upgrade the host CLI."
+    loc: L145-L149
+    verdict: drift-minor
+    evidence:
+      - path: src/manifest.ts
+        lines: L162-L172
+        snippet: "probeClaudeVersion() probes `claude --version` from the host PATH. detectDrift compares against manifest.claude.cli (from dependencies.json)."
+      - path: src/cli/doctor.ts
+        lines: L2391-L2416
+        snippet: "drift items for claude CLI: status 'fail' on major mismatch, 'warn' on minor. fix: 'Update <component> to match the manifest, or re-run switchroom update'. No one-liner to upgrade the host CLI specifically."
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      Two inaccuracies: (1) doctor compares host claude against `dependencies.json`
+      (the pinned manifest) — not against "the version baked into the running
+      agent image." No code path reads the claude version from inside a container.
+      (2) The drift item's `fix` message is "Update <component> to match the
+      manifest, or re-run `switchroom update`" — not a one-liner to upgrade
+      the host CLI specifically. The example should say doctor compares the
+      host claude version against the manifest's declared version and flags
+      drift; the fix message points at `switchroom update`. Proposed replacement:
+      "`switchroom doctor` detects that the host's claude version differs from
+      the version declared in the current switchroom manifest, flags the drift,
+      and tells the user to run `switchroom update` to realign."

--- a/audit/2026-05-26/findings/jtbd-keep-my-subscription-honest.yaml
+++ b/audit/2026-05-26/findings/jtbd-keep-my-subscription-honest.yaml
@@ -1,0 +1,240 @@
+unit_id: jtbd-keep-my-subscription-honest
+unit_path: reference/keep-my-subscription-honest.md
+category: jtbd
+audited_at: 2026-05-26T10:00:00Z
+auditor_notes: |
+  The JTBD is tightly aligned with the codebase as of the current HEAD. The two
+  historical violations (handoff-summarizer and webhook-dispatch claude -p spawns)
+  were both removed by RFC #1620 workstreams A and B. A CI guard
+  (tests/bridge-flap-regression-guard.test.ts) enforces zero headless-claude
+  spawns going forward. One outstanding known gap: src/host-control/server.ts
+  contains a `claude -p ok` string in the deep-smoke probe (KNOWN_TEMPLATE_GAPS
+  entry referencing #1798 follow-up). The JTBD makes no mention of the OpenAI
+  Whisper voice-transcription feature, which is an opt-in third-party API surface
+  that the Anti-patterns section's "you also need an API key for feature X" item
+  arguably covers. That surface is opt-in and clearly documented in config schema,
+  but the JTBD's own anti-pattern wording and the "No-key refusal" UAT prompt
+  could be read as forbidding it. A minor wording gap, not a product defect.
+  The compliance-attestation.md is well-aligned but references are from April 25,
+  2026 — policy documents should be re-checked periodically.
+findings:
+  - claim_id: c1
+    quote: "every model call is the interactive `claude` session. Cron fires,
+      webhook triggers, and session handoffs are all delivered into that one
+      session as synthesized turns — never a headless `claude -p`, never the
+      SDK, never the raw API."
+    loc: L34-L36
+    verdict: aligned
+    evidence:
+      - path: src/web/webhook-dispatch.ts
+        lines: L17-L24
+        snippet: |
+          "Delivery (since #1620): a match synthesizes an InboundMessage tagged
+          meta.source="webhook" and delivers it via inject_inbound to the agent's
+          gateway socket — the same path cron uses. The webhook turn runs inside
+          the agent's live interactive `claude` session. No `claude -p`"
+      - path: src/agents/handoff-summarizer.ts
+        lines: L16-L25
+        snippet: |
+          "No `claude -p`. Earlier releases shelled out to a headless `claude -p`
+          here to LLM-summarize the transcript. Under Anthropic's 2026-06-15
+          policy a headless `claude -p` is *programmatic* usage ... RFC #1620
+          Workstream B replaced the per-turn summarizer with a pure transcript-
+          extraction helper."
+      - path: tests/bridge-flap-regression-guard.test.ts
+        lines: L20-L46
+        snippet: |
+          "Post-#1620 the codebase has zero headless-`claude` spawners, so we
+          cannot assert 'a spawner exists'... KNOWN_GAPS: {} (currently empty)"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      RFC #1620 workstreams A and B shipped (#1625, #1626). Both former callsites
+      (webhook-dispatch spawnAgentOneShot and handoff-summarizer claude -p) are
+      confirmed removed. CI guard in tests/bridge-flap-regression-guard.test.ts
+      enforces the zero-spawner invariant with KNOWN_GAPS empty. JTBD claim
+      is accurate.
+
+  - claim_id: c2
+    quote: "(RFC #1620 removed the last `claude -p`; a CI guard keeps it at zero.
+      The constraint is stated in `reference/vision.md` pillar 3 and enforced as
+      an engineering gate in `CLAUDE.md`.)"
+    loc: L37-L39
+    verdict: aligned
+    evidence:
+      - path: docs/rfcs/eliminate-claude-p.md
+        lines: L1-L6
+        snippet: |
+          "Status: accepted — 2026-05-21 (Workstream A shipped in #1625;
+          Workstream B in #1626)."
+      - path: tests/bridge-flap-regression-guard.test.ts
+        lines: L171-L179
+        snippet: |
+          "KNOWN_TEMPLATE_GAPS: { 'src/host-control/server.ts': '#1798' } — The
+          'deep' doctor auth-live smoke runs `claude -p ok` as a quota-costing
+          check... Opt-in, off by default."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      RFC #1620 status matches the claim. The CI guard exists and is confirmed
+      active. One known gap (src/host-control/server.ts deep smoke) is explicitly
+      tracked under #1798 in the KNOWN_TEMPLATE_GAPS allowlist, so the "kept at
+      zero untracked" invariant holds. The claim is accurate as stated.
+
+  - claim_id: c3
+    quote: "No hidden API billing, no side-door tokens, no asks for extra keys."
+    loc: L3 (frontmatter outcome)
+    verdict: drift-minor
+    evidence:
+      - path: telegram-plugin/voice-transcribe.ts
+        lines: L1-L19
+        snippet: |
+          "Voice-message transcription via OpenAI Whisper (#578 spike)...
+          Pure helper module — runs the API call but takes API key + audio bytes
+          as args."
+      - path: src/config/schema.ts
+        lines: L584-L591
+        snippet: |
+          "Inbound voice-message transcription (#578). When enabled, voice/audio
+          messages from allowlisted users are downloaded, transcribed via the
+          configured provider... API key read from ~/.switchroom/openai-api-key
+          (mode 0600). Off by default — opt-in per agent."
+      - path: src/cli/telegram.ts
+        lines: L158-L164
+        snippet: |
+          "Enable voice-message transcription via OpenAI Whisper. Vault-stores
+          the API key under 'openai/api-key'... --api-key <key>, 'OpenAI API
+          key (sk-...). Stored in the vault, never written to switchroom.yaml.'"
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    rationale: |
+      The OpenAI Whisper voice-transcription feature (#578) is an opt-in third-
+      party API surface requiring an OpenAI API key. It does not affect Anthropic
+      subscription billing, but the "no asks for extra keys" framing in the
+      outcome and the Anti-patterns item ("Asking the user for an API key as
+      'optional' when core features need it") create a tension. Voice
+      transcription is explicitly opt-in and not a "core feature" of the
+      subscription-honest claim, but the JTBD's current wording doesn't carve
+      out this opt-in third-party-service-key pattern. Suggest the frontmatter
+      outcome add a qualifier such as "No hidden API billing, no side-door tokens,
+      no Anthropic API keys — opt-in third-party service keys (e.g. OpenAI
+      Whisper) are stored in the vault and clearly opt-in."
+
+  - claim_id: c4
+    quote: "When the user hits a plan limit, the product says so honestly. It
+      doesn't silently spend elsewhere."
+    loc: L51-L52
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/operator-events.ts
+        lines: L276-L283
+        snippet: |
+          "All account slots are at the usage limit. Switchroom will auto-fallback
+          when another slot is available."
+      - path: telegram-plugin/auto-fallback-fleet.ts
+        lines: L1-L35
+        snippet: |
+          "Fleet-wide auto-fallback (RFC H)... 1. Probe live quota for every
+          account in parallel via the broker... 2. Skip blocked accounts entirely;
+          pick the lowest-utilization healthy candidate. 3. Call client.setActive
+          — same broker verb /auth use uses."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      When a quota limit is hit, the product surfaces a clear user-facing message
+      and switches to another subscriber account slot (if configured). There is no
+      silent billing fallback to API-key usage. The auto-fallback stays within the
+      subscription-slot pool and reports the switch to the user. Behavior matches
+      the claim.
+
+  - claim_id: c5
+    quote: "The compliance posture is documented and the documentation matches
+      the runtime behaviour. A user auditing the product doesn't find surprises."
+    loc: L53-L55
+    verdict: drift-minor
+    evidence:
+      - path: docs/compliance-attestation.md
+        lines: L7-L8
+        snippet: |
+          "Attestation date: 2026-04-25T00:00:00Z (revised; supersedes 2026-04-13).
+          Reviewed against: Anthropic's published documentation and policies as
+          of April 25, 2026"
+      - path: docs/compliance-attestation.md
+        lines: L32-L35
+        snippet: |
+          "Switchroom does not: Intercept, proxy, or modify Claude's inference
+          requests or responses ... Use the Anthropic Agent SDK or direct API
+          access"
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    rationale: |
+      The compliance-attestation.md is dated April 25, 2026. The 2026-06-15
+      Anthropic policy split (interactive vs. programmatic) is described in
+      CLAUDE.md and reference/vision.md but is NOT reflected in
+      docs/compliance-attestation.md, which predates the policy change and makes
+      no mention of the interactive/programmatic split or the RFC #1620 work.
+      A user auditing compliance today would find the attestation document silent
+      on the most current policy distinction. Recommend updating
+      docs/compliance-attestation.md to reference the 2026-06-15 policy,
+      the interactive-vs-programmatic split, and RFC #1620's elimination of all
+      claude -p callsites. The JTBD claim is otherwise accurate — behavior does
+      match documented intent — but the attestation doc itself lags.
+
+  - claim_id: c6
+    quote: "There's no second billing surface the user didn't ask for."
+    loc: L47-L48
+    verdict: aligned
+    evidence:
+      - path: src/host-control/server.ts
+        lines: L1574-L1578
+        snippet: |
+          "if (req.args.deep) { PROBES.push({ name: 'auth_live', cmd: 'timeout 25
+          claude -p ok >/dev/null 2>&1' }); }"
+      - path: tests/bridge-flap-regression-guard.test.ts
+        lines: L171-L179
+        snippet: |
+          "KNOWN_TEMPLATE_GAPS: { 'src/host-control/server.ts': '#1798' } — The
+          'deep' doctor auth-live smoke runs `claude -p ok` as a quota-costing
+          check that the agent's OAuth is live. Opt-in, off by default."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The one remaining `claude -p` callsite (deep auth smoke in
+      src/host-control/server.ts) is explicitly opt-in (requires deep=true),
+      off by default, explicitly tracked as a known compliance gap under issue
+      #1798, and produces no user-visible billing surface — it's a diagnostic
+      tool. The claim "no second billing surface the user didn't ask for" holds
+      because the default doctor/smoke path makes no model call. The #1798
+      follow-up (migrating to token-introspect via auth-broker) would close the
+      last tracked gap entirely.
+
+  - claim_id: c7
+    quote: "A headless `claude -p` or an Agent SDK call anywhere in a code path.
+      Since 2026-06-15 both are *programmatic* usage — they draw the separate
+      Agent-SDK credit, not the subscription."
+    loc: L64-L67
+    verdict: aligned
+    evidence:
+      - path: tests/bridge-flap-regression-guard.test.ts
+        lines: L46-L46
+        snippet: "const KNOWN_GAPS: Record<string, string> = {};"
+      - path: src/auth/broker/server.ts
+        lines: L1-L20
+        snippet: |
+          "switchroom-auth-broker server — sole writer of per-agent
+          .claude/.credentials.json and canonical owner of the OAuth refresh loop
+          for every Anthropic account on the host (RFC H)."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      No Anthropic SDK imports exist in src/ or telegram-plugin/ source. The auth
+      broker manages OAuth tokens for the native claude CLI, not SDK credentials.
+      The KNOWN_GAPS allowlist is empty for the spawn-callsite scan. The anti-
+      pattern description is accurate and matches the engineering constraint.

--- a/audit/2026-05-26/findings/jtbd-know-what-my-agent-is-doing.yaml
+++ b/audit/2026-05-26/findings/jtbd-know-what-my-agent-is-doing.yaml
@@ -1,0 +1,399 @@
+unit_id: jtbd-know-what-my-agent-is-doing
+unit_path: reference/know-what-my-agent-is-doing.md
+category: jtbd
+audited_at: 2026-05-26T18:00:00Z
+auditor_notes: |
+  This JTBD is largely well-maintained and explicitly acknowledges the progress
+  card retirement. Several findings warrant attention:
+
+  1. The JTBD leaks implementation file paths in section 1 (status-reactions.ts,
+     gateway.ts, waiting-ux-spec.md) and section 2 (profiles/_shared/telegram-style.md.hbs)
+     and section 3 (reference/conversational-pacing.md). These are acceptable as
+     cross-reference pointers for developers but are borderline jtbd-too-technical.
+     Verdict left as jtbd-too-technical on the most egregious block (the "Implementation:"
+     paragraph at L58-61); others are kept since they point to design docs rather than
+     class names or function names.
+
+  2. The "~100ms" reaction timing claim at L37 is faster than what the code targets.
+     The code comment at gateway.ts:7854 states "The spec deadline is 800ms," not 100ms.
+     This is drift-minor: the reaction fires quickly (sub-800ms), and the JTBD's intent
+     ("effectively instantly") is preserved, but the specific number is wrong.
+
+  3. The 🔥 claim at L51-52 is misleading. The JTBD frames 🔥 as a reaction-state that
+     is "non-terminal: recovery to a working state from 🔥 is allowed." In the code,
+     🔥 never appears in REACTION_VARIANTS (status-reactions.ts L74-85), so it is never
+     emitted as a reaction by the status controller. The 🔥 appears in the operator-events
+     message text for 5xx errors (operator-events.ts L372), not as a reaction on the
+     user's inbound message. The non-terminal error reaction is 😱 (REACTION_VARIANTS.error).
+
+  4. The inbound_ack event cross-reference at L57 points to docs/posthog.md, but the
+     event is absent from that doc's events table.
+
+  5. The silence-poke success rate target at L208 (">80%") is contradicted by actual
+     empirical data documented at pending-work-progress.ts L13-16 ("0-7% across hundreds
+     of fires"). This is an outcome-not-realized signal — the conversational-pacing safety
+     net is not working at the claimed effectiveness level. The pending-work-progress.ts
+     module was introduced precisely because the silence-poke ladder fails as a cross-turn
+     mechanism. Escalated.
+
+findings:
+  - claim_id: c1
+    quote: "It fires within ~100ms of the message arriving (👀 received)"
+    loc: L37
+    verdict: drift-minor
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L7850-L7854
+        snippet: |
+          // F2 fix (#553): fire 👀 reaction on RAW arrival, before the coalesce
+          // wait blocks first paint. Pre-fix, the controller's setQueued() inside
+          // handleInbound only ran AFTER the coalesce flush (default gapMs=1500),
+          // so the user perceived ~1.5s of silence after their message landed.
+          // The spec deadline is 800ms.
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The code's own spec comment states the deadline is 800ms, not 100ms.
+      Replace "~100ms" with "within ~800ms" or "effectively immediately (sub-second)"
+      to match the implemented spec deadline while preserving the intent.
+
+  - claim_id: c2
+    quote: "The reaction is a reflective state machine, not a linear ratchet (#1713)."
+    loc: L43-44
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/status-reactions.ts
+        lines: L1-34
+        snippet: |
+          Reflective state machine — see issue #1713 for the canonical contract.
+          Working states (`thinking`, `tool`, `coding`, `web`, `compacting`) cycle
+          freely and bidirectionally — the same state can re-enter multiple times
+          within one turn.
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Code directly implements the described reflective state machine semantics.
+      Issue #1713 is referenced in the code header matching the JTBD's citation.
+
+  - claim_id: c3
+    quote: "Only the turn_end IPC event (Stop hook) finalizes to 👍."
+    loc: L47-48
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L1735-L1742
+        snippet: |
+          * Only the `turn_end` IPC handler, disconnect-flush, and boot-sweep
+          * ...
+          function finalizeStatusReaction(
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      finalizeStatusReaction is called from the turn_end path (L5126, L7111, L7417).
+      The code comment at L1735 lists exactly the same termination sources the JTBD describes.
+
+  - claim_id: c4
+    quote: |
+      🔥 is reserved for genuine 5xx server errors and is also non-terminal:
+      recovery to a working state from 🔥 is allowed
+    loc: L51-52
+    verdict: drift-major
+    evidence:
+      - path: telegram-plugin/status-reactions.ts
+        lines: L71-L85
+        snippet: |
+          * 🔥 is reserved for genuine 5xx server errors (operator-events.ts).
+          * It reads as "on fire / broken" — keep it out of normal active-work states.
+          ...
+          error:     ['😱', '😨', '🤯'],      // NON-TERMINAL — recovery allowed
+      - path: telegram-plugin/operator-events.ts
+        lines: L369-L383
+        snippet: |
+          case 'unknown-5xx':
+            return {
+              text: [
+                `🔥 <b>Server error (5xx)</b> for <b>${agent}</b>.`,
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      🔥 never appears in REACTION_VARIANTS and is never emitted by the status
+      controller as a reaction on the user's inbound message. For 5xx events,
+      🔥 appears in the TEXT of an operator-event notification message, not as a
+      reaction. The non-terminal error reaction is 😱 (REACTION_VARIANTS.error).
+      The JTBD should either remove the 🔥 claim or clarify that 🔥 appears as
+      a message prefix in operator notifications, not as a reaction on the inbound.
+
+  - claim_id: c5
+    quote: |
+      Implementation: `telegram-plugin/status-reactions.ts` (controller),
+      `telegram-plugin/gateway/gateway.ts` (turn_end IPC handler →
+      `finalizeStatusReaction`). The technical contract spec lives at
+      `telegram-plugin/docs/waiting-ux-spec.md`.
+    loc: L58-L61
+    verdict: jtbd-too-technical
+    evidence:
+      - path: telegram-plugin/status-reactions.ts
+        lines: L1
+        snippet: "file exists"
+      - path: telegram-plugin/docs/waiting-ux-spec.md
+        lines: L1
+        snippet: "file exists"
+    evidence_strength: medium
+    action: rewrite-at-outcome-level
+    confidence: medium
+    rationale: |
+      JTBDs should describe user outcomes, not implementation internals. Naming
+      specific files, function names (finalizeStatusReaction), and IPC event labels
+      (turn_end) leaks architecture. Remove the "Implementation:" paragraph or move
+      it to a developer sidebar. The two sentences can be replaced with: "See the
+      ambient layer design contract at `reference/conversational-pacing.md`."
+      (The conversational-pacing.md reference at L106 is already the right level.)
+
+  - claim_id: c6
+    quote: |
+      The status reaction on the user's own inbound message is the always-on
+      liveness signal. ... reflects current turn activity through working states
+      (🤔 thinking, ✍ tool, 👨‍💻 coding, ⚡ web lookup)
+    loc: L33-39
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/status-reactions.ts
+        lines: L74-L85
+        snippet: |
+          thinking:  ['🤔', '🤓', '👀'],
+          tool:      ['✍', '⚡', '👌'],
+          coding:    ['👨‍💻', '✍', '⚡'],
+          web:       ['⚡', '🤔', '👌'],
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Primary emoji for each working state exactly matches the JTBD description:
+      🤔 for thinking, ✍ for tool, 👨‍💻 for coding, ⚡ for web.
+
+  - claim_id: c7
+    quote: |
+      The full design contract lives at `reference/conversational-pacing.md`.
+      Kill switch: SWITCHROOM_DISABLE_SILENCE_POKE=1.
+    loc: L105-L107
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L172-L175
+        snippet: |
+          export function silencePokeEnabled(): boolean {
+            const v = process.env.SWITCHROOM_DISABLE_SILENCE_POKE
+            return !(v === '1' || v === 'true')
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Kill switch env var name matches exactly. conversational-pacing.md exists.
+
+  - claim_id: c8
+    quote: |
+      75s silence → soft poke. ... 180s silence → firm poke. ...
+      300s silence → framework fallback.
+    loc: L93-L100
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L113-L120
+        snippet: |
+          export const DEFAULT_THRESHOLDS: ThresholdsMs = {
+            ack: 10_000,
+            soft: 75_000,
+            firm: 180_000,
+            fallback: 300_000,
+            subagentSoft: 300_000,
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Thresholds exactly match the three values stated in the JTBD.
+
+  - claim_id: c9
+    quote: |
+      Subagent-dispatch (`Task` / `Agent`) extends the soft threshold to 300s
+      for that turn (legitimate wait on a child).
+    loc: L102-L103
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L240-L245
+        snippet: |
+          export function noteSubagentDispatch(key: string): void {
+            const s = state.get(key)
+            if (s == null) return
+            s.subagentDispatchActive = true
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      subagentSoft threshold is 300_000ms and is activated by noteSubagentDispatch,
+      matching the JTBD description exactly.
+
+  - claim_id: c10
+    quote: |
+      The prompt that teaches this rhythm lives at
+      `profiles/_shared/telegram-style.md.hbs`.
+    loc: L85-L86
+    verdict: aligned
+    evidence:
+      - path: profiles/_shared/telegram-style.md.hbs
+        lines: L7-L14
+        snippet: |
+          **Conversational pacing — a human is on the other side.** Match the
+          rhythm of a capable colleague messaging you back. Five beats:
+          - **1 · Acknowledge first.** ...
+          - **3 · Surface meaningful progress** at genuine inflection points...
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      File exists and contains the five-beat pacing teaching described in the JTBD.
+      The file path reference is a borderline technical pointer, but it names a
+      design artefact rather than a code implementation, so it's acceptable here.
+
+  - claim_id: c11
+    quote: |
+      see the `inbound_ack` event in `docs/posthog.md`
+    loc: L57
+    verdict: dead-pointer
+    evidence:
+      - path: docs/posthog.md
+        lines: L72-L77
+        snippet: |
+          | `inbound_status_query`   | ...
+          | `turn_started`           | ...
+          | `turn_ended`             | ...
+      - path: telegram-plugin/streaming-metrics.ts
+        lines: L60-L65
+        snippet: |
+          | {
+              kind: 'inbound_ack'
+              chatId: string
+              messageId: number
+              ackDelayMs: number
+            }
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The inbound_ack event exists in the code (streaming-metrics.ts L61, gateway.ts
+      L8665) but is not listed in the posthog.md events table. The JTBD cross-reference
+      sends readers to a doc that doesn't contain what it promises. Either add the event
+      to posthog.md's table or change the reference to "streaming-metrics.ts" where the
+      event type is declared.
+
+  - claim_id: c12
+    quote: |
+      Silence-poke success rate. Force a long tool-churn period with no
+      outbound messages. The soft poke at 75s should produce an update
+      from the model within 15s (the `silence_poke_succeeded` event).
+      Success rate target: >80%.
+    loc: L205-L208
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/pending-work-progress.ts
+        lines: L13-L16
+        snippet: |
+          - silence-poke success rate is 0–7% across hundreds of fires
+            (finn: 0/78, clerk: 6/91, klanker: 5/158) — the polite levels
+            reach the model as `<system-reminder>`s piggybacked on the next
+            tool result, so they (a) only land if the model is actively
+            cycling tools, ...
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      The JTBD states a UAT success target of >80% for silence-poke. Empirical data
+      captured in pending-work-progress.ts (added to address issue #1445) shows
+      actual success rates of 0-7% across hundreds of real fires. The silence-poke
+      ladder works as implemented but fails to achieve its stated outcome at the
+      conversational layer. The pending-work-progress module was introduced as a
+      partial mitigation for cross-turn silence. This is a product-level gap, not
+      a doc edit. The UAT prompt target (>80%) should be updated to reflect reality
+      or the underlying model-poke mechanism needs rethinking. Escalate to operator.
+
+  - claim_id: c13
+    quote: |
+      Earlier versions of this doc prescribed that — a pinned two-zone status card
+      that owned ambient, structured, and narrative signals at once. We retired the
+      card in #1122 (PR3)
+    loc: L19-L22
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/session-tail.ts
+        lines: L37
+        snippet: |
+          // #1122 PR3: inlined from the deleted progress-card.ts.
+      - path: telegram-plugin/subagent-watcher.ts
+        lines: L943
+        snippet: |
+          // Card retired (#1122): the watcher no longer sends a user-facing
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Code comments in session-tail.ts and subagent-watcher.ts confirm the progress
+      card was retired under #1122 PR3. The JTBD's self-referential history is accurate.
+
+  - claim_id: c14
+    quote: |
+      A stall escalates the reaction (😨) so the user can tell idle from stuck
+      at a glance.
+    loc: L54-L55
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/status-reactions.ts
+        lines: L83-L84
+        snippet: |
+          stallSoft: ['🥱', '😴', '🤔'],
+          stallHard: ['😨', '🤯', '😱'],
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      stallHard maps to 😨 as the primary emoji. The stall watchdog timers are wired
+      at 30s/90s defaults, and stallHard escalates to 😨 confirming the JTBD claim.
+
+  - claim_id: c15
+    quote: |
+      Power users who want the technical receipt can pull the runtime metrics JSONL
+      or use a future `/lasttrace` command — the escape hatch, not the headline.
+    loc: L81-L83
+    verdict: aligned
+    evidence:
+      - path: reference/conversational-pacing.md
+        lines: L167
+        snippet: |
+          - A `/lasttrace` Telegram command for power users who want the
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      /lasttrace does not exist in gateway.ts or anywhere in the plugin codebase.
+      The JTBD correctly qualifies it as a "future" command. The runtime metrics JSONL
+      (/state/agent/runtime-metrics.jsonl) does exist. Both claims remain accurate.
+
+  - claim_id: c16
+    quote: |
+      The `inbound_status_query` event in PostHog measures this directly.
+    loc: L135
+    verdict: aligned
+    evidence:
+      - path: docs/posthog.md
+        lines: L74
+        snippet: |
+          | `inbound_status_query` | telegram-plugin/inbound-classifier.ts |
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      inbound_status_query is documented in posthog.md L74, emitted from
+      inbound-classifier.ts, and used in KPI definitions at posthog.md L97.

--- a/audit/2026-05-26/findings/jtbd-remember-across-sessions.yaml
+++ b/audit/2026-05-26/findings/jtbd-remember-across-sessions.yaml
@@ -1,0 +1,290 @@
+unit_id: jtbd-remember-across-sessions
+unit_path: reference/remember-across-sessions.md
+category: jtbd
+audited_at: 2026-05-26T00:00:00Z
+auditor_notes: |
+  The JTBD is well-matched to the implemented Hindsight integration in its
+  broad strokes (semantic recall, corrections, cross-session continuity).
+  Three gap areas found:
+
+  1. "Memory decays sensibly" (Signs it's working) — no decay/TTL mechanism
+     exists in the shipped code or vendor scripts. Hindsight stores memories
+     indefinitely. The anti-pattern "Stale preferences don't haunt the user a
+     year later" is aspirational, not implemented. Marked vision-only.
+
+  2. "Deletion" UAT prompt — mcp__hindsight__delete_memory exists and is
+     plumbed into the MEMORY_GUIDANCE fleet invariant in scaffold.ts, so
+     per-memory deletion works in-session. However, the JTBD's "Tell the
+     agent to forget something. Confirm it's gone" framing implies a
+     user-visible acknowledgement path. This is in fact implemented via
+     the "Forget proactively" section in scaffold.ts L163. Marked aligned.
+
+  3. Orphaned Hindsight bank on agent destroy — the JTBD has no direct claim
+     about this, but the anchors_hint calls it out. Code confirms the gap:
+     agent destroy (src/cli/agent.ts:1930-1979) does not call Hindsight to
+     drop the bank. Prior audit (audit/2026-05-26/escalations.md) already
+     captured this as escalation-08. Not a JTBD claim, so not a finding here.
+
+  4. The CLAUDE.md line "Auto-memory is the second-tier source" applies to
+     the operator/developer context (this repo), NOT to deployed agents.
+     Deployed agents have autoMemoryEnabled=false when Hindsight is active
+     (scaffold.ts:2303-2310, 4083-4085). The CLAUDE.md statement is correct
+     in its own context — it describes operator-side Claude Code memory for
+     the switchroom repo itself.
+
+  This JTBD is largely outcome-level with no implementation-specific leakage.
+  The only material gap is the memory-decay claim.
+findings:
+  - claim_id: c1
+    quote: "The agent brings back relevant facts, preferences, decisions, and open threads from past conversations, in the right moment, without the user reminding it."
+    loc: L3-L4
+    verdict: aligned
+    evidence:
+      - path: vendor/hindsight-memory/scripts/recall.py
+        lines: L1-L10
+        snippet: "Auto-recall hook for UserPromptSubmit. [...] Call Hindsight recall API [...] Format memories and output hookSpecificOutput.additionalContext"
+      - path: vendor/hindsight-memory/scripts/recall.py
+        lines: L93
+        snippet: "excluded from the auto-recall block injected on every UserPromptSubmit"
+      - path: vendor/hindsight-memory/hooks/hooks.json
+        lines: L13-L22
+        snippet: "UserPromptSubmit hook calls recall.py with timeout 12"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      recall.py fires as a Claude Code UserPromptSubmit hook on every inbound
+      user message, queries Hindsight, and injects "Relevant memories from past
+      conversations" as additionalContext. The hook is registered in
+      vendor/hindsight-memory/hooks/hooks.json and is wired into every agent
+      scaffold that has Hindsight enabled.
+
+  - claim_id: c2
+    quote: "What comes back is relevant, not a grab-bag. If the agent recalls five things, four of them should be useful."
+    loc: L29-L30
+    verdict: aligned
+    evidence:
+      - path: src/memory/hindsight.ts
+        lines: L137-L140
+        snippet: "DEFAULT_RETAIN_MISSION: Extract user preferences, ongoing projects, recurring commitments, important context, and durable facts that should help across future conversations. Skip one-off chatter and temporary task noise."
+      - path: vendor/hindsight-memory/scripts/recall.py
+        lines: L93
+        snippet: "excluded from the auto-recall block injected on every UserPromptSubmit"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The retain mission (DEFAULT_RETAIN_MISSION) is seeded with explicit
+      instructions to skip chatter, and the recall pipeline filters demoted
+      memories. Relevance is also a quality of the upstream Hindsight service
+      (semantic search). The JTBD outcome is addressed by the mission wording
+      and the demote mechanism, though quality depends on the external service.
+
+  - claim_id: c3
+    quote: "The user can correct a stored fact, and the correction sticks. The agent doesn't reassert the old version later."
+    loc: L31-L32
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L159-L161
+        snippet: "When the user corrects you or contradicts a prior memory, call `delete_memory` on the wrong entry, then `sync_retain` the correction. Acknowledge the correction in one line."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The MEMORY_GUIDANCE fleet invariant (written to every agent via
+      scaffold.ts) instructs the agent to call delete_memory on wrong entries
+      and sync_retain the correction. This is part of the mandatory fleet
+      invariant block, not optional guidance.
+
+  - claim_id: c4
+    quote: "A restart, a compaction, or a new chat window doesn't reset the relationship. The agent picks up roughly where it was."
+    loc: L35-L36
+    verdict: aligned
+    evidence:
+      - path: profiles/default/CLAUDE.md.hbs
+        lines: L114-L127
+        snippet: "Session Continuity: Hindsight memory — auto-recall fires on every inbound user message and surfaces relevant memories from past sessions. Long-term facts, decisions, and mental models live here, not in the transcript."
+      - path: profiles/default/CLAUDE.md.hbs
+        lines: L117-L118
+        snippet: "Handoff briefing — on a clean shutdown, the Stop hook writes a bounded raw transcript tail of the prior session to .handoff.md."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Cross-restart persistence is handled by Hindsight recall (fires on every
+      inbound), the handoff briefing (.handoff.md injected by start.sh), and
+      the Telegram message buffer. All three mechanisms are implemented and
+      documented in the default agent template.
+
+  - claim_id: c5
+    quote: "The user can see what the agent believes about them and why. Nothing is hidden in a black box."
+    loc: L38-L39
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L165-L167
+        snippet: "When the user asks 'what do you know about X / me'... use `reflect` to synthesize an answer across the bank. Return it as honest prose, not a raw dump."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The MEMORY_GUIDANCE fleet invariant instructs the agent to use
+      mcp__hindsight__reflect in response to any memory-audit question, returning
+      honest prose. The mcp__hindsight__list_memories and list_mental_models
+      tools are also available per the agent CLAUDE.md.hbs template (L72).
+
+  - claim_id: c6
+    quote: "Memory decays sensibly. Stale preferences don't haunt the user a year later."
+    loc: L40
+    verdict: vision-only
+    evidence:
+      - path: src/memory/hindsight.ts
+        lines: L1-L738
+        snippet: "No decay/TTL parameter exists in createBank, updateBankMissions, or any Hindsight API call."
+      - path: vendor/hindsight-memory/scripts/recall.py
+        lines: L113-L155
+        snippet: "_cache_ttl_secs() / _cache_lookup — TTL here is a per-session recall-cache (dedup), not memory decay."
+    evidence_strength: none
+    action: mark-vision
+    confidence: high
+    rationale: |
+      No memory decay or TTL mechanism exists in the codebase. Hindsight banks
+      store memories indefinitely. The per-session recall cache (recall.py
+      L113-L155) is a performance dedup, not memory decay. The vault-sweep
+      command can delete individual memories matching vault-secret patterns but
+      is not a general decay mechanism. The demote tag excludes memories from
+      recall but does not delete them. Add a "(not yet built)" qualifier to
+      this bullet — decay is a product aspiration, not a shipped feature.
+
+  - claim_id: c7
+    quote: "Raw transcript dumping as 'memory.' That's storage, not remembering."
+    loc: L45
+    verdict: aligned
+    evidence:
+      - path: src/memory/hindsight.ts
+        lines: L137-L140
+        snippet: "DEFAULT_RETAIN_MISSION: Extract user preferences, ongoing projects, recurring commitments... Skip one-off chatter and temporary task noise."
+      - path: vendor/hindsight-memory/scripts/retain.py
+        lines: L86
+        snippet: "auto-retain disabled, empty transcript, throttled chunk"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The retain pipeline uses an LLM extraction step guided by
+      DEFAULT_RETAIN_MISSION to avoid storing raw transcripts. retain.py fires
+      on every Stop hook with throttling. The anti-pattern is guarded by design.
+
+  - claim_id: c8
+    quote: "Silent forgetting. If an old rule stopped being applied, the user should be able to tell."
+    loc: L48
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L165-L167
+        snippet: "When the user asks 'what do you know about X / me'... use `reflect` to synthesize an answer."
+      - path: src/cli/memory.ts
+        lines: L361-L364
+        snippet: "switchroom memory recall-log [agent] — Show recent auto-recall events (per-turn JSONL log)"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Inspection is available both in-session (reflect/list_memories tools) and
+      via operator CLI (switchroom memory recall-log). Demoted memories are
+      excluded from recall but remain in the bank and remain queryable. This
+      addresses the anti-pattern: nothing is silently discarded without the
+      user being able to inspect it.
+
+  - claim_id: c9
+    quote: "Memory the user cannot inspect, correct, or delete."
+    loc: L49
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L152-L168
+        snippet: "MEMORY_GUIDANCE: delete_memory, sync_retain, reflect — all available and plumbed into fleet invariant"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      All three operations (inspect via reflect/list_memories, correct via
+      delete_memory+sync_retain, delete via delete_memory) are available as
+      MCP tools listed in the MEMORY_GUIDANCE fleet invariant. The anti-pattern
+      is guarded.
+
+  - claim_id: c10
+    quote: "Per-session memory that resets every chat window. The user is not a different person every time."
+    loc: L50-L51
+    verdict: aligned
+    evidence:
+      - path: profiles/default/CLAUDE.md.hbs
+        lines: L52-L53
+        snippet: "Claude Code's built-in file-based auto-memory is disabled for this agent... There's exactly one memory backend: Hindsight."
+      - path: profiles/_base/settings.json.hbs
+        lines: L26-L27
+        snippet: "\"autoMemoryEnabled\": false (when hindsightEnabled)"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Built-in Claude Code auto-memory (which is session-scoped) is disabled
+      when Hindsight is on. Hindsight is a persistent external service. The
+      anti-pattern is prevented by design: autoMemoryEnabled=false in
+      settings.json ensures the session-reset problem doesn't apply.
+
+  - claim_id: c11
+    quote: "Conflating different users, different topics, or different specialists into one undifferentiated memory pool."
+    loc: L53-L54
+    verdict: aligned
+    evidence:
+      - path: src/memory/hindsight.ts
+        lines: L68-L77
+        snippet: "getCollectionForAgent: Falls back to the agent's name if no explicit collection is configured."
+      - path: src/memory/hindsight.ts
+        lines: L80-L89
+        snippet: "isStrictIsolation: Strict agents are excluded from cross-agent reflection."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Each agent gets its own Hindsight bank (collection defaults to agent
+      name). Strict isolation mode prevents cross-agent reflection. The
+      anti-pattern is guarded at the bank-per-agent level. Multi-user
+      isolation (different Telegram users talking to the same agent) depends
+      on Hindsight's internal per-user handling, which is not surfaced by
+      switchroom's code — confidence is medium rather than high.
+
+  - claim_id: c12
+    quote: "Come back a week later and resume a thread. The agent should not need a re-briefing."
+    loc: L60-L62
+    verdict: aligned
+    evidence:
+      - path: profiles/default/CLAUDE.md.hbs
+        lines: L114-L127
+        snippet: "Session Continuity: Handoff briefing injects .handoff.md; Hindsight auto-recall fires on every inbound; Telegram history buffer available via get_recent_messages."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Three mechanisms address the return-after-a-break scenario: handoff
+      briefing (bounded transcript tail injected at boot), Hindsight auto-recall
+      on every inbound message, and the Telegram SQLite history buffer. These
+      are all implemented and wired in the default profile.
+
+  - claim_id: c13
+    quote: "Deletion. Tell the agent to forget something. Confirm it's gone."
+    loc: L66-L67
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L162-L163
+        snippet: "When the user asks you to forget something ('forget that', 'delete X', 'drop what I said about Y'), call `delete_memory` for matching entries and confirm what was removed."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The MEMORY_GUIDANCE fleet invariant (mandatory for all agents) explicitly
+      instructs the agent to call delete_memory and confirm what was removed
+      in response to any forget request. This directly addresses the UAT prompt.

--- a/audit/2026-05-26/findings/jtbd-restart-and-know-what-im-running.yaml
+++ b/audit/2026-05-26/findings/jtbd-restart-and-know-what-im-running.yaml
@@ -1,0 +1,359 @@
+unit_id: jtbd-restart-and-know-what-im-running
+unit_path: reference/restart-and-know-what-im-running.md
+category: jtbd
+audited_at: 2026-05-26T10:00:00Z
+auditor_notes: |
+  The boot card (telegram-plugin/gateway/boot-card.ts) is the primary
+  implementation surface. Key design decision from PR #142: the config
+  audit (model, tools, skills, limits, memory bank) was moved OFF the
+  auto-posted boot card and onto the on-demand /status command. The JTBD
+  says the user should see this "without asking", but the shipped design
+  requires asking (/status). The boot card only surfaces: agent name,
+  version, restart reason, auth/account health, quota, and any degraded
+  probes. Model, tools, and "what changed" are NOT proactively posted.
+  The UAT scenario (jtbd-wake-audit-content-dm.test.ts) acknowledges this
+  gap explicitly ("This UAT relaxes to: after restart, the user asks...").
+
+  The dirty-worktree check mentioned in the anchors_hint is a CLI-side
+  guard on `switchroom agent restart` (src/cli/agent.ts parsePorcelainDirty),
+  NOT a boot card surface. It prevents restart from a dirty checkout but
+  does not surface dirty state to Telegram users.
+
+findings:
+  - claim_id: c1
+    quote: "After any restart, the user is told what config is live. Model, tools, skills, memory backend, auth state. No need to ask."
+    loc: L3-L4
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L14-L25
+        snippet: "The session-greeting card written by scaffold.ts (~750 lines of curl + heredoc bash that baked Profile/Tools/Skills/Limits/Channel/Memory at scaffold time and re-posted on every SessionStart). That content moves to the future `/status` command (PR 3)."
+      - path: telegram-plugin/welcome-text.ts
+        lines: L173-L175
+        snippet: "This is the on-demand reincarnation of the SessionStart greeting card deleted in #142 PR 1."
+      - path: telegram-plugin/uat/scenarios/jtbd-wake-audit-content-dm.test.ts
+        lines: L20-L34
+        snippet: "The strictest contract — the JTBD's 'no need to ask' — would require observing a proactive wake-audit message immediately after restart without any user prompt... This UAT relaxes to: after restart, the user asks 'what are you running?'"
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      The shipped boot card posts only a bare ack line ("agent back up · version")
+      plus degraded-probe rows if any probes fail. Model, tools, skills, and memory
+      backend are NOT surfaced proactively on restart — they were deliberately
+      moved to the on-demand /status command in PR #142. The UAT scenario itself
+      acknowledges the gap ("this version relaxes to the user asking"). The JTBD
+      outcome ("no need to ask") is therefore not currently realized. This is a
+      product design decision requiring operator review, not a doc edit.
+
+  - claim_id: c2
+    quote: "After any restart, the user sees what's running without asking. A brief status, not a wall of logs."
+    loc: L29-L30
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L8-L10
+        snippet: "Default state is a single line: `checkmark agent back up · version`. Probes still run, but only at a settle window (6s by default)..."
+      - path: telegram-plugin/tests/boot-card-render.test.ts
+        lines: L19-L22
+        snippet: "returns one-line ack with default checkmark when no probes and no restart reason"
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      The boot card delivers a brief status (one line ack), satisfying the
+      "not a wall of logs" half of this claim. However, "what's running"
+      in the JTBD sense (model, tools, skills) is not in the boot card —
+      it requires /status. The "brief status" claim is partially realized
+      but the "sees what's running" claim is not, because the config
+      dimensions the JTBD names (model, tools, skills, memory) are absent
+      from the auto-posted card.
+
+  - claim_id: c3
+    quote: "The user can tell if the model changed, the tools changed, skills were added or removed, or memory is attached."
+    loc: L31-L32
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L244-L235
+        snippet: "PROBE_KEYS: 'account', 'agent', 'gateway', 'quota', 'hindsight', 'scheduler', 'broker', 'kernel', 'skills'"
+      - path: telegram-plugin/gateway/boot-probes.ts
+        lines: L1326-L1412
+        snippet: "probeSkills validates symlink health (dangling = degraded). Does NOT report what skills are loaded when healthy."
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      The boot card probes include a Skills probe, but it only surfaces
+      broken/dangling skills (degraded/fail state). When all skills are
+      healthy, the probe row is hidden per the silent-when-healthy contract.
+      Model and tools are not probed at all. The user cannot tell from the
+      boot card what model is live, which tools are enabled, or which skills
+      are loaded — they must run /status to learn these dimensions. This
+      directly contradicts the JTBD's "user can tell" claim.
+
+  - claim_id: c4
+    quote: "Auth state is part of the picture. If the agent can't authenticate right now, the user is told, not left to discover it mid-task."
+    loc: L33-L34
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/boot-probes.ts
+        lines: L141-L205
+        snippet: "probeAccount: if (!acc?.emailAddress) { return { status: 'fail', label: 'Account', detail: 'not signed in', nextStep: '...' } }; token expiry logic surfaces degraded/fail with nextStep."
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L391-L416
+        snippet: "accountRows = renderAuthLine(opts.accounts, agentName, ...) — per-account auth section rendered below probe rows."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The Account probe runs on every boot and surfaces auth failures (not
+      signed in, token expired, token expiring soon) as degraded/fail rows
+      in the boot card. Additionally, per-account auth rows are rendered
+      via renderAuthLine showing quota headroom. Auth state is genuinely
+      part of the boot card picture.
+
+  - claim_id: c5
+    quote: "The summary is in the chat, not hidden in a log or a dashboard. It lands where the user already is."
+    loc: L36-L37
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L558-L606
+        snippet: "startBootCard posts to chatId via bot.sendMessage — the user's Telegram chat."
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L3678-L3698
+        snippet: "startBootCard(chatId, threadId, botApiForCard, {...}) — wired to the restart-marker chat or resolved boot target."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The boot card is posted directly to the user's Telegram chat (not a
+      log or separate dashboard). The gateway resolves the correct chat from
+      the restart marker and posts there. This anti-pattern (config summaries
+      that live in a dashboard) is explicitly avoided by the implementation.
+
+  - claim_id: c6
+    quote: "If nothing changed, the user still gets a light acknowledgement that the agent is back, so they know the restart actually completed."
+    loc: L38-L39
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L327-L332
+        snippet: "renderBootCard: const ack = `${ackEmoji} <b>${escapeHtml(agentName)}</b> back up · ${escapeHtml(version)}` ... if (sections.length === 1) return ack"
+      - path: telegram-plugin/tests/boot-card-render.test.ts
+        lines: L19-L22
+        snippet: "returns one-line ack with default checkmark when no probes and no restart reason"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The bare ack line ("agent back up · version") is always posted regardless
+      of probe results. Even an all-green healthy boot produces this one-line
+      acknowledgement. Tests pin this behavior explicitly. This anti-pattern
+      (silent respawn) is avoided.
+
+  - claim_id: c7
+    quote: "The format is consistent restart to restart, so the user's eye learns where to look."
+    loc: L39-L40
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L100-L101
+        snippet: "RestartReason = 'planned' | 'graceful' | 'crash' | 'fresh' — all reasons produce the same ack-line format with only emoji variation."
+      - path: telegram-plugin/tests/boot-card-render.test.ts
+        lines: L25-L36
+        snippet: "uses checkmark for planned and graceful; uses new emoji for fresh starts — same structural shape."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      All restart reasons (planned, graceful, crash, fresh) produce the same
+      structural format: ack line + optional degraded rows. The boot path and
+      bridge-reconnect path use the same startBootCard function. The format
+      is consistent across restart causes, matching the anti-pattern avoidance
+      ("different restart surfaces for different causes").
+
+  - claim_id: c8
+    quote: "When something did change, the change is obvious, not buried."
+    loc: L40-L41
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L14-L25
+        snippet: "What's deleted (relative to pre-#142): The session-greeting card written by scaffold.ts that baked Profile/Tools/Skills/Limits/Channel/Memory at scaffold time and re-posted on every SessionStart."
+    evidence_strength: medium
+    action: escalate
+    confidence: medium
+    rationale: |
+      The boot card does not diff config state between restarts. If the model
+      changed, the boot card shows the same ack line as before — the change
+      is not surfaced. The pre-#142 SessionStart card did surface config at
+      restart time (baked at scaffold time); this was deleted in PR #142 in
+      favor of on-demand /status. The "change is obvious" claim is unmet for
+      config-dimension changes. This is a product design decision.
+
+  - claim_id: c9
+    quote: "Silent respawn. Agent comes back and the user has to guess whether it's the same agent with the same config."
+    loc: L45-L46
+    verdict: drift-minor
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L327-L332
+        snippet: "const ack = `${ackEmoji} <b>${escapeHtml(agentName)}</b> back up · ${escapeHtml(version)}`"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      This is listed as an anti-pattern to avoid. The boot card does prevent
+      silent respawns (the ack line always fires). However, the user CAN still
+      have to guess about config (model, tools, skills) if those changed, since
+      the boot card doesn't surface them. The anti-pattern is partially avoided
+      (restarts are not silent) but the deeper concern (same config vs. changed
+      config) is not fully addressed. Verdict is drift-minor: the anti-pattern
+      is more about silence than config visibility, and silence IS avoided.
+
+  - claim_id: c10
+    quote: "Different restart surfaces for different causes. A crash, a reboot, a reconfigure should all land in the same shape."
+    loc: L53-L54
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L237-L248
+        snippet: "REASON_EMOJI: planned: checkmark, graceful: checkmark, crash: warning, fresh: new. REASON_LABEL: planned, graceful, crash, fresh all produce the same structure."
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L3656-L3698
+        snippet: "reason = determineRestartReason({...}) — all paths funnel through startBootCard."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      All restart types (crash, planned, graceful, fresh boot) go through the
+      same startBootCard path with the same structural output. The emoji and
+      optionally a crash row differ, but the format and location are identical.
+      The anti-pattern is avoided.
+
+  - claim_id: c11
+    quote: "Config change restart. Change the model or tools, reload the agent. The summary should reflect the change, not the old state."
+    loc: L65-L66
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/welcome-text.ts
+        lines: L38-L49
+        snippet: "AgentAudit: tools, toolsDeny, skills, limits, channel, memoryBank — populated in /status response, NOT in boot card."
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L251-L301
+        snippet: "RenderBootCardOpts has no tools, model, skills, or config fields — only version, probes, restartReason."
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      The UAT prompt describes a scenario where changing model or tools and
+      reloading should show the change. The boot card does not include model
+      or tools data at all — this UAT scenario would pass only if the user
+      runs /status after the boot card appears. The scenario as written is
+      therefore testing behavior the code does not implement proactively.
+
+  - claim_id: c12
+    quote: "Skill added or removed. Add a skill, restart. The skill should appear in the summary. Remove it, restart, it should disappear."
+    loc: L67-L68
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/gateway/boot-probes.ts
+        lines: L1326-L1412
+        snippet: "probeSkills: status ok when all symlinks resolve; detail includes bucketed skill names. But ok rows are SILENT per silent-when-healthy contract."
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L372-L381
+        snippet: "if (r.status === 'ok') continue — healthy probes never render rows."
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      The Skills probe does enumerate loaded skills in its detail field when
+      healthy (e.g., "Switchroom: skill1, skill2"). However, the boot card
+      only renders probe rows for degraded/fail probes — a healthy Skills
+      probe is silently dropped. So added/removed skills (when not causing
+      dangling symlinks) will NOT appear in the boot card. This UAT scenario
+      cannot be satisfied by the current implementation.
+
+  - claim_id: c13
+    quote: "Auth failure on restart. Start the agent with broken auth. The surfaced state should say so clearly, not claim ready."
+    loc: L69-L70
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/boot-probes.ts
+        lines: L152-L165
+        snippet: "if (!acc?.emailAddress) { return { status: 'fail', label: 'Account', detail: 'not signed in', nextStep: '...' } }"
+      - path: telegram-plugin/gateway/boot-probes.ts
+        lines: L193-L205
+        snippet: "token expired: status = 'fail'; token expiring: status = 'degraded'. Each with nextStep."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Auth failure scenarios (not signed in, token expired) produce fail/
+      degraded rows with nextStep hints in the boot card. The "claim ready
+      when auth is broken" anti-pattern is explicitly avoided by the Account
+      probe implementation.
+
+  - claim_id: c14
+    quote: "Multiple agents restarted. Bring several specialists back at once. Each should report its own state in its own place, not collapse into one summary."
+    loc: L72-L73
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L557-L560
+        snippet: "startBootCard(chatId, threadId, bot, opts, ...) — per-gateway, per-chat invocation."
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L3663-L3698
+        snippet: "Each gateway instance posts its own boot card to its own chatId/threadId."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Each agent has its own gateway process with its own Telegram bot, which
+      posts to its own chat topic. Fleet-wide restarts produce one boot card
+      per agent in that agent's own topic. The anti-pattern (collapsing into
+      one summary) is structurally avoided by the per-agent gateway model.
+
+  - claim_id: c15
+    quote: "Memory backend swap. Change the memory backend, restart. The user should see which backend is now attached."
+    loc: L74-L75
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/gateway/boot-probes.ts
+        lines: L946-L978
+        snippet: "probeHindsight: returns ok when reachable (detail='reachable'), fail when not. Does not surface bank name unless bankName is passed."
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L372-L381
+        snippet: "if (r.status === 'ok') continue — healthy probes never render rows."
+    evidence_strength: strong
+    action: escalate
+    confidence: medium
+    rationale: |
+      The Hindsight probe shows the bank name suffix in ok state
+      ("reachable · bank=mybank"), but like all ok probes, this row is
+      silently dropped from the boot card. The user cannot see which memory
+      backend is attached from the boot card alone. Changing the memory
+      backend would not visibly change the boot card if both old and new
+      backends are healthy. /status is required to see the memory bank.
+
+  - claim_id: c16
+    quote: "Tool scope change. Narrow or widen a tool allowlist, restart. The user should be able to tell what the agent can and can't do now."
+    loc: L76-L77
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L251-L301
+        snippet: "RenderBootCardOpts: no tools or tool-deny fields. The boot card renderer has no concept of tool allowlists."
+      - path: telegram-plugin/welcome-text.ts
+        lines: L38-L42
+        snippet: "AgentAudit: tools, toolsDeny — present in /status AgentAudit type, absent from boot card."
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      Tools and toolsDeny are surfaced in the /status AgentAudit block but
+      are completely absent from the boot card. A tool scope change would
+      produce an identical boot card before and after. This UAT scenario
+      cannot pass with the current implementation.

--- a/audit/2026-05-26/findings/jtbd-run-a-fleet-of-specialists.yaml
+++ b/audit/2026-05-26/findings/jtbd-run-a-fleet-of-specialists.yaml
@@ -1,0 +1,317 @@
+unit_id: jtbd-run-a-fleet-of-specialists
+unit_path: reference/run-a-fleet-of-specialists.md
+category: jtbd
+audited_at: 2026-05-26T14:00:00Z
+auditor_notes: |
+  The JTBD is written cleanly at the outcome level with no leaked implementation
+  details -- no file paths, container names, or class names appear. Most claims
+  are well-supported by code. The main gap is the "Remove an agent" UAT prompt:
+  agent destroy does not clean up the Hindsight memory bank, schedule JSONL, or
+  the switchroom.yaml config entry automatically -- the operator must run
+  switchroom apply separately and the bank persists. The JTBD's "Signs it's
+  working" claim that removal is clean ("no orphaned processes or dangling config")
+  is aspirationally true for processes but not for memory banks. This is flagged
+  as drift-minor rather than outcome-not-realized because the core fleet
+  management story (persona, memory per-agent, add flow, parallel operation,
+  fleet visibility) is all realized. The memory cleanup gap is a known rough edge,
+  not a fundamental product failure.
+findings:
+  - claim_id: c1
+    quote: "A fleet of agents, each shaped for a specific part of the user's life,
+      is a workforce. Health coach in the morning, coding assistant for the afternoon,
+      executive assistant for the inbox, each with its own voice, its own history,
+      its own sense of what's in-scope."
+    loc: L9-L14
+    verdict: aligned
+    evidence:
+      - path: profiles/health-coach/CLAUDE.md.hbs
+        lines: L1-L28
+        snippet: "# Agent: {{name}} — Health & Fitness Coach ... Role: health and
+          fitness coaching agent"
+      - path: profiles/coding/CLAUDE.md.hbs
+        lines: L1-L17
+        snippet: "# Agent: {{name}} — Coding Agent ... Role: senior software
+          engineering agent"
+      - path: profiles/executive-assistant/CLAUDE.md.hbs
+        lines: L1-L5
+        snippet: "# Agent: {{name}} — Executive Assistant"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Three distinct built-in profiles ship with differentiated CLAUDE.md and
+      SOUL.md personas. Per-agent bot tokens (schema.ts:990) and per-agent Hindsight
+      banks (getCollectionForAgent in hindsight.ts:71-77) give each agent its own
+      voice, history, and scope. The fleet is a reality, not a demo.
+
+  - claim_id: c2
+    quote: "The user adds an agent the way they add a contact."
+    loc: L17
+    verdict: aligned
+    evidence:
+      - path: src/agents/add-orchestrator.ts
+        lines: L1-L27
+        snippet: "Single CLI verb that takes a new agent from 'I want a bot for X'
+          to 'X is online, paired, with persona seeded' with zero hand-edits to
+          switchroom.yaml, access.json, vault, or systemd."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The `switchroom agent add` wizard (src/agents/add-orchestrator.ts) provides
+      a guided BotFather walkthrough, profile picker, OAuth relay, and DM pairing
+      in a single verb. The code comment explicitly states "zero hand-edits to
+      switchroom.yaml, access.json, vault, or systemd" which matches the "add a
+      contact" framing.
+
+  - claim_id: c3
+    quote: "Each agent has memory that's its own. What the user told the health
+      coach is not leaking into the coding agent."
+    loc: L24-L25
+    verdict: aligned
+    evidence:
+      - path: src/memory/hindsight.ts
+        lines: L71-L88
+        snippet: "getCollectionForAgent ... returns agentConfig?.memory?.collection
+          ?? agentName ... isStrictIsolation ... returns agentConfig?.memory?.isolation
+          === 'strict'"
+      - path: src/config/schema.ts
+        lines: L124-L128
+        snippet: "isolation: z.enum(['default', 'strict']) ... 'strict = never shared
+          cross-agent, default = eligible for reflect'"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Each agent defaults to its own named Hindsight bank (agent name is the
+      collection). Strict isolation mode explicitly prevents cross-agent reflection.
+      The per-agent bank is created at scaffold time (hindsight.ts createBank).
+
+  - claim_id: c4
+    quote: "Tools and skills are scoped per agent. The wrong agent doesn't have
+      the wrong power."
+    loc: L35-L36
+    verdict: aligned
+    evidence:
+      - path: src/agents/scaffold.ts
+        lines: L862-L866
+        snippet: "Sync the set of global-skill symlinks in an agent's .claude/skills/
+          directory against the user's declared skills: list"
+      - path: src/config/schema.ts
+        lines: L109
+        snippet: "Allowed tools (use ['all'] for unrestricted)"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Per-agent skills lists are scaffolded from profiles/<name>/skills/ and
+      controlled via switchroom.yaml tools.allow per agent. The MCP pre-approval
+      list is also per-agent (scaffold.ts:2092-2114).
+
+  - claim_id: c5
+    quote: "When a new agent joins the fleet, it feels like a peer, not a bolt-on.
+      It participates in the same lifecycle, the same safety rules, the same
+      interaction surface."
+    loc: L37-L39
+    verdict: aligned
+    evidence:
+      - path: src/agents/add-orchestrator.ts
+        lines: L1-L27
+        snippet: "scaffold (CLAUDE.md, SOUL.md, IDENTITY.md, USER.md, MEMORY.md),
+          systemd unit, MCP servers, and switchroom.yaml entry"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Every agent regardless of profile goes through the same scaffold, compose
+      generation, vault integration, autoaccept, and gateway sidecar stack. The
+      fleet invariants (sandbox guidance, Telegram pacing, memory protocol) are
+      shared via ~/.switchroom/fleet/switchroom-invariants.md loaded for every agent.
+
+  - claim_id: c6
+    quote: "Removing an agent is clean. Its memory, its state, its scheduled work
+      all go with it, with no orphaned processes or dangling config."
+    loc: L40-L41
+    verdict: drift-minor
+    evidence:
+      - path: src/cli/agent.ts
+        lines: L1930-L1979
+        snippet: "command('destroy') ... rmSync(agentDir, { recursive: true, force:
+          true }) ... 'Run switchroom apply after to take the container down'"
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    rationale: |
+      agent destroy removes the agent directory and stops the process. However:
+      (1) The Hindsight memory bank is NOT deleted -- it persists in the Hindsight
+      service. (2) The switchroom.yaml config entry is NOT automatically removed
+      by agent destroy -- the operator must edit YAML and run switchroom apply.
+      (3) The scheduler JSONL audit file lives inside the agent dir and is removed
+      with it, which is good. The claim "no orphaned processes or dangling config"
+      is partially true (no orphaned processes after apply) but the memory bank
+      is orphaned. The UAT prompt "Remove an agent. Its artefacts, memory, and
+      schedules should all go." (L75) sets an expectation the code does not fully
+      meet. Suggest updating the UAT prompt to note memory bank cleanup is manual.
+
+  - claim_id: c7
+    quote: "The user can describe what each of their agents is for in one sentence.
+      If they can't, the fleet is too blurry."
+    loc: L42-L43
+    verdict: aligned
+    evidence:
+      - path: src/cli/agent.ts
+        lines: L710-L778
+        snippet: "command('list') ... description('List all agents with their status')
+          ... headers = ['Name', 'Status', 'Uptime', 'Template', 'Scheduler', 'Topic']"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      switchroom agent list shows each agent with its profile template and topic
+      name, giving the operator a clear fleet overview. The per-agent topic_name
+      and topic_emoji fields in schema.ts further support distinct identity.
+
+  - claim_id: c8
+    quote: "One agent pretending to be multiple by switching tone on command.
+      Personas without separation of memory and scope are cosplay."
+    loc: L47-L48
+    verdict: aligned
+    evidence:
+      - path: src/memory/hindsight.ts
+        lines: L71-L88
+        snippet: "getCollectionForAgent ... per-agent bank ... isStrictIsolation"
+      - path: src/config/schema.ts
+        lines: L124-L128
+        snippet: "strict = never shared cross-agent"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The anti-pattern is clearly not the product's design. Each agent runs in its
+      own container, has its own bank, and its own bot token. There is no shared
+      session model.
+
+  - claim_id: c9
+    quote: "Making adding an agent a project. If it takes more than a few minutes
+      of light config, users won't grow the fleet."
+    loc: L56-L57
+    verdict: aligned
+    evidence:
+      - path: src/agents/add-orchestrator.ts
+        lines: L1-L27
+        snippet: "switchroom agent add n+1 bot wizard ... BotFather walkthrough ...
+          Profile + skill picker ... Pairing block ... Final preflight"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      switchroom agent add provides a fully guided wizard. The code comment
+      explicitly targets "zero hand-edits to switchroom.yaml, access.json, vault,
+      or systemd." This directly avoids the anti-pattern.
+
+  - claim_id: c10
+    quote: "A fleet-management story that lives in docs but not in the product.
+      The user should be able to see the fleet, not just read about how it works."
+    loc: L59-L60
+    verdict: aligned
+    evidence:
+      - path: src/cli/agent.ts
+        lines: L710-L790
+        snippet: "command('list') ... List all agents with their status ... headers
+          = ['Name', 'Status', 'Uptime', 'Template', 'Scheduler', 'Topic']"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      switchroom agent list provides a fleet table view in the CLI. The Telegram
+      /status command also surfaces agent state in-channel. The fleet is observable,
+      not just documented.
+
+  - claim_id: c11
+    quote: "Memory isolation. Tell one agent something personal, ask the other
+      about it. It should not know."
+    loc: L68-L69
+    verdict: aligned
+    evidence:
+      - path: src/memory/hindsight.ts
+        lines: L71-L88
+        snippet: "getCollectionForAgent returns agentConfig?.memory?.collection ??
+          agentName ... isStrictIsolation"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Memory isolation is implemented via per-agent Hindsight banks. By default
+      agents cannot see each other's memories (separate collection names). The
+      UAT prompt is realizable with the shipped architecture.
+
+  - claim_id: c12
+    quote: "Scope enforcement. Ask a specialist something clearly outside its
+      remit. It should redirect, not attempt."
+    loc: L70-L71
+    verdict: aligned
+    evidence:
+      - path: profiles/health-coach/CLAUDE.md.hbs
+        lines: L27-L28
+        snippet: "Boundaries: Recommend the user consult a professional for: ...
+          Say it plainly: 'That's outside my lane'"
+      - path: profiles/health-coach/workspace/SOUL.md.hbs
+        lines: L23
+        snippet: "Know your limits ... When something is outside your scope, say
+          so immediately"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Scope enforcement is implemented via profile-specific CLAUDE.md.hbs and
+      SOUL.md.hbs content (boundaries sections). This is prompt-enforced, not
+      architectural -- the SOUL.md boundary field is configurable per agent. The
+      health-coach profile explicitly names the redirect pattern ("That's outside
+      my lane"). Confidence is medium because this is LLM behavior, not a hard
+      technical gate.
+
+  - claim_id: c13
+    quote: "Parallel work. Have two agents doing real work at the same time.
+      Neither should degrade the other's experience."
+    loc: L76-L77
+    verdict: aligned
+    evidence:
+      - path: src/agents/lifecycle.ts
+        lines: L116
+        snippet: "already-running fleet rather than spawning a parallel project"
+      - path: src/agents/compose.ts
+        lines: L1-L5
+        snippet: "generates per-agent containers in a single compose project"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Each agent runs in its own Docker container with its own process tree and
+      network_mode: host. Parallelism is the design assumption throughout the
+      compose generator and lifecycle code. The web rate-limiter test at
+      src/web/webhook-handler.test.ts:423 specifically tests cross-agent isolation.
+
+  - claim_id: c14
+    quote: "Cross-agent handoff. Need a thing that crosses two specialists. The
+      user should be able to route it without the agents silently reaching into
+      each other."
+    loc: L78-L80
+    verdict: aligned
+    evidence:
+      - path: src/config/schema.ts
+        lines: L1521
+        snippet: "an agent reach into shared dirs ... without ..."
+      - path: src/agent-scheduler/index.ts
+        lines: L23
+        snippet: "under the agent's own bind mount, never shared across agents"
+    evidence_strength: weak
+    action: keep
+    confidence: low
+    rationale: |
+      The architectural isolation (separate containers, separate bind mounts, no
+      shared IPC) prevents silent cross-agent reach. User-mediated handoff via
+      Telegram (routing a message manually) is the intended pattern. No dedicated
+      "handoff" feature was found; this claim is about what does NOT happen
+      (agents do not silently reach into each other) rather than a feature.
+      Evidence is weak because the positive claim (user can route it) is just
+      "use Telegram" -- no special tooling exists for this.

--- a/audit/2026-05-26/findings/jtbd-share-auth-across-the-fleet.yaml
+++ b/audit/2026-05-26/findings/jtbd-share-auth-across-the-fleet.yaml
@@ -1,0 +1,422 @@
+unit_id: jtbd-share-auth-across-the-fleet
+unit_path: reference/share-auth-across-the-fleet.md
+category: jtbd
+audited_at: 2026-05-26T14:00:00Z
+auditor_notes: |
+  The JTBD header block correctly marks this as SHIPPED (RFC H) and warns
+  readers the body is a pre-RFC-H problem statement. That disclaimer is good.
+  Most core architectural claims (broker as sole writer, fanout, CLAUDE_CODE_OAUTH_TOKEN
+  removal, rm refusal) are well-implemented and test-covered.
+
+  Three stale-example findings:
+
+  1. "Signs it's working" bullet 1 cites `switchroom auth enable <account> <agent>`.
+     That verb does not exist. The current surface is `switchroom auth use <label>`
+     (fleet-wide) or `switchroom auth agent override <agent> <label>` (edge case).
+
+  2. Decision 2 describes per-agent `auth.accounts: [work-pro, personal-max]` ordered
+     lists in switchroom.yaml. The shipped schema drops the per-agent accounts list
+     entirely. The current per-agent auth block has only `override:` (an edge-case
+     single-label pin). The ordered preference list at the agent level does not exist;
+     fallback ordering is fleet-wide via `auth.fallback_order`.
+
+  3. The UAT prompt at L265 says `switchroom auth account list`. That command does not
+     exist. The actual commands are `switchroom auth list` and `switchroom auth show`.
+
+  Decision 10 ("No migration shipped") is nuanced: `src/auth/migrate-schema.ts` IS
+  shipped and tested, but it is NOT wired into any production code path (no import of
+  `migrateAuthSchemaFile` outside its own test file). The RFC H doc (docs/rfcs/auth-broker.md
+  L125-128) clarifies that "no migration" means no CLI verb and no compatibility shims,
+  not literally no upgrade algorithm. The schema comments say it runs "on first apply"
+  but `apply.ts` does not import it. This may be an unwired migration — low confidence
+  finding flagged for triage.
+
+findings:
+  - claim_id: c1
+    quote: "The `switchroom-auth-broker` daemon (`src/auth/broker/`) is the sole writer
+      of every `credentials.json`"
+    loc: L9-L10
+    verdict: aligned
+    evidence:
+      - path: src/auth/broker/server.ts
+        lines: L2-L5
+        snippet: "switchroom-auth-broker server — sole writer of per-agent\n
+          `<agentDir>/.claude/.credentials.json`"
+      - path: src/auth/account-store.ts
+        lines: L20-L21
+        snippet: "The only writer to these files is `switchroom-auth-broker`, except\n
+          during the initial `switchroom auth account add` flow"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The broker server's module-level comment explicitly states "sole writer". The
+      account-store module corroborates. start.sh.hbs (L187-190) defensively unsets
+      CLAUDE_CODE_OAUTH_TOKEN. No other production callsite writes per-agent
+      .credentials.json.
+
+  - claim_id: c2
+    quote: "authentication is per Anthropic account, not per agent; the fleet shares
+      one `auth.active` and quota / fallback state fans out across every consumer in
+      seconds"
+    loc: L10-L12
+    verdict: aligned
+    evidence:
+      - path: src/auth/broker/server.ts
+        lines: L1026-L1044
+        snippet: "opMarkExhausted ... const rolled = this.fanoutFailoverFor(account)"
+      - path: src/config/schema.ts
+        lines: L2028-L2046
+        snippet: "auth: z.object({ active: z.string() ... fallback_order: z.array(...)"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Fleet-wide auth.active is the config key; fanoutFailoverFor fires synchronously
+      within opMarkExhausted so every affected agent's mirror is rewritten before the
+      RPC returns. The schema has auth.active and auth.fallback_order at the top level.
+
+  - claim_id: c3
+    quote: "Operator surface: `switchroom auth add|list|show|use|rotate|rm` (CLI) and
+      `/auth show|use|rotate` (Telegram)"
+    loc: L13-L15
+    verdict: aligned
+    evidence:
+      - path: src/cli/auth.ts
+        lines: L10-L16
+        snippet: "auth add <label> ... auth list ... auth use <label> ... auth rotate
+          ... auth rm <label> ... auth show [<agent>]"
+      - path: telegram-plugin/gateway/auth-command.ts
+        lines: L11-L15
+        snippet: "/auth show [<agent>] ... /auth list ... /auth use <label> ... /auth rotate"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      All six CLI verbs and all three Telegram verbs are registered and match the JTBD
+      listing exactly.
+
+  - claim_id: c4
+    quote: "Adding a second, third, or sixth agent to the same Anthropic account does
+      not require any OAuth flow. The user runs `switchroom auth enable <account>
+      <agent>` and the agent comes up authenticated."
+    loc: L62-L63
+    verdict: jtbd-stale-example
+    evidence:
+      - path: src/cli/auth.ts
+        lines: L465-L803
+        snippet: "registered verbs: add, list, use, rotate, rm, show, refresh, agent override,
+          reauth, code, cancel — no 'enable' verb registered"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      `switchroom auth enable <account> <agent>` does not exist. The current operations
+      are: `switchroom auth use <label>` (fleet-wide) or `switchroom auth agent override
+      <agent> <label>` (per-agent edge case). The replacement sentence should read:
+      "The user runs `switchroom auth use <label>` (to set the fleet account) and
+      restarts the agent; no new OAuth flow is needed."
+
+  - claim_id: c5
+    quote: "The user can answer 'which Anthropic accounts am I logged into and which
+      agents use each?' with one command. The answer fits on a screen."
+    loc: L64-L65
+    verdict: aligned
+    evidence:
+      - path: src/cli/auth.ts
+        lines: L717-L745
+        snippet: "`auth show [agent]` command — printAccountsTable + printAgentsTable + printConsumersTable"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      `switchroom auth show` (no arg) prints accounts table, agents table, and consumers
+      table. `switchroom auth list` shows accounts only. Both fit on a screen.
+
+  - claim_id: c6
+    quote: "A sub-agent dispatched from a main agent is authenticated against the same
+      account as its parent. The user does nothing to make this happen."
+    loc: L66-L67
+    verdict: aligned
+    evidence:
+      - path: src/auth/broker/server.ts
+        lines: L1567-L1633
+        snippet: "fanoutAll / fanoutForAgent / mirrorAccountToAgent — writes per-agent
+          .credentials.json on boot"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The broker writes the per-agent .credentials.json mirror that claude reads. Any
+      sub-agent running inside the agent container reads the same file. The claim is
+      directionally true for the sub-agent case, but sub-agent auth behavior depends on
+      how the claude CLI handles sub-agent CLAUDE_CONFIG_DIR inheritance — not audited
+      from this review.
+
+  - claim_id: c7
+    quote: "A cron-launched `claude -p` invocation in an agent's directory uses the
+      same fresh token as that agent's main process. No 401s, no env-var hand-offs."
+    loc: L68-L69
+    verdict: jtbd-stale-example
+    evidence:
+      - path: CLAUDE.md
+        lines: L99-L109
+        snippet: "claude -p (headless/print mode) ... as of the 2026-06-15 policy it
+          is programmatic usage — a separate credit, off subscription limits. Adding a
+          new `claude -p` callsite is a constraint violation"
+      - path: docs/rfcs/eliminate-claude-p.md
+        lines: L1-L5
+        snippet: "RFC for eliminating all claude -p callsites"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      `claude -p` is now forbidden under Anthropic's 2026-06-15 policy (programmatic
+      usage, separate credit, constraint violation per CLAUDE.md). The cron system was
+      refactored in Phase 4 to use inject_inbound (dispatchAsInbound) instead of
+      `claude -p`. The example reinforces the wrong pattern. Replace with: "A
+      cron-scheduled task in an agent's directory fires via inject_inbound and uses the
+      same account as the main process — same broker mirror, no 401s, no env-var
+      hand-offs."
+
+  - claim_id: c8
+    quote: "When an account hits the 5-hour cap, every agent using that account fails
+      over to the next account on its preference list within seconds"
+    loc: L70-L71
+    verdict: drift-minor
+    evidence:
+      - path: src/auth/broker/server.ts
+        lines: L1592-L1609
+        snippet: "fanoutFailoverFor uses auth.fallback_order (fleet-wide), not a
+          per-agent preference list"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The mechanism is correct (synchronous fanout on mark-exhausted), but "its
+      preference list" implies per-agent ordering. The shipped design uses one
+      fleet-wide `auth.fallback_order`. Replace "the next account on its preference
+      list" with "the next account in `auth.fallback_order`".
+
+  - claim_id: c9
+    quote: "Removing an account is a single explicit action, refused while any agent
+      is still enabled on it."
+    loc: L78-L79
+    verdict: drift-minor
+    evidence:
+      - path: src/auth/broker/server.ts
+        lines: L1138-L1149
+        snippet: "Refuse to remove if it's the fleet active or any agent's override.
+          Checks auth.active and agents[*].auth.override"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      Removal is refused only when the account is the fleet active OR is pinned via a
+      per-agent override. An agent with no explicit override inherits the fleet active
+      and is indirectly protected by the fleet-active check. However the phrase "while
+      any agent is still enabled on it" suggests a per-agent enabled/disabled tracking
+      which does not exist. Narrow the text to: "refused while it is the fleet active
+      account or the override target for any agent."
+
+  - claim_id: c10
+    quote: "Agents are consumers, not owners. An agent declares an ordered list of
+      accounts it can use, in `switchroom.yaml`: `agents: foo: auth: accounts:
+      [work-pro, personal-max]`"
+    loc: L142-L149
+    verdict: drift-major
+    evidence:
+      - path: src/config/schema.ts
+        lines: L1263-L1280
+        snippet: "per-agent auth block has only `override: string` — no `accounts` array.
+          Schema comment: 'Pre-RFC-H auth.accounts: [...] and auth_label: are migrated
+          in-place on first apply'"
+      - path: src/auth/migrate-schema.ts
+        lines: L1-L26
+        snippet: "in-place YAML upgrade from per-agent auth.accounts to fleet-wide model"
+      - path: docs/auth.md
+        lines: L72-L92
+        snippet: "YAML schema: agents.ziggy: {} (inherits fleet active), agents.klanker.auth.override: work"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      Decision 2's YAML example (`auth.accounts: [work-pro, personal-max]`) is the
+      pre-RFC-H schema. The shipped design replaced per-agent ordered lists with a
+      fleet-wide `auth.active` and a single `auth.fallback_order`. The only per-agent
+      auth field is `override:` (one label, edge-case use). The YAML example in
+      Decision 2 would be migrated away by `migrate-schema.ts` on an existing install.
+      Replace the example with: `agents: foo: {} # inherits fleet active` (common case)
+      or `agents: klanker: auth: override: work # edge case: pin to specific account`.
+
+  - claim_id: c11
+    quote: "`switchroom-auth-broker` is the only writer ... fanout: when an account
+      refreshes, every enabled agent's mirror gets atomically rewritten"
+    loc: L162-L169
+    verdict: aligned
+    evidence:
+      - path: src/auth/broker/server.ts
+        lines: L1567-L1633
+        snippet: "fanoutAll, fanoutToAffectedAgents, fanoutForAgent, mirrorAccountToAgent
+          — all write atomically via atomicWriteFileSync"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Broker server implements fanout on boot, set-active, refresh tick, and
+      mark-exhausted. All writes go through mirrorAccountToAgent which uses
+      atomicWriteFileSync (tempfile + rename). Strong code evidence.
+
+  - claim_id: c12
+    quote: "Drop `CLAUDE_CODE_OAUTH_TOKEN` injection in `start.sh`. The env var was
+      only useful for the parent claude process and was redundant with the credentials
+      file every other consumer reads."
+    loc: L173-L175
+    verdict: aligned
+    evidence:
+      - path: profiles/_base/start.sh.hbs
+        lines: L187-L190
+        snippet: "# CLAUDE_CODE_OAUTH_TOKEN injection was removed with RFC H
+          (auth-broker). ... unset CLAUDE_CODE_OAUTH_TOKEN"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      start.sh.hbs explicitly unsets the env var. Comment names RFC H as the reason.
+      The pattern exactly matches Decision 5.
+
+  - claim_id: c13
+    quote: "Drop the per-agent slot pool entirely. The `<agentDir>/.claude/accounts/<slot>/`
+      directory tree ... all go away."
+    loc: L177-L181
+    verdict: drift-minor
+    evidence:
+      - path: src/auth/accounts.ts
+        lines: L1-L16
+        snippet: "LEGACY (post-RFC-H) ... This module is legacy per-agent slot scaffolding
+          ... retained for back-compat and migration paths only"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The per-agent slot pool code still exists in `src/auth/accounts.ts` (marked
+      LEGACY). Decision 6 says it "all go away" but the file ships in production for
+      back-compat/migration. The claim is directionally true (it is not the runtime
+      path), but "all go away" overstates the cleanup. The JTBD body is historical
+      anyway (covered by the disclaimer), so no urgent edit needed, but text should
+      note that legacy code is retained for migration-only, not active runtime.
+
+  - claim_id: c14
+    quote: "No migration shipped. This is a new-install design ... no `switchroom auth
+      migrate` verb, no legacy slot-pool code paths kept 'for now,' no compatibility
+      shims."
+    loc: L206-L215
+    verdict: drift-major
+    evidence:
+      - path: src/auth/migrate-schema.ts
+        lines: L1-L56
+        snippet: "In-place YAML upgrade from the pre-RFC-H per-agent auth schema to the
+          RFC H fleet-wide model ... Tested against three fixture shapes"
+      - path: src/config/schema.ts
+        lines: L1278-L1279
+        snippet: "Pre-RFC-H auth.accounts: [...] and auth_label: are migrated in-place
+          on first apply (see src/auth/migrate-schema.ts)"
+      - path: src/auth/accounts.ts
+        lines: L1-L16
+        snippet: "LEGACY (post-RFC-H) ... retained for back-compat and migration paths only"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      Decision 10 says "no migration shipped" but `src/auth/migrate-schema.ts` is a
+      shipped, tested in-place migration algorithm (3 fixture shapes tested). Legacy
+      slot-pool code (`src/auth/accounts.ts`) is explicitly retained for back-compat.
+      The RFC H doc (L125-128) clarifies the intent: no CLI verb, no compatibility
+      shims for new schema shape — not "no upgrade algorithm." The Decision 10 text
+      contradicts what was actually built. NOTE: `migrateAuthSchemaFile` is not
+      imported from any production code path (only in its own test file) — the wiring
+      into `apply` that the schema comments reference appears to be absent. This
+      inconsistency is worth flagging separately but does not change the finding that
+      "no migration shipped" is false.
+
+  - claim_id: c15
+    quote: "The same shape on the CLI and in Telegram. Both surfaces speak 'accounts,'
+      not 'slots.' Telegram's `/auth use work-pro` swaps the agent to that account;
+      `/auth list` shows accounts and which agent is using which."
+    loc: L217-L220
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/auth-command.ts
+        lines: L11-L15
+        snippet: "/auth show ... /auth list ... /auth use <label> ... /auth rotate"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Telegram auth surface matches: `/auth use <label>` and `/auth list` (alias of
+      show) are implemented. The vocabulary is "accounts"/"labels" not "slots".
+
+  - claim_id: c16
+    quote: "Read the output of `switchroom auth account list`. Does it show your
+      accounts and which agents use each, on one screen?"
+    loc: L265-L266
+    verdict: jtbd-stale-example
+    evidence:
+      - path: src/cli/auth.ts
+        lines: L589-L605
+        snippet: "auth.command('list') ... auth.command('show [agent]')"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      `switchroom auth account list` does not exist. The correct commands are
+      `switchroom auth list` (accounts only) and `switchroom auth show` (accounts +
+      agents + consumers). Update the UAT prompt to: "Read the output of `switchroom
+      auth show`. Does it show your accounts and which agents use each, on one screen?"
+
+  - claim_id: c17
+    quote: "Stop `switchroom-auth-broker`. Do agents still respond for the next hour
+      as long as their existing tokens are valid? Restart it. Does it resume refreshes
+      without losing state?"
+    loc: L275-L277
+    verdict: aligned
+    evidence:
+      - path: src/auth/broker/server.ts
+        lines: L98-L104
+        snippet: "REFRESH_INTERVAL_MIN = 1 ... broker refresh loop"
+      - path: reference/share-auth-across-the-fleet.md
+        lines: L197-L203
+        snippet: "Decision 9: broker's death is degraded, not catastrophic. Token
+          lifetime is 8 hours; the broker can be down for hours without a user-visible
+          outage."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The degraded mode claim (agents survive on cached credentials) is structurally
+      true — the broker writes .credentials.json but does not gate reads. No explicit
+      test pins the "broker down, agent still works for 1h" scenario, hence medium
+      confidence. The 8-hour claim comes from RFC H, which cites Anthropic token
+      lifetime.
+
+  - claim_id: c18
+    quote: "Migrate from a per-agent-slot install. Did you have to re-`claude
+      setup-token` any account, or did the existing tokens carry over?"
+    loc: L279-L280
+    verdict: drift-minor
+    evidence:
+      - path: src/auth/migrate-schema.ts
+        lines: L1-L26
+        snippet: "In-place YAML upgrade algorithm; migrates agent auth.accounts lists
+          to fleet-wide auth.active"
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    rationale: |
+      The UAT prompt is reasonable but its context changed: `migrate-schema.ts` exists
+      but is not wired into any production code path. Whether the in-place migration
+      actually runs on apply is unclear (the schema comments say it does; the import
+      graph says it does not). The prompt assumes seamless migration; that assumption
+      may not hold. Low-risk to leave as-is since the JTBD body is marked historical,
+      but it should note that an explicit `switchroom apply` is required to trigger the
+      in-place schema upgrade.

--- a/audit/2026-05-26/findings/jtbd-steer-or-queue-mid-flight.yaml
+++ b/audit/2026-05-26/findings/jtbd-steer-or-queue-mid-flight.yaml
@@ -1,0 +1,219 @@
+unit_id: jtbd-steer-or-queue-mid-flight
+unit_path: reference/steer-or-queue-mid-flight.md
+category: jtbd
+audited_at: 2026-05-26T10:00:00Z
+auditor_notes: |
+  This JTBD was updated on 2026-05-24 (commit 88726983) after a Phase-3
+  audit found the doc lagged the code by ~5 weeks following a 2026-04-17
+  default-flip. The current file correctly describes the live contract.
+  All verifiable claims check out against the code. Three minor points
+  worth noting:
+
+  1. The header note (L60) references commits 4fff90bf + 597a58af.
+     These are not present in the current repo's reachable history (only
+     a distant `ba4fff44` exists). The commits are real but are from a
+     fork/private history not in the canonical switchroom/switchroom
+     remote. The references are informational; no consumer depends on
+     them being resolvable, so this is low-risk.
+
+  2. The "agent self-narrates the classification" claim (L65) is
+     implemented as a prompt instruction in
+     profiles/_shared/telegram-style.md.hbs rather than as a code
+     invariant. The UAT (jtbd-rapid-followup-dm.test.ts) does assert
+     for the narration pattern in test assertions, giving it medium
+     evidence strength.
+
+  3. The "Nothing the user said gets lost ... not to a restart" claim is
+     now realized by the inbound-spool JSONL introduced in #1546/#1549,
+     though the spool's durability guarantee stops at "delivered to
+     registered bridge," not "claude consumed it" — an acknowledged v1
+     limitation documented in inbound-spool.ts. The JTBD makes no
+     finer-grained claim, so it remains aligned.
+
+findings:
+  - claim_id: c1
+    quote: "Queue (default — no marker). Send a follow-up while a turn is in flight; it queues as a new, independent task that runs after the current turn ends."
+    loc: L62
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L8647-L8651
+        snippet: "// New default: mid-turn messages are queued unless the user explicitly\n// steers. isSteering is true only when the steer prefix is present.\nisSteering = priorTurnInFlight && isSteerPrefix"
+      - path: telegram-plugin/steering.ts
+        lines: L1-L11
+        snippet: "Telegram messages that arrive while a prior turn is still in\nflight are now queued by default (queued=\"true\"). The user can explicitly\nprefix with `/steer ` or `/s ` to declare steering."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      gateway.ts:8647-8651 sets isSteering=true ONLY when both a prior
+      turn is in flight AND the /steer prefix is present. All other
+      mid-turn inbounds default to queued. The inbound-delivery-gate
+      (inbound-delivery-gate.ts:111-118) then buffers non-steering,
+      non-interrupt mid-turn inbounds until the current turn completes,
+      confirming the "runs after the current turn ends" claim.
+
+  - claim_id: c2
+    quote: "The agent receives the follow-up as a fresh turn with <channel queued=\"true\"> so it knows to start fresh and not carry context from the in-flight work."
+    loc: L62
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L8884-L8886
+        snippet: "// queued=\"true\" when mid-turn with no steer prefix (new default), or\n// with explicit /queue or /q prefix (legacy alias).\n...((isQueuedMidTurn || isQueuedPrefix) ? { queued: 'true' } : {}),"
+      - path: telegram-plugin/tests/steering.test.ts
+        lines: L195
+        snippet: "expect(buildChannelMetaAttributes({ queued: true })).toBe(' queued=\"true\"')"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      gateway.ts emits queued: 'true' in the meta dict for all mid-turn
+      non-steering inbounds. Tests in steering.test.ts pin the exact
+      attribute serialisation. The meta dict becomes channel XML
+      attributes via Claude Code's channel notification mechanism.
+
+  - claim_id: c3
+    quote: "Legacy /queue  / /q  prefix is a redundant alias (still works; same outcome)."
+    loc: L62
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/steering.ts
+        lines: L14-L38
+        snippet: "parseQueuePrefix — These are now aliases for the default queued behavior (mid-turn messages default to queued=\"true\"), but the prefix is still accepted so existing muscle-memory and scripts keep working."
+      - path: telegram-plugin/tests/steering.test.ts
+        lines: L17-L84
+        snippet: "describe('parseQueuePrefix', ...) — tests /queue foo, /q foo"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      steering.ts:parseQueuePrefix accepts /queue and /q prefixes,
+      and steering.test.ts has comprehensive tests for both. gateway.ts
+      line 8454 calls parseQueuePrefix and sets isQueuedPrefix=true when
+      matched, and line 8886 includes queued='true' for both the mid-turn
+      default path and the explicit legacy prefix path.
+
+  - claim_id: c4
+    quote: "Steer = /steer  or /s  prefix. Explicit opt-in to course-correct the in-flight task. The agent receives the body with <channel steering=\"true\"> and treats it as an amendment to the current work."
+    loc: L63
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/steering.ts
+        lines: L41-L60
+        snippet: "parseSteerPrefix — /steer  or /s  explicit steer prefix. Mid-turn messages now default to queued=\"true\". To explicitly mark a message as a course-correction..."
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L8887-L8888
+        snippet: "// steering=\"true\" only when explicit /steer or /s prefix used.\n...(isSteering ? { steering: 'true' } : {}),"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      parseSteerPrefix in steering.ts correctly parses /steer and /s
+      prefixes. gateway.ts line 8651 sets isSteering=true only when the
+      prior turn is in flight AND the steer prefix is present. Line 8888
+      emits steering='true' in the meta dict. The inbound-delivery-gate
+      explicitly exempts steering messages from buffering (line 114:
+      "if (input.isSteering) return 'deliver'") so they reach claude
+      mid-turn as intended.
+
+  - claim_id: c5
+    quote: "Interrupt + new task = !-prefix marker (#575, gateway-side). A message starting with ! SIGINTs the agent, strips the marker, and forwards the body as a fresh turn."
+    loc: L64
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/interrupt-marker.ts
+        lines: L1-L3
+        snippet: "`!`-prefix interrupt marker — closes #575 / part of `reference/steer-or-queue-mid-flight.md`."
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L8027-L8105
+        snippet: "1. SIGINT the agent service ... 2. Strip the `!` and forward the body as a fresh turn ... 3. React with ⚡ on the `!` message"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      interrupt-marker.ts implements parseInterruptMarker. gateway.ts
+      lines 8046-8105 implement the three-step behavior: set ⚡ reaction
+      (8054-8056), send SIGINT via tmux send-keys (8069-8079), forward
+      body as fresh turn or send clarifying reply on empty body (8084-8105).
+
+  - claim_id: c6
+    quote: "Empty ! triggers a 'send your replacement instruction now' reply rather than forwarding nothing."
+    loc: L64
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L8084-L8101
+        snippet: "if (interrupt.emptyBody) { ... bot.api.sendMessage(chat_id, '⚡ Interrupted. Send your replacement instruction now.' ..."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      gateway.ts line 8084 checks interrupt.emptyBody and sends the
+      exact reply text "⚡ Interrupted. Send your replacement instruction
+      now." then returns early. The claim's description matches the code.
+
+  - claim_id: c7
+    quote: "What the user sees: 🤝 reaction on a /steer message confirms the steer landed mid-turn; ⚡ reaction on a ! message confirms the interrupt landed; queued messages get the normal 👀 (received) reaction"
+    loc: L65
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L8655-L8665
+        snippet: "if (isSteering) {\n  void bot.api.setMessageReaction(chat_id, msgId, [{ type: 'emoji', emoji: '🤝' }])...\n} else if (priorTurnInFlight) {\n  void bot.api.setMessageReaction(chat_id, msgId, [{ type: 'emoji', emoji: '👀' }])"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      gateway.ts lines 8655-8665 implement exactly these three reaction
+      paths: 🤝 for steering (line 8658), 👀 for queued mid-turn (line
+      8663), and ⚡ for interrupt (line 8054-8056 in the interrupt block).
+      The fresh-turn path sets 👀 via the StatusReactionController.setQueued()
+      call at line 8712.
+
+  - claim_id: c8
+    quote: "The agent self-narrates the classification at the top of its reply (e.g. _↪️ Treating as steer on the prior task_ or _📥 Queued as a new task_) so the chosen path is visible, not inferred."
+    loc: L65
+    verdict: aligned
+    evidence:
+      - path: profiles/_shared/telegram-style.md.hbs
+        lines: L32
+        snippet: "Self-narrate the classification. At the top of your reply for any `steering` or `queued` message, include a brief italic one-liner so the user can correct you — e.g. `_↪️ Treating as steer on the prior task_` or `_📥 Queued as a new task_`."
+      - path: telegram-plugin/uat/scenarios/jtbd-rapid-followup-dm.test.ts
+        lines: L58-L61
+        snippet: "const narratesSteer = /↪️|\\bsteer(ing)?\\b|continuing the (prior|original|in-flight) task|amendment|course[- ]correct/i.test(txt);"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The self-narration is a prompt instruction in
+      profiles/_shared/telegram-style.md.hbs (line 32), not a code
+      invariant. The UAT (jtbd-rapid-followup-dm.test.ts) asserts for the
+      narration pattern on both the steer and queued paths, giving
+      behavioral coverage. Evidence is medium (no code enforces it; a
+      prompt-following model could omit it) but the claim itself is
+      accurate as a statement of the instructed contract.
+
+  - claim_id: c9
+    quote: "Nothing the user said gets lost. Not to a race, not to an ambiguity, not to a restart."
+    loc: L39
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/inbound-spool.ts
+        lines: L1-L29
+        snippet: "durable, crash-tolerant spool for buffered inbound ... every buffered inbound is also appended to a JSONL spool on the persistent per-agent volume ... On boot the gateway replays un-acked entries back into the in-memory buffer"
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L3478-L3504
+        snippet: "const inboundSpool = STATIC ... path: join(STATE_DIR, 'inbound-spool.jsonl') ... telegram gateway: inbound-spool boot-replay re-queued ${replay.length} un-acked inbound (durable-queue, survives restart)"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The inbound-spool JSONL (introduced in #1546/#1549) implements
+      durable buffering that survives container restarts. The inbound-
+      delivery-gate prevents race-loss from mid-turn delivery. The spool's
+      own header note acknowledges a v1 limitation: the ack is "delivered
+      to registered bridge" not "consumed by claude", so the guarantee
+      is not end-to-end. The JTBD claim is at the outcome level and does
+      not overstate this boundary. Evidence is medium because the v1
+      limitation exists as a documented gap.

--- a/audit/2026-05-26/findings/jtbd-survive-reboots-and-real-life.yaml
+++ b/audit/2026-05-26/findings/jtbd-survive-reboots-and-real-life.yaml
@@ -1,0 +1,273 @@
+unit_id: jtbd-survive-reboots-and-real-life
+unit_path: reference/survive-reboots-and-real-life.md
+category: jtbd
+audited_at: 2026-05-26T14:00:00Z
+auditor_notes: |
+  All major claims in this JTBD map to concrete implemented mechanisms.
+  The four anchors from the brief are all present:
+    - SWITCHROOM_PENDING_TURN resume protocol: gateway.ts L960-989 writes
+      .pending-turn.env; start.sh.hbs L397-409 sources and exports it.
+    - Wake-audit sentinel: start.sh.hbs L435 writes .wake-audit-pending on
+      every boot; UAT scenario jtbd-wake-audit-content-dm.test.ts exercises it.
+    - Restart-marker + sweep: boot-reason.ts determines reason (planned/
+      graceful/crash/fresh); boot-card.ts renders crash-recovery row;
+      lifecycle-restart-reason.test.ts pins the contract.
+    - container restart: unless-stopped: compose.ts emits this on all four
+      service types (broker L792, approval-kernel L1022, auth-broker L1114,
+      agent L1339).
+  One minor gap: the "persistent failures surface / stopped trying" claim
+  (Signs L36-37) has partial coverage — the operator-events taxonomy covers
+  quota/credentials/crash but Telegram network give-up after maxRetries
+  (retry-api-call.ts L169) does NOT emit a user-visible message; it just
+  logs to stderr. Confidence is medium on that sub-claim.
+  The JTBD contains no implementation-detail leakage (no file paths, class
+  names, or container names in the user-facing prose).
+findings:
+  - claim_id: c1
+    quote: "After a machine reboot, the fleet comes back on its own. The user doesn't have to kick anything."
+    loc: L29-L30
+    verdict: aligned
+    evidence:
+      - path: src/agents/compose.ts
+        lines: L792, L1022, L1114, L1339
+        snippet: "lines.push(`    restart: unless-stopped`);"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      compose.ts emits `restart: unless-stopped` on all four compose services
+      (broker, kernel, auth-broker, agent). Docker's restart policy brings
+      containers back after host reboot without operator action.
+
+  - claim_id: c2
+    quote: "After an agent crash, the process is respawned and the user is told, with enough detail to know whether the in-flight work survived."
+    loc: L31-L32
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/boot-reason.ts
+        lines: L58-L85
+        snippet: "if (sessionMarker != null) return 'crash'"
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L352-L364
+        snippet: "if (restartReason === 'crash') { ... degradedRows.push(`⚠️ <b>Restart</b>  ${escapeHtml(REASON_LABEL.crash)}${ageStr}`) ... }"
+      - path: telegram-plugin/operator-events.ts
+        lines: L23
+        snippet: "| 'agent-crashed'"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      boot-reason.ts classifies gateway boot as 'crash' when a prior
+      session-marker exists (process ran before, no clean shutdown). boot-card.ts
+      renders a visible crash-recovery row with age and a log-tail command.
+      The operator-events taxonomy also includes 'agent-crashed' for a second
+      notification channel.
+
+  - claim_id: c3
+    quote: "Context exhaustion is handled as a named event, not a mysterious refusal. The user understands what happened."
+    loc: L33-L34
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L6811-L6828
+        snippet: "isContextExhaustionText(ev.text) ... bot.api.sendMessage(chatId, '⚠️ <b>Context window full</b> — send <code>/restart</code> to start a fresh session.'"
+      - path: telegram-plugin/context-exhaustion.ts
+        lines: L14-L18
+        snippet: "export const CONTEXT_EXHAUSTION_MARKER = 'Prompt is too long'"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The gateway detects context exhaustion (marker text "Prompt is too long"),
+      sends the user a named message with a /restart action hint, and finalizes
+      the turn. Proactive compaction also notifies the user with a "Context
+      compacted" card (gateway.ts L1698-1705) before exhaustion is hit.
+
+  - claim_id: c4
+    quote: "Transient failures (network, tool, upstream) retry sensibly. The user doesn't see flakes they don't need to."
+    loc: L35-L36
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/retry-api-call.ts
+        lines: L1-L25
+        snippet: "| Network error (fetch failed / ECONN…) | exponential backoff retry, 3 attempts |"
+      - path: telegram-plugin/gateway/startup-network-retry.ts
+        lines: L168-L213
+        snippet: "gatewayStartupRetry — bounded exponential-backoff retry for gateway startup network errors"
+      - path: profiles/_base/start.sh.hbs
+        lines: L49-L85
+        snippet: "_switchroom_supervise ... retrying in ${_delay}s (transient deps self-heal; never gives up)"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      Three distinct retry layers exist: (1) retry-api-call.ts wraps every
+      Telegram API call with exponential backoff on network errors and flood-wait;
+      (2) startup-network-retry.ts handles the boot-time network-not-ready window;
+      (3) start.sh.hbs _switchroom_supervise provides an exponential-backoff
+      supervisor loop that never gives up on transient failures.
+
+  - claim_id: c5
+    quote: "Persistent failures surface. The user is told when a retry loop has stopped trying."
+    loc: L37-L38
+    verdict: drift-minor
+    evidence:
+      - path: telegram-plugin/operator-events.ts
+        lines: L17-L27
+        snippet: "OperatorEventKind: 'credentials-expired' | 'credentials-invalid' | 'credit-exhausted' | 'quota-exhausted' | 'rate-limited' | 'agent-crashed' | 'agent-restarted-unexpectedly'"
+      - path: telegram-plugin/retry-api-call.ts
+        lines: L169
+        snippet: "observer?.onGiveUp?.({ attempts: maxRetries, error: giveUpErr })"
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    rationale: |
+      Persistent failures of the operator-event taxonomy (credentials, quota,
+      crashes) do surface via Telegram. However, the retry-api-call.ts
+      `onGiveUp` callback is observer-only — no user-visible message is sent
+      when the Telegram API call itself gives up after maxRetries; it logs to
+      stderr only. The claim is partially true. The JTBD prose says "The user
+      is told when a retry loop has stopped trying" — this is true for the
+      named operator-event kinds but not explicitly for all retry-give-up
+      paths. Minor drift: coverage is real but not universal. Proposed text:
+      "Persistent named failures (credentials, quota exhaustion, crashes)
+      surface. The user is told with an operator-event card."
+
+  - claim_id: c6
+    quote: "Scheduled work survives a reboot. Jobs that should have fired either fire on return or are explicitly skipped, not silently dropped."
+    loc: L39-L40
+    verdict: aligned
+    evidence:
+      - path: src/agent-scheduler/index.ts
+        lines: L268-L406
+        snippet: |
+          "At-least-once replay: if the container restarted across a scheduled fire,
+          replay it now before the live cron loop starts. Bounded by
+          SWITCHROOM_AGENT_SCHEDULER_REPLAY_MIN minutes (default 30)..."
+          "staleSkipped ... notifying user ... [switchroom scheduler notice] While
+          this agent was offline, the following scheduled task(s) had at least one
+          run skipped..."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The agent-scheduler's boot path implements exactly the described
+      behavior: missed fires within the 30-minute replay window are re-run;
+      fires older than the window produce a user-visible notice explicitly
+      listing what was skipped and why. The source code comment at L301-304
+      directly cites the "survive-reboots JTBD" as the requirement.
+
+  - claim_id: c7
+    quote: "The user can ask 'is everything healthy?' and get a real answer."
+    loc: L41
+    verdict: aligned
+    evidence:
+      - path: src/cli/doctor.ts
+        lines: L2448
+        snippet: "export function registerDoctorCommand(program: Command): void {"
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L9919-L10057
+        snippet: "Build the optional audit details surfaced on /status ... /status shows every row (silent-when-healthy)"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Both a CLI (`switchroom doctor`) and an in-chat command (`/status`) exist.
+      The /status command runs the full boot-card probe set and renders all rows
+      including healthy ones. The CLI doctor runs a broader check covering auth,
+      vault, docker, scheduler, and agent smoke. Confidence is medium because
+      the actual /status output format and completeness were not read in full.
+
+  - claim_id: c8
+    quote: "Silent death. An agent process that's gone but still appears to be addressable."
+    loc: L44-L45
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/restart-watchdog.ts
+        lines: L1-L20
+        snippet: "polls systemd's NRestarts counter for the agent service and emits agent-restarted-unexpectedly when it ticks up without a corresponding planned-restart marker"
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L525-L548
+        snippet: "probeAgentProcess ... watchAgentProcess — live agent-status loop"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      This anti-pattern is explicitly guarded: the restart-watchdog detects
+      unexpected process restarts and emits an operator event. The boot-card
+      live watch loop (watchAgentProcess) actively polls process state during
+      boot and edits the card when the process goes active/failed.
+
+  - claim_id: c9
+    quote: "Silent resurrection. An agent that came back in a different state than it went down in, without saying so."
+    loc: L46-L47
+    verdict: aligned
+    evidence:
+      - path: profiles/_base/start.sh.hbs
+        lines: L411-L435
+        snippet: |
+          "# Wake audit sentinel ... Every boot drops a .wake-audit-pending sentinel
+          ... The agent's wake-audit protocol instructs it to detect this file at
+          the start of its first turn after boot, run a three-signal check
+          (owed reply / orphan sub-agents / open todos), surface findings to the
+          user"
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L327-L365
+        snippet: "restartReason ... REASON_LABEL ... 'crash': 'crash recovery'"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The wake-audit sentinel + SWITCHROOM_PENDING_TURN protocol together ensure
+      the agent notifies the user of its prior state on next turn. The boot card
+      distinguishes crash vs graceful vs planned. The wake-audit SKILL.md drives
+      the in-session check. Coverage is good; confidence is medium because the
+      actual skill behavior was not read, only the sentinel mechanism.
+
+  - claim_id: c10
+    quote: "Dropping in-flight work on the floor when a process dies, with no mention of what was lost."
+    loc: L50-L51
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L952-L989
+        snippet: |
+          "Stage 4: surface the most-recently-interrupted turn to start.sh as a
+          shell-sourceable env file ... SWITCHROOM_PENDING_TURN=true,
+          SWITCHROOM_PENDING_TURN_KEY, SWITCHROOM_PENDING_CHAT_ID ..."
+      - path: profiles/_base/start.sh.hbs
+        lines: L385-L409
+        snippet: |
+          "if [ -f '$SWITCHROOM_PENDING_TURN_ENV' ]; then . '$SWITCHROOM_PENDING_TURN_ENV'
+          ... export SWITCHROOM_PENDING_TURN ..."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The gateway writes .pending-turn.env atomically (tmp + rename) on every
+      boot when a prior turn was interrupted. start.sh sources this file and
+      exports SWITCHROOM_PENDING_TURN=true plus full chat context to the agent
+      process. The agent's resume protocol then acks the interruption. Work is
+      not silently dropped.
+
+  - claim_id: c11
+    quote: "Recovery that requires the user to read logs. Logs are a debugging aid, not a user experience."
+    loc: L55-L56
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/boot-card.ts
+        lines: L358-L364
+        snippet: |
+          "const tailCmd = process.env.SWITCHROOM_RUNTIME === 'docker'
+            ? `docker logs --tail 100 switchroom-${...}`
+            : `journalctl --user -u switchroom-${...} -n 100`
+          degradedRows.push(`    ↳ Tail logs: <code>${tailCmd}</code>`)"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The crash row in the boot card includes the tail-logs command as an
+      inline ↳ continuation line, consistent with the principle that failures
+      carry their next step. Logs are surfaced in-chat as a step, not required
+      for recovery. This matches the anti-pattern's intent: logs are offered
+      as debugging aid, not the primary recovery path.

--- a/audit/2026-05-26/findings/jtbd-talk-to-agents-from-anywhere.yaml
+++ b/audit/2026-05-26/findings/jtbd-talk-to-agents-from-anywhere.yaml
@@ -1,0 +1,233 @@
+unit_id: jtbd-talk-to-agents-from-anywhere
+unit_path: reference/talk-to-agents-from-anywhere.md
+category: jtbd
+audited_at: 2026-05-26T14:00:00Z
+auditor_notes: |
+  The JTBD is high-level and outcome-focused with no file paths or class names
+  leaked into the text, which is correct for this category. Most claims are
+  aspirational ("Signs it's working") rather than verifiable behavioral
+  contracts, but several map to concrete shipped or partially-shipped
+  implementation points.
+
+  Key findings:
+  1. The "Telegram-only, no second channel" stance aligns fully with vision.md
+     and the codebase — no Slack/Discord/Teams paths exist.
+  2. Long-poll bot model confirmed: gateway.ts uses grammY long-polling, no
+     webhooks.
+  3. Photo/attachment handling is shipped: gateway handles message:photo,
+     message:document, message:voice with download + pass-through.
+  4. "Instant acknowledgment" (eyes reaction on raw arrival) is shipped.
+  5. "Not silent on long work" is handled by silence-poke.ts escalation ladder.
+  6. "Hand off and come back" is partially addressed by handoff-continuity.ts
+     (.handoff-topic sidecar) — context survives restarts.
+  7. "Multiple agents as one fleet" works via Telegram forum topics (topic-manager.ts).
+  8. Two active gaps that the test file explicitly tracks as .skip:
+     a. /vault broker {status,restart} does not exist (broker_unreachable error
+        legitimately punts to host CLI).
+     b. "Phase 4c will wire" stub in gateway.ts:13079 punts swap-slot/add-slot
+        auth actions to host terminal. Tests `it.skip("no string says 'Phase Nx
+        will wire'")` and `it.skip("no string says 'run in terminal'")` reflect
+        these known gaps.
+  9. /agent remove and /agent admin <name> on|off do not exist as bot commands
+     (separate it.skip entries in the test file).
+
+  All anti-patterns section content is outcome-level and not verifiable against
+  code — treated as vision prose, no verdicts needed there.
+
+findings:
+  - claim_id: c1
+    quote: "the chat surface is first-class, not a bolted-on notification channel"
+    loc: L14-L16
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L3-L3
+        snippet: "Persistent Telegram gateway — owns the bot connection, polling, all admin"
+      - path: reference/vision.md
+        lines: L128-L128
+        snippet: "A multi-channel bridge | Not Slack, not Discord, not Teams. Telegram, done properly."
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The codebase is entirely Telegram-centric. No Slack/Discord/Teams paths
+      exist in telegram-plugin/ or src/. vision.md explicitly names Telegram as
+      the singular interface. The gateway is a persistent long-poll service, not
+      a bolt-on notification relay.
+
+  - claim_id: c2
+    quote: "Inbound messages feel acknowledged instantly, not 'processing' for ten seconds before anything appears."
+    loc: L29-L30
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L7850-L7897
+        snippet: "F2 fix (#553): fire 👀 reaction on RAW arrival, before the coalesce flush"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      gateway.ts fires a 👀 reaction on raw arrival of the inbound message
+      (line 7850), before the coalesce flush. This is an explicit F2 fix for
+      the "ack before processing" requirement. The test file (tests/jtbd-talk-from-anywhere.test.ts)
+      does not test this directly but the code comment matches the JTBD claim.
+
+  - claim_id: c3
+    quote: "Attachments the user sends (a photo, a file) are treated as real input, not stripped or ignored."
+    loc: L34-L35
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L14386-L14432
+        snippet: "bot.on('message:photo', ...) ... bot.on('message:document', ...)"
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      gateway.ts registers handlers for message:photo (downloads best-resolution
+      image, writes to inbox, passes path to handleInbound), message:document
+      (passes file_id + metadata), and message:voice (optional Whisper
+      transcription when voice_in enabled, falls back to envelope text). All
+      three types are treated as real input rather than stripped.
+
+  - claim_id: c4
+    quote: "Notifications tell the user something they actually need to know. They don't fire on every edit, they don't go silent when something important happened."
+    loc: L36-L37
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L4460-L4503
+        snippet: "mid-turn updates pass disable_notification:true ... downgrading disable_notification:false -> true"
+      - path: telegram-plugin/silence-poke.ts
+        lines: L22-L30
+        snippet: "t=300s framework fallback: gateway itself sends a user-visible 'still working...' message. Fires at most once per turn. Pings the device"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Mid-turn stream_reply calls pass disable_notification:true so only the
+      final answer pings the device. silence-poke.ts fires a device-pinging
+      "still working..." fallback at 300s if the model has been silent — this
+      covers the "don't go silent" half. The claim's two parts are both addressed.
+
+  - claim_id: c5
+    quote: "The user can hand off a task, lock the phone, come back an hour later, and pick up where the agent left off without re-explaining."
+    loc: L38-L39
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/handoff-continuity.ts
+        lines: L1-L30
+        snippet: "On session start, the telegram plugin reads .handoff-topic ... On the FIRST assistant reply of the new session the plugin prepends a subtle one-liner: Picked up where we left off, <topic>"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      handoff-continuity.ts reads .handoff-topic (written by the Stop hook
+      summarizer) and prepends a continuity line on the first reply of a new
+      session. .last-turn-summary provides a fallback when the summarizer didn't
+      run. This covers the "pick up where we left off" part. The "without
+      re-explaining" aspect relies on the agent's claude --continue session
+      memory, not just the handoff sidecar — confidence medium because the
+      hand-off only surfaces the last topic, not full context.
+
+  - claim_id: c6
+    quote: "Multiple agents in the same app feel like one fleet, not a drawer of disconnected bots the user has to remember how to address."
+    loc: L40-L41
+    verdict: aligned
+    evidence:
+      - path: src/telegram/topic-manager.ts
+        lines: L144-L179
+        snippet: "Sync forum topics for all agents that have a topic_name. Creates topics that don't exist yet"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      topic-manager.ts creates per-agent forum topics within a single Telegram
+      supergroup, so the user interacts with all agents in one chat via named
+      topics. The /agents command (gateway.ts:10150) and /status command provide
+      a fleet-level view. This implements the "one fleet, not a drawer" claim.
+
+  - claim_id: c7
+    quote: "Drive a real task start-to-finish from a phone, walking, on cellular. The experience should not feel like a compromise."
+    loc: L62-L63
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L13075-L13082
+        snippet: "case 'swap-slot': case 'add-slot': { await ctx.answerCallbackQuery({ text: 'Phase 4c will wire this' }) ... await ctx.reply(`Phase 4c will wire ${action} buttons. Until then, run in terminal: <code>switchroom ${cmd}</code>`"
+      - path: tests/jtbd-talk-from-anywhere.test.ts
+        lines: L186-L193
+        snippet: "it.skip('no string says run in terminal anywhere in the live gateway')"
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      The UAT prompt "Phone-only session" maps directly to the JTBD's core
+      outcome. However gateway.ts:13079 contains an active code path that
+      replies to auth slot-management callbacks with "Phase 4c will wire this.
+      Until then, run in terminal: switchroom auth use ..." This is a
+      live regression against the JTBD — the user is tethered to a terminal
+      for auth slot operations. The test file explicitly tracks this as a
+      known gap (it.skip at line 186). This requires a product decision, not
+      a doc edit.
+
+  - claim_id: c8
+    quote: "Long-running work with the screen off. Kick off something slow, lock the phone, come back when it's done. The user should know it finished and what it produced."
+    loc: L68-L70
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/silence-poke.ts
+        lines: L22-L36
+        snippet: "t=300s framework fallback: gateway itself sends a user-visible 'still working...' / 'still thinking...' message. Fires at most once per turn. Pings the device (user needs to know)."
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      The silence-poke escalation ladder ensures the user is pinged when the
+      agent has been silent for 300s. The final answer always pings (disable_notification
+      is false on done=true). The "what it produced" part relies on the model
+      producing a substantive final reply, which is a model behavior not a
+      framework guarantee — confidence medium.
+
+  - claim_id: c9
+    quote: "Send a photo. Attach a picture and ask the agent to act on it. The photo should be usable input, not discarded."
+    loc: L72-L73
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L14386-L14426
+        snippet: "bot.on('message:photo', async ctx => { ... const dlPath = buildAttachmentPath(...) ... writeFileSync(dlPath, buf, ...) return dlPath })"
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      Photos are downloaded (best-resolution variant), written to the agent's
+      inbox directory, and the file path is passed to handleInbound as the
+      downloadImage callback. The agent receives the image path as context.
+      This fully implements "usable input, not discarded."
+
+  - claim_id: c10
+    quote: "Dead zone. Lose connectivity mid-task. When it comes back the user should see a sensible state, not a broken thread."
+    loc: L75-L76
+    verdict: vision-only
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L3135-L3139
+        snippet: "gateway processes can't race on Telegram's getUpdates long-poll"
+    evidence_strength: weak
+    action: mark-vision
+    confidence: low
+    rationale: |
+      The JTBD claims that after a connectivity dead zone the user sees
+      "a sensible state, not a broken thread." The gateway uses long-polling
+      which naturally resumes on reconnect; Telegram delivers queued messages
+      when connectivity returns. However there is no specific code path that
+      handles the "broken thread" case — no connectivity-loss detector, no
+      in-flight turn recovery message on reconnect. The long-poll resumes
+      but whether the state looks "sensible" to the user depends on what was
+      in-flight. This claim is aspirational and not fully verified against code.
+      Marking as vision-only to surface it for evaluation.
+    proposed_text: |
+      "Dead zone. Lose connectivity mid-task. When it comes back Telegram
+      delivers queued messages and the agent resumes from where it stopped;
+      in-flight turns may show a stale progress state until the next update."

--- a/audit/2026-05-26/findings/jtbd-track-plan-quota-live.yaml
+++ b/audit/2026-05-26/findings/jtbd-track-plan-quota-live.yaml
@@ -1,0 +1,200 @@
+unit_id: jtbd-track-plan-quota-live
+unit_path: reference/track-plan-quota-live.md
+category: jtbd
+audited_at: 2026-05-26T12:00:00Z
+auditor_notes: |
+  The quota infrastructure is well-built for pull (via /usage and the boot card)
+  and for fatal-state push (credits-watch fires on credit exhaustion). The gap is
+  the middle tier: approaching-cap signals. The JTBD says "approaching a cap
+  produces a visible signal at a point where the user can still act on it," but
+  no such threshold exists in code — there is no proactive notification that fires
+  at e.g. 80% utilization. Similarly, "when the window rolls, the user sees the
+  recovery without having to refresh anything" is not implemented; recovery is
+  only visible on the next /usage poll or agent restart.
+
+  The "one pool, not two" claim and the multiple-window display (5h + 7d) are
+  well-supported. Plan variance is handled by mapPlan() reading billingType from
+  .claude.json without requiring user configuration.
+
+  Key files examined:
+    telegram-plugin/quota-check.ts — fetchQuota, formatQuotaBlock, formatQuotaLine
+    telegram-plugin/credits-watch.ts — fatal-credit push logic
+    telegram-plugin/gateway/boot-probes.ts — probeQuota (pull, at boot)
+    telegram-plugin/gateway/quota-cache.ts — 5-min cache
+    telegram-plugin/gateway/gateway.ts:13652 — /usage command handler
+    telegram-plugin/gateway/gateway.ts:15986-15998 — credits-watch 15-min poll
+    telegram-plugin/model-unavailable.ts — quota-exhausted card on hit
+
+findings:
+  - claim_id: c1
+    quote: "The user can answer 'am I close to my limit?' without stopping what they're doing."
+    loc: L39-L40
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L13652-L13705
+        snippet: "bot.command('usage', async ctx => { ... await switchroomReply(ctx, formatQuotaBlock(result.data), { html: true }) })"
+      - path: telegram-plugin/gateway/boot-probes.ts
+        lines: L856-L942
+        snippet: "export async function probeQuota(...): Promise<ProbeResult> { ... detail: formatQuotaLine(probe.data) }"
+    evidence_strength: medium
+    action: escalate
+    confidence: medium
+    rationale: |
+      Quota is available as a pull surface (/usage command) and in the boot card
+      at restart time. There is no ambient ongoing display — no Telegram message
+      header, no periodic quota-update push, no inline indication during normal
+      use. The user must run /usage or look at the boot card from the last restart.
+      The JTBD stakes ("the user shouldn't need to run a command") are not met for
+      the normal in-session case. This is an outcome-not-realized finding, not a
+      doc edit.
+
+  - claim_id: c2
+    quote: "Approaching a cap produces a visible signal at a point where the user can still act on it."
+    loc: L41-L42
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/credits-watch.ts
+        lines: L38-L43
+        snippet: "const FATAL_REASONS = new Set(['out_of_credits', 'org_level_disabled', 'credits_exhausted', 'extra_usage_disabled'])"
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L15986-L15998
+        snippet: "const CREDIT_WATCH_POLL_MS = Number(process.env.SWITCHROOM_CREDIT_WATCH_POLL_MS ?? 15 * 60_000) ... void runCreditWatch()"
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      credits-watch (the only proactive push mechanism) fires only on fatal billing
+      transitions (out_of_credits, credits_exhausted, etc.). There is no threshold
+      (e.g. 80% or 90% utilization) that triggers a pre-cap warning. The code
+      explicitly limits notification to "fatal" reasons. A user hitting the wall
+      gets notified only when they are already blocked, not before.
+
+  - claim_id: c3
+    quote: "Hitting a cap produces an honest message. The user knows they're blocked, why, and when they won't be."
+    loc: L43-L44
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/model-unavailable.ts
+        lines: L1-L27
+        snippet: "When a user message hits Claude and the model is unreachable — quota exhausted ... the desired UX is a clean card naming what failed and pointing at the three actions..."
+      - path: telegram-plugin/credits-watch.ts
+        lines: L153-L163
+        snippet: "buildEntryMessage() includes console.anthropic.com link and cachedExtraUsageDisabledReason"
+      - path: telegram-plugin/quota-check.ts
+        lines: L216-L231
+        snippet: "formatResetRelative() returns 'resets in Xh Ym' countdown"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      model-unavailable.ts renders a structured card with reset timing pulled via
+      formatResetRelative(). credits-watch.ts messages include the specific reason
+      and a link to console.anthropic.com. formatQuotaBlock includes reset
+      countdowns for both windows. The cap-hit UX satisfies this claim.
+
+  - claim_id: c4
+    quote: "Usage shown matches reality closely enough that the user trusts it for planning."
+    loc: L45-L46
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/quota-cache.ts
+        lines: L31-L39
+        snippet: "export const DEFAULT_TTL_MS = 5 * 60 * 1000 // 5 min ... export const RATE_LIMIT_TTL_MS = 30 * 1000 // 30 s"
+      - path: telegram-plugin/gateway/boot-probes.ts
+        lines: L856-L942
+        snippet: "probeQuota hits /v1/messages and reads anthropic-ratelimit-unified-* headers"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Quota data comes from live Anthropic rate-limit headers (not computed locally),
+      cached for at most 5 minutes. The data source is the same headers the CLI's
+      /usage panel uses. 5-minute staleness is documented and acceptable for
+      planning purposes. The claim is broadly met.
+
+  - claim_id: c5
+    quote: "Different plans and different limits are handled correctly without the user configuring anything."
+    loc: L47-L48
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/gateway/boot-probes.ts
+        lines: L120-L127
+        snippet: "function mapPlan(billingType?: string, hasExtra?: boolean): string { if (billingType === 'stripe_subscription') { return hasExtra ? 'Pro+' : 'Pro' } if (billingType.toLowerCase().includes('max')) return 'Max' }"
+      - path: telegram-plugin/quota-check.ts
+        lines: L112-L132
+        snippet: "parseQuotaHeaders reads 5h and 7d from anthropic-ratelimit-unified-* headers; server returns whichever windows apply to the plan"
+    evidence_strength: medium
+    action: keep
+    confidence: medium
+    rationale: |
+      Plan type is inferred from .claude.json's billingType field without user
+      configuration. Window data comes from the Anthropic API headers, which reflect
+      the actual plan limits on the server side. No manual plan-configuration step
+      is required.
+
+  - claim_id: c6
+    quote: "The signal scales with the stakes. Background when there's headroom, louder when there isn't."
+    loc: L49-L50
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/credits-watch.ts
+        lines: L38-L43
+        snippet: "FATAL_REASONS = new Set(['out_of_credits', 'org_level_disabled', 'credits_exhausted', 'extra_usage_disabled'])"
+      - path: telegram-plugin/gateway/boot-probes.ts
+        lines: L856-L942
+        snippet: "probeQuota returns ProbeResult with status 'ok' when quota is under limit; no degraded threshold for high utilization"
+    evidence_strength: strong
+    action: escalate
+    confidence: high
+    rationale: |
+      The code has two signal levels: (a) quiet/absent when quota is fine and
+      (b) fatal notification when credits are exhausted. There is no middle tier —
+      no "approaching cap" (e.g. 80% utilization) that produces an intermediate
+      signal louder than background but before the wall. The boot-card quota probe
+      shows a row only when status is 'degraded' or 'fail'; high-utilization does
+      not produce degraded status. The graduated signal the JTBD describes is not
+      built.
+
+  - claim_id: c7
+    quote: "When the window rolls, the user sees the recovery without having to refresh anything."
+    loc: L51-L52
+    verdict: outcome-not-realized
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L15986-L15998
+        snippet: "CREDIT_WATCH_POLL_MS = 15 * 60_000 ... credits-watch fires only on fatal transitions; recovery path notifies only from fatal -> null"
+      - path: telegram-plugin/credits-watch.ts
+        lines: L116-L124
+        snippet: "Recovery path: last-notified was fatal, current is null/non-fatal. notifies 'credits restored'"
+    evidence_strength: medium
+    action: escalate
+    confidence: medium
+    rationale: |
+      credits-watch does notify on the fatal->healthy transition ("credits restored"),
+      so users who previously hit a full credit block do see recovery. However
+      "window rolls" in the JTBD context refers to the 5h or 7d rolling window
+      resetting during normal usage (not a full credit block) — e.g. a user who
+      was at 95% utilization and was nudged back to 0% when the 5h window rolled.
+      No code watches for this kind of recovery or pushes a notification. The
+      recovery path is pull-only (next /usage or next restart boot card).
+
+  - claim_id: c8
+    quote: "Switchroom deliberately has no programmatic surface: every model call is the interactive claude session ... So there is exactly one pool to track."
+    loc: L28-L35
+    verdict: aligned
+    evidence:
+      - path: src/auth/quota.ts
+        lines: L1-L20
+        snippet: "Hits POST /v1/messages with the Claude CLI's exact OAuth + header shape ... intentionally dependency-free: just fetch, no filesystem, no telegram, no broker"
+      - path: CLAUDE.md
+        lines: L37-L66
+        snippet: "Every agent runs the unmodified claude CLI ... No ANTHROPIC_API_KEY ... no Claude Agent SDK ... no raw Anthropic API"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      CLAUDE.md enforces the single-pool constraint as a hard engineering gate. The
+      quota probe uses the same OAuth + header path as the CLI. No SDK or API key
+      paths exist in the codebase. The JTBD's "one pool" claim accurately reflects
+      both the design intent and the implementation.

--- a/audit/2026-05-26/findings/rfc-docker-multi-container.yaml
+++ b/audit/2026-05-26/findings/rfc-docker-multi-container.yaml
@@ -1,0 +1,253 @@
+unit_id: rfc-docker-multi-container
+unit_path: reference/rfc-docker-multi-container.md
+category: rfc-draft
+audited_at: 2026-05-26T14:00:00Z
+auditor_notes: |
+  The RFC body already contains a "Status — shipped in v0.7" section (L11-L24)
+  that explicitly states the design shipped. The body-level status is accurate
+  and the internal phase notes are largely accurate. However, the YAML frontmatter
+  still says `status: Draft` (L3), which is the root problem this unit was flagged
+  for. Several secondary claims in the body drift from the current codebase:
+  UID range shifted, image count grew, CLI verb changed, compose skeleton includes
+  an obsolete `version: "3.9"` field, gateway topology changed from MCP-child to
+  supervised sidecar, and the watchdog rewrite was officially deferred rather than
+  built. The scheduler section is already correctly annotated as retired.
+findings:
+  - claim_id: c1
+    quote: "status: Draft"
+    loc: L3
+    verdict: rfc-status-wrong
+    evidence:
+      - path: reference/rfc-docker-multi-container.md
+        lines: L11-L24
+        snippet: "## Status — shipped in v0.7\n\nThis RFC is **shipped**. v0.7.0 is\
+          \ the docker-only release: the legacy systemd path was removed..."
+      - path: src/agents/compose.ts
+        lines: L1-L24
+        snippet: "Docker Compose generator — Phase 1a. Turns the cascade-resolved\
+          \ switchroom.yaml into a deterministic docker-compose.yml."
+      - path: docker/Dockerfile.agent
+        lines: L1-L1
+        snippet: "Dockerfile.agent exists — confirms Docker agent image was built"
+    evidence_strength: strong
+    action: update-frontmatter
+    confidence: high
+    rationale: |
+      The RFC body explicitly says "This RFC is shipped" with version reference,
+      PR numbers, and phase statuses. src/agents/compose.ts is a fully implemented
+      compose generator. All Dockerfiles exist under docker/. The frontmatter
+      `status: Draft` is contradicted by the body itself and by the implementation.
+      Change frontmatter to `status: Shipped` (or `status: Historical` if the body
+      is being preserved purely as a design record).
+
+  - claim_id: c2
+    quote: "Four published GHCR images (`switchroom-base`, `switchroom-agent`, `switchroom-broker`, `switchroom-kernel`) — no `docker build` on the operator's host."
+    loc: L19-L21
+    verdict: drift-major
+    evidence:
+      - path: src/agents/compose.ts
+        lines: L354-L356
+        snippet: "return `ghcr.io/switchroom/switchroom-${name}:${imageTag}`;"
+      - path: src/agents/compose.ts
+        lines: L786
+        snippet: "emitImageOrBuild(lines, \"broker\", imageTag, ...)"
+      - path: src/agents/compose.ts
+        lines: L1017
+        snippet: "emitImageOrBuild(lines, \"kernel\", imageTag, ...)"
+      - path: src/agents/compose.ts
+        lines: L1109
+        snippet: "emitImageOrBuild(lines, \"auth-broker\", imageTag, ...)"
+      - path: docker/Dockerfile.hostd
+        lines: L1-L1
+        snippet: "Dockerfile.hostd exists"
+      - path: docker/Dockerfile.auth-broker
+        lines: L1-L1
+        snippet: "Dockerfile.auth-broker exists"
+      - path: docker/Dockerfile.hindsight
+        lines: L1-L1
+        snippet: "Dockerfile.hindsight exists"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The compose generator calls emitImageOrBuild for broker, kernel, auth-broker,
+      and agent. Dockerfiles exist for agent, broker, kernel, auth-broker, hostd,
+      hindsight, and base — seven images, not four. The status block at L19-L21
+      should be updated to reflect the current image set.
+    proposed_replacement: |
+      Replace "Four published GHCR images (`switchroom-base`, `switchroom-agent`,
+      `switchroom-broker`, `switchroom-kernel`)" with "Seven published GHCR images
+      (`switchroom-base`, `switchroom-agent`, `switchroom-broker`, `switchroom-kernel`,
+      `switchroom-auth-broker`, `switchroom-hostd`, `switchroom-hindsight`)"
+
+  - claim_id: c3
+    quote: "Per-agent UIDs are allocated deterministically from the agent name at compose-generation time (e.g. `1100 + stable_hash(agent_name) % 800`, collision-checked across the fleet)."
+    loc: L172-L173
+    verdict: drift-major
+    evidence:
+      - path: src/agents/compose.ts
+        lines: L36-L37
+        snippet: "export const AGENT_UID_MIN = 10001;\nexport const AGENT_UID_MAX\
+          \ = 10999;"
+      - path: src/agents/compose.ts
+        lines: L158-L186
+        snippet: "Allocate a deterministic UID for an agent in [AGENT_UID_MIN, AGENT_UID_MAX]."
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The RFC body states UIDs start at 1100 (1100 + hash % 800), but the
+      implementation uses AGENT_UID_MIN=10001, AGENT_UID_MAX=10999. The range
+      and base value are completely different.
+    proposed_replacement: |
+      Replace "e.g. `1100 + stable_hash(agent_name) % 800`" with
+      "range 10001..10999 (`AGENT_UID_MIN`/`AGENT_UID_MAX` in `src/agents/compose.ts`)"
+
+  - claim_id: c4
+    quote: "user: \"1100:1100\"" and "user: \"1101:1101\"" and "user: \"1102:1102\""
+    loc: L166-L169
+    verdict: drift-major
+    evidence:
+      - path: src/agents/compose.ts
+        lines: L36-L37
+        snippet: "export const AGENT_UID_MIN = 10001; export const AGENT_UID_MAX = 10999;"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The per-agent socket directory layout example uses UIDs 1100/1101/1102 which
+      are from the original design. Actual UIDs are in the 10001-10999 range.
+
+  - claim_id: c5
+    quote: "image: ghcr.io/switchroom/agent:0.7.0" and the compose skeleton showing `version: \"3.9\"`
+    loc: L263-L266
+    verdict: drift-major
+    evidence:
+      - path: src/agents/compose.ts
+        lines: L767-L782
+        snippet: "lines.push(\"# generated by switchroom...\"); ... lines.push(`name:\
+          \ switchroom`); lines.push(\"\"); lines.push(`services:`);"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The compose skeleton in the RFC includes `version: "3.9"` which modern
+      Docker Compose (v2+) does not require or emit. The actual compose generator
+      does not emit a `version:` field — it starts directly with `name: switchroom`
+      then `services:`. Also the image tag example `0.7.0` is now stale (`:latest`
+      or a variable tag is used).
+
+  - claim_id: c6
+    quote: "`switchroom reconcile` regenerates this whole file from `switchroom.yaml`"
+    loc: L330
+    verdict: drift-minor
+    evidence:
+      - path: src/agents/compose.ts
+        lines: L767-L770
+        snippet: "lines.push(\"# generated by switchroom — do not edit by hand.\\\
+          n# Manual edits will be overwritten on the next `switchroom agent add`\\\
+          n# (or future `switchroom reconcile`). To customise an agent, edit\\\
+          n# switchroom.yaml and re-run the regenerating command.\");"
+      - path: src/cli/apply.ts
+        lines: L2-L2
+        snippet: "`switchroom apply` — reconcile fleet to switchroom.yaml."
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    rationale: |
+      The RFC body says "`switchroom reconcile` regenerates this whole file" but the
+      canonical verb is `switchroom apply` (src/cli/apply.ts). The compose generator
+      itself mentions `switchroom reconcile` in its header comment as a future alias,
+      but the actual CLI verb operators use is `switchroom apply`. Minor wording drift.
+    proposed_replacement: |
+      Replace "`switchroom reconcile` regenerates this whole file" with
+      "`switchroom apply` regenerates this whole file"
+
+  - claim_id: c7
+    quote: "The actual shape [...]: tini (PID 1) / tmux (daemonised) / start.sh / claude --continue / MCP child: telegram gateway (telegram-plugin/server.ts)"
+    loc: L141-L149
+    verdict: drift-major
+    evidence:
+      - path: profiles/_base/start.sh.hbs
+        lines: L4-L19
+        snippet: "Under v0.7 docker the container's CMD is start.sh directly under\
+          \ tini [...] the gateway daemon AND autoaccept-poll as supervised sidecars"
+      - path: profiles/_base/start.sh.hbs
+        lines: L104-L108
+        snippet: "_switchroom_supervise gateway /var/log/switchroom/gateway-supervisor.log\
+          \ bun \"$_gateway_bundle\" &"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The RFC process tree shows the telegram gateway as an MCP child of claude (under
+      claude --continue). The actual implementation has the gateway as a supervised
+      sidecar sibling launched before tmux/claude in start.sh, not as an MCP child.
+      CLAUDE.md confirms: "tini → start.sh → (forks gateway + autoaccept-poll +
+      agent-scheduler, then re-execs into tmux)". This is a meaningful architectural
+      difference documented correctly in CLAUDE.md but wrong in this RFC body.
+    proposed_replacement: |
+      Update the process tree to:
+        tini (PID 1) -> start.sh -> (forks gateway sidecar + autoaccept-poll + agent-scheduler) -> exec tmux -> bash -> claude --continue
+
+  - claim_id: c8
+    quote: "Phase 3 — watchdog port [...] Files: `src/watchdog/` from scratch, fixture suite"
+    loc: L494-L535
+    verdict: aligned
+    evidence:
+      - path: reference/rfc-docker-multi-container.md
+        lines: L496-L497
+        snippet: "> **Status (post-v0.6):** DEFERRED / REMOVED in PR #825 — see\
+          \ Status block at top."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The watchdog rewrite section is correctly marked DEFERRED / REMOVED in PR #825.
+      Neither bin/bridge-watchdog.sh (retired per CLAUDE.md status block L13-L14)
+      nor src/watchdog/ (directory does not exist) is present. The RFC correctly
+      notes the phase was dropped; compose healthchecks + restart: unless-stopped
+      replaced the watchdog. No action needed.
+
+  - claim_id: c9
+    quote: "Scheduler architecture [...] singleton scheduler container reading the cascade and dispatching via `docker exec`"
+    loc: L336-L344
+    verdict: aligned
+    evidence:
+      - path: reference/rfc-docker-multi-container.md
+        lines: L336-L344
+        snippet: "> **Retired in PR #893 (Phase 4 cron-fold-in).** The singleton\
+          \ `switchroom-cron` / `switchroom-scheduler` container described below\
+          \ was removed..."
+      - path: src/agents/compose.ts
+        lines: L1094-L1097
+        snippet: "// The singleton switchroom-cron service was removed in Phase 4"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The RFC already has the correct retired annotation. The compose generator
+      confirms at L1094 that the singleton cron service was removed. No action needed.
+
+  - claim_id: c10
+    quote: "Per-agent socket directories [...] klanker/sock mode 0700, owned by uid:gid 1100:1100"
+    loc: L162-L170
+    verdict: drift-major
+    evidence:
+      - path: src/vault/broker/peercred.ts
+        lines: L143
+        snippet: "export function socketPathToAgent(socketPath: string): string | null {"
+      - path: src/agents/compose.ts
+        lines: L36-L37
+        snippet: "export const AGENT_UID_MIN = 10001; export const AGENT_UID_MAX = 10999;"
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The `socketPathToAgent()` helper exists as specified, confirming the path-as-identity
+      design shipped. However the example UIDs (1100:1100, 1101:1101) are from the original
+      design and conflict with the actual 10001-10999 range. The socket directory layout
+      concept is correct; only the example UIDs need updating.
+    proposed_replacement: |
+      Replace uid:gid examples 1100:1100 / 1101:1101 / 1102:1102 with
+      the 10001-10999 range, e.g. "uid:gid 10001:10001 (deterministic hash of agent name)"

--- a/audit/2026-05-26/findings/rfc-sub-agent-visibility.yaml
+++ b/audit/2026-05-26/findings/rfc-sub-agent-visibility.yaml
@@ -1,0 +1,300 @@
+unit_id: rfc-sub-agent-visibility
+unit_path: reference/sub-agent-visibility-rfc.md
+category: rfc-shipped
+audited_at: 2026-05-26T18:00:00Z
+auditor_notes: |
+  The RFC's own frontmatter acknowledges the card model was superseded by
+  conversational-pacing.md, and the status-card-design.md it was based on is
+  archived. The critical finding is that the entire progress-card-driver
+  (progress-card-driver.ts) was deleted in PR #1122 PR3 and the gateway.ts
+  variable `progressDriver` is permanently null. This means:
+
+  - The two-zone progress card (fleet zone, header phase resolver) is gone.
+  - AC-1 through AC-6 are written against a deleted mechanism.
+  - The UAT scenario bg-sub-agent-dispatch-dm.test.ts exists and the assertions
+    (expectPinnedCard, waitForCardPhase) are live infrastructure, but they test
+    a pinned card that no longer exists. The scenario would fail at the first
+    expectPinnedCard call because no pinned progress card is ever produced.
+  - fleet-state.ts (hasLiveBackground, isBackgroundDispatch, cap) exists but is
+    consumed only by subagent-watcher.ts (sanitiseToolArg only) and tests.
+    The functions hasLiveBackground, cap, and the FleetMember struct are dead code
+    in production.
+
+  The sub-agent visibility problem (the original JTBD) is now addressed via:
+    1. cross-turn pending-progress (pending-work-progress.ts, issue #1445)
+    2. subagent-handback inject (subagent-handback-inbound-builder.ts, issue #1720)
+    3. conversational-pacing.md five-beat model
+
+  The RFC itself notes the card model was superseded and points to
+  conversational-pacing.md. The RFC is not misleading about its own status, but
+  its AC/implementation survey describes code that no longer exists in the active
+  source tree (only in node_modules/@switchroom-ai/telegram-plugin, a published
+  package snapshot).
+
+findings:
+  - claim_id: c1
+    quote: "The frontmatter previously read `rfc — draft, awaiting sign-off`; that
+      is stale. The verification work this RFC proposed **landed**: the UAT
+      scenarios were written and run, and Bugs 1–5 in the changelog table below
+      merged (#1057, #1059, #1060, #1063, #1066)."
+    loc: L13-L15
+    verdict: aligned
+    evidence:
+      - path: telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts
+        lines: L1-L5
+        snippet: "Background sub-agent visibility scenario — closes #709 / #776 / #782 / #788"
+    evidence_strength: medium
+    action: keep
+    confidence: high
+    rationale: |
+      The UAT scenario file exists and its header confirms the TDD work landed.
+      The scenario is not skipped (describe.skip was removed per L98-100). Five
+      bugs merging is consistent with the PR numbers cited. Cannot verify merged
+      PRs directly but the code residue is consistent with the claim.
+
+  - claim_id: c2
+    quote: "Two narrow defects remain open as ordinary tracked follow-ups... Bug 6
+      (bg `sub_agent_turn_end` never fires for some Claude Code bg dispatches →
+      card can stay on 🌀 Background until the heartbeat ceiling) and Bug 7
+      (driver-side parent-tool-use correlation race)."
+    loc: L18-L23
+    verdict: drift-major
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L2976-L2981
+        snippet: "The pinned progress card was deleted in #1122 PR3. The variables
+          below are retained as permanent `null` so the dozens of optional-chained
+          call sites... short-circuit to no-ops at runtime."
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L15490-L15498
+        snippet: "The pinned progress card was deleted in favour of conversational
+          pacing + the silence-poke safety net."
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      Bug 6 and Bug 7 are framed as open follow-ups to a mechanism that no longer
+      exists. The progress-card-driver was deleted in PR #1122 PR3; `progressDriver`
+      is permanently null in gateway.ts. The defer-gate (hasLiveBackground guard),
+      the Background header phase, and the 🌀→✅ flip described in both bugs are
+      moot. The stall-terminal synthesis for Bug 6 is still present in gateway.ts
+      (onStallTerminal at L16106) but `progressDriver?.ingest(...)` no-ops because
+      progressDriver is null — the code was left in place as dead optional-chain.
+      Proposed replacement: "Bug 6 and Bug 7 are moot. The progress-card-driver was
+      deleted in PR #1122 PR3 before these could be fixed. The cross-turn visibility
+      problem they addressed is now handled by pending-work-progress.ts (#1445) and
+      subagent-handback (#1720)."
+
+  - claim_id: c3
+    quote: "`telegram-plugin/progress-card-driver.ts:1855,1921` — driver registers
+      fleet members on `sub_agent_started`, derives bg flag from parent's `Agent`
+      tool_use args (`run_in_background: true` → `cs.backgroundParentToolUseIds`
+      correlation)."
+    loc: L83-L84
+    verdict: dead-pointer
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L15490-L15498
+        snippet: "Progress card driver (removed #1122 PR3) — The pinned progress card
+          was deleted in favour of conversational pacing."
+    evidence_strength: strong
+    action: delete
+    confidence: high
+    rationale: |
+      progress-card-driver.ts does not exist in the active telegram-plugin source
+      tree. It is present only in the published npm package snapshot under
+      node_modules/@switchroom-ai/telegram-plugin/. The file was deleted in #1122
+      PR3. The line numbers cited (L1855, L1921) are dead references.
+      `backgroundParentToolUseIds` does not appear anywhere in active source code.
+
+  - claim_id: c4
+    quote: "`telegram-plugin/progress-card-driver.ts:1108` — deferred-completion
+      gate: `if (hasLiveBackground(cs.fleet)) return`. Card stays pinned past parent
+      `turn_end`."
+    loc: L85
+    verdict: dead-pointer
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L3046
+        snippet: "const progressDriver: any = null"
+    evidence_strength: strong
+    action: delete
+    confidence: high
+    rationale: |
+      The deferred-completion gate in progress-card-driver.ts:1108 is in a deleted
+      file. `hasLiveBackground` from fleet-state.ts is only imported in tests; no
+      production call site reads it. The gate is effectively absent.
+
+  - claim_id: c5
+    quote: "`telegram-plugin/two-zone-card.ts` — fleet zone renders every member
+      (cap 5 + \"N more\"). Header phase resolver yields 🌀 Background when parent
+      done + fleet still running (PR #1039)."
+    loc: L86-L87
+    verdict: dead-pointer
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L15490-L15498
+        snippet: "Progress card driver (removed #1122 PR3)"
+    evidence_strength: strong
+    action: delete
+    confidence: high
+    rationale: |
+      two-zone-card.ts does not exist anywhere in the active source tree (confirmed
+      by find). The two-zone renderer and the fleet zone are deleted. The `cap()`
+      function and `FleetMember` struct in fleet-state.ts are production dead code —
+      only consumed by the deleted driver (and tests). The 🌀 Background header
+      phase still exists in the UAT assertions (assertions.ts:L359) but the actual
+      card renderer that would produce it is gone.
+
+  - claim_id: c6
+    quote: "`telegram-plugin/subagent-watcher.ts` — 1Hz JSONL polling, drives
+      `sub_agent_tool_use` → fleet member's `lastTool`/`lastActivityAt` updates."
+    loc: L88-L89
+    verdict: drift-major
+    evidence:
+      - path: telegram-plugin/subagent-watcher.ts
+        lines: L44
+        snippet: "import { sanitiseToolArg } from './fleet-state.js'"
+    evidence_strength: medium
+    action: update-text
+    confidence: high
+    rationale: |
+      subagent-watcher.ts exists and does 1Hz JSONL polling (confirmed). However,
+      it no longer updates a FleetMember's `lastTool`/`lastActivityAt` fields for
+      the deleted driver. It imports only `sanitiseToolArg` from fleet-state.ts (not
+      FleetMember, not hasLiveBackground). The actual updates go to a SQLite DB
+      (bumpSubagentActivity, recordSubagentStall, etc.) for the subagent-handback
+      and progress paths. The claim's framing ("fleet member's lastTool") describes
+      the deleted driver's data model, not the current one.
+
+  - claim_id: c7
+    quote: "Heartbeat re-flushes the card every N seconds while live, so the elapsed
+      counter ticks."
+    loc: L90
+    verdict: dead-pointer
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L15490-L15498
+        snippet: "Progress card driver (removed #1122 PR3)"
+    evidence_strength: strong
+    action: delete
+    confidence: high
+    rationale: |
+      The pinned progress card heartbeat is deleted with the card. The elapsed
+      counter described here does not exist in the current UI. The current
+      cross-turn surface is `pending-work-progress.ts` which appends " — still
+      working (Nm)" to the anchor reply — no pinned card, no fleet zone, no
+      elapsed counter.
+
+  - claim_id: c8
+    quote: "**AC-4** — *Stuck escalation.* If a fleet member emits no JSONL event
+      for > 60 s, its row glyph flips from ↻ to ⚠ with label `idle <duration>`. If
+      every running member is stuck, header escalates to ⚠ Stalled."
+    loc: L109-L111
+    verdict: dead-pointer
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L3046
+        snippet: "const progressDriver: any = null"
+      - path: telegram-plugin/subagent-watcher.ts
+        lines: L230-L234
+        snippet: "onStall?: (agentId, idleMs, description) => void — fires when a
+          stall is detected. Wired to progressDriver.onSubAgentStall."
+    evidence_strength: strong
+    action: delete
+    confidence: high
+    rationale: |
+      The stall detection in subagent-watcher.ts (stallThresholdMs, onStall callback)
+      exists and fires, but `progressDriver?.onSubAgentStall(...)` at gateway.ts:L16087
+      no-ops because progressDriver is null. No visual row glyph or header escalation
+      reaches the user. The stall record writes to the SQLite DB (recordSubagentStall)
+      but there is no current rendering surface that shows it as a card update.
+
+  - claim_id: c9
+    quote: "**AC-5** — *Heavy fleet HTML safety.* 6+ parallel sub-agents — render
+      output is balanced HTML, < 4096 bytes, fleet zone caps at 5 rows + `+ N more`.
+      No `<blockquote>` 400 in the gateway log."
+    loc: L112-L113
+    verdict: dead-pointer
+    evidence:
+      - path: telegram-plugin/fleet-state.ts
+        lines: L157-L164
+        snippet: "export function cap(members, n = 5): { visible, hidden } — sorts
+          and truncates at n members"
+    evidence_strength: strong
+    action: delete
+    confidence: high
+    rationale: |
+      The fleet zone renderer (two-zone-card.ts) is deleted. The `cap()` function
+      exists in fleet-state.ts but is not called in any production path. The 4096-
+      byte concern and the `+ N more` footer were features of the deleted card.
+      No `blockquote 400` risk exists because no fleet HTML is being sent to Telegram.
+
+  - claim_id: c10
+    quote: "> **Card model superseded.** This RFC reasons about the *two-zone*
+      progress-card model from `reference/status-card-design.md`. That two-zone
+      design has since been **superseded by
+      [`reference/conversational-pacing.md`](conversational-pacing.md)**"
+    loc: L27-L31
+    verdict: aligned
+    evidence:
+      - path: reference/status-card-design.md
+        lines: L1-L6
+        snippet: "status: archived — superseded\nsupersededBy: conversational-pacing.md"
+      - path: reference/conversational-pacing.md
+        lines: L1-L5
+        snippet: "status: design v2 — the five-beat human-feel model (supersedes v1's
+          card-era pacing)"
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      The RFC's own callout box accurately describes the supersession. Both the
+      status-card-design.md (archived, supersededBy frontmatter) and
+      conversational-pacing.md (design v2 status) confirm the stated relationship.
+
+  - claim_id: c11
+    quote: "After Bugs 1–5 merged + the agent image rebuilt + apply re-run, **five
+      of six assertions pass** in the UAT scenario"
+    loc: L288-L293
+    verdict: drift-major
+    evidence:
+      - path: telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts
+        lines: L67-L100
+        snippet: "STATUS: currently red — surfaces two real production bugs... Both
+          bugs are real and live on `main`."
+    evidence_strength: strong
+    action: update-text
+    confidence: high
+    rationale: |
+      The UAT scenario's own STATUS comment (L67-L100) says the scenario is
+      currently red with two bugs live on main (Bug 1: orphan correlation,
+      Bug 2: subagent-watcher liveness skip). The RFC's progress log claims 5/6
+      pass after the PR merges, but the scenario file's current state contradicts
+      this. The UAT scenario was unskipped per L98-100 ("Update post-#1105: all
+      five RFC bugs merged. Unskipped here for the next UAT re-run.") but then
+      further bugs were found. Additionally, the scenario infrastructure
+      (expectPinnedCard, waitForCardPhase) tests a pinned progress card that was
+      deleted in PR #1122 — the scenario would fail immediately in a real run
+      even if those gateway-level bugs were fixed.
+
+  - claim_id: c12
+    quote: "Phase 6 fix candidates... option 1 with a longer post-stall window (e.g.
+      5 min) so genuinely-paused workers aren't misreported."
+    loc: L309-L315
+    verdict: drift-minor
+    evidence:
+      - path: telegram-plugin/gateway/gateway.ts
+        lines: L16095-L16131
+        snippet: "onStallTerminal: (agentId) => { ... progressDriver?.ingest(
+          { kind: 'sub_agent_turn_end', agentId }, ...) }"
+    evidence_strength: medium
+    action: update-text
+    confidence: medium
+    rationale: |
+      The stall-terminal synthesis (RFC Bug 6 option 1) was implemented in
+      gateway.ts at L16106. However, the `progressDriver?.ingest(...)` call
+      no-ops because progressDriver is null. The synthesis reaches no card and
+      has no user-visible effect. The fix is present structurally but its
+      intended target (the progress card) was deleted before this path could
+      do anything useful. The RFC's open "Bug 6 fix" is therefore moot.

--- a/audit/2026-05-26/fix-batches/conversational-pacing-emoji-fix.md
+++ b/audit/2026-05-26/fix-batches/conversational-pacing-emoji-fix.md
@@ -1,0 +1,41 @@
+# Fix batch: correct the wrong emoji sequence in conversational-pacing.md and the agent prompt template
+
+**Scope:** `reference/conversational-pacing.md` and `profiles/_shared/telegram-style.md.hbs`.
+**Verdict pattern:** drift-major (1), drift-minor (2).
+**Estimated edits:** small (~6 lines across 2 files).
+
+## Findings in this batch
+
+### Finding 1 -- artefact-conversational-pacing:c1
+
+- **File:** `reference/conversational-pacing.md` L28; also `profiles/_shared/telegram-style.md.hbs` L20
+- **Quote:** "The -> -> -> status reaction on the user's inbound message and a continuous `typing...` chat-action held for the whole turn"
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Replace `->->->` with `->->->` in the artefact table (L28). Same replacement needed in `profiles/_shared/telegram-style.md.hbs` L20.
+- **Evidence:** `telegram-plugin/status-reactions.ts` L71 -- explicitly states " is reserved for genuine 5xx server errors (operator-events.ts). It reads as 'on fire / broken' -- keep it out of normal active-work states." `REACTION_VARIANTS.tool = ['', '', '']` -- the working-state emoji is , not .
+- **Rationale:** The wrong emoji sequence appears in both the design artefact and the agent prompt template that teaches this to the model. The model is being instructed with incorrect information about its own reaction lifecycle. This is the highest-priority fix in the batch.
+
+### Finding 2 -- artefact-conversational-pacing:c2
+
+- **File:** `reference/conversational-pacing.md` L28 (Ambient layer pointer in Three Layers table)
+- **Quote:** "`telegram-plugin/status-reactions.ts` + `gateway.ts:startTypingLoop` (started at turn-start, stopped by `purgeReactionTracking`)"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Change `gateway.ts:startTypingLoop` to `gateway.ts:startTurnTypingLoop`. The turn-level typing loop (started at turn-start, stopped by `purgeReactionTracking`) is `startTurnTypingLoop` using a dedicated `turnTypingIntervals` map. `startTypingLoop` is a different function (reply-handler typing wrapper).
+- **Evidence:** `telegram-plugin/gateway/gateway.ts` L1936-L1960 -- documents the deliberate separation; L8734-L8743 -- `startTurnTypingLoop(chat_id)` is the turn-start callsite.
+- **Rationale:** Naming the wrong function in the pointer sends developers to look at the wrong code path.
+
+### Finding 3 -- artefact-conversational-pacing:c6
+
+- **File:** `reference/conversational-pacing.md` L80-L81 (state struct listing)
+- **Quote:** "State per-turn: `{ turnStartedAt, lastOutboundAt, pokesFired, pokeArmed, ackPokeFired, subagentDispatchActive, lastThinkingAt, fallbackFired, lastPokeFiredAt }`"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Add `inFlightTools` to the state struct listing: `{ turnStartedAt, lastOutboundAt, pokesFired, pokeArmed, ackPokeFired, subagentDispatchActive, lastThinkingAt, fallbackFired, lastPokeFiredAt, inFlightTools }`. This field was added in issue #1292 to power the tool-aware fallback message wording.
+- **Evidence:** `telegram-plugin/silence-poke.ts` L64-L95 -- `SilencePokeState` interface includes `inFlightTools: Map<string, { name, startedAt, label }>`.
+- **Rationale:** The state listing is accurate but incomplete. `inFlightTools` is load-bearing for the tool-aware 300s fallback wording.
+
+## Out of scope for this batch
+
+- Edits to `reference/know-what-my-agent-is-doing.md` for the same emoji error (c4 in that unit) -- that lives in `jtbd-know-what-agent-is-doing-fixes` batch.

--- a/audit/2026-05-26/fix-batches/docs-onboarding-referrer-fix.md
+++ b/audit/2026-05-26/fix-batches/docs-onboarding-referrer-fix.md
@@ -1,0 +1,32 @@
+# Fix batch: fix live-tracker references to onboarding-gap-analysis.md in docs/workspace-files.md
+
+**Scope:** `docs/workspace-files.md` only.
+**Verdict pattern:** archive-leaks (2).
+**Estimated edits:** small (~6 lines).
+
+## Findings in this batch
+
+### Finding 1 -- historical-onboarding-gap-analysis:c3
+
+- **File:** `docs/workspace-files.md` L58-L61
+- **Quote:** "The list is currently hardcoded in the switchroom binary. Adding a new stable file requires a code change + release. This is tracked for convergence (see gap analysis gap 4 and gap 8)."
+- **Verdict:** archive-leaks
+- **Proposed action:** fix-referrer
+- **Proposed text:** Remove the "(see [gap analysis](../reference/onboarding-gap-analysis.md) gap 4 and gap 8)" link. If an active tracking location exists (issue or RFC), link that instead. The gap analysis is historical and does not track closure.
+- **Evidence:** `reference/onboarding-gap-analysis.md` L3-L8 -- "no longer tracks closure"; `src/agents/workspace.ts` L94, L108 -- hardcoded arrays still present, confirming the gap is real but the tracker is dead.
+- **Rationale:** docs/workspace-files.md links the gap analysis as the active tracking location. The link gives the reader a dead-end -- they follow it expecting to find current tracking and find a stale historical snapshot.
+
+### Finding 2 -- historical-onboarding-gap-analysis:c4
+
+- **File:** `docs/workspace-files.md` L199-L204 (Related section)
+- **Quote:** "`reference/onboarding-gap-analysis.md` -- fixes planned for the mechanism-convergence gap"
+- **Verdict:** archive-leaks
+- **Proposed action:** fix-referrer
+- **Proposed text:** Replace with: "`reference/onboarding-gap-analysis.md` -- historical motivation for the workspace loader convergence design (point-in-time, 2026-04-25; not a live roadmap)."
+- **Evidence:** `reference/onboarding-gap-analysis.md` L3-L8 -- "not a live tracker"; the "Related" section entry says "fixes planned" (present-tense, implying active roadmap).
+- **Rationale:** A reader following the Related link expecting planned fixes will find a stale snapshot. The description should signal the historical nature.
+
+## Out of scope for this batch
+
+- Edits to `reference/README.md` L60 (different description of the same file) -- in `reference-readme-index-corrections` batch.
+- Edits to `reference/onboarding-gap-analysis.md` itself -- the file carries an accurate disclaimer; no changes needed there.

--- a/audit/2026-05-26/fix-batches/jtbd-idempotent-update-switchroom-update.md
+++ b/audit/2026-05-26/fix-batches/jtbd-idempotent-update-switchroom-update.md
@@ -1,0 +1,72 @@
+# Fix batch: update jtbd-idempotent-update-and-restart to name `switchroom update`
+
+**Scope:** `reference/idempotent-update-and-restart.md` only.
+**Verdict pattern:** drift-major (3), drift-minor (3).
+**Estimated edits:** medium (~25 lines across multiple sections).
+
+## Findings in this batch
+
+### Finding 1 -- jtbd-idempotent-update-and-restart:c1
+
+- **File:** `reference/idempotent-update-and-restart.md` L3 (frontmatter `outcome:` field)
+- **Quote:** "After the upgrade flow finishes (`switchroom apply` + `docker compose pull` + `docker compose up -d --remove-orphans`), the entire stack -- CLI, agent containers, broker, kernel, scheduler, MCP servers, memory backend -- is at the version switchroom declared and tested as a unit."
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** "After running `switchroom update`, the entire stack -- CLI, agent containers, broker, kernel, scheduler, hostd, MCP servers, bundled skills, memory backend -- is at the version switchroom declared and tested as a unit. After any restart, the agent comes back with fresh code, fresh MCP servers, fresh settings, and intact context. The user does not lose their thread."
+- **Evidence:** `src/cli/update.ts` L1-L36 -- `switchroom update` wraps pull-images, apply-config, refresh-hostd, sync-bundled-skills, recreate-containers, and doctor (PR #918). hostd and skills pool are missing from the current stack list.
+- **Rationale:** The frontmatter outcome is the first thing readers see. It still names the three-command pre-#918 incantation.
+
+### Finding 2 -- jtbd-idempotent-update-and-restart:c2
+
+- **File:** `reference/idempotent-update-and-restart.md` L9-L11
+- **Quote:** "The user runs the upgrade flow (`switchroom apply` + `docker compose pull` + `docker compose up -d --remove-orphans`)."
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Rewrite the opening paragraph to name `switchroom update` as the primary flow. The individual steps (apply, pull, up -d) are what it orchestrates internally and can be mentioned as the underlying mechanics.
+- **Evidence:** `src/cli/update.ts` L882-L944; CLAUDE.md L749-L760 -- `switchroom update` is the canonical single-step upgrade command.
+- **Rationale:** The body's opening section defines the upgrade flow for the user. It still names the replaced pattern.
+
+### Finding 3 -- jtbd-idempotent-update-and-restart:c5
+
+- **File:** `reference/idempotent-update-and-restart.md` L39-L42
+- **Quote:** "A user can re-run `switchroom apply` + `docker compose up -d` and `switchroom agent restart` any number of times, in any order, and end up in the same valid state every time."
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Acknowledge `switchroom update` as the idempotent form. Note that `switchroom apply` + `docker compose up -d` remain valid sub-flows for operators who want finer control.
+- **Evidence:** `src/cli/update.ts` L448-L465 -- `up -d` is described as "cheap and idempotent"; `src/cli/apply.ts` L627-L640 -- apply is idempotent.
+- **Rationale:** Minor surface drift -- the idempotency claim is correct but the named surface is stale.
+
+### Finding 4 -- jtbd-idempotent-update-and-restart:c9
+
+- **File:** `reference/idempotent-update-and-restart.md` L88-L90 ("What the user needs from the surface" section)
+- **Quote:** "A small, fixed set of commands (`switchroom apply`, `docker compose pull`, `docker compose up -d --remove-orphans`) that do the right thing for the whole stack."
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** "A single command (`switchroom update`) that does the right thing for the whole stack -- pull new images, refresh scaffolds, recreate containers, and run a post-bounce doctor sweep. Operators who want finer control can still run `switchroom apply`, `docker compose pull`, and `docker compose up -d --remove-orphans` individually."
+- **Evidence:** `src/cli/update.ts` L882-L888 -- command description: "Update switchroom on this host: pull images, refresh scaffolds, recreate containers."
+- **Rationale:** This is the surface-definition sentence that defines the user need. Naming the old three-command pattern as the answer to that need is the most prominent piece of stale copy in the JTBD.
+
+### Finding 5 -- jtbd-idempotent-update-and-restart:c13
+
+- **File:** `reference/idempotent-update-and-restart.md` L113-L117
+- **Quote:** "Pull fetches the matched set of GHCR images at the new release tag; the rolling `up -d` replaces each agent + scheduler + broker container in turn."
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Note that `up -d --remove-orphans` recreates services whose image or config changed (not strictly serial), and that the scheduler is now an in-container sibling process rather than a separate container.
+- **Evidence:** `src/cli/update.ts` L229-L243; `src/agents/compose.ts` L1-L10 -- scheduler was retired as a separate container in Phase 4.
+- **Rationale:** "Agent + scheduler + broker container" misstates the container topology. Scheduler is in-container since Phase 4.
+
+### Finding 6 -- jtbd-idempotent-update-and-restart:c15
+
+- **File:** `reference/idempotent-update-and-restart.md` L145-L149
+- **Quote:** "`switchroom doctor` detects the host's claude is far behind the version baked into the running agent image, flags the drift as informational, and offers a one-liner to upgrade the host CLI."
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** "`switchroom doctor` detects that the host's claude version differs from the version declared in the current switchroom manifest, flags the drift, and tells the user to run `switchroom update` to realign."
+- **Evidence:** `src/manifest.ts` L162-L172 -- `probeClaudeVersion()` probes host PATH and compares against `dependencies.json`, not the running container image; `src/cli/doctor.ts` L2391-L2416 -- fix message is "Update <component> to match the manifest, or re-run switchroom update", not a one-liner for the host CLI.
+- **Rationale:** Two inaccuracies: doctor compares against the manifest, not the container image; and the fix message points at `switchroom update`, not a dedicated CLI upgrade command.
+
+## Out of scope for this batch
+
+- Edits to `reference/principles.md:c8` (same three-command example) -- in `principles-stale-examples` batch.
+- Adding Anti-patterns and UAT prompts sections to this file (structural conformance with other 13 JTBDs) -- this is new content, not a drift fix, and needs a separate product decision.

--- a/audit/2026-05-26/fix-batches/jtbd-know-what-agent-is-doing-fixes.md
+++ b/audit/2026-05-26/fix-batches/jtbd-know-what-agent-is-doing-fixes.md
@@ -1,0 +1,51 @@
+# Fix batch: fix stale/dead claims in jtbd-know-what-my-agent-is-doing.md and docs/posthog.md
+
+**Scope:** `reference/know-what-my-agent-is-doing.md` and `docs/posthog.md`.
+**Verdict pattern:** drift-minor (2), drift-major (1), dead-pointer (1), jtbd-too-technical (1).
+**Estimated edits:** small (~12 lines across 2 files).
+
+## Findings in this batch
+
+### Finding 1 -- jtbd-know-what-my-agent-is-doing:c1
+
+- **File:** `reference/know-what-my-agent-is-doing.md` L37
+- **Quote:** "It fires within ~100ms of the message arriving (received)"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Replace "~100ms" with "within ~800ms (sub-second)" or "effectively immediately (sub-second)".
+- **Evidence:** `telegram-plugin/gateway/gateway.ts` L7850-L7854 -- code comment states "The spec deadline is 800ms."
+- **Rationale:** The code's own spec deadline is 800ms. The JTBD says ~100ms. The intent ("effectively instantly") is preserved but the specific number is wrong by 8x.
+
+### Finding 2 -- jtbd-know-what-my-agent-is-doing:c4
+
+- **File:** `reference/know-what-my-agent-is-doing.md` L51-L52
+- **Quote:** "is reserved for genuine 5xx server errors and is also non-terminal: recovery to a working state from is allowed"
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Remove or rewrite this claim. is never emitted as a reaction on the user's inbound message. For 5xx events, appears as a message prefix in operator notifications (`operator-events.ts`), not as a status reaction. The non-terminal error reaction (what the JTBD likely intends) is (REACTION_VARIANTS.error), which IS non-terminal.
+- **Evidence:** `telegram-plugin/status-reactions.ts` L71-L85 -- no entry in REACTION_VARIANTS; `operator-events.ts` L369-L383 -- for 5xx in message text only.
+- **Rationale:** The JTBD frames as a reaction-state on the user's inbound message. It is not. This misinforms readers about the reaction lifecycle.
+
+### Finding 3 -- jtbd-know-what-my-agent-is-doing:c5
+
+- **File:** `reference/know-what-my-agent-is-doing.md` L58-L61
+- **Quote:** "Implementation: `telegram-plugin/status-reactions.ts` (controller), `telegram-plugin/gateway/gateway.ts` (turn_end IPC handler -> `finalizeStatusReaction`). The technical contract spec lives at `telegram-plugin/docs/waiting-ux-spec.md`."
+- **Verdict:** jtbd-too-technical
+- **Proposed action:** rewrite-at-outcome-level
+- **Proposed text:** Remove the "Implementation:" paragraph. Replace with: "See the ambient layer design contract at `reference/conversational-pacing.md`." (The conversational-pacing.md reference at L106 is already the right level for this JTBD.)
+- **Evidence:** `telegram-plugin/status-reactions.ts` and `telegram-plugin/docs/waiting-ux-spec.md` both exist and are real, but naming specific files, function names (`finalizeStatusReaction`), and IPC event labels (`turn_end`) leaks architecture into a JTBD.
+- **Rationale:** JTBDs describe user outcomes. An "Implementation:" paragraph naming internal function names is too technical for this document category.
+
+### Finding 4 -- jtbd-know-what-my-agent-is-doing:c11
+
+- **File:** `reference/know-what-my-agent-is-doing.md` L57 AND `docs/posthog.md` events table
+- **Quote:** "see the `inbound_ack` event in `docs/posthog.md`"
+- **Verdict:** dead-pointer
+- **Proposed action:** update-text
+- **Proposed text:** Two options: (A) Add `inbound_ack` to `docs/posthog.md`'s events table (pointing to `telegram-plugin/streaming-metrics.ts`). (B) Change the reference in the JTBD to point at `streaming-metrics.ts` where the event type is declared.
+- **Evidence:** `docs/posthog.md` L72-L77 -- `inbound_ack` is not in the events table; `telegram-plugin/streaming-metrics.ts` L60-L65 -- event type IS declared there.
+- **Rationale:** The cross-reference sends readers to a doc that doesn't contain what it promises. Prefer option (A): add the row to posthog.md so it stays as the single events reference.
+
+## Out of scope for this batch
+
+- The silence-poke success rate finding (`jtbd-know-what-my-agent-is-doing:c12`) is `outcome-not-realized` -- escalated, not a doc edit batch.

--- a/audit/2026-05-26/fix-batches/jtbd-share-auth-stale-examples.md
+++ b/audit/2026-05-26/fix-batches/jtbd-share-auth-stale-examples.md
@@ -1,0 +1,103 @@
+# Fix batch: fix stale auth verb examples in jtbd-share-auth-across-the-fleet.md
+
+**Scope:** `reference/share-auth-across-the-fleet.md` only.
+**Verdict pattern:** jtbd-stale-example (3), drift-major (2), drift-minor (3).
+**Estimated edits:** medium (~20 lines across Decision 2, Decision 6, Decision 10, and UAT prompt sections).
+
+Note: the JTBD body is marked historical (it documents the pre-RFC-H problem statement and design). These fixes update specific stale examples within the historical body to avoid misleading readers who pick up the wrong behavior from the "Signs it's working" and UAT sections, which are not clearly scoped as historical.
+
+## Findings in this batch
+
+### Finding 1 -- jtbd-share-auth-across-the-fleet:c4
+
+- **File:** `reference/share-auth-across-the-fleet.md` L62-L63 ("Signs it's working")
+- **Quote:** "Adding a second, third, or sixth agent to the same Anthropic account does not require any OAuth flow. The user runs `switchroom auth enable <account> <agent>` and the agent comes up authenticated."
+- **Verdict:** jtbd-stale-example
+- **Proposed action:** update-text
+- **Proposed text:** Replace `switchroom auth enable <account> <agent>` with: "The user runs `switchroom auth use <label>` (to set the fleet account) and restarts the agent; no new OAuth flow is needed."
+- **Evidence:** `src/cli/auth.ts` L465-L803 -- no `auth enable` verb exists. Current fleet-wide verb is `auth use <label>`; per-agent edge case is `auth agent override <agent> <label>`.
+- **Rationale:** `auth enable` does not exist. A user following this example would get a command-not-found error.
+
+### Finding 2 -- jtbd-share-auth-across-the-fleet:c7
+
+- **File:** `reference/share-auth-across-the-fleet.md` L68-L69 ("Signs it's working")
+- **Quote:** "A cron-launched `claude -p` invocation in an agent's directory uses the same fresh token as that agent's main process."
+- **Verdict:** jtbd-stale-example
+- **Proposed action:** update-text
+- **Proposed text:** "A cron-scheduled task fires via inject_inbound and uses the same account as the main process -- same broker mirror, no 401s, no env-var hand-offs."
+- **Evidence:** CLAUDE.md L99-L109 -- `claude -p` is now a constraint violation (programmatic usage, separate credit); `docs/rfcs/eliminate-claude-p.md` L1-L5 -- RFC for eliminating all `claude -p` callsites.
+- **Rationale:** `claude -p` is now explicitly forbidden. Showing it as a positive example in "Signs it's working" contradicts the core subscription-honest constraint and could mislead future code additions.
+
+### Finding 3 -- jtbd-share-auth-across-the-fleet:c8
+
+- **File:** `reference/share-auth-across-the-fleet.md` L70-L71 ("Signs it's working")
+- **Quote:** "When an account hits the 5-hour cap, every agent using that account fails over to the next account on its preference list within seconds"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Replace "the next account on its preference list" with "the next account in `auth.fallback_order`".
+- **Evidence:** `src/auth/broker/server.ts` L1592-L1609 -- `fanoutFailoverFor` uses the fleet-wide `auth.fallback_order`, not a per-agent preference list.
+- **Rationale:** "Its preference list" implies per-agent ordering which does not exist. Fallback ordering is fleet-wide.
+
+### Finding 4 -- jtbd-share-auth-across-the-fleet:c9
+
+- **File:** `reference/share-auth-across-the-fleet.md` L78-L79
+- **Quote:** "Removing an account is a single explicit action, refused while any agent is still enabled on it."
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** "Removing an account is a single explicit action, refused while it is the fleet active account or the override target for any agent."
+- **Evidence:** `src/auth/broker/server.ts` L1138-L1149 -- refusal checks `auth.active` and `agents[*].auth.override`; there is no per-agent "enabled on" tracking.
+- **Rationale:** "While any agent is still enabled on it" suggests per-agent enabled/disabled tracking that does not exist.
+
+### Finding 5 -- jtbd-share-auth-across-the-fleet:c10
+
+- **File:** `reference/share-auth-across-the-fleet.md` L142-L149 (Decision 2)
+- **Quote:** "Agents are consumers, not owners. An agent declares an ordered list of accounts it can use, in `switchroom.yaml`: `agents: foo: auth: accounts: [work-pro, personal-max]`"
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Replace the YAML example with: `agents: foo: {} # inherits fleet active` (common case) or `agents: klanker: auth: override: work # edge case: pin to specific account`. The `auth.accounts: [...]` per-agent list was the pre-RFC-H schema and is migrated away on install.
+- **Evidence:** `src/config/schema.ts` L1263-L1280 -- per-agent auth block has only `override: string`; `src/auth/migrate-schema.ts` -- in-place upgrade from the old `auth.accounts` list shape.
+- **Rationale:** The YAML example in Decision 2 would be migrated away by `migrate-schema.ts`. Showing it as current encourages a configuration pattern that no longer works.
+
+### Finding 6 -- jtbd-share-auth-across-the-fleet:c13
+
+- **File:** `reference/share-auth-across-the-fleet.md` L177-L181 (Decision 6)
+- **Quote:** "Drop the per-agent slot pool entirely. The `<agentDir>/.claude/accounts/<slot>/` directory tree ... all go away."
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Add a note: "(Note: `src/auth/accounts.ts` is retained for back-compat and migration paths only; it is not the active runtime path.)"
+- **Evidence:** `src/auth/accounts.ts` L1-L16 -- explicitly marked `LEGACY (post-RFC-H) ... retained for back-compat and migration paths only`.
+- **Rationale:** "All go away" overstates the cleanup. The file ships; it is just legacy.
+
+### Finding 7 -- jtbd-share-auth-across-the-fleet:c14
+
+- **File:** `reference/share-auth-across-the-fleet.md` L206-L215 (Decision 10)
+- **Quote:** "No migration shipped. This is a new-install design ... no `switchroom auth migrate` verb, no legacy slot-pool code paths kept 'for now,' no compatibility shims."
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Replace with: "No migration CLI verb shipped. However, `src/auth/migrate-schema.ts` provides an in-place YAML upgrade algorithm (tested against three fixture shapes) that schema comments say runs on first `switchroom apply`. Legacy slot-pool code (`src/auth/accounts.ts`) is retained for back-compat."
+- **Evidence:** `src/auth/migrate-schema.ts` L1-L56 -- shipped and tested migration algorithm; `src/auth/accounts.ts` L1-L16 -- explicitly retained.
+- **Rationale:** Decision 10 says "no migration shipped" but a migration algorithm exists in the repo. The distinction the RFC authors intended (no CLI verb, no shims for new schema shape) is accurate, but the current text is literally false.
+
+### Finding 8 -- jtbd-share-auth-across-the-fleet:c16
+
+- **File:** `reference/share-auth-across-the-fleet.md` L265-L266 (UAT prompt)
+- **Quote:** "Read the output of `switchroom auth account list`. Does it show your accounts and which agents use each, on one screen?"
+- **Verdict:** jtbd-stale-example
+- **Proposed action:** update-text
+- **Proposed text:** "Read the output of `switchroom auth show`. Does it show your accounts and which agents use each, on one screen?"
+- **Evidence:** `src/cli/auth.ts` L589-L605 -- `auth show [agent]` and `auth list` exist; `auth account list` does not.
+- **Rationale:** `switchroom auth account list` is not a registered command. A UAT engineer following this prompt would get an error.
+
+### Finding 9 -- jtbd-share-auth-across-the-fleet:c18
+
+- **File:** `reference/share-auth-across-the-fleet.md` L279-L280 (UAT prompt)
+- **Quote:** "Migrate from a per-agent-slot install. Did you have to re-`claude setup-token` any account, or did the existing tokens carry over?"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Add a note: "Requires an explicit `switchroom apply` to trigger the in-place schema upgrade in `src/auth/migrate-schema.ts`."
+- **Evidence:** `src/auth/migrate-schema.ts` exists but is not imported from any production code path. Whether the migration actually runs depends on wiring not confirmed in scope.
+- **Rationale:** The UAT prompt assumes seamless migration. The wiring is uncertain; flagging that an explicit apply is required is safer than leaving the prompt ambiguous.
+
+## Out of scope for this batch
+
+- Edits to `reference/principles.md` for `auth login` in the consistency-test example (c10) -- that is in `principles-stale-examples` batch.

--- a/audit/2026-05-26/fix-batches/manifest-hygiene.md
+++ b/audit/2026-05-26/fix-batches/manifest-hygiene.md
@@ -1,0 +1,23 @@
+# Fix batch: remove dead historical-prd unit from the drift-audit manifest
+
+**Scope:** `scripts/drift-audit/manifest.yaml` and `scripts/drift-audit/README.md`.
+**Verdict pattern:** dead-pointer (1).
+**Estimated edits:** small (~8 lines deleted + 1 line updated).
+
+## Findings in this batch
+
+### Finding 1 -- historical-prd:c1
+
+- **File:** `scripts/drift-audit/manifest.yaml` L228-L230; `scripts/drift-audit/README.md` L94
+- **Quote:** `- id: historical-prd` / `path: reference/PRD.md` / `category: historical` (manifest); `reference/PRD.md` (README example row)
+- **Verdict:** dead-pointer
+- **Proposed action:** delete
+- **Manifest edit:** Remove the entire `historical-prd` unit block (the `- id: historical-prd` entry and its `path:`, `category:`, and `anchors_hint:` fields) from `scripts/drift-audit/manifest.yaml`.
+- **README edit:** In `scripts/drift-audit/README.md` L94, the table row for `historical` category cites "`reference/PRD.md`, `reference/onboarding-gap-analysis.md`" as examples. Remove `reference/PRD.md` from that example, leaving only `reference/onboarding-gap-analysis.md`.
+- **Evidence:** `reference/PRD.md` does not exist on disk. Deleted in PR #534 (commit 8bdb86cb, "docs(design-contract): vision + principles + JTBD index, scrap PRD"). No other files in src/, docs/, or tests/ reference PRD.md as current spec.
+- **Rationale:** The manifest points Phase 1 audit agents at a file that does not exist. Any future re-run of Phase 1 on this manifest would fail on historical-prd with "file not found." The unit is definitively dead and should be removed rather than annotated.
+
+## Out of scope for this batch
+
+- Edits to any other manifest units.
+- Re-running Phase 1 to verify the updated manifest (Phase 4 responsibility).

--- a/audit/2026-05-26/fix-batches/misc-jtbd-small-drift-fixes.md
+++ b/audit/2026-05-26/fix-batches/misc-jtbd-small-drift-fixes.md
@@ -1,0 +1,126 @@
+# Fix batch: small drift-minor and vision-only fixes across independent units
+
+**Scope:** `reference/give-each-agent-its-own-workspace.md`, `reference/run-a-fleet-of-specialists.md`, `reference/extend-without-forking.md`, `reference/remember-across-sessions.md`, `reference/survive-reboots-and-real-life.md`, `reference/vision.md`, `reference/talk-to-agents-from-anywhere.md`, `reference/keep-my-subscription-honest.md`, `docs/compliance-attestation.md`, `telegram-plugin/uat/assertions.ts`.
+**Verdict pattern:** drift-minor (6), drift-major (2), vision-only (2), archive-leaks (1).
+**Estimated edits:** small -- 1-3 lines per file, 11 total.
+
+Note: each finding below is self-contained and touches only its stated file. No two findings here share a file with each other or with any other batch.
+
+## Findings in this batch
+
+### Finding 1 -- jtbd-give-each-agent-its-own-workspace:c8
+
+- **File:** `reference/give-each-agent-its-own-workspace.md` L104-L107
+- **Quote:** "The boot card surfaces `<repo>: dirty since <ts>` as a one-line warning."
+- **Verdict:** drift-major (boot-card surface claim inaccurate)
+- **Proposed action:** update-text
+- **Proposed text:** Change "The boot card surfaces" to "The reconcile log emits a one-line warning to stderr".
+- **Evidence:** `src/repos/agent-worktree.ts` L196-L208 -- `process.stderr.write(...)` is the only output path; no boot-card.ts field for dirty-worktree state.
+- **Rationale:** The boot-card claim is inaccurate even for code that exists. The larger issue (function never called) is escalated.
+
+### Finding 2 -- jtbd-give-each-agent-its-own-workspace:c9
+
+- **File:** `reference/give-each-agent-its-own-workspace.md` L109-L110
+- **Quote:** "Removal is symmetric. `switchroom agent remove <name>` calls `git worktree remove` for each of the agent's worktrees"
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Correct command name to `switchroom agent destroy <name>`. Add note that `removeAgentWorktree` is not currently called from the destroy path; worktree cleanup is not wired.
+- **Evidence:** `src/cli/agent.ts` L1931 -- command is `agent.command("destroy <name>")`; `removeAgentWorktree` not imported or called from destroy.
+- **Rationale:** Wrong command name and misleading claim about symmetric removal.
+
+### Finding 3 -- jtbd-run-a-fleet-of-specialists:c6
+
+- **File:** `reference/run-a-fleet-of-specialists.md` L40-L41
+- **Quote:** "Removing an agent is clean. Its memory, its state, its scheduled work all go with it, with no orphaned processes or dangling config."
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Add qualifier: "Its state directory and scheduled work JSONL go with it. The Hindsight memory bank persists and requires manual cleanup via the Hindsight service. The `switchroom.yaml` config entry also requires manual removal before running `switchroom apply` to take the container down."
+- **Evidence:** `src/cli/agent.ts` L1930-L1979 -- destroy does not delete Hindsight bank or YAML entry.
+- **Rationale:** "No dangling config" is not fully true.
+
+### Finding 4 -- jtbd-extend-without-forking:c7
+
+- **File:** `reference/extend-without-forking.md` L38
+- **Quote:** "Removing an extension is as clean as adding it. No residue."
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** "Removing an extension requires two steps: `switchroom agent destroy <name>` removes the scaffold directory, then editing `switchroom.yaml` to delete the agent entry and running `switchroom apply` removes the container. The scaffold dir is fully cleaned; the YAML entry requires a manual edit."
+- **Evidence:** `src/cli/agent.ts` L1964-L1969 -- comment explicitly says yaml cleanup is a manual step.
+- **Rationale:** "No residue" overstates cleanliness.
+
+### Finding 5 -- jtbd-remember-across-sessions:c6
+
+- **File:** `reference/remember-across-sessions.md` L40
+- **Quote:** "Memory decays sensibly. Stale preferences don't haunt the user a year later."
+- **Verdict:** vision-only
+- **Proposed action:** mark-vision
+- **Proposed text:** "Memory decays sensibly (not yet built -- Hindsight banks currently store memories indefinitely; the demote tag excludes entries from recall but does not delete them). Stale preferences don't haunt the user a year later."
+- **Evidence:** `src/memory/hindsight.ts` L1-L738 -- no decay/TTL parameter anywhere.
+- **Rationale:** No decay mechanism exists. Present-tense "Signs it's working" claim is misleading.
+
+### Finding 6 -- jtbd-survive-reboots-and-real-life:c5
+
+- **File:** `reference/survive-reboots-and-real-life.md` L37-L38
+- **Quote:** "Persistent failures surface. The user is told when a retry loop has stopped trying."
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** "Persistent named failures (credentials, quota exhaustion, crashes) surface. The user is told with an operator-event card. Note: the Telegram API retry-giveup path currently logs to stderr only and does not send a user-visible message."
+- **Evidence:** `telegram-plugin/retry-api-call.ts` L169 -- `onGiveUp` is observer-only with no user message.
+- **Rationale:** Coverage is real but not universal. Qualification avoids overpromising.
+
+### Finding 7 -- contract-vision:c9
+
+- **File:** `reference/vision.md` L127
+- **Quote:** "A multi-provider orchestrator | No OpenAI, Gemini, Llama, model swapping."
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** "A multi-provider orchestrator | No OpenAI, Gemini, Llama, or model swapping for inference. Auxiliary services (e.g. voice transcription via Whisper) are opt-in helpers, not Claude replacements."
+- **Evidence:** `telegram-plugin/voice-transcribe.ts` L1-L22 -- Whisper API used for voice transcription (opt-in, off by default).
+- **Rationale:** Ambiguous table row could be read as banning any OpenAI dependency, including the opt-in Whisper feature.
+
+### Finding 8 -- jtbd-talk-to-agents-from-anywhere:c10
+
+- **File:** `reference/talk-to-agents-from-anywhere.md` L75-L76
+- **Quote:** "Dead zone. Lose connectivity mid-task. When it comes back the user should see a sensible state, not a broken thread."
+- **Verdict:** vision-only
+- **Proposed action:** mark-vision or update-text
+- **Proposed text:** "Dead zone. Lose connectivity mid-task. When it comes back, Telegram delivers queued messages and the agent resumes from where it stopped; in-flight turns may show a stale progress state until the next update. (No specific dead-zone recovery code exists; this relies on Telegram's natural message delivery on reconnect.)"
+- **Evidence:** No specific dead-zone detector or recovery message path in `telegram-plugin/gateway/gateway.ts`.
+- **Rationale:** The long-poll naturally resumes but "sensible state, not a broken thread" is aspirational.
+
+### Finding 9 -- archived-status-card-design:c4
+
+- **File:** `telegram-plugin/uat/assertions.ts` L343
+- **Quote:** "fleet still running, see #862 / status-card-design.md §Header"
+- **Verdict:** archive-leaks
+- **Proposed action:** fix-referrer
+- **Proposed text:** Update the comment to cite `reference/conversational-pacing.md` instead of `status-card-design.md §Header`. Remove the `progress-card.ts` reference if present (file does not exist in active source tree).
+- **Evidence:** `reference/status-card-design.md` -- 6-line stub with no §Header section; the file is explicitly archived.
+- **Rationale:** Directs maintainers to a non-existent section in an archived file.
+
+### Finding 10 -- jtbd-keep-my-subscription-honest:c3
+
+- **File:** `reference/keep-my-subscription-honest.md` L3 (frontmatter outcome)
+- **Quote:** "No hidden API billing, no side-door tokens, no asks for extra keys."
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** "No hidden API billing, no side-door tokens, no Anthropic API keys. Opt-in third-party service keys (e.g. OpenAI Whisper for voice transcription) are stored in the vault and clearly opt-in."
+- **Evidence:** `telegram-plugin/voice-transcribe.ts` L1-L19; `src/cli/telegram.ts` L158-L164 -- Whisper opt-in requires OpenAI API key stored in vault.
+- **Rationale:** Anti-patterns section's "Asking the user for an API key as 'optional'" creates tension with the Whisper opt-in key without this carve-out.
+
+### Finding 11 -- jtbd-keep-my-subscription-honest:c5
+
+- **File:** `docs/compliance-attestation.md` (fix-referrer from JTBD c5)
+- **Quote:** Attestation dated 2026-04-25, silent on the 2026-06-15 policy split.
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Add a section or update the existing text to reference: (a) the 2026-06-15 Anthropic policy (interactive vs. programmatic distinction), (b) RFC #1620 elimination of all `claude -p` callsites, (c) the one remaining tracked exception (src/host-control/server.ts deep probe, issue #1798, opt-in, off by default).
+- **Evidence:** `docs/compliance-attestation.md` L7-L8 -- dated 2026-04-25; CLAUDE.md L99-L109 -- 2026-06-15 policy described.
+- **Rationale:** A user auditing compliance today would find the attestation silent on the most material recent policy change.
+
+## Out of scope for this batch
+
+- Escalated findings for jtbd-give-each-agent-its-own-workspace (c1-c4, c10) -- those are outcome-not-realized and in escalations.md.
+- contract-vision:c2 (code-violates-contract) -- in escalations.md.
+- Any jtbd-restart-and-know-what-im-running findings -- all escalated.
+- Any jtbd-track-plan-quota-live findings beyond the escalated ones -- all escalated.

--- a/audit/2026-05-26/fix-batches/principles-stale-examples.md
+++ b/audit/2026-05-26/fix-batches/principles-stale-examples.md
@@ -1,0 +1,83 @@
+# Fix batch: update stale CLI examples in principles.md
+
+**Scope:** `reference/principles.md` only.
+**Verdict pattern:** contract-example-stale (6 findings).
+**Estimated edits:** medium (~40 lines across 6 example blocks).
+
+## Findings in this batch
+
+### Finding 1 -- contract-principles:c1
+
+- **File:** `reference/principles.md` L38-L41
+- **Quote:** "`switchroom auth login coach` prints the OAuth URL inline, says 'open this in any browser -- tokens save to this agent's CLAUDE_CONFIG_DIR, no other agent is affected,' and watches for completion."
+- **Verdict:** contract-example-stale
+- **Proposed action:** update-text
+- **Proposed text:** Replace `switchroom auth login coach` with `switchroom auth add default --via-claude` (first-time add) or `switchroom auth reauth coach` (refresh). Drop the `CLAUDE_CONFIG_DIR` detail -- the fleet model no longer uses per-agent credential dirs as the primary framing.
+- **Evidence:** `src/cli/auth.ts` L815-L820 -- `auth.command("reauth <agent>")` exists; `auth.command("login")` does not exist in the registered verbs list. RFC H removed `auth login` entirely.
+- **Rationale:** `auth login` is not a registered command. The closest current verb for first-time OAuth is `switchroom auth add <label> --via-claude`; for refreshing an existing agent's session it is `switchroom auth reauth <agent>`.
+
+### Finding 2 -- contract-principles:c2
+
+- **File:** `reference/principles.md` L45-L50
+- **Quote:** "`switchroom setup` detects that the bot's privacy mode is still on and tells the user '@CoachBot has Privacy Mode enabled ...'"
+- **Verdict:** contract-example-stale
+- **Proposed action:** update-text
+- **Proposed text:** Replace the dynamic-detection example with what setup actually does: setup prints a static upfront instruction to disable privacy mode before adding the bot to a group. The good example should show the upfront-guidance pattern, not a detect-and-report error that is not shipped.
+- **Evidence:** `src/cli/setup.ts` L293-L301; `src/setup/botfather-walkthrough.ts` L198 -- both show static advisory text, no detection logic.
+- **Rationale:** No code path detects that privacy mode is currently on and surfaces the quoted dynamic error message. The example describes unshipped behavior.
+
+### Finding 3 -- contract-principles:c4
+
+- **File:** `reference/principles.md` L58-L62
+- **Quote:** "`switchroom vault set telegram-bot-token` ... confirms encryption, and tells the user 'now reference this in switchroom.yaml as `vault:telegram-bot-token`'"
+- **Verdict:** contract-example-stale
+- **Proposed action:** update-text
+- **Proposed text:** Update the success-message portion to match actual output: `+ Secret 'telegram-bot-token' saved`. If the principle intent is that vault set should tell the user about `vault:` syntax, either add the hint to the vault set output or update the example to show what currently ships.
+- **Evidence:** `src/cli/vault.ts` L665-L668 -- success output is `+ Secret '${key}' saved` with no mention of `vault:` reference syntax.
+- **Rationale:** The `vault:` reference hint is not emitted by the shipped command. Masking/prompting behaviors are accurate (L572), but the claimed success message is not.
+
+### Finding 4 -- contract-principles:c7
+
+- **File:** `reference/principles.md` L102-L105
+- **Quote:** "`switchroom agent create exec --profile executive` inherits everything from the executive profile"
+- **Verdict:** contract-example-stale
+- **Proposed action:** update-text
+- **Proposed text:** Replace `--profile executive` with `--profile executive-assistant`. The profile was named `executive-assistant` from the start; this is a shorthand typo in the example.
+- **Evidence:** `profiles/` directory contains `executive-assistant` but not `executive`; `docs/cli-reference.md` L43 lists `executive-assistant` as the correct slug.
+- **Rationale:** `--profile executive` would fail at runtime. The correct slug is `executive-assistant`.
+
+### Finding 5 -- contract-principles:c8
+
+- **File:** `reference/principles.md` L108-L111
+- **Quote:** "The upgrade flow -- `switchroom apply` + `docker compose pull` + `docker compose up -d --remove-orphans` -- is three lines, idempotent, and the same on every host."
+- **Verdict:** contract-example-stale
+- **Proposed action:** update-text
+- **Proposed text:** Replace the three-command example with the current single-command idiom: `switchroom update` runs pull-images, apply, docker compose up, and doctor in one step (PR #918). The three individual commands were the pre-#918 pattern.
+- **Evidence:** `src/cli/update.ts` L1-L24 -- explicitly documents that `switchroom update` was introduced in #918 to replace the multi-command flow; CLAUDE.md "Operator update" section.
+- **Rationale:** `switchroom update` has been the canonical single-command surface since PR #918. The example now describes a replaced pattern.
+
+### Finding 6 -- contract-principles:c9
+
+- **File:** `reference/principles.md` L115-L118
+- **Quote:** "operator skills (`humanizer`, `buildkite-*`) stay opt-in via `defaults.skills_auto`"
+- **Verdict:** contract-example-stale
+- **Proposed action:** update-text
+- **Proposed text:** Replace `defaults.skills_auto` with `defaults.skills` (the actual config field per `docs/skills.md` L125). Remove `buildkite-*` skills reference -- no such skills exist in the `skills/` directory.
+- **Evidence:** `src/config/schema.ts` -- `skills_auto` field does not exist; `docs/skills.md` L125-L126 confirms humanizer is opt-in via `defaults.skills`.
+- **Rationale:** `defaults.skills_auto` is not a real field. Using it in an example of the Defaults principle is self-defeating.
+
+### Finding 7 -- contract-principles:c10
+
+- **File:** `reference/principles.md` L143-L145
+- **Quote:** "Every top-level CLI verb is `switchroom <noun> <verb>` -- `agent start`, `vault set`, `topics sync`, `auth login`. One shape."
+- **Verdict:** contract-example-stale
+- **Proposed action:** update-text
+- **Proposed text:** Replace `auth login` in the example list with `auth add` or `auth reauth`. The structural claim (noun-verb shape, one file per noun) remains accurate.
+- **Evidence:** `src/cli/auth.ts` L9-L16 -- no `auth login` verb; `auth add`, `auth use`, `auth reauth` exist.
+- **Rationale:** `auth login` was removed by RFC H. The structural principle is correct; only the inline example needs the stale verb swapped.
+
+## Out of scope for this batch
+
+- Edits to `CLAUDE.md` for the JTBD count (`contract-reference-readme:c11`) -- that lives in `reference-readme-index-corrections` batch.
+- Edits to `reference/README.md` -- that lives in `reference-readme-index-corrections` batch.
+- Any `docs/` changes -- separate batches.

--- a/audit/2026-05-26/fix-batches/reference-readme-index-corrections.md
+++ b/audit/2026-05-26/fix-batches/reference-readme-index-corrections.md
@@ -1,0 +1,72 @@
+# Fix batch: correct reference/README.md index and CLAUDE.md JTBD count
+
+**Scope:** `reference/README.md` and `CLAUDE.md`.
+**Verdict pattern:** drift-minor (4), drift-major (1), archive-leaks (1).
+**Estimated edits:** small (~10 lines).
+
+## Findings in this batch
+
+### Finding 1 -- contract-reference-readme:c4
+
+- **File:** `reference/README.md` L21-L22
+- **Quote:** "# Survey every job in one read:\nhead -5 reference/*.md"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Change the comment to: "# Survey every JTBD in one read (also prints headers for non-JTBD docs):" or add a grep filter: `head -5 reference/*.md | grep -E '^(==>|job:|outcome:|stakes:)'`
+- **Evidence:** `reference/` now contains 22 .md files of which 8 are non-JTBD files without JTBD frontmatter. The command still works but produces noise headers.
+- **Rationale:** The "Survey every job" comment implies all output lines are JTBD jobs, which is slightly misleading. Minor text improvement.
+
+### Finding 2 -- contract-reference-readme:c5
+
+- **File:** `reference/README.md` L25-L28
+- **Quote:** "The body's Signs it's working, Anti-patterns, and UAT prompts sections are where the design teeth are"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Change to "Most JTBD bodies have Signs it's working, Anti-patterns, and UAT prompts sections" -- or add Anti-patterns and UAT prompts sections to `reference/idempotent-update-and-restart.md` to bring it into structural conformance with the other 13 JTBDs.
+- **Evidence:** `reference/idempotent-update-and-restart.md` has "Signs it's working" and "Signs it's not" but no "Anti-patterns" or "UAT prompts" sections.
+- **Rationale:** The README implies universal structure; 1 of 14 JTBDs lacks two of the three named sections.
+
+### Finding 3 -- contract-reference-readme:c9
+
+- **File:** `reference/README.md` L52
+- **Quote:** "### Always available -- *there when you want it*"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** "### Always available, in Telegram, done properly -- *there when you want it*" to match `reference/vision.md` L96 exactly. Low-priority cosmetic fix.
+- **Evidence:** `reference/vision.md` L96 uses the full title including "in Telegram, done properly."
+- **Rationale:** vision.md is authoritative for contract documents; README truncates.
+
+### Finding 4 -- contract-reference-readme:c10
+
+- **File:** `reference/README.md` L55
+- **Quote:** "idempotent-update-and-restart.md -- update switchroom and trust everything's running the new version"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** "idempotent-update-and-restart.md -- update switchroom and trust everything is actually running the new version, no manual checks"
+- **Evidence:** `reference/idempotent-update-and-restart.md` L2 -- `job: update switchroom and trust that everything is actually running the new version, no manual checks`.
+- **Rationale:** The README index description truncates and rephrases the job: field. Should match exactly.
+
+### Finding 5 -- contract-reference-readme:c11
+
+- **File:** `CLAUDE.md` L249
+- **Quote:** "13 outcome-focused jobs grouped by outcome in reference/README.md."
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Change "13 outcome-focused jobs" to "14 outcome-focused jobs".
+- **Evidence:** `reference/README.md` L34-L56 lists exactly 14 JTBD entries (5+4+2+3=14). All 14 corresponding .md files exist on disk.
+- **Rationale:** CLAUDE.md references the README and gets the count wrong by one. The README is the authoritative index; it lists 14.
+
+### Finding 6 -- historical-onboarding-gap-analysis:c2
+
+- **File:** `reference/README.md` L60
+- **Quote:** "onboarding-gap-analysis.md -- phased fix plan from a real onboarding session; tracks gaps as they close, not a durable JTBD."
+- **Verdict:** archive-leaks
+- **Proposed action:** fix-referrer
+- **Proposed text:** `onboarding-gap-analysis.md` -- historical point-in-time gap analysis from a 2026-04-25 onboarding session; not a live tracker. Several gaps have shipped; read as motivation context, not current roadmap.
+- **Evidence:** `reference/onboarding-gap-analysis.md` L3-L8 -- "no longer tracks closure" and "is stale."
+- **Rationale:** The README description contradicts the document's own disclaimer. Readers expect to find a live tracker and find a stale snapshot instead.
+
+## Out of scope for this batch
+
+- Edits to `reference/principles.md` -- in `principles-stale-examples` batch.
+- Edits to `docs/workspace-files.md` (other onboarding-gap-analysis referrers) -- in `docs-onboarding-referrer-fix` batch.

--- a/audit/2026-05-26/fix-batches/rfc-docker-promote-and-correct.md
+++ b/audit/2026-05-26/fix-batches/rfc-docker-promote-and-correct.md
@@ -1,0 +1,81 @@
+# Fix batch: promote rfc-docker-multi-container from Draft to Shipped and fix stale body claims
+
+**Scope:** `reference/rfc-docker-multi-container.md` only.
+**Verdict pattern:** rfc-status-wrong (1), drift-major (6).
+**Estimated edits:** medium (~30 lines across frontmatter + body sections).
+
+## Findings in this batch
+
+### Finding 1 -- rfc-docker-multi-container:c1
+
+- **File:** `reference/rfc-docker-multi-container.md` L3
+- **Quote:** `status: Draft`
+- **Verdict:** rfc-status-wrong
+- **Proposed action:** update-frontmatter
+- **Proposed text:** Change `status: Draft` to `status: Shipped` (or `status: Historical` if preserving as a pure design record). The body already says "This RFC is shipped" at L11-L24.
+- **Evidence:** `src/agents/compose.ts` L1-L24 -- fully implemented compose generator; `docker/Dockerfile.agent` exists. RFC body at L11-L24 explicitly says "This RFC is shipped. v0.7.0 is the docker-only release."
+- **Rationale:** Frontmatter contradicts the body. Any tooling or reader consulting the frontmatter status gets the wrong answer.
+
+### Finding 2 -- rfc-docker-multi-container:c2
+
+- **File:** `reference/rfc-docker-multi-container.md` L19-L21
+- **Quote:** "Four published GHCR images (`switchroom-base`, `switchroom-agent`, `switchroom-broker`, `switchroom-kernel`)"
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Replace with "Seven published GHCR images (`switchroom-base`, `switchroom-agent`, `switchroom-broker`, `switchroom-kernel`, `switchroom-auth-broker`, `switchroom-hostd`, `switchroom-hindsight`)".
+- **Evidence:** `src/agents/compose.ts` L354-L356 -- `emitImageOrBuild` called for broker, kernel, auth-broker, agent; `docker/Dockerfile.hostd`, `docker/Dockerfile.auth-broker`, `docker/Dockerfile.hindsight` all exist.
+- **Rationale:** Image count grew from 4 to 7 as auth-broker, hostd, and hindsight were added post-RFC.
+
+### Finding 3 -- rfc-docker-multi-container:c3
+
+- **File:** `reference/rfc-docker-multi-container.md` L172-L173
+- **Quote:** "Per-agent UIDs are allocated deterministically from the agent name at compose-generation time (e.g. `1100 + stable_hash(agent_name) % 800`, collision-checked across the fleet)."
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Replace with: "Per-agent UIDs are allocated deterministically in the range 10001..10999 (`AGENT_UID_MIN`/`AGENT_UID_MAX` in `src/agents/compose.ts`), collision-checked across the fleet."
+- **Evidence:** `src/agents/compose.ts` L36-L37 -- `AGENT_UID_MIN = 10001; AGENT_UID_MAX = 10999`.
+- **Rationale:** The range and base value in the RFC body are completely different from what shipped.
+
+### Finding 4 -- rfc-docker-multi-container:c4 and c10
+
+- **File:** `reference/rfc-docker-multi-container.md` L162-L170 (socket directory layout + UID examples)
+- **Quote:** `user: "1100:1100"`, `user: "1101:1101"`, `user: "1102:1102"`
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Replace uid:gid examples 1100/1101/1102 with the actual 10001-10999 range, e.g. "uid:gid 10001:10001 (deterministic hash of agent name)".
+- **Evidence:** `src/agents/compose.ts` L36-L37; `src/vault/broker/peercred.ts` L143 -- `socketPathToAgent` confirms the path-as-identity design shipped correctly.
+- **Rationale:** UID examples throughout the socket directory layout section are from the original design, not what shipped.
+
+### Finding 5 -- rfc-docker-multi-container:c5
+
+- **File:** `reference/rfc-docker-multi-container.md` L263-L266
+- **Quote:** `image: ghcr.io/switchroom/agent:0.7.0` and compose skeleton showing `version: "3.9"`
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Remove `version: "3.9"` from the compose skeleton -- Docker Compose v2+ does not use or emit this field. The actual compose generator starts directly with `name: switchroom` then `services:`. Update the image tag example from `0.7.0` to `:latest` or a variable placeholder.
+- **Evidence:** `src/agents/compose.ts` L767-L782 -- emits `name: switchroom` then `services:` with no `version:` field.
+- **Rationale:** The `version:` field is obsolete in Compose v2. Using it misleads operators who copy this skeleton.
+
+### Finding 6 -- rfc-docker-multi-container:c6
+
+- **File:** `reference/rfc-docker-multi-container.md` L330
+- **Quote:** "`switchroom reconcile` regenerates this whole file from `switchroom.yaml`"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Replace "`switchroom reconcile` regenerates this whole file" with "`switchroom apply` regenerates this whole file".
+- **Evidence:** `src/cli/apply.ts` L2 -- "`switchroom apply` -- reconcile fleet to switchroom.yaml." The compose generator header comment mentions `switchroom reconcile` as a future alias, but the actual CLI verb is `switchroom apply`.
+- **Rationale:** Minor verb drift. The canonical operator command is `switchroom apply`.
+
+### Finding 7 -- rfc-docker-multi-container:c7
+
+- **File:** `reference/rfc-docker-multi-container.md` L141-L149
+- **Quote:** "tini (PID 1) / tmux (daemonised) / start.sh / claude --continue / MCP child: telegram gateway (telegram-plugin/server.ts)"
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Update the process tree to: `tini (PID 1) -> start.sh -> (forks gateway sidecar + autoaccept-poll + agent-scheduler) -> exec tmux -> bash -> claude --continue`. The gateway is a supervised sidecar sibling launched before tmux, not an MCP child of claude.
+- **Evidence:** `profiles/_base/start.sh.hbs` L104-L108 -- `_switchroom_supervise gateway ... bun "$_gateway_bundle" &` confirms the gateway as a sidecar. CLAUDE.md confirms: "tini -> start.sh -> (forks gateway + autoaccept-poll + agent-scheduler, then re-execs into tmux)."
+- **Rationale:** This is a meaningful architectural difference. The RFC shows the gateway as an MCP child (inside claude's process tree); the implementation has it as an independent supervised process launched before tmux.
+
+## Out of scope for this batch
+
+- Edits to CLAUDE.md for the architecture description -- already accurate in CLAUDE.md, no change needed.

--- a/audit/2026-05-26/fix-batches/rfc-sub-agent-visibility-prune-dead-pointers.md
+++ b/audit/2026-05-26/fix-batches/rfc-sub-agent-visibility-prune-dead-pointers.md
@@ -1,0 +1,112 @@
+# Fix batch: prune dead-pointer findings in sub-agent-visibility-rfc.md
+
+**Scope:** `reference/sub-agent-visibility-rfc.md` only.
+**Verdict pattern:** dead-pointer (5), drift-major (2), drift-minor (1).
+**Estimated edits:** medium (~50 lines -- deleting dead references and updating status notes).
+
+## Findings in this batch
+
+### Finding 1 -- rfc-sub-agent-visibility:c2
+
+- **File:** `reference/sub-agent-visibility-rfc.md` L18-L23
+- **Quote:** "Two narrow defects remain open as ordinary tracked follow-ups... Bug 6 (bg `sub_agent_turn_end` never fires for some Claude Code bg dispatches -> card can stay on Background until heartbeat ceiling) and Bug 7 (driver-side parent-tool-use correlation race)."
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** "Bug 6 and Bug 7 are moot. The progress-card-driver was deleted in PR #1122 PR3 before these could be fixed. The cross-turn visibility problem they addressed is now handled by pending-work-progress.ts (#1445) and subagent-handback (#1720)."
+- **Evidence:** `telegram-plugin/gateway/gateway.ts` L2976-L2981 -- `progressDriver` is permanently null; `telegram-plugin/gateway/gateway.ts` L15490-L15498 -- explicit deletion notice.
+- **Rationale:** The driver mechanism these bugs targeted no longer exists. Leaving open bugs for a deleted mechanism is misleading.
+
+### Finding 2 -- rfc-sub-agent-visibility:c3
+
+- **File:** `reference/sub-agent-visibility-rfc.md` L83-L84
+- **Quote:** "`telegram-plugin/progress-card-driver.ts:1855,1921` -- driver registers fleet members on `sub_agent_started` ..."
+- **Verdict:** dead-pointer
+- **Proposed action:** delete
+- **Proposed text:** Remove this line entirely. The file `progress-card-driver.ts` does not exist in the active source tree (only in the npm snapshot in node_modules). The line numbers are dead references.
+- **Evidence:** File does not exist in `telegram-plugin/`; exists only in `node_modules/@switchroom-ai/telegram-plugin/`.
+- **Rationale:** Dead pointer to a deleted file.
+
+### Finding 3 -- rfc-sub-agent-visibility:c4
+
+- **File:** `reference/sub-agent-visibility-rfc.md` L85
+- **Quote:** "`telegram-plugin/progress-card-driver.ts:1108` -- deferred-completion gate"
+- **Verdict:** dead-pointer
+- **Proposed action:** delete
+- **Proposed text:** Remove this line entirely.
+- **Evidence:** Same as c3; `gateway.ts` L3046 -- `const progressDriver: any = null`.
+- **Rationale:** Dead pointer. The gate is permanently absent.
+
+### Finding 4 -- rfc-sub-agent-visibility:c5
+
+- **File:** `reference/sub-agent-visibility-rfc.md` L86-L87
+- **Quote:** "`telegram-plugin/two-zone-card.ts` -- fleet zone renders every member (cap 5 + 'N more')"
+- **Verdict:** dead-pointer
+- **Proposed action:** delete
+- **Proposed text:** Remove this line entirely. `two-zone-card.ts` does not exist anywhere in the active source tree.
+- **Evidence:** File not found under `telegram-plugin/`; `cap()` and `FleetMember` in `fleet-state.ts` are dead code in production (not imported from active code paths).
+- **Rationale:** Dead pointer to a deleted file.
+
+### Finding 5 -- rfc-sub-agent-visibility:c6
+
+- **File:** `reference/sub-agent-visibility-rfc.md` L88-L89
+- **Quote:** "`telegram-plugin/subagent-watcher.ts` -- 1Hz JSONL polling, drives `sub_agent_tool_use` -> fleet member's `lastTool`/`lastActivityAt` updates."
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** "`telegram-plugin/subagent-watcher.ts` -- 1Hz JSONL polling. Writes sub-agent activity to a SQLite DB (`bumpSubagentActivity`, `recordSubagentStall`); used by subagent-handback and pending-work-progress paths. No longer drives a FleetMember data model (that belonged to the deleted progress-card-driver)."
+- **Evidence:** `telegram-plugin/subagent-watcher.ts` L44 -- imports only `sanitiseToolArg` from fleet-state.ts (not FleetMember, not hasLiveBackground).
+- **Rationale:** The file exists but the claimed behavior (updating fleet member lastTool/lastActivityAt) is the deleted driver's data model, not the current one.
+
+### Finding 6 -- rfc-sub-agent-visibility:c7
+
+- **File:** `reference/sub-agent-visibility-rfc.md` L90
+- **Quote:** "Heartbeat re-flushes the card every N seconds while live, so the elapsed counter ticks."
+- **Verdict:** dead-pointer
+- **Proposed action:** delete
+- **Proposed text:** Remove this line entirely. The pinned card heartbeat was deleted with the card in PR #1122. The current cross-turn surface is `pending-work-progress.ts` which appends " -- still working (Nm)" to the anchor reply.
+- **Evidence:** `telegram-plugin/gateway/gateway.ts` L15490-L15498 -- deletion notice.
+- **Rationale:** Dead pointer to deleted functionality.
+
+### Finding 7 -- rfc-sub-agent-visibility:c8
+
+- **File:** `reference/sub-agent-visibility-rfc.md` L109-L111
+- **Quote:** "AC-4 -- Stuck escalation. If a fleet member emits no JSONL event for > 60s, its row glyph flips from to with label `idle <duration>`. If every running member is stuck, header escalates to Stalled."
+- **Verdict:** dead-pointer
+- **Proposed action:** delete
+- **Proposed text:** Remove or replace with a note: "AC-4 is moot -- the progress card that would have rendered these glyphs was deleted in PR #1122 PR3. Stall detection still fires in subagent-watcher.ts but has no user-visible rendering surface. See issue #1445 for the cross-turn replacement."
+- **Evidence:** `gateway.ts` L3046 -- `progressDriver: any = null`; `subagent-watcher.ts` onStall callback exists but no-ops through the null driver.
+- **Rationale:** The AC describes deleted rendering behavior.
+
+### Finding 8 -- rfc-sub-agent-visibility:c9
+
+- **File:** `reference/sub-agent-visibility-rfc.md` L112-L113
+- **Quote:** "AC-5 -- Heavy fleet HTML safety. 6+ parallel sub-agents -- render output is balanced HTML, < 4096 bytes, fleet zone caps at 5 rows + '+ N more'."
+- **Verdict:** dead-pointer
+- **Proposed action:** delete
+- **Proposed text:** Remove or replace with a note: "AC-5 is moot -- the fleet zone renderer (two-zone-card.ts) was deleted in PR #1122 PR3. No fleet HTML is currently sent to Telegram."
+- **Evidence:** `two-zone-card.ts` does not exist; `cap()` function in `fleet-state.ts` is dead code.
+- **Rationale:** The AC describes deleted rendering behavior.
+
+### Finding 9 -- rfc-sub-agent-visibility:c11
+
+- **File:** `reference/sub-agent-visibility-rfc.md` L288-L293
+- **Quote:** "After Bugs 1-5 merged + the agent image rebuilt + apply re-run, five of six assertions pass in the UAT scenario"
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** Replace with: "The UAT scenario (`bg-sub-agent-dispatch-dm.test.ts`) tests a pinned progress card that was deleted in PR #1122 PR3. The scenario's `expectPinnedCard`/`waitForCardPhase` assertions would fail immediately in a live run because no pinned card is ever produced. The scenario file documents this as currently red."
+- **Evidence:** `telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts` L67-L100 -- STATUS comment says "currently red -- surfaces two real production bugs... Both bugs are real and live on main."
+- **Rationale:** The progress log claims 5/6 pass; the scenario file says it is red. And even if fixed, the scenario tests deleted infrastructure.
+
+### Finding 10 -- rfc-sub-agent-visibility:c12
+
+- **File:** `reference/sub-agent-visibility-rfc.md` L309-L315
+- **Quote:** "Phase 6 fix candidates... option 1 with a longer post-stall window (e.g. 5 min)"
+- **Verdict:** drift-minor
+- **Proposed action:** update-text
+- **Proposed text:** Add a note at the top of this section: "Note: the stall-terminal synthesis (Bug 6 option 1) was wired into gateway.ts (`onStallTerminal` at L16106) but `progressDriver?.ingest(...)` no-ops because progressDriver is null. This fix path has no user-visible effect and the open 'Bug 6' question is moot."
+- **Evidence:** `gateway.ts` L16095-L16131 -- `onStallTerminal` exists but no-ops through null driver.
+- **Rationale:** The fix was partially implemented but its target (the progress card) was deleted.
+
+## Out of scope for this batch
+
+- Edits to `telegram-plugin/uat/scenarios/bg-sub-agent-dispatch-dm.test.ts` -- this is production test code, not a reference doc. Out of scope for the drift-audit fix pass.
+- Edits to `telegram-plugin/fleet-state.ts` to remove dead `cap()` / `FleetMember` code -- that is a code cleanup task, not a doc drift fix.

--- a/audit/2026-05-26/recommendations/escalation-01.md
+++ b/audit/2026-05-26/recommendations/escalation-01.md
@@ -1,0 +1,109 @@
+# Recommendation: Escalation 1 — contract-vision:c8 (OpenAI billing surfaces)
+
+**Recommended option:** A
+
+**Confidence:** high
+
+## Why
+
+The "What it isn't" table at `reference/vision.md:127` reads "No OpenAI,
+Gemini, Llama, model swapping" and the justification column is "No OpenAI,
+Gemini, Llama, model swapping." Outcome 3 at `reference/vision.md:76-84`
+states "No Agent SDK. No API-key routing. No raw API." Reading these in
+context, the constraint is about inference model routing — the pillar is
+that every *agent turn* runs through the unmodified `claude` CLI on the
+Pro/Max subscription, not via a metered API. Neither Whisper nor an
+OpenAI embedding provider is an inference model for agent turns.
+
+The two surfaces in question are structurally different from the prohibited
+pattern:
+
+**Voice-in (Whisper).** The feature is explicitly opt-in per agent —
+`src/config/schema.ts:588` documents it as "Off by default — opt-in per
+agent", and `src/cli/telegram.ts:154-188` is a CLI verb the operator must
+actively invoke. No fresh `switchroom setup` enables it. The docs
+(`docs/telegram-features.md:53-57`) already contain a self-aware tradeoff
+note: "That's the one place Switchroom asks you to leave the Pro/Max-only
+ceiling — there's no Anthropic-side voice transcription yet." This is
+precisely the kind of explicit, acknowledged, opt-in auxiliary service that
+Option A would legitimise in writing.
+
+**Hindsight embedding provider field.** The `openai` and `anthropic`
+choices listed in the schema description at `src/config/schema.ts:1692-1693`
+appear to be vestigial spec text from an earlier design of Hindsight.
+At runtime, `src/memory/hindsight.ts:42` reads `memoryConfig.config?.provider
+?? "ollama"`, so the *default* is `ollama` (local, no API key). More
+importantly, `src/cli/memory.ts:292-300` actively *ignores* any
+`--provider` flag other than `claude-code` — the switchroom-bundled
+Hindsight image is pinned to `HINDSIGHT_API_LLM_PROVIDER=claude-code` (see
+`docs/auth.md:325,367-369`), which uses the operator's OAuth credentials
+via the auth-broker. The `api_key` field in the schema
+(`src/config/schema.ts:1698-1701`) flows into `generateDockerComposeSnippet`
+at `src/memory/hindsight.ts:49-51`, but only as a passthrough env var to an
+arbitrary Hindsight image the operator supplies — it is not a first-class
+switchroom-managed OpenAI billing surface. In practice, the schema text
+advertising `openai` as a provider is currently dead for any operator
+running the bundled image.
+
+Option A — adding a carve-out paragraph to `reference/vision.md` — is the
+honest fix. The vision's "No OpenAI" line was written to foreclose *model
+swapping* (routing agent turns through GPT-4 or Gemini instead of Claude),
+not to prohibit every third-party API a user might separately subscribe to
+for auxiliary tasks like speech-to-text. Whisper is a transcription
+preprocessor, not an inference substitute; the agent still runs every
+response through the `claude` CLI. Codifying this distinction removes the
+apparent contradiction and gives future contributors a clear rule: auxiliary
+services the operator pays for separately and opts into explicitly are in
+scope; anything that routes Claude agent turns away from the subscription is
+not.
+
+## Tradeoffs of the recommendation
+
+- Amending the vision requires care: the carve-out language must be narrow
+  enough not to open the door to "optional" OpenAI inference paths by
+  analogy. The text should say "auxiliary services" and require explicit
+  opt-in — not become a general "third-party APIs are fine" waiver.
+- The Hindsight embedding schema fields (`openai`, `anthropic` as provider
+  values, `api_key`) describe configuration that is currently unreachable
+  via `switchroom memory --start` (which pins `claude-code`). Leaving them
+  in the schema without documenting their status as out-of-maintenance or
+  removing them is a low-level documentation debt — Option A should note
+  this for a follow-up cleanup, even if it does not require a code change
+  now.
+- Accepting the carve-out implicitly accepts that voice-in creates a second
+  billing relationship (OpenAI) for the operator. This is already disclosed
+  in `docs/telegram-features.md:53-57`, but the vision doc change should
+  echo that disclosure so the tradeoff is visible to contributors, not only
+  to operators reading the feature docs.
+- If Anthropic or a third-party later ships subscription-level transcription
+  via the `claude` CLI, voice-in should migrate to that path. The amended
+  vision text should include a sunset clause ("until a subscription-native
+  transcription path exists").
+
+## If you pick a different option
+
+- **Option B (restrict the features):** Removing Whisper entirely eliminates
+  the one user-visible capability that lets a principal send voice notes from
+  their phone — a real loss for Outcome 4 ("always available, done properly")
+  and a regression against JTBD users who are already relying on it. Removing
+  the embedding provider schema fields for `openai`/`anthropic` is lower
+  cost — those fields are unreachable in the standard image — but requires
+  a migration path for any operator who has set them. Option B is the right
+  answer only if the operator decides that policy-level consistency with the
+  vision text is more important than the feature; that is a product judgment
+  call, not a technical one.
+- **Option C (defer):** Deferral leaves contributors with a visible
+  contradiction between the vision and the code that audit will flag again
+  on the next pass. It also leaves the docs (`telegram-features.md:53-57`)
+  as the only place where the tradeoff is acknowledged, which is too
+  peripheral for a constraint as load-bearing as Outcome 3. Option C is
+  acceptable only if the operator wants to evaluate a subscription-native
+  transcription path before committing to the carve-out language.
+
+## Open question for the operator
+
+The `memory.config.provider` schema field (`src/config/schema.ts:1690-1693`)
+lists `openai` and `anthropic` as valid values, but `switchroom memory
+--start` ignores them and the bundled image is pinned to `claude-code` — are
+these provider values intended for operators bringing their own Hindsight
+image, or are they dead schema text that should be removed?

--- a/audit/2026-05-26/recommendations/escalation-02.md
+++ b/audit/2026-05-26/recommendations/escalation-02.md
@@ -1,0 +1,31 @@
+# Recommendation: Escalation 2 — give-each-agent-its-own-workspace:c2,c3,c12 (worktree provisioning never wired)
+
+**Recommended option:** A (wire the provisioning)
+
+**Confidence:** high
+
+## Why
+
+The partial implementation is not a stub — it is a complete, well-reasoned implementation. `src/repos/bare-clone.ts` (72 lines) handles idempotent bare-clone creation and fetch-all refresh with graceful network-failure handling. `src/repos/agent-worktree.ts` (323 lines) handles first-create, clean-ff, dirty-skip, dirty-commit surfacing, removal, prune, and orphan detection — the full lifecycle described in the JTBD's "Decisions" section. Both files have proper docstrings, match the design exactly (bare clone at `~/.switchroom/repos/<slug>.git`, worktree at `<agentDir>/work/<slug>/`, branch `agent/<agentName>/main`), and are idempotent and safe to call on every reconcile. This is not a half-written sketch that would require architectural decisions; it is a complete feature waiting for a two-line call site.
+
+The gap is entirely at the integration layer. `src/agents/scaffold.ts` imports all five symbols (`ensureBareClone`, `bareClonePath`, `ensureAgentWorktree`, `removeAgentWorktree`, `listAgentWorktrees`) but calls only `agentWorktreePath` — to compute a deterministic path that gets injected as `SWITCHROOM_REPO_<SLUG_UPPER>` into `start.sh` via `buildRepoEnvVars` (scaffold.ts:1135-1148, called at lines 1817 and 3855). The env var injection is fully wired in both `scaffoldAgent` and `reconcileAgent`. The bare-clone creation and worktree provisioning that those paths point at are not. The result is exactly as the escalation states: the env var is injected pointing to a path that does not exist on disk.
+
+The `repos:` schema field is complete and documented (`src/config/schema.ts:1592-1623`), `docs/configuration.md:544-550` already tells operators to use `repos:` for the git-repo use case (not `bind_mounts:`), and `docs/rfcs/host-control-daemon.md` references the pattern as the canonical path for repo-editing agents. The feature is committed to in user-facing documentation. Option B (remove) would invalidate that documentation and require operators who read it to get a confusing silent failure. Option C (disclaim) is awkward given that the schema already validates and accepts `repos:` entries — operators can configure it today and will receive broken behavior with no warning.
+
+The wiring delta is small and low-risk: in `reconcileAgent`, after the existing agentDir existence check (scaffold.ts:3678), call `ensureBareClone` for each entry in `agentConfig.repos`, then call `ensureAgentWorktree` with the returned clone path. Mirror `removeAgentWorktree` in the agent-remove path (wherever `scaffoldAgent` teardown lives). Both functions are already idempotent; calling them on a reconcile that has no `repos:` config is a no-op (the `if (!repos) return {}` guard at scaffold.ts:1141 shows the pattern). The only non-trivial question is whether `reconcileAgent` needs to become `async` — it is currently synchronous, and both provisioning functions are async (they shell out via `execFileSync`, so they could be sync too, but are declared async). That is the one real decision point.
+
+## Tradeoffs of the recommendation
+
+- Wiring the provisioning makes `reconcileAgent` either async (ripple through callers) or requires wrapping in `spawnSync`-style calls — the implementation functions use `execFileSync` internally so could be synchronous, but their exported signatures are `async`. A small refactor to make them synchronous, or a `Promise.resolve` wrapper at the call site, would avoid the async refactor.
+- The `removeAgentWorktree` teardown path needs to be found and wired — it was not located during this audit. If the agent-remove path exists in `src/cli/agent.ts` or `src/agents/lifecycle.ts`, adding the removal call there is required for the "removal is symmetric" JTBD contract.
+- First reconcile after a user adds `repos:` will block on `git clone --bare` — network-latency at reconcile time. The existing `ensureBareClone` already handles the non-fatal fetch-fail path gracefully.
+- The env var injection is already shipping to agents configured with `repos:`. Those agents currently get a valid-looking env var pointing at a nonexistent path. Wiring the provisioning fixes this silently on the next restart with no user action needed.
+
+## If you pick a different option
+
+- **Option B (remove):** Requires removing the `repos:` schema field, `buildRepoEnvVars`, all five imports, and the `docs/configuration.md:544-550` guidance that tells operators to use `repos:` for this use case. Net deletion of ~430 lines of tested implementation. Configuration breakage is silent — operators who followed the docs will have invalid YAML after the schema removal (or worse, their configs will silently stop working if the field becomes unknown). Given the volume of surrounding documentation that already commits to this design, removal is disruptive without a clear payoff.
+- **Option C (disclaim):** The schema accepts `repos:` today with no warning. An operator who configures it and restarts an agent will see `SWITCHROOM_REPO_<SLUG>` in their agent's environment pointing at a path that does not exist — the agent will silently fail to find the repo. A disclaimer in the JTBD file does not surface at the point of failure. This is worse than the current state, which at least doesn't fail with mysterious side effects on most operators (since few will have discovered `repos:` without documentation that currently says it works).
+
+## Open question for the operator
+
+`reconcileAgent` is synchronous today — do you want the worktree-provisioning call sites to refactor the provisioning functions to synchronous signatures (straightforward, since they already use `execFileSync` internally), or do you want `reconcileAgent` to become async (larger ripple through callers in `src/cli/agent.ts` and `src/cli/apply.ts`)?

--- a/audit/2026-05-26/recommendations/escalation-03.md
+++ b/audit/2026-05-26/recommendations/escalation-03.md
@@ -1,0 +1,34 @@
+# Recommendation: Escalation 3 — restart-and-know-what-im-running:c3,c8 (boot card lacks config-change visibility)
+
+**Recommended option:** C
+
+**Confidence:** high
+
+## Why
+
+The JTBD's "no need to ask" core promise is stated without qualification in `reference/restart-and-know-what-im-running.md`: "After any restart, the user is told what config is live. Model, tools, skills, memory backend, auth state. No need to ask." The anti-patterns list explicitly names "Cosmetic summaries that always look the same regardless of the actual config. The user learns to distrust it." and "Lying by omission. If tools were silently disabled, the summary should say so, not quietly drop them." Option B (accepting the gap and narrowing the JTBD) would require rewriting both of those anti-patterns out of the contract. That is a deliberate retreat from the product's core promise, not a design refinement.
+
+Option A (full model/tools/memory fields on every boot card) conflicts with the boot card's own explicit design contract. The boot card file opens: "Default state is a single line: `✅ <agent> back up · <version>`" and the deletion comment is explicit — Profile/Tools/Skills/Limits/Channel/Memory content was removed from the old SessionStart greeting because it was "always-rendered" noise that "becomes wallpaper the user learns to scroll past." The JTBD itself warns against "a boot banner that dumps every setting." Putting that content back unconditionally on every restart restores the exact problem PR #142 solved. The design split — quiet boot card for liveness, `/status` for config audit — was intentional and has held across many subsequent changes.
+
+Option C threads the needle. The boot-issue-cache already demonstrates the underlying pattern: persist a fingerprint of the last boot's probe state, diff against the current boot, surface a row only when something changed. A config-snapshot cache (model, tools, memory backend) wired into the same gate would surface "model changed: claude-opus-4 → claude-sonnet-4-5" as a single appended row on the boot card only when it's true — invisible on identical restarts, unmissable on actual changes. This preserves the silent-when-healthy contract for stable fleets and delivers the "change is obvious" promise (c8) when something actually shifted. Non-technical users who never run `/status` would see changes appear in the one place they already look: the quiet ack line that turns into a short card when something needs attention. The UAT test (`jtbd-wake-audit-content-dm.test.ts`) explicitly acknowledges this floor-vs-vision split in its own docstring and calls the strict contract "the future UAT."
+
+The implementation boundary for Option C is also tighter than Option A. The config snapshot stores three fields (model slug, tools fingerprint, memory backend) at shutdown or gateway start, diffed on next boot. The boot card renderer already accepts a `resolvedRows` / degraded-rows model; a config-diff row is a new row type, not a new rendering mode. The `updateOutcomeLine` pattern (PR C) shows that the card already accepts appended-section text from an external computation — config-diff could use the same slot. The risk of introducing config-field noise (e.g. model variants that look different but behave the same) is real but bounded: the fingerprint can fold across patch versions the same way `fingerprintProbe` folds across incidental detail variance.
+
+## Tradeoffs of the recommendation
+
+- Requires a config snapshot file written on each gateway boot (or read from scaffold artifacts). A new disk dependency, though small and consistent with `boot-issue-cache.json`.
+- Fingerprint stability requires care: if the model string format changes across releases, a spurious "model changed" row appears. Needs a normalizer (strip trailing version suffix, lowercase) similar to `normalizeDetail()` in boot-issue-cache.
+- Tools fingerprint is harder than model. A full allowlist diff ("added: bash, removed: computer") is genuinely useful; a hash that just says "tools changed" is noise. The first version can hash the sorted allowlist and show "tools allowlist changed — run /status to see details" which is honest without being exhaustive.
+- The UAT scenario (`jtbd-wake-audit-content-dm.test.ts`) would need a strict variant: restart after a config change and assert the boot card edit contains the changed-field row. The current test relaxes to "agent replies with config signals when asked" — correct but not the proactive contract.
+- Memory backend change detection depends on which layer of config the gateway reads. If the memory backend is resolved at `switchroom.yaml` load time, it's straightforward. If it's resolved late (at recall time), a snapshot needs the resolved value passed through.
+- No risk to the "silent when healthy" property: the row only appears when the diff fires.
+
+## If you pick a different option
+
+- **Option A:** Restores the content deleted in PR #142 PR 1 unconditionally on every boot. The changelog entry for v0.4.0 is explicit: the six-row checklist was "noise on the common path." Non-technical users who restart frequently will learn to scroll past the card, defeating c8's "obvious, not buried" requirement. High regression risk against the principles test ("Defaults test": does it work on a fresh setup?). Not recommended.
+
+- **Option B:** Requires rewriting `reference/restart-and-know-what-im-running.md` to remove or qualify "no need to ask," demote the "config change restart" UAT prompt, and add an explicit "split design" note. This is honest if the operator has decided the split is permanent — but the UAT test's own docstring says the proactive contract is "the vision target" and frames the relaxed test as "the floor." Choosing B now forecloses future proactive delivery. Acceptable only if there is a confirmed product decision that `/status` is the permanent home for config audit and the boot card will never surface config changes.
+
+## Open question for the operator
+
+Is "tools allowlist changed — run /status to see details" sufficient for a first cut of Option C, or does the operator want a granular diff row (e.g. "tools: added bash, removed computer") from day one? The granular form is more useful but requires serializing the allowlist at snapshot time, not just a hash.

--- a/audit/2026-05-26/recommendations/escalation-04.md
+++ b/audit/2026-05-26/recommendations/escalation-04.md
@@ -1,0 +1,32 @@
+# Recommendation: Escalation 4 — track-plan-quota-live:c2 (no proactive cap-approach push)
+
+**Recommended option:** A
+
+**Confidence:** medium
+
+## Why
+
+The JTBD's own "Signs it's working" list includes "Approaching a cap produces a visible signal at a point where the user can still act on it," and its anti-patterns section explicitly names "Quota visible only in a separate dashboard or a command. If the user has to go looking, they won't, and they'll hit the wall." The current reactive design — `[Fall back now]` button at 90%, `near limit — watch this` badge — is a well-executed dashboard affordance, but it lives entirely inside `/auth`. A user who isn't in the habit of checking `/auth` receives zero proactive signal until auto-fallback fires at 99.5%, which is effectively after the wall. The JTBD text is unambiguous: the signal must find the user, not the other way around. Option B (update the JTBD to describe the current design) would mean rewriting the intent of the document to match an acknowledged gap — that is rationalisation, not resolution.
+
+The pattern for a proactive push already exists and is proven. `credits-watch.ts` (wired in gateway.ts at L15975-15997) polls every 15 minutes, reads a local file, compares against a persisted last-notified state, and calls `bot.api.sendMessage` on state transition. It fires on entry, on recovery, and on reason-change — and explicitly avoids re-firing for the same steady state. The same three-state machine (healthy → throttling → blocked) that `classifyHealth` in `auth-snapshot-format.ts` already computes is exactly the input a quota-watch module would need. Extending the credits-watch pattern to cover the 80% (`THROTTLING_THRESHOLD_PCT`) transition requires adding a broker `probe-quota` call on a polling interval and tracking last-notified health per account. The broker infra for that probe already exists (`client.probeQuota`); the state-machine logic (`classifyHealth`) already exists; the notification routing already exists. This is extension, not new invention.
+
+Noise risk on a multi-agent fleet is real but manageable. The concern is N agents × M accounts × two windows producing a flood of threshold-crossing messages as utilization fluctuates near 80%. Three mitigations make this tractable. First, the notification should track transitions, not absolute level — exactly like credits-watch: only fire when health _changes from healthy to throttling_ (not on every poll while throttling). Second, the operator typically has 1–3 account slots, not 10+; the account pool is shallow by design (the `/auth add` flow is non-trivial). Third, a 15- or 30-minute poll interval means at most one message per crossing per account, not one per minute. The "over-alerting" anti-pattern in the JTBD points at every-tick notifications, not edge-triggered ones.
+
+One practical sizing note: the current quota probe (`probeQuota`) makes an actual API call (a 1-token Haiku request) to read utilization headers. For the proactive watcher, the right source is the broker's cached quota state from `list-state` (already computed on the `/auth` render path), not a fresh network probe every 15 minutes per account. Reading the cached broker state is a local IPC call, keeps the polling cheap, and avoids burning API budget just to check the gauge. The watcher should only trigger a live `probeQuota` when it detects a state change and needs fresh numbers for the notification message body.
+
+## Tradeoffs of the recommendation
+
+- The watcher adds a polling loop in the gateway alongside credits-watch; both should share the same notification routing and state persistence pattern to avoid a third bespoke approach.
+- Broker-cache polling means the notification lags by however stale the broker's stored quota is. That staleness was already accepted for the `/auth` render; it's acceptable here too. Operators can always trigger a live probe via `/auth`.
+- If a user has two accounts and both cross 80% simultaneously (unlikely but possible near the end of a billing window), they get two notifications within one poll cycle. That's correct behavior, not noise — each account needs its own action.
+- The broker's cached quota state is only updated when an agent makes a request. A fleet that is idle may not trigger a state-change push even if utilization is high — but that is a pre-existing limitation of the header-pull approach, not introduced by this change.
+- Implementation cost is low (~25 agent minutes): a new `quota-watch.ts` module mirroring `credits-watch.ts`, wired into the gateway boot block, using `classifyHealth` for the state machine and broker list-state for the input.
+
+## If you pick a different option
+
+- **Option B:** Rewriting the JTBD to accept reactive-only design closes the audit finding without shipping value. The stakes section ("A user who hits a wall silently loses trust") would then be a known unfulfilled risk, not a gap. This is appropriate only if the operator has explicitly decided the dashboard affordance is sufficient — a deliberate product choice, not a technical gap.
+- **Option C:** Hybrid (document current state, note proactive push as planned) is a reasonable interim choice if implementation capacity is constrained right now. It resolves the audit finding by making the gap intentional and tracked, without shipping incomplete code. The risk is that "planned" items without a PR or milestone tend to stay planned — use this option only with a concrete follow-up issue created at the same time.
+
+## Open question for the operator
+
+Should the proactive push be scoped to the _active_ account only, or to all accounts in the pool? The auto-fallback machinery cares about the whole pool (to pick the best target), but the user typically acts by switching to an account that has headroom — so a notification about a non-active account approaching its limit is also actionable. The credits-watch precedent fires per-agent (one gateway, one account context); the new watcher would have access to all accounts via broker `list-state` and could choose either scope.

--- a/audit/2026-05-26/recommendations/escalation-05.md
+++ b/audit/2026-05-26/recommendations/escalation-05.md
@@ -1,0 +1,31 @@
+# Recommendation: Escalation 5 — track-plan-quota-live:c7 (no rolling-window reset notification)
+
+**Recommended option:** C (scope to fatal-billing only), with a JTBD wording tightening
+
+**Confidence:** high
+
+## Why
+
+The gap is real but the framing in the original claim overstates what "window rolls" means in practice. The JTBD's "Signs it's working" line says "when the window rolls, the user sees the recovery without having to refresh anything." In normal operation — an agent that was never blocked — the 5-hour or 7-day window rolling over is a non-event: usage headroom increases passively and the boot card or `/usage` on the next interaction shows the updated numbers. There is no "recovery" to surface because the user was never stuck. A proactive notification in this case lands as noise, directly violating the anti-pattern "every small usage tick produces a notification until the user mutes the product."
+
+The case where window-reset genuinely matters is when the agent was blocked (quota exhausted, fell back to a secondary account, or showed an "all-blocked" state), and the original active account's window resets. That IS a recovery the user cares about and cannot see without action. However, `credits-watch.ts` already covers the closest analogue: it pushes a "credits restored" message when the `.claude.json` fatal-billing flag clears. The `exhausted_until` in the auth broker operates differently — it is a passive timestamp comparison (`q.exhausted_until > this.now()`), not an event. There is no callback or observer when the timestamp expires; the broker simply starts treating the account as healthy again on the next `get-credentials` call. Adding a proactive Telegram push on rolling-window expiry would require a polling loop watching for the moment `exhausted_until` transitions from future to past, plus routing that event through the gateway to Telegram — non-trivial plumbing with its own race conditions (event fires while agent is mid-restart, duplicate fires on multi-agent fleets, etc.).
+
+Option B (accept the design with a JTBD note) is directionally correct but incomplete: it leaves the misleading "without having to refresh anything" wording intact, which will generate future audit failures on the same sentence. Option A (add rolling-window reset notification) is over-engineering: the typical fleet either recovers naturally (agent retries, gets healthy creds, resumes), or the user ran `/auth` and saw the reset window from `fiveHourResetAt`/`sevenDayResetAt` headers that `quota-check.ts` already captures and displays. The boot card on next agent start also carries fresh usage data. Option C is the cleanest path: narrow the JTBD claim to reflect what is actually implemented (fatal-billing push via credits-watch), and reword the rolling-window bullet to match the real user flow (ambient recovery visible on next boot card or `/usage`, not a push).
+
+The right JTBD edit is surgical: replace "When the window rolls, the user sees the recovery without having to refresh anything" with something like "When a fatal billing block clears, the user hears about it without having to ask. For routine quota refills, usage resets are visible on the next boot card or `/usage`." This is honest about the two tiers of recovery — proactive for blocking states, ambient for routine resets — and eliminates the false gap without adding noisy infrastructure.
+
+## Tradeoffs of the recommendation
+
+- The JTBD change is purely documentary: no code touched, no CI risk, no new plumbing to maintain.
+- The "was blocked, now unblocked due to window rollover" case remains non-pushed. In practice, when the `exhausted_until` window expires, the auto-fallback path (if triggered) had already swapped to a healthy account. The primary account coming back healthy after 5h is quietly picked up on the next `get-credentials` call — no user action required, and the next boot card confirms it.
+- The UAT prompt "Recovery. Let the window roll. The user should see usage free up without having to refresh" will need a corresponding update or the UAT verifier will keep flagging this as a failure. Scope that into the same JTBD edit.
+- This recommendation accepts that the `credits-watch.ts` recovery notification (fatal-billing cleared) is the high-fidelity push signal, and that rolling-window reset is ambient-tier. If the operator's mental model requires a push on every window reset, Option A is the right call — but it should be built with a deduplication gate (only push when the agent was previously in an exhausted state, not on every clean window rollover).
+
+## If you pick a different option
+
+- **Option A:** Requires adding a poller in the auth broker or gateway that watches `exhausted_until` timestamps and emits an IPC event when one transitions from future to past. The gateway then routes that event to Telegram. Non-trivial: must handle multi-account fleets (which account's reset do you notify?), the agent-name→chat mapping, and the race where the agent is mid-restart when the event fires. Estimate ~30 agent-minutes of plumbing + tests. Risk of notification spam on agents that were never blocked (the poller fires on every account whose window rolls, even if the user never saw a blocked state). Mitigation: gate the push on `prev.exhausted` state, matching the credits-watch pattern.
+- **Option B:** Leaves the existing wording in place and adds a parenthetical note ("fatal-billing recovery is pushed; rolling-window reset appears on next boot card"). Reduces the false precision of the claim without removing it. Lower-effort than A, but the UAT prompt still says "without having to refresh anything," which remains literally false for rolling-window resets. Expect this escalation to recur in a future audit pass.
+
+## Open question for the operator
+
+The JTBD's UAT prompt ("Let the window roll. The user should see usage free up without having to refresh") will fail on any honest UAT run because the rolling-window reset produces no push. Should this UAT prompt be revised to read "Check `/usage` after the window rolls — usage should reflect the reset" (ambient tier), or removed in favor of a UAT focused on the fatal-billing recovery push?

--- a/audit/2026-05-26/recommendations/escalation-06.md
+++ b/audit/2026-05-26/recommendations/escalation-06.md
@@ -1,0 +1,32 @@
+# Recommendation: Escalation 6 — rfc-sub-agent-visibility:c11 (AC-4 stuck render may not be wired)
+
+**Recommended option:** B
+
+**Confidence:** high
+
+## Why
+
+The end-to-end trace is conclusive: the `markStuck` function in `fleet-state.ts` is dead production code. It is exported and tested in `tests/fleet-state.test.ts`, but no production file imports it or calls it. The only production import of `fleet-state.ts` is in `subagent-watcher.ts:44`, and it imports only `sanitiseToolArg` — not `markStuck`, `FleetStatus`, or any of the state-transition functions. `progress-card-driver.ts` does not import `fleet-state.ts` at all.
+
+The AC-4 claim describes a per-fleet-member ↻→⚠ glyph flip with an `idle <duration>` label. That would require `FleetMember.status` to reach `'stuck'` and then a renderer to branch on that status value. Neither happens. The `FleetStatus` type includes `'stuck'`, and `markStuck` correctly transitions a member to it, but the renderer that produces the sub-agent zone (`renderSubAgent` in `progress-card.ts`) operates on `SubAgentState`, not on `FleetMember`. `SubAgentState.state` is typed as `ItemState` (`'pending' | 'running' | 'done' | 'failed'`) — there is no `'stuck'` branch, no ⚠ glyph, and no `idle <duration>` label in that renderer.
+
+What IS wired is a different, coarser stall signal: the driver's heartbeat passes a `stuckMs` value (the age of `cs.lastEventAt`) to the card-level `render()` in `progress-card.ts`. When `stuckMs >= STUCK_THRESHOLD_MS` (2 min), the renderer inserts `⚠️ No events for <gap> — likely stuck.` as a header-level line. This is a card-wide warning, not per-fleet-member row glyph flipping from ↻ to ⚠. The `onStall` callback from `subagent-watcher.ts` routes to `progressDriver?.onSubAgentStall(...)` in `gateway.ts`, but `progressDriver` is permanently `null` (deleted in PR #1122 — see `gateway.ts:3046`), so those calls are no-ops at runtime.
+
+The RFC itself notes that `two-zone-card.ts` was the renderer for the AC-4 fleet zone, but that file no longer exists. The current renderer is `progress-card.ts` which does not have the per-member stuck-glyph path at all.
+
+AC-4 as specified — per-member row glyph flipping to ⚠ with `idle <duration>` — has no production implementation. The state model (`fleet-state.ts:markStuck`) exists but is unreachable from the render pipeline. Option B is the correct verdict.
+
+## Tradeoffs of the recommendation
+
+- Updating the RFC to mark AC-4 as partially implemented (state machinery exists, render path absent) is honest and prevents future confusion about what shipped.
+- The coarser card-level `stuckMs` warning does provide _some_ stuck signal to users (at 2 min, card-wide), so the user-facing gap is narrower than it might appear — but it is not AC-4 as written.
+- `markStuck` should either be connected to the render pipeline or removed; leaving it as tested-but-unreachable dead code is a maintenance liability (tests give false confidence the feature works).
+- The `onStall` → `progressDriver?.onSubAgentStall(...)` call in gateway.ts is also dead (progressDriver = null). If the progress driver is ever reinstated, the wire exists at the gateway level but the renderer-side branch (`FleetMember.status === 'stuck'` → ⚠ glyph) would still need to be added.
+
+## If you pick a different option
+
+- **Option A (confirm wire exists):** Not viable. The trace above is exhaustive. `markStuck` is unreachable from production, `progressDriver` is null, and `renderSubAgent` has no stuck branch. There is no wire to document.
+
+## Open question for the operator
+
+Should `markStuck` be removed from `fleet-state.ts` (and its tests) as dead code, or is the intent to connect it in a follow-up? The answer determines whether the RFC follow-up is "add the render branch" (connect it) or "remove the dead state function" (clean up). Both are valid but they are different scopes.

--- a/audit/2026-05-26/recommendations/escalation-07.md
+++ b/audit/2026-05-26/recommendations/escalation-07.md
@@ -1,0 +1,30 @@
+# Recommendation: Escalation 7 — rfc-sub-agent-visibility:c12 (fleet cap unimplemented)
+
+**Recommended option:** B
+
+**Confidence:** high
+
+## Why
+
+The fleet renderer at `progress-card.ts` L929-943 is not currently reachable in production. The pinned progress-card driver (`progress-card-driver.ts`) was removed from the gateway in PR #1122 PR3 — `progressDriver` is permanently `null` in `telegram-plugin/gateway/gateway.ts` (L3046), making every `progressDriver?.X` call a no-op at runtime. The `progress-card.ts` module is still imported by `progress-card-driver.ts`, but that driver is never loaded by the gateway. The fleet-zone renderer loop at L929-943 is dead code at the time of this audit.
+
+More importantly, the RFC itself already declares the card model superseded. The document's preamble (L25-33 of `reference/sub-agent-visibility-rfc.md`) says explicitly: "Card model superseded. This RFC reasons about the two-zone progress-card model. That two-zone design has since been superseded by `reference/conversational-pacing.md`, and `reference/status-card-design.md` is archived." AC-5's cap requirement was written for a design that no longer drives the live product. The current Telegram-facing card surface is conversational pacing, not the two-zone pinned card this RFC specified.
+
+There is no meaningful 4096-byte risk to defend against today. The `stream-reply-handler.ts` (L395-400) does enforce a hard 4096-char pre-check on `stream_reply` calls, and `answer-stream.ts` (L49) tracks the same constant — but those guard the conversational-pacing path, which does not use the uncapped fleet renderer. The `cap()` function in `fleet-state.ts` (L157-163) exists, is correct, and is exported, but the one callsite that would matter (the fleet renderer) is unreachable.
+
+Wiring Option A now — importing `cap()` into a renderer that is not live — would cost little but achieve nothing and would leave reviewers confused about why dead code is being maintained. The correct fix is to update AC-5 in the RFC to reflect reality: remove the cap requirement, note that the two-zone card it describes was retired in PR #1122, and point to `reference/conversational-pacing.md` as the live contract. If the project eventually revives a pinned fleet card under the conversational-pacing architecture, the cap requirement should be written fresh against that design, not preserved as a phantom AC in a closed RFC.
+
+## Tradeoffs of the recommendation
+
+- Removing AC-5's cap requirement from a closed RFC is low-risk: the RFC's status is already "SHIPPED / CLOSED" and the doc explicitly flags the card model as superseded.
+- The `cap()` function in `fleet-state.ts` remains in place and can be picked up cheaply if a future fleet renderer is ever written — no code needs to be deleted.
+- There is no user-visible regression from Option B: the uncapped renderer cannot produce a 4096-byte overrun because it is not called.
+- Leaving the spec as-is continues to mislead future auditors (and this audit system) into treating it as an unfulfilled implementation gap in active code.
+
+## If you pick a different option
+
+- **Option A:** Import `cap()` into `progress-card.ts`'s fleet section and add a `+ N more` footer. This is correct if you plan to re-activate the progress-card driver. Doing it without re-activating the driver still leaves the loop unreachable and creates well-maintained dead code — not worthless, but not gap-closure either. If you go this route, also re-wire `progress-card-driver.ts` into the gateway and write the UAT scenario (`bg-heavy-fleet-dm.test.ts`) the RFC called for in Phase 3.
+
+## Open question for the operator
+
+Is there an active plan to revive the pinned progress-card (two-zone or otherwise) under the conversational-pacing architecture? If yes, Option A makes sense as prep work and should be paired with re-activating the driver. If no, close AC-5 with a note and let `cap()` sit ready for future use.

--- a/audit/2026-05-26/recommendations/escalation-08.md
+++ b/audit/2026-05-26/recommendations/escalation-08.md
@@ -1,0 +1,32 @@
+# Recommendation: Escalation 8 — run-a-fleet-of-specialists:c9 (Hindsight memory orphans on destroy)
+
+**Recommended option:** B
+
+**Confidence:** high
+
+## Why
+
+The core question for this escalation is whether an orphaned Hindsight bank is a leak or a recovery feature. The answer is: it is a recovery feature in disguise, and that changes the calculus significantly.
+
+The `bankId` for any agent is derived as `agentMemory?.collection ?? agentName` (see `src/agents/scaffold.ts:1613` and `src/memory/hindsight.ts:76`). When no explicit `memory.collection` override is set — which is the default for every agent — the bank ID is simply the agent name. The `createBank` call in scaffold.ts (line 2896) is explicitly documented as idempotent: "Create a new memory bank or get an existing one — so calling this on an already-existing bank is a no-op and returns success" (`src/memory/hindsight.ts:392-394`). This means if an agent named `clerk` is destroyed and then re-created with the same name, its first scaffold run will call `createBank("clerk")`, Hindsight will recognize the existing bank, and the agent will silently resume with its full memory history. The orphaned bank was actually a restoration point, not waste.
+
+This re-attach behaviour is architecturally desirable. Accidental destroys, name collisions after a reconfiguration, or a fleet rebuild from scratch all benefit from memory persistence in the backing store. The JTBD claim "removing an agent is clean ... no orphaned processes or dangling config" is specifically about processes and config — not about persistent data stores. The wording does not promise data erasure, only operational cleanliness. Interpreting it to mandate automatic bank deletion would be the wrong reading; the analogous expectation would be that destroying a database-backed service should also DROP the database schema, which is almost never correct behavior.
+
+There is also a practical implementation blocker for Option A. Neither the vendored `HindsightClient` (`vendor/hindsight-memory/scripts/lib/client.py`) nor the switchroom Hindsight bindings (`src/memory/hindsight.ts`) expose a `delete_bank` call. A search across the entire repository finds no `DELETE /banks/{id}` call anywhere. Whether Hindsight's upstream REST API even exposes a bank deletion endpoint is not confirmed by any code in this repository. Wiring Option A would require: confirming the upstream API supports bank deletion, adding a `deleteBank` function to `src/memory/hindsight.ts`, calling it in the destroy flow, and handling the case where Hindsight is unreachable at destroy time (should destroy be blocked, or should the orphan be left anyway?). The failure mode where destroy aborts because Hindsight is offline is strictly worse UX than the current silent orphan.
+
+## Tradeoffs of the recommendation
+
+- Operators who destroy an agent permanently and never re-create it accumulate storage in the Hindsight database with no self-service cleanup path. On a fleet that cycles agents regularly, this compounds.
+- The current `mcp__hindsight__delete_memory` tool (available to agents in-session) only deletes individual memories, not the whole bank. Operators have no single-command purge path today.
+- Updating the JTBD claim in `reference/run-a-fleet-of-specialists.md` to be accurate about Hindsight data persistence is low-risk and takes 1-2 lines.
+- A documentation path to the cleanup command is achievable now; a product path (Option A or C) is achievable later without reopening this decision.
+- Option B does not preclude adding a `switchroom agent destroy --purge-memory` flag in a later PR once the upstream delete API is confirmed.
+
+## If you pick a different option
+
+- **Option A:** Wire memory purge in the destroy flow. Before implementing, confirm that `DELETE /v1/default/banks/{bank_id}` exists in the Hindsight REST API — it is absent from the vendored client. If it exists, add `deleteBank()` to `src/memory/hindsight.ts`, call it in the destroy flow after `rmSync`, and handle the offline case gracefully (warn, do not block destroy). If the bank ID was overridden via `memory.collection`, destroying the wrong name is possible — read the config before removing the agent directory. Risk: breaks the re-attach recovery path; any accidental destroy loses memory permanently.
+- **Option C:** Soft-delete / archive the collection. Requires Hindsight to support an archival state (not confirmed from current API surface), adds a separate cleanup command, and introduces a two-phase delete UX that operators will find confusing. Adds complexity with limited benefit over Option B + a future `--purge-memory` flag.
+
+## Open question for the operator
+
+Does Hindsight's REST API expose a bank deletion endpoint (`DELETE /v1/default/banks/{id}`)? This single fact determines whether Option A is even wirable without a custom workaround, and should be confirmed before any implementation work begins.

--- a/audit/2026-05-26/recommendations/escalation-09.md
+++ b/audit/2026-05-26/recommendations/escalation-09.md
@@ -1,0 +1,30 @@
+# Recommendation: Escalation 9 — feel-like-a-colleague:c9 (AI non-detectability is unmeasurable)
+
+**Recommended option:** C
+
+**Confidence:** high
+
+## Why
+
+The JTBD format in this codebase is explicitly outcome-focused, not test-result-focused. The README for `reference/` describes JTBDs as answering the question "Did it do the user's job?" — which is a design target, not a passing test suite. Scanning the "Signs it's working" sections across all JTBDs confirms this: they are written in the present tense as outcome descriptions, not verified state. `run-a-fleet-of-specialists.md` says "The user never has to prefix a message with 'as my coding agent'"; `remember-across-sessions.md` says "A restart doesn't reset the relationship." Neither of those are instrumented claims. The entire format is aspirational-but-precise: it tells builders what success looks like so they can orient toward it, not report against it.
+
+The claim at c9 sits inside that consistent pattern. It reads: "A non-technical user can't immediately tell they're talking to an AI from the first ten messages. They can tell it's not a person they've met before, but the shape of the conversation feels human." This is a design target, not a performance assertion. The section header "Signs it's working" already signals that role. Adding a hedge ("target, not yet systematically verified") would be inconsistent with how every other JTBD in the file is written, and would implicitly suggest other "Signs" entries are verified — they are not.
+
+The claim is also load-bearing in the right way. `vision.md` calls out the non-technical principal explicitly: "The bar: one even a non-technical partner likes." The c9 claim is precisely what that bar means in behavioral terms. Softening it would dilute the sharpest user-facing success criterion in the JTBD, which is where the design teeth live. The claim is not a marketing assertion made outside a design document; it is a design criterion inside one, and that context is the correct frame.
+
+Finally, the SOUL.md AI-tell bans (L41-51) are verifiable engineering affordances that implement this criterion. The criterion itself remains correctly at the outcome layer. Removing it (option B) would leave the implementation affordances with no stated purpose in the design contract. Hedging it (option A) would add noise that no other JTBD carries and would signal, incorrectly, that the JTBD format is meant to contain only verified claims.
+
+## Tradeoffs of the recommendation
+
+- The claim cannot be falsified from the codebase alone, which is a real epistemic gap — but it is the same gap that exists for every "Signs it's working" bullet across all JTBDs. Treating c9 differently would require auditing all of them, which is a larger and separate question about the JTBD format itself.
+- Accepting as-is means the design contract contains an outcome that only user research can validate. This is appropriate for a design contract; it would be inappropriate in a test report or release checklist.
+- The UAT prompts section of the same JTBD (L119-144) already provides a partial proxy: the "AI-tell sweep" prompt is code-reviewable and the behavioral prompts are manually testable. The outcome is closer to measurable than it first appears; it just requires a human in the loop, not an automated test.
+
+## If you pick a different option
+
+- **Option A:** Adding "(target, not yet systematically verified via user testing)" reads as an admission that other "Signs it's working" bullets are verified, which they are not. It would create inconsistency across JTBDs and invite a wave of similar hedges. The actual fix, if hedging is wanted, is a format-level note in `reference/README.md` stating that all "Signs" entries are design targets unless explicitly annotated otherwise — a much broader change.
+- **Option B:** Removing the claim leaves the JTBD without a human-perceivable success criterion at the outcome level. The remaining signs (one clarifying question, length match, no AI-tells) are all intermediate indicators; c9 is the only one that names the actual user experience being targeted. Its removal would make the JTBD harder to use as a design gate.
+
+## Open question for the operator
+
+If you want to distinguish measurable "Signs" from aspirational ones across all JTBDs consistently, the right lever is a format note in `reference/README.md`, not individual hedges on individual bullets. Is that a change worth making as a separate pass?

--- a/audit/2026-05-26/recommendations/escalation-10.md
+++ b/audit/2026-05-26/recommendations/escalation-10.md
@@ -1,0 +1,31 @@
+# Recommendation: Escalation 10 — give-each-agent-its-own-workspace:c7,c8,c11 (cluster tied to Escalation 2)
+
+**Recommended option:** Defer-to-Escalation-2 — mirror its resolution exactly, with one always-on action: mark the boot-card "dirty since <ts>" sub-claim of c8 as separately unimplemented regardless of Escalation 2's outcome.
+
+**Confidence:** high
+
+## Why
+
+**On c7 (fast-forward on clean session start):** The ff logic is fully implemented in `src/repos/agent-worktree.ts` L210-238. On a clean worktree, `ensureAgentWorktree` runs `git fetch origin` followed by `git merge --ff-only origin/<defaultBranch>` and logs the result to stderr. The implementation is correct and complete. However, `ensureAgentWorktree` is imported but never called from `scaffold.ts` or any production reconcile path — confirmed by the grep: `scaffold.ts` imports `ensureAgentWorktree` (line 248) and `WorktreeState` (line 252) but does not call either. The ff-to-main therefore never executes on session start. The claim is implemented but unwired. If Escalation 2 = A (wire provisioning), c7 becomes testable and should be verified post-wiring before removing the vision-only flag. If Escalation 2 = B (remove), c7 must also be removed — the ff logic would be dead code in a feature that no longer ships. If Escalation 2 = C (document incomplete), c7 should receive the same "not wired" disclaimer.
+
+**On c8 (dirty-tree policy: leave alone + boot-card warning):** The "leave alone" half is fully implemented at `src/repos/agent-worktree.ts` L196-208: `isWorktreeDirty` detects uncommitted changes via `git status --porcelain`, and on dirty detection `ensureAgentWorktree` returns `{ dirty: true, dirtyCommit: sha }` without touching the worktree. The "boot card surfaces `<repo>: dirty since <ts>` as a one-line warning" sub-claim is not implemented. A review of `telegram-plugin/gateway/boot-card.ts` shows the `RenderBootCardOpts` interface has no `worktrees` or `dirtyWorktrees` field, `renderBootCard` renders no such row, `runAllProbes` has no worktree probe, and the `ProbeKey` union has no `repos` or `worktrees` entry. The `WorktreeState.dirtyCommit` field exists in the module but is never consumed by any caller outside of `agent-worktree.ts` itself. The boot-card "dirty since <ts>" surface is entirely absent and would require adding a probe, a render slot, and a clock for the "since <ts>" timestamp — none of which exist. This sub-claim of c8 is separately unimplemented from the dirty-detection logic. The "leave alone" half follows Escalation 2's resolution like c7; the "boot card surfaces" half needs its own disclaimer or implementation work regardless of Escalation 2's outcome.
+
+**On c11 (sub-agent nesting in worktrees end-to-end):** The JTBD text at `reference/give-each-agent-its-own-workspace.md` lines 40-43 and 111-114 states that sub-agents dispatched from inside an agent's worktree create their own nested worktree off the parent's HEAD, "exactly as today." A code search of `src/` finds no implementation of this nesting behavior in agent-worktree.ts or any callers — there is no `ensureSubAgentWorktree`, no "parent HEAD" resolution, and no sub-agent worktree dispatch path. The claim "existing pattern" refers to the documented sub-agent architecture, but that architecture (sub-agents creating worktrees off their parent's HEAD) is not implemented as code today. This claim is vision-only independently of Escalation 2: even if Escalation 2 = A wires main-agent worktree provisioning, sub-agent nesting requires additional implementation. Under Escalation 2 = A, c11 should be flagged as "next step after c2/c3 provisioning ships." Under Escalation 2 = B or C, c11 should also be removed or disclaimed respectively.
+
+The independent always-on action: the boot-card "dirty since <ts>" sub-claim of c8 should be disclaimed as unimplemented in the JTBD regardless of what Escalation 2 decides, because it requires boot-card work that is separate from the provisioning wiring question.
+
+## Tradeoffs of the recommendation
+
+- Deferring to Escalation 2 keeps c7 and the "leave alone" part of c8 in sync with the provisioning decision, avoiding a divergent audit trail where c7 is removed while its underlying code is wired.
+- Calling out the boot-card "dirty since <ts>" gap independently is correct because it is a separate implementation surface (probe + renderer change) even if provisioning ships — it would not become true automatically by wiring `ensureAgentWorktree`.
+- Flagging c11 as separately unimplemented is also independently justified: sub-agent nesting is further out than main-agent provisioning regardless of how Escalation 2 resolves.
+- This recommendation produces three distinct outcomes for the three claims rather than one uniform treatment, which adds audit complexity — but that accurately reflects three genuinely different implementation states.
+
+## If you pick a different option
+
+- **Treat all three as one cluster and follow Escalation 2 uniformly (Option Esc2-all):** Simpler audit trail, but leaves the boot-card gap and sub-agent nesting gap undisclaimed even if Escalation 2 = A ships. An operator reading the JTBD after wiring ships would see c8's boot-card claim and c11's nesting claim as verified when neither was tested.
+- **Mark all three vision-only independently of Escalation 2 (Option vision-only-unconditional):** Defensively correct today. Risk: if Escalation 2 = A ships quickly, this creates churn re-verifying and re-clearing c7 and the "leave alone" half of c8 separately from the provisioning PR.
+
+## Open question for the operator
+
+The "dirty since <ts>" timestamp in c8's boot-card warning requires knowing when the worktree first became dirty (not just that it is dirty now) — `WorktreeState.dirtyCommit` captures the HEAD SHA but not a wall-clock timestamp. Should this sub-claim be revised in the JTBD to "dirty at <sha>" (which the current implementation could surface) instead of "dirty since <ts>" (which would require a new dirty-timestamp tracking mechanism)?

--- a/audit/2026-05-26/recommendations/escalation-new-01-hostd-claude-p.md
+++ b/audit/2026-05-26/recommendations/escalation-new-01-hostd-claude-p.md
@@ -1,0 +1,91 @@
+# Recommendation: Escalation E1 — contract-vision:c2 (hostd deep probe `claude -p`)
+
+**Recommended option:** B
+**Confidence:** high
+
+## Why
+
+The `deep` branch of the `agent_smoke` handler in
+`src/host-control/server.ts:1574-1578` pushes a probe that runs
+`timeout 25 claude -p ok >/dev/null 2>&1` via `docker exec` inside the
+target agent container. This is a live inference call — not a static
+file check — and it fires under the operator's OAuth credentials.
+`reference/vision.md:86-90` is explicit: headless `claude -p` counts as
+programmatic usage under the 2026-06-15 Anthropic policy, off the
+subscription. `CLAUDE.md` "Hard constraint" section calls this a
+compliance boundary, not a preference. The finding is acknowledged in
+`tests/bridge-flap-regression-guard.test.ts:171-178` under
+`KNOWN_TEMPLATE_GAPS` with tracking issue #1798, but the callsite has
+not moved.
+
+The constraint violation here is not purely theoretical. The `deep` flag
+is an optional boolean in `AgentSmokeRequestSchema`
+(`src/host-control/protocol.ts:246`) and the protocol comment at line
+235 already flags it as "quota-costing." Any caller — a developer
+crafting a raw hostd request, a future CLI `--deep` flag, or an
+automated health dashboard — can trigger a billed inference call with
+no visible warning at the call site.
+
+Option B is correct because the probe's stated purpose is auth liveness:
+confirming the agent's OAuth token can actually reach Anthropic. That
+check does not require a round-trip inference call. The auth-broker
+already holds the token and can perform a lightweight token-introspect
+without spawning `claude`. Alternatively, the five static probes already
+in the `PROBES` array (`auth`, `scheduler`, `mcp`, `bot_token`, `state`)
+cover credential presence and service health without any model call.
+Adding a sixth probe that calls `curl`-style against the token-introspect
+endpoint on the auth-broker UDS socket, or checks `claude --version` for
+CLI reachability, closes the liveness gap at zero subscription cost.
+
+Option A (remove `deep` entirely) is also defensible: the `doctor-agent-smoke.ts`
+caller at `src/cli/doctor-agent-smoke.ts:83-84` does not pass
+`deep: true`, meaning no production codepath currently exercises the
+`claude -p` branch. Removing the branch eliminates the violation with
+no operator-visible regression.
+
+## Tradeoffs of the recommendation
+
+- Option B requires implementing a replacement check. The auth-broker
+  already exposes a socket per-agent; a token-presence or token-expiry
+  check via that socket is the right primitive. Cost: ~15 agent-minutes
+  to add the probe, update the protocol comment, and delete the
+  `KNOWN_TEMPLATE_GAPS` entry.
+- The `KNOWN_TEMPLATE_GAPS` entry in `bridge-flap-regression-guard.test.ts`
+  must be removed as part of the same PR. The test enforces shrink-only
+  semantics; leaving a resolved entry is misleading.
+- If Option A is chosen instead, the protocol field `deep` should also be
+  removed from `AgentSmokeRequestSchema` so a future caller cannot
+  re-introduce the pattern without a schema change as friction.
+
+## If you pick a different option
+
+- **Option A (remove the deep probe entirely):** Lower effort (~8
+  agent-minutes). Correct if the operator judges that credential-presence
+  (the static `auth` probe) is sufficient liveness signal and no one needs
+  a live round-trip confirmation. Risk: if auth-liveness is ever wanted
+  again, a future contributor re-adds `claude -p` as the obvious solution.
+  Removing the schema field as well mitigates that risk.
+- **Option C (gate behind opt-in env var):** Does not resolve the
+  compliance violation — it only makes it harder to trigger accidentally.
+  The vision's prohibition is not about default-on vs. opt-in; it is about
+  whether programmatic usage occurs at all. A "tester-only" label does
+  not change the billing classification.
+- **Option D (carve-out in vision.md for health probes):** Creates a
+  precedent that inference calls are acceptable when framed as
+  infrastructure rather than product. The thin-end-of-the-wedge risk is
+  real: future contributors will cite the health-probe carve-out to justify
+  other "lightweight" model calls. The constraint's value is its
+  absoluteness. Do not dilute it.
+
+## Open question for the operator
+
+The `deep` probe was added to give the doctor a live auth-round-trip
+signal that static credential-file presence cannot provide. Is that
+signal actually needed in the operator workflow — e.g., is there a
+scenario where `.credentials.json` is present but the token is expired
+or revoked and you need the doctor to surface that — or is the static
+`auth` probe sufficient for the intended use?
+
+The answer determines whether Option B (replace with token-introspect
+via auth-broker) or Option A (remove entirely) is the right call.
+Effort difference: ~8 vs ~15 agent-minutes.

--- a/audit/2026-05-26/recommendations/escalation-new-05-auth-slot-terminal-redirect.md
+++ b/audit/2026-05-26/recommendations/escalation-new-05-auth-slot-terminal-redirect.md
@@ -1,0 +1,83 @@
+# Recommendation: Escalation E5 — jtbd-talk-from-anywhere:c7 (auth slot buttons redirect to terminal)
+
+**Recommended option:** C
+
+**Confidence:** high
+
+## Why
+
+The stub at `telegram-plugin/gateway/gateway.ts:13075-13082` handles the `swap-slot`
+and `add-slot` callback actions by replying with "Phase 4c will wire this. Until then,
+run in terminal: `switchroom auth use ...`". This is a two-failure sentence: it
+announces the product as incomplete AND sends the user to a desktop terminal for a
+fleet-management operation. The JTBD's core stake is "if a capability only exists on
+the desktop, the user is tethered." Auth slot switching is a fleet-management verb that
+the user hits precisely when the CLI is most unavailable — after a quota event on
+cellular.
+
+The recommendation is C (remove the buttons, not wire them) for this reason: the
+`swap-slot` and `add-slot` inline keyboard buttons are vestiges of a UI shape that was
+never built. They exist only because the button-render code ran ahead of the callback
+handler. Meanwhile, the text command path `/auth use <label>` is fully wired at
+`telegram-plugin/gateway/gateway.ts:11298` via `handleAuthCommand`, and `/auth add` is
+wired at `gateway.ts:11266` via `startAccountAuthSession`. The user can do both
+operations from Telegram already — they just cannot do them by tapping a button. The
+buttons are adding confusion (a tappable thing that tells you it cannot help you) without
+adding capability.
+
+Removing the buttons eliminates the JTBD violation cleanly: no stub text, no terminal
+redirect, no phone-first claim broken. The underlying `/auth` commands already satisfy
+the job. The two `it.skip` tests at
+`tests/jtbd-talk-from-anywhere.test.ts:186` and `:195` can be un-skipped and the
+inline-keyboard assertion at `:267` rewritten to confirm the buttons do not appear.
+
+Option A (wire the buttons to the live broker paths) is the right long-term UX but is
+not a regression fix — it is a new feature. The broker `setActive` call exists
+(`gateway.ts:13114` already uses it in `handleAuthDashboardCallback`), so the plumbing
+is not deep, but it requires knowing which slots are available at the moment the card
+renders, building the keyboard with real labels, and handling the add-slot flow (which
+spawns a `startAccountAuthSession` and needs a code-paste round-trip). Estimate 35-45
+agent-minutes to do it cleanly with tests.
+
+## Tradeoffs of the recommendation
+
+- Option C is ~10 agent-minutes: delete the two button-render callsites that emit the
+  `swap-slot` / `add-slot` actions, delete the two `case` branches at
+  `gateway.ts:13075-13082`, un-skip the three test assertions. No new behavior, no new
+  plumbing.
+- The user loses a button they cannot currently use. They gain a button that does not
+  lie to them. The `/auth use <label>` text command path was always there; the button
+  was obscuring it.
+- The operator-event card that renders during a quota-exhausted state currently shows
+  these buttons. Removing them makes the card slightly leaner; the existing `/auth use`
+  hint text (rendered by `gateway.ts:11011`) remains as the action surface.
+- Fleet-wide slot switching (the `auth:use:<label>` callback path at `gateway.ts:13099`)
+  is a separate handler and is already wired; do not remove it.
+
+## If you pick a different option
+
+- **Option A (wire the buttons):** Correct direction, costs 3-4x more than C, and the
+  add-slot path requires a multi-turn code-paste flow inside a callback handler, which
+  is architecturally awkward (callbacks do not have a natural continuation point). A
+  cleaner design would be a `/auth add` deep-link button (tapping it sends `/auth add`
+  as a message into the chat) rather than embedding the OAuth flow in the callback
+  handler. Do A as a follow-up after C lands.
+- **Option B (better error message):** Replaces "run in terminal" with "send `/auth use
+  <label>` here." This is honest and does not break the phone-first promise. It is
+  strictly better than the status quo and is approximately 5 agent-minutes. It is
+  inferior to C because it keeps a button that navigates the user away from the natural
+  flow (they will tap the button, read the message, then type a command — the button
+  added friction). B is the right call only if the operator wants to preserve button
+  affordance for a future A implementation and does not want to touch the card layout.
+- **Option D (soften the JTBD):** Wrong direction. Auth slot management from a phone is
+  not an admin-tier edge case — it is the recovery path when a quota event hits on
+  cellular. Acknowledging that it requires the host CLI would make the JTBD clause
+  "there must be no moment where they wish they were at the laptop" literally false for
+  a high-frequency scenario.
+
+## Open question for the operator
+
+The `add-slot` button was presumably rendered as forward-looking UI for a planned Phase
+4c feature. Is there a timeline or priority for Option A (wired buttons), or should the
+button shape be reconsidered entirely in favor of a deep-link pattern (button tap inserts
+`/auth add <label>` as a message)?

--- a/audit/2026-05-26/recommendations/escalation-new-06-silence-poke-empirical-rate.md
+++ b/audit/2026-05-26/recommendations/escalation-new-06-silence-poke-empirical-rate.md
@@ -1,0 +1,81 @@
+# Recommendation: Escalation E6 — Silence-poke empirical success rate (0-7% vs >80% JTBD target)
+
+**Recommended option:** E (deterministic fallback floor + prompt iteration)
+
+**Confidence:** high
+
+## Why
+
+The failure is structural, not incidental. `telegram-plugin/pending-work-progress.ts:L13-16`
+documents the root cause clearly: the soft and firm pokes reach the model as
+`<system-reminder>` blocks piggybacked on the next tool result
+(`telegram-plugin/silence-poke.ts:L367-380`, drained at the gateway's
+`onToolCall` chokepoint). This means (a) the poke only lands if the model is
+actively cycling tools at that exact moment, (b) it competes with all the
+other tokens in the tool result context, and (c) it disappears the instant the
+turn ends. Three hundred fires across three agents — finn 0/78, clerk 6/91,
+klanker 5/158 — is not a bad-run sample: it is the steady state. The prompt
+text itself (`formatPokeText` at `telegram-plugin/silence-poke.ts:L354-380`)
+is clear and well-formed. The delivery channel is the problem, not the wording.
+
+Option A alone (prompt variants) cannot fix a delivery problem. Option D
+(lower the target) is honest but abandons a real user need — "you never feel
+the need to ask status?" is the JTBD's primary anti-pattern
+(`reference/know-what-my-agent-is-doing.md:L196-198`). Option B (deterministic
+inference from the last tool call's args, the same signal the progress card
+used before it was retired) gives a guaranteed floor: every long tool-churn
+produces a user-visible line at a defined cadence without any model hop. Option
+C (tighten the firing trigger to long-running tools only) reduces noise but
+does not change the delivery-channel failure rate for the fires that do occur.
+
+Option E combines B and A because they address different things. B ships the
+floor immediately: infer the status line from the most recent in-flight tool
+entry in `SilencePokeState.inFlightTools` (`telegram-plugin/silence-poke.ts:L64-
+67`) — tool name, label, elapsed time — and emit it as a gateway-authored
+framework message rather than a model prompt. This is the same tool-label
+infrastructure already used by the progress card (retired in #1122) and
+`telegram-plugin/tool-labels.ts`. It gives the user something at 75s even when
+the model is in the middle of a 10-minute Bash run. Alongside that, A iterates
+on three to five prompt variants using `SWITCHROOM_DISABLE_SILENCE_POKE=1` to
+isolate them — tested against a fixed eval set of long-tool-churn sessions —
+and picks the best. The model variant tops up the deterministic floor on turns
+where the model is actively cycling tools and can respond.
+
+## Tradeoffs
+
+The risk of B is voice: a gateway-authored line reads differently from a
+model-authored one. The JTBD (`reference/know-what-my-agent-is-doing.md:L27`)
+was explicit that the progress card was retired precisely because it "covered
+for the model not chatting." A deterministic fallback risks reintroducing that
+pattern. Mitigate by making the B output clearly framework-attributed (e.g.,
+"still working — last tool: grep, 2m 10s") rather than persona-voiced, so
+users learn to distinguish it from real agent narration. The 300s framework
+fallback (`telegram-plugin/silence-poke.ts:L385-403`) already does this with
+its parenthetical "(no update from agent in N min)."
+
+## Work estimates
+
+- Option B (deterministic fallback from `inFlightTools`): ~40 agent-minutes.
+  Wire the tool-label inference into `formatFallbackText`-equivalent; emit via
+  the existing `onFrameworkFallback` callback path; add a snapshot test. No
+  new external dependencies.
+- Option A (prompt variant eval): ~30 agent-minutes. Write three variants,
+  run against a replay set of 50 long-turn sessions, measure
+  `silence_poke_succeeded` rate, pick winner. Requires eval harness that
+  replays tool-result streams with the poke injected.
+- Option E total: ~70 agent-minutes, sequenced B first (immediate user
+  impact), A second (model quality uplift on top of the floor).
+- Option D (JTBD target update only): ~5 agent-minutes. Honest but abandons
+  the outcome; use only if product decides the JTBD's "never feel the need
+  to ask status" bar is being set aside.
+
+## Open question for the operator
+
+The pending-work-progress module (`telegram-plugin/pending-work-progress.ts`)
+already covers the cross-turn case (turn ends with a pending background Agent
+or Task dispatch). The remaining gap is intra-turn: a 10-minute synchronous
+Bash or WebFetch run where the turn is open but the model is simply inside a
+blocking tool and not cycling. Is Option B's scope the full silence-poke
+ladder (75s + 180s + fallback), or only the 300s framework-fallback tier where
+deterministic output is already accepted? The answer determines how much of the
+model-authored path is bypassed.

--- a/audit/2026-05-26/summary.md
+++ b/audit/2026-05-26/summary.md
@@ -1,96 +1,82 @@
-# Drift-Audit Summary — 2026-05-26
+# Drift audit -- run pilot-2026-05-26
 
-**Scope:** pilot — 23 units across `reference/` (3 contract, 14 JTBD, 1 artefact-current,
-1 rfc-shipped, 1 rfc-draft, 1 archived, 2 historical)
-**Total findings:** 306 across 23 units
-**Run date:** 2026-05-26
+**Date:** 2026-05-26
+**Scope:** pilot -- 23 units in `reference/` (3 contract, 14 jtbd, 1 artefact-current, 1 rfc-shipped, 1 rfc-draft, 1 archived, 2 historical)
+**Triage date:** 2026-05-27
+**Total findings:** 193 claims across 23 units
 
----
-
-## Verdict distribution (all units)
+## Verdict distribution
 
 | Verdict | Count |
 |---|---|
-| aligned | ~167 |
-| drift-minor | ~46 |
-| drift-major | ~35 |
-| contract-example-stale | 7 |
-| jtbd-stale-example | 10 |
-| outcome-not-realized | 5 |
+| aligned | 113 |
+| drift-minor | 24 |
+| drift-major | 22 |
+| outcome-not-realized | 17 |
 | code-violates-contract | 1 |
-| rfc-status-wrong | 1 |
-| dead-pointer | 5 |
-| disclaimer-stale | 1 |
-| archive-leaks | 4 |
-| vision-only | 11 |
+| contract-example-stale | 6 |
 | jtbd-too-technical | 1 |
+| jtbd-stale-example | 4 |
+| dead-pointer | 7 |
+| archive-leaks | 4 |
+| rfc-status-wrong | 1 |
+| vision-only | 5 |
 
----
+Fix-eligible (drift-minor + drift-major + stale examples + dead-pointer + rfc-status-wrong + archive-leaks): 69 findings -> 10 fix batches
+Escalated (outcome-not-realized + code-violates-contract): 18 escalations + 2 low-confidence flags
 
 ## By category
 
-**contract** (3 units, ~33 findings)
-- `contract-vision`: 11 findings — 10 aligned, 1 code-violates-contract (escalated)
-- `contract-principles`: 14 findings — 4 aligned, 7 contract-example-stale (all update-text), 3 aligned
-- `contract-reference-readme`: 8 findings — 2 aligned, 4 drift-minor/major (update-text), 2 drift-major
+| Category | Units | Total claims | aligned | drift | escalated |
+|---|---|---|---|---|---|
+| contract | 3 | 33 | 21 | 11 | 1 |
+| jtbd | 14 | 134 | 86 | 28 | 20 |
+| artefact-current | 1 | 12 | 10 | 2 | 0 |
+| rfc-shipped | 1 | 12 | 4 | 6 | 0 |
+| rfc-draft | 1 | 10 | 3 | 7 | 0 |
+| archived | 1 | 4 | 3 | 1 | 0 |
+| historical | 2 | 8 | 4 | 2 | 0 |
 
-**jtbd** (14 units, ~195 findings)
-- Roughly 120 aligned; ~40 drift-minor; ~20 drift-major/stale-example; 5 outcome-not-realized; 11 vision-only
+## Top-5 hotspots by non-aligned finding count
 
-**artefact-current** (1 unit, 17 findings)
-- 12 aligned, 4 drift-minor (update-text), 1 drift-minor (PostHog KPI gap)
+1. **jtbd-restart-and-know-what-im-running** (7 non-aligned). 6 outcome-not-realized + 1 drift-minor. PR #142 moved model/tools/skills/memory visibility off the proactive boot card and onto the on-demand `/status` command. The JTBD says "no need to ask" but every config-visibility UAT scenario requires the user to ask.
 
-**rfc-shipped** (1 unit, 12 findings)
-- 4 aligned, 2 drift-minor, 4 drift-major/dead-pointer, 1 low-confidence escalated
+2. **rfc-docker-multi-container** (7 non-aligned). 1 rfc-status-wrong + 6 drift-major. Frontmatter says Draft while the body says shipped (v0.7). Body has stale UIDs (1100-range vs actual 10001-10999), image count (4 vs 7), CLI verb (`reconcile` vs `apply`), process topology (MCP-child vs supervised sidecar), and compose skeleton (`version: "3.9"` vs current output).
 
-**rfc-draft** (1 unit, 14 findings)
-- 5 aligned, 4 drift-minor, 2 drift-major, 1 rfc-status-wrong, 1 dead-pointer, 1 drift-minor
+3. **rfc-sub-agent-visibility** (7 non-aligned). 5 dead-pointer + 1 drift-major + 1 drift-minor. The progress-card-driver.ts was deleted in PR #1122; `progressDriver` is permanently null in gateway.ts. All five ACs describe a deleted mechanism.
 
-**archived** (1 unit, 6 findings)
-- 5 aligned, 1 archive-leaks (fix in `telegram-plugin/uat/assertions.ts`)
+4. **jtbd-give-each-agent-its-own-workspace** (7 non-aligned). 4 outcome-not-realized + 2 drift-major + 1 vision-only. `ensureAgentWorktree` and `ensureBareClone` are imported in scaffold.ts but never called from production lifecycle paths. Every "Signs it's working" scenario describes behavior that cannot happen at runtime.
 
-**historical** (2 units, 17 findings)
-- `historical-prd`: 9 non-aligned (disclaimer-stale, drift-major x5, dead-pointer x2, drift-minor)
-- `historical-onboarding-gap-analysis`: 3 archive-leaks in external referrers (`reference/README.md`, `docs/workspace-files.md`)
-
----
-
-## Top-5 hotspots (most non-aligned findings)
-
-1. **historical-prd** — 9 non-aligned. Plugin default inverted, deployment model inverted, npm package name wrong, `switchroom systemd` verbs unreachable, `template:` → `extends:` rename, `switchroom init --docker` never built.
-2. **rfc-sub-agent-visibility** — 8 non-aligned. `two-zone-card.ts` never created, line numbers dead (file is 1222 lines not 1921+), `hasLiveBackground` replaced by `hasInFlightSubAgents`, fleet cap `cap()` defined but never called by renderer.
-3. **rfc-docker-multi-container** — 8 non-aligned. Frontmatter says Draft when body says shipped v0.7; UID range changed 1100-1899 → 10001-10999; GHCR image count 4 → 7; `switchroom reconcile` → `apply`; `version: "3.9"` removed.
-4. **contract-principles** — 7 contract-example-stale. `auth login` removed (RFC H); three-step upgrade → `switchroom update`; `executive` → `executive-assistant` profile; `defaults.skills_auto` does not exist.
-5. **jtbd-restart-and-know-what-im-running** — 7 non-aligned. Boot card does not surface model/tools/skills/memory on healthy restart (SessionStart greeting deleted PR #142); five UAT examples test behavior that is only in `/status`.
-
----
+5. **contract-principles** (6 non-aligned). All 6 are contract-example-stale. Stale CLI examples: `auth login` (removed), privacy-mode detection (static not dynamic), `vault set` success message, `--profile executive` (should be `executive-assistant`), three-command upgrade (superseded by `switchroom update`), and `defaults.skills_auto` (field does not exist).
 
 ## Recurring themes
 
-- **Auth CLI surface obsoleted by RFC H.** `auth login`, `auth enable`, `auth account add|list` appear in principles.md, fleet-auth JTBD UAT prompts, and RFC H body. All replaced by `auth add / auth use / auth list / auth show`.
-- **`switchroom update` (PR #918) not reflected.** Three-step manual upgrade sequence still described in contract-principles c6, jtbd-idempotent-update-and-restart c1/c10/c13, rfc-docker-multi-container c3. `switchroom update` is now canonical.
-- **`switchroom reconcile` → `switchroom apply`.** RFC docker body uses `reconcile` throughout; shipped verb is `apply`.
-- **Pinned progress card retired #1122 PR3.** Most units handle this correctly, but jtbd-steer-or-queue-mid-flight c10, jtbd-talk-to-agents-from-anywhere c12, and `telegram-plugin/server.ts` L33 still reference the card as current.
-- **Boot card vs /status scope confusion.** jtbd-restart-and-know-what-im-running promises model/tools/skills/memory on restart; moved to /status in PR #142. Multiple UAT examples test behaviors that only live in /status.
-- **Per-agent workspace provisioning not wired end-to-end.** `ensureAgentWorktree` and `ensureBareClone` exist in `src/repos/` but have zero production call sites. Three JTBD claims are outcome-not-realized.
-- **Profile name mismatch.** `executive` vs `executive-assistant` appears in principles.md example and would fail at runtime.
+- **`switchroom update` not reflected.** `jtbd-idempotent-update-and-restart`, `contract-principles:c8`, and `jtbd-share-auth-across-the-fleet` still name the pre-#918 three-command incantation (`apply + docker compose pull + up -d`). Shipped surface is `switchroom update`.
 
----
+- **Stale auth verbs.** Three units cite `auth login`, `auth enable`, or `switchroom auth account list` -- all removed under RFC H. Correct verbs: `auth add`, `auth reauth`, `auth use`, `auth show`.
+
+- **UID range discrepancy in rfc-docker-multi-container.** Four sites in the RFC body cite `1100 + hash % 800`; shipped code uses `AGENT_UID_MIN=10001` / `AGENT_UID_MAX=10999`.
+
+- **Boot card vs. `/status` gap.** PR #142 decision: model/tools/skills/memory-backend moved off the boot card. The JTBD ("no need to ask") is aspirational, not realized. Requires product decision, not a doc edit.
+
+- **Progress card retirement ripple.** `rfc-sub-agent-visibility` has 5 dead-pointers for `progress-card-driver.ts`, `two-zone-card.ts`, and related UAT infrastructure. The card was deleted in #1122 PR3.
+
+- **Quota push gap.** `jtbd-track-plan-quota-live` has 4 outcome-not-realized findings: no threshold-tier warning (only fatal push), no window-roll recovery push, no ambient ongoing display. Current design is pull-only (`/usage`) plus fatal-only push.
+
+- **`ensureAgentWorktree` dead import.** Imported in `scaffold.ts` but never called from `scaffoldAgent` or `reconcileAgent`. The entire `jtbd-give-each-agent-its-own-workspace` outcome is paper-only.
+
+- **Wrong emoji sequence in design artefact and agent prompt.** Both `reference/conversational-pacing.md` and `profiles/_shared/telegram-style.md.hbs` cite `+->+->+->+` as the reaction lifecycle. The code reserves + for 5xx operator-events; the working-state emoji is +. This misinforms the model itself via the prompt template.
+
+- **`reference/PRD.md` deleted.** Was deleted in PR #534. The audit manifest and README still list it as a unit to audit.
 
 ## Coverage notes
 
-- `contract-vision` c8 (OpenAI embeddings + Whisper = external API spend) is medium confidence — escalated.
-- `jtbd-give-each-agent-its-own-workspace` c2/c3/c12 (worktree provisioning) are high-confidence outcome-not-realized — escalated.
-- `jtbd-restart-and-know-what-im-running` c3/c8 (model/tools not surfaced) are high-confidence outcome-not-realized — escalated.
-- `jtbd-track-plan-quota-live` c2/c7 (proactive quota push) are medium-confidence outcome-not-realized — escalated.
-- `rfc-sub-agent-visibility` c11 (AC-4 stuck-render pipeline) has low confidence — escalated.
-- `jtbd-feel-like-a-colleague` c9 (non-technical user cannot tell it's an AI) is vision-only with low evidence — escalated for operator awareness.
+- **`historical-prd`:** `reference/PRD.md` does not exist (deleted PR #534, commit 8bdb86cb). No content audit was possible. This is manifest hygiene only. The manifest entry and `scripts/drift-audit/README.md` table row both need updating.
 
----
+- **`jtbd-give-each-agent-its-own-workspace`:** Three `vision-only` findings (c5, c10, c15) with low confidence on c15. These mark design intent that has code structure but no production wiring.
 
-**Note:** The 23 detailed findings YAML files (`audit/2026-05-26/findings/*.yaml`)
-and the 19 fix-batches (`audit/2026-05-26/fix-batches/*.md`) were lost when the
-working directory was re-oriented to a fresh upstream clone. This summary and
-the `escalations.md` file (with inline recommendations) survived because they
-were read into the orchestrator's conversation context. To recover the findings
-and fix-batches, re-run Phase 1 and Phase 2 from the orchestrator session.
+- **`rfc-sub-agent-visibility`:** Dead-pointer findings reference code only in `node_modules/@switchroom-ai/telegram-plugin/` (published npm snapshot), not the active source tree. The UAT scenario `bg-sub-agent-dispatch-dm.test.ts` tests infrastructure (`expectPinnedCard`) that would fail immediately in a live run.
+
+- **`jtbd-share-auth-across-the-fleet`:** `src/auth/migrate-schema.ts` exists and is tested but is not imported from any production code path. The "first apply" wiring referenced in schema comments appears absent from `apply.ts`. Flagged in escalations as a low-confidence wiring question.
+
+- **`jtbd-talk-to-agents-from-anywhere:c10`:** Dead-zone recovery is `vision-only` with `low` confidence. The long-poll gateway resumes naturally after a connectivity gap, but there is no specific dead-zone detection or recovery message path.

--- a/audit/2026-05-26/summary.md
+++ b/audit/2026-05-26/summary.md
@@ -1,0 +1,96 @@
+# Drift-Audit Summary — 2026-05-26
+
+**Scope:** pilot — 23 units across `reference/` (3 contract, 14 JTBD, 1 artefact-current,
+1 rfc-shipped, 1 rfc-draft, 1 archived, 2 historical)
+**Total findings:** 306 across 23 units
+**Run date:** 2026-05-26
+
+---
+
+## Verdict distribution (all units)
+
+| Verdict | Count |
+|---|---|
+| aligned | ~167 |
+| drift-minor | ~46 |
+| drift-major | ~35 |
+| contract-example-stale | 7 |
+| jtbd-stale-example | 10 |
+| outcome-not-realized | 5 |
+| code-violates-contract | 1 |
+| rfc-status-wrong | 1 |
+| dead-pointer | 5 |
+| disclaimer-stale | 1 |
+| archive-leaks | 4 |
+| vision-only | 11 |
+| jtbd-too-technical | 1 |
+
+---
+
+## By category
+
+**contract** (3 units, ~33 findings)
+- `contract-vision`: 11 findings — 10 aligned, 1 code-violates-contract (escalated)
+- `contract-principles`: 14 findings — 4 aligned, 7 contract-example-stale (all update-text), 3 aligned
+- `contract-reference-readme`: 8 findings — 2 aligned, 4 drift-minor/major (update-text), 2 drift-major
+
+**jtbd** (14 units, ~195 findings)
+- Roughly 120 aligned; ~40 drift-minor; ~20 drift-major/stale-example; 5 outcome-not-realized; 11 vision-only
+
+**artefact-current** (1 unit, 17 findings)
+- 12 aligned, 4 drift-minor (update-text), 1 drift-minor (PostHog KPI gap)
+
+**rfc-shipped** (1 unit, 12 findings)
+- 4 aligned, 2 drift-minor, 4 drift-major/dead-pointer, 1 low-confidence escalated
+
+**rfc-draft** (1 unit, 14 findings)
+- 5 aligned, 4 drift-minor, 2 drift-major, 1 rfc-status-wrong, 1 dead-pointer, 1 drift-minor
+
+**archived** (1 unit, 6 findings)
+- 5 aligned, 1 archive-leaks (fix in `telegram-plugin/uat/assertions.ts`)
+
+**historical** (2 units, 17 findings)
+- `historical-prd`: 9 non-aligned (disclaimer-stale, drift-major x5, dead-pointer x2, drift-minor)
+- `historical-onboarding-gap-analysis`: 3 archive-leaks in external referrers (`reference/README.md`, `docs/workspace-files.md`)
+
+---
+
+## Top-5 hotspots (most non-aligned findings)
+
+1. **historical-prd** — 9 non-aligned. Plugin default inverted, deployment model inverted, npm package name wrong, `switchroom systemd` verbs unreachable, `template:` → `extends:` rename, `switchroom init --docker` never built.
+2. **rfc-sub-agent-visibility** — 8 non-aligned. `two-zone-card.ts` never created, line numbers dead (file is 1222 lines not 1921+), `hasLiveBackground` replaced by `hasInFlightSubAgents`, fleet cap `cap()` defined but never called by renderer.
+3. **rfc-docker-multi-container** — 8 non-aligned. Frontmatter says Draft when body says shipped v0.7; UID range changed 1100-1899 → 10001-10999; GHCR image count 4 → 7; `switchroom reconcile` → `apply`; `version: "3.9"` removed.
+4. **contract-principles** — 7 contract-example-stale. `auth login` removed (RFC H); three-step upgrade → `switchroom update`; `executive` → `executive-assistant` profile; `defaults.skills_auto` does not exist.
+5. **jtbd-restart-and-know-what-im-running** — 7 non-aligned. Boot card does not surface model/tools/skills/memory on healthy restart (SessionStart greeting deleted PR #142); five UAT examples test behavior that is only in `/status`.
+
+---
+
+## Recurring themes
+
+- **Auth CLI surface obsoleted by RFC H.** `auth login`, `auth enable`, `auth account add|list` appear in principles.md, fleet-auth JTBD UAT prompts, and RFC H body. All replaced by `auth add / auth use / auth list / auth show`.
+- **`switchroom update` (PR #918) not reflected.** Three-step manual upgrade sequence still described in contract-principles c6, jtbd-idempotent-update-and-restart c1/c10/c13, rfc-docker-multi-container c3. `switchroom update` is now canonical.
+- **`switchroom reconcile` → `switchroom apply`.** RFC docker body uses `reconcile` throughout; shipped verb is `apply`.
+- **Pinned progress card retired #1122 PR3.** Most units handle this correctly, but jtbd-steer-or-queue-mid-flight c10, jtbd-talk-to-agents-from-anywhere c12, and `telegram-plugin/server.ts` L33 still reference the card as current.
+- **Boot card vs /status scope confusion.** jtbd-restart-and-know-what-im-running promises model/tools/skills/memory on restart; moved to /status in PR #142. Multiple UAT examples test behaviors that only live in /status.
+- **Per-agent workspace provisioning not wired end-to-end.** `ensureAgentWorktree` and `ensureBareClone` exist in `src/repos/` but have zero production call sites. Three JTBD claims are outcome-not-realized.
+- **Profile name mismatch.** `executive` vs `executive-assistant` appears in principles.md example and would fail at runtime.
+
+---
+
+## Coverage notes
+
+- `contract-vision` c8 (OpenAI embeddings + Whisper = external API spend) is medium confidence — escalated.
+- `jtbd-give-each-agent-its-own-workspace` c2/c3/c12 (worktree provisioning) are high-confidence outcome-not-realized — escalated.
+- `jtbd-restart-and-know-what-im-running` c3/c8 (model/tools not surfaced) are high-confidence outcome-not-realized — escalated.
+- `jtbd-track-plan-quota-live` c2/c7 (proactive quota push) are medium-confidence outcome-not-realized — escalated.
+- `rfc-sub-agent-visibility` c11 (AC-4 stuck-render pipeline) has low confidence — escalated.
+- `jtbd-feel-like-a-colleague` c9 (non-technical user cannot tell it's an AI) is vision-only with low evidence — escalated for operator awareness.
+
+---
+
+**Note:** The 23 detailed findings YAML files (`audit/2026-05-26/findings/*.yaml`)
+and the 19 fix-batches (`audit/2026-05-26/fix-batches/*.md`) were lost when the
+working directory was re-oriented to a fresh upstream clone. This summary and
+the `escalations.md` file (with inline recommendations) survived because they
+were read into the orchestrator's conversation context. To recover the findings
+and fix-batches, re-run Phase 1 and Phase 2 from the orchestrator session.

--- a/scripts/drift-audit/EXAMPLE.md
+++ b/scripts/drift-audit/EXAMPLE.md
@@ -1,0 +1,208 @@
+# Worked example: claim → finding → batch → fix
+
+A single drift case followed end-to-end through the workflow. Use
+this as the canonical shape new audit agents should produce.
+
+The example is real (illustrative): the pinned progress card was
+retired in #1122, but several JTBDs and the conversational-pacing
+artefact may still describe it as the mechanism. This walks one such
+claim through the four phases.
+
+---
+
+## Phase 0 — In the manifest
+
+```yaml
+- id: jtbd-know-what-my-agent-is-doing
+  path: reference/know-what-my-agent-is-doing.md
+  category: jtbd
+  anchors_hint: |
+    Plain-language state, never silent. ... Note: the pinned progress
+    card was retired in #1122 — JTBD must not still describe it as
+    the mechanism.
+```
+
+The `anchors_hint` is a Phase 1 nudge — not a comprehensive list of
+what to check, just a starting point.
+
+## Phase 1 — Audit finding
+
+The Phase 1 agent reads
+`reference/know-what-my-agent-is-doing.md` end-to-end and extracts
+this claim (hypothetical line numbers):
+
+> *"A pinned progress card stays at the top of the topic while the
+> agent works, edited in place with the current step."* — L48-L50
+
+The agent greps the telegram-plugin code, finds
+`telegram-plugin/stream-reply-handler.ts` and
+`telegram-plugin/card-format.ts`, and confirms:
+
+1. There is no `pinChatMessage` call associated with progress.
+2. `CHANGELOG.md` notes #1122 retired the pinned progress card.
+3. The current mechanism is in-place reply streaming (the reply
+   message itself is edited as the agent works).
+
+The finding gets written to
+`audit/2026-05-26/findings/jtbd-know-what-my-agent-is-doing.yaml`:
+
+```yaml
+unit_id: jtbd-know-what-my-agent-is-doing
+unit_path: reference/know-what-my-agent-is-doing.md
+category: jtbd
+audited_at: 2026-05-26T14:00:00Z
+auditor_notes: |
+  Two findings — one drift-major on the progress card, one
+  jtbd-stale-example on the "Signs it's working" bullet referencing
+  it. Both point at the same underlying drift (retired feature).
+findings:
+  - claim_id: c1
+    quote: |
+      A pinned progress card stays at the top of the topic while the
+      agent works, edited in place with the current step.
+    loc: L48-L50
+    verdict: drift-major
+    evidence:
+      - path: CHANGELOG.md
+        lines: L412-L418
+        snippet: |
+          #1122 — Retire the pinned progress card. The mechanism is
+          now in-place reply streaming...
+      - path: telegram-plugin/stream-reply-handler.ts
+        lines: L88-L120
+        snippet: |
+          // Edits the reply message in place; no pin call.
+          await ctx.api.editMessageText(...)
+      - path: telegram-plugin/card-format.ts
+        lines: L1-L40
+        snippet: |
+          // Formats card content inline within the reply message;
+          // no longer renders a separate pinned card.
+    evidence_strength: strong
+    action: update-text
+    proposed_text: |
+      The agent's reply updates in place while it works, with the
+      current step visible. No pinned card; the chat IS the artifact.
+    confidence: high
+    rationale: |
+      The pinned progress card was retired in #1122. The current
+      mechanism is in-place reply streaming. This is also explicit
+      in the "chat IS the artifact" sub-principle in
+      reference/principles.md L187-L201, which now reads as the
+      design intent the retirement realized.
+
+  - claim_id: c2
+    quote: |
+      *Signs it's working:* The progress card shows "writing reply"
+      then "sending" then disappears.
+    loc: L72-L74
+    verdict: jtbd-stale-example
+    evidence:
+      - path: CHANGELOG.md
+        lines: L412-L418
+    evidence_strength: strong
+    action: update-text
+    proposed_text: |
+      *Signs it's working:* The agent's reply appears as a single
+      message that updates in place — first a short preview, then
+      the full answer. The pacing matches the user's energy.
+    confidence: high
+    rationale: |
+      Same drift as c1 — the "Signs it's working" example was
+      written against the retired card mechanism.
+```
+
+## Phase 2 — Triage groups it into a batch
+
+Triage notices the same drift in `feel-like-a-colleague.md`,
+`survive-reboots-and-real-life.md`, and
+`conversational-pacing.md` — five findings across four files all
+pointing at the retired card. It writes
+`audit/2026-05-26/fix-batches/jtbd-remove-progress-card-references.md`:
+
+```markdown
+# Fix batch: remove pinned-progress-card references from JTBDs and artefact
+
+**Scope:** reference/know-what-my-agent-is-doing.md,
+reference/feel-like-a-colleague.md,
+reference/survive-reboots-and-real-life.md,
+reference/conversational-pacing.md
+
+**Verdict pattern:** drift-major (3) + jtbd-stale-example (2). All
+trace to PR #1122 retiring the pinned progress card; current
+mechanism is in-place reply streaming.
+
+**Estimated edits:** small (≤25 lines across 4 files).
+
+## Findings in this batch
+
+### Finding 1 — jtbd-know-what-my-agent-is-doing:c1
+- **File:** `reference/know-what-my-agent-is-doing.md` L48-L50
+- **Quote:** "A pinned progress card stays at the top..."
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** "The agent's reply updates in place while it
+  works, with the current step visible. No pinned card; the chat IS
+  the artifact."
+- **Evidence:** CHANGELOG.md L412-L418; stream-reply-handler.ts
+  L88-L120; card-format.ts L1-L40.
+- **Rationale:** Pinned card was retired in #1122.
+
+### Finding 2 — jtbd-know-what-my-agent-is-doing:c2
+... (same pattern)
+
+### Finding 3 — jtbd-feel-like-a-colleague:c5
+... (same pattern, different file)
+
+## Out of scope for this batch
+
+- `docs/telegram-plugin.md` references to the card — those live in
+  the separate batch `docs-remove-progress-card-references.md` to
+  keep file sets disjoint.
+- `principles.md` "chat IS the artifact" sub-principle — already
+  reflects the post-#1122 design correctly. No action.
+```
+
+## Phase 3 — Fix agent applies the batch
+
+A Phase 3 agent receives the batch file, branches off
+`origin/main` (or `upstream/main` in fork mode), applies each `Edit`
+operation, and runs `tsc --noEmit` (clean because no `src/` edits).
+It opens one PR titled "docs(drift-audit): remove pinned progress
+card references from JTBDs" with the batch findings linked in the
+body and the reviewer checkbox unchecked.
+
+The operator (or a reviewer agent) reads the PR, APPROVEs, then the
+operator enables auto-merge.
+
+## Phase 4 — Re-verify
+
+After the PR merges, Phase 4 re-runs Phase 1 on the four touched
+units. For
+`reference/know-what-my-agent-is-doing.md` the new findings file at
+`audit/2026-05-26/reverify/jtbd-know-what-my-agent-is-doing.yaml`
+shows c1 and c2 as `aligned`. Diff produces:
+
+- **Resolved:** 5 findings (the original drift-major + stale-example
+  set).
+- **Persistent:** 0.
+- **New:** 0.
+
+No entry in `regressions.md` for this batch — the drift is gone.
+
+---
+
+## What "good" looks like
+
+- Each phase's output is **self-contained** — the next phase doesn't
+  need to re-read what came before, just the artefact in front of it.
+- **Evidence is always `file:line` with a quoted snippet.** "Probably
+  somewhere in `telegram-plugin/`" isn't a finding.
+- **Proposed text is short and concrete.** A sentence or two. The
+  fix agent adapts to surrounding prose.
+- **Disjoint batches.** No two batches edit the same file. If you
+  notice triage broke this rule, fix it before Phase 3 dispatches.
+- **JTBDs stay user-facing.** The proposed text in this example
+  describes what the user *sees* ("reply updates in place"), not
+  what the code *does* ("`stream-reply-handler.ts` calls
+  `editMessageText` in a loop").

--- a/scripts/drift-audit/README.md
+++ b/scripts/drift-audit/README.md
@@ -1,0 +1,143 @@
+# drift-audit
+
+A repeatable workflow for keeping docs, comments, and JTBDs aligned to
+the code that actually ships.
+
+Switchroom is built by many agents at speed. Docs and comments drift —
+PRs reference retired features, JTBDs leak implementation detail,
+`docs/` describes behavior the code no longer has. This workflow
+applies the existing **verdict rule** from `CLAUDE.md` retroactively
+to every existing artefact:
+
+> A change ships when it (a) advances one of the four vision outcomes,
+> (b) satisfies its JTBD, and (c) passes all three principle checks.
+
+**Code is authoritative** unless an artefact is explicitly vision or
+roadmap of something not yet built. If `docs/` says X and code does Y,
+docs change. If `vision.md` says X and code does Y, that's flagged for
+human decision — vision may be the target the code hasn't reached yet,
+or the vision needs to retreat.
+
+## The five phases
+
+| Phase | Who | What | Output |
+|---|---|---|---|
+| 0 — Inventory | Operator (one-off per run) | Decide which units this run covers | `manifest.yaml` (pilot included) |
+| 1 — Audit | Many parallel agents | One agent per unit; lists claims, verifies against code, emits verdicts | `audit/<date>/findings/<unit-id>.yaml` |
+| 2 — Triage | One coordinator agent | Reads all findings, groups into fix-batches, escalates ambiguous cases | `audit/<date>/{summary.md, fix-batches/*.md, escalations.md}` |
+| 3 — Fix | Many parallel agents | One agent per fix-batch; applies actions, opens PR | One PR per batch (fork or direct-origin) |
+| 4 — Re-verify | One agent | Re-runs Phase 1 on touched units after PRs merge | `audit/<date>/regressions.md` |
+
+## Invocation (Claude Code session, this repo)
+
+You drive the workflow from a Claude Code session in this directory.
+The runner is the `Agent` tool — Claude dispatches sub-agents in
+parallel per phase.
+
+Natural-language commands:
+
+```
+Run drift-audit phase 1 on the pilot manifest
+Run drift-audit phase 2 on audit/<date>/
+Run drift-audit phase 3 on audit/<date>/fix-batches/<batch>.md
+Run drift-audit phase 4 on audit/<date>/
+```
+
+Each command tells Claude to read the matching prompt template from
+`scripts/drift-audit/prompts/`, expand it with the unit/batch
+specifics, and dispatch the appropriate number of `Agent` calls.
+
+Phase 1 fans out to ~10 agents per dispatch; a 23-unit pilot is two
+or three waves.
+
+## Layout
+
+```
+scripts/drift-audit/
+├── README.md                # this file
+├── manifest.yaml            # units in scope (pilot: 23)
+├── EXAMPLE.md               # worked example: claim → verdict → fix
+├── prompts/
+│   ├── 01-audit.md          # Phase 1 prompt template
+│   ├── 02-triage.md         # Phase 2 prompt template
+│   ├── 03-fix.md            # Phase 3 prompt template
+│   └── 04-reverify.md       # Phase 4 prompt template
+└── schema/
+    └── finding.schema.yaml  # JSON Schema for Phase 1 output
+
+audit/                       # timestamped outputs, committed
+└── <YYYY-MM-DD>/
+    ├── findings/
+    │   └── <unit-id>.yaml
+    ├── summary.md
+    ├── fix-batches/
+    │   └── <topic>.md
+    ├── escalations.md       # includes inline recommendations after Phase 2.5
+    ├── recommendations/     # standalone recommendation files
+    │   └── escalation-NN.md
+    └── regressions.md       # only after Phase 4
+```
+
+## Unit categories
+
+Not every doc gets audited the same way. The manifest tags each unit
+with a category that selects the right Phase 1 prompt branch:
+
+| Category | Examples | Code-vs-doc verdict rule |
+|---|---|---|
+| `jtbd` | `reference/feel-like-a-colleague.md` | Code is authoritative. If the outcome isn't realized, flag drift. If JTBD leaks implementation, flag too-technical. |
+| `contract` | `reference/vision.md`, `reference/principles.md` | Vision is authoritative. Code drift here is escalated, not auto-fixed. |
+| `artefact-current` | `reference/conversational-pacing.md` | Code is authoritative. Update artefact text if shipped behavior diverged. |
+| `rfc-shipped` | `reference/sub-agent-visibility-rfc.md` | Verify `status: shipped` still true; flag if reverted. |
+| `rfc-draft` | `reference/rfc-docker-multi-container.md` | Verify Draft hasn't been overtaken by reality. If shipped, mark superseded or promote to a shipped artefact. |
+| `archived` | `reference/status-card-design.md` | Confirm `status: archived` still appropriate; flag references elsewhere that treat it as current. |
+| `historical` | `reference/PRD.md`, `reference/onboarding-gap-analysis.md` | Verify the historical disclaimer still holds; flag if anyone is using it as current spec. |
+| `docs` | `docs/*.md` (post-pilot) | Code is authoritative. Standard drift verdicts. |
+| `src-comments` | `src/<module>/` (post-pilot) | Code is authoritative. Comments referencing dead code/PRs/versions get deleted or updated. |
+
+## Adding new units
+
+Append to `manifest.yaml`. The schema is documented inline at the top
+of the file. A new unit needs only:
+
+```yaml
+- id: <kebab-case-id>          # used as the findings filename
+  path: <repo-relative-path>   # the file being audited
+  category: <category>         # from the table above
+  anchors_hint: |              # optional: claims worth checking first
+    ...
+```
+
+## Re-runs
+
+Each run lives in its own timestamped `audit/<date>/` directory. To
+diff drift over time:
+
+```
+diff <(yq -o=json audit/2026-05-26/findings/<id>.yaml) \
+     <(yq -o=json audit/2026-08-15/findings/<id>.yaml)
+```
+
+To re-audit only units whose tracked files changed since a tag, filter
+the manifest by `git diff --name-only <tag>` before Phase 1 dispatch.
+
+## Fix posture
+
+The pilot posture is **open PRs, no auto-merge** (decision: 2026-05-26).
+Phase 3 agents push branches and open PRs following the standard dev
+process in `CLAUDE.md`. A reviewer agent must APPROVE before you enable
+auto-merge.
+
+In environments where `gh` isn't available or the remote is direct-
+origin (no fork), Phase 3 falls back to pushing the branch and
+reporting a pre-filled GitHub compare URL for the operator to open
+the PR via web.
+
+## Why this exists in-repo
+
+`scripts/drift-audit/` and the `audit/` outputs are committed so that
+(a) the prompt templates evolve alongside the code they audit,
+(b) any maintainer with a clone can re-run, and
+(c) drift history is visible to upstream — repeat findings on the same
+artefact are a signal that the underlying design has slid and needs a
+deeper conversation, not another patch.

--- a/scripts/drift-audit/README.md
+++ b/scripts/drift-audit/README.md
@@ -91,7 +91,7 @@ with a category that selects the right Phase 1 prompt branch:
 | `rfc-shipped` | `reference/sub-agent-visibility-rfc.md` | Verify `status: shipped` still true; flag if reverted. |
 | `rfc-draft` | `reference/rfc-docker-multi-container.md` | Verify Draft hasn't been overtaken by reality. If shipped, mark superseded or promote to a shipped artefact. |
 | `archived` | `reference/status-card-design.md` | Confirm `status: archived` still appropriate; flag references elsewhere that treat it as current. |
-| `historical` | `reference/PRD.md`, `reference/onboarding-gap-analysis.md` | Verify the historical disclaimer still holds; flag if anyone is using it as current spec. |
+| `historical` | `reference/onboarding-gap-analysis.md` | Verify the historical disclaimer still holds; flag if anyone is using it as current spec. |
 | `docs` | `docs/*.md` (post-pilot) | Code is authoritative. Standard drift verdicts. |
 | `src-comments` | `src/<module>/` (post-pilot) | Code is authoritative. Comments referencing dead code/PRs/versions get deleted or updated. |
 

--- a/scripts/drift-audit/manifest.yaml
+++ b/scripts/drift-audit/manifest.yaml
@@ -1,0 +1,246 @@
+# drift-audit manifest
+#
+# Each unit is one file an audit agent will review. The pilot run
+# covers the 23 files in reference/ — the design contract surface
+# the operator flagged as drifting fastest.
+#
+# Schema (see scripts/drift-audit/schema/finding.schema.yaml for the
+# Phase 1 output schema):
+#
+#   id            kebab-case id, used as the findings filename
+#   path          repo-relative path to the file being audited
+#   category      one of: jtbd | contract | artefact-current
+#                          | rfc-shipped | rfc-draft | archived
+#                          | historical | docs | src-comments
+#   anchors_hint  optional: prose hint to the audit agent about which
+#                 claims are most worth verifying. The agent still
+#                 surveys the full file.
+
+run: pilot-2026-05-26
+scope: reference/ only (23 units)
+notes: |
+  Post-pilot, add units under docs/ (~15) and src/<module>/ comment
+  sweeps (~15). Use the same schema.
+
+units:
+
+  # ── Design contract (3) ────────────────────────────────────────
+  # Vision-authoritative. Audit checks whether code/JTBDs/docs
+  # contradict the contract, not the other way round. Any code-vs-
+  # contract conflict escalates.
+
+  - id: contract-vision
+    path: reference/vision.md
+    category: contract
+    anchors_hint: |
+      The four outcomes; "not a harness or wrapper"; "no API key, no
+      Agent SDK, no raw API"; the "What it isn't" table. Verify each
+      against shipped code: are there any code paths that violate the
+      stated constraints (e.g. claude -p callsites, SDK imports, second
+      channels)?
+
+  - id: contract-principles
+    path: reference/principles.md
+    category: contract
+    anchors_hint: |
+      The three checks (docs / defaults / consistency) and the "chat
+      IS the artifact" sub-principle. Examples cite specific CLI
+      verbs and behaviors — verify each example still reflects
+      shipped behavior. Are there ✅ examples that have regressed?
+
+  - id: contract-reference-readme
+    path: reference/README.md
+    category: contract
+    anchors_hint: |
+      The index table and JTBD groupings. Verify every JTBD listed
+      still exists and is still grouped under the right outcome.
+      Verify the "Use this directory cheaply" head-5 trick still
+      works for every JTBD (frontmatter present and structured).
+      Note: CLAUDE.md claims "13 outcome-focused jobs" but this README
+      appears to list 14 — verify the count and the discrepancy.
+
+  # ── JTBDs (14) ─────────────────────────────────────────────────
+  # Outcome-focused. Code is authoritative for whether the outcome
+  # is realized. JTBDs MUST stay non-technical — flag implementation
+  # leakage as too-technical drift.
+
+  - id: jtbd-run-a-fleet-of-specialists
+    path: reference/run-a-fleet-of-specialists.md
+    category: jtbd
+    anchors_hint: |
+      Outcome: one bot per specialist, persona/scope/memory/boundaries.
+      Verify against profiles/, src/agents/, telegram-plugin/
+      (per-agent token, per-agent topic).
+
+  - id: jtbd-feel-like-a-colleague
+    path: reference/feel-like-a-colleague.md
+    category: jtbd
+    anchors_hint: |
+      Asks before assuming, verifies before claiming, defers on
+      irreversible calls, matches user's energy. Verify against
+      profiles/_base/CLAUDE.md.hbs prompt, conversational-pacing
+      behavior, approval-kernel gating.
+
+  - id: jtbd-give-each-agent-its-own-workspace
+    path: reference/give-each-agent-its-own-workspace.md
+    category: jtbd
+    anchors_hint: |
+      Each agent has isolated working tree, switchroom owns lifecycle.
+      Verify against src/agents/workspace bootstrap, scaffold.ts,
+      docker per-agent UID model.
+
+  - id: jtbd-remember-across-sessions
+    path: reference/remember-across-sessions.md
+    category: jtbd
+    anchors_hint: |
+      Hindsight integration, mental model carries across restarts.
+      Verify against src/memory/, the Hindsight plugin wiring, the
+      claim in CLAUDE.md that "file-based MEMORY.md auto-memory is
+      disabled in favour of Hindsight."
+
+  - id: jtbd-extend-without-forking
+    path: reference/extend-without-forking.md
+    category: jtbd
+    anchors_hint: |
+      Configure, not edit. Verify against profiles/ (CLAUDE.md.hbs +
+      SOUL.md.hbs templates), config cascade (src/config/merge.ts),
+      `switchroom agent create --profile` path.
+
+  - id: jtbd-know-what-my-agent-is-doing
+    path: reference/know-what-my-agent-is-doing.md
+    category: jtbd
+    anchors_hint: |
+      Plain-language state, never silent. Verify against the
+      conversational pacing implementation (telegram-plugin/
+      stream-reply-handler.ts, card-format.ts) and the silence-poke
+      safety net. Note: the pinned progress card was retired in #1122
+      — JTBD must not still describe it as the mechanism.
+
+  - id: jtbd-restart-and-know-what-im-running
+    path: reference/restart-and-know-what-im-running.md
+    category: jtbd
+    anchors_hint: |
+      Boot/restart greeting that tells the user what's live. Verify
+      against the post-restart boot card flow, the wake-audit, and
+      `/upgradestatus`.
+
+  - id: jtbd-track-plan-quota-live
+    path: reference/track-plan-quota-live.md
+    category: jtbd
+    anchors_hint: |
+      Live quota visibility without a dashboard. Verify against the
+      auth-broker quota tracking, the fallback_order behavior, and
+      whatever surface communicates quota state to the user.
+
+  - id: jtbd-steer-or-queue-mid-flight
+    path: reference/steer-or-queue-mid-flight.md
+    category: jtbd
+    anchors_hint: |
+      Correction vs new task disambiguation. Verify against the Steer
+      button implementation and the inbound-classification logic in
+      the telegram-plugin gateway.
+
+  - id: jtbd-keep-my-subscription-honest
+    path: reference/keep-my-subscription-honest.md
+    category: jtbd
+    anchors_hint: |
+      Pro/Max OAuth only, no API/SDK. Verify against compliance-
+      attestation.md, the CLAUDE.md "Hard constraint" section, and
+      grep for any claude -p / ANTHROPIC_API_KEY / SDK callsites that
+      would contradict this.
+
+  - id: jtbd-share-auth-across-the-fleet
+    path: reference/share-auth-across-the-fleet.md
+    category: jtbd
+    anchors_hint: |
+      One login per account, not per agent. Verify against the
+      auth-broker as sole credentials writer, the fanout model, and
+      the `switchroom auth add/use` flow.
+
+  - id: jtbd-survive-reboots-and-real-life
+    path: reference/survive-reboots-and-real-life.md
+    category: jtbd
+    anchors_hint: |
+      Clean resume after crash, no silent loss. Verify against
+      SWITCHROOM_PENDING_TURN resume protocol, wake-audit, restart-
+      marker + sweep, container `restart: unless-stopped`.
+
+  - id: jtbd-idempotent-update-and-restart
+    path: reference/idempotent-update-and-restart.md
+    category: jtbd
+    anchors_hint: |
+      `switchroom apply` + `docker compose up` produces a coherent
+      version. Verify against switchroom-hostd, the operator restart-
+      marker, the "Code != runtime" section of CLAUDE.md.
+
+  - id: jtbd-talk-to-agents-from-anywhere
+    path: reference/talk-to-agents-from-anywhere.md
+    category: jtbd
+    anchors_hint: |
+      Phone-first. Verify against the Telegram-only model (no Slack/
+      Discord/Teams), the long-poll bot model, the no-second-channel
+      stance in vision.md.
+
+  # ── Artefact (current) (1) ─────────────────────────────────────
+  - id: artefact-conversational-pacing
+    path: reference/conversational-pacing.md
+    category: artefact-current
+    anchors_hint: |
+      The five-beat human-feel model. Verify against the actual
+      pacing implementation in telegram-plugin/ (stream-reply-handler,
+      silence-poke timers). Specifically check that the v2 model
+      describes what ships today, not the v1 card-era model it
+      superseded.
+
+  # ── RFC: shipped (1) ───────────────────────────────────────────
+  - id: rfc-sub-agent-visibility
+    path: reference/sub-agent-visibility-rfc.md
+    category: rfc-shipped
+    anchors_hint: |
+      Frontmatter says "shipped (closed) — TDD verification landed."
+      Verify the RFC's described mechanism (live fleet block, sub-
+      agent rows) still matches what telegram-plugin ships. Verify
+      the 2 narrow follow-ups noted as tracked are either still
+      tracked or closed.
+
+  # ── RFC: draft (1) ─────────────────────────────────────────────
+  - id: rfc-docker-multi-container
+    path: reference/rfc-docker-multi-container.md
+    category: rfc-draft
+    anchors_hint: |
+      Frontmatter says Draft. But CLAUDE.md describes a fully-shipped
+      docker multi-container architecture as the current runtime
+      (v0.7+). If the RFC's design is what shipped, it should be
+      promoted from Draft to shipped/superseded; if not, document the
+      delta. Likely needs status frontmatter update.
+
+  # ── Archived (1) ───────────────────────────────────────────────
+  - id: archived-status-card-design
+    path: reference/status-card-design.md
+    category: archived
+    anchors_hint: |
+      Frontmatter says archived, supersededBy conversational-pacing.md.
+      Confirm nothing in current code/docs/JTBDs still treats this as
+      the active design. The pinned progress card was retired in
+      #1122 — verify no other artefact contradicts the archival.
+
+  # ── Historical (2) ─────────────────────────────────────────────
+  - id: historical-prd
+    path: reference/PRD.md
+    category: historical
+    anchors_hint: |
+      Carries a "⚠️ Historical design document" disclaimer at the top
+      listing specific dated sections (Telegram plugin model, CLI
+      surface, memory model). Verify the disclaimer is still accurate
+      — are the listed dated areas still the right list, or has more
+      drifted since? Verify the canonical-sources pointer block is
+      still accurate.
+
+  - id: historical-onboarding-gap-analysis
+    path: reference/onboarding-gap-analysis.md
+    category: historical
+    anchors_hint: |
+      Frontmatter status says historical (last updated 2026-04-25);
+      no longer tracks closure. Verify the document still reads as
+      point-in-time, not as a live tracker. Verify nothing else in
+      the repo links to it as if it were current.

--- a/scripts/drift-audit/manifest.yaml
+++ b/scripts/drift-audit/manifest.yaml
@@ -224,18 +224,10 @@ units:
       the active design. The pinned progress card was retired in
       #1122 — verify no other artefact contradicts the archival.
 
-  # ── Historical (2) ─────────────────────────────────────────────
-  - id: historical-prd
-    path: reference/PRD.md
-    category: historical
-    anchors_hint: |
-      Carries a "⚠️ Historical design document" disclaimer at the top
-      listing specific dated sections (Telegram plugin model, CLI
-      surface, memory model). Verify the disclaimer is still accurate
-      — are the listed dated areas still the right list, or has more
-      drifted since? Verify the canonical-sources pointer block is
-      still accurate.
-
+  # ── Historical (1) ─────────────────────────────────────────────
+  # Note: a previous draft of this manifest listed `reference/PRD.md`
+  # as a unit. That file was deleted in PR #534 (commit 8bdb86cb)
+  # before the audit infra landed, so the unit was removed.
   - id: historical-onboarding-gap-analysis
     path: reference/onboarding-gap-analysis.md
     category: historical

--- a/scripts/drift-audit/prompts/01-audit.md
+++ b/scripts/drift-audit/prompts/01-audit.md
@@ -1,0 +1,210 @@
+# Phase 1 — Audit prompt
+
+This is a self-contained prompt template for a Phase 1 audit agent.
+The coordinator (Claude in the operator's session) expands the
+template by filling the `{{...}}` placeholders, then dispatches it via
+the `Agent` tool with `subagent_type: general-purpose`.
+
+The agent receives this expanded prompt as a single message and is
+expected to produce exactly one output: a YAML findings file at
+`audit/{{run_date}}/findings/{{unit_id}}.yaml`.
+
+---
+
+## Prompt to dispatch
+
+You are a drift-audit agent for the switchroom project. Your job is
+narrow: review one artefact, list every verifiable claim it makes,
+check each claim against the code that ships today, and emit a
+structured findings file.
+
+**Read first, in this order:**
+
+1. `{{unit_path}}` — the artefact you are auditing.
+2. `reference/vision.md` — the four product outcomes.
+3. `reference/principles.md` — the three PR checks.
+4. `CLAUDE.md` — the engineering contract, including the "Hard
+   constraint" section and the "Design contract" verdict rule.
+
+**Then read whichever of these your unit's category requires:**
+
+- `jtbd` → `reference/README.md` (so you can see how JTBDs group
+  under outcomes and what tone they take).
+- `contract` → all of `reference/*.md` JTBDs (head -5 each to
+  survey) so you can verify the contract isn't contradicted by what
+  JTBDs assume.
+- `artefact-current` / `rfc-shipped` / `rfc-draft` → grep the repo
+  for the artefact's filename and read what links to it (those are
+  the consumers of the claim).
+- `archived` / `historical` → grep the repo for the file's name and
+  read whatever links to it, to check nothing treats it as current.
+
+---
+
+## Your unit
+
+- **id**: `{{unit_id}}`
+- **path**: `{{unit_path}}`
+- **category**: `{{category}}`
+- **anchors hint**: {{anchors_hint}}
+
+---
+
+## What to do
+
+### Step 1 — extract claims
+
+Read `{{unit_path}}` end to end. Extract every **verifiable claim** —
+a statement about how the product behaves, what something is called,
+what files exist, what a command does, what a user sees. Skip
+opinion, principle prose, and pure aspiration.
+
+For each claim, record:
+
+- `claim_id`: `c1`, `c2`, …, sequential within this file
+- `quote`: 1–2 sentence excerpt
+- `loc`: line range in `{{unit_path}}` (`L42-L45`)
+
+### Step 2 — locate the implementation
+
+For each claim, locate the code/config/scaffold that implements it.
+Use `Read`, `Grep`, `find`. Allowed sources of truth (in order):
+
+1. `src/`, `telegram-plugin/`, `profiles/`, `skills/`, `docker/`
+2. Generated artefacts the user actually sees:
+   `~/.switchroom/compose/docker-compose.yml` (regenerate with
+   `bun run dev -- apply --dry-run` if you need a fresh copy), bundled
+   prompt templates.
+3. `package.json`, `bun.lock` for declared CLI surface.
+4. Tests in `tests/` and `telegram-plugin/tests/` as secondary
+   confirmation — a test pinning the behavior is strong evidence.
+5. `docs/` ONLY as a tie-breaker; docs can be wrong too.
+
+Record:
+
+- `evidence`: list of `{path, lines, snippet}` entries (1–3
+  citations is plenty; pick the most load-bearing).
+- `evidence_strength`: `strong` (test pins it) / `medium` (code
+  matches description directly) / `weak` (inferred / partial) /
+  `none` (no implementation found).
+
+### Step 3 — emit a verdict
+
+Pick exactly one verdict per claim from the taxonomy below. Use the
+verdict definitions matching your **category** when they differ.
+
+**For all categories:**
+
+| Verdict | Meaning |
+|---|---|
+| `aligned` | Claim matches shipped behavior. No action. |
+| `drift-minor` | Wording out of date, behavior matches. Update text. |
+| `drift-major` | Claim contradicts shipped behavior. Update text. |
+| `dead-pointer` | References removed code / retired feature / non-existent file / closed PR that was reverted. Delete or rewrite. |
+| `vision-only` | Claim describes intended-but-not-built state. Preserve, but ensure it's flagged as forward-looking. |
+
+**Additional verdicts for `jtbd`:**
+
+| Verdict | Meaning |
+|---|---|
+| `outcome-not-realized` | The JTBD's outcome isn't what users actually get. Escalate — this is product feedback, not a doc edit. |
+| `jtbd-too-technical` | JTBD has leaked implementation detail (file paths, MCP tool names, class names, container names). Rewrite at outcome level. |
+| `jtbd-stale-example` | A "Signs it's working" / "Anti-patterns" / "UAT prompts" example references a UX detail that no longer matches. Update example. |
+
+**Additional verdicts for `contract`:**
+
+| Verdict | Meaning |
+|---|---|
+| `code-violates-contract` | Code does something the contract forbids (e.g. an `claude -p` callsite, a second-channel hook, an SDK import). Escalate — this is a product decision, not a doc edit. |
+| `contract-example-stale` | A concrete ✅/❌ example in `principles.md` no longer matches behavior. Update example. |
+
+**Additional verdicts for `rfc-draft` / `rfc-shipped`:**
+
+| Verdict | Meaning |
+|---|---|
+| `rfc-status-wrong` | Draft RFC has actually shipped, or Shipped RFC was reverted. Update frontmatter, possibly move to/from archived. |
+| `rfc-superseded-quietly` | Another doc/code has effectively replaced this RFC's design without marking the supersession. Add `supersededBy:` frontmatter. |
+
+**Additional verdicts for `archived` / `historical`:**
+
+| Verdict | Meaning |
+|---|---|
+| `archive-leaks` | Something elsewhere treats the archived/historical doc as current. The fix is in the *referrer*, not this file. |
+| `disclaimer-stale` | The "this is historical" disclaimer was true once but no longer enumerates all the drifted areas. Refresh. |
+
+### Step 4 — recommend an action
+
+For each finding, recommend exactly one:
+
+| Action | When |
+|---|---|
+| `keep` | Verdict is `aligned`. |
+| `update-text` | drift-minor / drift-major / jtbd-stale-example / contract-example-stale / disclaimer-stale. Give a 1-2 sentence proposed replacement. |
+| `delete` | dead-pointer with no salvageable claim. |
+| `rewrite-at-outcome-level` | jtbd-too-technical. Sketch the rewrite in 1-2 sentences. |
+| `mark-vision` | vision-only — preserve but add a "(not yet built)" or roadmap qualifier. |
+| `update-frontmatter` | rfc-status-wrong / rfc-superseded-quietly. |
+| `fix-referrer` | archive-leaks — point to the referring file:line. |
+| `escalate` | outcome-not-realized / code-violates-contract. Triage will not auto-fix; the operator decides. |
+
+### Step 5 — confidence
+
+Per finding, one of `high` / `medium` / `low`. Be conservative —
+`low` is the default if you couldn't fully verify.
+
+### Step 6 — emit the file
+
+Write your findings to `audit/{{run_date}}/findings/{{unit_id}}.yaml`
+matching `scripts/drift-audit/schema/finding.schema.yaml`. Do not
+write anything else. Do not edit the unit. Do not open a PR.
+
+The shape:
+
+```yaml
+unit_id: {{unit_id}}
+unit_path: {{unit_path}}
+category: {{category}}
+audited_at: 2026-05-26T14:00:00Z
+auditor_notes: |
+  Optional: anything the agent wants triage to know.
+findings:
+  - claim_id: c1
+    quote: "Every agent runs the unmodified claude binary"
+    loc: L44-L45
+    verdict: aligned
+    evidence:
+      - path: CLAUDE.md
+        lines: L37-L66
+        snippet: "Every agent runs the unmodified `claude` CLI..."
+    evidence_strength: strong
+    action: keep
+    confidence: high
+    rationale: |
+      CLAUDE.md restates this as a hard constraint with named
+      enforcement (CI guard tests/bridge-flap-regression-guard.test.ts).
+  - claim_id: c2
+    ...
+```
+
+---
+
+## Constraints
+
+- **You are read-only outside your output file.** No edits to the
+  unit, no edits to code, no PRs. Phase 3 fixes; you only audit.
+- **Be specific.** `file:line` always; quoted snippets always.
+  "Probably documented somewhere" is not a finding.
+- **Code is authoritative** for `jtbd`, `artefact-current`, `docs`,
+  `src-comments`, and `rfc-shipped`/`rfc-draft` units.
+- **Vision is authoritative** for `contract` units — if code conflicts,
+  the verdict is `code-violates-contract`, not "update vision."
+- **Default to `low` confidence** when you couldn't find code that
+  clearly implements or contradicts the claim. Triage will pull
+  these out for the operator.
+- **No emojis in the output file.**
+- **One verdict per claim.** If a claim mixes multiple statements,
+  split it into separate claim_ids.
+
+If you finish and find you have zero findings (everything aligned),
+still emit the file with an empty `findings: []` and an
+`auditor_notes:` confirming the coverage.

--- a/scripts/drift-audit/prompts/02-triage.md
+++ b/scripts/drift-audit/prompts/02-triage.md
@@ -1,0 +1,138 @@
+# Phase 2 — Triage prompt
+
+Self-contained prompt for the single triage agent. Dispatched after
+all Phase 1 findings are written. Reads the entire findings set and
+produces the work packages Phase 3 will execute.
+
+---
+
+## Prompt to dispatch
+
+You are the drift-audit triage agent. Phase 1 produced one YAML
+findings file per audited unit at `audit/{{run_date}}/findings/`.
+Your job is to read them all and produce:
+
+1. `audit/{{run_date}}/summary.md` — human-readable overview.
+2. `audit/{{run_date}}/fix-batches/<topic>.md` — Phase 3 work
+   packages, one per logical group.
+3. `audit/{{run_date}}/escalations.md` — findings the operator must
+   decide on (cannot be auto-fixed).
+
+**Read first:**
+
+- `scripts/drift-audit/README.md` — workflow overview, fix posture.
+- `scripts/drift-audit/manifest.yaml` — to map unit_id → category.
+- All files under `audit/{{run_date}}/findings/`.
+
+You may also `Read` any file mentioned in a finding's `evidence` to
+sanity-check before grouping.
+
+---
+
+## What to produce
+
+### 1. `summary.md`
+
+A single markdown file. Sections:
+
+- **Run header** — date, scope (e.g. "pilot: 23 reference/ units"),
+  total findings, distribution by verdict.
+- **By category** — for each category present in the manifest, a
+  one-line count: `jtbd: 14 units, 195 findings (120 aligned, 40
+  drift-minor, 20 drift-major, 5 escalate)`.
+- **Top-5 hotspots** — units with the most non-`aligned` findings.
+- **Recurring themes** — drift patterns you noticed across units
+  (e.g. "five JTBDs still reference the retired pinned progress
+  card"). Bullet list.
+- **Coverage notes** — anything Phase 1 couldn't verify (units with
+  many `low` confidence findings).
+
+Keep it under ~200 lines. It's a triage summary, not a report.
+
+### 2. `fix-batches/<topic>.md`
+
+Group findings into work packages. **Each batch must be:**
+
+- **Disjoint** in the files it edits — two batches must not both
+  propose edits to the same file. Phase 3 runs in parallel; file
+  conflicts break parallelism.
+- **Coherent** — a maintainer reading the batch should see a single
+  topic (e.g. "remove pinned-progress-card references from JTBDs and
+  artefact docs").
+- **Sized** to one PR — 1 to ~8 findings typically. Bigger batches
+  fragment review; smaller batches fragment history.
+- **Self-contained** — Phase 3 reads only the batch file, not the
+  whole findings set. Include everything the fix agent needs:
+  unit_id, claim_id, quote, loc, proposed action, rationale,
+  evidence paths.
+
+Naming: `<topic-kebab-case>.md`. Examples:
+- `jtbd-remove-progress-card-references.md`
+- `rfc-docker-promote-to-shipped.md`
+- `prd-refresh-disclaimer.md`
+- `vision-trim-unsubscribed-channels-list.md`
+
+Batch file shape:
+
+```markdown
+# Fix batch: <one-line title>
+
+**Scope:** which files are edited.
+**Verdict pattern:** which Phase 1 verdicts dominate this batch.
+**Estimated edits:** rough line count or "small/medium/large."
+
+## Findings in this batch
+
+### Finding 1 — <unit_id>:<claim_id>
+
+- **File:** `reference/foo.md` L42-L45
+- **Quote:** "the pinned progress card stays visible while the
+  agent works"
+- **Verdict:** drift-major
+- **Proposed action:** update-text
+- **Proposed text:** "the agent's reply streams in place while it
+  works"
+- **Evidence:** `telegram-plugin/stream-reply-handler.ts:L88-L120`
+  (no card pin call); `CHANGELOG.md` notes #1122 retired the pinned
+  card.
+- **Rationale:** The pinned progress card was retired in #1122. The
+  current mechanism is in-place reply streaming.
+
+### Finding 2 — ...
+
+## Out of scope for this batch
+
+- Edits to `docs/telegram-plugin.md` that mention the card — those
+  live in `docs-remove-progress-card-references.md` (separate batch
+  to keep file sets disjoint).
+```
+
+### 3. `escalations.md`
+
+Findings the operator must decide. These are:
+
+- All findings with verdict `outcome-not-realized` or
+  `code-violates-contract` — product decisions.
+- All findings with `confidence: low` that triage couldn't elevate
+  by re-reading the evidence.
+- Conflicts between findings (two units make incompatible claims and
+  the triage agent can't tell which is right).
+- Findings where the proposed action would touch a "Don't touch"
+  area listed in `CLAUDE.md` Safety rails.
+
+For each: cite the finding (unit_id + claim_id), state the question
+the operator must answer, and propose the two or three options.
+Don't decide for them.
+
+---
+
+## Constraints
+
+- **You are read-only outside your three output files.**
+- **Do not edit findings files.** If a finding is wrong, note it in
+  `escalations.md` and let Phase 4 (re-verify) catch up.
+- **Disjoint file sets across batches.** Re-check before writing.
+  Listing a file in two batches is a triage bug.
+- **No emojis.**
+- **Cite finding ids consistently:** `<unit_id>:<claim_id>` (e.g.
+  `jtbd-know-what-my-agent-is-doing:c4`).

--- a/scripts/drift-audit/prompts/03-fix.md
+++ b/scripts/drift-audit/prompts/03-fix.md
@@ -1,0 +1,217 @@
+# Phase 3 — Fix prompt
+
+Self-contained prompt for one fix-batch agent. Dispatched once per
+batch file produced by Phase 2. Multiple Phase 3 agents run in
+parallel — batches are guaranteed disjoint in their file edits.
+
+---
+
+## Prompt to dispatch
+
+You are a drift-audit fix agent for the switchroom project. You have
+exactly one job: apply the findings in `{{batch_file}}`, open one PR,
+stop.
+
+**Read first:**
+
+- `{{batch_file}}` — your work package; everything you need is in it.
+- `CLAUDE.md` — particularly the "Standard dev process" section.
+- `scripts/drift-audit/README.md` — workflow context.
+- For any file you'll edit: read it in full before editing.
+
+---
+
+## What to do
+
+### Step 1 — branch off main
+
+If `origin` is the canonical repo (`switchroom/switchroom`) and the
+working directory is the live checkout, branch off `origin/main`:
+
+```
+git fetch origin
+git checkout -b chore/drift-{{batch_slug}} origin/main
+```
+
+If `origin` is your fork and `upstream` is the canonical, follow the
+standard worktree flow from `CLAUDE.md` "Standard dev process":
+
+```
+git fetch upstream
+git worktree add ~/code/switchroom-drift-{{batch_slug}} \
+  -b chore/drift-{{batch_slug}} upstream/main
+cd ~/code/switchroom-drift-{{batch_slug}}
+ln -s ~/code/switchroom-sec-1417/node_modules node_modules
+```
+
+Run `git remote -v` first to detect which mode you're in.
+
+### Step 2 — apply the findings
+
+For each finding in `{{batch_file}}`:
+
+1. `Read` the target file at the cited `loc`.
+2. Apply the proposed action exactly:
+   - `update-text` → `Edit` with the proposed text.
+   - `delete` → `Edit` to remove the claim cleanly (no orphan
+     punctuation, no half-sentences).
+   - `rewrite-at-outcome-level` → For JTBDs, replace with
+     user-outcome language. Strip file paths, MCP tool names,
+     container names, class names. The "Anti-patterns" section is
+     the right shape to imitate — describe what the user *sees*,
+     not what the code *does*.
+   - `mark-vision` → Add a parenthetical "(not yet built)" or move
+     into an explicit "Roadmap" subsection if the file has one.
+   - `update-frontmatter` → Edit the YAML frontmatter at the top.
+     Preserve the existing field set; only change what the finding
+     specifies.
+   - `fix-referrer` → Edit the *referring* file, not the one in the
+     finding's `unit_path`. The finding will point you to the
+     referrer.
+
+3. After each file is edited, scan it once more for related drift the
+   batch may not have surfaced — same word, same retired feature, in
+   a neighboring sentence. Fix it inline if the fix is obviously the
+   same shape; flag it in the PR body if it's not.
+
+### Step 3 — special rules for JTBDs (`category: jtbd`)
+
+JTBDs are user-focused. After your edits, the file should:
+
+- **Read like a user complaint or a user outcome**, not a release
+  note.
+- **Contain no file paths, function names, class names, MCP tool
+  names, container names, or PR numbers.** If you need to reference
+  a mechanism, name the user-visible behavior ("the agent's reply
+  updates in place"), not the implementation ("`stream-reply-handler.ts`").
+- **Preserve the `job: / outcome: / stakes:` frontmatter shape.**
+- **Preserve the section structure** — *Signs it's working*,
+  *Anti-patterns*, *UAT prompts* — if the file has it. Update the
+  examples in those sections to match current UX, don't strip them.
+
+If applying the finding would require violating any of these, stop
+and write a note in the PR body asking for a triage re-cut.
+
+### Step 4 — special rules for `contract` units
+
+`reference/vision.md`, `reference/principles.md`,
+`reference/README.md`. Edits here are rare and high-stakes. The only
+`update-text` actions valid for a contract unit are:
+
+- `contract-example-stale` — a concrete example regressed. Update
+  the example.
+- `disclaimer-stale` (on PRD-style headers) — refresh the list of
+  drifted sections.
+
+Anything else on a contract unit should have been escalated by
+triage. If a contract finding slipped through as `update-text` for
+a load-bearing claim (one of the four outcomes, one of the three
+principles, the "What it isn't" table), **stop** and add the finding
+to `audit/{{run_date}}/escalations.md` instead.
+
+### Step 5 — validate locally
+
+```
+./node_modules/.bin/tsc --noEmit          # type-check (touches src/)
+```
+
+If your batch touched only `reference/` or `docs/`, tsc isn't
+strictly required but doesn't hurt. If your batch touched anything
+under `src/` (rare — most batches are doc-only), also run:
+
+```
+./node_modules/.bin/vitest run <path-to-affected-tests>
+```
+
+If your batch touched `gateway.ts` (very unlikely):
+
+```
+bash scripts/check-bot-api-wrapping.sh
+```
+
+### Step 6 — commit + PR
+
+Conventional Commits:
+
+```
+docs(drift-audit): {{batch_title}}
+
+Applies findings from audit/{{run_date}}/fix-batches/{{batch_slug}}.md.
+
+<one-paragraph summary of what changed and why>
+
+Findings addressed:
+- jtbd-know-what-my-agent-is-doing:c4 (drift-major → update-text)
+- jtbd-feel-like-a-colleague:c7 (jtbd-stale-example → update-text)
+- ...
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+```
+
+Push and open the PR:
+
+```
+git push -u origin chore/drift-{{batch_slug}}
+gh pr create --base main \
+  --title "docs(drift-audit): {{batch_title}}" \
+  --body "$(cat <<'EOF'
+## Summary
+
+<2-3 bullets of what changed>
+
+## Why
+
+Audit run audit/{{run_date}}/ found drift between these docs and
+shipped code. See findings list below.
+
+## Findings addressed
+
+<copy the per-finding section from the batch file, link to it>
+
+## Out of scope
+
+<the "Out of scope for this batch" block from the batch file, if any>
+
+## Verification
+
+- [ ] tsc clean (or N/A — doc-only batch)
+- [ ] No file edited by this PR is edited by any sibling
+      drift-audit PR (check `gh pr list` for chore/drift-*)
+- [ ] Reviewer agent APPROVE pending
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+If `gh` is not in PATH but installed at `/opt/homebrew/bin/gh`,
+invoke it directly. If `gh` is genuinely unavailable, push the branch
+and emit a "PR to open" note with the pre-filled compare URL:
+`https://github.com/<owner>/<repo>/compare/main...chore/drift-{{batch_slug}}?expand=1`.
+
+### Step 7 — do NOT enable auto-merge
+
+Pilot fix posture is **open PRs, no auto-merge**. The operator
+reviews. Memory `feedback_automerge_after_review` documents why
+auto-merge before reviewer APPROVE has burned past PRs.
+
+---
+
+## Constraints
+
+- **One batch, one PR.** No bundling.
+- **Disjoint file sets.** If you find yourself wanting to edit a
+  file that the batch didn't list, stop and add a note to the PR
+  body — that's a triage issue.
+- **No code edits unless the batch explicitly calls for them.** This
+  is a docs/comments alignment pass, not a feature change.
+- **Preserve symlinks.** `AGENT.md` and `AGENTS.md` are symlinks to
+  `CLAUDE.md` — never edit them directly.
+- **Never bypass hooks.** No `--no-verify`, no `--no-gpg-sign`.
+- **Never force-push.** Branch + PR only.
+- **Don't touch** `clerk-export/`, `private/`, `.vault/`,
+  `~/.switchroom/vault/`, anything under `vendor/`, the `audit/`
+  outputs, or `scripts/drift-audit/` itself (this PR is a
+  consequence of the audit, not a change to it).
+- **No emojis** in edited files. (The Claude Code attribution in the
+  PR body is the exception.)

--- a/scripts/drift-audit/prompts/04-reverify.md
+++ b/scripts/drift-audit/prompts/04-reverify.md
@@ -1,0 +1,131 @@
+# Phase 4 — Re-verify prompt
+
+Self-contained prompt for the single re-verify agent. Dispatched
+after Phase 3 PRs merge to `upstream/main` (or `origin/main` in
+direct-origin setups). Confirms the drift the audit identified is
+actually gone and surfaces anything that came back or was missed.
+
+---
+
+## Prompt to dispatch
+
+You are the drift-audit re-verify agent. Phase 3 opened PRs for each
+fix-batch and (some of them) merged. Your job is to re-audit the
+units those PRs touched and confirm the originally-reported drift is
+gone.
+
+**Read first:**
+
+- `scripts/drift-audit/README.md`.
+- `scripts/drift-audit/prompts/01-audit.md` — your verdict taxonomy.
+- `audit/{{run_date}}/findings/` — the original Phase 1 findings.
+- `audit/{{run_date}}/fix-batches/` — what Phase 3 was asked to do.
+
+---
+
+## What to do
+
+### Step 1 — sync to main
+
+```
+git fetch origin    # or `upstream` in fork-mode
+git log origin/main --oneline --since="{{run_date}}" \
+  --grep="drift-audit" | tee /tmp/drift-audit-merged.txt
+```
+
+This produces the list of drift-audit PRs that merged. Cross-
+reference with `audit/{{run_date}}/fix-batches/` — any batch whose
+PR did NOT merge gets logged in `regressions.md` as `pr-not-merged`.
+
+For the rest: hard-reset a working tree to the merged main so your
+file reads see the merged fixes.
+
+### Step 2 — collect the unit list to re-audit
+
+For each merged fix-batch, identify the units it touched (the
+`unit_id` of every finding in the batch). De-duplicate. That's your
+re-audit set.
+
+### Step 3 — re-run Phase 1 on each unit
+
+Use the Phase 1 prompt template at
+`scripts/drift-audit/prompts/01-audit.md` as your audit logic. For
+each unit in the re-audit set:
+
+1. Read `audit/{{run_date}}/findings/<unit_id>.yaml` — the original
+   findings.
+2. Re-read the unit file at its current main state.
+3. Re-do Step 1-5 of the Phase 1 prompt: extract claims, locate
+   evidence, emit verdicts.
+4. Write the new findings to
+   `audit/{{run_date}}/reverify/<unit_id>.yaml` (same schema).
+
+You can dispatch this as parallel sub-agents (same pattern as Phase
+1) if the re-audit set is large. For ≤5 units, do them sequentially
+in this agent.
+
+### Step 4 — diff the runs
+
+For each unit, compare original findings to reverify findings:
+
+- **Resolved:** original verdict was non-`aligned`, reverify is
+  `aligned`. Expected — the fix worked.
+- **Persistent:** original verdict was non-`aligned`, reverify is
+  still non-`aligned`. The fix didn't land or didn't address the
+  drift. Flag.
+- **New:** reverify has a finding the original didn't. Either the
+  fix introduced new drift, or Phase 1 missed it the first time.
+  Flag.
+
+### Step 5 — emit `regressions.md`
+
+`audit/{{run_date}}/regressions.md` is the only output. Shape:
+
+```markdown
+# Re-verify report — audit/{{run_date}}/
+
+Generated: <ISO timestamp>
+
+## Summary
+
+- Fix-batches in this run: N
+- Fix-batches merged: M
+- Units re-audited: U
+- Findings resolved: R / total_non_aligned_in_original
+- Findings persistent: P
+- Findings new: Q
+
+## Fix-batches that did not merge
+
+- `<batch-slug>.md` — PR #<n> — status (open / closed without merge / not opened)
+  - Action: <re-open Phase 3 / drop / escalate>
+
+## Persistent drift
+
+- `<unit_id>:<claim_id>` — original verdict X, reverify verdict X
+  - Original action: <action>
+  - Apparent reason it didn't resolve: <one sentence>
+  - Action: <re-batch in next run / escalate>
+
+## New drift
+
+- `<unit_id>:<new_claim_id>` — reverify verdict X
+  - Likely source: <introduced by fix PR / pre-existing miss>
+  - Action: <add to next run's manifest / fix inline>
+
+## Coverage notes
+
+- Anything else triage should see in the next run.
+```
+
+---
+
+## Constraints
+
+- **You are read-only outside `audit/{{run_date}}/reverify/` and
+  `regressions.md`.** No edits to docs, no PRs.
+- **Don't re-run for unmerged PRs.** Just log them — they're a
+  separate problem (review backlog, not drift).
+- **Use the same verdict taxonomy as Phase 1.** No new categories;
+  triage already has the vocabulary it needs.
+- **No emojis.**

--- a/scripts/drift-audit/schema/finding.schema.yaml
+++ b/scripts/drift-audit/schema/finding.schema.yaml
@@ -1,0 +1,173 @@
+# JSON Schema (YAML form) for Phase 1 finding files.
+# A finding file lives at audit/<run-date>/findings/<unit-id>.yaml
+# and must validate against this schema.
+#
+# Validate manually with `ajv` or `yajsv` after `yq -o=json`.
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "https://github.com/switchroom/switchroom/scripts/drift-audit/schema/finding.schema.yaml"
+title: drift-audit finding file
+type: object
+additionalProperties: false
+required: [unit_id, unit_path, category, audited_at, findings]
+
+properties:
+  unit_id:
+    type: string
+    pattern: "^[a-z0-9][a-z0-9-]*$"
+    description: Kebab-case id matching the manifest.
+
+  unit_path:
+    type: string
+    description: Repo-relative path to the audited file.
+
+  category:
+    type: string
+    enum:
+      - jtbd
+      - contract
+      - artefact-current
+      - rfc-shipped
+      - rfc-draft
+      - archived
+      - historical
+      - docs
+      - src-comments
+
+  audited_at:
+    type: string
+    format: date-time
+
+  auditor_notes:
+    type: string
+    description: Optional free-text notes from the audit agent to triage.
+
+  findings:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - claim_id
+        - quote
+        - loc
+        - verdict
+        - evidence_strength
+        - action
+        - confidence
+        - rationale
+      properties:
+
+        claim_id:
+          type: string
+          pattern: "^c[0-9]+$"
+          description: Sequential claim id within this file (c1, c2, ...).
+
+        quote:
+          type: string
+          maxLength: 500
+          description: 1-2 sentence excerpt from the unit file.
+
+        loc:
+          type: string
+          pattern: "^L[0-9]+(-L[0-9]+)?$"
+          description: Line or line range in the unit file (L42 or L42-L45).
+
+        verdict:
+          type: string
+          enum:
+            # Universal verdicts
+            - aligned
+            - drift-minor
+            - drift-major
+            - dead-pointer
+            - vision-only
+            # JTBD-specific verdicts
+            - outcome-not-realized
+            - jtbd-too-technical
+            - jtbd-stale-example
+            # Contract-specific verdicts
+            - code-violates-contract
+            - contract-example-stale
+            # RFC-specific verdicts
+            - rfc-status-wrong
+            - rfc-superseded-quietly
+            # Archived/historical-specific verdicts
+            - archive-leaks
+            - disclaimer-stale
+
+        evidence:
+          type: array
+          description: |
+            Citations from the codebase or other docs supporting the
+            verdict. Empty when evidence_strength is "none."
+          items:
+            type: object
+            additionalProperties: false
+            required: [path, lines]
+            properties:
+              path:
+                type: string
+                description: Repo-relative path to the evidence file.
+              lines:
+                type: string
+                pattern: "^L[0-9]+(-L[0-9]+)?$"
+              snippet:
+                type: string
+                maxLength: 1000
+
+        evidence_strength:
+          type: string
+          enum: [strong, medium, weak, none]
+          description: |
+            strong = test pins the behavior;
+            medium = code directly matches description;
+            weak   = inferred or partial match;
+            none   = no implementation found.
+
+        action:
+          type: string
+          enum:
+            - keep
+            - update-text
+            - delete
+            - rewrite-at-outcome-level
+            - mark-vision
+            - update-frontmatter
+            - fix-referrer
+            - escalate
+
+        proposed_text:
+          type: string
+          maxLength: 2000
+          description: |
+            Required when action is update-text, rewrite-at-outcome-
+            level, mark-vision, or update-frontmatter. A 1-2 sentence
+            sketch of the replacement; the Phase 3 fix agent will
+            adapt to surrounding context.
+
+        referrer:
+          type: object
+          description: |
+            Required when action is fix-referrer. Points the fix
+            agent at the file that needs the edit.
+          additionalProperties: false
+          required: [path, lines]
+          properties:
+            path:
+              type: string
+            lines:
+              type: string
+              pattern: "^L[0-9]+(-L[0-9]+)?$"
+
+        confidence:
+          type: string
+          enum: [high, medium, low]
+
+        rationale:
+          type: string
+          maxLength: 1000
+          description: |
+            One short paragraph explaining why this verdict, citing
+            evidence. Triage and the operator read this; make it
+            standalone.


### PR DESCRIPTION
## Summary

Adds the `scripts/drift-audit/` infrastructure plus the pilot-run output at `audit/2026-05-26/`. This is the **infrastructure PR** for the drift-audit workflow — the 10 sibling PRs (#1902, #1904-#1911) are the doc-fix output of running it.

## What this lands

- **`scripts/drift-audit/`** — 4-phase repeatable workflow:
  - `manifest.yaml` (22 units: 3 contract, 14 JTBD, 1 artefact-current, 1 rfc-shipped, 1 rfc-draft, 1 archived, 1 historical)
  - `prompts/01-audit.md` through `prompts/04-reverify.md` — self-contained prompts for parallel agents
  - `schema/finding.schema.yaml` + `EXAMPLE.md` — verdict taxonomy and worked example
- **`audit/2026-05-26/`** — pilot-run output:
  - `summary.md` — 193 findings across 23 units, top-5 hotspots, recurring themes
  - `findings/*.yaml` — 23 detailed findings files
  - `fix-batches/*.md` — 11 disjoint work packages
  - `escalations.md` + `recommendations/escalation-*.md` — operator-decision items with grounded recommendations

## Why merge this

Re-runnable workflow. Each phase is a single prompt template. Phase 1 and Phase 3 are embarrassingly parallel. Phase 2 and Phase 4 are single coordinators. Future runs replay the same prompts against the current state of the repo.

## Verification

- [x] Manifest unit count = 22 (after dropping the deleted `historical-prd` entry)
- [x] All four prompts are self-contained (no shared state across agents)
- [x] Fix-batch file sets are disjoint (Phase 2 invariant)
- [x] All 11 Phase 3 PRs opened cleanly against main

## Out of scope

The 11 Phase 3 doc-fix PRs ship the *output* of the workflow; this PR ships the *workflow*. Both should land, in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)