### PR TITLE
fix(draft-mirror): replay sidecar history to late subscribers

### DIFF
--- a/telegram-plugin/tests/tool-label-sidecar.test.ts
+++ b/telegram-plugin/tests/tool-label-sidecar.test.ts
@@ -83,6 +83,42 @@ describe('tool-label-sidecar', () => {
     s.stop()
   })
 
+  it('replays pre-existing rows to a subscriber that attaches after construction', () => {
+    // Regression: the gateway's session-tail constructs the sidecar (which
+    // does an initial drain of the file) and only THEN wires `onLabel`. On a
+    // fast/clustered turn — or a resumed/flipped session — the hook has
+    // already written labels, so the initial drain consumed them with an
+    // empty subscriber set. Before the replay fix the late subscriber got
+    // nothing, so the real-time draft-mirror never fired (every label lost).
+    const sessionId = 'sess-replay'
+    const f = join(stateDir, `tool-labels-${sessionId}.jsonl`)
+    writeFileSync(
+      f,
+      JSON.stringify({ ts: 1, tool_use_id: 'A', agent_id: 'g', label: 'Reading foo.ts', tool_name: 'Read' }) + '\n' +
+      JSON.stringify({ ts: 2, tool_use_id: 'B', agent_id: 'g', label: 'List workspace', tool_name: 'Bash' }) + '\n',
+    )
+    const sched = makeManualScheduler()
+    const s = createToolLabelSidecar({ stateDir, sessionId, scheduler: sched })
+    // Subscribe AFTER construction (the real ensureSidecar ordering).
+    const seen: Array<[string, string, string]> = []
+    s.onLabel((id, label, toolName) => seen.push([id, label, toolName]))
+    expect(seen).toEqual([
+      ['A', 'Reading foo.ts', 'Read'],
+      ['B', 'List workspace', 'Bash'],
+    ])
+
+    // And a row appended afterwards still reaches the subscriber exactly once
+    // (no double-emit of the replayed rows).
+    appendFileSync(f, JSON.stringify({ ts: 3, tool_use_id: 'C', agent_id: 'g', label: 'Searching memory', tool_name: 'mcp__hindsight__recall' }) + '\n')
+    s.poll()
+    expect(seen).toEqual([
+      ['A', 'Reading foo.ts', 'Read'],
+      ['B', 'List workspace', 'Bash'],
+      ['C', 'Searching memory', 'mcp__hindsight__recall'],
+    ])
+    s.stop()
+  })
+
   it('ignores malformed JSON lines', () => {
     const sessionId = 'sess4'
     const sched = makeManualScheduler()

--- a/telegram-plugin/tool-label-sidecar.ts
+++ b/telegram-plugin/tool-label-sidecar.ts
@@ -66,6 +66,14 @@ export interface SidecarOptions {
 export function createToolLabelSidecar(opts: SidecarOptions): ToolLabelSidecar {
   const path = join(opts.stateDir, `tool-labels-${opts.sessionId}.jsonl`)
   const labels = new Map<string, string>()
+  // Ordered log of every row ingested so far (label + tool_name), used to
+  // replay history to a subscriber that attaches AFTER rows were already
+  // read. Without this, a sidecar whose file is already populated when
+  // `onLabel` is wired (fast/clustered turns, resumed/flipped sessions —
+  // the gateway's `ensureSidecar` subscribes *after* construction's initial
+  // drain) would silently lose every pre-existing label, breaking the
+  // real-time draft-mirror determinism the sidecar exists to provide.
+  const seen: Array<{ toolUseId: string; label: string; toolName: string }> = []
   const subscribers = new Set<(toolUseId: string, label: string, toolName: string) => void>()
   let offset = 0
   let stopped = false
@@ -97,6 +105,7 @@ export function createToolLabelSidecar(opts: SidecarOptions): ToolLabelSidecar {
       // expect duplicates, but if one lands we keep the earliest.
       if (labels.has(row.tool_use_id)) continue
       labels.set(row.tool_use_id, row.label)
+      seen.push({ toolUseId: row.tool_use_id, label: row.label, toolName: row.tool_name })
       for (const cb of subscribers) {
         try { cb(row.tool_use_id, row.label, row.tool_name) } catch { /* ignore */ }
       }
@@ -134,6 +143,15 @@ export function createToolLabelSidecar(opts: SidecarOptions): ToolLabelSidecar {
       return labels.get(toolUseId)
     },
     onLabel(cb) {
+      // Replay rows already ingested before this subscriber attached, then
+      // register for future rows. Single-threaded: no row can be ingested
+      // between the replay loop and the add, so each row reaches `cb`
+      // exactly once. This is what makes the draft-mirror deterministic
+      // regardless of when the gateway subscribes relative to the hook's
+      // writes (see the `seen` declaration above).
+      for (const r of seen) {
+        try { cb(r.toolUseId, r.label, r.toolName) } catch { /* ignore */ }
+      }
       subscribers.add(cb)
       return () => subscribers.delete(cb)
     },


### PR DESCRIPTION
## Summary
The real-time draft-mirror feed (#1963) is driven by the PreToolUse tool-label sidecar. `createToolLabelSidecar` does an initial drain (`poll()`) in its constructor, but the gateway's session-tail wires `onLabel` only **after** construction (`ensureSidecar`: create → set → onLabel). On a fast/clustered turn — or a resumed/flipped session — the hook has already written every label by the time `ensureSidecar` runs, so the initial drain consumes them all with an **empty subscriber set** and advances the read offset to EOF. The subscriber that attaches microseconds later receives nothing → no `tool_label` events → the draft never fires. This is precisely the flush-independence #1963 promised, silently lost on the turns it targets.

## Why this matters
This is the root cause of the draft-mirror not streaming on v0.14.3. Repro'd live on the test-harness canary: a 28s clustered-tool turn wrote a fully-populated sidecar (`Bash`/`Read`/`ToolSearch` labels) yet **zero** `tool_label` events reached the gateway and **no** `sendMessageDraft` fired. Confirmed in isolation: constructing the sidecar on a pre-populated file then subscribing yields an empty subscriber callback.

## Fix
Buffer every ingested row (`label` + `tool_name`) in an ordered `seen` log; on `onLabel`, replay the buffer to the new subscriber, then register for future rows. Single-threaded, so each row reaches the callback **exactly once** regardless of subscribe timing. The sidecar is now deterministic no matter when the gateway subscribes relative to the hook's writes.

## Test plan
- [x] New regression test: pre-existing rows are replayed to a subscriber that attaches after construction; a subsequently-appended row still arrives exactly once (no double-emit).
- [x] All 7 `tool-label-sidecar` tests pass (`bun test`).
- [x] `tsc --noEmit` clean.
- [ ] Live re-validation on test-harness v0.14.3 + dev-build (clustered-tool mtcute turn → accumulating draft with HTML formatting).

## Risk
Low. Additive (an in-memory ordered buffer + replay on subscribe); no change to poll/offset/getLabel semantics or the wire protocol. Behind the existing `SWITCHROOM_DRAFT_MIRROR` flag (default off).