### PR TITLE
chore: bump bundled claude CLI to 2.1.159 (v0.14.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ provider). 2.1.156 was pinned in v0.14.8 as the build that fixed the
 Opus 4.8 "thinking block cannot be modified" 400 under low reasoning
 effort (#1978); the 2.1.157–2.1.159 changelogs contain no revert of that
 fix and no breaking changes affecting switchroom's MCP / hooks / session
-path, and the bump was canaried with a live turn confirming the 400 did
-not return. 2.1.157 also auto-loads `.claude/skills` without a
-marketplace and hardens managed-settings MCP allow/deny parsing.
+path. The bump is gated on a live-turn canary (test-harness, Opus 4.8 at
+low effort) confirming the 400 does not return before fleet rollout.
+2.1.157 also auto-loads `.claude/skills` without a marketplace and
+hardens managed-settings MCP allow/deny parsing.
 
 ## v0.14.25 — Surface foreground sub-agent activity after the ack
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.14.26 — Bump bundled claude CLI to 2.1.159
+
+Moves the hard-pinned `@anthropic-ai/claude-code` from **2.1.156** to
+**2.1.159** in both images that bundle it (`docker/Dockerfile.base`, used
+by every agent, and `docker/Dockerfile.hindsight`, used by the memory
+provider). 2.1.156 was pinned in v0.14.8 as the build that fixed the
+Opus 4.8 "thinking block cannot be modified" 400 under low reasoning
+effort (#1978); the 2.1.157–2.1.159 changelogs contain no revert of that
+fix and no breaking changes affecting switchroom's MCP / hooks / session
+path, and the bump was canaried with a live turn confirming the 400 did
+not return. 2.1.157 also auto-loads `.claude/skills` without a
+marketplace and hardens managed-settings MCP allow/deny parsing.
+
 ## v0.14.25 — Surface foreground sub-agent activity after the ack
 
 ### PR — surface foreground sub-agent activity after the ack-first reply (#2034)

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -166,7 +166,7 @@ ARG CACHE_BUST=default
 # bumps.
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     echo "cache-bust=${CACHE_BUST}" > /dev/null \
- && npm install -g @anthropic-ai/claude-code@2.1.156 \
+ && npm install -g @anthropic-ai/claude-code@2.1.159 \
  && claude --version >&2
 
 # Phase 1b: install bun. The broker server (src/vault/broker/server.ts)

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -40,7 +40,7 @@ USER root
 # hindsight memory provider runs the identical claude bundle as the agent
 # containers — a version skew here could reintroduce the thinking-block /
 # thinking-effort class of failures on memory reflection (see #1978).
-RUN npm install -g @anthropic-ai/claude-code@2.1.156 \
+RUN npm install -g @anthropic-ai/claude-code@2.1.159 \
  && claude --version >&2
 
 # Install claude-agent-sdk into the same venv the hindsight API runs from.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.25",
+  "version": "0.14.26",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bumps the hard-pinned `@anthropic-ai/claude-code` from **2.1.156 → 2.1.159** in both images that bundle it:
- `docker/Dockerfile.base:169` — every agent container
- `docker/Dockerfile.hindsight:43` — the memory provider

Plus version bump to 0.14.26 + CHANGELOG.

## Why

2.1.156 was pinned in v0.14.8 as the build that fixed the Opus 4.8 "thinking block cannot be modified" 400 error under low reasoning effort (#1978). The fleet had drifted 3 patch releases behind latest. Reviewed the 2.1.157–2.1.159 changelogs:
- **2.1.157**: no touch to the thinking/effort path; `.claude/skills` now auto-load without a marketplace; managed-settings MCP allow/deny parsing hardened. No breaking changes.
- **2.1.158**: Auto-mode on Bedrock/Vertex/Foundry (opt-in, irrelevant — we're subscription OAuth).
- **2.1.159**: internal only.

No revert of the #1978 fix in any of them.

## Test plan

- [ ] CI `build-base` + `build-dependents` succeed — this actually builds the images with 2.1.159 and runs `claude --version` in-layer, so a bad/uninstallable pin fails the required check.
- [ ] **Canary (the real gate):** deploy v0.14.26 to test-harness, run a live Opus-4.8 / low-effort turn, confirm the "thinking block cannot be modified" 400 does NOT return in the gateway log. Then fleet rollout.

## Risk

Medium — the pin exists specifically to dodge an Opus 4.8 regression, so the live-turn canary is mandatory before fleet. Both bundling images bumped together (no agent/hindsight skew). Easy revert: re-pin to 2.1.156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)