### PR TITLE
fix(gateway): approval cards undeliverable to DM operators (topic-id bug)

### DIFF
--- a/src/telegram/topic-router.test.ts
+++ b/src/telegram/topic-router.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveOutboundTopic,
+  topicForRecipient,
   validateCronTopicAliases,
   type OutboundEvent,
   type TopicRouterConfig,
@@ -293,5 +294,34 @@ describe("validateCronTopicAliases", () => {
       { cron: "0 8 * * *", topic: "planning" },
     ]);
     expect(errors).toHaveLength(1);
+  });
+});
+
+// The marko brevo wedge (2026-06-02): approval/permission cards fan out to the
+// operator's allowFrom (DMs), but the resolved topic is only valid in the
+// agent's supergroup. Attaching it to a DM → 400 "message thread not found" →
+// card never arrives → auto-deny → the agent wedges on the open prompt.
+describe("topicForRecipient — only the owning supergroup gets the thread id", () => {
+  const SUPERGROUP = "-1003831053471";
+  const DM = "8248703757";
+  const TOPIC = 3;
+
+  it("attaches the topic when the recipient IS the agent's supergroup", () => {
+    expect(topicForRecipient({ recipientChatId: SUPERGROUP, resolvedTopic: TOPIC, supergroupChatId: SUPERGROUP })).toBe(TOPIC);
+  });
+  it("drops the topic for an operator DM recipient (the wedge fix)", () => {
+    expect(topicForRecipient({ recipientChatId: DM, resolvedTopic: TOPIC, supergroupChatId: SUPERGROUP })).toBeUndefined();
+  });
+  it("drops the topic for a different supergroup than the owning one", () => {
+    expect(topicForRecipient({ recipientChatId: "-1009999999999", resolvedTopic: TOPIC, supergroupChatId: SUPERGROUP })).toBeUndefined();
+  });
+  it("returns undefined when there is no resolved topic", () => {
+    expect(topicForRecipient({ recipientChatId: SUPERGROUP, resolvedTopic: undefined, supergroupChatId: SUPERGROUP })).toBeUndefined();
+  });
+  it("returns undefined when the agent isn't in supergroup mode (no supergroup chat id)", () => {
+    expect(topicForRecipient({ recipientChatId: DM, resolvedTopic: TOPIC, supergroupChatId: undefined })).toBeUndefined();
+  });
+  it("matches string and numeric chat ids equivalently", () => {
+    expect(topicForRecipient({ recipientChatId: -1003831053471, resolvedTopic: TOPIC, supergroupChatId: "-1003831053471" })).toBe(TOPIC);
   });
 });

--- a/src/telegram/topic-router.test.ts
+++ b/src/telegram/topic-router.test.ts
@@ -302,8 +302,8 @@ describe("validateCronTopicAliases", () => {
 // agent's supergroup. Attaching it to a DM → 400 "message thread not found" →
 // card never arrives → auto-deny → the agent wedges on the open prompt.
 describe("topicForRecipient — only the owning supergroup gets the thread id", () => {
-  const SUPERGROUP = "-1003831053471";
-  const DM = "8248703757";
+  const SUPERGROUP = "-1001234567890";
+  const DM = "12345";
   const TOPIC = 3;
 
   it("attaches the topic when the recipient IS the agent's supergroup", () => {
@@ -313,7 +313,7 @@ describe("topicForRecipient — only the owning supergroup gets the thread id", 
     expect(topicForRecipient({ recipientChatId: DM, resolvedTopic: TOPIC, supergroupChatId: SUPERGROUP })).toBeUndefined();
   });
   it("drops the topic for a different supergroup than the owning one", () => {
-    expect(topicForRecipient({ recipientChatId: "-1009999999999", resolvedTopic: TOPIC, supergroupChatId: SUPERGROUP })).toBeUndefined();
+    expect(topicForRecipient({ recipientChatId: "-1009876543210", resolvedTopic: TOPIC, supergroupChatId: SUPERGROUP })).toBeUndefined();
   });
   it("returns undefined when there is no resolved topic", () => {
     expect(topicForRecipient({ recipientChatId: SUPERGROUP, resolvedTopic: undefined, supergroupChatId: SUPERGROUP })).toBeUndefined();
@@ -322,6 +322,6 @@ describe("topicForRecipient — only the owning supergroup gets the thread id", 
     expect(topicForRecipient({ recipientChatId: DM, resolvedTopic: TOPIC, supergroupChatId: undefined })).toBeUndefined();
   });
   it("matches string and numeric chat ids equivalently", () => {
-    expect(topicForRecipient({ recipientChatId: -1003831053471, resolvedTopic: TOPIC, supergroupChatId: "-1003831053471" })).toBe(TOPIC);
+    expect(topicForRecipient({ recipientChatId: -1001234567890, resolvedTopic: TOPIC, supergroupChatId: "-1001234567890" })).toBe(TOPIC);
   });
 });

--- a/src/telegram/topic-router.ts
+++ b/src/telegram/topic-router.ts
@@ -139,6 +139,32 @@ export function resolveOutboundTopic(
 }
 
 /**
+ * Decide the `message_thread_id` to attach when an approval / permission card
+ * is sent to a SPECIFIC recipient chat.
+ *
+ * A forum topic id (what {@link resolveOutboundTopic} returns) is valid ONLY
+ * inside the agent's own supergroup (`channels.telegram.chat_id`). The approval
+ * emitters, however, fan out to the operator's `allowFrom` chats — which are
+ * normally **DMs**, and DMs have no topics. Attaching a topic id to a DM makes
+ * Telegram reject the send with `400 Bad Request: message thread not found`, so
+ * the card never arrives, the request auto-denies at its TTL, and the agent
+ * wedges on the still-open prompt (the `marko` brevo incident, 2026-06-02).
+ *
+ * So attach the resolved topic ONLY to the recipient that actually owns it —
+ * the agent's supergroup chat — and send thread-less to everyone else.
+ * Returns `undefined` (no `message_thread_id`) for any non-owning recipient.
+ */
+export function topicForRecipient(args: {
+  recipientChatId: string | number;
+  resolvedTopic: number | undefined;
+  supergroupChatId: string | number | undefined;
+}): number | undefined {
+  const { recipientChatId, resolvedTopic, supergroupChatId } = args;
+  if (resolvedTopic == null || supergroupChatId == null) return undefined;
+  return String(recipientChatId) === String(supergroupChatId) ? resolvedTopic : undefined;
+}
+
+/**
  * Validate that every per-cron `topic:` field in `schedule[]` is
  * resolvable — either a numeric topic ID (always accepted) or a
  * string alias defined in `topic_aliases`.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -251,7 +251,7 @@ import { handleInjectCommand } from './inject-handler.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
 import { loadConfig as loadSwitchroomConfig, findConfigFile as findSwitchroomConfigFile } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
-import { resolveOutboundTopic as resolveOutboundTopicHelper, type TopicRouterConfig as _OutboundRouterConfig } from '../../src/telegram/topic-router.js'
+import { resolveOutboundTopic as resolveOutboundTopicHelper, topicForRecipient, type TopicRouterConfig as _OutboundRouterConfig } from '../../src/telegram/topic-router.js'
 import { readTurnUsages } from '../../src/agents/perf.js'
 import { decideProactiveCompact, initialCompactState, type CompactState } from './proactive-compact.js'
 import { nextCompactNotify, idleCompactNotifyState, type CompactNotifyState } from './compact-notify.js'
@@ -2273,14 +2273,20 @@ function postPermissionResumeMessage(opts: {
   const targets: Array<{ chatId: string; threadId: number | undefined }> =
     turn != null
       ? [{ chatId: turn.sessionChatId, threadId: turn.sessionThreadId }]
-      : loadAccess().allowFrom.map(chatId => ({
-          chatId,
-          threadId: resolveAgentOutboundTopic({
+      : (() => {
+          const sg = resolveAgentSupergroupChatId()
+          const topic = resolveAgentOutboundTopic({
             kind: 'permission',
             turnInitiated: false,
             originThreadId: undefined,
-          }),
-        }))
+          })
+          // allowFrom is normally operator DMs — attach the topic only to a
+          // recipient that owns it (the supergroup), never a DM (marko wedge).
+          return loadAccess().allowFrom.map(chatId => ({
+            chatId,
+            threadId: topicForRecipient({ recipientChatId: chatId, resolvedTopic: topic, supergroupChatId: sg }),
+          }))
+        })()
   for (const { chatId, threadId } of targets) {
     // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy); thread-aware send
     void swallowingApiCall(
@@ -4664,16 +4670,20 @@ const ipcServer: IpcServer = createIpcServer({
       turnInitiated: activeTurn != null,
       originThreadId: activeTurn?.sessionThreadId,
     })
+    const permSupergroup = resolveAgentSupergroupChatId()
     for (const chat_id of access.allowFrom) {
       // parse_mode=HTML pairs with formatPermissionCardBody (#1790)
       // so the <b>/<i> tags render as formatting.
-      // PR4b emitter sweep — opts now optionally carries
-      // message_thread_id when supergroup mode is on.
+      // The resolved topic is valid only in the agent's supergroup — attach
+      // it ONLY when this recipient IS that supergroup. allowFrom DMs get the
+      // card thread-less; attaching a topic to a DM yields 400 "message thread
+      // not found" → card never arrives → auto-deny → wedge (marko 2026-06-02).
+      const permThread = topicForRecipient({ recipientChatId: chat_id, resolvedTopic: permTopic, supergroupChatId: permSupergroup })
       // allow-raw-bot-api: permission-request keyboard fan-out; topic-aware opts
       void bot.api.sendMessage(chat_id, text, {
         parse_mode: 'HTML',
         reply_markup: keyboard,
-        ...(permTopic != null ? { message_thread_id: permTopic } : {}),
+        ...(permThread != null ? { message_thread_id: permThread } : {}),
       }).catch(e => {
         process.stderr.write(`telegram gateway: permission_request send to ${chat_id} failed: ${e}\n`)
       })
@@ -4811,9 +4821,15 @@ const ipcServer: IpcServer = createIpcServer({
         // topic. Drive approval cards follow the originating turn
         // (operator-initiated tool call), admin alias fallback.
         const activeTurn = currentTurn
-        const driveTopic = resolveAgentOutboundTopic({
-          kind: 'hostd-approval',
-          originThreadId: activeTurn?.sessionThreadId,
+        // Attach the topic only when `operator` IS the agent's supergroup —
+        // operator DMs have no topics (marko brevo wedge, 2026-06-02).
+        const driveTopic = topicForRecipient({
+          recipientChatId: operator,
+          resolvedTopic: resolveAgentOutboundTopic({
+            kind: 'hostd-approval',
+            originThreadId: activeTurn?.sessionThreadId,
+          }),
+          supergroupChatId: resolveAgentSupergroupChatId(),
         })
         return {
           chatId: operator,
@@ -4884,9 +4900,14 @@ const ipcServer: IpcServer = createIpcServer({
         // alias fallback for background cases. Same shape as hostd /
         // drive approvals below.
         const activeTurn = currentTurn
-        const ms365Topic = resolveAgentOutboundTopic({
-          kind: 'hostd-approval',
-          originThreadId: activeTurn?.sessionThreadId,
+        // Topic valid only in the agent's supergroup — never on the operator DM.
+        const ms365Topic = topicForRecipient({
+          recipientChatId: operator,
+          resolvedTopic: resolveAgentOutboundTopic({
+            kind: 'hostd-approval',
+            originThreadId: activeTurn?.sessionThreadId,
+          }),
+          supergroupChatId: resolveAgentSupergroupChatId(),
         })
         return {
           chatId: operator,
@@ -4963,9 +4984,14 @@ const ipcServer: IpcServer = createIpcServer({
         // returns undefined for non-supergroup agents → behavior
         // unchanged.
         const activeTurn = currentTurn
-        const cfgTopic = resolveAgentOutboundTopic({
-          kind: 'hostd-approval',
-          originThreadId: activeTurn?.sessionThreadId,
+        // Topic valid only in the agent's supergroup — never on the operator DM.
+        const cfgTopic = topicForRecipient({
+          recipientChatId: operator,
+          resolvedTopic: resolveAgentOutboundTopic({
+            kind: 'hostd-approval',
+            originThreadId: activeTurn?.sessionThreadId,
+          }),
+          supergroupChatId: resolveAgentSupergroupChatId(),
         })
         return {
           chatId: operator,
@@ -11062,6 +11088,30 @@ function resolveAgentOutboundTopic(
     // caller's existing fallback). Only supergroup-owned agents
     // (with default_topic_id set) get a routed value.
     return resolveOutboundTopicHelper(tg as _OutboundRouterConfig, event)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * The agent's supergroup chat id (`channels.telegram.chat_id`) when it is in
+ * supergroup-owned mode, else undefined. A forum topic id resolved by
+ * {@link resolveAgentOutboundTopic} is valid ONLY in this chat — used by
+ * {@link topicForRecipient} to decide whether an approval/permission card sent
+ * to a given recipient (operator DMs vs the supergroup itself) may carry a
+ * `message_thread_id`. Attaching a topic to a DM is the marko brevo wedge
+ * (2026-06-02): the card fails with "message thread not found" and auto-denies.
+ */
+function resolveAgentSupergroupChatId(): string | undefined {
+  const agentName = process.env.SWITCHROOM_AGENT_NAME
+  if (!agentName) return undefined
+  try {
+    const cfg = loadSwitchroomConfig()
+    const rawAgent = cfg.agents?.[agentName]
+    if (!rawAgent) return undefined
+    const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent)
+    const tg = resolved.channels?.telegram as { chat_id?: string | number } | undefined
+    return tg?.chat_id != null ? String(tg.chat_id) : undefined
   } catch {
     return undefined
   }


### PR DESCRIPTION
## Summary
Fixes a live, recurring wedge (root-caused from a marko incident): **HIGH-RISK approval/permission cards an agent raises from inside a supergroup topic never reach the operator**, so the request auto-denies after its 10-min TTL and the agent sits at the open prompt — wedged, unable to do anything else (including reporting on its topics).

JTBD: **you hold the leash** — an approval the operator must tap has to actually arrive.

## Root cause
The "PR4b emitter sweep" routed every approval card's `message_thread_id` from `resolveAgentOutboundTopic(originThreadId)` — a forum topic id valid **only in the agent's supergroup**. But the cards fan out to the operator's `allowFrom` chats, which are normally **DMs**. A DM `sendMessage` carrying a `message_thread_id` is rejected by Telegram with `400 Bad Request: message thread not found` → card never arrives → auto-deny at TTL → agent wedges.

Live evidence (marko): a Panorama "Winter Special" **Brevo EDM** approval looping `permission_request send to 8248703757 failed … message thread not found` → `permission TTL expired — auto-deny tool=mcp__brevo__post`, while marko sat at the prompt and stopped reporting on its topics.

Affects **5 emitters**: permission fan-out, drive-approval, ms365-approval, config-approval, and the no-turn re-emit fallback.

## Fix
A pure, unit-tested guard:
```ts
topicForRecipient({ recipientChatId, resolvedTopic, supergroupChatId })
// → resolvedTopic only when recipient IS the owning supergroup chat; else undefined
```
Attach the topic **only** to the recipient that owns it (the agent's `channels.telegram.chat_id`); send thread-less to operator DMs. The turn-initiated re-emit branch (already posts to the originating chat+thread) is unchanged.

## Test plan
- [x] +6 unit cases on `topic-router` (supergroup→topic, DM→none, wrong-supergroup→none, no-topic, no-supergroup-mode, string/number id equivalence) — **39 pass**
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean
- [ ] Canary: verify an approval card from a supergroup-topic turn now lands in the operator DM (tappable) before fleet rollout

## Risk
Low + well-scoped. The guard only ever *removes* an invalid `message_thread_id` (the one that was 400-ing); it never adds one where there wasn't. Worst case for a misconfig is a thread-less card in a DM — which is exactly what a DM should get. No behavior change for the already-correct turn-initiated supergroup path.

Root-caused while investigating the marko wedge; related delivery-path work: #2093, #2094.