### PR TITLE
chore: release v0.14.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.14.19 — Scannable replies, for real + resuming-beat across gates
+
+### Scannable formatting reaches agents via the live carrier (#2012)
+
+v0.14.18's #2008 added multi-section formatting guidance to
+`profiles/_shared/telegram-style.md.hbs` — but that fragment is **orphaned
+dead code**: no template uses `{{> telegram-style}}` anymore (the fleet
+moved its "Lane 1" invariants out of per-agent `CLAUDE.md` into the
+release-controlled `~/.switchroom/fleet/switchroom-invariants.md`). So the
+guidance never reached a single agent. This adds a **"Formatting — make it
+scannable"** subsection to the live carrier — the `TELEGRAM_GUIDANCE`
+constant in `src/agents/scaffold.ts`, rendered by `renderFleetInvariants()`
+and loaded by every agent via `--add-dir ~/.switchroom/fleet`. Conversational
+one-liners stay minimal; multi-section messages (status updates, summaries,
+and the message posted **before kicking off a sub-agent/worker**) get a bold
+label on each section's own line plus blank-line spacing. Takes effect
+fleet-wide on apply + restart.
+
+### Resuming beat + awaiting-reaction across permission gates (#2011)
+
+Carried in from upstream/main — permission-gate flows now emit a resuming
+beat and preserve the awaiting-reaction state across the gate.
+
 ## v0.14.18 — Inbound burst coalescing + scannable status replies
 
 ### Coalesce forwarded / split-paste bursts into one turn (#2007)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.18",
+  "version": "0.14.19",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Cuts v0.14.19. Delivers the **real** scannable-formatting fix to agents.

### Why this release exists
v0.14.18 shipped a formatting fix (#2008) that edited `profiles/_shared/telegram-style.md.hbs` — but that fragment is **orphaned dead code**: no template renders `{{> telegram-style}}` anymore, so the edit never reached a live prompt. The guidance agents actually read is the `TELEGRAM_GUIDANCE` constant in `src/agents/scaffold.ts`, which `renderFleetInvariants()` writes into `~/.switchroom/fleet/switchroom-invariants.md` (loaded via `claude --add-dir`).

### What's in it
- **#2012** — adds the "Formatting — make it scannable" block to `TELEGRAM_GUIDANCE` (the live carrier). Teaches bold section labels + blank-line spacing for multi-section/dispatch messages while keeping conversational one-liners minimal. Pinned by a `renderFleetInvariants()` test. (Already reviewed + merged to main.)
- **#2011** — resuming beat + awaiting-reaction across permission gates (carried in from upstream).

## Test plan
- [x] `node scripts/build.mjs` → exit 0, `dist/cli/switchroom.js` present (3.0MB)
- [x] scaffold.test.ts `renderFleetInvariants() teaches scannable formatting` passes (merged in #2012)
- [ ] CI green (lint, vitest, bun-test, build-base, build-dependents ×5)
- [ ] Post-merge: tag, npm publish, GH release, fleet rollout, verify block in live fleet-invariants file

## Risk
Low — version + CHANGELOG diff only; the behavior change (#2012) already merged and reviewed. Delivery to agents happens at `apply` + restart.