### PR TITLE
docs(drift-audit): tighten know-what-agent-is-doing JTBD & posthog events

### DIFF
--- a/docs/posthog.md
+++ b/docs/posthog.md
@@ -71,6 +71,7 @@ Emitted from inside each agent container by the telegram-plugin gateway.
 
 | Event                    | Source                                                                                  | Key properties                                                                                                              |
 |--------------------------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `inbound_ack`            | [telegram-plugin/streaming-metrics.ts](../telegram-plugin/streaming-metrics.ts)          | `chat_id`, `message_id`, `thread_id`, `ack_ms` — fired when the 👀 reaction lands; measures time-to-ack from message receipt |
 | `inbound_status_query`   | [telegram-plugin/inbound-classifier.ts](../telegram-plugin/inbound-classifier.ts)        | `chat_id`, `message_id`, `thread_id`, `text_length`, `prior_turn_in_flight`, `seconds_since_turn_start`                     |
 | `turn_started`           | [telegram-plugin/gateway/gateway.ts](../telegram-plugin/gateway/gateway.ts) (fresh-turn) | `chat_id`, `message_id`, `thread_id`, `inbound_classified_as_status_query`                                                  |
 | `turn_ended`             | [telegram-plugin/gateway/gateway.ts](../telegram-plugin/gateway/gateway.ts) (turn_end)   | `chat_id`, `thread_id`, `duration_ms`, `ttfo_ms`, `outbound_count`, `longest_silent_gap_ms`, `ended_via`                    |

--- a/reference/know-what-my-agent-is-doing.md
+++ b/reference/know-what-my-agent-is-doing.md
@@ -31,8 +31,8 @@ The shape now is three layers, in priority order:
 ## 1. Ambient — the reaction lifecycle
 
 The status reaction on the user's *own* inbound message is the
-always-on liveness signal. It fires within ~100ms of the message
-arriving (👀 received), reflects current turn activity through
+always-on liveness signal. It fires within ~800ms of the message
+arriving (👀 received, sub-second), reflects current turn activity through
 working states (🤔 thinking, ✍ tool, 👨‍💻 coding, ⚡ web lookup),
 and resolves on turn end (👍). It's free, glanceable, lives on the
 user's message (not competing with the conversation), and never
@@ -43,22 +43,19 @@ The reaction is a **reflective state machine**, not a linear ratchet
 (#1713). Working states cycle freely and bidirectionally — the same
 state can re-enter multiple times within one turn, no state is
 "higher" than another, and mid-turn replies (ack or final answer)
-are non-events for the reaction. **Only the `turn_end` IPC event
-(Stop hook) finalizes to 👍.** Sending a message is not a state
-transition; the reaction reflects what the agent is doing, not what
-just landed in the chat.
+are non-events for the reaction. Only turn completion finalizes the
+reaction to 👍. Sending a message is not a state transition; the
+reaction reflects what the agent is doing, not what just landed in
+the chat.
 
-🔥 is reserved for genuine 5xx server errors and is also non-terminal:
-recovery to a working state from 🔥 is allowed; only `turn_end`
-ends the controller. A stall escalates the reaction (😨) so the user
-can tell idle from stuck at a glance. The reaction is also where
-time-to-ack is measured — see the `inbound_ack` event in
-`docs/posthog.md`.
+😱 is the non-terminal error reaction: recovery to a working state
+from 😱 is allowed; only turn completion ends the controller. A stall
+escalates the reaction (😨) so the user can tell idle from stuck at a
+glance. The reaction is also where time-to-ack is measured — see the
+`inbound_ack` event in `docs/posthog.md`.
 
-Implementation: `telegram-plugin/status-reactions.ts` (controller),
-`telegram-plugin/gateway/gateway.ts` (turn_end IPC handler →
-`finalizeStatusReaction`). The technical contract spec lives at
-`telegram-plugin/docs/waiting-ux-spec.md`.
+See the ambient layer design contract at
+`reference/conversational-pacing.md`.
 
 ## 2. Conversational — the chat itself is the artifact
 


### PR DESCRIPTION
## Summary

- Corrects the time-to-ack figure in the reaction lifecycle section from ~100ms to ~800ms (sub-second), matching the gateway code's own spec deadline comment.
- Fixes the 🔥 emoji claim: 🔥 is operator-event message text only, not a reaction state. The actual non-terminal error reaction is 😱 per `status-reactions.ts`.
- Removes the "Implementation:" paragraph from the JTBD that leaked file paths, function names, and IPC event labels; replaced with a pointer to the design contract at `reference/conversational-pacing.md`.
- Adds the missing `inbound_ack` event row to the `docs/posthog.md` gateway events table so the cross-reference in the JTBD resolves to a real entry.

## Why

Audit run `audit/2026-05-26/` found drift between these docs and shipped code. See findings list below.

## Findings addressed

### c1 — drift-minor
- **File:** `reference/know-what-my-agent-is-doing.md` (ambient section)
- "It fires within ~100ms" → "within ~800ms (sub-second)". The code's own spec deadline is 800ms.

### c4 — drift-major
- **File:** `reference/know-what-my-agent-is-doing.md` (ambient section)
- 🔥 was described as a non-terminal reaction state. It is not in `REACTION_VARIANTS` at all — 🔥 appears only as a text prefix in operator-event notifications. The actual non-terminal error reaction is 😱.

### c5 — jtbd-too-technical
- **File:** `reference/know-what-my-agent-is-doing.md` (ambient section)
- Removed the "Implementation:" paragraph naming internal file paths, function names, and IPC event labels. JTBDs describe user outcomes; implementation pointers belong in design contracts or code comments. Replaced with a pointer to `reference/conversational-pacing.md`.

### c11 — dead-pointer
- **Files:** `reference/know-what-my-agent-is-doing.md` (ambient section) + `docs/posthog.md`
- The JTBD references "the `inbound_ack` event in `docs/posthog.md`" but the event was absent from the table. Added the row pointing to `telegram-plugin/streaming-metrics.ts`.

## Out of scope

- `jtbd-know-what-my-agent-is-doing:c12` (`outcome-not-realized` — silence-poke success rate) is escalated, not a doc edit.

## Adjacent drift noted (not fixed in this batch — flagged for triage)

- `#1713` PR number reference remains in the JTBD. PR numbers are technically prohibited by Step 3 rules but were not in this batch scope.
- `profiles/_shared/telegram-style.md.hbs` file path at L83 of the JTBD — a file path in a JTBD, also not in batch scope.

## Verification

- [x] tsc clean (N/A — doc-only batch)
- [x] No file edited by this PR is edited by any sibling drift-audit PR
- [ ] Reviewer agent APPROVE pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)