### PR TITLE
chore: release v0.14.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## v0.14.33 — Blocking-TUI wedge fix (AskUserQuestion deny + wedge-watchdog)
+
+Closes a wedge class where claude's **blocking interactive TUI selectors**
+(the `AskUserQuestion` / `ExitPlanMode` class — a full-screen
+multiple-choice list with the footer "❯ 1. … · Enter to select · ↑/↓ to
+navigate · Esc to cancel") freeze a **headless** agent forever. With no
+human at the terminal the selector blocks indefinitely: the turn never
+completes, queued Telegram inbounds pile up, and the agent looks **mute**
+(real incident: klanker, 2026-06-01, recovered only by a manual tmux `Esc`).
+
+Two defensive layers:
+
+### Layer 1 — deny `AskUserQuestion` fleet-wide (#2064)
+
+`AskUserQuestion` is now an unconditional fleet-baseline deny
+(`INTERACTIVE_TUI_FLEET_DENY_TOOLS` in `src/agents/scaffold.ts`), wired into
+the fresh-scaffold `toolsDeny`, the `reconcileAgent` `desiredDeny`, AND the
+existing-agent merge branch in `scaffoldAgent` (the `switchroom apply`
+convergence path). A denied `AskUserQuestion` does **not** crash the turn —
+claude degrades gracefully and asks the same question as **plain text**,
+which reaches the operator over Telegram. A one-off power-user need can
+re-enable via the `settings_raw` deep-merge escape hatch.
+
+### Layer 2 — continuous mid-session wedge-watchdog (#2065)
+
+Defense-in-depth for blocking selectors Layer 1's deny can't reach (a
+`settings_raw` override, a not-yet-reconciled agent, a future selector tool,
+or `ExitPlanMode`). The `autoaccept-poll` sidecar now runs two phases in one
+process: the existing boot phase, then a continuous `runWedgeWatchdog` that
+polls the pane and dismisses a **stable** blocking selector with `Esc`
+(which claude treats as "user declined" — non-destructive).
+
+Conservative by design — false positives (Esc into a *live* turn) are worse
+than false negatives. Fires only on **all three** of: a strict footer
+signature (same-line "Esc…cancel" AND a select/navigate affordance — rejects
+the working footer "esc to interrupt" and the idle REPL footer);
+byte-identical stability across N consecutive polls (default 3 @ 5s ≈ 15s
+confirmed-stuck — a working pane's spinner/timer changes between polls); and
+a post-fire cooldown (default 60s). Defers to first-run prompts (those want
+Enter) and soft-fails throughout. Kill-switch: `SWITCHROOM_WEDGE_WATCHDOG=0`
+restores legacy boot-only behaviour.
+
 ## v0.14.32 — Background worker card routes to the dispatch chat (#2061)
 
 Fixes a routing bug where a background sub-agent's live worker card

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.32",
+  "version": "0.14.33",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release v0.14.33 — the blocking-TUI wedge fix, both layers:

- **Layer 1 (#2064)** — deny `AskUserQuestion` fleet-wide so claude degrades
  to plain text instead of rendering a blocking selector no headless agent
  can answer.
- **Layer 2 (#2065)** — continuous mid-session wedge-watchdog that dismisses
  a *stable* blocking selector with `Esc` (defense-in-depth for selectors
  Layer 1's deny can't reach). Kill-switch `SWITCHROOM_WEDGE_WATCHDOG=0`.

## Why

klanker wedged on a blocking `AskUserQuestion` selector 2026-06-01 and went
mute until a manual tmux `Esc`. These two layers close the class.

## Test plan

- [x] Both constituent PRs reviewed + merged (#2064 APPROVE, #2065 APPROVE).
- [x] `node scripts/build.mjs` clean; `dist/cli/switchroom.js` ~3.0MB.
- [ ] CI green (10 required checks).
- [ ] Canary on test-harness + UAT before fleet rollout.

## Risk

Both layers take effect on agent restart/apply (Layer 2 changes the baked
`autoaccept-poll` bundle). Layer 2 is an always-on keystroke injector,
mitigated by strict signature + multi-poll stability + cooldown + first-run
deferral; only key sent is `Esc`.