### PR TITLE
test(uat): multi-topic + cross-surface ordering stress + UNROUTED telemetry false-alarm fix

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1932,8 +1932,10 @@ function findLatestEndedTurnForChat(chatId: string): CurrentTurn | null {
  * timestamps. This wrapper logs, per reply: which precedence tier won (`via`),
  * the resolved thread, the origin turn + its thread, and whether the reply was
  * late (turn already ended). `via=recovered` marks a late reply this fix saved
- * from General; `UNROUTED` flags a supergroup reply that still resolved to no
- * topic (the residual gap to watch).
+ * from General; `UNROUTED` flags a supergroup reply that resolved to no topic
+ * with NO owner turn to attribute it to (genuinely lost — the residual gap to
+ * watch). A General-topic turn legitimately has no thread, so its replies are
+ * NOT flagged.
  */
 function resolveAnswerThreadWithLog(
   chatId: string,
@@ -1971,7 +1973,12 @@ function resolveAnswerThreadWithLog(
     : 'none'
   const ownerTurn = originTurn ?? recovered ?? liveTurn
   const isSupergroup = chatId.startsWith('-100')
-  const unrouted = isSupergroup && threadId == null
+  // UNROUTED = a supergroup reply that resolved to NO topic with NO owner turn
+  // to attribute it to (genuinely lost). A General-topic turn legitimately has
+  // no thread, so a reply owned by it resolving to `-` is CORRECT, not lost —
+  // gate on `ownerTurn == null` so General replies don't false-alarm (found by
+  // the multi-topic UAT stress, 2026-06-05).
+  const unrouted = isSupergroup && threadId == null && ownerTurn == null
   process.stderr.write(
     `telegram gateway: reply-route surface=${surface} chat=${chatId} ` +
       `resolved_thread=${threadId ?? '-'} via=${via} late=${liveTurn == null} ` +

--- a/telegram-plugin/uat/scenarios/fuzz-cross-surface-ordering-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/fuzz-cross-surface-ordering-channel.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Cross-surface ordering stress — a DM question and a supergroup question
+ * back-to-back, assert each answer lands in ITS OWN surface (DM answer in the
+ * DM, channel answer in the channel) with no cross-contamination.
+ *
+ * One Claude CLI serves both the DM and the supergroup through a singleton
+ * currentTurn; a late or mis-attributed reply can leak across surfaces (a DM
+ * answer posted into the channel, or vice versa) — the cross-surface twin of
+ * the multi-topic bleed. This is the "handling messages in multiple channels"
+ * concern at the DM-vs-channel axis. Self-skips green without a resolvable
+ * SWITCHROOM_UAT_CHAT_ID supergroup (uat/** is non-gating).
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { spinUp, type Scenario } from "../harness.js";
+import { isWorkerFeedMessage, isActivityFeedMessage } from "../assertions.js";
+import type { ObservedMessage } from "../driver.js";
+
+const SUPERGROUP_ID = Number.parseInt(process.env.SWITCHROOM_UAT_CHAT_ID ?? "", 10);
+
+interface Hit { chatId: number; text: string; messageId: number; }
+
+function isAnswer(m: ObservedMessage, driverUserId: number): boolean {
+  return m.senderUserId !== driverUserId && !m.edited
+    && !isWorkerFeedMessage(m) && !isActivityFeedMessage(m) && m.text.trim().length > 0;
+}
+
+describe("uat: cross-surface ordering — DM Q + channel Q, no surface bleed", () => {
+  let sc: Scenario | null = null;
+  let postable = false;
+
+  beforeAll(async () => {
+    if (!Number.isFinite(SUPERGROUP_ID)) {
+      console.warn("[uat] SWITCHROOM_UAT_CHAT_ID unset — skipping cross-surface ordering");
+      return;
+    }
+    sc = await spinUp({ agent: "test-harness" });
+    await sc.driver.primeDialogs();
+    postable = await sc.driver.canResolve(SUPERGROUP_ID);
+    if (!postable) console.warn(`[uat] supergroup ${SUPERGROUP_ID} not resolvable — skipping`);
+  });
+
+  it("DM answer stays in the DM and channel answer stays in the channel (no leak)", async () => {
+    if (sc == null || !postable) return; // self-skip green
+    const { driver, driverUserId, botUserId } = sc;
+    await driver.primeDialogs();
+
+    const dmIter = driver.observeMessages(botUserId)[Symbol.asyncIterator]();
+    const sgIter = driver.observeMessages(SUPERGROUP_ID)[Symbol.asyncIterator]();
+
+    // Distinct answers per surface: DM → 14, channel → 42.
+    await driver.sendText(botUserId, "Reply with only the number and nothing else: what is 7 + 7?");
+    await driver.sendText(SUPERGROUP_ID, "Reply with only the number and nothing else: what is 40 + 2?");
+
+    let dmHit: Hit | undefined;
+    let sgHit: Hit | undefined;
+    const strays: Hit[] = []; // an expected-answer token observed in the WRONG surface
+
+    const deadline = Date.now() + 120_000;
+    const pump = async (iter: AsyncIterator<ObservedMessage>, chatId: number) => {
+      while (Date.now() < deadline && !(dmHit && sgHit)) {
+        const next = await Promise.race([
+          iter.next(),
+          new Promise<{ done: true; value: undefined }>((r) =>
+            setTimeout(() => r({ done: true, value: undefined }), Math.max(0, deadline - Date.now())),
+          ),
+        ]);
+        if (next.done || next.value == null) break;
+        const m = next.value as ObservedMessage;
+        if (!isAnswer(m, driverUserId)) continue;
+        const hit: Hit = { chatId: m.chatId, text: m.text, messageId: m.messageId };
+        const has14 = /(^|\D)14(\D|$)/.test(m.text);
+        const has42 = /(^|\D)42(\D|$)/.test(m.text);
+        if (chatId === botUserId) {
+          if (has14 && dmHit == null) dmHit = hit;
+          if (has42) strays.push(hit); // channel answer leaked into the DM
+        } else {
+          if (has42 && sgHit == null) sgHit = hit;
+          if (has14) strays.push(hit); // DM answer leaked into the channel
+        }
+      }
+    };
+    await Promise.all([pump(dmIter, botUserId), pump(sgIter, SUPERGROUP_ID)]);
+    void dmIter.return?.();
+    void sgIter.return?.();
+
+    console.log(
+      `[cross-surface] dm(7+7=14)=${dmHit ? `msg=${dmHit.messageId}` : "MISSING"} ` +
+        `channel(40+2=42)=${sgHit ? `msg=${sgHit.messageId}` : "MISSING"} strays=${strays.length}`,
+    );
+
+    // Invariant 1: both answered.
+    expect(dmHit, "DM question (7+7=14) was never answered in the DM").toBeDefined();
+    expect(sgHit, "channel question (40+2=42) was never answered in the channel").toBeDefined();
+    // Invariant 2: no answer leaked to the wrong surface.
+    expect(strays, `an answer leaked across surfaces: ${JSON.stringify(strays)}`).toHaveLength(0);
+    // Invariant 3 (belt+braces): the right answer is in the right chat.
+    expect(dmHit!.chatId).toBe(botUserId);
+    expect(sgHit!.chatId).toBe(SUPERGROUP_ID);
+  }, 150_000);
+});

--- a/telegram-plugin/uat/scenarios/fuzz-multitopic-routing-channel.test.ts
+++ b/telegram-plugin/uat/scenarios/fuzz-multitopic-routing-channel.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Multi-topic routing stress (channel) — two questions in TWO forum topics
+ * back-to-back, assert each answer lands in ITS OWN topic with no cross-bleed.
+ *
+ * This exercises live the failure class behind #2137 ("two questions in two
+ * forum topics → both answers in one topic, the other unanswered") and the
+ * #2166 late-reply topic recovery — the exact "handling messages in multiple
+ * channels" concern. One Claude CLI owns every topic via a singleton
+ * currentTurn, so a late/misrouted reply can land in the wrong topic.
+ *
+ * The test supergroup has General (message_thread_id omitted → observed
+ * threadId undefined) plus a real topic (thread=5). mtcute sends into a topic
+ * via messageThreadId→replyTo and reads each observed message's threadId, so we
+ * can prove WHICH topic each answer landed in. Self-skips green without
+ * SWITCHROOM_UAT_CHAT_ID or an unresolvable supergroup (uat/** is non-gating).
+ *
+ * mtcute caveat: it can't enumerate topics, so the topic id is pinned (5, the
+ * active non-General topic in the test supergroup). If that topic is ever
+ * deleted the send 400s and the test skips with a clear message.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { spinUp, type Scenario } from "../harness.js";
+import { isWorkerFeedMessage, isActivityFeedMessage } from "../assertions.js";
+import type { ObservedMessage } from "../driver.js";
+
+const SUPERGROUP_ID = Number.parseInt(process.env.SWITCHROOM_UAT_CHAT_ID ?? "", 10);
+const TOPIC_THREAD = 5; // a real non-General topic in the test supergroup
+
+interface Hit {
+  text: string;
+  threadId: number | undefined;
+  messageId: number;
+  at: number;
+}
+
+describe("uat: multi-topic routing — two topics back-to-back, no answer bleed", () => {
+  let sc: Scenario | null = null;
+  let postable = false;
+
+  beforeAll(async () => {
+    if (!Number.isFinite(SUPERGROUP_ID)) {
+      console.warn("[uat] SWITCHROOM_UAT_CHAT_ID unset — skipping multi-topic routing");
+      return;
+    }
+    sc = await spinUp({ agent: "test-harness" });
+    await sc.driver.primeDialogs();
+    postable = await sc.driver.canResolve(SUPERGROUP_ID);
+    if (!postable) console.warn(`[uat] supergroup ${SUPERGROUP_ID} not resolvable — skipping`);
+  });
+
+  it("topic-5 Q and General Q are each answered IN THEIR OWN topic (no swap, no drop)", async () => {
+    if (sc == null || !postable) return; // self-skip green
+    const driver = sc.driver;
+    const driverUserId = sc.driverUserId;
+    await driver.primeDialogs();
+
+    // Distinct, unambiguous answers so we can tell the two replies apart by
+    // content and check the topic each landed in. 7+7=14 (topic 5), 40+2=42
+    // (General) — no digit overlap, no accidental substring match.
+    const iter = driver.observeMessages(SUPERGROUP_ID)[Symbol.asyncIterator]();
+    let topic5: Hit | undefined;
+    let general: Hit | undefined;
+
+    try {
+      await driver.sendText(
+        SUPERGROUP_ID,
+        "Reply with only the number and nothing else: what is 7 + 7?",
+        { messageThreadId: TOPIC_THREAD },
+      );
+    } catch (err) {
+      console.warn(`[uat] could not post to topic ${TOPIC_THREAD} (${(err as Error).message}) — skipping`);
+      return;
+    }
+    // Back-to-back (the #2137 bleed trigger): General question immediately after.
+    await driver.sendText(
+      SUPERGROUP_ID,
+      "Reply with only the number and nothing else: what is 40 + 2?",
+    );
+
+    const deadline = Date.now() + 120_000;
+    while (Date.now() < deadline && !(topic5 && general)) {
+      const next = await Promise.race([
+        iter.next(),
+        new Promise<{ done: true; value: undefined }>((r) =>
+          setTimeout(() => r({ done: true, value: undefined }), Math.max(0, deadline - Date.now())),
+        ),
+      ]);
+      if (next.done || next.value == null) break;
+      const m = next.value as ObservedMessage;
+      if (m.senderUserId === driverUserId) continue; // our own sends
+      if (isWorkerFeedMessage(m) || isActivityFeedMessage(m)) continue; // status surfaces, not answers
+      const hit: Hit = { text: m.text, threadId: m.threadId, messageId: m.messageId, at: Date.now() };
+      if (topic5 == null && /(^|\D)14(\D|$)/.test(m.text)) topic5 = hit;
+      if (general == null && /(^|\D)42(\D|$)/.test(m.text)) general = hit;
+    }
+    void iter.return?.();
+
+    console.log(
+      `[multitopic] topic5(7+7=14)=${topic5 ? `thread=${topic5.threadId ?? "-"} msg=${topic5.messageId}` : "MISSING"} ` +
+        `general(40+2=42)=${general ? `thread=${general.threadId ?? "-"} msg=${general.messageId}` : "MISSING"}`,
+    );
+
+    // Invariant 1: BOTH questions were answered (no drop — the #2137 "other
+    // topic unanswered" half).
+    expect(topic5, "topic-5 question (7+7=14) was never answered").toBeDefined();
+    expect(general, "General question (40+2=42) was never answered").toBeDefined();
+
+    // Invariant 2: each answer landed in ITS OWN topic (no bleed/swap). The
+    // topic-5 answer carries threadId=5; the General answer omits the thread.
+    expect(topic5!.threadId).toBe(TOPIC_THREAD);
+    expect(general!.threadId).toBeUndefined();
+  }, 150_000);
+
+  it("a SLOW topic-5 turn whose answer lands LATE (after a fast General turn) still routes to topic-5", async () => {
+    if (sc == null || !postable) return; // self-skip green
+    const { driver, driverUserId } = sc;
+    await driver.primeDialogs();
+
+    // The #2137 trigger: topic-5 turn is still working when General's turn
+    // arrives, so the singleton currentTurn flips to General. The slow topic-5
+    // answer then lands AFTER General's — it must STILL route to topic-5 (via
+    // origin_turn_id / the #2166 late-reply recovery), not bleed into General.
+    const iter = driver.observeMessages(SUPERGROUP_ID)[Symbol.asyncIterator]();
+    let slowHit: Hit | undefined; // topic-5, distinctive token
+    let fastHit: Hit | undefined; // General, the number 42
+
+    try {
+      await driver.sendText(
+        SUPERGROUP_ID,
+        "Do this slowly, ONE step at a time with a brief note on each (I want to see you work): run uname -a, then nproc, " +
+          "then lscpu, then cat /proc/cpuinfo | grep -c processor, then free -h, then df -h. After all six, tell me how many " +
+          "CPU cores this machine has and end your reply with the exact token CORESDONE on its own line.",
+        { messageThreadId: TOPIC_THREAD },
+      );
+    } catch (err) {
+      console.warn(`[uat] could not post to topic ${TOPIC_THREAD} (${(err as Error).message}) — skipping`);
+      return;
+    }
+    // Let the slow turn get underway, then fire the fast General question while
+    // it's still working. Use an unusual WORD token (not a number) so the slow
+    // turn's tool output (which prints numbers like "42Gi") can't false-match.
+    await new Promise((r) => setTimeout(r, 3000));
+    await driver.sendText(SUPERGROUP_ID, "Reply with only this exact word and nothing else: ZUCCHINI.");
+
+    const deadline = Date.now() + 130_000;
+    while (Date.now() < deadline && !(slowHit && fastHit)) {
+      const next = await Promise.race([
+        iter.next(),
+        new Promise<{ done: true; value: undefined }>((r) =>
+          setTimeout(() => r({ done: true, value: undefined }), Math.max(0, deadline - Date.now())),
+        ),
+      ]);
+      if (next.done || next.value == null) break;
+      const m = next.value as ObservedMessage;
+      if (m.senderUserId === driverUserId) continue;
+      if (isWorkerFeedMessage(m) || isActivityFeedMessage(m)) continue;
+      const hit: Hit = { text: m.text, threadId: m.threadId, messageId: m.messageId, at: Date.now() };
+      if (slowHit == null && /CORESDONE/i.test(m.text)) slowHit = hit;
+      if (fastHit == null && /ZUCCHINI/i.test(m.text)) fastHit = hit;
+    }
+    void iter.return?.();
+
+    console.log(
+      `[multitopic-late] slow(CORESDONE)=${slowHit ? `thread=${slowHit.threadId ?? "-"} msg=${slowHit.messageId}` : "MISSING"} ` +
+        `fast(ZUCCHINI)=${fastHit ? `thread=${fastHit.threadId ?? "-"} msg=${fastHit.messageId}` : "MISSING"} ` +
+        `slowArrivedAfterFast=${slowHit && fastHit ? slowHit.at > fastHit.at : "n/a"}`,
+    );
+
+    expect(slowHit, "slow topic-5 answer (CORESDONE) never arrived").toBeDefined();
+    expect(fastHit, "fast General answer (42) never arrived").toBeDefined();
+    // Honest about whether the LATE-after-flip stress was actually exercised:
+    // it only is if the slow topic-5 answer landed AFTER the fast General one.
+    if (slowHit!.at <= fastHit!.at) {
+      console.warn(
+        "[multitopic-late] topic-5 answered BEFORE General — the late-after-flip case " +
+          "was not exercised this run (routing still asserted below).",
+      );
+    }
+    // The crux: the slow answer routed to topic-5, NOT bled into General — and
+    // this holds whether or not it arrived late (the stronger claim is when late).
+    expect(slowHit!.threadId).toBe(TOPIC_THREAD);
+    expect(fastHit!.threadId).toBeUndefined();
+  }, 160_000);
+});


### PR DESCRIPTION
## Summary
Stress coverage for **message ordering / status placement / multiple channels**, using the test supergroup's General topic + a real topic (`thread=5`). The driver sends into a topic via `messageThreadId`→`replyTo` and reads each observed message's `threadId`, so *which* topic each answer landed in is provable.

### New scenarios (non-gating, self-skip green without a resolvable supergroup)
- **`fuzz-multitopic-routing-channel`** — two questions in two forum topics back-to-back (the #2137 bleed shape): each answer must land in **its own topic**, no swap/drop. Plus a **slow-topic-5 + fast-General** variant where the slow answer lands **late** (after `currentTurn` flipped) and must still route to topic-5 (#2166 late-reply recovery).
- **`fuzz-cross-surface-ordering-channel`** — a DM question + a channel question back-to-back: neither answer may leak across surfaces (singleton-`currentTurn` cross-contamination).

**All pass live on test-harness @ v0.14.68** — routing is correct in the simple, late-after-flip, and cross-surface cases.

### Telemetry fix found *by* this stress
The `reply-route` `UNROUTED(supergroup→no-topic)` flag fired on **every legitimate General-topic reply** (a General turn correctly resolves to no thread — `thread=-` is right for General). It now gates on **`ownerTurn == null`** — fires only when a supergroup reply resolved to no topic with **no owner turn** to attribute it to (genuinely lost). General replies no longer false-alarm, so the flag is useful for catching real bleeds again.

> Note: the stress *initially* flagged a "bleed", which turned out to be my test's `/42/` regex matching `~42Gi` in the slow turn's `free -h` tool output — the real General answer routed to General correctly. Fixed with an unambiguous word token (`ZUCCHINI`). Good reminder that answer-tokens must not collide with tool output.

## Test plan
- [x] `tsc` clean; `answer-thread-resolve` + `multitopic-routing-wiring` (26) green; lint clean
- [x] 3 stress scenarios pass live on test-harness @ v0.14.68

🤖 Generated with [Claude Code](https://claude.com/claude-code)