### PR TITLE
fix(telegram): don't purge live sibling supergroup topics on silence-poke (#2)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4041,16 +4041,29 @@ silencePoke.startTimer({
     // SAME chat (different threads, or a `null` vs `undefined`-thread
     // variant left over from a normal turn-end path that nulled
     // currentTurn without invoking purgeReactionTracking — the
-    // gymbro/klanker held-mid-turn symptom, 2026-05-20). Any sibling
-    // for fbChatId is by definition stale when THIS fallback fires
-    // (the chat has been silent ≥5 min); sweep them via the same
-    // purger. Multi-chat-safe — only touches keys for fbChatId, so
+    // gymbro/klanker held-mid-turn symptom, 2026-05-20); sweep them via
+    // the same purger. Multi-chat-safe — only touches keys for fbChatId, so
     // #1546's intentional cross-chat safety guard is preserved.
+    //
+    // BUT a sibling is NOT "by definition stale": in one-agent-owns-supergroup
+    // every forum topic shares fbChatId, so a chatId-only sweep would purge a
+    // LIVE sibling topic's reaction controller + typing loop when THIS topic's
+    // poke fires. Gate each sibling on its OWN silence clock — purge only those
+    // also silent ≥ the fallback threshold (their own poke would fire too),
+    // sparing topics that are actively mid-turn. Use silence, not turn-start
+    // age, so a long-but-narrating turn isn't mistaken for stale.
     // See turn-state-purge.ts.
+    const fbNow = Date.now()
     const fbExtraPurge = purgeStaleTurnsForChat(
       fbChatId,
       activeTurnStartedAt.keys(),
       purgeReactionTracking,
+      (siblingKey) => {
+        if (siblingKey === fbKey) return true // the firing key is genuinely stale
+        const sib = silencePoke.silenceMsForKey(siblingKey, fbNow)
+        // No silence-poke state → dangling (turn ended, key not purged) → stale.
+        return sib == null || sib >= silencePoke.DEFAULT_THRESHOLDS.fallback
+      },
     )
     // Null `currentTurn` if it's still pointing at the wedged turn —
     // when claude eventually fires a late `turn_end` for this session

--- a/telegram-plugin/gateway/turn-state-purge.ts
+++ b/telegram-plugin/gateway/turn-state-purge.ts
@@ -50,6 +50,19 @@ export function purgeStaleTurnsForChat(
   chatId: string,
   keys: Iterable<string>,
   purger: (key: string) => void,
+  /**
+   * Per-sibling staleness gate. A sibling key for `chatId` is purged only when
+   * this returns true. CRITICAL for one-agent-owns-supergroup: all of an
+   * agent's forum topics share the SAME chatId, so a chatId-only match would
+   * purge a LIVE sibling topic's reaction controller + typing loop when ANOTHER
+   * topic's 300s silence-poke fires (the gymbro/klanker wedge class). The
+   * caller passes a predicate true only for siblings themselves silent ≥ the
+   * fallback threshold (their own poke would also fire) — preserving the #1556
+   * dangling-key cleanup while sparing live siblings. Defaults to always-stale
+   * for back-compat (DM / single-topic callers, where every sibling is
+   * genuinely dangling).
+   */
+  isStale: (key: string) => boolean = () => true,
 ): PurgeStaleTurnsResult {
   if (!chatId) return { purged: [] }
   const purged: string[] = []
@@ -64,6 +77,7 @@ export function purgeStaleTurnsForChat(
     if (sep < 0) continue // malformed / non-statusKey shape — skip
     const keyChat = key.slice(0, sep)
     if (keyChat !== chatId) continue
+    if (!isStale(key)) continue // live sibling topic — leave its turn state intact
     purger(key)
     purged.push(key)
   }

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -245,6 +245,23 @@ export function endTurn(key: string): void {
 }
 
 /**
+ * Current silence duration (ms) for a key — `now - (lastOutboundAt ??
+ * turnStartedAt)`, the same clock `tick()` uses to decide the 300s fallback —
+ * or null when no turn state exists for the key. Lets the sibling-topic purge
+ * distinguish a STALE/wedged sibling (silent ≥ the fallback threshold, so its
+ * own poke would also fire) from a LIVE one mid-turn (recent outbound, low
+ * silence), so a silence-poke on one supergroup topic doesn't purge a live
+ * sibling topic's reaction controller + typing loop. NB: this is silence, NOT
+ * turn-start age — a long but actively-narrating turn has low silence and must
+ * not be treated as stale.
+ */
+export function silenceMsForKey(key: string, now: number): number | null {
+  const s = state.get(key)
+  if (s == null) return null
+  return now - (s.lastOutboundAt ?? s.turnStartedAt)
+}
+
+/**
  * Verbatim framework-fallback text — the user-visible "still working / still
  * thinking" message the gateway sends at the 300s threshold when the model
  * hasn't broken its own silence. Wording is load-bearing (see

--- a/telegram-plugin/tests/silence-poke.test.ts
+++ b/telegram-plugin/tests/silence-poke.test.ts
@@ -7,6 +7,7 @@ import {
   noteToolEnd,
   noteToolLabel,
   endTurn,
+  silenceMsForKey,
   silencePokeEnabled,
   formatFrameworkFallbackText,
   __tickForTests,
@@ -358,6 +359,21 @@ describe('silence-poke — #1292 tool-aware framework fallback', () => {
     }
     __tickForTests(305_000)
     expect(fx.fallbacks).toHaveLength(1)
+  })
+
+  it('silenceMsForKey reports silence from last outbound (or turn start), null when unknown', () => {
+    setupDeps()
+    startTurn('k', 1_000)
+    // No outbound yet → silence measured from turnStartedAt.
+    expect(silenceMsForKey('k', 1_000 + 120_000)).toBe(120_000)
+    noteOutbound('k', 1_000 + 50_000)
+    // After an outbound → silence measured from lastOutboundAt.
+    expect(silenceMsForKey('k', 1_000 + 120_000)).toBe(70_000)
+    // Unknown key / ended turn → null (used by the sibling purge to treat a
+    // dangling key as stale).
+    expect(silenceMsForKey('never-started', 999_999)).toBeNull()
+    endTurn('k')
+    expect(silenceMsForKey('k', 999_999)).toBeNull()
   })
 
   it('Task tool populates inFlightTools so the fallback names it as the observable', () => {

--- a/telegram-plugin/tests/turn-state-purge.test.ts
+++ b/telegram-plugin/tests/turn-state-purge.test.ts
@@ -106,4 +106,32 @@ describe('purgeStaleTurnsForChat', () => {
     expect(r.purged.sort()).toEqual(['123:7', '123:_'])
     expect([...map.keys()]).toEqual(['999:_']) // multi-chat safety preserved
   })
+
+  // #2 supergroup sibling-topic fix: one agent owns the supergroup, so all
+  // forum topics share the chatId. A 300s poke on topic A must NOT purge a
+  // LIVE sibling topic B's turn state — only siblings that are themselves stale.
+  it('isStale predicate spares live sibling topics (the supergroup fix)', () => {
+    const purged: string[] = []
+    const live = new Set(['-100:7']) // topic 7 is actively mid-turn
+    const r = purgeStaleTurnsForChat(
+      '-100',
+      ['-100:4', '-100:7', '999:_'],
+      (k) => purged.push(k),
+      (k) => !live.has(k), // stale iff not live
+    )
+    expect(r.purged).toEqual(['-100:4']) // only the stale topic purged
+    expect(purged).toEqual(['-100:4']) // live topic 7 + other chat untouched
+  })
+
+  it('isStale=false for every sibling purges nothing (all topics live)', () => {
+    const purged: string[] = []
+    purgeStaleTurnsForChat('-100', ['-100:4', '-100:7'], (k) => purged.push(k), () => false)
+    expect(purged).toEqual([])
+  })
+
+  it('default isStale (omitted) purges every chatId match — back-compat', () => {
+    const purged: string[] = []
+    const r = purgeStaleTurnsForChat('123', ['123:_', '123:7', '999:_'], (k) => purged.push(k))
+    expect(r.purged.sort()).toEqual(['123:7', '123:_'])
+  })
 })


### PR DESCRIPTION
## Summary
The silence-poke fallback sweeps sibling turn-state for the firing chat (`purgeStaleTurnsForChat`) as defense-in-depth against dangling keys — matching on **chatId only**, with the now-false comment *"any sibling is by definition stale."* In **one-agent-owns-supergroup**, every forum topic shares the agent's chatId, so a 300s poke on topic A purges a **LIVE sibling topic B's** reaction controller + typing loop — B silently loses its status surface mid-turn (the gymbro/klanker held-mid-turn wedge class, now reachable per-topic).

JTBD: **always-available** — a live topic must keep its status surface when an unrelated topic times out.

## Fix
Gate each sibling on its **own** silence clock:
- Add an `isStale` predicate to `purgeStaleTurnsForChat` (default always-stale → DM / single-topic **back-compat**).
- The gateway passes a predicate that purges a sibling only when it is itself silent ≥ the fallback threshold (its own poke would fire too) **or** has no silence-poke state (dangling).
- New `silencePoke.silenceMsForKey(key, now)` returns `now − (lastOutboundAt ?? turnStartedAt)` — **silence**, not turn-start age, so a long-but-actively-narrating turn isn't mistaken for stale.

The #1556 dangling-key cleanup is preserved; live siblings are spared.

⚠️ **Caveat baked in (per the investigation):** the predicate uses an **absolute per-sibling silence threshold** (matching the fallback), NOT a chatId match — using anything weaker would reopen the #1556 held-forever wedge.

## Test plan
- [x] +3 `turn-state-purge` cases (live sibling spared; all-live purges nothing; default back-compat) + `silenceMsForKey` (silence from outbound/start; null when unknown)
- [x] 54 unit tests pass; tsc + bot-api-wrapping clean
- [ ] Canary: a 2-topic supergroup where topic A times out while topic B is live — confirm B keeps its reaction/typing surface. (mtcute has no multi-topic create API, so this is partly pinned by the unit tests; UAT covers the single-topic no-regression.)

## Risk
Low-moderate — touches the silence-poke unwedge primitive. Mitigation: back-compat default preserves DM/single-topic behaviour exactly; the predicate only ever makes the sweep MORE conservative (skips live siblings), never less; the firing key itself is always purged. Source: turn-wedge follow-up thread 3, item #2 (3 of 3 fix-now). Siblings: #2107 (honesty, merging), #2108 (post-ack feed, merging).