### PR TITLE
chore: release v0.14.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.14.49 — Reboot cards edit in place → zero notification (#2121)
+
+Agent reboot "back up" cards already arrived silently (no sound/banner,
+`disable_notification: true`), but a freshly *sent* message still bumps the
+unread badge — and the Telegram Bot API has no flag to suppress that. So a
+routine reboot now **edits the prior boot card in place** instead of sending
+a new one; edits never touch the badge, so reboots are truly notification-
+free.
+
+- **Routine reboots (operator update / cli rollout / crash / fresh boot)**
+  reuse the prior boot card: the gateway persists its message id per
+  (chat, topic) under the agent's state dir and edits that message on the
+  next boot. The first boot after upgrading still sends one card (to
+  establish the message it'll reuse); every reboot after that is a silent
+  in-place edit → no sound, no banner, no badge.
+- **Telegram-initiated `/restart`** still sends a fresh card that replies to
+  your command — you asked and you're watching, so it should land at the
+  bottom of the chat.
+- Safe fallback: if the prior card was deleted, or on first boot, it sends a
+  fresh (silent) card. A new `editMessageTextStrict` distinguishes
+  "message gone" from a landed edit so the card is never silently lost.
+
+Trade-off: the chat shows each agent's CURRENT status (one card, updated)
+rather than a scroll-back of every past reboot.
+
 ## v0.14.48 — Don't lose a message sent while an agent is restarting (#2117)
 
 A DM (or supergroup-topic message) sent while an agent was mid-restart could

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.48",
+  "version": "0.14.49",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.14.49 — agent reboot cards now edit the prior card in place instead of sending a new one, so routine reboots produce zero notification (no sound, no banner, no badge). Bundles #2121 (reviewer-APPROVED, merged). Version bump + CHANGELOG only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)