### PR TITLE
feat(hostd): persist "always allow" for every agent (self-scoped config edit)

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -1643,28 +1643,34 @@ function emitAgentService(
         `      - ${homePrefix}/.switchroom/host-control-audit.log:/state/agent/home/.switchroom/host-control-audit.log:ro`,
       );
     }
-    // Host-control daemon socket (#1164 follow-up — RFC C).
-    // ADMIN-ONLY and gated on `host_control.enabled: true`. The
-    // daemon (a systemd user unit on the host) binds the per-agent
-    // socket at `~/.switchroom/hostd/<name>/sock`, chowns it to the
-    // agent UID, and the agent connects via the in-container path
-    // `/run/switchroom/hostd/<name>/sock`. Same bind-mount shape
-    // the broker uses; identity comes from the host-side bind
-    // path so the agent can't forge it.
-    //
-    // No singleton container in Phase 1 (the daemon lives outside
-    // compose); only the per-agent volume here. The agent end is
-    // the directory, not the file, so the daemon can bind the
-    // socket inside it after starting. existsSync guard on the
-    // directory: if the daemon hasn't run yet, the directory will
-    // be missing — compose `up` would hard-fail on a missing :ro
-    // source. We bind read-write so the daemon can chown the
-    // socket file from the host side; the agent only connects.
-    if (hostControlEnabled && existsSync(`${hostHomeForChecks}/.switchroom/hostd/${a.name}`)) {
-      lines.push(
-        `      - ${homePrefix}/.switchroom/hostd/${a.name}:/run/switchroom/hostd/${a.name}`,
-      );
-    }
+  }
+  // Host-control daemon socket (#1164 follow-up — RFC C).
+  // Mounted for EVERY agent (gated only on `host_control.enabled:
+  // true`), NOT just admin agents — that's why it lives outside the
+  // `a.admin === true` block above: binding a socket ≠ granting admin.
+  // Every privileged verb is still gated server-side in hostd's
+  // `checkGate`; the one verb a non-admin agent can reach is a
+  // self-scoped `config_propose_edit` (it may only widen its OWN
+  // `tools.allow`) so "🔁 Always allow" persists for the whole fleet,
+  // not just the 3 admin agents. The daemon binds the per-agent socket
+  // at `~/.switchroom/hostd/<name>/sock`, chowns it to the agent UID,
+  // and the agent connects via the in-container path
+  // `/run/switchroom/hostd/<name>/sock`. Same bind-mount shape the
+  // broker uses; identity comes from the host-side bind path so the
+  // agent can't forge it.
+  //
+  // No singleton container in Phase 1 (the daemon lives outside
+  // compose); only the per-agent volume here. The agent end is the
+  // directory, not the file, so the daemon can bind the socket inside
+  // it after starting. existsSync guard on the directory: if the
+  // daemon hasn't run yet, the directory will be missing — compose
+  // `up` would hard-fail on a missing source. We bind read-write so
+  // the daemon can chown the socket file from the host side; the agent
+  // only connects.
+  if (hostControlEnabled && existsSync(`${hostHomeForChecks}/.switchroom/hostd/${a.name}`)) {
+    lines.push(
+      `      - ${homePrefix}/.switchroom/hostd/${a.name}:/run/switchroom/hostd/${a.name}`,
+    );
   }
   // Operator-declared extra bind-mounts (#1164). ADMIN-ONLY: emitting
   // anything for a non-admin agent is a hard error — bind_mounts is the

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -103,7 +103,7 @@ services:
       - no-new-privileges:true
     volumes:
       # Bind-mounts the entire ~/.switchroom dir so the daemon can:
-      #   - create ~/.switchroom/hostd/<agent>/sock per admin agent
+      #   - create ~/.switchroom/hostd/<agent>/sock per agent
       #   - append to ~/.switchroom/host-control-audit.log
       - ${hostHome}/.switchroom:/host-home/.switchroom:rw
       # ~/.switchroom/switchroom.yaml is a symlink on many operator
@@ -192,14 +192,12 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
     );
   }
 
-  const adminAgents = Object.entries(cfg.agents ?? {})
-    .filter(([, a]) => a?.admin === true)
-    .map(([name]) => name);
-  if (adminAgents.length === 0) {
+  const allAgents = Object.keys(cfg.agents ?? {});
+  if (allAgents.length === 0) {
     console.error(
       chalk.yellow(
-        "No admin-flagged agents in switchroom.yaml. The daemon binds one socket per admin agent — with none, it will exit on startup.\n" +
-          "Set \`admin: true\` on at least one agent (typically the test runner or a dedicated operator agent).",
+        "No agents in switchroom.yaml. The daemon binds one socket per agent — with none, it will exit on startup.\n" +
+          "Add at least one agent before installing hostd.",
       ),
     );
   }
@@ -228,9 +226,17 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
 
   writeFileSync(composePath, yaml, "utf8");
   console.log(chalk.green(`  ✓ Wrote ${composePath}`));
+  const adminAgents = Object.entries(cfg.agents ?? {})
+    .filter(([, a]) => a?.admin === true)
+    .map(([name]) => name);
   console.log(
     chalk.dim(
-      `    admin agents: ${adminAgents.length === 0 ? "(none)" : adminAgents.join(", ")}`,
+      `    agents served (one socket each): ${allAgents.length === 0 ? "(none)" : allAgents.join(", ")}`,
+    ),
+  );
+  console.log(
+    chalk.dim(
+      `    admin agents (full config-edit verbs): ${adminAgents.length === 0 ? "(none)" : adminAgents.join(", ")}`,
     ),
   );
 

--- a/src/host-control/config-edit-validator.ts
+++ b/src/host-control/config-edit-validator.ts
@@ -41,6 +41,7 @@ import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from "no
 import { tmpdir } from "node:os";
 import { join, isAbsolute, normalize } from "node:path";
 import { spawnSync } from "node:child_process";
+import { isDeepStrictEqual } from "node:util";
 import {
   parseDocument,
   isAlias,
@@ -479,4 +480,114 @@ export function validateConfigEdit(
   const leakErr = secretLeakGuard(beforeData, parsedAfter.data);
   if (leakErr) return leakErr;
   return { ok: true, postApplyContent: applied.after };
+}
+
+export type SelfScopeResult = { ok: true } | { ok: false; detail: string };
+
+/**
+ * Authorize a NON-admin `config_propose_edit` against the self-scope
+ * contract: a non-admin agent may persist its own "🔁 Always allow"
+ * grants, and nothing else. Concretely, the only field the edit may
+ * change is `agents.<caller>.tools.allow`, and it may only GROW it
+ * (additive — no silent removal of an existing rule, no reorder that
+ * drops entries). Every other byte of the config must be byte-for-byte
+ * (structurally) identical before vs. after.
+ *
+ * This is the server-side half of the forge-resistant always-allow
+ * path: the #1977 operator-tap correlation proves a human approved the
+ * grant; this check proves the grant can ONLY widen the caller's own
+ * allow-list. Binding a hostd socket for every agent (see
+ * `main.ts`) is therefore safe — a non-admin socket cannot escalate
+ * because this gate rejects any edit that touches another agent, a
+ * different field, the cascade defaults, or the caller's non-`allow`
+ * settings.
+ *
+ * Pure: parses both YAML blobs, no IO. Returns `{ ok: false }` (deny,
+ * not throw) on any parse failure so the caller stays on the safe side.
+ *
+ * @param beforeContent  Live config bytes (pre-apply).
+ * @param afterContent   Post-apply config bytes (validator's
+ *                       `postApplyContent`).
+ * @param caller         The non-admin agent name proposing the edit.
+ */
+export function assertSelfScopedAllowEdit(
+  beforeContent: string,
+  afterContent: string,
+  caller: string,
+): SelfScopeResult {
+  let before: Record<string, unknown>;
+  let after: Record<string, unknown>;
+  try {
+    before = toObject(parseDocument(beforeContent, { merge: false, strict: false }).toJS());
+    after = toObject(parseDocument(afterContent, { merge: false, strict: false }).toJS());
+  } catch (e) {
+    return { ok: false, detail: `self-scope: config did not parse (${(e as Error).message})` };
+  }
+
+  // 1. Additive-only on the caller's own allow-list: every rule that
+  //    existed before must still be present after. (Adding rules is the
+  //    whole point; dropping one isn't an escalation but it isn't a
+  //    "🔁 Always allow" tap either — keep the contract tight.)
+  const beforeAllow = readCallerAllow(before, caller);
+  const afterAllow = readCallerAllow(after, caller);
+  for (const rule of beforeAllow) {
+    if (!afterAllow.includes(rule)) {
+      return {
+        ok: false,
+        detail: `self-scope: edit removes existing allow rule "${rule}" from agents.${caller}.tools.allow`,
+      };
+    }
+  }
+
+  // 2. Nothing else changed: strip agents.<caller>.tools.allow from both
+  //    sides (identically) and require deep structural equality of the
+  //    remainder. Stripping the whole sub-path — collapsing an emptied
+  //    `tools` object — handles the case where the edit CREATES
+  //    `tools:`/`allow:` that didn't exist before.
+  const beforeStripped = stripCallerAllow(before, caller);
+  const afterStripped = stripCallerAllow(after, caller);
+  if (!isDeepStrictEqual(beforeStripped, afterStripped)) {
+    return {
+      ok: false,
+      detail:
+        `self-scope: edit changes config outside agents.${caller}.tools.allow ` +
+        `(a non-admin agent may only widen its own allow-list)`,
+    };
+  }
+  return { ok: true };
+}
+
+function toObject(v: unknown): Record<string, unknown> {
+  return v && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : {};
+}
+
+function readCallerAllow(cfg: Record<string, unknown>, caller: string): string[] {
+  const agents = cfg.agents;
+  if (!agents || typeof agents !== "object") return [];
+  const agent = (agents as Record<string, unknown>)[caller];
+  if (!agent || typeof agent !== "object") return [];
+  const tools = (agent as Record<string, unknown>).tools;
+  if (!tools || typeof tools !== "object") return [];
+  const allow = (tools as Record<string, unknown>).allow;
+  return Array.isArray(allow) ? allow.filter((x): x is string => typeof x === "string") : [];
+}
+
+function stripCallerAllow(
+  cfg: Record<string, unknown>,
+  caller: string,
+): Record<string, unknown> {
+  const clone = structuredClone(cfg);
+  const agents = clone.agents;
+  if (!agents || typeof agents !== "object") return clone;
+  const agent = (agents as Record<string, unknown>)[caller];
+  if (!agent || typeof agent !== "object") return clone;
+  const tools = (agent as Record<string, unknown>).tools;
+  if (!tools || typeof tools !== "object") return clone;
+  delete (tools as Record<string, unknown>).allow;
+  if (Object.keys(tools as Record<string, unknown>).length === 0) {
+    delete (agent as Record<string, unknown>).tools;
+  }
+  return clone;
 }

--- a/src/host-control/main.ts
+++ b/src/host-control/main.ts
@@ -44,16 +44,21 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  // Bind a per-agent UDS for EVERY agent, not just admin-flagged ones.
+  // The socket is identity (path-as-identity, forge-resistant); binding
+  // it does NOT grant admin — every privileged verb is still gated in
+  // `checkGate`. The one verb a non-admin agent can reach is a
+  // self-scoped `config_propose_edit` (operator-tapped, single-shot)
+  // that adds rules to its OWN `tools.allow` so "🔁 Always allow"
+  // persists for the whole fleet, not only the 3 admin agents.
   const agentUids: Record<string, number> = {};
-  for (const [name, agent] of Object.entries(config.agents)) {
-    if (agent.admin === true) {
-      agentUids[name] = allocateAgentUid(name);
-    }
+  for (const name of Object.keys(config.agents)) {
+    agentUids[name] = allocateAgentUid(name);
   }
 
   if (Object.keys(agentUids).length === 0) {
     process.stderr.write(
-      "hostd: no admin-flagged agents — nothing to serve. Set `admin: true` on at least one agent.\n",
+      "hostd: no agents configured — nothing to serve.\n",
     );
     process.exit(2);
   }

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -52,7 +52,10 @@ import { chainRow, seedChain, type ChainState } from "../util/audit-hashchain.js
 import { socketPathToIdentity, type SocketIdentity } from "./peercred.js";
 import { redact } from "../secret-detect/redact.js";
 import { detectInstallType, type InstallType } from "../cli/install-detect.js";
-import { validateConfigEdit } from "./config-edit-validator.js";
+import {
+  validateConfigEdit,
+  assertSelfScopedAllowEdit,
+} from "./config-edit-validator.js";
 import type { ApprovalGateway } from "./approval-gateway.js";
 
 /** Subset of switchroom.yaml the daemon reads. */
@@ -777,15 +780,18 @@ export class HostdServer {
           ? null
           : `doctor requires admin: true on caller "${caller.name}"`;
       case "config_propose_edit":
-        // Admin-only at the wire layer. The verb proposes mutations to
-        // the central switchroom.yaml — strictly broader blast radius
-        // than per-agent operations. The handler still returns
-        // E_CONFIG_EDIT_DISABLED when the operator hasn't opted in,
-        // but we refuse non-admin callers before that check so an
-        // un-admin'd peer can't even probe the feature flag state.
-        return callerAdmin
-          ? null
-          : `config_propose_edit requires admin: true on caller "${caller.name}"`;
+        // Admin callers may propose ANY edit to the central
+        // switchroom.yaml. Non-admin callers are admitted here but
+        // confined to a SELF-SCOPED edit: `handleConfigProposeEdit`
+        // runs `assertSelfScopedAllowEdit` after validation and rejects
+        // anything that touches more than the caller's own
+        // `agents.<caller>.tools.allow`. This is the one privileged
+        // verb a non-admin agent can reach — it's what makes
+        // "🔁 Always allow" persist for the whole fleet (operator-tapped,
+        // single-shot, #1977 correlation), not just the 3 admin agents.
+        // Binding a socket ≠ granting admin: the self-scope check is the
+        // enforced boundary, not this gate.
+        return null;
     }
   }
 
@@ -1286,6 +1292,37 @@ export class HostdServer {
         .caller(caller.kind === "agent" ? "agent" : "operator")
         .agentName(caller.kind === "agent" ? caller.name : undefined)
         .build(req.request_id, Date.now() - started);
+    }
+    // ── Self-scope gate (non-admin callers) ─────────────────────────
+    // checkGate admits non-admin agents to this verb; this is the
+    // enforced boundary. A non-admin agent may only widen its OWN
+    // `agents.<caller>.tools.allow` — the "🔁 Always allow" persistence
+    // path. Operators and admin agents skip the check (full trust).
+    if (caller.kind === "agent" && this.opts.config.agents[caller.name]?.admin !== true) {
+      let beforeContent: string;
+      try {
+        beforeContent = readFileSync(configPath, "utf-8");
+      } catch {
+        beforeContent = "";
+      }
+      const scope = assertSelfScopedAllowEdit(
+        beforeContent,
+        verdict.postApplyContent,
+        caller.name,
+      );
+      if (!scope.ok) {
+        return err("E_NOT_SELF_SCOPED", scope.detail)
+          .why(
+            "non-admin agents may only add rules to their own " +
+              "agents.<self>.tools.allow via config_propose_edit",
+          )
+          .fixBadInput("unified_diff")
+          .op("config_propose_edit")
+          .caller("agent")
+          .agentName(caller.name)
+          .asDenied()
+          .build(req.request_id, Date.now() - started);
+      }
     }
     // ── Approval card ───────────────────────────────────────────────
     if (!this.opts.approvalGateway) {

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -1968,9 +1968,13 @@ describe("agent bind_mounts (#1164)", () => {
 });
 
 describe("host-control daemon bind mount (RFC C Phase 1)", () => {
-  // Admin agents get an extra per-agent UDS bind mount when
+  // EVERY agent gets a per-agent UDS bind mount when
   // host_control.enabled is true AND the host-side directory
   // exists (compose `up` hard-fails on missing bind sources).
+  // Binding a socket ≠ granting admin: the socket is mounted for
+  // admin and non-admin agents alike so "🔁 Always allow" can persist
+  // fleet-wide via the self-scoped config_propose_edit path; every
+  // privileged verb is still gated server-side in hostd's checkGate.
   // Since RFC C Phase 2 default-flip the schema defaults `enabled`
   // to true, so the bind mount appears when the block is absent.
 
@@ -2016,7 +2020,7 @@ describe("host-control daemon bind mount (RFC C Phase 1)", () => {
     }
   });
 
-  it("does NOT emit the hostd bind mount on non-admin agents even when enabled", async () => {
+  it("DOES emit the hostd bind mount on non-admin agents when enabled (binding a socket ≠ admin)", async () => {
     const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
@@ -2030,7 +2034,9 @@ describe("host-control daemon bind mount (RFC C Phase 1)", () => {
         ),
         homeDir: tmp,
       });
-      expect(out).not.toMatch(
+      // Non-admin bob gets the socket so its operator-tapped
+      // "🔁 Always allow" grants persist via self-scoped config_propose_edit.
+      expect(out).toMatch(
         /agent-bob:[\s\S]*?\.switchroom\/hostd\/bob:\/run\/switchroom\/hostd\/bob/,
       );
     } finally {
@@ -2038,13 +2044,14 @@ describe("host-control daemon bind mount (RFC C Phase 1)", () => {
     }
   });
 
-  it("emits the hostd bind mount when admin AND enabled AND host dir exists", async () => {
+  it("emits the hostd bind mount for both admin and non-admin agents when enabled AND host dir exists", async () => {
     const { mkdtempSync, mkdirSync, rmSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
     const tmp = mkdtempSync(join(tmpdir(), "hostd-mount-on-"));
     try {
       mkdirSync(join(tmp, ".switchroom/hostd/klanker"), { recursive: true });
+      mkdirSync(join(tmp, ".switchroom/hostd/bob"), { recursive: true });
       const out = generateCompose({
         config: makeConfig(
           { klanker: { admin: true }, bob: {} },
@@ -2057,9 +2064,11 @@ describe("host-control daemon bind mount (RFC C Phase 1)", () => {
           `agent-klanker:[\\s\\S]*?${tmp.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}/\\.switchroom/hostd/klanker:/run/switchroom/hostd/klanker(?!:)`,
         ),
       );
-      // bob (non-admin) does not get the mount even on the same fleet.
-      expect(out).not.toMatch(
-        /agent-bob:[\s\S]*?\.switchroom\/hostd\/bob:/,
+      // bob (non-admin) gets the mount on the same fleet too.
+      expect(out).toMatch(
+        new RegExp(
+          `agent-bob:[\\s\\S]*?${tmp.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}/\\.switchroom/hostd/bob:/run/switchroom/hostd/bob(?!:)`,
+        ),
       );
     } finally {
       rmSync(tmp, { recursive: true, force: true });

--- a/tests/host-control/config-edit-validator.test.ts
+++ b/tests/host-control/config-edit-validator.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   validateConfigEdit,
+  assertSelfScopedAllowEdit,
   MAX_PATCH_BYTES,
 } from "../../src/host-control/config-edit-validator.js";
 
@@ -68,5 +69,86 @@ describe("validateConfigEdit — oversize cap (defense-in-depth)", () => {
       expect(result.code).toBe("E_PATCH_INVALID_SHAPE");
       expect(result.detail).toMatch(/LF-only/);
     }
+  });
+});
+
+describe("assertSelfScopedAllowEdit — non-admin always-allow boundary", () => {
+  const base = (gymbroTools?: string) =>
+    "switchroom:\n" +
+    "  version: 1\n" +
+    "agents:\n" +
+    "  gymbro:\n" +
+    '    persona: "lifting coach"\n' +
+    (gymbroTools ?? "") +
+    "  clerk:\n" +
+    '    persona: "office"\n';
+
+  it("ALLOWS adding a rule to the caller's own tools.allow", () => {
+    const before = base();
+    const after = base("    tools:\n      allow:\n        - mcp__perplexity__search\n");
+    expect(assertSelfScopedAllowEdit(before, after, "gymbro")).toEqual({ ok: true });
+  });
+
+  it("ALLOWS appending to an existing own allow-list", () => {
+    const before = base("    tools:\n      allow:\n        - Edit\n");
+    const after = base(
+      "    tools:\n      allow:\n        - Edit\n        - mcp__perplexity__search\n",
+    );
+    expect(assertSelfScopedAllowEdit(before, after, "gymbro")).toEqual({ ok: true });
+  });
+
+  it("REJECTS adding a rule to a DIFFERENT agent's allow-list", () => {
+    const before = base();
+    const after =
+      "switchroom:\n" +
+      "  version: 1\n" +
+      "agents:\n" +
+      "  gymbro:\n" +
+      '    persona: "lifting coach"\n' +
+      "  clerk:\n" +
+      '    persona: "office"\n' +
+      "    tools:\n      allow:\n        - Bash\n";
+    const r = assertSelfScopedAllowEdit(before, after, "gymbro");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toMatch(/outside agents\.gymbro\.tools\.allow/);
+  });
+
+  it("REJECTS changing a non-allow field on the caller's own agent", () => {
+    const before = base();
+    const after = base('    model: "claude-opus-4-8"\n');
+    const r = assertSelfScopedAllowEdit(before, after, "gymbro");
+    expect(r.ok).toBe(false);
+  });
+
+  it("REJECTS removing an existing rule from the caller's own allow-list", () => {
+    const before = base(
+      "    tools:\n      allow:\n        - Edit\n        - Bash\n",
+    );
+    const after = base("    tools:\n      allow:\n        - Edit\n");
+    const r = assertSelfScopedAllowEdit(before, after, "gymbro");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toMatch(/removes existing allow rule "Bash"/);
+  });
+
+  it("REJECTS widening a cascade default (defaults.allowed_tools)", () => {
+    const before = base();
+    const after =
+      "switchroom:\n" +
+      "  version: 1\n" +
+      "defaults:\n" +
+      "  allowed_tools:\n" +
+      "    - mcp__perplexity__search\n" +
+      "agents:\n" +
+      "  gymbro:\n" +
+      '    persona: "lifting coach"\n' +
+      "  clerk:\n" +
+      '    persona: "office"\n';
+    const r = assertSelfScopedAllowEdit(before, after, "gymbro");
+    expect(r.ok).toBe(false);
+  });
+
+  it("denies (does not throw) on unparseable config", () => {
+    const r = assertSelfScopedAllowEdit(": : :\n  - [", "agents: {}\n", "gymbro");
+    expect(r.ok).toBe(false);
   });
 });

--- a/tests/host-control/config-edit-validator.test.ts
+++ b/tests/host-control/config-edit-validator.test.ts
@@ -147,6 +147,20 @@ describe("assertSelfScopedAllowEdit — non-admin always-allow boundary", () => 
     expect(r.ok).toBe(false);
   });
 
+  it("REJECTS escalating the caller's own agent to admin: true", () => {
+    const before = base();
+    const after = base("    admin: true\n");
+    const r = assertSelfScopedAllowEdit(before, after, "gymbro");
+    expect(r.ok).toBe(false);
+  });
+
+  it("REJECTS removing a deny rule from the caller's own agent", () => {
+    const before = base("    tools:\n      deny:\n        - Bash\n");
+    const after = base("    tools:\n      deny: []\n");
+    const r = assertSelfScopedAllowEdit(before, after, "gymbro");
+    expect(r.ok).toBe(false);
+  });
+
   it("denies (does not throw) on unparseable config", () => {
     const r = assertSelfScopedAllowEdit(": : :\n  - [", "agents: {}\n", "gymbro");
     expect(r.ok).toBe(false);

--- a/tests/host-control/config-propose-edit.test.ts
+++ b/tests/host-control/config-propose-edit.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HostdServer } from "../../src/host-control/server.js";
@@ -161,16 +161,86 @@ describe("hostd config_propose_edit — PR 1a gates (still live)", () => {
     expect(resp.error).toMatch(/^E_CONFIG_EDIT_DISABLED/);
   });
 
-  it("denies non-admin callers before reading the flag", async () => {
+  it("denies a non-admin caller's NON-self-scoped edit with E_NOT_SELF_SCOPED", async () => {
+    // Non-admin callers are now ADMITTED to config_propose_edit (every
+    // agent gets a hostd socket) but confined to widening their OWN
+    // tools.allow. This diff changes agents.bob.model — bob's own
+    // block, but NOT tools.allow — so it's rejected as not-self-scoped.
+    writeFileSync(configPath, BOB_CONFIG);
     server = makeServer({ configEditEnabled: true, configPath });
     await server.start();
+    const notAllowDiff =
+      "--- a/switchroom.yaml\n" +
+      "+++ b/switchroom.yaml\n" +
+      "@@ -7,3 +7,3 @@\n" +
+      "   bob:\n" +
+      '     topic_name: "Bob"\n' +
+      '-    model: "claude-opus-4-8"\n' +
+      '+    model: "claude-haiku-4-5"\n';
     const resp = await send({
       sockOwner: "bob",
-      unified_diff: TINY_DIFF,
+      unified_diff: notAllowDiff,
       request_id: "cpe-3",
     });
     expect(resp.result).toBe("denied");
-    expect(resp.error).toMatch(/requires admin: true/);
+    expect(resp.error).toMatch(/^E_NOT_SELF_SCOPED/);
+    expect(resp.error).toMatch(/agents\.bob\.tools\.allow/);
+  });
+});
+
+// Shared by the self-scope tests: bob exists as a non-admin agent with
+// one anchor field (model) so the always-allow diff has stable context.
+const BOB_CONFIG =
+  "switchroom:\n" +
+  "  version: 1\n" +
+  "telegram:\n" +
+  '  bot_token: "x"\n' +
+  '  forum_chat_id: "1"\n' +
+  "agents:\n" +
+  "  bob:\n" +
+  '    topic_name: "Bob"\n' +
+  '    model: "claude-opus-4-8"\n';
+
+describe("hostd config_propose_edit — non-admin self-scoped always-allow", () => {
+  // Adds a rule to agents.bob.tools.allow — the "🔁 Always allow" path.
+  const SELF_SCOPED_DIFF =
+    "--- a/switchroom.yaml\n" +
+    "+++ b/switchroom.yaml\n" +
+    "@@ -7,3 +7,6 @@\n" +
+    "   bob:\n" +
+    '     topic_name: "Bob"\n' +
+    '     model: "claude-opus-4-8"\n' +
+    "+    tools:\n" +
+    "+      allow:\n" +
+    "+        - mcp__perplexity__search\n";
+
+  it("admits the non-admin caller and applies after operator approval", async () => {
+    writeFileSync(configPath, BOB_CONFIG);
+    const { gw, finalizeCalls, requests } = stubGateway("approve");
+    let reconcileInvocations = 0;
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      generateApprovalId: () => "feedface",
+      runReconcile: async () => {
+        reconcileInvocations += 1;
+        return { exit_code: 0, stdout: "applied ok", stderr: "" };
+      },
+    });
+    await server.start();
+    const resp = await send({
+      sockOwner: "bob",
+      unified_diff: SELF_SCOPED_DIFF,
+      request_id: "ss-1",
+    });
+    expect(resp.result).toBe("completed");
+    expect(requests.length).toBe(1);
+    expect(requests[0]!.agentName).toBe("bob");
+    expect(finalizeCalls).toEqual([{ outcome: "applied" }]);
+    const live = readFileSync(configPath, "utf8");
+    expect(live).toContain("mcp__perplexity__search");
+    expect(reconcileInvocations).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

"🔁 Always allow" only persisted for the 3 admin-flagged agents. Every other agent's "always" tap was silently lost on restart (the legacy `agent grant` path writes the read-only-mounted in-container config). This binds a hostd socket for **all** agents and opens exactly one self-scoped verb so any agent can persist a rule into its **own** `tools.allow`.

## Why

JTBD / vision pillar #2 ("you hold the leash"): when the operator taps "always allow," that decision must stick — for the whole fleet, not just admin agents. Binding a socket is identity, not authority: every privileged hostd verb stays admin-gated. The one verb a non-admin agent can reach is a self-scoped `config_propose_edit` confined server-side to its own `agents.<self>.tools.allow`.

## What changed

- **main.ts** — allocate a per-agent UID (→ socket) for every configured agent, not just admin ones.
- **compose.ts** — mount the per-agent hostd socket for every agent (gated only on `host_control.enabled`), moved out of the admin-only block. Audit-log mounts stay admin-only.
- **server.ts** — `checkGate` admits non-admin callers to `config_propose_edit`; `handleConfigProposeEdit` runs `assertSelfScopedAllowEdit` after validation and rejects (`E_NOT_SELF_SCOPED`) anything broader than the caller's own allow-list. Operators + admin agents skip the check.
- **config-edit-validator.ts** — new `assertSelfScopedAllowEdit`: additive-only (can't remove existing rules), confined to the caller's own allow-list (can't widen another agent's tools, `defaults`, or any non-allow field), denies on unparseable config.
- **hostd.ts** — install summary reports agents-served vs admin-config-edit agents.

## Test plan

- [x] `assertSelfScopedAllowEdit` unit tests (9): own-add, append, reject cross-agent, reject non-allow field, reject removal, reject `defaults.allowed_tools` widening, deny on unparseable
- [x] `config-propose-edit` integration (24): non-admin non-self-scoped → `E_NOT_SELF_SCOPED`; non-admin self-scoped → completed + applied + reconciled
- [x] compose-generator (154): socket mount emitted for both admin and non-admin agents when enabled
- [x] full host-control suite (349 across 10 files) green; `tsc --noEmit` clean

## Risk

Security-sensitive: widens which agents can reach hostd. Mitigated by (a) socket presence ≠ authority — `checkGate` still admin-gates every other verb; (b) the self-scope check is the enforced boundary and is additive-only + own-allow-list-only; (c) the existing #1977 single-tap correlation + approval round-trip are unchanged.