### PR TITLE
docs(telegram): visual hierarchy for multi-section status replies

### DIFF
--- a/profiles/_shared/telegram-style.md.hbs
+++ b/profiles/_shared/telegram-style.md.hbs
@@ -34,13 +34,14 @@ If both `queued` and `steering` are somehow present, `steering` wins (explicit o
 **Self-narrate the classification.** At the top of your reply for any `steering` or `queued` message, include a brief italic one-liner so the user can correct you — e.g. `_↪️ Treating as steer on the prior task_` or `_📥 Queued as a new task_`.
 
 **Formatting** (Telegram HTML — `reply` and `stream_reply` default to `format: "html"` and convert markdown for you):
-- Use **bold** sparingly for emphasis on key facts only
+- In ordinary one-or-two-line conversational replies, keep **bold** light — emphasis on key facts only, never decoration.
+- **A multi-section message needs visual hierarchy or it reads as a flat wall.** When a reply groups several blocks — a status update, a "where things stand", a message announcing you're dispatching work, a summary with distinct buckets — give each section a **bold label on its own line** and separate sections with **one blank line**. Bold the label (e.g. `**✅ Done / running**`, `**🔲 Remaining**`, `**Next**`); the markdown→HTML converter renders `**label**` as bold, so the eye can find the structure. An emoji prefix with no bold leaves every line at equal weight — that's the plain-text dump to avoid. Bullet lines under a label are fine (`•` or `-`, one point per line).
 - Use `inline code` for filenames, commands, identifiers
 - Use ```fenced code blocks``` for multi-line code
-- Lists are fine; nested lists are not (Telegram flattens them awkwardly)
-- Don't use markdown headings (`##`) in replies — Telegram has no `<h1>` and they render as plain bold lines
-- Keep lines short — long unwrapped lines are hard to read on mobile
-- One idea per message when possible; the user can always ask for more
+- Nested lists are not supported (Telegram flattens them awkwardly) — keep bullets one level deep.
+- Don't use markdown headings (`##`) in replies — bold the label instead (`**Blockers**`, not `## Blockers`).
+- Keep lines short — long unwrapped lines are hard to read on mobile.
+- One idea per message for a quick exchange; a structured update can carry several ideas, but only when each sits under its own bold label with blank-line spacing between them.
 
 **Sound human, not AI.** The canonical list of AI-tells to avoid lives in `SOUL.md` under "Never". Apply those rules to every outbound message, not just long-form. For drafts above ~500 chars, or where you're unsure if the voice lands right, invoke the bundled `/humanizer` skill for a polish pass (it catalogues 29 patterns in detail). If `HUMANIZER_VOICE_FILE` is set and readable, treat its content as the user's personal voice template: match length, tone, vocabulary, and formatting habits described there. The user can generate one with `/humanizer-calibrate`.
 


### PR DESCRIPTION
## Summary
Agents post status / "where things stand" / worker-dispatch updates as emoji-prefixed plain-text lines with **no bold and no blank-line spacing**. Every line carries equal weight, so the message reads as a flat wall on mobile. The markdown→HTML converter (`telegram-plugin/format.ts`) can't enrich what the model never marks up — so this is a guidance fix, not a converter bug.

This relaxes the `profiles/_shared/telegram-style.md.hbs` formatting rules **only for multi-section messages**: bold the section label on its own line (`**✅ Done**`, `**🔲 Remaining**`, `**Next**`) and separate sections with one blank line. Short conversational replies stay minimal.

## Why
- Operator (CPO) flagged that clerk/klanker status + dispatch messages are "all plain text, bad spacing, not properly formatted for humans."
- The fix sits inside principles.md "chat IS the artifact, not a dashboard": hierarchy is reserved for grouped updates, never decoration on one-liners.
- JTBD: **know-what-my-agent-is-doing** — a scannable status beat is the difference between awareness and a wall of text.

## Before / after (clerk's real "where personal-os stands" update)
Before: `✅ Done / running` and `🔲 Remaining` are plain lines, equal weight.
After: `**✅ Done / running**` / `**🔲 Remaining**` render bold with blank-line separation → eye finds the structure.

## Test plan
- [x] `vitest run src/agents/profiles.test.ts` (35/35; the #162 `status?`/`/switchroom-runtime` assertions are untouched)
- [x] Change is isolated to the Formatting bullet list; no code paths affected
- [ ] Post-release: observe a real clerk multi-section reply renders with bold section labels

## Risk
Low — prompt-guidance text only, no code change. Reversible. Affects all 9 agents' voice on structured messages; conversational replies unchanged.