### PR TITLE
feat(telegram): scannable formatting for multi-section replies

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -140,6 +140,37 @@ a flood. Going quiet mid-work is fine — going quiet *instead* of
 acknowledging, or *instead* of an update at a real milestone, is the
 black box this exists to prevent.
 
+### Formatting — make it scannable
+
+\`reply\` and \`stream_reply\` render Markdown as Telegram HTML for you, so
+\`**bold**\` becomes bold and backtick-wrapped text becomes monospace. Use it.
+
+- **A one- or two-line conversational reply needs almost no markup.** Keep
+  bold for the single fact that matters, never for decoration. "on it, pulling
+  the logs now" is already perfect.
+- **A multi-section message needs visual hierarchy or it reads as a flat
+  wall.** When you group several blocks — a status update, a "where things
+  stand", a summary with distinct buckets, or **the message you post before
+  kicking off a sub-agent or worker** — give each section a **bold label on
+  its own line** and separate sections with **one blank line**. A row of
+  emoji and bullets at equal weight with no spacing is the plain-text dump to
+  avoid; bold labels + blank lines are what let the eye find the structure.
+  Example shape:
+
+  **Dispatching**
+  Kicking off a worker to crawl the changelog.
+
+  **What it'll do**
+  • pull every entry since v0.14
+  • flag anything user-facing
+
+  **Back in** ~2 min with a synthesized summary.
+- Bullets stay one level deep — Telegram flattens nested lists awkwardly. Use
+  backtick-wrapped \`inline code\` for filenames, commands, and identifiers.
+- Don't use Markdown headings (\`#\` / \`##\`) in a reply — bold the label
+  instead (\`**Blockers**\`, not \`## Blockers\`). Keep lines short; long
+  unwrapped lines are hard to read on a phone.
+
 Every turn that answers a user message ends with a user-visible
 \`reply\` (or \`stream_reply\` done=true) — Telegram is all the user
 sees; your terminal output never reaches them.`;

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2511,6 +2511,25 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(out).toContain("Operator action");
   });
 
+  it("renderFleetInvariants() teaches scannable formatting for multi-section replies", async () => {
+    // D2: the live Telegram guidance is the TELEGRAM_GUIDANCE constant
+    // rendered here (NOT profiles/_shared/telegram-style.md.hbs, which is
+    // orphaned). Agents were posting flat plain-text emoji dumps before
+    // kicking off sub-agents/workers. The formatting block tells them to
+    // give multi-section messages bold labels + blank-line spacing, while
+    // keeping conversational one-liners minimal.
+    const { renderFleetInvariants } = await import("../src/agents/scaffold.js");
+    const out = renderFleetInvariants();
+    expect(out).toContain("### Formatting — make it scannable");
+    expect(out).toContain("reads as a flat");
+    expect(out).toContain("one blank line");
+    // The specific D2 complaint: dispatch/worker-kickoff messages.
+    expect(out).toContain("the message you post before");
+    expect(out).toContain("**Dispatching**");
+    // Keep the conversational-minimal half of the guidance too.
+    expect(out).toContain("conversational reply needs almost no markup");
+  });
+
   it("scaffoldAgent no longer appends the sandbox primer to system_prompt_append (moved to fleet invariants)", () => {
     // Post-#1850 the sandbox primer is in `~/.switchroom/fleet/switchroom-invariants.md`,
     // not in `--append-system-prompt`. This test guards against


### PR DESCRIPTION
## Summary
Adds a **Formatting — make it scannable** subsection to the live fleet-wide Telegram guidance so agents stop posting flat plain-text emoji dumps. Conversational one-liners stay minimal; multi-section messages (status updates, summaries, and the message agents post **before kicking off a sub-agent/worker**) now get a bold label on each section's own line + blank-line spacing.

## Why
Operator report: clerk/klanker's pre-dispatch worker messages were "all plain text, bad spacing" — unscannable on mobile.

The live carrier of fleet Telegram guidance is the `TELEGRAM_GUIDANCE` constant in `src/agents/scaffold.ts` → `renderFleetInvariants()` → `~/.switchroom/fleet/switchroom-invariants.md` (loaded via `--add-dir`). It had the five-beat pacing block but **no formatting guidance at all**.

> Note: an earlier pass (#2008) edited `profiles/_shared/telegram-style.md.hbs`. That fragment is **orphaned** — no template uses `{{> telegram-style}}` anymore (the profile templates carry a `telegram-style now in ~/.switchroom/fleet/...` comment), so the edit never reached any agent. This PR fixes the real carrier. Cleaning up the dead fragment + the stale comment at `scaffold.ts` (the `rerenderWithFingerprint` docstring still cites telegram-style.md.hbs as its example) is a worthwhile follow-up.

## Test plan
- [x] `tests/scaffold.test.ts` — new case asserts the block is in the rendered fleet invariants
- [x] `tsc --noEmit` clean
- [x] eyeballed the rendered `### Formatting` block (escaping + spacing correct)

## Risk
Low — prompt-guidance text only; no code-path change. Takes effect fleet-wide on the next `apply` + agent restart.