### PR TITLE
fix(telegram): age-bound boot-promotion to stop stale dead-worker handback replay

### DIFF
--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -209,6 +209,23 @@ export interface SubagentWatcherConfig {
    */
   silentStallTerminalMs?: number
   /**
+   * Freshness window (ms) for promoting a running-at-boot worker file to
+   * live. A file whose last write (mtime) is older than this is treated as
+   * a dead prior-session worker and stays historical/suppressed, NOT
+   * promoted. Default 15 min (DEFAULT_INFLIGHT_PROMOTE_MAX_AGE_MS); env
+   * override `SWITCHROOM_SUBAGENT_INFLIGHT_MAX_AGE_MS`. Guards the v0.14.23
+   * stale-handback replay regression.
+   */
+  inflightPromoteMaxAgeMs?: number
+  /**
+   * Kill-switch for the boot-scan promotion path. When false, a
+   * running-at-boot worker is never promoted — the watcher reverts to the
+   * pre-v0.14.23 behaviour of leaving every boot-scan file historical
+   * (suppressed). Default true; env `SWITCHROOM_SUBAGENT_BOOT_PROMOTE=0`
+   * disables it fleet-wide without a code change (emergency lever).
+   */
+  bootPromoteEnabled?: boolean
+  /**
    * Reaper TTL (ms): background rows in `status='running'` whose
    * `last_activity_at` (or `started_at` if liveness never wrote) is older
    * than this are transitioned to `status='stalled'` with a result_summary
@@ -381,6 +398,29 @@ const DEFAULT_SILENT_SYNTHESIS_STALL_THRESHOLD_MS = 300_000
  * ceiling that closed-out cards used to wait on.
  */
 const DEFAULT_SILENT_STALL_TERMINAL_MS = 300_000
+
+/**
+ * Freshness window for the boot-scan "in-flight at boot → promote to
+ * live" path. A worker file still in `running` state at boot is only
+ * promoted (un-suppressed) if its last write (file mtime) is within this
+ * window of now. The signal cleanly separates the two populations:
+ *
+ *  - A worker genuinely in-flight across a restart / fleet rollout was
+ *    writing right up until the container was recreated, so its mtime is
+ *    seconds-to-minutes before the new gateway boots — well inside the
+ *    window. The user is still awaiting it; promote it.
+ *  - A worker that died in a PRIOR session without writing a terminal
+ *    `turn_end` is also `running` in the file, but its mtime is hours-to-
+ *    weeks old. These accumulate by the dozen-to-hundred in a long-lived
+ *    agent's subagents dir. Promoting them replays stale handbacks
+ *    (often `failed`, from old error lines) on every boot — the v0.14.23
+ *    regression. Leave them historical/suppressed, exactly as before.
+ *
+ * 15 min is generous for any plausible restart gap (container recreate +
+ * image pull) yet far below the staleness of a dead prior-session file.
+ * Override with `SWITCHROOM_SUBAGENT_INFLIGHT_MAX_AGE_MS`.
+ */
+const DEFAULT_INFLIGHT_PROMOTE_MAX_AGE_MS = 15 * 60_000
 
 /**
  * Cap on the result text retained per sub-agent (`entry.lastResultText`)
@@ -810,6 +850,14 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     config.silentStallTerminalMs
     ?? parseEnvMs('SWITCHROOM_SUBAGENT_STALL_TERMINAL_MS')
     ?? DEFAULT_SILENT_STALL_TERMINAL_MS
+  const inflightPromoteMaxAgeMs =
+    config.inflightPromoteMaxAgeMs
+    ?? parseEnvMs('SWITCHROOM_SUBAGENT_INFLIGHT_MAX_AGE_MS')
+    ?? DEFAULT_INFLIGHT_PROMOTE_MAX_AGE_MS
+  // Kill-switch: not parseEnvMs (which rejects `0`) — an explicit `=0`
+  // here MUST disable promotion (revert to pre-v0.14.23 suppression).
+  const bootPromoteEnabled =
+    config.bootPromoteEnabled ?? (process.env.SWITCHROOM_SUBAGENT_BOOT_PROMOTE !== '0')
   const reaperTtlMs = config.reaperTtlMs ?? DEFAULT_REAPER_TTL_MS
   const reaperIntervalMs = config.reaperIntervalMs ?? DEFAULT_REAPER_INTERVAL_MS
   const rescanMs = config.rescanMs ?? DEFAULT_RESCAN_MS
@@ -961,18 +1009,40 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
     // already `done` at boot stays historical and is short-circuited just
     // below — it finished before this session.)
     if (isHistorical && entry.state === 'running') {
-      entry.historical = false
-      log?.(`subagent-watcher: ${agentId} was in-flight at boot — promoting to live (predates watcher; user still awaiting handback)`)
-      // The prior gateway life's registration normally linked
-      // jsonl_agent_id already, but re-run the backfill idempotently in
-      // case that life crashed before the link persisted — the handback's
-      // isBackground lookup is keyed on jsonl_agent_id, and an unlinked row
-      // would mis-resolve the worker as foreground and drop the handback.
-      if (db != null) {
-        try {
-          backfillJsonlAgentId(db, filePath, agentId, log)
-        } catch (err) {
-          log?.(`subagent-watcher: backfill error for ${agentId}: ${(err as Error).message}`)
+      // Freshness gate (v0.14.24): only promote a file whose LAST WRITE is
+      // recent. A genuinely in-flight-across-a-restart worker was writing
+      // until the container was recreated (mtime seconds-to-minutes old); a
+      // dead prior-session worker that never wrote a terminal turn_end is
+      // also `running` but hours-to-weeks stale. Promoting the latter
+      // replayed stale `failed` handbacks on every boot (the v0.14.23
+      // fleet-wide regression). Unreadable mtime → treat as stale (suppress
+      // rather than risk re-spamming). The kill-switch reverts to pre-fix
+      // suppression entirely.
+      let fileAgeMs = Infinity
+      try {
+        const st = fs.statSync(filePath)
+        if (typeof st.mtimeMs === 'number') fileAgeMs = n - st.mtimeMs
+      } catch {
+        /* unreadable → Infinity → treated as stale below */
+      }
+      if (!bootPromoteEnabled) {
+        log?.(`subagent-watcher: ${agentId} running at boot but promotion disabled (SWITCHROOM_SUBAGENT_BOOT_PROMOTE=0) — leaving historical`)
+      } else if (fileAgeMs > inflightPromoteMaxAgeMs) {
+        log?.(`subagent-watcher: ${agentId} running at boot but stale (last write ${Math.round(fileAgeMs / 1000)}s ago > ${Math.round(inflightPromoteMaxAgeMs / 1000)}s) — leaving historical (dead prior-session worker, not in-flight)`)
+      } else {
+        entry.historical = false
+        log?.(`subagent-watcher: ${agentId} was in-flight at boot — promoting to live (last write ${Math.round(fileAgeMs / 1000)}s ago; user still awaiting handback)`)
+        // The prior gateway life's registration normally linked
+        // jsonl_agent_id already, but re-run the backfill idempotently in
+        // case that life crashed before the link persisted — the handback's
+        // isBackground lookup is keyed on jsonl_agent_id, and an unlinked row
+        // would mis-resolve the worker as foreground and drop the handback.
+        if (db != null) {
+          try {
+            backfillJsonlAgentId(db, filePath, agentId, log)
+          } catch (err) {
+            log?.(`subagent-watcher: backfill error for ${agentId}: ${(err as Error).message}`)
+          }
         }
       }
     }

--- a/telegram-plugin/tests/subagent-watcher-handback-gaps.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-handback-gaps.test.ts
@@ -80,6 +80,14 @@ function makeHarness(opts: {
   stallThresholdMs?: number
   silentStallTerminalMs?: number
   rescanMs?: number
+  /** How long ago (ms) the boot file was last written, i.e. its mtime is
+   *  `currentTime - bootFileAgeMs` at registration. Default 0 (fresh, so the
+   *  freshness gate promotes it). Set large to simulate a dead prior-session
+   *  worker that must NOT be promoted. */
+  bootFileAgeMs?: number
+  /** Kill-switch passthrough; default true (promotion enabled). */
+  bootPromoteEnabled?: boolean
+  inflightPromoteMaxAgeMs?: number
 }): Harness {
   const {
     agentId = 'gap-agent',
@@ -87,6 +95,9 @@ function makeHarness(opts: {
     stallThresholdMs = 60_000,
     silentStallTerminalMs = 300_000,
     rescanMs = 500,
+    bootFileAgeMs = 0,
+    bootPromoteEnabled = true,
+    inflightPromoteMaxAgeMs,
   } = opts
 
   let currentTime = 1000
@@ -104,6 +115,10 @@ function makeHarness(opts: {
 
   const fileContents = new Map<string, Buffer>()
   fileContents.set(jsonlPath, Buffer.from(buildJSONL(...bootLines), 'utf-8'))
+  // Per-file mtime (ms). The boot file's last write is `bootFileAgeMs` in the
+  // past; appends bump it to currentTime. The freshness gate reads this.
+  const fileMtimes = new Map<string, number>()
+  fileMtimes.set(jsonlPath, 1000 - bootFileAgeMs)
 
   let lastOpenedPath: string | null = null
   const mockFs = {
@@ -121,7 +136,7 @@ function makeHarness(opts: {
       if (ps === subagentsDir) return [`agent-${agentId}.jsonl`]
       return []
     }) as unknown as typeof fs.readdirSync,
-    statSync: ((p: fs.PathLike) => ({ size: fileContents.get(String(p))?.length ?? 0 }) as fs.Stats) as typeof fs.statSync,
+    statSync: ((p: fs.PathLike) => ({ size: fileContents.get(String(p))?.length ?? 0, mtimeMs: fileMtimes.get(String(p)) ?? currentTime }) as fs.Stats) as typeof fs.statSync,
     openSync: ((p: fs.PathLike) => {
       lastOpenedPath = String(p)
       return 42
@@ -153,6 +168,8 @@ function makeHarness(opts: {
     silentSynthesisStallThresholdMs: stallThresholdMs,
     silentStallTerminalMs,
     rescanMs,
+    bootPromoteEnabled,
+    ...(inflightPromoteMaxAgeMs != null ? { inflightPromoteMaxAgeMs } : {}),
     onStallTerminal: (id) => stallTerminalCalls.push({ agentId: id }),
     onFinish: ({ agentId: id, outcome, resultText }) =>
       finishCalls.push({ agentId: id, outcome, resultText }),
@@ -186,6 +203,7 @@ function makeHarness(opts: {
     const cur = fileContents.get(jsonlPath) ?? Buffer.alloc(0)
     const more = buildJSONL(...lines)
     fileContents.set(jsonlPath, Buffer.concat([cur, Buffer.from(more, 'utf-8')]))
+    fileMtimes.set(jsonlPath, currentTime)
   }
 
   return { stallTerminalCalls, finishCalls, logs, advance, watcher, fileContents, jsonlPath, append }
@@ -242,6 +260,75 @@ describe('Gap 1 — background worker in-flight across a gateway restart', () =>
     h.advance(600_000) // well past any stall window
     expect(h.finishCalls).toHaveLength(0)
     expect(h.stallTerminalCalls).toHaveLength(0)
+  })
+})
+
+describe('Gap 1 freshness gate — v0.14.24 stale-replay regression', () => {
+  // The v0.14.23 regression: promoting EVERY running-at-boot file replayed
+  // weeks-old dead prior-session workers as handbacks (often `failed`, from
+  // old error lines) on every boot, spamming the whole fleet. The gate
+  // promotes only files whose last write is recent.
+
+  it('a STALE running-at-boot worker (weeks-old mtime) is NOT promoted — no handback, no stall', () => {
+    const h = makeHarness({
+      agentId: 'gap1-stale-running',
+      bootLines: [subAgentUserMsg('bg task from weeks ago')], // running: no turn_end
+      bootFileAgeMs: 21 * 24 * 60 * 60_000, // 21 days old — clearly dead
+      silentStallTerminalMs: 120_000,
+    })
+
+    h.advance(600)
+    h.advance(600_000) // far past every stall/synthesis window
+    expect(h.finishCalls).toHaveLength(0) // pre-fix: a spurious (often failed) handback
+    expect(h.stallTerminalCalls).toHaveLength(0)
+    expect(h.logs.some((l) => l.includes('stale') && l.includes('leaving historical'))).toBe(true)
+  })
+
+  it('a FRESH running-at-boot worker (recent mtime) IS still promoted and hands back', () => {
+    // Preserve the genuine Gap 1 fix: a worker in-flight across a restart
+    // (wrote moments before the bounce) must still get promoted + handed back.
+    const h = makeHarness({
+      agentId: 'gap1-fresh-running',
+      bootLines: [subAgentUserMsg('bg task')],
+      bootFileAgeMs: 30_000, // 30s old — in-flight across a quick restart
+    })
+
+    h.append(subAgentText('Finished the migration'), subAgentTurnEnd())
+    h.advance(600)
+
+    expect(h.finishCalls).toHaveLength(1)
+    expect(h.finishCalls[0].outcome).toBe('completed')
+    expect(h.logs.some((l) => l.includes('promoting to live'))).toBe(true)
+  })
+
+  it('kill-switch (bootPromoteEnabled=false) suppresses even a fresh running-at-boot worker', () => {
+    const h = makeHarness({
+      agentId: 'gap1-killswitch',
+      bootLines: [subAgentUserMsg('bg task')],
+      bootFileAgeMs: 5_000, // fresh — would normally promote
+      bootPromoteEnabled: false,
+      silentStallTerminalMs: 120_000,
+    })
+
+    h.advance(600)
+    h.advance(600_000)
+    expect(h.finishCalls).toHaveLength(0)
+    expect(h.logs.some((l) => l.includes('promotion disabled'))).toBe(true)
+  })
+
+  it('a worker just past the freshness window is NOT promoted (boundary)', () => {
+    const h = makeHarness({
+      agentId: 'gap1-boundary',
+      bootLines: [subAgentUserMsg('bg task')],
+      inflightPromoteMaxAgeMs: 60_000, // 60s window
+      bootFileAgeMs: 90_000, // 90s old → just stale
+      silentStallTerminalMs: 120_000,
+    })
+
+    h.advance(600)
+    h.advance(600_000)
+    expect(h.finishCalls).toHaveLength(0)
+    expect(h.logs.some((l) => l.includes('stale'))).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

Hotfix for a fleet-wide regression introduced by #2029 (v0.14.23). That PR promoted **every** worker file still in `running` state at boot to "live" so a worker in-flight across a restart would hand back instead of dropping as `orphan`. The flaw: a worker that died in a **prior session** without writing a terminal `turn_end` is *also* `running` in its file — and those stale files accumulate by the dozen-to-hundred in a long-lived agent's `subagents/` dir. On the v0.14.23 rollout, every agent's boot scan promoted all of them and replayed weeks-old handbacks — many `failed`, from old error lines in the transcripts — spamming the whole fleet.

**Observed in prod:** clerk promoted **218** files at a single boot instant (22:25:22), with file mtimes **3–4 weeks old** (April 28 / May 5). finn 184, reggie 54, etc.

## Fix

Gate the promotion on **file freshness**:
- Promote a running-at-boot file only if its last write (mtime) is within `DEFAULT_INFLIGHT_PROMOTE_MAX_AGE_MS` (15 min; env `SWITCHROOM_SUBAGENT_INFLIGHT_MAX_AGE_MS`).
- A genuinely in-flight worker wrote seconds-to-minutes before the bounce → still promoted, Gap 1 preserved.
- A dead prior-session file is hours-to-weeks stale → stays `historical`/suppressed, exactly the pre-v0.14.23 behaviour.
- Unreadable mtime → treated as stale (suppress rather than risk re-spamming).

Plus the **kill-switch #2029 should have had**: `SWITCHROOM_SUBAGENT_BOOT_PROMOTE=0` disables promotion entirely (full revert to pre-fix suppression) with no code change.

## Why

The `historical` flag existed precisely to suppress replay of prior-session workers; #2029 broke that for the running-at-boot subset without bounding it. The mtime cleanly separates the two populations (restart-gap seconds-to-minutes vs. dead-weeks). Serves vision outcome 2 (awareness + control) without the spam.

## Test plan

- [x] 4 new tests: 21-day-old running-at-boot **not** promoted (no handback, no stall); 30s-old running-at-boot **still** promoted + handed back; kill-switch suppresses even a fresh file; boundary just past the window is stale. Harness extended to drive file mtime.
- [x] Existing 6 Gap-1/Gap-2 tests still green.
- [x] Full telegram-plugin suite green under **both** vitest (3128) and bun (3745); `tsc --noEmit` clean.

## Risk

Low and de-risking. Narrows an over-broad behaviour back toward the long-standing suppression default; the only files that change handling are stale dead ones (now correctly suppressed) — fresh in-flight workers behave as in #2029. Adds an emergency kill-switch.

## Rollout

Ships as v0.14.24. The fixed boot scan suppresses the stale files, so the rollout itself is clean (no replay). Follows #2029 (already merged/rolled).