### PR TITLE
fix(telegram): bind worker completion to authoritative signals, not turn-end

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2119,6 +2119,13 @@ function finalizeStatusReaction(
  * fired its `done`/`failed` onFinish no longer counts here.
  */
 function countRunningWorkers(): number {
+  // Prefer the dispatch-time DB count: a background worker's row is INSERTed
+  // `status='running'` when its `Agent` tool_use fires, i.e. BEFORE the parent
+  // turn ends. The registry below is populated by on-disk file discovery, which
+  // lags dispatch by a poll/fswatch tick — so a just-dispatched worker was
+  // invisible to the deferred-done gate and the 👍 promoted prematurely.
+  const dbCount = subagentWatcher?.countRunningBackgroundWorkers?.()
+  if (dbCount != null) return dbCount
   const reg = subagentWatcher?.getRegistry()
   if (reg == null) return 0
   let n = 0

--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -371,14 +371,25 @@ export function getSubagentByJsonlId(db: SqliteDatabase, jsonlAgentId: string): 
  * snapshotting the file-discovery registry (which lags dispatch by a poll/fswatch
  * tick and so missed just-dispatched workers — the premature-👍 race).
  *
- * `stalled` counts as still-running: a stalled worker isn't done. Genuinely
- * dead rows are swept to a terminal status by the reaper (`reapStuckRunning`),
- * so this can't get wedged above zero forever.
+ * Counts `running` ONLY — `stalled` is deliberately excluded. `stalled` is NOT
+ * a terminal status: the reaper (`reapStuckRunningRows`) transitions a row to
+ * `stalled`, never to `completed`/`failed`. A genuinely-orphaned background row
+ * — one INSERTed at dispatch whose JSONL was never linked, so no activity ever
+ * bumped it and the in-memory silent-stall synthesis never terminalised it —
+ * sits in `stalled` indefinitely (the 1h reaper TTL is the only thing that
+ * moves it off `running`). Counting `stalled` would wedge the deferred 👍 above
+ * zero forever for that row (`reaction-defer.ts` `promote()` bails while the
+ * count is > 0). A live-but-quiet worker, by contrast, is driven to `completed`
+ * by the watcher's terminal paths (end_turn signal OR silent-stall synthesis,
+ * both call `recordSubagentEnd`) long before the 1h reaper, and a stalled row
+ * that genuinely resumes is flipped back to `running` by `recordSubagentResume`
+ * — so excluding `stalled` never releases the 👍 on a worker that's merely
+ * paused rather than dead.
  */
 export function countRunningBackgroundSubagents(db: SqliteDatabase): number {
   const row = db
     .prepare(
-      "SELECT count(*) AS n FROM subagents WHERE background = 1 AND status IN ('running', 'stalled')",
+      "SELECT count(*) AS n FROM subagents WHERE background = 1 AND status = 'running'",
     )
     .get() as { n: number } | undefined
   return row?.n ?? 0

--- a/telegram-plugin/registry/subagents-schema.ts
+++ b/telegram-plugin/registry/subagents-schema.ts
@@ -361,6 +361,30 @@ export function getSubagentByJsonlId(db: SqliteDatabase, jsonlAgentId: string): 
 }
 
 /**
+ * Count background subagents that have not yet reached a terminal state.
+ *
+ * This is the dispatch-time source of truth for "is a background worker still
+ * running" — the row is INSERTed with `status='running'` by `recordSubagentStart`
+ * the moment the parent's `Agent` tool_use fires (keyed on the `toolu_…` id),
+ * which is BEFORE the parent's turn ends. The deferred-done-reaction gate reads
+ * this so it holds the 👍 the instant a worker is dispatched, rather than
+ * snapshotting the file-discovery registry (which lags dispatch by a poll/fswatch
+ * tick and so missed just-dispatched workers — the premature-👍 race).
+ *
+ * `stalled` counts as still-running: a stalled worker isn't done. Genuinely
+ * dead rows are swept to a terminal status by the reaper (`reapStuckRunning`),
+ * so this can't get wedged above zero forever.
+ */
+export function countRunningBackgroundSubagents(db: SqliteDatabase): number {
+  const row = db
+    .prepare(
+      "SELECT count(*) AS n FROM subagents WHERE background = 1 AND status IN ('running', 'stalled')",
+    )
+    .get() as { n: number } | undefined
+  return row?.n ?? 0
+}
+
+/**
  * Record that a subagent has reached a terminal state (completed or failed).
  * Sets `ended_at`, `status`, and optionally `result_summary`.
  *

--- a/telegram-plugin/registry/subagents.test.ts
+++ b/telegram-plugin/registry/subagents.test.ts
@@ -28,6 +28,7 @@ import {
   bumpSubagentActivity,
   getSubagent,
   reapStuckRunningRows,
+  countRunningBackgroundSubagents,
 } from './subagents-schema.js'
 
 // ---------------------------------------------------------------------------
@@ -178,6 +179,47 @@ describe('recordSubagentStart + recordSubagentEnd happy path', () => {
     recordSubagentStart(db, { id: 'sa-bg', background: true, startedAt: 5000 })
     const row = getSubagent(db, 'sa-bg')
     expect(row!.background).toBe(true)
+    db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// countRunningBackgroundSubagents — the dispatch-time gate for the
+// deferred-done 👍 reaction. A row counts as "still running" the instant
+// recordSubagentStart inserts it (status='running'), closing the
+// file-discovery registration race that promoted the 👍 prematurely.
+// ---------------------------------------------------------------------------
+
+describe('countRunningBackgroundSubagents', () => {
+  it('counts a background worker the moment it starts (before any terminal)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    expect(countRunningBackgroundSubagents(db)).toBe(0)
+    recordSubagentStart(db, { id: 'bg-1', background: true, startedAt: 1000 })
+    expect(countRunningBackgroundSubagents(db)).toBe(1)
+    db.close()
+  })
+
+  it('still counts a stalled worker (stalled is not done)', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'bg-2', background: true, startedAt: 1000 })
+    recordSubagentStall(db, { id: 'bg-2', stalledAt: 1500 })
+    expect(countRunningBackgroundSubagents(db)).toBe(1)
+    db.close()
+  })
+
+  it('drops to zero once the worker reaches a terminal status', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'bg-3', background: true, startedAt: 1000 })
+    expect(countRunningBackgroundSubagents(db)).toBe(1)
+    recordSubagentEnd(db, { id: 'bg-3', endedAt: 2000, status: 'completed' })
+    expect(countRunningBackgroundSubagents(db)).toBe(0)
+    db.close()
+  })
+
+  it('ignores foreground subagents — only background workers gate the reaction', () => {
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'fg-1', background: false, startedAt: 1000 })
+    expect(countRunningBackgroundSubagents(db)).toBe(0)
     db.close()
   })
 })

--- a/telegram-plugin/registry/subagents.test.ts
+++ b/telegram-plugin/registry/subagents.test.ts
@@ -199,10 +199,46 @@ describe('countRunningBackgroundSubagents', () => {
     db.close()
   })
 
-  it('still counts a stalled worker (stalled is not done)', () => {
+  it('does NOT count a stalled worker — stalled is the reaper sink, never terminalised', () => {
+    // A `stalled` row is NOT terminal and is NOT actively running. The only
+    // way a background row reaches `stalled` is the 1h reaper firing on a row
+    // that never linked a JSONL (no activity bumps, no silent-stall synthesis
+    // to drive it to `completed`) — i.e. an orphaned/dead dispatch. Counting it
+    // would wedge the deferred 👍 above zero forever (promote() bails while the
+    // count is > 0). A live-but-quiet worker terminalises to `completed` long
+    // before the reaper, so `stalled` always means "dead" here.
     const db = openFreshSubagentsDbInMemory()
     recordSubagentStart(db, { id: 'bg-2', background: true, startedAt: 1000 })
     recordSubagentStall(db, { id: 'bg-2', stalledAt: 1500 })
+    expect(countRunningBackgroundSubagents(db)).toBe(0)
+    db.close()
+  })
+
+  it('a row reaped to stalled does not keep the gate above zero (permanent-👍-hold regression guard)', () => {
+    // Regression guard for the orphaned-dispatch wedge: dispatch inserts a
+    // `running` row, the JSONL never links, and the reaper transitions it to
+    // `stalled`. The deferred-👍 gate must read zero so promote() can fire —
+    // counting the reaped row would hold the 👍 forever.
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'bg-orphan', background: true, startedAt: 1000 })
+    expect(countRunningBackgroundSubagents(db)).toBe(1)
+    const result = reapStuckRunningRows(db, { ttlMs: 500, now: 5000 })
+    expect(result.reaped).toBe(1)
+    expect(getSubagent(db, 'bg-orphan')!.status).toBe('stalled')
+    expect(countRunningBackgroundSubagents(db)).toBe(0)
+    db.close()
+  })
+
+  it('re-counts a stalled worker that resumes — recordSubagentResume flips it back to running', () => {
+    // A worker that's merely paused (not dead) and resumes JSONL activity is
+    // flipped stalled → running by recordSubagentResume, so the gate holds the
+    // 👍 again. Excluding `stalled` from the count never releases the 👍 on a
+    // worker that's only paused.
+    const db = openFreshSubagentsDbInMemory()
+    recordSubagentStart(db, { id: 'bg-resume', background: true, startedAt: 1000 })
+    recordSubagentStall(db, { id: 'bg-resume', stalledAt: 1500 })
+    expect(countRunningBackgroundSubagents(db)).toBe(0)
+    recordSubagentResume(db, { id: 'bg-resume', resumedAt: 2000 })
     expect(countRunningBackgroundSubagents(db)).toBe(1)
     db.close()
   })

--- a/telegram-plugin/session-tail.ts
+++ b/telegram-plugin/session-tail.ts
@@ -390,6 +390,21 @@ export function projectSubagentLine(
         events.push({ kind: 'sub_agent_text', agentId, text })
       }
     }
+    // Authoritative early terminal: a background `Agent` worker's JSONL on
+    // claude ≥2.1.156 never writes the `system/turn_duration` line below, so
+    // the watcher used to only learn the worker finished via the ~5-min
+    // silent-stall synthesis net — leaving the card stuck "running" and the
+    // deferred 👍 held for minutes after the work was actually done. The
+    // worker DOES write a final assistant message with
+    // `stop_reason: 'end_turn'` (a tool-using turn is `'tool_use'` and keeps
+    // going), so treat that as the terminal signal. Emitted AFTER the content
+    // events so the final text/preamble still renders; the watcher's turn_end
+    // handler is guarded on `state === 'running'`, so a later real
+    // turn_duration line is a no-op.
+    const stopReason = message?.stop_reason as string | undefined
+    if (stopReason === 'end_turn') {
+      events.push({ kind: 'sub_agent_turn_end', agentId })
+    }
     return events
   }
 

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -43,7 +43,7 @@ import { homedir } from 'os'
 import { projectSubagentLine, sanitizeCwdToProjectName, detectErrorInTranscriptLine } from './session-tail.js'
 import { sanitiseToolArg } from './fleet-state.js'
 import { escapeHtml, truncate } from './card-format.js'
-import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows } from './registry/subagents-schema.js'
+import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows, countRunningBackgroundSubagents } from './registry/subagents-schema.js'
 import { touchTurnActiveMarker } from './gateway/turn-active-marker.js'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -377,6 +377,13 @@ export interface SubagentWatcherHandle {
   stop(): void
   /** Snapshot of current registry for tests/inspection. */
   getRegistry(): ReadonlyMap<string, WorkerEntry>
+  /**
+   * Count background workers still in flight, read from the dispatch-time DB
+   * (not the file-discovery registry). Returns null when no DB is wired so the
+   * caller can fall back to the registry snapshot. Drives the deferred-done
+   * reaction gate — see `countRunningBackgroundSubagents`.
+   */
+  countRunningBackgroundWorkers(): number | null
 }
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -1497,6 +1504,17 @@ export function startSubagentWatcher(config: SubagentWatcherConfig): SubagentWat
 
     getRegistry(): ReadonlyMap<string, WorkerEntry> {
       return registry
+    },
+
+    countRunningBackgroundWorkers(): number | null {
+      if (db == null) return null
+      try {
+        return countRunningBackgroundSubagents(db)
+      } catch {
+        // A torn/locked DB read must not wedge the reaction gate — fall back
+        // to the registry snapshot by returning null.
+        return null
+      }
     },
   }
 }

--- a/telegram-plugin/tests/session-tail.test.ts
+++ b/telegram-plugin/tests/session-tail.test.ts
@@ -492,6 +492,49 @@ describe('projectSubagentLine', () => {
     expect(events).toEqual([{ kind: 'sub_agent_turn_end', agentId: 'X' }])
   })
 
+  it('emits sub_agent_turn_end after the text when the final assistant message stop_reason is end_turn', () => {
+    // Background `Agent` workers (claude ≥2.1.156) never write the
+    // system/turn_duration line, only a final assistant message with
+    // stop_reason 'end_turn'. That IS the authoritative completion signal —
+    // without treating it as terminal the card hung "running" until the
+    // ~5-min stall-synthesis net fired (the screenshot bug).
+    const st = { hasEmittedStart: true }
+    const events = projectSubagentLine(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: 'Done. Fixed the bug.' }],
+        },
+      }),
+      'X',
+      st,
+    )
+    // Text first (so the final summary still renders), turn_end last.
+    expect(events).toEqual([
+      { kind: 'sub_agent_text', agentId: 'X', text: 'Done. Fixed the bug.' },
+      { kind: 'sub_agent_turn_end', agentId: 'X' },
+    ])
+  })
+
+  it('does NOT emit sub_agent_turn_end for a tool-using assistant message (stop_reason tool_use)', () => {
+    // A mid-run assistant message that calls a tool has stop_reason 'tool_use'
+    // and keeps going — it must not be mistaken for completion.
+    const st = { hasEmittedStart: true }
+    const events = projectSubagentLine(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          stop_reason: 'tool_use',
+          content: [{ type: 'tool_use', id: 'toolu_a', name: 'Read', input: { file_path: '/a' } }],
+        },
+      }),
+      'X',
+      st,
+    )
+    expect(events.some((e) => e.kind === 'sub_agent_turn_end')).toBe(false)
+  })
+
   it('skips malformed lines silently', () => {
     const st = { hasEmittedStart: false }
     expect(projectSubagentLine('{not-json', 'X', st)).toEqual([])


### PR DESCRIPTION
## Summary

Two coordinated fixes for the background-worker handback UX. The reported symptom (screenshot): the original request got a **premature 👍** while the worker was still running, and the 🛠 worker card hung at `running · 03:01 · 21 tools` for ~9 min before terminalizing with a cut-off `## Summary`.

The raw-markdown cutoff was already fixed in #2050. This PR fixes the **two timing bugs** behind it.

### Fix A — early, authoritative worker terminal
A background `Agent` worker's JSONL on claude ≥2.1.156 **never writes the `system/turn_duration` line**, so the watcher only learned the worker finished via the ~5-min silent-stall synthesis net — leaving the card stuck `running` for minutes after the work was done, and the deferred 👍 held that whole time.

The worker **does** write a final assistant message with `stop_reason: 'end_turn'` (a tool-using turn is `'tool_use'` and keeps going). `projectSubagentLine` now treats that as the terminal signal, emitted *after* the final text so the summary still renders. The stall-synthesis net stays as the backstop for workers that die without writing `end_turn`.

### Fix B — close the premature-👍 registration race
`countRunningWorkers()` read the in-memory watcher registry, which is populated by on-disk **file discovery a poll/fswatch tick AFTER dispatch**. With the ack-first pattern (reply "On it" → dispatch worker → end turn), the parent turn-end fires the deferred-done gate *before* the worker is registered → count 0 → 👍 promotes immediately.

It now reads the **dispatch-time DB** (`subagents` rows `status IN (running, stalled) AND background=1`) via a new `countRunningBackgroundSubagents` helper exposed on the watcher handle. The row is INSERTed when the `Agent` tool_use fires, *before* turn-end. The reaper sweeps genuinely-dead rows, and Fix A makes live rows reach terminal promptly, so the count can't wedge above zero. Falls back to the registry snapshot if no DB is wired.

**Net:** 👍 now means "job done" — held the instant a worker is dispatched, promoted when the worker truly finishes — and the card terminalizes on real completion.

## Why
Root cause confirmed from clerk's live `gateway.log` + `registry.db`: workers register in the file-discovery registry a tick after dispatch (premature 👍), and bg workers on 2.1.159 never emit `sub_agent_turn_end` (card lag). Diagnosis ruled out the 540k `EACCES statx` log lines as noise (TOCTOU on already-deleted ephemeral worker JSONLs — the worker that rendered the 21-tool card was read fine).

JTBD: **you hold the leash** — the reaction + card must reflect real job state, not a turn-lifecycle artifact.

## Test plan
- [x] `projectSubagentLine` emits `sub_agent_turn_end` after text on `stop_reason: 'end_turn'`; does NOT on `stop_reason: 'tool_use'` (session-tail.test.ts)
- [x] `countRunningBackgroundSubagents` counts at start, counts stalled, drops at terminal, ignores foreground (subagents.test.ts)
- [x] watcher + session-tail regression suites (61 tests) green — stall-synthesis backstop intact
- [x] `tsc --noEmit` + full `npm run lint` clean (bot-api-wrapping allowlist unaffected)
- [ ] Pre-rollout UAT on test-harness (worker-feed scenario) before fleet rollout

## Risk
Low-moderate. The `end_turn` terminal is guarded by the watcher's existing `state === 'running'` check (a later real `turn_duration` is a no-op). The DB count falls back to the old registry scan on any DB error. Stall-synthesis backstop unchanged.