### PR TITLE
feat(setup): discoverable supergroup mode — wizard step, example, guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ operators jump to **Operating**; contributors and reviewers use
 | [status-ask-cause-classes.md](status-ask-cause-classes.md) | Cause-class catalog for driving the status-ask rate to zero. |
 | [session-optimization.md](session-optimization.md) | Managing context/tokens in long-running agents. |
 | [sub-agents.md](sub-agents.md) | Sub-agent delegation ("Opus plans, Sonnet implements"). |
+| [supergroup-mode.md](supergroup-mode.md) | One agent owns a Telegram forum supergroup, routing work into per-topic threads (opt-in). |
 | [google-workspace.md](google-workspace.md) | Agents reading Google Docs/Sheets/Slides/folders. |
 | [webhook-ingest.md](webhook-ingest.md) | Pushing external events into a specific agent's log. |
 | [posthog.md](posthog.md) | Telemetry: product analytics + error tracking via PostHog. |

--- a/docs/supergroup-mode.md
+++ b/docs/supergroup-mode.md
@@ -1,0 +1,125 @@
+# Supergroup mode
+
+By default every switchroom agent talks to you in a **private DM** — one
+bot, one chat. **Supergroup mode** is the alternative topology: a single
+agent **owns a Telegram forum supergroup** and routes all of its traffic —
+your conversations *and* its automated events — into **per-topic threads**
+inside that one group.
+
+Use it when one agent does enough varied work that a flat DM becomes a
+firehose. A marketing agent, say, can keep "Meta Campaigns", "CRM", and
+"Planning" as separate topics, so each thread reads as its own focused
+conversation instead of an interleaved scroll.
+
+DM mode stays the default and needs zero of this. Supergroup mode is
+opt-in and per-agent — you can run a mixed fleet (most agents DM, one owns
+a supergroup).
+
+> Internals and the routing design live in
+> [rfcs/supergroup-mode.md](rfcs/supergroup-mode.md) and
+> [rfcs/supergroup-easy-defaults.md](rfcs/supergroup-easy-defaults.md).
+> This page is the operator how-to.
+
+## What you get
+
+When an agent owns a supergroup:
+
+- **Replies follow the conversation.** A message you send in the "CRM"
+  topic gets answered in the "CRM" topic — the agent threads its reply
+  back to the topic the inbound came from.
+- **Automated events route by class.** Boot cards, watchdog alerts, and
+  compaction notices go to your `alerts` topic; vault / permission /
+  fleet-mutation events go to your `admin` topic; everything else falls
+  back to General. You name those topics once (see `topic_aliases`).
+- **Cron picks its topic.** Each scheduled task can name the topic it
+  posts into — see [scheduling.md → Targeting a forum
+  topic](scheduling.md#targeting-a-forum-topic-supergroup-owned-agents).
+
+## Set it up
+
+### 1. Create the supergroup in Telegram
+
+In Telegram: create a **group**, open its settings, and enable **Topics**
+(this turns it into a *forum* supergroup). Add the agent's bot as an
+**admin** with permission to manage topics and send messages. Create the
+topics you want (e.g. *General*, *Planning*, *Alerts*, *Admin*).
+
+> One agent, one supergroup. Each agent that owns a supergroup needs its
+> **own** BotFather bot — the same rule as DM agents.
+
+### 2. Find the numeric ids
+
+- **Supergroup `chat_id`** — open any message in the group and copy its
+  link (`t.me/c/<id>/<thread>/<msg>`). The `<id>` is your supergroup,
+  written with a `-100` prefix: link id `1234567890` → `chat_id:
+  "-1001234567890"`. It is always a **negative integer as a string**.
+- **Topic `thread_id`** — open the topic and read the trailing number in a
+  message link, or read it off an inbound the agent already received in
+  that topic. **General is always thread `1`.**
+
+### 3. Configure the agent
+
+`switchroom setup` offers this as an **optional step** ("Supergroup mode")
+— answer yes, pick the agent, and paste the `chat_id`. That writes the one
+required field for you; you add the topic names afterward.
+
+Or edit `switchroom.yaml` by hand:
+
+```yaml
+agents:
+  social:
+    topic_name: "Social"
+    bot_token: "vault:telegram-social-bot-token"   # its own bot
+    channels:
+      telegram:
+        chat_id: "-1001234567890"   # the forum supergroup this agent owns
+        default_topic_id: 1         # fallback topic (1 = General); optional
+        topic_aliases:              # name → topic id
+          alerts: 12                # boot / watchdog / compaction events
+          admin: 7                  # vault / permission / mutation events
+          planning: 3
+```
+
+Only `chat_id` is required. When you omit `default_topic_id`, switchroom
+smart-defaults it to **General (topic 1)**. `topic_aliases` is optional —
+add it to route automated events and to give cron entries friendly topic
+names. Aliases are validated at config load, so a typo fails `switchroom
+apply` instead of mis-routing silently.
+
+### 4. Apply
+
+```bash
+switchroom apply              # regenerate compose + scaffold
+switchroom agent restart social --wait --force
+```
+
+Send a message in one of the topics and confirm the reply threads back
+into the same topic.
+
+## Field reference
+
+| Field | Required | Default | Meaning |
+|---|---|---|---|
+| `channels.telegram.chat_id` | Yes (to enable) | — | The forum supergroup this agent owns. Negative integer as a string (e.g. `"-1001234567890"`). Setting it is what turns supergroup mode on. Forbidden when `dm_only: true`. |
+| `channels.telegram.default_topic_id` | No | `1` (General) | The forum topic untargeted outbounds fall back to. Auto-defaults to General when `chat_id` is set. |
+| `channels.telegram.topic_aliases` | No | `{}` | `name → numeric thread_id` map. Referenced by automated-event routing (`alerts`, `admin`) and per-cron `topic:` fields. |
+
+## Notes & gotchas
+
+- **DM agents are unaffected.** No `chat_id` → DM mode, exactly as before.
+  An empty/0 thread id is a Telegram `400 message thread not found`, so
+  switchroom never attaches a topic to a DM send.
+- **`dm_only: true` and `chat_id` are mutually exclusive** — the schema
+  rejects setting both.
+- **Reserved alias names** `alerts` and `admin` drive automated-event
+  routing. Other alias names are free for your own cron targeting.
+- **Discovering topic ids has no CLI shortcut yet** — use the
+  message-link method above. (The General topic is always `1`.)
+
+## See also
+
+- [scheduling.md](scheduling.md) — per-cron topic targeting.
+- [configuration.md](configuration.md) — the full `switchroom.yaml`
+  cascade.
+- [rfcs/supergroup-mode.md](rfcs/supergroup-mode.md) — design + routing
+  internals.

--- a/examples/switchroom.yaml
+++ b/examples/switchroom.yaml
@@ -285,3 +285,29 @@ agents:
   #   admin: true
   #   system_prompt_append: |
   #     You are the fleet admin agent. Always respond concisely.
+
+  # ── Supergroup mode (advanced, opt-in) ───────────────────────────
+  # By default every agent DMs you privately. Supergroup mode instead
+  # has ONE agent OWN a Telegram forum supergroup: its replies and its
+  # automated events (boot, alerts, cron, approvals) route into per-
+  # topic threads inside that one group, so a busy agent's work stays
+  # organised by subject instead of flooding a single DM.
+  #
+  # `switchroom setup` offers this as an optional step, or add it by
+  # hand below. Setting `chat_id` is the minimum — `default_topic_id`
+  # auto-defaults to General (topic 1). Create the forum supergroup in
+  # Telegram first, add the bot as an admin, and find the numeric id
+  # (the digits after t.me/c/ in a message link, written as -100…).
+  # Full guide: docs/supergroup-mode.md.
+  #
+  # social:
+  #   topic_name: "Social"
+  #   bot_token: "vault:telegram-social-bot-token"   # its own bot
+  #   channels:
+  #     telegram:
+  #       chat_id: "-1001234567890"   # the forum supergroup this agent owns
+  #       default_topic_id: 1         # fallback topic (1 = General); optional
+  #       topic_aliases:              # name → topic id, for cron + ops routing
+  #         alerts: 12                # boot / watchdog / compaction events
+  #         admin: 7                  # vault / permission / mutation events
+  #         planning: 3

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -45,6 +45,10 @@ import {
 } from "../setup/prompt.js";
 import { captureEvent, captureException } from "../analytics/posthog.js";
 import { insertVaultBrokerApprovalAuth } from "./setup-posture-rewrite.js";
+import {
+  isValidSupergroupChatId,
+  setAgentSupergroupChatId,
+} from "./supergroup-setup-yaml.js";
 
 const STEP_PENDING = chalk.gray("○");
 const STEP_ACTIVE = chalk.blue("->");
@@ -103,11 +107,14 @@ export function registerSetupCommand(program: Command): void {
           saveUserConfig(userId);
         }
 
-        // ── Step 4: (group/forum setup retired in v0.7) ──────────
-        // Per-agent bot DM-only is the default. Sentinel "0" lands in
-        // scaffolded access.json wherever a forum chat ID was previously
-        // stored; the schema still requires `telegram.forum_chat_id`,
-        // and existing configs that set a real one continue to work.
+        // ── Step 4: Supergroup mode (optional) ───────────────────
+        // Per-agent bot DM-only is still the default. This optional step
+        // lets ONE agent own a Telegram forum supergroup by writing
+        // `agents.<name>.channels.telegram.chat_id`. Skipped by default
+        // (one keystroke) so the zero-config DM path is untouched. The
+        // fleet-wide `telegram.forum_chat_id` sentinel "0" below is the
+        // legacy DM-only marker, unrelated to per-agent supergroup mode.
+        await stepSupergroupMode(agentBots, switchroomConfigPath, nonInteractive);
         const forumChatId = "0";
 
         // ── Step 5: Create topics ────────────────────────────────
@@ -590,10 +597,142 @@ async function stepDmPairing(
   }
 }
 
-// ─── Step 4: retired in v0.7 ─────────────────────────────────────────────────
-// Forum/group setup prompts were removed when per-agent bot DM-only became
-// the default. Existing configs with a real `telegram.forum_chat_id` keep
-// working; new setups land sentinel "0" via `stepScaffoldAgents` below.
+// ─── Step 4: Supergroup mode (optional) ──────────────────────────────────────
+//
+// DM-only is the default and stays one keystroke away (the prompt defaults to
+// "no"). This step exists for discoverability: an operator setting up should
+// learn supergroup mode is available and be able to flip a single agent into
+// it without hand-editing YAML or hunting through docs. It writes only
+// `agents.<name>.channels.telegram.chat_id` — the schema smart-defaults
+// `default_topic_id` to General — and points at docs/supergroup-mode.md
+// for the richer knobs (default_topic_id, topic_aliases, ops-lane routing).
+const SUPERGROUP_DOC = "docs/supergroup-mode.md";
+
+async function stepSupergroupMode(
+  agentBots: Record<string, BotTokenInfo>,
+  configPath: string,
+  nonInteractive: boolean,
+): Promise<void> {
+  stepHeader(4, "Supergroup mode (optional)", STEP_ACTIVE);
+
+  if (nonInteractive) {
+    console.log(
+      chalk.gray(
+        `  ${STEP_DONE} Skipped (DM-only default). To have one agent own a forum`,
+      ),
+    );
+    console.log(chalk.gray(`     supergroup, see ${SUPERGROUP_DOC}.`));
+    return;
+  }
+
+  console.log(
+    chalk.gray(
+      "  Most setups stay DM-only — each agent DMs you privately. Supergroup",
+    ),
+  );
+  console.log(
+    chalk.gray(
+      "  mode instead has ONE agent own a Telegram forum supergroup and route",
+    ),
+  );
+  console.log(
+    chalk.gray("  its replies + automated events into per-topic threads. Opt-in."),
+  );
+
+  const want = await askYesNo(
+    "  Configure an agent to own a forum supergroup now?",
+    false,
+  );
+  if (!want) {
+    console.log(
+      chalk.gray(`  ${STEP_DONE} Staying DM-only. Enable later via ${SUPERGROUP_DOC}.`),
+    );
+    return;
+  }
+
+  const agentNames = Object.keys(agentBots);
+  if (agentNames.length === 0) {
+    console.log(
+      chalk.yellow(`  No agents configured yet — skipping. See ${SUPERGROUP_DOC}.`),
+    );
+    return;
+  }
+  const agent =
+    agentNames.length === 1
+      ? agentNames[0]
+      : await askChoice("  Which agent owns the supergroup?", agentNames);
+
+  console.log(
+    chalk.gray(
+      "  First create the forum supergroup in Telegram (a group with Topics",
+    ),
+  );
+  console.log(
+    chalk.gray(
+      "  enabled) and add the agent's bot as an admin. Its id is the digits in",
+    ),
+  );
+  console.log(
+    chalk.gray(
+      "  a message link t.me/c/<id>/… written as a negative -100… number.",
+    ),
+  );
+
+  const chatId = await ask(
+    "  Supergroup chat_id (e.g. -1001234567890, or Enter to skip)",
+  );
+  if (!chatId) {
+    console.log(
+      chalk.gray(`  ${STEP_DONE} Skipped — no chat_id entered. See ${SUPERGROUP_DOC}.`),
+    );
+    return;
+  }
+  if (!isValidSupergroupChatId(chatId)) {
+    console.log(
+      chalk.yellow(
+        `  "${chatId}" isn't a valid supergroup id (need a negative integer like`,
+      ),
+    );
+    console.log(
+      chalk.yellow(`  -1001234567890). Add it by hand later — ${SUPERGROUP_DOC}.`),
+    );
+    return;
+  }
+
+  try {
+    const fs = await import("node:fs");
+    const { atomicWriteFileSync } = await import("../util/atomic.js");
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const after = setAgentSupergroupChatId(raw, agent, chatId);
+    let mode = 0o644;
+    try {
+      mode = fs.statSync(configPath).mode & 0o777;
+    } catch {
+      /* default */
+    }
+    atomicWriteFileSync(configPath, after, mode);
+    console.log(
+      chalk.green(
+        `  ${STEP_DONE} ${agent} now owns supergroup ${chatId} — replies + ops route to its topics.`,
+      ),
+    );
+    console.log(
+      chalk.gray(
+        "     Fallback topic defaults to General (1). Add default_topic_id /",
+      ),
+    );
+    console.log(
+      chalk.gray(
+        `     topic_aliases by hand — ${SUPERGROUP_DOC}. Run \`switchroom apply\` to activate.`,
+      ),
+    );
+  } catch (err) {
+    console.log(
+      chalk.yellow(`  Could not write chat_id: ${(err as Error).message}`),
+    );
+    console.log(chalk.gray(`  Add it by hand — see ${SUPERGROUP_DOC}.`));
+  }
+}
 
 // ─── Step 5: Create Topics ───────────────────────────────────────────────────
 

--- a/src/cli/supergroup-setup-yaml.ts
+++ b/src/cli/supergroup-setup-yaml.ts
@@ -1,0 +1,81 @@
+/**
+ * YAML editor for the per-agent `agents.<name>.channels.telegram.chat_id`
+ * field — the one knob that flips an agent into supergroup-owned mode.
+ *
+ * Pure module — string-in / string-out — so the setup wizard can read the
+ * existing file, mutate, and atomic-write the result without losing
+ * comments or surrounding formatting. Mirrors `auth-active-yaml.ts`.
+ *
+ * Setting `chat_id` is the minimum to activate supergroup mode: the
+ * config schema smart-defaults `default_topic_id` to General (topic 1)
+ * when `chat_id` is present and `default_topic_id` is omitted
+ * (`src/config/schema.ts`), so the wizard only needs to write the chat_id.
+ * `default_topic_id` and `topic_aliases` are left for the operator to add
+ * by hand — see `docs/supergroup-mode.md`.
+ */
+
+import { parseDocument, isMap } from "yaml";
+
+/**
+ * A Telegram supergroup id is a negative integer rendered as a string
+ * (e.g. "-1001234567890"). Same shape the schema enforces — validate
+ * here so the wizard never writes a malformed value to disk.
+ */
+export function isValidSupergroupChatId(value: string): boolean {
+  return /^-\d+$/.test(value);
+}
+
+/**
+ * Set `agents.<agentName>.channels.telegram.chat_id: <chatId>` in the
+ * YAML text, creating the `channels` / `channels.telegram` maps if
+ * missing while preserving any existing siblings and comments.
+ * Idempotent — returns the input verbatim when the value already matches.
+ *
+ * Throws if the agent isn't present in the config (the caller is
+ * expected to offer only agents that already exist). Returns the new
+ * YAML text; the caller owns the atomic-write + mode preservation.
+ */
+export function setAgentSupergroupChatId(
+  yamlText: string,
+  agentName: string,
+  chatId: string,
+): string {
+  if (!isValidSupergroupChatId(chatId)) {
+    throw new Error(
+      `setAgentSupergroupChatId: chat_id must be a negative integer string (got "${chatId}")`,
+    );
+  }
+  const doc = parseDocument(yamlText);
+  const root = doc.contents;
+  if (!isMap(root)) {
+    throw new Error("setAgentSupergroupChatId: YAML root is not a map");
+  }
+  const agents = root.get("agents", true);
+  if (!isMap(agents)) {
+    throw new Error("setAgentSupergroupChatId: config has no `agents:` map");
+  }
+  const agent = agents.get(agentName, true);
+  if (!isMap(agent)) {
+    throw new Error(
+      `setAgentSupergroupChatId: agent "${agentName}" not found in config`,
+    );
+  }
+
+  // Coerce a null/scalar intermediate (e.g. a bare `channels:` key) to a
+  // fresh map — setIn/set crash otherwise, same hazard as auth-active-yaml.
+  const channels = agent.get("channels", true);
+  if (isMap(channels)) {
+    const telegram = channels.get("telegram", true);
+    if (isMap(telegram)) {
+      if (telegram.get("chat_id") === chatId) return yamlText; // idempotent
+      telegram.set("chat_id", chatId);
+    } else {
+      channels.set("telegram", doc.createNode({ chat_id: chatId }));
+    }
+  } else {
+    agent.set("channels", doc.createNode({ telegram: { chat_id: chatId } }));
+  }
+
+  const out = String(doc);
+  return out.endsWith("\n") ? out : out + "\n";
+}

--- a/tests/supergroup-setup-yaml.test.ts
+++ b/tests/supergroup-setup-yaml.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidSupergroupChatId,
+  setAgentSupergroupChatId,
+} from "../src/cli/supergroup-setup-yaml.js";
+import { parseDocument, parse } from "yaml";
+import { SwitchroomConfigSchema } from "../src/config/schema.js";
+
+describe("isValidSupergroupChatId", () => {
+  it("accepts a negative-integer string", () => {
+    expect(isValidSupergroupChatId("-1001234567890")).toBe(true);
+    expect(isValidSupergroupChatId("-100")).toBe(true);
+  });
+  it("rejects positive, zero, non-numeric, and decorated forms", () => {
+    for (const bad of ["1001234567890", "0", "-0x1", "-12.3", "", "abc", "-12 ", " -12"]) {
+      expect(isValidSupergroupChatId(bad)).toBe(false);
+    }
+  });
+});
+
+const BASE = `switchroom:
+  version: 1
+telegram:
+  bot_token: "vault:telegram-bot-token"
+  forum_chat_id: "0"
+agents:
+  marko:
+    topic_name: "Marko"
+  clerk:
+    topic_name: "Clerk"
+`;
+
+describe("setAgentSupergroupChatId", () => {
+  it("writes channels.telegram.chat_id under the named agent", () => {
+    const out = setAgentSupergroupChatId(BASE, "marko", "-1001234567890");
+    const doc = parseDocument(out);
+    expect(doc.getIn(["agents", "marko", "channels", "telegram", "chat_id"])).toBe(
+      "-1001234567890",
+    );
+    // The other agent is untouched.
+    expect(doc.getIn(["agents", "clerk", "channels"])).toBeUndefined();
+    // The topic_name sibling survives.
+    expect(doc.getIn(["agents", "marko", "topic_name"])).toBe("Marko");
+  });
+
+  it("is idempotent — same value returns the input verbatim", () => {
+    const once = setAgentSupergroupChatId(BASE, "marko", "-100777");
+    const twice = setAgentSupergroupChatId(once, "marko", "-100777");
+    expect(twice).toBe(once);
+  });
+
+  it("preserves an existing channels.telegram sibling (e.g. default_topic_id)", () => {
+    const withTelegram = `version: 1
+telegram:
+  bot_token: "vault:t"
+  forum_chat_id: "0"
+agents:
+  marko:
+    channels:
+      telegram:
+        default_topic_id: 7
+`;
+    const out = setAgentSupergroupChatId(withTelegram, "marko", "-100999");
+    const doc = parseDocument(out);
+    expect(doc.getIn(["agents", "marko", "channels", "telegram", "chat_id"])).toBe("-100999");
+    expect(doc.getIn(["agents", "marko", "channels", "telegram", "default_topic_id"])).toBe(7);
+  });
+
+  it("coerces a bare/null `channels:` key to a fresh map", () => {
+    const bareChannels = `version: 1
+telegram:
+  bot_token: "vault:t"
+  forum_chat_id: "0"
+agents:
+  marko:
+    channels:
+`;
+    const out = setAgentSupergroupChatId(bareChannels, "marko", "-100555");
+    const doc = parseDocument(out);
+    expect(doc.getIn(["agents", "marko", "channels", "telegram", "chat_id"])).toBe("-100555");
+  });
+
+  it("throws on a malformed chat_id (never writes a bad value)", () => {
+    expect(() => setAgentSupergroupChatId(BASE, "marko", "1234")).toThrow(/negative integer/);
+    expect(() => setAgentSupergroupChatId(BASE, "marko", "")).toThrow(/negative integer/);
+  });
+
+  it("throws when the agent isn't in the config", () => {
+    expect(() => setAgentSupergroupChatId(BASE, "ghost", "-100123")).toThrow(/not found/);
+  });
+
+  it("produces a config the schema accepts + smart-defaults default_topic_id to General", () => {
+    const out = setAgentSupergroupChatId(BASE, "marko", "-1001234567890");
+    // The schema smart-defaults default_topic_id to General (1) when chat_id
+    // is present — so the written config is valid with no other edits.
+    const cfg = SwitchroomConfigSchema.parse(parse(out));
+    expect(cfg.agents.marko.channels?.telegram?.chat_id).toBe("-1001234567890");
+    expect(cfg.agents.marko.channels?.telegram?.default_topic_id).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Gap #1 of the DM-hardcoding→supergroup-mode audit: **discoverability**. Supergroup mode (one agent owns a Telegram forum supergroup, routing its work into per-topic threads) was real and shipping, but an operator had no way to *learn it exists* or turn it on without hand-editing `channels.telegram.chat_id` and reading the RFC. The setup wizard's forum step had been retired to a sentinel, the only user-facing mention was an aside in `scheduling.md`, and there was no example block.

This closes the gap on three surfaces.

## Why

The **docs test** (principles.md): can someone use this without opening `docs/`? Before this PR, no — supergroup mode failed it. The fix makes the feature self-revealing at setup time while keeping the **defaults test** intact: the wizard step is opt-in and **skip-by-default (one keystroke)**, so a fresh `switchroom setup` with zero config still lands DM mode exactly as before.

## What changed

1. **Wizard** — resurrect Step 4 as an optional *"Supergroup mode"* step (`src/cli/setup.ts`). Defaults to **no**. On opt-in: pick the owning agent, paste the supergroup `chat_id`, validate the `-100…` shape, and write `agents.<name>.channels.telegram.chat_id` via a pure YAML editor. The schema smart-defaults `default_topic_id` to General, so the one field is enough to activate.
2. **Example** — commented per-agent supergroup block in `examples/switchroom.yaml` (`chat_id` / `default_topic_id` / `topic_aliases`) with the id-discovery tip inline.
3. **Guide** — new `docs/supergroup-mode.md` (what it is, when to use it, how to find `chat_id` + `thread_id`, the config block, a field reference, gotchas), linked from `docs/README.md` next to `scheduling.md`.

New pure helper `src/cli/supergroup-setup-yaml.ts` — `isValidSupergroupChatId` + `setAgentSupergroupChatId` — mirrors `auth-active-yaml.ts` (parseDocument → mutate → atomic write, comments/siblings preserved; idempotent; coerces a bare `channels:` key).

## Test plan

- [x] `tests/supergroup-setup-yaml.test.ts` — 9 cases: write-under-agent, idempotent, sibling-preserving, bare-channels coercion, malformed-chat_id rejection, missing-agent throw, and a **schema-parse assertion** proving the written config validates and `default_topic_id` smart-defaults to `1`.
- [x] `tsc --noEmit` clean
- [x] merge / setup / config suites (130 tests) green
- [x] `examples/switchroom.yaml` still parses (commented block inert)

## Risk

Low. The wizard step is opt-in and skip-by-default; the helper is new and only invoked on explicit opt-in; the docs/example additions are inert. No change to any runtime routing path.

JTBD: *a standing team that knows you / always-available* — an operator can stand up a supergroup-owned specialist from the wizard instead of reverse-engineering the config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)