### PR TITLE
fix(config): cascade allowed_tools/disallowed_tools from defaults

### DIFF
--- a/src/config/merge.test.ts
+++ b/src/config/merge.test.ts
@@ -48,3 +48,69 @@ describe("mergeAgentConfig — release cascade", () => {
     expect(result.release).toBeUndefined();
   });
 });
+
+describe("mergeAgentConfig — allowed_tools / disallowed_tools cascade", () => {
+  it("cascades defaults.allowed_tools when the agent sets none (the silent-no-op bug)", () => {
+    const defaults = {
+      allowed_tools: ["mcp__perplexity", "mcp__perplexity__*"],
+    } as AgentDefaults;
+    const result = mergeAgentConfig(defaults, baseAgent());
+    expect(result.allowed_tools).toEqual([
+      "mcp__perplexity",
+      "mcp__perplexity__*",
+    ]);
+  });
+
+  it("unions defaults + agent allowed_tools (defaults first, agent extends)", () => {
+    const defaults = {
+      allowed_tools: ["mcp__perplexity__*"],
+    } as AgentDefaults;
+    const agent = baseAgent({
+      allowed_tools: ["Bash(git *)"],
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.allowed_tools).toEqual([
+      "mcp__perplexity__*",
+      "Bash(git *)",
+    ]);
+  });
+
+  it("dedups overlapping entries preserving first-seen (defaults) order", () => {
+    const defaults = {
+      allowed_tools: ["mcp__perplexity__*", "Edit"],
+    } as AgentDefaults;
+    const agent = baseAgent({
+      allowed_tools: ["Edit", "Bash(npm *)"],
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.allowed_tools).toEqual([
+      "mcp__perplexity__*",
+      "Edit",
+      "Bash(npm *)",
+    ]);
+  });
+
+  it("uses agent allowed_tools when defaults absent", () => {
+    const agent = baseAgent({
+      allowed_tools: ["mcp__webkite__*"],
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig(undefined, agent);
+    expect(result.allowed_tools).toEqual(["mcp__webkite__*"]);
+  });
+
+  it("leaves allowed_tools undefined when neither layer sets it", () => {
+    const result = mergeAgentConfig({} as AgentDefaults, baseAgent());
+    expect(result.allowed_tools).toBeUndefined();
+  });
+
+  it("cascades disallowed_tools the same way", () => {
+    const defaults = {
+      disallowed_tools: ["WebFetch"],
+    } as AgentDefaults;
+    const agent = baseAgent({
+      disallowed_tools: ["Bash(rm *)"],
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.disallowed_tools).toEqual(["WebFetch", "Bash(rm *)"]);
+  });
+});

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -586,6 +586,34 @@ export function mergeAgentConfig(
     ];
   }
 
+  // --- allowed_tools / disallowed_tools: union, dedup-preserving-order
+  //     (defaults first) ---
+  //
+  // Both feed Claude Code's --allowedTools / --disallowedTools flags
+  // (#199). Before this clause `mergeAgentConfig` copied an explicit
+  // scalar/array field list and silently omitted these two, so
+  // `defaults.allowed_tools` was accepted by the schema but never
+  // reached the agent's `exec claude` invocation — a silent no-op that
+  // looked like it should work (e.g. fleet-wide pre-approval of an
+  // operator-defined MCP server's tools like `mcp__perplexity__*`).
+  // Union+dedup (not concat) because these are permission PATTERNS, not
+  // repeatable CLI flags: a default grant + an identical agent grant is
+  // redundant, and the agent layer EXTENDS the fleet policy rather than
+  // replacing it. Dedup preserves first-seen order (defaults before
+  // agent-specific entries).
+  if (defaults.allowed_tools || merged.allowed_tools) {
+    merged.allowed_tools = dedupe([
+      ...(defaults.allowed_tools ?? []),
+      ...(merged.allowed_tools ?? []),
+    ]);
+  }
+  if (defaults.disallowed_tools || merged.disallowed_tools) {
+    merged.disallowed_tools = dedupe([
+      ...(defaults.disallowed_tools ?? []),
+      ...(merged.disallowed_tools ?? []),
+    ]);
+  }
+
   // --- extra_stable_files: union, dedup-preserving-order (defaults first) ---
   //
   // Follows the same pattern as `skills`: defaults provide the base list,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1511,6 +1511,30 @@ const profileFields = {
       "Opt-in flags for experimental / legacy behaviours. Cascades through " +
       "defaults → profile → per-agent.",
     ),
+  // Mirror of AgentSchema.allowed_tools / disallowed_tools — repeated
+  // here (AgentSchema does not spread profileFields, same as
+  // `resources`) so the fields are accepted at the defaults + profile
+  // levels and cascade to agents via mergeAgentConfig. Without these,
+  // `defaults.allowed_tools` was stripped at parse (unknown key) AND
+  // dropped at merge — a silent double no-op. See #199 + the
+  // allowed_tools/disallowed_tools cascade clause in merge.ts.
+  allowed_tools: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Granular tool allowlist passed verbatim to Claude Code's --allowedTools " +
+      "flag. Cascades defaults → profile → per-agent (union, dedup). Supports " +
+      "patterns like 'Bash(git *)' or 'mcp__perplexity__*' that the coarse " +
+      "`tools.allow` field can't express. See #199."
+    ),
+  disallowed_tools: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Granular tool denylist passed verbatim to Claude Code's --disallowedTools " +
+      "flag. Cascades defaults → profile → per-agent (union, dedup). Same pattern " +
+      "syntax as allowed_tools (e.g. 'Bash(rm *)'). See #199."
+    ),
 };
 
 /**


### PR DESCRIPTION
## Summary

`defaults.allowed_tools` (and `disallowed_tools`) was a **silent double
no-op**: stripped at parse (not in `AgentDefaultsSchema`) AND dropped at
merge (no cascade clause in `mergeAgentConfig`). An operator setting a
fleet-wide granular tool policy — e.g. pre-approving an operator-defined
MCP server's tools with `allowed_tools: [mcp__perplexity, mcp__perplexity__*]`
— saw it silently ignored; every agent still prompted on first perplexity
tool call.

Discovered while wiring fleet-wide pre-approval for the perplexity MCP
(the secret `perplexity/api-key` is already broker-allowlisted via
`defaults.mcp_servers.perplexity.secrets`; only the tool *invocations*
were prompting).

## Root cause

`allowed_tools`/`disallowed_tools` are agent-only fields (defined inline
in `AgentSchema`, #199), and `AgentSchema` deliberately does **not**
spread `profileFields` — shared fields must be mirrored in both (same
convention as `resources`). They were never mirrored, so they never
existed at the defaults/profile levels.

## Fix

- **schema.ts** — mirror both fields into `profileFields` so
  `AgentDefaultsSchema` + `ProfileSchema` accept them.
- **merge.ts** — cascade both in `mergeAgentConfig`: union, dedup-
  preserving-order (defaults first), mirroring `extra_stable_files`.
  Union (not REPLACE) so an agent's grants EXTEND the fleet policy;
  dedup because these are permission patterns, not repeatable flags.
- **merge.test.ts** — 6 new cases (defaults-only cascade, union,
  dedup-order, agent-only, neither, disallowed_tools mirror).

## Verification

End-to-end against the live operator config: `defaults.allowed_tools`
now survives parse AND resolves onto a downstream agent (clerk) — was
dropped on both counts before.

## Test plan
- [x] 258/258 `src/config/` vitest
- [x] 178/178 `tests/scaffold.test.ts` (the #199 `--allowedTools` render path)
- [x] tsc clean; plugin-references / bot-api-wrapping / bun-test-imports / no-pii clean
- [x] `node scripts/build.mjs` clean

## Scope note
Deliberately does NOT auto-pre-approve all operator-defined MCP servers'
tools in `scaffold.ts` permissionAllow — tool pre-approval stays an
explicit operator policy via `allowed_tools` rather than an implicit
blanket auto-approve.

## Risk
Low. Union+dedup cascade can only ADD patterns; existing agents with no
`allowed_tools` are unaffected (clause only fires when a layer sets it).
settings.json `permissions.allow` (built from `tools.allow`) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)