### PR TITLE
fix(telegram): keep the live activity feed alive when an ack-first turn keeps working

### DIFF
--- a/telegram-plugin/final-answer-detect.ts
+++ b/telegram-plugin/final-answer-detect.ts
@@ -81,3 +81,37 @@ export function isFinalAnswerReply(input: FinalAnswerReplyInput): boolean {
   if (input.text.length >= FINAL_ANSWER_MIN_CHARS) return true
   return false
 }
+
+/**
+ * Pure predicate: was this reply a *substantive* final answer (as opposed
+ * to a reply that is only "final" because it pinged)? `true` if EITHER:
+ *
+ *   - `done === true` — a `stream_reply` terminal call closing the stream.
+ *   - `text.length >= FINAL_ANSWER_MIN_CHARS` — a substantive-length answer.
+ *
+ * This is `isFinalAnswerReply` MINUS the notification-only path. The
+ * distinction matters for the feed-reopen-after-ack gate
+ * (`feed-reopen-gate.ts`): a *short pinging* reply ("on it, checking
+ * Brevo…") is classified final by `isFinalAnswerReply` (because it pings)
+ * yet is NOT substantive — it is an interim ACK. Only such an ack should
+ * cause the live activity feed to re-open when post-ack tool work arrives.
+ *
+ * A genuine final answer (long, or a stream `done: true`) followed by
+ * routine post-answer housekeeping (a memory write / TodoWrite / Bash —
+ * none of which are surface tools, so they reach the tool_label handler)
+ * must NOT re-open the feed and must NOT reset `finalAnswerDelivered`,
+ * otherwise the silent-end re-prompt would spuriously fire and the agent
+ * would re-deliver a duplicate / garbled answer.
+ *
+ * Residual: a reply that is genuinely the final answer yet is BOTH short
+ * (<200 chars) AND pinging (e.g. "Done!") is indistinguishable here from
+ * an ack, so post-answer housekeeping after it still re-opens the feed.
+ * That is much rarer than the housekeeping-after-long-answer case this
+ * predicate protects, and is kill-switchable via
+ * `SWITCHROOM_FEED_REOPEN_AFTER_ACK=0`.
+ */
+export function isSubstantiveFinalReply(input: FinalAnswerReplyInput): boolean {
+  if (input.done === true) return true
+  if (input.text.length >= FINAL_ANSWER_MIN_CHARS) return true
+  return false
+}

--- a/telegram-plugin/gateway/feed-reopen-gate.ts
+++ b/telegram-plugin/gateway/feed-reopen-gate.ts
@@ -1,0 +1,127 @@
+/**
+ * Feed-reopen-after-ack gate (ack-first live-activity visibility).
+ *
+ * Pure decision: a `tool_label` arrived (the model is calling a tool, i.e.
+ * still WORKING) for a turn that has already been classified as having
+ * delivered its final answer. Should the gateway *re-open* the live
+ * activity feed for the post-ack work?
+ *
+ * ## The bug this closes
+ *
+ * In a forum supergroup one agent owns the whole supergroup — a single
+ * sequential `claude` CLI with a singleton `currentTurn`. When the model
+ * ACKS FIRST ("on it, checking Brevo…") and then does the actual work,
+ * that ack reply is classified as the *final answer* by
+ * `isFinalAnswerReply` (final-answer-detect.ts) whenever it pings
+ * (`!disable_notification`) OR is ≥200 chars — both common for a natural
+ * human-feel ack. That sets `turn.finalAnswerDelivered = true`, and the
+ * `tool_label` handler's `if (turn.finalAnswerDelivered) return` then
+ * drops EVERY subsequent tool label → the live feed goes dark for the
+ * real work. The agent looks silent after "On it".
+ *
+ * ## The decision
+ *
+ * A new tool label after `finalAnswerDelivered` means the earlier "final"
+ * reply was actually an interim ACK — the turn has NOT delivered its final
+ * answer if it is still doing tool work. So reclassify: re-open the feed.
+ * The caller then resets `turn.finalAnswerDelivered = false` and
+ * `turn.activityMessageId = null` (so a FRESH feed message opens below the
+ * ack) and proceeds with the normal append + drain. When the model later
+ * sends its REAL final answer, `executeReply` / `stream_reply` re-set
+ * `finalAnswerDelivered = true` via `isFinalAnswerReply` and the feed gates
+ * off correctly again.
+ *
+ * ## Interactions (the reset is correct for all three consumers)
+ *
+ *  1. #2137 deliver-before-drain gate (`mayDrainBufferedInbound`): reads the
+ *     ending turn's `finalAnswerDelivered` at turn-end. With the reset, an
+ *     ack-first turn that is still working keeps it false → the next topic
+ *     is correctly HELD (no mid-work cross-topic bleed); the bounded
+ *     no-reply drain timer (~2.5s) still releases the queue if the turn
+ *     truly ends without a final answer.
+ *  2. silent-end re-prompt: a turn that acks, works, then ends with NO real
+ *     final answer keeps `finalAnswerDelivered=false` → the re-prompt fires
+ *     (correct — the user got only an ack, no answer).
+ *  3. the feed gate itself — this module.
+ *
+ * ## Kill switch
+ *
+ * `SWITCHROOM_FEED_REOPEN_AFTER_ACK=0` reverts to the legacy behaviour: a
+ * tool label after `finalAnswerDelivered` is dropped (`return`), and the
+ * post-ack feed stays dark. The kill switch is read by the CALLER, which
+ * passes `enabled` here.
+ */
+
+export interface FeedReopenInput {
+  /** Whether the turn has already been classified as having delivered its
+   *  final answer (`turn.finalAnswerDelivered`). On an ack-first turn this
+   *  is set true by the ack reply (it pinged or was ≥200 chars), even
+   *  though the model is still working. */
+  finalAnswerDelivered: boolean
+  /** Kill-switch state. When false the reopen behaviour is OFF and a tool
+   *  label after `finalAnswerDelivered` is dropped (legacy). */
+  enabled: boolean
+}
+
+/**
+ * Pure. Given a tool label has just arrived (the model is calling a tool,
+ * so it is still working), returns true when the live activity feed should
+ * be RE-OPENED for the post-ack work.
+ *
+ * - !finalAnswerDelivered → false: the feed was never gated off; the normal
+ *   append/drain path applies (no reopen needed).
+ * - finalAnswerDelivered && !enabled (kill switch off) → false: legacy
+ *   behaviour, the label is dropped by the caller.
+ * - finalAnswerDelivered && enabled → true: the "final" reply was an
+ *   interim ack; re-open the feed.
+ */
+export function shouldReopenFeedAfterAck(input: FeedReopenInput): boolean {
+  if (!input.finalAnswerDelivered) return false
+  return input.enabled === true
+}
+
+/** The feed-state fields the caller mutates on reopen. */
+export interface FeedReopenState {
+  finalAnswerDelivered: boolean
+  activityMessageId: number | null
+  activityLastSentRender: string | null
+}
+
+/** The branch outcome the tool_label handler takes for a finalAnswer-
+ *  delivered turn: either drop the label (legacy `return`) or reopen the
+ *  feed with the given reset state. */
+export interface FeedReopenOutcome {
+  /** True → the handler returns early (legacy: label dropped, feed dark). */
+  dropLabel: boolean
+  /** When dropLabel is false, the new feed-state fields to write on `turn`
+   *  before the normal append/drain proceeds. */
+  reset?: FeedReopenState
+}
+
+/**
+ * Pure. The complete tool_label decision for a turn already marked
+ * finalAnswerDelivered. Mirrors exactly what the gateway handler does:
+ *  - reopen disabled / not applicable → drop the label (legacy `return`).
+ *  - reopen → reclassify the interim ack: finalAnswerDelivered back to
+ *    false (the turn has NOT delivered its final answer while still doing
+ *    tool work), activityMessageId cleared so a FRESH feed message opens
+ *    below the ack, and activityLastSentRender cleared so the drain loop's
+ *    `pending !== lastSent` guard never mistakes the fresh render for an
+ *    already-sent one.
+ *
+ * Returning the deltas (rather than mutating) keeps the decision unit-
+ * testable; the handler applies them to the live `turn` atom.
+ */
+export function decideFeedReopen(input: FeedReopenInput): FeedReopenOutcome {
+  if (!shouldReopenFeedAfterAck(input)) {
+    return { dropLabel: true }
+  }
+  return {
+    dropLabel: false,
+    reset: {
+      finalAnswerDelivered: false,
+      activityMessageId: null,
+      activityLastSentRender: null,
+    },
+  }
+}

--- a/telegram-plugin/gateway/feed-reopen-gate.ts
+++ b/telegram-plugin/gateway/feed-reopen-gate.ts
@@ -22,14 +22,36 @@
  * ## The decision
  *
  * A new tool label after `finalAnswerDelivered` means the earlier "final"
- * reply was actually an interim ACK — the turn has NOT delivered its final
- * answer if it is still doing tool work. So reclassify: re-open the feed.
- * The caller then resets `turn.finalAnswerDelivered = false` and
+ * reply MIGHT have been an interim ACK — the turn has NOT delivered its
+ * final answer if it is still doing tool work. So reclassify: re-open the
+ * feed. The caller then resets `turn.finalAnswerDelivered = false` and
  * `turn.activityMessageId = null` (so a FRESH feed message opens below the
  * ack) and proceeds with the normal append + drain. When the model later
  * sends its REAL final answer, `executeReply` / `stream_reply` re-set
  * `finalAnswerDelivered = true` via `isFinalAnswerReply` and the feed gates
  * off correctly again.
+ *
+ * ## ACK-ONLY refinement
+ *
+ * `finalAnswerDelivered` latches true for BOTH a short pinging ack AND a
+ * substantive final answer — `isFinalAnswerReply` treats any pinging reply
+ * as "final". So reopening unconditionally is HARMFUL after a *genuine*
+ * final answer: routine post-answer housekeeping (a memory write /
+ * TodoWrite / Bash — none of these are surface tools, so they reach the
+ * tool_label handler) fires a tool label → an unconditional reopen would
+ * reset `finalAnswerDelivered=false` → the turn-end silent-end re-prompt
+ * (`if (turn.finalAnswerDelivered === false)`, NOT gated on zero-outbound)
+ * would FIRE → the agent re-delivers a DUPLICATE / garbled answer. Agents
+ * routinely write memory after answering, so this would be frequent.
+ *
+ * The fix: reopen ONLY when the prior reply that set `finalAnswerDelivered`
+ * was a SHORT ACK, not a substantive answer. The caller tracks this on the
+ * turn as `finalAnswerSubstantive` (set via `isSubstantiveFinalReply` at
+ * every site that sets `finalAnswerDelivered = true`). Reopen iff
+ * `finalAnswerDelivered && !finalAnswerSubstantive`. When the prior final
+ * was substantive, drop the label (legacy gate) — no reopen, no reset — so
+ * the silent-end re-prompt and the #2137 drain both see the genuine final
+ * correctly.
  *
  * ## Interactions (the reset is correct for all three consumers)
  *
@@ -58,6 +80,13 @@ export interface FeedReopenInput {
    *  is set true by the ack reply (it pinged or was ≥200 chars), even
    *  though the model is still working. */
   finalAnswerDelivered: boolean
+  /** Whether the reply that set `finalAnswerDelivered` was a *substantive*
+   *  final answer (stream `done`, or ≥200 chars) as opposed to a short
+   *  pinging interim ACK (`turn.finalAnswerSubstantive`, set via
+   *  `isSubstantiveFinalReply`). Only a short ACK should re-open the feed:
+   *  reopening after a genuine final answer + post-answer housekeeping
+   *  would spuriously trip the silent-end re-prompt → duplicate answer. */
+  finalAnswerSubstantive: boolean
   /** Kill-switch state. When false the reopen behaviour is OFF and a tool
    *  label after `finalAnswerDelivered` is dropped (legacy). */
   enabled: boolean
@@ -70,13 +99,18 @@ export interface FeedReopenInput {
  *
  * - !finalAnswerDelivered → false: the feed was never gated off; the normal
  *   append/drain path applies (no reopen needed).
+ * - finalAnswerDelivered && finalAnswerSubstantive → false: the prior final
+ *   was a genuine answer (not an ack). Post-answer housekeeping tool work
+ *   must NOT reopen — keep the legacy gate so the silent-end re-prompt and
+ *   the #2137 drain see the delivered final correctly.
  * - finalAnswerDelivered && !enabled (kill switch off) → false: legacy
  *   behaviour, the label is dropped by the caller.
- * - finalAnswerDelivered && enabled → true: the "final" reply was an
- *   interim ack; re-open the feed.
+ * - finalAnswerDelivered && !finalAnswerSubstantive && enabled → true: the
+ *   "final" reply was a short interim ack; re-open the feed.
  */
 export function shouldReopenFeedAfterAck(input: FeedReopenInput): boolean {
   if (!input.finalAnswerDelivered) return false
+  if (input.finalAnswerSubstantive) return false
   return input.enabled === true
 }
 
@@ -101,7 +135,8 @@ export interface FeedReopenOutcome {
 /**
  * Pure. The complete tool_label decision for a turn already marked
  * finalAnswerDelivered. Mirrors exactly what the gateway handler does:
- *  - reopen disabled / not applicable → drop the label (legacy `return`).
+ *  - reopen disabled / substantive final / not applicable → drop the label
+ *    (legacy `return`); the genuine final answer's gate is preserved.
  *  - reopen → reclassify the interim ack: finalAnswerDelivered back to
  *    false (the turn has NOT delivered its final answer while still doing
  *    tool work), activityMessageId cleared so a FRESH feed message opens

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -94,7 +94,7 @@ import { classifyInbound } from '../inbound-classifier.js'
 import * as silencePoke from '../silence-poke.js'
 import * as pendingProgress from '../pending-work-progress.js'
 import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd } from '../silent-end.js'
-import { isFinalAnswerReply } from '../final-answer-detect.js'
+import { isFinalAnswerReply, isSubstantiveFinalReply } from '../final-answer-detect.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
 import { parseVisibleAnswerStreamEnabled } from '../answer-stream-flag.js'
 import { type SessionEvent } from '../session-tail.js'
@@ -1563,6 +1563,20 @@ type CurrentTurn = {
   // even though `replyCalled` is true — the #1664 case where the real answer
   // ended up as plain transcript text rendered into an ephemeral draft.
   finalAnswerDelivered: boolean
+  // Feed-reopen-after-ack refinement — whether the reply that set
+  // `finalAnswerDelivered` was a *substantive* final answer (stream
+  // `done`, or ≥200 chars) as opposed to a short pinging interim ACK.
+  // Set via `isSubstantiveFinalReply` at every site that sets
+  // `finalAnswerDelivered = true`. The tool_label handler re-opens the
+  // live activity feed ONLY when `finalAnswerDelivered && !finalAnswer-
+  // Substantive` (the prior "final" was an ack). After a genuine final
+  // answer this stays true, so routine post-answer housekeeping (memory
+  // write / TodoWrite / Bash — non-surface tools that reach the handler)
+  // does NOT reopen and does NOT reset `finalAnswerDelivered`, which would
+  // otherwise spuriously trip the silent-end re-prompt → duplicate answer.
+  // Reset to false on every fresh-turn enqueue alongside
+  // `finalAnswerDelivered`.
+  finalAnswerSubstantive: boolean
   // #1675 (over-ping safety net): wall-clock ms of the first reply
   // this turn that landed with `disable_notification: false` (a real
   // device ping). The conversational-pacing contract
@@ -6316,6 +6330,12 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
             })
           ) {
             turn.finalAnswerDelivered = true
+            // Feed-reopen refinement: a substantive merged silent-anchor
+            // answer must NOT re-open the feed on post-answer housekeeping.
+            turn.finalAnswerSubstantive = isSubstantiveFinalReply({
+              text: decision.mergedText,
+              disableNotification,
+            })
           }
           outboundDedup.record(
             chat_id,
@@ -6655,6 +6675,10 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
     // end re-prompt from spuriously firing on a delivered final.
     if (turn != null && isFinalAnswerReply({ text: rawText, disableNotification })) {
       turn.finalAnswerDelivered = true
+      // Feed-reopen refinement: track whether this final was substantive
+      // (≥200 chars or stream-done — not a short pinging ack) so post-answer
+      // housekeeping tool work does NOT re-open the feed / trip silent-end.
+      turn.finalAnswerSubstantive = isSubstantiveFinalReply({ text: rawText, disableNotification })
       // #1728: release the buffer gate + emit terminal 👍. Mid-turn
       // acks bypass this branch and remain non-events for the
       // reaction (preserves #1713). The full turn-state teardown
@@ -6998,6 +7022,14 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     })
   ) {
     turn.finalAnswerDelivered = true
+    // Feed-reopen refinement: a stream_reply done=true (or a ≥200-char
+    // chunk) is substantive; a short pinging non-done chunk is an ack. Only
+    // the latter should re-open the feed on subsequent post-answer work.
+    turn.finalAnswerSubstantive = isSubstantiveFinalReply({
+      text: (args.text as string | undefined) ?? '',
+      disableNotification: args.disable_notification === true,
+      done: args.done === true,
+    })
     // #1744 follow-up — stream_reply edge case. The first-emit gate at
     // L5178 only clears silent-end state on the FIRST emit of a stream.
     // If a stream's first emit was ack-shaped (disable_notification:true,
@@ -8588,6 +8620,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           gatewayReceiveAt: startedAt,
           replyCalled: false,
           finalAnswerDelivered: false,
+          finalAnswerSubstantive: false,
           firstPingAt: null,
           silentAnchorMessageId: null,
           silentAnchorText: '',
@@ -8808,17 +8841,29 @@ function handleSessionEvent(ev: SessionEvent): void {
       //
       // Feed-reopen-after-ack: a tool label here means the model is STILL
       // working. If the turn was already marked finalAnswerDelivered, the
-      // "final" reply was an interim ACK ("on it, checking Brevo…" pings or
-      // runs ≥200 chars, both classified final by isFinalAnswerReply), so the
+      // "final" reply MIGHT have been an interim ACK ("on it, checking
+      // Brevo…" pings, classified final by isFinalAnswerReply), so the
       // post-ack work had no live feed — the gate above dropped every label.
-      // Reclassify: the turn has NOT delivered its final answer if it is still
-      // doing tool work. Reset the flag and clear activityMessageId so a FRESH
-      // feed message opens below the ack, then proceed normally. When the
-      // model's REAL final answer lands, executeReply / stream_reply re-set
-      // finalAnswerDelivered=true via isFinalAnswerReply and the feed gates off
-      // again. The reset keeps the #2137 serialize gate HOLDING the next topic
-      // mid-work (next-topic liveness is the bounded no-reply timer's job) and
-      // lets the silent-end re-prompt fire if the turn ends on only an ack.
+      //
+      // ACK-ONLY refinement: finalAnswerDelivered latches true for BOTH a
+      // short pinging ack AND a substantive answer. Reopening unconditionally
+      // is harmful after a GENUINE final answer — routine post-answer
+      // housekeeping (memory write / TodoWrite / Bash; non-surface tools that
+      // reach here) would reset finalAnswerDelivered=false and trip the
+      // silent-end re-prompt (NOT zero-outbound gated) → duplicate answer. So
+      // reopen ONLY when the prior final was a short ack
+      // (finalAnswerSubstantive=false). When it was substantive, drop the
+      // label (legacy gate) so the genuine final stays delivered.
+      //
+      // On reopen: reclassify the interim ack — the turn has NOT delivered its
+      // final answer while still doing tool work. Reset the flag and clear
+      // activityMessageId so a FRESH feed message opens below the ack, then
+      // proceed normally. When the model's REAL final answer lands,
+      // executeReply / stream_reply re-set finalAnswerDelivered=true (and
+      // finalAnswerSubstantive) and the feed gates off again. The reset keeps
+      // the #2137 serialize gate HOLDING the next topic mid-work (next-topic
+      // liveness is the bounded no-reply timer's job) and lets the silent-end
+      // re-prompt fire if the turn ends on only an ack.
       // Kill switch SWITCHROOM_FEED_REOPEN_AFTER_ACK=0 → legacy `return`.
       if (turn.finalAnswerDelivered) {
         // decideFeedReopen returns dropLabel (legacy return) or the reset
@@ -8829,6 +8874,10 @@ function handleSessionEvent(ev: SessionEvent): void {
         // mistakes the fresh render for the ack's finalized one and skips it).
         const reopen = decideFeedReopen({
           finalAnswerDelivered: turn.finalAnswerDelivered,
+          // ACK-ONLY: reopen only when the prior final was a short ack, not a
+          // substantive answer — otherwise post-answer housekeeping would
+          // reset finalAnswerDelivered and trip the silent-end re-prompt.
+          finalAnswerSubstantive: turn.finalAnswerSubstantive,
           enabled: FEED_REOPEN_AFTER_ACK_ENABLED,
         })
         if (reopen.dropLabel) return
@@ -9189,6 +9238,11 @@ function handleSessionEvent(ev: SessionEvent): void {
           turn.answerStream = null
           streamFinalizedAsAnswer = true
           turn.finalAnswerDelivered = true
+          // Feed-reopen refinement: the stream is being finalized as the
+          // turn's answer (the model's terminal text), i.e. done=true by
+          // construction → substantive. Post-answer housekeeping must NOT
+          // re-open the feed.
+          turn.finalAnswerSubstantive = true
           // Capture the old streamed message_id BEFORE materialize so
           // we can delete it after the fresh ping send. materialize()
           // overwrites `streamMsgId` internally with the new send's id;
@@ -9465,6 +9519,12 @@ function handleSessionEvent(ev: SessionEvent): void {
         // it keeps the captured `turn` atom internally consistent for any
         // future reader.)
         turn.finalAnswerDelivered = true
+        // Feed-reopen refinement: turn-flush delivers the model's terminal
+        // transcript text as the genuine answer (not an ack). Default to
+        // substantive so a late tool label does NOT re-open the feed / trip
+        // the silent-end re-prompt. (Belt-and-braces, like the set above —
+        // this branch returns before any further tool_label can arrive.)
+        turn.finalAnswerSubstantive = true
 
         // #654 deterministic double-message fix. Hand off the pinned
         // progress card BEFORE state reset so the driver doesn't keep

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -282,6 +282,7 @@ import { createInboundSpool } from './inbound-spool.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
 import { mayDrainBufferedInbound, shouldArmNoReplyDrain } from './serialize-drain-gate.js'
+import { decideFeedReopen } from './feed-reopen-gate.js'
 import { resolveAnswerThreadId } from './answer-thread-resolve.js'
 import {
   createDeliveryQueue,
@@ -1419,6 +1420,16 @@ const TOPIC_FRAMING_ENABLED =
 // → no placeholder (the 👀 ack reaction still fires). Delete-on-answer.
 const QUEUED_STATUS_UX_ENABLED =
   process.env.SWITCHROOM_QUEUED_STATUS_UX !== '0'
+// Feed-reopen-after-ack. When a tool label arrives for a turn already
+// marked finalAnswerDelivered, the model is still WORKING — so the earlier
+// "final" reply was an interim ACK (an ack-first reply pings or runs ≥200
+// chars, both of which isFinalAnswerReply classifies as final). Re-open the
+// live activity feed for the post-ack work instead of dropping the label.
+// Kill switch off (=0) → legacy behaviour: the label is dropped and the
+// post-ack feed stays dark. See `feed-reopen-gate.ts` for the rationale and
+// the finalAnswerDelivered-consumer interactions.
+const FEED_REOPEN_AFTER_ACK_ENABLED =
+  process.env.SWITCHROOM_FEED_REOPEN_AFTER_ACK !== '0'
 
 /**
  * Authoritative "is a turn in flight?" for every gate that previously
@@ -8794,7 +8805,37 @@ function handleSessionEvent(ev: SessionEvent): void {
       // the FINAL answer would re-`sendMessage` a fresh feed below it (flicker).
       // Safe ordering: `tool_label` is real-time (PreToolUse, ~250ms) while
       // `finalAnswerDelivered` is set from executeReply on the final answer.
-      if (turn.finalAnswerDelivered) return
+      //
+      // Feed-reopen-after-ack: a tool label here means the model is STILL
+      // working. If the turn was already marked finalAnswerDelivered, the
+      // "final" reply was an interim ACK ("on it, checking Brevo…" pings or
+      // runs ≥200 chars, both classified final by isFinalAnswerReply), so the
+      // post-ack work had no live feed — the gate above dropped every label.
+      // Reclassify: the turn has NOT delivered its final answer if it is still
+      // doing tool work. Reset the flag and clear activityMessageId so a FRESH
+      // feed message opens below the ack, then proceed normally. When the
+      // model's REAL final answer lands, executeReply / stream_reply re-set
+      // finalAnswerDelivered=true via isFinalAnswerReply and the feed gates off
+      // again. The reset keeps the #2137 serialize gate HOLDING the next topic
+      // mid-work (next-topic liveness is the bounded no-reply timer's job) and
+      // lets the silent-end re-prompt fire if the turn ends on only an ack.
+      // Kill switch SWITCHROOM_FEED_REOPEN_AFTER_ACK=0 → legacy `return`.
+      if (turn.finalAnswerDelivered) {
+        // decideFeedReopen returns dropLabel (legacy return) or the reset
+        // deltas: finalAnswerDelivered→false (the turn has NOT delivered its
+        // final answer while still doing tool work), activityMessageId→null
+        // (a FRESH feed message opens below the ack), activityLastSentRender
+        // →null (so the drain loop's `pending !== lastSent` guard never
+        // mistakes the fresh render for the ack's finalized one and skips it).
+        const reopen = decideFeedReopen({
+          finalAnswerDelivered: turn.finalAnswerDelivered,
+          enabled: FEED_REOPEN_AFTER_ACK_ENABLED,
+        })
+        if (reopen.dropLabel) return
+        turn.finalAnswerDelivered = reopen.reset!.finalAnswerDelivered
+        turn.activityMessageId = reopen.reset!.activityMessageId
+        turn.activityLastSentRender = reopen.reset!.activityLastSentRender
+      }
       const rendered = appendActivityLabel(turn.mirrorLines, ev.label)
       if (rendered != null) {
         // Recompose so any active foreground sub-agent's nested block (Model A)

--- a/telegram-plugin/tests/feed-reopen-gate.test.ts
+++ b/telegram-plugin/tests/feed-reopen-gate.test.ts
@@ -15,39 +15,77 @@ import {
  * then dropped every subsequent label. This predicate decides whether a tool
  * label arriving after finalAnswerDelivered (the model is still working)
  * should RE-OPEN the feed.
+ *
+ * ACK-ONLY refinement: finalAnswerDelivered latches true for BOTH a short
+ * pinging ack AND a substantive answer. Reopening after a GENUINE final
+ * answer is harmful — post-answer housekeeping (memory write / TodoWrite /
+ * Bash) would reset finalAnswerDelivered=false and trip the silent-end
+ * re-prompt → duplicate answer. So the gate reopens ONLY when the prior
+ * final was a short ack (finalAnswerSubstantive=false).
  */
 describe('shouldReopenFeedAfterAck', () => {
-  it('reopens when finalAnswerDelivered AND enabled (the ack-first fix)', () => {
+  it('reopens when delivered AND NOT substantive AND enabled (the ack-first fix)', () => {
     expect(
-      shouldReopenFeedAfterAck({ finalAnswerDelivered: true, enabled: true }),
+      shouldReopenFeedAfterAck({
+        finalAnswerDelivered: true,
+        finalAnswerSubstantive: false,
+        enabled: true,
+      }),
     ).toBe(true)
+  })
+
+  it('does NOT reopen when the prior final was SUBSTANTIVE (the new guard)', () => {
+    // A real final answer followed by post-answer housekeeping tool work:
+    // keep the legacy gate (no reopen) so the silent-end re-prompt and the
+    // #2137 drain see the delivered final correctly. This is the harmful
+    // case the refinement closes.
+    expect(
+      shouldReopenFeedAfterAck({
+        finalAnswerDelivered: true,
+        finalAnswerSubstantive: true,
+        enabled: true,
+      }),
+    ).toBe(false)
   })
 
   it('does NOT reopen when the kill switch is off (legacy: drop the label)', () => {
     expect(
-      shouldReopenFeedAfterAck({ finalAnswerDelivered: true, enabled: false }),
+      shouldReopenFeedAfterAck({
+        finalAnswerDelivered: true,
+        finalAnswerSubstantive: false,
+        enabled: false,
+      }),
     ).toBe(false)
   })
 
   it('does NOT reopen when the final answer was never delivered (no reopen needed)', () => {
     // The feed was never gated off — the normal append/drain path applies.
     expect(
-      shouldReopenFeedAfterAck({ finalAnswerDelivered: false, enabled: true }),
+      shouldReopenFeedAfterAck({
+        finalAnswerDelivered: false,
+        finalAnswerSubstantive: false,
+        enabled: true,
+      }),
     ).toBe(false)
     expect(
-      shouldReopenFeedAfterAck({ finalAnswerDelivered: false, enabled: false }),
+      shouldReopenFeedAfterAck({
+        finalAnswerDelivered: false,
+        finalAnswerSubstantive: false,
+        enabled: false,
+      }),
     ).toBe(false)
   })
 })
 
 describe('decideFeedReopen — tool_label branch outcome for a delivered turn', () => {
-  it('tool_label after finalAnswerDelivered (kill switch ON) → reset + render proceeds', () => {
+  it('tool_label after a SHORT ACK (not substantive, kill switch ON) → reset + render proceeds', () => {
     // The exact contract the gateway tool_label handler applies: the interim
     // ack is reclassified — finalAnswerDelivered back to false, a FRESH feed
     // message (activityMessageId null), last-sent render cleared so the drain
     // re-sends. dropLabel false → the handler proceeds to append + drain.
     const outcome = decideFeedReopen({
       finalAnswerDelivered: true,
+      finalAnswerSubstantive: false,
       enabled: true,
     })
     expect(outcome.dropLabel).toBe(false)
@@ -58,9 +96,23 @@ describe('decideFeedReopen — tool_label branch outcome for a delivered turn', 
     })
   })
 
+  it('tool_label after a SUBSTANTIVE final → drops the label (the new guard, feed stays gated)', () => {
+    // Genuine final answer + post-answer housekeeping: NO reopen, NO reset.
+    // finalAnswerDelivered stays true so the silent-end re-prompt does not
+    // fire and the #2137 drain proceeds correctly.
+    const outcome = decideFeedReopen({
+      finalAnswerDelivered: true,
+      finalAnswerSubstantive: true,
+      enabled: true,
+    })
+    expect(outcome.dropLabel).toBe(true)
+    expect(outcome.reset).toBeUndefined()
+  })
+
   it('kill switch OFF → drops the label (legacy early return, feed stays dark)', () => {
     const outcome = decideFeedReopen({
       finalAnswerDelivered: true,
+      finalAnswerSubstantive: false,
       enabled: false,
     })
     expect(outcome.dropLabel).toBe(true)
@@ -72,6 +124,7 @@ describe('decideFeedReopen — tool_label branch outcome for a delivered turn', 
     // but the predicate is total: a false flag yields dropLabel (no reset).
     const outcome = decideFeedReopen({
       finalAnswerDelivered: false,
+      finalAnswerSubstantive: false,
       enabled: true,
     })
     expect(outcome.dropLabel).toBe(true)

--- a/telegram-plugin/tests/feed-reopen-gate.test.ts
+++ b/telegram-plugin/tests/feed-reopen-gate.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  decideFeedReopen,
+  shouldReopenFeedAfterAck,
+} from '../gateway/feed-reopen-gate.js'
+
+/**
+ * Feed-reopen-after-ack — pure decision gate.
+ *
+ * A supergroup agent that ACKS FIRST ("on it, checking Brevo…") then works
+ * had its live activity feed go dark for the real work: the ack reply is
+ * classified as the final answer by isFinalAnswerReply (it pings or is ≥200
+ * chars), setting turn.finalAnswerDelivered=true, and the tool_label handler
+ * then dropped every subsequent label. This predicate decides whether a tool
+ * label arriving after finalAnswerDelivered (the model is still working)
+ * should RE-OPEN the feed.
+ */
+describe('shouldReopenFeedAfterAck', () => {
+  it('reopens when finalAnswerDelivered AND enabled (the ack-first fix)', () => {
+    expect(
+      shouldReopenFeedAfterAck({ finalAnswerDelivered: true, enabled: true }),
+    ).toBe(true)
+  })
+
+  it('does NOT reopen when the kill switch is off (legacy: drop the label)', () => {
+    expect(
+      shouldReopenFeedAfterAck({ finalAnswerDelivered: true, enabled: false }),
+    ).toBe(false)
+  })
+
+  it('does NOT reopen when the final answer was never delivered (no reopen needed)', () => {
+    // The feed was never gated off — the normal append/drain path applies.
+    expect(
+      shouldReopenFeedAfterAck({ finalAnswerDelivered: false, enabled: true }),
+    ).toBe(false)
+    expect(
+      shouldReopenFeedAfterAck({ finalAnswerDelivered: false, enabled: false }),
+    ).toBe(false)
+  })
+})
+
+describe('decideFeedReopen — tool_label branch outcome for a delivered turn', () => {
+  it('tool_label after finalAnswerDelivered (kill switch ON) → reset + render proceeds', () => {
+    // The exact contract the gateway tool_label handler applies: the interim
+    // ack is reclassified — finalAnswerDelivered back to false, a FRESH feed
+    // message (activityMessageId null), last-sent render cleared so the drain
+    // re-sends. dropLabel false → the handler proceeds to append + drain.
+    const outcome = decideFeedReopen({
+      finalAnswerDelivered: true,
+      enabled: true,
+    })
+    expect(outcome.dropLabel).toBe(false)
+    expect(outcome.reset).toEqual({
+      finalAnswerDelivered: false,
+      activityMessageId: null,
+      activityLastSentRender: null,
+    })
+  })
+
+  it('kill switch OFF → drops the label (legacy early return, feed stays dark)', () => {
+    const outcome = decideFeedReopen({
+      finalAnswerDelivered: true,
+      enabled: false,
+    })
+    expect(outcome.dropLabel).toBe(true)
+    expect(outcome.reset).toBeUndefined()
+  })
+
+  it('finalAnswerDelivered false → no reopen branch (handler never reaches it)', () => {
+    // The handler only calls decideFeedReopen inside `if (finalAnswerDelivered)`,
+    // but the predicate is total: a false flag yields dropLabel (no reset).
+    const outcome = decideFeedReopen({
+      finalAnswerDelivered: false,
+      enabled: true,
+    })
+    expect(outcome.dropLabel).toBe(true)
+    expect(outcome.reset).toBeUndefined()
+  })
+})

--- a/telegram-plugin/tests/final-answer-detect.test.ts
+++ b/telegram-plugin/tests/final-answer-detect.test.ts
@@ -16,7 +16,11 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { isFinalAnswerReply, FINAL_ANSWER_MIN_CHARS } from '../final-answer-detect.js'
+import {
+  isFinalAnswerReply,
+  isSubstantiveFinalReply,
+  FINAL_ANSWER_MIN_CHARS,
+} from '../final-answer-detect.js'
 
 describe('isFinalAnswerReply — #1664 final-answer classification', () => {
   it('classifies a notification-bearing reply as the final answer', () => {
@@ -85,5 +89,67 @@ describe('isFinalAnswerReply — #1664 final-answer classification', () => {
     // Guards the constant against silent drift — the value is referenced
     // in the CurrentTurn doc-comment and the Stop-hook rationale.
     expect(FINAL_ANSWER_MIN_CHARS).toBe(200)
+  })
+})
+
+describe('isSubstantiveFinalReply — feed-reopen ACK-ONLY distinction', () => {
+  // isSubstantiveFinalReply is isFinalAnswerReply MINUS the ping-only path.
+  // It tells "genuine final answer" (stream-done or ≥200 chars) apart from
+  // "final only because it pinged" (a short interim ack). The feed-reopen
+  // gate reopens only when finalAnswerDelivered && !substantive, so a real
+  // answer + post-answer housekeeping does NOT spuriously reopen / trip the
+  // silent-end re-prompt.
+
+  it('stream_reply done=true → substantive (closes the stream = the answer)', () => {
+    expect(
+      isSubstantiveFinalReply({ text: 'ok', disableNotification: true, done: true }),
+    ).toBe(true)
+  })
+
+  it('a reply at/over the length backstop → substantive', () => {
+    expect(
+      isSubstantiveFinalReply({
+        text: 'x'.repeat(FINAL_ANSWER_MIN_CHARS),
+        disableNotification: true,
+      }),
+    ).toBe(true)
+    // One under the threshold, silent → not substantive.
+    expect(
+      isSubstantiveFinalReply({
+        text: 'x'.repeat(FINAL_ANSWER_MIN_CHARS - 1),
+        disableNotification: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('a short PINGING reply is final but NOT substantive (the ack case)', () => {
+    // The crux: isFinalAnswerReply says true (it pings), but this is the
+    // ack the feed-reopen gate must treat as reopen-eligible — NOT a real
+    // answer. So isSubstantiveFinalReply must say false.
+    expect(
+      isFinalAnswerReply({ text: 'on it, checking Brevo…', disableNotification: false }),
+    ).toBe(true)
+    expect(
+      isSubstantiveFinalReply({ text: 'on it, checking Brevo…', disableNotification: false }),
+    ).toBe(false)
+  })
+
+  it('a short SILENT interim reply is neither final nor substantive', () => {
+    expect(
+      isFinalAnswerReply({ text: 'thinking…', disableNotification: true }),
+    ).toBe(false)
+    expect(
+      isSubstantiveFinalReply({ text: 'thinking…', disableNotification: true }),
+    ).toBe(false)
+  })
+
+  it('a long reply is substantive regardless of the ping flag', () => {
+    const longText = 'x'.repeat(FINAL_ANSWER_MIN_CHARS)
+    expect(
+      isSubstantiveFinalReply({ text: longText, disableNotification: false }),
+    ).toBe(true)
+    expect(
+      isSubstantiveFinalReply({ text: longText, disableNotification: true }),
+    ).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

A supergroup agent that **acks first** ("on it, checking Brevo…") then does the actual work showed **no live status** during the work — operator-reported on marko's CRM Brevo topic ("not reporting status on what he is doing").

## Root cause (verified live, not guessed)

The activity feed works fine in topics (proved: a tools-then-answer turn narrates live in a non-General topic). The gap: the feed is gated off in the `tool_label` handler by `if (turn.finalAnswerDelivered) return`, and `finalAnswerDelivered` is set by **any** reply `isFinalAnswerReply` deems final (pings **or** ≥200 chars) — including a short pinging "on it" ack. So an ack-first reply darkens the feed for the work that follows. (Two deep-dive theories — missing `$TELEGRAM_STATE_DIR`, missing `message_thread_id` on edits — were checked against the running system and **refuted**.) Long-standing gap (the "surface foreground activity after an ack" item), not introduced by #2137/#2139.

## Fix

When a `tool_label` arrives after `finalAnswerDelivered` **and the prior reply was a short ACK, not a substantive final answer**, re-open a fresh live feed for the post-ack work (reset `finalAnswerDelivered=false`, new feed message). "Substantive" = `isSubstantiveFinalReply` = `done || ≥200 chars` (final-detect minus the ping-only path); tracked per-turn as `finalAnswerSubstantive`. So:
- short pinging "on it" ack → work → **feed re-opens** (the fix);
- genuine final answer (long/stream-done) → post-answer housekeeping (memory write / TodoWrite / Bash) → **no reset, no spurious silent-end re-prompt, no duplicate answer** (the regression the ack-only refinement closes).

Kill-switch `SWITCHROOM_FEED_REOPEN_AFTER_ACK` (default ON; `=0` → exact legacy gate). Pure decision module `feed-reopen-gate.ts` + `isSubstantiveFinalReply`.

## Why it's safe (all 3 `finalAnswerDelivered` consumers, both scenarios — reviewer-verified)

- **silent-end re-prompt** (`finalAnswerDelivered===false` at turn-end): genuine-final + housekeeping keeps the flag true → no spurious re-prompt / duplicate. Ack-then-work-then-no-answer keeps it false → re-prompts (correct).
- **#2137 deliver-before-drain**: ack-first holds the next topic until the real answer (no cross-topic bleed); the bounded no-reply timer still releases the queue → no wedge.
- **feed spam**: one fresh feed per ack-cycle, then edit-in-place (not one message per tool).

## Test plan

- [x] `feed-reopen-gate` + `isSubstantiveFinalReply` unit tests (reopen iff ack & enabled; no reopen when substantive; kill-switch OFF = legacy)
- [x] no-regression: serialize-drain / multitopic-routing / silent-end / no-reply-bounded-drain green; 4060 non-UAT telegram-plugin tests pass
- [x] `tsc`, bot-api-wrapping, plugin-references, PII clean; gateway-only (compliant)
- [x] Two fresh-process reviewers APPROVE (2nd independently verified the duplicate-answer regression is closed)
- [ ] Supergroup canary: ack-first-then-work turn in a topic → live feed narrates the post-ack work; + a genuine-final-then-memory-write turn → no duplicate answer

## Residual (acknowledged, kill-switchable)

A *short pinging real answer* ("Done!") + post-answer housekeeping still re-opens a small feed — much rarer than the long-answer case, mitigated by the over-ping downgrade, strictly better than going dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)