### PR TITLE
feat(memory): memory.file gate to retire curated MEMORY.md (hindsight-native)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1520,6 +1520,13 @@ function seedWorkspaceBootstrapFiles(params: {
   created: string[];
   skipped: string[];
   rewrittenWithBackup: string[];
+  /**
+   * When false (agent `memory.file: false`), do NOT seed the curated
+   * workspace MEMORY.md. Hindsight-native agents carry memory in the bank
+   * (directives + mental models + retained facts), so seeding the file
+   * here would re-create it after a migration delete. Defaults to seeding.
+   */
+  seedMemoryFile?: boolean;
 }): void {
   const profileWorkspaceDir = join(params.profilePath, "workspace");
   if (!existsSync(profileWorkspaceDir)) {
@@ -1542,6 +1549,14 @@ function seedWorkspaceBootstrapFiles(params: {
         continue;
       }
       if (entry === ".gitkeep") continue; // presence-only marker, ignore
+      // Hindsight-native gate: skip the curated MEMORY.md when the agent
+      // opted out of file memory (memory.file: false). Covers both the
+      // `.hbs` template and a plain MEMORY.md. Without this, a reconcile
+      // would re-seed the file after a migration delete.
+      if (params.seedMemoryFile === false && relPath.replace(/\.hbs$/, "") === "MEMORY.md") {
+        params.skipped.push(join(agentWorkspaceDir, "MEMORY.md"));
+        continue;
+      }
       if (entry.endsWith(".hbs")) {
         const destRel = relPath.replace(/\.hbs$/, "");
         const destPath = join(agentWorkspaceDir, destRel);
@@ -3130,6 +3145,7 @@ export function scaffoldAgent(
     created,
     skipped,
     rewrittenWithBackup,
+    seedMemoryFile: agentConfig.memory?.file !== false,
   });
   ensureClaudeMdSymlinks(phase5WorkspaceDir, created);
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -5217,6 +5217,10 @@ export function reconcileAgent(
       created: changes,
       skipped: [],
       rewrittenWithBackup: changes,
+      // Hindsight-native gate must hold on the RECONCILE path too — this is
+      // what runs on every `agent restart` / `apply`, so without it a deleted
+      // MEMORY.md would be re-seeded here and the migration would not stick.
+      seedMemoryFile: agentConfig.memory?.file !== false,
     });
     ensureClaudeMdSymlinks(reconcileWorkspaceDir, changes);
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -136,6 +136,16 @@ export const AgentMemorySchema = z
       .boolean()
       .default(true)
       .describe("Auto-search memories before each response"),
+    file: z
+      .boolean()
+      .default(true)
+      .describe(
+        "Maintain a curated workspace MEMORY.md file (seeded once, " +
+        "auto-loaded every turn). Set false for hindsight-only memory: " +
+        "the file is not seeded or re-created, so once migrated into " +
+        "Hindsight and deleted it stays gone. Recall + directives carry " +
+        "the memory instead. Cascade: override (per-agent wins over default)."
+      ),
     isolation: z
       .enum(["default", "strict"])
       .default("default")

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1150,6 +1150,35 @@ describe("scaffoldAgent", () => {
     expect(existsSync(join(workspaceDir, "AGENTS.md.hbs"))).toBe(false);
   });
 
+  it("memory.file: false gates the workspace MEMORY.md seed (hindsight-native), leaving siblings intact", () => {
+    const config = makeAgentConfig({ memory: { file: false } as AgentConfig["memory"] });
+    const result = scaffoldAgent("hindsight-native-agent", config, tmpDir, telegramConfig);
+    const workspaceDir = join(result.agentDir, "workspace");
+
+    // The curated MEMORY.md must NOT be seeded — so a migration delete sticks
+    // across reconcile instead of being re-created as an empty template.
+    expect(existsSync(join(workspaceDir, "MEMORY.md"))).toBe(false);
+
+    // Every OTHER bootstrap file is unaffected by the gate.
+    expect(existsSync(join(workspaceDir, "USER.md"))).toBe(true);
+    expect(existsSync(join(workspaceDir, "IDENTITY.md"))).toBe(true);
+    expect(existsSync(join(workspaceDir, "SOUL.md"))).toBe(true);
+
+    // Default (file omitted) still seeds MEMORY.md — gate is opt-in only.
+    const def = scaffoldAgent("file-default-agent", makeAgentConfig({}), tmpDir, telegramConfig);
+    expect(existsSync(join(def.agentDir, "workspace", "MEMORY.md"))).toBe(true);
+  });
+
+  it("memory.file: false survives reconcile — MEMORY.md is not re-seeded", () => {
+    const config = makeAgentConfig({ memory: { file: false } as AgentConfig["memory"] });
+    const r1 = scaffoldAgent("native-reconcile-agent", config, tmpDir, telegramConfig);
+    const memPath = join(r1.agentDir, "workspace", "MEMORY.md");
+    expect(existsSync(memPath)).toBe(false);
+    // Re-scaffold (reconcile) must not bring it back.
+    scaffoldAgent("native-reconcile-agent", config, tmpDir, telegramConfig);
+    expect(existsSync(memPath)).toBe(false);
+  });
+
   it("start.sh respects session_continuity.resume_mode in the generated script", () => {
     // handoff is now the default (no explicit resume_mode in config)
     const defaultResult = scaffoldAgent(

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -1169,13 +1169,31 @@ describe("scaffoldAgent", () => {
     expect(existsSync(join(def.agentDir, "workspace", "MEMORY.md"))).toBe(true);
   });
 
-  it("memory.file: false survives reconcile — MEMORY.md is not re-seeded", () => {
-    const config = makeAgentConfig({ memory: { file: false } as AgentConfig["memory"] });
-    const r1 = scaffoldAgent("native-reconcile-agent", config, tmpDir, telegramConfig);
-    const memPath = join(r1.agentDir, "workspace", "MEMORY.md");
-    expect(existsSync(memPath)).toBe(false);
-    // Re-scaffold (reconcile) must not bring it back.
-    scaffoldAgent("native-reconcile-agent", config, tmpDir, telegramConfig);
+  it("memory.file: false makes a deleted MEMORY.md stick across reconcile (the migration scenario)", () => {
+    // 1. Normal agent — MEMORY.md is seeded.
+    const normal = makeAgentConfig({});
+    const normalSc: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "mig-agent": normal },
+    } as SwitchroomConfig;
+    const r = scaffoldAgent("mig-agent", normal, tmpDir, telegramConfig, normalSc);
+    const memPath = join(r.agentDir, "workspace", "MEMORY.md");
+    expect(existsSync(memPath)).toBe(true);
+
+    // 2. Migrate: operator deletes the file and flips memory.file: false.
+    rmSync(memPath);
+    const migrated = makeAgentConfig({ memory: { file: false } as AgentConfig["memory"] });
+    const migratedSc: SwitchroomConfig = {
+      switchroom: { version: 1, agents_dir: tmpDir },
+      telegram: telegramConfig,
+      agents: { "mig-agent": migrated },
+    } as SwitchroomConfig;
+
+    // 3. reconcile() is the path that runs on every `agent restart` / `apply`.
+    //    It MUST NOT re-seed the deleted file — otherwise the migration never
+    //    sticks. (This fails against an ungated reconcile call site.)
+    reconcileAgent("mig-agent", migrated, tmpDir, telegramConfig, migratedSc);
     expect(existsSync(memPath)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
Adds a per-agent `memory.file` boolean (default `true` = no behavior change). When `false`, the scaffold stops seeding the curated workspace `MEMORY.md`, so once its content is migrated into Hindsight and the file deleted, the delete **sticks** across reconcile (today MEMORY.md is seed-once → a bare delete gets re-created as an empty template).

## Why
switchroom runs **two** parallel memory systems: Hindsight (auto-recall + auto-retain hooks + agent `sync_retain`) and a curated `MEMORY.md` that's seeded once and auto-loaded every turn. The architecture goal is to converge on Hindsight as the single backend ("hindsight-native"). This is the mechanism that lets us retire the file per-agent after migrating its content into Hindsight (directives for standing rules + auto-synthesized mental models + retained facts).

The per-turn loader already skips absent files gracefully (`loadNamedFile` → `missing: true`), so only the **seed** path needed gating.

## Changes
- `memory.file` field on `AgentMemorySchema` (override cascade, documented).
- `seedWorkspaceBootstrapFiles` skips `MEMORY.md` (both `.hbs` and plain) when `memory.file: false`.
- Caller threads `agentConfig.memory?.file !== false`.

## Test plan
- [x] `vitest run tests/scaffold.test.ts` — 193 pass, incl. 2 new (gate skips MEMORY.md + siblings intact + default still seeds; gate survives reconcile)
- [x] config schema tests — 44 pass
- [x] `tsc --noEmit` clean

## Risk
Low — additive, opt-in, default `true`. No existing agent changes behavior. Serves the **REMEMBER = one backend** box of the agent-context architecture (single source of truth, no file/bank divergence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)