### PR TITLE
fix(telegram): stop the answer-stream flash (decouple visible-preview from draft retirement)

### DIFF
--- a/telegram-plugin/answer-stream-flag.ts
+++ b/telegram-plugin/answer-stream-flag.ts
@@ -35,3 +35,72 @@ export function parseDraftLaneRetiredEnabled(raw: string | undefined): boolean {
   const v = raw.trim().toLowerCase()
   return !(v === '0' || v === 'false' || v === 'off' || v === 'no')
 }
+
+/**
+ * `minInitialChars` sentinel meaning "never open a visible chat-timeline
+ * preview" — mirrors the `Number.MAX_SAFE_INTEGER` gate the createAnswerStream
+ * call site uses so the lane stays silent.
+ */
+export const ANSWER_LANE_NEVER_OPENS = Number.MAX_SAFE_INTEGER
+
+export type AnswerLaneState = 'visible' | 'draft' | 'dormant'
+
+export interface AnswerLaneConfig {
+  /** `minInitialChars` for createAnswerStream: `1` opens a visible preview on
+   *  the first text chunk; `ANSWER_LANE_NEVER_OPENS` suppresses it. */
+  minInitialChars: number
+  /** Whether the lane streams to the invisible compose-box draft transport. */
+  usesDraftTransport: boolean
+  /** Whether a USER-VISIBLE chat-timeline preview opens — i.e. the surface that
+   *  flashed (raw preview → formatted reply → preview deleted). This is THE
+   *  regression invariant: it must equal `visibleEnabled`, never depend on the
+   *  draft flag. */
+  opensVisiblePreview: boolean
+  /** Label for the boot log. */
+  state: AnswerLaneState
+}
+
+/**
+ * Resolve the answer-lane config from the two INDEPENDENT inputs.
+ *
+ * The visible PREVIEW (the flash surface) is gated on `visibleEnabled` ALONE;
+ * draft retirement controls only the TRANSPORT (whether `sendMessageDraft` is
+ * available). Conflating them was the v0.14.68 regression: retiring the draft
+ * (the default) forced a visible preview that flashed on every streaming turn,
+ * re-opening the flash v0.14.52 had removed. The load-bearing invariant —
+ * `opensVisiblePreview === visibleEnabled` for EVERY `draftFnAvailable` — is
+ * what this function exists to make total-enumerable (the gateway IIFE is not).
+ *
+ *   visibleEnabled                       → 'visible'  (preview opens, minChars 1)
+ *   !visible, draft transport available  → 'draft'    (no preview; draft renders)
+ *   !visible, no draft transport         → 'dormant'  (no preview, no draft:
+ *                                                       the reply tool is the
+ *                                                       only message — the default)
+ */
+export function resolveAnswerLaneConfig(input: {
+  visibleEnabled: boolean
+  draftFnAvailable: boolean
+}): AnswerLaneConfig {
+  if (input.visibleEnabled) {
+    return {
+      minInitialChars: 1,
+      usesDraftTransport: false,
+      opensVisiblePreview: true,
+      state: 'visible',
+    }
+  }
+  if (input.draftFnAvailable) {
+    return {
+      minInitialChars: ANSWER_LANE_NEVER_OPENS,
+      usesDraftTransport: true,
+      opensVisiblePreview: false,
+      state: 'draft',
+    }
+  }
+  return {
+    minInitialChars: ANSWER_LANE_NEVER_OPENS,
+    usesDraftTransport: false,
+    opensVisiblePreview: false,
+    state: 'dormant',
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -9673,13 +9673,27 @@ function handleSessionEvent(ev: SessionEvent): void {
             // General). With the gate unreachable the only posted message is
             // the canonical reply. (The gate is bypassed for DM draft
             // transport, so DM draft streaming is unaffected.)
-            // Draft retired (default) OR visible explicitly on → a real
-            // edit-in-place message (minInitialChars:1, no draft): observable by
-            // the UAT and the onMetric silence-liveness reset fires on visible
-            // sends in DMs AND supergroups. Legacy draft only when the kill
-            // switch re-enables it (DRAFT_ANSWER_LANE_RETIRED=false), which also
-            // restores sendMessageDraftFn above.
-            ...(ANSWER_STREAM_VISIBLE_ENABLED || DRAFT_ANSWER_LANE_RETIRED
+            // VISIBLE preview gating decoupled from the draft-transport flag
+            // (2026-06-05 flash regression fix). The visible flag ALONE decides
+            // whether a user-visible preview opens; DRAFT_ANSWER_LANE_RETIRED
+            // controls only the TRANSPORT (whether sendMessageDraftFn exists).
+            // The earlier `|| DRAFT_ANSWER_LANE_RETIRED` here meant retiring the
+            // draft (the default since v0.14.68) silently forced minInitialChars:1
+            // → a visible preliminary opened on every streaming turn and was then
+            // retracted (deleted) when the reply tool fired — the exact "raw bubble
+            // appears, formatted reply lands, raw bubble vanishes" flash that
+            // turning the visible stream OFF (v0.14.52) was meant to remove. So
+            // v0.14.68 silently undid v0.14.52 fleet-wide. Now:
+            //   - VISIBLE on (opt-in) → minInitialChars:1, a real edit-in-place
+            //     preview (observable by UAT, silence-liveness reset on its sends).
+            //   - VISIBLE off (default) → minInitialChars:MAX so NO visible preview
+            //     ever opens; the reply tool is the single canonical formatted
+            //     message (no flash). With the draft retired (default) there is no
+            //     transport either, so the lane stays dormant; with the kill switch
+            //     DRAFT_ANSWER_LANE=0 the legacy compose-box draft transport is
+            //     restored (sendMessageDraftFn defined above, gate bypassed for DM
+            //     draft so #1664 DM draft streaming is unaffected).
+            ...(ANSWER_STREAM_VISIBLE_ENABLED
               ? { minInitialChars: 1 }
               : { sendMessageDraft: sendMessageDraftFn, minInitialChars: Number.MAX_SAFE_INTEGER }),
             // #1075: route through robustApiCall so flood-wait,
@@ -9969,13 +9983,18 @@ function handleSessionEvent(ev: SessionEvent): void {
         const streamedMsgId = stream.messageId()
         const streamedFinalText = turn.capturedText.join('').trim()
         if (
-          // Broadened for draft retirement: a text-only no-reply turn that
-          // streamed a VISIBLE preview must materialize a pinged final answer +
-          // delete the preview. Without this, the retired-default path would
-          // fall into the else-branch retract() and delete the user's only copy
-          // of the answer (a lost-answer bug). The reply-tool branch still hits
-          // retract() → single canonical formatted reply, no flash.
-          (ANSWER_STREAM_VISIBLE_ENABLED || DRAFT_ANSWER_LANE_RETIRED)
+          // Only when a VISIBLE preview actually opened (visible flag on): a
+          // text-only no-reply turn that streamed a visible preview must
+          // materialize a pinged final answer + delete the preview, NOT fall into
+          // the else-branch retract() which would delete the user's only copy of
+          // the answer (a lost-answer bug). Gated on the visible flag alone (the
+          // flash-regression decoupling): with the visible stream OFF (default)
+          // no preview opens (minInitialChars:MAX), so streamedMsgId is null and
+          // this branch is unreachable — the no-reply answer is delivered by the
+          // turn-flush backstop below instead, the pre-v0.14.68 path. The
+          // reply-tool branch hits retract() on a non-opened lane (a no-op), so
+          // there is no preliminary to flash.
+          ANSWER_STREAM_VISIBLE_ENABLED
           && !turn.replyCalled
           && streamedMsgId != null
           && streamedFinalText.length > 0
@@ -20705,7 +20724,15 @@ void (async () => {
         }
       }
 
-      process.stderr.write(`telegram gateway: answer-stream lane=${DRAFT_ANSWER_LANE_RETIRED ? 'visible(draft-retired)' : (ANSWER_STREAM_VISIBLE_ENABLED ? 'visible' : 'draft')} draftFn=${sendMessageDraftFn != null ? 'available' : 'off'} grammy=${GRAMMY_VERSION}\n`)
+      // Lane state (post flash-decouple): VISIBLE only when the visible flag is
+      // on; otherwise 'draft' if the draft transport is available, else 'dormant'
+      // (draft retired + visible off = the default: no preview, reply tool is the
+      // only message). The old label wrongly reported 'visible(draft-retired)' for
+      // the dormant default, masking the flash regression.
+      const answerLaneState = ANSWER_STREAM_VISIBLE_ENABLED
+        ? 'visible'
+        : (sendMessageDraftFn != null ? 'draft' : 'dormant')
+      process.stderr.write(`telegram gateway: answer-stream lane=${answerLaneState} draftFn=${sendMessageDraftFn != null ? 'available' : 'off'} visible=${ANSWER_STREAM_VISIBLE_ENABLED} draftRetired=${DRAFT_ANSWER_LANE_RETIRED} grammy=${GRAMMY_VERSION}\n`)
       process.stderr.write(`telegram gateway: starting bot polling pid=${process.pid} agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} stateDir=${STATE_DIR} historyEnabled=${HISTORY_ENABLED} streamMode=${process.env.SWITCHROOM_TG_STREAM_MODE ?? 'checklist'}\n`)
       runnerHandle = run(bot, {
         runner: {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -98,7 +98,7 @@ import * as pendingProgress from '../pending-work-progress.js'
 import { writeSilentEndState, clearSilentEndState, recordUndeliveredTurnEnd } from '../silent-end.js'
 import { isFinalAnswerReply, isSubstantiveFinalReply } from '../final-answer-detect.js'
 import { createAnswerStream, type AnswerStreamHandle } from '../answer-stream.js'
-import { parseVisibleAnswerStreamEnabled, parseDraftLaneRetiredEnabled } from '../answer-stream-flag.js'
+import { parseVisibleAnswerStreamEnabled, parseDraftLaneRetiredEnabled, resolveAnswerLaneConfig } from '../answer-stream-flag.js'
 import { type SessionEvent } from '../session-tail.js'
 import {
   shouldSuppressToolActivity,
@@ -4589,6 +4589,16 @@ const TURN_FLUSH_SAFETY_ENABLED = isTurnFlushSafetyEnabled()
 const ANSWER_STREAM_VISIBLE_ENABLED = parseVisibleAnswerStreamEnabled(
   process.env.SWITCHROOM_VISIBLE_ANSWER_STREAM,
 )
+// Single source of truth for the answer-lane behaviour (flash-decouple,
+// 2026-06-05). The visible preview gates on the visible flag ALONE; the draft
+// flag controls only the transport. Resolved here once and consulted at the
+// createAnswerStream config, the materialize-as-answer guard, and the boot log,
+// so all three can never drift back into the `visible || retired` conflation
+// that re-opened the flash. Total-enumerated in answer-stream-flag.test.ts.
+const ANSWER_LANE = resolveAnswerLaneConfig({
+  visibleEnabled: ANSWER_STREAM_VISIBLE_ENABLED,
+  draftFnAvailable: sendMessageDraftFn != null,
+})
 
 // Whether to DELETE the activity/status feed when the final answer lands.
 // Default OFF (2026-06-04, operator request): the status message stays in the
@@ -9693,9 +9703,9 @@ function handleSessionEvent(ev: SessionEvent): void {
             //     DRAFT_ANSWER_LANE=0 the legacy compose-box draft transport is
             //     restored (sendMessageDraftFn defined above, gate bypassed for DM
             //     draft so #1664 DM draft streaming is unaffected).
-            ...(ANSWER_STREAM_VISIBLE_ENABLED
-              ? { minInitialChars: 1 }
-              : { sendMessageDraft: sendMessageDraftFn, minInitialChars: Number.MAX_SAFE_INTEGER }),
+            ...(ANSWER_LANE.usesDraftTransport
+              ? { sendMessageDraft: sendMessageDraftFn, minInitialChars: ANSWER_LANE.minInitialChars }
+              : { minInitialChars: ANSWER_LANE.minInitialChars }),
             // #1075: route through robustApiCall so flood-wait,
             // benign-400, and THREAD_NOT_FOUND are handled uniformly
             // instead of crashing the answer-stream loop on a deleted
@@ -9994,7 +10004,7 @@ function handleSessionEvent(ev: SessionEvent): void {
           // turn-flush backstop below instead, the pre-v0.14.68 path. The
           // reply-tool branch hits retract() on a non-opened lane (a no-op), so
           // there is no preliminary to flash.
-          ANSWER_STREAM_VISIBLE_ENABLED
+          ANSWER_LANE.opensVisiblePreview
           && !turn.replyCalled
           && streamedMsgId != null
           && streamedFinalText.length > 0
@@ -20725,14 +20735,12 @@ void (async () => {
       }
 
       // Lane state (post flash-decouple): VISIBLE only when the visible flag is
-      // on; otherwise 'draft' if the draft transport is available, else 'dormant'
-      // (draft retired + visible off = the default: no preview, reply tool is the
-      // only message). The old label wrongly reported 'visible(draft-retired)' for
-      // the dormant default, masking the flash regression.
-      const answerLaneState = ANSWER_STREAM_VISIBLE_ENABLED
-        ? 'visible'
-        : (sendMessageDraftFn != null ? 'draft' : 'dormant')
-      process.stderr.write(`telegram gateway: answer-stream lane=${answerLaneState} draftFn=${sendMessageDraftFn != null ? 'available' : 'off'} visible=${ANSWER_STREAM_VISIBLE_ENABLED} draftRetired=${DRAFT_ANSWER_LANE_RETIRED} grammy=${GRAMMY_VERSION}\n`)
+      // Lane state from the single-source-of-truth resolver: 'visible' (preview
+      // on), 'draft' (compose-box transport), or 'dormant' (the default: no
+      // preview, no draft — reply tool is the only message). The old label
+      // wrongly reported 'visible(draft-retired)' for the dormant default, which
+      // masked the flash regression.
+      process.stderr.write(`telegram gateway: answer-stream lane=${ANSWER_LANE.state} draftFn=${sendMessageDraftFn != null ? 'available' : 'off'} visible=${ANSWER_STREAM_VISIBLE_ENABLED} draftRetired=${DRAFT_ANSWER_LANE_RETIRED} grammy=${GRAMMY_VERSION}\n`)
       process.stderr.write(`telegram gateway: starting bot polling pid=${process.pid} agent=${process.env.SWITCHROOM_AGENT_NAME ?? '-'} stateDir=${STATE_DIR} historyEnabled=${HISTORY_ENABLED} streamMode=${process.env.SWITCHROOM_TG_STREAM_MODE ?? 'checklist'}\n`)
       runnerHandle = run(bot, {
         runner: {

--- a/telegram-plugin/tests/answer-stream-flag.test.ts
+++ b/telegram-plugin/tests/answer-stream-flag.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { parseVisibleAnswerStreamEnabled, parseDraftLaneRetiredEnabled } from '../answer-stream-flag.js'
+import { parseVisibleAnswerStreamEnabled, parseDraftLaneRetiredEnabled, resolveAnswerLaneConfig } from '../answer-stream-flag.js'
 
 describe('parseVisibleAnswerStreamEnabled — default OFF, opt-in', () => {
   it('defaults OFF when unset', () => {
@@ -41,5 +41,77 @@ describe('parseDraftLaneRetiredEnabled — default RETIRED (2026-06-05), kill-sw
     for (const v of ['0', 'false', 'off', 'no', ' FALSE ', 'Off', 'NO']) {
       expect(parseDraftLaneRetiredEnabled(v)).toBe(false)
     }
+  })
+})
+
+// ── resolveAnswerLaneConfig — TOTAL-ENUMERATION REGRESSION PROOF ─────────────
+//
+// This is the behavioural guard for the flash regression (the gateway IIFE is
+// not importable, so the decision lives in this pure function and the gateway
+// delegates to it). The input space is finite — visibleEnabled × draftFnAvailable
+// = 4 — so we enumerate ALL of it and assert the full decision table plus the
+// load-bearing INVARIANT: opensVisiblePreview === visibleEnabled, ALWAYS. That
+// invariant is exactly what v0.14.68 broke (it made the preview depend on the
+// draft flag), so a future change that re-conflates them fails here, not in prod.
+describe('resolveAnswerLaneConfig — total enumeration (flash-regression proof)', () => {
+  const MAX = Number.MAX_SAFE_INTEGER
+  const ALL = [
+    { visibleEnabled: false, draftFnAvailable: false }, // the DEFAULT (visible off, draft retired)
+    { visibleEnabled: false, draftFnAvailable: true }, // draft kill switch on
+    { visibleEnabled: true, draftFnAvailable: false }, // opt-in visible
+    { visibleEnabled: true, draftFnAvailable: true }, // visible wins over draft
+  ]
+
+  it('the input space is exactly 4 rows (2×2)', () => {
+    expect(ALL.length).toBe(4)
+  })
+
+  it('INVARIANT (the regression guard): opensVisiblePreview === visibleEnabled for EVERY draftFnAvailable', () => {
+    for (const input of ALL) {
+      expect(resolveAnswerLaneConfig(input).opensVisiblePreview).toBe(input.visibleEnabled)
+    }
+  })
+
+  it('TOTAL: every input returns a defined config and never throws', () => {
+    for (const input of ALL) {
+      expect(() => resolveAnswerLaneConfig(input)).not.toThrow()
+      expect(resolveAnswerLaneConfig(input).state).toBeDefined()
+    }
+  })
+
+  it('DEFAULT (visible off, draft retired) → DORMANT: no preview, no draft, MAX gate (no flash)', () => {
+    expect(resolveAnswerLaneConfig({ visibleEnabled: false, draftFnAvailable: false })).toEqual({
+      minInitialChars: MAX,
+      usesDraftTransport: false,
+      opensVisiblePreview: false,
+      state: 'dormant',
+    })
+  })
+
+  it('visible off + draft transport available → DRAFT: no visible preview, draft renders', () => {
+    expect(resolveAnswerLaneConfig({ visibleEnabled: false, draftFnAvailable: true })).toEqual({
+      minInitialChars: MAX,
+      usesDraftTransport: true,
+      opensVisiblePreview: false,
+      state: 'draft',
+    })
+  })
+
+  it('visible on → VISIBLE: preview opens on the first chunk (minChars 1), no draft', () => {
+    for (const draftFnAvailable of [false, true]) {
+      expect(resolveAnswerLaneConfig({ visibleEnabled: true, draftFnAvailable })).toEqual({
+        minInitialChars: 1,
+        usesDraftTransport: false,
+        opensVisiblePreview: true,
+        state: 'visible',
+      })
+    }
+  })
+
+  it('a visible preview NEVER opens unless explicitly enabled (no draftFnAvailable forces it on)', () => {
+    // The exact v0.14.68 failure shape: retiring the draft (draftFnAvailable=false)
+    // must NOT open a visible preview.
+    expect(resolveAnswerLaneConfig({ visibleEnabled: false, draftFnAvailable: false }).opensVisiblePreview).toBe(false)
+    expect(resolveAnswerLaneConfig({ visibleEnabled: false, draftFnAvailable: false }).minInitialChars).toBe(MAX)
   })
 })

--- a/telegram-plugin/tests/answer-stream.test.ts
+++ b/telegram-plugin/tests/answer-stream.test.ts
@@ -6,6 +6,7 @@ import {
   DRAFT_METHOD_UNAVAILABLE_RE,
   DRAFT_CHAT_UNSUPPORTED_RE,
 } from '../answer-stream.js'
+import { resolveAnswerLaneConfig, ANSWER_LANE_NEVER_OPENS } from '../answer-stream-flag.js'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -90,6 +91,35 @@ describe('answer-stream — minInitialChars threshold', () => {
     // 200 chars < 400 threshold
     stream.update('x'.repeat(200))
     vi.advanceTimersByTime(1000)
+    await flushMicrotasks()
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(editMessageText).not.toHaveBeenCalled()
+  })
+
+  it('FLASH REGRESSION: the DORMANT config (visible off, draft retired) sends NOTHING, even for a full answer', async () => {
+    // End-to-end proof that the resolved default config produces no visible
+    // preview → nothing to retract → no flash. Wires the ACTUAL resolver output
+    // (not a hand-picked threshold) into the stream.
+    const lane = resolveAnswerLaneConfig({ visibleEnabled: false, draftFnAvailable: false })
+    expect(lane.state).toBe('dormant')
+    expect(lane.minInitialChars).toBe(ANSWER_LANE_NEVER_OPENS)
+
+    const sendMessage = makeSendMessage()
+    const editMessageText = makeEditMessageText()
+    const stream = createAnswerStream({
+      chatId: 'chat1',
+      isPrivateChat: false,
+      minInitialChars: lane.minInitialChars,
+      throttleMs: 250,
+      sendMessage,
+      editMessageText,
+      // no sendMessageDraft — dormant lane has no transport
+    })
+
+    // A realistic full answer — 2000 chars, far above any normal threshold.
+    stream.update('The answer is '.repeat(150))
+    vi.advanceTimersByTime(5000)
     await flushMicrotasks()
 
     expect(sendMessage).not.toHaveBeenCalled()

--- a/telegram-plugin/tests/draft-retirement-wiring.test.ts
+++ b/telegram-plugin/tests/draft-retirement-wiring.test.ts
@@ -1,18 +1,24 @@
 /**
- * Draft-answer-lane retirement — gateway wiring guards (2026-06-05).
+ * Answer-lane wiring guards — draft retirement + flash decoupling.
  *
- * The retirement switches the live answer lane from the invisible compose-box
- * draft to a real, mtcute-observable edit-in-place message, default-on. The
- * design review flagged two ways this silently breaks (gateway IIFE can't be
- * instantiated in-process, so these are source-level assertions, same pattern as
- * silence-liveness-wiring.test):
+ * History:
+ *  - v0.14.52 turned the VISIBLE answer-stream OFF by default to remove the
+ *    "raw preview appears, formatted reply lands, raw preview deleted" flash.
+ *  - v0.14.68 retired the invisible compose-box DRAFT transport. The original
+ *    wiring (and the first version of this test) conflated the two flags —
+ *    `ANSWER_STREAM_VISIBLE_ENABLED || DRAFT_ANSWER_LANE_RETIRED` — so retiring
+ *    the draft (default) silently forced a VISIBLE preview (minInitialChars:1)
+ *    even with the visible flag off, re-introducing the flash FLEET-WIDE
+ *    (v0.14.68 undid v0.14.52). The first revision of this file pinned that
+ *    conflation as a "guard" — i.e. it asserted the bug.
+ *  - 2026-06-05 flash-decouple: the VISIBLE preview now gates on the visible
+ *    flag ALONE; DRAFT_ANSWER_LANE_RETIRED controls only the TRANSPORT. With
+ *    defaults (visible off, draft retired) the lane is DORMANT — no preview, the
+ *    reply tool is the single formatted message, no flash. The no-reply text-only
+ *    answer is delivered by the turn-flush backstop (the pre-v0.14.68 path).
  *
- *  PRIMARY: drop sendMessageDraftFn but FORGET to flip minInitialChars to 1 →
- *  the lane becomes a total no-op (the MAX gate never opens it), losing ALL
- *  answer-lane status AND the #2169 onMetric silence-liveness reset.
- *  SECONDARY: flip the lane to visible but FORGET to broaden the
- *  materialize-as-answer guard → a text-only no-reply turn falls into retract()
- *  and deletes the user's only copy of the answer (a lost-answer bug).
+ * gateway IIFE can't be instantiated in-process, so these are source-level
+ * assertions (same pattern as silence-liveness-wiring.test).
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -20,8 +26,8 @@ import { resolve } from 'node:path'
 
 const gatewaySrc = readFileSync(resolve(__dirname, '..', 'gateway', 'gateway.ts'), 'utf-8')
 
-describe('draft-retirement wiring', () => {
-  it('sendMessageDraftFn is gated on the retirement (the single chokepoint)', () => {
+describe('answer-lane wiring (draft retirement + flash decoupling)', () => {
+  it('sendMessageDraftFn is gated on the retirement (the single transport chokepoint)', () => {
     expect(gatewaySrc).toMatch(/!DRAFT_ANSWER_LANE_RETIRED && typeof _rawSendMessageDraft === 'function'/)
   })
 
@@ -32,19 +38,35 @@ describe('draft-retirement wiring', () => {
     expect(firstUseIdx).toBeGreaterThan(declIdx)
   })
 
-  it('PRIMARY GUARD: retired lane uses minInitialChars:1 (visible), never the MAX no-op gate', () => {
-    // The config must pick the {minInitialChars:1} branch when retired, so the
-    // lane actually opens a real message. The MAX branch is draft-only (legacy).
-    expect(gatewaySrc).toMatch(/ANSWER_STREAM_VISIBLE_ENABLED \|\| DRAFT_ANSWER_LANE_RETIRED\s*\n?\s*\?\s*\{ minInitialChars: 1 \}/)
+  it('FLASH GUARD: the VISIBLE preview gates on the visible flag ALONE, never on the draft-retired flag', () => {
+    // The minInitialChars:1 (visible-preview) branch must be selected by
+    // ANSWER_STREAM_VISIBLE_ENABLED only. Conflating it with the retired-draft
+    // default is what re-opened the flash fleet-wide.
+    expect(gatewaySrc).toMatch(/\.\.\.\(ANSWER_STREAM_VISIBLE_ENABLED\s*\n?\s*\?\s*\{ minInitialChars: 1 \}/)
   })
 
-  it('SECONDARY GUARD: the materialize-as-answer guard is broadened in lockstep', () => {
-    // A text-only no-reply turn must materialize (ping + delete preview), not
-    // retract() the answer away.
-    expect(gatewaySrc).toMatch(/\(ANSWER_STREAM_VISIBLE_ENABLED \|\| DRAFT_ANSWER_LANE_RETIRED\)\s*\n?\s*&& !turn\.replyCalled/)
+  it('FLASH GUARD: the visible-OR-retired conflation is GONE everywhere (it pinned the flash)', () => {
+    // No answer-lane path may re-introduce `VISIBLE || RETIRED` — that is the
+    // exact regression this fix removes. Asserted globally so neither the config
+    // branch nor the materialize-as-answer guard can quietly bring it back.
+    expect(gatewaySrc).not.toMatch(/ANSWER_STREAM_VISIBLE_ENABLED \|\| DRAFT_ANSWER_LANE_RETIRED/)
   })
 
-  it('the #2169 onMetric silence-liveness reset is preserved (fires on visible sends now)', () => {
+  it('LOST-ANSWER GUARD: materialize-as-answer gates on the visible flag alone (only fires when a preview actually opened)', () => {
+    // A text-only no-reply turn materializes (ping + keep) ONLY when a visible
+    // preview opened (visible flag on). With visible off the lane never opens
+    // (minInitialChars:MAX) so this branch is unreachable and the answer is
+    // delivered by turn-flush instead — never retracted away.
+    expect(gatewaySrc).toMatch(/\n\s*ANSWER_STREAM_VISIBLE_ENABLED\s*\n\s*&& !turn\.replyCalled/)
+  })
+
+  it('LOST-ANSWER GUARD: turn-flush is skipped ONLY when the stream finalized as the answer (so dormant-lane no-reply turns still flush)', () => {
+    // flushDecision skips only on streamFinalizedAsAnswer; with the lane dormant
+    // that stays false, so decideTurnFlush runs and delivers the no-reply answer.
+    expect(gatewaySrc).toMatch(/const flushDecision = streamFinalizedAsAnswer\s*\n?\s*\?/)
+  })
+
+  it('the #2169 onMetric silence-liveness reset is still wired (fires on visible sends when opted in)', () => {
     const onMetric = (gatewaySrc.split('onMetric: (metricEv) => {')[1] ?? '').split('\n            },')[0]
     expect(onMetric).toMatch(/silencePoke\.noteProduction/)
     expect(onMetric).toMatch(/currentTurn === turn/)

--- a/telegram-plugin/tests/draft-retirement-wiring.test.ts
+++ b/telegram-plugin/tests/draft-retirement-wiring.test.ts
@@ -38,26 +38,34 @@ describe('answer-lane wiring (draft retirement + flash decoupling)', () => {
     expect(firstUseIdx).toBeGreaterThan(declIdx)
   })
 
-  it('FLASH GUARD: the VISIBLE preview gates on the visible flag ALONE, never on the draft-retired flag', () => {
-    // The minInitialChars:1 (visible-preview) branch must be selected by
-    // ANSWER_STREAM_VISIBLE_ENABLED only. Conflating it with the retired-draft
-    // default is what re-opened the flash fleet-wide.
-    expect(gatewaySrc).toMatch(/\.\.\.\(ANSWER_STREAM_VISIBLE_ENABLED\s*\n?\s*\?\s*\{ minInitialChars: 1 \}/)
+  it('the lane behaviour is resolved by the single-source-of-truth pure function', () => {
+    // The flag→config decision lives in resolveAnswerLaneConfig (total-enumerated
+    // in answer-stream-flag.test.ts); the gateway delegates so the three use-sites
+    // can never drift apart.
+    expect(gatewaySrc).toMatch(/const ANSWER_LANE = resolveAnswerLaneConfig\(\{/)
+    expect(gatewaySrc).toMatch(/visibleEnabled: ANSWER_STREAM_VISIBLE_ENABLED/)
+    expect(gatewaySrc).toMatch(/draftFnAvailable: sendMessageDraftFn != null/)
+  })
+
+  it('FLASH GUARD: the createAnswerStream config is driven by ANSWER_LANE (preview gated on the visible flag alone)', () => {
+    // The minInitialChars / draft-transport choice comes from the resolved lane,
+    // never from a `visible || retired` inline conflation.
+    expect(gatewaySrc).toMatch(/\.\.\.\(ANSWER_LANE\.usesDraftTransport/)
+    expect(gatewaySrc).toMatch(/minInitialChars: ANSWER_LANE\.minInitialChars/)
   })
 
   it('FLASH GUARD: the visible-OR-retired conflation is GONE everywhere (it pinned the flash)', () => {
     // No answer-lane path may re-introduce `VISIBLE || RETIRED` — that is the
-    // exact regression this fix removes. Asserted globally so neither the config
-    // branch nor the materialize-as-answer guard can quietly bring it back.
+    // exact regression this fix removes.
     expect(gatewaySrc).not.toMatch(/ANSWER_STREAM_VISIBLE_ENABLED \|\| DRAFT_ANSWER_LANE_RETIRED/)
   })
 
-  it('LOST-ANSWER GUARD: materialize-as-answer gates on the visible flag alone (only fires when a preview actually opened)', () => {
+  it('LOST-ANSWER GUARD: materialize-as-answer gates on ANSWER_LANE.opensVisiblePreview (only fires when a preview actually opened)', () => {
     // A text-only no-reply turn materializes (ping + keep) ONLY when a visible
-    // preview opened (visible flag on). With visible off the lane never opens
-    // (minInitialChars:MAX) so this branch is unreachable and the answer is
-    // delivered by turn-flush instead — never retracted away.
-    expect(gatewaySrc).toMatch(/\n\s*ANSWER_STREAM_VISIBLE_ENABLED\s*\n\s*&& !turn\.replyCalled/)
+    // preview opened. With visible off the lane is dormant (minInitialChars:MAX),
+    // so this branch is unreachable and the answer is delivered by turn-flush
+    // instead — never retracted away.
+    expect(gatewaySrc).toMatch(/\n\s*ANSWER_LANE\.opensVisiblePreview\s*\n\s*&& !turn\.replyCalled/)
   })
 
   it('LOST-ANSWER GUARD: turn-flush is skipped ONLY when the stream finalized as the answer (so dormant-lane no-reply turns still flush)', () => {


### PR DESCRIPTION
## Summary

Fixes the recurring **"unformatted message → formatted message → unformatted one deleted"** flash users see on most turns. It's a fleet-wide regression where one fix silently undid another, plus proper behavioural regression coverage.

## Why

The flash is the **visible answer-stream**: a raw preview the agent posts as it streams, retracted (deleted) when the formatted `reply` tool fires. v0.14.52 (#2128) turned that surface **OFF by default** *specifically to remove this flash*. v0.14.68 (#2173) retired the invisible compose-box draft transport but wired the preview-open condition as `(ANSWER_STREAM_VISIBLE_ENABLED || DRAFT_ANSWER_LANE_RETIRED)` — and the draft is retired **by default**, so a visible preview opened on every streaming turn and got retracted. **v0.14.68 re-opened the flash v0.14.52 removed**, fleet-wide, with the visible flag still off.

Live evidence (current logs): `clerk` 190, `marko` 128, `gymbro` 92 `answer-stream: retracted preliminary` events.

## What

**The fix** — decouple the two flags. The visible preview gates on `ANSWER_STREAM_VISIBLE_ENABLED` alone; draft retirement controls only the **transport**. With defaults the lane is **dormant** (no preview, no draft) → the `reply` tool is the single formatted message → no flash. No-reply text-only answers still deliver via the turn-flush backstop (the pre-v0.14.68 path).

**The decision is now a pure function** — `resolveAnswerLaneConfig` (in `answer-stream-flag.ts`); the gateway delegates to it at all three use-sites so they can't drift back into the conflation.

## Regression coverage

- **Total-enumeration** of `resolveAnswerLaneConfig` — all 4 flag combos + the load-bearing invariant `opensVisiblePreview === visibleEnabled` (the exact property v0.14.68 broke).
- **End-to-end behavioural test** — the resolved dormant config wired into `createAnswerStream` → a 2000-char answer sends **nothing** (no preview → no flash).
- **Wiring guards** — the gateway delegates to the function; a global negative assertion that `VISIBLE || RETIRED` is gone. (The previous wiring test had *asserted the bug* — it pinned the conflation as a "guard"; rewritten.)

## Verification

Adversarial 5-lens verification (lost-answer, flash-gone, silence-poke, opt-in-visible, kill-switch-draft) → **SHIP**, `lostAnswerSafe: true`, no blockers. The lost-answer path (the severe failure mode) is proven: a no-reply answer is delivered by turn-flush, never retracted.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 240 gateway/answer-stream vitest + 55 bun tests green (both runners)
- [x] total-enumeration + end-to-end dormant-config behavioural tests
- [ ] canary: confirm `answer-stream: retracted preliminary` drops to **zero** on test-harness/marko

## Risk

LOW. Behaviour-equivalent on the opt-in-visible and kill-switch-draft paths; the default path goes from "flash" to "single clean reply". Kill switches unchanged (`SWITCHROOM_VISIBLE_ANSWER_STREAM`, `SWITCHROOM_DRAFT_ANSWER_LANE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)