### PR TITLE
test(uat): skip tool-activity feed in memory-recall matcher

### DIFF
--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -35,6 +35,35 @@ export function isWorkerFeedMessage(m: ObservedMessage): boolean {
   return WORKER_FEED_RE.test(m.text);
 }
 
+/**
+ * A single tool-activity-feed line as rendered by
+ * `renderActivityFeed` (telegram-plugin/tool-activity-summary.ts): the
+ * in-progress step is `→ <label>`, finished steps are `✓ <label>`, and a
+ * long turn gets a `✓ +N earlier…` header. Telegram strips the bold/italic
+ * wrapping, so the observed text is just the marker glyph + label.
+ */
+const ACTIVITY_FEED_LINE_RE = /^[→✓]\s/u;
+
+/**
+ * True when `m` is the live tool-activity feed (the one-message list of
+ * "what the agent is doing this turn") rather than the agent's reply. A
+ * message qualifies only when EVERY non-empty line is an activity line —
+ * so a real reply that merely contains an arrow is never misclassified.
+ *
+ * Recall/reply scenarios must skip this in addition to
+ * {@link isWorkerFeedMessage}: on a turn that uses tools, the feed paints
+ * `→ Finding the right tool` as its own bot message before the real answer
+ * lands, and an `expectMessage(/\S/)` would otherwise latch onto it.
+ */
+export function isActivityFeedMessage(m: ObservedMessage): boolean {
+  const lines = m.text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  if (lines.length === 0) return false;
+  return lines.every((l) => ACTIVITY_FEED_LINE_RE.test(l));
+}
+
 export interface PollOptions {
   /** Hard deadline; the predicate must resolve truthy before this. */
   timeout: number;

--- a/telegram-plugin/uat/feed-matcher.test.ts
+++ b/telegram-plugin/uat/feed-matcher.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { isWorkerFeedMessage, WORKER_FEED_RE } from "./assertions.js";
+import {
+  isActivityFeedMessage,
+  isWorkerFeedMessage,
+  WORKER_FEED_RE,
+} from "./assertions.js";
 
 // Pins the worker-activity-feed detector (#2000) used by recall/reply
 // scenarios to skip feed noise. The live UAT it guards can't run in CI
@@ -37,5 +41,40 @@ describe("isWorkerFeedMessage", () => {
 
   it("exposes the regex for scenarios that assert on the feed directly", () => {
     expect(WORKER_FEED_RE.test("🔧 Worker · x")).toBe(true);
+  });
+});
+
+describe("isActivityFeedMessage", () => {
+  it("matches the in-progress step line", () => {
+    expect(isActivityFeedMessage(feed("→ Finding the right tool"))).toBe(true);
+  });
+
+  it("matches a multi-line feed (done steps + in-progress)", () => {
+    expect(
+      isActivityFeedMessage(feed("✓ Reading CLAUDE.md\n→ Searching memory")),
+    ).toBe(true);
+  });
+
+  it("matches the +N earlier header", () => {
+    expect(
+      isActivityFeedMessage(feed("✓ +3 earlier…\n✓ Reading CLAUDE.md\n→ Searching memory")),
+    ).toBe(true);
+  });
+
+  it("does NOT match an ordinary agent reply", () => {
+    expect(isActivityFeedMessage(feed("on it, pulling the logs now"))).toBe(false);
+    expect(
+      isActivityFeedMessage(feed("SWITCHROOM_UAT_MEM_DEADBEEFCAFE1234")),
+    ).toBe(false);
+  });
+
+  it("does NOT match a reply that merely contains an arrow mid-text", () => {
+    expect(
+      isActivityFeedMessage(feed("The flow is request → response → render.")),
+    ).toBe(false);
+  });
+
+  it("does NOT match an empty message", () => {
+    expect(isActivityFeedMessage(feed("   "))).toBe(false);
   });
 });

--- a/telegram-plugin/uat/scenarios/jtbd-memory-survives-restart-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-memory-survives-restart-dm.test.ts
@@ -53,19 +53,23 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { execSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { spinUp } from "../harness.js";
-import { isWorkerFeedMessage } from "../assertions.js";
+import { isActivityFeedMessage, isWorkerFeedMessage } from "../assertions.js";
 import type { ObservedMessage } from "../driver.js";
 
 const AGENT = "test-harness";
 
-// The worker-activity feed (#2000) is default-on fleet-wide since
-// v0.14.19, so a stray background sub-agent can post a `🔧 Worker · …`
-// message into this DM. A bare `/\S/` matcher would latch onto that feed
-// paint instead of the agent's reply — failing the verbatim-token check
-// against feed text, not a real memory miss. Match the first non-empty
-// bot reply that ISN'T the feed.
+// Two classes of bot message are NOT the agent's reply and must be
+// skipped, or a bare `/\S/` matcher latches onto them and the
+// verbatim-token check fails against noise instead of catching a real
+// memory miss:
+//   1. The worker-activity feed (#2000, default-on since v0.14.19) — a
+//      stray background sub-agent posts `🔧 Worker · …` into this DM.
+//   2. The tool-activity feed — on a turn that uses tools (memory recall
+//      does), `→ Finding the right tool` paints as its own message before
+//      the real answer lands.
+// Match the first non-empty bot reply that is neither.
 const isReply = (m: ObservedMessage): boolean =>
-  /\S/.test(m.text) && !isWorkerFeedMessage(m);
+  /\S/.test(m.text) && !isWorkerFeedMessage(m) && !isActivityFeedMessage(m);
 
 const RESTART_BUDGET_MS = 90_000;
 const CAPTURE_REPLY_BUDGET_MS = 60_000;


### PR DESCRIPTION
## Summary
Extends the memory-survives-restart recall matcher (#2020) to also skip the **tool-activity feed**, not just the worker-activity feed.

## Why
#2020 made the recall matcher ignore `🔧 Worker · …` feed messages. But the live UAT still failed: on any turn that uses tools — memory recall does — `renderActivityFeed` (`telegram-plugin/tool-activity-summary.ts:214`) paints `→ Finding the right tool` as its own bot message before the real answer lands. The `/\S/`-based matcher latched onto it, and the verbatim-token assertion failed against feed text rather than catching a genuine memory miss.

Observed live failure before this fix:
```
[memory-survives] capture phase: TTFO=8691ms, reply length=24
× ... CONTRACT FAILED: token SWITCHROOM_UAT_MEM_5177007E298E6CF8 not present.
  Reply was: "→ Finding the right tool"
```

## What changed
- `assertions.ts`: new `isActivityFeedMessage` — a message qualifies only when **every** non-empty line starts with `→ ` or `✓ ` (so a real reply that merely contains an arrow is never misclassified).
- `jtbd-memory-survives-restart-dm.test.ts`: `isReply` now excludes both feeds.
- `feed-matcher.test.ts`: +6 unit cases pinning `isActivityFeedMessage`.

A genuine recall miss now surfaces as a timeout instead of a false latch — the correct behavior for a regression guard.

## Test plan
- [x] `bun test telegram-plugin/uat/feed-matcher.test.ts` — 12 pass
- [x] `tsc --noEmit` clean
- [x] **Live UAT** `jtbd-memory-survives-restart-dm` now PASSES (recall TTFO ~27s, token round-trips) — same scenario that failed pre-fix

## Risk
Test-only change (UAT harness + its unit test). No runtime/agent code touched.