### PR TITLE
fix(telegram): bind turn-pacing 'answer' to the reply tool (cut orphaned-reply flushes)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4139,7 +4139,15 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
     '"Sent.", "Hope that helps." as a separate message once you have ' +
     'already replied. Your answer is the last thing the user should ' +
     'see; a follow-up "Done." is dead-air clutter (and the user\'s ' +
-    'device already pinged on the answer). Stop after the answer.</turn-pacing>';
+    'device already pinged on the answer). Stop after the answer.\n\n' +
+    'CRITICAL: "answer" means a call to the reply tool ' +
+    '(mcp__switchroom-telegram__reply, or stream_reply with done=true). ' +
+    'Your terminal/transcript text is NEVER delivered to Telegram — the ' +
+    'user sees only what you send through the reply tool. After a long ' +
+    'tool sequence (scheduling, multi-step research, sub-agent handback), ' +
+    'do not let your closing narration stand as the answer: end the turn ' +
+    'by passing that narration to the reply tool. No reply tool call = the ' +
+    'user got nothing, however much text you wrote.</turn-pacing>';
   const switchroomUserPromptSubmit: Array<Record<string, unknown>> = [
     ...(useHotReloadStable
       ? [

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2464,6 +2464,44 @@ describe("scaffoldAgent with global defaults cascade", () => {
     ]);
   });
 
+  it("turn-pacing directive ties the answer to the reply tool", () => {
+    // Regression for the orphaned-reply visibility defect: the model
+    // (esp. marko on long Postiz tasks) ended turns with plain transcript
+    // text and no reply tool call, so the 30s orphaned-reply backstop had
+    // to flush late. The turn-pacing directive previously said "just
+    // answer" / "Stop after the answer" without binding "answer" to the
+    // reply tool — the model satisfied it by writing terminal text. This
+    // assertion pins the explicit reply-tool requirement so the guidance
+    // can't silently regress. The directive is passed verbatim into a
+    // printf hook command, so it appears literally in settings.json.
+    const agentConfig = makeAgentConfig({});
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "pacing-agent": agentConfig },
+    } as SwitchroomConfig;
+    const result = scaffoldAgent(
+      "pacing-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const pacingHook = (settings.hooks.UserPromptSubmit as Array<{
+      hooks: Array<{ command: string }>;
+    }>)
+      .flatMap((g) => g.hooks)
+      .find((h) => h.command.includes("turn-pacing"));
+    expect(pacingHook).toBeDefined();
+    const cmd = pacingHook!.command;
+    expect(cmd).toContain("mcp__switchroom-telegram__reply");
+    expect(cmd).toMatch(/terminal\/transcript text is NEVER delivered/);
+    expect(cmd).toMatch(/No reply tool call = the user got nothing/);
+  });
+
   it("unions defaults.hooks with per-agent hooks", () => {
     const agentConfig = makeAgentConfig({
       hooks: {


### PR DESCRIPTION
## Summary

Fleet-wide, agents (esp. marko on long Postiz tool sequences) sometimes end a turn with the answer written as plain transcript text and **no reply-tool call**. Telegram only delivers text sent via the reply tool, so the gateway's 30s `orphaned-reply` backstop flushes the captured text **~30s late** — which reads to the operator as "marko isn't posting updates." Measured at **15–40% of turns across the fleet** (marko ~25%, lawgpt ~40%, gymbro ~39%) — not marko-specific.

## Root cause (investigation, adversarially verified)

A **guidance gap**, not a timing bug. The per-turn `turnPacingDirective` (the live UserPromptSubmit hook the model reads each turn) said "just answer / stop after the answer" but never bound **"answer" to a reply-tool call**. After a long tool sequence the model lets its closing narration stand as the answer and stops — never calling reply — so only the 30s backstop surfaces it.

## Fix — the one verified-safe lever (prompt-only)

Append a CRITICAL clause to `turnPacingDirective` (`src/agents/scaffold.ts`): *"answer" means a call to the reply tool; transcript text is NEVER delivered to Telegram; after a long tool sequence, pass your closing narration to the reply tool.* Takes effect on restart; reverts by reverting the commit; no kill switch needed (a prompt clause can't itself cause a wrong send). The existing NO_REPLY carve-outs (greetings, genuine non-prompts) are intact.

## Deferred (with evidence — do NOT ship)

- **Tighten the 30s timeout — REFUTED unsafe.** `resetOrphanedReplyTimeout` resets only on assistant *text* (single callsite, never on tool_use), so a shorter timer fires mid-tool-sequence → premature partial flush, and the model's later real reply also sends (exact-string dedup misses partial-vs-full) → **double-send**.
- **A turn-end reply nudge — already exists** (`silent-end-interrupt-stop.mjs`). A second one widens the flush-vs-reply race.
- **De-flicker the answer-stream — moot** (visible stream OFF since v0.14.52 / #2128).

## Test plan

- [x] New regression test (`tests/scaffold.test.ts`): the rendered `settings.json` turn-pacing hook command contains the reply-tool binding + the two new sentences (pins the live carrier).
- [x] 188 vitest pass; `tsc --noEmit` clean.
- [x] Fresh-process reviewer APPROVE (live-carrier confirmed, no NO_REPLY regression, deferred-levers validated).
- [ ] UAT: after roll, tail `orphaned-reply timeout` / `turn-flush firing` vs `reply: invoked` on a long-tool-sequence turn — expect the turn-flush ratio to drop.

## Risk

Low — prompt-only, no code-path change, no new emitter (so no new double-send surface), timeout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)