### PR TITLE
feat(telegram): retire the invisible compose-box draft → testable visible answer lane

### DIFF
--- a/telegram-plugin/answer-stream-flag.ts
+++ b/telegram-plugin/answer-stream-flag.ts
@@ -16,3 +16,22 @@ export function parseVisibleAnswerStreamEnabled(raw: string | undefined): boolea
   const v = raw.trim().toLowerCase()
   return v === '1' || v === 'true' || v === 'on' || v === 'yes'
 }
+
+/**
+ * Draft-answer-lane retirement (2026-06-05). The compose-box draft transport
+ * (`sendMessageDraft`) is invisible to the mtcute UAT harness, so the live
+ * answer-stream surface couldn't be tested. Retired by DEFAULT: the answer lane
+ * now opens a real, observable edit-in-place message instead of the compose-box
+ * draft (and the onMetric silence-liveness reset from #2169 now fires on visible
+ * sends in BOTH DMs and supergroups, not just DM drafts). Kill switch
+ * `SWITCHROOM_DRAFT_ANSWER_LANE=0` (also false/off/no) restores the legacy
+ * invisible draft.
+ *
+ * Returns true when the draft lane is RETIRED (the default — env unset or any
+ * truthy value); false only for an explicit disable of the retirement.
+ */
+export function parseDraftLaneRetiredEnabled(raw: string | undefined): boolean {
+  if (raw == null) return true
+  const v = raw.trim().toLowerCase()
+  return !(v === '0' || v === 'false' || v === 'off' || v === 'no')
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -98,7 +98,7 @@ import * as pendingProgress from '../pending-work-progress.js'
 import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd } from '../silent-end.js'
 import { isFinalAnswerReply, isSubstantiveFinalReply } from '../final-answer-detect.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
-import { parseVisibleAnswerStreamEnabled } from '../answer-stream-flag.js'
+import { parseVisibleAnswerStreamEnabled, parseDraftLaneRetiredEnabled } from '../answer-stream-flag.js'
 import { type SessionEvent } from '../session-tail.js'
 import {
   shouldSuppressToolActivity,
@@ -678,6 +678,14 @@ const AGENT_ADMIN = process.env.SWITCHROOM_AGENT_ADMIN === 'true'
 const bot = new Bot(TOKEN)
 installTgPostLogger(bot)
 
+// Draft-answer-lane retirement (2026-06-05): default RETIRED so the live answer
+// lane uses a real, mtcute-observable message instead of the invisible
+// compose-box draft. Declared HERE (above the boot-probe block) because
+// `sendMessageDraftFn` below reads it — keep it above its first use to avoid a
+// temporal-dead-zone ReferenceError at boot. Kill switch
+// SWITCHROOM_DRAFT_ANSWER_LANE=0 restores the legacy draft.
+const DRAFT_ANSWER_LANE_RETIRED = parseDraftLaneRetiredEnabled(process.env.SWITCHROOM_DRAFT_ANSWER_LANE)
+
 // ─── sendMessageDraft boot probe ──────────────────────────────────────────
 // grammY 1.x exposes all Telegram Bot API methods through bot.api.raw.
 // bot.api.sendMessageDraft (the typed wrapper) takes chat_id as number, but
@@ -695,7 +703,11 @@ const GRAMMY_VERSION: string = (() => {
 const sendMessageDraftFn: (
   (chatId: string, draftId: number, text: string, params?: { message_thread_id?: number; parse_mode?: 'HTML' }) => Promise<unknown>
 ) | undefined =
-  typeof _rawSendMessageDraft === 'function'
+  // When the draft lane is retired (default), force this undefined so BOTH
+  // consumers (the answer-stream config + the stream_reply handler) drop the
+  // draft transport and fall back to visible message transport — the single
+  // chokepoint for the retirement.
+  !DRAFT_ANSWER_LANE_RETIRED && typeof _rawSendMessageDraft === 'function'
     ? (chatId, draftId, text, params) =>
         (_rawSendMessageDraft as (args: Record<string, unknown>) => Promise<unknown>)({
           chat_id: Number(chatId),
@@ -9545,7 +9557,13 @@ function handleSessionEvent(ev: SessionEvent): void {
             // General). With the gate unreachable the only posted message is
             // the canonical reply. (The gate is bypassed for DM draft
             // transport, so DM draft streaming is unaffected.)
-            ...(ANSWER_STREAM_VISIBLE_ENABLED
+            // Draft retired (default) OR visible explicitly on → a real
+            // edit-in-place message (minInitialChars:1, no draft): observable by
+            // the UAT and the onMetric silence-liveness reset fires on visible
+            // sends in DMs AND supergroups. Legacy draft only when the kill
+            // switch re-enables it (DRAFT_ANSWER_LANE_RETIRED=false), which also
+            // restores sendMessageDraftFn above.
+            ...(ANSWER_STREAM_VISIBLE_ENABLED || DRAFT_ANSWER_LANE_RETIRED
               ? { minInitialChars: 1 }
               : { sendMessageDraft: sendMessageDraftFn, minInitialChars: Number.MAX_SAFE_INTEGER }),
             // #1075: route through robustApiCall so flood-wait,
@@ -9835,7 +9853,13 @@ function handleSessionEvent(ev: SessionEvent): void {
         const streamedMsgId = stream.messageId()
         const streamedFinalText = turn.capturedText.join('').trim()
         if (
-          ANSWER_STREAM_VISIBLE_ENABLED
+          // Broadened for draft retirement: a text-only no-reply turn that
+          // streamed a VISIBLE preview must materialize a pinged final answer +
+          // delete the preview. Without this, the retired-default path would
+          // fall into the else-branch retract() and delete the user's only copy
+          // of the answer (a lost-answer bug). The reply-tool branch still hits
+          // retract() → single canonical formatted reply, no flash.
+          (ANSWER_STREAM_VISIBLE_ENABLED || DRAFT_ANSWER_LANE_RETIRED)
           && !turn.replyCalled
           && streamedMsgId != null
           && streamedFinalText.length > 0
@@ -20565,7 +20589,7 @@ void (async () => {
         }
       }
 
-      process.stderr.write(`telegram gateway: answer-stream draft transport=${sendMessageDraftFn != null ? 'available' : 'unavailable'} grammy=${GRAMMY_VERSION}\n`)
+      process.stderr.write(`telegram gateway: answer-stream lane=${DRAFT_ANSWER_LANE_RETIRED ? 'visible(draft-retired)' : (ANSWER_STREAM_VISIBLE_ENABLED ? 'visible' : 'draft')} draftFn=${sendMessageDraftFn != null ? 'available' : 'off'} grammy=${GRAMMY_VERSION}\n`)
       process.stderr.write(`telegram gateway: starting bot polling pid=${process.pid} agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} stateDir=${STATE_DIR} historyEnabled=${HISTORY_ENABLED} streamMode=${process.env.SWITCHROOM_TG_STREAM_MODE ?? 'checklist'}\n`)
       runnerHandle = run(bot, {
         runner: {

--- a/telegram-plugin/tests/answer-stream-flag.test.ts
+++ b/telegram-plugin/tests/answer-stream-flag.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { parseVisibleAnswerStreamEnabled } from '../answer-stream-flag.js'
+import { parseVisibleAnswerStreamEnabled, parseDraftLaneRetiredEnabled } from '../answer-stream-flag.js'
 
 describe('parseVisibleAnswerStreamEnabled — default OFF, opt-in', () => {
   it('defaults OFF when unset', () => {
@@ -22,6 +22,24 @@ describe('parseVisibleAnswerStreamEnabled — default OFF, opt-in', () => {
   it('opts IN only on explicit truthy values (case/space-insensitive)', () => {
     for (const v of ['1', 'true', 'on', 'yes', ' TRUE ', 'On', 'YES']) {
       expect(parseVisibleAnswerStreamEnabled(v)).toBe(true)
+    }
+  })
+})
+
+describe('parseDraftLaneRetiredEnabled — default RETIRED (2026-06-05), kill-switch off', () => {
+  it('defaults to RETIRED (true) when unset — the draft lane is gone by default', () => {
+    expect(parseDraftLaneRetiredEnabled(undefined)).toBe(true)
+  })
+
+  it('stays RETIRED for any non-disable value (including unrecognized)', () => {
+    for (const v of ['1', 'true', 'on', 'yes', '', '   ', 'whatever', 'retired']) {
+      expect(parseDraftLaneRetiredEnabled(v)).toBe(true)
+    }
+  })
+
+  it('restores the legacy draft (false) ONLY on an explicit disable (case/space-insensitive)', () => {
+    for (const v of ['0', 'false', 'off', 'no', ' FALSE ', 'Off', 'NO']) {
+      expect(parseDraftLaneRetiredEnabled(v)).toBe(false)
     }
   })
 })

--- a/telegram-plugin/tests/draft-retirement-wiring.test.ts
+++ b/telegram-plugin/tests/draft-retirement-wiring.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Draft-answer-lane retirement — gateway wiring guards (2026-06-05).
+ *
+ * The retirement switches the live answer lane from the invisible compose-box
+ * draft to a real, mtcute-observable edit-in-place message, default-on. The
+ * design review flagged two ways this silently breaks (gateway IIFE can't be
+ * instantiated in-process, so these are source-level assertions, same pattern as
+ * silence-liveness-wiring.test):
+ *
+ *  PRIMARY: drop sendMessageDraftFn but FORGET to flip minInitialChars to 1 →
+ *  the lane becomes a total no-op (the MAX gate never opens it), losing ALL
+ *  answer-lane status AND the #2169 onMetric silence-liveness reset.
+ *  SECONDARY: flip the lane to visible but FORGET to broaden the
+ *  materialize-as-answer guard → a text-only no-reply turn falls into retract()
+ *  and deletes the user's only copy of the answer (a lost-answer bug).
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const gatewaySrc = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf-8')
+
+describe('draft-retirement wiring', () => {
+  it('sendMessageDraftFn is gated on the retirement (the single chokepoint)', () => {
+    expect(gatewaySrc).toMatch(/!DRAFT_ANSWER_LANE_RETIRED && typeof _rawSendMessageDraft === 'function'/)
+  })
+
+  it('DRAFT_ANSWER_LANE_RETIRED is declared before its first use (no TDZ at boot)', () => {
+    const declIdx = gatewaySrc.indexOf('const DRAFT_ANSWER_LANE_RETIRED =')
+    const firstUseIdx = gatewaySrc.indexOf('!DRAFT_ANSWER_LANE_RETIRED && typeof _rawSendMessageDraft')
+    expect(declIdx).toBeGreaterThan(0)
+    expect(firstUseIdx).toBeGreaterThan(declIdx)
+  })
+
+  it('PRIMARY GUARD: retired lane uses minInitialChars:1 (visible), never the MAX no-op gate', () => {
+    // The config must pick the {minInitialChars:1} branch when retired, so the
+    // lane actually opens a real message. The MAX branch is draft-only (legacy).
+    expect(gatewaySrc).toMatch(/ANSWER_STREAM_VISIBLE_ENABLED \|\| DRAFT_ANSWER_LANE_RETIRED\s*\n?\s*\?\s*\{ minInitialChars: 1 \}/)
+  })
+
+  it('SECONDARY GUARD: the materialize-as-answer guard is broadened in lockstep', () => {
+    // A text-only no-reply turn must materialize (ping + delete preview), not
+    // retract() the answer away.
+    expect(gatewaySrc).toMatch(/\(ANSWER_STREAM_VISIBLE_ENABLED \|\| DRAFT_ANSWER_LANE_RETIRED\)\s*\n?\s*&& !turn\.replyCalled/)
+  })
+
+  it('the #2169 onMetric silence-liveness reset is preserved (fires on visible sends now)', () => {
+    const onMetric = (gatewaySrc.split('onMetric: (metricEv) => {')[1] ?? '').split('\n            },')[0]
+    expect(onMetric).toMatch(/silencePoke\.noteProduction/)
+    expect(onMetric).toMatch(/currentTurn === turn/)
+  })
+})


### PR DESCRIPTION
## Summary
The live answer-stream rendered to the **compose-box draft** (`sendMessageDraft`), which the **mtcute UAT harness cannot observe** — so the live answer surface was untestable (it's why the real-work UAT kept reporting `botMsgs=0`). Per the operator's request, retire it and switch live status to a surface we can **test reliably**.

**Design** (workflow-investigated, hybrid): retire the draft **and** flip the answer lane to a **visible edit-in-place message** (`sendMessage` + `editMessageText`) — fully mtcute-observable. Default RETIRED; kill switch `SWITCHROOM_DRAFT_ANSWER_LANE=0` restores the legacy draft.

### Why not just disable the lane
The #2169 `onMetric → noteProduction` silence-liveness reset is the **only** reset for a long pure-compose DM turn (no tools, no reply yet). Disabling the lane — or dropping the draft without flipping `minInitialChars` to 1 — would lose that reset → a 300s false "still working" nudge over a composing agent (a **#2169 regression**). Switching to visible **preserves** the reset and **broadens** it from DM-only to DM+supergroup (supergroups had zero answer-lane reset before).

### Changes (single chokepoint + paired flips, all behind the kill switch)
- `answer-stream-flag.ts`: `parseDraftLaneRetiredEnabled` (default true).
- `gateway.ts`: `DRAFT_ANSWER_LANE_RETIRED` hoisted above the draft probe (no TDZ); `sendMessageDraftFn` gated off when retired (drops the draft from **both** the answer-stream config and the `:7437` `stream_reply` consumer — which already falls back to message transport when the draft API is absent, as in channels); answer-stream config → `{minInitialChars:1}` (visible) when retired; the **materialize-as-answer guard broadened in lockstep** (else a text-only no-reply turn would `retract()` + delete the user's only answer copy); boot log clarified.

### Flash
Bounded by model behavior: on the common think→tool→reply turn the model emits ~zero interstitial text past the 150ms preamble window, so the visible lane **never opens** (no flash); reply-tool turns retract the preview and the single formatted reply is canonical; the only fresh-send+delete is the one-shot beat-5 ping on text-only no-reply turns (the same path that already ran in visible mode).

## Test plan
- [x] `tsc` clean; `parseDraftLaneRetiredEnabled` unit tests (6)
- [x] **wiring guards (5)** pin the PRIMARY (must flip `minInitialChars:1`), SECONDARY (materialize lockstep), TDZ-order, and onMetric-preserved risks the design flagged
- [x] answer-stream + silence-poke + silence-liveness-wiring regression (91) green; lint clean
- [ ] post-deploy canary (**DM + supergroup**): `visible-answer-stream-dm` passes with **no env override** (visible is now default); `jtbd-fast-trivial-dm` shows no streamed-then-deleted preliminary (no per-turn flash); a long pure-prose turn doesn't trip the 300s fallback (onMetric reset survived); kill-switch verified.

## Risk
Medium-low, fully kill-switched (env var + restart, no image rebuild for the flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)