### PR TITLE
fix(hindsight): repair the user-profile mental model (creation + refresh hook)

### DIFF
--- a/bin/user-profile-refresh-hook.sh
+++ b/bin/user-profile-refresh-hook.sh
@@ -18,21 +18,45 @@ if [ -f "$MARKER" ]; then
 fi
 # Fire-and-forget refresh via MCP. Timeout bounded by Claude Code hook.
 # Output nothing on success or failure; errors are surfaced via doctor.
+#
+# Two bugs this fixes (2026-06-07):
+#  1. The Hindsight server is STATELESS (HINDSIGHT_API_MCP_STATELESS=true) and
+#     returns NO mcp-session-id header, so the old code's `[ -n "$SESSION" ]`
+#     gate was ALWAYS false → the refresh NEVER fired. Stateless MCP needs no
+#     session — drop the gate (mirrors src/memory/hindsight.ts, which tolerates
+#     a missing session id).
+#  2. refresh_mental_model takes `mental_model_id` (a UUID), NOT `name`. Passing
+#     `name` returns isError "Missing required argument: mental_model_id". So we
+#     list_mental_models, resolve the `user-profile` model's id, then refresh
+#     by id.
 {
-  # JSON-RPC flow: initialize → tools/call refresh_mental_model
-  SESSION=$(curl -sS -X POST "$API_URL/mcp/" \
+  # initialize (no session id needed on the stateless server).
+  curl -sS -X POST "$API_URL/mcp/" \
     -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
-    -H "X-Bank-Id: $BANK_ID" -D /tmp/mm-refresh-$$.headers \
+    -H "X-Bank-Id: $BANK_ID" \
     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mm-refresh","version":"0.1"}}}' \
-    -m 3 -o /dev/null 2>/dev/null && grep -i mcp-session-id /tmp/mm-refresh-$$.headers | cut -d' ' -f2 | tr -d '\r\n')
-  if [ -n "$SESSION" ]; then
+    -m 3 -o /dev/null 2>/dev/null || true
+
+  # Resolve the user-profile mental model's id (refresh is by id, not name).
+  # list_mental_models returns the items as a JSON STRING nested in
+  # .result.structuredContent.result, so parse with jq (fromjson). The agent
+  # image ships jq; if it's somehow absent, MM_ID stays empty → skip (the next
+  # Stop fires it again; fire-and-forget, no wedge).
+  MM_ID=$(curl -sS -X POST "$API_URL/mcp/" \
+    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+    -H "X-Bank-Id: $BANK_ID" \
+    -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_mental_models","arguments":{}}}' \
+    -m 5 2>/dev/null \
+    | grep '^data:' | sed 's/^data: //' \
+    | jq -r '.result.structuredContent.result | fromjson | .items[] | select(.name=="user-profile") | .id' 2>/dev/null | head -1)
+
+  if [ -n "$MM_ID" ]; then
     curl -sS -X POST "$API_URL/mcp/" \
       -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
-      -H "X-Bank-Id: $BANK_ID" -H "mcp-session-id: $SESSION" \
-      -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"refresh_mental_model","arguments":{"name":"user-profile"}}}' \
+      -H "X-Bank-Id: $BANK_ID" \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"refresh_mental_model\",\"arguments\":{\"mental_model_id\":\"$MM_ID\"}}}" \
       -m 5 -o /dev/null 2>/dev/null || true
   fi
-  rm -f /tmp/mm-refresh-$$.headers 2>/dev/null || true
   date +%s > "$MARKER"
 } &
 exit 0

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -375,7 +375,16 @@ export async function ensureUserProfileMentalModel(
           name: "create_mental_model",
           arguments: {
             name: "user-profile",
-            query: "What are the key facts, preferences, context, and communication style about the user I talk to? Summarize what matters for making the agent feel like it knows them.",
+            // The server's create_mental_model argument is `source_query`, not
+            // `query` (an upstream rename). Passing `query` returns HTTP 200
+            // with isError:true "Missing required argument: source_query" — and
+            // because the old code only checked `createResponse.ok` (HTTP
+            // status), it reported {ok:true} while creating NOTHING. That broke
+            // the user-profile mental model fleet-wide (the "knows you" feature):
+            // banks had zero mental models despite "ready". Fixed: correct arg +
+            // the isError check below.
+            source_query:
+              "What are the key facts, preferences, context, and communication style about the user I talk to? Summarize what matters for making the agent feel like it knows them.",
             types: ["world", "experience"],
           },
         },
@@ -387,6 +396,23 @@ export async function ensureUserProfileMentalModel(
 
     if (!createResponse.ok) {
       return { ok: false, reason: `Create MM HTTP ${createResponse.status}` };
+    }
+
+    // Check the MCP result envelope — a tools/call can return HTTP 200 with
+    // isError:true (e.g. a missing/renamed argument). Don't report success on
+    // an error, or the next `ensureUserProfileMentalModel` keeps "creating" a
+    // model that never lands.
+    try {
+      const created = await parseSseOrJson<{
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      }>(createResponse);
+      if (created.result?.isError === true) {
+        const msg = created.result.content?.[0]?.text ?? "create returned isError";
+        return { ok: false, reason: msg };
+      }
+    } catch {
+      // Unparseable body — treat HTTP 200 as success (legacy) rather than fail
+      // a working create on a parse hiccup.
     }
 
     return { ok: true };

--- a/tests/memory.user-profile.test.ts
+++ b/tests/memory.user-profile.test.ts
@@ -1,7 +1,30 @@
 import { describe, it, expect, vi } from "vitest";
 import { ensureUserProfileMentalModel } from "../src/memory/hindsight.js";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+describe("user-profile-refresh-hook.sh — refresh actually fires (source guards)", () => {
+  const hook = readFileSync(
+    resolve(__dirname, "..", "bin", "user-profile-refresh-hook.sh"),
+    "utf-8",
+  );
+
+  it("does NOT gate the refresh on a session id (the stateless server returns none)", () => {
+    // The old `if [ -n "$SESSION" ]` gate meant the refresh never fired on the
+    // stateless server. The gate must be gone.
+    expect(hook).not.toMatch(/if \[ -n "\$SESSION" \]/);
+    expect(hook).not.toMatch(/mcp-session-id: \$SESSION/);
+  });
+
+  it("refreshes by mental_model_id (resolved via list), not by name", () => {
+    // refresh_mental_model requires mental_model_id, not name.
+    expect(hook).toMatch(/list_mental_models/);
+    expect(hook).toMatch(/select\(\.name=="user-profile"\) \| \.id/);
+    expect(hook).toMatch(/mental_model_id\\?":\\?"\$MM_ID/);
+    // The old name-based refresh call must be gone.
+    expect(hook).not.toMatch(/refresh_mental_model[^}]*name\\?":\\?"user-profile/);
+  });
+});
 
 describe("ensureUserProfileMentalModel", () => {
   it("creates mental model when list returns empty", async () => {
@@ -28,13 +51,39 @@ describe("ensureUserProfileMentalModel", () => {
     expect(result).toEqual({ ok: true });
     expect(mockFetch).toHaveBeenCalledTimes(3);
 
-    // Verify create_mental_model was called
+    // Verify create_mental_model was called with the CORRECT arg name. The
+    // server's argument is `source_query`, not `query` (an upstream rename) —
+    // passing `query` returns isError "Missing required argument: source_query"
+    // and creates nothing.
     const createCall = mockFetch.mock.calls[2];
     const createBody = JSON.parse(createCall[1].body);
     expect(createBody.params.name).toBe("create_mental_model");
     expect(createBody.params.arguments.name).toBe("user-profile");
-    expect(createBody.params.arguments.query).toContain("key facts, preferences");
+    expect(createBody.params.arguments.source_query).toContain("key facts, preferences");
+    expect(createBody.params.arguments.query).toBeUndefined();
     expect(createBody.params.arguments.types).toEqual(["world", "experience"]);
+  });
+
+  it("HONEST FAILURE: returns ok:false when create returns isError (not a silent ok:true)", async () => {
+    // The old code only checked HTTP status and reported ok:true even when the
+    // server rejected the create (isError) — so "User-profile Mental Model
+    // ready" printed while the bank stayed empty. The isError envelope must
+    // surface as ok:false.
+    const errorBody =
+      'data: {"jsonrpc":"2.0","id":3,"result":{"isError":true,"content":[{"type":"text","text":"Missing required argument: source_query"}]}}\n';
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, headers: new Map(), text: async () => "" } as any) // initialize
+      .mockResolvedValueOnce({ ok: true, text: async () => 'data: {"result":{"content":[{"text":"{\\"items\\":[]}"}]}}\n' } as any) // list (empty)
+      .mockResolvedValueOnce({ ok: true, text: async () => errorBody } as any); // create → isError
+
+    const result = await ensureUserProfileMentalModel(
+      "http://test.local/mcp/",
+      "test-bank",
+      { fetchImpl: mockFetch as any }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/source_query/);
   });
 
   it("returns success when MM already exists (idempotent)", async () => {


### PR DESCRIPTION
## Summary

Started as "fix the dead Stop hook" — turned out the **entire user-profile mental-model feature was non-functional fleet-wide** (vision pillar 1, "an agent that knows you"). An upstream hindsight argument rename, masked by the `isError`-not-checked bug class. All claims proven live against the running server.

## What was broken

**Creation** (`src/memory/hindsight.ts` `ensureUserProfileMentalModel`):
- `create_mental_model`'s argument is `source_query`, not `query` (upstream rename). Passing `query` → HTTP 200 + `isError:true "Missing required argument: source_query"`. The old code only checked the HTTP status, so it reported `{ok:true}` and printed *"User-profile Mental Model ready"* while creating **nothing**. Every agent's bank had **zero** mental models (verified: marko `list_mental_models` → `{"items":[]}`).

**Stop-hook refresh** (`bin/user-profile-refresh-hook.sh`) — two bugs, both made the per-session refresh a silent no-op:
1. The server is **stateless** (no `mcp-session-id` header), but the hook gated the refresh on a non-empty session id → it **never fired**.
2. `refresh_mental_model` takes `mental_model_id` (a UUID), not `name`.

## The fix

- Creation: `query` → `source_query`, **+ check `isError`** so it stops reporting false "ready".
- Hook: drop the session gate; `list_mental_models` → resolve the `user-profile` id via `jq` (the items are a nested JSON string) → `refresh_mental_model {mental_model_id}`.

## Proven live (against the running hindsight server)
- `create_mental_model` with `source_query` → `isError:false`, model persists (restored marko's missing MM during verification).
- The fixed hook sequence in marko's container → resolves the id, refresh returns `isError:false` (accepted; the server runs the actual refresh async).

## Rollout note
A `switchroom apply` re-runs `ensureUserProfileMentalModel` (now fixed) → creates the user-profile MM for all agents that are currently missing it.

## Test plan
- [x] tsc clean; 9 tests (`source_query` arg + `query` absent + `isError`→`ok:false`; hook has no session gate + refreshes by resolved `mental_model_id`)
- [x] `bash -n` clean; live end-to-end verification on marko

## Risk
LOW. Both paths were no-ops (the feature never worked), so making them work can't regress a working feature. Hook is fire-and-forget (failures swallowed, no agent wedge). No kill switch needed.

## Note on the shm item
The other open item — codifying `--shm-size=2g` durably — was **already shipped** in #2190 (`HINDSIGHT_DEFAULT_SHM_SIZE = "2g"` in both the `docker run` path and the compose snippet), in v0.14.77. No action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)