### PR TITLE
fix(agents): deny AskUserQuestion fleet-wide (blocking-TUI wedge fix)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -792,6 +792,31 @@ const DEFAULT_READ_ONLY_PREAPPROVED_TOOLS = [
 const WEBKITE_FLEET_DENY_TOOLS = ["WebFetch", "WebSearch"];
 
 /**
+ * Fleet-baseline deny for blocking interactive TUI tools.
+ *
+ * `AskUserQuestion` renders a *blocking* full-screen multiple-choice
+ * selector inside claude's TUI ("❯ 1. … · Enter to select · ↑/↓ to
+ * navigate · Esc to cancel"). Every switchroom agent is driven from
+ * Telegram with no human at the terminal, so that selector blocks
+ * forever — claude waits on a keystroke that never comes, the turn
+ * never completes, and queued inbounds pile up behind it until the
+ * agent looks mute (real incident: klanker wedged this way 2026-06-01,
+ * recovered only by a manual tmux `Esc`).
+ *
+ * Denying the tool is the root-cause fix, not a workaround: a denied
+ * `AskUserQuestion` does NOT crash the turn — claude degrades gracefully
+ * and asks the same question as plain text, which is exactly what we
+ * want (the question reaches the operator over Telegram instead of
+ * stalling at an invisible TUI).
+ *
+ * Unconditional (no per-agent opt-out knob): there is no fleet scenario
+ * where a headless, Telegram-driven agent benefits from a blocking
+ * terminal selector. A power-user who genuinely needs it can still
+ * re-enable via the `settings_raw` deep-merge escape hatch.
+ */
+const INTERACTIVE_TUI_FLEET_DENY_TOOLS = ["AskUserQuestion"];
+
+/**
  * In-container PATH location of the operator-mounted webkite binary
  * (compose.ts mounts `~/.switchroom/bin/webkite` here). Host-side
  * staging path is `~/.switchroom/bin/webkite`.
@@ -1953,6 +1978,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     toolsDeny: dedupe([
       ...(tools.deny ?? []),
       ...webkiteDenyForAgent(agentConfig),
+      ...INTERACTIVE_TUI_FLEET_DENY_TOOLS,
     ]),
     permissionAllow,
     defaultModeAcceptEdits: hasAllWildcard,
@@ -2703,6 +2729,22 @@ export function scaffoldAgent(
         if (!allow.includes(t)) allow.push(t);
       }
       settings.permissions.allow = allow;
+
+      // Fleet-baseline interactive-TUI deny must also re-seed into EXISTING
+      // agents on `switchroom apply` — writeIfMissing above skips the
+      // settings.json template for existing agents, so the fresh-path deny
+      // (buildWorkspaceContext.toolsDeny) never lands on a deployed agent.
+      // Additive so any user-declared or webkite denies already present are
+      // preserved. Without this, a deployed agent keeps rendering the
+      // blocking AskUserQuestion selector until it next goes through the
+      // reconcileAgent path. See INTERACTIVE_TUI_FLEET_DENY_TOOLS.
+      const deny: string[] = Array.isArray(settings.permissions.deny)
+        ? settings.permissions.deny
+        : [];
+      for (const t of INTERACTIVE_TUI_FLEET_DENY_TOOLS) {
+        if (!deny.includes(t)) deny.push(t);
+      }
+      settings.permissions.deny = deny;
 
       // #235: actively retract the legacy switchroom-mcp entry on reconcile
       // so existing agents stop spawning the dormant child process. The 4
@@ -4351,6 +4393,7 @@ export function reconcileAgent(
   const desiredDeny = dedupe([
     ...(tools.deny ?? []),
     ...webkiteDenyForAgent(agentConfig),
+    ...INTERACTIVE_TUI_FLEET_DENY_TOOLS,
   ]);
 
   // Resolve topic ID for the start.sh template and session greeting

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -491,7 +491,15 @@ describe("scaffoldAgent", () => {
       // reaches for the webkite_* MCP tools instead. Per-agent
       // `mcp_servers.webkite: false` opts both webkite AND this deny
       // out together.
-      expect(settings.permissions.deny).toEqual(["bash", "WebFetch", "WebSearch"]);
+      // "AskUserQuestion" is the unconditional fleet-baseline interactive-TUI
+      // deny (scaffold.ts:INTERACTIVE_TUI_FLEET_DENY_TOOLS), appended after the
+      // webkite strip.
+      expect(settings.permissions.deny).toEqual([
+        "bash",
+        "WebFetch",
+        "WebSearch",
+        "AskUserQuestion",
+      ]);
       expect(settings.permissions.defaultMode).toBeUndefined();
     } finally {
       if (prev === undefined) delete process.env.SWITCHROOM_WEBKITE_BINARY;
@@ -573,12 +581,60 @@ describe("scaffoldAgent", () => {
       const settings = JSON.parse(
         readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
       );
-      // Only the user-declared deny — no WebFetch/WebSearch strip.
-      expect(settings.permissions.deny).toEqual(["bash"]);
+      // No WebFetch/WebSearch strip — but the AskUserQuestion fleet-baseline
+      // deny is unconditional (independent of webkite), so it still lands.
+      expect(settings.permissions.deny).toEqual(["bash", "AskUserQuestion"]);
     } finally {
       if (prev === undefined) delete process.env.SWITCHROOM_WEBKITE_BINARY;
       else process.env.SWITCHROOM_WEBKITE_BINARY = prev;
     }
+  });
+
+  it("AskUserQuestion is denied fleet-wide regardless of webkite presence", () => {
+    // The blocking interactive-TUI selector wedges a headless,
+    // Telegram-driven agent (no human at the terminal to answer it).
+    // Denying it forces claude's graceful plain-text fallback. This deny
+    // is unconditional — it must land whether or not webkite is staged
+    // and with no per-agent config opting into it.
+    const prev = process.env.SWITCHROOM_WEBKITE_BINARY;
+    process.env.SWITCHROOM_WEBKITE_BINARY = join(tmpDir, "no-webkite-here");
+    try {
+      const config = makeAgentConfig({}); // no tools.deny, webkite absent
+      const result = scaffoldAgent("askq-agent", config, tmpDir, telegramConfig);
+      const settings = JSON.parse(
+        readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+      );
+      expect(settings.permissions.deny).toContain("AskUserQuestion");
+    } finally {
+      if (prev === undefined) delete process.env.SWITCHROOM_WEBKITE_BINARY;
+      else process.env.SWITCHROOM_WEBKITE_BINARY = prev;
+    }
+  });
+
+  it("reconcile re-seeds AskUserQuestion deny into an EXISTING agent", () => {
+    // Mirrors the webkite re-seed guard: a deployed agent that predates
+    // this deny must converge on it at the next `switchroom apply`
+    // (reconcile rewrites settings.permissions.deny wholesale).
+    const config = makeAgentConfig({});
+    const cfg = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "askq-existing": config },
+    } as SwitchroomConfig;
+    const result = scaffoldAgent("askq-existing", config, tmpDir, telegramConfig, cfg);
+    const settingsPath = join(result.agentDir, ".claude", "settings.json");
+    // Simulate a pre-deny deployed agent: strip AskUserQuestion from deny.
+    const s1 = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    s1.permissions.deny = (s1.permissions.deny as string[]).filter(
+      (x) => x !== "AskUserQuestion",
+    );
+    writeFileSync(settingsPath, JSON.stringify(s1, null, 2));
+    expect(JSON.parse(readFileSync(settingsPath, "utf-8")).permissions.deny)
+      .not.toContain("AskUserQuestion");
+    // Re-scaffold (existing-agent reconcile path) must re-seed it.
+    scaffoldAgent("askq-existing", config, tmpDir, telegramConfig, cfg);
+    const s2 = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    expect(s2.permissions.deny).toContain("AskUserQuestion");
   });
 
   // #1400 apex-chain link 1: the hostd MCP server exposes mutating /

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -611,10 +611,14 @@ describe("scaffoldAgent", () => {
     }
   });
 
-  it("reconcile re-seeds AskUserQuestion deny into an EXISTING agent", () => {
-    // Mirrors the webkite re-seed guard: a deployed agent that predates
-    // this deny must converge on it at the next `switchroom apply`
-    // (reconcile rewrites settings.permissions.deny wholesale).
+  it("scaffoldAgent re-seeds AskUserQuestion deny into an EXISTING agent (apply path)", () => {
+    // Mirrors the webkite allow re-seed guard. A deployed agent that
+    // predates this deny must converge on it at the next `switchroom
+    // apply`, which calls scaffoldAgent — whose existing-agent merge
+    // branch additively re-seeds settings.permissions.deny (writeIfMissing
+    // skips the template for existing agents, so the fresh-path deny never
+    // lands). This is the convergence path that matters for live agents;
+    // the reconcileAgent path shares the same dedupe spread.
     const config = makeAgentConfig({});
     const cfg = {
       switchroom: { version: 1, agents_dir: tmpDir },


### PR DESCRIPTION
## Summary
- Deny `AskUserQuestion` fleet-wide so a headless, Telegram-driven agent never renders claude's blocking full-screen multiple-choice TUI selector.
- Seeded as an unconditional fleet-baseline deny (`INTERACTIVE_TUI_FLEET_DENY_TOOLS`) into the fresh-scaffold path, the `reconcileAgent` path, **and** the existing-agent merge branch in `scaffoldAgent` (which previously re-seeded `allow` but not `deny`).

## Why
`AskUserQuestion` renders a blocking selector ("❯ 1. … · Enter to select · ↑/↓ to navigate · Esc to cancel"). With no human at the terminal it blocks forever: the turn never completes, queued inbounds pile up, and the agent looks mute. klanker wedged exactly this way on 2026-06-01 and was only recovered by a manual tmux `Esc`.

Denying the tool is the **root-cause fix, not a workaround** — a denied `AskUserQuestion` does not crash the turn. claude degrades gracefully and asks the same question as plain text, which reaches the operator over Telegram (the desired behaviour) instead of stalling at an invisible TUI.

Unconditional (no per-agent opt-out knob): there is no fleet scenario where a headless agent benefits from a blocking terminal selector. A power user can still re-enable via the `settings_raw` deep-merge escape hatch.

The existing-agent merge branch fix matters because `switchroom apply` calls `scaffoldAgent` (not `reconcileAgent`) and skips the settings.json template for deployed agents — without re-seeding `deny` there, the new deny would only reach existing agents on the `reconcileAgent` path.

## Test plan
- [x] New `tests/scaffold.test.ts` cases: AskUserQuestion denied regardless of webkite presence; reconcile re-seeds it into an existing agent.
- [x] Updated the two exact-array `permissions.deny` assertions.
- [x] `tsc --noEmit` clean.
- [x] `tests/scaffold.test.ts` 186/186 green; broader suite green after `dist` build (remaining failures are dist/network-dependent build-shape guards, unrelated to this change).

## Risk
Low. Behaviour change is a graceful degradation (TUI selector → plain-text question). Takes effect on agent restart/reconcile.

JTBD: "You hold the leash" / "Always available" — an agent that goes mute on a blocking prompt fails both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)