### PR TITLE
feat(silence-poke): awareness ping at ~60s — give user status before the 5min fallback (closes #1918)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3321,6 +3321,43 @@ silencePoke.startTimer({
     // Re-emit through the unified runtime-metrics fan-out (PostHog + JSONL).
     emitRuntimeMetric(event)
   },
+  onAwarenessPing: async (ctx) => {
+    // Early framework-owned awareness signal (~60s) so the user never
+    // faces a silent chat while the model is busy / held / thinking.
+    // Distinct from the 300s onFrameworkFallback: fires earlier, sends
+    // a SILENT message (disable_notification: true — ambient liveness,
+    // not a device buzz), and is bounded to ONE per turn by the silence-
+    // poke module's `awarenessPingFired` flag. Reuses
+    // `formatFrameworkFallbackText` so the wording stays consistent and
+    // in-flight tools are named when known. If the model has been
+    // silent long enough to cross 300s, the heavier framework_fallback
+    // escalates with a notification.
+    //
+    // Late-fire guard mirrors the framework_fallback handler: skip if
+    // the turn ended cleanly between the silence-poke arming and this
+    // timer-fired handler so we don't talk over a clean response.
+    if (activeTurnStartedAt.get(ctx.key) == null && currentTurn == null) {
+      return
+    }
+    const text = silencePoke.formatFrameworkFallbackText(
+      ctx.fallbackKind,
+      ctx.silenceMs,
+      ctx.inFlightTools,
+    )
+    try {
+      await robustApiCall(
+        () => bot.api.sendMessage(ctx.chatId, text, {
+          ...(ctx.threadId != null ? { message_thread_id: ctx.threadId } : {}),
+          disable_notification: true,
+        }),
+        { chat_id: ctx.chatId, ...(ctx.threadId != null ? { threadId: ctx.threadId } : {}) },
+      )
+    } catch (err) {
+      process.stderr.write(
+        `silence-poke awareness-ping sendMessage failed chat=${ctx.chatId} thread=${ctx.threadId}: ${err}\n`,
+      )
+    }
+  },
   onFrameworkFallback: async (ctx) => {
     // Late-fire short-circuit (2026-05-23 audit finding). The fallback
     // can race a clean turn-end: the model's actual reply lands inside

--- a/telegram-plugin/runtime-metrics.ts
+++ b/telegram-plugin/runtime-metrics.ts
@@ -105,6 +105,23 @@ export type RuntimeMetricEvent =
       silence_ms: number
     }
   /**
+   * Awareness ping (~60s, default): framework-owned user-visible
+   * "still working… / still thinking…" message sent BEFORE the 300s
+   * fallback so the user never faces a silent chat for the full 5
+   * minutes. Silent (no device ping); one-shot per turn; suppressed
+   * by any outbound or sub-agent dispatch. A high rate is the
+   * diagnostic signal that frequent silences exist (held-inbound,
+   * extended-thinking, slow startup), and the rate of the heavier
+   * silence_fallback_sent that still follows tells us how many of
+   * those escalate all the way to 5 min.
+   */
+  | {
+      kind: 'awareness_ping_sent'
+      key: string
+      fallback_kind: 'working' | 'thinking'
+      silence_ms: number
+    }
+  /**
    * #1445 cross-turn pending-async ambient lifecycle. `started` fires
    * when a turn ends with a captured anchor AND a pending Agent/Task/
    * Bash-background dispatch — i.e. the framework will now edit the

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -80,6 +80,13 @@ export interface SilencePokeState {
    *  the ack nudge is specifically about the *first* outbound, so it
    *  never re-arms even after the model later goes quiet again. */
   ackPokeFired: boolean
+  /** True once the early awareness-ping has fired this turn. One-shot:
+   *  the user only needs one "we know it's slow" cue before the heavier
+   *  300s fallback escalates. Independent of the ack-poke (which targets
+   *  the model via piggyback) — awareness-ping targets the user directly
+   *  via Telegram, so it lands even during pure-thinking or held-inbound
+   *  silences when no tool_result is available to piggyback on. */
+  awarenessPingFired: boolean
   /** Wall-clock ms of last poke fire — used for poke-success latency. */
   lastPokeFiredAt: number | null
   /** #1292: in-flight tool calls keyed by toolUseId. Populated by
@@ -101,6 +108,14 @@ export interface ThresholdsMs {
    *  75s `soft` threshold, which measures silence-since-last-outbound
    *  and is the wrong instrument for "you never said hello." */
   ack: number
+  /** Awareness ping: if NO outbound has landed this many ms after turn
+   *  start, send a framework-owned user-visible "still working…" status
+   *  message directly via Telegram. Sits between the model-targeted ack
+   *  poke (10s) and the 300s framework_fallback. Lands even during pure
+   *  extended-thinking or held-inbound silences when no tool_result is
+   *  available to piggyback the model-targeted pokes onto. One-shot per
+   *  turn — the 300s fallback handles further escalation if still silent. */
+  awarenessPing: number
   soft: number
   firm: number
   fallback: number
@@ -112,6 +127,7 @@ export interface ThresholdsMs {
 
 export const DEFAULT_THRESHOLDS: ThresholdsMs = {
   ack: 10_000,
+  awarenessPing: 60_000,
   soft: 75_000,
   firm: 180_000,
   fallback: 300_000,
@@ -145,6 +161,7 @@ export type SilencePokeMetric =
   | { kind: 'silence_poke_fired'; key: string; level: PokeLevel; silence_ms: number; subagent_wait: boolean }
   | { kind: 'silence_poke_succeeded'; key: string; level: PokeLevel; latency_ms: number }
   | { kind: 'silence_fallback_sent'; key: string; fallback_kind: 'working' | 'thinking'; silence_ms: number }
+  | { kind: 'awareness_ping_sent'; key: string; fallback_kind: 'working' | 'thinking'; silence_ms: number }
 
 export interface SilencePokeDeps {
   /** Called when the 300s fallback fires. Caller sends the user-visible
@@ -153,6 +170,12 @@ export interface SilencePokeDeps {
    *  not a model-sourced one, and we want pokes to continue (well, no,
    *  fallbackFired ensures only one per turn anyway). */
   onFrameworkFallback: (ctx: FrameworkFallbackContext) => Promise<void> | void
+  /** Called when the awareness ping fires (default 60s). Caller sends
+   *  a user-visible "still working…" message — silent (no device ping),
+   *  framework-owned, one-shot per turn. Reuses the same context shape
+   *  as onFrameworkFallback so the gateway can reuse `formatFrameworkFallbackText`
+   *  and the in-flight-tool enrichment. */
+  onAwarenessPing: (ctx: FrameworkFallbackContext) => Promise<void> | void
   /** Telemetry sink for poke events. */
   emitMetric: (event: SilencePokeMetric) => void
   /** Threshold overrides (tests). */
@@ -188,6 +211,7 @@ export function startTurn(key: string, now: number): void {
     lastThinkingAt: null,
     fallbackFired: false,
     ackPokeFired: false,
+    awarenessPingFired: false,
     lastPokeFiredAt: null,
     inFlightTools: new Map(),
   })
@@ -483,6 +507,64 @@ function tick(now: number): void {
         subagent_wait: s.subagentDispatchActive,
       })
       continue
+    }
+
+    // Awareness ping — framework-owned user-visible status BEFORE the
+    // 300s heavy fallback. Lands at ~60s even when the model is in pure
+    // extended-thinking or the inbound is held (#1892 follow-up), since
+    // it's delivered directly via the gateway → Telegram, not
+    // piggybacked on tool_result. One-shot per turn; suppressed if any
+    // outbound has happened. The 300s fallback is unchanged and
+    // escalates further if silence persists.
+    //
+    // Independent of pokesFired so soft/firm/fallback still escalate on
+    // their own schedule. Independent of ackPokeFired so a long-running
+    // turn that already received the ack-poke (then went silent again)
+    // still gets the user-facing awareness ping.
+    if (
+      !s.awarenessPingFired
+      && s.lastOutboundAt == null
+      && !s.subagentDispatchActive
+      && silence >= thresholds.awarenessPing
+    ) {
+      s.awarenessPingFired = true
+      const { chatId, threadId } = parseKey(key)
+      const recentThinking = s.lastThinkingAt != null
+        && (now - s.lastThinkingAt) < 30_000
+      const fallbackKind: 'working' | 'thinking' = recentThinking ? 'thinking' : 'working'
+      const inFlightTools: ToolSnapshot[] = Array.from(s.inFlightTools.values())
+        .sort((a, b) => a.startedAt - b.startedAt)
+        .map(t => ({
+          name: t.name,
+          label: t.label,
+          durationMs: now - t.startedAt,
+        }))
+      activeDeps.emitMetric({
+        kind: 'awareness_ping_sent',
+        key,
+        fallback_kind: fallbackKind,
+        silence_ms: silence,
+      })
+      try {
+        const ret = activeDeps.onAwarenessPing({
+          key,
+          chatId,
+          threadId,
+          fallbackKind,
+          silenceMs: silence,
+          inFlightTools,
+        })
+        if (ret != null && typeof (ret as Promise<unknown>).then === 'function') {
+          ;(ret as Promise<unknown>).catch(err => {
+            process.stderr.write(`silence-poke: awareness-ping handler rejected: ${err}\n`)
+          })
+        }
+      } catch (err) {
+        process.stderr.write(`silence-poke: awareness-ping handler threw: ${err}\n`)
+      }
+      // Don't `continue` — soft/firm/fallback can still arm in the same tick
+      // if their thresholds have also been crossed. Awareness-ping is a
+      // sibling signal, not part of the ladder.
     }
 
     if (s.pokesFired === 0 && silence >= softThreshold) {

--- a/telegram-plugin/tests/silence-poke.test.ts
+++ b/telegram-plugin/tests/silence-poke.test.ts
@@ -26,20 +26,27 @@ const ORIGINAL_KILL_SWITCH = process.env.SWITCHROOM_DISABLE_SILENCE_POKE
 interface TestFixtures {
   emitted: SilencePokeMetric[]
   fallbacks: FrameworkFallbackContext[]
+  awarenessPings: FrameworkFallbackContext[]
 }
 
 function setupDeps(opts?: { thresholds?: Partial<typeof DEFAULT_THRESHOLDS> }): TestFixtures {
-  const fixtures: TestFixtures = { emitted: [], fallbacks: [] }
+  const fixtures: TestFixtures = { emitted: [], fallbacks: [], awarenessPings: [] }
   __setDepsForTests({
     emitMetric: (e) => fixtures.emitted.push(e),
     onFrameworkFallback: (ctx) => { fixtures.fallbacks.push(ctx) },
+    onAwarenessPing: (ctx) => { fixtures.awarenessPings.push(ctx) },
     // The ack budget (a new poke that fires *earlier* than `soft`) is
     // disabled by default in this fixture so the soft/firm/fallback
     // ladder tests stay isolated from it. The 'ack budget' describe
     // block opts back in with a real value.
+    //
+    // The 60s awarenessPing is also disabled by default so the existing
+    // soft/firm/fallback ladder tests don't see the new sibling event;
+    // the 'awareness ping' describe block opts back in.
     thresholdsMs: {
       ...DEFAULT_THRESHOLDS,
       ack: Number.MAX_SAFE_INTEGER,
+      awarenessPing: Number.MAX_SAFE_INTEGER,
       ...(opts?.thresholds ?? {}),
     },
   })
@@ -733,13 +740,18 @@ describe('silence-poke — independence across turns', () => {
 
 describe('silence-poke — fallback handler errors do not break timer', () => {
   it('continues to function if onFrameworkFallback throws', () => {
-    const fx: TestFixtures = { emitted: [], fallbacks: [] }
+    const fx: TestFixtures = { emitted: [], fallbacks: [], awarenessPings: [] }
     __setDepsForTests({
       emitMetric: (e) => fx.emitted.push(e),
       onFrameworkFallback: () => { throw new Error('oh no') },
-      // ack budget out of the way — this test exercises the
+      onAwarenessPing: () => {},
+      // ack + awareness-ping out of the way — this test exercises the
       // soft/firm/fallback ladder under a throwing fallback handler.
-      thresholdsMs: { ...DEFAULT_THRESHOLDS, ack: Number.MAX_SAFE_INTEGER },
+      thresholdsMs: {
+        ...DEFAULT_THRESHOLDS,
+        ack: Number.MAX_SAFE_INTEGER,
+        awarenessPing: Number.MAX_SAFE_INTEGER,
+      },
     })
     startTurn('k', 0)
     expect(() => {
@@ -752,12 +764,17 @@ describe('silence-poke — fallback handler errors do not break timer', () => {
   })
 
   it('continues to function if onFrameworkFallback returns a rejected promise', async () => {
-    const fx: TestFixtures = { emitted: [], fallbacks: [] }
+    const fx: TestFixtures = { emitted: [], fallbacks: [], awarenessPings: [] }
     __setDepsForTests({
       emitMetric: (e) => fx.emitted.push(e),
       onFrameworkFallback: () => Promise.reject(new Error('async fail')),
-      // ack budget out of the way — see the throwing-handler test above.
-      thresholdsMs: { ...DEFAULT_THRESHOLDS, ack: Number.MAX_SAFE_INTEGER },
+      onAwarenessPing: () => {},
+      // ack + awareness-ping out of the way — see the throwing-handler test above.
+      thresholdsMs: {
+        ...DEFAULT_THRESHOLDS,
+        ack: Number.MAX_SAFE_INTEGER,
+        awarenessPing: Number.MAX_SAFE_INTEGER,
+      },
     })
     startTurn('k', 0)
     __tickForTests(75_000)
@@ -858,5 +875,98 @@ describe('silence-poke — performance', () => {
     // 1000 turns should tick in well under 50ms — guards against an
     // accidentally-quadratic implementation.
     expect(elapsed).toBeLessThan(50)
+  })
+})
+
+describe('silence-poke — awareness ping (early framework-owned user-visible status)', () => {
+  it('fires once at 60s when no outbound has happened', () => {
+    const fx = setupDeps({ thresholds: { awarenessPing: 60_000 } })
+    startTurn('k', 0)
+    __tickForTests(59_000)
+    expect(fx.awarenessPings.length).toBe(0)
+    __tickForTests(60_000)
+    expect(fx.awarenessPings.length).toBe(1)
+    expect(fx.awarenessPings[0]!.silenceMs).toBeGreaterThanOrEqual(60_000)
+    expect(fx.emitted.some(e => e.kind === 'awareness_ping_sent')).toBe(true)
+  })
+
+  it('is one-shot per turn — does not re-fire as silence continues', () => {
+    const fx = setupDeps({ thresholds: { awarenessPing: 60_000 } })
+    startTurn('k', 0)
+    __tickForTests(60_000)
+    __tickForTests(120_000)
+    __tickForTests(180_000)
+    expect(fx.awarenessPings.length).toBe(1)
+  })
+
+  it('is suppressed by an early outbound', () => {
+    const fx = setupDeps({ thresholds: { awarenessPing: 60_000 } })
+    startTurn('k', 0)
+    noteOutbound('k', 30_000)
+    __tickForTests(90_000)
+    expect(fx.awarenessPings.length).toBe(0)
+  })
+
+  it('is suppressed when subagentDispatchActive is true', () => {
+    // Sub-agent dispatch already widens soft to 300s; the awareness-ping
+    // should also defer so we don't pre-empt the sub-agent's natural
+    // progress signal.
+    const fx = setupDeps({ thresholds: { awarenessPing: 60_000 } })
+    startTurn('k', 0)
+    noteSubagentDispatch('k')
+    __tickForTests(120_000)
+    expect(fx.awarenessPings.length).toBe(0)
+  })
+
+  it('does NOT advance the soft/firm/fallback ladder', () => {
+    // Awareness ping is a sibling signal; soft/firm/fallback continue
+    // to escalate on their own schedule (and the model-targeted ack-poke
+    // similarly remains independent).
+    const fx = setupDeps({ thresholds: { awarenessPing: 60_000 } })
+    startTurn('k', 0)
+    __tickForTests(60_000) // awareness fires
+    __tickForTests(75_000) // soft fires
+    __tickForTests(180_000) // firm fires
+    __tickForTests(300_000) // fallback fires
+    expect(fx.awarenessPings.length).toBe(1)
+    expect(fx.fallbacks.length).toBe(1)
+    expect(fx.emitted.filter(e => e.kind === 'silence_poke_fired').map(e => (e as { level: string }).level))
+      .toEqual(['soft', 'firm'])
+    expect(fx.emitted.some(e => e.kind === 'silence_fallback_sent')).toBe(true)
+  })
+
+  it('carries fallbackKind=thinking when a recent thinking event landed', () => {
+    const fx = setupDeps({ thresholds: { awarenessPing: 60_000 } })
+    startTurn('k', 0)
+    noteThinking('k', 45_000)
+    __tickForTests(60_000)
+    expect(fx.awarenessPings.length).toBe(1)
+    expect(fx.awarenessPings[0]!.fallbackKind).toBe('thinking')
+  })
+
+  it('does not fire if turn ends before the threshold', () => {
+    const fx = setupDeps({ thresholds: { awarenessPing: 60_000 } })
+    startTurn('k', 0)
+    endTurn('k')
+    __tickForTests(120_000)
+    expect(fx.awarenessPings.length).toBe(0)
+  })
+
+  it('handler errors do not break the timer', () => {
+    const fx: TestFixtures = { emitted: [], fallbacks: [], awarenessPings: [] }
+    __setDepsForTests({
+      emitMetric: (e) => fx.emitted.push(e),
+      onFrameworkFallback: () => {},
+      onAwarenessPing: () => { throw new Error('awareness handler boom') },
+      thresholdsMs: {
+        ...DEFAULT_THRESHOLDS,
+        ack: Number.MAX_SAFE_INTEGER,
+        awarenessPing: 60_000,
+      },
+    })
+    startTurn('k', 0)
+    expect(() => __tickForTests(60_000)).not.toThrow()
+    // Telemetry still emitted
+    expect(fx.emitted.some(e => e.kind === 'awareness_ping_sent')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Add a framework-owned **awareness ping** at ~60s. Sibling to the existing 300s framework_fallback, but earlier, silent (no device ping), and one-shot per turn. Lands even when the model is in pure extended-thinking or the inbound is held — situations where the model-targeted ack/soft/firm pokes can't reach the model via tool_result piggyback. Closes #1918.

## Why

User-observed wedge on clerk 2026-05-27: msg received at 12:50:57, **5min 12s of silent chat**, framework_fallback finally fires at 12:55:58, model recovers at 12:56:09. Trace showed the session was completely idle during the silence (held-inbound delivery — separate root cause to investigate). From the user's perspective, the chat is just *dead*.

Per the design contract (`reference/conversational-pacing.md` and Ken's call today): **extended thinking is fine, leaving the user with no status of current action is not.** The 300s fallback is too late — five minutes of silent chat is the "black box" the design exists to prevent. The framework should backstop the user's awareness BEFORE the heavy fallback fires.

## What changed

- `silence-poke.ts`:
  - New `ThresholdsMs.awarenessPing` (default 60_000)
  - New `SilencePokeState.awarenessPingFired` one-shot flag
  - New `SilencePokeDeps.onAwarenessPing` callback (same context shape as `onFrameworkFallback` for reuse)
  - New `awareness_ping_sent` metric
  - `tick()` fires the awareness ping once per turn when no outbound has happened by threshold, suppressed during sub-agent dispatch; INDEPENDENT of the soft/firm/fallback ladder which keeps escalating on its own schedule
- `gateway.ts`:
  - `onAwarenessPing` handler sends a silent Telegram message reusing `formatFrameworkFallbackText` so wording + in-flight tool naming are identical to the 300s fallback; just no device ping
  - Late-fire guard mirrors `onFrameworkFallback` (skip if turn ended cleanly)
- `tests/silence-poke.test.ts`: 8 new cases pinning the contract + existing fixtures updated to provide the new dep stub

## UX

Pre-fix at 60s into a wedged turn: user sees nothing.
Post-fix at 60s into a wedged turn: silent Telegram message *"still working… (no update from agent in 1 min)"* — same wording/style as the 300s fallback so the user reads it as "framework status, not the model talking."

At 300s if still silent the heavy fallback fires with a device ping (unchanged).

## Risk

Low. Additive — new beat that doesn't touch the ack/soft/firm/fallback ladder. Kill-switched via the existing `SWITCHROOM_DISABLE_SILENCE_POKE=1`. Handler errors caught + logged, timer survives. Default threshold (60s) is conservative — well past any normal model latency, well before the user gives up.

The reused `formatFrameworkFallbackText` already produces honest framework-tagged wording (the `(no update from agent in N min)` suffix). When in-flight tools are known, it names them — same enrichment carries over.

## Test plan

- [x] 8 new awareness-ping cases — fires at threshold, one-shot, suppressed by outbound, suppressed during sub-agent, ladder-independent, thinking-kind detection, end-of-turn safe, handler-error safe
- [x] silence-poke.test.ts: 67/67 pass
- [x] telegram-plugin/tests/: 3500/3500 pass
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)