### PR TITLE
chore: release v0.14.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.14.23 — git-lfs in the base agent image
+
+### PR — add git-lfs to the base agent image (#2030)
+
+Agent containers shipped without a `git-lfs` binary, so any repo an agent
+clones that tracks large assets via LFS (images, video, SQLite DBs) would
+materialise those files as 130-byte pointer stubs rather than the real
+content — and a naive `git add`/commit would push the raw pointer or, with
+the smudge filter unconfigured, the raw binary. Agents working with a media
+or content library (e.g. a marketing agent reusing historical social posts,
+photos, and video) had no usable path to the actual bytes.
+
+`docker/Dockerfile.base` now installs `git-lfs` and runs
+`git lfs install --system --skip-repo`, registering the LFS smudge/clean
+filters in `/etc/gitconfig` so they apply to every per-agent `HOME` (a
+`--global` install wouldn't persist, since each agent boots a fresh home).
+`tests/docker/e2e.test.ts` gains `git-lfs` to the Tier-1 binary-presence
+loop and a new assertion that the system-wide smudge filter resolves to
+`git-lfs smudge`.
+
+This is a base-image change: it reaches the fleet on the next image build +
+rollout. No CLI/runtime behaviour changes.
+
 ## v0.14.22 — Foreground sub-agent visibility + self-resuming interrupted turns
 
 Two visibility/reliability features land on top of the v0.14.21 worker

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.22",
+  "version": "0.14.23",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Release v0.14.23 — ships git-lfs in the base agent image (#2030).

## Why
Agent containers had no `git-lfs` binary, so LFS-tracked assets (images,
video, SQLite content DBs) materialised as 130-byte pointer stubs. Agents
working with a media/content library had no usable path to the real bytes,
and a naive commit risked pushing the raw pointer/binary. The base image now
installs git-lfs and runs `git lfs install --system --skip-repo` so the
smudge/clean filters apply across every per-agent `HOME`.

## What's in it
- #2030 — git-lfs added to `docker/Dockerfile.base` + e2e binary-presence
  and system-filter assertions in `tests/docker/e2e.test.ts`.

## Test plan
- [x] `node scripts/build.mjs` clean, `dist/cli/switchroom.js` present (~3.0MB)
- [ ] CI green (10 required checks)
- [ ] Tag → docker-images build → all 5 images pull-able under v0.14.23
- [ ] Staggered fleet rollout with `--version` assertion

## Risk
Low. Base-image-only change; no CLI/runtime behaviour change. Reaches the
fleet on the next image build + rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)