### PR TITLE
chore: release v0.14.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.14.75 — Hindsight memory: durable shm fix + hindsight-native file gate
+
+Foundation for converging agent memory onto Hindsight as the single
+backend (retiring the parallel curated `MEMORY.md`).
+
+### Durable shm fix (#2190)
+
+The `switchroom-hindsight` container launched with no `--shm-size`, so it
+got Docker's 64MB default `/dev/shm`. Its embedded PostgreSQL needs far
+more (~533MB+ for shared query/sort segments), so every such allocation
+failed with `could not resize shared memory segment ... No space left on
+device` — taking down **all** memory writes fleet-wide. Adds
+`HINDSIGHT_DEFAULT_SHM_SIZE=2g` to both the `docker run` and compose launch
+paths so a future recreate can't regress to the broken default.
+
+### `memory.file` gate (#2191)
+
+Adds a per-agent `memory.file` boolean (default `true` = no change). When
+`false`, the scaffold stops seeding the curated `workspace/MEMORY.md` on
+**both** the scaffold and reconcile paths — so once an agent's memory is
+migrated into Hindsight and the file deleted, the delete sticks across
+`agent restart` / `apply` instead of being re-seeded as an empty template.
+This is the mechanism for the hindsight-native migration; the per-turn
+loader already tolerates an absent file.
+
 ## v0.14.74 — Two-file persona (switchroom baseline + operator override); dead-carrier cleanup (#2188)
 
 **Persona two-file.** Adds `SOUL.default.md`, a small switchroom-owned

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.74",
+  "version": "0.14.75",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v0.14.75 — Hindsight memory: durable shm fix + hindsight-native file gate

Foundation for converging agent memory onto Hindsight (retiring the parallel curated `MEMORY.md`).

- **#2190** durable shm fix — `--shm-size=2g` on both hindsight launch paths so a recreate can't regress to Docker's 64MB default (which silently took down all memory writes fleet-wide).
- **#2191** `memory.file` gate — per-agent boolean (default true); when false, the scaffold stops seeding `workspace/MEMORY.md` on both scaffold AND reconcile paths, so a migration-time delete sticks.

Both already merged + reviewed. Release-only diff (version + CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)