### PR TITLE
feat(auth-broker): consumer-quota sensor so dedicated-account consumers fail over

### DIFF
--- a/src/auth/broker/consumer-quota-sensor.test.ts
+++ b/src/auth/broker/consumer-quota-sensor.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the pure consumer-quota-sensor decision layer. The loop + I/O
+ * (probe → mark) live in server.ts and are covered there via the
+ * _testFetchQuota seam; here we pin the exhaustion decision itself.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  quotaIndicatesExhaustion,
+  resolveConsumerProbeIntervalMs,
+  EXHAUSTION_PCT,
+  DEFAULT_CONSUMER_PROBE_INTERVAL_MS,
+} from "./consumer-quota-sensor.js";
+import type { QuotaResult } from "../quota.js";
+
+function ok(part: Partial<{
+  fiveHourUtilizationPct: number;
+  sevenDayUtilizationPct: number;
+  fiveHourResetAt: Date | null;
+  sevenDayResetAt: Date | null;
+}>): QuotaResult {
+  return {
+    ok: true,
+    data: {
+      fiveHourUtilizationPct: part.fiveHourUtilizationPct ?? 0,
+      sevenDayUtilizationPct: part.sevenDayUtilizationPct ?? 0,
+      fiveHourResetAt: part.fiveHourResetAt ?? null,
+      sevenDayResetAt: part.sevenDayResetAt ?? null,
+      representativeClaim: null,
+      overageStatus: null,
+      overageDisabledReason: null,
+    },
+  };
+}
+
+describe("quotaIndicatesExhaustion", () => {
+  it("not exhausted when both windows are below the wall", () => {
+    expect(quotaIndicatesExhaustion(ok({ fiveHourUtilizationPct: 80, sevenDayUtilizationPct: 50 })))
+      .toEqual({ exhausted: false, until: null });
+  });
+
+  it("exhausted when the 5h window is at/above the wall; until = its reset", () => {
+    const reset = new Date("2026-06-07T05:00:00Z");
+    const d = quotaIndicatesExhaustion(ok({ fiveHourUtilizationPct: 100, fiveHourResetAt: reset }));
+    expect(d.exhausted).toBe(true);
+    expect(d.until).toBe(reset.getTime());
+  });
+
+  it("exhausted when the 7d window is walled even if 5h is fine", () => {
+    const reset = new Date("2026-06-10T00:00:00Z");
+    const d = quotaIndicatesExhaustion(ok({
+      fiveHourUtilizationPct: 10,
+      sevenDayUtilizationPct: EXHAUSTION_PCT,
+      sevenDayResetAt: reset,
+    }));
+    expect(d.exhausted).toBe(true);
+    expect(d.until).toBe(reset.getTime());
+  });
+
+  it("when both windows are walled, until = the LATER reset", () => {
+    const five = new Date("2026-06-07T05:00:00Z");
+    const seven = new Date("2026-06-10T00:00:00Z");
+    const d = quotaIndicatesExhaustion(ok({
+      fiveHourUtilizationPct: 100, fiveHourResetAt: five,
+      sevenDayUtilizationPct: 100, sevenDayResetAt: seven,
+    }));
+    expect(d.until).toBe(seven.getTime());
+  });
+
+  it("exhausted with until=null when the probe carried no reset", () => {
+    expect(quotaIndicatesExhaustion(ok({ fiveHourUtilizationPct: 100 })))
+      .toEqual({ exhausted: true, until: null });
+  });
+
+  it("a FAILED probe is NEVER exhaustion (no fail-over on transient errors)", () => {
+    const failed: QuotaResult = { ok: false, reason: "HTTP 503" };
+    expect(quotaIndicatesExhaustion(failed)).toEqual({ exhausted: false, until: null });
+  });
+});
+
+describe("resolveConsumerProbeIntervalMs", () => {
+  it("defaults when unset", () => {
+    expect(resolveConsumerProbeIntervalMs({})).toBe(DEFAULT_CONSUMER_PROBE_INTERVAL_MS);
+  });
+  it("kill-switch disables (returns 0)", () => {
+    expect(resolveConsumerProbeIntervalMs({ SWITCHROOM_DISABLE_CONSUMER_QUOTA_PROBE: "1" })).toBe(0);
+  });
+  it("honors an explicit override", () => {
+    expect(resolveConsumerProbeIntervalMs({ SWITCHROOM_CONSUMER_QUOTA_PROBE_MS: "60000" })).toBe(60000);
+  });
+  it("explicit 0 disables", () => {
+    expect(resolveConsumerProbeIntervalMs({ SWITCHROOM_CONSUMER_QUOTA_PROBE_MS: "0" })).toBe(0);
+  });
+  it("ignores a garbage override (falls back to default)", () => {
+    expect(resolveConsumerProbeIntervalMs({ SWITCHROOM_CONSUMER_QUOTA_PROBE_MS: "abc" }))
+      .toBe(DEFAULT_CONSUMER_PROBE_INTERVAL_MS);
+  });
+});

--- a/src/auth/broker/consumer-quota-sensor.ts
+++ b/src/auth/broker/consumer-quota-sensor.ts
@@ -1,0 +1,82 @@
+/**
+ * Consumer-account quota sensor (pure decision layer).
+ *
+ * The broker fails an account over only when something marks it exhausted
+ * (`this.quota[account]`, set by the `mark-exhausted` verb). AGENTS raise that
+ * signal when their gateway sees a 429. A CONSUMER pinned to a dedicated
+ * account that no agent shares (e.g. hindsight on its own account, kept out of
+ * `fallback_order` for quota isolation) has NO ONE to raise it — so its
+ * serving-failover (consumerAccountWithFailover, #2194) never triggers and the
+ * consumer sits dead on an exhausted account (the 2026-06-06 hindsight outage).
+ *
+ * The fix is a broker-side probe of consumer-pinned accounts that marks
+ * exhaustion itself. This module is the PURE decision: given a quota probe,
+ * is the account walled, and until when. The loop + I/O live in server.ts.
+ */
+
+import type { QuotaResult } from "../quota.js";
+
+/**
+ * Utilization at/above this on the binding window counts as a hard wall.
+ * Matches `classifyHealth`'s 'blocked' threshold in auth-snapshot-format.ts so
+ * the sensor and the /auth health view agree on what "exhausted" means.
+ */
+export const EXHAUSTION_PCT = 99.5;
+
+/**
+ * Default cadence for the consumer-account probe. A consumer account that no
+ * agent shares is probed by the broker itself; 10 min catches exhaustion
+ * within a window at ~6 tiny (haiku) probes/hr per consumer account —
+ * negligible quota. Override with SWITCHROOM_CONSUMER_QUOTA_PROBE_MS; disable
+ * with SWITCHROOM_DISABLE_CONSUMER_QUOTA_PROBE=1 (or interval 0).
+ */
+export const DEFAULT_CONSUMER_PROBE_INTERVAL_MS = 10 * 60 * 1000;
+
+export interface ExhaustionDecision {
+  exhausted: boolean;
+  /**
+   * Epoch ms when the maxed window resets, so the caller can set
+   * `exhausted_until` to the real reset and let it expire (race-free, no
+   * explicit clear). Null when the probe carried no reset — caller falls back
+   * to a default window.
+   */
+  until: number | null;
+}
+
+/**
+ * Decide whether a quota probe indicates the account is exhausted (a hard
+ * wall), and when it resets. PURE — no I/O.
+ *
+ * A FAILED probe is NOT exhaustion. A transient network/probe error must never
+ * fail a consumer over — that was the `all-blocked`-from-stale-probe lesson.
+ * Only a successful probe showing the binding window at/above the wall counts.
+ */
+export function quotaIndicatesExhaustion(result: QuotaResult): ExhaustionDecision {
+  if (!result.ok) return { exhausted: false, until: null };
+  const d = result.data;
+  const fiveBlocked = d.fiveHourUtilizationPct >= EXHAUSTION_PCT;
+  const sevenBlocked = d.sevenDayUtilizationPct >= EXHAUSTION_PCT;
+  if (!fiveBlocked && !sevenBlocked) return { exhausted: false, until: null };
+  // Use the reset of the maxed window; if both are walled, the later one
+  // (the account stays exhausted until the longer window clears).
+  const fiveReset = fiveBlocked ? (d.fiveHourResetAt?.getTime() ?? null) : null;
+  const sevenReset = sevenBlocked ? (d.sevenDayResetAt?.getTime() ?? null) : null;
+  const candidates = [fiveReset, sevenReset].filter((x): x is number => x != null);
+  const until = candidates.length > 0 ? Math.max(...candidates) : null;
+  return { exhausted: true, until };
+}
+
+/**
+ * Resolve the probe interval from env, or the default. Returns 0 when the
+ * sensor is disabled (kill-switch or explicit 0), which the caller treats as
+ * "don't arm the timer".
+ */
+export function resolveConsumerProbeIntervalMs(env: NodeJS.ProcessEnv): number {
+  if (env.SWITCHROOM_DISABLE_CONSUMER_QUOTA_PROBE === "1") return 0;
+  const raw = env.SWITCHROOM_CONSUMER_QUOTA_PROBE_MS;
+  if (raw !== undefined) {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return DEFAULT_CONSUMER_PROBE_INTERVAL_MS;
+}

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -346,6 +346,86 @@ describe("AuthBroker — consumer failover on quota exhaustion", () => {
     broker.stop();
   });
 
+  it("consumer-quota-sensor fails a consumer over with NO agent on the account (the hindsight gap)", async () => {
+    // This is the gap the sensor closes: a consumer pinned to a dedicated
+    // account that NO agent shares (so nobody raises mark-exhausted). The
+    // broker probes it itself and marks it exhausted → serving-failover kicks.
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      consumers: [{ name: "hindsight", account: "secondary" }],
+      // NOTE: no agent on `secondary` — nobody to raise mark-exhausted.
+    });
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
+    // Injected probe: `secondary` is walled (5h at 100%), everything else fine.
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async ({ accessToken }) =>
+        accessToken.includes("secondary")
+          ? { ok: true, data: {
+              fiveHourUtilizationPct: 100,
+              sevenDayUtilizationPct: 10,
+              fiveHourResetAt: new Date(Date.now() + 60 * 60 * 1000),
+              sevenDayResetAt: null,
+              representativeClaim: "five_hour",
+              overageStatus: null,
+              overageDisabledReason: null,
+            } }
+          : { ok: true, data: {
+              fiveHourUtilizationPct: 5,
+              sevenDayUtilizationPct: 5,
+              fiveHourResetAt: null,
+              sevenDayResetAt: null,
+              representativeClaim: null,
+              overageStatus: null,
+              overageDisabledReason: null,
+            } },
+    });
+    await broker.start();
+
+    // Before the probe: pinned account is healthy in the broker's view → served.
+    const before = await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "1", op: "get-credentials",
+    }) as { ok: boolean; data: { account: string } };
+    expect(before.data.account).toBe("secondary");
+
+    // Drive one sensor tick (the timer is disabled in tests).
+    await broker.consumerQuotaProbeTick();
+
+    // Now the consumer fails over to the healthy default — no agent needed.
+    const after = await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "2", op: "get-credentials",
+    }) as { ok: boolean; data: { account: string } };
+    expect(after.data.account).toBe("default");
+    broker.stop();
+  });
+
+  it("consumer-quota-sensor does NOT mark on a probe that is healthy or failed", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      consumers: [{ name: "hindsight", account: "secondary" }],
+    });
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
+    // Probe FAILS for secondary (transient) — must NOT fail the consumer over.
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => ({ ok: false, reason: "HTTP 503" }),
+    });
+    await broker.start();
+    await broker.consumerQuotaProbeTick();
+    const resp = await rpc(join(h.socketRoot, "hindsight", "sock"), {
+      v: 1, id: "1", op: "get-credentials",
+    }) as { ok: boolean; data: { account: string } };
+    // Still served the pinned account — a transient probe error is not exhaustion.
+    expect(resp.data.account).toBe("secondary");
+    broker.stop();
+  });
+
   it("keeps the pinned account when no healthy fallback exists (retry beats nothing)", async () => {
     const h = makeHarness();
     const config = makeConfig(h, {

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -42,6 +42,10 @@ import { dirname, join, resolve } from "node:path";
 import { allocateAgentUid } from "../../agents/compose.js";
 import { resolveAgentsDir } from "../../config/loader.js";
 import { fetchQuota, type QuotaResult } from "../quota.js";
+import {
+  quotaIndicatesExhaustion,
+  resolveConsumerProbeIntervalMs,
+} from "./consumer-quota-sensor.js";
 import type { AuthConfig, AuthConsumer, SwitchroomConfig } from "../../config/schema.js";
 import { atomicWriteFileSync, atomicWriteJsonSync } from "../../util/atomic.js";
 import {
@@ -201,6 +205,9 @@ export interface AuthBrokerOptions {
    * never sets this; the entry point reads from disk.
    */
   _testConfig?: SwitchroomConfig;
+  /** Test-only: replace the quota fetcher so the consumer-probe sensor (and
+   *  probe-quota) can be driven without real api.anthropic.com calls. */
+  _testFetchQuota?: typeof fetchQuota;
 }
 
 /* ───────────────────────── Helpers ───────────────────────── */
@@ -264,6 +271,11 @@ export class AuthBroker {
   private config: SwitchroomConfig;
   private listeners = new Map<string, Listener>();
   private refreshTimer: NodeJS.Timeout | null = null;
+  /** Periodic probe of consumer-pinned accounts → auto mark-exhausted. See
+   *  consumer-quota-sensor.ts. Null when disabled or no consumers. */
+  private consumerProbeTimer: NodeJS.Timeout | null = null;
+  /** Quota fetcher — injectable for tests via opts._testFetchQuota. */
+  private fetchQuotaImpl: typeof fetchQuota;
   private stateDir: string;
   private socketRoot: string;
   private home: string | undefined;
@@ -310,6 +322,7 @@ export class AuthBroker {
     this.now = opts.now ?? nowMs;
     this.operatorUid = opts.operatorUid;
     this.fetcher = opts.fetcher;
+    this.fetchQuotaImpl = opts._testFetchQuota ?? fetchQuota;
     this.stateDir =
       opts.stateDir ?? resolve(this.homeRoot(), ".switchroom", "state", "auth-broker");
     this.socketRoot = opts.socketRoot ?? AUTH_BROKER_ROOT;
@@ -410,6 +423,23 @@ export class AuthBroker {
         });
       }, REFRESH_TICK_INTERVAL_MS);
       this.refreshTimer.unref();
+
+      // Consumer-account quota sensor — periodically probe accounts pinned by
+      // a consumer (e.g. hindsight) and auto mark-exhausted, so a consumer on
+      // a dedicated account no agent shares still fails over (its
+      // serving-failover is wired but otherwise never triggers). Only armed
+      // when enabled AND there is at least one consumer; a no-consumer fleet
+      // pays nothing. See consumer-quota-sensor.ts.
+      const probeMs = resolveConsumerProbeIntervalMs(process.env);
+      const hasConsumers = (this.config.auth?.consumers ?? []).length > 0;
+      if (probeMs > 0 && hasConsumers) {
+        this.consumerProbeTimer = setInterval(() => {
+          this.consumerQuotaProbeTick().catch((err) => {
+            this.logErr(`consumer-quota-probe threw: ${(err as Error).message}`);
+          });
+        }, probeMs);
+        this.consumerProbeTimer.unref();
+      }
     }
 
     // Boot fanout — write per-agent .credentials.json mirrors for every
@@ -448,6 +478,10 @@ export class AuthBroker {
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer);
       this.refreshTimer = null;
+    }
+    if (this.consumerProbeTimer) {
+      clearInterval(this.consumerProbeTimer);
+      this.consumerProbeTimer = null;
     }
     for (const [sock, lis] of this.listeners) {
       try { lis.server.close(); } catch { /* ignore */ }
@@ -1114,7 +1148,7 @@ export class AuthBroker {
           this.audit({ op: "probe-quota", identity, account: label, ok: false, error: "missing-credentials" });
           return { label, result };
         }
-        const result = await fetchQuota({ accessToken: token, timeoutMs });
+        const result = await this.fetchQuotaImpl({ accessToken: token, timeoutMs });
         this.audit({
           op: "probe-quota",
           identity,
@@ -1141,6 +1175,48 @@ export class AuthBroker {
       }),
     );
     socket.write(encodeSuccess(id, { results }));
+  }
+
+  /**
+   * Consumer-account quota sensor tick. Probes every account pinned by a
+   * consumer and, when a probe shows a hard wall, marks it exhausted so the
+   * consumer's serving-failover (consumerAccountWithFailover) kicks in. This
+   * is the missing TRIGGER for a consumer (e.g. hindsight) on a dedicated
+   * account that no agent shares — nothing else ever raises mark-exhausted for
+   * it. Public for tests (driven directly via the `_testFetchQuota` seam).
+   *
+   * Sets `exhausted_until` to the probe's real reset time so it expires
+   * race-free (no explicit clear). A FAILED probe is a no-op (never fail a
+   * consumer over on a transient probe error). Never throws into the timer.
+   */
+  async consumerQuotaProbeTick(): Promise<void> {
+    const accounts = Array.from(
+      new Set((this.config.auth?.consumers ?? []).map((c) => c.account)),
+    );
+    for (const label of accounts) {
+      const creds = readAccountCredentials(label, this.home);
+      const token = creds?.claudeAiOauth?.accessToken;
+      if (!token) continue; // no creds → nothing to probe (don't mark)
+      let result: QuotaResult;
+      try {
+        result = await this.fetchQuotaImpl({ accessToken: token });
+      } catch (err) {
+        this.logErr(`consumer-quota-probe ${label}: ${(err as Error).message}`);
+        continue;
+      }
+      const decision = quotaIndicatesExhaustion(result);
+      if (!decision.exhausted) continue;
+      const exhaustedUntil = decision.until ?? this.now() + MARK_EXHAUSTED_DEFAULT_MS;
+      // Idempotent: skip the write/persist if already marked at/past this reset.
+      const existing = this.quota[label]?.exhausted_until;
+      if (existing !== undefined && existing >= exhaustedUntil) continue;
+      this.quota[label] = { exhausted_until: exhaustedUntil };
+      this.persistQuota();
+      this.audit({ op: "mark-exhausted", identity: { kind: "operator" }, account: label, ok: true });
+      process.stdout.write(
+        `auth-broker: consumer-quota-sensor marked ${label} exhausted until ${new Date(exhaustedUntil).toISOString()} — consumer(s) fail over\n`,
+      );
+    }
   }
 
   private async opSetActive(


### PR DESCRIPTION
## Summary

Closes the one gap the v0.14.80 auto-fallback fix left open: **hindsight (a consumer) doesn't fail over.**

Hindsight pins a *dedicated* Anthropic account, deliberately kept out of `fallback_order` for quota isolation. Its serving-failover is already wired (#2194 `consumerAccountWithFailover`), but the exhaustion state it keys off (`this.quota[account]`) is **only** ever set by `mark-exhausted` — which **agents** raise when their gateway sees a 429. An account that **no agent shares** has nobody to raise it, so the failover never triggers and hindsight sits dead on an exhausted account (the **2026-06-06 outage**). The broker has no quota-probe loop — the only timer refreshes tokens.

This adds a broker-side **sensor**: periodically probe consumer-pinned accounts and auto `mark-exhausted` when a probe shows a hard wall, so the consumer's serving-failover kicks in — then it reverts automatically when the window resets.

## Design
- `consumer-quota-sensor.ts` — **pure** decision (`quotaIndicatesExhaustion`) + interval resolver. Wall threshold (99.5%) matches `classifyHealth`'s `blocked`.
- `exhausted_until` is set to the probe's **real reset time**, so it expires race-free (no explicit clear that could fight an agent's `mark-exhausted`).
- A **FAILED probe is a no-op** — a transient probe error must never fail a consumer over (the `all-blocked`-from-stale-probe lesson).
- `server.ts` — `fetchQuota` made injectable (`_testFetchQuota` seam; also routes `opProbeQuota`); `consumerProbeTimer` armed in `start()` **only when enabled AND consumers exist** (a no-consumer fleet pays nothing), cleared in `stop()`; `consumerQuotaProbeTick()` probes → marks (idempotent, audited, logged).
- **Only marks** — never changes `auth.active`, never touches agent creds.

## Config
- Default cadence **10 min** (~6 tiny haiku probes/hr per consumer account — negligible quota).
- `SWITCHROOM_CONSUMER_QUOTA_PROBE_MS` to tune · `SWITCHROOM_DISABLE_CONSUMER_QUOTA_PROBE=1` (or `0`) to disable.

## Test plan
- [x] pure: exhaustion decision across 5h/7d/both/no-reset/**failed-probe**; interval resolver (default/kill-switch/override/garbage)
- [x] broker integration (via `_testFetchQuota`): a consumer with **no agent** on its account **fails over after one sensor tick** (the exact gap); a failed/healthy probe does **not** fail it over
- [x] `vitest src/auth` 295 green · `tsc --noEmit` clean

## Risk
Low. Purely additive — a new opt-in timer that only marks exhaustion (the same state `mark-exhausted` already sets) and only for consumer-pinned accounts. Off-switch + interval knob. Builds on v0.14.80.

## Rollout
Auth-broker singleton recreate (same as v0.14.80) — the sensor runs in the broker. Verify on test-harness, watch for the `consumer-quota-sensor marked … exhausted` log if hindsight's account ever walls.

## Follow-up
Cron preflight + retry (the last of the three failover gaps) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)