### PR TITLE
docs(web): fix stale claude -p reference in webhook-handler JSDoc

### DIFF
--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -90,8 +90,11 @@ export interface WebhookHandlerArgs {
   /**
    * Optional dispatch rules from `channels.telegram.webhook_dispatch`.
    * When present, verified events are evaluated against the rules and
-   * matching ones spawn one-shot `claude -p` turns. Passed through to
-   * the dispatch evaluator; the ingest path itself does not consume it.
+   * matching ones are delivered as synthesized `inject_inbound` turns to
+   * the agent's interactive `claude` session (never headless `claude -p`,
+   * which is programmatic usage under Anthropic's 2026-06-15 policy).
+   * Passed through to the dispatch evaluator; the ingest path itself does
+   * not consume it.
    */
   dispatchConfig?: WebhookDispatchConfig
 }


### PR DESCRIPTION
## Summary

Fixes the one new drift item Phase 4 re-verify found: `src/web/webhook-handler.ts:93` JSDoc on `WebhookHandlerOpts.dispatchConfig` still said matched webhook events "spawn one-shot `claude -p` turns."

## Why

`src/web/webhook-dispatch.ts` already delivers matched events as synthesized `inject_inbound` turns into the agent's interactive `claude` session, and explicitly documents "No `claude -p`" (it's programmatic usage under the 2026-06-15 policy). This handler comment was stale from before the eliminate-claude-p migration — exactly the misleading-comment class the drift audit targets.

## Change

Comment-only. Updated the JSDoc to describe the actual `inject_inbound` mechanism.

## Verification

- [ ] Comment-only; no behavior change. Local tsc/vitest deferred to CI (no toolchain on orchestrator host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)