### PR TITLE
feat(telegram): live worker-activity feed for background sub-agents

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -53,6 +53,7 @@ import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import { createInboundCoalescer, inboundCoalesceKey } from './inbound-coalesce.js'
 import { StatusReactionController } from '../status-reactions.js'
 import { DeferredDoneReactions } from '../reaction-defer.js'
+import { createWorkerActivityFeed } from '../worker-activity-feed.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel } from '../tool-activity-summary.js'
 import { toolLabel } from '../tool-labels.js'
@@ -17256,6 +17257,45 @@ void (async () => {
         if (streamMode === 'checklist') {
           const watcherAgentDir = resolveAgentDirFromEnv()
           if (watcherAgentDir != null) {
+            // #PR2 — live worker-activity feed. A *background* sub-agent
+            // decouples from the parent turn, so when the turn ends nothing
+            // surfaces its ongoing jsonl activity and a long worker reads as
+            // silence. This feed posts ONE regular chat message per worker
+            // and edits it in place as work happens (current tool + elapsed),
+            // finalizing on completion — the same "live, growing message"
+            // shape the main agent's answer uses, NOT card chrome (the pinned
+            // card was deleted in #1126). Flag-gated; when ON it also
+            // supersedes the coarse 5-min bucket relay below to avoid
+            // double-surfacing the same progress beat.
+            const workerFeedEnabled = process.env.SWITCHROOM_WORKER_ACTIVITY_FEED === '1'
+            const workerActivityFeed = createWorkerActivityFeed({
+              bot: {
+                sendMessage: async (cid, text, sendOpts) => {
+                  const sent = await robustApiCall(
+                    () =>
+                      lockedBot.api.sendMessage(
+                        cid,
+                        text,
+                        sendOpts as Parameters<typeof lockedBot.api.sendMessage>[2],
+                      ),
+                    { chat_id: cid, verb: 'worker-feed' },
+                  )
+                  return sent as { message_id: number }
+                },
+                editMessageText: (cid, mid, text, editOpts) =>
+                  robustApiCall(
+                    () =>
+                      lockedBot.api.editMessageText(
+                        cid,
+                        mid,
+                        text,
+                        editOpts as Parameters<typeof lockedBot.api.editMessageText>[3],
+                      ),
+                    { chat_id: cid, verb: 'worker-feed' },
+                  ),
+              },
+              log: (msg) => process.stderr.write(`telegram gateway: ${msg}\n`),
+            })
             subagentWatcher = startSubagentWatcher({
               agentDir: watcherAgentDir,
               // Issue #1116 (Bug A): restrict project-dir enumeration to
@@ -17348,7 +17388,7 @@ void (async () => {
               // Gated to background completions: foreground sub-agents
               // need nothing here, and 'orphan' is a stale historical-at-
               // boot row, not a fresh completion the user is waiting on.
-              onFinish: ({ agentId, outcome, description, resultText }) => {
+              onFinish: ({ agentId, outcome, description, resultText, toolCount, durationMs }) => {
                 // Reaction promotion: if the parent turn already ended
                 // with this (or another) worker still running, its 👍 was
                 // deferred (held on ✍️/⚡). Now that a worker finished,
@@ -17356,6 +17396,21 @@ void (async () => {
                 // handback gating below, so it must run before any early
                 // return. Cheap no-op when nothing is deferred.
                 deferredDoneReactions.promote()
+                // #PR2 live worker-feed: force the terminal recap edit on
+                // the worker's live message. No-op when no message was ever
+                // posted (trivial workers stay silent; handback covers them).
+                // 'orphan' is a stale boot row, not a fresh completion — map
+                // it to 'done' so an already-posted message still finalizes.
+                if (workerFeedEnabled) {
+                  void workerActivityFeed.finish(agentId, {
+                    description,
+                    lastTool: null,
+                    toolCount,
+                    latestSummary: resultText,
+                    elapsedMs: durationMs,
+                    state: outcome === 'failed' ? 'failed' : 'done',
+                  })
+                }
                 // IO: resolve the fleet chat id and the background flag.
                 // The DECISION (gating + inbound build) is delegated to
                 // the pure `decideSubagentHandback` so it is unit-tested
@@ -17453,7 +17508,7 @@ void (async () => {
               // suppresses stale-after-restart delivery (a 4-h-old
               // "still working (5m)" would be a lie). Sweep on handback
               // lives in the `onFinish` block just above.
-              onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx }) => {
+              onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx, lastTool, toolCount }) => {
                 let fleetChatId = ''
                 let isBackground = false
                 try {
@@ -17474,6 +17529,28 @@ void (async () => {
                   } catch { /* best-effort */ }
                 }
                 if (!isBackground) return // skip overhead for foreground
+
+                // #PR2 live worker-feed: when ON, the worker's live chat
+                // message owns the progress beat. Push a running cue and
+                // return BEFORE the legacy bucket relay so the same activity
+                // isn't double-surfaced (in-message edit + injected
+                // "still working" inbound turn). Chat = owner DM, since the
+                // pinned-card fleet is gone and every agent is DM-shaped.
+                if (workerFeedEnabled) {
+                  void workerActivityFeed.update(
+                    agentId,
+                    fleetChatId || (loadAccess().allowFrom[0] ?? ''),
+                    {
+                      description,
+                      lastTool,
+                      toolCount,
+                      latestSummary,
+                      elapsedMs,
+                      state: 'running',
+                    },
+                  )
+                  return
+                }
 
                 const decision = decideSubagentProgress({
                   disableEnvValue: process.env.SWITCHROOM_DISABLE_SUBAGENT_PROGRESS,

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -305,6 +305,11 @@ export interface SubagentWatcherConfig {
     elapsedMs: number
     prevBucketIdx: number | null
     setBucketIdx: (b: number) => void
+    /** Most recent tool the worker invoked, or null if none yet. Feeds
+     *  the live worker-activity feed (#PR2); the bucket relay ignores it. */
+    lastTool: { name: string; sanitisedArg: string } | null
+    /** Tool-use count observed so far. */
+    toolCount: number
   }) => void
   /** `Date.now` override for tests. */
   now?: () => number
@@ -522,6 +527,12 @@ export function readSubTail(
     elapsedMs: number
     prevBucketIdx: number | null
     setBucketIdx: (b: number) => void
+    /** Most recent tool the worker invoked (name + sanitised arg), or
+     *  null if no tool_use has been observed yet. For the live
+     *  worker-activity feed (#PR2) — the legacy bucket relay ignores it. */
+    lastTool: { name: string; sanitisedArg: string } | null
+    /** Tool-use count observed so far. */
+    toolCount: number
   }) => void,
 ): void {
   try {
@@ -675,6 +686,8 @@ export function readSubTail(
                 setBucketIdx: (b: number) => {
                   entry.lastProgressBucketIdx = b
                 },
+                lastTool: entry.lastTool,
+                toolCount: entry.toolCount,
               })
             } catch (cbErr) {
               log?.(`subagent-watcher: onProgress callback error ${entry.agentId}: ${(cbErr as Error).message}`)

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -236,6 +236,16 @@ describe('createWorkerActivityFeed', () => {
     expect(feed.has('w1')).toBe(true)
   })
 
+  it('skips entirely when chatId is empty (owner DM unconfigured)', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock })
+    await feed.update('w1', '', view())
+    expect(bot.sent).toHaveLength(0)
+    expect(feed.has('w1')).toBe(false)
+    expect(feed.size).toBe(0)
+  })
+
   it('forwards threadId as message_thread_id on send', async () => {
     const bot = makeFakeBot()
     let clock = 10_000

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest'
+import {
+  renderWorkerActivity,
+  createWorkerActivityFeed,
+  type WorkerActivityView,
+  type BotApiForWorkerFeed,
+} from '../worker-activity-feed.js'
+
+function view(partial: Partial<WorkerActivityView> = {}): WorkerActivityView {
+  return {
+    description: 'research competitors',
+    lastTool: { name: 'Bash', sanitisedArg: 'grep -r pricing' },
+    toolCount: 3,
+    latestSummary: 'scanning vendor pages',
+    elapsedMs: 10_000,
+    state: 'running',
+    ...partial,
+  }
+}
+
+interface FakeBot extends BotApiForWorkerFeed {
+  sent: Array<{ chatId: string; text: string; opts?: Record<string, unknown> }>
+  edits: Array<{ messageId: number; text: string }>
+  failNextSendWith?: unknown
+  failNextEditWith?: unknown
+}
+
+function makeFakeBot(): FakeBot {
+  let nextId = 1000
+  const fb: FakeBot = {
+    sent: [],
+    edits: [],
+    sendMessage: async (chatId, text, opts) => {
+      if (fb.failNextSendWith != null) {
+        const e = fb.failNextSendWith
+        fb.failNextSendWith = undefined
+        throw e
+      }
+      fb.sent.push({ chatId, text, opts })
+      return { message_id: nextId++ }
+    },
+    editMessageText: async (_chatId, messageId, text) => {
+      if (fb.failNextEditWith != null) {
+        const e = fb.failNextEditWith
+        fb.failNextEditWith = undefined
+        throw e
+      }
+      fb.edits.push({ messageId, text })
+      return {}
+    },
+  }
+  return fb
+}
+
+// ─── renderWorkerActivity (pure) ─────────────────────────────────────────────
+
+describe('renderWorkerActivity', () => {
+  it('renders running header + tool activity line + summary', () => {
+    const out = renderWorkerActivity(view())
+    expect(out).toContain('🔧 <b>Worker</b> · <i>research competitors</i>')
+    expect(out).toContain('⚡ <code>Bash</code> grep -r pricing')
+    expect(out).toContain('(3 tools · ')
+    expect(out).toContain('↳ <i>scanning vendor pages</i>')
+  })
+
+  it('shows a "starting…" line when no tool has run yet', () => {
+    const out = renderWorkerActivity(view({ lastTool: null, latestSummary: '' }))
+    expect(out).toContain('🔧 <b>Worker</b>')
+    expect(out).toContain('starting…')
+    expect(out).not.toContain('⚡')
+  })
+
+  it('omits the summary line when latestSummary is blank', () => {
+    const out = renderWorkerActivity(view({ latestSummary: '   ' }))
+    expect(out).not.toContain('↳')
+  })
+
+  it('uses singular "tool" for a single tool call', () => {
+    const out = renderWorkerActivity(view({ toolCount: 1 }))
+    expect(out).toContain('(1 tool · ')
+  })
+
+  it('renders a done terminal recap', () => {
+    const out = renderWorkerActivity(view({ state: 'done', toolCount: 5 }))
+    expect(out).toContain('✅ <b>Worker done</b> · <i>research competitors</i>')
+    expect(out).toContain('5 tools · ')
+    expect(out).not.toContain('⚡')
+  })
+
+  it('renders a failed terminal recap', () => {
+    const out = renderWorkerActivity(view({ state: 'failed' }))
+    expect(out).toContain('⚠️ <b>Worker failed</b>')
+  })
+
+  it('escapes HTML in description, tool, arg, and summary', () => {
+    const out = renderWorkerActivity(
+      view({
+        description: 'a <b>bold</b> task',
+        lastTool: { name: 'Ba<sh', sanitisedArg: 'x & y' },
+        latestSummary: 'a > b',
+      }),
+    )
+    expect(out).toContain('a &lt;b&gt;bold&lt;/b&gt; task')
+    expect(out).toContain('Ba&lt;sh')
+    expect(out).toContain('x &amp; y')
+    expect(out).toContain('a &gt; b')
+  })
+})
+
+// ─── createWorkerActivityFeed (lifecycle) ────────────────────────────────────
+
+describe('createWorkerActivityFeed', () => {
+  it('holds first paint until the worker has run firstPaintMinMs', async () => {
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      firstPaintMinMs: 8000,
+    })
+    clock = 5000
+    await feed.update('w1', 'chat', view({ elapsedMs: 5000 }))
+    expect(bot.sent).toHaveLength(0)
+    expect(feed.has('w1')).toBe(false)
+
+    clock = 9000
+    await feed.update('w1', 'chat', view({ elapsedMs: 9000 }))
+    expect(bot.sent).toHaveLength(1)
+    expect(bot.sent[0].chatId).toBe('chat')
+    expect(bot.sent[0].opts?.parse_mode).toBe('HTML')
+    expect(feed.has('w1')).toBe(true)
+  })
+
+  it('dedups an identical body (no edit)', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+    await feed.update('w1', 'chat', view())
+    expect(bot.sent).toHaveLength(1)
+    clock = 20_000
+    await feed.update('w1', 'chat', view()) // same body
+    expect(bot.edits).toHaveLength(0)
+  })
+
+  it('throttles edits inside minEditIntervalMs but lets them through after', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 2500 })
+    await feed.update('w1', 'chat', view({ toolCount: 1 }))
+    expect(bot.sent).toHaveLength(1)
+
+    clock = 11_000 // +1000 < 2500
+    await feed.update('w1', 'chat', view({ toolCount: 2 }))
+    expect(bot.edits).toHaveLength(0)
+
+    clock = 13_000 // +3000 since last edit > 2500
+    await feed.update('w1', 'chat', view({ toolCount: 3 }))
+    expect(bot.edits).toHaveLength(1)
+    expect(bot.edits[0].text).toContain('(3 tools · ')
+  })
+
+  it('forces a terminal edit on finish, skipping the throttle', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 9_999_999 })
+    await feed.update('w1', 'chat', view())
+    expect(bot.sent).toHaveLength(1)
+
+    clock = 10_500 // well within the throttle window
+    await feed.finish('w1', view({ state: 'done', toolCount: 5 }))
+    expect(bot.edits).toHaveLength(1)
+    expect(bot.edits[0].text).toContain('✅ <b>Worker done</b>')
+    // finish forgets the worker.
+    expect(feed.has('w1')).toBe(false)
+    expect(feed.size).toBe(0)
+  })
+
+  it('finish is a no-op when no message was ever posted', async () => {
+    const bot = makeFakeBot()
+    let clock = 0
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, firstPaintMinMs: 8000 })
+    clock = 2000
+    await feed.update('w1', 'chat', view({ elapsedMs: 2000 })) // too short to paint
+    expect(bot.sent).toHaveLength(0)
+    await feed.finish('w1', view({ state: 'done' }))
+    expect(bot.edits).toHaveLength(0)
+    expect(bot.sent).toHaveLength(0)
+  })
+
+  it('drop forgets a worker without editing', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock })
+    await feed.update('w1', 'chat', view())
+    expect(feed.has('w1')).toBe(true)
+    feed.drop('w1')
+    expect(feed.has('w1')).toBe(false)
+    expect(feed.size).toBe(0)
+    await feed.finish('w1', view({ state: 'done' }))
+    expect(bot.edits).toHaveLength(0)
+  })
+
+  it('honours a 429 cooldown before retrying the first paint', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, firstPaintMinMs: 0 })
+    bot.failNextSendWith = { error_code: 429, parameters: { retry_after: 2 } }
+    await feed.update('w1', 'chat', view())
+    expect(bot.sent).toHaveLength(0) // failed send
+
+    clock = 11_000 // still inside cooldown (10_000 + 2000 + 500 jitter = 12_500)
+    await feed.update('w1', 'chat', view())
+    expect(bot.sent).toHaveLength(0)
+
+    clock = 13_000 // past cooldown
+    await feed.update('w1', 'chat', view())
+    expect(bot.sent).toHaveLength(1)
+  })
+
+  it('re-posts after a stale-message edit failure', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+    await feed.update('w1', 'chat', view({ toolCount: 1 }))
+    expect(bot.sent).toHaveLength(1)
+
+    clock = 20_000
+    bot.failNextEditWith = new Error('Bad Request: message to edit not found')
+    await feed.update('w1', 'chat', view({ toolCount: 2 }))
+    expect(bot.edits).toHaveLength(0) // edit threw
+    expect(feed.has('w1')).toBe(false) // messageId reset
+
+    clock = 30_000
+    await feed.update('w1', 'chat', view({ toolCount: 3 }))
+    expect(bot.sent).toHaveLength(2) // re-posted
+    expect(feed.has('w1')).toBe(true)
+  })
+
+  it('forwards threadId as message_thread_id on send', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock })
+    await feed.update('w1', 'chat', view(), 42)
+    expect(bot.sent[0].opts?.message_thread_id).toBe(42)
+  })
+})

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -272,6 +272,9 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       return handles.size
     },
     update(agentId, chatId, view, threadId) {
+      // No chat to post to (owner DM unconfigured) — don't create a
+      // handle that would retry a failing send('') every tick.
+      if (chatId.length === 0) return Promise.resolve()
       let h = handles.get(agentId)
       if (h == null) {
         h = {

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -1,0 +1,311 @@
+/**
+ * Live worker-activity feed — a regular chat message that edits in place
+ * while a *background* sub-agent (Agent/Task `run_in_background: true`)
+ * runs, then finalizes when the worker completes.
+ *
+ * Why this exists: the pinned progress card was deleted (#1126) and the
+ * "Chat is the artifact" principle bars re-adding card chrome. But a
+ * background worker decouples from the parent turn — when the parent's
+ * turn ends, nothing surfaces the worker's ongoing jsonl activity, so a
+ * long worker reads as silence (the exact gap an operator hit watching a
+ * dispatched worker go quiet). This module surfaces that activity the
+ * same way the main agent's live answer does: a normal Telegram message
+ * that grows/edits as work happens — indistinguishable from "the agent
+ * is typing live", not a status widget.
+ *
+ * Pure render (`renderWorkerActivity`) + an injected bot API
+ * (`BotApiForWorkerFeed`), mirroring `issues-card.ts` so the gateway
+ * reuses the same wiring. The manager (`createWorkerActivityFeed`) owns
+ * one edit-in-place message per worker, keyed by jsonl agent id, with:
+ *   - a first-paint delay so trivial sub-second workers never post a
+ *     message (their result still lands via the handback reply),
+ *   - a proactive min-edit-interval throttle (worker jsonl ticks ~1/s;
+ *     Telegram rate-limits edits) plus body-dedup,
+ *   - per-worker serialization so two rapid ticks can't double-send,
+ *   - 429 cooldown + message_id drift resilience (re-post on stale edit),
+ *   - a forced terminal edit on `finish` regardless of throttle.
+ *
+ * The feed is gated to BACKGROUND workers and lives behind the
+ * `SWITCHROOM_WORKER_ACTIVITY_FEED` flag — see the gateway wiring. The
+ * watcher already drives the cues (it polls the worker jsonl directly,
+ * so it keeps firing after the parent turn ends), which is why the feed
+ * is fed from watcher callbacks rather than the bridge event stream.
+ */
+
+import { escapeHtml, formatDuration, truncate } from './card-format.js'
+
+export type WorkerActivityState = 'running' | 'done' | 'failed'
+
+/** The render-relevant snapshot of a worker at one instant. */
+export interface WorkerActivityView {
+  /** Dispatch-time task description (stable across the worker's life). */
+  description: string
+  /** Most recent tool the worker invoked, with a pre-sanitised arg. */
+  lastTool: { name: string; sanitisedArg: string } | null
+  /** Number of tool calls observed so far. */
+  toolCount: number
+  /** The worker's latest narrative line, if any (already capped upstream). */
+  latestSummary: string
+  /** Wall-clock since dispatch, ms. */
+  elapsedMs: number
+  state: WorkerActivityState
+}
+
+export interface BotApiForWorkerFeed {
+  sendMessage(
+    chatId: string,
+    text: string,
+    opts?: Record<string, unknown>,
+  ): Promise<{ message_id: number }>
+  editMessageText(
+    chatId: string,
+    messageId: number,
+    text: string,
+    opts?: Record<string, unknown>,
+  ): Promise<unknown>
+}
+
+const DESC_MAX = 80
+const TOOL_ARG_MAX = 64
+const SUMMARY_MAX = 100
+
+/**
+ * Render the worker-activity message body as Telegram HTML.
+ *
+ * Layout (running):
+ *   🔧 <b>Worker</b> · <i>{description}</i>
+ *   ⚡ <code>{tool}</code> {arg} <i>({n} tools · {elapsed})</i>
+ *     ↳ <i>{latest summary}</i>
+ *
+ * Terminal collapses the activity line to a tool-count + duration recap:
+ *   ✅ <b>Worker done</b> · <i>{description}</i>
+ *   <i>{n} tools · {elapsed}</i>
+ */
+export function renderWorkerActivity(v: WorkerActivityView): string {
+  const desc = truncate(v.description.trim() || 'background task', DESC_MAX)
+  const elapsed = formatDuration(v.elapsedMs)
+  const toolWord = v.toolCount === 1 ? 'tool' : 'tools'
+
+  if (v.state === 'done' || v.state === 'failed') {
+    const head =
+      v.state === 'done'
+        ? `✅ <b>Worker done</b> · <i>${escapeHtml(desc)}</i>`
+        : `⚠️ <b>Worker failed</b> · <i>${escapeHtml(desc)}</i>`
+    return `${head}\n<i>${v.toolCount} ${toolWord} · ${elapsed}</i>`
+  }
+
+  const header = `🔧 <b>Worker</b> · <i>${escapeHtml(desc)}</i>`
+
+  let activity: string
+  if (v.lastTool != null) {
+    const arg = v.lastTool.sanitisedArg.trim()
+    const argPart = arg.length > 0 ? ` ${escapeHtml(truncate(arg, TOOL_ARG_MAX))}` : ''
+    activity = `⚡ <code>${escapeHtml(v.lastTool.name)}</code>${argPart} <i>(${v.toolCount} ${toolWord} · ${elapsed})</i>`
+  } else {
+    activity = `<i>starting… (${elapsed})</i>`
+  }
+
+  const summary = v.latestSummary.trim()
+  const lines = [header, activity]
+  if (summary.length > 0) {
+    lines.push(`  ↳ <i>${escapeHtml(truncate(summary, SUMMARY_MAX))}</i>`)
+  }
+  return lines.join('\n')
+}
+
+export interface WorkerActivityFeedOpts {
+  bot: BotApiForWorkerFeed
+  /** `Date.now` override for tests. */
+  now?: () => number
+  /**
+   * Minimum ms between in-place edits to one worker's message. Worker
+   * jsonl ticks roughly once per second; without this we'd burn through
+   * Telegram's edit budget. Default 2500ms. First paint and the terminal
+   * `finish` edit bypass it.
+   */
+  minEditIntervalMs?: number
+  /**
+   * A worker must have been running at least this long before its first
+   * message is posted. Sub-second / trivial workers never surface a live
+   * message — their result still reaches the user via the handback
+   * reply, so a message would be pure noise. Default 8000ms.
+   */
+  firstPaintMinMs?: number
+  /** stderr-style log sink. Defaults to noop. */
+  log?: (msg: string) => void
+}
+
+interface WorkerHandle {
+  chatId: string
+  threadId?: number
+  messageId: number | null
+  lastBody: string | null
+  lastEditAt: number
+  cooldownUntil: number
+  /** Per-worker serialization chain so ticks can't interleave sends. */
+  chain: Promise<void>
+}
+
+const COOLDOWN_JITTER_MS = 500
+
+function extractRetryAfterSecs(err: unknown): number | null {
+  if (err == null || typeof err !== 'object') return null
+  const e = err as { error_code?: unknown; parameters?: { retry_after?: unknown } }
+  if (e.error_code !== 429) return null
+  const ra = e.parameters?.retry_after
+  if (typeof ra === 'number' && Number.isFinite(ra) && ra > 0) return ra
+  return null
+}
+
+/**
+ * Manager owning one live message per background worker. Keyed by jsonl
+ * agent id. The gateway calls `update` on each watcher activity cue and
+ * `finish` on terminal; `drop` discards a worker's state without a final
+ * edit (error / supersession paths).
+ */
+export interface WorkerActivityFeed {
+  /** True if a message is currently posted for this worker. */
+  has(agentId: string): boolean
+  /** Push a running-state cue. Returns the serialized op for tests. */
+  update(
+    agentId: string,
+    chatId: string,
+    view: WorkerActivityView,
+    threadId?: number,
+  ): Promise<void>
+  /** Force the terminal recap edit. No-op if no message was ever posted. */
+  finish(agentId: string, view: WorkerActivityView): Promise<void>
+  /** Forget a worker's state without editing (e.g. error path). */
+  drop(agentId: string): void
+  /** Number of tracked workers (test/inspection hook). */
+  readonly size: number
+}
+
+export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerActivityFeed {
+  const log = opts.log ?? (() => {})
+  const nowFn = opts.now ?? Date.now
+  const minEditInterval = opts.minEditIntervalMs ?? 2500
+  const firstPaintMin = opts.firstPaintMinMs ?? 8000
+  const handles = new Map<string, WorkerHandle>()
+
+  function sendOptsFor(h: WorkerHandle): Record<string, unknown> {
+    return {
+      parse_mode: 'HTML',
+      disable_web_page_preview: true,
+      ...(h.threadId != null ? { message_thread_id: h.threadId } : {}),
+    }
+  }
+
+  function noteRateLimited(h: WorkerHandle, err: unknown, label: string): void {
+    const retryAfter = extractRetryAfterSecs(err)
+    if (retryAfter == null) return
+    h.cooldownUntil = nowFn() + retryAfter * 1000 + COOLDOWN_JITTER_MS
+    log(`worker-feed: ${label} 429 — backing off ${retryAfter}s`)
+  }
+
+  async function doUpdate(h: WorkerHandle, view: WorkerActivityView): Promise<void> {
+    if (nowFn() < h.cooldownUntil) return
+    const body = renderWorkerActivity(view)
+
+    // First paint: hold off until the worker has run long enough to be
+    // worth a message; trivial workers stay silent (handback covers them).
+    if (h.messageId == null) {
+      if (view.elapsedMs < firstPaintMin) return
+      try {
+        const sent = await opts.bot.sendMessage(h.chatId, body, sendOptsFor(h))
+        h.messageId = sent.message_id
+        h.lastBody = body
+        h.lastEditAt = nowFn()
+      } catch (err) {
+        noteRateLimited(h, err, 'send')
+        log(`worker-feed: send failed: ${(err as Error).message}`)
+      }
+      return
+    }
+
+    // Dedup + proactive throttle.
+    if (body === h.lastBody) return
+    if (nowFn() - h.lastEditAt < minEditInterval) return
+
+    try {
+      await opts.bot.editMessageText(h.chatId, h.messageId, body, sendOptsFor(h))
+      h.lastBody = body
+      h.lastEditAt = nowFn()
+    } catch (err) {
+      noteRateLimited(h, err, 'edit')
+      // Stale message_id (manually deleted / edit window gone). Re-post
+      // on the next tick rather than now, so we don't double-down inside
+      // a cooldown.
+      log(`worker-feed: edit failed, will re-post: ${(err as Error).message}`)
+      h.messageId = null
+      h.lastBody = null
+    }
+  }
+
+  async function doFinish(h: WorkerHandle, view: WorkerActivityView): Promise<void> {
+    // No message ever posted → nothing to finalize. The worker's result
+    // reaches the user via the handback reply; a bare "done" recap with
+    // no preceding activity would be noise.
+    if (h.messageId == null) return
+    if (nowFn() < h.cooldownUntil) {
+      // Honour the flood-wait; a terminal edit isn't worth a ban. The
+      // message is left at its last running render — stale but harmless.
+      return
+    }
+    const body = renderWorkerActivity(view)
+    if (body === h.lastBody) return
+    try {
+      await opts.bot.editMessageText(h.chatId, h.messageId, body, sendOptsFor(h))
+      h.lastBody = body
+      h.lastEditAt = nowFn()
+    } catch (err) {
+      noteRateLimited(h, err, 'finish')
+      log(`worker-feed: finish edit failed: ${(err as Error).message}`)
+    }
+  }
+
+  return {
+    has(agentId) {
+      return handles.get(agentId)?.messageId != null
+    },
+    get size() {
+      return handles.size
+    },
+    update(agentId, chatId, view, threadId) {
+      let h = handles.get(agentId)
+      if (h == null) {
+        h = {
+          chatId,
+          threadId,
+          messageId: null,
+          lastBody: null,
+          lastEditAt: 0,
+          cooldownUntil: 0,
+          chain: Promise.resolve(),
+        }
+        handles.set(agentId, h)
+      }
+      const handle = h
+      handle.chain = handle.chain.then(() => doUpdate(handle, view)).catch((err) => {
+        log(`worker-feed: update chain error ${agentId}: ${(err as Error).message}`)
+      })
+      return handle.chain
+    },
+    finish(agentId, view) {
+      const h = handles.get(agentId)
+      if (h == null) return Promise.resolve()
+      h.chain = h.chain
+        .then(() => doFinish(h, view))
+        .catch((err) => {
+          log(`worker-feed: finish chain error ${agentId}: ${(err as Error).message}`)
+        })
+        .finally(() => {
+          handles.delete(agentId)
+        })
+      return h.chain
+    },
+    drop(agentId) {
+      handles.delete(agentId)
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Background sub-agents (`run_in_background: true`) decouple from the parent turn — when the turn ends nothing surfaces the worker's ongoing jsonl activity, so a long background worker reads as **silence** (the exact gap an operator hit watching a dispatched worker go quiet).

This surfaces that activity the same way the main agent's live answer does: **one regular Telegram message per worker that edits in place** as work happens (current tool + short summary + elapsed), finalized with a tool-count + duration recap on completion.

Layout (running → terminal):
```
🔧 Worker · research competitors
⚡ Bash grep -r "pricing" (3 tools · 00:42)
  ↳ scanning vendor pages…
        ↓ (edits in place)
✅ Worker done · research competitors
5 tools · 01:18
```

## Why

- **JTBD "you hold the leash":** a dispatched background worker going quiet is the awareness gap. This restores live awareness without babysitting.
- **Not card chrome.** The pinned progress card was deleted in #1126 and "Chat IS the artifact" bars re-adding widgets. This is framework-authored content in a normal growing chat message — indistinguishable from "the agent is typing live", the same shape as visible-answer-stream.

## What

- **New `worker-activity-feed.ts`** — pure `renderWorkerActivity` + an injected `BotApiForWorkerFeed`, mirroring `issues-card.ts`. One edit-in-place message per worker keyed by jsonl agent id, with: first-paint delay (trivial sub-second workers stay silent — handback covers them), min-edit-interval throttle + body-dedup, per-worker serialization, 429 cooldown, message_id-drift re-post, forced terminal edit on finish.
- **Watcher `onProgress` enriched** with `lastTool` + `toolCount` — no new callback / signature change (the legacy bucket relay ignores them).
- **Gateway wiring** is watcher-driven (survives turn end), BACKGROUND-gated, behind `SWITCHROOM_WORKER_ACTIVITY_FEED`. When ON it supersedes the coarse 5-min bucket relay to avoid double-surfacing the same beat.

Flag-gated **default-off** (visible-answer-stream convention) — validated via UAT before flipping the default.

## Test plan

- [x] `worker-activity-feed.test.ts` — 16 tests: render (running/starting/done/failed/escape/singular), first-paint delay, dedup, throttle, forced terminal edit, finish no-op when unposted, drop, 429 cooldown, stale-edit re-post, threadId forwarding. Green under **both** vitest and bun.
- [x] subagent-watcher suite (44 tests) still green after the `onProgress` enrichment.
- [x] `tsc --noEmit`, `check-bot-api-wrapping.sh`, `check-plugin-references.mjs` clean.
- [ ] UAT against test-harness with the flag ON before flipping default.

## Risk

Low. New surface is behind `SWITCHROOM_WORKER_ACTIVITY_FEED` (default off) — zero behaviour change until explicitly enabled. The only always-on change is the additive `onProgress` payload fields, which the existing bucket relay ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)