### PR TITLE
feat(web): containerize dashboard + webhook receiver (switchroom-web)

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -169,6 +169,7 @@ jobs:
           - { name: kernel,       file: docker/Dockerfile.kernel }
           - { name: hostd,        file: docker/Dockerfile.hostd }
           - { name: auth-broker,  file: docker/Dockerfile.auth-broker }
+          - { name: web,          file: docker/Dockerfile.web }
           # hindsight is NOT here — it has its own `build-hindsight`
           # job (PR #1310) that runs in parallel with build-base
           # because Dockerfile.hindsight extends upstream

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,0 +1,77 @@
+# switchroom/web — dashboard + GitHub-webhook receiver container (Phase 3).
+#
+# Replaces the `switchroom-web.service` systemd unit that ran the web
+# server straight off the shared source checkout
+# (`bun bin/switchroom.ts web`). That arrangement was fragile: any other
+# agent's worktree activity could delete the hoisted root node_modules
+# out from under the long-lived process, so the NEXT restart crash-looped
+# on ENOENT even though the code was unchanged. Pinning the receiver to an
+# image makes it immune to repo churn and brings the last systemd holdout
+# in line with the rest of the fleet (vault-broker, kernel, hostd, agents
+# are all containers).
+#
+# What this container runs:
+#   `switchroom web --port 8080 --bind 127.0.0.1`
+#   - The web dashboard (served from /opt/switchroom/dist/cli/ui).
+#   - The GitHub-webhook receiver (POST /webhook/:agent/:source), which —
+#     when an agent has channels.telegram.webhook_via_gateway: true —
+#     forwards verified+rendered events to that agent's in-container
+#     gateway over ~/.switchroom/agents/<agent>/telegram/webhook.sock.
+#
+# Why host networking (set in the compose file, not here):
+#   Two host-side consumers reach the server on 127.0.0.1:8080 and that
+#   address must NOT change:
+#     - cloudflared tunnel (hooks.switchroom.ai → 127.0.0.1:8080) for
+#       GitHub webhooks.
+#     - `tailscale serve` proxies the tailnet host → http://127.0.0.1:8080
+#       for the dashboard (the CSRF origin gate trusts the
+#       Tailscale-User-Login header from loopback, PR #1380).
+#   network_mode: host makes the container's 127.0.0.1 the host loopback,
+#   so both keep working with zero Cloudflare/Tailscale reconfiguration.
+#
+# Why uid = operator (set via `user:` in the compose file, not here):
+#   The webhook.sock the receiver connects to is peercred-gated by the
+#   agent's gateway to {agent's own uid, SWITCHROOM_WEBHOOK_RECEIVER_UID}
+#   (telegram-plugin/gateway/gateway.ts), and SWITCHROOM_WEBHOOK_RECEIVER_UID
+#   is set by the compose generator to the operator uid
+#   (src/agents/compose.ts). Run as any other uid and every forward gets
+#   503'd. The operator uid also owns ~/.switchroom, so file reads (config,
+#   secrets, edge-secret, web-token) work.
+#
+# Deliberately minimal attack surface — this is the one internet-facing
+# component: NO docker socket, NO extra capabilities, no-new-privileges.
+# It does NOT bake profiles/ or vendor/ (those are apply-path assets; the
+# web server never runs `apply`).
+
+ARG BASE_IMAGE=switchroom/base:latest
+FROM ${BASE_IMAGE}
+
+ARG TARGETARCH=amd64
+RUN echo "switchroom/web building for arch=${TARGETARCH}" >&2
+
+# Home dir for the operator-uid runtime user. The real ~/.switchroom is
+# bind-mounted over /host-home/.switchroom at runtime (see compose), so
+# this is just the mountpoint.
+RUN install -d -m 0755 /host-home /host-home/.switchroom
+
+# The CLI bundle (carries the `web` verb + webhook handlers) and the
+# dashboard static assets. server.ts resolves the UI via
+# resolve(import.meta.dirname, "ui") → /opt/switchroom/dist/cli/ui, so the
+# assets MUST sit beside the bundle.
+COPY dist/cli/switchroom.js /opt/switchroom/dist/cli/switchroom.js
+COPY dist/cli/ui/ /opt/switchroom/dist/cli/ui/
+
+# Wrapper so `switchroom` on PATH resolves to the bundled CLI under bun.
+# bun (not node): the bundle imports bun-specific modules (Bun.serve,
+# bun:sqlite, …) marked external by scripts/build.mjs; node throws
+# ERR_UNSUPPORTED_ESM_URL_SCHEME. Mirrors the hostd/broker images.
+RUN printf '#!/bin/sh\nexec bun /opt/switchroom/dist/cli/switchroom.js "$@"\n' \
+    > /usr/local/bin/switchroom \
+ && chmod 0755 /usr/local/bin/switchroom
+
+# Non-root default; the compose file pins `user:` to the operator uid.
+USER 1000:1000
+
+# tini for clean SIGTERM forwarding to the bun process on `docker stop`.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["switchroom", "web", "--port", "8080", "--bind", "127.0.0.1"]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -288,3 +288,17 @@ health summary); a follow-up may rename it to `drift` or fold it into
   runs refresh hostd automatically, so the manual `install` path is
   the fallback for debugging a stuck daemon. *Grounded in:*
   `src/cli/hostd.ts`.
+- **`switchroom webd <install|status|uninstall>`** manages
+  `switchroom-web`, the dashboard + GitHub-webhook receiver container.
+  `install` writes `~/.switchroom/web/docker-compose.yml` and brings the
+  container up in its own compose project (separate from the agent fleet
+  by design), `network_mode: host` so it keeps owning host loopback
+  `127.0.0.1:8080` for the cloudflared tunnel + `tailscale serve`
+  consumers, running as the operator uid so its webhook forwards pass
+  each agent gateway's peercred ACL; `status` shows container state;
+  `uninstall` stops it but leaves the compose file for re-install.
+  Replaces the legacy `switchroom-web.service` systemd unit. `switchroom
+  update` refreshes it only when `web_service.managed: true` is set in
+  `switchroom.yaml` (default off — existing systemd installs are
+  untouched). See `docs/webhook-ingest.md` § Deployment. *Grounded in:*
+  `src/cli/webd.ts`.

--- a/docs/webhook-ingest.md
+++ b/docs/webhook-ingest.md
@@ -65,6 +65,39 @@ Tell the agent (or have it know via CLAUDE.md) to `cat` or `tail` this file when
 - Source unknown → 400.
 - Verification fails → 401 with a generic body, but the operator log line carries the specific reason for debugging.
 
+## Deployment — the receiver container
+
+The webhook receiver is the GitHub-webhook half of the `switchroom web`
+server (the other half is the dashboard). It can run two ways:
+
+- **Legacy (systemd):** `switchroom-web.service` runs the server straight
+  off the source checkout. Fragile — another agent's worktree activity
+  can delete the shared `node_modules` out from under the long-lived
+  process, crash-looping the next restart on ENOENT.
+
+- **Container (preferred):** `switchroom webd install` packages it as an
+  image-pinned container in its own compose project (`switchroom-web`),
+  separate from the agent fleet so the fleet's `compose up -d
+  --remove-orphans` cycle can't recreate it mid-request. Three load-
+  bearing properties of the compose shape (`src/cli/webd.ts`):
+  - `network_mode: host` — the server must own host loopback
+    `127.0.0.1:8080`, where the cloudflared tunnel (webhooks) and
+    `tailscale serve` (dashboard) both reach it. The dashboard CSRF gate
+    trusts the `Tailscale-User-Login` header only on loopback (PR #1380),
+    which only host networking preserves.
+  - runs as the **operator uid** — the receiver's forward to each agent's
+    `webhook.sock` is peercred-gated to `{agent uid,
+    SWITCHROOM_WEBHOOK_RECEIVER_UID = operator uid}`. Any other uid → 503.
+  - **no docker socket, no added caps** — minimal surface for the one
+    internet-facing component.
+
+  Manage it with `switchroom webd <install|status|uninstall>`. Cutover
+  from systemd: bring the container up, verify, then `systemctl --user
+  stop && disable switchroom-web.service`. To keep the container refreshed
+  by `switchroom update`, set `web_service.managed: true` in
+  `switchroom.yaml` (default `false`, so existing systemd installs are
+  untouched).
+
 ## Out of scope
 
 - Auto-posting to Telegram. Today the user has to ask the agent ("anything new from GitHub?"). Auto-post requires bot-token resolution + topic mapping; future PR.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,6 +38,7 @@ import { registerSkillSearchCommand } from "./skill-search.js";
 import { registerAgentConfigMcpCommand } from "./mcp-agent-config.js";
 import { registerHostdMcpCommand } from "./mcp-hostd.js";
 import { registerHostdCommand } from "./hostd.js";
+import { registerWebdCommand } from "./webd.js";
 import { captureEvent, installGlobalErrorHandlers } from "../analytics/posthog.js";
 
 installGlobalErrorHandlers();
@@ -100,3 +101,4 @@ registerSkillSearchCommand(program);
 registerAgentConfigMcpCommand(program);
 registerHostdMcpCommand(program);
 registerHostdCommand(program);
+registerWebdCommand(program);

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -26,16 +26,21 @@ function fakeRunner() {
 }
 
 describe("planUpdate", () => {
-  it("produces 7 steps in default mode (no --rebuild)", () => {
+  it("produces 8 steps in default mode (no --rebuild)", () => {
     const tmp = mkdtempSync(join(tmpdir(), "update-plan-"));
     try {
       const composePath = join(tmp, "docker-compose.yml");
       writeFileSync(composePath, "services: {}\n");
-      const steps = planUpdate({ composePath, hostControlEnabled: false });
+      const steps = planUpdate({
+        composePath,
+        hostControlEnabled: false,
+        webServiceManaged: false,
+      });
       expect(steps.map((s) => s.name)).toEqual([
         "pull-images",
         "apply-config",
         "refresh-hostd",
+        "refresh-web",
         "sync-bundled-skills",
         "stamp-restart-marker",
         "recreate-containers",
@@ -104,12 +109,18 @@ describe("planUpdate", () => {
     try {
       const composePath = join(tmp, "docker-compose.yml");
       writeFileSync(composePath, "services: {}\n");
-      const steps = planUpdate({ composePath, rebuild: true, hostControlEnabled: false });
+      const steps = planUpdate({
+        composePath,
+        rebuild: true,
+        hostControlEnabled: false,
+        webServiceManaged: false,
+      });
       expect(steps.map((s) => s.name)).toEqual([
         "pull-images",
         "rebuild-source",
         "apply-config",
         "refresh-hostd",
+        "refresh-web",
         "sync-bundled-skills",
         "stamp-restart-marker",
         "recreate-containers",
@@ -338,6 +349,61 @@ describe("planUpdate", () => {
         runner: runner.fn,
       });
       expect(() => refresh.run()).toThrow(/switchroom hostd install failed/);
+    });
+  });
+
+  // refresh-web: Phase 3 — the web service lives in a separate compose
+  // project (switchroom-web) and is opt-in (web_service.managed) so
+  // existing systemd-mode installs aren't surprised.
+  describe("refresh-web step", () => {
+    function planFor(opts: Parameters<typeof planUpdate>[0]) {
+      const tmp = mkdtempSync(join(tmpdir(), "update-web-"));
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const steps = planUpdate({ composePath, ...opts });
+      const refresh = steps.find((s) => s.name === "refresh-web")!;
+      rmSync(tmp, { recursive: true, force: true });
+      return { steps, refresh };
+    }
+
+    it("runs (no skipReason) when web_service.managed is true and --skip-images is not set", () => {
+      const { refresh } = planFor({ webServiceManaged: true });
+      expect(refresh.skipReason).toBeUndefined();
+    });
+
+    it("skips with a clear reason when web_service.managed is false (default — legacy systemd unit)", () => {
+      const { refresh } = planFor({ webServiceManaged: false });
+      expect(refresh.skipReason).toMatch(/web_service\.managed is not true/);
+    });
+
+    it("skips when --skip-images is set even with web_service.managed enabled", () => {
+      const { refresh } = planFor({
+        webServiceManaged: true,
+        skipImages: true,
+      });
+      expect(refresh.skipReason).toMatch(/--skip-images/);
+    });
+
+    it("invokes `switchroom webd install` via re-exec when run()", () => {
+      const runner = fakeRunner();
+      const { refresh } = planFor({
+        webServiceManaged: true,
+        runner: runner.fn,
+      });
+      refresh.run();
+      expect(runner.calls).toHaveLength(1);
+      const call = runner.calls[0]!;
+      expect(call.args.slice(-2)).toEqual(["webd", "install"]);
+    });
+
+    it("throws if webd install exits non-zero", () => {
+      const runner = fakeRunner();
+      runner.setNextStatus(1);
+      const { refresh } = planFor({
+        webServiceManaged: true,
+        runner: runner.fn,
+      });
+      expect(() => refresh.run()).toThrow(/switchroom webd install failed/);
     });
   });
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -80,6 +80,9 @@ interface UpdateOptions {
   /** Test seam — override `host_control.enabled` detection for the
    *  `refresh-hostd` step instead of reading from switchroom.yaml. */
   hostControlEnabled?: boolean;
+  /** Test seam — override `web_service.managed` detection for the
+   *  `refresh-web` step instead of reading from switchroom.yaml. */
+  webServiceManaged?: boolean;
   /** One-shot release-channel override (mirrors `apply --channel`). */
   channel?: "dev" | "rc" | "latest";
   /** One-shot release-pin override (mirrors `apply --pin`). Mutually
@@ -334,6 +337,47 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
     run: () => {
       const r = runner(process.execPath, [scriptPath, "hostd", "install"]);
       if (r.status !== 0) throw new Error("switchroom hostd install failed");
+    },
+  });
+
+  // refresh-web: pull the latest web-service image and recreate the
+  // container. Same isolation rationale as refresh-hostd — the web
+  // service runs in its own compose project (`switchroom-web`), so the
+  // agent fleet's pull-images step never touches it and an operator
+  // who ran `switchroom update` after a web change would otherwise be
+  // left on a stale dashboard/webhook receiver. This step folds the
+  // refresh into the update, mirroring refresh-hostd exactly.
+  //
+  // OPT-IN: skipped unless web_service.managed is true. The default is
+  // false because existing installs run the web server as the legacy
+  // `switchroom-web.service` systemd unit — pulling up the container
+  // unprompted would fight the unit for host loopback 127.0.0.1:8080.
+  // Operators flip managed: true only after cutting over (stop+disable
+  // the unit, `switchroom webd install`). Also skipped on --skip-images.
+  let webServiceManaged: boolean;
+  if (typeof opts.webServiceManaged === "boolean") {
+    webServiceManaged = opts.webServiceManaged;
+  } else {
+    try {
+      webServiceManaged = loadConfig().web_service?.managed === true;
+    } catch {
+      // Best-effort: skip rather than fail the whole update if config
+      // can't be loaded.
+      webServiceManaged = false;
+    }
+  }
+  steps.push({
+    name: "refresh-web",
+    description:
+      "switchroom webd install — pull latest web-service image + recreate the dashboard/webhook container (separate compose project)",
+    skipReason: !webServiceManaged
+      ? "web_service.managed is not true — web container not in use (legacy systemd unit)"
+      : opts.skipImages
+        ? "--skip-images flag set"
+        : undefined,
+    run: () => {
+      const r = runner(process.execPath, [scriptPath, "webd", "install"]);
+      if (r.status !== 0) throw new Error("switchroom webd install failed");
     },
   });
 

--- a/src/cli/webd.test.ts
+++ b/src/cli/webd.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for `switchroom webd` — Phase 3 web-service packaging verb.
+ *
+ * Scope: the pure compose-rendering logic. Does NOT exercise `docker
+ * compose` itself; those calls go through spawnSync and are not invoked
+ * by these tests.
+ *
+ * The web container's compose shape has three invariants that diverge
+ * from hostd and are the whole point of this image — they're each
+ * pinned below:
+ *   1. network_mode: host (owns host loopback 127.0.0.1:8080).
+ *   2. runs as the operator uid (peercred gate on per-agent webhook.sock).
+ *   3. NO docker.sock, NO cap_add (minimal internet-facing surface).
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderWebComposeFile } from "./webd.js";
+
+describe("renderWebComposeFile", () => {
+  it("renders a valid yaml-shaped string for the switchroom-web service", () => {
+    const out = renderWebComposeFile({
+      hostHome: "/home/operator",
+      imageTag: "v0.14.12",
+      operatorUid: 1000,
+    });
+    expect(out).toContain("services:");
+    expect(out).toContain("web:");
+    expect(out).toContain("container_name: switchroom-web");
+  });
+
+  it("uses network_mode: host so the container owns host loopback :8080", () => {
+    // The cloudflared tunnel (webhooks) and tailscale serve (dashboard)
+    // both reach the server on 127.0.0.1:8080, and the dashboard CSRF
+    // gate trusts the Tailscale-User-Login header only on loopback
+    // (PR #1380). Only host networking preserves that.
+    const out = renderWebComposeFile({ hostHome: "/h", imageTag: "latest", operatorUid: 1000 });
+    expect(out).toContain("network_mode: host");
+  });
+
+  it("runs as the operator uid so webhook.sock forwards pass the gateway peercred ACL", () => {
+    const out = renderWebComposeFile({ hostHome: "/h", imageTag: "latest", operatorUid: 1000 });
+    expect(out).toContain('user: "1000:1000"');
+
+    // Different operator uid → different user line, verbatim.
+    const other = renderWebComposeFile({ hostHome: "/h", imageTag: "latest", operatorUid: 1234 });
+    expect(other).toContain('user: "1234:1234"');
+  });
+
+  it("does NOT mount the docker socket (minimal internet-facing surface)", () => {
+    const out = renderWebComposeFile({ hostHome: "/h", imageTag: "latest", operatorUid: 1000 });
+    expect(out).not.toContain("docker.sock");
+  });
+
+  it("drops ALL caps and re-adds NONE (web server never chowns or shells docker)", () => {
+    const out = renderWebComposeFile({ hostHome: "/h", imageTag: "latest", operatorUid: 1000 });
+    expect(out).toContain("cap_drop:");
+    expect(out).toMatch(/cap_drop:\s*\n\s+- ALL/);
+    expect(out).not.toContain("cap_add:");
+    expect(out).not.toContain("SYS_ADMIN");
+    expect(out).not.toContain("privileged: true");
+  });
+
+  it("sets no-new-privileges:true", () => {
+    const out = renderWebComposeFile({ hostHome: "/h", imageTag: "latest", operatorUid: 1000 });
+    expect(out).toContain("no-new-privileges:true");
+  });
+
+  it("substitutes the host home into the bind mounts (rw tree + ro symlink-safe yaml)", () => {
+    const out = renderWebComposeFile({ hostHome: "/home/alice", imageTag: "latest", operatorUid: 1000 });
+    // Whole ~/.switchroom tree rw — the receiver reads secrets and
+    // connects per-agent webhook.sock under it.
+    expect(out).toContain("/home/alice/.switchroom:/host-home/.switchroom:rw");
+    // Dashboard only READS the config → symlink-safe direct file bind, :ro.
+    expect(out).toContain(
+      "/home/alice/.switchroom/switchroom.yaml:/state/config/switchroom.yaml:ro",
+    );
+  });
+
+  it("pins the image tag exactly as passed", () => {
+    const out = renderWebComposeFile({ hostHome: "/h", imageTag: "v0.14.12", operatorUid: 1000 });
+    expect(out).toContain("image: ghcr.io/switchroom/switchroom-web:v0.14.12");
+    expect(out).not.toContain("ghcr.io/switchroom/switchroom-web:latest");
+  });
+
+  it("sets HOME, SWITCHROOM_CONFIG, PATH env", () => {
+    const out = renderWebComposeFile({ hostHome: "/h", imageTag: "latest", operatorUid: 1000 });
+    expect(out).toContain("HOME: /host-home");
+    expect(out).toContain("SWITCHROOM_CONFIG: /state/config/switchroom.yaml");
+    expect(out).toContain("PATH:");
+  });
+
+  it("byte-deterministic for the same inputs", () => {
+    const a = renderWebComposeFile({ hostHome: "/h", imageTag: "v1", operatorUid: 1000 });
+    const b = renderWebComposeFile({ hostHome: "/h", imageTag: "v1", operatorUid: 1000 });
+    expect(a).toBe(b);
+  });
+
+  it("warns against operator hand-edits at the top of the file", () => {
+    const out = renderWebComposeFile({ hostHome: "/h", imageTag: "latest", operatorUid: 1000 });
+    expect(out.split("\n")[0]).toContain("AUTO-GENERATED");
+    expect(out).toContain("do not hand-edit");
+  });
+
+  it("uses a 15s stop_grace_period for clean bun shutdown on docker stop", () => {
+    const out = renderWebComposeFile({ hostHome: "/h", imageTag: "latest", operatorUid: 1000 });
+    expect(out).toContain("stop_grace_period: 15s");
+  });
+});

--- a/src/cli/webd.ts
+++ b/src/cli/webd.ts
@@ -1,0 +1,377 @@
+/**
+ * `switchroom webd` — install / status / uninstall the web service
+ * container (dashboard + GitHub-webhook receiver). Phase 3 of the
+ * webhook Docker-native migration.
+ *
+ * Replaces the `switchroom-web.service` systemd unit that ran the web
+ * server straight off the shared source checkout
+ * (`bun bin/switchroom.ts web`). That arrangement was fragile: any
+ * other agent's worktree activity could delete the hoisted root
+ * node_modules out from under the long-lived process, so the NEXT
+ * restart crash-looped on ENOENT even though the code was unchanged.
+ * Pinning the receiver to an image makes it immune to repo churn and
+ * brings the last systemd holdout in line with the rest of the fleet
+ * (vault-broker, kernel, hostd, agents are all containers).
+ *
+ * Like hostd, the daemon runs in a SEPARATE compose project
+ * (`switchroom-web`) from the agent fleet (`switchroom`) so a
+ * `compose -p switchroom up -d --remove-orphans` cycle of the agent
+ * fleet cannot recreate this container mid-request. See
+ * project_docker_first / RFC C §5.1 for the isolation rationale.
+ *
+ * Subcommands:
+ *   install    — write ~/.switchroom/web/docker-compose.yml + start
+ *   status     — show container state
+ *   uninstall  — stop the container (leaves the sibling compose file
+ *                on disk for re-install)
+ *
+ * Idempotent: `install` re-writes the compose template every time
+ * (operator hand-edits get backed up to `docker-compose.yml.bak-<ts>`)
+ * and re-runs `compose up -d`. Safe to call repeatedly.
+ *
+ * IMPORTANT — the systemd unit is NOT removed by `uninstall`. The
+ * intended cutover is: container up on alt port → verify → stop
+ * systemd unit → re-`install` container on 8080. If the container
+ * misbehaves, re-enable the systemd unit and you're back on the
+ * source-checkout server in seconds. Retiring the unit is a deliberate,
+ * separate operator step once the container has soaked.
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { existsSync, mkdirSync, writeFileSync, copyFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { withConfigError } from "./helpers.js";
+import { resolveOperatorUid } from "./operator-uid.js";
+
+/**
+ * Image tag the install verb pins. Defaults to `:latest`. Override
+ * via `--tag <X>` when standing up a specific version (recommended
+ * for production deploys; `:latest` is the dev/operator default).
+ */
+const DEFAULT_IMAGE_TAG = "latest";
+
+/**
+ * Compose project name for the web service. MUST be distinct from
+ * `switchroom` (the agent-fleet project) so a `compose -p switchroom
+ * up -d --remove-orphans` cycle cannot recreate this container
+ * mid-request. Same isolation contract as switchroom-hostd.
+ */
+const WEB_COMPOSE_PROJECT = "switchroom-web";
+
+/**
+ * Render the sibling compose file. Pure-string template.
+ *
+ * Three load-bearing differences from the hostd compose template, each
+ * forced by what the web service is:
+ *
+ *   1. `network_mode: host`. The server MUST own host loopback
+ *      127.0.0.1:8080 — two host-side consumers reach it there and
+ *      that address cannot change:
+ *        - cloudflared tunnel (hooks.switchroom.ai → 127.0.0.1:8080)
+ *          for GitHub webhooks.
+ *        - `tailscale serve` proxies the tailnet host →
+ *          http://127.0.0.1:8080 for the dashboard (the CSRF origin
+ *          gate trusts the Tailscale-User-Login header from loopback,
+ *          PR #1380).
+ *      Host networking makes the container's 127.0.0.1 the host
+ *      loopback, so both keep working with zero Cloudflare/Tailscale
+ *      reconfiguration. (A published-port mapping would NOT — the
+ *      loopback trust in the CSRF gate keys on the request arriving on
+ *      127.0.0.1, which only host-net preserves.)
+ *
+ *   2. `user: "<operatorUid>:<operatorUid>"`. The webhook.sock the
+ *      receiver forwards to is peercred-gated by each agent's gateway
+ *      to {agent's own uid, SWITCHROOM_WEBHOOK_RECEIVER_UID}, and the
+ *      compose generator sets SWITCHROOM_WEBHOOK_RECEIVER_UID to the
+ *      operator uid (src/agents/compose.ts). Run as any other uid and
+ *      every forward gets 503'd. The operator uid also owns
+ *      ~/.switchroom, so the file reads (config, webhook-secrets,
+ *      edge-secret, web-token) work.
+ *
+ *   3. NO docker.sock, NO cap_add. This is the one internet-facing
+ *      component, so it gets the minimal attack surface: the bind
+ *      mounts it needs and nothing else. cap_drop ALL +
+ *      no-new-privileges, like hostd, but without re-adding any cap
+ *      (the web server never chowns sockets or shells out to docker).
+ */
+export function renderWebComposeFile(opts: {
+  hostHome: string;
+  imageTag: string;
+  /** Host operator UID — the container runs as this so its forwards to
+   *  per-agent webhook.sock pass the gateway's peercred ACL, and so its
+   *  reads of operator-owned ~/.switchroom files succeed. REQUIRED:
+   *  without it the receiver can neither read its secrets nor forward. */
+  operatorUid: number;
+}): string {
+  const { hostHome, imageTag, operatorUid } = opts;
+  return `# AUTO-GENERATED by \`switchroom webd install\` — do not hand-edit.
+# Edits land at \`switchroom webd install\` time; backed up to
+# docker-compose.yml.bak-<ts> on overwrite.
+#
+# Separate compose project (\`switchroom-web\`) from the agent fleet
+# (\`switchroom\`) so \`compose up -d --remove-orphans\` against the fleet
+# cannot recreate this container mid-request. Same isolation contract
+# as switchroom-hostd.
+
+services:
+  web:
+    image: ghcr.io/switchroom/switchroom-web:${imageTag}
+    container_name: switchroom-web
+    restart: unless-stopped
+    # The server MUST own host loopback 127.0.0.1:8080 — the cloudflared
+    # tunnel (GitHub webhooks) and \`tailscale serve\` (dashboard) both
+    # reach it there, and the dashboard CSRF gate trusts the
+    # Tailscale-User-Login header only when the request arrives on
+    # loopback (PR #1380). Host networking makes the container's
+    # 127.0.0.1 the host loopback, so both keep working unchanged.
+    network_mode: host
+    # The webhook.sock forward is peercred-gated by each agent's gateway
+    # to {agent uid, SWITCHROOM_WEBHOOK_RECEIVER_UID = operator uid}.
+    # Run as any other uid → every forward is 503'd. Operator uid also
+    # owns ~/.switchroom so config/secret reads work.
+    user: "${operatorUid}:${operatorUid}"
+    # tini (image ENTRYPOINT) forwards SIGTERM to the bun process on
+    # \`docker stop\`; Bun.serve shuts its listener within the grace
+    # window. 15s mirrors hostd.
+    stop_grace_period: 15s
+    cap_drop:
+      - ALL
+    # Deliberately NO cap_add — the web server never chowns sockets or
+    # shells out to docker. Minimal surface for the one internet-facing
+    # component.
+    security_opt:
+      - no-new-privileges:true
+    volumes:
+      # The receiver reads operator-owned files under ~/.switchroom:
+      #   - webhook-secrets.json (per-source HMAC secrets)
+      #   - webhook-edge-secret (Cloudflare edge lock, Phase 2)
+      #   - web-token (dashboard auth)
+      # and forwards verified events to per-agent webhook.sock at
+      #   ~/.switchroom/agents/<agent>/telegram/webhook.sock
+      # so it needs the whole tree read-write (the sock connect is a
+      # write-side operation on the agent dir).
+      - ${hostHome}/.switchroom:/host-home/.switchroom:rw
+      # ~/.switchroom/switchroom.yaml is a symlink on many operator
+      # setups (into a separate config repo). Mounting the file directly
+      # forces docker to follow the symlink at mount time and bind the
+      # underlying file. The dashboard only READS the config, so :ro.
+      # Mirrors how the agent + hostd containers expose the config at
+      # /state/config/switchroom.yaml.
+      - ${hostHome}/.switchroom/switchroom.yaml:/state/config/switchroom.yaml:ro
+      # No docker socket is mounted — the web server never touches docker.
+    environment:
+      # The CLI resolves homedir() for ~/.switchroom paths; pin it to
+      # /host-home (bind-mounted to the operator's home) so the paths
+      # the server reads/writes match the host paths the agent fleet
+      # binds (~/.switchroom/agents/<agent>/telegram/webhook.sock, …).
+      HOME: /host-home
+      # Read the same config the agent fleet's compose generator did.
+      SWITCHROOM_CONFIG: /state/config/switchroom.yaml
+      # PATH must include /usr/local/bin for the switchroom shim.
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    # network_mode: host means no custom network is attached; the
+    # container shares the host network namespace directly.
+
+# Healthcheck deferred — the server has no /healthz endpoint yet and a
+# probe that hits the dashboard route would need the web-token. For now,
+# \`switchroom webd status\` is the operator surface and the server's
+# stderr lands in \`docker logs switchroom-web\`.
+`;
+}
+
+function webdDir(): string {
+  return join(homedir(), ".switchroom", "web");
+}
+
+function webdComposePath(): string {
+  return join(webdDir(), "docker-compose.yml");
+}
+
+function backupExistingCompose(): string | null {
+  const p = webdComposePath();
+  if (!existsSync(p)) return null;
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const bak = `${p}.bak-${ts}`;
+  copyFileSync(p, bak);
+  return bak;
+}
+
+function runDocker(args: string[]): { ok: boolean; stdout: string; stderr: string } {
+  const r = spawnSync("docker", args, { encoding: "utf8" });
+  return {
+    ok: r.status === 0,
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+  };
+}
+
+interface InstallOptions {
+  tag?: string;
+  dryRun?: boolean;
+}
+
+async function doInstall(opts: InstallOptions): Promise<void> {
+  // The container MUST run as the operator uid (peercred gate + file
+  // ownership). Refuse to write a compose file that would run as root
+  // or with an unknown uid — a root-mode forward is silently 503'd by
+  // every agent gateway, which is the exact silent-breakage class this
+  // migration exists to kill.
+  const operatorUid = resolveOperatorUid();
+  if (operatorUid === undefined) {
+    console.error(
+      chalk.red(
+        "Could not resolve the operator uid (no SUDO_UID and getuid() is 0 or unavailable).\n" +
+          "The web container must run as the operator uid so its webhook forwards pass\n" +
+          "each agent gateway's peercred ACL. Run `switchroom webd install` as the\n" +
+          "operator user (not root), or under `sudo` from the operator's shell.",
+      ),
+    );
+    process.exit(1);
+  }
+
+  const dir = webdDir();
+  const composePath = webdComposePath();
+  mkdirSync(dir, { recursive: true });
+
+  const yaml = renderWebComposeFile({
+    hostHome: homedir(),
+    imageTag: opts.tag ?? DEFAULT_IMAGE_TAG,
+    operatorUid,
+  });
+
+  if (opts.dryRun) {
+    console.log(chalk.dim(`# Would write: ${composePath}`));
+    console.log(yaml);
+    console.log(chalk.dim(`# Would run: docker compose -p ${WEB_COMPOSE_PROJECT} -f ${composePath} up -d`));
+    return;
+  }
+
+  const bak = backupExistingCompose();
+  if (bak) console.log(chalk.dim(`  Backed up existing compose to ${bak}`));
+
+  writeFileSync(composePath, yaml, "utf8");
+  console.log(chalk.green(`  ✓ Wrote ${composePath}`));
+  console.log(chalk.dim(`    running as uid ${operatorUid} (operator), network_mode: host`));
+
+  // Pull, then up. We pull explicitly so a pull failure (network
+  // glitch, GHCR throttle) surfaces before the up step rather than
+  // mid-recreate. `docker compose pull` is idempotent and skips images
+  // already at the requested digest.
+  console.log(chalk.dim(`    Pulling ghcr.io/switchroom/switchroom-web:${opts.tag ?? DEFAULT_IMAGE_TAG}…`));
+  const pull = runDocker(["compose", "-p", WEB_COMPOSE_PROJECT, "-f", composePath, "pull"]);
+  if (!pull.ok) {
+    console.error(chalk.red(`  pull failed:\n${pull.stderr}`));
+    console.error(
+      chalk.yellow(
+        `  Hint: \`ghcr.io/switchroom/switchroom-web:${opts.tag ?? DEFAULT_IMAGE_TAG}\` may not be published yet.\n` +
+          `  Check the docker-images workflow run and verify the tag at:\n` +
+          `      https://github.com/switchroom/switchroom/pkgs/container/switchroom-web`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  console.log(chalk.dim(`    Bringing up web service…`));
+  const up = runDocker(["compose", "-p", WEB_COMPOSE_PROJECT, "-f", composePath, "up", "-d"]);
+  if (!up.ok) {
+    console.error(chalk.red(`  up failed:\n${up.stderr}`));
+    process.exit(1);
+  }
+  console.log(chalk.green(`  ✓ Web service running (project: ${WEB_COMPOSE_PROJECT})`));
+  console.log(chalk.dim(`    Logs: docker logs switchroom-web --tail 50`));
+  console.log(chalk.dim(`    Verify: switchroom webd status`));
+  console.log(
+    chalk.yellow(
+      `    NOTE: the switchroom-web.service systemd unit (if still installed) also\n` +
+        `    binds 127.0.0.1:8080. Stop it before this container can claim the port:\n` +
+        `        systemctl --user stop switchroom-web.service\n` +
+        `        systemctl --user disable switchroom-web.service`,
+    ),
+  );
+}
+
+function doStatus(): void {
+  const composeYml = webdComposePath();
+
+  console.log(chalk.bold("switchroom-web"));
+  console.log("");
+
+  if (!existsSync(composeYml)) {
+    console.log(chalk.yellow("  compose:    not installed"));
+    console.log(chalk.dim("              run `switchroom webd install` to set up."));
+    return;
+  }
+  console.log(chalk.green(`  compose:    ${composeYml}`));
+
+  const ps = runDocker([
+    "compose",
+    "-p",
+    WEB_COMPOSE_PROJECT,
+    "-f",
+    composeYml,
+    "ps",
+    "--format",
+    "{{.Name}} {{.Status}} {{.Image}}",
+  ]);
+  if (!ps.ok || !ps.stdout.trim()) {
+    console.log(chalk.yellow("  container:  not running"));
+  } else {
+    console.log(chalk.green(`  container:  ${ps.stdout.trim()}`));
+  }
+}
+
+function doUninstall(): void {
+  const composeYml = webdComposePath();
+  if (!existsSync(composeYml)) {
+    console.log(chalk.yellow("  No web-service install detected (no compose file at this path)."));
+    return;
+  }
+  console.log(chalk.dim(`  Stopping ${WEB_COMPOSE_PROJECT}…`));
+  const down = runDocker(["compose", "-p", WEB_COMPOSE_PROJECT, "-f", composeYml, "down"]);
+  if (!down.ok) {
+    console.error(chalk.red(`  down failed:\n${down.stderr}`));
+    process.exit(1);
+  }
+  console.log(chalk.green("  ✓ Web service stopped"));
+  console.log(chalk.dim(`    Compose file left in place at ${composeYml}`));
+  console.log(chalk.dim(`    To re-enable: switchroom webd install`));
+  console.log(
+    chalk.yellow(
+      `    If you cut over from the systemd unit, re-enable it to restore the\n` +
+        `    dashboard + webhook receiver:\n` +
+        `        systemctl --user enable --now switchroom-web.service`,
+    ),
+  );
+}
+
+export function registerWebdCommand(program: Command): void {
+  const webd = program
+    .command("webd")
+    .description(
+      "Manage switchroom-web, the dashboard + GitHub-webhook receiver container",
+    );
+
+  webd
+    .command("install")
+    .description("Install or refresh the web container (writes ~/.switchroom/web/docker-compose.yml + docker compose up -d)")
+    .option("--tag <tag>", "Image tag (default: latest)", DEFAULT_IMAGE_TAG)
+    .option("--dry-run", "Print the compose file and the docker commands without writing or running anything")
+    .action(
+      withConfigError(async (opts: InstallOptions) => {
+        await doInstall(opts);
+      }),
+    );
+
+  webd
+    .command("status")
+    .description("Show web-service container state")
+    .action(() => doStatus());
+
+  webd
+    .command("uninstall")
+    .description("Stop the web container. Leaves the compose file in place for re-install.")
+    .action(() => doUninstall());
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2349,6 +2349,32 @@ export const HostControlConfigSchema = z.object({
 });
 
 /**
+ * Web-service (dashboard + GitHub-webhook receiver) container config.
+ * Phase 3 of the webhook Docker-native migration: the web server used
+ * to run as a systemd unit straight off the shared source checkout;
+ * `switchroom webd install` packages it as an image-pinned container in
+ * its own compose project (`switchroom-web`).
+ */
+export const WebServiceConfigSchema = z.object({
+  managed: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Whether `switchroom update` refreshes the web-service container " +
+      "(dashboard + GitHub-webhook receiver) via `switchroom webd " +
+      "install`. Default: false — existing installs run the web server " +
+      "as the legacy `switchroom-web.service` systemd unit and must not " +
+      "be surprised by a container takeover of host loopback 127.0.0.1:" +
+      "8080 mid-update. Set true ONLY after cutting over to the " +
+      "container (stop+disable the systemd unit, `switchroom webd " +
+      "install`). The container runs in its own compose project " +
+      "(`switchroom-web`), separate from the agent fleet, with " +
+      "network_mode: host so it keeps owning loopback:8080 for the " +
+      "cloudflared tunnel + tailscale serve consumers.",
+    ),
+});
+
+/**
  * hostd verb-level knobs (separate from `host_control:` which gates
  * the daemon itself).
  *
@@ -2548,6 +2574,13 @@ export const SwitchroomConfigSchema = z.object({
     "from `host_control:` which governs whether the daemon runs at " +
     "all. Currently scopes the opt-in flag and rate cap for the new " +
     "`config_propose_edit` verb (PR 1a — disabled by default).",
+  ),
+  web_service: WebServiceConfigSchema.default({}).describe(
+    "Web-service container (dashboard + GitHub-webhook receiver) config. " +
+    "Defaults to managed=false so existing systemd-mode installs are " +
+    "untouched. Set managed: true after cutting over to the " +
+    "`switchroom-web` container — then `switchroom update` keeps it " +
+    "refreshed. See `switchroom webd install`.",
   ),
   google_accounts: z
     .record(


### PR DESCRIPTION
## Summary

Phase 3 of the webhook Docker-native migration. Packages the `switchroom web` server (dashboard + GitHub-webhook receiver) as an image-pinned container in its own compose project (`switchroom-web`), replacing the legacy `switchroom-web.service` systemd unit.

- **`docker/Dockerfile.web`** — thin `switchroom/base` extension running `switchroom web` under bun as uid 1000; copies `dist/cli/switchroom.js` + `dist/cli/ui`; tini entrypoint; no docker socket / caps.
- **`src/cli/webd.ts`** — `install`/`status`/`uninstall` lifecycle. Compose project `switchroom-web` at `~/.switchroom/web/docker-compose.yml`. `install` refuses to write a root-uid compose (silent-503 guard).
- **`switchroom update`** — opt-in `refresh-web` step gated on a new `web_service.managed` config flag (default **false**) so existing systemd installs aren't surprised.
- **CI** — `web` leg added to the `build-dependents` matrix.
- **Docs** — `webhook-ingest.md` Deployment section + `cli-reference.md` `webd` entry.

## Why

The systemd unit ran the server straight off the shared source checkout. Any other agent's worktree activity could delete the hoisted root `node_modules` out from under the long-lived process, so the next restart crash-looped on ENOENT. Pinning it to an image makes it immune to repo churn and brings the last systemd holdout in line with the rest of the fleet.

Three load-bearing properties of the compose shape, each forced by what the web service is:
- `network_mode: host` — the server must own host loopback `127.0.0.1:8080`, where the cloudflared tunnel (webhooks) and `tailscale serve` (dashboard) both reach it; the dashboard CSRF gate trusts the `Tailscale-User-Login` header only on loopback (PR #1380).
- runs as the **operator uid** — the receiver's forward to each agent's `webhook.sock` is peercred-gated to `{agent uid, SWITCHROOM_WEBHOOK_RECEIVER_UID = operator uid}`; any other uid → 503.
- **no docker socket, no added caps** — minimal surface for the one internet-facing component.

## Rollback safety

The systemd unit is intentionally NOT removed by this PR or by `uninstall`. Cutover is a deliberate manual operator step (container up → verify → `systemctl --user stop && disable switchroom-web.service`). If the container misbehaves, re-enable the unit and you're back on the source-checkout server in seconds.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `src/cli/webd.test.ts` — pins compose invariants (host net, operator uid, no docker socket, no caps, no-new-privileges, symlink-safe `:ro` yaml mount, tag pinning, determinism)
- [x] `src/cli/update.test.ts` — `refresh-web` gating (managed flag, `--skip-images`, re-exec to `webd install`, non-zero failure); step-list expectations updated
- [x] config schema tests green (new `web_service.managed` flag)
- [ ] After merge + release: build `switchroom-web` image, canary on reggie (stage → cut over → verify CF webhook 202 + edge-403 matrix + dashboard via Tailscale → disable unit)

## Follow-up (not in this PR)

- Ruleset `16470166` PUT to add `build-dependents (web, docker/Dockerfile.web)` as a **gating** required check (the leg runs now but won't gate until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)