### PR TITLE
feat(secret-detect): mask agent-echoed secrets in outbound transport path

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8211,6 +8211,14 @@ function handleSessionEvent(ev: SessionEvent): void {
         const backstopThreadId = threadId
         const backstopCtrl = ctrl
 
+        // Outbound secret scrub (#2044). Turn-flush delivers the model's
+        // terminal answer prose when it skipped reply/stream_reply — that
+        // is arbitrary agent free-text, sent via sendMessage/editMessageText
+        // and previewed to stderr below, so it needs the same mask as the
+        // three reply tools. Mirror the voice scrub: mask before the send,
+        // the preview, and recordOutbound.
+        capturedText = redactOutboundText(capturedText, 'turn_flush')
+
         // Voice scrub (PR #1683 follow-up). Turn-flush is the path
         // that fires when the model emits raw transcript text WITHOUT
         // calling reply / stream_reply. That captured text bypasses

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -355,6 +355,7 @@ import { defaultVaultWrite, defaultVaultList, defaultVaultWritePosture } from '.
 import { parseVaultCliError, renderVaultCliError } from '../secret-detect/vault-error.js'
 import { recentDenialsFromAuditLog, type RecentDenial } from './recent-denials.js'
 import { detectSecrets } from '../secret-detect/index.js'
+import { redact } from '../secret-detect/redact.js'
 import { classifyAdminGate } from '../admin-commands/index.js'
 import {
   startSubagentWatcher,
@@ -5170,6 +5171,32 @@ async function executeUpdateChecklist(args: Record<string, unknown>): Promise<{ 
   return { content: [{ type: 'text', text: `checklist updated (id: ${message_id})` }] }
 }
 
+/**
+ * Outbound secret scrub (#2044). The agent is trusted, but it can still
+ * echo a secret it read from a file, env, or a not-yet-vaulted value into
+ * a reply — and outbound text had no redaction at all. This masks any
+ * detected secret in agent-authored text BEFORE it is logged (the stderr
+ * previews), forwarded (sent to Telegram), or stored (recordOutbound).
+ *
+ * It runs the SAME `detectSecrets` engine as the inbound gate, so a
+ * pattern added once (e.g. the Sanctum `<id>|<token>` shape, #2043) covers
+ * both directions. Applied at the entry of every agent-free-text tool
+ * (reply / stream_reply / edit_message), mutating the text in place so all
+ * downstream consumers — voice scrub, dedup key, chunker, answer-stream
+ * diffing, history record — see the masked value. This is the same
+ * in-place-mutation contract the voice scrub already relies on, which
+ * keeps the answer-stream's incremental edit diffing consistent (it always
+ * compares redacted-against-redacted).
+ */
+function redactOutboundText(text: string, site: string): string {
+  const masked = redact(text)
+  if (masked !== text) {
+    // Never log the secret — only that a mask fired, and where.
+    process.stderr.write(`telegram gateway: outbound secret masked site=${site}\n`)
+  }
+  return masked
+}
+
 async function executeReply(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
   // #1664 — pin the turn this reply belongs to at entry. The
   // finalAnswerDelivered write near the end of this function runs after
@@ -5183,6 +5210,11 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   const rawText = args.text as string | undefined
   if (rawText == null || rawText === '') throw new Error('reply: text is required and cannot be empty')
   let text = repairEscapedWhitespace(rawText)
+  // Outbound secret scrub (#2044): mask any secret the agent echoed BEFORE
+  // the stderr preview below, the dedup key, the send, and the history
+  // record. Mutates `text` so every downstream consumer sees the masked
+  // value, exactly like the voice scrub that follows.
+  text = redactOutboundText(text, 'reply')
   // Voice scrub (#1683): replace em / en dashes with commas / periods.
   // Runs BEFORE outboundDedup so retries see the scrubbed key, and
   // BEFORE markdownToHtml so code-block content is correctly parked
@@ -5934,6 +5966,12 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   const turn = currentTurn
   if (!args.chat_id) throw new Error('stream_reply: chat_id is required')
   if (args.text == null || args.text === '') throw new Error('stream_reply: text is required and cannot be empty')
+
+  // Outbound secret scrub (#2044): mask before the dedup key, the draft
+  // stream sends, and the history record. stream_reply carries the FULL
+  // text-so-far on every call, so redacting each call keeps the answer-
+  // stream's incremental diffing comparing redacted-against-redacted.
+  args.text = redactOutboundText(args.text as string, 'stream_reply')
 
   // Voice scrub (PR #1683 follow-up). Modern Claude on the fleet
   // uses the answer-stream / draft-stream path for multi-paragraph
@@ -6991,6 +7029,9 @@ async function executeEditMessage(args: Record<string, unknown>): Promise<unknow
   const editConfigMode = editAccess.parseMode ?? 'html'
   const editFormat = (args.format as string | undefined) ?? editConfigMode
   let editRawText = repairEscapedWhitespace(args.text as string)
+  // Outbound secret scrub (#2044): an edit must not re-introduce a raw
+  // secret into a live bubble or the history row. Mask before scrub/send.
+  editRawText = redactOutboundText(editRawText, 'edit_message')
   // Voice scrub (#1683): same em-dash scrub as the reply path. Edits
   // are how silent-anchor and progress-update mutate already-sent
   // bubbles, so without this an edit can re-introduce dashes the

--- a/telegram-plugin/tests/gateway-outbound-redact.test.ts
+++ b/telegram-plugin/tests/gateway-outbound-redact.test.ts
@@ -61,6 +61,15 @@ describe('gateway outbound secret-scrub — structural wiring', () => {
     expect(scrubIdx).toBeGreaterThan(redactIdx)
   })
 
+  it('turn-flush backstop: scrubs the model terminal prose before send', () => {
+    // Turn-flush delivers the model's answer when it skipped reply/stream_reply
+    // — arbitrary agent free-text that hits the wire + stderr preview.
+    const redactIdx = src.indexOf(`redactOutboundText(capturedText, 'turn_flush')`)
+    const scrubSiteIdx = src.indexOf(`site: 'turn_flush'`)
+    expect(redactIdx).toBeGreaterThan(0)
+    expect(scrubSiteIdx).toBeGreaterThan(redactIdx) // mask BEFORE the voice scrub + send
+  })
+
   it('does not log the secret value when a mask fires', () => {
     const idx = src.indexOf('function redactOutboundText(')
     const body = src.slice(idx, idx + 400)

--- a/telegram-plugin/tests/gateway-outbound-redact.test.ts
+++ b/telegram-plugin/tests/gateway-outbound-redact.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * Structural test for the outbound secret-scrub (#2044).
+ *
+ * Outbound (agent→user) text previously had NO redaction — an agent that
+ * echoed a secret it read from a file/env/not-yet-vaulted value would send
+ * the raw bytes to Telegram, log a preview to stderr, and store them in
+ * history. This pins that `redactOutboundText()` runs at the ENTRY of each
+ * agent-free-text tool (reply / stream_reply / edit_message), before the
+ * stderr preview, the dedup key, the send, and the history record.
+ *
+ * Why structural: executeReply/executeStreamReply/executeEditMessage are
+ * not exported (same constraint as gateway-secret-detect.test.ts). The
+ * masking itself — that `redact()` covers the Sanctum shape and every
+ * provider token — is exercised behaviorally in secret-detect-sanctum.test.ts
+ * and the redact() unit tests; what's left to pin here is the wiring + slot.
+ */
+describe('gateway outbound secret-scrub — structural wiring', () => {
+  const src = readFileSync(
+    new URL('../gateway/gateway.ts', import.meta.url),
+    'utf8',
+  )
+
+  it('imports the shared redactor', () => {
+    expect(src).toMatch(/import \{ redact \} from '\.\.\/secret-detect\/redact\.js'/)
+  })
+
+  it('defines the redactOutboundText helper backed by redact()', () => {
+    const idx = src.indexOf('function redactOutboundText(')
+    expect(idx).toBeGreaterThan(0)
+    const body = src.slice(idx, idx + 400)
+    expect(body).toMatch(/redact\(text\)/)
+  })
+
+  it('reply: scrubs at entry, before the stderr preview log', () => {
+    const start = src.indexOf('async function executeReply(')
+    const redactIdx = src.indexOf(`redactOutboundText(text, 'reply')`, start)
+    const previewIdx = src.indexOf('reply: invoked chatId=', start)
+    expect(start).toBeGreaterThan(0)
+    expect(redactIdx).toBeGreaterThan(start)
+    expect(previewIdx).toBeGreaterThan(redactIdx) // mask BEFORE the preview is logged
+  })
+
+  it('stream_reply: scrubs at entry, before the voice scrub + dedup', () => {
+    const start = src.indexOf('async function executeStreamReply(')
+    const redactIdx = src.indexOf(`redactOutboundText(args.text as string, 'stream_reply')`, start)
+    const scrubIdx = src.indexOf(`site: 'stream_reply'`, start)
+    expect(start).toBeGreaterThan(0)
+    expect(redactIdx).toBeGreaterThan(start)
+    expect(scrubIdx).toBeGreaterThan(redactIdx)
+  })
+
+  it('edit_message: scrubs at entry, before the voice scrub + send', () => {
+    const start = src.indexOf('async function executeEditMessage(')
+    const redactIdx = src.indexOf(`redactOutboundText(editRawText, 'edit_message')`, start)
+    const scrubIdx = src.indexOf(`site: 'edit_message'`, start)
+    expect(start).toBeGreaterThan(0)
+    expect(redactIdx).toBeGreaterThan(start)
+    expect(scrubIdx).toBeGreaterThan(redactIdx)
+  })
+
+  it('does not log the secret value when a mask fires', () => {
+    const idx = src.indexOf('function redactOutboundText(')
+    const body = src.slice(idx, idx + 400)
+    // The log line names the site, never the text/masked value.
+    expect(body).toMatch(/outbound secret masked site=\$\{site\}/)
+    expect(body).not.toMatch(/\$\{text\}|\$\{masked\}/)
+  })
+})


### PR DESCRIPTION
Closes #2044. Follow-up to #2043.

## Summary
#2043 closed the inbound leak (pattern coverage) and added **storage-layer** masking in both directions (`history.ts`). This adds the missing piece: masking agent-authored text on the **live outbound transport path**, before it reaches Telegram or the stderr preview log.

## Why
Outbound (agent→user) text had **zero** redaction. A trusted agent can still echo a secret it read from a file, env, or a not-yet-vaulted value into a reply — it would hit Telegram and the stderr preview *before* the #2043 storage mask ever saw it.

## What
`redactOutboundText()` (backed by the shared `redact()` / `detectSecrets` engine — same patterns as the inbound gate, so the Sanctum `<id>|<token>` shape from #2043 is already covered) at the entry of every agent-free-text tool:
- `reply` (`executeReply`)
- `stream_reply` (`executeStreamReply`)
- `edit_message` (`executeEditMessage`)

It **mutates the text in place** — the exact contract the existing voice scrub relies on — so every downstream consumer (stderr preview, #546 dedup key, chunker, answer-stream incremental diffing, history record) sees the masked value. `stream_reply` carries the full text-so-far on every call, and the mask is applied at entry on every call, so the answer-stream's incremental `editMessageText` diffing stays consistent (redacted-vs-redacted). A mask firing logs `outbound secret masked site=<tool>` (never the value).

## Test plan
- [x] `telegram-plugin/tests/gateway-outbound-redact.test.ts` (new, 6) — pins the import, the helper, and that the scrub runs at each handler's entry **before** the preview/scrub/send (structural — handlers aren't exported, same constraint as `gateway-secret-detect.test.ts`).
- [x] Masking behavior covered by `redact()` unit tests + `secret-detect-sanctum.test.ts`.
- [x] `tsc --noEmit` + full `npm run lint` clean (incl. `check-bot-api-wrapping` — no allowlist drift).
- [ ] **UAT pending (operator-gated):** mtcute streaming scenario to confirm no progress-card / draft-stream regression before fleet rollout. The in-place-mutation contract matches the proven voice-scrub pattern, so risk is low, but a streaming UAT pass is the rollout gate.

## Risk
Low-to-medium. Touches the streaming hot path, but only sanitizes the text string at entry using the same mutate-in-place pattern the voice scrub already uses (no control-flow change). `redact()` masks all detections (incl. suppressed/ambiguous) — for the agent-output direction that's the safe default; a documented token-format example in agent prose would be masked.

## Scope
Covers the three deliberate agent-output tools. Framework backstop/turn-flush emitters inherit storage masking via #2043's `recordOutbound`; their transport coverage is a smaller residual (they emit session-derived text, not arbitrary agent free-text).

JTBD: *you-hold-the-leash* / *subscription-honest* — secrets must never leave the box in plaintext, in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)