### PR TITLE
feat(quota-watch): fleet-wide all-exhausted operator alert

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -412,6 +412,8 @@ import {
 } from '../credits-watch.js'
 import {
   evaluateQuotaWatchAccount,
+  evaluateFleetAllExhausted,
+  FLEET_ALL_EXHAUSTED_KEY,
   loadQuotaWatchState,
   saveQuotaWatchState,
   patchQuotaWatchState,
@@ -14804,6 +14806,44 @@ async function runQuotaWatch(): Promise<void> {
   let watchState = loadQuotaWatchState(stateDir)
   const now = Date.now()
   const access = loadAccess()
+
+  // Fleet-wide all-exhausted check FIRST — must run before the per-account
+  // early-return below. When every account is exhausted, the per-account loop
+  // produces only 'blocked' skips → pendingTransitions empty → early return;
+  // so this fleet-level alert (the one the trigger-based all-blocked card
+  // misses during quiet periods / for the consumer+cron paths) would never
+  // fire if placed after. Authoritative source: broker `exhausted` flags.
+  {
+    const fleetPrev = watchState[FLEET_ALL_EXHAUSTED_KEY] ?? emptyAccountState()
+    const fleetDecision = evaluateFleetAllExhausted({
+      accounts: listStateData.accounts,
+      prev: fleetPrev,
+      now,
+    })
+    if (fleetDecision.kind === 'notify') {
+      for (const chat_id of access.allowFrom) {
+        await swallowingApiCall(
+          () =>
+            bot.api.sendMessage(chat_id, fleetDecision.message, {
+              parse_mode: 'HTML',
+              link_preview_options: { is_disabled: true },
+            }),
+          { chat_id, verb: 'quota-watch.fleet-all-exhausted' },
+        )
+      }
+      // Persist immediately — the per-account early-return path below would
+      // otherwise drop this flag change (edge-trigger would re-fire next poll).
+      watchState = patchQuotaWatchState(watchState, FLEET_ALL_EXHAUSTED_KEY, fleetDecision.newState)
+      try {
+        saveQuotaWatchState(stateDir, watchState)
+      } catch (err) {
+        process.stderr.write(`telegram gateway: quota-watch: fleet-state save failed: ${err}\n`)
+      }
+      process.stderr.write(
+        `telegram gateway: quota-watch: fleet all-exhausted ${fleetDecision.transition}\n`,
+      )
+    }
+  }
 
   // First pass: evaluate all accounts against cached state. Collect
   // labels that need a live probe (i.e. accounts with a detected transition

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -160,6 +160,99 @@ export function evaluateQuotaWatchAccount(args: {
   return { kind: "skip", accountLabel: label, reason: "no-matching-transition" };
 }
 
+// ─── Fleet-level: all accounts exhausted ───────────────────────────────────────
+
+/**
+ * Reserved key under which the fleet-wide "all accounts exhausted" alert state
+ * is stored in the same quota-watch.json map. Not a valid account label (emails
+ * can't contain this), so it never collides with a per-account entry, and the
+ * per-account loop (which iterates account snapshots, not state-map keys) never
+ * sees it. Encoded as a QuotaWatchAccountState so the existing load validator
+ * accepts it: lastNotifiedHealth "throttling" = currently alerting all-exhausted,
+ * "healthy"/null = not. Backward-compatible — old files simply lack the key.
+ */
+export const FLEET_ALL_EXHAUSTED_KEY = "__fleet_all_exhausted__";
+
+export type FleetAllExhaustedDecision =
+  | { kind: "notify"; message: string; newState: QuotaWatchAccountState; transition: "entered" | "recovered" }
+  | { kind: "skip"; reason: string };
+
+/**
+ * Fleet-wide all-exhausted alert (edge-triggered).
+ *
+ * Fires ONCE when every account enters the broker's exhausted state (no healthy
+ * account to fail over to — agents go quiet, crons defer, consumers/hindsight
+ * silently serve an exhausted account), and ONCE on recovery. This catches the
+ * cases the trigger-based interactive all-blocked card misses: a quiet period
+ * (no agent happens to 429 into the wall) and the consumer/cron paths.
+ *
+ * Authoritative source: the broker's per-account `exhausted` flag (set by
+ * mark-exhausted via failover + the consumer sensor), NOT probe-derived health
+ * — so there is no probe-failure false-alarm. Requires at least one account;
+ * an empty fleet never alerts.
+ */
+export function evaluateFleetAllExhausted(args: {
+  accounts: Array<{ label: string; exhausted: boolean; exhausted_until?: number }>;
+  prev: QuotaWatchAccountState;
+  now: number;
+}): FleetAllExhaustedDecision {
+  const { accounts, prev, now } = args;
+  const allExhausted = accounts.length > 0 && accounts.every((a) => a.exhausted);
+  // "throttling" doubles as the "currently alerting all-exhausted" marker.
+  const wasAlerting = prev.lastNotifiedHealth === "throttling";
+
+  if (allExhausted && !wasAlerting) {
+    return {
+      kind: "notify",
+      message: buildAllExhaustedMessage(accounts, now),
+      newState: { lastNotifiedHealth: "throttling", lastNotifiedAt: now },
+      transition: "entered",
+    };
+  }
+  if (!allExhausted && wasAlerting) {
+    return {
+      kind: "notify",
+      message: buildFleetRecoveredMessage(accounts),
+      newState: { lastNotifiedHealth: "healthy", lastNotifiedAt: now },
+      transition: "recovered",
+    };
+  }
+  return { kind: "skip", reason: allExhausted ? "still-all-exhausted" : "not-all-exhausted" };
+}
+
+function buildAllExhaustedMessage(
+  accounts: Array<{ label: string; exhausted_until?: number }>,
+  now: number,
+): string {
+  const resets = accounts
+    .map((a) => a.exhausted_until)
+    .filter((x): x is number => typeof x === "number" && x > now);
+  const earliest = resets.length > 0 ? Math.min(...resets) : null;
+  const resetLine = earliest
+    ? `Earliest reset: ${formatRelative(new Date(earliest), new Date(now))}.`
+    : `Reset time unknown (no window data).`;
+  return [
+    `🔴 <b>All accounts exhausted</b>`,
+    ``,
+    `Every Anthropic account (${accounts.length}) is quota-walled — there is no healthy account to fail over to.`,
+    resetLine,
+    ``,
+    `<i>This is self-healing: agents resume and deferred scheduled jobs run automatically once a window resets. Nothing is lost. Add headroom with <code>/auth add</code> if this recurs.</i>`,
+  ].join("\n");
+}
+
+function buildFleetRecoveredMessage(
+  accounts: Array<{ label: string; exhausted: boolean }>,
+): string {
+  const healthy = accounts.filter((a) => !a.exhausted).map((a) => a.label);
+  const which = healthy.length > 0 ? ` (<code>${escapeHtml(healthy[0]!)}</code>)` : "";
+  return [
+    `🟢 <b>Fleet recovered</b> — at least one account is healthy again${which}.`,
+    ``,
+    `<i>Agents are back; any deferred scheduled jobs will run on their next occurrence.</i>`,
+  ].join("\n");
+}
+
 // ─── Message builders ─────────────────────────────────────────────────────────
 
 function buildThrottlingMessage(agentName: string, snap: AccountSnapshot): string {

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   evaluateQuotaWatchAccount,
+  evaluateFleetAllExhausted,
   loadQuotaWatchState,
   saveQuotaWatchState,
   patchQuotaWatchState,
@@ -362,5 +363,76 @@ describe("patchQuotaWatchState", () => {
     };
     patchQuotaWatchState(current, "bob@example.com", { lastNotifiedHealth: null, lastNotifiedAt: 0 });
     expect(current["bob@example.com"]).toBeUndefined();
+  });
+});
+
+describe("evaluateFleetAllExhausted", () => {
+  const notAlerting = { lastNotifiedHealth: null, lastNotifiedAt: 0 };
+  const alerting = { lastNotifiedHealth: "throttling" as const, lastNotifiedAt: 1000 };
+
+  it("notifies (entered) when every account is exhausted and we weren't alerting", () => {
+    const d = evaluateFleetAllExhausted({
+      accounts: [
+        { label: "a", exhausted: true, exhausted_until: 5_000 },
+        { label: "b", exhausted: true, exhausted_until: 9_000 },
+      ],
+      prev: notAlerting,
+      now: 1_000,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind === "notify") {
+      expect(d.transition).toBe("entered");
+      expect(d.newState.lastNotifiedHealth).toBe("throttling");
+      expect(d.message).toContain("All accounts exhausted");
+      // earliest reset is the 5_000 one
+      expect(d.message).toContain("Earliest reset");
+    }
+  });
+
+  it("skips (still) when all exhausted and already alerting — no re-spam", () => {
+    const d = evaluateFleetAllExhausted({
+      accounts: [{ label: "a", exhausted: true }, { label: "b", exhausted: true }],
+      prev: alerting,
+      now: 2_000,
+    });
+    expect(d.kind).toBe("skip");
+  });
+
+  it("notifies (recovered) when one account frees after we were alerting", () => {
+    const d = evaluateFleetAllExhausted({
+      accounts: [{ label: "a", exhausted: false }, { label: "b", exhausted: true }],
+      prev: alerting,
+      now: 3_000,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind === "notify") {
+      expect(d.transition).toBe("recovered");
+      expect(d.newState.lastNotifiedHealth).toBe("healthy");
+      expect(d.message).toContain("Fleet recovered");
+      expect(d.message).toContain("a"); // names the healthy account
+    }
+  });
+
+  it("skips (not-all) when some account is healthy and we weren't alerting", () => {
+    const d = evaluateFleetAllExhausted({
+      accounts: [{ label: "a", exhausted: false }, { label: "b", exhausted: true }],
+      prev: notAlerting,
+      now: 4_000,
+    });
+    expect(d.kind).toBe("skip");
+  });
+
+  it("never alerts on an empty fleet", () => {
+    expect(evaluateFleetAllExhausted({ accounts: [], prev: notAlerting, now: 1 }).kind).toBe("skip");
+  });
+
+  it("shows reset-unknown when no exhausted_until is present", () => {
+    const d = evaluateFleetAllExhausted({
+      accounts: [{ label: "a", exhausted: true }],
+      prev: notAlerting,
+      now: 1_000,
+    });
+    expect(d.kind).toBe("notify");
+    if (d.kind === "notify") expect(d.message).toContain("Reset time unknown");
   });
 });


### PR DESCRIPTION
## Summary

A fleet-wide **all-accounts-exhausted** alert — the one piece of operator visibility the failover trilogy (#2206/#2209/#2212) didn't cover.

The existing trigger-based all-blocked card only fires when an **agent** 429s into the wall. It misses two now-real cases:
- a **quiet period** — the fleet goes all-exhausted but no agent happens to hit it, so you're never told;
- the **consumer (hindsight)** and **cron** paths added in v0.14.81/82, which degrade *silently* (hindsight serves an exhausted account; crons defer to the JSONL audit).

The broker is a separate container with no Telegram path, so it can't alert itself. `quota-watch` already polls broker `listState`, classifies health, and posts with edge-trigger dedup — but had no fleet-level tier. This adds one.

## Design
- **`evaluateFleetAllExhausted`** (pure, edge-triggered) — fires **once** on entering all-exhausted (with earliest-reset line + self-healing reassurance) and **once** on recovery. Keyed off the broker's **authoritative** per-account `exhausted` flag (set by mark-exhausted via failover + the consumer sensor), **not** probe-derived health — so there is **no probe-failure false alarm**.
- State stored under a reserved key in the existing `quota-watch.json` — backward-compatible, survives the load validator, and the per-account loop (which iterates account snapshots, not state-map keys) never sees it.
- **`runQuotaWatch`** — the fleet check runs **before** the per-account early-return (all-exhausted means the per-account loop is all skips → it would return early), sends via the existing `swallowingApiCall` path, and persists immediately so the edge-trigger doesn't re-fire.

## Re-scope note (important)
This **supersedes** the originally-proposed "split all-blocked vs probe-failed in logs." Post-v0.14.80 the all-blocked decision is **broker-authoritative** (`rolledTo===null`), so that log ambiguity no longer exists — the genuine gap was the missing quiet-period/consumer/cron alert, which this fills. I verified that before building rather than ship the now-redundant log split.

## What it is NOT
Observability only — **no behavior/recovery change.** Failover, defer/retry, and self-healing are all unchanged. Purely additive; reuses the existing poll + dedup + send infra.

## Test plan
- [x] pure: entered / still (no re-spam) / recovered / not-all / empty-fleet / reset-unknown — 6 cases
- [x] runs under **both** vitest AND bun (30 tests in file, 0 fail)
- [x] `tsc --noEmit` clean; `check-bot-api-wrapping.sh` clean (new send wrapped); `check-plugin-references.mjs` clean

## Risk
Very low. New edge-triggered alert on authoritative state; dedup prevents spam; off the hot path; no decision/behavior change. Worst case is a missed alert (fails safe), never a wrong action.

## Rollout
Gateway change → fleet agent restart (sidecar), staggered + version-asserted. Or fold into the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)