### PR TITLE
feat(agents): mid-session wedge watchdog (Layer 2 of blocking-TUI fix)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -111,10 +111,15 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
     echo "[start.sh] channels.telegram.enabled=false — skipping gateway sidecar" >&2
   fi
 
-  # 2) autoaccept-poll — first-run TUI prompt dispatcher. Single-shot
-  #    by design (exits cleanly after idle-timeout once prompts have
-  #    fired); the supervisor's exponential backoff keeps a flaky
-  #    autoaccept from busy-looping.
+  # 2) autoaccept-poll — first-run TUI prompt dispatcher, then continuous
+  #    wedge-watchdog. Two phases in one process: a one-shot boot phase
+  #    dispatches the first-run prompts and returns after idle-timeout,
+  #    then the process stays alive running the wedge-watchdog (dismisses a
+  #    stuck blocking modal selector mid-session — the AskUserQuestion /
+  #    ExitPlanMode class — with Esc). So it is NORMALLY long-lived; the
+  #    supervisor only respawns it if it crashes/exits, and its backoff
+  #    keeps a flaky run from busy-looping. Set SWITCHROOM_WEDGE_WATCHDOG=0
+  #    to restore the legacy boot-only single-shot behaviour.
   if [ -f /opt/switchroom/autoaccept-poll.js ] && command -v bun >/dev/null 2>&1; then
     _switchroom_supervise autoaccept /var/log/switchroom/autoaccept.log \
       bun /opt/switchroom/autoaccept-poll.js "{{name}}" &

--- a/src/agents/wedge-watchdog.ts
+++ b/src/agents/wedge-watchdog.ts
@@ -1,0 +1,191 @@
+// Mid-session wedge watchdog — defense-in-depth for blocking interactive
+// TUI prompts that no human is present to answer.
+//
+// The boot-time autoaccept poller (`runAutoaccept`, autoaccept.ts) is a
+// one-shot: it dispatches the small set of first-run prompts (theme, MCP
+// trust, dev-channels) and exits after ~30s. It cannot catch a prompt that
+// claude renders LATER, mid-session. The dominant such case is a blocking
+// modal selector (e.g. claude's `AskUserQuestion`, or `ExitPlanMode`'s
+// menu): a full-screen multiple-choice list with the footer
+//   "❯ 1. … · Enter to select · ↑/↓ to navigate · Esc to cancel".
+// With no human at the terminal it blocks forever — the turn never
+// completes and queued Telegram inbounds pile up behind it until the agent
+// looks mute (real incident: klanker, 2026-06-01, recovered only by a
+// manual tmux `Esc`).
+//
+// Layer 1 of the fix denies `AskUserQuestion` fleet-wide so claude degrades
+// to plain text (see scaffold.ts:INTERACTIVE_TUI_FLEET_DENY_TOOLS). This
+// watchdog is Layer 2: a conservative, continuous safety net that catches
+// ANY stuck blocking selector — including ones Layer 1 can't reach (a
+// settings_raw override, a not-yet-reconciled agent, a future selector tool
+// claude introduces, or ExitPlanMode). It sends `Esc`, which claude treats
+// as "user declined" — non-destructive.
+//
+// Hard contracts (inherited from autoaccept.ts):
+//   * Soft-fail throughout. Never throw out of `runWedgeWatchdog`.
+//   * Only ever inject `Escape` via tmux send-keys. No destructive verbs.
+//   * False positives are worse than false negatives — interrupting a live
+//     turn is a regression, a missed wedge is just the pre-watchdog status
+//     quo. So we require BOTH a precise blocking-modal signature AND
+//     multi-poll stability before acting, and a cooldown after firing.
+
+import { capturePane, sendKeys, PROMPTS, type PromptRule } from "./autoaccept.js";
+
+/**
+ * Blocking-modal footer signature. Deliberately strict: requires BOTH
+ *   (a) an "Esc … cancel" affordance — the modal-cancel footer, which is
+ *       distinct from the working-turn footer ("esc to interrupt") and the
+ *       idle REPL footer, AND
+ *   (b) a selection / navigation affordance ("to select" / "to navigate" /
+ *       the ↑/↓ glyphs).
+ * Only a blocking multiple-choice selector shows both at once. A streaming
+ * turn, an idle REPL, or a plain confirmation prompt fails at least one
+ * branch, so the watchdog leaves them alone.
+ */
+export const WEDGE_FOOTER_SIGNATURE =
+  /(?=[\s\S]*[Ee]sc(?:ape)?[^\n]*cancel)(?=[\s\S]*(?:to select|to navigate|↑\/↓))/;
+
+const DEFAULT_POLL_MS = 5_000;
+const DEFAULT_STABILITY_THRESHOLD = 3;
+const DEFAULT_COOLDOWN_MS = 60_000;
+
+export interface WedgeWatchdogOptions {
+  agentName: string;
+  /** Poll cadence in ms. Default 5000. */
+  pollIntervalMs?: number;
+  /**
+   * Number of CONSECUTIVE identical-and-wedged captures required before
+   * sending Esc. Default 3. The pane of a working agent (spinner, token
+   * stream, elapsed timer) changes between polls, so a static blocking
+   * selector is the only thing that stays byte-identical across this many
+   * polls. With the default 5s cadence that's ~15s of confirmed-stuck.
+   */
+  stabilityThreshold?: number;
+  /**
+   * After firing Esc, suppress further fires for this long so we don't
+   * tight-loop Esc into a prompt that re-renders. Default 60000.
+   */
+  cooldownMs?: number;
+  /**
+   * First-run prompts to DEFER to: if the pane matches one of these, the
+   * boot autoaccept poller owns it (it wants Enter, not Esc), so the
+   * watchdog must not fire. Default: the autoaccept PROMPTS set.
+   */
+  deferToPrompts?: PromptRule[];
+  /** Override the blocking-modal signature (tests / tuning). */
+  wedgeSignature?: RegExp;
+  /** Test seam: cap total polls. Default Infinity (runs until killed). */
+  maxPolls?: number;
+  /** Test seam: clock override. */
+  now?: () => number;
+  /** Test seam: sleep override. */
+  sleep?: (ms: number) => Promise<void> | void;
+  /** Test seam: pane capture override. Default: capturePane (real tmux). */
+  capture?: (agentName: string) => string;
+  /** Test seam: keystroke send override. Default: sendKeys (real tmux). */
+  send?: (agentName: string, keys: string[]) => boolean;
+}
+
+export interface WedgeWatchdogResult {
+  /** Number of times Esc was dispatched to dismiss a stuck prompt. */
+  fires: number;
+  /** Total polls executed (bounded only in tests via maxPolls). */
+  polls: number;
+  reason: "max-polls" | "stopped";
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Normalize a pane snapshot for stability comparison: strip trailing
+ * whitespace per line so cursor-position jitter doesn't defeat the
+ * identical-capture check.
+ */
+function stabilityKey(text: string): string {
+  return text
+    .split("\n")
+    .map((l) => l.replace(/\s+$/, ""))
+    .join("\n");
+}
+
+/**
+ * Continuously watch an agent's tmux pane and dismiss a STABLE blocking
+ * modal selector with Esc. Never throws. Designed to run for the container
+ * lifetime (the autoaccept-poll sidecar enters this after its boot phase).
+ */
+export async function runWedgeWatchdog(
+  opts: WedgeWatchdogOptions,
+): Promise<WedgeWatchdogResult> {
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
+  const stabilityThreshold = opts.stabilityThreshold ?? DEFAULT_STABILITY_THRESHOLD;
+  const cooldownMs = opts.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+  const deferToPrompts = opts.deferToPrompts ?? PROMPTS;
+  const signature = opts.wedgeSignature ?? WEDGE_FOOTER_SIGNATURE;
+  const maxPolls = opts.maxPolls ?? Number.POSITIVE_INFINITY;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? defaultSleep;
+  const capture = opts.capture ?? capturePane;
+  const send = opts.send ?? sendKeys;
+
+  let stableCount = 0;
+  let lastKey: string | null = null;
+  let cooldownUntil = 0;
+  let fires = 0;
+  let polls = 0;
+
+  while (polls < maxPolls) {
+    polls++;
+    let text = "";
+    try {
+      text = capture(opts.agentName);
+    } catch (err) {
+      // capturePane is contracted to soft-fail, but defence-in-depth.
+      console.error(
+        `[wedge-watchdog] ${opts.agentName}: capture threw: ${(err as Error).message}`,
+      );
+      text = "";
+    }
+
+    const isBlockingModal =
+      !!text &&
+      signature.test(text) &&
+      // Defer to the boot autoaccept poller for first-run prompts — those
+      // want Enter, not Esc.
+      !deferToPrompts.some((p) => p.match.test(text));
+
+    if (isBlockingModal) {
+      const key = stabilityKey(text);
+      if (key === lastKey) {
+        stableCount++;
+      } else {
+        stableCount = 1;
+        lastKey = key;
+      }
+      if (stableCount >= stabilityThreshold && now() >= cooldownUntil) {
+        console.error(
+          `[wedge-watchdog] ${opts.agentName}: dismissing stuck blocking prompt ` +
+            `(Esc) after ${stableCount} stable polls (~${
+              (stableCount * pollIntervalMs) / 1000
+            }s) — no human to answer it`,
+        );
+        send(opts.agentName, ["Escape"]);
+        fires++;
+        cooldownUntil = now() + cooldownMs;
+        // Reset so we require a fresh stability streak before firing again.
+        stableCount = 0;
+        lastKey = null;
+      }
+    } else {
+      // Pane is doing something else (working, idle REPL, plain text) — drop
+      // any accumulated streak.
+      stableCount = 0;
+      lastKey = null;
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  return { fires, polls, reason: "max-polls" };
+}

--- a/src/agents/wedge-watchdog.ts
+++ b/src/agents/wedge-watchdog.ts
@@ -170,7 +170,15 @@ export async function runWedgeWatchdog(
               (stableCount * pollIntervalMs) / 1000
             }s) — no human to answer it`,
         );
-        send(opts.agentName, ["Escape"]);
+        try {
+          send(opts.agentName, ["Escape"]);
+        } catch (err) {
+          // sendKeys is contracted to soft-fail (returns boolean), but the
+          // never-throw sidecar contract must hold even for a custom seam.
+          console.error(
+            `[wedge-watchdog] ${opts.agentName}: send threw: ${(err as Error).message}`,
+          );
+        }
         fires++;
         cooldownUntil = now() + cooldownMs;
         // Reset so we require a fresh stability streak before firing again.

--- a/src/cli/autoaccept-poll.ts
+++ b/src/cli/autoaccept-poll.ts
@@ -1,16 +1,27 @@
 #!/usr/bin/env bun
-// Small CLI wrapper around `runAutoaccept` (#725 PR-4).
+// Small CLI wrapper around `runAutoaccept` + `runWedgeWatchdog` (#725 PR-4).
 //
 // Invoked from the agent's docker entrypoint after the tmux supervisor
 // is launched (default since #725 PR-1), when the agent has not opted
 // into the legacy `expect`-based autoaccept wrapper via
 // `experimental.legacy_autoaccept_expect: true`.
 //
-// argv[2] = agent name. Always exits 0 — the poller is best-effort and
-// must never fail the unit start. tmux not running yet, capture-pane
-// erroring, send-keys racing the prompt: all soft-failures.
+// Two phases in one process:
+//   1. Boot phase — `runAutoaccept` dispatches the first-run TUI prompts
+//      (theme / MCP trust / dev-channels) and returns after idle-timeout.
+//   2. Watch phase — `runWedgeWatchdog` then runs for the container
+//      lifetime, dismissing any STABLE blocking modal selector that wedges
+//      the agent mid-session (the AskUserQuestion / ExitPlanMode class).
+//      This phase does not return; the process lives until the container
+//      stops. Disable it with `SWITCHROOM_WEDGE_WATCHDOG=0`, which restores
+//      the legacy single-shot (boot-only) behaviour.
+//
+// argv[2] = agent name. Best-effort throughout — never fails the unit
+// start. tmux not running yet, capture-pane erroring, send-keys racing the
+// prompt: all soft-failures.
 
 import { runAutoaccept } from "../agents/autoaccept.js";
+import { runWedgeWatchdog } from "../agents/wedge-watchdog.js";
 
 async function main(): Promise<void> {
   const agentName = process.argv[2];
@@ -18,10 +29,12 @@ async function main(): Promise<void> {
     console.error("[autoaccept-poll] missing agent name argv");
     process.exit(0);
   }
+
+  // --- Boot phase: first-run prompt dispatch (one-shot). ---
   try {
     const res = await runAutoaccept({ agentName });
     console.error(
-      `[autoaccept-poll] ${agentName}: done reason=${res.reason} fired=${
+      `[autoaccept-poll] ${agentName}: boot done reason=${res.reason} fired=${
         res.fired.length ? res.fired.join(",") : "(none)"
       }`,
     );
@@ -29,7 +42,27 @@ async function main(): Promise<void> {
     // runAutoaccept is contracted to never throw, but defence-in-depth:
     // any synchronous-throw at boot must not fail the agent unit.
     console.error(
-      `[autoaccept-poll] ${agentName}: unexpected throw: ${(err as Error).message}`,
+      `[autoaccept-poll] ${agentName}: boot unexpected throw: ${(err as Error).message}`,
+    );
+  }
+
+  // --- Watch phase: continuous mid-session wedge watchdog. ---
+  if (process.env.SWITCHROOM_WEDGE_WATCHDOG === "0") {
+    console.error(
+      `[autoaccept-poll] ${agentName}: wedge-watchdog disabled (SWITCHROOM_WEDGE_WATCHDOG=0) — exiting after boot phase`,
+    );
+    process.exit(0);
+  }
+  try {
+    console.error(`[autoaccept-poll] ${agentName}: entering wedge-watchdog (continuous)`);
+    // Runs until the container stops (maxPolls defaults to Infinity).
+    const res = await runWedgeWatchdog({ agentName });
+    console.error(
+      `[autoaccept-poll] ${agentName}: wedge-watchdog returned reason=${res.reason} fires=${res.fires}`,
+    );
+  } catch (err) {
+    console.error(
+      `[autoaccept-poll] ${agentName}: wedge-watchdog unexpected throw: ${(err as Error).message}`,
     );
   }
   process.exit(0);

--- a/tests/wedge-watchdog.test.ts
+++ b/tests/wedge-watchdog.test.ts
@@ -1,0 +1,212 @@
+// Unit tests for the mid-session wedge watchdog (Layer 2 of the
+// blocking-TUI-prompt fix). We drive the pure state machine through the
+// `capture` / `send` test seams so no real tmux is involved.
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  runWedgeWatchdog,
+  WEDGE_FOOTER_SIGNATURE,
+} from "../src/agents/wedge-watchdog.js";
+
+// A realistic blocking-modal pane (the klanker AskUserQuestion shape).
+const WEDGE_SCREEN =
+  "Which option do you want?\n" +
+  "❯ 1. First choice\n" +
+  "  2. Second choice\n" +
+  "\n" +
+  "Enter to select · ↑/↓ to navigate · Esc to cancel";
+
+// The working / idle REPL footer — must NOT trip the watchdog.
+const IDLE_SCREEN =
+  "⏵⏵ accept edits on (shift+tab to cycle) · esc to interrupt\n> ";
+
+/**
+ * Build a `capture` seam that yields canned screens in order; once
+ * exhausted it repeats the LAST screen (so an all-wedged steady state is
+ * easy to express with a single-element array).
+ */
+function captureSeq(screens: string[]) {
+  let i = 0;
+  return (_agent: string): string => {
+    const s = i < screens.length ? screens[i] : screens[screens.length - 1];
+    i++;
+    return s ?? "";
+  };
+}
+
+function recordSend() {
+  const calls: string[][] = [];
+  const send = (_agent: string, keys: string[]): boolean => {
+    calls.push([...keys]);
+    return true;
+  };
+  return { send, calls };
+}
+
+describe("WEDGE_FOOTER_SIGNATURE", () => {
+  it("matches a blocking modal selector footer", () => {
+    expect(WEDGE_FOOTER_SIGNATURE.test(WEDGE_SCREEN)).toBe(true);
+  });
+
+  it("does NOT match the working/idle REPL footer ('esc to interrupt')", () => {
+    expect(WEDGE_FOOTER_SIGNATURE.test(IDLE_SCREEN)).toBe(false);
+  });
+
+  it("does NOT match streaming output or a plain confirmation", () => {
+    const negatives = [
+      "Thinking… (12s · esc to interrupt)",
+      "Here is the answer you asked for.\n\nDone.",
+      "Do you want to proceed?\n❯ 1. Yes\n  2. No\nPress enter to confirm",
+      "", // empty pane
+    ];
+    for (const text of negatives) {
+      expect(WEDGE_FOOTER_SIGNATURE.test(text), `matched: ${text}`).toBe(false);
+    }
+  });
+});
+
+describe("runWedgeWatchdog", () => {
+  it("fires Esc once a stable blocking selector persists past the threshold", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "klanker",
+      stabilityThreshold: 3,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 3,
+      capture: captureSeq([WEDGE_SCREEN]),
+      send,
+    });
+    expect(res.fires).toBe(1);
+    expect(calls).toEqual([["Escape"]]);
+  });
+
+  it("does NOT fire before the stability threshold is reached", async () => {
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "a",
+      stabilityThreshold: 3,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 2, // only 2 stable polls — one short of the threshold
+      capture: captureSeq([WEDGE_SCREEN]),
+      send,
+    });
+    expect(res.fires).toBe(0);
+    expect(calls).toEqual([]);
+  });
+
+  it("does NOT fire when the pane keeps changing (a working agent)", async () => {
+    // Each capture matches the modal footer but the body differs every
+    // poll — a static stuck prompt would be byte-identical, so a moving
+    // pane must never trip the stability guard.
+    const moving = [0, 1, 2, 3, 4].map(
+      (n) =>
+        `Working step ${n}\n❯ 1. opt${n}\nEnter to select · ↑/↓ to navigate · Esc to cancel`,
+    );
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "a",
+      stabilityThreshold: 3,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 5,
+      capture: captureSeq(moving),
+      send,
+    });
+    expect(res.fires).toBe(0);
+    expect(calls).toEqual([]);
+  });
+
+  it("defers to the boot autoaccept poller for first-run prompts (no Esc)", async () => {
+    // A dev-channels first-run prompt that ALSO carries a modal footer:
+    // autoaccept owns it (it wants Enter), so the watchdog must not Esc it.
+    const firstRunWithFooter =
+      "Yes, I accept the use of development channels\n" +
+      "❯ 1. Accept\nEnter to select · ↑/↓ to navigate · Esc to cancel";
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "a",
+      stabilityThreshold: 3,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 6,
+      capture: captureSeq([firstRunWithFooter]),
+      send,
+    });
+    expect(res.fires).toBe(0);
+    expect(calls).toEqual([]);
+  });
+
+  it("resets its streak when the pane leaves the wedged state", async () => {
+    // wedge, wedge, IDLE (reset), wedge, wedge — never 3 consecutive.
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "a",
+      stabilityThreshold: 3,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 5,
+      capture: captureSeq([
+        WEDGE_SCREEN,
+        WEDGE_SCREEN,
+        IDLE_SCREEN,
+        WEDGE_SCREEN,
+        WEDGE_SCREEN,
+      ]),
+      send,
+    });
+    expect(res.fires).toBe(0);
+    expect(calls).toEqual([]);
+  });
+
+  it("honors the cooldown: re-fires only after it elapses", async () => {
+    // Clock advances by pollIntervalMs each poll (via the sleep seam), so
+    // cooldown is measured in poll-time. threshold 3 + cooldown 60s @ 5s
+    // cadence → fire at poll 3, blocked until clock≥70s, fire again at
+    // poll 15. 20 polls → exactly 2 fires.
+    let clock = 0;
+    const { send, calls } = recordSend();
+    const res = await runWedgeWatchdog({
+      agentName: "a",
+      stabilityThreshold: 3,
+      pollIntervalMs: 5_000,
+      cooldownMs: 60_000,
+      now: () => clock,
+      sleep: (ms) => {
+        clock += ms;
+      },
+      maxPolls: 20,
+      capture: captureSeq([WEDGE_SCREEN]),
+      send,
+    });
+    expect(res.fires).toBe(2);
+    expect(calls).toEqual([["Escape"], ["Escape"]]);
+  });
+
+  it("soft-fails when capture throws (no fire, no throw)", async () => {
+    const { send, calls } = recordSend();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await runWedgeWatchdog({
+      agentName: "a",
+      stabilityThreshold: 1,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 3,
+      capture: () => {
+        throw new Error("tmux: no server running");
+      },
+      send,
+    });
+    expect(res.fires).toBe(0);
+    expect(calls).toEqual([]);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/tests/wedge-watchdog.test.ts
+++ b/tests/wedge-watchdog.test.ts
@@ -209,4 +209,25 @@ describe("runWedgeWatchdog", () => {
     expect(errSpy).toHaveBeenCalled();
     errSpy.mockRestore();
   });
+
+  it("soft-fails when send throws (counts the fire, no throw)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await runWedgeWatchdog({
+      agentName: "a",
+      stabilityThreshold: 1,
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 1,
+      capture: captureSeq([WEDGE_SCREEN]),
+      send: () => {
+        throw new Error("tmux: send-keys failed");
+      },
+    });
+    // The fire is attempted (and counted) but the throw is swallowed so the
+    // sidecar loop survives.
+    expect(res.fires).toBe(1);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

Layer 2 of the blocking-interactive-TUI-prompt fix. A continuous,
conservative wedge-watchdog that dismisses a STABLE blocking modal
selector (the `AskUserQuestion` / `ExitPlanMode` class) that wedges a
headless agent mid-session — by sending `Esc`, which claude treats as
"user declined" (non-destructive).

The autoaccept-poll sidecar now runs **two phases in one process**:
1. **Boot phase** (unchanged) — `runAutoaccept` dispatches first-run TUI
   prompts and returns after idle-timeout.
2. **Watch phase** (new) — `runWedgeWatchdog` polls the pane for the
   container lifetime and dismisses any stuck blocking selector.

Kill-switch: `SWITCHROOM_WEDGE_WATCHDOG=0` restores legacy boot-only
behaviour.

## Why

The boot poller is one-shot — it can't catch a prompt claude renders
*later*, mid-session. With no human at the terminal a blocking selector
blocks forever: the turn never completes, queued Telegram inbounds pile up,
and the agent looks **mute** (klanker incident, 2026-06-01, recovered only
by a manual tmux `Esc`).

Layer 1 (#2064) denies `AskUserQuestion` fleet-wide so claude degrades to
plain text. This Layer 2 is defense-in-depth: it catches ANY stuck blocking
selector, including ones Layer 1 can't reach — a `settings_raw` override, a
not-yet-reconciled agent, a future selector tool, or `ExitPlanMode`.

## Design — false positives are worse than false negatives

Interrupting a *live* turn is a regression; a missed wedge is just the
pre-watchdog status quo. So firing requires **all three**:
- a strict blocking-modal footer signature (`Esc…cancel` AND a
  select/navigate affordance — distinct from the working footer
  "esc to interrupt" and the idle REPL footer),
- byte-identical stability across N consecutive polls (default 3 @ 5s =
  ~15s confirmed-stuck; a working pane's spinner/timer changes between
  polls), and
- a post-fire cooldown (default 60s) so we never tight-loop Esc into a
  re-rendering prompt.

It also **defers to the boot autoaccept poller** for first-run prompts
(those want Enter, not Esc), and **soft-fails throughout** (never throws,
only ever injects `Escape`).

## Test plan

- [x] `tests/wedge-watchdog.test.ts` — 10 tests: footer signature
      positive/negatives (idle footer, streaming, plain confirmation,
      empty), fires after threshold, no-fire before threshold, no-fire on
      a moving pane, defers to first-run prompt, resets streak on
      non-wedge interleave, cooldown re-fire math, soft-fail on capture
      throw.
- [x] `tsc --noEmit` clean.
- [x] `node scripts/build.mjs` clean; the baked `dist/cli/autoaccept-poll.js`
      bundle picks up the new watchdog.

## Risk

An always-on keystroke injector on the live fleet. Mitigated by the strict
signature + multi-poll stability + cooldown + first-run deferral above; the
only key it ever sends is `Esc`. Kill-switch `SWITCHROOM_WEDGE_WATCHDOG=0`.
Takes effect on agent restart/apply (changes the baked autoaccept-poll
bundle). Related: #2064 (Layer 1).