### PR TITLE
feat(web): Connections dashboard tab — Google + Microsoft + Notion visibility

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -34,6 +34,10 @@ import type { ApprovalDecisionMeta } from "../vault/broker/protocol.js";
 import { captureEvent, captureException } from "../analytics/posthog.js";
 import { resolveAgentsDir } from "../config/loader.js";
 import { resolveAgentConfig } from "../config/merge.js";
+import {
+  agentCanAccessNotionDB,
+  shouldEmitNotionMcp,
+} from "../config/notion-workspace-acl.js";
 import { getAccountInfos, type AccountInfo } from "../auth/account-store.js";
 import {
   AuthBrokerError,
@@ -772,16 +776,27 @@ export interface NotionWorkspaceDashboard {
   vaultKey: string | null;
   /** Declared friendly-name → id databases with their agent grants. */
   databases: NotionDatabaseInfo[];
+  /**
+   * Agents with UNRESTRICTED Notion access (a `notion_workspace:` block
+   * with no `databases` filter → every DB the integration can see). They
+   * also appear in each database's `enabledFor`, but are surfaced here
+   * so the UI can render "full access" once instead of in every row.
+   */
+  fullAccessAgents: string[];
 }
 
 /**
  * Notion workspace view for the dashboard. Unlike Google/Microsoft,
  * Notion has no per-account concept (one operator-owned internal
  * integration token); access is per-DATABASE via each agent's
- * `notion_workspace.databases` friendly-name list. This surfaces the
- * declared databases and, for each, which agents are granted it — the
- * "which agents can reach Notion (and which DBs)" answer. The token
- * itself never leaves the vault and is never returned here.
+ * `notion_workspace.databases` friendly-name list — OR unrestricted when
+ * an agent has a `notion_workspace:` block with no `databases` filter.
+ * This surfaces the declared databases and, for each, which agents are
+ * granted it — the "which agents can reach Notion (and which DBs)"
+ * answer. Per-DB grants are computed via the canonical
+ * `agentCanAccessNotionDB` so the dashboard exactly matches runtime
+ * authorization (including the empty-filter = full-access case). The
+ * token itself never leaves the vault and is never returned here.
  */
 export function handleGetNotionWorkspace(
   config: SwitchroomConfig,
@@ -792,27 +807,41 @@ export function handleGetNotionWorkspace(
     }
   ).notion_workspace;
   if (!nw) {
-    return { configured: false, vaultKey: null, databases: [] };
+    return { configured: false, vaultKey: null, databases: [], fullAccessAgents: [] };
   }
   const declared = nw.databases ?? {};
-  // Index agent grants: agent → set of friendly DB names it may use.
-  const agents = (config.agents ?? {}) as Record<
-    string,
-    { notion_workspace?: { databases?: string[] } }
-  >;
+  const agentNames = Object.keys(config.agents ?? {});
+
   const databases: NotionDatabaseInfo[] = Object.entries(declared)
     .map(([name, id]) => {
-      const enabledFor = Object.entries(agents)
-        .filter(([, a]) => (a.notion_workspace?.databases ?? []).includes(name))
-        .map(([n]) => n)
+      // Canonical ACL — credits both explicit-filter and full-access
+      // (no-filter) agents, exactly as runtime authorization does.
+      const enabledFor = agentNames
+        .filter((n) => agentCanAccessNotionDB(config, n, id))
         .sort();
       return { name, id, enabledFor };
     })
     .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Full-access agents: a notion_workspace block present (gate) with no
+  // databases filter. These reach every DB the integration can see.
+  const agentsRaw = (config.agents ?? {}) as Record<
+    string,
+    { notion_workspace?: { databases?: string[] } }
+  >;
+  const fullAccessAgents = agentNames
+    .filter((n) => {
+      if (!shouldEmitNotionMcp(n, config)) return false;
+      const dbs = agentsRaw[n]?.notion_workspace?.databases;
+      return dbs === undefined || dbs.length === 0;
+    })
+    .sort();
+
   return {
     configured: true,
     vaultKey: nw.vault_key ?? null,
     databases,
+    fullAccessAgents,
   };
 }
 

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -683,6 +683,139 @@ export async function handleGetGoogleAccounts(
   return out;
 }
 
+export interface MicrosoftAccountDashboardInfo {
+  account: string;
+  expiresAt: number | null;
+  scope: string | null;
+  clientId: string | null;
+  /** "personal" (outlook.com/hotmail MSA) or "work" (M365 tenant). */
+  accountType: "personal" | "work" | null;
+  /** Agents allowed to use this account (config ACL). */
+  enabledFor: string[];
+  /** false when the broker couldn't confirm the slot exists. */
+  brokerKnown: boolean;
+}
+
+/**
+ * Microsoft account inventory for the dashboard — mirrors
+ * {@link handleGetGoogleAccounts} (RFC #1873). Unions the config ACL
+ * (`microsoft_accounts.<email>.enabled_for[]`) with the broker's
+ * live credential inventory (`listMicrosoftAccounts`), so an account
+ * present in only one source is still visible. Degrades gracefully when
+ * the broker is unreachable (ACL renders, live fields null).
+ */
+export async function handleGetMicrosoftAccounts(
+  config: SwitchroomConfig,
+): Promise<MicrosoftAccountDashboardInfo[]> {
+  const live = new Map<
+    string,
+    {
+      expiresAt: number;
+      scope: string;
+      clientId: string;
+      accountType: "personal" | "work";
+    }
+  >();
+  try {
+    await withAuthBrokerClient(async (client) => {
+      const data = await client.listMicrosoftAccounts();
+      for (const a of data.accounts) {
+        live.set(a.account.toLowerCase(), {
+          expiresAt: a.expiresAt,
+          scope: a.scope,
+          clientId: a.clientId,
+          accountType: a.accountType,
+        });
+      }
+    });
+  } catch (err) {
+    if (!(err instanceof AuthBrokerUnreachableError)) throw err;
+    // Degraded: ACL still renders from config; live fields stay null.
+  }
+  const cfgAccounts =
+    (config as { microsoft_accounts?: Record<string, { enabled_for?: string[] }> })
+      .microsoft_accounts ?? {};
+  const keys = new Set<string>([
+    ...Object.keys(cfgAccounts).map((k) => k.toLowerCase()),
+    ...live.keys(),
+  ]);
+  const out: MicrosoftAccountDashboardInfo[] = [];
+  for (const key of [...keys].sort()) {
+    const cfg = cfgAccounts[key];
+    const l = live.get(key);
+    out.push({
+      account: key,
+      expiresAt: l?.expiresAt ?? null,
+      scope: l?.scope ?? null,
+      clientId: l?.clientId ?? null,
+      accountType: l?.accountType ?? null,
+      enabledFor: cfg?.enabled_for ? [...cfg.enabled_for].sort() : [],
+      brokerKnown: l != null,
+    });
+  }
+  return out;
+}
+
+export interface NotionDatabaseInfo {
+  /** Friendly name operators/agents reference. */
+  name: string;
+  /** Notion database UUID. */
+  id: string;
+  /** Agents whose notion_workspace.databases grants this DB. */
+  enabledFor: string[];
+}
+
+export interface NotionWorkspaceDashboard {
+  /** True when a top-level notion_workspace block is configured. */
+  configured: boolean;
+  /** Vault key holding the integration token (not the token itself). */
+  vaultKey: string | null;
+  /** Declared friendly-name → id databases with their agent grants. */
+  databases: NotionDatabaseInfo[];
+}
+
+/**
+ * Notion workspace view for the dashboard. Unlike Google/Microsoft,
+ * Notion has no per-account concept (one operator-owned internal
+ * integration token); access is per-DATABASE via each agent's
+ * `notion_workspace.databases` friendly-name list. This surfaces the
+ * declared databases and, for each, which agents are granted it — the
+ * "which agents can reach Notion (and which DBs)" answer. The token
+ * itself never leaves the vault and is never returned here.
+ */
+export function handleGetNotionWorkspace(
+  config: SwitchroomConfig,
+): NotionWorkspaceDashboard {
+  const nw = (
+    config as {
+      notion_workspace?: { vault_key?: string; databases?: Record<string, string> };
+    }
+  ).notion_workspace;
+  if (!nw) {
+    return { configured: false, vaultKey: null, databases: [] };
+  }
+  const declared = nw.databases ?? {};
+  // Index agent grants: agent → set of friendly DB names it may use.
+  const agents = (config.agents ?? {}) as Record<
+    string,
+    { notion_workspace?: { databases?: string[] } }
+  >;
+  const databases: NotionDatabaseInfo[] = Object.entries(declared)
+    .map(([name, id]) => {
+      const enabledFor = Object.entries(agents)
+        .filter(([, a]) => (a.notion_workspace?.databases ?? []).includes(name))
+        .map(([n]) => n)
+        .sort();
+      return { name, id, enabledFor };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return {
+    configured: true,
+    vaultKey: nw.vault_key ?? null,
+    databases,
+  };
+}
+
 /**
  * Cron schedule view: every cascade-resolved schedule entry plus the
  * most-recent fire rows from each agent's host-side `scheduler.jsonl`

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -30,6 +30,8 @@ import {
   handleUseAccount,
   handleGetSystemHealth,
   handleGetGoogleAccounts,
+  handleGetMicrosoftAccounts,
+  handleGetNotionWorkspace,
   handleGetSchedule,
   handleGetApprovals,
 } from "./api.js";
@@ -377,6 +379,16 @@ function parseRoute(
     return { handler: "getGoogleAccounts", params: {} };
   }
 
+  // GET /api/microsoft-accounts
+  if (method === "GET" && pathname === "/api/microsoft-accounts") {
+    return { handler: "getMicrosoftAccounts", params: {} };
+  }
+
+  // GET /api/notion-workspace
+  if (method === "GET" && pathname === "/api/notion-workspace") {
+    return { handler: "getNotionWorkspace", params: {} };
+  }
+
   // GET /api/schedule
   if (method === "GET" && pathname === "/api/schedule") {
     return { handler: "getSchedule", params: {} };
@@ -578,6 +590,13 @@ export function startWebServer(
           case "getGoogleAccounts":
             return (async () =>
               jsonResponse(await handleGetGoogleAccounts(config)))();
+
+          case "getMicrosoftAccounts":
+            return (async () =>
+              jsonResponse(await handleGetMicrosoftAccounts(config)))();
+
+          case "getNotionWorkspace":
+            return jsonResponse(handleGetNotionWorkspace(config));
 
           case "getSchedule":
             return jsonResponse(handleGetSchedule(config));

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -1068,13 +1068,20 @@
           </div>`;
         }).join('');
       }
-      const notionSection = _connectionSection(
-        'Notion' + (notion.configured && notion.vaultKey ? ` <span style="text-transform:none;font-weight:400">· token <code>${escapeHtml(notion.vaultKey)}</code></span>` : ''),
-        notion.configured
-          ? 'Notion configured but no databases declared. Add them under <code>notion_workspace.databases:</code>.'
-          : 'Notion not configured. See <code>docs/notion-integration.md</code>.',
-        notionCards,
-      );
+      const notionTitle = 'Notion' + (notion.configured && notion.vaultKey ? ` <span style="text-transform:none;font-weight:400">· token <code>${escapeHtml(notion.vaultKey)}</code></span>` : '');
+      const fullAccessBanner = (notion.fullAccessAgents && notion.fullAccessAgents.length)
+        ? `<div style="margin:0 0 .6rem;font-size:.85rem;color:var(--text-dim)">Full access (all databases): ${notion.fullAccessAgents.map(escapeHtml).join(', ')}</div>`
+        : '';
+      const notionBody = notionCards
+        ? `<div class="accounts-grid">${notionCards}</div>`
+        : `<div class="loading" style="padding:.8rem">${notion.configured
+            ? 'Notion configured but no databases declared. Add them under <code>notion_workspace.databases:</code>.'
+            : 'Notion not configured. See <code>docs/notion-integration.md</code>.'}</div>`;
+      const notionSection = `
+        <div style="margin-bottom:1.5rem">
+          <h3 style="margin:0 0 .6rem;font-size:.95rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.04em">${notionTitle}</h3>
+          ${fullAccessBanner}${notionBody}
+        </div>`;
 
       container.innerHTML = googleSection + microsoftSection + notionSection;
     }

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -409,7 +409,7 @@
     <button id="tab-agents" onclick="switchTab('agents')">Agents</button>
     <button id="tab-accounts" onclick="switchTab('accounts')">Accounts</button>
     <button id="tab-system" onclick="switchTab('system')">System</button>
-    <button id="tab-google" onclick="switchTab('google')">Google</button>
+    <button id="tab-connections" onclick="switchTab('connections')">Connections</button>
     <button id="tab-schedule" onclick="switchTab('schedule')">Schedule</button>
     <button id="tab-approvals" onclick="switchTab('approvals')">Approvals</button>
   </nav>
@@ -419,7 +419,7 @@
     <div id="agents" style="display:none" class="loading">Loading agents...</div>
     <div id="accounts" style="display:none"></div>
     <div id="system" style="display:none"></div>
-    <div id="google" style="display:none"></div>
+    <div id="connections" style="display:none"></div>
     <div id="schedule" style="display:none"></div>
     <div id="approvals" style="display:none"></div>
   </main>
@@ -493,14 +493,17 @@
       }
     }
 
-    async function fetchGoogleAccounts() {
+    async function fetchConnections() {
       try {
-        const res = await fetch(`${API}/api/google-accounts`, { headers: authHeaders() });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        renderGoogleAccounts(await res.json());
+        const [google, microsoft, notion] = await Promise.all([
+          fetch(`${API}/api/google-accounts`, { headers: authHeaders() }).then(r => r.ok ? r.json() : []),
+          fetch(`${API}/api/microsoft-accounts`, { headers: authHeaders() }).then(r => r.ok ? r.json() : []),
+          fetch(`${API}/api/notion-workspace`, { headers: authHeaders() }).then(r => r.ok ? r.json() : { configured: false, databases: [] }),
+        ]);
+        renderConnections({ google, microsoft, notion });
         clearError();
       } catch (err) {
-        showError(`Failed to fetch Google accounts: ${err.message}`);
+        showError(`Failed to fetch connections: ${err.message}`);
       }
     }
 
@@ -527,7 +530,7 @@
     }
 
     function switchTab(tab) {
-      const tabs = ['summary', 'agents', 'accounts', 'system', 'google', 'schedule', 'approvals'];
+      const tabs = ['summary', 'agents', 'accounts', 'system', 'connections', 'schedule', 'approvals'];
       for (const t of tabs) {
         document.getElementById(`tab-${t}`).classList.toggle('active', tab === t);
         document.getElementById(t).style.display = tab === t ? '' : 'none';
@@ -535,7 +538,7 @@
       if (tab === 'summary') fetchSummary();
       if (tab === 'accounts') fetchAccounts();
       if (tab === 'system') fetchSystemHealth();
-      if (tab === 'google') fetchGoogleAccounts();
+      if (tab === 'connections') fetchConnections();
       if (tab === 'schedule') fetchSchedule();
       if (tab === 'approvals') fetchApprovals();
     }
@@ -988,37 +991,92 @@
       return String(ts).replace('T', ' ').replace(/\.\d+Z?$/, '').replace(/Z$/, '');
     }
 
-    function renderGoogleAccounts(rows) {
-      const container = document.getElementById('google');
-      if (!rows || rows.length === 0) {
-        container.innerHTML = '<div class="loading">No Google accounts. Add one under <code>google_accounts:</code> in switchroom.yaml and run <code>switchroom auth google account add</code>.</div>';
-        return;
-      }
-      const dim = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
-      const cards = rows.map(a => {
-        const expires = a.expiresAt ? formatTimestamp(a.expiresAt) : dim('—');
-        const scope = a.scope ? escapeHtml(a.scope) : dim('broker offline');
-        const known = a.brokerKnown
-          ? '<span class="usage-pill primary">slot present</span>'
-          : '<span style="color:var(--yellow)">config-only (no broker slot)</span>';
-        const acl = (a.enabledFor && a.enabledFor.length)
-          ? a.enabledFor.map(escapeHtml).join(', ')
-          : dim('no agents enabled');
-        return `
-        <div class="account-card">
-          <div class="account-card-header">
-            <div class="account-label">${escapeHtml(a.account)}</div>
-            <span style="margin-left:auto">${known}</span>
-          </div>
-          <div class="account-usage"><label style="color:var(--text-dim);opacity:.7">Enabled for: </label>${acl}</div>
-          <div class="card-meta" style="padding:0">
-            <div class="meta-item"><label>Expires </label><span>${expires}</span></div>
-            <div class="meta-item" title="${a.scope ? escapeHtml(a.scope) : ''}"><label>Scope </label><span>${a.scope ? escapeHtml(a.scope.split(' ').length + ' scope(s)') : dim('—')}</span></div>
-            <div class="meta-item"><label>Client </label><span>${a.clientId ? escapeHtml(a.clientId.slice(0, 16) + '…') : dim('—')}</span></div>
-          </div>
+    const _dimC = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
+
+    // One OAuth-account card (Google or Microsoft — same shape; Microsoft
+    // adds an account-type pill).
+    function renderOAuthAccountCard(a, opts) {
+      const expires = a.expiresAt ? formatTimestamp(a.expiresAt) : _dimC('—');
+      const known = a.brokerKnown
+        ? '<span class="usage-pill primary">slot present</span>'
+        : '<span style="color:var(--yellow)">config-only (no broker slot)</span>';
+      const acl = (a.enabledFor && a.enabledFor.length)
+        ? a.enabledFor.map(escapeHtml).join(', ')
+        : _dimC('no agents enabled');
+      const typePill = (opts && opts.showType && a.accountType)
+        ? `<span class="usage-pill" style="margin-left:.4rem">${escapeHtml(a.accountType)}</span>`
+        : '';
+      return `
+      <div class="account-card">
+        <div class="account-card-header">
+          <div class="account-label">${escapeHtml(a.account)}${typePill}</div>
+          <span style="margin-left:auto">${known}</span>
+        </div>
+        <div class="account-usage"><label style="color:var(--text-dim);opacity:.7">Enabled for: </label>${acl}</div>
+        <div class="card-meta" style="padding:0">
+          <div class="meta-item"><label>Expires </label><span>${expires}</span></div>
+          <div class="meta-item" title="${a.scope ? escapeHtml(a.scope) : ''}"><label>Scope </label><span>${a.scope ? escapeHtml(a.scope.split(' ').length + ' scope(s)') : _dimC('—')}</span></div>
+          <div class="meta-item"><label>Client </label><span>${a.clientId ? escapeHtml(a.clientId.slice(0, 16) + '…') : _dimC('—')}</span></div>
+        </div>
+      </div>`;
+    }
+
+    function _connectionSection(title, emptyHtml, cardsHtml) {
+      return `
+        <div style="margin-bottom:1.5rem">
+          <h3 style="margin:0 0 .6rem;font-size:.95rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.04em">${title}</h3>
+          ${cardsHtml ? `<div class="accounts-grid">${cardsHtml}</div>` : `<div class="loading" style="padding:.8rem">${emptyHtml}</div>`}
         </div>`;
-      }).join('');
-      container.innerHTML = `<div class="accounts-grid">${cards}</div>`;
+    }
+
+    // Unified external-connections view: Google + Microsoft accounts and
+    // the Notion workspace, each showing which agents have access.
+    function renderConnections(data) {
+      const container = document.getElementById('connections');
+      const google = data.google || [];
+      const microsoft = data.microsoft || [];
+      const notion = data.notion || { configured: false, databases: [] };
+
+      const googleSection = _connectionSection(
+        'Google',
+        'No Google accounts. Add one under <code>google_accounts:</code> and run <code>switchroom auth google account add</code>.',
+        google.map(a => renderOAuthAccountCard(a, { showType: false })).join(''),
+      );
+
+      const microsoftSection = _connectionSection(
+        'Microsoft 365',
+        'No Microsoft accounts. Connect one from Telegram with <code>/connect microsoft</code> (admin DM), or <code>switchroom auth microsoft account add</code>.',
+        microsoft.map(a => renderOAuthAccountCard(a, { showType: true })).join(''),
+      );
+
+      let notionCards = '';
+      if (notion.configured) {
+        notionCards = (notion.databases || []).map(db => {
+          const acl = (db.enabledFor && db.enabledFor.length)
+            ? db.enabledFor.map(escapeHtml).join(', ')
+            : _dimC('no agents enabled');
+          return `
+          <div class="account-card">
+            <div class="account-card-header">
+              <div class="account-label">${escapeHtml(db.name)}</div>
+              <span style="margin-left:auto" class="usage-pill">database</span>
+            </div>
+            <div class="account-usage"><label style="color:var(--text-dim);opacity:.7">Enabled for: </label>${acl}</div>
+            <div class="card-meta" style="padding:0">
+              <div class="meta-item"><label>DB id </label><span>${escapeHtml(db.id.slice(0, 12))}…</span></div>
+            </div>
+          </div>`;
+        }).join('');
+      }
+      const notionSection = _connectionSection(
+        'Notion' + (notion.configured && notion.vaultKey ? ` <span style="text-transform:none;font-weight:400">· token <code>${escapeHtml(notion.vaultKey)}</code></span>` : ''),
+        notion.configured
+          ? 'Notion configured but no databases declared. Add them under <code>notion_workspace.databases:</code>.'
+          : 'Notion not configured. See <code>docs/notion-integration.md</code>.',
+        notionCards,
+      );
+
+      container.innerHTML = googleSection + microsoftSection + notionSection;
     }
 
     function renderSchedule(data) {

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -755,12 +755,12 @@ describe("handleGetNotionWorkspace", () => {
       ...mockConfig,
       notion_workspace: {
         vault_key: "notion/integration-token",
-        databases: { crm: "uuid-crm-1234", hr: "uuid-hr-5678" },
+        databases: { crm: "11111111-1111-1111-1111-111111111111", hr: "22222222-2222-2222-2222-222222222222" },
       },
       agents: {
         marko: { notion_workspace: { databases: ["crm"] } },
         clerk: { notion_workspace: { databases: ["crm", "hr"] } },
-        ziggy: {},
+        ziggy: {}, // no notion_workspace block → no access at all
       },
     } as unknown as SwitchroomConfig;
     const out = handleGetNotionWorkspace(cfg);
@@ -769,8 +769,55 @@ describe("handleGetNotionWorkspace", () => {
     const byName = Object.fromEntries(out.databases.map((d) => [d.name, d]));
     expect(byName.crm.enabledFor).toEqual(["clerk", "marko"]);
     expect(byName.hr.enabledFor).toEqual(["clerk"]);
-    // The token itself is never returned — only the vault key reference.
-    expect(JSON.stringify(out)).not.toContain("token-value");
+    // ziggy (no notion_workspace block) reaches nothing.
+    expect(out.fullAccessAgents).toEqual([]);
+  });
+
+  it("credits a no-filter agent (notion_workspace:{}) as full-access on EVERY database", () => {
+    // The bug the reviewer caught: an admin/orchestrator agent with an
+    // empty notion_workspace block has full access per the runtime ACL,
+    // but the naive enabledFor scan missed it.
+    const cfg = {
+      ...mockConfig,
+      notion_workspace: {
+        vault_key: "notion/integration-token",
+        databases: { crm: "11111111-1111-1111-1111-111111111111", hr: "22222222-2222-2222-2222-222222222222" },
+      },
+      agents: {
+        orchestrator: { notion_workspace: {} }, // no databases filter → ALL
+        scoped: { notion_workspace: { databases: ["crm"] } },
+      },
+    } as unknown as SwitchroomConfig;
+    const out = handleGetNotionWorkspace(cfg);
+    const byName = Object.fromEntries(out.databases.map((d) => [d.name, d]));
+    // orchestrator appears on BOTH databases; scoped only on crm.
+    expect(byName.crm.enabledFor).toEqual(["orchestrator", "scoped"]);
+    expect(byName.hr.enabledFor).toEqual(["orchestrator"]);
+    // ...and is surfaced as a full-access agent for the UI.
+    expect(out.fullAccessAgents).toEqual(["orchestrator"]);
+  });
+
+  it("never returns the Notion token, only its vault key reference", () => {
+    const cfg = {
+      ...mockConfig,
+      notion_workspace: {
+        vault_key: "notion/integration-token",
+        databases: { crm: "11111111-1111-1111-1111-111111111111" },
+      },
+      agents: { marko: { notion_workspace: { databases: ["crm"] } } },
+    } as unknown as SwitchroomConfig;
+    const out = handleGetNotionWorkspace(cfg);
+    // The shape exposes vault_key (a reference) but no token field at all.
+    expect(out.vaultKey).toBe("notion/integration-token");
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toMatch(/secret|token["']?\s*:/i);
+    // Only the declared keys exist — no token-bearing field leaked in.
+    expect(Object.keys(out).sort()).toEqual([
+      "configured",
+      "databases",
+      "fullAccessAgents",
+      "vaultKey",
+    ]);
   });
 });
 

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -91,6 +91,8 @@ import {
   handleGetLogs,
   handleGetSystemHealth,
   handleGetGoogleAccounts,
+  handleGetMicrosoftAccounts,
+  handleGetNotionWorkspace,
   handleGetSchedule,
   handleGetAccounts,
   handleUseAccount,
@@ -667,6 +669,108 @@ describe("handleGetGoogleAccounts", () => {
     ]);
     expect(out.find((a) => a.account === "ghost@example.com")!.brokerKnown).toBe(true);
     expect(out.find((a) => a.account === "declared@example.com")!.brokerKnown).toBe(false);
+  });
+});
+
+describe("handleGetMicrosoftAccounts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    brokerImpl.run = null;
+  });
+
+  const cfgWith = (ma: Record<string, { enabled_for: string[] }>) =>
+    ({ ...mockConfig, microsoft_accounts: ma }) as unknown as SwitchroomConfig;
+
+  it("merges broker live data (incl. accountType) with the config ACL", async () => {
+    brokerImpl.run = async (fn) =>
+      (fn as (c: unknown) => Promise<unknown>)({
+        listMicrosoftAccounts: async () => ({
+          accounts: [
+            {
+              account: "lisa@outlook.com",
+              expiresAt: 456,
+              scope: "Mail.ReadWrite Files.ReadWrite.All",
+              clientId: "9dff88fa",
+              accountType: "personal",
+            },
+          ],
+        }),
+      });
+    const out = await handleGetMicrosoftAccounts(
+      cfgWith({ "lisa@outlook.com": { enabled_for: ["marko"] } }),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      account: "lisa@outlook.com",
+      expiresAt: 456,
+      accountType: "personal",
+      enabledFor: ["marko"],
+      brokerKnown: true,
+    });
+  });
+
+  it("degrades to config-only ACL when the broker is unreachable", async () => {
+    brokerImpl.run = null; // throws FakeUnreachable
+    const out = await handleGetMicrosoftAccounts(
+      cfgWith({ "ken@contoso.com": { enabled_for: ["clerk"] } }),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      account: "ken@contoso.com",
+      expiresAt: null,
+      accountType: null,
+      enabledFor: ["clerk"],
+      brokerKnown: false,
+    });
+  });
+
+  it("unions config-declared and broker-only accounts", async () => {
+    brokerImpl.run = async (fn) =>
+      (fn as (c: unknown) => Promise<unknown>)({
+        listMicrosoftAccounts: async () => ({
+          accounts: [
+            { account: "ghost@outlook.com", expiresAt: 1, scope: "s", clientId: "c", accountType: "work" },
+          ],
+        }),
+      });
+    const out = await handleGetMicrosoftAccounts(
+      cfgWith({ "declared@outlook.com": { enabled_for: [] } }),
+    );
+    expect(out.map((a) => a.account).sort()).toEqual([
+      "declared@outlook.com",
+      "ghost@outlook.com",
+    ]);
+  });
+});
+
+describe("handleGetNotionWorkspace", () => {
+  it("reports not-configured when no notion_workspace block", () => {
+    const out = handleGetNotionWorkspace(mockConfig as unknown as SwitchroomConfig);
+    expect(out.configured).toBe(false);
+    expect(out.databases).toEqual([]);
+  });
+
+  it("lists declared databases with per-agent grants (which agents can reach which DB)", () => {
+    const cfg = {
+      ...mockConfig,
+      notion_workspace: {
+        vault_key: "notion/integration-token",
+        databases: { crm: "uuid-crm-1234", hr: "uuid-hr-5678" },
+      },
+      agents: {
+        marko: { notion_workspace: { databases: ["crm"] } },
+        clerk: { notion_workspace: { databases: ["crm", "hr"] } },
+        ziggy: {},
+      },
+    } as unknown as SwitchroomConfig;
+    const out = handleGetNotionWorkspace(cfg);
+    expect(out.configured).toBe(true);
+    expect(out.vaultKey).toBe("notion/integration-token");
+    const byName = Object.fromEntries(out.databases.map((d) => [d.name, d]));
+    expect(byName.crm.enabledFor).toEqual(["clerk", "marko"]);
+    expect(byName.hr.enabledFor).toEqual(["clerk"]);
+    // The token itself is never returned — only the vault key reference.
+    expect(JSON.stringify(out)).not.toContain("token-value");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a unified **Connections** tab to the web dashboard (renamed from the old read-only "Google" tab) showing all three external integrations — Google, Microsoft 365, Notion — and, for each account/database, **which agents have access** (the `enabled_for` ACL). This is the visibility foundation for managing connections from the UI.

## Why

The dashboard could show Google accounts but had **no view of Microsoft or Notion**, and Microsoft is the freshly-shipped integration (the `/connect microsoft` flow) with zero UI. Operators asked to *see and manage* external connections + per-agent access from the management UI. This PR is the read half; the write half (connect / choose-agents) is the follow-up.

## What changed

- **`api.ts`** — `handleGetMicrosoftAccounts` mirrors `handleGetGoogleAccounts`: unions the `microsoft_accounts` config ACL with the broker's `listMicrosoftAccounts` inventory, adds `accountType` (personal/work), degrades to config-only when the broker is unreachable. `handleGetNotionWorkspace`: Notion has no per-account model, so it surfaces the declared `databases` + which agents' `notion_workspace.databases` grant each — the token itself is **never returned**, only its vault-key reference.
- **`server.ts`** — `GET /api/microsoft-accounts` + `GET /api/notion-workspace` via the existing `parseRoute`→switch dispatch.
- **`ui/index.html`** — the Google tab becomes **Connections**, fetching all three endpoints in parallel and rendering Google / Microsoft 365 / Notion sections. OAuth account cards show enabled-for agents, expiry, scope count, client; Microsoft cards add a personal/work pill; Notion shows each database + granted agents. Empty states point at the connect path.

## Read-only

Pure visibility — no write/mutation. Managing access (connect a service, choose which agents) is the follow-up PR (needs the config-write-path decision: direct yaml editor vs hostd).

## Validation

Smoke-tested **live against the running v0.14.67 broker**: the view surfaces the real connected Microsoft account (`ken.thompson@outlook.com.au`, personal, minted by the shipped default app `9dff88fa…`) with `enabledFor: []` — exactly the "connected but not yet wired to an agent" state the view is meant to make visible.

## Test plan

- [x] `tests/web.test.ts` (+6): Microsoft merge / broker-degrade / config∪broker union (mirrors the Google cases) + Notion not-configured / databases-with-per-agent-grants / token-never-leaked.
- [x] `tsc --noEmit` + full lint chain green; UI inline JS parses (`new Function` over each `<script>`).
- [x] Live handler smoke against the real broker.

## Risk

Low. Two new **read-only** GET endpoints mirroring an existing one; the broker calls (`listMicrosoftAccounts`) already shipped (#2088) and degrade gracefully when unreachable. The UI change renames one tab and adds two sections; no other tab touched. Dashboard auth/CSRF unchanged (same bearer/tailnet gate as the existing GETs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)