### PR TITLE
docs(drift-audit): align idempotent-update JTBD with switchroom update verb

### DIFF
--- a/reference/idempotent-update-and-restart.md
+++ b/reference/idempotent-update-and-restart.md
@@ -1,18 +1,19 @@
 ---
 job: update switchroom and trust that everything is actually running the new version, no manual checks
-outcome: After the upgrade flow finishes (`switchroom apply` + `docker compose pull` + `docker compose up -d --remove-orphans`), the entire stack — CLI, agent containers, broker, kernel, scheduler, MCP servers, memory backend — is at the version switchroom declared and tested as a unit. After any restart, the agent comes back with fresh code, fresh MCP servers, fresh settings, and intact context (recent messages, memory, today's plan). The user does not lose their thread.
+outcome: After running `switchroom update`, the entire stack — CLI, agent containers, broker, kernel, scheduler, hostd, MCP servers, bundled skills, memory backend — is at the version switchroom declared and tested as a unit. After any restart, the agent comes back with fresh code, fresh MCP servers, fresh settings, and intact context. The user does not lose their thread.
 stakes: If `update` quietly leaves stale processes running, the user thinks they're talking to a new agent and they're talking to last week's. Bugs come back from the dead. New features advertised in the changelog don't actually load. The user loses faith that the version reported by the CLI matches reality. Updates become a thing to dread.
 ---
 
 # The job
 
-The user runs the upgrade flow (`switchroom apply` + `docker compose
-pull` + `docker compose up -d --remove-orphans`). Maybe they're picking
-up a bug fix. Maybe a dependency security advisory landed. Maybe a new
-feature shipped. The job is for the next agent reply to be backed by
-the new version of *everything* — without the user having to know which
+The user runs `switchroom update`. Maybe they're picking up a bug fix.
+Maybe a dependency security advisory landed. Maybe a new feature
+shipped. The job is for the next agent reply to be backed by the new
+version of *everything* — without the user having to know which
 processes survive a restart, which dependencies are pinned where, or
-which container secretly held a stale handle.
+which service secretly held a stale handle. Under the hood, the command
+pulls new images, refreshes scaffolds, recreates containers, and runs a
+post-bounce health sweep — but the user only needs to know one verb.
 
 The same is true for restarts. When a unit restarts, the agent should
 come back as a fresh process with current settings, not a zombie of
@@ -36,10 +37,12 @@ of GHCR images. No piece moves on its own.
 - The version reported by the CLI matches the version actually loaded
   into every running process. `switchroom doctor` confirms with a
   green check.
-- A user can re-run `switchroom apply` + `docker compose up -d` and
-  `switchroom agent restart` any number of times, in any order, and
-  end up in the same valid state every time. No accumulating side
-  effects. No "if you did X, now you have to do Y to fix it."
+- A user can re-run `switchroom update` any number of times and end up
+  in the same valid state every time. No accumulating side effects. No
+  "if you did X, now you have to do Y to fix it." Operators who want
+  finer control can still run `switchroom apply`, `docker compose pull`,
+  and `docker compose up -d --remove-orphans` individually — each step
+  is idempotent on its own.
 - After a restart, the agent's first response demonstrates it knows
   what was happening — references the user's last message, today's
   calendar, an in-flight task — without being prompted.
@@ -85,10 +88,12 @@ of GHCR images. No piece moves on its own.
 
 ## What the user needs from the surface
 
-- A small, fixed set of commands (`switchroom apply`, `docker compose
-  pull`, `docker compose up -d --remove-orphans`) that do the right
-  thing for the whole stack. Not a runbook of ten commands and two
-  README links.
+- A single command (`switchroom update`) that does the right thing for
+  the whole stack — pull new images, refresh scaffolds, recreate
+  containers, and run a post-bounce health sweep. Operators who want
+  finer control can still run `switchroom apply`, `docker compose pull`,
+  and `docker compose up -d --remove-orphans` individually. Not a
+  runbook of ten commands and two README links.
 - A clear failure mode if the update can't finish cleanly. "Stopped at
   step X because Y failed; nothing was applied" beats "applied half,
   please figure out the rest yourself".
@@ -109,15 +114,15 @@ of GHCR images. No piece moves on its own.
 
 ### Update lands a security patch
 
-The user reads about a CVE in a transitive dependency. They re-run the
-installer for a newer switchroom binary, then `switchroom apply`,
-`docker compose pull`, `docker compose up -d --remove-orphans`. Pull
-fetches the matched set of GHCR images at the new release tag; the
-rolling `up -d` replaces each agent + scheduler + broker container in
-turn. After it finishes, every container is on the new version. The
-user sends "ping" and the agent replies within seconds, demonstrating
-it picked up the change without being asked. `switchroom doctor`
-reports no drift.
+The user reads about a CVE in a transitive dependency. They install the
+newer switchroom binary and run `switchroom update`. The command fetches
+the matched set of images at the new release tag, recreates services
+whose image or configuration changed, and runs a post-bounce health
+sweep. The scheduler runs as an in-container sibling process — it comes
+up with the agent container, not as a separate service to manage. After
+it finishes, every service is on the new version. The user sends "ping"
+and the agent replies within seconds, demonstrating it picked up the
+change without being asked. `switchroom doctor` reports no drift.
 
 ### A restart in the middle of a busy thread
 
@@ -143,7 +148,7 @@ on demand.
 The user installed claude CLI manually on the host six months ago and
 forgot. (The host claude is only used for `switchroom auth login`; the
 agent itself runs the claude baked into the agent image.) `switchroom
-doctor` detects the host's claude is far behind the version baked into
-the running agent image, flags the drift as informational, and offers a
-one-liner to upgrade the host CLI. Either way the user knows *before*
-their next OAuth login fails or behaves oddly.
+doctor` detects that the host's claude version differs from the version
+declared in the current switchroom manifest, flags the drift, and tells
+the user to run `switchroom update` to realign. Either way the user
+knows *before* their next OAuth login fails or behaves oddly.


### PR DESCRIPTION
## Summary

- Replace the pre-v0.13 three-command incantation (`switchroom apply` + `docker compose pull` + `docker compose up -d`) with `switchroom update` throughout the file — frontmatter outcome, opening paragraph, Signs it's working bullet, What the user needs bullet, and the security-patch worked example.
- Correct the scheduler topology claim: the scheduler is now an in-container sibling process, not a separate container.
- Correct the `switchroom doctor` description: it compares against the manifest, not the running image, and the fix message points at `switchroom update`, not a dedicated host CLI upgrade one-liner.

## Why

Audit run `audit/2026-05-26/` found drift between `reference/idempotent-update-and-restart.md` and shipped code. The `switchroom update` command is the canonical single-step upgrade surface since v0.13; the JTBD still described the replaced three-command pattern as the answer to the user's need. Three findings were drift-major (the most reader-visible sections) and three were drift-minor (topology and doctor-message accuracy).

## Findings addressed

- `jtbd-idempotent-update-and-restart:c1` (drift-major) — frontmatter `outcome:` field named the three-command incantation
- `jtbd-idempotent-update-and-restart:c2` (drift-major) — opening paragraph of "# The job" named the replaced pattern
- `jtbd-idempotent-update-and-restart:c5` (drift-minor) — idempotency bullet in "Signs it's working" named stale sub-commands
- `jtbd-idempotent-update-and-restart:c9` (drift-major) — "What the user needs from the surface" bullet defined user need using the old three-command form
- `jtbd-idempotent-update-and-restart:c13` (drift-minor) — security patch worked example named deprecated container topology (separate scheduler container)
- `jtbd-idempotent-update-and-restart:c15` (drift-minor) — stale dependency worked example said doctor compares against running image and offers a host CLI one-liner

## Out of scope

- `reference/principles.md:c8` (same three-command example) — in `principles-stale-examples` batch.
- Adding Anti-patterns and UAT prompts sections — new content, not a drift fix, needs a separate product decision.

## Adjacent drift noted (not edited — out of batch scope)

The "A new MCP server is added" worked example (around L136-144) references `switchroom agent reconcile` and mentions `settings.json` by filename. These are mild implementation leakage in an otherwise outcome-focused section. The batch does not include these lines; flagging here for a follow-on triage decision.

## Verification

- [x] tsc clean (N/A — doc-only batch)
- [x] No file edited by this PR is edited by any sibling drift-audit PR (single file: `reference/idempotent-update-and-restart.md`)
- [ ] Reviewer agent APPROVE pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)