### PR TITLE
chore: release v0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## v0.14.4 — draft-mirror determinism fix (sidecar subscribe race) + CI/doctor
+
+### draft-mirror: replay sidecar history to late subscribers (#1969)
+
+The headline fix. v0.14.3's real-time sidecar (#1963) had a
+subscribe-after-drain ordering bug that silently lost the entire
+activity feed on exactly the turns it was built for, so the draft never
+streamed. Found by live validation on the test-harness canary: a 28s
+clustered-tool turn wrote a fully-populated sidecar
+(`Bash`/`Read`/`ToolSearch` labels) yet produced **zero** `tool_label`
+events and **no** `sendMessageDraft`.
+
+Root cause: `createToolLabelSidecar` does an initial drain (`poll()`) in
+its constructor, but the gateway's `ensureSidecar` wires `onLabel` only
+*after* construction (`create → set → onLabel`). On a fast/clustered
+turn — or any resumed/flipped session where the hook already wrote
+labels — the initial drain consumes every row into the read offset with
+an empty subscriber set, and the subscriber that attaches microseconds
+later receives nothing.
+
+Fix: buffer every ingested row (`label` + `tool_name`) in an ordered
+`seen` log and replay it to each subscriber when it attaches via
+`onLabel`, then register for future rows. Single-threaded, so each row
+reaches the callback exactly once regardless of subscribe timing — the
+sidecar is now deterministic no matter when the gateway subscribes
+relative to the hook's writes. Still behind `SWITCHROOM_DRAFT_MIRROR`
+(default OFF).
+
+### other
+
+- CI: docker-images now uses a GHCR registry cache instead of the flaky
+  `type=gha` cache, fixing the recurring SAS-token-expiry / stalled-blob
+  build failures on the heavy agent image (#1965 / #1968).
+- gateway: a failed always-allow grant is now surfaced loudly and the
+  grant is verified persisted before proceeding (#1967).
+- doctor: new probe asserting approval-kernel DB durability —
+  `allow_always` grants survive a container recreate (#1966).
+
 ## v0.14.3 — draft-mirror determinism (real-time sidecar) + pacing fixes
 
 ### draft-mirror: real-time via PreToolUse sidecar (#1963)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Patch release. Headline: fixes the v0.14.3 draft-mirror that never actually streamed — a subscribe-after-drain race in the tool-label sidecar (#1969) silently lost the activity feed on fast/clustered/resumed-session turns. Also bundles the docker-images CI cache fix (#1968), a gateway always-allow grant fix (#1967), and a new approval-kernel durability doctor probe (#1966).

## Constituent PRs (all reviewed/merged to main)
- #1969 fix(draft-mirror): replay sidecar history to late subscribers — reviewer APPROVED
- #1968/#1965 ci(docker-images): GHCR registry cache, drop flaky type=gha
- #1967 fix(gateway): failed always-allow loud + verify grant persisted
- #1966 feat(doctor): approval-kernel DB durability probe

## Test plan
- [x] All constituent PRs green on main; tool-label-sidecar tests + tsc clean.
- [ ] Tag → image build → npm publish → roll test-harness → live clustered-tool mtcute re-validation (the draft must now stream + accumulate with HTML).

## Risk
Low. The draft-mirror change is behind `SWITCHROOM_DRAFT_MIRROR` (default off). Release diff is version bump + changelog.