### PR TITLE
fix(telegram): honest silence-poke when blocked on an approval tap

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3912,10 +3912,18 @@ silencePoke.startTimer({
       // (CC-4 in `docs/status-ask-cause-classes.md`). Derives "N min" suffix
       // from `ctx.silenceMs` so the wording stays honest if the 300s
       // threshold is tuned.
+      // Honesty: if the turn is parked on an approval card (the dominant
+      // benign "wedge" class — claude is alive, waiting on the operator's
+      // tap), say so instead of "still working…". The reaction controller
+      // already tracks this (setAwaiting on the permission-request park).
+      const blockedOnApproval = activeStatusReactions
+        .get(statusKey(ctx.chatId, ctx.threadId))
+        ?.isAwaiting() ?? false
       text = silencePoke.formatFrameworkFallbackText(
         ctx.fallbackKind,
         ctx.silenceMs,
         ctx.inFlightTools,
+        blockedOnApproval,
       )
     }
     try {

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -264,8 +264,17 @@ export function formatFrameworkFallbackText(
   fallbackKind: 'working' | 'thinking',
   silenceMs: number,
   inFlightTools: ToolSnapshot[] = [],
+  blockedOnApproval = false,
 ): string {
   const minutes = Math.max(1, Math.round(silenceMs / 60_000))
+  // The turn isn't stalled — it's parked on an approval card waiting for YOUR
+  // tap (the dominant live "wedge" class is benign approval-latency, not a
+  // hang). Saying "still working…" here actively lies; name the real blocker so
+  // the operator knows the ball is in their court. Takes precedence over the
+  // in-flight-tool framing (a tool awaiting approval isn't "running").
+  if (blockedOnApproval) {
+    return `waiting for your approval — tap Approve or Deny on the card above (${minutes} min)`
+  }
   const suffix = `(no update from agent in ${minutes} min)`
   // #1292 case (a): tools in flight. Name the longest-running one
   // (entry[0] — caller pre-sorts by startedAt ascending). Avoid the

--- a/telegram-plugin/status-reactions.ts
+++ b/telegram-plugin/status-reactions.ts
@@ -144,6 +144,10 @@ export class StatusReactionController {
   private stallHardTimer: ReturnType<typeof setTimeout> | null = null
   private finished = false
   private held = false
+  // True while parked on the awaiting-approval state (🙏): the turn is blocked
+  // on the operator's tap, not stalled. Read by the silence-poke fallback so it
+  // says "waiting for your approval" instead of the dishonest "still working…".
+  private awaitingApproval = false
   private readonly debounceMs: number
   private readonly stallSoftMs: number
   private readonly stallHardMs: number
@@ -272,11 +276,21 @@ export class StatusReactionController {
 
   // ──────────────────────────────────────────────────────────────────────
 
+  /** True while the turn is parked awaiting the operator's approval tap (🙏).
+   *  The silence-poke fallback reads this to phrase its 300s message honestly
+   *  ("waiting for your approval") instead of "still working…". */
+  isAwaiting(): boolean {
+    return this.awaitingApproval && !this.finished
+  }
+
   private scheduleState(
     state: ReactionState,
     opts: { immediate?: boolean; skipStallReset?: boolean } = {},
   ): void {
     if (this.finished) return
+    // Track the awaiting-approval state for isAwaiting(). Any non-awaiting
+    // state transition (setThinking/setTool/… on verdict resume) clears it.
+    this.awaitingApproval = state === 'awaiting'
     const emoji = this.resolveEmoji(state)
     if (emoji == null) {
       if (!opts.skipStallReset) this.resetStallTimers()

--- a/telegram-plugin/tests/silence-poke.test.ts
+++ b/telegram-plugin/tests/silence-poke.test.ts
@@ -275,6 +275,26 @@ describe('silence-poke — #1292 tool-aware framework fallback', () => {
     ).toBe('still working… (no update from agent in 5 min)')
   })
 
+  it('blockedOnApproval names the real blocker instead of the dishonest "still working…"', () => {
+    expect(
+      formatFrameworkFallbackText('working', 305_000, [], true),
+    ).toBe('waiting for your approval — tap Approve or Deny on the card above (5 min)')
+  })
+
+  it('blockedOnApproval takes precedence over an in-flight tool (a tool awaiting approval is not "running")', () => {
+    expect(
+      formatFrameworkFallbackText('working', 305_000, [
+        { name: 'Bash', label: 'rm -rf build', durationMs: 305_000 },
+      ], true),
+    ).toBe('waiting for your approval — tap Approve or Deny on the card above (5 min)')
+  })
+
+  it('blockedOnApproval=false keeps the existing wording (default, back-compat)', () => {
+    expect(
+      formatFrameworkFallbackText('working', 305_000, [], false),
+    ).toBe('still working… (no update from agent in 5 min)')
+  })
+
   it('tool-aware wording wins over "thinking" — the actual observable beats the inferred kind', () => {
     const text = formatFrameworkFallbackText('thinking', 305_000, [
       { name: 'Grep', label: '"foo"', durationMs: 305_000 },

--- a/telegram-plugin/tests/status-reactions.test.ts
+++ b/telegram-plugin/tests/status-reactions.test.ts
@@ -94,6 +94,22 @@ describe('StatusReactionController', () => {
     expect(calls).toEqual(['👀'])
   })
 
+  it('isAwaiting() tracks the awaiting-approval state (for the honest silence-poke copy)', async () => {
+    const { emit } = makeEmitter()
+    const ctrl = new StatusReactionController(emit)
+    expect(ctrl.isAwaiting()).toBe(false)
+    ctrl.setAwaiting()
+    expect(ctrl.isAwaiting()).toBe(true)
+    // The verdict resume (setThinking) un-parks → no longer awaiting.
+    ctrl.setThinking()
+    expect(ctrl.isAwaiting()).toBe(false)
+    // Re-park, then finish → isAwaiting is false once the turn ends.
+    ctrl.setAwaiting()
+    expect(ctrl.isAwaiting()).toBe(true)
+    ctrl.finalize()
+    expect(ctrl.isAwaiting()).toBe(false)
+  })
+
   it('setThinking is debounced by 3500ms (#1713)', async () => {
     const { emit, calls } = makeEmitter()
     const ctrl = new StatusReactionController(emit)


### PR DESCRIPTION
## Summary
The 300s framework-fallback says *"still working… (no update from agent in 5 min)"* even when the turn is parked on an **approval card waiting for the operator's tap**. A prod-log investigation across the fleet (gymbro 14×, clerk 6×) found the recurring "turn-wedges" are *mostly this benign class* — claude is alive and mid-turn, blocked on a Write/Edit/Bash/MCP permission prompt, self-recovering the instant the human answers (no drops). In that state the copy actively **lies**: the agent isn't computing, it's waiting on **you**.

JTBD: **you hold the leash** — the status surface must tell you when the ball is in your court.

## Fix
The reaction controller already tracks the approval park (`setAwaiting()` on the permission-request — the same signal that suspends the stall watchdog). Expose it via `isAwaiting()`, read it at the `onFrameworkFallback` callsite, and have `formatFrameworkFallbackText` emit:

> waiting for your approval — tap Approve or Deny on the card above (N min)

instead of *"still working…"*. Takes precedence over the in-flight-tool framing (a tool *awaiting approval* isn't "running"). **Pure copy/branch — the 300s self-recovery behaviour is unchanged.**

## Test plan
- [x] +3 `formatFrameworkFallbackText` cases (approval copy; precedence over an in-flight tool; back-compat default) + `isAwaiting()` state-transition test
- [x] 73 status-reactions + silence-poke tests pass
- [x] `tsc --noEmit` clean; `check-bot-api-wrapping.sh` clean

## Risk
Minimal — a copy branch gated on an existing state signal. When `isAwaiting()` is false (every non-approval turn) the wording is byte-identical to today. No change to *when* the fallback fires or to the unwedge/self-recovery.

Source: the turn-wedge root-cause investigation (follow-up thread 1). 1 of 3 fix-now follow-ups; #5 (post-ack feed) and #2 (sibling-purge) follow as separate PRs.