### PR TITLE
chore: release v0.14.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.14.51 — A resumed turn recovers the full original request (#2126)
+
+- **Restart-resume no longer loses the tail of a long request (#2126).** A turn
+  resumed after a restart only saw a truncated preview of what you'd asked: the
+  registry stores the first ~200 characters of the message, and the resume
+  wake-up sliced that again to 160 — so instructions near the end of a long,
+  detailed task were silently dropped, and the agent resumed only the part it
+  could still see. The full message was always on disk (the per-chat history
+  buffer stores it verbatim and survives restarts), the resume just never went
+  back for it. Now the resume wake-up includes the full stored preview and tells
+  the agent to pull its complete original message (and surrounding context) from
+  recent history before continuing — so it picks the *whole* task back up, not a
+  clipped version. No behaviour change for short requests.
+
+- Also lands the permanent restart/resume UAT regression gates (#2125,
+  dev-only test infra).
+
 ## v0.14.50 — Resumed turns get a progress card + survive a not-ready restart (#2122)
 
 When an agent restarts mid-work, the boot-resume wake-up (the synthetic message

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.50",
+  "version": "0.14.51",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.14.51 — ships #2126 (a resumed turn recovers the full original request, not a 160-char slice) + #2125 (permanent restart/resume UAT gates, dev-only). Constituent PRs reviewed (APPROVE). 🤖 Generated with [Claude Code](https://claude.com/claude-code)