### PR TITLE
feat(memory): accept memory.file at the defaults tier (fleet-default hindsight-native)

### DIFF
--- a/src/config/merge.test.ts
+++ b/src/config/merge.test.ts
@@ -49,6 +49,21 @@ describe("mergeAgentConfig — release cascade", () => {
   });
 });
 
+describe("mergeAgentConfig — memory.file cascade (fleet-default hindsight-native)", () => {
+  it("an agent inherits defaults.memory.file:false when it sets no memory.file", () => {
+    const defaults = { memory: { file: false } } as AgentDefaults;
+    const result = mergeAgentConfig(defaults, baseAgent());
+    expect(result.memory?.file).toBe(false);
+  });
+
+  it("a per-agent memory.file:true opts back in over the fleet default", () => {
+    const defaults = { memory: { file: false } } as AgentDefaults;
+    const agent = baseAgent({ memory: { collection: "x", file: true } } as Partial<AgentConfig>);
+    const result = mergeAgentConfig(defaults, agent);
+    expect(result.memory?.file).toBe(true);
+  });
+});
+
 describe("mergeAgentConfig — allowed_tools / disallowed_tools cascade", () => {
   it("cascades defaults.allowed_tools when the agent sets none (the silent-no-op bug)", () => {
     const defaults = {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1471,6 +1471,10 @@ const profileFields = {
     .object({
       collection: z.string().optional(),
       auto_recall: z.boolean().optional(),
+      // Mirror of AgentMemorySchema.file — accepted at the defaults/profile tier
+      // too, so `defaults.memory.file: false` makes the whole fleet (and future
+      // agents) hindsight-native by default, with per-agent `file: true` opt-in.
+      file: z.boolean().optional(),
       isolation: z.enum(["default", "strict"]).optional(),
       recall: z
         .object({


### PR DESCRIPTION
## Summary
Adds `file` to the **defaults/profile** memory schema (it was added to the per-agent schema in #2191 but not the parallel defaults one). This lets a single `defaults.memory.file: false` make the whole fleet — and future agents — hindsight-native by default, with per-agent `memory.file: true` as the opt-in.

## Why
After the hindsight-native migration (#2191 + the per-agent rollout), the only file-based memory left is the **empty-template MEMORY.md on the 5 stub agents** + whatever a *new* agent would seed. A fleet default cleanly retires both. The defaults memory schema already has `collection` optional, so `defaults.memory.file: false` needs no collection — just the `file` field.

## Changes
- `file: z.boolean().optional()` on the defaults/profile memory schema (schema.ts ~1471).

## Test plan
- [x] `vitest run src/config/merge.test.ts` — 15 pass, incl. 2 new (agent inherits `defaults.memory.file:false`; per-agent `file:true` opts back in)
- [x] `tsc --noEmit` clean

## Risk
Minimal — additive optional field; no behavior change until an operator sets `defaults.memory.file`. Completes the hindsight-native architecture (single source of truth, file opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)