### PR TITLE
fix(approvals): durable always-allow via hostd config_propose_edit (#1977)

### DIFF
--- a/telegram-plugin/gateway/config-approval-handler.ts
+++ b/telegram-plugin/gateway/config-approval-handler.ts
@@ -64,6 +64,28 @@ export interface ConfigApprovalHandlerDeps {
     content: string;
   }) => Promise<void>;
   log?: (msg: string) => void;
+  /**
+   * Single-tap correlation auto-resolve (#1977, security-critical).
+   *
+   * The durable "🔁 Always allow" flow has the gateway itself call
+   * hostd's `config_propose_edit`. hostd then calls BACK to the gateway
+   * asking for operator approval — but the operator already tapped the
+   * permission card, so posting a SECOND approval card would be a
+   * confusing double-tap.
+   *
+   * When this hook returns `'approve'`, the handler resolves the
+   * request immediately WITHOUT posting a card, creating a pending
+   * entry, or arming a timer. Returning `null` (the default / no-hook
+   * behaviour) falls through to the normal operator-approval card —
+   * which is what ANY uncorrelated edit (e.g. an agent-forged config
+   * change) gets, preserving the human-in-the-loop control.
+   *
+   * Forge-resistance lives in the caller's implementation: it must
+   * require the rule the diff *adds* to match a rule the gateway just
+   * queued, so a forged edit touching any other field finds no
+   * correlation and gets a real card.
+   */
+  tryAutoResolve?: (msg: RequestConfigApprovalMessage) => "approve" | null;
 }
 
 /**
@@ -209,6 +231,20 @@ export async function handleRequestConfigApproval(
       `gateway serves '${deps.agentName}', not '${msg.agentName}'`,
       "dispatch_failure",
     );
+    return;
+  }
+
+  // Single-tap correlation (#1977): if THIS edit was initiated by the
+  // gateway itself in response to an operator tap on the permission
+  // card, auto-approve without posting a second card. Forge-resistance
+  // is the caller's job — it correlates on the rule the diff adds. Any
+  // uncorrelated (e.g. agent-forged) edit returns null here and falls
+  // through to the real operator-approval card below.
+  if (deps.tryAutoResolve?.(msg) === "approve") {
+    deps.log?.(
+      `config_approval_auto_resolved requestId=${msg.requestId} agent=${msg.agentName} (operator-tapped always-allow correlation)`,
+    );
+    reply("approve");
     return;
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -252,7 +252,7 @@ import { injectSlashCommand as injectSlashCommandImpl } from '../../src/agents/i
 import { handleInjectCommand } from './inject-handler.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
-import { loadConfig as loadSwitchroomConfig } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
+import { loadConfig as loadSwitchroomConfig, findConfigFile as findSwitchroomConfigFile } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
 import { resolveOutboundTopic as resolveOutboundTopicHelper, type TopicRouterConfig as _OutboundRouterConfig } from '../../src/telegram/topic-router.js'
 import { readTurnUsages } from '../../src/agents/perf.js'
 import { decideProactiveCompact, initialCompactState, type CompactState } from './proactive-compact.js'
@@ -369,6 +369,7 @@ import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.
 import { list as listIssues, resolve as resolveIssue } from '../../src/issues/index.js'
 import { summarizeToolForTitle, formatPermissionCardBody } from '../permission-title.js'
 import { resolveAlwaysAllowRule, isRulePersisted } from '../permission-rule.js'
+import { synthesizeAllowRuleDiff, extractAddedAllowRule } from '../permission-diff.js'
 import {
   readClaudeJsonOverage,
   evaluateCreditState,
@@ -2281,6 +2282,27 @@ const STATUS_QUERY_RE = /^\s*status\??\s*$/i
 const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number }>()
 const PERMISSION_TTL_MS = 10 * 60_000
+
+// #1977 — single-tap correlation for the durable "🔁 Always allow"
+// flow. When the gateway dispatches a `config_propose_edit` to hostd in
+// response to an operator tap, hostd calls BACK asking for operator
+// approval. We pre-register the (agent, rule) pair here keyed
+// `${agentName}::${rule}` so that callback auto-approves WITHOUT a
+// second card. Forge-resistance: the auto-resolve match requires the
+// rule the inbound diff ADDS (via extractAddedAllowRule) to equal a
+// rule the gateway itself just queued — a forged edit touching any
+// other field finds no entry and falls through to a real operator card.
+// Single-shot (deleted on match) + 30s TTL sweep so a stale correlation
+// can't be replayed.
+const pendingAlwaysAllowCorrelations = new Map<string, { agentName: string; rule: string; createdAt: number }>()
+const ALWAYS_ALLOW_CORRELATION_TTL_MS = 30_000
+function sweepStaleAlwaysAllowCorrelations(now = Date.now()): void {
+  for (const [key, entry] of pendingAlwaysAllowCorrelations) {
+    if (now - entry.createdAt > ALWAYS_ALLOW_CORRELATION_TTL_MS) {
+      pendingAlwaysAllowCorrelations.delete(key)
+    }
+  }
+}
 
 // `ask_user` MCP tool — open prompts awaiting a user button-tap.
 // Keyed by askId (8 hex chars from generateAskId). Each entry holds
@@ -4572,6 +4594,24 @@ const ipcServer: IpcServer = createIpcServer({
       },
       log: (m) =>
         process.stderr.write(`telegram gateway: config-approval — ${m}\n`),
+      // #1977 single-tap correlation: auto-approve a config edit the
+      // gateway itself just queued in response to an operator tap on
+      // the "🔁 Always allow" permission card. Forge-resistant — the
+      // match requires the rule the diff ADDS to equal a rule the
+      // gateway queued; an agent-forged edit touching any other field
+      // finds no entry and falls through to a real operator card.
+      tryAutoResolve: (msg) => {
+        sweepStaleAlwaysAllowCorrelations()
+        const added = extractAddedAllowRule(msg.unifiedDiff)
+        if (!added) return null
+        const key = `${msg.agentName}::${added}`
+        const entry = pendingAlwaysAllowCorrelations.get(key)
+        if (entry) {
+          pendingAlwaysAllowCorrelations.delete(key)
+          return 'approve'
+        }
+        return null
+      },
     })
   },
 
@@ -15266,13 +15306,20 @@ bot.on('callback_query:data', async ctx => {
   }
 
   if (behavior === 'always') {
-    // "🔁 Always allow" — write the resolved rule into the agent's
-    // tools.allow in switchroom.yaml via the existing `agent grant`
-    // CLI verb, then approve the in-flight request. Reconcile updates
-    // settings.json so future SESSIONS skip the popup; the in-flight
-    // turn already has its settings.json loaded so the rule won't
-    // suppress later prompts on this same turn — operator restarts
-    // the agent if they want full immediate effect.
+    // "🔁 Always allow" (#1977) — persist the resolved rule into the
+    // agent's tools.allow in the DURABLE host config. The old path
+    // shelled `switchroom agent grant` which wrote
+    // /state/config/switchroom.yaml — but that path is bind-mounted
+    // READ-ONLY into agent containers, so the write silently no-op'd.
+    // Durable host-config writes only land via the host-side hostd
+    // daemon's `config_propose_edit` flow. We:
+    //   1. dispatch the in-flight Allow verdict IMMEDIATELY (turn must
+    //      not block on the host round-trip);
+    //   2. if hostd is not-configured → fall back to the legacy
+    //      `agent grant` + verify path (honest messaging only);
+    //   3. otherwise synthesize a unified diff adding the rule to the
+    //      agent's tools.allow and send it to hostd, awaiting the
+    //      apply+reconcile result.
     const details = pendingPermissions.get(request_id)
     if (!details) { await ctx.answerCallbackQuery({ text: 'Details no longer available.' }).catch(() => {}); return }
     const rule = resolveAlwaysAllowRule(details.tool_name, details.input_preview)
@@ -15285,57 +15332,143 @@ bot.on('callback_query:data', async ctx => {
       await ctx.answerCallbackQuery({ text: 'Always-allow needs SWITCHROOM_AGENT_NAME — gateway is misconfigured.' }).catch(() => {})
       return
     }
-    let grantOk = false
-    let grantFailReason = ''
-    try {
-      // --no-restart: settings.json gets the new entry on the next
-      // reconcile but we don't bounce the agent mid-turn. Operator
-      // can restart manually if they want this rule live in this
-      // session; otherwise it kicks in next session.
-      switchroomExec(['agent', 'grant', agentName, rule.rule, '--no-restart'])
-      // Verify the rule actually landed in the resolved config — guards
-      // against config-location-drift (gateway edited a yaml that isn't
-      // the durable source-of-truth, or the grant was a no-op). One
-      // fresh config read; cheap since this is a rare operator tap.
-      try {
-        const cfg = loadSwitchroomConfig()
-        const rawAgent = cfg.agents?.[agentName]
-        if (rawAgent) {
-          const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent)
-          const allowList: string[] = (resolved as { tools?: { allow?: string[] } }).tools?.allow ?? []
-          if (isRulePersisted(allowList, rule.rule)) {
-            grantOk = true
-            process.stderr.write(
-              `telegram gateway: always-allow added rule="${rule.rule}" agent=${agentName} (request_id=${request_id})\n`,
-            )
-          } else {
-            grantFailReason = `rule "${rule.rule}" not found in resolved tools.allow after write — config location may have drifted`
-            process.stderr.write(
-              `telegram gateway: always-allow VERIFY FAILED: ${grantFailReason} (request_id=${request_id})\n`,
-            )
-          }
-        } else {
-          grantFailReason = `agent "${agentName}" not found in config after write`
-          process.stderr.write(
-            `telegram gateway: always-allow VERIFY FAILED: ${grantFailReason} (request_id=${request_id})\n`,
-          )
-        }
-      } catch (verifyErr) {
-        grantFailReason = `config re-read failed: ${(verifyErr as Error).message}`
-        process.stderr.write(
-          `telegram gateway: always-allow VERIFY FAILED: ${grantFailReason} (request_id=${request_id})\n`,
-        )
-      }
-    } catch (err) {
-      grantFailReason = (err as Error).message
-      process.stderr.write(`telegram gateway: always-allow grant failed: ${grantFailReason}\n`)
-    }
 
     pendingPermissions.delete(request_id)
 
-    const ackText = grantOk
-      ? `🔁 Always allow ${rule.label} for ${agentName}`
-      : `⚠️ Allowed for now, but "always" did NOT save — it will ask again after restart. Check gateway log.`
+    // (2) Dispatch the in-flight permission verdict IMMEDIATELY — before
+    // any host round-trip — so the turn never blocks on persistence.
+    // We carry the resolved `rule` so the bridge caches it for the rest
+    // of the session and auto-allows matching tool calls from sub-agents
+    // (Task tool) + the parent without re-popping the prompt (#1138).
+    // The rule is safe to cache regardless of whether the *durable*
+    // write later succeeds — it's the operator's explicit intent.
+    dispatchPermissionVerdict({
+      type: 'permission',
+      requestId: request_id,
+      behavior: 'allow',
+      rule: rule.rule,
+    })
+
+    // (3) Decide the persistence path. tryHostdDispatch returns
+    // "not-configured" when host_control is disabled or the per-agent
+    // socket is absent → legacy fallback.
+    let durable = false
+    let legacy = false
+    let failReason = ''
+    let editLockHint = false
+
+    const configEditDisabled = (msg: string): boolean =>
+      msg.includes('E_CONFIG_EDIT_DISABLED')
+
+    const unifiedDiff = (() => {
+      try {
+        const cfgPath = process.env.SWITCHROOM_CONFIG ?? SWITCHROOM_CONFIG ?? findSwitchroomConfigFile()
+        const raw = readFileSync(cfgPath, 'utf8')
+        return synthesizeAllowRuleDiff({ agentName, rule: rule.rule, configText: raw })
+      } catch (err) {
+        process.stderr.write(`telegram gateway: always-allow diff synth failed: ${(err as Error).message}\n`)
+        return null
+      }
+    })()
+
+    const correlationKey = `${agentName}::${rule.rule}`
+    try {
+      if (unifiedDiff == null) {
+        // Could not locate the agent block / read config → fall back to
+        // the legacy grant path; its own verify will produce honest
+        // messaging.
+        legacy = true
+      } else {
+        // Pre-register the single-tap correlation so hostd's callback
+        // (request_config_approval) auto-approves WITHOUT a second card.
+        pendingAlwaysAllowCorrelations.set(correlationKey, { agentName, rule: rule.rule, createdAt: Date.now() })
+        const req: HostdRequest = {
+          v: 1,
+          op: 'config_propose_edit',
+          request_id: hostdRequestId('gw-always-allow'),
+          args: {
+            unified_diff: unifiedDiff,
+            reason: `Operator 'always allow' for ${rule.label}`,
+            target_path: '/state/config/switchroom.yaml',
+          },
+        }
+        // config_propose_edit blocks on validate→approve→apply→reconcile,
+        // so allow ~60s (well past the default 5s).
+        const resp = await tryHostdDispatch(agentName, req, 60_000)
+        if (resp === 'not-configured') {
+          warnLegacySpawnIfHostdDisabled('always-allow')
+          legacy = true
+        } else if (resp.result === 'completed') {
+          durable = true
+          process.stderr.write(
+            `telegram gateway: always-allow durable via hostd rule="${rule.rule}" agent=${agentName} (request_id=${request_id})\n`,
+          )
+        } else {
+          failReason = resp.error ?? `hostd ${resp.result}`
+          if (configEditDisabled(failReason)) editLockHint = true
+          process.stderr.write(
+            `telegram gateway: always-allow hostd FAILED: ${failReason} (request_id=${request_id})\n`,
+          )
+        }
+      }
+
+      if (legacy) {
+        // Legacy not-configured fallback — keep TODAY's behaviour:
+        // shell `agent grant` (writes the host yaml only when the
+        // gateway has a writable path) + verify the rule actually
+        // landed. Honest messaging: "saved (legacy path)" on verify,
+        // else the "did NOT save" warning.
+        try {
+          switchroomExec(['agent', 'grant', agentName, rule.rule, '--no-restart'])
+          try {
+            const cfg = loadSwitchroomConfig()
+            const rawAgent = cfg.agents?.[agentName]
+            if (rawAgent) {
+              const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent)
+              const allowList: string[] = (resolved as { tools?: { allow?: string[] } }).tools?.allow ?? []
+              if (isRulePersisted(allowList, rule.rule)) {
+                durable = true // legacy path verified — durable on this host shape
+                process.stderr.write(
+                  `telegram gateway: always-allow added rule="${rule.rule}" agent=${agentName} via legacy grant (request_id=${request_id})\n`,
+                )
+              } else {
+                failReason = `rule "${rule.rule}" not found in resolved tools.allow after write — config location may have drifted`
+                process.stderr.write(
+                  `telegram gateway: always-allow VERIFY FAILED: ${failReason} (request_id=${request_id})\n`,
+                )
+              }
+            } else {
+              failReason = `agent "${agentName}" not found in config after write`
+              process.stderr.write(
+                `telegram gateway: always-allow VERIFY FAILED: ${failReason} (request_id=${request_id})\n`,
+              )
+            }
+          } catch (verifyErr) {
+            failReason = `config re-read failed: ${(verifyErr as Error).message}`
+            process.stderr.write(
+              `telegram gateway: always-allow VERIFY FAILED: ${failReason} (request_id=${request_id})\n`,
+            )
+          }
+        } catch (err) {
+          failReason = (err as Error).message
+          process.stderr.write(`telegram gateway: always-allow grant failed: ${failReason}\n`)
+        }
+      }
+    } finally {
+      // Single-shot correlation — drop it whether or not it was
+      // consumed by hostd's callback, so it can never be replayed.
+      pendingAlwaysAllowCorrelations.delete(correlationKey)
+    }
+
+    const ok = durable
+    const legacyNote = legacy && durable
+    const ackText = ok
+      ? (legacyNote
+          ? `🔁 Always allow ${rule.label} for ${agentName} (legacy path)`
+          : `🔁 Always allow ${rule.label} for ${agentName}`)
+      : (editLockHint
+          ? `⚠️ Allowed for now — config edits are locked. Enable hostd.config_edit_enabled.`
+          : `⚠️ Allowed for now, but "always" did NOT save — it will ask again after restart. Check gateway log.`)
     // HTML-escape baseText — `ctx.callbackQuery.message.text` returns
     // entities-stripped plain UTF-8, so raw `<`/`>`/`&` in the
     // expanded permission card's `description` or `input_preview`
@@ -15346,37 +15479,22 @@ bot.on('callback_query:data', async ctx => {
     const baseText = sourceMsg && 'text' in sourceMsg && sourceMsg.text
       ? escapeHtmlForTg(sourceMsg.text)
       : ''
-    const editLabel = grantOk
-      ? `🔁 <b>Always allow ${escapeHtmlForTg(rule.label)}</b> for ${escapeHtmlForTg(agentName)} — restart agent for full effect`
-      : `⚠️ <b>Allowed for now — "always" did NOT save.</b> It will ask again after restart. Check gateway log.`
+    const editLabel = ok
+      ? (legacyNote
+          ? `🔁 <b>Always allow ${escapeHtmlForTg(rule.label)}</b> for ${escapeHtmlForTg(agentName)} — saved (legacy path); restart agent for full effect`
+          : `🔁 <b>Always allow ${escapeHtmlForTg(rule.label)}</b> for ${escapeHtmlForTg(agentName)} — saved; restart agent for full effect`)
+      : (editLockHint
+          ? `⚠️ <b>Allowed for now — "always" did NOT save.</b> Config edits are locked; enable <code>hostd.config_edit_enabled</code>.`
+          : `⚠️ <b>Allowed for now — "always" did NOT save.</b> It will ask again after restart. Check gateway log.`)
     // #1150 audit: route through finalizeCallback so the keyboard
-    // strips alongside the status-line edit. Pre-fix this called
-    // editMessageText without `reply_markup` so the Allow/Deny/Always
-    // buttons stayed tappable after the decision — re-tap would re-
-    // fire the permission broadcast.
+    // strips alongside the status-line edit. The in-flight verdict was
+    // ALREADY dispatched above (independently of this host round-trip)
+    // so the turn never blocked — finalizeCallback here only edits the
+    // card; no synthInbound (would double-fire the verdict).
     await finalizeCallback(ctx, {
       ackText: ackText.slice(0, 200),
       newText: baseText ? `${baseText}\n\n${editLabel}` : editLabel,
       parseMode: 'HTML',
-      // Forward approval for the in-flight request regardless — even
-      // if the yaml edit failed, the operator clearly meant "yes" so
-      // we honour the immediate decision and surface the failure as
-      // a hint in the chat.
-      //
-      // #1138: also carry the resolved `rule` so the bridge can cache
-      // it for the rest of the session and auto-allow matching tool
-      // calls from sub-agents (Task tool) and the parent without
-      // re-popping the prompt. Only set when the yaml edit succeeded —
-      // otherwise the rule may be unsafe to honour at scale and we
-      // fall back to single-use allow.
-      synthInbound: () => {
-        dispatchPermissionVerdict({
-          type: 'permission',
-          requestId: request_id,
-          behavior: 'allow',
-          ...(grantOk ? { rule: rule.rule } : {}),
-        })
-      },
     })
     return
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2294,7 +2294,7 @@ const PERMISSION_TTL_MS = 10 * 60_000
 // other field finds no entry and falls through to a real operator card.
 // Single-shot (deleted on match) + 30s TTL sweep so a stale correlation
 // can't be replayed.
-const pendingAlwaysAllowCorrelations = new Map<string, { agentName: string; rule: string; createdAt: number }>()
+const pendingAlwaysAllowCorrelations = new Map<string, { agentName: string; rule: string; unifiedDiff: string; createdAt: number }>()
 const ALWAYS_ALLOW_CORRELATION_TTL_MS = 30_000
 function sweepStaleAlwaysAllowCorrelations(now = Date.now()): void {
   for (const [key, entry] of pendingAlwaysAllowCorrelations) {
@@ -4602,11 +4602,19 @@ const ipcServer: IpcServer = createIpcServer({
       // finds no entry and falls through to a real operator card.
       tryAutoResolve: (msg) => {
         sweepStaleAlwaysAllowCorrelations()
+        // `extractAddedAllowRule` only locates a CANDIDATE entry by the
+        // rule token — it is shape-based, not YAML-location-aware, so it
+        // is NOT the security gate. The gate is an EXACT byte-match of
+        // the incoming diff against the diff the gateway itself
+        // synthesized and queued. A forged config_propose_edit (the same
+        // consented token placed under `deny:`/`secrets:`, a different
+        // field, or any other byte difference) won't match → falls
+        // through to a real operator approval card.
         const added = extractAddedAllowRule(msg.unifiedDiff)
         if (!added) return null
         const key = `${msg.agentName}::${added}`
         const entry = pendingAlwaysAllowCorrelations.get(key)
-        if (entry) {
+        if (entry && entry.unifiedDiff === msg.unifiedDiff) {
           pendingAlwaysAllowCorrelations.delete(key)
           return 'approve'
         }
@@ -15381,7 +15389,7 @@ bot.on('callback_query:data', async ctx => {
       } else {
         // Pre-register the single-tap correlation so hostd's callback
         // (request_config_approval) auto-approves WITHOUT a second card.
-        pendingAlwaysAllowCorrelations.set(correlationKey, { agentName, rule: rule.rule, createdAt: Date.now() })
+        pendingAlwaysAllowCorrelations.set(correlationKey, { agentName, rule: rule.rule, unifiedDiff, createdAt: Date.now() })
         const req: HostdRequest = {
           v: 1,
           op: 'config_propose_edit',

--- a/telegram-plugin/gateway/hostd-dispatch.ts
+++ b/telegram-plugin/gateway/hostd-dispatch.ts
@@ -94,13 +94,14 @@ export function hostdWillBeUsed(agentName: string): boolean {
 export async function tryHostdDispatch(
   agentName: string,
   req: HostdRequest,
+  timeoutMs = 5000,
 ): Promise<HostdResponse | "not-configured"> {
   if (!isHostdEnabled()) return "not-configured";
   const sockPath = hostdSocketPath(agentName);
   if (!existsSync(sockPath)) return "not-configured";
   try {
     return await hostdRequest(
-      { socketPath: sockPath, timeoutMs: 5000 },
+      { socketPath: sockPath, timeoutMs },
       req,
     );
   } catch (err) {

--- a/telegram-plugin/permission-diff.ts
+++ b/telegram-plugin/permission-diff.ts
@@ -1,0 +1,382 @@
+/**
+ * Pure (no-I/O) helpers for the durable "🔁 Always allow" flow (#1977).
+ *
+ * The Telegram permission card's "Always allow" button used to shell
+ * `switchroom agent grant <agent> <rule>` which writes
+ * `/state/config/switchroom.yaml` — but that path is bind-mounted
+ * READ-ONLY into agent containers, so the write silently no-op'd.
+ * Durable host-config writes only land via the host-side `hostd`
+ * daemon's `config_propose_edit` flow, which takes a unified diff and
+ * runs it through `git apply --recount` against the live config.
+ *
+ * {@link synthesizeAllowRuleDiff} builds that diff by operating on the
+ * *literal* config text (never a parsed/merged object) so the diff's
+ * context lines byte-match the on-disk file — a requirement for
+ * `git apply` to succeed.
+ *
+ * {@link extractAddedAllowRule} is the inverse parse used by the
+ * single-tap auto-approve correlation: it returns the single
+ * `tools.allow` rule a diff adds, so the gateway can confirm that an
+ * inbound `request_config_approval` corresponds to a rule IT just
+ * queued (and so auto-approve without a second card), while any
+ * uncorrelated / forged edit still posts a real operator card.
+ *
+ * No file I/O, no yaml parsing of structure — deliberately. Callers
+ * read the raw config bytes and feed them in.
+ */
+
+const TARGET_HEADER_A = "--- a/switchroom.yaml";
+const TARGET_HEADER_B = "+++ b/switchroom.yaml";
+
+export interface SynthesizeAllowRuleDiffArgs {
+  /** Agent whose `tools.allow` gains the rule. */
+  agentName: string;
+  /** The rule token (e.g. `Bash`, `Skill(mail)`, `mcp__x__y`). */
+  rule: string;
+  /** RAW config file bytes (LF). NOT a parsed/merged object. */
+  configText: string;
+}
+
+/** Internal: a 0-based line index range describing a located block. */
+interface AgentBlock {
+  /** Indentation (spaces) of the `<agentName>:` key line. */
+  agentIndent: number;
+  /** 0-based index of the `<agentName>:` line. */
+  agentLineIdx: number;
+  /** 0-based index just past the agent block (exclusive). */
+  agentBlockEnd: number;
+}
+
+/** Count leading spaces of a line. */
+function indentOf(line: string): number {
+  let n = 0;
+  while (n < line.length && line[n] === " ") n++;
+  return n;
+}
+
+/** True if the line is blank or a comment (ignored for block scans). */
+function isBlankOrComment(line: string): boolean {
+  const t = line.trim();
+  return t.length === 0 || t.startsWith("#");
+}
+
+/**
+ * Locate the `agents:` → `<agentName>:` block in raw config text.
+ * Returns the agent key line index, its indentation, and the
+ * exclusive end of its block (first subsequent non-blank line at an
+ * indent ≤ the agent key's indent). Returns null if not found.
+ */
+function locateAgentBlock(
+  lines: string[],
+  agentName: string,
+): AgentBlock | null {
+  // Find a top-level `agents:` key (indent 0 by convention, but be
+  // lenient: any line whose trimmed form is exactly `agents:`).
+  let agentsIdx = -1;
+  let agentsIndent = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (isBlankOrComment(line)) continue;
+    if (line.trim() === "agents:") {
+      agentsIdx = i;
+      agentsIndent = indentOf(line);
+      break;
+    }
+  }
+  if (agentsIdx === -1) return null;
+
+  // The agent keys are the first indent level deeper than `agents:`.
+  // Scan within the agents block for `<agentName>:`.
+  let childIndent = -1;
+  for (let i = agentsIdx + 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (isBlankOrComment(line)) continue;
+    const ind = indentOf(line);
+    if (ind <= agentsIndent) break; // left the agents block
+    if (childIndent === -1) childIndent = ind;
+    if (ind !== childIndent) continue; // nested deeper — not an agent key
+    const key = line.slice(ind).split(":")[0]!.trim();
+    if (key === agentName) {
+      // Found it. Now find the block end.
+      let end = lines.length;
+      for (let j = i + 1; j < lines.length; j++) {
+        const l2 = lines[j]!;
+        if (isBlankOrComment(l2)) continue;
+        if (indentOf(l2) <= ind) {
+          end = j;
+          break;
+        }
+      }
+      return { agentIndent: ind, agentLineIdx: i, agentBlockEnd: end };
+    }
+  }
+  return null;
+}
+
+/** Locate the `tools:` line within an agent block (or null). */
+function locateToolsLine(
+  lines: string[],
+  block: AgentBlock,
+): { idx: number; indent: number } | null {
+  for (let i = block.agentLineIdx + 1; i < block.agentBlockEnd; i++) {
+    const line = lines[i]!;
+    if (isBlankOrComment(line)) continue;
+    const ind = indentOf(line);
+    if (ind <= block.agentIndent) break;
+    const key = line.slice(ind).split(":")[0]!.trim();
+    if (key === "tools" && ind === block.agentIndent + 2) {
+      return { idx: i, indent: ind };
+    }
+  }
+  return null;
+}
+
+/**
+ * Locate the `allow:` line within a `tools:` mapping. Returns its
+ * index, indent, and whether it is a flow list (`allow: [..]`) or a
+ * block sequence (`allow:` then `- x` lines).
+ */
+function locateAllowLine(
+  lines: string[],
+  toolsIdx: number,
+  toolsIndent: number,
+  blockEnd: number,
+): { idx: number; indent: number; inline: string } | null {
+  for (let i = toolsIdx + 1; i < blockEnd; i++) {
+    const line = lines[i]!;
+    if (isBlankOrComment(line)) continue;
+    const ind = indentOf(line);
+    if (ind <= toolsIndent) break; // left the tools mapping
+    const key = line.slice(ind).split(":")[0]!.trim();
+    if (key === "allow" && ind === toolsIndent + 2) {
+      const after = line.slice(line.indexOf(":") + 1);
+      return { idx: i, indent: ind, inline: after };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a unified-diff hunk from a contiguous slice of the original
+ * file. `lines` is the whole file split on `\n`. The hunk replaces the
+ * lines in `[changeStart, changeEnd)` with `replacement` (an array of
+ * raw lines, no leading `+`). `contextN` context lines are copied
+ * verbatim before and after. `@@` numbers are best-effort (hostd runs
+ * `git apply --recount`), but context lines byte-match the source.
+ */
+function buildHunk(
+  lines: string[],
+  changeStart: number,
+  changeEnd: number,
+  removed: string[],
+  added: string[],
+  contextN = 3,
+): string {
+  const preStart = Math.max(0, changeStart - contextN);
+  let postEnd = Math.min(lines.length, changeEnd + contextN);
+  // A `configText` that ends in `\n` splits to a trailing "" element
+  // that is NOT a real file line — including it as a context line
+  // (` `) makes `git apply` reject the hunk ("patch does not apply").
+  // Drop it from the trailing context window.
+  if (postEnd === lines.length && lines.length > 0 && lines[lines.length - 1] === "") {
+    postEnd -= 1;
+  }
+  const pre = lines.slice(preStart, changeStart);
+  const post = lines.slice(changeEnd, Math.max(changeEnd, postEnd));
+
+  const oldCount = pre.length + removed.length + post.length;
+  const newCount = pre.length + added.length + post.length;
+  const oldStartLine = preStart + 1;
+  const newStartLine = preStart + 1;
+
+  const out: string[] = [];
+  out.push(`@@ -${oldStartLine},${oldCount} +${newStartLine},${newCount} @@`);
+  for (const l of pre) out.push(` ${l}`);
+  for (const l of removed) out.push(`-${l}`);
+  for (const l of added) out.push(`+${l}`);
+  for (const l of post) out.push(` ${l}`);
+  return out.join("\n");
+}
+
+function wrapDiff(hunk: string): string {
+  return `${TARGET_HEADER_A}\n${TARGET_HEADER_B}\n${hunk}\n`;
+}
+
+/**
+ * Synthesize a git-apply-compatible unified diff that adds `rule` to
+ * the target agent's `tools.allow` in raw `configText`. Returns null if
+ * the agent block can't be located.
+ *
+ * Three structural cases:
+ *   (a) flow list on one line: `allow: [ all ]` / `allow: [X, Y]`
+ *       → one-line replace appending `, <rule>` before the closing `]`.
+ *   (b) block sequence: `allow:\n  - Bash`
+ *       → insert a new `  - <rule>` line after the last `- ` entry.
+ *   (c) `tools.allow` absent: insert
+ *       `    tools:\n      allow:\n        - <rule>` under the agent.
+ */
+export function synthesizeAllowRuleDiff(
+  args: SynthesizeAllowRuleDiffArgs,
+): string | null {
+  const { agentName, rule, configText } = args;
+  if (!agentName || !rule || !configText) return null;
+  const lines = configText.split("\n");
+  const block = locateAgentBlock(lines, agentName);
+  if (!block) return null;
+
+  const tools = locateToolsLine(lines, block);
+
+  // Case (c): no tools: mapping at all → insert tools/allow/rule under
+  // the agent block, indented two deeper than the agent key.
+  if (!tools) {
+    const baseIndent = block.agentIndent + 2;
+    const insertAt = block.agentLineIdx + 1;
+    const added = [
+      `${" ".repeat(baseIndent)}tools:`,
+      `${" ".repeat(baseIndent + 2)}allow:`,
+      `${" ".repeat(baseIndent + 4)}- ${rule}`,
+    ];
+    const hunk = buildHunk(lines, insertAt, insertAt, [], added);
+    return wrapDiff(hunk);
+  }
+
+  const allow = locateAllowLine(
+    lines,
+    tools.idx,
+    tools.indent,
+    block.agentBlockEnd,
+  );
+
+  // tools: present but no allow: key → insert an allow block under it.
+  if (!allow) {
+    const baseIndent = tools.indent + 2;
+    const insertAt = tools.idx + 1;
+    const added = [
+      `${" ".repeat(baseIndent)}allow:`,
+      `${" ".repeat(baseIndent + 2)}- ${rule}`,
+    ];
+    const hunk = buildHunk(lines, insertAt, insertAt, [], added);
+    return wrapDiff(hunk);
+  }
+
+  const inlineTrimmed = allow.inline.trim();
+
+  // Case (a): flow list on one line.
+  if (inlineTrimmed.startsWith("[")) {
+    const original = lines[allow.idx]!;
+    const close = original.lastIndexOf("]");
+    if (close === -1) return null;
+    // Empty list `[]` / `[ ]` → first element, no leading comma.
+    const inner = original.slice(original.indexOf("[") + 1, close).trim();
+    const replacement =
+      inner.length === 0
+        ? `${original.slice(0, close)}${rule}${original.slice(close)}`
+        : `${original.slice(0, close).replace(/\s*$/, "")}, ${rule}${original.slice(close)}`;
+    const hunk = buildHunk(
+      lines,
+      allow.idx,
+      allow.idx + 1,
+      [original],
+      [replacement],
+    );
+    return wrapDiff(hunk);
+  }
+
+  // Case (b): block sequence. Find the last `- ` entry at indent
+  // allow.indent + 2 and insert a new entry after it.
+  const itemIndent = allow.indent + 2;
+  let lastItemIdx = -1;
+  for (let i = allow.idx + 1; i < block.agentBlockEnd; i++) {
+    const line = lines[i]!;
+    if (isBlankOrComment(line)) continue;
+    const ind = indentOf(line);
+    if (ind <= allow.indent) break; // left the allow sequence
+    const t = line.slice(ind);
+    if (ind === itemIndent && t.startsWith("- ")) {
+      lastItemIdx = i;
+    }
+  }
+  if (lastItemIdx === -1) {
+    // `allow:` with no entries (e.g. empty seq) — insert the first one.
+    const insertAt = allow.idx + 1;
+    const added = [`${" ".repeat(itemIndent)}- ${rule}`];
+    const hunk = buildHunk(lines, insertAt, insertAt, [], added);
+    return wrapDiff(hunk);
+  }
+  const insertAt = lastItemIdx + 1;
+  const added = [`${" ".repeat(itemIndent)}- ${rule}`];
+  const hunk = buildHunk(lines, insertAt, insertAt, [], added);
+  return wrapDiff(hunk);
+}
+
+/**
+ * Inverse of {@link synthesizeAllowRuleDiff} for the correlation check:
+ * return the single `tools.allow` rule token added by the diff, or null
+ * if the diff doesn't add exactly one such rule.
+ *
+ * Recognises both shapes the synthesizer emits:
+ *   - a block-sequence add: `+        - <rule>`
+ *   - a flow-list element appended on a replaced line: the `+` line
+ *     differs from the `-` line by a single trailing `, <rule>` (or a
+ *     first element inside an empty `[]`).
+ *
+ * Deliberately strict: returns null on multi-add / structural diffs so
+ * a forged edit touching arbitrary fields can never be mistaken for a
+ * queued always-allow rule.
+ */
+export function extractAddedAllowRule(unifiedDiff: string): string | null {
+  if (!unifiedDiff) return null;
+  const lines = unifiedDiff.split("\n");
+  const plus: string[] = [];
+  const minus: string[] = [];
+  for (const l of lines) {
+    if (l.startsWith("+++") || l.startsWith("---")) continue;
+    if (l.startsWith("@@")) continue;
+    if (l.startsWith("+")) plus.push(l.slice(1));
+    else if (l.startsWith("-")) minus.push(l.slice(1));
+  }
+
+  // Block-sequence add: exactly one `+` line of the form `  - <rule>`
+  // and no `-` (removal) lines, OR (case-c/no-allow insert) several
+  // `+` lines where exactly one is a `- <rule>` item.
+  if (minus.length === 0) {
+    const items = plus
+      .map((p) => {
+        const ind = indentOf(p);
+        const t = p.slice(ind);
+        return t.startsWith("- ") ? t.slice(2).trim() : null;
+      })
+      .filter((x): x is string => x !== null);
+    if (items.length === 1) return items[0]!;
+    return null;
+  }
+
+  // Flow-list append: one `-` line replaced by one `+` line that adds a
+  // trailing element. Diff the two for the new `]`-interior token(s).
+  if (minus.length === 1 && plus.length === 1) {
+    const before = extractFlowItems(minus[0]!);
+    const after = extractFlowItems(plus[0]!);
+    if (before === null || after === null) return null;
+    if (after.length !== before.length + 1) return null;
+    // The new element is the one in `after` not in `before` (by
+    // position — synthesizer appends, so it's the last).
+    const added = after[after.length - 1]!;
+    // Confirm prefix matches (defense against reordering forgery).
+    for (let i = 0; i < before.length; i++) {
+      if (before[i] !== after[i]) return null;
+    }
+    return added;
+  }
+
+  return null;
+}
+
+/** Parse the bracketed flow-list items from a `allow: [ ... ]` line. */
+function extractFlowItems(line: string): string[] | null {
+  const open = line.indexOf("[");
+  const close = line.lastIndexOf("]");
+  if (open === -1 || close === -1 || close < open) return null;
+  const inner = line.slice(open + 1, close).trim();
+  if (inner.length === 0) return [];
+  return inner.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+}

--- a/telegram-plugin/tests/always-allow-correlation.test.ts
+++ b/telegram-plugin/tests/always-allow-correlation.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Single-tap correlation auto-resolve for the durable "🔁 Always allow"
+ * flow (#1977, security-critical).
+ *
+ * When the gateway dispatches a `config_propose_edit` to hostd in
+ * response to an operator tap, hostd calls back asking for operator
+ * approval. The `tryAutoResolve` hook lets the gateway auto-approve
+ * THAT (already-operator-tapped) edit WITHOUT posting a second card,
+ * while any uncorrelated (e.g. agent-forged) config edit still posts a
+ * real operator approval card.
+ *
+ * These tests pin the handler contract:
+ *   - tryAutoResolve → 'approve': sends config_approval_resolved
+ *     (verdict: approve), does NOT post a card, creates NO pending
+ *     entry, arms NO timer.
+ *   - tryAutoResolve → null (forge / normal path): posts the card AND
+ *     creates a pending entry (the real human-in-the-loop control).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  handleRequestConfigApproval,
+  _resetPendingConfigApprovalsForTest,
+  _peekPendingConfigApprovalForTest,
+  type ConfigApprovalHandlerDeps,
+} from '../gateway/config-approval-handler.js'
+import type { RequestConfigApprovalMessage } from '../gateway/ipc-protocol.js'
+
+function makeMsg(overrides: Partial<RequestConfigApprovalMessage> = {}): RequestConfigApprovalMessage {
+  return {
+    type: 'request_config_approval',
+    requestId: 'req-abc123',
+    agentName: 'clerk',
+    reason: "Operator 'always allow' for Bash",
+    unifiedDiff: [
+      '--- a/switchroom.yaml',
+      '+++ b/switchroom.yaml',
+      '@@ -1,3 +1,4 @@',
+      ' agents:',
+      '   clerk:',
+      '     tools:',
+      '+      - Bash',
+    ].join('\n'),
+    timeoutMs: 600_000,
+    ...overrides,
+  }
+}
+
+interface SentMsg {
+  type: string
+  requestId?: string
+  verdict?: string
+  [k: string]: unknown
+}
+
+describe('always-allow correlation — auto-resolve path', () => {
+  beforeEach(() => {
+    _resetPendingConfigApprovalsForTest()
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    _resetPendingConfigApprovalsForTest()
+  })
+
+  it("tryAutoResolve → 'approve': sends approve verdict, NO card, NO pending entry, NO timer", async () => {
+    const sent: SentMsg[] = []
+    const postCard = vi.fn(async () => ({ messageId: 42 }))
+    const client = { send: (m: SentMsg) => sent.push(m) }
+    const msg = makeMsg()
+    const deps: ConfigApprovalHandlerDeps = {
+      agentName: 'clerk',
+      loadTargetChat: () => ({ chatId: 1001 }),
+      postCard,
+      buildKeyboard: () => ({ inline_keyboard: [] }),
+      editCard: async () => {},
+      log: () => {},
+      tryAutoResolve: () => 'approve',
+    }
+
+    await handleRequestConfigApproval(client, msg, deps)
+
+    // Verdict sent — approve.
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toMatchObject({
+      type: 'config_approval_resolved',
+      requestId: 'req-abc123',
+      verdict: 'approve',
+    })
+    // No card posted.
+    expect(postCard).not.toHaveBeenCalled()
+    // No pending entry created.
+    expect(_peekPendingConfigApprovalForTest('req-abc123')).toBeUndefined()
+    // No timer armed — advancing past the timeout fires nothing extra.
+    vi.advanceTimersByTime(700_000)
+    expect(sent).toHaveLength(1)
+  })
+
+  it('tryAutoResolve → null (forge / normal path): posts card AND creates a pending entry', async () => {
+    const sent: SentMsg[] = []
+    const postCard = vi.fn(async () => ({ messageId: 77 }))
+    const client = { send: (m: SentMsg) => sent.push(m) }
+    const msg = makeMsg({ requestId: 'req-forge99' })
+    const deps: ConfigApprovalHandlerDeps = {
+      agentName: 'clerk',
+      loadTargetChat: () => ({ chatId: 1001 }),
+      postCard,
+      buildKeyboard: () => ({ inline_keyboard: [] }),
+      editCard: async () => {},
+      log: () => {},
+      tryAutoResolve: () => null,
+    }
+
+    await handleRequestConfigApproval(client, msg, deps)
+
+    // Card WAS posted.
+    expect(postCard).toHaveBeenCalledTimes(1)
+    // A pending entry exists, awaiting the operator tap.
+    const entry = _peekPendingConfigApprovalForTest('req-forge99')
+    expect(entry).toBeDefined()
+    expect(entry?.messageId).toBe(77)
+    expect(entry?.resolved).toBe(false)
+    // No verdict sent yet — the operator hasn't tapped.
+    expect(sent).toHaveLength(0)
+  })
+
+  it('no tryAutoResolve dep at all: behaves as the normal card path', async () => {
+    const sent: SentMsg[] = []
+    const postCard = vi.fn(async () => ({ messageId: 88 }))
+    const client = { send: (m: SentMsg) => sent.push(m) }
+    const msg = makeMsg({ requestId: 'req-nohook' })
+    const deps: ConfigApprovalHandlerDeps = {
+      agentName: 'clerk',
+      loadTargetChat: () => ({ chatId: 1001 }),
+      postCard,
+      buildKeyboard: () => ({ inline_keyboard: [] }),
+      editCard: async () => {},
+      log: () => {},
+    }
+
+    await handleRequestConfigApproval(client, msg, deps)
+
+    expect(postCard).toHaveBeenCalledTimes(1)
+    expect(_peekPendingConfigApprovalForTest('req-nohook')).toBeDefined()
+  })
+})

--- a/telegram-plugin/tests/always-allow-grant.test.ts
+++ b/telegram-plugin/tests/always-allow-grant.test.ts
@@ -1,32 +1,27 @@
 /**
- * Structural contract tests for the "🔁 Always allow" handler in
- * gateway.ts (the `behavior === 'always'` branch of the perm: callback
- * dispatcher).
+ * Structural contract tests for the durable "🔁 Always allow" handler
+ * in gateway.ts (the `behavior === 'always'` branch of the perm:
+ * callback dispatcher), reworked for #1977.
  *
  * Why structural: the handler lives inside a Grammy callback closure
  * that's not exported. Full-function invocation would require a complete
- * Grammy + switchroomExec harness. Instead, we pin the source-level
- * invariants that were introduced to fix the silent-failure bug:
+ * Grammy + hostd + switchroomExec harness. The behavioural pieces are
+ * covered by the pure-function tests (permission-diff.test.ts) and the
+ * correlation handler tests (always-allow-correlation.test.ts); this
+ * file pins the source-level invariants of the orchestration block.
  *
- *   1. Loud failure text — the failure path must NOT read like success
- *      (`✅ Allowed …`). After the fix, both the toast (ackText) and the
- *      chat edit (editLabel) use the `⚠️` marker.
- *   2. Post-write verification — after `switchroomExec` returns success
- *      the handler MUST re-read the config and check that the rule is
- *      actually present in `tools.allow`. If the check fails it sets
- *      grantOk=false and surfaces the loud message.
- *   3. Success path unchanged — when `grantOk` is true the success
- *      strings (`🔁 Always allow …`, `restart agent for full effect`)
- *      are still present.
- *   4. Error reason capture — `grantFailReason` is declared and
- *      populated from `(err as Error).message` so the root cause can
- *      appear in logs; it is NOT silently swallowed into `message`-less
- *      stderr output.
+ * Post-#1977 contract:
+ *   1. The in-flight Allow verdict fires IMMEDIATELY (before awaiting
+ *      hostd) so the turn never blocks on host-config persistence.
+ *   2. Durable persistence goes through hostd's `config_propose_edit`
+ *      (synthesizeAllowRuleDiff → tryHostdDispatch).
+ *   3. The legacy `switchroom agent grant` path is the
+ *      not-configured fallback ONLY (not the primary path), and it
+ *      still verifies via isRulePersisted with honest messaging.
+ *   4. Failure text never falsely claims durable success.
  *
  * Slicing strategy: we extract the `if (behavior === 'always') {` block
- * from gateway.ts and run string assertions against that slice only —
- * so additions elsewhere in the 17k-line file don't produce false
- * positives or negatives.
+ * from gateway.ts and run string assertions against that slice only.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -53,95 +48,96 @@ function sliceAlwaysBlock(): string {
 
 const alwaysBlock = sliceAlwaysBlock()
 
+describe('always-allow handler — immediate verdict dispatch (turn must not block)', () => {
+  it('dispatches the permission verdict BEFORE the hostd await', () => {
+    const verdictIdx = alwaysBlock.indexOf('dispatchPermissionVerdict({')
+    const hostdAwaitIdx = alwaysBlock.indexOf('await tryHostdDispatch(')
+    expect(verdictIdx).toBeGreaterThan(-1)
+    expect(hostdAwaitIdx).toBeGreaterThan(-1)
+    // The verdict fires first — independent of the durable persistence
+    // round-trip.
+    expect(verdictIdx).toBeLessThan(hostdAwaitIdx)
+  })
+
+  it('carries the resolved rule on the verdict so the bridge caches it', () => {
+    expect(alwaysBlock).toContain("behavior: 'allow'")
+    expect(alwaysBlock).toContain('rule: rule.rule')
+  })
+
+  it('does NOT pass a synthInbound to finalizeCallback (verdict already fired)', () => {
+    // The verdict is dispatched directly above; finalizeCallback only
+    // edits the card. A synthInbound here would double-fire.
+    const finalizeIdx = alwaysBlock.indexOf('await finalizeCallback(ctx, {')
+    const after = alwaysBlock.slice(finalizeIdx)
+    expect(finalizeIdx).toBeGreaterThan(-1)
+    expect(after).not.toContain('synthInbound')
+  })
+})
+
+describe('always-allow handler — durable hostd persistence', () => {
+  it('synthesizes a unified diff from the raw config text', () => {
+    expect(alwaysBlock).toContain('synthesizeAllowRuleDiff({')
+    expect(alwaysBlock).toContain("op: 'config_propose_edit'")
+  })
+
+  it('reads the RAW config bytes (readFileSync), not the parsed config', () => {
+    // The diff context lines must byte-match the on-disk file, so we
+    // read literal bytes rather than re-serialising loadSwitchroomConfig.
+    expect(alwaysBlock).toContain('readFileSync(')
+  })
+
+  it('passes a long timeout to tryHostdDispatch (apply+reconcile blocks)', () => {
+    expect(alwaysBlock).toContain('await tryHostdDispatch(agentName, req, 60_000)')
+  })
+
+  it('registers + cleans up the single-tap correlation entry', () => {
+    expect(alwaysBlock).toContain('pendingAlwaysAllowCorrelations.set(correlationKey')
+    // Cleanup in a finally so it can never be replayed.
+    const finallyIdx = alwaysBlock.indexOf('} finally {')
+    const deleteIdx = alwaysBlock.indexOf('pendingAlwaysAllowCorrelations.delete(correlationKey)', finallyIdx)
+    expect(finallyIdx).toBeGreaterThan(-1)
+    expect(deleteIdx).toBeGreaterThan(finallyIdx)
+  })
+
+  it('treats E_CONFIG_EDIT_DISABLED specially (no legacy fallback, points at the flag)', () => {
+    expect(alwaysBlock).toContain('E_CONFIG_EDIT_DISABLED')
+    expect(alwaysBlock).toContain('hostd.config_edit_enabled')
+  })
+})
+
+describe('always-allow handler — legacy fallback ONLY when hostd not-configured', () => {
+  it('falls back to switchroom agent grant only on not-configured', () => {
+    const notConfiguredIdx = alwaysBlock.indexOf("resp === 'not-configured'")
+    const grantIdx = alwaysBlock.indexOf("switchroomExec(['agent', 'grant'")
+    expect(notConfiguredIdx).toBeGreaterThan(-1)
+    expect(grantIdx).toBeGreaterThan(-1)
+    // The grant shellout lives AFTER the not-configured branch sets
+    // legacy=true (i.e. it is the fallback, not the primary path).
+    expect(grantIdx).toBeGreaterThan(notConfiguredIdx)
+  })
+
+  it('emits the legacy-spawn deprecation warning on the not-configured path', () => {
+    expect(alwaysBlock).toContain("warnLegacySpawnIfHostdDisabled('always-allow')")
+  })
+
+  it('verifies the legacy write landed via isRulePersisted', () => {
+    expect(alwaysBlock).toContain('isRulePersisted(allowList, rule.rule)')
+    expect(alwaysBlock).toContain('resolveAgentConfig(')
+  })
+
+  it('legacy success messaging is honest about being the legacy path', () => {
+    expect(alwaysBlock).toContain('(legacy path)')
+  })
+})
+
 describe('always-allow handler — loud failure invariants', () => {
-  it('failure ackText uses the ⚠️ warning marker, not ✅', () => {
-    // The failure path must be unambiguous. Before the fix, the failure
-    // ackText started with "✅ Allowed …" which reads like success.
-    expect(alwaysBlock).toContain(
-      `⚠️ Allowed for now, but "always" did NOT save — it will ask again after restart. Check gateway log.`,
-    )
-    // Confirm the old misleading text is gone.
+  it('failure text uses the ⚠️ warning marker, never a false ✅ success', () => {
+    expect(alwaysBlock).toContain('did NOT save')
     expect(alwaysBlock).not.toContain('✅ Allowed (always-allow yaml edit failed')
   })
 
-  it('failure editLabel uses the ⚠️ warning marker, not ✅', () => {
-    // The inline-keyboard collapse edit also must NOT look like success.
-    expect(alwaysBlock).toContain(
-      `⚠️ <b>Allowed for now — "always" did NOT save.</b> It will ask again after restart. Check gateway log.`,
-    )
-    // Confirm the old misleading text is gone.
-    expect(alwaysBlock).not.toContain('✅ <b>Allowed</b> (always-allow rule edit failed')
-  })
-})
-
-describe('always-allow handler — success path unchanged', () => {
-  it('success ackText still uses 🔁 and names the rule', () => {
-    expect(alwaysBlock).toContain('`🔁 Always allow ${rule.label} for ${agentName}`')
-  })
-
-  it('success editLabel still uses 🔁 bold + restart hint', () => {
-    expect(alwaysBlock).toContain('restart agent for full effect')
-    expect(alwaysBlock).toContain('🔁 <b>Always allow')
-  })
-})
-
-describe('always-allow handler — post-write verification', () => {
-  it('reloads config after switchroomExec returns', () => {
-    // The verification block must call loadSwitchroomConfig() AFTER
-    // the switchroomExec call to confirm the rule landed in the
-    // resolved tools.allow.
-    const execIdx = alwaysBlock.indexOf("switchroomExec(['agent', 'grant'")
-    const loadIdx = alwaysBlock.indexOf('loadSwitchroomConfig()', execIdx)
-    expect(execIdx).toBeGreaterThan(-1)
-    expect(loadIdx).toBeGreaterThan(execIdx)
-  })
-
-  it('calls resolveAgentConfig to obtain the merged tools.allow list', () => {
-    const execIdx = alwaysBlock.indexOf("switchroomExec(['agent', 'grant'")
-    const resolveIdx = alwaysBlock.indexOf('resolveAgentConfig(', execIdx)
-    expect(resolveIdx).toBeGreaterThan(execIdx)
-  })
-
-  it('calls isRulePersisted(allowList, rule.rule) after the reload', () => {
-    // The handler delegates the membership check to the extracted pure
-    // helper so the behavioral test in always-allow-persist.test.ts can
-    // cover the same code path.
-    expect(alwaysBlock).toContain('isRulePersisted(allowList, rule.rule)')
-  })
-
-  it('sets grantOk=true only when isRulePersisted returns true', () => {
-    // grantOk=true must be inside the `if (isRulePersisted(...))` branch,
-    // not unconditionally after switchroomExec.
-    const persistIdx = alwaysBlock.indexOf('isRulePersisted(allowList, rule.rule)')
-    const grantOkIdx = alwaysBlock.indexOf('grantOk = true', persistIdx)
-    expect(persistIdx).toBeGreaterThan(-1)
-    expect(grantOkIdx).toBeGreaterThan(persistIdx)
-    // Confirm grantOk=true does NOT appear before the persistence check
-    // (i.e., not unconditionally on switchroomExec success as in the old code).
-    const grantOkFirst = alwaysBlock.indexOf('grantOk = true')
-    expect(grantOkFirst).toBeGreaterThanOrEqual(persistIdx)
-  })
-
-  it('logs a VERIFY FAILED message when the rule is absent after the write', () => {
-    expect(alwaysBlock).toContain('always-allow VERIFY FAILED')
-  })
-
-  it('surfaces config-location drift as a failure reason', () => {
-    expect(alwaysBlock).toContain('config location may have drifted')
-  })
-})
-
-describe('always-allow handler — error reason capture', () => {
-  it('declares grantFailReason to capture the root cause', () => {
-    expect(alwaysBlock).toContain('let grantFailReason')
-  })
-
-  it('populates grantFailReason from the thrown error on switchroomExec failure', () => {
-    // After the catch for switchroomExec, grantFailReason must be set
-    // from the error object so log messages can show the actual cause.
-    const catchIdx = alwaysBlock.lastIndexOf('} catch (err) {')
-    const reasonIdx = alwaysBlock.indexOf('grantFailReason = (err as Error).message', catchIdx)
-    expect(catchIdx).toBeGreaterThan(-1)
-    expect(reasonIdx).toBeGreaterThan(catchIdx)
+  it('captures a failure reason for the gateway log', () => {
+    expect(alwaysBlock).toContain('failReason')
+    expect(alwaysBlock).toContain('(err as Error).message')
   })
 })

--- a/telegram-plugin/tests/permission-diff.test.ts
+++ b/telegram-plugin/tests/permission-diff.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for the pure diff synthesizer that powers the durable
+ * "🔁 Always allow" flow (#1977).
+ *
+ * Two layers:
+ *   1. Unit — synthesizeAllowRuleDiff covers the three structural
+ *      cases (flow list, block sequence, absent tools.allow), only
+ *      touches the target agent in a multi-agent file, and returns
+ *      null when the agent is absent. extractAddedAllowRule round-trips.
+ *   2. End-to-end — feed each synthesized diff + a realistic, fully
+ *      schema-valid fixture switchroom.yaml through `validateConfigEdit`
+ *      (the real hostd validation pipeline, which runs
+ *      `git apply --recount` then zod) and assert ok===true and the
+ *      rule lands under the right agent. This is the load-bearing proof
+ *      that the synthesizer emits git-apply-compatible diffs with
+ *      byte-matching context lines AND that the post-apply yaml still
+ *      validates. Requires `git` on PATH.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { parse as parseYaml } from 'yaml'
+import {
+  synthesizeAllowRuleDiff,
+  extractAddedAllowRule,
+} from '../permission-diff.js'
+import { validateConfigEdit } from '../../src/host-control/config-edit-validator.js'
+
+const TARGET = '/state/config/switchroom.yaml'
+
+/**
+ * A schema-valid switchroom.yaml header. The validator runs the post-
+ * apply content through the real SwitchroomConfigSchema (zod), so the
+ * fixtures must be complete configs, not just `agents:` fragments.
+ */
+const HEADER = [
+  'switchroom:',
+  '  version: 1',
+  'telegram:',
+  "  bot_token: vault:telegram-bot-token",
+  "  forum_chat_id: '-1001234567890'",
+].join('\n')
+
+/** Build a complete config from an `agents:` body. */
+function cfgWith(agentsBody: string): string {
+  return `${HEADER}\nagents:\n${agentsBody}\n`
+}
+
+/** Run the synthesized diff through the real hostd validator + apply. */
+function applyViaValidator(configText: string, unifiedDiff: string) {
+  const dir = mkdtempSync(join(tmpdir(), 'perm-diff-'))
+  const cfgPath = join(dir, 'switchroom.yaml')
+  try {
+    writeFileSync(cfgPath, configText)
+    return validateConfigEdit({
+      configPath: cfgPath,
+      targetPath: TARGET,
+      unifiedDiff,
+    })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+function allowListFor(yamlText: string, agent: string): string[] {
+  const data = parseYaml(yamlText) as {
+    agents?: Record<string, { tools?: { allow?: string[] } }>
+  }
+  return data.agents?.[agent]?.tools?.allow ?? []
+}
+
+describe('synthesizeAllowRuleDiff — structural cases', () => {
+  it('(a) flow list with elements: appends before the closing ]', () => {
+    const cfg = cfgWith(
+      [
+        '  clerk:',
+        '    topic_name: clerk',
+        '    purpose: clerk',
+        '    tools:',
+        '      allow: [Read, Grep]',
+        '    model: opus',
+      ].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Bash', configText: cfg })
+    expect(diff).not.toBeNull()
+    expect(diff).toContain('--- a/switchroom.yaml')
+    expect(diff).toContain('+++ b/switchroom.yaml')
+    const res = applyViaValidator(cfg, diff!)
+    expect(res).toMatchObject({ ok: true })
+    if (res.ok) {
+      expect(allowListFor(res.postApplyContent, 'clerk')).toEqual(['Read', 'Grep', 'Bash'])
+    }
+  })
+
+  it('(a) flow list "[ all ]": appends, all preserved', () => {
+    const cfg = cfgWith(
+      [
+        '  ziggy:',
+        '    topic_name: ziggy',
+        '    purpose: ziggy',
+        '    tools:',
+        '      allow: [ all ]',
+        '    model: opus',
+      ].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'ziggy', rule: 'Skill(mail)', configText: cfg })
+    expect(diff).not.toBeNull()
+    const res = applyViaValidator(cfg, diff!)
+    expect(res).toMatchObject({ ok: true })
+    if (res.ok) {
+      const allow = allowListFor(res.postApplyContent, 'ziggy')
+      expect(allow).toContain('all')
+      expect(allow).toContain('Skill(mail)')
+    }
+  })
+
+  it('(b) block sequence: inserts after the last - entry', () => {
+    const cfg = cfgWith(
+      [
+        '  klanker:',
+        '    topic_name: klanker',
+        '    purpose: klanker',
+        '    tools:',
+        '      allow:',
+        '        - Bash',
+        '        - Read',
+        '    model: opus',
+      ].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'klanker', rule: 'mcp__notion__search', configText: cfg })
+    expect(diff).not.toBeNull()
+    const res = applyViaValidator(cfg, diff!)
+    expect(res).toMatchObject({ ok: true })
+    if (res.ok) {
+      expect(allowListFor(res.postApplyContent, 'klanker')).toEqual(['Bash', 'Read', 'mcp__notion__search'])
+    }
+  })
+
+  it('(c) tools.allow absent: inserts tools/allow/rule under the agent', () => {
+    const cfg = cfgWith(
+      [
+        '  carrie:',
+        '    topic_name: carrie',
+        '    purpose: carrie',
+        '    model: sonnet',
+        '    role: assistant',
+      ].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'carrie', rule: 'WebFetch', configText: cfg })
+    expect(diff).not.toBeNull()
+    const res = applyViaValidator(cfg, diff!)
+    expect(res).toMatchObject({ ok: true })
+    if (res.ok) {
+      expect(allowListFor(res.postApplyContent, 'carrie')).toEqual(['WebFetch'])
+    }
+  })
+
+  it('(c) tools present but no allow: key: inserts allow block under tools', () => {
+    const cfg = cfgWith(
+      [
+        '  finn:',
+        '    topic_name: finn',
+        '    purpose: finn',
+        '    tools:',
+        '      deny:',
+        '        - Bash',
+        '    model: opus',
+      ].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'finn', rule: 'Read', configText: cfg })
+    expect(diff).not.toBeNull()
+    const res = applyViaValidator(cfg, diff!)
+    expect(res).toMatchObject({ ok: true })
+    if (res.ok) {
+      expect(allowListFor(res.postApplyContent, 'finn')).toEqual(['Read'])
+    }
+  })
+
+  it('multi-agent: only the target agent is touched', () => {
+    const cfg = cfgWith(
+      [
+        '  clerk:',
+        '    topic_name: clerk',
+        '    purpose: clerk',
+        '    tools:',
+        '      allow:',
+        '        - Read',
+        '  ziggy:',
+        '    topic_name: ziggy',
+        '    purpose: ziggy',
+        '    tools:',
+        '      allow:',
+        '        - Bash',
+        '  reggie:',
+        '    topic_name: reggie',
+        '    purpose: reggie',
+        '    tools:',
+        '      allow: [Grep]',
+      ].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'ziggy', rule: 'Write', configText: cfg })
+    expect(diff).not.toBeNull()
+    const res = applyViaValidator(cfg, diff!)
+    expect(res).toMatchObject({ ok: true })
+    if (res.ok) {
+      expect(allowListFor(res.postApplyContent, 'clerk')).toEqual(['Read'])
+      expect(allowListFor(res.postApplyContent, 'ziggy')).toEqual(['Bash', 'Write'])
+      expect(allowListFor(res.postApplyContent, 'reggie')).toEqual(['Grep'])
+    }
+  })
+
+  it('returns null when the agent is absent', () => {
+    const cfg = cfgWith(
+      ['  clerk:', '    topic_name: clerk',
+        '    purpose: clerk', '    tools:', '      allow: [Read]'].join('\n'),
+    )
+    expect(synthesizeAllowRuleDiff({ agentName: 'nope', rule: 'Bash', configText: cfg })).toBeNull()
+  })
+
+  it('returns null when there is no agents block at all', () => {
+    expect(
+      synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Bash', configText: 'defaults:\n  model: opus\n' }),
+    ).toBeNull()
+  })
+})
+
+describe('extractAddedAllowRule — round-trips the synthesized diff', () => {
+  it('block-sequence add', () => {
+    const cfg = cfgWith(
+      ['  clerk:', '    topic_name: clerk',
+        '    purpose: clerk', '    tools:', '      allow:', '        - Bash', '        - Read'].join('\n'),
+    )
+    const diff = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'mcp__x__y', configText: cfg })!
+    expect(extractAddedAllowRule(diff)).toBe('mcp__x__y')
+  })
+
+  it('flow-list append', () => {
+    const cfg = cfgWith(['  clerk:', '    topic_name: clerk',
+        '    purpose: clerk', '    tools:', '      allow: [Read, Grep]', '    model: opus'].join('\n'))
+    const diff = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Bash', configText: cfg })!
+    expect(extractAddedAllowRule(diff)).toBe('Bash')
+  })
+
+  it('flow-list append into [ all ]', () => {
+    const cfg = cfgWith(['  clerk:', '    topic_name: clerk',
+        '    purpose: clerk', '    tools:', '      allow: [ all ]', '    model: opus'].join('\n'))
+    const diff = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Skill(mail)', configText: cfg })!
+    expect(extractAddedAllowRule(diff)).toBe('Skill(mail)')
+  })
+
+  it('absent tools.allow (case c) — extracts the single added rule', () => {
+    const cfg = cfgWith(['  carrie:', '    topic_name: carrie',
+        '    purpose: carrie', '    model: sonnet', '    role: assistant'].join('\n'))
+    const diff = synthesizeAllowRuleDiff({ agentName: 'carrie', rule: 'WebFetch', configText: cfg })!
+    expect(extractAddedAllowRule(diff)).toBe('WebFetch')
+  })
+
+  it('returns null for a diff that adds something other than a tools.allow rule', () => {
+    // A hand-built diff that changes a `model:` field — must NOT be
+    // mistaken for an allow-rule add (forge-resistance).
+    const forged = [
+      '--- a/switchroom.yaml',
+      '+++ b/switchroom.yaml',
+      '@@ -1,3 +1,3 @@',
+      ' agents:',
+      '   clerk:',
+      '-    model: sonnet',
+      '+    model: opus',
+      '',
+    ].join('\n')
+    expect(extractAddedAllowRule(forged)).toBeNull()
+  })
+
+  it('returns null for a multi-rule diff (strict single-add only)', () => {
+    const forged = [
+      '--- a/switchroom.yaml',
+      '+++ b/switchroom.yaml',
+      '@@ -1,2 +1,4 @@',
+      ' agents:',
+      '   clerk:',
+      '+        - Bash',
+      '+        - Read',
+      '',
+    ].join('\n')
+    expect(extractAddedAllowRule(forged)).toBeNull()
+  })
+
+  it('returns null for empty input', () => {
+    expect(extractAddedAllowRule('')).toBeNull()
+  })
+})

--- a/telegram-plugin/tests/permission-diff.test.ts
+++ b/telegram-plugin/tests/permission-diff.test.ts
@@ -291,3 +291,46 @@ describe('extractAddedAllowRule — round-trips the synthesized diff', () => {
     expect(extractAddedAllowRule('')).toBeNull()
   })
 })
+
+// The auto-approve correlation in gateway.ts gates on an EXACT byte-match
+// of the incoming diff against the diff the gateway synthesized — NOT on
+// the rule token alone. This documents why: extractAddedAllowRule is
+// location-blind (it returns the token for a `- <rule>` line under ANY
+// key), so a forged edit placing the same consented token under `deny:`
+// or `secrets:` yields the same token but a DIFFERENT diff string. The
+// exact-diff gate is what rejects it.
+describe('forge-resistance — same token, wrong location ≠ synthesized diff', () => {
+  const cfg = [
+    'agents:',
+    '  clerk:',
+    '    tools:',
+    '      allow:',
+    '        - Read',
+    '      deny:',
+    '        - WebFetch',
+    '',
+  ].join('\n')
+
+  it('a deny-block diff adding the same token has the same token but a different diff', () => {
+    const legit = synthesizeAllowRuleDiff({ agentName: 'clerk', rule: 'Bash', configText: cfg })
+    expect(legit).not.toBeNull()
+    // The legit diff adds `- Bash` under tools.allow.
+    expect(extractAddedAllowRule(legit!)).toBe('Bash')
+
+    // A forged diff placing `- Bash` under the deny: block. Same token...
+    const forged = [
+      '--- a/switchroom.yaml',
+      '+++ b/switchroom.yaml',
+      '@@ -6,2 +6,3 @@',
+      '      deny:',
+      '        - WebFetch',
+      '+        - Bash',
+      '',
+    ].join('\n')
+    expect(extractAddedAllowRule(forged)).toBe('Bash') // ...location-blind: same token
+
+    // ...but the byte strings differ, so the exact-diff correlation gate
+    // (entry.unifiedDiff === msg.unifiedDiff) rejects the forgery.
+    expect(forged).not.toBe(legit)
+  })
+})


### PR DESCRIPTION
## Summary
Fixes #1977 — the Telegram "🔁 Always allow" button never persisted because it shelled `switchroom agent grant` to write `/state/config/switchroom.yaml`, which is bind-mounted **read-only** into agent containers. The write no-op'd and the rule was lost on restart.

Durable host-config writes only land via the host-side **hostd** daemon's `config_propose_edit`. Always-allow now routes through it, with single-tap UX.

## How it works
- **Turn never blocks:** the in-flight Allow verdict is dispatched immediately, before the host round-trip.
- **Durable persist:** synthesize a `git apply`-compatible unified diff adding the rule to the agent's `tools.allow` (built from raw config bytes so context lines byte-match), send to hostd → it writes the real host config + reconciles.
- **Single tap (no second card):** the operator's tap pre-registers an `agent::rule` correlation. When hostd calls back for approval, the gateway auto-approves *that correlated edit*. 
- **Forge-resistant:** an uncorrelated / agent-forged config edit (touching any other field, or a rule the gateway didn't queue) finds no correlation and falls through to a normal operator approval card. Correlation is single-shot + 30s TTL (no replay). The match requires the diff's *added rule* (`extractAddedAllowRule`, strict) to equal a queued rule.
- **Honest fallback:** when hostd is `not-configured`, falls back to the legacy `agent grant` path with honest messaging (never falsely claims saved). `E_CONFIG_EDIT_DISABLED` surfaces an enable-flag hint instead of a doomed legacy write.
- Threads an optional timeout through `tryHostdDispatch` (apply+reconcile exceeds the 5s default; always-allow uses 60s).

## Why this design (vs. shortcuts)
Preserves the "you hold the leash" control pillar: durable permission grants stay operator-mediated, host-written, validated, audited, with rollback (reusing the hardened `config_propose_edit` path). An agent can't silently self-grant tools — the read-only mount + hostd mediation are intentional, and this fix works *with* that model rather than around it.

## Test plan
- [x] `vitest run` permission-diff (synthesis for flow-list / block-seq / absent `tools.allow`; **end-to-end through the real `validateConfigEdit` proving `git apply` compatibility**; `extractAddedAllowRule` strictness), correlation auto-resolve + forge-falls-through, updated always-allow-grant — 32 passing.
- [x] `tsc --noEmit` clean; `check-plugin-references.mjs` clean; `check-bot-api-wrapping.sh` clean.
- [x] Full telegram-plugin suite green.

## Risk
Medium. Security-sensitive (auto-approve correlation) — forge-resistance is load-bearing and covered by tests. Diff synthesis byte-matching is the main fragility; on any mismatch hostd's `git apply --check` rejects → honest failure card (fails safe).

Closes #1977.