### PR TITLE
fix(telegram): route vault grant/save/secret outcomes back to the work topic

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -2913,6 +2913,10 @@ interface PendingVaultRequestSave {
   chat_id: string
   /** Card message id (filled in after we send the card). */
   card_message_id?: number
+  /** Supergroup forum topic the agent was working in when it requested the
+   *  save — carried into the save-outcome inbound so the resumed reply lands
+   *  back in that topic, not General. */
+  threadId?: number
   /** Currently-suggested slug; may be renamed by the user. */
   key: string
   /** Storage shape — 'string' (default) or 'binary'. */
@@ -2954,6 +2958,10 @@ interface PendingVaultRequestAccess {
   chat_id: string
   /** Card message id (filled in after we send the card). */
   card_message_id?: number
+  /** Supergroup forum topic the agent was working in when it requested (the
+   *  card's originating thread). Carried into the grant-outcome inbound so the
+   *  resumed reply lands back in that topic, not General. */
+  threadId?: number
   /** Vault key the agent wants to read. */
   key: string
   /** 'read' (default) or 'write'. */
@@ -7080,6 +7088,8 @@ async function executeVaultRequestSave(args: Record<string, unknown>): Promise<{
   // crashing the tool call.
   const text = renderVaultRequestSaveCard(pending, agentSlug)
   const threadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
+  // Remember the agent's working topic so the save-outcome inbound resumes in it.
+  if (threadId != null) pending.threadId = threadId
   const sent = await retryWithThreadFallback<{ message_id: number }>(
     robustApiCall,
     (tid) =>
@@ -7120,12 +7130,16 @@ interface PendingSecretRequest {
   reason?: string
   staged_at: number
   card_message_id?: number
+  /** Supergroup forum topic the agent was working in — carried into the
+   *  provide/decline/fail outcome inbounds so the resumed reply lands back
+   *  in that topic, not General. */
+  threadId?: number
 }
 // stageId -> request (lives until tapped or TTL).
 const pendingSecretRequests = new Map<string, PendingSecretRequest>()
 // chat_id -> the armed capture: the operator's NEXT message in this chat is
 // the value for `key`. Set when [Provide securely] is tapped.
-interface ArmedSecretCapture { key: string; agent: string; stageId: string; armed_at: number }
+interface ArmedSecretCapture { key: string; agent: string; stageId: string; armed_at: number; threadId?: number }
 const armedSecretCaptures = new Map<string, ArmedSecretCapture>()
 const PENDING_SECRET_REQUEST_TTL_MS = 30 * 60_000 // card lifetime
 const ARMED_SECRET_CAPTURE_TTL_MS = 10 * 60_000   // window to send the value after tapping
@@ -7194,6 +7208,8 @@ async function executeRequestSecret(args: Record<string, unknown>): Promise<{ co
 
   const text = renderSecretRequestCard(pending)
   const threadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
+  // Remember the agent's working topic so the provide/decline/fail inbound resumes in it.
+  if (threadId != null) pending.threadId = threadId
   const sent = await retryWithThreadFallback<{ message_id: number }>(
     robustApiCall,
     (tid) =>
@@ -7269,12 +7285,19 @@ async function captureProvidedSecret(
     const failMsg: InboundMessage = {
       type: 'inbound',
       chatId: chat_id,
+      ...(armed.threadId != null ? { threadId: armed.threadId } : {}),
       messageId: fts,
       user: 'vault-broker',
       userId: 0,
       ts: fts,
       text: `⚠️ The secret you requested for \`vault:${armed.key}\` could NOT be saved (vault write failed). Do not assume it is available; tell the operator or try request_secret again.`,
-      meta: { source: 'secret_provide_failed', agent: armed.agent, key: armed.key, stage_id: armed.stageId },
+      meta: {
+        source: 'secret_provide_failed',
+        agent: armed.agent,
+        ...(armed.threadId != null ? { message_thread_id: String(armed.threadId) } : {}),
+        key: armed.key,
+        stage_id: armed.stageId,
+      },
     }
     const fdelivered = ipcServer.sendToAgent(armed.agent, failMsg)
     if (fdelivered) markClaudeBusyForInbound(failMsg)
@@ -7294,6 +7317,7 @@ async function captureProvidedSecret(
   const synthetic: InboundMessage = {
     type: 'inbound',
     chatId: chat_id,
+    ...(armed.threadId != null ? { threadId: armed.threadId } : {}),
     messageId: ts,
     user: 'vault-broker',
     userId: 0,
@@ -7305,6 +7329,7 @@ async function captureProvidedSecret(
     meta: {
       source: 'secret_provided',
       agent: armed.agent,
+      ...(armed.threadId != null ? { message_thread_id: String(armed.threadId) } : {}),
       key: armed.key,
       stage_id: armed.stageId,
     },
@@ -7345,6 +7370,7 @@ async function handleSecretRequestCallback(ctx: Context, data: string): Promise<
       agent: pending.agent,
       stageId,
       armed_at: Date.now(),
+      ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
     })
     await ctx.answerCallbackQuery({ text: 'Send the value now — it auto-deletes.' }).catch(() => {})
     if (pending.card_message_id != null) {
@@ -7377,12 +7403,19 @@ async function handleSecretRequestCallback(ctx: Context, data: string): Promise<
     const synthetic: InboundMessage = {
       type: 'inbound',
       chatId: pending.chat_id,
+      ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
       messageId: ts,
       user: 'vault-broker',
       userId: 0,
       ts,
       text: `🚫 Operator declined your request for \`vault:${pending.key}\`. Proceed without it or ask how they'd like to handle the task.`,
-      meta: { source: 'secret_declined', agent: pending.agent, key: pending.key, stage_id: stageId },
+      meta: {
+        source: 'secret_declined',
+        agent: pending.agent,
+        ...(pending.threadId != null ? { message_thread_id: String(pending.threadId) } : {}),
+        key: pending.key,
+        stage_id: stageId,
+      },
     }
     const delivered = ipcServer.sendToAgent(pending.agent, synthetic)
     if (delivered) markClaudeBusyForInbound(synthetic)
@@ -7530,6 +7563,8 @@ async function executeVaultRequestAccess(args: Record<string, unknown>): Promise
 
   const text = renderVaultRequestAccessCard(pending)
   const threadId = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
+  // Remember the agent's working topic so the grant-outcome inbound resumes in it.
+  if (threadId != null) pending.threadId = threadId
   // #1075: deleted-topic safe — fall back to main chat.
   const sent = await retryWithThreadFallback<{ message_id: number }>(
     robustApiCall,
@@ -14023,6 +14058,7 @@ async function performVaultAccessApproval(
       scope: pending.scope,
       chat_id: pending.chat_id,
       ttl_seconds: pending.ttl_seconds,
+      ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
     },
     grantId: id,
     stageId,
@@ -14104,6 +14140,7 @@ async function handleVaultRequestAccessCallback(ctx: Context, data: string): Pro
         scope: pending.scope,
         chat_id: pending.chat_id,
         ttl_seconds: pending.ttl_seconds,
+        ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
       },
       stageId,
       operatorId: senderId,
@@ -14278,7 +14315,12 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
     // tool returned "waiting for operator", the turn ended, and a
     // Discard left the agent silently idle forever.
     const discardInbound = buildVaultSaveDiscardedInbound({
-      ctx: { agent: pending.agent, key: pending.key, chat_id: pending.chat_id },
+      ctx: {
+        agent: pending.agent,
+        key: pending.key,
+        chat_id: pending.chat_id,
+        ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
+      },
       stageId,
       operatorId: senderId,
     })
@@ -14401,7 +14443,12 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
       const failReason =
         (write.output || 'vault write error').split('\n')[0]!.slice(0, 200)
       const failInbound = buildVaultSaveFailedInbound({
-        ctx: { agent: pending.agent, key: pending.key, chat_id: pending.chat_id },
+        ctx: {
+          agent: pending.agent,
+          key: pending.key,
+          chat_id: pending.chat_id,
+          ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
+        },
         stageId,
         operatorId: senderId,
         reason: failReason,
@@ -14432,7 +14479,12 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
     // task that was blocked on this credential (symmetric with the
     // vra: approve path; buffered if the bridge is mid-reconnect).
     const okInbound = buildVaultSaveCompletedInbound({
-      ctx: { agent: pending.agent, key: pending.key, chat_id: pending.chat_id },
+      ctx: {
+        agent: pending.agent,
+        key: pending.key,
+        chat_id: pending.chat_id,
+        ...(pending.threadId != null ? { threadId: pending.threadId } : {}),
+      },
       stageId,
       operatorId: senderId,
     })

--- a/telegram-plugin/gateway/vault-grant-inbound-builders.ts
+++ b/telegram-plugin/gateway/vault-grant-inbound-builders.ts
@@ -34,6 +34,10 @@ export interface VaultGrantInboundContext {
   chat_id: string
   /** Seconds. For approved grants; ignored for deny. */
   ttl_seconds: number
+  /** Supergroup forum topic (message_thread_id) the agent was working in
+   *  when it requested the credential — so the resumed turn's reply lands
+   *  back in that topic, not General. Undefined for DM / non-topic requests. */
+  threadId?: number
 }
 
 /**
@@ -62,6 +66,7 @@ export function buildVaultGrantApprovedInbound(opts: {
   return {
     type: 'inbound',
     chatId: opts.ctx.chat_id,
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
     messageId: ts, // synthetic — no Telegram message id exists
     user: 'vault-broker',
     userId: 0,
@@ -76,6 +81,7 @@ export function buildVaultGrantApprovedInbound(opts: {
     meta: {
       source: 'vault_grant_approved',
       agent: opts.ctx.agent,
+      ...(opts.ctx.threadId != null ? { message_thread_id: String(opts.ctx.threadId) } : {}),
       key: opts.ctx.key,
       scope: opts.ctx.scope,
       grant_id: opts.grantId,
@@ -103,6 +109,7 @@ export function buildVaultGrantDeniedInbound(opts: {
   return {
     type: 'inbound',
     chatId: opts.ctx.chat_id,
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
     messageId: ts,
     user: 'vault-broker',
     userId: 0,
@@ -116,6 +123,7 @@ export function buildVaultGrantDeniedInbound(opts: {
     meta: {
       source: 'vault_grant_denied',
       agent: opts.ctx.agent,
+      ...(opts.ctx.threadId != null ? { message_thread_id: String(opts.ctx.threadId) } : {}),
       key: opts.ctx.key,
       scope: opts.ctx.scope,
       stage_id: opts.stageId,
@@ -133,6 +141,9 @@ export interface VaultSaveInboundContext {
   /** Telegram chat the save card lived in — keeps the synthesized
    *  resume-turn associated with the originating conversation. */
   chat_id: string
+  /** Supergroup forum topic the agent was working in when it requested the
+   *  save — so the resumed reply lands in that topic, not General. */
+  threadId?: number
 }
 
 /**
@@ -154,6 +165,7 @@ export function buildVaultSaveCompletedInbound(opts: {
   return {
     type: 'inbound',
     chatId: opts.ctx.chat_id,
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
     messageId: ts,
     user: 'vault-broker',
     userId: 0,
@@ -165,6 +177,7 @@ export function buildVaultSaveCompletedInbound(opts: {
     meta: {
       source: 'vault_save_completed',
       agent: opts.ctx.agent,
+      ...(opts.ctx.threadId != null ? { message_thread_id: String(opts.ctx.threadId) } : {}),
       key: opts.ctx.key,
       stage_id: opts.stageId,
       operator_id: opts.operatorId,
@@ -187,6 +200,7 @@ export function buildVaultSaveFailedInbound(opts: {
   return {
     type: 'inbound',
     chatId: opts.ctx.chat_id,
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
     messageId: ts,
     user: 'vault-broker',
     userId: 0,
@@ -200,6 +214,7 @@ export function buildVaultSaveFailedInbound(opts: {
     meta: {
       source: 'vault_save_failed',
       agent: opts.ctx.agent,
+      ...(opts.ctx.threadId != null ? { message_thread_id: String(opts.ctx.threadId) } : {}),
       key: opts.ctx.key,
       stage_id: opts.stageId,
       operator_id: opts.operatorId,
@@ -221,6 +236,7 @@ export function buildVaultSaveDiscardedInbound(opts: {
   return {
     type: 'inbound',
     chatId: opts.ctx.chat_id,
+    ...(opts.ctx.threadId != null ? { threadId: opts.ctx.threadId } : {}),
     messageId: ts,
     user: 'vault-broker',
     userId: 0,
@@ -234,6 +250,7 @@ export function buildVaultSaveDiscardedInbound(opts: {
     meta: {
       source: 'vault_save_discarded',
       agent: opts.ctx.agent,
+      ...(opts.ctx.threadId != null ? { message_thread_id: String(opts.ctx.threadId) } : {}),
       key: opts.ctx.key,
       stage_id: opts.stageId,
       operator_id: opts.operatorId,

--- a/telegram-plugin/tests/vault-grant-inbound-builders.test.ts
+++ b/telegram-plugin/tests/vault-grant-inbound-builders.test.ts
@@ -16,7 +16,11 @@ import { describe, it, expect } from 'vitest'
 import {
   buildVaultGrantApprovedInbound,
   buildVaultGrantDeniedInbound,
+  buildVaultSaveCompletedInbound,
+  buildVaultSaveFailedInbound,
+  buildVaultSaveDiscardedInbound,
   type VaultGrantInboundContext,
+  type VaultSaveInboundContext,
 } from '../gateway/vault-grant-inbound-builders.js'
 
 const FIXED_NOW = 1_700_000_000_000
@@ -223,4 +227,84 @@ describe('approve vs deny shape invariants', () => {
     expect(String(approve.meta?.source)).toMatch(/^vault_grant_approved$/)
     expect(String(deny.meta?.source)).toMatch(/^vault_grant_denied$/)
   })
+})
+
+// ── Supergroup topic routing (gap #2) ──────────────────────────────────────
+//
+// When the agent requested the credential from inside a forum topic, the
+// grant/save-outcome inbound must carry that topic so the resumed turn's
+// reply lands back in it — not General. The carrier is two-fold and BOTH
+// halves are load-bearing:
+//   - top-level `threadId` → the gateway's per-topic busy-key / deliver-
+//     until-acked keying (markClaudeBusyForInbound reads it).
+//   - `meta.message_thread_id` (stringified) → rendered into the
+//     `<channel message_thread_id="…">` XML, which session-tail's
+//     parseChannelMeta re-extracts to set currentTurn.sessionThreadId, which
+//     the reply tool defaults to. Drop either and the reply mis-routes.
+//
+// DM / non-topic requests must leave BOTH absent (an empty-string or 0
+// thread is a Telegram 400 "message thread not found").
+describe('grant/save outcome topic routing', () => {
+  const SAVE_CTX: VaultSaveInboundContext = {
+    agent: 'marko',
+    key: 'brevo/api-key',
+    chat_id: '-1001234567890',
+  }
+  const THREAD = 4242
+
+  const grantBuilders = [
+    {
+      name: 'approved',
+      build: (ctx: VaultGrantInboundContext) =>
+        buildVaultGrantApprovedInbound({ ctx, grantId: 'vg_x', stageId: 's', operatorId: '1' }),
+    },
+    {
+      name: 'denied',
+      build: (ctx: VaultGrantInboundContext) =>
+        buildVaultGrantDeniedInbound({ ctx, stageId: 's', operatorId: '1' }),
+    },
+  ]
+  const saveBuilders = [
+    {
+      name: 'save-completed',
+      build: (ctx: VaultSaveInboundContext) =>
+        buildVaultSaveCompletedInbound({ ctx, stageId: 's', operatorId: '1' }),
+    },
+    {
+      name: 'save-failed',
+      build: (ctx: VaultSaveInboundContext) =>
+        buildVaultSaveFailedInbound({ ctx, stageId: 's', operatorId: '1', reason: 'disk full' }),
+    },
+    {
+      name: 'save-discarded',
+      build: (ctx: VaultSaveInboundContext) =>
+        buildVaultSaveDiscardedInbound({ ctx, stageId: 's', operatorId: '1' }),
+    },
+  ]
+
+  for (const { name, build } of grantBuilders) {
+    it(`${name}: threadId set → top-level threadId + meta.message_thread_id (stringified)`, () => {
+      const msg = build({ ...CTX_READ, threadId: THREAD })
+      expect(msg.threadId).toBe(THREAD)
+      expect(msg.meta?.message_thread_id).toBe(String(THREAD))
+    })
+    it(`${name}: threadId absent → both omitted (DM stays thread-less)`, () => {
+      const msg = build(CTX_READ)
+      expect(msg.threadId).toBeUndefined()
+      expect(msg.meta?.message_thread_id).toBeUndefined()
+    })
+  }
+
+  for (const { name, build } of saveBuilders) {
+    it(`${name}: threadId set → top-level threadId + meta.message_thread_id (stringified)`, () => {
+      const msg = build({ ...SAVE_CTX, threadId: THREAD })
+      expect(msg.threadId).toBe(THREAD)
+      expect(msg.meta?.message_thread_id).toBe(String(THREAD))
+    })
+    it(`${name}: threadId absent → both omitted (DM stays thread-less)`, () => {
+      const msg = build(SAVE_CTX)
+      expect(msg.threadId).toBeUndefined()
+      expect(msg.meta?.message_thread_id).toBeUndefined()
+    })
+  }
 })


### PR DESCRIPTION
## Summary

Supergroup mode follow-up (gap #2 of the DM-hardcoding→supergroup audit). When an agent fires `vault_request_access`, `vault_request_save`, or `request_secret` from inside a forum topic, the synthetic wake-up inbound the gateway injects after the operator taps **Approve / Save / Provide** carried **no thread** — so the resumed turn's reply landed in **General** instead of the topic the agent was working in.

This threads the originating topic end-to-end across all three credential flows.

## Why

This is the same class as #2096 (approval-card THREAD_NOT_FOUND) and #2098 (cron synthesized inbounds), but for the *resume* side of the vault/secret request flows. An agent working in topic *X* that needs a credential would, after approval, reply in General — invisible in the topic where the work lives. Supergroup mode (`channels.telegram.chat_id` + `default_topic_id`) makes this user-visible; DM agents were unaffected (no threads).

## What changed

Each pending-request struct captures the working topic at card-post time (`args.message_thread_id`):
- `PendingVaultRequestAccess`, `PendingVaultRequestSave`, `PendingSecretRequest`, `ArmedSecretCapture` each gain an optional `threadId`.

Every outcome inbound now carries it **both ways** (the established two-carrier pattern):
- **top-level `threadId`** → drives the gateway's per-topic busy-key / deliver-until-acked keying (`markClaudeBusyForInbound`).
- **`meta.message_thread_id`** (stringified) → rendered into the `<channel message_thread_id="…">` envelope, which `session-tail`'s `parseChannelMeta` re-extracts to set `currentTurn.sessionThreadId`, which the reply tool defaults to.

Covers the 8 outcome inbounds across the three flows: `vault_grant_approved`, `vault_grant_denied`, `vault_save_completed`, `vault_save_failed`, `vault_save_discarded`, `secret_provided`, `secret_provide_failed`, `secret_declined`.

**Purely additive** — DM / non-topic requests leave both fields absent, so the thread-less send is unchanged (an empty/0 thread is a Telegram 400 "message thread not found").

## Test plan

- [x] `vault-grant-inbound-builders.test.ts`: 10 new cases pin `threadId` set → top-level `threadId` + stringified `meta.message_thread_id` on all 5 builders, and `threadId` absent → both omitted (DM stays thread-less). 23 pass.
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean
- [x] adjacent vault / channel-envelope / session-tail suites green

## Risk

Low — optional field, no behavior change on the DM path. Worst case under a bug would be a thread-less send (current behavior), never a crash.

JTBD: *always-available specialist that holds the leash* — credential approvals resume the conversation where the user is looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)