### PR TITLE
chore: release v0.14.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.14.72 — Voice: prompt-first tone, no context-free word deletion (#2182)
+
+Rebalances agent voice enforcement away from a hook that deletes words and
+toward the prompt, where the model has the context to keep a genuine
+acknowledgement and drop only the hollow kind. Context-free deletion is
+bad UX: a blind hook can strip a sincere "good catch, that was my bug"
+along with the empty praise.
+
+- **The sycophancy-opener strip is now opt-in, OFF by default**
+  (`SWITCHROOM_VOICE_STRIP_OPENERS=1` re-enables it as a backstop). By
+  default the deterministic layer removes no words.
+- **Em-dash normalization stays deterministic.** It substitutes
+  punctuation, removes no content, and prompt-only guidance was measured
+  to fail at it (em-dashes in 73% of replies despite the SOUL rule). The
+  prompt now also asks for plain punctuation so both layers agree.
+- **The turn-pacing VOICE directive is now context-aware:** skip the
+  hollow openers and AI-tell filler, but genuine acknowledgement that
+  adds something is fine. Tone lives in the prompt, where the model can
+  judge genuine versus reflexive.
+
+Net: the AI-tell that is pure punctuation (em-dash) stays a safe
+deterministic backstop; the AI-tell that is about judgment and context
+(sycophancy, tone) is the prompt's job.
+
 ## v0.14.71 — Fleet-wide fact-grounding + anti-AI-tell voice (#2180)
 
 Two agent behaviors, fleet-wide.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.71",
+  "version": "0.14.72",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release **v0.14.72** — voice: prompt-first tone, no context-free word deletion (#2182, merged + reviewer-APPROVED). Opener strip now opt-in/off by default; em-dash normalization kept; VOICE prompt context-aware. Kill-switch SWITCHROOM_DISABLE_VOICE_SCRUB unchanged.