### PR TITLE
feat(telegram): pending-progress suffix signals agent is still reachable

### DIFF
--- a/telegram-plugin/pending-work-progress.ts
+++ b/telegram-plugin/pending-work-progress.ts
@@ -35,7 +35,11 @@
  *   turn_end with pending+anchor → activate the timer for the key
  *   tick (every 5s, edit every  → editMessageText against the anchor
  *     EDIT_INTERVAL_MS)            appending/refreshing the suffix
- *                                  " — still working (Nm)"
+ *                                  " — still working (Nm) · message me
+ *                                  anytime, I'll keep you posted"
+ *                                  (the reachability clause signals the
+ *                                  agent is still listening while a
+ *                                  background worker runs — issue PR3)
  *   inbound user message        → clear (user re-engaged or moved on)
  *   subagent_handback inject    → clear (model about to re-engage)
  *   MAX_LIFETIME_MS budget cap  → clear (give up; 30 min default)
@@ -70,10 +74,13 @@ export const TELEGRAM_MSG_CAP = 4000
 /**
  * Regex matching the suffix we append. Used to strip a prior suffix
  * before appending the next one. The (\d+) covers "1m" / "12m" / etc.
+ * The reachability clause is optional so anchors carrying a pre-v0.14.30
+ * suffix (no clause) are still stripped during a rolling upgrade.
  * Kept anchored to end-of-string so it only matches OUR suffix, not
  * something the model happened to write.
  */
-const SUFFIX_RE = /\n\n— still working \(\d+m\)$/
+const SUFFIX_RE =
+  /\n\n— still working \(\d+m\)( · message me anytime, I'll keep you posted)?$/
 
 export interface PendingProgressEditCtx {
   chatId: string
@@ -380,7 +387,7 @@ function tick(now: number): void {
     // user-visible counter reads honestly (we only edit at intervals
     // ≥ EDIT_INTERVAL_MS = 60s).
     const minutes = Math.max(1, Math.round(elapsed / 60_000))
-    const suffix = `\n\n— still working (${minutes}m)`
+    const suffix = `\n\n— still working (${minutes}m) · message me anytime, I'll keep you posted`
     const newText = s.anchorOriginalText + suffix
 
     if (newText.length > TELEGRAM_MSG_CAP) {

--- a/telegram-plugin/tests/pending-work-progress.test.ts
+++ b/telegram-plugin/tests/pending-work-progress.test.ts
@@ -139,7 +139,7 @@ describe('pending-work-progress', () => {
     expect(cap.edits).toHaveLength(1)
     expect(cap.edits[0].messageId).toBe(100)
     expect(cap.edits[0].newText).toBe(
-      'Background sleep running; awaiting completion.\n\n— still working (1m)',
+      "Background sleep running; awaiting completion.\n\n— still working (1m) · message me anytime, I'll keep you posted",
     )
 
     // Tick at 3 intervals total — second edit, "3m".
@@ -148,7 +148,7 @@ describe('pending-work-progress', () => {
     await flush()
     expect(cap.edits).toHaveLength(2)
     expect(cap.edits[1].newText).toBe(
-      'Background sleep running; awaiting completion.\n\n— still working (3m)',
+      "Background sleep running; awaiting completion.\n\n— still working (3m) · message me anytime, I'll keep you posted",
     )
   })
 
@@ -168,7 +168,25 @@ describe('pending-work-progress', () => {
     await flush()
     // The new edit should be based on 'worker dispatched' alone.
     expect(cap.edits[0].newText).toBe(
-      'worker dispatched\n\n— still working (1m)',
+      "worker dispatched\n\n— still working (1m) · message me anytime, I'll keep you posted",
+    )
+  })
+
+  it('strips a prior NEW-shape suffix (with reachability clause) too', async () => {
+    const cap = setup()
+    startTurn(KEY)
+    noteAsyncDispatch(KEY)
+    noteOutbound(KEY, {
+      messageId: 100,
+      text:
+        "worker dispatched\n\n— still working (12m) · message me anytime, I'll keep you posted",
+    })
+    noteTurnEnd(KEY)
+    cap.now = EDIT_INTERVAL_MS
+    __tickForTests(cap.now)
+    await flush()
+    expect(cap.edits[0].newText).toBe(
+      "worker dispatched\n\n— still working (1m) · message me anytime, I'll keep you posted",
     )
   })
 
@@ -338,7 +356,7 @@ describe('pending-work-progress', () => {
     expect(cap.edits).toHaveLength(1)
     expect(cap.edits[0].parseMode).toBe('HTML')
     expect(cap.edits[0].newText).toBe(
-      '<b>Worker back.</b> Both blockers fixed.\n\n— still working (1m)',
+      "<b>Worker back.</b> Both blockers fixed.\n\n— still working (1m) · message me anytime, I'll keep you posted",
     )
   })
 

--- a/telegram-plugin/uat/scenarios/cross-turn-pending-progress-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/cross-turn-pending-progress-dm.test.ts
@@ -81,7 +81,8 @@ interface TrailEntry {
   text: string;
 }
 
-const SUFFIX_RE = /\n\n— still working \(\d+m\)$/;
+const SUFFIX_RE =
+  /\n\n— still working \(\d+m\)( · message me anytime, I'll keep you posted)?$/;
 
 function pad(s: string, n: number): string {
   return s.length >= n ? s : s + " ".repeat(n - s.length);

--- a/telegram-plugin/uat/scenarios/jtbd-pending-progress-html-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-pending-progress-html-dm.test.ts
@@ -40,7 +40,8 @@ const PROMPT =
   `the bash, send that one HTML reply, end your turn. When it finishes ` +
   `much later, reply with the single word "done".`;
 
-const SUFFIX_RE = /\n\n— still working \(\d+m\)$/;
+const SUFFIX_RE =
+  /\n\n— still working \(\d+m\)( · message me anytime, I'll keep you posted)?$/;
 
 describe("uat: pending-progress edit preserves HTML formatting (#1698 regression gate)", () => {
   it(


### PR DESCRIPTION
## Summary

Make a delegating agent *feel* reachable while a background worker runs.
The ambient cross-turn ticker becomes:

> — still working (3m) · message me anytime, I'll keep you posted

Pure render/copy change to the `pending-work-progress` suffix — no new
dispatch path, no model call, no typing churn. Edited in place every 60s
exactly as today (jsonl-tail → render only), so it stays inside the
subscription boundary.

## Why

After an agent delegates to a background worker and ends its turn, the
silent "— still working (Nm)" ticker reads as *"agent is unresponsive"*.
The user waits instead of messaging. But the agent is reachable the whole
time: a background-worker dispatch never sets `turnInFlight`, so an inbound
user message is delivered as a fresh turn (not buffered, not raced against
a handback). The gap was signaling, not capability — so the fix is copy.

JTBD: **You hold the leash** — awareness + control; the user should know
they can reach in at any moment.

## What changed

- `pending-work-progress.ts`: suffix string + doc comment.
- `SUFFIX_RE` made backward-compatible (reachability clause optional) so
  an anchor carrying a *pre-upgrade* suffix is still stripped on the next
  edit during a rolling fleet upgrade. Suffix stays plain-text-safe under
  HTML parse_mode (no `<`, `>`, `&`).
- Unit tests updated + new "strips a prior NEW-shape suffix" case.
- Two UAT scenario `SUFFIX_RE`s updated to the new shape.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `bun test telegram-plugin/tests/` — 3813 pass, 0 fail
- [x] `pending-work-progress.test.ts` — 21 pass (cadence, strip old+new
      suffix, HTML parse_mode preserved)
- [ ] Operator eyeball on official Telegram app after rollout

## Risk

Low. Copy-only; no control-flow change. Worst case is suffix wording.
Backward-compatible regex protects the rolling-upgrade window.