### PR TITLE
test(uat): accept "switched to X as you asked" steer narration

### DIFF
--- a/telegram-plugin/uat/scenarios/jtbd-rapid-followup-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-rapid-followup-dm.test.ts
@@ -56,14 +56,16 @@ describe("uat: rapid follow-ups — steering vs queued classification", () => {
             const txt = m.text;
             const mentionsMd5 = /\bmd5\b/i.test(txt);
             // Steer narration: the agent acknowledges amending the in-flight
-            // task. Accept the phrasings the model actually uses — including
-            // "Switched to MD5 per your update/follow-up" (the 2026-06-02
-            // canary reply that the old regex wrongly rejected). Anchored on
-            // "per your <qualifier>" / continuation language so it stays
-            // distinct from the QUEUED path (a fresh answer with no such
-            // course-correction narration).
+            // task. Accept the phrasings the model actually uses — "Switched
+            // to MD5 per your update/follow-up" (2026-06-02 canary) AND
+            // "Switched to MD5 as you asked" (2026-06-03 canary) — i.e. a
+            // "switch(ed) to <algo>" acknowledgement qualified by EITHER
+            // "per your <qualifier>" OR "as (you) asked/requested/...". The
+            // qualifier keeps it distinct from the QUEUED path (a fresh answer
+            // with no such course-correction narration — the queued test uses
+            // its own /queued|new task/ matcher, so broadening here is safe).
             const narratesSteer =
-              /↪️|\bsteer(ing)?\b|switch(?:ed|ing)? to \w+ per your (?:update|follow-?up|guidance|request|steer)|continuing the (prior|original|in-flight) task|amendment|course[- ]correct/i.test(
+              /↪️|\bsteer(ing)?\b|switch(?:ed|ing)? to \w+ (?:per your (?:update|follow-?up|guidance|request|steer)|as (?:you )?(?:asked|requested|instructed|wanted|said))|continuing the (prior|original|in-flight) task|amendment|course[- ]correct/i.test(
                 txt,
               );
             return mentionsMd5 && narratesSteer;


### PR DESCRIPTION
## Summary
The `jtbd-rapid-followup` steer assertion's `narratesSteer` regex required "switch(ed) to <algo> **per your** <qualifier>", but on a v0.14.42 canary the model narrated the steer as **"Switched to MD5 as you asked"** — a phrasing #2091's broadening still missed → recurring **false** UAT failure, even though the agent steered correctly (switched algorithms, **zero re-deliveries** — gateway log confirmed #2092's no-loop fix held).

Accept `as (you) asked/requested/instructed/wanted/said` as an alternative qualifier after "switch(ed) to <algo>".

## Why it's safe
- Stays distinct from the QUEUED path, which uses its own `/queued|new task/` matcher (broadening `narratesSteer` doesn't touch it).
- Validated against the real canary strings: the failing "Switched to MD5 as you asked" now matches; back-compat "per your update" still matches; the queued fresh-answer "The MD5 of … is …" correctly does **not** match.

## Context
Found while running the release-critical mtcute UAT against the v0.14.42 fleet. The *product* validated cleanly (no-drop re-run passed + gateway log showed zero drops; steer switched algorithms with no loop; always-on-after-restart ≤2min). The two scenario failures were both **test-matcher artifacts** — this PR fixes the steer one. Test-only change.

Test plan: regex validated against real canary strings; no product code touched.