### PR TITLE
fix(telegram): route sub-agent handback/progress to the dispatching topic

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5577,7 +5577,21 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
 
   assertAllowedChat(chat_id)
 
-  let threadId = resolveThreadId(chat_id, args.message_thread_id as string | undefined)
+  // Thread resolution precedence: (1) an explicit message_thread_id the
+  // model passed, else (2) THIS turn's own originating topic
+  // (turn-pinned, #1664), else (3) the chat's last-seen topic
+  // (chatThreadMap). Preferring the turn's own thread over the chat
+  // last-seen heuristic fixes synthetic turns (subagent handback/progress,
+  // cron) — whose topic the model is never told and which never write
+  // chatThreadMap — and is strictly more correct under multi-topic
+  // concurrency (a reply lands in the topic the turn came from, not
+  // whichever topic most recently received a message). DM: both are
+  // undefined → unchanged.
+  let threadId = resolveThreadId(
+    chat_id,
+    (args.message_thread_id as string | undefined) ??
+      (turn?.sessionThreadId != null ? turn.sessionThreadId : undefined),
+  )
 
   if (reply_to == null && quoteOptIn && HISTORY_ENABLED) {
     try {
@@ -18581,6 +18595,7 @@ void (async () => {
                   })
                 }
 
+                const handbackOrigin = resolveSubagentOriginChat(agentId)
                 const decision = decideSubagentHandback({
                   handbackEnvValue: process.env.SWITCHROOM_SUBAGENT_HANDBACK,
                   outcome,
@@ -18589,11 +18604,18 @@ void (async () => {
                   // turn) back to the conversation the Task was dispatched
                   // from, so the result lands where the user asked — not the
                   // agent's DM. Falls back to fleetChatId/ownerChatId.
-                  fleetChatId: resolveSubagentOriginChat(agentId)?.chatId || fleetChatId,
+                  fleetChatId: handbackOrigin?.chatId || fleetChatId,
+                  // Supergroup topic the Task was dispatched from. Plumbed
+                  // through so the handback turn (and the model's in-voice
+                  // "here's what the worker found" reply) land in the
+                  // originating topic — not the chat's last-seen topic.
+                  // Applied only when the origin chat resolved (DM fallback
+                  // is topic-less).
+                  ...(handbackOrigin?.threadId != null
+                    ? { originThreadId: handbackOrigin.threadId }
+                    : {}),
                   // Owner-chat fallback: if the parent-turn chat can't be
-                  // resolved, route to the owner chat. Every switchroom fleet
-                  // agent is DM-shaped, so allowFrom[0] is the conversation
-                  // that dispatched.
+                  // resolved, route to the owner chat.
                   ownerChatId: loadAccess().allowFrom[0] ?? '',
                   taskDescription: description,
                   resultText,
@@ -18746,12 +18768,18 @@ void (async () => {
                   return
                 }
 
+                const progressOrigin = resolveSubagentOriginChat(agentId)
                 const decision = decideSubagentProgress({
                   disableEnvValue: process.env.SWITCHROOM_DISABLE_SUBAGENT_PROGRESS,
                   isBackground,
                   // Prefer the conversation the Task was dispatched from over
                   // the owner DM (see resolveSubagentOriginChat).
-                  fleetChatId: resolveSubagentOriginChat(agentId)?.chatId || fleetChatId,
+                  fleetChatId: progressOrigin?.chatId || fleetChatId,
+                  // Carry the dispatching topic so the progress wake lands in
+                  // it (applied only when the origin chat resolved).
+                  ...(progressOrigin?.threadId != null
+                    ? { originThreadId: progressOrigin.threadId }
+                    : {}),
                   ownerChatId: loadAccess().allowFrom[0] ?? '',
                   subagentJsonlId: agentId,
                   taskDescription: description,
@@ -18769,10 +18797,11 @@ void (async () => {
                 // model is about to compose an explicit in-voice
                 // progress line — letting the "— still working (Nm)"
                 // edit fire in parallel would double-surface the
-                // signal. Progress envelopes target the chat level
-                // (no thread id), matching how the inbound lands.
+                // signal. Key the clear on the topic the envelope lands
+                // in (origin thread) so the right lane is yielded in a
+                // supergroup; chat-level for DM-shaped agents.
                 pendingProgress.clearPending(
-                  statusKey(decision.chatId, undefined),
+                  statusKey(decision.chatId, progressOrigin?.threadId),
                   'progress',
                 )
                 process.stderr.write(

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6190,6 +6190,16 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   const turn = currentTurn
   if (!args.chat_id) throw new Error('stream_reply: chat_id is required')
   if (args.text == null || args.text === '') throw new Error('stream_reply: text is required and cannot be empty')
+  // Thread precedence (matches executeReply): when the model passes no
+  // explicit message_thread_id, fall back to THIS turn's originating
+  // topic before handleStreamReply's chatThreadMap last-seen heuristic.
+  // Injecting here threads every downstream consumer consistently — the
+  // dedup key, the voice-scrub metric, the draft transport, and the send
+  // — so a streamed handback/synthetic-turn reply lands in the right
+  // supergroup topic. DM: sessionThreadId undefined → unchanged.
+  if (args.message_thread_id == null && turn?.sessionThreadId != null) {
+    args.message_thread_id = String(turn.sessionThreadId)
+  }
 
   // Outbound secret scrub (#2044): mask before the dedup key, the draft
   // stream sends, and the history record. stream_reply carries the FULL

--- a/telegram-plugin/gateway/subagent-handback-inbound-builder.ts
+++ b/telegram-plugin/gateway/subagent-handback-inbound-builder.ts
@@ -40,6 +40,12 @@ export interface SubagentHandbackContext {
   /** Telegram chat the work was dispatched from — the synthesized
    *  handback turn lands here so it stays with the conversation. */
   chatId: string
+  /** Supergroup topic (message_thread_id) the work was dispatched from.
+   *  Carried so the synthesized handback turn — and the model's
+   *  in-voice "here's what the worker found" reply — land in the
+   *  originating topic, not the chat's last-seen topic. Omitted for
+   *  DM-shaped chats (no topics). See `gateway.ts:resolveSubagentOriginChat`. */
+  threadId?: number
   /** Dispatch-time task description (the sub-agent's `description`). */
   taskDescription: string
   /** The worker's final result text — its last narrative emission
@@ -98,6 +104,9 @@ export function buildSubagentHandbackInbound(opts: {
   return {
     type: 'inbound',
     chatId: opts.ctx.chatId,
+    // Top-level threadId → the enqueued turn's sessionThreadId, so the
+    // handback turn's live activity feed routes to the originating topic.
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
     messageId: ts, // synthetic — no Telegram message id exists
     user: 'subagent-watcher',
     userId: 0,
@@ -106,6 +115,10 @@ export function buildSubagentHandbackInbound(opts: {
     meta: {
       source: 'subagent_handback',
       outcome: opts.ctx.outcome,
+      // meta.message_thread_id is the model-visible channel attribute
+      // (mirrors the real-inbound shape) so the model's reply targets
+      // the dispatching topic. Mirrors gateway.ts:10557.
+      ...(opts.ctx.threadId != null ? { message_thread_id: String(opts.ctx.threadId) } : {}),
       ...(opts.ctx.jsonlAgentId ? { subagent_jsonl_id: opts.ctx.jsonlAgentId } : {}),
     },
   }
@@ -135,6 +148,10 @@ export interface SubagentHandbackDecisionInput {
   fleetChatId: string
   /** Owner chat fallback (access.json allowFrom[0]); '' if none. */
   ownerChatId: string
+  /** Supergroup topic the work was dispatched from (from the parent
+   *  turn). Applied ONLY when `fleetChatId` resolved (the origin chat
+   *  won) — the `ownerChatId` DM fallback has no topic. */
+  originThreadId?: number
   taskDescription: string
   resultText: string
   /** JSONL filename stem for this Claude Code spawn — forwarded into
@@ -185,9 +202,14 @@ export function decideSubagentHandback(
   if (!chatId) {
     return { deliver: false, reason: 'no-chat' }
   }
+  // Thread only when the origin chat (fleetChatId) won — the ownerChatId
+  // DM fallback is topic-less, so a stray thread id would mis-address it.
+  const threadId =
+    input.fleetChatId && input.originThreadId != null ? input.originThreadId : undefined
   const inbound = buildSubagentHandbackInbound({
     ctx: {
       chatId,
+      ...(threadId != null ? { threadId } : {}),
       taskDescription: input.taskDescription,
       resultText: input.resultText,
       outcome: input.outcome,

--- a/telegram-plugin/gateway/subagent-progress-inbound-builder.ts
+++ b/telegram-plugin/gateway/subagent-progress-inbound-builder.ts
@@ -62,6 +62,10 @@ export const DEFAULT_PROGRESS_INTERVAL_MS = 5 * 60 * 1000
 export interface SubagentProgressContext {
   /** Telegram chat the work was dispatched from. */
   chatId: string
+  /** Supergroup topic (message_thread_id) the work was dispatched from,
+   *  so the progress wake-up turn and the model's reply land in the
+   *  originating topic. Omitted for DM-shaped chats. */
+  threadId?: number
   /** JSONL-derived sub-agent id (stable per Claude Code spawn). Pinned
    *  into the spool id so envelopes for the same worker dedup across
    *  buckets cleanly and survive gateway restarts. */
@@ -125,6 +129,7 @@ export function buildSubagentProgressInbound(opts: {
   return {
     type: 'inbound',
     chatId: opts.ctx.chatId,
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
     messageId: ts, // synthetic — no Telegram message id exists
     user: 'subagent-watcher',
     userId: 0,
@@ -132,6 +137,7 @@ export function buildSubagentProgressInbound(opts: {
     text,
     meta: {
       source: 'subagent_progress',
+      ...(opts.ctx.threadId != null ? { message_thread_id: String(opts.ctx.threadId) } : {}),
       subagent_jsonl_id: opts.ctx.subagentJsonlId,
       bucket_idx: String(opts.ctx.bucketIdx),
       expiresAt: String(expiresAt),
@@ -155,6 +161,10 @@ export interface SubagentProgressDecisionInput {
   fleetChatId: string
   /** Owner chat fallback (access.json allowFrom[0]); '' if none. */
   ownerChatId: string
+  /** Supergroup topic the work was dispatched from. Applied ONLY when
+   *  `fleetChatId` resolved (the origin chat won); the DM fallback is
+   *  topic-less. */
+  originThreadId?: number
   subagentJsonlId: string
   taskDescription: string
   latestSummary: string
@@ -240,9 +250,12 @@ export function decideSubagentProgress(
   if (input.lastBucketIdx != null && bucketIdx <= input.lastBucketIdx) {
     return { deliver: false, reason: 'bucket-already-fired' }
   }
+  const threadId =
+    input.fleetChatId && input.originThreadId != null ? input.originThreadId : undefined
   const inbound = buildSubagentProgressInbound({
     ctx: {
       chatId,
+      ...(threadId != null ? { threadId } : {}),
       subagentJsonlId: input.subagentJsonlId,
       taskDescription: input.taskDescription,
       latestSummary: input.latestSummary,

--- a/telegram-plugin/tests/subagent-handback-decision.test.ts
+++ b/telegram-plugin/tests/subagent-handback-decision.test.ts
@@ -109,4 +109,36 @@ describe('decideSubagentHandback', () => {
       expect(d.inbound.text).toContain('Applied 3 migrations')
     }
   })
+
+  // Supergroup topic routing (#status-channel-routing).
+  it('threads the inbound to the origin topic when the origin (fleet) chat won', () => {
+    const d = decideSubagentHandback({ ...base, fleetChatId: '-100777', originThreadId: 42 })
+    expect(d.deliver).toBe(true)
+    if (d.deliver) {
+      expect(d.chatId).toBe('-100777')
+      expect(d.inbound.threadId).toBe(42)
+      expect(d.inbound.meta.message_thread_id).toBe('42')
+    }
+  })
+
+  it('does NOT thread when falling back to the owner DM (topic-less)', () => {
+    // fleetChatId empty → owner DM wins; a stray originThreadId must not
+    // be applied to a DM chat that has no topics.
+    const d = decideSubagentHandback({ ...base, fleetChatId: '', originThreadId: 42 })
+    expect(d.deliver).toBe(true)
+    if (d.deliver) {
+      expect(d.chatId).toBe('999')
+      expect(d.inbound.threadId).toBeUndefined()
+      expect(d.inbound.meta.message_thread_id).toBeUndefined()
+    }
+  })
+
+  it('omits thread carriers when no originThreadId is supplied (DM-shaped agent)', () => {
+    const d = decideSubagentHandback({ ...base, fleetChatId: '777' })
+    expect(d.deliver).toBe(true)
+    if (d.deliver) {
+      expect(d.inbound.threadId).toBeUndefined()
+      expect(d.inbound.meta.message_thread_id).toBeUndefined()
+    }
+  })
 })

--- a/telegram-plugin/tests/subagent-handback-inbound-builder.test.ts
+++ b/telegram-plugin/tests/subagent-handback-inbound-builder.test.ts
@@ -124,4 +124,39 @@ describe('buildSubagentHandbackInbound', () => {
     })
     expect(inbound.text).toContain('(no description)')
   })
+
+  // Supergroup topic routing (#status-channel-routing). The handback turn
+  // and the model's in-voice reply must land in the topic the work was
+  // dispatched from — not the chat's last-seen topic. The carriers are the
+  // top-level threadId (→ turn.sessionThreadId, routes the activity feed)
+  // and meta.message_thread_id (the model-visible channel attribute,
+  // mirrors the real-inbound shape at gateway.ts:10557).
+  it('carries top-level threadId AND meta.message_thread_id when ctx.threadId is set', () => {
+    const inbound = buildSubagentHandbackInbound({
+      ctx: {
+        chatId: '-1001234567890',
+        threadId: 42,
+        taskDescription: 'Research competitors',
+        resultText: 'Found 3 relevant comps.',
+        outcome: 'completed',
+      },
+      nowMs: FIXED_NOW,
+    })
+    expect(inbound.threadId).toBe(42)
+    expect(inbound.meta.message_thread_id).toBe('42')
+  })
+
+  it('omits both thread carriers when ctx.threadId is absent (DM-shaped chat)', () => {
+    const inbound = buildSubagentHandbackInbound({
+      ctx: {
+        chatId: '12345',
+        taskDescription: 'x',
+        resultText: 'y',
+        outcome: 'completed',
+      },
+      nowMs: FIXED_NOW,
+    })
+    expect(inbound.threadId).toBeUndefined()
+    expect(inbound.meta.message_thread_id).toBeUndefined()
+  })
 })

--- a/telegram-plugin/tests/subagent-progress-inbound-builder.test.ts
+++ b/telegram-plugin/tests/subagent-progress-inbound-builder.test.ts
@@ -158,6 +158,42 @@ describe('buildSubagentProgressInbound', () => {
     })
     expect(spoolId(bucket1)).not.toBe(spoolId(bucket2))
   })
+
+  // Supergroup topic routing (#status-channel-routing).
+  it('carries top-level threadId AND meta.message_thread_id when ctx.threadId is set', () => {
+    const inbound = buildSubagentProgressInbound({
+      ctx: {
+        chatId: '-100999',
+        threadId: 7,
+        subagentJsonlId: 'jsonl-abc',
+        taskDescription: 'x',
+        latestSummary: 'still going',
+        elapsedMs: 7 * 60 * 1000,
+        bucketIdx: 1,
+        progressIntervalMs: INTERVAL_MS,
+      },
+      nowMs: FIXED_NOW,
+    })
+    expect(inbound.threadId).toBe(7)
+    expect(inbound.meta.message_thread_id).toBe('7')
+  })
+
+  it('omits both thread carriers when ctx.threadId is absent (DM-shaped chat)', () => {
+    const inbound = buildSubagentProgressInbound({
+      ctx: {
+        chatId: '12345',
+        subagentJsonlId: 'jsonl-abc',
+        taskDescription: 'x',
+        latestSummary: 'y',
+        elapsedMs: 7 * 60 * 1000,
+        bucketIdx: 1,
+        progressIntervalMs: INTERVAL_MS,
+      },
+      nowMs: FIXED_NOW,
+    })
+    expect(inbound.threadId).toBeUndefined()
+    expect(inbound.meta.message_thread_id).toBeUndefined()
+  })
 })
 
 describe('isEnvFlagOn — bool env parser', () => {
@@ -265,5 +301,25 @@ describe('decideSubagentProgress', () => {
     const d = decideSubagentProgress(baseInput({ subagentJsonlId: '' }))
     expect(d.deliver).toBe(false)
     if (!d.deliver) expect(d.reason).toBe('missing-jsonl-id')
+  })
+
+  // Supergroup topic routing (#status-channel-routing).
+  it('threads to the origin topic when the origin (fleet) chat won', () => {
+    const d = decideSubagentProgress(baseInput({ fleetChatId: '-100abc', originThreadId: 7 }))
+    expect(d.deliver).toBe(true)
+    if (d.deliver) {
+      expect(d.inbound.threadId).toBe(7)
+      expect(d.inbound.meta.message_thread_id).toBe('7')
+    }
+  })
+
+  it('does NOT thread when falling back to the owner DM', () => {
+    const d = decideSubagentProgress(baseInput({ fleetChatId: '', originThreadId: 7 }))
+    expect(d.deliver).toBe(true)
+    if (d.deliver) {
+      expect(d.chatId).toBe('999')
+      expect(d.inbound.threadId).toBeUndefined()
+      expect(d.inbound.meta.message_thread_id).toBeUndefined()
+    }
   })
 })


### PR DESCRIPTION
## Summary

Background sub-agent status was reliable in DMs but **mis-routed in supergroups**. When a background worker/researcher finishes, the agent's in-voice "here's what I found" handback reply landed in the chat's *last-seen* topic instead of the topic the work was dispatched from — reading as **silence** in the topic the user was actually watching. First of a series closing the "status must work in channels" gaps (operator-reported).

## Why

`resolveSubagentOriginChat` resolves **both** the origin chat and topic from the parent turn, but:
- the handback (beat 4, `gateway.ts:18592`) and progress (beat 3, `gateway.ts:18754`) callsites took only `.chatId` and **dropped `.threadId`**;
- the inbound builders (`subagent-handback-inbound-builder.ts`, `subagent-progress-inbound-builder.ts`) had **no thread carrier** at all.

So the synthesized handback turn was born thread-blind. Replies are auto-routed (the model is never told the topic — `server.ts:25`), so `executeReply` fell back to `chatThreadMap` (chat last-seen topic) → wrong topic. The worker-feed **running** cue already threaded correctly (`origin?.threadId`, `gateway.ts:18744`), making the asymmetry stark: live activity in the right topic, the result in the wrong one. Background workers run for minutes, so cross-topic activity is the norm in one-agent-owns-supergroup mode — this was a routine mis-route, not an edge case.

## What changed (pure jsonl-tail → render; no model call — inside the subscription-honest boundary)

- **Both builders** now carry the origin topic: top-level `threadId` (→ the enqueued turn's `sessionThreadId`, which routes the handback turn's live activity feed) **and** `meta.message_thread_id` (model-visible channel attribute), mirroring the real-inbound shape at `gateway.ts:10557`. Applied **only** when the origin chat resolved — the owner-DM fallback is topic-less.
- **`executeReply`** prefers THIS turn's own originating topic (turn-pinned, #1664) over the chat's last-seen topic when no explicit `message_thread_id`. Fixes synthetic turns (handback/progress/cron) and is strictly more correct under multi-topic concurrency. **DM behavior unchanged** (both undefined).
- Progress path's pending-ticker clear is keyed on the origin thread so the right lane is yielded in a supergroup.

## Test plan

- [x] `tsc --noEmit` clean
- [x] +24 new assertions across handback/progress **builders + decisions**: thread carried when origin chat wins; omitted on DM fallback / when no origin thread (`subagent-handback-inbound-builder.test.ts`, `subagent-handback-decision.test.ts`, `subagent-progress-inbound-builder.test.ts`)
- [x] Full bun unit suite: 3933 pass / 0 fail
- [x] Full vitest suite green (after `dist` build; remaining failures are unrelated build-artifact/process-spawn env flakes)

## Risk

Low. Builder/decision changes are additive and off the hot send path. The one behavioral change is `executeReply`'s thread precedence — identical result for normal DM/topic turns (turn thread == chat last-seen), only diverges for synthetic turns (the bug) and concurrent multi-topic (more correct). Follow-up PRs in this series: worker-feed DM-fallback, sibling-topic purge, post-ack parent feed, channel UAT coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)