### PR TITLE
feat(telegram): /connect microsoft — device-code connect from your phone

### DIFF
--- a/src/cli/auth-microsoft.ts
+++ b/src/cli/auth-microsoft.ts
@@ -32,6 +32,9 @@ import {
 } from "./microsoft-accounts-yaml.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import { resolveMicrosoftClientId } from "../auth/default-oauth-clients.js";
+import { selectMicrosoftScopes } from "../microsoft/scopes.js";
+import { buildMicrosoftCredentials as buildMicrosoftCredentialsCore } from "../microsoft/credentials.js";
+import type { MicrosoftCredentialsShape } from "../auth/broker/protocol.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 export function registerAuthMicrosoftSubcommands(
@@ -229,26 +232,6 @@ function registerList(microsoftParent: Command, program: Command): void {
  * MSA + standard work surfaces. `org_mode: true` opts in to SharePoint
  * (and softeria's --org-mode for Teams tools at PR 3 time).
  */
-const SCOPE_SET_DEFAULT = [
-  "openid",
-  "profile",
-  "email",
-  "offline_access",
-  "User.Read",
-  "Mail.ReadWrite",
-  "Calendars.ReadWrite",
-  "Files.ReadWrite.All",
-];
-
-const SCOPE_SET_ORG_MODE = [
-  ...SCOPE_SET_DEFAULT,
-  "Sites.ReadWrite.All",
-];
-
-function selectMicrosoftScopes(orgMode: boolean): string[] {
-  return orgMode ? SCOPE_SET_ORG_MODE : SCOPE_SET_DEFAULT;
-}
-
 function registerAccountAdd(accountParent: Command): void {
   accountParent
     .command("add <account>")
@@ -691,68 +674,27 @@ function buildMicrosoftCredentials(opts: {
   clientId: string;
   accountEmail: string;
   fallbackScope: string;
-}): import("../auth/broker/protocol.js").MicrosoftCredentialsShape {
-  const { tokens, clientId, accountEmail, fallbackScope } = opts;
+}): MicrosoftCredentialsShape {
+  // Shared, side-effect-free core (also used by the Telegram device-code
+  // connect flow). The CLI keeps its loud requested-vs-authenticated
+  // email mismatch warning here so the operator catches a typo'd arg.
+  const built = buildMicrosoftCredentialsCore(opts);
 
-  // Lazy module-level import to keep CLI startup snappy.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { decodeJwtPayloadUnsafe, classifyAccountType, buildHomeAccountId } =
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require("../microsoft/oauth.js") as typeof import("../microsoft/oauth.js");
-
-  let tenantId = "";
-  let accountType: "personal" | "work" = "work";
-  let homeAccountId = "";
-  let resolvedEmail = accountEmail;
-
-  if (tokens.id_token) {
-    const claims = decodeJwtPayloadUnsafe(tokens.id_token);
-    if (claims) {
-      if (typeof claims.tid === "string") tenantId = claims.tid;
-      if (tenantId) accountType = classifyAccountType(tenantId);
-      const home = buildHomeAccountId(claims);
-      if (home) homeAccountId = home;
-      if (typeof claims.preferred_username === "string") {
-        resolvedEmail = claims.preferred_username.toLowerCase();
-      } else if (typeof claims.email === "string") {
-        resolvedEmail = claims.email.toLowerCase();
-      }
-    }
-  }
-
-  // Catch typo'd account args: if Microsoft authenticated a different
-  // email than what the operator passed, warn loudly. Easy to miss
-  // otherwise — broker indexes by the passed arg, credentials.json says
-  // the real email, and `enable` on the typo would still "work" but
-  // route to the wrong account. Reviewer ask.
-  if (resolvedEmail.toLowerCase() !== accountEmail.toLowerCase()) {
+  if (built.emailMismatch) {
     console.warn();
     console.warn(
-      `  ⚠ Account argument was '${accountEmail}' but Microsoft authenticated as '${resolvedEmail}'.`,
+      `  ⚠ Account argument was '${opts.accountEmail}' but Microsoft authenticated as '${built.resolvedEmail}'.`,
     );
     console.warn(
-      `    The broker will index by '${accountEmail}' (what you typed). If this isn't what`,
+      `    The broker will index by '${opts.accountEmail}' (what you typed). If this isn't what`,
     );
     console.warn(
-      `    you intended (e.g. a typo), 'switchroom auth microsoft account remove ${accountEmail}' to undo.`,
+      `    you intended (e.g. a typo), 'switchroom auth microsoft account remove ${opts.accountEmail}' to undo.`,
     );
     console.warn();
   }
 
-  return {
-    microsoftOauth: {
-      accessToken: tokens.access_token,
-      refreshToken: tokens.refresh_token ?? "",
-      expiresAt: Date.now() + tokens.expires_in * 1000,
-      scope: tokens.scope ?? fallbackScope,
-      clientId,
-      accountEmail: resolvedEmail,
-      tokenType: "Bearer",
-      tenantId,
-      accountType,
-      homeAccountId,
-    },
-  };
+  return built.credentials;
 }
 
 /**

--- a/src/microsoft/credentials.test.ts
+++ b/src/microsoft/credentials.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { buildMicrosoftCredentials } from "./credentials.js";
+import type { MicrosoftTokenResponse } from "./oauth.js";
+
+const PERSONAL_MSA_TID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+
+/** Build an unsigned JWT with the given payload (decodeJwtPayloadUnsafe
+ *  only reads the payload segment — signature is ignored). */
+function fakeIdToken(payload: Record<string, unknown>): string {
+  const b64 = (o: unknown) =>
+    Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64({ alg: "none", typ: "JWT" })}.${b64(payload)}.sig`;
+}
+
+function tokens(overrides: Partial<MicrosoftTokenResponse> = {}): MicrosoftTokenResponse {
+  return {
+    access_token: "at-xyz",
+    refresh_token: "rt-xyz",
+    expires_in: 3600,
+    token_type: "Bearer",
+    scope: "Mail.ReadWrite Files.ReadWrite.All",
+    ...overrides,
+  };
+}
+
+describe("buildMicrosoftCredentials", () => {
+  it("derives personal account identity from a personal-MSA id_token", () => {
+    const id_token = fakeIdToken({
+      tid: PERSONAL_MSA_TID,
+      oid: "oid-123",
+      preferred_username: "Lisa@Outlook.com",
+    });
+    const built = buildMicrosoftCredentials({
+      tokens: tokens({ id_token }),
+      clientId: "client-1",
+      accountEmail: "", // device-code: no requested email
+      fallbackScope: "Mail.ReadWrite",
+      now: () => 1_000,
+    });
+    expect(built.resolvedEmail).toBe("lisa@outlook.com"); // lowercased
+    expect(built.emailMismatch).toBe(false); // no requested email to mismatch
+    const o = built.credentials.microsoftOauth;
+    expect(o.accountType).toBe("personal");
+    expect(o.tenantId).toBe(PERSONAL_MSA_TID);
+    expect(o.accountEmail).toBe("lisa@outlook.com");
+    expect(o.homeAccountId).toBe(`oid-123.${PERSONAL_MSA_TID}`);
+    expect(o.expiresAt).toBe(1_000 + 3600 * 1000);
+    expect(o.refreshToken).toBe("rt-xyz");
+    expect(o.tokenType).toBe("Bearer");
+  });
+
+  it("classifies a non-MSA tenant as a work account", () => {
+    const id_token = fakeIdToken({
+      tid: "contoso-tenant-9999",
+      oid: "oid-9",
+      preferred_username: "ken@contoso.com",
+    });
+    const built = buildMicrosoftCredentials({
+      tokens: tokens({ id_token }),
+      clientId: "client-1",
+      accountEmail: "",
+      fallbackScope: "Mail.ReadWrite",
+    });
+    expect(built.credentials.microsoftOauth.accountType).toBe("work");
+    expect(built.resolvedEmail).toBe("ken@contoso.com");
+  });
+
+  it("flags an email mismatch when the token names a different account than requested", () => {
+    const id_token = fakeIdToken({
+      tid: PERSONAL_MSA_TID,
+      oid: "oid-1",
+      preferred_username: "real@outlook.com",
+    });
+    const built = buildMicrosoftCredentials({
+      tokens: tokens({ id_token }),
+      clientId: "client-1",
+      accountEmail: "typo@outlook.com",
+      fallbackScope: "Mail.ReadWrite",
+    });
+    expect(built.emailMismatch).toBe(true);
+    expect(built.resolvedEmail).toBe("real@outlook.com");
+  });
+
+  it("falls back to the requested email + empty discriminators when no id_token", () => {
+    const built = buildMicrosoftCredentials({
+      tokens: tokens({ id_token: undefined }),
+      clientId: "client-1",
+      accountEmail: "fallback@outlook.com",
+      fallbackScope: "Mail.ReadWrite Files.ReadWrite.All",
+    });
+    expect(built.resolvedEmail).toBe("fallback@outlook.com");
+    expect(built.emailMismatch).toBe(false);
+    expect(built.credentials.microsoftOauth.tenantId).toBe("");
+    expect(built.credentials.microsoftOauth.homeAccountId).toBe("");
+  });
+
+  it("uses the granted token scope, falling back when absent", () => {
+    const withScope = buildMicrosoftCredentials({
+      tokens: tokens({ scope: "Mail.Read" }),
+      clientId: "c",
+      accountEmail: "a@b.com",
+      fallbackScope: "FALLBACK",
+    });
+    expect(withScope.credentials.microsoftOauth.scope).toBe("Mail.Read");
+    const noScope = buildMicrosoftCredentials({
+      tokens: tokens({ scope: undefined }),
+      clientId: "c",
+      accountEmail: "a@b.com",
+      fallbackScope: "FALLBACK",
+    });
+    expect(noScope.credentials.microsoftOauth.scope).toBe("FALLBACK");
+  });
+});

--- a/src/microsoft/credentials.ts
+++ b/src/microsoft/credentials.ts
@@ -1,0 +1,93 @@
+/**
+ * Build the broker on-disk credentials shape from a Microsoft token
+ * response (RFC #1873).
+ *
+ * Extracted from `src/cli/auth-microsoft.ts` so the Telegram-native
+ * device-code connect flow (which has no CLI / no console) can reuse it.
+ * This core is **side-effect free** — it returns the resolved identity
+ * (email/tenant/type) so the caller decides how to surface a
+ * requested-vs-authenticated email mismatch (the CLI prints a warning;
+ * the gateway shows it on the connect card; the device-code flow has no
+ * requested email at all and simply adopts the authenticated one).
+ *
+ * Identity fields (tenantId / accountType / homeAccountId / email) come
+ * from the `id_token` claims when present — the same logic the broker's
+ * MicrosoftProvider uses on refresh. When `id_token` is absent we fall
+ * back to the caller-supplied `accountEmail` and leave the discriminators
+ * empty (the next refresh that returns an id_token will populate them).
+ */
+
+import {
+  buildHomeAccountId,
+  classifyAccountType,
+  decodeJwtPayloadUnsafe,
+  type MicrosoftTokenResponse,
+} from "./oauth.js";
+import type { MicrosoftCredentialsShape } from "../auth/broker/protocol.js";
+
+export interface BuiltMicrosoftCredentials {
+  credentials: MicrosoftCredentialsShape;
+  /** The email the broker should index this account by (from id_token
+   *  when available, else the caller-supplied `accountEmail`). */
+  resolvedEmail: string;
+  /** True when an id_token was present and named a different email than
+   *  the caller requested — the caller decides whether to warn. */
+  emailMismatch: boolean;
+}
+
+export function buildMicrosoftCredentials(opts: {
+  tokens: MicrosoftTokenResponse;
+  clientId: string;
+  /** Email the caller requested (CLI arg). Empty string is fine for the
+   *  device-code flow, which learns the email from the token. */
+  accountEmail: string;
+  /** Granted-scope fallback when the token response omits `scope`. */
+  fallbackScope: string;
+  now?: () => number;
+}): BuiltMicrosoftCredentials {
+  const { tokens, clientId, accountEmail, fallbackScope } = opts;
+  const now = opts.now ?? Date.now;
+
+  let tenantId = "";
+  let accountType: "personal" | "work" = "work";
+  let homeAccountId = "";
+  let resolvedEmail = accountEmail;
+
+  if (tokens.id_token) {
+    const claims = decodeJwtPayloadUnsafe(tokens.id_token);
+    if (claims) {
+      if (typeof claims.tid === "string") tenantId = claims.tid;
+      if (tenantId) accountType = classifyAccountType(tenantId);
+      const home = buildHomeAccountId(claims);
+      if (home) homeAccountId = home;
+      if (typeof claims.preferred_username === "string") {
+        resolvedEmail = claims.preferred_username.toLowerCase();
+      } else if (typeof claims.email === "string") {
+        resolvedEmail = claims.email.toLowerCase();
+      }
+    }
+  }
+
+  const emailMismatch =
+    accountEmail.length > 0 &&
+    resolvedEmail.toLowerCase() !== accountEmail.toLowerCase();
+
+  return {
+    credentials: {
+      microsoftOauth: {
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token ?? "",
+        expiresAt: now() + tokens.expires_in * 1000,
+        scope: tokens.scope ?? fallbackScope,
+        clientId,
+        accountEmail: resolvedEmail,
+        tokenType: "Bearer",
+        tenantId,
+        accountType,
+        homeAccountId,
+      },
+    },
+    resolvedEmail,
+    emailMismatch,
+  };
+}

--- a/src/microsoft/scopes.test.ts
+++ b/src/microsoft/scopes.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  SCOPE_SET_DEFAULT,
+  SCOPE_SET_ORG_MODE,
+  selectMicrosoftScopes,
+} from "./scopes.js";
+
+describe("selectMicrosoftScopes", () => {
+  it("default mode returns the base set including offline_access + resource scopes", () => {
+    const s = selectMicrosoftScopes(false);
+    expect(s).toBe(SCOPE_SET_DEFAULT);
+    // offline_access is mandatory or there's no refresh token.
+    expect(s).toContain("offline_access");
+    expect(s).toContain("Mail.ReadWrite");
+    expect(s).toContain("Calendars.ReadWrite");
+    expect(s).toContain("Files.ReadWrite.All");
+    // SharePoint is NOT in the default set.
+    expect(s).not.toContain("Sites.ReadWrite.All");
+  });
+
+  it("org mode adds SharePoint on top of the default set", () => {
+    const s = selectMicrosoftScopes(true);
+    expect(s).toBe(SCOPE_SET_ORG_MODE);
+    expect(s).toContain("Sites.ReadWrite.All");
+    for (const base of SCOPE_SET_DEFAULT) expect(s).toContain(base);
+  });
+});

--- a/src/microsoft/scopes.ts
+++ b/src/microsoft/scopes.ts
@@ -1,0 +1,37 @@
+/**
+ * Microsoft Graph delegated scope sets (RFC #1873 §4.3).
+ *
+ * Extracted from `src/cli/auth-microsoft.ts` so both the host-CLI
+ * connect path AND the Telegram-native device-code connect flow
+ * (telegram-plugin/gateway) request the same scopes — they must not
+ * drift, or a token minted by one path would surface different tools
+ * than the other.
+ *
+ * `org_mode: false` (the default) covers personal MSA + standard work
+ * surfaces (Mail / Calendar / OneDrive). `org_mode: true` opts in to
+ * SharePoint (`Sites.ReadWrite.All`). `offline_access` is mandatory —
+ * without it Microsoft returns no refresh token and the account can't
+ * survive the first access-token expiry.
+ *
+ * All scopes here are user-consentable for personal Microsoft accounts
+ * (no admin consent). On work/school tenants Mail.ReadWrite /
+ * Files.ReadWrite.All may require a one-time tenant-admin approval —
+ * the documented "personal-first, work best-effort" boundary.
+ */
+
+export const SCOPE_SET_DEFAULT = [
+  "openid",
+  "profile",
+  "email",
+  "offline_access",
+  "User.Read",
+  "Mail.ReadWrite",
+  "Calendars.ReadWrite",
+  "Files.ReadWrite.All",
+];
+
+export const SCOPE_SET_ORG_MODE = [...SCOPE_SET_DEFAULT, "Sites.ReadWrite.All"];
+
+export function selectMicrosoftScopes(orgMode: boolean): string[] {
+  return orgMode ? SCOPE_SET_ORG_MODE : SCOPE_SET_DEFAULT;
+}

--- a/telegram-plugin/gateway/auth-broker-client.ts
+++ b/telegram-plugin/gateway/auth-broker-client.ts
@@ -11,6 +11,7 @@
  */
 
 import { AuthBrokerClient as BrokerClient, type AddAccountCredentials } from '../../src/auth/broker/client.js'
+import type { ProviderName } from '../../src/auth/broker/protocol.js'
 import type { AuthBrokerClient } from './auth-command.js'
 
 /**
@@ -56,21 +57,30 @@ export async function getAuthBrokerClient(
 }
 
 /**
- * Add an account via the broker. Used exclusively by the `/auth add`
- * chat flow — the narrow {@link AuthBrokerClient} surface in
- * `auth-command.ts` deliberately omits `addAccount` because the verb
- * is gateway-routed (not handler-routed). Constructs and closes a
- * one-shot {@link BrokerClient} so the gateway doesn't need a
- * long-lived handle just for this verb.
+ * Add an account via the broker. Used by the `/auth add` chat flow
+ * (Anthropic) and the `/connect microsoft` device-code flow — the narrow
+ * {@link AuthBrokerClient} surface in `auth-command.ts` deliberately
+ * omits `addAccount` because the verb is gateway-routed (not
+ * handler-routed). Constructs and closes a one-shot {@link BrokerClient}
+ * so the gateway doesn't need a long-lived handle just for this verb.
+ *
+ * `provider` defaults to Anthropic (back-compat with the `/auth add`
+ * caller, which omits it). The device-code flow passes `"microsoft"`
+ * with a `MicrosoftAddAccountCredentials` payload.
  */
 export async function addAccountViaBroker(
   label: string,
   credentials: AddAccountCredentials,
-  opts: { replace?: boolean } = {},
+  opts: { replace?: boolean; provider?: ProviderName } = {},
 ): Promise<{ label: string; expiresAt?: number }> {
   const broker = new BrokerClient()
   try {
-    return await broker.addAccount(label, credentials, opts.replace)
+    return await broker.addAccount(
+      label,
+      credentials,
+      opts.replace,
+      opts.provider,
+    )
   } finally {
     await broker.close()
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -116,6 +116,11 @@ import {
 import type { AuthBrokerClient } from './auth-command.js'
 import type { ListStateData } from './auth-line.js'
 import { getAuthBrokerClient, addAccountViaBroker } from './auth-broker-client.js'
+import {
+  pendingMicrosoftConnectFlows,
+  startMicrosoftConnect,
+  runMicrosoftConnectPoll,
+} from './microsoft-connect-flow.js'
 import { resolveAuthBrokerSocketPath } from '../../src/auth/broker/client.js'
 import { createFleetFallbackGate } from '../fleet-fallback-gate.js'
 import {
@@ -3697,6 +3702,15 @@ const pendingStateReaper = setInterval(() => {
     if (now - v.startedAt > REAUTH_INTERCEPT_TTL_MS) {
       cancelAccountAuthSession(v)
       pendingAuthAddFlows.delete(k)
+    }
+  }
+  // Microsoft connect flows self-expire at the device code's own expiry
+  // (~15 min) — sweep past that + grace so an abandoned card doesn't pin
+  // its key. Setting cancelled makes any still-running poll bail.
+  for (const [k, v] of pendingMicrosoftConnectFlows) {
+    if (now - v.startedAt > v.device.expires_in * 1000 + 30_000) {
+      v.cancelled = true
+      pendingMicrosoftConnectFlows.delete(k)
     }
   }
   for (const [k, v] of awaitingAuthCodeAt) {
@@ -14309,6 +14323,200 @@ async function runQuotaWatch(): Promise<void> {
   }
 }
 
+/**
+ * Edit a Microsoft connect card from the BACKGROUND device-code poll
+ * (no `ctx` — we hold the chat+message id). Wrapped in robustApiCall;
+ * swallows failures (a deleted card / closed topic must not crash the
+ * poll). RFC #1873 Phase 2.
+ */
+async function editMicrosoftConnectCard(
+  chatId: number | string,
+  messageId: number,
+  html: string,
+): Promise<void> {
+  await robustApiCall(
+    // allow-raw-bot-api: background connect-card edit by message id (no thread_id; not the reply chunk loop)
+    () => bot.api.editMessageText(chatId, messageId, html, {
+      parse_mode: 'HTML',
+      link_preview_options: { is_disabled: true },
+    }),
+    { chat_id: String(chatId), verb: 'microsoftConnectCard' },
+  ).catch(() => {})
+}
+
+/**
+ * Background half of `/connect microsoft`: poll Microsoft for consent,
+ * register the account with the broker, then edit the card to the
+ * outcome. Fire-and-forget from the command handler.
+ */
+async function finalizeMicrosoftConnect(key: string): Promise<void> {
+  const flow = pendingMicrosoftConnectFlows.get(key)
+  if (!flow) return
+  const agentName = getMyAgentName()
+  const result = await runMicrosoftConnectPoll(flow)
+  // A `/connect cancel` (command or button) between consent and write
+  // already edited the card and dropped the entry — don't clobber it.
+  if (result.kind === 'cancelled' || !pendingMicrosoftConnectFlows.has(key)) {
+    pendingMicrosoftConnectFlows.delete(key)
+    return
+  }
+  pendingMicrosoftConnectFlows.delete(key)
+
+  let html: string
+  if (result.kind === 'connected') {
+    html =
+      `✅ <b>Connected</b> <code>${escapeHtmlForTg(result.account)}</code> ` +
+      `(${result.accountType}).\n\n` +
+      `To let <b>${escapeHtmlForTg(agentName)}</b> use it, run on the host:\n` +
+      `<code>switchroom auth microsoft enable ${escapeHtmlForTg(result.account)} ${escapeHtmlForTg(agentName)}</code>\n` +
+      `then restart ${escapeHtmlForTg(agentName)}.`
+  } else if (result.kind === 'no-refresh-token') {
+    html =
+      `⚠ Microsoft returned no refresh token (the account would expire in ~1h), ` +
+      `so it was not registered. Try <code>/connect microsoft</code> again, or ` +
+      `connect from the host CLI.`
+  } else {
+    html =
+      `❌ <b>Connect failed:</b> ${escapeHtmlForTg(result.message)}\n\n` +
+      `<i>Work/school accounts can't use the phone flow at /common — connect those ` +
+      `from the host: <code>switchroom auth microsoft account add &lt;email&gt;</code>.</i>`
+  }
+  await editMicrosoftConnectCard(flow.cardChatId, flow.cardMessageId, html)
+}
+
+/**
+ * `/connect microsoft` — Telegram-native device-code connect for a
+ * Microsoft account (RFC #1873 Phase 2). The user signs in on their
+ * phone; we register the account with the auth-broker (shipped default
+ * app unless the operator BYO'd one). Admin-gated like `/auth add`.
+ * `/connect cancel` aborts a pending flow. Google stays host-CLI.
+ */
+bot.command('connect', async ctx => {
+  const arg = String(ctx.match ?? '').trim().toLowerCase()
+  const chatId = String(ctx.chat?.id ?? '')
+  const key = chatKey(chatId, ctx.message?.message_thread_id ?? null) as string
+
+  // Admin gate — same source as /auth add and /restart (agent's own
+  // `admin: true`). The broker also enforces server-side on add-account.
+  let isAdmin = false
+  try {
+    const cfg = loadSwitchroomConfig()
+    const me = (cfg as unknown as { agents?: Record<string, { admin?: boolean }> })
+      ?.agents?.[getMyAgentName()]
+    isAdmin = me?.admin === true
+  } catch { /* non-admin is the safe default */ }
+  if (!isAuthAdmin({ isAdmin })) {
+    await switchroomReply(
+      ctx,
+      `<b>Not authorized.</b> <code>/connect</code> is admin-only ` +
+        `(set <code>admin: true</code> on this agent in switchroom.yaml).`,
+      { html: true },
+    )
+    return
+  }
+
+  if (arg === 'cancel') {
+    const existing = pendingMicrosoftConnectFlows.get(key)
+    if (!existing) {
+      await switchroomReply(ctx, '<i>No pending connect flow in this chat.</i>', { html: true })
+      return
+    }
+    existing.cancelled = true
+    pendingMicrosoftConnectFlows.delete(key)
+    await switchroomReply(ctx, 'Cancelled.', { html: true })
+    return
+  }
+
+  if (arg !== '' && arg !== 'microsoft' && arg !== 'ms') {
+    await switchroomReply(
+      ctx,
+      `<b>Usage:</b> <code>/connect microsoft</code> to link a Microsoft account ` +
+        `(Outlook / Office 365), or <code>/connect cancel</code>.\n` +
+        `<i>Google accounts are connected from the host CLI.</i>`,
+      { html: true },
+    )
+    return
+  }
+
+  if (pendingMicrosoftConnectFlows.has(key)) {
+    await switchroomReply(
+      ctx,
+      '<i>A Microsoft connect flow is already in progress here. Finish it on your phone, ' +
+        'or send <code>/connect cancel</code>.</i>',
+      { html: true },
+    )
+    return
+  }
+
+  let configClientId: string | undefined
+  let orgMode = false
+  try {
+    const cfg = loadSwitchroomConfig() as unknown as {
+      microsoft_workspace?: { microsoft_client_id?: string; org_mode?: boolean }
+    }
+    configClientId = cfg?.microsoft_workspace?.microsoft_client_id
+    orgMode = cfg?.microsoft_workspace?.org_mode === true
+  } catch { /* fall back to the shipped default */ }
+
+  const started = await startMicrosoftConnect({ configClientId, orgMode })
+  if (started.kind === 'byo-vault') {
+    await switchroomReply(
+      ctx,
+      `<b>Can't connect from chat:</b> this install uses a vaulted custom Microsoft ` +
+        `app (<code>${escapeHtmlForTg(started.ref)}</code>) only the host CLI can read. ` +
+        `Run <code>switchroom auth microsoft account add &lt;email&gt;</code> on the host.`,
+      { html: true },
+    )
+    return
+  }
+  if (started.kind === 'error') {
+    await switchroomReply(
+      ctx,
+      `<b>/connect failed:</b> ${escapeHtmlForTg(started.message)}`,
+      { html: true },
+    )
+    return
+  }
+
+  const appNote =
+    started.source === 'default'
+      ? "<i>Using switchroom's shipped Microsoft app.</i>"
+      : '<i>Using your configured Microsoft app.</i>'
+  const keyboard = new InlineKeyboard()
+    .url('🔐 Sign in to Microsoft', started.device.verification_uri)
+    .row()
+    .text('✖ Cancel', `cn:cancel:${key}`)
+  const sent = await ctx.reply(
+    `🔗 <b>Connect a Microsoft account</b>\n\n` +
+      `1. Tap <b>Sign in to Microsoft</b> below.\n` +
+      `2. Enter this code: <code>${escapeHtmlForTg(started.device.user_code)}</code>\n` +
+      `3. Approve the requested permissions (Mail, Calendar, Files).\n\n` +
+      `I'll confirm here once it's connected (within ~15 min).\n${appNote}`,
+    {
+      parse_mode: 'HTML',
+      link_preview_options: { is_disabled: true },
+      reply_markup: keyboard,
+      ...(ctx.message?.message_thread_id != null
+        ? { message_thread_id: ctx.message.message_thread_id }
+        : {}),
+    },
+  )
+
+  pendingMicrosoftConnectFlows.set(key, {
+    initiatedBy: String(ctx.from?.id ?? ''),
+    cardChatId: ctx.chat!.id,
+    cardMessageId: sent.message_id,
+    device: started.device,
+    clientId: started.clientId,
+    scopes: started.scopes,
+    startedAt: Date.now(),
+    cancelled: false,
+  })
+
+  // Background: poll Microsoft, register the account, edit the card.
+  void finalizeMicrosoftConnect(key)
+})
+
 bot.command("auth", async ctx => {
   // sec WS7-F2b (#1394): `/auth` drives the auth-broker credential
   // lifecycle (`/auth add` mints/attaches an Anthropic account token,
@@ -17051,6 +17259,37 @@ bot.on('callback_query:data', async ctx => {
   // existing CLI invocations plus dashboard refresh.
   if (data.startsWith('auth:')) {
     await handleAuthDashboardCallback(ctx)
+    return
+  }
+
+  // `cn:cancel:<key>` — cancel a pending Microsoft connect flow (the
+  // Cancel button on the /connect card). RFC #1873 Phase 2.
+  if (data.startsWith('cn:')) {
+    const access = loadAccess()
+    const senderId = String(ctx.from?.id ?? '')
+    if (!access.allowFrom.includes(senderId)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' })
+      return
+    }
+    const rest = data.slice('cn:'.length)
+    const sep = rest.indexOf(':')
+    const action = sep >= 0 ? rest.slice(0, sep) : rest
+    const flowKey = sep >= 0 ? rest.slice(sep + 1) : ''
+    if (action === 'cancel') {
+      const pending = pendingMicrosoftConnectFlows.get(flowKey)
+      if (pending) {
+        pending.cancelled = true
+        pendingMicrosoftConnectFlows.delete(flowKey)
+      }
+      await ctx.answerCallbackQuery({ text: 'Connect cancelled.' })
+      await ctx
+        .editMessageText('Microsoft connect cancelled.', {
+          reply_markup: { inline_keyboard: [] },
+        })
+        .catch(() => {})
+    } else {
+      await ctx.answerCallbackQuery()
+    }
     return
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -3704,17 +3704,19 @@ const pendingStateReaper = setInterval(() => {
       pendingAuthAddFlows.delete(k)
     }
   }
+  for (const [k, v] of awaitingAuthCodeAt) {
+    if (now - v > AUTH_CODE_CONTEXT_TTL_MS) awaitingAuthCodeAt.delete(k)
+  }
   // Microsoft connect flows self-expire at the device code's own expiry
   // (~15 min) — sweep past that + grace so an abandoned card doesn't pin
-  // its key. Setting cancelled makes any still-running poll bail.
+  // its key. Setting cancelled makes any still-running poll bail. Placed
+  // AFTER the OAuth-code cluster above, which secret-detect-oauth-code.
+  // test.ts pins as contiguous within the first 800 chars of the reaper.
   for (const [k, v] of pendingMicrosoftConnectFlows) {
     if (now - v.startedAt > v.device.expires_in * 1000 + 30_000) {
       v.cancelled = true
       pendingMicrosoftConnectFlows.delete(k)
     }
-  }
-  for (const [k, v] of awaitingAuthCodeAt) {
-    if (now - v > AUTH_CODE_CONTEXT_TTL_MS) awaitingAuthCodeAt.delete(k)
   }
   // Auth-refresh throttle entries decay quickly (5s window); sweep
   // anything older than 60s so abandoned snapshot messages don't pin
@@ -14392,12 +14394,38 @@ async function finalizeMicrosoftConnect(key: string): Promise<void> {
  * `/connect cancel` aborts a pending flow. Google stays host-CLI.
  */
 bot.command('connect', async ctx => {
+  // Credential-plane admin is OPERATOR-PRIVATE (WS7-F2 / #1408), exactly
+  // like `/auth`: honor `/connect` ONLY in a private chat from a strict
+  // `access.allowFrom` sender — never the group-permissive
+  // `isAuthorizedSender` (an empty group `allowFrom` = allow-all, so a
+  // forum member could otherwise bind THEIR OWN Microsoft account as the
+  // agent's credential). The agent-`admin:true` flag check below is
+  // orthogonal and the broker enforces it server-side on add-account.
+  const senderId = String(ctx.from?.id ?? '')
+  const operatorPrivate =
+    ctx.chat?.type === 'private' && loadAccess().allowFrom.includes(senderId)
+  if (!operatorPrivate) {
+    if (ctx.chat?.type !== 'private') {
+      process.stderr.write(
+        `telegram gateway: /connect refused (not operator-private) agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} chat=${ctx.chat?.type ?? '?'} sender=${senderId}\n`,
+      )
+      await switchroomReply(
+        ctx,
+        `⚠️ <code>/connect</code> links account credentials — it is <b>operator-private</b>. ` +
+          `Send it as a direct message to me from your operator account (a private chat where ` +
+          `your Telegram ID is on the access allowlist), not in a group or forum.`,
+        { html: true },
+      ).catch(() => {})
+    }
+    return
+  }
+
   const arg = String(ctx.match ?? '').trim().toLowerCase()
   const chatId = String(ctx.chat?.id ?? '')
   const key = chatKey(chatId, ctx.message?.message_thread_id ?? null) as string
 
-  // Admin gate — same source as /auth add and /restart (agent's own
-  // `admin: true`). The broker also enforces server-side on add-account.
+  // Agent-`admin:true` gate (orthogonal to operator-private above; same
+  // source as /auth + the broker's server-side add-account enforcement).
   let isAdmin = false
   try {
     const cfg = loadSwitchroomConfig()
@@ -14408,8 +14436,8 @@ bot.command('connect', async ctx => {
   if (!isAuthAdmin({ isAdmin })) {
     await switchroomReply(
       ctx,
-      `<b>Not authorized.</b> <code>/connect</code> is admin-only ` +
-        `(set <code>admin: true</code> on this agent in switchroom.yaml).`,
+      `<b>Not authorized.</b> <code>/connect</code> requires this agent to have ` +
+        `<code>admin: true</code> in switchroom.yaml.`,
       { html: true },
     )
     return

--- a/telegram-plugin/gateway/microsoft-connect-flow.ts
+++ b/telegram-plugin/gateway/microsoft-connect-flow.ts
@@ -1,0 +1,226 @@
+/**
+ * Telegram-native Microsoft connect — device-code flow (RFC #1873 /
+ * out-of-box, Phase 2).
+ *
+ * The headline "connect from your phone" path: a user runs
+ * `/connect microsoft`, the gateway shows a card with a Microsoft
+ * sign-in link + a short code, the user approves on their phone, and the
+ * gateway registers the resulting account with the auth-broker — no host
+ * shell, no Azure portal (the shipped default app is used unless the
+ * operator BYO'd one).
+ *
+ * This module is the framework-agnostic core: it talks to Microsoft's
+ * device-code endpoints (RFC 8628, engine in `src/microsoft/oauth.ts`)
+ * and the auth-broker, and returns plain data. The gateway owns the
+ * Telegram surface (card rendering, edits, callbacks). All network +
+ * broker boundaries are injectable so the flow is testable without
+ * hitting Microsoft or a live broker, and it contains NO raw bot.api
+ * calls (the bot-api-wrapping lint trap lives only in the gateway).
+ *
+ * Mirrors `auth-add-flow.ts` (the Anthropic `/auth add` template) but
+ * needs no child subprocess and no pasted code: device-code consent
+ * happens entirely on Microsoft's domain, so nothing secret is ever
+ * pasted into chat (strictly better than paste-back — no redaction
+ * needed). Personal Microsoft accounts (outlook.com/hotmail) are the
+ * clean case at `/common`; a work/school account that fails device-code
+ * at `/common` surfaces a clear "use the host CLI" error (the documented
+ * "personal-first, work best-effort" boundary).
+ */
+
+import {
+  requestDeviceCode as realRequestDeviceCode,
+  pollDeviceToken as realPollDeviceToken,
+  type MicrosoftDeviceCodeResponse,
+  type MicrosoftOAuthClientConfig,
+} from '../../src/microsoft/oauth.js'
+import { selectMicrosoftScopes } from '../../src/microsoft/scopes.js'
+import { buildMicrosoftCredentials } from '../../src/microsoft/credentials.js'
+import { resolveMicrosoftClientId } from '../../src/auth/default-oauth-clients.js'
+import { isVaultReference } from '../../src/vault/resolver.js'
+import { addAccountViaBroker } from './auth-broker-client.js'
+import type { MicrosoftAddAccountCredentials } from '../../src/auth/broker/client.js'
+
+/** A connect flow in flight, keyed by `chatKey(chatId, threadId)`. */
+export interface PendingMicrosoftConnectFlow {
+  /** Telegram user id that started the flow (consent owner; Phase 3). */
+  initiatedBy: string
+  /** Card we posted, so the poll loop can edit it on completion. */
+  cardChatId: number | string
+  cardMessageId: number
+  device: MicrosoftDeviceCodeResponse
+  clientId: string
+  scopes: string[]
+  startedAt: number
+  /** Flipped by cancel so the in-flight poll bails without writing. */
+  cancelled: boolean
+}
+
+export const pendingMicrosoftConnectFlows = new Map<
+  string,
+  PendingMicrosoftConnectFlow
+>()
+
+export interface MicrosoftConnectDeps {
+  /** `config.microsoft_workspace?.microsoft_client_id` (may be a vault: ref). */
+  configClientId?: string
+  orgMode?: boolean
+  requestDeviceCode?: (
+    cfg: MicrosoftOAuthClientConfig,
+  ) => Promise<MicrosoftDeviceCodeResponse>
+  pollDeviceToken?: typeof realPollDeviceToken
+  addAccount?: (
+    label: string,
+    credentials: MicrosoftAddAccountCredentials,
+    opts: { replace?: boolean; provider: 'microsoft' },
+  ) => Promise<{ label: string; expiresAt?: number }>
+  now?: () => number
+}
+
+export type StartResult =
+  | {
+      kind: 'started'
+      device: MicrosoftDeviceCodeResponse
+      clientId: string
+      scopes: string[]
+      /** 'default' = shipped app; 'config'/'env' = BYO. */
+      source: 'env' | 'config' | 'default'
+    }
+  | {
+      // The operator BYO'd a Microsoft client via a vault: reference,
+      // which the gateway can't resolve in-process — host CLI only.
+      kind: 'byo-vault'
+      ref: string
+    }
+  | { kind: 'error'; message: string }
+
+/**
+ * Request a device code and return the data the gateway needs to render
+ * the connect card. Does NOT mutate the pending map — the gateway stores
+ * the pending entry (with the card message id) after it posts the card.
+ */
+export async function startMicrosoftConnect(
+  deps: MicrosoftConnectDeps = {},
+): Promise<StartResult> {
+  const resolved = resolveMicrosoftClientId(deps.configClientId)
+
+  // A vaulted BYO client_id can't be resolved from the gateway process
+  // (the gateway has no passphrase / vault-broker read path here). The
+  // shipped default and literal config values are fine.
+  if (isVaultReference(resolved.clientId)) {
+    return { kind: 'byo-vault', ref: resolved.clientId }
+  }
+
+  const scopes = selectMicrosoftScopes(deps.orgMode ?? false)
+  const cfg: MicrosoftOAuthClientConfig = {
+    client_id: resolved.clientId,
+    scopes,
+  }
+  try {
+    const device = await (deps.requestDeviceCode ?? realRequestDeviceCode)(cfg)
+    return {
+      kind: 'started',
+      device,
+      clientId: resolved.clientId,
+      scopes,
+      source: resolved.source,
+    }
+  } catch (err) {
+    return { kind: 'error', message: (err as Error).message }
+  }
+}
+
+export type PollResult =
+  | {
+      kind: 'connected'
+      account: string
+      accountType: 'personal' | 'work'
+      expiresAt: number
+    }
+  | { kind: 'cancelled' }
+  | { kind: 'no-refresh-token' }
+  | { kind: 'failed'; message: string }
+
+/**
+ * Poll Microsoft for consent completion, then register the account with
+ * the broker. Blocks (with the device-code `interval`) up to the
+ * device's `expires_in`. Returns a discriminated result the gateway
+ * turns into a card edit. Reads `flow.cancelled` after the (potentially
+ * long) poll so a `/connect cancel` between consent and write is
+ * honored.
+ */
+export async function runMicrosoftConnectPoll(
+  flow: Pick<
+    PendingMicrosoftConnectFlow,
+    'device' | 'clientId' | 'scopes' | 'cancelled'
+  >,
+  deps: MicrosoftConnectDeps = {},
+): Promise<PollResult> {
+  const now = deps.now ?? Date.now
+  const cfg: MicrosoftOAuthClientConfig = {
+    client_id: flow.clientId,
+    scopes: flow.scopes,
+  }
+
+  let tokens
+  try {
+    tokens = await (deps.pollDeviceToken ?? realPollDeviceToken)(
+      cfg,
+      flow.device,
+      { now },
+    )
+  } catch (err) {
+    return { kind: 'failed', message: (err as Error).message }
+  }
+
+  if (flow.cancelled) return { kind: 'cancelled' }
+
+  const built = buildMicrosoftCredentials({
+    tokens,
+    clientId: flow.clientId,
+    accountEmail: '', // device-code learns the email from the id_token
+    fallbackScope: flow.scopes.join(' '),
+    now,
+  })
+
+  // offline_access is requested, so a refresh token is expected; without
+  // one the account dies at the first access-token expiry — fail loud
+  // rather than register an un-refreshable account.
+  if (!built.credentials.microsoftOauth.refreshToken) {
+    return { kind: 'no-refresh-token' }
+  }
+
+  const account = built.resolvedEmail
+  if (!account) {
+    return {
+      kind: 'failed',
+      message: 'Microsoft did not return an account identity (no id_token).',
+    }
+  }
+
+  const addAccount = deps.addAccount ?? defaultAddAccount
+  try {
+    await addAccount(account, built.credentials as MicrosoftAddAccountCredentials, {
+      provider: 'microsoft',
+      // replace:true so reconnecting an already-linked account just
+      // refreshes its tokens rather than erroring.
+      replace: true,
+    })
+  } catch (err) {
+    return { kind: 'failed', message: (err as Error).message }
+  }
+
+  return {
+    kind: 'connected',
+    account,
+    accountType: built.credentials.microsoftOauth.accountType,
+    expiresAt: built.credentials.microsoftOauth.expiresAt,
+  }
+}
+
+function defaultAddAccount(
+  label: string,
+  credentials: MicrosoftAddAccountCredentials,
+  opts: { replace?: boolean; provider: 'microsoft' },
+): Promise<{ label: string; expiresAt?: number }> {
+  return addAccountViaBroker(label, credentials, opts)
+}

--- a/telegram-plugin/tests/microsoft-connect-flow.test.ts
+++ b/telegram-plugin/tests/microsoft-connect-flow.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  startMicrosoftConnect,
+  runMicrosoftConnectPoll,
+} from '../gateway/microsoft-connect-flow.js'
+import { DEFAULT_MICROSOFT_CLIENT_ID } from '../../src/auth/default-oauth-clients.js'
+import type {
+  MicrosoftDeviceCodeResponse,
+  MicrosoftOAuthClientConfig,
+  MicrosoftTokenResponse,
+} from '../../src/microsoft/oauth.js'
+
+const PERSONAL_MSA_TID = '9188040d-6c67-4c5b-b112-36a304b66dad'
+
+const DEVICE: MicrosoftDeviceCodeResponse = {
+  device_code: 'dc-abc',
+  user_code: 'ABCD-EFGH',
+  verification_uri: 'https://microsoft.com/devicelogin',
+  expires_in: 900,
+  interval: 5,
+}
+
+function fakeIdToken(payload: Record<string, unknown>): string {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url')
+  return `${b64({ alg: 'none' })}.${b64(payload)}.sig`
+}
+
+describe('startMicrosoftConnect', () => {
+  it('uses the shipped default client_id + default scopes when there is no config', async () => {
+    let seen: MicrosoftOAuthClientConfig | undefined
+    const res = await startMicrosoftConnect({
+      requestDeviceCode: async (cfg) => {
+        seen = cfg
+        return DEVICE
+      },
+    })
+    expect(res.kind).toBe('started')
+    if (res.kind === 'started') {
+      expect(res.source).toBe('default')
+      expect(res.clientId).toBe(DEFAULT_MICROSOFT_CLIENT_ID)
+      expect(res.scopes).toContain('offline_access')
+      expect(res.device.user_code).toBe('ABCD-EFGH')
+    }
+    expect(seen?.client_id).toBe(DEFAULT_MICROSOFT_CLIENT_ID)
+  })
+
+  it('refuses a vaulted BYO client (gateway can\'t resolve vault refs)', async () => {
+    const res = await startMicrosoftConnect({
+      configClientId: 'vault:microsoft-oauth-client-id',
+      requestDeviceCode: async () => DEVICE,
+    })
+    expect(res.kind).toBe('byo-vault')
+    if (res.kind === 'byo-vault') {
+      expect(res.ref).toBe('vault:microsoft-oauth-client-id')
+    }
+  })
+
+  it('uses a literal BYO config client_id (source=config)', async () => {
+    const res = await startMicrosoftConnect({
+      configClientId: 'byo-literal-123',
+      requestDeviceCode: async () => DEVICE,
+    })
+    expect(res.kind).toBe('started')
+    if (res.kind === 'started') {
+      expect(res.source).toBe('config')
+      expect(res.clientId).toBe('byo-literal-123')
+    }
+  })
+
+  it('returns an error when the device-code request fails', async () => {
+    const res = await startMicrosoftConnect({
+      requestDeviceCode: async () => {
+        throw new Error('device_code request failed (400): boom')
+      },
+    })
+    expect(res.kind).toBe('error')
+    if (res.kind === 'error') expect(res.message).toContain('boom')
+  })
+})
+
+describe('runMicrosoftConnectPoll', () => {
+  const flow = {
+    device: DEVICE,
+    clientId: 'client-1',
+    scopes: ['offline_access', 'Mail.ReadWrite'],
+    cancelled: false,
+  }
+
+  function tokens(o: Partial<MicrosoftTokenResponse> = {}): MicrosoftTokenResponse {
+    return {
+      access_token: 'at',
+      refresh_token: 'rt',
+      expires_in: 3600,
+      token_type: 'Bearer',
+      scope: 'Mail.ReadWrite',
+      ...o,
+    }
+  }
+
+  it('connects: registers the account via the broker keyed by the authenticated email', async () => {
+    const id_token = fakeIdToken({
+      tid: PERSONAL_MSA_TID,
+      oid: 'oid-1',
+      preferred_username: 'Lisa@Outlook.com',
+    })
+    const calls: Array<{ label: string; opts: unknown; refreshToken: string }> = []
+    const res = await runMicrosoftConnectPoll(flow, {
+      pollDeviceToken: async () => tokens({ id_token }),
+      addAccount: async (label, creds, opts) => {
+        calls.push({
+          label,
+          opts,
+          refreshToken: creds.microsoftOauth.refreshToken,
+        })
+        return { label }
+      },
+    })
+    expect(res.kind).toBe('connected')
+    if (res.kind === 'connected') {
+      expect(res.account).toBe('lisa@outlook.com')
+      expect(res.accountType).toBe('personal')
+    }
+    expect(calls).toHaveLength(1)
+    expect(calls[0].label).toBe('lisa@outlook.com')
+    expect(calls[0].opts).toEqual({ provider: 'microsoft', replace: true })
+    expect(calls[0].refreshToken).toBe('rt')
+  })
+
+  it('cancelled: does NOT register if the flow was cancelled during the poll', async () => {
+    let added = false
+    const res = await runMicrosoftConnectPoll(
+      { ...flow, cancelled: true },
+      {
+        pollDeviceToken: async () => tokens(),
+        addAccount: async () => {
+          added = true
+          return { label: 'x' }
+        },
+      },
+    )
+    expect(res.kind).toBe('cancelled')
+    expect(added).toBe(false)
+  })
+
+  it('no-refresh-token: refuses to register an un-refreshable account', async () => {
+    let added = false
+    const res = await runMicrosoftConnectPoll(flow, {
+      pollDeviceToken: async () => tokens({ refresh_token: undefined }),
+      addAccount: async () => {
+        added = true
+        return { label: 'x' }
+      },
+    })
+    expect(res.kind).toBe('no-refresh-token')
+    expect(added).toBe(false)
+  })
+
+  it('failed: surfaces a poll error (e.g. a work account rejected at /common)', async () => {
+    const res = await runMicrosoftConnectPoll(flow, {
+      pollDeviceToken: async () => {
+        throw new Error('Token poll failed: AADSTS9001023 work account')
+      },
+      addAccount: async () => ({ label: 'x' }),
+    })
+    expect(res.kind).toBe('failed')
+    if (res.kind === 'failed') expect(res.message).toContain('AADSTS9001023')
+  })
+})

--- a/telegram-plugin/tests/microsoft-connect-flow.test.ts
+++ b/telegram-plugin/tests/microsoft-connect-flow.test.ts
@@ -166,4 +166,20 @@ describe('runMicrosoftConnectPoll', () => {
     expect(res.kind).toBe('failed')
     if (res.kind === 'failed') expect(res.message).toContain('AADSTS9001023')
   })
+
+  it('failed: refuses to register when Microsoft returns no id_token (no account identity)', async () => {
+    let added = false
+    const res = await runMicrosoftConnectPoll(flow, {
+      // Has a refresh token but no id_token → no resolvable email to key
+      // the broker account by; must NOT register a label-less account.
+      pollDeviceToken: async () => tokens({ id_token: undefined }),
+      addAccount: async () => {
+        added = true
+        return { label: 'x' }
+      },
+    })
+    expect(res.kind).toBe('failed')
+    if (res.kind === 'failed') expect(res.message).toContain('account identity')
+    expect(added).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

The headline **"connect from your phone"** win (RFC #1873 Phase 2; builds on #2088 broker repair + #2144 default app). An admin runs `/connect microsoft` in Telegram, taps a Microsoft sign-in link, approves on their phone, and the account is registered with the auth-broker — **no host shell, no Azure portal** (the shipped default app is used unless the operator BYO'd one).

Mirrors the existing `/auth add` flow but uses the RFC 8628 device-code engine already in `src/microsoft/oauth.ts`. No child subprocess, no pasted code — consent happens entirely on Microsoft's domain, so **nothing secret ever touches chat history** (strictly better than paste-back; no redaction needed).

## Why

Delivers the operator's headline goal (a non-technical partner connecting their own Microsoft account from a phone). Serves `talk-to-agents-from-anywhere`. Personal Microsoft accounts are the clean device-code case at `/common`; work/school accounts that Microsoft rejects there get a clear "use the host CLI" message — the documented personal-first / work-best-effort boundary.

## What changed

- **`microsoft-connect-flow.ts` (new)** — framework-agnostic core: `startMicrosoftConnect` (resolve client_id via the Phase-1 resolver → `requestDeviceCode`) + `runMicrosoftConnectPoll` (`pollDeviceToken` → `buildMicrosoftCredentials` → `addAccount`). All network/broker boundaries injectable; **zero raw `bot.api` calls** (the lint trap stays in the gateway). A vaulted BYO client is refused with a host-CLI pointer (the gateway can't resolve vault refs in-process); the shipped default + literal config values work.
- **`gateway.ts`** — `/connect microsoft` command (admin-gated like `/auth add`, keyed by `chatKey` so supergroup topics don't collide), a `cn:cancel:` card button + `/connect cancel`, a background poll that edits the card to the outcome (✅ connected as `<email>` + the enable command, or a clear failure), and a reaper sweep at the device's own expiry. The one raw `bot.api` edit (background card edit, no `ctx`) is wrapped in `robustApiCall` with an inline `allow-raw-bot-api` marker.
- **Extractions** — `selectMicrosoftScopes` (`src/microsoft/scopes.ts`) + the console-free credential builder (`src/microsoft/credentials.ts`) pulled out of `src/cli/auth-microsoft.ts` so the CLI and the gateway share **one** scope set + **one** id_token→credentials mapping. The CLI keeps its requested-vs-authenticated email-mismatch warning via the new `emailMismatch` return.
- **`auth-broker-client.ts`** — `addAccountViaBroker` now takes an optional `provider` (defaults Anthropic for `/auth add`; the connect flow passes `"microsoft"`).

## Scope (v1)

The flow connects + registers the account broker-wide and tells the operator the one command to enable it for an agent (`switchroom auth microsoft enable <email> <agent>` + restart). **Auto-enable + consent-owner binding are Phase 3.**

## Test plan

- [x] `src/microsoft/scopes.test.ts` (2) + `src/microsoft/credentials.test.ts` (5) — scope sets incl. mandatory `offline_access`; id_token→identity mapping (personal vs work, email lowercasing, mismatch flag, no-id_token fallback, scope fallback).
- [x] `telegram-plugin/tests/microsoft-connect-flow.test.ts` (8) — start: default client_id + scopes / BYO-vault refusal / literal-config / device-code error; poll: connected (registers keyed by authenticated email, `replace:true`), cancelled (no write), no-refresh-token (no write), failed (surfaces poll error).
- [x] Full lint chain green (`tsc`, plugin-references, **bot-api-wrapping**, bun-test-imports, no-pii-secrets, vault-hermeticity, no-broadcast). Build clean.

## Risk

Moderate (touches the gateway). Mitigations: the flow logic is isolated + fully unit-tested with injected boundaries; the gateway delta is a self-contained command + callback + reaper line; admin-gated; the `cn:` callback re-checks `allowFrom`; no secret in chat (device-code). Known v1 limitation: a gateway restart mid-poll drops the in-memory pending flow (the card stalls; the user re-runs `/connect`) — acceptable, noted for Phase 3.

## Follow-ups

- Phase 3: auto-enable the initiating agent + `connected_by` owner binding + self-disconnect + re-consent card on refresh failure.
- Release: bundle #2088 + #2144 + this into one "Microsoft out-of-box connect" release with a UAT + live canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)