### PR TITLE
fix(telegram): stop two always-failing status sends (resume-feed 400 + compact DM thread-leak)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -66,6 +66,7 @@ import { StatusReactionController } from '../status-reactions.js'
 import { DeferredDoneReactions } from '../reaction-defer.js'
 import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
 import { formatTurnLifecycle, detectStatusSurfaceDegraded } from './status-surface-log.js'
+import { parseSourceMessageId } from './source-message-id.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel, renderActivityFeedWithNested } from '../tool-activity-summary.js'
 import { toolLabel } from '../tool-labels.js'
@@ -2681,9 +2682,18 @@ async function postCompactCard(occ: number, cap: number): Promise<void> {
     // instead of conversation lanes. Fleet/DM agents fall through to
     // the existing chatThreadMap last-seen-thread fallback (no
     // observable change).
-    const threadId =
-      resolveAgentOutboundTopic({ kind: 'compact-watchdog' })
-      ?? chatThreadMap.get(chatId);
+    // The compact-watchdog topic is valid ONLY in the agent's supergroup;
+    // attaching it to an operator DM recipient 400s "message thread not found"
+    // and the notice silently vanishes (the marko #2096 class — proactiveCompact
+    // was the one operator-send still missing this guard, 2026-06-05). DM
+    // recipients get a thread-less send; the supergroup owner keeps the lane.
+    const threadId = topicForRecipient({
+      recipientChatId: chatId,
+      resolvedTopic:
+        resolveAgentOutboundTopic({ kind: 'compact-watchdog' })
+        ?? chatThreadMap.get(chatId),
+      supergroupChatId: resolveAgentSupergroupChatId(),
+    });
     const text =
       `🗜️ <b>Context compaction</b>\n` +
       `Working context hit ~${occ.toLocaleString()} tokens ` +
@@ -9054,9 +9064,13 @@ function handleSessionEvent(ev: SessionEvent): void {
         const next: CurrentTurn = {
           sessionChatId: ev.chatId,
           sessionThreadId: enqThreadIdNum,
-          sourceMessageId: ev.messageId != null && /^\d+$/.test(ev.messageId)
-            ? Number(ev.messageId)
-            : null,
+          // Accept the inbound id as a reply anchor only when it is a plausible
+          // Telegram message id. Synthetic boot-resume inbounds fabricate a
+          // 13-digit Date.now() message_id (for ack-tracking); if that reached
+          // the activity-feed reply anchor it 400'd every feed send and darkened
+          // the live feed for the whole resume turn (2026-06-05). The ack-queue
+          // still keys on ev.messageId independently — only the anchor is gated.
+          sourceMessageId: parseSourceMessageId(ev.messageId),
           startedAt,
           gatewayReceiveAt: startedAt,
           replyCalled: false,

--- a/telegram-plugin/gateway/source-message-id.test.ts
+++ b/telegram-plugin/gateway/source-message-id.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { parseSourceMessageId, MAX_TELEGRAM_MESSAGE_ID } from './source-message-id.js'
+
+describe('parseSourceMessageId', () => {
+  it('accepts a plausible Telegram message id (string or number)', () => {
+    expect(parseSourceMessageId('903')).toBe(903)
+    expect(parseSourceMessageId(905)).toBe(905)
+    expect(parseSourceMessageId('1')).toBe(1)
+  })
+
+  it('REJECTS a fabricated 13-digit Date.now() timestamp (the resume-dark-feed bug)', () => {
+    // 2026-06-04T23:34:21.578Z — the exact value that 400'd every feed send.
+    expect(parseSourceMessageId('1780616061578')).toBeNull()
+    expect(parseSourceMessageId(1_780_616_061_578)).toBeNull()
+  })
+
+  it('rejects anything at or above the Telegram message-id ceiling (2^31)', () => {
+    expect(parseSourceMessageId(MAX_TELEGRAM_MESSAGE_ID)).toBeNull()
+    expect(parseSourceMessageId(MAX_TELEGRAM_MESSAGE_ID - 1)).toBe(MAX_TELEGRAM_MESSAGE_ID - 1)
+  })
+
+  it('rejects null / undefined / empty / non-numeric / non-positive', () => {
+    expect(parseSourceMessageId(null)).toBeNull()
+    expect(parseSourceMessageId(undefined)).toBeNull()
+    expect(parseSourceMessageId('')).toBeNull()
+    expect(parseSourceMessageId('12a')).toBeNull()
+    expect(parseSourceMessageId('-5')).toBeNull() // leading "-" fails the digit test
+    expect(parseSourceMessageId(0)).toBeNull()
+    expect(parseSourceMessageId(-5)).toBeNull()
+    expect(parseSourceMessageId('3.5')).toBeNull()
+  })
+})

--- a/telegram-plugin/gateway/source-message-id.ts
+++ b/telegram-plugin/gateway/source-message-id.ts
@@ -1,0 +1,41 @@
+/**
+ * Guard for the per-turn reply anchor (`turn.sourceMessageId`).
+ *
+ * Telegram Bot API message ids are positive integers that fit within a signed
+ * 32-bit int; `reply_parameters.message_id` HARD-rejects anything larger with
+ * 400 "field 'message_id' must be a valid Number" (and `allow_sending_without_reply`
+ * does NOT bypass that range check).
+ *
+ * Synthetic boot-resume inbounds (`resume-inbound-builder.ts`) fabricate a
+ * `message_id` from `Date.now()` (~1.78e13) so the deliver-until-acked queue can
+ * ack the synthetic by its own enqueue id. That round-trip is fine on its own —
+ * but the enqueue handler also turns `ev.messageId` into `turn.sourceMessageId`,
+ * which `drainActivitySummary` sends as the activity-feed reply anchor. A
+ * fabricated 13-digit timestamp there 400s EVERY feed send for the whole turn,
+ * so the live status feed is dark for the entire first post-restart turn (the
+ * resume-dark-feed incident, 2026-06-05).
+ *
+ * This guard accepts a value as a real anchor ONLY when it is a plausible
+ * Telegram message id; anything non-numeric or out of range yields null, so the
+ * feed posts UNANCHORED (still correct — the anchor is a nicety, not required).
+ * The synthetic's ack-tracking is unaffected: it keys on the enqueue event's own
+ * id, never on this anchor.
+ */
+
+/** Telegram message ids fit within a signed 32-bit int for reply anchoring;
+ *  anything at/above this is not a real message id (e.g. a wall-clock ms ts). */
+export const MAX_TELEGRAM_MESSAGE_ID = 2 ** 31
+
+/**
+ * Parse an inbound's `messageId` into a usable reply anchor, or null when it is
+ * not a plausible Telegram message id (non-numeric, non-positive, non-integer,
+ * or out of the reply-anchor range — e.g. a fabricated `Date.now()` timestamp).
+ */
+export function parseSourceMessageId(raw: string | number | undefined | null): number | null {
+  if (raw == null) return null
+  const s = String(raw)
+  if (!/^\d+$/.test(s)) return null
+  const n = Number(s)
+  if (!Number.isSafeInteger(n) || n <= 0 || n >= MAX_TELEGRAM_MESSAGE_ID) return null
+  return n
+}


### PR DESCRIPTION
## Summary
PR **2 of the marko "status went dark" fix** (companion to #2162 observability). Two **strictly-corrective** fixes — each targets a send that **always 400s today** (Telegram rejects it regardless of our code), so neither changes a working path and neither needs a kill-switch flag.

### Fix B — resume-turn dark feed (acute, every first turn after a restart)
Synthetic boot-resume inbounds fabricate a `message_id` from `Date.now()` (~1.78e13) so the deliver-until-acked queue can ack the synthetic by its own enqueue id. But the enqueue handler also turned that into `turn.sourceMessageId`, which `drainActivitySummary` sends as the activity-feed `reply_parameters.message_id` — **829× over Telegram's 2³¹ max**, so *every* feed send on the first post-restart turn 400'd `message_id must be a valid Number` and the live feed was dark the whole turn (proven in the marko log: 10 failed sends / 0 edits vs 3/11 on a normal turn).

New `gateway/source-message-id.ts` `parseSourceMessageId()` accepts the id as a reply anchor **only when it's a plausible Telegram message id**; an out-of-range value → `null` → the feed posts **unanchored** (still correct; the anchor is a nicety). The synthetic's ack-tracking is untouched — it keys on the enqueue event's own id, not this anchor. `resume-inbound-builder.ts` is unchanged.

### Fix C — proactiveCompact DM thread-leak (silent operator-notice drops)
The compact-watchdog notice attached the agent's **supergroup topic id** to **operator-DM** sends → `400 message thread not found` → the notice silently vanished (29× in the marko log; same class as the #2096 approval-card wedge). `proactiveCompact.start` was the *one* operator-send still missing the `topicForRecipient` guard the sibling sites (operator-event, drive, ms365, config) already use — now applied.

## Why (JTBD)
Outcome **4 (always available / predictable)** + **2 (you hold the leash)**: the live status surface and operator lifecycle notices must actually reach the operator.

## Test plan
- [x] `tsc --noEmit` clean
- [x] new `source-message-id.test.ts` (4) pins the 13-digit-timestamp rejection + in-range / 2³¹-boundary cases
- [x] `topicForRecipient` DM-strip already pinned (`topic-router.test.ts:313` "drops the topic for an operator DM recipient — the wedge fix")
- [x] gateway + topic-router vitest sweep — 206 green; `resume-inbound-builder` bun — 31 green
- [x] lint gates clean (plugin-refs, bun-test-imports, bot-api-wrapping, no-pii, vault-hermeticity, no-broadcast)

## Risk
Low — both fixes correct always-failing sends; no flag, no working-path change.

## Follow-up
**Fix A** (the persistent 300s silence-poke teardown that nulls `currentTurn` mid-work) lands as its **own PR** — it's the delicate, incident-prone one and wants a marko canary against #2162's now-merged telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)