### PR TITLE
fix(telegram): topic-safe ops-lane sends + threaded typing (supergroup)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3537,18 +3537,24 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
   // Fleet-shared / DM agents see `undefined` → no `message_thread_id`
   // is added to the broadcast opts → behavior unchanged.
   const opEventTopic = resolveAgentOutboundTopic({ kind: 'compact-watchdog' })
+  const opEventSupergroup = resolveAgentSupergroupChatId()
 
   process.stderr.write(
     `telegram gateway: operator-event posting agent=${agent} kind=${kind} to ${access.allowFrom.length} chat(s)` +
       (opEventTopic != null ? ` topic=${opEventTopic}` : '') + '\n',
   )
   for (const chat_id of access.allowFrom) {
+    // The resolved topic is valid ONLY in the agent's supergroup — attaching
+    // it to an operator DM recipient yields 400 "message thread not found" and
+    // the event silently fails to deliver (the marko #2096 class). Guard it:
+    // DM recipients get a thread-less send; the supergroup owner gets the lane.
+    const opEventThread = topicForRecipient({ recipientChatId: chat_id, resolvedTopic: opEventTopic, supergroupChatId: opEventSupergroup })
     // grammy's Other<...> opts type is generated and stricter than our
     // call shape; runtime accepts both. Cast through unknown.
     const opts = {
       parse_mode: 'HTML' as const,
       ...(renderedKeyboard ? { reply_markup: renderedKeyboard } : {}),
-      ...(opEventTopic != null ? { message_thread_id: opEventTopic } : {}),
+      ...(opEventThread != null ? { message_thread_id: opEventThread } : {}),
     }
     // Comment-only context for the reader; the lint marker on the
     // very next line is what unlocks the raw bot.api call.
@@ -10159,7 +10165,14 @@ async function handleInbound(
     // No staged entry to act on — fall through to normal handling.
   }
 
-  void bot.api.sendChatAction(chat_id, 'typing').catch(() => {})
+  // Typing indicator in the ORIGINATING topic — on a supergroup-topic inbound,
+  // an un-threaded sendChatAction shows "typing" in General, not the topic the
+  // user is in. messageThreadId is the inbound's thread (undefined in a DM).
+  void bot.api.sendChatAction(
+    chat_id,
+    'typing',
+    messageThreadId != null ? { message_thread_id: messageThreadId } : {},
+  ).catch(() => {})
 
   // Parse explicit prefixes first. `/steer ` / `/s ` opts IN to steering;
   // `/queue ` / `/q ` are legacy aliases that opt in to the new default (queued).
@@ -11088,10 +11101,14 @@ function resolveBootChatId(
   // → behavior unchanged (lands at chat-root as today). PR4b of
   // supergroup-mode rollout (docs/rfcs/supergroup-mode.md).
   const supergroupBootTopic = resolveAgentOutboundTopic({ kind: 'boot' })
+  const bootSupergroup = resolveAgentSupergroupChatId()
+  // The boot topic is valid only in the agent's supergroup — attach it per
+  // recipient so a DM owner doesn't 400 (marko #2096 class); the supergroup
+  // owner gets the boot/alerts lane, a DM gets a thread-less boot card.
 
   // 2. Env var
   const envChat = process.env.SUBAGENT_OWNER_CHAT_ID
-  if (envChat) return { chatId: envChat, threadId: supergroupBootTopic, ackMsgId: undefined }
+  if (envChat) return { chatId: envChat, threadId: topicForRecipient({ recipientChatId: envChat, resolvedTopic: supergroupBootTopic, supergroupChatId: bootSupergroup }), ackMsgId: undefined }
   // 3. Most-recent inbound from history
   if (HISTORY_ENABLED) {
     try {
@@ -11099,7 +11116,7 @@ function resolveBootChatId(
       const ownerChatId = access.allowFrom[0]
       if (ownerChatId) {
         const recent = queryHistory({ chat_id: ownerChatId, limit: 1 })
-        if (recent.length > 0) return { chatId: ownerChatId, threadId: supergroupBootTopic, ackMsgId: undefined }
+        if (recent.length > 0) return { chatId: ownerChatId, threadId: topicForRecipient({ recipientChatId: ownerChatId, resolvedTopic: supergroupBootTopic, supergroupChatId: bootSupergroup }), ackMsgId: undefined }
       }
     } catch {}
   }


### PR DESCRIPTION
## Summary
From the DM-hardcoding → supergroup audit (gaps #3 + #4). Two ops-lane outbound paths attach a supergroup-resolved topic to operator **DM** recipients **without** the per-recipient guard — the same latent `400 message thread not found` class #2096 fixed for approval cards, except here the event **silently fails to deliver** for a supergroup-owned agent (DM `allowFrom`):
- **operator-event broadcast** (boot-crash / restart-watchdog / model-unavailable) — topic attached to every `allowFrom` chat unconditionally.
- **boot card** — topic attached to `envChat` / `allowFrom[0]` unconditionally.

Both now route through `topicForRecipient({recipientChatId, resolvedTopic, supergroupChatId})`: a DM recipient gets a **thread-less** send (no 400); the supergroup owner gets the boot/alerts lane. **No destination redesign** — DM-config agents are byte-identical.

Plus #4: the main `handleInbound` **typing** indicator was un-threaded → showed in General on a supergroup-topic inbound. Now carries the inbound's `message_thread_id`.

## Scope notes (verified during the audit re-check)
- The audit's "marko wedge in approval emitters" and "reactions in wrong topic" findings were **false** (already guarded by #2096; `setMessageReaction` has no thread param). This PR is the *genuinely-unguarded* ops-lane subset.
- The early-ack typing is already DM-only-guarded (not a gap). The fleet auto-fallback broadcast is *deliberately* DM-only/no-thread (no 400) — routing it to the alerts lane is a destination-design choice, deferred with the slot-banner (#421).

## Test plan
- [x] `tsc --noEmit` + `check-bot-api-wrapping.sh` clean
- [x] `topicForRecipient` already unit-tested (`topic-router.test.ts`); wiring verified by tsc
- [ ] Canary: a supergroup agent fires a boot/operator-event → lands (no silent 400)

## Risk
Low — DM agents unchanged (guard returns undefined → no thread, exactly today's behavior); only ever *removes* an invalid thread or routes a supergroup recipient correctly. 1 of the supergroup-gap PR series (vault-grant #2 + setup/docs #1 follow).