### PR TITLE
chore: release v0.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## v0.14.8 — pin claude CLI to the thinking-block-fix build; durable approvals; activity feed
+
+Bundles the claude-CLI thinking-block-400 fix, two reliability fixes
+that merged to `main` since v0.14.7, and the flag-gated activity feed.
+
+### Claude CLI pinned to `@2.1.156` (the 400-fix build)
+
+`docker/Dockerfile.base` and `docker/Dockerfile.hindsight` now install
+`@anthropic-ai/claude-code@2.1.156` (was `@latest`). 2.1.156 proactively
+strips stale `thinking`/`redacted_thinking` blocks before re-sending the
+assistant turn, which fixes the `400 "thinking blocks ... cannot be
+modified"` failures that hit Opus 4.x agents under concurrent sub-agent
+dispatch (see #1978). Hard-pinning makes the built image deterministic
+and auditable — a CLI bump is now an explicit, reviewable one-line
+change rather than "whatever `@latest` resolved at build time."
+
+The hindsight image is pinned to the same version so the memory
+provider runs the identical claude bundle as the agent containers —
+a version skew there could reintroduce the thinking-block class of
+failures on memory reflection.
+
+### PR — durable always-allow approvals (#1979 / #1977)
+
+Approval grants marked always-allow are now persisted durably via
+hostd `config_propose_edit` instead of living only in process memory,
+so they survive a gateway/agent restart.
+
+### PR — doctor flags risky `thinking_effort` × adaptive-model combos (#1980 / #1978)
+
+`switchroom doctor` now warns when an Opus 4.x agent is configured with
+`thinking_effort` above the `low` floor — the combination that triggers
+the thinking-block 400s above. Sonnet is explicitly exempt (it runs
+higher effort fine in practice — avoids false alarms).
+
+### PR — pin claude to the image binary, prune user-local shadows (#1981)
+
+`start.sh` now resolves `claude` to the image-baked
+`/usr/local/bin/claude` and prunes any user-local `claude` install
+shadowing it on `PATH`, so an agent always runs the audited, pinned CLI
+bundle rather than a stale per-HOME copy.
+
+### PR — activity feed via in-place edited message + reply-quote (#1982)
+
+The live tool-activity feed (`SWITCHROOM_DRAFT_MIRROR`, **default OFF**)
+now renders through a single `sendMessage` that is then repeatedly
+`editMessageText`-ed in place, reply-quoting the originating message,
+instead of the old compose-draft transport that conflicted with the
+answer-stream over Telegram's single draft slot. Dormant unless the
+flag is enabled.
+
 ## v0.14.7 — cite Claude Opus 4.8 as the current flagship model (#1975)
 
 Docs refresh: Opus 4.8 (released 2026-05-28) supersedes 4.7 as

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -134,9 +134,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
  && apt-get install -y --no-install-recommends gh \
  && gh --version >&2
 
-# Pin claude CLI version in the base image so every agent / scheduler
-# container resolves the SAME bundle. The version floats with the
-# upstream tag at image-build time; agents do NOT install claude.
+# Pin claude CLI to an EXACT version in the base image so every agent /
+# scheduler container resolves the SAME, auditable bundle — the built
+# image is deterministic, not "whatever @latest resolved at build time."
+# Bumping the CLI is therefore an explicit, reviewable one-line change
+# here (see #1978). Agents do NOT install claude.
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a
@@ -145,12 +147,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # CACHE_BUST is wired through from the workflow as
 # `${{ github.run_attempt }}` — fresh pushes to main (attempt=1) hit
 # the cache for fast turnaround, but a `gh run rerun` (attempt=2+)
-# changes the layer hash and forces a fresh `npm install` that re-
-# resolves `@latest` from the registry. Without this, buildkit's
-# `cache-from: type=gha,scope=base` reuses the prior layer even on
-# rerun and the version stays stuck at whatever first cached it.
-# Default `default` so local `docker build` (no build-arg) still
-# works deterministically.
+# changes the layer hash and forces a fresh `npm install`. With an
+# exact pin the re-resolve always yields the same version; CACHE_BUST
+# still matters for the other layers in this stage. Default `default`
+# so local `docker build` (no build-arg) works deterministically.
 ARG CACHE_BUST=default
 # Cache the npm download dir so a CACHE_BUST-driven re-run only pays the
 # version-resolve + install cost, not the ~30s re-download. /root/.npm is
@@ -158,7 +158,7 @@ ARG CACHE_BUST=default
 # bumps.
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     echo "cache-bust=${CACHE_BUST}" > /dev/null \
- && npm install -g @anthropic-ai/claude-code@latest \
+ && npm install -g @anthropic-ai/claude-code@2.1.156 \
  && claude --version >&2
 
 # Phase 1b: install bun. The broker server (src/vault/broker/server.ts)

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -36,9 +36,11 @@ USER root
 
 # Node was already present in the upstream `standalone` stage (used for
 # the Control Plane). We piggyback on it to install the claude CLI
-# globally. Pinning to @latest at build time matches docker/Dockerfile.base
-# — we want the same claude bundle the agent containers ship.
-RUN npm install -g @anthropic-ai/claude-code@latest \
+# globally. Pin the EXACT same version docker/Dockerfile.base ships so the
+# hindsight memory provider runs the identical claude bundle as the agent
+# containers — a version skew here could reintroduce the thinking-block /
+# thinking-effort class of failures on memory reflection (see #1978).
+RUN npm install -g @anthropic-ai/claude-code@2.1.156 \
  && claude --version >&2
 
 # Install claude-agent-sdk into the same venv the hindsight API runs from.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release v0.14.8. Pins the claude CLI to the thinking-block-400 fix build and bundles three reliability PRs already on `main` plus the flag-gated activity feed.

- **Pin claude CLI to `@2.1.156`** in `docker/Dockerfile.base` + `docker/Dockerfile.hindsight` (was `@latest`). 2.1.156 proactively strips stale `thinking`/`redacted_thinking` blocks, fixing the `400 "thinking blocks ... cannot be modified"` failures on Opus 4.x under concurrent sub-agent dispatch (#1978). Hard-pin → deterministic, auditable image.
- **#1979** durable always-allow approvals via hostd `config_propose_edit` (survive restart).
- **#1980** doctor flags risky `thinking_effort` × Opus-4.x combos (Sonnet exempt).
- **#1981** start.sh pins claude to the image binary, prunes user-local shadows on PATH.
- **#1982** activity feed via in-place edited message + reply-quote (`SWITCHROOM_DRAFT_MIRROR`, default OFF — dormant).

## Why

The fleet hit `400` thinking-block errors on Opus 4.x agents under concurrent sub-agent dispatch. Pinning to the fixed CLI build closes that class deterministically, and bundling the merged reliability fixes + the dormant activity feed cuts a single coherent release.

## Test plan

- [x] `node scripts/build.mjs` exit 0; `dist/cli/switchroom.js` present (3.0 MB)
- [x] build-info.ts reverted post-build
- [ ] CI: all 10 required checks green
- [ ] Canary: clean sub-agent-heavy turn on test-harness, no thinking-block 400
- [ ] Hindsight retain/recall smoke on 2.1.156 image

## Risk

Low. Three PRs already validated on `main`; #1982 is flag-gated OFF. The only net-new change here is the exact-version claude pin, which is the fix for the observed failure class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)