### PR TITLE
fix(telegram): hold 👍 reaction until background workers finish

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1096,6 +1096,18 @@ if (!STATIC) setInterval(checkApprovals, 5000).unref()
 const chatThreadMap = new Map<string, number>()
 const activeStatusReactions = new Map<string, StatusReactionController>()
 const activeReactionMsgIds = new Map<string, { chatId: string; messageId: number }>()
+// Reactions whose terminal 👍 is deferred because a background sub-agent
+// worker was still running when the parent's `turn_end` fired. Painting 👍
+// then would read as "done / nothing happening" while the worker keeps
+// going. The controller is `hold()`-frozen on a working glyph; the entry
+// is promoted to 👍 by `promoteDeferredDoneReactions` when the watcher's
+// `onFinish` reports the last worker complete. Keyed by statusKey; the
+// stored controller instance guards against a newer turn superseding the
+// held one (promote no-ops if `activeStatusReactions[key] !== ctrl`).
+const deferredDoneReactions = new Map<
+  string,
+  { chatId: string; threadId: number | undefined; ctrl: StatusReactionController }
+>()
 
 // #546 — outbound content-dedup window. PR #599 introduced the four read
 // sites (`outboundDedup.check` / `.record` in executeReply, executeStreamReply,
@@ -1898,8 +1910,61 @@ function finalizeStatusReaction(
   const key = statusKey(chatId, threadId)
   const ctrl = activeStatusReactions.get(key)
   if (!ctrl) return
+  // Don't paint the terminal 👍 while a background sub-agent worker is
+  // still running — it reads as "done / nothing happening" even though
+  // the text said work continues. Hold the working glyph (✍️/⚡) and
+  // defer the terminal until the last worker finishes
+  // (`promoteDeferredDoneReactions`, fired from the watcher's onFinish).
+  // Errors are terminal regardless: a failed/aborted turn shouldn't wait
+  // on a worker.
+  if (reason === 'done' && countRunningWorkers() > 0) {
+    ctrl.hold()
+    deferredDoneReactions.set(key, { chatId, threadId, ctrl })
+    // Race guard: a worker may have transitioned to done between the
+    // count above and this registration, having already fired onFinish
+    // before the deferred entry existed. Re-check and promote now so the
+    // held reaction can't hang on a 👍 that will never come.
+    if (countRunningWorkers() === 0) promoteDeferredDoneReactions()
+    return
+  }
+  deferredDoneReactions.delete(key)
   ctrl.finalize(reason)
   purgeReactionTracking(key)
+}
+
+/**
+ * Count sub-agent workers currently running (excludes historical
+ * boot-leftover entries and any already-terminal worker). The registry
+ * deletes terminal entries after a short grace, so a worker that has
+ * fired its `done`/`failed` onFinish no longer counts here.
+ */
+function countRunningWorkers(): number {
+  const reg = subagentWatcher?.getRegistry()
+  if (reg == null) return 0
+  let n = 0
+  for (const e of reg.values()) {
+    if (e.state === 'running' && !e.historical) n++
+  }
+  return n
+}
+
+/**
+ * Promote any deferred-done reactions to the terminal 👍 once no workers
+ * remain running. Called from the watcher's `onFinish`. Instance-guarded:
+ * if a newer turn replaced the held controller for that key, the deferred
+ * entry is simply dropped (the new turn owns the reaction now).
+ */
+function promoteDeferredDoneReactions(): void {
+  if (deferredDoneReactions.size === 0) return
+  if (countRunningWorkers() > 0) return
+  for (const [key, { ctrl }] of deferredDoneReactions) {
+    const live = activeStatusReactions.get(key)
+    if (live != null && live === ctrl) {
+      live.finalize('done')
+      purgeReactionTracking(key)
+    }
+  }
+  deferredDoneReactions.clear()
 }
 
 /**
@@ -17312,6 +17377,13 @@ void (async () => {
               // need nothing here, and 'orphan' is a stale historical-at-
               // boot row, not a fresh completion the user is waiting on.
               onFinish: ({ agentId, outcome, description, resultText }) => {
+                // Reaction promotion: if the parent turn already ended
+                // with this (or another) worker still running, its 👍 was
+                // deferred (held on ✍️/⚡). Now that a worker finished,
+                // promote to 👍 iff none remain running. Independent of the
+                // handback gating below, so it must run before any early
+                // return. Cheap no-op when nothing is deferred.
+                promoteDeferredDoneReactions()
                 // IO: resolve the fleet chat id and the background flag.
                 // The DECISION (gating + inbound build) is delegated to
                 // the pure `decideSubagentHandback` so it is unit-tested

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -52,6 +52,7 @@ import {
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import { createInboundCoalescer, inboundCoalesceKey } from './inbound-coalesce.js'
 import { StatusReactionController } from '../status-reactions.js'
+import { DeferredDoneReactions } from '../reaction-defer.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel } from '../tool-activity-summary.js'
 import { toolLabel } from '../tool-labels.js'
@@ -1100,14 +1101,14 @@ const activeReactionMsgIds = new Map<string, { chatId: string; messageId: number
 // worker was still running when the parent's `turn_end` fired. Painting 👍
 // then would read as "done / nothing happening" while the worker keeps
 // going. The controller is `hold()`-frozen on a working glyph; the entry
-// is promoted to 👍 by `promoteDeferredDoneReactions` when the watcher's
-// `onFinish` reports the last worker complete. Keyed by statusKey; the
-// stored controller instance guards against a newer turn superseding the
-// held one (promote no-ops if `activeStatusReactions[key] !== ctrl`).
-const deferredDoneReactions = new Map<
-  string,
-  { chatId: string; threadId: number | undefined; ctrl: StatusReactionController }
->()
+// is promoted to 👍 by `deferredDoneReactions.promote()` (wired to the
+// watcher's `onFinish`) when the last worker completes. See
+// `reaction-defer.ts` for the promote/purge interaction the unit tests pin.
+const deferredDoneReactions = new DeferredDoneReactions<StatusReactionController>({
+  countRunningWorkers: () => countRunningWorkers(),
+  getActive: (key) => activeStatusReactions.get(key),
+  purge: (key) => purgeReactionTracking(key),
+})
 
 // #546 — outbound content-dedup window. PR #599 introduced the four read
 // sites (`outboundDedup.check` / `.record` in executeReply, executeStreamReply,
@@ -1912,22 +1913,12 @@ function finalizeStatusReaction(
   if (!ctrl) return
   // Don't paint the terminal 👍 while a background sub-agent worker is
   // still running — it reads as "done / nothing happening" even though
-  // the text said work continues. Hold the working glyph (✍️/⚡) and
-  // defer the terminal until the last worker finishes
-  // (`promoteDeferredDoneReactions`, fired from the watcher's onFinish).
-  // Errors are terminal regardless: a failed/aborted turn shouldn't wait
-  // on a worker.
-  if (reason === 'done' && countRunningWorkers() > 0) {
-    ctrl.hold()
-    deferredDoneReactions.set(key, { chatId, threadId, ctrl })
-    // Race guard: a worker may have transitioned to done between the
-    // count above and this registration, having already fired onFinish
-    // before the deferred entry existed. Re-check and promote now so the
-    // held reaction can't hang on a 👍 that will never come.
-    if (countRunningWorkers() === 0) promoteDeferredDoneReactions()
-    return
-  }
-  deferredDoneReactions.delete(key)
+  // the text said work continues. `tryDefer` holds the working glyph
+  // (✍️/⚡) and registers the controller; the watcher's onFinish promotes
+  // it to 👍 once the last worker completes. Errors are terminal
+  // regardless: a failed/aborted turn shouldn't wait on a worker.
+  if (reason === 'done' && deferredDoneReactions.tryDefer(key, ctrl)) return
+  deferredDoneReactions.drop(key)
   ctrl.finalize(reason)
   purgeReactionTracking(key)
 }
@@ -1946,25 +1937,6 @@ function countRunningWorkers(): number {
     if (e.state === 'running' && !e.historical) n++
   }
   return n
-}
-
-/**
- * Promote any deferred-done reactions to the terminal 👍 once no workers
- * remain running. Called from the watcher's `onFinish`. Instance-guarded:
- * if a newer turn replaced the held controller for that key, the deferred
- * entry is simply dropped (the new turn owns the reaction now).
- */
-function promoteDeferredDoneReactions(): void {
-  if (deferredDoneReactions.size === 0) return
-  if (countRunningWorkers() > 0) return
-  for (const [key, { ctrl }] of deferredDoneReactions) {
-    const live = activeStatusReactions.get(key)
-    if (live != null && live === ctrl) {
-      live.finalize('done')
-      purgeReactionTracking(key)
-    }
-  }
-  deferredDoneReactions.clear()
 }
 
 /**
@@ -17383,7 +17355,7 @@ void (async () => {
                 // promote to 👍 iff none remain running. Independent of the
                 // handback gating below, so it must run before any early
                 // return. Cheap no-op when nothing is deferred.
-                promoteDeferredDoneReactions()
+                deferredDoneReactions.promote()
                 // IO: resolve the fleet chat id and the background flag.
                 // The DECISION (gating + inbound build) is delegated to
                 // the pure `decideSubagentHandback` so it is unit-tested

--- a/telegram-plugin/reaction-defer.ts
+++ b/telegram-plugin/reaction-defer.ts
@@ -1,0 +1,98 @@
+/**
+ * Deferred terminal-reaction bookkeeping for the "hold 👍 until background
+ * sub-agent workers finish" behaviour.
+ *
+ * The status reaction on a user's inbound message reflects CURRENT TURN
+ * ACTIVITY (see `status-reactions.ts`). When a turn dispatches a background
+ * worker (Agent/Task) and then ends, the parent's `turn_end` would paint
+ * the terminal 👍 immediately — reading as "done / nothing happening" even
+ * though the worker keeps running and the model's own text said work is
+ * ongoing. This helper holds the working glyph and defers the terminal 👍
+ * until the sub-agent watcher reports the last worker complete.
+ *
+ * Extracted as a pure, dependency-injected unit so the gateway-side
+ * interaction that bit us in review — `finalizeStatusReaction` defers, then
+ * `endCurrentTurnAtomic` purges the controller out of `activeStatusReactions`
+ * in the SAME `turn_end` sequence — is directly testable. The fix: promotion
+ * finalizes off the STORED controller reference (its emit closure still binds
+ * the right message id), not a re-lookup that the purge has already emptied.
+ */
+
+/** Minimal controller surface this helper drives. */
+export interface HoldableController {
+  /** Freeze on a working glyph, suppress stall promotion, stay non-terminal. */
+  hold(): void
+  /** Terminate to 👍 (done) / 😱 (error). Idempotent once finished. */
+  finalize(reason?: 'done' | 'error'): void
+}
+
+export interface DeferredDoneDeps<C extends HoldableController> {
+  /** Count of sub-agent workers still running (excludes historical/terminal). */
+  countRunningWorkers(): number
+  /** Current live controller registered for `key`, if any. */
+  getActive(key: string): C | undefined
+  /** Canonical turn-end cleanup for `key` (drops reaction/typing/etc state). */
+  purge(key: string): void
+}
+
+export class DeferredDoneReactions<C extends HoldableController> {
+  private readonly map = new Map<string, { ctrl: C }>()
+
+  constructor(private readonly deps: DeferredDoneDeps<C>) {}
+
+  /**
+   * Attempt to defer a terminal 'done' for `key`/`ctrl`. Returns true when
+   * deferred (the caller must NOT finalize or purge — the held controller
+   * owns the reaction until {@link promote}). Returns false when there is no
+   * running worker, in which case the caller finalizes normally.
+   */
+  tryDefer(key: string, ctrl: C): boolean {
+    if (this.deps.countRunningWorkers() > 0) {
+      ctrl.hold()
+      this.map.set(key, { ctrl })
+      // Race guard: a worker may have transitioned to done between the count
+      // above and this registration, having already fired its completion
+      // callback before the deferred entry existed. Re-check and promote now
+      // so the held reaction can't hang on a 👍 that will never come.
+      if (this.deps.countRunningWorkers() === 0) this.promote()
+      return true
+    }
+    this.map.delete(key)
+    return false
+  }
+
+  /** Drop any deferred entry for `key` without finalizing (e.g. on error). */
+  drop(key: string): void {
+    this.map.delete(key)
+  }
+
+  /**
+   * Promote every deferred reaction to the terminal 👍 — but only once no
+   * workers remain running. Finalize off the stored controller reference:
+   * the canonical `turn_end` path purges the key out of the active map right
+   * after deferring, so a key re-lookup would find nothing. `finalize()` is
+   * idempotent, and the controller's emit closure still targets the correct
+   * message. Only re-purge when the active map STILL points at this exact
+   * controller — if a newer turn replaced it, that turn owns the key now and
+   * must not be clobbered (and the turn_end path already purged, so we skip
+   * a redundant second purge).
+   */
+  promote(): void {
+    if (this.map.size === 0) return
+    if (this.deps.countRunningWorkers() > 0) return
+    for (const [key, { ctrl }] of this.map) {
+      ctrl.finalize('done')
+      if (this.deps.getActive(key) === ctrl) this.deps.purge(key)
+    }
+    this.map.clear()
+  }
+
+  /** Test/inspection hook. */
+  has(key: string): boolean {
+    return this.map.has(key)
+  }
+
+  get size(): number {
+    return this.map.size
+  }
+}

--- a/telegram-plugin/status-reactions.ts
+++ b/telegram-plugin/status-reactions.ts
@@ -141,6 +141,7 @@ export class StatusReactionController {
   private stallSoftTimer: ReturnType<typeof setTimeout> | null = null
   private stallHardTimer: ReturnType<typeof setTimeout> | null = null
   private finished = false
+  private held = false
   private readonly debounceMs: number
   private readonly stallSoftMs: number
   private readonly stallHardMs: number
@@ -219,8 +220,36 @@ export class StatusReactionController {
   cancel(): void {
     if (this.finished) return
     this.finished = true
+    this.held = false
     this.clearDebounceTimer()
     this.clearStallTimers()
+  }
+
+  /**
+   * Freeze the controller in a WORKING state pending out-of-turn
+   * background work — sub-agent workers that are still running after the
+   * parent's `turn_end` fired. Painting the terminal 👍 here would read
+   * as "done / nothing happening" while the worker keeps going; instead
+   * we hold a working glyph (✍️/⚡) and let the gateway call `finalize()`
+   * once the last worker completes.
+   *
+   * Non-terminal: the controller stays live, so `finalize()` still works
+   * afterward. Suppresses stall promotion (🥱/😨) for the held window —
+   * the parent turn isn't stalled, a worker is legitimately busy, and the
+   * sub-agent watcher owns its own stall detection. Promotes a non-working
+   * current state (👀 read-receipt / 🤔 thinking) to an explicit working
+   * glyph so the user can tell work is ongoing.
+   */
+  hold(): void {
+    if (this.finished) return
+    this.held = true
+    this.clearStallTimers()
+    const working = this.resolveEmoji('tool')
+    if (working != null && working !== this.currentEmoji && working !== this.pendingEmoji) {
+      this.clearDebounceTimer()
+      this.pendingEmoji = working
+      this.enqueue(working)
+    }
   }
 
   // ──────────────────────────────────────────────────────────────────────
@@ -256,6 +285,7 @@ export class StatusReactionController {
   private finishWithState(state: ReactionState): void {
     if (this.finished) return
     this.finished = true
+    this.held = false
     this.clearStallTimers()
     // F1 fix (#553): if a non-terminal reaction is sitting in the
     // debounce window when the turn ends, flush it BEFORE the terminal
@@ -311,7 +341,7 @@ export class StatusReactionController {
 
   private resetStallTimers(): void {
     this.clearStallTimers()
-    if (this.finished) return
+    if (this.finished || this.held) return
     this.stallSoftTimer = setTimeout(() => {
       this.stallSoftTimer = null
       // Don't reset the stall timers when the stall transition itself fires —

--- a/telegram-plugin/tests/reaction-defer.test.ts
+++ b/telegram-plugin/tests/reaction-defer.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from 'vitest'
+import { DeferredDoneReactions, type HoldableController } from '../reaction-defer.js'
+
+/** Fake controller recording hold/finalize calls; finalize is idempotent. */
+function makeCtrl() {
+  let finished = false
+  const ctrl: HoldableController & { held: number; doneCount: number } = {
+    held: 0,
+    doneCount: 0,
+    hold() {
+      this.held++
+    },
+    finalize(reason: 'done' | 'error' = 'done') {
+      if (finished) return
+      finished = true
+      if (reason === 'done') this.doneCount++
+    },
+  }
+  return ctrl
+}
+
+/**
+ * Harness modelling the gateway maps so the promote/purge interaction is
+ * exercised end-to-end. `purge` deletes from `active` exactly as
+ * `purgeReactionTracking` does, so a turn_end that purges right after a
+ * defer is faithfully simulated.
+ */
+function makeHarness(initialRunning = 0) {
+  const active = new Map<string, ReturnType<typeof makeCtrl>>()
+  let running = initialRunning
+  const purged: string[] = []
+  const deferred = new DeferredDoneReactions<ReturnType<typeof makeCtrl>>({
+    countRunningWorkers: () => running,
+    getActive: (key) => active.get(key),
+    purge: (key) => {
+      purged.push(key)
+      active.delete(key)
+    },
+  })
+  return {
+    active,
+    deferred,
+    purged,
+    setRunning: (n: number) => {
+      running = n
+    },
+  }
+}
+
+describe('DeferredDoneReactions', () => {
+  it('does not defer when no workers are running', () => {
+    const h = makeHarness(0)
+    const ctrl = makeCtrl()
+    h.active.set('k', ctrl)
+    expect(h.deferred.tryDefer('k', ctrl)).toBe(false)
+    expect(ctrl.held).toBe(0)
+    expect(h.deferred.size).toBe(0)
+  })
+
+  it('defers and holds while a worker runs', () => {
+    const h = makeHarness(1)
+    const ctrl = makeCtrl()
+    h.active.set('k', ctrl)
+    expect(h.deferred.tryDefer('k', ctrl)).toBe(true)
+    expect(ctrl.held).toBe(1)
+    expect(ctrl.doneCount).toBe(0)
+    expect(h.deferred.has('k')).toBe(true)
+  })
+
+  it('promotes to 👍 only once the last worker finishes', () => {
+    const h = makeHarness(2)
+    const ctrl = makeCtrl()
+    h.active.set('k', ctrl)
+    h.deferred.tryDefer('k', ctrl)
+
+    // First worker done — one still running → no promotion.
+    h.setRunning(1)
+    h.deferred.promote()
+    expect(ctrl.doneCount).toBe(0)
+    expect(h.deferred.has('k')).toBe(true)
+
+    // Last worker done → promote to 👍 and clear.
+    h.setRunning(0)
+    h.deferred.promote()
+    expect(ctrl.doneCount).toBe(1)
+    expect(h.deferred.size).toBe(0)
+  })
+
+  it('REGRESSION: promotes off the stored ref even after turn_end purged the active map', () => {
+    // This is the bug review #1999 caught: on the canonical turn_end path,
+    // finalizeStatusReaction defers, then endCurrentTurnAtomic →
+    // purgeReactionTracking deletes the controller from activeStatusReactions
+    // in the SAME sequence. A key re-lookup would find nothing and the held
+    // reaction would hang forever on the working glyph.
+    const h = makeHarness(1)
+    const ctrl = makeCtrl()
+    h.active.set('k', ctrl)
+    h.deferred.tryDefer('k', ctrl)
+
+    // Simulate endCurrentTurnAtomic purging the key out of the active map.
+    h.active.delete('k')
+
+    // Worker finishes.
+    h.setRunning(0)
+    h.deferred.promote()
+
+    // Must still reach 👍 via the stored controller reference.
+    expect(ctrl.doneCount).toBe(1)
+    // No double-purge: active map no longer holds the controller, so promote
+    // skips the redundant purge (turn_end already purged).
+    expect(h.purged).toEqual([])
+  })
+
+  it('purges via the helper when the active map still owns the controller (reply path)', () => {
+    // executeReply path keeps currentTurn (and the active map entry) alive,
+    // so promote must own the purge.
+    const h = makeHarness(1)
+    const ctrl = makeCtrl()
+    h.active.set('k', ctrl)
+    h.deferred.tryDefer('k', ctrl)
+
+    h.setRunning(0)
+    h.deferred.promote()
+
+    expect(ctrl.doneCount).toBe(1)
+    expect(h.purged).toEqual(['k'])
+  })
+
+  it('instance guard: a newer turn that replaced the key is never finalized or purged', () => {
+    const h = makeHarness(1)
+    const oldCtrl = makeCtrl()
+    h.active.set('k', oldCtrl)
+    h.deferred.tryDefer('k', oldCtrl)
+
+    // A fresh turn arrives on the same key with a brand-new controller.
+    const newCtrl = makeCtrl()
+    h.active.set('k', newCtrl)
+
+    h.setRunning(0)
+    h.deferred.promote()
+
+    // Old held controller still reaches its 👍 (its message's workers done)...
+    expect(oldCtrl.doneCount).toBe(1)
+    // ...but the new turn's controller is untouched and its key not purged.
+    expect(newCtrl.doneCount).toBe(0)
+    expect(h.purged).toEqual([])
+    expect(h.active.get('k')).toBe(newCtrl)
+  })
+
+  it('race guard: promotes immediately if the worker finished during defer', () => {
+    // countRunningWorkers returns >0 on the first call (so we defer) then 0
+    // on the re-check inside tryDefer — emulating a worker completing in the
+    // window between the two reads.
+    const active = new Map<string, ReturnType<typeof makeCtrl>>()
+    const ctrl = makeCtrl()
+    active.set('k', ctrl)
+    let calls = 0
+    const deferred = new DeferredDoneReactions<ReturnType<typeof makeCtrl>>({
+      countRunningWorkers: () => (calls++ === 0 ? 1 : 0),
+      getActive: (key) => active.get(key),
+      purge: (key) => active.delete(key),
+    })
+    expect(deferred.tryDefer('k', ctrl)).toBe(true)
+    // Race guard fired promote() inside tryDefer → already at 👍, map cleared.
+    expect(ctrl.doneCount).toBe(1)
+    expect(deferred.size).toBe(0)
+  })
+
+  it('drop() clears a deferred entry without finalizing (error path)', () => {
+    const h = makeHarness(1)
+    const ctrl = makeCtrl()
+    h.active.set('k', ctrl)
+    h.deferred.tryDefer('k', ctrl)
+    expect(h.deferred.has('k')).toBe(true)
+
+    h.deferred.drop('k')
+    expect(h.deferred.has('k')).toBe(false)
+    expect(ctrl.doneCount).toBe(0)
+  })
+
+  it('promote is a no-op when nothing is deferred', () => {
+    const h = makeHarness(0)
+    h.deferred.promote()
+    expect(h.purged).toEqual([])
+    expect(h.deferred.size).toBe(0)
+  })
+})

--- a/telegram-plugin/tests/status-reactions.test.ts
+++ b/telegram-plugin/tests/status-reactions.test.ts
@@ -340,4 +340,83 @@ describe('StatusReactionController', () => {
     await flush()
     expect(calls).toEqual(['👀'])
   })
+
+  // hold(): freeze on a WORKING glyph while background sub-agent workers
+  // outlive the parent turn, deferring the terminal 👍 (worker-reaction fix).
+  describe('hold() — defer 👍 while a background worker runs', () => {
+    it('suppresses stall promotion (no 🥱/😨) while held', async () => {
+      const { emit, calls } = makeEmitter()
+      const ctrl = new StatusReactionController(emit)
+      ctrl.setQueued()
+      ctrl.setTool('Bash') // working: 👨‍💻
+      vi.advanceTimersByTime(3500)
+      await flush()
+
+      ctrl.hold()
+      await flush()
+      // Well past both stall thresholds — held must not yawn or panic.
+      vi.advanceTimersByTime(120000)
+      await flush()
+      expect(calls).not.toContain('🥱')
+      expect(calls).not.toContain('😨')
+    })
+
+    it('promotes a read/thinking glyph to a working glyph on hold', async () => {
+      const { emit, calls } = makeEmitter()
+      const ctrl = new StatusReactionController(emit)
+      ctrl.setQueued() // 👀 (read-receipt)
+      await flush()
+      expect(calls).toEqual(['👀'])
+
+      ctrl.hold() // should paint an explicit WORKING glyph (✍️)
+      await flush()
+      expect(calls[calls.length - 1]).toBe('✍')
+    })
+
+    it('finalize() still terminates to 👍 after hold (deferred terminal)', async () => {
+      const { emit, calls } = makeEmitter()
+      const ctrl = new StatusReactionController(emit)
+      ctrl.setQueued()
+      ctrl.setTool() // ✍
+      vi.advanceTimersByTime(3500)
+      await flush()
+
+      ctrl.hold()
+      await flush()
+      // Worker runs for a while, then completes → gateway finalizes.
+      vi.advanceTimersByTime(60000)
+      await flush()
+      ctrl.finalize('done')
+      await flush()
+      expect(calls[calls.length - 1]).toBe('👍')
+    })
+
+    it('does not double-paint when already on a working glyph', async () => {
+      const { emit, calls } = makeEmitter()
+      const ctrl = new StatusReactionController(emit)
+      ctrl.setQueued()
+      ctrl.setTool() // ✍
+      vi.advanceTimersByTime(3500)
+      await flush()
+      const before = calls.length
+
+      ctrl.hold() // already on ✍ → no new emit
+      await flush()
+      expect(calls.length).toBe(before)
+    })
+
+    it('hold() after finalize is a no-op (cannot resurrect a finished controller)', async () => {
+      const { emit, calls } = makeEmitter()
+      const ctrl = new StatusReactionController(emit)
+      ctrl.setQueued()
+      ctrl.finalize('done')
+      await flush()
+      const snapshot = [...calls]
+
+      ctrl.hold()
+      vi.advanceTimersByTime(120000)
+      await flush()
+      expect(calls).toEqual(snapshot)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- The terminal 👍 reaction was painted at the parent turn's `turn_end`, **independent of background sub-agent worker lifecycle**. A turn that dispatched a worker (Agent/Task) and ended showed 👍 — reading as "done / nothing happening" — while the worker kept running and the model's own reply said work was ongoing. (Operator-observed on a live agent.)
- Add `StatusReactionController.hold()`: freeze on a **working** glyph (✍️/⚡), suppress stall promotion (🥱/😨) for the held window, stay non-terminal so `finalize()` still works.
- `finalizeStatusReaction` defers the `'done'` terminal while `countRunningWorkers() > 0` (registers the held controller); the sub-agent watcher's `onFinish` calls `promoteDeferredDoneReactions()` to flip to 👍 once no workers remain running.

## Why
JTBD `know-what-my-agent-is-doing`: the ambient reaction must reflect *current activity*, not the parent turn boundary. Showing 👍 while a worker runs is a false "finished" signal.

## How it's safe
- **Instance-guarded**: promote no-ops if a newer turn replaced the held controller for that key (the new turn owns the reaction).
- **Race guard**: after holding, re-check `countRunningWorkers()` and promote immediately if the last worker finished between the count and the registration.
- **Errors finalize regardless** — a failed/aborted turn never waits on a worker.
- **No-hang backstop**: the watcher's silent-stall synthesis sets `state='done'` → fires `onFinish` (≤5 min after a worker goes silent), so a held reaction always resolves to 👍.
- Historical (boot-leftover) and already-terminal workers are excluded from the running count.

## Test plan
- [x] `status-reactions.test.ts` — new `hold()` suite: suppresses stall, promotes read/thinking → working glyph, `finalize()` still reaches 👍, no double-paint, no-op after finalize. Green under **both** vitest and bun.
- [x] Existing reaction suites (active-reactions, sweep, reply-terminal, allowed-filter) green.
- [x] `tsc --noEmit` clean; `check-bot-api-wrapping.sh` clean.
- [ ] UAT + fleet rollout (post-merge).

## Risk
Low. Pure additive controller method + a guarded branch in one finalize path. No change when there are no running workers (the dominant case) — `countRunningWorkers()` returns 0 and behavior is identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)