### PR TITLE
feat(telegram): edit boot card in place so routine reboots never notify

### DIFF
--- a/telegram-plugin/gateway/boot-card-msgid.ts
+++ b/telegram-plugin/gateway/boot-card-msgid.ts
@@ -1,0 +1,70 @@
+/**
+ * Cross-reboot persistence for the boot card's Telegram message id.
+ *
+ * Why: a freshly *sent* Telegram message always bumps the chat's unread
+ * badge — `disable_notification: true` removes the sound/banner but not the
+ * badge (there is no Bot API flag for that). To make routine reboots produce
+ * ZERO notification (operator request, 2026-06-03), the gateway reuses the
+ * PRIOR boot card's message and EDITS it in place instead of sending a new
+ * one — and edits never touch the badge.
+ *
+ * That requires remembering the last boot card's `message_id` across gateway
+ * restarts, keyed by the chat (+ forum topic) it lives in. This module is the
+ * tiny JSON store for that, mirroring `config-snapshot.ts` /
+ * `boot-issue-cache.ts`: one file under the agent's (bind-mounted, reboot-
+ * surviving) state dir, read once on boot, written once after the id is
+ * established. All failures are non-fatal — a missing/corrupt file just means
+ * "no prior card", so the boot path falls back to a fresh (silent) send.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+/** Stable key for a boot-card target: chat id + optional forum topic. A DM
+ *  agent always boots to the same `<chatId>:` key; a supergroup agent keys by
+ *  `<chatId>:<threadId>` so a topic change starts a fresh card. */
+export function bootCardChatKey(chatId: string, threadId: number | undefined): string {
+  return `${chatId}:${threadId ?? ''}`
+}
+
+type Store = Record<string, number>
+
+function readStore(path: string): Store {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Store
+    }
+  } catch {
+    /* missing / corrupt → treat as empty */
+  }
+  return {}
+}
+
+/** The persisted message id for this chat+topic, or null when there's no
+ *  prior boot card to reuse (first boot, corrupt file, different chat). */
+export function loadBootCardMsgId(
+  path: string,
+  chatKey: string,
+): number | null {
+  const id = readStore(path)[chatKey]
+  return typeof id === 'number' && Number.isFinite(id) && id > 0 ? id : null
+}
+
+/** Record the current boot card's message id for this chat+topic. Merges into
+ *  the existing store (other chats' ids survive). Non-fatal on write failure —
+ *  the worst case is the next reboot sends a fresh card (one badge). */
+export function saveBootCardMsgId(
+  path: string,
+  chatKey: string,
+  messageId: number,
+): void {
+  if (!(Number.isFinite(messageId) && messageId > 0)) return
+  try {
+    const store = readStore(path)
+    if (store[chatKey] === messageId) return // idempotent — no rewrite
+    store[chatKey] = messageId
+    writeFileSync(path, JSON.stringify(store), 'utf8')
+  } catch {
+    /* non-fatal */
+  }
+}

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -67,6 +67,7 @@ import {
   type ConfigDiff,
 } from './config-snapshot.js'
 import { join } from 'path'
+import { bootCardChatKey, loadBootCardMsgId, saveBootCardMsgId } from './boot-card-msgid.js'
 import { loadConfig as _loadSwitchroomConfig } from '../../src/config/loader.js'
 import { resolveAgentConfig as _resolveAgentConfig } from '../../src/config/merge.js'
 
@@ -134,6 +135,21 @@ export interface BotApiForBootCard {
     text: string,
     opts?: Record<string, unknown>,
   ): Promise<unknown>
+  /**
+   * Like `editMessageText`, but reports whether the target message still
+   * exists rather than swallowing a "message to edit not found" the way the
+   * shared retry policy does (retry-api-call.ts) — the boot path needs to
+   * know so it can fall back to a fresh send when the prior card was deleted.
+   * `'edited'` = the edit landed (or content was identical → message exists);
+   * `'gone'` = the message is missing (or any other error → send fresh).
+   * Optional so existing callers/tests without it fall back to always-send.
+   */
+  editMessageTextStrict?(
+    chatId: string,
+    messageId: number,
+    text: string,
+    opts?: Record<string, unknown>,
+  ): Promise<'edited' | 'gone'>
 }
 
 export interface BootCardHandle {
@@ -568,6 +584,17 @@ export interface RunProbesOpts {
    * resolve the default memory collection label.
    */
   configSnapshotPath?: string
+  /**
+   * Cross-reboot store for the boot card's Telegram message id (JSON,
+   * typically `<agentDir>/.boot-card-msgid.json`). When set AND the bot
+   * supports `editMessageTextStrict`, a routine reboot (no `ackMessageId`)
+   * EDITS the prior boot card in place instead of sending a new one — edits
+   * never bump the unread badge, so reboots produce zero notification
+   * (operator request 2026-06-03). Falls back to a fresh silent send when
+   * there's no prior card or it was deleted. Omit to keep the always-send
+   * behaviour.
+   */
+  bootCardStatePath?: string
 }
 
 /** Run all six probes concurrently with their own per-probe timeouts.
@@ -641,20 +668,60 @@ export async function startBootCard(
   // the chat is where you look, and nothing here warrants a push.
   const silentBootCard = true
 
-  let messageId: number
-  try {
-    const sent = await bot.sendMessage(chatId, ackText, {
-      parse_mode: 'HTML',
-      link_preview_options: { is_disabled: true },
-      ...(threadId != null ? { message_thread_id: threadId } : {}),
-      ...(ackMessageId != null ? { reply_parameters: { message_id: ackMessageId } } : {}),
-      ...(silentBootCard ? { disable_notification: true } : {}),
-    })
-    messageId = sent.message_id
-    logger(`telegram gateway: boot-card: posted msgId=${messageId} chatId=${chatId} reason=${opts.restartReason ?? '-'} reason_detail=${opts.restartReasonDetail ?? '-'} silent=${silentBootCard}\n`)
-  } catch (err: unknown) {
-    logger(`telegram gateway: boot-card: failed to post ack: ${(err as Error)?.message ?? String(err)}\n`)
-    return { messageId: -1, complete: () => {} }
+  // Edit-in-place to produce ZERO notification (operator request 2026-06-03).
+  // A sent message always bumps the unread badge — `disable_notification`
+  // only kills the sound/banner. So for a ROUTINE reboot (no `ackMessageId`:
+  // operator update / cli rollout / crash / fresh) we EDIT the prior boot
+  // card in place — edits never touch the badge — instead of sending a new
+  // one. We only do this when the bot can tell us the prior message still
+  // exists (`editMessageTextStrict`); if it's gone, or this is a
+  // Telegram-initiated `/restart` (ackMessageId set — the operator asked and
+  // is watching, and the card should reply to their command), we fall back to
+  // a fresh silent send.
+  const chatKey = bootCardChatKey(chatId, threadId)
+  const reuseId =
+    ackMessageId == null && opts.bootCardStatePath != null && bot.editMessageTextStrict != null
+      ? loadBootCardMsgId(opts.bootCardStatePath, chatKey)
+      : null
+
+  let messageId = -1
+  if (reuseId != null && bot.editMessageTextStrict != null) {
+    try {
+      const outcome = await bot.editMessageTextStrict(chatId, reuseId, ackText, {
+        parse_mode: 'HTML',
+        link_preview_options: { is_disabled: true },
+        ...(threadId != null ? { message_thread_id: threadId } : {}),
+      })
+      if (outcome === 'edited') {
+        messageId = reuseId
+        logger(`telegram gateway: boot-card: reused msgId=${messageId} chatId=${chatId} reason=${opts.restartReason ?? '-'} reason_detail=${opts.restartReasonDetail ?? '-'} edit_in_place=true notify=none\n`)
+      }
+    } catch (err: unknown) {
+      logger(`telegram gateway: boot-card: edit-in-place probe failed (${(err as Error)?.message ?? String(err)}) — sending fresh\n`)
+    }
+  }
+
+  if (messageId < 0) {
+    try {
+      const sent = await bot.sendMessage(chatId, ackText, {
+        parse_mode: 'HTML',
+        link_preview_options: { is_disabled: true },
+        ...(threadId != null ? { message_thread_id: threadId } : {}),
+        ...(ackMessageId != null ? { reply_parameters: { message_id: ackMessageId } } : {}),
+        ...(silentBootCard ? { disable_notification: true } : {}),
+      })
+      messageId = sent.message_id
+      logger(`telegram gateway: boot-card: posted msgId=${messageId} chatId=${chatId} reason=${opts.restartReason ?? '-'} reason_detail=${opts.restartReasonDetail ?? '-'} silent=${silentBootCard}\n`)
+    } catch (err: unknown) {
+      logger(`telegram gateway: boot-card: failed to post ack: ${(err as Error)?.message ?? String(err)}\n`)
+      return { messageId: -1, complete: () => {} }
+    }
+  }
+
+  // Remember this card's id so the NEXT reboot can edit it in place (no
+  // notification). Idempotent on reuse; non-fatal on write failure.
+  if (opts.bootCardStatePath != null && messageId > 0) {
+    saveBootCardMsgId(opts.bootCardStatePath, chatKey, messageId)
   }
 
   // Determine the live window for agent-service status updates. Callers

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9,7 +9,7 @@
  * is connected, inbound LLM messages get a "⏳ Agent is restarting…" reply.
  */
 
-import { Bot, GrammyError, InlineKeyboard, InputFile, type Context } from 'grammy'
+import { Bot, GrammyError, InlineKeyboard, InputFile, type Context, type Api } from 'grammy'
 import { run, type RunnerHandle } from '@grammyjs/runner'
 import type { ReactionTypeEmoji } from 'grammy/types'
 import { randomBytes } from 'crypto'
@@ -2603,6 +2603,26 @@ function wrapBootCardApi(
           ),
         opts(cid),
       ) as Promise<unknown>,
+    // Strict edit for the boot-card edit-in-place probe: distinguishes
+    // "message gone" (→ 'gone', caller sends fresh) from a landed/identical
+    // edit (→ 'edited'). robustApiCall SWALLOWS "message to edit not found"
+    // to undefined (retry-api-call.ts), so this can't go through it — a
+    // deliberate single-attempt raw edit that classifies the error itself.
+    editMessageTextStrict: async (cid, mid, text, editOpts) => {
+      type EditOpts = Parameters<Api['editMessageText']>[3]
+      try {
+        // allow-raw-bot-api: boot-card edit-in-place probe — must detect a deleted target, which the shared retry policy swallows.
+        await lockedBot.api.editMessageText(cid, mid, text, editOpts as EditOpts)
+        return 'edited'
+      } catch (err) {
+        const desc =
+          err instanceof GrammyError ? err.description : err instanceof Error ? err.message : String(err)
+        // Content identical → message still exists; reuse it.
+        if (typeof desc === 'string' && desc.toLowerCase().includes('not modified')) return 'edited'
+        // Not found, or any other error → fall back to a fresh silent send.
+        return 'gone'
+      }
+    },
   }
 }
 
@@ -4578,6 +4598,7 @@ const ipcServer: IpcServer = createIpcServer({
             tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
             dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
             configSnapshotPath: join(resolvedAgentDirForCard, '.config-snapshot.json'),
+            bootCardStatePath: join(resolvedAgentDirForCard, '.boot-card-msgid.json'),
             ...(updateOutcomeLine ? { updateOutcomeLine } : {}),
           }, ackMsgId).then(handle => {
             activeBootCard = handle
@@ -18469,6 +18490,7 @@ void (async () => {
                       tmuxSupervisor: process.env.SWITCHROOM_TMUX_SUPERVISOR === '1',
                       dockerMode: process.env.SWITCHROOM_RUNTIME === 'docker',
                       configSnapshotPath: join(resolvedAgentDirForBootCard, '.config-snapshot.json'),
+                      bootCardStatePath: join(resolvedAgentDirForBootCard, '.boot-card-msgid.json'),
                       ...(updateOutcomeLine ? { updateOutcomeLine } : {}),
                     }, ackMsgId)
                     activeBootCard = handle

--- a/telegram-plugin/tests/boot-card-edit-in-place.test.ts
+++ b/telegram-plugin/tests/boot-card-edit-in-place.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Edit-in-place boot card (zero-notification reboots, operator request
+ * 2026-06-03). A routine reboot must EDIT the prior boot card rather than
+ * send a new one — a sent message bumps the unread badge even with
+ * `disable_notification: true`; an edit never does.
+ *
+ * Pins the startBootCard contract:
+ *   - first boot (no persisted id) → SEND + persist the id
+ *   - next routine boot (persisted id exists) → EDIT in place, NO send
+ *   - persisted id but message deleted ('gone') → fall back to SEND
+ *   - Telegram-initiated /restart (ackMessageId set) → SEND fresh (replies to
+ *     the operator's command; they asked and are watching)
+ *   - no bootCardStatePath → always SEND (back-compat)
+ *
+ * State is an isolated mkdtemp file — NEVER ~/.switchroom (test discipline).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { startBootCard } from '../gateway/boot-card.js'
+import type { BotApiForBootCard } from '../gateway/boot-card.js'
+
+let dir: string
+let statePath: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'boot-card-eip-'))
+  statePath = join(dir, '.boot-card-msgid.json')
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+/** Capturing bot with a configurable strict-edit outcome. */
+function makeBot(strictOutcome: 'edited' | 'gone' | null) {
+  const sends: Array<{ chatId: string; opts: Record<string, unknown> }> = []
+  const strictEdits: Array<{ chatId: string; messageId: number }> = []
+  let nextId = 1000
+  const bot: BotApiForBootCard = {
+    sendMessage: async (chatId, _text, opts) => {
+      sends.push({ chatId, opts: opts ?? {} })
+      return { message_id: ++nextId }
+    },
+    editMessageText: async () => ({}),
+    ...(strictOutcome != null
+      ? {
+          editMessageTextStrict: async (chatId: string, messageId: number) => {
+            strictEdits.push({ chatId, messageId })
+            return strictOutcome
+          },
+        }
+      : {}),
+  }
+  return { bot, sends, strictEdits }
+}
+
+function mkOpts(overrides: Record<string, unknown> = {}) {
+  return {
+    agentName: 'TestAgent',
+    agentSlug: 'test-agent',
+    version: 'v0.0.0-test',
+    agentDir: dir,
+    gatewayInfo: { pid: 1, startedAtMs: Date.now() },
+    restartReason: 'graceful' as const,
+    agentLiveWindowMs: 0, // disable the live loop — we assert the initial post/edit only
+    settleWindowMs: 1_000_000,
+    bootCardStatePath: statePath,
+    ...overrides,
+  }
+}
+
+describe('boot card — edit-in-place (zero-notification reboots)', () => {
+  it('first boot with no persisted id → sends, and persists the id', async () => {
+    const { bot, sends, strictEdits } = makeBot('edited')
+    await startBootCard('chat1', undefined, bot, mkOpts())
+    expect(sends).toHaveLength(1) // first boot must send (one badge, ever)
+    expect(strictEdits).toHaveLength(0)
+    expect(sends[0]!.opts.disable_notification).toBe(true) // still silent
+  })
+
+  it('second routine boot → edits the prior card in place, NO new send', async () => {
+    // Boot 1 sends + persists.
+    const first = makeBot('edited')
+    await startBootCard('chat1', undefined, first.bot, mkOpts())
+    expect(first.sends).toHaveLength(1)
+
+    // Boot 2 (same state file) → reuse via strict edit, no send.
+    const second = makeBot('edited')
+    await startBootCard('chat1', undefined, second.bot, mkOpts())
+    expect(second.sends).toHaveLength(0) // ← zero notification: no new message
+    expect(second.strictEdits).toHaveLength(1)
+    // Boot 1's send returned message_id 1001 (nextId starts at 1000, ++ first);
+    // boot 2 must edit exactly that persisted id.
+    expect(second.strictEdits[0]!.messageId).toBe(1001)
+  })
+
+  it('persisted id but message was deleted (gone) → falls back to a fresh send', async () => {
+    const first = makeBot('edited')
+    await startBootCard('chat1', undefined, first.bot, mkOpts())
+
+    const second = makeBot('gone')
+    await startBootCard('chat1', undefined, second.bot, mkOpts())
+    expect(second.strictEdits).toHaveLength(1) // probed the old id
+    expect(second.sends).toHaveLength(1) // and fell back to a fresh send
+    expect(second.sends[0]!.opts.disable_notification).toBe(true)
+  })
+
+  it('Telegram-initiated /restart (ackMessageId set) → sends fresh, never edits', async () => {
+    // Seed a persisted id from a routine boot.
+    const seed = makeBot('edited')
+    await startBootCard('chat1', undefined, seed.bot, mkOpts())
+
+    // A /restart passes ackMessageId → must reply with a fresh card, not edit.
+    const restart = makeBot('edited')
+    await startBootCard('chat1', undefined, restart.bot, mkOpts(), 555)
+    expect(restart.strictEdits).toHaveLength(0) // no reuse on user-initiated restart
+    expect(restart.sends).toHaveLength(1)
+    expect(restart.sends[0]!.opts.reply_parameters).toEqual({ message_id: 555 })
+  })
+
+  it('no bootCardStatePath → always sends (back-compat, unchanged)', async () => {
+    const { bot, sends, strictEdits } = makeBot('edited')
+    await startBootCard('chat1', undefined, bot, mkOpts({ bootCardStatePath: undefined }))
+    expect(sends).toHaveLength(1)
+    expect(strictEdits).toHaveLength(0)
+  })
+
+  it('bot without editMessageTextStrict → always sends (graceful degrade)', async () => {
+    const { bot, sends } = makeBot(null) // no strict method
+    await startBootCard('chat1', undefined, bot, mkOpts())
+    const second = makeBot(null)
+    await startBootCard('chat1', undefined, second.bot, mkOpts())
+    // Both boots send — no strict method means no in-place reuse path.
+    expect(sends).toHaveLength(1)
+    expect(second.sends).toHaveLength(1)
+  })
+})

--- a/telegram-plugin/tests/boot-card-msgid.test.ts
+++ b/telegram-plugin/tests/boot-card-msgid.test.ts
@@ -30,8 +30,8 @@ afterEach(() => {
 
 describe('bootCardChatKey', () => {
   it('keys a DM (no topic) distinctly from a supergroup topic', () => {
-    expect(bootCardChatKey('8248703757', undefined)).toBe('8248703757:')
-    expect(bootCardChatKey('-1003831053471', 4)).toBe('-1003831053471:4')
+    expect(bootCardChatKey('12345', undefined)).toBe('12345:')
+    expect(bootCardChatKey('-1001234567890', 4)).toBe('-1001234567890:4')
     // Different topics in the same supergroup are distinct cards.
     expect(bootCardChatKey('-100', 3)).not.toBe(bootCardChatKey('-100', 4))
   })

--- a/telegram-plugin/tests/boot-card-msgid.test.ts
+++ b/telegram-plugin/tests/boot-card-msgid.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the cross-reboot boot-card message-id store
+ * (gateway/boot-card-msgid.ts) — the persistence that lets a routine reboot
+ * EDIT the prior boot card in place (zero notification) instead of sending a
+ * new one.
+ *
+ * All I/O is to an isolated mkdtemp dir — NEVER ~/.switchroom (test discipline).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  bootCardChatKey,
+  loadBootCardMsgId,
+  saveBootCardMsgId,
+} from '../gateway/boot-card-msgid.js'
+
+let dir: string
+let path: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'boot-card-msgid-'))
+  path = join(dir, '.boot-card-msgid.json')
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('bootCardChatKey', () => {
+  it('keys a DM (no topic) distinctly from a supergroup topic', () => {
+    expect(bootCardChatKey('8248703757', undefined)).toBe('8248703757:')
+    expect(bootCardChatKey('-1003831053471', 4)).toBe('-1003831053471:4')
+    // Different topics in the same supergroup are distinct cards.
+    expect(bootCardChatKey('-100', 3)).not.toBe(bootCardChatKey('-100', 4))
+  })
+})
+
+describe('loadBootCardMsgId / saveBootCardMsgId', () => {
+  it('returns null when the file does not exist (first boot)', () => {
+    expect(loadBootCardMsgId(path, 'dm:')).toBeNull()
+  })
+
+  it('round-trips a saved id', () => {
+    saveBootCardMsgId(path, 'dm:', 353)
+    expect(loadBootCardMsgId(path, 'dm:')).toBe(353)
+  })
+
+  it('keeps ids for different chats independent', () => {
+    saveBootCardMsgId(path, 'dm:', 100)
+    saveBootCardMsgId(path, '-100:4', 200)
+    expect(loadBootCardMsgId(path, 'dm:')).toBe(100)
+    expect(loadBootCardMsgId(path, '-100:4')).toBe(200)
+    // Updating one leaves the other intact.
+    saveBootCardMsgId(path, 'dm:', 101)
+    expect(loadBootCardMsgId(path, 'dm:')).toBe(101)
+    expect(loadBootCardMsgId(path, '-100:4')).toBe(200)
+  })
+
+  it('returns null for an unknown chat key', () => {
+    saveBootCardMsgId(path, 'dm:', 1)
+    expect(loadBootCardMsgId(path, 'other:')).toBeNull()
+  })
+
+  it('rejects non-positive / non-finite ids on save and load', () => {
+    saveBootCardMsgId(path, 'dm:', 0)
+    saveBootCardMsgId(path, 'dm:', -5)
+    saveBootCardMsgId(path, 'dm:', Number.NaN)
+    expect(loadBootCardMsgId(path, 'dm:')).toBeNull()
+  })
+
+  it('treats a corrupt file as empty (falls back to fresh send)', () => {
+    writeFileSync(path, 'not json{', 'utf8')
+    expect(loadBootCardMsgId(path, 'dm:')).toBeNull()
+    // And a subsequent save still works (overwrites the garbage).
+    saveBootCardMsgId(path, 'dm:', 7)
+    expect(loadBootCardMsgId(path, 'dm:')).toBe(7)
+  })
+
+  it('does not rewrite the file when the id is unchanged (idempotent)', () => {
+    saveBootCardMsgId(path, 'dm:', 42)
+    expect(existsSync(path)).toBe(true)
+    // Saving the same value again is a no-op; the value is still readable.
+    saveBootCardMsgId(path, 'dm:', 42)
+    expect(loadBootCardMsgId(path, 'dm:')).toBe(42)
+  })
+})


### PR DESCRIPTION
## Summary

Operator request: agent reboot "back up" cards should produce **zero notification**. They already pass `disable_notification: true` (no sound, no banner — verified fleet-wide, #1990), but a freshly *sent* Telegram message still bumps the **unread badge**, and the Bot API has no flag to suppress that. The only way to surface boot info in the chat without a badge is to stop sending a new message — so a routine reboot now **edits the prior boot card in place** (edits never touch the badge).

## What changed

- **`gateway/boot-card-msgid.ts`** (new) — persists the last boot card's `message_id` per (chat, topic) under the agent's bind-mounted state dir (`.boot-card-msgid.json`), surviving gateway restarts. Mirrors the existing `config-snapshot` / `boot-issue-cache` stores; missing/corrupt → "no prior card".
- **`startBootCard`** — routine reboot (no `ackMessageId`) with a persisted id + a bot that supports `editMessageTextStrict` → **edit in place** (zero notification). Falls back to a fresh silent send on first boot (one badge, ever) or if the prior card was deleted.
- **`editMessageTextStrict`** (new optional `BotApiForBootCard` method) — the shared retry policy *swallows* "message to edit not found" to `undefined`, so the boot path couldn't tell a deleted message from a successful edit. This reports `'gone'` (→ fresh send) vs `'edited'` (incl. identical content). Raw call, lint-annotated.
- **Telegram `/restart`** (`ackMessageId` set) still sends a fresh card replying to the operator's command — they asked and are watching; edit-in-place targets the routine badge-flood (operator update / cli rollout / crash / fresh boot).

## Trade-off (operator-approved)

The chat shows each agent's **current** status (one card, updated in place) rather than a scroll-back of every past reboot.

## Test plan
- [x] `boot-card-msgid.test.ts` — persistence (round-trip, per-chat isolation, corrupt-file, non-positive guard, idempotent), isolated tmpdir
- [x] `boot-card-edit-in-place.test.ts` — first-boot-sends+persists; second-boot-edits-NO-send; deleted→fallback-send; /restart→fresh-send; no-state-path→send; no-strict-method→send
- [x] existing boot-card suite (82) green; full unit suite **3984 pass, 0 fail**
- [x] `tsc --noEmit` + `check-bot-api-wrapping.sh` clean
- [ ] canary on test-harness: reboot twice, confirm the 2nd edits in place (no badge) via gateway log `edit_in_place=true notify=none`

## Risk
Low, opt-in by data: no state file (or a bot without the strict method) → always-send, exactly today's behavior. `disable_notification:true` retained on every fresh send. DM + supergroup both covered (keyed by chat+topic).

JTBD: *you hold the leash* — reboots are a silent, in-place status record, not a notification flood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)