### PR TITLE
chore: release v0.14.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.14.17 — Worker-feed hardening: regression pin + docs/comment sweep (#2004)
+
+Hardening pass on the v0.14.15/16 worker-activity feed — no behaviour
+change, all default-off.
+
+The real-task-description wiring shipped in #2002 (feed header renders
+`🔧 Worker · <real task>` from the `subagents` registry row) had no fast
+test pinning it — only the slow, non-gating mtcute UAT. A refactor could
+have silently swapped it back to the watcher's generic `'sub-agent'`
+placeholder and CI would stay green. This release closes that gap:
+
+- New DB-free pure helper `resolveWorkerFeedDispatch(sub, watcherDescription)`
+  (`telegram-plugin/gateway/worker-feed-dispatch.ts`) returns
+  `{ isBackground, feedDescription }`, preferring a non-empty registry
+  description and falling back to the watcher label on null/empty.
+  Pinned by `worker-feed-dispatch.test.ts` (6 cases, runs under both
+  vitest and bun).
+- `gateway.ts` `onProgress`/`onFinish` now route the registry read
+  through the typed `getSubagentByJsonlId` helper + `resolveWorkerFeedDispatch`,
+  replacing two copies of inlined raw SQL — behaviour-preserving,
+  reviewer-confirmed equivalent.
+- Swept the stale `subagent-watcher.ts` comment that implied
+  `WorkerEntry.description` carries the real task name (it's a fixed
+  `'sub-agent'` placeholder, never reassigned) — it now points readers
+  at `resolveWorkerFeedDispatch`.
+- Updated JTBD (`reference/know-what-my-agent-is-doing.md`), user docs
+  (`docs/telegram-plugin.md` + env-var table), and agent guidance
+  (`CLAUDE.md`).
+
 ## v0.14.16 — Worker-feed real task description + live UAT (#2002)
 
 Follow-up polish to the v0.14.15 worker-activity feed. The feed header

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.16",
+  "version": "0.14.17",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Release v0.14.17 — worker-feed hardening (regression pin + docs/comment sweep). Bundles #2004.

No behaviour change; feed remains default-off (`SWITCHROOM_WORKER_ACTIVITY_FEED`).

## Changes
- Version bump 0.14.16 → 0.14.17.
- CHANGELOG entry for the #2004 hardening pass (pure helper `resolveWorkerFeedDispatch` + unit pin, gateway raw-SQL → typed helper, stale-comment sweep, JTBD/docs/CLAUDE.md updates).

## Risk
Trivial — release bookkeeping over an already-reviewed-and-merged feature PR (#2004, reviewer APPROVE).