### PR TITLE
fix(wedge): detect /rate-limit-options weekly-quota menu → trigger failover

### DIFF
--- a/src/agents/rate-limit-signal.ts
+++ b/src/agents/rate-limit-signal.ts
@@ -1,0 +1,108 @@
+// One-shot gateway signal for the rate-limit (weekly-quota) wedge.
+//
+// When the wedge-watchdog (autoaccept-poll sidecar) detects claude's
+// `/rate-limit-options` menu, it must trigger the gateway's EXISTING account-
+// failover chain (markExhausted → roll → quota-watch alert). The watchdog runs
+// in a separate process from the gateway, so it signals over the gateway's
+// per-agent UDS — the same socket + trust model the agent-scheduler uses
+// (anything inside this container's network namespace may connect; the agent
+// name is validated server-side, never trusted from the wire alone).
+//
+// Fire-and-forget, one connection per signal (the signal fires at most once per
+// watchdog cooldown, ~60s). Soft-fail throughout — must NEVER throw, to honour
+// the sidecar's never-throw contract. A dropped signal just means failover
+// isn't triggered this tick; the next stable detection retries.
+
+import { createConnection, type Socket } from "node:net";
+import { join } from "node:path";
+
+/** The NDJSON envelope written to the gateway socket. Mirrors the
+ *  ipc-protocol `QuotaWallDetectedMessage`. */
+export interface QuotaWallSignal {
+  type: "quota_wall_detected";
+  agentName: string;
+  /** Parsed weekly-reset epoch-ms, or omitted when unparseable (the gateway
+   *  substitutes a weekly-scale default — never the ~5h markExhausted default,
+   *  which would un-exhaust a weekly wall and re-wedge). */
+  resetAt?: number;
+}
+
+export interface SignalOptions {
+  socketPath?: string;
+  connectTimeoutMs?: number;
+  /** Test seam: replace createConnection. */
+  _connect?: (path: string) => Socket;
+  /** Test seam: log sink. */
+  _log?: (msg: string) => void;
+}
+
+/** Resolve the gateway socket the same way the agent-scheduler does. */
+export function resolveGatewaySocketPath(): string {
+  const stateDir = process.env.TELEGRAM_STATE_DIR ?? "/state/agent/telegram";
+  return process.env.SWITCHROOM_GATEWAY_SOCKET ?? join(stateDir, "gateway.sock");
+}
+
+/**
+ * Send a `quota_wall_detected` signal to the gateway. Fire-and-forget,
+ * never throws. Returns a Promise that resolves true if the bytes were written
+ * to the socket (the strongest delivery signal a fire-and-forget client gets),
+ * false on any failure. The watchdog does not await it (so a slow/absent socket
+ * can never stall the poll loop), but it is awaitable for tests.
+ */
+export function signalQuotaWall(
+  agentName: string,
+  resetAt: number | null,
+  opts: SignalOptions = {},
+): Promise<boolean> {
+  const socketPath = opts.socketPath ?? resolveGatewaySocketPath();
+  const connect = opts._connect ?? ((p: string) => createConnection(p));
+  const log = opts._log ?? ((m: string) => console.error(m));
+  const connectTimeoutMs = opts.connectTimeoutMs ?? 5_000;
+
+  const msg: QuotaWallSignal = { type: "quota_wall_detected", agentName };
+  if (resetAt != null) msg.resetAt = resetAt;
+  const line = JSON.stringify(msg) + "\n";
+
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const done = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(ok);
+    };
+    let sock: Socket;
+    try {
+      sock = connect(socketPath);
+    } catch (err) {
+      log(`[rate-limit-signal] ${agentName}: connect threw: ${(err as Error).message}`);
+      done(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      log(`[rate-limit-signal] ${agentName}: connect timed out`);
+      try { sock.destroy(); } catch { /* ignore */ }
+      done(false);
+    }, connectTimeoutMs);
+
+    sock.on("connect", () => {
+      try {
+        sock.write(line, () => {
+          clearTimeout(timer);
+          try { sock.end(); } catch { /* ignore */ }
+          log(`[rate-limit-signal] ${agentName}: quota_wall_detected sent`);
+          done(true);
+        });
+      } catch (err) {
+        clearTimeout(timer);
+        log(`[rate-limit-signal] ${agentName}: write threw: ${(err as Error).message}`);
+        try { sock.destroy(); } catch { /* ignore */ }
+        done(false);
+      }
+    });
+    sock.on("error", (err) => {
+      clearTimeout(timer);
+      log(`[rate-limit-signal] ${agentName}: socket error: ${(err as Error).message}`);
+      done(false);
+    });
+  });
+}

--- a/src/agents/wedge-watchdog.ts
+++ b/src/agents/wedge-watchdog.ts
@@ -45,6 +45,99 @@ import { capturePane, sendKeys, PROMPTS, type PromptRule } from "./autoaccept.js
 export const WEDGE_FOOTER_SIGNATURE =
   /(?=[\s\S]*[Ee]sc(?:ape)?[^\n]*cancel)(?=[\s\S]*(?:to select|to navigate|↑\/↓))/;
 
+/**
+ * The claude CLI's WEEKLY-quota wall surfaces as an interactive
+ * `/rate-limit-options` chooser, NOT as a stderr 429 — so the gateway's
+ * inference-path 429 detection never sees it and none of the failover/alert
+ * machinery (markExhausted → roll → quota-watch) ever engages. A headless
+ * agent then sits silently dead on a menu no human will answer (real incident:
+ * finn, 2026-06-07 — wedged for hours, unrecovered).
+ *
+ * Crucially the generic WEDGE_FOOTER_SIGNATURE above does NOT match this menu:
+ * its footer is "Enter to confirm · Esc to cancel" with NO "to select" /
+ * "to navigate" / ↑↓ affordance, so the generic branch leaves it untouched.
+ * Hence a dedicated detector.
+ *
+ * Two INDEPENDENT anchors, both required, so it can never false-positive on
+ * normal model output (verified against the live wedged pane, 2026-06-07):
+ *   (a) the literal slash-command claude prints for this menu, which cannot
+ *       appear in ordinary output: `/rate-limit-options`;
+ *   (b) an option string ONLY this menu shows: "Switch to usage credits" or
+ *       "Upgrade your plan".
+ * (Grep of the repo confirmed zero pre-existing occurrences of any of these.)
+ */
+export const RATE_LIMIT_MENU_SIGNATURE =
+  /(?=[\s\S]*\/rate-limit-options)(?=[\s\S]*(?:Switch to usage credits|Upgrade your plan))/;
+
+const MONTHS: Record<string, number> = {
+  jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
+  jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11,
+};
+
+/**
+ * Parse claude's weekly-reset line ("… resets Jun 9, 5am (Australia/Melbourne)")
+ * into an epoch-ms timestamp, tz-aware. Returns null on ANY parse failure — the
+ * caller MUST substitute a weekly-scale fallback (now + 7d), never `undefined`:
+ * markExhausted's default `until` is ~5h, which would un-exhaust a WEEKLY-walled
+ * account after 5h and re-wedge it. A wrong reset time only changes WHEN the
+ * broker re-probes the account, never compliance or correctness.
+ */
+export function parseWeeklyReset(text: string, nowMs: number = Date.now()): number | null {
+  // "resets Jun 9, 5am (Australia/Melbourne)" / "... 5pm (...)" / "... 11:30am"
+  const m = text.match(
+    /resets\s+([A-Za-z]{3,9})\s+(\d{1,2}),?\s+(\d{1,2})(?::(\d{2}))?\s*([ap]m)?\s*(?:\(([^)]+)\))?/i,
+  );
+  if (!m) return null;
+  const mon = MONTHS[m[1].slice(0, 3).toLowerCase()];
+  if (mon === undefined) return null;
+  const day = Number(m[2]);
+  let hour = Number(m[3]);
+  const minute = m[4] ? Number(m[4]) : 0;
+  const ampm = m[5]?.toLowerCase();
+  if (ampm === "pm" && hour < 12) hour += 12;
+  if (ampm === "am" && hour === 12) hour = 0;
+  if (!Number.isFinite(day) || !Number.isFinite(hour) || day < 1 || day > 31 || hour > 23) {
+    return null;
+  }
+  const tz = m[6]?.trim();
+  // Resolve the year as the next occurrence (roll forward if M/D already passed).
+  const probeYear = new Date(nowMs).getUTCFullYear();
+  for (const year of [probeYear, probeYear + 1]) {
+    const epoch = wallClockToEpoch(year, mon, day, hour, minute, tz);
+    if (epoch != null && epoch > nowMs - 60_000) return epoch;
+  }
+  return null;
+}
+
+/**
+ * Convert a wall-clock time in an IANA tz to epoch-ms (null if the tz is
+ * unknown). Resolves the tz's offset AT that date via Intl, so it is correct
+ * across DST — NOT `new Date(localString)`, which assumes the container TZ.
+ */
+function wallClockToEpoch(
+  year: number, month: number, day: number, hour: number, minute: number, tz: string | undefined,
+): number | null {
+  const asUtc = Date.UTC(year, month, day, hour, minute, 0);
+  if (!tz) return asUtc; // no tz given → best-effort UTC
+  try {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false,
+    });
+    const parts = Object.fromEntries(
+      fmt.formatToParts(new Date(asUtc)).filter((p) => p.type !== "literal").map((p) => [p.type, p.value]),
+    );
+    const shown = Date.UTC(
+      Number(parts.year), Number(parts.month) - 1, Number(parts.day),
+      Number(parts.hour) % 24, Number(parts.minute), Number(parts.second),
+    );
+    const offset = shown - asUtc; // how far ahead the tz wall clock is of UTC
+    return asUtc - offset;
+  } catch {
+    return null; // unknown tz
+  }
+}
+
 const DEFAULT_POLL_MS = 5_000;
 const DEFAULT_STABILITY_THRESHOLD = 3;
 const DEFAULT_COOLDOWN_MS = 60_000;
@@ -74,6 +167,26 @@ export interface WedgeWatchdogOptions {
   deferToPrompts?: PromptRule[];
   /** Override the blocking-modal signature (tests / tuning). */
   wedgeSignature?: RegExp;
+  /**
+   * Rate-limit (weekly-quota) menu detection. When the pane shows claude's
+   * `/rate-limit-options` chooser, the agent is quota-walled and headless — no
+   * 429 reached the gateway, so failover never fired. On a stable match the
+   * watchdog (a) signals the gateway to trigger the EXISTING account-failover
+   * (markExhausted → roll, or the all-exhausted alert) via `onRateLimitMenu`,
+   * then (b) parks the menu with `Esc` (the SAME compliant verb — Esc cancels
+   * without selecting any option, so it can never pick "Switch to usage
+   * credits" = off-subscription). Disabled when `rateLimitSignature` is null.
+   */
+  rateLimitSignature?: RegExp | null;
+  /**
+   * Called on a stability-confirmed rate-limit menu, with the parsed weekly
+   * reset (epoch-ms, or null when unparseable). Default: signal the gateway
+   * over its UDS. Soft-fail — must never throw. Set to undefined to detect +
+   * park WITHOUT signalling (e.g. tests).
+   */
+  onRateLimitMenu?: (agentName: string, resetAt: number | null) => void;
+  /** Test seam: clock-injected weekly-reset parser. Default: parseWeeklyReset. */
+  parseReset?: (text: string, nowMs: number) => number | null;
   /** Test seam: cap total polls. Default Infinity (runs until killed). */
   maxPolls?: number;
   /** Test seam: clock override. */
@@ -87,8 +200,12 @@ export interface WedgeWatchdogOptions {
 }
 
 export interface WedgeWatchdogResult {
-  /** Number of times Esc was dispatched to dismiss a stuck prompt. */
+  /** Number of times Esc was dispatched to dismiss a stuck prompt (includes
+   *  rate-limit-menu parks). */
   fires: number;
+  /** Subset of `fires` that were rate-limit (weekly-quota) menu detections —
+   *  each also signalled failover. */
+  rateLimitFires: number;
   /** Total polls executed (bounded only in tests via maxPolls). */
   polls: number;
   reason: "max-polls" | "stopped";
@@ -123,6 +240,11 @@ export async function runWedgeWatchdog(
   const cooldownMs = opts.cooldownMs ?? DEFAULT_COOLDOWN_MS;
   const deferToPrompts = opts.deferToPrompts ?? PROMPTS;
   const signature = opts.wedgeSignature ?? WEDGE_FOOTER_SIGNATURE;
+  // `null` disables rate-limit detection (kill switch); `undefined` → default on.
+  const rateLimitSignature =
+    opts.rateLimitSignature === null ? null : (opts.rateLimitSignature ?? RATE_LIMIT_MENU_SIGNATURE);
+  const onRateLimitMenu = opts.onRateLimitMenu;
+  const parseReset = opts.parseReset ?? parseWeeklyReset;
   const maxPolls = opts.maxPolls ?? Number.POSITIVE_INFINITY;
   const now = opts.now ?? Date.now;
   const sleep = opts.sleep ?? defaultSleep;
@@ -133,6 +255,7 @@ export async function runWedgeWatchdog(
   let lastKey: string | null = null;
   let cooldownUntil = 0;
   let fires = 0;
+  let rateLimitFires = 0;
   let polls = 0;
 
   while (polls < maxPolls) {
@@ -148,14 +271,64 @@ export async function runWedgeWatchdog(
       text = "";
     }
 
+    // Rate-limit (weekly-quota) menu takes PRECEDENCE over the generic modal
+    // branch: it must be SIGNALLED (to trigger failover) before any Esc, and a
+    // bare Esc alone would just clear the visual block and re-wedge next turn.
+    const isRateLimitMenu = !!text && rateLimitSignature !== null && rateLimitSignature.test(text);
+
     const isBlockingModal =
+      !isRateLimitMenu &&
       !!text &&
       signature.test(text) &&
       // Defer to the boot autoaccept poller for first-run prompts — those
       // want Enter, not Esc.
       !deferToPrompts.some((p) => p.match.test(text));
 
-    if (isBlockingModal) {
+    if (isRateLimitMenu) {
+      const key = stabilityKey(text);
+      if (key === lastKey) {
+        stableCount++;
+      } else {
+        stableCount = 1;
+        lastKey = key;
+      }
+      if (stableCount >= stabilityThreshold && now() >= cooldownUntil) {
+        const resetAt = parseReset(text, now());
+        console.error(
+          `[wedge-watchdog] ${opts.agentName}: rate-limit (weekly-quota) menu detected ` +
+            `after ${stableCount} stable polls — signalling failover` +
+            (resetAt != null ? ` (resets ${new Date(resetAt).toISOString()})` : " (reset unparsed)") +
+            ` then parking with Esc`,
+        );
+        // (a) Trigger the EXISTING gateway failover chain. Soft-fail — the
+        //     never-throw sidecar contract holds even for a custom seam.
+        if (onRateLimitMenu) {
+          try {
+            onRateLimitMenu(opts.agentName, resetAt);
+          } catch (err) {
+            console.error(
+              `[wedge-watchdog] ${opts.agentName}: onRateLimitMenu threw: ${(err as Error).message}`,
+            );
+          }
+        }
+        // (b) Park the menu compliantly. ESC ONLY — cancels the modal without
+        //     selecting any option, so it can NEVER land on "Switch to usage
+        //     credits" (off-subscription) or "Upgrade your plan". Never send a
+        //     Down/numeric key here.
+        try {
+          send(opts.agentName, ["Escape"]);
+        } catch (err) {
+          console.error(
+            `[wedge-watchdog] ${opts.agentName}: send threw: ${(err as Error).message}`,
+          );
+        }
+        fires++;
+        rateLimitFires++;
+        cooldownUntil = now() + cooldownMs;
+        stableCount = 0;
+        lastKey = null;
+      }
+    } else if (isBlockingModal) {
       const key = stabilityKey(text);
       if (key === lastKey) {
         stableCount++;
@@ -195,5 +368,5 @@ export async function runWedgeWatchdog(
     await sleep(pollIntervalMs);
   }
 
-  return { fires, polls, reason: "max-polls" };
+  return { fires, rateLimitFires, polls, reason: "max-polls" };
 }

--- a/src/cli/autoaccept-poll.ts
+++ b/src/cli/autoaccept-poll.ts
@@ -22,6 +22,7 @@
 
 import { runAutoaccept } from "../agents/autoaccept.js";
 import { runWedgeWatchdog } from "../agents/wedge-watchdog.js";
+import { signalQuotaWall } from "../agents/rate-limit-signal.js";
 
 async function main(): Promise<void> {
   const agentName = process.argv[2];
@@ -53,12 +54,30 @@ async function main(): Promise<void> {
     );
     process.exit(0);
   }
+  // Rate-limit (weekly-quota) menu detection: default ON. When detected, the
+  // watchdog signals the gateway to trigger account failover, then Esc-parks the
+  // menu. Kill switch SWITCHROOM_RATE_LIMIT_DETECT=0 → detect-disabled (the
+  // watchdog behaves exactly as before: generic-modal Esc only).
+  const rateLimitDetect = process.env.SWITCHROOM_RATE_LIMIT_DETECT !== "0";
   try {
-    console.error(`[autoaccept-poll] ${agentName}: entering wedge-watchdog (continuous)`);
-    // Runs until the container stops (maxPolls defaults to Infinity).
-    const res = await runWedgeWatchdog({ agentName });
     console.error(
-      `[autoaccept-poll] ${agentName}: wedge-watchdog returned reason=${res.reason} fires=${res.fires}`,
+      `[autoaccept-poll] ${agentName}: entering wedge-watchdog (continuous)` +
+        (rateLimitDetect ? " +rate-limit-detect" : " (rate-limit-detect OFF)"),
+    );
+    // Runs until the container stops (maxPolls defaults to Infinity).
+    const res = await runWedgeWatchdog({
+      agentName,
+      rateLimitSignature: rateLimitDetect ? undefined : null,
+      onRateLimitMenu: rateLimitDetect
+        ? (name, resetAt) => {
+            // Fire-and-forget; do not await (a slow/absent gateway socket must
+            // never stall the poll loop).
+            void signalQuotaWall(name, resetAt);
+          }
+        : undefined,
+    });
+    console.error(
+      `[autoaccept-poll] ${agentName}: wedge-watchdog returned reason=${res.reason} fires=${res.fires} rateLimitFires=${res.rateLimitFires}`,
     );
   } catch (err) {
     console.error(

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -348,6 +348,7 @@ import type {
   PtyPartialForward,
   InboundMessage,
   InjectInboundMessage,
+  QuotaWallDetectedMessage,
   PermissionEvent,
 } from './ipc-protocol.js'
 import { DebounceBuffer, HourCap, buildReactionInboundMeta, buildReactionInboundText, evaluateTriggerCandidate, isGroupChat, resolveReactionsConfig, truncatePreview, type PendingReaction, type ReactionBatch, type ReactionsResolvedConfig } from './reaction-trigger.js'
@@ -6257,6 +6258,30 @@ const ipcServer: IpcServer = createIpcServer({
     if (!delivered) {
       pendingInboundBuffer.push(msg.agentName, msg.inbound)
     }
+  },
+
+  // The wedge-watchdog detected claude's /rate-limit-options weekly-quota menu
+  // (a TUI wall that never produced a 429, so the inference-path auto-fallback
+  // never fired). Trigger the SAME fleet auto-fallback the 429 path uses,
+  // threading the parsed weekly reset as markExhausted's `until` — with a
+  // weekly-scale FALLBACK when the sidecar couldn't parse it (resetAt absent):
+  // passing undefined would let markExhausted use its ~5h default, which would
+  // un-exhaust a weekly-walled account and re-wedge it within hours. The
+  // existing chain handles the rest (roll to a fallback subscription account,
+  // or the all-exhausted operator alert when none has quota). Fire-and-forget.
+  onQuotaWallDetected(_client: IpcClient, msg: QuotaWallDetectedMessage) {
+    const WEEKLY_MS = 7 * 24 * 60 * 60 * 1000
+    const untilMs =
+      typeof msg.resetAt === 'number' && Number.isFinite(msg.resetAt) && msg.resetAt > Date.now()
+        ? msg.resetAt
+        : Date.now() + WEEKLY_MS
+    process.stderr.write(
+      `telegram gateway: quota_wall_detected agent=${msg.agentName} ` +
+        `until=${new Date(untilMs).toISOString()}` +
+        (msg.resetAt == null ? ' (reset unparsed → +7d default)' : '') +
+        ' — triggering fleet auto-fallback\n',
+    )
+    void fireFleetAutoFallback(msg.agentName, untilMs)
   },
 
   log: (msg) => process.stderr.write(`telegram gateway: ipc — ${msg}\n`),
@@ -14605,9 +14630,9 @@ function wouldFireFleetAutoFallback(): boolean {
  * so the user sees the outcome inline with the original "Model
  * unavailable" card.
  */
-async function fireFleetAutoFallback(triggerAgent: string): Promise<void> {
+async function fireFleetAutoFallback(triggerAgent: string, untilMs?: number): Promise<void> {
   return fleetFallbackGate.fire(
-    () => doFireFleetAutoFallback(triggerAgent),
+    () => doFireFleetAutoFallback(triggerAgent, untilMs),
     (err) => {
       process.stderr.write(
         `telegram gateway: [fleet-fallback] error agent=${triggerAgent}: ${(err as Error)?.message ?? err}\n`,
@@ -14620,7 +14645,7 @@ async function fireFleetAutoFallback(triggerAgent: string): Promise<void> {
  *  user-visible announcement was broadcast). False on no-op /
  *  error / idempotent-skip — caller uses this to decide whether to
  *  arm the post-fire suppression window. */
-async function doFireFleetAutoFallback(triggerAgent: string): Promise<boolean> {
+async function doFireFleetAutoFallback(triggerAgent: string, untilMs?: number): Promise<boolean> {
   try {
     const client = await getAuthBrokerClient(triggerAgent)
     if (!client) {
@@ -14655,7 +14680,11 @@ async function doFireFleetAutoFallback(triggerAgent: string): Promise<boolean> {
       // operator is explicitly choosing, and is admin); only this automatic
       // path moves to the non-admin verb.
       failover: async () => {
-        const r = await client.markExhausted()
+        // The 429 inference path passes no `until` (broker ~5h default). The
+        // rate-limit-MENU path (quota_wall_detected) passes the parsed WEEKLY
+        // reset, so the walled account isn't re-probed (and re-wedged) within
+        // the 5h default while it's weekly-capped.
+        const r = await client.markExhausted(untilMs)
         return { rolledTo: r.rolledTo ?? null, rolled: r.rolled }
       },
       triggerAgent,

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -393,6 +393,26 @@ export interface RequestConfigFinalizeMessage {
   detail?: string;
 }
 
+/**
+ * The autoaccept-poll wedge-watchdog detected claude's `/rate-limit-options`
+ * weekly-quota menu (a TUI wall that never produced a 429 the gateway could
+ * see). Asks the gateway to trigger the EXISTING account-failover chain
+ * (markExhausted → roll to a fallback subscription account, or the
+ * all-exhausted operator alert). Fire-and-forget; no reply.
+ *
+ * Trust model (same as inject_inbound): the socket is per-agent inside the
+ * container, but `agentName` is still validated server-side and never trusted
+ * to authorize anything beyond triggering the agent's own failover.
+ */
+export interface QuotaWallDetectedMessage {
+  type: "quota_wall_detected";
+  agentName: string;
+  /** Parsed weekly-reset epoch-ms. Omitted when the sidecar couldn't parse it;
+   *  the gateway then uses a weekly-scale default for markExhausted's `until`
+   *  (NOT the ~5h default, which would un-exhaust a weekly wall and re-wedge). */
+  resetAt?: number;
+}
+
 export type ClientToGateway =
   | RegisterMessage
   | ToolCallMessage
@@ -407,4 +427,5 @@ export type ClientToGateway =
   | RequestDriveApprovalMessage
   | RequestMs365ApprovalMessage
   | RequestConfigApprovalMessage
-  | RequestConfigFinalizeMessage;
+  | RequestConfigFinalizeMessage
+  | QuotaWallDetectedMessage;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -4,6 +4,7 @@ import type {
   GatewayToClient,
   HeartbeatMessage,
   InjectInboundMessage,
+  QuotaWallDetectedMessage,
   OperatorEventForward,
   PermissionRequestForward,
   PtyPartialForward,
@@ -44,6 +45,14 @@ export interface IpcServerOptions {
    * inline scheduler simply ignore inject_inbound messages.
    */
   onInjectInbound?: (client: IpcClient, msg: InjectInboundMessage) => void;
+  /**
+   * The autoaccept-poll wedge-watchdog detected claude's `/rate-limit-options`
+   * weekly-quota menu (no 429 ever reached the gateway). Handler is expected to
+   * trigger the existing fleet auto-fallback for `msg.agentName`, threading
+   * `msg.resetAt` as the markExhausted `until`. Fire-and-forget; gateways that
+   * don't run failover simply ignore it.
+   */
+  onQuotaWallDetected?: (client: IpcClient, msg: QuotaWallDetectedMessage) => void;
   /**
    * RFC E §4.2 Cut 2 — Drive-write PreToolUse hook asks the gateway
    * to register a kernel approval request + post a diff-preview
@@ -237,6 +246,15 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
         && typeof inb.meta === "object"
         && inb.meta !== null;
     }
+    case "quota_wall_detected": {
+      // wedge-watchdog detected the /rate-limit-options weekly-quota menu.
+      if (typeof m.agentName !== "string"
+        || !AGENT_NAME_RE.test(m.agentName as string)) return false;
+      // resetAt optional; when present it must be a finite epoch-ms.
+      if (m.resetAt !== undefined
+        && (typeof m.resetAt !== "number" || !Number.isFinite(m.resetAt as number))) return false;
+      return true;
+    }
     case "request_config_approval": {
       // #1623 — hostd-initiated config-edit approval card. Wire shape
       // only; the handler module validates the diff content.
@@ -317,6 +335,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onOperatorEvent,
     onPtyPartial,
     onInjectInbound,
+    onQuotaWallDetected,
     onRequestDriveApproval,
     onRequestMs365Approval,
     onRequestConfigApproval,
@@ -424,6 +443,9 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
         break;
       case "inject_inbound":
         if (onInjectInbound) onInjectInbound(client, msg as InjectInboundMessage);
+        break;
+      case "quota_wall_detected":
+        if (onQuotaWallDetected) onQuotaWallDetected(client, msg as QuotaWallDetectedMessage);
         break;
       case "request_drive_approval":
         if (onRequestDriveApproval) {

--- a/telegram-plugin/tests/ipc-server-validate-quota-wall.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-quota-wall.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Validation contract for the `quota_wall_detected` IPC verb — the signal the
+ * autoaccept-poll wedge-watchdog sends when it sees claude's /rate-limit-options
+ * weekly-quota menu, asking the gateway to trigger account failover.
+ *
+ * A rogue process on the same UDS must not be able to inject a malformed
+ * payload: agentName is required + name-shaped, resetAt (optional) must be a
+ * finite number.
+ */
+import { describe, it, expect } from "vitest";
+import { validateClientMessage } from "../gateway/ipc-server.js";
+
+describe("validateClientMessage — quota_wall_detected", () => {
+  it("accepts a well-formed signal (with resetAt)", () => {
+    expect(
+      validateClientMessage({ type: "quota_wall_detected", agentName: "finn", resetAt: 1_780_000_000_000 }),
+    ).toBe(true);
+  });
+
+  it("accepts a well-formed signal WITHOUT resetAt (optional)", () => {
+    expect(validateClientMessage({ type: "quota_wall_detected", agentName: "finn" })).toBe(true);
+  });
+
+  it("rejects a missing / non-string / malformed agentName", () => {
+    expect(validateClientMessage({ type: "quota_wall_detected" })).toBe(false);
+    expect(validateClientMessage({ type: "quota_wall_detected", agentName: 123 })).toBe(false);
+    expect(validateClientMessage({ type: "quota_wall_detected", agentName: "" })).toBe(false);
+    expect(validateClientMessage({ type: "quota_wall_detected", agentName: "../etc" })).toBe(false);
+    expect(validateClientMessage({ type: "quota_wall_detected", agentName: "Finn UPPER" })).toBe(false);
+  });
+
+  it("rejects a non-finite / non-number resetAt", () => {
+    expect(validateClientMessage({ type: "quota_wall_detected", agentName: "finn", resetAt: "soon" })).toBe(false);
+    expect(validateClientMessage({ type: "quota_wall_detected", agentName: "finn", resetAt: NaN })).toBe(false);
+    expect(validateClientMessage({ type: "quota_wall_detected", agentName: "finn", resetAt: Infinity })).toBe(false);
+  });
+});

--- a/tests/rate-limit-menu-detect.test.ts
+++ b/tests/rate-limit-menu-detect.test.ts
@@ -1,0 +1,165 @@
+// Unit tests for the rate-limit (weekly-quota) menu detector in the
+// wedge-watchdog. The COMPLIANCE assertion (only ['Escape'] is ever sent —
+// never a Down/2/3 that could select "Switch to usage credits" = off-
+// subscription) is the load-bearing one (vision.md pillar 3).
+
+import { describe, it, expect } from "vitest";
+import {
+  runWedgeWatchdog,
+  parseWeeklyReset,
+  RATE_LIMIT_MENU_SIGNATURE,
+  WEDGE_FOOTER_SIGNATURE,
+} from "../src/agents/wedge-watchdog.js";
+
+// The REAL wedged pane captured live from finn, 2026-06-07.
+const RATE_LIMIT_SCREEN =
+  "← switchroom-telegram: Kiosk outage watcher tick. Run\n" +
+  "`~/.switchroom/agents/finn/w…\n" +
+  "  ⎿  You've hit your weekly limit · resets Jun 9, 5am (Australia/Melbourne)\n" +
+  "\n" +
+  "✻ Churned for 1s\n" +
+  "\n" +
+  "❯ /rate-limit-options\n" +
+  "\n" +
+  "────────────────────────────────────────\n" +
+  "  What do you want to do?\n" +
+  "\n" +
+  "  ❯ 1. Stop and wait for limit to reset\n" +
+  "    2. Switch to usage credits\n" +
+  "    3. Upgrade your plan\n" +
+  "\n" +
+  "  Enter to confirm · Esc to cancel";
+
+const NORMAL_SCREEN =
+  "⏵⏵ accept edits on (shift+tab to cycle) · esc to interrupt\n❯ ";
+
+function captureSeq(screens: string[]) {
+  let i = 0;
+  return (_a: string) => (i < screens.length ? screens[i++] : screens[screens.length - 1] ?? "");
+}
+function recordSend() {
+  const calls: string[][] = [];
+  return { send: (_a: string, keys: string[]) => (calls.push([...keys]), true), calls };
+}
+
+describe("RATE_LIMIT_MENU_SIGNATURE", () => {
+  it("matches the real /rate-limit-options pane", () => {
+    expect(RATE_LIMIT_MENU_SIGNATURE.test(RATE_LIMIT_SCREEN)).toBe(true);
+  });
+  it("does NOT match normal output / a generic modal / empty", () => {
+    expect(RATE_LIMIT_MENU_SIGNATURE.test(NORMAL_SCREEN)).toBe(false);
+    expect(RATE_LIMIT_MENU_SIGNATURE.test("Which option?\n❯ 1. Yes\n  2. No\nEnter to select · Esc to cancel")).toBe(false);
+    expect(RATE_LIMIT_MENU_SIGNATURE.test("")).toBe(false);
+    // Needs BOTH anchors — one alone is not enough.
+    expect(RATE_LIMIT_MENU_SIGNATURE.test("see /rate-limit-options docs")).toBe(false);
+    expect(RATE_LIMIT_MENU_SIGNATURE.test("you could Upgrade your plan someday")).toBe(false);
+  });
+  it("the GENERIC wedge signature does NOT match this menu (why a dedicated detector is needed)", () => {
+    // The footer is 'Enter to confirm · Esc to cancel' — no 'to select/navigate/↑↓'.
+    expect(WEDGE_FOOTER_SIGNATURE.test(RATE_LIMIT_SCREEN)).toBe(false);
+  });
+});
+
+describe("parseWeeklyReset", () => {
+  const NOW = Date.UTC(2026, 5, 7, 0, 0, 0); // 2026-06-07
+  it("parses 'resets Jun 9, 5am (Australia/Melbourne)' to the correct epoch", () => {
+    const epoch = parseWeeklyReset(RATE_LIMIT_SCREEN, NOW);
+    expect(epoch).not.toBeNull();
+    // Jun 9 2026 05:00 Australia/Melbourne (AEST, UTC+10) = Jun 8 19:00 UTC.
+    expect(epoch).toBe(Date.UTC(2026, 5, 8, 19, 0, 0));
+  });
+  it("handles pm + minutes + bare tz/no-tz", () => {
+    expect(parseWeeklyReset("resets Jul 1, 5:30pm (UTC)", NOW)).toBe(Date.UTC(2026, 6, 1, 17, 30, 0));
+    expect(parseWeeklyReset("resets Jul 1, 12am (UTC)", NOW)).toBe(Date.UTC(2026, 6, 1, 0, 0, 0));
+    expect(parseWeeklyReset("resets Dec 31, 11pm", NOW)).toBe(Date.UTC(2026, 11, 31, 23, 0, 0)); // no tz → UTC
+  });
+  it("rolls to next year when the M/D already passed", () => {
+    const lateNow = Date.UTC(2026, 11, 15); // Dec 15
+    const epoch = parseWeeklyReset("resets Jan 2, 9am (UTC)", lateNow);
+    expect(epoch).toBe(Date.UTC(2027, 0, 2, 9, 0, 0));
+  });
+  it("returns null on garbage / unparseable (caller substitutes +7d)", () => {
+    expect(parseWeeklyReset("no reset info here", NOW)).toBeNull();
+    expect(parseWeeklyReset("resets someday soon", NOW)).toBeNull();
+    expect(parseWeeklyReset("resets Foo 9, 5am", NOW)).toBeNull();
+  });
+});
+
+describe("runWedgeWatchdog — rate-limit branch", () => {
+  it("on a stable rate-limit menu: signals failover (with parsed reset) AND parks with Esc", async () => {
+    const { send, calls } = recordSend();
+    const signals: Array<{ name: string; resetAt: number | null }> = [];
+    const res = await runWedgeWatchdog({
+      agentName: "finn",
+      now: () => Date.UTC(2026, 5, 7, 0, 0, 0),
+      sleep: () => {},
+      maxPolls: 3,
+      capture: captureSeq([RATE_LIMIT_SCREEN]),
+      send,
+      onRateLimitMenu: (name, resetAt) => signals.push({ name, resetAt }),
+    });
+    expect(res.rateLimitFires).toBe(1);
+    expect(res.fires).toBe(1);
+    // Signal fired with the agent + the PARSED weekly reset.
+    expect(signals).toHaveLength(1);
+    expect(signals[0].name).toBe("finn");
+    expect(signals[0].resetAt).toBe(Date.UTC(2026, 5, 8, 19, 0, 0));
+    // COMPLIANCE: the ONLY keystroke ever sent is Escape — never Down/2/3.
+    expect(calls).toEqual([["Escape"]]);
+  });
+
+  it("does NOT fire before the stability threshold", async () => {
+    const { send, calls } = recordSend();
+    const signals: unknown[] = [];
+    const res = await runWedgeWatchdog({
+      agentName: "finn", now: () => 0, sleep: () => {}, maxPolls: 2,
+      capture: captureSeq([RATE_LIMIT_SCREEN]), send,
+      onRateLimitMenu: () => signals.push(1),
+    });
+    expect(res.rateLimitFires).toBe(0);
+    expect(signals).toHaveLength(0);
+    expect(calls).toEqual([]);
+  });
+
+  it("does NOT fire on normal output (no false positive)", async () => {
+    const { send, calls } = recordSend();
+    const signals: unknown[] = [];
+    const res = await runWedgeWatchdog({
+      agentName: "finn", now: () => 0, sleep: () => {}, maxPolls: 5,
+      capture: captureSeq([NORMAL_SCREEN]), send,
+      onRateLimitMenu: () => signals.push(1),
+    });
+    expect(res.rateLimitFires).toBe(0);
+    expect(signals).toHaveLength(0);
+    expect(calls).toEqual([]);
+  });
+
+  it("KILL SWITCH: rateLimitSignature=null → no detection, no signal (back to v0.14.83 behaviour)", async () => {
+    const { send, calls } = recordSend();
+    const signals: unknown[] = [];
+    const res = await runWedgeWatchdog({
+      agentName: "finn", now: () => 0, sleep: () => {}, maxPolls: 4,
+      capture: captureSeq([RATE_LIMIT_SCREEN]), send,
+      rateLimitSignature: null,
+      onRateLimitMenu: () => signals.push(1),
+    });
+    expect(res.rateLimitFires).toBe(0);
+    expect(signals).toHaveLength(0);
+    // And the generic branch must not touch it either (footer lacks 'to select').
+    expect(calls).toEqual([]);
+  });
+
+  it("COMPLIANCE (exhaustive): over many polls, the rate-limit branch NEVER emits Down/Up/Enter/2/3", async () => {
+    const { send, calls } = recordSend();
+    await runWedgeWatchdog({
+      agentName: "finn", now: () => 0, sleep: () => {}, maxPolls: 20,
+      capture: captureSeq([RATE_LIMIT_SCREEN]), send,
+      onRateLimitMenu: () => {},
+    });
+    const banned = ["Down", "Up", "Enter", "2", "3", "Tab"];
+    for (const keys of calls) {
+      expect(keys).toEqual(["Escape"]);
+      for (const k of keys) expect(banned).not.toContain(k);
+    }
+  });
+});

--- a/tests/rate-limit-signal.test.ts
+++ b/tests/rate-limit-signal.test.ts
@@ -1,0 +1,73 @@
+// Unit tests for the one-shot gateway signal client (signalQuotaWall). Uses a
+// fake socket via the _connect seam — no real UDS.
+
+import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Socket } from "node:net";
+import { signalQuotaWall } from "../src/agents/rate-limit-signal.js";
+
+/** Minimal fake Socket: emits 'connect' on next tick, records writes. */
+function fakeSocket(opts: { failConnect?: boolean } = {}) {
+  const ee = new EventEmitter() as unknown as Socket & EventEmitter & { written: string[]; ended: boolean };
+  (ee as any).written = [];
+  (ee as any).ended = false;
+  (ee as any).write = (data: string, cb?: () => void) => {
+    (ee as any).written.push(data);
+    cb?.();
+    return true;
+  };
+  (ee as any).end = () => { (ee as any).ended = true; };
+  (ee as any).destroy = () => {};
+  queueMicrotask(() => {
+    if (opts.failConnect) ee.emit("error", new Error("ECONNREFUSED"));
+    else ee.emit("connect");
+  });
+  return ee;
+}
+
+describe("signalQuotaWall", () => {
+  it("writes ONE NDJSON quota_wall_detected envelope with agentName + resetAt", async () => {
+    let sock: ReturnType<typeof fakeSocket> | undefined;
+    const ok = await signalQuotaWall("finn", 1_780_000_000_000, {
+      _connect: () => (sock = fakeSocket()) as unknown as Socket,
+      _log: () => {},
+    });
+    expect(ok).toBe(true);
+    expect(sock!.written).toHaveLength(1);
+    const line = sock!.written[0];
+    expect(line.endsWith("\n")).toBe(true);
+    expect(JSON.parse(line)).toEqual({
+      type: "quota_wall_detected",
+      agentName: "finn",
+      resetAt: 1_780_000_000_000,
+    });
+    expect(sock!.ended).toBe(true);
+  });
+
+  it("OMITS resetAt when null (gateway then uses the +7d default)", async () => {
+    let sock: ReturnType<typeof fakeSocket> | undefined;
+    await signalQuotaWall("finn", null, {
+      _connect: () => (sock = fakeSocket()) as unknown as Socket,
+      _log: () => {},
+    });
+    const parsed = JSON.parse(sock!.written[0]);
+    expect(parsed.resetAt).toBeUndefined();
+    expect(parsed.type).toBe("quota_wall_detected");
+  });
+
+  it("soft-fails (returns false, never throws) when the socket errors", async () => {
+    const ok = await signalQuotaWall("finn", null, {
+      _connect: () => fakeSocket({ failConnect: true }) as unknown as Socket,
+      _log: () => {},
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("soft-fails when connect THROWS synchronously", async () => {
+    const ok = await signalQuotaWall("finn", null, {
+      _connect: () => { throw new Error("boom"); },
+      _log: () => {},
+    });
+    expect(ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Durable fix for the rate-limit TUI wedge that left **finn silently dead for hours** (2026-06-07). The claude CLI's **weekly** quota wall surfaces as an interactive `/rate-limit-options` menu, *not* a stderr 429 — so the gateway never sees it, `markExhausted` is never called, and **none** of the v0.14.80-83 failover/alert machinery engages. A headless agent then sits forever on a menu no human will answer.

The generic wedge-watchdog doesn't catch it either: the menu footer is "Enter to confirm · Esc to cancel" with no "to select/navigate/↑↓", so `WEDGE_FOOTER_SIGNATURE` fails to match. finn was **wedged-forever-undetected**.

## The fix (small — reuses the entire existing chain)
1. **Detect** in `wedge-watchdog.ts`: a dedicated branch (checked before the generic modal branch, same stability gate + cooldown). Two-anchor `RATE_LIMIT_MENU_SIGNATURE` (`/rate-limit-options` **and** `Switch to usage credits|Upgrade your plan`) — verified against the live pane, zero false-positive risk.
2. **Parse** the weekly reset (`parseWeeklyReset`, tz-aware via `Intl`).
3. **Signal** the gateway (`quota_wall_detected` IPC verb → `onQuotaWallDetected`) which triggers the **existing** `fireFleetAutoFallback`, threading the parsed reset as `markExhausted`'s `until` (with a **+7d fallback** when unparsed — passing undefined would let the ~5h default un-exhaust a weekly wall and re-wedge). The existing chain rolls to a fallback subscription account, or fires #2215's all-exhausted operator alert.
4. **Park** with Esc.

## Compliance (vision.md pillar 3) — central
Recovery is *only* subscription-account failover or graceful Esc-park. The park is **Esc-only** (cancels without selecting) — a unit test asserts the branch can **never** emit `Down`/`Up`/`Enter`/`2`/`3`, so it can never pick "Switch to usage credits" (off-subscription) or "Upgrade your plan". Esc-dismiss + the exact option wording were **verified against finn's live wedged pane** (the menu literally prints "Esc to cancel").

## Reuses (no parallel machinery)
`markExhausted` · `fireFleetAutoFallback`/`runFleetAutoFallback` (incl. #2206's idempotency guard + single-authoritative-chooser) · the operator-announcement broadcast · #2215 `quota-watch` all-exhausted alert · the wedge-watchdog stability/cooldown/Esc seams · the agent-scheduler IPC trust model.

## Design notes
- **Gateway-signal, not sidecar-direct** `markExhausted` — so it goes through the existing idempotency guard + single-chooser (#2206) instead of recreating the divergent path #2206 deleted.
- **Separate from this code fix:** an agent needs a usable fallback account to actually *roll* vs just park+alert. finn rides shared `auth.active=default` with no fallback — a **config** gap handled in recovery, not this PR.

## Test plan
- [x] tsc clean; 27 vitest (detect / parse incl. AEST→UTC / **exhaustive compliance keystroke** / kill-switch / signal client) + 12 bun (IPC verb validation)
- [ ] Live: recover finn (config fallback + restart) and confirm the detector signals failover on the real menu

## Risk
LOW, kill-switched (`SWITCHROOM_RATE_LIMIT_DETECT=0` → exact v0.14.83 behaviour). Esc-only park means a false positive is harmless (just declines a modal). The signal is fire-and-forget soft-fail. No new model-calling path; the claude CLI stays unmodified on OAuth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)