### PR TITLE
feat(doctor): webkite health section (binary arch, cloakbrowser, scaffold wiring)

### DIFF
--- a/src/cli/doctor-webkite.test.ts
+++ b/src/cli/doctor-webkite.test.ts
@@ -1,0 +1,182 @@
+/**
+ * doctor-webkite — surfaces the webkite fleet-default failure classes.
+ *
+ * Each case pins a bug that shipped during the webkite rollout:
+ *   - wrong-arch binary (macOS Mach-O / non-x86-64) → won't run
+ *     in-container (the canary catch that forced the trixie bump)
+ *   - cloakbrowser absent → no local render, cloud-only
+ *   - permissions.allow missing mcp__webkite__* → first fetch wedges
+ *     on a permission prompt (#1949)
+ *   - agent-UID-owned scaffold unreadable by the operator → skip,
+ *     never fail (the no-sudo doctor discipline)
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { runWebkiteChecks, type WebkiteProbeDeps } from "./doctor-webkite.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+function cfg(partial: Partial<SwitchroomConfig>): SwitchroomConfig {
+  return partial as unknown as SwitchroomConfig;
+}
+
+function byName(rs: { name: string; status: string; detail?: string }[], name: string) {
+  return rs.find((r) => r.name === name);
+}
+
+// ELF x86-64 header: 0x7F 'E' 'L' 'F', class=2, ... e_machine(0x3E) at 18.
+const ELF_X64 = Buffer.from([
+  0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0x3e, 0x00,
+]);
+// ELF aarch64: e_machine 0xB7.
+const ELF_ARM64 = Buffer.from([
+  0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0xb7, 0x00,
+]);
+// Mach-O 64 (macOS) magic 0xFEEDFACF — NOT ELF.
+const MACHO = Buffer.from([
+  0xcf, 0xfa, 0xed, 0xfe, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+]);
+
+interface FakeFs {
+  files?: Record<string, string>;
+  dirs?: Record<string, string[]>;
+  heads?: Record<string, Buffer>;
+  eaccess?: Set<string>;
+}
+
+function deps(fs: FakeFs, extra: Partial<WebkiteProbeDeps> = {}): WebkiteProbeDeps {
+  const present = new Set<string>([
+    ...Object.keys(fs.files ?? {}),
+    ...Object.keys(fs.dirs ?? {}),
+    ...Object.keys(fs.heads ?? {}),
+  ]);
+  return {
+    homeDir: "/home/op",
+    agentsDir: "/home/op/.switchroom/agents",
+    existsSync: (p) => present.has(p),
+    readFileSync: (p) => {
+      if (fs.eaccess?.has(p)) {
+        const e = new Error("EACCES") as NodeJS.ErrnoException;
+        e.code = "EACCES";
+        throw e;
+      }
+      const v = fs.files?.[p];
+      if (v === undefined) throw new Error(`no file ${p}`);
+      return v;
+    },
+    readdirSync: (p) => fs.dirs?.[p] ?? [],
+    readHead: (p) => fs.heads?.[p] ?? null,
+    ...extra,
+  };
+}
+
+const BIN = "/home/op/.switchroom/bin/webkite";
+const CLOAK = "/home/op/.cloakbrowser";
+const CHROME = "/home/op/.cloakbrowser/chromium-146/chrome";
+
+describe("runWebkiteChecks", () => {
+  it("returns [] when every agent opts out of webkite", () => {
+    const config = cfg({
+      agents: { a: { mcp_servers: { webkite: false } } as never },
+    });
+    expect(runWebkiteChecks(config, deps({}))).toEqual([]);
+  });
+
+  it("warns when the binary is not staged", () => {
+    const config = cfg({ agents: { a: {} as never } });
+    const r = runWebkiteChecks(config, deps({ dirs: { [CLOAK]: ["chromium-146"] }, files: { [CHROME]: "" } }));
+    expect(byName(r, "webkite: binary")?.status).toBe("warn");
+  });
+
+  it("fails when the staged binary is a non-ELF (macOS) build", () => {
+    const config = cfg({ agents: { a: {} as never } });
+    const r = runWebkiteChecks(config, deps({ heads: { [BIN]: MACHO } }));
+    const bin = byName(r, "webkite: binary");
+    expect(bin?.status).toBe("fail");
+    expect(bin?.detail).toMatch(/not a Linux ELF/i);
+  });
+
+  it("fails when the staged binary is the wrong CPU arch (arm64 ELF)", () => {
+    const config = cfg({ agents: { a: {} as never } });
+    const r = runWebkiteChecks(config, deps({ heads: { [BIN]: ELF_ARM64 } }));
+    expect(byName(r, "webkite: binary")?.status).toBe("fail");
+  });
+
+  it("passes the binary check for a linux x86-64 ELF", () => {
+    const config = cfg({ agents: { a: {} as never } });
+    const r = runWebkiteChecks(config, deps({ heads: { [BIN]: ELF_X64 } }));
+    expect(byName(r, "webkite: binary")?.status).toBe("ok");
+  });
+
+  it("warns when cloakbrowser is absent", () => {
+    const config = cfg({ agents: { a: {} as never } });
+    const r = runWebkiteChecks(config, deps({ heads: { [BIN]: ELF_X64 } }));
+    expect(byName(r, "webkite: cloakbrowser")?.status).toBe("warn");
+  });
+
+  it("passes cloakbrowser when chromium/chrome is present", () => {
+    const config = cfg({ agents: { a: {} as never } });
+    const r = runWebkiteChecks(
+      config,
+      deps({ heads: { [BIN]: ELF_X64 }, dirs: { [CLOAK]: ["chromium-146"] }, files: { [CHROME]: "" } }),
+    );
+    expect(byName(r, "webkite: cloakbrowser")?.status).toBe("ok");
+  });
+
+  it("OK per-agent scaffold when wired + pre-approved + WebFetch denied", () => {
+    const config = cfg({
+      switchroom: { version: 1, agents_dir: "/home/op/.switchroom/agents" } as never,
+      agents: { clerk: {} as never },
+    });
+    const sp = "/home/op/.switchroom/agents/clerk/.claude/settings.json";
+    const mp = "/home/op/.switchroom/agents/clerk/.mcp.json";
+    const r = runWebkiteChecks(
+      config,
+      deps({
+        heads: { [BIN]: ELF_X64 },
+        files: {
+          [sp]: JSON.stringify({ permissions: { allow: ["mcp__webkite__*"], deny: ["WebFetch", "WebSearch"] } }),
+          [mp]: JSON.stringify({ mcpServers: { webkite: { command: "webkite" } } }),
+        },
+      }),
+    );
+    expect(byName(r, "webkite: clerk scaffold")?.status).toBe("ok");
+  });
+
+  it("warns per-agent when permissions.allow is missing the webkite pre-approval (#1949 regression)", () => {
+    const config = cfg({
+      switchroom: { version: 1, agents_dir: "/home/op/.switchroom/agents" } as never,
+      agents: { clerk: {} as never },
+    });
+    const sp = "/home/op/.switchroom/agents/clerk/.claude/settings.json";
+    const mp = "/home/op/.switchroom/agents/clerk/.mcp.json";
+    const r = runWebkiteChecks(
+      config,
+      deps({
+        heads: { [BIN]: ELF_X64 },
+        files: {
+          [sp]: JSON.stringify({ permissions: { allow: [], deny: ["WebFetch", "WebSearch"] } }),
+          [mp]: JSON.stringify({ mcpServers: { webkite: {} } }),
+        },
+      }),
+    );
+    const s = byName(r, "webkite: clerk scaffold");
+    expect(s?.status).toBe("warn");
+    expect(s?.detail).toMatch(/mcp__webkite__\*/);
+  });
+
+  it("SKIPS (never fails) per-agent scaffold when the operator can't read agent-private files", () => {
+    const config = cfg({
+      switchroom: { version: 1, agents_dir: "/home/op/.switchroom/agents" } as never,
+      agents: { clerk: {} as never },
+    });
+    const sp = "/home/op/.switchroom/agents/clerk/.claude/settings.json";
+    const r = runWebkiteChecks(
+      config,
+      deps({ heads: { [BIN]: ELF_X64 }, files: { [sp]: "x" }, eaccess: new Set([sp]) }),
+    );
+    expect(byName(r, "webkite: clerk scaffold")?.status).toBe("skip");
+  });
+});

--- a/src/cli/doctor-webkite.ts
+++ b/src/cli/doctor-webkite.ts
@@ -1,0 +1,274 @@
+/**
+ * Webkite integration doctor checks.
+ *
+ * Webkite is the fleet-default web fetcher (v0.13.62+): every agent
+ * gets the `webkite_*` MCP tools and native WebFetch/WebSearch are
+ * denied unless the agent opts out via `mcp_servers.webkite: false`.
+ * The rollout shipped through three SILENT failure classes, each of
+ * which these probes convert into one upfront, operator-visible line:
+ *
+ *   1. binary arch       — the operator stages a private-beta binary at
+ *      `~/.switchroom/bin/webkite`. A wrong-arch build (e.g. a macOS
+ *      arm64 Mach-O instead of linux x86-64 ELF, or a glibc-too-new
+ *      build) won't run in-container — the agent silently loses web
+ *      access. We read the ELF header on the host so the gross mistake
+ *      is caught before a fleet roll, not after.
+ *   2. cloakbrowser      — the local stealth Chromium render path lives
+ *      at `~/.cloakbrowser/`. Absent → webkite can only cloud-render
+ *      (Cloudflare/Firecrawl) and fails on bot-gated sites with no
+ *      local fallback.
+ *   3. scaffold wiring   — for each webkite-enabled agent that HAS been
+ *      scaffolded: `.mcp.json` must carry the `webkite` entry,
+ *      `settings.json` `permissions.allow` must pre-approve
+ *      `mcp__webkite__*` (the bug that wedged the first fetch on a
+ *      permission prompt — #1949), and `permissions.deny` must carry
+ *      WebFetch/WebSearch (so the model reaches for webkite).
+ *
+ * Filesystem access is dependency-injected so unit tests drive every
+ * branch without a real scaffold tree (mirrors `doctor-drive.ts`). The
+ * EACCES/EPERM split is load-bearing: scaffold artifacts are
+ * agent-UID-owned 0600 and the host operator running `doctor` (without
+ * sudo) cannot read them — that must read as `skip`, never `fail`.
+ */
+
+import {
+  existsSync as realExistsSync,
+  readFileSync as realReadFileSync,
+  readdirSync as realReaddirSync,
+  openSync as realOpenSync,
+  readSync as realReadSync,
+  closeSync as realCloseSync,
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+import { resolveAgentsDir } from "../config/loader.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+export interface WebkiteProbeDeps {
+  /** Home dir override (tests). Defaults to os.homedir(). */
+  homeDir?: string;
+  /** Defaults to `resolveAgentsDir(config)`, resolved lazily + guarded. */
+  agentsDir?: string;
+  existsSync?: (p: string) => boolean;
+  readFileSync?: (p: string) => string;
+  readdirSync?: (p: string) => string[];
+  /** Read the first `n` bytes of a file (for the ELF-header arch probe). */
+  readHead?: (p: string, n: number) => Buffer | null;
+}
+
+interface ResolvedDeps {
+  homeDir: string;
+  agentsDir: string | undefined;
+  existsSync: (p: string) => boolean;
+  readFileSync: (p: string) => string;
+  readdirSync: (p: string) => string[];
+  readHead: (p: string, n: number) => Buffer | null;
+}
+
+function defaultReadHead(p: string, n: number): Buffer | null {
+  let fd: number | undefined;
+  try {
+    fd = realOpenSync(p, "r");
+    const buf = Buffer.alloc(n);
+    const read = realReadSync(fd, buf, 0, n, 0);
+    return buf.subarray(0, read);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try { realCloseSync(fd); } catch { /* ignore */ }
+    }
+  }
+}
+
+function resolveDeps(config: SwitchroomConfig, deps: WebkiteProbeDeps): ResolvedDeps {
+  let agentsDir = deps.agentsDir;
+  if (agentsDir === undefined) {
+    try {
+      agentsDir = resolveAgentsDir(config);
+    } catch {
+      agentsDir = undefined;
+    }
+  }
+  return {
+    homeDir: deps.homeDir ?? homedir(),
+    agentsDir,
+    existsSync: deps.existsSync ?? ((p) => realExistsSync(p)),
+    readFileSync: deps.readFileSync ?? ((p) => realReadFileSync(p, "utf-8")),
+    readdirSync: deps.readdirSync ?? ((p) => realReaddirSync(p)),
+    readHead: deps.readHead ?? defaultReadHead,
+  };
+}
+
+/** ELF header classification of the staged binary. */
+type ArchVerdict = "elf-x64" | "elf-other-arch" | "not-elf" | "unreadable";
+
+function classifyArch(d: ResolvedDeps, path: string): ArchVerdict {
+  const head = d.readHead(path, 20);
+  if (head === null || head.length < 20) return "unreadable";
+  // ELF magic: 0x7F 'E' 'L' 'F'
+  if (!(head[0] === 0x7f && head[1] === 0x45 && head[2] === 0x4c && head[3] === 0x46)) {
+    return "not-elf"; // e.g. a Mach-O (macOS) build — the arm64 mistake
+  }
+  // e_machine is a 16-bit LE field at offset 18. 0x3E = EM_X86_64.
+  const eMachine = head[18]! | (head[19]! << 8);
+  return eMachine === 0x3e ? "elf-x64" : "elf-other-arch";
+}
+
+function webkiteEnabled(config: SwitchroomConfig, agent: string): boolean {
+  const mcp = (config.agents?.[agent] as { mcp_servers?: Record<string, unknown> } | undefined)
+    ?.mcp_servers;
+  return (mcp ?? {})["webkite"] !== false;
+}
+
+/**
+ * Run all webkite checks. Returns [] only when EVERY agent has opted
+ * out of webkite (so the section stays silent on installs that don't
+ * use it). On the default fleet (webkite on) it always emits.
+ */
+export function runWebkiteChecks(
+  config: SwitchroomConfig,
+  deps: WebkiteProbeDeps = {},
+): CheckResult[] {
+  const agents = Object.keys(config.agents ?? {});
+  const enabledAgents = agents.filter((a) => webkiteEnabled(config, a));
+  if (enabledAgents.length === 0) return [];
+
+  const d = resolveDeps(config, deps);
+  const results: CheckResult[] = [];
+
+  // ── 1. binary present + arch ──────────────────────────────────────
+  const binPath = join(d.homeDir, ".switchroom", "bin", "webkite");
+  if (!d.existsSync(binPath)) {
+    results.push({
+      name: "webkite: binary",
+      status: "warn",
+      detail: `not staged at ${binPath} — agents run in degraded "no-webkite" mode (native WebFetch kept by the fail-safe gate)`,
+      fix: "Stage the private-beta binary: cp <webkite> ~/.switchroom/bin/webkite && chmod +x; then `switchroom update`.",
+    });
+  } else {
+    const arch = classifyArch(d, binPath);
+    if (arch === "elf-x64") {
+      results.push({ name: "webkite: binary", status: "ok", detail: `staged, linux x86-64 ELF (${binPath})` });
+    } else if (arch === "unreadable") {
+      results.push({ name: "webkite: binary", status: "skip", detail: `present but unreadable by the operator — re-run doctor without sudo` });
+    } else if (arch === "not-elf") {
+      results.push({
+        name: "webkite: binary",
+        status: "fail",
+        detail: `${binPath} is not a Linux ELF binary (likely a macOS/other-OS build) — it cannot run in the agent container`,
+        fix: "Replace with a linux x86-64 build (static musl preferred). See the webkite release artifacts.",
+      });
+    } else {
+      results.push({
+        name: "webkite: binary",
+        status: "fail",
+        detail: `${binPath} is an ELF binary for the wrong CPU arch (not x86-64) — it cannot run in the agent container`,
+        fix: "Replace with a linux x86-64 (amd64) build.",
+      });
+    }
+  }
+
+  // ── 2. cloakbrowser local render ──────────────────────────────────
+  const cloakDir = join(d.homeDir, ".cloakbrowser");
+  let chromeFound = false;
+  if (d.existsSync(cloakDir)) {
+    try {
+      for (const entry of d.readdirSync(cloakDir)) {
+        if (entry.startsWith("chromium-") && d.existsSync(join(cloakDir, entry, "chrome"))) {
+          chromeFound = true;
+          break;
+        }
+      }
+    } catch { /* unreadable dir — fall through to the not-found branch */ }
+  }
+  if (chromeFound) {
+    results.push({ name: "webkite: cloakbrowser", status: "ok", detail: "stealth Chromium present (local render available)" });
+  } else {
+    results.push({
+      name: "webkite: cloakbrowser",
+      status: "warn",
+      detail: "no local stealth Chromium at ~/.cloakbrowser/chromium-*/chrome — webkite can only cloud-render (Cloudflare/Firecrawl) and will fail bot-gated sites with no local fallback",
+      fix: "Install once on the host: XDG_DATA_HOME=~/.switchroom/webkite-share webkite setup --yes cloakbrowser",
+    });
+  }
+
+  // ── 3. per-agent scaffold wiring ──────────────────────────────────
+  if (d.agentsDir === undefined) {
+    results.push({
+      name: "webkite: scaffold",
+      status: "warn",
+      detail: "agents_dir unresolved (no switchroom.agents_dir) — cannot verify per-agent webkite wiring",
+    });
+    return results;
+  }
+
+  for (const agent of enabledAgents) {
+    const agentDir = join(d.agentsDir, agent);
+    const settingsPath = join(agentDir, ".claude", "settings.json");
+    const mcpPath = join(agentDir, ".mcp.json");
+    if (!d.existsSync(settingsPath) && !d.existsSync(mcpPath)) {
+      // Agent not scaffolded yet — silent (apply will scaffold it).
+      continue;
+    }
+
+    let settings: { permissions?: { allow?: string[]; deny?: string[] } } | null = null;
+    let mcp: { mcpServers?: Record<string, unknown> } | null = null;
+    let unreadable = false;
+    for (const [path, set] of [
+      [settingsPath, (v: unknown) => { settings = v as typeof settings; }],
+      [mcpPath, (v: unknown) => { mcp = v as typeof mcp; }],
+    ] as const) {
+      if (!d.existsSync(path)) continue;
+      try {
+        set(JSON.parse(d.readFileSync(path)));
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code;
+        if (code === "EACCES" || code === "EPERM") { unreadable = true; }
+        // corrupt/other → leave as null, handled below
+      }
+    }
+
+    if (unreadable) {
+      results.push({
+        name: `webkite: ${agent} scaffold`,
+        status: "skip",
+        detail: "scaffold files are agent-UID-owned (0600) — re-run doctor without sudo to read them",
+      });
+      continue;
+    }
+
+    const mcpHasWebkite = !!(mcp && (mcp as { mcpServers?: Record<string, unknown> }).mcpServers?.["webkite"]);
+    const allow = (settings as { permissions?: { allow?: string[] } } | null)?.permissions?.allow ?? [];
+    const deny = (settings as { permissions?: { deny?: string[] } } | null)?.permissions?.deny ?? [];
+    const allowOk = allow.includes("mcp__webkite__*");
+    const denyOk = deny.includes("WebFetch");
+
+    const problems: string[] = [];
+    if (!mcpHasWebkite) problems.push(".mcp.json missing the webkite entry");
+    if (!allowOk) problems.push("permissions.allow missing mcp__webkite__* (first fetch will prompt)");
+    if (!denyOk) problems.push("permissions.deny missing WebFetch (native fetch not disabled)");
+
+    if (problems.length === 0) {
+      results.push({ name: `webkite: ${agent} scaffold`, status: "ok", detail: "wired + pre-approved + WebFetch denied" });
+    } else {
+      results.push({
+        name: `webkite: ${agent} scaffold`,
+        status: "warn",
+        detail: problems.join("; "),
+        fix: "Run `switchroom apply` (or `switchroom agent restart <agent>`) to re-scaffold the webkite wiring.",
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -31,6 +31,7 @@ import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runHostdChecks } from "./doctor-hostd.js";
 import { runDriveChecks, runDriveBrokerReachabilityChecks } from "./doctor-drive.js";
+import { runWebkiteChecks } from "./doctor-webkite.js";
 import { runMicrosoftChecks } from "./doctor-microsoft.js";
 import { runNotionChecks } from "./doctor-notion.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
@@ -2603,6 +2604,7 @@ export function registerDoctorCommand(program: Command): void {
             }),
           },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath, config) },
+          { title: "Webkite", results: runWebkiteChecks(config) },
         ];
 
         // Repo Hygiene (#1072): only when doctor runs from a switchroom


### PR DESCRIPTION
## Summary

Webkite is the fleet-default web fetcher now (#1941/#1944/#1949), so operators need upfront health visibility. New `doctor` **Webkite** section converts the three silent-failure classes the rollout hit into operator-visible lines.

## Checks

| Check | Catches |
|---|---|
| **binary** | Reads the ELF header of `~/.switchroom/bin/webkite`. Non-ELF (macOS Mach-O) or wrong-CPU (arm64) → **FAIL**. This is exactly the class the v0.13.62 canary caught the hard way — now a one-line preflight. Absent → WARN (degraded no-webkite mode). |
| **cloakbrowser** | `~/.cloakbrowser/chromium-*/chrome` present → local render; absent → WARN (cloud-only). |
| **per-agent scaffold** | `.mcp.json` has webkite + `permissions.allow` pre-approves `mcp__webkite__*` (the #1949 wedge regression) + `permissions.deny` has WebFetch. Agent-UID-owned 0600 files unreadable by the host operator → **SKIP, never FAIL** (no-sudo doctor discipline). |

## Live output (v0.13.65 fleet)
```
Webkite
  ✓ webkite: binary  (staged, linux x86-64 ELF)
  ✓ webkite: cloakbrowser  (stealth Chromium present)
  – webkite: <agent> scaffold  (agent-UID-owned 0600 — re-run without sudo)  ×9
```

## Tests
10 unit tests, FS dependency-injected: macho→fail, arm64→fail, x64→ok, cloakbrowser present/absent, allow-missing→warn, EACCES→skip, all-opted-out→[].

## Test plan
- [x] tsc clean; 10 doctor-webkite tests pass
- [x] Live-verified against the fleet
- [ ] CI green
- [ ] Reviewer APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)