### PR TITLE
fix(telegram): surface foreground sub-agent activity after ack-first reply

### DIFF
--- a/telegram-plugin/gateway/foreground-nesting.ts
+++ b/telegram-plugin/gateway/foreground-nesting.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure state-transition helpers for Model A foreground sub-agent activity
+ * nesting (#2027). Extracted from gateway.ts so the `replyCalled` gate is
+ * unit-testable on its own — the exact seam #2027 shipped without, which let
+ * the feature silently no-op for every ack-first turn (reply "On it…" then
+ * delegate) and go unnoticed in production. See
+ * `tests/foreground-nesting.test.ts`.
+ *
+ * Subscription-honest: every caller is pure jsonl-tail → render, no model
+ * call. These functions decide *whether/what* to render; the gateway owns the
+ * `currentTurn` mutation and the Telegram edit.
+ */
+
+export interface ForegroundProgressGate {
+  /** `SWITCHROOM_FOREGROUND_SUBAGENT_NESTING !== '0'` — the kill-switch. */
+  nestingEnabled: boolean
+  /**
+   * Whether the parent turn has already emitted a reply. Accepted as input
+   * but intentionally NOT a gate: a foreground `Task` is a *blocking* call,
+   * so the parent cannot have issued its FINAL answer while the sub-agent is
+   * still running — any `replyCalled === true` observed here is therefore an
+   * *interim* ack. The pre-fix code bailed on this flag, which is precisely
+   * why ack-first turns showed zero live foreground activity.
+   */
+  replyCalled: boolean
+}
+
+/**
+ * Whether a foreground sub-agent progress tick should accumulate its narrative
+ * and re-render the activity feed. Gated ONLY by the kill-switch — never by
+ * `replyCalled` (see the field doc above).
+ */
+export function shouldRenderForegroundProgress(g: ForegroundProgressGate): boolean {
+  return g.nestingEnabled
+}
+
+export type ForegroundFinishAction = 'recompose' | 'handoff-clear' | 'none'
+
+export interface ForegroundFinishInput {
+  /** Was this agentId actually an active foreground sub-agent we tracked? */
+  removed: boolean
+  /** Has the parent turn already emitted a reply (an interim ack)? */
+  replyCalled: boolean
+  /** Foreground sub-agents still active AFTER removing the finished one. */
+  remainingForeground: number
+}
+
+/**
+ * What the gateway should do when a foreground sub-agent finishes:
+ *
+ *  - `'none'`         — it wasn't one we were tracking (e.g. background, or a
+ *                       stale boot row); leave the feed alone.
+ *  - `'handoff-clear'`— it was the LAST foreground sub-agent and the parent
+ *                       has already acked. The re-opened post-ack feed now
+ *                       hands off to the imminent final answer, mirroring the
+ *                       first-reply hand-off. (turn_end is the safety net if
+ *                       this is somehow missed.)
+ *  - `'recompose'`    — collapse the finished sub-agent's block and re-render
+ *                       (pre-ack flow, or other sub-agents still running).
+ */
+export function foregroundFinishAction(i: ForegroundFinishInput): ForegroundFinishAction {
+  if (!i.removed) return 'none'
+  if (i.replyCalled && i.remainingForeground === 0) return 'handoff-clear'
+  return 'recompose'
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -303,6 +303,10 @@ import {
   decideSubagentProgress,
   DEFAULT_PROGRESS_INTERVAL_MS,
 } from './subagent-progress-inbound-builder.js'
+import {
+  shouldRenderForegroundProgress,
+  foregroundFinishAction,
+} from './foreground-nesting.js'
 import { createPollHealthCheck, type PollHealthCheckHandle } from './poll-health.js'
 import type {
   ToolCallMessage,
@@ -17843,16 +17847,26 @@ void (async () => {
                   // tool result, so there's no handback to deliver. Reaction
                   // promotion already ran above.
                   const turn = currentTurn
-                  if (
-                    turn != null &&
-                    turn.foregroundSubAgents.delete(agentId) &&
-                    !turn.replyCalled
-                  ) {
-                    const rendered = composeTurnActivity(turn)
-                    if (rendered != null) {
-                      turn.activityPendingRender = rendered
-                      if (turn.activityInFlight == null) {
-                        turn.activityInFlight = drainActivitySummary(turn)
+                  const removed = turn != null && turn.foregroundSubAgents.delete(agentId)
+                  if (turn != null && removed) {
+                    const action = foregroundFinishAction({
+                      removed,
+                      replyCalled: turn.replyCalled,
+                      remainingForeground: turn.foregroundSubAgents.size,
+                    })
+                    if (action === 'handoff-clear') {
+                      // Post-ack: the last foreground sub-agent finished and
+                      // the parent will now produce its answer inline. Hand
+                      // the re-opened feed off to the answer, mirroring the
+                      // first-reply clear (turn_end is the safety net).
+                      clearActivitySummary(turn)
+                    } else if (action === 'recompose') {
+                      const rendered = composeTurnActivity(turn)
+                      if (rendered != null) {
+                        turn.activityPendingRender = rendered
+                        if (turn.activityInFlight == null) {
+                          turn.activityInFlight = drainActivitySummary(turn)
+                        }
                       }
                     }
                   }
@@ -17972,9 +17986,17 @@ void (async () => {
                   // activity draft rather than a separate worker message. Pure
                   // jsonl-tail → render (no model call), inside the
                   // subscription-honest boundary.
-                  if (!foregroundNestingEnabled) return // kill-switch: skip overhead
                   const turn = currentTurn
-                  if (turn == null || turn.replyCalled) return
+                  if (turn == null) return
+                  // Render regardless of `replyCalled` — a foreground Task
+                  // blocks the parent, so any reply seen while it runs is an
+                  // interim ack, never the final answer. Gating on replyCalled
+                  // (pre-#2032) made ack-first turns show zero live foreground
+                  // activity. Kill-switch lives in the predicate.
+                  if (!shouldRenderForegroundProgress({
+                    nestingEnabled: foregroundNestingEnabled,
+                    replyCalled: turn.replyCalled,
+                  })) return
                   const child = latestSummary.trim().slice(0, 120)
                   if (child.length === 0) return
                   let narrative = turn.foregroundSubAgents.get(agentId)

--- a/telegram-plugin/tests/foreground-nesting.test.ts
+++ b/telegram-plugin/tests/foreground-nesting.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression guard for the Model A foreground sub-agent nesting gate (#2032).
+ *
+ * #2027 shipped foreground nesting but gated every render path on
+ * `turn.replyCalled`. Because the framework's ack-first pattern replies
+ * "On it…" FIRST and then delegates, `replyCalled` was already true before any
+ * foreground sub-agent ran — so the feature silently produced ZERO live
+ * foreground activity for the exact case it was built for, and that went
+ * unnoticed because #2027 only tested the pure renderer, never the gate.
+ *
+ * These tests pin the gate decisions directly so the replyCalled-independence
+ * can never regress silently again.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  shouldRenderForegroundProgress,
+  foregroundFinishAction,
+} from '../gateway/foreground-nesting.js'
+import { renderActivityFeedWithNested } from '../tool-activity-summary.js'
+
+describe('shouldRenderForegroundProgress', () => {
+  it('renders even after the parent has acked (the #2027 blindspot)', () => {
+    // THE regression guard: ack-first sets replyCalled=true before the
+    // foreground sub-agent runs. It MUST still render.
+    expect(
+      shouldRenderForegroundProgress({ nestingEnabled: true, replyCalled: true }),
+    ).toBe(true)
+  })
+
+  it('renders before any reply (pre-ack flow, unchanged)', () => {
+    expect(
+      shouldRenderForegroundProgress({ nestingEnabled: true, replyCalled: false }),
+    ).toBe(true)
+  })
+
+  it('is independent of replyCalled — the flag never flips the outcome', () => {
+    const on = shouldRenderForegroundProgress({ nestingEnabled: true, replyCalled: true })
+    const off = shouldRenderForegroundProgress({ nestingEnabled: true, replyCalled: false })
+    expect(on).toBe(off)
+  })
+
+  it('honours the kill-switch regardless of replyCalled', () => {
+    expect(
+      shouldRenderForegroundProgress({ nestingEnabled: false, replyCalled: false }),
+    ).toBe(false)
+    expect(
+      shouldRenderForegroundProgress({ nestingEnabled: false, replyCalled: true }),
+    ).toBe(false)
+  })
+})
+
+describe('foregroundFinishAction', () => {
+  it('hands off to the answer when the last sub-agent finishes post-ack', () => {
+    expect(
+      foregroundFinishAction({ removed: true, replyCalled: true, remainingForeground: 0 }),
+    ).toBe('handoff-clear')
+  })
+
+  it('recomposes when other foreground sub-agents are still running post-ack', () => {
+    expect(
+      foregroundFinishAction({ removed: true, replyCalled: true, remainingForeground: 1 }),
+    ).toBe('recompose')
+  })
+
+  it('recomposes pre-ack (original behaviour preserved)', () => {
+    expect(
+      foregroundFinishAction({ removed: true, replyCalled: false, remainingForeground: 0 }),
+    ).toBe('recompose')
+  })
+
+  it('does nothing for an agent it was not tracking', () => {
+    expect(
+      foregroundFinishAction({ removed: false, replyCalled: true, remainingForeground: 0 }),
+    ).toBe('none')
+  })
+})
+
+describe('end-to-end render shape under ack-first', () => {
+  it('produces a live nested block from a post-ack foreground narrative', () => {
+    // marko's real scenario: parent acked with no prior steps (empty mirror),
+    // then a foreground researcher emits progress. The gate now ALLOWS this
+    // render; prove the render is a real, non-empty nested feed with a live
+    // bold "→ current" line — i.e. the user would actually see activity.
+    const html = renderActivityFeedWithNested(
+      [],
+      [
+        'searching Unsplash CC0 desk',
+        'checking license on 4 candidates',
+        'ranking by resolution',
+      ],
+    )
+    expect(html).not.toBeNull()
+    // newest child is the live, bold current step
+    expect(html).toContain('<b>→ ranking by resolution</b>')
+    // an earlier child is present as a done/italic step
+    expect(html).toContain('checking license on 4 candidates')
+  })
+})


### PR DESCRIPTION
## Summary

Foreground sub-agent live nesting (#2027, Model A) never actually showed
anything in practice. Every render path bailed on `turn.replyCalled`, but the
framework's ack-first pattern replies **"On it…" first, then delegates** — so
`replyCalled` is already `true` before any foreground sub-agent runs. The
feature silently produced **zero live foreground activity** for the exact case
it was built for.

This was the root cause behind "marko's researcher sub-agent showed no Telegram
activity": ack at 23:14:08 → `replyCalled=true` → researcher ran 23:14–23:16
with every nesting tick returning early → user saw ack, then silence, then the
final answer.

## Why it went unnoticed

#2027 added tests for the pure renderer (`renderActivityFeedWithNested`) but
**none for the gate**. The boolean that broke it was never exercised with
`replyCalled=true`. This PR closes that seam.

## What changed

- **`telegram-plugin/gateway/foreground-nesting.ts`** (new, pure): two
  decision helpers extracted so the gate is unit-testable —
  `shouldRenderForegroundProgress` (kill-switch only; `replyCalled` accepted
  but intentionally **not** a gate) and `foregroundFinishAction`
  (`recompose` / `handoff-clear` / `none`).
- **gateway.ts onProgress**: render foreground progress regardless of
  `replyCalled`. A foreground `Task` blocks the parent, so any reply observed
  while it runs is an *interim* ack, never the final answer — the invariant
  that makes this safe.
- **gateway.ts onFinish**: when the **last** foreground sub-agent finishes
  post-ack, hand the re-opened feed off to the imminent answer
  (`clearActivitySummary`), mirroring the first-reply hand-off. Pre-ack
  behaviour (`recompose`) unchanged.
- **`tests/foreground-nesting.test.ts`** (new): pins replyCalled-independence,
  the finish state machine, and an end-to-end render-shape assertion for
  marko's scenario.

## Safety / scope

- Kill-switch unchanged: `SWITCHROOM_FOREGROUND_SUBAGENT_NESTING=0` disables
  the whole path (now folded into the predicate).
- turn_end (`gateway.ts:7884`) unconditionally clears the feed, so a re-opened
  post-ack feed is always cleaned up even if the sub-agent stalls/never fires
  `onFinish`.
- `tool_label` (parent's own steps) hand-off at first reply is **left as-is** —
  only the foreground sub-agent narrative re-opens the lane, keeping blast
  radius minimal and avoiding the flicker-below-final-answer the existing guard
  prevents.
- Subscription-honest: pure jsonl-tail → render, no model call.

## Test plan

- [x] `vitest run` new + sibling `tool-activity-summary` tests (30 pass)
- [x] `bun test` new test (9 pass — runs under both runners)
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean
- [x] `check-plugin-references.mjs` clean

JTBD-2 ("you hold the leash"): closes the named foreground visibility blindspot.