### PR TITLE
fix(session-tail): replay in-flight turn's enqueue on first attach

### DIFF
--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -604,6 +604,66 @@ export interface SessionTailHandle {
 }
 
 /**
+ * Byte offset to seek to on the FIRST attach to a session transcript.
+ *
+ * Normally EOF — we only want NEW events, not replayed history. But if the
+ * agent restarted MID-TURN (the bridge's session-tail starts only after
+ * claude has already written this turn's `queue-operation enqueue` line),
+ * a plain seek-to-EOF skips that enqueue. `enqueue` is the ONLY event that
+ * carries the chatId and that sets the gateway's `currentTurn`, so missing
+ * it leaves the first post-restart turn with no currentTurn — killing the
+ * progress card, draft-mirror, and silence-poke for that turn.
+ *
+ * Fix: in a bounded tail scan, find the last `enqueue` that has NO
+ * `turn_duration` (turn_end) after it — an in-flight turn — and return its
+ * line offset so it (and the turn's subsequent events) replay. A completed
+ * turn (a `turn_duration` follows the enqueue) returns EOF: no replay.
+ */
+export function computeFirstAttachCursor(file: string, size: number): number {
+  const SCAN_CAP = 1024 * 1024 // bound the tail read at 1 MiB
+  const scanStart = Math.max(0, size - SCAN_CAP)
+  let buf: Buffer
+  try {
+    const fd = openSync(file, 'r')
+    try {
+      buf = Buffer.allocUnsafe(size - scanStart)
+      readSync(fd, buf, 0, buf.length, scanStart)
+    } finally {
+      closeSync(fd)
+    }
+  } catch {
+    return size
+  }
+  let lastEnqueueOffset = -1
+  let turnEndedAfterEnqueue = false
+  let lineStart = 0
+  // If the scan didn't start at byte 0, the first line is a partial — skip it.
+  let skipPartial = scanStart > 0
+  for (let i = 0; i <= buf.length; i++) {
+    if (i !== buf.length && buf[i] !== 0x0a) continue
+    if (skipPartial) {
+      skipPartial = false
+    } else if (i > lineStart) {
+      const line = buf.toString('utf8', lineStart, i)
+      if (
+        line.includes('"type":"queue-operation"') &&
+        line.includes('"operation":"enqueue"')
+      ) {
+        lastEnqueueOffset = scanStart + lineStart
+        turnEndedAfterEnqueue = false
+      } else if (lastEnqueueOffset >= 0 && line.includes('"subtype":"turn_duration"')) {
+        turnEndedAfterEnqueue = true
+      }
+    }
+    lineStart = i + 1
+  }
+  if (lastEnqueueOffset >= 0 && !turnEndedAfterEnqueue) {
+    return lastEnqueueOffset
+  }
+  return size
+}
+
+/**
  * Start tailing the active Claude Code session file. The tailer:
  *  1. Polls the projects dir for the most recent .jsonl
  *  2. Opens it, seeks to current end (only NEW events are reported), and
@@ -778,14 +838,20 @@ export function startSessionTail(config: SessionTailConfig): SessionTailHandle {
       log?.(`session-tail: re-attached to ${file} (cursor=${cursor}, restored)`)
     } else {
       // First attach to this file — seek to current end so we only see
-      // new events, not history.
+      // new events, EXCEPT replay from an in-flight turn's enqueue if the
+      // agent restarted mid-turn (see firstAttachCursor).
       pendingPartial = ''
       try {
-        cursor = statSync(file).size
+        const size = statSync(file).size
+        cursor = computeFirstAttachCursor(file, size)
+        if (cursor < size) {
+          log?.(`session-tail: attached to ${file} (cursor=${cursor}, replaying in-flight turn from offset; size=${size})`)
+        } else {
+          log?.(`session-tail: attached to ${file} (cursor=${cursor})`)
+        }
       } catch {
         cursor = 0
       }
-      log?.(`session-tail: attached to ${file} (cursor=${cursor})`)
     }
     // Eagerly create + subscribe the PreToolUse sidecar for this session
     // NOW (on attach), not lazily on the first JSONL tool_use — otherwise

--- a/telegram-plugin/tests/session-tail-first-attach.test.ts
+++ b/telegram-plugin/tests/session-tail-first-attach.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { computeFirstAttachCursor } from '../session-tail.js'
+
+/**
+ * computeFirstAttachCursor: on first attach to a transcript, seek to EOF
+ * UNLESS the agent restarted mid-turn (an `enqueue` with no `turn_duration`
+ * after it). Missing that enqueue strands the first post-restart turn with
+ * no currentTurn (dead progress card / draft-mirror / silence-poke).
+ */
+
+const ENQUEUE = '{"type":"queue-operation","operation":"enqueue","content":"chat:123 msg:1"}'
+const DEQUEUE = '{"type":"queue-operation","operation":"dequeue"}'
+const ASSISTANT = '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}'
+const TURN_DURATION = '{"type":"system","subtype":"turn_duration","durationMs":4200}'
+
+function writeTranscript(dir: string, lines: string[]): { file: string; size: number } {
+  const file = join(dir, 'sess.jsonl')
+  writeFileSync(file, lines.join('\n') + '\n')
+  return { file, size: statSync(file).size }
+}
+
+function offsetOfLine(lines: string[], index: number): number {
+  let off = 0
+  for (let i = 0; i < index; i++) off += Buffer.byteLength(lines[i]!, 'utf8') + 1 // +1 for '\n'
+  return off
+}
+
+describe('computeFirstAttachCursor', () => {
+  let dir: string
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'first-attach-')) })
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+  it('in-flight turn (enqueue, no turn_duration after) → replays from the enqueue offset', () => {
+    const lines = [ASSISTANT, ENQUEUE, DEQUEUE, ASSISTANT] // enqueue at index 1, no turn_duration
+    const { file, size } = writeTranscript(dir, lines)
+    expect(computeFirstAttachCursor(file, size)).toBe(offsetOfLine(lines, 1))
+  })
+
+  it('completed turn (turn_duration after the enqueue) → EOF, no replay', () => {
+    const lines = [ENQUEUE, DEQUEUE, ASSISTANT, TURN_DURATION]
+    const { file, size } = writeTranscript(dir, lines)
+    expect(computeFirstAttachCursor(file, size)).toBe(size)
+  })
+
+  it('no enqueue in the tail → EOF', () => {
+    const lines = [ASSISTANT, ASSISTANT, TURN_DURATION]
+    const { file, size } = writeTranscript(dir, lines)
+    expect(computeFirstAttachCursor(file, size)).toBe(size)
+  })
+
+  it('completed turn followed by a NEW in-flight turn → replays from the second enqueue', () => {
+    // turn 1: enqueue+turn_duration (done). turn 2: enqueue, still running.
+    const lines = [ENQUEUE, ASSISTANT, TURN_DURATION, ENQUEUE, DEQUEUE, ASSISTANT]
+    const { file, size } = writeTranscript(dir, lines)
+    expect(computeFirstAttachCursor(file, size)).toBe(offsetOfLine(lines, 3))
+  })
+
+  it('empty / missing file → returns the given size (degrades to EOF)', () => {
+    const missing = join(dir, 'nope.jsonl')
+    expect(computeFirstAttachCursor(missing, 0)).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
The **first turn after every agent restart** loses its `currentTurn`, so the **progress card, draft-mirror, and silence-poke** are all dead for that turn (the reply still lands; the per-turn UI does not).

## Root cause (validated live, not inferred)
The gateway sets `currentTurn` **only** from the `enqueue` session event — the sole event carrying the chatId (`forwardSessionEvent` attaches chatId for `enqueue` only). The bridge's session-tail emits `enqueue` when it reads the transcript's `queue-operation enqueue` line, but on **first attach it seeks to EOF** (`statSync(file).size`, "only new events"). When the agent restarts mid-turn — or a spooled inbound is processed during boot — that enqueue line is written *before* the tail attaches, so seek-to-EOF skips it → no `enqueue` event → `currentTurn` never set.

Runtime evidence from the test-harness canary (instrumented build):
- **Cold (first-post-restart) turn:** gateway received every `tool_use`/`tool_label` with `currentTurn=false`; draft handler bails at `if (turn == null) return`. No `sendMessageDraft`. The transcript *did* contain the enqueue line — the tail had seeked past it.
- **Warm turn:** `enqueue` received → `currentTurn=true` → `sendMessageDraft` fired and **accumulated** (bytes 34→59→0), `parse_mode=HTML`, cleared at `turn_end`.

So the draft-mirror feature itself is correct (works on warm turns); the bug is the missed enqueue on first attach. It also explains a pre-existing latent issue: the progress card has always been skipped on the first post-restart turn.

## Fix
`computeFirstAttachCursor(file, size)` does a bounded (1 MiB) backward-aware tail scan on first attach. If it finds an **in-flight turn** (the last `enqueue` with no `turn_duration`/turn_end after it), it returns that enqueue's byte offset so the turn replays from its start → the enqueue is emitted → `currentTurn` is set. A **completed turn** (a `turn_duration` follows the enqueue) still seeks to EOF — no history replay. Re-attach (sub-agent file flips) is unchanged (restores the saved per-file cursor).

## Test plan
- [x] New unit test `session-tail-first-attach.test.ts` (5 deterministic cases): in-flight→enqueue offset; completed→EOF; no-enqueue→EOF; completed-then-in-flight→second enqueue; missing-file→size.
- [x] All 12 session-tail + sidecar unit tests pass (`bun test`); `tsc --noEmit` clean.
- [x] Live: clean build on test-harness — warm + first-post-restart turns both stream the accumulating HTML draft, cleared at turn_end.

## Risk
Low and bounded. Only the **first attach** changes, and only when an in-flight enqueue is detected; otherwise behavior is identical (EOF). The replay is the same read-from-cursor path the tail already uses. Flag-independent (helps the progress card too), but the draft-mirror is still behind `SWITCHROOM_DRAFT_MIRROR` (default off).