### PR TITLE
fix(telegram): default the visible answer-stream OFF (no unformatted flash)

### DIFF
--- a/telegram-plugin/answer-stream-flag.ts
+++ b/telegram-plugin/answer-stream-flag.ts
@@ -1,0 +1,18 @@
+/**
+ * Parse the `SWITCHROOM_VISIBLE_ANSWER_STREAM` env flag.
+ *
+ * Default **OFF** (flipped 2026-06-03, operator request) — see the rationale
+ * on the `ANSWER_STREAM_VISIBLE_ENABLED` gate in `gateway/gateway.ts`. When
+ * off, the answer lane streams to the invisible compose-box draft and the
+ * reply tool is the single canonical formatted message — no unformatted
+ * preliminary that flashes and gets deleted. Opt back IN per agent with
+ * `SWITCHROOM_VISIBLE_ANSWER_STREAM=1` (also accepts true/on/yes).
+ *
+ * Extracted as a pure function so the default + parsing are unit-testable
+ * (gateway.ts is not importable in isolation — top-level side effects).
+ */
+export function parseVisibleAnswerStreamEnabled(raw: string | undefined): boolean {
+  if (raw == null) return false
+  const v = raw.trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'on' || v === 'yes'
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8437,9 +8437,19 @@ function handleSessionEvent(ev: SessionEvent): void {
             // tool_use stream (case 'tool_use' above) where the real
             // signal lives. assistant.text keeps its visible-message
             // home; the reply tool stays the canonical answer.
+            // Flag OFF (default): use the compose-box draft for DMs, and set
+            // minInitialChars effectively-infinite so the lane NEVER opens a
+            // visible chat message. This matters in supergroup TOPICS, where
+            // draft transport is unsupported (gateway.ts:6422) so the lane
+            // would otherwise fall to message transport and post a visible
+            // preview once interstitial text passed the default 50-char gate
+            // — which retract() then deletes (the unformatted flash, marko
+            // General). With the gate unreachable the only posted message is
+            // the canonical reply. (The gate is bypassed for DM draft
+            // transport, so DM draft streaming is unaffected.)
             ...(ANSWER_STREAM_VISIBLE_ENABLED
               ? { minInitialChars: 1 }
-              : { sendMessageDraft: sendMessageDraftFn }),
+              : { sendMessageDraft: sendMessageDraftFn, minInitialChars: Number.MAX_SAFE_INTEGER }),
             // #1075: route through robustApiCall so flood-wait,
             // benign-400, and THREAD_NOT_FOUND are handled uniformly
             // instead of crashing the answer-stream loop on a deleted

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -96,6 +96,7 @@ import * as pendingProgress from '../pending-work-progress.js'
 import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd } from '../silent-end.js'
 import { isFinalAnswerReply } from '../final-answer-detect.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
+import { parseVisibleAnswerStreamEnabled } from '../answer-stream-flag.js'
 import { type SessionEvent } from '../session-tail.js'
 import {
   shouldSuppressToolActivity,
@@ -3738,23 +3739,33 @@ const TURN_FLUSH_SAFETY_ENABLED = isTurnFlushSafetyEnabled()
 // the cross-turn pending-progress system (#1445/#1669) is the
 // canonical surface and DOES ping at the appropriate boundaries.
 //
-// 2026-05-25: default flipped ON after fleet-log audit showed
-// framework-fallback rate at ~19% of inbounds (target per
-// `reference/conversational-pacing.md`: <0.5%). Streaming the
-// model's text events live into the chat closes the
-// catastrophic-UX failure mode at the lane-of-first-defense level.
-// Aligned with the "chat IS the artifact" sub-principle (the user
-// sees a normal chat message that grows — no chrome, no parallel
-// widget). Override with SWITCHROOM_VISIBLE_ANSWER_STREAM=0 to
-// disable, e.g. for an agent that needs the legacy draft-only
-// behaviour during debugging.
-const ANSWER_STREAM_VISIBLE_ENABLED = (() => {
-  const raw = process.env.SWITCHROOM_VISIBLE_ANSWER_STREAM
-  if (raw == null) return true
-  const v = raw.trim().toLowerCase()
-  if (v === '0' || v === 'false' || v === 'off' || v === 'no') return false
-  return true
-})()
+// 2026-05-25: default flipped ON after a fleet-log audit showed a ~19%
+// framework-fallback ("still working…") rate — the visible stream gave an
+// immediate in-timeline signal that suppressed the silence-poke.
+//
+// 2026-06-03: default flipped back OFF (operator request). In practice the
+// visible stream delivered ~none of its intended benefit while imposing a
+// jarring cost:
+//   - Telegram rate-limits editMessageText to roughly once/second, so real
+//     "watch it type" streaming is impossible; and the model emits almost no
+//     interstitial assistant.text (it thinks → tool → reply), so the
+//     preliminary was a near-empty bubble (observed: 5–13 byte edits).
+//   - On every turn where the model calls the reply tool (≈always), the reply
+//     posts a SEPARATE canonical message and the stream RETRACTS (deletes) its
+//     preliminary — the user sees a raw bubble appear then vanish, replaced by
+//     the formatted reply. In supergroup topics it also mis-routed (preliminary
+//     → General, reply → topic). Net: an unformatted flash + a delete, no
+//     streaming value.
+// The anti-silence role the visible stream once filled is now covered by the
+// live ACTIVITY FEED (tool-use streaming, below), the "…typing" chat-action
+// loop, and `thinking_effort: low` (fast tool-less turns) — so off-by-default
+// no longer regresses the framework-fallback rate. With the flag off the lane
+// uses the invisible compose-box draft (the original default, #1664-compatible)
+// and the reply tool is the single canonical, formatted message.
+// Opt back IN per agent with SWITCHROOM_VISIBLE_ANSWER_STREAM=1.
+const ANSWER_STREAM_VISIBLE_ENABLED = parseVisibleAnswerStreamEnabled(
+  process.env.SWITCHROOM_VISIBLE_ANSWER_STREAM,
+)
 
 // Activity feed. The gateway streams a live "what it's doing" tool-activity
 // feed for every turn. The PreToolUse sidecar emits a `tool_label` per tool

--- a/telegram-plugin/tests/answer-stream-flag.test.ts
+++ b/telegram-plugin/tests/answer-stream-flag.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Pin the SWITCHROOM_VISIBLE_ANSWER_STREAM contract: default OFF (2026-06-03),
+ * opt-in only on a truthy value. Guards against an accidental flip back to
+ * default-on (which would reintroduce the unformatted-preliminary flash +
+ * delete-on-every-reply — see the gateway gate comment).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parseVisibleAnswerStreamEnabled } from '../answer-stream-flag.js'
+
+describe('parseVisibleAnswerStreamEnabled — default OFF, opt-in', () => {
+  it('defaults OFF when unset', () => {
+    expect(parseVisibleAnswerStreamEnabled(undefined)).toBe(false)
+  })
+
+  it('stays OFF for empty / falsey / unrecognized values', () => {
+    for (const v of ['', '   ', '0', 'false', 'off', 'no', 'nope', 'enabled', 'x']) {
+      expect(parseVisibleAnswerStreamEnabled(v)).toBe(false)
+    }
+  })
+
+  it('opts IN only on explicit truthy values (case/space-insensitive)', () => {
+    for (const v of ['1', 'true', 'on', 'yes', ' TRUE ', 'On', 'YES']) {
+      expect(parseVisibleAnswerStreamEnabled(v)).toBe(true)
+    }
+  })
+})

--- a/telegram-plugin/tests/gateway-no-reply-single-emit.test.ts
+++ b/telegram-plugin/tests/gateway-no-reply-single-emit.test.ts
@@ -68,6 +68,41 @@ describe('#656 — answer-stream retract() at turn_end emits nothing', () => {
     expect(deleteMessage).not.toHaveBeenCalled()
   })
 
+  // Visible-answer-stream OFF (default since 2026-06-03): the gateway passes
+  // minInitialChars=MAX_SAFE_INTEGER so a SUPERGROUP turn (message transport —
+  // draft is unsupported in forum topics) NEVER opens a visible preview, no
+  // matter how much interstitial assistant.text streams. This is the full fix
+  // for the marko-General unformatted-flash (the DM path is already covered by
+  // draft transport). Without it, message transport opens at the 50-char gate
+  // and retract() then deletes it.
+  it('flag-off supergroup: huge minInitialChars never opens a message even past the 50-char gate', async () => {
+    const sendMessage = vi.fn(async () => ({ message_id: nextMessageId++ }))
+    const editMessageText = vi.fn(async () => {})
+    const deleteMessage = vi.fn(async () => {})
+
+    const stream = createAnswerStream({
+      chatId: 'supergroup-topic',
+      isPrivateChat: false, // supergroup → message transport (no draft)
+      threadId: 4,
+      minInitialChars: Number.MAX_SAFE_INTEGER,
+      throttleMs: 250,
+      sendMessage: sendMessage as never,
+      editMessageText: editMessageText as never,
+      deleteMessage: deleteMessage as never,
+    })
+
+    // Feed 200 chars — well past the default 50-char open gate.
+    stream.update('x'.repeat(200))
+    vi.advanceTimersByTime(1000)
+    await flushMicrotasks()
+    expect(sendMessage).not.toHaveBeenCalled() // never opened a preview
+    expect(editMessageText).not.toHaveBeenCalled()
+
+    await stream.retract()
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(deleteMessage).not.toHaveBeenCalled() // nothing to delete → no flash
+  })
+
   it('retract after a preliminary send: deletes the prelim, no fresh sendMessage', async () => {
     const THROTTLE = 1000
     const sendMessage = vi.fn(async () => ({ message_id: nextMessageId++ }))


### PR DESCRIPTION
## Summary

On every reply (DMs **and** supergroups) an unformatted message appears, then a properly-formatted message is sent, then the unformatted one is deleted. This disables the mechanism causing it.

## Root cause (verified live)

The **visible answer-stream** (default-on since 2026-05-25) posts a "preliminary" chat message seeded with the model's **raw markdown** and edits it as tokens stream. When the model calls the **reply tool (≈every turn)**, the reply posts a **separate** canonical formatted message and the stream **`retract()`s — deletes — its preliminary**. Net: an unformatted bubble flashes and vanishes, replaced by the formatted reply. In supergroup topics it also mis-routes (preliminary → General, reply → topic).

Live evidence (clerk DM + marko SG): the preliminary gets only **1–2 tiny edits (5–13 bytes)** before deletion — Telegram rate-limits `editMessageText` to ~1/s so real "watch it type" streaming is impossible, and the model emits almost no interstitial `assistant.text` (thinks → tool → reply). So the visible stream delivered ~no value while imposing the flash + delete every turn.

## Fix

Flip the `SWITCHROOM_VISIBLE_ANSWER_STREAM` default to **OFF** (extracted to `parseVisibleAnswerStreamEnabled`, unit-tested). With it off the answer lane uses the invisible compose-box draft (the original default) and the **reply tool is the single canonical, formatted message** — no preliminary post, no delete. Opt back in per agent with `SWITCHROOM_VISIBLE_ANSWER_STREAM=1`.

## Anti-silence note (the one risk to validate)

The visible stream was originally flipped on to cut a **~19% framework-fallback ("still working…") rate**. That role is now covered by the live **activity feed** (tool-use streaming), the **"…typing"** chat-action loop, and `thinking_effort: low` (fast tool-less turns). **Canary will confirm the framework-fallback rate does not regress before fleet rollout** — revert is a one-flag flip.

## Test plan
- [x] `answer-stream-flag.test.ts` — default OFF; opt-in only on `1/true/on/yes`
- [x] `tsc` + full lint chain clean; plugin unit suite **3999 pass, 0 fail**
- [ ] canary test-harness: tool-using + tool-less turns, DM **and** forum topic → (a) NO `answer-stream: sent`/`retracted` + single formatted reply, (b) framework-fallback rate not regressed

## Risk
Low + reversible. No change to the reply path; the lane reverts to draft transport. `retract()` only deletes a posted message (`answer-stream.ts:621`), so off ⇒ no `deleteMessage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)