### PR TITLE
feat(telegram): resuming beat + awaiting-reaction across permission gates

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1954,6 +1954,24 @@ function paintStatusReactionError(chatId: string, threadId: number | undefined):
   ctrl.setError()
 }
 
+/**
+ * Flip the current turn's status reaction off 🙏 (awaiting-approval) back
+ * to a working glyph once a permission verdict has been dispatched. The
+ * turn was suspended *inside* the bridge's permission call, so `currentTurn`
+ * still points at it; the verdict un-parks claude and it resumes the SAME
+ * turn. `setThinking()` re-arms the stall watchdog that `setAwaiting()`
+ * suspended, so a genuine post-approval hang still promotes to 🥱/😨, and
+ * it is replaced by the real tool glyph (✍/⚡) as soon as the resumed turn
+ * fires its next PreToolUse. Non-terminal — 👍 still waits for `turn_end`.
+ */
+function resumeReactionAfterVerdict(): void {
+  const turn = currentTurn
+  if (turn == null) return
+  activeStatusReactions
+    .get(statusKey(turn.sessionChatId, turn.sessionThreadId))
+    ?.setThinking()
+}
+
 function resolveThreadId(chat_id: string, explicit?: string | number | null): number | undefined {
   if (explicit != null) return Number(explicit)
   return chatThreadMap.get(chat_id)
@@ -2876,6 +2894,9 @@ const pendingStateReaper = setInterval(() => {
       // dispatchPermissionVerdict so it's buffered+redelivered too if
       // the bridge is also offline at sweep time.
       dispatchPermissionVerdict({ type: 'permission', requestId: k, behavior: 'deny' })
+      // The auto-deny un-parks the suspended turn — flip 🙏 → working so
+      // it doesn't sit on the awaiting glyph (or stall) after the timeout.
+      resumeReactionAfterVerdict()
       process.stderr.write(
         `telegram gateway: permission TTL expired — auto-deny request=${k} ` +
         `tool=${v.tool_name} (no operator response in ` +
@@ -4226,6 +4247,16 @@ const ipcServer: IpcServer = createIpcServer({
       }).catch(e => {
         process.stderr.write(`telegram gateway: permission_request send to ${chat_id} failed: ${e}\n`)
       })
+    }
+    // Park the turn's status reaction on 🙏 (awaiting your tap) and
+    // suspend the stall watchdog — a turn blocked on the operator is not
+    // stalled, so it must not degrade to 🥱/😨 while the card sits
+    // unanswered. The verdict path (`resumeReactionAfterVerdict`) flips it
+    // back to a working state the instant you tap.
+    if (activeTurn != null) {
+      activeStatusReactions
+        .get(statusKey(activeTurn.sessionChatId, activeTurn.sessionThreadId))
+        ?.setAwaiting()
     }
   },
 
@@ -11759,6 +11790,7 @@ async function handlePermissionSlash(ctx: Context, behavior: 'allow' | 'deny'): 
   }
   // Forward to connected bridges — same IPC the button handler uses.
   dispatchPermissionVerdict({ type: 'permission', requestId: request_id, behavior })
+  resumeReactionAfterVerdict()
   pendingPermissions.delete(request_id)
   process.stderr.write(
     `[telegram gateway] slash-${behavior} request_id=${request_id} tool=${details.tool_name} by=${senderId}\n`,
@@ -15409,6 +15441,10 @@ bot.on('callback_query:data', async ctx => {
       behavior: 'allow',
       rule: chosen.rule,
     })
+    // The turn resumes now (independent of the host persistence round-trip
+    // below). Un-park 🙏 → working immediately so the operator sees the
+    // agent continue while hostd writes the durable rule.
+    resumeReactionAfterVerdict()
 
     // (3) Decide the persistence path. tryHostdDispatch returns
     // "not-configured" when host_control is disabled or the per-agent
@@ -15562,7 +15598,16 @@ bot.on('callback_query:data', async ctx => {
 
   // Forward permission decision to connected bridges
   pendingPermissions.delete(request_id)
-  const label = behavior === 'allow' ? '✅ Allowed' : '❌ Denied'
+  // Deterministic "▶️ resuming…" beat (framework-posted, not model text):
+  // the verdict un-parks the suspended turn, so confirm to the operator
+  // that the agent received it and is continuing — closing the "is it
+  // working or did my tap do nothing?" gap. Allow and deny both resume the
+  // turn (deny just hands claude a refusal it then handles).
+  const resumeAgent = process.env.SWITCHROOM_AGENT_NAME
+  const resumeBeat = resumeAgent
+    ? `▶️ ${escapeHtmlForTg(resumeAgent)} resuming…`
+    : '▶️ resuming…'
+  const label = `${behavior === 'allow' ? '✅ Allowed' : '❌ Denied'} · ${resumeBeat}`
   // HTML-escape the source text — same hazard as the scope-commit and
   // recent-denial paths above. The permission card body
   // (formatPermissionCardBody) appends claude-supplied `description`
@@ -15590,6 +15635,9 @@ bot.on('callback_query:data', async ctx => {
         requestId: request_id,
         behavior: behavior as 'allow' | 'deny',
       })
+      // Un-park the status reaction: 🙏 → working, re-arming the stall
+      // watchdog that setAwaiting() suspended.
+      resumeReactionAfterVerdict()
     },
   })
 })

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8955,6 +8955,7 @@ async function handleInbound(
       requestId: request_id,
       behavior,
     })
+    resumeReactionAfterVerdict()
     if (msgId != null) {
       const emoji = behavior === 'allow' ? '✅' : '❌'
       void bot.api.setMessageReaction(chat_id, msgId, [

--- a/telegram-plugin/status-reactions.ts
+++ b/telegram-plugin/status-reactions.ts
@@ -53,6 +53,7 @@ export type ReactionState =
   | 'web'
   | 'tool'
   | 'compacting'
+  | 'awaiting'
   | 'done'
   | 'error'
   | 'stallSoft'
@@ -78,6 +79,7 @@ export const REACTION_VARIANTS: Record<ReactionState, string[]> = {
   coding:    ['👨‍💻', '✍', '⚡'],     // WORKING: writing / running code
   web:       ['⚡', '🤔', '👌'],      // WORKING: lookup in motion
   compacting:['✍', '🤔', '👀'],
+  awaiting:  ['🙏', '🤔', '👀'],      // BLOCKED ON HUMAN: parked on a permission card
   done:      ['👍', '💯', '🎉'],      // FINISHED: turn_end fired
   error:     ['😱', '😨', '🤯'],      // NON-TERMINAL — recovery allowed
   stallSoft: ['🥱', '😴', '🤔'],
@@ -178,6 +180,22 @@ export class StatusReactionController {
   /** ✍ — context compaction in progress. Debounced, non-terminal, bidirectional. */
   setCompacting(): void {
     this.scheduleState('compacting')
+  }
+
+  /**
+   * 🙏 — the turn is parked on a human decision (a permission card is
+   * waiting for the operator to tap Allow/Deny). Immediate, non-terminal,
+   * and crucially SUSPENDS the stall watchdog: a turn blocked on the
+   * operator is not stalled, so it must NOT promote to 🥱/😨 while the
+   * card sits unanswered. The next working transition (setTool /
+   * setThinking, fired when the verdict resumes the turn) re-arms the
+   * watchdog normally. Bypasses debounce so 🙏 lands as soon as the card
+   * is posted.
+   */
+  setAwaiting(): void {
+    if (this.finished) return
+    this.scheduleState('awaiting', { immediate: true, skipStallReset: true })
+    this.clearStallTimers()
   }
 
   /**

--- a/telegram-plugin/tests/status-reactions.test.ts
+++ b/telegram-plugin/tests/status-reactions.test.ts
@@ -341,6 +341,75 @@ describe('StatusReactionController', () => {
     expect(calls).toEqual(['👀'])
   })
 
+  // setAwaiting(): park on 🙏 while a permission card waits for the
+  // operator. A turn blocked on a human is NOT stalled, so the watchdog
+  // must stay quiet — but it re-arms once the verdict resumes work.
+  describe('setAwaiting() — park on a human permission decision', () => {
+    it('emits 🙏 immediately (bypasses debounce)', async () => {
+      const { emit, calls } = makeEmitter()
+      const ctrl = new StatusReactionController(emit)
+      ctrl.setQueued()
+      await flush()
+      ctrl.setAwaiting()
+      await flush()
+      expect(calls).toEqual(['👀', '🙏'])
+    })
+
+    it('suppresses stall promotion (no 🥱/😨) while the card sits unanswered', async () => {
+      const { emit, calls } = makeEmitter()
+      const ctrl = new StatusReactionController(emit)
+      ctrl.setQueued()
+      ctrl.setTool('Bash') // working: 👨‍💻
+      vi.advanceTimersByTime(3500)
+      await flush()
+      ctrl.setAwaiting()
+      await flush()
+      // Well past both stall thresholds — awaiting must not yawn or panic.
+      vi.advanceTimersByTime(120000)
+      await flush()
+      expect(calls).not.toContain('🥱')
+      expect(calls).not.toContain('😨')
+      expect(calls[calls.length - 1]).toBe('🙏')
+    })
+
+    it('re-arms the stall watchdog once a working transition resumes the turn', async () => {
+      const { emit, calls } = makeEmitter()
+      const ctrl = new StatusReactionController(emit)
+      ctrl.setQueued()
+      await flush()
+      ctrl.setAwaiting()
+      await flush()
+      vi.advanceTimersByTime(120000) // long human wait — no stall
+      await flush()
+      expect(calls).toEqual(['👀', '🙏'])
+
+      // Verdict dispatched → gateway calls setThinking() to un-park.
+      ctrl.setThinking()
+      vi.advanceTimersByTime(3500)
+      await flush()
+      expect(calls).toEqual(['👀', '🙏', '🤔'])
+
+      // A genuine post-approval hang must still promote to 🥱 — the
+      // watchdog was re-armed by the resuming transition.
+      vi.advanceTimersByTime(30000)
+      await flush()
+      expect(calls).toContain('🥱')
+    })
+
+    it('is a no-op after finalize (cannot resurrect a finished controller)', async () => {
+      const { emit, calls } = makeEmitter()
+      const ctrl = new StatusReactionController(emit)
+      ctrl.setQueued()
+      ctrl.finalize('done')
+      await flush()
+      const snapshot = [...calls]
+      ctrl.setAwaiting()
+      vi.advanceTimersByTime(5000)
+      await flush()
+      expect(calls).toEqual(snapshot)
+    })
+  })
+
   // hold(): freeze on a WORKING glyph while background sub-agent workers
   // outlive the parent turn, deferring the terminal 👍 (worker-reaction fix).
   describe('hold() — defer 👍 while a background worker runs', () => {


### PR DESCRIPTION
## Summary

Closes the "did my Allow tap do anything?" UX gap on permission cards. A permission gate suspends the turn **inside** the bridge's permission call, so no hook events reach the status-reaction controller while the operator decides. Two problems followed:

1. After ~30s/90s the **stall watchdog painted 🥱/😨** on a turn that was healthily waiting on a human — it looked dead.
2. After tapping Allow/Deny, **nothing visibly signalled** that the agent received the verdict and resumed; the operator had to poke the agent to know it was still working.

## What changed (framework-side only — no model narration)

This is consistent with the #1988 decision to drop framework chatter: the framework owns the *beat*, not the words.

- **`status-reactions.ts`** — new `awaiting` state (🙏) via `setAwaiting()`. It parks the reaction immediately **and suspends the stall watchdog** (a turn blocked on the operator is not stalled). Unlike `hold()`, it does **not** set `held`, so the next working transition re-arms the watchdog — a genuine *post-approval* hang still promotes to 🥱/😨.
- **`gateway.ts`** — `onPermissionRequest` parks the active turn's reaction on 🙏. Every verdict path (button allow/deny, always-allow `asn`/`asb`, `/allow`·`/deny` slash, TTL auto-deny) calls `resumeReactionAfterVerdict()` to flip 🙏 → working the instant the turn un-parks. `currentTurn` still points at the suspended turn (no `turn_end` fires mid-gate), so the helper addresses the right controller.
- **`gateway.ts`** — the allow/deny card edit now appends a deterministic `· ▶️ <agent> resuming…` beat, so the operator sees the agent acknowledge the verdict and continue. **👍 still only lands on `turn_end`** — done is never premature.

## Why this is the right shape

`turn_end` (the Stop hook) is the only thing that paints 👍, and it can't fire while claude is parked inside the permission call — so "done" already correctly waits for post-approval work to finish. The real defect was purely *feedback*: the wait looked like a stall and the resume was invisible. Both are fixed at the reaction/card layer without re-introducing the within-turn nudge ladder.

## Test plan

- [x] `status-reactions.test.ts` — 4 new tests: 🙏 emits immediately; stall suppressed for 120s while awaiting; watchdog **re-arms** (🥱) once a working transition resumes; no-op after `finalize`. (30/30 pass)
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean (no allowlist drift)
- [x] `check-plugin-references.mjs` clean
- [x] always-allow + permission + reaction suites green (119 tests across 9 files)
- [ ] UAT canary on test-harness before fleet rollout (interactive permission card flow)

## Risk

Low. Additive reaction state + a card-text append; no change to verdict plumbing, persistence, or `turn_end` finalize. Worst case if `currentTurn` was already nulled (swept turn): `resumeReactionAfterVerdict()` no-ops.

## JTBD

`know-what-my-agent-is-doing` — the status reaction must reflect real turn activity; "waiting on you" and "back to work" are now legible instead of masquerading as a stall.