### PR TITLE
feat(supergroup): zero-config easy-mode defaults

### DIFF
--- a/docs/rfcs/supergroup-easy-defaults.md
+++ b/docs/rfcs/supergroup-easy-defaults.md
@@ -1,0 +1,107 @@
+# RFC: Supergroup easy-mode defaults (zero-config "agent owns a working room")
+
+**Status:** Phase 1 implemented (this PR)
+**Owner:** Ken Thompson
+**Date:** 2026-06-02
+**Related:** [supergroup-mode.md](./supergroup-mode.md) (the topology this builds on),
+`reference/principles.md`, `reference/extend-without-forking.md`,
+`reference/talk-to-agents-from-anywhere.md`.
+
+## 1. Summary
+
+Make the supergroup-owned topology **zero-config easy mode**: an operator
+points an agent at a Telegram supergroup and it Just Works — responds to
+every message, in every topic (including ones created later), with DMs
+still served — without hand-editing `access.json` or picking a default
+topic.
+
+This came out of enabling marko in the "Panorama Marketing" group, which
+required: discovering the `group_unknown` drop, knowing `access.json` is
+`writeIfMissing`, hand-merging the group, and hand-picking `default_topic_id`.
+None of that is something a user should have to do.
+
+## 2. Which outcome / JTBD it serves
+
+- **Outcome 1 — "a standing team that knows you":** *"Add a specialist in
+  ten lines of YAML. You don't fork the product."* A supergroup specialist
+  should be the same: a couple of config lines, not surgery.
+- **JTBD `extend-without-forking`:** *"adds a new agent… by configuring it,
+  not by editing the product. The scaffolding does the boilerplate."*
+- **JTBD `talk-to-agents-from-anywhere`:** a dedicated working room per
+  specialist is a natural surface.
+
+**Leash check (outcome 2):** unchanged. "Responds to everything" only
+affects which messages the agent *reads* in a group it *owns*; **actions**
+(tools, credentials, sends) still go through Allow/Deny cards, and
+`allowFrom` still gates *who* can talk to it. No self-elevation, no new
+blast radius.
+
+## 3. The three principle checks (the verdict rule)
+
+- **P1 "If they need the docs, we've failed":** Today the bot joins a group
+  and **silently drops** every message (`group_unknown`) until the operator
+  reads docs + edits JSON — this is *verbatim* the ❌ example in
+  `principles.md`. Phase 1 fixes the silent-config-gap half (config drives
+  registration). Phase 2 adds the in-Telegram "enable this group?" nudge so
+  the silent-drop is gone end-to-end. **Pass (P1) after phase 2; phase 1 is
+  the load-bearing half.**
+- **P2 "Batteries included, assembly optional":** was punting two decisions
+  into `switchroom.yaml` (group registration + `default_topic_id`). Now
+  both have smart defaults; complexity (mention-only, per-topic deny, a
+  pinned default topic) is opt-*in*. **Pass.**
+- **P3 "One mind built this":** reuses the existing config-cascade + the
+  `access.json` reconcile model; the phase-2 CLI on-ramp will use the
+  established `switchroom agent <verb> --topology` shape. **Pass.**
+
+## 4. Design
+
+### Phase 1 (this PR) — the zero-config core
+1. **Config-driven group registration.** `reconcileConfiguredGroup`
+   (scaffold) idempotently merges the agent's configured supergroup
+   (`channels.telegram.chat_id`, which overrides the fleet
+   `telegram.forum_chat_id`) into `access.json` on every reconcile —
+   strictly additive: only adds the group if absent, preserves
+   `allowFrom` / pairings / other groups / operator policy overrides.
+   This closes the `writeIfMissing` gap that made a post-scaffold
+   supergroup never register (the marko case). Smart default for the
+   new group: `requireMention: false` (a room the agent owns answers
+   everything), all topics covered (the gate is per-group, not per-topic).
+2. **`default_topic_id` defaults to General (1).** Setting `chat_id` no
+   longer *requires* `default_topic_id`; it falls back to General (the
+   outbound wrapper strips `thread_id === 1` on send). Operators pin a
+   different fallback only if they want one.
+
+Net phase-1 easy path:
+```yaml
+agents:
+  marko:
+    channels:
+      telegram:
+        chat_id: "-1003831053471"   # that's it — answers everywhere, DMs still work
+```
+
+### Phase 2 (follow-up PRs)
+3. **CLI on-ramp:** `switchroom agent add --topology supergroup --chat-id <id>`
+   and `agent set-topology <name> supergroup` (convert an existing agent) —
+   writes the stanza + reconciles, so no YAML editing at all.
+4. **Kill the silent drop (P1 completion):** when a bot is in a group it
+   isn't enabled for, post a one-tap "enable this group for <agent>?"
+   prompt to the operator DM instead of dropping `group_unknown` in silence.
+
+## 5. Overrides (opt-in complexity, preserved)
+
+- `requireMention: true` per group — for a shared channel where the agent
+  should only answer when @-mentioned.
+- per-group `topic_deny: [...]` (phase 2) — active everywhere *except* listed
+  topics (the inverse of the default auto-join-all).
+- `default_topic_id` / `topic_aliases` — pin a fallback topic + name topics
+  for cron targeting.
+
+## 6. Tests
+
+- `tests/scaffold.reconcile-group.test.ts` — additive merge, preservation of
+  allowFrom/pairings/other-groups, no-overwrite of operator policy,
+  idempotency, dm_only / no-forum / absent-file no-ops.
+- `src/config/schema.test.ts` — `default_topic_id` defaults to General when
+  `chat_id` is set alone; explicit value preserved; still rejects
+  `default_topic_id` without `chat_id`.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4,6 +4,7 @@ import {
   writeFileSync,
   appendFileSync,
   readFileSync,
+  renameSync,
   chmodSync,
   symlinkSync,
   copyFileSync,
@@ -3248,6 +3249,18 @@ export function scaffoldAgent(
     skipped,
     0o600,
   );
+  // access.json is writeIfMissing (the gateway owns it at runtime for
+  // pairing), so a supergroup added to switchroom.yaml AFTER first scaffold
+  // would never register — the gateway silently drops its messages as
+  // `group_unknown` (the marko case). Reconcile the CONFIGURED group in
+  // idempotently so "set chat_id in config → the agent answers there" is the
+  // zero-config default (principles 1 + 2), preserving runtime-added
+  // allowFrom / pairings / other groups and any operator policy override.
+  reconcileConfiguredGroup(
+    join(agentDir, "telegram", "access.json"),
+    agentConfig,
+    telegramConfig,
+  );
 
   // --- Sub-agent definitions (.claude/agents/<name>.md) ---
   //
@@ -5410,6 +5423,60 @@ function rerenderWithFingerprint(
   // post-apply summary reflects that the file was rewritten rather
   // than silently absent from both columns.
   created.push(filePath);
+}
+
+/**
+ * Idempotently reconcile the agent's CONFIGURED supergroup/forum chat into an
+ * existing `access.json`'s `groups`. Called on every reconcile (apply,
+ * agent restart) AFTER the writeIfMissing above.
+ *
+ * Why: `access.json` is writeIfMissing — the gateway owns it at runtime
+ * (pairing, operator policy edits). So a supergroup added to switchroom.yaml
+ * after the agent was first scaffolded never lands in `groups`, and the
+ * gateway drops every message from it as `group_unknown` (the marko case).
+ * This closes that gap so the supergroup easy-path is zero-config.
+ *
+ * Strictly additive + non-destructive:
+ *  - only ADDS the configured group if absent — never rewrites an existing
+ *    group's policy (so an operator's `requireMention: true` / topic edits
+ *    survive),
+ *  - preserves `allowFrom`, pairings, other groups, and every other field,
+ *  - no-op for dm_only agents and when no real forum chat is in scope.
+ *
+ * Smart default for a newly-registered group: `requireMention: false` — a
+ * supergroup the agent OWNS is a dedicated working room, so it answers every
+ * message (override to `true` for a shared channel).
+ */
+export function reconcileConfiguredGroup(
+  accessPath: string,
+  agentConfig: AgentConfig,
+  telegramConfig: TelegramConfig,
+): void {
+  if (!existsSync(accessPath)) return; // fresh agent — buildAccessJson handled it
+  const forumChatId = telegramConfig.forum_chat_id;
+  const hasRealForumChat = forumChatId !== "" && forumChatId !== "0";
+  if (agentConfig.dm_only || !hasRealForumChat) return;
+
+  let access: Record<string, unknown>;
+  try {
+    access = JSON.parse(readFileSync(accessPath, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return; // malformed runtime file — leave it for the gateway/operator
+  }
+  const groups = (access.groups ??= {}) as Record<string, unknown>;
+  if (groups[forumChatId] !== undefined) return; // already registered — preserve operator policy
+
+  const allowFrom = Array.isArray(access.allowFrom) ? access.allowFrom : [];
+  groups[forumChatId] = { requireMention: false, allowFrom };
+  const tmp = accessPath + ".tmp";
+  writeFileSync(tmp, JSON.stringify(access, null, 2) + "\n", { mode: 0o600 });
+  renameSync(tmp, accessPath);
+  console.log(
+    chalk.green(
+      `  registered supergroup ${forumChatId} in access.json ` +
+      `(responds to all topics; requireMention=false)`,
+    ),
+  );
 }
 
 function buildAccessJson(

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -5447,13 +5447,31 @@ function rerenderWithFingerprint(
  * supergroup the agent OWNS is a dedicated working room, so it answers every
  * message (override to `true` for a shared channel).
  */
+/**
+ * Effective supergroup chat for an agent. The per-agent
+ * `channels.telegram.chat_id` override (supergroup-owned topology) wins
+ * over the fleet-wide `telegram.forum_chat_id` (fleet-shared topology).
+ * Mirrors resolveAgentChannelTarget in
+ * `src/agent-scheduler/channel-target.ts` — same precedence so the access
+ * list, the cron router, and the gateway all agree on which chat the
+ * agent owns. (`agentConfig` is already cascade-resolved by the caller.)
+ */
+function resolveAgentForumChatId(
+  agentConfig: AgentConfig,
+  telegramConfig: TelegramConfig,
+): string {
+  const override = agentConfig.channels?.telegram?.chat_id;
+  if (typeof override === "string" && override.length > 0) return override;
+  return telegramConfig.forum_chat_id ?? "";
+}
+
 export function reconcileConfiguredGroup(
   accessPath: string,
   agentConfig: AgentConfig,
   telegramConfig: TelegramConfig,
 ): void {
   if (!existsSync(accessPath)) return; // fresh agent — buildAccessJson handled it
-  const forumChatId = telegramConfig.forum_chat_id;
+  const forumChatId = resolveAgentForumChatId(agentConfig, telegramConfig);
   const hasRealForumChat = forumChatId !== "" && forumChatId !== "0";
   if (agentConfig.dm_only || !hasRealForumChat) return;
 
@@ -5513,7 +5531,13 @@ function buildAccessJson(
   // `switchroom agent add --topology dm` emits when no real forum
   // chat is in scope, and the bug surfaced as a spurious 404 on every
   // fresh DM-topology agent.
-  const forumChatId = telegramConfig.forum_chat_id;
+  //
+  // Supergroup-owned agents carry their chat at the per-agent
+  // `channels.telegram.chat_id` override, which wins over the fleet
+  // `forum_chat_id` — resolve the effective chat so a fresh
+  // supergroup-owned agent registers the chat it actually owns, not the
+  // shared fleet forum.
+  const forumChatId = resolveAgentForumChatId(agentConfig, telegramConfig);
   const hasRealForumChat = forumChatId !== "" && forumChatId !== "0";
   if (!agentConfig.dm_only && hasRealForumChat) {
     access.groups = {

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -19,8 +19,30 @@ import {
   GoogleWorkspaceTierSchema,
   ScheduleEntrySchema,
   SwitchroomConfigSchema,
+  TelegramChannelSchema,
   VaultConfigSchema,
 } from "./schema.js";
+
+describe("TelegramChannelSchema — supergroup smart defaults", () => {
+  it("defaults default_topic_id to General (1) when chat_id is set and it is omitted", () => {
+    const r = TelegramChannelSchema.parse({ chat_id: "-1003831053471" });
+    expect(r?.default_topic_id).toBe(1);
+  });
+
+  it("preserves an explicit default_topic_id", () => {
+    const r = TelegramChannelSchema.parse({ chat_id: "-1003831053471", default_topic_id: 17 });
+    expect(r?.default_topic_id).toBe(17);
+  });
+
+  it("does NOT inject default_topic_id when there is no chat_id", () => {
+    const r = TelegramChannelSchema.parse({ bot_token: "vault:x" });
+    expect(r?.default_topic_id).toBeUndefined();
+  });
+
+  it("still rejects default_topic_id without chat_id (meaningless)", () => {
+    expect(() => TelegramChannelSchema.parse({ default_topic_id: 5 })).toThrow();
+  });
+});
 
 describe("ScheduleEntrySchema.secrets", () => {
   it("accepts a list of valid vault key names", () => {
@@ -780,14 +802,13 @@ describe("TelegramChannelSchema supergroup-owned fields", () => {
     });
   });
 
-  it("rejects chat_id without default_topic_id (mutual dependency)", () => {
-    expect(() =>
-      AgentSchema.parse(
-        baseAgentInput({
-          channels: { telegram: { chat_id: "-1001234567890" } },
-        }),
-      ),
-    ).toThrow(/default_topic_id/);
+  it("defaults default_topic_id to General (1) when chat_id is set alone (smart default, was an error pre-#supergroup-easy-defaults)", () => {
+    const parsed = AgentSchema.parse(
+      baseAgentInput({
+        channels: { telegram: { chat_id: "-1001234567890" } },
+      }),
+    );
+    expect(parsed.channels?.telegram?.default_topic_id).toBe(1);
   });
 
   it("rejects default_topic_id without chat_id (mutual dependency)", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -822,7 +822,9 @@ export const TelegramChannelSchema = z
       .optional()
       .describe(
         "Forum topic ID this agent's automated outbounds default to when " +
-        "no more-specific alias resolves. Required when `chat_id` is set. " +
+        "no more-specific alias resolves. Defaults to General (topic 1) when " +
+        "`chat_id` is set and this is omitted — set it only to pin a different " +
+        "fallback topic. " +
         "Telegram's General topic is `id=1` at MTProto but sends omit the " +
         "field — the outbound wrapper strips `message_thread_id === 1` " +
         "on send. Forbidden when `dm_only: true`.",
@@ -841,13 +843,9 @@ export const TelegramChannelSchema = z
   .optional()
   .superRefine((tg, ctx) => {
     if (!tg) return;
-    if (tg.chat_id != null && tg.default_topic_id == null) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "`channels.telegram.chat_id` requires `default_topic_id` — supergroup-mode agents need a fallback topic for unclassified outbounds.",
-        path: ["default_topic_id"],
-      });
-    }
+    // Smart default (P2): `chat_id` no longer *requires* `default_topic_id`
+    // — it falls back to General below. We only reject the reverse
+    // (default_topic_id without chat_id) which is meaningless.
     if (tg.default_topic_id != null && tg.chat_id == null) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -862,6 +860,17 @@ export const TelegramChannelSchema = z
         path: ["topic_aliases"],
       });
     }
+  })
+  .transform((tg) => {
+    // Smart default: a supergroup-owned agent (chat_id set) that doesn't pin
+    // a default topic falls back to General (topic 1 — the outbound wrapper
+    // strips thread_id===1 on send). Keeps the easy path zero-config (P2):
+    // the operator sets only `chat_id` and the agent answers, with proactive
+    // posts defaulting to General.
+    if (tg && tg.chat_id != null && tg.default_topic_id == null) {
+      return { ...tg, default_topic_id: 1 };
+    }
+    return tg;
   });
 
 export const ChannelsSchema = z

--- a/tests/scaffold.reconcile-group.test.ts
+++ b/tests/scaffold.reconcile-group.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { reconcileConfiguredGroup } from "../src/agents/scaffold.js";
+import type { AgentConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * reconcileConfiguredGroup — idempotently registers the agent's configured
+ * supergroup into access.json (the marko-class fix: access.json is
+ * writeIfMissing, so a supergroup added to switchroom.yaml after first
+ * scaffold never registered and the gateway dropped its messages as
+ * group_unknown). Must be strictly additive + non-destructive.
+ */
+
+const SG = "-1003831053471";
+const agent = (overrides: Partial<AgentConfig> = {}): AgentConfig =>
+  ({ extends: "default", ...overrides } as unknown as AgentConfig);
+const tg = (forum_chat_id: string): TelegramConfig =>
+  ({ forum_chat_id } as unknown as TelegramConfig);
+
+let dir: string;
+let accessPath: string;
+const writeAccess = (obj: unknown) => writeFileSync(accessPath, JSON.stringify(obj, null, 2));
+const readAccess = () => JSON.parse(readFileSync(accessPath, "utf-8"));
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "reconcile-group-"));
+  accessPath = join(dir, "access.json");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("reconcileConfiguredGroup", () => {
+  it("adds the configured supergroup with smart defaults (requireMention:false, all topics)", () => {
+    writeAccess({ dmPolicy: "allowlist", allowFrom: ["111", "222"] });
+    reconcileConfiguredGroup(accessPath, agent(), tg(SG));
+    const a = readAccess();
+    expect(a.groups[SG]).toEqual({ requireMention: false, allowFrom: ["111", "222"] });
+  });
+
+  it("preserves existing allowFrom, OTHER groups, and runtime fields (pairings)", () => {
+    writeAccess({
+      dmPolicy: "allowlist",
+      allowFrom: ["111", "222"],
+      groups: { "-5164217975": { requireMention: false, allowFrom: ["111"] } },
+      pending: { abc123: { senderId: "999", chatId: "999" } },
+      stickers: { ok: "CAAC..." },
+    });
+    reconcileConfiguredGroup(accessPath, agent(), tg(SG));
+    const a = readAccess();
+    expect(Object.keys(a.groups).sort()).toEqual([SG, "-5164217975"]);
+    expect(a.groups["-5164217975"]).toEqual({ requireMention: false, allowFrom: ["111"] });
+    expect(a.allowFrom).toEqual(["111", "222"]);
+    expect(a.pending).toEqual({ abc123: { senderId: "999", chatId: "999" } });
+    expect(a.stickers).toEqual({ ok: "CAAC..." });
+  });
+
+  it("does NOT overwrite an existing policy for the same group (operator override survives)", () => {
+    writeAccess({
+      dmPolicy: "allowlist",
+      allowFrom: ["111"],
+      groups: { [SG]: { requireMention: true, allowFrom: ["111"], topic_deny: [42] } },
+    });
+    reconcileConfiguredGroup(accessPath, agent(), tg(SG));
+    expect(readAccess().groups[SG]).toEqual({ requireMention: true, allowFrom: ["111"], topic_deny: [42] });
+  });
+
+  it("is idempotent — a second run changes nothing", () => {
+    writeAccess({ dmPolicy: "allowlist", allowFrom: ["111"] });
+    reconcileConfiguredGroup(accessPath, agent(), tg(SG));
+    const first = readFileSync(accessPath, "utf-8");
+    reconcileConfiguredGroup(accessPath, agent(), tg(SG));
+    expect(readFileSync(accessPath, "utf-8")).toBe(first);
+  });
+
+  it("no-ops for dm_only agents", () => {
+    writeAccess({ dmPolicy: "allowlist", allowFrom: ["111"] });
+    reconcileConfiguredGroup(accessPath, agent({ dm_only: true }), tg(SG));
+    expect(readAccess().groups).toBeUndefined();
+  });
+
+  it("no-ops when no real forum chat is in scope (empty / sentinel)", () => {
+    writeAccess({ dmPolicy: "allowlist", allowFrom: ["111"] });
+    reconcileConfiguredGroup(accessPath, agent(), tg(""));
+    reconcileConfiguredGroup(accessPath, agent(), tg("0"));
+    expect(readAccess().groups).toBeUndefined();
+  });
+
+  it("no-ops when access.json is absent (fresh agent — buildAccessJson owns it)", () => {
+    expect(existsSync(accessPath)).toBe(false);
+    reconcileConfiguredGroup(accessPath, agent(), tg(SG));
+    expect(existsSync(accessPath)).toBe(false);
+  });
+});

--- a/tests/scaffold.reconcile-group.test.ts
+++ b/tests/scaffold.reconcile-group.test.ts
@@ -14,8 +14,12 @@ import type { AgentConfig, TelegramConfig } from "../src/config/schema.js";
  */
 
 const SG = "-1003831053471";
+const FLEET_FORUM = "-1003852747971"; // a DIFFERENT chat — the shared fleet forum
 const agent = (overrides: Partial<AgentConfig> = {}): AgentConfig =>
   ({ extends: "default", ...overrides } as unknown as AgentConfig);
+// supergroup-owned: per-agent channels.telegram.chat_id override (the prod shape)
+const ownedAgent = (chat_id: string, overrides: Partial<AgentConfig> = {}): AgentConfig =>
+  ({ extends: "default", channels: { telegram: { chat_id } }, ...overrides } as unknown as AgentConfig);
 const tg = (forum_chat_id: string): TelegramConfig =>
   ({ forum_chat_id } as unknown as TelegramConfig);
 
@@ -36,6 +40,24 @@ describe("reconcileConfiguredGroup", () => {
     reconcileConfiguredGroup(accessPath, agent(), tg(SG));
     const a = readAccess();
     expect(a.groups[SG]).toEqual({ requireMention: false, allowFrom: ["111", "222"] });
+  });
+
+  it("registers the per-agent chat_id OVERRIDE, not the fleet forum_chat_id (the marko case)", () => {
+    // supergroup-owned: channels.telegram.chat_id (SG) must win over the
+    // shared fleet forum (FLEET_FORUM). Registering the fleet chat would
+    // both miss marko's owned group AND re-introduce the #1002 boot-probe
+    // 404 against a chat the bot isn't a member of.
+    writeAccess({ dmPolicy: "allowlist", allowFrom: ["111"] });
+    reconcileConfiguredGroup(accessPath, ownedAgent(SG), tg(FLEET_FORUM));
+    const a = readAccess();
+    expect(a.groups[SG]).toEqual({ requireMention: false, allowFrom: ["111"] });
+    expect(a.groups[FLEET_FORUM]).toBeUndefined();
+  });
+
+  it("registers the owned chat even with no fleet forum_chat_id at all", () => {
+    writeAccess({ dmPolicy: "allowlist", allowFrom: ["111"] });
+    reconcileConfiguredGroup(accessPath, ownedAgent(SG), tg(""));
+    expect(readAccess().groups[SG]).toEqual({ requireMention: false, allowFrom: ["111"] });
   });
 
   it("preserves existing allowFrom, OTHER groups, and runtime fields (pairings)", () => {


### PR DESCRIPTION
## Summary
Make the **supergroup-owned topology zero-config easy mode** — the direction you asked for after the marko setup needed `access.json` surgery. Point an agent at a supergroup and it answers **everywhere, all topics, DMs intact**, with no hand-editing.

Reviewed against the contract (RFC: `docs/rfcs/supergroup-easy-defaults.md`): the current state *fails* principles 1 + 2 by their own examples (the silent `group_unknown` drop is verbatim the P1 ❌ example; `default_topic_id`-required + manual group registration is the P2 ❌). Serves outcome 1 ("add a specialist in ten lines of YAML") + the `extend-without-forking` JTBD. Leash (outcome 2) unchanged — this only affects which messages the agent *reads* in a room it owns; actions still gate through Allow/Deny + `allowFrom`.

## What's in this PR (phase 1 — the zero-config core)
1. **`reconcileConfiguredGroup`** (scaffold): idempotently merges the agent's configured supergroup (`channels.telegram.chat_id`) into `access.json` on every reconcile. **Strictly additive** — only adds the group if absent; preserves `allowFrom`, pairings, other groups, and operator policy overrides. Closes the `writeIfMissing` gap that made a post-scaffold supergroup never register (the marko `group_unknown` silent-drop). Smart default: `requireMention: false`, all topics.
2. **`default_topic_id` → General (1) default** when `chat_id` is set alone (was a hard error).

Net easy path:
```yaml
channels: { telegram: { chat_id: "-1003831053471" } }   # answers everywhere, DMs still work
```

## Phase 2 (follow-up, in the RFC)
- `switchroom agent add --topology supergroup --chat-id` + `agent set-topology` (no YAML editing).
- In-Telegram "enable this group for <agent>?" one-tap nudge → completes the P1 silent-drop fix end-to-end.

## Test plan
- [x] `tests/scaffold.reconcile-group.test.ts` (7) — additive/non-destructive merge, preserves allowFrom/pairings/other-groups, **never overwrites** an existing group's policy, idempotent, `dm_only`/no-forum/absent-file no-ops.
- [x] `src/config/schema.test.ts` — General default; explicit value preserved; `default_topic_id` without `chat_id` still rejected. Updated the one existing test that pinned the old require-behavior.
- [x] Full config + scaffold cluster (532) green; `tsc` + `npm run lint` clean.

## Risk
Low. The reconcile is strictly additive + idempotent (unit-tested for preservation/no-overwrite); never removes or rewrites existing access. The schema change relaxes a validation (required→defaulted) — backward-compatible (existing configs with explicit `default_topic_id` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)