### PR TITLE
chore: release v0.14.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased — activity feed is the unconditional default (#1984)
+## v0.14.9 — activity feed is the unconditional default (#1984)
 
 The live tool-activity feed (#1982) is now **on for every agent by
 default**. The `SWITCHROOM_DRAFT_MIRROR` env flag and its kill-switch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Release v0.14.9. Single feature commit since v0.14.8: #1984 makes the live tool-activity feed the unconditional built-in default.

## Why
The `SWITCHROOM_DRAFT_MIRROR` env flag guarded an *earlier* draft-slot design that contended with the answer-stream. #1982 already moved the feed onto a separate in-place edited message (reply-quoted), so the kill-switch protected nothing. #1984 un-gates the feed, deletes the legacy verb-count summary lane, and ships the feed zero-config to new agents and fresh installs.

## Test plan
- [x] `node scripts/build.mjs` clean, `dist/cli/switchroom.js` present (3.0 MB)
- [x] Feed test suite green (16 tests)
- [x] #1984 reviewed (APPROVE) and merged to main
- [ ] CI 10 required checks green
- [ ] Canary UAT on test-harness before fleet roll

## Risk
Low. Fleet is already running the feed via the v0.14.8 env stopgap; this release makes the identical behavior the code default. Constituent PR #1984 was reviewed and merged.