### PR TITLE
feat(pacing): ack-first PreToolUse gate — framework enforces beat 1

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -181,6 +181,13 @@ RUN chmod 0755 /opt/switchroom/hooks/ms-365-write-pretool.mjs
 COPY dist/cli/notion-write-pretool.mjs /opt/switchroom/hooks/notion-write-pretool.mjs
 RUN chmod 0755 /opt/switchroom/hooks/notion-write-pretool.mjs
 
+# ack-first-pretool — enforces the human-feel "ack first" beat
+# (`reference/conversational-pacing.md` beat 1). Blocks non-reply tool
+# calls when no reply has been sent this turn; reply itself always
+# allowed. Reads $TELEGRAM_STATE_DIR/ack-sent.flag (gateway-owned).
+COPY dist/cli/ack-first-pretool.mjs /opt/switchroom/hooks/ack-first-pretool.mjs
+RUN chmod 0755 /opt/switchroom/hooks/ack-first-pretool.mjs
+
 # Advisory skill-shape linter (RFC native-by-default skill authoring,
 # Phase 1). Non-blocking — nudges the model toward a well-formed skill
 # when it writes under .claude/skills/; only the per-skill byte cap is

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -163,6 +163,25 @@ if (ms365HookEscape.changed) {
   console.log(`[build] ASCII-escaped ${ms365HookEscape.nonAsciiCount} non-ASCII code units in dist/cli/ms-365-write-pretool.mjs`);
 }
 
+// Bundle the ack-first-pretool hook — enforces the human-feel "ack
+// first" beat. Reads $TELEGRAM_STATE_DIR/ack-sent.flag (touched by
+// the gateway at first reply, cleared at turn_started); blocks any
+// non-reply tool call when the flag is absent. Standalone self-
+// contained .mjs — pure decide() with a tiny runHook() wrapper, no
+// switchroom-side imports needed beyond node:fs/node:path so the
+// bundle stays small and fail-open by construction.
+console.log("[build] bundling src/cli/ack-first-pretool.ts -> dist/cli/ack-first-pretool.mjs");
+execSync(
+  `bun build ${JSON.stringify(resolve(root, "src/cli/ack-first-pretool.ts"))} --outfile ${JSON.stringify(resolve(outDir, "ack-first-pretool.mjs"))} --target node`,
+  { stdio: "inherit", cwd: root }
+);
+const ackHookOutFile = resolve(outDir, "ack-first-pretool.mjs");
+chmodSync(ackHookOutFile, 0o755);
+const ackHookEscape = escapeBundleNonAscii(ackHookOutFile);
+if (ackHookEscape.changed) {
+  console.log(`[build] ASCII-escaped ${ackHookEscape.nonAsciiCount} non-ASCII code units in dist/cli/ack-first-pretool.mjs`);
+}
+
 // Bundle the notion-write-pretool hook — RFC docs/rfcs/notion-integration.md
 // §8 PR 3. Same pattern: self-contained .mjs the agent container runs
 // via node. Imports the shared resolver + cache + config-loader from

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3518,6 +3518,30 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
           ],
         },
         {
+          // Ack-first enforcement (`reference/conversational-pacing.md`
+          // beat 1). UAT (2026-05-28 jtbd-fast-ack-dm) showed the
+          // advisory prompt + silence-poke ack-poke combination delivered
+          // a real fast ack on only 1 of 8 non-trivial prompts; this
+          // hook is the framework's structural lever to make the beat
+          // happen every time. Reads `$TELEGRAM_STATE_DIR/ack-sent.flag`
+          // (gateway-owned — touched at first reply, cleared at
+          // turn_started). Reply tools are unconditionally allowed; the
+          // hook decides internally so a single registration covers
+          // every other tool name. Kill-switched via
+          // SWITCHROOM_DISABLE_ACK_FIRST_GATE=1 on the agent env.
+          hooks: [
+            {
+              type: "command",
+              command: wrap(
+                "hook:ack-first-pretool",
+                `node "${join(DOCKER_BUNDLED_HOOKS_PATH, "ack-first-pretool.mjs")}"`,
+              ),
+              // Tiny hook (one existsSync + stdin parse). 5s is generous.
+              timeout: 5,
+            },
+          ],
+        },
+        {
           // RFC native-by-default skill authoring, Phase 1 — advisory
           // skill-shape linter. Scoped to file-write tools; the hook
           // itself no-ops unless the target path is under

--- a/src/cli/ack-first-pretool.test.ts
+++ b/src/cli/ack-first-pretool.test.ts
@@ -101,11 +101,12 @@ describe("ack-first-pretool — decide()", () => {
       ).toBe("allow");
     });
 
-    it("treats missing tool_name as a non-reply tool (block)", () => {
-      // Defensive: an empty / missing tool_name shouldn't crash. It falls
-      // through to the "non-reply" branch which blocks — fail-safe for the
-      // protocol-error case.
-      expect(decide({}, stateDir).decision).toBe("block");
+    it("allows when tool_name is missing (protocol-error → fail-open)", () => {
+      // A Claude Code protocol error (no tool_name) shouldn't gate
+      // anything — we don't know what we'd be gating. Fail-open per
+      // the file-doc.
+      expect(decide({}, stateDir).decision).toBe("allow");
+      expect(decide({ tool_name: "" }, stateDir).decision).toBe("allow");
     });
   });
 });

--- a/src/cli/ack-first-pretool.test.ts
+++ b/src/cli/ack-first-pretool.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { decide, ACK_SENT_MARKER, type HookInput } from "./ack-first-pretool.js";
+
+describe("ack-first-pretool — decide()", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "ack-first-pretool-"));
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  describe("reply tools always allowed", () => {
+    it("allows mcp__switchroom-telegram__reply with no ack flag present", () => {
+      const input: HookInput = {
+        tool_name: "mcp__switchroom-telegram__reply",
+        tool_input: { chat_id: "1", text: "hi" },
+      };
+      expect(decide(input, stateDir)).toEqual({ decision: "allow" });
+    });
+
+    it("allows mcp__switchroom-telegram__stream_reply with no ack flag present", () => {
+      const input: HookInput = {
+        tool_name: "mcp__switchroom-telegram__stream_reply",
+        tool_input: { chat_id: "1", text: "hi" },
+      };
+      expect(decide(input, stateDir)).toEqual({ decision: "allow" });
+    });
+  });
+
+  describe("non-reply tools gated on ack flag", () => {
+    it("blocks WebSearch when no ack flag exists", () => {
+      const input: HookInput = {
+        tool_name: "WebSearch",
+        tool_input: { query: "test" },
+      };
+      const result = decide(input, stateDir);
+      expect(result.decision).toBe("block");
+      expect(result.reason).toMatch(/acknowledgement/);
+      expect(result.reason).toMatch(/mcp__switchroom-telegram__reply/);
+    });
+
+    it("blocks Bash when no ack flag exists", () => {
+      const input: HookInput = {
+        tool_name: "Bash",
+        tool_input: { command: "ls" },
+      };
+      expect(decide(input, stateDir).decision).toBe("block");
+    });
+
+    it("allows non-reply tools once the ack flag is present", () => {
+      writeFileSync(join(stateDir, ACK_SENT_MARKER), "");
+      const tools = [
+        "WebSearch",
+        "WebFetch",
+        "Bash",
+        "Read",
+        "mcp__google-workspace__list_drive_files",
+        "Task",
+      ];
+      for (const tool_name of tools) {
+        expect(decide({ tool_name }, stateDir).decision).toBe("allow");
+      }
+    });
+
+    it("blocks again after the flag is removed (turn-restart simulation)", () => {
+      writeFileSync(join(stateDir, ACK_SENT_MARKER), "");
+      expect(decide({ tool_name: "Bash" }, stateDir).decision).toBe("allow");
+      // turn_started clears the flag
+      rmSync(join(stateDir, ACK_SENT_MARKER));
+      expect(decide({ tool_name: "Bash" }, stateDir).decision).toBe("block");
+    });
+  });
+
+  describe("fail-open shape", () => {
+    it("allows when stateDir is undefined (misconfigured agent)", () => {
+      expect(decide({ tool_name: "Bash" }, undefined).decision).toBe("allow");
+    });
+
+    it("allows when stateDir is empty string", () => {
+      expect(decide({ tool_name: "Bash" }, "").decision).toBe("allow");
+    });
+
+    it("blocks (not crashes) when stateDir path is unreadable but tool is non-reply", () => {
+      // Pointing at a non-existent dir: existsSync(.../ack-sent.flag) just
+      // returns false. So the hook blocks — same as the "no ack yet" case.
+      const phantom = join(stateDir, "does-not-exist");
+      expect(decide({ tool_name: "Bash" }, phantom).decision).toBe("block");
+    });
+
+    it("allows reply tools even with undefined stateDir", () => {
+      expect(
+        decide({ tool_name: "mcp__switchroom-telegram__reply" }, undefined)
+          .decision,
+      ).toBe("allow");
+    });
+
+    it("treats missing tool_name as a non-reply tool (block)", () => {
+      // Defensive: an empty / missing tool_name shouldn't crash. It falls
+      // through to the "non-reply" branch which blocks — fail-safe for the
+      // protocol-error case.
+      expect(decide({}, stateDir).decision).toBe("block");
+    });
+  });
+});

--- a/src/cli/ack-first-pretool.ts
+++ b/src/cli/ack-first-pretool.ts
@@ -87,6 +87,12 @@ export function decide(
 ): HookDecision {
   const toolName = input.tool_name ?? "";
 
+  // Fail-open: a missing/empty tool_name is a Claude Code protocol
+  // error — never gate on it (we don't know what we'd be gating).
+  if (toolName === "") {
+    return { decision: "allow" };
+  }
+
   // Reply tools are always allowed — that's literally the call the
   // hook asks the model to make.
   if (REPLY_TOOL_NAMES.has(toolName)) {

--- a/src/cli/ack-first-pretool.ts
+++ b/src/cli/ack-first-pretool.ts
@@ -1,0 +1,177 @@
+/**
+ * PreToolUse hook — enforces the human-feel "ack first" beat
+ * (`reference/conversational-pacing.md` beat 1).
+ *
+ * Bundled to `/opt/switchroom/hooks/ack-first-pretool.mjs` at build
+ * time so it runs inside every switchroom-telegram-plugin agent.
+ *
+ * Contract:
+ *   Input:  JSON on stdin — `{ session_id, tool_name, tool_input, ... }`
+ *   Output: exit 0 + empty stdout → allow.
+ *           exit 0 + JSON `{ decision: "block", reason: "..." }` → block.
+ *
+ * Behaviour:
+ *   - Reply / stream_reply tool calls themselves: always allowed. The
+ *     hook never gates the very tool it asks the model to call.
+ *   - Any other tool call: allowed IFF an ack has already been sent
+ *     this turn (`$TELEGRAM_STATE_DIR/ack-sent.flag` exists). The
+ *     gateway touches this flag at `executeReply` on the first reply
+ *     of each turn and clears it at `turn_started`.
+ *   - If the flag is absent: BLOCK with a clear reason. The model's
+ *     next move is forced into `reply` with a brief acknowledgement.
+ *
+ * Why this exists (the diagnostic that motivated it):
+ *   The prompt-side directives (`profiles/_shared/telegram-style.md.hbs`,
+ *   the per-turn `<turn-pacing>` UserPromptSubmit hook, the silence-
+ *   poke ack-budget `<system-reminder>` piggyback at 10s) are all
+ *   advisory. UAT (2026-05-28 jtbd-fast-ack-dm 8-prompt fuzz on
+ *   v0.13.55) showed the model produced a real fast ack in only 1 of
+ *   8 non-trivial prompts; 3 of 8 were full-answer dumps with no ack
+ *   at all. The framework owns the beat — this hook is the
+ *   enforcement primitive.
+ *
+ * Cost model:
+ *   - Trivial-answer turns that don't use other tools: no overhead.
+ *     The model calls `reply` with the whole answer; flag fires;
+ *     turn ends normally.
+ *   - Heavy turns that need tools first: ONE extra `reply` call
+ *     forced before the tool. ~100-300ms of model+network. The user
+ *     gets immediate awareness in return — the whole point of the
+ *     5-beat design.
+ *
+ * Fail modes (all fail-OPEN so a broken hook never wedges the model):
+ *   - Stdin parse fails → allow (let Claude Code report its own
+ *     protocol error if any).
+ *   - TELEGRAM_STATE_DIR env missing → allow. Without the flag path,
+ *     we can't gate; better to let the model proceed than wedge it.
+ *   - Filesystem error reading the flag → allow.
+ *
+ * Kill switch: `SWITCHROOM_DISABLE_ACK_FIRST_GATE=1` allows all tool
+ * calls regardless. Defence-in-depth for fleet operators if the hook
+ * ever produces a regression class we need to clear urgently.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Reply tools that satisfy the ack requirement. Both the main reply
+ *  and the streaming variant count — stream_reply landing its first
+ *  emit fires the gateway's `recordOutbound` + `markAckSent` the same
+ *  way as `reply` does. */
+const REPLY_TOOL_NAMES = new Set([
+  "mcp__switchroom-telegram__reply",
+  "mcp__switchroom-telegram__stream_reply",
+]);
+
+/** Marker filename inside `$TELEGRAM_STATE_DIR`. Touched by the gateway
+ *  on the first reply of each turn, removed at the next `turn_started`. */
+export const ACK_SENT_MARKER = "ack-sent.flag";
+
+export interface HookInput {
+  session_id?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+}
+
+export interface HookDecision {
+  decision: "allow" | "block";
+  /** Operator-facing reason; surfaced to the model when blocked. */
+  reason?: string;
+}
+
+/** Pure decision function — given a parsed input + the resolved state
+ *  dir, compute allow/block. Exposed for unit tests. */
+export function decide(
+  input: HookInput,
+  stateDir: string | undefined,
+): HookDecision {
+  const toolName = input.tool_name ?? "";
+
+  // Reply tools are always allowed — that's literally the call the
+  // hook asks the model to make.
+  if (REPLY_TOOL_NAMES.has(toolName)) {
+    return { decision: "allow" };
+  }
+
+  if (!stateDir) {
+    // Can't gate without the state dir. Allow so a misconfigured
+    // agent isn't bricked.
+    return { decision: "allow" };
+  }
+
+  const markerPath = join(stateDir, ACK_SENT_MARKER);
+  let ackAlreadySent = false;
+  try {
+    ackAlreadySent = existsSync(markerPath);
+  } catch {
+    // Filesystem error — allow (fail-open).
+    return { decision: "allow" };
+  }
+  if (ackAlreadySent) {
+    return { decision: "allow" };
+  }
+
+  return {
+    decision: "block",
+    reason:
+      "First call `mcp__switchroom-telegram__reply` with a brief one-line " +
+      "acknowledgement in your persona's voice before using any other tool — " +
+      'e.g. "on it — checking", "good question — one sec", "let me dig in". ' +
+      "This is the framework's enforcement of the human-feel design " +
+      "(`reference/conversational-pacing.md` beat 1): a colleague answers " +
+      "in a beat. The reply can be the entire short answer if you have one " +
+      "ready (then no further work needed); otherwise it's a brief status " +
+      "and you continue with the work after.",
+  };
+}
+
+/** Live hook entry — reads stdin, writes stdout, exits. */
+export async function runHook(): Promise<void> {
+  if (process.env.SWITCHROOM_DISABLE_ACK_FIRST_GATE === "1") {
+    process.exit(0);
+  }
+
+  const stdin = await readStdin();
+  let input: HookInput;
+  try {
+    input = JSON.parse(stdin) as HookInput;
+  } catch {
+    // Fail-open: malformed stdin shouldn't block tools.
+    process.exit(0);
+  }
+
+  const stateDir = process.env.TELEGRAM_STATE_DIR;
+  const decision = decide(input, stateDir);
+
+  if (decision.decision === "block") {
+    process.stdout.write(
+      JSON.stringify({ decision: "block", reason: decision.reason }) + "\n",
+    );
+  }
+  process.exit(0);
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on("data", (chunk: Buffer) => chunks.push(chunk));
+    process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    process.stdin.on("error", reject);
+    // If stdin closes immediately (no data), resolve empty.
+    if (process.stdin.isTTY) resolve("");
+  });
+}
+
+// CLI entry point — when the bundled mjs is invoked directly.
+if (
+  typeof process !== "undefined" &&
+  process.argv?.[1]?.endsWith("ack-first-pretool.mjs")
+) {
+  runHook().catch((err) => {
+    process.stderr.write(
+      `ack-first-pretool: hook failed unexpectedly: ${err}\n`,
+    );
+    // Fail-open even on unexpected error.
+    process.exit(0);
+  });
+}

--- a/telegram-plugin/ack-flag.ts
+++ b/telegram-plugin/ack-flag.ts
@@ -1,0 +1,66 @@
+/**
+ * Ack-first state flag — load-bearing for the ack-first-pretool hook
+ * (see `src/cli/ack-first-pretool.ts` and
+ * `reference/conversational-pacing.md` beat 1).
+ *
+ * The gateway is the source of truth for "has the model called reply
+ * yet this turn?". The PreToolUse hook runs as a short-lived child
+ * process so it can't read gateway in-memory state; the hand-off is
+ * a single file inside `$TELEGRAM_STATE_DIR`:
+ *
+ *   - `markAckSent()` touches the file on the first reply per turn.
+ *   - `clearAckSent()` removes it at turn_started.
+ *   - The hook checks `existsSync(path)` → allow / block.
+ *
+ * Per-agent isolation is built-in: `$TELEGRAM_STATE_DIR` is the
+ * agent's per-container state dir (~/.switchroom/agents/<name>/telegram,
+ * bind-mounted into /state/agent/home/.switchroom/agents/<name>/telegram
+ * inside the container).
+ *
+ * All operations are best-effort: a write or unlink failure logs to
+ * stderr and returns; the gate is informational UX, not a safety
+ * primitive, so a broken state-dir must never wedge reply itself.
+ */
+
+import { closeSync, existsSync, openSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+export const ACK_SENT_MARKER = "ack-sent.flag";
+
+function markerPath(): string | null {
+  const dir = process.env.TELEGRAM_STATE_DIR;
+  if (!dir) return null;
+  return join(dir, ACK_SENT_MARKER);
+}
+
+/** Create the ack-sent marker. Idempotent (no-op if it exists). */
+export function markAckSent(): void {
+  const path = markerPath();
+  if (path == null) return;
+  if (existsSync(path)) return;
+  try {
+    const fd = openSync(path, "w");
+    closeSync(fd);
+  } catch (err) {
+    process.stderr.write(
+      `ack-flag: markAckSent failed path=${path}: ${err}\n`,
+    );
+  }
+}
+
+/** Remove the ack-sent marker. Idempotent. */
+export function clearAckSent(): void {
+  const path = markerPath();
+  if (path == null) return;
+  try {
+    unlinkSync(path);
+  } catch (err: unknown) {
+    // ENOENT is the common case (turn started before any prior turn
+    // ran a reply); silently swallow.
+    const code = (err as { code?: string } | undefined)?.code;
+    if (code === "ENOENT") return;
+    process.stderr.write(
+      `ack-flag: clearAckSent failed path=${path}: ${err}\n`,
+    );
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6791,6 +6791,14 @@ function handleSessionEvent(ev: SessionEvent): void {
           statusKey(ev.chatId, enqThreadId),
           'handback',
         )
+        // Ack-first gate (`reference/conversational-pacing.md` beat 1):
+        // wipe the prior turn's `ack-sent.flag` so the ack-first-
+        // pretool hook re-arms for this fresh turn. Centralised HERE
+        // (not in handleInbound) because `enqueue` is the single
+        // canonical fresh-turn atom — fires for real inbounds, cron
+        // fires, subagent-handback channel wakes, vault-grant resumes,
+        // and restart markers alike. Best-effort — see ack-flag.ts.
+        clearAckSent()
       }
       if (ev.chatId) {
         // Issue #195: if a previous turn left an answer-lane stream open
@@ -9051,12 +9059,11 @@ async function handleInbound(
         // the framework can nudge the model if it goes quiet past the
         // soft / firm thresholds.
         silencePoke.startTurn(statusKey(chat_id, messageThreadId), Date.now())
-        // Ack-first gate (`reference/conversational-pacing.md` beat 1):
-        // wipe the previous turn's marker so the ack-first-pretool hook
-        // re-arms for this fresh turn. The first reply this turn will
-        // re-touch the flag, unlocking subsequent non-reply tool calls.
-        // Best-effort — see ack-flag.ts.
-        clearAckSent()
+        // Ack-first gate clear is centralised in handleSessionEvent's
+        // `enqueue` branch — that fires for EVERY fresh turn atom
+        // (real inbound, cron, subagent-handback, vault-grant wake,
+        // restart marker) so cron/handback turns also re-arm the gate.
+        // See the call site under `case 'enqueue'` (~line 6794).
         // #1445 cross-turn pending-async ambient. A new turn starting
         // (user inbound, synthesised wake, or handback channel) is the
         // signal that the model is about to re-engage — clear any

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -80,6 +80,7 @@ import { classifyInbound } from '../inbound-classifier.js'
 import * as silencePoke from '../silence-poke.js'
 import * as pendingProgress from '../pending-work-progress.js'
 import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd } from '../silent-end.js'
+import { markAckSent, clearAckSent } from '../ack-flag.js'
 import { isFinalAnswerReply } from '../final-answer-detect.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
 import { type SessionEvent } from '../session-tail.js'
@@ -4944,6 +4945,16 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // silence-poke clock so the next poke is measured from this send.
   signalTracker.noteOutbound(statusKey(chat_id, threadId), Date.now())
   silencePoke.noteOutbound(statusKey(chat_id, threadId), Date.now())
+  // Ack-first gate (`reference/conversational-pacing.md` beat 1):
+  // touch the state-dir flag so the ack-first-pretool hook lets
+  // subsequent non-reply tool calls through this turn. Cleared at
+  // turn_started. Best-effort — a write failure shouldn't break
+  // reply, and the hook is kill-switched anyway.
+  try {
+    markAckSent()
+  } catch (err) {
+    process.stderr.write(`telegram gateway: markAckSent failed: ${err}\n`)
+  }
   // #1741 — only clear silent-end state on a plausibly-final reply.
   // An interim ack (disable_notification:true, short text, no done)
   // must NOT clear the state file; otherwise a turn that ends with
@@ -5539,6 +5550,13 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       const sKey = statusKey(streamChatId, streamThreadId)
       signalTracker.noteOutbound(sKey, Date.now())
       silencePoke.noteOutbound(sKey, Date.now())
+      // Ack-first gate: stream_reply's first emit also unlocks subsequent
+      // tool calls. See ack-flag.ts + ack-first-pretool.ts.
+      try {
+        markAckSent()
+      } catch (err) {
+        process.stderr.write(`telegram gateway: markAckSent (stream_reply) failed: ${err}\n`)
+      }
       // #1741 — see executeReply for the rationale: only a plausibly-
       // final stream_reply clears the silent-end state. An interim
       // ack via stream_reply must NOT clear; the Stop hook needs
@@ -9033,6 +9051,12 @@ async function handleInbound(
         // the framework can nudge the model if it goes quiet past the
         // soft / firm thresholds.
         silencePoke.startTurn(statusKey(chat_id, messageThreadId), Date.now())
+        // Ack-first gate (`reference/conversational-pacing.md` beat 1):
+        // wipe the previous turn's marker so the ack-first-pretool hook
+        // re-arms for this fresh turn. The first reply this turn will
+        // re-touch the flag, unlocking subsequent non-reply tool calls.
+        // Best-effort — see ack-flag.ts.
+        clearAckSent()
         // #1445 cross-turn pending-async ambient. A new turn starting
         // (user inbound, synthesised wake, or handback channel) is the
         // signal that the model is about to re-engage — clear any

--- a/telegram-plugin/tests/ack-flag.test.ts
+++ b/telegram-plugin/tests/ack-flag.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { markAckSent, clearAckSent, ACK_SENT_MARKER } from "../ack-flag.js";
+
+describe("ack-flag — gateway-side state file for ack-first hook", () => {
+  let stateDir: string;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "ack-flag-"));
+    prevEnv = process.env.TELEGRAM_STATE_DIR;
+    process.env.TELEGRAM_STATE_DIR = stateDir;
+  });
+
+  afterEach(() => {
+    if (prevEnv != null) process.env.TELEGRAM_STATE_DIR = prevEnv;
+    else delete process.env.TELEGRAM_STATE_DIR;
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("markAckSent creates the marker file", () => {
+    expect(existsSync(join(stateDir, ACK_SENT_MARKER))).toBe(false);
+    markAckSent();
+    expect(existsSync(join(stateDir, ACK_SENT_MARKER))).toBe(true);
+  });
+
+  it("markAckSent is idempotent (second call is a no-op)", () => {
+    markAckSent();
+    expect(() => markAckSent()).not.toThrow();
+    expect(existsSync(join(stateDir, ACK_SENT_MARKER))).toBe(true);
+  });
+
+  it("clearAckSent removes the marker file", () => {
+    markAckSent();
+    expect(existsSync(join(stateDir, ACK_SENT_MARKER))).toBe(true);
+    clearAckSent();
+    expect(existsSync(join(stateDir, ACK_SENT_MARKER))).toBe(false);
+  });
+
+  it("clearAckSent is idempotent (works when marker doesn't exist)", () => {
+    expect(existsSync(join(stateDir, ACK_SENT_MARKER))).toBe(false);
+    expect(() => clearAckSent()).not.toThrow();
+  });
+
+  it("round-trip: mark → clear → mark cycles work across turns", () => {
+    // turn 1
+    markAckSent();
+    expect(existsSync(join(stateDir, ACK_SENT_MARKER))).toBe(true);
+    // turn end / next turn start
+    clearAckSent();
+    expect(existsSync(join(stateDir, ACK_SENT_MARKER))).toBe(false);
+    // turn 2 first reply
+    markAckSent();
+    expect(existsSync(join(stateDir, ACK_SENT_MARKER))).toBe(true);
+  });
+
+  it("noop when TELEGRAM_STATE_DIR is unset (best-effort)", () => {
+    delete process.env.TELEGRAM_STATE_DIR;
+    expect(() => markAckSent()).not.toThrow();
+    expect(() => clearAckSent()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Add a structural enforcement primitive for **beat 1 of the conversational-pacing design** (ack first, before any other tool). UAT showed advisory prompts + `<system-reminder>` pokes deliver a real fast ack only **1 of 8** non-trivial prompts on v0.13.55. The framework owns the beat; this PR makes the framework actually own it.

Closes the heart of #1918's structural-ceiling investigation.

## UAT-driven diagnosis (2026-05-28)

Ran `jtbd-fast-ack-dm` on the live v0.13.55 fleet against test-harness. 8 fuzzy non-trivial prompts:

| Prompt | TTFO | Length | Pattern |
|---|---|---|---|
| machine-summary research | 8.5s | 5 chars | minimal ack |
| compound date math | 7.4s | 62 chars | **proper ack** |
| open-ended prioritisation | 8.8s | 175 chars | mixed |
| plain-language summary | 10.1s | 450 chars | **answer dump, no ack** |
| bash one-liner | 10.9s | 428 chars | **answer dump, no ack** |
| reflective open ask | 9.3s | 297 chars | borderline |
| tech comparison | 11.4s | 599 chars | **answer dump, no ack** |
| disk-usage investigation | 9.1s | 8 chars | minimal ack |

7 of 8 missed the vision target. 3 of 8 produced no ack at all. The advisory levers (`telegram-style.md.hbs`, per-turn `<turn-pacing>` hook, silence-poke ack-poke piggyback) are not sufficient.

## The fix — structural

PreToolUse hook fires on every tool call. Reply tools always pass. Non-reply tools are blocked when `$TELEGRAM_STATE_DIR/ack-sent.flag` is absent. The gateway touches the flag on first reply per turn, clears it at `turn_started`. The model is forced into ack-first compliance by mechanism, not suggestion.

Trivial-answer turns are unaffected (their first tool call IS reply). Heavy turns gain exactly one extra reply call (~100-300ms) and the user gets immediate awareness in return.

## Files

- `src/cli/ack-first-pretool.ts` + bundle wiring — pure `decide()` + `runHook()` entry, ~150 lines, fail-open by construction
- `telegram-plugin/ack-flag.ts` — gateway-side `markAckSent` / `clearAckSent` helpers (~60 lines)
- `telegram-plugin/gateway/gateway.ts` — `markAckSent()` on reply + stream_reply first-emit, `clearAckSent()` at turn_started
- `src/agents/scaffold.ts` — registers the hook in settings.json PreToolUse
- `docker/Dockerfile.agent` + `scripts/build.mjs` — bake the bundle into the image
- Tests: `src/cli/ack-first-pretool.test.ts` (11 cases) + `telegram-plugin/tests/ack-flag.test.ts` (6 cases)

## Kill switch

`SWITCHROOM_DISABLE_ACK_FIRST_GATE=1` on the agent env bypasses the gate.

## Risk

Low. Hook is fail-open by construction (any malformed input / missing env / FS error → allow). Reply tools always allowed so the model can never get stuck. Bundle is 2.4KB. Node-spawn cost per tool call is real but bounded (~50-100ms); for a typical heavy turn (5 tool calls) that's ~500ms extra wall-clock — the design trade for the UX gain.

## Test plan

- [x] `vitest run src/cli/ack-first-pretool.test.ts` — 11/11 pass
- [x] `bun test telegram-plugin/tests/ack-flag.test.ts` — 6/6 pass
- [x] `vitest run tests/scaffold` — 239/239 pass
- [x] `bun test telegram-plugin/tests/silence-poke.test.ts` — 67/67 pass
- [x] Smoke-test of built bundle: block-then-allow + reply-always-allowed
- [x] `tsc --noEmit` clean
- [x] `check-plugin-references` clean
- [x] `check-bot-api-wrapping` clean

**Post-merge UAT** (mandatory): re-run `jtbd-fast-ack-dm` on the fleet rolled to this build. Success rate of the ack one-liner should jump from 1/8 to 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)