### PR TITLE
chore: release v0.14.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased — Reliable inbound delivery: deliver-until-acked
+## v0.14.40 — Reliable inbound delivery: deliver-until-acked
 
 Telegram inbounds reach claude as an MCP channel notification that the
 unmodified CLI appends to its TUI composer and auto-submits only when the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.39",
+  "version": "0.14.40",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.14.40 — **Reliable inbound delivery: deliver-until-acked** (#2089).

Ships the merged drop-wedge fix: a delivered inbound is acked only by claude's `enqueue` (turn actually started), re-delivered until acked, never dropped. Reviewer-APPROVED, 9 unit tests, kill switch `SWITCHROOM_INBOUND_DELIVERY_CONFIRM=0`.

Trivial release diff (CHANGELOG + version). Comprehensive E2E (no-drop scenario + full delivery UAT suite + live re-delivery demo + forensic) runs on the test-harness canary and gates the fleet rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)