### PR TITLE
feat(repos): wire worktree provisioning into reconcile + destroy

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -247,13 +247,10 @@ import {
   createMinimalClaudeConfig,
   loadUserConfig,
 } from "../setup/onboarding.js";
-import { ensureBareClone, bareClonePath } from "../repos/bare-clone.js";
+import { ensureBareClone } from "../repos/bare-clone.js";
 import {
   ensureAgentWorktree,
-  removeAgentWorktree,
-  listAgentWorktrees,
   agentWorktreePath,
-  type WorktreeState,
 } from "../repos/agent-worktree.js";
 
 export interface ScaffoldResult {
@@ -4041,6 +4038,26 @@ export function reconcileAgent(
   const hindsightTopicFilterMode = (
     agentConfig.memory?.recall as { topic_filter_mode?: string } | undefined
   )?.topic_filter_mode;
+
+  // --- Provision worktrees for repos: entries ---
+  // Runs on every reconcile so the paths injected as SWITCHROOM_REPO_<SLUG>
+  // env vars in start.sh actually exist on disk. Both functions are
+  // idempotent: first call creates; subsequent calls fetch + ff-only merge
+  // (or skip when dirty). Network failures in ensureBareClone are non-fatal
+  // (logged and continued) so an unreachable remote does not block reconcile.
+  if (agentConfig.repos) {
+    for (const [slug, entry] of Object.entries(agentConfig.repos)) {
+      try {
+        const clonePath = ensureBareClone(slug, entry.url);
+        ensureAgentWorktree(name, slug, clonePath, agentDir);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[switchroom] repo "${slug}": provisioning failed (continuing): ${msg}\n`,
+        );
+      }
+    }
+  }
 
   // --- Reconcile start.sh (purely template-driven, safe to overwrite) ---
   // No existsSync guard: start.sh is a pure function of config+template.

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -10,6 +10,8 @@ import { isHindsightEnabled } from "../memory/hindsight.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import { scaffoldAgent, reconcileAgent, buildSettingsHooksBlock, detectHooksDrift } from "../agents/scaffold.js";
+import { bareClonePath } from "../repos/bare-clone.js";
+import { removeAgentWorktree } from "../repos/agent-worktree.js";
 import { listAvailableProfiles } from "../agents/profiles.js";
 import {
   startAgent,
@@ -1967,6 +1969,31 @@ export function registerAgentCommand(program: Command): void {
         // down. We don't shell out to docker here — the operator may be
         // on a non-Docker fleet, and either way the compose layer is
         // owned by `apply`, not `agent destroy`.
+
+        // Remove worktrees for repos: entries before wiping the agent dir.
+        // resolveAgentConfig applies the cascade so repos: from profiles/defaults
+        // is also respected. Non-fatal: a failed worktree removal is logged and
+        // skipped — the agentDir rmSync below will clean up any leftover files.
+        const rawAgentConfig = config.agents[name];
+        if (rawAgentConfig) {
+          const resolvedAgentConfig = resolveAgentConfig(
+            config.defaults,
+            config.profiles,
+            rawAgentConfig,
+          );
+          if (resolvedAgentConfig.repos) {
+            for (const slug of Object.keys(resolvedAgentConfig.repos)) {
+              try {
+                removeAgentWorktree(name, slug, bareClonePath(slug), agentDir);
+              } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                process.stderr.write(
+                  `[switchroom] repo "${slug}": worktree removal failed (continuing): ${msg}\n`,
+                );
+              }
+            }
+          }
+        }
 
         // Remove agent directory
         if (existsSync(agentDir)) {

--- a/src/repos/agent-worktree.ts
+++ b/src/repos/agent-worktree.ts
@@ -139,17 +139,20 @@ function resolveDefaultBranch(bareClonePath: string): string {
  *   3. Subsequent calls (dirty worktree): leaves the worktree unchanged,
  *      returns dirty: true.
  *
+ * Synchronous: uses execFileSync internally; exported as a sync function
+ * so that callers (reconcileAgent) do not need to become async.
+ *
  * @param agentName      Agent identifier (e.g. "clerk")
  * @param slug           Repo slug (e.g. "switchroom-web")
  * @param bareClonePath  Absolute path to the bare clone directory
  * @param agentDir       Agent directory (e.g. ~/.switchroom/agents/clerk)
  */
-export async function ensureAgentWorktree(
+export function ensureAgentWorktree(
   agentName: string,
   slug: string,
   bareClonePath: string,
   agentDir: string,
-): Promise<WorktreeState> {
+): WorktreeState {
   const worktreePath = agentWorktreePath(agentDir, slug);
   const branch = agentBranchName(agentName);
   const defaultBranch = resolveDefaultBranch(bareClonePath);
@@ -246,13 +249,16 @@ export async function ensureAgentWorktree(
  *   2. `git branch -D agent/<agentName>/main` from the bare clone.
  *
  * Idempotent — safe to call even when the worktree or branch is absent.
+ *
+ * Synchronous: uses execFileSync internally; exported as a sync function
+ * so that callers do not need to become async.
  */
-export async function removeAgentWorktree(
+export function removeAgentWorktree(
   agentName: string,
   slug: string,
   bareClonePath: string,
   agentDir: string,
-): Promise<void> {
+): void {
   const worktreePath = agentWorktreePath(agentDir, slug);
   const branch = agentBranchName(agentName);
 

--- a/src/repos/bare-clone.ts
+++ b/src/repos/bare-clone.ts
@@ -31,11 +31,14 @@ export function bareClonePath(slug: string): string {
  *
  * Idempotent — safe to call on every reconcile.
  *
+ * Synchronous: uses execFileSync internally; exported as a sync function
+ * so that callers (reconcileAgent) do not need to become async.
+ *
  * @param slug   Kebab-case repo key from switchroom.yaml (e.g. "switchroom-web")
  * @param url    Git remote URL (used verbatim; never auto-derived)
  * @returns      Absolute path to the bare clone directory
  */
-export async function ensureBareClone(slug: string, url: string): Promise<string> {
+export function ensureBareClone(slug: string, url: string): string {
   const reposDir = resolveStatePath("repos");
   mkdirSync(reposDir, { recursive: true });
 

--- a/tests/scaffold.repo-provisioning.test.ts
+++ b/tests/scaffold.repo-provisioning.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests that reconcileAgent correctly calls the worktree provisioning
+ * functions (ensureBareClone, ensureAgentWorktree) when repos: entries
+ * are configured.
+ *
+ * These tests use vi.mock so they don't require a real git remote or
+ * git binary. The mocked functions record calls so we can assert that
+ * reconcileAgent actually drives provisioning.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+// Mock the repos modules before importing reconcileAgent so that vitest
+// hoisting replaces the implementations with stubs.
+vi.mock("../src/repos/bare-clone.js", () => ({
+  ensureBareClone: vi.fn((slug: string, _url: string) => `/mock/repos/${slug}.git`),
+  bareClonePath: vi.fn((slug: string) => `/mock/repos/${slug}.git`),
+}));
+
+vi.mock("../src/repos/agent-worktree.js", () => ({
+  ensureAgentWorktree: vi.fn(() => ({
+    path: "/mock/worktree",
+    branch: "agent/test/main",
+    dirty: false,
+  })),
+  removeAgentWorktree: vi.fn(),
+  agentWorktreePath: vi.fn((agentDir: string, slug: string) => join(agentDir, "work", slug)),
+  listAgentWorktrees: vi.fn(() => []),
+}));
+
+import { reconcileAgent } from "../src/agents/scaffold.js";
+import { ensureBareClone } from "../src/repos/bare-clone.js";
+import { ensureAgentWorktree } from "../src/repos/agent-worktree.js";
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(
+  agentName: string,
+  agentConfig: AgentConfig,
+): SwitchroomConfig {
+  return {
+    switchroom: { version: 1 },
+    telegram: telegramConfig,
+    agents: { [agentName]: agentConfig },
+  } as SwitchroomConfig;
+}
+
+describe("reconcileAgent — repos: worktree provisioning", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-repo-prov-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("calls ensureBareClone and ensureAgentWorktree for each repos: entry", () => {
+    const agentConfig = makeAgentConfig({
+      repos: {
+        "my-app": { url: "https://github.com/example/my-app.git" },
+        "shared-lib": { url: "git@github.com:example/shared-lib.git" },
+      },
+    });
+
+    const switchroomConfig = makeSwitchroomConfig("test-agent", agentConfig);
+
+    // Pre-create the agent directory (reconcileAgent requires it to exist)
+    const agentDir = join(tmpDir, "test-agent");
+    mkdirSync(agentDir, { recursive: true });
+
+    reconcileAgent("test-agent", agentConfig, tmpDir, telegramConfig, switchroomConfig);
+
+    // ensureBareClone should have been called once per repos: entry
+    expect(ensureBareClone).toHaveBeenCalledTimes(2);
+    expect(ensureBareClone).toHaveBeenCalledWith("my-app", "https://github.com/example/my-app.git");
+    expect(ensureBareClone).toHaveBeenCalledWith("shared-lib", "git@github.com:example/shared-lib.git");
+
+    // ensureAgentWorktree should have been called once per repos: entry
+    // with the agentName, slug, clonePath (returned by ensureBareClone), agentDir
+    expect(ensureAgentWorktree).toHaveBeenCalledTimes(2);
+    expect(ensureAgentWorktree).toHaveBeenCalledWith(
+      "test-agent",
+      "my-app",
+      "/mock/repos/my-app.git",
+      agentDir,
+    );
+    expect(ensureAgentWorktree).toHaveBeenCalledWith(
+      "test-agent",
+      "shared-lib",
+      "/mock/repos/shared-lib.git",
+      agentDir,
+    );
+  });
+
+  it("does not call provisioning functions when repos: is absent", () => {
+    const agentConfig = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig("no-repos-agent", agentConfig);
+    const agentDir = join(tmpDir, "no-repos-agent");
+    mkdirSync(agentDir, { recursive: true });
+
+    reconcileAgent("no-repos-agent", agentConfig, tmpDir, telegramConfig, switchroomConfig);
+
+    expect(ensureBareClone).not.toHaveBeenCalled();
+    expect(ensureAgentWorktree).not.toHaveBeenCalled();
+  });
+
+  it("continues reconcile when provisioning throws (non-fatal)", () => {
+    const mockEnsureBareClone = ensureBareClone as ReturnType<typeof vi.fn>;
+    mockEnsureBareClone.mockImplementationOnce(() => {
+      throw new Error("simulated git clone failure");
+    });
+
+    const agentConfig = makeAgentConfig({
+      repos: {
+        "failing-repo": { url: "https://github.com/example/bad.git" },
+      },
+    });
+
+    const switchroomConfig = makeSwitchroomConfig("fault-agent", agentConfig);
+    const agentDir = join(tmpDir, "fault-agent");
+    mkdirSync(agentDir, { recursive: true });
+
+    // reconcileAgent must not throw — provisioning failure is non-fatal
+    expect(() =>
+      reconcileAgent("fault-agent", agentConfig, tmpDir, telegramConfig, switchroomConfig),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- **Gap closed:** `reconcileAgent` now calls `ensureBareClone` + `ensureAgentWorktree` for each `repos:` entry, so `SWITCHROOM_REPO_<SLUG>` env vars point at paths that actually exist on disk. Previously the env var was injected but the worktree was never created — operators who configured `repos:` got a valid-looking path to a nonexistent directory.
- **Symmetric teardown:** `agent destroy` now calls `removeAgentWorktree` for each `repos:` entry (via `resolveAgentConfig` cascade) before the `rmSync(agentDir)` wipe, so bare-clone worktrees are cleanly unregistered from git's worktree admin.
- **Sync refactor:** `ensureBareClone`, `ensureAgentWorktree`, and `removeAgentWorktree` changed from `async` → sync. All three use `execFileSync` internally; the `async` decoration was structural overhead. Keeping them sync avoids making `reconcileAgent` (and its callers in `apply.ts`) async — the operator's explicit preference (escalation-02 recommendation, "Option A + sync refactor").

## Why

Drift-audit escalation E2 (`give-each-agent-its-own-workspace` c2, c3, c12). The JTBD documents (`reference/give-each-agent-its-own-workspace.md`) and `docs/configuration.md:544` already tell operators to use `repos:` for this use case. The implementation in `src/repos/` was complete and correct — bare clone + per-agent worktree with ff-to-main on clean, dirty-skip, idempotent removal. The only gap was a missing two-line call site in `reconcileAgent`.

## Test plan

- [ ] `tests/scaffold.repo-provisioning.test.ts` (new): verifies via `vi.mock` that `reconcileAgent` calls `ensureBareClone` + `ensureAgentWorktree` once per `repos:` entry with correct args; verifies no-op when `repos:` absent; verifies non-fatal on provisioning error
- [ ] Existing `tests/scaffold.test.ts` suite: no changes expected (no `repos:` in existing fixtures)
- [ ] CI: `vitest` + `lint` + `build-*` checks

## Out of scope

- Boot-card "dirty since `<ts>`" row (JTBD c8 sub-claim) — separate `boot-card.ts` probe + renderer change per escalation-10 recommendation
- Sub-agent nesting in worktrees (JTBD c11) — vision-only, separately tracked

Local tsc/vitest gates deferred to CI — orchestrator host lacks Node toolchain.

**No auto-merge** — awaiting reviewer approval per standard dev process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)