### PR TITLE
feat(boot-card): surface config changes since last boot

### DIFF
--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -57,8 +57,18 @@ import {
   applyAndSave as saveBootIssueCache,
   type ProbeDiffMap,
 } from './boot-issue-cache.js'
+import {
+  loadSnapshot as loadConfigSnapshot,
+  persistSnapshot as persistConfigSnapshot,
+  captureConfigSnapshot,
+  diffSnapshots as diffConfigSnapshots,
+  renderConfigChangeDim,
+  type ConfigSnapshot,
+  type ConfigDiff,
+} from './config-snapshot.js'
 import { join } from 'path'
 import { loadConfig as _loadSwitchroomConfig } from '../../src/config/loader.js'
+import { resolveAgentConfig as _resolveAgentConfig } from '../../src/config/merge.js'
 
 // ─── Persona name resolution ─────────────────────────────────────────────────
 
@@ -298,6 +308,16 @@ export interface RenderBootCardOpts {
    *  the operator sees what happened with the update that triggered
    *  this boot without trawling the audit log. */
   updateOutcomeLine?: string
+  /**
+   * Config-change dimensions detected since the previous boot.
+   * One row per changed field (model, tools, skills, memory backend).
+   * Empty array / undefined = no config changes → section is silent,
+   * preserving the "silent-when-healthy" boot card contract.
+   *
+   * Computed by diffing the current config snapshot against the
+   * persisted snapshot from the prior boot. See `config-snapshot.ts`.
+   */
+  configChanges?: ConfigDiff
 }
 
 /**
@@ -403,6 +423,17 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
     ? renderAuthLine(opts.accounts, agentName, (opts.now ?? new Date()).getTime())
     : []
 
+  // Config-change rows (E3: boot card surfaces config changes since last boot).
+  // Only rendered when the diff is non-empty — silent on identical boots.
+  // Each changed dimension gets its own row; model and memory backend show
+  // verbatim before/after; tools and skills show a coarse hash-diff hint.
+  const configChangeRows: string[] = []
+  if (opts.configChanges && opts.configChanges.length > 0) {
+    for (const dim of opts.configChanges) {
+      configChangeRows.push(renderConfigChangeDim(dim))
+    }
+  }
+
   const sections: string[] = [ack]
   if (degradedRows.length > 0) sections.push('', ...degradedRows)
   if (accountRows.length > 0) sections.push('', ...accountRows)
@@ -411,6 +442,9 @@ export function renderBootCard(opts: RenderBootCardOpts): string {
     // sections array so the join('\n') below renders the multi-line
     // failure-with-recovery hint cleanly.
     sections.push('', ...opts.updateOutcomeLine.split('\n'))
+  }
+  if (configChangeRows.length > 0) {
+    sections.push('', ...configChangeRows)
   }
   if (sections.length === 1) return ack
   return sections.join('\n')
@@ -520,6 +554,20 @@ export interface RunProbesOpts {
    *  failure body with a recovery hint. Append-only — never replaces
    *  the existing ack/probe sections. */
   updateOutcomeLine?: string
+  /**
+   * Path to the per-agent config snapshot file.  When set, the post-settle
+   * render diffs the current resolved config against the persisted snapshot
+   * from the prior boot and appends a row per changed dimension (model,
+   * tools allowlist, skills, memory backend).
+   *
+   * Omit to disable config-change detection entirely (legacy behaviour /
+   * test harnesses that don't need it).
+   *
+   * Typically `<agentDir>/.config-snapshot.json`.  Must be provided
+   * alongside `agentName` — the capture function reads `agentName` to
+   * resolve the default memory collection label.
+   */
+  configSnapshotPath?: string
 }
 
 /** Run all six probes concurrently with their own per-probe timeouts.
@@ -670,6 +718,53 @@ export async function startBootCard(
           }
         }
 
+        // Config-snapshot diff (E3): compare this boot's resolved config
+        // against the snapshot persisted on the previous boot. Fires once
+        // per gateway lifetime — read up-front, write on the way out.
+        // Silent on first boot (no prior snapshot) and on identical boots.
+        let configChanges: ConfigDiff = []
+        if (opts.configSnapshotPath) {
+          try {
+            const agentSlug = opts.agentSlug ?? opts.agentName
+            const agentName = process.env.SWITCHROOM_AGENT_NAME ?? agentSlug
+            let currentCfg: ConfigSnapshot | undefined
+            try {
+              const loaded = _loadSwitchroomConfig()
+              const rawAgent = loaded.agents?.[agentName] ?? {}
+              const resolved = _resolveAgentConfig(loaded.defaults, loaded.profiles, rawAgent)
+              currentCfg = captureConfigSnapshot({
+                agentName,
+                model: resolved.model,
+                toolsAllow: resolved.tools?.allow,
+                skills: resolved.skills,
+                memoryCollection: resolved.memory?.collection,
+              })
+            } catch {
+              // Config unreadable (test env, no switchroom.yaml) — skip diff.
+            }
+            if (currentCfg != null) {
+              const previousSnapshot = loadConfigSnapshot(opts.configSnapshotPath)
+              configChanges = diffConfigSnapshots(currentCfg, previousSnapshot)
+              // Persist unconditionally so the next boot always has a
+              // fresh baseline. A failed persist is non-fatal.
+              persistConfigSnapshot(opts.configSnapshotPath, currentCfg)
+              if (configChanges.length > 0) {
+                logger(
+                  `telegram gateway: boot-card: config-snapshot diff detected ${configChanges.length} change(s): ${
+                    configChanges.map(d => d.field).join(', ')
+                  }\n`,
+                )
+              }
+            }
+          } catch (snapErr: unknown) {
+            logger(
+              `telegram gateway: boot-card: config-snapshot diff failed: ${
+                (snapErr as Error)?.message ?? String(snapErr)
+              }\n`,
+            )
+          }
+        }
+
         // Render with current probe state and edit if anything changed.
         let currentText = renderBootCard({
           agentName: opts.agentName,
@@ -682,6 +777,7 @@ export async function startBootCard(
           ...(resolvedRows.length > 0 ? { resolvedRows } : {}),
           ...(snoozeRows.length > 0 ? { snoozeRows } : {}),
           ...(opts.updateOutcomeLine ? { updateOutcomeLine: opts.updateOutcomeLine } : {}),
+          ...(configChanges.length > 0 ? { configChanges } : {}),
         })
 
         if (currentText !== ackText) {
@@ -734,6 +830,10 @@ export async function startBootCard(
             ...(resolvedRows.length > 0 ? { resolvedRows } : {}),
             ...(snoozeRows.length > 0 ? { snoozeRows } : {}),
             ...(opts.updateOutcomeLine ? { updateOutcomeLine: opts.updateOutcomeLine } : {}),
+            // Config-change rows are stable for the lifetime of this card
+            // (computed once in Phase 1). Pass them through unchanged so
+            // the live-agent-status edits keep the config-diff rows.
+            ...(configChanges.length > 0 ? { configChanges } : {}),
           })
 
           if (updatedText === currentText) continue

--- a/telegram-plugin/gateway/config-snapshot.ts
+++ b/telegram-plugin/gateway/config-snapshot.ts
@@ -1,0 +1,274 @@
+/**
+ * Config-snapshot cache — captures a fingerprint of each agent's
+ * active configuration at gateway boot and diffs against the prior boot.
+ *
+ * Closes the JTBD "no need to ask" gap in `restart-and-know-what-im-running`:
+ * a user who restarts after editing switchroom.yaml now sees exactly what
+ * changed on the boot card, without running `/status`.
+ *
+ * What's captured:
+ *   - model slug (single string, shown verbatim in the diff row)
+ *   - tools allowlist hash (sorted SHA-256 prefix — coarse diff only;
+ *     granular enumeration is a follow-up)
+ *   - skills hash (same pattern)
+ *   - memory backend / collection name (single string, shown verbatim)
+ *
+ * Diff policy:
+ *   - model / memoryBackend: shown verbatim ("model: A → B")
+ *   - toolsHash / skillsHash: "tools allowlist changed — run /status for
+ *     details" (honest without being exhaustive for long allowlists)
+ *
+ * Silent when unchanged: the caller ONLY surfaces a row when
+ * `diffSnapshots()` returns at least one `ConfigChangeDim`.
+ *
+ * First boot (no prior snapshot): returns an empty diff and persists
+ * the current snapshot for the next boot.  Corrupt / missing snapshot:
+ * treated as first boot.
+ *
+ * Storage: `<agentDir>/.config-snapshot.json` (mode 0600), same
+ * location pattern as `boot-issue-cache.json`.
+ */
+
+import { createHash } from 'crypto'
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'fs'
+import { dirname } from 'path'
+import { escapeHtml } from '../card-format.js'
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface ConfigSnapshot {
+  /** Schema version — bump on incompatible layout changes. */
+  schema: 1
+  /** Wall-clock ms at the time of capture (for forensics / GC). */
+  capturedAtMs: number
+  /** Resolved model slug, e.g. "claude-sonnet-4-5".
+   *  null when not set in config (gateway uses the claude CLI default). */
+  model: string | null
+  /**
+   * Sorted SHA-256 prefix of the tools allowlist.
+   * Null when the allowlist is unset / empty (uses claude CLI default).
+   * Computed from the sorted join of the array so reordering the YAML
+   * does not fire a spurious diff.
+   */
+  toolsHash: string | null
+  /**
+   * Sorted SHA-256 prefix of the skills list.
+   * Null when no skills are configured.
+   */
+  skillsHash: string | null
+  /**
+   * Memory backend identifier — `memory.collection` from switchroom.yaml,
+   * or null when not configured.
+   */
+  memoryBackend: string | null
+}
+
+/** One dimension that changed between the prior snapshot and this boot. */
+export interface ConfigChangeDim {
+  /** Which field changed. */
+  field: 'model' | 'tools' | 'skills' | 'memoryBackend'
+  /** Previous value (null = "not configured" or "first boot"). */
+  from: string | null
+  /** Current value (null = "removed" — field was cleared in config). */
+  to: string | null
+}
+
+export type ConfigDiff = ConfigChangeDim[]
+
+// ─── Hashing ────────────────────────────────────────────────────────────────
+
+/**
+ * Compute a short deterministic fingerprint for an array of strings.
+ * Sort before hashing so reordering the array in YAML doesn't fire a
+ * spurious diff row. Returns null for empty / null input.
+ */
+export function hashStringArray(items: string[] | null | undefined): string | null {
+  if (!items || items.length === 0) return null
+  const sorted = [...items].sort()
+  const raw = createHash('sha256').update(sorted.join('\0')).digest('hex')
+  // 12-char prefix is visually compact and collision-resistant enough for
+  // config arrays that rarely exceed a few dozen entries.
+  return raw.slice(0, 12)
+}
+
+/**
+ * Normalize a model slug for comparison: lowercase, strip trailing
+ * whitespace, collapse multiple spaces. Prevents spurious diffs from
+ * case/whitespace variance in the YAML value.
+ */
+export function normalizeModel(model: string | null | undefined): string | null {
+  if (!model || model.trim().length === 0) return null
+  return model.trim().toLowerCase()
+}
+
+// ─── Capture ────────────────────────────────────────────────────────────────
+
+export interface CaptureInput {
+  /** Agent name — used for the default memoryBackend when not explicitly set. */
+  agentName: string
+  /** Resolved model from the config cascade (may be undefined/null). */
+  model?: string | null
+  /** Full tools allowlist from the config cascade (may be undefined/null). */
+  toolsAllow?: string[] | null
+  /** Full skills list from the config cascade (may be undefined/null). */
+  skills?: string[] | null
+  /** Memory collection name from the config cascade (may be undefined/null). */
+  memoryCollection?: string | null
+  /** Clock injection for tests. */
+  now?: () => number
+}
+
+/**
+ * Build a ConfigSnapshot from the current resolved agent config.
+ *
+ * The caller is responsible for loading the config and passing the
+ * relevant fields. This function is pure — no disk I/O.
+ */
+export function captureConfigSnapshot(input: CaptureInput): ConfigSnapshot {
+  return {
+    schema: 1,
+    capturedAtMs: (input.now ?? Date.now)(),
+    model: normalizeModel(input.model),
+    toolsHash: hashStringArray(input.toolsAllow ?? null),
+    skillsHash: hashStringArray(input.skills ?? null),
+    memoryBackend: input.memoryCollection?.trim() || null,
+  }
+}
+
+// ─── Diff ────────────────────────────────────────────────────────────────────
+
+/**
+ * Compare `current` against `previous` and return one entry per changed
+ * dimension. Returns an empty array when nothing changed.
+ *
+ * Edge cases:
+ *   - `previous` is null (first boot or corrupt cache): returns empty diff.
+ *     The caller will persist `current` for the next boot.
+ *   - A field is null on both sides: not a change.
+ */
+export function diffSnapshots(
+  current: ConfigSnapshot,
+  previous: ConfigSnapshot | null,
+): ConfigDiff {
+  if (previous === null) return []
+
+  const changes: ConfigDiff = []
+
+  if (current.model !== previous.model) {
+    changes.push({ field: 'model', from: previous.model, to: current.model })
+  }
+  if (current.toolsHash !== previous.toolsHash) {
+    changes.push({ field: 'tools', from: previous.toolsHash, to: current.toolsHash })
+  }
+  if (current.skillsHash !== previous.skillsHash) {
+    changes.push({ field: 'skills', from: previous.skillsHash, to: current.skillsHash })
+  }
+  if (current.memoryBackend !== previous.memoryBackend) {
+    changes.push({
+      field: 'memoryBackend',
+      from: previous.memoryBackend,
+      to: current.memoryBackend,
+    })
+  }
+
+  return changes
+}
+
+// ─── Rendering ───────────────────────────────────────────────────────────────
+
+/**
+ * Render a single config-change row for the boot card.
+ *
+ * Model and memory backend: shown verbatim ("model: A → B").
+ * Tools / skills: coarse hash diff ("tools allowlist changed — run /status
+ * for details"), since enumerating the full list would be too verbose.
+ *
+ * The null-to-value case means "field was first configured on this boot".
+ * The value-to-null case means "field was removed" (unusual but legal).
+ */
+export function renderConfigChangeDim(dim: ConfigChangeDim): string {
+  switch (dim.field) {
+    case 'model': {
+      const from = escapeHtml(dim.from ?? '(default)')
+      const to = escapeHtml(dim.to ?? '(default)')
+      return `⚙️ <b>Config</b>  model: ${from} → ${to}`
+    }
+    case 'memoryBackend': {
+      const from = escapeHtml(dim.from ?? '(default)')
+      const to = escapeHtml(dim.to ?? '(default)')
+      return `⚙️ <b>Config</b>  memory backend: ${from} → ${to}`
+    }
+    case 'tools':
+      return `⚙️ <b>Config</b>  tools allowlist changed — run /status for details`
+    case 'skills':
+      return `⚙️ <b>Config</b>  skills changed — run /status for details`
+  }
+}
+
+// ─── Persistence ─────────────────────────────────────────────────────────────
+
+/**
+ * Load the config snapshot from `path`.
+ *
+ * Returns null on:
+ *   - file missing (first boot)
+ *   - JSON parse error (corrupt — renamed aside for forensics)
+ *   - schema mismatch
+ */
+export function loadSnapshot(path: string, now: () => number = Date.now): ConfigSnapshot | null {
+  if (!existsSync(path)) return null
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf-8')
+  } catch {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    // Corrupt — preserve for forensics, return null (treat as first boot).
+    try {
+      renameSync(path, `${path}.corrupt-${now()}`)
+    } catch {
+      // best-effort
+    }
+    return null
+  }
+  const obj = parsed as Partial<ConfigSnapshot>
+  if (!obj || obj.schema !== 1) return null
+  // Validate required keys exist (defensive against partial writes).
+  if (
+    typeof obj.capturedAtMs !== 'number' ||
+    !('model' in obj) ||
+    !('toolsHash' in obj) ||
+    !('skillsHash' in obj) ||
+    !('memoryBackend' in obj)
+  ) {
+    return null
+  }
+  return {
+    schema: 1,
+    capturedAtMs: obj.capturedAtMs,
+    model: obj.model ?? null,
+    toolsHash: obj.toolsHash ?? null,
+    skillsHash: obj.skillsHash ?? null,
+    memoryBackend: obj.memoryBackend ?? null,
+  }
+}
+
+/**
+ * Persist `snapshot` to `path` atomically (via `.tmp` + rename).
+ * Failures are swallowed — the snapshot is best-effort and should not
+ * block the boot sequence.
+ */
+export function persistSnapshot(path: string, snapshot: ConfigSnapshot): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true })
+    const tmp = `${path}.tmp`
+    writeFileSync(tmp, JSON.stringify(snapshot), { mode: 0o600 })
+    renameSync(tmp, path)
+  } catch {
+    // Non-fatal: best-effort persistence. Next boot will re-detect.
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3878,11 +3878,12 @@ const ipcServer: IpcServer = createIpcServer({
           const updateOutcomeLine = (() => {
             try { return maybeRenderUpdateAnnouncement() ?? undefined } catch { return undefined }
           })()
+          const resolvedAgentDirForCard = agentDir ?? (process.env.TELEGRAM_STATE_DIR ? require('path').dirname(process.env.TELEGRAM_STATE_DIR) : '/tmp')
           startBootCard(chatId, threadId, botApiForCard, {
             agentName: agentDisplayName,
             agentSlug,
             version: formatBootVersion(),
-            agentDir: agentDir ?? (process.env.TELEGRAM_STATE_DIR ? require('path').dirname(process.env.TELEGRAM_STATE_DIR) : '/tmp'),
+            agentDir: resolvedAgentDirForCard,
             gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
             restartReason: reason,
             restartAgeMs: markerAgeMs,
@@ -3891,6 +3892,7 @@ const ipcServer: IpcServer = createIpcServer({
             probeQuotaViaBroker: (t) => probeQuotaForBootCard(agentSlug, t),
             tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
             dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
+            configSnapshotPath: join(resolvedAgentDirForCard, '.config-snapshot.json'),
             ...(updateOutcomeLine ? { updateOutcomeLine } : {}),
           }, ackMsgId).then(handle => {
             activeBootCard = handle
@@ -16630,11 +16632,12 @@ void (async () => {
                     const updateOutcomeLine = (() => {
                       try { return maybeRenderUpdateAnnouncement() ?? undefined } catch { return undefined }
                     })()
+                    const resolvedAgentDirForBootCard = agentDir ?? join(homedir(), '.switchroom', 'agents', agentSlug)
                     const handle = await startBootCard(chatId, threadId, botApiForCard, {
                       agentName: agentDisplayName,
                       agentSlug,
                       version: formatBootVersion(),
-                      agentDir: agentDir ?? join(homedir(), '.switchroom', 'agents', agentSlug),
+                      agentDir: resolvedAgentDirForBootCard,
                       gatewayInfo: { pid: process.pid, startedAtMs: GATEWAY_STARTED_AT_MS },
                       restartReason: reason,
                       restartAgeMs: markerAgeMs,
@@ -16643,6 +16646,7 @@ void (async () => {
                       probeQuotaViaBroker: (t) => probeQuotaForBootCard(agentSlug, t),
                       tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
                       dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
+                      configSnapshotPath: join(resolvedAgentDirForBootCard, '.config-snapshot.json'),
                       ...(updateOutcomeLine ? { updateOutcomeLine } : {}),
                     }, ackMsgId)
                     activeBootCard = handle

--- a/telegram-plugin/tests/boot-card-render.test.ts
+++ b/telegram-plugin/tests/boot-card-render.test.ts
@@ -364,3 +364,96 @@ describe('renderBootCard — resolved / snooze rendering', () => {
     expect(out).toContain('✅ <b>Broker</b>  resolved')
   })
 })
+
+// ── Config-change row rendering (E3) ─────────────────────────────────────────
+
+describe('renderBootCard — configChanges rows', () => {
+  it('silent when configChanges is absent', () => {
+    const out = renderBootCard({ agentName: 'k', version: 'v' })
+    expect(out).toBe('✅ <b>k</b> back up · v')
+    expect(out).not.toContain('Config')
+  })
+
+  it('silent when configChanges is empty array', () => {
+    const out = renderBootCard({ agentName: 'k', version: 'v', configChanges: [] })
+    expect(out).toBe('✅ <b>k</b> back up · v')
+    expect(out).not.toContain('Config')
+  })
+
+  it('renders a model-change row when model changed', () => {
+    const out = renderBootCard({
+      agentName: 'k',
+      version: 'v',
+      configChanges: [{ field: 'model', from: 'claude-opus-4', to: 'claude-sonnet-4-5' }],
+    })
+    expect(out).toContain('⚙️ <b>Config</b>')
+    expect(out).toContain('claude-opus-4')
+    expect(out).toContain('claude-sonnet-4-5')
+    expect(out).toContain('→')
+  })
+
+  it('renders a coarse tools-changed row for tools diff', () => {
+    const out = renderBootCard({
+      agentName: 'k',
+      version: 'v',
+      configChanges: [{ field: 'tools', from: 'aaa', to: 'bbb' }],
+    })
+    expect(out).toContain('tools allowlist changed')
+    expect(out).toContain('/status')
+    expect(out).not.toContain('aaa')
+    expect(out).not.toContain('bbb')
+  })
+
+  it('renders a coarse skills-changed row for skills diff', () => {
+    const out = renderBootCard({
+      agentName: 'k',
+      version: 'v',
+      configChanges: [{ field: 'skills', from: 'ccc', to: 'ddd' }],
+    })
+    expect(out).toContain('skills changed')
+    expect(out).toContain('/status')
+  })
+
+  it('renders multiple config-change rows (all four fields)', () => {
+    const out = renderBootCard({
+      agentName: 'k',
+      version: 'v',
+      configChanges: [
+        { field: 'model', from: 'claude-opus-4', to: 'claude-sonnet-4-5' },
+        { field: 'tools', from: 'abc', to: 'def' },
+        { field: 'skills', from: 'ghi', to: 'jkl' },
+        { field: 'memoryBackend', from: 'finn', to: 'finn-v2' },
+      ],
+    })
+    const lines = out.split('\n')
+    // Should have more than 1 line (ack + separator + config rows).
+    expect(lines.length).toBeGreaterThan(2)
+    expect(out).toContain('claude-opus-4')
+    expect(out).toContain('tools allowlist changed')
+    expect(out).toContain('skills changed')
+    expect(out).toContain('finn')
+    expect(out).toContain('finn-v2')
+  })
+
+  it('config-change rows appear after probe rows', () => {
+    const out = renderBootCard({
+      agentName: 'k',
+      version: 'v',
+      probes: {
+        broker: { status: 'fail', label: 'Broker', detail: 'socket missing' },
+      },
+      configChanges: [{ field: 'model', from: 'a', to: 'b' }],
+    })
+    const brokerIdx = out.indexOf('Broker')
+    const configIdx = out.indexOf('Config')
+    expect(brokerIdx).toBeGreaterThan(-1)
+    expect(configIdx).toBeGreaterThan(-1)
+    expect(configIdx).toBeGreaterThan(brokerIdx)
+  })
+
+  it('bare ack still returned when configChanges fires but produces only empty rows (defensive)', () => {
+    // Edge: empty configChanges array passed → should not produce rows.
+    const out = renderBootCard({ agentName: 'k', version: 'v', configChanges: [] })
+    expect(out).toBe('✅ <b>k</b> back up · v')
+  })
+})

--- a/telegram-plugin/tests/config-snapshot.test.ts
+++ b/telegram-plugin/tests/config-snapshot.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Unit tests for the config-snapshot module (config-snapshot.ts).
+ *
+ * Covers:
+ *   1. captureConfigSnapshot — field normalization, null handling
+ *   2. diffSnapshots — model changed only; tools changed only; everything
+ *      changed; nothing changed; first boot (previous=null)
+ *   3. renderConfigChangeDim — verbatim for model/memory, coarse for tools/skills
+ *   4. loadSnapshot / persistSnapshot — round-trip, corrupt file, first boot
+ *   5. hashStringArray — deterministic, order-independent, null/empty handling
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  captureConfigSnapshot,
+  diffSnapshots,
+  renderConfigChangeDim,
+  hashStringArray,
+  normalizeModel,
+  loadSnapshot,
+  persistSnapshot,
+  type ConfigSnapshot,
+  type ConfigDiff,
+} from '../gateway/config-snapshot.js'
+
+let tmp: string
+beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'cfg-snap-')) })
+afterEach(() => { rmSync(tmp, { recursive: true, force: true }) })
+
+// ── hashStringArray ───────────────────────────────────────────────────────────
+
+describe('hashStringArray', () => {
+  it('returns null for null input', () => {
+    expect(hashStringArray(null)).toBeNull()
+  })
+
+  it('returns null for empty array', () => {
+    expect(hashStringArray([])).toBeNull()
+  })
+
+  it('returns a 12-char hex string for a non-empty array', () => {
+    const h = hashStringArray(['bash', 'computer'])
+    expect(typeof h).toBe('string')
+    expect(h!.length).toBe(12)
+    expect(/^[0-9a-f]{12}$/.test(h!)).toBe(true)
+  })
+
+  it('is order-independent — sorted before hashing', () => {
+    const h1 = hashStringArray(['bash', 'computer', 'str_replace_based_edit_tool'])
+    const h2 = hashStringArray(['str_replace_based_edit_tool', 'bash', 'computer'])
+    expect(h1).toBe(h2)
+  })
+
+  it('produces different hashes for different content', () => {
+    const h1 = hashStringArray(['bash'])
+    const h2 = hashStringArray(['computer'])
+    expect(h1).not.toBe(h2)
+  })
+})
+
+// ── normalizeModel ────────────────────────────────────────────────────────────
+
+describe('normalizeModel', () => {
+  it('lowercases the model string', () => {
+    expect(normalizeModel('Claude-Sonnet-4-5')).toBe('claude-sonnet-4-5')
+  })
+
+  it('trims whitespace', () => {
+    expect(normalizeModel('  claude-opus-4  ')).toBe('claude-opus-4')
+  })
+
+  it('returns null for null, undefined, or empty string', () => {
+    expect(normalizeModel(null)).toBeNull()
+    expect(normalizeModel(undefined)).toBeNull()
+    expect(normalizeModel('')).toBeNull()
+    expect(normalizeModel('   ')).toBeNull()
+  })
+})
+
+// ── captureConfigSnapshot ────────────────────────────────────────────────────
+
+describe('captureConfigSnapshot', () => {
+  it('captures all fields from config', () => {
+    const snap = captureConfigSnapshot({
+      agentName: 'finn',
+      model: 'claude-sonnet-4-5',
+      toolsAllow: ['bash', 'computer'],
+      skills: ['search'],
+      memoryCollection: 'finn-memories',
+      now: () => 1000,
+    })
+    expect(snap.schema).toBe(1)
+    expect(snap.capturedAtMs).toBe(1000)
+    expect(snap.model).toBe('claude-sonnet-4-5')
+    expect(snap.toolsHash).not.toBeNull()
+    expect(snap.skillsHash).not.toBeNull()
+    expect(snap.memoryBackend).toBe('finn-memories')
+  })
+
+  it('produces null fields when config fields are absent', () => {
+    const snap = captureConfigSnapshot({ agentName: 'finn' })
+    expect(snap.model).toBeNull()
+    expect(snap.toolsHash).toBeNull()
+    expect(snap.skillsHash).toBeNull()
+    expect(snap.memoryBackend).toBeNull()
+  })
+
+  it('normalizes model to lowercase', () => {
+    const snap = captureConfigSnapshot({ agentName: 'finn', model: 'Claude-Sonnet-4-5' })
+    expect(snap.model).toBe('claude-sonnet-4-5')
+  })
+
+  it('tools hash is order-independent', () => {
+    const a = captureConfigSnapshot({ agentName: 'x', toolsAllow: ['bash', 'computer'] })
+    const b = captureConfigSnapshot({ agentName: 'x', toolsAllow: ['computer', 'bash'] })
+    expect(a.toolsHash).toBe(b.toolsHash)
+  })
+})
+
+// ── diffSnapshots ─────────────────────────────────────────────────────────────
+
+function makeSnap(overrides: Partial<ConfigSnapshot> = {}): ConfigSnapshot {
+  return {
+    schema: 1,
+    capturedAtMs: 1000,
+    model: 'claude-sonnet-4-5',
+    toolsHash: hashStringArray(['bash', 'computer']),
+    skillsHash: hashStringArray(['search']),
+    memoryBackend: 'finn',
+    ...overrides,
+  }
+}
+
+describe('diffSnapshots', () => {
+  it('returns empty diff when previous is null (first boot)', () => {
+    const current = makeSnap()
+    expect(diffSnapshots(current, null)).toEqual([])
+  })
+
+  it('returns empty diff when nothing changed', () => {
+    const snap = makeSnap()
+    expect(diffSnapshots(snap, snap)).toEqual([])
+  })
+
+  it('detects model change only', () => {
+    const prev = makeSnap({ model: 'claude-opus-4' })
+    const curr = makeSnap({ model: 'claude-sonnet-4-5' })
+    const diff = diffSnapshots(curr, prev)
+    expect(diff).toHaveLength(1)
+    expect(diff[0].field).toBe('model')
+    expect(diff[0].from).toBe('claude-opus-4')
+    expect(diff[0].to).toBe('claude-sonnet-4-5')
+  })
+
+  it('detects tools allowlist change only', () => {
+    const prevHash = hashStringArray(['bash'])
+    const currHash = hashStringArray(['bash', 'computer'])
+    const prev = makeSnap({ toolsHash: prevHash })
+    const curr = makeSnap({ toolsHash: currHash })
+    const diff = diffSnapshots(curr, prev)
+    expect(diff).toHaveLength(1)
+    expect(diff[0].field).toBe('tools')
+  })
+
+  it('detects skills change only', () => {
+    const prev = makeSnap({ skillsHash: hashStringArray(['search']) })
+    const curr = makeSnap({ skillsHash: hashStringArray(['search', 'code']) })
+    const diff = diffSnapshots(curr, prev)
+    expect(diff).toHaveLength(1)
+    expect(diff[0].field).toBe('skills')
+  })
+
+  it('detects memory backend change only', () => {
+    const prev = makeSnap({ memoryBackend: 'finn' })
+    const curr = makeSnap({ memoryBackend: 'finn-v2' })
+    const diff = diffSnapshots(curr, prev)
+    expect(diff).toHaveLength(1)
+    expect(diff[0].field).toBe('memoryBackend')
+    expect(diff[0].from).toBe('finn')
+    expect(diff[0].to).toBe('finn-v2')
+  })
+
+  it('detects all four fields changing at once', () => {
+    const prev = makeSnap({
+      model: 'claude-opus-4',
+      toolsHash: hashStringArray(['bash']),
+      skillsHash: hashStringArray(['search']),
+      memoryBackend: 'old-bank',
+    })
+    const curr = makeSnap({
+      model: 'claude-sonnet-4-5',
+      toolsHash: hashStringArray(['bash', 'computer']),
+      skillsHash: hashStringArray(['search', 'code']),
+      memoryBackend: 'new-bank',
+    })
+    const diff = diffSnapshots(curr, prev)
+    expect(diff).toHaveLength(4)
+    const fields = diff.map(d => d.field)
+    expect(fields).toContain('model')
+    expect(fields).toContain('tools')
+    expect(fields).toContain('skills')
+    expect(fields).toContain('memoryBackend')
+  })
+
+  it('does not fire when both sides have null for the same field', () => {
+    const prev = makeSnap({ model: null })
+    const curr = makeSnap({ model: null })
+    const diff = diffSnapshots(curr, prev)
+    const modelDiff = diff.find(d => d.field === 'model')
+    expect(modelDiff).toBeUndefined()
+  })
+
+  it('fires when model transitions from null to a value (first explicit model set)', () => {
+    const prev = makeSnap({ model: null })
+    const curr = makeSnap({ model: 'claude-sonnet-4-5' })
+    const diff = diffSnapshots(curr, prev)
+    const modelDiff = diff.find(d => d.field === 'model')
+    expect(modelDiff).toBeDefined()
+    expect(modelDiff!.from).toBeNull()
+    expect(modelDiff!.to).toBe('claude-sonnet-4-5')
+  })
+})
+
+// ── renderConfigChangeDim ─────────────────────────────────────────────────────
+
+describe('renderConfigChangeDim', () => {
+  it('model: shows verbatim from → to', () => {
+    const row = renderConfigChangeDim({
+      field: 'model',
+      from: 'claude-opus-4',
+      to: 'claude-sonnet-4-5',
+    })
+    expect(row).toContain('claude-opus-4')
+    expect(row).toContain('claude-sonnet-4-5')
+    expect(row).toContain('→')
+    expect(row).toContain('model:')
+  })
+
+  it('model: shows "(default)" when from or to is null', () => {
+    const row = renderConfigChangeDim({ field: 'model', from: null, to: 'claude-sonnet-4-5' })
+    expect(row).toContain('(default)')
+    expect(row).toContain('claude-sonnet-4-5')
+  })
+
+  it('memoryBackend: shows verbatim from → to', () => {
+    const row = renderConfigChangeDim({
+      field: 'memoryBackend',
+      from: 'finn',
+      to: 'finn-v2',
+    })
+    expect(row).toContain('finn')
+    expect(row).toContain('finn-v2')
+    expect(row).toContain('memory backend:')
+  })
+
+  it('tools: coarse message with /status hint', () => {
+    const row = renderConfigChangeDim({
+      field: 'tools',
+      from: 'abc123',
+      to: 'def456',
+    })
+    expect(row).toContain('tools allowlist changed')
+    expect(row).toContain('/status')
+    // Should NOT contain raw hashes in the user-facing text.
+    expect(row).not.toContain('abc123')
+    expect(row).not.toContain('def456')
+  })
+
+  it('skills: coarse message with /status hint', () => {
+    const row = renderConfigChangeDim({
+      field: 'skills',
+      from: 'abc123',
+      to: 'def456',
+    })
+    expect(row).toContain('skills changed')
+    expect(row).toContain('/status')
+  })
+
+  it('all rows start with the ⚙️ Config prefix', () => {
+    const fields: Array<ConfigDiff[number]['field']> = ['model', 'tools', 'skills', 'memoryBackend']
+    for (const field of fields) {
+      const row = renderConfigChangeDim({ field, from: 'a', to: 'b' })
+      expect(row).toContain('⚙️')
+      expect(row).toContain('<b>Config</b>')
+    }
+  })
+})
+
+// ── loadSnapshot / persistSnapshot ───────────────────────────────────────────
+
+describe('loadSnapshot / persistSnapshot — persistence', () => {
+  it('returns null when file does not exist (first boot)', () => {
+    const path = join(tmp, 'snap.json')
+    expect(loadSnapshot(path)).toBeNull()
+  })
+
+  it('round-trips: persist then load yields the same snapshot', () => {
+    const path = join(tmp, 'snap.json')
+    const snap = makeSnap({ capturedAtMs: 9999 })
+    persistSnapshot(path, snap)
+    expect(existsSync(path)).toBe(true)
+    const loaded = loadSnapshot(path)
+    expect(loaded).not.toBeNull()
+    expect(loaded!.model).toBe(snap.model)
+    expect(loaded!.toolsHash).toBe(snap.toolsHash)
+    expect(loaded!.skillsHash).toBe(snap.skillsHash)
+    expect(loaded!.memoryBackend).toBe(snap.memoryBackend)
+    expect(loaded!.capturedAtMs).toBe(9999)
+  })
+
+  it('corrupt JSON file is renamed aside and null is returned', () => {
+    const path = join(tmp, 'snap.json')
+    writeFileSync(path, 'not-valid-json-{{{')
+    const loaded = loadSnapshot(path, () => 55555)
+    expect(loaded).toBeNull()
+    // Corrupt file preserved with timestamp suffix.
+    expect(existsSync(`${path}.corrupt-55555`)).toBe(true)
+  })
+
+  it('schema mismatch returns null', () => {
+    const path = join(tmp, 'snap.json')
+    writeFileSync(path, JSON.stringify({ schema: 99, capturedAtMs: 1, model: null, toolsHash: null, skillsHash: null, memoryBackend: null }))
+    expect(loadSnapshot(path)).toBeNull()
+  })
+
+  it('persists and overwrites on subsequent calls (baseline update)', () => {
+    const path = join(tmp, 'snap.json')
+    const first = makeSnap({ model: 'claude-opus-4' })
+    const second = makeSnap({ model: 'claude-sonnet-4-5' })
+    persistSnapshot(path, first)
+    persistSnapshot(path, second)
+    const loaded = loadSnapshot(path)
+    expect(loaded!.model).toBe('claude-sonnet-4-5')
+  })
+})
+
+// ── Integration: full boot-to-boot lifecycle ──────────────────────────────────
+
+describe('boot-to-boot lifecycle', () => {
+  it('first boot: no diff; subsequent boot with same config: no diff', () => {
+    const path = join(tmp, 'snap.json')
+    const snap1 = captureConfigSnapshot({
+      agentName: 'finn',
+      model: 'claude-sonnet-4-5',
+      toolsAllow: ['bash'],
+      skills: ['search'],
+      memoryCollection: 'finn',
+      now: () => 1000,
+    })
+
+    // First boot: no prior snapshot → no diff.
+    const prev1 = loadSnapshot(path)
+    const diff1 = diffSnapshots(snap1, prev1)
+    expect(diff1).toEqual([])
+    persistSnapshot(path, snap1)
+
+    // Second boot with SAME config → no diff.
+    const snap2 = captureConfigSnapshot({
+      agentName: 'finn',
+      model: 'claude-sonnet-4-5',
+      toolsAllow: ['bash'],
+      skills: ['search'],
+      memoryCollection: 'finn',
+      now: () => 2000,
+    })
+    const prev2 = loadSnapshot(path)
+    const diff2 = diffSnapshots(snap2, prev2)
+    expect(diff2).toEqual([])
+    persistSnapshot(path, snap2)
+  })
+
+  it('third boot after model change: diff fires once, then silent again', () => {
+    const path = join(tmp, 'snap.json')
+
+    // Boot 1: snapshot with old model.
+    const snap1 = captureConfigSnapshot({
+      agentName: 'finn',
+      model: 'claude-opus-4',
+      now: () => 1000,
+    })
+    persistSnapshot(path, snap1)
+
+    // Boot 2: model changed.
+    const snap2 = captureConfigSnapshot({
+      agentName: 'finn',
+      model: 'claude-sonnet-4-5',
+      now: () => 2000,
+    })
+    const prev2 = loadSnapshot(path)
+    const diff2 = diffSnapshots(snap2, prev2)
+    expect(diff2).toHaveLength(1)
+    expect(diff2[0].field).toBe('model')
+    persistSnapshot(path, snap2)
+
+    // Boot 3: same model as boot 2 → no diff.
+    const snap3 = captureConfigSnapshot({
+      agentName: 'finn',
+      model: 'claude-sonnet-4-5',
+      now: () => 3000,
+    })
+    const prev3 = loadSnapshot(path)
+    const diff3 = diffSnapshots(snap3, prev3)
+    expect(diff3).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Closes the JTBD c3/c8 gap in `restart-and-know-what-im-running`: boot card was silent on config after PR #142; users had to run `/status` to see what was live
- Implements Option C from escalation-03.md: config-snapshot cache + change-detection row, **silent when unchanged**
- New `config-snapshot.ts` captures model slug, tools-allowlist hash, skills hash, memory backend at boot; diffs against the prior boot's persisted snapshot
- Model and memory backend: verbatim diff row ("model: claude-opus-4 → claude-sonnet-4-5"); tools/skills: coarse hash-diff with `/status` pointer (first cut; granular diff is a follow-up)
- First boot or identical config: no row rendered — preserves the "silent-when-healthy" contract from PR #142

## Why

The JTBD criterion c8 says "change is obvious, not buried." The anti-patterns block explicitly names "Cosmetic summaries that always look the same regardless of the actual config — the user learns to distrust it." Today every restart produces the same single ack line even if the operator just changed the model or disabled a tool. This PR makes config changes unmissable at the one place users already look: the boot card.

## What changed

- **New**: `telegram-plugin/gateway/config-snapshot.ts` — pure capture/diff/render/persist module (no gateway coupling)
- **`boot-card.ts`**: `RenderBootCardOpts.configChanges?: ConfigDiff` + `RunProbesOpts.configSnapshotPath?`; config-snapshot diff runs in the post-settle phase alongside probe dedup; config-change rows render after `updateOutcomeLine`
- **`gateway.ts`**: `configSnapshotPath: join(agentDir, '.config-snapshot.json')` wired into both `startBootCard` callsites (boot path + bridge-reconnect path)
- **Tests**: `telegram-plugin/tests/config-snapshot.test.ts` (30+ cases: capture, diff, render, persistence round-trip) + 8 new cases in `boot-card-render.test.ts`

## Test plan

- [ ] `vitest run telegram-plugin/tests/config-snapshot.test.ts` — new module tests
- [ ] `vitest run telegram-plugin/tests/boot-card-render.test.ts` — extended renderer tests
- [ ] `vitest run` — full suite clean (no regressions in probe/dedup/render)
- [ ] `npm run lint` — tsc + plugin-references check

Note: Local tsc/vitest gates deferred to CI — orchestrator host lacks Node toolchain.

## Risk

Low. Config-snapshot is fully optional (omit `configSnapshotPath` = old behaviour). All disk I/O is best-effort (swallowed errors). No change to the ack-line path or probe rows — only a new append section that fires when config actually changed.

Related: escalation-03.md (drift audit 2026-05-26), JTBD `reference/restart-and-know-what-im-running.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)