### PR TITLE
feat(docker): base → Debian trixie (glibc 2.41) + fail-safe webkite deny

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -2,7 +2,7 @@
 # switchroom/base — shared image for agent / broker / kernel / scheduler.
 #
 # Multi-arch: declare TARGETARCH so buildx (linux/amd64 + linux/arm64) picks
-# the right artifacts. node:22-bookworm-slim has both arches upstream; tini
+# the right artifacts. node:22-trixie-slim has both arches upstream; tini
 # and tmux are arch-portable from Debian repos.
 #
 # The claude CLI is installed via npm — the upstream package ships a thin
@@ -10,12 +10,18 @@
 # ARG TARGETARCH is informational here (logged at build time for forensics).
 ARG TARGETARCH=amd64
 
-# sec WS9-F4 (#1418): pinned by digest. The mutable `:22-bookworm-slim`
+# sec WS9-F4 (#1418): pinned by digest. The mutable `:22-trixie-slim`
 # tag is the base for the WHOLE fleet (incl. the root singletons); an
 # upstream tag repoint would flow into published images undetected.
 # Tag retained for readability + Dependabot `docker` ecosystem, which
 # raises digest bumps as reviewed PRs (.github/dependabot.yml).
-FROM node:22-bookworm-slim@sha256:7af03b14a13c8cdd38e45058fd957bf00a72bbe17feac43b1c15a689c029c732
+#
+# Debian 13 (trixie) — glibc 2.41, python 3.13. Bumped from bookworm
+# (glibc 2.36, python 3.11) so binaries built against a modern glibc
+# floor run in-container — the webkite MCP binary requires GLIBC_2.39,
+# which bookworm's 2.36 can't satisfy (caught by the v0.13.62 canary
+# before fleet rollout). Trixie's 2.41 clears it with headroom.
+FROM node:22-trixie-slim@sha256:e637ac91fb4f2f40761d217c5d48c41a05edf0b65eb9c34e72c27cce55af9e65
 
 ARG TARGETARCH
 RUN echo "switchroom/base building for arch=${TARGETARCH}" >&2

--- a/docker/Dockerfile.hostd
+++ b/docker/Dockerfile.hostd
@@ -35,7 +35,9 @@
 #
 # Multi-arch: switchroom/base sets up linux/amd64 + linux/arm64; both
 # arches have node + tini + bash. The docker CLI install below uses
-# Docker's official Debian-bookworm apt repo which ships both.
+# Docker's official Debian-trixie apt repo which ships both (suite must
+# match the base OS — switchroom/base is Debian 13 trixie since the
+# glibc-2.41 bump; Docker publishes a trixie suite, verified present).
 
 ARG BASE_IMAGE=switchroom/base:latest
 FROM ${BASE_IMAGE}
@@ -55,7 +57,7 @@ RUN apt-get update \
  && curl -fsSL https://download.docker.com/linux/debian/gpg \
     | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
  && chmod a+r /etc/apt/keyrings/docker.gpg \
- && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian trixie stable" \
     > /etc/apt/sources.list.d/docker.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1003,7 +1003,7 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   }
   // /etc/machine-id passthrough — required so the broker can derive
   // the same machine-bound key the host's `enable-auto-unlock` used
-  // to seal the auto-unlock blob. The agent base image (node:22-bookworm-slim)
+  // to seal the auto-unlock blob. The agent base image (node:22-trixie-slim)
   // ships without /etc/machine-id; without this mount the broker
   // errors out "Cannot derive machine-bound key: neither /etc/machine-id
   // nor /var/lib/dbus/machine-id is readable" and falls back to

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -730,6 +730,57 @@ const DEFAULT_READ_ONLY_PREAPPROVED_TOOLS = [
 const WEBKITE_FLEET_DENY_TOOLS = ["WebFetch", "WebSearch"];
 
 /**
+ * In-container PATH location of the operator-mounted webkite binary
+ * (compose.ts mounts `~/.switchroom/bin/webkite` here). Host-side
+ * staging path is `~/.switchroom/bin/webkite`.
+ */
+const WEBKITE_BINARY_CONTAINER_PATH = "/usr/local/bin/webkite";
+
+/**
+ * Fail-safe gate for the WebFetch/WebSearch deny: only strip the
+ * native tools when a webkite binary is actually staged, so a
+ * degraded install (binary missing, glibc-incompatible build pulled,
+ * operator hasn't run the one-time setup yet) keeps native WebFetch
+ * as a safety net instead of going dark on web access entirely.
+ *
+ * Checks BOTH contexts scaffold/reconcile can run in:
+ *   - host apply  → `~/.switchroom/bin/webkite` (operator staging path)
+ *   - in-container reconcile → `/usr/local/bin/webkite` (compose mount)
+ *
+ * This is deliberately a presence check, not a runnability check — we
+ * can't exec the binary at scaffold time across both contexts. A
+ * present-but-broken binary still trips the deny; the doctor probe
+ * (follow-up) is where runnability gets surfaced. Presence alone
+ * closes the dominant failure mode: operator simply hasn't staged it.
+ *
+ * `SWITCHROOM_WEBKITE_BINARY` env overrides the probe path entirely —
+ * a real operator knob for a non-standard webkite location, and the
+ * deterministic seam tests use (point it at a tmp file to simulate
+ * "staged", at a bogus path to simulate "absent").
+ */
+function webkiteBinaryAvailable(): boolean {
+  const override = process.env.SWITCHROOM_WEBKITE_BINARY;
+  if (override !== undefined && override !== "") {
+    return existsSync(override);
+  }
+  return (
+    existsSync(join(homedir(), ".switchroom", "bin", "webkite")) ||
+    existsSync(WEBKITE_BINARY_CONTAINER_PATH)
+  );
+}
+
+/**
+ * Resolve the effective WebFetch/WebSearch deny for an agent.
+ * Applied only when webkite is BOTH not-opted-out AND actually
+ * staged (the fail-safe gate above).
+ */
+function webkiteDenyForAgent(agentConfig: AgentConfig): string[] {
+  if (agentConfig.mcp_servers?.["webkite"] === false) return [];
+  if (!webkiteBinaryAvailable()) return [];
+  return WEBKITE_FLEET_DENY_TOOLS;
+}
+
+/**
  * Switchroom-shipped default model + thinking effort for main agents.
  *
  * Sonnet 4.6 + effort=low is the right starting point for the
@@ -1839,9 +1890,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     tools,
     toolsDeny: dedupe([
       ...(tools.deny ?? []),
-      ...(agentConfig.mcp_servers?.["webkite"] === false
-        ? []
-        : WEBKITE_FLEET_DENY_TOOLS),
+      ...webkiteDenyForAgent(agentConfig),
     ]),
     permissionAllow,
     defaultModeAcceptEdits: hasAllWildcard,
@@ -4193,9 +4242,7 @@ export function reconcileAgent(
   ]);
   const desiredDeny = dedupe([
     ...(tools.deny ?? []),
-    ...(agentConfig.mcp_servers?.["webkite"] === false
-      ? []
-      : WEBKITE_FLEET_DENY_TOOLS),
+    ...webkiteDenyForAgent(agentConfig),
   ]);
 
   // Resolve topic ID for the start.sh template and session greeting

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -381,28 +381,65 @@ describe("scaffoldAgent", () => {
     expect(access.groups["-1001234567890"].requireMention).toBe(false);
   });
 
-  it("generates settings.json with tool permissions", () => {
-    const config = makeAgentConfig({
-      tools: { allow: ["calendar", "notion"], deny: ["bash"] },
-    });
-    const result = scaffoldAgent("tools-agent", config, tmpDir, telegramConfig);
-    const settings = JSON.parse(
-      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
-    );
+  it("generates settings.json with tool permissions (webkite staged → WebFetch denied)", () => {
+    // Simulate the webkite binary being staged so the fail-safe gate
+    // (webkiteBinaryAvailable) trips and the deny applies. Point the
+    // override env at a real file under tmpDir.
+    const fakeWebkite = join(tmpDir, "webkite-bin");
+    writeFileSync(fakeWebkite, "#!/bin/sh\n");
+    const prev = process.env.SWITCHROOM_WEBKITE_BINARY;
+    process.env.SWITCHROOM_WEBKITE_BINARY = fakeWebkite;
+    try {
+      const config = makeAgentConfig({
+        tools: { allow: ["calendar", "notion"], deny: ["bash"] },
+      });
+      const result = scaffoldAgent("tools-agent", config, tmpDir, telegramConfig);
+      const settings = JSON.parse(
+        readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+      );
 
-    // User-declared tools end up on the allowlist
-    expect(settings.permissions.allow).toContain("calendar");
-    expect(settings.permissions.allow).toContain("notion");
-    // #235: switchroom-mcp deprecated — mcp__switchroom__* is no longer
-    // pre-approved (the underlying server is removed).
-    expect(settings.permissions.allow).not.toContain("mcp__switchroom__*");
-    // Webkite is fleet-default (scaffold.ts:WEBKITE_FLEET_DENY_TOOLS) —
-    // the native WebFetch / WebSearch tools are denied so the model
-    // reaches for the webkite_* MCP tools instead. Per-agent
-    // `mcp_servers.webkite: false` opts both webkite AND this deny
-    // out together.
-    expect(settings.permissions.deny).toEqual(["bash", "WebFetch", "WebSearch"]);
-    expect(settings.permissions.defaultMode).toBeUndefined();
+      // User-declared tools end up on the allowlist
+      expect(settings.permissions.allow).toContain("calendar");
+      expect(settings.permissions.allow).toContain("notion");
+      // #235: switchroom-mcp deprecated — mcp__switchroom__* is no longer
+      // pre-approved (the underlying server is removed).
+      expect(settings.permissions.allow).not.toContain("mcp__switchroom__*");
+      // Webkite is fleet-default (scaffold.ts:WEBKITE_FLEET_DENY_TOOLS) —
+      // the native WebFetch / WebSearch tools are denied so the model
+      // reaches for the webkite_* MCP tools instead. Per-agent
+      // `mcp_servers.webkite: false` opts both webkite AND this deny
+      // out together.
+      expect(settings.permissions.deny).toEqual(["bash", "WebFetch", "WebSearch"]);
+      expect(settings.permissions.defaultMode).toBeUndefined();
+    } finally {
+      if (prev === undefined) delete process.env.SWITCHROOM_WEBKITE_BINARY;
+      else process.env.SWITCHROOM_WEBKITE_BINARY = prev;
+    }
+  });
+
+  it("fail-safe: webkite binary ABSENT → native WebFetch/WebSearch kept", () => {
+    // The fleet-default deny is gated on a webkite binary actually
+    // being staged (webkiteBinaryAvailable). When it's absent — fresh
+    // install, operator hasn't run setup, or a glibc-incompatible
+    // build was pulled — the agent must KEEP native WebFetch as a
+    // safety net rather than losing web access entirely. Point the
+    // override at a path that does not exist.
+    const prev = process.env.SWITCHROOM_WEBKITE_BINARY;
+    process.env.SWITCHROOM_WEBKITE_BINARY = join(tmpDir, "does-not-exist-webkite");
+    try {
+      const config = makeAgentConfig({
+        tools: { allow: ["calendar"], deny: ["bash"] },
+      });
+      const result = scaffoldAgent("nofetch-agent", config, tmpDir, telegramConfig);
+      const settings = JSON.parse(
+        readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+      );
+      // Only the user-declared deny — no WebFetch/WebSearch strip.
+      expect(settings.permissions.deny).toEqual(["bash"]);
+    } finally {
+      if (prev === undefined) delete process.env.SWITCHROOM_WEBKITE_BINARY;
+      else process.env.SWITCHROOM_WEBKITE_BINARY = prev;
+    }
   });
 
   // #1400 apex-chain link 1: the hostd MCP server exposes mutating /


### PR DESCRIPTION
## Summary

Unblocks the webkite rollout. The v0.13.62 canary caught the webkite binary requiring **GLIBC_2.39**, which the bookworm base (glibc 2.36) can't satisfy. Two coupled fixes:

1. **Base bookworm → trixie** (glibc 2.36→2.41, python 3.11→3.13).
2. **Fail-safe WebFetch deny** — native WebFetch only stripped when a webkite binary is actually staged, so a degraded install keeps web access.

## Why trixie (not a webkite rebuild)

Operator chose to be self-sufficient rather than gated on the webkite team's build env. Trixie's glibc 2.41 clears the floor with headroom and is where Debian's heading anyway.

## Validation (built agent image on trixie, ran in-container)

| Check | Result |
|---|---|
| `webkite --version` (glibc 2.39 floor) | ✅ webkite 0.4.0 runs |
| `webkite doctor` | ✅ cloakbrowser detected, 12 MCP tools, 0 errors |
| cloakbrowser pipx bake | ✅ finds Chromium |
| python | ✅ 3.13.5 |
| hindsight hooks | ✅ all 22 scripts compile on 3.13 |
| playwright python binding | ✅ imports |
| node | ✅ v22.22.3 |

## Changes

- `docker/Dockerfile.base`: FROM `node:22-trixie-slim` digest-pinned (sec WS9-F4 reviewed bump).
- `docker/Dockerfile.hostd`: docker-CLI apt suite `bookworm` → `trixie` (Docker publishes a trixie suite — verified present at download.docker.com).
- `src/agents/scaffold.ts`: `webkiteBinaryAvailable()` + `webkiteDenyForAgent()` — deny gated on binary presence; `SWITCHROOM_WEBKITE_BINARY` override (operator knob + test seam). Both scaffold & reconcile deny sites routed through the helper.
- `src/agents/compose.ts`: machine-id comment updated to trixie.
- `tests/scaffold.test.ts`: fail-safe case (binary absent → native WebFetch kept) + host-independent staged-case pin.

## Test plan
- [x] tsc --noEmit clean
- [x] vitest affected suites (scaffold, registry, compose, acl) 390/390
- [x] trixie agent image built + in-container validation gate (table above)
- [ ] CI 10 required checks green (incl. build-base on trixie + 5 build-dependents)
- [ ] Reviewer APPROVE
- [ ] Release v0.13.63 → canary (will now pass) → fleet rollout

## Risk

- Base bump touches all 5 images. Mitigated by the in-container validation above + CI's build-base + build-dependents matrix.
- Python 3.11→3.13: hindsight hooks compile-validated; playwright binding import-validated. Watch hindsight retain/recall on the canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)