### PR TITLE
docs(security): single-tenant access model; descope hard-boundary/second-bot

### DIFF
--- a/docs/rfcs/approval-kernel.md
+++ b/docs/rfcs/approval-kernel.md
@@ -1,10 +1,24 @@
 # RFC B: Unified human-approval kernel
 
-Status: Draft v4
+Status: Draft v4 — **partially shipped; hard-boundary direction descoped for single-tenant (2026-06-02)**
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
 
-Prerequisite: **RFC A — Bot token to vault** (`docs/rfcs/bot-token-to-vault.md`) must land first. Without it the kernel's trust chain has a hole — an agent that can read the bot token can post fake approval cards.
+> **Scope note (2026-06-02).** The kernel, nonce/scope binding, per-agent
+> socket ACL, and `apv:` callback flow are shipped. The "hard boundary"
+> direction this RFC anticipates — making the agent↔gateway channel
+> unforgeable against a **same-uid** actor (a host-side operator verifier
+> setting `origin='operator'`, flipping
+> `SWITCHROOM_REQUIRE_OPERATOR_APPROVAL_MINT=1`, and the second-bot idea
+> floated alongside it) — is **descoped for the single-tenant deployment**
+> switchroom targets. Same-uid is out of scope by construction
+> (`docs/vault.md`), so that machinery defends a threat this product
+> doesn't have, at real cost. The authorization contract that supersedes
+> the hard-boundary framing is [`reference/access-model.md`](../../reference/access-model.md);
+> the mint flag stays **off** by default. Reopen only if the deployment
+> model changes (untrusted agents / multi-operator / hostile network).
+
+Prerequisite: **RFC A — Bot token to vault** (`docs/rfcs/bot-token-to-vault.md`). Keeping the token in the vault rather than plaintext `.env` is still worthwhile hygiene (one revocation surface, no casual read); it is **not** relied on as a security boundary against a same-uid agent per the access model.
 
 ## 1. Summary
 

--- a/docs/rfcs/bot-token-to-vault.md
+++ b/docs/rfcs/bot-token-to-vault.md
@@ -1,8 +1,16 @@
 # RFC A: Complete the bot-token-to-vault migration
 
-Status: Draft v2
+Status: Draft v2 — **hygiene, not a boundary (2026-06-02)**
 Author: klanker (sub-agent draft)
 Date: 2026-05-06
+
+> **Scope note (2026-06-02).** Worth doing as **hygiene** — one revocation
+> surface, no plaintext token `cat`-able on disk. But per
+> [`reference/access-model.md`](../../reference/access-model.md) it is
+> **not** a security boundary: a same-uid agent is out of scope by
+> construction, so vaulting the token does not "stop the agent reading
+> it." Don't frame this migration as closing a forgery hole; frame it as
+> consolidating secrets. The approval model does not depend on it.
 
 ## 1. Summary
 

--- a/reference/README.md
+++ b/reference/README.md
@@ -7,6 +7,7 @@ Three documents, three questions. Read in this order.
 | [`vision.md`](vision.md) | *Should we build this?* — the four outcomes, who it's for, what it isn't |
 | [`principles.md`](principles.md) | *Did we build it well?* — three PR checks (docs / defaults / consistency) |
 | JTBDs (below) | *Did it do the user's job?* — outcome-focused jobs, one per file |
+| [`access-model.md`](access-model.md) | *Can an agent escalate past what the operator gave it?* — the single-tenant authorization contract; read before any change that grants, checks, or prompts for access |
 
 The verdict rule lives in `CLAUDE.md` ("Design contract" section): a
 change ships only when it advances one of the four outcomes, satisfies

--- a/reference/access-model.md
+++ b/reference/access-model.md
@@ -49,18 +49,29 @@ an agent must never escalate to lives behind a _different_ uid.**
 - **Agent → another agent's data, sockets, credentials** — different
   uid → OS-enforced. Not reachable, full stop.
 - **Agent → its own authorization** (tools, MCP servers, vault grants)
-  — operator-owned config, bind-mounted **read-only**. The agent reads
-  its sandbox; it cannot rewrite it.
+  — the authoritative source is operator-owned `switchroom.yaml`,
+  bind-mounted **read-only**. The agent's own scaffold files
+  (`settings.json`, `.mcp.json`) are writable by it, but they are
+  **regenerated from `switchroom.yaml` on every reconcile/restart**, so a
+  self-edit doesn't survive — and the one sanctioned self-edit path
+  (`config_propose_edit`) is **server-validated additive-to-self behind
+  an operator tap**. The agent reads its sandbox; it cannot durably
+  rewrite it.
 - **Agent → host / fleet control** — `hostd` is a separate daemon →
   admin-gated.
 
-The only place an agent shares a uid is with **its own gateway**, and
-everything reachable there is *already inside that agent's
-operator-granted scope*. Minting a scoped token from a credential you
-were already granted is **not** escalation — it's using what you have.
-So the same-uid softness never crosses into "things it shouldn't have";
-those are all behind the uid boundary. This is why the model needs no
-cryptographic proofing of the agent↔gateway channel.
+The only place an agent shares a uid is with **its own gateway**. By
+default that softness is inert: minting a scoped credential goes through
+the operator (`vault.broker.approvalAuth: passphrase`, the default), so
+the agent self-mints nothing. The agent↔gateway channel only becomes
+forgeable if the operator **opts in** to single-factor posture mint for a
+named agent (`approvalAuth: telegram-id` **and** adding the agent to
+`vault.broker.postureMintAgents` — both default-off). Even then it's
+bounded: `adminOnlyKeys` claws the sensitive keys back to
+**passphrase-only**, which a same-uid agent still can't satisfy. So the
+same-uid surface is an operator opt-in gated by a factor the agent lacks
+— not an open door — which is why the model needs no cryptographic
+proofing of the agent↔gateway channel.
 
 ## Three tiers, three minimal mechanisms
 
@@ -69,7 +80,7 @@ requires.
 
 | Tier | What | Enforcement |
 |---|---|---|
-| **Sandbox** | tools, MCP servers, standing credentials the operator declared | Operator-owned, read-only config. Agent works freely inside it, **no prompts.** |
+| **Sandbox** | tools, MCP servers, standing credentials the operator declared | Authoritative `switchroom.yaml` is operator-owned + read-only; scaffold files regenerate from it on reconcile. Agent works freely inside it, **no prompts.** |
 | **Ad-hoc** | something not in the sandbox | One **honest** approval card → the operator's Telegram tap. `callback_query.from.id` is Telegram-authenticated; an agent cannot fake it. |
 | **Crown jewels** | irreversible actions, admin credentials | Operator **passphrase** — a secret the agent structurally never holds. The only tier above a tap. |
 

--- a/reference/access-model.md
+++ b/reference/access-model.md
@@ -1,0 +1,149 @@
+---
+job: stop an eager agent from escalating into access the operator never gave it
+outcome: Every access decision — a secret, a tool, an MCP server, a host action — flows from operator-authored config or an operator tap, enforced where the agent can't rewrite it. An agent can ask for more; it can never grant itself more.
+stakes: The risk on a single-tenant box isn't a remote attacker. It's a well-meaning agent reaching for a credential, another agent's data, or host control to finish a job. If an agent can author its own authorization, "helpful" becomes "escalated" with no one in the loop.
+---
+
+# Switchroom access model
+
+This is the security contract for authorization in switchroom. It is
+deliberately small. Read it before changing anything that grants,
+checks, or prompts for access — secrets, tools, MCP servers, vault
+grants, or host/fleet verbs.
+
+## The deployment we actually secure
+
+Switchroom is a **local install on a single-tenant Linux server**: one
+operator, their own box, agents that are **eager to help, not
+adversarial**. That reality is what lets the model be simple — so don't
+import a multi-tenant or hostile-network threat model and over-build for
+it.
+
+- There is no second tenant and no remote attacker in scope. The
+  operator is root.
+- A **same-uid attacker is out of scope by construction** (`docs/vault.md`:
+  *"the vault ACL is misconfiguration protection, not a security
+  boundary"*). The real boundary is filesystem perms + the vault
+  passphrase. Hardening against a process that already shares the
+  agent's uid is effort spent on a threat this product doesn't have —
+  and it's where the over-built proposals went (see *Closed
+  directions*).
+- The threat we **do** secure is escalation by a helpful agent: it
+  reaches for something the operator didn't give it.
+
+## The one invariant
+
+> **An agent can _request_ more access, but it can never _author_ its
+> own authorization. Every grant is written by the operator, in a place
+> the agent cannot write.**
+
+If a change lets an agent widen its own access without the operator,
+the change is wrong — redesign it, don't gate it after the fact.
+
+## The one boundary — and it's free
+
+On a single-tenant box the OS already gives the only hard boundary we
+need, and it's the right one: **each agent runs as its own uid; anything
+an agent must never escalate to lives behind a _different_ uid.**
+
+- **Agent → another agent's data, sockets, credentials** — different
+  uid → OS-enforced. Not reachable, full stop.
+- **Agent → its own authorization** (tools, MCP servers, vault grants)
+  — operator-owned config, bind-mounted **read-only**. The agent reads
+  its sandbox; it cannot rewrite it.
+- **Agent → host / fleet control** — `hostd` is a separate daemon →
+  admin-gated.
+
+The only place an agent shares a uid is with **its own gateway**, and
+everything reachable there is *already inside that agent's
+operator-granted scope*. Minting a scoped token from a credential you
+were already granted is **not** escalation — it's using what you have.
+So the same-uid softness never crosses into "things it shouldn't have";
+those are all behind the uid boundary. This is why the model needs no
+cryptographic proofing of the agent↔gateway channel.
+
+## Three tiers, three minimal mechanisms
+
+Match the enforcement to the sensitivity. Nothing heavier than the tier
+requires.
+
+| Tier | What | Enforcement |
+|---|---|---|
+| **Sandbox** | tools, MCP servers, standing credentials the operator declared | Operator-owned, read-only config. Agent works freely inside it, **no prompts.** |
+| **Ad-hoc** | something not in the sandbox | One **honest** approval card → the operator's Telegram tap. `callback_query.from.id` is Telegram-authenticated; an agent cannot fake it. |
+| **Crown jewels** | irreversible actions, admin credentials | Operator **passphrase** — a secret the agent structurally never holds. The only tier above a tap. |
+
+The passphrase — not process-isolation tricks — is the unforgeable line,
+because it's a capability the agent **lacks**, not a barrier we hope it
+won't cross. Mark genuinely-sensitive vault keys passphrase-required
+(`vault.broker.adminOnlyKeys`) so an eager agent can't posture-mint them.
+
+## Honest cards
+
+An approval an agent can socially-engineer is no approval. A card must
+show the **exact scope being granted** — the vault key, the fileId, the
+verb — not a friendly label the agent chose. Keep the
+wrapper-attested-truth vs `💬` agent-framing split (the Drive
+diff-preview is the reference implementation) on every approval surface.
+
+- ✅ **Good:** "⚠ clerk wants to write to `Q3 Plan` (`1aBc…xyz`)" — the
+  operator approves the exact file that becomes the scope.
+- ❌ **Bad:** a card whose displayed label and granted scope come from
+  different sources, so the agent can show one thing and obtain another.
+
+## Dead-ends breed workarounds
+
+Half of access security here is **legibility**, because an eager agent
+that hits a confusing wall improvises — and improvisation is where the
+leaks happen (an agent told the user to paste a raw token into chat
+because the vault slot was empty; agents guess vault key names and burn
+operator taps). So:
+
+- An agent should be able to **see its own sandbox** — what it's
+  authorized for — so it stops guessing and overreaching.
+- When it hits the edge, the sanctioned path ("you don't have X — here's
+  the one-tap request") must be **frictionless and obvious**, so it
+  never routes around the gate.
+
+A blocked-but-unclear path is a security risk, not just a UX one.
+
+## Closed directions (do not reopen for single-tenant)
+
+These were proposed to make the agent↔gateway channel unforgeable
+against a same-uid actor. That actor is out of scope; these add real
+friction and infrastructure for a threat this product doesn't have.
+Park them unless the deployment model changes (untrusted agents,
+multi-operator, hostile network):
+
+- **A second Telegram bot** for approvals. Defends a descoped threat,
+  doesn't fully close it (same-uid can still read the vault file /
+  gateway memory), and means two BotFather bots + a second poller + the
+  operator juggling two chats.
+- **A host-side approval verifier** setting `origin='operator'` and
+  flipping `SWITCHROOM_REQUIRE_OPERATOR_APPROVAL_MINT=1`. Same rationale;
+  the flag stays **off** by default on single-tenant.
+- **Tap-per-mint.** The operator already approved the credential when
+  they granted it; re-tapping every scoped-token mint is babysitting.
+
+The cheap, always-welcome hardening that *isn't* over-built: keep the
+bot token in the vault rather than plaintext `.env` (one revocation
+surface, no casual read), reject any wire-supplied `origin` field at the
+kernel, and the honest-card + passphrase items above.
+
+## Check questions — for any access-touching change
+
+- Could an agent end up with access the operator never wrote down or
+  tapped for? (If yes, redesign.)
+- Is the grant enforced where the agent **can't write it** (different
+  uid, or operator-owned read-only config) — not in something the agent
+  controls?
+- Does the approval card show the **real scope**, sourced the same way
+  it's enforced?
+- For the irreversible / crown-jewel case, is it behind the
+  **passphrase**, not just a tap?
+- When access is denied, does the agent get a clean one-tap path to
+  request it — so it won't improvise around the gate?
+
+If you're reaching for a new daemon, a second bot, or per-action crypto
+to answer these, stop: on single-tenant the uid boundary + read-only
+operator config + the passphrase already answer them.


### PR DESCRIPTION
## Summary

Adds **`reference/access-model.md`** — the authorization contract for the deployment switchroom actually targets: a **local, single-tenant Linux box**, one operator, agents that are **eager to help, not adversarial**.

It states one invariant, one boundary, three tiers — and formally closes the over-built proposals so future agents don't reopen them.

## The model

- **Invariant:** an agent can *request* more access but can never *author* its own authorization. Every grant is operator-written, enforced where the agent can't write it.
- **One boundary (free, OS-enforced):** per-agent uid. Anything an agent must never escalate to (another agent's data, host control, ungranted credentials) lives behind a *different* uid. The only same-uid surface (agent↔its own gateway) is entirely *within that agent's already-granted scope* — not escalation.
- **Three tiers / minimal mechanism each:** read-only operator config (sandbox, no prompts) → honest approval card + Telegram tap (ad-hoc) → operator passphrase (crown jewels — the one capability the agent structurally lacks).
- **Legibility as security:** a helpful agent that hits a confusing dead-end improvises (the chat-paste leak, vault-key guessing). The sanctioned path must be visible and one-tap, so it never routes around the gate.

## Closed directions (descoped for single-tenant)

A second Telegram bot, a host-side operator verifier (`origin='operator'`), flipping `SWITCHROOM_REQUIRE_OPERATOR_APPROVAL_MINT=1`, and tap-per-mint. They harden the agent↔gateway channel against a **same-uid** actor that is **out of scope by construction** (`docs/vault.md`), at real cost. Scope notes added to the `approval-kernel` and `bot-token-to-vault` RFCs; bot-token vaulting reframed as hygiene, not a boundary.

## Why (the JTBD)

Serves **"you hold the leash"** — purposeful, controlled agents — and the new `access-model` job: stop an eager agent escalating into access the operator never gave it, *without* over-building for a threat a single-tenant box doesn't have.

## Scope

Docs only: new `reference/access-model.md`, indexed in `reference/README.md`, scope notes on two RFCs. No code change. Follow-ups (separate PRs): honest-card standard fleet-wide; agent self-sandbox legibility + one-tap request-on-deny; mark crown-jewel vault keys passphrase-required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)