### PR TITLE
feat(gateway): draft-mirror real-time via PreToolUse sidecar (determinism fix)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -59,6 +59,7 @@ import {
   registerAndRender,
   describeToolUse,
   appendActivityLine,
+  appendActivityLabel,
   type ActivityState,
 } from '../tool-activity-summary.js'
 import { toolLabel } from '../tool-labels.js'
@@ -7195,7 +7196,12 @@ function handleSessionEvent(ev: SessionEvent): void {
         // empty draft to wipe the compose-area preview; for persisted
         // messages, delete. The user sees the real reply land in the
         // same beat the summary disappears.
-        if (wasFirstReply) {
+        // Legacy (flag-off): the activity summary clears on the first
+        // reply — it was a one-shot "what I did" line. DRAFT_MIRROR keeps
+        // the live feed running through mid-turn replies and clears it at
+        // turn_end instead, so an early reply doesn't wipe the stream
+        // (the fast-turn determinism fix).
+        if (wasFirstReply && !DRAFT_MIRROR_ENABLED) {
           clearActivitySummary(turn)
         }
       }
@@ -7218,22 +7224,19 @@ function handleSessionEvent(ev: SessionEvent): void {
       // exactly once at a time and re-running until pending matches
       // the last-sent. Captures `turn` so a late drain after turn-swap
       // can't corrupt the next turn's atom.
-      // DRAFT_MIRROR (RFC draft-mirror-preview): accumulate each tool_use
-      // into a human-friendly running feed in the live preview, using the
-      // model-authored descriptive field (Bash.description, Read/Edit file
-      // basename, hindsight→"Searching memory", etc. — see describeToolUse
-      // / appendActivityLine). The draft shows the turn's actions as a
-      // capped chronological list (Claude Code-style), clears on reply.
-      // Never surfaces raw shell/query syntax — option A, uniform across
-      // code + non-code agents.
-      //
       // Flag OFF (default): the legacy generic verb-count summary
       // ("Ran 5 commands") via registerAndRender — byte-identical to
-      // pre-draft-mirror behavior.
-      if (!turn.replyCalled && !isTelegramSurfaceTool(name)) {
-        const rendered = DRAFT_MIRROR_ENABLED
-          ? appendActivityLine(turn.mirrorLines, name, ev.input)
-          : registerAndRender(turn.toolActivity, name)
+      // pre-draft-mirror behavior, cleared on first reply.
+      //
+      // DRAFT_MIRROR: the draft is NOT driven from this (flush-gated)
+      // tool_use event — it's driven by the real-time `tool_label` event
+      // (PreToolUse sidecar, fires at tool-call time regardless of when
+      // claude flushes the transcript). See `case 'tool_label'`. That's
+      // the determinism fix: on a fast/clustered-tool turn the JSONL
+      // tool_use rows aren't on disk until ~turn-end, so sourcing the
+      // draft here lost the feed; the sidecar is flush-independent.
+      if (!DRAFT_MIRROR_ENABLED && !turn.replyCalled && !isTelegramSurfaceTool(name)) {
+        const rendered = registerAndRender(turn.toolActivity, name)
         if (rendered != null) {
           turn.activityPendingRender = rendered
           if (turn.activityInFlight == null) {
@@ -7246,6 +7249,31 @@ function handleSessionEvent(ev: SessionEvent): void {
       ctrl.setTool(name)
       if (ev.toolUseId) {
         typingWrapper.onToolUse(ev.toolUseId, turn.sessionChatId, name, turn.sessionThreadId ?? null)
+      }
+      return
+    }
+    case 'tool_label': {
+      // DRAFT_MIRROR real-time driver. The PreToolUse hook wrote this
+      // label synchronously at tool-call time; the sidecar surfaced it
+      // here (~250ms) independent of the transcript flush. Accumulate it
+      // into the live feed and update the ephemeral draft — this is what
+      // makes the draft deterministic on fast/clustered-tool turns where
+      // the JSONL tool_use rows arrive too late.
+      if (!DRAFT_MIRROR_ENABLED) return
+      const turn = currentTurn
+      if (turn == null) return
+      // Surface tools (reply/stream_reply/react) are the conversation, not
+      // activity — the hook labels them ("Replying"), so filter by name.
+      if (isTelegramSurfaceTool(ev.toolName)) return
+      // Unlike the legacy tool_use path, do NOT gate on replyCalled — the
+      // whole point is to show activity even when a reply raced ahead of
+      // the (lagged) transcript. The feed clears at turn_end.
+      const rendered = appendActivityLabel(turn.mirrorLines, ev.label)
+      if (rendered != null) {
+        turn.activityPendingRender = rendered
+        if (turn.activityInFlight == null) {
+          turn.activityInFlight = drainActivitySummary(turn)
+        }
       }
       return
     }
@@ -7518,6 +7546,14 @@ function handleSessionEvent(ev: SessionEvent): void {
       if (turn?.orphanedReplyTimeoutId != null) {
         clearTimeout(turn.orphanedReplyTimeoutId)
         turn.orphanedReplyTimeoutId = null
+      }
+      // DRAFT_MIRROR: the live activity feed runs through the whole turn
+      // (it is NOT cleared on the first reply, unlike the legacy summary)
+      // so an early/mid-turn reply can't wipe it. Clear it here, at the
+      // real end of the turn — the ephemeral compose-area draft goes away
+      // once the work is actually done.
+      if (DRAFT_MIRROR_ENABLED && turn != null) {
+        clearActivitySummary(turn)
       }
       // #549 fix — flush any pending preamble BEFORE the answer stream is
       // nulled below. Text emitted immediately before turn_end (no tool

--- a/telegram-plugin/hooks/tool-label-pretool.mjs
+++ b/telegram-plugin/hooks/tool-label-pretool.mjs
@@ -74,15 +74,24 @@ function urlHostPath(u) {
 export function computeLabel(toolName, input) {
   const i = input ?? {}
 
-  // Tools whose labels are already handled elsewhere — emit nothing so
-  // the existing description / TodoWrite / sub-agent paths win.
+  // Bash / Task / ToolSearch / TodoWrite: previously emitted nothing
+  // (deferred to the session-JSONL description path). The draft-mirror
+  // now drives off THIS sidecar in real time (flush-independent), so we
+  // must label them here too — otherwise the most common tool (Bash)
+  // never reaches the live draft. Uses the model-authored `description`
+  // for Bash/Task, matching the gateway's describeToolUse rendering.
   switch (toolName) {
     case 'Bash':
+      return clip(String(i.description ?? ''), 70).trim() || 'Running a command'
     case 'Task':
-    case 'Agent':
+    case 'Agent': {
+      const d = clip(String(i.description ?? ''), 60).trim()
+      return d ? `Delegating: ${d}` : 'Delegating to a sub-agent'
+    }
     case 'TodoWrite':
+      return 'Updating the plan'
     case 'ToolSearch':
-      return null
+      return 'Finding the right tool'
   }
 
   // Built-in rule table.

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -93,6 +93,11 @@ export type SessionEvent =
   | { kind: 'dequeue' }
   | { kind: 'thinking' }
   | { kind: 'tool_use'; toolName: string; toolUseId?: string | null; input?: Record<string, unknown>; precomputedLabel?: string }
+  // Real-time tool label from the PreToolUse-hook sidecar — fires when the
+  // hook writes the label (synchronous at tool-call time), independent of
+  // the lazily-flushed transcript. The draft-mirror drives off THIS, not
+  // the flush-gated `tool_use`, so activity streams deterministically.
+  | { kind: 'tool_label'; toolUseId: string; label: string; toolName: string }
   | { kind: 'text'; text: string }
   | { kind: 'tool_result'; toolUseId: string; toolName: string | null; isError?: boolean; errorText?: string }
   | { kind: 'turn_end'; durationMs: number }
@@ -639,6 +644,13 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
     try {
       const s = createToolLabelSidecar({ stateDir: stateDirForSidecar, sessionId })
       sidecars.set(sessionId, s)
+      // Real-time draft-mirror source: emit a `tool_label` event the moment
+      // the hook writes a label (flush-independent), so the gateway can
+      // stream the activity feed without waiting on the transcript flush.
+      // Subscribed once per sidecar (this is the only creation site).
+      s.onLabel((toolUseId, label, toolName) => {
+        rawOnEvent({ kind: 'tool_label', toolUseId, label, toolName })
+      })
       return s
     } catch (err) {
       log?.(`session-tail: sidecar create failed: ${(err as Error).message}`)
@@ -775,6 +787,12 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
       }
       log?.(`session-tail: attached to ${file} (cursor=${cursor})`)
     }
+    // Eagerly create + subscribe the PreToolUse sidecar for this session
+    // NOW (on attach), not lazily on the first JSONL tool_use — otherwise
+    // the real-time `tool_label` source wouldn't exist until a flush-gated
+    // tool_use arrived, re-introducing the very lag the sidecar avoids.
+    const attachSid = sessionIdForFile(file)
+    if (attachSid) ensureSidecar(attachSid)
     try {
       watcher = watch(file, () => readNew())
     } catch (err) {

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -7,6 +7,7 @@ import {
   verbForTool,
   describeToolUse,
   appendActivityLine,
+  appendActivityLabel,
   renderActivityFeed,
   MIRROR_MAX_LINES,
 } from "../tool-activity-summary.js";
@@ -326,5 +327,23 @@ describe("appendActivityLine + renderActivityFeed — accumulating draft feed", 
 
   it("renderActivityFeed returns null on empty", () => {
     expect(renderActivityFeed([])).toBeNull();
+  });
+});
+
+describe("appendActivityLabel — precomputed label feed (tool_label path)", () => {
+  it("accumulates precomputed labels, dedups consecutive, ignores empty", () => {
+    const lines: string[] = [];
+    expect(appendActivityLabel(lines, "Searching memory")).toBe("· Searching memory");
+    expect(appendActivityLabel(lines, "List workspace")).toBe(
+      "· Searching memory\n· List workspace",
+    );
+    // consecutive dup collapses
+    appendActivityLabel(lines, "List workspace");
+    expect(lines).toEqual(["Searching memory", "List workspace"]);
+    // empty / whitespace → null, no push
+    expect(appendActivityLabel(lines, "")).toBeNull();
+    expect(appendActivityLabel(lines, "   ")).toBeNull();
+    expect(appendActivityLabel(lines, undefined)).toBeNull();
+    expect(lines.length).toBe(2);
   });
 });

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -382,3 +382,21 @@ export function renderActivityFeed(lines: string[]): string | null {
   const body = shown.map((l) => `· ${l}`).join("\n");
   return hidden > 0 ? `· +${hidden} earlier…\n${body}` : body;
 }
+
+/**
+ * Like appendActivityLine, but for a pre-computed label (from the
+ * real-time PreToolUse sidecar / `tool_label` event) — the hook already
+ * rendered the friendly text, so we skip describeToolUse. Returns the
+ * rendered feed, or null when the label is empty.
+ */
+export function appendActivityLabel(
+  lines: string[],
+  label: string | undefined,
+): string | null {
+  const l = (label ?? "").trim();
+  if (l.length === 0) return null;
+  if (lines.length === 0 || lines[lines.length - 1] !== l) {
+    lines.push(l);
+  }
+  return renderActivityFeed(lines);
+}

--- a/telegram-plugin/tool-label-sidecar.ts
+++ b/telegram-plugin/tool-label-sidecar.ts
@@ -40,8 +40,11 @@ export interface ToolLabelRow {
 export interface ToolLabelSidecar {
   /** Synchronous label lookup. */
   getLabel(toolUseId: string): string | undefined
-  /** Subscribe to "label arrived" notifications. */
-  onLabel(cb: (toolUseId: string, label: string) => void): () => void
+  /** Subscribe to "label arrived" notifications. Fires once per new
+   *  sidecar line, in real time (~pollMs after the hook's appendFileSync),
+   *  independent of when the claude transcript flushes. `toolName` lets
+   *  subscribers filter surface tools (reply/react) from a live feed. */
+  onLabel(cb: (toolUseId: string, label: string, toolName: string) => void): () => void
   /** Force a re-poll (tests). */
   poll(): void
   /** Stop polling and release resources. */
@@ -63,7 +66,7 @@ export interface SidecarOptions {
 export function createToolLabelSidecar(opts: SidecarOptions): ToolLabelSidecar {
   const path = join(opts.stateDir, `tool-labels-${opts.sessionId}.jsonl`)
   const labels = new Map<string, string>()
-  const subscribers = new Set<(toolUseId: string, label: string) => void>()
+  const subscribers = new Set<(toolUseId: string, label: string, toolName: string) => void>()
   let offset = 0
   let stopped = false
 
@@ -90,7 +93,7 @@ export function createToolLabelSidecar(opts: SidecarOptions): ToolLabelSidecar {
       if (labels.has(row.tool_use_id)) continue
       labels.set(row.tool_use_id, row.label)
       for (const cb of subscribers) {
-        try { cb(row.tool_use_id, row.label) } catch { /* ignore */ }
+        try { cb(row.tool_use_id, row.label, row.tool_name) } catch { /* ignore */ }
       }
     }
   }

--- a/telegram-plugin/tool-label-sidecar.ts
+++ b/telegram-plugin/tool-label-sidecar.ts
@@ -87,7 +87,12 @@ export function createToolLabelSidecar(opts: SidecarOptions): ToolLabelSidecar {
       } catch {
         continue
       }
-      if (!row || typeof row.tool_use_id !== 'string' || typeof row.label !== 'string') continue
+      if (
+        !row ||
+        typeof row.tool_use_id !== 'string' ||
+        typeof row.label !== 'string' ||
+        typeof row.tool_name !== 'string'
+      ) continue
       // First write wins — sidecar lines are append-only and we don't
       // expect duplicates, but if one lands we keep the earliest.
       if (labels.has(row.tool_use_id)) continue


### PR DESCRIPTION
## Summary
Makes the draft-mirror **deterministic** regardless of when the unmodified `claude` CLI flushes its session transcript. Still behind `SWITCHROOM_DRAFT_MIRROR` (default OFF).

**Problem:** the draft sourced from the lazily-flushed session JSONL (`tool_use` events). On fast/clustered-tool turns the tool_use rows aren't on disk until ~turn-end, so the instant reply IPC flips `replyCalled` first and the draft is suppressed — zero draft even on a 42s turn. (Slow/spaced web-fetch turns happened to work because claude flushed between them.)

**Fix (operator's idea — "cache the JSONL separately"):** drive the draft off the **PreToolUse hook sidecar**, written synchronously at tool-call time, flush-independent.
- Hook (`tool-label-pretool.mjs`): now labels *all* tools (Bash via `input.description`, Task, ToolSearch — were `null`).
- `tool-label-sidecar.ts`: `onLabel` passes `tool_name`.
- `session-tail.ts`: new real-time `tool_label` event; sidecar created+subscribed **eagerly on session-attach** (was lazy on first JSONL tool_use).
- `gateway.ts`: `case 'tool_label'` drives the draft (not gated on `replyCalled`); clears at `turn_end` (not first reply) so a mid-turn reply can't wipe it. `tool_use` draft trigger is now flag-OFF-only.

## Test plan
- [x] tsc + bot-api-wrapping + plugin-references clean; tool-activity-summary 35 pass, sidecar 6 pass
- [ ] **mtcute (post-deploy):** the fast/clustered-tool turn that showed zero drafts now streams an accumulating feed (Reading X → Searching memory → …), clears on turn end

## Risk
Flag-off path byte-identical (draft driven by `tool_label` only under the flag; `tool_use` legacy path untouched when off). The hook change adds sidecar lines for Bash/Task/ToolSearch — used by the draft + harmless to other consumers.