### PR TITLE
feat(gateway): draft-mirror Phase 2 — accumulating feed + Telegram format

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -58,6 +58,7 @@ import {
   makeEmptyActivityState,
   registerAndRender,
   describeToolUse,
+  appendActivityLine,
   type ActivityState,
 } from '../tool-activity-summary.js'
 import { toolLabel } from '../tool-labels.js'
@@ -1338,6 +1339,11 @@ type CurrentTurn = {
   activityInFlight: Promise<void> | null
   activityPendingRender: string | null
   activityLastSentRender: string | null
+  // Draft-mirror Phase 2: accumulating friendly-action feed for this turn
+  // (DRAFT_MIRROR only). Each non-surface tool_use appends a line via
+  // `appendActivityLine`; the feed renders as a capped chronological list
+  // in the ephemeral draft and clears on reply. Reset per turn.
+  mirrorLines: string[]
   // Issue #195 — answer-lane streaming. Lazily created on the first text
   // event of a turn (once enough text has accumulated, the stream itself
   // gates on minInitialChars). Materialized and cleared at turn_end.
@@ -7001,6 +7007,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           activityInFlight: null,
           activityPendingRender: null,
           activityLastSentRender: null,
+          mirrorLines: [],
           answerStream: null,
           isDm: isDmChatId(ev.chatId),
         }
@@ -7146,11 +7153,12 @@ function handleSessionEvent(ev: SessionEvent): void {
       // exactly once at a time and re-running until pending matches
       // the last-sent. Captures `turn` so a late drain after turn-swap
       // can't corrupt the next turn's atom.
-      // DRAFT_MIRROR (RFC draft-mirror-preview): render each tool_use as a
-      // human-friendly line in the live preview, using the model-authored
-      // descriptive field (Bash.description, Read/Edit file basename,
-      // hindsight→"Searching memory", etc. — see describeToolUse). Latest
-      // action wins (the draft shows "doing X" live), clears on reply.
+      // DRAFT_MIRROR (RFC draft-mirror-preview): accumulate each tool_use
+      // into a human-friendly running feed in the live preview, using the
+      // model-authored descriptive field (Bash.description, Read/Edit file
+      // basename, hindsight→"Searching memory", etc. — see describeToolUse
+      // / appendActivityLine). The draft shows the turn's actions as a
+      // capped chronological list (Claude Code-style), clears on reply.
       // Never surfaces raw shell/query syntax — option A, uniform across
       // code + non-code agents.
       //
@@ -7159,7 +7167,7 @@ function handleSessionEvent(ev: SessionEvent): void {
       // pre-draft-mirror behavior.
       if (!turn.replyCalled && !isTelegramSurfaceTool(name)) {
         const rendered = DRAFT_MIRROR_ENABLED
-          ? describeToolUse(name, ev.input)
+          ? appendActivityLine(turn.mirrorLines, name, ev.input)
           : registerAndRender(turn.toolActivity, name)
         if (rendered != null) {
           turn.activityPendingRender = rendered

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -6,6 +6,9 @@ import {
   registerAndRender,
   verbForTool,
   describeToolUse,
+  appendActivityLine,
+  renderActivityFeed,
+  MIRROR_MAX_LINES,
 } from "../tool-activity-summary.js";
 
 describe("describeToolUse — friendly per-tool rendering (draft-mirror)", () => {
@@ -281,5 +284,47 @@ describe("registerAndRender — ergonomic full-pipeline call", () => {
     ).toBeNull();
     // State unchanged
     expect(s.firstToolName).toBeNull();
+  });
+});
+
+describe("appendActivityLine + renderActivityFeed — accumulating draft feed", () => {
+  it("accumulates distinct actions chronologically (newest last)", () => {
+    const lines: string[] = [];
+    expect(appendActivityLine(lines, "Read", { file_path: "a/gateway.ts" })).toBe(
+      "· Reading gateway.ts",
+    );
+    expect(appendActivityLine(lines, "mcp__hindsight__reflect", { query: "x" })).toBe(
+      "· Reading gateway.ts\n· Searching memory",
+    );
+    expect(appendActivityLine(lines, "Bash", { command: "ls", description: "List workspace" })).toBe(
+      "· Reading gateway.ts\n· Searching memory\n· List workspace",
+    );
+  });
+
+  it("collapses consecutive exact-duplicate lines", () => {
+    const lines: string[] = [];
+    appendActivityLine(lines, "Read", { file_path: "a.ts" });
+    appendActivityLine(lines, "Read", { file_path: "a.ts" }); // dup → collapsed
+    expect(lines).toEqual(["Reading a.ts"]);
+  });
+
+  it("returns null (no feed update) for surface tools", () => {
+    const lines: string[] = [];
+    expect(appendActivityLine(lines, "mcp__switchroom-telegram__reply", { text: "hi" })).toBeNull();
+    expect(lines).toEqual([]);
+  });
+
+  it("caps to the last MIRROR_MAX_LINES with a '+N earlier' header", () => {
+    const lines = Array.from({ length: 9 }, (_, i) => `Action ${i + 1}`);
+    const out = renderActivityFeed(lines)!;
+    expect(out.startsWith("· +3 earlier…\n")).toBe(true);
+    // Only the last 6 actions are shown.
+    expect(out).toContain("· Action 4");
+    expect(out).toContain("· Action 9");
+    expect(out).not.toContain("· Action 3\n");
+  });
+
+  it("renderActivityFeed returns null on empty", () => {
+    expect(renderActivityFeed([])).toBeNull();
   });
 });

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -335,3 +335,50 @@ export function describeToolUse(
       return "Working…";
   }
 }
+
+// ─── Accumulating activity feed (draft-mirror Phase 2) ──────────────────────
+//
+// Phase 1 showed only the latest action; this accumulates the turn's actions
+// into a running feed — like Claude Code's own UI — streamed into the
+// ephemeral draft and cleared on reply. Chronological (oldest first, newest
+// last), consecutive exact-duplicates collapsed, capped to the most recent
+// MIRROR_MAX_LINES with a "+N earlier" header so a heavy turn stays readable
+// inside Telegram's compose-area draft.
+
+export const MIRROR_MAX_LINES = 6;
+
+/**
+ * Append a tool_use's friendly line to the running feed (mutates `lines`)
+ * and return the rendered draft body — or null when the tool is a surface
+ * tool / produced no line (caller skips the draft update).
+ *
+ * Dedups only consecutive identical lines (e.g. a burst of parallel Reads of
+ * the same file) so distinct actions are all preserved.
+ */
+export function appendActivityLine(
+  lines: string[],
+  toolName: string,
+  input: Record<string, unknown> | undefined,
+): string | null {
+  const line = describeToolUse(toolName, input);
+  if (line == null) return null;
+  if (lines.length === 0 || lines[lines.length - 1] !== line) {
+    lines.push(line);
+  }
+  return renderActivityFeed(lines);
+}
+
+/**
+ * Render the accumulated feed as a plain-text block (one action per line).
+ * The caller HTML-escapes + wraps it for Telegram. Returns null when empty.
+ *
+ * Newest-last chronological order; capped to the last MIRROR_MAX_LINES with a
+ * dim "+N earlier" header when the turn ran longer.
+ */
+export function renderActivityFeed(lines: string[]): string | null {
+  if (lines.length === 0) return null;
+  const shown = lines.slice(-MIRROR_MAX_LINES);
+  const hidden = lines.length - shown.length;
+  const body = shown.map((l) => `· ${l}`).join("\n");
+  return hidden > 0 ? `· +${hidden} earlier…\n${body}` : body;
+}


### PR DESCRIPTION
## Summary
Phase 2 of the draft-mirror (still behind `SWITCHROOM_DRAFT_MIRROR`, default OFF). Phase 1 showed only the latest action; Phase 2 accumulates the turn's actions into a running Claude-Code-style feed in the ephemeral draft, with proper Telegram formatting.

- `appendActivityLine` / `renderActivityFeed` — chronological list (newest last), `· ` bullets, consecutive exact-dupes collapsed, capped to last 6 with `· +N earlier…` header.
- gateway `case 'tool_use'`: per-turn `mirrorLines` accumulator. `drainActivitySummary` HTML-escapes + wraps the block in `<i>…</i>` (parse_mode HTML) → clean multi-line italic list; newlines render as breaks.
- Flag-OFF path byte-identical (registerAndRender verb-counts).

## Test plan
- [x] 34 tests in `tool-activity-summary.test.ts` (5 new: accumulation order, dedup, surface-skip, cap+header, empty); tsc / bot-api-wrapping / plugin-references clean
- [ ] mtcute UAT after deploy: multi-tool turn shows the accumulating feed, renders cleanly in Telegram, clears on reply

## Risk
Low (flag default-off, flag-off byte-identical). Escaping prevents the literal-tag class; cap prevents unbounded draft growth.