### PR TITLE
refactor(host-control): replace claude -p deep probe with auth-broker token check

### DIFF
--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -231,10 +231,12 @@ export const DoctorRequestSchema = z.object({
  * (auth creds present, scheduler block + sidecar, .mcp.json /
  * .claude.json valid, bot-token present, /state writable). Every
  * probe returns only a boolean/state — NEVER a secret value. `deep`
- * opts into a real, quota-costing `claude -p` auth smoke; the default
- * makes NO model call (subscription-honest). Self-target is allowed;
- * cross-agent requires admin (mirrors agent_logs/agent_exec). The
- * doctor CLI (operator socket) + Telegram /doctor consume this to
+ * opts into an additional `auth_live` probe that parses the in-container
+ * `.credentials.json` and verifies the OAuth token format and expiry —
+ * no model call, no programmatic usage (subscription-honest). The
+ * default (deep absent/false) still makes NO model call. Self-target is
+ * allowed; cross-agent requires admin (mirrors agent_logs/agent_exec).
+ * The doctor CLI (operator socket) + Telegram /doctor consume this to
  * upgrade the WS6-F2 host-unverifiable `skip` rows to real ok/fail;
  * a down container / unreachable hostd degrades to skip, never fail.
  */

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1572,9 +1572,30 @@ export class HostdServer {
       { name: "state", cmd: "test -w /state/agent" },
     ];
     if (req.args.deep) {
+      // Token-introspect probe: parse .credentials.json in-container and
+      // verify the OAuth access token is present (correct format) and
+      // non-expired. No model call — no programmatic usage. Replaces the
+      // former `claude -p ok` check which was a compliance violation under
+      // Anthropic's 2026-06-15 policy (programmatic usage, off subscription).
+      // Closes #1798.
       PROBES.push({
         name: "auth_live",
-        cmd: "timeout 25 claude -p ok >/dev/null 2>&1",
+        // python3 is already used by the `mcp` probe above so it is
+        // guaranteed available. The script exits 0 only when:
+        //   1. .credentials.json exists and is valid JSON
+        //   2. claudeAiOauth.accessToken matches sk-ant-oat\d+- prefix
+        //   3. claudeAiOauth.expiresAt is absent OR in the future (ms epoch)
+        // Single-quoted around the python body so shell passes it verbatim.
+        // Nothing is printed — exit code is the only signal; no token value
+        // can leak into the hostd response or operator audit log.
+        cmd:
+          "python3 -c 'import json,sys,time,re;" +
+          'c=json.load(open("/state/agent/.claude/.credentials.json"));' +
+          'o=c.get("claudeAiOauth",{});' +
+          't=o.get("accessToken","");' +
+          'sys.exit(0 if re.match(r"sk-ant-oat\\d+-",t)' +
+          ' and ("expiresAt" not in o or o["expiresAt"]>time.time()*1000)' +
+          " else 1)'",
       });
     }
 

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -1235,8 +1235,9 @@ export class HostdServer {
    * `skip`; the verb itself is always `completed` when it ran (a
    * failing probe is a *finding* the caller renders, not a
    * verb-dispatch failure — same posture as the doctor verb). `deep`
-   * adds a real, quota-costing `claude -p` auth smoke; the default
-   * makes NO model call.
+   * adds an auth-liveness check that reads the agent's stored OAuth
+   * credential and verifies it is present and unexpired; it makes NO
+   * model call (the default path makes no model call either).
    */
   /**
    * `config_propose_edit` — full apply path (#1623 / RFC §3.3-3.4).

--- a/tests/bridge-flap-regression-guard.test.ts
+++ b/tests/bridge-flap-regression-guard.test.ts
@@ -169,13 +169,8 @@ describe("bridge-flap regression guard — headless claude must use --strict-mcp
    * below enforces that.
    */
   const KNOWN_TEMPLATE_GAPS: Record<string, string> = {
-    // The "deep" doctor auth-live smoke runs `claude -p ok` as a quota-
-    // costing check that the agent's OAuth is live. Opt-in, off by default
-    // (deep === true is required). Same compliance concern as any other
-    // `claude -p` callsite — needs migration to a session-side liveness
-    // check (e.g. token-introspect via auth-broker, or `mcp__hindsight__
-    // ping` round-trip). Tracking issue: #1798 follow-up.
-    "src/host-control/server.ts": "#1798",
+    // #1798 resolved: `claude -p ok` deep probe replaced with a
+    // token-introspect check against .credentials.json (no model call).
   };
 
   it("no source file emits a `claude -p` string template to disk (#1798)", () => {


### PR DESCRIPTION
## Summary

- The `deep` branch of the `agent_smoke` hostd handler was running `timeout 25 claude -p ok` via `docker exec` to test auth liveness. This is programmatic usage under Anthropic's 2026-06-15 policy — off the subscription, violating CLAUDE.md pillar 3 ("subscription-honest").
- Replaces the callsite with a `python3` one-liner that parses `/state/agent/.claude/.credentials.json` inside the container, validates `claudeAiOauth.accessToken` format, and checks `expiresAt` is absent or in the future. Zero model calls, zero network round-trips, zero subscription cost.
- Removes the `KNOWN_TEMPLATE_GAPS` entry in `bridge-flap-regression-guard.test.ts` — shrink-only semantics require removal once the violation is fixed.

## Why

`claude -p` is programmatic usage under Anthropic's 2026-06-15 policy (see `reference/vision.md:86-90` and the "Hard constraint" section of CLAUDE.md). The violation was acknowledged as a known gap in `tests/bridge-flap-regression-guard.test.ts` with tracking issue #1798. No production codepath currently passes `deep: true` (confirmed by reading `src/cli/doctor-agent-smoke.ts`), but the callsite was still present as a latent compliance risk.

The replacement probe uses the same `python3` interpreter already invoked by the `mcp` probe — guaranteed available in the agent container — and reads the same credentials file that the host-side `auth` probe checks for presence. It adds expiry validation that the static `test -s` probe does not provide, making `deep: true` more useful, not less.

## Closes

Closes #1798

## Files touched

- `src/host-control/server.ts` — replace `claude -p ok` cmd with python3 token-introspect
- `src/host-control/protocol.ts` — update JSDoc for `deep` field (remove "quota-costing" language)
- `tests/bridge-flap-regression-guard.test.ts` — remove resolved `KNOWN_TEMPLATE_GAPS` entry

## Test plan

- [ ] `bridge-flap-regression-guard.test.ts` — the `KNOWN_TEMPLATE_GAPS` stale-entry test will now pass without the allowlist entry (no `claude -p` string template remains in `src/host-control/server.ts`)
- [ ] `bridge-flap-regression-guard.test.ts` — the main scan will not flag `server.ts` (no `claude -p` template in non-comment source after strip)
- [ ] No new test file added — the probe logic is a shell one-liner; behaviour is covered by the guard test above and the existing `agent_smoke` integration path

## Risk

Low. The `deep: true` branch has no production callers (`src/cli/doctor-agent-smoke.ts` does not pass `deep: true`). The change replaces dead-but-non-compliant code with a correct equivalent. The probe return shape (`name: "auth_live"`, `state: "ok"|"fail"|"skip"`) is unchanged.

## Verification

Local tsc/vitest gates deferred to CI — orchestrator host lacks Node toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)