### PR TITLE
fix(telegram): stop '[object Object]' in activity feed for object-valued MCP inputs

### DIFF
--- a/telegram-plugin/hooks/tool-label-pretool.mjs
+++ b/telegram-plugin/hooks/tool-label-pretool.mjs
@@ -36,6 +36,26 @@ function readStdin() {
 }
 
 /**
+ * Coerce a tool-input field to display text WITHOUT the `[object Object]`
+ * trap. Only primitives carry a meaningful label: strings pass through,
+ * numbers/booleans stringify cleanly. Objects and arrays return '' so the
+ * caller falls through to its next fallback (a sibling field, or the
+ * humanized tool name) instead of surfacing literal "[object Object]".
+ *
+ * This guards the MCP-tool path in particular: an operator-configured
+ * server (e.g. Brevo CRM) may pass a filter/query OBJECT in `query` /
+ * `description` / `title`, and the old `String(i.query ?? '')` coercion
+ * rendered that as "[object Object]" on the live activity feed. The
+ * renderer's own `clip()` already rejects non-strings; this mirrors that
+ * contract at the hook so the bad value never reaches the sidecar JSONL.
+ */
+function asText(v) {
+  if (typeof v === 'string') return v
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  return ''
+}
+
+/**
  * One-line, length-bounded escape of a value for inclusion in a label.
  * Newlines collapsed, very long strings truncated with an ellipsis.
  */
@@ -82,10 +102,10 @@ export function computeLabel(toolName, input) {
   // for Bash/Task, matching the gateway's describeToolUse rendering.
   switch (toolName) {
     case 'Bash':
-      return clip(String(i.description ?? ''), 70).trim() || 'Running a command'
+      return clip(asText(i.description), 70).trim() || 'Running a command'
     case 'Task':
     case 'Agent': {
-      const d = clip(String(i.description ?? ''), 60).trim()
+      const d = clip(asText(i.description), 60).trim()
       return d ? `Delegating: ${d}` : 'Delegating to a sub-agent'
     }
     case 'TodoWrite':
@@ -103,16 +123,16 @@ export function computeLabel(toolName, input) {
     case 'Write':
       return `Writing ${clip(safeBasename(i.file_path))}`.trim()
     case 'Grep': {
-      const path = i.path ? clip(String(i.path), 40) : '.'
-      const pat = clip(String(i.pattern ?? ''), 40)
+      const path = i.path ? clip(asText(i.path), 40) : '.'
+      const pat = clip(asText(i.pattern), 40)
       return `Searching ${path} for ${pat}`
     }
     case 'Glob':
-      return `Finding files matching ${clip(String(i.pattern ?? ''), 60)}`
+      return `Finding files matching ${clip(asText(i.pattern), 60)}`
     case 'WebFetch':
       return `Fetching ${clip(urlHostPath(i.url), 60)}`
     case 'WebSearch':
-      return `Searching the web for ${clip(String(i.query ?? ''), 60)}`
+      return `Searching the web for ${clip(asText(i.query), 60)}`
     case 'NotebookEdit':
       return `Editing notebook ${clip(safeBasename(i.notebook_path))}`
     case 'BashOutput':
@@ -128,7 +148,7 @@ export function computeLabel(toolName, input) {
       // sidecar JSONL and recover which skill fired per turn —
       // the progress card path that used to surface this was retired
       // when `progressDriver` was nulled out in #1122 PR3.
-      const slug = clip(String(i.skill ?? ''), 64)
+      const slug = clip(asText(i.skill), 64)
       return slug ? `Running skill ${slug}` : null
     }
   }
@@ -141,7 +161,7 @@ export function computeLabel(toolName, input) {
       case 'mcp__switchroom-telegram__stream_reply':
         return 'Replying'
       case 'mcp__switchroom-telegram__react': {
-        const emoji = clip(String(i.emoji ?? ''), 8)
+        const emoji = clip(asText(i.emoji), 8)
         return emoji ? `Reacting ${emoji}` : 'Reacting'
       }
       case 'mcp__switchroom-telegram__get_recent_messages':
@@ -177,7 +197,7 @@ export function computeLabel(toolName, input) {
       return 'Looking through your files'
     if (server === 'notion' || server === 'claude_ai_notion') return 'Checking your notes'
     if (server === 'perplexity') {
-      const q = clip(String(i.query ?? i.description ?? ''), 60).trim()
+      const q = clip(asText(i.query) || asText(i.description), 60).trim()
       return q ? `Searching the web for ${q}` : 'Searching the web'
     }
     if (server === 'webkite') {
@@ -186,9 +206,9 @@ export function computeLabel(toolName, input) {
     }
     // Unknown MCP server: prefer a model-authored field, else humanized tool.
     const desc =
-      clip(String(i.description ?? ''), 60).trim() ||
-      clip(String(i.query ?? ''), 50).trim() ||
-      clip(String(i.title ?? ''), 50).trim()
+      clip(asText(i.description), 60).trim() ||
+      clip(asText(i.query), 50).trim() ||
+      clip(asText(i.title), 50).trim()
     if (desc) return desc
     return `Using ${tool.replace(/[-_]+/g, ' ')}`
   }

--- a/tests/tool-label-pretool.test.ts
+++ b/tests/tool-label-pretool.test.ts
@@ -299,6 +299,37 @@ describe("tool-label-pretool.mjs", () => {
     });
   });
 
+  it("object-valued MCP input fields never render '[object Object]' (Brevo CRM bug)", () => {
+    // An operator-configured MCP server (e.g. Brevo) may pass an OBJECT
+    // in query / description / title — a filter, a payload, etc. The old
+    // `String(i.query ?? '')` coercion turned that into the literal
+    // "[object Object]" on the live activity feed (marko Meta Campaigns
+    // thread, 2026-06-05). Object fields must be ignored so the label
+    // falls through to the humanized tool name.
+    const cases: Array<[string, Record<string, unknown>, string]> = [
+      // query is an object → fall through to "Using <tool>"
+      ["mcp__brevo__get_contacts", { query: { listIds: [3], limit: 50 } }, "Using get contacts"],
+      // description is an object → fall through
+      ["mcp__brevo__send_email", { description: { to: "x@y.z" } }, "Using send email"],
+      // title is an object, but a sibling string description wins
+      ["mcp__brevo__get_report", { title: { a: 1 }, description: "Day 0 pricelist report" }, "Day 0 pricelist report"],
+      // array-valued field → also ignored, not "[object Object]" / commas
+      ["mcp__acme__bulk", { query: ["a", "b"] }, "Using bulk"],
+    ];
+    cases.forEach(([tool, input, expected], idx) => {
+      const sess = `sess-objobj-${idx}`;
+      const r = run(
+        { session_id: sess, tool_use_id: `t-${tool}-${idx}`, tool_name: tool, tool_input: input },
+        stateDir,
+        sess,
+      );
+      expect(r.status).toBe(0);
+      expect(r.sidecarLines, `${tool} should emit a sidecar label`).toHaveLength(1);
+      expect(r.sidecarLines[0].label).toBe(expected);
+      expect(r.sidecarLines[0].label).not.toContain("[object Object]");
+    });
+  });
+
   it("missing TELEGRAM_STATE_DIR → silent skip, exit 0", () => {
     const r = run(
       {


### PR DESCRIPTION
## Summary
Marko's Meta Campaigns thread showed `✓ [object Object]` status beats. Root cause: the PreToolUse tool-label hook (`telegram-plugin/hooks/tool-label-pretool.mjs`) coerced tool-input fields with `String(i.query ?? '')` before clipping. An operator MCP server (Brevo CRM) passed an **object** in `query`/`description`/`title` (a filter/payload), so `String({...})` → `"[object Object]"`, which is truthy → became the label.

## Why the existing guard missed it
The renderer's `clip()` in `tool-activity-summary.ts` already rejects non-strings (`typeof s !== "string" → null`). But this hook runs *earlier* and writes the precomputed label into the sidecar JSONL via the `tool_label` event — its `String()` coercion happened before the value ever reached the renderer's guard.

## Fix
Add `asText(v)` — string pass-through, number/boolean clean-stringify, **object/array → `''`** — and swap every `String(i.<field>)` callsite to it. Object-valued fields now fall through to the next sibling field or the humanized tool name (`Using get contacts`).

Before → after (verified):
- `{query:{listIds:[3]}}` → ~~`[object Object]`~~ → `Using get contacts`
- `{description:"Day 0 pricelist report"}` → `Day 0 pricelist report` (string still wins)
- `{query:42}` → `42` (numbers still coerce)

## Test plan
- [x] `tests/tool-label-pretool.test.ts` — new case: object query/description/title + array field never yield `[object Object]` (16 pass)
- [x] `tests/tool-activity-summary.test.ts` renderer suite green (34)
- [x] `check-bun-test-imports` clean

## Risk
Low — pure label-string change on an exit-0 fail-silent hook; the only behavior change is that object/array fields stop rendering as `[object Object]`. Ships in the agent image (baked hook), so takes effect on fleet roll.