### PR TITLE
chore: release v0.14.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased — Sub-agent attribution stamped at dispatch (#2081, #2083, #2084)
+## v0.14.39 — Sub-agent attribution stamped at dispatch (#2081, #2083, #2084)
 
 Make a sub-agent's parent turn **ground truth captured at dispatch**
 instead of reconstructed after the fact — fixing wrong-topic worker-card

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.38",
+  "version": "0.14.39",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.14.39 — **Sub-agent attribution stamped at dispatch** (#2081, #2083, #2084).

Ships the merged #2085: the PreToolUse hook stamps `parent_turn_key` from the live turn-active marker at dispatch (correct topic in supergroups, no overlap mis-attribution, attributes the ~8% that never link JSONL), plus the hardened async-launch ACK detection. #2082's attribution harm is eliminated by the same change (scoped — see issue).

Constituent PR #2085 was reviewed (2 adversarial rounds → APPROVE) and is green on main. Trivial release diff: CHANGELOG + package.json bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)