### PR TITLE
test(uat): fix flaky /steer assertion + wire no-drop into ci-uat

### DIFF
--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -117,3 +117,14 @@ jobs:
         # gate. Keep them separate; operators run both during UAT.
         working-directory: telegram-plugin
         run: bun run test:uat jtbd-always-on-after-restart
+
+      - name: UAT reliable-delivery regression (rapid-fire no-drop)
+        if: steps.secrets.outputs.ok == 'true'
+        # Fires back-to-back messages at the turn-completion boundary and
+        # asserts every one gets its own reply — the regression gate for the
+        # deliver-until-acked queue (#2089), which replaced fire-and-forget
+        # delivery that stranded inbounds in the composer and dropped them at
+        # the 300s silence-poke. Driver-only (no sudo), but kept in its own
+        # step so a flake can't stall the fuzz pool.
+        working-directory: telegram-plugin
+        run: bun run test:uat inbound-no-drop

--- a/telegram-plugin/uat/scenarios/jtbd-rapid-followup-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-rapid-followup-dm.test.ts
@@ -55,8 +55,15 @@ describe("uat: rapid follow-ups — steering vs queued classification", () => {
           (m) => {
             const txt = m.text;
             const mentionsMd5 = /\bmd5\b/i.test(txt);
+            // Steer narration: the agent acknowledges amending the in-flight
+            // task. Accept the phrasings the model actually uses — including
+            // "Switched to MD5 per your update/follow-up" (the 2026-06-02
+            // canary reply that the old regex wrongly rejected). Anchored on
+            // "per your <qualifier>" / continuation language so it stays
+            // distinct from the QUEUED path (a fresh answer with no such
+            // course-correction narration).
             const narratesSteer =
-              /↪️|\bsteer(ing)?\b|continuing the (prior|original|in-flight) task|amendment|course[- ]correct/i.test(
+              /↪️|\bsteer(ing)?\b|switch(?:ed|ing)? to \w+ per your (?:update|follow-?up|guidance|request|steer)|continuing the (prior|original|in-flight) task|amendment|course[- ]correct/i.test(
                 txt,
               );
             return mentionsMd5 && narratesSteer;


### PR DESCRIPTION
Two follow-ups from the deliver-until-acked work (#2089):

1. **Flaky `/steer` assertion** — `jtbd-rapid-followup-dm`'s narration regex rejected the valid reply *Switched to MD5 per your update* (the 2026-06-02 canary; the 2026-05-27 run hit the same non-match). Broadened to accept `switch(ed|ing) to X per your update/follow-up/guidance/request/steer`, anchored on "per your <qualifier>" so it stays distinct from the queued path. Verified: matches the steer reply, rejects a fresh queued answer.
2. **ci-uat wiring** — added `inbound-no-drop-rapid-fire-dm` as its own isolated, secrets-gated step (mirroring `jtbd-always-on-after-restart`) so the deliver-until-acked regression coverage stays live.

Test-infra only; no production code. tsc clean, YAML valid, regex behavior verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
