### PR TITLE
fix(agents): export gateway-consumed env before the gateway fork in start.sh

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -33,6 +33,24 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
   # same path the rest of start.sh + the MCP sidecar expects.
   export TELEGRAM_STATE_DIR="{{agentDir}}/telegram"
 
+  # Gateway-consumed env MUST be exported HERE, before the gateway fork
+  # below. The gateway daemon reads channels.telegram.* knobs (and any
+  # agent env) from process.env at startup — e.g. SWITCHROOM_TG_STREAM_
+  # THROTTLE_MS, SWITCHROOM_TG_EDIT_BUDGET_THRESHOLD,
+  # SWITCHROOM_TG_CLEAR_STATUS_ON_COMPLETION. The inner tmux pass
+  # re-exports the SAME user-env block below for claude, because tmux
+  # does not reliably propagate arbitrary env across the
+  # re-exec. Without this hoist these vars only ever reach the inner
+  # (claude) pass and the already-forked gateway never sees them — every
+  # channels.telegram env knob silently defaults on docker agents (the
+  # start.sh env-fork landmine, same class as #1997 /
+  # SWITCHROOM_HANDOFF_SHOW_LINE). Pinned by the scaffold-order test
+  # asserting these exports precede the gateway-fork line.
+{{#if userEnvQuoted}}
+{{#each userEnvQuoted}}  export {{@key}}={{{this}}}
+{{/each}}
+{{/if}}
+
   # Tiny in-process supervisor: runs cmd in a respawn loop with
   # exponential backoff (1→2→4…→60s cap) and NEVER permanently gives
   # up. Rationale (RFC J / install-validation 2026-05-17): the

--- a/tests/scaffold.gateway-env-order.test.ts
+++ b/tests/scaffold.gateway-env-order.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * Regression guard for the start.sh env-fork landmine
+ * (feedback_startsh_env_before_gateway_fork, same class as #1997 /
+ * SWITCHROOM_HANDOFF_SHOW_LINE).
+ *
+ * The docker runtime forks the gateway daemon in start.sh's OUTER pass and
+ * then re-execs into a tmux inner pass for claude. The gateway reads
+ * channels.telegram.* knobs (SWITCHROOM_TG_*) from process.env at startup —
+ * so those exports MUST appear before the gateway-fork line. Before the fix
+ * they only rendered in the inner pass (after the fork), so the daemon never
+ * saw them and every channels.telegram env knob silently defaulted on docker.
+ */
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeSwitchroomConfig(agentName: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [agentName]: agentConfig },
+  };
+}
+
+const GATEWAY_FORK = 'bun "$_gateway_bundle"';
+
+describe("start.sh: gateway-consumed env exported before the gateway fork", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-gw-env-order-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function renderStartSh(): string {
+    const config = {
+      extends: "default",
+      topic_name: "Test Topic",
+      schedule: [],
+      channels: {
+        telegram: {
+          clear_status_on_completion: true,
+          stream_throttle_ms: 1234,
+        },
+      },
+    } as AgentConfig;
+    const sw = makeSwitchroomConfig("test-agent", config);
+    const result = scaffoldAgent("test-agent", config, tmpDir, telegramConfig, sw);
+    return readFileSync(join(result.agentDir, "start.sh"), "utf-8");
+  }
+
+  it("hoists SWITCHROOM_TG_* exports AHEAD of the gateway fork (docker outer pass)", () => {
+    const startSh = renderStartSh();
+    const forkIdx = startSh.indexOf(GATEWAY_FORK);
+    expect(forkIdx).toBeGreaterThan(-1);
+
+    const clearIdx = startSh.indexOf("export SWITCHROOM_TG_CLEAR_STATUS_ON_COMPLETION=");
+    const throttleIdx = startSh.indexOf("export SWITCHROOM_TG_STREAM_THROTTLE_MS=");
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(throttleIdx).toBeGreaterThan(-1);
+
+    // The FIRST occurrence (outer-pass hoist) must precede the fork, or the
+    // gateway daemon never sees the var.
+    expect(clearIdx).toBeLessThan(forkIdx);
+    expect(throttleIdx).toBeLessThan(forkIdx);
+  });
+
+  it("still re-exports the same vars in the inner pass (after the fork) for claude", () => {
+    const startSh = renderStartSh();
+    const forkIdx = startSh.indexOf(GATEWAY_FORK);
+
+    const first = startSh.indexOf("export SWITCHROOM_TG_CLEAR_STATUS_ON_COMPLETION=");
+    const second = startSh.indexOf(
+      "export SWITCHROOM_TG_CLEAR_STATUS_ON_COMPLETION=",
+      first + 1,
+    );
+    // Hoisted copy before the fork (gateway), re-exported copy after it (claude
+    // — tmux does not reliably propagate arbitrary env across the re-exec).
+    expect(first).toBeGreaterThan(-1);
+    expect(first).toBeLessThan(forkIdx);
+    expect(second).toBeGreaterThan(forkIdx);
+  });
+});


### PR DESCRIPTION
## Summary

The docker runtime forks the gateway daemon in start.sh's **outer** pass and then re-execs into a tmux **inner** pass for claude. `channels.telegram.*` env knobs (`SWITCHROOM_TG_*`, from `channelsToEnv` → `userEnvQuoted`) were rendered only in the inner pass — *after* the gateway fork — so the gateway daemon, which reads them from `process.env` at startup, never saw them. **Every `channels.telegram` env knob silently defaulted on docker agents.**

Same env-fork landmine class as #1997 (`SWITCHROOM_HANDOFF_SHOW_LINE`).

## How it surfaced

Shipped `channels.telegram.clear_status_on_completion` (#2132 / v0.14.54). Canarying the opt-in on test-harness: setting `clear_status_on_completion: true` did **not** delete the status feed. `/proc/<gateway-pid>/environ` showed **0** `SWITCHROOM_TG_*` vars — the gateway took the default branch because it never received the var.

## Fix

Hoist the `userEnv` export block into the docker outer pass, **before** the gateway fork (`bun "$_gateway_bundle"`). The inner pass keeps its own copy — tmux does not reliably propagate arbitrary env across the re-exec, so claude still needs the inner export.

## Blast radius

**Zero fleet behavior change.** No agent currently sets any `channels.telegram` env knob (verified against the live config — only test-harness's canary `clear_status_on_completion`). This purely makes the knobs functional where set.

## Test plan

- [x] `tests/scaffold.gateway-env-order.test.ts` — `SWITCHROOM_TG_*` export precedes the gateway-fork line (outer pass); same vars re-exported after the fork (inner pass) for claude
- [x] `tsc --noEmit` clean
- [x] full scaffold suite (210) green

## Risk

Low. The `start.sh.hbs` change is additive (extra exports in the outer pass); the inner-pass block is unchanged. Effect takes hold on agent restart (start.sh is re-rendered at reconcile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)