### PR TITLE
fix(vault): correct secret-guard block message + doctor check for IDs-stored-as-secrets

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -286,7 +286,18 @@ name from that list.
 Only call the \`vault_request_access\` MCP tool — which pings the
 operator for a Telegram approval — for a key you've **confirmed via
 \`vault list\` you don't already have.** Requesting access to a guessed
-or already-held key wastes the operator's tap and fails.`;
+or already-held key wastes the operator's tap and fails.
+
+**Never put a secret's value — or a \`vault:<key>\` placeholder — in a
+tool call.** Tool arguments are sent to the underlying API verbatim;
+nothing resolves a \`vault:\` reference for them. A real secret never
+needs to appear in a tool call — the launcher injects it into the
+tool's environment for you. A value you genuinely must pass literally
+(an account or customer ID) is a public identifier, not a secret, and
+belongs in plain config, not the vault. If a tool call is **blocked for
+containing a vaulted secret**, report that exact block message to the
+operator and stop — don't theorise about auth or tokens; it just means
+a stored value reached a tool argument.`;
 
 /**
  * Canonical rendering of the fleet invariants file written to

--- a/src/cli/vault-doctor.ts
+++ b/src/cli/vault-doctor.ts
@@ -19,7 +19,7 @@
 import type { Command } from "commander";
 import chalk from "chalk";
 import { existsSync } from "node:fs";
-import { analyseVaultHealth, type Diagnostic, type DiagnosticLevel } from "../vault/doctor.js";
+import { analyseVaultHealth, looksLikeIdentifierValue, type Diagnostic, type DiagnosticLevel } from "../vault/doctor.js";
 import { openVault, VaultError } from "../vault/vault.js";
 import { loadConfig, resolvePath } from "../config/loader.js";
 import { statusViaBroker, resolveBrokerSocketPath } from "../vault/broker/client.js";
@@ -91,7 +91,10 @@ export function registerVaultDoctorCommand(vault: Command, program: Command): vo
       // ── Open vault (if passphrase available) ───────────────────────
       const passphrase = process.env.SWITCHROOM_VAULT_PASSPHRASE;
       let vaultKeys:
-        | Record<string, { scope?: { allow?: string[]; deny?: string[] } }>
+        | Record<
+            string,
+            { scope?: { allow?: string[]; deny?: string[] }; looksLikeIdentifier?: boolean }
+          >
         | undefined = undefined;
 
       if (passphrase && existsSync(vaultPath)) {
@@ -104,6 +107,12 @@ export function registerVaultDoctorCommand(vault: Command, program: Command): vo
                 "scope" in entry && entry.scope
                   ? (entry.scope as { allow?: string[]; deny?: string[] })
                   : undefined,
+              // Shape-check the value here so the raw secret never enters the
+              // pure analysis layer — only the boolean classification does.
+              looksLikeIdentifier:
+                entry.kind === "string"
+                  ? looksLikeIdentifierValue(entry.value)
+                  : false,
             };
           }
         } catch (err) {

--- a/src/vault/doctor.test.ts
+++ b/src/vault/doctor.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the vault-doctor pure layer — specifically the
+ * identifier-stored-as-secret check (a public ID miscategorised as a vault
+ * secret, which the secret-guard PreToolUse hook would then block from ever
+ * appearing in a tool call). See src/vault/doctor.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import { analyseVaultHealth, looksLikeIdentifierValue } from "./doctor.js";
+
+describe("looksLikeIdentifierValue", () => {
+  it("flags identifier-shaped values (digits, optionally grouped)", () => {
+    expect(looksLikeIdentifierValue("1356752511")).toBe(true); // Google Ads customer-id
+    expect(looksLikeIdentifierValue("8996755792")).toBe(true); // login-customer-id
+    expect(looksLikeIdentifierValue("135-675-2511")).toBe(true); // dashed grouping
+    expect(looksLikeIdentifierValue("899 675 5792")).toBe(true); // spaced grouping
+    expect(looksLikeIdentifierValue(" 1356752511 ")).toBe(true); // surrounding whitespace
+  });
+
+  it("does NOT flag real secrets (letters / symbols / high entropy)", () => {
+    expect(looksLikeIdentifierValue("ghp_secret_token_12345")).toBe(false);
+    expect(looksLikeIdentifierValue("sk-ant-abc123-xyz")).toBe(false);
+    expect(looksLikeIdentifierValue("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")).toBe(false);
+    expect(looksLikeIdentifierValue("1//04i4ckx6E6BVFCgYIARAAGAQSNwF")).toBe(false); // slash + letters
+  });
+
+  it("does NOT flag values shorter than 8 digits or longer than 24 chars", () => {
+    expect(looksLikeIdentifierValue("1234567")).toBe(false); // 7 digits — under the guard length
+    expect(looksLikeIdentifierValue("abc")).toBe(false);
+    expect(looksLikeIdentifierValue("1".repeat(25))).toBe(false); // long numeric — likely a real secret
+    expect(looksLikeIdentifierValue("")).toBe(false);
+  });
+});
+
+describe("analyseVaultHealth — identifier-stored-as-secret", () => {
+  const base = {
+    agentSchedules: {},
+    brokerConfigured: false,
+    brokerRunning: undefined,
+  };
+
+  it("warns when a vault key holds an identifier-like value", () => {
+    const diags = analyseVaultHealth({
+      ...base,
+      vaultKeys: {
+        "google-ads/customer-id": { looksLikeIdentifier: true },
+        "google-ads/refresh-token": { looksLikeIdentifier: false },
+      },
+    });
+    const hit = diags.find((d) => d.check === "identifier-stored-as-secret");
+    expect(hit).toBeDefined();
+    expect(hit?.level).toBe("warn");
+    expect(hit?.message).toContain("google-ads/customer-id");
+    expect(hit?.message).not.toContain("google-ads/refresh-token");
+  });
+
+  it("does not emit the check when no key is identifier-shaped", () => {
+    const diags = analyseVaultHealth({
+      ...base,
+      vaultKeys: {
+        "google-ads/refresh-token": { looksLikeIdentifier: false },
+        "marko/postiz-api-key": {},
+      },
+    });
+    expect(diags.some((d) => d.check === "identifier-stored-as-secret")).toBe(false);
+  });
+});

--- a/src/vault/doctor.ts
+++ b/src/vault/doctor.ts
@@ -30,6 +30,28 @@ const SENSITIVE_KEY_RE =
   /oauth(?![a-zA-Z])|token(?![a-zA-Z])|secret(?![a-zA-Z])|api[-_]?key(?![a-zA-Z])|password(?![a-zA-Z])/i;
 
 /**
+ * True when a vault VALUE looks like a public identifier — digits, optionally
+ * grouped with spaces or dashes (account/customer IDs, phone numbers, numeric
+ * handles) — rather than a high-entropy secret.
+ *
+ * These are the values an agent often must pass *literally* in a tool call,
+ * at which point the secret-guard PreToolUse hook blocks them: that hook
+ * matches stored vault values verbatim and cannot tell a public ID from a
+ * token. Such a value almost never belongs in the vault — it belongs in
+ * plain config. We bound the length so a long all-numeric secret (rare) does
+ * not trip the heuristic, and require >= 8 digits so we only flag values the
+ * hook would actually guard (its MIN_VALUE_LENGTH_TO_GUARD is 8).
+ */
+export function looksLikeIdentifierValue(value: string): boolean {
+  const v = value.trim();
+  if (v.length < 8 || v.length > 24) return false;
+  // Only digits and group separators (space / dash), digit-bounded.
+  if (!/^[0-9][0-9 -]*[0-9]$/.test(v)) return false;
+  const digitCount = v.replace(/[^0-9]/g, "").length;
+  return digitCount >= 8;
+}
+
+/**
  * Input shape for analyseVaultHealth.
  *
  * All fields are optional so callers can provide only what they have
@@ -45,6 +67,13 @@ export interface VaultHealthInput {
     {
       /** Per-entry scope, if set. */
       scope?: { allow?: string[]; deny?: string[] };
+      /**
+       * True when the entry's VALUE looks like a public identifier (digits,
+       * optionally dash/space-grouped) rather than a secret. Computed by the
+       * CLI via looksLikeIdentifierValue() so raw values never enter this
+       * pure layer. Drives the identifier-stored-as-secret warning.
+       */
+      looksLikeIdentifier?: boolean;
     }
   >;
 
@@ -139,6 +168,28 @@ export function analyseVaultHealth(input: VaultHealthInput): Diagnostic[] {
         message:
           `${unscopedSensitive.length} sensitive-looking key(s) have no per-key ACL:\n${keyList}`,
         fix: "Consider `switchroom vault set <key> --allow <agent>` to restrict access",
+      });
+    }
+
+    // ── Public identifiers stored as secrets ─────────────────────────
+    // A value that looks like an account/customer ID, not a token. If an
+    // agent must pass it in a tool call, the secret-guard PreToolUse hook
+    // blocks it (it matches stored values verbatim and can't tell a public
+    // ID from a secret) — so such values belong in plain config, not here.
+    const identifierKeys: string[] = [];
+    for (const [keyName, entry] of Object.entries(input.vaultKeys)) {
+      if (entry.looksLikeIdentifier) identifierKeys.push(keyName);
+    }
+
+    if (identifierKeys.length > 0) {
+      const keyList = identifierKeys.map((k) => `  ${k}`).join("\n");
+      diagnostics.push({
+        level: "warn",
+        check: "identifier-stored-as-secret",
+        message:
+          `${identifierKeys.length} vault key(s) hold an identifier-like value (digits only):\n${keyList}\n` +
+          `If an agent must pass one of these in a tool call, the secret-guard hook will block it — it cannot tell a public ID from a secret.`,
+        fix: "If the value is a public identifier (account/customer ID), remove it from the vault and pass it as plain config (e.g. hardcode it in the MCP launcher). If it is genuinely secret, ignore this.",
       });
     }
 

--- a/telegram-plugin/hooks/secret-guard-pretool.mjs
+++ b/telegram-plugin/hooks/secret-guard-pretool.mjs
@@ -194,10 +194,19 @@ async function main() {
   }
   const hit = scanToolInput(toolInput, vaultValues)
   if (hit) {
+    // The reason is read by the model. It must be CORRECT and actionable:
+    // earlier versions said "reference it as vault:<key> instead", which
+    // suggested a `vault:` resolver that does not exist for tool arguments
+    // — sending agents (and operators) chasing a phantom mechanism. State
+    // the two real resolutions instead, and do NOT imply a resolver.
     process.stdout.write(
       JSON.stringify({
         decision: 'block',
-        reason: `tool_input contains a vaulted secret — reference it as vault:${hit.key} instead`,
+        reason:
+          `Blocked: this tool input contains the value of vault secret '${hit.key}'. ` +
+          `Secrets must never appear in a tool call. ` +
+          `If '${hit.key}' is a real secret, do not pass it as an argument — the launcher injects it into the tool's environment, so you never type it. ` +
+          `If '${hit.key}' is actually a public identifier (e.g. an account or customer ID that must appear in the call), it should not be in the vault — ask the operator to move it to plain config.`,
       }),
     )
     process.exit(0)

--- a/telegram-plugin/tests/secret-guard-pretool.test.ts
+++ b/telegram-plugin/tests/secret-guard-pretool.test.ts
@@ -132,7 +132,13 @@ describe('secret-guard-pretool.mjs (broker-direct)', () => {
     })
     expect(r.status).toBe(0)
     expect(r.stdout).toContain('"decision":"block"')
-    expect(r.stdout).toContain('vault:gh-token')
+    // The reason must name the offending key and explain the real fix.
+    expect(r.stdout).toContain('gh-token')
+    expect(r.stdout).toContain('Secrets must never appear in a tool call')
+    // It must NOT resurrect the old, misleading "reference it as vault:<key>"
+    // suggestion — there is no vault: resolver for tool arguments, and that
+    // advice sent agents down a dead end (see the hook's block-reason note).
+    expect(r.stdout).not.toContain('reference it as vault:')
   })
 
   it('allows when tool_input contains no vaulted value', async () => {


### PR DESCRIPTION
## Summary

Closes the rabbit hole behind the Google Ads / marko incident: a **public identifier stored as a vault secret** that the secret-guard PreToolUse hook then blocked from ever appearing in a tool call — while telling the agent to *"reference it as `vault:<key>` instead"*, a mechanism that **does not exist** for tool arguments. The agent could neither pass the literal (hook blocked it) nor a `vault:` ref (it reached Google verbatim → `INVALID_CUSTOMER_ID`), and confabulated auth/token causes for hours.

Three changes, all addressing *how the system responds* so it self-corrects instead of misleading:

1. **Hook message (the highest-leverage fix).** `secret-guard-pretool.mjs` no longer suggests a phantom `vault:` resolver. The block reason now states the two real resolutions: a genuine secret should never be a tool argument (the launcher env-injects it); a value you must pass literally (an account/customer ID) is a *public identifier* and shouldn't be vaulted at all.

2. **`vault doctor` check (proactive).** New `identifier-stored-as-secret` warn flags vault values that look like public identifiers (≥8 digits, optionally dash/space-grouped) — the exact footgun. The shape is classified in the CLI layer so **raw secret values never enter the pure analysis layer**.

3. **Fleet guidance (`VAULT_GUIDANCE`).** Tells every agent: never pass a secret value or a `vault:` placeholder as a tool argument; if a call is blocked for containing a vaulted secret, report the verbatim message and stop — don't theorise about auth/tokens.

## Why

`vault:` *does* resolve for config values (e.g. `bot_token`), but **not** for MCP tool arguments — so the hook's old advice was a dead end. The miscategorisation (public ID in the vault) is the root cause; #1 + #2 make it cheap to detect and impossible to chase the wrong way. See the marko Google Ads incident.

## Test plan

- [x] `src/vault/doctor.test.ts` (new, 5 tests) — heuristic true/false cases + the check fires only on identifier-shaped keys
- [x] `secret-guard-pretool.test.ts` — asserts the new message + **absence** of the old `reference it as vault:` phrase; still blocks real secrets, still fails open
- [x] scaffold tests (198) green — fleet-guidance rendering unaffected
- [x] `tsc --noEmit` clean · `check-plugin-references.mjs` clean

## Risk

Low. Hook behaviour is unchanged (still blocks the same inputs) — only the human-readable `reason` string changed. The doctor check is purely additive (new warn, defaults off when no value is identifier-shaped). Guidance is prompt-only.

## JTBD

Serves *"you hold the leash"* / predictability: the secret guard still protects tokens, but stops sending agents (and the operator) down a phantom path when it fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)