### PR TITLE
chore: release v0.14.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v0.14.18 — Inbound burst coalescing + scannable status replies
+
+### Coalesce forwarded / split-paste bursts into one turn (#2007)
+
+Forwarding several Telegram messages — or pasting a long block Telegram
+splits across messages — made Claude reply to each fragment as its own
+turn, reasoning with partial context. Media handlers now route through
+`handleInboundCoalesced` (with three guards that keep album / multi-
+attachment behaviour identical to today — at most one attachment per
+flush, no silent drops), and a new pure `planBufferedRedelivery`
+collapses consecutive same-`(chat,thread,user)` source-less inbounds on
+buffer drain. System inbounds (vault grants, approvals, cron, handbacks)
+never merge. New cascade knob `channels.telegram.coalesce.window_ms`
+(default 500ms, `0` disables); the 👀 ack still fires on the first
+message so perceived latency is unchanged.
+
+### Visual hierarchy for multi-section status replies (#2008)
+
+Agents posted "where things stand" / worker-dispatch updates as emoji-
+prefixed plain-text lines with no bold and no blank-line spacing, so
+every line carried equal weight and the message read as a flat wall on
+mobile. The markdown→HTML converter can't enrich what the model never
+marks up — so this is a prompt-guidance fix in
+`profiles/_shared/telegram-style.md.hbs`, not a converter change. It
+relaxes the "bold sparingly / no headings" rule **only for multi-section
+messages**: bold the section label on its own line (`**✅ Done**`,
+`**🔲 Remaining**`, `**Next**`) with one blank line between sections.
+Short conversational replies stay minimal — hierarchy is reserved for
+grouped updates, keeping inside the "chat is the artifact, not a
+dashboard" principle.
+
 ## v0.14.17 — Worker-feed hardening: regression pin + docs/comment sweep (#2004)
 
 Hardening pass on the v0.14.15/16 worker-activity feed — no behaviour

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.17",
+  "version": "0.14.18",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release v0.14.18 — inbound burst coalescing + scannable status replies.

Bundles three already-merged-to-main PRs:

- **#2007 (headline)** — `feat(telegram): coalesce forwarded/split-paste bursts into one turn`. Media handlers now route through `handleInboundCoalesced` (≤1 attachment per flush, no silent drops), and `planBufferedRedelivery` collapses consecutive same-`(chat,thread,user)` source-less inbounds on buffer drain. New cascade knob `channels.telegram.coalesce.window_ms` (default 500ms, `0` disables). System inbounds (vault grants, approvals, cron, handbacks) never merge.
- **#2008** — `docs(telegram)`: visual hierarchy for multi-section status/dispatch replies.
- **#2006** — `test(telegram)`: fuzz `resolveWorkerFeedDispatch` over 20k random rows.

## Why

A forwarded burst or a split paste is one thought; the agent was answering fragment 1 before the rest arrived. Closes the media + buffer-on-drain holes left by the pure-text coalescer.

## Test plan

- [x] `node scripts/build.mjs` clean, `dist/cli/switchroom.js` present (~3.0MB)
- [x] Constituent PRs each reviewed + CI-green before merge
- [ ] Required GHA checks green on this release PR
- [ ] Post-merge: tag, GitHub release, npm publish (tarball verified)
- [ ] Canary test-harness + mtcute UAT (`jtbd-fast-trivial-dm` 3x) before fleet rollout

## Risk

Low. Coalescing default window is unchanged (500ms); the 👀 ack still fires on first message so perceived latency is unchanged. Constituent feature code already merged + reviewed.