### PR TITLE
chore: release v0.14.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.14.50 — Resumed turns get a progress card + survive a not-ready restart (#2122)
+
+When an agent restarts mid-work, the boot-resume wake-up (the synthetic message
+that makes it pick up the interrupted task without being re-prompted) is now a
+first-class turn and can't be silently dropped.
+
+- **Resumed turns show progress and route to the right place (#2122).** The
+  boot-resume synthetics carried only `meta.source` — no `chat_id` / topic. The
+  gateway builds a turn's `currentTurn` (progress card, silence-poke hang
+  protection, reply routing) only when the enqueue carries a `chat_id`, and the
+  channel attributes are rendered from `meta` alone. So a resumed turn ran with
+  **no progress card and no silence-poke**, and on a supergroup agent its reply
+  fell back to the default chat instead of the topic the interrupted work lived
+  in. Both resume builders now carry `chat_id` + `message_thread_id` in meta
+  (the same shape real inbounds and sub-agent handbacks already use), so a
+  resumed/report turn shows live progress, is hang-protected, and answers in the
+  originating chat/topic.
+
+- **The resume wake survives a not-ready restart (#2122).** The resume synthetic
+  is buffered and redelivered on bridge-up exactly like a user inbound, but it
+  was excluded from the deliver-until-acked queue — so a restart that dropped it
+  into a still-booting (slow MCP) session silently failed to pick the work back
+  up (the resume-side of the v0.14.48 lost-message race). The `resume_interrupted`
+  synthetic now also carries a `message_id`, letting it enrol in the queue and
+  re-deliver until claude consumes it, keyed and id-matched so it can never
+  re-deliver forever. The watchdog "report" stays untracked; every other
+  synthetic (cron / vault / handback) is unchanged. Rides the existing
+  `SWITCHROOM_INBOUND_DELIVERY_CONFIRM` kill switch.
+
 ## v0.14.49 — Reboot cards edit in place → zero notification (#2121)
 
 Agent reboot "back up" cards already arrived silently (no sound/banner,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.49",
+  "version": "0.14.50",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release **v0.14.50** — ships #2122: *resumed turns get a progress card + survive a not-ready restart.*

## Why

When an agent restarts mid-work, the boot-resume wake-up (which makes it pick up the interrupted task without being re-prompted) carried only `meta.source`. Two gaps: (1) no `meta.chat_id` → the gateway never built a `currentTurn`, so resumed turns ran with **no progress card, no silence-poke**, and mis-routed replies to the default chat on supergroup agents; (2) it was excluded from the deliver-until-acked queue, so a restart that dropped it into a still-booting session silently failed to resume (the resume-side of the v0.14.48 race).

## What's in it

- **#2122** — both resume builders carry `chat_id` + `message_thread_id` (currentTurn + origin routing, mirroring real inbounds + handback); the `resume_interrupted` builder also carries `message_id` so it enrols in deliver-until-acked (rescued if dropped) — keyed + id-matched so it can never re-deliver forever. Reviewer-verified storm-impossible + reply-safe.

## Test plan

- [x] `npm run build` clean, `dist/cli/switchroom.js` present (~3MB)
- [x] 3981 bun + 3563 vitest green; tsc, bot-api-wrapping, plugin-references, PII clean
- [x] Fresh-process reviewer APPROVE (storm + reply-quote chains traced independently)
- [ ] CI green → auto-merge
- [ ] Canary: real interrupted turn on test-harness → restart → resume turn shows a progress card, routes correctly, and is rescued if it lands in a not-ready session
- [ ] Staggered fleet rollout, marko last

## Risk

Low. Rides the existing `SWITCHROOM_INBOUND_DELIVERY_CONFIRM` kill switch. Behavior change: resume/report turns become first-class (get a currentTurn) — the intended improvement. Supergroup topic routing rests on the handback precedent (mtcute can't create non-General topics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)