### PR TITLE
fix(telegram): obligation escalate-grace window — stop false nudges on slow turns

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1423,6 +1423,22 @@ const OBLIGATION_ESCALATE_MAX = 3
 // bounded escalate ladder to a terminal. 45s comfortably exceeds robustApiCall's
 // 3-attempt network backoff so a legitimate slow send isn't cut short.
 const OBLIGATION_ESCALATE_SEND_DEADLINE_MS = 45_000
+// Escalate-grace window. A slow / background-worker / multi-segment turn ends
+// (the in-flight gate clears) BEFORE its trailing answer's reply lands, and the
+// 5s sweep would re-present/escalate in that gap — a false "⚠️ I may have missed
+// this" on a message that's actively being answered (fuzz-confirmed on v0.14.62:
+// ~14% of marko's no-reply turn-ends had the answer in flight). An obligation
+// whose handling turn ended < this ago is skipped by decideAtIdle, giving the
+// trailing answer's close a beat to fire. Bounded: each re-present is itself a
+// turn that re-stamps once, representCount is capped → the ladder still
+// terminates. 45s > the observed "answer lands within ~60s, usually <40s" gap.
+// Kill switch: SWITCHROOM_OBLIGATION_ESCALATE_GRACE_MS=0 → pre-grace behaviour.
+const OBLIGATION_ESCALATE_GRACE_MS = (() => {
+  const raw = process.env.SWITCHROOM_OBLIGATION_ESCALATE_GRACE_MS
+  if (raw == null || raw === '') return 45_000
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 0 ? n : 45_000
+})()
 // Durable snapshot of the open obligation set on the persistent per-agent
 // volume (STATE_DIR = /state/agent/telegram in prod). Closes the restart hole:
 // the in-memory ledger alone empties on restart and the spool's boot-replay
@@ -2426,8 +2442,17 @@ function endCurrentTurnAtomic(turn: CurrentTurn): void {
   // finalAnswerDelivered===false → stays open → re-presented (the intended
   // catch). close() is a no-op for synthetic turns (turnId not in the ledger).
   // No-op when the flag is off.
-  if (OBLIGATION_LEDGER_ENABLED && turn.finalAnswerDelivered) {
-    obligationLedger.close(turn.turnId)
+  if (OBLIGATION_LEDGER_ENABLED) {
+    if (turn.finalAnswerDelivered) {
+      obligationLedger.close(turn.turnId)
+    } else {
+      // Turn ended WITHOUT a final answer. If this turn was handling an open
+      // obligation, stamp its grace clock so the idle sweep waits before
+      // re-presenting/escalating — a slow/worker answer may still be in flight
+      // (the over-escalation fix). No-op when turn.turnId isn't an open
+      // obligation (synthetic / already-closed turn).
+      obligationLedger.noteTurnEnded(turn.turnId, Date.now())
+    }
   }
   // Component 2 — clear any prior no-reply drain timer for this turn; a
   // fresh end re-evaluates below. (Idempotent — null when never armed.)
@@ -4925,7 +4950,13 @@ function obligationSweep(): void {
   if (!obligationLedger.hasOpen()) return
   if (turnInFlightForGate()) return // a turn is running — let it finish/answer
   const agent = process.env.SWITCHROOM_AGENT_NAME ?? ''
-  const decision = obligationLedger.decideAtIdle()
+  // Grace window: skip an obligation whose handling turn ended < grace ago — its
+  // trailing slow/worker answer may still be landing (over-escalation fix).
+  const decision = obligationLedger.decideAtIdle(
+    OBLIGATION_ESCALATE_GRACE_MS > 0
+      ? { now: Date.now(), graceMs: OBLIGATION_ESCALATE_GRACE_MS }
+      : undefined,
+  )
   const o = decision.obligation
   if (decision.action === 'none' || o == null) return
   if (decision.action === 'represent') {

--- a/telegram-plugin/gateway/obligation-ledger.ts
+++ b/telegram-plugin/gateway/obligation-ledger.ts
@@ -44,6 +44,17 @@ export interface Obligation {
    *  can't loop forever — and, because it is part of the durable snapshot,
    *  can't become a boot-surviving poison record either. */
   escalateAttempts?: number
+  /** Wall-clock ms the most recent turn handling THIS obligation ended (stamped
+   *  at turn_end via noteTurnEnded). Drives the escalate-grace window: a slow /
+   *  background-worker / multi-segment turn ends (the in-flight gate clears)
+   *  before its trailing answer's reply lands, and the sweep would otherwise
+   *  re-present/escalate in that gap — a false "I may have missed this" on a
+   *  message that's actively being answered (fuzz-confirmed on v0.14.62). The
+   *  decision waits `graceMs` after this stamp before acting, so the trailing
+   *  answer's close has a beat to fire. Bounded: each re-present is itself a turn
+   *  that re-stamps this once, and representCount is capped, so the ladder still
+   *  terminates. Durable (part of the snapshot) so the grace survives restart. */
+  lastTurnEndedAt?: number
 }
 
 /** What the gateway should do for the oldest open obligation at an idle boundary. */
@@ -162,17 +173,48 @@ export class ObligationLedger {
    * does not mutate. The caller performs the side effect then calls
    * markRepresented / close accordingly.
    *
-   *  - 'none'      → no open obligation; the agent may idle.
+   *  - 'none'      → no open obligation (or all open ones are within their
+   *                  escalate-grace window); the agent may idle.
    *  - 'represent' → re-present `obligation` as a fresh must-answer turn.
    *  - 'escalate'  → it has already been re-presented maxRepresents times; send
    *                  ONE operator-visible "did I miss this?" and close it
    *                  (caller calls close) rather than loop forever.
+   *
+   * GRACE WINDOW (opts.graceMs > 0): an obligation whose handling turn ended less
+   * than `graceMs` ago is SKIPPED — its trailing answer may still be in flight
+   * (a worker / long-think / multi-segment turn ends the in-flight gate before
+   * the reply lands). We pick the oldest obligation that is OUT of grace, so a
+   * genuinely-stale one is still acted on while a freshly-ended one waits. Pure
+   * (clock injected via opts.now, mirroring the builder convention). With no opts
+   * (or graceMs<=0) this is the pre-grace behaviour exactly.
    */
-  decideAtIdle(): LedgerDecision {
-    const o = this.oldest()
+  decideAtIdle(opts?: { now: number; graceMs: number }): LedgerDecision {
+    const o =
+      opts != null && opts.graceMs > 0 ? this.oldestEligible(opts.now, opts.graceMs) : this.oldest()
     if (o === undefined) return { action: 'none' }
     if (o.representCount >= this.maxRepresents) return { action: 'escalate', obligation: o }
     return { action: 'represent', obligation: o }
+  }
+
+  /** The oldest open obligation whose handling turn ended at least `graceMs` ago
+   *  (or never ended — a still-queued obligation has no lastTurnEndedAt and is
+   *  always eligible; it can't have a trailing answer in flight). */
+  private oldestEligible(now: number, graceMs: number): Obligation | undefined {
+    let best: Obligation | undefined
+    for (const o of this.open.values()) {
+      if (o.lastTurnEndedAt != null && now - o.lastTurnEndedAt < graceMs) continue // within grace
+      if (best === undefined || o.openedAt < best.openedAt) best = o
+    }
+    return best
+  }
+
+  /** Stamp that the most recent turn handling `originTurnId` just ended (drives
+   *  the escalate-grace window). No-op if the obligation isn't open. Persists. */
+  noteTurnEnded(originTurnId: string, ts: number): void {
+    const o = this.open.get(originTurnId)
+    if (o === undefined) return
+    o.lastTurnEndedAt = ts
+    this.persist()
   }
 
   /**

--- a/telegram-plugin/tests/obligation-determinism.test.ts
+++ b/telegram-plugin/tests/obligation-determinism.test.ts
@@ -89,12 +89,18 @@ interface Sim {
   steps: number;
 }
 
-function runSchedule(msgs: Msg[], seed: number): Sim {
+function runSchedule(msgs: Msg[], seed: number, graceMs = 0): Sim {
   const PATH = "/state/agent/telegram/obligations.json";
   const store = memStore();
   let ledger = new ObligationLedger(MAX_REPRESENTS, {
     onChange: (snap) => persistObligations(PATH, store.fs, snap),
   });
+  // Virtual monotonic clock (only meaningful when graceMs>0). Advances every
+  // step by more than one sweep tick so the grace window deterministically
+  // expires within the step budget — proving grace DELAYS but never PREVENTS a
+  // terminal (no livelock).
+  let clock = 1_000_000;
+  const SWEEP_TICK = 5_000;
   const r = rng(seed);
 
   const pending = [...msgs]; // not yet received
@@ -109,11 +115,18 @@ function runSchedule(msgs: Msg[], seed: number): Sim {
   };
 
   // Run one turn for an obligation; close if the model answers on this attempt.
+  // If it does NOT answer and grace is on, stamp the turn-end clock (mirrors the
+  // gateway's endCurrentTurnAtomic !finalAnswerDelivered branch) so the next
+  // decideAtIdle({now, graceMs}) waits out the grace before re-presenting.
   const deliverTurn = (id: string) => {
     const had = (turnsHad.get(id) ?? 0);
     const attemptIndex = had; // 0-based
     turnsHad.set(id, had + 1);
-    if (byId.get(id)!.answerOnAttempt === attemptIndex) close(id, "answered");
+    if (byId.get(id)!.answerOnAttempt === attemptIndex) {
+      close(id, "answered");
+    } else if (graceMs > 0 && ledger.isOpen(id)) {
+      ledger.noteTurnEnded(id, clock);
+    }
   };
 
   const ESC_IN_FLIGHT = new Set<string>(); // mirrors the gateway's concurrency guard (no-op in a sync model)
@@ -139,7 +152,14 @@ function runSchedule(msgs: Msg[], seed: number): Sim {
       });
       deliverTurn(m.id); // original turn (attempt 0)
     } else if (open) {
-      const decision = ledger.decideAtIdle();
+      const decision =
+        graceMs > 0 ? ledger.decideAtIdle({ now: clock, graceMs }) : ledger.decideAtIdle();
+      if (decision.action === "none") {
+        // Every open obligation is within its grace window — the sweep waits.
+        // Advance the clock so grace deterministically expires; no livelock.
+        clock += SWEEP_TICK;
+        continue;
+      }
       const o = decision.obligation as Obligation;
       // INVARIANT (no double-ask): a terminated obligation must never resurface.
       expect(terminals.has(o.originTurnId)).toBe(false);
@@ -169,6 +189,9 @@ function runSchedule(msgs: Msg[], seed: number): Sim {
       });
       ledger.hydrate(loadObligations(PATH, store.fs));
     }
+    // Advance the virtual clock every step so any stamped grace window
+    // deterministically expires within the step budget.
+    clock += SWEEP_TICK;
   }
 
   return { terminals, steps };
@@ -214,6 +237,43 @@ describe("obligation determinism — every inbound reaches a terminal, no silent
           expect(t).toBe("escalation-delivered");
         } else {
           // never answered, escalation permanently undeliverable → bounded give-up
+          expect(t).toBe("escalation-give-up");
+        }
+      }
+    }
+  });
+
+  it("holds across 3000 schedules WITH the escalate-grace window on (grace delays, never prevents a terminal)", () => {
+    const ANSWER = [0, 1, 2, 3, 99];
+    const ESCFAIL = [0, 1, 2, 3, 5];
+    const GRACE_MS = 45_000;
+    for (let seed = 1; seed <= 3000; seed++) {
+      const r = rng(seed * 7919);
+      const n = 1 + Math.floor(r() * 5);
+      const msgs: Msg[] = [];
+      for (let i = 0; i < n; i++) {
+        const msgId = seed * 100 + i;
+        msgs.push({
+          id: `c:3#${msgId}`,
+          msgId,
+          answerOnAttempt: pick(ANSWER, r),
+          escalateFailsFor: pick(ESCFAIL, r),
+        });
+      }
+      // Same enumeration as the no-grace proof, but the ledger now runs the grace
+      // path: every non-answering turn stamps noteTurnEnded and the sweep waits
+      // out the window before acting. The terminal each message reaches must be
+      // IDENTICAL to the no-grace run — grace only delays.
+      const { terminals, steps } = runSchedule(msgs, seed * 104729, GRACE_MS);
+      expect(steps).toBeLessThan(10_000); // still terminates (no grace livelock)
+      for (const m of msgs) {
+        const t = terminals.get(m.id);
+        expect(t, `grace seed=${seed} msg=${m.id} answer=${m.answerOnAttempt} escFail=${m.escalateFailsFor}`).toBeDefined();
+        if (m.answerOnAttempt <= MAX_REPRESENTS) {
+          expect(t).toBe("answered");
+        } else if (m.escalateFailsFor < ESCALATE_MAX) {
+          expect(t).toBe("escalation-delivered");
+        } else {
           expect(t).toBe("escalation-give-up");
         }
       }

--- a/telegram-plugin/tests/obligation-ledger.test.ts
+++ b/telegram-plugin/tests/obligation-ledger.test.ts
@@ -234,3 +234,81 @@ describe("ObligationLedger — durability hooks + escalate-attempt counter", () 
     expect(L.size()).toBe(1);
   });
 });
+
+describe("ObligationLedger — escalate-grace window (over-escalation fix)", () => {
+  function input(id: string, openedAt: number) {
+    return { originTurnId: id, chatId: "-100123", threadId: 3, messageId: Number(id.split("#").pop() ?? 0), text: "x", openedAt };
+  }
+
+  it("no opts (or graceMs<=0) → pre-grace behaviour: acts immediately", () => {
+    const L = new ObligationLedger();
+    L.openIfAbsent(input("c:3#1", 1000));
+    L.noteTurnEnded("c:3#1", 5000); // a turn just ended
+    expect(L.decideAtIdle().action).toBe("represent"); // no grace → act now
+    expect(L.decideAtIdle({ now: 5001, graceMs: 0 }).action).toBe("represent"); // graceMs 0 → off
+  });
+
+  it("skips an obligation whose turn ended < graceMs ago (the trailing-answer window)", () => {
+    const L = new ObligationLedger();
+    L.openIfAbsent(input("c:3#1", 1000));
+    L.noteTurnEnded("c:3#1", 5000);
+    // 30s after turn-end, grace 45s → still within grace → wait (none)
+    expect(L.decideAtIdle({ now: 35000, graceMs: 45000 }).action).toBe("none");
+    // 46s after turn-end → out of grace → act
+    expect(L.decideAtIdle({ now: 51000, graceMs: 45000 }).action).toBe("represent");
+  });
+
+  it("an obligation that never had a turn end (still-queued) is always eligible — no trailing answer to wait for", () => {
+    const L = new ObligationLedger();
+    L.openIfAbsent(input("c:3#1", 1000)); // no noteTurnEnded
+    expect(L.decideAtIdle({ now: 1001, graceMs: 45000 }).action).toBe("represent");
+  });
+
+  it("picks the oldest ELIGIBLE: a newer in-grace obligation does not block an older out-of-grace one", () => {
+    const L = new ObligationLedger();
+    L.openIfAbsent(input("c:3#1", 1000)); // older
+    L.openIfAbsent(input("c:3#2", 2000)); // newer
+    L.noteTurnEnded("c:3#1", 5000); // older's turn ended at 5000 (out of grace by now)
+    L.noteTurnEnded("c:3#2", 60000); // newer's turn ended at 60000 (in grace)
+    const d = L.decideAtIdle({ now: 70000, graceMs: 45000 });
+    // older (#1) ended 65s ago → eligible; newer (#2) ended 10s ago → in grace.
+    // pick oldest eligible = #1.
+    expect(d.action).toBe("represent");
+    expect(d.obligation?.originTurnId).toBe("c:3#1");
+  });
+
+  it("returns none when EVERY open obligation is within grace", () => {
+    const L = new ObligationLedger();
+    L.openIfAbsent(input("c:3#1", 1000));
+    L.openIfAbsent(input("c:3#2", 2000));
+    L.noteTurnEnded("c:3#1", 60000);
+    L.noteTurnEnded("c:3#2", 61000);
+    expect(L.decideAtIdle({ now: 65000, graceMs: 45000 }).action).toBe("none");
+  });
+
+  it("noteTurnEnded is a no-op for an unknown/closed obligation and persists when it applies", () => {
+    const snapshots: Obligation[][] = [];
+    const L = new ObligationLedger(2, { onChange: (s) => snapshots.push(s) });
+    L.openIfAbsent(input("c:3#1", 1000)); // persist #1
+    L.noteTurnEnded("nope", 5000); // unknown → no persist
+    expect(snapshots.length).toBe(1);
+    L.noteTurnEnded("c:3#1", 5000); // applies → persist
+    expect(snapshots.length).toBe(2);
+    expect(snapshots[1][0].lastTurnEndedAt).toBe(5000);
+  });
+
+  it("grace still terminates the ladder: represent → escalate once each is out of grace", () => {
+    const L = new ObligationLedger(2);
+    L.openIfAbsent(input("c:3#1", 1000));
+    // turn 0 ended at 1000; out of grace by t=50000
+    L.noteTurnEnded("c:3#1", 1000);
+    expect(L.decideAtIdle({ now: 50000, graceMs: 45000 }).action).toBe("represent");
+    L.markRepresented("c:3#1");
+    L.noteTurnEnded("c:3#1", 50000); // re-present turn ended
+    expect(L.decideAtIdle({ now: 96000, graceMs: 45000 }).action).toBe("represent");
+    L.markRepresented("c:3#1");
+    L.noteTurnEnded("c:3#1", 96000);
+    // representCount now 2 == max → escalate (once out of grace)
+    expect(L.decideAtIdle({ now: 142000, graceMs: 45000 }).action).toBe("escalate");
+  });
+});


### PR DESCRIPTION
## Summary
Fuzz testing on v0.14.62 (obligation ledger live on marko) surfaced a real false-positive: a slow / background-worker / multi-segment turn **ends** (the in-flight gate clears) before its trailing answer's reply lands, so the 5s sweep re-presents then escalates in that gap — firing a user-facing **"⚠️ I may have missed this"** on a message the agent is *actively answering*.

## Evidence
- Live log on test-harness: obligation `#4334` escalated at `13:58:24`, then `reply: invoked "Spinning up a worker…"` at `13:58:25`, answer at `13:58:36`.
- Real frequency: **~14%** of marko's no-reply turn-ends had the answer in flight; on test-harness (fast synthetic traffic) ~37%, breaking **10 fuzz assertions**. marko has fired **0** false cards live (humans pause), so it's latent there — but would fire on a research/worker turn.

## Fix (in the pure, durable ledger — unit-testable + survives restart)
- `Obligation.lastTurnEndedAt`; `noteTurnEnded` stamps it at `turn_end` when the turn ended **without** a final answer (obligation stays open).
- `decideAtIdle({now, graceMs})` skips an obligation whose handling turn ended `< graceMs` ago, picking the **oldest eligible** — a genuinely-stale message still acts while a freshly-ended one waits for its trailing close.
- Default 45s; kill switch `SWITCHROOM_OBLIGATION_ESCALATE_GRACE_MS=0` → byte-identical pre-grace behaviour.

## Correctness
- **Determinism preserved:** `decideAtIdle()` with no args is the exact pre-grace path → the 3000-schedule determinism proof passes unchanged.
- **Ladder still terminates:** grace only ever *delays*; each turn re-stamps `lastTurnEndedAt` at most once and `representCount` is capped → bounded. Pinned by a "grace still terminates the ladder" test + eligibility/ordering tests (7 new).
- **715 unaffected:** a thread that never gets an answer has no trailing reply, grace expires, it re-presents/escalates as before.

## Test plan
- [x] `obligation-ledger.test.ts` 29 (7 new grace) + store/determinism/escalation-drive/with-deadline = 50 green.
- [x] `tsc`, `check-plugin-references`, `check-bot-api-wrapping` clean; full `telegram-plugin/` suite 3484/0.

## Risk
Low; flag-gated (live on marko, off elsewhere), instant rollback via the env knob. Prerequisite for the mid-turn auto-classifier work.