### PR TITLE
fix(hindsight): phantom-caller honesty + defer the MCP tool allowlist (audit found it unsafe)

### DIFF
--- a/src/cli/vault-sweep.ts
+++ b/src/cli/vault-sweep.ts
@@ -256,9 +256,27 @@ export function makeHttpHindsightClient(
       })) as { items: HindsightMemory[]; total: number }
       return { items: res.items ?? [], total: res.total ?? 0 }
     },
-    async deleteMemory(bankId, memoryId) {
-      const sid = await initSession(bankId)
-      await callTool(bankId, sid, 'delete_memory', { bank_id: bankId, memory_id: memoryId })
+    async deleteMemory(_bankId, _memoryId) {
+      // HONEST FAILURE (2026-06-07 security audit). The vault secret-scrub
+      // cannot delete a single matched memory on this hindsight server, and
+      // pretending otherwise is dangerous — it would report leaked secrets as
+      // "scrubbed" while leaving them in the bank. Proven live:
+      //   • there is NO `delete_memory` MCP tool (the original call — phantom);
+      //   • `delete_document(document_id)` IS real but a `list_memories` item's
+      //     `id` is a MEMORY-UNIT id, not a document_id: get_memory(id) → OK,
+      //     get_document(id) → "Document not found", so it deletes nothing;
+      //   • there is no by-id single-memory-unit delete on the MCP or REST
+      //     surface (REST has whole-document delete + collection-clear only).
+      // So we FAIL LOUDLY: the sweep reports matches it could not remove, and
+      // the operator redacts manually (bank UI) or clears the bank. Restoring
+      // an actual scrub needs a document-granularity rework (resolve each match
+      // to its document_id, DELETE the document, accepting clean siblings die)
+      // — tracked separately; out of scope for the context-token work.
+      throw new Error(
+        'hindsight exposes no single-memory delete API (delete_memory is not a ' +
+          'real tool; a memory id is not a document_id) — matched secrets cannot ' +
+          'be auto-scrubbed; redact manually via the bank UI',
+      )
     },
   }
 }
@@ -306,12 +324,23 @@ export async function sweepHindsightBank(
 
   let deleted = 0
   if (!opts.dryRun) {
+    let warnedOnce = false
     for (const m of matched) {
       try {
         await client.deleteMemory(bankId, m.id)
         deleted++
-      } catch {
-        /* best-effort; keep trying the rest */
+      } catch (err) {
+        // Surface WHY a matched secret could not be deleted (once) instead of
+        // swallowing it — a vault scrub that finds leaked secrets but cannot
+        // remove them must say so, or the operator wrongly believes the bank is
+        // clean. `deleted` stays below `matched.length`, and the reason prints.
+        if (!warnedOnce) {
+          warnedOnce = true
+          process.stderr.write(
+            `vault-sweep: ${matched.length} secret(s) matched in bank '${bankId}' but ` +
+              `could NOT be auto-deleted: ${(err as Error).message}\n`,
+          )
+        }
       }
     }
   }

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -696,12 +696,18 @@ export async function addMemoryTag(
       ? { "mcp-session-id": sessionId }
       : {};
 
-    // Step 2: call update_memory with `add_tags` to append (rather than
-    // replace) the tag. Hindsight's update_memory accepts an `add_tags`
-    // list per the MCP tool schema; if the deployment is older and only
-    // accepts `tags` (replace), the tool call returns ok but the tag
-    // may overwrite. Operators on stale deployments should bump the
-    // plugin (#438 Tier 1).
+    // Step 2: call update_memory with `add_tags` to append the tag.
+    //
+    // HONEST-FAILURE note (2026-06-07 audit): the live hindsight server has NO
+    // `update_memory` tool — it returns HTTP 200 with an MCP error envelope
+    // `{result:{isError:true, content:[{text:"Unknown tool: 'update_memory'"}]}}`.
+    // The prior code only checked `toolResponse.ok` (the HTTP status), so it
+    // returned `{ok:true}` and `switchroom memory demote` reported success while
+    // tagging nothing. We now inspect `result.isError` so the call fails
+    // honestly here AND stays forward-compatible: if a future hindsight build
+    // adds `update_memory`/`add_tags` it just works. (There is no single-memory
+    // tag path on the current MCP or REST surface; restoring demote needs a
+    // document-granularity rework — tracked separately.)
     const timeout2 = setTimeout(() => controller.abort(), timeoutMs);
     const toolResponse = await fetchImpl(`${apiUrl}`, {
       method: "POST",
@@ -731,6 +737,21 @@ export async function addMemoryTag(
 
     if (!toolResponse.ok) {
       return { ok: false, reason: `Tool call HTTP ${toolResponse.status}` };
+    }
+
+    // Check the MCP result envelope — a tools/call can return HTTP 200 with
+    // isError:true (e.g. "Unknown tool"). Don't report success on an error.
+    try {
+      const parsed = await parseSseOrJson<{
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      }>(toolResponse);
+      if (parsed.result?.isError === true) {
+        const msg = parsed.result.content?.[0]?.text ?? "tool returned isError";
+        return { ok: false, reason: msg };
+      }
+    } catch {
+      // Body unparseable — treat HTTP-200 as success (legacy behaviour) rather
+      // than fail a working call on a parse hiccup.
     }
 
     return { ok: true };

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -100,24 +100,41 @@ export const HINDSIGHT_DEFAULT_MODEL = "claude-sonnet-4-6";
 export const HINDSIGHT_DEFAULT_MCP_STATELESS = true;
 
 /**
- * NOTE on trimming the hindsight MCP tool surface (29 advertised tools).
+ * DEFER the hindsight MCP tool-surface allowlist (29 advertised tools) — the
+ * 2026-06-07 adversarial audit (3 independent host-caller hunts) found it is
+ * high-blast-radius for ~no net benefit. Recorded so we don't re-attempt it.
  *
  * The server DOES support a global allowlist (`HINDSIGHT_API_MCP_ENABLED_TOOLS`,
- * config.py:1665 — comma-separated, filters both tools/list and invocation),
- * and an agent only uses ~5 (recall/reflect/sync_retain/retain/delete_document).
- * BUT the filter is GLOBAL across banks, and switchroom's own HOST-SIDE code
- * (this file + src/memory/hindsight.ts + src/cli/vault-sweep.ts) calls a broad
- * set on the SAME agent banks — create_bank, create_mental_model,
- * list_mental_models, update_bank, create_directive, list_memories — so a
- * 5-tool allowlist would silently break mental-model setup and the vault-sweep
- * memory scrub. A safe allowlist needs a COMPLETE host-caller audit first
- * (which also surfaced two phantom callers: vault-sweep calls a non-existent
- * `delete_memory`, hindsight.ts calls a non-existent `update_memory`).
+ * config.py:1665 — comma-separated, filters BOTH tools/list and invocation,
+ * GLOBALLY across all banks). But "trim to ~5" is unsafe: the agent and
+ * switchroom's host code legitimately reach a BROAD set on the same banks:
+ *   • agent (model-invoked via MEMORY_GUIDANCE + the fleet CLAUDE.md): recall,
+ *     reflect, sync_retain, retain, delete_document, AND — instructed in EVERY
+ *     agent's CLAUDE.md (profiles/default/CLAUDE.md.hbs:70-72) — create_directive,
+ *     list_directives, delete_directive, refresh_mental_model, update_mental_model;
+ *   • host setup (src/memory/hindsight.ts): create_bank, create_mental_model,
+ *     list_mental_models, update_bank;
+ *   • host (src/agents/status.ts): list_banks; (src/cli/vault-sweep.ts): list_memories;
+ *   • an agent Stop hook (bin/user-profile-refresh-hook.sh): refresh_mental_model.
+ * The minimum SAFE allowlist is therefore ~16 of 29 — and the audit found TWO
+ * callers a first-pass grep missed (refresh_mental_model, create_directive), so
+ * a too-narrow list would SILENTLY break a model-instructed capability across
+ * the whole fleet (the allowlist filters the SHARED singleton). Completeness
+ * can't be guaranteed cheaply, and a miss is a silent fleet-wide degradation.
  *
- * Deferred intentionally: the token win the allowlist would buy is already
- * captured by Claude Code tool-search (#2198), which defers all 29 schemas out
- * of the AGENT's context regardless of the advertised count. Revisit as a
- * focused follow-up that audits + fixes the host callers, then trims.
+ * And the token win is already captured: Claude Code tool-search (#2198) defers
+ * all 29 schemas out of the AGENT's context regardless of the advertised count,
+ * so the allowlist would only shave the tool-search-OFF fallback path (~5-6k tok
+ * at 16/29) — not worth the blast radius. NOT shipping it.
+ *
+ * The two PHANTOM callers the audit surfaced WERE fixed (real bugs, independent
+ * of the allowlist): vault-sweep's `delete_memory` (no such tool; a memory id is
+ * not a document_id either — proven live) and hindsight.ts addMemoryTag's
+ * `update_memory` (no such tool) now FAIL HONESTLY instead of silently
+ * reporting success. SEPARATE security follow-up still open: vault-sweep's
+ * secret-scrub has no working single-memory delete path AND hard-throws on the
+ * stateless server at vault-sweep.ts:194 — it needs a document-granularity
+ * rework to actually scrub, not just fail loudly.
  */
 
 /**

--- a/tests/memory.add-memory-tag.test.ts
+++ b/tests/memory.add-memory-tag.test.ts
@@ -28,6 +28,36 @@ describe("DEMOTE_FROM_RECALL_TAG", () => {
 });
 
 describe("addMemoryTag — happy path", () => {
+  it("HONEST FAILURE: returns ok:false when the server rejects update_memory with isError (not a silent ok:true)", async () => {
+    // The live server has no `update_memory` tool → HTTP 200 + an MCP error
+    // envelope. The prior code only checked HTTP status and reported ok:true,
+    // so `memory demote` lied. Now the isError body must surface as ok:false.
+    const errorBody =
+      'event: message\n' +
+      'data: {"jsonrpc":"2.0","id":2,"result":{"isError":true,"content":[{"type":"text","text":"Unknown tool: \'update_memory\'"}]}}\n';
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([["mcp-session-id", "test-session"]]),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => errorBody,
+      } as any);
+
+    const result = await addMemoryTag(
+      "http://test.local/mcp/",
+      "clerk",
+      "mem-abc123",
+      DEMOTE_FROM_RECALL_TAG,
+      { fetchImpl: mockFetch as any, timeoutMs: 5000 },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/Unknown tool.*update_memory/);
+  });
+
   it("calls update_memory with add_tags after MCP initialize", async () => {
     const mockFetch = vi
       .fn()

--- a/tests/vault-sweep.hindsight.test.ts
+++ b/tests/vault-sweep.hindsight.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import {
   sweepHindsightBank,
   getBanksToSweep,
@@ -160,5 +162,38 @@ describe('getBanksToSweep', () => {
   it('returns [] when config is undefined or has no agents', () => {
     expect(getBanksToSweep(undefined)).toEqual([])
     expect(getBanksToSweep({ switchroom: { version: 1 }, agents: {} } as unknown as SwitchroomConfig)).toEqual([])
+  })
+})
+
+describe('deleteMemory — honest failure, no phantom tool call, no silent lie', () => {
+  const src = readFileSync(resolve(__dirname, '..', 'src', 'cli', 'vault-sweep.ts'), 'utf-8')
+
+  it('does NOT call any single-memory delete tool (delete_memory is phantom; a memory id is not a document_id)', () => {
+    // Proven live: delete_memory is not a real tool, and delete_document(id)
+    // targets a non-existent document (get_document(memoryId) → not found), so
+    // it would silently no-op the scrub. The real client must NOT emit either.
+    expect(src).not.toMatch(/callTool\([^)]*'delete_memory'/)
+    expect(src).not.toMatch(/callTool\([^)]*'delete_document'/)
+  })
+
+  it('throws an explicit "no single-memory delete API" error so the scrub fails loudly', () => {
+    expect(src).toMatch(/hindsight exposes no single-memory delete API/)
+  })
+
+  it('the sweep surfaces undeletable matches (deleted stays below matched, with a reason)', async () => {
+    // A real (throwing) client → matches found but deleted=0, reason warned.
+    const throwing: HindsightMcpClient = {
+      async listMemories() {
+        return { items: [{ id: 'm1', text: `leak ${SK}` }], total: 1 }
+      },
+      async deleteMemory() {
+        throw new Error('hindsight exposes no single-memory delete API …')
+      },
+    }
+    const report = await sweepHindsightBank(throwing, 'bank-a', [{ key: 'K', value: SK }], {
+      dryRun: false,
+    })
+    expect(report.matched).toHaveLength(1)
+    expect(report.deleted).toBe(0) // honest: matched 1, deleted 0 — not a false success
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to the context-token audit. The hindsight MCP tool-surface allowlist (29→trim) was gated on a complete host-caller audit + fixing 2 phantom callers. A 3-hunt **adversarial completeness audit** reached a clear verdict: **don't ship the allowlist**, and the 2 phantoms are deeper bugs than expected — both silently **lie** about success. This PR fixes the real bugs and records why the allowlist is deferred.

## Why NOT the allowlist (recorded in `src/setup/hindsight.ts`)

The allowlist (`HINDSIGHT_API_MCP_ENABLED_TOOLS`) filters the **shared hindsight singleton** across all banks. The audit found the *safe* set is **~16 of 29**, not 5 — every agent's CLAUDE.md instructs the model to use `create_directive`/`list_directives`/`delete_directive`/`refresh_mental_model`/`update_mental_model` on top of recall/reflect/retain/delete_document, plus host setup tools and a Stop hook. Crucially, the audit found **two callers a first-pass grep missed** (`refresh_mental_model`, `create_directive`) — so a too-narrow list would **silently break a model-instructed capability fleet-wide**. Completeness can't be guaranteed cheaply, and a miss is a silent fleet-wide degradation of the shared memory store.

And the token win is **already captured** by tool-search (#2198), which defers all 29 schemas from the agent context regardless of the advertised count — the allowlist would only shave the tool-search-OFF fallback (~5-6k tok at 16/29). Not worth the blast radius.

*(Catastrophic risk cleared: the auto-recall/retain hooks use REST, not MCP, so an allowlist couldn't break memory formation — but we're not shipping it regardless.)*

## Phantom-caller fixes (real bugs — both silently reported success)

- **`vault-sweep` `delete_memory` → honest failure.** Proven live: `delete_memory` is not a real tool, and `delete_document(id)` is wrong too — a `list_memories` item's `id` is a **memory-unit id, not a document_id** (`get_memory(id)` ok, `get_document(id)` "not found"). There is no by-id single-memory delete on MCP or REST. The scrub now throws a clear "no single-memory delete API; redact manually" and the sweep surfaces matched-but-undeleted (deleted < matched) to stderr instead of a false `deleted=N`. **(Reverts a `delete_document` swap I nearly shipped — the adversarial check caught the security regression.)**
- **`addMemoryTag` `update_memory` → inspects `result.isError`.** The server returns HTTP 200 + `{isError:true, "Unknown tool"}`; the old code checked only HTTP status and returned `ok:true`, so `memory demote` lied. Now returns `ok:false` honestly, forward-compatible if a future build adds the tool.

## Separate security follow-up flagged (out of scope)

vault-sweep's secret-scrub has no working delete path **and** hard-throws on the stateless server (`vault-sweep.ts:194`) — it needs a document-granularity rework to actually scrub, not just fail loudly. Flagged, not rushed.

## Also done operationally (not in this diff): the memory-prose re-seed

The other context follow-up — re-seeding the seed-once `workspace/CLAUDE.md` (the file-memory contradiction fixed in #2199's template) — was executed on all 11 live agents (atomic overwrite, byte-exact to the v0.14.77 template render, backups kept). Takes effect at each agent's next restart.

## Test plan
- [x] tsc clean; 28 tests (vault-sweep honest-failure + sweep surfaces undeleted; addMemoryTag isError → ok:false; memory-prose render)
- [x] All claims verified live against the running hindsight server (get_memory vs get_document, Unknown-tool envelope)

## Risk
LOW. The phantom fixes turn silent lies into honest failures (strictly safer). No allowlist shipped → zero risk to the shared singleton. No kill switch needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)