### PR TITLE
chore: release v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,39 @@
 # Changelog
 
-## v0.14.2 — draft-mirror Phase 2: accumulating activity feed
+## v0.14.3 — draft-mirror determinism (real-time sidecar) + pacing fixes
+
+### draft-mirror: real-time via PreToolUse sidecar (#1963)
+
+Makes the draft-mirror deterministic regardless of when the unmodified
+`claude` CLI flushes its session transcript. Still behind
+`SWITCHROOM_DRAFT_MIRROR` (default OFF; flag-off byte-identical).
+
+The draft previously sourced from the lazily-flushed session JSONL, so
+on fast/clustered-tool turns the tool_use rows weren't on disk until
+~turn-end and the instant reply IPC suppressed the feed (zero draft
+even on a 42s turn). It now sources from the **PreToolUse hook
+sidecar**, written synchronously at tool-call time (flush-independent):
+the hook labels every tool, the sidecar is created+subscribed eagerly
+on session-attach, and a new real-time `tool_label` event drives the
+draft — not gated on `replyCalled`, cleared at `turn_end` so a mid-turn
+reply can't wipe it.
+
+### pacing + fuzz (#1962)
+
+Turn-pacing directive discourages the trailing `"Done."`/`"Sent."` the
+model emits after its answer. Conversational-pacing fuzz de-staled:
+`sleep`→`python3 time.sleep` (Claude Code's bash sandbox blocks
+standalone `sleep`), and the CC-2 assertion tolerates a trailing
+confirmation. Fuzz went 9→4 failing (remaining are reaction-observation
++ long-wait-ceiling edge cases, not regressions).
+
+### other
+
+- PR3b: turn-in-flight gate cut over to the delivery state machine
+  (#1961). Docs: stale `claude -p` reference fix (#1960), drift-audit
+  phase-4 report (#1959).
+
+
 
 Phase 2 of the draft-mirror (#1957), still behind `SWITCHROOM_DRAFT_MIRROR`
 (**default OFF**; flag-off behavior byte-identical to v0.14.1).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {

--- a/tests/tool-label-pretool.test.ts
+++ b/tests/tool-label-pretool.test.ts
@@ -228,16 +228,39 @@ describe("tool-label-pretool.mjs", () => {
     }
   });
 
-  it("suppressed tools (Bash, Task, Agent, TodoWrite, send_typing, sync_retain, exotic mcp__) emit nothing", () => {
+  it("Bash / Task / Agent / TodoWrite / ToolSearch now emit labels (draft-mirror real-time source)", () => {
+    // Previously suppressed (deferred to the JSONL description path). Since
+    // the draft-mirror drives off this sidecar in real time, they must be
+    // labelled here too. Bash/Task use the model-authored description.
+    const cases: Array<[string, Record<string, unknown>, string]> = [
+      ["Bash", { command: "ls -la", description: "List workspace" }, "List workspace"],
+      ["Bash", { command: "ls" }, "Running a command"], // no description → safe fallback
+      ["Task", { description: "Review the migration", prompt: "y" }, "Delegating: Review the migration"],
+      ["Agent", { description: "Audit deps", prompt: "y" }, "Delegating: Audit deps"],
+      ["TodoWrite", { todos: [] }, "Updating the plan"],
+      ["ToolSearch", { query: "x" }, "Finding the right tool"],
+    ];
+    cases.forEach(([tool, input, expected], idx) => {
+      // Unique session per case so the per-session sidecar file isn't
+      // shared/accumulated across iterations. `run()` reads the sidecar
+      // via its 3rd arg, so it must match the payload's session_id.
+      const sess = `sess-${idx}`;
+      const r = run(
+        { session_id: sess, tool_use_id: `t-${tool}-${idx}`, tool_name: tool, tool_input: input },
+        stateDir,
+        sess,
+      );
+      expect(r.status).toBe(0);
+      expect(r.sidecarLines, `${tool} should emit a sidecar label`).toHaveLength(1);
+      expect(r.sidecarLines[0].label).toBe(expected);
+    });
+  });
+
+  it("genuinely-suppressed tools (send_typing, sync_retain, exotic mcp__) still emit nothing", () => {
     const cases: Array<[string, Record<string, unknown>]> = [
-      ["Bash", { command: "ls" }],
-      ["Task", { description: "x", prompt: "y" }],
-      ["Agent", { description: "x", prompt: "y" }],
-      ["TodoWrite", { todos: [] }],
       ["mcp__switchroom-telegram__send_typing", {}],
       ["mcp__hindsight__sync_retain", {}],
       ["mcp__some-other-server__random_tool", { foo: "bar" }],
-      ["ToolSearch", {}],
     ];
     for (const [tool, input] of cases) {
       const r = run(
@@ -247,7 +270,6 @@ describe("tool-label-pretool.mjs", () => {
       expect(r.status).toBe(0);
       expect(r.stdout).toBe("");
     }
-    // No sidecar file at all should have been created (no labels emitted).
     const files = readdirSync(stateDir).filter((f) => f.startsWith("tool-labels-"));
     expect(files).toHaveLength(0);
   });


### PR DESCRIPTION
draft-mirror determinism via real-time PreToolUse sidecar (#1963) + pacing/fuzz fixes (#1962) + PR3b (#1961). Flag-gated draft-mirror default off; flag-off byte-identical. See CHANGELOG.