### PR TITLE
fix(telegram): don't lose inbounds redelivered into a not-ready session on restart

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1064,7 +1064,19 @@ try {
   const pending = findLatestTurnIfInterrupted(turnsDb)
   const selfAgent = process.env.SWITCHROOM_AGENT_NAME ?? ''
   if (pending != null && selfAgent) {
-    const kind = selectResumeBuilder(pending.ended_via)
+    // 3h staleness failsafe (operator spec, 2026-06-03): never AUTO-resume
+    // interrupted work older than RESUME_MAX_AGE_MS — selectResumeBuilder
+    // downgrades a stale 'resume' to the passive 'report' so the user is told
+    // ("I was working on X ~Nh ago") but nothing replays unprompted. Env
+    // override SWITCHROOM_RESUME_MAX_AGE_MS (ms); set very high to disable.
+    const RESUME_MAX_AGE_MS = (() => {
+      const v = Number(process.env.SWITCHROOM_RESUME_MAX_AGE_MS)
+      return Number.isFinite(v) && v > 0 ? v : 10_800_000 // 3h
+    })()
+    const kind = selectResumeBuilder(pending.ended_via, {
+      ageMs: Math.max(0, Date.now() - pending.started_at),
+      maxAgeMs: RESUME_MAX_AGE_MS,
+    })
     if (kind === 'resume') {
       bootResumeInbound = { agent: selfAgent, msg: buildResumeInterruptedInbound({ turn: pending }) }
     } else if (kind === 'report') {
@@ -1801,6 +1813,7 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
           return d
         },
         inboundSpool,
+        trackRedeliveredInbound,
       )
       if (fr.redelivered > 0) {
         process.stderr.write(
@@ -1896,6 +1909,7 @@ function releaseTurnBufferGate(key: string): void {
           return d
         },
         inboundSpool,
+        trackRedeliveredInbound,
       )
       if (fr.redelivered > 0) {
         process.stderr.write(
@@ -4110,6 +4124,7 @@ silencePoke.startTimer({
         return d
       },
       inboundSpool,
+      trackRedeliveredInbound,
     )
     process.stderr.write(
       `telegram gateway: silence-poke framework-fallback ended wedged turn ` +
@@ -4138,6 +4153,45 @@ const _deliveryMachineTick = setInterval(() => {
   shadowEmit({ kind: 'tick', now: Date.now() })
 }, DELIVERY_MACHINE_TICK_MS)
 _deliveryMachineTick.unref?.()
+
+// Enrol a buffer-redelivered inbound in the deliver-until-acked queue so the
+// existing sweep re-delivers it until claude's `enqueue` ack lands. Wired into
+// EVERY redelivery path (bridgeUp drain, silence-poke fallback, flap/reply-gate
+// flushes) — `send` returning true only means the bytes reached the bridge, NOT
+// that claude consumed them. Right after a restart (esp. a slow MCP boot) the
+// inject can hit a not-ready session and be silently dropped, and nothing
+// retried it: the clerk 2026-06-03 lost-message incident. Mirrors the
+// live-delivery tracking at the handleInbound site (chatKey + messageId), so
+// DMs and supergroup forum topics are handled identically. Only real user
+// inbounds are tracked — shouldTrackDelivery excludes steer/interrupt/
+// synthetic-source/empty, which never produce an `enqueue` and would otherwise
+// re-deliver forever.
+function trackRedeliveredInbound(merged: InboundMessage): void {
+  if (!DELIVERY_CONFIRM_ENABLED) return
+  if (
+    !shouldTrackDelivery({
+      isSteering: false,
+      isInterrupt: false,
+      // Synthetic inbounds (cron / vault / handback / resume) carry a source
+      // and are NOT tracked here — they enqueue under their own semantics, and
+      // (for the resume synthetics) tracking them safely first needs the
+      // resume builder to emit meta.message_id so the deliver-until-acked ack
+      // matches its enqueue. Tracked separately as a follow-up (see PR notes).
+      hasSource: merged.meta?.source != null,
+      effectiveText: merged.text,
+    })
+  ) {
+    return
+  }
+  const key = chatKey(merged.chatId, merged.threadId != null ? Number(merged.threadId) : null)
+  trackDelivery(
+    deliveryQueue,
+    key,
+    merged,
+    Date.now(),
+    merged.messageId != null ? String(merged.messageId) : null,
+  )
+}
 
 // Re-deliver stranded inbounds until claude acks (the marko drop-wedge).
 // Every few seconds, re-send any inbound that was handed to claude but never
@@ -4376,6 +4430,11 @@ const ipcServer: IpcServer = createIpcServer({
           inboundSpool: inboundSpool ?? null,
           pendingPermissionBuffer,
           client,
+          // Enrol each drained user inbound in the deliver-until-acked queue
+          // so the 5s sweep re-delivers until claude's `enqueue` ack lands —
+          // a socket-write into a still-booting session is NOT consumption
+          // (clerk lost-message incident, 2026-06-03).
+          onUserInboundDelivered: trackRedeliveredInbound,
         })
       } else {
         // Kill-switch fallback: imperative drain (parity with pre-cutover

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4445,6 +4445,10 @@ const ipcServer: IpcServer = createIpcServer({
           try {
             client.send(msg)
             inboundSpool?.ack(msg)
+            // Same enrol as the cutover drain path: a socket-write success is
+            // not proof claude consumed it — enrol so the sweep re-delivers
+            // until `enqueue` (clerk lost-message incident, 2026-06-03).
+            trackRedeliveredInbound(msg)
           } catch (err) {
             process.stderr.write(
               `telegram gateway: pending-inbound drain failed agent=${client.agentName} ` +
@@ -5362,6 +5366,7 @@ if (!STATIC) {
         return d
       },
       inboundSpool,
+      trackRedeliveredInbound,
     )
     if (r != null && r.redelivered > 0) {
       process.stderr.write(

--- a/telegram-plugin/gateway/inbound-delivery-machine-dispatch.ts
+++ b/telegram-plugin/gateway/inbound-delivery-machine-dispatch.ts
@@ -45,6 +45,15 @@ export interface DispatchCtx {
   readonly client?: IpcClient
   /** Optional log sink — default stderr. Test hook. */
   readonly log?: (line: string) => void
+  /**
+   * Optional: enrol a drained+redelivered inbound in the deliver-until-acked
+   * queue. The bridgeUp drain's socket-write "success" is NOT proof claude
+   * consumed the message — right after a restart (esp. with a slow MCP boot)
+   * the inject can hit a not-ready session and be dropped. Wiring this makes
+   * the existing 5s sweep re-deliver until claude's `enqueue` ack lands.
+   * (clerk lost-message incident, 2026-06-03.)
+   */
+  readonly onUserInboundDelivered?: (merged: InboundMessage) => void
 }
 
 const enabled = process.env.SWITCHROOM_DELIVERY_MACHINE_CUTOVER !== '0'
@@ -103,6 +112,9 @@ function dispatchOne(effect: Effect, ctx: DispatchCtx): void {
         ctx.selfAgent,
         send,
         ctx.inboundSpool ?? undefined,
+        ctx.onUserInboundDelivered
+          ? (merged) => ctx.onUserInboundDelivered!(merged)
+          : undefined,
       )
       if (result.drained > 0) {
         log(

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -270,11 +270,15 @@ export function idleDrainTick(
   isBridgeAlive: () => boolean,
   send: (msg: InboundMessage) => boolean,
   spool?: InboundSpool,
+  // Forwarded to redeliverBufferedInbound so the post-flap-settle drain also
+  // enrols redelivered inbounds in the deliver-until-acked queue (parity with
+  // the bridgeUp drain — clerk lost-message incident, 2026-06-03).
+  onDelivered?: (merged: InboundMessage, originals: InboundMessage[]) => void,
 ): { drained: number; redelivered: number; rebuffered: number } | null {
   if (!agent) return null
   if (buffer.depth(agent) === 0) return null
   if (!isBridgeAlive()) return null
-  return redeliverBufferedInbound(buffer, agent, send, spool)
+  return redeliverBufferedInbound(buffer, agent, send, spool, onDelivered)
 }
 
 export function createPendingInboundBuffer(

--- a/telegram-plugin/gateway/pending-inbound-buffer.ts
+++ b/telegram-plugin/gateway/pending-inbound-buffer.ts
@@ -87,6 +87,14 @@ export function redeliverBufferedInbound(
   agent: string,
   send: (msg: InboundMessage) => boolean,
   spool?: InboundSpool,
+  // Called once per merged group on CONFIRMED delivery (after spool.ack).
+  // The caller uses it to enrol the redelivered inbound in the
+  // deliver-until-acked queue (`trackDelivery`) so it is re-sent until
+  // claude's `enqueue` ack lands — closing the restart boot-race where a
+  // socket-write "succeeds" into a not-ready session and the message is
+  // silently dropped (clerk 2026-06-03). `send` returning true only means
+  // the bytes reached the bridge, NOT that claude consumed them.
+  onDelivered?: (merged: InboundMessage, originals: InboundMessage[]) => void,
 ): { drained: number; redelivered: number; rebuffered: number } {
   const pending = buffer.drain(agent)
   let redelivered = 0
@@ -110,6 +118,10 @@ export function redeliverBufferedInbound(
       // originals are, so we ack by original identity.
       for (const o of originals) spool?.ack(o)
       redelivered += originals.length
+      // Enrol in the deliver-until-acked queue (caller's hook). A bare
+      // socket-write success is NOT proof claude consumed it; the queue's
+      // sweep re-delivers until the `enqueue` ack lands.
+      onDelivered?.(merged, originals)
     } else {
       // Re-buffer the originals (not the merged synthetic) so the spool
       // identity is preserved and the next drain re-merges them losslessly.

--- a/telegram-plugin/gateway/resume-inbound-builder.ts
+++ b/telegram-plugin/gateway/resume-inbound-builder.ts
@@ -172,9 +172,25 @@ export function buildResumeWatchdogReportInbound(
  */
 export function selectResumeBuilder(
   endedVia: TurnEndedVia | null,
+  // 3h staleness failsafe (operator spec, 2026-06-03): when the interrupted
+  // turn is older than `maxAgeMs`, an AUTO-resume is downgraded to the passive
+  // `report` — silently re-injecting hours-old work could act on long-stale
+  // context (a tax figure, a "send it" the user has moved on from). Pass both
+  // to enable; omit (default) keeps the legacy blanket-resume behaviour.
+  opts?: { ageMs?: number; maxAgeMs?: number },
 ): 'resume' | 'report' | null {
-  if (endedVia === 'timeout') return 'report'
-  if (endedVia === 'restart' || endedVia === 'sigterm' || endedVia === 'unknown') return 'resume'
-  if (endedVia == null) return 'resume' // still-open at boot = killed mid-flight
-  return null
+  let kind: 'resume' | 'report' | null
+  if (endedVia === 'timeout') kind = 'report'
+  else if (endedVia === 'restart' || endedVia === 'sigterm' || endedVia === 'unknown') kind = 'resume'
+  else if (endedVia == null) kind = 'resume' // still-open at boot = killed mid-flight
+  else kind = null
+  if (
+    kind === 'resume' &&
+    opts?.ageMs != null &&
+    opts?.maxAgeMs != null &&
+    opts.ageMs > opts.maxAgeMs
+  ) {
+    return 'report' // too old to safely auto-resume — passive notice only
+  }
+  return kind
 }

--- a/telegram-plugin/tests/pending-inbound-buffer.test.ts
+++ b/telegram-plugin/tests/pending-inbound-buffer.test.ts
@@ -220,6 +220,33 @@ describe('redeliverBufferedInbound — wedge-clear self-heal (fleet-update incid
     expect(calls).toBe(0)
   })
 
+  // onDelivered: the deliver-until-acked enrol hook (clerk lost-message
+  // incident 2026-06-03). A socket-write "success" is not proof claude
+  // consumed it; the caller uses onDelivered to enrol the redelivered inbound
+  // in the deliver-until-acked queue so the sweep re-delivers until `enqueue`.
+  it('calls onDelivered for each CONFIRMED-delivered group (per merged identity)', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('klanker', inbound('user', 1))
+    buf.push('klanker', inbound('cron', 2)) // source-tagged → its own group
+    const delivered: number[] = []
+    const r = redeliverBufferedInbound(buf, 'klanker', () => true, undefined, (merged) => {
+      delivered.push(merged.messageId as number)
+    })
+    expect(r.redelivered).toBe(2)
+    expect(delivered).toEqual([1, 2]) // fired once per group, carrying the merged identity
+  })
+
+  it('does NOT call onDelivered for a group that failed to send (re-buffered, not enrolled)', () => {
+    const buf = createPendingInboundBuffer({ log: () => {} })
+    buf.push('klanker', inbound('user', 1))
+    const delivered: number[] = []
+    const r = redeliverBufferedInbound(buf, 'klanker', () => false, undefined, (m) =>
+      delivered.push(m.messageId as number),
+    )
+    expect(r.rebuffered).toBe(1)
+    expect(delivered).toEqual([]) // never enrolled — buffer/spool still own it
+  })
+
   it('only touches the named agent', () => {
     const buf = createPendingInboundBuffer({ log: () => {} })
     buf.push('klanker', inbound('user', 1))

--- a/telegram-plugin/tests/resume-inbound-builder.test.ts
+++ b/telegram-plugin/tests/resume-inbound-builder.test.ts
@@ -179,4 +179,23 @@ describe('selectResumeBuilder', () => {
       expect(selectResumeBuilder(endedVia)).toBe(expected)
     })
   }
+
+  // 3h staleness failsafe (operator spec, 2026-06-03).
+  const MAX = 10_800_000 // 3h
+  it('downgrades a fresh resume to report when older than maxAgeMs (no auto-resume of stale work)', () => {
+    expect(selectResumeBuilder('restart', { ageMs: MAX + 1, maxAgeMs: MAX })).toBe('report')
+    expect(selectResumeBuilder(null, { ageMs: MAX + 60_000, maxAgeMs: MAX })).toBe('report')
+  })
+  it('keeps resume when within maxAgeMs', () => {
+    expect(selectResumeBuilder('restart', { ageMs: MAX - 1, maxAgeMs: MAX })).toBe('resume')
+    expect(selectResumeBuilder('sigterm', { ageMs: 1000, maxAgeMs: MAX })).toBe('resume')
+  })
+  it('age cap never UPGRADES — report/null stay as-is regardless of age', () => {
+    expect(selectResumeBuilder('timeout', { ageMs: MAX + 1, maxAgeMs: MAX })).toBe('report')
+    expect(selectResumeBuilder('stop', { ageMs: MAX + 1, maxAgeMs: MAX })).toBe(null)
+  })
+  it('legacy behaviour preserved when age/maxAge omitted (blanket resume)', () => {
+    expect(selectResumeBuilder('restart')).toBe('resume')
+    expect(selectResumeBuilder('restart', { ageMs: MAX + 1 })).toBe('resume') // needs BOTH to cap
+  })
 })


### PR DESCRIPTION
## The live bug (clerk, 2026-06-03, hit twice)
A DM that arrived **while the agent was mid-restart** was buffered, redelivered on `bridge registered`, then **lost** — the user saw "your message is queued…" then "still working… (5 min)" then nothing. Both clerk incidents had the identical trace:

```
inbound  bridge_dead → [bufferInbound, persistInbound]      ✓ buffered
bridge registered → drainBuffer → drained=1 redelivered=1   ✓ pulled + socket-write
…claude produced ZERO activity (still booting, Hindsight timed out)…
turnEnd outbound=false; silence-poke … drained_buffered=0/0  ✗ dropped, not retried
```

## Root cause
`bridge registered` ≠ claude session **ready**. The bridgeUp drain (and the silence-poke fallback + flap flushes) ack delivery on a bare `socket.write` returning `true`, and — unlike the live `handleInbound` path — **never call `trackDelivery`**. So the existing 5s deliver-until-acked **sweep** (re-delivers while `currentTurn==null` until `enqueue` acks — it would have rescued this verbatim) never enrolled the message. The spool was also tombstoned on the socket-write, so nothing retried it.

## Phase A — stop losing it
- `redeliverBufferedInbound` gains an `onDelivered(merged)` hook (fired on confirmed delivery).
- `DispatchCtx.onUserInboundDelivered` threads it into the bridgeUp drain; the fallback + both flap flushes pass it too.
- `trackRedeliveredInbound` enrols the redelivered inbound in the deliver-until-acked queue, **keyed `chatKey(chatId, threadId)` (DM and supergroup topics identical)** with `String(messageId)` so the `enqueue` ack matches — mirroring the live tracking. `shouldTrackDelivery` still excludes steer/interrupt/synthetic-source/empty (those never enqueue → would re-deliver forever).
- Net: redelivered inbound re-sent every 5s until claude boots + enqueues, instead of dropped at 300s. **Would have caught both clerk incidents.**

## Phase C — 3h staleness failsafe (operator spec)
`selectResumeBuilder(endedVia, { ageMs, maxAgeMs })` downgrades a stale auto-resume (interrupted turn older than `RESUME_MAX_AGE_MS`, default 3h, env `SWITCHROOM_RESUME_MAX_AGE_MS`) to the passive `report` — the user is told but hours-old work never replays unprompted.

## Deferred (noted) — to avoid a storm
- **B1** (track the boot-resume synthetics) needs the resume builder to emit `meta.message_id` first — else its `enqueue` carries `null`, the deliver-until-acked ack never matches, and it **re-delivers forever**. Verified: `buildResumeInterruptedInbound`'s meta has no `message_id`. Clean follow-up (+ reply-quote side-effect check), ideally coordinated with the `feat/honest-restart-resume` work.
- **B2** (resume a background turn shadowed by a foreground turn) — `turns-schema` scan widening.

## Test plan
- [x] tsc clean; **84 vitest + 27 bun** affected tests pass; delivery-machine/ipc/gateway-bridge/spool regression suites green (68)
- [x] onDelivered fires per confirmed group / not on re-buffer; 3h cap downgrades resume→report past maxAge, keeps within, never upgrades, legacy preserved
- [ ] **MANDATORY canary** (this is the most incident-dense path): pin test-harness, restart **with Hindsight forced down**, send a DM in the boot window → must be answered (was the live failure); + a supergroup-topic variant; tail for `enqueue`/`ackDelivery` follow-through (not `drained_buffered=0/0`). Then **staggered** roll.

## Risk
Pure orchestration (inject_inbound, acked by session `enqueue`; no claude -p/SDK/API). Kill-switch: existing `SWITCHROOM_INBOUND_DELIVERY_CONFIRM`. Highest residual: ack-key correctness — guarded by tracking the merged anchor `messageId` (matches the live path) + the synthetic-source exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)