### PR TITLE
fix(telegram): cancel the interrupted turn's obligation on ! interrupt

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1999,6 +1999,29 @@ let pendingDeferredInterrupt: PendingDeferredInterrupt | null = null
  * Idempotent: nulls the slot and clears the timer before doing any work so a
  * boundary event and the timeout can't double-fire.
  */
+/**
+ * An `!` interrupt SIGINT-kills the in-flight turn. That turn was handling a
+ * user message with an open obligation, and the killed turn does NOT reliably
+ * emit turn_end (so endCurrentTurnAtomic never closes it) — so without this the
+ * obligation survives and the idle sweep later re-presents/escalates "you have
+ * an earlier message you never answered" for a question the user EXPLICITLY
+ * cancelled. An interrupt is a deliberate redirect, so closing that obligation
+ * is the correct terminal (the user chose to interrupt; they can re-ask). Only
+ * the interrupted turn's OWN obligation is closed — queued siblings (other open
+ * obligations) are untouched. No-op when the flag is off, no turn is in flight,
+ * or the turn isn't a tracked obligation (synthetic / already closed).
+ */
+function cancelInterruptedObligation(): void {
+  if (!OBLIGATION_LEDGER_ENABLED) return
+  const turn = currentTurn
+  if (turn == null) return
+  if (obligationLedger.close(turn.turnId)) {
+    process.stderr.write(
+      `telegram gateway: obligation cancelled by interrupt origin=${turn.turnId}\n`,
+    )
+  }
+}
+
 async function fireDeferredInterrupt(reason: 'boundary' | 'timeout'): Promise<void> {
   const pending = pendingDeferredInterrupt
   if (pending == null) return
@@ -2026,6 +2049,10 @@ async function fireDeferredInterrupt(reason: 'boundary' | 'timeout'): Promise<vo
   } catch (err) {
     process.stderr.write(`telegram gateway: deferred-interrupt SIGINT failed: ${(err as Error).message}\n`)
   }
+
+  // The SIGINT just killed the in-flight turn — cancel its obligation so the
+  // interrupted (user-redirected) question isn't re-presented/escalated later.
+  cancelInterruptedObligation()
 
   // Deliver the replacement body as a fresh turn to the freshly-killed
   // bridge — same sendToAgent + buffer-on-miss primitive the synchronous
@@ -10784,6 +10811,9 @@ async function handleInbound(
       } catch (err) {
         process.stderr.write(`telegram gateway: interrupt-marker SIGINT failed: ${(err as Error).message}\n`)
       }
+      // The SIGINT just killed the in-flight turn — cancel its obligation so the
+      // interrupted (user-redirected) question isn't re-presented/escalated later.
+      cancelInterruptedObligation()
     }
     if (interrupt.emptyBody) {
       // #1075: thread-id-bearing — route through swallowingApiCall so

--- a/telegram-plugin/tests/obligation-ledger.test.ts
+++ b/telegram-plugin/tests/obligation-ledger.test.ts
@@ -225,6 +225,20 @@ describe("ObligationLedger — durability hooks + escalate-attempt counter", () 
     expect(L.decideAtIdle().action).toBe("escalate");
   });
 
+  it("interrupt-cancel semantics: closing the in-flight turn's obligation removes it from the sweep, sibling untouched", () => {
+    // Mirrors cancelInterruptedObligation: an `!` interrupt SIGINT-kills the
+    // in-flight turn and closes its obligation, so the sweep can't later
+    // re-present/escalate the question the user explicitly redirected away from.
+    // A queued SIBLING obligation must survive.
+    const L = new ObligationLedger();
+    L.openIfAbsent(input("c:3#700", 1000)); // the in-flight turn's message
+    L.openIfAbsent(input("c:3#701", 1001)); // a queued sibling
+    expect(L.close("c:3#700")).toBe(true); // interrupt cancels the in-flight one
+    expect(L.isOpen("c:3#700")).toBe(false);
+    expect(L.decideAtIdle().obligation?.originTurnId).toBe("c:3#701"); // sibling still actionable
+    expect(L.close("c:3#700")).toBe(false); // re-close / unknown is a safe no-op
+  });
+
   it("hydrate skips malformed rows", () => {
     const L = new ObligationLedger();
     L.hydrate([


### PR DESCRIPTION
## Summary
An `!` interrupt SIGINT-kills the in-flight turn, but the killed turn doesn't reliably emit `turn_end`, so `endCurrentTurnAtomic` never closes its obligation. The obligation survives → the idle sweep later re-presents/escalates **"⚠️ I may have missed an earlier message"** for a question the user **explicitly cancelled by interrupting**. (Surfaced by the mode × obligation-ledger matrix review.)

## Fix
`cancelInterruptedObligation()` closes the in-flight turn's obligation the moment the SIGINT fires, on **both** the synchronous (`gateway.ts` interrupt-marker path) and **deferred** (`fireDeferredInterrupt`) paths. An interrupt is a deliberate redirect → closing is the correct terminal; the user can re-ask. **Only the interrupted turn's own obligation** is closed (`currentTurn.turnId`); queued siblings are untouched. No-op when the flag is off / no turn in flight / turn not tracked.

## Test plan
- [x] New ledger test pins the interrupt-cancel semantics (close in-flight → sweep won't return it; sibling survives; re-close is a safe no-op).
- [x] `tsc`, `check-plugin-references`, `check-bot-api-wrapping` clean; full `telegram-plugin/` suite **3478/0**.

## Risk
Low; flag-gated (live on marko, off elsewhere). Independent of the grace-window PR (#2156). Pure terminal-on-explicit-cancel.