### PR TITLE
fix(gateway): cut turn-in-flight gate to delivery machine (PR3b) — kills 5-min wedge

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -286,7 +286,7 @@ import { chatKey, chatKeyWithSuffix, chatIdOfChatKey } from './chat-key.js'
 // should do. Behavior unchanged in this PR — the imperative code below
 // still runs everything. PR 3 will cut over to executing the machine's
 // effects.
-import { shadowEmit } from './inbound-delivery-machine-shadow.js'
+import { shadowEmit, isMachineInTurn, isDeliveryCutoverEnabled } from './inbound-delivery-machine-shadow.js'
 import type { ChatKey as _ChatKey } from './inbound-delivery-machine.js'
 import { dispatchEffects, isDispatchEnabled } from './inbound-delivery-machine-dispatch.js'
 import { maybeFireWarmup } from './prefix-warmup.js'
@@ -1161,6 +1161,24 @@ function markClaudeBusyForInbound(m: {
   }
   claudeBusyKeys.add(chatKey(m.chatId, tid))
 }
+
+/**
+ * Authoritative "is a turn in flight?" for every gate that previously
+ * read `claudeBusyKeys.size`. PR 3b cutover (extends PR 3a's bridgeUp
+ * dispatch): when the delivery state machine is authoritative
+ * (`SWITCHROOM_DELIVERY_MACHINE_CUTOVER` on + shadow on) the answer is
+ * its single-`activeTurn` global state, which — unlike the
+ * per-delivery `claudeBusyKeys` set — cannot accumulate orphan keys and
+ * wedge the gate "in-flight forever" (the gymbro/clerk 5-min dangle,
+ * 2026-05-28). Kill-switch off → exact legacy claudeBusyKeys behaviour.
+ *
+ * NOT for the inbound-receipt gate (line ~8551): that must snapshot the
+ * machine state BEFORE the inbound event advances it, or a fresh-turn
+ * message self-blocks. See the snapshot at the inbound handler.
+ */
+function turnInFlightForGate(): boolean {
+  return isDeliveryCutoverEnabled() ? isMachineInTurn() : claudeBusyKeys.size > 0
+}
 const pendingRestarts = new Map<string, number>()  // agentName -> timestamp when restart was requested
 
 // ─── Proactive context compaction (session.max_context_tokens) ──────────
@@ -1490,7 +1508,11 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
   // activeTurnStartedAt entry in the fresh-turn branch) doesn't pin this
   // gate forever while claude is genuinely idle. See the claudeBusyKeys
   // declaration for the supergroup deadlock this fixes.
-  if (claudeBusyKeys.size === 0) {
+  // PR3b-cutover: `turnInFlightForGate()` reads the delivery machine
+  // when the cutover kill-switch is on; the turnEnd event was emitted
+  // just above (purgeReactionTracking head), so the machine is already
+  // idle here.
+  if (!turnInFlightForGate()) {
     // #1556: the deterministic delivery point. claude has just gone
     // idle — flush any inbound held mid-turn so the channel
     // notification lands at the idle prompt and submits as a fresh
@@ -1590,7 +1612,9 @@ function releaseTurnBufferGate(key: string): void {
   // test-harness's 13:02 UAT now opens after the reply.
   //
   // PR3b: gated on claudeBusyKeys (see purgeReactionTracking comment).
-  if (claudeBusyKeys.size === 0) {
+  // PR3b-cutover: turnEnd was emitted just above (releaseTurnBufferGate
+  // head), so the machine is already idle when the cutover gate reads.
+  if (!turnInFlightForGate()) {
     const selfAgentForFlush = process.env.SWITCHROOM_AGENT_NAME ?? ''
     if (pendingInboundBuffer.depth(selfAgentForFlush) > 0) {
       const fr = redeliverBufferedInbound(
@@ -3656,6 +3680,23 @@ silencePoke.startTimer({
   },
 })
 
+// PR3b-cutover: drive the delivery machine's TTL `tick`. The machine
+// expires any turn whose `turnStartedAt` is older than TURN_TTL_MS
+// (5 min) and drops global state back to idle — its structural
+// equivalent of the imperative silence-poke framework-fallback. This
+// is the load-bearing safety net for the cutover gate: even if a
+// `turnEnd` event is somehow missed (the dangle class), the machine
+// self-heals at TTL instead of pinning the gate "in-flight forever".
+// shadowEmit only advances state + logs the predicted effects; we
+// deliberately do NOT execute the machine's firePoke here (the
+// imperative silence-poke still owns the user-facing ping), so there
+// is no double-poke. unref so the interval never holds the process.
+const DELIVERY_MACHINE_TICK_MS = 30_000
+const _deliveryMachineTick = setInterval(() => {
+  shadowEmit({ kind: 'tick', now: Date.now() })
+}, DELIVERY_MACHINE_TICK_MS)
+_deliveryMachineTick.unref?.()
+
 // #1445 cross-turn pending-async ambient. When a turn ends after the
 // model dispatched background async work (Agent / Task / Bash run-in-
 // background) and the model has stopped speaking, keep editing the
@@ -4195,7 +4236,8 @@ const ipcServer: IpcServer = createIpcServer({
     // PR3b: gated on claudeBusyKeys (actually-handed-to-claude turns)
     // not activeTurnStartedAt (receipt-eager), so a buffered topic-B
     // inbound doesn't pin this as turnInFlight=true forever.
-    const turnInFlight = claudeBusyKeys.size > 0;
+    // PR3b-cutover: reads the delivery machine when the kill-switch is on.
+    const turnInFlight = turnInFlightForGate();
 
     if (!turnInFlight) {
       // No active turn, restart immediately. Cycle both the agent and
@@ -4615,7 +4657,8 @@ if (!STATIC) {
         // #1556: never drain mid-turn — that re-creates the composer
         // wedge this buffer exists to prevent.
         // PR3b: gated on claudeBusyKeys (see purgeReactionTracking).
-        if (claudeBusyKeys.size > 0) return false
+        // PR3b-cutover: reads the delivery machine when the kill-switch is on.
+        if (turnInFlightForGate()) return false
         const c = ipcServer.getClient(selfAgent)
         return c != null && c.isAlive()
       },
@@ -5020,6 +5063,11 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // silence-poke clock so the next poke is measured from this send.
   signalTracker.noteOutbound(statusKey(chat_id, threadId), Date.now())
   silencePoke.noteOutbound(statusKey(chat_id, threadId), Date.now())
+  // PR3b-cutover: feed lastOutboundAt to the delivery machine so its
+  // TTL `tick` suppresses the fallback for a long-but-active turn
+  // (model streaming past 5 min) — parity with silencePoke's own
+  // suppression, so the cutover gate doesn't clear a live turn.
+  shadowEmit({ kind: 'modelOutbound', key: statusKey(chat_id, threadId) as _ChatKey, at: Date.now() })
   // #1741 — only clear silent-end state on a plausibly-final reply.
   // An interim ack (disable_notification:true, short text, no done)
   // must NOT clear the state file; otherwise a turn that ends with
@@ -5615,6 +5663,9 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       const sKey = statusKey(streamChatId, streamThreadId)
       signalTracker.noteOutbound(sKey, Date.now())
       silencePoke.noteOutbound(sKey, Date.now())
+      // PR3b-cutover: feed lastOutboundAt to the delivery machine (see
+      // executeReply) so its TTL tick suppresses an active-turn fallback.
+      shadowEmit({ kind: 'modelOutbound', key: sKey as _ChatKey, at: Date.now() })
       // #1741 — see executeReply for the rationale: only a plausibly-
       // final stream_reply clears the silent-end state. An interim
       // ack via stream_reply must NOT clear; the Stop hook needs
@@ -7012,6 +7063,20 @@ function handleSessionEvent(ev: SessionEvent): void {
           isDm: isDmChatId(ev.chatId),
         }
         currentTurn = next
+        // PR3b-cutover: feed the authoritative turn-start to the delivery
+        // machine. `enqueue` fires for EVERY turn atom regardless of
+        // source — inbound, cron, subagent-handback, vault-resume,
+        // restart-marker — so it is the single chokepoint that captures
+        // the non-inbound turns the machine's own `inbound` event never
+        // sees (those bypass handleInbound). Without it the machine reads
+        // idle during a cron/handback turn and the gate would mis-deliver
+        // a concurrent inbound mid-turn (the #1556 composer wedge).
+        // Idempotent when already in_turn (turnStart only sets perKey).
+        shadowEmit({
+          kind: 'turnStart',
+          key: statusKey(ev.chatId, ev.threadId != null ? Number(ev.threadId) : undefined) as _ChatKey,
+          at: startedAt,
+        })
         // #549 fix — fresh turn, reset preamble-suppression state.
         preambleSuppressor.reset()
         // Reset the silent-end retry budget for this chat. The stored
@@ -8505,6 +8570,14 @@ async function handleInbound(
   // vs mid-turn — its decision will be visible in the gw-trace shadow
   // line emitted to stderr.
   const _shadowKey = statusKey(ctx.chat?.id != null ? String(ctx.chat.id) : '0', ctx.message?.message_thread_id) as _ChatKey
+  // PR3b-cutover: snapshot the machine's in-turn state BEFORE the
+  // inbound event advances it. A fresh-turn inbound transitions the
+  // machine idle→in_turn; reading after the emit would see THIS
+  // message's own just-started turn and self-block it (the same
+  // self-block hazard the claudeBusyKeys snapshot below guards). When
+  // the kill-switch is off this is null and the gate uses the legacy
+  // claudeBusyKeys read.
+  const machineInTurnAtReceipt = isDeliveryCutoverEnabled() ? isMachineInTurn() : null
   shadowEmit({
     kind: 'inbound',
     key: _shadowKey,
@@ -8556,7 +8629,12 @@ async function handleInbound(
   // no turn_end ever fires). With claudeBusyKeys, B sees true (A is
   // busy) → B is buffered correctly, AND the gate cleanly reopens
   // when A's turn_end deletes keyA → flush triggers → B delivered.
-  const turnInFlightAtReceipt = claudeBusyKeys.size > 0
+  // PR3b-cutover: prefer the machine snapshot taken before the inbound
+  // event advanced it (machineInTurnAtReceipt); null when the
+  // kill-switch is off, in which case the legacy claudeBusyKeys read
+  // stands. Both are "was a turn in flight at receipt", not a live
+  // post-this-inbound read — see machineInTurnAtReceipt's comment.
+  const turnInFlightAtReceipt = machineInTurnAtReceipt ?? (claudeBusyKeys.size > 0)
 
   const access = result.access
   const from = ctx.from!

--- a/telegram-plugin/gateway/inbound-delivery-machine-shadow.ts
+++ b/telegram-plugin/gateway/inbound-delivery-machine-shadow.ts
@@ -43,6 +43,39 @@ import {
 let state: State = initialState()
 const enabled = process.env.SWITCHROOM_DELIVERY_MACHINE_SHADOW !== '0'
 
+// Phase 2b PR 3 — STAGED CUTOVER. When enabled, the gateway's
+// "is a turn in flight?" gate reads this machine's global state
+// instead of the PR3b `claudeBusyKeys` set. The machine tracks ONE
+// `activeTurn` (single bridge) plus TTL `tick` expiry, so — unlike a
+// per-delivery key set — it cannot accumulate orphan keys and wedge
+// the gate "in-flight forever" (the gymbro/clerk 5-min dangle of
+// 2026-05-28). Scope is the turn-in-flight GATE only; the poke ladder
+// and perm-verdict effects stay imperative for a follow-up PR.
+//
+// Kill switch: `SWITCHROOM_DELIVERY_MACHINE_CUTOVER=0` reverts every
+// gate to the legacy claudeBusyKeys read (zero behaviour change).
+// Requires shadow mode ON — with shadow off the machine state is
+// frozen and must NOT be read as authoritative.
+const cutoverEnabled = enabled && process.env.SWITCHROOM_DELIVERY_MACHINE_CUTOVER !== '0'
+
+/**
+ * True when the kill-switch leaves the delivery machine authoritative
+ * for the turn-in-flight gate. Gateway gate sites branch on this.
+ */
+export function isDeliveryCutoverEnabled(): boolean {
+  return cutoverEnabled
+}
+
+/**
+ * Authoritative "is a turn currently in flight?" read for the gate.
+ * Maps the machine's global state to the boolean the legacy
+ * `claudeBusyKeys.size > 0` gate produced. `bridge_dead` and
+ * `bridge_alive_idle` are both "not in flight".
+ */
+export function isMachineInTurn(): boolean {
+  return state.global.kind === 'bridge_alive_in_turn'
+}
+
 /**
  * Run an event through the state machine in shadow mode. The machine
  * state advances, the predicted effects are LOGGED, but no I/O fires.

--- a/telegram-plugin/tests/inbound-delivery-cutover-gate.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-cutover-gate.test.ts
@@ -1,0 +1,93 @@
+/**
+ * PR3b cutover — the turn-in-flight GATE now reads the delivery state
+ * machine (`isMachineInTurn`) instead of the PR3b `claudeBusyKeys` set.
+ *
+ * The bug this closes (gymbro/clerk, 2026-05-28): `claudeBusyKeys` is a
+ * per-delivery Set — every delivery `.add`s a key, but turn-end `.delete`s
+ * exactly one. When a turn-end is missed (or fires under a non-matching
+ * key) the set keeps an orphan, `size > 0` reads true forever, and EVERY
+ * subsequent inbound buffers as "held mid-turn" until the 5-min
+ * framework-fallback force-drains it.
+ *
+ * The machine cannot accumulate orphans: global state holds ONE
+ * `activeTurn`, so any matching turnEnd returns it to idle, and the TTL
+ * `tick` self-heals a missed turnEnd. These tests pin both the normal
+ * reopen and the dangle-recovery path on the accessors the gate reads.
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  shadowEmit,
+  isMachineInTurn,
+  isDeliveryCutoverEnabled,
+  __shadowResetForTests,
+} from '../gateway/inbound-delivery-machine-shadow.js'
+import { TURN_TTL_MS, type ChatKey } from '../gateway/inbound-delivery-machine.js'
+
+const KEY_A = '111:_' as ChatKey
+const KEY_B = '222:_' as ChatKey
+
+function inbound(key: ChatKey, at: number, msgId = 1) {
+  shadowEmit({ kind: 'inbound', key, msg: { msgId, isSteering: false, payload: null }, at })
+}
+
+describe('PR3b cutover gate accessors', () => {
+  beforeEach(() => __shadowResetForTests())
+
+  it('enabled by default (shadow on, no kill-switch in test env)', () => {
+    expect(isDeliveryCutoverEnabled()).toBe(true)
+  })
+
+  it('reads idle before any turn (bridge alive)', () => {
+    shadowEmit({ kind: 'bridgeUp', at: 1000 })
+    expect(isMachineInTurn()).toBe(false)
+  })
+
+  it('flips in-turn on a fresh inbound and reopens on turnEnd (the gate reopen)', () => {
+    shadowEmit({ kind: 'bridgeUp', at: 1000 })
+    inbound(KEY_A, 2000)
+    expect(isMachineInTurn()).toBe(true)
+    shadowEmit({ kind: 'turnEnd', key: KEY_A, at: 3000, outboundEmitted: true })
+    // Gate reopens immediately — this is the path claudeBusyKeys danged on.
+    expect(isMachineInTurn()).toBe(false)
+  })
+
+  it('self-heals a MISSED turnEnd via the TTL tick (the dangle the fix kills)', () => {
+    shadowEmit({ kind: 'bridgeUp', at: 1000 })
+    // Turn A starts via enqueue (turnStart), then turn B starts before A's
+    // turnEnd ever lands — the orphan scenario. The machine keeps
+    // activeTurn=A (turnStart is a no-op on global when already in_turn),
+    // so a later turnEnd(B) does NOT match and would leave A dangling.
+    shadowEmit({ kind: 'turnStart', key: KEY_A, at: 2000 })
+    shadowEmit({ kind: 'turnStart', key: KEY_B, at: 3000 })
+    shadowEmit({ kind: 'turnEnd', key: KEY_B, at: 4000, outboundEmitted: true })
+    // Without tick, the gate would still read in-turn (activeTurn=A stuck).
+    expect(isMachineInTurn()).toBe(true)
+    // TTL tick past A's start clears the orphan and reopens the gate —
+    // the structural guarantee claudeBusyKeys lacked.
+    shadowEmit({ kind: 'tick', now: 2000 + TURN_TTL_MS + 1 })
+    expect(isMachineInTurn()).toBe(false)
+  })
+
+  it('does NOT clear a long-but-ACTIVE turn (modelOutbound suppression)', () => {
+    shadowEmit({ kind: 'bridgeUp', at: 1000 })
+    shadowEmit({ kind: 'turnStart', key: KEY_A, at: 2000 })
+    // Model is still streaming just before the TTL boundary.
+    const justBeforeTtl = 2000 + TURN_TTL_MS - 5_000
+    shadowEmit({ kind: 'modelOutbound', key: KEY_A, at: justBeforeTtl })
+    // Tick past TTL — but recent outbound is within the suppression window,
+    // so the turn is NOT cleared (parity with the imperative silence-poke).
+    shadowEmit({ kind: 'tick', now: 2000 + TURN_TTL_MS + 1 })
+    expect(isMachineInTurn()).toBe(true)
+  })
+
+  it('a buffered sibling inbound does not change the active turn', () => {
+    shadowEmit({ kind: 'bridgeUp', at: 1000 })
+    inbound(KEY_A, 2000) // fresh turn A
+    inbound(KEY_B, 2500) // mid-turn — buffered, must NOT start a new turn
+    expect(isMachineInTurn()).toBe(true)
+    shadowEmit({ kind: 'turnEnd', key: KEY_A, at: 3000, outboundEmitted: true })
+    // A ended; nothing else active → gate reopens so B can drain.
+    expect(isMachineInTurn()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
The gymbro/clerk **"5-min silence" wedge** (live, 2026-05-28): every inbound buffered as `held mid-turn` for ~5 min until the silence-poke framework-fallback force-drained it — while claude sat **idle**. This cuts the turn-in-flight **gate** over to the already-shadow-validated delivery state machine, which structurally cannot exhibit the dangle.

## Why
The PR3b `claudeBusyKeys` gate is a **per-delivery Set**: each delivery `.add`s a key, turn-end `.delete`s exactly one. A missed or key-mismatched turn-end leaves an orphan → `size > 0` reads true forever → the **global** inbound gate holds every message on the agent. In gymbro's logs the shadow machine computed the correct state (`idle`) the entire time the live gate was wedged.

The machine holds a single `activeTurn` (cleared by any matching `turnEnd`) + TTL `tick` self-heal — it cannot accumulate orphans. This is **PR 3b** of the cutover, extending the merged **PR 3a** (`bridgeUp` dispatch). Same kill-switch.

## What changed
- 5 turn-in-flight gate sites (inbound-receipt, 2 idle-drains, self-restart, on-register drain) now read `isMachineInTurn()` when cutover is enabled; legacy `claudeBusyKeys.size` when off.
- Emit `turnStart` at the bridge `enqueue` chokepoint (captures cron / handback / vault-resume / restart turns the machine's `inbound` event misses — prevents a #1556 mis-deliver).
- Emit `modelOutbound` at the 2 outbound sites so the machine's tick suppresses the fallback for a long-but-**active** turn (parity with silence-poke).
- 30s `tick` driver (unref'd) — TTL self-heal safety net.
- Inbound-receipt gate snapshots machine state **before** the inbound event advances it (fresh-turn self-block guard).

Scope is the **gate only** — poke ladder + perm-verdict effects stay imperative for a follow-up PR.

## Kill switch
`SWITCHROOM_DELIVERY_MACHINE_CUTOVER=0` reverts every gate to the legacy `claudeBusyKeys` read (zero behaviour change). Requires shadow mode on; with shadow off the gate auto-falls-back.

## Test plan
- [x] `tsc --noEmit` clean; all 6 lint gates pass (no bot-api-wrapping allowlist drift)
- [x] new `inbound-delivery-cutover-gate.test.ts` (6): gate reopen, **dangle-recovery via tick**, active-turn suppression, sibling-buffer
- [x] 158 wedge/turn vitest + 62 bun gateway tests pass, machine property tests (5 invariants) pass
- [ ] mtcute UAT on test-harness: `jtbd-fast-trivial-dm`, `jtbd-always-on-after-restart-dm`, rapid multi-turn (gate-reopen)

## Risk
Touches the fleet's whole delivery gate. Mitigated by: env kill-switch, machine already shadow-validated in prod, gate-only scope, imperative paths untouched when flag off. Not auto-deployed (fleet on v0.13.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)