### PR TITLE
feat(telegram): agent-voiced "continuing" message on permission verdicts

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -372,7 +372,7 @@ import { maybeRenderUpdateAnnouncement } from './update-announce.js'
 import { createIssuesCardHandle, type IssuesCardHandle } from '../issues-card.js'
 import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.js'
 import { list as listIssues, resolve as resolveIssue } from '../../src/issues/index.js'
-import { formatPermissionCardBody, describeGrant } from '../permission-title.js'
+import { formatPermissionCardBody, describeGrant, naturalAction, formatPermissionResumeMessage } from '../permission-title.js'
 import { resolveScopedAllowChoices, isRulePersisted } from '../permission-rule.js'
 import { synthesizeAllowRuleDiff, extractAddedAllowRule } from '../permission-diff.js'
 import {
@@ -2159,6 +2159,60 @@ function resumeReactionAfterVerdict(): void {
     ?.setThinking()
 }
 
+/**
+ * Post the agent-voiced "got your verdict — continuing" message the
+ * instant the operator answers a permission card. Travels right beside
+ * `resumeReactionAfterVerdict()` at every operator-driven verdict site so
+ * the legible signal (a distinct message naming the work) can't drift away
+ * from the reaction flip — the same 5-paths-drift hazard #2019 guards.
+ *
+ * The card edit + 🙏→working reaction are easy to miss (a reaction lands on
+ * the turn's triggering message far up the chat; the card footnote is a
+ * one-liner). This message is the thing the operator actually sees.
+ *
+ * Posts to the suspended turn's chat/thread (`currentTurn` still points at
+ * it mid-gate — the same controller `resumeReactionAfterVerdict` addresses)
+ * so it lands in the conversation the gate belongs to; falls back to the
+ * configured operator chats when there's no active turn (e.g. a swept turn
+ * at TTL-sweep time). Kill-switch: `SWITCHROOM_RESUME_MSG=0`.
+ */
+function postPermissionResumeMessage(opts: {
+  behavior: 'allow' | 'deny'
+  action: string
+  timeoutMinutes?: number
+}): void {
+  if (process.env.SWITCHROOM_RESUME_MSG === '0') return
+  const text = formatPermissionResumeMessage({
+    agentName: process.env.SWITCHROOM_AGENT_NAME ?? null,
+    behavior: opts.behavior,
+    action: opts.action,
+    timeoutMinutes: opts.timeoutMinutes,
+  })
+  const turn = currentTurn
+  const targets: Array<{ chatId: string; threadId: number | undefined }> =
+    turn != null
+      ? [{ chatId: turn.sessionChatId, threadId: turn.sessionThreadId }]
+      : loadAccess().allowFrom.map(chatId => ({
+          chatId,
+          threadId: resolveAgentOutboundTopic({
+            kind: 'permission',
+            turnInitiated: false,
+            originThreadId: undefined,
+          }),
+        }))
+  for (const { chatId, threadId } of targets) {
+    // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy); thread-aware send
+    void swallowingApiCall(
+      () =>
+        bot.api.sendMessage(chatId, text, {
+          parse_mode: 'HTML',
+          ...(threadId != null ? { message_thread_id: threadId } : {}),
+        }),
+      { chat_id: chatId, verb: 'permission-resume', ...(threadId != null ? { threadId } : {}) },
+    )
+  }
+}
+
 function resolveThreadId(chat_id: string, explicit?: string | number | null): number | undefined {
   if (explicit != null) return Number(explicit)
   return chatThreadMap.get(chat_id)
@@ -3067,6 +3121,11 @@ const pendingStateReaper = setInterval(() => {
       // The auto-deny un-parks the suspended turn — flip 🙏 → working so
       // it doesn't sit on the awaiting glyph (or stall) after the timeout.
       resumeReactionAfterVerdict()
+      postPermissionResumeMessage({
+        behavior: 'deny',
+        action: naturalAction(v.tool_name, v.input_preview),
+        timeoutMinutes: Math.round(PERMISSION_TTL_MS / 60000),
+      })
       process.stderr.write(
         `telegram gateway: permission TTL expired — auto-deny request=${k} ` +
         `tool=${v.tool_name} (no operator response in ` +
@@ -9265,6 +9324,11 @@ async function handleInbound(
       behavior,
     })
     resumeReactionAfterVerdict()
+    const ftDetails = pendingPermissions.get(request_id)
+    postPermissionResumeMessage({
+      behavior,
+      action: ftDetails ? naturalAction(ftDetails.tool_name, ftDetails.input_preview) : '',
+    })
     if (msgId != null) {
       const emoji = behavior === 'allow' ? '✅' : '❌'
       void bot.api.setMessageReaction(chat_id, msgId, [
@@ -12158,6 +12222,10 @@ async function handlePermissionSlash(ctx: Context, behavior: 'allow' | 'deny'): 
   // Forward to connected bridges — same IPC the button handler uses.
   dispatchPermissionVerdict({ type: 'permission', requestId: request_id, behavior })
   resumeReactionAfterVerdict()
+  postPermissionResumeMessage({
+    behavior,
+    action: naturalAction(details.tool_name, details.input_preview),
+  })
   pendingPermissions.delete(request_id)
   process.stderr.write(
     `[telegram gateway] slash-${behavior} request_id=${request_id} tool=${details.tool_name} by=${senderId}\n`,
@@ -15812,6 +15880,10 @@ bot.on('callback_query:data', async ctx => {
     // below). Un-park 🙏 → working immediately so the operator sees the
     // agent continue while hostd writes the durable rule.
     resumeReactionAfterVerdict()
+    postPermissionResumeMessage({
+      behavior: 'allow',
+      action: naturalAction(details.tool_name, details.input_preview),
+    })
 
     // (3) Decide the persistence path. tryHostdDispatch returns
     // "not-configured" when host_control is disabled or the per-agent
@@ -15963,18 +16035,20 @@ bot.on('callback_query:data', async ctx => {
     return
   }
 
-  // Forward permission decision to connected bridges
+  // Forward permission decision to connected bridges. Capture the work
+  // phrase BEFORE deleting the pending entry — postPermissionResumeMessage
+  // (fired in synthInbound below) names the resumed work.
+  const resumeAction = (() => {
+    const d = pendingPermissions.get(request_id)
+    return d ? naturalAction(d.tool_name, d.input_preview) : ''
+  })()
   pendingPermissions.delete(request_id)
-  // Deterministic "▶️ resuming…" beat (framework-posted, not model text):
-  // the verdict un-parks the suspended turn, so confirm to the operator
-  // that the agent received it and is continuing — closing the "is it
-  // working or did my tap do nothing?" gap. Allow and deny both resume the
-  // turn (deny just hands claude a refusal it then handles).
-  const resumeAgent = process.env.SWITCHROOM_AGENT_NAME
-  const resumeBeat = resumeAgent
-    ? `▶️ ${escapeHtmlForTg(resumeAgent)} resuming…`
-    : '▶️ resuming…'
-  const label = `${behavior === 'allow' ? '✅ Allowed' : '❌ Denied'} · ${resumeBeat}`
+  // The card collapses to a plain verdict label. The distinct agent-voiced
+  // "got it, continuing: …" message (posted on resume below) now carries
+  // the "is it working or did my tap do nothing?" signal the old
+  // `▶️ resuming…` card footnote used to — and names the work, which the
+  // footnote never did. Keeps the card terse and the resume legible.
+  const label = behavior === 'allow' ? '✅ Allowed' : '❌ Denied'
   // HTML-escape the source text — same hazard as the scope-commit and
   // recent-denial paths above. The permission card body
   // (formatPermissionCardBody) appends claude-supplied `description`
@@ -16005,6 +16079,10 @@ bot.on('callback_query:data', async ctx => {
       // Un-park the status reaction: 🙏 → working, re-arming the stall
       // watchdog that setAwaiting() suspended.
       resumeReactionAfterVerdict()
+      postPermissionResumeMessage({
+        behavior: behavior as 'allow' | 'deny',
+        action: resumeAction,
+      })
     },
   })
 })

--- a/telegram-plugin/permission-title.ts
+++ b/telegram-plugin/permission-title.ts
@@ -248,6 +248,54 @@ export function describeGrant(
   }
 }
 
+/**
+ * Agent-voiced "I got your verdict and I'm continuing" message, posted as
+ * a *distinct* Telegram message the instant the operator answers a
+ * permission card (allow / deny / always / slash / free-text). The card
+ * edit + status reaction are easy to miss — a reaction lands on the turn's
+ * triggering message far up the chat, and the card footnote is a one-liner
+ * the operator scrolls past — so this is the legible signal that the tap
+ * landed and names the work being (re)started.
+ *
+ * Mirrors `formatPermissionCardBody`'s style ("🔐 <b>Gymbro</b> wants to
+ * edit: log.md" → "▶️ <b>Gymbro</b> — got it, continuing: edit: log.md").
+ * `action` is a phrase from {@link naturalAction} (already operator-facing,
+ * no tool ids). Output is HTML-escaped for `parse_mode: 'HTML'`.
+ *
+ * `timeoutMinutes` marks the TTL auto-deny variant (no operator tapped —
+ * the request aged out) so the wording reflects "no answer" rather than a
+ * deliberate denial.
+ */
+export function formatPermissionResumeMessage(opts: {
+  agentName: string | null;
+  behavior: "allow" | "deny";
+  action: string;
+  timeoutMinutes?: number;
+}): string {
+  const who =
+    opts.agentName && opts.agentName.length > 0
+      ? `<b>${escapeTgHtml(capFirst(opts.agentName))}</b>`
+      : `<b>Agent</b>`;
+  const act = (opts.action ?? "").trim();
+  const hasAction = act.length > 0;
+
+  if (opts.behavior === "allow") {
+    return hasAction
+      ? `▶️ ${who} — got it, continuing: <i>${escapeTgHtml(act)}</i>`
+      : `▶️ ${who} — got it, back to work.`;
+  }
+
+  // deny
+  if (opts.timeoutMinutes != null) {
+    return hasAction
+      ? `🚫 ${who} — no answer in ${opts.timeoutMinutes}m, continuing without it (<i>${escapeTgHtml(act)}</i>).`
+      : `🚫 ${who} — no answer in ${opts.timeoutMinutes}m, continuing without it.`;
+  }
+  return hasAction
+    ? `🚫 ${who} — noted, I won't ${escapeTgHtml(lowerFirst(act))}. Continuing without it.`
+    : `🚫 ${who} — noted, continuing without it.`;
+}
+
 function resolveSkillName(input: Record<string, unknown>): string | null {
   return (
     readString(input, "skill") ??

--- a/telegram-plugin/tests/permission-title.test.ts
+++ b/telegram-plugin/tests/permission-title.test.ts
@@ -12,6 +12,7 @@ import {
   naturalAction,
   describeGrant,
   formatPermissionCardBody,
+  formatPermissionResumeMessage,
 } from '../permission-title.js'
 import type { ScopeOption } from '../permission-rule.js'
 
@@ -191,5 +192,72 @@ describe('describeGrant — phrased from the chosen scope', () => {
     expect(describeGrant('mcp__perplexity__search', undefined, opt('mcp__perplexity__search'))).toBe(
       'search the web (Perplexity)',
     )
+  })
+})
+
+describe('formatPermissionResumeMessage — agent-voiced verdict ack', () => {
+  test('allow names the work it is resuming', () => {
+    expect(
+      formatPermissionResumeMessage({
+        agentName: 'gymbro',
+        behavior: 'allow',
+        action: 'edit: supplement-log.md',
+      }),
+    ).toBe('▶️ <b>Gymbro</b> — got it, continuing: <i>edit: supplement-log.md</i>')
+  })
+
+  test('deny names what it will skip, lower-cased inline', () => {
+    expect(
+      formatPermissionResumeMessage({
+        agentName: 'ziggy',
+        behavior: 'deny',
+        action: 'Search the web',
+      }),
+    ).toBe("🚫 <b>Ziggy</b> — noted, I won't search the web. Continuing without it.")
+  })
+
+  test('TTL auto-deny variant reads as a timeout, not a tap', () => {
+    expect(
+      formatPermissionResumeMessage({
+        agentName: 'finn',
+        behavior: 'deny',
+        action: 'run: deploy.sh',
+        timeoutMinutes: 5,
+      }),
+    ).toBe('🚫 <b>Finn</b> — no answer in 5m, continuing without it (<i>run: deploy.sh</i>).')
+  })
+
+  test('HTML-escapes a hostile action phrase (no raw </>& injection)', () => {
+    const out = formatPermissionResumeMessage({
+      agentName: 'clerk',
+      behavior: 'allow',
+      action: 'run: echo <b>&"pwned"</b>',
+    })
+    expect(out).toContain('&lt;b&gt;&amp;')
+    expect(out).not.toContain('<b>&"pwned"')
+  })
+
+  test('cap-first on the agent name', () => {
+    const out = formatPermissionResumeMessage({
+      agentName: 'lawgpt',
+      behavior: 'allow',
+      action: 'read: contract.pdf',
+    })
+    expect(out).toContain('<b>Lawgpt</b>')
+  })
+
+  test('empty action falls back to a generic continue (no dangling phrase)', () => {
+    expect(
+      formatPermissionResumeMessage({ agentName: 'carrie', behavior: 'allow', action: '' }),
+    ).toBe('▶️ <b>Carrie</b> — got it, back to work.')
+    expect(
+      formatPermissionResumeMessage({ agentName: 'carrie', behavior: 'deny', action: '   ' }),
+    ).toBe('🚫 <b>Carrie</b> — noted, continuing without it.')
+  })
+
+  test('null agent name degrades to a neutral "Agent" label', () => {
+    expect(
+      formatPermissionResumeMessage({ agentName: null, behavior: 'allow', action: 'edit: x.md' }),
+    ).toBe('▶️ <b>Agent</b> — got it, continuing: <i>edit: x.md</i>')
   })
 })

--- a/telegram-plugin/tests/permission-verdict-resume-guard.test.ts
+++ b/telegram-plugin/tests/permission-verdict-resume-guard.test.ts
@@ -22,6 +22,12 @@
  * This guard fails loudly if any `dispatchPermissionVerdict(...)`
  * callsite is not paired with a `resumeReactionAfterVerdict()` within a
  * few lines — i.e. a new (or refactored) verdict path drops the resume.
+ *
+ * Same pin applies to `postPermissionResumeMessage(...)`: the distinct
+ * agent-voiced "got it, continuing: <work>" message is the legible signal
+ * the operator actually sees (the reaction lands on a far-up message; the
+ * card edit is a one-liner). It rides the exact same 5-paths-drift hazard,
+ * so every verdict path must post it too.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -82,5 +88,34 @@ describe('permission verdict → resume reaction wiring', () => {
     expect(/function\s+resumeReactionAfterVerdict\s*\(/.test(GATEWAY_SRC)).toBe(
       true,
     )
+  })
+
+  // postPermissionResumeMessage rides ~1–2 lines after resumeReactionAfterVerdict
+  // on every path, so it can sit a touch further from the dispatch than the
+  // resume call — give it a little more headroom.
+  const POST_WINDOW = 20
+
+  it('every dispatchPermissionVerdict() callsite posts the agent-voiced resume message via postPermissionResumeMessage()', () => {
+    const unpaired: number[] = []
+    for (const idx of dispatchCallsites) {
+      const window = LINES.slice(idx, idx + POST_WINDOW + 1).join('\n')
+      if (!/\bpostPermissionResumeMessage\s*\(/.test(window)) {
+        unpaired.push(idx + 1)
+      }
+    }
+    expect(
+      unpaired,
+      `dispatchPermissionVerdict() at gateway.ts line(s) ` +
+        `${unpaired.join(', ')} has no postPermissionResumeMessage() within ` +
+        `${POST_WINDOW} lines — that verdict path resumes the turn silently, ` +
+        `so the operator never gets the "got it, continuing: <work>" message. ` +
+        `Add the post call next to resumeReactionAfterVerdict() (see sibling paths).`,
+    ).toEqual([])
+  })
+
+  it('the resume-message helper still exists', () => {
+    expect(
+      /function\s+postPermissionResumeMessage\s*\(/.test(GATEWAY_SRC),
+    ).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

When the operator answers a permission card (skill / MCP / secret tool gate), the agent now posts a **distinct, agent-styled message the instant the verdict lands** — naming the actual work:

- **Allow:** `▶️ <b>Ziggy</b> — got it, continuing: <i>edit: supplement-log.md</i>`
- **Deny:** `🚫 <b>Ziggy</b> — noted, I won't edit: supplement-log.md. Continuing without it.`

One operator tap → exactly one ack message.

## Why

The v0.14.18 / #2011 resume signal — a 🙏→working reaction + a `▶️ resuming…` card footnote — is wired correctly and deployed fleet-wide, but it's **imperceptible**:

1. The 🙏 reaction lands on the turn's *triggering message* (far up the chat), not the card.
2. The `▶️ resuming…` footnote is a one-liner shown **only on Allow-once / Deny** — the common **🔁 Always** tap shows grant-confirmation text with no resume beat — and it **names no work**.

So tapping Allow reads as "nothing happened." This adds the legible, work-naming signal the operator actually sees. (Diagnosis confirmed against the live v0.14.26 fleet: the wiring fires; it's just invisible by design.)

## What changed

- **`permission-title.ts`** — new pure builder `formatPermissionResumeMessage()` (sibling to `formatPermissionCardBody` / `describeGrant`; HTML-escaped via the same path). Reuses `naturalAction()` for the work phrase, so "wants to X" → "got it, continuing: X" is symmetric.
- **`gateway.ts`** — new `postPermissionResumeMessage()` called beside `resumeReactionAfterVerdict()` at **all 5 verdict paths** (button, 🔁 Always `asn`/`asb`, `/allow`·`/deny` slash, free-text `y`/`no`, TTL auto-deny). Posts to the suspended turn's chat/thread; routed through `swallowingApiCall` (retry policy, thread-aware). TTL auto-deny gets a timeout-worded variant.
- Button card edit simplified from `✅ Allowed · ▶️ resuming…` to just `✅ Allowed` — the new message now owns the resume signal.
- **Kill-switch:** `SWITCHROOM_RESUME_MSG=0` (default on) — instant revert without a code change.

## Test plan

- [x] `vitest run permission-title.test.ts permission-verdict-resume-guard.test.ts` — 36 pass (7 new builder cases: allow/deny/timeout/HTML-escape/cap-first/empty-action/null-agent).
- [x] Guard test **extended**: every `dispatchPermissionVerdict()` callsite must also pair with `postPermissionResumeMessage()` within 20 lines — same 5-paths-drift pin as #2019.
- [x] `tsc --noEmit` clean; `check-bot-api-wrapping.sh` clean (inline `// allow-raw-bot-api` marker, no allowlist drift); `check-plugin-references.mjs` clean.
- [x] Adjacent suites green: `status-reactions`, `always-allow-grant`, `finalize-callback` (58 pass).
- [ ] Canary on test-harness — message is a normal Telegram message (observable, unlike reactions): tap Allow → confirm `▶️ … got it, continuing: …` bubble; repeat Deny + 🔁 Always. Then one real human DM round-trip before fleet rollout.

## Risk

Low. Additive message + a card-text simplification; no change to verdict plumbing, persistence, `turn_end`, or the reaction state machine. Kill-switch backstops if it reads as noise.

**Known tradeoff:** a turn that hits many permission prompts posts one message per operator tap. Bounded by actual taps (always-allow caches the rule so matching calls don't re-prompt, #1138); kill-switch available if noisy.

## JTBD

`know-what-my-agent-is-doing` — "I tapped Allow; the agent got it and is doing X" is now a message you can't miss, not a reaction + footnote that read as silence.