### PR TITLE
fix(telegram): route late replies to their origin topic + reply-route telemetry

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4153,7 +4153,11 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
     'tool sequence (scheduling, multi-step research, sub-agent handback), ' +
     'do not let your closing narration stand as the answer: end the turn ' +
     'by passing that narration to the reply tool. No reply tool call = the ' +
-    'user got nothing, however much text you wrote.</turn-pacing>';
+    'user got nothing, however much text you wrote. Call the reply tool as ' +
+    'your FIRST action when you have the answer — do not write it out as ' +
+    'transcript text first and call reply afterward: a framework backstop ' +
+    'flushes unsent text after a delay and then your real reply lands late ' +
+    'and out of order.</turn-pacing>';
   const switchroomUserPromptSubmit: Array<Record<string, unknown>> = [
     ...(useHotReloadStable
       ? [

--- a/telegram-plugin/gateway/answer-thread-resolve.test.ts
+++ b/telegram-plugin/gateway/answer-thread-resolve.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { resolveAnswerThreadId } from './answer-thread-resolve.js'
+
+describe('resolveAnswerThreadId — precedence', () => {
+  it('(1) explicit model thread wins over everything', () => {
+    expect(
+      resolveAnswerThreadId({
+        explicitThreadId: 7,
+        originResolved: true,
+        originThreadId: 3,
+        liveThreadId: 4,
+        lastEndedResolvedForChat: true,
+        lastEndedThreadIdForChat: 9,
+      }),
+    ).toBe(7)
+  })
+
+  it('(2) origin turn thread wins over the live turn (the Brevo→Meta fix)', () => {
+    expect(
+      resolveAnswerThreadId({ originResolved: true, originThreadId: 3, liveThreadId: 4 }),
+    ).toBe(3)
+  })
+
+  it('(2) a DM origin (resolved, thread undefined) pins to undefined, not the live thread', () => {
+    expect(
+      resolveAnswerThreadId({ originResolved: true, originThreadId: undefined, liveThreadId: 4 }),
+    ).toBeUndefined()
+  })
+
+  it('(3) no origin → falls back to the live turn thread (legacy #1664)', () => {
+    expect(
+      resolveAnswerThreadId({ originResolved: false, liveThreadId: 4 }),
+    ).toBe(4)
+  })
+
+  // ── tier (4): late-reply topic recovery (2026-06-05) ──────────────────────
+  it('(4) no explicit, no origin, NO live turn → recovers the most-recent ended turn thread', () => {
+    // The marko bug: a reply that fired after the orphaned-reply backstop ended
+    // its turn. Pre-fix this returned undefined (General); now it recovers topic 3.
+    expect(
+      resolveAnswerThreadId({
+        originResolved: false,
+        liveThreadId: undefined,
+        lastEndedResolvedForChat: true,
+        lastEndedThreadIdForChat: 3,
+      }),
+    ).toBe(3)
+  })
+
+  it('(4) a recovered DM turn (ended, thread undefined) stays threadless', () => {
+    expect(
+      resolveAnswerThreadId({
+        originResolved: false,
+        liveThreadId: undefined,
+        lastEndedResolvedForChat: true,
+        lastEndedThreadIdForChat: undefined,
+      }),
+    ).toBeUndefined()
+  })
+
+  it('(4) recovery does NOT override a live turn — live thread still wins at tier 3', () => {
+    expect(
+      resolveAnswerThreadId({
+        originResolved: false,
+        liveThreadId: 4,
+        lastEndedResolvedForChat: true,
+        lastEndedThreadIdForChat: 3,
+      }),
+    ).toBe(4)
+  })
+
+  it('(4) no recovery candidate → legacy result (undefined), unchanged', () => {
+    expect(
+      resolveAnswerThreadId({
+        originResolved: false,
+        liveThreadId: undefined,
+        lastEndedResolvedForChat: false,
+      }),
+    ).toBeUndefined()
+  })
+
+  it('pure DM (every tier undefined) → undefined', () => {
+    expect(resolveAnswerThreadId({ originResolved: false })).toBeUndefined()
+  })
+})

--- a/telegram-plugin/gateway/answer-thread-resolve.ts
+++ b/telegram-plugin/gateway/answer-thread-resolve.ts
@@ -26,10 +26,14 @@
  *   3. Else the LIVE turn's thread — but ONLY when the live turn IS the
  *      origin turn (no flip happened) OR no origin turn could be resolved
  *      at all (origin id absent/unknown; legacy / pre-stamp path).
- *   4. Else (origin resolved AND it differs from the live turn) we pin to
- *      the origin thread and explicitly DO NOT fall through to the chat's
- *      last-seen `chatThreadMap` thread. For answer surfaces the chat
- *      last-seen heuristic is exactly what produced the wrong-topic bug.
+ *   4. Else (no explicit, no origin echoed, no live turn) — a LATE reply that
+ *      fired after its turn already ended (the orphaned-reply backstop case) —
+ *      recover the origin topic from the most-recently-ended turn for this
+ *      chat. Without this, such a reply defaults to the main chat (General in a
+ *      supergroup) and its answer vanishes from the topic the user is reading
+ *      (the 2026-06-05 marko triage). Still NOT the `chatThreadMap` last-seen
+ *      heuristic — the recovered turn is the chat's own most-recent turn, not
+ *      whichever topic last received any message.
  *
  * The `chatThreadMap` last-seen fallback is preserved for NON-answer
  * surfaces (`send_typing`, `forward_message`, `progress_update`) by NOT
@@ -53,6 +57,20 @@ export interface AnswerThreadInput {
    *  (no live turn, or a DM live turn). The legacy (#1664) fallback when
    *  no origin turn is resolvable. */
   liveThreadId?: number | undefined
+  /**
+   * Late-reply topic recovery (2026-06-05). Thread of the most-recently-ended
+   * turn for THIS chat (from `recentTurnsById`), used as a deterministic
+   * fallback when the model echoed no `origin_turn_id` AND there is no live
+   * turn — the late-reply-after-turn-end case. Without it, a reply that fires
+   * after the orphaned-reply backstop closed its turn defaults to the main chat
+   * (General topic in a supergroup), so its answer vanishes from the topic the
+   * user is reading. Only consulted at tier (4); a DM origin yields undefined,
+   * which is correct.
+   */
+  lastEndedThreadIdForChat?: number | undefined
+  /** Whether a recently-ended turn exists for this chat — distinguishes
+   *  "ended turn exists, DM (thread undefined)" from "no ended turn at all". */
+  lastEndedResolvedForChat?: boolean
 }
 
 /**
@@ -75,5 +93,13 @@ export function resolveAnswerThreadId(input: AnswerThreadInput): number | undefi
   if (input.originResolved) return input.originThreadId
   // (3) no origin resolved (legacy / pre-stamp / evicted) → fall back to
   //     the live turn's thread, the existing turn-pinned behaviour (#1664).
+  if (input.liveThreadId != null) return input.liveThreadId
+  // (4) no explicit, no origin echoed, no live turn — a LATE reply that fired
+  //     after its turn already ended (the orphaned-reply backstop case).
+  //     Recover the origin topic from the most-recently-ended turn for this
+  //     chat so the answer lands in the topic it belongs to instead of
+  //     defaulting to the main chat (General). When no ended turn is known,
+  //     fall through to liveThreadId (undefined) — the legacy result.
+  if (input.lastEndedResolvedForChat) return input.lastEndedThreadIdForChat
   return input.liveThreadId
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1888,6 +1888,83 @@ function findTurnByOriginId(originTurnId: string | null | undefined): CurrentTur
   return recentTurnsById.get(originTurnId) ?? null
 }
 
+// Late-reply topic recovery (2026-06-05 marko triage). Default ON; kill switch
+// SWITCHROOM_LATE_REPLY_TOPIC_RECOVERY=0 restores the legacy behaviour (a late
+// reply with no echoed origin and no live turn defaults to General).
+const LATE_REPLY_TOPIC_RECOVERY_ENABLED =
+  process.env.SWITCHROOM_LATE_REPLY_TOPIC_RECOVERY !== '0'
+
+/**
+ * The most-recently-started turn for a chat from the bounded recently-ended
+ * registry — the deterministic fallback for a LATE answer reply when the model
+ * echoed no `origin_turn_id` and `currentTurn` has already cleared. Iterates in
+ * insertion order so the last match is the most recent turn for that chat.
+ * Returns null when the chat has no remembered turn (so the caller keeps the
+ * legacy result). NB: this is the chat's own most-recent TURN, not the
+ * `chatThreadMap` last-seen-any-message heuristic that caused the wrong-topic
+ * bug — a late reply almost always belongs to the turn that just ended.
+ */
+function findLatestEndedTurnForChat(chatId: string): CurrentTurn | null {
+  let latest: CurrentTurn | null = null
+  for (const t of recentTurnsById.values()) {
+    if (t.sessionChatId === chatId) latest = t
+  }
+  return latest
+}
+
+/**
+ * Resolve the answer-reply thread AND emit `reply-route` telemetry. The
+ * 2026-06-05 triage showed reply routing was the blind spot: `reply: invoked`
+ * logged only chat + char count, so a late reply landing in the wrong topic was
+ * invisible without hand-correlating raw tg-post threads against turn-lifecycle
+ * timestamps. This wrapper logs, per reply: which precedence tier won (`via`),
+ * the resolved thread, the origin turn + its thread, and whether the reply was
+ * late (turn already ended). `via=recovered` marks a late reply this fix saved
+ * from General; `UNROUTED` flags a supergroup reply that still resolved to no
+ * topic (the residual gap to watch).
+ */
+function resolveAnswerThreadWithLog(
+  chatId: string,
+  explicitThreadId: number | undefined,
+  originTurn: CurrentTurn | null,
+  liveTurn: CurrentTurn | null,
+  surface: 'reply' | 'stream_reply',
+): number | undefined {
+  const recovered =
+    LATE_REPLY_TOPIC_RECOVERY_ENABLED &&
+    explicitThreadId == null &&
+    originTurn == null &&
+    liveTurn?.sessionThreadId == null
+      ? findLatestEndedTurnForChat(chatId)
+      : null
+  const threadId = resolveAnswerThreadId({
+    explicitThreadId,
+    originResolved: originTurn != null,
+    originThreadId: originTurn?.sessionThreadId,
+    liveThreadId: liveTurn?.sessionThreadId,
+    lastEndedResolvedForChat: recovered != null,
+    lastEndedThreadIdForChat: recovered?.sessionThreadId,
+  })
+  const via =
+    explicitThreadId != null ? 'explicit'
+    : originTurn != null ? 'origin'
+    : liveTurn?.sessionThreadId != null ? 'live'
+    : recovered != null ? 'recovered'
+    : 'none'
+  const ownerTurn = originTurn ?? recovered ?? liveTurn
+  const isSupergroup = chatId.startsWith('-100')
+  const unrouted = isSupergroup && threadId == null
+  process.stderr.write(
+    `telegram gateway: reply-route surface=${surface} chat=${chatId} ` +
+      `resolved_thread=${threadId ?? '-'} via=${via} late=${liveTurn == null} ` +
+      `originTurn=${ownerTurn?.turnId ?? '-'} origin_thread=${ownerTurn?.sessionThreadId ?? '-'}` +
+      (via === 'recovered' ? ' RECOVERED' : '') +
+      (unrouted ? ' UNROUTED(supergroup→no-topic)' : '') +
+      '\n',
+  )
+  return threadId
+}
+
 /**
  * PR2 obligation-ledger CLOSE. Called when a SUBSTANTIVE final answer lands
  * (not a bare interim ack — using finalAnswerSubstantive, the #2141 signal): the
@@ -6522,12 +6599,13 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   if (TURN_ORIGIN_ROUTING_ENABLED) {
     const explicit = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
     const originTurn = findTurnByOriginId(args.origin_turn_id as string | undefined)
-    threadId = resolveAnswerThreadId({
-      explicitThreadId: Number.isFinite(explicit as number) ? (explicit as number) : undefined,
-      originResolved: originTurn != null,
-      originThreadId: originTurn?.sessionThreadId,
-      liveThreadId: turn?.sessionThreadId,
-    })
+    threadId = resolveAnswerThreadWithLog(
+      chat_id,
+      Number.isFinite(explicit as number) ? (explicit as number) : undefined,
+      originTurn,
+      turn,
+      'reply',
+    )
   } else {
     threadId = resolveThreadId(
       chat_id,
@@ -7178,12 +7256,13 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
     let injected: number | undefined
     if (TURN_ORIGIN_ROUTING_ENABLED) {
       const originTurn = findTurnByOriginId(args.origin_turn_id as string | undefined)
-      injected = resolveAnswerThreadId({
-        explicitThreadId: undefined,
-        originResolved: originTurn != null,
-        originThreadId: originTurn?.sessionThreadId,
-        liveThreadId: turn?.sessionThreadId,
-      })
+      injected = resolveAnswerThreadWithLog(
+        String(args.chat_id),
+        undefined,
+        originTurn,
+        turn,
+        'stream_reply',
+      )
     } else {
       injected = turn?.sessionThreadId
     }

--- a/telegram-plugin/tests/multitopic-routing-wiring.test.ts
+++ b/telegram-plugin/tests/multitopic-routing-wiring.test.ts
@@ -45,13 +45,15 @@ describe('component 3 — turn-origin reply routing', () => {
     const fn = gatewaySrc.split('async function executeReply')[1]?.split('\nasync function ')[0] ?? ''
     expect(fn).toMatch(/TURN_ORIGIN_ROUTING_ENABLED/)
     expect(fn).toMatch(/findTurnByOriginId\(args\.origin_turn_id/)
-    expect(fn).toMatch(/resolveAnswerThreadId\(/)
+    // The resolution + reply-route telemetry go through resolveAnswerThreadWithLog,
+    // which calls the pure resolveAnswerThreadId internally (incl. tier-4 recovery).
+    expect(fn).toMatch(/resolveAnswerThread\w*\(/)
   })
 
   it('executeStreamReply resolves the answer thread via the origin turn too', () => {
     const fn = gatewaySrc.split('async function executeStreamReply')[1]?.split('\nasync function ')[0] ?? ''
     expect(fn).toMatch(/findTurnByOriginId\(args\.origin_turn_id/)
-    expect(fn).toMatch(/resolveAnswerThreadId\(/)
+    expect(fn).toMatch(/resolveAnswerThread\w*\(/)
   })
 
   it('the reply + stream_reply tool schemas expose origin_turn_id to the model', () => {


### PR DESCRIPTION
## Summary
Fixes the **2026-06-05 marko triage**: a reply that fires *after* the orphaned-reply backstop ended its turn lost its topic and landed in **General** — so in a forum supergroup the answer vanished from the topic the user was reading (the "out of order / missing message" symptom). Two late replies from the *same* dead turn routed to *different* topics, because resolution depended on the model echoing `origin_turn_id`, which it does inconsistently.

### Fix B2 — deterministic late-reply topic recovery (the robust fix)
New precedence tier (4) in `resolveAnswerThreadId`: when there's **no explicit thread, no echoed origin, AND no live turn** (`currentTurn` already cleared), recover the origin topic from the **most-recently-ended turn for that chat** (`findLatestEndedTurnForChat` over `recentTurnsById`). Deterministic — no model echo required. It is **not** the `chatThreadMap` last-seen heuristic (that caused the original wrong-topic bug); it's the chat's own most-recent turn, which a late reply almost always belongs to. Wired into **both** answer paths (`executeReply` + `executeStreamReply`). Kill switch: `SWITCHROOM_LATE_REPLY_TOPIC_RECOVERY=0`.

### reply-route telemetry — the blind spot this triage exposed
One line per answer reply: which precedence tier won (`via=explicit|origin|live|recovered|none`), the resolved thread, the origin turn + its thread, and whether the reply was **late** (`currentTurn` null). `via=recovered` marks a late reply this fix saved from General; **`UNROUTED`** flags a supergroup reply that still resolved to no topic (the residual gap to watch). Turns "did this answer land in the right topic?" into one `grep`.

### Fix B1 — best-effort directive reinforcement
The turn-pacing directive already strongly binds "answer"=reply tool; reinforced with the specific failure mode (call reply as the FIRST action; don't write the answer as transcript text then call reply after — the backstop flushes unsent text late and out of order). B1 is fundamentally model behaviour; **B2 makes its effect benign regardless** of whether the backstop still occasionally fires.

## Why (JTBD)
Outcome **2 (you hold the leash)** + **4 (predictable)** — the agent's answer must land in the topic the user asked in, in order.

## Test plan
- [x] `tsc --noEmit` clean
- [x] new `answer-thread-resolve.test.ts` (9): full precedence incl. tier-4 recovery, DM origin, recovery-doesn't-override-live, no-candidate legacy result
- [x] `scaffold.test.ts` (188) green — directive assertion is a substring match
- [x] gateway vitest sweep 176 green; lint gates clean

## Risk
Low/medium — tier 4 only adds a fallback where the old result was `undefined` (General); behind a kill switch; live-turn + origin precedence unchanged. Telemetry is additive. Will be exercised in the MTCute DM + channel UAT for this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)