### PR TITLE
chore(telegram): graduate obligation ledger + mid-turn shadow to default-on

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1400,9 +1400,12 @@ const deliveryQueue = createDeliveryQueue<InboundMessage>()
 // re-presented (bounded) until it closes, so a message the model read but never
 // answered (the marko 715 drop) cannot be silently lost. ADDITIVE + flagged: it
 // runs ALONGSIDE the existing acks/spool/buffer (PR3 retires the redundant
-// pieces). Default OFF — the canary turns it on (713/715 interleave UAT) before
-// any fleet activation. When off, every hook below is a no-op → zero change.
-const OBLIGATION_LEDGER_ENABLED = process.env.SWITCHROOM_OBLIGATION_LEDGER === '1'
+// pieces). DEFAULT ON (graduated from canary 2026-06-04 after the hang-fix
+// (#2152, total-proof), the escalate-grace (#2156, kills the fuzz-found
+// over-escalation), and interrupt-cancel (#2157) — proven on marko (supergroup)
+// + test-harness for days with 0 false cards). Kill switch:
+// SWITCHROOM_OBLIGATION_LEDGER=0 → every hook below is a no-op → zero change.
+const OBLIGATION_LEDGER_ENABLED = process.env.SWITCHROOM_OBLIGATION_LEDGER !== '0'
 const OBLIGATION_REPRESENT_MAX = 2
 const OBLIGATION_SWEEP_MS = 5_000
 // Bound on escalation SEND attempts. The escalation now closes only AFTER a
@@ -1449,8 +1452,10 @@ const OBLIGATION_ESCALATE_GRACE_MS = (() => {
 // ms_since_out) but the behaviour is UNCHANGED (still queue) — to gather the
 // real-world distribution (how often mid-turn messages are same-topic
 // continuations vs cross-topic, and the recency spread) before any action flips
-// on. Default OFF → zero overhead. The action windows below stay 0 in shadow.
-const AUTOCLASSIFY_MIDTURN_SHADOW = process.env.SWITCHROOM_AUTOCLASSIFY_MIDTURN_SHADOW === '1'
+// on. DEFAULT ON fleet-wide (data-gathering: zero behaviour change — only logs +
+// a bounded recency map). This is a TEMPORARY default; when auto-steer ships it
+// supersedes shadow. Kill switch: SWITCHROOM_AUTOCLASSIFY_MIDTURN_SHADOW=0.
+const AUTOCLASSIFY_MIDTURN_SHADOW = process.env.SWITCHROOM_AUTOCLASSIFY_MIDTURN_SHADOW !== '0'
 // Per-(chat,thread) wall-clock ms of the agent's LAST visible output — the
 // recency clock the classifier uses (NOT turn age: a long actively-narrating
 // worker turn must not read "stale"). Stamped beside signalTracker.noteOutbound.


### PR DESCRIPTION
## Summary
Graduate two canary flags to **default-on** (kill-switch `!== '0'` pattern, matching `FEED_HEARTBEAT`):

- **`SWITCHROOM_OBLIGATION_LEDGER`** — the no-drop obligation guarantee. Canary'd on marko (supergroup, hardest case) + test-harness for days with the full hardening: hang-wedge (#2152, total-proof), escalate-grace (#2156, kills the fuzz-found over-escalation), interrupt-cancel (#2157). **0 false cards on marko.** Now the fleet default; kill switch `SWITCHROOM_OBLIGATION_LEDGER=0`.
- **`SWITCHROOM_AUTOCLASSIFY_MIDTURN_SHADOW`** — fleet-wide data gathering (zero behaviour change, logs + a bounded recency map only; temporary until auto-steer ships). Kill switch `=0`.

**Behaviour delta:** all agents now track/​re-present/​escalate unanswered inbounds (the over-escalation grace suppresses false fires) and log shadow classifications. No code path beyond the default constants changed.

## Test plan
- [x] `tsc`, `check-plugin-references`, `check-bot-api-wrapping` clean.
- [x] Full `telegram-plugin/` suite **3497/0**; no test gates on these env defaults.
- [x] Kill switches verified: `=0` returns to pre-feature behaviour.

## Risk
Medium (fleet-wide behaviour change), mitigated: proven on the two canary agents incl. the hardest (supergroup) case, the main false-positive (over-escalation) is fixed, both have instant kill switches, and rollout is staggered with log-watching. Auto-steer is **not** affected (unbuilt; shadow stays logging-only).