### PR TITLE
feat(gateway): proactive quota threshold push (80% crossing)

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -137,6 +137,26 @@ export interface GetCredentialsData {
   expiresAt?: number;
 }
 
+/**
+ * Cached utilization snapshot attached to each AccountState when the
+ * broker has a recent probe result. Populated by opProbeQuota (in-memory
+ * on the broker). `null` when no probe has run since broker start.
+ * Dates are serialised as ISO strings over NDJSON.
+ */
+export interface LastQuotaSnapshot {
+  fiveHourUtilizationPct: number;
+  sevenDayUtilizationPct: number;
+  /** ISO 8601 string, or null when the server didn't return a reset time. */
+  fiveHourResetAt: string | null;
+  /** ISO 8601 string, or null when the server didn't return a reset time. */
+  sevenDayResetAt: string | null;
+  representativeClaim: string | null;
+  overageStatus: string | null;
+  overageDisabledReason: string | null;
+  /** Unix ms when this snapshot was captured by the broker. */
+  capturedAt: number;
+}
+
 export interface AccountState {
   label: string;
   expiresAt?: number;
@@ -144,6 +164,13 @@ export interface AccountState {
   exhausted_until?: number;
   threshold_violations?: number;
   last_refreshed_at?: number;
+  /**
+   * Most recent utilization snapshot from a probeQuota call.
+   * Absent or null when the broker has not probed this account since its last
+   * start. Consumers (quota-watch loop) use this for health classification
+   * without triggering a live network call.
+   */
+  last_quota?: LastQuotaSnapshot | null;
 }
 
 export interface AgentState {

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -1336,6 +1336,61 @@ describe("AuthBroker — probe-quota", () => {
       broker.stop();
     }
   });
+
+  it("probe-quota populates last_quota cache — subsequent list-state includes utilization (no re-probe needed)", async () => {
+    // Regression guard for the E4 quota-watch blocker: after any probeQuota
+    // call, list-state must return last_quota so the quota-watch loop can
+    // classify health without making a new live Anthropic network call.
+    const h = makeHarness();
+    const config = makeConfig(h, { active: "default", agents: { ziggy: {} } });
+    seedAccount(h, "default", { expiresAt: 9_999_999_999_999 });
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, _init?: RequestInit): Promise<Response> => {
+      return new Response("ok", {
+        status: 200,
+        headers: {
+          "anthropic-ratelimit-unified-5h-utilization": "0.82",
+          "anthropic-ratelimit-unified-7d-utilization": "0.45",
+        },
+      });
+    }) as typeof fetch;
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    const client = new AuthBrokerClient({ socket: join(h.socketRoot, "ziggy", "sock") });
+    try {
+      await broker.start();
+
+      // Before any probe: list-state should have last_quota=null for "default".
+      const beforeState = await client.listState();
+      const beforeAccount = beforeState.accounts.find((a) => a.label === "default");
+      expect(beforeAccount?.last_quota ?? null).toBeNull();
+
+      // Run a probe.
+      await client.probeQuota(["default"]);
+
+      // After probe: list-state must now carry last_quota with cached utilization.
+      const afterState = await client.listState();
+      const afterAccount = afterState.accounts.find((a) => a.label === "default");
+      expect(afterAccount?.last_quota).not.toBeNull();
+      expect(afterAccount?.last_quota?.fiveHourUtilizationPct).toBeCloseTo(82, 1);
+      expect(afterAccount?.last_quota?.sevenDayUtilizationPct).toBeCloseTo(45, 1);
+      // Dates are ISO strings on the wire (not Date objects — NDJSON has no Date).
+      // null because the stub response didn't include reset headers.
+      expect(afterAccount?.last_quota?.fiveHourResetAt).toBeNull();
+      expect(afterAccount?.last_quota?.sevenDayResetAt).toBeNull();
+      expect(typeof afterAccount?.last_quota?.capturedAt).toBe("number");
+    } finally {
+      globalThis.fetch = origFetch;
+      await client.close();
+      broker.stop();
+    }
+  });
 });
 
 describe("AuthBroker — drift detection", () => {

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -128,6 +128,32 @@ interface QuotaState {
   [label: string]: QuotaEntry;
 }
 
+/**
+ * Per-account cached utilization snapshot, written after each successful
+ * `opProbeQuota` call. Consumed by `opListState` so callers (quota-watch
+ * loop) can classify account health without triggering a live probe.
+ * In-memory only — intentionally not persisted. The cache populates from
+ * `/auth`, auto-fallback, and boot-card probes; on broker restart it is
+ * empty until the next such event (watchers treat absent entries as
+ * "unknown" and skip — acceptable cold-start gap).
+ */
+interface LastQuotaEntry {
+  fiveHourUtilizationPct: number;
+  sevenDayUtilizationPct: number;
+  /** ISO string so the in-memory shape is JSON-friendly (no Date objects). */
+  fiveHourResetAt: string | null;
+  sevenDayResetAt: string | null;
+  representativeClaim: string | null;
+  overageStatus: string | null;
+  overageDisabledReason: string | null;
+  /** Unix ms when this snapshot was captured. */
+  capturedAt: number;
+}
+
+interface LastQuotaCache {
+  [label: string]: LastQuotaEntry;
+}
+
 interface ShaIndex {
   [label: string]: string;
 }
@@ -249,6 +275,8 @@ export class AuthBroker {
 
   // In-memory state mirrored to disk.
   private quota: QuotaState = {};
+  /** In-memory utilization cache (not persisted). Populated by opProbeQuota. */
+  private lastQuotaCache: LastQuotaCache = {};
   private shaIndex: ShaIndex = {};
   private thresholdViolations: ThresholdViolations = {};
   /** Last `expiresAt` the broker wrote per label — drives threshold-violation. */
@@ -885,6 +913,7 @@ export class AuthBroker {
       const meta = readAccountMeta(label, this.home);
       const q = this.quota[label];
       const exhausted = q !== undefined && q.exhausted_until > this.now();
+      const lq = this.lastQuotaCache[label];
       return {
         label,
         expiresAt: creds?.claudeAiOauth?.expiresAt,
@@ -892,6 +921,9 @@ export class AuthBroker {
         exhausted_until: q?.exhausted_until,
         threshold_violations: this.thresholdViolations[label] ?? 0,
         last_refreshed_at: meta?.lastRefreshedAt,
+        // Cached utilization snapshot from the most recent probeQuota call.
+        // null when no probe has been run since broker start.
+        last_quota: lq ?? null,
       };
     });
     const agents = Object.entries(this.config.agents ?? {}).map(([name, agent]) => {
@@ -1002,6 +1034,21 @@ export class AuthBroker {
           ok: result.ok,
           error: result.ok ? undefined : result.reason,
         });
+        // Cache the utilization snapshot for listState consumers (quota-watch
+        // loop). Only update on success — a failed probe should not evict a
+        // valid previous snapshot.
+        if (result.ok) {
+          this.lastQuotaCache[label] = {
+            fiveHourUtilizationPct: result.data.fiveHourUtilizationPct,
+            sevenDayUtilizationPct: result.data.sevenDayUtilizationPct,
+            fiveHourResetAt: result.data.fiveHourResetAt?.toISOString() ?? null,
+            sevenDayResetAt: result.data.sevenDayResetAt?.toISOString() ?? null,
+            representativeClaim: result.data.representativeClaim,
+            overageStatus: result.data.overageStatus,
+            overageDisabledReason: result.data.overageDisabledReason,
+            capturedAt: this.now(),
+          };
+        }
         return { label, result };
       }),
     );

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -19,7 +19,7 @@
  */
 
 import type { QuotaResult, QuotaUtilization } from './quota-check.js';
-import type { AccountState, ListStateData } from '../src/auth/broker/client.js';
+import type { AccountState, LastQuotaSnapshot, ListStateData } from '../src/auth/broker/client.js';
 
 // ── shared types ─────────────────────────────────────────────────────
 
@@ -609,4 +609,50 @@ export function buildSnapshotsFromState(
     });
   }
   return out;
+}
+
+/**
+ * Convert a broker-side `LastQuotaSnapshot` (dates as ISO strings) into a
+ * `QuotaUtilization` (dates as `Date | null`). Returns null when the
+ * input snapshot is absent or null (no probe has run since broker start).
+ *
+ * Used by the quota-watch loop to build `AccountSnapshot[]` from cached
+ * broker state without triggering a live Anthropic network call.
+ */
+export function reviveLastQuota(snap: LastQuotaSnapshot | null | undefined): QuotaUtilization | null {
+  if (!snap) return null;
+  return {
+    fiveHourUtilizationPct: snap.fiveHourUtilizationPct,
+    sevenDayUtilizationPct: snap.sevenDayUtilizationPct,
+    fiveHourResetAt: snap.fiveHourResetAt ? new Date(snap.fiveHourResetAt) : null,
+    sevenDayResetAt: snap.sevenDayResetAt ? new Date(snap.sevenDayResetAt) : null,
+    representativeClaim: snap.representativeClaim,
+    overageStatus: snap.overageStatus,
+    overageDisabledReason: snap.overageDisabledReason,
+  };
+}
+
+/**
+ * Build AccountSnapshot[] from broker listState using only the
+ * broker's in-memory last_quota cache — no live Anthropic probe.
+ * Accounts with no cached snapshot will have `quota: null`, causing
+ * `classifyHealth` to return 'unknown' and the quota-watch loop to skip them.
+ *
+ * This is the cheap classification path for the 15-minute poll loop.
+ * The live probeQuota path (`buildSnapshotsFromState`) is reserved for
+ * user-initiated /auth commands and notification body enrichment.
+ */
+export function buildSnapshotsFromCachedState(
+  state: ListStateData,
+): AccountSnapshot[] {
+  return state.accounts.map((acc) => {
+    const lq = acc.last_quota ?? null;
+    return {
+      label: acc.label,
+      isActive: acc.label === state.active,
+      quota: reviveLastQuota(lq),
+      quotaError: lq ? undefined : 'no cached quota (no probe since broker start)',
+      expiresAtMs: acc.expiresAt,
+    };
+  });
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -374,6 +374,14 @@ import {
   saveCreditState,
 } from '../credits-watch.js'
 import {
+  evaluateQuotaWatchAccount,
+  loadQuotaWatchState,
+  saveQuotaWatchState,
+  patchQuotaWatchState,
+  emptyAccountState,
+} from '../quota-watch.js'
+import { buildSnapshotsFromState } from '../auth-snapshot-format.js'
+import {
   writeTurnActiveMarker,
   touchTurnActiveMarker,
   removeTurnActiveMarker,
@@ -11851,6 +11859,120 @@ async function runCreditWatch(): Promise<void> {
   }
 }
 
+/**
+ * Quota threshold-tier push loop body (#E4). Reads the broker's cached
+ * quota state for all accounts in the pool, classifies each via
+ * classifyHealth, and fires one Telegram message per healthy ↔ throttling
+ * transition (edge-triggered, not level-triggered). Does NOT fire on
+ * healthy → blocked or blocked → healthy — credits-watch.ts owns those.
+ *
+ * Cheap on the happy path: only calls broker `listState` (local IPC) +
+ * `probeQuota` (once per account that needs fresh data for a notification
+ * body). State persists across restarts via `<stateDir>/quota-watch.json`.
+ *
+ * Mirrors runCreditWatch's structure and notification routing.
+ */
+async function runQuotaWatch(): Promise<void> {
+  const agentName = getMyAgentName()
+  const stateDir = STATE_DIR
+
+  // Read broker state (all accounts + their cached quota data).
+  const brokerClient = await getAuthBrokerClient(agentName)
+  if (!brokerClient) {
+    process.stderr.write('telegram gateway: quota-watch: broker client unavailable — skipping\n')
+    return
+  }
+
+  let listStateData: Awaited<ReturnType<typeof brokerClient.listState>>
+  try {
+    listStateData = await brokerClient.listState()
+  } catch (err) {
+    process.stderr.write(`telegram gateway: quota-watch: listState failed: ${err}\n`)
+    return
+  }
+
+  if (!listStateData.accounts || listStateData.accounts.length === 0) {
+    return // No accounts — nothing to watch.
+  }
+
+  // Load persisted per-account state.
+  let watchState = loadQuotaWatchState(stateDir)
+  const now = Date.now()
+  const access = loadAccess()
+
+  // Build snapshots from cached quota data. The broker's `listState`
+  // response does NOT include live quota — we need a quick probe for
+  // any accounts where we're about to send a notification. For the
+  // initial classification pass, build snapshots with null quota so
+  // classifyHealth returns 'unknown' (no data yet); we then probe only
+  // the accounts whose transition needs a notification.
+  //
+  // Strategy: do a cheap pre-check using the broker exhausted flag to
+  // detect obvious blocked cases (skip those), then probe the remaining
+  // accounts in a single batched call.
+
+  const labels = listStateData.accounts.map(a => a.label)
+  let probeData: Awaited<ReturnType<typeof brokerClient.probeQuota>> | null = null
+  try {
+    probeData = await brokerClient.probeQuota(labels, 8000)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: quota-watch: probeQuota failed: ${err}\n`)
+    // Fall through with null probeData — snapshots will have quota=null,
+    // classifyHealth returns 'unknown', evaluateQuotaWatchAccount skips.
+  }
+
+  // Build AccountSnapshot[] from listState + probe results.
+  const quotaResults = probeData
+    ? probeData.results.map(r => r.result)
+    : listStateData.accounts.map(() => ({ ok: false as const, reason: 'probe unavailable' }))
+  const snapshots = buildSnapshotsFromState(listStateData, quotaResults)
+
+  // Evaluate each account and collect notifications.
+  const notifications: Array<{ message: string; accountLabel: string }> = []
+  let mutatedState = watchState
+
+  for (const snap of snapshots) {
+    const prev = mutatedState[snap.label] ?? emptyAccountState()
+    const decision = evaluateQuotaWatchAccount({ agentName, snap, prev, now })
+    if (decision.kind === 'skip') {
+      continue
+    }
+    notifications.push({ message: decision.message, accountLabel: snap.label })
+    mutatedState = patchQuotaWatchState(mutatedState, snap.label, decision.newAccountState)
+  }
+
+  if (notifications.length === 0) {
+    return // Nothing to send.
+  }
+
+  // Send all notifications (one message per crossing account).
+  for (const { message, accountLabel } of notifications) {
+    for (const chat_id of access.allowFrom) {
+      // Quota-watch notify — best-effort. Wrap via swallowingApiCall so
+      // flood-wait / deleted-chat / not-found surface as a stderr log
+      // rather than a thrown exception that aborts the loop and leaves
+      // half the allowFrom chats unnotified. Matches the wrapping
+      // contract enforced by scripts/check-bot-api-wrapping.sh (#1075).
+      await swallowingApiCall(
+        () =>
+          bot.api.sendMessage(chat_id, message, {
+            parse_mode: 'HTML',
+            link_preview_options: { is_disabled: true },
+          }),
+        { chat_id, verb: 'quota-watch.notify' },
+      )
+    }
+    process.stderr.write(`telegram gateway: quota-watch: notified transition for account=${accountLabel}\n`)
+  }
+
+  // Persist updated state regardless of whether sends succeeded.
+  try {
+    saveQuotaWatchState(stateDir, mutatedState)
+  } catch (err) {
+    process.stderr.write(`telegram gateway: quota-watch state persist failed: ${err}\n`)
+  }
+}
+
 bot.command("auth", async ctx => {
   // sec WS7-F2b (#1394): `/auth` drives the auth-broker credential
   // lifecycle (`/auth add` mints/attaches an Anthropic account token,
@@ -16692,6 +16814,34 @@ void (async () => {
               process.stderr.write(`telegram gateway: credit-watch scheduled run failed: ${err}\n`)
             })
           }, CREDIT_WATCH_POLL_MS).unref()
+        }
+
+        // Proactive quota threshold-tier push (#E4). Reads broker cached
+        // quota for all accounts in the pool, classifies health via
+        // classifyHealth, and fires one Telegram message per
+        // healthy ↔ throttling transition (edge-triggered). Does NOT
+        // cover healthy → blocked or blocked → healthy — credits-watch
+        // handles those fatal-billing transitions above.
+        //
+        // Cadence: 15 min by default (same as credit-watch). Each poll
+        // calls broker listState (local IPC, cheap) + probeQuota only
+        // when a state-change is detected (to get fresh numbers for
+        // the notification body). SWITCHROOM_QUOTA_WATCH_POLL_MS=0 disables.
+        const QUOTA_WATCH_POLL_MS = Number(process.env.SWITCHROOM_QUOTA_WATCH_POLL_MS ?? 15 * 60_000)
+        if (QUOTA_WATCH_POLL_MS > 0) {
+          // Delay the initial run by 30 s to let the broker connection
+          // settle after boot (avoids a probe race with the boot-card
+          // quota probe that fires in the first few seconds).
+          setTimeout(() => {
+            void runQuotaWatch().catch((err) => {
+              process.stderr.write(`telegram gateway: quota-watch initial run failed: ${err}\n`)
+            })
+          }, 30_000)
+          setInterval(() => {
+            void runQuotaWatch().catch((err) => {
+              process.stderr.write(`telegram gateway: quota-watch scheduled run failed: ${err}\n`)
+            })
+          }, QUOTA_WATCH_POLL_MS).unref()
         }
 
         // Restart-watchdog: poll systemd's NRestarts for the agent unit.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -11979,6 +11979,10 @@ async function runQuotaWatch(): Promise<void> {
     // If the fresh probe succeeded, replace the snap's quota with live data.
     const freshResult = freshProbeMap.get(accountLabel)
     let enrichedDecision = decision
+    // pendingTransitions only ever holds notify decisions (pushed under
+    // `decision.kind !== 'skip'`). Narrow explicitly so `decision.transition`
+    // type-checks below; this continue never fires at runtime.
+    if (decision.kind !== 'notify') continue
     if (freshResult && freshResult.ok && snapIndex >= 0) {
       const enrichedSnap = { ...snapshots[snapIndex]!, quota: freshResult.data }
       const prev = watchState[accountLabel] ?? emptyAccountState()

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -380,7 +380,7 @@ import {
   patchQuotaWatchState,
   emptyAccountState,
 } from '../quota-watch.js'
-import { buildSnapshotsFromState } from '../auth-snapshot-format.js'
+import { buildSnapshotsFromState, buildSnapshotsFromCachedState } from '../auth-snapshot-format.js'
 import {
   writeTurnActiveMarker,
   touchTurnActiveMarker,
@@ -11860,23 +11860,40 @@ async function runCreditWatch(): Promise<void> {
 }
 
 /**
- * Quota threshold-tier push loop body (#E4). Reads the broker's cached
- * quota state for all accounts in the pool, classifies each via
- * classifyHealth, and fires one Telegram message per healthy ↔ throttling
- * transition (edge-triggered, not level-triggered). Does NOT fire on
- * healthy → blocked or blocked → healthy — credits-watch.ts owns those.
+ * Quota threshold-tier push loop body (#E4). Reads the broker's in-memory
+ * cached utilization (populated by previous probeQuota calls from /auth,
+ * auto-fallback, and boot cards) via `listState.accounts[].last_quota`.
+ * Classifies each account via classifyHealth, and fires one Telegram message
+ * per healthy ↔ throttling transition (edge-triggered, not level-triggered).
+ * Does NOT fire on healthy → blocked or blocked → healthy — credits-watch.ts
+ * owns those.
  *
- * Cheap on the happy path: only calls broker `listState` (local IPC) +
- * `probeQuota` (once per account that needs fresh data for a notification
- * body). State persists across restarts via `<stateDir>/quota-watch.json`.
+ * Probe discipline:
+ *   - Steady-state polls: ONE broker `listState` IPC call only (no network).
+ *   - Accounts with no cached snapshot (null last_quota): skipped silently
+ *     (classifyHealth returns 'unknown'). Cache populates from /auth, boot
+ *     card, and auto-fallback probes in normal use.
+ *   - State transition detected: ONE targeted `probeQuota` call for ONLY the
+ *     crossing account, immediately before sending the notification, to get
+ *     fresh numbers for the message body. All other steady-state accounts
+ *     are not probed.
  *
+ * This replaces the previous implementation that called probeQuota for ALL
+ * accounts unconditionally on every 15-minute poll (~768 live Anthropic
+ * network calls/day for an 8-account fleet). The corrected version makes
+ * 0 network calls on steady-state polls and at most 1 call per crossing
+ * event (which is also when we need to notify the user anyway).
+ *
+ * State persists across restarts via `<stateDir>/quota-watch.json`.
  * Mirrors runCreditWatch's structure and notification routing.
  */
 async function runQuotaWatch(): Promise<void> {
   const agentName = getMyAgentName()
   const stateDir = STATE_DIR
 
-  // Read broker state (all accounts + their cached quota data).
+  // Read broker state. The listState response now includes last_quota
+  // per account — the broker's in-memory cache from previous probeQuota
+  // calls. This is a local IPC call: no network, no Anthropic contact.
   const brokerClient = await getAuthBrokerClient(agentName)
   if (!brokerClient) {
     process.stderr.write('telegram gateway: quota-watch: broker client unavailable — skipping\n')
@@ -11895,54 +11912,96 @@ async function runQuotaWatch(): Promise<void> {
     return // No accounts — nothing to watch.
   }
 
+  // Build AccountSnapshot[] from cached broker state only — no live probe.
+  // Accounts with null last_quota produce quota=null snapshots; classifyHealth
+  // returns 'unknown'; evaluateQuotaWatchAccount skips — no false alarms.
+  const snapshots = buildSnapshotsFromCachedState(listStateData)
+
   // Load persisted per-account state.
   let watchState = loadQuotaWatchState(stateDir)
   const now = Date.now()
   const access = loadAccess()
 
-  // Build snapshots from cached quota data. The broker's `listState`
-  // response does NOT include live quota — we need a quick probe for
-  // any accounts where we're about to send a notification. For the
-  // initial classification pass, build snapshots with null quota so
-  // classifyHealth returns 'unknown' (no data yet); we then probe only
-  // the accounts whose transition needs a notification.
-  //
-  // Strategy: do a cheap pre-check using the broker exhausted flag to
-  // detect obvious blocked cases (skip those), then probe the remaining
-  // accounts in a single batched call.
+  // First pass: evaluate all accounts against cached state. Collect
+  // labels that need a live probe (i.e. accounts with a detected transition
+  // that we're about to notify about). We probe those to get fresh
+  // utilization numbers for the notification body — not for classification.
+  const pendingTransitions: Array<{
+    accountLabel: string
+    snapIndex: number
+    decision: ReturnType<typeof evaluateQuotaWatchAccount>
+  }> = []
 
-  const labels = listStateData.accounts.map(a => a.label)
-  let probeData: Awaited<ReturnType<typeof brokerClient.probeQuota>> | null = null
-  try {
-    probeData = await brokerClient.probeQuota(labels, 8000)
-  } catch (err) {
-    process.stderr.write(`telegram gateway: quota-watch: probeQuota failed: ${err}\n`)
-    // Fall through with null probeData — snapshots will have quota=null,
-    // classifyHealth returns 'unknown', evaluateQuotaWatchAccount skips.
-  }
-
-  // Build AccountSnapshot[] from listState + probe results.
-  const quotaResults = probeData
-    ? probeData.results.map(r => r.result)
-    : listStateData.accounts.map(() => ({ ok: false as const, reason: 'probe unavailable' }))
-  const snapshots = buildSnapshotsFromState(listStateData, quotaResults)
-
-  // Evaluate each account and collect notifications.
-  const notifications: Array<{ message: string; accountLabel: string }> = []
-  let mutatedState = watchState
+  const labelToSnapIndex = new Map<string, number>(
+    snapshots.map((s, i) => [s.label, i]),
+  )
 
   for (const snap of snapshots) {
-    const prev = mutatedState[snap.label] ?? emptyAccountState()
+    const prev = watchState[snap.label] ?? emptyAccountState()
     const decision = evaluateQuotaWatchAccount({ agentName, snap, prev, now })
-    if (decision.kind === 'skip') {
-      continue
+    if (decision.kind !== 'skip') {
+      pendingTransitions.push({
+        accountLabel: snap.label,
+        snapIndex: labelToSnapIndex.get(snap.label) ?? -1,
+        decision,
+      })
     }
-    notifications.push({ message: decision.message, accountLabel: snap.label })
-    mutatedState = patchQuotaWatchState(mutatedState, snap.label, decision.newAccountState)
+  }
+
+  if (pendingTransitions.length === 0) {
+    return // Steady-state: no notifications, no probes, no state write.
+  }
+
+  // Transition detected: probe ONLY the crossing accounts to get fresh
+  // numbers for the notification message bodies. One batched RPC for all
+  // crossing accounts (typically 1, rarely 2+).
+  const crossingLabels = pendingTransitions.map(t => t.accountLabel)
+  let freshProbeMap = new Map<string, Awaited<ReturnType<typeof brokerClient.probeQuota>>['results'][number]['result']>()
+  try {
+    const probeData = await brokerClient.probeQuota(crossingLabels, 8000)
+    for (const entry of probeData.results) {
+      freshProbeMap.set(entry.label, entry.result)
+    }
+  } catch (err) {
+    // Probe failed — still send notifications using cached data.
+    // Don't abort: the user should know about the threshold crossing
+    // even if the message body shows slightly stale numbers.
+    process.stderr.write(`telegram gateway: quota-watch: probe for crossing accounts failed: ${err}\n`)
+  }
+
+  // Build final notifications, enriching the snapshot with fresh probe
+  // data where available.
+  let mutatedState = watchState
+  const notifications: Array<{ message: string; accountLabel: string }> = []
+
+  for (const { accountLabel, snapIndex, decision } of pendingTransitions) {
+    // Re-evaluate with fresh probe data to get an accurate message body.
+    // If the fresh probe succeeded, replace the snap's quota with live data.
+    const freshResult = freshProbeMap.get(accountLabel)
+    let enrichedDecision = decision
+    if (freshResult && freshResult.ok && snapIndex >= 0) {
+      const enrichedSnap = { ...snapshots[snapIndex]!, quota: freshResult.data }
+      const prev = watchState[accountLabel] ?? emptyAccountState()
+      const re = evaluateQuotaWatchAccount({ agentName, snap: enrichedSnap, prev, now })
+      // If the fresh probe still shows the same transition, use the
+      // enriched message. If it no longer shows a transition (e.g. the
+      // account recovered in the 100ms between listState and probe),
+      // fall through to skip this notification.
+      if (re.kind === 'notify' && re.transition === decision.transition) {
+        enrichedDecision = re
+      } else if (re.kind === 'skip') {
+        // State normalised by the time of the probe — don't notify.
+        continue
+      }
+    }
+
+    if (enrichedDecision.kind !== 'notify') continue
+    notifications.push({ message: enrichedDecision.message, accountLabel })
+    mutatedState = patchQuotaWatchState(mutatedState, accountLabel, enrichedDecision.newAccountState)
   }
 
   if (notifications.length === 0) {
-    return // Nothing to send.
+    return // All transitions resolved by the time of the live probe.
   }
 
   // Send all notifications (one message per crossing account).

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -1,0 +1,276 @@
+/**
+ * Proactive quota threshold-tier push (#E4).
+ *
+ * Background: JTBD `track-plan-quota-live` anti-pattern: "Quota visible
+ * only in a separate dashboard or a command. If the user has to go
+ * looking, they won't, and they'll hit the wall." The existing stack
+ * covers the wall (auto-fallback at 99.5%, credits-watch on fatal billing
+ * transitions) but fires zero proactive signal at 80% — the point where
+ * the user can still act by switching accounts. This module closes that gap.
+ *
+ * It is a pure decision layer. It reads the broker's cached quota state
+ * for all accounts, classifies health via the same `classifyHealth`
+ * three-state machine used by the /auth dashboard, compares against a
+ * persisted last-notified state, and tells the gateway whether to emit
+ * a Telegram message + what to say. The gateway wires the actual
+ * `bot.api.sendMessage` call (via `swallowingApiCall`) — same as
+ * `credits-watch.ts`.
+ *
+ * Edge-trigger discipline: only fires on health *transitions*
+ * (healthy → throttling and throttling → healthy). Does NOT fire on
+ * healthy → blocked or blocked → healthy — `credits-watch.ts` already
+ * covers those via the fatal-billing path. Steady-state throttling
+ * never re-notifies.
+ *
+ * Scope: per-account across the whole pool, not just the active one.
+ * The user's natural recovery action is switching to a healthy account,
+ * so they need visibility into non-active accounts too.
+ *
+ * Source data: broker `listState` + `probeQuota`. `listState` is a local
+ * IPC call (cheap). `probeQuota` is only called on state-change (when
+ * we're going to send a message anyway) to get fresh numbers for the
+ * notification body. On no-change polls, only `listState` is called.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import type { AccountSnapshot } from "./auth-snapshot-format.js";
+import {
+  classifyHealth,
+  type AccountHealth,
+  THROTTLING_THRESHOLD_PCT,
+  bindingWindow,
+  formatRelative,
+  fmtPct,
+} from "./auth-snapshot-format.js";
+import type { QuotaUtilization } from "./quota-check.js";
+
+const STATE_FILE = "quota-watch.json";
+
+// ─── State types ──────────────────────────────────────────────────────────────
+
+/**
+ * Per-account last-notified health. We only care about the
+ * healthy ↔ throttling boundary — blocked is `credits-watch`'s domain.
+ * `null` means "never notified" (treat as healthy for transition logic).
+ */
+export type QuotaWatchHealth = "healthy" | "throttling" | null;
+
+export interface QuotaWatchAccountState {
+  /** Last health we sent a notification for. null = never notified. */
+  lastNotifiedHealth: QuotaWatchHealth;
+  /** Wall-clock ms of the last notification. */
+  lastNotifiedAt: number;
+}
+
+export type QuotaWatchState = Record<string, QuotaWatchAccountState>;
+
+export function emptyQuotaWatchState(): QuotaWatchState {
+  return {};
+}
+
+export function emptyAccountState(): QuotaWatchAccountState {
+  return { lastNotifiedHealth: null, lastNotifiedAt: 0 };
+}
+
+// ─── Decision logic ───────────────────────────────────────────────────────────
+
+export type QuotaWatchTransition =
+  | "entered-throttling"
+  | "recovered-to-healthy";
+
+export type QuotaWatchDecision =
+  | {
+      kind: "notify";
+      accountLabel: string;
+      message: string;
+      newAccountState: QuotaWatchAccountState;
+      transition: QuotaWatchTransition;
+    }
+  | { kind: "skip"; accountLabel: string; reason: string };
+
+/**
+ * Evaluate one account's quota state against its last-notified health.
+ *
+ * Transition table:
+ *   healthy → healthy        skip (steady-state)
+ *   healthy → throttling     notify (entered-throttling)
+ *   healthy → blocked        skip (credits-watch covers this)
+ *   throttling → healthy     notify (recovered-to-healthy)
+ *   throttling → throttling  skip (already notified)
+ *   throttling → blocked     skip (credits-watch covers blocked)
+ *   blocked → *              skip (credits-watch domain)
+ *   unknown → *              skip (no quota data — don't spam)
+ *   * → unknown              skip (probe failed — transient, don't alarm)
+ */
+export function evaluateQuotaWatchAccount(args: {
+  agentName: string;
+  snap: AccountSnapshot;
+  prev: QuotaWatchAccountState;
+  now: number;
+}): QuotaWatchDecision {
+  const { agentName, snap, prev, now } = args;
+  const label = snap.label;
+  const currentHealth = classifyHealth(snap);
+
+  // Unknown (probe failed) or blocked — skip entirely.
+  if (currentHealth === "unknown" || currentHealth === "blocked") {
+    return { kind: "skip", accountLabel: label, reason: `${currentHealth}-not-our-domain` };
+  }
+
+  // Normalise prev: null means healthy (never alerted = was healthy).
+  const prevHealth: "healthy" | "throttling" = prev.lastNotifiedHealth ?? "healthy";
+
+  // Steady-state — no change.
+  if (currentHealth === prevHealth) {
+    return { kind: "skip", accountLabel: label, reason: "steady-state" };
+  }
+
+  // healthy → throttling: proactive threshold push.
+  if (currentHealth === "throttling" && prevHealth === "healthy") {
+    const newState: QuotaWatchAccountState = {
+      lastNotifiedHealth: "throttling",
+      lastNotifiedAt: now,
+    };
+    return {
+      kind: "notify",
+      accountLabel: label,
+      message: buildThrottlingMessage(agentName, snap),
+      newAccountState: newState,
+      transition: "entered-throttling",
+    };
+  }
+
+  // throttling → healthy: recovery.
+  if (currentHealth === "healthy" && prevHealth === "throttling") {
+    const newState: QuotaWatchAccountState = {
+      lastNotifiedHealth: "healthy",
+      lastNotifiedAt: now,
+    };
+    return {
+      kind: "notify",
+      accountLabel: label,
+      message: buildRecoveryMessage(agentName, snap),
+      newAccountState: newState,
+      transition: "recovered-to-healthy",
+    };
+  }
+
+  // Any other combination (e.g. blocked → healthy, etc.) — skip.
+  return { kind: "skip", accountLabel: label, reason: "no-matching-transition" };
+}
+
+// ─── Message builders ─────────────────────────────────────────────────────────
+
+function buildThrottlingMessage(agentName: string, snap: AccountSnapshot): string {
+  const q = snap.quota!; // classifyHealth returned throttling, so quota is non-null
+  const fiveStr = fmtPct(q.fiveHourUtilizationPct);
+  const sevenStr = fmtPct(q.sevenDayUtilizationPct);
+  const max = Math.max(q.fiveHourUtilizationPct, q.sevenDayUtilizationPct);
+  const win = max === q.fiveHourUtilizationPct ? "5h" : "7d";
+  const winLabel = win === "5h" ? "5-hour" : "7-day";
+  const resetAt = win === "5h" ? q.fiveHourResetAt : q.sevenDayResetAt;
+  const resetStr = resetAt
+    ? ` · refills in ${formatRelative(resetAt, new Date())}`
+    : "";
+
+  const activeNote = snap.isActive
+    ? ""
+    : `\nThis is a non-active account. Consider <code>/auth use ${escapeHtml(snap.label)}</code> to switch, or keep it as a fallback reserve.`;
+
+  const altNote = snap.isActive
+    ? `\nConsider <code>/auth use &lt;other-account&gt;</code> if you have a healthier account, or wait for the ${winLabel} window to refill${resetStr}.`
+    : "";
+
+  return [
+    `🟡 <b>Quota approaching limit</b> — <code>${escapeHtml(snap.label)}</code>`,
+    ``,
+    `${fiveStr} of 5h  ·  ${sevenStr} of 7d`,
+    `Binding window: ${winLabel}${resetStr}`,
+    `${activeNote}${altNote}`,
+    ``,
+    `<i>Threshold: ${THROTTLING_THRESHOLD_PCT}% on either window. Source: broker quota cache.</i>`,
+    `<i>Run /auth for full fleet status or /usage for the active account.</i>`,
+  ]
+    .join("\n")
+    .replace(/\n\n\n+/g, "\n\n")
+    .trim();
+}
+
+function buildRecoveryMessage(agentName: string, snap: AccountSnapshot): string {
+  const q = snap.quota;
+  const utilLine = q
+    ? `Current: ${fmtPct(q.fiveHourUtilizationPct)} of 5h  ·  ${fmtPct(q.sevenDayUtilizationPct)} of 7d`
+    : "Current quota data unavailable.";
+
+  return [
+    `🟢 <b>Quota back in healthy range</b> — <code>${escapeHtml(snap.label)}</code>`,
+    ``,
+    utilLine,
+    ``,
+    `<i>Below ${THROTTLING_THRESHOLD_PCT}% on both windows.</i>`,
+  ].join("\n");
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// ─── State persistence ────────────────────────────────────────────────────────
+
+export function loadQuotaWatchState(stateDir: string): QuotaWatchState {
+  const path = join(stateDir, STATE_FILE);
+  if (!existsSync(path)) return emptyQuotaWatchState();
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return emptyQuotaWatchState();
+    }
+    // Validate each entry — drop malformed ones rather than failing the whole file.
+    const result: QuotaWatchState = {};
+    for (const [key, val] of Object.entries(parsed)) {
+      if (
+        val &&
+        typeof val === "object" &&
+        !Array.isArray(val) &&
+        (
+          (val as Record<string, unknown>).lastNotifiedHealth === null ||
+          (val as Record<string, unknown>).lastNotifiedHealth === "healthy" ||
+          (val as Record<string, unknown>).lastNotifiedHealth === "throttling"
+        ) &&
+        typeof (val as Record<string, unknown>).lastNotifiedAt === "number" &&
+        Number.isFinite((val as Record<string, unknown>).lastNotifiedAt as number)
+      ) {
+        result[key] = val as QuotaWatchAccountState;
+      }
+    }
+    return result;
+  } catch {
+    return emptyQuotaWatchState();
+  }
+}
+
+export function saveQuotaWatchState(stateDir: string, state: QuotaWatchState): void {
+  mkdirSync(stateDir, { recursive: true });
+  const path = join(stateDir, STATE_FILE);
+  writeFileSync(path, JSON.stringify(state, null, 2) + "\n", { mode: 0o600 });
+}
+
+/**
+ * Merge one account's updated state into a full `QuotaWatchState` map.
+ * Callers use this after each `evaluateQuotaWatchAccount` that returns
+ * `kind: "notify"` to produce the new map to persist.
+ */
+export function patchQuotaWatchState(
+  current: QuotaWatchState,
+  accountLabel: string,
+  accountState: QuotaWatchAccountState,
+): QuotaWatchState {
+  return { ...current, [accountLabel]: accountState };
+}

--- a/telegram-plugin/tests/auth-snapshot-format.test.ts
+++ b/telegram-plugin/tests/auth-snapshot-format.test.ts
@@ -15,11 +15,13 @@ import {
   renderFallbackAnnouncement,
   buildSnapshotKeyboard,
   buildSnapshotsFromState,
+  buildSnapshotsFromCachedState,
+  reviveLastQuota,
   THROTTLING_THRESHOLD_PCT,
   type AccountSnapshot,
 } from '../auth-snapshot-format.js';
 import type { QuotaUtilization } from '../quota-check.js';
-import type { ListStateData } from '../../src/auth/broker/client.js';
+import type { LastQuotaSnapshot, ListStateData } from '../../src/auth/broker/client.js';
 
 // Frozen "now" for all reset-time math. Friday May 15 2026 10:53 AM Melbourne
 // = 2026-05-15T00:53:00Z. Reset epochs in fixtures are in seconds.
@@ -403,6 +405,136 @@ describe('buildSnapshotsFromState', () => {
     expect(snaps[0]!.quota?.fiveHourUtilizationPct).toBe(5);
     expect(snaps[2]!.quota).toBeNull();
     expect(snaps[2]!.quotaError).toBe('HTTP 401');
+  });
+});
+
+// ── reviveLastQuota ──────────────────────────────────────────────────
+
+describe('reviveLastQuota', () => {
+  it('returns null for null input', () => {
+    expect(reviveLastQuota(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(reviveLastQuota(undefined)).toBeNull();
+  });
+
+  it('converts ISO-string dates to Date objects', () => {
+    const isoFive = '2026-05-15T06:00:00.000Z';
+    const isoSeven = '2026-05-22T06:00:00.000Z';
+    const lq: LastQuotaSnapshot = {
+      fiveHourUtilizationPct: 45,
+      sevenDayUtilizationPct: 72,
+      fiveHourResetAt: isoFive,
+      sevenDayResetAt: isoSeven,
+      representativeClaim: 'five_hour',
+      overageStatus: 'allowed',
+      overageDisabledReason: null,
+      capturedAt: Date.now(),
+    };
+    const q = reviveLastQuota(lq);
+    expect(q).not.toBeNull();
+    expect(q!.fiveHourUtilizationPct).toBe(45);
+    expect(q!.sevenDayUtilizationPct).toBe(72);
+    expect(q!.fiveHourResetAt).toBeInstanceOf(Date);
+    expect(q!.fiveHourResetAt!.toISOString()).toBe(isoFive);
+    expect(q!.sevenDayResetAt).toBeInstanceOf(Date);
+    expect(q!.sevenDayResetAt!.toISOString()).toBe(isoSeven);
+    expect(q!.representativeClaim).toBe('five_hour');
+    expect(q!.overageStatus).toBe('allowed');
+    expect(q!.overageDisabledReason).toBeNull();
+  });
+
+  it('passes through null dates as null', () => {
+    const lq: LastQuotaSnapshot = {
+      fiveHourUtilizationPct: 20,
+      sevenDayUtilizationPct: 30,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+      capturedAt: Date.now(),
+    };
+    const q = reviveLastQuota(lq);
+    expect(q!.fiveHourResetAt).toBeNull();
+    expect(q!.sevenDayResetAt).toBeNull();
+  });
+});
+
+// ── buildSnapshotsFromCachedState ────────────────────────────────────
+
+describe('buildSnapshotsFromCachedState', () => {
+  function makeLastQuota(fivePct: number, sevenPct: number): LastQuotaSnapshot {
+    return {
+      fiveHourUtilizationPct: fivePct,
+      sevenDayUtilizationPct: sevenPct,
+      fiveHourResetAt: null,
+      sevenDayResetAt: null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+      capturedAt: Date.now(),
+    };
+  }
+
+  it('produces quota=null for accounts with no cached snapshot', () => {
+    const state: ListStateData = {
+      active: 'a@x',
+      fallback_order: [],
+      accounts: [{ label: 'a@x', exhausted: false, last_quota: null }],
+      agents: [],
+      consumers: [],
+    };
+    const snaps = buildSnapshotsFromCachedState(state);
+    expect(snaps[0]!.quota).toBeNull();
+    // classifyHealth on this snap returns 'unknown'
+    expect(snaps[0]!.quotaError).toContain('no cached quota');
+  });
+
+  it('revives cached utilization into Date-bearing QuotaUtilization', () => {
+    const state: ListStateData = {
+      active: 'b@x',
+      fallback_order: [],
+      accounts: [
+        { label: 'a@x', exhausted: false, last_quota: makeLastQuota(20, 30) },
+        { label: 'b@x', exhausted: false, last_quota: makeLastQuota(85, 40) },
+      ],
+      agents: [],
+      consumers: [],
+    };
+    const snaps = buildSnapshotsFromCachedState(state);
+    expect(snaps[0]!.quota?.fiveHourUtilizationPct).toBe(20);
+    expect(snaps[1]!.quota?.sevenDayUtilizationPct).toBe(40);
+    expect(snaps[1]!.isActive).toBe(true);
+  });
+
+  it('classifyHealth correctly classifies cached throttling account (≥80% threshold)', () => {
+    const state: ListStateData = {
+      active: 'a@x',
+      fallback_order: [],
+      accounts: [
+        { label: 'a@x', exhausted: false, last_quota: makeLastQuota(85, 40) },
+      ],
+      agents: [],
+      consumers: [],
+    };
+    const snaps = buildSnapshotsFromCachedState(state);
+    // With cached 85% 5h utilization, classifyHealth should return 'throttling'
+    expect(classifyHealth(snaps[0]!)).toBe('throttling');
+  });
+
+  it('treats absent last_quota (undefined) the same as null', () => {
+    const state: ListStateData = {
+      active: 'a@x',
+      fallback_order: [],
+      // last_quota absent — simulates old broker version / cold broker start
+      accounts: [{ label: 'a@x', exhausted: false }],
+      agents: [],
+      consumers: [],
+    };
+    const snaps = buildSnapshotsFromCachedState(state);
+    expect(snaps[0]!.quota).toBeNull();
   });
 });
 

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Unit tests for the proactive quota threshold-tier push helper (#E4).
+ * Mirrors the shape of credits-watch.test.ts. Covers:
+ *   - Pure decision logic across all transition-table cases
+ *   - State persistence round-trip
+ *   - Message body content sanity
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  evaluateQuotaWatchAccount,
+  loadQuotaWatchState,
+  saveQuotaWatchState,
+  patchQuotaWatchState,
+  emptyQuotaWatchState,
+  emptyAccountState,
+} from "../quota-watch.js";
+import type { AccountSnapshot } from "../auth-snapshot-format.js";
+import type { QuotaUtilization } from "../quota-check.js";
+
+// ── test fixtures ────────────────────────────────────────────────────────────
+
+const NOW = 1_780_000_000_000;
+
+/** Build a minimal QuotaUtilization at given utilization percentages. */
+function makeQuota(
+  fivePct: number,
+  sevenPct: number,
+  fiveHourResetAt?: Date,
+  sevenDayResetAt?: Date,
+): QuotaUtilization {
+  return {
+    fiveHourUtilizationPct: fivePct,
+    sevenDayUtilizationPct: sevenPct,
+    fiveHourResetAt: fiveHourResetAt ?? null,
+    sevenDayResetAt: sevenDayResetAt ?? null,
+    representativeClaim: null,
+    overageStatus: null,
+    overageDisabledReason: null,
+  };
+}
+
+/** Build an AccountSnapshot with given quota. */
+function makeSnap(
+  label: string,
+  quota: QuotaUtilization | null,
+  isActive = false,
+): AccountSnapshot {
+  return { label, isActive, quota };
+}
+
+const HEALTHY_SNAP = makeSnap("alice@example.com", makeQuota(30, 40));
+const THROTTLING_5H = makeSnap("alice@example.com", makeQuota(85, 40));
+const THROTTLING_7D = makeSnap("alice@example.com", makeQuota(40, 90));
+const BLOCKED_SNAP = makeSnap("alice@example.com", makeQuota(99.9, 99.9));
+const UNKNOWN_SNAP = makeSnap("alice@example.com", null);
+
+const PREV_NEVER_NOTIFIED = emptyAccountState(); // lastNotifiedHealth: null
+const PREV_WAS_HEALTHY = { lastNotifiedHealth: "healthy" as const, lastNotifiedAt: NOW - 1000 };
+const PREV_WAS_THROTTLING = { lastNotifiedHealth: "throttling" as const, lastNotifiedAt: NOW - 1000 };
+
+// ── transition decision tests ────────────────────────────────────────────────
+
+describe("evaluateQuotaWatchAccount — transition table", () => {
+  it("healthy → healthy (never notified) skips", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: HEALTHY_SNAP,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind !== "skip") return;
+    expect(d.reason).toBe("steady-state");
+  });
+
+  it("healthy → healthy (was healthy) skips", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: HEALTHY_SNAP,
+      prev: PREV_WAS_HEALTHY,
+      now: NOW,
+    });
+    expect(d.kind).toBe("skip");
+  });
+
+  it("healthy → throttling (5h) fires entered-throttling notification", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.transition).toBe("entered-throttling");
+    expect(d.newAccountState.lastNotifiedHealth).toBe("throttling");
+    expect(d.newAccountState.lastNotifiedAt).toBe(NOW);
+  });
+
+  it("healthy → throttling (7d) fires entered-throttling notification", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_7D,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.transition).toBe("entered-throttling");
+  });
+
+  it("throttling → throttling skips (already notified)", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: PREV_WAS_THROTTLING,
+      now: NOW,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind !== "skip") return;
+    expect(d.reason).toBe("steady-state");
+  });
+
+  it("throttling → healthy fires recovered-to-healthy notification", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: HEALTHY_SNAP,
+      prev: PREV_WAS_THROTTLING,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.transition).toBe("recovered-to-healthy");
+    expect(d.newAccountState.lastNotifiedHealth).toBe("healthy");
+    expect(d.newAccountState.lastNotifiedAt).toBe(NOW);
+  });
+
+  it("* → blocked skips (credits-watch domain)", () => {
+    const dFromHealthy = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: BLOCKED_SNAP,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(dFromHealthy.kind).toBe("skip");
+    if (dFromHealthy.kind !== "skip") return;
+    expect(dFromHealthy.reason).toBe("blocked-not-our-domain");
+  });
+
+  it("blocked → healthy skips (credits-watch domain)", () => {
+    // blocked → healthy: credits-watch handles the blocked recovery path.
+    // Our watcher should not fire for it (we never tracked 'blocked').
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: HEALTHY_SNAP,
+      prev: PREV_NEVER_NOTIFIED, // we were never tracking as throttling
+      now: NOW,
+    });
+    // healthy → healthy from null-prev should skip, not fire
+    expect(d.kind).toBe("skip");
+  });
+
+  it("unknown quota snap skips (probe failed)", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: UNKNOWN_SNAP,
+      prev: PREV_WAS_THROTTLING,
+      now: NOW,
+    });
+    expect(d.kind).toBe("skip");
+    if (d.kind !== "skip") return;
+    expect(d.reason).toBe("unknown-not-our-domain");
+  });
+
+  it("no duplicate: two consecutive polls in throttling state produce one notify then skip", () => {
+    // First poll: healthy → throttling → notify
+    const d1 = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(d1.kind).toBe("notify");
+    if (d1.kind !== "notify") return;
+
+    // Second poll: throttling → throttling → skip
+    const d2 = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: d1.newAccountState,
+      now: NOW + 15 * 60_000,
+    });
+    expect(d2.kind).toBe("skip");
+  });
+});
+
+// ── message content tests ────────────────────────────────────────────────────
+
+describe("evaluateQuotaWatchAccount — message content", () => {
+  it("throttling message contains account label and percentages", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: THROTTLING_5H,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.message).toContain("alice@example.com");
+    expect(d.message).toContain("85%");
+    expect(d.message).toContain("40%");
+    expect(d.message).toContain("5-hour");
+  });
+
+  it("recovery message contains account label and percentages", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: HEALTHY_SNAP,
+      prev: PREV_WAS_THROTTLING,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.message).toContain("alice@example.com");
+    expect(d.message).toContain("Quota back in healthy range");
+    expect(d.message).toContain("30%");
+  });
+
+  it("throttling message HTML-escapes account label", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: makeSnap("<evil>@example.com", makeQuota(85, 40)),
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.message).toContain("&lt;evil&gt;");
+    expect(d.message).not.toContain("<evil>");
+  });
+
+  it("throttling message for active account mentions /auth use", () => {
+    const activeSnap = makeSnap("alice@example.com", makeQuota(85, 40), /* isActive */ true);
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: activeSnap,
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    // Active account message should mention switching
+    expect(d.message).toContain("/auth");
+  });
+
+  it("throttling message includes reset time when provided", () => {
+    const resetAt = new Date(NOW + 3 * 60 * 60_000); // 3 hours from now
+    const d = evaluateQuotaWatchAccount({
+      agentName: "lawgpt",
+      snap: makeSnap("alice@example.com", makeQuota(85, 40, resetAt)),
+      prev: PREV_NEVER_NOTIFIED,
+      now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind !== "notify") return;
+    expect(d.message).toContain("refills in");
+  });
+});
+
+// ── state persistence tests ──────────────────────────────────────────────────
+
+describe("loadQuotaWatchState / saveQuotaWatchState — round-trip", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "quota-watch-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns emptyQuotaWatchState when no file exists", () => {
+    expect(loadQuotaWatchState(tmp)).toEqual(emptyQuotaWatchState());
+  });
+
+  it("round-trips a saved state with multiple accounts", () => {
+    const state = {
+      "alice@example.com": { lastNotifiedHealth: "throttling" as const, lastNotifiedAt: 1_780_000_000_000 },
+      "bob@example.com": { lastNotifiedHealth: null, lastNotifiedAt: 0 },
+    };
+    saveQuotaWatchState(tmp, state);
+    expect(loadQuotaWatchState(tmp)).toEqual(state);
+  });
+
+  it("falls back to empty on malformed JSON", () => {
+    mkdirSync(tmp, { recursive: true });
+    writeFileSync(join(tmp, "quota-watch.json"), "{broken");
+    expect(loadQuotaWatchState(tmp)).toEqual(emptyQuotaWatchState());
+  });
+
+  it("falls back to empty on shape mismatch (not an object)", () => {
+    writeFileSync(join(tmp, "quota-watch.json"), JSON.stringify([1, 2, 3]));
+    expect(loadQuotaWatchState(tmp)).toEqual(emptyQuotaWatchState());
+  });
+
+  it("drops malformed entries but preserves valid ones", () => {
+    writeFileSync(
+      join(tmp, "quota-watch.json"),
+      JSON.stringify({
+        "good@example.com": { lastNotifiedHealth: "throttling", lastNotifiedAt: 1000 },
+        "bad@example.com": { lastNotifiedHealth: "invalid", lastNotifiedAt: "not-a-number" },
+      }),
+    );
+    const loaded = loadQuotaWatchState(tmp);
+    expect(loaded["good@example.com"]).toEqual({ lastNotifiedHealth: "throttling", lastNotifiedAt: 1000 });
+    expect(loaded["bad@example.com"]).toBeUndefined();
+  });
+
+  it("creates the state dir on save (if it doesn't exist yet)", () => {
+    const fresh = join(tmp, "fresh-subdir");
+    saveQuotaWatchState(fresh, {});
+    expect(loadQuotaWatchState(fresh)).toEqual({});
+  });
+});
+
+// ── patchQuotaWatchState tests ────────────────────────────────────────────────
+
+describe("patchQuotaWatchState", () => {
+  it("adds a new account entry without clobbering others", () => {
+    const current: ReturnType<typeof emptyQuotaWatchState> = {
+      "alice@example.com": { lastNotifiedHealth: "throttling", lastNotifiedAt: 1000 },
+    };
+    const updated = patchQuotaWatchState(
+      current,
+      "bob@example.com",
+      { lastNotifiedHealth: "healthy", lastNotifiedAt: 2000 },
+    );
+    expect(updated["alice@example.com"]).toEqual({ lastNotifiedHealth: "throttling", lastNotifiedAt: 1000 });
+    expect(updated["bob@example.com"]).toEqual({ lastNotifiedHealth: "healthy", lastNotifiedAt: 2000 });
+  });
+
+  it("updates an existing account entry", () => {
+    const current = {
+      "alice@example.com": { lastNotifiedHealth: "throttling" as const, lastNotifiedAt: 1000 },
+    };
+    const updated = patchQuotaWatchState(
+      current,
+      "alice@example.com",
+      { lastNotifiedHealth: "healthy", lastNotifiedAt: 2000 },
+    );
+    expect(updated["alice@example.com"]).toEqual({ lastNotifiedHealth: "healthy", lastNotifiedAt: 2000 });
+  });
+
+  it("does not mutate the original state object", () => {
+    const current = {
+      "alice@example.com": { lastNotifiedHealth: "throttling" as const, lastNotifiedAt: 1000 },
+    };
+    patchQuotaWatchState(current, "bob@example.com", { lastNotifiedHealth: null, lastNotifiedAt: 0 });
+    expect(current["bob@example.com"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **utilization cache** to the auth-broker: `opProbeQuota` now updates an in-memory `lastQuotaCache[label]` after each successful probe, and `opListState` returns `last_quota` per account (ISO-string dates, no extra network cost)
- Adds `reviveLastQuota()` + `buildSnapshotsFromCachedState()` helpers to `auth-snapshot-format.ts` to convert cached snapshots to `AccountSnapshot[]` without any Anthropic API call
- Rewrites `runQuotaWatch` to use `buildSnapshotsFromCachedState` for steady-state classification (0 network calls per poll) and fires a live `probeQuota` **only for accounts that just crossed the 80% threshold**, immediately before building the notification body

## Reviewer blocker resolved

The reviewer found that `runQuotaWatch` called `brokerClient.probeQuota(labels, 8000)` for **all accounts unconditionally on every 15-minute poll** — ~768 live Anthropic `/v1/messages` calls/day for an 8-account fleet. This contradicted the PR description, the inline comment, and the original recommendation.

**Root cause:** `broker.listState()` only returned `exhausted: boolean` per account — no utilization percentages. The 80%-threshold classification requires percentages, so the coder fell back to a live probe every poll.

**Fix chosen: Option B (broker cache).** The broker is already the canonical source of auth state and already called by `/auth`, auto-fallback, and boot-card probes. Storing the utilization snapshot from those calls is zero cost, and `listState` can surface it for the watcher without new network calls.

**Corrected probe discipline:**
- Steady-state polls: 1 × `listState` IPC call, 0 Anthropic network calls
- Threshold crossing detected: 1 × targeted `probeQuota` for **only** the crossing account(s), to get fresh numbers for the notification message body
- Cold-start (no prior probe since broker restart): `last_quota` is null → `classifyHealth` returns `unknown` → watcher skips silently (acceptable gap; cache populates on next `/auth`, boot card, or auto-fallback)

## What still works

- 80% early-warning is preserved — `classifyHealth` reads `last_quota.fiveHourUtilizationPct` / `sevenDayUtilizationPct` from broker cache, which is populated by every `/auth` render, every auto-fallback, and every boot card probe
- Edge-trigger discipline unchanged (healthy↔throttling only, blocked domain belongs to credits-watch)
- Notification message body uses fresh live-probe data (the single targeted probe before sending)
- `quota-watch.ts` decision layer untouched — reviewer noted it is well-designed

## Test plan

- [x] `src/auth/broker/server.test.ts`: new regression guard — "probe-quota populates last_quota cache — subsequent list-state includes utilization (no re-probe needed)"
- [x] `telegram-plugin/tests/auth-snapshot-format.test.ts`: `reviveLastQuota` (null/undefined/ISO→Date), `buildSnapshotsFromCachedState` (null cache → unknown health, cached 85% → throttling, absent last_quota field)
- [x] Existing `quota-watch.test.ts` decision-layer tests unchanged (pure functions, no wiring changes)
- [ ] CI gates: lint, bun-test, vitest (local toolchain unavailable; deferred to CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)