### PR TITLE
feat(webhook): Cloudflare-only edge lock (X-Switchroom-Edge)

### DIFF
--- a/docs/rfcs/webhook-cloudflare-edge-lock.md
+++ b/docs/rfcs/webhook-cloudflare-edge-lock.md
@@ -1,0 +1,141 @@
+# RFC: Cloudflare-only edge lock for webhook ingest
+
+Status: Draft v1
+Author: Ken (via Claude pair-design)
+Date: 2026-05-29
+
+## 1. Summary
+
+Add a per-agent opt-in (`channels.telegram.webhook_require_edge: true`)
+that requires every webhook request to carry an `X-Switchroom-Edge`
+header matching an operator-held secret before any HMAC work runs. A
+Cloudflare Transform Rule injects that header on requests that transit
+the edge (`hooks.switchroom.ai`); requests that reach the tunnel origin
+by any other path don't carry it and are rejected `403`.
+
+This is Phase 2 of the Docker-native webhook work (Phase 1:
+`webhook-via-gateway-socket.md`). It is **defence in depth**, stacking
+on the two controls already in place — not replacing either:
+
+1. **GitHub-IP WAF allowlist** at the Cloudflare edge (network origin).
+2. **Per-agent HMAC** (`X-Hub-Signature-256`) at the receiver (body
+   provenance — proves a secret-holder produced the body).
+
+The gap this closes: the HMAC proves *who signed the body*, not *which
+network path the request took*. If anyone learns the tunnel origin, or a
+co-located service is coerced into an SSRF against `localhost:8080`, the
+HMAC is the only thing standing — and for a public-repo webhook the
+"secret" is only as private as GitHub's storage. The edge header proves
+"this request entered through our Cloudflare edge", which nothing else
+on the request can.
+
+## 2. Motivation
+
+The receiver (`switchroom-web`) listens on `127.0.0.1:8080` and is
+fronted by a cloudflared tunnel. Cloudflare's WAF only admits GitHub's
+published IP ranges. But the receiver itself cannot tell a request that
+came *through* Cloudflare from one that arrived at the tunnel origin
+some other way — both look like loopback once cloudflared forwards them.
+A header that only Cloudflare can inject (because only Cloudflare's
+Transform Rule holds the secret) lets the receiver assert the network
+path.
+
+The owner's ask, verbatim: *"Can we make it only work for cloudflare??"*
+
+## 3. Design
+
+### 3.1 The secret
+
+A single endpoint-global value at `~/.switchroom/webhook-edge-secret`
+(mode `0600`, one line, trailing whitespace trimmed on read). It guards
+the whole receiver, not a single agent — the per-agent grain is already
+the HMAC. The same value is configured as the injected header value in
+the Cloudflare Transform Rule.
+
+`src/web/webhook-edge.ts`:
+- `EDGE_HEADER = 'x-switchroom-edge'` (lower-cased for `Headers.get`).
+- `loadEdgeSecret(path?)` → trimmed string, or `null` if missing/empty.
+- `verifyEdgeHeader(headerValue, expectedSecret)` → constant-time
+  compare (`crypto.timingSafeEqual`), `false` (never throws) on any
+  null/length/value mismatch.
+
+### 3.2 The gate
+
+In `handleWebhookIngest` (`src/web/webhook-handler.ts`), after the
+source-allowed (`403`) check and **before** the per-source secret read /
+HMAC verification:
+
+```
+if (args.requireEdge) {
+  if (!verifyEdgeHeader(headers.get(EDGE_HEADER), args.edgeSecret)) {
+    return 403 { ok: false, error: 'forbidden' }
+  }
+}
+```
+
+Placing it before the HMAC means a non-edge request is cheaply rejected
+and never consumes a signature verification. The `403` body leaks no
+detail (`forbidden`); the *reason* (missing/mismatch vs.
+unconfigured-secret) goes only to the operator log.
+
+`handleWebhookRoute` (`src/web/server.ts`) reads
+`webhook_require_edge === true` from the resolved agent config and lazily
+loads the edge secret only when required, passing `requireEdge` +
+`edgeSecret` into the handler.
+
+### 3.3 Fail-closed
+
+If `requireEdge` is true but `edgeSecret` is `null` (file missing /
+empty / unreadable), **every** request is rejected `403`. A
+misconfigured lock must never silently fall open — the failure mode of a
+security control is "deny", not "allow".
+
+### 3.4 Cloudflare Transform Rule
+
+On the `hooks.switchroom.ai` zone, add an HTTP Request Header
+Modification rule:
+
+- **When**: hostname equals `hooks.switchroom.ai` (and/or path starts
+  with `/webhook/`).
+- **Set static header**: `X-Switchroom-Edge` = `<the secret>`.
+
+Cloudflare strips/overwrites any client-supplied `X-Switchroom-Edge` so
+a forged value from outside cannot survive the edge — the rule *sets*
+(not appends) the header. The secret lives only in the Transform Rule
+config and the local file; it never appears in repo, compose, or agent
+state.
+
+## 4. Scope
+
+- **Per-agent opt-in** (`webhook_require_edge`), canaried on `reggie`
+  first, mirroring Phase 1's `webhook_via_gateway` rollout.
+- **Receiver-side only.** The check happens entirely in the host web
+  receiver; no gateway, compose, or agent-image change. Orthogonal to
+  `webhook_via_gateway` (an agent can have either, both, or neither).
+- **No vault dependency** in v1 — a flat operator file, matching the
+  existing `webhook-secrets.json` precedent. A vault-backed resolver is
+  a future option if operator burden materialises.
+
+## 5. Rollout
+
+1. Write `~/.switchroom/webhook-edge-secret` (random value, `0600`).
+2. Add the Cloudflare Transform Rule with the same value.
+3. Flip `reggie`'s `webhook_require_edge: true`; `apply` (no agent
+   restart needed — receiver-side flag), restart the receiver.
+4. Verify: a signed POST *through* `hooks.switchroom.ai` → `202`; a
+   signed POST direct to `127.0.0.1:8080` (no edge header) → `403`.
+5. Green → leave on reggie; widen per-agent as desired.
+
+## 6. Test plan
+
+- `src/web/webhook-edge.test.ts` — `loadEdgeSecret` (present/missing/
+  empty), `verifyEdgeHeader` (match/mismatch/length/null/fail-closed).
+- `src/web/webhook-handler.test.ts` — edge gate: match→202,
+  missing→403, wrong→403, fail-closed (null secret)→403, flag-off
+  ignored→202, gate-before-HMAC (valid edge + bad sig → 401 not 403).
+
+## 7. Phase 3 (not this RFC)
+
+Dedicated `switchroom-webhook` container in its own compose project,
+retiring the systemd unit and the shared-checkout fragility. Tracked
+separately.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -723,6 +723,20 @@ export const TelegramChannelSchema = z
         "webhook_dispatch. Off by default for back-compat with host-runtime " +
         "installs. See docs/rfcs/webhook-via-gateway-socket.md.",
       ),
+    webhook_require_edge: z
+      .boolean()
+      .optional()
+      .describe(
+        "Cloudflare-only edge lock: require the X-Switchroom-Edge header " +
+        "(injected by a Cloudflare Transform Rule on hooks.switchroom.ai) to " +
+        "match the operator's edge secret at ~/.switchroom/webhook-edge-secret " +
+        "before any HMAC verification; reject 403 otherwise. Proves the " +
+        "request entered through our Cloudflare edge — the per-agent HMAC " +
+        "alone can't (it proves body provenance, not network path). Stacks " +
+        "on the GitHub-IP WAF + per-agent HMAC. Fail-closed: when required " +
+        "but the secret file is missing/empty every request is rejected. Off " +
+        "by default. See docs/rfcs/webhook-cloudflare-edge-lock.md.",
+      ),
     // ─── Supergroup-owned mode (RFC docs/rfcs/supergroup-mode.md) ──────
     // Per-agent override of the fleet-wide telegram.forum_chat_id.
     // When set, this agent owns its own supergroup with forum topics

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -34,6 +34,7 @@ import {
   handleGetApprovals,
 } from "./api.js";
 import { handleWebhookIngest } from "./webhook-handler.js";
+import { loadEdgeSecret } from "./webhook-edge.js";
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html",
@@ -280,6 +281,13 @@ async function handleWebhookRoute(
   const allSecrets = loadWebhookSecrets();
   const agentSecrets = allSecrets[agent] ?? {};
 
+  // Cloudflare-only edge lock (Phase 2). Per-agent opt-in; the secret
+  // itself is endpoint-global (one file guards the whole receiver). Loaded
+  // lazily only when the agent requires it; null when the file is
+  // missing/empty, which fails closed inside the handler.
+  const requireEdge = agentConfig?.channels?.telegram?.webhook_require_edge === true;
+  const edgeSecret = requireEdge ? loadEdgeSecret() : null;
+
   let bodyBuf: Uint8Array;
   try {
     bodyBuf = new Uint8Array(await req.arrayBuffer());
@@ -303,6 +311,8 @@ async function handleWebhookRoute(
       // Docker-runtime: forward to the agent's gateway instead of writing
       // the per-agent-UID-owned dir as the host operator UID (EACCES 500).
       viaGateway: agentConfig?.channels?.telegram?.webhook_via_gateway === true,
+      requireEdge,
+      edgeSecret,
     },
     {},
   );

--- a/src/web/webhook-edge.test.ts
+++ b/src/web/webhook-edge.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the Cloudflare-only edge lock primitives (Phase 2).
+ * Uses vitest + tmpdir for file I/O isolation.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync, chmodSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { EDGE_HEADER, loadEdgeSecret, verifyEdgeHeader } from './webhook-edge.js'
+
+function tmpFile(contents: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'webhook-edge-'))
+  const p = join(dir, 'webhook-edge-secret')
+  writeFileSync(p, contents, { mode: 0o600 })
+  return p
+}
+
+describe('EDGE_HEADER', () => {
+  it('is lower-cased for case-insensitive Headers.get lookups', () => {
+    expect(EDGE_HEADER).toBe('x-switchroom-edge')
+  })
+})
+
+describe('loadEdgeSecret', () => {
+  it('returns the trimmed secret when the file exists', () => {
+    const p = tmpFile('super-secret-value\n')
+    expect(loadEdgeSecret(p)).toBe('super-secret-value')
+  })
+
+  it('returns null when the file is missing', () => {
+    expect(loadEdgeSecret(join(tmpdir(), 'does-not-exist-' + Math.random()))).toBeNull()
+  })
+
+  it('returns null when the file is empty / whitespace only', () => {
+    expect(loadEdgeSecret(tmpFile(''))).toBeNull()
+    expect(loadEdgeSecret(tmpFile('   \n  '))).toBeNull()
+  })
+})
+
+describe('verifyEdgeHeader', () => {
+  it('accepts a matching header', () => {
+    expect(verifyEdgeHeader('s3cr3t', 's3cr3t')).toBe(true)
+  })
+
+  it('rejects a mismatched header', () => {
+    expect(verifyEdgeHeader('wrong', 's3cr3t')).toBe(false)
+  })
+
+  it('rejects a length-mismatched header without throwing', () => {
+    expect(verifyEdgeHeader('short', 'a-much-longer-secret')).toBe(false)
+  })
+
+  it('rejects when the header is null/undefined/empty', () => {
+    expect(verifyEdgeHeader(null, 's3cr3t')).toBe(false)
+    expect(verifyEdgeHeader(undefined, 's3cr3t')).toBe(false)
+    expect(verifyEdgeHeader('', 's3cr3t')).toBe(false)
+  })
+
+  it('rejects when the expected secret is null (fail-closed)', () => {
+    expect(verifyEdgeHeader('anything', null)).toBe(false)
+  })
+})

--- a/src/web/webhook-edge.ts
+++ b/src/web/webhook-edge.ts
@@ -1,0 +1,79 @@
+/**
+ * Cloudflare-only edge lock for the webhook ingest path (Phase 2 of the
+ * Docker-native webhook work — see docs/rfcs/webhook-via-gateway-socket.md
+ * and docs/rfcs/webhook-cloudflare-edge-lock.md).
+ *
+ * The receiver is reachable only behind Cloudflare (`hooks.switchroom.ai`
+ * → cloudflared tunnel → localhost:8080). A Cloudflare Transform Rule
+ * injects a shared secret as the `X-Switchroom-Edge` header on every
+ * request that transits the edge. Requests that did NOT come through
+ * Cloudflare (e.g. someone who learned the tunnel origin, or a SSRF from
+ * a co-located service) won't carry the header and are rejected 403.
+ *
+ * This stacks on the existing defences (GitHub-IP WAF allowlist at the
+ * edge + per-agent HMAC) — it is not a replacement for either. Its job is
+ * to prove "this request entered through our Cloudflare edge", which the
+ * HMAC alone cannot (HMAC proves the body came from a secret-holder, not
+ * the network path).
+ *
+ * Fail-closed: when an agent opts in (`webhook_require_edge: true`) but the
+ * secret file is missing/unreadable, EVERY request is rejected 403. A
+ * misconfigured lock must never silently fall open.
+ */
+
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import { timingSafeEqual } from 'crypto'
+
+/** Header the Cloudflare Transform Rule injects. Lower-cased for the
+ *  Headers.get() lookup (HTTP header names are case-insensitive). */
+export const EDGE_HEADER = 'x-switchroom-edge'
+
+/**
+ * Operator-managed secret file. Single value (the shared secret), no
+ * structure. Mode 0600. Matches the Cloudflare Transform Rule's injected
+ * value. Endpoint-global — one secret guards the whole receiver, not
+ * per-agent (the per-agent grain is HMAC; this is the network-path proof).
+ */
+export function edgeSecretPath(): string {
+  return join(homedir(), '.switchroom', 'webhook-edge-secret')
+}
+
+/**
+ * Load the edge secret. Returns null when the file is missing or empty
+ * (callers fail-closed on null when the lock is required). Trailing
+ * whitespace/newlines are trimmed so an `echo > file` write matches a
+ * header value that carries none.
+ */
+export function loadEdgeSecret(path?: string): string | null {
+  const p = path ?? edgeSecretPath()
+  try {
+    if (!existsSync(p)) return null
+    const raw = readFileSync(p, 'utf-8').trim()
+    return raw.length > 0 ? raw : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Constant-time compare of the presented header value against the
+ * expected secret. Returns false (never throws) on any mismatch,
+ * including a null/absent header or a null secret — the fail-closed
+ * contract lives at the call site, this just answers "do they match".
+ */
+export function verifyEdgeHeader(
+  headerValue: string | null | undefined,
+  expectedSecret: string | null,
+): boolean {
+  if (!headerValue || !expectedSecret) return false
+  const a = Buffer.from(headerValue, 'utf8')
+  const b = Buffer.from(expectedSecret, 'utf8')
+  if (a.length !== b.length) {
+    // Compare against self to keep timing independent of length.
+    timingSafeEqual(a, a)
+    return false
+  }
+  return timingSafeEqual(a, b)
+}

--- a/src/web/webhook-handler.test.ts
+++ b/src/web/webhook-handler.test.ts
@@ -592,3 +592,83 @@ describe('handleWebhookIngest — viaGateway forward', () => {
     expect(result.status).toBe(503)
   })
 })
+
+describe('handleWebhookIngest — Cloudflare edge lock (requireEdge)', () => {
+  const EDGE = 'edge-shared-secret'
+
+  function withEdge(h: Headers, value?: string): Headers {
+    if (value !== undefined) h.set('x-switchroom-edge', value)
+    return h
+  }
+
+  it('matching edge header → proceeds to record (202)', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody()
+    const headers = withEdge(makeGithubHeaders(body, 'edge-ok'), EDGE)
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), requireEdge: true, edgeSecret: EDGE },
+      baseDeps(resolveAgentDir, 1000, { dedupStore: makeDedupStore(), rateLimiter: makeRateLimiter() }),
+    )
+    expect(result.status).toBe(202)
+  })
+
+  it('missing edge header → 403 before any HMAC work', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'edge-missing') // no x-switchroom-edge
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), requireEdge: true, edgeSecret: EDGE },
+      baseDeps(resolveAgentDir, 1000),
+    )
+    expect(result.status).toBe(403)
+    expect(JSON.parse(result.body)).toMatchObject({ ok: false, error: 'forbidden' })
+  })
+
+  it('wrong edge header → 403', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody()
+    const headers = withEdge(makeGithubHeaders(body, 'edge-wrong'), 'not-the-secret')
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), requireEdge: true, edgeSecret: EDGE },
+      baseDeps(resolveAgentDir, 1000),
+    )
+    expect(result.status).toBe(403)
+  })
+
+  it('fail-closed: requireEdge but edgeSecret null → 403 even with a header present', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody()
+    const headers = withEdge(makeGithubHeaders(body, 'edge-noconf'), EDGE)
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), requireEdge: true, edgeSecret: null },
+      baseDeps(resolveAgentDir, 1000),
+    )
+    expect(result.status).toBe(403)
+  })
+
+  it('flag off: edge header ignored entirely, normal flow (202) even with no edge secret', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody()
+    const headers = makeGithubHeaders(body, 'edge-off')
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), requireEdge: false, edgeSecret: null },
+      baseDeps(resolveAgentDir, 1000, { dedupStore: makeDedupStore(), rateLimiter: makeRateLimiter() }),
+    )
+    expect(result.status).toBe(202)
+  })
+
+  it('edge gate runs before signature check: valid edge + bad HMAC → 401 (not 403)', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody()
+    const headers = new Headers()
+    headers.set('x-hub-signature-256', 'sha256=' + 'deadbeef'.repeat(8))
+    headers.set('x-github-delivery', 'edge-order')
+    headers.set('x-github-event', 'pull_request')
+    withEdge(headers, EDGE)
+    const result = await handleWebhookIngest(
+      { ...baseArgs(body, headers), requireEdge: true, edgeSecret: EDGE },
+      baseDeps(resolveAgentDir, 1000),
+    )
+    expect(result.status).toBe(401)
+  })
+})

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -52,6 +52,7 @@ import {
 } from './webhook-verify.js'
 import type { WebhookDispatchConfig } from './webhook-dispatch.js'
 import { forwardToGateway, type WebhookForwardResponse } from './webhook-ingest-client.js'
+import { EDGE_HEADER, verifyEdgeHeader } from './webhook-edge.js'
 
 export interface WebhookConfig {
   /** Per-source secrets, declared in vault under
@@ -112,6 +113,22 @@ export interface WebhookHandlerArgs {
    * append, and dispatch. See docs/rfcs/webhook-via-gateway-socket.md.
    */
   viaGateway?: boolean
+  /**
+   * Cloudflare-only edge lock (channels.telegram.webhook_require_edge).
+   * When true, the request MUST carry the `X-Switchroom-Edge` header
+   * matching `edgeSecret` (injected by a Cloudflare Transform Rule on the
+   * edge) or it is rejected 403 before any HMAC work. Fail-closed: if the
+   * lock is required but `edgeSecret` is null (secret file missing), every
+   * request is rejected. Off by default. See
+   * docs/rfcs/webhook-cloudflare-edge-lock.md.
+   */
+  requireEdge?: boolean
+  /**
+   * The expected edge secret, loaded by the route from
+   * `~/.switchroom/webhook-edge-secret`. null when the file is
+   * missing/empty — combined with `requireEdge: true` this fails closed.
+   */
+  edgeSecret?: string | null
 }
 
 export interface WebhookHandlerResult {
@@ -342,6 +359,21 @@ export async function handleWebhookIngest(
   if (!args.allowedSources.includes(source)) {
     log(`webhook-ingest: agent='${args.agent}' source='${source}' rejected: source not in agent's webhook_sources allowlist\n`)
     return jsonReply(403, { ok: false, error: 'source not allowed for this agent' })
+  }
+
+  // ── Cloudflare edge lock (fail-closed) ────────────────────────────────────
+  // Proves the request entered through our Cloudflare edge (Transform Rule
+  // injects X-Switchroom-Edge). Stacks on the GitHub-IP WAF + per-agent HMAC.
+  // Runs before the HMAC work so a non-edge request is cheaply rejected and
+  // never reaches signature verification. A required-but-unconfigured lock
+  // (edgeSecret null) rejects everything rather than silently falling open.
+  if (args.requireEdge) {
+    const presented = args.headers.get(EDGE_HEADER)
+    if (!verifyEdgeHeader(presented, args.edgeSecret ?? null)) {
+      const why = !args.edgeSecret ? 'edge secret not configured (fail-closed)' : 'edge header missing/mismatch'
+      log(`webhook-ingest: agent='${args.agent}' source='${source}' rejected: ${why}\n`)
+      return jsonReply(403, { ok: false, error: 'forbidden' })
+    }
   }
 
   const secret = args.config.secrets[source]


### PR DESCRIPTION
## Summary

Phase 2 of the Docker-native webhook work (Phase 1: #1986). Adds a
per-agent opt-in `channels.telegram.webhook_require_edge`. When set, a
webhook request must carry an `X-Switchroom-Edge` header matching the
operator's secret (`~/.switchroom/webhook-edge-secret`, injected by a
Cloudflare Transform Rule on `hooks.switchroom.ai`) before any HMAC
verification — otherwise `403`.

## Why

Owner ask: *"Can we make it only work for cloudflare?"* The per-agent
HMAC proves *who signed the body*, not *which network path the request
took*. Anyone who reaches the tunnel origin directly (or an SSRF from a
co-located service) bypasses the GitHub-IP WAF. The edge header proves
"this request entered through our Cloudflare edge" — which nothing else
on the request can. Stacks on the existing WAF + HMAC; replaces neither.

## Design

- `src/web/webhook-edge.ts` — `EDGE_HEADER`, `loadEdgeSecret()` (trimmed
  value or `null`), `verifyEdgeHeader()` (constant-time, never throws).
- Gate in `handleWebhookIngest` runs **after** source-allowed and
  **before** the per-source HMAC, so non-edge requests are cheaply
  denied and never consume a signature verification. `403` body leaks no
  detail; the reason goes only to the operator log.
- `handleWebhookRoute` reads `webhook_require_edge === true` and lazily
  loads the edge secret only when required.
- **Fail-closed**: required + secret file missing/empty → every request
  `403`. A misconfigured lock must never fall open.
- **Receiver-side only** — no gateway/compose/agent-image change;
  orthogonal to `webhook_via_gateway`. Per-agent opt-in (canary reggie).

## Test plan

- [x] `src/web/webhook-edge.test.ts` — `loadEdgeSecret`
  (present/missing/empty) + `verifyEdgeHeader`
  (match/mismatch/length/null/fail-closed).
- [x] `src/web/webhook-handler.test.ts` — edge gate: match→202,
  missing→403, wrong→403, fail-closed→403, flag-off→202,
  gate-before-HMAC (valid edge + bad sig → 401 not 403).
- [x] `tsc --noEmit` clean; 32 tests pass.
- [ ] Canary on reggie: add CF Transform Rule + secret file, flip flag,
  verify edge-POST→202 / direct-POST→403.

## Risk

Low. Off by default; receiver-side; fail-closed. Existing webhook flow
unchanged when the flag is absent. JTBD: *always-on* — keeps the
auto-review channel reachable only through the trusted edge.

See `docs/rfcs/webhook-cloudflare-edge-lock.md`.