### PR TITLE
feat(doctor): memory-backend health check (catch silent hindsight outages)

### DIFF
--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -1,0 +1,154 @@
+/**
+ * Memory-backend health checks for `switchroom doctor`.
+ *
+ * The existing hindsight checks (`checkHindsight`) confirm the backend is
+ * *reachable and speaking MCP* — but the 2026-06-06 outage proved that's not
+ * enough: the container was up and serving MCP while every memory write
+ * silently failed. Two distinct failure modes hid behind a healthy-looking
+ * port:
+ *
+ *   1. **shm exhaustion** — PostgreSQL needs ~533MB+ of shared memory for
+ *      large query/sort segments; Docker's 64MB default made every write fail
+ *      with `could not resize shared memory segment ... No space left on
+ *      device`. (Now prevented at launch by --shm-size, #2190 — but a
+ *      pre-#2190 container or a hand-rolled one can still hit it.)
+ *   2. **OAuth quota exhaustion** — hindsight's fact-extraction `claude` calls
+ *      hit the account's weekly limit (429), so retains were accepted but
+ *      extracted 0 facts → nothing became recallable.
+ *
+ * Neither is visible over the MCP port. Both ARE visible in the container's
+ * shm config and recent logs. These checks surface them so the next outage is
+ * caught by `doctor`, not by a user noticing their agents went amnesiac.
+ *
+ * The pure classifiers below are unit-tested against real log/shm samples; the
+ * docker wrapper is best-effort and silently skips when hindsight isn't a
+ * local container (remote URL / no docker / inside an agent container).
+ */
+import { execFileSync } from "node:child_process";
+
+export interface CheckResult {
+  name: string;
+  status: "ok" | "warn" | "fail";
+  detail?: string;
+  fix?: string;
+}
+
+/** 1 GiB in bytes — the floor below which PostgreSQL's shared segments fail. */
+export const MIN_HINDSIGHT_SHM_BYTES = 1024 * 1024 * 1024;
+
+/** Pure: classify a container's ShmSize (bytes) into a health result. */
+export function classifyShmSize(bytes: number): CheckResult {
+  const mib = Math.round(bytes / 1024 / 1024);
+  if (bytes < MIN_HINDSIGHT_SHM_BYTES) {
+    return {
+      name: "hindsight shm-size",
+      status: "fail",
+      detail:
+        `${mib}MB — PostgreSQL needs ~533MB+ for shared segments; writes will ` +
+        `fail with "No space left on device"`,
+      fix:
+        "Recreate hindsight with a larger shm. The launch path now sets " +
+        "--shm-size=2g (#2190); pull a release that includes it and run " +
+        "`switchroom memory --restart`, or recreate the container manually " +
+        "preserving the `switchroom-hindsight-data` volume.",
+    };
+  }
+  const gib = (bytes / 1024 / 1024 / 1024).toFixed(bytes % (1024 ** 3) === 0 ? 0 : 1);
+  return { name: "hindsight shm-size", status: "ok", detail: `${gib}g` };
+}
+
+/**
+ * Pure: classify recent hindsight logs for fact-extraction health. Catches the
+ * two silent-write failure modes by their log signatures.
+ */
+export function classifyExtractionLogs(logs: string): CheckResult {
+  const noSpace = /No space left on device|could not resize shared memory/i.test(logs);
+  // What hindsight's OWN logs show when fact-extraction `claude` calls fail
+  // (quota/429, auth, or model error): the provider logs an "error result" and
+  // extraction yields 0 facts. The literal "429"/"weekly limit" string lives in
+  // the `claude -p` envelope, not hindsight's logs — so match the provider error.
+  const llmError = /Claude Code returned an error result|claude_code_llm[\s\S]{0,80}error|Fact extraction failed|Content extraction failed/i.test(logs);
+  const quotaHint = /weekly limit|api_error_status["':\s]+429|\b429\b|hit your[\s\S]{0,24}limit/i.test(logs);
+  const zeroFacts = (logs.match(/Extract facts:\s*0 facts/gi) ?? []).length;
+  const okFacts = (logs.match(/Extract facts:\s*[1-9]\d* facts/gi) ?? []).length;
+
+  if (noSpace) {
+    return {
+      name: "hindsight extraction",
+      status: "fail",
+      detail: "shared-memory exhaustion in recent logs — memory writes are failing",
+      fix: "See the `hindsight shm-size` check — the container's /dev/shm is too small.",
+    };
+  }
+  if (llmError && okFacts === 0) {
+    return {
+      name: "hindsight extraction",
+      status: "fail",
+      detail:
+        "fact-extraction LLM calls are failing" +
+        (quotaHint ? " (429 / weekly-limit detected)" : "") +
+        " — retains are accepted but extract 0 facts, so nothing becomes recallable",
+      fix:
+        "Usually hindsight's `auth.consumers[hindsight].account` is quota-" +
+        "exhausted or its OAuth broke. Repoint it to an account with quota in " +
+        "switchroom.yaml, then `docker restart switchroom-auth-broker` and " +
+        "`docker restart switchroom-hindsight` (single-file config mount needs " +
+        "the broker restart to re-read). Confirm with a `claude -p` inside the " +
+        "container.",
+    };
+  }
+  if (zeroFacts >= 3 && okFacts === 0) {
+    return {
+      name: "hindsight extraction",
+      status: "warn",
+      detail:
+        `${zeroFacts} recent extractions produced 0 facts and none succeeded — ` +
+        "fact extraction may be failing",
+      fix: "Inspect `docker logs switchroom-hindsight` for the extraction error.",
+    };
+  }
+  return {
+    name: "hindsight extraction",
+    status: "ok",
+    detail: okFacts > 0
+      ? `healthy (${okFacts} recent successful extractions)`
+      : "no recent extraction activity to assess",
+  };
+}
+
+/**
+ * Best-effort: inspect the local `switchroom-hindsight` container's shm + recent
+ * logs. Returns [] (silently skipped) when hindsight isn't a local container —
+ * a remote `memory.config.url`, no docker, or running inside an agent container.
+ */
+export function checkHindsightContainerHealth(
+  opts?: { exec?: (cmd: string, args: string[]) => string; containerName?: string },
+): CheckResult[] {
+  const name = opts?.containerName ?? "switchroom-hindsight";
+  const exec =
+    opts?.exec ??
+    ((cmd: string, args: string[]) =>
+      execFileSync(cmd, args, { stdio: ["ignore", "pipe", "ignore"], timeout: 8000 }).toString());
+
+  const results: CheckResult[] = [];
+
+  let shmRaw: string;
+  try {
+    shmRaw = exec("docker", ["inspect", name, "--format", "{{.HostConfig.ShmSize}}"]).trim();
+  } catch {
+    return []; // not a local container / no docker — nothing to check here
+  }
+  const shmBytes = parseInt(shmRaw, 10);
+  if (Number.isFinite(shmBytes) && shmBytes > 0) {
+    results.push(classifyShmSize(shmBytes));
+  }
+
+  try {
+    const logs = exec("docker", ["logs", "--since", "10m", name]);
+    results.push(classifyExtractionLogs(logs));
+  } catch {
+    // logs unavailable — skip the extraction check rather than fail the run
+  }
+
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -28,6 +28,7 @@ import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
 import { probeHindsight, isHindsightEnabled } from "../memory/hindsight.js";
+import { checkHindsightContainerHealth } from "./doctor-memory.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runHostdChecks } from "./doctor-hostd.js";
@@ -1006,6 +1007,12 @@ async function checkHindsight(config: SwitchroomConfig): Promise<CheckResult[]> 
   // the legacy env-leak probe (the OpenAI-key shape it watched for
   // is no longer in use).
   results.push(checkHindsightConsumer(config));
+
+  // Backend health (#outage 2026-06-06): reachability over MCP is NOT enough —
+  // the container can be up and serving MCP while every write silently fails
+  // (shm exhaustion or OAuth quota 429). These surface both from the local
+  // container's shm config + recent logs; no-ops on a remote/dockerless setup.
+  results.push(...checkHindsightContainerHealth());
 
   // Per-agent bank health checks
   for (const [agentName, agentConfig] of Object.entries(config.agents)) {

--- a/tests/cli.doctor.memory-health.test.ts
+++ b/tests/cli.doctor.memory-health.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyShmSize,
+  classifyExtractionLogs,
+  checkHindsightContainerHealth,
+  MIN_HINDSIGHT_SHM_BYTES,
+} from "../src/cli/doctor-memory.js";
+
+describe("classifyShmSize", () => {
+  it("fails on Docker's 64MB default (the 2026-06-06 outage cause)", () => {
+    const r = classifyShmSize(67108864); // 64 MiB
+    expect(r.status).toBe("fail");
+    expect(r.detail).toMatch(/64MB/);
+    expect(r.detail).toMatch(/No space left on device/);
+    expect(r.fix).toMatch(/shm/i);
+  });
+
+  it("passes on the 2g the fix sets", () => {
+    const r = classifyShmSize(2 * 1024 * 1024 * 1024);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toBe("2g");
+  });
+
+  it("passes at exactly the 1g floor", () => {
+    expect(classifyShmSize(MIN_HINDSIGHT_SHM_BYTES).status).toBe("ok");
+    expect(classifyShmSize(MIN_HINDSIGHT_SHM_BYTES - 1).status).toBe("fail");
+  });
+});
+
+describe("classifyExtractionLogs", () => {
+  it("fails on shm exhaustion in logs (write path down)", () => {
+    const logs = [
+      "2026-06-06 03:50:00 INFO worker starting",
+      'could not resize shared memory segment "/PostgreSQL.1644583554" to 533794816 bytes: No space left on device',
+    ].join("\n");
+    const r = classifyExtractionLogs(logs);
+    expect(r.status).toBe("fail");
+    expect(r.detail).toMatch(/shared-memory exhaustion/);
+  });
+
+  it("fails on the LLM-provider error with 0 successful extractions (quota/auth)", () => {
+    const logs = [
+      "ERROR - hindsight_api.engine.providers.claude_code_llm - Claude Code error after 4 attempts: Claude Code returned an error result: success",
+      "WARNING - hindsight_api.engine.retain.fact_extraction - Content extraction failed (skipping)",
+      "Extract facts: 0 facts, 0 chunks from 1 contents in 17.401s",
+      "Extract facts: 0 facts, 0 chunks from 1 contents in 18.100s",
+    ].join("\n");
+    const r = classifyExtractionLogs(logs);
+    expect(r.status).toBe("fail");
+    expect(r.detail).toMatch(/extract 0 facts|failing/);
+    expect(r.fix).toMatch(/quota|account|auth-broker/i);
+  });
+
+  it("warns on sustained 0-fact extractions with no clear error", () => {
+    const logs = Array.from({ length: 4 }, () => "Extract facts: 0 facts, 0 chunks from 1 contents in 9s").join("\n");
+    expect(classifyExtractionLogs(logs).status).toBe("warn");
+  });
+
+  it("is OK when extractions are succeeding (post-fix)", () => {
+    const logs = [
+      "Extract facts: 5 facts, 1 chunks from 1 contents in 18.503s",
+      "Extract facts: 6 facts, 1 chunks from 1 contents in 20.031s",
+      // a single transient error amid successes must NOT flip it to fail
+      "Claude Code returned an error result: success",
+    ].join("\n");
+    const r = classifyExtractionLogs(logs);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toMatch(/healthy/);
+  });
+
+  it("is OK (not failing) when there's simply no recent extraction activity", () => {
+    expect(classifyExtractionLogs("worker idle\nno jobs").status).toBe("ok");
+  });
+});
+
+describe("checkHindsightContainerHealth (docker wrapper)", () => {
+  it("silently skips when the container isn't a local docker container", () => {
+    const exec = () => { throw new Error("No such container"); };
+    expect(checkHindsightContainerHealth({ exec })).toEqual([]);
+  });
+
+  it("classifies shm + logs when docker is available", () => {
+    const exec = (_cmd: string, args: string[]) => {
+      if (args.includes("inspect")) return "2147483648\n";
+      if (args.includes("logs")) return "Extract facts: 4 facts, 1 chunks from 1 contents in 12s";
+      return "";
+    };
+    const results = checkHindsightContainerHealth({ exec });
+    expect(results.map((r) => r.name)).toEqual(["hindsight shm-size", "hindsight extraction"]);
+    expect(results.every((r) => r.status === "ok")).toBe(true);
+  });
+
+  it("surfaces a broken backend (small shm + failing extraction) that MCP reachability would miss", () => {
+    const exec = (_cmd: string, args: string[]) => {
+      if (args.includes("inspect")) return "67108864\n"; // 64MB
+      if (args.includes("logs")) return "Claude Code returned an error result: success\nExtract facts: 0 facts, 0 chunks from 1 contents in 17s";
+      return "";
+    };
+    const results = checkHindsightContainerHealth({ exec });
+    expect(results.find((r) => r.name === "hindsight shm-size")?.status).toBe("fail");
+    expect(results.find((r) => r.name === "hindsight extraction")?.status).toBe("fail");
+  });
+});


### PR DESCRIPTION
## Summary
Adds `switchroom doctor` checks for the two **silent** hindsight failure modes that an MCP-reachability probe can't see — both of which took down fleet memory for an entire session on 2026-06-06 before anyone noticed.

## Why
The existing check confirms hindsight is reachable + speaking MCP. But the container can be up and serving MCP while every write silently fails:
1. **shm exhaustion** — PostgreSQL needs ~533MB+ shared memory; Docker's 64MB default → `No space left on device` on every write.
2. **OAuth quota 429** — fact-extraction `claude` calls hit the weekly limit → retains accepted but 0 facts extracted → nothing recallable.

Neither shows over the MCP port; both show in the container's shm config + recent logs.

## Changes
- `src/cli/doctor-memory.ts`: pure classifiers `classifyShmSize` (fail < 1g) and `classifyExtractionLogs` (shm exhaustion / LLM-provider error with 0 successes / sustained 0-fact runs), plus a best-effort docker wrapper that **silently skips** when hindsight isn't a local container (remote URL / no docker / inside an agent container).
- Wired into `checkHindsight` under the existing "Memory (Hindsight)" doctor section.

## Test plan
- [x] `vitest run tests/cli.doctor.memory-health.test.ts` — 11 pass, classifiers tested against this session's **real** log + shm samples (64MB shm, the `claude_code_llm` error + `Extract facts: 0 facts`, healthy `5 facts`)
- [x] `tsc --noEmit` clean

## Risk
Low — read-only diagnostics, best-effort, no-ops on remote/dockerless setups. Serves "always available" (vision #4): memory outages get caught by `doctor` instead of by users noticing their agents went amnesiac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)