### PR TITLE
fix(telegram): deterministic answer-routing — prove the core, recover origin without the model echo

### DIFF
--- a/telegram-plugin/gateway/answer-thread-resolve.test.ts
+++ b/telegram-plugin/gateway/answer-thread-resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveAnswerThreadId } from './answer-thread-resolve.js'
+import { resolveAnswerThreadId, type AnswerThreadInput } from './answer-thread-resolve.js'
 
 describe('resolveAnswerThreadId — precedence', () => {
   it('(1) explicit model thread wins over everything', () => {
@@ -81,5 +81,139 @@ describe('resolveAnswerThreadId — precedence', () => {
 
   it('pure DM (every tier undefined) → undefined', () => {
     expect(resolveAnswerThreadId({ originResolved: false })).toBeUndefined()
+  })
+})
+
+// ── TOTAL-ENUMERATION DETERMINISM PROOF ─────────────────────────────────────
+//
+// The operator standard (memory feedback_prove_finite_fsm_not_sample): a
+// passing sample is not a proof. `resolveAnswerThreadId` is a PURE decision
+// function over a FINITE input space — so we can prove its determinism by
+// CONSTRUCTION: enumerate every reachable input and assert totality,
+// determinism, no-fabrication, and the precedence the doc-comment promises.
+// Any future edit that perturbs the decision table on ANY of the 64 inputs
+// fails here — this block is the regression guard, the 9 examples above are
+// the human-readable map.
+//
+// Distinct symbolic thread ids so an output's provenance is unambiguous (no
+// two tiers share a value): explicit=70, origin=50, live=30, lastEnded=90.
+const T = 70 // explicit (tier 1)
+const O = 50 // origin   (tier 2)
+const L = 30 // live     (tier 3)
+const E = 90 // lastEnded(tier 4)
+
+function allInputs(): AnswerThreadInput[] {
+  const rows: AnswerThreadInput[] = []
+  for (const explicitThreadId of [undefined, T])
+    for (const originResolved of [false, true])
+      for (const originThreadId of [undefined, O])
+        for (const liveThreadId of [undefined, L])
+          for (const lastEndedResolvedForChat of [false, true])
+            for (const lastEndedThreadIdForChat of [undefined, E])
+              rows.push({
+                explicitThreadId,
+                originResolved,
+                originThreadId,
+                lastEndedResolvedForChat,
+                lastEndedThreadIdForChat,
+                liveThreadId,
+              })
+  return rows
+}
+
+// Independent reference encoding the documented precedence (the SPEC), kept
+// deliberately separate from the implementation so a regression in either
+// surfaces as a divergence rather than a silently-shared bug.
+function specExpected(i: AnswerThreadInput): number | undefined {
+  if (i.explicitThreadId != null) return i.explicitThreadId // tier 1
+  if (i.originResolved) return i.originThreadId // tier 2 (may be undefined: DM origin)
+  if (i.liveThreadId != null) return i.liveThreadId // tier 3
+  if (i.lastEndedResolvedForChat) return i.lastEndedThreadIdForChat // tier 4
+  return i.liveThreadId // catch-all (undefined here)
+}
+
+describe('resolveAnswerThreadId — total-enumeration determinism proof (all 64 inputs)', () => {
+  const ROWS = allInputs()
+
+  it('the input space is exactly 64 rows (2^6)', () => {
+    expect(ROWS.length).toBe(64)
+  })
+
+  it('TOTAL: every input returns without throwing', () => {
+    for (const i of ROWS) {
+      expect(() => resolveAnswerThreadId(i)).not.toThrow()
+    }
+  })
+
+  it('DETERMINISTIC: each input maps to exactly one output (idempotent across repeated calls)', () => {
+    for (const i of ROWS) {
+      const a = resolveAnswerThreadId(i)
+      const b = resolveAnswerThreadId({ ...i })
+      expect(b).toBe(a)
+    }
+  })
+
+  it('NO FABRICATION: every output is undefined or one of the four input thread fields', () => {
+    for (const i of ROWS) {
+      const out = resolveAnswerThreadId(i)
+      const provenance = new Set([
+        undefined,
+        i.explicitThreadId,
+        i.originThreadId,
+        i.liveThreadId,
+        i.lastEndedThreadIdForChat,
+      ])
+      expect(provenance.has(out)).toBe(true)
+    }
+  })
+
+  it('PRECEDENCE: matches the documented spec on all 64 inputs', () => {
+    for (const i of ROWS) {
+      expect(resolveAnswerThreadId(i)).toBe(specExpected(i))
+    }
+  })
+
+  // ── By-construction invariants: the output depends ONLY on the highest
+  //    RESOLVED tier, so no lower-tier input (notably a flipped live turn)
+  //    can perturb a higher tier's decision. These are the routing guarantees
+  //    the resolver exists to provide. ─────────────────────────────────────
+
+  it('INV-1 explicit DOMINANCE: explicit set ⇒ output === explicit, independent of all other fields', () => {
+    for (const i of ROWS) {
+      if (i.explicitThreadId != null) expect(resolveAnswerThreadId(i)).toBe(i.explicitThreadId)
+    }
+  })
+
+  it('INV-2 origin FLIP-IMMUNITY: no explicit + originResolved ⇒ output === originThreadId, for EVERY liveThreadId/lastEnded combo (the Brevo→Meta fix: a currentTurn flip cannot steal a resolved origin)', () => {
+    for (const i of ROWS) {
+      if (i.explicitThreadId == null && i.originResolved) {
+        expect(resolveAnswerThreadId(i)).toBe(i.originThreadId)
+      }
+    }
+  })
+
+  it('INV-3 recovery REACHABILITY: tier-4 (lastEnded) result occurs ONLY when no explicit, no origin, no live turn', () => {
+    for (const i of ROWS) {
+      const out = resolveAnswerThreadId(i)
+      // If the result came from the lastEnded field (and that field is the
+      // only one carrying that distinct value E), the three higher tiers must
+      // all be absent.
+      if (out === E) {
+        expect(i.explicitThreadId).toBeUndefined()
+        expect(i.originResolved).toBe(false)
+        expect(i.liveThreadId).toBeUndefined()
+        expect(i.lastEndedResolvedForChat).toBe(true)
+      }
+    }
+  })
+
+  it('INV-4 live-tier REACHABILITY: tier-3 (live) result occurs ONLY when no explicit and no resolved origin', () => {
+    for (const i of ROWS) {
+      const out = resolveAnswerThreadId(i)
+      if (out === L) {
+        expect(i.explicitThreadId).toBeUndefined()
+        expect(i.originResolved).toBe(false)
+      }
+    }
   })
 })

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1549,6 +1549,18 @@ const SERIALIZE_NOREPLY_DRAIN_MS =
 // behaviour (#1664: thread from the live currentTurn capture).
 const TURN_ORIGIN_ROUTING_ENABLED =
   process.env.SWITCHROOM_TURN_ORIGIN_ROUTING !== '0'
+// Framework-owned origin recovery (2026-06-05 determinism pass). The origin
+// signal that survives a currentTurn flip (tier 2) travels through the MODEL
+// (it echoes `origin_turn_id`). When the model OMITS it, routing falls to the
+// live turn — the wrong topic if currentTurn flipped (HOLE a). The model rarely
+// passes `reply_to` explicitly, but WHEN it quotes a specific earlier message
+// that message_id is a FRAMEWORK-owned anchor: reverse-index it to the turn
+// that owns it and recover the origin without the model echo. Strictly
+// additive — it only fires when the echo is absent AND a quote is present, and
+// resolves to the ACTUAL origin turn (never the live successor), so it cannot
+// mask a misroute. Kill switch off (=0) → echo-only origin (today's behaviour).
+const FRAMEWORK_ORIGIN_ROUTING_ENABLED =
+  process.env.SWITCHROOM_FRAMEWORK_ORIGIN_ROUTING !== '0'
 // Component 4 (per-turn topic framing). Add a one-line directive to the
 // channel meta + bridge instructions telling the model to answer ONLY the
 // current message's topic. Kill switch off (=0) → no framing field.
@@ -1858,13 +1870,56 @@ let currentTurn: CurrentTurn | null = null
 // a long-lived supergroup session.
 const RECENT_TURNS_MAX = 32
 const recentTurnsById = new Map<string, CurrentTurn>()
+// Framework-owned origin recovery: reverse-index from an inbound's source
+// message_id to the turnId that owns it, so a reply that QUOTES a specific
+// message (args.reply_to) resolves its origin turn deterministically — a
+// real message_id the framework stamped, never a model-asserted thread.
+// Evicted in lock-step with recentTurnsById so it can't outgrow it.
+const recentTurnIdBySourceMessageId = new Map<number, string>()
 function rememberRecentTurn(turn: CurrentTurn): void {
   recentTurnsById.set(turn.turnId, turn)
+  if (turn.sourceMessageId != null) {
+    recentTurnIdBySourceMessageId.set(turn.sourceMessageId, turn.turnId)
+  }
   while (recentTurnsById.size > RECENT_TURNS_MAX) {
     const oldest = recentTurnsById.keys().next().value
     if (oldest === undefined) break
+    const evicted = recentTurnsById.get(oldest)
     recentTurnsById.delete(oldest)
+    // Drop the reverse-index entry for the evicted turn (only when it still
+    // points at THIS turn — a newer turn may have reused the same message id).
+    if (evicted?.sourceMessageId != null &&
+        recentTurnIdBySourceMessageId.get(evicted.sourceMessageId) === oldest) {
+      recentTurnIdBySourceMessageId.delete(evicted.sourceMessageId)
+    }
   }
+}
+
+/**
+ * Framework-owned origin recovery (kill switch SWITCHROOM_FRAMEWORK_ORIGIN_ROUTING).
+ * Resolve the turn that owns a reply from the message_id it QUOTES (args.reply_to),
+ * via the source-message reverse index. Returns null when disabled, when reply_to
+ * is absent/non-numeric, or when no turn owns that message id (evicted / unknown).
+ * Deterministic: a real framework-stamped message_id → its turn, with no model
+ * thread assertion and no dependence on the live currentTurn.
+ *
+ * SCOPED to `chatId`: Telegram numbers message ids PER CHAT, so the same numeric
+ * id exists in a DM and a supergroup. The reverse index is keyed by id alone, so
+ * the resolved turn MUST be confirmed to belong to this reply's chat — otherwise
+ * a reply quoting its own id could inherit another chat's thread (a cross-chat
+ * leak). On a chat mismatch we return null (decline to recover → fall through to
+ * the live-turn behaviour), never a wrong-chat thread.
+ */
+function findTurnByQuotedMessageId(chatId: string, replyTo: unknown): CurrentTurn | null {
+  if (!FRAMEWORK_ORIGIN_ROUTING_ENABLED) return null
+  if (replyTo == null) return null
+  const mid = Number(replyTo)
+  if (!Number.isFinite(mid)) return null
+  const owner = recentTurnIdBySourceMessageId.get(mid)
+  if (owner == null) return null
+  const turn = recentTurnsById.get(owner) ?? null
+  if (turn == null || turn.sessionChatId !== chatId) return null
+  return turn
 }
 /**
  * Component 3 — derive the stable per-turn identity from the chat, thread,
@@ -1932,15 +1987,26 @@ function findLatestEndedTurnForChat(chatId: string): CurrentTurn | null {
  * timestamps. This wrapper logs, per reply: which precedence tier won (`via`),
  * the resolved thread, the origin turn + its thread, and whether the reply was
  * late (turn already ended). `via=recovered` marks a late reply this fix saved
- * from General; `UNROUTED` flags a supergroup reply that resolved to no topic
- * with NO owner turn to attribute it to (genuinely lost — the residual gap to
- * watch). A General-topic turn legitimately has no thread, so its replies are
- * NOT flagged.
+ * from General; `via=quoted` marks an origin recovered from the framework-owned
+ * quoted message_id (no model echo); `UNROUTED` flags a supergroup reply that
+ * resolved to no topic with NO owner turn to attribute it to (genuinely lost).
+ * `MISROUTE_RISK` flags the irreducible determinism residual: a no-echo,
+ * no-quote reply that fell to the LIVE turn while a DIFFERENT topic recently had
+ * a turn — the framework cannot tell which topic the bare reply answers, so the
+ * routing MIGHT be wrong (HOLE a). It is observability only (the reply still
+ * routes to the live turn) — it makes the one case that is genuinely
+ * model-dependent visible instead of silently mis-routed. A General-topic turn
+ * legitimately has no thread, so its replies are NOT UNROUTED-flagged.
+ *
+ * `originVia` distinguishes how the origin turn was resolved: 'echo' (model
+ * echoed origin_turn_id), 'quoted' (framework recovered it from args.reply_to),
+ * or null (no origin turn). It only affects the `via` label, never the routing.
  */
 function resolveAnswerThreadWithLog(
   chatId: string,
   explicitThreadId: number | undefined,
   originTurn: CurrentTurn | null,
+  originVia: 'echo' | 'quoted' | null,
   liveTurn: CurrentTurn | null,
   surface: 'reply' | 'stream_reply',
 ): number | undefined {
@@ -1967,7 +2033,7 @@ function resolveAnswerThreadWithLog(
   })
   const via =
     explicitThreadId != null ? 'explicit'
-    : originTurn != null ? 'origin'
+    : originTurn != null ? (originVia === 'quoted' ? 'quoted' : 'origin')
     : liveTurn?.sessionThreadId != null ? 'live'
     : recovered != null ? 'recovered'
     : 'none'
@@ -1979,15 +2045,46 @@ function resolveAnswerThreadWithLog(
   // gate on `ownerTurn == null` so General replies don't false-alarm (found by
   // the multi-topic UAT stress, 2026-06-05).
   const unrouted = isSupergroup && threadId == null && ownerTurn == null
+  // MISROUTE_RISK = the irreducible determinism residual (HOLE a). A no-echo,
+  // no-quote reply fell to the LIVE turn (via=live), but a DIFFERENT topic
+  // recently had a turn for this chat — so this bare reply MIGHT belong to that
+  // other topic and we cannot tell without the model's echo. Observability only;
+  // routing is unchanged. This is the one case framework state cannot
+  // disambiguate, surfaced instead of silently mis-routed.
+  const misrouteRisk =
+    isSupergroup &&
+    via === 'live' &&
+    hasDifferentThreadedRecentTurn(chatId, liveTurn?.sessionThreadId)
   process.stderr.write(
     `telegram gateway: reply-route surface=${surface} chat=${chatId} ` +
       `resolved_thread=${threadId ?? '-'} via=${via} late=${liveTurn == null} ` +
       `originTurn=${ownerTurn?.turnId ?? '-'} origin_thread=${ownerTurn?.sessionThreadId ?? '-'}` +
       (via === 'recovered' ? ' RECOVERED' : '') +
+      (via === 'quoted' ? ' QUOTED(framework-origin)' : '') +
       (unrouted ? ' UNROUTED(supergroup→no-topic)' : '') +
+      (misrouteRisk ? ' MISROUTE_RISK(no-echo→live-successor)' : '') +
       '\n',
   )
   return threadId
+}
+
+/**
+ * Determinism-residual detector (HOLE a observability). True when a DIFFERENT
+ * forum topic recently had a turn for this chat than the live turn's thread —
+ * i.e. a currentTurn flip plausibly happened, so a no-echo / no-quote reply
+ * routed to the live turn MIGHT belong to the other topic. Scans the bounded
+ * recently-ended registry; cheap (≤32 entries). Used only to ALARM, never to
+ * route.
+ */
+function hasDifferentThreadedRecentTurn(
+  chatId: string,
+  liveThreadId: number | undefined,
+): boolean {
+  const live = liveThreadId ?? null
+  for (const t of recentTurnsById.values()) {
+    if (t.sessionChatId === chatId && (t.sessionThreadId ?? null) !== live) return true
+  }
+  return false
 }
 
 /**
@@ -6638,11 +6735,17 @@ async function executeReply(args: Record<string, unknown>): Promise<{ content: A
   let threadId: number | undefined
   if (TURN_ORIGIN_ROUTING_ENABLED) {
     const explicit = args.message_thread_id != null ? Number(args.message_thread_id) : undefined
-    const originTurn = findTurnByOriginId(args.origin_turn_id as string | undefined)
+    // Origin precedence: model echo first (authoritative), then the
+    // framework-owned quoted message_id (deterministic, no model thread
+    // assertion) as a fallback when the model omitted the echo.
+    const echoedTurn = findTurnByOriginId(args.origin_turn_id as string | undefined)
+    const quotedTurn = echoedTurn == null ? findTurnByQuotedMessageId(chat_id, args.reply_to) : null
+    const originTurn = echoedTurn ?? quotedTurn
     threadId = resolveAnswerThreadWithLog(
       chat_id,
       Number.isFinite(explicit as number) ? (explicit as number) : undefined,
       originTurn,
+      originTurn == null ? null : echoedTurn != null ? 'echo' : 'quoted',
       turn,
       'reply',
     )
@@ -7295,11 +7398,17 @@ async function executeStreamReply(args: Record<string, unknown>): Promise<unknow
   if (args.message_thread_id == null) {
     let injected: number | undefined
     if (TURN_ORIGIN_ROUTING_ENABLED) {
-      const originTurn = findTurnByOriginId(args.origin_turn_id as string | undefined)
+      // Origin precedence: model echo first, then the framework-owned quoted
+      // message_id as a deterministic fallback (mirrors executeReply).
+      const echoedTurn = findTurnByOriginId(args.origin_turn_id as string | undefined)
+      const quotedTurn =
+        echoedTurn == null ? findTurnByQuotedMessageId(String(args.chat_id), args.reply_to) : null
+      const originTurn = echoedTurn ?? quotedTurn
       injected = resolveAnswerThreadWithLog(
         String(args.chat_id),
         undefined,
         originTurn,
+        originTurn == null ? null : echoedTurn != null ? 'echo' : 'quoted',
         turn,
         'stream_reply',
       )

--- a/telegram-plugin/tests/multitopic-routing-wiring.test.ts
+++ b/telegram-plugin/tests/multitopic-routing-wiring.test.ts
@@ -67,6 +67,51 @@ describe('component 3 — turn-origin reply routing', () => {
   })
 })
 
+describe('framework-owned origin recovery (determinism residual, 2026-06-05)', () => {
+  it('a source-message reverse index is populated at enqueue and EVICTED in parity with recentTurnsById', () => {
+    expect(gatewaySrc).toMatch(/const recentTurnIdBySourceMessageId = new Map<number, string>\(\)/)
+    // Populated inside rememberRecentTurn from the turn's sourceMessageId.
+    const fn = gatewaySrc.split('function rememberRecentTurn')[1]?.split('\nfunction ')[0] ?? ''
+    expect(fn).toMatch(/recentTurnIdBySourceMessageId\.set\(turn\.sourceMessageId, turn\.turnId\)/)
+    // Eviction parity: the reverse entry is dropped when its turn is evicted —
+    // so the index cannot outgrow the bounded RECENT_TURNS_MAX registry.
+    expect(fn).toMatch(/recentTurnIdBySourceMessageId\.delete\(evicted\.sourceMessageId\)/)
+  })
+
+  it('both reply paths recover origin from the quoted message_id when the model omits the echo', () => {
+    for (const name of ['executeReply', 'executeStreamReply']) {
+      const fn = gatewaySrc.split(new RegExp(`async function ${name}`))[1]?.split('\nasync function ')[0] ?? ''
+      // Echo first (authoritative), quoted message_id as the framework fallback.
+      expect(fn).toMatch(/const echoedTurn = findTurnByOriginId\(args\.origin_turn_id/)
+      // Quoted lookup is CHAT-SCOPED (cross-chat message-id collision guard).
+      expect(fn).toMatch(/findTurnByQuotedMessageId\([^,]+, args\.reply_to\)/)
+      expect(fn).toMatch(/echoedTurn \?\? quotedTurn/)
+    }
+  })
+
+  it('findTurnByQuotedMessageId is gated on the kill switch and resolves a real turn (never the live successor)', () => {
+    const fn = gatewaySrc.split('function findTurnByQuotedMessageId')[1]?.split('\nfunction ')[0] ?? ''
+    expect(fn).toMatch(/FRAMEWORK_ORIGIN_ROUTING_ENABLED/)
+    expect(fn).toMatch(/recentTurnIdBySourceMessageId\.get\(mid\)/)
+    expect(fn).toMatch(/recentTurnsById\.get\(owner\)/)
+    // Cross-chat collision guard: the resolved turn must belong to this chat.
+    expect(fn).toMatch(/turn\.sessionChatId !== chatId/)
+  })
+
+  it('the irreducible no-echo residual is ALARMED (MISROUTE_RISK), never silently mis-routed', () => {
+    expect(gatewaySrc).toMatch(/MISROUTE_RISK\(no-echo→live-successor\)/)
+    expect(gatewaySrc).toMatch(/function hasDifferentThreadedRecentTurn/)
+    // The alarm is observability-only: it fires on via=live with a different
+    // recent topic, and does NOT change the resolved thread.
+    expect(gatewaySrc).toMatch(/const misrouteRisk =/)
+    expect(gatewaySrc).toMatch(/via === 'quoted' \? ' QUOTED\(framework-origin\)' : ''/)
+  })
+
+  it('the kill switch defaults ON and is independent of TURN_ORIGIN_ROUTING', () => {
+    expect(gatewaySrc).toMatch(/SWITCHROOM_FRAMEWORK_ORIGIN_ROUTING !== '0'/)
+  })
+})
+
 describe('component 4 — per-turn topic framing', () => {
   it('the gateway stamps a topic_scope directive for forum-topic inbounds (kill-switched)', () => {
     expect(gatewaySrc).toMatch(/TOPIC_FRAMING_ENABLED/)


### PR DESCRIPTION
## Summary

Forum-supergroup answer/topic routing was **conditionally deterministic** — correct only when the model echoes `origin_turn_id` (precedence tier 2). A finite-FSM proof (total enumeration of the pure resolver + adversarial trace of the routing FSM that feeds it) found the load-bearing hole and this PR proves the deterministic core, recovers origin without the model where the framework owns the signal, and makes the irreducible residual observable.

## Why

The origin signal that survives a `currentTurn` flip travels through the **model** (it echoes `origin_turn_id`). When the model omits it **and** `currentTurn` has flipped to a successor topic — reachable by construction via the 2.5s no-reply escape-hatch drain or the 300s silence-poke — the reply falls to the live successor's thread = **wrong topic**, and silently (not even `UNROUTED`-flagged). This is the original Brevo→Meta multi-topic bleed, reopened on every model omission while a successor is live. A live fuzz never saw it because the model echoed every time, so it couldn't distinguish "routing is deterministic" from "the model happened to echo."

JTBD: *you hold the leash* (`reference/` outcome 2) — an answer must land where the user is reading, not get stolen by another topic.

## What

1. **Prove the deterministic core.** `answer-thread-resolve.test.ts` is promoted from 9 sampled cases to a **total enumeration** over the whole 64-input space: totality, determinism (idempotence), no-fabrication, the full precedence decision table, and the by-construction invariants — notably **INV-2 origin flip-immunity** (once origin is resolved, the result is independent of `liveThreadId` for *every* combination, so a `currentTurn` flip cannot steal a resolved origin).

2. **Recover origin without the model echo, deterministically.** When the model quotes a specific message (`reply_to`), that message id is a *framework-owned* anchor. A new source-message reverse index (evicted in lock-step with `recentTurnsById`, chat-scoped to avoid cross-chat id collisions) maps it back to the owning turn. `executeReply`/`executeStreamReply` resolve origin as `echo ?? quoted` — echo stays authoritative; the quote is a strictly-additive fallback that resolves the **actual** origin turn (never the live successor), so it cannot mask a misroute. Kill switch `SWITCHROOM_FRAMEWORK_ORIGIN_ROUTING` (default on, independent of `SWITCHROOM_TURN_ORIGIN_ROUTING`).

3. **Alarm the irreducible residual.** A bare no-echo, no-quote late reply is genuinely model-dependent — only the model knows which ended turn it answers. Rather than route it to the live successor silently, emit `MISROUTE_RISK(no-echo→live-successor)` telemetry when a different topic recently had a turn. Observability only; routing unchanged. Mirrors the obligation ledger's `resolveCloseTarget` stance: when ambiguous, surface it, never wrong-attribute.

## Determinism verdict

NOT fully deterministic-by-construction even after this PR — a bare non-quoted late reply with no echo is the irreducible model-dependent tail. The honest ceiling: the deterministic **core** (the echo/quote paths) is now *proven*, the framework recovers everything it owns, and the one case it cannot is **alarmed, not silent**.

## Test plan

- [x] `answer-thread-resolve.test.ts` total-enumeration proof — 18 tests
- [x] `multitopic-routing-wiring.test.ts` — reverse-index population + eviction parity + chat-scope guard + resolve order + residual alarm pinned (22 tests)
- [x] `tsc --noEmit` clean
- [x] 185 gateway vitest + 52 routing/obligation bun tests green
- [ ] Supergroup UAT (`fuzz-multitopic-routing-channel`, `fuzz-cross-surface-ordering-channel`) on the General-topic harness
- [ ] Live marko canary: tail `reply-route` telemetry for `via=` distribution + any `MISROUTE_RISK` / `QUOTED` before fleet roll

## Risk

MEDIUM, kill-switched. The pure-resolver proof is zero-risk (additive, pure fn). The framework-origin recovery only fires on the absent-echo branch (today's buggy path), echo-first so an obedient model is unaffected; chat-scoped so it can never leak a cross-chat thread (worst case it declines to recover → today's behaviour). The alarm is telemetry-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)