### PR TITLE
feat(telegram): mid-turn auto-classify (steer-vs-queue) in shadow mode

### DIFF
--- a/telegram-plugin/gateway/auto-classify-mid-turn.ts
+++ b/telegram-plugin/gateway/auto-classify-mid-turn.ts
@@ -1,0 +1,119 @@
+/**
+ * auto-classify-mid-turn.ts — deterministic, model-free classification of a
+ * mid-turn inbound into STEER (amend the in-flight turn) vs QUEUE (new task),
+ * using TOPIC-vs-active-turn + reply-RECENCY as proxies for intent. No model
+ * inference: the gateway must decide at inbound time while the single CLI is
+ * busy.
+ *
+ * Today a no-prefix mid-turn message always QUEUES (the default flipped
+ * 2026-04-17 away from the blunt "everything steers" — see
+ * reference/steer-or-queue-mid-flight.md). This module is the basis for a
+ * smarter default. It ships first in SHADOW mode (the gateway logs what it WOULD
+ * decide but still queues), to gather real-world data — how often mid-turn
+ * messages are same-topic continuations vs cross-topic new tasks, and the
+ * recency distribution — before any behaviour flips on.
+ *
+ * Signal strength (be honest):
+ *  - TOPIC (supergroup): STRONG + structural. A message in a DIFFERENT forum
+ *    topic than the active turn is, by the supergroup-mode invariant, a separate
+ *    conversation → queue. This needs no timing guess.
+ *  - RECENCY: weaker. Within the same topic it cannot tell "also do X" (steer)
+ *    from "new question, same topic" (queue) — only a tight window + the
+ *    visible/correctable UX (the JTBD doc) makes auto-steer acceptable, and
+ *    that is gated separately. The recency clock is the agent's LAST OUTPUT
+ *    (msSinceLastAgentOutput), NOT turn age: a long actively-narrating worker
+ *    turn must not read "stale".
+ *  - DM: no topic at all → timing-only (the pre-2026-04-17 regime that
+ *    over-steered). DM auto-steer is OFF by default (window 0).
+ *
+ * Pure (no gateway imports) ⇒ unit-testable.
+ */
+
+export type MidTurnClass = 'steer' | 'queue'
+
+export type MidTurnReason =
+  | 'steer_prefix'
+  | 'queue_prefix'
+  | 'not_mid_turn'
+  | 'cross_topic'
+  | 'same_topic_recent'
+  | 'same_topic_stale'
+  | 'dm_recent'
+  | 'dm_disabled'
+  | 'topic_disabled'
+
+export interface AutoClassifyInput {
+  /** Explicit `/steer`|`/s` prefix present — the user's stated intent, authoritative. */
+  isSteerPrefix: boolean
+  /** Explicit `/queue`|`/q` prefix present. */
+  isQueuePrefix: boolean
+  /** Is a turn in flight for this chat/thread? (no → not our decision). */
+  priorTurnInFlight: boolean
+  /** DM (no forum topics) → timing-only. */
+  isDm: boolean
+  /** Incoming message's thread id (undefined/null in a DM). */
+  incomingThreadId: number | null | undefined
+  /** The in-flight turn's thread id (currentTurn.sessionThreadId). */
+  activeTurnThreadId: number | null | undefined
+  /** ms since the agent's LAST visible output in this chat/thread; null when no
+   *  output has been recorded (cold topic) → treated as not-recent. */
+  msSinceLastAgentOutput: number | null
+  /** Auto-steer recency window in a DM. 0 (default) = DM auto-steer OFF. */
+  dmSteerWindowMs: number
+  /** Auto-steer recency window in a supergroup topic. 0 = topic auto-steer OFF. */
+  topicSteerWindowMs: number
+}
+
+export interface AutoClassifyResult {
+  decision: MidTurnClass
+  reason: MidTurnReason
+  /** Whether the incoming message is in the SAME thread as the active turn
+   *  (canonicalized). Undefined when not applicable (no prefix-free mid-turn). */
+  sameTopic?: boolean
+}
+
+/** Canonical thread compare, matching chatKey's collapse (null/undefined/0 → same
+ *  "no-thread" bucket) — never raw === on raw ids (the silence-poke key-mismatch
+ *  bug class). */
+function sameThread(a: number | null | undefined, b: number | null | undefined): boolean {
+  const norm = (t: number | null | undefined): number | null => (t == null || t === 0 ? null : t)
+  return norm(a) === norm(b)
+}
+
+/**
+ * Classify a mid-turn inbound. Precedence: explicit prefix → not-mid-turn →
+ * DM(timing) / supergroup(topic then timing). Defaults bias to QUEUE (the safe,
+ * reversible, current behaviour); STEER only on a strong/recent signal AND its
+ * window enabled.
+ */
+export function autoClassifyMidTurnInbound(i: AutoClassifyInput): AutoClassifyResult {
+  // Explicit prefixes always win — the user's stated intent is authoritative.
+  if (i.isSteerPrefix) return { decision: 'steer', reason: 'steer_prefix' }
+  if (i.isQueuePrefix) return { decision: 'queue', reason: 'queue_prefix' }
+  // No turn in flight → caller starts a fresh turn (not a steer/queue decision).
+  if (!i.priorTurnInFlight) return { decision: 'queue', reason: 'not_mid_turn' }
+
+  const recent =
+    i.msSinceLastAgentOutput != null && i.msSinceLastAgentOutput >= 0
+
+  if (i.isDm) {
+    // DM: no topic → timing-only. Default OFF (dmSteerWindowMs 0).
+    if (i.dmSteerWindowMs <= 0) return { decision: 'queue', reason: 'dm_disabled' }
+    return recent && i.msSinceLastAgentOutput! <= i.dmSteerWindowMs
+      ? { decision: 'steer', reason: 'dm_recent' }
+      : { decision: 'queue', reason: 'dm_disabled' }
+  }
+
+  // Supergroup: topic identity is the PRIMARY signal.
+  const topicMatch = sameThread(i.incomingThreadId, i.activeTurnThreadId)
+  if (i.topicSteerWindowMs <= 0) {
+    return { decision: 'queue', reason: 'topic_disabled', sameTopic: topicMatch }
+  }
+  // Different topic than the in-flight turn → ALWAYS queue (a separate
+  // conversation; never steer it into the wrong topic's turn).
+  if (!topicMatch) return { decision: 'queue', reason: 'cross_topic', sameTopic: false }
+  // Same topic: steer only if recent enough; else a new question → queue.
+  return recent && i.msSinceLastAgentOutput! <= i.topicSteerWindowMs
+    ? { decision: 'steer', reason: 'same_topic_recent', sameTopic: true }
+    : { decision: 'queue', reason: 'same_topic_stale', sameTopic: true }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -142,6 +142,7 @@ import {
   resolveRetentionDays as resolveRegistryRetentionDays,
 } from '../registry/reaper.js'
 import { parseQueuePrefix, parseSteerPrefix, formatPriorAssistantPreview, formatReplyToText } from '../steering.js'
+import { autoClassifyMidTurnInbound } from './auto-classify-mid-turn.js'
 import {
   renderOperatorEvent,
   shouldEmitOperatorEvent,
@@ -1439,6 +1440,31 @@ const OBLIGATION_ESCALATE_GRACE_MS = (() => {
   const n = Number(raw)
   return Number.isFinite(n) && n >= 0 ? n : 45_000
 })()
+
+// ─── Mid-turn auto-classify (steer-vs-queue), SHADOW mode ─────────────────────
+// Today a no-prefix mid-turn message always QUEUES. autoClassifyMidTurnInbound
+// (auto-classify-mid-turn.ts) is the basis for a smarter default using
+// topic-vs-active-turn + reply-recency. Phase 1 ships SHADOW-ONLY: when this
+// flag is on we COMPUTE + LOG what we'd decide (decision/reason/same_topic/
+// ms_since_out) but the behaviour is UNCHANGED (still queue) — to gather the
+// real-world distribution (how often mid-turn messages are same-topic
+// continuations vs cross-topic, and the recency spread) before any action flips
+// on. Default OFF → zero overhead. The action windows below stay 0 in shadow.
+const AUTOCLASSIFY_MIDTURN_SHADOW = process.env.SWITCHROOM_AUTOCLASSIFY_MIDTURN_SHADOW === '1'
+// Per-(chat,thread) wall-clock ms of the agent's LAST visible output — the
+// recency clock the classifier uses (NOT turn age: a long actively-narrating
+// worker turn must not read "stale"). Stamped beside signalTracker.noteOutbound.
+// LRU-bounded so a long-lived gateway with many topics can't grow unboundedly.
+const lastAgentOutputAt = new Map<string, number>()
+const LAST_OUTPUT_MAX_KEYS = 512
+function noteAgentOutputAt(key: string, ts: number): void {
+  lastAgentOutputAt.delete(key) // re-insert → most-recently-used at the tail
+  lastAgentOutputAt.set(key, ts)
+  if (lastAgentOutputAt.size > LAST_OUTPUT_MAX_KEYS) {
+    const oldest = lastAgentOutputAt.keys().next().value
+    if (oldest !== undefined) lastAgentOutputAt.delete(oldest)
+  }
+}
 // Durable snapshot of the open obligation set on the persistent per-agent
 // volume (STATE_DIR = /state/agent/telegram in prod). Closes the restart hole:
 // the in-memory ledger alone empties on restart and the spool's boot-replay
@@ -6537,6 +6563,10 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   // silence-poke clock so the next poke is measured from this send.
   signalTracker.noteOutbound(statusKey(chat_id, threadId), Date.now())
   silencePoke.noteOutbound(statusKey(chat_id, threadId), Date.now())
+  // Mid-turn auto-classify recency clock: the agent just produced visible output
+  // in this chat/thread (cross-turn, unlike silencePoke's per-turn lastOutboundAt).
+  // Only maintained when the shadow flag is on → truly zero overhead by default.
+  if (AUTOCLASSIFY_MIDTURN_SHADOW) noteAgentOutputAt(statusKey(chat_id, threadId), Date.now())
   // PR3b-cutover: feed lastOutboundAt to the delivery machine so its
   // TTL `tick` suppresses the fallback for a long-but-active turn
   // (model streaming past 5 min) — parity with silencePoke's own
@@ -11450,6 +11480,33 @@ async function handleInbound(
     // it's false so the message goes through as queued="true".)
     isSteering = priorTurnInFlight && isSteerPrefix
     if (priorTurnInFlight) priorTurnStartedAt = activeTurnStartedAt.get(key)
+
+    // Mid-turn auto-classify SHADOW: compute what a topic+recency classifier
+    // WOULD decide and log it — behaviour is UNCHANGED (isSteering above is
+    // untouched). Gathers the real-world distribution (same-topic continuation
+    // vs cross-topic, recency spread) to tune auto-steer before it ever acts.
+    // No-op unless the shadow flag is on AND a turn is in flight (the only case
+    // a steer-vs-queue decision is meaningful).
+    if (AUTOCLASSIFY_MIDTURN_SHADOW && priorTurnInFlight) {
+      const lastOut = lastAgentOutputAt.get(key)
+      const msSinceOut = lastOut != null ? Date.now() - lastOut : null
+      const shadow = autoClassifyMidTurnInbound({
+        isSteerPrefix,
+        isQueuePrefix: isQueuedPrefix,
+        priorTurnInFlight,
+        isDm: isDmChatId(chat_id),
+        incomingThreadId: messageThreadId ?? null,
+        activeTurnThreadId: currentTurn?.sessionThreadId ?? null,
+        msSinceLastAgentOutput: msSinceOut,
+        dmSteerWindowMs: 0, // DM auto-steer stays off (the April regime)
+        topicSteerWindowMs: 8_000, // candidate window — what we're tuning
+      })
+      process.stderr.write(
+        `telegram gateway: autoclassify-shadow chat_id=${chat_id} ` +
+        `would=${shadow.decision} reason=${shadow.reason} same_topic=${shadow.sameTopic ?? '-'} ` +
+        `ms_since_out=${msSinceOut ?? '-'} actual=${isSteering ? 'steer' : 'queue'}\n`,
+      )
+    }
 
     if (access.statusReactions !== false) {
       if (isSteering) {

--- a/telegram-plugin/tests/auto-classify-mid-turn.test.ts
+++ b/telegram-plugin/tests/auto-classify-mid-turn.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { autoClassifyMidTurnInbound, type AutoClassifyInput } from "../gateway/auto-classify-mid-turn.js";
+
+function base(over: Partial<AutoClassifyInput> = {}): AutoClassifyInput {
+  return {
+    isSteerPrefix: false,
+    isQueuePrefix: false,
+    priorTurnInFlight: true,
+    isDm: false,
+    incomingThreadId: 3,
+    activeTurnThreadId: 3,
+    msSinceLastAgentOutput: 2000,
+    dmSteerWindowMs: 0, // DM auto-steer off by default
+    topicSteerWindowMs: 8000,
+    ...over,
+  };
+}
+
+describe("autoClassifyMidTurnInbound", () => {
+  it("explicit /steer prefix always wins", () => {
+    const r = autoClassifyMidTurnInbound(base({ isSteerPrefix: true, incomingThreadId: 9, activeTurnThreadId: 3 }));
+    expect(r.decision).toBe("steer");
+    expect(r.reason).toBe("steer_prefix");
+  });
+
+  it("explicit /queue prefix always wins", () => {
+    expect(autoClassifyMidTurnInbound(base({ isQueuePrefix: true })).decision).toBe("queue");
+  });
+
+  it("no turn in flight → queue (fresh turn, not our decision)", () => {
+    const r = autoClassifyMidTurnInbound(base({ priorTurnInFlight: false }));
+    expect(r.decision).toBe("queue");
+    expect(r.reason).toBe("not_mid_turn");
+  });
+
+  // ── Supergroup: topic is the strong signal ──
+  it("supergroup, DIFFERENT topic than the active turn → queue (cross_topic), regardless of recency", () => {
+    const r = autoClassifyMidTurnInbound(base({ incomingThreadId: 5, activeTurnThreadId: 3, msSinceLastAgentOutput: 100 }));
+    expect(r.decision).toBe("queue");
+    expect(r.reason).toBe("cross_topic");
+    expect(r.sameTopic).toBe(false);
+  });
+
+  it("supergroup, SAME topic + recent → steer", () => {
+    const r = autoClassifyMidTurnInbound(base({ msSinceLastAgentOutput: 3000, topicSteerWindowMs: 8000 }));
+    expect(r.decision).toBe("steer");
+    expect(r.reason).toBe("same_topic_recent");
+    expect(r.sameTopic).toBe(true);
+  });
+
+  it("supergroup, SAME topic but STALE (older than window) → queue", () => {
+    const r = autoClassifyMidTurnInbound(base({ msSinceLastAgentOutput: 20000, topicSteerWindowMs: 8000 }));
+    expect(r.decision).toBe("queue");
+    expect(r.reason).toBe("same_topic_stale");
+  });
+
+  it("supergroup, no recency recorded (null) → queue (not treated as recent)", () => {
+    const r = autoClassifyMidTurnInbound(base({ msSinceLastAgentOutput: null }));
+    expect(r.decision).toBe("queue");
+    expect(r.reason).toBe("same_topic_stale");
+  });
+
+  it("topicSteerWindowMs=0 (auto-steer off) → queue, still reports sameTopic", () => {
+    const r = autoClassifyMidTurnInbound(base({ topicSteerWindowMs: 0, incomingThreadId: 3, activeTurnThreadId: 3 }));
+    expect(r.decision).toBe("queue");
+    expect(r.reason).toBe("topic_disabled");
+    expect(r.sameTopic).toBe(true);
+  });
+
+  it("canonical thread compare: null/undefined/0 collapse to the same no-thread bucket", () => {
+    expect(autoClassifyMidTurnInbound(base({ incomingThreadId: 0, activeTurnThreadId: null })).sameTopic).toBe(true);
+    expect(autoClassifyMidTurnInbound(base({ incomingThreadId: undefined, activeTurnThreadId: 0 })).sameTopic).toBe(true);
+    expect(autoClassifyMidTurnInbound(base({ incomingThreadId: 1, activeTurnThreadId: 0 })).sameTopic).toBe(false);
+  });
+
+  // ── DM: timing-only, off by default ──
+  it("DM with dmSteerWindowMs=0 (default) → queue even if recent (DM auto-steer off)", () => {
+    const r = autoClassifyMidTurnInbound(base({ isDm: true, incomingThreadId: null, activeTurnThreadId: null, msSinceLastAgentOutput: 500, dmSteerWindowMs: 0 }));
+    expect(r.decision).toBe("queue");
+    expect(r.reason).toBe("dm_disabled");
+  });
+
+  it("DM with dmSteerWindowMs>0 + recent → steer; stale → queue", () => {
+    expect(autoClassifyMidTurnInbound(base({ isDm: true, incomingThreadId: null, activeTurnThreadId: null, msSinceLastAgentOutput: 5000, dmSteerWindowMs: 10000 })).decision).toBe("steer");
+    expect(autoClassifyMidTurnInbound(base({ isDm: true, incomingThreadId: null, activeTurnThreadId: null, msSinceLastAgentOutput: 15000, dmSteerWindowMs: 10000 })).decision).toBe("queue");
+  });
+});


### PR DESCRIPTION
## Summary
First step toward letting users steer/queue by **intent** instead of explicit `/steer` `/q` prefixes: a deterministic, **model-free** classifier using **topic-vs-active-turn + reply-recency** as proxies. Strong signal is structural — a message in a *different* forum topic than the in-flight turn is a separate conversation (queue); same-topic + recent is a steer candidate.

**Ships SHADOW-ONLY** behind `SWITCHROOM_AUTOCLASSIFY_MIDTURN_SHADOW` (default OFF): logs what it *would* decide; **behaviour unchanged** (no-prefix still queues). Gathers the real-world distribution to tune the auto-steer window + measure how often same-topic continuations happen — *before* any behaviour flips on. Honours "you hold the leash" (auto-steer is an irreversible injection → must earn its way in with data) and the April-2026 lesson (unconditional implicit-steer was too blunt).

## What's in it
- **`auto-classify-mid-turn.ts`** — pure decision fn: prefix wins → cross-topic→queue (strong) → same-topic recent→steer / stale→queue → DM timing-only & OFF by default. Canonical thread compare (null/0/undefined collapse). **11 unit tests.**
- **Recency clock** `lastAgentOutputAt` per `(chat,thread)` — the agent's last *output* (not turn age, so a long narrating worker turn doesn't read "stale"), stamped beside `noteOutbound`, LRU-bounded, **only when the flag is on**.
- **Shadow hook** at the classify site logs `would=/reason=/same_topic=/ms_since_out=/actual=`; `isSteering` (behaviour) untouched.

## Test plan
- [x] `auto-classify-mid-turn.test.ts` 11 (prefix override, cross/same-topic, recency, DM-off, canonical-collapse).
- [x] `tsc`, `check-plugin-references`, `check-bot-api-wrapping` clean; full `telegram-plugin/` suite **3497/0**.
- [x] Flag off → byte-identical + zero overhead (map only maintained when on).

## Risk
Minimal — no behaviour change; shadow logging only, default off. Next PR flips auto-steer behind its own flag after the shadow data + a product call (DM stays off; supergroup window tuned from the data).