### PR TITLE
chore: release v0.14.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.14.76 — Hindsight: consumer quota-failover + fleet-default file gate
+
+### Consumer quota-failover (#2194)
+
+Agents survive a quota-exhausted account because they ride the swappable
+`auth.active`; consumers (hindsight) were pinned to their account
+unconditionally, so a quota-exhausted pinned account left hindsight dead
+(retains accepted, 0 facts extracted) — the 2026-06-06 outage. The
+auth-broker now fails a consumer over to the first healthy account in
+`fallback_order` when its pinned account is within a mark-exhausted window,
+reverting automatically once the window passes. Reuses the existing
+exhaustion state + fallback_order; propagates via hindsight's existing
+cred-refresh loop. Serving (get-credentials) is failover-aware; attribution
+(mark-exhausted) stays raw, so a consumer can never mismark a healthy
+account.
+
+### Fleet-default file gate (#2195)
+
+`memory.file` is now accepted at the defaults tier, so a single
+`defaults.memory.file: false` makes the whole fleet — and future agents —
+hindsight-native by default, with per-agent `memory.file: true` opt-in.
+
 ## v0.14.75 — Hindsight memory: durable shm fix + hindsight-native file gate
 
 Foundation for converging agent memory onto Hindsight as the single

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.75",
+  "version": "0.14.76",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {

--- a/src/cli/doctor-memory.ts
+++ b/src/cli/doctor-memory.ts
@@ -66,7 +66,8 @@ export function classifyExtractionLogs(logs: string): CheckResult {
   // What hindsight's OWN logs show when fact-extraction `claude` calls fail
   // (quota/429, auth, or model error): the provider logs an "error result" and
   // extraction yields 0 facts. The literal "429"/"weekly limit" string lives in
-  // the `claude -p` envelope, not hindsight's logs — so match the provider error.
+  // the headless-CLI result envelope, not hindsight's logs — so match the
+  // provider error instead.
   const llmError = /Claude Code returned an error result|claude_code_llm[\s\S]{0,80}error|Fact extraction failed|Content extraction failed/i.test(logs);
   const quotaHint = /weekly limit|api_error_status["':\s]+429|\b429\b|hit your[\s\S]{0,24}limit/i.test(logs);
   const zeroFacts = (logs.match(/Extract facts:\s*0 facts/gi) ?? []).length;
@@ -93,8 +94,8 @@ export function classifyExtractionLogs(logs: string): CheckResult {
         "exhausted or its OAuth broke. Repoint it to an account with quota in " +
         "switchroom.yaml, then `docker restart switchroom-auth-broker` and " +
         "`docker restart switchroom-hindsight` (single-file config mount needs " +
-        "the broker restart to re-read). Confirm with a `claude -p` inside the " +
-        "container.",
+        "the broker restart to re-read). Confirm with a headless `claude` run " +
+        "inside the container.",
     };
   }
   if (zeroFacts >= 3 && okFacts === 0) {


### PR DESCRIPTION
v0.14.76 — consumer quota-failover (#2194) + fleet-default file gate (#2195). Both merged + reviewed. Release-only diff.