### PR TITLE
fix(auth): auto-fallback via non-admin mark-exhausted, not admin set-active

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -230,6 +230,10 @@ export interface ProbeQuotaData {
 export interface MarkExhaustedData {
   account: string;
   rolled: string[];
+  /** The account the fleet rolled TO (next non-exhausted in fallback_order),
+   *  or null when every fallback is also exhausted. Added so a non-admin
+   *  caller can announce an accurate swap target without an admin set-active. */
+  rolledTo?: string | null;
 }
 
 export interface RefreshAccountData {

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -402,6 +402,10 @@ export const SetActiveDataSchema = z.object({
 export const MarkExhaustedDataSchema = z.object({
   account: z.string(),
   rolled: z.array(z.string()),
+  // The account the fleet rolled TO (next non-exhausted in fallback_order),
+  // or null when every fallback is also exhausted. Lets a non-admin caller
+  // (auto-fallback) announce an accurate target without an admin set-active.
+  rolledTo: z.string().nullable().optional(),
 });
 
 export const RefreshAccountDataSchema = z.object({

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -496,18 +496,54 @@ describe("AuthBroker — mark-exhausted", () => {
     });
     await broker.start();
     const until = Date.now() + 60_000;
+    // ziggy is NOT an admin agent (admin_agents is unset here) — yet
+    // mark-exhausted succeeds. This is the whole point of routing auto-fallback
+    // through mark-exhausted instead of the admin-gated set-active: the agent
+    // that just 429'd can self-heal the fleet without being admin.
     const resp = await rpc(join(h.socketRoot, "ziggy", "sock"), {
       v: 1, id: "1", op: "mark-exhausted", until,
-    }) as { ok: boolean; data: { account: string; rolled: string[] } };
+    }) as { ok: boolean; data: { account: string; rolled: string[]; rolledTo: string | null } };
     expect(resp.ok).toBe(true);
     expect(resp.data.account).toBe("default");
     expect(resp.data.rolled).toContain("ziggy");
+    // rolledTo names the account the fleet rolled to (next non-exhausted in
+    // fallback_order) so a non-admin caller can announce an accurate swap.
+    expect(resp.data.rolledTo).toBe("secondary");
     // Persisted to disk
     const quota = JSON.parse(readFileSync(join(h.stateDir, "quota.json"), "utf-8"));
     expect(quota["default"].exhausted_until).toBe(until);
     // Agent mirror now holds the secondary account creds.
     const mirror = readFileSync(join(h.agentsDir, "ziggy", ".claude", ".credentials.json"), "utf-8");
     expect(mirror).toContain("at-secondary");
+    broker.stop();
+  });
+
+  it("returns rolledTo=null when there is no other account to roll to", async () => {
+    // fallback_order has only the (now-exhausted) active account → nowhere to
+    // roll → rolledTo null, rolled empty. The gateway maps this to the
+    // all-blocked announcement.
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default"],
+      agents: { ziggy: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "ziggy"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+    });
+    await broker.start();
+    const resp = await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1, id: "1", op: "mark-exhausted", until: Date.now() + 60_000,
+    }) as { ok: boolean; data: { account: string; rolled: string[]; rolledTo: string | null } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data.account).toBe("default");
+    expect(resp.data.rolledTo).toBeNull();
+    expect(resp.data.rolled).toEqual([]);
     broker.stop();
   });
 });

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -1190,8 +1190,13 @@ export class AuthBroker {
     this.persistQuota();
     // Fan out next-fallback creds to every agent whose active account is `account`.
     const rolled = this.fanoutFailoverFor(account);
+    // The account the fleet rolled TO — same selection the fanout used. Lets a
+    // non-admin caller (the agent that just 429'd, via auto-fallback) report an
+    // accurate "switched to <X>" without a follow-up admin set-active. `null`
+    // when every fallback_order entry is also exhausted (genuine all-blocked).
+    const rolledTo = this.nextHealthyAccount(account, this.config.auth?.fallback_order ?? []);
     this.audit({ op: "mark-exhausted", identity, account, ok: true });
-    socket.write(encodeSuccess(id, { account, rolled }));
+    socket.write(encodeSuccess(id, { account, rolled, rolledTo }));
   }
 
   private async opRefreshAccount(

--- a/telegram-plugin/auto-fallback-fleet.ts
+++ b/telegram-plugin/auto-fallback-fleet.ts
@@ -40,7 +40,6 @@ import {
   renderFallbackAnnouncement,
   classifyHealth,
   buildSnapshotsFromState,
-  type AccountSnapshot,
 } from './auth-snapshot-format.js';
 
 export type FleetFallbackOutcome =
@@ -52,10 +51,12 @@ export type FleetFallbackOutcome =
       /** Quota for the OLD account at the moment of failure — caller
        *  may persist this as the broker's `quota.json` so the next
        *  /auth render reflects the freshly-known exhaustion without
-       *  another probe. */
-      oldQuota: QuotaUtilization;
-      /** Quota for the new active account, useful for caller logging. */
-      newQuota: QuotaUtilization;
+       *  another probe. Null when the live probe failed but the broker
+       *  rolled anyway (it owns the authoritative exhaustion state). */
+      oldQuota: QuotaUtilization | null;
+      /** Quota for the new active account, useful for caller logging.
+       *  Null when the rolled-to account had no successful probe. */
+      newQuota: QuotaUtilization | null;
     }
   | {
       kind: 'all-blocked';
@@ -82,8 +83,15 @@ export interface FleetFallbackDeps {
    *  Get via `client.probeQuota(state.accounts.map(a => a.label))`
    *  and map the response back to per-account results (#1336). */
   quotas: QuotaResult[];
-  /** Broker `setActive` invoker. Returns the result for logging. */
-  setActive: (label: string) => Promise<{ active: string; fanned: string[] }>;
+  /** Non-admin failover invoker — the broker's `mark-exhausted` verb. Marks
+   *  the triggering agent's (exhausted) account and rolls every agent on it to
+   *  the next non-exhausted `fallback_order` account, returning that target as
+   *  `rolledTo` (null when every fallback is also exhausted). This is what lets
+   *  auto-fallback work from ANY agent — `set-active` (the admin verb the manual
+   *  /auth button uses) is gated to admin agents, so a non-admin agent that
+   *  429'd could never self-heal. mark-exhausted derives the account from the
+   *  caller's own identity, so it needs no admin. */
+  failover: () => Promise<{ rolledTo: string | null; rolled: string[] }>;
   /** Agent that triggered this fallback (for the announcement byline). */
   triggerAgent: string;
   /** Operator timezone for absolute reset times in the announcement. */
@@ -131,10 +139,18 @@ export async function runFleetAutoFallback(
     };
   }
 
-  const target = pickFallbackTarget(snapshots);
-  if (!target) {
-    // All-blocked path: no eligible target. Still notify the user with
-    // earliest-reset info via the announcement formatter.
+  // Execute the non-admin swap. The broker marks the triggering agent's
+  // (exhausted) account and rolls the fleet to the next non-exhausted
+  // fallback_order account, returning it as `rolledTo`. We trust the broker's
+  // choice (same `nextHealthyAccount` selection /auth rotate uses) rather than
+  // picking here, so the announcement matches what actually happened. Caller
+  // catches and surfaces failures — we don't double-wrap.
+  const { rolledTo } = await deps.failover();
+
+  if (!rolledTo) {
+    // All-blocked path: the broker found no non-exhausted fallback. The active
+    // account IS now marked exhausted (good for consumers/telemetry), but there
+    // was nowhere to roll. Notify with earliest-reset info.
     return {
       kind: 'all-blocked',
       oldLabel: oldSnap.label,
@@ -151,22 +167,22 @@ export async function runFleetAutoFallback(
     };
   }
 
-  // Execute the broker swap. Caller catches and surfaces the failure
-  // — we don't double-wrap.
-  await deps.setActive(target.label);
+  // Quota for the rolled-to account, looked up from the same probe snapshots
+  // (the broker chose by fallback_order, which may differ from the
+  // lowest-utilization heuristic — the announcement reflects the real target).
+  const newQuota = snapshots.find((s) => s.label === rolledTo)?.quota ?? null;
 
   return {
     kind: 'switched',
     oldLabel: oldSnap.label,
-    newLabel: target.label,
-    oldQuota: oldSnap.quota!, // non-null: only `unknown` health gets here through
-    // the no-target branch, never the switched one
-    newQuota: target.quota!,
+    newLabel: rolledTo,
+    oldQuota: oldSnap.quota,
+    newQuota,
     announcement: renderFallbackAnnouncement({
       oldLabel: oldSnap.label,
       oldQuota: oldSnap.quota,
-      newLabel: target.label,
-      newQuota: target.quota,
+      newLabel: rolledTo,
+      newQuota,
       triggerAgent: deps.triggerAgent,
       tz,
       now,
@@ -174,40 +190,12 @@ export async function runFleetAutoFallback(
   };
 }
 
-/**
- * Pick the best non-active fallback target. Selection order:
- *   1. Healthy accounts, sorted by lowest 5h utilization (most
- *      runway).
- *   2. If no healthy alternative, throttling accounts sorted by
- *      lowest binding-window utilization (least worst).
- *   3. Skip blocked + unknown entirely — never recommend a switch
- *      into a wall, never bet on creds we couldn't probe.
- *
- * Returns null when no eligible target exists.
- */
-export function pickFallbackTarget(
-  snapshots: AccountSnapshot[],
-): AccountSnapshot | null {
-  const candidates = snapshots
-    .filter((s) => !s.isActive && s.quota != null)
-    .map((s) => ({ snap: s, health: classifyHealth(s) }));
-
-  const healthy = candidates
-    .filter((c) => c.health === 'healthy')
-    .sort((a, b) => a.snap.quota!.fiveHourUtilizationPct - b.snap.quota!.fiveHourUtilizationPct);
-  if (healthy.length > 0) return healthy[0]!.snap;
-
-  const throttling = candidates
-    .filter((c) => c.health === 'throttling')
-    .sort((a, b) => maxWindow(a.snap.quota!) - maxWindow(b.snap.quota!));
-  if (throttling.length > 0) return throttling[0]!.snap;
-
-  return null;
-}
-
-function maxWindow(q: QuotaUtilization): number {
-  return Math.max(q.fiveHourUtilizationPct, q.sevenDayUtilizationPct);
-}
+// NOTE: target SELECTION now lives in the broker (`nextHealthyAccount`,
+// fallback_order order — the same selection /auth rotate uses). This module
+// no longer picks a target; it calls the non-admin `failover()` (mark-exhausted)
+// and announces whatever the broker rolled to. A second, divergent selector
+// here (the old lowest-utilization `pickFallbackTarget`) was removed so there's
+// one authoritative chooser.
 
 function pctSummary(q: QuotaUtilization | null): string {
   if (!q) return 'no probe';

--- a/telegram-plugin/gateway/auth-broker-client.ts
+++ b/telegram-plugin/gateway/auth-broker-client.ts
@@ -27,6 +27,7 @@ export function createAuthBrokerClient(): {
   const client: AuthBrokerClient = {
     listState: () => broker.listState(),
     setActive: (label: string) => broker.setActive(label),
+    markExhausted: (until?: number) => broker.markExhausted(until),
     rmAccount: (label: string) => broker.rmAccount(label),
     refreshAccount: (label: string) => broker.refreshAccount(label),
     setOverride: (agent: string, account: string | null) =>

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -214,6 +214,14 @@ export function parseAuthCommand(text: string): ParsedAuthCommand | null {
 export interface AuthBrokerClient {
   listState(): Promise<ListStateData>
   setActive(label: string): Promise<{ active: string; fanned: string[] }>
+  /**
+   * Non-admin failover (broker `mark-exhausted`). Marks the CALLER's own
+   * account exhausted and rolls every agent on it to the next non-exhausted
+   * `fallback_order` account, returned as `rolledTo` (null when none). Unlike
+   * `setActive` this needs no admin — the account is derived from the caller's
+   * identity — so auto-fallback works from any agent.
+   */
+  markExhausted(until?: number): Promise<{ account: string; rolled: string[]; rolledTo?: string | null }>
   rmAccount(label: string): Promise<{ label: string }>
   refreshAccount(label: string): Promise<{ account: string; expiresAt?: number }>
   setOverride(

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -14644,7 +14644,18 @@ async function doFireFleetAutoFallback(triggerAgent: string): Promise<boolean> {
     const outcome = await runFleetAutoFallback({
       state,
       quotas,
-      setActive: (label) => client.setActive(label),
+      // Non-admin swap: mark-exhausted derives the account from THIS agent's
+      // own identity and rolls the fleet to the next fallback. Replaces the
+      // admin-gated client.setActive(), which 403'd ("set-active requires
+      // admin") for every non-admin agent — i.e. the whole production fleet —
+      // so auto-fallback only ever worked when an admin agent happened to be
+      // the one that 429'd. The manual /auth button stays on set-active (the
+      // operator is explicitly choosing, and is admin); only this automatic
+      // path moves to the non-admin verb.
+      failover: async () => {
+        const r = await client.markExhausted()
+        return { rolledTo: r.rolledTo ?? null, rolled: r.rolled }
+      },
       triggerAgent,
       tz,
     })

--- a/telegram-plugin/tests/auto-fallback-fleet.test.ts
+++ b/telegram-plugin/tests/auto-fallback-fleet.test.ts
@@ -1,10 +1,17 @@
 /**
  * Tests for the fleet-wide auto-fallback planner. Pure-data —
- * no broker UDS, no Telegram bot. The injected `setActive` is a
- * vi.fn we assert on.
+ * no broker UDS, no Telegram bot.
+ *
+ * Contract change (fix/auto-fallback-non-admin): the swap now goes through
+ * the broker's NON-ADMIN `mark-exhausted` verb via the injected `failover()`
+ * dep, which returns the account the broker rolled TO (`rolledTo`). Target
+ * SELECTION moved to the broker (`nextHealthyAccount`, fallback_order order —
+ * what /auth rotate uses); this module no longer picks, it announces whatever
+ * the broker rolled to. The old admin-gated `setActive` dep is gone — that
+ * gate is exactly why a non-admin agent that 429'd could never self-heal.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { runFleetAutoFallback, pickFallbackTarget } from '../auto-fallback-fleet.js';
+import { runFleetAutoFallback } from '../auto-fallback-fleet.js';
 import type { QuotaResult, QuotaUtilization } from '../quota-check.js';
 import type { ListStateData } from '../../src/auth/broker/client.js';
 
@@ -38,38 +45,35 @@ function state(active: string, accounts: string[]): ListStateData {
 }
 
 describe('runFleetAutoFallback', () => {
-  it('switches to the lowest-utilization healthy account via broker.setActive', async () => {
-    const setActive = vi.fn(async (label: string) => ({
-      active: label,
-      fanned: ['alice', 'bob'],
-    }));
+  it('swaps via the non-admin failover() and announces the broker’s rolledTo', async () => {
+    // The broker (mark-exhausted → nextHealthyAccount) chose you@x.
+    const failover = vi.fn(async () => ({ rolledTo: 'you@x', rolled: ['alice', 'bob'] }));
     const out = await runFleetAutoFallback({
       state: state('ken@x', ['ken@x', 'me@x', 'you@x']),
       quotas: [
-        // ken: just blew 5h
+        // ken: just blew 5h (the trigger)
         qOk({
           fiveHourUtilizationPct: 100,
           fiveHourResetAt: new Date('2026-05-15T05:50:00Z'),
           representativeClaim: 'five_hour',
         }),
-        // me: dead on 7d for 2 days
+        // me: dead on 7d
         qOk({
           sevenDayUtilizationPct: 100,
           sevenDayResetAt: new Date('2026-05-17T10:00:00Z'),
           representativeClaim: 'seven_day',
         }),
-        // you: healthy 5h/7d
+        // you: healthy — the rolled-to account, used for the headroom line
         qOk({ fiveHourUtilizationPct: 8, sevenDayUtilizationPct: 20 }),
       ],
-      setActive,
+      failover,
       triggerAgent: 'carrie',
       now: NOW,
       tz: 'UTC',
     });
 
     expect(out.kind).toBe('switched');
-    expect(setActive).toHaveBeenCalledTimes(1);
-    expect(setActive).toHaveBeenCalledWith('you@x');
+    expect(failover).toHaveBeenCalledTimes(1);
     if (out.kind === 'switched') {
       expect(out.oldLabel).toBe('ken@x');
       expect(out.newLabel).toBe('you@x');
@@ -79,8 +83,8 @@ describe('runFleetAutoFallback', () => {
     }
   });
 
-  it('returns all-blocked WITHOUT calling setActive when every alternative is blocked', async () => {
-    const setActive = vi.fn();
+  it('returns all-blocked when the broker reports rolledTo=null (nowhere to roll)', async () => {
+    const failover = vi.fn(async () => ({ rolledTo: null, rolled: [] }));
     const out = await runFleetAutoFallback({
       state: state('ken@x', ['ken@x', 'me@x']),
       quotas: [
@@ -95,117 +99,77 @@ describe('runFleetAutoFallback', () => {
           representativeClaim: 'seven_day',
         }),
       ],
-      setActive,
+      failover,
       triggerAgent: 'carrie',
       now: NOW,
       tz: 'UTC',
     });
 
     expect(out.kind).toBe('all-blocked');
-    expect(setActive).not.toHaveBeenCalled();
+    // failover IS called even on all-blocked — marking the active exhausted is
+    // correct (consumers/telemetry); there was just nowhere to roll.
+    expect(failover).toHaveBeenCalledTimes(1);
     if (out.kind === 'all-blocked') {
       expect(out.announcement).toContain('All accounts blocked');
       expect(out.announcement).toContain('/auth add');
     }
   });
 
-  it('idempotency: skips swap when active probes healthy (stale event)', async () => {
-    const setActive = vi.fn();
+  it('idempotency: skips the swap WITHOUT calling failover when active probes healthy', async () => {
+    const failover = vi.fn();
     const out = await runFleetAutoFallback({
       state: state('ken@x', ['ken@x', 'you@x']),
       quotas: [
         qOk({ fiveHourUtilizationPct: 5, sevenDayUtilizationPct: 10 }),
         qOk({ fiveHourUtilizationPct: 5, sevenDayUtilizationPct: 10 }),
       ],
-      setActive,
+      failover,
       triggerAgent: 'carrie',
       now: NOW,
       tz: 'UTC',
     });
 
     expect(out.kind).toBe('no-eligible-target');
-    expect(setActive).not.toHaveBeenCalled();
+    expect(failover).not.toHaveBeenCalled();
     expect(out.announcement).toContain('skipped');
     expect(out.announcement).toContain('Stale event?');
   });
 
-  it('returns no-old-active when broker has no active account (corrupt state)', async () => {
-    const setActive = vi.fn();
+  it('returns no-old-active (no failover) when broker has no active account', async () => {
+    const failover = vi.fn();
     const out = await runFleetAutoFallback({
       state: { active: '', fallback_order: [], accounts: [], agents: [], consumers: [] },
       quotas: [],
-      setActive,
+      failover,
       triggerAgent: 'carrie',
       now: NOW,
       tz: 'UTC',
     });
 
     expect(out.kind).toBe('no-old-active');
-    expect(setActive).not.toHaveBeenCalled();
+    expect(failover).not.toHaveBeenCalled();
   });
 
-  it('falls back to a throttling alternative when no healthy one exists', async () => {
-    const setActive = vi.fn(async (label: string) => ({ active: label, fanned: [] }));
+  it('announces even when the live probe of the active account failed (broker still rolled)', async () => {
+    // Probe failure for the active account → oldQuota null, but the broker
+    // (authoritative exhaustion state) still rolled. We must still announce.
+    const failover = vi.fn(async () => ({ rolledTo: 'you@x', rolled: ['alice'] }));
     const out = await runFleetAutoFallback({
       state: state('ken@x', ['ken@x', 'you@x']),
       quotas: [
-        qOk({
-          fiveHourUtilizationPct: 100,
-          fiveHourResetAt: new Date('2026-05-15T05:50:00Z'),
-          representativeClaim: 'five_hour',
-        }),
-        // you throttling at 85% but not blocked
-        qOk({ fiveHourUtilizationPct: 85, sevenDayUtilizationPct: 20 }),
-      ],
-      setActive,
-      triggerAgent: 'carrie',
-      now: NOW,
-      tz: 'UTC',
-    });
-
-    expect(out.kind).toBe('switched');
-    expect(setActive).toHaveBeenCalledWith('you@x');
-    if (out.kind === 'switched') {
-      expect(out.announcement).toContain('near limit — watch this');
-    }
-  });
-
-  it('skips unknown-health (probe failed) when picking a target', async () => {
-    const setActive = vi.fn(async (label: string) => ({ active: label, fanned: [] }));
-    const out = await runFleetAutoFallback({
-      state: state('ken@x', ['ken@x', 'broken@x', 'you@x']),
-      quotas: [
-        qOk({ fiveHourUtilizationPct: 100, fiveHourResetAt: new Date('2026-05-15T05:50:00Z') }),
-        { ok: false, reason: 'HTTP 401' },
+        { ok: false, reason: 'HTTP 401' }, // active probe failed → unknown health (not 'healthy', so we proceed)
         qOk({ fiveHourUtilizationPct: 5 }),
       ],
-      setActive,
+      failover,
       triggerAgent: 'carrie',
       now: NOW,
       tz: 'UTC',
     });
 
     expect(out.kind).toBe('switched');
-    expect(setActive).toHaveBeenCalledWith('you@x');
-  });
-});
-
-describe('pickFallbackTarget', () => {
-  it('prefers lower-5h-utilization healthy account', () => {
-    const snaps = [
-      { label: 'a@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100 }) },
-      { label: 'low@x', isActive: false, quota: quota({ fiveHourUtilizationPct: 5 }) },
-      { label: 'med@x', isActive: false, quota: quota({ fiveHourUtilizationPct: 30 }) },
-    ];
-    const target = pickFallbackTarget(snaps);
-    expect(target?.label).toBe('low@x');
-  });
-
-  it('returns null when only blocked alternatives exist', () => {
-    const snaps = [
-      { label: 'a@x', isActive: true, quota: quota({ fiveHourUtilizationPct: 100 }) },
-      { label: 'b@x', isActive: false, quota: quota({ sevenDayUtilizationPct: 100 }) },
-    ];
-    expect(pickFallbackTarget(snaps)).toBeNull();
+    expect(failover).toHaveBeenCalledTimes(1);
+    if (out.kind === 'switched') {
+      expect(out.newLabel).toBe('you@x');
+    }
   });
 });


### PR DESCRIPTION
## Summary

**Auto-fallback never worked for the production fleet.** On a quota 429, the gateway called the broker's **admin-gated `set-active`** — but it runs as the agent that hit the wall, which is almost always a non-admin agent. The broker rejected it with `set-active requires admin` and no swap happened. It only succeeded when an admin agent (klanker/carrie/test-harness) happened to be the one to exhaust.

The operator had been **manually working around this** by tapping the `/auth` card's switch button — which works *only* because that button inherits admin from the admin bot it's tapped on. Same `setActive` verb; the only difference is the caller's admin flag.

This routes auto-fallback through the broker's existing **non-admin** verb, `mark-exhausted`, which derives the account from the caller's own identity, marks it exhausted, and rolls every agent on it to the next non-exhausted `fallback_order` account — exactly what `/auth rotate` does, just automatic and from any agent.

## Changes
- **broker** (`server.ts`, `client.ts`, `protocol.ts`): `mark-exhausted` additively returns `rolledTo` (the account it rolled to, or `null` when every fallback is exhausted) so a non-admin caller can announce an accurate swap. No change to existing callers.
- **gateway** (`auto-fallback-fleet.ts`, `gateway.ts`, `auth-command.ts`, `auth-broker-client.ts`): `runFleetAutoFallback` takes a non-admin `failover()` dep (`client.markExhausted`) instead of `setActive`, and announces the broker's `rolledTo`. Target **selection** moves entirely to the broker's `nextHealthyAccount` — removed the divergent lowest-utilization `pickFallbackTarget` so there's **one** authoritative chooser (matches `/auth rotate`).
- **Manual `/auth use`/`rotate` and the card button stay on `set-active`** (operator is explicitly choosing, and is admin). Only the *automatic* path changes.

## Why no restart machinery
Matching the manual button (which the operator confirms rolls the fleet over without a restart): agents pick up the rolled creds on `claude`'s next refresh — the broker mirrors `.credentials.json` before claude's refresh window. Immediate failed-turn **re-run** is a deliberate separate follow-up, not needed for parity with the working manual path.

## Test plan
- [x] broker: a **non-admin** agent (`ziggy`) calling `mark-exhausted` succeeds and returns `rolledTo` (the exact bug, now a regression test); `rolledTo=null` when there's nowhere to roll
- [x] gateway: `runFleetAutoFallback` calls `failover()` not `setActive`, announces `rolledTo`, maps `null`→all-blocked, idempotency/no-old-active unchanged
- [x] vitest **287** + bun **4192** green; `tsc --noEmit` + `check-plugin-references.mjs` clean

## Risk
Low–moderate. The broker change is additive. The gateway change swaps which verb the auto path calls; manual paths untouched. Rolls out as an auth-broker (singleton) + fleet recreate — will canary on test-harness first.

## Follow-ups (separate PRs)
1. **broker quota-probe sensor** — so hindsight (a consumer pinned to an account no agent shares) auto-fails over; serving-failover (#2194) is already wired but nothing ever marks that account exhausted.
2. **cron preflight + retry** — crons currently fire blind during exhaustion and are logged as success.

## JTBD
"Always available" + "subscription-honest": the fleet now self-heals across accounts on a quota wall instead of waiting for the operator to tap `/auth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)