### PR TITLE
fix(secret-detect): cover Sanctum/Coolify tokens + redact history both directions

### DIFF
--- a/src/secret-detect/redact.ts
+++ b/src/secret-detect/redact.ts
@@ -2,97 +2,19 @@
  * `redact(text)` — sanitize text by replacing detected secrets and
  * credential-bearing URL parts with `[REDACTED]` markers.
  *
- * This is the chokepoint used by:
- *   - `switchroom issues record` — every code path that writes to
- *     `issues.jsonl` flows through `src/issues/store.ts:capDetail`,
- *     which calls `redact()` before truncating to `DETAIL_MAX_BYTES`.
- *     `bin/run-hook.sh` is the canonical caller; programmatic callers
- *     elsewhere in the codebase get the scrub for free.
- *   - `switchroom secret-detect redact --stdin` — bash-callable shim
- *     for ad-hoc operator use and tests. (Not on the hook hot path;
- *     each `bun` CLI fork costs ~785ms cold-start, so chaining
- *     `... | secret-detect redact | issues record` would double per-
- *     failure latency for no additional security beyond the server-
- *     side chokepoint above.)
+ * The implementation now lives in the telegram-plugin so the gateway's
+ * inbound/outbound history persistence (`telegram-plugin/history.ts`) and
+ * the src-side callers below share ONE redactor backed by the same
+ * `detectSecrets` engine — a pattern added once covers every path. This
+ * module re-exports it so existing importers keep working unchanged:
  *
- * Threat model: any token a failing hook prints on its error path (a 401
- * echoing the bearer, a `git clone` failure showing a PAT URL, a recall.py
- * traceback echoing the LLM provider response) used to land verbatim in
- * `issues.jsonl` and surface in Telegram via the issues-card / `/issues`
- * list. This module is the choke point that prevents that.
+ *   - `switchroom issues record` — `src/issues/store.ts:capDetail`, which
+ *     calls `redact()` before truncating to `DETAIL_MAX_BYTES`.
+ *     `bin/run-hook.sh` is the canonical caller.
+ *   - `switchroom secret-detect redact --stdin` — `src/cli/secret-detect.ts`.
+ *   - hostd — `src/host-control/server.ts`.
  *
- * Detection is delegated to the existing telegram-plugin engine
- * (`telegram-plugin/secret-detect/index.ts`) — same patterns, same
- * suppressor behavior, same secretlint integration as the outbound
- * Telegram redaction path. We do NOT re-invent regexes here.
- *
- * Idempotence: for token-shape detections the marker doesn't re-match
- * (no high-entropy run, no provider prefix). For *structural* detectors
- * — `cli_flag` (`--api-key <value>`), `json_secret_field` (`"key":
- * "value"`) — a second pass over already-redacted text will replace
- * `[REDACTED:openai_api_key]` with `[REDACTED:cli_flag]`. The bytes
- * remain redacted in either case, so this is a tag-rewrite, not a
- * leak. Don't rely on `redact(redact(x)) === redact(x)` for every `x`;
- * do rely on "no detected secret bytes survive any number of passes".
+ * Threat model and idempotence notes: see
+ * `telegram-plugin/secret-detect/redact.ts`.
  */
-
-import {
-  detectSecrets,
-  redactUrls,
-  type Detection,
-} from "../../telegram-plugin/secret-detect/index.js";
-
-export const REDACTED_MARKER = "[REDACTED]";
-
-/**
- * Synchronous, fast redactor. Uses the vendored pattern engine only —
- * no secretlint (which is async). Suitable for the hot path (every
- * failing hook fires this).
- *
- * Order matters:
- *   1. URL credentials (`https://u:p@host` → `https://***@host`,
- *      sensitive query params → `?key=***`). This catches credentials
- *      that the token-shape detector wouldn't, AND normalizes them so
- *      step 2 doesn't double-redact a URL that already had its
- *      sensitive parts scrubbed.
- *   2. Token-shape detection over the URL-normalized text. We replace
- *      matched byte ranges right-to-left so earlier offsets remain
- *      valid.
- */
-export function redact(text: string): string {
-  if (!text || text.length === 0) return text;
-
-  // Step 1 — URL credentials and known-sensitive query params.
-  const urlScrubbed = redactUrls(text);
-
-  // Step 2 — token shape detection over the URL-scrubbed text.
-  const hits: Detection[] = detectSecrets(urlScrubbed);
-  if (hits.length === 0) return urlScrubbed;
-
-  // Apply replacements right-to-left so byte offsets stay valid.
-  const sorted = [...hits].sort((a, b) => b.start - a.start);
-  let out = urlScrubbed;
-  for (const h of sorted) {
-    // Use a rule-tagged marker so operators can identify what was
-    // scrubbed without seeing the bytes. The tag is detector-controlled
-    // (never user-input bytes), so it remains safe to render in
-    // Telegram HTML / chat.
-    out = out.slice(0, h.start) + redactedMarker(h.rule_id) + out.slice(h.end);
-  }
-  return out;
-}
-
-/**
- * `[REDACTED:<rule_id>]` when the rule_id is informative,
- * `[REDACTED]` otherwise. The rule_id is detector-emitted, so it
- * never contains attacker-controlled bytes — safe to embed verbatim.
- */
-function redactedMarker(ruleId: string): string {
-  // Strip the `kv_` / `env_` heuristic prefixes that aren't useful to
-  // operators; keep provider-shape tags like `github_pat`, `openai_key`.
-  const trimmed = ruleId.replace(/^(kv|env)_/, "");
-  if (!trimmed || trimmed === "key_value" || trimmed === "kv_entropy") {
-    return REDACTED_MARKER;
-  }
-  return `[REDACTED:${trimmed}]`;
-}
+export { redact, REDACTED_MARKER } from "../../telegram-plugin/secret-detect/redact.js";

--- a/telegram-plugin/history.ts
+++ b/telegram-plugin/history.ts
@@ -27,6 +27,7 @@
 
 import { chmodSync, mkdirSync } from 'fs'
 import { join } from 'path'
+import { redact } from './secret-detect/redact.js'
 
 /**
  * `bun:sqlite` is a Bun built-in — Vite/Node loaders can't resolve it
@@ -300,6 +301,10 @@ export function recordInbound(args: RecordInboundArgs): void {
       (chat_id, thread_id, message_id, role, user, user_id, ts, text, attachment_kind, group_id, reply_to_message_id, reply_to_text)
     VALUES (?, ?, ?, 'user', ?, ?, ?, ?, ?, NULL, ?, ?)
   `)
+  // Defense-in-depth: never persist a detected secret to the message store.
+  // The inbound gate (server.ts handleInbound) already deletes + vaults a
+  // high-confidence hit before reaching here, so for caught secrets this is
+  // a no-op; it's the backstop for any shape the gate's pattern set misses.
   stmt.run(
     args.chat_id,
     args.thread_id ?? null,
@@ -307,10 +312,10 @@ export function recordInbound(args: RecordInboundArgs): void {
     args.user ?? null,
     args.user_id ?? null,
     args.ts,
-    args.text,
+    redact(args.text),
     args.attachment_kind ?? null,
     args.reply_to_message_id ?? null,
-    args.reply_to_text ?? null,
+    args.reply_to_text != null ? redact(args.reply_to_text) : (args.reply_to_text ?? null),
   )
 }
 
@@ -356,9 +361,14 @@ export function recordOutbound(args: RecordOutboundArgs): void {
       )
     }
   }) as (...args: unknown[]) => unknown)
+  // Outbound redaction: the agent→user direction has no other secret
+  // scrub, so this is the chokepoint that keeps an agent-echoed secret out
+  // of the message store (e.g. an agent quoting a token it read from a file
+  // or a not-yet-vaulted value). Masks the secret bytes in place; the
+  // surrounding reply text is preserved.
   const rows: Array<[number, string, string | null]> = args.message_ids.map((id, i) => [
     id,
-    args.texts[i] ?? '',
+    redact(args.texts[i] ?? ''),
     args.attachment_kinds?.[i] ?? null,
   ])
   tx(rows)
@@ -387,7 +397,9 @@ export function recordEdit(args: RecordEditArgs): void {
          SET text = ?
        WHERE chat_id = ? AND message_id = ?
     `)
-    .run(args.text, args.chat_id, args.message_id)
+    // Same outbound chokepoint as recordOutbound — an edit must not
+    // reintroduce a raw secret into the stored row.
+    .run(redact(args.text), args.chat_id, args.message_id)
 }
 
 export interface RecordReactionArgs {

--- a/telegram-plugin/secret-detect/patterns.ts
+++ b/telegram-plugin/secret-detect/patterns.ts
@@ -54,6 +54,14 @@ export const ANCHORED_PATTERNS: PatternDef[] = [
   // Telegram bot tokens: with "bot" prefix or bare ID:token.
   { rule_id: 'telegram_bot_token_prefixed', regex: /\bbot(\d{6,}:[A-Za-z0-9_-]{20,})\b/g, captureIndex: 1, slugHint: 'telegram_bot_token' },
   { rule_id: 'telegram_bot_token', regex: /\b(\d{6,}:[A-Za-z0-9_-]{20,})\b/g, captureIndex: 1, slugHint: 'telegram_bot_token' },
+  // Laravel Sanctum / Coolify personal-access tokens. Shape: `<id>|<token>`
+  // where <id> is the integer PK and <token> is `Str::random(40)` — 40 base62
+  // chars. The `|` separator is what distinguishes this from a Telegram
+  // `id:token` (colon) or a JWT. Length floor 40 (the Sanctum default) keeps
+  // this off short pipe-joined chat like `1|foo` or markdown table cells.
+  // Incident 2026-06-01: a live `17|<40-char>` Coolify token pasted by a user
+  // slipped every existing pattern and persisted in plaintext.
+  { rule_id: 'laravel_sanctum_token', regex: /\b(\d+\|[A-Za-z0-9]{40,})\b/g, captureIndex: 1, slugHint: 'api_token' },
   { rule_id: 'aws_access_key', regex: /\b(AKIA[0-9A-Z]{16})\b/g, captureIndex: 1, slugHint: 'aws_access_key' },
   { rule_id: 'jwt', regex: /\b(eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b/g, captureIndex: 1, slugHint: 'jwt' },
 ]

--- a/telegram-plugin/secret-detect/redact.ts
+++ b/telegram-plugin/secret-detect/redact.ts
@@ -1,0 +1,76 @@
+/**
+ * `redact(text)` — sanitize text by replacing detected secrets and
+ * credential-bearing URL parts with `[REDACTED]` markers, in place.
+ *
+ * This is the shared mask-in-place chokepoint. Unlike the inbound
+ * vault-staging flow (which DELETES the Telegram message and offers to
+ * save the secret), `redact()` leaves the surrounding prose intact and
+ * only masks the secret byte-ranges — the right behavior when we must
+ * keep a record but never store/log/forward the raw value:
+ *
+ *   - INBOUND + OUTBOUND history persistence — `history.ts`
+ *     `recordInbound` / `recordOutbound` redact before the row hits
+ *     SQLite, so no detected secret survives in the message store in
+ *     either direction (defense-in-depth behind the inbound gate, and
+ *     the only redaction on the agent→user direction).
+ *   - `switchroom issues record` — `src/issues/store.ts:capDetail`.
+ *   - `switchroom secret-detect redact --stdin` — bash-callable shim.
+ *   - hostd — `src/host-control/server.ts`.
+ *
+ * Detection is delegated to `detectSecrets()` (same patterns, same
+ * suppressor, same engine as the inbound Telegram gate) so a pattern
+ * added once — e.g. the Laravel/Coolify Sanctum `<id>|<token>` shape —
+ * covers detection, inbound interception, and this redactor uniformly.
+ *
+ * Idempotence: for token-shape detections the marker doesn't re-match.
+ * For *structural* detectors (`cli_flag`, `json_secret_field`) a second
+ * pass may rewrite the tag, but the bytes stay redacted. Rely on "no
+ * detected secret bytes survive any number of passes", not on strict
+ * `redact(redact(x)) === redact(x)`.
+ */
+import { detectSecrets, type Detection } from './index.js'
+import { redactUrls } from './url-redact.js'
+
+export const REDACTED_MARKER = '[REDACTED]'
+
+/**
+ * Synchronous, fast redactor. Vendored pattern engine only (no async
+ * secretlint) so it is safe on hot paths (every stored message).
+ *
+ * Order matters:
+ *   1. URL credentials (`https://u:p@host` → `https://***@host`,
+ *      sensitive query params → `?key=***`).
+ *   2. Token-shape detection over the URL-normalized text; matched byte
+ *      ranges are replaced right-to-left so earlier offsets stay valid.
+ */
+export function redact(text: string): string {
+  if (!text || text.length === 0) return text
+
+  // Step 1 — URL credentials and known-sensitive query params.
+  const urlScrubbed = redactUrls(text)
+
+  // Step 2 — token shape detection over the URL-scrubbed text.
+  const hits: Detection[] = detectSecrets(urlScrubbed)
+  if (hits.length === 0) return urlScrubbed
+
+  // Apply replacements right-to-left so byte offsets stay valid.
+  const sorted = [...hits].sort((a, b) => b.start - a.start)
+  let out = urlScrubbed
+  for (const h of sorted) {
+    out = out.slice(0, h.start) + redactedMarker(h.rule_id) + out.slice(h.end)
+  }
+  return out
+}
+
+/**
+ * `[REDACTED:<rule_id>]` when the rule_id is informative,
+ * `[REDACTED]` otherwise. The rule_id is detector-emitted, so it never
+ * contains attacker-controlled bytes — safe to embed verbatim.
+ */
+function redactedMarker(ruleId: string): string {
+  const trimmed = ruleId.replace(/^(kv|env)_/, '')
+  if (!trimmed || trimmed === 'key_value' || trimmed === 'kv_entropy') {
+    return REDACTED_MARKER
+  }
+  return `[REDACTED:${trimmed}]`
+}

--- a/telegram-plugin/tests/history.test.ts
+++ b/telegram-plugin/tests/history.test.ts
@@ -362,3 +362,62 @@ describe('getRecentOutboundCount (backstop dedup helper)', () => {
     expect(getRecentOutboundCount('-200', 2)).toBe(1)
   })
 })
+
+describe('secret redaction at persistence (both directions)', () => {
+  beforeEach(() => initHistory(stateDir, 30))
+
+  // Built by concatenation so the source never holds a contiguous
+  // secret-shaped literal (repo Push Protection / no-pii lint).
+  const SANCTUM = `19|${'qP4mN7rT2v'.repeat(4)}` // <id>|<40 base62> (Sanctum/Coolify)
+  const GH_PAT = `ghp_${'A1b2C3d4E5'.repeat(3)}` // ghp_<30 base62>
+
+  it('masks a user-pasted secret before it is stored (inbound)', () => {
+    recordInbound({
+      chat_id: '-100',
+      thread_id: null,
+      message_id: 1,
+      user: 'alice',
+      user_id: '111',
+      ts: 1000,
+      text: `the new coolify token is ${SANCTUM}, save it`,
+    })
+    const text = query({ chat_id: '-100' })[0]!.text as string
+    expect(text).not.toContain(SANCTUM)
+    expect(text).toContain('[REDACTED')
+    expect(text).toContain('the new coolify token is') // surrounding prose preserved
+  })
+
+  it('masks a secret echoed by the agent before it is stored (outbound)', () => {
+    recordOutbound({
+      chat_id: '-100',
+      thread_id: null,
+      message_ids: [2],
+      texts: [`sure — your key is ${GH_PAT}, keep it safe`],
+      ts: 2000,
+    })
+    const text = query({ chat_id: '-100' })[0]!.text as string
+    expect(text).not.toContain(GH_PAT)
+    expect(text).toContain('[REDACTED')
+  })
+
+  it('masks a secret introduced by an edit', () => {
+    recordOutbound({ chat_id: '-100', thread_id: null, message_ids: [3], texts: ['placeholder'], ts: 3000 })
+    recordEdit({ chat_id: '-100', message_id: 3, text: `token: ${SANCTUM}` })
+    const text = query({ chat_id: '-100' })[0]!.text as string
+    expect(text).not.toContain(SANCTUM)
+    expect(text).toContain('[REDACTED')
+  })
+
+  it('leaves ordinary prose untouched', () => {
+    recordInbound({
+      chat_id: '-100',
+      thread_id: null,
+      message_id: 4,
+      user: 'a',
+      user_id: '1',
+      ts: 4000,
+      text: 'hello, how are you?',
+    })
+    expect(query({ chat_id: '-100' })[0]!.text).toBe('hello, how are you?')
+  })
+})

--- a/telegram-plugin/tests/secret-detect-sanctum.test.ts
+++ b/telegram-plugin/tests/secret-detect-sanctum.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { detectSecrets } from '../secret-detect/index.js'
+import { redact } from '../secret-detect/redact.js'
+
+/**
+ * Regression for the 2026-06-01 incident: a live Laravel Sanctum / Coolify
+ * personal-access token (`<id>|<40-char base62>`, e.g. `17|aB3d…`) pasted by
+ * a USER into chat slipped every existing pattern and persisted in plaintext.
+ *
+ * Diagnosis: the inbound gate (gateway handleInbound) already runs
+ * `detectSecrets` at ingest, fail-closed, BEFORE recordInbound + IPC dispatch
+ * — so the leak was NOT an inbound bypass and NOT render-time masking. It was
+ * pure PATTERN COVERAGE: no rule matched the `<id>|<token>` shape. These tests
+ * pin the new `laravel_sanctum_token` rule and the redactor that backs both
+ * the history-store persistence (both directions) and the issues pipeline.
+ */
+
+// Build token fixtures by concatenation so the source file never contains a
+// contiguous secret-shaped literal (repo Push Protection / no-pii lint).
+const ID = '17'
+const BODY40 = 'aB3dE6fH9j'.repeat(4) // 40 base62 chars — Sanctum's Str::random(40)
+const SANCTUM = `${ID}|${BODY40}` // e.g. 17|aB3dE6fH9j…
+
+describe('laravel/coolify sanctum token detection', () => {
+  it('detects <id>|<40-char> as a high-confidence laravel_sanctum_token', () => {
+    const hits = detectSecrets(`here is the token: ${SANCTUM}`)
+    const hit = hits.find((d) => d.rule_id === 'laravel_sanctum_token')
+    expect(hit).toBeDefined()
+    expect(hit!.matched_text).toBe(SANCTUM)
+    expect(hit!.confidence).toBe('high')
+    expect(hit!.suppressed).toBe(false)
+  })
+
+  it('satisfies the exact inbound-gate predicate (high + not suppressed)', () => {
+    // This is verbatim the condition gateway handleInbound uses to decide to
+    // delete + defer-to-vault: if it is truthy, the pasted token is
+    // intercepted before recordInbound() and the IPC broadcast to the agent.
+    const detections = detectSecrets(SANCTUM)
+    const gateHit = detections.find((d) => d.confidence === 'high' && !d.suppressed)
+    expect(gateHit).toBeDefined()
+  })
+
+  it('redact() masks the token in place, preserving surrounding prose', () => {
+    const out = redact(`new token: ${SANCTUM}\nuse it for the deploy API`)
+    expect(out).not.toContain(SANCTUM)
+    expect(out).not.toContain(BODY40)
+    expect(out).toContain('[REDACTED:laravel_sanctum_token]')
+    // Surrounding prose is untouched.
+    expect(out).toContain('new token:')
+    expect(out).toContain('use it for the deploy API')
+  })
+
+  it('covers longer-than-40 token bodies', () => {
+    const longTok = `42|${'Xy7Zk2Qp9w'.repeat(6)}` // 60 base62 chars
+    const hits = detectSecrets(longTok)
+    expect(hits.find((d) => d.rule_id === 'laravel_sanctum_token')?.matched_text).toBe(longTok)
+  })
+
+  describe('false-positive guards', () => {
+    it('does NOT match a pipe-joined value under the 40-char floor', () => {
+      const short = `1|${'abcDEF123'}` // 9 chars after the pipe
+      expect(detectSecrets(short).some((d) => d.rule_id === 'laravel_sanctum_token')).toBe(false)
+    })
+
+    it('does NOT match exactly 39 base62 chars (one under the floor)', () => {
+      const justUnder = `17|${BODY40.slice(0, 39)}`
+      expect(
+        detectSecrets(justUnder).some((d) => d.rule_id === 'laravel_sanctum_token'),
+      ).toBe(false)
+    })
+
+    it('does NOT match a number with no pipe-delimited token', () => {
+      expect(
+        detectSecrets('order 17 shipped 40 items').some(
+          (d) => d.rule_id === 'laravel_sanctum_token',
+        ),
+      ).toBe(false)
+    })
+
+    it('does NOT match a spaced markdown table cell', () => {
+      // Table cells are `| value |` with spaces around the pipe; the Sanctum
+      // shape has the token immediately adjacent to the pipe.
+      const table = `| 17 | ${BODY40} |`
+      expect(
+        detectSecrets(table).some((d) => d.rule_id === 'laravel_sanctum_token'),
+      ).toBe(false)
+    })
+  })
+
+  it('suppresses a token sitting next to an example/fixture marker', () => {
+    // A documented example must not trigger a destructive delete+vault.
+    const hits = detectSecrets(`example token: ${SANCTUM}`)
+    const hit = hits.find((d) => d.rule_id === 'laravel_sanctum_token')
+    expect(hit).toBeDefined()
+    expect(hit!.suppressed).toBe(true)
+  })
+})

--- a/telegram-plugin/tests/secret-detect-sanctum.test.ts
+++ b/telegram-plugin/tests/secret-detect-sanctum.test.ts
@@ -56,6 +56,24 @@ describe('laravel/coolify sanctum token detection', () => {
     expect(hits.find((d) => d.rule_id === 'laravel_sanctum_token')?.matched_text).toBe(longTok)
   })
 
+  it('catches a token mid-sentence and masks only the token', () => {
+    const out = redact(`use ${SANCTUM} when deploying, ok?`)
+    expect(out).not.toContain(SANCTUM)
+    expect(out).toContain('use ')
+    expect(out).toContain(' when deploying, ok?')
+  })
+
+  it('catches multiple tokens in one message (redact right-to-left loop)', () => {
+    const second = `88|${'mK2pR7vT4x'.repeat(4)}` // distinct <id>|<40 base62>
+    const detected = detectSecrets(`old ${SANCTUM} new ${second}`)
+      .filter((d) => d.rule_id === 'laravel_sanctum_token')
+    expect(detected).toHaveLength(2)
+    const out = redact(`old ${SANCTUM} new ${second}`)
+    expect(out).not.toContain(SANCTUM)
+    expect(out).not.toContain(second)
+    expect(out).not.toContain(BODY40)
+  })
+
   describe('false-positive guards', () => {
     it('does NOT match a pipe-joined value under the 40-char floor', () => {
       const short = `1|${'abcDEF123'}` // 9 chars after the pipe


### PR DESCRIPTION
## Summary
A live Coolify / Laravel Sanctum API token (`<id>|<40-char base62>`, e.g. `17|aB3d…`) **pasted by a user** into chat was not redacted and persisted in plaintext. Token revoked; this closes the gap.

## Diagnosis — which of the 3 hypothesized causes were actually present
Verified by reading the inbound path (`gateway.ts handleInbound`, the `detectSecrets` gate, `recordInbound`/IPC dispatch) and the pattern engine:

| Hypothesis | Present? | Evidence |
|---|---|---|
| **Inbound vs outbound asymmetry** (redaction skips user input) | ❌ No | Inbound runs `detectSecrets` at ingest, fail-closed, **before** `recordInbound()` and the IPC broadcast; a high-confidence hit deletes the message + defers to vault and returns early. User input is **not** bypassed. (The real asymmetry is the *other* way — agent **output** had zero redaction; see fix #2.) |
| **Render-time vs ingest-time** (mask only at display) | ❌ No | Inbound detection is ingest-time, before persistence/forwarding. |
| **Pattern coverage** | ✅ **Sole cause** | No rule matched the `<id>\|<token>` shape — the Telegram rule needs a `:` separator; the rest are provider-prefixed (`sk-…`, `ghp_…`, JWT, …). `detectSecrets` returned 0 hits, so the message fell through to persist + forward. |

## Fix
1. **Add the `laravel_sanctum_token` anchored pattern** (`\b(\d+\|[A-Za-z0-9]{40,})\b`, high-confidence). The inbound gate and `redact()` share the same `detectSecrets` engine, so this one addition closes inbound interception **and** the redactor uniformly.
2. **Mask in both directions at ingest, before stored/logged/forwarded** (acceptance bullet 1). Outbound (agent→user) had *zero* redaction. Moved `redact()` into the plugin (`src/secret-detect/redact.ts` now re-exports — issues/hostd/CLI callers unchanged) and applied it at the single persistence chokepoint: `recordInbound` / `recordOutbound` / `recordEdit` in `history.ts`. No detected secret now lands in the message store in either direction — a backstop behind the inbound gate, and the only scrub on the agent-output direction.

## Why
The redaction system is the control that's supposed to prevent exactly this. The inbound gate was sound; it just lacked the pattern. Adding it (plus the both-directions persistence backstop) restores the guarantee.

## Test plan
- [x] `telegram-plugin/tests/secret-detect-sanctum.test.ts` (new) — `17|<40>` detected high-confidence as `laravel_sanctum_token`; **satisfies the exact inbound-gate predicate** (`confidence==='high' && !suppressed`); masked by `redact()`; false-positive guards (under-40 floor, 39-char, no-pipe, spaced markdown table cell); example-marker suppression.
- [x] `telegram-plugin/tests/history.test.ts` (extended) — `recordInbound`/`recordOutbound`/`recordEdit` mask a secret before storage (**both directions**); ordinary prose untouched.
- [x] `src/secret-detect/redact.test.ts` + `tests/issues.redact-detail.test.ts` green (re-export is behavior-preserving; issues pipeline + `bin/run-hook.sh` e2e pass against a fresh build).
- [x] Full `secret-detect` vitest cluster: 123 passed (no regressions). `history.test.ts` under bun: 33 passed.
- [x] `npm run lint` clean (tsc, plugin-references, bot-api-wrapping, bun-test-imports, no-pii-secrets, vault-hermeticity, no-broadcast-delivery). Token fixtures built by concatenation (no contiguous secret literal).

## Risk
Low. The pattern is anchored + length-floored (40) to avoid false positives; suppressor still demotes documented examples. The redactor move is a re-export (existing callers + tests unchanged). The history-store masking only alters text that contains a *detected* secret — ordinary messages pass through byte-identical.

## Out of scope (flagged — recommend separate tickets)
- **Outbound transport masking**: masking agent output in the live **send/stream** path (before bytes reach Telegram). Storage/logging is covered here; the streaming/progress-card hot path is load-bearing and warrants its own PR + UAT.
- **Upstream design flaw**: an agent (Clerk) asked the user to paste a raw secret because the vault entry was empty. The right fix is a secure **save-card → vault** flow that never echoes the value. Separate ticket. This PR limits the blast radius: such a paste is now caught + deleted + offered for vaulting even when the agent prompts for it.

JTBD: *you-hold-the-leash* / *subscription-honest* — secrets the operator handles over the channel must never persist in plaintext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)