### PR TITLE
fix(hindsight): user-profile MM existence check by name, not substring

### DIFF
--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -346,14 +346,26 @@ export async function ensureUserProfileMentalModel(
         const listData = await parseSseOrJson<{
           result?: { content?: Array<{ text?: string }> };
         }>(listResponse);
+        // The list payload is a JSON STRING of {items:[{name,...}]}. The old
+        // existence check did a naive substring `models.includes("user-profile")`
+        // on that whole blob — which FALSE-POSITIVED whenever ANOTHER mental
+        // model's name / source_query / content merely contained the substring
+        // "user-profile" (e.g. lawgpt's Lisa-focused models, or a sibling
+        // "User Profile" model). That made `ensureUserProfileMentalModel` skip
+        // creation and report "ready" while the bank had NO user-profile model.
+        // Match by exact item NAME instead.
         const models = listData.result?.content?.[0]?.text;
-        if (models && typeof models === "string" && models.includes("user-profile")) {
-          return { ok: true }; // Already exists
+        if (models && typeof models === "string") {
+          const parsed = JSON.parse(models) as { items?: Array<{ name?: string }> };
+          const items = Array.isArray(parsed?.items) ? parsed.items : [];
+          if (items.some((m) => m?.name === "user-profile")) {
+            return { ok: true }; // Already exists (by exact name)
+          }
         }
       } catch {
-        // Parse failed (not SSE and not JSON). Fall through to create attempt;
-        // if the MM already exists, create will return an idempotent error
-        // we also swallow below.
+        // Parse failed (not SSE / not the expected JSON shape). Fall through to
+        // the create attempt; if the MM already exists, create returns an
+        // idempotent error we swallow below.
       }
     }
 

--- a/tests/memory.user-profile.test.ts
+++ b/tests/memory.user-profile.test.ts
@@ -86,19 +86,15 @@ describe("ensureUserProfileMentalModel", () => {
     if (!result.ok) expect(result.reason).toMatch(/source_query/);
   });
 
-  it("returns success when MM already exists (idempotent)", async () => {
+  it("returns success when MM already exists (idempotent) — matched by exact name", async () => {
+    // The list payload is a JSON string of {items:[{name,...}]}. An item NAMED
+    // user-profile means it exists → skip create.
+    const listBody = JSON.stringify({
+      result: { content: [{ text: JSON.stringify({ items: [{ name: "user-profile" }, { name: "Active Projects" }] }) }] },
+    });
     const mockFetch = vi.fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        headers: new Map([["mcp-session-id", "test-session"]]),
-        json: async () => ({}),
-        text: async () => JSON.stringify({}),
-      } as any)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ result: { content: [{ text: "user-profile\nother-model" }] } }),
-        text: async () => JSON.stringify({ result: { content: [{ text: "user-profile\nother-model" }] } }),
-      } as any);
+      .mockResolvedValueOnce({ ok: true, headers: new Map(), text: async () => "" } as any) // init
+      .mockResolvedValueOnce({ ok: true, text: async () => `data: ${listBody}\n` } as any); // list (has user-profile)
 
     const result = await ensureUserProfileMentalModel(
       "http://test.local/mcp/",
@@ -107,7 +103,32 @@ describe("ensureUserProfileMentalModel", () => {
     );
 
     expect(result).toEqual({ ok: true });
-    expect(mockFetch).toHaveBeenCalledTimes(2); // Only init + list, no create
+    expect(mockFetch).toHaveBeenCalledTimes(2); // init + list, NO create
+  });
+
+  it("FALSE-POSITIVE GUARD: creates when no item is NAMED user-profile, even if another model mentions the substring", async () => {
+    // The old substring check skipped creation whenever ANY model's name/query/
+    // content contained "user-profile" — leaving banks (e.g. lawgpt's
+    // Lisa-focused models) without a real user-profile model. Match by name.
+    const listBody = JSON.stringify({
+      result: { content: [{ text: JSON.stringify({ items: [
+        { name: "Lisa Profile", source_query: "what to know about the user-profile of Lisa" },
+        { name: "User Profile" },
+      ] }) }] },
+    });
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, headers: new Map(), text: async () => "" } as any) // init
+      .mockResolvedValueOnce({ ok: true, text: async () => `data: ${listBody}\n` } as any) // list (substring present, no exact name)
+      .mockResolvedValueOnce({ ok: true, text: async () => 'data: {"result":{"isError":false}}\n' } as any); // create
+
+    const result = await ensureUserProfileMentalModel(
+      "http://test.local/mcp/",
+      "lawgpt",
+      { fetchImpl: mockFetch as any }
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(3); // init + list + CREATE (not skipped)
   });
 
   it("returns error when Hindsight unreachable", async () => {


### PR DESCRIPTION
## Summary

Third bug in `ensureUserProfileMentalModel` (after #2203's `source_query` + `isError` fixes), found live during the v0.14.78 rollout.

The "already exists?" check did a naive substring `models.includes("user-profile")` on the whole list-response blob. It **false-positived** whenever any *other* mental model's name / `source_query` / content merely contained the substring "user-profile" — so it **skipped creation and reported "ready" while the bank had no user-profile model**.

Hit two agents on rollout:
- **lawgpt** — Lisa-focused models whose queries mention "user-profile".
- **clerk** (shared `assistant` bank) — a sibling "User Profile" model.

#2203's test only mocked an *empty* list, so it missed this.

## Fix
Parse the `{items:[{name}]}` payload and match by **exact name** (`items.some(m => m.name === "user-profile")`), not a substring on the blob.

## Live state
All 11 agents' user-profile models exist now (the two skipped banks were created by hand during verification). This fix prevents recurrence on future reconciles / new agents whose banks contain substring-matching models.

## Test plan
- [x] tsc clean; 10 tests, including a **false-positive guard** (substring present, no exact-name item → still creates) and the corrected idempotent-skip (exact name → skip).

## Risk
LOW. Tightens an existence check from substring to exact-name; the only behavior change is *correctly creating* where it previously wrongly skipped. Idempotent skip still works (a real user-profile item → skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)