### PR TITLE
fix(gateway): make failed always-allow loud + verify grant persisted

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -15286,25 +15286,56 @@ bot.on('callback_query:data', async ctx => {
       return
     }
     let grantOk = false
+    let grantFailReason = ''
     try {
       // --no-restart: settings.json gets the new entry on the next
       // reconcile but we don't bounce the agent mid-turn. Operator
       // can restart manually if they want this rule live in this
       // session; otherwise it kicks in next session.
       switchroomExec(['agent', 'grant', agentName, rule.rule, '--no-restart'])
-      grantOk = true
-      process.stderr.write(
-        `telegram gateway: always-allow added rule="${rule.rule}" agent=${agentName} (request_id=${request_id})\n`,
-      )
+      // Verify the rule actually landed in the resolved config — guards
+      // against config-location-drift (gateway edited a yaml that isn't
+      // the durable source-of-truth, or the grant was a no-op). One
+      // fresh config read; cheap since this is a rare operator tap.
+      try {
+        const cfg = loadSwitchroomConfig()
+        const rawAgent = cfg.agents?.[agentName]
+        if (rawAgent) {
+          const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent)
+          const allowList: string[] = (resolved as { tools?: { allow?: string[] } }).tools?.allow ?? []
+          if (allowList.includes(rule.rule)) {
+            grantOk = true
+            process.stderr.write(
+              `telegram gateway: always-allow added rule="${rule.rule}" agent=${agentName} (request_id=${request_id})\n`,
+            )
+          } else {
+            grantFailReason = `rule "${rule.rule}" not found in resolved tools.allow after write — config location may have drifted`
+            process.stderr.write(
+              `telegram gateway: always-allow VERIFY FAILED: ${grantFailReason} (request_id=${request_id})\n`,
+            )
+          }
+        } else {
+          grantFailReason = `agent "${agentName}" not found in config after write`
+          process.stderr.write(
+            `telegram gateway: always-allow VERIFY FAILED: ${grantFailReason} (request_id=${request_id})\n`,
+          )
+        }
+      } catch (verifyErr) {
+        grantFailReason = `config re-read failed: ${(verifyErr as Error).message}`
+        process.stderr.write(
+          `telegram gateway: always-allow VERIFY FAILED: ${grantFailReason} (request_id=${request_id})\n`,
+        )
+      }
     } catch (err) {
-      process.stderr.write(`telegram gateway: always-allow grant failed: ${(err as Error).message}\n`)
+      grantFailReason = (err as Error).message
+      process.stderr.write(`telegram gateway: always-allow grant failed: ${grantFailReason}\n`)
     }
 
     pendingPermissions.delete(request_id)
 
     const ackText = grantOk
       ? `🔁 Always allow ${rule.label} for ${agentName}`
-      : `✅ Allowed (always-allow yaml edit failed; check gateway log)`
+      : `⚠️ Allowed for now, but "always" did NOT save — it will ask again after restart. Check gateway log.`
     // HTML-escape baseText — `ctx.callbackQuery.message.text` returns
     // entities-stripped plain UTF-8, so raw `<`/`>`/`&` in the
     // expanded permission card's `description` or `input_preview`
@@ -15317,7 +15348,7 @@ bot.on('callback_query:data', async ctx => {
       : ''
     const editLabel = grantOk
       ? `🔁 <b>Always allow ${escapeHtmlForTg(rule.label)}</b> for ${escapeHtmlForTg(agentName)} — restart agent for full effect`
-      : `✅ <b>Allowed</b> (always-allow rule edit failed; see logs)`
+      : `⚠️ <b>Allowed for now — "always" did NOT save.</b> It will ask again after restart. Check gateway log.`
     // #1150 audit: route through finalizeCallback so the keyboard
     // strips alongside the status-line edit. Pre-fix this called
     // editMessageText without `reply_markup` so the Allow/Deny/Always

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -368,7 +368,7 @@ import { createIssuesCardHandle, type IssuesCardHandle } from '../issues-card.js
 import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.js'
 import { list as listIssues, resolve as resolveIssue } from '../../src/issues/index.js'
 import { summarizeToolForTitle, formatPermissionCardBody } from '../permission-title.js'
-import { resolveAlwaysAllowRule } from '../permission-rule.js'
+import { resolveAlwaysAllowRule, isRulePersisted } from '../permission-rule.js'
 import {
   readClaudeJsonOverage,
   evaluateCreditState,
@@ -15303,7 +15303,7 @@ bot.on('callback_query:data', async ctx => {
         if (rawAgent) {
           const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent)
           const allowList: string[] = (resolved as { tools?: { allow?: string[] } }).tools?.allow ?? []
-          if (allowList.includes(rule.rule)) {
+          if (isRulePersisted(allowList, rule.rule)) {
             grantOk = true
             process.stderr.write(
               `telegram gateway: always-allow added rule="${rule.rule}" agent=${agentName} (request_id=${request_id})\n`,

--- a/telegram-plugin/permission-rule.ts
+++ b/telegram-plugin/permission-rule.ts
@@ -133,6 +133,28 @@ function skillBasenameFromPath(input: Record<string, unknown>): string | null {
 }
 
 /**
+ * Verify that a grant actually landed in the resolved `tools.allow` list.
+ *
+ * Called by the `perm:always:*` handler after `switchroom agent grant`
+ * returns to guard against silently-failed or misdirected yaml writes.
+ * Extracted as a pure helper so it can be unit-tested without a full
+ * Grammy + switchroomExec harness.
+ *
+ * @param resolvedAllow  The `tools.allow` array from `resolveAgentConfig`
+ *                       for the target agent (pass `[]` when absent/undefined).
+ * @param ruleRule       The rule string produced by `resolveAlwaysAllowRule`
+ *                       (e.g. `"Skill(garmin)"`, `"Bash"`, `"mcp__x__y"`).
+ * @returns `true` when the rule is present (grant confirmed), `false` when
+ *          absent (grant failed / config location drifted).
+ */
+export function isRulePersisted(
+  resolvedAllow: readonly string[],
+  ruleRule: string,
+): boolean {
+  return resolvedAllow.includes(ruleRule);
+}
+
+/**
  * Inverse of `resolveAlwaysAllowRule` — does a stored allow-rule cover a
  * fresh `permission_request`? Used by the bridge's session-scoped
  * always-allow cache (issue #1138) to short-circuit prompts when the

--- a/telegram-plugin/tests/always-allow-grant.test.ts
+++ b/telegram-plugin/tests/always-allow-grant.test.ts
@@ -102,21 +102,24 @@ describe('always-allow handler — post-write verification', () => {
     expect(resolveIdx).toBeGreaterThan(execIdx)
   })
 
-  it('checks allowList.includes(rule.rule) after the reload', () => {
-    expect(alwaysBlock).toContain('allowList.includes(rule.rule)')
+  it('calls isRulePersisted(allowList, rule.rule) after the reload', () => {
+    // The handler delegates the membership check to the extracted pure
+    // helper so the behavioral test in always-allow-persist.test.ts can
+    // cover the same code path.
+    expect(alwaysBlock).toContain('isRulePersisted(allowList, rule.rule)')
   })
 
-  it('sets grantOk=true only when the rule IS present in the reloaded config', () => {
-    // grantOk=true must be inside the `if (allowList.includes(rule.rule))`
-    // branch, not unconditionally after switchroomExec.
-    const allowListIdx = alwaysBlock.indexOf('allowList.includes(rule.rule)')
-    const grantOkIdx = alwaysBlock.indexOf('grantOk = true', allowListIdx)
-    expect(allowListIdx).toBeGreaterThan(-1)
-    expect(grantOkIdx).toBeGreaterThan(allowListIdx)
-    // Confirm it does NOT appear before the includes check (i.e., not
-    // unconditionally on switchroomExec success as in the old code).
-    const grantOkBeforeCheck = alwaysBlock.indexOf('grantOk = true')
-    expect(grantOkBeforeCheck).toBeGreaterThanOrEqual(allowListIdx)
+  it('sets grantOk=true only when isRulePersisted returns true', () => {
+    // grantOk=true must be inside the `if (isRulePersisted(...))` branch,
+    // not unconditionally after switchroomExec.
+    const persistIdx = alwaysBlock.indexOf('isRulePersisted(allowList, rule.rule)')
+    const grantOkIdx = alwaysBlock.indexOf('grantOk = true', persistIdx)
+    expect(persistIdx).toBeGreaterThan(-1)
+    expect(grantOkIdx).toBeGreaterThan(persistIdx)
+    // Confirm grantOk=true does NOT appear before the persistence check
+    // (i.e., not unconditionally on switchroomExec success as in the old code).
+    const grantOkFirst = alwaysBlock.indexOf('grantOk = true')
+    expect(grantOkFirst).toBeGreaterThanOrEqual(persistIdx)
   })
 
   it('logs a VERIFY FAILED message when the rule is absent after the write', () => {

--- a/telegram-plugin/tests/always-allow-grant.test.ts
+++ b/telegram-plugin/tests/always-allow-grant.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Structural contract tests for the "🔁 Always allow" handler in
+ * gateway.ts (the `behavior === 'always'` branch of the perm: callback
+ * dispatcher).
+ *
+ * Why structural: the handler lives inside a Grammy callback closure
+ * that's not exported. Full-function invocation would require a complete
+ * Grammy + switchroomExec harness. Instead, we pin the source-level
+ * invariants that were introduced to fix the silent-failure bug:
+ *
+ *   1. Loud failure text — the failure path must NOT read like success
+ *      (`✅ Allowed …`). After the fix, both the toast (ackText) and the
+ *      chat edit (editLabel) use the `⚠️` marker.
+ *   2. Post-write verification — after `switchroomExec` returns success
+ *      the handler MUST re-read the config and check that the rule is
+ *      actually present in `tools.allow`. If the check fails it sets
+ *      grantOk=false and surfaces the loud message.
+ *   3. Success path unchanged — when `grantOk` is true the success
+ *      strings (`🔁 Always allow …`, `restart agent for full effect`)
+ *      are still present.
+ *   4. Error reason capture — `grantFailReason` is declared and
+ *      populated from `(err as Error).message` so the root cause can
+ *      appear in logs; it is NOT silently swallowed into `message`-less
+ *      stderr output.
+ *
+ * Slicing strategy: we extract the `if (behavior === 'always') {` block
+ * from gateway.ts and run string assertions against that slice only —
+ * so additions elsewhere in the 17k-line file don't produce false
+ * positives or negatives.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, '..', 'gateway', 'gateway.ts'),
+  'utf-8',
+)
+
+/**
+ * Extract the `behavior === 'always'` block from the perm: callback
+ * dispatcher. The slice runs from the `if (behavior === 'always')` guard
+ * up to (but not including) the next top-level `// Forward permission`
+ * comment which opens the allow/deny branch.
+ */
+function sliceAlwaysBlock(): string {
+  const start = gatewaySrc.indexOf("if (behavior === 'always')")
+  const end = gatewaySrc.indexOf('// Forward permission decision to connected bridges', start)
+  if (start === -1 || end === -1) return ''
+  return gatewaySrc.slice(start, end)
+}
+
+const alwaysBlock = sliceAlwaysBlock()
+
+describe('always-allow handler — loud failure invariants', () => {
+  it('failure ackText uses the ⚠️ warning marker, not ✅', () => {
+    // The failure path must be unambiguous. Before the fix, the failure
+    // ackText started with "✅ Allowed …" which reads like success.
+    expect(alwaysBlock).toContain(
+      `⚠️ Allowed for now, but "always" did NOT save — it will ask again after restart. Check gateway log.`,
+    )
+    // Confirm the old misleading text is gone.
+    expect(alwaysBlock).not.toContain('✅ Allowed (always-allow yaml edit failed')
+  })
+
+  it('failure editLabel uses the ⚠️ warning marker, not ✅', () => {
+    // The inline-keyboard collapse edit also must NOT look like success.
+    expect(alwaysBlock).toContain(
+      `⚠️ <b>Allowed for now — "always" did NOT save.</b> It will ask again after restart. Check gateway log.`,
+    )
+    // Confirm the old misleading text is gone.
+    expect(alwaysBlock).not.toContain('✅ <b>Allowed</b> (always-allow rule edit failed')
+  })
+})
+
+describe('always-allow handler — success path unchanged', () => {
+  it('success ackText still uses 🔁 and names the rule', () => {
+    expect(alwaysBlock).toContain('`🔁 Always allow ${rule.label} for ${agentName}`')
+  })
+
+  it('success editLabel still uses 🔁 bold + restart hint', () => {
+    expect(alwaysBlock).toContain('restart agent for full effect')
+    expect(alwaysBlock).toContain('🔁 <b>Always allow')
+  })
+})
+
+describe('always-allow handler — post-write verification', () => {
+  it('reloads config after switchroomExec returns', () => {
+    // The verification block must call loadSwitchroomConfig() AFTER
+    // the switchroomExec call to confirm the rule landed in the
+    // resolved tools.allow.
+    const execIdx = alwaysBlock.indexOf("switchroomExec(['agent', 'grant'")
+    const loadIdx = alwaysBlock.indexOf('loadSwitchroomConfig()', execIdx)
+    expect(execIdx).toBeGreaterThan(-1)
+    expect(loadIdx).toBeGreaterThan(execIdx)
+  })
+
+  it('calls resolveAgentConfig to obtain the merged tools.allow list', () => {
+    const execIdx = alwaysBlock.indexOf("switchroomExec(['agent', 'grant'")
+    const resolveIdx = alwaysBlock.indexOf('resolveAgentConfig(', execIdx)
+    expect(resolveIdx).toBeGreaterThan(execIdx)
+  })
+
+  it('checks allowList.includes(rule.rule) after the reload', () => {
+    expect(alwaysBlock).toContain('allowList.includes(rule.rule)')
+  })
+
+  it('sets grantOk=true only when the rule IS present in the reloaded config', () => {
+    // grantOk=true must be inside the `if (allowList.includes(rule.rule))`
+    // branch, not unconditionally after switchroomExec.
+    const allowListIdx = alwaysBlock.indexOf('allowList.includes(rule.rule)')
+    const grantOkIdx = alwaysBlock.indexOf('grantOk = true', allowListIdx)
+    expect(allowListIdx).toBeGreaterThan(-1)
+    expect(grantOkIdx).toBeGreaterThan(allowListIdx)
+    // Confirm it does NOT appear before the includes check (i.e., not
+    // unconditionally on switchroomExec success as in the old code).
+    const grantOkBeforeCheck = alwaysBlock.indexOf('grantOk = true')
+    expect(grantOkBeforeCheck).toBeGreaterThanOrEqual(allowListIdx)
+  })
+
+  it('logs a VERIFY FAILED message when the rule is absent after the write', () => {
+    expect(alwaysBlock).toContain('always-allow VERIFY FAILED')
+  })
+
+  it('surfaces config-location drift as a failure reason', () => {
+    expect(alwaysBlock).toContain('config location may have drifted')
+  })
+})
+
+describe('always-allow handler — error reason capture', () => {
+  it('declares grantFailReason to capture the root cause', () => {
+    expect(alwaysBlock).toContain('let grantFailReason')
+  })
+
+  it('populates grantFailReason from the thrown error on switchroomExec failure', () => {
+    // After the catch for switchroomExec, grantFailReason must be set
+    // from the error object so log messages can show the actual cause.
+    const catchIdx = alwaysBlock.lastIndexOf('} catch (err) {')
+    const reasonIdx = alwaysBlock.indexOf('grantFailReason = (err as Error).message', catchIdx)
+    expect(catchIdx).toBeGreaterThan(-1)
+    expect(reasonIdx).toBeGreaterThan(catchIdx)
+  })
+})

--- a/telegram-plugin/tests/always-allow-persist.test.ts
+++ b/telegram-plugin/tests/always-allow-persist.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Behavioral tests for the always-allow grant verification helper
+ * (`isRulePersisted` in `permission-rule.ts`).
+ *
+ * The `perm:always:*` handler in gateway.ts calls `isRulePersisted` after
+ * `switchroom agent grant` returns to confirm the rule actually landed in
+ * `tools.allow`. These tests drive the invariants that the structural test
+ * in `always-allow-grant.test.ts` can only pin by text-slicing:
+ *
+ *   1. exec "succeeds" but the reloaded allow-list does NOT contain the
+ *      rule  →  isRulePersisted returns false  (loud-failure path).
+ *   2. reloaded allow-list DOES contain the rule  →  returns true
+ *      (success path).
+ *   3. Realistic rule values (`Skill(garmin)`, `Bash`, `mcp__x__y`) round-
+ *      trip correctly — guards against normalization divergence where the
+ *      value written by `agent grant` and the value read back from yaml
+ *      diverge in shape.
+ *
+ * Because `isRulePersisted` is a pure function (takes the already-resolved
+ * allow-list directly), no mocking of `loadSwitchroomConfig` /
+ * `resolveAgentConfig` is required here.  The handler's interaction with
+ * those config loaders is covered by the structural test.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { isRulePersisted, resolveAlwaysAllowRule } from '../permission-rule.js'
+
+// ---------------------------------------------------------------------------
+// Core behavioral invariants
+// ---------------------------------------------------------------------------
+
+describe('isRulePersisted — failure path', () => {
+  it('returns false when the allow-list is empty (exec succeeded but nothing was written)', () => {
+    expect(isRulePersisted([], 'Bash')).toBe(false)
+  })
+
+  it('returns false when the rule is absent from a non-empty allow-list', () => {
+    expect(isRulePersisted(['Read', 'Write', 'Edit'], 'Bash')).toBe(false)
+  })
+
+  it('returns false for a Skill rule when the list only contains the bare tool name', () => {
+    // `agent grant` for Skill(garmin) should write `Skill(garmin)`, not
+    // `Skill`. If the yaml ended up with the wrong shape, the verification
+    // must catch it.
+    expect(isRulePersisted(['Skill'], 'Skill(garmin)')).toBe(false)
+  })
+
+  it('returns false for a bare tool name when only the parameterized form is present', () => {
+    expect(isRulePersisted(['Skill(garmin)'], 'Bash')).toBe(false)
+  })
+
+  it('returns false when a similar-looking rule is present but not an exact match', () => {
+    expect(isRulePersisted(['mcp__garmin__read_activity'], 'mcp__garmin__list_activities')).toBe(false)
+  })
+})
+
+describe('isRulePersisted — success path', () => {
+  it('returns true when the exact rule is present', () => {
+    expect(isRulePersisted(['Read', 'Bash', 'Write'], 'Bash')).toBe(true)
+  })
+
+  it('returns true when the rule is the only entry', () => {
+    expect(isRulePersisted(['Skill(garmin)'], 'Skill(garmin)')).toBe(true)
+  })
+
+  it('returns true for a namespaced MCP tool rule', () => {
+    expect(isRulePersisted(['mcp__garmin__list_activities', 'Bash'], 'mcp__garmin__list_activities')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Round-trip: resolveAlwaysAllowRule → isRulePersisted
+// Simulates the full handler flow: resolve the rule from a permission_request,
+// "grant" it (allow-list contains the resolved rule.rule), then verify.
+// Guards against normalization divergence between the value the handler
+// resolves and the value `agent grant` writes + the config reader returns.
+// ---------------------------------------------------------------------------
+
+describe('rule round-trip through isRulePersisted', () => {
+  it('Skill tool: resolved rule persists correctly', () => {
+    const rule = resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'garmin' }))
+    expect(rule).not.toBeNull()
+    // Simulate: allow-list now contains the rule that `agent grant` wrote.
+    expect(isRulePersisted([rule!.rule], rule!.rule)).toBe(true)
+    // Confirm the written form is `Skill(garmin)` — not a bare `Skill`.
+    expect(rule!.rule).toBe('Skill(garmin)')
+  })
+
+  it('Skill tool: absent rule is detected', () => {
+    const rule = resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'garmin' }))
+    expect(rule).not.toBeNull()
+    // allow-list was not updated (silent grant failure).
+    expect(isRulePersisted([], rule!.rule)).toBe(false)
+    expect(isRulePersisted(['Skill'], rule!.rule)).toBe(false)
+  })
+
+  it('Bash tool: round-trips correctly', () => {
+    const rule = resolveAlwaysAllowRule('Bash', undefined)
+    expect(rule).not.toBeNull()
+    expect(rule!.rule).toBe('Bash')
+    expect(isRulePersisted(['Bash', 'Read'], rule!.rule)).toBe(true)
+    expect(isRulePersisted(['Read'], rule!.rule)).toBe(false)
+  })
+
+  it('MCP tool: round-trips with exact namespaced form', () => {
+    const toolName = 'mcp__garmin__list_activities'
+    const rule = resolveAlwaysAllowRule(toolName, undefined)
+    expect(rule).not.toBeNull()
+    expect(rule!.rule).toBe(toolName)
+    expect(isRulePersisted([toolName], rule!.rule)).toBe(true)
+    expect(isRulePersisted(['mcp__garmin__read_activity'], rule!.rule)).toBe(false)
+  })
+
+  it('multiple Skill tools do not cross-contaminate', () => {
+    const garmin = resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'garmin' }))
+    const mail = resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'mail' }))
+    expect(garmin).not.toBeNull()
+    expect(mail).not.toBeNull()
+    // Allow-list only has garmin's rule.
+    const allowList = [garmin!.rule]
+    expect(isRulePersisted(allowList, garmin!.rule)).toBe(true)
+    expect(isRulePersisted(allowList, mail!.rule)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- **Loud failure**: When always-allow grant fails, the toast and inline-keyboard edit now use `⚠️` and unambiguous text ("Allowed for now, but 'always' did NOT save — it will ask again after restart") instead of the old `✅ Allowed (always-allow yaml edit failed; ...)` which read almost like success.
- **Post-write verification**: After `switchroomExec(['agent','grant',...])` returns success, the handler re-reads the resolved agent config (`loadSwitchroomConfig` + `resolveAgentConfig`) and confirms `rule.rule` is present in `tools.allow`. If absent, it treats the result as failure and shows the loud warning. This catches config-location drift (gateway editing a non-durable yaml) and no-op grants.
- **Error capture**: `grantFailReason` is populated from the thrown error and from the verify-fail reason, making the stderr log lines actionable.

## Why

An operator tapping "🔁 Always allow Skill(X)" could easily believe the rule persisted when the yaml write silently failed: the old failure ack started with `✅ Allowed`, the old edit label said `✅ Allowed (always-allow rule edit failed; see logs)`. After a restart the popup would return, with no clear explanation. Even a successful `switchroomExec` call gave no guarantee the rule appeared in the config that `scaffold.ts` reads on reconcile — the gateway might have edited a different yaml.

## What changed

`telegram-plugin/gateway/gateway.ts` — `behavior === 'always'` handler only (~45 line diff):
- Added `grantFailReason` variable to capture root cause
- Added inner try/catch after `switchroomExec` success: calls `loadSwitchroomConfig()` + `resolveAgentConfig()`, checks `tools.allow` includes `rule.rule`, sets `grantOk=true` only on confirmation
- Changed failure `ackText` from `✅ Allowed (always-allow yaml edit failed; ...)` to `⚠️ Allowed for now, but "always" did NOT save — ...`
- Changed failure `editLabel` from `✅ <b>Allowed</b> (always-allow rule edit failed; see logs)` to `⚠️ <b>Allowed for now — "always" did NOT save.</b> ...`
- Success path messaging and `synthInbound`/rule forwarding are unchanged

`telegram-plugin/tests/always-allow-grant.test.ts` — new structural test file:
- Pins loud failure text (ackText + editLabel use `⚠️`, old `✅` text absent)
- Pins that `loadSwitchroomConfig` is called after `switchroomExec`
- Pins that `grantOk=true` only inside `allowList.includes(rule.rule)` (not unconditionally)
- Pins `grantFailReason` capture and `VERIFY FAILED` log lines

## Verification

- Local toolchain not available on orchestrator; CI validates (`vitest`, `bun-test`, `lint`, `build-*`). Note: Local gates deferred to CI.
- `check-bot-api-wrapping.sh` passes (no new raw `bot.api`/`ctx.api` callsites — only existing `finalizeCallback` + `answerCallbackQuery` wrappers are used).

## Risk

Low — change is confined to the failure path of the always-allow handler. The success path (rule verified in config) keeps the existing `🔁 Always allow ...` + "restart agent for full effect" messaging. The `synthInbound` rule-forwarding logic (session-level auto-allow for sub-agents) is unchanged. The one new side effect in the success path is a single `loadSwitchroomConfig()` read — cheap and consistent with patterns already used in `resolveAgentOutboundTopic` and `getReactionsConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)