### PR TITLE
feat(telegram): nest foreground sub-agent tool steps, not just prose

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -18736,7 +18736,7 @@ void (async () => {
               // suppresses stale-after-restart delivery (a 4-h-old
               // "still working (5m)" would be a lie). Sweep on handback
               // lives in the `onFinish` block just above.
-              onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx, lastTool, toolCount }) => {
+              onProgress: ({ agentId, description, latestSummary, elapsedMs, prevBucketIdx, setBucketIdx, lastTool, toolCount, progressLine }) => {
                 let fleetChatId = ''
                 try {
                   const fleets = progressDriver?.peekAllFleets() ?? []
@@ -18776,7 +18776,15 @@ void (async () => {
                     nestingEnabled: foregroundNestingEnabled,
                     replyCalled: turn.replyCalled,
                   })) return
-                  const child = latestSummary.trim().slice(0, 120)
+                  // Prefer the tick's own display line: `progressLine` (a
+                  // friendly tool-step label) on tool ticks, else the
+                  // worker's narrative (`latestSummary`) on text ticks. This
+                  // lets a foreground sub-agent that runs tools without
+                  // emitting prose still nest its steps under the parent
+                  // feed (the foreground blindspot) — mirroring the
+                  // main-turn activity feed, which surfaces both tool labels
+                  // and prose.
+                  const child = (progressLine ?? latestSummary).trim().slice(0, 120)
                   if (child.length === 0) return
                   let narrative = turn.foregroundSubAgents.get(agentId)
                   if (narrative == null) {

--- a/telegram-plugin/subagent-watcher.ts
+++ b/telegram-plugin/subagent-watcher.ts
@@ -42,6 +42,7 @@ import { basename, join } from 'path'
 import { homedir } from 'os'
 import { projectSubagentLine, sanitizeCwdToProjectName, detectErrorInTranscriptLine } from './session-tail.js'
 import { sanitiseToolArg } from './fleet-state.js'
+import { describeToolUse } from './tool-activity-summary.js'
 import { escapeHtml, truncate } from './card-format.js'
 import { bumpSubagentActivity, recordSubagentStall, recordSubagentResume, recordSubagentEnd, reapStuckRunningRows, countRunningBackgroundSubagents } from './registry/subagents-schema.js'
 import { touchTurnActiveMarker } from './gateway/turn-active-marker.js'
@@ -348,6 +349,13 @@ export interface SubagentWatcherConfig {
     lastTool: { name: string; sanitisedArg: string } | null
     /** Tool-use count observed so far. */
     toolCount: number
+    /** Friendly display line for THIS tick. Set on `sub_agent_tool_use`
+     *  events to a `describeToolUse` label ("Reading X", "Running a
+     *  command") so a foreground sub-agent that runs tools without
+     *  emitting prose still surfaces its steps in the parent's nested
+     *  feed. Undefined on `sub_agent_text` ticks — the gateway falls back
+     *  to `latestSummary` (the narrative line), preserving prior behavior. */
+    progressLine?: string
   }) => void
   /** `Date.now` override for tests. */
   now?: () => number
@@ -645,6 +653,9 @@ export function readSubTail(
     lastTool: { name: string; sanitisedArg: string } | null
     /** Tool-use count observed so far. */
     toolCount: number
+    /** Friendly display line for THIS tick (set on tool ticks; see the
+     *  SubagentWatcherConfig.onProgress doc). */
+    progressLine?: string
   }) => void,
 ): void {
   try {
@@ -780,6 +791,39 @@ export function readSubTail(
           entry.lastTool = {
             name: ev.toolName,
             sanitisedArg: sanitiseToolArg(ev.toolName, ev.input ?? {}),
+          }
+          // Surface a tool-step progress cue. A foreground sub-agent that
+          // runs tools WITHOUT emitting prose (e.g. a researcher reading
+          // files) previously produced no onProgress tick at all — only
+          // `sub_agent_text` fired it — so its steps never nested under the
+          // parent's activity feed (the named foreground blindspot). Fire
+          // here too, carrying a friendly `describeToolUse` label as
+          // `progressLine` so the gateway can render "Reading X" / "Running
+          // a command" the same way the main-turn feed does. `latestSummary`
+          // stays the worker's narrative result (never polluted with tool
+          // labels — the handback payload depends on it). Pure jsonl-tail →
+          // render, no model call.
+          if (onProgress != null && entry.state === 'running' && !entry.historical) {
+            const toolLine = describeToolUse(ev.toolName, ev.input ?? {})
+            if (toolLine != null && toolLine.length > 0) {
+              try {
+                onProgress({
+                  agentId: entry.agentId,
+                  description: entry.description,
+                  latestSummary: entry.lastResultText,
+                  elapsedMs: now - entry.dispatchedAt,
+                  prevBucketIdx: entry.lastProgressBucketIdx,
+                  setBucketIdx: (b: number) => {
+                    entry.lastProgressBucketIdx = b
+                  },
+                  lastTool: entry.lastTool,
+                  toolCount: entry.toolCount,
+                  progressLine: toolLine,
+                })
+              } catch (cbErr) {
+                log?.(`subagent-watcher: onProgress (tool) callback error ${entry.agentId}: ${(cbErr as Error).message}`)
+              }
+            }
           }
         } else if (ev.kind === 'sub_agent_text') {
           // Do NOT overwrite description with narrative text — description is

--- a/telegram-plugin/tests/subagent-watcher.test.ts
+++ b/telegram-plugin/tests/subagent-watcher.test.ts
@@ -373,6 +373,7 @@ describe('startSubagentWatcher', () => {
     function startWatcherSync(opts: {
       agentDir: string
       onFinish?: Parameters<typeof startSubagentWatcher>[0]['onFinish']
+      onProgress?: Parameters<typeof startSubagentWatcher>[0]['onProgress']
     }): {
       notifications: string[]
       poll: () => void
@@ -392,6 +393,7 @@ describe('startSubagentWatcher', () => {
           notifications.push(`✓ Worker done: ${info.description}`)
           opts.onFinish?.(info)
         },
+        ...(opts.onProgress ? { onProgress: opts.onProgress } : {}),
         stallThresholdMs: 60_000,
         rescanMs: 500,
         now: () => Date.now(),
@@ -475,6 +477,46 @@ describe('startSubagentWatcher', () => {
       const entry = h.watcher.getRegistry().get('deadbeef')
       expect(entry).toBeDefined()
       expect(entry?.toolCount).toBe(3)
+    })
+
+    it('fires onProgress with a friendly tool-step progressLine on a tool_use tick (foreground visibility)', () => {
+      // A foreground sub-agent that runs tools WITHOUT emitting prose used
+      // to fire no onProgress cue at all — only `sub_agent_text` did — so
+      // its steps never nested under the parent's activity feed (the named
+      // foreground blindspot). The tool_use branch now fires onProgress
+      // carrying a `describeToolUse` label so the gateway can render
+      // "Reading X" the same way the main-turn feed does.
+      const progress: Array<{ progressLine?: string; toolCount: number; latestSummary: string }> = []
+      const agentDir = join(tmpRoot, 'agent')
+      const subagentsDir = join(agentDir, '.claude', 'projects', 'p1', 'session-abc', 'subagents')
+      mkdirSync(subagentsDir, { recursive: true })
+      const jsonlPath = join(subagentsDir, 'agent-deadbeef.jsonl')
+
+      const h = startWatcherSync({
+        agentDir,
+        onProgress: ({ progressLine, toolCount, latestSummary }) => {
+          progress.push({ progressLine, toolCount, latestSummary })
+        },
+      })
+      // Register running, post-boot (same pattern as the onFinish test).
+      writeFileSync(jsonlPath, buildJSONL(subAgentUserMsg('Research the competitors')))
+      h.poll()
+      expect(h.watcher.getRegistry().get('deadbeef')?.state).toBe('running')
+
+      // The sub-agent reads a file — a tool_use with no accompanying prose.
+      appendFileSync(jsonlPath, buildJSONL({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', name: 'Read', id: 'r1', input: { file_path: '/x/CLAUDE.md' } }] },
+      }))
+      h.poll()
+
+      const toolTick = progress.find((p) => p.progressLine != null)
+      expect(toolTick).toBeDefined()
+      // Friendly label, matching the main-turn activity feed's renderer.
+      expect(toolTick?.progressLine).toBe('Reading CLAUDE.md')
+      // latestSummary stays the (empty) narrative result — never polluted
+      // with the tool label, so the handback payload is unaffected.
+      expect(toolTick?.latestSummary).toBe('')
     })
 
     it('captures the full last narrative line into lastResultText (handback)', () => {


### PR DESCRIPTION
## Summary

A foreground sub-agent (Task/Agent, no `run_in_background`) that runs tools **without narrating** (a researcher reading files, a worker running commands) currently surfaces **nothing** in the parent turn's nested ↳ activity block. Its steps were invisible — delegated work reads as silence between "Delegating: …" and the final result. Second in the status-visibility series (after #2098).

## Why

Model A (#2027/#2032) nests a foreground sub-agent's live steps under the parent's activity feed, fed by the watcher's `onProgress`. But `onProgress` fired **only** on `sub_agent_text` (narrative prose) events — never on `sub_agent_tool_use` (`subagent-watcher.ts:774` updated `lastTool`/`toolCount` but didn't fire). And the gateway keyed the nested line solely on `latestSummary` (the prose, `gateway.ts:18729`). So a tool-only sub-agent produced zero ticks → zero nested visibility. This is the foreground half of the visibility-parity goal (JTBD-2).

## What changed (pure jsonl-tail → render; no model call)

- **`subagent-watcher.ts`**: fire `onProgress` from the `sub_agent_tool_use` branch too, carrying a friendly `describeToolUse` label as a new optional `progressLine` arg ("Reading CLAUDE.md", "Running a command") — the **same renderer** the main-turn activity feed uses, so foreground steps read identically. `latestSummary` stays the worker's narrative result, **never** polluted with tool labels (the beat-4 handback payload depends on it).
- **`gateway.ts` foreground branch**: render `progressLine ?? latestSummary` — tool ticks surface their step, text ticks keep showing prose, interleaved chronologically like the main feed.

## Background side-effect (intentional, harmless)

The background worker feed ignores `progressLine` (keeps using `latestSummary`), so its content is unchanged. It may first-paint slightly sooner on a tool tick — throttled (2.5s min edit interval, 8s first-paint floor), harmless, arguably an improvement.

## Test plan

- [x] `tsc --noEmit` clean
- [x] New watcher test: a prose-less `Read` tool tick fires `onProgress` with `progressLine === "Reading CLAUDE.md"`, and `latestSummary` stays `''` (handback payload intact)
- [x] `subagent-watcher.test.ts` (22), `foreground-nesting.test.ts` (9), `tool-activity-summary.test.ts` (21), `subagent-watcher-handback-gaps.test.ts` (10) green
- [x] bun watcher/subagent suites: 77 pass / 0 fail

## Risk

Low–medium. The watcher change is additive (a new onProgress firing path); the gateway change is one line (`progressLine ?? latestSummary`). The gateway accumulate/compose seam itself remains gateway-internal (untested directly — same limitation flagged for the series; the dedicated test-coverage PR will extract a pure helper + add channel UAT). No model call; subscription-honest boundary untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)