### PR TITLE
feat(telegram): activity-feed heartbeat so long single steps don't freeze

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1431,6 +1431,25 @@ const QUEUED_STATUS_UX_ENABLED =
 const FEED_REOPEN_AFTER_ACK_ENABLED =
   process.env.SWITCHROOM_FEED_REOPEN_AFTER_ACK !== '0'
 
+// Activity-feed heartbeat (PR1). The feed is pull-only — it only re-renders on
+// a tool_label event, so a long single step that emits no new label leaves the
+// feed frozen on "→ doing X" for tens of seconds (the marko ~26s freeze). The
+// heartbeat re-renders the live feed every FEED_HEARTBEAT_TICK_MS with a
+// climbing " · Ns" elapsed on the in-progress line, but only once the current
+// step has run >= FEED_HEARTBEAT_MIN_STALE_MS (so a normally-advancing feed is
+// untouched). Kill switch: SWITCHROOM_FEED_HEARTBEAT=0. Default on.
+const FEED_HEARTBEAT_ENABLED = process.env.SWITCHROOM_FEED_HEARTBEAT !== '0'
+const FEED_HEARTBEAT_TICK_MS = 6_000
+const FEED_HEARTBEAT_MIN_STALE_MS = 6_000
+
+/** Compact mm/ss-ish elapsed for the live feed suffix: "18s", "1m05s". */
+function formatFeedElapsed(ms: number): string {
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  return `${m}m${(s % 60).toString().padStart(2, '0')}s`
+}
+
 /**
  * Authoritative "is a turn in flight?" for every gate that previously
  * read `claudeBusyKeys.size`. PR 3b cutover (extends PR 3a's bridgeUp
@@ -1653,6 +1672,12 @@ type CurrentTurn = {
   activityInFlight: Promise<void> | null
   activityPendingRender: string | null
   activityLastSentRender: string | null
+  // Wall-clock anchor for the newest in-progress feed step — set each time a
+  // tool_label re-renders the feed. The heartbeat (`feedHeartbeatTick`) reads
+  // it to show a climbing " · Ns" elapsed on the live line so a long single
+  // step that emits no new label doesn't read as frozen (the feed is otherwise
+  // pull-only). undefined until the first label of the turn renders.
+  lastToolLabelAt?: number
   // Accumulating friendly-action feed for this turn. Each non-surface
   // tool_label appends a line via `appendActivityLabel`; the feed renders
   // (via `renderActivityFeed`) as a capped chronological list into the
@@ -8496,6 +8521,35 @@ async function drainActivitySummary(turn: CurrentTurn): Promise<void> {
 }
 
 /**
+ * Heartbeat tick (PR1): keep the live activity feed visibly advancing during a
+ * long single step that emits no new tool_label. Re-renders the feed with a
+ * climbing " · Ns" elapsed on the in-progress line through the SAME single-flight
+ * drain path the tool_label handler uses (no separate transport, no race). Pure
+ * no-op unless there is a live in-flight feed whose newest step has gone stale.
+ * Skips once the final answer landed (the feed is handing off) and after the
+ * turn ends (activityMessageId nulled by clearActivitySummary). Deterministic +
+ * framework-owned — never depends on the model.
+ */
+function feedHeartbeatTick(): void {
+  const turn = currentTurn
+  if (turn == null) return
+  if (turn.activityMessageId == null) return // no live feed yet / already cleared
+  if (turn.finalAnswerDelivered) return // feed handed off to the answer
+  if (turn.lastToolLabelAt == null) return // feed not driven by a labelled step
+  const elapsed = Date.now() - turn.lastToolLabelAt
+  if (elapsed < FEED_HEARTBEAT_MIN_STALE_MS) return // step is fresh; feed advancing normally
+  const rendered = composeTurnActivity(turn, false, ` · ${formatFeedElapsed(elapsed)}`)
+  if (rendered == null) return
+  turn.activityPendingRender = rendered
+  if (turn.activityInFlight == null) {
+    turn.activityInFlight = drainActivitySummary(turn)
+  }
+}
+if (!STATIC && FEED_HEARTBEAT_ENABLED) {
+  setInterval(feedHeartbeatTick, FEED_HEARTBEAT_TICK_MS).unref()
+}
+
+/**
  * Reconcile the activity summary when the model's reply tool takes over as the
  * authoritative surface. Awaits any in-flight render so we don't race a stale
  * write, then EITHER:
@@ -8887,6 +8941,10 @@ function handleSessionEvent(ev: SessionEvent): void {
       }
       const rendered = appendActivityLabel(turn.mirrorLines, ev.label)
       if (rendered != null) {
+        // A new tool label = a new live step → re-anchor the heartbeat clock so
+        // the " · Ns" elapsed restarts from this step (and the feed itself just
+        // advanced, so it isn't stale).
+        turn.lastToolLabelAt = Date.now()
         // Recompose so any active foreground sub-agent's nested block (Model A)
         // is preserved when the parent appends its own step. composeTurnActivity
         // == the flat render when no foreground sub-agent is active.

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -8442,12 +8442,12 @@ const FOREGROUND_SUBAGENT_ACCUM_MAX = 12
  * order; the single-sub-agent common case nests precisely under its
  * Delegating line.
  */
-function composeTurnActivity(turn: CurrentTurn, final = false): string | null {
+function composeTurnActivity(turn: CurrentTurn, final = false, liveSuffix = ''): string | null {
   const childLines: string[] = []
   for (const narrative of turn.foregroundSubAgents.values()) {
     childLines.push(...narrative)
   }
-  return renderActivityFeedWithNested(turn.mirrorLines, childLines, final)
+  return renderActivityFeedWithNested(turn.mirrorLines, childLines, final, liveSuffix)
 }
 
 /**

--- a/telegram-plugin/tests/tool-activity-summary.test.ts
+++ b/telegram-plugin/tests/tool-activity-summary.test.ts
@@ -146,6 +146,33 @@ describe("appendActivityLine + renderActivityFeed — accumulating activity feed
   it("final defaults false (live render keeps the → in-progress newest line)", () => {
     expect(renderActivityFeed(["Reading a.ts"])).toBe("<b>→ Reading a.ts</b>");
   });
+
+  // liveSuffix (PR1 heartbeat): appended INSIDE the newest in-progress line so a
+  // long single step visibly advances ("→ Pulling Meta data · 18s") even though
+  // the feed is pull-only and no new tool label arrived.
+  describe("liveSuffix (heartbeat)", () => {
+    it("appends the suffix to the newest in-progress line only", () => {
+      expect(renderActivityFeed(["Reading a.ts", "Running a command"], false, " · 18s")).toBe(
+        "<i>✓ Reading a.ts</i>\n<b>→ Running a command · 18s</b>",
+      );
+    });
+    it("single live line gets the suffix", () => {
+      expect(renderActivityFeed(["Pulling Meta data"], false, " · 1m05s")).toBe(
+        "<b>→ Pulling Meta data · 1m05s</b>",
+      );
+    });
+    it("final=true ignores the suffix (a finalized record never ticks)", () => {
+      const out = renderActivityFeed(["Reading a.ts", "Running a command"], true, " · 18s")!;
+      expect(out).not.toContain("·");
+      expect(out).not.toContain("→");
+      expect(out).toBe("<i>✓ Reading a.ts</i>\n<i>✓ Running a command</i>");
+    });
+    it("default empty suffix is byte-identical to no suffix", () => {
+      expect(renderActivityFeed(["Reading a.ts"], false, "")).toBe(
+        renderActivityFeed(["Reading a.ts"]),
+      );
+    });
+  });
 });
 
 describe("appendActivityLabel — precomputed label feed (tool_label path)", () => {
@@ -220,6 +247,23 @@ describe("renderActivityFeedWithNested — foreground sub-agent nesting (Model A
   it("final=true with no children delegates to the finalized flat render", () => {
     expect(renderActivityFeedWithNested(["Reading a.ts"], [], true)).toBe(
       "<i>✓ Reading a.ts</i>",
+    );
+  });
+
+  it("liveSuffix (heartbeat) lands on the nested newest in-progress step", () => {
+    const out = renderActivityFeedWithNested(
+      ["Delegating: x"],
+      ["Reading schema.ts", "Looking for foreign keys"],
+      false,
+      " · 22s",
+    )!;
+    expect(out).toContain("   ↳ <b>→ Looking for foreign keys · 22s</b>");
+    expect(out).not.toContain("Reading schema.ts · "); // only the newest line ticks
+  });
+
+  it("liveSuffix passes through to the flat render when there are no children", () => {
+    expect(renderActivityFeedWithNested(["Reading a.ts"], [], false, " · 9s")).toBe(
+      "<b>→ Reading a.ts · 9s</b>",
     );
   });
 

--- a/telegram-plugin/tool-activity-summary.ts
+++ b/telegram-plugin/tool-activity-summary.ts
@@ -200,7 +200,11 @@ function escapeFeedHtml(s: string): string {
  * `✓ +N earlier…` header when the turn ran longer. Returns null when empty.
  * Callers send the result verbatim — do NOT re-escape or re-wrap it.
  */
-export function renderActivityFeed(lines: string[], final = false): string | null {
+export function renderActivityFeed(
+  lines: string[],
+  final = false,
+  liveSuffix = "",
+): string | null {
   if (lines.length === 0) return null;
   const shown = lines.slice(-MIRROR_MAX_LINES);
   const hidden = lines.length - shown.length;
@@ -210,10 +214,14 @@ export function renderActivityFeed(lines: string[], final = false): string | nul
   // Newest line = in-progress step (bold, →); earlier = done (italic, ✓).
   // `final` (turn complete, feed left as a record): ALL lines render done (✓)
   // so the persisted message doesn't freeze on a misleading "→ in-progress".
+  // `liveSuffix` (heartbeat): appended INSIDE the newest in-progress line only
+  // (e.g. " · 18s") so the feed visibly advances during a long single step that
+  // emits no new tool label — the feed is otherwise pull-only and freezes.
+  // Caller passes framework-generated, HTML-safe text; never final + suffix.
   // Returns ready Telegram HTML — callers must NOT re-escape or re-wrap it.
   shown.forEach((l, i) => {
     const esc = escapeFeedHtml(l);
-    out.push(i === lastIdx && !final ? `<b>→ ${esc}</b>` : `<i>✓ ${esc}</i>`);
+    out.push(i === lastIdx && !final ? `<b>→ ${esc}${liveSuffix}</b>` : `<i>✓ ${esc}</i>`);
   });
   return out.join("\n");
 }
@@ -248,9 +256,10 @@ export function renderActivityFeedWithNested(
   lines: string[],
   childLines: string[],
   final = false,
+  liveSuffix = "",
 ): string | null {
   const children = childLines.map((s) => s.trim()).filter((s) => s.length > 0);
-  if (children.length === 0) return renderActivityFeed(lines, final);
+  if (children.length === 0) return renderActivityFeed(lines, final, liveSuffix);
 
   const out: string[] = [];
   const shownParent = lines.slice(-MIRROR_MAX_LINES);
@@ -264,12 +273,13 @@ export function renderActivityFeedWithNested(
   const lastChildIdx = shownChild.length - 1;
   // `final`: the nested newest step also renders done (✓) so the left-behind
   // feed reads as completed, not stuck on a "→ in-progress" child step.
+  // `liveSuffix` (heartbeat): appended to the nested newest in-progress step.
   shownChild.forEach((l, i) => {
     const t = l.length > NESTED_LINE_MAX ? l.slice(0, NESTED_LINE_MAX - 1) + "…" : l;
     const esc = escapeFeedHtml(t);
     out.push(
       i === lastChildIdx && !final
-        ? `${NESTED_PREFIX}<b>→ ${esc}</b>`
+        ? `${NESTED_PREFIX}<b>→ ${esc}${liveSuffix}</b>`
         : `${NESTED_PREFIX}<i>${esc}</i>`,
     );
   });


### PR DESCRIPTION
## Summary (systems-analysis PR1 of 3 — the "no status" half)

The activity feed is **pull-only**: it re-renders only when a `tool_label` event arrives. A long single step (a 26s Meta-ads pull, a long think) emits no new label, so the feed freezes on "→ doing X" for tens of seconds and the turn reads as ghosting. Confirmed on marko: feed froze ~26s, only the typing indicator moving, `cardMsgId=none`.

Add a **deterministic, framework-owned heartbeat**: a 6s wall-clock timer re-renders the live feed through the *same* single-flight drain path with a climbing `· Ns` elapsed on the in-progress line — but only once the current step has run ≥6s (so a normally-advancing feed is untouched). No new transport, no race; it reuses `activityPendingRender` + `drainActivitySummary`. Skips after the final answer (feed handing off) and after turn-end (`activityMessageId` nulled).

This is the low-risk, independent half of the systems analysis — it addresses the **"no status"** freeze only, not the drop (that's PR2, the obligation ledger).

## Implementation
- `renderActivityFeed` / `renderActivityFeedWithNested` gain an optional `liveSuffix` (default `''` → byte-identical for every existing caller; ignored when `final=true` so a finalized record never ticks).
- `CurrentTurn.lastToolLabelAt` re-anchors on each label → the elapsed restarts per step.
- `feedHeartbeatTick` + a single `setInterval`, gated `!STATIC && FEED_HEARTBEAT_ENABLED`.

## Test plan
- [x] `tool-activity-summary.test.ts`: `liveSuffix` on flat + nested newest line; `final=true` ignores it; empty suffix byte-identical to no-suffix
- [x] `tsc --noEmit`, `check-bot-api-wrapping` clean
- [x] full plugin bun suite — 4066 pass / 0 fail
- [ ] canary: confirm the feed visibly advances during a long MCP turn (mtcute-observable, message transport)

## Risk
Low. Kill switch `SWITCHROOM_FEED_HEARTBEAT=0`. Default on. The only new behavior is an extra in-place edit of an already-existing feed message every ~6s during a stale step; subject to the existing drain throttle/budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)