### PR TITLE
chore: release v0.14.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.14.54 — The "what it's doing" status stays as a record (#2132)
+
+- **The live activity/status feed now stays in the chat by default (#2132).**
+  The in-place "what it's doing" message (Reading X, Searching the web for Y,
+  …) used to be **deleted** the moment the final answer landed. On trivial
+  turns that produced a visible post-then-delete flicker, and it threw away a
+  useful "what I just did" trail. It now **stays**: when the answer lands the
+  message is finalized in place — every step marked done (`✓`), no frozen
+  "→ in-progress" arrow — and left beside the reply as a record. No
+  post-then-delete. Opt back into deletion per agent with
+  `channels.telegram.clear_status_on_completion: true`. Config-only change;
+  takes effect on restart.
+
 ## v0.14.53 — Answers post promptly after long tasks (#2130)
 
 - **No more ~30-second blank after a long task (#2130).** Agents sometimes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.53",
+  "version": "0.14.54",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.14.54 — **the "what it's doing" status stays as a record**.

Constituent PR (reviewed + merged):
- #2132 — configurable status-message clear-on-completion, **default off**. The live activity/status feed is now finalized in place (all steps `✓`) and left beside the reply instead of deleted; opt into deletion via `channels.telegram.clear_status_on_completion: true`.

Trivial diff (version bump + CHANGELOG). The feature PR was independently reviewed (APPROVE) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)