### PR TITLE
fix(gateway): suppress composite silent-noise leak (Sent. + NO_REPLY)

### DIFF
--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -52,7 +52,7 @@ describe('isCompositeSilentNoise — Stop-hook re-prompt leak backstop', () => {
 describe('decideTurnFlush — composite silent noise is skipped, not leaked', () => {
   it('skips "Sent.\\nNO_REPLY\\nNO_REPLY" (the live clerk/test-harness leak)', () => {
     const d = decideTurnFlush({
-      chatId: '8248703757',
+      chatId: '12345',
       replyCalled: false,
       capturedText: ['Sent.', 'NO_REPLY', 'NO_REPLY'],
     })
@@ -60,7 +60,7 @@ describe('decideTurnFlush — composite silent noise is skipped, not leaked', ()
   })
   it('still flushes genuine trailing answer text', () => {
     const d = decideTurnFlush({
-      chatId: '8248703757',
+      chatId: '12345',
       replyCalled: false,
       capturedText: ['The page summarises three news stories.'],
     })

--- a/telegram-plugin/tests/turn-flush-safety.test.ts
+++ b/telegram-plugin/tests/turn-flush-safety.test.ts
@@ -17,8 +17,56 @@ import { describe, it, expect } from 'vitest'
 import {
   decideTurnFlush,
   isSilentFlushMarker,
+  isCompositeSilentNoise,
   isTurnFlushSafetyEnabled,
 } from '../turn-flush-safety.js'
+
+describe('isCompositeSilentNoise — Stop-hook re-prompt leak backstop', () => {
+  it('suppresses the observed leak "Sent.\\nNO_REPLY\\nNO_REPLY"', () => {
+    expect(isCompositeSilentNoise('Sent.\nNO_REPLY\nNO_REPLY')).toBe(true)
+  })
+  it('suppresses repeated bare markers and marker+confirmation variants', () => {
+    expect(isCompositeSilentNoise('NO_REPLY\nNO_REPLY')).toBe(true)
+    expect(isCompositeSilentNoise('Done\nNO_REPLY')).toBe(true)
+    expect(isCompositeSilentNoise('NO_REPLY\nHEARTBEAT_OK')).toBe(true)
+  })
+  it('requires at least one real marker — standalone confirmations still flush', () => {
+    // Conservative: no NO_REPLY/HEARTBEAT_OK present → NOT suppressed here,
+    // so we never silently drop a turn that wasn\'t already signalling silence.
+    expect(isCompositeSilentNoise('Sent.')).toBe(false)
+    expect(isCompositeSilentNoise('Done.\nOK')).toBe(false)
+  })
+  it('does NOT suppress real content glued to a marker', () => {
+    expect(
+      isCompositeSilentNoise('Here is the summary of the page.\nNO_REPLY'),
+    ).toBe(false)
+    expect(isCompositeSilentNoise('NO_REPLY\nThe answer is 42.')).toBe(false)
+  })
+  it('handles non-strings / empty safely', () => {
+    expect(isCompositeSilentNoise(undefined)).toBe(false)
+    expect(isCompositeSilentNoise('')).toBe(false)
+    expect(isCompositeSilentNoise('   \n  ')).toBe(false)
+  })
+})
+
+describe('decideTurnFlush — composite silent noise is skipped, not leaked', () => {
+  it('skips "Sent.\\nNO_REPLY\\nNO_REPLY" (the live clerk/test-harness leak)', () => {
+    const d = decideTurnFlush({
+      chatId: '8248703757',
+      replyCalled: false,
+      capturedText: ['Sent.', 'NO_REPLY', 'NO_REPLY'],
+    })
+    expect(d).toEqual({ kind: 'skip', reason: 'silent-marker' })
+  })
+  it('still flushes genuine trailing answer text', () => {
+    const d = decideTurnFlush({
+      chatId: '8248703757',
+      replyCalled: false,
+      capturedText: ['The page summarises three news stories.'],
+    })
+    expect(d.kind).toBe('flush')
+  })
+})
 
 describe('decideTurnFlush', () => {
   it('(a) does NOT flush when the reply tool was called', () => {

--- a/telegram-plugin/turn-flush-safety.ts
+++ b/telegram-plugin/turn-flush-safety.ts
@@ -50,6 +50,48 @@ export function isSilentFlushMarker(text: string | undefined): boolean {
   return SILENT_MARKERS.has(trimmed.toUpperCase())
 }
 
+// Trivial end-of-turn confirmations the model emits as terminal text after
+// calling reply (e.g. "Sent." once the reply tool returns). On their own
+// they're harmless; the danger is when they're glued to silent markers
+// across Stop-hook re-prompt cycles into a composite blob like
+// "Sent.\nNO_REPLY\nNO_REPLY" — which `isSilentFlushMarker` can't match
+// (multi-line, over the length guard) so it leaks to chat. See
+// `isCompositeSilentNoise`.
+const TRIVIAL_CONFIRMATIONS = new Set(['SENT', 'DONE', 'OK', 'OKAY', 'ACK'])
+
+function isTrivialConfirmationLine(line: string): boolean {
+  let t = line.trim()
+  if (t.length === 0 || t.length > 8) return false
+  if (/\W$/.test(t)) t = t.slice(0, -1) // strip a single trailing punct ("Sent.")
+  return TRIVIAL_CONFIRMATIONS.has(t.toUpperCase())
+}
+
+/**
+ * Recognise a multi-line composite that is *entirely* silent noise — every
+ * non-empty line is a silent marker (NO_REPLY / HEARTBEAT_OK) or a trivial
+ * confirmation ("Sent."), AND at least one line is a real silent marker.
+ *
+ * Backstop for the Stop-hook re-prompt leak: the model replies cleanly,
+ * emits a terminal "Sent.", gets re-prompted by the silent-end Stop hook,
+ * answers "NO_REPLY" one or more times, and the accumulated `capturedText`
+ * ("Sent.\nNO_REPLY\nNO_REPLY") flushes as a visible message because
+ * `isSilentFlushMarker` only matches a single sentinel. Requiring ≥1 hard
+ * marker keeps this conservative — a standalone "Sent." (no NO_REPLY) is NOT
+ * suppressed here, so we never silently drop a turn that wasn't already
+ * signalling "nothing to add".
+ */
+export function isCompositeSilentNoise(text: string | undefined): boolean {
+  if (typeof text !== 'string') return false
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0)
+  if (lines.length === 0) return false
+  const hasMarker = lines.some(l => isSilentFlushMarker(l))
+  if (!hasMarker) return false
+  return lines.every(l => isSilentFlushMarker(l) || isTrivialConfirmationLine(l))
+}
+
 export type FlushDecision =
   | { kind: 'flush'; text: string }
   | { kind: 'skip'; reason: FlushSkipReason }
@@ -115,6 +157,11 @@ export function decideTurnFlush(input: FlushDecisionInput): FlushDecision {
   const joined = input.capturedText.join('\n').trim()
   if (joined.length === 0) return { kind: 'skip', reason: 'empty-text' }
   if (isSilentFlushMarker(joined)) return { kind: 'skip', reason: 'silent-marker' }
+  // Composite silent noise — e.g. "Sent.\nNO_REPLY\nNO_REPLY" accumulated
+  // across Stop-hook re-prompt cycles. The single-sentinel check above
+  // misses it (multi-line, over the length guard); without this the blob
+  // leaks to chat as a visible message.
+  if (isCompositeSilentNoise(joined)) return { kind: 'skip', reason: 'silent-marker' }
   return { kind: 'flush', text: joined }
 }
 


### PR DESCRIPTION
## Summary

Live bug on test-harness + clerk: after a clean reply, the bot leaks a `Sent.\nNO_REPLY\nNO_REPLY` blob as a **visible chat message**, once per turn.

**Mechanism** (confirmed via JSONL + gateway log):
1. Model calls `reply` (real answer delivered) → emits trailing `text: "Sent."`
2. silent-end Stop hook re-prompts → model answers `NO_REPLY` (correctly)
3. re-prompts again → `NO_REPLY` again
4. accumulated `capturedText = "Sent.\nNO_REPLY\nNO_REPLY"` (23 chars) hits turn-flush → leaks (`turn-flush firing — 23 chars` in the log)

**Root cause:** `isSilentFlushMarker` only exact-matches a *single* sentinel; the multi-line 23-char composite exceeds the `SILENT_MARKER_MAX_LEN` (13) guard, so it's not recognised as silent.

## Fix
New `isCompositeSilentNoise(text)` — suppresses a multi-line blob whose non-empty lines are **all** silent markers (`NO_REPLY`/`HEARTBEAT_OK`) or trivial confirmations (`Sent.`/`Done.`/`OK`), **and at least one is a real marker**. The ≥1-marker requirement is conservative: a standalone `Sent.` is NOT suppressed, so we never silently drop a turn that wasn't already signalling silence. Wired into `decideTurnFlush` after the existing single-sentinel check.

## Not in scope (follow-up)
The deeper cause is the silent-end Stop hook re-prompting a turn that **already** delivered a clean reply (3 wasted model cycles/turn). That's a `finalAnswerDelivered`/Stop-hook change, riskier — this PR is the robust backstop for the user-visible leak.

## Test plan
- [x] 8 new unit tests (29 in `turn-flush-safety.test.ts`); tsc clean
- [ ] mtcute UAT after deploy: drive multi-tool turns, confirm no `NO_REPLY` bubble leaks

## Risk
Low — pure-function suppression, additive after the existing checks. Only suppresses blobs that contain a real silent marker; genuine answer text (even glued to a marker) still flushes (tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)