### PR TITLE
fix(telegram): keep the live feed alive during long in-flight tool work (silence-poke defer)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -4579,7 +4579,27 @@ function ensureIssuesCard(chatId: string, threadId: number | undefined): void {
 // incident fix. In-memory only; a gateway recreate naturally resets it.
 let inFlightUpdate: { requestId: string; startedAt: number } | null = null
 
+// Fix A — silence-fallback tuning (status-surface darkening, 2026-06-05). A long
+// quiet tool stretch (foreground sub-agent / big research) crossed the 300s
+// fallback and nulled currentTurn, darkening the live activity feed mid-work.
+//   SWITCHROOM_SILENCE_FALLBACK_MS         — base threshold (default 300000)
+//   SWITCHROOM_SILENCE_FALLBACK_HARD_MS    — hard ceiling for the in-flight-tool
+//                                            defer (default 900000 = 15min)
+//   SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS=1 — enable the defer (default OFF;
+//                                            canary on marko against #2162 telemetry)
+function parsePositiveMsEnv(name: string, fallbackMs: number): number {
+  const raw = process.env[name]
+  if (raw == null || raw === '') return fallbackMs
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallbackMs
+}
+const SILENCE_FALLBACK_MS = parsePositiveMsEnv('SWITCHROOM_SILENCE_FALLBACK_MS', 300_000)
+const SILENCE_FALLBACK_HARD_MS = parsePositiveMsEnv('SWITCHROOM_SILENCE_FALLBACK_HARD_MS', 900_000)
+const SILENCE_DEFER_INFLIGHT_TOOLS = process.env.SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS === '1'
+
 silencePoke.startTimer({
+  thresholdsMs: { fallback: SILENCE_FALLBACK_MS, fallbackHardCeiling: SILENCE_FALLBACK_HARD_MS },
+  deferFallbackWhileToolInFlight: SILENCE_DEFER_INFLIGHT_TOOLS,
   emitMetric: (event) => {
     // Re-emit through the unified runtime-metrics fan-out (PostHog + JSONL).
     emitRuntimeMetric(event)

--- a/telegram-plugin/silence-poke.ts
+++ b/telegram-plugin/silence-poke.ts
@@ -20,6 +20,14 @@
  * edits, and tool churn DO NOT reset the silence clock — the model could
  * be ripping through 20 tool calls and still be "silent" to the user.
  *
+ * Fix A caveat (opt-in, `deferFallbackWhileToolInFlight`): tool churn still
+ * doesn't reset the *clock*, but when the threshold is crossed WITH a parent
+ * tool genuinely in flight, the terminal unwedge is DEFERRED (not skipped) up to
+ * `fallbackHardCeiling`. Since #2162 the live activity feed renders that tool
+ * work, so the "still silent to the user" premise no longer holds while a tool
+ * is visibly running; nulling `currentTurn` there would darken the very feed the
+ * user is watching. A turn with no in-flight tool is unaffected.
+ *
  * Terminal action, once per turn:
  *
  *   t=0       startTurn() — silence clock starts at turnStartedAt
@@ -81,6 +89,16 @@ export interface ThresholdsMs {
   /** Silence (since last outbound, or turn start) after which the
    *  framework sends the user-visible fallback AND unwedges the turn. */
   fallback: number
+  /**
+   * Fix A — hard ceiling for the in-flight-tool defer. When
+   * `deferFallbackWhileToolInFlight` is on, the fallback is held back while a
+   * parent tool is genuinely in flight (the agent is demonstrably working and
+   * the live activity feed is showing it). This bounds that defer: once silence
+   * crosses the ceiling the fallback fires REGARDLESS of an in-flight tool, so a
+   * hung-mid-tool turn can't pin the conversation forever. Ignored unless the
+   * defer is on; defaults to no ceiling (Infinity) when omitted.
+   */
+  fallbackHardCeiling?: number
 }
 
 export const DEFAULT_THRESHOLDS: ThresholdsMs = {
@@ -122,6 +140,21 @@ export interface SilencePokeDeps {
   thresholdsMs?: ThresholdsMs
   /** Poll interval (tests). */
   pollIntervalMs?: number
+  /**
+   * Fix A — when true, the 300s framework fallback is DEFERRED while a parent
+   * tool is genuinely in flight (`inFlightTools` non-empty): the agent is
+   * demonstrably working, and since #2162 the live activity feed shows that
+   * work, so nulling `currentTurn` (which the fallback does) would darken a feed
+   * the user is actively watching. The defer is bounded by
+   * `thresholdsMs.fallbackHardCeiling` so a hung-mid-tool turn still unwedges; a
+   * turn with NO in-flight tool fires at the base threshold exactly as before.
+   * Default false (legacy behaviour) — enable per-agent to canary.
+   *
+   * A crashed agent is recovered independently by the bridge-disconnect sweep
+   * (`onDanglingTurnsSwept`), so deferring here does not reintroduce the #1556
+   * dangling-turn wedge for the crash case.
+   */
+  deferFallbackWhileToolInFlight?: boolean
 }
 
 const state = new Map<string, SilencePokeState>()
@@ -366,6 +399,20 @@ function tick(now: number): void {
     if (silence < 0) continue
 
     if (!s.fallbackFired && silence >= thresholds.fallback) {
+      // Fix A: defer the unwedge while a parent tool is genuinely in flight —
+      // the agent is demonstrably working and the live activity feed is showing
+      // it, so firing here (which nulls currentTurn) would darken that feed
+      // mid-work. Bounded by the hard ceiling so a hung-mid-tool turn still
+      // unwedges. `continue` WITHOUT setting fallbackFired so the next tick
+      // re-checks — once the tool ends and the turn stays silent past the base
+      // threshold, or the ceiling is crossed, it fires normally.
+      if (
+        activeDeps.deferFallbackWhileToolInFlight === true &&
+        s.inFlightTools.size > 0 &&
+        silence < (thresholds.fallbackHardCeiling ?? Number.POSITIVE_INFINITY)
+      ) {
+        continue
+      }
       s.fallbackFired = true
       const { chatId, threadId } = parseKey(key)
       const recentThinking = s.lastThinkingAt != null

--- a/telegram-plugin/tests/silence-poke.test.ts
+++ b/telegram-plugin/tests/silence-poke.test.ts
@@ -26,7 +26,10 @@ interface TestFixtures {
   fallbacks: FrameworkFallbackContext[]
 }
 
-function setupDeps(opts?: { thresholds?: Partial<typeof DEFAULT_THRESHOLDS> }): TestFixtures {
+function setupDeps(opts?: {
+  thresholds?: Partial<typeof DEFAULT_THRESHOLDS> & { fallbackHardCeiling?: number }
+  deferFallbackWhileToolInFlight?: boolean
+}): TestFixtures {
   const fixtures: TestFixtures = { emitted: [], fallbacks: [] }
   __setDepsForTests({
     emitMetric: (e) => fixtures.emitted.push(e),
@@ -35,6 +38,9 @@ function setupDeps(opts?: { thresholds?: Partial<typeof DEFAULT_THRESHOLDS> }): 
       ...DEFAULT_THRESHOLDS,
       ...(opts?.thresholds ?? {}),
     },
+    ...(opts?.deferFallbackWhileToolInFlight != null
+      ? { deferFallbackWhileToolInFlight: opts.deferFallbackWhileToolInFlight }
+      : {}),
   })
   return fixtures
 }
@@ -526,5 +532,67 @@ describe('silence-poke — performance', () => {
     __tickForTests(75_000) // under fallback threshold — pure iteration cost
     const elapsed = performance.now() - start
     expect(elapsed).toBeLessThan(50)
+  })
+})
+
+// ─── Fix A: defer the unwedge while a parent tool is genuinely in flight ──────
+// A long quiet tool stretch (foreground sub-agent / big research) crossed the
+// 300s fallback and nulled currentTurn, darkening the live activity feed
+// mid-work. The opt-in defer keeps the turn alive while a tool is in flight,
+// bounded by a hard ceiling so a hung-mid-tool turn still unwedges.
+describe('silence-poke — Fix A: in-flight-tool defer', () => {
+  it('legacy default (defer OFF): fires at 300s even with a tool in flight', () => {
+    const f = setupDeps() // deferFallbackWhileToolInFlight unset → off
+    startTurn('c:0', 0)
+    noteToolStart('c:0', 't1', 'Bash', 'long audit', 10_000)
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(1) // unchanged legacy behaviour
+  })
+
+  it('defer ON: does NOT fire at 300s while a tool is in flight', () => {
+    const f = setupDeps({ deferFallbackWhileToolInFlight: true, thresholds: { fallbackHardCeiling: 900_000 } })
+    startTurn('c:0', 0)
+    noteToolStart('c:0', 't1', 'Bash', 'long audit', 10_000)
+    __tickForTests(300_000)
+    __tickForTests(450_000) // still working, tool still in flight
+    expect(f.fallbacks).toHaveLength(0) // deferred — the live feed stays alive
+  })
+
+  it('defer ON: fires once the tool ends and the turn stays silent past threshold', () => {
+    const f = setupDeps({ deferFallbackWhileToolInFlight: true, thresholds: { fallbackHardCeiling: 900_000 } })
+    startTurn('c:0', 0)
+    noteToolStart('c:0', 't1', 'Bash', null, 10_000)
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(0) // deferred while in flight
+    noteToolEnd('c:0', 't1', 400_000) // tool completes, no reply follows
+    __tickForTests(400_001) // silence (from turn start) already well past 300s
+    expect(f.fallbacks).toHaveLength(1) // now unwedges promptly
+  })
+
+  it('defer ON: fires at the hard ceiling even with a tool still in flight (hung-mid-tool)', () => {
+    const f = setupDeps({ deferFallbackWhileToolInFlight: true, thresholds: { fallbackHardCeiling: 900_000 } })
+    startTurn('c:0', 0)
+    noteToolStart('c:0', 't1', 'Bash', 'wedged tool', 10_000)
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(0) // deferred
+    __tickForTests(900_000) // crosses the hard ceiling
+    expect(f.fallbacks).toHaveLength(1) // bounded — still unwedges
+  })
+
+  it('defer ON: a turn with NO in-flight tool fires at the base threshold (genuine silence)', () => {
+    const f = setupDeps({ deferFallbackWhileToolInFlight: true, thresholds: { fallbackHardCeiling: 900_000 } })
+    startTurn('c:0', 0)
+    // no tool ever started — genuinely silent/wedged
+    __tickForTests(300_000)
+    expect(f.fallbacks).toHaveLength(1) // unaffected by the defer
+  })
+
+  it('defer ON without a hard ceiling: defers indefinitely while the tool stays in flight', () => {
+    const f = setupDeps({ deferFallbackWhileToolInFlight: true }) // no fallbackHardCeiling → Infinity
+    startTurn('c:0', 0)
+    noteToolStart('c:0', 't1', 'Bash', null, 10_000)
+    __tickForTests(300_000)
+    __tickForTests(3_600_000) // an hour in
+    expect(f.fallbacks).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
PR **3 of the marko "status went dark" fix** — the **persistent, dominant** cause (companions: #2162 observability, #2163 resume/compact fixes).

The 300s silence-poke "framework fallback" nulls `currentTurn` (which drives the progress card / activity feed / typing) when there's been **no model reply** for 5 min. Activity-feed edits don't reset that clock, so a long quiet tool stretch — a foreground sub-agent, a big research pass, *exactly marko's background work* — tripped the fallback and **darkened the live feed mid-work while the agent kept going**. Proven 6× over 3 days in the marko log (e.g. card froze 22:57:51, dark from 23:02:10, answer landed 23:05:55).

The module header's *"the model could be ripping through 20 tool calls and still be silent to the user"* rationale **predates the live activity feed** (#2162): with the feed rendering tool progress, an actively-tool-churning turn is **not** silent to the user, so nulling `currentTurn` (killing that very feed) is counterproductive.

## The fix (opt-in, default OFF — canary first)
When the fallback threshold is crossed **with a parent tool genuinely in flight**, **defer** the unwedge (keep the turn + its live feed alive) instead of firing — **bounded by a hard ceiling** so a hung-mid-tool turn still unwedges and can't pin the conversation.

Safety preserved:
- A turn with **no in-flight tool** fires at the base threshold exactly as before → the #1556 dangling-turn protection is intact.
- A **crashed** agent is independently recovered by the bridge-disconnect sweep (`onDanglingTurnsSwept`) → deferring here doesn't reintroduce the crash-wedge.
- The defer `continue`s WITHOUT setting `fallbackFired`, so once the tool ends and the turn stays silent past threshold (or the ceiling is crossed) it fires promptly.

## Knobs (gateway env → silence-poke deps)
| env | default | effect |
|---|---|---|
| `SWITCHROOM_SILENCE_DEFER_INFLIGHT_TOOLS` | **off** | enable the defer |
| `SWITCHROOM_SILENCE_FALLBACK_MS` | 300000 | base threshold |
| `SWITCHROOM_SILENCE_FALLBACK_HARD_MS` | 900000 | defer hard ceiling |

Default-OFF so it ships dormant; enable on **marko** and verify against #2162's `turn-lifecycle` / `status-surface DEGRADED` telemetry before fleet.

## Why (JTBD)
Outcome **2 (you hold the leash)** — the live status of long background work must stay visible while it runs.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `silence-poke.test.ts` +6 Fix A cases: legacy-off unchanged at 300s; defer holds at 300s; fires once tool ends + silent; fires at hard ceiling (hung-mid-tool); no-tool turn unaffected; no-ceiling defers indefinitely — **49 green**
- [x] gateway + silence-poke vitest sweep — **216 green**
- [x] lint gates clean (plugin-refs, bun-test-imports, bot-api-wrapping, no-pii, vault-hermeticity, no-broadcast)

## Risk
**Medium** — touches the wedge-recovery path. Mitigated by: default-OFF flag, the bounded hard ceiling, the preserved no-in-flight-tool path, and independent bridge-disconnect crash recovery. **Canary on marko before fleet rollout.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)