### PR TITLE
fix(telegram): route background worker card + handback to the dispatch chat, not the DM

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -427,6 +427,7 @@ import {
   recordTurnEnd,
   findLatestTurnIfInterrupted,
   findRecentTurnsForChat,
+  getTurnByKey,
 } from '../registry/turns-schema.js'
 import {
   buildResumeInterruptedInbound,
@@ -1115,6 +1116,41 @@ try {
 } catch (err) {
   process.stderr.write(`telegram gateway: turn-registry init failed (${(err as Error).message}) — turn tracking disabled\n`)
   turnsDb = null
+}
+
+/**
+ * Resolve the chat/thread a background sub-agent was dispatched from, so
+ * its live worker card + handback route back to the originating
+ * conversation (group / forum topic) instead of the operator DM.
+ *
+ * Walks jsonl_agent_id → `subagents.parent_turn_key` →
+ * `turns.chat_id`/`thread_id`. Returns null on any miss so the caller
+ * keeps its existing `allowFrom[0]` DM fallback — best-effort, never
+ * throws out of the worker-card hot path. This restores the chat context
+ * the pinned-card fleet used to carry before it was removed in #1122
+ * (progressDriver is permanently null, so the old fleet lookup always
+ * yielded the DM for a Task dispatched from a group/topic).
+ */
+function resolveSubagentOriginChat(
+  agentId: string,
+): { chatId: string; threadId?: number } | null {
+  if (turnsDb == null) return null
+  try {
+    const sub = getSubagentByJsonlId(turnsDb, agentId)
+    if (sub?.parent_turn_key == null) return null
+    const turn = getTurnByKey(turnsDb, sub.parent_turn_key)
+    if (turn == null || turn.chat_id.length === 0) return null
+    const threadNum =
+      turn.thread_id != null && turn.thread_id.length > 0
+        ? Number(turn.thread_id)
+        : NaN
+    return {
+      chatId: turn.chat_id,
+      threadId: Number.isFinite(threadNum) ? threadNum : undefined,
+    }
+  } catch {
+    return null
+  }
 }
 
 // ─── Periodic history reaper (#1073) ──────────────────────────────────────
@@ -18371,11 +18407,15 @@ void (async () => {
                   handbackEnvValue: process.env.SWITCHROOM_SUBAGENT_HANDBACK,
                   outcome,
                   isBackground,
-                  fleetChatId,
-                  // Owner-chat fallback: if the progress-driver fleet
-                  // entry was already cleaned up, route to the owner
-                  // chat. Every switchroom fleet agent is DM-shaped, so
-                  // allowFrom[0] is the conversation that dispatched.
+                  // Route the handback (the worker's result → a synthesized
+                  // turn) back to the conversation the Task was dispatched
+                  // from, so the result lands where the user asked — not the
+                  // agent's DM. Falls back to fleetChatId/ownerChatId.
+                  fleetChatId: resolveSubagentOriginChat(agentId)?.chatId || fleetChatId,
+                  // Owner-chat fallback: if the parent-turn chat can't be
+                  // resolved, route to the owner chat. Every switchroom fleet
+                  // agent is DM-shaped, so allowFrom[0] is the conversation
+                  // that dispatched.
                   ownerChatId: loadAccess().allowFrom[0] ?? '',
                   taskDescription: description,
                   resultText,
@@ -18505,12 +18545,16 @@ void (async () => {
                 // message owns the progress beat. Push a running cue and
                 // return BEFORE the legacy bucket relay so the same activity
                 // isn't double-surfaced (in-message edit + injected
-                // "still working" inbound turn). Chat = owner DM, since the
-                // pinned-card fleet is gone and every agent is DM-shaped.
+                // "still working" inbound turn). Route to the conversation
+                // the Task was dispatched from (group / forum topic) via the
+                // parent turn; fall back to the owner DM when that can't be
+                // resolved (the pinned-card fleet that used to carry the chat
+                // is gone — see resolveSubagentOriginChat).
                 if (workerFeedEnabled) {
+                  const origin = resolveSubagentOriginChat(agentId)
                   void workerActivityFeed.update(
                     agentId,
-                    fleetChatId || (loadAccess().allowFrom[0] ?? ''),
+                    origin?.chatId || fleetChatId || (loadAccess().allowFrom[0] ?? ''),
                     {
                       description: dispatch.feedDescription,
                       lastTool,
@@ -18519,6 +18563,7 @@ void (async () => {
                       elapsedMs,
                       state: 'running',
                     },
+                    origin?.threadId,
                   )
                   return
                 }
@@ -18526,7 +18571,9 @@ void (async () => {
                 const decision = decideSubagentProgress({
                   disableEnvValue: process.env.SWITCHROOM_DISABLE_SUBAGENT_PROGRESS,
                   isBackground,
-                  fleetChatId,
+                  // Prefer the conversation the Task was dispatched from over
+                  // the owner DM (see resolveSubagentOriginChat).
+                  fleetChatId: resolveSubagentOriginChat(agentId)?.chatId || fleetChatId,
                   ownerChatId: loadAccess().allowFrom[0] ?? '',
                   subagentJsonlId: agentId,
                   taskDescription: description,

--- a/telegram-plugin/registry/turns-schema.test.ts
+++ b/telegram-plugin/registry/turns-schema.test.ts
@@ -116,19 +116,19 @@ describe('getTurnByKey', () => {
 
   it('recovers chat_id + thread_id for a group/topic turn', () => {
     const db = openTurnsDbInMemory()
-    recordTurnStart(db, { turnKey: 'g:11', chatId: '-1003852747971', threadId: '42' })
+    recordTurnStart(db, { turnKey: 'g:11', chatId: '-1001234567890', threadId: '42' })
     const turn = getTurnByKey(db, 'g:11')
     expect(turn?.turn_key).toBe('g:11')
-    expect(turn?.chat_id).toBe('-1003852747971')
+    expect(turn?.chat_id).toBe('-1001234567890')
     expect(turn?.thread_id).toBe('42')
     db.close()
   })
 
   it('recovers chat_id with null thread_id for a plain group/DM turn', () => {
     const db = openTurnsDbInMemory()
-    recordTurnStart(db, { turnKey: 'dm:7', chatId: '8248703757' })
+    recordTurnStart(db, { turnKey: 'dm:7', chatId: '12345' })
     const turn = getTurnByKey(db, 'dm:7')
-    expect(turn?.chat_id).toBe('8248703757')
+    expect(turn?.chat_id).toBe('12345')
     expect(turn?.thread_id).toBeNull()
     db.close()
   })

--- a/telegram-plugin/registry/turns-schema.test.ts
+++ b/telegram-plugin/registry/turns-schema.test.ts
@@ -20,6 +20,7 @@ import {
   recordTurnStart,
   recordTurnEnd,
   findRecentTurnsForChat,
+  getTurnByKey,
 } from './turns-schema.js'
 
 // ---------------------------------------------------------------------------
@@ -96,6 +97,39 @@ describe('findRecentTurnsForChat', () => {
     const done = rows.find(r => r.turn_key === 'turn_done')
     expect(running?.ended_at).toBeNull()
     expect(typeof done?.ended_at).toBe('number')
+    db.close()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getTurnByKey — recover the dispatch chat/thread for a sub-agent's parent
+// turn (subagents.parent_turn_key -> turns.turn_key). Without this the
+// worker card / handback fall back to the operator DM (#worker-card-routing).
+// ---------------------------------------------------------------------------
+
+describe('getTurnByKey', () => {
+  it('returns null when the turn key does not exist', () => {
+    const db = openTurnsDbInMemory()
+    expect(getTurnByKey(db, 'nope')).toBeNull()
+    db.close()
+  })
+
+  it('recovers chat_id + thread_id for a group/topic turn', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'g:11', chatId: '-1003852747971', threadId: '42' })
+    const turn = getTurnByKey(db, 'g:11')
+    expect(turn?.turn_key).toBe('g:11')
+    expect(turn?.chat_id).toBe('-1003852747971')
+    expect(turn?.thread_id).toBe('42')
+    db.close()
+  })
+
+  it('recovers chat_id with null thread_id for a plain group/DM turn', () => {
+    const db = openTurnsDbInMemory()
+    recordTurnStart(db, { turnKey: 'dm:7', chatId: '8248703757' })
+    const turn = getTurnByKey(db, 'dm:7')
+    expect(turn?.chat_id).toBe('8248703757')
+    expect(turn?.thread_id).toBeNull()
     db.close()
   })
 })

--- a/telegram-plugin/registry/turns-schema.ts
+++ b/telegram-plugin/registry/turns-schema.ts
@@ -348,6 +348,24 @@ export function findOrphanedTurns(db: SqliteDatabase, chatId: string): Turn[] {
   return rows.map(mapRow)
 }
 
+/**
+ * Fetch a single turn by its primary key, or null if absent.
+ *
+ * Used to recover the chat/thread a background sub-agent was dispatched
+ * from: `subagents.parent_turn_key` is an FK-by-convention to
+ * `turns.turn_key`, so this resolves the originating conversation
+ * (chat_id + thread_id) for a worker card / handback. Without it the
+ * worker feed falls back to the operator DM (the pinned-card fleet that
+ * used to carry the chat was removed in #1122), so a Task dispatched from
+ * a group/topic posted its progress to the agent's DM instead.
+ */
+export function getTurnByKey(db: SqliteDatabase, turnKey: string): Turn | null {
+  const row = db
+    .prepare(`SELECT * FROM turns WHERE turn_key = ?`)
+    .get(turnKey) as RawTurnRow | undefined
+  return row ? mapRow(row) : null
+}
+
 export interface OrphanClassifyOpts {
   /**
    * `turnKey` from the on-disk `turn-active.json` marker — the single


### PR DESCRIPTION
## Summary

A background sub-agent's live **worker card** (`🛠 Worker · <task> running · NN:NN · N tools`) and its **completion handback** were always posted to the operator **DM**, even when the user dispatched the Task from a **group / forum topic**. Observed live: Marko was asked to do deep research *in a group*; it replied in the group correctly, but every worker-progress beat (and the eventual result) went to Marko's DM.

## Root cause

The worker-card chat came from the pinned-card "fleet" lookup (`progressDriver.peekAllFleets()`). `progressDriver` was removed in #1122 and is now **permanently `null`**, so `fleetChatId` is always `''` and all three emit paths fall back to `loadAccess().allowFrom[0]` (the DM). The dispatch chat was never stored or recoverable.

## Fix

Recover the originating conversation from the per-agent registry — `jsonl_agent_id → subagents.parent_turn_key → turns.chat_id/thread_id` — and use it for the worker card (chat **and** thread), the legacy progress envelope, and the handback. Best-effort: returns `null` on any miss and the existing DM fallback is preserved, so **DM-shaped agents are completely unaffected** (origin resolves to their DM anyway).

- `registry/turns-schema.ts` — new `getTurnByKey(db, turnKey)` reader (mirrors `findOrphanedTurns`).
- `gateway/gateway.ts` — `resolveSubagentOriginChat(agentId)` helper (uses the already-open `turnsDb` + existing `getSubagentByJsonlId`); wired into the `onProgress` worker-feed `update()`, `decideSubagentProgress`, and `onFinish` `decideSubagentHandback`.
- `registry/turns-schema.test.ts` — 3 cases (missing key / group+topic / plain group-DM).

## Test plan

- [x] `bun test` registry + subagent/worker suites — 8 + 52 + 40 + 39 pass (incl. 3 new).
- [x] `tsc --noEmit` clean.
- [x] `check-bot-api-wrapping.sh` clean (no new raw `bot.api`), `check-plugin-references.mjs` clean.
- [ ] Live verify on a group-owning agent (Marko) once its in-flight research finishes — see Risk.

## Risk

Low and self-limiting. Pure-additive resolver with a graceful DM fallback; no behavior change for DM-only agents. Worst case (registry miss) = today's behavior (DM).

**Rollout note:** Marko has a long background research running right now; deploying this (image + restart) must wait until that completes so the worker isn't killed mid-run. Other agents are DM-shaped → no-op.

## JTBD

`know-what-my-agent-is-doing` — the live worker card and the result must appear **where you asked**, not in a DM you're not looking at.