### PR TITLE
fix(activity-summary): parse HTML in draft, sharpen MCP labels

### DIFF
--- a/telegram-plugin/answer-stream.ts
+++ b/telegram-plugin/answer-stream.ts
@@ -82,7 +82,7 @@ export interface AnswerStreamConfig {
     chatId: string,
     draftId: number,
     text: string,
-    params?: { message_thread_id?: number },
+    params?: { message_thread_id?: number; parse_mode?: 'HTML' },
   ) => Promise<unknown>
   sendMessage: (
     chatId: string,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -638,7 +638,7 @@ const GRAMMY_VERSION: string = (() => {
   }
 })()
 const sendMessageDraftFn: (
-  (chatId: string, draftId: number, text: string, params?: { message_thread_id?: number }) => Promise<unknown>
+  (chatId: string, draftId: number, text: string, params?: { message_thread_id?: number; parse_mode?: 'HTML' }) => Promise<unknown>
 ) | undefined =
   typeof _rawSendMessageDraft === 'function'
     ? (chatId, draftId, text, params) =>
@@ -6828,7 +6828,7 @@ async function drainActivitySummary(turn: CurrentTurn): Promise<void> {
             turn.activityDraftId = allocateDraftId()
           }
           const draftId = turn.activityDraftId
-          await sendMessageDraftFn!(chat, draftId, html, undefined)
+          await sendMessageDraftFn!(chat, draftId, html, { parse_mode: 'HTML' })
         } else if (turn.activityMessageId == null) {
           const sent = await robustApiCall(
             () => bot.api.sendMessage(chat, html, {

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -433,6 +433,15 @@ export function formatFrameworkFallbackText(
   //   running Grep "foo" for 4m (no update from agent in 5 min)
   //   running Grep "foo" + 2 more (4m) (no update from agent in 5 min)
   //   running Grep (no label) for 4m (no update from agent in 5 min)
+  //
+  // Raw MCP tool names (`mcp__server__tool`) are technical identifiers
+  // and look like a leak when surfaced to a user. When the tool name
+  // matches that shape AND a human-friendly label is available, drop
+  // the raw name and lead with the label instead:
+  //   Searching memory for 4m (no update from agent in 5 min)
+  // Built-in tool names (Grep, Read, Bash) stay as-is — they ARE
+  // human-readable, and the label is supplementary detail (e.g. the
+  // search pattern) that reads naturally after the verb.
   if (inFlightTools.length > 0) {
     const longest = inFlightTools[0]!
     const dur = formatDurationShort(longest.durationMs)
@@ -442,6 +451,13 @@ export function formatFrameworkFallbackText(
     const more = inFlightTools.length > 1
       ? ` + ${inFlightTools.length - 1} more`
       : ''
+    const isMcpRawName = /^mcp__/.test(longest.name)
+    if (isMcpRawName && labelTail !== '') {
+      // Label-only: "Searching memory for 4m (…)". Drop the raw
+      // `mcp__server__tool` and the leading "running" because the
+      // label already reads as a gerund phrase.
+      return `${truncateLabel(longest.label!)}${more} for ${dur} ${suffix}`
+    }
     return `running ${longest.name}${labelTail}${more} for ${dur} ${suffix}`
   }
   return fallbackKind === 'thinking'

--- a/telegram-plugin/tests/silence-poke.test.ts
+++ b/telegram-plugin/tests/silence-poke.test.ts
@@ -533,6 +533,43 @@ describe('silence-poke — #1292 tool-aware framework fallback', () => {
     )
   })
 
+  it('raw mcp__ tool name with a human label drops the technical name and leads with the label', () => {
+    // mcp__hindsight__reflect is the internal MCP identifier — looks
+    // like a leak when surfaced to a user. The label table emits
+    // "Searching memory" for it (see hooks/tool-label-pretool.mjs);
+    // the fallback message should lead with the label, not concatenate
+    // both.
+    const text = formatFrameworkFallbackText('working', 305_000, [
+      { name: 'mcp__hindsight__reflect', label: 'Searching memory', durationMs: 305_000 },
+    ])
+    expect(text).toBe(
+      'Searching memory for 5m (no update from agent in 5 min)',
+    )
+  })
+
+  it('raw mcp__ tool name with NO label falls back to the bare name (no leak-but-no-better-option)', () => {
+    // If the label table doesn't recognise an MCP tool, we have nothing
+    // better to show than the raw name. Better honest-ugly than silent.
+    const text = formatFrameworkFallbackText('working', 305_000, [
+      { name: 'mcp__some-third-party__do_thing', label: null, durationMs: 305_000 },
+    ])
+    expect(text).toBe(
+      'running mcp__some-third-party__do_thing for 5m (no update from agent in 5 min)',
+    )
+  })
+
+  it('built-in tool (Grep) with a label keeps the prior "running Name label" shape — name is already human-readable', () => {
+    // Regression guard: don't accidentally drop the built-in tool name
+    // when generalising the MCP rule. "Grep" is human-readable; the
+    // label ("foo") is supplementary detail like the search pattern.
+    const text = formatFrameworkFallbackText('working', 305_000, [
+      { name: 'Grep', label: 'foo', durationMs: 305_000 },
+    ])
+    expect(text).toBe(
+      'running Grep foo for 5m (no update from agent in 5 min)',
+    )
+  })
+
   it('empty inFlightTools falls back to the base "still working" wording', () => {
     expect(
       formatFrameworkFallbackText('working', 305_000, []),

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -32,9 +32,25 @@ describe("verbForTool — tool name → past-tense verb", () => {
     expect(verbForTool("mcp__switchroom-telegram__react")).toBeNull();
   });
 
-  it("returns 'used' for unknown / non-switchroom MCP tools", () => {
-    expect(verbForTool("mcp__google-workspace__list_files")).toBe("used");
-    expect(verbForTool("mcp__notion__query_database")).toBe("used");
+  it("maps recognised MCP tools (hindsight, google-workspace, notion) to specific verbs", () => {
+    // hindsight: recall/reflect → searched, retain/update_memory → saved
+    expect(verbForTool("mcp__hindsight__reflect")).toBe("searched");
+    expect(verbForTool("mcp__hindsight__recall")).toBe("searched");
+    expect(verbForTool("mcp__hindsight__retain")).toBe("saved");
+    expect(verbForTool("mcp__hindsight__update_memory")).toBe("saved");
+    // google-workspace / claude.ai variants: read-shaped → searched, write-shaped → edited
+    expect(verbForTool("mcp__google-workspace__list_files")).toBe("searched");
+    expect(verbForTool("mcp__claude_ai_Gmail__search_messages")).toBe("searched");
+    expect(verbForTool("mcp__google-workspace__create_file")).toBe("edited");
+    expect(verbForTool("mcp__claude_ai_Google_Drive__download_file_content")).toBe("searched");
+    // notion: query/get → searched, create/update → edited
+    expect(verbForTool("mcp__notion__query_database")).toBe("searched");
+    expect(verbForTool("mcp__claude_ai_Notion__notion-search")).toBe("searched");
+    expect(verbForTool("mcp__claude_ai_Notion__notion-update-page")).toBe("edited");
+  });
+
+  it("returns 'used' for genuinely unknown MCP / future tools (generic fallback)", () => {
+    expect(verbForTool("mcp__random-third-party__do_thing")).toBe("used");
     expect(verbForTool("SomeFutureUnknownTool")).toBe("used");
   });
 
@@ -112,12 +128,24 @@ describe("register + formatSummary — Claude Code-style summary", () => {
     expect(formatSummary(s)).toBeNull(); // nothing tracked
   });
 
-  it("includes generic 'used' for unknown MCP tools", () => {
+  it("includes generic 'used' for genuinely-unknown MCP tools (fallback)", () => {
     const s = makeEmptyActivityState();
-    register(s, "mcp__google-workspace__list_files");
+    register(s, "mcp__random-third-party__do_thing");
     expect(formatSummary(s)).toBe("Used a tool");
-    register(s, "mcp__google-workspace__create_file");
+    register(s, "mcp__another-unknown-server__something_else");
     expect(formatSummary(s)).toBe("Used 2 tools");
+  });
+
+  it("maps recognised MCP tools to natural-language summaries (no generic 'Used N tools')", () => {
+    // hindsight search shows up as 'searched' (memory)
+    const s = makeEmptyActivityState();
+    register(s, "mcp__hindsight__reflect");
+    expect(formatSummary(s)).toBe("Ran a search");
+    register(s, "mcp__hindsight__reflect");
+    expect(formatSummary(s)).toBe("Ran 2 searches");
+    // hindsight retain shows up as 'saved a memory'
+    register(s, "mcp__hindsight__retain");
+    expect(formatSummary(s)).toBe("Ran 2 searches, saved a memory");
   });
 
   it("tracks firstToolName for forensic / telemetry use", () => {

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -40,6 +40,7 @@ export type ActivityVerb =
   | "fetched"
   | "dispatched"
   | "noted"
+  | "saved" // memory-retain class (hindsight, etc.) — distinct from "noted" (TodoWrite)
   | "used"; // generic fallback
 
 /** Object form so `register()` can mutate; pure functions inside the
@@ -66,10 +67,44 @@ export function makeEmptyActivityState(): ActivityState {
  *  like reply/stream_reply) return null — the caller skips them. */
 export function verbForTool(toolName: string): ActivityVerb | null {
   if (!toolName) return null;
-  const mcpMatch = /^mcp__([^_]+)__(.+)$/.exec(toolName);
+  // Lazy match on the server segment so names containing underscores
+  // (e.g. `mcp__claude_ai_Gmail__search`) parse as
+  //   server="claude_ai_Gmail", tool="search"
+  // instead of the prior `[^_]+` which stopped at the first inner `_`.
+  const mcpMatch = /^mcp__(.+?)__(.+)$/.exec(toolName);
   // Skip user-facing Telegram-plugin tools entirely — those ARE the
   // surface, never to be summarised.
   if (mcpMatch && mcpMatch[1] === "switchroom-telegram") return null;
+
+  // MCP allowlist — map common MCP tools to specific verbs so the summary
+  // reads as "Searched memory" or "Read 2 files" instead of the generic
+  // fallback "Used 2 tools". Tools NOT on this list fall through to the
+  // generic "used" verb, which is still better than nothing for one-offs
+  // but hurts on heavy MCP turns. Mirrors the label table in
+  // `telegram-plugin/hooks/tool-label-pretool.mjs` — keep them in sync.
+  if (mcpMatch) {
+    // Case-insensitive match — claude.ai prefixes use mixed-case
+    // server names ("claude_ai_Gmail", "claude_ai_Google_Drive") so we
+    // lowercase both sides before comparing.
+    const server = mcpMatch[1].toLowerCase();
+    const mcpTool = mcpMatch[2].toLowerCase();
+    if (server === "hindsight") {
+      if (mcpTool === "recall" || mcpTool === "reflect") return "searched";
+      if (mcpTool === "retain" || mcpTool === "update_memory" || mcpTool === "sync_retain") return "saved";
+    }
+    if (server === "google-workspace" || server === "claude_ai_google_drive" || server === "claude_ai_gmail" || server === "claude_ai_google_calendar") {
+      if (/^(search|list|query|read|get|fetch|download)/i.test(mcpTool)) return "searched";
+      if (/^(create|update|write|send|move|copy|duplicate)/i.test(mcpTool)) return "edited";
+    }
+    if (server === "notion" || server === "claude_ai_notion") {
+      // claude.ai Notion exposes tools as `notion-search`, `notion-update-page`,
+      // etc. Strip the redundant `notion-` prefix before matching the verb.
+      const action = mcpTool.replace(/^notion-/, "");
+      if (/^(search|fetch|query|get|read)/i.test(action)) return "searched";
+      if (/^(create|update|move|duplicate|comment)/i.test(action)) return "edited";
+    }
+  }
+
   const suffix = (mcpMatch ? mcpMatch[2] : toolName).toLowerCase();
   switch (suffix) {
     case "read":
@@ -128,6 +163,7 @@ const VERB_PHRASE: Record<ActivityVerb, VerbPhrase> = {
   fetched: { singular: "fetched a URL", plural: "fetched $N URLs" },
   dispatched: { singular: "dispatched a sub-agent", plural: "dispatched $N sub-agents" },
   noted: { singular: "updated the todo list", plural: "updated the todo list ($N edits)" },
+  saved: { singular: "saved a memory", plural: "saved $N memories" },
   used: { singular: "used a tool", plural: "used $N tools" },
 };
 


### PR DESCRIPTION
## Summary

Three user-visible UX bugs in the activity-summary draft path that landed alongside Option B (#1934/#1937):

1. **Literal `<i>` tags in DM drafts** — `gateway.ts:drainActivitySummary` sent `<i>${summary}</i>` to `sendMessageDraft` without `parse_mode='HTML'`, so Telegram rendered the brackets literally (`<i>Ran a command, dispatched a sub-agent</i>` instead of italicized text). Sibling sendMessage / editMessageText branches already pass HTML.

2. **"Used 2 tools" generic fallback** for recognised MCP tools (hindsight, google-workspace, notion). The pre-tool hook label table already maps these (`'Searching memory'` for hindsight); the activity-summary builder was unaware. Now:
   - hindsight recall/reflect → "searched"
   - hindsight retain/update_memory → new `"saved"` verb → "saved a memory"
   - google-workspace + claude.ai variants: read-shaped → "searched", write-shaped → "edited"
   - notion: search/fetch → "searched", create/update → "edited"

3. **Raw `mcp__server__tool` leaking into silence-poke fallback** — the 300s message was `running mcp__hindsight__reflect Searching memory for 46s` (both name and label). Now when an MCP-shaped name has a human label, drop the name: `Searching memory for 46s`. Built-in names (Grep, Read, Bash) keep their prior `running ${name} ${label}` shape.

Also fixes the MCP-name regex (`[^_]+` → `(.+?)`) so server names with underscores (`claude_ai_Gmail`) parse, and lowercases the server segment for mixed-case claude.ai names.

## Test plan

- [x] `tool-activity-summary.test.ts` — 21 pass (2 updated, 1 added covering the MCP allowlist)
- [x] `silence-poke.test.ts` — 70 pass (3 added: mcp-label-only, mcp-no-label fallback, built-in-tool regression guard)
- [x] `tsc --noEmit` clean
- [x] `check-plugin-references.mjs` clean
- [x] `check-bot-api-wrapping.sh` clean
- [x] Full vitest suite: 500/500 files, 8027/8027 tests pass
- [ ] Live UAT post-deploy (verify draft preview shows italicized text + activity summary reads "Ran a search, saved a memory" not "Used 2 tools")

## Risk

- `sendMessageDraft` may not accept `parse_mode` if the beta Bot API method doesn't support it. The existing `shouldFallbackFromDraftTransport` fallback already catches "unsupported parameter" type rejections and degrades to message transport — at worst we get a brief blip then a graceful fallback. Live log shows the method has been accepting our calls (`status=ok`) for months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)