### PR TITLE
fix(telegram): boot-resume turns get origin routing + survive a not-ready restart

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -287,6 +287,7 @@ import {
   sweep as sweepDeliveryQueue,
   forgetDelivery,
   shouldTrackDelivery,
+  isTrackableResumeSynthetic,
   type PendingDelivery,
 } from './inbound-delivery-confirm.js'
 import { createPendingPermissionBuffer } from './pending-permission-decisions.js'
@@ -4192,15 +4193,17 @@ _deliveryMachineTick.unref?.()
 // re-deliver forever.
 function trackRedeliveredInbound(merged: InboundMessage): void {
   if (!DELIVERY_CONFIRM_ENABLED) return
+  // The boot-resume synthetic ('resume_interrupted') is the ONE synthetic we DO
+  // enrol: a restart can drop it into a not-ready session exactly like a user
+  // inbound, leaving the interrupted work silently un-resumed. Safe iff it
+  // carries the chat_id + message_id that make its enqueue ack-able — see
+  // isTrackableResumeSynthetic. Every other synthetic stays excluded below.
+  const isTrackableResume = isTrackableResumeSynthetic(merged.meta)
   if (
+    !isTrackableResume &&
     !shouldTrackDelivery({
       isSteering: false,
       isInterrupt: false,
-      // Synthetic inbounds (cron / vault / handback / resume) carry a source
-      // and are NOT tracked here — they enqueue under their own semantics, and
-      // (for the resume synthetics) tracking them safely first needs the
-      // resume builder to emit meta.message_id so the deliver-until-acked ack
-      // matches its enqueue. Tracked separately as a follow-up (see PR notes).
       hasSource: merged.meta?.source != null,
       effectiveText: merged.text,
     })

--- a/telegram-plugin/gateway/inbound-delivery-confirm.ts
+++ b/telegram-plugin/gateway/inbound-delivery-confirm.ts
@@ -158,3 +158,29 @@ export function shouldTrackDelivery(input: {
   if (input.effectiveText !== undefined && input.effectiveText.trim().length === 0) return false
   return true
 }
+
+/**
+ * The ONE synthetic-source inbound that IS safe to enrol in the
+ * deliver-until-acked queue: the boot-resume synthetic
+ * (`meta.source === 'resume_interrupted'`). A restart can drop it into a
+ * not-ready (slow MCP boot) session exactly like a user inbound, leaving the
+ * interrupted work silently un-resumed — so it needs the same re-delivery
+ * backstop. It is safe to track ONLY when it carries BOTH:
+ *   - `meta.chat_id` — so the gateway's enqueue handler (gated on `ev.chatId`)
+ *     builds a currentTurn AND fires `ackDelivery` for it; and
+ *   - `meta.message_id` — so the enqueue's id round-trips and `ackDelivery`
+ *     matches THIS synthetic, stopping the sweep (no re-deliver-forever storm).
+ * Every other synthetic (cron / vault / handback / the watchdog `report`) omits
+ * `meta.message_id` and stays excluded by `shouldTrackDelivery`'s `hasSource`
+ * gate. We require message_id here (chat_id is implied by the ack mechanics);
+ * without a round-trippable id, tracking would storm.
+ */
+export function isTrackableResumeSynthetic(
+  meta: Record<string, string> | undefined,
+): boolean {
+  return (
+    meta?.source === 'resume_interrupted' &&
+    meta.message_id != null &&
+    meta.message_id !== ''
+  )
+}

--- a/telegram-plugin/gateway/resume-inbound-builder.ts
+++ b/telegram-plugin/gateway/resume-inbound-builder.ts
@@ -78,14 +78,33 @@ function promptClause(turn: Turn): string {
 export function buildResumeInterruptedInbound(ctx: ResumeInboundContext): InboundMessage {
   const ts = ctx.nowMs ?? Date.now()
   const elapsed = humanizeElapsed(ts - ctx.turn.started_at)
+  const threadId = threadIdNum(ctx.turn)
   const meta: Record<string, string> = {
     source: 'resume_interrupted',
+    // Carry the originating chat/topic as model-visible channel attributes
+    // (mirrors the real-inbound + subagent_handback shapes — see
+    // gateway.ts:10753 and subagent-handback-inbound-builder.ts:115-121).
+    // Without meta.chat_id the enqueue's channel XML has no chat_id, so the
+    // gateway's enqueue handler (gateway.ts `if (ev.chatId)`) never builds a
+    // currentTurn for the resume turn — meaning no progress card, no
+    // silence-poke protection, and the reply falling back to the agent's
+    // default chat instead of the topic the interrupted work lived in.
+    chat_id: ctx.turn.chat_id,
+    ...(threadId != null ? { message_thread_id: String(threadId) } : {}),
+    // message_id rounds-trips the fabricated `ts` through the enqueue's
+    // channel XML so the deliver-until-acked queue can ack THIS synthetic by
+    // its own enqueue id (gateway trackRedeliveredInbound carve-in). It is
+    // never used as a Telegram reply_to: the model's reply tool quotes the
+    // real prior user message via getLatestInboundMessageId (role='user',
+    // synthetics aren't in history), and the activity feed anchors with
+    // allow_sending_without_reply. Required so tracking the resume can ack and
+    // never re-delivers forever.
+    message_id: String(ts),
     resume_turn_key: ctx.turn.turn_key,
     interrupted_via: ctx.turn.ended_via ?? 'restart',
     started_at: String(ctx.turn.started_at),
   }
   if (ctx.turn.user_prompt_preview) meta.original_prompt = ctx.turn.user_prompt_preview
-  const threadId = threadIdNum(ctx.turn)
   return {
     type: 'inbound',
     chatId: ctx.turn.chat_id,
@@ -127,8 +146,15 @@ export function buildResumeWatchdogReportInbound(
     ctx.turn.tool_call_count != null && ctx.turn.tool_call_count > 0
       ? ` You'd run ${ctx.turn.tool_call_count} tool call${ctx.turn.tool_call_count === 1 ? '' : 's'} before it stalled.`
       : ''
+  const threadId = threadIdNum(ctx.turn)
   const meta: Record<string, string> = {
     source: 'resume_watchdog_timeout',
+    // Origin chat/topic as channel attributes so the report turn gets a
+    // currentTurn (progress card + silence-poke) and the "your last turn was
+    // interrupted" notice lands in the topic the work lived in, not the
+    // agent's default chat. Same rationale as buildResumeInterruptedInbound.
+    chat_id: ctx.turn.chat_id,
+    ...(threadId != null ? { message_thread_id: String(threadId) } : {}),
     resume_turn_key: ctx.turn.turn_key,
     interrupted_via: 'timeout',
     idle_ms: String(ctx.idleMs),
@@ -136,7 +162,6 @@ export function buildResumeWatchdogReportInbound(
   }
   if (ctx.turn.tool_call_count != null) meta.tool_call_count = String(ctx.turn.tool_call_count)
   if (ctx.turn.user_prompt_preview) meta.original_prompt = ctx.turn.user_prompt_preview
-  const threadId = threadIdNum(ctx.turn)
   return {
     type: 'inbound',
     chatId: ctx.turn.chat_id,

--- a/telegram-plugin/tests/inbound-delivery-confirm.test.ts
+++ b/telegram-plugin/tests/inbound-delivery-confirm.test.ts
@@ -4,6 +4,7 @@ import {
   ackDelivery,
   createDeliveryQueue,
   forgetDelivery,
+  isTrackableResumeSynthetic,
   shouldTrackDelivery,
   sweep,
   trackDelivery,
@@ -176,5 +177,65 @@ describe('shouldTrackDelivery — only fresh-turn messages are tracked', () => {
   })
   it('tracks a normal message when effectiveText is provided and non-empty', () => {
     expect(shouldTrackDelivery({ isSteering: false, isInterrupt: false, effectiveText: 'draft the email' })).toBe(true)
+  })
+})
+
+// The boot-resume synthetic is the one synthetic ENROLLED for re-delivery (so a
+// restart can't silently drop the "pick up your interrupted work" wake into a
+// not-ready session). It is safe ONLY because it carries a round-trippable
+// message_id that its own enqueue acks — without that it would re-deliver
+// forever (the storm the hasSource exclusion otherwise prevents).
+describe('isTrackableResumeSynthetic — resume carve-in to the deliver-until-acked queue', () => {
+  it('tracks a resume_interrupted synthetic that carries a message_id', () => {
+    expect(isTrackableResumeSynthetic({ source: 'resume_interrupted', message_id: '1700000000000' })).toBe(true)
+  })
+  it('does NOT track a resume_interrupted WITHOUT a message_id (would never ack → storm)', () => {
+    expect(isTrackableResumeSynthetic({ source: 'resume_interrupted' })).toBe(false)
+    expect(isTrackableResumeSynthetic({ source: 'resume_interrupted', message_id: '' })).toBe(false)
+  })
+  it('does NOT track the watchdog report (untracked by design) even though it carries chat_id', () => {
+    expect(isTrackableResumeSynthetic({ source: 'resume_watchdog_timeout', chat_id: '123' })).toBe(false)
+  })
+  it('does NOT track other synthetics (cron / vault / handback) even if they somehow had a message_id', () => {
+    expect(isTrackableResumeSynthetic({ source: 'cron', message_id: '1' })).toBe(false)
+    expect(isTrackableResumeSynthetic({ source: 'subagent_handback', message_id: '1' })).toBe(false)
+    expect(isTrackableResumeSynthetic({ source: 'vault_grant_approved', message_id: '1' })).toBe(false)
+  })
+  it('does NOT track a real (no source) inbound here — that path is shouldTrackDelivery', () => {
+    expect(isTrackableResumeSynthetic({ chat_id: '1', message_id: '2' })).toBe(false)
+    expect(isTrackableResumeSynthetic(undefined)).toBe(false)
+  })
+})
+
+// End-to-end queue contract for the resume synthetic: tracked by its fabricated
+// id, acked by its OWN enqueue (which round-trips the same id), and — crucially
+// — it can never re-deliver forever (the storm the original deferral feared).
+describe('resume synthetic: tracked, acked by own enqueue, never storms', () => {
+  const RESUME_ID = '1700000000000' // String(ts), the fabricated message_id
+  it('acks when its own enqueue arrives with the matching id (no storm)', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'resume…' }, 1_000, RESUME_ID)
+    // The resume turn starts → enqueue fires carrying the round-tripped id.
+    expect(ackDelivery(q, 'chat:_', RESUME_ID)).toBe(true)
+    expect(q.pending.size).toBe(0)
+    // Never re-delivered after the ack — bounded, not a forever loop.
+    expect(sweep(q, 1_000 + 999_999, TIMEOUT)).toHaveLength(0)
+  })
+  it('strands then re-delivers until acked (rescues a drop into a not-ready session)', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'resume…' }, 1_000, RESUME_ID)
+    // Dropped into a not-ready session: no enqueue within the timeout → re-deliver.
+    const stranded = sweep(q, 1_000 + TIMEOUT + 1, TIMEOUT)
+    expect(stranded).toHaveLength(1)
+    expect(stranded[0]!.messageId).toBe(RESUME_ID)
+    // Once claude is ready, its enqueue acks it and the loop stops.
+    expect(ackDelivery(q, 'chat:_', RESUME_ID)).toBe(true)
+    expect(sweep(q, 1_000 + TIMEOUT * 10, TIMEOUT)).toHaveLength(0)
+  })
+  it('a DIFFERENT enqueue id (e.g. a racing real user msg) does NOT false-ack the resume', () => {
+    const q = fresh()
+    trackDelivery(q, 'chat:_', { text: 'resume…' }, 1_000, RESUME_ID)
+    expect(ackDelivery(q, 'chat:_', '999')).toBe(false) // not our id
+    expect(q.pending.size).toBe(1) // still pending, will re-deliver
   })
 })

--- a/telegram-plugin/tests/resume-inbound-builder.test.ts
+++ b/telegram-plugin/tests/resume-inbound-builder.test.ts
@@ -124,6 +124,27 @@ describe('buildResumeInterruptedInbound', () => {
     const msg = buildResumeInterruptedInbound({ turn: makeTurn({ thread_id: null }) })
     expect(msg.threadId).toBeUndefined()
   })
+
+  // Origin routing + ack-ability (the resume-deliver hardening). meta.chat_id
+  // makes the gateway build a currentTurn (progress card + silence-poke) and
+  // fire ackDelivery; meta.message_id round-trips so the deliver-until-acked
+  // queue can ack THIS synthetic by its own enqueue id (no re-deliver storm).
+  it('carries origin chat_id + message_id in meta (DM)', () => {
+    const turn = makeTurn({ chat_id: '8248703757', thread_id: null })
+    const msg = buildResumeInterruptedInbound({ turn, nowMs: 1_700_000_000_000 })
+    expect(msg.meta.chat_id).toBe('8248703757')
+    expect(msg.meta.message_id).toBe('1700000000000')
+    expect(msg.messageId).toBe(1_700_000_000_000)
+    expect(msg.meta.message_thread_id).toBeUndefined()
+  })
+
+  it('carries message_thread_id in meta for a forum topic (supergroup routing)', () => {
+    const turn = makeTurn({ chat_id: '-1003982767197', thread_id: '42' })
+    const msg = buildResumeInterruptedInbound({ turn })
+    expect(msg.meta.chat_id).toBe('-1003982767197')
+    expect(msg.meta.message_thread_id).toBe('42')
+    expect(msg.threadId).toBe(42)
+  })
 })
 
 describe('buildResumeWatchdogReportInbound', () => {
@@ -162,6 +183,18 @@ describe('buildResumeWatchdogReportInbound', () => {
     const turn = makeTurn({ ended_via: 'timeout', tool_call_count: 0 })
     const msg = buildResumeWatchdogReportInbound({ turn, idleMs: 300_000 })
     expect(msg.text).not.toContain('tool call')
+  })
+
+  // The report turn ALSO gets origin routing (currentTurn + topic) — a "your
+  // last turn was interrupted" notice should land in the topic the work lived
+  // in — but it is NOT deliver-until-acked tracked, so it carries NO
+  // message_id (only the 'resume_interrupted' builder does, gating tracking).
+  it('carries origin chat_id + message_thread_id but NO message_id (report is untracked)', () => {
+    const turn = makeTurn({ ended_via: 'timeout', chat_id: '-1003982767197', thread_id: '42' })
+    const msg = buildResumeWatchdogReportInbound({ turn, idleMs: 300_000 })
+    expect(msg.meta.chat_id).toBe('-1003982767197')
+    expect(msg.meta.message_thread_id).toBe('42')
+    expect(msg.meta.message_id).toBeUndefined()
   })
 })
 

--- a/telegram-plugin/tests/resume-inbound-builder.test.ts
+++ b/telegram-plugin/tests/resume-inbound-builder.test.ts
@@ -130,18 +130,18 @@ describe('buildResumeInterruptedInbound', () => {
   // fire ackDelivery; meta.message_id round-trips so the deliver-until-acked
   // queue can ack THIS synthetic by its own enqueue id (no re-deliver storm).
   it('carries origin chat_id + message_id in meta (DM)', () => {
-    const turn = makeTurn({ chat_id: '8248703757', thread_id: null })
+    const turn = makeTurn({ chat_id: '12345', thread_id: null })
     const msg = buildResumeInterruptedInbound({ turn, nowMs: 1_700_000_000_000 })
-    expect(msg.meta.chat_id).toBe('8248703757')
+    expect(msg.meta.chat_id).toBe('12345')
     expect(msg.meta.message_id).toBe('1700000000000')
     expect(msg.messageId).toBe(1_700_000_000_000)
     expect(msg.meta.message_thread_id).toBeUndefined()
   })
 
   it('carries message_thread_id in meta for a forum topic (supergroup routing)', () => {
-    const turn = makeTurn({ chat_id: '-1003982767197', thread_id: '42' })
+    const turn = makeTurn({ chat_id: '-1001234567890', thread_id: '42' })
     const msg = buildResumeInterruptedInbound({ turn })
-    expect(msg.meta.chat_id).toBe('-1003982767197')
+    expect(msg.meta.chat_id).toBe('-1001234567890')
     expect(msg.meta.message_thread_id).toBe('42')
     expect(msg.threadId).toBe(42)
   })
@@ -190,9 +190,9 @@ describe('buildResumeWatchdogReportInbound', () => {
   // in — but it is NOT deliver-until-acked tracked, so it carries NO
   // message_id (only the 'resume_interrupted' builder does, gating tracking).
   it('carries origin chat_id + message_thread_id but NO message_id (report is untracked)', () => {
-    const turn = makeTurn({ ended_via: 'timeout', chat_id: '-1003982767197', thread_id: '42' })
+    const turn = makeTurn({ ended_via: 'timeout', chat_id: '-1001234567890', thread_id: '42' })
     const msg = buildResumeWatchdogReportInbound({ turn, idleMs: 300_000 })
-    expect(msg.meta.chat_id).toBe('-1003982767197')
+    expect(msg.meta.chat_id).toBe('-1001234567890')
     expect(msg.meta.message_thread_id).toBe('42')
     expect(msg.meta.message_id).toBeUndefined()
   })


### PR DESCRIPTION
## Summary

The boot-resume synthetics — the wake-ups that make an agent **pick up work it was doing when it restarted** — carried only `meta.source` (no `chat_id`, `message_thread_id`, or `message_id`). Two real gaps fall out of that, both in the operator's "if it was restarted mid doing work it should pick up that work without prompting" area:

1. **No `currentTurn` for resume turns.** The gateway's enqueue handler gates the entire `currentTurn` construction on `ev.chatId` (parsed from the channel XML, which renders from `meta`). With no `meta.chat_id`, a resumed turn ran with **no progress card and no silence-poke protection**, and its reply fell back to the agent's **default chat** instead of the topic the interrupted work lived in (a supergroup mis-route — same class as the handback / permission-card topic-routing fixes; handback already carries this meta, resume did not).

2. **Not rescued if dropped.** The resume wake is buffered + spool-replayed and drained on bridge-up exactly like a user inbound, but `trackRedeliveredInbound` excludes all `meta.source` synthetics — so a restart that dropped it into a still-booting (slow MCP) session **silently failed to pick the work back up**. This is the resume-side of the #2117 lost-message race.

## What changed

- `buildResumeInterruptedInbound` / `buildResumeWatchdogReportInbound` carry `chat_id` + `message_thread_id` in meta (mirrors the real-inbound + `subagent_handback` shapes) → resumed/report turns now get a `currentTurn` (progress card + silence-poke) and route to the originating chat/topic.
- `buildResumeInterruptedInbound` additionally carries `message_id` (= its fabricated `ts`) so its enqueue id round-trips and the deliver-until-acked queue can ack **this** synthetic by its own enqueue — enrolled via a narrow carve-in (`isTrackableResumeSynthetic`) so it re-delivers until claude consumes it and **cannot re-deliver forever** (the storm the original deferral feared). The watchdog `report` stays untracked (no `message_id`); every other synthetic (cron/vault/handback) stays excluded.

## Why it's storm-safe + reply-safe (the two risks)

- **No storm:** the ack fires (it's gated on `ev.chatId`, now present via `meta.chat_id`) and matches (`ev.messageId` = `meta.message_id` = `String(ts)` = the tracked id). Unit-tested: tracked → acked by own enqueue → sweep empty; a *different* enqueue id does not false-ack.
- **No bad reply-quote:** the fabricated `message_id` is never a Telegram `reply_to`. The model's reply tool quotes the real prior user message via `getLatestInboundMessageId` (`role='user'`; synthetics aren't in history); the activity feed anchors with `allow_sending_without_reply`.

## Test plan

- [x] `isTrackableResumeSynthetic` carve-in (resume-with-id tracked; resume-without-id / report / cron / handback / real all excluded)
- [x] resume tracked → acked by own enqueue → never storms; strands-then-rescues
- [x] builder meta: `chat_id`/`message_thread_id`/`message_id` present on resume; report has chat_id/thread but **no** message_id
- [x] 3981 bun + 3563 vitest green, `tsc --noEmit` clean, bot-api-wrapping + plugin-references clean
- [ ] Canary: real interrupted turn on test-harness (DM) → restart → resume turn shows a progress card + is rescued if it lands in a not-ready session; tail for `boot-resume queued kind=resume` → enqueue → reply
- [ ] Supergroup topic routing rests on the `subagent_handback` precedent (same mechanism) + gateway unit thread-assertions — mtcute can't create non-General topics

## Risk

Low. Rides the existing `SWITCHROOM_INBOUND_DELIVERY_CONFIRM` kill switch. The behavior change is that resume/report turns now become first-class turns (get a `currentTurn`) — which is the intended improvement (visibility + wedge protection). Note: a cap-downgraded stale resume routes its "report" to origin too (correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)