### PR TITLE
test(telegram): fuzz worker-feed dispatch resolution (20k random rows)

### DIFF
--- a/telegram-plugin/tests/worker-feed-dispatch.test.ts
+++ b/telegram-plugin/tests/worker-feed-dispatch.test.ts
@@ -61,3 +61,80 @@ describe('resolveWorkerFeedDispatch (#2002 regression pin)', () => {
     expect(resolveWorkerFeedDispatch(null, '').isBackground).toBe(false)
   })
 })
+
+// Deterministic PRNG (mulberry32) so a failing case is reproducible from the
+// printed seed rather than flaking once and vanishing.
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+// Adversarial description fragments the gateway might hand us — empty, the
+// literal watcher placeholder, whitespace-only, control chars, multi-byte
+// unicode/emoji, and a pathologically long task. A registry description is
+// only "real" (must win the feed header) when it's a non-empty string.
+const DESC_POOL: (string | null)[] = [
+  null,
+  '',
+  'sub-agent',
+  '   ',
+  '\n\t',
+  'Background ten-step worker',
+  'Crawl the repo for dead code',
+  '🔧 deploy · staging',
+  'café — naïve façade',
+  '0',
+  'false',
+  'a'.repeat(4096),
+  'line1\nline2\nline3',
+  'desc with "quotes" & <tags>',
+]
+
+const WATCHER_POOL = ['sub-agent', '', 'sub-agent ', 'fallback', '🤖', 'x'.repeat(512)]
+
+describe('resolveWorkerFeedDispatch — randomized property sweep', () => {
+  it('holds the #2002 invariants across 20k random registry rows', () => {
+    for (let seed = 1; seed <= 20000; seed++) {
+      const rng = mulberry32(seed)
+      const pick = <T>(arr: T[]): T => arr[Math.floor(rng() * arr.length)]!
+
+      const rowMissing = rng() < 0.25
+      const background = rng() < 0.5
+      const description = pick(DESC_POOL)
+      const watcher = pick(WATCHER_POOL)
+      const sub = rowMissing ? null : makeSub({ background, description })
+
+      const out = resolveWorkerFeedDispatch(sub, watcher)
+      const ctx = `seed=${seed} rowMissing=${rowMissing} bg=${background} desc=${JSON.stringify(description)} watcher=${JSON.stringify(watcher)}`
+
+      // 1. Types are always concrete — the feed renderer never sees undefined.
+      expect(typeof out.isBackground, ctx).toBe('boolean')
+      expect(typeof out.feedDescription, ctx).toBe('string')
+
+      // 2. isBackground mirrors the row (or false when missing) — a registry
+      //    miss must never promote a foreground turn into a background one.
+      expect(out.isBackground, ctx).toBe(rowMissing ? false : background)
+
+      const realDescription =
+        !rowMissing && typeof description === 'string' && description.length > 0
+
+      if (realDescription) {
+        // 3. THE bug guard: a real registry description always wins the header,
+        //    regardless of the watcher's generic 'sub-agent' placeholder.
+        expect(out.feedDescription, ctx).toBe(description)
+      } else {
+        // 4. Otherwise we fall back to exactly the watcher label, untouched.
+        expect(out.feedDescription, ctx).toBe(watcher)
+      }
+
+      // 5. Pure + deterministic: identical inputs yield a deep-equal result.
+      expect(resolveWorkerFeedDispatch(sub, watcher), ctx).toEqual(out)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
Adds a seeded, randomized property sweep for `resolveWorkerFeedDispatch` (the #2002 worker-feed header wiring), which previously had only 6 example-based cases.

## Why
The operator asked, fairly, whether the worker-feed hardening was *fuzz*-tested — it wasn't. The helper is a pure function that decides whether the feed header shows the real dispatch task or falls back to the watcher's generic `sub-agent` placeholder. That precedence is exactly the bug #2002 fixed, so it deserves randomized coverage, not just hand-picked examples.

## What
- 20k iterations, deterministic `mulberry32(seed)` PRNG so any failure is reproducible from the printed seed/context.
- Adversarial description pool: `null`, `''`, the literal `'sub-agent'`, whitespace-only, control chars, multi-byte unicode/emoji, `'0'`/`'false'` truthiness traps, a 4 KB task, embedded newlines/quotes/tags — crossed with random background/null-row/watcher combos.
- Invariants asserted: real registry description always wins the header; otherwise feedDescription === the watcher label untouched; `isBackground` mirrors the row and is `false` on a registry miss; types stay concrete; pure/deterministic.
- **Mutation-verified**: inverting the helper precedence (watcher wins) turns the sweep red, so it genuinely guards the regression.

## Test plan
- [x] vitest: 7/7 pass
- [x] bun: 7/7 pass (100,010 expect() calls)
- [x] tsc --noEmit clean
- [x] mutation check: precedence inversion → red

## Risk
None — test-only addition; runtime helper untouched. Does not ship to agents (tests aren't in the runtime bundle), so no release/rollout needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)