### PR TITLE
feat(vault): operator-set agent-level standing secrets grant

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ Each field type has specific merge behavior when values exist at multiple layers
 | `hooks` | per-event concat | Claude Code lifecycle hooks (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SessionEnd) |
 | `env` | per-key | Environment variables for start.sh |
 | `mcp_servers` | per-key | Additional MCP server configurations. Set a key to `false` to suppress a built-in default (e.g. `playwright: false`) |
+| `secrets` | union | **Operator-set** standing vault grant: vault keys this agent may read via the broker, independent of any cron or MCP server. Use for credentials an agent needs both interactively and in its own (agent-managed) schedules. Agents cannot self-grant — this is operator-only by design ([vision.md](../reference/vision.md) outcome 2). See [§ Standing vault grants](#standing-vault-grants-agentsnamesecrets). |
 | `system_prompt_append` | concatenate | Appended to the system prompt via `--append-system-prompt` |
 | `skills` | union | Named skills from the global skills pool (`switchroom.skills_dir`) |
 | `bundled_skills` | per-key | Opt-out map for switchroom's bundled-default skills. Set a key to `false` to suppress (e.g. `pdf: false`). See [docs/skills.md](./skills.md). |
@@ -203,6 +204,40 @@ agents:
     mcp_servers:
       perplexity: false   # this agent doesn't get perplexity (or its vault grant)
 ```
+
+### Standing vault grants — `agents.<name>.secrets`
+
+`mcp_servers[].secrets` ties a grant to an MCP server, and a cron's
+`schedule[].secrets` ties it to one schedule entry. When an agent needs a
+vault key **independent of any server or cron** — typically a skill the
+agent runs both interactively *and* in its own (agent-managed) schedules
+(e.g. a calendar/mail skill that reads an OAuth token via `switchroom vault
+get`) — declare a **standing grant**:
+
+```yaml
+agents:
+  clerk:
+    # Vault keys clerk may read via the broker, always — not welded to a
+    # specific cron or MCP server. Cascades UNION across defaults → profile
+    # → agent. Exact key names.
+    secrets:
+      - microsoft/ken-tokens
+      - microsoft/azure-app
+      - compass/credentials
+```
+
+This is the clean home for "**what this agent may access**", separate from
+"**when it runs**". With it in place, the agent's schedules can be moved to
+agent-managed overlays (which deliberately **cannot** carry `secrets:`) and
+still work, because the standing grant covers the keys.
+
+**Operator-only, by design.** Agents cannot edit `switchroom.yaml` and
+cannot self-grant — only the operator sets `secrets:`. This is
+[vision.md](../reference/vision.md) outcome 2 ("you hold the leash; only
+your tap grants it"): a standing grant *is* the tap, expressed as config.
+Grant another agent's or operator-owned secret only after a deliberate
+decision; never as a way to let an agent reach for credentials it wasn't
+given. Enforced by the vault-broker in `src/vault/broker/acl.ts`.
 
 The `false` opt-out drops the ACL grant too — the broker won't serve `perplexity/api-key` to an agent that disabled the MCP.
 

--- a/src/config/merge.test.ts
+++ b/src/config/merge.test.ts
@@ -114,3 +114,25 @@ describe("mergeAgentConfig — allowed_tools / disallowed_tools cascade", () => 
     expect(result.disallowed_tools).toEqual(["WebFetch", "Bash(rm *)"]);
   });
 });
+
+describe("mergeAgentConfig — secrets (operator standing grant) cascade", () => {
+  it("unions defaults + agent secrets (defaults first, dedup)", () => {
+    const defaults = { secrets: ["shared/key"] } as AgentDefaults;
+    const agent = baseAgent({
+      secrets: ["microsoft/token", "shared/key"],
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.secrets).toEqual(["shared/key", "microsoft/token"]);
+  });
+
+  it("uses agent secrets when defaults absent", () => {
+    const agent = baseAgent({ secrets: ["compass/creds"] } as Partial<AgentConfig>);
+    const result = mergeAgentConfig({} as AgentDefaults, agent);
+    expect(result.secrets).toEqual(["compass/creds"]);
+  });
+
+  it("leaves secrets undefined when neither layer sets it", () => {
+    const result = mergeAgentConfig({} as AgentDefaults, baseAgent({}));
+    expect(result.secrets).toBeUndefined();
+  });
+});

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -343,6 +343,18 @@ export function mergeAgentConfig(
     };
   }
 
+  // --- secrets: union (operator-set STANDING vault grant; defaults first) ---
+  // Cascades like tools.allow so a profile can grant a baseline set and an
+  // agent adds more. Operator-only — agents cannot self-grant. The broker
+  // (acl.ts) reads the SAME union directly from raw yaml; this keeps the
+  // merged-config view consistent for anything else that reads it.
+  if (defaults.secrets || merged.secrets) {
+    merged.secrets = dedupe([
+      ...(defaults.secrets ?? []),
+      ...(merged.secrets ?? []),
+    ]);
+  }
+
   // --- soul: shallow field merge, agent wins ---
   //
   // A default soul can provide a fallback persona ("warm, concise") that

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1449,6 +1449,26 @@ const profileFields = {
     })
     .optional(),
   schedule: z.array(ScheduleEntrySchema).optional(),
+  secrets: z
+    .array(
+      z
+        .string()
+        .regex(
+          /^[a-zA-Z0-9_\-/]+$/,
+          "Secret key names must contain only alphanumeric characters, underscores, hyphens, and forward slashes",
+        ),
+    )
+    .optional()
+    .describe(
+      "Operator-granted STANDING vault keys this agent may read via the " +
+      "broker — independent of any cron or MCP server. Use when an agent " +
+      "needs a credential both interactively and in its own (agent-managed) " +
+      "schedules, so the grant lives with the agent rather than welded to a " +
+      "specific cron's `secrets[]`. OPERATOR-SET ONLY: agents cannot edit " +
+      "switchroom.yaml or self-grant (reference/vision.md outcome 2 — 'you " +
+      "hold the leash; only your tap grants it'). Exact key names. Cascades " +
+      "UNION across defaults -> profile -> agent (see docs/configuration.md).",
+    ),
   reactions: ReactionsSchema,
   model: z
     .string()
@@ -1800,6 +1820,20 @@ export const AgentSchema = z.object({
   tools: AgentToolsSchema,
   memory: AgentMemorySchema,
   schedule: z.array(ScheduleEntrySchema).default([]),
+  // Mirror of profileFields.secrets — must be repeated here because
+  // AgentSchema does not spread profileFields (same pattern as `resources`
+  // below). Operator-set STANDING vault grant; see profileFields.secrets
+  // for the full doc + the broker enforcement in src/vault/broker/acl.ts.
+  secrets: z
+    .array(
+      z
+        .string()
+        .regex(
+          /^[a-zA-Z0-9_\-/]+$/,
+          "Secret key names must contain only alphanumeric characters, underscores, hyphens, and forward slashes",
+        ),
+    )
+    .optional(),
   reactions: ReactionsSchema,
   model: z
     .string()

--- a/src/vault/broker/acl.test.ts
+++ b/src/vault/broker/acl.test.ts
@@ -1019,3 +1019,73 @@ describe("ACL: user-declared MCP-server secrets", () => {
     expect(checkAclByAgent(config, "gymbro", "perplexity/api-key").allow).toBe(false);
   });
 });
+
+describe("ACL: operator-set standing grant (agents.<name>.secrets[])", () => {
+  const cfg = (extra: Record<string, unknown>): SwitchroomConfig =>
+    ({
+      switchroom: { version: 1 },
+      telegram: { bot_token: "t", forum_chat_id: "1" },
+      vault: {
+        path: "~/.switchroom/vault.enc",
+        broker: { socket: "s", enabled: true },
+      },
+      ...extra,
+    }) as unknown as SwitchroomConfig;
+
+  it("grants a key in the agent's standing secrets even with no schedule", () => {
+    const config = cfg({
+      agents: { alice: { topic_name: "alice", secrets: ["microsoft/token"] } },
+    });
+    expect(checkAclByAgent(config, "alice", "microsoft/token").allow).toBe(true);
+  });
+
+  it("denies a key not in the standing grant (no schedule, no mcp)", () => {
+    const config = cfg({
+      agents: { alice: { topic_name: "alice", secrets: ["microsoft/token"] } },
+    });
+    const r = checkAclByAgent(config, "alice", "compass/creds");
+    expect(r.allow).toBe(false);
+    if (!r.allow) expect(r.reason).toContain("standing grant");
+  });
+
+  it("cascades from defaults.secrets", () => {
+    const config = cfg({
+      defaults: { secrets: ["shared/key"] },
+      agents: { alice: { topic_name: "alice" } },
+    });
+    expect(checkAclByAgent(config, "alice", "shared/key").allow).toBe(true);
+  });
+
+  it("cascades from the agent's profile.secrets via extends", () => {
+    const config = cfg({
+      profiles: { base: { secrets: ["profile/key"] } },
+      agents: { alice: { topic_name: "alice", extends: "base" } },
+    });
+    expect(checkAclByAgent(config, "alice", "profile/key").allow).toBe(true);
+  });
+
+  it("unions defaults + profile + agent (all three readable)", () => {
+    const config = cfg({
+      defaults: { secrets: ["d/key"] },
+      profiles: { base: { secrets: ["p/key"] } },
+      agents: {
+        alice: { topic_name: "alice", extends: "base", secrets: ["a/key"] },
+      },
+    });
+    expect(checkAclByAgent(config, "alice", "d/key").allow).toBe(true);
+    expect(checkAclByAgent(config, "alice", "p/key").allow).toBe(true);
+    expect(checkAclByAgent(config, "alice", "a/key").allow).toBe(true);
+    expect(checkAclByAgent(config, "alice", "x/key").allow).toBe(false);
+  });
+
+  it("is per-agent — alice's standing grant is not readable by bob", () => {
+    const config = cfg({
+      agents: {
+        alice: { topic_name: "alice", secrets: ["alice/key"] },
+        bob: { topic_name: "bob", secrets: ["bob/key"] },
+      },
+    });
+    expect(checkAclByAgent(config, "bob", "alice/key").allow).toBe(false);
+    expect(checkAclByAgent(config, "alice", "alice/key").allow).toBe(true);
+  });
+});

--- a/src/vault/broker/acl.ts
+++ b/src/vault/broker/acl.ts
@@ -429,11 +429,41 @@ export function checkAclByAgent(
     }
   }
 
+  // Operator-set STANDING grant — agents.<name>.secrets[] (cascaded
+  // defaults -> profile -> agent, UNION). The clean home for "what this
+  // agent may access", decoupled from a specific cron's schedule[].secrets[]
+  // (which welds access to one schedule entry) and from MCP-server secrets.
+  // Operator-controlled: agents cannot edit switchroom.yaml or self-grant
+  // (reference/vision.md outcome 2 — "you hold the leash; only your tap
+  // grants it"). Read directly from raw yaml here, same as the mcp_servers
+  // cascade above, because the broker doesn't run the full merge pipeline
+  // per request.
+  const cfgSecrets = config as {
+    defaults?: { secrets?: unknown };
+    profiles?: Record<string, { secrets?: unknown }>;
+  };
+  const profileSecrets =
+    profileName != null && profileName.length > 0
+      ? cfgSecrets.profiles?.[profileName]?.secrets
+      : undefined;
+  const standingSecrets: string[] = [
+    ...(Array.isArray(cfgSecrets.defaults?.secrets)
+      ? (cfgSecrets.defaults!.secrets as string[])
+      : []),
+    ...(Array.isArray(profileSecrets) ? (profileSecrets as string[]) : []),
+    ...(Array.isArray((agentConfig as { secrets?: unknown }).secrets)
+      ? ((agentConfig as { secrets?: string[] }).secrets as string[])
+      : []),
+  ];
+  if (standingSecrets.includes(key)) {
+    return { allow: true };
+  }
+
   const schedule = agentConfig.schedule ?? [];
   if (schedule.length === 0) {
     return {
       allow: false,
-      reason: `agent '${agentName}' has no schedule entries declaring 'secrets' and no mcp_servers.*.secrets[] declaring '${key}'; nothing is broker-accessible`,
+      reason: `agent '${agentName}' has no schedule entries declaring 'secrets', no mcp_servers.*.secrets[], and no agents.${agentName}.secrets[] standing grant declaring '${key}'; nothing is broker-accessible`,
     };
   }
 


### PR DESCRIPTION
## Summary
Adds `agents.<name>.secrets[]` — an **operator-set standing vault grant** the broker honours for an agent **independent of any cron or MCP server**. Cascades UNION across `defaults → profile → agent`.

## Why (design review against the vision)
Today an agent can only be granted a vault key by welding it to a specific cron's `schedule[].secrets[]` or an `mcp_servers[].secrets`. Skill-based credentials an agent needs **both interactively and in its own agent-managed schedules** (e.g. clerk's `microsoft/*` + `compass/credentials`, read via `switchroom vault get` inside the mail/calendar/compass skills) had no clean home — the grant leaked in only via a cron, tangling *"what the agent may access"* with *"when it runs."*

This separates them: a **standing grant** is "what it may access"; the **schedule** is "when it runs." It's the primitive that lets an agent own its scheduling (overlay crons, which deliberately can't carry secrets) while the operator still controls access.

**Operator-only by design** — agents can't edit `switchroom.yaml` or self-grant ([vision.md](../blob/main/reference/vision.md) outcome 2, *"you hold the leash; only your tap grants it"*). A standing grant **is** the tap, expressed as config. This was deliberately scoped to *not* add agent self-grant / ownership-confers-authority, which fails outcome 2 and all three principle checks.

**Purely additive:** an agent with no `secrets:` is unaffected — the new ACL clause yields an empty set and falls through to the existing mcp/schedule paths.

## Changes
- `schema.ts`: `secrets` in `profileFields` (defaults/profile) + mirrored into `AgentSchema` (which doesn't spread profileFields).
- `merge.ts`: UNION cascade (defaults first, dedup), mirroring `tools.allow`.
- `acl.ts` (broker enforcement): grant if key ∈ cascaded standing set; updated the no-access deny reason.
- `docs/configuration.md`: field-reference row + "Standing vault grants" section.

## Test plan
- [x] 6 acl tests + 3 merge tests (standing grant w/ no schedule, defaults/profile cascade, 3-layer union, per-agent isolation, deny-reason).
- [x] Full `vitest run src/vault src/config` — **584 pass**.
- [x] `npm run lint` — all 7 guards clean (tsc, plugin-refs, bot-api, bun-test-imports, no-pii, vault-hermeticity, no-broadcast).

## Risk
Low / additive. New grant clause only; no existing path altered. Broker-side change → requires a broker roll on release. DM/no-`secrets` agents unaffected.

## Follow-up (separate security PR, **not** bundled)
`mint_grant` has no key-ACL check on the posture path — a `postureMintAgents` agent that can speak the broker wire protocol could self-mint arbitrary grants. The safe fix binds mint to a consumed approval-kernel decision (so `vault_request_access` keeps working). Its own carefully-tested PR.

## JTBD / vision
Outcome 2 — *you hold the leash.* Makes "operator grants standing access, decoupled from crons" first-class, so agents can own their schedules without owning the grant.