### PR TITLE
chore: release v0.14.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.14.16 — Worker-feed real task description + live UAT (#2002)
+
+Follow-up polish to the v0.14.15 worker-activity feed. The feed header
+rendered `🔧 Worker · sub-agent` because `entry.description` was never
+reassigned from its init default — the real dispatch description was
+sitting unused in the registry DB. The gateway now reads the real
+description from the `subagents` registry row in both the live
+(`onProgress`) and terminal (`onFinish`) paths, so the feed renders
+`🔧 Worker · <real task>` (e.g. `🔧 Worker · Background ten-step
+worker`). The `onFinish` restructure moves the feed `finish()` call
+after the registry query while keeping `deferredDoneReactions.promote()`
+unconditionally first — behaviour-preserving, reviewer-confirmed.
+
+Also lands the end-to-end mtcute UAT scenario
+(`jtbd-worker-activity-feed-dm`) that dispatches a real background
+worker and asserts the full feed lifecycle: first paint (`🔧 Worker`),
+in-place edit while work is in flight, and terminal recap (`✅ Worker
+done · … / N tools`). The UAT worker is paced (~10 short narrated steps,
+~2s jsonl gaps) to stay under the test-harness stall window
+(`SWITCHROOM_SUBAGENT_STALL_MS=5000`) so it runs to real completion
+instead of tripping a synthesized terminal turn_end mid-flight. Feed
+stays default-off (`SWITCHROOM_WORKER_ACTIVITY_FEED`).
+
 ## v0.14.15 — Background-worker visibility (#1999, #2000)
 
 A *background* sub-agent (`run_in_background: true`) decouples from the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.15",
+  "version": "0.14.16",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release v0.14.16 — worker-feed real task description + live UAT (#2002).

## Why

Follow-up polish to the v0.14.15 worker-activity feed: the feed header
rendered `🔧 Worker · sub-agent` because `entry.description` was never
reassigned from its init default. The gateway now reads the real
dispatch description from the `subagents` registry row in both the live
and terminal feed paths, so it renders `🔧 Worker · <real task>`. Also
lands the end-to-end mtcute UAT (`jtbd-worker-activity-feed-dm`)
asserting the full feed lifecycle.

## Test plan

- [x] `node scripts/build.mjs` → EXIT 0, dist/cli/switchroom.js present (~3MB)
- [x] Constituent PR #2002 reviewed APPROVE + 10/10 required checks green
- [x] worker-feed UAT GREEN on test-harness (run3, 120s, 1 passed)
- [ ] CI green on this release PR
- [ ] Post-tag: canary test-harness + re-run UAT, then staggered fleet rollout

## Risk

Low — release commit is CHANGELOG + version bump only. Feed stays
default-off fleet-wide (`SWITCHROOM_WORKER_ACTIVITY_FEED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)