### PR TITLE
fix(gateway): don't track steering/interrupt deliveries (re-deliver-loop fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
-## v0.14.40 — Reliable inbound delivery: deliver-until-acked
+## unreleased — Delivery-confirm: don't track steering/interrupt (re-deliver-loop fix)
+
+Follow-up hardening to v0.14.40's deliver-until-acked queue. That change
+tracked **every** delivered inbound for an `enqueue` ack — including
+`/steer` and `!`-interrupt messages. But those are delivered mid-turn to
+*amend the running turn* and never emit a fresh `enqueue`, so they were
+never acked and the 5s sweep re-delivered them (duplicate turns / a
+re-delivery loop). An adversarial stress-test of the v0.14.40 fix caught
+this before it bit in anger (the canary's steer test had passed only by
+ack-timing luck).
+
+- **Track only fresh-turn deliveries.** `shouldTrackDelivery` gates
+  tracking to non-steering, non-interrupt inbounds — exactly the messages
+  the #1556 buffer-gate holds-then-delivers, which are the ones that
+  produce an `enqueue` to ack against. Steering/interrupt are the gate's
+  carve-outs and are now equally exempt from the delivery-confirm queue.
+  Pure helper + unit tests pin the invariant. Also removes the only
+  realistic source of unbounded queue growth (never-acking entries).
 
 Telegram inbounds reach claude as an MCP channel notification that the
 unmodified CLI appends to its TUI composer and auto-submits only when the

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -286,6 +286,7 @@ import {
   ackDelivery,
   sweep as sweepDeliveryQueue,
   forgetDelivery,
+  shouldTrackDelivery,
   type PendingDelivery,
 } from './inbound-delivery-confirm.js'
 import { createPendingPermissionBuffer } from './pending-permission-decisions.js'
@@ -10670,8 +10671,10 @@ async function handleInbound(
     const busyKey = markClaudeBusyForInbound(inboundMsg)
     // Track until claude acks via `enqueue` (the marko drop-wedge): if no ack
     // lands, the message stranded in the composer and the sweep re-delivers
-    // it. See inbound-delivery-confirm.ts.
-    if (DELIVERY_CONFIRM_ENABLED) {
+    // it. Track ONLY fresh-turn messages (not steering / `!` interrupt) —
+    // those amend the running turn and never emit `enqueue`, so tracking them
+    // would re-deliver forever. See shouldTrackDelivery (inbound-delivery-confirm.ts).
+    if (DELIVERY_CONFIRM_ENABLED && shouldTrackDelivery({ isSteering, isInterrupt: interrupt.isInterrupt })) {
       trackDelivery(deliveryQueue, busyKey, inboundMsg, Date.now())
     }
   }

--- a/telegram-plugin/gateway/inbound-delivery-confirm.ts
+++ b/telegram-plugin/gateway/inbound-delivery-confirm.ts
@@ -94,3 +94,23 @@ export function sweep<M>(
 export function forgetDelivery<M>(q: DeliveryQueue<M>, key: string): void {
   q.pending.delete(key)
 }
+
+/**
+ * Should this delivered inbound be tracked for ack/re-delivery?
+ *
+ * ONLY fresh-turn messages — the ones the #1556 buffer-gate holds until claude
+ * is idle, then delivers — produce a fresh `enqueue` session-event, which is
+ * the ack that clears tracking. Steering (`/steer`) and `!` interrupt inbounds
+ * are the gate's *carve-outs*: they're delivered mid-turn to AMEND the running
+ * turn, so they do NOT start a fresh turn and never emit `enqueue`. Tracking
+ * them would leave an entry that is never acked → the sweep re-delivers it
+ * indefinitely (duplicate turns). So mirror the gate's carve-outs here: track a
+ * delivery iff it is neither steering nor interrupt — i.e. exactly the messages
+ * that produce an `enqueue` to ack against.
+ */
+export function shouldTrackDelivery(input: {
+  isSteering: boolean
+  isInterrupt: boolean
+}): boolean {
+  return !input.isSteering && !input.isInterrupt
+}

--- a/telegram-plugin/tests/inbound-delivery-confirm.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-confirm.test.ts
@@ -4,6 +4,7 @@ import {
   ackDelivery,
   createDeliveryQueue,
   forgetDelivery,
+  shouldTrackDelivery,
   sweep,
   trackDelivery,
   type DeliveryQueue,
@@ -105,5 +106,24 @@ describe('inbound-delivery-confirm (reliable deliver-until-acked queue)', () => 
     forgetDelivery(q, 'chat:_')
     expect(q.pending.size).toBe(0)
     expect(sweep(q, 999_999, TIMEOUT)).toHaveLength(0)
+  })
+})
+
+// Regression for the steer/interrupt re-delivery loop: steering and `!`
+// interrupt inbounds amend the running turn and never emit `enqueue`, so they
+// must NOT be tracked (else the sweep re-delivers them forever). Only
+// fresh-turn messages — which DO enqueue — are tracked.
+describe('shouldTrackDelivery — only fresh-turn messages are tracked', () => {
+  it('tracks a normal (non-steering, non-interrupt) message', () => {
+    expect(shouldTrackDelivery({ isSteering: false, isInterrupt: false })).toBe(true)
+  })
+  it('does NOT track a /steer message (amends the turn — never acks)', () => {
+    expect(shouldTrackDelivery({ isSteering: true, isInterrupt: false })).toBe(false)
+  })
+  it('does NOT track a ! interrupt message (amends the turn — never acks)', () => {
+    expect(shouldTrackDelivery({ isSteering: false, isInterrupt: true })).toBe(false)
+  })
+  it('does NOT track when both flags set (defensive)', () => {
+    expect(shouldTrackDelivery({ isSteering: true, isInterrupt: true })).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #2089 (deliver-until-acked). That queue tracked **every** delivered inbound for an `enqueue` ack — including `/steer` and `!`-interrupt messages. Those are delivered mid-turn to **amend the running turn** and never emit a fresh `enqueue`, so they were never acked and the 5s sweep **re-delivered them (duplicate turns / loop)**.

Found by an adversarial stress-test of the v0.14.40 fix — the canary's steer test had passed only by ack-timing luck, so it shipped latent. Live on the fleet since v0.14.40.

## Fix

Gate tracking on `shouldTrackDelivery({ isSteering, isInterrupt })` — track only **non-steering, non-interrupt** inbounds (the fresh-turn messages the #1556 buffer-gate holds-then-delivers, which are exactly the ones that produce an `enqueue` to ack against). Steering/interrupt are the gate's existing carve-outs; they're now equally exempt from the delivery-confirm queue. Also removes the only realistic source of unbounded queue growth (never-acking entries).

## Test plan
- [x] new pure `shouldTrackDelivery` + 4 unit tests (normal→track; steer→no; interrupt→no; both→no)
- [x] full plugin bun surface: **4229 pass / 0 fail**
- [x] tsc, check-bot-api-wrapping clean
- [ ] canary on test-harness (steer + interrupt round-trips, confirm 0 re-deliveries) + staggered rollout — post-merge

## Risk
Low + narrowing: it makes the queue track *fewer* messages (strictly the ones that ack). No change to the fresh-turn no-drop behavior #2089 fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
