### PR TITLE
fix(telegram): close the obligation-ledger hang-wedge (bound the escalation send)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -289,6 +289,7 @@ import {
   obligationEscalationText,
 } from './obligation-ledger.js'
 import { loadObligations, persistObligations } from './obligation-store.js'
+import { withDeadline } from './with-deadline.js'
 import { createInboundSpool } from './inbound-spool.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
@@ -1411,6 +1412,17 @@ const OBLIGATION_SWEEP_MS = 5_000
 // attempts the gateway closes best-effort (loud log): the user is genuinely
 // unreachable, so a bounded give-up beats an infinite/poison loop.
 const OBLIGATION_ESCALATE_MAX = 3
+// Deadline for a single escalation send. grammy/fetch impose NO request timeout,
+// and the in-flight guard (obligationEscalateInFlight) is cleared only in the
+// send's `.finally` — which never runs if the send hangs. Without a bound, one
+// stalled send leaks the in-flight flag forever and the obligation is stuck OPEN
+// (never re-escalated, never closed) — the sole liveness hole a total proof
+// found. Racing the send against this deadline makes the wait bounded BY
+// CONSTRUCTION (see with-deadline.ts): the chain always settles, `.finally`
+// always clears the flag, and a hang becomes a bounded reject that feeds the
+// bounded escalate ladder to a terminal. 45s comfortably exceeds robustApiCall's
+// 3-attempt network backoff so a legitimate slow send isn't cut short.
+const OBLIGATION_ESCALATE_SEND_DEADLINE_MS = 45_000
 // Durable snapshot of the open obligation set on the persistent per-agent
 // volume (STATE_DIR = /state/agent/telegram in prod). Closes the restart hole:
 // the in-memory ledger alone empties on restart and the spool's boot-replay
@@ -4890,16 +4902,39 @@ const pendingInboundBuffer = createPendingInboundBuffer({ spool: inboundSpool })
 // OPEN via meta.source; reuses tested delivery). Bounded: after maxRepresents,
 // escalate to ONE operator-visible "did I miss this?" and close — no loop.
 // No-op unless the flag is on; gated on the same idle predicate as the drains.
+// DETERMINISM (closed-form, not sampled). The obligation ledger itself
+// (obligation-ledger.ts) is a finite FSM with a total transition function and a
+// strictly-decreasing measure μ = (REPRESENT_MAX - representCount) +
+// (ESCALATE_MAX - escalateAttempts): every markRepresented/markEscalateAttempt
+// decreases μ, both terms are bounded below, and at the floor the only move is
+// close → terminal. So on the FSM, every OPEN reaches answered | escalation-
+// delivered | bounded give-up (no cycle re-increments a counter). This sweep is
+// the FSM's driver; its termination rests on three liveness facts, all bounded:
+//   (1) the 5s setInterval keeps firing;
+//   (2) the gate (turnInFlightForGate) opens — claudeBusyKeys is cleared at
+//       turn-end (purgeReactionTracking / releaseTurnBufferGate), on bridge
+//       disconnect (disconnect-flush.ts), and by the 300s silence-poke watchdog;
+//   (3) the escalation send settles — bounded BY CONSTRUCTION via withDeadline
+//       below (grammy has no request timeout, so an unbounded send was the one
+//       way an obligation could get stuck OPEN forever — now closed).
+// The only residual liveness assumption is the bridge eventually reconnecting /
+// the process restarting, which the entire gateway's inbound delivery already
+// depends on and which durable spool + boot-replay make self-healing.
 function obligationSweep(): void {
   if (!OBLIGATION_LEDGER_ENABLED) return
   if (!obligationLedger.hasOpen()) return
   if (turnInFlightForGate()) return // a turn is running — let it finish/answer
   const agent = process.env.SWITCHROOM_AGENT_NAME ?? ''
-  if (pendingInboundBuffer.depth(agent) > 0) return // existing drain runs first; avoids double-present
   const decision = obligationLedger.decideAtIdle()
   const o = decision.obligation
   if (decision.action === 'none' || o == null) return
   if (decision.action === 'represent') {
+    // Re-present goes through the bridge → buffer. Only the represent path is
+    // gated on an empty buffer (let the existing drain run first, avoid
+    // double-presenting). Escalation below is NOT gated on the buffer — it is a
+    // direct Telegram send, independent of the bridge, so a represent stranded
+    // behind a dead bridge can never block the operator nudge.
+    if (pendingInboundBuffer.depth(agent) > 0) return
     pendingInboundBuffer.push(agent, buildObligationRepresentInbound(o, Date.now()))
     const attempt = obligationLedger.markRepresented(o.originTurnId)
     process.stderr.write(
@@ -4925,13 +4960,22 @@ function obligationSweep(): void {
   // retryWithThreadFallback: a stale/renumbered topic returns THREAD_NOT_FOUND;
   // retry WITHOUT the thread so the nudge still lands in the chat (the #2096
   // pattern) instead of being permanently undeliverable to a dead topic.
-  void retryWithThreadFallback(
-    robustApiCall,
-    (tid) =>
-      bot.api.sendMessage(o.chatId, obligationEscalationText(o), {
-        ...(tid != null ? { message_thread_id: tid } : {}),
-      }),
-    { threadId: o.threadId, chat_id: o.chatId, verb: 'obligation.escalate' },
+  // withDeadline: grammy/fetch impose no request timeout and `.finally` (which
+  // clears the in-flight flag) only runs on settle — so a hung send would leak
+  // the flag forever and wedge this obligation OPEN. Racing against a deadline
+  // guarantees the chain settles, the flag always clears, and a hang becomes a
+  // bounded reject handled exactly like any other failed attempt.
+  void withDeadline(
+    retryWithThreadFallback(
+      robustApiCall,
+      (tid) =>
+        bot.api.sendMessage(o.chatId, obligationEscalationText(o), {
+          ...(tid != null ? { message_thread_id: tid } : {}),
+        }),
+      { threadId: o.threadId, chat_id: o.chatId, verb: 'obligation.escalate' },
+    ),
+    OBLIGATION_ESCALATE_SEND_DEADLINE_MS,
+    'obligation escalation send timed out',
   )
     .then(() => {
       obligationLedger.close(escId)

--- a/telegram-plugin/gateway/with-deadline.ts
+++ b/telegram-plugin/gateway/with-deadline.ts
@@ -1,0 +1,43 @@
+/**
+ * withDeadline — bound a promise so the chain off it ALWAYS settles within `ms`.
+ *
+ * Why this exists (the obligation-ledger determinism hole): the escalation send
+ * in `obligationSweep` is fire-and-forget and clears its in-flight guard
+ * (`obligationEscalateInFlight`) only in a `.finally` — which runs only if the
+ * awaited promise SETTLES. grammy's `bot.api` has no request timeout
+ * (`new Bot(TOKEN)`, no `client.timeoutSeconds`) and `retryApiCall`'s `await
+ * fn()` does not bound a hang (its retry cap applies to rejections, not to a
+ * promise that never resolves). So a stalled send (half-open TCP, unresponsive
+ * Telegram) would never settle → `.finally` never fires → the in-flight id is
+ * leaked forever → every later sweep early-returns at the guard → the
+ * obligation is stuck OPEN: never re-presented, never escalated, never closed.
+ * That is a silent loss of the "every inbound is answered-or-escalated"
+ * guarantee — the one liveness hole a total state-machine proof surfaced (a
+ * sampling test cannot, because its model never includes "send never settles").
+ *
+ * Racing the send against a deadline makes the wait bounded BY CONSTRUCTION:
+ * the returned promise settles in ≤ `ms`, so the caller's `.then/.catch/.finally`
+ * always run and the in-flight flag always clears. A hang becomes a bounded
+ * rejection that feeds the already-bounded escalate ladder
+ * (`escalateAttempts → OBLIGATION_ESCALATE_MAX`) to a terminal. The losing
+ * (still-pending) promise is given a no-op `.catch` so its eventual rejection
+ * is not an unhandled rejection, and the timer is cleared + unref'd so it
+ * neither leaks nor keeps the event loop alive.
+ *
+ * Pure (no gateway/Telegram coupling) ⇒ unit-testable; see
+ * tests/with-deadline.test.ts.
+ */
+export function withDeadline<T>(p: Promise<T>, ms: number, timeoutMessage: string): Promise<T> {
+  // Swallow a late rejection from the loser after the race has already settled,
+  // so a hung-then-eventually-rejected send is never an unhandled rejection.
+  p.catch(() => {})
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(timeoutMessage)), ms)
+    // Don't keep the process alive solely for this timer.
+    ;(timer as unknown as { unref?: () => void }).unref?.()
+  })
+  return Promise.race([p, deadline]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer)
+  }) as Promise<T>
+}

--- a/telegram-plugin/tests/obligation-determinism.test.ts
+++ b/telegram-plugin/tests/obligation-determinism.test.ts
@@ -7,30 +7,30 @@ import {
 } from "../gateway/obligation-store.js";
 
 /**
- * DETERMINISM PROOF (by exhaustive simulation, not live observation).
+ * REGRESSION GUARD — not the proof.
  *
- * The operator's requirement: be confident — by reasoning — that EVERY real
- * inbound reaches answered-or-escalated for ANY model behaviour and ANY timing,
- * including across a restart, with no silent drop and no double-ask of a message
- * that WAS answered.
+ * The actual determinism argument is closed-form and lives WITH the code: the
+ * ledger is a finite FSM with a total transition function and a strictly-
+ * decreasing measure μ = (REPRESENT_MAX - representCount) + (ESCALATE_MAX -
+ * escalateAttempts) ⇒ every OPEN reaches a terminal (see the proof comment on
+ * obligationSweep in gateway.ts and the ledger methods in obligation-ledger.ts).
+ * A total state-machine proof also found — and a fix closed — the one liveness
+ * hole this kind of SAMPLING test structurally cannot reach: a hung escalation
+ * send leaking the in-flight flag (now bounded by withDeadline; guarded by
+ * with-deadline.test.ts). The lesson stands: a random-schedule test only
+ * exercises the behaviours its model encodes; it is evidence, never the proof.
  *
- * This drives the REAL ObligationLedger + the REAL durable snapshot store
- * (obligation-store, over an in-memory fs whose rename is atomic) through a
- * faithful model of the gateway's obligation lifecycle:
- *
- *   OPEN     — on receipt (handleInbound, idempotent).
- *   close    — at turn_end iff the turn delivered a final answer (finalAnswerDelivered).
- *   represent— idle sweep, bounded by maxRepresents, drives a fresh must-answer turn.
- *   escalate — ladder exhausted: send the operator nudge; close ONLY after it
- *              lands; a transient send failure stays OPEN and retries; a permanent
- *              one is bounded (OBLIGATION_ESCALATE_MAX) → close best-effort.
- *   restart  — fresh ledger hydrated from the durable snapshot (counters intact).
- *
- * Over thousands of random schedules it asserts the invariant holds and the
- * engine always terminates (no infinite loop). The COALESCED PARTIAL-ANSWER
- * residual is deliberately NOT modelled — it is the one honest hard limit (a
- * turn-keyed ledger cannot see "answered half" without parsing model prose) and
- * is mitigated by coalescing policy, not the ledger.
+ * What this file still earns its keep doing: drive the REAL ObligationLedger +
+ * REAL durable snapshot store over many random {model-behaviour × timing ×
+ * restart} schedules to catch a regression that breaks the FSM invariant
+ * (no silent drop, no double-ask of an answered message, bounded termination).
+ * It models the lifecycle SYNCHRONOUSLY (open at receipt; close at turn_end on a
+ * delivered answer; bounded represent→escalate; restart = hydrate from snapshot)
+ * — so it does NOT and cannot cover async/coupling liveness (hung send, gate
+ * never opening, drain wedging); those are proven/bounded in the code, not here.
+ * The coalesced PARTIAL-ANSWER residual is also out of model — the one honest
+ * hard limit (a turn-keyed ledger can't see "answered half" without parsing the
+ * model's prose), mitigated by coalescing policy, not the ledger.
  */
 
 // Mirrors the gateway constants under test.

--- a/telegram-plugin/tests/with-deadline.test.ts
+++ b/telegram-plugin/tests/with-deadline.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { withDeadline } from "../gateway/with-deadline.js";
+
+const tick = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("withDeadline — bounds the obligation escalation send so a hang can't leak the in-flight flag", () => {
+  it("resolves with the inner value when the promise settles before the deadline", async () => {
+    await expect(withDeadline(Promise.resolve("ok"), 1000, "timed out")).resolves.toBe("ok");
+  });
+
+  it("rejects with the inner error when the promise rejects before the deadline", async () => {
+    await expect(withDeadline(Promise.reject(new Error("boom")), 1000, "timed out")).rejects.toThrow(
+      "boom",
+    );
+  });
+
+  it("rejects with the timeout message when the promise NEVER settles (the hang case)", async () => {
+    // The whole point: a promise that never resolves/rejects (a stalled send)
+    // must still settle the chain so the caller's .finally clears the in-flight flag.
+    const neverSettles = new Promise<string>(() => {});
+    await expect(withDeadline(neverSettles, 20, "obligation escalation send timed out")).rejects.toThrow(
+      "obligation escalation send timed out",
+    );
+  });
+
+  it("the .finally chained after it ALWAYS runs even when the inner promise hangs", async () => {
+    // This mirrors the gateway's obligationEscalateInFlight clear: it lives in a
+    // .finally on withDeadline(...), and must fire within the deadline regardless.
+    let flagCleared = false;
+    await withDeadline(new Promise<void>(() => {}), 20, "timed out")
+      .catch(() => {})
+      .finally(() => {
+        flagCleared = true;
+      });
+    expect(flagCleared).toBe(true);
+  });
+
+  it("a hung-then-late-rejecting inner promise does not produce an unhandled rejection", async () => {
+    const seen: unknown[] = [];
+    const onUnhandled = (reason: unknown) => seen.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const lateReject = new Promise<void>((_, reject) => {
+        setTimeout(() => reject(new Error("late-zombie-rejection")), 30);
+      });
+      // withDeadline rejects at 10ms; the inner promise rejects later at 30ms.
+      await withDeadline(lateReject, 10, "timed out").catch(() => {});
+      await tick(60); // let the late rejection fire
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+    expect(seen.some((r) => r instanceof Error && r.message === "late-zombie-rejection")).toBe(false);
+  });
+
+  it("clears its timer on a fast settle (no dangling work keeps the loop alive)", async () => {
+    // Sanity: a fast resolve settles immediately, not after the deadline.
+    const start = Date.now();
+    await withDeadline(Promise.resolve(1), 5000, "timed out");
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
## Summary
A **total** state-machine proof (every reachable state × every input event — not a sampled property test) found the obligation guarantee (`SWITCHROOM_OBLIGATION_LEDGER`, live on marko) was **not deterministic by construction**: it rested on one unproven liveness assumption a sampling test structurally cannot reach — *the escalation send settles*. This closes it.

## The hole (real, reachable, confirmed in code)
The escalation send is fire-and-forget and clears its in-flight guard (`obligationEscalateInFlight`) only in a `.finally`, which runs **only if the promise settles**. grammy's `bot.api` has no request timeout (`new Bot(TOKEN)`, gateway.ts:674) and `retryApiCall`'s `await fn()` bounds *rejections*, not a *hang* (retry-api-call.ts:91-93). So a stalled send (half-open TCP / unresponsive Telegram) never settles → the in-flight id leaks forever → every later sweep early-returns at the guard (gateway.ts:4918) → the obligation is **stuck OPEN: never re-presented, never escalated, never closed**. A silent loss of the answer guarantee, in the live process. The property test modeled send as synchronously succeed/fail, so it *could not* catch this.

## Fix — correct by construction, not by test
- **`withDeadline`** (new, pure, unit-tested) races the send against a 45s deadline so the chain **always** settles → `.finally` always clears the flag → a hang becomes a bounded reject, handled exactly like any other failed attempt, feeding the already-bounded escalate ladder (`escalateAttempts → OBLIGATION_ESCALATE_MAX`) to a terminal. Loser swallowed (no unhandled rejection); timer cleared + `unref`'d.
- **Decouple escalation from the buffer-depth gate**: escalation is a direct Telegram send, bridge-independent, so a represent stranded behind a dead bridge can no longer block the operator nudge. Only the `represent` path waits on an empty buffer. (The proof's second, lesser hole — a delay, not a drop, but it needlessly blocked escalation too.)
- Records the **closed-form determinism argument with the code**: the ledger is a finite FSM with a strictly-decreasing measure μ = (REPRESENT_MAX−representCount) + (ESCALATE_MAX−escalateAttempts); the sweep's termination now rests only on bounded facts (5s tick; gate opens via turn-end / `disconnect-flush.ts` / 300s watchdog; the send is bounded) plus the one irreducible assumption shared by *all* inbound delivery (bridge reconnects / process restarts, self-healing via durable spool + boot-replay).
- The property test is demoted in its own header to a **regression guard** — evidence, never the proof.

## What the proof refuted (don't "fix" non-bugs)
- *"`claudeBusyKeys` is never deleted → gate wedges forever"* — **wrong**: deletes at `disconnect-flush.ts:114/134/160`, `gateway.ts:2237/2359`, plus the 300s watchdog. (This is why the sweep fired live at all.)
- *buffer-drain stall* — backstopped by durable spool + boot-replay; a delivery delay, not a drop.

## Test plan
- [x] `with-deadline.test.ts` (6) — incl. the **hang case** (`never-settles` → bounded reject) and "the `.finally` always runs even when the inner promise hangs".
- [x] `obligation-{ledger,store,determinism}.test.ts` (32) green; determinism test re-headed as a regression guard.
- [x] `tsc --noEmit`, `check-plugin-references.mjs`, `check-bot-api-wrapping.sh` all clean (the escalation send stays wrapped in `retryWithThreadFallback(robustApiCall, …)`).

## Risk
Low; flag-gated (live on marko, off elsewhere). Strictly improves the escalation terminal — turns the one unbounded wait into a bounded one. Follow-up to #2149.