### PR TITLE
fix(notion): close v0.13.55 follow-ups (search privacy gate, cache poisoning, verb wording)

### DIFF
--- a/docs/notion-integration.md
+++ b/docs/notion-integration.md
@@ -27,12 +27,21 @@ the design rationale.
   Notion's UI; switchroom can read + write existing DBs only.
 - **Standalone-page access.** Pages without a database parent are
   hard-denied. Move them into a database to give agent access.
+- **Search for filtered agents.** If an agent has a non-empty
+  `notion_workspace.databases:` allowlist (e.g. `carrie:
+  notion_workspace: { databases: [essays] }`), the `search` tool is
+  **blocked** for that agent. The privacy-preserving post-filter is
+  shipped as code (`src/notion/search-filter.ts`) but not yet wired
+  into the launcher's stdio bridge, so allowing search would leak
+  snippets from other DBs the integration was shared with.
+  Admin-shaped agents (no `databases:` filter) can still search.
+  Tracked at [switchroom/switchroom#1913](https://github.com/switchroom/switchroom/issues/1913) — the wire-up lifts this restriction.
 - **Operator approval cards on writes.** v1 ships the allowlist
-  primitive; a follow-up PR will add the m365/drive-style approval
-  card on top.
+  primitive; a follow-up adds the m365/drive-style approval card on
+  top. Tracked at [switchroom/switchroom#1914](https://github.com/switchroom/switchroom/issues/1914).
 - **Coordinated rate-limit bucket.** The broker primitive shipped
   but isn't wired into the hook yet — relies on Notion's own 429
-  retry behaviour.
+  retry behaviour. Tracked at [switchroom/switchroom#1915](https://github.com/switchroom/switchroom/issues/1915).
 
 ## Bootstrap order (read this — order matters)
 

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -47,10 +47,12 @@ disallowed database, you'll get a clean block reason naming the DB.
 The Notion MCP exposes the standard set:
 
 - **Search.** `search` finds pages or databases by title/content
-  across what the integration can see. switchroom's PreToolUse hook
-  post-filters results to your allowlist — pages outside it are
-  dropped before they reach you. The response's metadata field
-  indicates how many were filtered.
+  across what the integration can see. **In switchroom v1, `search`
+  is BLOCKED for any agent with a non-empty
+  `notion_workspace.databases:` allowlist** — the post-filter that
+  would strip out-of-allowlist results isn't wired yet. Use
+  `query_database` against your allowed DBs instead. Admin-shaped
+  agents (no per-DB filter) can search normally.
 - **Database queries.** `query_database` runs a filter+sort against
   a database. You need the database's UUID (operator gives these
   via friendly names in `notion_workspace.databases` — ask the
@@ -98,11 +100,13 @@ The Notion MCP exposes the standard set:
 
 ### "Find that thing about X"
 
-1. `search` with the query. Take only the top result unless ambiguous.
-2. The post-filter has already redacted out-of-allowlist results;
-   don't worry about leakage.
-3. If 0 results: try a `query_database` against the most likely DB
-   with a property filter (matches the value).
+1. If you have full search access (no `databases:` filter): `search`
+   with the query, take the top result unless ambiguous.
+2. If `search` is blocked for you (the hook will return a clear
+   message naming the v1 limitation): `query_database` against
+   each of your allowed DBs in turn, with a title-contains or
+   property filter. List your allowed DBs by checking
+   `notion_workspace.databases:` in your config via `config_get`.
 
 ### "Update the page about X"
 

--- a/src/cli/notion-write-pretool.test.ts
+++ b/src/cli/notion-write-pretool.test.ts
@@ -252,7 +252,25 @@ describe("decide — args-malformed", () => {
 });
 
 describe("decide — search special-case", () => {
-  it("allows search when the agent has notion_workspace", async () => {
+  it("allows search for admin-shaped agents (no databases filter)", async () => {
+    // clerk has notion_workspace: {} — full access. Search is unfiltered
+    // at the upstream-share-list boundary, which is acceptable for admin
+    // agents.
+    const r = await decide(
+      {
+        tool_name: "mcp__notion__search",
+        tool_input: { query: "essays" },
+      },
+      { agentName: "clerk", configLoader: cfg, apiClient: NULL_CLIENT, cache: freshCache() },
+    );
+    expect(r.decision).toBe("allow");
+  });
+
+  it("BLOCKS search for agents with a databases filter (v1 privacy gate)", async () => {
+    // carrie has notion_workspace: { databases: [essays] }. Without the
+    // launcher-side post-filter (tracked at #1913), allowing carrie's
+    // search would leak snippets from other DBs the integration was
+    // shared with. v1 posture: block honestly.
     const r = await decide(
       {
         tool_name: "mcp__notion__search",
@@ -260,7 +278,10 @@ describe("decide — search special-case", () => {
       },
       { agentName: "carrie", configLoader: cfg, apiClient: NULL_CLIENT, cache: freshCache() },
     );
-    expect(r.decision).toBe("allow");
+    expect(r.decision).toBe("block");
+    expect(r.reason).toMatch(/search.*blocked/i);
+    expect(r.reason).toMatch(/query_database/);
+    expect(r.reason).toMatch(/1913/);
   });
 
   it("blocks search when the agent has no notion_workspace", async () => {

--- a/src/cli/notion-write-pretool.ts
+++ b/src/cli/notion-write-pretool.ts
@@ -112,17 +112,33 @@ export async function decide(
 
   const bare = toolName.slice(TOOL_PREFIX.length);
 
-  // `search` is special-cased BEFORE the regular dispatch — the
-  // dispatcher returns args-malformed for search (it's handled at
-  // response time by the post-filter), but the hook still needs to
-  // gate at call time on whether the agent has notion_workspace at
-  // all. The actual result-filtering happens elsewhere (search-
-  // filter.ts) once the response comes back.
+  // `search` v1 posture: the post-filter (src/notion/search-filter.ts)
+  // is unit-tested but not yet wired into the launcher's stdio bridge
+  // (tracked at https://github.com/switchroom/switchroom/issues/1913).
+  // Until that wire-up lands, allowing search for an agent with a
+  // narrowed `databases:` filter would leak snippets from other DBs
+  // the integration was shared with — the privacy invariant RFC §8.5
+  // promised. The honest v1 gate: block search for filtered agents.
+  //
+  // Admin-shaped agents (no `databases:` filter; access whatever the
+  // upstream integration can see) are unaffected — the filter would
+  // have been a no-op for them anyway.
   if (bare === "search") {
     if (!agentHasNotionWorkspace(deps.agentName, config)) {
       return {
         decision: "block",
         reason: `Agent ${deps.agentName} has no notion_workspace config; Notion tool calls are not permitted.`,
+      };
+    }
+    const filter = config.agents?.[deps.agentName]?.notion_workspace?.databases;
+    if (filter !== undefined && filter.length > 0) {
+      return {
+        decision: "block",
+        reason:
+          `Notion \`search\` is blocked for ${deps.agentName} in v1 because the ` +
+          `per-agent allowlist (notion_workspace.databases: [${filter.join(", ")}]) ` +
+          `cannot yet be enforced on search results. Use \`query_database\` against ` +
+          `your allowed DBs instead. Tracked at switchroom/switchroom#1913.`,
       };
     }
     return { decision: "allow" };

--- a/src/cli/notion.ts
+++ b/src/cli/notion.ts
@@ -51,7 +51,7 @@ export function registerNotionCommand(program: Command): void {
   cmd
     .command("test <agent>")
     .description(
-      "Smoke-test Notion access for an agent. Calls /v1/users/me via the broker and prints the integration's bot user.",
+      "Smoke-test the Notion integration token (does NOT exercise per-agent ACL — use `switchroom doctor` for that). Verifies the agent has notion_workspace configured + the token works against Notion's API. Calls /v1/users/me via the operator-side broker and prints the integration's bot user.",
     )
     .option(
       "--vault-key <key>",

--- a/src/notion/db-resolver.test.ts
+++ b/src/notion/db-resolver.test.ts
@@ -120,6 +120,23 @@ describe("resolveDbForNode — no-DB outcomes", () => {
     expect(r.kind).toBe("no-db");
     expect(r.apiCalls).toBe(MAX_WALK_DEPTH);
   });
+
+  it("does NOT poison the cache when hitting MAX_WALK_DEPTH", async () => {
+    // The original cap-exhaustion path wrote `null` to the cache,
+    // which would short-circuit every subsequent lookup of the same
+    // node to no-db forever — even if the real chain is just one
+    // hop deeper than the cap. Regression-gate for that fix.
+    const pages: Record<string, { type: "page_id"; page_id: string }> = {};
+    for (let i = 0; i < MAX_WALK_DEPTH + 2; i += 1) {
+      pages[`page-${i}`] = { type: "page_id", page_id: `page-${i + 1}` };
+    }
+    const client = mockClient(pages);
+    const cache = new PageDbCache();
+    await resolveDbForNode("page-0", "page", client, cache);
+    // The starting node MUST NOT be in the cache as null — that's
+    // the poisoning case.
+    expect(cache.get("page-0").kind).toBe("miss");
+  });
 });
 
 describe("resolveDbForNode — cache short-circuit", () => {

--- a/src/notion/db-resolver.ts
+++ b/src/notion/db-resolver.ts
@@ -32,8 +32,23 @@
 
 import type { PageDbCache } from "./page-db-cache.js";
 
-/** Max walk depth before we give up and call it "no-db". */
-export const MAX_WALK_DEPTH = 4;
+/**
+ * Max walk depth before we give up and call it "no-db".
+ *
+ * Raised from 4 → 6 in v0.13.55 follow-up: Notion blocks can nest
+ * deeper than the original budget (column → callout → toggle →
+ * sub-block → page → DB is 5 hops). 4 was an over-aggressive cap
+ * that surfaced as fail-closed denials on legitimately nested
+ * pages. 6 gives margin without unbounding the walk.
+ *
+ * IMPORTANT: when the depth cap is hit, we do NOT cache the result
+ * as `null` (no-db) — caching would poison subsequent lookups for
+ * the same node. Instead we return `no-db` for the current call but
+ * leave the cache untouched so the next lookup re-walks (and may
+ * succeed if the API was transiently slow on the prior call). See
+ * `resolveDbForNode` end-of-walk handling.
+ */
+export const MAX_WALK_DEPTH = 6;
 
 export type ResolutionResult =
   | { kind: "db"; dbId: string; apiCalls: number }
@@ -150,8 +165,13 @@ export async function resolveDbForNode(
     };
   }
 
-  // Hit walk-depth cap — almost certainly the workspace root.
-  cache.set(startId, null);
+  // Hit walk-depth cap. Deny THIS call (fail-closed), but DO NOT
+  // poison the cache with `null`. If we cached `null`, every future
+  // lookup of the same node would short-circuit to no-db forever
+  // — even if the real chain is only one hop deeper than the cap.
+  // Returning `no-db` without writing to cache lets the next call
+  // re-walk fresh (and possibly succeed if MAX_WALK_DEPTH gets
+  // raised, or if the deeper page gets moved closer to its DB).
   return { kind: "no-db", apiCalls };
 }
 


### PR DESCRIPTION
v0.13.55 shipped 5 PRs of Notion integration. This closes the three
reviewer non-blockers + the search-filter-not-wired correctness gap
discovered during follow-up review.

## Changes

1. **Search privacy gate** (partial #1913). The
   \`src/notion/search-filter.ts\` post-filter is shipped + unit-tested
   but not yet wired into the launcher stdio bridge. Allowing
   \`search\` for an agent with a narrowed \`databases:\` filter would
   leak snippets — the RFC §8.5 invariant unenforced. v1 fix: block
   \`search\` for filtered agents, fail-closed with a clear error
   directing them to \`query_database\`.

2. **Cache poisoning at MAX_WALK_DEPTH**. Original behaviour cached
   \`null\` at depth-cap exhaustion, poisoning the cache forever for
   that node. Raised cap 4→6 + skip the cache write at exhaustion.
   Regression-gate test added.

3. **\`notion test <agent>\` verb wording**. Reviewer noted the verb
   help text was misleading (claims agent-scoped but uses operator
   socket). Clarified to direct operators to \`switchroom doctor\`
   for per-agent ACL checks.

4. **Doc + skill updates** reflecting the v1 search limitation,
   with links to the four tracking issues filed for the deferred
   surface (#1913, #1914, #1915, #1916).

## Test plan

- [x] 76/76 vitest cases passing
- [x] tsc + 4 lint gates clean
- [x] Three new test cases pin the new behaviour (search-allow-admin,
      search-block-filtered, no-cache-poison-at-depth-cap)

## Risk

Low. Only behaviour change is the search-block for agents with a
non-empty \`databases:\` filter. Admin-shaped agents (and the
operator setup path) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)