### PR TITLE
fix(telegram): harden worker-feed real-description wiring + docs/comment sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -826,6 +826,17 @@ JTBDs — see "Design contract" above.)
 - **Config resolution** → `src/config/merge.ts` + `docs/configuration.md`.
 - **Progress card** → `telegram-plugin/stream-reply-handler.ts` +
   `telegram-plugin/card-format.ts` + `docs/telegram-plugin.md`.
+- **Background worker-activity feed** (flag
+  `SWITCHROOM_WORKER_ACTIVITY_FEED`, default off) → live edit-in-place
+  message per `run_in_background` sub-agent. Render in
+  `telegram-plugin/worker-activity-feed.ts`; wired in
+  `telegram-plugin/gateway/gateway.ts` `onProgress`/`onFinish`. The feed
+  header's real task description comes from the registry `subagents`
+  row via `telegram-plugin/gateway/worker-feed-dispatch.ts`
+  (`resolveWorkerFeedDispatch`, pinned by `worker-feed-dispatch.test.ts`)
+  — the watcher only carries a generic `'sub-agent'` placeholder, so do
+  NOT source the header from `subagent-watcher.ts`. E2E gate:
+  `telegram-plugin/uat/scenarios/jtbd-worker-activity-feed-dm.test.ts`.
 - **Auth** → `src/auth/accounts.ts` (slots) + `src/auth/manager.ts`
   (OAuth). Telegram `/auth` routing: `telegram-plugin/auth-slot-parser.ts`.
 - **Runtime inspection** → `switchroom debug turn <agent>` (prompt

--- a/docs/telegram-plugin.md
+++ b/docs/telegram-plugin.md
@@ -41,6 +41,29 @@ The plugin automatically reacts to the user's inbound message with a lifecycle p
 
 Stall watchdogs promote to 🥱 (30s idle) then 😨 (90s) so the user always knows the agent is alive. Tool-specific reactions show what the agent is doing (👨‍💻 for bash/edit, ⚡ for web search/fetch).
 
+### Background worker activity feed
+
+When an agent dispatches a sub-agent with `run_in_background: true`, that worker decouples from the parent turn — once the turn ends, a long-running worker would read as silence with nothing surfacing its progress. The worker-activity feed closes that gap.
+
+While the flag `SWITCHROOM_WORKER_ACTIVITY_FEED` is set (default **off**), the gateway posts **one regular Telegram message per background worker and edits it in place** as work happens:
+
+```
+🔧 Worker · Crawl the repo for dead code
+⚡ Bash rg --files (4 tools · 00:21)
+  ↳ Scanning src/ for unreferenced exports.
+```
+
+The header carries the **real dispatch task** (the `description` passed to the `Agent` tool), not a generic "sub-agent" label — it's read from the per-agent registry's `subagents` row. The message updates with the current tool, a running tool count, elapsed time, and a one-line summary, then finalizes to a terminal recap on completion:
+
+```
+✅ Worker done · Crawl the repo for dead code
+20 tools · 01:36
+```
+
+(Failures finalize to `⚠️ Worker failed · …`.) It's the same "live, growing message" shape the agent's own answer uses — not a separate pinned card. Independently, the turn's 👍 (done) reaction is **held** while any background worker is still running, so the reaction never implies the work finished while a worker is still grinding.
+
+The feed is off by default and is intended for agents that routinely fan out background work. Enable it per-agent by setting `SWITCHROOM_WORKER_ACTIVITY_FEED=1` in the agent's gateway environment.
+
 ### Message history
 
 A local SQLite database records every inbound and outbound message. After a Claude Code restart, the agent can call `get_recent_messages` to recover context instead of asking "what were we doing?". History survives process restarts and session resets.
@@ -175,3 +198,4 @@ The switchroom fork reads additional env vars from `start.sh`:
 | `TELEGRAM_STATE_DIR` | Auto-set by scaffold | Path to `telegram/` dir (history.db, access.json) |
 | `SWITCHROOM_AGENT_NAME` | Auto-set by scaffold | Agent name for self-restart detection |
 | `SWITCHROOM_CONFIG` | Auto-set by scaffold | Path to switchroom.yaml for config resolution |
+| `SWITCHROOM_WORKER_ACTIVITY_FEED` | Gateway env (opt-in) | `1` enables the background worker-activity feed (default off). See "Background worker activity feed" above |

--- a/reference/know-what-my-agent-is-doing.md
+++ b/reference/know-what-my-agent-is-doing.md
@@ -72,6 +72,18 @@ competent chat partner does this naturally:
 - **Sub-agent narration** in chat: *"spinning up @reviewer to look at
   this"* → *"@reviewer says: ship it, one nit on the logging."* Fleet
   visibility is a story the conversation tells.
+- **Background workers** are the one case the parent turn *can't*
+  narrate — a `run_in_background` sub-agent decouples, so when the
+  parent turn closes a long worker would read as silence. The
+  **worker-activity feed** (flag `SWITCHROOM_WORKER_ACTIVITY_FEED`,
+  default off) closes that gap: one regular Telegram message per
+  background worker, edited in place as work happens — current tool +
+  short summary + elapsed, headed by the real dispatch task
+  (*"🔧 Worker · <task>"*) — finalizing with a tool-count + duration
+  recap (*"✅ Worker done · …"*). Same "live, growing message" shape as
+  the agent's own answer, not a separate card. The turn's 👍 also holds
+  until the last background worker finishes, so the reaction never
+  implies done while a worker is still grinding.
 - **The final answer** as a fresh `reply` (pings once).
 
 A user scrolling back a week later reads a real conversation, not a

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -418,7 +418,8 @@ import {
   findMostRecentInterruptedTurn,
   findRecentTurnsForChat,
 } from '../registry/turns-schema.js'
-import { applySubagentsSchema } from '../registry/subagents-schema.js'
+import { applySubagentsSchema, getSubagentByJsonlId } from '../registry/subagents-schema.js'
+import { resolveWorkerFeedDispatch, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
 import { formatIdleFooter } from '../idle-footer.js'
 import { resolveCallingSubagent } from './resolve-calling-subagent.js'
 
@@ -17402,11 +17403,6 @@ void (async () => {
                 // independent of the gateway — see
                 // `subagent-handback-decision.test.ts`.
                 let fleetChatId = ''
-                let isBackground = false
-                // Dispatch-time task description from the registry row —
-                // see the onProgress note; used for the feed's terminal recap
-                // header so it matches the running header ("· <real task>").
-                let dispatchDesc = ''
                 try {
                   const fleets = progressDriver?.peekAllFleets() ?? []
                   for (const f of fleets) {
@@ -17419,17 +17415,18 @@ void (async () => {
                   // peek failures are non-fatal — fall through to the
                   // owner-chat fallback inside decideSubagentHandback.
                 }
+                // Background flag + feed header description, both derived from
+                // the registry row via the pure resolveWorkerFeedDispatch
+                // (worker-feed-dispatch.ts, pinned by its test). Best-effort:
+                // a DB hiccup keeps the watcher's generic label rather than
+                // throwing out of the terminal handler.
+                let dispatch: WorkerFeedDispatch = resolveWorkerFeedDispatch(null, description)
                 if (turnsDb != null) {
                   try {
-                    const row = turnsDb
-                      .prepare('SELECT background, description FROM subagents WHERE jsonl_agent_id = ?')
-                      .get(agentId) as { background: number; description: string | null } | undefined
-                    if (row != null) {
-                      isBackground = row.background === 1
-                      dispatchDesc = row.description ?? ''
-                    }
+                    dispatch = resolveWorkerFeedDispatch(getSubagentByJsonlId(turnsDb, agentId), description)
                   } catch { /* best-effort */ }
                 }
+                const isBackground = dispatch.isBackground
                 // #PR2 live worker-feed: force the terminal recap edit on
                 // the worker's live message. No-op when no message was ever
                 // posted (trivial workers stay silent; handback covers them).
@@ -17437,7 +17434,7 @@ void (async () => {
                 // it to 'done' so an already-posted message still finalizes.
                 if (workerFeedEnabled) {
                   void workerActivityFeed.finish(agentId, {
-                    description: dispatchDesc || description,
+                    description: dispatch.feedDescription,
                     lastTool: null,
                     toolCount,
                     latestSummary: resultText,
@@ -17517,12 +17514,6 @@ void (async () => {
               // lives in the `onFinish` block just above.
               onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx, lastTool, toolCount }) => {
                 let fleetChatId = ''
-                let isBackground = false
-                // The watcher's `description` is its 'sub-agent' default (it
-                // never reassigns it from the worker jsonl). The dispatch-time
-                // task description lives in the registry row — prefer it so the
-                // feed header reads "🔧 Worker · <real task>" not "· sub-agent".
-                let dispatchDesc = ''
                 try {
                   const fleets = progressDriver?.peekAllFleets() ?? []
                   for (const f of fleets) {
@@ -17532,17 +17523,18 @@ void (async () => {
                     }
                   }
                 } catch { /* peek failures non-fatal */ }
+                // The watcher's `description` is its 'sub-agent' default (it
+                // never reassigns it from the worker jsonl). The dispatch-time
+                // task description lives in the registry row — resolveWorkerFeedDispatch
+                // prefers it so the header reads "🔧 Worker · <real task>" not
+                // "· sub-agent" (worker-feed-dispatch.ts, pinned by its test).
+                let dispatch: WorkerFeedDispatch = resolveWorkerFeedDispatch(null, description)
                 if (turnsDb != null) {
                   try {
-                    const row = turnsDb
-                      .prepare('SELECT background, description FROM subagents WHERE jsonl_agent_id = ?')
-                      .get(agentId) as { background: number; description: string | null } | undefined
-                    if (row != null) {
-                      isBackground = row.background === 1
-                      dispatchDesc = row.description ?? ''
-                    }
+                    dispatch = resolveWorkerFeedDispatch(getSubagentByJsonlId(turnsDb, agentId), description)
                   } catch { /* best-effort */ }
                 }
+                const isBackground = dispatch.isBackground
                 if (!isBackground) return // skip overhead for foreground
 
                 // #PR2 live worker-feed: when ON, the worker's live chat
@@ -17556,7 +17548,7 @@ void (async () => {
                     agentId,
                     fleetChatId || (loadAccess().allowFrom[0] ?? ''),
                     {
-                      description: dispatchDesc || description,
+                      description: dispatch.feedDescription,
                       lastTool,
                       toolCount,
                       latestSummary,

--- a/telegram-plugin/gateway/worker-feed-dispatch.ts
+++ b/telegram-plugin/gateway/worker-feed-dispatch.ts
@@ -1,0 +1,37 @@
+import type { Subagent } from '../registry/subagents-schema.js'
+
+export interface WorkerFeedDispatch {
+  /** True when the sub-agent was dispatched with `run_in_background: true`. */
+  isBackground: boolean
+  /**
+   * The human-readable task to render in the feed header
+   * ("🔧 Worker · <feedDescription>").
+   */
+  feedDescription: string
+}
+
+/**
+ * Resolve the two registry-derived inputs the worker-activity feed needs:
+ * whether the sub-agent was a background dispatch, and the task description
+ * to show in the feed header.
+ *
+ * The live watcher only carries a generic 'sub-agent' label — it never
+ * reassigns `description` from the worker jsonl. The real dispatch-time
+ * description lives in the registry `subagents` row (written by the pretool
+ * hook from the `Agent(description:)` input). Prefer it; fall back to the
+ * watcher's label only when the row is missing or its description is empty.
+ *
+ * Pure + DB-free so it pins the #2002 behavior under both vitest and bun —
+ * see worker-feed-dispatch.test.ts. The gateway must never inline this
+ * decision again: a regression here silently reverts the feed header to
+ * "· sub-agent".
+ */
+export function resolveWorkerFeedDispatch(
+  sub: Subagent | null,
+  watcherDescription: string,
+): WorkerFeedDispatch {
+  return {
+    isBackground: sub?.background ?? false,
+    feedDescription: (sub?.description ?? '') || watcherDescription,
+  }
+}

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -73,7 +73,13 @@ export interface WorkerEntry {
   readonly agentId: string
   /** File path of the JSONL. */
   readonly filePath: string
-  /** Short description — from the sub-agent's first text/narrative line. */
+  /**
+   * Generic 'sub-agent' placeholder — the watcher deliberately does NOT
+   * reassign this from the worker jsonl (see the init at construction and
+   * the "Do NOT overwrite" note in the line-handler). The real dispatch-time
+   * task description lives in the registry `subagents` row; the gateway reads
+   * it there via resolveWorkerFeedDispatch for the worker-feed header.
+   */
   description: string
   /** Current lifecycle state. */
   state: WorkerState
@@ -864,6 +870,9 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     const entry: WorkerEntry = {
       agentId,
       filePath,
+      // Generic placeholder only — never overwritten from the jsonl. The
+      // gateway substitutes the real registry description for the worker
+      // feed (resolveWorkerFeedDispatch). See the WorkerEntry.description doc.
       description: 'sub-agent',
       state: 'running',
       dispatchedAt: n,

--- a/telegram-plugin/tests/worker-feed-dispatch.test.ts
+++ b/telegram-plugin/tests/worker-feed-dispatch.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import type { Subagent } from '../registry/subagents-schema.js'
+import { resolveWorkerFeedDispatch } from '../gateway/worker-feed-dispatch.js'
+
+function makeSub(over: Partial<Subagent>): Subagent {
+  return {
+    id: 'toolu_01ABC',
+    parent_session_id: null,
+    parent_turn_key: null,
+    agent_type: 'general-purpose',
+    description: null,
+    background: false,
+    started_at: 0,
+    last_activity_at: null,
+    ended_at: null,
+    status: 'running',
+    result_summary: null,
+    jsonl_agent_id: 'a37ad7639ae61476c',
+    ...over,
+  }
+}
+
+describe('resolveWorkerFeedDispatch (#2002 regression pin)', () => {
+  it('uses the real registry description for the feed header, not the watcher label', () => {
+    const sub = makeSub({ background: true, description: 'Background ten-step worker' })
+    const out = resolveWorkerFeedDispatch(sub, 'sub-agent')
+    expect(out.isBackground).toBe(true)
+    expect(out.feedDescription).toBe('Background ten-step worker')
+  })
+
+  it('falls back to the watcher label when the registry row is missing', () => {
+    const out = resolveWorkerFeedDispatch(null, 'sub-agent')
+    expect(out.isBackground).toBe(false)
+    expect(out.feedDescription).toBe('sub-agent')
+  })
+
+  it('falls back to the watcher label when the registry description is null', () => {
+    const sub = makeSub({ background: true, description: null })
+    const out = resolveWorkerFeedDispatch(sub, 'sub-agent')
+    expect(out.isBackground).toBe(true)
+    expect(out.feedDescription).toBe('sub-agent')
+  })
+
+  it('falls back to the watcher label when the registry description is empty', () => {
+    const sub = makeSub({ background: true, description: '' })
+    const out = resolveWorkerFeedDispatch(sub, 'sub-agent')
+    expect(out.feedDescription).toBe('sub-agent')
+  })
+
+  it('reports a foreground sub-agent as not background', () => {
+    const sub = makeSub({ background: false, description: 'inline helper' })
+    const out = resolveWorkerFeedDispatch(sub, 'sub-agent')
+    expect(out.isBackground).toBe(false)
+    // description still resolves — callers gate on isBackground separately.
+    expect(out.feedDescription).toBe('inline helper')
+  })
+
+  it('a missing row defaults isBackground false so the feed never fires blind', () => {
+    // The gateway gates the feed on isBackground; a registry miss must not
+    // flip a foreground turn into a background one.
+    expect(resolveWorkerFeedDispatch(null, '').isBackground).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Pin the #2002 worker-feed real-description behavior with a fast unit test so it can't silently regress (today it's only covered by the slow, non-gating UAT).
- Extract the duplicated inlined raw-SQL registry read in `gateway.ts` onProgress/onFinish into the existing typed `getSubagentByJsonlId` + a new DB-free pure helper `resolveWorkerFeedDispatch` (DRYs the two call sites, gives a regression pin).
- Sweep the stale comment on `subagent-watcher.ts:77` that misled readers into thinking `WorkerEntry.description` carries the real task name (it's a generic `'sub-agent'` placeholder, never reassigned).
- Update JTBD (`reference/know-what-my-agent-is-doing.md`), user docs (`docs/telegram-plugin.md` + env table), and agent guidance (`CLAUDE.md`).

## Why
The worker-activity feed's headline value is the **real dispatch task** in the header (`🔧 Worker · <task>`). That wiring (registry `description` → feed) had no fast test pinning it — a refactor could swap it back to the watcher's `'sub-agent'` label and only the slow UAT would catch it. This adds the pin and removes the comment that would actively mislead the next agent into sourcing the header from the watcher.

## Test plan
- [x] `tsc --noEmit` EXIT 0
- [x] `check-bot-api-wrapping.sh` clean (gateway.ts line shifts absorbed)
- [x] `check-plugin-references.mjs` clean
- [x] vitest: worker-feed-dispatch (6) + worker-activity-feed (17) + subagent-progress-inbound-builder (18)
- [x] bun: worker-feed-dispatch (6) + subagent-tracker-hooks (10)
- [ ] UAT `jtbd-worker-activity-feed-dm` (pre-rollout gate)

## Risk
Low — behavior-preserving gateway refactor onto an already-tested helper plus a new pure helper; no flag-state or default change (feed stays default-off fleet-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)