### PR TITLE
fix(telegram): finalize the foreground+ack-first activity feed to done (✓)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8467,8 +8467,18 @@ async function drainActivitySummary(turn: CurrentTurn): Promise<void> {
  * Called on the first reply (hand-off) and again at turn_end (no-reply safety
  * net); finalize edits are idempotent (a 'message is not modified' on the
  * second call is swallowed).
+ *
+ * `finalHtmlOverride` (finalize path only): a render captured by the caller
+ * BEFORE it tore down turn state the finalize render depends on. The
+ * foreground handoff-clear path passes this — it deletes the just-finished
+ * sub-agent's narrative right after this call, so the async
+ * `composeTurnActivity(turn, true)` below would see an emptied feed (and, on
+ * ack-first turns, empty `mirrorLines`), render null, and skip the finalize —
+ * freezing the last live "→ in-progress" line. The captured render keeps the
+ * persisted record reading done (✓). Omitted → compute it here (the common
+ * reply/turn_end callers, where state is stable).
  */
-function clearActivitySummary(turn: CurrentTurn): void {
+function clearActivitySummary(turn: CurrentTurn, finalHtmlOverride?: string | null): void {
   const chat = turn.sessionChatId
   const thread = turn.sessionThreadId
   const inFlight = turn.activityInFlight ?? Promise.resolve()
@@ -8489,7 +8499,8 @@ function clearActivitySummary(turn: CurrentTurn): void {
     }
     // Default: leave the status message as a record, edited to a terminal
     // all-done state so it doesn't freeze on a misleading "→ in-progress" line.
-    const finalHtml = composeTurnActivity(turn, true)
+    const finalHtml =
+      finalHtmlOverride !== undefined ? finalHtmlOverride : composeTurnActivity(turn, true)
     if (finalHtml == null) return
     try {
       await robustApiCall(
@@ -19278,20 +19289,32 @@ void (async () => {
                   // tool result, so there's no handback to deliver. Reaction
                   // promotion already ran above.
                   const turn = currentTurn
-                  const removed = turn != null && turn.foregroundSubAgents.delete(agentId)
-                  if (turn != null && removed) {
+                  // has()-then-delete (not delete-up-front): the handoff-clear
+                  // branch must render the finished sub-agent's steps as done
+                  // WHILE its narrative is still in the map, then remove it.
+                  if (turn != null && turn.foregroundSubAgents.has(agentId)) {
                     const action = foregroundFinishAction({
-                      removed,
+                      removed: true,
                       replyCalled: turn.replyCalled,
-                      remainingForeground: turn.foregroundSubAgents.size,
+                      // size AFTER this agent's impending removal
+                      remainingForeground: turn.foregroundSubAgents.size - 1,
                     })
                     if (action === 'handoff-clear') {
                       // Post-ack: the last foreground sub-agent finished and
                       // the parent will now produce its answer inline. Hand
                       // the re-opened feed off to the answer, mirroring the
-                      // first-reply clear (turn_end is the safety net).
-                      clearActivitySummary(turn)
+                      // first-reply clear (turn_end is the safety net). Capture
+                      // the finalized render (child steps done ✓) BEFORE the
+                      // delete, then pass it so the persisted record doesn't
+                      // freeze on a stale "→ in-progress" line (the emptied-feed
+                      // skip — see clearActivitySummary's finalHtmlOverride doc).
+                      const finalHtml = composeTurnActivity(turn, true)
+                      turn.foregroundSubAgents.delete(agentId)
+                      clearActivitySummary(turn, finalHtml)
                     } else if (action === 'recompose') {
+                      // Collapse the finished sub-agent's block: delete first,
+                      // then render WITHOUT it (live feed keeps its → step).
+                      turn.foregroundSubAgents.delete(agentId)
                       const rendered = composeTurnActivity(turn)
                       if (rendered != null) {
                         turn.activityPendingRender = rendered

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -222,4 +222,30 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
       "<i>✓ Reading a.ts</i>",
     );
   });
+
+  // Pins the invariant the gateway's foreground handoff-clear path relies on:
+  // on an ack-first turn the parent feed is empty (mirrorLines=[]) and the only
+  // content is the foreground sub-agent's nested narrative. The finalized
+  // render MUST be captured WHILE that narrative is present — once the gateway
+  // removes the finished sub-agent from the map, the render collapses to null
+  // and the finalize would be skipped, freezing the last live "→" line. This is
+  // exactly why clearActivitySummary takes a pre-delete finalHtmlOverride.
+  describe("foreground handoff-clear: capture-before-delete invariant", () => {
+    it("ack-first (empty parent) + child present → non-null all-done render (✓, no →)", () => {
+      const out = renderActivityFeedWithNested(
+        [],
+        ["Sleep 2 for step 8", "Step 8 done; final echo", "All eight steps completed"],
+        true,
+      );
+      expect(out).not.toBeNull();
+      expect(out).not.toContain("→");
+      expect(out).toContain("All eight steps completed");
+    });
+
+    it("ack-first (empty parent) + child REMOVED → null (the emptied-feed skip the gateway must avoid)", () => {
+      // After foregroundSubAgents.delete(agentId), the parent has nothing left
+      // to render on an ack-first turn → null → finalize would no-op.
+      expect(renderActivityFeedWithNested([], [], true)).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes the cosmetic follow-up from v0.14.55. When a foreground sub-agent finishes on an **ack-first** turn ("On it" → `Task`), the persisted status feed froze on its last live `→ in-progress` line instead of reading done (`✓`).

**Root cause:** the handoff-clear path deleted the finished sub-agent from `turn.foregroundSubAgents` *before* calling `clearActivitySummary`. The finalize runs async (`inFlight.then`), so `composeTurnActivity(turn, true)` then saw an empty map **and** empty parent `mirrorLines` (ack-first) → rendered `null` → skipped the finalize edit. The message still **persisted** (the operator's ask), so this was purely cosmetic; common (non-foreground) turns finalized to all-`✓` correctly.

## Fix

In the `handoff-clear` branch, capture `composeTurnActivity(turn, true)` **while the finished sub-agent's narrative is still in the map**, then delete it, then pass the captured render to `clearActivitySummary(turn, finalHtmlOverride)` (new optional param). The two non-foreground callers omit the param → compute as before (byte-identical). The `recompose` branch keeps its delete-then-render order (it deliberately collapses the finished block). Switched the foreground block from delete-up-front to `has()`-then-delete so the capture can precede removal; `remainingForeground` is `size - 1` (equivalent given `has()` confirmed presence).

## Test plan

- [x] `tool-activity-summary.test.ts` — pins the capture-before-delete invariant: ack-first (empty parent) + child present → non-null all-`✓` (no `→`); child removed → `null` (the emptied-feed skip the gateway must avoid)
- [x] existing `foreground-nesting` + activity tests green; full plugin bun suite (4047 pass)
- [x] `tsc`, `check-bot-api-wrapping`, `check-plugin-references` clean
- [ ] live canary: re-run `jtbd-foreground-subagent-activity-dm` + confirm the persisted feed finalizes to `✓` (no `→`)

## Risk

Low/medium — touches the delicate foreground handoff path. The behavior change is confined to the `handoff-clear` case (ack-first + last sub-agent); `recompose`, delete-mode, and the non-foreground callers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)