### PR TITLE
fix(telegram): backfill subagent parent_turn_key from started_at at jsonl-link time

### DIFF
--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -263,10 +263,11 @@ function main() {
       id: event.tool_use_id ?? null,
       parentSessionId: event.session_id ?? null,
       // parent_turn_key is intentionally NULL here. Claude Code's PreToolUse
-      // payload carries its own session id, not the Telegram turn_key
-      // (chat_id:msg_id) the gateway keys turns on — `event.turn_id` is always
-      // undefined, and even if a future CLI populated it, it would not match a
-      // `turns.turn_key`. The gateway resolves parent_turn_key from the
+      // payload carries its own session id, not the gateway-minted Telegram
+      // turn_key (a chat+topic+turn key) the `turns` table is keyed on —
+      // `event.turn_id` is always undefined, and even if a future CLI
+      // populated it, it would not match a `turns.turn_key`. The gateway
+      // resolves parent_turn_key from the
       // sub-agent's started_at at jsonl-link time (subagent-watcher.ts
       // backfillJsonlAgentId), which works even after the parent turn ends.
       // Writing a bogus value here would defeat that backfill's

--- a/telegram-plugin/hooks/subagent-tracker-pretool.mjs
+++ b/telegram-plugin/hooks/subagent-tracker-pretool.mjs
@@ -262,7 +262,16 @@ function main() {
     {
       id: event.tool_use_id ?? null,
       parentSessionId: event.session_id ?? null,
-      parentTurnKey: event.turn_id ?? null,
+      // parent_turn_key is intentionally NULL here. Claude Code's PreToolUse
+      // payload carries its own session id, not the Telegram turn_key
+      // (chat_id:msg_id) the gateway keys turns on — `event.turn_id` is always
+      // undefined, and even if a future CLI populated it, it would not match a
+      // `turns.turn_key`. The gateway resolves parent_turn_key from the
+      // sub-agent's started_at at jsonl-link time (subagent-watcher.ts
+      // backfillJsonlAgentId), which works even after the parent turn ends.
+      // Writing a bogus value here would defeat that backfill's
+      // `parent_turn_key IS NULL` guard.
+      parentTurnKey: null,
       agentType: input.subagent_type ?? null,
       description: input.description ?? null,
       background: input.run_in_background === true ? 1 : 0,

--- a/telegram-plugin/registry/subagents-bugs.test.ts
+++ b/telegram-plugin/registry/subagents-bugs.test.ts
@@ -387,8 +387,16 @@ describe('Bug 4 — result_summary always NULL (hook integration)', () => {
 
 // ─── Bug 5 — parent_turn_key always NULL ─────────────────────────────────────
 
-describe('Bug 5 — parent_turn_key always NULL (hook integration)', () => {
-  it('pretool stores parent_turn_key from event.turn_id', () => {
+describe('Bug 5 — parent_turn_key backfilled by gateway, not the hook', () => {
+  it('pretool writes parent_turn_key=NULL even when event.turn_id is present', () => {
+    // Claude Code's PreToolUse payload carries its own session id, never the
+    // gateway-minted Telegram turn_key (a chat+topic+turn key) the `turns`
+    // table is keyed on. `event.turn_id` — even if a future CLI populated it —
+    // would not match a `turns.turn_key`, so the hook intentionally writes
+    // NULL and lets the gateway backfill parent_turn_key from the sub-agent's
+    // started_at at jsonl-link time (subagent-watcher.ts backfillJsonlAgentId).
+    // Writing a bogus value here would defeat that backfill's
+    // `parent_turn_key IS NULL` guard.
     const event = {
       session_id: 'sess-turnkey',
       turn_id: 'turn-abc-001',
@@ -406,8 +414,8 @@ describe('Bug 5 — parent_turn_key always NULL (hook integration)', () => {
       | undefined
 
     expect(row).toBeDefined()
-    // After fix: parent_turn_key should be populated from event.turn_id
-    expect(row!.parent_turn_key).toBe('turn-abc-001')
+    // The hook never trusts event.turn_id — gateway backfill owns this column.
+    expect(row!.parent_turn_key).toBeNull()
   })
 
   it('pretool stores parent_turn_key as NULL when turn_id absent (no regression)', () => {

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -560,8 +560,9 @@ export function backfillJsonlAgentId(
   log?.(`subagent-watcher: backfill linked ${agentId} → ${candidate.id}`)
 
   // Backfill parent_turn_key (gateway-side). The PreToolUse hook can't know
-  // the Telegram turn_key (chat_id:msg_id) — it only sees Claude Code's
-  // session id — so the row was inserted with parent_turn_key=NULL. Resolve
+  // the gateway-minted Telegram turn_key (a chat+topic+turn key) — it only
+  // sees Claude Code's session id — so the row was inserted with
+  // parent_turn_key=NULL. Resolve
   // it now from the turn whose [started_at, ended_at] window contained the
   // sub-agent's dispatch (its started_at). Keying on the historical
   // started_at, NOT "the turn active now", is what makes this correct for a

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -508,7 +508,10 @@ interface FsLike {
  *   - Row already linked to a different agentId: SQL `WHERE jsonl_agent_id IS
  *     NULL` skips it. Re-runs are safe.
  */
-function backfillJsonlAgentId(
+// Exported for unit-testing the parent_turn_key backfill (telegram-plugin/
+// tests/subagent-watcher-parent-turn-key.test.ts). Not intended for
+// consumption by other modules.
+export function backfillJsonlAgentId(
   db: SubagentLivenessDb,
   jsonlPath: string,
   agentId: string,
@@ -555,6 +558,46 @@ function backfillJsonlAgentId(
     .prepare('UPDATE subagents SET jsonl_agent_id = ? WHERE id = ?')
     .run(agentId, candidate.id)
   log?.(`subagent-watcher: backfill linked ${agentId} → ${candidate.id}`)
+
+  // Backfill parent_turn_key (gateway-side). The PreToolUse hook can't know
+  // the Telegram turn_key (chat_id:msg_id) — it only sees Claude Code's
+  // session id — so the row was inserted with parent_turn_key=NULL. Resolve
+  // it now from the turn whose [started_at, ended_at] window contained the
+  // sub-agent's dispatch (its started_at). Keying on the historical
+  // started_at, NOT "the turn active now", is what makes this correct for a
+  // background worker that outlives its parent turn: the turn may have already
+  // ended by link time, but the containment match still finds it. Turns are
+  // processed serially per agent, so at most one window contains a given
+  // instant; the ORDER BY ... DESC LIMIT 1 is just a defensive tie-break.
+  //
+  // Without this, resolveSubagentOriginChat() returns null and the live
+  // worker card + handback fall back to the operator DM instead of the
+  // originating group/forum-topic, and resolveCallingSubagent()'s turn-scoped
+  // heuristic (WHERE parent_turn_key = ?) can never see the row. Best-effort:
+  // any failure leaves parent_turn_key NULL (today's behaviour) and never
+  // throws out of the watcher poll loop.
+  try {
+    const linkedRow = db
+      .prepare('SELECT started_at, parent_turn_key FROM subagents WHERE id = ?')
+      .get(candidate.id) as { started_at: number; parent_turn_key: string | null } | null
+    if (linkedRow != null && linkedRow.parent_turn_key == null) {
+      const turn = db
+        .prepare(
+          `SELECT turn_key FROM turns
+           WHERE started_at <= ? AND (ended_at IS NULL OR ended_at >= ?)
+           ORDER BY started_at DESC LIMIT 1`,
+        )
+        .get(linkedRow.started_at, linkedRow.started_at) as { turn_key: string } | null
+      if (turn?.turn_key != null) {
+        db
+          .prepare('UPDATE subagents SET parent_turn_key = ? WHERE id = ?')
+          .run(turn.turn_key, candidate.id)
+        log?.(`subagent-watcher: backfill parent_turn_key ${candidate.id} → ${turn.turn_key}`)
+      }
+    }
+  } catch (err) {
+    log?.(`subagent-watcher: parent_turn_key backfill skipped for ${candidate.id} — ${(err as Error).message}`)
+  }
 }
 
 // Exported for unit-testing the ENOENT/EACCES deregister path

--- a/telegram-plugin/tests/subagent-watcher-parent-turn-key.test.ts
+++ b/telegram-plugin/tests/subagent-watcher-parent-turn-key.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for the parent_turn_key backfill in subagent-watcher.ts
+ * (backfillJsonlAgentId).
+ *
+ * The PreToolUse hook records a sub-agent row with parent_turn_key=NULL — it
+ * only sees Claude Code's session id, never the Telegram turn_key
+ * (chat_id:msg_id) the gateway keys turns on. The gateway backfills
+ * parent_turn_key when it links the JSONL stem to the row, resolving it from
+ * the turn whose [started_at, ended_at] window contained the sub-agent's
+ * dispatch (its started_at). These tests pin that resolution — in particular
+ * that it stays correct for a background worker that outlives its parent turn.
+ *
+ * bun:sqlite — run under Bun:
+ *   bun test telegram-plugin/tests/subagent-watcher-parent-turn-key.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { openTurnsDbInMemory } from '../registry/turns-schema.js'
+import { applySubagentsSchema } from '../registry/subagents-schema.js'
+import { backfillJsonlAgentId } from '../subagent-watcher.js'
+
+type Db = ReturnType<typeof openTurnsDbInMemory>
+
+let tempDir: string
+let db: Db
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'sub-parent-turn-'))
+  db = openTurnsDbInMemory()
+  applySubagentsSchema(db)
+})
+
+afterEach(() => {
+  try { db.close() } catch { /* ignore */ }
+  try { rmSync(tempDir, { recursive: true, force: true }) } catch { /* ignore */ }
+})
+
+function insertTurn(args: {
+  turnKey: string
+  chatId: string
+  threadId?: string | null
+  startedAt: number
+  endedAt?: number | null
+}) {
+  db.prepare(`
+    INSERT INTO turns (turn_key, chat_id, thread_id, started_at, ended_at, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    args.turnKey,
+    args.chatId,
+    args.threadId ?? null,
+    args.startedAt,
+    args.endedAt ?? null,
+    args.startedAt,
+    args.startedAt,
+  )
+}
+
+function insertSub(args: {
+  id: string
+  agentType: string
+  description: string
+  startedAt: number
+  parentTurnKey?: string | null
+}) {
+  db.prepare(`
+    INSERT INTO subagents
+      (id, parent_session_id, parent_turn_key, agent_type, description,
+       background, started_at, last_activity_at, status, jsonl_agent_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'running', NULL)
+  `).run(
+    args.id,
+    'sess-1',
+    args.parentTurnKey ?? null,
+    args.agentType,
+    args.description,
+    1,
+    args.startedAt,
+    args.startedAt,
+  )
+}
+
+/** Write the meta.json the backfill reads to match a row by (agentType, description). */
+function writeMeta(agentType: string, description: string): string {
+  const jsonlPath = join(tempDir, 'worker.jsonl')
+  writeFileSync(join(tempDir, 'worker.meta.json'), JSON.stringify({ agentType, description }))
+  return jsonlPath
+}
+
+function readSub(id: string) {
+  return db.prepare('SELECT jsonl_agent_id, parent_turn_key FROM subagents WHERE id = ?').get(id) as
+    | { jsonl_agent_id: string | null; parent_turn_key: string | null }
+    | undefined
+}
+
+describe('backfillJsonlAgentId — parent_turn_key resolution', () => {
+  it('resolves parent_turn_key from the turn whose window contains the sub-agent started_at', () => {
+    insertTurn({ turnKey: '555:10', chatId: '555', threadId: '42', startedAt: 1000, endedAt: 2000 })
+    insertSub({ id: 'toolu_a', agentType: 'worker', description: 'Go-live sync', startedAt: 1500 })
+
+    const jsonlPath = writeMeta('worker', 'Go-live sync')
+    backfillJsonlAgentId(db, jsonlPath, 'agentstem_a')
+
+    const row = readSub('toolu_a')
+    expect(row?.jsonl_agent_id).toBe('agentstem_a')
+    expect(row?.parent_turn_key).toBe('555:10')
+  })
+
+  it('resolves to the parent turn even after it has ended (background worker outlives the turn)', () => {
+    // Parent turn already ended at 1600; a later turn is active "now".
+    insertTurn({ turnKey: '555:10', chatId: '555', startedAt: 1000, endedAt: 1600 })
+    insertTurn({ turnKey: '555:20', chatId: '555', startedAt: 1700, endedAt: null })
+    // The worker was dispatched at 1500 — inside the FIRST (now-ended) turn.
+    insertSub({ id: 'toolu_b', agentType: 'worker', description: 'Long task', startedAt: 1500 })
+
+    const jsonlPath = writeMeta('worker', 'Long task')
+    backfillJsonlAgentId(db, jsonlPath, 'agentstem_b')
+
+    // Must pick the containing (ended) turn, NOT the turn active at link time.
+    expect(readSub('toolu_b')?.parent_turn_key).toBe('555:10')
+  })
+
+  it('does NOT overwrite an already-populated parent_turn_key', () => {
+    insertTurn({ turnKey: '555:10', chatId: '555', startedAt: 1000, endedAt: 2000 })
+    insertSub({
+      id: 'toolu_c',
+      agentType: 'worker',
+      description: 'Preset',
+      startedAt: 1500,
+      parentTurnKey: '999:9',
+    })
+
+    const jsonlPath = writeMeta('worker', 'Preset')
+    backfillJsonlAgentId(db, jsonlPath, 'agentstem_c')
+
+    expect(readSub('toolu_c')?.parent_turn_key).toBe('999:9')
+  })
+
+  it('leaves parent_turn_key NULL when no turn window contains the dispatch', () => {
+    insertTurn({ turnKey: '555:10', chatId: '555', startedAt: 1000, endedAt: 2000 })
+    // Dispatched at 50 — before any turn started.
+    insertSub({ id: 'toolu_d', agentType: 'worker', description: 'Orphan', startedAt: 50 })
+
+    const jsonlPath = writeMeta('worker', 'Orphan')
+    backfillJsonlAgentId(db, jsonlPath, 'agentstem_d')
+
+    const row = readSub('toolu_d')
+    // Still linked, but no turn to attribute it to.
+    expect(row?.jsonl_agent_id).toBe('agentstem_d')
+    expect(row?.parent_turn_key == null).toBe(true)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -182,6 +182,8 @@ export default defineConfig({
       "**/telegram-plugin/tests/idle-footer-wiring.test.ts",
       // subagent-tracker-hooks.test.ts uses bun:test — excluded here, run via test:bun.
       "**/telegram-plugin/tests/subagent-tracker-hooks.test.ts",
+      // subagent-watcher-parent-turn-key.test.ts uses bun:sqlite + bun:test — run via test:bun.
+      "**/telegram-plugin/tests/subagent-watcher-parent-turn-key.test.ts",
       // subagents-bugs.test.ts uses bun:sqlite + bun:test — excluded here, run via test:bun.
       "**/telegram-plugin/registry/subagents-bugs.test.ts",
       // subagents-schema-init-order.test.ts uses bun:sqlite + bun:test — excluded here, run via test:bun.


### PR DESCRIPTION
## Summary

A sub-agent registry row's `parent_turn_key` was **always NULL** in production. The PreToolUse hook read `event.turn_id`, but Claude Code's hook payload carries only its own **session id**, never the Telegram **turn_key** (`chat_id:msg_id`) the gateway keys turns on. This PR resolves `parent_turn_key` gateway-side instead.

## Why

`parent_turn_key` is the only link from a sub-agent back to the conversation it was dispatched from. With it NULL:

1. **Worker card / handback route to the operator DM**, not the originating group/forum-topic — `resolveSubagentOriginChat()` (`gateway.ts:1141`) bails on `sub?.parent_turn_key == null`. (This is the residual gap noted when #2075 landed: the background worker card now fires, but lands in DM.)
2. **`resolveCallingSubagent()`'s turn-scoped heuristic** (`resolve-calling-subagent.ts:63`, `WHERE parent_turn_key = ?`) can never see the row, weakening `progress_update` attribution.

The hook fundamentally can't know the turn_key — it's a Telegram-side construct the gateway mints. So resolve it where the gateway *does* know: at jsonl-link time.

## What changed

`telegram-plugin/subagent-watcher.ts` — `backfillJsonlAgentId` (now exported for testing): after linking the JSONL stem to the row, if `parent_turn_key IS NULL`, resolve it from the turn whose `[started_at, ended_at]` window **contained the sub-agent's `started_at`** and write it.

- **Keying on the historical `started_at`, not "the turn active now", is the crux.** A background worker outlives its parent turn (the clerk case — ran ~3 min past turn-end), so a "current turn" lookup would miss or mis-attribute. The containment match still finds the now-ended parent turn. A test pins exactly this (a *later* turn is active at link time; the backfill must still pick the earlier containing one).
- Turns are processed serially per agent → at most one window contains a given instant; `ORDER BY started_at DESC LIMIT 1` is a defensive tie-break.
- **Best-effort + idempotent:** never overwrites an existing value, leaves NULL when no window matches, wrapped in try/catch so it never throws out of the watcher poll loop.

`telegram-plugin/hooks/subagent-tracker-pretool.mjs` — writes `parent_turn_key=NULL` explicitly, dropping the dead `event.turn_id` read. Prevents a future CLI that populates `turn_id` with a non-turn_key value from writing a bogus key that would defeat the backfill's `IS NULL` guard.

## Test plan

- [x] `bun test telegram-plugin/tests/subagent-watcher-parent-turn-key.test.ts` — 4/4 (new file):
  - resolves from the containing turn window
  - resolves to the parent turn **even after it ended** (bg worker outlives turn; a later turn is active)
  - does NOT overwrite an already-populated `parent_turn_key`
  - leaves NULL when no window contains the dispatch
- [x] Regression: `subagent-watcher` / `subagent-tracker-hooks` / `subagent-registry-bugs` / `resolve-calling-subagent` / `enoent-deregister` — 59/59 pass
- [x] `tsc --noEmit` clean · `check-plugin-references.mjs` clean

## Risk

Low, surgical, additive. No schema change (the column has existed). Worst case (clock skew / overlapping turns) is the same NULL we have today → DM fallback. Follows #2075 (background-flag fix) — together they make the background worker card both *fire* and *land in the right topic*. Serves the worker-activity-feed visibility JTBD.