### PR TITLE
fix(agents): pre-approve webkite MCP tools (first fetch was wedging on a permission prompt)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -660,6 +660,24 @@ const HOSTD_MCP_TOOLS = [
 ];
 
 /**
+ * Pre-approved MCP tool names for the fleet-default `webkite` server
+ * (wired by resolveWebkiteMcpEntry unless the agent opts out). Without
+ * these in the allow list, the FIRST time the model reaches for any
+ * webkite_* tool — i.e. the first "read this URL for me" — Claude Code
+ * blocks on a permission prompt the operator must approve via Telegram,
+ * wedging the turn. Since webkite REPLACES native WebFetch/WebSearch
+ * (those are denied), that first web fetch is guaranteed and common, so
+ * an un-approved webkite is effectively a broken web-fetch capability.
+ * Wildcard covers all 13 webkite tools (read/search/extract/crawl/map/
+ * clip/session/diagnose/…) and any future additions without a re-bump.
+ * Same shape + rationale as AGENT_CONFIG_MCP_TOOLS above.
+ */
+const WEBKITE_MCP_TOOLS = [
+  "mcp__webkite",
+  "mcp__webkite__*",
+];
+
+/**
  * Legacy `mcp__switchroom__*` permission tokens that pre-#235 agents have
  * baked into their `settings.permissions.allow`. The switchroom-mcp server
  * is deprecated (#235) — its 4 tools were dormant (zero callers) and the
@@ -2476,6 +2494,13 @@ export function scaffoldAgent(
     // (daemon-side gates remain the real security boundary).
     ...AGENT_CONFIG_MCP_TOOLS,
     ...HOSTD_MCP_TOOLS,
+    // Webkite is fleet-default (resolveWebkiteMcpEntry) unless the agent
+    // opts out. Pre-approve its tools so the first web fetch doesn't
+    // wedge on a permission prompt — webkite IS the web-fetch path now
+    // (native WebFetch/WebSearch are denied). Gated on the same opt-out
+    // as the MCP entry emission, so a webkite-disabled agent doesn't
+    // carry dangling pre-approvals.
+    ...(agentConfig.mcp_servers?.["webkite"] === false ? [] : WEBKITE_MCP_TOOLS),
   ]);
 
   // Compute Hindsight plugin context for the start.sh + settings.json
@@ -2621,7 +2646,17 @@ export function scaffoldAgent(
         ? settings.permissions.allow
         : []
       ).filter((p: string) => !LEGACY_HOSTD_BLANKET_TOKENS.includes(p));
-      for (const t of [...AGENT_CONFIG_MCP_TOOLS, ...HOSTD_MCP_TOOLS]) {
+      // Webkite is fleet-default; re-seed its tools into EXISTING agents'
+      // allow on apply (writeIfMissing above skips the template for
+      // existing agents, so the fresh permissionAllow never lands). This
+      // is the existing-agent twin of the permissionAllow webkite spread.
+      // Without it, every deployed agent's first webkite_* call wedges on
+      // a permission prompt even though .mcp.json wires webkite (the merge
+      // at the INTEGRATION_MCP_RESOLVERS loop below). Gated on the same
+      // opt-out as the MCP entry emission.
+      const webkiteAllowTools =
+        agentConfig.mcp_servers?.["webkite"] === false ? [] : WEBKITE_MCP_TOOLS;
+      for (const t of [...AGENT_CONFIG_MCP_TOOLS, ...HOSTD_MCP_TOOLS, ...webkiteAllowTools]) {
         if (!allow.includes(t)) allow.push(t);
       }
       settings.permissions.allow = allow;
@@ -4246,6 +4281,7 @@ export function reconcileAgent(
     // MCP servers so first-use doesn't wedge on a permission prompt.
     ...AGENT_CONFIG_MCP_TOOLS,
     ...HOSTD_MCP_TOOLS,
+    ...(agentConfig.mcp_servers?.["webkite"] === false ? [] : WEBKITE_MCP_TOOLS),
   ]);
   const desiredDeny = dedupe([
     ...(tools.deny ?? []),

--- a/telegram-plugin/uat/scenarios/jtbd-webkite-read-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-webkite-read-dm.test.ts
@@ -1,0 +1,115 @@
+/**
+ * JTBD scenario — the agent fetches the web via webkite, transparently.
+ *
+ * Validates the v0.13.62/63 webkite rollout end-to-end through real
+ * Telegram: the user sends a URL and asks about its content WITHOUT
+ * ever naming "webkite". The agent must:
+ *
+ *   1. Reach for webkite on its own (the native WebFetch/WebSearch
+ *      tools are denied fleet-wide — see scaffold.ts
+ *      WEBKITE_FLEET_DENY_TOOLS — so the ONLY way the agent can answer
+ *      a "read this URL" prompt is via the webkite_* MCP tools). If the
+ *      agent returns the page's content, webkite did the work by
+ *      construction — there is no other web-fetch tool available.
+ *
+ *   2. Render JavaScript. The target is `quotes.toscrape.com/js/`, a
+ *      purpose-built scraping-practice SPA whose quotes are injected by
+ *      JS at runtime. A raw HTTP fetch (what the old WebFetch did) sees
+ *      an empty page — `curl` returns zero `class="quote"` nodes. Only
+ *      a JS-executing renderer (webkite → cloakbrowser headless
+ *      Chromium) produces the visible quote text. So a correct quote in
+ *      the reply is positive proof that JS rendering happened.
+ *
+ * The first quote on that page is Einstein's "The world as we have
+ * created it is a process of our thinking…". We assert the reply names
+ * Einstein AND carries a recognizable fragment of that quote.
+ *
+ * ## What this catches that other UATs don't
+ *
+ * - `jtbd-fast-trivial-dm` proves the agent replies fast, but never
+ *   touches a tool. This is the first UAT that forces a real web fetch.
+ * - The in-container `webkite read` smoke proves the binary works, but
+ *   not that the *model* chooses webkite unprompted over a denied
+ *   WebFetch, nor that the full inbound→claude→MCP→outbound path works.
+ *
+ * ## Failure modes this guards against
+ *
+ * - A regression that re-enables WebFetch (the model might fetch raw
+ *   HTML and miss the JS-rendered quotes → wrong/empty answer).
+ * - webkite MCP not wired / not trusted (agent says it can't browse).
+ * - cloakbrowser broken (agent returns the empty static page → no
+ *   quote, or a "page had no content" apology).
+ * - The glibc regression that the v0.13.62 canary caught (webkite
+ *   dead-on-arrival → agent can't browse at all).
+ */
+
+import { describe, it, expect } from "vitest";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+
+// JS-rendered scraping-practice page. Quotes exist ONLY after JS runs;
+// a raw fetch sees none. Stable, purpose-built, no auth.
+const JS_URL = "https://quotes.toscrape.com/js/";
+
+// Deliberately does NOT mention webkite, fetch, browser, or any tool —
+// a natural "read this for me" ask. The agent must pick the tool.
+const PROMPT =
+  `Open ${JS_URL} and tell me the exact text of the very first quote ` +
+  `on the page and who said it. Just the quote and the author.`;
+
+// The first quote's author + a distinctive fragment of its text.
+const EXPECTED_AUTHOR = /einstein/i;
+const EXPECTED_FRAGMENT =
+  /world as we have created it|process of our thinking|changing our thinking/i;
+
+// Phrases that would indicate the agent FAILED to browse (fell back to
+// "I can't access the web" or got the empty static page).
+const CANT_BROWSE = [
+  /can.?t (access|browse|open|reach|fetch)/i,
+  /unable to (access|browse|open|reach|fetch)/i,
+  /no content|empty page|couldn.?t (find|load)/i,
+  /don.?t have (web|internet|browsing)/i,
+];
+
+describe("uat: agent fetches the web via webkite (JS page, unprompted)", () => {
+  it(
+    "URL prompt → agent returns JS-rendered content (proves webkite + cloakbrowser)",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        await sc.sendDM(PROMPT);
+
+        // Generous budget: a real cloakbrowser render of an SPA is
+        // slower than a trivial reply (Chromium spawn + JS execution).
+        const reply = await sc.expectMessage(EXPECTED_FRAGMENT, {
+          from: "bot",
+          timeout: 90_000,
+        });
+
+        // Positive proof: the JS-gated quote text came back.
+        expect(reply.text).toMatch(EXPECTED_FRAGMENT);
+        // And the author — confirms it parsed the actual quote, not noise.
+        expect(reply.text).toMatch(EXPECTED_AUTHOR);
+
+        // Negative proof: no "I can't browse" fallback. (WebFetch is
+        // denied, so a failure to use webkite surfaces as an apology,
+        // not a wrong fetch.)
+        const failedToBrowse = CANT_BROWSE.some((re) => re.test(reply.text));
+        expect(
+          failedToBrowse,
+          `agent reply looks like a can't-browse fallback: ${JSON.stringify(reply.text.slice(0, 300))}`,
+        ).toBe(false);
+
+        console.log(
+          `[webkite-read] agent returned JS-rendered quote via webkite — ` +
+          `WebFetch denied, cloakbrowser rendered the SPA. ` +
+          `reply: ${JSON.stringify(reply.text.slice(0, 200))}`,
+        );
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    120_000,
+  );
+});

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -307,6 +307,25 @@ describe("scaffoldAgent", () => {
     expect(startSh).toContain("--permission-mode bypassPermissions");
   });
 
+  it("reconcile pre-approves webkite MCP tools in permissions.allow", () => {
+    // The live `switchroom apply` path reconciles EXISTING agents
+    // (reconcileAgent), not scaffoldAgent. This pins that the reconcile
+    // desiredAllow also carries mcp__webkite__* — the path that actually
+    // runs on every restart/apply for a deployed fleet.
+    const config = makeAgentConfig({});
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "webkite-reconcile": config },
+    } as SwitchroomConfig;
+    scaffoldAgent("webkite-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    reconcileAgent("webkite-reconcile", config, tmpDir, telegramConfig, switchroomConfig);
+    const settings = JSON.parse(
+      readFileSync(join(tmpDir, "webkite-reconcile", ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.permissions.allow).toContain("mcp__webkite__*");
+  });
+
   it("reconcile re-renders start.sh with fallback_model flag", () => {
     const config = makeAgentConfig({ fallback_model: "sonnet" });
     const switchroomConfig: SwitchroomConfig = {
@@ -415,6 +434,63 @@ describe("scaffoldAgent", () => {
       if (prev === undefined) delete process.env.SWITCHROOM_WEBKITE_BINARY;
       else process.env.SWITCHROOM_WEBKITE_BINARY = prev;
     }
+  });
+
+  it("webkite MCP tools are pre-approved in permissions.allow (no first-use prompt)", () => {
+    // Webkite replaces native WebFetch — the first "read this URL" is a
+    // guaranteed, common turn. If webkite_* tools aren't pre-approved,
+    // that call wedges on a Claude Code permission prompt. Pre-approval
+    // is gated only on the per-agent opt-out (NOT on binary presence),
+    // matching when the MCP entry is emitted.
+    const config = makeAgentConfig({});
+    const result = scaffoldAgent("webkite-allow-agent", config, tmpDir, telegramConfig);
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.permissions.allow).toContain("mcp__webkite__*");
+    expect(settings.permissions.allow).toContain("mcp__webkite");
+  });
+
+  it("re-seeds webkite pre-approval into an EXISTING agent's allow (merge path)", () => {
+    // The bug this guards: `switchroom apply` on a deployed (existing)
+    // agent hits writeIfMissing — which SKIPS the settings.json template
+    // — then the MCP-merge block re-seeds allow. Pre-fix that block only
+    // re-seeded agent-config + hostd, so webkite never reached existing
+    // agents' allow and every deployed agent's first webkite_* call
+    // wedged on a permission prompt (caught live on the v0.13.63 fleet).
+    const config = makeAgentConfig({});
+    // First scaffold creates settings.json (fresh path — has webkite).
+    const result = scaffoldAgent("wk-existing", config, tmpDir, telegramConfig, {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "wk-existing": config },
+    } as SwitchroomConfig);
+    const settingsPath = join(result.agentDir, ".claude", "settings.json");
+    // Simulate a PRE-webkite deployed agent: strip webkite from allow.
+    const s1 = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    s1.permissions.allow = s1.permissions.allow.filter(
+      (x: string) => !x.includes("webkite"),
+    );
+    writeFileSync(settingsPath, JSON.stringify(s1, null, 2));
+    expect(JSON.parse(readFileSync(settingsPath, "utf-8")).permissions.allow)
+      .not.toContain("mcp__webkite__*");
+    // Re-scaffold (existing-agent merge path) must re-seed webkite.
+    scaffoldAgent("wk-existing", config, tmpDir, telegramConfig, {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "wk-existing": config },
+    } as SwitchroomConfig);
+    const s2 = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    expect(s2.permissions.allow).toContain("mcp__webkite__*");
+  });
+
+  it("webkite opt-out removes the pre-approval too", () => {
+    const config = makeAgentConfig({ mcp_servers: { webkite: false } } as Partial<AgentConfig>);
+    const result = scaffoldAgent("webkite-optout-agent", config, tmpDir, telegramConfig);
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.permissions.allow).not.toContain("mcp__webkite__*");
   });
 
   it("fail-safe: webkite binary ABSENT → native WebFetch/WebSearch kept", () => {


### PR DESCRIPTION
## Summary

The webkite rollout (#1941/#1944) wired the webkite MCP server + denied native WebFetch/WebSearch — but **never pre-approved the `webkite_*` tools** in `settings.json` `permissions.allow`. So the first "read this URL" turn hit a Claude Code permission prompt and wedged. Observed live on the v0.13.63 fleet ("agent is requesting the skill/mcp").

## Root cause (the subtle part)

`switchroom apply` on a **deployed (existing)** agent hits `writeIfMissing` — which **skips** the settings.json template — then an MCP-merge block re-seeds `permissions.allow`. Pre-fix that block only re-seeded `agent-config` + `hostd` tools, so webkite never reached existing agents' allow. **Fresh-scaffold unit tests passed while the deployed fleet still prompted** — that divergence is exactly what made this sneaky.

## Fix (`src/agents/scaffold.ts`)

- `WEBKITE_MCP_TOOLS = ["mcp__webkite", "mcp__webkite__*"]`, pre-approved in `permissionAllow` (fresh scaffold) AND `desiredAllow` (reconcile), gated on the `mcp_servers.webkite: false` opt-out.
- **The load-bearing one:** added webkite to the existing-agent MCP-merge re-seed loop (the path `apply` actually runs on a deployed fleet).

## Tests

- `scaffold.test`: fresh-scaffold pre-approval, reconcile pre-approval, **existing-agent merge re-seed** (the actual bug), opt-out removes it.
- New UAT `jtbd-webkite-read-dm`: DMs a JS-rendered SPA URL **without naming webkite**; asserts the agent returns the JS-gated quote — proving webkite chosen unprompted + cloakbrowser renders JS + no permission wedge.

## Live validation

After the fix, re-ran the UAT against test-harness: agent returned *"The world as we have created it is a process of our thinking..." — Albert Einstein* from `quotes.toscrape.com/js/` (JS-rendered, absent from static HTML) in 49s. ✅

## Test plan
- [x] tsc clean; 6 webkite tests + 408 affected-suite tests pass
- [x] Live UAT pass on test-harness
- [ ] CI green
- [ ] Reviewer APPROVE
- [ ] Release v0.13.65 + fleet roll (all 8 other agents still need this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)