### PR TITLE
refactor(scaffold,doctor): integration MCP registry + checkScaffoldWiring for ms-365/notion

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2151,6 +2151,74 @@ export function resolveNotionMcpEntry(
   return entry;
 }
 
+/**
+ * Registry of MCP-server integrations resolved by scaffold + reconcile.
+ *
+ * Each entry pairs the `resolve` predicate with two keys: `emitKey`
+ * (the mcpServers key the resolver returns when it emits an entry —
+ * matches the integration's settings.json key) and `retractionKey`
+ * (the literal mcpServers key to `delete` at the reconcile site when
+ * resolve returns null). They are equal today for every integration,
+ * but kept as separate fields so a future integration whose
+ * opt-out key differs from its emit key can't silently drift.
+ *
+ * **Iteration order is part of the contract.** The order here
+ * determines which integration's entry lands first at every call
+ * site; that matters at Site 2 (.mcp.json framework-wins), where a
+ * later user-spread can override but two integrations colliding on
+ * the same key would have the last-wins ordering pinned here. Today
+ * no two integrations share a key — but the order is still load-
+ * bearing for the tests that pin precedence semantics
+ * (`tests/scaffold.integration-registry.test.ts`).
+ *
+ * Adding a new integration: append one entry here + define the
+ * `resolve` function above. The 4 mcpServers-assembly sites in
+ * `scaffold.ts` (and the reconcile-side equivalents) pick it up
+ * automatically.
+ *
+ * @see `tests/scaffold.integration-registry.test.ts` for the
+ * regression-gate tests pinning each site's conflict policy.
+ */
+export interface IntegrationMcpResolver {
+  /** Display label for diagnostics. */
+  label: string;
+  /** The mcpServers key the resolver emits — also the user-facing opt-out key (`mcp_servers.<key>: false`). */
+  emitKey: string;
+  /**
+   * The literal mcpServers key to `delete` at Site 3 (settings.json
+   * reconcile) when resolve returns null. Kept separate from
+   * emitKey so a future opt-out-key vs emit-key drift can't silently
+   * break retraction.
+   */
+  retractionKey: string;
+  resolve: (
+    name: string,
+    agentConfig: AgentConfig,
+    switchroomConfig: SwitchroomConfig | undefined,
+  ) => { key: string; value: McpServerConfig } | null;
+}
+
+export const INTEGRATION_MCP_RESOLVERS: readonly IntegrationMcpResolver[] = [
+  {
+    label: "Google Workspace",
+    emitKey: "gdrive",
+    retractionKey: "gdrive",
+    resolve: resolveGdriveMcpEntry,
+  },
+  {
+    label: "Microsoft 365",
+    emitKey: "ms-365",
+    retractionKey: "ms-365",
+    resolve: resolveMs365McpEntry,
+  },
+  {
+    label: "Notion",
+    emitKey: "notion",
+    retractionKey: "notion",
+    resolve: resolveNotionMcpEntry,
+  },
+];
+
 export function scaffoldAgent(
   name: string,
   agentConfigRaw: AgentConfig,
@@ -2420,18 +2488,14 @@ export function scaffoldAgent(
       // `mcp_servers: { gdrive: false }` hard opt-out. A user-declared
       // `gdrive` entry (already in settings.mcpServers) wins, same as the
       // built-in defaults above.
-      {
-        const gdrive = resolveGdriveMcpEntry(name, agentConfig, switchroomConfig);
-        if (gdrive && !settings.mcpServers[gdrive.key]) {
-          settings.mcpServers[gdrive.key] = gdrive.value;
-        }
-        const ms365 = resolveMs365McpEntry(name, agentConfig, switchroomConfig);
-        if (ms365 && !settings.mcpServers[ms365.key]) {
-          settings.mcpServers[ms365.key] = ms365.value;
-        }
-        const notion = resolveNotionMcpEntry(name, agentConfig, switchroomConfig);
-        if (notion && !settings.mcpServers[notion.key]) {
-          settings.mcpServers[notion.key] = notion.value;
+      // Site 1 — user-wins precedence: a user-declared mcp_servers
+      // entry already in settings.mcpServers takes priority. Registry
+      // iteration preserves the gdrive → ms-365 → notion order from
+      // INTEGRATION_MCP_RESOLVERS.
+      for (const integration of INTEGRATION_MCP_RESOLVERS) {
+        const entry = integration.resolve(name, agentConfig, switchroomConfig);
+        if (entry && !settings.mcpServers[entry.key]) {
+          settings.mcpServers[entry.key] = entry.value;
         }
       }
 
@@ -2591,17 +2655,15 @@ export function scaffoldAgent(
     // loads for switchroom-telegram-plugin agents — see the block
     // comment at the top of this branch. Same shared broker-ACL gate.
     if (switchroomConfig) {
-      const gdrive = resolveGdriveMcpEntry(name, agentConfig, switchroomConfig);
-      if (gdrive) {
-        mcpServers[gdrive.key] = gdrive.value;
-      }
-      const ms365 = resolveMs365McpEntry(name, agentConfig, switchroomConfig);
-      if (ms365) {
-        mcpServers[ms365.key] = ms365.value;
-      }
-      const notion = resolveNotionMcpEntry(name, agentConfig, switchroomConfig);
-      if (notion) {
-        mcpServers[notion.key] = notion.value;
+      // Site 2 — framework-wins on first write; subsequent user
+      // spread (below) wins on key collision. Order preserved from
+      // INTEGRATION_MCP_RESOLVERS so two integrations never silently
+      // disagree on precedence between sites.
+      for (const integration of INTEGRATION_MCP_RESOLVERS) {
+        const entry = integration.resolve(name, agentConfig, switchroomConfig);
+        if (entry) {
+          mcpServers[entry.key] = entry.value;
+        }
       }
     }
 
@@ -4283,27 +4345,18 @@ export function reconcileAgent(
     // google_workspace.account / google_accounts.enabled_for[] in
     // switchroom.yaml adds or retracts the entry on the next reconcile.
     {
-      const gdrive = resolveGdriveMcpEntry(name, agentConfig, switchroomConfig);
-      if (gdrive) {
-        mcpServers[gdrive.key] = gdrive.value;
-      } else {
-        // Retraction: if the agent lost authorization (account removed
-        // from enabled_for[], or opt-out flipped), drop any stale entry
-        // so reconcile is the source of truth — mirrors how the #235
-        // switchroom-mcp retraction works.
-        delete mcpServers["gdrive"];
-      }
-      const ms365 = resolveMs365McpEntry(name, agentConfig, switchroomConfig);
-      if (ms365) {
-        mcpServers[ms365.key] = ms365.value;
-      } else {
-        delete mcpServers["ms-365"];
-      }
-      const notion = resolveNotionMcpEntry(name, agentConfig, switchroomConfig);
-      if (notion) {
-        mcpServers[notion.key] = notion.value;
-      } else {
-        delete mcpServers["notion"];
+      // Site 3 — settings.json reconcile: emit-or-retract. Retraction
+      // is keyed off `integration.retractionKey` (a separate field from
+      // `emitKey`), so a future integration whose opt-out key differs
+      // from its emit key cannot silently drift between emit and
+      // retract paths. Mirrors how #235 switchroom-mcp retraction works.
+      for (const integration of INTEGRATION_MCP_RESOLVERS) {
+        const entry = integration.resolve(name, agentConfig, switchroomConfig);
+        if (entry) {
+          mcpServers[entry.key] = entry.value;
+        } else {
+          delete mcpServers[integration.retractionKey];
+        }
       }
     }
 
@@ -4611,17 +4664,14 @@ export function reconcileAgent(
     // simply isn't re-added (no explicit delete needed). Same shared
     // broker-ACL gate as scaffoldAgent / settings paths.
     {
-      const gdrive = resolveGdriveMcpEntry(name, agentConfig, switchroomConfig);
-      if (gdrive) {
-        mcpServers[gdrive.key] = gdrive.value;
-      }
-      const ms365 = resolveMs365McpEntry(name, agentConfig, switchroomConfig);
-      if (ms365) {
-        mcpServers[ms365.key] = ms365.value;
-      }
-      const notion = resolveNotionMcpEntry(name, agentConfig, switchroomConfig);
-      if (notion) {
-        mcpServers[notion.key] = notion.value;
+      // Site 4 — .mcp.json reconcile: emit-only. mcpServers is rebuilt
+      // fresh from the hardcoded set each reconcile, so a retracted
+      // entry simply isn't re-added (no explicit delete needed).
+      for (const integration of INTEGRATION_MCP_RESOLVERS) {
+        const entry = integration.resolve(name, agentConfig, switchroomConfig);
+        if (entry) {
+          mcpServers[entry.key] = entry.value;
+        }
       }
     }
 

--- a/src/cli/doctor-microsoft.ts
+++ b/src/cli/doctor-microsoft.ts
@@ -38,6 +38,7 @@ import { homedir } from "node:os";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 import type { CheckStatus } from "./doctor-status.js";
+import { checkIntegrationScaffoldWiring } from "./doctor-scaffold-wiring.js";
 
 export interface CheckResult {
   name: string;
@@ -325,6 +326,18 @@ export function runMicrosoftChecks(
   const msAgents = computeMicrosoftEnabledAgents(config);
   results.push(...checkOAuthClient(config, msAgents.length > 0));
   results.push(...checkLauncherHeartbeat(msAgents, d));
+  results.push(
+    ...checkIntegrationScaffoldWiring({
+      label: "microsoft",
+      mcpKey: "ms-365",
+      agents: msAgents,
+      agentsDir: d.agentsDir,
+      deps: {
+        existsSync: d.existsSync,
+        readFileSync: (path: string) => d.readFileSync(path, "utf-8"),
+      },
+    }),
+  );
 
   return results;
 }

--- a/src/cli/doctor-notion.ts
+++ b/src/cli/doctor-notion.ts
@@ -46,6 +46,7 @@ import { homedir } from "node:os";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 import type { CheckStatus } from "./doctor-status.js";
+import { checkIntegrationScaffoldWiring } from "./doctor-scaffold-wiring.js";
 
 export interface CheckResult {
   name: string;
@@ -320,6 +321,18 @@ export async function runNotionChecks(
   if (notionAgents.length > 0 && config.notion_workspace) {
     results.push(...(await checkVaultAclAligned(config, notionAgents, d)));
     results.push(...checkLauncherHeartbeat(notionAgents, d));
+    results.push(
+      ...checkIntegrationScaffoldWiring({
+        label: "notion",
+        mcpKey: "notion",
+        agents: notionAgents,
+        agentsDir: d.agentsDir,
+        deps: {
+          existsSync: d.existsSync,
+          readFileSync: (path: string) => d.readFileSync(path, "utf-8"),
+        },
+      }),
+    );
   }
 
   return results;

--- a/src/cli/doctor-scaffold-wiring.test.ts
+++ b/src/cli/doctor-scaffold-wiring.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for the shared scaffold-wiring probe (extracted from
+ * `doctor-drive.ts` so m365 + notion can reuse it).
+ *
+ * Two regression-gate classes pinned here:
+ *   - **bug-8 class**: `.mcp.json` carries the integration's entry
+ *     but with no env block. Claude spawns the MCP with a sanitized
+ *     env so the launcher can't reach switchroom.yaml / the broker.
+ *   - **bug-9 class**: `.claude.json` `projects[<agentDir>].enabledMcpjsonServers`
+ *     doesn't include the integration's key — Claude silently ignores
+ *     the un-allowlisted server.
+ *
+ * Both are scaffold-side failures that the original `doctor-drive`
+ * probe added to catch (and which the m365 + notion releases
+ * inherited unguarded). The shared helper closes both gaps for the
+ * other two integrations.
+ */
+
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  checkIntegrationScaffoldWiring,
+  type ScaffoldWiringDeps,
+} from "./doctor-scaffold-wiring.js";
+
+const AGENTS_DIR = "/tmp/agents";
+
+function fakeFs(files: Record<string, string | "unreadable">): ScaffoldWiringDeps {
+  return {
+    existsSync: (p: string) => p in files,
+    readFileSync: (p: string) => {
+      const v = files[p];
+      if (v === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      if (v === "unreadable") throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+      return v;
+    },
+  };
+}
+
+describe("checkIntegrationScaffoldWiring — empty agents", () => {
+  it("returns no results when agents list is empty", () => {
+    const r = checkIntegrationScaffoldWiring({
+      label: "notion",
+      mcpKey: "notion",
+      agents: [],
+      agentsDir: AGENTS_DIR,
+      deps: fakeFs({}),
+    });
+    expect(r).toEqual([]);
+  });
+
+  it("warns once when agentsDir is undefined", () => {
+    const r = checkIntegrationScaffoldWiring({
+      label: "ms-365",
+      mcpKey: "ms-365",
+      agents: ["clerk"],
+      agentsDir: undefined,
+      deps: fakeFs({}),
+    });
+    expect(r.length).toBe(1);
+    expect(r[0].status).toBe("warn");
+    expect(r[0].detail).toMatch(/agents directory/);
+  });
+});
+
+describe("checkIntegrationScaffoldWiring — happy path", () => {
+  it("emits ok when .mcp.json has the entry with env AND .claude.json trusts it", () => {
+    const agentDir = resolve(AGENTS_DIR, "clerk");
+    const mcpPath = join(agentDir, ".mcp.json");
+    const claudeJsonPath = join(agentDir, ".claude", ".claude.json");
+    const fs = fakeFs({
+      [agentDir]: "",
+      [mcpPath]: JSON.stringify({
+        mcpServers: { notion: { command: "x", env: { HOME: "/tmp" } } },
+      }),
+      [claudeJsonPath]: JSON.stringify({
+        projects: { [agentDir]: { enabledMcpjsonServers: ["notion"] } },
+      }),
+    });
+
+    const r = checkIntegrationScaffoldWiring({
+      label: "notion",
+      mcpKey: "notion",
+      agents: ["clerk"],
+      agentsDir: AGENTS_DIR,
+      deps: fs,
+    });
+
+    expect(r.length).toBe(1);
+    expect(r[0].status).toBe("ok");
+    expect(r[0].name).toBe("notion: clerk scaffold");
+    expect(r[0].detail).toMatch(/wired in \.mcp\.json/);
+  });
+});
+
+describe("checkIntegrationScaffoldWiring — bug-8 (missing env block)", () => {
+  it("FAILS when entry exists but env is missing/empty", () => {
+    const agentDir = resolve(AGENTS_DIR, "carrie");
+    const mcpPath = join(agentDir, ".mcp.json");
+    const claudeJsonPath = join(agentDir, ".claude", ".claude.json");
+    const fs = fakeFs({
+      [agentDir]: "",
+      [mcpPath]: JSON.stringify({
+        mcpServers: { notion: { command: "x" } }, // no env!
+      }),
+      [claudeJsonPath]: JSON.stringify({
+        projects: { [agentDir]: { enabledMcpjsonServers: ["notion"] } },
+      }),
+    });
+
+    const r = checkIntegrationScaffoldWiring({
+      label: "notion",
+      mcpKey: "notion",
+      agents: ["carrie"],
+      agentsDir: AGENTS_DIR,
+      deps: fs,
+    });
+
+    expect(r[0].status).toBe("fail");
+    expect(r[0].detail).toMatch(/env block|bug-8/);
+    expect(r[0].fix).toMatch(/switchroom agent restart carrie/);
+  });
+});
+
+describe("checkIntegrationScaffoldWiring — bug-9 (trust list missing)", () => {
+  it("FAILS when .mcp.json is fine but .claude.json doesn't enable the server", () => {
+    const agentDir = resolve(AGENTS_DIR, "clerk");
+    const mcpPath = join(agentDir, ".mcp.json");
+    const claudeJsonPath = join(agentDir, ".claude", ".claude.json");
+    const fs = fakeFs({
+      [agentDir]: "",
+      [mcpPath]: JSON.stringify({
+        mcpServers: { "ms-365": { command: "x", env: { HOME: "/tmp" } } },
+      }),
+      [claudeJsonPath]: JSON.stringify({
+        projects: { [agentDir]: { enabledMcpjsonServers: [] } }, // ms-365 NOT enabled
+      }),
+    });
+
+    const r = checkIntegrationScaffoldWiring({
+      label: "ms-365",
+      mcpKey: "ms-365",
+      agents: ["clerk"],
+      agentsDir: AGENTS_DIR,
+      deps: fs,
+    });
+
+    expect(r[0].status).toBe("fail");
+    expect(r[0].detail).toMatch(/enabledMcpjsonServers|bug-9/);
+  });
+});
+
+describe("checkIntegrationScaffoldWiring — entry missing entirely", () => {
+  it("FAILS when .mcp.json has no entry for the integration's key", () => {
+    const agentDir = resolve(AGENTS_DIR, "clerk");
+    const mcpPath = join(agentDir, ".mcp.json");
+    const claudeJsonPath = join(agentDir, ".claude", ".claude.json");
+    const fs = fakeFs({
+      [agentDir]: "",
+      [mcpPath]: JSON.stringify({ mcpServers: { gdrive: { env: { x: "y" } } } }),
+      [claudeJsonPath]: JSON.stringify({
+        projects: { [agentDir]: { enabledMcpjsonServers: ["gdrive"] } },
+      }),
+    });
+
+    const r = checkIntegrationScaffoldWiring({
+      label: "notion",
+      mcpKey: "notion",
+      agents: ["clerk"],
+      agentsDir: AGENTS_DIR,
+      deps: fs,
+    });
+
+    expect(r[0].status).toBe("fail");
+    expect(r[0].detail).toMatch(/no notion server/);
+  });
+});
+
+describe("checkIntegrationScaffoldWiring — unreadable (EACCES, 0600 by agent UID)", () => {
+  it("SKIPS rather than fails — host operator can't read agent-owned files", () => {
+    const agentDir = resolve(AGENTS_DIR, "clerk");
+    const mcpPath = join(agentDir, ".mcp.json");
+    const claudeJsonPath = join(agentDir, ".claude", ".claude.json");
+    const fs = fakeFs({
+      [agentDir]: "",
+      [mcpPath]: "unreadable",
+      [claudeJsonPath]: "unreadable",
+    });
+
+    const r = checkIntegrationScaffoldWiring({
+      label: "ms-365",
+      mcpKey: "ms-365",
+      agents: ["clerk"],
+      agentsDir: AGENTS_DIR,
+      deps: fs,
+    });
+
+    expect(r[0].status).toBe("skip");
+    expect(r[0].detail).toMatch(/agent-UID-owned/);
+  });
+});
+
+describe("checkIntegrationScaffoldWiring — corrupt JSON", () => {
+  it("FAILS when .mcp.json is unparseable", () => {
+    const agentDir = resolve(AGENTS_DIR, "clerk");
+    const mcpPath = join(agentDir, ".mcp.json");
+    const claudeJsonPath = join(agentDir, ".claude", ".claude.json");
+    const fs = fakeFs({
+      [agentDir]: "",
+      [mcpPath]: "{ not valid json",
+      [claudeJsonPath]: JSON.stringify({
+        projects: { [agentDir]: { enabledMcpjsonServers: ["notion"] } },
+      }),
+    });
+
+    const r = checkIntegrationScaffoldWiring({
+      label: "notion",
+      mcpKey: "notion",
+      agents: ["clerk"],
+      agentsDir: AGENTS_DIR,
+      deps: fs,
+    });
+
+    expect(r[0].status).toBe("fail");
+    expect(r[0].detail).toMatch(/not valid JSON/);
+  });
+});
+
+describe("checkIntegrationScaffoldWiring — unscaffolded agent", () => {
+  it("WARNS when agent dir doesn't exist yet", () => {
+    const r = checkIntegrationScaffoldWiring({
+      label: "notion",
+      mcpKey: "notion",
+      agents: ["new-agent"],
+      agentsDir: AGENTS_DIR,
+      deps: fakeFs({}),
+    });
+    expect(r[0].status).toBe("warn");
+    expect(r[0].detail).toMatch(/not scaffolded yet/);
+  });
+});

--- a/src/cli/doctor-scaffold-wiring.ts
+++ b/src/cli/doctor-scaffold-wiring.ts
@@ -1,0 +1,184 @@
+/**
+ * Shared scaffold-wiring doctor probe — verifies that a per-agent
+ * MCP integration's wiring is intact on disk, not just declared in
+ * config.
+ *
+ * Originally lifted from `doctor-drive.ts:checkScaffoldWiring` after
+ * the v0.12.x bug-8 (env-block missing) and bug-9 (scaffold-ordering
+ * vs `enabledMcpjsonServers` trust) incidents. m365 + notion have
+ * exactly the same drift surface — same `.mcp.json` + `.claude.json`
+ * shape, same scaffold pipeline — so a single shared helper captures
+ * the probe with the integration's MCP key as the only varying input.
+ *
+ * Inputs:
+ *   - `label` — operator-facing tag in probe names ("drive", "ms-365",
+ *     "notion").
+ *   - `mcpKey` — the mcpServers key the resolver emits (one of
+ *     `INTEGRATION_MCP_RESOLVERS[*].emitKey`).
+ *   - `agents` — the set of agents the integration's
+ *     `shouldEmit*` predicate would return true for. Computed by
+ *     each caller via its own `compute*Agents` helper.
+ *   - `agentsDir` — resolved agents directory; when undefined a
+ *     single warn-status result is emitted.
+ *   - `deps` — filesystem-injection seam for unit tests.
+ *
+ * Failure-mode classification mirrors the original drive probe:
+ *   - `absent`     → no scaffold yet, warn ("run `switchroom apply`")
+ *   - `unreadable` → 0600 EACCES from the host operator, skip
+ *     (NOT a real failure — agent UID reads it fine)
+ *   - `corrupt`    → file present but invalid JSON, fail
+ *   - `ok`         → JSON parsed; check the MCP key + env block, and
+ *     the .claude.json trust list
+ */
+
+import { join, resolve } from "node:path";
+
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface ScaffoldWiringCheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+export interface ScaffoldWiringDeps {
+  existsSync: (path: string) => boolean;
+  readFileSync: (path: string) => string;
+}
+
+type ReadJsonResult =
+  | { kind: "ok"; data: Record<string, unknown> }
+  | { kind: "absent" }
+  | { kind: "unreadable" }
+  | { kind: "corrupt" };
+
+function readJson(d: ScaffoldWiringDeps, path: string): ReadJsonResult {
+  if (!d.existsSync(path)) return { kind: "absent" };
+  let raw: string;
+  try {
+    raw = d.readFileSync(path);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "EACCES" || code === "EPERM") return { kind: "unreadable" };
+    return { kind: "absent" };
+  }
+  try {
+    return { kind: "ok", data: JSON.parse(raw) as Record<string, unknown> };
+  } catch {
+    return { kind: "corrupt" };
+  }
+}
+
+export function checkIntegrationScaffoldWiring(args: {
+  label: string;
+  mcpKey: string;
+  agents: string[];
+  agentsDir: string | undefined;
+  deps: ScaffoldWiringDeps;
+}): ScaffoldWiringCheckResult[] {
+  const { label, mcpKey, agents, agentsDir, deps } = args;
+  const results: ScaffoldWiringCheckResult[] = [];
+
+  if (agents.length === 0) return results;
+
+  if (agentsDir === undefined) {
+    return [
+      {
+        name: `${label}: scaffold wiring`,
+        status: "warn",
+        detail:
+          "could not resolve the agents directory (no switchroom block) — skipped scaffold wiring check",
+      },
+    ];
+  }
+
+  for (const name of agents) {
+    const agentDir = resolve(agentsDir, name);
+    if (!deps.existsSync(agentDir)) {
+      results.push({
+        name: `${label}: ${name} scaffold`,
+        status: "warn",
+        detail: `${agentDir} not scaffolded yet — run \`switchroom apply\``,
+      });
+      continue;
+    }
+
+    const mcpPath = join(agentDir, ".mcp.json");
+    const claudeJsonPath = join(agentDir, ".claude", ".claude.json");
+
+    const mcpRead = readJson(deps, mcpPath);
+    const trustRead = readJson(deps, claudeJsonPath);
+
+    if (mcpRead.kind === "unreadable" || trustRead.kind === "unreadable") {
+      results.push({
+        name: `${label}: ${name} scaffold`,
+        status: "skip",
+        detail:
+          "scaffold files are agent-UID-owned (mode 0600) — unverifiable from the host operator; the agent process reads them fine. Verify in-container if needed: `docker exec switchroom-" +
+          name +
+          " sh -lc 'python3 -m json.tool /state/agent/.mcp.json >/dev/null && echo ok'`",
+      });
+      continue;
+    }
+
+    // .mcp.json must carry the integration's MCP server WITH a non-
+    // empty env block. (Claude Code spawns MCP servers with a
+    // sanitized env, so without an env block the launcher can't
+    // reach switchroom.yaml / the broker — bug-8 class.)
+    let mcpOk = false;
+    let mcpDetail = `no .mcp.json`;
+    if (mcpRead.kind === "ok") {
+      const mcpServers = (mcpRead.data?.mcpServers as
+        | Record<string, { env?: Record<string, unknown> }>
+        | undefined) ?? {};
+      const entry = mcpServers[mcpKey];
+      if (!entry) {
+        mcpDetail = `.mcp.json has no ${mcpKey} server`;
+      } else if (!entry.env || Object.keys(entry.env).length === 0) {
+        mcpDetail =
+          `${mcpKey} entry has no env block — Claude spawns MCP with a sanitized env; the launcher can't reach switchroom.yaml/the broker (bug-8 class)`;
+      } else {
+        mcpOk = true;
+      }
+    } else if (mcpRead.kind === "corrupt") {
+      mcpDetail = ".mcp.json exists but is not valid JSON (corrupt)";
+    }
+
+    // .claude.json must TRUST the integration's MCP key under the
+    // agent's project key (bug-9 / scaffold-ordering class).
+    let trustOk = false;
+    let trustDetail = "no .claude/.claude.json";
+    if (trustRead.kind === "ok") {
+      const projects = (trustRead.data?.projects as
+        | Record<string, { enabledMcpjsonServers?: unknown }>
+        | undefined) ?? {};
+      const proj = projects[resolve(agentDir)];
+      const enabled: unknown = proj?.enabledMcpjsonServers;
+      if (Array.isArray(enabled) && enabled.includes(mcpKey)) {
+        trustOk = true;
+      } else {
+        trustDetail =
+          `${mcpKey} not in projects[].enabledMcpjsonServers — Claude silently ignores the un-allowlisted server (bug-9 / scaffold-ordering class)`;
+      }
+    } else if (trustRead.kind === "corrupt") {
+      trustDetail = ".claude.json exists but is not valid JSON (corrupt)";
+    }
+
+    if (mcpOk && trustOk) {
+      results.push({
+        name: `${label}: ${name} scaffold`,
+        status: "ok",
+        detail: `${mcpKey} wired in .mcp.json (with env) and trusted in .claude.json`,
+      });
+    } else {
+      results.push({
+        name: `${label}: ${name} scaffold`,
+        status: "fail",
+        detail: !mcpOk ? mcpDetail : trustDetail,
+        fix: "`switchroom agent restart " + name + "` (reconcile regenerates .mcp.json + re-trusts); if it persists, this is a scaffold bug — report it",
+      });
+    }
+  }
+  return results;
+}

--- a/tests/scaffold.integration-registry.test.ts
+++ b/tests/scaffold.integration-registry.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression-gate tests for the integration MCP registry in
+ * `src/agents/scaffold.ts`.
+ *
+ * Three load-bearing invariants:
+ *
+ *   1. **Emit/retract symmetry**: when a resolver returns null, the
+ *      site that retracts must delete the SAME key the resolver
+ *      would have emitted. Today every integration's `emitKey` ===
+ *      `retractionKey`, but they're declared as separate fields so a
+ *      future drift can't slip through. This test pins that they
+ *      stay synchronized.
+ *
+ *   2. **Iteration order**: gdrive → ms-365 → notion. Pinned so a
+ *      reorder in the registry can't silently change which
+ *      integration wins on a hypothetical key collision (and, more
+ *      practically, so the user-spread at Site 2 always lands after
+ *      all framework integrations in deterministic order).
+ *
+ *   3. **All three integrations registered**: a future integration
+ *      added by appending to the registry shouldn't accidentally
+ *      drop one of the existing three. Defensive — but cheap.
+ *
+ * The end-to-end emit/retract behaviour at each of the four scaffold
+ * call sites (settings.json scaffold, .mcp.json scaffold,
+ * settings.json reconcile, .mcp.json reconcile) is covered by the
+ * existing scaffold tests; this file is the registry-shape
+ * regression gate.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { INTEGRATION_MCP_RESOLVERS } from "../src/agents/scaffold.js";
+
+describe("INTEGRATION_MCP_RESOLVERS — registry shape", () => {
+  it("contains exactly the three shipped integrations in order", () => {
+    const labels = INTEGRATION_MCP_RESOLVERS.map((i) => i.label);
+    expect(labels).toEqual(["Google Workspace", "Microsoft 365", "Notion"]);
+  });
+
+  it("each entry has matching emitKey and retractionKey (today's invariant)", () => {
+    // Today every integration's emit key equals its retraction key
+    // (gdrive/gdrive, ms-365/ms-365, notion/notion). Keep them as
+    // separate fields so a future divergence is explicit, but pin
+    // the current state — a silent drift here is exactly the bug
+    // class the separate fields exist to catch.
+    for (const integration of INTEGRATION_MCP_RESOLVERS) {
+      expect(integration.emitKey).toBe(integration.retractionKey);
+    }
+  });
+
+  it("emitKeys are unique (no two integrations collide)", () => {
+    const keys = INTEGRATION_MCP_RESOLVERS.map((i) => i.emitKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("retractionKeys are unique (no two integrations would retract each other)", () => {
+    const keys = INTEGRATION_MCP_RESOLVERS.map((i) => i.retractionKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("expected keys are present", () => {
+    const keys = INTEGRATION_MCP_RESOLVERS.map((i) => i.emitKey);
+    expect(keys).toContain("gdrive");
+    expect(keys).toContain("ms-365");
+    expect(keys).toContain("notion");
+  });
+
+  it("each resolver is callable and accepts the (name, agentConfig, switchroomConfig) shape", () => {
+    // Call each with a minimal disable config — they should all
+    // return null without throwing. Smoke-test that the registry's
+    // type contract isn't broken.
+    for (const integration of INTEGRATION_MCP_RESOLVERS) {
+      const result = integration.resolve(
+        "test-agent",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        undefined,
+      );
+      expect(result).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
Consensus follow-up to the v0.13.55 Notion integration series. Three
Opus reviewers (code / principles / red-team) audited a 5-candidate
simplification proposal; this PR ships only what survived consensus
plus a real gap one of them surfaced that wasn't on the original list.

## What's shipped

### 1. \`INTEGRATION_MCP_RESOLVERS\` registry (Tier 1A with R3's guardrails)

Today \`scaffold.ts\` has 4 sites × 3 integrations of duplicated
\`resolveX(); if (entry) ... else delete mcpServers["<literal>"]\`
blocks. The registry collapses them, and crucially separates
\`emitKey\` from \`retractionKey\` — today they're equal but the
separate fields prevent the silent-drift bug class a future
integration with a divergent opt-out key would introduce.

Each of the four call sites preserves its distinct conflict policy
(user-wins / framework-wins / emit-or-retract / emit-only) — the
registry is iteration only, not policy.

\`tests/scaffold.integration-registry.test.ts\` pins iteration order,
emitKey/retractionKey symmetry, uniqueness, and the resolver
contract.

### 2. \`checkScaffoldWiring\` for ms-365 + notion (R1's catch)

Drive has had \`checkScaffoldWiring\` since the v0.12.x bug-8 (env-block
missing) + bug-9 (.claude.json trust drift) incidents. m365 + notion
silently inherit the same drift surfaces with no probe — agents would
get the integration listed in YAML but the scaffold could write a
\`.mcp.json\` entry with no env block (so the launcher can't reach
switchroom.yaml / the broker), or fail to add the key to
\`projects[].enabledMcpjsonServers\` (so Claude silently ignores the
un-allowlisted server). Both bug classes are now structurally caught
at \`switchroom doctor\` time for all three integrations.

\`src/cli/doctor-scaffold-wiring.ts\` is a parameterized helper that
m365 + notion now call. Drive's existing inline function is
unchanged (has shape-pinning tests; refactoring it is scope creep).

## What's NOT shipped (consensus rejected)

- **B — Unified \`MCP_PINS\` registry**: 3-of-3 against. The
  sha-vs-semver split forces a discriminator wider than the three
  labelled constants, and loses load-bearing bump-discipline
  docstrings (operator docs anchored to each constant).
- **C as originally framed — "backfill notion vault-acl-aligned to
  gdrive + m365"**: corrected by reviewers. gdrive already has it
  via \`runDriveBrokerReachabilityChecks\`; m365 (public-client) has
  no comparable gap surface.
- **D — Shared PreToolUse hook base**: m365's approval lives at
  \`telegram-plugin/gateway/ms365-write-approval.ts\` (gateway-side),
  not as a \`*-write-pretool.ts\` hook. Only drive + notion have
  hooks, and they have structurally different shapes. Wait for a
  third symmetric hook (#1914 will add notion's approval-card hook
  on top of the allowlist gate — may re-evaluate then).
- **E — Broader shared doctor primitives**: heartbeat semantics
  genuinely differ (m365 parses refresh-loop timestamps; notion
  reads bare mtime). Only the narrow scaffold-wiring slice (above)
  survived consensus.

## Test plan

- [x] 7812/7812 src/ + tests/ vitest passing
- [x] 244/244 scaffold tests passing (registry refactor doesn't
      break the existing scaffold pinning tests)
- [x] 43/43 directly-touched tests passing (doctor-scaffold-wiring
      x9, doctor-microsoft x20, doctor-notion x14)
- [x] tsc clean
- [x] All 5 CI lint gates clean

## Risk

Low. The registry refactor preserves each site's conflict policy
verbatim; existing scaffold tests pin the user-wins / framework-wins
precedence and still pass. The new doctor probes are additive (new
result rows under existing sections; SKIP cleanly when the
integration isn't configured). Drive's existing scaffold-wiring
probe is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)