### PR TITLE
chore: release v0.14.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.14.27 — Native Telegram worker card (#2041)
+
+The background-worker card (the live, edit-in-place card a
+`run_in_background: true` sub-agent gets) now renders as clean Telegram
+HTML that matches the normal activity card, instead of leaking raw
+model-authored Markdown.
+
+Before, `renderWorkerActivity` HTML-escaped the model's text but never
+stripped Markdown, so `**bold**`, backticks, and `---` rules rendered as
+literal characters in Telegram — the card looked half-finished and
+off-style versus the framework's other cards.
+
+Now:
+
+- A shared `stripMarkdown` + `cleanWorkerResultParagraph` pair in
+  `telegram-plugin/card-format.ts` removes emphasis, inline code, links,
+  headings, list/quote markers, horizontal rules, and code fences before
+  the text is escaped and placed into the card.
+- The card body is a `✓` / `→` step feed (newest step bold-arrowed,
+  prior steps checked, older steps collapsed into a `+N earlier…`
+  overflow line) — the same visual grammar as the foreground
+  tool-activity summary.
+- The terminal card shows a `finished · completed|failed · N tools ·
+  MM:SS` line, a divider rule, and a cleaned one-paragraph result with a
+  `✅`/`⚠️` lead.
+
+No behavior change to dispatch, throttling, or the
+`SWITCHROOM_WORKER_ACTIVITY_FEED` flag — this is presentation only.
+
 ## v0.14.26 — Bump bundled claude CLI to 2.1.159
 
 Moves the hard-pinned `@anthropic-ai/claude-code` from **2.1.156** to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.26",
+  "version": "0.14.27",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release **v0.14.27** — Native Telegram worker card.

Bundles the merged, reviewed feature PR #2041: the background-worker
card (live edit-in-place card for `run_in_background: true` sub-agents)
now renders as clean Telegram HTML matching the framework's other
activity cards instead of leaking raw model-authored Markdown.

## Why

The card escaped the model's text but never stripped Markdown, so
`**bold**`, backticks, and `---` rules rendered as literal characters —
the card looked half-finished and off-style. This release ships the fix
fleet-wide.

## What's in it

- `stripMarkdown` + `cleanWorkerResultParagraph` in `card-format.ts`
- `✓`/`→` step feed with `+N earlier…` overflow (matches the foreground
  tool-activity summary grammar)
- terminal card: `finished · completed|failed · N tools · MM:SS` +
  divider rule + cleaned `✅`/`⚠️` result paragraph

Presentation-only — no change to dispatch, throttling, or the
`SWITCHROOM_WORKER_ACTIVITY_FEED` flag.

## Test plan

- [x] Constituent feature PR #2041 reviewed (APPROVE) + merged
- [x] `node scripts/build.mjs` exits 0, `dist/cli/switchroom.js` present (~3.0MB)
- [ ] CI green (10 required checks)
- [ ] Canary worker-feed UAT on test-harness post-publish

## Risk

Low — presentation-only diff already on `main` via #2041; this PR only
bumps `package.json` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)