### PR TITLE
fix(credits-watch): stop false 'out of pre-paid credits' alarms (subscription-only)

### DIFF
--- a/telegram-plugin/credits-watch.ts
+++ b/telegram-plugin/credits-watch.ts
@@ -64,7 +64,8 @@ const KNOWN_CREDIT_REASONS = [
 /**
  * Resolve the active fatal-reason set. Empty by default (subscription-only);
  * if `SWITCHROOM_CREDITS_WATCH_FATAL_REASONS` is set, parse it as a
- * comma-separated list (unknown tokens ignored). `*` opts in all known reasons.
+ * comma-separated list (tokens kept verbatim — an unknown token is harmless,
+ * it simply never matches a real reason value). `*` opts in all known reasons.
  */
 export function resolveCreditWatchFatalReasons(env: NodeJS.ProcessEnv): Set<string> {
   const raw = env.SWITCHROOM_CREDITS_WATCH_FATAL_REASONS;

--- a/telegram-plugin/credits-watch.ts
+++ b/telegram-plugin/credits-watch.ts
@@ -27,20 +27,52 @@ import { join } from "path";
 const STATE_FILE = "credits-watch.json";
 
 /**
- * Possible values of `cachedExtraUsageDisabledReason` in `.claude.json`
- * that warrant a user-facing notification. Other values (null,
- * undefined, transient unknowns) are treated as "no notification
- * needed".
+ * Which `cachedExtraUsageDisabledReason` values warrant a user-facing alarm.
  *
- * Conservative list: only fatal-billing reasons. We don't want to fire
- * on every transient API blip the cache happens to write.
+ * IMPORTANT — empty by default (subscription-only model). The flag name says it
+ * all: `cachedExtraUsageDisabledReason` is *always* "why **extra usage** (the
+ * optional pay-as-you-go layer beyond the Pro/Max plan) is disabled." switchroom
+ * is subscription-only by design (compliance pillar 3 — "the plan is the
+ * ceiling, no API/pay-as-you-go"), so extra usage being OFF is the **expected,
+ * desired** state. Every value (`out_of_credits`, `extra_usage_disabled`,
+ * `credits_exhausted`, even `org_level_disabled` = "org admin disabled extra
+ * usage") describes that benign state — none indicates a real switchroom
+ * failure. Firing a "cron + replies will fail, buy credits" card on it is a
+ * false alarm AND advises something that contradicts the subscription-honest
+ * model.
+ *
+ * The genuine failure modes are covered elsewhere:
+ *   - an account's subscription window exhausts → stderr → fleet auto-fallback
+ *     (model-unavailable.ts → fireFleetAutoFallback) rolls to a healthy account;
+ *   - the WHOLE fleet exhausts → the quota-watch all-exhausted operator alert.
+ *
+ * So credits-watch defaults to silent. An operator who actually runs on
+ * pay-as-you-go and wants the alarm can opt specific reasons back in via
+ * `SWITCHROOM_CREDITS_WATCH_FATAL_REASONS` (comma-separated). See
+ * `resolveCreditWatchFatalReasons`.
  */
-const FATAL_REASONS = new Set([
+export const DEFAULT_CREDIT_FATAL_REASONS = new Set<string>();
+
+/** All reason strings recognized for opt-in via the env var. */
+const KNOWN_CREDIT_REASONS = [
   "out_of_credits",
   "org_level_disabled",
   "credits_exhausted",
   "extra_usage_disabled",
-]);
+] as const;
+
+/**
+ * Resolve the active fatal-reason set. Empty by default (subscription-only);
+ * if `SWITCHROOM_CREDITS_WATCH_FATAL_REASONS` is set, parse it as a
+ * comma-separated list (unknown tokens ignored). `*` opts in all known reasons.
+ */
+export function resolveCreditWatchFatalReasons(env: NodeJS.ProcessEnv): Set<string> {
+  const raw = env.SWITCHROOM_CREDITS_WATCH_FATAL_REASONS;
+  if (!raw || raw.trim().length === 0) return new Set(DEFAULT_CREDIT_FATAL_REASONS);
+  if (raw.trim() === "*") return new Set(KNOWN_CREDIT_REASONS);
+  const wanted = new Set(raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0));
+  return wanted;
+}
 
 export interface CreditState {
   /** Last reason we notified the user about. null when healthy / never notified. */
@@ -103,15 +135,22 @@ export function evaluateCreditState(args: {
   currentReason: string | null;
   prev: CreditState;
   now: number;
+  /**
+   * Which reasons are treated as fatal (worth alarming). Defaults to
+   * `DEFAULT_CREDIT_FATAL_REASONS` (empty — subscription-only: extra-usage-off
+   * is never a real failure). The gateway passes the env-resolved set.
+   */
+  fatalReasons?: Set<string>;
 }): CreditDecision {
   const { agentName, currentReason, prev, now } = args;
+  const fatalReasons = args.fatalReasons ?? DEFAULT_CREDIT_FATAL_REASONS;
 
   // Non-fatal current state (null, or some unknown reason) — no
   // notification regardless of prev (we already notified on entry to
   // fatal; recovery from a known-fatal state below is the only path
   // that fires when current is null).
-  const currentIsFatal = currentReason != null && FATAL_REASONS.has(currentReason);
-  const prevIsFatal = prev.lastNotifiedReason != null && FATAL_REASONS.has(prev.lastNotifiedReason);
+  const currentIsFatal = currentReason != null && fatalReasons.has(currentReason);
+  const prevIsFatal = prev.lastNotifiedReason != null && fatalReasons.has(prev.lastNotifiedReason);
 
   // Recovery path: last-notified was fatal, current is null/non-fatal.
   if (!currentIsFatal && prevIsFatal) {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -408,6 +408,7 @@ import { synthesizeAllowRuleDiff, extractAddedAllowRule } from '../permission-di
 import {
   readClaudeJsonOverage,
   evaluateCreditState,
+  resolveCreditWatchFatalReasons,
   loadCreditState,
   saveCreditState,
 } from '../credits-watch.js'
@@ -14742,6 +14743,9 @@ async function runCreditWatch(): Promise<void> {
     currentReason: reason,
     prev,
     now: Date.now(),
+    // Subscription-only: empty by default → extra-usage-off never alarms.
+    // Opt back in via SWITCHROOM_CREDITS_WATCH_FATAL_REASONS. See credits-watch.ts.
+    fatalReasons: resolveCreditWatchFatalReasons(process.env),
   })
   if (decision.kind === 'skip') {
     return

--- a/telegram-plugin/tests/credits-watch.test.ts
+++ b/telegram-plugin/tests/credits-watch.test.ts
@@ -13,6 +13,7 @@ import { join } from "path";
 import {
   readClaudeJsonOverage,
   evaluateCreditState,
+  resolveCreditWatchFatalReasons,
   loadCreditState,
   saveCreditState,
   emptyCreditState,
@@ -81,10 +82,14 @@ describe("readClaudeJsonOverage", () => {
   });
 });
 
-describe("evaluateCreditState — transition decisions", () => {
+describe("evaluateCreditState — transition decisions (machinery, explicit fatal set)", () => {
   const NOW = 1_780_000_000_000;
   const HEALTHY = emptyCreditState();
   const FATAL_OUT = { lastNotifiedReason: "out_of_credits", lastNotifiedAt: NOW - 1000 };
+  // The transition machinery is policy-agnostic — pass an explicit fatal set so
+  // these tests pin entered/changed/exited behaviour independent of the (now
+  // empty) subscription-only default.
+  const FATAL = new Set(["out_of_credits", "org_level_disabled", "credits_exhausted", "extra_usage_disabled"]);
 
   it("entry: healthy → fatal triggers a notify", () => {
     const d = evaluateCreditState({
@@ -92,6 +97,7 @@ describe("evaluateCreditState — transition decisions", () => {
       currentReason: "out_of_credits",
       prev: HEALTHY,
       now: NOW,
+      fatalReasons: FATAL,
     });
     expect(d.kind).toBe("notify");
     if (d.kind !== "notify") return;
@@ -108,6 +114,7 @@ describe("evaluateCreditState — transition decisions", () => {
       currentReason: "out_of_credits",
       prev: FATAL_OUT,
       now: NOW,
+      fatalReasons: FATAL,
     });
     expect(d.kind).toBe("skip");
     if (d.kind !== "skip") return;
@@ -120,6 +127,7 @@ describe("evaluateCreditState — transition decisions", () => {
       currentReason: "org_level_disabled",
       prev: FATAL_OUT,
       now: NOW,
+      fatalReasons: FATAL,
     });
     expect(d.kind).toBe("notify");
     if (d.kind !== "notify") return;
@@ -134,6 +142,7 @@ describe("evaluateCreditState — transition decisions", () => {
       currentReason: null,
       prev: FATAL_OUT,
       now: NOW,
+      fatalReasons: FATAL,
     });
     expect(d.kind).toBe("notify");
     if (d.kind !== "notify") return;
@@ -148,6 +157,7 @@ describe("evaluateCreditState — transition decisions", () => {
       currentReason: "some_unknown_transient_reason",
       prev: HEALTHY,
       now: NOW,
+      fatalReasons: FATAL,
     });
     expect(d.kind).toBe("skip");
     if (d.kind !== "skip") return;
@@ -160,6 +170,7 @@ describe("evaluateCreditState — transition decisions", () => {
       currentReason: null,
       prev: HEALTHY,
       now: NOW,
+      fatalReasons: FATAL,
     });
     expect(d.kind).toBe("skip");
   });
@@ -170,11 +181,64 @@ describe("evaluateCreditState — transition decisions", () => {
       currentReason: "out_of_credits",
       prev: HEALTHY,
       now: NOW,
+      fatalReasons: FATAL,
     });
     expect(d.kind).toBe("notify");
     if (d.kind !== "notify") return;
     expect(d.message).toContain("&lt;evil&gt;");
     expect(d.message).not.toContain("<evil>");
+  });
+});
+
+describe("evaluateCreditState — subscription-only default (the fix)", () => {
+  const NOW = 1_780_000_000_000;
+  const HEALTHY = emptyCreditState();
+
+  // With the default (empty) fatal set, NONE of the extra-usage reasons alarm —
+  // because for subscription-only switchroom, extra-usage-off is the expected
+  // state and real exhaustion is handled by failover. This is the bug fix.
+  for (const reason of ["out_of_credits", "extra_usage_disabled", "credits_exhausted", "org_level_disabled"]) {
+    it(`default: '${reason}' does NOT alarm (no false 'out of credits' card)`, () => {
+      const d = evaluateCreditState({
+        agentName: "clerk",
+        currentReason: reason,
+        prev: HEALTHY,
+        now: NOW,
+        // fatalReasons omitted → DEFAULT_CREDIT_FATAL_REASONS (empty)
+      });
+      expect(d.kind).toBe("skip");
+    });
+  }
+
+  it("opt-in via explicit set restores the alarm (operator on pay-as-you-go)", () => {
+    const d = evaluateCreditState({
+      agentName: "clerk",
+      currentReason: "out_of_credits",
+      prev: HEALTHY,
+      now: NOW,
+      fatalReasons: new Set(["out_of_credits"]),
+    });
+    expect(d.kind).toBe("notify");
+  });
+});
+
+describe("resolveCreditWatchFatalReasons", () => {
+  it("defaults to EMPTY (subscription-only)", () => {
+    expect(resolveCreditWatchFatalReasons({}).size).toBe(0);
+  });
+  it("parses a comma-separated opt-in list", () => {
+    const s = resolveCreditWatchFatalReasons({ SWITCHROOM_CREDITS_WATCH_FATAL_REASONS: "out_of_credits, org_level_disabled" });
+    expect(s.has("out_of_credits")).toBe(true);
+    expect(s.has("org_level_disabled")).toBe(true);
+    expect(s.size).toBe(2);
+  });
+  it("'*' opts in all known reasons", () => {
+    const s = resolveCreditWatchFatalReasons({ SWITCHROOM_CREDITS_WATCH_FATAL_REASONS: "*" });
+    expect(s.has("out_of_credits")).toBe(true);
+    expect(s.size).toBeGreaterThanOrEqual(4);
+  });
+  it("blank/whitespace → empty", () => {
+    expect(resolveCreditWatchFatalReasons({ SWITCHROOM_CREDITS_WATCH_FATAL_REASONS: "  " }).size).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Agents were posting `⚠️ out of pre-paid credits — cron tasks and inbound replies will fail until resolved · check your subscription or pre-paid usage`. **It's a false alarm.**

The card comes from `credits-watch` reading `cachedExtraUsageDisabledReason=out_of_credits` from `.claude.json`. By its name, that flag is *always* "why **extra usage** (the optional pay-as-you-go layer beyond the Pro/Max plan) is disabled." switchroom is **subscription-only by design** (compliance pillar 3 — the plan is the ceiling, no API/pay-as-you-go), so extra usage being **off is the expected, desired state**. Every reason value (`out_of_credits` / `extra_usage_disabled` / `credits_exhausted` / `org_level_disabled` = "org admin disabled *extra usage*") describes that benign state — **none indicates a real switchroom failure.** The card also advised buying credits, which *contradicts* the subscription-honest model.

**Evidence it was benign:** the flag was cleared fleet-wide, agents kept answering (clerk completed a 6-tool reply right after the card), all accounts healthy.

The genuine failure modes are already covered:
- an account's subscription window exhausts → stderr → **fleet auto-fallback** rolls to a healthy account (#2206);
- the **whole** fleet exhausts → the **all-exhausted alert** (#2215).

So credits-watch's `out_of_credits` alarm is redundant noise on top.

## Change
- `DEFAULT_CREDIT_FATAL_REASONS` is now **empty** (subscription-only: extra-usage-off never alarms).
- `resolveCreditWatchFatalReasons(env)` — **opt back in** via `SWITCHROOM_CREDITS_WATCH_FATAL_REASONS` (comma list, or `*`) for an operator who actually runs on pay-as-you-go.
- `evaluateCreditState` takes an optional `fatalReasons` set; gateway passes the env-resolved one.
- The transition **machinery** (entered/changed/exited) is unchanged — only the default *policy* of which reasons are fatal changed (now none). Fully reversible via env.

## Re-scope note
Diagnosis revealed the flag is *categorically* about extra-usage (even `org_level_disabled`), so the right fix was to default the whole alarm off for subscription-only — not just drop one reason. Surfaced + verified before building.

## Test plan
- [x] machinery tests pass an explicit fatal set (policy-agnostic)
- [x] new: default (empty) set → each extra-usage reason **skips** (the fix); explicit opt-in restores the alarm; `resolveCreditWatchFatalReasons` default-empty / comma-parse / `*` / blank
- [x] **28 tests pass under both vitest AND bun**; `tsc` + `check-plugin-references` + `check-bot-api-wrapping` clean

## Risk
Low. Observability-only; reversible via env. Worst case = a real pay-as-you-go operator misses the alarm until they set the env var (switchroom isn't that — subscription-only is the whole product). Genuine exhaustion still surfaces via failover + all-exhausted alert.

## Rollout
Gateway change → staggered fleet restart, or fold into the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)