### PR TITLE
fix(gateway): remove auth-slot buttons that redirect to terminal

### DIFF
--- a/src/agents/create-orchestrator.ts
+++ b/src/agents/create-orchestrator.ts
@@ -114,9 +114,10 @@ export interface CompletionResult {
 /**
  * Regex that agent names must match — mirrors the yaml schema constraint.
  * Max length 51 chars. Telegram callback_data is capped at 64 BYTES; the
- * longest operator-event prefix is `op:swap-slot:` (13 bytes), leaving 51
- * for the agent name. Agents with longer names would have broken buttons
- * in Phase 4a/4b. See operator-events.ts callback_data contract.
+ * longest operator-event prefix is `op:dismiss:`/`op:restart:` (11 bytes),
+ * so a 51-char cap leaves comfortable headroom for the agent name. Agents
+ * with longer names would risk broken buttons. See operator-events.ts
+ * callback_data contract.
  */
 const AGENT_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,50}$/;
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -12135,8 +12135,7 @@ function resolveAgentDirForName(agent: string): string | null {
  *   restart   — systemctl --user restart switchroom-<agent>
  *   reauth    — delegate to runSwitchroomAuthCommand (same flow as /auth reauth)
  *   logs      — post last 30 lines of journalctl for the agent
- *   swap-slot, add-slot — Phase 4c will wire these; for now toast with the
- *                         equivalent CLI command for the user to run manually.
+ *   slot management buttons — removed (E5); use /auth use or /auth add instead.
  */
 /**
  * Issue #44: handle taps on the deferred-secret card's inline buttons.
@@ -13765,15 +13764,6 @@ async function handleOperatorEventCallback(ctx: Context, data: string): Promise<
       }
       return
     }
-    case 'swap-slot':
-    case 'add-slot': {
-      await ctx.answerCallbackQuery({ text: 'Phase 4c will wire this' }).catch(() => {})
-      const cmd = action === 'swap-slot' ? `auth use ${agent} <slot-name>` : `auth add ${agent}`
-      await ctx.reply(`Phase 4c will wire ${action} buttons. Until then, run in terminal: <code>switchroom ${cmd}</code>`, {
-        parse_mode: 'HTML',
-      })
-      return
-    }
     default: {
       await ctx.answerCallbackQuery({ text: `Unknown action: ${action}` }).catch(() => {})
       return
@@ -14668,7 +14658,7 @@ bot.on('callback_query:data', async ctx => {
 
   // op:<action>:<encoded-agent> callbacks from operator-events.ts
   // renderOperatorEvent(). Agent name is URL-encoded at emit (issue #24).
-  // Actions: dismiss, restart, reauth, swap-slot, add-slot, logs.
+  // Actions: dismiss, restart, reauth, logs.
   if (data.startsWith('op:')) {
     await handleOperatorEventCallback(ctx, data)
     return

--- a/telegram-plugin/operator-events.ts
+++ b/telegram-plugin/operator-events.ts
@@ -257,16 +257,12 @@ export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
         text: [
           `💳 <b>Credit balance too low</b> for <b>${agent}</b>.`,
           detail ? `<i>${detail}</i>` : '',
-          `Swap to another account slot or add a new one.`,
+          `Use <code>/auth use &lt;label&gt;</code> to switch account slot or <code>/auth add</code> to add one.`,
         ]
           .filter(Boolean)
           .join('\n'),
         keyboard: {
           inline_keyboard: [
-            [
-              { text: '🔄 Swap slot', callback_data: `op:swap-slot:${encodeURIComponent(ev.agent)}` },
-              { text: '➕ Add slot', callback_data: `op:add-slot:${encodeURIComponent(ev.agent)}` },
-            ],
             [{ text: '⏳ Wait', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
           ],
         },
@@ -280,16 +276,12 @@ export function renderOperatorEvent(ev: OperatorEvent): RenderResult {
         text: [
           `⚠️ <b>Quota exhausted</b> for <b>${agent}</b>.`,
           detail ? `<i>${detail}</i>` : '',
-          `All account slots are at the usage limit. Switchroom will auto-fallback when another slot is available.`,
+          `All account slots are at the usage limit. Switchroom will auto-fallback when another slot is available. Use <code>/auth use &lt;label&gt;</code> to switch manually.`,
         ]
           .filter(Boolean)
           .join('\n'),
         keyboard: {
           inline_keyboard: [
-            [
-              { text: '🔄 Swap slot', callback_data: `op:swap-slot:${encodeURIComponent(ev.agent)}` },
-              { text: '➕ Add slot', callback_data: `op:add-slot:${encodeURIComponent(ev.agent)}` },
-            ],
             [{ text: '⏳ Wait', callback_data: `op:dismiss:${encodeURIComponent(ev.agent)}` }],
           ],
         },

--- a/telegram-plugin/tests/operator-events.test.ts
+++ b/telegram-plugin/tests/operator-events.test.ts
@@ -177,23 +177,29 @@ describe('renderOperatorEvent — credentials-invalid', () => {
 })
 
 describe('renderOperatorEvent — credit-exhausted', () => {
-  it('offers swap + add slot buttons', () => {
+  it('shows credit balance text with /auth use hint and no stub buttons (E5)', () => {
     const { text, keyboard } = renderOperatorEvent(makeEvent('credit-exhausted'))
     expect(text).toContain('Credit balance')
+    expect(text).toContain('/auth use')
     const buttons = keyboard.inline_keyboard.flat()
-    expect(buttons.some(b => b.callback_data?.includes('swap-slot'))).toBe(true)
-    expect(buttons.some(b => b.callback_data?.includes('add-slot'))).toBe(true)
+    // swap-slot and add-slot buttons removed (E5 — they redirected to terminal)
+    expect(buttons.some(b => b.callback_data?.includes('swap-slot'))).toBe(false)
+    expect(buttons.some(b => b.callback_data?.includes('add-slot'))).toBe(false)
+    expect(buttons.some(b => b.callback_data?.includes('dismiss'))).toBe(true)
   })
 })
 
 describe('renderOperatorEvent — quota-exhausted', () => {
-  it('renders quota text + swap/add buttons', () => {
+  it('renders quota text with /auth use hint and no stub buttons (E5)', () => {
     const { text, keyboard } = renderOperatorEvent(makeEvent('quota-exhausted'))
     expect(text).toContain('Quota exhausted')
     expect(text).toContain('<b>gymbro</b>')
+    expect(text).toContain('/auth use')
     const buttons = keyboard.inline_keyboard.flat()
-    expect(buttons.some(b => b.callback_data?.includes('swap-slot'))).toBe(true)
-    expect(buttons.some(b => b.callback_data?.includes('add-slot'))).toBe(true)
+    // swap-slot and add-slot buttons removed (E5 — they redirected to terminal)
+    expect(buttons.some(b => b.callback_data?.includes('swap-slot'))).toBe(false)
+    expect(buttons.some(b => b.callback_data?.includes('add-slot'))).toBe(false)
+    expect(buttons.some(b => b.callback_data?.includes('dismiss'))).toBe(true)
   })
 
   it('contains auto-fallback slot info in detail when provided', () => {

--- a/tests/jtbd-talk-from-anywhere.test.ts
+++ b/tests/jtbd-talk-from-anywhere.test.ts
@@ -183,19 +183,18 @@ describe("JTBD/talk-from-anywhere — no live code path tells the operator to le
     return src;
   }
 
-  it.skip("no string says 'run in terminal' anywhere in the live gateway", () => {
-    // Today (gateway.ts:8980): "Phase 4c will wire ${action} buttons.
-    // Until then, run in terminal: switchroom auth use ..."
-    //
-    // Anti-pattern: tells the operator the product is incomplete AND
-    // shoves them to the desktop. Two failures in one sentence.
+  it("no string says 'run in terminal' anywhere in the live gateway", () => {
+    // The Phase 4c stub at gateway.ts said "run in terminal: switchroom auth use ..."
+    // That stub has been removed (E5). Text commands /auth use and /auth add
+    // are the supported surface; no terminal redirect should appear.
     expect(gatewaySrcWithoutAllowedPunts()).not.toMatch(/run in terminal/i);
   });
 
-  it.skip("no string says 'Phase Nx will wire …' as a feature stub", () => {
+  it("no string says 'Phase Nx will wire …' as a feature stub", () => {
     // Principle 2 (defaults test): "Does this work with zero
     // configuration?" Stub callbacks that promise future work fail.
     // Either ship the button or remove the button.
+    // The Phase 4c swap-slot/add-slot stub has been removed (E5).
     expect(gatewaySrcWithoutAllowedPunts()).not.toMatch(/Phase \d[a-z]? will wire/i);
   });
 
@@ -264,10 +263,14 @@ describe("JTBD/talk-from-anywhere — every fleet-mutation has a Telegram-native
     expect(gatewaySrc).toMatch(/bot\.command\(['"]agent[-_ ]?admin['"]/);
   });
 
-  it.skip("/auth slot management is fully wired (no Phase 4c stub)", () => {
-    // Vision outcome 3: subscription-honest. Operator manages auth
-    // slots; switching the active slot today requires SSH.
+  it("/auth slot management has no terminal-redirect buttons (E5 regression guard)", () => {
+    // The vestigial swap-slot / add-slot inline-keyboard buttons have been
+    // removed (E5). The supported path is /auth use <label> and /auth add.
+    // Guard against re-introducing stub buttons that tell the operator to
+    // use the terminal.
     expect(gatewaySrc).not.toMatch(/Phase 4c will wire/);
+    expect(gatewaySrc).not.toMatch(/swap-slot/);
+    expect(gatewaySrc).not.toMatch(/add-slot/);
   });
 
   it.skip("/vault broker {status,restart} — operator can recover a dead broker", () => {


### PR DESCRIPTION
## Summary

- **E5 regression fix** (drift-audit 2026-05-26): removes the vestigial `swap-slot` and `add-slot` inline-keyboard buttons from the `credit-exhausted` and `quota-exhausted` operator-event cards in `operator-events.ts`
- **Deletes the Phase 4c callback stub** in `handleOperatorEventCallback` (`gateway.ts`) that replied with _"Phase 4c will wire this. Until then, run in terminal: `switchroom auth use …`"_
- **Adds `/auth use` hint text** to both card bodies so operators know their next action without tapping a broken button
- **Un-skips two JTBD regression guards** and adds a new live guard confirming the buttons do not reappear

## Why

JTBD `reference/talk-to-agents-from-anywhere.md`: _"there must be no moment where they wish they were at the laptop."_ A quota event on cellular is precisely when the operator cannot reach the laptop. The buttons were the only action surface on the card and they told the user to go to the terminal — a two-failure sentence. The text commands `/auth use <label>` and `/auth add` already work from any DM; the buttons were adding confusion without adding capability. Option C from the audit recommendation (remove buttons, keep text commands).

## Files changed

| File | Change |
|---|---|
| `telegram-plugin/gateway/gateway.ts` | Delete `swap-slot` / `add-slot` case branches from `handleOperatorEventCallback` |
| `telegram-plugin/operator-events.ts` | Remove stub buttons from `credit-exhausted` / `quota-exhausted` keyboards; add `/auth use` hint text |
| `telegram-plugin/tests/operator-events.test.ts` | Update to assert buttons absent, hint text present |
| `tests/jtbd-talk-from-anywhere.test.ts` | Un-skip two guards; rewrite slot-management test as live E5 regression guard |

## Test plan

- [ ] `vitest run tests/jtbd-talk-from-anywhere.test.ts` — two previously-skipped tests now run and pass
- [ ] `bun test telegram-plugin/tests/operator-events.test.ts` — credit-exhausted and quota-exhausted tests updated to assert no stub buttons
- [ ] `bash scripts/check-bot-api-wrapping.sh` — no gateway.ts line-range entries affected; allowlist uses inline markers and context-based detection

Note: local tsc/vitest gates deferred to CI — orchestrator host lacks Node toolchain. Bot-API allowlist uses inline markers + context detection (not line-range entries) for gateway.ts, so no allowlist update needed for this deletion.

## Related

- Drift audit escalation E5: `audit/2026-05-26/recommendations/escalation-new-05-auth-slot-terminal-redirect.md`
- JTBD: `reference/talk-to-agents-from-anywhere.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)