### PR TITLE
feat(telegram): native Telegram worker card (strip Markdown, ✓/→ feed)

### DIFF
--- a/telegram-plugin/card-format.ts
+++ b/telegram-plugin/card-format.ts
@@ -60,3 +60,65 @@ export function escapeHtml(s: string): string {
 export function truncate(s: string, n: number): string {
   return s.length > n ? s.slice(0, n - 1) + '…' : s;
 }
+
+/**
+ * Strip Markdown markup from a single line, leaving plain prose.
+ *
+ * Worker narration is authored as Markdown — the model writes `**bold**`,
+ * `` `code` ``, `- bullets`, `# headings`. The status cards render Telegram
+ * HTML, which does NOT interpret Markdown, so an unstripped `**` shows up as
+ * two literal asterisks (the #94-class "half-done" look). Strip the markup
+ * here so the card reads as clean prose.
+ *
+ * Run this BEFORE `truncate` + `escapeHtml`: clean → measure → escape. (The
+ * stripper never touches `<`/`>`/`&`, so escaping stays the last step.)
+ */
+export function stripMarkdown(s: string): string {
+  let out = s;
+  // Inline + leftover code spans → bare text.
+  out = out.replace(/`+/g, '');
+  // Links / images: [text](url) and ![alt](url) → the label.
+  out = out.replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1');
+  // Paired bold / emphasis runs (longest marker first).
+  out = out.replace(/\*\*(.+?)\*\*/g, '$1');
+  out = out.replace(/__(.+?)__/g, '$1');
+  out = out.replace(/\*(.+?)\*/g, '$1');
+  out = out.replace(/(?<![A-Za-z0-9])_(.+?)_(?![A-Za-z0-9])/g, '$1');
+  // Leading block markup: heading, blockquote, bullet, ordered item.
+  out = out.replace(/^\s{0,3}#{1,6}\s+/, '');
+  out = out.replace(/^\s{0,3}>\s?/, '');
+  out = out.replace(/^\s{0,3}[-*+]\s+/, '');
+  out = out.replace(/^\s{0,3}\d+[.)]\s+/, '');
+  // Residual unpaired bold markers (a lone `*` is left alone so `3 * 4`
+  // survives; only the doubled form is markup-by-construction).
+  out = out.replace(/\*\*/g, '');
+  return out.trim();
+}
+
+/** True for a whole-line horizontal rule: `---`, `___`, `***` (3+ of one). */
+function isRuleLine(s: string): boolean {
+  return /^\s*([-_*])\1{2,}\s*$/.test(s);
+}
+
+/**
+ * Clean a worker's multi-line result/narration into a single plain-text
+ * paragraph for a card's finished body. Drops fenced code blocks and
+ * horizontal rules, strips per-line Markdown, then space-joins what's left.
+ * Output is plain text — the caller still truncates + escapes before
+ * interpolating into HTML.
+ */
+export function cleanWorkerResultParagraph(s: string): string {
+  const kept: string[] = [];
+  let inFence = false;
+  for (const raw of s.split('\n')) {
+    if (/^\s*```/.test(raw)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    if (isRuleLine(raw)) continue;
+    const cleaned = stripMarkdown(raw);
+    if (cleaned.length > 0) kept.push(cleaned);
+  }
+  return kept.join(' ').replace(/\s+/g, ' ').trim();
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -17971,7 +17971,7 @@ void (async () => {
                 // The watcher's `description` is its 'sub-agent' default (it
                 // never reassigns it from the worker jsonl). The dispatch-time
                 // task description lives in the registry row — resolveWorkerFeedDispatch
-                // prefers it so the header reads "🔧 Worker · <real task>" not
+                // prefers it so the header reads "🛠 Worker · <real task>" not
                 // "· sub-agent" (worker-feed-dispatch.ts, pinned by its test).
                 let dispatch: WorkerFeedDispatch = resolveWorkerFeedDispatch(null, description)
                 if (turnsDb != null) {

--- a/telegram-plugin/gateway/worker-feed-dispatch.ts
+++ b/telegram-plugin/gateway/worker-feed-dispatch.ts
@@ -5,7 +5,7 @@ export interface WorkerFeedDispatch {
   isBackground: boolean
   /**
    * The human-readable task to render in the feed header
-   * ("🔧 Worker · <feedDescription>").
+   * ("🛠 Worker · <feedDescription>").
    */
   feedDescription: string
 }

--- a/telegram-plugin/tests/card-format.test.ts
+++ b/telegram-plugin/tests/card-format.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  cleanWorkerResultParagraph,
+  escapeHtml,
+  formatDuration,
+  stripMarkdown,
+  truncate,
+} from '../card-format.js'
+
+describe('stripMarkdown', () => {
+  it('strips paired bold and emphasis', () => {
+    expect(stripMarkdown('a **bold** and *em* and __b__ and _e_')).toBe(
+      'a bold and em and b and e',
+    )
+  })
+
+  it('strips inline code spans', () => {
+    expect(stripMarkdown('run `git push` now')).toBe('run git push now')
+  })
+
+  it('strips leading headings, blockquotes, bullets, and ordered items', () => {
+    expect(stripMarkdown('### Heading')).toBe('Heading')
+    expect(stripMarkdown('> quoted')).toBe('quoted')
+    expect(stripMarkdown('- a bullet')).toBe('a bullet')
+    expect(stripMarkdown('* star bullet')).toBe('star bullet')
+    expect(stripMarkdown('1. first')).toBe('first')
+    expect(stripMarkdown('2) second')).toBe('second')
+  })
+
+  it('reduces a link to its label', () => {
+    expect(stripMarkdown('see [the PR](https://x/y) here')).toBe('see the PR here')
+  })
+
+  it('removes residual doubled markers but keeps a lone asterisk (math)', () => {
+    expect(stripMarkdown('**dangling')).toBe('dangling')
+    expect(stripMarkdown('3 * 4 = 12')).toBe('3 * 4 = 12')
+  })
+
+  it('does not touch HTML-significant characters (escaping stays separate)', () => {
+    expect(stripMarkdown('a < b & c > d')).toBe('a < b & c > d')
+  })
+})
+
+describe('cleanWorkerResultParagraph', () => {
+  it('collapses multi-line Markdown into one plain paragraph', () => {
+    const input = '## Done\n\n**PR #21** opened\n\n- merged\n- pushed'
+    expect(cleanWorkerResultParagraph(input)).toBe('Done PR #21 opened merged pushed')
+  })
+
+  it('drops fenced code blocks entirely', () => {
+    const input = 'before\n```ts\nconst x = 1\n```\nafter'
+    expect(cleanWorkerResultParagraph(input)).toBe('before after')
+  })
+
+  it('drops horizontal rules', () => {
+    expect(cleanWorkerResultParagraph('a\n---\nb\n***\nc')).toBe('a b c')
+  })
+
+  it('returns empty for whitespace/markup-only input', () => {
+    expect(cleanWorkerResultParagraph('   \n---\n')).toBe('')
+  })
+})
+
+describe('formatDuration', () => {
+  it('renders sub-second as ms and seconds/minutes as MM:SS', () => {
+    expect(formatDuration(500)).toBe('500ms')
+    expect(formatDuration(1000)).toBe('00:01')
+    expect(formatDuration(60_000)).toBe('01:00')
+  })
+})
+
+describe('escapeHtml / truncate', () => {
+  it('escapes the three HTML-significant characters', () => {
+    expect(escapeHtml('a <b> & c')).toBe('a &lt;b&gt; &amp; c')
+  })
+  it('truncates with an ellipsis', () => {
+    expect(truncate('abcdef', 4)).toBe('abc…')
+    expect(truncate('abc', 4)).toBe('abc')
+  })
+})

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -69,72 +69,122 @@ function makeFakeBot(): FakeBot {
 // ─── renderWorkerActivity (pure) ─────────────────────────────────────────────
 
 describe('renderWorkerActivity', () => {
-  it('renders running header + tool activity line + summary', () => {
+  /** Count of step-feed bullets (`✓` done + `→` in-progress) in a body. */
+  const stepCount = (s: string) => (s.match(/[✓→]/g) ?? []).length
+
+  it('renders the native header + running status + step feed', () => {
     const out = renderWorkerActivity(view())
-    expect(out).toContain('🔧 <b>Worker</b> · <i>research competitors</i>')
-    expect(out).toContain('⚡ <code>Bash</code> grep -r pricing')
-    expect(out).toContain('(3 tools · ')
-    expect(out).toContain('↳ <i>scanning vendor pages</i>')
-  })
-
-  it('shows a "starting…" line when no tool has run yet', () => {
-    const out = renderWorkerActivity(view({ lastTool: null, latestSummary: '' }))
-    expect(out).toContain('🔧 <b>Worker</b>')
-    expect(out).toContain('starting…')
+    expect(out).toContain('🛠 <b>Worker</b> · <i>research competitors</i>')
+    expect(out).toContain('running · ')
+    expect(out).toContain('3 tools')
+    // No narrativeLines → the latestSummary surfaces as the newest `→` step.
+    expect(out).toContain('<b>→ scanning vendor pages</b>')
+    // The old tool/arg chrome is gone.
     expect(out).not.toContain('⚡')
+    expect(out).not.toContain('<code>')
   })
 
-  it('omits the summary line when latestSummary is blank', () => {
+  it('shows a "starting…" line when no step has run yet', () => {
+    const out = renderWorkerActivity(view({ lastTool: null, latestSummary: '' }))
+    expect(out).toContain('🛠 <b>Worker</b>')
+    expect(out).toContain('starting…')
+    expect(out).not.toContain('→')
+  })
+
+  it('falls back to starting… when the summary is blank', () => {
     const out = renderWorkerActivity(view({ latestSummary: '   ' }))
-    expect(out).not.toContain('↳')
+    expect(out).toContain('starting…')
+    expect(stepCount(out)).toBe(0)
   })
 
   it('uses singular "tool" for a single tool call', () => {
     const out = renderWorkerActivity(view({ toolCount: 1 }))
-    expect(out).toContain('(1 tool · ')
+    expect(out).toContain('1 tool')
+    expect(out).not.toContain('1 tools')
   })
 
-  it('renders a done terminal recap', () => {
-    const out = renderWorkerActivity(view({ state: 'done', toolCount: 5 }))
-    expect(out).toContain('✅ <b>Worker done</b> · <i>research competitors</i>')
-    expect(out).toContain('5 tools · ')
-    expect(out).not.toContain('⚡')
+  it('renders a done terminal recap with a rule + cleaned result', () => {
+    const out = renderWorkerActivity(
+      view({ state: 'done', toolCount: 5, latestSummary: 'PR #21 opened' }),
+    )
+    expect(out).toContain('🛠 <b>Worker</b> · <i>research competitors</i>')
+    expect(out).toContain('finished · completed · 5 tools · ')
+    expect(out).toContain('─────')
+    expect(out).toContain('✅ <i>PR #21 opened</i>')
   })
 
   it('renders a failed terminal recap', () => {
-    const out = renderWorkerActivity(view({ state: 'failed' }))
-    expect(out).toContain('⚠️ <b>Worker failed</b>')
+    const out = renderWorkerActivity(view({ state: 'failed', latestSummary: 'blew up' }))
+    expect(out).toContain('finished · failed · ')
+    expect(out).toContain('⚠️ <i>blew up</i>')
   })
 
-  it('grows a narrative block when narrativeLines is present', () => {
+  it('omits the rule + result line when the terminal result is empty', () => {
+    const out = renderWorkerActivity(view({ state: 'done', latestSummary: '   ' }))
+    expect(out).toContain('finished · completed · ')
+    expect(out).not.toContain('─────')
+  })
+
+  it('grows a step feed when narrativeLines is present (prior ✓, newest →)', () => {
     const out = renderWorkerActivity(
       view({
         latestSummary: 'newest only — should be ignored',
         narrativeLines: ['read the brief', 'scanned vendor A', 'scanned vendor B'],
       }),
     )
-    expect(out).toContain('↳ <i>read the brief</i>')
-    expect(out).toContain('↳ <i>scanned vendor A</i>')
-    expect(out).toContain('↳ <i>scanned vendor B</i>')
+    expect(out).toContain('<i>✓ read the brief</i>')
+    expect(out).toContain('<i>✓ scanned vendor A</i>')
+    expect(out).toContain('<b>→ scanned vendor B</b>')
     // The single-line latestSummary fallback is NOT used when a block is present.
     expect(out).not.toContain('newest only')
-    // Three narrative lines → three ↳ lines.
-    expect(out.match(/↳/g) ?? []).toHaveLength(3)
+    expect(stepCount(out)).toBe(3)
   })
 
   it('falls back to latestSummary when narrativeLines is empty', () => {
     const out = renderWorkerActivity(view({ narrativeLines: [], latestSummary: 'one line' }))
-    expect(out).toContain('↳ <i>one line</i>')
-    expect(out.match(/↳/g) ?? []).toHaveLength(1)
+    expect(out).toContain('<b>→ one line</b>')
+    expect(stepCount(out)).toBe(1)
   })
 
-  it('drops blank narrative lines from the block', () => {
-    const out = renderWorkerActivity(
-      view({ narrativeLines: ['kept', '   ', 'also kept'] }),
+  it('drops blank narrative lines from the feed', () => {
+    const out = renderWorkerActivity(view({ narrativeLines: ['kept', '   ', 'also kept'] }))
+    expect(out).toContain('<i>✓ kept</i>')
+    expect(out).toContain('<b>→ also kept</b>')
+    expect(stepCount(out)).toBe(2)
+  })
+
+  it('shows an overflow header when the feed exceeds the cap', () => {
+    const lines = Array.from({ length: 9 }, (_, i) => `step ${i + 1}`)
+    const out = renderWorkerActivity(view({ narrativeLines: lines }))
+    expect(out).toContain('<i>✓ +3 earlier…</i>')
+    expect(out).not.toContain('step 1')
+    expect(out).toContain('<i>✓ step 4</i>')
+    expect(out).toContain('<b>→ step 9</b>')
+    // 6 visible step lines (the overflow header is not itself a step).
+    expect(out.match(/step \d/g) ?? []).toHaveLength(6)
+  })
+
+  it('strips Markdown markup from narrative + description + result', () => {
+    const running = renderWorkerActivity(
+      view({
+        description: '**Build** the `sync`',
+        narrativeLines: ['- ran the **full** suite', '`git push`'],
+      }),
     )
-    expect(out).toContain('↳ <i>kept</i>')
-    expect(out).toContain('↳ <i>also kept</i>')
-    expect(out.match(/↳/g) ?? []).toHaveLength(2)
+    expect(running).toContain('🛠 <b>Worker</b> · <i>Build the sync</i>')
+    expect(running).toContain('ran the full suite')
+    expect(running).toContain('git push')
+    expect(running).not.toContain('**')
+    expect(running).not.toContain('`')
+
+    const done = renderWorkerActivity(
+      view({ state: 'done', latestSummary: '## Done\n\n**PR #21** opened\n\n---\n`merged`' }),
+    )
+    expect(done).toContain('Done PR #21 opened merged')
+    expect(done).not.toContain('**')
+    expect(done).not.toContain('`')
+    // The card's own divider is the box-drawing rule, never a raw `---`.
+    expect(done).not.toMatch(/(^|\n)\s*-{3,}\s*(\n|$)/)
   })
 
   it('escapes HTML inside narrative lines', () => {
@@ -142,17 +192,11 @@ describe('renderWorkerActivity', () => {
     expect(out).toContain('a &lt;b&gt;x&lt;/b&gt; &amp; y')
   })
 
-  it('escapes HTML in description, tool, arg, and summary', () => {
+  it('escapes HTML in description and summary', () => {
     const out = renderWorkerActivity(
-      view({
-        description: 'a <b>bold</b> task',
-        lastTool: { name: 'Ba<sh', sanitisedArg: 'x & y' },
-        latestSummary: 'a > b',
-      }),
+      view({ description: 'a <b>bold</b> task', latestSummary: 'a > b' }),
     )
     expect(out).toContain('a &lt;b&gt;bold&lt;/b&gt; task')
-    expect(out).toContain('Ba&lt;sh')
-    expect(out).toContain('x &amp; y')
     expect(out).toContain('a &gt; b')
   })
 })
@@ -206,7 +250,7 @@ describe('createWorkerActivityFeed', () => {
     clock = 13_000 // +3000 since last edit > 2500
     await feed.update('w1', 'chat', view({ toolCount: 3 }))
     expect(bot.edits).toHaveLength(1)
-    expect(bot.edits[0].text).toContain('(3 tools · ')
+    expect(bot.edits[0].text).toContain('3 tools')
   })
 
   it('forces a terminal edit on finish, skipping the throttle', async () => {
@@ -219,7 +263,7 @@ describe('createWorkerActivityFeed', () => {
     clock = 10_500 // well within the throttle window
     await feed.finish('w1', view({ state: 'done', toolCount: 5 }))
     expect(bot.edits).toHaveLength(1)
-    expect(bot.edits[0].text).toContain('✅ <b>Worker done</b>')
+    expect(bot.edits[0].text).toContain('finished · completed · 5 tools')
     // finish forgets the worker.
     expect(feed.has('w1')).toBe(false)
     expect(feed.size).toBe(0)
@@ -303,7 +347,7 @@ describe('createWorkerActivityFeed', () => {
 
     await feed.update('w1', 'chat', view({ toolCount: 1, latestSummary: 'read the brief' }))
     expect(bot.sent).toHaveLength(1)
-    expect(bot.sent[0].text).toContain('↳ <i>read the brief</i>')
+    expect(bot.sent[0].text).toContain('<b>→ read the brief</b>')
 
     clock = 11_000
     await feed.update('w1', 'chat', view({ toolCount: 2, latestSummary: 'scanned vendor A' }))
@@ -311,10 +355,10 @@ describe('createWorkerActivityFeed', () => {
     await feed.update('w1', 'chat', view({ toolCount: 3, latestSummary: 'scanned vendor B' }))
 
     const last = bot.edits.at(-1)!
-    expect(last.text).toContain('↳ <i>read the brief</i>')
-    expect(last.text).toContain('↳ <i>scanned vendor A</i>')
-    expect(last.text).toContain('↳ <i>scanned vendor B</i>')
-    expect(last.text.match(/↳/g) ?? []).toHaveLength(3)
+    expect(last.text).toContain('<i>✓ read the brief</i>')
+    expect(last.text).toContain('<i>✓ scanned vendor A</i>')
+    expect(last.text).toContain('<b>→ scanned vendor B</b>')
+    expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(3)
   })
 
   it('dedups a repeated narrative line so the block does not duplicate', async () => {
@@ -329,7 +373,7 @@ describe('createWorkerActivityFeed', () => {
     await feed.update('w1', 'chat', view({ toolCount: 2, latestSummary: 'same line' }))
 
     const last = bot.edits.at(-1)!
-    expect(last.text.match(/↳/g) ?? []).toHaveLength(1)
+    expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(1)
   })
 
   it('caps the narrative block to the last 6 lines', async () => {
@@ -343,7 +387,7 @@ describe('createWorkerActivityFeed', () => {
     }
 
     const last = bot.edits.at(-1)!
-    expect(last.text.match(/↳/g) ?? []).toHaveLength(6)
+    expect(last.text.match(/[✓→]/g) ?? []).toHaveLength(6)
     // Oldest lines evicted; newest retained.
     expect(last.text).not.toContain('line 1')
     expect(last.text).not.toContain('line 3')
@@ -368,9 +412,9 @@ describe('createWorkerActivityFeed', () => {
     clock = 13_000
     await feed.update('w1', 'chat', view({ toolCount: 3, latestSummary: 'line C' }))
     const last = bot.edits.at(-1)!
-    expect(last.text).toContain('↳ <i>line A</i>')
-    expect(last.text).toContain('↳ <i>line B</i>')
-    expect(last.text).toContain('↳ <i>line C</i>')
+    expect(last.text).toContain('<i>✓ line A</i>')
+    expect(last.text).toContain('<i>✓ line B</i>')
+    expect(last.text).toContain('<b>→ line C</b>')
   })
 
   it('forwards threadId as message_thread_id on send', async () => {

--- a/telegram-plugin/uat/assertions.ts
+++ b/telegram-plugin/uat/assertions.ts
@@ -13,16 +13,18 @@ import type { Driver, ObservedMessage, ObservedReaction } from "./driver.js";
 
 /**
  * Canonical shape of a worker-activity-feed message (#2000) as rendered
- * in Telegram: a running header `🔧 Worker · …` that edits in place and
- * finalizes to `✅ Worker done · …` / `⚠️ Worker failed · …`. The feed is
- * default-on fleet-wide as of v0.14.19, so background sub-agent activity
- * now surfaces as its own bot message in any chat — including DMs whose
- * scenario only cares about the agent's conversational reply.
+ * in Telegram: a native card with a `🛠 Worker · …` header that edits in
+ * place (running) and finalizes to a `finished · completed/failed · …`
+ * status line. The header is present in every state, so it's the primary
+ * key. The feed is default-on fleet-wide as of v0.14.19, so background
+ * sub-agent activity surfaces as its own bot message in any chat —
+ * including DMs whose scenario only cares about the agent's conversational
+ * reply.
  *
  * Single source of truth; the worker-feed scenario asserts against this,
  * and recall/reply scenarios exclude it via {@link isWorkerFeedMessage}.
  */
-export const WORKER_FEED_RE = /🔧\s*Worker|✅\s*Worker done|⚠️\s*Worker failed|Worker (?:done|failed)/i;
+export const WORKER_FEED_RE = /🛠[️]?\s*Worker\b|finished\s*·\s*(?:completed|failed)/i;
 
 /**
  * True when `m` is a worker-activity-feed message rather than the agent's

--- a/telegram-plugin/uat/feed-matcher.test.ts
+++ b/telegram-plugin/uat/feed-matcher.test.ts
@@ -13,17 +13,23 @@ const feed = (text: string) => ({ text }) as Parameters<typeof isWorkerFeedMessa
 
 describe("isWorkerFeedMessage", () => {
   it("matches the running feed header", () => {
-    expect(isWorkerFeedMessage(feed("🔧 Worker · crawling changelog · 0:12"))).toBe(true);
+    expect(isWorkerFeedMessage(feed("🛠 Worker · crawling changelog"))).toBe(true);
+    expect(
+      isWorkerFeedMessage(feed("🛠 Worker · crawling changelog\nrunning · 00:12 · 4 tools")),
+    ).toBe(true);
   });
 
-  it("matches the terminal done/failed recaps", () => {
-    expect(isWorkerFeedMessage(feed("✅ Worker done · 10 tools · 1:03"))).toBe(true);
-    expect(isWorkerFeedMessage(feed("⚠️ Worker failed · 3 tools"))).toBe(true);
+  it("matches the terminal finished status (completed/failed)", () => {
+    expect(
+      isWorkerFeedMessage(feed("🛠 Worker · crawl\nfinished · completed · 10 tools · 01:03")),
+    ).toBe(true);
+    expect(
+      isWorkerFeedMessage(feed("🛠 Worker · crawl\nfinished · failed · 3 tools · 00:08")),
+    ).toBe(true);
   });
 
-  it("matches a done/failed header even without the leading emoji", () => {
-    expect(isWorkerFeedMessage(feed("Worker done · 2 tools"))).toBe(true);
-    expect(isWorkerFeedMessage(feed("Worker failed mid-step"))).toBe(true);
+  it("matches the finished status even on its own line (header-stripped edge)", () => {
+    expect(isWorkerFeedMessage(feed("finished · completed · 2 tools · 00:30"))).toBe(true);
   });
 
   it("does NOT match an ordinary agent reply", () => {
@@ -40,7 +46,7 @@ describe("isWorkerFeedMessage", () => {
   });
 
   it("exposes the regex for scenarios that assert on the feed directly", () => {
-    expect(WORKER_FEED_RE.test("🔧 Worker · x")).toBe(true);
+    expect(WORKER_FEED_RE.test("🛠 Worker · x")).toBe(true);
   });
 });
 

--- a/telegram-plugin/uat/scenarios/jtbd-worker-activity-feed-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-worker-activity-feed-dm.test.ts
@@ -12,12 +12,14 @@
  * sleep/echo work, so it narrates between tools and the feed can paint
  * + edit), then asserts:
  *
- *   1. a worker-feed message appears (🔧 Worker · …), distinct from the
+ *   1. a worker-feed message appears (🛠 Worker · …), distinct from the
  *      parent's ack reply — proving background activity surfaces after
  *      the parent turn closed;
  *   2. the message edits in place while work is in flight (body changes
  *      across a window) — proving it's live, not a one-shot post;
- *   3. it finalizes to the terminal recap (✅ Worker done · … / N tools).
+ *   3. it finalizes to the terminal recap (finished · completed · N tools);
+ *   4. the native card never leaks raw Markdown (no `**`, backticks, or
+ *      ASCII `---` rule) — the #94-class regression guard.
  *
  * It logs every observed body so a human can read the real rendered UX.
  *
@@ -53,10 +55,11 @@ const BG_DISPATCH_PROMPT =
   `brief reply saying you've kicked off the background worker so I can ` +
   `watch its progress.`;
 
-// The feed header rendered in Telegram: "🔧 Worker · <desc>" (running)
-// or "✅ Worker done · …" / "⚠️ Worker failed · …" (terminal).
-const WORKER_FEED_RE = /🔧\s*Worker|Worker done|Worker failed|⚡/i;
-const WORKER_DONE_RE = /✅\s*Worker done|⚠️\s*Worker failed/i;
+// The feed header rendered in Telegram: "🛠 Worker · <desc>" with a
+// "running · …" status (running) or "finished · completed/failed · …"
+// (terminal).
+const WORKER_FEED_RE = /🛠\s*Worker|running\s*·|finished\s*·/i;
+const WORKER_DONE_RE = /finished\s*·\s*(completed|failed)/i;
 
 describe("uat: live worker-activity feed (#2000)", () => {
   it(
@@ -116,6 +119,14 @@ describe("uat: live worker-activity feed (#2000)", () => {
         expect(doneText!).toMatch(/tools?|tool ·/i);
         // Did the body actually move between first paint and terminal?
         expect(doneText).not.toBe(before);
+        // #94-class regression guard: the native card strips worker Markdown,
+        // so the rendered body must never carry raw `**`, backticks, or an
+        // ASCII `---` rule (the finished divider is the box-drawing `─────`).
+        expect(doneText!, "raw ** leaked into the card").not.toMatch(/\*\*/);
+        expect(doneText!, "raw backtick leaked into the card").not.toContain("`");
+        expect(doneText!, "raw --- rule leaked into the card").not.toMatch(
+          /(^|\n)\s*-{3,}\s*(\n|$)/,
+        );
       } finally {
         await sc.tearDown();
       }

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -32,7 +32,13 @@
  * the feed is fed from watcher callbacks rather than the bridge event stream.
  */
 
-import { escapeHtml, formatDuration, truncate } from './card-format.js'
+import {
+  cleanWorkerResultParagraph,
+  escapeHtml,
+  formatDuration,
+  stripMarkdown,
+  truncate,
+} from './card-format.js'
 
 /** Worker-activity feed is ON by default; an operator opts out with
  *  SWITCHROOM_WORKER_ACTIVITY_FEED=0. */
@@ -80,8 +86,10 @@ export interface BotApiForWorkerFeed {
 }
 
 const DESC_MAX = 80
-const TOOL_ARG_MAX = 64
-const SUMMARY_MAX = 100
+const STEP_MAX = 100
+const RESULT_MAX = 320
+/** Subtle horizontal rule between the running feed and the finished result. */
+const RULE = '─────'
 /**
  * How many trailing narrative lines the live feed keeps visible. The feed
  * grows like the main agent's answer but can't grow unbounded — Telegram
@@ -91,57 +99,83 @@ const SUMMARY_MAX = 100
 const NARRATIVE_MAX_LINES = 6
 
 /**
- * Render the worker-activity message body as Telegram HTML.
+ * Append the accumulated step feed to `lines`, mirroring the main agent's
+ * activity card (`renderActivityFeed`): prior steps render done (`✓`, italic),
+ * the newest renders in-progress (`→`, bold) unless `allDone`, and an overflow
+ * header (`✓ +N earlier…`) appears when the feed exceeds NARRATIVE_MAX_LINES.
+ * `steps` are already cleaned + escaped HTML.
+ */
+function appendStepFeed(lines: string[], steps: string[], allDone: boolean): void {
+  if (steps.length === 0) return
+  const shown = steps.slice(-NARRATIVE_MAX_LINES)
+  const hidden = steps.length - shown.length
+  if (hidden > 0) lines.push(`<i>✓ +${hidden} earlier…</i>`)
+  const lastIdx = shown.length - 1
+  shown.forEach((s, i) => {
+    lines.push(!allDone && i === lastIdx ? `<b>→ ${s}</b>` : `<i>✓ ${s}</i>`)
+  })
+}
+
+/**
+ * Render the worker-activity message body as native Telegram HTML, matching
+ * the main agent's activity card (`renderActivityFeed` in
+ * tool-activity-summary.ts): a `🛠 Worker · <desc>` header, a one-line status,
+ * then a `✓`/`→` step feed. Worker narration is authored as Markdown, so every
+ * text fragment is run through `stripMarkdown` before escaping — without it the
+ * raw `**`/`` ` ``/`---` leak through as literal characters (the "half-done"
+ * look we're fixing).
  *
  * Layout (running):
- *   🔧 <b>Worker</b> · <i>{description}</i>
- *   ⚡ <code>{tool}</code> {arg} <i>({n} tools · {elapsed})</i>
- *     ↳ <i>{latest summary}</i>
+ *   🛠 <b>Worker</b> · <i>{description}</i>
+ *   <i>running · {elapsed} · {n} tools</i>
+ *   <i>✓ {earlier step}</i>
+ *   <b>→ {newest step}</b>
  *
- * Terminal collapses the activity line to a tool-count + duration recap:
- *   ✅ <b>Worker done</b> · <i>{description}</i>
- *   <i>{n} tools · {elapsed}</i>
+ * Layout (finished): the feed renders all-done, then a rule + cleaned result:
+ *   🛠 <b>Worker</b> · <i>{description}</i>
+ *   <i>finished · completed · {n} tools · {elapsed}</i>
+ *   <i>✓ {step}</i>
+ *   ─────
+ *   ✅ <i>{cleaned result paragraph}</i>
  */
 export function renderWorkerActivity(v: WorkerActivityView): string {
-  const desc = truncate(v.description.trim() || 'background task', DESC_MAX)
+  const desc = truncate(stripMarkdown(v.description).trim() || 'background task', DESC_MAX)
   const elapsed = formatDuration(v.elapsedMs)
   const toolWord = v.toolCount === 1 ? 'tool' : 'tools'
+  const header = `🛠 <b>Worker</b> · <i>${escapeHtml(desc)}</i>`
+  const finished = v.state === 'done' || v.state === 'failed'
 
-  if (v.state === 'done' || v.state === 'failed') {
-    const head =
-      v.state === 'done'
-        ? `✅ <b>Worker done</b> · <i>${escapeHtml(desc)}</i>`
-        : `⚠️ <b>Worker failed</b> · <i>${escapeHtml(desc)}</i>`
-    return `${head}\n<i>${v.toolCount} ${toolWord} · ${elapsed}</i>`
-  }
-
-  const header = `🔧 <b>Worker</b> · <i>${escapeHtml(desc)}</i>`
-
-  let activity: string
-  if (v.lastTool != null) {
-    const arg = v.lastTool.sanitisedArg.trim()
-    const argPart = arg.length > 0 ? ` ${escapeHtml(truncate(arg, TOOL_ARG_MAX))}` : ''
-    activity = `⚡ <code>${escapeHtml(v.lastTool.name)}</code>${argPart} <i>(${v.toolCount} ${toolWord} · ${elapsed})</i>`
-  } else {
-    activity = `<i>starting… (${elapsed})</i>`
-  }
-
-  const lines = [header, activity]
-
-  // Growing narrative block when the manager has accumulated lines; the feed
-  // reads like the main agent's live answer rather than a single replaced
-  // status line. Fall back to the single latestSummary line otherwise.
-  const narrative = (v.narrativeLines ?? [])
-    .map((s) => s.trim())
+  const steps = (v.narrativeLines ?? [])
+    .map((s) => stripMarkdown(s))
     .filter((s) => s.length > 0)
-  if (narrative.length > 0) {
-    for (const line of narrative) {
-      lines.push(`  ↳ <i>${escapeHtml(truncate(line, SUMMARY_MAX))}</i>`)
+    .map((s) => escapeHtml(truncate(s, STEP_MAX)))
+
+  if (finished) {
+    const verb = v.state === 'done' ? 'completed' : 'failed'
+    const lines = [header, `<i>finished · ${verb} · ${v.toolCount} ${toolWord} · ${elapsed}</i>`]
+    appendStepFeed(lines, steps, true)
+    // On terminal, latestSummary carries the worker's final result text
+    // (gateway onFinish), distinct from the running narrative steps.
+    const result = cleanWorkerResultParagraph(v.latestSummary)
+    if (result.length > 0) {
+      const emoji = v.state === 'done' ? '✅' : '⚠️'
+      lines.push(RULE)
+      lines.push(`${emoji} <i>${escapeHtml(truncate(result, RESULT_MAX))}</i>`)
     }
+    return lines.join('\n')
+  }
+
+  const lines = [header, `<i>running · ${elapsed} · ${v.toolCount} ${toolWord}</i>`]
+  if (steps.length > 0) {
+    appendStepFeed(lines, steps, false)
   } else {
-    const summary = v.latestSummary.trim()
+    // Back-compat for direct render callers that pass only latestSummary;
+    // the manager always supplies narrativeLines.
+    const summary = stripMarkdown(v.latestSummary)
     if (summary.length > 0) {
-      lines.push(`  ↳ <i>${escapeHtml(truncate(summary, SUMMARY_MAX))}</i>`)
+      lines.push(`<b>→ ${escapeHtml(truncate(summary, STEP_MAX))}</b>`)
+    } else {
+      lines.push('<i>starting…</i>')
     }
   }
   return lines.join('\n')
@@ -307,7 +341,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       // message is left at its last running render — stale but harmless.
       return
     }
-    const body = renderWorkerActivity(view)
+    const body = renderWorkerActivity({ ...view, narrativeLines: h.narrative })
     if (body === h.lastBody) return
     try {
       await opts.bot.editMessageText(h.chatId, h.messageId, body, sendOptsFor(h))

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -60,10 +60,11 @@ export interface WorkerActivityView {
   latestSummary: string
   /**
    * Accumulated narrative lines, oldest→newest, already deduped + capped by
-   * the feed manager. When present and non-empty, the render grows a block
-   * of `↳` lines (mirroring the main agent's live answer) instead of
-   * collapsing to the single `latestSummary` line. Absent/empty → the
-   * single-line fallback (back-compat for direct render callers).
+   * the feed manager. When present and non-empty, the render grows a `✓`/`→`
+   * step feed (prior steps done, newest in-progress — mirroring the main
+   * agent's activity card) instead of collapsing to the single `latestSummary`
+   * line. Absent/empty → the single-line fallback (back-compat for direct
+   * render callers).
    */
   narrativeLines?: string[]
   /** Wall-clock since dispatch, ms. */


### PR DESCRIPTION
## Summary

The background **worker-activity card** (the live message a `run_in_background` sub-agent posts and edits in place) HTML-escaped its text but never stripped the **Markdown the model authors** into its narration. Raw `**bold**`, `` `code` ``, and `---` rules rendered as literal characters in the card — the "half-done", non-Telegram-native look an operator flagged on the Clerk worker card.

This rewrites the card to the same idiom as the main agent's activity feed (`renderActivityFeed`), and strips Markdown at the boundary so nothing leaks.

**Running:**
```
🛠 Worker · Build shopping 3-way sync
running · 04:04 · 69 tools
✓ Vault denied — degraded gracefully
✓ Ran the full suite, committed, pushed
→ Opening PR…
```
**Finished:**
```
🛠 Worker · Build shopping 3-way sync
finished · completed · 71 tools · 04:12
✓ Vault denied — degraded gracefully
✓ Ran the full suite, committed, pushed
✓ Opened the PR
─────
✅ PR #21 opened, calendar-app. Notion as a true LWW peer, dedup + tombstones
```

## Why

JTBD: *you hold the leash* — background work must surface with the same legibility as a main turn. A card full of raw `**`/backticks/`---` reads as broken chrome, not "the agent is working". The fix matches the established activity-card visual so the two surfaces are consistent (principle 3).

## What changed

- **`card-format.ts`** (dependency-free): new `stripMarkdown` (inline code, bold/emphasis, links, leading headings/blockquotes/bullets/ordered-items, residual `**`) + `cleanWorkerResultParagraph` (drops fenced code + horizontal rules, collapses multi-line result to one paragraph). Order is always **clean → truncate → escape**.
- **`worker-activity-feed.ts`**: `renderWorkerActivity` rewritten to the `🛠 Worker` header + status line + `✓`/`→` step feed + finished `─────` rule + cleaned result. Every fragment stripped before escape. The manager now passes the accumulated narrative into the **terminal** render so the finished card keeps its step context. Tool/arg `⚡ <code>` chrome retired.
- **Tests**: `worker-activity-feed.test.ts` render+manager assertions moved to the new shape; new `card-format.test.ts` covers the strippers; markdown-strip / overflow / empty-result / finished cases added.
- **UAT**: `jtbd-worker-activity-feed-dm.test.ts` regexes moved to the new header + a **no-raw-Markdown regression guard** (asserts the rendered body has no `**`, backtick, or ASCII `---`). Shared `WORKER_FEED_RE` in `assertions.ts` (used by recall/reply scenarios to skip feed noise) re-keyed to the new header + finished status, tolerant of a Telegram variation selector.

No gateway callsite changed — the manager still sends via the existing `robustApiCall`-wrapped bot, so the bot-api-wrapping allowlist is untouched.

## Test plan

- [x] `vitest run telegram-plugin/tests/worker-activity-feed.test.ts` — 31 pass
- [x] `vitest run telegram-plugin/tests/card-format.test.ts` — 13 pass
- [x] `bun test telegram-plugin/uat/feed-matcher.test.ts` — 12 pass
- [x] `vitest run telegram-plugin/tests telegram-plugin/uat` — 3153 pass
- [x] `tsc --noEmit` clean
- [x] `check-plugin-references` / `check-bot-api-wrapping` / `check-bun-test-imports` clean
- [ ] Live UAT `jtbd-worker-activity-feed-dm` on test-harness (post-merge canary, mtcute can observe sendMessage/editMessageText)

## Risk

Low. Pure-render + string-helper change; no IPC/gateway/auth surface. Worst case is a cosmetic render regression caught by the unit + UAT guards. Behind the existing `SWITCHROOM_WORKER_ACTIVITY_FEED` flag (on by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)