### PR TITLE
fix: clear agent composer before inbound delivery (idle-session wedge)

### DIFF
--- a/src/agents/tmux.ts
+++ b/src/agents/tmux.ts
@@ -182,6 +182,62 @@ export function sendAgentInterrupt(opts: SendInterruptOptions): SendInterruptRes
   return { error: lastError ?? "tmux send-keys C-c failed" };
 }
 
+export interface ClearComposerOptions {
+  agentName: string;
+}
+
+export type ClearComposerResult = { ok: true } | { error: string };
+
+/**
+ * Wipe any stranded typed-ahead / ghost text out of the agent's claude TUI
+ * composer via `tmux send-keys`, BEFORE an inbound channel notification is
+ * delivered.
+ *
+ * ## Why this exists (the marko wedge)
+ *
+ * Inbound Telegram messages reach the agent's claude session as an MCP
+ * `notifications/claude/channel` notification (NOT via send-keys). The
+ * unmodified CLI appends that text into its input composer and auto-submits
+ * ONLY when the composer is empty and idle. The #1556 inbound-delivery-gate
+ * defers delivery until `turnInFlight === false`, but it ASSUMES idle ⇒
+ * empty composer. That assumption breaks when stale typed-ahead text is
+ * stranded in the composer and was never submitted (observed live on agent
+ * `marko`: the literal text "Yes, go ahead on both" sat in the composer).
+ * The appended inbound then fails to submit cleanly and the session silently
+ * swallows every subsequent queued inbound until a hard container restart.
+ *
+ * Nothing else clears the composer, so we do it here: `C-u` (kill from
+ * cursor to line start) plus belt-and-suspenders `C-a` (move to start) and
+ * `C-k` (kill to line end) wipe the whole line regardless of cursor
+ * position. On an already-empty composer (the happy path) these are no-ops.
+ *
+ * ## Soft-fail contract
+ *
+ * Returns `{ error }` on any tmux failure (no session — e.g. an agent under
+ * `experimental.legacy_pty=true` has no tmux session, socket missing,
+ * timeout, exec error). Never throws. Callers MUST proceed with delivery
+ * regardless — a clear failure must never block an inbound.
+ */
+export function clearAgentComposer(opts: ClearComposerOptions): ClearComposerResult {
+  const { agentName } = opts;
+  const socket = `switchroom-${agentName}`;
+  // C-u: kill to line start. C-a C-k: move to start, kill to line end.
+  // Together they wipe the composer line regardless of cursor position.
+  const args = ["-L", socket, "send-keys", "-t", agentName, "C-u", "C-a", "C-k"];
+
+  try {
+    execFileSync("tmux", args, {
+      timeout: 3000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { ok: true };
+  } catch (err) {
+    const msg = `tmux send-keys composer-clear failed: ${(err as Error).message}`;
+    console.error(`[tmux-composer-clear] ${agentName}: ${msg}`);
+    return { error: msg };
+  }
+}
+
 function sleepSync(ms: number): void {
   // Atomics.wait on a fresh SharedArrayBuffer is a portable synchronous
   // sleep — keeps the helper self-contained and testable without forcing

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -10085,6 +10085,33 @@ async function handleInbound(
     return
   }
 
+  // Pre-send composer clear (the marko wedge). The inbound is about to be
+  // delivered as an MCP `notifications/claude/channel` notification, which
+  // the unmodified CLI appends into its composer and auto-submits ONLY when
+  // the composer is empty + idle. The #1556 gate above guarantees idle, but
+  // NOT empty: stale typed-ahead / ghost text stranded in the composer
+  // (observed live on agent `marko`: "Yes, go ahead on both") makes the
+  // appended inbound fail to submit and silently swallows every subsequent
+  // queued inbound until a hard restart. Wipe the composer first so the
+  // notification lands at a clean line. Soft-fail by contract — a clear
+  // failure (no tmux session under legacy_pty, socket missing, timeout)
+  // must NEVER block delivery; log and proceed.
+  if (selfAgent) {
+    try {
+      const { clearAgentComposer } = await import('../../src/agents/tmux.js')
+      const cleared = clearAgentComposer({ agentName: selfAgent })
+      if ('error' in cleared) {
+        process.stderr.write(
+          `telegram gateway: pre-send composer-clear soft-failed agent=${selfAgent}: ${cleared.error} — delivering anyway\n`,
+        )
+      }
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: pre-send composer-clear threw agent=${selfAgent}: ${(err as Error).message} — delivering anyway\n`,
+      )
+    }
+  }
+
   const delivered = ipcServer.sendToAgent(selfAgent, inboundMsg)
   if (delivered) markClaudeBusyForInbound(inboundMsg)
   if (!delivered) {

--- a/tests/tmux-send-interrupt.test.ts
+++ b/tests/tmux-send-interrupt.test.ts
@@ -7,7 +7,7 @@ vi.mock("node:child_process", () => {
 });
 
 import { execFileSync } from "node:child_process";
-import { sendAgentInterrupt } from "../src/agents/tmux.js";
+import { sendAgentInterrupt, clearAgentComposer } from "../src/agents/tmux.js";
 
 const mockedExec = execFileSync as unknown as ReturnType<typeof vi.fn>;
 
@@ -96,5 +96,65 @@ describe("sendAgentInterrupt", () => {
     });
     expect("error" in result).toBe(true);
     expect(mockedExec).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("clearAgentComposer", () => {
+  beforeEach(() => {
+    mockedExec.mockReset();
+  });
+
+  it("returns {ok:true} on happy path", () => {
+    mockedExec.mockReturnValue(Buffer.from(""));
+    const result = clearAgentComposer({ agentName: "klanker" });
+    expect(result).toEqual({ ok: true });
+    expect(mockedExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("issues send-keys C-u C-a C-k against the right pane/socket", () => {
+    mockedExec.mockReturnValue(Buffer.from(""));
+    clearAgentComposer({ agentName: "klanker" });
+    const [bin, args] = mockedExec.mock.calls[0]!;
+    expect(bin).toBe("tmux");
+    expect(args).toEqual([
+      "-L",
+      "switchroom-klanker",
+      "send-keys",
+      "-t",
+      "klanker",
+      "C-u",
+      "C-a",
+      "C-k",
+    ]);
+  });
+
+  it("uses a 3s timeout on the exec call", () => {
+    mockedExec.mockReturnValue(Buffer.from(""));
+    clearAgentComposer({ agentName: "klanker" });
+    const opts = mockedExec.mock.calls[0]![2] as { timeout?: number };
+    expect(opts?.timeout).toBe(3000);
+  });
+
+  it("soft-fails (returns {error}) when there is no tmux session — e.g. legacy_pty — without throwing", () => {
+    // An agent under experimental.legacy_pty=true has no tmux session, so
+    // tmux send-keys errors with "no server running". The helper must
+    // swallow that into {error} so the caller proceeds with delivery.
+    mockedExec.mockImplementation(() => {
+      throw new Error("no server running on /tmp/tmux-1000/switchroom-x");
+    });
+    const result = clearAgentComposer({ agentName: "x" });
+    expect("error" in result).toBe(true);
+    if (!("error" in result)) return;
+    expect(result.error).toMatch(/no server running/);
+  });
+
+  it("returns {error} on timeout-style failure without throwing", () => {
+    mockedExec.mockImplementation(() => {
+      const err = new Error("ETIMEDOUT") as Error & { code?: string };
+      err.code = "ETIMEDOUT";
+      throw err;
+    });
+    const result = clearAgentComposer({ agentName: "x" });
+    expect("error" in result).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Inbound Telegram messages reach the agent's `claude` session as an MCP `notifications/claude/channel` notification (NOT via tmux `send-keys`). The unmodified CLI appends that text into its input composer and auto-submits **only when the composer is empty and idle**.

The existing #1556 inbound-delivery-gate (`gateway/inbound-delivery-gate.ts`, the "lawgpt composer-wedge" fix) defers delivery until `turnInFlight === false` — but it **assumes idle implies an empty composer**. That assumption breaks when stale typed-ahead / ghost text is stranded in the composer and was never submitted.

**Observed live on agent `marko`:** the literal text `"Yes, go ahead on both"` sat stranded in the composer. The appended inbound then failed to submit cleanly and the session silently swallowed every subsequent queued inbound until a hard container restart.

No code anywhere cleared the composer before delivery — that absence was both the bug and the fix.

## Why / outcome

Serves vision outcome **#4 (always available)** — an idle agent must reliably accept the next inbound, not silently wedge until a restart. JTBD: messages land and get actioned without operator babysitting.

## What changed

- **`src/agents/tmux.ts`** — new exported `clearAgentComposer({ agentName })`, modeled on `sendAgentInterrupt`. Issues `tmux send-keys -t <agent> C-u C-a C-k` on socket `switchroom-<agent>` (C-u kills to line start; C-a C-k moves to start and kills to line end — wipes the whole line regardless of cursor position). Soft-fail by contract: returns `{ error }` on any tmux failure (no session under `legacy_pty`, socket missing, timeout, exec error), never throws. 3s timeout.
- **`telegram-plugin/gateway/gateway.ts`** — wired into the deliver path immediately before `ipcServer.sendToAgent`, after the #1556 gate has already guaranteed idle. Dynamic-imports the helper (same pattern as the interrupt-marker `sendAgentInterrupt` callsite). Guarded so a clear failure logs to stderr and proceeds — a clear failure must never block delivery. Only fires when `selfAgent` is set.

An agent under `experimental.legacy_pty=true` has no tmux session, so `clearAgentComposer` returns `{ error }` and delivery proceeds unchanged — matching how `sendAgentInterrupt` routes. On the happy path (already-empty composer) the clear is a no-op.

## Test plan

- [x] `vitest run tests/tmux-send-interrupt.test.ts` — extended with a `clearAgentComposer` suite: asserts the exact `send-keys C-u C-a C-k` argv against the right pane/socket, the 3s timeout, soft-fail on a "no server running" (legacy_pty) error, and soft-fail on timeout-style errors. 12 tests pass.
- [x] `vitest run telegram-plugin/tests/inbound-delivery-gate.test.ts` — 10 tests pass (unchanged behavior).
- [x] `tsc --noEmit` clean for touched files.
- [x] `scripts/check-bot-api-wrapping.sh` clean (no allowlist drift — the edit is above the existing `bot.api.sendMessage` callsite).

## Risk

Low. The clear is additive and soft-fails closed-to-delivery (a failure never blocks an inbound). Happy-path (empty composer) C-u is a no-op, preserving existing behavior. Only the deliver path for tmux-supervised agents is affected; legacy_pty agents are untouched.

Refs: the `marko` stranded-composer incident; builds on #1556 (lawgpt composer-wedge idle-gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)