### PR TITLE
test(telegram): permanent restart-resume regression gates (#2117/#2122)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -753,6 +753,16 @@ lifecycle changes):
 - `jtbd-always-on-after-restart-dm` — first message after restart
   ≤60s (5-min wedge regression gate).
 - `jtbd-memory-survives-restart-dm` — memory persistence across restart.
+- `jtbd-message-during-restart-dm` / `-channel` — a message sent
+  *during* the restart boot window is still answered (v0.14.48 / #2117
+  lost-message gate; sends DURING boot, unlike always-on which sends
+  after). Set `SWITCHROOM_UAT_BOOT_SEND_DELAY_MS=6000` to land it deep
+  enough in the not-ready window to exercise the strand-rescue sweep.
+- `jtbd-interrupted-turn-resumes-dm` — a turn interrupted by a restart
+  is resumed (and the resume turn completes, not silently dropped)
+  (v0.14.50 / #2122 gate). Asserts the resume *framing*, not an
+  end-token (the resume synthetic only carries the first ~160 chars of
+  the original prompt).
 - Any feature-specific scenario.
 
 **Supergroup / channel UAT (status-routing work — required).** Every

--- a/telegram-plugin/uat/scenarios/jtbd-interrupted-turn-resumes-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-interrupted-turn-resumes-dm.test.ts
@@ -1,0 +1,90 @@
+/**
+ * JTBD — always-on: a turn interrupted by a restart is RESUMED without
+ * re-prompting, and the resume turn runs to completion (it is not silently
+ * dropped into a not-ready session). Regression gate for v0.14.50 / #2122.
+ *
+ * Flow: send a long-running task, let it get in-flight, then restart the agent
+ * (--force, NOT --wait, so it interrupts rather than draining). On boot the
+ * gateway finds the orphaned turn and injects the `resume_interrupted`
+ * synthetic. With #2122 that synthetic carries meta.chat_id + message_id, so the
+ * resumed turn (a) builds a currentTurn (progress card + silence-poke), (b)
+ * routes its reply to the originating chat, and (c) re-enrols in
+ * deliver-until-acked so a drop into a still-booting session is rescued rather
+ * than lost.
+ *
+ * Assertion: a reply arrives after the interrupting restart whose FRAMING shows
+ * the agent is resuming ("picking this back up" / "interrupted" / "cut off by a
+ * restart"). We deliberately do NOT assert an end-token: the resume synthetic
+ * only carries the first ~160 chars of the original prompt (promptClause
+ * truncation), so instructions in the prompt's tail are not guaranteed to
+ * survive — the resume FRAMING is the stable, builder-guaranteed signal.
+ *
+ * Self-skips green without NOPASSWD sudo.
+ */
+
+import { describe, it, expect } from "vitest";
+import { execSync, spawn } from "node:child_process";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+const MID_TURN_MS = 10_000;        // let the turn enqueue (become a recorded interrupted turn)
+const RESUME_BUDGET_MS = 180_000;  // boot + resume + reply
+
+// The resume builder tells the model to "briefly let the user know you're
+// resuming what was interrupted" — so the reply always opens with this framing.
+const RESUME_FRAMING = /resum|picking .*back|interrupted|cut off|just restarted/i;
+
+function canShellSudo(): boolean {
+  try {
+    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function kickRestartDetached(name: string): void {
+  // --force WITHOUT --wait → recreate now, interrupting the in-flight turn.
+  const child = spawn(
+    "sudo",
+    ["-n", "env", `PATH=${process.env.PATH}`, `HOME=${process.env.HOME}`,
+      "switchroom", "agent", "restart", name, "--force"],
+    { detached: true, stdio: "ignore" },
+  );
+  child.unref();
+}
+
+const sudoOk = canShellSudo();
+
+(sudoOk ? describe : describe.skip)("uat: interrupted turn resumes after restart (DM)", () => {
+  it(
+    "a turn interrupted by a restart is resumed and the resume turn completes",
+    async () => {
+      const sc = await spinUp({ agent: AGENT, settleMs: 0 });
+      try {
+        // A task long enough that it's still in-flight at MID_TURN_MS.
+        await sc.sendDM(
+          `Please write a thorough, detailed ~300-word explanation of how a ` +
+          `mechanical typewriter's typebar mechanism works, step by step. Take ` +
+          `your time and be complete.`,
+        );
+
+        await new Promise((r) => setTimeout(r, MID_TURN_MS));
+        kickRestartDetached(AGENT);
+
+        // After boot, the resume synthetic should make the agent pick the work
+        // back up and say so. (The newest interrupted turn — this one — is the
+        // one findLatestTurnIfInterrupted resumes.)
+        const reply = await sc.expectMessage((m) => RESUME_FRAMING.test(m.text), {
+          from: "bot",
+          timeout: RESUME_BUDGET_MS,
+        });
+        expect(reply.text).toMatch(RESUME_FRAMING);
+        expect(reply.text.length).toBeGreaterThan(40); // a substantive resumed reply, not a stub
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    RESUME_BUDGET_MS + 60_000,
+  );
+});

--- a/telegram-plugin/uat/scenarios/jtbd-message-during-restart-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-message-during-restart-channel.test.ts
@@ -1,0 +1,95 @@
+/**
+ * JTBD — always-on in a supergroup: a message sent into a forum topic WHILE the
+ * agent is restarting must still be answered IN the group (the channel twin of
+ * jtbd-message-during-restart-dm). Regression gate for v0.14.48 / #2117, proving
+ * the restart-redeliver rescue is keyed per (chat, thread) so DM and supergroup
+ * topics recover identically.
+ *
+ * Self-skips green when SWITCHROOM_UAT_CHAT_ID is unset or the chat isn't a
+ * resolvable forum supergroup the driver is in (uat/** is excluded from gating
+ * CI). mtcute caveat: no forum-topic create API, so this uses the supergroup's
+ * General topic — it proves DM-vs-channel routing, not "correct topic among
+ * many" (pinned by the gateway unit thread-assertions).
+ */
+
+import { describe, it, expect } from "vitest";
+import { execSync, spawn } from "node:child_process";
+import { spinUp } from "../harness.js";
+import { expectMessage } from "../assertions.js";
+
+const AGENT = "test-harness";
+const SUPERGROUP_ID = Number.parseInt(process.env.SWITCHROOM_UAT_CHAT_ID ?? "", 10);
+const BOOT_SEND_DELAY_MS = Number.parseInt(
+  process.env.SWITCHROOM_UAT_BOOT_SEND_DELAY_MS ?? "12000",
+  10,
+);
+const REPLY_BUDGET_MS = 180_000;
+
+function canShellSudo(): boolean {
+  try {
+    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function kickRestartDetached(name: string): void {
+  const child = spawn(
+    "sudo",
+    ["-n", "env", `PATH=${process.env.PATH}`, `HOME=${process.env.HOME}`,
+      "switchroom", "agent", "restart", name, "--force"],
+    { detached: true, stdio: "ignore" },
+  );
+  child.unref();
+}
+
+const sudoOk = canShellSudo();
+
+(sudoOk ? describe : describe.skip)("uat: message sent during a restart (supergroup)", () => {
+  it(
+    "a supergroup-topic message sent DURING the restart boot window is still answered in the group",
+    async () => {
+      if (!Number.isFinite(SUPERGROUP_ID)) {
+        console.warn("[during-restart-channel] SWITCHROOM_UAT_CHAT_ID unset — skipping");
+        return;
+      }
+      const sc = await spinUp({ agent: AGENT, settleMs: 0 });
+      try {
+        await sc.driver.primeDialogs();
+        if (!(await sc.driver.canResolve(SUPERGROUP_ID))) {
+          console.warn(
+            `[during-restart-channel] supergroup ${SUPERGROUP_ID} not resolvable — skipping ` +
+              `(ensure forum supergroup with Topics + driver is a member)`,
+          );
+          return;
+        }
+
+        const nonce = `bootsg-${Date.now().toString(36)}`;
+        kickRestartDetached(AGENT);
+        await new Promise((r) => setTimeout(r, BOOT_SEND_DELAY_MS));
+
+        const sendStart = Date.now();
+        await sc.driver.sendText(
+          SUPERGROUP_ID,
+          `You are being restart-tested in this group. Reply in this group with exactly this token and nothing else: ${nonce}`,
+        );
+
+        const reply = await expectMessage(
+          sc.driver,
+          SUPERGROUP_ID,
+          (m) => m.text.includes(nonce),
+          { timeout: REPLY_BUDGET_MS, senderFilter: { notUserId: sc.driverUserId } },
+        );
+        const ttfo = Date.now() - sendStart;
+        console.warn(`[during-restart-channel] answered in ${ttfo}ms (nonce ${nonce})`);
+        expect(reply.chatId).toBe(SUPERGROUP_ID);
+        expect(reply.fromBot).toBe(true);
+        expect(reply.text).toContain(nonce);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    REPLY_BUDGET_MS + 60_000,
+  );
+});

--- a/telegram-plugin/uat/scenarios/jtbd-message-during-restart-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-message-during-restart-dm.test.ts
@@ -1,0 +1,95 @@
+/**
+ * JTBD — always-on: a message sent WHILE the agent is restarting must still be
+ * answered (DM). Regression gate for the v0.14.48 / #2117 lost-message incident
+ * (clerk/KenGPT, 2026-06-03).
+ *
+ * The wedge this guards: an inbound that arrives during a restart is buffered +
+ * spool-persisted, then redelivered on bridge-up — but `bridge registered` is
+ * not the same as `claude` session-ready. If claude is slow to boot (e.g. a
+ * Hindsight MCP timeout) the redelivered inject hit a still-booting session and
+ * was silently dropped; the 300s silence-poke then ended a phantom turn
+ * (`drained_buffered=0/0`) and the message was gone. The fix re-enrols the
+ * redelivered inbound in the deliver-until-acked queue so it re-delivers every
+ * 5s until claude actually consumes it.
+ *
+ * Unlike `jtbd-always-on-after-restart-dm` (which sends ~5s AFTER the restart
+ * returns, exercising the live path), this sends DURING the boot window so the
+ * message goes through the restart-redeliver path the fix patches. The mtcute
+ * driver sends straight to Telegram — independent of the agent's bridge — so the
+ * message queues server-side and is delivered the moment the new gateway
+ * reconnects.
+ *
+ * Self-skips green without NOPASSWD sudo (can't restart the agent).
+ */
+
+import { describe, it, expect } from "vitest";
+import { execSync, spawn } from "node:child_process";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+
+// After kicking the restart, wait this long before sending — long enough that
+// the reconcile + docker recreate have dropped the bridge, so the message
+// buffers and is drained on bridge-up (the restart-redeliver path). Override
+// for forensics (e.g. 6000 to land it deeper in the not-ready window so the
+// strand-rescue sweep fires).
+const BOOT_SEND_DELAY_MS = Number.parseInt(
+  process.env.SWITCHROOM_UAT_BOOT_SEND_DELAY_MS ?? "12000",
+  10,
+);
+
+// Generous: the fix re-delivers every 5s until claude is ready. The wedge
+// symptom is ≥300s (silence-poke floor) or never — both fail this.
+const REPLY_BUDGET_MS = 180_000;
+
+function canShellSudo(): boolean {
+  try {
+    execSync("sudo -n true", { stdio: "ignore", timeout: 2_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Kick a marker-safe restart and return immediately (detached). */
+function kickRestartDetached(name: string): void {
+  const child = spawn(
+    "sudo",
+    ["-n", "env", `PATH=${process.env.PATH}`, `HOME=${process.env.HOME}`,
+      "switchroom", "agent", "restart", name, "--force"],
+    { detached: true, stdio: "ignore" },
+  );
+  child.unref();
+}
+
+const sudoOk = canShellSudo();
+
+(sudoOk ? describe : describe.skip)("uat: message sent during a restart (DM)", () => {
+  it(
+    "a DM sent DURING the restart boot window is still answered (not lost)",
+    async () => {
+      const sc = await spinUp({ agent: AGENT, settleMs: 0 });
+      try {
+        const nonce = `bootdm-${Date.now().toString(36)}`;
+        kickRestartDetached(AGENT);
+        await new Promise((r) => setTimeout(r, BOOT_SEND_DELAY_MS));
+
+        const sendStart = Date.now();
+        await sc.sendDM(
+          `You are being restart-tested. Reply with exactly this token and nothing else: ${nonce}`,
+        );
+
+        const reply = await sc.expectMessage((m) => m.text.includes(nonce), {
+          from: "bot",
+          timeout: REPLY_BUDGET_MS,
+        });
+        const ttfo = Date.now() - sendStart;
+        console.warn(`[during-restart-dm] answered in ${ttfo}ms (nonce ${nonce})`);
+        expect(reply.text).toContain(nonce);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    REPLY_BUDGET_MS + 60_000,
+  );
+});


### PR DESCRIPTION
## Summary

Promotes the two throwaway canaries from the v0.14.48 (#2117) and v0.14.50 (#2122) rollouts into **permanent UAT regression gates** for the restart/delivery bug class.

These live in `telegram-plugin/uat/scenarios/` — **non-gating** (uat/** is excluded from gating CI) and **self-skip green** without NOPASSWD sudo (or, for the channel one, without a wired forum supergroup). They're runnable via `bun run --cwd telegram-plugin test:uat <name>`.

## Gates added

- **`jtbd-message-during-restart-dm`** / **`-channel`** — a message sent *DURING* the restart boot window is still answered (the #2117 lost-message gate). Distinct from `jtbd-always-on-after-restart-dm`, which sends ~5s *after* the restart returns (live path); these send during boot so the message goes through the restart-redeliver path. `SWITCHROOM_UAT_BOOT_SEND_DELAY_MS=6000` lands it deep enough in the not-ready window to exercise the strand-rescue sweep.
- **`jtbd-interrupted-turn-resumes-dm`** — a turn interrupted by a restart is resumed and the resume turn *completes* (not silently dropped) — the #2122 gate. Asserts the resume **framing** (`/resum|picking .*back|interrupted|cut off/i`), not an end-token: the resume synthetic only carries the first ~160 chars of the original prompt, so tail instructions aren't guaranteed to survive.

## Test plan

- [x] All three discovered by the uat runner (`vitest list --config ../vitest.uat.config.ts`)
- [x] `jtbd-interrupted-turn-resumes-dm` verified green live (56s — real interrupt → resume → completion)
- [x] during-restart DM/channel are byte-identical logic to the canaries already proven during the v0.14.48 rollout (DM answered 13.8s, supergroup 13.6s, strand-rescue fired at 6s delay)
- [x] `tsc --noEmit` clean
- CLAUDE.md release-critical scenarios list updated

## Risk

Minimal — additive test scenarios (non-gating, self-skipping) + a doc list update. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)