### PR TITLE
feat(auth): ship a default Microsoft OAuth app — zero-config connect

### DIFF
--- a/src/auth/broker/server-microsoft.test.ts
+++ b/src/auth/broker/server-microsoft.test.ts
@@ -334,6 +334,46 @@ describe("AuthBroker — Microsoft get-credentials op", () => {
 
     broker.stop();
   });
+
+  it("serves credentials with NO microsoft_workspace block — the shipped default registers the provider", async () => {
+    // Out-of-box: even without a microsoft_workspace: block, the broker
+    // registers MicrosoftProvider via the shipped default client_id, so
+    // get-credentials for an enabled agent succeeds end-to-end.
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      agents: { ziggy: { microsoft_workspace: { account: "lisa@outlook.com" } } },
+      microsoftAccounts: { "lisa@outlook.com": { enabled_for: ["ziggy"] } },
+      withProvider: false, // NO microsoft_workspace block at all
+    });
+    seedMicrosoftAccount(h, "lisa@outlook.com", {
+      expiresAt: Date.now() + 3600_000,
+      accessToken: "at-lisa-default",
+    });
+
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+
+    const resp = (await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1,
+      id: "ms-default",
+      op: "get-credentials",
+      provider: "microsoft",
+    })) as {
+      ok: true;
+      data: { account: string; credentials: MicrosoftCredentialsShape };
+    };
+
+    expect(resp.ok).toBe(true);
+    expect(resp.data.account).toBe("lisa@outlook.com");
+    expect(resp.data.credentials.microsoftOauth.accessToken).toBe("at-lisa-default");
+
+    broker.stop();
+  });
 });
 
 describe("AuthBroker — Microsoft add-account / rm-account ops", () => {
@@ -651,7 +691,12 @@ describe("AuthBroker — Microsoft refresh-tick", () => {
     broker.stop();
   });
 
-  it("is a no-op when microsoft_workspace config is absent (provider not registered)", async () => {
+  it("refreshes even with NO microsoft_workspace block — the shipped default registers the provider", async () => {
+    // Out-of-box behavior change: a default Microsoft public client_id
+    // ships, so the broker registers MicrosoftProvider unconditionally
+    // (resolveMicrosoftClientId falls back to the default). A near-expiry
+    // account is therefore refreshed even when the operator never added
+    // a microsoft_workspace: block.
     const h = makeHarness();
     const config = makeConfig(h, { agents: {}, withProvider: false });
     seedMicrosoftAccount(h, "alice@outlook.com", {
@@ -669,7 +714,8 @@ describe("AuthBroker — Microsoft refresh-tick", () => {
     await broker.start();
     await broker._tick();
 
-    expect(calls).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("login.microsoftonline.com/common/oauth2/v2.0/token");
     broker.stop();
   });
 });

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -52,6 +52,7 @@ import {
 import { AnthropicProvider } from "./anthropic-provider.js";
 import { GoogleProvider } from "./google-provider.js";
 import { MicrosoftProvider } from "./microsoft-provider.js";
+import { resolveMicrosoftClientId } from "../default-oauth-clients.js";
 import {
   googleAccountExists,
   listGoogleAccounts,
@@ -352,20 +353,23 @@ export class AuthBroker {
         }),
       );
     }
-    // RFC #1873 — Microsoft provider registers only when the
-    // microsoft_workspace block exists with a client id. client_secret is
-    // optional (public-client apps don't need one), so only client_id
-    // gates registration.
-    const microsoftClientId = config.microsoft_workspace?.microsoft_client_id;
-    if (microsoftClientId !== undefined) {
-      this.providers.register(
-        new MicrosoftProvider({
-          clientId: microsoftClientId,
-          clientSecret: config.microsoft_workspace?.microsoft_client_secret,
-          fetcher: opts.fetcher as typeof fetch | undefined,
-        }),
-      );
-    }
+    // RFC #1873 / out-of-box — the Microsoft provider always registers.
+    // A shipped default public client_id makes Microsoft available with
+    // zero config; operators override via
+    // microsoft_workspace.microsoft_client_id (resolveMicrosoftClientId
+    // encodes env → config → default). Registering unconditionally is
+    // safe: with no Microsoft accounts on disk the refresh tick is a
+    // no-op and get-credentials returns ACCOUNT_NOT_FOUND. client_secret
+    // stays optional — the default app is a public client (no secret).
+    this.providers.register(
+      new MicrosoftProvider({
+        clientId: resolveMicrosoftClientId(
+          config.microsoft_workspace?.microsoft_client_id,
+        ).clientId,
+        clientSecret: config.microsoft_workspace?.microsoft_client_secret,
+        fetcher: opts.fetcher as typeof fetch | undefined,
+      }),
+    );
 
     this.assertConfigConsistent(config);
   }

--- a/src/auth/default-oauth-clients.test.ts
+++ b/src/auth/default-oauth-clients.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Shipped default OAuth client resolution (out-of-box connect).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_MICROSOFT_CLIENT_ID,
+  resolveMicrosoftClientId,
+} from "./default-oauth-clients.js";
+
+const ENV_KEY = "SWITCHROOM_MICROSOFT_CLIENT_ID";
+
+describe("resolveMicrosoftClientId — precedence env → config → default", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+  });
+
+  it("falls back to the shipped default when neither env nor config is set", () => {
+    const r = resolveMicrosoftClientId(undefined);
+    expect(r.clientId).toBe(DEFAULT_MICROSOFT_CLIENT_ID);
+    expect(r.source).toBe("default");
+  });
+
+  it("treats an empty-string config value as unset → default", () => {
+    const r = resolveMicrosoftClientId("");
+    expect(r.clientId).toBe(DEFAULT_MICROSOFT_CLIENT_ID);
+    expect(r.source).toBe("default");
+  });
+
+  it("uses the operator config value (BYO app) when present", () => {
+    const r = resolveMicrosoftClientId("byo-client-id-1234");
+    expect(r.clientId).toBe("byo-client-id-1234");
+    expect(r.source).toBe("config");
+  });
+
+  it("passes a vault: config reference through verbatim (caller resolves it)", () => {
+    const r = resolveMicrosoftClientId("vault:microsoft-oauth-client-id");
+    expect(r.clientId).toBe("vault:microsoft-oauth-client-id");
+    expect(r.source).toBe("config");
+  });
+
+  it("env override wins over config", () => {
+    process.env[ENV_KEY] = "env-client-id-9999";
+    const r = resolveMicrosoftClientId("byo-client-id-1234");
+    expect(r.clientId).toBe("env-client-id-9999");
+    expect(r.source).toBe("env");
+  });
+
+  it("env override wins over the default (no config)", () => {
+    process.env[ENV_KEY] = "env-client-id-9999";
+    const r = resolveMicrosoftClientId(undefined);
+    expect(r.clientId).toBe("env-client-id-9999");
+    expect(r.source).toBe("env");
+  });
+
+  it("trims surrounding whitespace on the env value; blank env is ignored", () => {
+    process.env[ENV_KEY] = "  spaced-id  ";
+    expect(resolveMicrosoftClientId(undefined).clientId).toBe("spaced-id");
+    process.env[ENV_KEY] = "   ";
+    const blank = resolveMicrosoftClientId(undefined);
+    expect(blank.source).toBe("default");
+  });
+
+  it("the shipped default is a plausible Entra GUID (public client id)", () => {
+    expect(DEFAULT_MICROSOFT_CLIENT_ID).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+});

--- a/src/auth/default-oauth-clients.ts
+++ b/src/auth/default-oauth-clients.ts
@@ -1,0 +1,81 @@
+/**
+ * Shipped default OAuth client IDs — out-of-box external-account connect
+ * (RFC #1873 / Microsoft-first out-of-box, see memory
+ * project_oauth_out_of_box_microsoft_first).
+ *
+ * A client_id is a PUBLIC identifier, not a secret. For a **public
+ * client** (PKCE / device-code, no client_secret) it is safe — and
+ * expected — to ship in a distributed application. This mirrors the
+ * Anthropic OAuth client baked into `src/auth/account-refresh.ts`
+ * (`DEFAULT_CLIENT_ID`): a module-level constant with an env override.
+ *
+ * **Microsoft.** switchroom.ai's multi-tenant + personal-accounts Entra
+ * app registration (`signInAudience: AzureADandPersonalMicrosoftAccount`,
+ * "Allow public client flows" enabled, NO client secret). Shipping it as
+ * the default lets a fresh install connect a Microsoft account with zero
+ * Azure-portal work — the "batteries included, assembly optional"
+ * default. Operators who want their own app (tighter scope control,
+ * publisher verification, single-tenant lockdown) override it via
+ * `microsoft_workspace.microsoft_client_id` in switchroom.yaml or the
+ * `SWITCHROOM_MICROSOFT_CLIENT_ID` env var. That BYO path is the opt-in
+ * complexity — never the default.
+ *
+ * Caveat (by design, not a bug): an UNVERIFIED multitenant app can't be
+ * consented by users in *external work/school* tenants with risk-based
+ * step-up consent on — those need a one-time tenant-admin approval (or a
+ * BYO app). Personal Microsoft accounts (outlook.com/hotmail) and the
+ * app's home tenant are unaffected, which is the headline "connect from
+ * your phone" case.
+ *
+ * **Google.** No default ships, by design. Google's full Drive/Gmail are
+ * "restricted" scopes requiring per-app brand verification + an annual
+ * third-party CASA security assessment to serve external users, so Google
+ * stays operator-owned / BYO. See the memory above for the decision.
+ */
+
+/**
+ * switchroom.ai's shipped Microsoft Entra public client.
+ *
+ * Multi-tenant + personal Microsoft accounts, "Allow public client
+ * flows" enabled, no secret. Public identifier — safe to ship.
+ */
+export const DEFAULT_MICROSOFT_CLIENT_ID =
+  "9dff88fa-3126-457b-9d1d-37e58c219019";
+
+/** Where a resolved Microsoft client_id came from. */
+export type MicrosoftClientIdSource = "env" | "config" | "default";
+
+export interface ResolvedMicrosoftClientId {
+  clientId: string;
+  source: MicrosoftClientIdSource;
+}
+
+/**
+ * Resolve the Microsoft OAuth client_id with the full precedence:
+ *
+ *   `SWITCHROOM_MICROSOFT_CLIENT_ID` env  →  operator config
+ *   (`microsoft_workspace.microsoft_client_id`)  →  shipped default.
+ *
+ * The returned `source` lets callers tell the operator whether they're
+ * on the shipped default vs. their own app (BYO). The config value is
+ * returned verbatim — it may be a `vault:<key>` reference the caller
+ * still has to resolve; the env value and the default are always
+ * literal client IDs.
+ *
+ * This is the single source of truth for Microsoft client_id precedence;
+ * the host-CLI connect path (`auth microsoft account add`) and the
+ * broker refresh path (`AuthBroker` ctor) both call it so they can't
+ * drift.
+ */
+export function resolveMicrosoftClientId(
+  configClientId?: string,
+): ResolvedMicrosoftClientId {
+  const env = process.env.SWITCHROOM_MICROSOFT_CLIENT_ID;
+  if (env !== undefined && env.trim().length > 0) {
+    return { clientId: env.trim(), source: "env" };
+  }
+  if (configClientId !== undefined && configClientId.length > 0) {
+    return { clientId: configClientId, source: "config" };
+  }
+  return { clientId: DEFAULT_MICROSOFT_CLIENT_ID, source: "default" };
+}

--- a/src/cli/auth-microsoft.ts
+++ b/src/cli/auth-microsoft.ts
@@ -31,6 +31,7 @@ import {
   removeMicrosoftAccountEntry,
 } from "./microsoft-accounts-yaml.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
+import { resolveMicrosoftClientId } from "../auth/default-oauth-clients.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 export function registerAuthMicrosoftSubcommands(
@@ -286,28 +287,29 @@ function registerAccountAdd(accountParent: Command): void {
           ]);
 
           const config = loadConfig();
+          // microsoft_workspace is optional — when absent, the shipped
+          // default Microsoft app is used (zero-config out-of-box).
           const mw = config.microsoft_workspace;
-          if (!mw) {
-            throw new Error(
-              microsoftClientSetupGuidance(
-                "switchroom.yaml has no `microsoft_workspace:` block, so there is no Microsoft OAuth app to connect accounts against.",
-              ),
-            );
-          }
 
-          let clientIdRaw =
-            process.env.SWITCHROOM_MICROSOFT_CLIENT_ID ?? mw.microsoft_client_id;
+          // Precedence: env → operator config → shipped default.
+          const resolvedClientId = resolveMicrosoftClientId(
+            mw?.microsoft_client_id,
+          );
+          let clientIdRaw = resolvedClientId.clientId;
           let clientSecretRaw =
             process.env.SWITCHROOM_MICROSOFT_CLIENT_SECRET ??
-            mw.microsoft_client_secret;
-          if (!clientIdRaw) {
-            throw new Error(
-              microsoftClientSetupGuidance(
-                "The `microsoft_workspace:` block is present but `microsoft_client_id` is empty.",
+            mw?.microsoft_client_secret;
+          // client_secret optional — public-client apps don't need one.
+          if (resolvedClientId.source === "default") {
+            console.error(
+              chalk.gray(
+                "  Using switchroom's shipped Microsoft OAuth app (zero-config).\n" +
+                "  To use your own Entra app instead, set " +
+                "microsoft_workspace.microsoft_client_id in switchroom.yaml\n" +
+                "  (or the SWITCHROOM_MICROSOFT_CLIENT_ID env var).",
               ),
             );
           }
-          // client_secret optional — public-client apps don't need one.
 
           const needsVault =
             isVaultReference(clientIdRaw) ||
@@ -385,7 +387,7 @@ function registerAccountAdd(accountParent: Command): void {
             }
           }
 
-          const orgMode = opts["orgMode"] ?? mw.org_mode ?? false;
+          const orgMode = opts["orgMode"] ?? mw?.org_mode ?? false;
           const scopes = selectMicrosoftScopes(orgMode);
           const oauthCfg = {
             client_id: clientIdRaw,
@@ -818,49 +820,4 @@ async function readHiddenLine(prompt: string): Promise<string> {
     };
     process.stdin.on("data", onData);
   });
-}
-
-export function microsoftClientSetupGuidance(reason: string): string {
-  return [
-    reason,
-    "",
-    "Switchroom ships no shared Microsoft OAuth app — register your own.",
-    "One-time per install:",
-    "",
-    "  1. Go to https://entra.microsoft.com → App registrations → New",
-    "     registration",
-    "  2. Supported account types: 'Accounts in any organizational",
-    "     directory AND personal Microsoft accounts' (multi-tenant + MSA)",
-    "  3. Redirect URI: platform 'Mobile and desktop applications',",
-    "     value `http://localhost` (port-agnostic; Microsoft ignores port",
-    "     for loopback URIs)",
-    "  4. Authentication → Advanced settings → 'Allow public client",
-    "     flows': Yes (enables device-code on personal MSA)",
-    "  5. Copy the Application (client) ID from the Overview page",
-    "  6. Optional: create a client secret in 'Certificates & secrets'",
-    "     (skip if using public-client flow only)",
-    "  7. Vault the credentials:",
-    "",
-    "    switchroom vault set microsoft-oauth-client-id",
-    "    switchroom vault set microsoft-oauth-client-secret  # optional",
-    "",
-    "  8. If your work tenant requires admin consent, your IT admin must",
-    "     grant the requested Graph scopes (Files.ReadWrite.All etc.) at",
-    "     first sign-in. Personal MSA accounts (outlook.com / hotmail.com)",
-    "     don't need this step.",
-    "  9. Add to ~/.switchroom/switchroom.yaml (top level):",
-    "",
-    "    microsoft_workspace:",
-    '      microsoft_client_id: "vault:microsoft-oauth-client-id"',
-    '      microsoft_client_secret: "vault:microsoft-oauth-client-secret"  # omit if public-client',
-    "      authority: https://login.microsoftonline.com/common",
-    "      org_mode: false",
-    "",
-    "Env vars SWITCHROOM_MICROSOFT_CLIENT_ID / _SECRET override the block",
-    "for one-off debugging.",
-    "",
-    "Full walkthrough: docs/microsoft-workspace.md (PR 5 will land this).",
-    "Don't reuse an existing Entra app — see RFC §4.1 (signInAudience",
-    "mismatch + token-version drift make app sharing brittle).",
-  ].join("\n");
 }

--- a/src/cli/doctor-microsoft.test.ts
+++ b/src/cli/doctor-microsoft.test.ts
@@ -126,22 +126,25 @@ describe("runMicrosoftChecks — OAuth client", () => {
     expect(oauth?.detail).toContain("public-client");
   });
 
-  it("missing microsoft_workspace block → fail with setup guidance", () => {
+  it("missing microsoft_workspace block → ok (uses shipped default app)", () => {
+    // A default Microsoft OAuth app ships, so omitting the block is the
+    // normal zero-config case — not a failure. The broker resolves the
+    // default client_id.
     const cfg = baseConfig();
     delete cfg.microsoft_workspace;
     const results = runMicrosoftChecks(cfg, defaultMockDeps());
     const oauth = results.find((r) => r.name === "microsoft:oauth-client-configured");
-    expect(oauth?.status).toBe("fail");
-    expect(oauth?.fix).toContain("switchroom auth microsoft account add");
+    expect(oauth?.status).toBe("ok");
+    expect(oauth?.detail).toContain("shipped default");
   });
 
-  it("empty client_id → fail with Entra registration guidance", () => {
+  it("empty client_id → ok (falls back to shipped default app)", () => {
     const cfg = baseConfig();
     cfg.microsoft_workspace!.microsoft_client_id = "";
     const results = runMicrosoftChecks(cfg, defaultMockDeps());
     const oauth = results.find((r) => r.name === "microsoft:oauth-client-configured");
-    expect(oauth?.status).toBe("fail");
-    expect(oauth?.fix).toContain("entra.microsoft.com");
+    expect(oauth?.status).toBe("ok");
+    expect(oauth?.detail).toContain("shipped default");
   });
 
   it("skips OAuth check entirely when no agents enabled (just YAML in setup)", () => {

--- a/src/cli/doctor-microsoft.ts
+++ b/src/cli/doctor-microsoft.ts
@@ -157,25 +157,17 @@ function checkOAuthClient(
   if (!anyAgentEnabled) return [];
 
   const mw = config.microsoft_workspace;
-  if (!mw) {
+  // A shipped default Microsoft OAuth app means "no block" / "empty
+  // client_id" is the normal zero-config case, not a failure — the
+  // broker resolves the default. Only a BYO app (operator-supplied
+  // client_id) is reported as such.
+  if (!mw || !clientValuePresent(mw.microsoft_client_id)) {
     return [
       {
         name: "microsoft:oauth-client-configured",
-        status: "fail",
+        status: "ok",
         detail:
-          "agents have microsoft_workspace.account set but the top-level microsoft_workspace: block is missing",
-        fix: "Add a microsoft_workspace block with microsoft_client_id (and optionally microsoft_client_secret) to switchroom.yaml. See `switchroom auth microsoft account add` error output for the full walkthrough.",
-      },
-    ];
-  }
-  if (!clientValuePresent(mw.microsoft_client_id)) {
-    return [
-      {
-        name: "microsoft:oauth-client-configured",
-        status: "fail",
-        detail:
-          "microsoft_workspace block present but microsoft_client_id is empty",
-        fix: "Register an Entra app at https://entra.microsoft.com → App registrations → New. Copy the Application (client) ID and vault it: `switchroom vault set microsoft-oauth-client-id`.",
+          "using switchroom's shipped default Microsoft OAuth app (no BYO app configured)",
       },
     ];
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1036,10 +1036,13 @@ export const MicrosoftWorkspaceConfigSchema = z
     microsoft_client_id: z
       .string()
       .min(1)
+      .optional()
       .describe(
         "Microsoft OAuth application (client) ID from Entra portal " +
         "(literal string or vault reference e.g. " +
-        "'vault:microsoft-oauth-client-id')."
+        "'vault:microsoft-oauth-client-id'). OPTIONAL — omit it to use " +
+        "switchroom's shipped default Microsoft app (zero-config). " +
+        "Set it only to bring your own Entra app (BYO)."
       ),
     microsoft_client_secret: z
       .string()


### PR DESCRIPTION
## Summary

Out-of-box external-account connect, **Microsoft-first**. Until now, every operator had to register their own Entra app before any Microsoft account could connect — the code literally said *"switchroom ships no shared Microsoft OAuth app — register your own."* That fails the Defaults principle (*"batteries included, assembly optional — make users opt **into** complexity"*). This flips it: switchroom.ai ships a default Microsoft **public client**; BYO becomes the documented opt-in.

Builds on #2088 (which repaired the broker so Microsoft works end-to-end at all).

## Why

Operator decision (Ken, 2026-06-02): Microsoft gets the full out-of-box treatment (shared multi-tenant public client, no secret); Google stays BYO/CLI (restricted-scope verification + annual CASA make a shared Google app unviable). Serves the `talk-to-agents-from-anywhere` JTBD (non-technical partner, phone-first) and passes the Defaults test.

## What changed

- **`src/auth/default-oauth-clients.ts` (new)** — `DEFAULT_MICROSOFT_CLIENT_ID` (switchroom.ai's multi-tenant + personal-accounts Entra public client; "Allow public client flows" on, **no secret**). A client_id is a public identifier — safe to ship, same pattern as the Anthropic `DEFAULT_CLIENT_ID`. `resolveMicrosoftClientId()` is the single source of truth for precedence **env → config → default** and reports the source.
- **`auth-microsoft.ts`** — connect no longer hard-errors without a `microsoft_workspace` block; resolves the default + prints a one-line "using shipped default; BYO via config" note. Removed the now-dead/contradicted `microsoftClientSetupGuidance`.
- **`broker/server.ts`** — `MicrosoftProvider` now registers **unconditionally** via the resolver (was gated on `microsoft_client_id`). Safe: no accounts → refresh tick is a no-op, get-credentials returns `ACCOUNT_NOT_FOUND`. This is what makes refresh work out of the box.
- **`doctor-microsoft.ts`** — "no block / empty client_id" flips from **fail → ok** ("using shipped default Microsoft OAuth app"). Absence is now the normal zero-config case.
- **`schema.ts`** — `microsoft_client_id` is now `.optional()` so a block can carry only `org_mode`/`authority` while still using the default.

## Validation

- The shipped client_id was checked **live** against `https://login.microsoftonline.com/common/oauth2/v2.0/devicecode` — it returns a `user_code` for the full `Mail.ReadWrite Calendars.ReadWrite Files.ReadWrite.All` scope set, confirming multi-tenant + public-client-flows are correctly configured.
- MCP servers are BYOT, so this is a pure switchroom-side credential change — the MCP servers don't care whose app minted the token.
- Does **not** touch the Claude-native/subscription compliance boundary (that's strictly the model/CLI inference path; Google/MS OAuth is third-party tooling under the vault/leash).

## Test plan

- [x] `src/auth/default-oauth-clients.test.ts` (8) — precedence env>config>default, empty-config→default, vault-ref passthrough, env-trim/blank, GUID shape.
- [x] `server-microsoft.test.ts` extended — get-credentials **and** refresh-tick now succeed with **no** `microsoft_workspace` block (default registers the provider).
- [x] `doctor-microsoft.test.ts` — flipped no-block / empty-id to the new `ok` semantics.
- [x] Full config + broker + MS CLI/doctor suites green (**335**); `tsc --noEmit` clean.

## Risk

Low–moderate. The behavior change is "MicrosoftProvider always registers" — verified harmless for non-Microsoft installs (no accounts → no-op tick; get-credentials gated per-agent). No secret is distributed (public client). BYO override preserved (env + config). The per-agent grant (connecting an account ≠ an agent getting access) is unchanged — the leash holds.

## Follow-ups (not in this PR)

- Phase 2: Telegram-native `/connect microsoft` device-code flow (the phone self-serve win).
- Phase 4: BYO-app walkthrough in `docs/microsoft-workspace.md`; setup-wizard step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)