### PR TITLE
fix(agents): pin claude to the image binary, prune user-local shadows at boot

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -183,6 +183,29 @@ export PATH="$HOME/.bun/bin:$PATH"
 # all land in these paths; survival across container restart is via the
 # /state/agent bind mount (HOME=/state/agent/home).
 export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.npm-global/bin:$PATH"
+# claude is delivered ONLY by the agent image (/usr/local, root-owned,
+# version-pinned, rebuilt deliberately via `switchroom update`). The
+# persistent-HOME dirs above precede /usr/local/bin on PATH so agents
+# can install their own npm/pip tools — but that same precedence means
+# a stray `claude` in the writable, state-persisted npm prefix would
+# silently SHADOW the image's, surviving every restart and drifting the
+# fleet off the tested binary (this bit test-harness with a months-old
+# self-installed 2.1.139). DISABLE_AUTOUPDATER=1 stops claude's own
+# self-update, but can't undo a pre-existing or manual drop. So prune
+# any user-local claude at boot — narrowly, by name, leaving every
+# other user-installed package intact — guaranteeing `claude` always
+# resolves to the image binary. Idempotent; no-op when clean.
+for _stray_claude in \
+  "$HOME/.npm-global/bin/claude" \
+  "$HOME/.local/bin/claude" \
+  "$HOME/bin/claude"; do
+  if [ -e "$_stray_claude" ] || [ -L "$_stray_claude" ]; then
+    echo "start.sh: pruning user-local claude shadow at $_stray_claude (image binary is authoritative)" >&2
+    rm -f "$_stray_claude"
+  fi
+done
+rm -rf "$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code" 2>/dev/null || true
+unset _stray_claude
 export CLAUDE_CONFIG_DIR="{{agentDir}}/.claude"
 # CLAUDE_CODE_OAUTH_TOKEN injection was removed with RFC H (auth-broker).
 # Claude reads .credentials.json directly; the broker is the sole writer

--- a/tests/scaffold.regenerate-start-sh.test.ts
+++ b/tests/scaffold.regenerate-start-sh.test.ts
@@ -82,6 +82,36 @@ describe("scaffoldAgent: start.sh content-aware regeneration (#879)", () => {
     expect(second.created).toContain(startShPath);
   });
 
+  it("prunes any user-local claude shadow at boot so the image binary is authoritative", () => {
+    const name = "pinned-agent";
+    const config = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig(name, config);
+
+    const res = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+    const startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+
+    // The persistent-HOME dirs precede /usr/local/bin on PATH (so agents
+    // can install their own npm/pip tools), which means a stray claude in
+    // the writable, state-persisted npm prefix would otherwise shadow the
+    // version-pinned image binary across every restart. start.sh must
+    // remove a user-local claude — by name, leaving other packages intact.
+    expect(startSh).toContain("$HOME/.npm-global/bin/claude");
+    expect(startSh).toContain("$HOME/.local/bin/claude");
+    expect(startSh).toContain("$HOME/bin/claude");
+    expect(startSh).toContain(
+      "$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code",
+    );
+    // The prune must come BEFORE claude is launched (start.sh later
+    // execs into tmux→bash→claude), i.e. before the CLAUDE_CONFIG_DIR
+    // export that anchors the runtime block.
+    expect(startSh.indexOf("pruning user-local claude shadow")).toBeGreaterThan(
+      0,
+    );
+    expect(startSh.indexOf("pruning user-local claude shadow")).toBeLessThan(
+      startSh.indexOf('export CLAUDE_CONFIG_DIR='),
+    );
+  });
+
   it("does NOT rewrite an existing start.sh when content already matches the template", () => {
     const name = "stable-agent";
     const config = makeAgentConfig();


### PR DESCRIPTION
## Summary
Guarantee that every agent runs the **image-delivered** `claude` and only that version — agents keep full npm/pip persistence for their own tooling.

## Why
`claude` is delivered solely by the agent image (`/usr/local`, root-owned, version-pinned, rolled forward via `switchroom update`), and `DISABLE_AUTOUPDATER=1` stops its self-update. But agent PATH puts the persistent-HOME dirs (`.local/bin`, `bin`, `.npm-global/bin`) **ahead** of `/usr/local/bin` so agents can `npm i -g` / `pip install --user` their own tools. That same precedence means a stray `claude` in the writable, **state-persisted** `~/.npm-global` silently **shadows** the image binary and survives every restart — drifting the agent off the tested CLI.

This actually bit **test-harness**: a months-old self-installed `claude 2.1.139` in `~/.npm-global/bin` outranked the image's `/usr/local/bin/claude` indefinitely, which is the recurring contamination behind the thinking-block 400 canary work.

## What
`profiles/_base/start.sh.hbs` prunes any user-local `claude` at boot — **narrowly, by name** (`.npm-global/bin/claude`, `.local/bin/claude`, `bin/claude`, and the `@anthropic-ai/claude-code` package dir), leaving every other user-installed npm/pip package intact. Runs before claude launches; idempotent; no-op when clean. So `claude` always resolves to the image binary while agents keep their own persistent tooling.

## Test plan
- [x] `tests/scaffold.regenerate-start-sh.test.ts` — new assertion that the rendered start.sh prunes each user-local claude path and does so before the runtime block
- [x] `tsc --noEmit` clean
- [x] `bash -n` on the rendered prune snippet
- [ ] Live: after rollout, `which -a claude` in every agent → only `/usr/local/bin/claude`; re-confirm a planted `~/.npm-global/bin/claude` is gone after restart

## Risk
Low. Removes only a `claude` binary/package from user-writable dirs (never the image's), touches nothing else under `.npm-global`. Worst case if an operator *intentionally* pinned a different local claude: that's explicitly disallowed by the Claude-native compliance constraint, so removing it is correct.