### PR TITLE
feat(docker): add git-lfs to base agent image

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -36,6 +36,12 @@ RUN echo "switchroom/base building for arch=${TARGETARCH}" >&2
 #   tmux       — agent supervisor surface (#725)
 #   bash, ca-certificates, procps — shell + TLS trust + ps
 #   git        — claude tool calls + agent workflows
+#   git-lfs    — large-asset repos (e.g. social-content backups with
+#                photos/videos tracked via LFS). Without it `git clone`/
+#                `pull` leave LFS files as ~130-byte pointer stubs instead
+#                of the real binaries. `git lfs install --system` (below)
+#                registers the smudge/clean filters image-wide so every
+#                agent's clones materialise LFS blobs.
 #   sqlite3    — kernel.db / scheduler.db / hindsight inspection
 #   openssh-client — claude bundle expects ssh-keygen
 #   curl       — also used by the bun installer below; keep above bun
@@ -88,6 +94,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       procps \
       psmisc \
       git \
+      git-lfs \
       sqlite3 \
       openssh-client \
       curl \
@@ -114,7 +121,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       dnsutils \
       iputils-ping \
       netcat-openbsd \
- && ln -sf /usr/bin/fdfind /usr/local/bin/fd
+ && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
+ && git lfs install --system --skip-repo
 
 # GitHub CLI (`gh`) — promoted to Tier 1 because `gh auth login` is
 # table stakes once Layer 1's persistent HOME makes the credentials

--- a/tests/docker/e2e.test.ts
+++ b/tests/docker/e2e.test.ts
@@ -293,7 +293,7 @@ describe.skipIf(!dockerOk || !allImagesPresent)(
       expect(r.stdout).toContain("OK");
     });
 
-    it("base image has Tier 1 tools on PATH (gh, ripgrep, fd, jq, pip, git, less, nano)", () => {
+    it("base image has Tier 1 tools on PATH (gh, ripgrep, fd, jq, pip, git, git-lfs, less, nano)", () => {
       // Pin the Tier 1 list — anything missing here is a regression in
       // docker/Dockerfile.base. These are the tools Claude reaches for
       // in the first 10 turns of a typical session; failing to install
@@ -303,12 +303,29 @@ describe.skipIf(!dockerOk || !allImagesPresent)(
         "docker",
         [
           "run", "--rm", ...LABELS_ARGV, "--entrypoint", "sh", IMAGES.base, "-c",
-          'for c in gh rg fd jq pip3 git less nano dig ping nc tree file; do command -v "$c" || echo "MISSING:$c"; done',
+          'for c in gh rg fd jq pip3 git git-lfs less nano dig ping nc tree file; do command -v "$c" || echo "MISSING:$c"; done',
         ],
         { encoding: "utf8" },
       );
       expect(r.status, `stderr=${r.stderr}`).toBe(0);
       expect(r.stdout).not.toMatch(/^MISSING:/m);
+    });
+
+    it("base image registers git-lfs smudge/clean filters system-wide", () => {
+      // `git lfs install --system` in Dockerfile.base must have written the
+      // filter.lfs.* config to /etc/gitconfig so an agent cloning an
+      // LFS-tracked repo materialises real binaries, not pointer stubs —
+      // even with a fresh per-agent HOME and no repo-local `git lfs install`.
+      const r = spawnSync(
+        "docker",
+        [
+          "run", "--rm", ...LABELS_ARGV, "--entrypoint", "sh", IMAGES.base, "-c",
+          "git config --system --get filter.lfs.smudge",
+        ],
+        { encoding: "utf8" },
+      );
+      expect(r.status, `stderr=${r.stderr}`).toBe(0);
+      expect(r.stdout).toMatch(/git-lfs smudge/);
     });
 
     it("agent image with cap_drop=ALL blocks mount (mount -t tmpfs → EPERM)", () => {


### PR DESCRIPTION
## Summary
- Install `git-lfs` in the base image's Tier-1 apt block (next to `git`).
- Run `git lfs install --system --skip-repo` so the smudge/clean filters are registered image-wide (`/etc/gitconfig`), independent of each agent's per-agent HOME.
- Extend `tests/docker/e2e.test.ts`: pin `git-lfs` on PATH + assert the system-level `filter.lfs.smudge` config is present.

## Why
Agents that clone an LFS-tracked repo (e.g. a social-content backup with photos/videos stored via git-lfs) previously got ~130-byte pointer stubs instead of the real binaries — the base image shipped no `git-lfs`, so `clone`/`pull` never smudged. This made large media assets unusable to agents even after a successful clone. Concrete case: the `panorama-socials` content library (2,418 images + 256 videos tracked via LFS) for the marko agent.

`git lfs install --system` writes the filters to `/etc/gitconfig` so they apply even with a fresh per-agent HOME and no repo-local `git lfs install`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Verified on the pinned `node:22-trixie-slim` base: `git-lfs/3.6.1` installs, `git lfs install --system` writes `filter.lfs.smudge = git-lfs smudge -- %f`
- [ ] CI `build-base` + `build-dependents` green (rebuilds base with the new layer)
- [ ] e2e Tier-1 + filter assertions pass

## Risk
Low. Additive package + one global config write. Adds a small layer to the base image; no behaviour change for agents that don't use LFS. JTBD: a standing specialist (marko) that can actually use its content library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)