### PR TITLE
test(telegram): make the obligation escalation hang-path executable

### DIFF
--- a/telegram-plugin/gateway/escalation-drive.ts
+++ b/telegram-plugin/gateway/escalation-drive.ts
@@ -1,0 +1,79 @@
+/**
+ * escalation-drive.ts — the obligation-ledger escalation step, extracted from
+ * obligationSweep so the hang → bounded → terminal behaviour is EXECUTABLE in a
+ * test with a fake hanging send. That path is unreachable by the two harnesses
+ * we have: mtcute can't make Telegram's API hang, and the synchronous property
+ * test can't model a promise that never settles — yet it is exactly the path the
+ * total proof flagged as the determinism hole. This file makes the real drive
+ * logic the sweep uses testable in isolation (escalation-drive.test.ts), so the
+ * fix is verified by execution, not only by reasoning + review.
+ *
+ * Invariant it upholds: a single escalation attempt
+ *  - is guarded so a sweep tick cannot fire a second concurrent send for the
+ *    same obligation while one is awaiting;
+ *  - bounds the send with `withDeadline`, so the chain ALWAYS settles within
+ *    `deadlineMs` ⇒ the in-flight flag ALWAYS clears (a hung send becomes a
+ *    bounded reject, handled like any other failed attempt);
+ *  - closes the obligation ONLY after a successful send; a transient failure
+ *    leaves it OPEN (retried next sweep); a permanent failure
+ *    (attempt ≥ maxAttempts) closes best-effort — so repeated hung/failed sends
+ *    reach a terminal in a bounded number of sweeps, never an infinite loop.
+ */
+import { withDeadline } from './with-deadline.js'
+
+/** The slice of the ledger the escalation step needs. */
+export interface EscalationLedger {
+  markEscalateAttempt(originTurnId: string): number
+  close(originTurnId: string | null | undefined): boolean
+}
+
+export interface DriveEscalationArgs {
+  escId: string
+  /** Set of origin ids with an escalation send in flight (concurrency guard). */
+  inFlight: Set<string>
+  ledger: EscalationLedger
+  /** Perform the operator-nudge send (already thread-fallback-wrapped). May hang. */
+  send: () => Promise<unknown>
+  /** Attempts before a permanent failure closes best-effort. */
+  maxAttempts: number
+  /** Bound on a single send so a hang can't leak the in-flight flag. */
+  deadlineMs: number
+  log?: (line: string) => void
+  /** Injectable for tests; defaults to the real withDeadline. */
+  withDeadlineFn?: typeof withDeadline
+}
+
+/**
+ * Drive one escalation attempt. Returns the settling chain promise (so tests can
+ * await it) or `undefined` if the call was a no-op because a send is already in
+ * flight for `escId`. obligationSweep calls this as `void driveEscalation(...)`.
+ */
+export function driveEscalation(args: DriveEscalationArgs): Promise<void> | undefined {
+  const { escId, inFlight, ledger, send, maxAttempts, deadlineMs } = args
+  const log = args.log ?? ((l: string) => process.stderr.write(l))
+  const wd = args.withDeadlineFn ?? withDeadline
+  if (inFlight.has(escId)) return undefined // a send is already awaiting
+  const attempt = ledger.markEscalateAttempt(escId)
+  inFlight.add(escId)
+  log(`telegram gateway: obligation escalating origin=${escId} attempt=${attempt}/${maxAttempts}\n`)
+  return wd(send(), deadlineMs, 'obligation escalation send timed out')
+    .then(() => {
+      ledger.close(escId)
+      log(`telegram gateway: obligation escalation delivered + closed origin=${escId}\n`)
+    })
+    .catch((err: unknown) => {
+      if (attempt >= maxAttempts) {
+        ledger.close(escId)
+        log(
+          `telegram gateway: obligation escalation PERMANENTLY undeliverable after ${attempt} attempts — closing best-effort origin=${escId}: ${err}\n`,
+        )
+      } else {
+        log(
+          `telegram gateway: obligation escalation send failed (attempt ${attempt}/${maxAttempts}), retrying next sweep origin=${escId}: ${err}\n`,
+        )
+      }
+    })
+    .finally(() => {
+      inFlight.delete(escId)
+    })
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -289,7 +289,7 @@ import {
   obligationEscalationText,
 } from './obligation-ledger.js'
 import { loadObligations, persistObligations } from './obligation-store.js'
-import { withDeadline } from './with-deadline.js'
+import { driveEscalation } from './escalation-drive.js'
 import { createInboundSpool } from './inbound-spool.js'
 import { purgeStaleTurnsForChat } from './turn-state-purge.js'
 import { decideInboundDelivery } from './inbound-delivery-gate.js'
@@ -4950,54 +4950,30 @@ function obligationSweep(): void {
   // (dead topic even after thread-fallback, blocked bot) is bounded by
   // OBLIGATION_ESCALATE_MAX → close best-effort (the user is unreachable, so a
   // bounded give-up beats an infinite loop / a boot-surviving poison record).
-  if (obligationEscalateInFlight.has(o.originTurnId)) return // a send is already awaiting
-  const escId = o.originTurnId
-  const attempt = obligationLedger.markEscalateAttempt(escId)
-  obligationEscalateInFlight.add(escId)
-  process.stderr.write(
-    `telegram gateway: obligation escalating (exhausted ${OBLIGATION_REPRESENT_MAX} re-presents) origin=${escId} attempt=${attempt}/${OBLIGATION_ESCALATE_MAX}\n`,
-  )
-  // retryWithThreadFallback: a stale/renumbered topic returns THREAD_NOT_FOUND;
-  // retry WITHOUT the thread so the nudge still lands in the chat (the #2096
-  // pattern) instead of being permanently undeliverable to a dead topic.
-  // withDeadline: grammy/fetch impose no request timeout and `.finally` (which
-  // clears the in-flight flag) only runs on settle — so a hung send would leak
-  // the flag forever and wedge this obligation OPEN. Racing against a deadline
-  // guarantees the chain settles, the flag always clears, and a hang becomes a
-  // bounded reject handled exactly like any other failed attempt.
-  void withDeadline(
-    retryWithThreadFallback(
-      robustApiCall,
-      (tid) =>
-        bot.api.sendMessage(o.chatId, obligationEscalationText(o), {
-          ...(tid != null ? { message_thread_id: tid } : {}),
-        }),
-      { threadId: o.threadId, chat_id: o.chatId, verb: 'obligation.escalate' },
-    ),
-    OBLIGATION_ESCALATE_SEND_DEADLINE_MS,
-    'obligation escalation send timed out',
-  )
-    .then(() => {
-      obligationLedger.close(escId)
-      process.stderr.write(
-        `telegram gateway: obligation escalation delivered + closed origin=${escId}\n`,
-      )
-    })
-    .catch((err) => {
-      if (attempt >= OBLIGATION_ESCALATE_MAX) {
-        obligationLedger.close(escId)
-        process.stderr.write(
-          `telegram gateway: obligation escalation PERMANENTLY undeliverable after ${attempt} attempts — closing best-effort origin=${escId}: ${err}\n`,
-        )
-      } else {
-        process.stderr.write(
-          `telegram gateway: obligation escalation send failed (attempt ${attempt}/${OBLIGATION_ESCALATE_MAX}), retrying next sweep origin=${escId}: ${err}\n`,
-        )
-      }
-    })
-    .finally(() => {
-      obligationEscalateInFlight.delete(escId)
-    })
+  // Drive one escalation attempt. The send is a direct Telegram nudge
+  // (retryWithThreadFallback: a stale/renumbered topic → THREAD_NOT_FOUND retries
+  // thread-less, the #2096 pattern). driveEscalation guards against concurrent
+  // sends, bounds the send with withDeadline (so a hung send can't leak the
+  // in-flight flag and wedge the obligation OPEN), closes only after a successful
+  // send, and bounds permanent failures to a best-effort close. Extracted so the
+  // hang → bounded → terminal path is executable in escalation-drive.test.ts —
+  // the path neither mtcute (can't hang Telegram) nor a synchronous test reaches.
+  void driveEscalation({
+    escId: o.originTurnId,
+    inFlight: obligationEscalateInFlight,
+    ledger: obligationLedger,
+    send: () =>
+      retryWithThreadFallback(
+        robustApiCall,
+        (tid) =>
+          bot.api.sendMessage(o.chatId, obligationEscalationText(o), {
+            ...(tid != null ? { message_thread_id: tid } : {}),
+          }),
+        { threadId: o.threadId, chat_id: o.chatId, verb: 'obligation.escalate' },
+      ),
+    maxAttempts: OBLIGATION_ESCALATE_MAX,
+    deadlineMs: OBLIGATION_ESCALATE_SEND_DEADLINE_MS,
+  })
 }
 if (!STATIC && OBLIGATION_LEDGER_ENABLED) {
   setInterval(obligationSweep, OBLIGATION_SWEEP_MS).unref()

--- a/telegram-plugin/tests/escalation-drive.test.ts
+++ b/telegram-plugin/tests/escalation-drive.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { driveEscalation } from "../gateway/escalation-drive.js";
+import { ObligationLedger } from "../gateway/obligation-ledger.js";
+
+// Drives the REAL escalation step (the code obligationSweep calls) with the REAL
+// ObligationLedger and the REAL withDeadline — including a fake hanging send,
+// the exact path the total proof flagged and that mtcute / a synchronous test
+// cannot reach. This is the executable verification of the hang-wedge fix.
+
+function openEscalatable(L: ObligationLedger, id: string) {
+  L.openIfAbsent({ originTurnId: id, chatId: "-100", threadId: 3, messageId: 1, text: "x", openedAt: 0 });
+}
+
+const MAX = 3;
+const DEADLINE = 15; // ms — short so the hang case settles fast and deterministically
+
+describe("driveEscalation — the obligation escalation step is bounded and always reaches a terminal", () => {
+  it("a successful send closes the obligation and clears the in-flight flag", async () => {
+    const L = new ObligationLedger(2);
+    openEscalatable(L, "c#1");
+    const inFlight = new Set<string>();
+    await driveEscalation({
+      escId: "c#1",
+      inFlight,
+      ledger: L,
+      send: () => Promise.resolve("sent"),
+      maxAttempts: MAX,
+      deadlineMs: DEADLINE,
+      log: () => {},
+    });
+    expect(L.isOpen("c#1")).toBe(false); // closed
+    expect(inFlight.has("c#1")).toBe(false); // flag cleared
+  });
+
+  it("a transient failure below the cap stays OPEN and clears the flag (retried next sweep)", async () => {
+    const L = new ObligationLedger(2);
+    openEscalatable(L, "c#1");
+    const inFlight = new Set<string>();
+    await driveEscalation({
+      escId: "c#1",
+      inFlight,
+      ledger: L,
+      send: () => Promise.reject(new Error("network blip")),
+      maxAttempts: MAX,
+      deadlineMs: DEADLINE,
+      log: () => {},
+    });
+    expect(L.isOpen("c#1")).toBe(true); // still open — will retry
+    expect(inFlight.has("c#1")).toBe(false); // flag cleared, so the next sweep can re-enter
+  });
+
+  it("THE FIX: a send that NEVER settles still clears the flag (bounded by the deadline)", async () => {
+    const L = new ObligationLedger(2);
+    openEscalatable(L, "c#1");
+    const inFlight = new Set<string>();
+    let sendInvoked = 0;
+    const start = Date.now();
+    // A promise that never resolves/rejects — the stalled send that, pre-fix,
+    // left the in-flight flag set forever and wedged the obligation OPEN.
+    await driveEscalation({
+      escId: "c#1",
+      inFlight,
+      ledger: L,
+      send: () => {
+        sendInvoked++;
+        return new Promise(() => {});
+      },
+      maxAttempts: MAX,
+      deadlineMs: DEADLINE,
+      log: () => {},
+    });
+    expect(sendInvoked).toBe(1);
+    expect(inFlight.has("c#1")).toBe(false); // cleared despite the hang — the wedge is gone
+    expect(Date.now() - start).toBeLessThan(DEADLINE + 500); // settled at the deadline, not "never"
+  });
+
+  it("repeated hung sends reach a bounded terminal (close best-effort), never an infinite loop", async () => {
+    const L = new ObligationLedger(2);
+    openEscalatable(L, "c#1");
+    const inFlight = new Set<string>();
+    let sends = 0;
+    let drives = 0;
+    // Simulate the 5s sweep firing repeatedly while every send hangs.
+    while (L.isOpen("c#1") && drives < 20) {
+      drives++;
+      const p = driveEscalation({
+        escId: "c#1",
+        inFlight,
+        ledger: L,
+        send: () => {
+          sends++;
+          return new Promise(() => {});
+        },
+        maxAttempts: MAX,
+        deadlineMs: DEADLINE,
+        log: () => {},
+      });
+      if (p) await p; // each attempt settles within the deadline
+    }
+    expect(L.isOpen("c#1")).toBe(false); // reached a terminal (closed best-effort)
+    expect(inFlight.has("c#1")).toBe(false);
+    expect(sends).toBe(MAX); // exactly maxAttempts sends, then close — bounded
+    expect(drives).toBeLessThanOrEqual(MAX + 1);
+  });
+
+  it("the in-flight guard prevents a concurrent second send for the same obligation", async () => {
+    const L = new ObligationLedger(2);
+    openEscalatable(L, "c#1");
+    const inFlight = new Set<string>();
+    let sends = 0;
+    const hang = () => {
+      sends++;
+      return new Promise<void>(() => {});
+    };
+    const p1 = driveEscalation({ escId: "c#1", inFlight, ledger: L, send: hang, maxAttempts: MAX, deadlineMs: 60, log: () => {} });
+    // Second call while the first is still awaiting → must be a no-op.
+    const p2 = driveEscalation({ escId: "c#1", inFlight, ledger: L, send: hang, maxAttempts: MAX, deadlineMs: 60, log: () => {} });
+    expect(p2).toBeUndefined(); // guarded
+    expect(sends).toBe(1); // only one send fired
+    expect(L.list()[0].escalateAttempts).toBe(1); // only one attempt recorded
+    await p1; // let the first settle so we don't leak a pending timer
+  });
+});


### PR DESCRIPTION
## Summary
Makes the obligation-ledger escalation **hang-path** executable in a test. The hang-wedge fix (#2152) was verified by a total proof + a `withDeadline` unit test in isolation + review of the wiring — but the *integrated* path (the `withDeadline` + close/bounded-retry/clear-flag chain in `obligationSweep`) had **never actually run with a hung send**: mtcute can't make Telegram hang, and the synchronous property test can't model a non-settling promise. So the exact behavior the fix changes rested on reasoning, not execution. This closes that gap — **no behavior change**.

## What changed
- Extract the escalation step from `obligationSweep` into **`driveEscalation`** (`escalation-drive.ts`) — pure, dependency-injected (`ledger` / `inFlight` set / `send` thunk / `maxAttempts` / `deadlineMs` / `withDeadlineFn`). The sweep now calls it; the logic is identical (verified by the unchanged gates).
- **`escalation-drive.test.ts`** drives the REAL `driveEscalation` with the REAL `ObligationLedger` and REAL `withDeadline`:
  - **a send that NEVER settles** → the in-flight flag still clears (the wedge is gone), settling at the deadline (proven by elapsed time);
  - **repeated hung sends** → bounded terminal in exactly `maxAttempts` sends, never an infinite loop;
  - transient-failure-stays-open, success-closes, and the concurrency guard (a second concurrent call is a no-op).

## Why (the honest gap this closes)
mtcute is a no-regression check on the *normal* path (it ran green on v0.14.62), but it structurally cannot exercise a hung send. The certainty on the changed behavior was a proof; this turns it into an executed, deterministic regression guard — the behavior-matched test the proof deserves.

## Test plan
- [x] `escalation-drive.test.ts` (5) + `with-deadline` (6) + `obligation-{ledger,store,determinism}` (32) = 43 green.
- [x] `tsc --noEmit`, `check-plugin-references.mjs`, `check-bot-api-wrapping.sh` clean (escalation send still wrapped in `retryWithThreadFallback(robustApiCall, …)`).

## Risk
Minimal — pure extraction, behavior-identical, flag-gated. Follow-up to #2152.