### PR TITLE
fix(uat): album driver must use file: scheme for local uploads

### DIFF
--- a/telegram-plugin/uat/driver.ts
+++ b/telegram-plugin/uat/driver.ts
@@ -663,8 +663,10 @@ export class Driver {
   ): Promise<{ messageIds: number[] }> {
     const c = this.requireClient();
     const replyTo = opts?.replyTo ?? opts?.messageThreadId;
+    // mtcute reads a bare string as a file_id/URL; the `file:` scheme is
+    // what forces an upload from local disk (see normalize-input-media).
     const medias = photoPaths.map((p, i) =>
-      InputMedia.photo(p, i === 0 && caption ? { caption } : undefined),
+      InputMedia.photo(`file:${p}`, i === 0 && caption ? { caption } : undefined),
     );
     const sent = await c.sendMediaGroup(
       chatId,


### PR DESCRIPTION
## Summary
`driver.sendAlbum` (added in #2023) passed bare filesystem paths to `InputMedia.photo`. mtcute classifies a bare string as a file_id/URL (`isFileIdLike`), runs it through `parseFileId`, and crashes — `Unsupported file ID version: 166` — instead of uploading the file. The album UAT scenario therefore could never actually send its album. Per mtcute's `normalize-input-media`, only a `file:`-prefixed string forces an upload from local disk.

## Why it slipped through
The scenario was type-checked and lint-clean, but UAT scenarios hit real Telegram and don't run on the gating CI path — the bug only surfaces at send time. It was caught the first time the scenario ran for real, during the v0.14.21 canary.

## Test plan
- [x] Validated live against test-harness (v0.14.21): with the fix, `jtbd-album-coalescing-dm` sends the 3-photo album and the agent replies `IMAGECOUNT=3` — album coalescing confirmed end-to-end. (25s, pass.)

## Risk
Test-only, one line; off the gating CI path. Restores the album gate from "always errors at send" to "actually exercises coalescing".