### PR TITLE
feat(telegram): human-readable scoped permission card

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -14874,7 +14874,7 @@ async function registerSwitchroomBotCommands(): Promise<void> {
 }
 
 // ─── Inline-button handler (permissions) ──────────────────────────────────
-// Handles `perm:(allow|deny|more):<id>` — permission request buttons
+// Handles `perm:(allow|deny|always|asn|asb|back):<id>` — permission request buttons
 bot.on('callback_query:data', async ctx => {
   const data = ctx.callbackQuery.data
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -361,8 +361,8 @@ import { maybeRenderUpdateAnnouncement } from './update-announce.js'
 import { createIssuesCardHandle, type IssuesCardHandle } from '../issues-card.js'
 import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.js'
 import { list as listIssues, resolve as resolveIssue } from '../../src/issues/index.js'
-import { summarizeToolForTitle, formatPermissionCardBody } from '../permission-title.js'
-import { resolveAlwaysAllowRule, isRulePersisted } from '../permission-rule.js'
+import { formatPermissionCardBody, describeGrant } from '../permission-title.js'
+import { resolveScopedAllowChoices, isRulePersisted } from '../permission-rule.js'
 import { synthesizeAllowRuleDiff, extractAddedAllowRule } from '../permission-diff.js'
 import {
   readClaudeJsonOverage,
@@ -3773,6 +3773,21 @@ const pendingPermissionBuffer = createPendingPermissionBuffer()
  * pre-2747 TTL sweep can reference it; ipcServer/pendingPermissionBuffer
  * are resolved at call-time, after module init.)
  */
+/**
+ * The default permission-card action row: ❌ Deny · ✅ Allow once ·
+ * 🔁 Always… (the last only when a meaningful always-rule exists).
+ * Tapping "🔁 Always…" swaps this row for the scope sub-menu; "← Back"
+ * rebuilds this row. callback_data stays tiny (verb + 5-char id) so we
+ * never approach Telegram's 64-byte ceiling.
+ */
+function buildPermissionActionRow(requestId: string, showAlways: boolean): InlineKeyboard {
+  const kb = new InlineKeyboard()
+    .text('❌ Deny', `perm:deny:${requestId}`)
+    .text('✅ Allow once', `perm:allow:${requestId}`)
+  if (showAlways) kb.text('🔁 Always…', `perm:always:${requestId}`)
+  return kb
+}
+
 function dispatchPermissionVerdict(ev: PermissionEvent): void {
   const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
   const delivered = ipcServer.sendToAgent(selfAgent, ev)
@@ -4106,37 +4121,25 @@ const ipcServer: IpcServer = createIpcServer({
     const { requestId, toolName, description, inputPreview } = msg
     pendingPermissions.set(requestId, { tool_name: toolName, description, input_preview: inputPreview, startedAt: Date.now() })
     const access = loadAccess()
-    // #1790 — multi-line collapsed body so the operator can see what
-    // is being requested and why without tapping "See more". Mirrors
-    // the `vault_request_access` card layout (the gold standard).
-    // The detail (expanded `tool_name` / pretty `input_preview`)
-    // still surfaces on the See-more tap; this is the
-    // collapsed-view fix only. Sent with parse_mode=HTML below.
+    // Natural-language card body — a plain sentence ("Gymbro wants to
+    // edit: supplement-log.md" + a why-line), never a raw tool id.
+    // The operator sees what is being requested and why at a glance.
+    // Mirrors the `vault_request_access` card layout. Sent with
+    // parse_mode=HTML below.
     const text = formatPermissionCardBody({
       toolName,
       inputPreview,
       description,
       agentName: _client.agentName,
     })
-    // Build the keyboard. The "🔁 Always" button only appears when we
-    // can synthesize a meaningful allow-rule for this tool — for an
-    // unknown tool we'd write a useless rule (or worse, a rule that
-    // expanded to too much). resolveAlwaysAllowRule returns null in
-    // that case and we fall back to the legacy 3-button layout.
-    const alwaysRule = resolveAlwaysAllowRule(toolName, inputPreview)
-    const keyboard = new InlineKeyboard()
-      .text('See more', `perm:more:${requestId}`)
-      .text('✅ Allow', `perm:allow:${requestId}`)
-      .text('❌ Deny', `perm:deny:${requestId}`)
-    if (alwaysRule != null) {
-      // Second row — full-width label like "🔁 Always allow Skill(mail)"
-      // so the operator sees exactly what rule they're whitelisting
-      // before tapping. Truncate at Telegram's 64-byte callback_data
-      // ceiling defensively (long MCP tool names can push past it).
-      keyboard
-        .row()
-        .text(`🔁 Always allow ${alwaysRule.label}`, `perm:always:${requestId}`)
-    }
+    // Compact action row: ❌ Deny · ✅ Allow once · 🔁 Always… — the
+    // scope of an "always" grant stays hidden until the operator taps
+    // "🔁 Always…", which swaps the row for a scope choice (this file /
+    // any file ⚠️). The "🔁 Always…" button only appears when we can
+    // synthesize a meaningful rule for this tool; unknown tools get the
+    // two-button row only.
+    const showAlways = resolveScopedAllowChoices(toolName, inputPreview) != null
+    const keyboard = buildPermissionActionRow(requestId, showAlways)
     // PR4b emitter sweep — supergroup-mode permission card routing.
     // Per CPO #3 the design is "turn-initiated requests follow the
     // conversation topic; background requests go to admin alias."
@@ -15246,33 +15249,40 @@ bot.on('callback_query:data', async ctx => {
   }
 
   // Permission request buttons.
-  const m = /^perm:(allow|deny|more|always):([a-km-z]{5})$/.exec(data)
+  const m = /^perm:(allow|deny|always|asn|asb|back):([a-km-z]{5})$/.exec(data)
   if (!m) { await ctx.answerCallbackQuery().catch(() => {}); return }
   const access = loadAccess()
   const senderId = String(ctx.from.id)
   if (!access.allowFrom.includes(senderId)) { await ctx.answerCallbackQuery({ text: 'Not authorized.' }).catch(() => {}); return }
   const [, behavior, request_id] = m
 
-  if (behavior === 'more') {
+  // "🔁 Always…" / "← Back" — toggle between the default action row and
+  // the scope sub-menu. Neither dispatches a verdict; the scope is only
+  // committed when the operator taps a scope button (asn / asb).
+  if (behavior === 'always' || behavior === 'back') {
     const details = pendingPermissions.get(request_id)
     if (!details) { await ctx.answerCallbackQuery({ text: 'Details no longer available.' }).catch(() => {}); return }
-    const { tool_name, description, input_preview } = details
-    let prettyInput: string
-    try { prettyInput = JSON.stringify(JSON.parse(input_preview), null, 2) } catch { prettyInput = input_preview }
-    const expanded = `🔐 Permission: ${tool_name}\n\ntool_name: ${tool_name}\ndescription: ${description}\ninput_preview:\n${prettyInput}`
-    const expandedRule = resolveAlwaysAllowRule(tool_name, input_preview)
-    const expandedKeyboard = new InlineKeyboard()
-      .text('✅ Allow', `perm:allow:${request_id}`)
-      .text('❌ Deny', `perm:deny:${request_id}`)
-    if (expandedRule != null) {
-      expandedKeyboard.row().text(`🔁 Always allow ${expandedRule.label}`, `perm:always:${request_id}`)
+    let keyboard: InlineKeyboard
+    if (behavior === 'back') {
+      keyboard = buildPermissionActionRow(request_id, true)
+    } else {
+      const choices = resolveScopedAllowChoices(details.tool_name, details.input_preview)
+      if (choices == null) {
+        await ctx.answerCallbackQuery({ text: 'No always-allow rule for this tool.' }).catch(() => {})
+        return
+      }
+      // Scope row: ← Back · [this thing] · [any thing] ⚠️ — the ⚠️
+      // rides on the broad option only. Scope stays hidden until now.
+      keyboard = new InlineKeyboard().text('← Back', `perm:back:${request_id}`)
+      if (choices.specific) keyboard.text(choices.specific.buttonLabel, `perm:asn:${request_id}`)
+      keyboard.text(`${choices.broad.buttonLabel} ⚠️`, `perm:asb:${request_id}`)
     }
-    await ctx.editMessageText(expanded, { reply_markup: expandedKeyboard }).catch(() => {})
+    await ctx.editMessageReplyMarkup({ reply_markup: keyboard }).catch(() => {})
     await ctx.answerCallbackQuery().catch(() => {})
     return
   }
 
-  if (behavior === 'always') {
+  if (behavior === 'asn' || behavior === 'asb') {
     // "🔁 Always allow" (#1977) — persist the resolved rule into the
     // agent's tools.allow in the DURABLE host config. The old path
     // shelled `switchroom agent grant` which wrote
@@ -15289,11 +15299,15 @@ bot.on('callback_query:data', async ctx => {
     //      apply+reconcile result.
     const details = pendingPermissions.get(request_id)
     if (!details) { await ctx.answerCallbackQuery({ text: 'Details no longer available.' }).catch(() => {}); return }
-    const rule = resolveAlwaysAllowRule(details.tool_name, details.input_preview)
-    if (rule == null) {
+    const choices = resolveScopedAllowChoices(details.tool_name, details.input_preview)
+    if (choices == null) {
       await ctx.answerCallbackQuery({ text: 'Cannot synthesize an always-allow rule for this tool.' }).catch(() => {})
       return
     }
+    // asn → the narrow/specific scope (falls back to broad when the tool
+    // has no sub-scope); asb → the broad, whole-category scope.
+    const chosen = behavior === 'asn' ? (choices.specific ?? choices.broad) : choices.broad
+    const grantPhrase = describeGrant(details.tool_name, details.input_preview, chosen)
     const agentName = process.env.SWITCHROOM_AGENT_NAME
     if (!agentName) {
       await ctx.answerCallbackQuery({ text: 'Always-allow needs SWITCHROOM_AGENT_NAME — gateway is misconfigured.' }).catch(() => {})
@@ -15304,7 +15318,7 @@ bot.on('callback_query:data', async ctx => {
 
     // (2) Dispatch the in-flight permission verdict IMMEDIATELY — before
     // any host round-trip — so the turn never blocks on persistence.
-    // We carry the resolved `rule` so the bridge caches it for the rest
+    // We carry the chosen `rule` so the bridge caches it for the rest
     // of the session and auto-allows matching tool calls from sub-agents
     // (Task tool) + the parent without re-popping the prompt (#1138).
     // The rule is safe to cache regardless of whether the *durable*
@@ -15313,7 +15327,7 @@ bot.on('callback_query:data', async ctx => {
       type: 'permission',
       requestId: request_id,
       behavior: 'allow',
-      rule: rule.rule,
+      rule: chosen.rule,
     })
 
     // (3) Decide the persistence path. tryHostdDispatch returns
@@ -15331,14 +15345,14 @@ bot.on('callback_query:data', async ctx => {
       try {
         const cfgPath = process.env.SWITCHROOM_CONFIG ?? SWITCHROOM_CONFIG ?? findSwitchroomConfigFile()
         const raw = readFileSync(cfgPath, 'utf8')
-        return synthesizeAllowRuleDiff({ agentName, rule: rule.rule, configText: raw })
+        return synthesizeAllowRuleDiff({ agentName, rule: chosen.rule, configText: raw })
       } catch (err) {
         process.stderr.write(`telegram gateway: always-allow diff synth failed: ${(err as Error).message}\n`)
         return null
       }
     })()
 
-    const correlationKey = `${agentName}::${rule.rule}`
+    const correlationKey = `${agentName}::${chosen.rule}`
     try {
       if (unifiedDiff == null) {
         // Could not locate the agent block / read config → fall back to
@@ -15348,14 +15362,14 @@ bot.on('callback_query:data', async ctx => {
       } else {
         // Pre-register the single-tap correlation so hostd's callback
         // (request_config_approval) auto-approves WITHOUT a second card.
-        pendingAlwaysAllowCorrelations.set(correlationKey, { agentName, rule: rule.rule, unifiedDiff, createdAt: Date.now() })
+        pendingAlwaysAllowCorrelations.set(correlationKey, { agentName, rule: chosen.rule, unifiedDiff, createdAt: Date.now() })
         const req: HostdRequest = {
           v: 1,
           op: 'config_propose_edit',
           request_id: hostdRequestId('gw-always-allow'),
           args: {
             unified_diff: unifiedDiff,
-            reason: `Operator 'always allow' for ${rule.label}`,
+            reason: `Operator 'always allow': ${agentName} can ${grantPhrase}`,
             target_path: '/state/config/switchroom.yaml',
           },
         }
@@ -15368,7 +15382,7 @@ bot.on('callback_query:data', async ctx => {
         } else if (resp.result === 'completed') {
           durable = true
           process.stderr.write(
-            `telegram gateway: always-allow durable via hostd rule="${rule.rule}" agent=${agentName} (request_id=${request_id})\n`,
+            `telegram gateway: always-allow durable via hostd rule="${chosen.rule}" agent=${agentName} (request_id=${request_id})\n`,
           )
         } else {
           failReason = resp.error ?? `hostd ${resp.result}`
@@ -15386,20 +15400,20 @@ bot.on('callback_query:data', async ctx => {
         // landed. Honest messaging: "saved (legacy path)" on verify,
         // else the "did NOT save" warning.
         try {
-          switchroomExec(['agent', 'grant', agentName, rule.rule, '--no-restart'])
+          switchroomExec(['agent', 'grant', agentName, chosen.rule, '--no-restart'])
           try {
             const cfg = loadSwitchroomConfig()
             const rawAgent = cfg.agents?.[agentName]
             if (rawAgent) {
               const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent)
               const allowList: string[] = (resolved as { tools?: { allow?: string[] } }).tools?.allow ?? []
-              if (isRulePersisted(allowList, rule.rule)) {
+              if (isRulePersisted(allowList, chosen.rule)) {
                 durable = true // legacy path verified — durable on this host shape
                 process.stderr.write(
-                  `telegram gateway: always-allow added rule="${rule.rule}" agent=${agentName} via legacy grant (request_id=${request_id})\n`,
+                  `telegram gateway: always-allow added rule="${chosen.rule}" agent=${agentName} via legacy grant (request_id=${request_id})\n`,
                 )
               } else {
-                failReason = `rule "${rule.rule}" not found in resolved tools.allow after write — config location may have drifted`
+                failReason = `rule "${chosen.rule}" not found in resolved tools.allow after write — config location may have drifted`
                 process.stderr.write(
                   `telegram gateway: always-allow VERIFY FAILED: ${failReason} (request_id=${request_id})\n`,
                 )
@@ -15431,8 +15445,8 @@ bot.on('callback_query:data', async ctx => {
     const legacyNote = legacy && durable
     const ackText = ok
       ? (legacyNote
-          ? `🔁 Always allow ${rule.label} for ${agentName} (legacy path)`
-          : `🔁 Always allow ${rule.label} for ${agentName}`)
+          ? `✅ Saved. ${agentName} can now ${grantPhrase} without asking (legacy path).`
+          : `✅ Saved. ${agentName} can now ${grantPhrase} without asking.`)
       : (editLockHint
           ? `⚠️ Allowed for now — config edits are locked. Enable hostd.config_edit_enabled.`
           : `⚠️ Allowed for now, but "always" did NOT save — it will ask again after restart. Check gateway log.`)
@@ -15448,8 +15462,8 @@ bot.on('callback_query:data', async ctx => {
       : ''
     const editLabel = ok
       ? (legacyNote
-          ? `🔁 <b>Always allow ${escapeHtmlForTg(rule.label)}</b> for ${escapeHtmlForTg(agentName)} — saved (legacy path); restart agent for full effect`
-          : `🔁 <b>Always allow ${escapeHtmlForTg(rule.label)}</b> for ${escapeHtmlForTg(agentName)} — saved; restart agent for full effect`)
+          ? `✅ <b>${escapeHtmlForTg(agentName)} can now ${escapeHtmlForTg(grantPhrase)}</b> without asking (legacy path); restart agent for full effect`
+          : `✅ <b>${escapeHtmlForTg(agentName)} can now ${escapeHtmlForTg(grantPhrase)}</b> without asking; restart agent for full effect`)
       : (editLockHint
           ? `⚠️ <b>Allowed for now — "always" did NOT save.</b> Config edits are locked; enable <code>hostd.config_edit_enabled</code>.`
           : `⚠️ <b>Allowed for now — "always" did NOT save.</b> It will ask again after restart. Check gateway log.`)
@@ -15469,13 +15483,11 @@ bot.on('callback_query:data', async ctx => {
   // Forward permission decision to connected bridges
   pendingPermissions.delete(request_id)
   const label = behavior === 'allow' ? '✅ Allowed' : '❌ Denied'
-  // HTML-escape the source text — same hazard as the `always` and
-  // recent-denial paths above. The original permission card was
-  // posted with plain text (`gateway.ts:2828` — `🔐 Permission:
-  // <toolName>`), but the expanded form via `behavior === 'more'`
-  // (this same handler, line ~11471) appends claude-supplied
-  // `description` and `input_preview` strings that frequently contain
-  // raw `<`/`>`/`&` (shell commands, JSON nested in JSON, etc). Mixing
+  // HTML-escape the source text — same hazard as the scope-commit and
+  // recent-denial paths above. The permission card body
+  // (formatPermissionCardBody) appends claude-supplied `description`
+  // and `input_preview` strings that frequently contain raw
+  // `<`/`>`/`&` (shell commands, JSON nested in JSON, etc). Mixing
   // a plain-text edit with `parseMode: 'HTML'` is the safe direction:
   // escaped baseText round-trips visually as plain text; the appended
   // status line carries our chosen styling cleanly.

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -32,8 +32,10 @@ export interface PermissionEvent {
    * tapped "Always allow" still hit the popup, because Claude Code reads
    * `.claude/settings.json` once at boot.
    *
-   * Format matches `resolveAlwaysAllowRule`'s output: bare tool name
-   * (`Edit`), `Skill(<name>)`, or `mcp__<server>__<tool>`.
+   * Format matches `resolveScopedAllowChoices`' output: bare tool name
+   * (`Edit`), scoped (`Edit(<path>)` / `Bash(<tok>:*)` / `Skill(<name>)`),
+   * exact MCP tool (`mcp__<server>__<tool>`), or server wildcard
+   * (`mcp__<server>__*`).
    */
   rule?: string;
 }

--- a/telegram-plugin/permission-rule.ts
+++ b/telegram-plugin/permission-rule.ts
@@ -1,108 +1,187 @@
 /**
- * Resolve a Claude Code permission allow-rule from a permission_request
- * payload — the value we'd add to `tools.allow` in switchroom.yaml so
+ * Resolve Claude Code permission allow-rules from a permission_request
+ * payload — the value(s) we'd add to `tools.allow` in switchroom.yaml so
  * future invocations of the same operation never pop another approval
  * dialog.
  *
- * Used by the Telegram permission popup's "🔁 Always allow" button
- * (issue follow-up to #186). Per-skill granularity for `Skill` so
- * tapping "Always" on a `Skill (mail)` prompt only whitelists `mail`,
- * not all skills. Other tools fall back to the bare tool name —
- * promoting `Bash` from per-call confirm to always-allow is a more
- * meaningful blast-radius decision and shouldn't be hidden behind a
- * one-tap button on an arbitrary command, but the bare-name behaviour
- * is consistent with how the existing `tools.allow: [Bash]` works.
+ * Used by the Telegram permission card's "🔁 Always…" button. The button
+ * no longer commits a single fixed-breadth rule: it opens a scope choice
+ * so the operator decides whether "always" means *this exact thing* (e.g.
+ * this one file, this one MCP action) or *the whole category* (any file,
+ * every tool on the server). The scope of the grant — especially for
+ * "always" — must be legible before the operator taps it (vision pillar
+ * #2: you hold the leash).
  *
- * Returns:
- *   - `{ rule, label }` when we can compute a rule for the agent's yaml
- *   - `null` when the tool is something we don't know how to allow at
- *     a meaningful granularity (caller should disable the Always button
- *     to avoid writing a useless or dangerously-broad rule)
+ * `resolveScopedAllowChoices` returns up to two options:
+ *   - `specific` — the narrow grant (this file / this command / this
+ *     MCP action). Omitted when the tool has no meaningful sub-scope.
+ *   - `broad` — the category grant (any file / any command / every tool
+ *     on the server). Always present when choices resolve at all; the
+ *     gateway flags it with a ⚠️ and places it last.
  *
- * The `label` is what we surface to the operator in the confirmation
- * — "🔁 Always allow Skill(mail) for clerk". The rule is what lands in
- * yaml: matches Claude Code's settings.json permission-rule grammar
- * (`Tool` or `Tool(arg)` for granular).
+ * Returns `null` when the tool is something we can't allow at a
+ * meaningful granularity — the caller hides the Always button rather
+ * than write a useless or dangerously-broad rule.
+ *
+ * The rule strings match Claude Code's settings.json permission-rule
+ * grammar (`Tool`, `Tool(arg)`, `mcp__server__tool`, `mcp__server__*`).
  */
 
 import { basename } from "node:path";
 
-export interface AlwaysAllowRule {
-  /** The exact string to add to `tools.allow` in switchroom.yaml. */
+/** One scope option offered behind the "🔁 Always…" button. */
+export interface ScopeOption {
+  /** Exact string to add to `tools.allow` in switchroom.yaml. */
   readonly rule: string;
-  /** Human-readable label for the confirmation message. */
-  readonly label: string;
+  /** Short button label, e.g. "This file" / "Any file" / "All Perplexity". */
+  readonly buttonLabel: string;
+  /** True for the broadest option — gateway rides a ⚠️ on it and shows it last. */
+  readonly broad: boolean;
 }
 
+export interface ScopedAllowChoices {
+  /** Narrow grant (this file / this command / this action). May be absent. */
+  readonly specific?: ScopeOption;
+  /** Broadest grant (any file / any command / every server tool). */
+  readonly broad: ScopeOption;
+}
+
+const FILE_TOOLS = new Set([
+  "Edit",
+  "Write",
+  "MultiEdit",
+  "NotebookEdit",
+  "Read",
+]);
+
+// Tools with no meaningful sub-scope — only a broad, whole-tool grant.
+const BROAD_ONLY_TOOLS = new Set([
+  "Glob",
+  "Grep",
+  "WebFetch",
+  "WebSearch",
+  "Task",
+  "Agent",
+  "TodoWrite",
+  "ExitPlanMode",
+]);
+
 /**
- * @param toolName    Claude Code's tool_name from the permission_request
+ * @param toolName     Claude Code's tool_name from the permission_request
  * @param inputPreview JSON string with the tool's input. May be undefined
  *                     or non-JSON; the function is conservative.
  */
-export function resolveAlwaysAllowRule(
+export function resolveScopedAllowChoices(
   toolName: string,
   inputPreview: string | undefined,
-): AlwaysAllowRule | null {
+): ScopedAllowChoices | null {
   if (!toolName) return null;
   const input = parseInput(inputPreview);
 
-  switch (toolName) {
-    case "Skill": {
-      // Per-skill granularity: `Skill(mail)`. Mirror permission-title's
-      // defensive field-fallback so the rule resolves whenever the
-      // popup managed to render the skill name in brackets.
-      if (!input) return null;
-      const skill =
-        readString(input, "skill") ??
-        readString(input, "skill_name") ??
-        readString(input, "skillName") ??
-        readString(input, "name") ??
-        skillBasenameFromPath(input);
-      if (!skill) return null;
-      // Claude Code's permission-rule grammar quotes the arg with
-      // parentheses, no inner quoting needed for typical skill names
-      // (alphanumeric + dash/underscore/dot). Refuse rules with
-      // characters that could break the parser or expand to unintended
-      // matches.
-      if (!/^[A-Za-z0-9._\-+]+$/.test(skill)) return null;
+  // ── Skill: per-skill is the narrow grant; all skills is the broad one.
+  if (toolName === "Skill") {
+    const skill = input ? resolveSkillName(input) : null;
+    if (!skill) return null; // can't name it → don't offer an always rule
+    if (!/^[A-Za-z0-9._\-+]+$/.test(skill)) return null;
+    return {
+      specific: { rule: `Skill(${skill})`, buttonLabel: "This skill", broad: false },
+      broad: { rule: "Skill", buttonLabel: "Any skill", broad: true },
+    };
+  }
+
+  // ── File tools: this exact path vs any file.
+  if (FILE_TOOLS.has(toolName)) {
+    const path = filePathFrom(input);
+    const broad: ScopeOption = { rule: toolName, buttonLabel: "Any file", broad: true };
+    if (path) {
       return {
-        rule: `Skill(${skill})`,
-        label: `Skill(${skill})`,
+        specific: { rule: `${toolName}(${path})`, buttonLabel: "This file", broad: false },
+        broad,
       };
     }
-    case "Bash":
-    case "Read":
-    case "Write":
-    case "Edit":
-    case "MultiEdit":
-    case "NotebookEdit":
-    case "Glob":
-    case "Grep":
-    case "WebFetch":
-    case "WebSearch":
-    case "Task":
-    case "Agent":
-    case "TodoWrite":
-    case "ExitPlanMode": {
-      // Bare tool name — same shape as `tools.allow: [Bash]`. We
-      // don't pattern-match the args here: that's the operator's job
-      // when they want fine control. The Telegram button is for the
-      // common "I trust this skill / this tool category" case, not
-      // for synthesizing precise Bash glob rules.
-      return { rule: toolName, label: toolName };
-    }
-    default: {
-      // MCP tools (mcp__server__tool) come through with their full
-      // namespaced name. Pre-approve the exact tool — same pattern
-      // the scaffold already uses for SWITCHROOM_TELEGRAM_MCP_TOOLS.
-      if (/^mcp__[A-Za-z0-9_\-]+(__[A-Za-z0-9_\-]+)?$/.test(toolName)) {
-        return { rule: toolName, label: toolName };
-      }
-      // Unknown tool — refuse rather than write a rule we can't
-      // explain. Leaves the operator to add it via the CLI.
-      return null;
-    }
+    return { broad };
   }
+
+  // ── Bash: this command family (`npm:*`) vs any command.
+  if (toolName === "Bash") {
+    const broad: ScopeOption = { rule: "Bash", buttonLabel: "Any command", broad: true };
+    const cmd = input ? readString(input, "command") : null;
+    const tok = cmd ? bashFirstToken(cmd) : null;
+    if (tok) {
+      return {
+        specific: { rule: `Bash(${tok}:*)`, buttonLabel: `${tok} commands`, broad: false },
+        broad,
+      };
+    }
+    return { broad };
+  }
+
+  if (BROAD_ONLY_TOOLS.has(toolName)) {
+    return { broad: { rule: toolName, buttonLabel: "Always allow", broad: true } };
+  }
+
+  // ── MCP tools: `mcp__<server>__<tool>`. This exact action vs every
+  // tool on the server (`mcp__<server>__*`).
+  const mcp = /^mcp__([A-Za-z0-9_-]+)__([A-Za-z0-9_-]+)$/.exec(toolName);
+  if (mcp) {
+    const server = mcp[1]!;
+    return {
+      specific: { rule: toolName, buttonLabel: "This action", broad: false },
+      broad: { rule: `mcp__${server}__*`, buttonLabel: `All ${prettyMcpServer(server)}`, broad: true },
+    };
+  }
+  // Server-only namespace (`mcp__hindsight`) — broad grant only.
+  if (/^mcp__[A-Za-z0-9_-]+$/.test(toolName)) {
+    return { broad: { rule: toolName, buttonLabel: "Always allow", broad: true } };
+  }
+
+  // Unknown tool — refuse rather than write a rule we can't explain.
+  return null;
+}
+
+/**
+ * Prettify an MCP server slug for display: `perplexity` → `Perplexity`,
+ * `google-workspace` → `Google Workspace`. Exported so the card title
+ * layer (permission-title.ts) renders the same server name as the
+ * scope button.
+ */
+export function prettyMcpServer(server: string): string {
+  return server
+    .split(/[-_]/)
+    .filter((w) => w.length > 0)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function resolveSkillName(input: Record<string, unknown>): string | null {
+  return (
+    readString(input, "skill") ??
+    readString(input, "skill_name") ??
+    readString(input, "skillName") ??
+    readString(input, "name") ??
+    skillBasenameFromPath(input)
+  );
+}
+
+function filePathFrom(input: Record<string, unknown> | null): string | null {
+  if (!input) return null;
+  return readString(input, "file_path") ?? readString(input, "notebook_path");
+}
+
+/**
+ * First token of a Bash command, used to synthesize a `Bash(<tok>:*)`
+ * prefix rule. Returns null for anything that isn't a clean command
+ * word (paths, shell metacharacters, traversal) — better to fall back
+ * to the explicit "any command" grant than emit a rule that doesn't
+ * match what the operator saw.
+ */
+function bashFirstToken(command: string): string | null {
+  const m = /^\s*([^\s|&;<>()`$]+)/.exec(command);
+  if (!m) return null;
+  const tok = m[1]!;
+  if (tok.includes("..")) return null;
+  // Allow a leading path (e.g. /usr/bin/ls) but keep it a single safe word.
+  return /^[A-Za-z0-9._\-\/]+$/.test(tok) ? tok : null;
 }
 
 function parseInput(raw: string | undefined): Record<string, unknown> | null {
@@ -134,18 +213,8 @@ function skillBasenameFromPath(input: Record<string, unknown>): string | null {
 
 /**
  * Verify that a grant actually landed in the resolved `tools.allow` list.
- *
- * Called by the `perm:always:*` handler after `switchroom agent grant`
- * returns to guard against silently-failed or misdirected yaml writes.
- * Extracted as a pure helper so it can be unit-tested without a full
- * Grammy + switchroomExec harness.
- *
- * @param resolvedAllow  The `tools.allow` array from `resolveAgentConfig`
- *                       for the target agent (pass `[]` when absent/undefined).
- * @param ruleRule       The rule string produced by `resolveAlwaysAllowRule`
- *                       (e.g. `"Skill(garmin)"`, `"Bash"`, `"mcp__x__y"`).
- * @returns `true` when the rule is present (grant confirmed), `false` when
- *          absent (grant failed / config location drifted).
+ * Called by the always-allow handler after the persistence round-trip to
+ * guard against silently-failed or misdirected yaml writes.
  */
 export function isRulePersisted(
   resolvedAllow: readonly string[],
@@ -155,27 +224,22 @@ export function isRulePersisted(
 }
 
 /**
- * Inverse of `resolveAlwaysAllowRule` — does a stored allow-rule cover a
- * fresh `permission_request`? Used by the bridge's session-scoped
- * always-allow cache (issue #1138) to short-circuit prompts when the
- * operator has already tapped "🔁 Always allow" for an equivalent tool
- * call earlier in the same session.
+ * Inverse of the rule resolver — does a stored allow-rule cover a fresh
+ * `permission_request`? Used by the bridge's session-scoped always-allow
+ * cache (#1138) to short-circuit prompts when the operator has already
+ * tapped an equivalent grant earlier in the same session.
  *
- * Matching rules (mirrors what `resolveAlwaysAllowRule` produces):
+ * Matching rules (mirror what `resolveScopedAllowChoices` produces):
  *
- *   - Bare tool name (`Edit`, `Bash`, `Write`, …) ⇒ matches any
- *     invocation of that tool. This is consistent with how
- *     `tools.allow: [Edit]` works in `.claude/settings.json` — there's
- *     no arg matching at this layer.
- *   - `Skill(<name>)` ⇒ matches only `Skill` invocations whose resolved
- *     skill name (via the same field-fallback chain as the resolver)
- *     equals `<name>`.
- *   - `mcp__<server>__<tool>` ⇒ matches the exact namespaced MCP tool
- *     name.
+ *   - Bare tool name (`Edit`, `Bash`, …) ⇒ any invocation of that tool.
+ *   - `Edit(<path>)` / `Read(<path>)` / … ⇒ that tool, that exact file.
+ *   - `Bash(<tok>:*)` ⇒ Bash whose first command token equals `<tok>`.
+ *   - `Skill(<name>)` ⇒ Skill whose resolved name equals `<name>`.
+ *   - `mcp__<server>__<tool>` ⇒ that exact namespaced MCP tool.
+ *   - `mcp__<server>__*` ⇒ any tool on that MCP server.
  *
  * Returns `false` for any malformed rule rather than throwing — the
- * caller (bridge) is on the hot permission path and should fall through
- * to the gateway prompt on bad input.
+ * caller (bridge) is on the hot permission path.
  */
 export function matchesAllowRule(
   rule: string,
@@ -184,23 +248,37 @@ export function matchesAllowRule(
 ): boolean {
   if (!rule || !toolName) return false;
 
-  // Skill(name) — extract the parenthesized argument and compare against
-  // the resolved skill identifier from the request.
-  const skillMatch = /^Skill\(([^)]+)\)$/.exec(rule);
-  if (skillMatch) {
-    if (toolName !== "Skill") return false;
-    const ruleSkill = skillMatch[1];
-    const input = parseInput(inputPreview);
-    if (!input) return false;
-    const reqSkill =
-      readString(input, "skill") ??
-      readString(input, "skill_name") ??
-      readString(input, "skillName") ??
-      readString(input, "name") ??
-      skillBasenameFromPath(input);
-    return reqSkill === ruleSkill;
+  // MCP wildcard: `mcp__server__*` covers every tool on that server.
+  if (rule.endsWith("__*") && rule.startsWith("mcp__")) {
+    const prefix = rule.slice(0, -1); // drop the trailing "*" → "mcp__server__"
+    return toolName.startsWith(prefix);
   }
 
-  // Bare tool name or namespaced MCP tool — exact string compare.
+  // `Tool(arg)` — scoped grants for Skill / file tools / Bash.
+  const scoped = /^([A-Za-z]+)\((.+)\)$/.exec(rule);
+  if (scoped) {
+    const ruleTool = scoped[1]!;
+    const arg = scoped[2]!;
+    if (ruleTool !== toolName) return false;
+    const input = parseInput(inputPreview);
+
+    if (ruleTool === "Skill") {
+      if (!input) return false;
+      return resolveSkillName(input) === arg;
+    }
+    if (ruleTool === "Bash") {
+      const cmd = input ? readString(input, "command") : null;
+      if (!cmd) return false;
+      const m = /^([^:]+):\*$/.exec(arg); // "<tok>:*"
+      if (!m) return false;
+      return bashFirstToken(cmd) === m[1];
+    }
+    if (FILE_TOOLS.has(ruleTool)) {
+      return filePathFrom(input) === arg;
+    }
+    return false;
+  }
+
+  // Bare tool name or exact namespaced MCP tool — exact string compare.
   return rule === toolName;
 }

--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -1,46 +1,35 @@
 /**
- * Build the inline-keyboard permission approval message — title + body.
+ * Human-readable text for the Telegram permission approval card.
  *
- * Two related concerns:
+ * The operator is (often) non-technical. A card must read as a plain
+ * sentence — "Gymbro wants to edit: supplement-log.md" — never a raw
+ * tool identifier (`mcp__perplexity__search`, `Edit:`). Two surfaces:
  *
- *   `summarizeToolForTitle` (one line, no escaping) is the bare summary
- *   used in the always-allow rule label and as the body-builder's
- *   internal building block. Pre-#186 the title was always `🔐
- *   Permission: ${toolName}` — for a `Skill` or `Bash` call the user
- *   couldn't tell which skill / command was being approved without
- *   tapping "See more".
+ *   `formatPermissionCardBody` — the card itself: a one-line natural
+ *   title plus the agent's stated reason. No tool ids, no scope chrome
+ *   (scope only appears once the operator taps "🔁 Always…").
  *
- *   `formatPermissionCardBody` (multi-line, HTML-escaped for
- *   parse_mode=HTML) is the body of the card itself. Pre-#1790 the
- *   collapsed card was a single line — operators had to tap "See more"
- *   to see the agent's stated reason or input preview. This mirrors
- *   the vault `vault_request_access` card's three-line layout (the
- *   gold standard) so every approval surface answers "what" + "why"
- *   without an expand tap.
+ *   `describeGrant` — the confirmation after a grant lands: "Gymbro can
+ *   now edit any file without asking" — phrased from the *scope the
+ *   operator chose*, so the breadth of an always-allow is legible after
+ *   the fact, not just before.
  *
- * See #186 (title) and #1790 (body).
+ * See #186 (title), #1790 (reason line), and the scoped-card work.
  */
 
 import { basename } from "node:path";
+import { prettyMcpServer, type ScopeOption } from "./permission-rule.js";
 
-const COMMAND_TITLE_MAX = 40;
-const PATH_TITLE_MAX = 40;
+const COMMAND_TITLE_MAX = 48;
 const DESCRIPTION_LINE_MAX = 240;
-const INPUT_VALUE_MAX = 60;
 
 /**
- * Human-friendly descriptions for switchroom-managed MCP tools. The
- * raw `mcp__<server>__<tool>` name is operator-unfriendly — they shouldn't
- * have to decode the namespace to understand what the agent is asking
- * to do. Use this map to turn the code-level identifier into a verb
- * phrase ("Read its own merged config" instead of
- * "mcp__agent-config__config_get") for the approval card.
- *
- * Note: post-#1215 these tools are pre-allowed in scaffolded
- * settings.permissions.allow, so the card should fire rarely.
- * This map is for the fallback path — agents the operator
- * narrowed the allowlist on, or tools added in future PRs that
- * haven't shipped the allowlist bump yet.
+ * Human verb-phrases for switchroom-managed MCP tools. The raw
+ * `mcp__<server>__<tool>` name is operator-hostile. Phrases are written
+ * to slot in after "wants to" / "can now" — e.g. "read its own merged
+ * config". Internal-server tools (agent-config / hostd / hindsight /
+ * telegram) read fine alone; external integrations get a "(Server)" tag
+ * appended so the operator knows which third party is involved.
  */
 const MCP_TOOL_DESCRIPTIONS: Record<string, string> = {
   // agent-config — every agent's self-service surface (#1163, #1215)
@@ -65,120 +54,27 @@ const MCP_TOOL_DESCRIPTIONS: Record<string, string> = {
   "mcp__hindsight__recall": "Recall relevant memories",
   "mcp__hindsight__retain": "Retain a memory",
   "mcp__hindsight__reflect": "Reflect across its memory bank",
+  // external integrations — common verbs (get a "(Server)" tag)
+  "mcp__perplexity__search": "Search the web",
+  "mcp__perplexity__ask": "Ask the web",
 };
 
-/**
- * Build a title fragment for a permission prompt. Returns the toolName
- * for any tool we don't recognise — the helper is intentionally
- * conservative: better to keep the bare name than render gibberish from
- * a malformed input_preview.
- */
-export function summarizeToolForTitle(
-  toolName: string,
-  inputPreview: string | undefined,
-): string {
-  // MCP tools: `mcp__<server>__<verb>`. Prefer a curated human
-  // description (so the card reads "Read its own merged config"
-  // instead of "mcp__agent-config__config_get"). Fall through to a
-  // generic `<server>: <verb-with-spaces>` shape for unknown MCP
-  // tools and finally to the raw name when even that fails. When
-  // we have an input preview, append the first arg-value pair so
-  // the operator sees what's being requested without expanding —
-  // e.g. `Read its own merged config (key: coolify/api-token)`
-  // rather than just `Read its own merged config`. (#1790)
-  if (toolName.startsWith("mcp__")) {
-    const curated = MCP_TOOL_DESCRIPTIONS[toolName];
-    const base = curated
-      ? curated
-      : (() => {
-          const parts = toolName.split("__");
-          if (parts.length >= 3) {
-            const server = parts[1]!;
-            const verb = parts.slice(2).join("__").replace(/_/g, " ");
-            return `${server}: ${verb}`;
-          }
-          return toolName;
-        })();
-    const argHint = firstScalarArgHint(parseInput(inputPreview));
-    return argHint ? `${base} (${argHint})` : base;
-  }
-
-  const input = parseInput(inputPreview);
-  if (!input) return toolName;
-
-  switch (toolName) {
-    case "Skill": {
-      // Claude Code's Skill tool input shape has shifted across versions
-      // and skill flavours. Read defensively from every known field
-      // before falling back. The skill name is the most identifying
-      // field of the prompt; never drop it silently.
-      //
-      // (#1790) Final fallback added: when no skill-name key matches,
-      // try `command` (some Skill variants pass the invocation under
-      // that key), then the first scalar arg-value pair. Pre-fix the
-      // default returned a bare `Skill` with zero context — operators
-      // saw "🔐 Permission: Skill" with no way to tell what was being
-      // asked without tapping See more.
-      const skill =
-        readString(input, "skill") ??
-        readString(input, "skill_name") ??
-        readString(input, "skillName") ??
-        readString(input, "name") ??
-        skillBasenameFromPath(input);
-      if (skill) return `${toolName} (${skill})`;
-      const command = readString(input, "command");
-      if (command) return `${toolName}: ${truncate(command, COMMAND_TITLE_MAX)}`;
-      const argHint = firstScalarArgHint(input);
-      return argHint ? `${toolName} (${argHint})` : toolName;
-    }
-    case "Bash": {
-      const command = readString(input, "command");
-      return command ? `${toolName}: ${truncate(command, COMMAND_TITLE_MAX)}` : toolName;
-    }
-    case "Read":
-    case "Edit":
-    case "Write":
-    case "MultiEdit":
-    case "NotebookEdit": {
-      const filePath = readString(input, "file_path") ?? readString(input, "notebook_path");
-      return filePath ? `${toolName}: ${truncate(basename(filePath), PATH_TITLE_MAX)}` : toolName;
-    }
-    case "Glob":
-    case "Grep": {
-      const pattern = readString(input, "pattern");
-      return pattern ? `${toolName}: ${truncate(pattern, COMMAND_TITLE_MAX)}` : toolName;
-    }
-    case "WebFetch":
-    case "WebSearch": {
-      const query = readString(input, "url") ?? readString(input, "query");
-      return query ? `${toolName}: ${truncate(query, COMMAND_TITLE_MAX)}` : toolName;
-    }
-    default:
-      return toolName;
-  }
-}
+const INTERNAL_MCP_SERVERS = new Set([
+  "agent-config",
+  "hostd",
+  "hindsight",
+  "switchroom-telegram",
+]);
 
 /**
- * Build the multi-line collapsed body of an approval card (#1790).
+ * Build the multi-line card body for an approval prompt.
  *
- * Pre-fix the card was a single line — `🔐 Permission: <title>` —
- * and the agent's stated `description` plus the input preview only
- * surfaced when the operator tapped "See more". For skill / generic
- * tool prompts the title alone (e.g. `Skill (mail)`) is rarely
- * enough to approve at a glance; the operator needs to see *why*
- * before they tap Allow / Deny.
+ *   🔐 <b>Gymbro</b> wants to edit: supplement-log.md
+ *   why: <i>logging today's lifts</i>
  *
- * Layout mirrors the `vault_request_access` card (the gold standard):
- *
- *   🔐 <agent> · <tool summary>
- *   why: <description-or-"not provided">
- *
- * The agent line is dropped when `agentName` is null (the
- * gateway's bridge client may be anonymous during early-boot edge
- * cases — better to render the title than a misleading blank).
- *
- * Output is HTML-escaped and intended for `parse_mode: 'HTML'`
- * via Telegram's Bot API.
+ * Output is HTML-escaped for `parse_mode: 'HTML'`. The agent name is
+ * capitalized for the sentence; dropped (with "wants to") when null —
+ * the bridge client can be anonymous during early-boot edge cases.
  */
 export function formatPermissionCardBody(opts: {
   toolName: string;
@@ -186,78 +82,202 @@ export function formatPermissionCardBody(opts: {
   description: string | undefined;
   agentName: string | null;
 }): string {
-  const summary = summarizeToolForTitle(opts.toolName, opts.inputPreview);
+  const action = naturalAction(opts.toolName, opts.inputPreview);
   const lines: string[] = [];
 
-  const agentBit = opts.agentName && opts.agentName.length > 0
-    ? `<b>${escapeTgHtml(opts.agentName)}</b> · `
-    : "";
-  lines.push(`🔐 ${agentBit}${escapeTgHtml(summary)}`);
+  if (opts.agentName && opts.agentName.length > 0) {
+    lines.push(
+      `🔐 <b>${escapeTgHtml(capFirst(opts.agentName))}</b> wants to ${escapeTgHtml(action)}`,
+    );
+  } else {
+    lines.push(`🔐 ${escapeTgHtml(capFirst(action))}`);
+  }
 
-  // The agent's stated reason. Always render the line — when the
-  // agent omitted a `description`, render an explicit
-  // `why: <i>not provided</i>` rather than skip silently, so the
-  // missing-rationale is visible as an agent-side failure (matches
-  // the vault card's #1790 treatment of an omitted `reason`).
   const rawWhy = (opts.description ?? "").replace(/\s+/g, " ").trim();
   const truncatedWhy =
     rawWhy.length > DESCRIPTION_LINE_MAX
       ? rawWhy.slice(0, DESCRIPTION_LINE_MAX - 1) + "…"
       : rawWhy;
-  if (truncatedWhy.length > 0) {
-    lines.push(`why: <i>${escapeTgHtml(truncatedWhy)}</i>`);
-  } else {
-    lines.push(`why: <i>not provided</i>`);
-  }
+  lines.push(
+    truncatedWhy.length > 0
+      ? `why: <i>${escapeTgHtml(truncatedWhy)}</i>`
+      : `why: <i>not provided</i>`,
+  );
 
   return lines.join("\n");
 }
 
 /**
- * Minimal HTML escape for Telegram `parse_mode=HTML`. Mirrors
- * `escapeHtmlForTg` in gateway.ts; duplicated here to keep
- * permission-title.ts free of a gateway import (the file is
- * referenced by both server.ts and gateway.ts).
+ * The natural-language action for a tool call — the part that reads
+ * after "wants to". No tool identifiers, no scope.
  */
+export function naturalAction(
+  toolName: string,
+  inputPreview: string | undefined,
+): string {
+  const input = parseInput(inputPreview);
+
+  if (toolName.startsWith("mcp__")) return naturalMcpAction(toolName, input);
+
+  switch (toolName) {
+    case "Edit":
+    case "MultiEdit":
+    case "NotebookEdit": {
+      const f = fileBase(input);
+      return f ? `edit: ${f}` : "edit files";
+    }
+    case "Write": {
+      const f = fileBase(input);
+      return f ? `write: ${f}` : "write files";
+    }
+    case "Read": {
+      const f = fileBase(input);
+      return f ? `read: ${f}` : "read files";
+    }
+    case "Bash": {
+      const c = input ? readString(input, "command") : null;
+      return c ? `run: ${truncate(c, COMMAND_TITLE_MAX)}` : "run shell commands";
+    }
+    case "Skill": {
+      const s = input ? resolveSkillName(input) : null;
+      return s ? `use the ${s} skill` : "use a skill";
+    }
+    case "Glob":
+    case "Grep": {
+      const p = input ? readString(input, "pattern") : null;
+      return p ? `search files for: ${truncate(p, COMMAND_TITLE_MAX)}` : "search files";
+    }
+    case "WebSearch": {
+      const q = input ? readString(input, "query") : null;
+      return q ? `search the web for: ${truncate(q, COMMAND_TITLE_MAX)}` : "search the web";
+    }
+    case "WebFetch": {
+      const u = input ? readString(input, "url") : null;
+      return u ? `fetch a web page: ${truncate(u, COMMAND_TITLE_MAX)}` : "fetch a web page";
+    }
+    case "Task":
+    case "Agent":
+      return "dispatch a sub-agent";
+    case "TodoWrite":
+      return "update its task list";
+    case "ExitPlanMode":
+      return "exit plan mode";
+    default:
+      return `use ${toolName}`;
+  }
+}
+
+function naturalMcpAction(
+  toolName: string,
+  input: Record<string, unknown> | null,
+): string {
+  void input;
+  const parts = toolName.split("__");
+  const server = parts.length >= 2 ? parts[1]! : "";
+  const curated = MCP_TOOL_DESCRIPTIONS[toolName];
+  if (curated) {
+    const phrase = lowerFirst(curated);
+    return INTERNAL_MCP_SERVERS.has(server)
+      ? phrase
+      : `${phrase} (${prettyMcpServer(server)})`;
+  }
+  if (parts.length >= 3) {
+    const verb = parts.slice(2).join("__").replace(/_/g, " ");
+    return INTERNAL_MCP_SERVERS.has(server)
+      ? verb
+      : `${verb} (${prettyMcpServer(server)})`;
+  }
+  return `use ${toolName}`;
+}
+
+/**
+ * Confirmation phrase describing a grant that just landed, derived from
+ * the *scope option the operator chose* — so an always-allow's breadth
+ * is legible after the fact. Slots in after "<Agent> can now …":
+ *
+ *   "edit any file" / "edit supplement-log.md" / "run npm commands" /
+ *   "use the mail skill" / "use any Perplexity tool"
+ */
+export function describeGrant(
+  toolName: string,
+  inputPreview: string | undefined,
+  option: ScopeOption,
+): string {
+  const rule = option.rule;
+
+  // MCP wildcard → "use any <Server> tool".
+  if (rule.endsWith("__*") && rule.startsWith("mcp__")) {
+    const server = rule.split("__")[1] ?? "";
+    return `use any ${prettyMcpServer(server)} tool`;
+  }
+
+  const scoped = /^([A-Za-z]+)\((.+)\)$/.exec(rule);
+  if (scoped) {
+    const t = scoped[1]!;
+    const arg = scoped[2]!;
+    if (t === "Skill") return `use the ${arg} skill`;
+    if (t === "Bash") {
+      const m = /^([^:]+):\*$/.exec(arg);
+      return m ? `run ${m[1]} commands` : "run that command";
+    }
+    if (t === "Edit" || t === "MultiEdit" || t === "NotebookEdit")
+      return `edit ${basename(arg)}`;
+    if (t === "Write") return `write ${basename(arg)}`;
+    if (t === "Read") return `read ${basename(arg)}`;
+    return naturalAction(toolName, inputPreview);
+  }
+
+  // Bare tool name — the broad, whole-category grants.
+  switch (rule) {
+    case "Edit":
+    case "MultiEdit":
+    case "NotebookEdit":
+      return "edit any file";
+    case "Write":
+      return "write any file";
+    case "Read":
+      return "read any file";
+    case "Bash":
+      return "run any command";
+    case "Skill":
+      return "use any skill";
+    default:
+      // Exact MCP tool or a broad-only built-in — fall back to the
+      // request's natural action.
+      return naturalAction(toolName, inputPreview);
+  }
+}
+
+function resolveSkillName(input: Record<string, unknown>): string | null {
+  return (
+    readString(input, "skill") ??
+    readString(input, "skill_name") ??
+    readString(input, "skillName") ??
+    readString(input, "name") ??
+    skillBasenameFromPath(input)
+  );
+}
+
+function fileBase(input: Record<string, unknown> | null): string | null {
+  if (!input) return null;
+  const p = readString(input, "file_path") ?? readString(input, "notebook_path");
+  return p ? basename(p) : null;
+}
+
+function lowerFirst(text: string): string {
+  return text.length > 0 ? text.charAt(0).toLowerCase() + text.slice(1) : text;
+}
+
+function capFirst(text: string): string {
+  return text.length > 0 ? text.charAt(0).toUpperCase() + text.slice(1) : text;
+}
+
+/** Minimal HTML escape for Telegram `parse_mode=HTML`. */
 function escapeTgHtml(text: string): string {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
-}
-
-/**
- * Return a `key: value` hint for the first scalar (string / number /
- * boolean) arg in the input preview. Used as a last-ditch context
- * line on uncurated MCP tools and Skill calls whose canonical
- * skill-name fields are all missing.
- *
- * Skips obviously-routing keys (`chat_id`, `message_thread_id`,
- * `request_id`) that aren't useful to a human operator deciding
- * whether to approve. Returns `null` when nothing scalar remains.
- */
-function firstScalarArgHint(
-  input: Record<string, unknown> | null,
-): string | null {
-  if (!input) return null;
-  const SKIP = new Set([
-    "chat_id",
-    "chatId",
-    "message_thread_id",
-    "messageThreadId",
-    "request_id",
-    "requestId",
-  ]);
-  for (const [key, value] of Object.entries(input)) {
-    if (SKIP.has(key)) continue;
-    if (typeof value === "string" && value.length > 0) {
-      return `${key}: ${truncate(value, INPUT_VALUE_MAX)}`;
-    }
-    if (typeof value === "number" || typeof value === "boolean") {
-      return `${key}: ${String(value)}`;
-    }
-  }
-  return null;
 }
 
 function parseInput(raw: string | undefined): Record<string, unknown> | null {
@@ -280,21 +300,13 @@ function readString(input: Record<string, unknown>, key: string): string | null 
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
-/**
- * Some Skill tool variants pass the skill as a directory path (e.g.
- * `skills/mail/SKILL.md` or `~/.switchroom/skills/mail`). Lift the
- * skill name out of the path so the popup still says `Skill (mail)`
- * instead of dumping the full path or bare `Skill`.
- */
 function skillBasenameFromPath(input: Record<string, unknown>): string | null {
   const path = readString(input, "path") ?? readString(input, "skill_path");
   if (!path) return null;
-  // Strip a trailing /SKILL.md or filename so we land on the directory
-  // basename — that's the canonical skill name in switchroom's layout.
   const trimmed = path.replace(/\/SKILL\.md$/i, "").replace(/\/$/, "");
   const lastSlash = trimmed.lastIndexOf("/");
-  const basename = lastSlash >= 0 ? trimmed.slice(lastSlash + 1) : trimmed;
-  return basename.length > 0 ? basename : null;
+  const base = lastSlash >= 0 ? trimmed.slice(lastSlash + 1) : trimmed;
+  return base.length > 0 ? base : null;
 }
 
 function truncate(text: string, max: number): string {

--- a/telegram-plugin/tests/always-allow-grant.test.ts
+++ b/telegram-plugin/tests/always-allow-grant.test.ts
@@ -1,16 +1,24 @@
 /**
  * Structural contract tests for the durable "🔁 Always allow" handler
- * in gateway.ts (the `behavior === 'always'` branch of the perm:
- * callback dispatcher), reworked for #1977.
+ * in gateway.ts, reworked for #1977 and the scoped-card split.
+ *
+ * The "Always…" flow is now TWO callback steps:
+ *   - `behavior === 'always' | 'back'` — swaps the action row for the
+ *     scope sub-menu (and back). Dispatches NO verdict and touches NO
+ *     host config; it only edits the keyboard.
+ *   - `behavior === 'asn' | 'asb'` — the operator picked a scope
+ *     (narrow / broad). THIS is where the verdict fires and the durable
+ *     persistence round-trip runs.
  *
  * Why structural: the handler lives inside a Grammy callback closure
  * that's not exported. Full-function invocation would require a complete
  * Grammy + hostd + switchroomExec harness. The behavioural pieces are
- * covered by the pure-function tests (permission-diff.test.ts) and the
- * correlation handler tests (always-allow-correlation.test.ts); this
- * file pins the source-level invariants of the orchestration block.
+ * covered by the pure-function tests (permission-diff.test.ts,
+ * permission-rule.test.ts) and the correlation handler tests
+ * (always-allow-correlation.test.ts); this file pins the source-level
+ * invariants of the orchestration block.
  *
- * Post-#1977 contract:
+ * Post-#1977 contract (now on the scope-commit `asn`/`asb` block):
  *   1. The in-flight Allow verdict fires IMMEDIATELY (before awaiting
  *      hostd) so the turn never blocks on host-config persistence.
  *   2. Durable persistence goes through hostd's `config_propose_edit`
@@ -19,9 +27,6 @@
  *      not-configured fallback ONLY (not the primary path), and it
  *      still verifies via isRulePersisted with honest messaging.
  *   4. Failure text never falsely claims durable success.
- *
- * Slicing strategy: we extract the `if (behavior === 'always') {` block
- * from gateway.ts and run string assertions against that slice only.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -34,110 +39,137 @@ const gatewaySrc = readFileSync(
 )
 
 /**
- * Extract the `behavior === 'always'` block from the perm: callback
- * dispatcher. The slice runs from the `if (behavior === 'always')` guard
- * up to (but not including) the next top-level `// Forward permission`
+ * Extract the scope-commit block (`behavior === 'asn' || behavior ===
+ * 'asb'`) from the perm: callback dispatcher. The slice runs from that
+ * guard up to (but not including) the `// Forward permission decision`
  * comment which opens the allow/deny branch.
  */
-function sliceAlwaysBlock(): string {
-  const start = gatewaySrc.indexOf("if (behavior === 'always')")
+function sliceCommitBlock(): string {
+  const start = gatewaySrc.indexOf("if (behavior === 'asn' || behavior === 'asb')")
   const end = gatewaySrc.indexOf('// Forward permission decision to connected bridges', start)
   if (start === -1 || end === -1) return ''
   return gatewaySrc.slice(start, end)
 }
 
-const alwaysBlock = sliceAlwaysBlock()
+/**
+ * Extract the keyboard-toggle block (`behavior === 'always' || behavior
+ * === 'back'`), which must NOT dispatch a verdict.
+ */
+function sliceToggleBlock(): string {
+  const start = gatewaySrc.indexOf("if (behavior === 'always' || behavior === 'back')")
+  const end = gatewaySrc.indexOf("if (behavior === 'asn' || behavior === 'asb')", start)
+  if (start === -1 || end === -1) return ''
+  return gatewaySrc.slice(start, end)
+}
 
-describe('always-allow handler — immediate verdict dispatch (turn must not block)', () => {
+const commitBlock = sliceCommitBlock()
+const toggleBlock = sliceToggleBlock()
+
+describe('always-allow — keyboard toggle block (no side effects)', () => {
+  it('exists and only edits the reply markup', () => {
+    expect(toggleBlock).not.toBe('')
+    expect(toggleBlock).toContain('editMessageReplyMarkup')
+  })
+
+  it('dispatches NO verdict and runs NO host round-trip', () => {
+    expect(toggleBlock).not.toContain('dispatchPermissionVerdict(')
+    expect(toggleBlock).not.toContain('tryHostdDispatch(')
+  })
+
+  it('surfaces the scope choice only now (specific + broad-with-⚠️)', () => {
+    expect(toggleBlock).toContain('choices.broad.buttonLabel')
+    expect(toggleBlock).toContain('⚠️')
+    expect(toggleBlock).toContain('perm:asn:')
+    expect(toggleBlock).toContain('perm:asb:')
+  })
+})
+
+describe('scope-commit — immediate verdict dispatch (turn must not block)', () => {
   it('dispatches the permission verdict BEFORE the hostd await', () => {
-    const verdictIdx = alwaysBlock.indexOf('dispatchPermissionVerdict({')
-    const hostdAwaitIdx = alwaysBlock.indexOf('await tryHostdDispatch(')
+    const verdictIdx = commitBlock.indexOf('dispatchPermissionVerdict({')
+    const hostdAwaitIdx = commitBlock.indexOf('await tryHostdDispatch(')
     expect(verdictIdx).toBeGreaterThan(-1)
     expect(hostdAwaitIdx).toBeGreaterThan(-1)
-    // The verdict fires first — independent of the durable persistence
-    // round-trip.
     expect(verdictIdx).toBeLessThan(hostdAwaitIdx)
   })
 
-  it('carries the resolved rule on the verdict so the bridge caches it', () => {
-    expect(alwaysBlock).toContain("behavior: 'allow'")
-    expect(alwaysBlock).toContain('rule: rule.rule')
+  it('carries the chosen scope rule on the verdict so the bridge caches it', () => {
+    expect(commitBlock).toContain("behavior: 'allow'")
+    expect(commitBlock).toContain('rule: chosen.rule')
+  })
+
+  it('resolves the chosen scope from the tapped button (asn=narrow, asb=broad)', () => {
+    expect(commitBlock).toContain('resolveScopedAllowChoices(')
+    expect(commitBlock).toContain("behavior === 'asn' ? (choices.specific ?? choices.broad) : choices.broad")
   })
 
   it('does NOT pass a synthInbound to finalizeCallback (verdict already fired)', () => {
-    // The verdict is dispatched directly above; finalizeCallback only
-    // edits the card. A synthInbound here would double-fire.
-    const finalizeIdx = alwaysBlock.indexOf('await finalizeCallback(ctx, {')
-    const after = alwaysBlock.slice(finalizeIdx)
+    const finalizeIdx = commitBlock.indexOf('await finalizeCallback(ctx, {')
+    const after = commitBlock.slice(finalizeIdx)
     expect(finalizeIdx).toBeGreaterThan(-1)
     expect(after).not.toContain('synthInbound')
   })
 })
 
-describe('always-allow handler — durable hostd persistence', () => {
+describe('scope-commit — durable hostd persistence', () => {
   it('synthesizes a unified diff from the raw config text', () => {
-    expect(alwaysBlock).toContain('synthesizeAllowRuleDiff({')
-    expect(alwaysBlock).toContain("op: 'config_propose_edit'")
+    expect(commitBlock).toContain('synthesizeAllowRuleDiff({')
+    expect(commitBlock).toContain("op: 'config_propose_edit'")
   })
 
   it('reads the RAW config bytes (readFileSync), not the parsed config', () => {
-    // The diff context lines must byte-match the on-disk file, so we
-    // read literal bytes rather than re-serialising loadSwitchroomConfig.
-    expect(alwaysBlock).toContain('readFileSync(')
+    expect(commitBlock).toContain('readFileSync(')
   })
 
   it('passes a long timeout to tryHostdDispatch (apply+reconcile blocks)', () => {
-    expect(alwaysBlock).toContain('await tryHostdDispatch(agentName, req, 60_000)')
+    expect(commitBlock).toContain('await tryHostdDispatch(agentName, req, 60_000)')
   })
 
   it('registers + cleans up the single-tap correlation entry', () => {
-    expect(alwaysBlock).toContain('pendingAlwaysAllowCorrelations.set(correlationKey')
-    // Cleanup in a finally so it can never be replayed.
-    const finallyIdx = alwaysBlock.indexOf('} finally {')
-    const deleteIdx = alwaysBlock.indexOf('pendingAlwaysAllowCorrelations.delete(correlationKey)', finallyIdx)
+    expect(commitBlock).toContain('pendingAlwaysAllowCorrelations.set(correlationKey')
+    const finallyIdx = commitBlock.indexOf('} finally {')
+    const deleteIdx = commitBlock.indexOf('pendingAlwaysAllowCorrelations.delete(correlationKey)', finallyIdx)
     expect(finallyIdx).toBeGreaterThan(-1)
     expect(deleteIdx).toBeGreaterThan(finallyIdx)
   })
 
   it('treats E_CONFIG_EDIT_DISABLED specially (no legacy fallback, points at the flag)', () => {
-    expect(alwaysBlock).toContain('E_CONFIG_EDIT_DISABLED')
-    expect(alwaysBlock).toContain('hostd.config_edit_enabled')
+    expect(commitBlock).toContain('E_CONFIG_EDIT_DISABLED')
+    expect(commitBlock).toContain('hostd.config_edit_enabled')
   })
 })
 
-describe('always-allow handler — legacy fallback ONLY when hostd not-configured', () => {
+describe('scope-commit — legacy fallback ONLY when hostd not-configured', () => {
   it('falls back to switchroom agent grant only on not-configured', () => {
-    const notConfiguredIdx = alwaysBlock.indexOf("resp === 'not-configured'")
-    const grantIdx = alwaysBlock.indexOf("switchroomExec(['agent', 'grant'")
+    const notConfiguredIdx = commitBlock.indexOf("resp === 'not-configured'")
+    const grantIdx = commitBlock.indexOf("switchroomExec(['agent', 'grant'")
     expect(notConfiguredIdx).toBeGreaterThan(-1)
     expect(grantIdx).toBeGreaterThan(-1)
-    // The grant shellout lives AFTER the not-configured branch sets
-    // legacy=true (i.e. it is the fallback, not the primary path).
     expect(grantIdx).toBeGreaterThan(notConfiguredIdx)
   })
 
   it('emits the legacy-spawn deprecation warning on the not-configured path', () => {
-    expect(alwaysBlock).toContain("warnLegacySpawnIfHostdDisabled('always-allow')")
+    expect(commitBlock).toContain("warnLegacySpawnIfHostdDisabled('always-allow')")
   })
 
   it('verifies the legacy write landed via isRulePersisted', () => {
-    expect(alwaysBlock).toContain('isRulePersisted(allowList, rule.rule)')
-    expect(alwaysBlock).toContain('resolveAgentConfig(')
+    expect(commitBlock).toContain('isRulePersisted(allowList, chosen.rule)')
+    expect(commitBlock).toContain('resolveAgentConfig(')
   })
 
   it('legacy success messaging is honest about being the legacy path', () => {
-    expect(alwaysBlock).toContain('(legacy path)')
+    expect(commitBlock).toContain('(legacy path)')
   })
 })
 
-describe('always-allow handler — loud failure invariants', () => {
+describe('scope-commit — loud failure invariants', () => {
   it('failure text uses the ⚠️ warning marker, never a false ✅ success', () => {
-    expect(alwaysBlock).toContain('did NOT save')
-    expect(alwaysBlock).not.toContain('✅ Allowed (always-allow yaml edit failed')
+    expect(commitBlock).toContain('did NOT save')
+    expect(commitBlock).not.toContain('✅ Allowed (always-allow yaml edit failed')
   })
 
   it('captures a failure reason for the gateway log', () => {
-    expect(alwaysBlock).toContain('failReason')
-    expect(alwaysBlock).toContain('(err as Error).message')
+    expect(commitBlock).toContain('failReason')
+    expect(commitBlock).toContain('(err as Error).message')
   })
 })

--- a/telegram-plugin/tests/always-allow-persist.test.ts
+++ b/telegram-plugin/tests/always-allow-persist.test.ts
@@ -23,7 +23,14 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { isRulePersisted, resolveAlwaysAllowRule } from '../permission-rule.js'
+import { isRulePersisted, resolveScopedAllowChoices } from '../permission-rule.js'
+
+/** The rule the handler dispatches when the operator taps a scope button. */
+const specificRule = (tool: string, input: string | undefined): string => {
+  const choices = resolveScopedAllowChoices(tool, input)
+  expect(choices).not.toBeNull()
+  return (choices!.specific ?? choices!.broad).rule
+}
 
 // ---------------------------------------------------------------------------
 // Core behavioral invariants
@@ -69,56 +76,50 @@ describe('isRulePersisted — success path', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Round-trip: resolveAlwaysAllowRule → isRulePersisted
-// Simulates the full handler flow: resolve the rule from a permission_request,
-// "grant" it (allow-list contains the resolved rule.rule), then verify.
+// Round-trip: resolveScopedAllowChoices → isRulePersisted
+// Simulates the full handler flow: resolve the scope the operator tapped,
+// "grant" it (allow-list contains the resolved rule), then verify.
 // Guards against normalization divergence between the value the handler
-// resolves and the value `agent grant` writes + the config reader returns.
+// dispatches and the value `agent grant`/hostd writes + the config reader
+// returns.
 // ---------------------------------------------------------------------------
 
 describe('rule round-trip through isRulePersisted', () => {
-  it('Skill tool: resolved rule persists correctly', () => {
-    const rule = resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'garmin' }))
-    expect(rule).not.toBeNull()
-    // Simulate: allow-list now contains the rule that `agent grant` wrote.
-    expect(isRulePersisted([rule!.rule], rule!.rule)).toBe(true)
+  it('Skill tool: the specific (this-skill) rule persists correctly', () => {
+    const rule = specificRule('Skill', JSON.stringify({ skill: 'garmin' }))
     // Confirm the written form is `Skill(garmin)` — not a bare `Skill`.
-    expect(rule!.rule).toBe('Skill(garmin)')
+    expect(rule).toBe('Skill(garmin)')
+    expect(isRulePersisted([rule], rule)).toBe(true)
   })
 
   it('Skill tool: absent rule is detected', () => {
-    const rule = resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'garmin' }))
-    expect(rule).not.toBeNull()
+    const rule = specificRule('Skill', JSON.stringify({ skill: 'garmin' }))
     // allow-list was not updated (silent grant failure).
-    expect(isRulePersisted([], rule!.rule)).toBe(false)
-    expect(isRulePersisted(['Skill'], rule!.rule)).toBe(false)
+    expect(isRulePersisted([], rule)).toBe(false)
+    expect(isRulePersisted(['Skill'], rule)).toBe(false)
   })
 
-  it('Bash tool: round-trips correctly', () => {
-    const rule = resolveAlwaysAllowRule('Bash', undefined)
-    expect(rule).not.toBeNull()
-    expect(rule!.rule).toBe('Bash')
-    expect(isRulePersisted(['Bash', 'Read'], rule!.rule)).toBe(true)
-    expect(isRulePersisted(['Read'], rule!.rule)).toBe(false)
+  it('Bash tool: the broad (any-command) rule round-trips correctly', () => {
+    const rule = resolveScopedAllowChoices('Bash', undefined)!.broad.rule
+    expect(rule).toBe('Bash')
+    expect(isRulePersisted(['Bash', 'Read'], rule)).toBe(true)
+    expect(isRulePersisted(['Read'], rule)).toBe(false)
   })
 
-  it('MCP tool: round-trips with exact namespaced form', () => {
+  it('MCP tool: the specific (this-action) rule round-trips with exact form', () => {
     const toolName = 'mcp__garmin__list_activities'
-    const rule = resolveAlwaysAllowRule(toolName, undefined)
-    expect(rule).not.toBeNull()
-    expect(rule!.rule).toBe(toolName)
-    expect(isRulePersisted([toolName], rule!.rule)).toBe(true)
-    expect(isRulePersisted(['mcp__garmin__read_activity'], rule!.rule)).toBe(false)
+    const rule = specificRule(toolName, undefined)
+    expect(rule).toBe(toolName)
+    expect(isRulePersisted([toolName], rule)).toBe(true)
+    expect(isRulePersisted(['mcp__garmin__read_activity'], rule)).toBe(false)
   })
 
   it('multiple Skill tools do not cross-contaminate', () => {
-    const garmin = resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'garmin' }))
-    const mail = resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'mail' }))
-    expect(garmin).not.toBeNull()
-    expect(mail).not.toBeNull()
+    const garmin = specificRule('Skill', JSON.stringify({ skill: 'garmin' }))
+    const mail = specificRule('Skill', JSON.stringify({ skill: 'mail' }))
     // Allow-list only has garmin's rule.
-    const allowList = [garmin!.rule]
-    expect(isRulePersisted(allowList, garmin!.rule)).toBe(true)
-    expect(isRulePersisted(allowList, mail!.rule)).toBe(false)
+    const allowList = [garmin]
+    expect(isRulePersisted(allowList, garmin)).toBe(true)
+    expect(isRulePersisted(allowList, mail)).toBe(false)
   })
 })

--- a/telegram-plugin/tests/permission-rule.test.ts
+++ b/telegram-plugin/tests/permission-rule.test.ts
@@ -1,194 +1,223 @@
 /**
- * Tests for the always-allow rule resolver — pinned by the Telegram
- * `🔁 Always allow` button (popup callback handler in gateway.ts).
+ * Tests for the scoped always-allow rule resolver — pinned by the
+ * Telegram "🔁 Always…" scope sub-menu (callback handler in gateway.ts).
  *
- * The shape we promise to the gateway:
+ * The shape we promise the gateway:
  *   - `null` ⇒ "don't show the Always button" (unknown tool, missing
  *     skill name, characters that could break Claude Code's
  *     permission-rule grammar).
- *   - `{rule, label}` ⇒ a string we can hand to
- *     `switchroom agent grant <agent> <rule>` and a human-readable
- *     label for the chat confirmation.
+ *   - `{ specific?, broad }` ⇒ one or two ScopeOptions. `specific` is the
+ *     narrow grant (this file / this command / this MCP action); `broad`
+ *     is the whole-category grant (any file / every server tool) and is
+ *     always present when choices resolve at all.
+ *
+ * `matchesAllowRule` is the inverse — does a stored rule cover a fresh
+ * request — used by the bridge's session-scoped allow cache (#1138).
  */
 
 import { describe, it, expect } from 'vitest'
-import { resolveAlwaysAllowRule, matchesAllowRule } from '../permission-rule.js'
+import {
+  resolveScopedAllowChoices,
+  matchesAllowRule,
+  isRulePersisted,
+  prettyMcpServer,
+} from '../permission-rule.js'
 
-describe('resolveAlwaysAllowRule — Skill', () => {
-  it('returns Skill(name) for a typical skill input', () => {
-    const result = resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'mail' }))
-    expect(result).toEqual({ rule: 'Skill(mail)', label: 'Skill(mail)' })
+describe('resolveScopedAllowChoices — Skill', () => {
+  it('offers this-skill (specific) + any-skill (broad)', () => {
+    const r = resolveScopedAllowChoices('Skill', JSON.stringify({ skill: 'mail' }))
+    expect(r).toEqual({
+      specific: { rule: 'Skill(mail)', buttonLabel: 'This skill', broad: false },
+      broad: { rule: 'Skill', buttonLabel: 'Any skill', broad: true },
+    })
   })
 
-  it('falls back to skill_name field', () => {
-    const result = resolveAlwaysAllowRule('Skill', JSON.stringify({ skill_name: 'calendar' }))
-    expect(result).toEqual({ rule: 'Skill(calendar)', label: 'Skill(calendar)' })
-  })
-
-  it('falls back to skillName field', () => {
-    const result = resolveAlwaysAllowRule('Skill', JSON.stringify({ skillName: 'garmin' }))
-    expect(result).toEqual({ rule: 'Skill(garmin)', label: 'Skill(garmin)' })
-  })
-
-  it('falls back to name field', () => {
-    const result = resolveAlwaysAllowRule('Skill', JSON.stringify({ name: 'home-assistant' }))
-    expect(result).toEqual({ rule: 'Skill(home-assistant)', label: 'Skill(home-assistant)' })
-  })
-
-  it('extracts skill name from path with SKILL.md', () => {
-    const result = resolveAlwaysAllowRule(
-      'Skill',
-      JSON.stringify({ path: 'skills/coolify/SKILL.md' }),
-    )
-    expect(result).toEqual({ rule: 'Skill(coolify)', label: 'Skill(coolify)' })
-  })
-
-  it('extracts skill name from a directory path', () => {
-    const result = resolveAlwaysAllowRule(
-      'Skill',
-      JSON.stringify({ skill_path: '/home/x/.switchroom/skills/mail' }),
-    )
-    expect(result).toEqual({ rule: 'Skill(mail)', label: 'Skill(mail)' })
+  it('follows the field fallback chain (skill_name / skillName / name / path)', () => {
+    for (const input of [
+      { skill_name: 'calendar' },
+      { skillName: 'calendar' },
+      { name: 'calendar' },
+    ]) {
+      expect(resolveScopedAllowChoices('Skill', JSON.stringify(input))?.specific?.rule).toBe(
+        'Skill(calendar)',
+      )
+    }
+    expect(
+      resolveScopedAllowChoices('Skill', JSON.stringify({ path: 'skills/coolify/SKILL.md' }))
+        ?.specific?.rule,
+    ).toBe('Skill(coolify)')
   })
 
   it('returns null when no skill identifier is present', () => {
-    expect(resolveAlwaysAllowRule('Skill', JSON.stringify({ unrelated: 'x' }))).toBeNull()
-    expect(resolveAlwaysAllowRule('Skill', undefined)).toBeNull()
-    expect(resolveAlwaysAllowRule('Skill', '')).toBeNull()
-    expect(resolveAlwaysAllowRule('Skill', 'not-json')).toBeNull()
+    expect(resolveScopedAllowChoices('Skill', JSON.stringify({ unrelated: 'x' }))).toBeNull()
+    expect(resolveScopedAllowChoices('Skill', undefined)).toBeNull()
+    expect(resolveScopedAllowChoices('Skill', 'not-json')).toBeNull()
   })
 
-  it('refuses skill names with characters that could break the rule grammar', () => {
-    // Parens, slashes, quotes, whitespace would break Claude Code's
-    // permission-rule parser or expand to unintended matches.
-    expect(resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'mail(secret)' }))).toBeNull()
-    expect(resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'mail/calendar' }))).toBeNull()
-    expect(resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'mail calendar' }))).toBeNull()
-    expect(resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'mail"calendar' }))).toBeNull()
+  it('refuses skill names with grammar-breaking characters', () => {
+    expect(resolveScopedAllowChoices('Skill', JSON.stringify({ skill: 'mail(secret)' }))).toBeNull()
+    expect(resolveScopedAllowChoices('Skill', JSON.stringify({ skill: 'mail/calendar' }))).toBeNull()
+    expect(resolveScopedAllowChoices('Skill', JSON.stringify({ skill: 'mail calendar' }))).toBeNull()
   })
 
   it('accepts the safe alphanumeric + ._-+ alphabet', () => {
-    expect(resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'home-assistant' }))).not.toBeNull()
-    expect(resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'home_assistant' }))).not.toBeNull()
-    expect(resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'docs.v2' }))).not.toBeNull()
-    expect(resolveAlwaysAllowRule('Skill', JSON.stringify({ skill: 'work+personal' }))).not.toBeNull()
+    for (const s of ['home-assistant', 'home_assistant', 'docs.v2', 'work+personal']) {
+      expect(resolveScopedAllowChoices('Skill', JSON.stringify({ skill: s }))).not.toBeNull()
+    }
   })
 })
 
-describe('resolveAlwaysAllowRule — built-in tools', () => {
-  it.each([
-    'Bash', 'Read', 'Write', 'Edit', 'MultiEdit', 'NotebookEdit',
-    'Glob', 'Grep', 'WebFetch', 'WebSearch',
-    'Task', 'Agent', 'TodoWrite', 'ExitPlanMode',
-  ])('returns the bare tool name for %s', (tool) => {
-    expect(resolveAlwaysAllowRule(tool, undefined)).toEqual({ rule: tool, label: tool })
+describe('resolveScopedAllowChoices — file tools', () => {
+  it('offers this-file (specific) + any-file (broad) when a path is present', () => {
+    const r = resolveScopedAllowChoices('Edit', JSON.stringify({ file_path: '/work/log.md' }))
+    expect(r).toEqual({
+      specific: { rule: 'Edit(/work/log.md)', buttonLabel: 'This file', broad: false },
+      broad: { rule: 'Edit', buttonLabel: 'Any file', broad: true },
+    })
   })
 
-  it('returns the bare name even when input_preview is present', () => {
-    // The button is for "trust this tool category" — fine-grained
-    // pattern rules (Bash(npm:*) etc.) are the operator's job to
-    // craft via the CLI.
-    const result = resolveAlwaysAllowRule(
-      'Bash',
-      JSON.stringify({ command: 'rm -rf /tmp/x' }),
+  it('falls back to broad-only when no path is present', () => {
+    const r = resolveScopedAllowChoices('Write', JSON.stringify({ unrelated: 'x' }))
+    expect(r).toEqual({ broad: { rule: 'Write', buttonLabel: 'Any file', broad: true } })
+  })
+
+  it('prefers notebook_path for NotebookEdit', () => {
+    const r = resolveScopedAllowChoices(
+      'NotebookEdit',
+      JSON.stringify({ notebook_path: '/work/a.ipynb' }),
     )
-    expect(result).toEqual({ rule: 'Bash', label: 'Bash' })
+    expect(r?.specific?.rule).toBe('NotebookEdit(/work/a.ipynb)')
+  })
+
+  it.each(['Edit', 'Write', 'MultiEdit', 'NotebookEdit', 'Read'])(
+    'treats %s as a file tool',
+    (tool) => {
+      const r = resolveScopedAllowChoices(tool, JSON.stringify({ file_path: '/x' }))
+      expect(r?.broad.rule).toBe(tool)
+    },
+  )
+})
+
+describe('resolveScopedAllowChoices — Bash', () => {
+  it('offers a command-family prefix (specific) + any-command (broad)', () => {
+    const r = resolveScopedAllowChoices('Bash', JSON.stringify({ command: 'npm run build' }))
+    expect(r).toEqual({
+      specific: { rule: 'Bash(npm:*)', buttonLabel: 'npm commands', broad: false },
+      broad: { rule: 'Bash', buttonLabel: 'Any command', broad: true },
+    })
+  })
+
+  it('falls back to broad-only when the first token is unsafe', () => {
+    const r = resolveScopedAllowChoices('Bash', JSON.stringify({ command: 'foo | bar' }))
+    // "foo" is a clean token, so this resolves; use a metacharacter-led command:
+    const r2 = resolveScopedAllowChoices('Bash', JSON.stringify({ command: '$(evil)' }))
+    expect(r?.specific?.rule).toBe('Bash(foo:*)')
+    expect(r2).toEqual({ broad: { rule: 'Bash', buttonLabel: 'Any command', broad: true } })
   })
 })
 
-describe('resolveAlwaysAllowRule — MCP tools', () => {
-  it('preserves the namespaced MCP tool name', () => {
-    expect(resolveAlwaysAllowRule('mcp__switchroom-telegram__reply', undefined))
-      .toEqual({ rule: 'mcp__switchroom-telegram__reply', label: 'mcp__switchroom-telegram__reply' })
+describe('resolveScopedAllowChoices — broad-only built-ins', () => {
+  it.each(['Glob', 'Grep', 'WebFetch', 'WebSearch', 'Task', 'Agent', 'TodoWrite', 'ExitPlanMode'])(
+    'offers a single "Always allow" broad grant for %s',
+    (tool) => {
+      expect(resolveScopedAllowChoices(tool, undefined)).toEqual({
+        broad: { rule: tool, buttonLabel: 'Always allow', broad: true },
+      })
+    },
+  )
+})
+
+describe('resolveScopedAllowChoices — MCP tools', () => {
+  it('offers this-action (specific) + all-server (broad)', () => {
+    const r = resolveScopedAllowChoices('mcp__perplexity__search', undefined)
+    expect(r).toEqual({
+      specific: { rule: 'mcp__perplexity__search', buttonLabel: 'This action', broad: false },
+      broad: { rule: 'mcp__perplexity__*', buttonLabel: 'All Perplexity', broad: true },
+    })
   })
 
-  it('accepts MCP server-only namespaces', () => {
-    expect(resolveAlwaysAllowRule('mcp__hindsight', undefined))
-      .toEqual({ rule: 'mcp__hindsight', label: 'mcp__hindsight' })
+  it('prettifies multi-word server slugs in the broad label', () => {
+    const r = resolveScopedAllowChoices('mcp__google-workspace__list_files', undefined)
+    expect(r?.broad).toEqual({
+      rule: 'mcp__google-workspace__*',
+      buttonLabel: 'All Google Workspace',
+      broad: true,
+    })
   })
 
-  it('refuses malformed mcp_ shapes (missing prefix structure)', () => {
-    expect(resolveAlwaysAllowRule('mcp_foo', undefined)).toBeNull()
-    expect(resolveAlwaysAllowRule('mcp__', undefined)).toBeNull()
+  it('offers a broad-only grant for a server-only namespace', () => {
+    expect(resolveScopedAllowChoices('mcp__hindsight', undefined)).toEqual({
+      broad: { rule: 'mcp__hindsight', buttonLabel: 'Always allow', broad: true },
+    })
+  })
+
+  it('refuses malformed mcp shapes', () => {
+    expect(resolveScopedAllowChoices('mcp_foo', undefined)).toBeNull()
+    expect(resolveScopedAllowChoices('mcp__', undefined)).toBeNull()
   })
 })
 
-describe('resolveAlwaysAllowRule — fallback', () => {
-  it('returns null for unknown tools', () => {
-    expect(resolveAlwaysAllowRule('UnknownTool', undefined)).toBeNull()
-    expect(resolveAlwaysAllowRule('', undefined)).toBeNull()
+describe('resolveScopedAllowChoices — fallback', () => {
+  it('returns null for unknown tools and empty input', () => {
+    expect(resolveScopedAllowChoices('UnknownTool', undefined)).toBeNull()
+    expect(resolveScopedAllowChoices('', undefined)).toBeNull()
+  })
+})
+
+describe('prettyMcpServer', () => {
+  it('title-cases and splits on - and _', () => {
+    expect(prettyMcpServer('perplexity')).toBe('Perplexity')
+    expect(prettyMcpServer('google-workspace')).toBe('Google Workspace')
+    expect(prettyMcpServer('agent_config')).toBe('Agent Config')
   })
 })
 
 describe('matchesAllowRule — bare tool names', () => {
-  // The whole point of #1138: a cached `Edit` rule covers every Edit
-  // call from the parent claude AND from sub-agents dispatched via the
-  // Task tool, no matter the file path.
   it('matches any invocation of the same tool', () => {
     expect(matchesAllowRule('Edit', 'Edit', undefined)).toBe(true)
-    expect(matchesAllowRule('Edit', 'Edit', JSON.stringify({ file_path: '/tmp/a' }))).toBe(true)
     expect(matchesAllowRule('Edit', 'Edit', JSON.stringify({ file_path: '/etc/passwd' }))).toBe(true)
   })
 
   it('does not bleed into other tools', () => {
     expect(matchesAllowRule('Edit', 'Write', undefined)).toBe(false)
-    expect(matchesAllowRule('Read', 'Edit', undefined)).toBe(false)
     expect(matchesAllowRule('Bash', 'BashOutput', undefined)).toBe(false)
   })
-
-  it.each(['Bash', 'Read', 'Write', 'MultiEdit', 'Glob', 'Grep', 'WebFetch', 'TodoWrite'])(
-    'roundtrips through resolve → match for %s',
-    (tool) => {
-      const resolved = resolveAlwaysAllowRule(tool, undefined)
-      expect(resolved).not.toBeNull()
-      expect(matchesAllowRule(resolved!.rule, tool, undefined)).toBe(true)
-    },
-  )
 })
 
-describe('matchesAllowRule — Skill(name)', () => {
-  it('matches only the specific skill', () => {
-    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ skill: 'mail' }))).toBe(true)
-    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ skill: 'calendar' }))).toBe(false)
+describe('matchesAllowRule — scoped file/Bash/Skill rules', () => {
+  it('matches a file rule only for that exact path', () => {
+    expect(matchesAllowRule('Edit(/work/log.md)', 'Edit', JSON.stringify({ file_path: '/work/log.md' }))).toBe(true)
+    expect(matchesAllowRule('Edit(/work/log.md)', 'Edit', JSON.stringify({ file_path: '/work/other.md' }))).toBe(false)
   })
 
-  it('uses the same field fallback chain as the resolver', () => {
-    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ skill_name: 'mail' }))).toBe(true)
-    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ skillName: 'mail' }))).toBe(true)
-    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ name: 'mail' }))).toBe(true)
-    expect(matchesAllowRule(
-      'Skill(coolify)',
-      'Skill',
-      JSON.stringify({ path: 'skills/coolify/SKILL.md' }),
-    )).toBe(true)
+  it('matches a Bash prefix rule by first command token', () => {
+    expect(matchesAllowRule('Bash(npm:*)', 'Bash', JSON.stringify({ command: 'npm run build' }))).toBe(true)
+    expect(matchesAllowRule('Bash(npm:*)', 'Bash', JSON.stringify({ command: 'git status' }))).toBe(false)
+  })
+
+  it('matches a Skill rule only for that skill', () => {
+    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ skill: 'mail' }))).toBe(true)
+    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ skill: 'calendar' }))).toBe(false)
   })
 
   it('does not match a different tool with the same arg', () => {
     expect(matchesAllowRule('Skill(mail)', 'Bash', JSON.stringify({ skill: 'mail' }))).toBe(false)
   })
-
-  it('returns false on malformed Skill input', () => {
-    expect(matchesAllowRule('Skill(mail)', 'Skill', undefined)).toBe(false)
-    expect(matchesAllowRule('Skill(mail)', 'Skill', 'not-json')).toBe(false)
-    expect(matchesAllowRule('Skill(mail)', 'Skill', JSON.stringify({ unrelated: 'x' }))).toBe(false)
-  })
 })
 
-describe('matchesAllowRule — MCP tools', () => {
+describe('matchesAllowRule — MCP', () => {
   it('matches the exact namespaced tool', () => {
-    expect(matchesAllowRule(
-      'mcp__switchroom-telegram__reply',
-      'mcp__switchroom-telegram__reply',
-      undefined,
-    )).toBe(true)
+    expect(matchesAllowRule('mcp__perplexity__search', 'mcp__perplexity__search', undefined)).toBe(true)
   })
 
-  it('does not match a different MCP tool on the same server', () => {
-    expect(matchesAllowRule(
-      'mcp__switchroom-telegram__reply',
-      'mcp__switchroom-telegram__stream_reply',
-      undefined,
-    )).toBe(false)
+  it('a server wildcard covers every tool on that server', () => {
+    expect(matchesAllowRule('mcp__perplexity__*', 'mcp__perplexity__search', undefined)).toBe(true)
+    expect(matchesAllowRule('mcp__perplexity__*', 'mcp__perplexity__ask', undefined)).toBe(true)
+    expect(matchesAllowRule('mcp__perplexity__*', 'mcp__other__search', undefined)).toBe(false)
+  })
+
+  it('an exact tool rule does not cover siblings on the same server', () => {
+    expect(matchesAllowRule('mcp__perplexity__search', 'mcp__perplexity__ask', undefined)).toBe(false)
   })
 })
 
@@ -196,5 +225,34 @@ describe('matchesAllowRule — defensive', () => {
   it('returns false for empty inputs', () => {
     expect(matchesAllowRule('', 'Edit', undefined)).toBe(false)
     expect(matchesAllowRule('Edit', '', undefined)).toBe(false)
+  })
+})
+
+describe('resolve → match roundtrip', () => {
+  it.each([
+    ['Skill', JSON.stringify({ skill: 'mail' })],
+    ['Edit', JSON.stringify({ file_path: '/work/log.md' })],
+    ['Bash', JSON.stringify({ command: 'npm run build' })],
+    ['mcp__perplexity__search', undefined],
+  ] as const)('specific rule from %s matches the originating request', (tool, input) => {
+    const choices = resolveScopedAllowChoices(tool, input)
+    const rule = (choices?.specific ?? choices?.broad)!.rule
+    expect(matchesAllowRule(rule, tool, input)).toBe(true)
+  })
+
+  it.each([
+    ['Edit', JSON.stringify({ file_path: '/work/log.md' })],
+    ['Bash', JSON.stringify({ command: 'npm run build' })],
+    ['mcp__perplexity__search', undefined],
+  ] as const)('broad rule from %s also matches the originating request', (tool, input) => {
+    const broad = resolveScopedAllowChoices(tool, input)!.broad
+    expect(matchesAllowRule(broad.rule, tool, input)).toBe(true)
+  })
+})
+
+describe('isRulePersisted', () => {
+  it('is a membership check against the resolved allow list', () => {
+    expect(isRulePersisted(['Edit', 'mcp__perplexity__*'], 'mcp__perplexity__*')).toBe(true)
+    expect(isRulePersisted(['Edit'], 'Write')).toBe(false)
   })
 })

--- a/telegram-plugin/tests/permission-title.test.ts
+++ b/telegram-plugin/tests/permission-title.test.ts
@@ -1,228 +1,111 @@
+/**
+ * Tests for the human-readable permission card text (#186, #1790, and
+ * the scoped-card work). Three surfaces:
+ *   - `naturalAction` — the verb-phrase after "wants to" (no tool ids).
+ *   - `formatPermissionCardBody` — the collapsed-view card body.
+ *   - `describeGrant` — the after-the-fact confirmation, phrased from
+ *     the *scope the operator chose*.
+ */
+
 import { describe, test, expect } from 'vitest'
-import { summarizeToolForTitle, formatPermissionCardBody } from '../permission-title.js'
+import {
+  naturalAction,
+  describeGrant,
+  formatPermissionCardBody,
+} from '../permission-title.js'
+import type { ScopeOption } from '../permission-rule.js'
 
-describe('summarizeToolForTitle (#186)', () => {
-  test('Skill: surfaces the skill name in brackets', () => {
-    const input = JSON.stringify({ skill: 'mail' })
-    expect(summarizeToolForTitle('Skill', input)).toBe('Skill (mail)')
+const opt = (rule: string): ScopeOption => ({ rule, buttonLabel: 'x', broad: false })
+
+describe('naturalAction — built-in tools', () => {
+  test('file tools surface the basename', () => {
+    const input = JSON.stringify({ file_path: '/a/b/server.ts' })
+    expect(naturalAction('Edit', input)).toBe('edit: server.ts')
+    expect(naturalAction('Write', input)).toBe('write: server.ts')
+    expect(naturalAction('Read', input)).toBe('read: server.ts')
   })
 
-  test('Bash: truncates long commands', () => {
-    const input = JSON.stringify({
-      command: 'find /var/log -name "*.log" -mtime -1 -exec gzip {} \\;',
-    })
-    const out = summarizeToolForTitle('Bash', input)
-    expect(out.startsWith('Bash: ')).toBe(true)
-    expect(out.length).toBeLessThanOrEqual(60)
-    expect(out.endsWith('…')).toBe(true)
+  test('file tools fall back to a generic phrase without a path', () => {
+    expect(naturalAction('Edit', undefined)).toBe('edit files')
+    expect(naturalAction('Write', JSON.stringify({ x: 1 }))).toBe('write files')
   })
 
-  test('Read/Edit/Write: shows basename only', () => {
-    const input = JSON.stringify({ file_path: '/long/absolute/path/to/server.ts' })
-    expect(summarizeToolForTitle('Read', input)).toBe('Read: server.ts')
-    expect(summarizeToolForTitle('Edit', input)).toBe('Edit: server.ts')
-    expect(summarizeToolForTitle('Write', input)).toBe('Write: server.ts')
+  test('Bash surfaces a truncated command', () => {
+    const out = naturalAction('Bash', JSON.stringify({ command: 'ls /tmp' }))
+    expect(out).toBe('run: ls /tmp')
   })
 
-  test('Glob/Grep: surfaces the pattern', () => {
-    const input = JSON.stringify({ pattern: '**/*.ts' })
-    expect(summarizeToolForTitle('Glob', input)).toBe('Glob: **/*.ts')
-    expect(summarizeToolForTitle('Grep', input)).toBe('Grep: **/*.ts')
+  test('Bash collapses whitespace and truncates long commands', () => {
+    const long = naturalAction(
+      'Bash',
+      JSON.stringify({ command: 'find /var/log -name "*.log" -mtime -1 -exec gzip {} \\;' }),
+    )
+    expect(long.startsWith('run: ')).toBe(true)
+    expect(long.endsWith('…')).toBe(true)
   })
 
-  test('WebFetch: surfaces the URL', () => {
-    const input = JSON.stringify({ url: 'https://example.com/some/page' })
-    expect(summarizeToolForTitle('WebFetch', input)).toBe(
-      'WebFetch: https://example.com/some/page',
+  test('Skill names the skill', () => {
+    expect(naturalAction('Skill', JSON.stringify({ skill: 'mail' }))).toBe('use the mail skill')
+    expect(naturalAction('Skill', undefined)).toBe('use a skill')
+  })
+
+  test('search / fetch tools surface their query or url', () => {
+    expect(naturalAction('Grep', JSON.stringify({ pattern: '**/*.ts' }))).toBe('search files for: **/*.ts')
+    expect(naturalAction('WebSearch', JSON.stringify({ query: 'tide times' }))).toBe('search the web for: tide times')
+    expect(naturalAction('WebFetch', JSON.stringify({ url: 'https://x.com' }))).toBe('fetch a web page: https://x.com')
+  })
+
+  test('agent-ish tools read as plain phrases', () => {
+    expect(naturalAction('Task', undefined)).toBe('dispatch a sub-agent')
+    expect(naturalAction('TodoWrite', undefined)).toBe('update its task list')
+    expect(naturalAction('ExitPlanMode', undefined)).toBe('exit plan mode')
+  })
+
+  test('unknown tool falls back to "use <name>"', () => {
+    expect(naturalAction('SomeCustomTool', undefined)).toBe('use SomeCustomTool')
+  })
+})
+
+describe('naturalAction — MCP tools', () => {
+  test('curated internal tool reads as a bare verb-phrase', () => {
+    expect(naturalAction('mcp__agent-config__skill_list', undefined)).toBe(
+      'list its own installed skills',
     )
   })
 
-  test('falls back to bare toolName for unrecognised tools', () => {
-    expect(summarizeToolForTitle('SomeCustomTool', JSON.stringify({ x: 1 }))).toBe(
-      'SomeCustomTool',
-    )
+  test('curated external tool gets a "(Server)" tag', () => {
+    expect(naturalAction('mcp__perplexity__search', undefined)).toBe('search the web (Perplexity)')
   })
 
-  test('falls back to bare toolName when input_preview is malformed', () => {
-    expect(summarizeToolForTitle('Skill', 'not-json')).toBe('Skill')
-    expect(summarizeToolForTitle('Skill', '')).toBe('Skill')
-    expect(summarizeToolForTitle('Skill', undefined)).toBe('Skill')
+  test('uncurated internal tool de-snakes the verb', () => {
+    expect(naturalAction('mcp__hostd__do_thing', undefined)).toBe('do thing')
   })
 
-  test('falls back to bare toolName for non-Skill tools when expected key is missing', () => {
-    const input = JSON.stringify({ unrelated: 'x' })
-    // Bash has no first-arg fallback (its only identifying field is command).
-    expect(summarizeToolForTitle('Bash', input)).toBe('Bash')
-  })
-
-  // #1790 — the prior contract was "fall back to bare toolName when no
-  // skill-name key matched"; that produced operator-hostile cards like
-  // `🔐 Permission: Skill` with zero context. The Skill summarizer now
-  // tries `command`, then a first-scalar-arg hint, before giving up.
-  test('Skill: when no skill-name key matches, falls back to command field (#1790)', () => {
-    const input = JSON.stringify({ command: 'gen calendar event' })
-    expect(summarizeToolForTitle('Skill', input)).toBe('Skill: gen calendar event')
-  })
-
-  test('Skill: when no skill-name and no command, surfaces the first scalar arg (#1790)', () => {
-    const input = JSON.stringify({ unrelated: 'x' })
-    expect(summarizeToolForTitle('Skill', input)).toBe('Skill (unrelated: x)')
-  })
-
-  test('Skill: skips routing-only keys when surfacing first scalar arg (#1790)', () => {
-    // chat_id / message_thread_id / request_id never help an operator
-    // decide; the helper skips them and finds the next useful field.
-    const input = JSON.stringify({
-      chat_id: '12345',
-      message_thread_id: '42',
-      topic: 'morning summary',
-    })
-    expect(summarizeToolForTitle('Skill', input)).toBe('Skill (topic: morning summary)')
-  })
-
-  test('Bash: collapses internal whitespace before truncating', () => {
-    const input = JSON.stringify({
-      command: 'echo  \t  hello\nworld',
-    })
-    expect(summarizeToolForTitle('Bash', input)).toBe('Bash: echo hello world')
-  })
-
-  test('NotebookEdit: prefers notebook_path when file_path absent', () => {
-    const input = JSON.stringify({ notebook_path: '/work/analysis.ipynb' })
-    expect(summarizeToolForTitle('NotebookEdit', input)).toBe(
-      'NotebookEdit: analysis.ipynb',
-    )
-  })
-
-  // Skill-name fallbacks — the user reported a `🔐 Permission: Skill`
-  // popup with no brackets. Pre-fix only `input.skill` was checked;
-  // these tests pin the wider field set so the skill name lands in
-  // brackets even when Claude Code passes the input in a different
-  // shape.
-  test('Skill: falls back to skill_name field', () => {
-    const input = JSON.stringify({ skill_name: 'calendar' })
-    expect(summarizeToolForTitle('Skill', input)).toBe('Skill (calendar)')
-  })
-
-  test('Skill: falls back to skillName field', () => {
-    const input = JSON.stringify({ skillName: 'garmin' })
-    expect(summarizeToolForTitle('Skill', input)).toBe('Skill (garmin)')
-  })
-
-  test('Skill: falls back to bare name field', () => {
-    const input = JSON.stringify({ name: 'home-assistant' })
-    expect(summarizeToolForTitle('Skill', input)).toBe('Skill (home-assistant)')
-  })
-
-  test('Skill: lifts basename out of a path field', () => {
-    const input = JSON.stringify({ path: 'skills/coolify/SKILL.md' })
-    expect(summarizeToolForTitle('Skill', input)).toBe('Skill (coolify)')
-  })
-
-  test('Skill: lifts basename out of a skill_path directory', () => {
-    const input = JSON.stringify({ skill_path: '/x/.switchroom/skills/mail' })
-    expect(summarizeToolForTitle('Skill', input)).toBe('Skill (mail)')
-  })
-
-  test('Skill: original `skill` field still wins when multiple are present', () => {
-    const input = JSON.stringify({ skill: 'mail', name: 'wrong' })
-    expect(summarizeToolForTitle('Skill', input)).toBe('Skill (mail)')
-  })
-
-  test('MCP curated: agent-config tools render as human verb-phrases (#1215)', () => {
-    expect(summarizeToolForTitle('mcp__agent-config__skill_list', undefined)).toBe(
-      'List its own installed skills',
-    )
-    expect(summarizeToolForTitle('mcp__agent-config__cron_list', undefined)).toBe(
-      'List its own scheduled tasks',
-    )
-    expect(summarizeToolForTitle('mcp__agent-config__peers_list', undefined)).toBe(
-      'List the other agents on this instance',
-    )
-  })
-
-  test('MCP curated: hostd tools render as human verb-phrases (#1215)', () => {
-    expect(summarizeToolForTitle('mcp__hostd__agent_logs', undefined)).toBe(
-      "Read another agent's container logs",
-    )
-    expect(summarizeToolForTitle('mcp__hostd__agent_exec', undefined)).toBe(
-      'Run a read-only inspection inside another agent',
-    )
-  })
-
-  test('MCP fallback: unknown mcp tool renders as `<server>: <verb with spaces>`', () => {
-    expect(summarizeToolForTitle('mcp__some-server__do_thing', undefined)).toBe(
-      'some-server: do thing',
-    )
-  })
-
-  test('MCP malformed: bare mcp__ prefix without __<server>__<verb> shape is left alone', () => {
-    expect(summarizeToolForTitle('mcp__bad', undefined)).toBe('mcp__bad')
-  })
-
-  // #1790 — append a `(key: value)` hint when an MCP tool's preview
-  // carries a scalar arg. Gives operators context on curated and
-  // uncurated MCP tools alike without an expand tap.
-  test('MCP curated tool appends first-arg hint when input_preview present (#1790)', () => {
-    const input = JSON.stringify({ key: 'coolify/api-token' })
-    expect(summarizeToolForTitle('mcp__agent-config__config_get', input)).toBe(
-      'Read its own merged config (key: coolify/api-token)',
-    )
-  })
-
-  test('MCP uncurated tool appends first-arg hint (#1790)', () => {
-    const input = JSON.stringify({ folder_id: 'abc123' })
-    expect(summarizeToolForTitle('mcp__google-workspace__list_files', input)).toBe(
-      'google-workspace: list files (folder_id: abc123)',
-    )
-  })
-
-  test('MCP arg hint skips routing-only keys (#1790)', () => {
-    const input = JSON.stringify({ chat_id: '12345', query: 'budget Q3' })
-    expect(summarizeToolForTitle('mcp__hindsight__recall', input)).toBe(
-      'Recall relevant memories (query: budget Q3)',
+  test('uncurated external tool de-snakes and tags the server', () => {
+    expect(naturalAction('mcp__google-workspace__list_files', undefined)).toBe(
+      'list files (Google Workspace)',
     )
   })
 })
 
-// ──────────────────────────────────────────────────────────────────────
-// #1790 — formatPermissionCardBody: multi-line collapsed-view body
-// for approval cards. Mirrors the vault_request_access card layout.
-// ──────────────────────────────────────────────────────────────────────
-
-describe('formatPermissionCardBody (#1790)', () => {
-  test('renders agent · summary, then a why-line, when both are present', () => {
+describe('formatPermissionCardBody', () => {
+  test('renders "<Agent> wants to <action>" + why line', () => {
     const body = formatPermissionCardBody({
-      toolName: 'Skill',
-      inputPreview: JSON.stringify({ skill: 'mail' }),
-      description: 'Compose the morning brief',
-      agentName: 'clerk',
-    })
-    expect(body).toBe(
-      [
-        '🔐 <b>clerk</b> · Skill (mail)',
-        'why: <i>Compose the morning brief</i>',
-      ].join('\n'),
-    )
-  })
-
-  test('renders "why: <i>not provided</i>" when description is missing', () => {
-    const body = formatPermissionCardBody({
-      toolName: 'Bash',
-      inputPreview: JSON.stringify({ command: 'ls /tmp' }),
-      description: undefined,
+      toolName: 'Edit',
+      inputPreview: JSON.stringify({ file_path: '/work/supplement-log.md' }),
+      description: 'logging today\'s lifts',
       agentName: 'gymbro',
     })
     expect(body).toBe(
-      ['🔐 <b>gymbro</b> · Bash: ls /tmp', 'why: <i>not provided</i>'].join('\n'),
+      ['🔐 <b>Gymbro</b> wants to edit: supplement-log.md', 'why: <i>logging today\'s lifts</i>'].join('\n'),
     )
   })
 
-  test('renders "not provided" when description is whitespace-only', () => {
+  test('shows "not provided" when description is missing or whitespace', () => {
     const body = formatPermissionCardBody({
       toolName: 'Bash',
       inputPreview: JSON.stringify({ command: 'ls /tmp' }),
-      description: '   \n  ',
+      description: '   \n ',
       agentName: 'gymbro',
     })
     expect(body).toContain('why: <i>not provided</i>')
@@ -235,10 +118,10 @@ describe('formatPermissionCardBody (#1790)', () => {
       description: 'do the thing',
       agentName: null,
     })
-    expect(body).toBe(['🔐 Skill (mail)', 'why: <i>do the thing</i>'].join('\n'))
+    expect(body).toBe(['🔐 Use the mail skill', 'why: <i>do the thing</i>'].join('\n'))
   })
 
-  test('HTML-escapes < > & in agentName / summary / description', () => {
+  test('HTML-escapes <, >, & in agentName / action / description', () => {
     const body = formatPermissionCardBody({
       toolName: 'Bash',
       inputPreview: JSON.stringify({ command: 'echo "a < b && c > d"' }),
@@ -248,28 +131,22 @@ describe('formatPermissionCardBody (#1790)', () => {
     expect(body).toContain('&lt;test&gt;')
     expect(body).toContain('&amp;')
     expect(body).not.toContain('<test>')
-    // The literal "<i>not provided</i>" and "<b>...</b>" wrapping tags
-    // around legitimate fields must survive untouched — only the
-    // user-supplied content is escaped.
     expect(body).toContain('<b>')
     expect(body).toContain('<i>')
   })
 
   test('truncates a very long description with an ellipsis', () => {
-    const longWhy = 'x'.repeat(500)
     const body = formatPermissionCardBody({
       toolName: 'Skill',
       inputPreview: JSON.stringify({ skill: 'mail' }),
-      description: longWhy,
+      description: 'x'.repeat(500),
       agentName: 'clerk',
     })
-    // 240-char ceiling + trailing ellipsis
     expect(body).toContain('xxxx…</i>')
-    // First line still intact
-    expect(body.split('\n')[0]).toBe('🔐 <b>clerk</b> · Skill (mail)')
+    expect(body.split('\n')[0]).toBe('🔐 <b>Clerk</b> wants to use the mail skill')
   })
 
-  test('collapses internal whitespace in description so the layout stays one-line', () => {
+  test('collapses internal whitespace in the description', () => {
     const body = formatPermissionCardBody({
       toolName: 'Skill',
       inputPreview: JSON.stringify({ skill: 'mail' }),
@@ -277,5 +154,42 @@ describe('formatPermissionCardBody (#1790)', () => {
       agentName: 'clerk',
     })
     expect(body).toContain('why: <i>first second paragraph</i>')
+  })
+})
+
+describe('describeGrant — phrased from the chosen scope', () => {
+  test('MCP server wildcard → "use any <Server> tool"', () => {
+    expect(describeGrant('mcp__perplexity__search', undefined, opt('mcp__perplexity__*'))).toBe(
+      'use any Perplexity tool',
+    )
+  })
+
+  test('scoped file rule → "edit <basename>"', () => {
+    expect(describeGrant('Edit', undefined, opt('Edit(/work/supplement-log.md)'))).toBe(
+      'edit supplement-log.md',
+    )
+    expect(describeGrant('Read', undefined, opt('Read(/a/b/notes.md)'))).toBe('read notes.md')
+  })
+
+  test('scoped Bash rule → "run <tok> commands"', () => {
+    expect(describeGrant('Bash', undefined, opt('Bash(npm:*)'))).toBe('run npm commands')
+  })
+
+  test('scoped Skill rule → "use the <name> skill"', () => {
+    expect(describeGrant('Skill', undefined, opt('Skill(mail)'))).toBe('use the mail skill')
+  })
+
+  test('bare category rules read as "any" grants', () => {
+    expect(describeGrant('Edit', undefined, opt('Edit'))).toBe('edit any file')
+    expect(describeGrant('Write', undefined, opt('Write'))).toBe('write any file')
+    expect(describeGrant('Read', undefined, opt('Read'))).toBe('read any file')
+    expect(describeGrant('Bash', undefined, opt('Bash'))).toBe('run any command')
+    expect(describeGrant('Skill', undefined, opt('Skill'))).toBe('use any skill')
+  })
+
+  test('exact MCP tool grant falls back to the natural action', () => {
+    expect(describeGrant('mcp__perplexity__search', undefined, opt('mcp__perplexity__search'))).toBe(
+      'search the web (Perplexity)',
+    )
   })
 })


### PR DESCRIPTION
## Summary

Replaces the operator-hostile Telegram permission card with a plain-language one, and makes **"always allow" express its grant scope explicitly** before the operator commits it. PR2 of the approval-system fix (PR1 = #1994, durable persistence for every agent).

The card body now reads as a sentence — `🔐 Gymbro wants to edit: supplement-log.md` + a `why:` line — instead of a raw tool id like `mcp__perplexity__search`. A non-technical operator can read it at a glance.

**Compact action row:** `❌ Deny · ✅ Allow once · 🔁 Always…`

Tapping **🔁 Always…** swaps the row for a scope choice — `← Back · This file · Any file ⚠️` — so the breadth of an always-grant is legible **before** the operator taps it (vision pillar #2, *you hold the leash*). The ⚠️ rides on the broadest option only; scope stays hidden until "Always…" is tapped.

After a grant lands, the confirmation is phrased from the **chosen scope**: "gymbro can now edit supplement-log.md without asking" / "…use any Perplexity tool…".

## Why

- **JTBD:** the permission card is the operator's control surface; raw `mcp__server__tool` ids and an undifferentiated "always allow" failed the *docs test* (can't use it without explaining the rule grammar) and obscured how much authority an "always" tap actually granted.
- Vision pillar #2 (controlled, legible, trustworthy) requires the **scope** of an always-grant to be visible before it's committed, not just after.

## What changed

- **`permission-rule.ts`** — `resolveScopedAllowChoices(tool, input)` returns up to two `ScopeOption`s (narrow `specific` + whole-category `broad`) per tool. `matchesAllowRule` extended to cover scoped `Edit(path)` / `Bash(tok:*)` / `Skill(name)` rules and `mcp__server__*` wildcards, so the session-scoped allow cache (#1138) keeps short-circuiting prompts for sub-agents under the new rule forms.
- **`permission-title.ts`** — `naturalAction` (verb-phrase after "wants to"), `formatPermissionCardBody`, and `describeGrant` (after-the-fact confirmation from the chosen scope). Curated human verb-phrases for switchroom MCP tools; external servers get a `(Server)` tag.
- **`gateway.ts`** — two-step "always" flow: `always`/`back` only toggles the keyboard (no verdict, no host round-trip); the verdict + durable hostd `config_propose_edit` fire on the scope button (`asn`/`asb`). The in-flight Allow verdict still dispatches immediately so the turn never blocks on persistence. Removed the old "See more" expansion (detail is inline now).

## Test plan

- [x] `permission-rule.test.ts` rewritten for `resolveScopedAllowChoices` + extended `matchesAllowRule` (47 tests)
- [x] `permission-title.test.ts` rewritten for `naturalAction` / `formatPermissionCardBody` / `describeGrant` (24 tests)
- [x] `always-allow-grant.test.ts` re-sliced for the split toggle/commit handler (18 tests)
- [x] `always-allow-persist.test.ts` round-trip updated to the scoped resolver (13 tests)
- [x] `always-allow-correlation.test.ts` + `permission-diff.test.ts` + `approval-card.test.ts` still green (128 total)
- [x] `tsc --noEmit` clean
- [x] `scripts/check-bot-api-wrapping.sh` clean
- [x] `scripts/check-plugin-references.mjs` clean
- [ ] UAT: operator taps Always… → scope choice → confirm rule persists across restart (manual, pre-rollout)

## Risk

Touches the live operator control surface. Callback grammar changed (`perm:more` removed; `perm:asn|asb|back` added) — old in-flight cards posted before deploy would have stale buttons until the next request, which is acceptable. Persistence path (PR1 / #1977 / hostd) is unchanged structurally; only the rule string it carries is now scope-aware.

Depends on / pairs with #1994 (every-agent durable persistence).