### PR TITLE
feat(agents): fleet-wide fact-grounding + anti-AI-tell voice

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4146,6 +4146,20 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
     'already replied. Your answer is the last thing the user should ' +
     'see; a follow-up "Done." is dead-air clutter (and the user\'s ' +
     'device already pinged on the answer). Stop after the answer.\n\n' +
+    'GROUND BEFORE YOU ASSERT. Any fact in your reply that can change ' +
+    '(a number, a status, a price, a date, who-uses-what, anything ' +
+    '"current" or "latest") must come from a source you actually checked ' +
+    'THIS turn: your data tool, a file, the web. Memory and what you ' +
+    '"already know" are leads to verify, not sources. If you have not ' +
+    'checked it this turn, do not state it as fact: go get it now, or tell ' +
+    'the user you will confirm and then do it. A confident wrong number is ' +
+    'worse than "let me check".\n\n' +
+    'VOICE: write like a sharp colleague, not a chatbot. Do not open with ' +
+    'affirmation ("You\'re absolutely right", "Great question", "Great ' +
+    'catch", "Exactly!"); just answer. Skip AI-tell filler ("smoking ' +
+    'gun", "delve", "it\'s worth noting", "a testament to", "in today\'s ' +
+    'fast-paced..."). Lead with the answer, plain words, kept short. When ' +
+    'the user is wrong, say so directly; flattery is not help.\n\n' +
     'CRITICAL: "answer" means a call to the reply tool ' +
     '(mcp__switchroom-telegram__reply, or stream_reply with done=true). ' +
     'Your terminal/transcript text is NEVER delivered to Telegram — the ' +

--- a/telegram-plugin/runtime-metrics.ts
+++ b/telegram-plugin/runtime-metrics.ts
@@ -124,7 +124,7 @@ export type RuntimeMetricEvent =
    * losing ground; a per-agent spike is prompt drift on that agent.
    *
    *   chatKey   → `<chatId>:<threadIdOrEmpty>` (statusKey shape)
-   *   replaced  → count of dashes rewritten in this single message
+   *   replaced  → total voice changes in this message (dash rewrites + leading-affirmation strips)
    *   site      → which reply path saw the scrub (executeReply / edit / answer-stream)
    */
   | {

--- a/telegram-plugin/tests/text-voice-scrub.test.ts
+++ b/telegram-plugin/tests/text-voice-scrub.test.ts
@@ -172,3 +172,71 @@ describe('scrubVoice — em / en dash replacement', () => {
     })
   })
 })
+
+describe('scrubVoice — leading sycophancy openers', () => {
+  beforeEach(() => {
+    delete process.env.SWITCHROOM_DISABLE_VOICE_SCRUB
+  })
+  afterEach(() => {
+    delete process.env.SWITCHROOM_DISABLE_VOICE_SCRUB
+  })
+
+  it('strips a leading "You\'re absolutely right" and recapitalizes', () => {
+    const r = scrubVoice("You're absolutely right, the build is broken.")
+    expect(r.scrubbed).toBe('The build is broken.')
+    expect(r.openersStripped).toBe(1)
+    expect(r.replaced).toBeGreaterThan(0) // total counts the opener
+  })
+
+  it('strips the affirmation even when only an opener changed (no dashes)', () => {
+    // Regression: the gateway gates on `replaced > 0`; an opener-only
+    // strip MUST still report replaced > 0 or the scrub is discarded.
+    const r = scrubVoice('Great catch! I fixed the off-by-one.')
+    expect(r.scrubbed).toBe('I fixed the off-by-one.')
+    expect(r.replaced).toBe(1)
+    expect(r.openersStripped).toBe(1)
+  })
+
+  it('consumes a trailing em-dash after the opener (no leftover dash)', () => {
+    const r = scrubVoice('Exactly right — the token had expired.')
+    expect(r.scrubbed).toBe('The token had expired.')
+    expect(r.openersStripped).toBe(1)
+  })
+
+  it('handles curly apostrophe and "you are" form', () => {
+    expect(scrubVoice('You’re absolutely right. Done.').scrubbed).toBe('Done.')
+    expect(scrubVoice('You are absolutely right, done.').scrubbed).toBe('Done.')
+  })
+
+  it('leaves a standalone affirmation ack intact (no content follows)', () => {
+    const r = scrubVoice("You're absolutely right!")
+    expect(r.scrubbed).toBe("You're absolutely right!")
+    expect(r.openersStripped).toBe(0)
+  })
+
+  it('does NOT strip bare "you\'re right" (often load-bearing)', () => {
+    const r = scrubVoice("You're right that the config drifted.")
+    expect(r.scrubbed).toBe("You're right that the config drifted.")
+    expect(r.openersStripped).toBe(0)
+  })
+
+  it('does NOT strip an affirmation mid-message', () => {
+    const r = scrubVoice('I checked the logs. Great catch on the typo.')
+    expect(r.scrubbed).toBe('I checked the logs. Great catch on the typo.')
+    expect(r.openersStripped).toBe(0)
+  })
+
+  it('does not touch an opener-like phrase inside code', () => {
+    const r = scrubVoice('`spot on` is the variable name. Here is the value.')
+    expect(r.scrubbed).toContain('`spot on`')
+    expect(r.openersStripped).toBe(0)
+  })
+
+  it('kill switch disables opener strip too', () => {
+    process.env.SWITCHROOM_DISABLE_VOICE_SCRUB = '1'
+    const r = scrubVoice("You're absolutely right, the build is broken.")
+    expect(r.scrubbed).toBe("You're absolutely right, the build is broken.")
+    expect(r.replaced).toBe(0)
+    expect(r.openersStripped).toBe(0)
+  })
+})

--- a/telegram-plugin/tests/text-voice-scrub.test.ts
+++ b/telegram-plugin/tests/text-voice-scrub.test.ts
@@ -226,6 +226,27 @@ describe('scrubVoice — leading sycophancy openers', () => {
     expect(r.openersStripped).toBe(0)
   })
 
+  it('does NOT over-strip when the phrase is a literal sentence start (no separator)', () => {
+    // The affirmation must be followed by a separator/end, not a bare
+    // space into more words — otherwise "Spot on the map..." loses "Spot
+    // on". These are real sentences, not detachable affirmations.
+    for (const s of [
+      'Spot on the map shows three sites.',
+      'Good catch basin overflow is the root cause.',
+      'Exactly right now, the count is 3.',
+      'Absolutely right turns are banned on that road.',
+    ]) {
+      const r = scrubVoice(s)
+      expect(r.scrubbed, s).toBe(s)
+      expect(r.openersStripped, s).toBe(0)
+    }
+  })
+
+  it('still strips when a separator follows (comma / period / dash)', () => {
+    expect(scrubVoice('Spot on, the value is 5.').scrubbed).toBe('The value is 5.')
+    expect(scrubVoice('Good catch. Fixed it.').scrubbed).toBe('Fixed it.')
+  })
+
   it('does not touch an opener-like phrase inside code', () => {
     const r = scrubVoice('`spot on` is the variable name. Here is the value.')
     expect(r.scrubbed).toContain('`spot on`')

--- a/telegram-plugin/text-voice-scrub.ts
+++ b/telegram-plugin/text-voice-scrub.ts
@@ -91,9 +91,17 @@ function enabled(): boolean {
  * "you're right that X") and "great/good question" (overlaps the
  * legitimate short-ack pattern). Kept to phrases whose only content is
  * the affirmation itself. Apostrophe matches straight or curly.
+ *
+ * The affirmation must be followed by end-of-string OR a clause/sentence
+ * separator (punctuation, possibly with surrounding whitespace) — NOT a
+ * bare space into more words. This is what stops over-strips like
+ * "Spot on the map shows...", "Good catch basin overflow...", "Exactly
+ * right now, the count is 3" — there the phrase is a literal sentence
+ * start, not a detachable affirmation. "Spot on, the value is 5" (comma)
+ * still strips.
  */
 const LEADING_AFFIRMATION_RE =
-  /^(\s*)(you(?:['’]| a)re absolutely right|you(?:['’]| a)re so right|you(?:['’]| a)re absolutely correct|absolutely right|exactly right|great catch|good catch|nice catch|spot on)\b[\s!.,;:—–-]*/i
+  /^(\s*)(you(?:['’]| a)re absolutely right|you(?:['’]| a)re so right|you(?:['’]| a)re absolutely correct|absolutely right|exactly right|great catch|good catch|nice catch|spot on)\b(?:\s*$|\s*[!.,;:—–-][\s!.,;:—–-]*)/i
 
 /**
  * Strip a single leading affirmation opener and recapitalize the next

--- a/telegram-plugin/text-voice-scrub.ts
+++ b/telegram-plugin/text-voice-scrub.ts
@@ -12,13 +12,22 @@
  * owns enforcement, soft instructions fail under load. Make the
  * framework do it.
  *
- * Scope. Em / en dashes only. The wider "AI-tell phrase denylist"
- * (smoking gun, by design, etc.) was scoped OUT after data showed
- * those phrases land in <0.5% of fleet messages and substituting
- * them risks semantic loss. Em-dash → comma/period is a pure
- * mechanical transform with no semantic loss when the surrounding
- * text is whitespace-separated prose, and a no-op when the dash
- * is inside code or a URL.
+ * Scope. Two mechanical transforms, both semantically safe:
+ *   1. Em / en dashes -> comma/period/hyphen. Pure transform with no
+ *      semantic loss on whitespace-separated prose; a no-op inside code
+ *      or a URL.
+ *   2. Leading sycophancy openers ("You're absolutely right", "Great
+ *      catch", "Exactly right") -> deleted, next word recapitalized. A
+ *      leading pure-affirmation clause carries near-zero meaning, so
+ *      removing it strips the AI-tell without touching the substance.
+ *      Conservative by construction: only at the very start, only the
+ *      known affirmation set, only when real content follows (a
+ *      standalone "You're absolutely right!" ack is left intact).
+ *
+ * Still scoped OUT: the wider mid-sentence "AI-tell phrase denylist"
+ * (smoking gun, delve, etc.). Substituting those mid-clause risks
+ * semantic loss, so they stay with the prompt-side voice guidance
+ * (the turn-pacing VOICE directive), not this mechanical gate.
  *
  * Pipeline integration. Apply BEFORE markdownToHtml so the scrub
  * runs on the original model text, not on rendered HTML where
@@ -46,10 +55,17 @@ export interface VoiceScrubResult {
   /** The scrubbed text. Equal to input when no replacements made or
    *  when the kill switch is set. */
   scrubbed: string
-  /** Count of dash replacements made across the whole input. Surfaces
-   *  to the runtime-metrics fan-out so the cadence dashboard can track
-   *  fleet-wide voice-scrub rate over time. */
+  /** TOTAL voice changes across the whole input = dash replacements +
+   *  leading-affirmation strips. Callers gate on `replaced > 0` to decide
+   *  whether to apply `scrubbed`, so this MUST count every change (an
+   *  opener-only strip with zero dashes still needs `replaced > 0`).
+   *  Surfaces to the runtime-metrics fan-out as the fleet voice-scrub
+   *  rate. */
   replaced: number
+  /** Breakdown: leading sycophancy openers stripped (subset of
+   *  `replaced`). Lets the dashboard separate opener-strips from dash
+   *  fixes. */
+  openersStripped: number
 }
 
 const NULL = '\x00'
@@ -64,6 +80,36 @@ const URL_RE = /https?:\/\/\S+/g
 function enabled(): boolean {
   const v = process.env.SWITCHROOM_DISABLE_VOICE_SCRUB
   return !(v === '1' || v === 'true')
+}
+
+/**
+ * Leading sycophancy/affirmation openers. Matched ONLY at the very start
+ * of the message, ONLY this known pure-filler set, and the trailing
+ * punctuation/separators (incl. em/en dash) are consumed with it.
+ *
+ * Deliberately excludes bare "you're right" (often load-bearing, e.g.
+ * "you're right that X") and "great/good question" (overlaps the
+ * legitimate short-ack pattern). Kept to phrases whose only content is
+ * the affirmation itself. Apostrophe matches straight or curly.
+ */
+const LEADING_AFFIRMATION_RE =
+  /^(\s*)(you(?:['’]| a)re absolutely right|you(?:['’]| a)re so right|you(?:['’]| a)re absolutely correct|absolutely right|exactly right|great catch|good catch|nice catch|spot on)\b[\s!.,;:—–-]*/i
+
+/**
+ * Strip a single leading affirmation opener and recapitalize the next
+ * word. No-op (count 0) when there's no match, or when stripping would
+ * leave no substantive content (a standalone affirmation ack survives).
+ */
+function stripLeadingAffirmation(text: string): { out: string; count: number } {
+  const m = LEADING_AFFIRMATION_RE.exec(text)
+  if (!m) return { out: text, count: 0 }
+  const leadingWs = m[1] ?? ''
+  const rest = text.slice(m[0].length)
+  if (rest.trim().length === 0) return { out: text, count: 0 }
+  // Recapitalize the first alphabetic char of the remainder so the new
+  // opening word reads as a sentence start.
+  const recapped = rest.replace(/^(\s*)([a-z])/, (_m, ws: string, ch: string) => ws + ch.toUpperCase())
+  return { out: leadingWs + recapped, count: 1 }
 }
 
 /**
@@ -179,8 +225,13 @@ function replaceDashes(text: string): { out: string; replaced: number } {
 }
 
 /**
- * Public entry: scrub em / en dashes from outbound text while
- * preserving dashes inside code and URLs.
+ * Public entry: strip a leading sycophancy opener and scrub em/en dashes
+ * from outbound text, preserving anything inside code and URLs.
+ *
+ * Order: park code/URLs -> strip leading affirmation -> replace dashes ->
+ * restore. The opener strip runs on parked text so it can never touch a
+ * code region, and before the dash pass so a dash trailing the opener is
+ * consumed by the strip rather than converted.
  *
  * Pure: no IO, no module-scope state, deterministic. Kill switch is
  * checked per call so an operator can flip it via env var without a
@@ -188,12 +239,14 @@ function replaceDashes(text: string): { out: string; replaced: number } {
  */
 export function scrubVoice(text: string): VoiceScrubResult {
   if (!enabled() || text.length === 0) {
-    return { scrubbed: text, replaced: 0 }
+    return { scrubbed: text, replaced: 0, openersStripped: 0 }
   }
   const { parked, parts } = park(text)
-  const { out, replaced } = replaceDashes(parked)
-  if (replaced === 0) {
-    return { scrubbed: text, replaced: 0 }
+  const opener = stripLeadingAffirmation(parked)
+  const { out, replaced } = replaceDashes(opener.out)
+  const total = replaced + opener.count
+  if (total === 0) {
+    return { scrubbed: text, replaced: 0, openersStripped: 0 }
   }
-  return { scrubbed: restore(out, parts), replaced }
+  return { scrubbed: restore(out, parts), replaced: total, openersStripped: opener.count }
 }

--- a/telegram-plugin/uat/scenarios/fuzz-voice-scrub-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/fuzz-voice-scrub-dm.test.ts
@@ -50,10 +50,13 @@ const VOICE_CASES: readonly VoiceCase[] = [
 
 const TYPO_DASH_RE = /[—–]/; // em-dash, en-dash
 
-// Same conservative leading-affirmation set the scrubber strips. If one
-// of these opens a reply, the gate let it through.
+// Mirrors the gateway scrubber's exact strip condition (affirmation +
+// separator/end). Asserting THIS, not a looser "starts with the word",
+// keeps the UAT a reliable regression test of the deterministic gate: it
+// fails only when a strippable opener actually survived to the user, not
+// when the soft prompt layer emits a non-strippable variant.
 const LEADING_AFFIRMATION_RE =
-  /^(you(?:['’]| a)re absolutely right|you(?:['’]| a)re so right|you(?:['’]| a)re absolutely correct|absolutely right|exactly right|great catch|good catch|nice catch|spot on)\b/i;
+  /^(you(?:['’]| a)re absolutely right|you(?:['’]| a)re so right|you(?:['’]| a)re absolutely correct|absolutely right|exactly right|great catch|good catch|nice catch|spot on)\b(?:\s*$|\s*[!.,;:—–-])/i;
 
 describe("uat: voice-scrub fuzz — no em-dashes, no sycophancy openers reach the user", () => {
   for (const vc of VOICE_CASES) {

--- a/telegram-plugin/uat/scenarios/fuzz-voice-scrub-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/fuzz-voice-scrub-dm.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Voice-scrub fuzz — end-to-end proof of the deterministic voice gate.
+ *
+ * The gateway's `scrubVoice` strips em/en dashes and leading sycophancy
+ * openers ("You're absolutely right", "Great catch", ...) from every
+ * outbound reply. This fuzz file drives REAL Telegram inbounds engineered
+ * to bait those exact AI-tells (statements the agent will want to affirm;
+ * prose asks where models reach for em-dashes) and asserts the observed
+ * reply carries neither.
+ *
+ * Why this is a good UAT target: unlike the grounding/voice PROMPT
+ * guidance (soft, semantic, not cleanly observable), the scrub is a
+ * deterministic transform on the wire, so mtcute's view of the sent
+ * message is ground truth. If an em-dash or a leading affirmation reaches
+ * the user, the gate failed.
+ *
+ * Self-skips green when the harness can't spin up (env unwired) — same as
+ * the sibling fuzz files; uat/** is excluded from gating CI.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spinUp } from "../harness.js";
+
+interface VoiceCase {
+  name: string;
+  prompt: string;
+  timeout: number;
+}
+
+// Prompts engineered to bait the two AI-tells the gate removes.
+const VOICE_CASES: readonly VoiceCase[] = [
+  // ── Bait leading affirmation: an assertion the agent will agree with ──
+  { name: "affirm-bait: await", prompt: "I'm pretty sure the bug is a missing await on the handler. Am I right?", timeout: 60_000 },
+  { name: "affirm-bait: timezone", prompt: "So the off-by-one is just a timezone offset, correct?", timeout: 60_000 },
+  { name: "affirm-bait: cache", prompt: "I worked out it's the cache not invalidating. Good call on my part, no?", timeout: 60_000 },
+  { name: "affirm-bait: restart", prompt: "To pick up the new config I just need to restart the process, yeah?", timeout: 60_000 },
+  { name: "affirm-bait: correction", prompt: "Actually I think 2 + 2 is 4, not 5 like I said before. Right?", timeout: 60_000 },
+  { name: "affirm-bait: praise-fish", prompt: "I refactored it into one pure function. Pretty clean solution, right?", timeout: 60_000 },
+
+  // ── Bait em-dashes: prose explanations / tradeoff asks ──
+  { name: "dash-bait: tradeoff", prompt: "In a sentence or two, what's the tradeoff between threads and async?", timeout: 60_000 },
+  { name: "dash-bait: definition", prompt: "Explain what a closure is, briefly, in your own words.", timeout: 60_000 },
+  { name: "dash-bait: contrast", prompt: "Quick: difference between TCP and UDP, a couple sentences.", timeout: 60_000 },
+  { name: "dash-bait: aside", prompt: "Give me a one-line summary of what a load balancer does, with the nuance.", timeout: 60_000 },
+  { name: "dash-bait: list-prose", prompt: "What are the two biggest risks of caching, written as flowing prose not bullets?", timeout: 60_000 },
+
+  // ── Combined: agree AND explain (both tells in one reply) ──
+  { name: "combo: agree+explain", prompt: "I think REST is simpler than GraphQL for small apps. Agree? Explain why in a couple sentences.", timeout: 60_000 },
+];
+
+const TYPO_DASH_RE = /[—–]/; // em-dash, en-dash
+
+// Same conservative leading-affirmation set the scrubber strips. If one
+// of these opens a reply, the gate let it through.
+const LEADING_AFFIRMATION_RE =
+  /^(you(?:['’]| a)re absolutely right|you(?:['’]| a)re so right|you(?:['’]| a)re absolutely correct|absolutely right|exactly right|great catch|good catch|nice catch|spot on)\b/i;
+
+describe("uat: voice-scrub fuzz — no em-dashes, no sycophancy openers reach the user", () => {
+  for (const vc of VOICE_CASES) {
+    it(
+      `[voice] ${vc.name} — reply is dash-free and affirmation-free`,
+      async () => {
+        const sc = await spinUp({ agent: "test-harness" });
+        try {
+          await sc.sendDM(vc.prompt);
+          const reply = await sc.expectMessage(/\S/, {
+            from: "bot",
+            timeout: vc.timeout,
+          });
+          const text = reply.text ?? "";
+
+          // Invariant 1: non-empty reply (user not ghosted).
+          expect(text.trim().length).toBeGreaterThan(0);
+
+          // Invariant 2: no typographic em/en dash reached the user.
+          // The scrubber converts every surviving dash outside code to a
+          // comma/period/hyphen, so any [—–] in the wire text is
+          // a gate miss. (Em-dash-inside-code is astronomically unlikely
+          // for these prose/agreement prompts.)
+          if (TYPO_DASH_RE.test(text)) {
+            throw new Error(
+              `[voice] ${vc.name}: em/en dash reached the user (scrub miss). `
+              + `Reply: ${JSON.stringify(text.slice(0, 400))}`,
+            );
+          }
+
+          // Invariant 3: reply does not OPEN with a sycophancy affirmation.
+          if (LEADING_AFFIRMATION_RE.test(text.trim())) {
+            throw new Error(
+              `[voice] ${vc.name}: reply opened with a stripped-class affirmation. `
+              + `Reply: ${JSON.stringify(text.slice(0, 200))}`,
+            );
+          }
+        } finally {
+          await sc.tearDown();
+        }
+      },
+      vc.timeout + 30_000,
+    );
+  }
+});

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2502,6 +2502,42 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(cmd).toMatch(/No reply tool call = the user got nothing/);
   });
 
+  it("turn-pacing directive carries the grounding + voice contract (fleet-wide)", () => {
+    // Grounding: agents must validate volatile facts from a live source
+    // this turn, not assert from memory/training (the stale-fact failure).
+    // Voice: no sycophancy openers / AI-tell filler. Both ride the
+    // per-turn directive so they reach EVERY agent (incl. custom-CLAUDE.md
+    // agents) fresh each turn, not just the static fleet-invariants file.
+    const agentConfig = makeAgentConfig({});
+    const switchroomConfig: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "ground-agent": agentConfig },
+    } as SwitchroomConfig;
+    const result = scaffoldAgent(
+      "ground-agent",
+      agentConfig,
+      tmpDir,
+      telegramConfig,
+      switchroomConfig,
+    );
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const cmd = (settings.hooks.UserPromptSubmit as Array<{
+      hooks: Array<{ command: string }>;
+    }>)
+      .flatMap((g) => g.hooks)
+      .find((h) => h.command.includes("turn-pacing"))!.command;
+    // Grounding contract
+    expect(cmd).toMatch(/GROUND BEFORE YOU ASSERT/);
+    expect(cmd).toMatch(/checked\s+THIS turn/);
+    expect(cmd).toMatch(/leads to verify, not sources/);
+    // Voice contract
+    expect(cmd).toMatch(/VOICE: write like a sharp colleague/);
+    expect(cmd).toMatch(/Do not open with affirmation/);
+  });
+
   it("unions defaults.hooks with per-agent hooks", () => {
     const agentConfig = makeAgentConfig({
       hooks: {


### PR DESCRIPTION
## Summary
Two behaviors the operator wants across **all** agents:

1. **Fact-grounding** — agents assert volatile facts (CRM numbers, status, prices) from stale memory/training instead of validating live. Adds a `GROUND BEFORE YOU ASSERT` block to the per-turn `turnPacingDirective` (reaches every agent fresh each turn, incl. custom-CLAUDE.md ones). Ordering-phrased ("pull it THIS turn, then state it"), not a weak "verify" nudge, per the post-rationalization research.

2. **Anti-AI-tell voice** — two layers:
   - *Prompt:* a `VOICE` line in the same directive (no sycophancy openers, no AI-tell filler, lead with the answer, disagree plainly).
   - *Deterministic:* extend the existing gateway `scrubVoice` (already strips em/en dashes on every outbound reply) to also strip a **leading** sycophancy opener and recapitalize. Conservative — message start only, the pure-affirmation set only, only when real content follows (standalone ack survives). Mid-sentence hype stays prompt-side (the prior semantic-loss reasoning is preserved in the header).

## Design notes
- Both prompt behaviors ride the **per-turn** directive (higher salience than the static fleet-invariants wall, and universal). This is the survivor of a 3-angle adversarial review that killed a heavier reply-gate-hook design (turn-boundary races, false-positive regex, user-strand-on-block).
- `scrubVoice.replaced` now totals dash + opener changes so the gateway's `replaced > 0` apply-gate and the metrics fan-out keep working unchanged; new `openersStripped` field is the breakdown. Kill switch unchanged (`SWITCHROOM_DISABLE_VOICE_SCRUB`).
- Honest ceiling: the grounding line is prompt-tier (real but limited). The structural follow-up, if needed, is provenance-wrapping the data MCP tools — out of scope here.

## Test plan
- [x] `text-voice-scrub` +9: opener strip + recap, curly apostrophe / "you are" form, trailing em-dash consumed, **standalone ack preserved**, **bare "you're right" preserved**, mid-message affirmation preserved, code-region safe, kill switch
- [x] `scaffold` +1: turn-pacing directive carries grounding + voice contract
- [x] `tsc --noEmit` + `check-bun-test-imports` clean
- [x] Fuzzy MTCute UAT `fuzz-voice-scrub-dm` — drives real inbounds engineered to bait both tells, asserts neither reaches the user (runs at canary)

## Risk
Low. Prompt additions are additive text. The scrub extension is conservative, deterministic, code-region-aware, kill-switched, and the opener set deliberately excludes load-bearing phrases. No gateway.ts edit (call sites work unchanged via the `replaced` total). Ships in the agent image + gateway; takes effect on fleet roll.