### PR TITLE
chore: release v0.14.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.14.55 — Telegram channel config knobs reach the gateway on docker (#2135)
+
+- **`channels.telegram.*` env knobs now actually take effect on docker
+  agents (#2135).** start.sh forks the Telegram gateway daemon in its outer
+  pass, then re-execs into a tmux inner pass for the agent. The
+  `channels.telegram.*` knobs the gateway reads from its environment
+  (stream throttle, edit budget, and the new
+  `clear_status_on_completion` from v0.14.54) were exported only in the
+  inner pass — *after* the gateway had already forked — so the daemon never
+  saw them and every such knob silently fell back to its default. They're
+  now exported before the gateway fork. No fleet behaviour change today (no
+  agent sets one of these knobs); this makes them functional for anyone who
+  does — including `clear_status_on_completion: true` to opt back into
+  deleting the live status feed on completion. Takes effect on restart.
+
 ## v0.14.54 — The "what it's doing" status stays as a record (#2132)
 
 - **The live activity/status feed now stays in the chat by default (#2132).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.54",
+  "version": "0.14.55",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.14.55 — **Telegram channel config knobs reach the gateway on docker**.

Constituent PR (reviewed APPROVE + merged):
- #2135 — fix the start.sh env-fork so `channels.telegram.*` knobs (`SWITCHROOM_TG_*`) are exported before the gateway daemon forks. They were inner-pass-only, so the gateway never saw them and every knob silently defaulted on docker. Makes `clear_status_on_completion: true` (and stream throttle / edit budget) functional.

Zero fleet behaviour change today (no agent sets one of these knobs). Trivial diff (version + CHANGELOG); feature PR independently reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)