### PR TITLE
fix(web): dashboard health — stop falsely reporting hindsight/agents DOWN

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import {
@@ -10,10 +10,9 @@ import {
   containerName,
 } from "../agents/lifecycle.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
-import { getCollectionForAgent } from "../memory/hindsight.js";
+import { getCollectionForAgent, probeHindsight } from "../memory/hindsight.js";
 import {
   getHindsightStatus,
-  isHindsightRunning,
 } from "../setup/hindsight.js";
 import {
   defaultAuditLogPath,
@@ -98,9 +97,30 @@ export interface AgentInfo {
   memoryCollection: string;
 }
 
+/**
+ * Docker-free agent-liveness check for the web container: an agent's gateway
+ * touches `<agentsDir>/<name>/telegram/.bridge-alive` every ~5s (bridge
+ * heartbeat). A mtime within `maxAgeMs` means the gateway is live. Returns
+ * false on any error (missing file / unreadable) — i.e. treat as not-alive.
+ */
+export function agentBridgeAlive(
+  agentsDir: string,
+  name: string,
+  maxAgeMs = 30_000,
+  now: number = Date.now(),
+): boolean {
+  try {
+    const f = resolve(agentsDir, name, "telegram", ".bridge-alive");
+    return now - statSync(f).mtimeMs <= maxAgeMs;
+  } catch {
+    return false;
+  }
+}
+
 export function handleGetAgents(config: SwitchroomConfig): AgentInfo[] {
   const statuses = getAllAgentStatuses(config);
   const authStatuses = getAllAuthStatuses(config);
+  const agentsDir = resolveAgentsDir(config);
   const agents: AgentInfo[] = [];
 
   for (const [name, agentConfig] of Object.entries(config.agents)) {
@@ -112,9 +132,22 @@ export function handleGetAgents(config: SwitchroomConfig): AgentInfo[] {
     // `auth.active`. No more per-agent fallback list.
     const primaryAccount = resolved.auth?.override ?? config.auth?.active;
 
+    // `getAllAgentStatuses` derives `active` from `docker ps`, which throws in
+    // the dockerless web container → every agent reads "inactive". Fall back to
+    // the gateway's `.bridge-alive` heartbeat (touched every ~5s; web mounts
+    // the agents dir): a fresh mtime means the gateway is live. Only used when
+    // the docker signal isn't already "active", so docker-context callers are
+    // unchanged.
+    const active =
+      status?.active === "active"
+        ? "active"
+        : agentBridgeAlive(agentsDir, name)
+          ? "active"
+          : (status?.active ?? "unknown");
+
     agents.push({
       name,
-      active: status?.active ?? "unknown",
+      active,
       uptime: status?.uptime ?? null,
       memory: status?.memory ?? null,
       extends: agentConfig.extends ?? "default",
@@ -590,6 +623,7 @@ function inspectEnv(
 }
 
 export async function handleGetSystemHealth(
+  config?: SwitchroomConfig,
   home?: string,
 ): Promise<SystemHealth> {
   // ── auth-broker ──────────────────────────────────────────────────
@@ -615,25 +649,38 @@ export async function handleGetSystemHealth(
   }
 
   // ── hindsight ────────────────────────────────────────────────────
-  const containerStatus = getHindsightStatus();
-  const running = isHindsightRunning();
-  const env = running
-    ? inspectEnv("switchroom-hindsight", [
-        "HINDSIGHT_API_LLM_MODEL",
-        "HINDSIGHT_API_LLM_PROVIDER",
-        "HINDSIGHT_API_MCP_STATELESS",
-      ])
-    : {
-        HINDSIGHT_API_LLM_MODEL: null,
-        HINDSIGHT_API_LLM_PROVIDER: null,
-        HINDSIGHT_API_MCP_STATELESS: null,
-      };
+  // "running" must come from an HTTP probe, NOT `docker ps`: the web
+  // container is dockerless by design (no socket mounted), so the docker
+  // helpers below throw and would falsely report hindsight DOWN even when it
+  // is serving. The web reaches hindsight over host networking, so probe its
+  // MCP endpoint — which also tests that it's actually *serving*, not merely
+  // that a container exists. The docker-based fields (containerStatus, env)
+  // stay best-effort: populated when docker IS available (CLI/host context),
+  // null in the web container — but they no longer gate the running dot.
+  const memoryUrl =
+    (config?.memory?.config?.url as string | undefined) ??
+    "http://127.0.0.1:18888/mcp/";
+  let running = false;
+  try {
+    running = (await probeHindsight(memoryUrl)).ok;
+  } catch {
+    running = false;
+  }
+  const containerStatus = getHindsightStatus(); // null without docker
+  const env = inspectEnv("switchroom-hindsight", [
+    "HINDSIGHT_API_LLM_MODEL",
+    "HINDSIGHT_API_LLM_PROVIDER",
+    "HINDSIGHT_API_MCP_STATELESS",
+  ]); // all null without docker — fine, the dot comes from `running`
   const statelessRaw = env.HINDSIGHT_API_MCP_STATELESS;
   const hindsight: SystemHealth["hindsight"] = {
     containerStatus,
     running,
     model: env.HINDSIGHT_API_LLM_MODEL,
-    provider: env.HINDSIGHT_API_LLM_PROVIDER,
+    // Fall back to the configured provider when docker inspect is unavailable.
+    provider:
+      env.HINDSIGHT_API_LLM_PROVIDER ??
+      ((config?.memory?.config?.provider as string | undefined) ?? null),
     mcpStateless:
       statelessRaw == null ? null : statelessRaw.toLowerCase() === "true",
   };

--- a/src/web/dashboard-health.test.ts
+++ b/src/web/dashboard-health.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { agentBridgeAlive } from "./api.js";
+
+/**
+ * The web container is dockerless by design, so the dashboard's agent-liveness
+ * must come from the gateway's `.bridge-alive` heartbeat file (touched ~every
+ * 5s), not `docker ps`. These pin that fallback.
+ */
+describe("agentBridgeAlive (dockerless agent liveness)", () => {
+  let agentsDir: string;
+  const NOW = 1_780_000_000_000;
+
+  beforeEach(() => {
+    agentsDir = mkdtempSync(join(tmpdir(), "sr-bridge-alive-"));
+  });
+  afterEach(() => {
+    rmSync(agentsDir, { recursive: true, force: true });
+  });
+
+  function writeHeartbeat(name: string, mtimeMs: number): void {
+    const dir = join(agentsDir, name, "telegram");
+    mkdirSync(dir, { recursive: true });
+    const f = join(dir, ".bridge-alive");
+    writeFileSync(f, "");
+    const secs = mtimeMs / 1000;
+    utimesSync(f, secs, secs);
+  }
+
+  it("is alive when the heartbeat mtime is within the window", () => {
+    writeHeartbeat("clerk", NOW - 4_000); // 4s old — fresh
+    expect(agentBridgeAlive(agentsDir, "clerk", 30_000, NOW)).toBe(true);
+  });
+
+  it("is alive exactly at the window boundary", () => {
+    writeHeartbeat("clerk", NOW - 30_000);
+    expect(agentBridgeAlive(agentsDir, "clerk", 30_000, NOW)).toBe(true);
+  });
+
+  it("is NOT alive when the heartbeat is stale (gateway dead)", () => {
+    writeHeartbeat("clerk", NOW - 120_000); // 2 min old
+    expect(agentBridgeAlive(agentsDir, "clerk", 30_000, NOW)).toBe(false);
+  });
+
+  it("is NOT alive when the heartbeat file is missing", () => {
+    // no file written
+    expect(agentBridgeAlive(agentsDir, "ghost", 30_000, NOW)).toBe(false);
+  });
+
+  it("is NOT alive when the agent dir doesn't exist at all", () => {
+    expect(agentBridgeAlive(join(agentsDir, "nope"), "x", 30_000, NOW)).toBe(false);
+  });
+});

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -637,7 +637,7 @@ export function startWebServer(
           }
 
           case "getSystemHealth":
-            return (async () => jsonResponse(await handleGetSystemHealth()))();
+            return (async () => jsonResponse(await handleGetSystemHealth(config)))();
 
           case "getGoogleAccounts":
             return (async () =>

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -83,6 +83,13 @@ vi.mock("../src/setup/hindsight.js", () => ({
   isHindsightRunning: vi.fn(() => false),
 }));
 
+// `running` now comes from an HTTP probe (probeHindsight), not docker.
+// Mock it; keep getCollectionForAgent real.
+vi.mock("../src/memory/hindsight.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/memory/hindsight.js")>();
+  return { ...actual, probeHindsight: vi.fn(async () => ({ ok: false, reason: "test-default" })) };
+});
+
 import {
   handleGetAgents,
   handleStartAgent,
@@ -116,7 +123,8 @@ import {
 import { isOriginAllowed, isTailscaleIdentified } from "../src/web/server.js";
 import { getAllAgentStatuses, startAgent, stopAgent, restartAgent } from "../src/agents/lifecycle.js";
 import { getAllAuthStatuses } from "../src/auth/manager.js";
-import { getHindsightStatus, isHindsightRunning } from "../src/setup/hindsight.js";
+import { getHindsightStatus } from "../src/setup/hindsight.js";
+import { probeHindsight } from "../src/memory/hindsight.js";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -499,7 +507,10 @@ describe("handleGetSystemHealth", () => {
     vi.clearAllMocks();
     brokerImpl.run = null;
     asMock(getHindsightStatus).mockReturnValue(null);
-    asMock(isHindsightRunning).mockReturnValue(false);
+    asMock(probeHindsight).mockResolvedValue({ ok: false, reason: "test-default" });
+    // Default: docker inspect unavailable (no docker) → inspectEnv yields nulls.
+    // clearAllMocks() resets call history but NOT return values, so reset here.
+    asMock(spawnSync).mockReturnValue({ status: 1, stdout: "", stderr: "no docker" } as never);
     home = mkdtempSync(join(tmpdir(), "syshealth-"));
   });
 
@@ -519,7 +530,7 @@ describe("handleGetSystemHealth", () => {
         }),
       });
 
-    const h = await handleGetSystemHealth(home);
+    const h = await handleGetSystemHealth(undefined, home);
     expect(h.broker.reachable).toBe(true);
     expect(h.broker.active).toBe("ken@example.com");
     expect(h.broker.accounts).toBe(2);
@@ -529,7 +540,7 @@ describe("handleGetSystemHealth", () => {
 
   it("reports broker unreachable without throwing", async () => {
     brokerImpl.run = null; // withAuthBrokerClient throws FakeUnreachable
-    const h = await handleGetSystemHealth(home);
+    const h = await handleGetSystemHealth(undefined, home);
     expect(h.broker.reachable).toBe(false);
     expect(h.broker.error).toContain("broker down");
   });
@@ -538,14 +549,14 @@ describe("handleGetSystemHealth", () => {
     brokerImpl.run = async () => {
       throw new brokerHoist.FakeBrokerError("EPROTO", "bad frame");
     };
-    const h = await handleGetSystemHealth(home);
+    const h = await handleGetSystemHealth(undefined, home);
     expect(h.broker.reachable).toBe(false);
     expect(h.broker.error).toBe("EPROTO: bad frame");
   });
 
-  it("reads live hindsight env from docker inspect when running", async () => {
+  it("reports hindsight running from the HTTP probe + env from docker inspect when available", async () => {
+    asMock(probeHindsight).mockResolvedValue({ ok: true, serverName: "hindsight", serverVersion: "1.0" });
     asMock(getHindsightStatus).mockReturnValue("Up 3 hours");
-    asMock(isHindsightRunning).mockReturnValue(true);
     asMock(spawnSync).mockReturnValue({
       status: 0,
       stdout: JSON.stringify([
@@ -557,23 +568,32 @@ describe("handleGetSystemHealth", () => {
       stderr: "",
     } as never);
 
-    const h = await handleGetSystemHealth(home);
-    expect(h.hindsight.running).toBe(true);
+    const h = await handleGetSystemHealth(undefined, home);
+    expect(h.hindsight.running).toBe(true); // from the HTTP probe, not docker
     expect(h.hindsight.containerStatus).toBe("Up 3 hours");
     expect(h.hindsight.model).toBe("claude-sonnet-4-6");
     expect(h.hindsight.provider).toBe("claude-code");
     expect(h.hindsight.mcpStateless).toBe(true);
   });
 
-  it("leaves hindsight env null when the container is absent", async () => {
+  it("reports hindsight NOT running when the probe fails (e.g. dockerless web, hindsight unreachable)", async () => {
+    asMock(probeHindsight).mockResolvedValue({ ok: false, reason: "Unreachable" });
     asMock(getHindsightStatus).mockReturnValue(null);
-    asMock(isHindsightRunning).mockReturnValue(false);
-    const h = await handleGetSystemHealth(home);
+    const h = await handleGetSystemHealth(undefined, home);
+    // running is false because the probe failed — NOT because docker said so.
     expect(h.hindsight.running).toBe(false);
     expect(h.hindsight.model).toBeNull();
     expect(h.hindsight.mcpStateless).toBeNull();
-    // docker inspect must NOT be probed when the container isn't running.
-    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the configured provider when docker inspect is unavailable but the probe succeeds", async () => {
+    asMock(probeHindsight).mockResolvedValue({ ok: true, serverName: "h", serverVersion: "1" });
+    asMock(getHindsightStatus).mockReturnValue(null);
+    asMock(spawnSync).mockReturnValue({ status: 1, stdout: "", stderr: "no docker" } as never);
+    const cfg = { memory: { config: { url: "http://127.0.0.1:18888/mcp/", provider: "claude-code" } } } as never;
+    const h = await handleGetSystemHealth(cfg, home);
+    expect(h.hindsight.running).toBe(true);
+    expect(h.hindsight.provider).toBe("claude-code"); // from config, not docker
   });
 
   it("parses the hostd audit log when present (newest entries, capped)", async () => {
@@ -593,7 +613,7 @@ describe("handleGetSystemHealth", () => {
       [line("restart", 0), line("update-apply", 1)].join("\n") + "\n",
     );
 
-    const h = await handleGetSystemHealth(home);
+    const h = await handleGetSystemHealth(undefined, home);
     expect(h.hostd.auditLogPresent).toBe(true);
     expect(h.hostd.recent).toHaveLength(2);
     expect(h.hostd.recent.map((e) => e.op)).toEqual([
@@ -603,7 +623,7 @@ describe("handleGetSystemHealth", () => {
   });
 
   it("reports hostd audit absent on a fresh install (no crash)", async () => {
-    const h = await handleGetSystemHealth(home);
+    const h = await handleGetSystemHealth(undefined, home);
     expect(h.hostd.auditLogPresent).toBe(false);
     expect(h.hostd.recent).toEqual([]);
   });


### PR DESCRIPTION
## Summary
The dashboard's health panel falsely shows **"Hindsight not running"** and **"Agents 0/11 active"** even when everything is healthy, because it determines liveness via `docker ps`/`docker inspect` — but the web container is **dockerless by design** (no socket mounted, for security), so those calls throw.

## Why this happens
- `isHindsightRunning()` / `getHindsightStatus()` / `inspectEnv()` and `getAllAgentStatuses()` all shell out to docker → throw in the web container → report DOWN.
- The Auth-broker + Hostd tiles are correct because they use the UDS socket + audit-log file, not docker.

(Diagnosed live: hindsight up + serving, all 11 agents up, but the panel showed red.)

## Fix — docker-free signals the web container already has
- **Hindsight `running`** → HTTP-probe the MCP endpoint (`probeHindsight`, URL from `memory.config.url`). The web reaches hindsight over host networking; the probe also confirms it's *serving*, not just that a container exists. Docker-based fields stay best-effort and no longer gate the dot; `provider` falls back to the configured value.
- **Agent `active`** → fall back to the gateway's `.bridge-alive` heartbeat (touched ~every 5s; web mounts the agents dir) when the docker signal isn't already "active". New `agentBridgeAlive()`: fresh mtime within 30s (6 missed beats) = live.

**No security change** — the web container still gets no docker access (it's a sensitive surface; the loopback-header-forge concern stands).

## Test plan
- [x] `vitest run src/web/dashboard-health.test.ts` — 5 (fresh / boundary / stale / missing / no-dir)
- [x] `vitest run src/web/` — 101 pass (no regression)
- [x] `tsc --noEmit` clean
- [ ] Live canary after deploy: dashboard Summary shows Hindsight green + Agents 11/11 active while healthy.

## Risk
Low — web-only; shared CLI status helpers untouched (the fallback only kicks in when docker's signal isn't "active", so CLI/host callers are unchanged). Serves the "you hold the leash" outcome: the dashboard must report true state, not cry false outages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)