### PR TITLE
fix(telegram): resumed turn recovers the FULL original prompt, not a 160-char slice

### DIFF
--- a/telegram-plugin/gateway/resume-inbound-builder.ts
+++ b/telegram-plugin/gateway/resume-inbound-builder.ts
@@ -66,9 +66,12 @@ function threadIdNum(turn: Turn): number | undefined {
 function promptClause(turn: Turn): string {
   const p = turn.user_prompt_preview?.trim()
   if (!p) return ''
-  // Quote-trim so a long preview doesn't bloat the channel body.
-  const snippet = p.length > 160 ? p.slice(0, 160) + '…' : p
-  return ` The request was: "${snippet}".`
+  // The stored preview is already capped at the first ~200 chars of the user
+  // message (TURN_PREVIEW_MAX). Include it verbatim as a hint — do NOT
+  // re-truncate (the old 160-char slice dropped instructions that lived in the
+  // tail of a longer request). The FULL original is recovered via
+  // get_recent_messages; the resume body tells the model to do that.
+  return ` The start of the request was: "${p}".`
 }
 
 /**
@@ -117,12 +120,18 @@ export function buildResumeInterruptedInbound(ctx: ResumeInboundContext): Inboun
       `You just restarted. Your previous turn was interrupted ${elapsed} ago, ` +
       `before it finished — it was cut off by a restart, not completed.` +
       promptClause(ctx.turn) +
-      ` Pick that work back up now and continue it through to completion. ` +
-      `In your first message, briefly let the user know you're resuming what ` +
-      `was interrupted (mention roughly how long ago in plain language) so ` +
-      `they're not left wondering — then carry on with the actual task. Do ` +
-      `not ask whether to resume; just resume. If you genuinely can't tell ` +
-      `what the work was, say so and ask.`,
+      ` That quoted text is only the first ~200 characters of the original ` +
+      `request, and you've lost your in-memory context across the restart — so ` +
+      `BEFORE you continue, call get_recent_messages for this chat to read your ` +
+      `full original message and the surrounding conversation, so you resume the ` +
+      `COMPLETE task (including any instructions in the tail of a long request), ` +
+      `not just the truncated preview. Then pick that work back up and carry it ` +
+      `through to completion. In your first message, briefly let the user know ` +
+      `you're resuming what was interrupted (mention roughly how long ago in ` +
+      `plain language) so they're not left wondering — then carry on with the ` +
+      `actual task. Do not ask whether to resume; just resume. If even after ` +
+      `reading the recent messages you genuinely can't tell what the work was, ` +
+      `say so and ask.`,
     meta,
   }
 }

--- a/telegram-plugin/tests/resume-inbound-builder.test.ts
+++ b/telegram-plugin/tests/resume-inbound-builder.test.ts
@@ -106,12 +106,22 @@ describe('buildResumeInterruptedInbound', () => {
     expect(msg.meta.original_prompt).toBe('refactor the auth module')
   })
 
-  it('truncates a long prompt preview in the body', () => {
-    const long = 'x'.repeat(300)
-    const turn = makeTurn({ user_prompt_preview: long })
-    const msg = buildResumeInterruptedInbound({ turn })
-    expect(msg.text).toContain('…')
-    expect(msg.text).not.toContain('x'.repeat(200))
+  it('includes the FULL stored preview in the body (no double-truncation below the 200-char storage cap)', () => {
+    // The turns table already caps the preview at ~200 chars (TURN_PREVIEW_MAX);
+    // the builder must NOT slice it shorter (the old 160-char cut dropped detail
+    // from the tail of a longer request). A 180-char preview must appear in full.
+    const preview = "step 1 do X; step 2 do Y; step 3 do Z; " + "d".repeat(141) // 180 chars
+    expect(preview.length).toBe(180)
+    const msg = buildResumeInterruptedInbound({ turn: makeTurn({ user_prompt_preview: preview }) })
+    expect(msg.text).toContain(preview) // verbatim, not sliced to 160
+    expect(msg.meta.original_prompt).toBe(preview)
+  })
+
+  it('tells the resumed turn to recover the FULL original via get_recent_messages', () => {
+    const msg = buildResumeInterruptedInbound({ turn: makeTurn({ user_prompt_preview: 'short task' }) })
+    expect(msg.text).toContain('get_recent_messages')
+    // Frames the quoted preview as partial so the model knows to fetch the rest.
+    expect(msg.text).toMatch(/first ~200 characters|start of the request/i)
   })
 
   it('routes to the forum thread when thread_id is numeric', () => {


### PR DESCRIPTION
## Summary

A turn resumed after a restart only saw a **truncated preview** of the original request. The turns table stores the first ~200 chars (`TURN_PREVIEW_MAX`), and the boot-resume synthetic sliced that *again* to 160 (`promptClause`) — so instructions in the tail of a long/detailed task were silently dropped on resume. (Surfaced by the v0.14.50 interrupt-resume canary: a token placed at the end of a ~340-char prompt never made it into the resumed turn.)

## Why this is the right fix

The full original message is **always recoverable**: `recordInbound` stores it verbatim in the SQLite history buffer (no truncation — `history.ts`), `get_recent_messages` returns it verbatim, and that buffer **survives restarts** (it's the documented post-restart recovery path). The resume synthetic just never told the model to fetch it. So rather than bloat the turns table or the synthetic, the fix points the resumed turn at the existing full-fidelity source.

## What changed (`buildResumeInterruptedInbound`)

- `promptClause` no longer re-slices below the storage cap — the ~200-char stored preview is included verbatim as a hint, framed as *"the start of the request"* (so the model knows it's partial). Fixes both resume + report builders (shared helper).
- The resume body now instructs the model to call `get_recent_messages` for this chat (it has lost in-memory context across the restart) to read the **full** original message + surrounding context **before** continuing — so it resumes the complete task, including tail instructions, not just the preview.

## Test plan

- [x] `tsc --noEmit` clean; plugin-references + PII clean
- [x] Updated unit tests: a 180-char preview is included **verbatim** (no 160-cut); the body instructs `get_recent_messages` recovery and frames the quote as partial
- [x] 3996 bun + 3577 vitest green; no other test asserts on the old text
- [ ] Reviewer
- [ ] Canary: real interrupt with a long, tail-loaded prompt → resume → confirm the model fetches recent messages and completes the *full* task (the v0.14.50 canary's end-token case)

## Risk

Low. Text/prompt-only change to the resume synthetic + dropping a redundant slice; no delivery/routing/storm surface touched. The model is *instructed* to fetch recent messages — worst case it doesn't and behaves as before (still has the ~200-char preview, which is now 200 not 160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)