### PR TITLE
chore: release v0.14.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## v0.14.25 — Surface foreground sub-agent activity after the ack
+
+### PR — surface foreground sub-agent activity after the ack-first reply (#2034)
+
+Fixes the foreground sub-agent visibility blindspot: a FOREGROUND
+sub-agent (`Agent`/`Task` *without* `run_in_background`) runs inline in
+the parent turn and its live steps were meant to nest into the parent's
+activity-summary feed (the #2027 "Model A" nesting). But every render
+path bailed on `turn.replyCalled`, and the framework's ack-first pattern
+replies "On it…" **first** and then delegates — so the sub-agent always
+ran with `replyCalled` already true and **nothing ever painted**. #2027
+only tested the pure renderer, so the regression shipped silently (the
+"marko's researcher showed no Telegram activity" report).
+
+The render gate no longer depends on `replyCalled`. The decision is
+extracted into a pure, tested seam (`gateway/foreground-nesting.ts`):
+`shouldRenderForegroundProgress` keys only on the kill-switch
+(`SWITCHROOM_FOREGROUND_SUBAGENT_NESTING`, default on), and
+`foregroundFinishAction` drives the post-ack hand-off (clear the feed
+when the last foreground sub-agent finishes, recompose while others run).
+Because a foreground `Task` blocks the parent, any `replyCalled` seen
+while it runs is necessarily an interim ack, never the final answer — so
+surfacing the nested narrative post-ack is always correct.
+
+Classification is task-agnostic: foreground vs. background keys solely on
+`run_in_background` in the PreToolUse tracker hook, never on
+`subagent_type`. A generic sub-agent narrates the same as a researcher.
+
+### PR — UAT for foreground sub-agent activity nesting (#2035)
+
+Adds the mtcute UAT (`jtbd-foreground-subagent-activity-dm.test.ts`) that
+exercises the fix end-to-end: forces the ack-first shape, dispatches a
+FOREGROUND general-purpose sub-agent that narrates eight paced steps, and
+asserts the activity-summary feed message carrying the nested marker
+("↳") surfaces **after** the ack and advances in place. Plus a unit
+regression guard (`foreground-nesting.test.ts`) pinning the
+`replyCalled`-independence directly, so the blindspot can't return
+silently.
+
 ## v0.14.24 — Age-bound the boot-promotion (stale-handback hotfix)
 
 ### PR — age-bound the boot-promotion so stale dead workers don't replay (#2032)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.24",
+  "version": "0.14.25",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release v0.14.25 — surfaces foreground sub-agent activity after the ack-first reply.

Constituent PRs (both already merged to main, both reviewed):
- **#2034** — fix: render foreground sub-agent nesting regardless of `turn.replyCalled` (the #2027 blindspot — foreground steps silently never painted once the parent had acked "On it…").
- **#2035** — test: mtcute UAT + unit regression guard pinning the `replyCalled`-independence.

## Why

The foreground sub-agent visibility blindspot ("marko's researcher showed no Telegram activity") shipped silently because #2027 only tested the pure renderer, never the ack-first gate. This release ships the fix + a two-layer guard (gating unit test on every PR; operator-host UAT).

## Test plan

- [x] Both constituent PRs merged green; reviewer APPROVE on each.
- [x] mtcute UAT passed live against a hot-patched test-harness (nested `↳` feed painted post-ack, advanced in place).
- [x] `node scripts/build.mjs` exit 0; `dist/cli/switchroom.js` present (~3MB).
- [ ] CI green → auto-merge.

## Risk

Low — fix is behind a kill-switch (`SWITCHROOM_FOREGROUND_SUBAGENT_NESTING`, default on); release diff is version bump + CHANGELOG only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)