### PR TITLE
docs(drift-audit): align reference/ index + JTBD count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ Three checks. A "no" on any one is a redesign, not a follow-up:
 3. **Consistency test** — same CLI shape, cascade, vault syntax, progress card as adjacent features?
 
 **JTBDs — `reference/<job>.md`** — *did it do the user's job?*
-13 outcome-focused jobs grouped by outcome in `reference/README.md`.
+14 outcome-focused jobs grouped by outcome in `reference/README.md`.
 Survey cheaply: `head -5 reference/*.md` reads every `job: / outcome:
 / stakes:` frontmatter in one shot. Read in full only the JTBD(s) the
 change touches.

--- a/reference/README.md
+++ b/reference/README.md
@@ -18,12 +18,12 @@ Each JTBD has a three-line frontmatter — `job:` / `outcome:` /
 `stakes:` — that captures 80% of the doc.
 
 ```bash
-# Survey every job in one read:
-head -5 reference/*.md
+# Survey every JTBD in one read (also prints headers for non-JTBD docs):
+head -5 reference/*.md | grep -E '^(==>|job:|outcome:|stakes:)'
 ```
 
-Read a JTBD in full only when your change touches it. The body's
-*Signs it's working*, *Anti-patterns*, and *UAT prompts* sections are
+Read a JTBD in full only when your change touches it. Most JTBD bodies have
+*Signs it's working*, *Anti-patterns*, and *UAT prompts* sections —
 where the design teeth are — open them before designing a UX surface
 that touches the job.
 
@@ -49,12 +49,12 @@ that touches the job.
 - [`keep-my-subscription-honest.md`](keep-my-subscription-honest.md) — keep my subscription the only thing I'm paying for
 - [`share-auth-across-the-fleet.md`](share-auth-across-the-fleet.md) — log into Anthropic once per account, not once per agent
 
-### Always available — *there when you want it*
+### Always available, in Telegram, done properly — *there when you want it*
 
 - [`survive-reboots-and-real-life.md`](survive-reboots-and-real-life.md) — survive reboots and real life
-- [`idempotent-update-and-restart.md`](idempotent-update-and-restart.md) — update switchroom and trust everything's running the new version
+- [`idempotent-update-and-restart.md`](idempotent-update-and-restart.md) — update switchroom and trust that everything is actually running the new version, no manual checks
 - [`talk-to-agents-from-anywhere.md`](talk-to-agents-from-anywhere.md) — talk to my agents from anywhere
 
 ## Working docs (not part of the design contract)
 
-- [`onboarding-gap-analysis.md`](onboarding-gap-analysis.md) — phased fix plan from a real onboarding session; tracks gaps as they close, not a durable JTBD.
+- [`onboarding-gap-analysis.md`](onboarding-gap-analysis.md) — historical point-in-time gap analysis from a 2026-04-25 onboarding session; not a live tracker. Several gaps have shipped; read as motivation context, not current roadmap.


### PR DESCRIPTION
## Summary

- Fix JTBD count in CLAUDE.md: `13` → `14` (the README has listed 14 since the 14th JTBD was added; CLAUDE.md was never updated)
- Align `reference/README.md` survey command, section-structure claim, "Always available" heading, `idempotent-update-and-restart` description, and `onboarding-gap-analysis` blurb to match current reality

## Why

Audit run `audit/2026-05-26/` found six instances of drift between `reference/README.md` / `CLAUDE.md` and the current state of the repo. See findings list below.

## Findings addressed

### Finding 1 — contract-reference-readme:c4 (drift-minor)

`reference/README.md` survey command comment implied all output lines are JTBD jobs. `reference/` now has 22 .md files of which 8 lack JTBD frontmatter. Comment updated and command filtered with `grep -E '^(==>|job:|outcome:|stakes:)'`.

### Finding 2 — contract-reference-readme:c5 (drift-minor)

"The body's Signs it's working, Anti-patterns, and UAT prompts sections are where the design teeth are" implies universal structure. `idempotent-update-and-restart.md` lacks Anti-patterns and UAT prompts. Claim hedged to "Most JTBD bodies have …".

### Finding 3 — contract-reference-readme:c9 (drift-minor)

Heading "### Always available" truncated vision.md's full title. Updated to "### Always available, in Telegram, done properly".

### Finding 4 — contract-reference-readme:c10 (drift-minor)

`idempotent-update-and-restart.md` description in the index truncated and rephrased. Now matches the file's own `job:` frontmatter exactly.

### Finding 5 — contract-reference-readme:c11 (drift-major)

CLAUDE.md: "13 outcome-focused jobs" is wrong — the README index lists exactly 14 (5+4+2+3). Changed to "14 outcome-focused jobs".

### Finding 6 — historical-onboarding-gap-analysis:c2 (archive-leaks)

`onboarding-gap-analysis.md` description called it a "phased fix plan … tracks gaps as they close" — contradicting the file's own disclaimer. Updated to accurately describe it as a historical point-in-time snapshot.

## Out of scope

- Edits to `reference/principles.md` — in `principles-stale-examples` batch.
- Edits to `docs/workspace-files.md` (other onboarding-gap-analysis referrers) — in `docs-onboarding-referrer-fix` batch.

## Verification

- [x] tsc N/A — doc-only batch
- [x] No file edited by this PR is edited by any sibling drift-audit PR
- [ ] Reviewer agent APPROVE pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)