### PR TITLE
feat(voice): prompt-first tone, stop context-free word deletion by default

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -4154,12 +4154,16 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
     'checked it this turn, do not state it as fact: go get it now, or tell ' +
     'the user you will confirm and then do it. A confident wrong number is ' +
     'worse than "let me check".\n\n' +
-    'VOICE: write like a sharp colleague, not a chatbot. Do not open with ' +
-    'affirmation ("You\'re absolutely right", "Great question", "Great ' +
-    'catch", "Exactly!"); just answer. Skip AI-tell filler ("smoking ' +
-    'gun", "delve", "it\'s worth noting", "a testament to", "in today\'s ' +
-    'fast-paced..."). Lead with the answer, plain words, kept short. When ' +
-    'the user is wrong, say so directly; flattery is not help.\n\n' +
+    'VOICE: write like a sharp colleague, not a chatbot. Lead with the ' +
+    'answer, plain words, plain punctuation (commas and periods, not ' +
+    'em-dashes). Skip the hollow openers ("You\'re absolutely right", ' +
+    '"Great question", "Great catch", "Exactly!") and AI-tell filler ' +
+    '("smoking gun", "delve", "it\'s worth noting", "a testament to", "in ' +
+    'today\'s fast-paced..."). Genuine acknowledgement is fine when it is ' +
+    'real and adds something ("good catch, that was my bug"); what to ' +
+    'avoid is the reflexive praise that opens every reply and means ' +
+    'nothing. When the user is wrong, say so directly; flattery is not ' +
+    'help.\n\n' +
     'CRITICAL: "answer" means a call to the reply tool ' +
     '(mcp__switchroom-telegram__reply, or stream_reply with done=true). ' +
     'Your terminal/transcript text is NEVER delivered to Telegram — the ' +

--- a/telegram-plugin/tests/text-voice-scrub.test.ts
+++ b/telegram-plugin/tests/text-voice-scrub.test.ts
@@ -173,12 +173,17 @@ describe('scrubVoice — em / en dash replacement', () => {
   })
 })
 
-describe('scrubVoice — leading sycophancy openers', () => {
+describe('scrubVoice — leading sycophancy openers (opt-in backstop)', () => {
+  // The opener strip is OFF by default (tone is the prompt's job); these
+  // tests opt it in to exercise the mechanism that remains available via
+  // SWITCHROOM_VOICE_STRIP_OPENERS=1.
   beforeEach(() => {
     delete process.env.SWITCHROOM_DISABLE_VOICE_SCRUB
+    process.env.SWITCHROOM_VOICE_STRIP_OPENERS = '1'
   })
   afterEach(() => {
     delete process.env.SWITCHROOM_DISABLE_VOICE_SCRUB
+    delete process.env.SWITCHROOM_VOICE_STRIP_OPENERS
   })
 
   it('strips a leading "You\'re absolutely right" and recapitalizes', () => {
@@ -259,5 +264,45 @@ describe('scrubVoice — leading sycophancy openers', () => {
     expect(r.scrubbed).toBe("You're absolutely right, the build is broken.")
     expect(r.replaced).toBe(0)
     expect(r.openersStripped).toBe(0)
+  })
+})
+
+describe('scrubVoice — opener strip is OFF by default (prompt carries tone)', () => {
+  // No SWITCHROOM_VOICE_STRIP_OPENERS set: the deterministic layer must
+  // NOT delete words. Em-dash normalization (punctuation, no content
+  // removed) still runs. Tone is the prompt VOICE directive's job.
+  beforeEach(() => {
+    delete process.env.SWITCHROOM_DISABLE_VOICE_SCRUB
+    delete process.env.SWITCHROOM_VOICE_STRIP_OPENERS
+  })
+  afterEach(() => {
+    delete process.env.SWITCHROOM_VOICE_STRIP_OPENERS
+  })
+
+  it('does NOT strip a leading affirmation by default', () => {
+    const r = scrubVoice("You're absolutely right, the build is broken.")
+    expect(r.scrubbed).toBe("You're absolutely right, the build is broken.")
+    expect(r.openersStripped).toBe(0)
+  })
+
+  it('does NOT strip "Great catch" by default', () => {
+    const r = scrubVoice('Great catch! Fixed it.')
+    expect(r.scrubbed).toBe('Great catch! Fixed it.')
+    expect(r.openersStripped).toBe(0)
+  })
+
+  it('STILL normalizes em-dashes by default (punctuation, no content removed)', () => {
+    const r = scrubVoice('on it — checking the calendar')
+    expect(r.scrubbed).toBe('on it, checking the calendar')
+    expect(r.replaced).toBe(1)
+    expect(r.openersStripped).toBe(0)
+  })
+
+  it('an affirmation opener with an em-dash keeps the words, fixes only the dash', () => {
+    const r = scrubVoice('Exactly right — the token had expired.')
+    // Opener preserved; the em-dash after it becomes a comma.
+    expect(r.scrubbed).toBe('Exactly right, the token had expired.')
+    expect(r.openersStripped).toBe(0)
+    expect(r.replaced).toBe(1)
   })
 })

--- a/telegram-plugin/text-voice-scrub.ts
+++ b/telegram-plugin/text-voice-scrub.ts
@@ -12,22 +12,27 @@
  * owns enforcement, soft instructions fail under load. Make the
  * framework do it.
  *
- * Scope. Two mechanical transforms, both semantically safe:
- *   1. Em / en dashes -> comma/period/hyphen. Pure transform with no
- *      semantic loss on whitespace-separated prose; a no-op inside code
- *      or a URL.
- *   2. Leading sycophancy openers ("You're absolutely right", "Great
- *      catch", "Exactly right") -> deleted, next word recapitalized. A
- *      leading pure-affirmation clause carries near-zero meaning, so
- *      removing it strips the AI-tell without touching the substance.
- *      Conservative by construction: only at the very start, only the
- *      known affirmation set, only when real content follows (a
- *      standalone "You're absolutely right!" ack is left intact).
+ * Scope. By default ONE mechanical transform, the only one that removes
+ * no content:
+ *   1. Em / en dashes -> comma/period/hyphen. Pure punctuation
+ *      substitution, no semantic loss on whitespace-separated prose; a
+ *      no-op inside code or a URL. Kept deterministic because prompt-only
+ *      guidance was measured to fail at it (em-dashes in 73% of replies
+ *      despite the SOUL rule).
  *
- * Still scoped OUT: the wider mid-sentence "AI-tell phrase denylist"
+ * OPT-IN, off by default:
+ *   2. Leading sycophancy openers ("You're absolutely right", "Great
+ *      catch") -> deleted + recapitalized. This one removes WORDS, and a
+ *      context-free hook can strip a sincere "good catch, that was my
+ *      bug" along with the hollow kind. Per operator steer (2026-06),
+ *      tone is carried by the prompt VOICE directive (where the model has
+ *      context to keep genuine acknowledgement and drop only the empty
+ *      reflexive praise), not by blind deletion here. Re-enable the
+ *      backstop with `SWITCHROOM_VOICE_STRIP_OPENERS=1`.
+ *
+ * Always scoped OUT: the wider mid-sentence "AI-tell phrase denylist"
  * (smoking gun, delve, etc.). Substituting those mid-clause risks
- * semantic loss, so they stay with the prompt-side voice guidance
- * (the turn-pacing VOICE directive), not this mechanical gate.
+ * semantic loss, so they stay with the prompt-side voice guidance.
  *
  * Pipeline integration. Apply BEFORE markdownToHtml so the scrub
  * runs on the original model text, not on rendered HTML where
@@ -80,6 +85,25 @@ const URL_RE = /https?:\/\/\S+/g
 function enabled(): boolean {
   const v = process.env.SWITCHROOM_DISABLE_VOICE_SCRUB
   return !(v === '1' || v === 'true')
+}
+
+/**
+ * Leading-affirmation stripping is OPT-IN and OFF by default.
+ *
+ * Rationale (operator steer, 2026-06): tone should be carried by the
+ * prompt (the VOICE directive), where the model has context to keep a
+ * genuine acknowledgement and drop only the hollow reflexive kind.
+ * Deleting an opener in a context-free hook is bad UX: it can strip a
+ * sincere "good catch, that was my bug" along with the empty praise.
+ * So the deterministic layer no longer removes WORDS by default; it
+ * only normalizes em/en dashes (a punctuation substitution that removes
+ * no content, and that prompt-only guidance was measured to fail at).
+ * Set `SWITCHROOM_VOICE_STRIP_OPENERS=1` to re-enable the deterministic
+ * opener strip as a backstop.
+ */
+function openerStripEnabled(): boolean {
+  const v = process.env.SWITCHROOM_VOICE_STRIP_OPENERS
+  return v === '1' || v === 'true'
 }
 
 /**
@@ -250,7 +274,13 @@ export function scrubVoice(text: string): VoiceScrubResult {
     return { scrubbed: text, replaced: 0, openersStripped: 0 }
   }
   const { parked, parts } = park(text)
-  const opener = stripLeadingAffirmation(parked)
+  // Opener strip is opt-in (default off) — see openerStripEnabled(). By
+  // default the deterministic layer removes no words; only em/en dashes
+  // are normalized below, and tone is left to the prompt's VOICE
+  // directive where the model can judge genuine vs hollow.
+  const opener = openerStripEnabled()
+    ? stripLeadingAffirmation(parked)
+    : { out: parked, count: 0 }
   const { out, replaced } = replaceDashes(opener.out)
   const total = replaced + opener.count
   if (total === 0) {

--- a/telegram-plugin/uat/scenarios/fuzz-voice-scrub-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/fuzz-voice-scrub-dm.test.ts
@@ -63,7 +63,7 @@ const LEADING_AFFIRMATION_RE =
 describe("uat: voice-scrub fuzz — no em-dashes, no sycophancy openers reach the user", () => {
   for (const vc of VOICE_CASES) {
     it(
-      `[voice] ${vc.name} — reply is dash-free and affirmation-free`,
+      `[voice] ${vc.name} — reply is dash-free (affirmation now prompt-tier)`,
       async () => {
         const sc = await spinUp({ agent: "test-harness" });
         try {

--- a/telegram-plugin/uat/scenarios/fuzz-voice-scrub-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/fuzz-voice-scrub-dm.test.ts
@@ -1,18 +1,20 @@
 /**
- * Voice-scrub fuzz — end-to-end proof of the deterministic voice gate.
+ * Voice-scrub fuzz — end-to-end check of the voice layers.
  *
- * The gateway's `scrubVoice` strips em/en dashes and leading sycophancy
- * openers ("You're absolutely right", "Great catch", ...) from every
- * outbound reply. This fuzz file drives REAL Telegram inbounds engineered
- * to bait those exact AI-tells (statements the agent will want to affirm;
- * prose asks where models reach for em-dashes) and asserts the observed
- * reply carries neither.
+ * Two layers with different strengths:
+ *   - Em/en dashes are DETERMINISTIC: the gateway's `scrubVoice`
+ *     normalizes every dash on every outbound reply, so "no em-dash
+ *     reaches the user" is a hard, observable guarantee (asserted).
+ *   - Sycophancy openers are PROBABILISTIC: the deterministic opener
+ *     strip is off by default (operator steer 2026-06: context-free word
+ *     deletion is bad UX), and tone is carried by the prompt VOICE
+ *     directive where the model can keep genuine acknowledgement. So an
+ *     opener is a soft signal (warn), not a gate failure.
  *
- * Why this is a good UAT target: unlike the grounding/voice PROMPT
- * guidance (soft, semantic, not cleanly observable), the scrub is a
- * deterministic transform on the wire, so mtcute's view of the sent
- * message is ground truth. If an em-dash or a leading affirmation reaches
- * the user, the gate failed.
+ * This fuzz file drives REAL Telegram inbounds engineered to bait both
+ * (statements the agent will want to affirm; prose asks where models
+ * reach for em-dashes). mtcute's view of the sent message is ground
+ * truth for the deterministic dash check.
  *
  * Self-skips green when the harness can't spin up (env unwired) — same as
  * the sibling fuzz files; uat/** is excluded from gating CI.
@@ -87,10 +89,15 @@ describe("uat: voice-scrub fuzz — no em-dashes, no sycophancy openers reach th
             );
           }
 
-          // Invariant 3: reply does not OPEN with a sycophancy affirmation.
+          // Invariant 3 (SOFT): reply ideally does not OPEN with a hollow
+          // affirmation. This is now PROBABILISTIC, not deterministic: the
+          // opener strip is off by default and tone is the prompt VOICE
+          // directive's job, so an occasional opener is a soft signal (the
+          // model judged it genuine), not a hard gate failure. Warn, don't
+          // fail — a hard assert here would flake on a prompt-driven lever.
           if (LEADING_AFFIRMATION_RE.test(text.trim())) {
-            throw new Error(
-              `[voice] ${vc.name}: reply opened with a stripped-class affirmation. `
+            console.warn(
+              `[voice] ${vc.name}: reply opened with an affirmation (prompt-tier, not enforced). `
               + `Reply: ${JSON.stringify(text.slice(0, 200))}`,
             );
           }

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -2533,9 +2533,13 @@ describe("scaffoldAgent with global defaults cascade", () => {
     expect(cmd).toMatch(/GROUND BEFORE YOU ASSERT/);
     expect(cmd).toMatch(/checked\s+THIS turn/);
     expect(cmd).toMatch(/leads to verify, not sources/);
-    // Voice contract
+    // Voice contract (context-aware: skip hollow openers, keep genuine
+    // acknowledgement; plain punctuation). Tone is prompt-driven; the
+    // deterministic opener strip is off by default.
     expect(cmd).toMatch(/VOICE: write like a sharp colleague/);
-    expect(cmd).toMatch(/Do not open with affirmation/);
+    expect(cmd).toMatch(/Skip the hollow openers/);
+    expect(cmd).toMatch(/Genuine acknowledgement is fine/);
+    expect(cmd).toMatch(/plain punctuation/);
   });
 
   it("unions defaults.hooks with per-agent hooks", () => {


### PR DESCRIPTION
## Summary
Operator steer: agent tone should be carried by the agent *understanding* it (prompt, context-aware), not by a hook blindly deleting words. Context-free removal is bad UX (it can strip a sincere "good catch, that was my bug" along with hollow praise).

- **Sycophancy-opener strip is now opt-in, OFF by default** (`SWITCHROOM_VOICE_STRIP_OPENERS=1` re-enables the backstop). By default the deterministic layer removes no words.
- **Em-dash normalization stays deterministic** — it substitutes punctuation, removes no content, and prompt-only was measured to fail at it (em-dashes in 73% of replies despite the SOUL rule). The prompt now also asks for plain punctuation so both layers align.
- **The turn-pacing VOICE directive becomes context-aware**: skip hollow openers and AI-tell filler, but genuine acknowledgement that adds something is fine. The model has context the hook never will, so tone lives there.

## Why this split
The AI-tell that is pure punctuation (em-dash) is safe to enforce deterministically. The AI-tell that is about judgment and context (sycophancy/tone) belongs in the prompt, where the model can keep what is genuine and drop what is hollow. This is the "deterministic for what is provably safe, prompt for what needs context" line the whole codebase already follows.

## Test plan
- [x] `text-voice-scrub` 34: opener tests opt-in via the flag; new default-off block proves openers preserved while em-dashes still fixed
- [x] `scaffold` 189: VOICE directive assertion updated (context-aware)
- [x] `tsc` + `check-bun-test-imports` clean
- [x] Fuzz UAT keeps the deterministic em-dash assertion (hard), downgrades the opener check to a soft warn (now probabilistic)

## Risk
Low and reversible. The opener-strip code is unchanged, just gated behind a default-off flag. Em-dash behavior is unchanged. The prompt change is additive text. Kill switch `SWITCHROOM_DISABLE_VOICE_SCRUB` still disables the whole scrub.