### PR TITLE
fix(web): Microsoft connect — stop double-submit (2 emails) + survive web restart

### DIFF
--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -606,7 +606,7 @@
             <div id="ms-connect-status" style="color:var(--text-dim);margin-top:.3rem">Waiting for sign-in… (this card expires in ~15 min)</div>
           </div>`);
         const statusEl = () => document.getElementById('ms-connect-status');
-        const started = Date.now();
+        const deadline = Date.now() + ((data.expiresInSec || 900) * 1000 + 30000);
         const showConnected = (label) => {
           show(`<div class="loading" style="padding:.8rem;color:var(--green)">✓ Connected ${escapeHtml(label)}. Use the access toggles below to grant an agent.</div>`);
           fetchConnections();
@@ -615,6 +615,11 @@
         // re-check the broker's actual account list before declaring failure:
         // a new account appearing means the connect really succeeded (e.g. the
         // status was lost to a web restart). Only error if nothing new landed.
+        // Limitations (acceptable — the in-memory 'connected' state is the
+        // primary signal; this is only the lost-status fallback): a concurrent
+        // connect of a DIFFERENT account in another tab/CLI could be mistaken
+        // for this one; and re-connecting an ALREADY-known account (token
+        // refresh) shows no new account so falls through to the error.
         const settleNonConnected = async (reason) => {
           const after = await fetchMicrosoftAccountEmails();
           const fresh = [...after].find(a => !before.has(a));
@@ -622,10 +627,22 @@
           done();
         };
         const poll = async () => {
-          const sres = await fetch(`${API}/api/connections/microsoft/connect/${encodeURIComponent(data.requestId)}`, { headers: authHeaders() });
-          const s = sres.ok ? await sres.json() : { state: 'failed', reason: `HTTP ${sres.status}` };
+          let s;
+          try {
+            const sres = await fetch(`${API}/api/connections/microsoft/connect/${encodeURIComponent(data.requestId)}`, { headers: authHeaders() });
+            s = sres.ok ? await sres.json() : { state: 'failed', reason: `HTTP ${sres.status}` };
+          } catch {
+            // Transient fetch failure — most likely the web process restarting
+            // mid-connect (the exact case this flow must survive). Don't die
+            // (that would strand msConnecting=true and lock the button): keep
+            // polling until the device-code deadline, then settle via the
+            // broker re-check (which recovers a token stored before the restart).
+            if (Date.now() > deadline) { await settleNonConnected('connection lost'); return; }
+            setTimeout(poll, 3000);
+            return;
+          }
           if (s.state === 'pending') {
-            if (Date.now() - started > ((data.expiresInSec || 900) * 1000 + 30000)) { const e = statusEl(); if (e) e.textContent = 'Expired — click Connect to try again.'; done(); return; }
+            if (Date.now() > deadline) { const e = statusEl(); if (e) e.textContent = 'Expired — click Connect to try again.'; done(); return; }
             setTimeout(poll, 3000);
             return;
           }

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -559,16 +559,42 @@
       }
     }
 
+    // Guards a second click from starting a second device-code flow (each
+    // start makes Microsoft send a sign-in email → the "2 emails" bug).
+    let msConnecting = false;
+
+    // The set of Microsoft account emails currently known to the broker.
+    // Used as a resilience baseline: the connect status lives only in the web
+    // process's memory, so if that process restarts mid-connect the status
+    // reads 'unknown' even when the token WAS stored. Diffing this list tells
+    // us the account really connected regardless of the lost status.
+    async function fetchMicrosoftAccountEmails() {
+      try {
+        const r = await fetch(`${API}/api/microsoft-accounts`, { headers: authHeaders() });
+        if (!r.ok) return new Set();
+        const list = await r.json();
+        return new Set((list || []).filter(a => a.brokerKnown).map(a => String(a.account).toLowerCase()));
+      } catch { return new Set(); }
+    }
+
     // Start an in-browser Microsoft connect: show the device code + link,
     // then poll until the operator completes sign-in on Microsoft's site.
     async function connectMicrosoft() {
+      if (msConnecting) return;              // double-submit guard
+      msConnecting = true;
+      const btn = document.getElementById('ms-connect-btn');
+      if (btn) btn.disabled = true;
+      const done = () => { msConnecting = false; const b = document.getElementById('ms-connect-btn'); if (b) b.disabled = false; };
       const card = document.getElementById('ms-connect-card');
       const show = (html) => { if (card) card.innerHTML = html; };
       show('<div class="loading" style="padding:.8rem">Starting…</div>');
+      // Snapshot already-connected accounts BEFORE starting, for the
+      // restart-resilient terminal check below.
+      const before = await fetchMicrosoftAccountEmails();
       try {
         const res = await fetch(`${API}/api/connections/microsoft/connect`, { method: 'POST', headers: authHeaders() });
         const data = await res.json();
-        if (!res.ok || !data.ok) { show(''); showError(data.error || `HTTP ${res.status}`); return; }
+        if (!res.ok || !data.ok) { show(''); showError(data.error || `HTTP ${res.status}`); done(); return; }
         const url = data.verificationUri, code = data.userCode;
         show(`<div class="account-card" style="border-color:var(--accent)">
             <div class="account-card-header"><div class="account-label">Connect a Microsoft account</div></div>
@@ -581,26 +607,40 @@
           </div>`);
         const statusEl = () => document.getElementById('ms-connect-status');
         const started = Date.now();
+        const showConnected = (label) => {
+          show(`<div class="loading" style="padding:.8rem;color:var(--green)">✓ Connected ${escapeHtml(label)}. Use the access toggles below to grant an agent.</div>`);
+          fetchConnections();
+        };
+        // On any non-'connected' terminal state ('failed' or 'unknown'),
+        // re-check the broker's actual account list before declaring failure:
+        // a new account appearing means the connect really succeeded (e.g. the
+        // status was lost to a web restart). Only error if nothing new landed.
+        const settleNonConnected = async (reason) => {
+          const after = await fetchMicrosoftAccountEmails();
+          const fresh = [...after].find(a => !before.has(a));
+          if (fresh) { showConnected(fresh); } else { show(''); showError(reason || 'connect failed'); }
+          done();
+        };
         const poll = async () => {
           const sres = await fetch(`${API}/api/connections/microsoft/connect/${encodeURIComponent(data.requestId)}`, { headers: authHeaders() });
           const s = sres.ok ? await sres.json() : { state: 'failed', reason: `HTTP ${sres.status}` };
           if (s.state === 'pending') {
-            if (Date.now() - started > ((data.expiresInSec || 900) * 1000 + 30000)) { const e = statusEl(); if (e) e.textContent = 'Expired — click Connect to try again.'; return; }
+            if (Date.now() - started > ((data.expiresInSec || 900) * 1000 + 30000)) { const e = statusEl(); if (e) e.textContent = 'Expired — click Connect to try again.'; done(); return; }
             setTimeout(poll, 3000);
             return;
           }
           if (s.state === 'connected') {
-            show(`<div class="loading" style="padding:.8rem;color:var(--green)">✓ Connected ${escapeHtml(s.account)} (${escapeHtml(s.accountType)}). Use the access toggles below to grant an agent.</div>`);
-            fetchConnections();
+            showConnected(`${s.account} (${s.accountType})`);
+            done();
           } else {
-            show('');
-            showError(s.reason || 'connect failed');
+            await settleNonConnected(s.reason);
           }
         };
         setTimeout(poll, 3000);
       } catch (err) {
         show('');
         showError(err.message);
+        done();
       }
     }
 
@@ -1165,7 +1205,7 @@
         <div style="margin-bottom:1.5rem">
           <h3 style="margin:0 0 .6rem;font-size:.95rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.04em">
             Microsoft 365
-            <button onclick="connectMicrosoft()" class="usage-pill primary" style="margin-left:.6rem;cursor:pointer;border:none;text-transform:none;font-weight:600">+ Connect a Microsoft account</button>
+            <button id="ms-connect-btn" onclick="connectMicrosoft()" class="usage-pill primary" style="margin-left:.6rem;cursor:pointer;border:none;text-transform:none;font-weight:600">+ Connect a Microsoft account</button>
           </h3>
           <div id="ms-connect-card"></div>
           ${msCards


### PR DESCRIPTION
## Summary
Fixes the two bugs hit connecting a Microsoft account from the admin dashboard: **two sign-in emails** per connect, and **"the tile disappears but doesn't connect."**

## Root causes
1. **Double-submit → 2 emails.** The Connect button had no in-flight guard. The device-code round-trip isn't instant, so a second click started a second device-code flow — and Microsoft sends a sign-in email *per device code*.
2. **"Disappears, doesn't connect."** The connect status lives only in-memory in the web process (`microsoftConnectStatuses`). When the web container restarts mid-connect (e.g. during a fleet roll — which is exactly what happened), the status reads `unknown` even though the background poll may have already stored the token in the broker. The frontend treated any non-`connected` terminal as a hard failure: cleared the card + error toast. (Confirmed live: the account WAS stored — `/api/microsoft-accounts` returns it `brokerKnown:true` — yet the UI showed failure.)

## Fixes (frontend only — `src/web/ui/index.html`)
- **`msConnecting` guard** + disable the `#ms-connect-btn` button while a connect is in flight; reset on every terminal state so retry-after-failure still works.
- **Restart-resilient terminal check:** snapshot the broker's known MS accounts before starting; on `failed`/`unknown`, re-fetch and diff — a newly-appeared account means it really connected (show success), else show the error. The broker (not the web process's memory) becomes the source of truth for "did it connect."

## Test plan
- [x] JS syntax of the embedded script validated (`node --check` on the extracted block)
- [x] `tsc --noEmit` clean
- [ ] **Live canary** after deploy: connect a MS account from the dashboard → exactly one email, card resolves to ✓ Connected; restart the web container mid-connect → still resolves to connected (no spurious failure).

## Notes
- `index.html` is served static (build copies `src/web/ui` → `dist/cli/ui`); deploys via the `switchroom-web:latest` image + container recreate.
- Out of scope (separate, pre-existing, and not what was hit): the dashboard connect registers the token with the broker but doesn't write a `microsoft_accounts` yaml entry — but the dashboard already displays broker-known accounts, so this is a CLI/dashboard consistency nicety, not the failure here. Server-side double-submit dedup (multi-tab) is possible follow-up hardening; the frontend guard covers the real double-click case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)