### PR TITLE
feat(telegram): instrument the live status-surface lane for triage

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -65,6 +65,7 @@ import {
 import { StatusReactionController } from '../status-reactions.js'
 import { DeferredDoneReactions } from '../reaction-defer.js'
 import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
+import { formatTurnLifecycle, detectStatusSurfaceDegraded } from './status-surface-log.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel, renderActivityFeedWithNested } from '../tool-activity-summary.js'
 import { toolLabel } from '../tool-labels.js'
@@ -1798,6 +1799,14 @@ type CurrentTurn = {
   activityInFlight: Promise<void> | null
   activityPendingRender: string | null
   activityLastSentRender: string | null
+  // Status-surface observability. `activityEverOpened` is sticky-true once the
+  // feed posts its first message — unlike `activityMessageId`, it is NOT nulled
+  // by `clearActivitySummary`, so the turn-end DEGRADED check can tell "feed
+  // never opened" (the resume-400 signature) from "feed finalized + cleared".
+  // `activityDrainFailures` counts real activity-feed send/edit failures this
+  // turn (429s + "message is not modified" excluded). Both reset per turn.
+  activityEverOpened: boolean
+  activityDrainFailures: number
   // Wall-clock anchor for the newest in-progress feed step — set each time a
   // tool_label re-renders the feed. The heartbeat (`feedHeartbeatTick`) reads
   // it to show a climbing " · Ns" elapsed on the live line so a long single
@@ -2488,6 +2497,20 @@ function releaseTurnBufferGate(key: string, endingTurn?: CurrentTurn): void {
 function endCurrentTurnAtomic(turn: CurrentTurn): void {
   if (currentTurn !== turn) return
   currentTurn = null
+  // Status-surface observability: one line at every turn CLEAR (with how far
+  // the turn got), plus a DEGRADED warning when the turn did tool work but the
+  // live feed never opened because its sends failed (the resume-400 signature).
+  process.stderr.write(
+    `telegram gateway: ${formatTurnLifecycle('clear', 'turn_end', turn, Date.now())}\n`,
+  )
+  const degraded = detectStatusSurfaceDegraded(turn)
+  if (degraded != null) {
+    process.stderr.write(
+      `telegram gateway: status-surface DEGRADED reason=${degraded.reason} ` +
+        `turnId=${turn.turnId} chat=${turn.sessionChatId} ` +
+        `thread=${turn.sessionThreadId ?? '-'} ${degraded.detail}\n`,
+    )
+  }
   // PR2 obligation-ledger CLOSE-at-turn-end. Close the ended turn's obligation
   // when it delivered a final answer. finalAnswerDelivered is the right signal
   // HERE (not isSubstantiveFinalReply at reply-time): a SHORT genuine answer
@@ -8850,6 +8873,7 @@ async function drainActivitySummary(turn: CurrentTurn): Promise<void> {
             { chat_id: chat, ...(thread != null ? { threadId: thread } : {}), verb: 'activity-summary.send' },
           )
           turn.activityMessageId = sent.message_id
+          turn.activityEverOpened = true
         } else {
           const id = turn.activityMessageId
           await robustApiCall(
@@ -8861,7 +8885,18 @@ async function drainActivitySummary(turn: CurrentTurn): Promise<void> {
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
         if (!msg.includes('message is not modified')) {
-          process.stderr.write(`telegram gateway: activity-summary drain failed: ${msg}\n`)
+          turn.activityDrainFailures += 1
+          // Surface the failing anchor + topic: the resume-400 bug fed a
+          // fabricated 13-digit message_id as the reply anchor here, so every
+          // send 400'd and the feed never opened. Logging the anchor +
+          // everOpened makes a feed-blanking send self-explanatory (and the
+          // turn-end DEGRADED line aggregates it).
+          process.stderr.write(
+            `telegram gateway: activity-summary drain failed: ${msg} ` +
+              `(chat=${chat} thread=${thread ?? '-'} ` +
+              `replyAnchor=${turn.sourceMessageId ?? 'none'} ` +
+              `everOpened=${turn.activityEverOpened} failures=${turn.activityDrainFailures})\n`,
+          )
         }
         // Mark as sent so we don't infinite-loop on a stuck render.
         turn.activityLastSentRender = target
@@ -9042,12 +9077,19 @@ function handleSessionEvent(ev: SessionEvent): void {
           activityInFlight: null,
           activityPendingRender: null,
           activityLastSentRender: null,
+          activityEverOpened: false,
+          activityDrainFailures: 0,
           mirrorLines: [],
           foregroundSubAgents: new Map(),
           answerStream: null,
           isDm: isDmChatId(ev.chatId),
         }
         currentTurn = next
+        // Status-surface observability: one line at every turn SET so a later
+        // dark card is traceable to which turn/topic key it belonged to.
+        process.stderr.write(
+          `telegram gateway: ${formatTurnLifecycle('set', 'enqueue', next, startedAt)}\n`,
+        )
         // Component 3 — retain in the bounded recently-ended registry so a
         // LATE reply (landing after currentTurn flips to a successor) can
         // still resolve THIS turn's origin thread by its turnId.

--- a/telegram-plugin/gateway/status-surface-log.test.ts
+++ b/telegram-plugin/gateway/status-surface-log.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatTurnLifecycle,
+  detectStatusSurfaceDegraded,
+  type StatusSurfaceTurnView,
+} from './status-surface-log.js'
+
+function turn(overrides: Partial<StatusSurfaceTurnView> = {}): StatusSurfaceTurnView {
+  return {
+    turnId: '-100123:_#1780000000000',
+    sessionChatId: '-100123',
+    sessionThreadId: undefined,
+    startedAt: 1_780_000_000_000,
+    toolCallCount: 0,
+    activityMessageId: null,
+    activityEverOpened: false,
+    activityDrainFailures: 0,
+    replyCalled: false,
+    finalAnswerDelivered: false,
+    ...overrides,
+  }
+}
+
+describe('formatTurnLifecycle', () => {
+  it('renders a set line with no age and a "-" thread for General', () => {
+    const line = formatTurnLifecycle('set', 'enqueue', turn(), 1_780_000_005_000)
+    expect(line).toContain('turn-lifecycle set reason=enqueue')
+    expect(line).toContain('turnId=-100123:_#1780000000000')
+    expect(line).toContain('chat=-100123')
+    expect(line).toContain('thread=-')
+    expect(line).toContain('age_ms=0') // set never reports age
+  })
+
+  it('renders a clear line with the turn age and live state', () => {
+    const line = formatTurnLifecycle(
+      'clear',
+      'turn_end',
+      turn({ sessionThreadId: 3, toolCallCount: 5, activityMessageId: 42, activityEverOpened: true, replyCalled: true, finalAnswerDelivered: true }),
+      1_780_000_300_000, // +300s
+    )
+    expect(line).toContain('turn-lifecycle clear reason=turn_end')
+    expect(line).toContain('thread=3')
+    expect(line).toContain('tools=5')
+    expect(line).toContain('activityMsgId=42')
+    expect(line).toContain('feedOpened=true')
+    expect(line).toContain('replyCalled=true')
+    expect(line).toContain('finalAnswer=true')
+    expect(line).toContain('age_ms=300000')
+  })
+
+  it('never emits a negative age even if startedAt is in the future (clock skew)', () => {
+    const line = formatTurnLifecycle('clear', 'turn_end', turn({ startedAt: 2_000_000_000_000 }), 1_780_000_000_000)
+    expect(line).toContain('age_ms=0')
+  })
+
+  it('carries no prefix or trailing newline — the caller owns transport', () => {
+    const line = formatTurnLifecycle('set', 'enqueue', turn(), 0)
+    expect(line.startsWith('telegram gateway:')).toBe(false)
+    expect(line.endsWith('\n')).toBe(false)
+  })
+})
+
+describe('detectStatusSurfaceDegraded', () => {
+  it('flags a turn that did tool work but never opened the feed due to send failures (the resume-400 signature)', () => {
+    const d = detectStatusSurfaceDegraded(
+      turn({ toolCallCount: 3, activityEverOpened: false, activityDrainFailures: 10 }),
+    )
+    expect(d).not.toBeNull()
+    expect(d!.reason).toBe('feed-never-opened')
+    expect(d!.detail).toContain('drainFailures=10')
+  })
+
+  it('does NOT flag a healthy turn where the feed opened, even if later cleared (activityMessageId nulled)', () => {
+    // clearActivitySummary nulls activityMessageId async on the healthy path;
+    // the sticky activityEverOpened keeps this from false-positiving.
+    expect(
+      detectStatusSurfaceDegraded(
+        turn({ toolCallCount: 4, activityMessageId: null, activityEverOpened: true, activityDrainFailures: 0 }),
+      ),
+    ).toBeNull()
+  })
+
+  it('does NOT flag a turn that never attempted a feed send (e.g. ack-first suppression)', () => {
+    expect(
+      detectStatusSurfaceDegraded(
+        turn({ toolCallCount: 2, activityEverOpened: false, activityDrainFailures: 0 }),
+      ),
+    ).toBeNull()
+  })
+
+  it('does NOT flag a turn with no tool work (nothing to surface)', () => {
+    expect(
+      detectStatusSurfaceDegraded(
+        turn({ toolCallCount: 0, activityEverOpened: false, activityDrainFailures: 3 }),
+      ),
+    ).toBeNull()
+  })
+})

--- a/telegram-plugin/gateway/status-surface-log.ts
+++ b/telegram-plugin/gateway/status-surface-log.ts
@@ -1,0 +1,102 @@
+/**
+ * Status-surface observability — pure formatters for the gateway's live-status
+ * lane (progress card / activity feed / typing indicator).
+ *
+ * Why a dedicated module: when an agent's live status went dark (marko,
+ * 2026-06-05), the lane was nearly silent in the logs — `currentTurn` (the
+ * variable that drives the card/feed/typing) was nulled with no breadcrumb, and
+ * the activity feed failed every send with no turn-level signal. Two latent
+ * bugs were invisible for days: a 300s silence-poke teardown that nulled the
+ * card mid-work, and a resume-synthetic whose fabricated 13-digit message_id
+ * made every feed send 400. Neither left a greppable "the card went dark and
+ * here's why" line.
+ *
+ * These pure functions give the gateway exactly that: ONE structured line per
+ * currentTurn lifecycle transition, and a single DEGRADED warning when a turn
+ * did tool work but the feed never opened because its sends failed. Pure
+ * formatters + injected transport (the caller owns `process.stderr.write`),
+ * mirroring `silence-poke.ts` / `worker-activity-feed.ts`, so they're
+ * unit-testable without a live gateway.
+ */
+
+/**
+ * The `currentTurn` fields the status-surface logs read. The gateway's
+ * `CurrentTurn` atom structurally satisfies this (TS structural typing), so the
+ * gateway passes the turn directly — no import cycle back into `gateway.ts`.
+ */
+export interface StatusSurfaceTurnView {
+  turnId: string
+  sessionChatId: string
+  sessionThreadId: number | undefined
+  startedAt: number
+  toolCallCount: number
+  /** Live activity-feed message id; null until the first send captures it. */
+  activityMessageId: number | null
+  /**
+   * Sticky: true once the activity feed ever opened a message this turn. Unlike
+   * `activityMessageId` (which `clearActivitySummary` nulls async on the
+   * healthy finalize path), this is never reset — so a turn that DID surface
+   * the feed can't false-positive as degraded at turn-end.
+   */
+  activityEverOpened: boolean
+  /** Count of real activity-feed send/edit failures this turn (429s and
+   *  "message is not modified" excluded). */
+  activityDrainFailures: number
+  replyCalled: boolean
+  finalAnswerDelivered: boolean
+}
+
+export type TurnLifecycleAction = 'set' | 'clear'
+
+/**
+ * One structured line per `currentTurn` set/clear. `currentTurn` drives the
+ * progress card / activity feed / typing; logging every transition — with the
+ * topic key, how far the turn got, and the reason it ended — makes a dark card
+ * explainable after the fact. Returned WITHOUT the `telegram gateway: ` prefix
+ * or trailing newline so the caller owns transport (and tests assert the body).
+ *
+ * `now` is only consulted for the `clear` age; for `set` it is ignored.
+ */
+export function formatTurnLifecycle(
+  action: TurnLifecycleAction,
+  reason: string,
+  t: StatusSurfaceTurnView,
+  now: number,
+): string {
+  const ageMs = action === 'clear' ? Math.max(0, now - t.startedAt) : 0
+  return (
+    `turn-lifecycle ${action} reason=${reason} turnId=${t.turnId} ` +
+    `chat=${t.sessionChatId} thread=${t.sessionThreadId ?? '-'} ` +
+    `tools=${t.toolCallCount} activityMsgId=${t.activityMessageId ?? 'none'} ` +
+    `feedOpened=${t.activityEverOpened} drainFailures=${t.activityDrainFailures} ` +
+    `replyCalled=${t.replyCalled} finalAnswer=${t.finalAnswerDelivered} age_ms=${ageMs}`
+  )
+}
+
+/**
+ * Turn-end health check: did the turn do tool work but never get a live feed
+ * message onto the screen BECAUSE its sends failed? That is the exact signature
+ * of the resume-400 bug (every activity-summary send throws, so the feed never
+ * opens) — a single greppable line would have caught it in seconds.
+ *
+ * Returns null when the surface was healthy or legitimately silent:
+ *   - no tool work this turn (nothing to surface), OR
+ *   - the feed opened fine (`activityEverOpened`), OR
+ *   - the feed never even attempted a send (`activityDrainFailures === 0`, e.g.
+ *     an ack-first turn whose feed was intentionally suppressed) — absence of a
+ *     send is not a failure.
+ */
+export function detectStatusSurfaceDegraded(
+  t: StatusSurfaceTurnView,
+): { reason: string; detail: string } | null {
+  if (t.toolCallCount === 0) return null
+  if (t.activityEverOpened) return null
+  if (t.activityDrainFailures === 0) return null
+  return {
+    reason: 'feed-never-opened',
+    detail:
+      `tools=${t.toolCallCount} drainFailures=${t.activityDrainFailures} ` +
+      `activityMsgId=none — the live activity feed failed every send this turn ` +
+      `(card was dark despite tool work)`,
+  }
+}

--- a/telegram-plugin/tests/worker-activity-feed.test.ts
+++ b/telegram-plugin/tests/worker-activity-feed.test.ts
@@ -440,3 +440,64 @@ describe('createWorkerActivityFeed', () => {
     expect(bot.sent[0].opts?.message_thread_id).toBe(42)
   })
 })
+
+// ─── log sink: success-path observability ────────────────────────────────────
+// Before this, the feed only logged on FAILURE, so a feed that rendered fine
+// was invisible in the gateway log — the exact gap that made the marko
+// status-dark incident hard to triage. Assert paint/edit/finish each emit a
+// structured, greppable line naming the worker, chat, thread, and message id.
+describe('createWorkerActivityFeed — log sink', () => {
+  it('logs paint on first send, edit on each in-place update, and finish on terminal', async () => {
+    const bot = makeFakeBot()
+    const logs: string[] = []
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({
+      bot,
+      now: () => clock,
+      minEditIntervalMs: 0,
+      log: (m) => logs.push(m),
+    })
+
+    await feed.update('w-research', 'chat-9', view({ toolCount: 1, latestSummary: 'first' }), 7)
+    clock = 11_000
+    await feed.update('w-research', 'chat-9', view({ toolCount: 2, latestSummary: 'second' }), 7)
+    clock = 12_000
+    await feed.finish('w-research', view({ state: 'done', toolCount: 2 }))
+
+    const paint = logs.find((l) => l.startsWith('worker-feed: paint'))
+    const edit = logs.find((l) => l.startsWith('worker-feed: edit'))
+    const finish = logs.find((l) => l.startsWith('worker-feed: finish'))
+
+    expect(paint).toBeDefined()
+    expect(paint).toContain('agent=w-research')
+    expect(paint).toContain('chat=chat-9')
+    expect(paint).toContain('thread=7')
+    expect(paint).toMatch(/msgId=\d+/)
+    expect(paint).toMatch(/bytes=\d+/)
+
+    expect(edit).toBeDefined()
+    expect(edit).toContain('agent=w-research')
+
+    expect(finish).toBeDefined()
+    expect(finish).toContain('state=done')
+  })
+
+  it('renders thread=- in the log line when no forum topic is set', async () => {
+    const bot = makeFakeBot()
+    const logs: string[] = []
+    let clock = 10_000
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, log: (m) => logs.push(m) })
+    await feed.update('w1', 'chat', view()) // no threadId
+    expect(logs.find((l) => l.startsWith('worker-feed: paint'))).toContain('thread=-')
+  })
+
+  it('does not log a paint when the worker stays below firstPaintMin (still silent)', async () => {
+    const bot = makeFakeBot()
+    const logs: string[] = []
+    let clock = 0
+    const feed = createWorkerActivityFeed({ bot, now: () => clock, firstPaintMinMs: 8000, log: (m) => logs.push(m) })
+    clock = 3000
+    await feed.update('w1', 'chat', view({ elapsedMs: 3000 }))
+    expect(logs.some((l) => l.startsWith('worker-feed: paint'))).toBe(false)
+  })
+})

--- a/telegram-plugin/worker-activity-feed.ts
+++ b/telegram-plugin/worker-activity-feed.ts
@@ -208,6 +208,8 @@ export interface WorkerActivityFeedOpts {
 }
 
 interface WorkerHandle {
+  /** jsonl agent id — carried so success/failure log lines can name the worker. */
+  agentId: string
   chatId: string
   threadId?: number
   messageId: number | null
@@ -309,6 +311,10 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
         h.messageId = sent.message_id
         h.lastBody = body
         h.lastEditAt = nowFn()
+        log(
+          `worker-feed: paint agent=${h.agentId} chat=${h.chatId} ` +
+            `thread=${h.threadId ?? '-'} msgId=${h.messageId} bytes=${body.length}`,
+        )
       } catch (err) {
         noteRateLimited(h, err, 'send')
         log(`worker-feed: send failed: ${(err as Error).message}`)
@@ -324,6 +330,10 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       await opts.bot.editMessageText(h.chatId, h.messageId, body, sendOptsFor(h))
       h.lastBody = body
       h.lastEditAt = nowFn()
+      log(
+        `worker-feed: edit agent=${h.agentId} chat=${h.chatId} ` +
+          `thread=${h.threadId ?? '-'} msgId=${h.messageId} bytes=${body.length}`,
+      )
     } catch (err) {
       noteRateLimited(h, err, 'edit')
       // Stale message_id (manually deleted / edit window gone). Re-post
@@ -351,6 +361,10 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       await opts.bot.editMessageText(h.chatId, h.messageId, body, sendOptsFor(h))
       h.lastBody = body
       h.lastEditAt = nowFn()
+      log(
+        `worker-feed: finish agent=${h.agentId} chat=${h.chatId} ` +
+          `thread=${h.threadId ?? '-'} msgId=${h.messageId} state=${view.state} bytes=${body.length}`,
+      )
     } catch (err) {
       noteRateLimited(h, err, 'finish')
       log(`worker-feed: finish edit failed: ${(err as Error).message}`)
@@ -371,6 +385,7 @@ export function createWorkerActivityFeed(opts: WorkerActivityFeedOpts): WorkerAc
       let h = handles.get(agentId)
       if (h == null) {
         h = {
+          agentId,
           chatId,
           threadId,
           messageId: null,


### PR DESCRIPTION
## Summary
PR **1 of 2** of the marko "status went dark" fix. Pure observability — **no behavior change**. Makes the live status-surface lane (progress card / activity feed / worker feed / typing) explainable from the gateway log, which is the gap that turned two one-line bugs into a multi-agent investigation.

The diagnosis (read-only, adversarially verified) found two latent, version-independent defects darkening the lane, plus a third silent-drop class — none of which left a greppable breadcrumb:
- **A (persistent):** the 300s silence-poke fallback nulls `currentTurn` (which drives the card/feed/typing) on any tool-work stretch >5min without a model reply.
- **B (acute, resume-only):** the resume-interrupted synthetic fabricates a `message_id` from `Date.now()` (~1.78e13) → used as the activity-feed reply anchor → **every** feed send 400s `message_id must be a valid Number` → feed dark the whole first post-restart turn.
- **C:** operator DM notifications carrying a supergroup topic id → `message thread not found`.

The **fixes** land in PR 2; this PR makes those fixes verifiable on the marko canary.

## What's added (additive logging only)
- **New pure module** `gateway/status-surface-log.ts` — `formatTurnLifecycle()` + `detectStatusSurfaceDegraded()`, unit-tested without a live gateway.
- **`currentTurn` lifecycle line** at every set (`enqueue`) and clear (`endCurrentTurnAtomic`): turnId, topic key, tool count, feed state, age, reason. (The other two clear paths — silence-poke fallback and disconnect-flush — already log their own reason.)
- **`CurrentTurn.activityEverOpened`** (sticky) + **`activityDrainFailures`** (counter); the `activity-summary drain failed` log now carries the failing **reply anchor + topic** — would have made bug B self-evident.
- **`status-surface DEGRADED`** line at turn-end when tools ran but the feed never opened because its sends failed (bug B's signature).
- **worker-activity-feed**: log `paint`/`edit`/`finish` on **success** (it previously logged only failures, so a healthy worker feed was invisible — exactly why the worker/sub-agent status looked dark in triage).

## Why (JTBD)
Serves outcome **2 (you hold the leash)** — awareness/control of what an agent is doing. When the live status lane fails, the operator must be able to tell *why* from the log, not reverse-engineer it.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest` `status-surface-log` (8) + `worker-activity-feed` log-sink cases — 43 green
- [x] gateway-area vitest sweep — 197 green
- [x] lint gates clean: plugin-refs, bun-test-imports, bot-api-wrapping, no-pii-secrets, vault-hermeticity, no-broadcast

## Risk
Low — additive logging + two new per-turn fields (initialized at enqueue, read only by the new log sites). No transport/routing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)