### PR TITLE
fix(auth-broker): route Microsoft provider in dispatch + refresh (RFC #1873 repair)

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -263,6 +263,19 @@ export interface ListGoogleAccountsData {
   accounts: GoogleAccountState[];
 }
 
+/** Per-account inventory entry returned by `listMicrosoftAccounts()`. */
+export interface MicrosoftAccountState {
+  account: string;
+  expiresAt: number;
+  scope: string;
+  clientId: string;
+  accountType: "personal" | "work";
+}
+
+export interface ListMicrosoftAccountsData {
+  accounts: MicrosoftAccountState[];
+}
+
 /** Anthropic-shaped credentials payload for `addAccount`. */
 export interface AnthropicAddAccountCredentials {
   claudeAiOauth: {
@@ -395,6 +408,15 @@ export class AuthBrokerClient {
       op: "list-google-accounts",
     });
     return data as ListGoogleAccountsData;
+  }
+
+  async listMicrosoftAccounts(): Promise<ListMicrosoftAccountsData> {
+    const data = await this.send({
+      v: PROTOCOL_VERSION,
+      id: randomUUID(),
+      op: "list-microsoft-accounts",
+    });
+    return data as ListMicrosoftAccountsData;
   }
 
   /**

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -295,6 +295,19 @@ export const ListGoogleAccountsRequestSchema = z.object({
 });
 
 /**
+ * RFC #1873 — Microsoft account inventory. Mirror of
+ * `list-google-accounts`: returns credential metadata only (account,
+ * expiry, scope, clientId, accountType) — never the refresh/access
+ * tokens. Powers `switchroom auth microsoft account list` so an
+ * operator can confirm the YAML ACL matches what the broker holds.
+ */
+export const ListMicrosoftAccountsRequestSchema = z.object({
+  v: z.literal(PROTOCOL_VERSION),
+  op: z.literal("list-microsoft-accounts"),
+  id: z.string().min(1),
+});
+
+/**
  * Probe live Anthropic quota for a set of accounts. The broker reads
  * each account's stored accessToken from `~/.switchroom/accounts/
  * <label>/credentials.json` (its source of truth, only the broker has
@@ -338,6 +351,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   RmAccountRequestSchema,
   SetOverrideRequestSchema,
   ListGoogleAccountsRequestSchema,
+  ListMicrosoftAccountsRequestSchema,
   ProbeQuotaRequestSchema,
 ]);
 
@@ -424,6 +438,24 @@ export const GoogleAccountStateSchema = z.object({
 
 export const ListGoogleAccountsDataSchema = z.object({
   accounts: z.array(GoogleAccountStateSchema),
+});
+
+/**
+ * Per-Microsoft-account inventory entry returned by
+ * `list-microsoft-accounts`. Like Google's, excludes refresh + access
+ * tokens; adds `accountType` so a personal MSA is distinguishable from
+ * a work/school account in the listing.
+ */
+export const MicrosoftAccountStateSchema = z.object({
+  account: z.string(),
+  expiresAt: z.number(),
+  scope: z.string(),
+  clientId: z.string(),
+  accountType: z.enum(["personal", "work"]),
+});
+
+export const ListMicrosoftAccountsDataSchema = z.object({
+  accounts: z.array(MicrosoftAccountStateSchema),
 });
 
 // ─── Response envelope ─────────────────────────────────────────────────────

--- a/src/auth/broker/server-microsoft.test.ts
+++ b/src/auth/broker/server-microsoft.test.ts
@@ -1,0 +1,675 @@
+/**
+ * auth-broker — Microsoft provider dispatch (RFC #1873 broker repair).
+ *
+ * Before this fix the broker registered MicrosoftProvider but the
+ * get-credentials / add-account / rm-account dispatch only routed
+ * `anthropic` and `google` — every Microsoft call fell through to
+ * `INTERNAL: unhandled provider 'microsoft'`, leaving the M365
+ * integration non-functional end-to-end. These tests pin the four
+ * Microsoft broker ops (get-credentials, add-account, rm-account,
+ * list-microsoft-accounts) plus the refresh-tick, mirroring the Google
+ * coverage in `server-list-google-accounts.test.ts` +
+ * `server-google-refresh.test.ts`.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as net from "node:net";
+
+import { AuthBroker } from "./server.js";
+import { decodeResponse, encodeRequest } from "./protocol.js";
+import {
+  microsoftAccountCredentialsPath,
+  microsoftAccountExists,
+  writeMicrosoftAccountCredentials,
+} from "./microsoft-storage.js";
+import type { SwitchroomConfig } from "../../config/schema.js";
+import type { MicrosoftCredentialsShape } from "./protocol.js";
+
+interface Harness {
+  tmp: string;
+  home: string;
+  agentsDir: string;
+  stateDir: string;
+  socketRoot: string;
+}
+
+let harnesses: Harness[] = [];
+
+function makeHarness(): Harness {
+  const tmp = mkdtempSync(join(tmpdir(), "auth-broker-microsoft-test-"));
+  const home = join(tmp, "home");
+  const agentsDir = join(home, ".switchroom", "agents");
+  const stateDir = join(home, ".switchroom", "state", "auth-broker");
+  const socketRoot = join(tmp, "run", "switchroom", "auth-broker");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(agentsDir, { recursive: true });
+  const h: Harness = { tmp, home, agentsDir, stateDir, socketRoot };
+  harnesses.push(h);
+  return h;
+}
+
+afterEach(() => {
+  for (const h of harnesses) {
+    try {
+      rmSync(h.tmp, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  harnesses = [];
+});
+
+/**
+ * Build a config with the Microsoft provider registered (client_id
+ * present, no secret — public-client posture). `agents` and
+ * `microsoft_accounts` are passed verbatim so tests can wire the
+ * per-agent `microsoft_workspace.account` selector + the per-account
+ * `enabled_for[]` ACL.
+ */
+function makeConfig(
+  h: Harness,
+  opts: {
+    agents?: Record<string, object>;
+    microsoftAccounts?: Record<string, { enabled_for?: string[] }>;
+    withProvider?: boolean;
+  } = {},
+): SwitchroomConfig {
+  const base: Record<string, unknown> = {
+    switchroom: { version: 1, agents_dir: h.agentsDir },
+    telegram: {},
+    agents: opts.agents ?? {},
+    auth: {},
+  };
+  if (opts.withProvider !== false) {
+    base.microsoft_workspace = {
+      microsoft_client_id: "11111111-2222-3333-4444-555555555555",
+      authority: "https://login.microsoftonline.com/common",
+    };
+  }
+  if (opts.microsoftAccounts) {
+    base.microsoft_accounts = opts.microsoftAccounts;
+  }
+  return base as unknown as SwitchroomConfig;
+}
+
+function seedMicrosoftAccount(
+  h: Harness,
+  account: string,
+  opts: {
+    expiresAt: number;
+    refreshToken?: string;
+    accessToken?: string;
+    scope?: string;
+    accountType?: "personal" | "work";
+    tenantId?: string;
+  } = { expiresAt: Date.now() + 3600_000 },
+): void {
+  const accountType = opts.accountType ?? "personal";
+  const creds: MicrosoftCredentialsShape = {
+    microsoftOauth: {
+      accessToken: opts.accessToken ?? `at-${account}`,
+      refreshToken: opts.refreshToken ?? `rt-${account}`,
+      expiresAt: opts.expiresAt,
+      scope:
+        opts.scope ??
+        "openid profile offline_access Mail.ReadWrite Files.ReadWrite.All",
+      clientId: "11111111-2222-3333-4444-555555555555",
+      accountEmail: account,
+      tokenType: "Bearer",
+      tenantId:
+        opts.tenantId ??
+        (accountType === "personal"
+          ? "9188040d-6c67-4c5b-b112-36a304b66dad"
+          : "contoso-tenant-id"),
+      accountType,
+      homeAccountId: `oid-${account}.${opts.tenantId ?? "tid"}`,
+    },
+  };
+  writeMicrosoftAccountCredentials(h.stateDir, account, creds);
+}
+
+/** Open UDS, send one request, read one response, close. */
+async function rpc(socketPath: string, req: object): Promise<unknown> {
+  return await new Promise<unknown>((resolveP, rejectP) => {
+    const c = net.createConnection(socketPath);
+    let buf = "";
+    let settled = false;
+    const settle = (v: unknown, err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      try {
+        c.destroy();
+      } catch {
+        /* ignore */
+      }
+      if (err) rejectP(err);
+      else resolveP(v);
+    };
+    c.on("connect", () => {
+      c.write(encodeRequest(req as Parameters<typeof encodeRequest>[0]));
+    });
+    c.on("data", (chunk) => {
+      buf += chunk.toString("utf-8");
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        const line = buf.slice(0, nl);
+        try {
+          settle(decodeResponse(line));
+        } catch (err) {
+          settle(null, err as Error);
+        }
+      }
+    });
+    c.on("error", (err) => settle(null, err));
+    setTimeout(() => settle(null, new Error("rpc timeout")), 3000);
+  });
+}
+
+/**
+ * Stub fetch returning a successful Microsoft token-exchange response.
+ * `withIdToken: false` omits the id_token (a real Microsoft refresh
+ * behavior under some scope/account combos) so we can assert the
+ * provider preserves canonical identity fields from priorCredentials.
+ */
+function makeOkFetcher(opts: {
+  newAccessToken?: string;
+  rotatedRefreshToken?: string;
+  expiresIn?: number;
+  withIdToken?: boolean;
+}): { fetcher: typeof fetch; calls: string[] } {
+  const calls: string[] = [];
+  const fetcher = (async (input: RequestInfo | URL) => {
+    calls.push(String(input));
+    const body: Record<string, unknown> = {
+      access_token: opts.newAccessToken ?? "at-new",
+      expires_in: opts.expiresIn ?? 3600,
+      token_type: "Bearer",
+      scope: "Mail.ReadWrite Files.ReadWrite.All",
+    };
+    if (opts.rotatedRefreshToken) {
+      body.refresh_token = opts.rotatedRefreshToken;
+    }
+    // id_token deliberately omitted unless requested — exercises the
+    // priorCredentials fallback in MicrosoftProvider.refresh.
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }) as unknown as Awaited<ReturnType<typeof fetch>>;
+  }) as unknown as typeof fetch;
+  return { fetcher, calls };
+}
+
+function makeInvalidGrantFetcher(): typeof fetch {
+  return (async () => {
+    return new Response(
+      JSON.stringify({
+        error: "invalid_grant",
+        error_description: "AADSTS70000: token revoked.",
+      }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    ) as unknown as Awaited<ReturnType<typeof fetch>>;
+  }) as unknown as typeof fetch;
+}
+
+describe("AuthBroker — Microsoft get-credentials op", () => {
+  it("returns stored credentials for an agent pinned + ACL-enabled on the account", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      agents: { ziggy: { microsoft_workspace: { account: "lisa@outlook.com" } } },
+      microsoftAccounts: { "lisa@outlook.com": { enabled_for: ["ziggy"] } },
+    });
+    seedMicrosoftAccount(h, "lisa@outlook.com", {
+      expiresAt: Date.now() + 3600_000,
+      accessToken: "at-lisa-live",
+    });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "ms-1",
+      op: "get-credentials",
+      provider: "microsoft",
+    })) as {
+      ok: true;
+      data: { account: string; credentials: MicrosoftCredentialsShape };
+    };
+
+    expect(resp.ok).toBe(true);
+    expect(resp.data.account).toBe("lisa@outlook.com");
+    expect(resp.data.credentials.microsoftOauth.accessToken).toBe("at-lisa-live");
+
+    broker.stop();
+  });
+
+  it("FORBIDs an agent not listed in the account's enabled_for[]", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      agents: { ziggy: { microsoft_workspace: { account: "lisa@outlook.com" } } },
+      // ziggy pinned to the account but NOT in enabled_for.
+      microsoftAccounts: { "lisa@outlook.com": { enabled_for: ["clerk"] } },
+    });
+    seedMicrosoftAccount(h, "lisa@outlook.com", { expiresAt: Date.now() + 3600_000 });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "ms-2",
+      op: "get-credentials",
+      provider: "microsoft",
+    })) as { ok: false; error: { code: string } };
+
+    expect(resp.ok).toBe(false);
+    expect(resp.error.code).toBe("FORBIDDEN");
+
+    broker.stop();
+  });
+
+  it("ACCOUNT_NOT_FOUND when the agent has no microsoft_workspace.account configured", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { agents: { ziggy: {} } });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "ms-3",
+      op: "get-credentials",
+      provider: "microsoft",
+    })) as { ok: false; error: { code: string } };
+
+    expect(resp.ok).toBe(false);
+    expect(resp.error.code).toBe("ACCOUNT_NOT_FOUND");
+
+    broker.stop();
+  });
+
+  it("ACCOUNT_NOT_FOUND when pinned + enabled but no credentials on disk", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      agents: { ziggy: { microsoft_workspace: { account: "lisa@outlook.com" } } },
+      microsoftAccounts: { "lisa@outlook.com": { enabled_for: ["ziggy"] } },
+    });
+    // No seedMicrosoftAccount — nothing on disk.
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "ms-4",
+      op: "get-credentials",
+      provider: "microsoft",
+    })) as { ok: false; error: { code: string } };
+
+    expect(resp.ok).toBe(false);
+    expect(resp.error.code).toBe("ACCOUNT_NOT_FOUND");
+
+    broker.stop();
+  });
+});
+
+describe("AuthBroker — Microsoft add-account / rm-account ops", () => {
+  const validCreds = {
+    microsoftOauth: {
+      accessToken: "at-new",
+      refreshToken: "rt-new",
+      expiresAt: Date.now() + 3600_000,
+      scope: "Mail.ReadWrite Files.ReadWrite.All",
+      clientId: "11111111-2222-3333-4444-555555555555",
+      accountEmail: "newguy@outlook.com",
+      tokenType: "Bearer" as const,
+      tenantId: "9188040d-6c67-4c5b-b112-36a304b66dad",
+      accountType: "personal" as const,
+      homeAccountId: "oid.tid",
+    },
+  };
+
+  it("admin can add a Microsoft account; non-admin cannot", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      agents: { ziggy: {}, clerk: { admin: true } },
+    });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const denied = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "add-1",
+      op: "add-account",
+      provider: "microsoft",
+      label: "newguy@outlook.com",
+      credentials: validCreds,
+    })) as { ok: false; error: { code: string } };
+    expect(denied.ok).toBe(false);
+    expect(denied.error.code).toBe("FORBIDDEN");
+    expect(microsoftAccountExists(h.stateDir, "newguy@outlook.com")).toBe(false);
+
+    const ok = (await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "add-2",
+      op: "add-account",
+      provider: "microsoft",
+      label: "newguy@outlook.com",
+      credentials: validCreds,
+    })) as { ok: true; data: { label: string } };
+    expect(ok.ok).toBe(true);
+    expect(ok.data.label).toBe("newguy@outlook.com");
+    expect(microsoftAccountExists(h.stateDir, "newguy@outlook.com")).toBe(true);
+
+    broker.stop();
+  });
+
+  it("ACCOUNT_ALREADY_EXISTS without replace; succeeds with replace", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { agents: { clerk: { admin: true } } });
+    seedMicrosoftAccount(h, "newguy@outlook.com", { expiresAt: Date.now() + 3600_000 });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const dup = (await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "add-3",
+      op: "add-account",
+      provider: "microsoft",
+      label: "newguy@outlook.com",
+      credentials: validCreds,
+    })) as { ok: false; error: { code: string } };
+    expect(dup.ok).toBe(false);
+    expect(dup.error.code).toBe("ACCOUNT_ALREADY_EXISTS");
+
+    const replaced = (await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "add-4",
+      op: "add-account",
+      provider: "microsoft",
+      label: "newguy@outlook.com",
+      credentials: validCreds,
+      replace: true,
+    })) as { ok: true };
+    expect(replaced.ok).toBe(true);
+
+    broker.stop();
+  });
+
+  it("rm-account refuses while the account is still enabled_for an agent", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      agents: { clerk: { admin: true } },
+      microsoftAccounts: { "lisa@outlook.com": { enabled_for: ["ziggy"] } },
+    });
+    seedMicrosoftAccount(h, "lisa@outlook.com", { expiresAt: Date.now() + 3600_000 });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const refused = (await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "rm-1",
+      op: "rm-account",
+      provider: "microsoft",
+      label: "lisa@outlook.com",
+    })) as { ok: false; error: { code: string; message: string } };
+    expect(refused.ok).toBe(false);
+    expect(refused.error.code).toBe("INVALID_ARGS");
+    expect(refused.error.message).toContain("still enabled");
+    expect(microsoftAccountExists(h.stateDir, "lisa@outlook.com")).toBe(true);
+
+    broker.stop();
+  });
+
+  it("rm-account removes an account with no remaining grants", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { agents: { clerk: { admin: true } } });
+    seedMicrosoftAccount(h, "lisa@outlook.com", { expiresAt: Date.now() + 3600_000 });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const removed = (await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1,
+      id: "rm-2",
+      op: "rm-account",
+      provider: "microsoft",
+      label: "lisa@outlook.com",
+    })) as { ok: true };
+    expect(removed.ok).toBe(true);
+    expect(microsoftAccountExists(h.stateDir, "lisa@outlook.com")).toBe(false);
+
+    broker.stop();
+  });
+});
+
+describe("AuthBroker — list-microsoft-accounts op", () => {
+  it("returns stored accounts sorted by email with accountType, no tokens", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { agents: { ziggy: {} } });
+    seedMicrosoftAccount(h, "carol@contoso.com", {
+      expiresAt: 3000,
+      accountType: "work",
+    });
+    seedMicrosoftAccount(h, "alice@outlook.com", {
+      expiresAt: 1000,
+      accountType: "personal",
+    });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "list-1",
+      op: "list-microsoft-accounts",
+    })) as { ok: true; data: { accounts: Array<Record<string, unknown>> } };
+
+    expect(resp.ok).toBe(true);
+    expect(resp.data.accounts.map((a) => a.account)).toEqual([
+      "alice@outlook.com",
+      "carol@contoso.com",
+    ]);
+    expect(resp.data.accounts[0].accountType).toBe("personal");
+    expect(resp.data.accounts[1].accountType).toBe("work");
+    for (const a of resp.data.accounts) {
+      expect(a).not.toHaveProperty("refreshToken");
+      expect(a).not.toHaveProperty("accessToken");
+    }
+
+    broker.stop();
+  });
+
+  it("returns an empty list when no Microsoft accounts are stored", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { agents: { ziggy: {} } });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "list-2",
+      op: "list-microsoft-accounts",
+    })) as { ok: true; data: { accounts: unknown[] } };
+
+    expect(resp.ok).toBe(true);
+    expect(resp.data.accounts).toEqual([]);
+
+    broker.stop();
+  });
+});
+
+describe("AuthBroker — Microsoft refresh-tick", () => {
+  it("refreshes a near-expiry account and preserves identity fields when the refresh omits id_token", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { agents: {} });
+    const aboutToExpire = Date.now() + 5 * 60 * 1000; // inside the 60-min threshold
+    seedMicrosoftAccount(h, "lisa@outlook.com", {
+      expiresAt: aboutToExpire,
+      refreshToken: "rt-lisa",
+      accountType: "work",
+      tenantId: "contoso-tenant-id",
+    });
+
+    const { fetcher, calls } = makeOkFetcher({
+      newAccessToken: "at-lisa-fresh",
+      rotatedRefreshToken: "rt-lisa-rotated",
+      withIdToken: false, // no id_token → must fall back to priorCredentials
+    });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      fetcher,
+    });
+    await broker.start();
+    await broker._tick();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("login.microsoftonline.com/common/oauth2/v2.0/token");
+
+    const onDisk = JSON.parse(
+      readFileSync(microsoftAccountCredentialsPath(h.stateDir, "lisa@outlook.com"), "utf-8"),
+    ) as MicrosoftCredentialsShape;
+    expect(onDisk.microsoftOauth.accessToken).toBe("at-lisa-fresh");
+    expect(onDisk.microsoftOauth.expiresAt).toBeGreaterThan(aboutToExpire);
+    // RT rotated and persisted.
+    expect(onDisk.microsoftOauth.refreshToken).toBe("rt-lisa-rotated");
+    // Identity fields preserved from priorCredentials (no id_token in response).
+    expect(onDisk.microsoftOauth.tenantId).toBe("contoso-tenant-id");
+    expect(onDisk.microsoftOauth.accountType).toBe("work");
+
+    broker.stop();
+  });
+
+  it("does NOT refresh when the token is comfortably valid (>1h remaining)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { agents: {} });
+    const farFuture = Date.now() + 24 * 60 * 60 * 1000;
+    seedMicrosoftAccount(h, "bob@outlook.com", { expiresAt: farFuture });
+
+    const { fetcher, calls } = makeOkFetcher({});
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      fetcher,
+    });
+    await broker.start();
+    await broker._tick();
+
+    expect(calls).toHaveLength(0);
+    broker.stop();
+  });
+
+  it("does NOT touch on-disk credentials when Microsoft returns invalid_grant", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { agents: {} });
+    const originalExpiresAt = Date.now() + 5 * 60 * 1000;
+    seedMicrosoftAccount(h, "dave@outlook.com", {
+      expiresAt: originalExpiresAt,
+      accessToken: "at-dave-original",
+      refreshToken: "rt-dave-revoked",
+    });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      fetcher: makeInvalidGrantFetcher(),
+    });
+    await broker.start();
+    await broker._tick(); // must not throw
+
+    const onDisk = JSON.parse(
+      readFileSync(microsoftAccountCredentialsPath(h.stateDir, "dave@outlook.com"), "utf-8"),
+    ) as MicrosoftCredentialsShape;
+    expect(onDisk.microsoftOauth.accessToken).toBe("at-dave-original");
+    expect(onDisk.microsoftOauth.refreshToken).toBe("rt-dave-revoked");
+    expect(onDisk.microsoftOauth.expiresAt).toBe(originalExpiresAt);
+
+    broker.stop();
+  });
+
+  it("is a no-op when microsoft_workspace config is absent (provider not registered)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { agents: {}, withProvider: false });
+    seedMicrosoftAccount(h, "alice@outlook.com", {
+      expiresAt: Date.now() + 5 * 60 * 1000,
+    });
+
+    const { fetcher, calls } = makeOkFetcher({});
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      fetcher,
+    });
+    await broker.start();
+    await broker._tick();
+
+    expect(calls).toHaveLength(0);
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -60,8 +60,16 @@ import {
   validateGoogleAccountLabel,
   writeGoogleAccountCredentials,
 } from "./google-storage.js";
+import {
+  listMicrosoftAccounts,
+  microsoftAccountExists,
+  readMicrosoftAccountCredentials,
+  removeMicrosoftAccount,
+  validateMicrosoftAccountLabel,
+  writeMicrosoftAccountCredentials,
+} from "./microsoft-storage.js";
 import { ProviderRegistry, type ProviderName } from "./provider.js";
-import type { GoogleCredentialsShape } from "./protocol.js";
+import type { GoogleCredentialsShape, MicrosoftCredentialsShape } from "./protocol.js";
 import {
   accountCredentialsPath,
   accountDir,
@@ -660,6 +668,10 @@ export class AuthBroker {
             await this.opGoogleGetCredentials(socket, reqId, identity);
             break;
           }
+          if (provider === "microsoft") {
+            await this.opMicrosoftGetCredentials(socket, reqId, identity);
+            break;
+          }
           socket.write(
             encodeError(
               reqId,
@@ -787,6 +799,21 @@ export class AuthBroker {
             );
             break;
           }
+          // Microsoft: writes to broker's own state dir under
+          // `~/.switchroom/state/auth-broker/microsoft/<account>/`,
+          // mirroring the Google shape (RFC #1873).
+          if (provider === "microsoft") {
+            const microsoftCreds = req.credentials as MicrosoftCredentialsShape;
+            await this.opMicrosoftAddAccount(
+              socket,
+              reqId,
+              identity,
+              req.label,
+              microsoftCreds,
+              req.replace ?? false,
+            );
+            break;
+          }
           // Unreachable today (registry has() rejects unknown
           // providers above), but defensive.
           socket.write(
@@ -818,6 +845,10 @@ export class AuthBroker {
             await this.opGoogleRmAccount(socket, reqId, identity, req.label);
             break;
           }
+          if (provider === "microsoft") {
+            await this.opMicrosoftRmAccount(socket, reqId, identity, req.label);
+            break;
+          }
           socket.write(
             encodeError(
               reqId,
@@ -832,6 +863,9 @@ export class AuthBroker {
           break;
         case "list-google-accounts":
           await this.opListGoogleAccounts(socket, reqId, identity);
+          break;
+        case "list-microsoft-accounts":
+          await this.opListMicrosoftAccounts(socket, reqId, identity);
           break;
         case "probe-quota":
           await this.opProbeQuota(
@@ -1410,6 +1444,189 @@ export class AuthBroker {
     socket.write(encodeSuccess(id, { label }));
   }
 
+  /**
+   * RFC #1873 — Microsoft get-credentials. Mirrors
+   * `opGoogleGetCredentials`: per-agent only, account derived from the
+   * agent's `microsoft_workspace.account` selector (never the wire —
+   * path-as-identity), ACL gated on
+   * `microsoft_accounts.<account>.enabled_for[]`, credentials read from
+   * the broker's own state dir.
+   */
+  private async opMicrosoftGetCredentials(
+    socket: net.Socket,
+    id: string,
+    identity: Identity,
+  ): Promise<void> {
+    if (identity.kind !== "agent") {
+      socket.write(
+        encodeError(
+          id,
+          "INVALID_ARGS",
+          `Microsoft get-credentials is per-agent only (caller kind '${identity.kind}' not supported); use the agent's per-agent socket bind`,
+        ),
+      );
+      return;
+    }
+    const agentName = identity.name;
+    const agent = (this.config.agents ?? {})[agentName] as
+      | { microsoft_workspace?: { account?: string } }
+      | undefined;
+    const account = agent?.microsoft_workspace?.account;
+    if (!account) {
+      this.audit({ op: "get-credentials", identity, ok: false, error: "no-microsoft-account-configured" });
+      socket.write(
+        encodeError(
+          id,
+          "ACCOUNT_NOT_FOUND",
+          `agent '${agentName}' has no microsoft_workspace.account configured in switchroom.yaml`,
+        ),
+      );
+      return;
+    }
+    // ACL: agent must be in microsoft_accounts.<account>.enabled_for[].
+    const ma = (this.config as { microsoft_accounts?: Record<string, { enabled_for?: string[] }> })
+      .microsoft_accounts;
+    const enabledFor = ma?.[account]?.enabled_for ?? [];
+    if (!enabledFor.includes(agentName)) {
+      this.audit({ op: "get-credentials", identity, account, ok: false, error: "acl-deny" });
+      socket.write(
+        encodeError(
+          id,
+          "FORBIDDEN",
+          `agent '${agentName}' not in microsoft_accounts['${account}'].enabled_for[] — operator must run \`switchroom auth microsoft enable ${account} ${agentName}\``,
+        ),
+      );
+      return;
+    }
+    // Storage read.
+    const creds = readMicrosoftAccountCredentials(this.stateDir, account);
+    if (!creds) {
+      this.audit({ op: "get-credentials", identity, account, ok: false, error: "missing-credentials" });
+      socket.write(
+        encodeError(
+          id,
+          "ACCOUNT_NOT_FOUND",
+          `no Microsoft credentials for account '${account}' — operator must run \`switchroom auth microsoft account add ${account}\``,
+        ),
+      );
+      return;
+    }
+    const expiresAt = creds.microsoftOauth?.expiresAt;
+    this.audit({ op: "get-credentials", identity, account, ok: true });
+    socket.write(encodeSuccess(id, { account, credentials: creds, expiresAt }));
+  }
+
+  private async opMicrosoftAddAccount(
+    socket: net.Socket,
+    id: string,
+    identity: Identity,
+    label: string,
+    credentials: MicrosoftCredentialsShape,
+    replace: boolean,
+  ): Promise<void> {
+    if (!this.isAdmin(identity)) {
+      this.audit({ op: "add-account", identity, account: label, ok: false, error: "FORBIDDEN" });
+      this.respondForbidden(socket, id, "add-account requires admin");
+      return;
+    }
+    // Defense-in-depth path-traversal guard (same posture as Google).
+    try {
+      validateMicrosoftAccountLabel(label);
+    } catch (err) {
+      socket.write(encodeError(id, "INVALID_ARGS", (err as Error).message));
+      return;
+    }
+    if (microsoftAccountExists(this.stateDir, label) && !replace) {
+      this.audit({ op: "add-account", identity, account: label, ok: false, error: "ACCOUNT_ALREADY_EXISTS" });
+      socket.write(encodeError(id, "ACCOUNT_ALREADY_EXISTS", `microsoft account '${label}' already exists; pass replace:true to overwrite`));
+      return;
+    }
+    try {
+      writeMicrosoftAccountCredentials(this.stateDir, label, credentials);
+    } catch (err) {
+      socket.write(encodeError(id, "INTERNAL", (err as Error).message));
+      return;
+    }
+    const expiresAt = credentials.microsoftOauth?.expiresAt;
+    this.audit({ op: "add-account", identity, account: label, ok: true, replace });
+    socket.write(encodeSuccess(id, { label, expiresAt }));
+  }
+
+  /**
+   * RFC #1873 — Microsoft rm-account. Refuses to remove while the
+   * account is in `microsoft_accounts.<label>.enabled_for[]` (an agent
+   * still depends on the credential). Operator must
+   * `auth microsoft disable <label> all` first.
+   */
+  private async opMicrosoftRmAccount(
+    socket: net.Socket,
+    id: string,
+    identity: Identity,
+    label: string,
+  ): Promise<void> {
+    if (!this.isAdmin(identity)) {
+      this.audit({ op: "rm-account", identity, account: label, ok: false, error: "FORBIDDEN" });
+      this.respondForbidden(socket, id, "rm-account requires admin");
+      return;
+    }
+    try {
+      validateMicrosoftAccountLabel(label);
+    } catch (err) {
+      socket.write(encodeError(id, "INVALID_ARGS", (err as Error).message));
+      return;
+    }
+    if (!microsoftAccountExists(this.stateDir, label)) {
+      socket.write(encodeError(id, "ACCOUNT_NOT_FOUND", `microsoft account '${label}' not found`));
+      return;
+    }
+    // Refuse if any agent is still enabled on this account.
+    const ma = (this.config as { microsoft_accounts?: Record<string, { enabled_for?: string[] }> }).microsoft_accounts;
+    const enabledFor = ma?.[label]?.enabled_for ?? [];
+    if (enabledFor.length > 0) {
+      socket.write(encodeError(id, "INVALID_ARGS", `microsoft account '${label}' is still enabled for agents: ${enabledFor.join(", ")}. Run \`auth microsoft disable ${label} all\` first.`));
+      return;
+    }
+    try {
+      removeMicrosoftAccount(this.stateDir, label);
+    } catch (err) {
+      socket.write(encodeError(id, "INTERNAL", (err as Error).message));
+      return;
+    }
+    this.audit({ op: "rm-account", identity, account: label, ok: true });
+    socket.write(encodeSuccess(id, { label }));
+  }
+
+  /**
+   * RFC #1873 — Microsoft account inventory. Mirror of
+   * `opListGoogleAccounts`: no ACL (same posture as `list-state`), never
+   * returns the refresh/access tokens, just the metadata an operator
+   * needs to confirm `auth microsoft list` (YAML) matches what the
+   * broker actually holds. Also surfaces accountType so the operator can
+   * tell a personal MSA from a work/school account at a glance.
+   */
+  private async opListMicrosoftAccounts(
+    socket: net.Socket,
+    id: string,
+    identity: Identity,
+  ): Promise<void> {
+    const accounts = listMicrosoftAccounts(this.stateDir)
+      .map((account) => {
+        const creds = readMicrosoftAccountCredentials(this.stateDir, account);
+        if (!creds) return null;
+        return {
+          account,
+          expiresAt: creds.microsoftOauth.expiresAt,
+          scope: creds.microsoftOauth.scope,
+          clientId: creds.microsoftOauth.clientId,
+          accountType: creds.microsoftOauth.accountType,
+        };
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+      .sort((a, b) => a.account.localeCompare(b.account));
+    this.audit({ op: "list-microsoft-accounts", identity, ok: true });
+    socket.write(encodeSuccess(id, { accounts }));
+  }
+
   private async opSetOverride(
     socket: net.Socket,
     id: string,
@@ -1463,6 +1680,23 @@ export class AuthBroker {
         } catch (err) {
           this.logErr(
             `refresh-tick google:${account}: ${(err as Error).message}`,
+          );
+        }
+      }
+    }
+    // RFC #1873 — also walk Microsoft accounts. Same no-op-if-unregistered
+    // guard as Google; keeps the on-disk access token fresh for the
+    // m365-mcp-launcher (which pulls via get-credentials({provider:
+    // "microsoft"})). Microsoft rotates the refresh token on every
+    // exchange, so refreshOneMicrosoftAccount persists the new RT
+    // atomically — see microsoft-storage.ts.
+    if (this.providers.has("microsoft")) {
+      for (const account of listMicrosoftAccounts(this.stateDir)) {
+        try {
+          await this.refreshOneMicrosoftAccount(account, /*force*/ false);
+        } catch (err) {
+          this.logErr(
+            `refresh-tick microsoft:${account}: ${(err as Error).message}`,
           );
         }
       }
@@ -1533,6 +1767,72 @@ export class AuthBroker {
       const newCreds = result.rawCredentials as GoogleCredentialsShape;
       // Provider returned the rawCredentials shape verbatim; persist.
       writeGoogleAccountCredentials(this.stateDir, account, newCreds);
+      return { kind: "refreshed", newExpiresAt: result.expiresAt };
+    } finally {
+      this.refreshInFlight.delete(leaseKey);
+    }
+  }
+
+  /**
+   * Pre-emptively refresh one Microsoft account's access token if it's
+   * within REFRESH_THRESHOLD_MS of expiry. Mirrors
+   * `refreshOneGoogleAccount` — same lease pattern, threshold, and
+   * outcome discriminant — but talks to MicrosoftProvider and writes
+   * back via `writeMicrosoftAccountCredentials`.
+   *
+   * **Microsoft-specific**: the provider needs `priorCredentials` to
+   * preserve canonical identity fields (tenantId / accountType /
+   * homeAccountId / accountEmail) when Microsoft's v2 `/token` omits
+   * `id_token` on a refresh response — without it the provider would
+   * clobber those with empty placeholders (see microsoft-provider.ts).
+   * Google's path doesn't pass this because its credential shape carries
+   * no identity claims a refresh could fail to return.
+   */
+  private async refreshOneMicrosoftAccount(
+    account: string,
+    force: boolean,
+  ): Promise<
+    | { kind: "noop" }
+    | { kind: "refreshed"; newExpiresAt: number }
+    | { kind: "failed"; error: string }
+  > {
+    // Namespaced lease key so Microsoft `alice@outlook.com` can't
+    // collide with an Anthropic/Google account named the same.
+    const leaseKey = `microsoft:${account}`;
+    if (this.refreshInFlight.has(leaseKey)) return { kind: "noop" };
+
+    const credsBefore = readMicrosoftAccountCredentials(this.stateDir, account);
+    if (!credsBefore) {
+      // Account vanished between listMicrosoftAccounts() and now — noop.
+      return { kind: "noop" };
+    }
+    const provider = this.providers.lookup("microsoft");
+    const onDiskExpires = provider.extractExpiresAt(credsBefore);
+    if (!force) {
+      const remaining = (onDiskExpires ?? 0) - this.now();
+      if (onDiskExpires !== undefined && remaining > REFRESH_THRESHOLD_MS) {
+        return { kind: "noop" };
+      }
+    }
+
+    this.refreshInFlight.add(leaseKey);
+    try {
+      const refreshToken = credsBefore.microsoftOauth.refreshToken;
+      const result = await provider.refresh({
+        refreshToken,
+        accountEmail: account,
+        clientId: credsBefore.microsoftOauth.clientId,
+        priorCredentials: credsBefore,
+      });
+      if (!result.ok) {
+        // Leave on-disk credentials untouched on failure — a transient
+        // network error may resolve next tick, and on invalid_grant the
+        // operator must re-OAuth (the launcher's get-credentials call
+        // surfaces a clean error to the consumer when it next reads).
+        return { kind: "failed", error: `${result.kind}: ${result.detail}` };
+      }
+      const newCreds = result.rawCredentials as MicrosoftCredentialsShape;
+      writeMicrosoftAccountCredentials(this.stateDir, account, newCreds);
       return { kind: "refreshed", newExpiresAt: result.expiresAt };
     } finally {
       this.refreshInFlight.delete(leaseKey);

--- a/src/cli/auth-microsoft.ts
+++ b/src/cli/auth-microsoft.ts
@@ -559,22 +559,76 @@ function registerAccountList(accountParent: Command): void {
     )
     .option("--json", "Emit raw JSON")
     .action(
-      withConfigError(async (_opts: { json?: boolean }) => {
-        // Phase 2 follow-up — needs a `list-microsoft-accounts` broker op
-        // (mirror of `list-google-accounts`). For now, fall back to
-        // pointing at the YAML view.
+      withConfigError(async (opts: { json?: boolean }) => {
+        const { brokerCall } = await import("./broker-call.js");
+        const data = await brokerCall(async (client) =>
+          client.listMicrosoftAccounts(),
+        );
+
+        if (opts.json) {
+          console.log(JSON.stringify(data, null, 2));
+          return;
+        }
+
         console.log();
+        if (data.accounts.length === 0) {
+          console.log(chalk.gray("  No Microsoft accounts stored in broker."));
+          console.log(
+            `  Add one: ${chalk.bold("switchroom auth microsoft account add <email>")}`,
+          );
+          console.log();
+          return;
+        }
+
+        const accountColWidth = Math.max(
+          ...data.accounts.map((a) => a.account.length),
+          "ACCOUNT".length,
+        );
+        const typeColWidth = "TYPE".length + 4;
+        const expiresColWidth = "EXPIRES".length + 2;
         console.log(
-          chalk.yellow(
-            "  Broker-side listing for Microsoft accounts is a follow-up (needs a list-microsoft-accounts wire op).",
-          ),
+          `${pad("ACCOUNT", accountColWidth)}  ${pad("TYPE", typeColWidth)}  ${pad("EXPIRES", expiresColWidth)}  SCOPE`,
         );
         console.log(
-          `  For now, see the YAML matrix: ${chalk.bold("switchroom auth microsoft list")}`,
+          `${pad("-".repeat(7), accountColWidth)}  ${pad("-".repeat(4), typeColWidth)}  ${pad("-".repeat(7), expiresColWidth)}  ${"-".repeat(5)}`,
         );
+        const now = Date.now();
+        for (const a of data.accounts) {
+          const expiresLabel = formatMicrosoftExpiry(a.expiresAt - now);
+          // Compress Graph scope display — drop the noisy openid/profile/
+          // email/offline_access scaffolding scopes; keep the resource
+          // scopes (Mail/Files/Calendars) that tell the operator what the
+          // account can actually do.
+          const scopes = a.scope
+            .split(" ")
+            .filter(
+              (s) =>
+                s.length > 0 &&
+                !["openid", "profile", "email", "offline_access"].includes(s),
+            )
+            .join(", ");
+          console.log(
+            `${pad(a.account, accountColWidth)}  ${pad(a.accountType, typeColWidth)}  ${pad(expiresLabel, expiresColWidth)}  ${scopes}`,
+          );
+        }
         console.log();
       }),
     );
+}
+
+/**
+ * Format a millisecond duration as a short relative time. Negative
+ * durations render as "expired" — the broker's refresh-tick keeps
+ * stored creds fresh, so this should be rare for a live account.
+ */
+function formatMicrosoftExpiry(remainingMs: number): string {
+  if (remainingMs <= 0) return chalk.red("expired");
+  const minutes = Math.round(remainingMs / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  const days = Math.round(hours / 24);
+  return `${days}d`;
 }
 
 // ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The auth-broker **registered** `MicrosoftProvider` but never routed it. The `get-credentials` / `add-account` / `rm-account` dispatch only branched on `anthropic` and `google`; `microsoft` fell through to `INTERNAL: unhandled provider 'microsoft'` (`server.ts`). So the M365 integration was **non-functional end-to-end** despite provider + storage + CLI + launcher all existing — `m365-mcp-launcher`'s `getCredentials("microsoft")` errored, and `auth microsoft account add` errored at the broker. (Found during an out-of-box-OAuth design review; the docs claimed all 5 PRs shipped but the dispatch wiring was missing.)

This wires the Microsoft branch into all three dispatch sites + the refresh loop, mirroring the existing Google ops.

## Why

Prerequisite for any Microsoft connect/out-of-box work — nothing Microsoft functions until the broker can serve its credentials. Pure repair: no behavior change for Anthropic/Google.

## What changed

- **`opMicrosoftGetCredentials`** — per-agent only; account derived from the agent's `microsoft_workspace.account` selector (path-as-identity, never the wire); ACL gated on `microsoft_accounts.<account>.enabled_for[]`. Mirrors `opGoogleGetCredentials`.
- **`opMicrosoftAddAccount` / `opMicrosoftRmAccount`** — admin-gated; label path-traversal guard; `rm` refuses while any agent is still in `enabled_for[]`.
- **`refreshOneMicrosoftAccount` + refresh-tick loop** — keeps the stored access token fresh for the launcher. Passes `priorCredentials` (Google's path doesn't need this) so canonical identity fields (`tenantId`/`accountType`/`homeAccountId`) survive a refresh response that omits `id_token`; persists the rotated refresh token atomically.
- **`list-microsoft-accounts`** op + client method; un-stubs `auth microsoft account list` (was a placeholder). Surfaces `accountType` so personal MSA vs work is visible. No tokens returned.

## Test plan

- [x] New `server-microsoft.test.ts` — 14 tests: get-credentials ACL allow/deny, no-account, no-creds; add-account admin gate + already-exists(+replace); rm-account refuse-while-enabled + clean remove; list inventory (sorted, accountType, no tokens); refresh-tick (near-expiry refresh + `priorCredentials` identity-preservation when id_token absent + RT rotation, no-op when valid, invalid_grant leaves creds untouched, no-op when provider unregistered).
- [x] Full broker + Microsoft CLI/launcher/doctor suite green — **299 tests**.
- [x] `tsc --noEmit` clean.

## Risk

Low. Additive server-side handlers; `ProviderNameSchema` already accepted `"microsoft"` on the wire, so no protocol break. Anthropic/Google paths untouched. The new `list-microsoft-accounts` op is read-only with no ACL (same posture as `list-google-accounts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)