### PR TITLE
feat(web): connect a Microsoft account from the dashboard (device-code)

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -65,6 +65,11 @@ import {
   type ProposeOutcome,
 } from "./hostd-config-propose.js";
 import { randomUUID } from "node:crypto";
+import {
+  startMicrosoftConnect,
+  runMicrosoftConnectPoll,
+  type MicrosoftConnectDeps,
+} from "./microsoft-connect.js";
 import { getAccountInfos, type AccountInfo } from "../auth/account-store.js";
 import {
   AuthBrokerError,
@@ -916,6 +921,129 @@ export function handleGetConnectionAccessStatus(
 /** Test-only reset. */
 export function __resetConnectionAccessStatuses(): void {
   connectionAccessStatuses.clear();
+}
+
+// ─── In-browser Microsoft connect (device-code) ───────────────────────────
+
+export type MicrosoftConnectStatus =
+  | { state: "pending"; startedAt: number; userCode: string; verificationUri: string; expiresInSec: number }
+  | { state: "connected"; startedAt: number; account: string; accountType: "personal" | "work" }
+  | { state: "failed"; startedAt: number; reason: string };
+
+const microsoftConnectStatuses = new Map<string, MicrosoftConnectStatus>();
+
+function reapMicrosoftConnects(now = Date.now()): void {
+  for (const [id, s] of microsoftConnectStatuses) {
+    // Settled entries > 30 min, or pending entries past their device-code
+    // expiry + grace, are dropped.
+    const ttl = s.state === "pending" ? s.expiresInSec * 1000 + 60_000 : 30 * 60_000;
+    if (now - s.startedAt > ttl) microsoftConnectStatuses.delete(id);
+  }
+}
+
+export interface StartConnectResult {
+  ok: boolean;
+  error?: string;
+  requestId?: string;
+  userCode?: string;
+  verificationUri?: string;
+  expiresInSec?: number;
+}
+
+/**
+ * Start an in-browser Microsoft connect (device-code). Returns the short
+ * code + verification URL for the operator to complete on Microsoft's
+ * site; polls for consent in the background and registers the account
+ * with the broker on success. Poll {@link handleGetMicrosoftConnectStatus}.
+ *
+ * `deps` is injectable for tests (device-code + poll + addAccount).
+ */
+export async function handleStartMicrosoftConnect(
+  config: SwitchroomConfig,
+  deps: MicrosoftConnectDeps = {},
+): Promise<StartConnectResult> {
+  const now = deps.now ?? Date.now;
+  const configClientId = (
+    config as { microsoft_workspace?: { microsoft_client_id?: string; org_mode?: boolean } }
+  ).microsoft_workspace?.microsoft_client_id;
+  const orgMode =
+    deps.orgMode ??
+    (config as { microsoft_workspace?: { org_mode?: boolean } }).microsoft_workspace?.org_mode === true;
+
+  const started = await startMicrosoftConnect({ ...deps, configClientId, orgMode });
+  if (started.kind === "byo-vault") {
+    return {
+      ok: false,
+      error:
+        `This install uses a vaulted custom Microsoft app (${started.ref}) the dashboard can't read. ` +
+        `Connect from the host: switchroom auth microsoft account add <email>.`,
+    };
+  }
+  if (started.kind === "error") {
+    return { ok: false, error: started.message };
+  }
+
+  const requestId = randomUUID();
+  microsoftConnectStatuses.set(requestId, {
+    state: "pending",
+    startedAt: now(),
+    userCode: started.device.user_code,
+    verificationUri: started.device.verification_uri,
+    expiresInSec: started.device.expires_in,
+  });
+  reapMicrosoftConnects(now());
+
+  // Background: poll Microsoft → register the account → record the outcome.
+  void runMicrosoftConnectPoll(
+    { device: started.device, clientId: started.clientId, scopes: started.scopes },
+    deps,
+  )
+    .then((res) => {
+      const startedAt = microsoftConnectStatuses.get(requestId)?.startedAt ?? now();
+      if (res.state === "connected") {
+        microsoftConnectStatuses.set(requestId, {
+          state: "connected",
+          startedAt,
+          account: res.account,
+          accountType: res.accountType,
+        });
+        void captureEvent("microsoft_connect", { outcome: "connected", source: "web_api" });
+      } else {
+        const reason =
+          res.state === "no-refresh-token"
+            ? "Microsoft returned no refresh token (account would expire in ~1h)."
+            : res.message;
+        microsoftConnectStatuses.set(requestId, { state: "failed", startedAt, reason });
+      }
+    })
+    .catch((err) => {
+      const startedAt = microsoftConnectStatuses.get(requestId)?.startedAt ?? now();
+      microsoftConnectStatuses.set(requestId, {
+        state: "failed",
+        startedAt,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+      void captureException(err, { action: "microsoft_connect" });
+    });
+
+  return {
+    ok: true,
+    requestId,
+    userCode: started.device.user_code,
+    verificationUri: started.device.verification_uri,
+    expiresInSec: started.device.expires_in,
+  };
+}
+
+export function handleGetMicrosoftConnectStatus(
+  requestId: string,
+): MicrosoftConnectStatus | { state: "unknown" } {
+  return microsoftConnectStatuses.get(requestId) ?? { state: "unknown" };
+}
+
+/** Test-only reset. */
+export function __resetMicrosoftConnectStatuses(): void {
+  microsoftConnectStatuses.clear();
 }
 
 /**

--- a/src/web/microsoft-connect.test.ts
+++ b/src/web/microsoft-connect.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { startMicrosoftConnect, runMicrosoftConnectPoll } from "./microsoft-connect.js";
+import { DEFAULT_MICROSOFT_CLIENT_ID } from "../auth/default-oauth-clients.js";
+import type {
+  MicrosoftDeviceCodeResponse,
+  MicrosoftOAuthClientConfig,
+  MicrosoftTokenResponse,
+} from "../microsoft/oauth.js";
+
+const PERSONAL_MSA_TID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+const DEVICE: MicrosoftDeviceCodeResponse = {
+  device_code: "dc",
+  user_code: "ABCD-EFGH",
+  verification_uri: "https://microsoft.com/devicelogin",
+  expires_in: 900,
+  interval: 5,
+};
+
+function fakeIdToken(payload: Record<string, unknown>): string {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64({ alg: "none" })}.${b64(payload)}.sig`;
+}
+function tokens(o: Partial<MicrosoftTokenResponse> = {}): MicrosoftTokenResponse {
+  return { access_token: "at", refresh_token: "rt", expires_in: 3600, token_type: "Bearer", scope: "Mail.ReadWrite", ...o };
+}
+
+describe("startMicrosoftConnect (web)", () => {
+  it("uses the shipped default client_id + scopes when there is no config", async () => {
+    let seen: MicrosoftOAuthClientConfig | undefined;
+    const res = await startMicrosoftConnect({ requestDeviceCode: async (cfg) => { seen = cfg; return DEVICE; } });
+    expect(res.kind).toBe("started");
+    if (res.kind === "started") {
+      expect(res.source).toBe("default");
+      expect(res.clientId).toBe(DEFAULT_MICROSOFT_CLIENT_ID);
+      expect(res.scopes).toContain("offline_access");
+      expect(res.device.user_code).toBe("ABCD-EFGH");
+    }
+    expect(seen?.client_id).toBe(DEFAULT_MICROSOFT_CLIENT_ID);
+  });
+
+  it("refuses a vaulted BYO client (web can't resolve vault refs)", async () => {
+    const res = await startMicrosoftConnect({
+      configClientId: "vault:microsoft-oauth-client-id",
+      requestDeviceCode: async () => DEVICE,
+    });
+    expect(res.kind).toBe("byo-vault");
+  });
+
+  it("surfaces a device-code request failure as error", async () => {
+    const res = await startMicrosoftConnect({ requestDeviceCode: async () => { throw new Error("boom"); } });
+    expect(res.kind).toBe("error");
+    if (res.kind === "error") expect(res.message).toContain("boom");
+  });
+});
+
+describe("runMicrosoftConnectPoll (web)", () => {
+  const flow = { device: DEVICE, clientId: "c1", scopes: ["offline_access", "Mail.ReadWrite"] };
+
+  it("connected: registers the account via the broker keyed by the authenticated email", async () => {
+    const id_token = fakeIdToken({ tid: PERSONAL_MSA_TID, oid: "oid-1", preferred_username: "Lisa@Outlook.com" });
+    const added: Array<{ label: string }> = [];
+    const res = await runMicrosoftConnectPoll(flow, {
+      pollDeviceToken: async () => tokens({ id_token }),
+      addAccount: async (label) => { added.push({ label }); return {}; },
+    });
+    expect(res.state).toBe("connected");
+    if (res.state === "connected") {
+      expect(res.account).toBe("lisa@outlook.com");
+      expect(res.accountType).toBe("personal");
+    }
+    expect(added).toEqual([{ label: "lisa@outlook.com" }]);
+  });
+
+  it("no-refresh-token: refuses to register an un-refreshable account", async () => {
+    let added = false;
+    const res = await runMicrosoftConnectPoll(flow, {
+      pollDeviceToken: async () => tokens({ refresh_token: undefined }),
+      addAccount: async () => { added = true; return {}; },
+    });
+    expect(res.state).toBe("no-refresh-token");
+    expect(added).toBe(false);
+  });
+
+  it("failed: surfaces a poll error (e.g. work account rejected at /common)", async () => {
+    const res = await runMicrosoftConnectPoll(flow, {
+      pollDeviceToken: async () => { throw new Error("AADSTS9001023 work account"); },
+      addAccount: async () => ({}),
+    });
+    expect(res.state).toBe("failed");
+    if (res.state === "failed") expect(res.message).toContain("AADSTS9001023");
+  });
+
+  it("failed: no id_token → no resolvable account identity, not registered", async () => {
+    let added = false;
+    const res = await runMicrosoftConnectPoll(flow, {
+      pollDeviceToken: async () => tokens({ id_token: undefined }),
+      addAccount: async () => { added = true; return {}; },
+    });
+    expect(res.state).toBe("failed");
+    if (res.state === "failed") expect(res.message).toContain("account identity");
+    expect(added).toBe(false);
+  });
+});

--- a/src/web/microsoft-connect.ts
+++ b/src/web/microsoft-connect.ts
@@ -1,0 +1,143 @@
+/**
+ * In-browser Microsoft connect for the dashboard — RFC 8628 device-code.
+ *
+ * The dashboard parity of the Telegram `/connect microsoft` flow: the
+ * operator clicks "Connect a Microsoft account", we start a device-code
+ * flow against the shipped default app (or a BYO client), surface the
+ * short user_code + verification URL, and poll Microsoft's token endpoint
+ * in the background. On consent we register the account with the
+ * auth-broker. Mirrors telegram-plugin/gateway/microsoft-connect-flow.ts
+ * but reuses the src-level OAuth primitives directly so the web layer
+ * doesn't import from the plugin.
+ *
+ * SECURITY: connecting an account is NOT a credential-access grant. The
+ * device-code consent is a human action on Microsoft's own domain (an
+ * agent can't complete someone else's sign-in), and a registered account
+ * is unusable by any agent until the operator approves access via the
+ * (Telegram-approval-gated) connection-access flow. So no approval card
+ * is needed to START a connect — the Microsoft sign-in is the gate.
+ */
+
+import {
+  requestDeviceCode as realRequestDeviceCode,
+  pollDeviceToken as realPollDeviceToken,
+  type MicrosoftDeviceCodeResponse,
+  type MicrosoftOAuthClientConfig,
+} from "../microsoft/oauth.js";
+import { selectMicrosoftScopes } from "../microsoft/scopes.js";
+import { buildMicrosoftCredentials } from "../microsoft/credentials.js";
+import { resolveMicrosoftClientId } from "../auth/default-oauth-clients.js";
+import { isVaultReference } from "../vault/resolver.js";
+import { withAuthBrokerClient } from "../auth/broker/client.js";
+import type { MicrosoftAddAccountCredentials } from "../auth/broker/client.js";
+
+export interface MicrosoftConnectDeps {
+  /** `config.microsoft_workspace?.microsoft_client_id` (may be a vault: ref). */
+  configClientId?: string;
+  orgMode?: boolean;
+  requestDeviceCode?: (
+    cfg: MicrosoftOAuthClientConfig,
+  ) => Promise<MicrosoftDeviceCodeResponse>;
+  pollDeviceToken?: typeof realPollDeviceToken;
+  addAccount?: (
+    label: string,
+    creds: MicrosoftAddAccountCredentials,
+  ) => Promise<unknown>;
+  now?: () => number;
+}
+
+export type StartResult =
+  | {
+      kind: "started";
+      device: MicrosoftDeviceCodeResponse;
+      clientId: string;
+      scopes: string[];
+      source: "env" | "config" | "default";
+    }
+  | { kind: "byo-vault"; ref: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Request a device code. Does not register anything — returns the data
+ * the dashboard needs to show the sign-in card. The caller stores the
+ * pending entry and kicks off {@link runMicrosoftConnectPoll}.
+ */
+export async function startMicrosoftConnect(
+  deps: MicrosoftConnectDeps = {},
+): Promise<StartResult> {
+  const resolved = resolveMicrosoftClientId(deps.configClientId);
+  // A vaulted BYO client_id can't be resolved from the web process — the
+  // operator must connect that install from the host CLI.
+  if (isVaultReference(resolved.clientId)) {
+    return { kind: "byo-vault", ref: resolved.clientId };
+  }
+  const scopes = selectMicrosoftScopes(deps.orgMode ?? false);
+  const cfg: MicrosoftOAuthClientConfig = { client_id: resolved.clientId, scopes };
+  try {
+    const device = await (deps.requestDeviceCode ?? realRequestDeviceCode)(cfg);
+    return { kind: "started", device, clientId: resolved.clientId, scopes, source: resolved.source };
+  } catch (err) {
+    return { kind: "error", message: (err as Error).message };
+  }
+}
+
+export type PollResult =
+  | { state: "connected"; account: string; accountType: "personal" | "work" }
+  | { state: "no-refresh-token" }
+  | { state: "failed"; message: string };
+
+/**
+ * Poll Microsoft for consent, then register the account with the broker.
+ * Blocks (with the device-code interval) up to `device.expires_in`.
+ */
+export async function runMicrosoftConnectPoll(
+  flow: { device: MicrosoftDeviceCodeResponse; clientId: string; scopes: string[] },
+  deps: MicrosoftConnectDeps = {},
+): Promise<PollResult> {
+  const now = deps.now ?? Date.now;
+  const cfg: MicrosoftOAuthClientConfig = { client_id: flow.clientId, scopes: flow.scopes };
+
+  let tokens;
+  try {
+    tokens = await (deps.pollDeviceToken ?? realPollDeviceToken)(cfg, flow.device, { now });
+  } catch (err) {
+    return { state: "failed", message: (err as Error).message };
+  }
+
+  const built = buildMicrosoftCredentials({
+    tokens,
+    clientId: flow.clientId,
+    accountEmail: "", // device-code learns the email from the id_token
+    fallbackScope: flow.scopes.join(" "),
+    now,
+  });
+
+  // offline_access is requested; without a refresh token the account dies
+  // at the first access-token expiry — refuse rather than register it.
+  if (!built.credentials.microsoftOauth.refreshToken) {
+    return { state: "no-refresh-token" };
+  }
+  const account = built.resolvedEmail;
+  if (!account) {
+    return { state: "failed", message: "Microsoft returned no account identity (no id_token)." };
+  }
+
+  const addAccount =
+    deps.addAccount ??
+    ((label: string, creds: MicrosoftAddAccountCredentials) =>
+      withAuthBrokerClient((client) =>
+        client.addAccount(label, creds, /*replace*/ true, "microsoft"),
+      ));
+
+  try {
+    await addAccount(account, built.credentials as MicrosoftAddAccountCredentials);
+  } catch (err) {
+    return { state: "failed", message: (err as Error).message };
+  }
+
+  return {
+    state: "connected",
+    account,
+    accountType: built.credentials.microsoftOauth.accountType,
+  };
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -34,6 +34,8 @@ import {
   handleGetMicrosoftAccounts,
   handleSetConnectionAccess,
   handleGetConnectionAccessStatus,
+  handleStartMicrosoftConnect,
+  handleGetMicrosoftConnectStatus,
   handleGetNotionWorkspace,
   handleGetSchedule,
   handleGetApprovals,
@@ -425,6 +427,21 @@ function parseRoute(
     };
   }
 
+  // POST /api/connections/microsoft/connect — start an in-browser
+  // device-code connect; returns a user code + verification URL to poll.
+  if (method === "POST" && pathname === "/api/connections/microsoft/connect") {
+    return { handler: "startMicrosoftConnect", params: {} };
+  }
+
+  // GET /api/connections/microsoft/connect/:requestId — poll the connect.
+  const msConnectMatch = pathname.match(/^\/api\/connections\/microsoft\/connect\/([^/]+)$/);
+  if (method === "GET" && msConnectMatch) {
+    return {
+      handler: "getMicrosoftConnectStatus",
+      params: { requestId: decodeURIComponent(msConnectMatch[1]) },
+    };
+  }
+
   // POST /api/auth/use
   //   body: { account: string }
   // Replaces the pre-RFC-H `/api/accounts/:label/promote` endpoint. The
@@ -698,6 +715,17 @@ export function startWebServer(
           case "getConnectionAccessStatus":
             return jsonResponse(
               handleGetConnectionAccessStatus(route.params.requestId),
+            );
+
+          case "startMicrosoftConnect":
+            return (async () => {
+              const result = await handleStartMicrosoftConnect(freshConfig());
+              return jsonResponse(result, result.ok ? 200 : 400);
+            })();
+
+          case "getMicrosoftConnectStatus":
+            return jsonResponse(
+              handleGetMicrosoftConnectStatus(route.params.requestId),
             );
 
           case "refreshQuota": {

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -559,6 +559,51 @@
       }
     }
 
+    // Start an in-browser Microsoft connect: show the device code + link,
+    // then poll until the operator completes sign-in on Microsoft's site.
+    async function connectMicrosoft() {
+      const card = document.getElementById('ms-connect-card');
+      const show = (html) => { if (card) card.innerHTML = html; };
+      show('<div class="loading" style="padding:.8rem">Starting…</div>');
+      try {
+        const res = await fetch(`${API}/api/connections/microsoft/connect`, { method: 'POST', headers: authHeaders() });
+        const data = await res.json();
+        if (!res.ok || !data.ok) { show(''); showError(data.error || `HTTP ${res.status}`); return; }
+        const url = data.verificationUri, code = data.userCode;
+        show(`<div class="account-card" style="border-color:var(--accent)">
+            <div class="account-card-header"><div class="account-label">Connect a Microsoft account</div></div>
+            <div style="padding:.3rem 0;line-height:1.7">
+              1. Open <a href="${escapeHtml(url)}" target="_blank" rel="noopener" style="color:var(--accent)">${escapeHtml(url)}</a><br>
+              2. Enter code: <code style="font-size:1.15rem;letter-spacing:.08em">${escapeHtml(code)}</code><br>
+              3. Approve the requested permissions (Mail, Calendar, Files).
+            </div>
+            <div id="ms-connect-status" style="color:var(--text-dim);margin-top:.3rem">Waiting for sign-in… (this card expires in ~15 min)</div>
+          </div>`);
+        const statusEl = () => document.getElementById('ms-connect-status');
+        const started = Date.now();
+        const poll = async () => {
+          const sres = await fetch(`${API}/api/connections/microsoft/connect/${encodeURIComponent(data.requestId)}`, { headers: authHeaders() });
+          const s = sres.ok ? await sres.json() : { state: 'failed', reason: `HTTP ${sres.status}` };
+          if (s.state === 'pending') {
+            if (Date.now() - started > ((data.expiresInSec || 900) * 1000 + 30000)) { const e = statusEl(); if (e) e.textContent = 'Expired — click Connect to try again.'; return; }
+            setTimeout(poll, 3000);
+            return;
+          }
+          if (s.state === 'connected') {
+            show(`<div class="loading" style="padding:.8rem;color:var(--green)">✓ Connected ${escapeHtml(s.account)} (${escapeHtml(s.accountType)}). Use the access toggles below to grant an agent.</div>`);
+            fetchConnections();
+          } else {
+            show('');
+            showError(s.reason || 'connect failed');
+          }
+        };
+        setTimeout(poll, 3000);
+      } catch (err) {
+        show('');
+        showError(err.message);
+      }
+    }
+
     async function fetchSchedule() {
       try {
         const res = await fetch(`${API}/api/schedule`, { headers: authHeaders() });
@@ -1115,11 +1160,18 @@
         google.map(a => renderOAuthAccountCard(a, { showType: false, provider: 'google', agentNames })).join(''),
       );
 
-      const microsoftSection = _connectionSection(
-        'Microsoft 365',
-        'No Microsoft accounts. Connect one from Telegram with <code>/connect microsoft</code> (admin DM), or <code>switchroom auth microsoft account add</code>.',
-        microsoft.map(a => renderOAuthAccountCard(a, { showType: true, provider: 'microsoft', agentNames })).join(''),
-      );
+      const msCards = microsoft.map(a => renderOAuthAccountCard(a, { showType: true, provider: 'microsoft', agentNames })).join('');
+      const microsoftSection = `
+        <div style="margin-bottom:1.5rem">
+          <h3 style="margin:0 0 .6rem;font-size:.95rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.04em">
+            Microsoft 365
+            <button onclick="connectMicrosoft()" class="usage-pill primary" style="margin-left:.6rem;cursor:pointer;border:none;text-transform:none;font-weight:600">+ Connect a Microsoft account</button>
+          </h3>
+          <div id="ms-connect-card"></div>
+          ${msCards
+            ? `<div class="accounts-grid">${msCards}</div>`
+            : `<div class="loading" style="padding:.8rem">No Microsoft accounts yet — click <b>Connect a Microsoft account</b> above (or <code>/connect microsoft</code> from Telegram).</div>`}
+        </div>`;
 
       let notionCards = '';
       if (notion.configured) {

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -99,6 +99,9 @@ import {
   handleSetConnectionAccess,
   handleGetConnectionAccessStatus,
   __resetConnectionAccessStatuses,
+  handleStartMicrosoftConnect,
+  handleGetMicrosoftConnectStatus,
+  __resetMicrosoftConnectStatuses,
   handleGetApprovals,
   handleRefreshAccountsQuota,
   __resetQuotaCacheForTests,
@@ -983,6 +986,85 @@ microsoft_accounts:
     expect(capturedAfter).toContain("account: b@outlook.com");
     const aBlock = capturedAfter.slice(capturedAfter.indexOf("a@outlook.com"));
     expect(aBlock.slice(0, aBlock.indexOf("b@outlook.com"))).not.toContain("- marko");
+  });
+});
+
+describe("handleStartMicrosoftConnect (in-browser device-code)", () => {
+  const PERSONAL_MSA_TID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+  const DEVICE = {
+    device_code: "dc",
+    user_code: "WXYZ-1234",
+    verification_uri: "https://microsoft.com/devicelogin",
+    expires_in: 900,
+    interval: 5,
+  };
+  const fakeIdToken = (p: Record<string, unknown>) => {
+    const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    return `${b64({ alg: "none" })}.${b64(p)}.sig`;
+  };
+  const okTokens = {
+    access_token: "at",
+    refresh_token: "rt",
+    expires_in: 3600,
+    token_type: "Bearer",
+    scope: "Mail.ReadWrite",
+    id_token: fakeIdToken({ tid: PERSONAL_MSA_TID, oid: "o1", preferred_username: "lisa@outlook.com" }),
+  };
+  const cfg = mockConfig as unknown as SwitchroomConfig;
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  beforeEach(() => __resetMicrosoftConnectStatuses());
+
+  it("returns the device code + URL immediately and registers on consent", async () => {
+    const added: string[] = [];
+    const res = await handleStartMicrosoftConnect(cfg, {
+      requestDeviceCode: async () => DEVICE,
+      pollDeviceToken: async () => okTokens as never,
+      addAccount: async (label) => { added.push(label); return {}; },
+    });
+    expect(res.ok).toBe(true);
+    expect(res.userCode).toBe("WXYZ-1234");
+    expect(res.verificationUri).toContain("devicelogin");
+    expect(res.requestId).toBeTruthy();
+    // Pending until the background poll resolves.
+    const before = handleGetMicrosoftConnectStatus(res.requestId!);
+    expect(before.state).toMatch(/pending|connected/);
+    await flush();
+    const after = handleGetMicrosoftConnectStatus(res.requestId!);
+    expect(after.state).toBe("connected");
+    if (after.state === "connected") expect(after.account).toBe("lisa@outlook.com");
+    expect(added).toEqual(["lisa@outlook.com"]);
+  });
+
+  it("surfaces a poll failure via the status endpoint (account NOT registered)", async () => {
+    let added = false;
+    const res = await handleStartMicrosoftConnect(cfg, {
+      requestDeviceCode: async () => DEVICE,
+      pollDeviceToken: async () => { throw new Error("expired_token"); },
+      addAccount: async () => { added = true; return {}; },
+    });
+    expect(res.ok).toBe(true);
+    await flush();
+    const st = handleGetMicrosoftConnectStatus(res.requestId!);
+    expect(st.state).toBe("failed");
+    if (st.state === "failed") expect(st.reason).toContain("expired_token");
+    expect(added).toBe(false);
+  });
+
+  it("refuses a vaulted BYO Microsoft client (points at the host CLI)", async () => {
+    const byoCfg = {
+      ...mockConfig,
+      microsoft_workspace: { microsoft_client_id: "vault:ms-id" },
+    } as unknown as SwitchroomConfig;
+    const res = await handleStartMicrosoftConnect(byoCfg, {
+      requestDeviceCode: async () => DEVICE,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("host");
+  });
+
+  it("returns 'unknown' for an unrecognized connect requestId", () => {
+    expect(handleGetMicrosoftConnectStatus("nope").state).toBe("unknown");
   });
 });
 


### PR DESCRIPTION
## Summary

UI Phase B-2: a **"Connect a Microsoft account"** button on the Connections tab runs the RFC 8628 **device-code** flow in the browser — dashboard parity with the Telegram `/connect microsoft` flow. Click → get a short code + `microsoft.com/devicelogin` link → sign in on Microsoft's site → the account registers with the broker and appears in the tab, ready for the (approval-gated, #2185) access toggle.

## What changed

- **`src/web/microsoft-connect.ts`** — `startMicrosoftConnect` (resolve the shipped default client_id → `requestDeviceCode`) + `runMicrosoftConnectPoll` (`pollDeviceToken` → `buildMicrosoftCredentials` → broker `addAccount(provider:microsoft, replace)`). Reuses the **src-level** OAuth primitives directly (no import from `telegram-plugin`); mirrors the reviewed gateway connect flow. Vaulted BYO client_id → host-CLI pointer; no refresh token → refuse to register.
- **`api.ts`** — `handleStartMicrosoftConnect` returns the code + URL **immediately** and polls in the background (device-code blocks up to ~15 min on the human sign-in; the POST must not hang); `handleGetMicrosoftConnectStatus` polls a pending map (reaped at device-expiry / 30 min).
- **`server.ts`** — `POST /api/connections/microsoft/connect` + `GET …/:requestId`, same auth/CSRF gate as the other endpoints.
- **`ui/index.html`** — Connect button in the Microsoft section → device-code card (link + code) → polls → on connected, refreshes.

## Security

Connecting an account is **NOT** a credential grant. The device-code consent is a human action on Microsoft's domain (an agent can't complete someone else's sign-in), and a registered account is **unusable by any agent until the operator approves access** via the Telegram-approval-gated flow (#2185). So starting a connect needs no approval card — the Microsoft sign-in is the gate. A forging agent could at most start a flow that nobody completes (it expires) or register *its own* account (benign clutter, no access). Google stays host-CLI; Notion (operator-owned vault token) stays CLI/docs — both deferred from in-UI connect by design.

## Test plan

- [x] **81 tests** across the touched suites: `microsoft-connect` (default / byo-vault / error start; connected / no-refresh-token / failed / no-id_token poll — account registered **only** on success) + the handler (code returned immediately, background poll → connected with broker `addAccount`, failure surfaced **without** registering, vaulted-BYO → host-CLI pointer, unknown requestId).
- [x] `tsc --noEmit` + full lint chain green; UI inline JS parses.

## Risk

Low–moderate. Additive endpoints reusing already-shipped, reviewed OAuth primitives (the same engine behind `/connect microsoft`). The POST returns promptly; the background poll never throws (mapped to a `failed` status); the pending map is bounded + reaped. No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)