### PR TITLE
docs(drift-audit): fix conversational-pacing emoji sequence

### DIFF
--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -17,7 +17,7 @@ The one thing to avoid is **spam**: a reply on every tool call, on a cadence, or
 - **`reply`** is the default. Use for acks, mid-turn updates, sub-agent handbacks, final answers. Pass `disable_notification: true` mid-turn.
 - **`stream_reply`** is for content whose final answer benefits from streaming character-by-character (long prose, code blocks). First call sends fresh; subsequent calls edit (no ping until `done=true`). Don't use it just to "show progress" — that's what `reply` is for.
 
-The 👀→🤔→🔥→👍 status reaction and the typing indicator are *ambient* liveness — they tell the user the agent is alive and working, automatically. They do **not** replace the five beats: ambient says "alive", your `reply` messages say "here's what's happening." Different layers; both run.
+The 👀→🤔→✍→👍 status reaction and the typing indicator are *ambient* liveness — they tell the user the agent is alive and working, automatically. They do **not** replace the five beats: ambient says "alive", your `reply` messages say "here's what's happening." Different layers; both run.
 
 **Reactions ON your replies.** Sometimes you'll receive a turn whose body is wrapped in `<channel source="reaction">`. That means the user reacted to one of your earlier messages and the gateway forwarded the reaction as a synthetic turn (the message preview is included so you know which reply they reacted to). 👎 / ❌ are stop signals — pause, reconsider the approach, ask what's off. 👍 / ✅ are acknowledgements — keep going if mid-task, no extra reply needed. A brief explicit acknowledgement is fine but not required; don't ceremonially reply to every reaction. The allowlist + per-hour cap are operator-tunable (default 10/hour); other emojis you might see don't trigger turns.
 

--- a/reference/conversational-pacing.md
+++ b/reference/conversational-pacing.md
@@ -25,7 +25,7 @@ the five beats below and removes the contradiction.
 
 | Layer | Purpose | Owns | Implementation |
 |---|---|---|---|
-| Ambient | "Is it alive?" — glance-level liveness | The 👀→🤔→🔥→👍 status reaction on the user's inbound message **and** a continuous `typing…` chat-action held for the whole turn | `telegram-plugin/status-reactions.ts` + `gateway.ts:startTypingLoop` (started at turn-start, stopped by `purgeReactionTracking`) |
+| Ambient | "Is it alive?" — glance-level liveness | The 👀→🤔→✍→👍 status reaction on the user's inbound message **and** a continuous `typing…` chat-action held for the whole turn | `telegram-plugin/status-reactions.ts` + `gateway.ts:startTurnTypingLoop` (started at turn-start, stopped by `purgeReactionTracking`) |
 | Conversational | "What is it doing? What did it find?" — meaningful state changes | The agent's own `reply` calls, paced by the five beats | `profiles/_shared/telegram-style.md.hbs` + the append-prompt block in `scaffold.ts` + `disable_notification` parameter |
 | Safety net | "Why has it gone quiet?" — framework backstop when the model fails to chat | The silence-poke subsystem: 75s/180s/300s ladder | `telegram-plugin/silence-poke.ts` |
 
@@ -79,7 +79,7 @@ of* a real milestone (beats 3–4) is the black box this prevents.
 The framework backstops the model. State per-turn:
 `{ turnStartedAt, lastOutboundAt, pokesFired, pokeArmed, ackPokeFired,
 subagentDispatchActive, lastThinkingAt, fallbackFired,
-lastPokeFiredAt }`. Polled every 5s.
+lastPokeFiredAt, inFlightTools }`. Polled every 5s.
 
 | Threshold | Action | Wire |
 |---|---|---|


### PR DESCRIPTION
## Summary

Three fixes from `audit/2026-05-26/fix-batches/conversational-pacing-emoji-fix.md`:

- **Wrong working-state emoji** in the conversational-pacing artefact and the agent prompt template — was telling the model the reaction lifecycle uses 🔥 (which is reserved for 5xx errors); corrected to ✍ (the actual working-state emoji in `REACTION_VARIANTS.tool`).
- **Function name correction** — `startTypingLoop` → `startTurnTypingLoop`.
- **Missing field** — added `inFlightTools` to the silence-poke state struct listing.

## Why

The pilot drift-audit (pilot-2026-05-26) found that `reference/conversational-pacing.md` and `profiles/_shared/telegram-style.md.hbs` document the wrong reaction emoji. Because the agent prompt is the input to every agent's system prompt, this misinforms the model itself about its own reaction lifecycle.

## Findings addressed

- `artefact-conversational-pacing:c1` — drift-major (wrong emoji)
- `artefact-conversational-pacing:c2` — drift-minor (function name)
- `artefact-conversational-pacing:c6` — drift-minor (missing field)

## Verification

- [ ] tsc: N/A (doc + handlebars template only)
- [ ] No file edited here is edited by any sibling drift-audit PR
- [ ] Reviewer agent APPROVE pending

## Note

This PR was supposed to open as part of the Phase 3 dispatch but the original `gh pr create` invocation got confused about working directory and opened the audit-infrastructure branch under this title instead. That PR has been retitled to its correct subject (#1903 = audit infra). This PR holds the actual emoji-fix content from branch `chore/drift-conversational-pacing-emoji-fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)