### PR TITLE
fix(hostd): bind-mount-safe config write (in-place, no rename-over-target)

### DIFF
--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -314,7 +314,6 @@ export function formatConfigApprovalDenyError(
   return `E_DENIED: operator denied config_propose_edit${suffix} (approval_id=${approvalId})`;
 }
 
-/** Best-effort tmp-file cleanup — swallowed errors. */
 /**
  * Write `content` to an existing file **in place**, preserving its inode.
  *

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -33,7 +33,11 @@ import {
   writeFileSync,
   renameSync,
   mkdirSync,
-  unlinkSync,
+  openSync,
+  ftruncateSync,
+  writeSync,
+  fsyncSync,
+  closeSync,
 } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { randomUUID, randomBytes } from "node:crypto";
@@ -311,11 +315,59 @@ export function formatConfigApprovalDenyError(
 }
 
 /** Best-effort tmp-file cleanup — swallowed errors. */
-function unlinkSyncBestEffort(path: string): void {
+/**
+ * Write `content` to an existing file **in place**, preserving its inode.
+ *
+ * The obvious atomic-write strategy — write a sibling `<path>.tmp` then
+ * `rename()` it over the target — is structurally broken for
+ * switchroom.yaml. That file is itself an individual read-only bind-mount
+ * source: it is bind-mounted into every agent container. `rename()` over a
+ * path that is an active bind-mount source returns `EBUSY` ("resource busy
+ * or locked"), so the swap never lands. (Confirmed via /proc/mounts:
+ * `/dev/nvme0n1p2 /state/config/switchroom.yaml ext4 ro,relatime`.)
+ *
+ * Instead we open the existing file `O_RDWR` (no create, no rename),
+ * truncate it, write the new bytes, and `fsync()`. The inode is preserved,
+ * so every bind mount stays valid and the kernel never sees a rename over a
+ * busy dentry. `O_RDWR` (mode `"r+"`) also preserves the file's existing
+ * mode and owner — we never re-create it.
+ *
+ * Tradeoff — non-atomic: a crash between truncate and the final write could
+ * leave a partial file. Callers mitigate by (a) snapshotting the prior
+ * content for rollback, (b) `fsync` here, and (c) re-validating immediately
+ * after (the reconcile run rejects a malformed config and triggers
+ * rollback). A short post-write read-back length check below catches a
+ * truncated write before reconcile even starts.
+ *
+ * @throws the underlying fs error (e.g. `EROFS`/`EACCES` if the mount is
+ *   read-only at the hostd vantage, `ENOENT` if the target does not exist).
+ */
+function writeFileInPlacePreservingInode(
+  targetPath: string,
+  content: string,
+): void {
+  const buf = Buffer.from(content, "utf-8");
+  // "r+" = O_RDWR, fails if the file is missing, never truncates/creates on
+  // open — so mode/owner are untouched and we operate on the live inode.
+  const fd = openSync(targetPath, "r+");
   try {
-    unlinkSync(path);
-  } catch {
-    /* noop */
+    ftruncateSync(fd, 0);
+    let off = 0;
+    while (off < buf.length) {
+      off += writeSync(fd, buf, off, buf.length - off, off);
+    }
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  // Immediate re-validate: confirm the bytes actually landed at full
+  // length before the caller hands off to reconcile. Cheap insurance
+  // against a silently short write leaving a truncated config.
+  const readBack = readFileSync(targetPath);
+  if (readBack.length !== buf.length) {
+    throw new Error(
+      `in-place write short: wrote ${buf.length} bytes but read back ${readBack.length}`,
+    );
   }
 }
 
@@ -1425,18 +1477,24 @@ export class HostdServer {
         );
       }
       const postApply = verdict.postApplyContent;
-      // Atomic write: `<path>.tmp` → rename.
-      const tmp = configPath + ".tmp";
+      // In-place write preserving the inode (bind-mount safe). The old
+      // `<path>.tmp` → rename() swap returned EBUSY here because
+      // switchroom.yaml is itself a read-only bind-mount source mounted
+      // into every agent container — see writeFileInPlacePreservingInode.
       try {
-        writeFileSync(tmp, postApply);
-        renameSync(tmp, configPath);
+        writeFileInPlacePreservingInode(configPath, postApply);
       } catch (e) {
-        // Pre-write or rename failed — try to clean up tmp; live
-        // file is untouched so no rollback needed.
-        unlinkSyncBestEffort(tmp);
+        // Write failed before any bytes were flushed, OR mid-write. We
+        // hold the snapshot, so restore it in place to be safe rather
+        // than assume the live file is untouched.
+        try {
+          writeFileInPlacePreservingInode(configPath, snapshot);
+        } catch {
+          /* best-effort restore; original error is the one that matters */
+        }
         await approval.finalize({
           outcome: "reconcile_failed_rolled_back",
-          detail: `atomic write failed: ${(e as Error).message}`,
+          detail: `in-place write failed: ${(e as Error).message}`,
         });
         return this.reconcileFailedRolledBack(
           `write failed: ${(e as Error).message}`,
@@ -1463,10 +1521,11 @@ export class HostdServer {
         };
       }
       // ── Reconcile failed → rollback to snapshot, re-run reconcile.
+      // Same in-place write (not rename) so the rollback path is also
+      // bind-mount safe.
       let rollbackDetail = "";
       try {
-        writeFileSync(tmp, snapshot);
-        renameSync(tmp, configPath);
+        writeFileInPlacePreservingInode(configPath, snapshot);
       } catch (e) {
         rollbackDetail = `snapshot restore failed: ${(e as Error).message}`;
         await approval.finalize({

--- a/tests/host-control/config-propose-edit.test.ts
+++ b/tests/host-control/config-propose-edit.test.ts
@@ -14,7 +14,15 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, readFileSync, chmodSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  chmodSync,
+  statSync,
+  rmSync,
+} from "node:fs";
+import { execSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { HostdServer } from "../../src/host-control/server.js";
@@ -708,4 +716,118 @@ describe("hostd config_propose_edit — apply path (#1623)", () => {
     // Genuine server fault — no actionable fix hint.
     expect(resp.error_envelope?.fix).toBeUndefined();
   });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Bind-mount-safe write (EBUSY fix). /state/config/switchroom.yaml is
+// itself an individual read-only bind-mount SOURCE mounted into every
+// agent container. The old apply path wrote `<file>.tmp` then
+// `rename(tmp, configPath)` — but you cannot rename() OVER an active
+// bind-mount source/target: the kernel returns EBUSY. The fix writes
+// in place (truncate + write the live inode) for both the forward apply
+// and the rollback restore, so the inode is preserved and the mounts
+// stay valid. These tests pin that behaviour: a rename-based writer
+// would change the inode (and reset the mode to the umask default),
+// failing the assertions below; the in-place writer preserves both.
+// ─────────────────────────────────────────────────────────────────────
+describe("hostd config_propose_edit — bind-mount-safe in-place write", () => {
+  it("preserves the target inode + mode across a successful apply (no rename-over-target)", async () => {
+    const { gw, finalizeCalls } = stubGateway("approve");
+    // A distinctive non-default mode the rename path would not reproduce.
+    chmodSync(configPath, 0o600);
+    const inoBefore = statSync(configPath).ino;
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async () => ({ exit_code: 0, stdout: "ok", stderr: "" }),
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "ip-1" });
+    expect(resp.result).toBe("completed");
+    expect(finalizeCalls).toEqual([{ outcome: "applied" }]);
+    // Content updated …
+    expect(readFile(configPath, "utf8")).toContain(
+      "# touched by apply-path test",
+    );
+    const st = statSync(configPath);
+    // … but the inode is the SAME (rename would have allocated a new one).
+    expect(st.ino).toBe(inoBefore);
+    // … and the mode is preserved (rename would reset to the umask default).
+    expect(st.mode & 0o777).toBe(0o600);
+  });
+
+  it("rollback restores via in-place write — inode preserved, snapshot restored", async () => {
+    const { gw, finalizeCalls } = stubGateway("approve");
+    chmodSync(configPath, 0o600);
+    const inoBefore = statSync(configPath).ino;
+    const snapshotBefore = readFile(configPath, "utf8");
+    const reconcileExitCodes = [1, 0]; // first fails → rollback, recovery ok
+    server = makeServer({
+      configEditEnabled: true,
+      configPath,
+      approvalGateway: gw,
+      runReconcile: async () => {
+        const ec = reconcileExitCodes.shift() ?? 0;
+        return {
+          exit_code: ec,
+          stdout: ec === 0 ? "ok" : "",
+          stderr: ec === 0 ? "" : "reconcile boom",
+        };
+      },
+    });
+    await server.start();
+    const resp = await send({ unified_diff: GOOD_DIFF, request_id: "ip-2" });
+    expect(resp.result).toBe("error");
+    expect(resp.error).toMatch(/^E_RECONCILE_FAILED_ROLLED_BACK/);
+    // Snapshot restored byte-for-byte …
+    expect(readFile(configPath, "utf8")).toBe(snapshotBefore);
+    const st = statSync(configPath);
+    // … via in-place write: same inode, same mode.
+    expect(st.ino).toBe(inoBefore);
+    expect(st.mode & 0o777).toBe(0o600);
+    expect(finalizeCalls[0]!.outcome).toBe("reconcile_failed_rolled_back");
+  });
+
+  // The real-world repro: the config path is itself a bind-mount target.
+  // `mount --bind` needs root + Linux, so this is gated. On a matching
+  // host it proves the EBUSY class is actually defeated end-to-end — a
+  // rename-over-target here would throw EBUSY and fail the apply.
+  const canBindMount =
+    process.platform === "linux" &&
+    typeof process.getuid === "function" &&
+    process.getuid() === 0;
+  it.skipIf(!canBindMount)(
+    "applies over a file that is itself a bind-mount target (EBUSY repro)",
+    async () => {
+      const { gw } = stubGateway("approve");
+      // backing.yaml holds the real bytes; configPath is an empty file we
+      // bind-mount the backing over, so configPath becomes a mount target.
+      const backing = join(tmp, "backing.yaml");
+      writeFileSync(backing, VALID_BASE_YAML);
+      // configPath already exists (beforeEach) — bind backing over it.
+      execSync(`mount --bind ${backing} ${configPath}`);
+      try {
+        server = makeServer({
+          configEditEnabled: true,
+          configPath,
+          approvalGateway: gw,
+          runReconcile: async () => ({
+            exit_code: 0,
+            stdout: "ok",
+            stderr: "",
+          }),
+        });
+        await server.start();
+        const resp = await send({ unified_diff: GOOD_DIFF, request_id: "ip-3" });
+        // The whole point: in-place write succeeds where rename → EBUSY.
+        expect(resp.result).toBe("completed");
+        expect(readFile(configPath, "utf8")).toContain(
+          "# touched by apply-path test",
+        );
+      } finally {
+        execSync(`umount ${configPath}`);
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary

`config_propose_edit` validated patches successfully but **failed to write** them, twice in production, with:

```
E_RECONCILE_FAILED_ROLLED_BACK: write failed: EBUSY: resource busy or locked,
rename '/state/config/switchroom.yaml.tmp' -> '/state/config/switchroom.yaml'
```

## Why

`/state/config/switchroom.yaml` is itself an **individual read-only bind-mount source** — it is bind-mounted into every agent container (`/proc/mounts`: `/dev/nvme0n1p2 /state/config/switchroom.yaml ext4 ro,relatime`). You cannot `rename()` over a path that is an active bind-mount source; the kernel returns `EBUSY`. hostd's `<path>.tmp` → `rename()` atomic-write strategy is therefore structurally broken for the bind-mounted config — the swap never lands.

## What changed

`src/host-control/server.ts` — replace the rename-based swap with an **in-place write that preserves the inode** (`writeFileInPlacePreservingInode`):

- `open(target, "r+")` (O_RDWR, no create) → `ftruncate(0)` → write bytes → `fsync` → close.
- Preserving the inode keeps every bind mount valid and the kernel never sees a rename over a busy dentry.
- `O_RDWR` open preserves the existing file mode/owner (rename would have reset to the umask default).
- Post-write read-back length check catches a short write before reconcile runs.
- **Both** the forward apply **and** the rollback restore use the in-place write, so rollback is bind-mount safe too.

**Tradeoff (documented):** non-atomic — a crash between truncate and the final write could leave a partial file. Mitigated by (a) the pre-write snapshot kept for rollback, (b) `fsync`, (c) the immediate read-back length re-validate, and (d) reconcile rejecting a malformed config and triggering rollback.

## Test plan

- [x] `tests/host-control/config-propose-edit.test.ts` — new "bind-mount-safe in-place write" describe:
  - apply preserves the target **inode + mode** (a rename would change both) — deterministic, runs everywhere.
  - rollback restores **in place** — inode preserved, snapshot restored byte-for-byte.
  - root-gated: applies over a file that is **itself a `mount --bind` target** — the real EBUSY repro; a rename here throws EBUSY. **Verified passing as root on the host.**
- [x] `tsc --noEmit` clean.
- [x] Full `tests/host-control/` suite green (199 passed, 1 skipped — the root-gated test).
- [x] plugin-references gate clean.

## Risk

Low. Confined to the config_propose_edit write path. The non-atomicity window is mitigated as above; the previous behaviour was a hard failure (EBUSY) on every edit, so any successful write is a strict improvement. No image rebuild needed for the host-CLI side, but hostd ships as a container — rollout is a hostd image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)