### PR TITLE
feat(web): manage agent↔account access from the dashboard (approval-gated)

### DIFF
--- a/src/config/agent-workspace-account.test.ts
+++ b/src/config/agent-workspace-account.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  setAgentWorkspaceAccount,
+  clearAgentWorkspaceAccount,
+  getAgentWorkspaceAccount,
+} from "./agent-workspace-account.js";
+
+const BASE = `agents:
+  marko:
+    extends: default
+  ziggy:
+    extends: default
+`;
+
+describe("setAgentWorkspaceAccount", () => {
+  it("creates the workspace block + account selector under a known agent", () => {
+    const after = setAgentWorkspaceAccount(BASE, "microsoft", "marko", "lisa@outlook.com");
+    expect(getAgentWorkspaceAccount(after, "microsoft", "marko")).toBe("lisa@outlook.com");
+    // Other agents untouched.
+    expect(getAgentWorkspaceAccount(after, "microsoft", "ziggy")).toBeNull();
+    // Comment-preserving editor keeps the rest of the file.
+    expect(after).toContain("ziggy:");
+  });
+
+  it("is idempotent (byte-equal when already set to the same value)", () => {
+    const once = setAgentWorkspaceAccount(BASE, "google", "marko", "a@b.com");
+    const twice = setAgentWorkspaceAccount(once, "google", "marko", "a@b.com");
+    expect(twice).toBe(once);
+  });
+
+  it("throws for an undeclared agent", () => {
+    expect(() => setAgentWorkspaceAccount(BASE, "microsoft", "nope", "x@y.com")).toThrow(
+      /not declared/,
+    );
+  });
+});
+
+describe("clearAgentWorkspaceAccount", () => {
+  it("removes the selector and drops the now-empty workspace block", () => {
+    const set = setAgentWorkspaceAccount(BASE, "microsoft", "marko", "lisa@outlook.com");
+    const cleared = clearAgentWorkspaceAccount(set, "microsoft", "marko");
+    expect(getAgentWorkspaceAccount(cleared, "microsoft", "marko")).toBeNull();
+    expect(cleared).not.toContain("microsoft_workspace");
+  });
+
+  it("keeps the workspace block when it carries other keys", () => {
+    const withOrg = `agents:
+  marko:
+    microsoft_workspace:
+      account: lisa@outlook.com
+      org_mode: true
+`;
+    const cleared = clearAgentWorkspaceAccount(withOrg, "microsoft", "marko");
+    expect(getAgentWorkspaceAccount(cleared, "microsoft", "marko")).toBeNull();
+    expect(cleared).toContain("org_mode: true");
+  });
+
+  it("is a no-op for an unset selector / unknown agent", () => {
+    expect(clearAgentWorkspaceAccount(BASE, "microsoft", "marko")).toBe(BASE);
+    expect(clearAgentWorkspaceAccount(BASE, "microsoft", "nope")).toBe(BASE);
+  });
+});

--- a/src/config/agent-workspace-account.ts
+++ b/src/config/agent-workspace-account.ts
@@ -1,0 +1,95 @@
+/**
+ * YAML editor for the per-agent workspace account selector —
+ * `agents.<name>.google_workspace.account` /
+ * `agents.<name>.microsoft_workspace.account`.
+ *
+ * The top-level `{google,microsoft}_accounts.<email>.enabled_for[]` ACL
+ * (edited by `{google,microsoft}-accounts-yaml.ts`) says WHICH agents
+ * MAY use an account; this per-agent selector says WHICH account an agent
+ * DOES use. Both are required for the broker to serve credentials —
+ * setting the ACL alone yields `ACCOUNT_NOT_FOUND` because the agent has
+ * no selector. The management UI writes both in one config mutation.
+ *
+ * Comment/format-preserving via the `yaml` Document API, matching the
+ * accounts-yaml editors. String-in / string-out.
+ */
+
+import { parseDocument, isMap, type YAMLMap } from "yaml";
+
+export type WorkspaceProvider = "google" | "microsoft";
+
+function blockKey(provider: WorkspaceProvider): string {
+  return `${provider}_workspace`;
+}
+
+/**
+ * Set `agents.<agent>.<provider>_workspace.account = <account>`, creating
+ * the agent entry / workspace block as needed. Idempotent (byte-equal
+ * pass-through when already set to the same value). Returns the edited
+ * YAML text.
+ *
+ * Throws if `agents` exists but isn't a map, or the named agent isn't
+ * declared — the UI must only pin a known agent.
+ */
+export function setAgentWorkspaceAccount(
+  yamlText: string,
+  provider: WorkspaceProvider,
+  agent: string,
+  account: string,
+): string {
+  const doc = parseDocument(yamlText);
+  const agentsNode = doc.get("agents");
+  if (!isMap(agentsNode)) {
+    throw new Error("switchroom.yaml has no `agents:` map");
+  }
+  if (!(agentsNode as YAMLMap).has(agent)) {
+    throw new Error(`agent '${agent}' is not declared in switchroom.yaml`);
+  }
+  const path = ["agents", agent, blockKey(provider), "account"];
+  const current = doc.getIn(path);
+  if (current === account) return yamlText;
+  doc.setIn(path, account);
+  return String(doc);
+}
+
+/**
+ * Clear the per-agent selector. Removes `…<provider>_workspace.account`;
+ * if the workspace block becomes empty as a result, removes the block
+ * too (so a cleared agent doesn't leave a dangling `microsoft_workspace:
+ * {}` that would still scaffold the MCP server). Idempotent.
+ */
+export function clearAgentWorkspaceAccount(
+  yamlText: string,
+  provider: WorkspaceProvider,
+  agent: string,
+): string {
+  const doc = parseDocument(yamlText);
+  const agentsNode = doc.get("agents");
+  if (!isMap(agentsNode)) return yamlText;
+  if (!(agentsNode as YAMLMap).has(agent)) return yamlText;
+  const blockPath = ["agents", agent, blockKey(provider)];
+  const block = doc.getIn(blockPath);
+  if (!isMap(block)) return yamlText;
+  const accountPath = [...blockPath, "account"];
+  if (doc.getIn(accountPath) === undefined) return yamlText;
+  doc.deleteIn(accountPath);
+  // Drop an empty workspace block so it doesn't keep scaffolding the MCP.
+  const after = doc.getIn(blockPath);
+  if (isMap(after) && (after as YAMLMap).items.length === 0) {
+    doc.deleteIn(blockPath);
+  }
+  return String(doc);
+}
+
+/**
+ * Read the per-agent selector. Returns the pinned account email or null.
+ */
+export function getAgentWorkspaceAccount(
+  yamlText: string,
+  provider: WorkspaceProvider,
+  agent: string,
+): string | null {
+  const doc = parseDocument(yamlText);
+  const v = doc.getIn(["agents", agent, blockKey(provider), "account"]);
+  return typeof v === "string" ? v : null;
+}

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -38,6 +38,33 @@ import {
   agentCanAccessNotionDB,
   shouldEmitNotionMcp,
 } from "../config/notion-workspace-acl.js";
+import {
+  enableAgentsOnGoogleAccount,
+  disableAgentsOnGoogleAccount,
+} from "../cli/google-accounts-yaml.js";
+import {
+  enableAgentsOnMicrosoftAccount,
+  disableAgentsOnMicrosoftAccount,
+} from "../cli/microsoft-accounts-yaml.js";
+import {
+  setAgentWorkspaceAccount,
+  clearAgentWorkspaceAccount,
+  getAgentWorkspaceAccount,
+  type WorkspaceProvider,
+} from "../config/agent-workspace-account.js";
+import {
+  planConfigEdit,
+  composeTransforms,
+  ConfigPlanError,
+  type YamlTransform,
+} from "./config-edit-plan.js";
+import { generateUnifiedDiff } from "./config-diff.js";
+import {
+  proposeConfigEditViaHostd,
+  resolveHostdOperatorSocket,
+  type ProposeOutcome,
+} from "./hostd-config-propose.js";
+import { randomUUID } from "node:crypto";
 import { getAccountInfos, type AccountInfo } from "../auth/account-store.js";
 import {
   AuthBrokerError,
@@ -843,6 +870,195 @@ export function handleGetNotionWorkspace(
     databases,
     fullAccessAgents,
   };
+}
+
+export type ConnectionAccessStatus =
+  | { state: "pending"; startedAt: number }
+  | { state: "applied"; startedAt: number; restartAgent: string }
+  | { state: "denied"; startedAt: number; reason: string }
+  | { state: "error"; startedAt: number; reason: string };
+
+export interface SetAccessResult {
+  ok: boolean;
+  error?: string;
+  /** False when nothing would change (already in that state) — no proposal raised. */
+  changed?: boolean;
+  /** Poll handle for the approval outcome (present when a proposal was raised). */
+  requestId?: string;
+  /** True when a Telegram Allow/Deny card was raised and is awaiting the tap. */
+  pendingApproval?: boolean;
+}
+
+/**
+ * In-flight + recently-settled connection-access proposals, keyed by a
+ * server-generated requestId. The dashboard POSTs, gets a requestId, and
+ * polls {@link handleGetConnectionAccessStatus} until the operator taps
+ * Allow/Deny in Telegram. Bounded by a reaper (see
+ * reapConnectionAccessStatuses).
+ */
+const connectionAccessStatuses = new Map<string, ConnectionAccessStatus>();
+
+/** Drop settled entries older than 30 min so the map can't grow without bound. */
+export function reapConnectionAccessStatuses(now = Date.now()): void {
+  for (const [id, s] of connectionAccessStatuses) {
+    if (s.state !== "pending" && now - s.startedAt > 30 * 60_000) {
+      connectionAccessStatuses.delete(id);
+    }
+  }
+}
+
+export function handleGetConnectionAccessStatus(
+  requestId: string,
+): ConnectionAccessStatus | { state: "unknown" } {
+  return connectionAccessStatuses.get(requestId) ?? { state: "unknown" };
+}
+
+/** Test-only reset. */
+export function __resetConnectionAccessStatuses(): void {
+  connectionAccessStatuses.clear();
+}
+
+/**
+ * Propose granting/revoking an agent's access to a Google/Microsoft
+ * account from the dashboard. SECURITY: the dashboard does NOT write
+ * config — that would be self-elevation (an agent on host networking can
+ * forge the dashboard's loopback auth). Instead this computes the edit
+ * (the enabled_for ACL + the per-agent workspace.account selector — the
+ * broker needs both), turns it into a unified diff, and proposes it to
+ * hostd over the operator socket. hostd raises a Telegram Allow/Deny card
+ * and is the sole writer — nothing changes without the operator's tap.
+ *
+ * Returns a requestId the dashboard polls; the actual approval resolves
+ * asynchronously (hostd blocks on the human tap up to 10 min, so we run
+ * the proposal in the background and never hang the HTTP POST). When the
+ * edit would be a no-op, returns `changed:false` with no card raised.
+ *
+ * `deps` is injectable for tests (diff generation + the hostd send).
+ */
+export function handleSetConnectionAccess(
+  configPath: string,
+  config: SwitchroomConfig,
+  args: { provider: string; account: string; agent: string; action: string },
+  deps: {
+    socketPath?: string | null;
+    propose?: (reqId: string, diff: string, reason: string) => Promise<ProposeOutcome>;
+    generateDiff?: (before: string, after: string) => string;
+    now?: () => number;
+  } = {},
+): SetAccessResult {
+  const provider = args.provider as WorkspaceProvider;
+  if (provider !== "google" && provider !== "microsoft") {
+    return { ok: false, error: `unsupported provider '${args.provider}' (google|microsoft)` };
+  }
+  if (args.action !== "enable" && args.action !== "disable") {
+    return { ok: false, error: `action must be 'enable' or 'disable'` };
+  }
+  const agent = args.agent;
+  if (!agent || !config.agents?.[agent]) {
+    return { ok: false, error: `unknown agent '${agent}'` };
+  }
+  const account = String(args.account ?? "").trim().toLowerCase();
+  if (!/^[^@\s:]+@[^@\s:]+\.[^@\s:]+$/.test(account)) {
+    return { ok: false, error: `invalid account email '${args.account}'` };
+  }
+
+  const enableAcl =
+    provider === "google" ? enableAgentsOnGoogleAccount : enableAgentsOnMicrosoftAccount;
+  const disableAcl =
+    provider === "google" ? disableAgentsOnGoogleAccount : disableAgentsOnMicrosoftAccount;
+
+  let transform: YamlTransform;
+  if (args.action === "enable") {
+    transform = composeTransforms(
+      (y) => enableAcl(y, account, [agent]),
+      (y) => setAgentWorkspaceAccount(y, provider, agent, account),
+    );
+  } else {
+    transform = composeTransforms(
+      (y) => disableAcl(y, account, [agent]),
+      // Only clear the per-agent pin if it actually points at THIS
+      // account — never disturb a pin to a different account.
+      (y) =>
+        getAgentWorkspaceAccount(y, provider, agent) === account
+          ? clearAgentWorkspaceAccount(y, provider, agent)
+          : y,
+    );
+  }
+
+  // 1. Compute + schema-validate the edit (no write). Reject a broken
+  //    edit before bothering the operator with a card.
+  let plan;
+  try {
+    plan = planConfigEdit(configPath, transform);
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof ConfigPlanError ? err.message : (err as Error).message,
+    };
+  }
+  if (!plan.changed) {
+    return { ok: true, changed: false };
+  }
+
+  // 2. Need hostd to write it (the sole writer + the approval card).
+  const socketPath = deps.socketPath !== undefined ? deps.socketPath : resolveHostdOperatorSocket();
+  if (!socketPath) {
+    return {
+      ok: false,
+      error:
+        "hostd operator socket not found — credential grants require hostd (the Telegram approval path). " +
+        "Ensure host_control is enabled and the switchroom-web container mounts ~/.switchroom.",
+    };
+  }
+
+  // 3. Build the diff and fire the proposal in the BACKGROUND (hostd
+  //    blocks on the operator's tap; the POST must return immediately).
+  let diff: string;
+  try {
+    diff = (deps.generateDiff ?? generateUnifiedDiff)(plan.before, plan.after);
+  } catch (err) {
+    return { ok: false, error: `could not build config diff: ${(err as Error).message}` };
+  }
+
+  const now = deps.now ?? Date.now;
+  const requestId = randomUUID();
+  const reason = `dashboard: ${args.action} ${agent} on ${account} (${provider})`;
+  connectionAccessStatuses.set(requestId, { state: "pending", startedAt: now() });
+  reapConnectionAccessStatuses(now());
+
+  const propose =
+    deps.propose ??
+    ((reqId, d, r) =>
+      proposeConfigEditViaHostd({ requestId: reqId, unifiedDiff: d, reason: r, socketPath }));
+
+  void propose(requestId, diff, reason)
+    .then((outcome) => {
+      const startedAt = connectionAccessStatuses.get(requestId)?.startedAt ?? now();
+      if (outcome.state === "applied") {
+        connectionAccessStatuses.set(requestId, { state: "applied", startedAt, restartAgent: agent });
+      } else if (outcome.state === "denied") {
+        connectionAccessStatuses.set(requestId, { state: "denied", startedAt, reason: outcome.reason });
+      } else {
+        connectionAccessStatuses.set(requestId, { state: "error", startedAt, reason: outcome.reason });
+      }
+      void captureEvent("connection_access", {
+        provider,
+        action: args.action,
+        outcome: outcome.state,
+        source: "web_api",
+      });
+    })
+    .catch((err) => {
+      const startedAt = connectionAccessStatuses.get(requestId)?.startedAt ?? now();
+      connectionAccessStatuses.set(requestId, {
+        state: "error",
+        startedAt,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+      void captureException(err, { action: "connection_access", provider });
+    });
+
+  return { ok: true, changed: true, requestId, pendingApproval: true };
 }
 
 /**

--- a/src/web/config-diff.test.ts
+++ b/src/web/config-diff.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { generateUnifiedDiff, ConfigDiffError } from "./config-diff.js";
+
+const hasGit = spawnSync("git", ["--version"]).status === 0;
+
+describe("generateUnifiedDiff", () => {
+  it("returns empty string when before === after", () => {
+    expect(generateUnifiedDiff("same\n", "same\n")).toBe("");
+  });
+
+  it.runIf(hasGit)("produces a hunked unified diff for a real change", () => {
+    const before = "a: 1\nb: 2\n";
+    const after = "a: 1\nb: 3\n";
+    const diff = generateUnifiedDiff(before, after);
+    expect(diff).toContain("@@");
+    expect(diff).toContain("+b: 3");
+    expect(diff).toContain("-b: 2");
+  });
+
+  it.runIf(hasGit)(
+    "round-trips: the diff applies cleanly with the SAME `git apply` flags hostd uses",
+    () => {
+      // hostd: git apply --whitespace=nowarn --recount --unidiff-zero (-p1).
+      const before = "agents:\n  marko: {}\n  ziggy: {}\n";
+      const after =
+        "agents:\n  marko:\n    microsoft_workspace:\n      account: lisa@outlook.com\n  ziggy: {}\n";
+      const diff = generateUnifiedDiff(before, after, "switchroom.yaml");
+
+      const dir = mkdtempSync(join(tmpdir(), "diff-roundtrip-"));
+      try {
+        // Mirror hostd's applyPatch: live config in scratchDir/<name>,
+        // patch in scratchDir/proposal.patch, apply -p1 from scratchDir.
+        writeFileSync(join(dir, "switchroom.yaml"), before);
+        writeFileSync(join(dir, "proposal.patch"), diff);
+        const r = spawnSync(
+          "git",
+          [
+            "apply",
+            "--whitespace=nowarn",
+            "--recount",
+            "--unidiff-zero",
+            "-p1",
+            "proposal.patch",
+          ],
+          { cwd: dir, encoding: "utf-8" },
+        );
+        expect(r.status).toBe(0); // applied cleanly
+        expect(readFileSync(join(dir, "switchroom.yaml"), "utf-8")).toBe(after);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("surfaces a generator failure as ConfigDiffError (bad gitBin)", () => {
+    expect(() =>
+      generateUnifiedDiff("a\n", "b\n", "switchroom.yaml", "/nonexistent/git-binary"),
+    ).toThrow(ConfigDiffError);
+  });
+});

--- a/src/web/config-diff.ts
+++ b/src/web/config-diff.ts
@@ -1,0 +1,90 @@
+/**
+ * Generate a git-compatible unified diff for a switchroom.yaml edit.
+ *
+ * hostd's `config_propose_edit` applies the proposed patch with
+ * `git apply --whitespace=nowarn --recount --unidiff-zero` (trying
+ * `-p1` then `-p0`) — see src/host-control/config-edit-validator.ts. To
+ * guarantee the patch round-trips, we GENERATE it with the same tool
+ * family: `git diff --no-index`. The two versions are written to
+ * `a/<name>` and `b/<name>` under a scratch dir so the diff carries
+ * `--- a/<name>` / `+++ b/<name>` headers that hostd's `-p1` strips back
+ * to `<name>` (the basename of its scratch copy of the live config).
+ *
+ * `git diff --no-index` exits 1 when the files differ (NOT an error) and
+ * 0 when identical; any other exit is a real failure.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync as mkdtemp,
+  rmSync as rmrf,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export class ConfigDiffError extends Error {}
+
+/**
+ * Produce a unified diff that transforms `before` into `after`, suitable
+ * for hostd's `git apply`. `name` is the target basename (default
+ * "switchroom.yaml"). Returns "" when there's no difference.
+ *
+ * `gitBin` is injectable for tests.
+ */
+export function generateUnifiedDiff(
+  before: string,
+  after: string,
+  name = "switchroom.yaml",
+  gitBin = "git",
+): string {
+  if (before === after) return "";
+  const dir = mkdtemp(join(tmpdir(), "switchroom-config-diff-"));
+  try {
+    // `git diff --no-index P1 P2` always prefixes the given paths with
+    // a/ and b/, so whatever sub-paths we pass would yield headers like
+    // `a/cur/<name>`. hostd applies with `-p1` (then `-p0`) against a
+    // scratch file named exactly `<name>` — so the header must be the
+    // canonical `a/<name>` / `b/<name>` for the single -component strip
+    // to land on `<name>`. We diff in sibling dirs then normalize the
+    // three path-carrying header lines.
+    mkdirSync(join(dir, "cur"), { recursive: true });
+    mkdirSync(join(dir, "new"), { recursive: true });
+    writeFileSync(join(dir, "cur", name), before);
+    writeFileSync(join(dir, "new", name), after);
+    const r = spawnSync(
+      gitBin,
+      ["diff", "--no-index", "--no-color", "--", `cur/${name}`, `new/${name}`],
+      { cwd: dir, encoding: "utf-8", timeout: 10_000 },
+    );
+    // git diff --no-index: 0 = identical, 1 = differ (expected), >1 = error.
+    if (r.status === 0) return "";
+    if (r.status !== 1) {
+      throw new ConfigDiffError(
+        `git diff failed (status=${r.status}): ${(r.stderr || r.error?.message || "").toString().trim()}`,
+      );
+    }
+    const raw = r.stdout ?? "";
+    if (!raw.includes("@@")) {
+      throw new ConfigDiffError("git diff produced no hunks");
+    }
+    // Normalize header paths → canonical a/<name> b/<name>.
+    const diff = raw
+      .split("\n")
+      .map((line) => {
+        if (line.startsWith("diff --git ")) return `diff --git a/${name} b/${name}`;
+        if (line.startsWith("--- ")) return `--- a/${name}`;
+        if (line.startsWith("+++ ")) return `+++ b/${name}`;
+        return line;
+      })
+      .join("\n");
+    return diff;
+  } finally {
+    try {
+      rmrf(dir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/src/web/config-edit-plan.test.ts
+++ b/src/web/config-edit-plan.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { planConfigEdit, composeTransforms, ConfigPlanError } from "./config-edit-plan.js";
+
+const VALID = `switchroom:
+  version: 1
+  agents_dir: ~/.switchroom/agents
+telegram:
+  bot_token: x
+  forum_chat_id: "-1001234"
+agents:
+  marko:
+    extends: default
+    topic_name: Marko
+microsoft_accounts: {}
+`;
+
+const dirs: string[] = [];
+function tmpConfig(text: string): string {
+  const d = mkdtempSync(join(tmpdir(), "plan-"));
+  dirs.push(d);
+  const p = join(d, "switchroom.yaml");
+  writeFileSync(p, text);
+  return p;
+}
+afterEach(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  dirs.length = 0;
+});
+
+describe("planConfigEdit", () => {
+  it("computes a schema-valid edit without writing the file", () => {
+    const p = tmpConfig(VALID);
+    const plan = planConfigEdit(p, (y) =>
+      y.replace("microsoft_accounts: {}", "microsoft_accounts:\n  lisa@outlook.com:\n    enabled_for:\n      - marko"),
+    );
+    expect(plan.changed).toBe(true);
+    expect(plan.after).toContain("lisa@outlook.com");
+    // File on disk is untouched (no write).
+    expect(plan.before).toBe(VALID);
+  });
+
+  it("reports changed:false for a no-op transform", () => {
+    const p = tmpConfig(VALID);
+    const plan = planConfigEdit(p, (y) => y);
+    expect(plan.changed).toBe(false);
+    expect(plan.after).toBe(plan.before);
+  });
+
+  it("rejects an edit that produces an invalid config (no write)", () => {
+    const p = tmpConfig(VALID);
+    // Break a required field — drop the switchroom version block.
+    expect(() =>
+      planConfigEdit(p, (y) => y.replace("version: 1", "version: not-a-number")),
+    ).toThrow(ConfigPlanError);
+  });
+
+  it("rejects an edit that produces unparseable YAML", () => {
+    const p = tmpConfig(VALID);
+    expect(() => planConfigEdit(p, () => "::: not : yaml : [")).toThrow(ConfigPlanError);
+  });
+
+  it("composeTransforms applies left to right", () => {
+    const t = composeTransforms(
+      (s) => s + "a",
+      (s) => s + "b",
+    );
+    expect(t("x")).toBe("xab");
+  });
+});

--- a/src/web/config-edit-plan.ts
+++ b/src/web/config-edit-plan.ts
@@ -1,0 +1,90 @@
+/**
+ * Compute (and schema-validate) a proposed switchroom.yaml edit WITHOUT
+ * writing it.
+ *
+ * The dashboard never writes the config itself — that would be a
+ * self-elevation hole (an agent on host networking can forge the
+ * dashboard's loopback auth; see config-diff.ts / the connection-access
+ * handler). Instead it computes the edited YAML here, turns it into a
+ * unified diff, and proposes it to hostd, which raises a Telegram
+ * Allow/Deny card and is the SOLE writer. This module is the
+ * compute-and-validate half: read current → apply a comment-preserving
+ * YAML transform → parse + `SwitchroomConfigSchema` the result (the same
+ * gate the loader runs) so an obviously-broken edit is rejected BEFORE
+ * the operator is bothered with a card. No write, no lock.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { parse as parseYaml } from "yaml";
+
+import { SwitchroomConfigSchema } from "../config/schema.js";
+
+export class ConfigPlanError extends Error {}
+
+/** A pure YAML-text transform (string in → string out). */
+export type YamlTransform = (yamlText: string) => string;
+
+export interface ConfigEditPlan {
+  /** Current on-disk YAML. */
+  before: string;
+  /** Edited YAML (schema-valid). Equal to `before` when the transform
+   *  was a no-op (already in the desired state). */
+  after: string;
+  /** False when after === before (nothing to propose). */
+  changed: boolean;
+}
+
+/** Compose several transforms into one (applied left to right). */
+export function composeTransforms(...transforms: YamlTransform[]): YamlTransform {
+  return (text) => transforms.reduce((acc, t) => t(acc), text);
+}
+
+/**
+ * Read `configPath`, apply `transform`, and validate the result against
+ * the config schema. Returns the before/after text + whether it changed.
+ * Throws {@link ConfigPlanError} (transform/parse/schema failure) — the
+ * file is never touched.
+ */
+export function planConfigEdit(
+  configPath: string,
+  transform: YamlTransform,
+): ConfigEditPlan {
+  let before: string;
+  try {
+    before = readFileSync(configPath, "utf-8");
+  } catch (err) {
+    throw new ConfigPlanError(`could not read config: ${(err as Error).message}`);
+  }
+
+  let after: string;
+  try {
+    after = transform(before);
+  } catch (err) {
+    throw new ConfigPlanError(`config edit failed: ${(err as Error).message}`);
+  }
+
+  if (after === before) {
+    return { before, after, changed: false };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(after);
+  } catch (err) {
+    throw new ConfigPlanError(
+      `edit produced unparseable YAML: ${(err as Error).message}`,
+    );
+  }
+  const check = SwitchroomConfigSchema.safeParse(parsed);
+  if (!check.success) {
+    throw new ConfigPlanError(
+      `edit produced an invalid config: ${check.error.issues
+        .slice(0, 3)
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ")}`,
+    );
+  }
+
+  return { before, after, changed: true };
+}

--- a/src/web/hostd-config-propose.test.ts
+++ b/src/web/hostd-config-propose.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  proposeConfigEditViaHostd,
+  resolveHostdOperatorSocket,
+} from "./hostd-config-propose.js";
+import type { HostdResponse } from "../host-control/protocol.js";
+
+function resp(partial: Partial<HostdResponse>): HostdResponse {
+  return {
+    v: 1,
+    request_id: "r1",
+    result: "completed",
+    exit_code: null,
+    duration_ms: 1,
+    ...partial,
+  } as HostdResponse;
+}
+
+describe("proposeConfigEditViaHostd", () => {
+  it("maps result=completed → applied, sending the right request shape", async () => {
+    let sent: unknown;
+    const out = await proposeConfigEditViaHostd({
+      unifiedDiff: "@@ patch @@",
+      reason: "dashboard: enable marko",
+      requestId: "req-1",
+      socketPath: "/x/sock",
+      send: async (_opts, req) => {
+        sent = req;
+        return resp({ result: "completed" });
+      },
+    });
+    expect(out).toEqual({ state: "applied" });
+    expect(sent).toMatchObject({
+      op: "config_propose_edit",
+      request_id: "req-1",
+      args: {
+        unified_diff: "@@ patch @@",
+        reason: "dashboard: enable marko",
+        target_path: "/state/config/switchroom.yaml",
+      },
+    });
+  });
+
+  it("maps result=denied → denied with the operator reason", async () => {
+    const out = await proposeConfigEditViaHostd({
+      unifiedDiff: "d",
+      reason: "r",
+      requestId: "req-2",
+      socketPath: "/x/sock",
+      send: async () => resp({ result: "denied", error: "operator said no" }),
+    });
+    expect(out).toEqual({ state: "denied", reason: "operator said no" });
+  });
+
+  it("maps result=error → error", async () => {
+    const out = await proposeConfigEditViaHostd({
+      unifiedDiff: "d",
+      reason: "r",
+      requestId: "req-3",
+      socketPath: "/x/sock",
+      send: async () => resp({ result: "error", error: "E_PATCH_APPLY_FAILED" }),
+    });
+    expect(out).toEqual({ state: "error", reason: "E_PATCH_APPLY_FAILED" });
+  });
+
+  it("never throws — a transport failure becomes state:error", async () => {
+    const out = await proposeConfigEditViaHostd({
+      unifiedDiff: "d",
+      reason: "r",
+      requestId: "req-4",
+      socketPath: "/x/sock",
+      send: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    expect(out.state).toBe("error");
+    if (out.state === "error") expect(out.reason).toContain("ECONNREFUSED");
+  });
+});
+
+describe("resolveHostdOperatorSocket", () => {
+  const KEY = "SWITCHROOM_HOSTD_OPERATOR_SOCKET";
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env[KEY];
+    delete process.env[KEY];
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env[KEY];
+    else process.env[KEY] = saved;
+  });
+
+  it("honors the env override first", () => {
+    expect(resolveHostdOperatorSocket({ [KEY]: "/custom/sock" } as NodeJS.ProcessEnv)).toBe(
+      "/custom/sock",
+    );
+  });
+
+  it("returns null when no candidate socket exists (no env, no mounts)", () => {
+    // In CI/dev there's no /host-home/... and no ~/.switchroom/hostd/operator/sock.
+    const r = resolveHostdOperatorSocket({} as NodeJS.ProcessEnv);
+    // Either null (typical) or a real socket if the dev box happens to run hostd.
+    expect(r === null || typeof r === "string").toBe(true);
+  });
+});

--- a/src/web/hostd-config-propose.ts
+++ b/src/web/hostd-config-propose.ts
@@ -1,0 +1,98 @@
+/**
+ * Propose a switchroom.yaml edit to hostd from the web dashboard.
+ *
+ * The dashboard is NOT a trusted writer (an agent on host networking can
+ * forge its loopback auth). So a "grant access" click never writes config
+ * — it proposes a unified diff to hostd over the OPERATOR socket. hostd
+ * validates the patch, raises an Allow/Deny card in the operator's
+ * Telegram (an out-of-band channel an agent can't forge), and applies it
+ * with `git apply` ONLY on the tap. hostd is the sole writer; this is the
+ * leash.
+ *
+ * `config_propose_edit` BLOCKS server-side until the operator decides or
+ * the 10-minute approval window expires, so the client timeout is set
+ * above that. The caller runs this in the background and exposes a poll
+ * endpoint — the HTTP POST must not hang on a human tap.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { hostdRequest } from "../host-control/client.js";
+import type { HostdRequest } from "../host-control/protocol.js";
+
+/** Slightly above hostd's 10-min CONFIG_APPROVAL_TIMEOUT_MS. */
+export const PROPOSE_TIMEOUT_MS = 11 * 60 * 1000;
+
+export type ProposeOutcome =
+  | { state: "applied" }
+  | { state: "denied"; reason: string }
+  | { state: "error"; reason: string };
+
+/**
+ * Resolve the hostd operator socket without an infra/env change. Order:
+ *   1. `SWITCHROOM_HOSTD_OPERATOR_SOCKET` override (tests / custom),
+ *   2. `/host-home/.switchroom/hostd/operator/sock` — the switchroom-web
+ *      container mounts the operator's `~/.switchroom` here,
+ *   3. `~/.switchroom/hostd/operator/sock` — host CLI.
+ * Returns the first that exists, or null when hostd isn't reachable.
+ */
+export function resolveHostdOperatorSocket(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const override = env.SWITCHROOM_HOSTD_OPERATOR_SOCKET;
+  if (override && override.length > 0) return override;
+  const candidates = [
+    "/host-home/.switchroom/hostd/operator/sock",
+    join(homedir(), ".switchroom", "hostd", "operator", "sock"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  return null;
+}
+
+export interface ProposeArgs {
+  unifiedDiff: string;
+  reason: string;
+  requestId: string;
+  socketPath: string;
+  timeoutMs?: number;
+  /** Injectable for tests (defaults to the real hostd client). */
+  send?: typeof hostdRequest;
+}
+
+/**
+ * Send the proposal and map hostd's response to a {@link ProposeOutcome}.
+ * Never throws — connection/timeout/decode failures become
+ * `{ state: "error" }`.
+ */
+export async function proposeConfigEditViaHostd(
+  args: ProposeArgs,
+): Promise<ProposeOutcome> {
+  const req: HostdRequest = {
+    v: 1,
+    op: "config_propose_edit",
+    request_id: args.requestId,
+    args: {
+      unified_diff: args.unifiedDiff,
+      reason: args.reason,
+      target_path: "/state/config/switchroom.yaml",
+    },
+  };
+  const send = args.send ?? hostdRequest;
+  try {
+    const resp = await send(
+      { socketPath: args.socketPath, timeoutMs: args.timeoutMs ?? PROPOSE_TIMEOUT_MS },
+      req,
+    );
+    if (resp.result === "completed") return { state: "applied" };
+    if (resp.result === "denied") {
+      return { state: "denied", reason: resp.error ?? "operator denied the change" };
+    }
+    return { state: "error", reason: resp.error ?? `hostd returned '${resp.result}'` };
+  } catch (err) {
+    return { state: "error", reason: (err as Error).message };
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -14,6 +14,7 @@ import { spawn } from "node:child_process";
 import { timingSafeEqual, randomBytes } from "node:crypto";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
+import { loadConfig } from "../config/loader.js";
 import { containerName } from "../agents/lifecycle.js";
 import {
   handleGetAgents,
@@ -31,6 +32,8 @@ import {
   handleGetSystemHealth,
   handleGetGoogleAccounts,
   handleGetMicrosoftAccounts,
+  handleSetConnectionAccess,
+  handleGetConnectionAccessStatus,
   handleGetNotionWorkspace,
   handleGetSchedule,
   handleGetApprovals,
@@ -404,6 +407,24 @@ function parseRoute(
     return { handler: "getAccounts", params: {} };
   }
 
+  // POST /api/connections/access
+  //   body: { provider, account, agent, action: "enable" | "disable" }
+  // PROPOSE granting/revoking an agent's access to a Google/Microsoft
+  // account. Does NOT write config — raises a Telegram Allow/Deny card via
+  // hostd (the sole writer). Returns a requestId to poll.
+  if (method === "POST" && pathname === "/api/connections/access") {
+    return { handler: "setConnectionAccess", params: {} };
+  }
+
+  // GET /api/connections/access/:requestId — poll the approval outcome.
+  const accessStatusMatch = pathname.match(/^\/api\/connections\/access\/([^/]+)$/);
+  if (method === "GET" && accessStatusMatch) {
+    return {
+      handler: "getConnectionAccessStatus",
+      params: { requestId: decodeURIComponent(accessStatusMatch[1]) },
+    };
+  }
+
   // POST /api/auth/use
   //   body: { account: string }
   // Replaces the pre-RFC-H `/api/accounts/:label/promote` endpoint. The
@@ -446,6 +467,20 @@ export function startWebServer(
   // Resolve symlinks once at startup so the traversal check compares real paths.
   const uiDir = existsSync(uiDirRaw) ? realpathSync(uiDirRaw) : uiDirRaw;
   const token = resolveWebToken();
+
+  // The connection views + the access-mutation endpoint must reflect the
+  // CURRENT switchroom.yaml — the startup `config` goes stale the moment
+  // the dashboard writes an ACL change. Re-read fresh from disk per
+  // request (cheap, and only for the config-derived connection routes);
+  // fall back to the startup config if the path is unset or a load fails.
+  const freshConfig = (): SwitchroomConfig => {
+    if (!configPath) return config;
+    try {
+      return loadConfig(configPath);
+    } catch {
+      return config;
+    }
+  };
 
   // Loopback-only when binding to a localhost address; any other bind address
   // (including 0.0.0.0) is considered a deliberate network-exposure opt-in.
@@ -589,14 +624,14 @@ export function startWebServer(
 
           case "getGoogleAccounts":
             return (async () =>
-              jsonResponse(await handleGetGoogleAccounts(config)))();
+              jsonResponse(await handleGetGoogleAccounts(freshConfig())))();
 
           case "getMicrosoftAccounts":
             return (async () =>
-              jsonResponse(await handleGetMicrosoftAccounts(config)))();
+              jsonResponse(await handleGetMicrosoftAccounts(freshConfig())))();
 
           case "getNotionWorkspace":
-            return jsonResponse(handleGetNotionWorkspace(config));
+            return jsonResponse(handleGetNotionWorkspace(freshConfig()));
 
           case "getSchedule":
             return jsonResponse(handleGetSchedule(config));
@@ -630,6 +665,40 @@ export function startWebServer(
               return jsonResponse(result);
             })();
           }
+
+          case "setConnectionAccess": {
+            return (async () => {
+              if (!configPath) {
+                return jsonResponse(
+                  { ok: false, error: "config path not available to the web server" },
+                  500,
+                );
+              }
+              let body: {
+                provider?: string;
+                account?: string;
+                agent?: string;
+                action?: string;
+              };
+              try {
+                body = (await req.json()) as typeof body;
+              } catch {
+                return jsonResponse({ ok: false, error: "Invalid JSON body" }, 400);
+              }
+              const result = handleSetConnectionAccess(configPath, freshConfig(), {
+                provider: String(body.provider ?? ""),
+                account: String(body.account ?? ""),
+                agent: String(body.agent ?? ""),
+                action: String(body.action ?? ""),
+              });
+              return jsonResponse(result, result.ok ? 200 : 400);
+            })();
+          }
+
+          case "getConnectionAccessStatus":
+            return jsonResponse(
+              handleGetConnectionAccessStatus(route.params.requestId),
+            );
 
           case "refreshQuota": {
             return (async () => {

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -495,15 +495,67 @@
 
     async function fetchConnections() {
       try {
-        const [google, microsoft, notion] = await Promise.all([
+        const [google, microsoft, notion, agents] = await Promise.all([
           fetch(`${API}/api/google-accounts`, { headers: authHeaders() }).then(r => r.ok ? r.json() : []),
           fetch(`${API}/api/microsoft-accounts`, { headers: authHeaders() }).then(r => r.ok ? r.json() : []),
           fetch(`${API}/api/notion-workspace`, { headers: authHeaders() }).then(r => r.ok ? r.json() : { configured: false, databases: [] }),
+          fetch(`${API}/api/agents`, { headers: authHeaders() }).then(r => r.ok ? r.json() : []),
         ]);
-        renderConnections({ google, microsoft, notion });
+        const agentNames = (agents || []).map(a => a.name).sort();
+        renderConnections({ google, microsoft, notion, agentNames });
         clearError();
       } catch (err) {
         showError(`Failed to fetch connections: ${err.message}`);
+      }
+    }
+
+    // Toggle an agent's access to an account. POSTs a proposal → hostd
+    // raises a Telegram Allow/Deny card → we poll the outcome. Nothing
+    // changes until the operator taps Allow on their phone (the leash).
+    async function toggleAccess(provider, account, agent, enable, btnId) {
+      const btn = document.getElementById(btnId);
+      const setLabel = (txt, dim) => { if (btn) { btn.textContent = txt; btn.style.opacity = dim ? '.6' : '1'; } };
+      setLabel('proposing…', true);
+      try {
+        const res = await fetch(`${API}/api/connections/access`, {
+          method: 'POST',
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+          body: JSON.stringify({ provider, account, agent, action: enable ? 'enable' : 'disable' }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data.ok) { setLabel('error', false); showError(data.error || `HTTP ${res.status}`); return; }
+        if (data.changed === false) { setLabel(enable ? 'enabled' : 'disabled', false); return; }
+        if (!data.requestId) { setLabel('done', false); fetchConnections(); return; }
+        setLabel('check Telegram → approve', true);
+        // Poll the approval outcome (operator has up to ~10 min to tap).
+        const started = Date.now();
+        const poll = async () => {
+          const sres = await fetch(`${API}/api/connections/access/${encodeURIComponent(data.requestId)}`, { headers: authHeaders() });
+          const s = sres.ok ? await sres.json() : { state: 'error', reason: `HTTP ${sres.status}` };
+          if (s.state === 'pending') {
+            if (Date.now() - started > 11 * 60 * 1000) { setLabel('timed out', false); return; }
+            setTimeout(poll, 2500);
+            return;
+          }
+          if (s.state === 'applied') {
+            setLabel('✓ approved', false);
+            showError('');
+            // Restart suggestion: the agent loads the MCP at boot.
+            if (s.restartAgent && confirm(`Approved. Restart ${s.restartAgent} now so it picks up the change?`)) {
+              await fetch(`${API}/api/agents/${encodeURIComponent(s.restartAgent)}/restart`, { method: 'POST', headers: authHeaders() }).catch(() => {});
+            }
+            fetchConnections();
+          } else if (s.state === 'denied') {
+            setLabel('denied', false);
+          } else {
+            setLabel('error', false);
+            showError(s.reason || 'proposal failed');
+          }
+        };
+        setTimeout(poll, 2000);
+      } catch (err) {
+        setLabel('error', false);
+        showError(err.message);
       }
     }
 
@@ -993,9 +1045,14 @@
 
     const _dimC = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
 
+    let _accessBtnSeq = 0;
+
     // One OAuth-account card (Google or Microsoft — same shape; Microsoft
-    // adds an account-type pill).
+    // adds an account-type pill). When agentNames is supplied, renders a
+    // per-agent "manage access" row (enable/disable → Telegram approval).
     function renderOAuthAccountCard(a, opts) {
+      const provider = (opts && opts.provider) || '';
+      const agentNames = (opts && opts.agentNames) || [];
       const expires = a.expiresAt ? formatTimestamp(a.expiresAt) : _dimC('—');
       const known = a.brokerKnown
         ? '<span class="usage-pill primary">slot present</span>'
@@ -1005,6 +1062,19 @@
         : _dimC('no agents enabled');
       const typePill = (opts && opts.showType && a.accountType)
         ? `<span class="usage-pill" style="margin-left:.4rem">${escapeHtml(a.accountType)}</span>`
+        : '';
+      const enabledSet = new Set(a.enabledFor || []);
+      const manage = (agentNames.length && provider)
+        ? `<div class="account-usage" style="margin-top:.5rem">
+             <label style="color:var(--text-dim);opacity:.7;display:block;margin-bottom:.3rem">Manage access (approve on Telegram):</label>
+             ${agentNames.map(name => {
+               const on = enabledSet.has(name);
+               const btnId = `acc-${++_accessBtnSeq}`;
+               const accJs = JSON.stringify(a.account), nameJs = JSON.stringify(name), provJs = JSON.stringify(provider);
+               return `<button id="${btnId}" class="usage-pill ${on ? 'primary' : ''}" style="margin:.15rem;cursor:pointer;border:none"
+                 onclick='toggleAccess(${provJs}, ${accJs}, ${nameJs}, ${!on}, "${btnId}")'>${on ? '✓ ' : '+ '}${escapeHtml(name)}</button>`;
+             }).join('')}
+           </div>`
         : '';
       return `
       <div class="account-card">
@@ -1018,6 +1088,7 @@
           <div class="meta-item" title="${a.scope ? escapeHtml(a.scope) : ''}"><label>Scope </label><span>${a.scope ? escapeHtml(a.scope.split(' ').length + ' scope(s)') : _dimC('—')}</span></div>
           <div class="meta-item"><label>Client </label><span>${a.clientId ? escapeHtml(a.clientId.slice(0, 16) + '…') : _dimC('—')}</span></div>
         </div>
+        ${manage}
       </div>`;
     }
 
@@ -1036,17 +1107,18 @@
       const google = data.google || [];
       const microsoft = data.microsoft || [];
       const notion = data.notion || { configured: false, databases: [] };
+      const agentNames = data.agentNames || [];
 
       const googleSection = _connectionSection(
         'Google',
         'No Google accounts. Add one under <code>google_accounts:</code> and run <code>switchroom auth google account add</code>.',
-        google.map(a => renderOAuthAccountCard(a, { showType: false })).join(''),
+        google.map(a => renderOAuthAccountCard(a, { showType: false, provider: 'google', agentNames })).join(''),
       );
 
       const microsoftSection = _connectionSection(
         'Microsoft 365',
         'No Microsoft accounts. Connect one from Telegram with <code>/connect microsoft</code> (admin DM), or <code>switchroom auth microsoft account add</code>.',
-        microsoft.map(a => renderOAuthAccountCard(a, { showType: true })).join(''),
+        microsoft.map(a => renderOAuthAccountCard(a, { showType: true, provider: 'microsoft', agentNames })).join(''),
       );
 
       let notionCards = '';

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -940,6 +940,50 @@ microsoft_accounts: {}
   it("returns 'unknown' for an unrecognized requestId", () => {
     expect(handleGetConnectionAccessStatus("nope").state).toBe("unknown");
   });
+
+  it("disabling from account A does NOT clear a pin that points at account B", () => {
+    // marko is pinned to B AND (inconsistently) listed in A's ACL.
+    // Disabling marko from A must remove it from A's enabled_for but
+    // leave the B pin intact — never revoke unrelated access.
+    const yaml = `switchroom:
+  version: 1
+  agents_dir: ~/.switchroom/agents
+telegram:
+  bot_token: x
+  forum_chat_id: "-1001234"
+agents:
+  marko:
+    extends: default
+    topic_name: Marko
+    microsoft_workspace:
+      account: b@outlook.com
+microsoft_accounts:
+  a@outlook.com:
+    enabled_for:
+      - marko
+  b@outlook.com:
+    enabled_for:
+      - marko
+`;
+    writeFileSync(cfgPath, yaml);
+    let capturedAfter = "";
+    const res = handleSetConnectionAccess(
+      cfgPath,
+      cfg,
+      { provider: "microsoft", account: "a@outlook.com", agent: "marko", action: "disable" },
+      {
+        socketPath: "/fake/sock",
+        generateDiff: (_before, after) => { capturedAfter = after; return "@@ d @@"; },
+        propose: async () => ({ state: "applied" }),
+      },
+    );
+    expect(res.ok).toBe(true);
+    expect(res.changed).toBe(true);
+    // The pin to B survives; only A's ACL entry is dropped.
+    expect(capturedAfter).toContain("account: b@outlook.com");
+    const aBlock = capturedAfter.slice(capturedAfter.indexOf("a@outlook.com"));
+    expect(aBlock.slice(0, aBlock.indexOf("b@outlook.com"))).not.toContain("- marko");
+  });
 });
 
 describe("handleGetSchedule", () => {

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -96,6 +96,9 @@ import {
   handleGetSchedule,
   handleGetAccounts,
   handleUseAccount,
+  handleSetConnectionAccess,
+  handleGetConnectionAccessStatus,
+  __resetConnectionAccessStatuses,
   handleGetApprovals,
   handleRefreshAccountsQuota,
   __resetQuotaCacheForTests,
@@ -112,7 +115,7 @@ import { getAllAgentStatuses, startAgent, stopAgent, restartAgent } from "../src
 import { getAllAuthStatuses } from "../src/auth/manager.js";
 import { getHindsightStatus, isHindsightRunning } from "../src/setup/hindsight.js";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SwitchroomConfig } from "../src/config/schema.js";
@@ -818,6 +821,124 @@ describe("handleGetNotionWorkspace", () => {
       "fullAccessAgents",
       "vaultKey",
     ]);
+  });
+});
+
+describe("handleSetConnectionAccess (hostd-routed, approval-gated)", () => {
+  const VALID_YAML = `switchroom:
+  version: 1
+  agents_dir: ~/.switchroom/agents
+telegram:
+  bot_token: x
+  forum_chat_id: "-1001234"
+agents:
+  marko:
+    extends: default
+    topic_name: Marko
+microsoft_accounts: {}
+`;
+  const cfg = {
+    ...mockConfig,
+    agents: { marko: { extends: "default" } },
+  } as unknown as SwitchroomConfig;
+
+  let tmp: string;
+  let cfgPath: string;
+  beforeEach(() => {
+    __resetConnectionAccessStatuses();
+    tmp = mkdtempSync(join(tmpdir(), "conn-access-"));
+    cfgPath = join(tmp, "switchroom.yaml");
+    writeFileSync(cfgPath, VALID_YAML);
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  it("rejects bad provider / unknown agent / invalid email without proposing", () => {
+    expect(handleSetConnectionAccess(cfgPath, cfg, { provider: "slack", account: "a@b.com", agent: "marko", action: "enable" }).ok).toBe(false);
+    expect(handleSetConnectionAccess(cfgPath, cfg, { provider: "microsoft", account: "a@b.com", agent: "ghost", action: "enable" }).ok).toBe(false);
+    expect(handleSetConnectionAccess(cfgPath, cfg, { provider: "microsoft", account: "not-an-email", agent: "marko", action: "enable" }).ok).toBe(false);
+  });
+
+  it("returns changed:false (no card) when disabling an already-absent grant", () => {
+    const res = handleSetConnectionAccess(
+      cfgPath,
+      cfg,
+      { provider: "microsoft", account: "lisa@outlook.com", agent: "marko", action: "disable" },
+      { socketPath: "/fake/sock", propose: async () => ({ state: "applied" }) },
+    );
+    expect(res).toMatchObject({ ok: true, changed: false });
+    expect(res.requestId).toBeUndefined();
+  });
+
+  it("does NOT write the config — it proposes via hostd and polls to applied", async () => {
+    const calls: Array<{ reqId: string; diff: string; reason: string }> = [];
+    const res = handleSetConnectionAccess(
+      cfgPath,
+      cfg,
+      { provider: "microsoft", account: "lisa@outlook.com", agent: "marko", action: "enable" },
+      {
+        socketPath: "/fake/operator/sock",
+        // node:child_process is globally mocked in this suite, so inject a
+        // diff stub instead of the real git generator (covered separately
+        // in config-diff.test.ts). The stub sees the computed before/after.
+        generateDiff: (before, after) =>
+          `--- a/switchroom.yaml\n+++ b/switchroom.yaml\n@@ @@\nDIFF(${after.includes("lisa@outlook.com") ? "has-account" : "no-account"})`,
+        propose: async (reqId, diff, reason) => {
+          calls.push({ reqId, diff, reason });
+          return { state: "applied" };
+        },
+      },
+    );
+    expect(res).toMatchObject({ ok: true, changed: true, pendingApproval: true });
+    expect(res.requestId).toBeTruthy();
+    // The config file on disk is UNCHANGED (hostd would write it; here propose is faked).
+    expect(readFileSync(cfgPath, "utf-8")).toBe(VALID_YAML);
+    // The proposal carries the computed diff + a descriptive reason.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].diff).toContain("has-account");
+    expect(calls[0].reason).toContain("enable marko");
+
+    // Initially pending; after the background propose resolves → applied.
+    expect(handleGetConnectionAccessStatus(res.requestId!).state).toMatch(/pending|applied/);
+    await flush();
+    const st = handleGetConnectionAccessStatus(res.requestId!);
+    expect(st.state).toBe("applied");
+    if (st.state === "applied") expect(st.restartAgent).toBe("marko");
+  });
+
+  it("surfaces an operator denial via the status poll", async () => {
+    const res = handleSetConnectionAccess(
+      cfgPath,
+      cfg,
+      { provider: "microsoft", account: "lisa@outlook.com", agent: "marko", action: "enable" },
+      {
+        socketPath: "/fake/sock",
+        generateDiff: () => "--- a/x\n+++ b/x\n@@ @@\n+y",
+        propose: async () => ({ state: "denied", reason: "operator denied" }),
+      },
+    );
+    await flush();
+    const st = handleGetConnectionAccessStatus(res.requestId!);
+    expect(st.state).toBe("denied");
+    if (st.state === "denied") expect(st.reason).toContain("denied");
+  });
+
+  it("fails clearly when hostd is unreachable (no socket)", () => {
+    const res = handleSetConnectionAccess(
+      cfgPath,
+      cfg,
+      { provider: "microsoft", account: "lisa@outlook.com", agent: "marko", action: "enable" },
+      { socketPath: null },
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("hostd");
+  });
+
+  it("returns 'unknown' for an unrecognized requestId", () => {
+    expect(handleGetConnectionAccessStatus("nope").state).toBe("unknown");
   });
 });
 


### PR DESCRIPTION
## Summary

UI Phase B: the **Connections** tab gets per-agent access toggles for Google and Microsoft accounts — *"give marko access to lisa@outlook.com"* from the dashboard. Builds on the read-only Connections tab (#2172).

## Security — the load-bearing design

The dashboard does **NOT** write config. An agent on host networking can **forge** the dashboard's loopback auth (it trusts `Tailscale-User-Login` on presence + loopback source, and agents run `network_mode:host`), so a direct-write grant endpoint would be a **self-elevation hole**. Instead a toggle **proposes a unified diff to hostd** over the operator socket; hostd validates it, raises an **Allow/Deny card in the operator's Telegram** (out-of-band — an agent can't forge the tap), and is the **sole writer** (`git apply` on approval). Nothing changes without the human tap. *This is the leash* (vision pillar 2).

> Caught during this work by the operator's question: *"what would stop an eager agent from doing this without approval?"* — the answer was "nothing" for a direct write, which is why this routes through the approval card.

## What changed

- **`config/agent-workspace-account.ts`** — comment-preserving editor for the per-agent `<provider>_workspace.account` selector (set/clear/get). The broker needs **both** the `enabled_for` ACL and this selector, so a grant writes both.
- **`web/config-edit-plan.ts`** — read → apply the ACL+selector transforms → schema-validate the result (same gate the loader runs), **no write**. Rejects a broken edit before raising a card.
- **`web/config-diff.ts`** — generate a git-compatible unified diff with `git diff --no-index` (the same tool family hostd's `git apply` consumes), normalizing path headers to `a/<name>`/`b/<name>` so hostd's `-p1` strip lands on its scratch basename. **Round-trip-tested against hostd's exact `git apply --recount --unidiff-zero` flags.**
- **`web/hostd-config-propose.ts`** — submit `config_propose_edit` to the hostd **operator** socket (resolved from the web container's `/host-home` mount or `~/.switchroom` — no infra change), 11-min timeout (> hostd's 10-min approval window), map completed/denied/error.
- **`api.ts` `handleSetConnectionAccess`** — orchestrates plan → diff → **background** hostd propose (the POST returns immediately; hostd blocks on the human tap) + a pending-status map; `handleGetConnectionAccessStatus` polls it (reaped at 30 min). Fresh-config reload so reads reflect an applied edit.
- **`ui/index.html`** — per-agent enable/disable pills on each account card; on click → *"check Telegram → approve"* → polls status → on applied, offers to restart the agent (it scaffolds the MCP at boot).

## Feasibility (verified live, no infra change)

The `switchroom-web` container (uid 1000) reaches the hostd operator socket (uid 1000, mode 0600, `SWITCHROOM_HOSTD_OPERATOR_UID=1000`) under its `~/.switchroom` mount; `host_control` + `hostd.config_edit_enabled` are on.

## Test plan

- [x] **90 tests** across the touched suites: pin editor (set/clear/get/idempotent/empty-block-drop); **config-diff round-trips through hostd's exact git-apply flags** + empty-on-no-op + ConfigDiffError; plan (schema-valid / no-op / rejects-invalid-and-unparseable, no write); propose (completed/denied/error mapping, never-throws, socket resolution); handler (bad-input rejection, no-op→no-card, **propose+poll→applied with config-unchanged-on-disk asserted**, denial via poll, hostd-unreachable).
- [x] `tsc --noEmit` + full lint chain green; UI inline JS parses.

## Risk

Moderate (touches the web server + config plane) but mitigated by design: the web server **cannot write config** — hostd is the sole writer and every grant requires the operator's Telegram tap. The plan is schema-validated before a card is raised; the diff round-trips through hostd's exact apply flags. No new dependency (uses the system `git`).

## Deferred (operator's call: "just my feature for now")

The existing dashboard write endpoints (`/api/auth/use`, agent restart) share the forgeable-header weakness — flagged for a separate hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)