### PR TITLE
chore: release v0.14.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v0.14.42 — Approval cards reach the operator from supergroup topics (#2096)
+
+A HIGH-RISK approval / permission card (e.g. a Brevo `POST`, or a Drive /
+MS-365 / hostd-config write) that an agent raised from **inside a supergroup
+topic** was undeliverable to the operator — so the request auto-denied after
+its 10-minute TTL and the agent sat at the still-open prompt, **wedged**,
+unable to do anything else (no replies, no topic status reports). Observed
+live on `marko`: a Panorama "Winter Special" Brevo EDM approval looping
+`permission_request send … 400 message thread not found` → `auto-deny
+tool=mcp__brevo__post`.
+
+- **Don't attach a supergroup topic id to a DM approval card.** The "PR4b
+  emitter sweep" routed every approval card's `message_thread_id` from the
+  originating turn's forum topic — but that topic id is valid **only in the
+  agent's supergroup**, while the cards fan out to the operator's `allowFrom`
+  chats, which are normally DMs. A DM `sendMessage` carrying a
+  `message_thread_id` is rejected by Telegram (`400 message thread not
+  found`), so the card never arrived. A new pure `topicForRecipient` guard
+  attaches the resolved topic **only** to the recipient that owns it (the
+  agent's `channels.telegram.chat_id`) and sends operator DMs thread-less.
+  Applied at all five affected emitters (permission, drive, MS-365, config,
+  the no-turn permission re-emit). Fire-and-forget informational broadcasts
+  (boot / compact-watchdog) were intentionally left alone — they swallow a
+  thread-not-found as a benign no-op and have no TTL to auto-deny. Pinned by
+  six focused `topic-router` unit tests.
+
 ## v0.14.41 — Delivery-path hardening: steer-loop fix + 6 audit findings (#2092, #2093)
 
 Two rounds of follow-up hardening to v0.14.40's deliver-until-acked queue —

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.41",
+  "version": "0.14.42",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release **v0.14.42** — approval cards reach the operator from supergroup topics (#2096, reviewer-APPROVED).

Fixes the live marko wedge: HIGH-RISK approval cards raised from a supergroup topic were undeliverable to operator DMs (supergroup topic id → Telegram 400 'message thread not found' → auto-deny → wedge). Guarded at all 5 emitters via the pure `topicForRecipient`.

## Test plan
- [x] #2096 reviewer-APPROVED + CI-green before merge
- [x] build clean, dist/cli/switchroom.js 3.05MB
- [ ] CI green → auto-merge
- [ ] Canary: a HIGH-RISK approval from a supergroup-topic turn lands in operator DM (tappable); marko rollout first

Trivial diff (CHANGELOG + version); code risk was in #2096.