### PR TITLE
docs(drift-audit): misc small drift fixes across JTBDs

### DIFF
--- a/docs/compliance-attestation.md
+++ b/docs/compliance-attestation.md
@@ -4,7 +4,7 @@
 
 Switchroom is a multi-agent orchestration tool for Claude Code. This document provides a point-in-time attestation that Switchroom's architecture is designed to comply with Anthropic's terms of service and usage policies for Claude Code.
 
-**Attestation date:** 2026-04-25T00:00:00Z (revised; supersedes 2026-04-13)
+**Attestation date:** 2026-04-25T00:00:00Z (revised; supersedes 2026-04-13; see addendum for 2026-06-15 policy update)
 **Model used for analysis:** Claude Opus 4.7
 **Reviewed against:** Anthropic's published documentation and policies as of April 25, 2026
 
@@ -187,6 +187,23 @@ At no point does any Switchroom component sit between Claude Code and Anthropic'
 | Legal and Compliance | https://code.claude.com/docs/en/legal-and-compliance | 2026-04-25 |
 | MCP | https://code.claude.com/docs/en/mcp | 2026-04-25 |
 | Plugins | https://code.claude.com/docs/en/plugins | 2026-04-25 |
+
+## Addendum: 2026-06-15 Anthropic Policy Split
+
+As of **2026-06-15** Anthropic distinguishes two usage modes for Claude Code:
+
+- **Interactive usage** (the `claude` CLI in a terminal session) draws the Pro/Max subscription as before.
+- **Programmatic usage** (headless `claude -p` / the Agent SDK / the raw Anthropic API) draws a separate Agent-SDK credit, off the subscription.
+
+**Switchroom's position after the split:**
+
+Switchroom routes every model call through the interactive `claude` session. Cron fires, webhook triggers, and session handoffs are all delivered as synthesized turns into that session — never as headless invocations. RFC #1620 removed the last `claude -p` callsites from the codebase; a CI guard (`tests/bridge-flap-regression-guard.test.ts`) enforces `--strict-mcp-config` on any headless spawn and keeps the count at zero.
+
+**One tracked exception:** the host-control deep-probe path (`src/host-control/server.ts`) contains a single opt-in diagnostic invocation that is off by default (issue #1798 tracks its removal). Operators who require zero programmatic usage should confirm this probe is disabled in their configuration.
+
+The `reference/keep-my-subscription-honest.md` JTBD and `reference/vision.md` pillar 3 document the constraint; `CLAUDE.md` enforces it as an engineering gate. This attestation was written before the 2026-06-15 split and should be re-reviewed against the final published policy once stable.
+
+---
 
 ## Limitations of This Attestation
 

--- a/reference/extend-without-forking.md
+++ b/reference/extend-without-forking.md
@@ -35,7 +35,7 @@ The product grows with them.
   for their own, without studying the framework internals.
 - Extensions inherit the product's safety, logging, and lifecycle
   behaviour automatically. The user doesn't have to reimplement it.
-- Removing an extension is as clean as adding it. No residue.
+- Removing an extension takes two steps: running `switchroom agent destroy <name>` removes the scaffold directory, then editing `switchroom.yaml` to delete the agent entry and running `switchroom apply` removes the container. The scaffold directory is fully cleaned; the config entry requires a manual edit.
 
 ## Anti-patterns: don't build this
 
@@ -66,8 +66,10 @@ The product grows with them.
   reference and build a peer. It should slot in without surprises.
 - **Upgrade survival.** Upgrade the product. User-added agents, skills,
   and tools should keep working.
-- **Clean removal.** Delete a user extension. Nothing should be left
-  behind in config, memory, or runtime.
+- **Clean removal.** Delete a user extension. The scaffold directory
+  should be gone after `switchroom agent destroy`. Confirm what manual
+  steps remain for config and memory cleanup — the UAT should reflect
+  current reality, not the ideal.
 - **Non-trivial extension.** Build something that exercises an
   intermediate capability. The documentation should cover it, not just
   the toy case.

--- a/reference/give-each-agent-its-own-workspace.md
+++ b/reference/give-each-agent-its-own-workspace.md
@@ -103,11 +103,12 @@ doesn't have to:
    reference repos by env, not by hardcoded path.
 6. **Dirty-tree policy: leave alone, warn.** If the worktree has
    uncommitted changes at session start, the ff-to-main step is skipped.
-   The session resumes on whatever branch the worktree was on. The boot
-   card surfaces "<repo>: dirty since <ts>" as a one-line warning.
-7. **Removal is symmetric.** `switchroom agent remove <name>` calls
-   `git worktree remove` for each of the agent's worktrees, then prunes
-   the per-agent branches. The host's `.git/worktrees/` stays clean.
+   The session resumes on whatever branch the worktree was on. The
+   reconcile log emits a one-line warning to stderr.
+7. **Removal.** `switchroom agent destroy <name>` removes the agent's
+   scaffold directory. Note: worktree cleanup is not currently wired into
+   the destroy path — orphan worktree directories are not automatically
+   removed. The host's `.git/worktrees/` requires manual pruning for now.
 8. **Sub-agents nest off the parent worktree.** Existing pattern. A
    worker dispatched by an agent on
    `<agent_dir>/work/switchroom/` creates its task worktree off
@@ -143,8 +144,10 @@ Use these to evaluate whether an implementation truly delivers the job:
   unexpected state?"
 - "Reboot the host while one agent has uncommitted work in its
   worktree. After reboot, is the work still there, on the same branch?"
-- "Remove an agent that owns worktrees on three different repos. Did
-  any orphan branches or directories survive?"
+- "Remove an agent that owns worktrees on three different repos. Check
+  whether any orphan directories remain — worktree cleanup is not yet
+  automatic; this UAT prompt verifies what the current state actually
+  is, not what it should be."
 - "Read your agent's SOUL.md and skills. Do any of them hardcode an
   absolute path to a repo? They shouldn't — they should use the env."
 

--- a/reference/keep-my-subscription-honest.md
+++ b/reference/keep-my-subscription-honest.md
@@ -1,6 +1,6 @@
 ---
 job: keep my subscription the only thing I'm paying for
-outcome: The agents run on the user's Claude Pro or Max subscription, transparently and compliantly. No hidden API billing, no side-door tokens, no asks for extra keys.
+outcome: The agents run on the user's Claude Pro or Max subscription, transparently and compliantly. No hidden API billing, no side-door tokens, no Anthropic API keys. Opt-in third-party service keys (e.g. OpenAI Whisper for voice transcription) are stored in the vault and clearly opt-in.
 stakes: If the product quietly routes to paid API or mixes billing models, the user loses trust and the product loses its licence to operate.
 ---
 
@@ -65,8 +65,11 @@ subscription is the only thing I'm paying for" stays literally true.
   Since 2026-06-15 both are *programmatic* usage — they draw the
   separate Agent-SDK credit, not the subscription, and silently split
   the billing model. Route the work through the interactive session.
-- Asking the user for an API key as "optional" when core features need
-  it. Either the subscription supports the feature, or it doesn't.
+- Asking the user for an API key when core features need it. Either the
+  subscription supports the feature, or it doesn't. Opt-in auxiliary
+  features (e.g. voice transcription via a third-party service) that
+  require a separate key must be clearly labelled as extensions — not
+  implied to be subscription-native.
 - Proxying subscription auth through the product in a way that bends
   the terms.
 - Feature marketing that implies subscription support when the real

--- a/reference/remember-across-sessions.md
+++ b/reference/remember-across-sessions.md
@@ -37,8 +37,10 @@ Memory the user can't inspect is memory the user won't trust.
   relationship. The agent picks up roughly where it was.
 - The user can see what the agent believes about them and why. Nothing
   is hidden in a black box.
-- Memory decays sensibly. Stale preferences don't haunt the user a year
-  later.
+- Memory decays sensibly (not yet built — Hindsight banks currently
+  store memories indefinitely; the demote tag excludes entries from
+  recall but does not delete them). Stale preferences don't haunt the
+  user a year later.
 
 ## Anti-patterns: don't build this
 

--- a/reference/run-a-fleet-of-specialists.md
+++ b/reference/run-a-fleet-of-specialists.md
@@ -37,8 +37,11 @@ not be second-guessing the user's sleep data. Separation is the point.
 - When a new agent joins the fleet, it feels like a peer, not a bolt-on.
   It participates in the same lifecycle, the same safety rules, the same
   interaction surface.
-- Removing an agent is clean. Its memory, its state, its scheduled work
-  all go with it, with no orphaned processes or dangling config.
+- Removing an agent takes down its container and clears its state
+  directory and scheduled work. The memory bank in the Hindsight
+  service persists and requires manual cleanup via that service. The
+  agent's entry in `switchroom.yaml` also requires a manual edit before
+  `switchroom apply` will remove the container.
 - The user can describe what each of their agents is for in one sentence.
   If they can't, the fleet is too blurry.
 

--- a/reference/survive-reboots-and-real-life.md
+++ b/reference/survive-reboots-and-real-life.md
@@ -33,8 +33,10 @@ is the bug.
   refusal. The user understands what happened.
 - Transient failures (network, tool, upstream) retry sensibly. The user
   doesn't see flakes they don't need to.
-- Persistent failures surface. The user is told when a retry loop has
-  stopped trying.
+- Persistent named failures (credentials, quota exhaustion, crashes)
+  surface. The user is told with an operator-event card. Note: the
+  Telegram API retry-giveup path currently logs to stderr only and
+  does not send a user-visible message.
 - Scheduled work survives a reboot. Jobs that should have fired either
   fire on return or are explicitly skipped, not silently dropped.
 - The user can ask "is everything healthy?" and get a real answer.

--- a/reference/talk-to-agents-from-anywhere.md
+++ b/reference/talk-to-agents-from-anywhere.md
@@ -71,7 +71,10 @@ experience should benefit from that discipline, not be diminished by it.
   photo should be usable input, not discarded.
 - **Noisy day.** Run several tasks across the morning. The user should not
   end the day with a muted chat because the agent over-notified.
-- **Dead zone.** Lose connectivity mid-task. When it comes back the user
-  should see a sensible state, not a broken thread.
+- **Dead zone.** Lose connectivity mid-task. When it comes back,
+  Telegram delivers queued messages and the agent resumes from where it
+  stopped; in-flight turns may show a stale progress state until the
+  next update. (No specific dead-zone recovery code exists; this relies
+  on Telegram's natural message delivery on reconnect.)
 - **One-handed correction.** Spot the agent going the wrong way while
   holding a coffee. A short reply should be enough to course-correct.

--- a/reference/vision.md
+++ b/reference/vision.md
@@ -124,7 +124,7 @@ hidden.
 | Not… | Because… |
 |---|---|
 | A harness or wrapper | Switchroom never intercepts auth or inference. The `claude` CLI is the runtime. |
-| A multi-provider orchestrator | No OpenAI, Gemini, Llama, model swapping. |
+| A multi-provider orchestrator | No OpenAI, Gemini, Llama, or model swapping for inference. Auxiliary services (e.g. voice transcription via Whisper) are opt-in helpers, not Claude replacements. |
 | A multi-channel bridge | Not Slack, not Discord, not Teams. Telegram, done properly. |
 | An autonomous agent | No heartbeats. Beck-and-call plus explicit schedules, on your leash. |
 | Multi-tenant | Single-operator by design. |

--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -337,10 +337,10 @@ export async function waitForCardPhase(
 /**
  * Detect the progress card's phase from its rendered text.
  *
- * The actual card render (telegram-plugin/progress-card.ts) uses
- * emoji markers in the header: `✅` for done, `❌` for errors, `⚙️`
- * while working (foreground), `🌀` for Background (parent done but
- * fleet still running, see #862 / status-card-design.md §Header),
+ * The actual card render uses emoji markers in the header: `✅` for
+ * done, `❌` for errors, `⚙️` while working (foreground), `🌀` for
+ * Background (parent done but fleet still running, see #862 /
+ * reference/conversational-pacing.md),
  * and `⏳` during the boot-card window. These markers are stable
  * enough to key on for UAT — finer parsing (checklist items,
  * sub-agent row content) is out of scope.


### PR DESCRIPTION
## Summary

- Correct 11 drift findings across 10 disjoint reference/docs files; no code changes.
- Largest changes: compliance-attestation gets a 2026-06-15 policy addendum; give-each-agent-its-own-workspace fixes a wrong CLI verb (remove → destroy) and a boot-card claim (corrected to stderr warning).
- All other edits are one-to-three line qualifications adding "(not yet built)", "(requires manual step)", or similar to over-confident "Signs it's working" claims.

## Why

Audit run `audit/2026-05-26/` found drift between these docs and shipped code. See batch file: `audit/2026-05-26/fix-batches/misc-jtbd-small-drift-fixes.md`.

## Findings addressed

| Finding | File | Type | Change |
|---------|------|------|--------|
| jtbd-give-each-agent-its-own-workspace:c8 | `reference/give-each-agent-its-own-workspace.md` L107 | drift-major | Boot-card claim corrected to reconcile-log stderr warning |
| jtbd-give-each-agent-its-own-workspace:c9 | `reference/give-each-agent-its-own-workspace.md` L108-110 | drift-major | Command corrected from `remove` to `destroy`; wiring gap noted |
| jtbd-run-a-fleet-of-specialists:c6 | `reference/run-a-fleet-of-specialists.md` L40-41 | drift-minor | Removal qualified: Hindsight bank and YAML entry require manual cleanup |
| jtbd-extend-without-forking:c7 | `reference/extend-without-forking.md` L38 | drift-minor | "No residue" replaced with two-step reality (destroy + YAML edit) |
| jtbd-remember-across-sessions:c6 | `reference/remember-across-sessions.md` L40 | vision-only | Memory decay marked not yet built; demote-tag behaviour noted |
| jtbd-survive-reboots-and-real-life:c5 | `reference/survive-reboots-and-real-life.md` L37-38 | drift-minor | Retry-giveup gap noted; coverage qualified to named failure types |
| contract-vision:c9 | `reference/vision.md` L127 | drift-minor | Whisper carve-out added to multi-provider-orchestrator row |
| jtbd-talk-to-agents-from-anywhere:c10 | `reference/talk-to-agents-from-anywhere.md` L75-76 | vision-only | Dead-zone recovery noted as Telegram-natural, not purpose-built |
| archived-status-card-design:c4 | `telegram-plugin/uat/assertions.ts` L343 | archive-leaks | Comment updated to cite `reference/conversational-pacing.md` |
| jtbd-keep-my-subscription-honest:c3 | `reference/keep-my-subscription-honest.md` L3 | drift-minor | Frontmatter and anti-pattern clarified to carve out Whisper opt-in |
| jtbd-keep-my-subscription-honest:c5 | `docs/compliance-attestation.md` | drift-minor | Addendum section added for 2026-06-15 interactive/programmatic split |

## Out of scope

- Escalated findings for jtbd-give-each-agent-its-own-workspace (c1-c4, c10) — those are outcome-not-realized and in escalations.md.
- contract-vision:c2 (code-violates-contract) — in escalations.md.
- Any jtbd-restart-and-know-what-im-running findings — all escalated.
- Any jtbd-track-plan-quota-live findings beyond the escalated ones — all escalated.

**Neighboring drift fixed inline (not in original batch):**
- `reference/give-each-agent-its-own-workspace.md` UAT prompt updated to reflect worktree cleanup is not yet automatic.
- `reference/extend-without-forking.md` UAT "Clean removal" prompt updated to match two-step reality.
- `reference/keep-my-subscription-honest.md` anti-pattern entry updated to explicitly carve out opt-in auxiliary features.

## Verification

- [x] tsc N/A — doc-only batch (no `src/` files touched)
- [x] No file edited by this PR is edited by any sibling drift-audit PR
- [ ] Reviewer agent APPROVE pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)