### PR TITLE
feat(telegram): deterministic delivery-obligation ledger (flagged off)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1765,9 +1765,48 @@ function closeObligationOnSubstantiveReply(
   liveTurn: CurrentTurn | null | undefined,
 ): void {
   if (!OBLIGATION_LEDGER_ENABLED) return
-  const originTurn = findTurnByOriginId(args.origin_turn_id as string | undefined) ?? liveTurn
-  const oid = originTurn?.turnId
-  if (oid != null) obligationLedger.close(oid)
+  const echoed = findTurnByOriginId(args.origin_turn_id as string | undefined)
+  const target = obligationLedger.resolveCloseTarget(echoed?.turnId, liveTurn?.turnId)
+  if (target != null) obligationLedger.close(target)
+}
+
+/**
+ * PR2 obligation-ledger OPEN. Track a fresh user inbound as an unanswered
+ * obligation the moment it is received — called BEFORE the buffer-until-idle /
+ * deliver split so a mid-turn cross-topic inbound (the 715 case: buffered while
+ * another turn runs) is tracked too. Drain paths re-deliver buffered inbounds
+ * via sendToAgent (NOT through handleInbound), so handleInbound is the ONLY
+ * point that sees every fresh inbound — opening here is mandatory for both
+ * branches. Same gate as delivery-tracking (real user turns only; synthetic /
+ * steering / `!` interrupt / empty excluded — they have no origin id / need no
+ * answer; deriveTurnId null-guards them). Idempotent → opening at buffer-time
+ * and any later delivery is safe. No-op unless the flag is on.
+ */
+function openObligationFromInbound(
+  inboundMsg: InboundMessage,
+  gate: { isSteering: boolean; isInterrupt: boolean; effectiveText: string },
+): void {
+  if (!OBLIGATION_LEDGER_ENABLED) return
+  if (
+    !shouldTrackDelivery({
+      isSteering: gate.isSteering,
+      isInterrupt: gate.isInterrupt,
+      hasSource: inboundMsg.meta?.source != null,
+      effectiveText: gate.effectiveText,
+    })
+  ) {
+    return
+  }
+  const oid = deriveTurnId(inboundMsg.chatId, inboundMsg.threadId, inboundMsg.messageId)
+  if (oid == null) return
+  obligationLedger.openIfAbsent({
+    originTurnId: oid,
+    chatId: inboundMsg.chatId,
+    threadId: inboundMsg.threadId,
+    messageId: inboundMsg.messageId,
+    text: inboundMsg.text ?? '',
+    openedAt: Date.now(),
+  })
 }
 
 /**
@@ -11530,6 +11569,15 @@ async function handleInbound(
     return
   }
 
+  // PR2 obligation-ledger OPEN — BEFORE the buffer-until-idle / deliver split so
+  // a mid-turn cross-topic inbound (the 715 case) is tracked whether it is
+  // buffered or delivered now. Idempotent + gated; no-op when the flag is off.
+  openObligationFromInbound(inboundMsg, {
+    isSteering,
+    isInterrupt: interrupt.isInterrupt,
+    effectiveText,
+  })
+
   if (
     decideInboundDelivery({
       turnInFlight: turnInFlightAtReceipt,
@@ -11596,35 +11644,6 @@ async function handleInbound(
   }
 
   const delivered = ipcServer.sendToAgent(selfAgent, inboundMsg)
-  // PR2 obligation-ledger OPEN. Track this inbound as an unanswered obligation
-  // the moment it is received (delivered-now OR buffered), keyed by its
-  // origin_turn_id. Same gate as delivery-tracking: real user turns only
-  // (steering / `!` interrupt / synthetic-source / empty excluded — they have
-  // no origin id / never need an answer). deriveTurnId returns null for those,
-  // a second guard. Idempotent (buffer-then-redeliver opens once). CLOSED only
-  // by a substantive reply resolving to this origin (executeReply); re-presented
-  // at idle until then (obligationSweep). No-op unless the flag is on.
-  if (
-    OBLIGATION_LEDGER_ENABLED &&
-    shouldTrackDelivery({
-      isSteering,
-      isInterrupt: interrupt.isInterrupt,
-      hasSource: inboundMsg.meta?.source != null,
-      effectiveText,
-    })
-  ) {
-    const oid = deriveTurnId(inboundMsg.chatId, inboundMsg.threadId, inboundMsg.messageId)
-    if (oid != null) {
-      obligationLedger.openIfAbsent({
-        originTurnId: oid,
-        chatId: inboundMsg.chatId,
-        threadId: inboundMsg.threadId,
-        messageId: inboundMsg.messageId,
-        text: inboundMsg.text ?? '',
-        openedAt: Date.now(),
-      })
-    }
-  }
   if (delivered) {
     const busyKey = markClaudeBusyForInbound(inboundMsg)
     // Track until claude acks via `enqueue` (the marko drop-wedge): if no ack

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -278,6 +278,11 @@ import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { handleRequestMs365Approval } from './ms365-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
+import {
+  ObligationLedger,
+  buildObligationRepresentInbound,
+  obligationEscalationText,
+} from './obligation-ledger.js'
 import { createInboundSpool } from './inbound-spool.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
@@ -1380,6 +1385,20 @@ const DELIVERY_CONFIRM_TIMEOUT_MS =
 const DELIVERY_CONFIRM_SWEEP_MS = 5_000
 const deliveryQueue = createDeliveryQueue<InboundMessage>()
 
+// ─── Deterministic delivery-obligation ledger (systems-analysis PR2) ──────────
+// An inbound is an OBLIGATION (keyed origin_turn_id) that is OPEN at receipt and
+// CLOSED only by an observable substantive reply resolving to that origin —
+// never the model's words. An open obligation that survives a turn boundary is
+// re-presented (bounded) until it closes, so a message the model read but never
+// answered (the marko 715 drop) cannot be silently lost. ADDITIVE + flagged: it
+// runs ALONGSIDE the existing acks/spool/buffer (PR3 retires the redundant
+// pieces). Default OFF — the canary turns it on (713/715 interleave UAT) before
+// any fleet activation. When off, every hook below is a no-op → zero change.
+const OBLIGATION_LEDGER_ENABLED = process.env.SWITCHROOM_OBLIGATION_LEDGER === '1'
+const OBLIGATION_REPRESENT_MAX = 2
+const OBLIGATION_SWEEP_MS = 5_000
+const obligationLedger = new ObligationLedger(OBLIGATION_REPRESENT_MAX)
+
 // ─── Serialize-until-replied (multitopic reply-routing) ───────────────────
 // Component 1 (deliver-before-drain gate). A buffered cross-topic inbound
 // drains ONLY after the just-ended turn delivered its reply to its own
@@ -1725,6 +1744,30 @@ function findTurnByOriginId(originTurnId: string | null | undefined): CurrentTur
   if (originTurnId == null || originTurnId === '') return null
   if (currentTurn != null && currentTurn.turnId === originTurnId) return currentTurn
   return recentTurnsById.get(originTurnId) ?? null
+}
+
+/**
+ * PR2 obligation-ledger CLOSE. Called when a SUBSTANTIVE final answer lands
+ * (not a bare interim ack — using finalAnswerSubstantive, the #2141 signal): the
+ * obligation discharged is the one for the SAME origin the answer routes to
+ * (origin_turn_id the model echoed, else the live turn). So 713's reply closes
+ * 713's obligation even after currentTurn flipped to 715, and 715 stays open
+ * until ITS own substantive answer. An ack does NOT close (so ack-then-ghost is
+ * re-presented, not re-dropped). turn.turnId === the obligation's origin id
+ * (both deriveTurnId(chat,thread,messageId) of the same inbound). No-op unless
+ * the flag is on. NOTE residual: a genuinely SHORT answer (<200 chars, not a
+ * stream-done) reads as non-substantive and won't close → a bounded re-ask
+ * (≤2) then one operator-visible nudge — the accepted double-ask tradeoff,
+ * measured in the canary.
+ */
+function closeObligationOnSubstantiveReply(
+  args: Record<string, unknown>,
+  liveTurn: CurrentTurn | null | undefined,
+): void {
+  if (!OBLIGATION_LEDGER_ENABLED) return
+  const originTurn = findTurnByOriginId(args.origin_turn_id as string | undefined) ?? liveTurn
+  const oid = originTurn?.turnId
+  if (oid != null) obligationLedger.close(oid)
 }
 
 /**
@@ -4700,6 +4743,51 @@ const inboundSpool = STATIC
       },
     })
 const pendingInboundBuffer = createPendingInboundBuffer({ spool: inboundSpool })
+
+// PR2 obligation-ledger idle sweep. Re-present an OPEN obligation only at a
+// CLEAN idle: no turn in flight AND the inbound buffer is empty — so the
+// existing buffer-drain has already had its turn and anything still OPEN is
+// "delivered but never answered" (the 715 gap). Re-present by pushing a
+// synthetic must-answer inbound through the SAME buffer→drain path (idempotent
+// OPEN via meta.source; reuses tested delivery). Bounded: after maxRepresents,
+// escalate to ONE operator-visible "did I miss this?" and close — no loop.
+// No-op unless the flag is on; gated on the same idle predicate as the drains.
+function obligationSweep(): void {
+  if (!OBLIGATION_LEDGER_ENABLED) return
+  if (!obligationLedger.hasOpen()) return
+  if (turnInFlightForGate()) return // a turn is running — let it finish/answer
+  const agent = process.env.SWITCHROOM_AGENT_NAME ?? ''
+  if (pendingInboundBuffer.depth(agent) > 0) return // existing drain runs first; avoids double-present
+  const decision = obligationLedger.decideAtIdle()
+  const o = decision.obligation
+  if (decision.action === 'none' || o == null) return
+  if (decision.action === 'represent') {
+    pendingInboundBuffer.push(agent, buildObligationRepresentInbound(o, Date.now()))
+    const attempt = obligationLedger.markRepresented(o.originTurnId)
+    process.stderr.write(
+      `telegram gateway: obligation re-presented origin=${o.originTurnId} attempt=${attempt}/${OBLIGATION_REPRESENT_MAX}\n`,
+    )
+    return
+  }
+  // escalate — close FIRST so the loop ends even if the send fails.
+  obligationLedger.close(o.originTurnId)
+  process.stderr.write(
+    `telegram gateway: obligation escalated (exhausted ${OBLIGATION_REPRESENT_MAX} re-presents) origin=${o.originTurnId}\n`,
+  )
+  void robustApiCall(
+    () =>
+      bot.api.sendMessage(o.chatId, obligationEscalationText(o), {
+        ...(o.threadId != null ? { message_thread_id: o.threadId } : {}),
+      }),
+    { chat_id: o.chatId, ...(o.threadId != null ? { threadId: o.threadId } : {}), verb: 'obligation.escalate' },
+  ).catch((err) => {
+    process.stderr.write(`telegram gateway: obligation escalation send failed: ${err}\n`)
+  })
+}
+if (!STATIC && OBLIGATION_LEDGER_ENABLED) {
+  setInterval(obligationSweep, OBLIGATION_SWEEP_MS).unref()
+}
+
 // Honest-restart-resume: inject the boot resume/report inbound built by the
 // registry classifier above. When the spool exists we only PUT it (the
 // boot-replay loop below pulls it into the in-memory buffer exactly once via
@@ -6336,6 +6424,7 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
               text: decision.mergedText,
               disableNotification,
             })
+            if (turn.finalAnswerSubstantive) closeObligationOnSubstantiveReply(args, turn)
           }
           outboundDedup.record(
             chat_id,
@@ -6686,6 +6775,9 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
       // the `turn_end` handler when it lands; this only fires the
       // observable side effects that #1718 deferred unconditionally.
       finalizeStatusReaction(chat_id, threadId, 'done')
+      // PR2: close this origin's obligation on a SUBSTANTIVE final answer
+      // (after finalize so the reaction guard test's anchor window is stable).
+      if (turn.finalAnswerSubstantive) closeObligationOnSubstantiveReply(args, turn)
     }
     // v0.13.30 follow-up — release the buffer gate on EVERY reply
     // finalize, not just on `isFinalAnswerReply`. The narrow
@@ -7030,6 +7122,7 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
       disableNotification: args.disable_notification === true,
       done: args.done === true,
     })
+    if (turn.finalAnswerSubstantive) closeObligationOnSubstantiveReply(args, turn)
     // #1744 follow-up — stream_reply edge case. The first-emit gate at
     // L5178 only clears silent-end state on the FIRST emit of a stream.
     // If a stream's first emit was ack-shaped (disable_notification:true,
@@ -11503,6 +11596,35 @@ async function handleInbound(
   }
 
   const delivered = ipcServer.sendToAgent(selfAgent, inboundMsg)
+  // PR2 obligation-ledger OPEN. Track this inbound as an unanswered obligation
+  // the moment it is received (delivered-now OR buffered), keyed by its
+  // origin_turn_id. Same gate as delivery-tracking: real user turns only
+  // (steering / `!` interrupt / synthetic-source / empty excluded — they have
+  // no origin id / never need an answer). deriveTurnId returns null for those,
+  // a second guard. Idempotent (buffer-then-redeliver opens once). CLOSED only
+  // by a substantive reply resolving to this origin (executeReply); re-presented
+  // at idle until then (obligationSweep). No-op unless the flag is on.
+  if (
+    OBLIGATION_LEDGER_ENABLED &&
+    shouldTrackDelivery({
+      isSteering,
+      isInterrupt: interrupt.isInterrupt,
+      hasSource: inboundMsg.meta?.source != null,
+      effectiveText,
+    })
+  ) {
+    const oid = deriveTurnId(inboundMsg.chatId, inboundMsg.threadId, inboundMsg.messageId)
+    if (oid != null) {
+      obligationLedger.openIfAbsent({
+        originTurnId: oid,
+        chatId: inboundMsg.chatId,
+        threadId: inboundMsg.threadId,
+        messageId: inboundMsg.messageId,
+        text: inboundMsg.text ?? '',
+        openedAt: Date.now(),
+      })
+    }
+  }
   if (delivered) {
     const busyKey = markClaudeBusyForInbound(inboundMsg)
     // Track until claude acks via `enqueue` (the marko drop-wedge): if no ack

--- a/telegram-plugin/gateway/obligation-ledger.ts
+++ b/telegram-plugin/gateway/obligation-ledger.ts
@@ -130,6 +130,27 @@ export class ObligationLedger {
     return { action: 'represent', obligation: o }
   }
 
+  /**
+   * Decide which obligation a substantive reply discharges — DETERMINISTICALLY,
+   * holding for any model behavior:
+   *  - `echoedTurnId` (the model echoed origin_turn_id back) → authoritative;
+   *    close exactly that (a no-op via close() if it isn't actually open).
+   *  - else, close the live turn's obligation ONLY when UNAMBIGUOUS — exactly
+   *    one obligation open. With >1 open and no echo we cannot tell which one
+   *    the reply answered; closing the live turn's would silently drop the other
+   *    (713's un-echoed reply landing while currentTurn=715 must NOT close 715).
+   *    So we close nothing → the real target stays open and is re-presented (a
+   *    bounded double-ask), never wrong-closed. Returns the id to close, or null.
+   */
+  resolveCloseTarget(
+    echoedTurnId: string | null | undefined,
+    liveTurnId: string | null | undefined,
+  ): string | null {
+    if (echoedTurnId != null) return echoedTurnId
+    if (liveTurnId != null && this.open.size === 1 && this.open.has(liveTurnId)) return liveTurnId
+    return null
+  }
+
   /** Record that an obligation was just re-presented (bumps representCount). */
   markRepresented(originTurnId: string): number {
     const o = this.open.get(originTurnId)

--- a/telegram-plugin/gateway/obligation-ledger.ts
+++ b/telegram-plugin/gateway/obligation-ledger.ts
@@ -1,0 +1,195 @@
+/**
+ * Deterministic delivery-obligation ledger (systems-analysis PR2).
+ *
+ * The framework today tracks whether an inbound was DELIVERED (read by claude),
+ * never whether it was ANSWERED — so a message claude reads but never replies to
+ * (the marko msg-715 verbal-deferral drop) is silently lost. This ledger adds
+ * the one missing invariant, and it is model-INDEPENDENT by construction:
+ *
+ *   An inbound is an OBLIGATION keyed by its origin_turn_id. It is OPEN the
+ *   moment the message is received, and CLOSED only by an observable framework
+ *   event — a reply-tool call whose resolved target equals that origin_turn_id
+ *   AND that carries a substantive answer (not a bare interim ack). The engine
+ *   may go idle only when no obligation is OPEN; an OPEN obligation that
+ *   survives a turn boundary is re-presented as a fresh must-answer turn until
+ *   it closes, bounded so a mis-close degrades to ONE operator-visible nudge
+ *   rather than an infinite re-ask loop.
+ *
+ * This file is PURE state + decisions — no Telegram, no claude, no timers. The
+ * gateway owns OPEN/CLOSE/re-present I/O and calls in here. Pure ⇒ unit-testable
+ * (see tests/obligation-ledger.test.ts), the seam the analysis demanded.
+ *
+ * The close event (substantive reply resolving to origin) is observed by the
+ * framework, never the model's narration/promise — that is the whole point: the
+ * 715 "I'll handle thread 3 as its own turn" does NOT close the obligation.
+ */
+
+import type { InboundMessage } from './ipc-protocol.js'
+
+export interface Obligation {
+  /** deriveTurnId(chat, thread, messageId) — the stable identity. */
+  readonly originTurnId: string
+  readonly chatId: string
+  readonly threadId?: number
+  readonly messageId: number
+  /** Original inbound text (may be truncated by the caller for re-presentation). */
+  readonly text: string
+  /** Wall-clock ms the obligation was first opened. */
+  readonly openedAt: number
+  /** How many times it has been re-presented (0 on first open). */
+  representCount: number
+}
+
+/** What the gateway should do for the oldest open obligation at an idle boundary. */
+export type LedgerAction = 'none' | 'represent' | 'escalate'
+
+export interface LedgerDecision {
+  action: LedgerAction
+  obligation?: Obligation
+}
+
+export interface ObligationInput {
+  originTurnId: string
+  chatId: string
+  threadId?: number
+  messageId: number
+  text: string
+  openedAt: number
+}
+
+export class ObligationLedger {
+  private readonly open = new Map<string, Obligation>()
+
+  /**
+   * @param maxRepresents max re-presentations before escalating to an
+   *   operator-visible nudge instead of re-asking again. Default 2.
+   */
+  constructor(private readonly maxRepresents = 2) {}
+
+  /**
+   * Open an obligation if not already tracked. Idempotent on originTurnId — a
+   * message that is buffered AND later enqueued opens once, keeping the first
+   * (earliest openedAt + accumulated representCount). Returns true if newly
+   * opened.
+   */
+  openIfAbsent(input: ObligationInput): boolean {
+    if (this.open.has(input.originTurnId)) return false
+    this.open.set(input.originTurnId, { ...input, representCount: 0 })
+    return true
+  }
+
+  /** Close by origin id. Returns true if an obligation was open and is now closed. */
+  close(originTurnId: string | null | undefined): boolean {
+    if (originTurnId == null) return false
+    return this.open.delete(originTurnId)
+  }
+
+  isOpen(originTurnId: string): boolean {
+    return this.open.has(originTurnId)
+  }
+
+  hasOpen(): boolean {
+    return this.open.size > 0
+  }
+
+  size(): number {
+    return this.open.size
+  }
+
+  /** Snapshot of open obligations, oldest first. For introspection/tests. */
+  list(): Obligation[] {
+    return [...this.open.values()].sort((a, b) => a.openedAt - b.openedAt)
+  }
+
+  /** The oldest open obligation, or undefined. */
+  private oldest(): Obligation | undefined {
+    let best: Obligation | undefined
+    for (const o of this.open.values()) {
+      if (best === undefined || o.openedAt < best.openedAt) best = o
+    }
+    return best
+  }
+
+  /**
+   * Decide what to do at an idle boundary (caller guarantees: no turn in flight
+   * AND the inbound buffer is empty — so the existing buffer-drain has already
+   * had its turn and anything still OPEN is "delivered but unanswered"). PURE —
+   * does not mutate. The caller performs the side effect then calls
+   * markRepresented / close accordingly.
+   *
+   *  - 'none'      → no open obligation; the agent may idle.
+   *  - 'represent' → re-present `obligation` as a fresh must-answer turn.
+   *  - 'escalate'  → it has already been re-presented maxRepresents times; send
+   *                  ONE operator-visible "did I miss this?" and close it
+   *                  (caller calls close) rather than loop forever.
+   */
+  decideAtIdle(): LedgerDecision {
+    const o = this.oldest()
+    if (o === undefined) return { action: 'none' }
+    if (o.representCount >= this.maxRepresents) return { action: 'escalate', obligation: o }
+    return { action: 'represent', obligation: o }
+  }
+
+  /** Record that an obligation was just re-presented (bumps representCount). */
+  markRepresented(originTurnId: string): number {
+    const o = this.open.get(originTurnId)
+    if (o === undefined) return 0
+    o.representCount += 1
+    return o.representCount
+  }
+}
+
+/** Original message preview length for re-presentation (mirrors resume builder). */
+const REPRESENT_PREVIEW_MAX = 200
+
+/**
+ * Build the synthetic inbound that RE-PRESENTS an open obligation as a fresh
+ * must-answer turn. Carries the obligation's original message_id (so the
+ * reply-quote and origin routing land in the right place) and origin_turn_id in
+ * meta (so the model's reply resolves back to THIS obligation → the close event
+ * matches). `source: obligation_represent` marks it synthetic, so it is NOT
+ * delivery-tracked and does NOT open a fresh obligation (the original stays
+ * open until a substantive reply closes it). Pure — the gateway injects it via
+ * the existing buffer→drain path. Context restoration (inject vs pointer) is a
+ * separate layer; here we point at get_recent_messages and quote the original.
+ */
+export function buildObligationRepresentInbound(o: Obligation, now: number): InboundMessage {
+  const preview =
+    o.text.length > REPRESENT_PREVIEW_MAX ? o.text.slice(0, REPRESENT_PREVIEW_MAX - 1) + '…' : o.text
+  const topicClause = o.threadId != null ? ' in this topic' : ''
+  return {
+    type: 'inbound',
+    chatId: o.chatId,
+    ...(o.threadId != null ? { threadId: o.threadId } : {}),
+    messageId: o.messageId,
+    user: 'switchroom',
+    userId: 0,
+    ts: now,
+    text:
+      `You have an earlier message${topicClause} that you started but never actually ` +
+      `answered (you may have set it aside mid-work): "${preview}". Answer it now via the ` +
+      `reply tool — deliver the real answer, don't just acknowledge it. If you've lost the ` +
+      `surrounding context, call get_recent_messages for this chat${topicClause} first. ` +
+      `That quoted text may be only the first ~200 characters of the original.`,
+    meta: {
+      source: 'obligation_represent',
+      origin_turn_id: o.originTurnId,
+      represent_count: String(o.representCount + 1),
+    },
+  }
+}
+
+/**
+ * Build the operator-visible escalation message text, used when an obligation
+ * has been re-presented maxRepresents times without closing — rather than loop
+ * forever (the new failure mode this trades silent-drop for), surface ONE
+ * honest "did I miss this?" and close it.
+ */
+export function obligationEscalationText(o: Obligation): string {
+  const preview =
+    o.text.length > REPRESENT_PREVIEW_MAX ? o.text.slice(0, REPRESENT_PREVIEW_MAX - 1) + '…' : o.text
+  return (
+    `⚠️ I may have missed an earlier message and I'm not sure I answered it: ` +
+    `"${preview}". If you still need it, please re-send.`
+  )
+}

--- a/telegram-plugin/tests/obligation-ledger.test.ts
+++ b/telegram-plugin/tests/obligation-ledger.test.ts
@@ -89,6 +89,38 @@ describe("ObligationLedger", () => {
     const L = new ObligationLedger();
     expect(L.markRepresented("nope")).toBe(0);
   });
+
+  describe("resolveCloseTarget — deterministic, holds for any model behavior", () => {
+    it("an echoed origin is authoritative (closes exactly that)", () => {
+      const L = new ObligationLedger();
+      L.openIfAbsent(input("c:635#713", 1000));
+      L.openIfAbsent(input("c:3#715", 1100));
+      // model echoed 713 while live turn is 715 → close 713, NOT the live turn
+      expect(L.resolveCloseTarget("c:635#713", "c:3#715")).toBe("c:635#713");
+    });
+
+    it("no echo + exactly ONE open → close the live turn (unambiguous)", () => {
+      const L = new ObligationLedger();
+      L.openIfAbsent(input("c:3#715", 1100));
+      expect(L.resolveCloseTarget(undefined, "c:3#715")).toBe("c:3#715");
+    });
+
+    it("no echo + MULTIPLE open → close NOTHING (never wrong-close/drop)", () => {
+      const L = new ObligationLedger();
+      L.openIfAbsent(input("c:635#713", 1000));
+      L.openIfAbsent(input("c:3#715", 1100));
+      // the marko race: 713's un-echoed reply lands while currentTurn=715.
+      // Closing 715 would silently drop it → resolveCloseTarget refuses.
+      expect(L.resolveCloseTarget(undefined, "c:3#715")).toBeNull();
+      expect(L.isOpen("c:3#715")).toBe(true); // 715 stays open → re-presented
+    });
+
+    it("no echo + live turn not an open obligation → null", () => {
+      const L = new ObligationLedger();
+      L.openIfAbsent(input("c:3#715", 1100));
+      expect(L.resolveCloseTarget(undefined, "c:9#999")).toBeNull();
+    });
+  });
 });
 
 describe("buildObligationRepresentInbound", () => {

--- a/telegram-plugin/tests/obligation-ledger.test.ts
+++ b/telegram-plugin/tests/obligation-ledger.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import {
+  ObligationLedger,
+  buildObligationRepresentInbound,
+  obligationEscalationText,
+  type Obligation,
+} from "../gateway/obligation-ledger.js";
+
+function input(id: string, openedAt: number, text = "do the thing") {
+  return { originTurnId: id, chatId: "-100123", threadId: 3, messageId: Number(id.split("#").pop() ?? 0), text, openedAt };
+}
+
+describe("ObligationLedger", () => {
+  it("opens, reports open, and closes by origin id", () => {
+    const L = new ObligationLedger();
+    expect(L.hasOpen()).toBe(false);
+    expect(L.openIfAbsent(input("c:3#715", 1000))).toBe(true);
+    expect(L.hasOpen()).toBe(true);
+    expect(L.isOpen("c:3#715")).toBe(true);
+    expect(L.close("c:3#715")).toBe(true);
+    expect(L.hasOpen()).toBe(false);
+    expect(L.close("c:3#715")).toBe(false); // already closed
+  });
+
+  it("openIfAbsent is idempotent — buffer-then-enqueue opens once, keeps the first", () => {
+    const L = new ObligationLedger();
+    expect(L.openIfAbsent(input("c:3#715", 1000, "first"))).toBe(true);
+    expect(L.openIfAbsent(input("c:3#715", 2000, "second"))).toBe(false);
+    expect(L.size()).toBe(1);
+    expect(L.list()[0].text).toBe("first");
+    expect(L.list()[0].openedAt).toBe(1000);
+  });
+
+  it("close(null/undefined) is a safe no-op", () => {
+    const L = new ObligationLedger();
+    L.openIfAbsent(input("c:3#715", 1000));
+    expect(L.close(null)).toBe(false);
+    expect(L.close(undefined)).toBe(false);
+    expect(L.hasOpen()).toBe(true);
+  });
+
+  it("decideAtIdle returns 'none' when nothing is open", () => {
+    expect(new ObligationLedger().decideAtIdle()).toEqual({ action: "none" });
+  });
+
+  it("decideAtIdle picks the OLDEST open obligation to re-present", () => {
+    const L = new ObligationLedger();
+    L.openIfAbsent(input("c:3#715", 2000));
+    L.openIfAbsent(input("c:4#690", 1000)); // older
+    const d = L.decideAtIdle();
+    expect(d.action).toBe("represent");
+    expect(d.obligation?.originTurnId).toBe("c:4#690");
+  });
+
+  it("re-presents up to maxRepresents, then escalates (no infinite loop)", () => {
+    const L = new ObligationLedger(2); // max 2 represents
+    L.openIfAbsent(input("c:3#715", 1000));
+    // represent #1
+    expect(L.decideAtIdle().action).toBe("represent");
+    expect(L.markRepresented("c:3#715")).toBe(1);
+    // represent #2
+    expect(L.decideAtIdle().action).toBe("represent");
+    expect(L.markRepresented("c:3#715")).toBe(2);
+    // now exhausted → escalate
+    const d = L.decideAtIdle();
+    expect(d.action).toBe("escalate");
+    expect(d.obligation?.originTurnId).toBe("c:3#715");
+    // caller closes on escalate → ledger empties (no loop)
+    expect(L.close("c:3#715")).toBe(true);
+    expect(L.decideAtIdle().action).toBe("none");
+  });
+
+  it("the 715 scenario: open at receipt, NOT closed by an unrelated reply, re-presented", () => {
+    const L = new ObligationLedger();
+    // 713 (video, topic 635) and 715 (Meta report, topic 3) both open
+    L.openIfAbsent(input("c:635#713", 1000, "video swap task"));
+    L.openIfAbsent(input("c:3#715", 1100, "do the Meta report"));
+    // 713 gets a substantive reply resolving to its origin → close 713 only
+    expect(L.close("c:635#713")).toBe(true);
+    // 715 was only verbally deferred (no reply resolved to it) → still OPEN
+    expect(L.isOpen("c:3#715")).toBe(true);
+    // at idle, 715 is re-presented (this is the fix — the drop becomes a re-ask)
+    const d = L.decideAtIdle();
+    expect(d.action).toBe("represent");
+    expect(d.obligation?.originTurnId).toBe("c:3#715");
+  });
+
+  it("markRepresented on an unknown/closed id is a harmless 0", () => {
+    const L = new ObligationLedger();
+    expect(L.markRepresented("nope")).toBe(0);
+  });
+});
+
+describe("buildObligationRepresentInbound", () => {
+  const ob: Obligation = {
+    originTurnId: "-100123:3#715",
+    chatId: "-100123",
+    threadId: 3,
+    messageId: 715,
+    text: "do the Meta report",
+    openedAt: 1000,
+    representCount: 0,
+  };
+
+  it("carries the original message_id + origin_turn_id so the reply resolves back", () => {
+    const m = buildObligationRepresentInbound(ob, 5000);
+    expect(m.type).toBe("inbound");
+    expect(m.chatId).toBe("-100123");
+    expect(m.threadId).toBe(3);
+    expect(m.messageId).toBe(715); // ORIGINAL id → reply-quote + origin routing
+    expect(m.meta.origin_turn_id).toBe("-100123:3#715");
+    expect(m.meta.source).toBe("obligation_represent"); // synthetic → not tracked, no new obligation
+    expect(m.meta.represent_count).toBe("1");
+    expect(m.text).toContain("do the Meta report");
+    expect(m.text).toMatch(/answer it now|reply tool/i);
+  });
+
+  it("omits threadId for a DM obligation", () => {
+    const m = buildObligationRepresentInbound({ ...ob, threadId: undefined }, 5000);
+    expect(m.threadId).toBeUndefined();
+  });
+
+  it("truncates a long original to ~200 chars", () => {
+    const long = "x".repeat(500);
+    const m = buildObligationRepresentInbound({ ...ob, text: long }, 5000);
+    expect(m.text).toContain("…");
+    expect(m.text).not.toContain("x".repeat(201));
+  });
+
+  it("escalation text names the message and asks to re-send", () => {
+    expect(obligationEscalationText(ob)).toMatch(/missed|not sure/i);
+    expect(obligationEscalationText(ob)).toContain("do the Meta report");
+    expect(obligationEscalationText(ob)).toMatch(/re-?send/i);
+  });
+});


### PR DESCRIPTION
## Summary (systems-analysis PR2 of 3 — the delivery *guarantee*)

The framework tracks whether an inbound was **delivered** (read by claude), never **answered** — so a message claude reads but verbally defers (the marko msg-715 silent drop) is lost with no error. This adds the single missing invariant, **model-independent by construction**:

> An inbound is an **obligation** keyed by `origin_turn_id`. OPEN at receipt; CLOSED only by an observable framework event — a **substantive** reply resolving to that origin (never the model's narration/promise). The engine re-presents an OPEN obligation at a clean idle until it closes, **bounded** so a mis-close degrades to one operator-visible nudge, not an infinite re-ask.

The close event is a reply echoing back a framework-stamped id — so the 715 *"I'll handle thread 3 as its own turn"* does **not** close it. Premature `turn_end`, no-reply turns, ack-then-ghost — none close it; all get re-presented.

**Default OFF** (`SWITCHROOM_OBLIGATION_LEDGER`). Every hook is a no-op when off → zero behavior change. Safe to merge before the canary; the flag is flipped only after the gating UAT passes.

## Design — pure core + thin gateway hooks (all flagged)
- **`obligation-ledger.ts`** (pure, 12 unit tests): OPEN/CLOSE/`decideAtIdle`/bounded-represent + `buildObligationRepresentInbound` (synthetic must-answer inbound carrying the original `message_id` + `origin_turn_id` so the reply resolves back) + `obligationEscalationText`.
- **OPEN** — `handleInbound`, same gate as delivery-tracking (real user turns only; `deriveTurnId` null-guards synthetics). Idempotent.
- **CLOSE** — `executeReply` ×3, on `finalAnswerSubstantive`, resolved to the origin the answer *routes* to (`findTurnByOriginId ?? live`) — so 713's reply closes 713 even after `currentTurn` flipped to 715.
- **RE-PRESENT** — a 5s idle sweep, only when no turn in flight **and** the buffer is empty (can't double-present with the existing drain); pushes the synthetic through the same buffer→drain path. Bounded (2) → escalate + close.
- **ADDITIVE** — `armNoReplyDrainTimer` / spool / delivery-queue untouched. PR3 retires the now-redundant pieces only after this proves out.

## Why "substantive" closes (not any reply)
A bare interim ack must not close, or ack-then-ghost re-drops (a real marko pattern). Residual: a genuinely short answer reads non-substantive → bounded re-ask then escalation — **the accepted double-ask tradeoff, to be measured in canary, not assumed.** The 715 headline case has *no* reply at all, so it's always re-presented regardless.

## Test plan
- [x] `obligation-ledger.test.ts` (12): open/close/idempotent, oldest-first, bounded represent→escalate, the 715 scenario, builder origin, escalation text
- [x] `tsc`, `check-plugin-references`, `check-bot-api-wrapping` clean
- [x] full plugin bun suite — 4073 pass / 0 fail
- [ ] **GATING canary (flag ON):** 713/715 interleave on test-harness supergroup — deferred topic answered **once** (not zero = old drop, not twice = double-ask); then marko, then fleet

## Risk
Medium, but **inert until the flag is on**. New failure mode = double-ask (bounded + escalation). Land additively now; activate only after the canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)