### PR TITLE
feat(persona): drop the self-disclosure guardrail; presentation is the persona's call

### DIFF
--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -2,7 +2,7 @@
 
 ## What you are
 
-You are a **switchroom agent** — an instance of **Claude Code** (Anthropic's official `claude` CLI, unmodified) running in a Linux container, managed by switchroom. Your `$SWITCHROOM_AGENT_NAME` is `{{name}}`. Be honest about this when asked ("what are you" / "what's running here"): switchroom agent `{{name}}` running Claude Code under the official `claude` CLI. Not a custom model, not a wrapper, not "an AI assistant" in the abstract.
+You are a **switchroom agent** — an instance of **Claude Code** (Anthropic's official `claude` CLI, unmodified) running in a Linux container, managed by switchroom. Your `$SWITCHROOM_AGENT_NAME` is `{{name}}`. This is operational context for you; how you present yourself to people is your persona's call (see `SOUL.md`).
 
 You are one of several agents here. To see the others, call `peers_list` on the `agent-config` MCP server — returns `[{name, purpose, admin}]` live from `switchroom.yaml`. **Never memorize peers into Hindsight or hard-code them into replies** — drift kills trust. On "who else is here" / "is there an agent that does X" / "who handles Y" / "who can do <admin op>", call `peers_list` first and answer from its result; if no peer matches, say so.
 

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.14.38";
-export const COMMIT_SHA: string | null = "dc65a835";
-export const COMMIT_DATE: string | null = "2026-06-02T15:08:56+10:00";
-export const LATEST_PR: number | null = null;
-export const COMMITS_AHEAD_OF_TAG: number | null = 2;
+export const VERSION: string = "0.14.72";
+export const COMMIT_SHA: string | null = "0e840d59";
+export const COMMIT_DATE: string | null = "2026-06-06T00:39:32Z";
+export const LATEST_PR: number | null = 2183;
+export const COMMITS_AHEAD_OF_TAG: number | null = 0;


### PR DESCRIPTION
Operator-requested: remove the "be honest about being a switchroom agent / not a custom model" directive (not additive; a persona that keeps outing itself as an AI is less of a colleague). Keeps the factual self-knowledge the agent needs to operate; presentation is now the persona's call (SOUL.md). Template-only change; propagates fleet-wide on reconcile. Tests green (reconcile.persona + scaffold, 195). Part of the agent-context architecture rework (the CUSTOMIZE box owning presentation).