### PR TITLE
fix(telegram): worker-feed shows real task description + live UAT

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -17396,21 +17396,6 @@ void (async () => {
                 // handback gating below, so it must run before any early
                 // return. Cheap no-op when nothing is deferred.
                 deferredDoneReactions.promote()
-                // #PR2 live worker-feed: force the terminal recap edit on
-                // the worker's live message. No-op when no message was ever
-                // posted (trivial workers stay silent; handback covers them).
-                // 'orphan' is a stale boot row, not a fresh completion — map
-                // it to 'done' so an already-posted message still finalizes.
-                if (workerFeedEnabled) {
-                  void workerActivityFeed.finish(agentId, {
-                    description,
-                    lastTool: null,
-                    toolCount,
-                    latestSummary: resultText,
-                    elapsedMs: durationMs,
-                    state: outcome === 'failed' ? 'failed' : 'done',
-                  })
-                }
                 // IO: resolve the fleet chat id and the background flag.
                 // The DECISION (gating + inbound build) is delegated to
                 // the pure `decideSubagentHandback` so it is unit-tested
@@ -17418,6 +17403,10 @@ void (async () => {
                 // `subagent-handback-decision.test.ts`.
                 let fleetChatId = ''
                 let isBackground = false
+                // Dispatch-time task description from the registry row —
+                // see the onProgress note; used for the feed's terminal recap
+                // header so it matches the running header ("· <real task>").
+                let dispatchDesc = ''
                 try {
                   const fleets = progressDriver?.peekAllFleets() ?? []
                   for (const f of fleets) {
@@ -17433,10 +17422,28 @@ void (async () => {
                 if (turnsDb != null) {
                   try {
                     const row = turnsDb
-                      .prepare('SELECT background FROM subagents WHERE jsonl_agent_id = ?')
-                      .get(agentId) as { background: number } | undefined
-                    if (row != null) isBackground = row.background === 1
+                      .prepare('SELECT background, description FROM subagents WHERE jsonl_agent_id = ?')
+                      .get(agentId) as { background: number; description: string | null } | undefined
+                    if (row != null) {
+                      isBackground = row.background === 1
+                      dispatchDesc = row.description ?? ''
+                    }
                   } catch { /* best-effort */ }
+                }
+                // #PR2 live worker-feed: force the terminal recap edit on
+                // the worker's live message. No-op when no message was ever
+                // posted (trivial workers stay silent; handback covers them).
+                // 'orphan' is a stale boot row, not a fresh completion — map
+                // it to 'done' so an already-posted message still finalizes.
+                if (workerFeedEnabled) {
+                  void workerActivityFeed.finish(agentId, {
+                    description: dispatchDesc || description,
+                    lastTool: null,
+                    toolCount,
+                    latestSummary: resultText,
+                    elapsedMs: durationMs,
+                    state: outcome === 'failed' ? 'failed' : 'done',
+                  })
                 }
 
                 const decision = decideSubagentHandback({
@@ -17511,6 +17518,11 @@ void (async () => {
               onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx, lastTool, toolCount }) => {
                 let fleetChatId = ''
                 let isBackground = false
+                // The watcher's `description` is its 'sub-agent' default (it
+                // never reassigns it from the worker jsonl). The dispatch-time
+                // task description lives in the registry row — prefer it so the
+                // feed header reads "🔧 Worker · <real task>" not "· sub-agent".
+                let dispatchDesc = ''
                 try {
                   const fleets = progressDriver?.peekAllFleets() ?? []
                   for (const f of fleets) {
@@ -17523,9 +17535,12 @@ void (async () => {
                 if (turnsDb != null) {
                   try {
                     const row = turnsDb
-                      .prepare('SELECT background FROM subagents WHERE jsonl_agent_id = ?')
-                      .get(agentId) as { background: number } | undefined
-                    if (row != null) isBackground = row.background === 1
+                      .prepare('SELECT background, description FROM subagents WHERE jsonl_agent_id = ?')
+                      .get(agentId) as { background: number; description: string | null } | undefined
+                    if (row != null) {
+                      isBackground = row.background === 1
+                      dispatchDesc = row.description ?? ''
+                    }
                   } catch { /* best-effort */ }
                 }
                 if (!isBackground) return // skip overhead for foreground
@@ -17541,7 +17556,7 @@ void (async () => {
                     agentId,
                     fleetChatId || (loadAccess().allowFrom[0] ?? ''),
                     {
-                      description,
+                      description: dispatchDesc || description,
                       lastTool,
                       toolCount,
                       latestSummary,

--- a/telegram-plugin/uat/scenarios/jtbd-worker-activity-feed-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-worker-activity-feed-dm.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Live worker-activity feed (#2000) — UAT.
+ *
+ * A *background* sub-agent decouples from the parent turn; when the turn
+ * ends nothing surfaces its ongoing jsonl activity and a long worker
+ * reads as silence. The feed (flag `SWITCHROOM_WORKER_ACTIVITY_FEED=1`,
+ * set on the test-harness agent for this run) posts ONE regular Telegram
+ * message per background worker and edits it in place — current tool +
+ * short summary + elapsed — finalizing with a recap on completion.
+ *
+ * This scenario dispatches a real background worker (~60s of paced
+ * sleep/echo work, so it narrates between tools and the feed can paint
+ * + edit), then asserts:
+ *
+ *   1. a worker-feed message appears (🔧 Worker · …), distinct from the
+ *      parent's ack reply — proving background activity surfaces after
+ *      the parent turn closed;
+ *   2. the message edits in place while work is in flight (body changes
+ *      across a window) — proving it's live, not a one-shot post;
+ *   3. it finalizes to the terminal recap (✅ Worker done · … / N tools).
+ *
+ * It logs every observed body so a human can read the real rendered UX.
+ *
+ * Prompt is the deterministic Option-1 dispatch from
+ * `bg-sub-agent-dispatch-dm.test.ts` (naming the Agent tool + arg keeps
+ * the model from running the sleeps inline via Bash).
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+// The worker must keep its jsonl ticking faster than the *test-harness*
+// stall window (SWITCHROOM_SUBAGENT_STALL_MS=5000 /
+// SWITCHROOM_SUBAGENT_STALL_TERMINAL_MS=10000 in switchroom.yaml — see
+// PR #1110): a worker silent for >15s gets a *synthesized* terminal
+// turn_end mid-flight, which flips the watcher entry to `done` and
+// suppresses every later onProgress (the feed then never paints). Long
+// silent `sleep 20`s tripped exactly that. So we drive ~10 short steps,
+// each its own Bash call with a one-line narration, keeping the gap
+// between jsonl emissions ~2s — well under the 5s stall floor — for
+// ~30-40s total: long enough to clear the 8s first-paint, throttle, and
+// land several in-place edits before the real end_turn.
+const BG_DISPATCH_PROMPT =
+  `Use the Agent tool with subagent_type "general-purpose" and ` +
+  `run_in_background: true to dispatch a worker with this exact task: ` +
+  `"Do ten steps, ONE AT A TIME, k = 1 through 10. Before each step ` +
+  `write a brief one-sentence narration of what you are about to do, ` +
+  `then run \`sleep 2\` via the Bash tool, then run \`echo step-k\` via ` +
+  `the Bash tool (substitute the real number for k). Run every sleep and ` +
+  `every echo as its OWN separate Bash call — never batch or chain them ` +
+  `with && — and narrate before each so progress surfaces incrementally. ` +
+  `Do not stop early; complete all ten steps." After dispatching, send a ` +
+  `brief reply saying you've kicked off the background worker so I can ` +
+  `watch its progress.`;
+
+// The feed header rendered in Telegram: "🔧 Worker · <desc>" (running)
+// or "✅ Worker done · …" / "⚠️ Worker failed · …" (terminal).
+const WORKER_FEED_RE = /🔧\s*Worker|Worker done|Worker failed|⚡/i;
+const WORKER_DONE_RE = /✅\s*Worker done|⚠️\s*Worker failed/i;
+
+describe("uat: live worker-activity feed (#2000)", () => {
+  it(
+    "surfaces a background worker as a live, editing message that finalizes",
+    async () => {
+      const sc = await spinUp({ agent: "test-harness" });
+      try {
+        await sc.sendDM(BG_DISPATCH_PROMPT);
+
+        // Parent ack — some bot reply so we know the parent turn closed.
+        const ack = await sc.expectMessage(/.+/, {
+          from: "bot",
+          timeout: 45_000,
+        });
+        console.log(`[worker-feed UAT] parent ack: ${JSON.stringify(ack.text)}`);
+
+        // The worker-feed message. May arrive after the parent ack since
+        // first-paint waits for the worker to run ~8s and narrate.
+        const feed = await sc.expectMessage(WORKER_FEED_RE, {
+          from: "bot",
+          timeout: 75_000,
+        });
+        console.log(
+          `[worker-feed UAT] first feed paint (id=${feed.messageId}): ${JSON.stringify(feed.text)}`,
+        );
+        expect(feed.messageId).toBeGreaterThan(0);
+
+        // Live edit: snapshot, wait past the throttle + a heartbeat, and
+        // re-fetch the SAME message. Body should change as work advances.
+        // Soft: a very terse worker might narrate only once; we still
+        // require the terminal recap below, which is the load-bearing
+        // proof. Log either way so the real cadence is visible.
+        const before = feed.text;
+        await new Promise((r) => setTimeout(r, 12_000));
+        const mid = await sc.driver.getMessage(sc.botUserId, feed.messageId);
+        console.log(
+          `[worker-feed UAT] after 12s (id=${feed.messageId}): ${JSON.stringify(mid?.text ?? null)}`,
+        );
+        expect(mid, "worker-feed message vanished mid-flight").not.toBeNull();
+
+        // Terminal recap — poll the same message until it flips to the
+        // done/failed header. Generous budget: ~60s of work + finalize.
+        let doneText: string | null = null;
+        const deadline = Date.now() + 120_000;
+        while (Date.now() < deadline) {
+          const m = await sc.driver.getMessage(sc.botUserId, feed.messageId);
+          if (m != null && WORKER_DONE_RE.test(m.text)) {
+            doneText = m.text;
+            break;
+          }
+          await new Promise((r) => setTimeout(r, 5_000));
+        }
+        console.log(
+          `[worker-feed UAT] terminal (id=${feed.messageId}): ${JSON.stringify(doneText)}`,
+        );
+        expect(doneText, "worker-feed never reached a terminal recap").not.toBeNull();
+        expect(doneText!).toMatch(/tools?|tool ·/i);
+        // Did the body actually move between first paint and terminal?
+        expect(doneText).not.toBe(before);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    240_000,
+  );
+});


### PR DESCRIPTION
## Summary

Follow-up to #2000 (live worker-activity feed). Two changes:

1. **Real task description in the feed header.** The feed rendered
   `🔧 Worker · sub-agent` because the subagent-watcher never reassigns
   its `'sub-agent'` default from the worker jsonl. The dispatch-time
   description already lives in the registry `subagents.description`
   row, so onProgress + onFinish now prefer it. Header reads
   `🔧 Worker · <real task>`.

2. **Adds the mtcute UAT scenario** that exercises the feed end-to-end:
   first paint → in-place edit → terminal recap.

## Why

The original #2000 UAT used a worker doing three silent `sleep 20`s.
That tripped the **test-harness** stall override
(`SWITCHROOM_SUBAGENT_STALL_MS=5000` / `_STALL_TERMINAL_MS=10000`, set
in switchroom.yaml for PR #1110): a worker silent >15s gets a
*synthesized* terminal `turn_end` mid-flight, which flips the watcher
entry to `done` and **suppresses every later onProgress** — so the feed
never painted (root-caused live: handback fired at +15s of a 20s sleep,
before the worker's real `end_turn`). Production thresholds (60s/300s)
don't hit this, but the UAT worker must stay active. The new scenario
drives ~10 short narrated steps (~2s gaps) so the jsonl keeps ticking
under the 5s stall floor, and documents the coupling in a comment.

## Test plan

- [x] `worker-activity-feed.test.ts` 17/17 (vitest + bun)
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean
- [x] mtcute UAT `jtbd-worker-activity-feed-dm` **green** on
      test-harness v0.14.15 — paint at 00:09 (`⚡ Bash echo step-1
      (2 tools · 00:09)`), in-place edit, `✅ Worker done` terminal recap
- [ ] description polish re-validated live during post-release canary

## Risk

Low. Behaviour-gated behind `SWITCHROOM_WORKER_ACTIVITY_FEED` (default
off, test-harness only). The description change is a string-source swap
(registry value preferred over the watcher default); one extra column
on an already-issued indexed query. No change when the flag is off.