### PR TITLE
feat(vault): stop agents guessing key names — self-correcting denied hint + discovery guidance

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -263,6 +263,31 @@ false\` in that agent's switchroom.yaml block — webkite goes away
 and the native tools come back together.`;
 
 /**
+ * Vault key discovery. One of the fleet invariant blocks. Stops the
+ * single most common vault failure: an agent GUESSING a secret's key
+ * name (\`postiz/api-key\`) when it already holds the real one
+ * (\`marko/postiz-api-key\`), then burning an operator approval on a
+ * \`vault_request_access\` for a key that doesn't exist.
+ * See SANDBOX_GUIDANCE above for the constant-vs-\`.hbs\` rationale.
+ */
+const VAULT_GUIDANCE = `## Secrets in the vault — discover, don't guess
+
+Your API keys and credentials live in the Switchroom vault. For normal
+MCP-tool work they're injected by the launchers and you never touch the
+raw values. When a task needs a secret directly (a direct API call an
+MCP tool has no verb for), read it with \`switchroom vault get <key>\`.
+
+**Never guess a key name.** Run \`switchroom vault list\` to see the
+exact keys you already hold — they're usually namespaced \`<you>/...\`
+(e.g. \`marko/postiz-api-key\`, not \`postiz/api-key\`). Use the real
+name from that list.
+
+Only call the \`vault_request_access\` MCP tool — which pings the
+operator for a Telegram approval — for a key you've **confirmed via
+\`vault list\` you don't already have.** Requesting access to a guessed
+or already-held key wastes the operator's tap and fails.`;
+
+/**
  * Canonical rendering of the fleet invariants file written to
  * `~/.switchroom/fleet/switchroom-invariants.md`. Apply checksums
  * this against the on-disk file and restores on drift. Operators
@@ -296,6 +321,8 @@ export function renderFleetInvariants(): string {
     MEMORY_GUIDANCE,
     "",
     WEB_FETCH_GUIDANCE,
+    "",
+    VAULT_GUIDANCE,
     "",
   ].join("\n");
 }

--- a/src/cli/vault-key-suggest.test.ts
+++ b/src/cli/vault-key-suggest.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { suggestVaultKeys } from "./vault-key-suggest.js";
+
+// The keys an agent (marko) actually holds, from `switchroom vault list`.
+const MARKO_KEYS = [
+  "perplexity/api-key",
+  "webkite/cloudflare-account-id",
+  "webkite/cloudflare-api-token",
+  "marko-bot-token",
+  "marko/postiz-api-key",
+  "marko/cf-access-client-id",
+  "marko/cf-access-client-secret",
+  "marko/brevo-api-key",
+  "marko/meta-access-token",
+  "meta/page-token",
+  "marko/meta-ads-token",
+];
+
+describe("suggestVaultKeys", () => {
+  it("maps a guessed postiz key to the real namespaced one, ranked first", () => {
+    const out = suggestVaultKeys("postiz/api-key", MARKO_KEYS);
+    expect(out[0]).toBe("marko/postiz-api-key");
+  });
+
+  it("maps a guessed cf-access key to the real one", () => {
+    expect(suggestVaultKeys("postiz/cf-access-client-id", MARKO_KEYS)[0]).toBe(
+      "marko/cf-access-client-id",
+    );
+    expect(
+      suggestVaultKeys("postiz/cf-access-client-secret", MARKO_KEYS)[0],
+    ).toBe("marko/cf-access-client-secret");
+  });
+
+  it("returns nothing when no token overlaps at all", () => {
+    expect(suggestVaultKeys("garmin/oauth-token-totally-different", ["foo/bar-baz"])).toEqual(
+      [],
+    );
+  });
+
+  it("never suggests the requested key itself", () => {
+    expect(suggestVaultKeys("marko/postiz-api-key", MARKO_KEYS)).not.toContain(
+      "marko/postiz-api-key",
+    );
+  });
+
+  it("caps the number of suggestions", () => {
+    expect(suggestVaultKeys("marko/x-token", MARKO_KEYS, 2).length).toBeLessThanOrEqual(2);
+  });
+
+  it("ranks more-shared-tokens above fewer", () => {
+    const out = suggestVaultKeys("marko/postiz-api-key-extra", MARKO_KEYS, 5);
+    // postiz-api-key shares postiz/api/key (+marko) — must outrank brevo-api-key (api/key).
+    expect(out.indexOf("marko/postiz-api-key")).toBeLessThan(
+      out.indexOf("marko/brevo-api-key"),
+    );
+  });
+
+  it("is case-insensitive and tolerates empty input", () => {
+    expect(suggestVaultKeys("POSTIZ/API-KEY", MARKO_KEYS)[0]).toBe("marko/postiz-api-key");
+    expect(suggestVaultKeys("", MARKO_KEYS)).toEqual([]);
+    expect(suggestVaultKeys("postiz/api-key", [])).toEqual([]);
+  });
+});

--- a/src/cli/vault-key-suggest.ts
+++ b/src/cli/vault-key-suggest.ts
@@ -1,0 +1,52 @@
+/**
+ * Near-match suggestion for a denied/guessed vault key.
+ *
+ * When an agent asks the broker for a key it doesn't hold, the most
+ * common cause is a *guessed* name (e.g. `postiz/api-key` when the
+ * real, already-granted key is `marko/postiz-api-key`). Rather than
+ * push the agent straight to `vault_request_access` — which mints a
+ * grant for a key that may not even exist — we surface the keys it
+ * ALREADY has access to that look like what it asked for.
+ *
+ * Pure + dependency-free so it's trivially unit-tested. The caller
+ * fetches `available` from the broker `list` op (which returns exactly
+ * the keys this agent is allowed to read — no info leak beyond what
+ * `switchroom vault list` already discloses to the agent).
+ */
+
+/** Split a key into lowercased, non-empty tokens on `/`, `-`, `_`, `.`. */
+function tokenize(key: string): string[] {
+  return key
+    .toLowerCase()
+    .split(/[/\-_.]+/)
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * Rank `available` keys by similarity to `requested` and return up to
+ * `max` of the closest. A candidate must share at least one token to
+ * be suggested at all. Ranking: most shared tokens first; ties broken
+ * by the smaller symmetric token difference (closer overall shape).
+ */
+export function suggestVaultKeys(
+  requested: string,
+  available: string[],
+  max = 3,
+): string[] {
+  const want = new Set(tokenize(requested));
+  if (want.size === 0) return [];
+
+  const scored = available
+    .map((key) => {
+      const have = new Set(tokenize(key));
+      let shared = 0;
+      for (const t of have) if (want.has(t)) shared++;
+      // symmetric difference: tokens in exactly one of the two sets
+      const diff = want.size + have.size - 2 * shared;
+      return { key, shared, diff };
+    })
+    .filter((c) => c.shared > 0 && c.key !== requested)
+    .sort((a, b) => b.shared - a.shared || a.diff - b.diff);
+
+  return scored.slice(0, max).map((c) => c.key);
+}

--- a/src/cli/vault.ts
+++ b/src/cli/vault.ts
@@ -28,6 +28,7 @@ import {
   resolveBrokerSocketPath,
   readVaultTokenFile,
 } from "../vault/broker/client.js";
+import { suggestVaultKeys } from "./vault-key-suggest.js";
 import { registerVaultBrokerCommand } from "./vault-broker.js";
 import { registerVaultDoctorCommand } from "./vault-doctor.js";
 import { registerVaultAuditCommand } from "./vault-audit.js";
@@ -102,6 +103,7 @@ function refuseSandboxDirectAccess(verbHint: string): never {
 function recoveryHint(
   situation: "denied" | "locked" | "unreachable",
   key?: string,
+  suggestions?: string[],
 ): string {
   if (!isSandboxContext()) {
     const keyArg = key ? ` ${key}` : "";
@@ -110,15 +112,36 @@ function recoveryHint(
   // Inside an agent. The vault.enc file isn't mounted; `--no-broker`
   // can't work. Tell the agent what *can* work.
   switch (situation) {
-    case "denied":
+    case "denied": {
+      // A denied get is usually a GUESSED key name, not a real missing
+      // grant. Steer the agent to the keys it ALREADY holds before it
+      // mints a grant for a name that may not exist. `vault list` /
+      // suggestions come first; `vault_request_access` is last resort.
+      const named = key ? `'${key}'` : "this key";
+      if (suggestions && suggestions.length > 0) {
+        return (
+          `Hint: you have no grant for ${named} — that key may not even exist. ` +
+          `You ALREADY have access to similar keys: ${suggestions.join(", ")}. ` +
+          `Try \`switchroom vault get <one-of-those>\` instead. ` +
+          `Run \`switchroom vault list\` to see every key you hold. ` +
+          `Only call the \`vault_request_access\` MCP tool for a key you've ` +
+          `confirmed (via \`vault list\`) you don't already have. ` +
+          `Do NOT retry with --no-broker — the vault file is not mounted ` +
+          `into agent containers.`
+        );
+      }
       return (
-        `Hint: this agent has no grant for ${key ? `'${key}'` : "this key"}. ` +
-        `Call the \`vault_request_access\` MCP tool ` +
+        `Hint: this agent has no grant for ${named}. ` +
+        `FIRST run \`switchroom vault list\` to see the keys you already hold — ` +
+        `the real name often differs from a guessed one (it's usually ` +
+        `namespaced \`<you>/...\`). ` +
+        `If you genuinely lack it, call the \`vault_request_access\` MCP tool ` +
         `(key=${key ? `'${key}'` : "'<key>'"}, scope='read') ` +
         `to ask the operator for access via a Telegram approval card. ` +
         `Do NOT retry with --no-broker — the vault file is not mounted ` +
         `into agent containers.`
       );
+    }
     case "locked":
       return (
         `Hint: the broker is locked. Ask the operator to unlock it ` +
@@ -875,12 +898,25 @@ export function registerVaultCommand(program: Command): void {
               );
               // fall through to direct-decrypt block below
             } else {
+              // A denied get is almost always a GUESSED key name. The
+              // broker `list` op returns exactly the keys THIS agent can
+              // read (no info leak beyond `switchroom vault list`), so we
+              // look up near-matches and steer the agent to a key it
+              // already holds instead of minting a grant for a name that
+              // may not exist. Best-effort — never let it mask the denial.
+              let suggestions: string[] = [];
+              try {
+                const myKeys = await listViaBroker(brokerOpts);
+                if (myKeys && key) suggestions = suggestVaultKeys(key, myKeys);
+              } catch {
+                /* suggestions are advisory; ignore lookup failures */
+              }
               // Write a VAULT-BROKER-DENIED prefix so scripts/agents that
               // capture stdout/stderr can grep for it even when the full
               // message isn't surfaced in their UI.
               process.stderr.write(
                 `VAULT-BROKER-DENIED [${result.code}]: ${result.msg}\n` +
-                `${recoveryHint("denied", key)}\n`
+                `${recoveryHint("denied", key, suggestions)}\n`
               );
               writeVaultDeniedEnvelope(key, result.code, result.msg);
               process.exit(2);

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2571,6 +2571,19 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(out).toContain("Operator action");
   });
 
+  it("renderFleetInvariants() tells agents to discover vault keys, not guess", async () => {
+    // Stops the most common vault failure: an agent guessing a key name
+    // (`postiz/api-key`) when it already holds `marko/postiz-api-key`,
+    // then burning an operator approval on a request for a non-existent
+    // key. Companion to the self-correcting denied-hint in vault.ts.
+    const { renderFleetInvariants } = await import("../src/agents/scaffold.js");
+    const out = renderFleetInvariants();
+    expect(out).toContain("Secrets in the vault");
+    expect(out).toContain("switchroom vault list");
+    expect(out).toContain("Never guess a key name");
+    expect(out).toContain("vault_request_access");
+  });
+
   it("renderFleetInvariants() teaches scannable formatting for multi-section replies", async () => {
     // D2: the live Telegram guidance is the TELEGRAM_GUIDANCE constant
     // rendered here (NOT profiles/_shared/telegram-style.md.hbs, which is


### PR DESCRIPTION
## Summary
Agents have no innate knowledge of their vault key names, so they **guess** — e.g. `postiz/api-key` when the real, already-granted key is `marko/postiz-api-key`. The old denied-hint then steered them straight to `vault_request_access`, **burning an operator approval on a key that doesn't exist**. (Live incident: marko, 2026-06-02 — three failed mint requests for non-existent `postiz/*` keys it already held under `marko/postiz-*`.)

## Why
JTBD: "you hold the leash" + the defaults/docs principle checks. A guessed key shouldn't cost the operator a tap; the system should self-correct the agent to a key it already has.

## Changes
**A. Self-correcting denied error** (`src/cli/vault.ts`, new `src/cli/vault-key-suggest.ts`)
- On a broker-denied `get` inside an agent, fetch the keys the agent **actually holds** (broker `list` op — same disclosure as `switchroom vault list`, no info leak) and surface near-matches via a pure token-overlap ranker.
- The hint now leads with *"you already have access to `<real key>` — use that"* and *"run `vault list`"*, demoting `vault_request_access` to a confirmed-last-resort.
- Best-effort: a list-lookup failure never masks the denial.

**B. Proactive fleet guidance** (`VAULT_GUIDANCE` in `scaffold.ts` → fleet invariants)
- Teaches every agent: read with `vault get`, **never guess**, `vault list` shows your real `<you>/...` keys, only `vault_request_access` for a key you've confirmed you lack.

## Test plan
- [x] `vault-key-suggest.test.ts` — 7 cases (guess→real mapping, ranking, no-overlap→empty, self-exclusion, cap, case-insensitivity)
- [x] `tests/scaffold.test.ts` — new assertion that invariants teach `vault list` / "never guess"
- [x] `vault-denied-envelope.test.ts` unaffected (envelope unchanged)
- [x] `tsc --noEmit` clean

## Risk
Low. The denied path is an error path; the change only enriches the human-readable hint string (the machine `ERROR-ENVELOPE:` line is untouched, so structured consumers are unaffected). The fleet-guidance const is additive text. No runtime/behavior change on the success path.