### PR TITLE
feat(agents): webkite MCP fleet-default + cloakbrowser + Cloudflare fallback

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -120,6 +120,33 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip3 install --break-system-packages "playwright==${PLAYWRIGHT_VERSION}" \
  && python3 -m playwright install chromium
 
+# Cloakbrowser — the local stealth Chromium driver used by webkite's
+# `webkite mcp` MCP server to fetch bot-gated sites. The webkite binary
+# itself is mounted from the operator's host (private beta — not
+# baked or committed); cloakbrowser is public OSS so we bake the
+# Python tool here. The 700MB chromium binary it spawns is shared
+# across the fleet via a host bind mount of `~/.cloakbrowser/` (see
+# compose.ts), NOT baked into the image.
+#
+# Why bake instead of per-agent install: a pipx venv has shebang lines
+# pointing at the venv's own python interpreter. If we mounted the
+# operator's pipx venv from the host, the shebang's interpreter path
+# might not exist inside the container (or, worse, point at a host
+# python with mismatched glibc). Baking gives every agent an identical,
+# image-deterministic install rooted at a stable absolute path.
+#
+# PIPX_HOME=/opt/cloakbrowser keeps the venv at a fixed image path so
+# the per-agent HOME at runtime can't shadow it. PIPX_BIN_DIR puts the
+# `cloakbrowser` shim on the system PATH. Same rare-changed bake zone
+# as playwright above so a typical src-only PR doesn't re-pay the
+# ~30s pipx install.
+ENV CLOAKBROWSER_PIPX_HOME=/opt/cloakbrowser
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pipx \
+ && rm -rf /var/lib/apt/lists/* \
+ && PIPX_HOME=${CLOAKBROWSER_PIPX_HOME} PIPX_BIN_DIR=/usr/local/bin \
+    pipx install cloakbrowser
+
 # Phase 2 cron-fold-in: the in-agent scheduler's node-cron runtime dep.
 # Bundle is built by scripts/build.mjs with --external node-cron, so the
 # image must provide it. node-cron is pure JS (no native compilation),

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -598,6 +598,29 @@ if [ -d "$SR_FLEET_DIR" ]; then
   SR_FLEET_ARG="--add-dir $SR_FLEET_DIR"
 fi
 
+# Webkite credential pre-auth — fetch Cloudflare + Firecrawl creds from
+# the vault-broker at boot and export into the agent process env so
+# `webkite mcp` (spawned by claude with sanitized env per .mcp.json)
+# inherits them via the agent's env on `exec claude`. Best-effort: a
+# missing key falls webkite back to cloakbrowser-only (no cloud render),
+# which still works for most sites. The broker enforces the per-key
+# ACL — if the operator hasn't `--allow`ed this agent on the key, the
+# get returns empty and webkite stays cloakbrowser-only.
+if command -v switchroom >/dev/null 2>&1; then
+  for sr_wk_pair in \
+    "CLOUDFLARE_ACCOUNT_ID:webkite/cloudflare-account-id" \
+    "CLOUDFLARE_API_TOKEN:webkite/cloudflare-api-token" \
+    "FIRECRAWL_API_KEY:webkite/firecrawl-api-key"; do
+    sr_wk_env="${sr_wk_pair%%:*}"
+    sr_wk_key="${sr_wk_pair##*:}"
+    sr_wk_val="$(switchroom vault get "$sr_wk_key" 2>/dev/null || true)"
+    if [ -n "$sr_wk_val" ]; then
+      export "$sr_wk_env=$sr_wk_val"
+    fi
+  done
+  unset sr_wk_pair sr_wk_env sr_wk_key sr_wk_val
+fi
+
 {{#if useSwitchroomPlugin}}
 if [ -n "$APPEND_PROMPT" ]; then
   exec claude $CONTINUE_FLAG --dangerously-load-development-channels server:switchroom-telegram --plugin-dir "{{securityPluginDir}}"{{#if hindsightEnabled}} --plugin-dir "{{agentDir}}/.claude/plugins/hindsight-memory"{{/if}} $SR_FLEET_ARG{{#if modelQ}} --model {{{modelQ}}}{{/if}}{{#if thinkingEffort}} --effort {{thinkingEffort}}{{/if}}{{#if permissionMode}} --permission-mode {{permissionMode}}{{/if}}{{#if fallbackModelQ}} --fallback-model {{{fallbackModelQ}}}{{/if}} --append-system-prompt "$APPEND_PROMPT"{{#if dangerousMode}} --dangerously-skip-permissions{{/if}}{{#if extraCliArgs}}{{{extraCliArgs}}}{{/if}}

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1808,6 +1808,39 @@ function emitAgentService(
       `      - ${homePrefix}/.switchroom-config/agents/${a.name}/personal-skills:${homePrefix}/.switchroom-config/agents/${a.name}/personal-skills:rw`,
     );
   }
+  // webkite binary + cloakbrowser shared Chromium (#TBD). The webkite
+  // binary is a private-beta release that lives on the operator's host
+  // only (`~/.switchroom/bin/webkite`), never committed to this repo or
+  // baked into the agent image. Mount it on the in-container PATH so
+  // every agent can spawn `webkite mcp` (the stdio MCP server) without
+  // any per-agent install. existsSync-guarded because dev installs
+  // without webkite staged should not hard-fail compose `up`.
+  //
+  // Cloakbrowser's stealth Chromium (~700MB extracted) lives at the
+  // operator's `~/.cloakbrowser/` (cloakbrowser hardcodes that path).
+  // Mounted RO at the per-agent HOME so cloakbrowser's runtime lookup
+  // (`$HOME/.cloakbrowser/chromium-*/chrome`) resolves to the shared
+  // operator install — one ~700MB copy on disk instead of N. The
+  // cloakbrowser pipx tool itself is baked into the agent image
+  // (Dockerfile.agent) so the venv shebang lines resolve in-container.
+  if (existsSync(`${hostHomeForChecks}/.switchroom/bin/webkite`)) {
+    lines.push(
+      `      - ${homePrefix}/.switchroom/bin/webkite:/usr/local/bin/webkite:ro`,
+    );
+  }
+  if (existsSync(`${hostHomeForChecks}/.cloakbrowser`)) {
+    lines.push(
+      `      - ${homePrefix}/.cloakbrowser:/state/agent/home/.cloakbrowser:ro`,
+    );
+  }
+  // Operator-authored shared webkite config (e.g. defaults.format,
+  // proxy rotation file). Optional — agents work fine without it,
+  // using webkite's built-in defaults.
+  if (existsSync(`${hostHomeForChecks}/.switchroom/webkite/config.toml`)) {
+    lines.push(
+      `      - ${homePrefix}/.switchroom/webkite/config.toml:/state/agent/home/.config/webkite/config.toml:ro`,
+    );
+  }
   // Bundled-skills pool: mount at the same absolute host path so the
   // symlinks created by reconcileAgentDefaultSkills (which target the
   // source-repo or npm-package skills/ dir — e.g.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -168,6 +168,54 @@ When the user asks "what do you know about X / me", "what do you remember about 
 Don't wait for a slash command. Don't ask permission. Memory work is table stakes, like a colleague who takes notes and remembers.`;
 
 /**
+ * The web-fetch contract. One of the fleet invariant blocks. The
+ * native WebFetch / WebSearch tools are disabled at the cascade
+ * level (`scaffold.ts:WEBKITE_FLEET_DENY_TOOLS`); webkite is wired
+ * in via `.mcp.json` and runs as a stdio MCP server with 12 tools.
+ *
+ * Cloudflare / Firecrawl credentials are pre-fetched from the vault
+ * by start.sh.hbs at boot — webkite picks them up via env and uses
+ * cloud render as a fallback when local cloakbrowser can't fetch a
+ * bot-gated site. No agent setup required.
+ */
+const WEB_FETCH_GUIDANCE = `## Fetching from the web
+
+The native \`WebFetch\` and \`WebSearch\` tools are disabled in this
+fleet. Use the \`webkite_*\` MCP tools instead — they're already
+wired up and authenticated.
+
+The 12 tools webkite exposes cover what you actually need:
+
+- \`webkite_read\` — fetch a URL and get clean article text or
+  markdown. The everyday "read this page" tool. Pass several URLs
+  to read them in one call.
+- \`webkite_search\` — web search; returns URLs + snippets. Use
+  before \`webkite_read\` when you don't already have the URL.
+- \`webkite_extract\` — pull specific fields from one page via a
+  JSON Schema you supply. Use when you want structured data, not
+  prose.
+- \`webkite_crawl\` — walk a site from a seed URL. Higher-cost than
+  \`read\` or \`map\` — reserve for "harvest everything under this
+  section."
+- \`webkite_map\` — list a site's URLs from its sitemap, no page
+  content. Cheap. Use when you only need URLs.
+- \`webkite_clip\` — save a page snapshot (Obsidian, file, or
+  screenshot).
+- session / cookie / diagnostics helpers.
+
+**Why this exists:** the fleet ships with a stealth Chromium
+(cloakbrowser) baked in for bot-gated sites the native fetcher can't
+touch, plus Cloudflare/Firecrawl fallback when local render fails.
+\`webkite_*\` Just Works — don't try to shell out to \`curl\` or
+\`wget\` as a fallback; if webkite can't fetch a URL, neither can
+they.
+
+If you genuinely need WebFetch back for one agent (e.g. a workflow
+that depends on its specific output shape), set \`mcp_servers.webkite:
+false\` in that agent's switchroom.yaml block — webkite goes away
+and the native tools come back together.`;
+
+/**
  * Canonical rendering of the fleet invariants file written to
  * `~/.switchroom/fleet/switchroom-invariants.md`. Apply checksums
  * this against the on-disk file and restores on drift. Operators
@@ -199,6 +247,8 @@ export function renderFleetInvariants(): string {
     TELEGRAM_GUIDANCE,
     "",
     MEMORY_GUIDANCE,
+    "",
+    WEB_FETCH_GUIDANCE,
     "",
   ].join("\n");
 }
@@ -663,6 +713,21 @@ const DEFAULT_READ_ONLY_PREAPPROVED_TOOLS = [
   // otherwise stall on an approval).
   "Skill",
 ];
+
+/**
+ * Fleet-baseline deny list seeded into every agent's settings.json
+ * `permissions.deny` unless the agent has opted out of webkite. The
+ * model still has full web-fetch capability — via the webkite_*
+ * MCP tools — but the native WebFetch / WebSearch tools are off so
+ * the model reaches for webkite by default. Webkite is operator-
+ * mounted (private beta binary) and pre-credentialed via the vault-
+ * broker; the model doesn't need to know about any of that.
+ *
+ * Opt-out: per-agent `mcp_servers.webkite: false` skips the deny too
+ * — the agent gets native WebFetch back. (Documented behavior — if
+ * you turn off webkite, you keep WebFetch.)
+ */
+const WEBKITE_FLEET_DENY_TOOLS = ["WebFetch", "WebSearch"];
 
 /**
  * Switchroom-shipped default model + thinking effort for main agents.
@@ -1772,7 +1837,12 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     user: (agentConfig as unknown as { user?: unknown }).user,
     agentConfig,
     tools,
-    toolsDeny: tools.deny ?? [],
+    toolsDeny: dedupe([
+      ...(tools.deny ?? []),
+      ...(agentConfig.mcp_servers?.["webkite"] === false
+        ? []
+        : WEBKITE_FLEET_DENY_TOOLS),
+    ]),
     permissionAllow,
     defaultModeAcceptEdits: hasAllWildcard,
     memory: agentConfig.memory,
@@ -2198,6 +2268,50 @@ export interface IntegrationMcpResolver {
   ) => { key: string; value: McpServerConfig } | null;
 }
 
+/**
+ * Resolve the per-agent `webkite` MCP entry.
+ *
+ * Unlike gdrive/ms-365/notion, webkite has no top-level switchroom.yaml
+ * config block to gate on — it's a fleet-default capability that swaps
+ * in for the native WebFetch/WebSearch tools (disabled at the cascade
+ * level — see defaults `disallowed_tools`). The only gate is the
+ * per-agent opt-out (`mcp_servers.webkite: false`).
+ *
+ * Distribution model (see docker/Dockerfile.agent + compose.ts):
+ *   - `webkite` binary: operator-mounted from `~/.switchroom/bin/webkite`
+ *     onto the in-container PATH at `/usr/local/bin/webkite`. The
+ *     binary itself is a private-beta release that never lives in this
+ *     repo or the agent image.
+ *   - cloakbrowser Python tool: baked into the agent image at
+ *     `/opt/cloakbrowser` (public OSS, no constraint violation).
+ *   - cloakbrowser Chromium: operator-mounted from `~/.cloakbrowser/`
+ *     so the whole fleet shares one ~700MB install.
+ *
+ * Credential injection: CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN /
+ * FIRECRAWL_API_KEY are fetched from the vault-broker by start.sh.hbs
+ * at agent boot and exported into the agent process env. Claude
+ * inherits them on `exec claude`, so the `webkite mcp` child process
+ * sees them via env inheritance. No per-server env block needed here —
+ * unlike gdrive/m365 (which spawn through a launcher that talks to the
+ * auth-broker), webkite's env-from-vault is one-shot at boot.
+ *
+ * Returns null when the entry must not be emitted.
+ */
+export function resolveWebkiteMcpEntry(
+  _agentName: string,
+  agentConfig: AgentConfig,
+  _switchroomConfig: SwitchroomConfig | undefined,
+): { key: string; value: McpServerConfig } | null {
+  if ((agentConfig.mcp_servers ?? {})["webkite"] === false) return null;
+  return {
+    key: "webkite",
+    value: {
+      command: "webkite",
+      args: ["mcp"],
+    },
+  };
+}
+
 export const INTEGRATION_MCP_RESOLVERS: readonly IntegrationMcpResolver[] = [
   {
     label: "Google Workspace",
@@ -2216,6 +2330,12 @@ export const INTEGRATION_MCP_RESOLVERS: readonly IntegrationMcpResolver[] = [
     emitKey: "notion",
     retractionKey: "notion",
     resolve: resolveNotionMcpEntry,
+  },
+  {
+    label: "Webkite",
+    emitKey: "webkite",
+    retractionKey: "webkite",
+    resolve: resolveWebkiteMcpEntry,
   },
 ];
 
@@ -4071,7 +4191,12 @@ export function reconcileAgent(
     ...AGENT_CONFIG_MCP_TOOLS,
     ...HOSTD_MCP_TOOLS,
   ]);
-  const desiredDeny = tools.deny ?? [];
+  const desiredDeny = dedupe([
+    ...(tools.deny ?? []),
+    ...(agentConfig.mcp_servers?.["webkite"] === false
+      ? []
+      : WEBKITE_FLEET_DENY_TOOLS),
+  ]);
 
   // Resolve topic ID for the start.sh template and session greeting
   let topicId = agentConfig.topic_id;

--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -310,6 +310,59 @@ describe("ACL: socket-path-as-identity (Phase 2a)", () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────
+// Webkite — fleet-default credential ACL (framework-emits-entry-AND-ACL)
+// ────────────────────────────────────────────────────────────────────────
+
+describe("ACL: webkite credential keys (fleet-default)", () => {
+  const WEBKITE_KEYS = [
+    "webkite/cloudflare-account-id",
+    "webkite/cloudflare-api-token",
+    "webkite/firecrawl-api-key",
+  ];
+
+  it("allows every webkite key by default — agent did not opt out", () => {
+    const config = makeConfig({
+      alice: [{ cron: "0 8 * * *", prompt: "hi", secrets: ["unrelated"] }],
+    });
+    for (const key of WEBKITE_KEYS) {
+      const r = checkAclByAgent(config, "alice", key);
+      expect(r.allow, `expected ${key} allowed for alice`).toBe(true);
+    }
+  });
+
+  it("denies webkite keys when the agent opted out via mcp_servers.webkite: false", () => {
+    const config = {
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: { path: "~/.switchroom/vault.enc" },
+      agents: {
+        alice: {
+          topic_name: "alice",
+          schedule: [],
+          mcp_servers: { webkite: false },
+        },
+      },
+    } as unknown as Parameters<typeof checkAclByAgent>[0];
+    for (const key of WEBKITE_KEYS) {
+      const r = checkAclByAgent(config, "alice", key);
+      expect(r.allow, `expected ${key} denied for opted-out alice`).toBe(false);
+    }
+  });
+
+  it("does not allow arbitrary webkite/* keys — only the canonical 3", () => {
+    const config = makeConfig({
+      alice: [{ cron: "0 8 * * *", prompt: "hi", secrets: [] }],
+    });
+    // A speculatively-shaped key that LOOKS like a webkite cred but
+    // isn't on the canonical allowlist must still be denied (so a
+    // future `webkite/private-thing` operator-put isn't silently
+    // exposed to every agent without a deliberate ACL).
+    const r = checkAclByAgent(config, "alice", "webkite/not-a-real-key");
+    expect(r.allow).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
 // RFC G Phase 2 — google: slot ACL via google_accounts[].enabled_for[]
 // ────────────────────────────────────────────────────────────────────────
 

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -45,8 +45,9 @@ import { isGoogleClientCredentialKeyForAgent } from "../../config/google-workspa
  * Canonical vault keys webkite reads when running as an in-agent MCP.
  * Mirrors `WEBKITE_VAULT_KEYS` in profiles/_base/start.sh.hbs (the
  * shell loop that fetches them at agent boot and exports as env
- * vars). Kept in sync by the test pin at
- * `tests/scaffold.webkite-mcp-resolver.test.ts`.
+ * vars). Kept in sync by the test pins at `src/vault/broker/acl.test.ts`
+ * (canonical-3 allow + opt-out deny + non-canonical deny cases) and
+ * `tests/scaffold.integration-registry.test.ts` (resolver shape).
  */
 const WEBKITE_VAULT_KEYS = new Set<string>([
   "webkite/cloudflare-account-id",

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -41,6 +41,34 @@ import type { PeerInfo } from "./peercred.js";
 import type { VaultEntryScope } from "../vault.js";
 import { isGoogleClientCredentialKeyForAgent } from "../../config/google-workspace-acl.js";
 
+/**
+ * Canonical vault keys webkite reads when running as an in-agent MCP.
+ * Mirrors `WEBKITE_VAULT_KEYS` in profiles/_base/start.sh.hbs (the
+ * shell loop that fetches them at agent boot and exports as env
+ * vars). Kept in sync by the test pin at
+ * `tests/scaffold.webkite-mcp-resolver.test.ts`.
+ */
+const WEBKITE_VAULT_KEYS = new Set<string>([
+  "webkite/cloudflare-account-id",
+  "webkite/cloudflare-api-token",
+  "webkite/firecrawl-api-key",
+]);
+
+/**
+ * Webkite is fleet-default — every agent reads these keys unless the
+ * agent explicitly opted out via `mcp_servers.webkite: false`. Same
+ * "framework-emits-entry-AND-ACL" shape as the gdrive client-secret
+ * special case (see acl.ts: isGoogleClientCredentialKeyForAgent).
+ */
+function isWebkiteCredentialKeyForAgent(
+  agentConfig: { mcp_servers?: Record<string, unknown> } | undefined,
+  key: string,
+): boolean {
+  if (!WEBKITE_VAULT_KEYS.has(key)) return false;
+  if ((agentConfig?.mcp_servers ?? {})["webkite"] === false) return false;
+  return true;
+}
+
 export interface AclAllow {
   allow: true;
 }
@@ -289,6 +317,26 @@ export function checkAclByAgent(
   // whether to emit the entry at all, so broker and scaffold can never
   // disagree. See config/google-workspace-acl.ts.
   if (isGoogleClientCredentialKeyForAgent(config, agentName, key)) {
+    return { allow: true };
+  }
+
+  // Webkite credentials — `webkite/cloudflare-account-id`,
+  // `webkite/cloudflare-api-token`, `webkite/firecrawl-api-key`.
+  //
+  // Webkite is a fleet-default MCP scaffolded by
+  // `resolveWebkiteMcpEntry` (src/agents/scaffold.ts) — every agent
+  // gets it unless it opts out via `mcp_servers.webkite: false`. Same
+  // shape as the gdrive client-secret special-case above: the
+  // framework EMITS the entry, so the framework must EMIT the broker
+  // ACL too (operator yaml never sees the webkite entry, so the
+  // `effectiveMcp` cascade path below can't find it).
+  //
+  // Gated on per-agent opt-out so an explicitly-disabled webkite
+  // agent can't read these keys. The keys themselves are operator-
+  // populated by `switchroom vault set webkite/*` — when absent, the
+  // broker returns UNKNOWN_KEY and webkite gracefully falls back to
+  // cloakbrowser-only (which is fine for non-bot-gated sites).
+  if (isWebkiteCredentialKeyForAgent(agentConfig, key)) {
     return { allow: true };
   }
 

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -780,6 +780,62 @@ describe("generateCompose", () => {
     }
   });
 
+  it("emits webkite binary + cloakbrowser + config mounts when present", async () => {
+    // Webkite binary is private-beta + operator-staged; cloakbrowser
+    // chromium is shared across the fleet via a host bind mount; the
+    // optional config.toml is operator-tunable defaults. All three are
+    // existsSync-guarded — docker compose `up` hard-fails on a missing
+    // `:ro` source.
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-webkite-present-"));
+    try {
+      mkdirSync(join(tmp, ".switchroom", "bin"), { recursive: true });
+      writeFileSync(join(tmp, ".switchroom", "bin", "webkite"), "#!/bin/sh\n");
+      mkdirSync(join(tmp, ".cloakbrowser", "chromium-1"), { recursive: true });
+      mkdirSync(join(tmp, ".switchroom", "webkite"), { recursive: true });
+      writeFileSync(join(tmp, ".switchroom", "webkite", "config.toml"), "");
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+      });
+      expect(out).toContain(
+        `${tmp}/.switchroom/bin/webkite:/usr/local/bin/webkite:ro`,
+      );
+      expect(out).toContain(
+        `${tmp}/.cloakbrowser:/state/agent/home/.cloakbrowser:ro`,
+      );
+      expect(out).toContain(
+        `${tmp}/.switchroom/webkite/config.toml:/state/agent/home/.config/webkite/config.toml:ro`,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("omits webkite + cloakbrowser mounts when host sources are absent", async () => {
+    // Mirrors the skills/credentials guard — a fresh install without
+    // the webkite binary staged or cloakbrowser installed should still
+    // produce valid compose. Webkite degrades gracefully (no MCP
+    // server resolves on first call — model gets a clear error).
+    const { mkdtempSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const tmp = mkdtempSync(join(tmpdir(), "compose-webkite-absent-"));
+    try {
+      const out = generateCompose({
+        config: makeConfig({ a: {} }),
+        homeDir: tmp,
+      });
+      expect(out).not.toContain(`/.switchroom/bin/webkite:`);
+      expect(out).not.toContain(`/.cloakbrowser:`);
+      expect(out).not.toContain(`/.switchroom/webkite/config.toml:`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("emits top-level project name 'switchroom' for collision protection", () => {
     // Belt-and-braces vs Coolify-managed (or other) compose stacks on
     // the same host. Pinning name: at file scope means

--- a/tests/docker/dockerfile-agent-bakes.test.ts
+++ b/tests/docker/dockerfile-agent-bakes.test.ts
@@ -96,3 +96,34 @@ describe("Dockerfile.agent Playwright provisioning", () => {
     expect(dockerfile).not.toMatch(/playwright@[\^~]/);
   });
 });
+
+/**
+ * Cloakbrowser — the local stealth Chromium driver used by webkite's
+ * `webkite mcp` stdio MCP. The webkite binary itself is operator-
+ * mounted (private beta); cloakbrowser's Python tool is baked here
+ * because (a) it's public OSS and (b) baking-in avoids a fragile
+ * per-agent pipx install in the boot path.
+ *
+ * The 700MB Chromium binary cloakbrowser spawns is NOT baked — it's
+ * shared across the fleet via a host bind mount of `~/.cloakbrowser/`
+ * (see src/agents/compose.ts).
+ */
+describe("Dockerfile.agent webkite/cloakbrowser provisioning", () => {
+  it("apt-installs pipx (the package manager cloakbrowser ships through)", () => {
+    expect(dockerfile).toMatch(
+      /apt-get\s+install[^\n]*\bpipx\b/,
+    );
+  });
+
+  it("pipx-installs cloakbrowser at a stable image-path PIPX_HOME", () => {
+    // PIPX_HOME must be a deterministic image path (not user $HOME, which
+    // the per-agent compose mount would shadow at runtime).
+    expect(dockerfile).toMatch(
+      /PIPX_HOME=\$\{CLOAKBROWSER_PIPX_HOME\}\s+PIPX_BIN_DIR=\/usr\/local\/bin\s+\\?\s*\n?\s*pipx\s+install\s+cloakbrowser/,
+    );
+  });
+
+  it("CLOAKBROWSER_PIPX_HOME is an absolute /opt path (not under HOME)", () => {
+    expect(dockerfile).toMatch(/ENV\s+CLOAKBROWSER_PIPX_HOME=\/opt\//);
+  });
+});

--- a/tests/scaffold.integration-registry.test.ts
+++ b/tests/scaffold.integration-registry.test.ts
@@ -35,7 +35,12 @@ import { INTEGRATION_MCP_RESOLVERS } from "../src/agents/scaffold.js";
 describe("INTEGRATION_MCP_RESOLVERS — registry shape", () => {
   it("contains exactly the three shipped integrations in order", () => {
     const labels = INTEGRATION_MCP_RESOLVERS.map((i) => i.label);
-    expect(labels).toEqual(["Google Workspace", "Microsoft 365", "Notion"]);
+    expect(labels).toEqual([
+      "Google Workspace",
+      "Microsoft 365",
+      "Notion",
+      "Webkite",
+    ]);
   });
 
   it("each entry has matching emitKey and retractionKey (today's invariant)", () => {
@@ -64,20 +69,52 @@ describe("INTEGRATION_MCP_RESOLVERS — registry shape", () => {
     expect(keys).toContain("gdrive");
     expect(keys).toContain("ms-365");
     expect(keys).toContain("notion");
+    expect(keys).toContain("webkite");
   });
 
   it("each resolver is callable and accepts the (name, agentConfig, switchroomConfig) shape", () => {
-    // Call each with a minimal disable config — they should all
-    // return null without throwing. Smoke-test that the registry's
-    // type contract isn't broken.
+    // Call each with a minimal disable config + per-server opt-out so
+    // every resolver returns null. Webkite is fleet-default (no opt-in
+    // gate) so the opt-out flag is required for it to return null —
+    // gdrive/m365/notion gate on their workspace blocks which are
+    // absent here, so they return null without the flag either way.
+    const optOutAll = {
+      mcp_servers: { gdrive: false, "ms-365": false, notion: false, webkite: false },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
     for (const integration of INTEGRATION_MCP_RESOLVERS) {
       const result = integration.resolve(
         "test-agent",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        {} as any,
+        optOutAll,
         undefined,
       );
       expect(result).toBeNull();
     }
+  });
+
+  it("webkite resolver emits the canonical entry when not opted out", () => {
+    const webkite = INTEGRATION_MCP_RESOLVERS.find((i) => i.emitKey === "webkite");
+    expect(webkite).toBeDefined();
+    const result = webkite!.resolve(
+      "test-agent",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      undefined,
+    );
+    expect(result).toEqual({
+      key: "webkite",
+      value: { command: "webkite", args: ["mcp"] },
+    });
+  });
+
+  it("webkite resolver returns null when the agent opts out", () => {
+    const webkite = INTEGRATION_MCP_RESOLVERS.find((i) => i.emitKey === "webkite");
+    const result = webkite!.resolve(
+      "test-agent",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { mcp_servers: { webkite: false } } as any,
+      undefined,
+    );
+    expect(result).toBeNull();
   });
 });

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -396,7 +396,12 @@ describe("scaffoldAgent", () => {
     // #235: switchroom-mcp deprecated — mcp__switchroom__* is no longer
     // pre-approved (the underlying server is removed).
     expect(settings.permissions.allow).not.toContain("mcp__switchroom__*");
-    expect(settings.permissions.deny).toEqual(["bash"]);
+    // Webkite is fleet-default (scaffold.ts:WEBKITE_FLEET_DENY_TOOLS) —
+    // the native WebFetch / WebSearch tools are denied so the model
+    // reaches for the webkite_* MCP tools instead. Per-agent
+    // `mcp_servers.webkite: false` opts both webkite AND this deny
+    // out together.
+    expect(settings.permissions.deny).toEqual(["bash", "WebFetch", "WebSearch"]);
     expect(settings.permissions.defaultMode).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

Adds **webkite** as a 4th fleet-default integration MCP, replacing native `WebFetch`/`WebSearch` everywhere. Every agent gets the `webkite_*` tools out of the box, pre-authed with Cloudflare/Firecrawl creds via the vault-broker. No per-agent setup.

## Why

- Stealth Chromium (cloakbrowser) handles bot-gated sites that WebFetch can't touch.
- Cloud render (Cloudflare/Firecrawl) as fallback.
- Cleaner DX than 12-tool MCP than shelling out to `curl`.

## Distribution model

| Piece | Where it lives | Why |
|---|---|---|
| `webkite` binary | Operator-staged at `~/.switchroom/bin/webkite`, RO mount to in-container PATH | Private beta — never in repo or image |
| Cloakbrowser Python tool | Baked in `docker/Dockerfile.agent` (pipx) | Public OSS; bake-in keeps shebangs sane |
| Stealth Chromium (~700MB) | Operator-staged at `~/.cloakbrowser/`, RO bind-mount fleet-wide | One install, shared across N agents |
| Cloudflare/Firecrawl creds | Vault → broker ACL → start.sh env export | Pre-authed at boot |

## Cascade

- `INTEGRATION_MCP_RESOLVERS` 4th entry — emits unless agent opts out via `mcp_servers.webkite: false`.
- `WEBKITE_FLEET_DENY_TOOLS = [WebFetch, WebSearch]` baseline-seeds settings.json `permissions.deny`. Per-agent opt-out re-enables native together with re-enabling webkite.
- `WEB_FETCH_GUIDANCE` joins the three existing fleet invariant blocks (`renderFleetInvariants`) — every agent reads "use webkite_*" via Claude Code's native CLAUDE.md discovery on the `--add-dir` fleet path.

## Broker

`isWebkiteCredentialKeyForAgent` joins the existing `isGoogleClientCredentialKeyForAgent` special case — framework-emitted MCP entries get framework-emitted broker ACL. Operator yaml never has to declare the keys. Gated on per-agent opt-out so disabled-webkite agents can't read the keys.

## Test plan

- [x] vitest 8032/8032 pass (10 new tests across 4 files)
- [x] bun: non-UAT pass; UAT requires real creds (pre-existing, not touched)
- [x] tsc --noEmit clean
- [ ] CI required checks green
- [ ] Reviewer agent APPROVE
- [ ] Canary on test-harness post-release (needs Linux webkite binary which is in-flight)
- [ ] UAT: `jtbd-webkite-read-dm` scenario (deferred — needs Linux binary)

## Operator setup (one-time)

```bash
cp /path/to/webkite ~/.switchroom/bin/webkite
XDG_DATA_HOME=~/.switchroom/webkite-share webkite setup --yes cloakbrowser
switchroom vault set webkite/cloudflare-account-id   # interactive
switchroom vault set webkite/cloudflare-api-token    # interactive
switchroom update                                    # re-apply + rebuild
```

## Risk

- Fleet-wide WebFetch deny may break workflows that relied on it. Mitigation: per-agent `mcp_servers.webkite: false` opts both webkite AND the deny out together.
- If the operator hasn't staged the webkite binary, the .mcp.json entry resolves but `webkite mcp` fails on spawn. The agent's reply will be a clean error, not a wedge. Doctor probe to surface this loudly is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)