### PR TITLE
feat(doctor): probe approval-kernel DB durability

### DIFF
--- a/src/cli/doctor-vault-broker-durability.test.ts
+++ b/src/cli/doctor-vault-broker-durability.test.ts
@@ -30,6 +30,7 @@ import {
   probeBindMountInode,
   formatBindMountResult,
   probeBrokerUnlocked,
+  probeKernelDbDurability,
   type BindMountStatResult,
   type BrokerStatResult,
 } from "./doctor-vault-broker-durability.js";
@@ -183,5 +184,97 @@ describe("probeBrokerUnlocked — runtime state, not just config", () => {
       statusProbe: () => null,
     });
     expect(r.status).toBe("skip");
+  });
+});
+
+describe("probeKernelDbDurability — approval-kernel approvals bind mount", () => {
+  // The probe targets the directory (/state/approvals host<->container)
+  // rather than the kernel.db file, because kernel.db is created lazily
+  // on the first allow_always decision. Directory inode equality is the
+  // robust signal that the compose bind mount is wired correctly.
+
+  const home = "/home/operator";
+
+  it("ok when host dir and kernel dir inodes match (mount wired)", () => {
+    const r = probeKernelDbDurability(home, {
+      statHost: () => ({ ino: 55555n, size: 4096 }),
+      statBroker: (): BrokerStatResult => ({
+        kind: "ok-with-stat",
+        ino: "55555",
+        size: 4096,
+      }),
+    });
+    expect(r.status).toBe("ok");
+    expect(r.name).toContain("approval-kernel");
+    expect(r.name).toContain("allow_always");
+    expect(r.detail).toContain("allow_always decisions persist");
+  });
+
+  it("fail when inodes differ (mount not wired — the ephemerality regression)", () => {
+    // Different inode means the kernel is operating on an ephemeral
+    // container-local directory — the regression class this probe catches.
+    const r = probeKernelDbDurability(home, {
+      statHost: () => ({ ino: 11111n, size: 4096 }),
+      statBroker: (): BrokerStatResult => ({
+        kind: "ok-with-stat",
+        ino: "99999",
+        size: 4096,
+      }),
+    });
+    expect(r.status).toBe("fail");
+    expect(r.detail).toContain("ephemeral");
+    expect(r.detail).toContain("allow_always");
+    // Remediation hint must name the fix: apply + kernel recreate.
+    expect(r.fix).toContain("switchroom apply");
+    expect(r.fix).toContain("approval-kernel");
+  });
+
+  it("skip when kernel container is not running (empty fleet, not broken)", () => {
+    const r = probeKernelDbDurability(home, {
+      statHost: () => ({ ino: 1n, size: 4096 }),
+      statBroker: (): BrokerStatResult => ({ kind: "broker-unreachable" }),
+    });
+    expect(r.status).toBe("skip");
+    expect(r.detail).toContain("approval-kernel");
+    expect(r.detail).toContain("unreachable");
+  });
+
+  it("warn when host approvals directory is absent (apply hasn't run yet)", () => {
+    // host-missing → warn, not fail. Directory is pre-created by
+    // `switchroom apply`; missing means apply hasn't run on this install yet.
+    const r = probeKernelDbDurability(home, {
+      statHost: () => null,
+      statBroker: (): BrokerStatResult => ({
+        kind: "ok-with-stat",
+        ino: "1",
+        size: 4096,
+      }),
+    });
+    expect(r.status).toBe("warn");
+    expect(r.fix).toContain("switchroom apply");
+  });
+
+  it("warn on transient docker exec error (no false fail)", () => {
+    // broker-stat-failed degrades to warn, not fail — no false alarms
+    // when docker exec has a transient error.
+    const r = probeKernelDbDurability(home, {
+      statHost: () => ({ ino: 1n, size: 4096 }),
+      statBroker: (): BrokerStatResult => ({
+        kind: "broker-stat-failed",
+        msg: "permission denied",
+      }),
+    });
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("approval-kernel stat failed");
+    expect(r.detail).toContain("permission denied");
+  });
+
+  it("probe name clearly identifies the allow_always durability concern", () => {
+    const r = probeKernelDbDurability(home, {
+      statHost: () => ({ ino: 1n, size: 4096 }),
+      statBroker: (): BrokerStatResult => ({ kind: "broker-unreachable" }),
+    });
+    expect(r.name).toContain("approval-kernel");
+    expect(r.name).toContain("allow_always");
   });
 });

--- a/src/cli/doctor-vault-broker-durability.ts
+++ b/src/cli/doctor-vault-broker-durability.ts
@@ -157,10 +157,29 @@ function spawnDockerStat(p: string): {
   stderr: string;
   error: Error | null;
 } {
+  return spawnDockerStatForContainer("switchroom-vault-broker", p);
+}
+
+/**
+ * Run `docker exec <containerName> stat -c '%i %s' <p>` and return the
+ * raw result. Extracted so multiple probes can target different containers
+ * without duplicating the exec + error-shape logic.
+ *
+ * @internal exported for testing
+ */
+export function spawnDockerStatForContainer(
+  containerName: string,
+  p: string,
+): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error: Error | null;
+} {
   try {
     const stdout = execFileSync(
       "docker",
-      ["exec", "switchroom-vault-broker", "stat", "-c", "%i %s", p],
+      ["exec", containerName, "stat", "-c", "%i %s", p],
       { stdio: ["ignore", "pipe", "pipe"], timeout: 3000, encoding: "utf8" },
     );
     return { status: 0, stdout, stderr: "", error: null };
@@ -312,6 +331,7 @@ export function runVaultBrokerDurabilityChecks(
   opts?: {
     inodeProbe?: typeof probeBindMountInode;
     statusProbe?: Parameters<typeof probeBrokerUnlocked>[0];
+    kernelStatBroker?: (p: string) => BrokerStatResult;
   },
 ): CheckResult[] {
   const home = homedir();
@@ -348,7 +368,113 @@ export function runVaultBrokerDurabilityChecks(
         "/root/.switchroom/vault-audit.log",
       ),
     ),
+    probeKernelDbDurability(home, {
+      statBroker: opts?.kernelStatBroker,
+    }),
   ];
+}
+
+/**
+ * Probe whether the approval-kernel's `/state/approvals` directory is
+ * backed by the host bind mount (`~/.switchroom/approvals`).
+ *
+ * We probe the **directory** inode rather than the `kernel.db` file
+ * because `kernel.db` is created lazily on the first `allow_always`
+ * decision — an empty fleet would false-positive "ephemeral" on a
+ * file-only probe. Directory inode equality is the durable signal
+ * that the compose bind mount is wired correctly.
+ *
+ * If the kernel container is not running, this returns `skip` rather
+ * than `fail`, matching the behaviour of the broker probes above.
+ *
+ * @internal exported for testing
+ */
+export function probeKernelDbDurability(
+  home: string,
+  opts?: {
+    statBroker?: (p: string) => BrokerStatResult;
+    statHost?: (p: string) => { ino: bigint; size: number } | null;
+  },
+): CheckResult {
+  const hostDir = join(home, ".switchroom", "approvals");
+  const containerDir = "/state/approvals";
+  const name = "approval-kernel: approvals bind mount (allow_always durability)";
+
+  const kernelStat = opts?.statBroker ?? defaultKernelStatBroker;
+
+  const result = probeBindMountInode(hostDir, containerDir, {
+    statBroker: kernelStat,
+    statHost: opts?.statHost,
+  });
+
+  if (result.kind === "ok") {
+    return {
+      name,
+      status: "ok",
+      detail: `${hostDir} == ${containerDir} (same inode) — allow_always decisions persist across kernel recreate`,
+    };
+  }
+  if (result.kind === "host-missing") {
+    return {
+      name,
+      status: "warn",
+      detail:
+        `host directory ${hostDir} missing — \`switchroom apply\` pre-creates it on greenfield`,
+      fix: "Run `switchroom apply` to pre-create the host approvals directory",
+    };
+  }
+  if (result.kind === "broker-unreachable") {
+    return {
+      name,
+      status: "skip",
+      detail: "approval-kernel container unreachable — bind mount unverified",
+    };
+  }
+  if (result.kind === "broker-stat-failed") {
+    return {
+      name,
+      status: "warn",
+      detail: `approval-kernel stat failed: ${result.msg}`,
+    };
+  }
+  // mismatch: the kernel is operating on an ephemeral container-local
+  // directory — allow_always decisions are lost on every container recreate.
+  return {
+    name,
+    status: "fail",
+    detail:
+      `inode mismatch — approval-kernel \`/state/approvals\` is NOT backed by the host bind mount. ` +
+      `host inode=${result.hostInode} size=${result.hostSize}; ` +
+      `kernel inode=${result.brokerInode} size=${result.brokerSize}. ` +
+      `The kernel is writing kernel.db to an ephemeral container-local directory; ` +
+      `all allow_always decisions are lost on every container recreate (e.g. after \`switchroom update\`).`,
+    fix:
+      "Run `switchroom apply` to regenerate compose with the " +
+      "`~/.switchroom/approvals:/state/approvals` bind mount, then " +
+      "`docker compose -p switchroom up -d approval-kernel` to recreate the kernel container.",
+  };
+}
+
+function defaultKernelStatBroker(p: string): BrokerStatResult {
+  const r = spawnDockerStatForContainer("switchroom-approval-kernel", p);
+  if (r.error || r.status === null) return { kind: "broker-unreachable" };
+  if (r.status !== 0) {
+    if (r.status >= 125) return { kind: "broker-unreachable" };
+    return {
+      kind: "broker-stat-failed",
+      msg: r.stderr?.trim() || `exit ${r.status}`,
+    };
+  }
+  const out = r.stdout.trim();
+  const [inoStr, sizeStr] = out.split(/\s+/);
+  const size = Number(sizeStr);
+  if (!inoStr || !Number.isFinite(size)) {
+    return {
+      kind: "broker-stat-failed",
+      msg: `unparseable stat output: ${out}`,
+    };
+  }
+  return { kind: "ok-with-stat", ino: inoStr, size };
 }
 
 function probeAutoUnlockBlob(home: string): CheckResult {


### PR DESCRIPTION
## Summary

- Adds a new `probeKernelDbDurability` probe to `runVaultBrokerDurabilityChecks` in `src/cli/doctor-vault-broker-durability.ts`
- The probe verifies the approval-kernel's `/state/approvals` directory is backed by the host bind mount (`~/.switchroom/approvals`) via inode equality
- Extracts `spawnDockerStatForContainer(name, path)` from the hardcoded `spawnDockerStat` so both the vault-broker and approval-kernel probes share the same exec + error-shape logic

## Why

The approval-kernel stores durable `allow_always` decisions in a SQLite DB at `/state/approvals/kernel.db` inside the `switchroom-approval-kernel` container. The compose generator binds it from `~/.switchroom/approvals:/state/approvals`.

**The gap:** if a deployed `docker-compose.yml` was generated by an older switchroom version *before* that bind-mount line existed, the kernel writes `kernel.db` into the container's ephemeral layer. Every kernel-container recreate (notably `switchroom update`) silently wipes all `allow_always` decisions. The existing durability doctor only covered the vault-broker's `vault-grants.db` and `vault-audit.log` (#1737); the kernel's approvals mount was completely undetected.

## What changed

- **`src/cli/doctor-vault-broker-durability.ts`**: added `probeKernelDbDurability(home, opts)` (exported for testing), `defaultKernelStatBroker` (execs into `switchroom-approval-kernel`), and `spawnDockerStatForContainer` (generalized from `spawnDockerStat`). Wired the new probe as the last entry in `runVaultBrokerDurabilityChecks`.
- **`src/cli/doctor-vault-broker-durability.test.ts`**: added a `probeKernelDbDurability` test suite covering: mount-wired (ok), inode-mismatch (fail + remediation hint), kernel-not-running (skip), host-dir-missing (warn), transient stat error (warn).

**Lazy-file handling:** the probe checks the **directory** inode (`~/.switchroom/approvals` ↔ `/state/approvals`), not the `kernel.db` file, because `kernel.db` is created lazily on the first `allow_always` decision. A file-only probe would false-positive "ephemeral" on a fresh fleet that has never tapped "always allow". Directory inode equality is the durable signal that the bind mount is wired.

**Kernel-not-running handling:** `broker-unreachable` from the docker exec → `skip` (not fail), matching the existing broker probe behaviour. An empty fleet reads clean.

## Verification

Local toolchain not available in this worktree. CI-only: lint, vitest (covers the new test suite), build.

## Risk

Low. Additive, read-only probe. No changes to the kernel itself, compose generation, gateway, or any write path. The `spawnDockerStat` refactor is a strict equivalence — the existing vault-broker probe's behavior is unchanged (it now delegates to `spawnDockerStatForContainer("switchroom-vault-broker", p)` which is identical to the inlined version).