### PR TITLE
feat(telegram): grow worker-activity feed narrative instead of one collapsing line (#2009)

### DIFF
--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -92,6 +92,42 @@ describe('renderWorkerActivity', () => {
     expect(out).toContain('⚠️ <b>Worker failed</b>')
   })
 
+  it('grows a narrative block when narrativeLines is present', () => {
+    const out = renderWorkerActivity(
+      view({
+        latestSummary: 'newest only — should be ignored',
+        narrativeLines: ['read the brief', 'scanned vendor A', 'scanned vendor B'],
+      }),
+    )
+    expect(out).toContain('↳ <i>read the brief</i>')
+    expect(out).toContain('↳ <i>scanned vendor A</i>')
+    expect(out).toContain('↳ <i>scanned vendor B</i>')
+    // The single-line latestSummary fallback is NOT used when a block is present.
+    expect(out).not.toContain('newest only')
+    // Three narrative lines → three ↳ lines.
+    expect(out.match(/↳/g) ?? []).toHaveLength(3)
+  })
+
+  it('falls back to latestSummary when narrativeLines is empty', () => {
+    const out = renderWorkerActivity(view({ narrativeLines: [], latestSummary: 'one line' }))
+    expect(out).toContain('↳ <i>one line</i>')
+    expect(out.match(/↳/g) ?? []).toHaveLength(1)
+  })
+
+  it('drops blank narrative lines from the block', () => {
+    const out = renderWorkerActivity(
+      view({ narrativeLines: ['kept', '   ', 'also kept'] }),
+    )
+    expect(out).toContain('↳ <i>kept</i>')
+    expect(out).toContain('↳ <i>also kept</i>')
+    expect(out.match(/↳/g) ?? []).toHaveLength(2)
+  })
+
+  it('escapes HTML inside narrative lines', () => {
+    const out = renderWorkerActivity(view({ narrativeLines: ['a <b>x</b> & y'] }))
+    expect(out).toContain('a &lt;b&gt;x&lt;/b&gt; &amp; y')
+  })
+
   it('escapes HTML in description, tool, arg, and summary', () => {
     const out = renderWorkerActivity(
       view({
@@ -244,6 +280,83 @@ describe('createWorkerActivityFeed', () => {
     expect(bot.sent).toHaveLength(0)
     expect(feed.has('w1')).toBe(false)
     expect(feed.size).toBe(0)
+  })
+
+  it('accumulates distinct narrative lines into a growing block across ticks', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    await feed.update('w1', 'chat', view({ toolCount: 1, latestSummary: 'read the brief' }))
+    expect(bot.sent).toHaveLength(1)
+    expect(bot.sent[0].text).toContain('↳ <i>read the brief</i>')
+
+    clock = 11_000
+    await feed.update('w1', 'chat', view({ toolCount: 2, latestSummary: 'scanned vendor A' }))
+    clock = 12_000
+    await feed.update('w1', 'chat', view({ toolCount: 3, latestSummary: 'scanned vendor B' }))
+
+    const last = bot.edits.at(-1)!
+    expect(last.text).toContain('↳ <i>read the brief</i>')
+    expect(last.text).toContain('↳ <i>scanned vendor A</i>')
+    expect(last.text).toContain('↳ <i>scanned vendor B</i>')
+    expect(last.text.match(/↳/g) ?? []).toHaveLength(3)
+  })
+
+  it('dedups a repeated narrative line so the block does not duplicate', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    await feed.update('w1', 'chat', view({ toolCount: 1, latestSummary: 'same line' }))
+    // Repeated narrative but a changed tool count → body differs, edit fires,
+    // but the narrative block must not gain a duplicate line.
+    clock = 11_000
+    await feed.update('w1', 'chat', view({ toolCount: 2, latestSummary: 'same line' }))
+
+    const last = bot.edits.at(-1)!
+    expect(last.text.match(/↳/g) ?? []).toHaveLength(1)
+  })
+
+  it('caps the narrative block to the last 6 lines', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 0 })
+
+    for (let i = 1; i <= 9; i++) {
+      clock += 1000
+      await feed.update('w1', 'chat', view({ toolCount: i, latestSummary: `line ${i}` }))
+    }
+
+    const last = bot.edits.at(-1)!
+    expect(last.text.match(/↳/g) ?? []).toHaveLength(6)
+    // Oldest lines evicted; newest retained.
+    expect(last.text).not.toContain('line 1')
+    expect(last.text).not.toContain('line 3')
+    expect(last.text).toContain('line 4')
+    expect(last.text).toContain('line 9')
+  })
+
+  it('grows the narrative even while throttled (line surfaces on next edit)', async () => {
+    const bot = makeFakeBot()
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, minEditIntervalMs: 2500 })
+
+    await feed.update('w1', 'chat', view({ toolCount: 1, latestSummary: 'line A' }))
+    expect(bot.sent).toHaveLength(1)
+
+    // Throttled tick — no edit, but the line must still be accumulated.
+    clock = 11_000
+    await feed.update('w1', 'chat', view({ toolCount: 2, latestSummary: 'line B' }))
+    expect(bot.edits).toHaveLength(0)
+
+    // Past the throttle — the edit now carries BOTH lines.
+    clock = 13_000
+    await feed.update('w1', 'chat', view({ toolCount: 3, latestSummary: 'line C' }))
+    const last = bot.edits.at(-1)!
+    expect(last.text).toContain('↳ <i>line A</i>')
+    expect(last.text).toContain('↳ <i>line B</i>')
+    expect(last.text).toContain('↳ <i>line C</i>')
   })
 
   it('forwards threadId as message_thread_id on send', async () => {

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -46,6 +46,14 @@ export interface WorkerActivityView {
   toolCount: number
   /** The worker's latest narrative line, if any (already capped upstream). */
   latestSummary: string
+  /**
+   * Accumulated narrative lines, oldest→newest, already deduped + capped by
+   * the feed manager. When present and non-empty, the render grows a block
+   * of `↳` lines (mirroring the main agent's live answer) instead of
+   * collapsing to the single `latestSummary` line. Absent/empty → the
+   * single-line fallback (back-compat for direct render callers).
+   */
+  narrativeLines?: string[]
   /** Wall-clock since dispatch, ms. */
   elapsedMs: number
   state: WorkerActivityState
@@ -68,6 +76,13 @@ export interface BotApiForWorkerFeed {
 const DESC_MAX = 80
 const TOOL_ARG_MAX = 64
 const SUMMARY_MAX = 100
+/**
+ * How many trailing narrative lines the live feed keeps visible. The feed
+ * grows like the main agent's answer but can't grow unbounded — Telegram
+ * caps message length and a wall of stale lines buries the live one. Six
+ * keeps recent context without dominating the chat.
+ */
+const NARRATIVE_MAX_LINES = 6
 
 /**
  * Render the worker-activity message body as Telegram HTML.
@@ -105,10 +120,23 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
     activity = `<i>starting… (${elapsed})</i>`
   }
 
-  const summary = v.latestSummary.trim()
   const lines = [header, activity]
-  if (summary.length > 0) {
-    lines.push(`  ↳ <i>${escapeHtml(truncate(summary, SUMMARY_MAX))}</i>`)
+
+  // Growing narrative block when the manager has accumulated lines; the feed
+  // reads like the main agent's live answer rather than a single replaced
+  // status line. Fall back to the single latestSummary line otherwise.
+  const narrative = (v.narrativeLines ?? [])
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+  if (narrative.length > 0) {
+    for (const line of narrative) {
+      lines.push(`  ↳ <i>${escapeHtml(truncate(line, SUMMARY_MAX))}</i>`)
+    }
+  } else {
+    const summary = v.latestSummary.trim()
+    if (summary.length > 0) {
+      lines.push(`  ↳ <i>${escapeHtml(truncate(summary, SUMMARY_MAX))}</i>`)
+    }
   }
   return lines.join('\n')
 }
@@ -142,6 +170,12 @@ interface WorkerHandle {
   lastBody: string | null
   lastEditAt: number
   cooldownUntil: number
+  /**
+   * Accumulated narrative lines (oldest→newest), deduped against the
+   * immediately-preceding line and capped to NARRATIVE_MAX_LINES. Grows the
+   * live render so the feed reads like the main agent's answer.
+   */
+  narrative: string[]
   /** Per-worker serialization chain so ticks can't interleave sends. */
   chain: Promise<void>
 }
@@ -203,9 +237,24 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
     log(`worker-feed: ${label} 429 — backing off ${retryAfter}s`)
   }
 
+  function accumulateNarrative(h: WorkerHandle, view: WorkerActivityView): void {
+    const line = view.latestSummary.trim()
+    if (line.length === 0) return
+    // Dedup against the immediately-preceding line — the watcher re-emits the
+    // same narrative across ticks while a tool runs; we only grow on change.
+    if (h.narrative[h.narrative.length - 1] === line) return
+    h.narrative.push(line)
+    if (h.narrative.length > NARRATIVE_MAX_LINES) {
+      h.narrative.splice(0, h.narrative.length - NARRATIVE_MAX_LINES)
+    }
+  }
+
   async function doUpdate(h: WorkerHandle, view: WorkerActivityView): Promise<void> {
+    // Accumulate before any gate so a throttled/cooled-down tick still grows
+    // the narrative — the line surfaces on the next edit that does fire.
+    accumulateNarrative(h, view)
     if (nowFn() < h.cooldownUntil) return
-    const body = renderWorkerActivity(view)
+    const body = renderWorkerActivity({ ...view, narrativeLines: h.narrative })
 
     // First paint: hold off until the worker has run long enough to be
     // worth a message; trivial workers stay silent (handback covers them).
@@ -284,6 +333,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
           lastBody: null,
           lastEditAt: 0,
           cooldownUntil: 0,
+          narrative: [],
           chain: Promise.resolve(),
         }
         handles.set(agentId, h)


### PR DESCRIPTION
## Summary

Makes the live **worker-activity feed** read like the main agent's
growing answer instead of a flickering one-liner. The feed (the
edit-in-place message that surfaces a *background* sub-agent's progress)
previously replaced its single `↳` summary line on every watcher tick.
This accumulates distinct narrative lines into a growing `↳` block.

Closes #2009.

## Why

#2009: a long background worker's feed collapsed each new narrative onto
the prior one, so the operator saw one line mutate rather than a trail of
what the worker had done — the opposite of the "chat is the artifact" feel
the main agent's live answer already has.

## What changed

- `WorkerActivityView` gains an optional `narrativeLines?: string[]`.
- `renderWorkerActivity` renders a growing block of `↳` lines when
  `narrativeLines` is present/non-empty; otherwise it falls back to the
  single `latestSummary` line (**full back-compat** for direct callers).
- The feed manager accumulates `latestSummary` into a per-worker
  `narrative[]`, deduped against the preceding line and **capped to the
  last 6**. Accumulation runs *before* the throttle / cooldown /
  first-paint gates, so a line is never lost during a held tick — it
  surfaces on the next edit that fires.
- **No gateway change**: the manager builds the block from the
  per-emission `latestSummary` the watcher already passes on each
  `sub_agent_text`.

## Scope / non-goals

- The hard limit from the issue stands: during a *single long tool* the
  watcher emits no narrative, so the feed legitimately holds. This is
  event-granular surfacing, not token smoothing — we never fabricate
  progress.
- Skipped the optional animated "still working" spinner the issue floated
  under "Consider": an animating frame defeats the body-dedup that
  protects Telegram's edit budget. Deliberate scope call.

## Test plan

- [x] `vitest run telegram-plugin/tests/worker-activity-feed.test.ts` — 25 pass (was 14; +11 for growing block, dedup, cap, throttle-still-accumulates, HTML-escape, back-compat fallback).
- [x] `tsc --noEmit` clean.
- [x] `node scripts/check-plugin-references.mjs` clean.
- [ ] UAT `jtbd-worker-activity-feed-dm` after batched release (flag-gated `SWITCHROOM_WORKER_ACTIVITY_FEED=1`).

## Risk

Low. Render-only + manager-internal accumulation behind the existing
worker-feed flag; no gateway/IPC surface touched; single-line behavior
unchanged when `narrativeLines` is absent.