### PR TITLE
feat(doctor): guard risky thinking_effort × adaptive-model combos (#1978)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 | Field | Cascade | Description |
 |-------|---------|-------------|
 | `model` | override | Claude model (`claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`). Haiku is the default for the handoff summarizer; agents typically use opus or sonnet. |
+| `thinking_effort` | override | Adaptive-thinking effort passed as `--effort` (`low`/`medium`/`high`/`xhigh`/`max`). Defaults to `low` when unset. **On Opus 4.x keep this at `low`** — `medium`+ emits thinking blocks that the bundled claude CLI can mis-merge under concurrent sub-agents, causing `400 'thinking blocks cannot be modified'` (issue #1978). `switchroom doctor` warns on the risky combo. Removing the field does *not* help: Opus 4.8 defaults `effort=high` when `--effort` is omitted. |
 | `extends` | — | Named profile to inherit from |
 | `tools.allow` / `tools.deny` | union | Tool permissions |
 | `soul` | per-field (**seed-time only**) | Agent persona (name, style, boundaries). Cascades per-field, but **only at first scaffold** — it seeds `workspace/SOUL.md`, which is then user-owned (see [Persona & SOUL.md ownership](#persona--soulmd-ownership)). Editing `soul:` later does **not** change an agent whose SOUL.md already exists. |

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -18,6 +18,7 @@ import { createPublicKey, createPrivateKey } from "node:crypto";
 import { listSecrets, getStringSecret } from "../vault/vault.js";
 import { resolveAgentsDir, resolvePath } from "../config/loader.js";
 import { resolveAgentConfig } from "../config/merge.js";
+import { assessThinkingEffortRisk } from "../config/thinking-effort-risk.js";
 import { resolveStatePath, LEGACY_STATE_DIR } from "../config/paths.js";
 import { getConfig, getConfigPath, withConfigError } from "./helpers.js";
 import { getAllAgentStatuses } from "../agents/lifecycle.js";
@@ -440,6 +441,35 @@ export function checkConfig(config: SwitchroomConfig, configPath: string): Check
       foundSubagents.length > 0
         ? undefined
         : "Add defaults.subagents to switchroom.yaml to enable Sonnet/Haiku delegation. See docs/sub-agents.md for the worker/researcher/reviewer pattern.",
+  });
+
+  // Adaptive-thinking effort guard (#1978). Opus 4.x + thinking_effort
+  // above the `low` floor can 400 on thinking blocks when work runs
+  // through concurrent sub-agents (an upstream claude CLI merge bug).
+  // Resolve each agent's effective model + effort and flag the combo so
+  // an operator sees it at `doctor`/`apply` time, not as silent 400s.
+  const effortRisks: string[] = [];
+  for (const [name, agentConfig] of Object.entries(config.agents)) {
+    const resolved = resolveAgentConfig(
+      config.defaults,
+      config.profiles,
+      agentConfig,
+    );
+    if (assessThinkingEffortRisk(resolved.model, resolved.thinking_effort).risky) {
+      effortRisks.push(name);
+    }
+  }
+  results.push({
+    name: "thinking_effort × adaptive model",
+    status: effortRisks.length > 0 ? "warn" : "ok",
+    detail:
+      effortRisks.length > 0
+        ? `${effortRisks.length} agent(s) on Opus 4.x with thinking_effort > low: ${effortRisks.join(", ")}`
+        : "no risky model/effort combos",
+    fix:
+      effortRisks.length > 0
+        ? "Pin `thinking_effort: low` for Opus 4.x agents — medium+ can 400 on 'thinking blocks cannot be modified' with concurrent sub-agents (issue #1978). Removing the field is NOT a fix (Opus 4.8 defaults effort=high when unset)."
+        : undefined,
   });
 
   return results;

--- a/src/config/thinking-effort-risk.test.ts
+++ b/src/config/thinking-effort-risk.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+  assessThinkingEffortRisk,
+  isAdaptiveThinkingOpus,
+} from "./thinking-effort-risk.js";
+
+describe("isAdaptiveThinkingOpus", () => {
+  it("matches the opus alias and pinned opus-4.x ids", () => {
+    expect(isAdaptiveThinkingOpus("opus")).toBe(true);
+    expect(isAdaptiveThinkingOpus("claude-opus-4-8")).toBe(true);
+    expect(isAdaptiveThinkingOpus("claude-opus-4-7")).toBe(true);
+    expect(isAdaptiveThinkingOpus("CLAUDE-OPUS-4-8")).toBe(true); // case-insensitive
+  });
+
+  it("does not match sonnet/haiku or unset", () => {
+    expect(isAdaptiveThinkingOpus("sonnet")).toBe(false);
+    expect(isAdaptiveThinkingOpus("claude-sonnet-4-6")).toBe(false);
+    expect(isAdaptiveThinkingOpus("haiku")).toBe(false);
+    expect(isAdaptiveThinkingOpus(undefined)).toBe(false);
+    expect(isAdaptiveThinkingOpus("")).toBe(false);
+  });
+});
+
+describe("assessThinkingEffortRisk", () => {
+  it("flags Opus 4.x with effort above the low floor", () => {
+    for (const effort of ["medium", "high", "xhigh", "max"]) {
+      const r = assessThinkingEffortRisk("claude-opus-4-8", effort);
+      expect(r.risky).toBe(true);
+      expect(r.reason).toContain("thinking");
+    }
+    expect(assessThinkingEffortRisk("opus", "medium").risky).toBe(true);
+  });
+
+  it("is safe when effort is the floor or unset (scaffold defaults to low)", () => {
+    expect(assessThinkingEffortRisk("claude-opus-4-8", "low").risky).toBe(false);
+    expect(assessThinkingEffortRisk("claude-opus-4-8", undefined).risky).toBe(false);
+    expect(assessThinkingEffortRisk("opus", undefined).risky).toBe(false);
+  });
+
+  it("is safe for non-Opus models even at high effort", () => {
+    expect(assessThinkingEffortRisk("claude-sonnet-4-6", "high").risky).toBe(false);
+    expect(assessThinkingEffortRisk("sonnet", "max").risky).toBe(false);
+    expect(assessThinkingEffortRisk("haiku", "medium").risky).toBe(false);
+  });
+
+  it("normalizes case/whitespace on the effort value", () => {
+    expect(assessThinkingEffortRisk("claude-opus-4-8", " MEDIUM ").risky).toBe(true);
+  });
+});

--- a/src/config/thinking-effort-risk.ts
+++ b/src/config/thinking-effort-risk.ts
@@ -1,0 +1,82 @@
+/**
+ * Model-aware thinking-effort risk guard (#1978).
+ *
+ * Opus 4.x models use *adaptive thinking* — they emit
+ * `thinking`/`redacted_thinking` blocks. switchroom dispatches work to
+ * concurrent sub-agents (worker/researcher/reviewer via the Task tool,
+ * often `background: true`), and the bundled `claude` CLI can mis-merge
+ * the interleaved streaming content blocks, after which the Anthropic
+ * API rejects the turn with:
+ *
+ *   400 messages.N.content.M: 'thinking' or 'redacted_thinking' blocks
+ *   in the latest assistant message cannot be modified.
+ *
+ * This is an UPSTREAM claude CLI bug (a fix is credited in claude's own
+ * changelog for the concurrent-agent / interleaved-streaming merge
+ * path), not a switchroom bug — so switchroom can't fully fix it; it can
+ * only (a) keep effort at the safe floor and (b) warn loudly when an
+ * operator configures a combo known to trigger it.
+ *
+ * `effort: low` keeps adaptive thinking near-zero (few/no thinking
+ * blocks to mis-merge) and is the safe floor; `medium`+ reliably
+ * reproduces the 400. The scaffold defaults unset `thinking_effort` to
+ * `low` (see SWITCHROOM_DEFAULT_THINKING_EFFORT), so an UNSET value is
+ * safe — only an explicit `medium`/`high`/`xhigh`/`max` on an Opus 4.x
+ * model is flagged.
+ *
+ * Scope note: this guard intentionally only flags the Opus 4.x family.
+ * Sonnet 4.6 also has adaptive thinking, but the fleet runs Sonnet
+ * sub-agents at higher effort without hitting this, so flagging it would
+ * be a false alarm. Revisit if the failure is observed on Sonnet.
+ *
+ * Pure (no I/O) so it can back both `switchroom doctor` and a config-load
+ * advisory, and be unit-tested directly.
+ */
+
+/** Effort levels that produce enough adaptive thinking to risk the merge bug. */
+const RISKY_EFFORTS = new Set(["medium", "high", "xhigh", "max"]);
+
+/**
+ * True for models whose adaptive thinking + switchroom's concurrent
+ * sub-agent dispatch is known to trigger the claude-CLI thinking-block
+ * merge 400. Matches the `opus` alias (resolves to the latest Opus,
+ * currently 4.8) and any pinned `claude-opus-4-*` id.
+ */
+export function isAdaptiveThinkingOpus(model: string | undefined): boolean {
+  if (!model) return false;
+  const m = model.trim().toLowerCase();
+  return m === "opus" || m.startsWith("claude-opus-4");
+}
+
+export interface ThinkingEffortRisk {
+  risky: boolean;
+  /** Operator-facing explanation, present iff `risky`. */
+  reason?: string;
+}
+
+/**
+ * Assess whether a (model, thinking_effort) combo risks the adaptive-
+ * thinking merge 400. Safe (`risky: false`) when effort is unset (→
+ * scaffold floor `low`), when effort is `low`, or when the model isn't an
+ * Opus 4.x adaptive-thinking model.
+ *
+ * @param model   Resolved model — alias (`opus`) or full id (`claude-opus-4-8`).
+ * @param effort  Resolved `thinking_effort` (may be undefined).
+ */
+export function assessThinkingEffortRisk(
+  model: string | undefined,
+  effort: string | undefined,
+): ThinkingEffortRisk {
+  if (!effort) return { risky: false };
+  if (!RISKY_EFFORTS.has(effort.trim().toLowerCase())) return { risky: false };
+  if (!isAdaptiveThinkingOpus(model)) return { risky: false };
+  return {
+    risky: true,
+    reason:
+      `thinking_effort '${effort}' on adaptive-thinking model '${model}' can trigger ` +
+      `'400 thinking/redacted_thinking blocks cannot be modified' errors when work runs ` +
+      `through concurrent sub-agents (issue #1978). Pin 'thinking_effort: low' (the safe ` +
+      `floor) unless the bundled claude CLI includes the concurrent-agent thinking-block ` +
+      `merge fix.`,
+  };
+}


### PR DESCRIPTION
## Summary
Fixes #1978. Opus 4.x uses adaptive thinking; with switchroom's concurrent sub-agent dispatch the bundled `claude` CLI can mis-merge interleaved streaming and the API rejects the turn with `400 'thinking'/'redacted_thinking' blocks cannot be modified`. This is an **upstream claude CLI bug** (a fix is credited in claude's changelog for the concurrent-agent merge path), so switchroom can't fully fix it — but it should fail **loud, not silent**.

## Investigation outcome (the "support higher effort?" question)
The agent image pins `@anthropic-ai/claude-code` (currently 2.1.153). The failure is in claude's concurrent-agent / interleaved-streaming message-merge path, not in switchroom. **Lifting the effort floor on Opus 4.x is gated on bumping the bundled claude CLI to a version that includes the merge fix** — not something switchroom can patch around. So this PR does the strategic, in-scope thing: make the constraint visible at config time.

## What this adds (the "flag properly for future agents" path)
- `assessThinkingEffortRisk(model, effort)` (pure, unit-tested): flags Opus 4.x (`opus` alias or `claude-opus-4-*`) + `thinking_effort` above the `low` floor. **Unset effort is safe** (scaffold defaults to `low`). Non-Opus models aren't flagged — Sonnet runs higher effort fine in practice, so flagging it would be a false alarm.
- `switchroom doctor` (which also runs on `apply`) emits a `warn` in the **Configuration** section listing at-risk agents, with a fix hint: pin `low`, and note that *removing* the field is worse (Opus 4.8 defaults `effort=high` when unset).
- Documents `thinking_effort` in `docs/configuration.md` with the caveat.

## Why a warn, not a hard block
An operator who bumps the bundled claude CLI may legitimately want higher effort. A doctor warning surfaces the risk without forbidding the config — consistent with switchroom's other advisory checks.

## Test plan
- [x] `vitest` `thinking-effort-risk.test.ts` (6): risky combos, safe floor/unset, non-Opus exclusion, case/whitespace normalization.
- [x] Full doctor test suite (134) green — the added Configuration check breaks no existing assertions.
- [x] `tsc --noEmit` clean.

Closes #1978.