### PR TITLE
fix(gateway): harden deliver-until-acked queue (6 audit findings)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1343,7 +1343,15 @@ const DELIVERY_CONFIRM_ENABLED = process.env.SWITCHROOM_INBOUND_DELIVERY_CONFIRM
 // a clean delivery, so 15s won't false-positive on a healthy turn. Tunable
 // (env) for tests/forensics; a too-low value re-delivers healthy slow turns
 // (duplicate turn), which is why the default is comfortably above ack latency.
-const DELIVERY_CONFIRM_TIMEOUT_MS = Number(process.env.SWITCHROOM_INBOUND_DELIVERY_TIMEOUT_MS) || 15_000
+const _deliveryTimeoutRaw = process.env.SWITCHROOM_INBOUND_DELIVERY_TIMEOUT_MS
+const _deliveryTimeoutParsed =
+  _deliveryTimeoutRaw != null && _deliveryTimeoutRaw !== '' ? Number(_deliveryTimeoutRaw) : 15_000
+// Clamp to a positive, finite value: a negative / zero / NaN env override would
+// make the sweep treat every tracked entry as stranded and re-deliver every
+// cycle forever (a self-inflicted re-delivery loop). To disable the feature,
+// use SWITCHROOM_INBOUND_DELIVERY_CONFIRM=0, not a degenerate timeout.
+const DELIVERY_CONFIRM_TIMEOUT_MS =
+  Number.isFinite(_deliveryTimeoutParsed) && _deliveryTimeoutParsed > 0 ? _deliveryTimeoutParsed : 15_000
 const DELIVERY_CONFIRM_SWEEP_MS = 5_000
 const deliveryQueue = createDeliveryQueue<InboundMessage>()
 
@@ -4107,7 +4115,16 @@ async function redeliverStrandedInbound(p: PendingDelivery<InboundMessage>): Pro
     if (selfAgent) clearAgentComposer({ agentName: selfAgent })
   } catch { /* best-effort; re-deliver regardless */ }
   const ok = ipcServer.sendToAgent(selfAgent, p.inbound)
-  if (!ok) {
+  if (ok) {
+    // Keep the #1556 gate coherent with the re-sent delivery, and survive an
+    // ack that raced the `await import` above: only `enqueue` clears tracking,
+    // so if a concurrent ack removed the entry, re-affirm it — never drop.
+    // Both ops are idempotent.
+    markClaudeBusyForInbound(p.inbound)
+    if (!deliveryQueue.pending.has(p.key)) {
+      trackDelivery(deliveryQueue, p.key, p.inbound, Date.now(), p.messageId)
+    }
+  } else {
     // Bridge offline between attempts — hand off to the offline buffer
     // (bridgeUp drains it) and stop tracking here; the spool owns it now.
     pendingInboundBuffer.push(selfAgent, p.inbound)
@@ -4116,6 +4133,16 @@ async function redeliverStrandedInbound(p: PendingDelivery<InboundMessage>): Pro
 }
 const _deliveryConfirmSweep = setInterval(() => {
   if (!DELIVERY_CONFIRM_ENABLED) return
+  // Re-deliver ONLY when claude is genuinely idle. `currentTurn` is set solely
+  // by the enqueue session-event and nulled at turn-end, so `currentTurn != null`
+  // means a real turn is in flight — re-clearing the composer + re-sending now
+  // would clobber it (the exact mid-turn wedge this queue exists to prevent). A
+  // pending permission / ask_user prompt is likewise a live interaction. Defer:
+  // leave the entry pending (it isn't acked) so the next idle sweep retries.
+  // NB: claudeBusyKeys (turnInFlightForGate) is set EAGERLY at delivery and
+  // stays set through a strand, so it is NOT a usable "idle" signal here.
+  if (currentTurn != null) return
+  if (pendingPermissions.size > 0 || pendingAskUser.size > 0) return
   for (const p of sweepDeliveryQueue(deliveryQueue, Date.now(), DELIVERY_CONFIRM_TIMEOUT_MS)) {
     void redeliverStrandedInbound(p)
   }
@@ -7946,9 +7973,14 @@ function handleSessionEvent(ev: SessionEvent): void {
         // re-delivery. `enqueue` carries the same chat/thread the inbound was
         // keyed on, so the key matches.
         if (DELIVERY_CONFIRM_ENABLED) {
+          // Match on the source message id: `enqueue` fires for EVERY turn
+          // start (cron / subagent-handback / vault-resume / restart-marker
+          // too — see comment below), so a key-only ack would let a synthetic
+          // turn clear a real user message still waiting under the same key.
           ackDelivery(
             deliveryQueue,
             chatKey(ev.chatId, ev.threadId != null ? Number(ev.threadId) : null),
+            ev.messageId,
           )
         }
         // PR3b-cutover: feed the authoritative turn-start to the delivery
@@ -10671,15 +10703,40 @@ async function handleInbound(
     const busyKey = markClaudeBusyForInbound(inboundMsg)
     // Track until claude acks via `enqueue` (the marko drop-wedge): if no ack
     // lands, the message stranded in the composer and the sweep re-delivers
-    // it. Track ONLY fresh-turn messages (not steering / `!` interrupt) —
-    // those amend the running turn and never emit `enqueue`, so tracking them
-    // would re-deliver forever. See shouldTrackDelivery (inbound-delivery-confirm.ts).
-    if (DELIVERY_CONFIRM_ENABLED && shouldTrackDelivery({ isSteering, isInterrupt: interrupt.isInterrupt })) {
-      trackDelivery(deliveryQueue, busyKey, inboundMsg, Date.now())
+    // it. Track ONLY messages that produce an `enqueue` to ack against —
+    // shouldTrackDelivery excludes steering / `!` interrupt (amend the running
+    // turn), synthetic (meta.source) inbounds, and empty bodies, all of which
+    // never enqueue and would re-deliver forever. The tracked messageId lets
+    // the ack match only THIS message's enqueue (not a synthetic turn sharing
+    // the key). See shouldTrackDelivery / ackDelivery (inbound-delivery-confirm.ts).
+    if (
+      DELIVERY_CONFIRM_ENABLED &&
+      shouldTrackDelivery({
+        isSteering,
+        isInterrupt: interrupt.isInterrupt,
+        hasSource: inboundMsg.meta?.source != null,
+        effectiveText,
+      })
+    ) {
+      trackDelivery(deliveryQueue, busyKey, inboundMsg, Date.now(), String(inboundMsg.messageId))
     }
   }
   if (!delivered) {
-    pendingInboundBuffer.push(selfAgent, inboundMsg)
+    // Only persist fresh user turns to the durable spool. Steering / `!`
+    // interrupt / empty bodies are mid-turn amendments or no-ops that would
+    // arrive orphaned if replayed as a fresh turn after a restart — drop them
+    // (the restart notice below tells the user to re-send). Mirrors the
+    // tracking + #1556-gate carve-outs.
+    if (
+      shouldTrackDelivery({
+        isSteering,
+        isInterrupt: interrupt.isInterrupt,
+        hasSource: inboundMsg.meta?.source != null,
+        effectiveText,
+      })
+    ) {
+      pendingInboundBuffer.push(selfAgent, inboundMsg)
+    }
     const threadOpts = messageThreadId != null ? { message_thread_id: messageThreadId } : {}
     // #1075: thread-id-bearing — swallow via robustApiCall so a deleted
     // topic doesn't crash the gateway. Fire-and-forget; the inbound is

--- a/telegram-plugin/gateway/inbound-delivery-confirm.ts
+++ b/telegram-plugin/gateway/inbound-delivery-confirm.ts
@@ -35,6 +35,14 @@ export interface PendingDelivery<M> {
   readonly key: string
   /** The exact inbound to re-send until claude acks it. */
   readonly inbound: M
+  /**
+   * Source message id of the tracked inbound (stringified Telegram
+   * `message_id`), or null if unknown. The `enqueue` ack matches on THIS so a
+   * synthetic-source turn (cron / resume / vault / reaction) that shares the
+   * chatKey can't false-ack — and silently drop — a real user message still
+   * waiting to land. See ackDelivery.
+   */
+  readonly messageId: string | null
   /** When the latest delivery attempt was made (unix-ms). */
   lastAttemptAt: number
 }
@@ -51,22 +59,44 @@ export function createDeliveryQueue<M>(): DeliveryQueue<M> {
  * Track a freshly-delivered inbound, awaiting claude's `enqueue` ack.
  * Overwrites any prior pending for the key — the #1556 gate serialises per
  * key, so a later inbound supersedes an earlier un-acked one for that key.
+ * `messageId` (stringified Telegram message_id) lets the ack match only the
+ * enqueue that belongs to THIS message; pass null when unknown.
  */
 export function trackDelivery<M>(
   q: DeliveryQueue<M>,
   key: string,
   inbound: M,
   now: number,
+  messageId: string | null = null,
 ): void {
-  q.pending.set(key, { key, inbound, lastAttemptAt: now })
+  q.pending.set(key, { key, inbound, messageId, lastAttemptAt: now })
 }
 
 /**
- * Ack a delivery — call from the `enqueue` session-event (claude started the
- * turn, so the message landed). Returns true if a pending entry was cleared.
+ * Ack a delivery — call from the `enqueue` session-event (claude started a
+ * turn). `enqueue` fires for EVERY turn start regardless of source (user
+ * inbound, cron, subagent-handback, vault-resume, restart-marker), so acking
+ * purely by chatKey would let a synthetic-source turn clear — and thus
+ * silently drop — a real user message still waiting under the same key. So
+ * ack ONLY when the enqueue's source message id matches the tracked one.
+ *
+ * Matching rule: if we recorded a messageId for the pending entry, require the
+ * enqueue's `enqueueMessageId` to equal it. If we never recorded one (legacy /
+ * defensive null), fall back to key-only ack. Returns true if an entry was
+ * cleared.
  */
-export function ackDelivery<M>(q: DeliveryQueue<M>, key: string): boolean {
-  return q.pending.delete(key)
+export function ackDelivery<M>(
+  q: DeliveryQueue<M>,
+  key: string,
+  enqueueMessageId: string | null = null,
+): boolean {
+  const entry = q.pending.get(key)
+  if (!entry) return false
+  // A different message started this turn — don't ack ours (it may still be
+  // waiting to land; the sweep will re-deliver it if it stranded).
+  if (entry.messageId != null && entry.messageId !== enqueueMessageId) return false
+  q.pending.delete(key)
+  return true
 }
 
 /**
@@ -98,19 +128,33 @@ export function forgetDelivery<M>(q: DeliveryQueue<M>, key: string): void {
 /**
  * Should this delivered inbound be tracked for ack/re-delivery?
  *
- * ONLY fresh-turn messages — the ones the #1556 buffer-gate holds until claude
- * is idle, then delivers — produce a fresh `enqueue` session-event, which is
- * the ack that clears tracking. Steering (`/steer`) and `!` interrupt inbounds
- * are the gate's *carve-outs*: they're delivered mid-turn to AMEND the running
- * turn, so they do NOT start a fresh turn and never emit `enqueue`. Tracking
- * them would leave an entry that is never acked → the sweep re-delivers it
- * indefinitely (duplicate turns). So mirror the gate's carve-outs here: track a
- * delivery iff it is neither steering nor interrupt — i.e. exactly the messages
- * that produce an `enqueue` to ack against.
+ * Track a delivery iff it is a fresh user turn that will produce exactly one
+ * `enqueue` to ack against. Everything that does NOT enqueue must be excluded,
+ * or the sweep re-delivers it forever (re-clearing the composer every cycle):
+ *
+ *   - `isSteering` / `isInterrupt` — the #1556 gate's carve-outs: delivered
+ *     mid-turn to AMEND the running turn, so they never start a fresh turn and
+ *     never emit `enqueue`.
+ *   - `hasSource` — synthetic inbounds (cron / vault-resume / subagent-handback
+ *     / reaction) carry a `meta.source`; they enqueue under their own semantics
+ *     and must never be tracked as if they were a queued user turn.
+ *   - empty `effectiveText` — an empty body (e.g. `/queue` with no text) is
+ *     silently dropped by claude's auto-submit and never enqueues, so tracking
+ *     it is a pure re-delivery loop (a self-inflicted DoS on the queue).
+ *
+ * Mirror the gate's carve-outs here so tracking is exactly the set of messages
+ * that produce an `enqueue`.
  */
 export function shouldTrackDelivery(input: {
   isSteering: boolean
   isInterrupt: boolean
+  hasSource?: boolean
+  effectiveText?: string
 }): boolean {
-  return !input.isSteering && !input.isInterrupt
+  if (input.isSteering || input.isInterrupt) return false
+  if (input.hasSource) return false
+  // Gate on empty text only when the caller actually provided it (undefined =
+  // "not supplied", left untracked-gated so existing callers keep their behaviour).
+  if (input.effectiveText !== undefined && input.effectiveText.trim().length === 0) return false
+  return true
 }

--- a/telegram-plugin/tests/inbound-delivery-confirm.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-confirm.test.ts
@@ -109,6 +109,47 @@ describe('inbound-delivery-confirm (reliable deliver-until-acked queue)', () => 
   })
 })
 
+// Regression for the cross-source ACK collision (silent drop): `enqueue` fires
+// for EVERY turn start regardless of source. A synthetic-source turn (cron /
+// resume / vault / reaction) that shares the chatKey of a real user message
+// still waiting to land would, with a key-only ack, clear — and silently drop
+// — that user message. The ack must match on the tracked message id.
+describe('ackDelivery — message-id-matched (cross-source false-ack guard)', () => {
+  it('acks when the enqueue message id matches the tracked one', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'real user msg' }, 0, '5001')
+    expect(ackDelivery(q, 'chat:_', '5001')).toBe(true)
+    expect(q.pending.size).toBe(0)
+  })
+
+  it('does NOT ack when a different (synthetic-source) turn enqueues under the same key', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'real user msg' }, 0, '5001')
+    // a cron / resume turn for the same chat enqueues first, with its own id
+    expect(ackDelivery(q, 'chat:_', '1716123456789')).toBe(false)
+    // the user message is still tracked — it strands → gets re-delivered, not dropped
+    expect(q.pending.size).toBe(1)
+    expect(sweep(q, 15_000, TIMEOUT)).toHaveLength(1)
+    // and its own enqueue (matching id) later acks it cleanly
+    expect(ackDelivery(q, 'chat:_', '5001')).toBe(true)
+    expect(q.pending.size).toBe(0)
+  })
+
+  it('does NOT ack when the enqueue carries no message id but the tracked one has one', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'real user msg' }, 0, '5001')
+    expect(ackDelivery(q, 'chat:_', null)).toBe(false)
+    expect(q.pending.size).toBe(1)
+  })
+
+  it('falls back to key-only ack when no message id was recorded (legacy/defensive)', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'x' }, 0) // no messageId
+    expect(ackDelivery(q, 'chat:_', '5001')).toBe(true)
+    expect(q.pending.size).toBe(0)
+  })
+})
+
 // Regression for the steer/interrupt re-delivery loop: steering and `!`
 // interrupt inbounds amend the running turn and never emit `enqueue`, so they
 // must NOT be tracked (else the sweep re-delivers them forever). Only
@@ -125,5 +166,15 @@ describe('shouldTrackDelivery — only fresh-turn messages are tracked', () => {
   })
   it('does NOT track when both flags set (defensive)', () => {
     expect(shouldTrackDelivery({ isSteering: true, isInterrupt: true })).toBe(false)
+  })
+  it('does NOT track a synthetic (meta.source) inbound — cron/resume/vault/reaction enqueue under their own semantics', () => {
+    expect(shouldTrackDelivery({ isSteering: false, isInterrupt: false, hasSource: true })).toBe(false)
+  })
+  it('does NOT track an empty-body message (e.g. `/queue` with no text) — never enqueues, would re-deliver forever', () => {
+    expect(shouldTrackDelivery({ isSteering: false, isInterrupt: false, effectiveText: '' })).toBe(false)
+    expect(shouldTrackDelivery({ isSteering: false, isInterrupt: false, effectiveText: '   ' })).toBe(false)
+  })
+  it('tracks a normal message when effectiveText is provided and non-empty', () => {
+    expect(shouldTrackDelivery({ isSteering: false, isInterrupt: false, effectiveText: 'draft the email' })).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
An exhaustive adversarial audit of the inbound→claude→reply path — run *after* the deliver-until-acked queue (#2089) and the steer-fix (#2092) — found that the re-delivery **sweep was bolted on without inheriting the protections the fresh-inbound path earned**. This PR fixes the six directly-reachable-and-harmful defects, all in the queue's own correctness.

JTBD: **always-available** — an operator message must never be silently dropped or trigger a re-delivery loop.

## Why (the six fixes)
1. **Mid-turn re-delivery** — the sweep re-cleared the composer + re-sent even while a turn was genuinely running, re-creating the exact wedge the queue exists to prevent. Now gated on `currentTurn == null` (the enqueue-confirmed idle signal) + no pending permission/ask_user.
   ⚠️ The audit's *suggested* fix (`!turnInFlightForGate()`) was **unsound**: `claudeBusyKeys` is set eagerly at delivery and stays set through a strand, so it would have broken re-delivery for the very stranded case. Corrected here.
2. **Cross-source ACK collision (silent drop)** — `enqueue` fires for *every* turn start (cron / subagent-handback / vault-resume / restart-marker), so a key-only ack let a synthetic turn clear — and drop — a real user message waiting under the same key. Ack now matches the tracked **message id** (preserved end-to-end via the channel XML).
3. **Empty-body re-delivery loop** — `/queue` with no text never enqueues → re-delivered every cycle forever (self-inflicted DoS). `shouldTrackDelivery` now excludes empty text + synthetic `meta.source`.
4. **Env-timeout coercion loop** — `Number(env) || 15000` let a *negative* override through → infinite re-delivery. Clamp to positive+finite.
5. **Orphaned replay of steer/interrupt** — the delivery-failure buffer push was unguarded; a steer/`!`-interrupt that failed delivery offline was persisted + replayed as a fresh orphaned turn after restart. Guarded with the same carve-out.
6. **Re-delivery ack-race / gate incoherence** — a successful re-send neither re-marked busy nor survived an ack racing the dynamic import. Re-mark + re-affirm tracking (idempotent); only `enqueue` clears tracking.

## Test plan
- [x] +7 unit cases in `inbound-delivery-confirm.test.ts` (messageId-matched ack incl. the synthetic-collision scenario; empty/whitespace/synthetic carve-outs)
- [x] Full `telegram-plugin` bun suite green — **3924 pass / 0 fail**
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean
- [ ] UAT (no-drop rapid-fire + steer + interrupt round-trips) on canary before fleet rollout

## Risk
Tightly scoped to the queue's own logic (sweep gate, ack match, tracking carve-outs, env clamp). The pure module is fully unit-tested; the gateway wiring reuses the in-scope `isSteering`/`interrupt.isInterrupt`/`effectiveText`/`inboundMsg.messageId` already used at the same callsite. Kill-switch `SWITCHROOM_INBOUND_DELIVERY_CONFIRM=0` unchanged.

## Deferred to a focused follow-up (NOT bundled — separate concerns / lower reachability, avoiding a risky mega-diff)
- turn_end gate-wedge backstop (a throw before purge wedges the #1556 gate — **bounded today by the 300s silence-poke**, so degraded not permanent)
- centralizing drain-path tracking via a shared `deliverAndTrack` helper (a buffer-drained message that re-strands isn't re-delivered)
- reaction-flush gate (reactions bypass the #1556 gate mid-turn)
- bridge-side messageId dedup (re-delivery double-execution of a slow-to-ack side-effectful command)

Related: #2089, #2092.