### PR TITLE
fix(telegram): worker card leaks raw ## markdown + multi-line steps

### DIFF
--- a/telegram-plugin/card-format.ts
+++ b/telegram-plugin/card-format.ts
@@ -85,10 +85,13 @@ export function stripMarkdown(s: string): string {
   out = out.replace(/\*(.+?)\*/g, '$1');
   out = out.replace(/(?<![A-Za-z0-9])_(.+?)_(?![A-Za-z0-9])/g, '$1');
   // Leading block markup: heading, blockquote, bullet, ordered item.
-  out = out.replace(/^\s{0,3}#{1,6}\s+/, '');
-  out = out.replace(/^\s{0,3}>\s?/, '');
-  out = out.replace(/^\s{0,3}[-*+]\s+/, '');
-  out = out.replace(/^\s{0,3}\d+[.)]\s+/, '');
+  // `gm` so the markers are stripped on EVERY line, not just the string
+  // start — a multi-line summary like "Done.\n\n## Summary\n…" must not
+  // leak a raw `## Summary` when rendered as a single card step.
+  out = out.replace(/^\s{0,3}#{1,6}\s+/gm, '');
+  out = out.replace(/^\s{0,3}>\s?/gm, '');
+  out = out.replace(/^\s{0,3}[-*+]\s+/gm, '');
+  out = out.replace(/^\s{0,3}\d+[.)]\s+/gm, '');
   // Residual unpaired bold markers (a lone `*` is left alone so `3 * 4`
   // survives; only the doubled form is markup-by-construction).
   out = out.replace(/\*\*/g, '');

--- a/telegram-plugin/tests/card-format.test.ts
+++ b/telegram-plugin/tests/card-format.test.ts
@@ -27,6 +27,22 @@ describe('stripMarkdown', () => {
     expect(stripMarkdown('2) second')).toBe('second')
   })
 
+  it('strips leading block markup on EVERY line, not just the string start', () => {
+    // The screenshot regression: a worker summary that opens with prose
+    // ("Done.") then a `## Summary` heading mid-string. Without the `gm`
+    // flags the heading marker leaked into the rendered card.
+    const headed = stripMarkdown('Done.\n\n## Summary\n\nFixed the bug')
+    expect(headed).not.toContain('##')
+    expect(headed).toContain('Done.')
+    expect(headed).toContain('Summary')
+    expect(headed).toContain('Fixed the bug')
+
+    const mixed = stripMarkdown('intro\n> quoted\n- item')
+    expect(mixed).not.toMatch(/(^|\n)\s*[>\-*]/)
+    expect(mixed).toContain('quoted')
+    expect(mixed).toContain('item')
+  })
+
   it('reduces a link to its label', () => {
     expect(stripMarkdown('see [the PR](https://x/y) here')).toBe('see the PR here')
   })

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -187,6 +187,21 @@ describe('renderWorkerActivity', () => {
     expect(done).not.toMatch(/(^|\n)\s*-{3,}\s*(\n|$)/)
   })
 
+  it('renders a multi-line narrative entry as one clean step (no raw ## leak)', () => {
+    // Screenshot regression: a running-card step whose narrative entry is
+    // itself multi-line ("Done.\n\n## Summary\n…"). The heading marker must
+    // not leak and the step must collapse to a single visual line.
+    const out = renderWorkerActivity(
+      view({
+        narrativeLines: ['Done.\n\n## Summary\n\nFixed the bug where a bad password logged you out'],
+        latestSummary: '',
+      }),
+    )
+    expect(out).not.toContain('## Summary')
+    expect(out).not.toContain('\n\n')
+    expect(out).toContain('Done. Summary Fixed the bug where a bad password logged you out')
+  })
+
   it('escapes HTML inside narrative lines', () => {
     const out = renderWorkerActivity(view({ narrativeLines: ['a <b>x</b> & y'] }))
     expect(out).toContain('a &lt;b&gt;x&lt;/b&gt; &amp; y')

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -147,7 +147,10 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
   const finished = v.state === 'done' || v.state === 'failed'
 
   const steps = (v.narrativeLines ?? [])
-    .map((s) => stripMarkdown(s))
+    // A narrative entry can itself be multi-line (e.g. a worker's final
+    // "Done.\n\n## Summary\n…"). Collapse to one visual line so a step
+    // slot stays single-line after the per-line markdown strip.
+    .map((s) => stripMarkdown(s).replace(/\s+/g, ' ').trim())
     .filter((s) => s.length > 0)
     .map((s) => escapeHtml(truncate(s, STEP_MAX)))
 
@@ -172,7 +175,7 @@ export function renderWorkerActivity(v: WorkerActivityView): string {
   } else {
     // Back-compat for direct render callers that pass only latestSummary;
     // the manager always supplies narrativeLines.
-    const summary = stripMarkdown(v.latestSummary)
+    const summary = stripMarkdown(v.latestSummary).replace(/\s+/g, ' ').trim()
     if (summary.length > 0) {
       lines.push(`<b>→ ${escapeHtml(truncate(summary, STEP_MAX))}</b>`)
     } else {


### PR DESCRIPTION
## Summary
Two presentation bugs in the v0.14.27 worker activity card (observed live on clerk): a raw `## Summary` heading leaked into the card, and a worker's final summary rendered as a multi-line blob inside a single step slot.

- `stripMarkdown` leading-block regexes (heading/blockquote/bullet/ordered) anchored `^` without the `m` flag, so they only stripped markup at the **start of the string**. A summary shaped `Done.\n\n## Summary\n…` kept its mid-string `## Summary`. → add `gm`.
- A narrative entry can itself be multi-line; the step renderer preserved the embedded newlines. → collapse internal whitespace to one space in the step + back-compat summary paths so each step is one visual line.

## Why
JTBD "you hold the leash" — the worker card is the user-visible window into delegated work. Raw markdown + a cut-off multi-line blob reads as broken. Real screenshot showed `→ Done.` followed by a raw `## Summary\n\nFixed the bug where a bad Keep app-password logged the user out of the entire ap…`.

## Test plan
- [x] `vitest run telegram-plugin/tests/card-format.test.ts telegram-plugin/tests/worker-activity-feed.test.ts` — 46 pass, incl. 2 new regression tests pinning the exact screenshot case.
- [x] `tsc --noEmit` clean.

## Risk
Low — presentation-only. No change to terminal/lifecycle/reaction behaviour. The slow (~6 min) card terminalization and the premature 👍-done reaction are tracked separately as a behavioral follow-up (turn-end ≠ job-completion); this PR does not touch those.