### PR TITLE
feat(telegram): default-on inbound coalescing, safe-boundary interrupt, worker feed

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -666,14 +666,13 @@ export const TelegramChannelSchema = z
           .optional()
           .describe(
             "Maximum number of media attachments carried into ONE coalesced " +
-            "Claude turn. Default 1 — a second photo/document/voice within the " +
-            "coalesce window (or an album / media_group_id) starts its own turn, " +
-            "preserving the historical single-attachment behaviour. Raise to let " +
-            "a forwarded album or a text+multi-image burst arrive as one turn; " +
-            "the agent then sees numbered attachment fields (image_path, " +
-            "image_path_2, …). Excess attachments beyond the cap spill into the " +
-            "next turn. Each attachment is downloaded, so a high cap on a slow " +
-            "link delays turn start."
+            "Claude turn. Default 10 — a full Telegram album (media_group caps " +
+            "at 10) or a text+multi-image forwarded burst arrives as a single " +
+            "turn; the agent sees numbered attachment fields (image_path, " +
+            "image_path_2, …). Set 1 to restore the historical " +
+            "single-attachment-per-turn behaviour. Excess attachments beyond " +
+            "the cap spill into the next turn. Each attachment is downloaded, " +
+            "so a high cap on a slow link delays turn start."
           ),
       })
       .optional()
@@ -688,15 +687,15 @@ export const TelegramChannelSchema = z
           .boolean()
           .optional()
           .describe(
-            "When true, a `!`-prefix interrupt that arrives while the agent is " +
-            "mid-tool-call is DEFERRED: the SIGINT and the replacement turn wait " +
-            "until the in-flight tool call finishes (a clean boundary) instead of " +
-            "C-c'ing the agent mid-write/mid-bash. If no tool is in flight the " +
-            "interrupt still fires immediately. Bounded by max_wait_ms so a long " +
-            "tool never strands the user. Default false — the interrupt fires " +
-            "synchronously the moment `!` is received (historical behaviour). " +
-            "Rapid repeated `!` while one is pending coalesce into a single " +
-            "deferred interrupt carrying the latest body."
+            "When true (the default), a `!`-prefix interrupt that arrives while " +
+            "the agent is mid-tool-call is DEFERRED: the SIGINT and the " +
+            "replacement turn wait until the in-flight tool call finishes (a " +
+            "clean boundary) instead of C-c'ing the agent mid-write/mid-bash. If " +
+            "no tool is in flight the interrupt still fires immediately. Bounded " +
+            "by max_wait_ms so a long tool never strands the user. Set false to " +
+            "fire synchronously the moment `!` is received (historical " +
+            "behaviour). Rapid repeated `!` while one is pending coalesce into a " +
+            "single deferred interrupt carrying the latest body."
           ),
         max_wait_ms: z
           .number()

--- a/telegram-plugin/gateway/coalesce-attachments.ts
+++ b/telegram-plugin/gateway/coalesce-attachments.ts
@@ -36,6 +36,15 @@ export interface ResolvedExtraAttachment {
  * `maxAttachments` is floored at 1 — a cap of 0 or negative would strip the
  * primary, silently dropping the only attachment.
  */
+/** Default attachments folded into one coalesced turn: a full Telegram album
+ *  (media_group caps at 10). Floored at 1 so the only attachment is never
+ *  stripped. Set channels.telegram.coalesce.max_attachments to override. */
+export const DEFAULT_MAX_ATTACHMENTS = 10
+
+export function resolveCoalesceMaxAttachments(configured: number | undefined): number {
+  return Math.max(1, configured ?? DEFAULT_MAX_ATTACHMENTS)
+}
+
 export function splitCoalescedAttachments<T>(
   entries: T[],
   hasAttachment: (e: T) => boolean,

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8733,11 +8733,11 @@ async function handleInboundCoalesced(
   const maxAttachments = coalesceMaxAttachments()
 
   // Albums (media_group_id): coalesce only when the cap allows >1 attachment
-  // (A2). At the default cap of 1 each album part keeps its own turn exactly
-  // as before — the single-attachment merge can't carry sibling photos, so
-  // bypassing avoids dropping them. With a raised cap the parts share the
-  // coalesce key and fold into one multi-attachment turn (the cap-overflow
-  // bypass below catches parts past the cap).
+  // (A2). At the default cap of 10 the parts share the coalesce key and fold
+  // into one multi-attachment turn (the cap-overflow bypass below catches
+  // parts past the cap). With the cap lowered to 1 each album part keeps its
+  // own turn — the single-attachment merge can't carry sibling photos, so
+  // bypassing avoids dropping them.
   if (hasAttachment && ctx.message?.media_group_id != null && maxAttachments <= 1) {
     return handleInbound(ctx, text, downloadImage, attachment)
   }
@@ -8747,7 +8747,8 @@ async function handleInboundCoalesced(
 
   // An attachment past the per-agent cap would be dropped by the capped merge.
   // Bypass it to its own turn so no media is silently lost. At the default
-  // cap of 1 this fires on the SECOND attachment, preserving A1 behaviour.
+  // cap of 10 this fires on the 11th attachment; with the cap lowered to 1 it
+  // fires on the SECOND, preserving A1 behaviour.
   if (hasAttachment) {
     const probeKey = inboundCoalesceKey(
       String(ctx.chat!.id),
@@ -8791,9 +8792,9 @@ async function handleInboundCoalesced(
   // Coalescing disabled (window <= 0): flush immediately, preserving any
   // media this message carried.
   if (result.bypass) return handleInbound(ctx, text, downloadImage, attachment)
-  // Count the open window's attachments so a third+ (or second, at the
-  // default cap) bypasses rather than overflows the capped merge (cleared
-  // in onFlush).
+  // Count the open window's attachments so any part past the cap (the 11th
+  // at the default cap of 10, or the second when lowered to 1) bypasses
+  // rather than overflows the capped merge (cleared in onFlush).
   if (hasAttachment) bufferedAttachmentKeys.set(key, (bufferedAttachmentKeys.get(key) ?? 0) + 1)
 }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -39,6 +39,7 @@ import {
   ToolFlightTracker,
   decideInterruptTiming,
   resolveInterruptMaxWaitMs,
+  resolveSafeBoundaryEnabled,
 } from './interrupt-defer.js'
 import {
   resolveStickerSendArgs,
@@ -56,10 +57,14 @@ import {
 } from '../telegraph.js'
 import { OutboundDedupCache } from '../recent-outbound-dedup.js'
 import { createInboundCoalescer, inboundCoalesceKey } from './inbound-coalesce.js'
-import { splitCoalescedAttachments, buildExtraAttachmentMeta } from './coalesce-attachments.js'
+import {
+  splitCoalescedAttachments,
+  buildExtraAttachmentMeta,
+  resolveCoalesceMaxAttachments,
+} from './coalesce-attachments.js'
 import { StatusReactionController } from '../status-reactions.js'
 import { DeferredDoneReactions } from '../reaction-defer.js'
-import { createWorkerActivityFeed } from '../worker-activity-feed.js'
+import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel } from '../tool-activity-summary.js'
 import { toolLabel } from '../tool-labels.js'
@@ -776,14 +781,15 @@ type Access = {
   parseMode?: 'html' | 'markdownv2' | 'text'
   disableLinkPreview?: boolean
   coalescingGapMs?: number
-  /** A2: max media attachments folded into one coalesced turn. Default 1
-   *  (single-attachment behaviour). Projected from
+  /** A2: max media attachments folded into one coalesced turn. Default 10
+   *  (a full Telegram album / forwarded burst arrives as one turn). Set 1 to
+   *  restore single-attachment behaviour. Projected from
    *  channels.telegram.coalesce.max_attachments by scaffold. */
   coalesceMaxAttachments?: number
-  /** Problem B: when true, a `!` interrupt that lands mid-tool-call is
-   *  deferred until the in-flight tool finishes (bounded by
-   *  interruptMaxWaitMs) before SIGINT + resume. Default false (fire
-   *  synchronously). Projected from channels.telegram.interrupt.safe_boundary. */
+  /** Problem B: when true (the default), a `!` interrupt that lands
+   *  mid-tool-call is deferred until the in-flight tool finishes (bounded by
+   *  interruptMaxWaitMs) before SIGINT + resume. Set false to fire
+   *  synchronously. Projected from channels.telegram.interrupt.safe_boundary. */
   interruptSafeBoundary?: boolean
   /** Upper bound (ms) to wait for a safe boundary before firing a deferred
    *  interrupt anyway. Default 8000. Projected from
@@ -3137,13 +3143,13 @@ type CoalescePayload = {
 
 // Count of attachment-bearing entries currently buffered per coalesce key.
 // A new attachment for a key whose count has reached the per-agent cap
-// (coalesce.max_attachments, default 1) bypasses coalescing (see
+// (coalesce.max_attachments, default 10) bypasses coalescing (see
 // handleInboundCoalesced) so no media is dropped past the cap. Cleared on
 // flush (below) and on the synchronous bypass path.
 const bufferedAttachmentKeys = new Map<string, number>()
 
 function coalesceMaxAttachments(): number {
-  return Math.max(1, loadAccess().coalesceMaxAttachments ?? 1)
+  return resolveCoalesceMaxAttachments(loadAccess().coalesceMaxAttachments)
 }
 
 const inboundCoalescer = createInboundCoalescer<CoalescePayload>({
@@ -8998,7 +9004,7 @@ async function handleInbound(
     deferInterrupt =
       !interrupt.emptyBody &&
       decideInterruptTiming({
-        safeBoundaryEnabled: access.interruptSafeBoundary === true,
+        safeBoundaryEnabled: resolveSafeBoundaryEnabled(access.interruptSafeBoundary),
         midToolCall: toolFlightTracker.isMidToolCall(),
       }) === 'defer'
     process.stderr.write(
@@ -17565,10 +17571,11 @@ void (async () => {
             // and edits it in place as work happens (current tool + elapsed),
             // finalizing on completion — the same "live, growing message"
             // shape the main agent's answer uses, NOT card chrome (the pinned
-            // card was deleted in #1126). Flag-gated; when ON it also
+            // card was deleted in #1126). On by default (set
+            // SWITCHROOM_WORKER_ACTIVITY_FEED=0 to disable); when ON it also
             // supersedes the coarse 5-min bucket relay below to avoid
             // double-surfacing the same progress beat.
-            const workerFeedEnabled = process.env.SWITCHROOM_WORKER_ACTIVITY_FEED === '1'
+            const workerFeedEnabled = isWorkerActivityFeedEnabled(process.env.SWITCHROOM_WORKER_ACTIVITY_FEED)
             const workerActivityFeed = createWorkerActivityFeed({
               bot: {
                 sendMessage: async (cid, text, sendOpts) => {

--- a/telegram-plugin/gateway/interrupt-defer.ts
+++ b/telegram-plugin/gateway/interrupt-defer.ts
@@ -98,3 +98,9 @@ export function resolveInterruptMaxWaitMs(configured: number | undefined): numbe
   if (typeof configured === 'number' && configured > 0) return configured
   return DEFAULT_INTERRUPT_MAX_WAIT_MS
 }
+
+/** safe_boundary defaults ON: a `!` mid-tool-call is deferred to a clean
+ *  boundary unless the operator explicitly sets it false. */
+export function resolveSafeBoundaryEnabled(configured: boolean | undefined): boolean {
+  return configured !== false
+}

--- a/telegram-plugin/tests/coalesce-attachments.test.ts
+++ b/telegram-plugin/tests/coalesce-attachments.test.ts
@@ -2,21 +2,39 @@
  * Unit tests for the A2 multi-attachment helpers
  * (telegram-plugin/gateway/coalesce-attachments.ts).
  *
- * These pin the two pure pieces of the multi-attachment fold-in that live
+ * These pin the pure pieces of the multi-attachment fold-in that live
  * outside gateway.ts so they can be exercised without loadAccess()/IPC:
- *   1. splitCoalescedAttachments — primary + capped extras, arrival order.
- *   2. buildExtraAttachmentMeta — numbered meta fields starting at _2.
+ *   1. resolveCoalesceMaxAttachments — the runtime cap default (10).
+ *   2. splitCoalescedAttachments — primary + capped extras, arrival order.
+ *   3. buildExtraAttachmentMeta — numbered meta fields starting at _2.
  *
- * The default cap (1) MUST reproduce the historical single-attachment shape:
- * primary only, no extras, no numbered meta.
+ * A cap of 1 reproduces the historical single-attachment shape: primary
+ * only, no extras, no numbered meta.
  */
 
 import { describe, expect, it } from 'vitest'
 import {
   splitCoalescedAttachments,
   buildExtraAttachmentMeta,
+  resolveCoalesceMaxAttachments,
+  DEFAULT_MAX_ATTACHMENTS,
   type ResolvedExtraAttachment,
 } from '../gateway/coalesce-attachments.js'
+
+describe('resolveCoalesceMaxAttachments (default 10 = full album)', () => {
+  it('defaults to 10 when unset', () => {
+    expect(resolveCoalesceMaxAttachments(undefined)).toBe(10)
+    expect(DEFAULT_MAX_ATTACHMENTS).toBe(10)
+  })
+  it('honours an explicit operator cap', () => {
+    expect(resolveCoalesceMaxAttachments(1)).toBe(1)
+    expect(resolveCoalesceMaxAttachments(25)).toBe(25)
+  })
+  it('floors a 0 / negative cap at 1 (never strips the only attachment)', () => {
+    expect(resolveCoalesceMaxAttachments(0)).toBe(1)
+    expect(resolveCoalesceMaxAttachments(-5)).toBe(1)
+  })
+})
 
 interface Entry {
   text: string
@@ -26,7 +44,7 @@ interface Entry {
 const has = (e: Entry): boolean => e.att != null
 
 describe('splitCoalescedAttachments', () => {
-  it('default cap 1: keeps only the first attachment as primary, no extras', () => {
+  it('cap 1: keeps only the first attachment as primary, no extras', () => {
     const entries: Entry[] = [
       { text: 'a', att: 'photo-1' },
       { text: 'b', att: 'photo-2' },

--- a/telegram-plugin/tests/interrupt-defer.test.ts
+++ b/telegram-plugin/tests/interrupt-defer.test.ts
@@ -15,6 +15,7 @@ import {
   ToolFlightTracker,
   decideInterruptTiming,
   resolveInterruptMaxWaitMs,
+  resolveSafeBoundaryEnabled,
   DEFAULT_INTERRUPT_MAX_WAIT_MS,
 } from '../gateway/interrupt-defer.js'
 
@@ -116,6 +117,18 @@ describe('decideInterruptTiming', () => {
     expect(
       decideInterruptTiming({ safeBoundaryEnabled: false, midToolCall: false }),
     ).toBe('fire-now')
+  })
+})
+
+describe('resolveSafeBoundaryEnabled (default ON)', () => {
+  it('defaults to true when unset', () => {
+    expect(resolveSafeBoundaryEnabled(undefined)).toBe(true)
+  })
+  it('stays true when explicitly true', () => {
+    expect(resolveSafeBoundaryEnabled(true)).toBe(true)
+  })
+  it('only an explicit false opts out', () => {
+    expect(resolveSafeBoundaryEnabled(false)).toBe(false)
   })
 })
 

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -2,9 +2,23 @@ import { describe, it, expect } from 'vitest'
 import {
   renderWorkerActivity,
   createWorkerActivityFeed,
+  isWorkerActivityFeedEnabled,
   type WorkerActivityView,
   type BotApiForWorkerFeed,
 } from '../worker-activity-feed.js'
+
+describe('isWorkerActivityFeedEnabled (default ON)', () => {
+  it('defaults to true when the env var is unset', () => {
+    expect(isWorkerActivityFeedEnabled(undefined)).toBe(true)
+  })
+  it('stays on for any value other than "0"', () => {
+    expect(isWorkerActivityFeedEnabled('1')).toBe(true)
+    expect(isWorkerActivityFeedEnabled('')).toBe(true)
+  })
+  it('only "0" disables it', () => {
+    expect(isWorkerActivityFeedEnabled('0')).toBe(false)
+  })
+})
 
 function view(partial: Partial<WorkerActivityView> = {}): WorkerActivityView {
   return {

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -25,14 +25,20 @@
  *   - 429 cooldown + message_id drift resilience (re-post on stale edit),
  *   - a forced terminal edit on `finish` regardless of throttle.
  *
- * The feed is gated to BACKGROUND workers and lives behind the
- * `SWITCHROOM_WORKER_ACTIVITY_FEED` flag — see the gateway wiring. The
- * watcher already drives the cues (it polls the worker jsonl directly,
- * so it keeps firing after the parent turn ends), which is why the feed
- * is fed from watcher callbacks rather than the bridge event stream.
+ * The feed is gated to BACKGROUND workers and is ON by default; set
+ * `SWITCHROOM_WORKER_ACTIVITY_FEED=0` to disable it — see the gateway
+ * wiring. The watcher already drives the cues (it polls the worker jsonl
+ * directly, so it keeps firing after the parent turn ends), which is why
+ * the feed is fed from watcher callbacks rather than the bridge event stream.
  */
 
 import { escapeHtml, formatDuration, truncate } from './card-format.js'
+
+/** Worker-activity feed is ON by default; an operator opts out with
+ *  SWITCHROOM_WORKER_ACTIVITY_FEED=0. */
+export function isWorkerActivityFeedEnabled(envVal: string | undefined): boolean {
+  return envVal !== '0'
+}
 
 export type WorkerActivityState = 'running' | 'done' | 'failed'
 


### PR DESCRIPTION
## Summary

Flips the three behavioral features shipped **default-off** in v0.14.20 to **default-on**, so they become the standard fleet behaviour with no flag/opt-in required.

| Feature | Old default | New default | Opt-out |
|---|---|---|---|
| A2 album coalescing (#2015) | `max_attachments=1` | `10` (full Telegram album) | set `max_attachments: 1` |
| `!` safe-boundary interrupt (#2016) | `safe_boundary=false` | `true` (defer to clean boundary, ≤8000ms) | set `safe_boundary: false` |
| Worker-activity feed (#2009) | flag off (`=1` to enable) | ON | `SWITCHROOM_WORKER_ACTIVITY_FEED=0` |

## Why

Operator directive: these three should be default behaviour, not flagged. They were sequenced default-off across PRs #2009/#2015/#2016 for a staged rollout; this PR completes that ramp.

## Implementation

- Each default is extracted into a small **pure, exported resolver** (`resolveCoalesceMaxAttachments`, `resolveSafeBoundaryEnabled`, `isWorkerActivityFeedEnabled`) mirroring the existing `resolveInterruptMaxWaitMs` seam, then called from the gateway in place of the inline expressions.
- Schema `describe()` text + `AccessFile` doc comments updated to document the new defaults and opt-outs.
- Scaffold projection unchanged (it still only projects when config sets a value; the default lives in the gateway), so the "field absent when unset" scaffold tests stay correct.

## Test plan

- [x] New unit tests pin each new default (undefined→10 / undefined→true / undefined→on) plus the opt-out and floor cases
- [x] `vitest` coalesce-attachments + interrupt-defer + worker-activity-feed: 63 pass
- [x] `vitest` scaffold.test.ts: 186 pass (projection unaffected)
- [x] `npm run lint` clean (tsc, plugin-references, bot-api-wrapping, bun-test-imports, no-pii, vault-hermeticity, no-broadcast)
- [ ] **Fleet UAT post-release** — #2015 album + #2016 interrupt paths go LIVE for the first time; UAT must exercise both (not just the worker feed) before rollout

## Risk

Medium — two paths (album coalescing, deferred interrupt) run in production for the first time at these defaults. Both are config-revertible without a code change. Worker feed already ran fleet-wide via the flag.