### PR TITLE
chore: release v0.14.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.14.57 — The left-behind status feed reads "done", not stuck mid-step (#2139)
+
+- **The persisted "what it's doing" feed now finalizes cleanly after a
+  delegated step (#2139).** Since v0.14.54 the live status feed stays in the
+  chat as a record, finalized to all-done (`✓`). One path missed that: when
+  the agent acked ("On it") and then handed a step to a foreground sub-agent,
+  the feed froze on its last `→ in-progress` line instead of `✓` once the
+  sub-agent finished — the sub-agent's steps were cleared from the feed a beat
+  before the finalize ran, leaving nothing to mark done. The finalize now
+  captures the done-state *before* clearing, so those turns read complete like
+  every other turn. Cosmetic only (the message always persisted); takes effect
+  on restart.
+
 ## v0.14.56 — Two questions in two topics get two answers, each in its own topic (#2137)
 
 - **Per-topic reply routing for multi-topic supergroups (#2137).** Asking an

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.56",
+  "version": "0.14.57",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.14.57 — **the left-behind status feed reads done, not stuck mid-step**. Constituent PR (adversarially reviewed, 4-lens panel APPROVE, merged): #2139 — finalize the foreground+ack-first activity feed to ✓ (capture the done-state before clearing the sub-agent's narrative). Cosmetic; the message always persisted. Trivial diff (version + CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)