### PR TITLE
fix(scaffold): export SWITCHROOM_HANDOFF_SHOW_LINE before the gateway fork

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -26,6 +26,21 @@
 # `src/agents/lifecycle.ts:attachAgent` expect — the contract is the
 # same one v0.6 systemd has always honored, just enforced inside the
 # container instead of by the host's user systemd manager.
+
+{{#if handoffEnabled}}
+# The telegram-plugin gateway reads SWITCHROOM_HANDOFF_SHOW_LINE to
+# decide whether to prepend the visible "↩️ Picked up where we left
+# off …" line on the first reply after a restart. It MUST be exported
+# *before* the gateway is forked in the docker preamble below (and
+# before the tmux re-exec), otherwise the gateway — the sole consumer —
+# never inherits it and session_continuity.show_handoff_line:false
+# silently no-ops on every docker agent. Living here, ahead of the
+# runtime branch, covers docker (both the outer fork pass and the inner
+# tmux pass) and the v0.6 non-docker path in one place. Gated on
+# handoffEnabled so a handoff-disabled agent emits no handoff env at all.
+export SWITCHROOM_HANDOFF_SHOW_LINE={{#if handoffShowLine}}true{{else}}false{{/if}}
+{{/if}}
+
 if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" ]; then
   # Hoist TELEGRAM_STATE_DIR up here so the gateway daemon (forked
   # below) finds gateway.sock / gateway.pid.json / history.db at the
@@ -510,9 +525,8 @@ if [ ! -s "$HANDOFF_FILE" ]; then
     timeout 5 handoff-briefing.sh 2>/dev/null || true
   fi
 fi
-# Telegram plugin reads this to decide whether to prepend the visible
-# "↩️ Picked up where we left off — <topic>" line on the first reply.
-export SWITCHROOM_HANDOFF_SHOW_LINE={{#if handoffShowLine}}true{{else}}false{{/if}}
+# SWITCHROOM_HANDOFF_SHOW_LINE is exported near the top of this script
+# (ahead of the docker preamble) so the gateway sidecar inherits it.
 APPEND_PROMPT={{#if systemPromptAppendShellQuoted}}{{{systemPromptAppendShellQuoted}}}{{else}}""{{/if}}
 # Inject .handoff-briefing.md first (assembled from live sources), then
 # .handoff.md (raw transcript tail from the Stop hook). If both

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1218,6 +1218,38 @@ describe("scaffoldAgent — docker-mode tmux supervisor preamble (v0.7.5)", () =
     expect(gatewayForkIdx).toBeGreaterThan(stateDirIdx);
   });
 
+  it("exports SWITCHROOM_HANDOFF_SHOW_LINE before the gateway fork so the sidecar inherits it", () => {
+    // The gateway is the SOLE consumer of SWITCHROOM_HANDOFF_SHOW_LINE
+    // — it decides whether to prepend the visible "↩️ Picked up where
+    // we left off …" line on the first reply after a restart. The
+    // gateway is forked in the docker preamble, so the export MUST
+    // precede that fork. Before this fix the export lived in the inner
+    // tmux pass (after the fork), so the gateway never inherited it and
+    // session_continuity.show_handoff_line:false silently no-oped on
+    // every docker agent.
+    const config = makeAgentConfig({
+      topic_id: 1,
+      session_continuity: { show_handoff_line: false },
+    });
+    const result = scaffoldAgent("hilda", config, tmpDir, telegramConfig);
+    const startSh = readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+    expect(startSh).toContain("SWITCHROOM_HANDOFF_SHOW_LINE=false");
+    const lines = startSh.split("\n");
+    const exportIdx = lines.findIndex((l) =>
+      l.includes("export SWITCHROOM_HANDOFF_SHOW_LINE="),
+    );
+    const gatewayForkIdx = lines.findIndex((l) =>
+      l.includes("_switchroom_supervise gateway"),
+    );
+    expect(exportIdx).toBeGreaterThan(0);
+    expect(gatewayForkIdx).toBeGreaterThan(exportIdx);
+    // Exactly one export — no stale late-pass duplicate left behind.
+    const exportCount = lines.filter((l) =>
+      l.includes("export SWITCHROOM_HANDOFF_SHOW_LINE="),
+    ).length;
+    expect(exportCount).toBe(1);
+  });
+
   it("supervisor backs off exponentially and never permanently gives up (RFC J Phase 2)", () => {
     // The old "10 restarts in 60s -> give up forever" turned a
     // routine broker recreate (which relocks the dockerized broker)


### PR DESCRIPTION
## Summary
- `SWITCHROOM_HANDOFF_SHOW_LINE` is read **only** by the telegram-plugin gateway (it gates the visible `↩️ Picked up where we left off …` line on the first reply after a restart).
- In the docker preamble the gateway is forked in the **outer** pass, *before* the `exec tmux` re-entry. The export lived in the inner-pass section **after** that fork, so the gateway never inherited it.
- Net effect: `session_continuity.show_handoff_line: false` has been a **silent no-op on every docker agent** since v0.7. Verified live — the running gateway's `/proc/<pid>/environ` had no such var even with the flag set.

## Fix
- Move the export ahead of the `if docker …` runtime branch (still gated on `handoffEnabled`) so it covers the docker outer fork pass, the inner tmux pass, and the v0.6 non-docker path in one place.
- Mirrors the existing `TELEGRAM_STATE_DIR` hoist (line ~33), which solved the identical fork-ordering problem for the gateway.
- Removes the now-redundant late export.

## Why (JTBD)
Serves **you-hold-the-leash** / config-honesty: a documented config field that silently does nothing erodes trust in the cascade. The flag now actually suppresses the banner where set (e.g. an autonomous webhook-driven review bot, where the handoff line is pure noise).

## Test plan
- [x] New regression test: rendered start.sh exports `SWITCHROOM_HANDOFF_SHOW_LINE` **before** the gateway fork, and exactly once.
- [x] Existing assertions preserved (`=true` default present; absent when handoff disabled).
- [x] `vitest run tests/scaffold.test.ts` → 179 passed.
- [x] `tsc --noEmit` clean.
- [x] `scaffold.regenerate-start-sh` + `lifecycle.docker` green.

## Risk
Low. Single env-export relocation in a template; gating unchanged; no runtime-behavior change other than the gateway now seeing the var it was always meant to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)