### PR TITLE
fix(telegram): surface operator MCP tools in the live activity feed

### DIFF
--- a/telegram-plugin/hooks/tool-label-pretool.mjs
+++ b/telegram-plugin/hooks/tool-label-pretool.mjs
@@ -133,8 +133,9 @@ export function computeLabel(toolName, input) {
     }
   }
 
-  // MCP allowlist.
+  // MCP tools.
   if (typeof toolName === 'string' && toolName.startsWith('mcp__')) {
+    // Explicit labels / suppressions for the built-in servers.
     switch (toolName) {
       case 'mcp__switchroom-telegram__reply':
       case 'mcp__switchroom-telegram__stream_reply':
@@ -150,15 +151,46 @@ export function computeLabel(toolName, input) {
         return 'Searching memory'
       case 'mcp__hindsight__retain':
         return 'Saving memory'
-      // Explicit suppressions — return null so we don't emit a sidecar
-      // line at all. (Falling through to the default below produces the
-      // same effect, but listing these makes the intent obvious.)
+      // Explicit suppressions — return null so we don't emit a sidecar line.
       case 'mcp__switchroom-telegram__send_typing':
       case 'mcp__hindsight__sync_retain':
         return null
     }
-    // Any other mcp__* tool: not on the allowlist, no label.
-    return null
+    // Generic fallback for ANY other MCP tool (operator-configured servers
+    // — perplexity, webkite, gdrive, notion, …). These previously returned
+    // null → invisible in the live activity feed, so a research turn driven
+    // entirely by MCP tools read as pure silence (only a typing dot + the
+    // 👀 reaction) — the "I can't see what it's doing" report. Mirror the
+    // gateway's describeToolUse: friendly per-server labels, else a
+    // model-authored field, else a humanized tool name. NEVER label
+    // switchroom-telegram surface/control tools (they ARE the conversation).
+    const m = /^mcp__(.+?)__(.+)$/.exec(toolName)
+    if (!m) return null
+    const server = m[1].toLowerCase()
+    const tool = m[2].toLowerCase()
+    if (server === 'switchroom-telegram') return null
+    if (server === 'hindsight') return 'Working with memory'
+    if (server === 'google-workspace' || server === 'claude_ai_google_calendar')
+      return 'Checking your calendar'
+    if (server === 'claude_ai_gmail') return 'Checking your email'
+    if (server === 'claude_ai_google_drive' || server === 'gdrive')
+      return 'Looking through your files'
+    if (server === 'notion' || server === 'claude_ai_notion') return 'Checking your notes'
+    if (server === 'perplexity') {
+      const q = clip(String(i.query ?? i.description ?? ''), 60).trim()
+      return q ? `Searching the web for ${q}` : 'Searching the web'
+    }
+    if (server === 'webkite') {
+      const u = clip(urlHostPath(i.url ?? ''), 60).trim()
+      return u ? `Reading ${u}` : 'Reading the web'
+    }
+    // Unknown MCP server: prefer a model-authored field, else humanized tool.
+    const desc =
+      clip(String(i.description ?? ''), 60).trim() ||
+      clip(String(i.query ?? ''), 50).trim() ||
+      clip(String(i.title ?? ''), 50).trim()
+    if (desc) return desc
+    return `Using ${tool.replace(/[-_]+/g, ' ')}`
   }
 
   return null

--- a/telegram-plugin/tests/tool-label-pretool.test.ts
+++ b/telegram-plugin/tests/tool-label-pretool.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for computeLabel in telegram-plugin/hooks/tool-label-pretool.mjs —
+ * the PreToolUse hook that drives the live activity feed's per-tool labels.
+ *
+ * Focus: the MCP generic fallback. Previously the hook allowlisted only
+ * switchroom-telegram + hindsight and returned null for every other MCP
+ * tool, so a research turn driven by operator-configured MCP servers
+ * (perplexity, webkite, …) produced NO activity-feed entries — the user
+ * saw only a typing dot + reaction (the "I can't see what it's doing"
+ * report). The fallback now mirrors the gateway's describeToolUse.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { computeLabel } from '../hooks/tool-label-pretool.mjs'
+
+describe('computeLabel — built-in + known MCP (regression)', () => {
+  it('labels common built-in tools', () => {
+    expect(computeLabel('Bash', { description: 'Run the tests' })).toBe('Run the tests')
+    expect(computeLabel('Read', { file_path: '/x/CLAUDE.md' })).toBe('Reading CLAUDE.md')
+    expect(computeLabel('WebSearch', { query: 'tasmania weather' })).toBe(
+      'Searching the web for tasmania weather',
+    )
+    expect(computeLabel('ToolSearch', {})).toBe('Finding the right tool')
+  })
+
+  it('labels / suppresses the built-in MCP servers as before', () => {
+    expect(computeLabel('mcp__switchroom-telegram__reply', {})).toBe('Replying')
+    expect(computeLabel('mcp__hindsight__recall', {})).toBe('Searching memory')
+    // surface/control tools are the conversation — never labeled
+    expect(computeLabel('mcp__switchroom-telegram__send_typing', {})).toBeNull()
+    expect(computeLabel('mcp__hindsight__sync_retain', {})).toBeNull()
+    // an UNlisted switchroom-telegram tool must still be suppressed
+    expect(computeLabel('mcp__switchroom-telegram__progress_update', {})).toBeNull()
+  })
+})
+
+describe('computeLabel — MCP generic fallback (the fix)', () => {
+  it('surfaces operator research tools that used to be invisible', () => {
+    // perplexity — the exact case behind the silent research turn
+    expect(computeLabel('mcp__perplexity__perplexity_search', { query: 'hobart forecast' })).toBe(
+      'Searching the web for hobart forecast',
+    )
+    expect(computeLabel('mcp__perplexity__perplexity_ask', {})).toBe('Searching the web')
+    // webkite read
+    expect(computeLabel('mcp__webkite__webkite_read', { url: 'https://bom.gov.au/tas' })).toBe(
+      'Reading bom.gov.au/tas',
+    )
+    expect(computeLabel('mcp__webkite__webkite_read', {})).toBe('Reading the web')
+  })
+
+  it('gives friendly labels for known workspace servers', () => {
+    expect(computeLabel('mcp__gdrive__search', {})).toBe('Looking through your files')
+    expect(computeLabel('mcp__claude_ai_gmail__list', {})).toBe('Checking your email')
+    expect(computeLabel('mcp__notion__notion-search', {})).toBe('Checking your notes')
+  })
+
+  it('falls back to a model-authored field, else a humanized tool name', () => {
+    expect(computeLabel('mcp__acme__do_thing', { description: 'Crunching the numbers' })).toBe(
+      'Crunching the numbers',
+    )
+    expect(computeLabel('mcp__acme__fetch_invoices', {})).toBe('Using fetch invoices')
+  })
+
+  it('NEVER returns null for a generic MCP tool (the regression that hid research)', () => {
+    // The whole point: an unknown MCP tool must produce SOME label now.
+    expect(computeLabel('mcp__perplexity__perplexity_ask', {})).not.toBeNull()
+    expect(computeLabel('mcp__webkite__webkite_read', {})).not.toBeNull()
+    expect(computeLabel('mcp__some_new_server__some_tool', {})).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
A research turn driven by operator MCP tools (perplexity, webkite, …) showed **no activity feed** — only a typing dot + 👀 — so it read as 'I can't see what it's doing' (operator report; confirmed in the session JSONL: `perplexity_ask`×2, `perplexity_search`, `webkite_read`×3 over 73s, **zero `tool_label` events**).

## Root cause
`tool-label-pretool.mjs` `computeLabel` **allowlisted only switchroom-telegram + hindsight** and returned `null` for every other `mcp__*` tool. The live activity feed is driven off this sidecar, so research tools produced nothing. (The gateway's `describeToolUse` already has a generic MCP fallback — the sidecar never got it.)

## Fix
Generic MCP fallback in `computeLabel` mirroring `describeToolUse`: friendly per-server labels (perplexity → 'Searching the web for …', webkite → 'Reading <host>', gdrive/gmail/notion/calendar), else a model-authored field, else 'Using <tool>'. switchroom-telegram surface tools stay suppressed.

## Test plan
- [x] tsc clean; +6 computeLabel cases (perplexity/webkite/gdrive/unknown MCP labeled; surface tools null; built-ins unchanged); tool-label-sidecar + tool-labels suites green (68 total)
- [ ] Live: re-run an MCP research turn post-release → activity feed shows 'Searching the web for …' / 'Reading …'

## Risk
Low. Pure label-derivation change in a PreToolUse hook (never blocks tools — exit 0). Baked into the agent image → needs a release + rollout to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)