### PR TITLE
feat(scaffold): enable tool-search to defer the ~31k-token MCP schema surface

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1413,6 +1413,31 @@ function buildHumanizerEnvVars(
 }
 
 /**
+ * Claude Code tool-search env. Defers (lazy-loads) MCP tool schemas so the
+ * heavy per-agent integration servers (webkite/perplexity/marketing — ~31k
+ * tokens of schema) stop occupying the context window every turn; the model
+ * fetches a schema only when it actually calls that tool. The load-bearing
+ * framework servers (switchroom-telegram, hindsight, agent-config) carry
+ * `alwaysLoad: true` in .mcp.json so reply/get_recent_messages/recall never
+ * defer (no per-turn ToolSearch round-trip).
+ *
+ * Default value `auto` (self-gating: claude only defers once the tool surface
+ * exceeds ~10% of the window, which every agent's does — a small-surface agent
+ * is left untouched). Override per fleet via SWITCHROOM_TOOL_SEARCH_MODE
+ * (e.g. `true` to force always-defer, `auto:N` for an N% threshold). Kill
+ * switch SWITCHROOM_DISABLE_TOOL_SEARCH=1 omits the var entirely → claude
+ * loads all tools (today's behaviour). A per-agent `env: {ENABLE_TOOL_SEARCH}`
+ * in switchroom.yaml still wins (spread after this in the env builder).
+ *
+ * Consumed by claude (inner start.sh pass), not the gateway, so the
+ * env-before-gateway-fork landmine does not constrain placement.
+ */
+export function buildToolSearchEnvVars(): Record<string, string> {
+  if (process.env.SWITCHROOM_DISABLE_TOOL_SEARCH === "1") return {};
+  return { ENABLE_TOOL_SEARCH: process.env.SWITCHROOM_TOOL_SEARCH_MODE ?? "auto" };
+}
+
+/**
  * Top-level settings.json keys that switchroom's scaffold/reconcile
  * pipeline owns and rebuilds on every run. When the settings_raw
  * escape hatch injects additional top-level keys (e.g. `effort`,
@@ -2107,6 +2132,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
       : undefined,
     userEnvQuoted: (() => {
       const combined = {
+        ...buildToolSearchEnvVars(),
         ...channelsToEnv(agentConfig),
         ...(agentConfig.env ?? {}),
         ...buildRepoEnvVars(name, agentDir, agentConfig),
@@ -2970,6 +2996,11 @@ export function scaffoldAgent(
           SWITCHROOM_CONFIG: resolvedConfigPath,
           SWITCHROOM_CLI_PATH: switchroomCliPath,
         },
+        // LOAD-BEARING under tool search: reply / stream_reply /
+        // get_recent_messages / react must never defer, or every turn pays a
+        // ToolSearch round-trip before it can answer (the orphaned-reply
+        // failure class). Pin them loaded.
+        alwaysLoad: true,
       },
       // Read-only agent-config broker. Exposes 4 tools (config_get,
       // cron_list, skill_list, audit_tail) that re-exec the switchroom
@@ -2982,6 +3013,8 @@ export function scaffoldAgent(
           SWITCHROOM_AGENT_NAME: name,
           SWITCHROOM_CONFIG: resolvedConfigPath,
         },
+        // Framework read-only server (4 tools) — keep loaded under tool search.
+        alwaysLoad: true,
       },
     };
 
@@ -4611,6 +4644,7 @@ export function reconcileAgent(
         : undefined,
       userEnvQuoted: (() => {
         const combined = {
+          ...buildToolSearchEnvVars(),
           ...channelsToEnv(agentConfig),
           ...(agentConfig.env ?? {}),
           ...buildRepoEnvVars(name, agentDir, agentConfig),
@@ -5071,6 +5105,11 @@ export function reconcileAgent(
           SWITCHROOM_CONFIG: resolvedConfigPath,
           SWITCHROOM_CLI_PATH: switchroomCliPath,
         },
+        // LOAD-BEARING under tool search: reply / stream_reply /
+        // get_recent_messages / react must never defer, or every turn pays a
+        // ToolSearch round-trip before it can answer (the orphaned-reply
+        // failure class). Pin them loaded.
+        alwaysLoad: true,
       },
       // Read-only agent-config broker. Exposes 4 tools (config_get,
       // cron_list, skill_list, audit_tail) that re-exec the switchroom
@@ -5083,6 +5122,8 @@ export function reconcileAgent(
           SWITCHROOM_AGENT_NAME: name,
           SWITCHROOM_CONFIG: resolvedConfigPath,
         },
+        // Framework read-only server (4 tools) — keep loaded under tool search.
+        alwaysLoad: true,
       },
     };
 

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -7,6 +7,18 @@ export interface McpServerConfig {
   env?: Record<string, string>;
   url?: string;
   headers?: Record<string, string>;
+  /**
+   * Claude Code tool-search escape hatch. When `ENABLE_TOOL_SEARCH` is on,
+   * the CLI defers (lazy-loads) every MCP server's tool schemas by default;
+   * `alwaysLoad: true` pins THIS server's tools to stay loaded so the model
+   * can call them without a ToolSearch round-trip. Set on the load-bearing
+   * framework servers (switchroom-telegram reply/get_recent_messages,
+   * hindsight, agent-config); the heavy per-agent integration servers
+   * (webkite/perplexity/marketing) deliberately omit it so they defer.
+   * Claude Code reads `config.alwaysLoad` (CLI ≥2.1.x); harmless/ignored when
+   * tool search is off or on older CLIs.
+   */
+  alwaysLoad?: boolean;
 }
 
 /**

--- a/src/memory/scaffold-integration.ts
+++ b/src/memory/scaffold-integration.ts
@@ -33,7 +33,10 @@ export function getHindsightSettingsEntry(
   const collection = getCollectionForAgent(agentName, config);
   const mcpConfig = generateHindsightMcpConfig(collection, memoryConfig);
 
-  return { key: "hindsight", value: mcpConfig };
+  // Keep hindsight's tools loaded under tool search — recall/reflect/retain
+  // are framework memory tools the agent is told to use proactively; deferring
+  // them would add a ToolSearch round-trip to every memory write.
+  return { key: "hindsight", value: { ...mcpConfig, alwaysLoad: true } };
 }
 
 /**

--- a/tests/scaffold.tool-search.test.ts
+++ b/tests/scaffold.tool-search.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tool-search wiring (context-token optimization, 2026-06-06).
+ *
+ * Enabling Claude Code's ENABLE_TOOL_SEARCH defers (lazy-loads) MCP tool
+ * schemas so the ~31k-token integration-server surface stops occupying the
+ * window every turn. Two halves must stay wired:
+ *   1. the ENABLE_TOOL_SEARCH env var (default `auto`, kill-switchable);
+ *   2. `alwaysLoad: true` pinned on the LOAD-BEARING framework servers
+ *      (switchroom-telegram, hindsight, agent-config) so reply /
+ *      get_recent_messages / recall never defer (the orphaned-reply hazard).
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { buildToolSearchEnvVars } from "../src/agents/scaffold.js";
+
+const scaffoldSrc = readFileSync(resolve(__dirname, "..", "src", "agents", "scaffold.ts"), "utf-8");
+
+const SAVED = {
+  disable: process.env.SWITCHROOM_DISABLE_TOOL_SEARCH,
+  mode: process.env.SWITCHROOM_TOOL_SEARCH_MODE,
+};
+afterEach(() => {
+  if (SAVED.disable === undefined) delete process.env.SWITCHROOM_DISABLE_TOOL_SEARCH;
+  else process.env.SWITCHROOM_DISABLE_TOOL_SEARCH = SAVED.disable;
+  if (SAVED.mode === undefined) delete process.env.SWITCHROOM_TOOL_SEARCH_MODE;
+  else process.env.SWITCHROOM_TOOL_SEARCH_MODE = SAVED.mode;
+});
+
+describe("buildToolSearchEnvVars — default, override, kill switch", () => {
+  it("defaults to ENABLE_TOOL_SEARCH=auto (self-gating, transparent on small tool sets)", () => {
+    delete process.env.SWITCHROOM_DISABLE_TOOL_SEARCH;
+    delete process.env.SWITCHROOM_TOOL_SEARCH_MODE;
+    expect(buildToolSearchEnvVars()).toEqual({ ENABLE_TOOL_SEARCH: "auto" });
+  });
+
+  it("SWITCHROOM_TOOL_SEARCH_MODE overrides the value (true / auto:N)", () => {
+    delete process.env.SWITCHROOM_DISABLE_TOOL_SEARCH;
+    process.env.SWITCHROOM_TOOL_SEARCH_MODE = "true";
+    expect(buildToolSearchEnvVars()).toEqual({ ENABLE_TOOL_SEARCH: "true" });
+    process.env.SWITCHROOM_TOOL_SEARCH_MODE = "auto:20";
+    expect(buildToolSearchEnvVars()).toEqual({ ENABLE_TOOL_SEARCH: "auto:20" });
+  });
+
+  it("KILL SWITCH: SWITCHROOM_DISABLE_TOOL_SEARCH=1 omits the var entirely (legacy: all tools loaded)", () => {
+    process.env.SWITCHROOM_DISABLE_TOOL_SEARCH = "1";
+    expect(buildToolSearchEnvVars()).toEqual({});
+  });
+});
+
+describe("tool-search wiring (source guards)", () => {
+  it("the env helper is spread into BOTH env-builder sites BEFORE agentConfig.env (so per-agent config wins)", () => {
+    // Two userEnvQuoted sites (buildScaffold + reconcile) must stay in lockstep.
+    const occurrences = scaffoldSrc.match(/\.\.\.buildToolSearchEnvVars\(\),/g) ?? [];
+    expect(occurrences.length).toBe(2);
+    // Both must precede the agentConfig.env spread.
+    for (const block of scaffoldSrc.split("...buildToolSearchEnvVars(),").slice(1)) {
+      const head = block.slice(0, 200);
+      expect(head).toMatch(/\.\.\.\(agentConfig\.env \?\? \{\}\)/);
+    }
+  });
+
+  it("the LOAD-BEARING framework servers carry alwaysLoad:true", () => {
+    // Each server-entry literal closes its env block first, so look in a
+    // window large enough to span past it to the entry's own alwaysLoad.
+    const telegram = scaffoldSrc.split('"switchroom-telegram": {')[1]?.slice(0, 600) ?? "";
+    expect(telegram).toMatch(/alwaysLoad: true/);
+    const agentConfig = scaffoldSrc.split('"agent-config": {')[1]?.slice(0, 500) ?? "";
+    expect(agentConfig).toMatch(/alwaysLoad: true/);
+    // hindsight pinned in scaffold-integration.ts.
+    const integ = readFileSync(resolve(__dirname, "..", "src", "memory", "scaffold-integration.ts"), "utf-8");
+    expect(integ).toMatch(/key: "hindsight", value: \{ \.\.\.mcpConfig, alwaysLoad: true \}/);
+  });
+
+  it("McpServerConfig carries the optional alwaysLoad field", () => {
+    const typeSrc = readFileSync(resolve(__dirname, "..", "src", "memory", "hindsight.ts"), "utf-8");
+    expect(typeSrc).toMatch(/alwaysLoad\?: boolean/);
+  });
+});


### PR DESCRIPTION
## Summary

The context audit found the per-turn floor is ~63k tok (~32% of a 200k window), and the biggest single slice is the **MCP tool-schema surface (~31k tok across 10–11 servers)** — bigger than all of switchroom's authored prompt text combined, and mostly unused on any given turn.

This enables the unmodified `claude` CLI's **`ENABLE_TOOL_SEARCH`** (confirmed present in the pinned 2.1.159 binary): MCP tool schemas are **deferred** — surfaced by name, full JSON fetched only when the model actually calls the built-in ToolSearch — reclaiming ~25–29k tok of window. It's a flag *on* the native CLI, so it stays inside the Claude-native compliance pillar.

## What

- `buildToolSearchEnvVars()` → `ENABLE_TOOL_SEARCH` default **`auto`** (self-gating: only defers once the tool surface exceeds ~10% of context — every agent's does; small-surface agents untouched). Override `SWITCHROOM_TOOL_SEARCH_MODE`; kill switch `SWITCHROOM_DISABLE_TOOL_SEARCH=1`. Spread into **both** `userEnvQuoted` sites (buildScaffold + reconcile), before `agentConfig.env` so per-agent config wins.
- **`alwaysLoad: true`** pinned on the load-bearing framework servers — **switchroom-telegram** (reply/stream_reply/get_recent_messages/react), **hindsight** (recall/retain), **agent-config**. Without this, `reply` defers and every turn pays a ToolSearch round-trip before it can answer (the orphaned-reply failure class). The heavy integration servers (webkite/perplexity/marketing) deliberately omit it → they defer = the win.
- `McpServerConfig` gains optional `alwaysLoad?: boolean`.

## Why this design

Per the audit's prompt-caching finding, the fixed stance is mostly cache-hot so this is **window-relief** (fewer auto-compactions, more working room) more than per-turn dollars — but the dollar win is real on cold-miss/restart turns. The tool surface was the right lever because it's the largest slice and lazy-loading it changes no prompt text.

## Test plan

- [x] tsc clean; 6 tests (default/override/kill-switch + the alwaysLoad pins + env-order lockstep)
- [ ] **test-harness canary** (the gate): confirm tool-search activates AND `reply` / `mcp__hindsight__recall` / `get_recent_messages` still resolve — always-on, fast-trivial, real-work UAT + a live DM round-trip.

## Risk

MEDIUM, kill-switched. Tool search is a CLI beta; the `alwaysLoad` pins protect the framework tools. Worst case: `SWITCHROOM_DISABLE_TOOL_SEARCH=1` + restart reverts to today's all-tools-loaded behavior. Per-turn ToolSearch round-trips add latency only on integration-heavy turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)