### PR TITLE
feat(telegram): coalesce forwarded/split-paste bursts into one turn

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `channels.telegram.deferred_completion_timeout_ms` | override | Progress-card: force-close timeout (ms) after parent `turn_end` while sub-agents are still running (default 180000) |
 | `channels.telegram.sub_agent_tick_interval_ms` | override | Progress-card: elapsed-counter tick interval (ms) while a sub-agent is running (default 10000) |
 | `channels.telegram.edit_budget_threshold` | override | Progress-card: card-edit budget per minute before throttled mode (default 18) |
+| `channels.telegram.coalesce.window_ms` | override | Sliding-window (ms) for merging consecutive inbound messages from the same sender+topic into ONE Claude turn. A forwarded burst or a long paste that Telegram splits across several messages arrives as a single shared-context turn instead of N rapid-fire turns. Each new message resets the timer. Default `500`. Set `0` to disable coalescing (each message is its own turn). The 👀 acknowledgement still fires immediately, so perceived latency is unchanged. |
 | `settings_raw` | deep merge | Escape hatch: raw settings.json overrides |
 | `claude_md_raw` | concatenate | Escape hatch: append to CLAUDE.md on scaffold |
 | `cli_args` | concatenate | Escape hatch: extra `exec claude` flags |

--- a/docs/telegram-features.md
+++ b/docs/telegram-features.md
@@ -1,8 +1,9 @@
 # Telegram features
 
-Three opt-in features tune how an agent talks on Telegram. All three
-land under `channels.telegram.*` in `switchroom.yaml` and cascade
-through the standard defaults → profile → agent layering.
+Several features tune how an agent talks on Telegram. They all land
+under `channels.telegram.*` in `switchroom.yaml` and cascade through
+the standard defaults → profile → agent layering. The first three are
+opt-in; inbound coalescing is default-on.
 
 The `switchroom telegram` CLI verb is the supported way to turn each
 one on. Hand-editing `switchroom.yaml` works too — the CLI just edits
@@ -62,6 +63,42 @@ itself still runs through your Pro/Max subscription.
 switchroom telegram enable voice-in --agent gymbro --api-key sk-...
 # stores the key in the vault, sets channels.telegram.voice_in.enabled
 ```
+
+## Inbound coalescing
+
+**What:** consecutive inbound messages from the same sender in the same
+topic are buffered for a short sliding window and merged into ONE Claude
+turn. When you forward a handful of messages at once, or paste a long
+block of text that Telegram silently splits into several messages, the
+agent sees them as a single shared-context turn instead of replying to
+each fragment in isolation.
+
+**Why:** a forwarded burst is usually one thought. Without coalescing
+the agent answers message 1 before messages 2–4 have even arrived, so
+it reasons with partial context and fires several disjoint replies.
+
+**Default-on, no setup.** This runs at the default 500ms window with
+zero config. The 👀 acknowledgement still fires the moment your first
+message lands, so the wait for the window to close is invisible.
+
+**Tune it** (yaml only — no CLI verb):
+
+```yaml
+channels:
+  telegram:
+    coalesce:
+      window_ms: 500   # default; raise for slower forwards, 0 to disable
+```
+
+Cascades through defaults → profile → agent like every other
+`channels.telegram.*` knob. `window_ms: 0` disables coalescing (each
+message becomes its own turn). Takes effect on the next message after
+`switchroom apply` + agent restart.
+
+**Scope (v1):** a coalesced turn carries the merged text plus at most
+one attachment. A second photo/document — or an album — starts a fresh
+turn rather than dropping the extra media, so nothing is silently lost.
+Full multi-attachment / album grouping is a follow-up.
 
 ## Webhook ingest
 

--- a/reference/steer-or-queue-mid-flight.md
+++ b/reference/steer-or-queue-mid-flight.md
@@ -63,6 +63,7 @@ user thinking they steered when they actually queued, or vice versa.
 - **Steer** = `/steer ` or `/s ` prefix. Explicit opt-in to course-correct the in-flight task. The agent receives the body with `<channel steering="true">` and treats it as an amendment to the current work.
 - **Interrupt + new task** = `!`-prefix marker (#575, gateway-side). A message starting with `!` SIGINTs the agent, strips the marker, and forwards the body as a fresh turn. Empty `!` triggers a "send your replacement instruction now" reply rather than forwarding nothing. The CLAUDE.md template tells the agent the rule so it can teach the user when asked.
 - **What the user sees**: 🤝 reaction on a `/steer` message confirms the steer landed mid-turn; ⚡ reaction on a `!` message confirms the interrupt landed; queued messages get the normal 👀 (received) reaction since they're a fresh turn from the agent's perspective. The agent self-narrates the classification at the top of its reply (e.g. `_↪️ Treating as steer on the prior task_` or `_📥 Queued as a new task_`) so the chosen path is visible, not inferred.
+- **Inbound coalescing** (default-on, `channels.telegram.coalesce.window_ms`, default 500ms). Before any of the above classification runs, consecutive messages from the same sender+topic within the window are merged into one turn. This is what makes a forwarded burst — or a long paste Telegram split into several messages — count as a single thought instead of N fragments racing the turn boundary. If part of a burst lands while a turn is already in flight (so the rest is buffered), the buffered fragments re-merge on drain rather than fanning out into separate queued turns. The window is sub-second and the 👀 ack fires on the first message, so coalescing is invisible to the user.
 
 ## UAT prompts
 
@@ -77,6 +78,10 @@ user thinking they steered when they actually queued, or vice versa.
   not pick up hallucinated context from the first.
 - **Rapid-fire follow-ups.** Send several messages while one task is
   running. None should be lost.
+- **Forwarded burst / split paste.** Forward 3–4 messages at once (or
+  paste a long block Telegram splits into several). The agent should
+  answer them as ONE turn with shared context, not reply to each
+  fragment separately.
 - **Unsafe interrupt point.** Send a steer while the agent is mid-tool-call.
   The amendment should take effect at a safe boundary, not corrupt
   the tool call.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -5341,6 +5341,14 @@ function buildAccessJson(
   if (tg?.telegraph) {
     access.telegraph = tg.telegraph;
   }
+  // Inbound coalescing window. Projected into the long-standing
+  // `coalescingGapMs` access field the gateway already reads per-message
+  // (createInboundCoalescer gapMs callback) so config-driven tuning takes
+  // effect at the next message after a scaffold+restart. Cascades from
+  // defaults.channels.telegram.coalesce.window_ms.
+  if (typeof tg?.coalesce?.window_ms === "number") {
+    access.coalescingGapMs = tg.coalesce.window_ms;
+  }
 
   return JSON.stringify(access, null, 2) + "\n";
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -641,6 +641,31 @@ export const TelegramChannelSchema = z
         "Cascades from defaults.channels.telegram.telegraph. " +
         "(Migrated from per-agent root in #596.)"
       ),
+    coalesce: z
+      .object({
+        window_ms: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe(
+            "Sliding-window (ms) for merging consecutive inbound messages from " +
+            "the same sender+topic into ONE Claude turn. Each new message resets " +
+            "the timer; the turn starts once the sender pauses for this long. " +
+            "Catches forwarded bursts, pasted text the Telegram client split " +
+            "into several messages, and mixed text+media forwards. Default 500. " +
+            "Set 0 to disable (every message becomes its own turn). Raise for " +
+            "users who think in multiple short messages; the trade-off is the " +
+            "single-message turn start is delayed by this much (the 👀 ack still " +
+            "fires immediately, so perceived latency is unchanged)."
+          ),
+      })
+      .optional()
+      .describe(
+        "Inbound coalescing — how the gateway groups rapid consecutive messages " +
+        "into a single turn so a forwarded album or split paste doesn't fan out " +
+        "into N separate turns. Cascades from defaults.channels.telegram.coalesce."
+      ),
     webhook_sources: z
       .array(z.enum(["github", "generic"]))
       .optional()

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2997,10 +2997,12 @@ type AttachmentMeta = {
 // `ctx` must be the *latest* message's context (latest message_id, etc.) so
 // the merge function picks the last entry's ctx.
 //
-// Image/attachment-bearing messages bypass the coalescer entirely (see
-// handleInboundCoalesced), so those fields stay optional and unused on the
-// coalesce path; preserved for future use if we ever want to coalesce
-// image+text bursts.
+// A single attachment-bearing message may ride along in a coalesce window
+// (so a [text][photo] forward becomes one turn). The handleInboundCoalesced
+// guards ensure AT MOST ONE attachment per window — albums (media_group_id)
+// and a second attachment both bypass to their own turn — so the single
+// `downloadImage`/`attachment` slot is never silently overwritten. Folding a
+// whole album into one multi-attachment turn is the A2 follow-on.
 type CoalescePayload = {
   text: string
   ctx: Context
@@ -3008,24 +3010,36 @@ type CoalescePayload = {
   attachment?: AttachmentMeta
 }
 
+// Coalesce keys whose open window already holds an attachment-bearing entry.
+// A second attachment for the same key bypasses coalescing (see
+// handleInboundCoalesced) so the single-attachment merge can't drop a photo.
+// Cleared on flush (below) and on the synchronous bypass path.
+const bufferedAttachmentKeys = new Set<string>()
+
 const inboundCoalescer = createInboundCoalescer<CoalescePayload>({
-  // Read per-call from the access file so `/access set-coalesce N` takes
-  // effect on the next message without restarting the gateway.
+  // Read per-call from the access file so an operator-tuned
+  // channels.telegram.coalesce.window_ms (projected to coalescingGapMs by
+  // scaffold) takes effect on the next message after apply+restart.
   //
   // Default lowered 1500 → 500 in #553 PR 3 to shrink the gateway-side
-  // contribution to first-real-text latency. Operators can still tune
-  // higher via `/access set-coalesce N` or the access file.
+  // contribution to first-real-text latency.
   gapMs: () => loadAccess().coalescingGapMs ?? 500,
   merge: (entries) => {
     const last = entries[entries.length - 1]
+    // At most one entry carries an attachment (guarded upstream), so pick
+    // whichever entry has it rather than blindly taking `last` — a
+    // [photo][text] burst keeps its image even though the last entry is
+    // text-only.
+    const withAttachment = entries.find((e) => e.downloadImage != null || e.attachment != null)
     return {
       text: entries.map((e) => e.text).join('\n'),
       ctx: last.ctx,
-      downloadImage: last.downloadImage,
-      attachment: last.attachment,
+      downloadImage: withAttachment?.downloadImage,
+      attachment: withAttachment?.attachment,
     }
   },
-  onFlush: (_key, merged) => {
+  onFlush: (key, merged) => {
+    bufferedAttachmentKeys.delete(key)
     void handleInbound(merged.ctx, merged.text, merged.downloadImage, merged.attachment)
   },
 })
@@ -8534,23 +8548,45 @@ async function handleInboundCoalesced(
   downloadImage: (() => Promise<string | undefined>) | undefined,
   attachment?: AttachmentMeta,
 ): Promise<void> {
-  // Image/attachment-bearing messages bypass coalescing — preserves the
-  // legacy invariant that media never gets merged with sibling text.
-  if (downloadImage || attachment) return handleInbound(ctx, text, downloadImage, attachment)
-
-  // `!`-prefix interrupt (#575) ALSO bypasses coalescing. If we let an
+  // `!`-prefix interrupt (#575) bypasses coalescing. If we let an
   // interrupt sit in the coalesce window, an earlier non-`!` message
   // arriving in the same window would prepend itself and the marker
   // would no longer be at position 0 — handleInbound's parser would
   // miss it and the user's interrupt would silently get merged into a
   // normal turn. Bypass to handleInbound directly so the marker
-  // stays at the start of the text.
+  // stays at the start of the text. Checked first so a `!`-prefixed
+  // media caption still interrupts.
   if (parseInterruptMarker(text).isInterrupt) {
-    return handleInbound(ctx, text, undefined, undefined)
+    return handleInbound(ctx, text, downloadImage, attachment)
+  }
+
+  const hasAttachment = downloadImage != null || attachment != null
+
+  // Albums (media_group_id) are NOT coalesced in A1 — each part keeps its
+  // own turn exactly as before. The single-attachment merge can carry only
+  // one image, so folding a 3-photo album into one turn requires the
+  // multi-attachment inbound payload (the A2 follow-on). Bypass to preserve
+  // current per-part behavior and avoid dropping sibling photos.
+  if (hasAttachment && ctx.message?.media_group_id != null) {
+    return handleInbound(ctx, text, downloadImage, attachment)
   }
 
   const from = ctx.from
   if (!from) return
+
+  // A second attachment landing in an already-open window would clobber the
+  // first under the single-attachment merge. Bypass it to its own turn so no
+  // media is silently dropped; A2's multi-attachment payload lifts this.
+  if (hasAttachment) {
+    const probeKey = inboundCoalesceKey(
+      String(ctx.chat!.id),
+      ctx.message?.message_thread_id,
+      String(from.id),
+    )
+    if (bufferedAttachmentKeys.has(probeKey)) {
+      return handleInbound(ctx, text, downloadImage, attachment)
+    }
+  }
 
   // F2 fix (#553): fire 👀 reaction on RAW arrival, before the coalesce
   // wait blocks first paint. Pre-fix, the controller's setQueued() inside
@@ -8581,7 +8617,12 @@ async function handleInboundCoalesced(
     String(from.id),
   )
   const result = inboundCoalescer.enqueue(key, { text, ctx, downloadImage, attachment })
-  if (result.bypass) return handleInbound(ctx, text, undefined, undefined)
+  // Coalescing disabled (window <= 0): flush immediately, preserving any
+  // media this message carried.
+  if (result.bypass) return handleInbound(ctx, text, downloadImage, attachment)
+  // Mark the open window as holding an attachment so a second attachment for
+  // this key bypasses rather than clobbers (cleared in onFlush).
+  if (hasAttachment) bufferedAttachmentKeys.add(key)
 }
 
 /**
@@ -15560,7 +15601,7 @@ bot.on('message:text', async ctx => {
 
 bot.on('message:photo', async ctx => {
   const caption = ctx.message.caption ?? '(photo)'
-  await handleInbound(ctx, caption, async () => {
+  await handleInboundCoalesced(ctx, caption, async () => {
     const photos = ctx.message.photo
     const best = photos[photos.length - 1]
     try {
@@ -15603,7 +15644,7 @@ bot.on('message:photo', async ctx => {
 bot.on('message:document', async ctx => {
   const doc = ctx.message.document
   const name = safeName(doc.file_name)
-  await handleInbound(ctx, ctx.message.caption ?? `(document: ${name ?? 'file'})`, undefined, { kind: 'document', file_id: doc.file_id, size: doc.file_size, mime: doc.mime_type, name })
+  await handleInboundCoalesced(ctx, ctx.message.caption ?? `(document: ${name ?? 'file'})`, undefined, { kind: 'document', file_id: doc.file_id, size: doc.file_size, mime: doc.mime_type, name })
 })
 
 bot.on('message:voice', async ctx => {
@@ -15626,7 +15667,7 @@ bot.on('message:voice', async ctx => {
       const text = ctx.message.caption
         ? `${ctx.message.caption}\n\n[voice transcript] ${transcript}`
         : `[voice transcript] ${transcript}`
-      await handleInbound(ctx, text, undefined, {
+      await handleInboundCoalesced(ctx, text, undefined, {
         kind: 'voice',
         file_id: voice.file_id,
         size: voice.file_size,
@@ -15636,7 +15677,7 @@ bot.on('message:voice', async ctx => {
     }
     // Fall through to the legacy path on transcription failure.
   }
-  await handleInbound(ctx, ctx.message.caption ?? '(voice message)', undefined, { kind: 'voice', file_id: voice.file_id, size: voice.file_size, mime: voice.mime_type })
+  await handleInboundCoalesced(ctx, ctx.message.caption ?? '(voice message)', undefined, { kind: 'voice', file_id: voice.file_id, size: voice.file_size, mime: voice.mime_type })
 })
 
 /**
@@ -15728,17 +15769,17 @@ async function maybeTranscribeVoice(
 bot.on('message:audio', async ctx => {
   const audio = ctx.message.audio
   const name = safeName(audio.file_name)
-  await handleInbound(ctx, ctx.message.caption ?? `(audio: ${safeName(audio.title) ?? name ?? 'audio'})`, undefined, { kind: 'audio', file_id: audio.file_id, size: audio.file_size, mime: audio.mime_type, name })
+  await handleInboundCoalesced(ctx, ctx.message.caption ?? `(audio: ${safeName(audio.title) ?? name ?? 'audio'})`, undefined, { kind: 'audio', file_id: audio.file_id, size: audio.file_size, mime: audio.mime_type, name })
 })
 
 bot.on('message:video', async ctx => {
   const video = ctx.message.video
-  await handleInbound(ctx, ctx.message.caption ?? '(video)', undefined, { kind: 'video', file_id: video.file_id, size: video.file_size, mime: video.mime_type, name: safeName(video.file_name) })
+  await handleInboundCoalesced(ctx, ctx.message.caption ?? '(video)', undefined, { kind: 'video', file_id: video.file_id, size: video.file_size, mime: video.mime_type, name: safeName(video.file_name) })
 })
 
 bot.on('message:video_note', async ctx => {
   const vn = ctx.message.video_note
-  await handleInbound(ctx, '(video note)', undefined, { kind: 'video_note', file_id: vn.file_id, size: vn.file_size })
+  await handleInboundCoalesced(ctx, '(video note)', undefined, { kind: 'video_note', file_id: vn.file_id, size: vn.file_size })
 })
 
 bot.on('message:sticker', async ctx => {
@@ -15753,7 +15794,7 @@ bot.on('message:sticker', async ctx => {
   if (sticker.emoji) parts.push(sticker.emoji)
   if (sticker.set_name) parts.push(`from "${sticker.set_name}"`)
   const text = parts.length > 0 ? `(sticker — ${parts.join(' ')})` : '(sticker)'
-  await handleInbound(ctx, text, undefined, { kind: 'sticker', file_id: sticker.file_id, size: sticker.file_size })
+  await handleInboundCoalesced(ctx, text, undefined, { kind: 'sticker', file_id: sticker.file_id, size: sticker.file_size })
 })
 
 bot.on('message:animation', async ctx => {
@@ -15766,7 +15807,7 @@ bot.on('message:animation', async ctx => {
   const animation = ctx.message.animation
   const caption = ctx.message.caption
   const text = caption ? `(gif) ${caption}` : '(gif)'
-  await handleInbound(ctx, text, undefined, {
+  await handleInboundCoalesced(ctx, text, undefined, {
     kind: 'animation',
     file_id: animation.file_id,
     size: animation.file_size,

--- a/telegram-plugin/gateway/inbound-coalesce.ts
+++ b/telegram-plugin/gateway/inbound-coalesce.ts
@@ -34,10 +34,11 @@ export interface InboundCoalescerOptions<T> {
    * `{ bypass: true }` and the caller should flush immediately).
    *
    * Pass a function (`() => number`) instead of a number when the
-   * window is config-driven and the operator can change it at runtime
-   * — gateway.ts reads it per-call from the access file so a
-   * `/access set-coalesce 500` takes effect on the next message
-   * without restarting the gateway.
+   * window is config-driven: gateway.ts reads it per-call from the
+   * access file (projected there from
+   * `channels.telegram.coalesce.window_ms` by the scaffold) so an
+   * operator-tuned window takes effect on the next message after
+   * apply + restart.
    */
   gapMs: number | (() => number)
   /**
@@ -146,9 +147,9 @@ export function createInboundCoalescer<T>(opts: InboundCoalescerOptions<T>): Inb
  *     CPO decision #9 ratified 2026-05-27)
  *
  * `threadId` collapses `null`/`undefined`/`0` to `_` via the same
- * convention as `chatKey()`. The 1.5s coalesce window is per-topic
- * intent ("user sends 3 sentences as one thought") — applying it
- * cross-topic merges genuinely separate conversations.
+ * convention as `chatKey()`. The coalesce window (default 500ms) is
+ * per-topic intent ("user sends 3 sentences as one thought") — applying
+ * it cross-topic merges genuinely separate conversations.
  */
 export function inboundCoalesceKey(
   chatId: string,

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -91,26 +91,117 @@ export function redeliverBufferedInbound(
   const pending = buffer.drain(agent)
   let redelivered = 0
   let rebuffered = 0
-  for (const msg of pending) {
+  // Collapse consecutive same-sender Telegram user messages into one turn
+  // (see planBufferedRedelivery) so a forwarded burst that spanned a turn
+  // boundary doesn't fan out into N sequential replies. System inbounds
+  // (vault grants, approvals, cron, handbacks — anything with meta.source)
+  // are never merged and are delivered individually exactly as before.
+  for (const { merged, originals } of planBufferedRedelivery(pending)) {
     let delivered = false
     try {
-      delivered = send(msg)
+      delivered = send(merged)
     } catch {
       delivered = false
     }
     if (delivered) {
-      redelivered++
       // Confirmed delivery to a live registered bridge → the durable
-      // promise is kept; tombstone the spool entry so it is NOT
-      // boot-replayed again. A miss leaves it spooled (re-pushed below
-      // AND still live in the spool) for the next drain / escalation.
-      spool?.ack(msg)
+      // promise is kept; tombstone EVERY original's spool entry so none is
+      // boot-replayed again. The merged message isn't itself spooled — the
+      // originals are, so we ack by original identity.
+      for (const o of originals) spool?.ack(o)
+      redelivered += originals.length
     } else {
-      buffer.push(agent, msg)
-      rebuffered++
+      // Re-buffer the originals (not the merged synthetic) so the spool
+      // identity is preserved and the next drain re-merges them losslessly.
+      for (const o of originals) buffer.push(agent, o)
+      rebuffered += originals.length
     }
   }
   return { drained: pending.length, redelivered, rebuffered }
+}
+
+/** True when `msg` is an ordinary Telegram user message eligible to be
+ *  merged with adjacent siblings. System inbounds (cron, vault grants,
+ *  approvals, subagent handbacks, warmup, reaction triggers) all tag a
+ *  `meta.source`; the user-message inbound built in gateway.ts sets none.
+ *  Restricting to source-less inbounds keeps merge-on-drain away from the
+ *  #1150 wake-up class entirely. */
+function isMergeableUserInbound(msg: InboundMessage): boolean {
+  return msg.type === 'inbound' && (msg.meta == null || msg.meta.source == null)
+}
+
+function inboundHasMedia(msg: InboundMessage): boolean {
+  return msg.imagePath != null || msg.attachment != null
+}
+
+/**
+ * Plan how a drained buffer is re-delivered. Walks `pending` in arrival
+ * order and groups runs of consecutive messages that:
+ *   - are both ordinary Telegram user messages (no meta.source), AND
+ *   - share the same (chatId, threadId, userId), AND
+ *   - would not put two attachments in one turn (A1 carries a single
+ *     attachment; a second media starts a new run so nothing is dropped).
+ *
+ * Each run collapses to one merged InboundMessage (texts joined by '\n',
+ * the run's single attachment carried, the LAST message's identity/meta
+ * kept as the turn anchor). A run of one passes through unchanged. The
+ * returned `originals` preserve spool identity for ack / re-buffer.
+ *
+ * Pure + deterministic so it can be exhaustively fuzzed.
+ */
+export function planBufferedRedelivery(
+  pending: InboundMessage[],
+): { merged: InboundMessage; originals: InboundMessage[] }[] {
+  const out: { merged: InboundMessage; originals: InboundMessage[] }[] = []
+  let run: InboundMessage[] = []
+  let runHasMedia = false
+
+  const sameTarget = (a: InboundMessage, b: InboundMessage): boolean =>
+    a.chatId === b.chatId &&
+    (a.threadId ?? null) === (b.threadId ?? null) &&
+    a.userId === b.userId
+
+  const flush = (): void => {
+    if (run.length === 0) return
+    out.push({ merged: run.length === 1 ? run[0]! : mergeRun(run), originals: run })
+    run = []
+    runHasMedia = false
+  }
+
+  for (const msg of pending) {
+    const msgHasMedia = inboundHasMedia(msg)
+    const canJoin =
+      run.length > 0 &&
+      isMergeableUserInbound(msg) &&
+      isMergeableUserInbound(run[run.length - 1]!) &&
+      sameTarget(run[run.length - 1]!, msg) &&
+      !(runHasMedia && msgHasMedia)
+    if (!canJoin) flush()
+    run.push(msg)
+    runHasMedia = runHasMedia || msgHasMedia
+  }
+  flush()
+  return out
+}
+
+/** Collapse a >1 run into a single turn. The newest message anchors the
+ *  turn (its messageId/ts/user/meta); texts join in arrival order; the
+ *  single attachment (if any) rides along from whichever message carried
+ *  it. Caller guarantees the run is mergeable + has at most one media. */
+function mergeRun(run: InboundMessage[]): InboundMessage {
+  const last = run[run.length - 1]!
+  const mediaEntry = run.find(inboundHasMedia)
+  const merged: InboundMessage = {
+    ...last,
+    text: run.map((m) => m.text).join('\n'),
+  }
+  // Re-seat the single attachment/imagePath from the entry that owns it
+  // (which may not be `last`), or strip them if the run is text-only.
+  delete merged.imagePath
+  delete merged.attachment
+  if (mediaEntry?.imagePath != null) merged.imagePath = mediaEntry.imagePath
+  if (mediaEntry?.attachment != null) merged.attachment = mediaEntry.attachment
+  return merged
 }
 
 /**

--- a/telegram-plugin/tests/inbound-coalesce.test.ts
+++ b/telegram-plugin/tests/inbound-coalesce.test.ts
@@ -140,4 +140,25 @@ describe('createInboundCoalescer', () => {
     expect(flushed).toEqual([])
     expect(c.size()).toBe(0)
   })
+
+  it('hands merge ALL entries in arrival order so the attachment can ride from a non-last entry', () => {
+    // The gateway merge picks the single attachment via entries.find(...),
+    // NOT entries[last]. Pin that the coalescer preserves arrival order and
+    // passes every buffered entry, so a [photo][text] burst keeps the photo.
+    interface MediaPayload { text: string; attachment?: string }
+    const mediaMerge = (entries: MediaPayload[]): MediaPayload => ({
+      text: entries.map((e) => e.text).join('\n'),
+      attachment: entries.find((e) => e.attachment != null)?.attachment,
+    })
+    const flushed: MediaPayload[] = []
+    const c = createInboundCoalescer<MediaPayload>({
+      gapMs: 1500,
+      merge: mediaMerge,
+      onFlush: (_key, merged) => flushed.push(merged),
+    })
+    c.enqueue('c1:u1', { text: 'look', attachment: 'photo-1' }) // media FIRST
+    c.enqueue('c1:u1', { text: 'at this' })                     // text second
+    vi.advanceTimersByTime(1500)
+    expect(flushed).toEqual([{ text: 'look\nat this', attachment: 'photo-1' }])
+  })
 })

--- a/telegram-plugin/tests/pending-inbound-buffer.test.ts
+++ b/telegram-plugin/tests/pending-inbound-buffer.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick, DEFAULT_PENDING_INBOUND_CAP } from '../gateway/pending-inbound-buffer.js'
+import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick, planBufferedRedelivery, DEFAULT_PENDING_INBOUND_CAP } from '../gateway/pending-inbound-buffer.js'
 import type { InboundMessage } from '../gateway/ipc-protocol.js'
 
 function inbound(source: string, ts = Date.now()): InboundMessage {
@@ -21,6 +21,35 @@ function inbound(source: string, ts = Date.now()): InboundMessage {
     text: `synthetic ${source}`,
     meta: { source },
   }
+}
+
+/** An ordinary Telegram user message — NO meta.source, so it's mergeable. */
+function userMsg(
+  opts: {
+    text: string
+    chatId?: string
+    threadId?: number
+    userId?: number
+    ts?: number
+    imagePath?: string
+    attachment?: InboundMessage['attachment']
+  },
+): InboundMessage {
+  const ts = opts.ts ?? Date.now()
+  const m: InboundMessage = {
+    type: 'inbound',
+    chatId: opts.chatId ?? 'c1',
+    messageId: ts,
+    user: 'alice',
+    userId: opts.userId ?? 42,
+    ts,
+    text: opts.text,
+    meta: {},
+  }
+  if (opts.threadId != null) m.threadId = opts.threadId
+  if (opts.imagePath != null) m.imagePath = opts.imagePath
+  if (opts.attachment != null) m.attachment = opts.attachment
+  return m
 }
 
 describe('pending-inbound-buffer', () => {
@@ -311,5 +340,260 @@ describe('durable-spool integration (finn/carrie lost-on-restart fix)', () => {
       redelivered: 1,
       rebuffered: 0,
     })
+  })
+})
+
+describe('planBufferedRedelivery — merge-on-drain (forwarded-burst across a turn boundary)', () => {
+  it('passes a single message through unchanged (run of one)', () => {
+    const a = userMsg({ text: 'solo', ts: 1 })
+    const plan = planBufferedRedelivery([a])
+    expect(plan).toHaveLength(1)
+    expect(plan[0]!.merged).toBe(a) // identity preserved, no synthetic copy
+    expect(plan[0]!.originals).toEqual([a])
+  })
+
+  it('merges consecutive same-sender user messages into one turn (texts joined by \\n)', () => {
+    const a = userMsg({ text: 'first', ts: 1 })
+    const b = userMsg({ text: 'second', ts: 2 })
+    const c = userMsg({ text: 'third', ts: 3 })
+    const plan = planBufferedRedelivery([a, b, c])
+    expect(plan).toHaveLength(1)
+    expect(plan[0]!.merged.text).toBe('first\nsecond\nthird')
+    expect(plan[0]!.originals).toEqual([a, b, c]) // all three acked/rebuffered together
+  })
+
+  it('anchors the merged turn on the LAST message identity/meta', () => {
+    const a = userMsg({ text: 'first', ts: 10 })
+    const b = userMsg({ text: 'second', ts: 20 })
+    const plan = planBufferedRedelivery([a, b])
+    expect(plan[0]!.merged.messageId).toBe(20)
+    expect(plan[0]!.merged.ts).toBe(20)
+  })
+
+  it('NEVER merges a system inbound — meta.source isolates the #1150 wake-up class', () => {
+    const u1 = userMsg({ text: 'hi', ts: 1 })
+    const grant = inbound('vault_grant_approved', 2)
+    const u2 = userMsg({ text: 'there', ts: 3 })
+    const plan = planBufferedRedelivery([u1, grant, u2])
+    // The grant breaks the run; nothing merges across it.
+    expect(plan.map((p) => p.merged.text)).toEqual([
+      'hi',
+      'synthetic vault_grant_approved',
+      'there',
+    ])
+    expect(plan.every((p) => p.originals.length === 1)).toBe(true)
+  })
+
+  it('does not merge across different senders', () => {
+    const a = userMsg({ text: 'from-alice', userId: 1, ts: 1 })
+    const b = userMsg({ text: 'from-bob', userId: 2, ts: 2 })
+    const plan = planBufferedRedelivery([a, b])
+    expect(plan).toHaveLength(2)
+  })
+
+  it('does not merge across different topics (threadId)', () => {
+    const a = userMsg({ text: 'planning', threadId: 7, ts: 1 })
+    const b = userMsg({ text: 'admin', threadId: 9, ts: 2 })
+    const plan = planBufferedRedelivery([a, b])
+    expect(plan).toHaveLength(2)
+  })
+
+  it('does not merge across different chats', () => {
+    const a = userMsg({ text: 'dm', chatId: 'cA', ts: 1 })
+    const b = userMsg({ text: 'group', chatId: 'cB', ts: 2 })
+    const plan = planBufferedRedelivery([a, b])
+    expect(plan).toHaveLength(2)
+  })
+
+  it('carries a single attachment along even when it is NOT the last message', () => {
+    const photo = userMsg({ text: 'look', ts: 1, imagePath: '/tmp/p.jpg' })
+    const txt = userMsg({ text: 'at this', ts: 2 })
+    const plan = planBufferedRedelivery([photo, txt])
+    expect(plan).toHaveLength(1)
+    expect(plan[0]!.merged.text).toBe('look\nat this')
+    expect(plan[0]!.merged.imagePath).toBe('/tmp/p.jpg')
+  })
+
+  it('carries a single document attachment from the entry that owns it', () => {
+    const txt = userMsg({ text: 'here', ts: 1 })
+    const doc = userMsg({
+      text: '',
+      ts: 2,
+      attachment: { fileId: 'F1', mimeType: 'application/pdf', fileName: 'r.pdf' },
+    })
+    const plan = planBufferedRedelivery([txt, doc])
+    expect(plan).toHaveLength(1)
+    expect(plan[0]!.merged.attachment).toEqual({
+      fileId: 'F1',
+      mimeType: 'application/pdf',
+      fileName: 'r.pdf',
+    })
+  })
+
+  it('splits a run rather than putting two attachments in one turn (no silent media loss)', () => {
+    const p1 = userMsg({ text: 'one', ts: 1, imagePath: '/tmp/a.jpg' })
+    const p2 = userMsg({ text: 'two', ts: 2, imagePath: '/tmp/b.jpg' })
+    const plan = planBufferedRedelivery([p1, p2])
+    expect(plan).toHaveLength(2)
+    expect(plan[0]!.merged.imagePath).toBe('/tmp/a.jpg')
+    expect(plan[1]!.merged.imagePath).toBe('/tmp/b.jpg')
+  })
+
+  it('a leading text then media then text → text+media merge, then a fresh run', () => {
+    const t1 = userMsg({ text: 'intro', ts: 1 })
+    const p = userMsg({ text: 'pic', ts: 2, imagePath: '/tmp/p.jpg' })
+    const t2 = userMsg({ text: 'caption', ts: 3 })
+    const plan = planBufferedRedelivery([t1, p, t2])
+    // All three share one attachment max → single merged turn.
+    expect(plan).toHaveLength(1)
+    expect(plan[0]!.merged.text).toBe('intro\npic\ncaption')
+    expect(plan[0]!.merged.imagePath).toBe('/tmp/p.jpg')
+  })
+
+  it('preserves the run total — sum of originals equals input length (lossless)', () => {
+    const msgs = [
+      userMsg({ text: 'a', ts: 1 }),
+      userMsg({ text: 'b', ts: 2 }),
+      inbound('cron', 3),
+      userMsg({ text: 'c', ts: 4 }),
+    ]
+    const plan = planBufferedRedelivery(msgs)
+    const total = plan.reduce((n, p) => n + p.originals.length, 0)
+    expect(total).toBe(msgs.length)
+  })
+
+  it('end-to-end: redeliverBufferedInbound fans a 3-message burst into ONE send', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('ziggy', userMsg({ text: 'part 1', ts: 1 }))
+    buf.push('ziggy', userMsg({ text: 'part 2', ts: 2 }))
+    buf.push('ziggy', userMsg({ text: 'part 3', ts: 3 }))
+    const sent: string[] = []
+    const r = redeliverBufferedInbound(buf, 'ziggy', (m) => {
+      sent.push(m.text)
+      return true
+    })
+    expect(sent).toEqual(['part 1\npart 2\npart 3']) // ONE turn, not three
+    expect(r).toEqual({ drained: 3, redelivered: 3, rebuffered: 0 })
+    expect(buf.depth('ziggy')).toBe(0)
+  })
+
+  it('end-to-end: a failed send re-buffers ALL originals of the merged run (lossless)', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('ziggy', userMsg({ text: 'part 1', ts: 1 }))
+    buf.push('ziggy', userMsg({ text: 'part 2', ts: 2 }))
+    const r = redeliverBufferedInbound(buf, 'ziggy', () => false)
+    expect(r).toEqual({ drained: 2, redelivered: 0, rebuffered: 2 })
+    expect(buf.depth('ziggy')).toBe(2) // both originals back, nothing lost
+    expect(buf.drain('ziggy').map((m) => m.text)).toEqual(['part 1', 'part 2'])
+  })
+})
+
+describe('planBufferedRedelivery — seeded fuzz over random burst schedules', () => {
+  // Tiny deterministic PRNG (mulberry32) so failures reproduce from the seed.
+  function rng(seed: number): () => number {
+    let s = seed >>> 0
+    return () => {
+      s |= 0
+      s = (s + 0x6d2b79f5) | 0
+      let t = Math.imul(s ^ (s >>> 15), 1 | s)
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+  }
+
+  const SOURCES = ['vault_grant_approved', 'cron', 'reaction', 'approval', 'handback']
+
+  function randomSchedule(rand: () => number): InboundMessage[] {
+    const n = 1 + Math.floor(rand() * 12)
+    const out: InboundMessage[] = []
+    for (let i = 0; i < n; i++) {
+      const roll = rand()
+      if (roll < 0.3) {
+        // system inbound (has meta.source) — never mergeable
+        out.push(inbound(SOURCES[Math.floor(rand() * SOURCES.length)]!, i + 1))
+      } else {
+        // user message: random sender/topic/chat, sometimes media
+        const hasImg = rand() < 0.2
+        const hasDoc = !hasImg && rand() < 0.15
+        out.push(
+          userMsg({
+            text: `m${i}`,
+            ts: i + 1,
+            chatId: rand() < 0.5 ? 'cA' : 'cB',
+            userId: rand() < 0.5 ? 1 : 2,
+            threadId: rand() < 0.4 ? (rand() < 0.5 ? 7 : 9) : undefined,
+            imagePath: hasImg ? `/tmp/img${i}.jpg` : undefined,
+            attachment: hasDoc
+              ? { fileId: `F${i}`, mimeType: 'application/pdf' }
+              : undefined,
+          }),
+        )
+      }
+    }
+    return out
+  }
+
+  function hasMedia(m: InboundMessage): boolean {
+    return m.imagePath != null || m.attachment != null
+  }
+  function isSystem(m: InboundMessage): boolean {
+    return m.meta != null && m.meta.source != null
+  }
+
+  it('holds all invariants across 5000 random schedules', () => {
+    const rand = rng(0xC0FFEE)
+    for (let iter = 0; iter < 5000; iter++) {
+      const pending = randomSchedule(rand)
+      const plan = planBufferedRedelivery(pending)
+
+      // 1. Lossless + order-preserving: flattening originals reproduces input.
+      const flat = plan.flatMap((p) => p.originals)
+      expect(flat).toEqual(pending)
+
+      // 2. Count is conserved.
+      expect(flat.length).toBe(pending.length)
+
+      for (const { merged, originals } of plan) {
+        // 3. A multi-message run never carries >1 attachment.
+        const mediaCount = originals.filter(hasMedia).length
+        expect(mediaCount).toBeLessThanOrEqual(1)
+
+        // 4. A system inbound is NEVER part of a multi-message run, and is
+        //    never silently mutated (passes through by identity).
+        if (originals.length > 1) {
+          expect(originals.every((m) => !isSystem(m))).toBe(true)
+        } else {
+          expect(merged).toBe(originals[0])
+        }
+
+        // 5. Every message in a merged run shares the same (chat, thread, user).
+        if (originals.length > 1) {
+          const k = (m: InboundMessage) =>
+            `${m.chatId}|${m.threadId ?? null}|${m.userId}`
+          expect(new Set(originals.map(k)).size).toBe(1)
+          // text is the \n-join of the run in order
+          expect(merged.text).toBe(originals.map((m) => m.text).join('\n'))
+          // the single attachment (if any) comes from the owning entry
+          const owner = originals.find(hasMedia)
+          expect(merged.imagePath).toBe(owner?.imagePath)
+          expect(merged.attachment).toEqual(owner?.attachment)
+        }
+      }
+    }
+  })
+
+  it('redeliver counts always satisfy drained == redelivered + rebuffered (5000 schedules)', () => {
+    const rand = rng(0x5EED)
+    for (let iter = 0; iter < 5000; iter++) {
+      const pending = randomSchedule(rand)
+      const buf = createPendingInboundBuffer({ log: () => {} })
+      for (const m of pending) buf.push('fuzz', m)
+      // Randomly succeed/fail each send to exercise both branches.
+      const r = redeliverBufferedInbound(buf, 'fuzz', () => rand() < 0.5)
+      expect(r.drained).toBe(pending.length)
+      expect(r.redelivered + r.rebuffered).toBe(r.drained)
+      // Whatever didn't deliver is still buffered (nothing lost).
+      expect(buf.depth('fuzz')).toBe(r.rebuffered)
+    }
   })
 })

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -588,6 +588,26 @@ describe("mergeAgentConfig channels block", () => {
     const result = mergeAgentConfig({ model: "opus" }, baseAgent());
     expect(result.channels).toBeUndefined();
   });
+
+  it("flows defaults.channels.telegram.coalesce.window_ms to an agent that omits it", () => {
+    const defaults: AgentDefaults = {
+      channels: { telegram: { coalesce: { window_ms: 750 } } },
+    };
+    const result = mergeAgentConfig(defaults, baseAgent());
+    expect(result.channels?.telegram?.coalesce?.window_ms).toBe(750);
+  });
+
+  it("lets an agent override the coalesce window from defaults", () => {
+    const defaults: AgentDefaults = {
+      channels: { telegram: { coalesce: { window_ms: 750 } } },
+    };
+    const agent = baseAgent({
+      channels: { telegram: { coalesce: { window_ms: 0 } } },
+    });
+    const result = mergeAgentConfig(defaults, agent);
+    // window_ms: 0 (disable) must win over the inherited 750, not be dropped.
+    expect(result.channels?.telegram?.coalesce?.window_ms).toBe(0);
+  });
 });
 
 describe("mergeAgentConfig deprecated Telegram fields (#596)", () => {

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -400,6 +400,37 @@ describe("scaffoldAgent", () => {
     expect(access.groups["-1001234567890"].requireMention).toBe(false);
   });
 
+  it("projects channels.telegram.coalesce.window_ms into access.coalescingGapMs", () => {
+    const config = makeAgentConfig({
+      channels: { telegram: { coalesce: { window_ms: 1200 } } },
+    });
+    const result = scaffoldAgent("coalesce-agent", config, tmpDir, telegramConfig);
+    const access = JSON.parse(
+      readFileSync(join(result.agentDir, "telegram", "access.json"), "utf-8"),
+    );
+    expect(access.coalescingGapMs).toBe(1200);
+  });
+
+  it("projects window_ms: 0 (coalescing disabled) — not dropped as falsy", () => {
+    const config = makeAgentConfig({
+      channels: { telegram: { coalesce: { window_ms: 0 } } },
+    });
+    const result = scaffoldAgent("coalesce-off", config, tmpDir, telegramConfig);
+    const access = JSON.parse(
+      readFileSync(join(result.agentDir, "telegram", "access.json"), "utf-8"),
+    );
+    expect(access.coalescingGapMs).toBe(0);
+  });
+
+  it("omits coalescingGapMs entirely when no coalesce config is set", () => {
+    const config = makeAgentConfig();
+    const result = scaffoldAgent("coalesce-default", config, tmpDir, telegramConfig);
+    const access = JSON.parse(
+      readFileSync(join(result.agentDir, "telegram", "access.json"), "utf-8"),
+    );
+    expect("coalescingGapMs" in access).toBe(false);
+  });
+
   it("generates settings.json with tool permissions (webkite staged → WebFetch denied)", () => {
     // Simulate the webkite binary being staged so the fail-safe gate
     // (webkiteBinaryAvailable) trips and the deny applies. Point the


### PR DESCRIPTION
## Summary

Forwarding several Telegram messages — or pasting a long block that Telegram splits across multiple messages — made Claude reply to each fragment as its own turn, reasoning with partial context and firing disjoint replies. This PR (Problem A, part 1 of 2) closes the gap.

Root cause was twofold:
- **Media path bypassed the coalescer.** Pure text already coalesced via `handleInboundCoalesced`, but every `message:photo/document/voice/audio/video/video_note/sticker/animation` handler called `handleInbound` directly. `media_group_id` was read nowhere.
- **Buffer-on-drain fanned out.** A burst that spanned a turn boundary (rest buffered in `pending-inbound-buffer`) was redelivered one-by-one as N queued turns.

## What changed

- **Media through the coalescer (single-attachment).** All media handlers now call `handleInboundCoalesced`. A single attachment can ride in a coalesce window; three guards guarantee **at most one attachment per flush** so no photo is ever silently dropped:
  - `!`-interrupt bypass (checked first, now passes media through)
  - album (`media_group_id`) bypass — each part keeps its own turn, exactly as today
  - second-attachment bypass, tracked via `bufferedAttachmentKeys`
  
  The merge picks the attachment via `find()` not `last`, so a `[photo][text]` burst keeps its image.
- **merge-on-drain.** New pure, exported `planBufferedRedelivery` collapses runs of consecutive same-`(chat,thread,user)` **source-less** user inbounds when redelivering a drained buffer. System inbounds (vault grants, approvals, cron, handbacks — the #1150 wake-up class) **never merge**; spool ack/re-buffer identity is preserved per original.
- **Config knob.** `channels.telegram.coalesce.window_ms` cascades defaults → profile → agent and projects into the existing `access.coalescingGapMs` the coalescer already reads per-message. Default **500ms**; `0` disables. Default-on, zero setup; the 👀 ack still fires on the first message so perceived latency is unchanged.

## Why

JTBD: *steer or queue mid-flight*. A forwarded burst is one thought — the agent should treat it as one shared-context turn, not race the turn boundary with partial input.

## Test plan

- [x] `bun test telegram-plugin/tests/{inbound-coalesce,pending-inbound-buffer}.test.ts` — 52 pass (incl. two 5000-iteration seeded fuzz sweeps: lossless + order-preserving, ≤1 attachment/run, system inbounds never merged, `drained == redelivered + rebuffered`)
- [x] `vitest run tests/{scaffold,merge}.test.ts` — 264 pass (coalesce projection + cascade)
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean (no allowlist drift)
- [x] `check-plugin-references.mjs` clean
- [ ] mtcute UAT: `jtbd-fast-trivial-dm` 3× (TTFO guard) + a forwarded-mixed-media scenario — to run on canary before fleet rollout

## Risk

Medium — touches the inbound hot path. Mitigations: the three attachment guards make album/multi-media behavior **identical to today** (no silent loss); coalescing is sub-second and the ack is unchanged; the knob defaults to the current 500ms and `0` fully disables. A2 (album grouping + multi-attachment inbound payload) is the follow-on PR.