### PR TITLE
feat(telegram): nest foreground sub-agent steps in the parent's live draft

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -66,7 +66,7 @@ import { StatusReactionController } from '../status-reactions.js'
 import { DeferredDoneReactions } from '../reaction-defer.js'
 import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
-import { appendActivityLabel } from '../tool-activity-summary.js'
+import { appendActivityLabel, renderActivityFeedWithNested } from '../tool-activity-summary.js'
 import { toolLabel } from '../tool-labels.js'
 import { createTypingWrapper } from '../typing-wrap.js'
 import { type DraftStreamHandle } from '../draft-stream.js'
@@ -1474,6 +1474,13 @@ type CurrentTurn = {
   // (via `renderActivityFeed`) as a capped chronological list into the
   // in-place edited activity message and clears on reply. Reset per turn.
   mirrorLines: string[]
+  // Model A — foreground sub-agent nesting. A foreground sub-agent (Task/Agent
+  // with no run_in_background) runs INSIDE this turn while the parent blocks at
+  // the Task tool, so its live steps nest under the parent's activity feed
+  // rather than a separate message. Keyed by jsonl agent id; value = the
+  // sub-agent's accumulated narrative lines (oldest→newest, deduped + capped).
+  // Background workers are NOT here — they get the standalone worker feed.
+  foregroundSubAgents: Map<string, string[]>
   // Issue #195 — answer-lane streaming. Lazily created on the first text
   // event of a turn (once enough text has accumulated, the stream itself
   // gates on minInitialChars). Materialized and cleared at turn_end.
@@ -7223,6 +7230,27 @@ function closeProgressLane(chatId: string, threadId: number | undefined): void {
   }
 }
 
+/** Accumulation cap for a foreground sub-agent's nested narrative lines.
+ *  Slightly larger than NESTED_MAX_LINES so the render's "↳ +N earlier…"
+ *  header is meaningful without growing unbounded on a long sub-agent. */
+const FOREGROUND_SUBAGENT_ACCUM_MAX = 12
+
+/**
+ * Render this turn's activity feed, nesting any active foreground sub-agent's
+ * narrative beneath the parent's own steps (Model A). With no active
+ * foreground sub-agent this is exactly the flat feed. Multiple concurrent
+ * foreground sub-agents (rare — parallel Task dispatch) flatten in insertion
+ * order; the single-sub-agent common case nests precisely under its
+ * Delegating line.
+ */
+function composeTurnActivity(turn: CurrentTurn): string | null {
+  const childLines: string[] = []
+  for (const narrative of turn.foregroundSubAgents.values()) {
+    childLines.push(...narrative)
+  }
+  return renderActivityFeedWithNested(turn.mirrorLines, childLines)
+}
+
 /**
  * Drain the tool-activity summary's pending render queue. Single-flight
  * by construction (caller assigns the returned promise to
@@ -7389,6 +7417,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           activityPendingRender: null,
           activityLastSentRender: null,
           mirrorLines: [],
+          foregroundSubAgents: new Map(),
           answerStream: null,
           isDm: isDmChatId(ev.chatId),
         }
@@ -7566,7 +7595,10 @@ function handleSessionEvent(ev: SessionEvent): void {
       if (turn.replyCalled) return
       const rendered = appendActivityLabel(turn.mirrorLines, ev.label)
       if (rendered != null) {
-        turn.activityPendingRender = rendered
+        // Recompose so any active foreground sub-agent's nested block (Model A)
+        // is preserved when the parent appends its own step. composeTurnActivity
+        // == the flat render when no foreground sub-agent is active.
+        turn.activityPendingRender = composeTurnActivity(turn) ?? rendered
         if (turn.activityInFlight == null) {
           turn.activityInFlight = drainActivitySummary(turn)
         }
@@ -17640,6 +17672,12 @@ void (async () => {
             // supersedes the coarse 5-min bucket relay below to avoid
             // double-surfacing the same progress beat.
             const workerFeedEnabled = isWorkerActivityFeedEnabled(process.env.SWITCHROOM_WORKER_ACTIVITY_FEED)
+            // Model A — foreground sub-agent nesting in the parent's live
+            // activity draft. ON by default; this edits the SAME activity-
+            // summary message the tool_label feed already owns (not the
+            // compose draft, so no answer-stream contention). The kill-switch
+            // disables only the nesting; the parent's own feed is unaffected.
+            const foregroundNestingEnabled = process.env.SWITCHROOM_FOREGROUND_SUBAGENT_NESTING !== '0'
             const workerActivityFeed = createWorkerActivityFeed({
               bot: {
                 sendMessage: async (cid, text, sendOpts) => {
@@ -17798,6 +17836,28 @@ void (async () => {
                   } catch { /* best-effort */ }
                 }
                 const isBackground = dispatch.isBackground
+                if (!isBackground) {
+                  // Model A — a foreground sub-agent finished. Collapse its
+                  // nested child block from the parent's activity draft; the
+                  // parent resumes and its result returns inline as the Task
+                  // tool result, so there's no handback to deliver. Reaction
+                  // promotion already ran above.
+                  const turn = currentTurn
+                  if (
+                    turn != null &&
+                    turn.foregroundSubAgents.delete(agentId) &&
+                    !turn.replyCalled
+                  ) {
+                    const rendered = composeTurnActivity(turn)
+                    if (rendered != null) {
+                      turn.activityPendingRender = rendered
+                      if (turn.activityInFlight == null) {
+                        turn.activityInFlight = drainActivitySummary(turn)
+                      }
+                    }
+                  }
+                  return
+                }
                 // #PR2 live worker-feed: force the terminal recap edit on
                 // the worker's live message. No-op when no message was ever
                 // posted (trivial workers stay silent; handback covers them).
@@ -17906,7 +17966,39 @@ void (async () => {
                   } catch { /* best-effort */ }
                 }
                 const isBackground = dispatch.isBackground
-                if (!isBackground) return // skip overhead for foreground
+                if (!isBackground) {
+                  // Model A — a foreground sub-agent runs inside the parent's
+                  // turn, so its live narrative nests under the parent's
+                  // activity draft rather than a separate worker message. Pure
+                  // jsonl-tail → render (no model call), inside the
+                  // subscription-honest boundary.
+                  if (!foregroundNestingEnabled) return // kill-switch: skip overhead
+                  const turn = currentTurn
+                  if (turn == null || turn.replyCalled) return
+                  const child = latestSummary.trim().slice(0, 120)
+                  if (child.length === 0) return
+                  let narrative = turn.foregroundSubAgents.get(agentId)
+                  if (narrative == null) {
+                    narrative = []
+                    turn.foregroundSubAgents.set(agentId, narrative)
+                  }
+                  // Dedup against the immediately-preceding line — the watcher
+                  // re-emits the same narrative across ticks while a tool runs.
+                  if (narrative[narrative.length - 1] !== child) {
+                    narrative.push(child)
+                    if (narrative.length > FOREGROUND_SUBAGENT_ACCUM_MAX) {
+                      narrative.splice(0, narrative.length - FOREGROUND_SUBAGENT_ACCUM_MAX)
+                    }
+                  }
+                  const rendered = composeTurnActivity(turn)
+                  if (rendered != null) {
+                    turn.activityPendingRender = rendered
+                    if (turn.activityInFlight == null) {
+                      turn.activityInFlight = drainActivitySummary(turn)
+                    }
+                  }
+                  return
+                }
 
                 // #PR2 live worker-feed: when ON, the worker's live chat
                 // message owns the progress beat. Push a running cue and

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -4,7 +4,9 @@ import {
   appendActivityLine,
   appendActivityLabel,
   renderActivityFeed,
+  renderActivityFeedWithNested,
   MIRROR_MAX_LINES,
+  NESTED_MAX_LINES,
 } from "../tool-activity-summary.js";
 
 describe("describeToolUse — friendly per-tool rendering (draft-mirror)", () => {
@@ -141,5 +143,47 @@ describe("appendActivityLabel — precomputed label feed (tool_label path)", () 
     expect(appendActivityLabel(lines, "   ")).toBeNull();
     expect(appendActivityLabel(lines, undefined)).toBeNull();
     expect(lines.length).toBe(2);
+  });
+});
+
+describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A)", () => {
+  it("with no child lines, is identical to the flat feed", () => {
+    const lines = ["Searching memory", "Delegating: review the migration"];
+    expect(renderActivityFeedWithNested(lines, [])).toBe(renderActivityFeed(lines));
+    // whitespace-only children also collapse to the flat feed
+    expect(renderActivityFeedWithNested(lines, ["  ", ""])).toBe(renderActivityFeed(lines));
+  });
+
+  it("done-styles ALL parent lines and nests the child block (newest = bold →)", () => {
+    const parent = ["Searching memory", "Delegating: review the migration"];
+    const child = ["Reading schema.ts", "Looking for foreign keys"];
+    const out = renderActivityFeedWithNested(parent, child)!;
+    // Parent is blocked at the Task tool → none of its lines is the live step.
+    expect(out).toContain("<i>✓ Searching memory</i>");
+    expect(out).toContain("<i>✓ Delegating: review the migration</i>");
+    expect(out).not.toContain("<b>→ Delegating");
+    // The live → step is the newest nested child line; earlier child = italic.
+    expect(out).toContain("   ↳ <i>Reading schema.ts</i>");
+    expect(out).toContain("   ↳ <b>→ Looking for foreign keys</b>");
+  });
+
+  it("caps the nested block to NESTED_MAX_LINES with a '↳ +N earlier…' header", () => {
+    const child = Array.from({ length: NESTED_MAX_LINES + 3 }, (_, i) => `step ${i + 1}`);
+    const out = renderActivityFeedWithNested(["Delegating: x"], child)!;
+    expect(out).toContain("   ↳ <i>+3 earlier…</i>");
+    // newest nested line is the live → step
+    expect(out).toContain(`   ↳ <b>→ step ${NESTED_MAX_LINES + 3}</b>`);
+    // the oldest (collapsed) lines are not rendered verbatim
+    expect(out).not.toContain("step 1<");
+  });
+
+  it("renders the child block even when the parent feed is empty", () => {
+    const out = renderActivityFeedWithNested([], ["Reading a.ts"]);
+    expect(out).toBe("   ↳ <b>→ Reading a.ts</b>");
+  });
+
+  it("HTML-escapes nested child text", () => {
+    const out = renderActivityFeedWithNested(["Delegating: x"], ["touch <a> & <b>"])!;
+    expect(out).toContain("   ↳ <b>→ touch &lt;a&gt; &amp; &lt;b&gt;</b>");
   });
 });

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -216,6 +216,61 @@ export function renderActivityFeed(lines: string[]): string | null {
   return out.join("\n");
 }
 
+// ─── Foreground sub-agent nesting (Model A) ─────────────────────────────────
+//
+// A foreground sub-agent (Task/Agent with no `run_in_background`) runs INSIDE
+// the parent's turn — the parent is blocked at the Task tool until it returns.
+// Rather than a separate message, its live steps nest under the parent's own
+// activity feed: the gold-standard main-turn visibility applied one level
+// down. The parent's lines render as done (the parent handed off; it isn't
+// the active worker), and the sub-agent's recent narrative lines render as an
+// indented `↳` block with the newest as the in-progress `→` step.
+
+/** Trailing nested child lines kept visible (Telegram length + readability). */
+export const NESTED_MAX_LINES = 4;
+/** Hard cap on a single nested narrative line. */
+const NESTED_LINE_MAX = 90;
+/** Indent marker for a nested sub-agent step. */
+const NESTED_PREFIX = "   ↳ ";
+
+/**
+ * Render the parent activity feed with an active foreground sub-agent's steps
+ * nested beneath it. When `childLines` is empty this is identical to
+ * `renderActivityFeed(lines)`. Otherwise the parent's own lines are all
+ * done-styled (`✓` italic) — the live `→` step lives in the nested block —
+ * and the child block is indented, newest = bold `→`, earlier = italic, with
+ * a `↳ +N earlier…` header when it overflows. Returns ready Telegram HTML
+ * (callers must NOT re-escape) or null when there is nothing to show.
+ */
+export function renderActivityFeedWithNested(
+  lines: string[],
+  childLines: string[],
+): string | null {
+  const children = childLines.map((s) => s.trim()).filter((s) => s.length > 0);
+  if (children.length === 0) return renderActivityFeed(lines);
+
+  const out: string[] = [];
+  const shownParent = lines.slice(-MIRROR_MAX_LINES);
+  const hiddenParent = lines.length - shownParent.length;
+  if (hiddenParent > 0) out.push(`<i>✓ +${hiddenParent} earlier…</i>`);
+  for (const l of shownParent) out.push(`<i>✓ ${escapeFeedHtml(l)}</i>`);
+
+  const shownChild = children.slice(-NESTED_MAX_LINES);
+  const hiddenChild = children.length - shownChild.length;
+  if (hiddenChild > 0) out.push(`${NESTED_PREFIX}<i>+${hiddenChild} earlier…</i>`);
+  const lastChildIdx = shownChild.length - 1;
+  shownChild.forEach((l, i) => {
+    const t = l.length > NESTED_LINE_MAX ? l.slice(0, NESTED_LINE_MAX - 1) + "…" : l;
+    const esc = escapeFeedHtml(t);
+    out.push(
+      i === lastChildIdx
+        ? `${NESTED_PREFIX}<b>→ ${esc}</b>`
+        : `${NESTED_PREFIX}<i>${esc}</i>`,
+    );
+  });
+  return out.length > 0 ? out.join("\n") : null;
+}
+
 /**
  * Like appendActivityLine, but for a pre-computed label (from the
  * real-time PreToolUse sidecar / `tool_label` event) — the hook already


### PR DESCRIPTION
## Summary

Closes the **foreground sub-agent** visibility blindspot — the biggest gap against the main-turn live-draft "gold standard" (CPO direction 2026-05-31, memory `visibility-parity-goal`).

A foreground sub-agent (`Task`/`Agent` with no `run_in_background`) previously surfaced only as the parent's `→ Delegating: <desc>` line plus a ticking elapsed timer — **zero** internal tool/narration detail. The watcher already tailed the sub-agent jsonl and fired `onProgress`, but the gateway bailed with `if (!isBackground) return`.

**Model A** (operator-chosen presentation): a foreground sub-agent runs *inside* the parent's turn while the parent blocks at the Task tool, so its live narrative now **nests under the parent's own activity feed** rather than a separate message.

- Parent's own lines render done-styled (`✓`); the live `→` step is the newest **nested** child line.
- Child steps render as an indented `↳` block (newest = bold `→`, earlier = italic), capped to `NESTED_MAX_LINES` with a `↳ +N earlier…` header.
- The block collapses when the sub-agent finishes — its result returns inline as the Task tool result, so there's no handback.

## Why

- Advances vision outcome **"you hold the leash — awareness + control"**: the operator can now see what a foreground sub-agent is actually doing, not just that one was dispatched.
- Edits the **same** activity-summary message the `tool_label` feed already owns (not the compose draft) → no answer-stream contention (cf. `feedback_draft_mirror_conflicts_answer_stream`).
- **Subscription-honest:** pure jsonl-tail → Telegram render. No model call, no API/SDK.

## What changed

- `tool-activity-summary.ts` — new pure `renderActivityFeedWithNested(lines, childLines)` (+ `NESTED_MAX_LINES`). Identical to the flat feed when there's no active sub-agent.
- `gateway.ts` — `CurrentTurn.foregroundSubAgents` map; accumulate sub-agent narrative in the watcher `onProgress` foreground branch (was an early `return`); recompose the `tool_label` render to preserve the nested block; collapse + redraw on foreground `onFinish`. New `composeTurnActivity(turn)` helper.
- Kill-switch `SWITCHROOM_FOREGROUND_SUBAGENT_NESTING=0` (default ON) disables only the nesting; the parent's own feed is unaffected. Background workers unchanged (standalone worker feed).

## Test plan

- [x] `renderActivityFeedWithNested` unit cases (no-child == flat feed; parent done-styled; child block + newest `→`; `+N earlier` cap; empty-parent; HTML-escape) — pass under **both** vitest and bun.
- [x] `tsc --noEmit` clean; `check-plugin-references` clean; `check-bot-api-wrapping` clean.
- [x] Full `telegram-plugin` bun suite: 3735 pass, 0 fail.
- [ ] UAT: foreground sub-agent DM scenario (post-merge, pre-rollout).

## Risk

Touches the main turn's live activity draft (higher blast radius than the background worker feed's separate message), hence the kill-switch. No new model calls. Multiple concurrent foreground sub-agents (rare parallel Task dispatch) flatten in insertion order — the common single-sub-agent case nests precisely.