### PR TITLE
fix(failover): durably hold weekly-quota auto-fallback (clerk wedge)

### DIFF
--- a/src/agents/wedge-watchdog.ts
+++ b/src/agents/wedge-watchdog.ts
@@ -59,15 +59,28 @@ export const WEDGE_FOOTER_SIGNATURE =
  * Hence a dedicated detector.
  *
  * Two INDEPENDENT anchors, both required, so it can never false-positive on
- * normal model output (verified against the live wedged pane, 2026-06-07):
- *   (a) the literal slash-command claude prints for this menu, which cannot
- *       appear in ordinary output: `/rate-limit-options`;
- *   (b) an option string ONLY this menu shows: "Switch to usage credits" or
- *       "Upgrade your plan".
- * (Grep of the repo confirmed zero pre-existing occurrences of any of these.)
+ * normal model output (verified against the live wedged panes, 2026-06-07):
+ *   (a) the interactive selector's option-1 row, which sits at the BOTTOM of
+ *       the pane (where the cursor is) and is therefore always inside the
+ *       captured viewport: "Stop and wait for …";
+ *   (b) an option string ONLY this menu shows: "usage credits" (covers both
+ *       "Switch to usage credits" and the newer "Add funds to continue with
+ *       usage credits" wording), "Upgrade your plan", or the literal
+ *       `/rate-limit-options` slash-command claude prints for the menu.
+ *
+ * v0.14.84 (#2218) anchored (a) on `/rate-limit-options` itself — but that
+ * line is printed ABOVE the menu options, so on a pane with enough preceding
+ * output it scrolls OFF the top of the `tmux capture-pane -p` viewport (which
+ * grabs only the visible ~50 lines, no scrollback). clerk wedged exactly this
+ * way on 2026-06-07 and the detector stayed silent (zero log fires). The fix
+ * re-anchors (a) on the option-1 row, which is pinned to the bottom of the
+ * pane and cannot scroll off; `/rate-limit-options` survives only as one of
+ * the (b) alternatives. "Stop and wait for" (not the full "…limit to reset")
+ * absorbs minor CLI wording drift (e.g. "…for your limit to reset").
+ * (Grep of the repo confirmed zero pre-existing occurrences of these.)
  */
 export const RATE_LIMIT_MENU_SIGNATURE =
-  /(?=[\s\S]*\/rate-limit-options)(?=[\s\S]*(?:Switch to usage credits|Upgrade your plan))/;
+  /(?=[\s\S]*Stop and wait for)(?=[\s\S]*(?:usage credits|Upgrade your plan|\/rate-limit-options))/;
 
 const MONTHS: Record<string, number> = {
   jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -2090,20 +2090,22 @@ describe("AuthBroker — historical-bug regressions (2026-05-14 fanout incident)
 });
 
 describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall durability)", () => {
-  // Fleet: active=ken, fallback ken→pixsoul, one agent (clerk). The auto-
-  // fallback path (mark-exhausted) marks ken's quota + mirrors the fallback
-  // ONCE but never rewrites auth.active, so the exhaustion-BLIND refresh-tick
-  // fanout used to silently re-mirror ken back onto the fleet within ~1h.
-  // These pin that the serving + fanout reads now honour the exhaustion window.
+  // Fleet: active=default, fallback default→secondary, one agent (clerk). The
+  // auto-fallback path (mark-exhausted) marks the active account's quota +
+  // mirrors the fallback ONCE but never rewrites auth.active, so the
+  // exhaustion-BLIND refresh-tick fanout used to silently re-mirror the walled
+  // account back onto the fleet within ~1h. These pin that the serving + fanout
+  // reads now honour the exhaustion window. (Models the real clerk incident,
+  // 2026-06-07, with neutral account labels.)
   function failoverHarness(opts: { now?: () => number } = {}) {
     const h = makeHarness();
     const config = makeConfig(h, {
-      active: "ken",
-      fallback_order: ["ken", "pixsoul"],
+      active: "default",
+      fallback_order: ["default", "secondary"],
       agents: { clerk: {} },
     });
-    seedAccount(h, "ken");
-    seedAccount(h, "pixsoul");
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
     mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
     const broker = new AuthBroker(config, {
       home: h.home,
@@ -2126,30 +2128,30 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     let resp = (await rpc(clerkSock, { v: 1, id: "1", op: "get-credentials" })) as {
       ok: boolean; data: { account: string };
     };
-    expect(resp.data.account).toBe("ken"); // healthy
-    // clerk hits the weekly wall → mark-exhausted(ken) with a weekly until.
+    expect(resp.data.account).toBe("default"); // healthy
+    // clerk hits the weekly wall → mark-exhausted(default) with a weekly until.
     await rpc(clerkSock, { v: 1, id: "2", op: "mark-exhausted", until: Date.now() + 7 * 24 * 3600_000 });
     resp = (await rpc(clerkSock, { v: 1, id: "3", op: "get-credentials" })) as {
       ok: boolean; data: { account: string };
     };
     expect(resp.ok).toBe(true);
-    expect(resp.data.account).toBe("pixsoul"); // NOT the walled ken
+    expect(resp.data.account).toBe("secondary"); // NOT the walled active
     broker.stop();
   });
 
   it("a refresh-tick fanout during exhaustion never re-mirrors the walled account (the rollback guard)", async () => {
     const { broker, clerkSock, mirror } = failoverHarness();
     await broker.start();
-    expect(readFileSync(mirror, "utf-8")).toContain("at-ken"); // boot mirror
+    expect(readFileSync(mirror, "utf-8")).toContain("at-default"); // boot mirror
     await rpc(clerkSock, { v: 1, id: "1", op: "mark-exhausted", until: Date.now() + 7 * 24 * 3600_000 });
-    expect(readFileSync(mirror, "utf-8")).toContain("at-pixsoul"); // failover fanout
-    // The exhaustion-BLIND refresh-tick fanout fires. auth.active is STILL ken
-    // (mark-exhausted never rewrote it), so pre-fix fanoutForAgent re-mirrored
-    // ken's refreshed-but-walled creds here → the rollback. Now it must hold.
+    expect(readFileSync(mirror, "utf-8")).toContain("at-secondary"); // failover fanout
+    // The exhaustion-BLIND refresh-tick fanout fires. auth.active is STILL the
+    // walled account (mark-exhausted never rewrote it), so pre-fix fanoutForAgent
+    // re-mirrored its refreshed-but-walled creds here → the rollback. Must hold.
     broker._fanoutAll();
     const after = readFileSync(mirror, "utf-8");
-    expect(after).toContain("at-pixsoul");
-    expect(after).not.toContain("at-ken");
+    expect(after).toContain("at-secondary");
+    expect(after).not.toContain("at-default");
     broker.stop();
   });
 
@@ -2165,25 +2167,25 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     let resp = (await rpc(clerkSock, { v: 1, id: "2", op: "get-credentials" })) as {
       ok: boolean; data: { account: string };
     };
-    expect(resp.data.account).toBe("pixsoul");
-    // Past the weekly window → auto-revert to ken (consumer-failover semantics).
+    expect(resp.data.account).toBe("secondary");
+    // Past the weekly window → auto-revert to the active account.
     clock = weeklyUntil + 1;
     resp = (await rpc(clerkSock, { v: 1, id: "3", op: "get-credentials" })) as {
       ok: boolean; data: { account: string };
     };
-    expect(resp.data.account).toBe("ken");
+    expect(resp.data.account).toBe("default");
     broker.stop();
   });
 
   it("keeps serving the walled active when EVERY fallback is also exhausted (retry beats dark)", async () => {
     const h = makeHarness();
     const config = makeConfig(h, {
-      active: "ken",
-      fallback_order: ["ken", "pixsoul"],
-      agents: { clerk: {}, gymbro: { auth: { override: "pixsoul" } } },
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      agents: { clerk: {}, gymbro: { auth: { override: "secondary" } } },
     });
-    seedAccount(h, "ken");
-    seedAccount(h, "pixsoul");
+    seedAccount(h, "default");
+    seedAccount(h, "secondary");
     mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
     mkdirSync(join(h.agentsDir, "gymbro"), { recursive: true });
     const broker = new AuthBroker(config, {
@@ -2191,15 +2193,15 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     });
     await broker.start();
     const until = Date.now() + 7 * 24 * 3600_000;
-    await rpc(join(h.socketRoot, "clerk", "sock"), { v: 1, id: "1", op: "mark-exhausted", until }); // marks ken
-    await rpc(join(h.socketRoot, "gymbro", "sock"), { v: 1, id: "2", op: "mark-exhausted", until }); // marks pixsoul
-    // clerk on ken (walled); its only fallback pixsoul is walled too → no
-    // healthy alternative → serve the pinned/active ken (retry) not nothing.
+    await rpc(join(h.socketRoot, "clerk", "sock"), { v: 1, id: "1", op: "mark-exhausted", until }); // marks default
+    await rpc(join(h.socketRoot, "gymbro", "sock"), { v: 1, id: "2", op: "mark-exhausted", until }); // marks secondary
+    // clerk on default (walled); its only fallback secondary is walled too → no
+    // healthy alternative → serve the pinned/active default (retry) not nothing.
     const resp = (await rpc(join(h.socketRoot, "clerk", "sock"), {
       v: 1, id: "3", op: "get-credentials",
     })) as { ok: boolean; data: { account: string } };
     expect(resp.ok).toBe(true);
-    expect(resp.data.account).toBe("ken");
+    expect(resp.data.account).toBe("default");
     broker.stop();
   });
 });

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -2088,3 +2088,118 @@ describe("AuthBroker — historical-bug regressions (2026-05-14 fanout incident)
     broker.stop();
   });
 });
+
+describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall durability)", () => {
+  // Fleet: active=ken, fallback ken→pixsoul, one agent (clerk). The auto-
+  // fallback path (mark-exhausted) marks ken's quota + mirrors the fallback
+  // ONCE but never rewrites auth.active, so the exhaustion-BLIND refresh-tick
+  // fanout used to silently re-mirror ken back onto the fleet within ~1h.
+  // These pin that the serving + fanout reads now honour the exhaustion window.
+  function failoverHarness(opts: { now?: () => number } = {}) {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "ken",
+      fallback_order: ["ken", "pixsoul"],
+      agents: { clerk: {} },
+    });
+    seedAccount(h, "ken");
+    seedAccount(h, "pixsoul");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      now: opts.now,
+    });
+    return {
+      h,
+      broker,
+      clerkSock: join(h.socketRoot, "clerk", "sock"),
+      mirror: join(h.agentsDir, "clerk", ".claude", ".credentials.json"),
+    };
+  }
+
+  it("serves an agent its healthy fallback while auth.active is walled", async () => {
+    const { broker, clerkSock } = failoverHarness();
+    await broker.start();
+    let resp = (await rpc(clerkSock, { v: 1, id: "1", op: "get-credentials" })) as {
+      ok: boolean; data: { account: string };
+    };
+    expect(resp.data.account).toBe("ken"); // healthy
+    // clerk hits the weekly wall → mark-exhausted(ken) with a weekly until.
+    await rpc(clerkSock, { v: 1, id: "2", op: "mark-exhausted", until: Date.now() + 7 * 24 * 3600_000 });
+    resp = (await rpc(clerkSock, { v: 1, id: "3", op: "get-credentials" })) as {
+      ok: boolean; data: { account: string };
+    };
+    expect(resp.ok).toBe(true);
+    expect(resp.data.account).toBe("pixsoul"); // NOT the walled ken
+    broker.stop();
+  });
+
+  it("a refresh-tick fanout during exhaustion never re-mirrors the walled account (the rollback guard)", async () => {
+    const { broker, clerkSock, mirror } = failoverHarness();
+    await broker.start();
+    expect(readFileSync(mirror, "utf-8")).toContain("at-ken"); // boot mirror
+    await rpc(clerkSock, { v: 1, id: "1", op: "mark-exhausted", until: Date.now() + 7 * 24 * 3600_000 });
+    expect(readFileSync(mirror, "utf-8")).toContain("at-pixsoul"); // failover fanout
+    // The exhaustion-BLIND refresh-tick fanout fires. auth.active is STILL ken
+    // (mark-exhausted never rewrote it), so pre-fix fanoutForAgent re-mirrored
+    // ken's refreshed-but-walled creds here → the rollback. Now it must hold.
+    broker._fanoutAll();
+    const after = readFileSync(mirror, "utf-8");
+    expect(after).toContain("at-pixsoul");
+    expect(after).not.toContain("at-ken");
+    broker.stop();
+  });
+
+  it("a weekly until holds past markExhausted's ~5h default, then auto-reverts", async () => {
+    let clock = Date.UTC(2026, 5, 7, 0, 0, 0);
+    const { broker, clerkSock } = failoverHarness({ now: () => clock });
+    await broker.start();
+    const weeklyUntil = clock + 7 * 24 * 3600_000;
+    await rpc(clerkSock, { v: 1, id: "1", op: "mark-exhausted", until: weeklyUntil });
+    // 6h in — PAST the ~5h MARK_EXHAUSTED_DEFAULT_MS. Pre-RC#2 a weekly wall got
+    // that ~5h default and would have un-exhausted + rolled back right here.
+    clock = Date.UTC(2026, 5, 7, 6, 0, 0);
+    let resp = (await rpc(clerkSock, { v: 1, id: "2", op: "get-credentials" })) as {
+      ok: boolean; data: { account: string };
+    };
+    expect(resp.data.account).toBe("pixsoul");
+    // Past the weekly window → auto-revert to ken (consumer-failover semantics).
+    clock = weeklyUntil + 1;
+    resp = (await rpc(clerkSock, { v: 1, id: "3", op: "get-credentials" })) as {
+      ok: boolean; data: { account: string };
+    };
+    expect(resp.data.account).toBe("ken");
+    broker.stop();
+  });
+
+  it("keeps serving the walled active when EVERY fallback is also exhausted (retry beats dark)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "ken",
+      fallback_order: ["ken", "pixsoul"],
+      agents: { clerk: {}, gymbro: { auth: { override: "pixsoul" } } },
+    });
+    seedAccount(h, "ken");
+    seedAccount(h, "pixsoul");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    mkdirSync(join(h.agentsDir, "gymbro"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+    });
+    await broker.start();
+    const until = Date.now() + 7 * 24 * 3600_000;
+    await rpc(join(h.socketRoot, "clerk", "sock"), { v: 1, id: "1", op: "mark-exhausted", until }); // marks ken
+    await rpc(join(h.socketRoot, "gymbro", "sock"), { v: 1, id: "2", op: "mark-exhausted", until }); // marks pixsoul
+    // clerk on ken (walled); its only fallback pixsoul is walled too → no
+    // healthy alternative → serve the pinned/active ken (retry) not nothing.
+    const resp = (await rpc(join(h.socketRoot, "clerk", "sock"), {
+      v: 1, id: "3", op: "get-credentials",
+    })) as { ok: boolean; data: { account: string } };
+    expect(resp.ok).toBe(true);
+    expect(resp.data.account).toBe("ken");
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -973,8 +973,13 @@ export class AuthBroker {
    */
   private servingAccount(identity: Identity): string | null {
     const account = this.callerAccount(identity);
-    if (identity.kind !== "consumer") return account;
-    return this.consumerAccountWithFailover(account);
+    // Operator serving stays attribution-true — the operator CLI owns
+    // auth.active explicitly and a forced `auth use` must mirror exactly what
+    // it asked for. Consumers (pinned for quota isolation) AND agents (riding
+    // the swappable auth.active) both fail a walled account over so neither is
+    // ever served exhausted credentials.
+    if (identity.kind === "operator") return account;
+    return this.accountWithFailover(account);
   }
 
   /** True if `account` is currently within a mark-exhausted window. */
@@ -984,18 +989,30 @@ export class AuthBroker {
   }
 
   /**
-   * A consumer's pinned account, unless it's exhausted — then the first
+   * `account`, unless it's within a mark-exhausted window — then the first
    * non-exhausted account in `fallback_order` that has stored credentials.
-   * Falls back to the pinned account if no healthy alternative exists (better
-   * to retry the pinned one than serve nothing).
+   * Falls back to `account` itself when no healthy alternative exists (better
+   * to retry the pinned/active account than serve nothing — an all-walled
+   * fleet keeps trying rather than going dark).
+   *
+   * Shared by the consumer serving path AND the agent serving/fanout path.
+   * The agent path is the durable half of the #2218 weekly-wall fix:
+   * `mark-exhausted` marks quota + mirrors failover creds once but leaves
+   * `auth.active` pointed at the walled account, so the exhaustion-BLIND
+   * refresh-tick fanout (refreshOneAccount → fanoutToAffectedAgents, every
+   * ~1h when the walled account's OAuth token refreshes — refresh works fine,
+   * a quota wall is not an auth failure) would otherwise silently re-mirror the
+   * walled creds back onto the fleet, undoing the auto-fallback. Routing
+   * fanout + serving through this read makes the exhaustion window actually
+   * hold, and — like the consumer path — auto-reverts once the window passes.
    */
-  private consumerAccountWithFailover(pinned: string | null): string | null {
-    if (!pinned || !this.isAccountExhausted(pinned)) return pinned;
+  private accountWithFailover(account: string | null | undefined): string | null {
+    if (!account || !this.isAccountExhausted(account)) return account ?? null;
     for (const cand of this.config.auth?.fallback_order ?? []) {
-      if (cand === pinned || this.isAccountExhausted(cand)) continue;
+      if (cand === account || this.isAccountExhausted(cand)) continue;
       if (readAccountCredentials(cand, this.home)) return cand;
     }
-    return pinned;
+    return account;
   }
 
   /* ─── Op handlers ───────────────────────────────────────────── */
@@ -1180,7 +1197,7 @@ export class AuthBroker {
   /**
    * Consumer-account quota sensor tick. Probes every account pinned by a
    * consumer and, when a probe shows a hard wall, marks it exhausted so the
-   * consumer's serving-failover (consumerAccountWithFailover) kicks in. This
+   * consumer's serving-failover (accountWithFailover) kicks in. This
    * is the missing TRIGGER for a consumer (e.g. hindsight) on a dedicated
    * account that no agent shares — nothing else ever raises mark-exhausted for
    * it. Public for tests (driven directly via the `_testFetchQuota` seam).
@@ -2070,12 +2087,18 @@ export class AuthBroker {
     return out;
   }
 
-  /** Fan out to every agent whose effective account == label. */
+  /** Fan out to every agent whose effective (failover-resolved) account == label. */
   private fanoutToAffectedAgents(label: string): string[] {
     const auth = this.config.auth ?? {};
     const fanned: string[] = [];
     for (const [name, agent] of Object.entries(this.config.agents ?? {})) {
-      const effective = agent.auth?.override ?? auth.active;
+      // Match on the SERVED account (post exhaustion-failover), not the raw
+      // auth.active. When auth.active is walled, an agent's served account is
+      // its healthy fallback — so refreshing the fallback re-mirrors it, while
+      // refreshing the walled account matches no agent (it serves none) and so
+      // can never re-mirror walled creds. With nothing exhausted this is
+      // identical to matching auth.active.
+      const effective = this.accountWithFailover(agent.auth?.override ?? auth.active);
       if (effective === label) {
         if (this.fanoutForAgent(name)) fanned.push(name);
       }
@@ -2124,7 +2147,11 @@ export class AuthBroker {
     const auth = this.config.auth ?? {};
     const agent = (this.config.agents ?? {})[name];
     if (!agent) return false;
-    const effective = agent.auth?.override ?? auth.active;
+    // Mirror the effective account THROUGH exhaustion-failover: when the raw
+    // effective (override ?? auth.active) is walled, write the healthy fallback
+    // instead. Without this, a refresh-tick fanout of the walled account would
+    // re-mirror it onto the agent and undo the auto-fallback (#2218 durability).
+    const effective = this.accountWithFailover(agent.auth?.override ?? auth.active);
     if (!effective) return false;
     return this.mirrorAccountToAgent(effective, name);
   }

--- a/telegram-plugin/gateway/exhaust-until.ts
+++ b/telegram-plugin/gateway/exhaust-until.ts
@@ -1,0 +1,45 @@
+/**
+ * exhaust-until.ts — the single decision for the `until` (epoch-ms) handed to
+ * the broker's mark-exhausted, shared by BOTH quota-wall paths in the gateway:
+ *   - the /rate-limit-options menu signal (onQuotaWallDetected), and
+ *   - the inference-path 429 (the model-unavailable operator-event path).
+ *
+ * Factored out of gateway.ts so the decision is unit-testable without importing
+ * the gateway module (heavy import-time side effects). Pure: no IPC, no clock
+ * except the injectable `now`.
+ *
+ * The ONE invariant both paths depend on: NEVER return undefined. A weekly wall
+ * reaches the gateway as a reset hint the parser can't always read:
+ *   - Menu path: the sidecar's parseWeeklyReset handles "resets Jun 9, 5am (tz)"
+ *     → a finite future epoch flows straight through.
+ *   - 429 path: model-unavailable.ts's parseResetTime handles the ROLLING
+ *     wordings ("resets in 2h", "retry after 60s") → a finite ~hours epoch. But
+ *     the WEEKLY wording reaches it as "resets <Mon> <D>, <H>am", which
+ *     parseResetTime CANNOT parse (`new Date('Jun 9, 5am 2026')` → Invalid Date)
+ *     → resetAtMs is undefined here EXACTLY when the wall is weekly.
+ *
+ * undefined (or a past / NaN reset) is the dangerous case: markExhausted's ~5h
+ * default would un-exhaust a weekly-walled account after 5h and let the broker
+ * re-mirror it onto the fleet (the #2218 rollback). So undefined → the +7d
+ * floor. A too-long `until` only delays the broker's re-probe of the account;
+ * it never serves an exhausted account, so erring long is the compliance-safe
+ * direction (vision.md pillar 3).
+ */
+
+/** Weekly-quota window — the safety floor for an exhaustion `until`. */
+export const EXHAUST_WEEKLY_FLOOR_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * Resolve the exhaustion `until` (epoch-ms) from a best-effort reset timestamp.
+ * Returns `resetAtMs` when it is a finite epoch in the future; otherwise the
+ * +7d floor anchored at `now`. NEVER returns undefined.
+ */
+export function resolveExhaustUntil(
+  resetAtMs: number | undefined,
+  now: number = Date.now(),
+): number {
+  if (typeof resetAtMs === 'number' && Number.isFinite(resetAtMs) && resetAtMs > now) {
+    return resetAtMs
+  }
+  return now + EXHAUST_WEEKLY_FLOOR_MS
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -14687,10 +14687,12 @@ async function doFireFleetAutoFallback(triggerAgent: string, untilMs?: number): 
       // operator is explicitly choosing, and is admin); only this automatic
       // path moves to the non-admin verb.
       failover: async () => {
-        // The 429 inference path passes no `until` (broker ~5h default). The
-        // rate-limit-MENU path (quota_wall_detected) passes the parsed WEEKLY
-        // reset, so the walled account isn't re-probed (and re-wedged) within
-        // the 5h default while it's weekly-capped.
+        // BOTH paths now pass a resolved `untilMs` via resolveExhaustUntil
+        // (never undefined): the rate-limit-MENU path threads the parsed weekly
+        // reset, and the 429 inference path threads parseResetTime's value or
+        // the +7d floor when it's a weekly wall it can't parse. So a
+        // weekly-capped account is never re-probed (and re-wedged) within the
+        // broker's ~5h default.
         const r = await client.markExhausted(untilMs)
         return { rolledTo: r.rolledTo ?? null, rolled: r.rolled }
       },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -125,6 +125,7 @@ import {
 } from './microsoft-connect-flow.js'
 import { resolveAuthBrokerSocketPath } from '../../src/auth/broker/client.js'
 import { createFleetFallbackGate } from '../fleet-fallback-gate.js'
+import { resolveExhaustUntil } from './exhaust-until.js'
 import {
   pendingAuthAddFlows,
   startAccountAuthSession,
@@ -4400,8 +4401,17 @@ function emitGatewayOperatorEvent(event: OperatorEvent): void {
     // separately with the causal-shape headline ("5-hour limit on
     // ken" instead of generic "quota exhausted") — see
     // auth-snapshot-format.ts → renderFallbackAnnouncement.
+    //
+    // Thread the parsed reset as markExhausted's `until` via the shared
+    // resolveExhaustUntil floor. parseResetTime gives a finite epoch for
+    // ROLLING wordings ("resets in 2h", "retry after 60s"); a WEEKLY wall
+    // ("resets Jun 9, 5am") is UNPARSEABLE here → undefined → +7d floor.
+    // Pre-fix this called fireFleetAutoFallback(agent) with no until, so a
+    // weekly wall that surfaced as a 429 got markExhausted's ~5h default and
+    // the broker re-mirrored the still-walled account onto the fleet after 5h.
     if (willActuallyFire) {
-      void fireFleetAutoFallback(agent)
+      const untilMs = resolveExhaustUntil(modelUnavailable.resetAt?.getTime())
+      void fireFleetAutoFallback(agent, untilMs)
     }
   } else {
     try {
@@ -6271,11 +6281,7 @@ const ipcServer: IpcServer = createIpcServer({
   // existing chain handles the rest (roll to a fallback subscription account,
   // or the all-exhausted operator alert when none has quota). Fire-and-forget.
   onQuotaWallDetected(_client: IpcClient, msg: QuotaWallDetectedMessage) {
-    const WEEKLY_MS = 7 * 24 * 60 * 60 * 1000
-    const untilMs =
-      typeof msg.resetAt === 'number' && Number.isFinite(msg.resetAt) && msg.resetAt > Date.now()
-        ? msg.resetAt
-        : Date.now() + WEEKLY_MS
+    const untilMs = resolveExhaustUntil(msg.resetAt)
     process.stderr.write(
       `telegram gateway: quota_wall_detected agent=${msg.agentName} ` +
         `until=${new Date(untilMs).toISOString()}` +

--- a/telegram-plugin/tests/exhaust-until.test.ts
+++ b/telegram-plugin/tests/exhaust-until.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the shared exhaustion-`until` decision (exhaust-until.ts) and
+ * the 429-path composition it sits in.
+ *
+ * The load-bearing invariant (vision.md pillar 3 + the #2218 weekly-wall
+ * rollback): the value handed to markExhausted is NEVER undefined, so a weekly
+ * wall can never fall back to the broker's ~5h default and un-exhaust early.
+ *
+ * The 429-path composition test runs the REAL detectModelUnavailable
+ * (model-unavailable.ts) into the REAL resolveExhaustUntil — proving the gateway
+ * 429 branch (`resolveExhaustUntil(modelUnavailable.resetAt?.getTime())`) threads
+ * a finite `until` for both the rolling and the unparseable-weekly wordings.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { resolveExhaustUntil, EXHAUST_WEEKLY_FLOOR_MS } from '../gateway/exhaust-until.js'
+import { detectModelUnavailable } from '../model-unavailable.js'
+
+const NOW = Date.UTC(2026, 5, 7, 0, 0, 0) // 2026-06-07
+
+describe('resolveExhaustUntil', () => {
+  it('passes through a finite reset in the future', () => {
+    const reset = NOW + 2 * 60 * 60 * 1000 // +2h (a rolling window)
+    expect(resolveExhaustUntil(reset, NOW)).toBe(reset)
+  })
+
+  it('undefined → +7d floor (the WEEKLY-wall case), never undefined', () => {
+    const until = resolveExhaustUntil(undefined, NOW)
+    expect(until).toBe(NOW + EXHAUST_WEEKLY_FLOOR_MS)
+    expect(until).toBeGreaterThan(NOW + 5 * 60 * 60 * 1000) // past the ~5h default
+  })
+
+  it('a past / now / NaN / non-finite reset → +7d floor (treated as unparsed)', () => {
+    expect(resolveExhaustUntil(NOW - 1, NOW)).toBe(NOW + EXHAUST_WEEKLY_FLOOR_MS)
+    expect(resolveExhaustUntil(NOW, NOW)).toBe(NOW + EXHAUST_WEEKLY_FLOOR_MS)
+    expect(resolveExhaustUntil(Number.NaN, NOW)).toBe(NOW + EXHAUST_WEEKLY_FLOOR_MS)
+    expect(resolveExhaustUntil(Number.POSITIVE_INFINITY, NOW)).toBe(NOW + EXHAUST_WEEKLY_FLOOR_MS)
+  })
+
+  it('the floor is comfortably longer than the broker ~5h mark-exhausted default', () => {
+    expect(EXHAUST_WEEKLY_FLOOR_MS).toBeGreaterThan(5 * 60 * 60 * 1000)
+    expect(EXHAUST_WEEKLY_FLOOR_MS).toBe(7 * 24 * 60 * 60 * 1000)
+  })
+})
+
+describe('429-path composition: detectModelUnavailable → resolveExhaustUntil', () => {
+  // This mirrors gateway.ts's 429 branch:
+  //   const untilMs = resolveExhaustUntil(modelUnavailable.resetAt?.getTime())
+  // NB: parseResetTime anchors RELATIVE wordings ("in 2h", "retry after Ns") at
+  // the real Date.now() — not injectable through detectModelUnavailable — so the
+  // rolling-window assertions check the SHAPE (finite, future, well below the
+  // +7d floor, no longer than the stated window), never an exact epoch.
+  function untilFor(stderr: string): { u: number; before: number } {
+    const before = Date.now()
+    const d = detectModelUnavailable(stderr)
+    expect(d).not.toBeNull()
+    return { u: resolveExhaustUntil(d?.resetAt?.getTime(), before), before }
+  }
+
+  it('ROLLING wording ("resets in 2h 15m") → a finite ~2h until, NOT the +7d floor', () => {
+    const { u, before } = untilFor('usage limit reached · resets in 2h 15m')
+    expect(Number.isFinite(u)).toBe(true)
+    expect(u).toBeGreaterThan(before)
+    const window = (2 * 60 + 15) * 60 * 1000
+    expect(u).toBeLessThanOrEqual(before + window + 2000) // ~2h15m, allow detect/resolve skew
+    expect(u).toBeLessThan(before + EXHAUST_WEEKLY_FLOOR_MS / 2) // unmistakably NOT the floor
+  })
+
+  it('ROLLING wording ("retry after 60 seconds") → a finite ~60s until, NOT the +7d floor', () => {
+    const { u, before } = untilFor('rate_limit_error: retry after 60 seconds — usage limit')
+    expect(u).toBeGreaterThan(before)
+    expect(u).toBeLessThanOrEqual(before + 60 * 1000 + 2000)
+    expect(u).toBeLessThan(before + EXHAUST_WEEKLY_FLOOR_MS / 2)
+  })
+
+  it("WEEKLY wording (\"resets Jun 9, 5am (tz)\") is UNPARSEABLE on the 429 path → +7d floor, NOT undefined/5h", () => {
+    // parseResetTime can't read the calendar weekly wording — Invalid Date →
+    // resetAt undefined. resolveExhaustUntil MUST floor it to +7d, otherwise
+    // markExhausted's ~5h default re-wedges the weekly-walled account.
+    const d = detectModelUnavailable("You've hit your limit · resets Jun 9, 5am (Australia/Melbourne)")
+    expect(d?.kind).toBe('quota_exhausted')
+    expect(d?.resetAt).toBeUndefined() // pins the parser-blind-spot premise
+    const u = resolveExhaustUntil(d?.resetAt?.getTime(), NOW)
+    expect(u).toBe(NOW + EXHAUST_WEEKLY_FLOOR_MS)
+  })
+})

--- a/tests/rate-limit-menu-detect.test.ts
+++ b/tests/rate-limit-menu-detect.test.ts
@@ -30,6 +30,25 @@ const RATE_LIMIT_SCREEN =
   "\n" +
   "  Enter to confirm · Esc to cancel";
 
+// The REAL way clerk wedged, 2026-06-07: the SAME menu, but with enough
+// preceding output that the `❯ /rate-limit-options` prompt line scrolled OFF
+// the top of the `tmux capture-pane -p` viewport (no scrollback). The v0.14.84
+// detector anchored on `/rate-limit-options` and so stayed SILENT here (zero
+// log fires) while clerk sat dead. This fixture omits that line and uses the
+// newer option-2 wording ("Add funds to continue with usage credits"). The
+// re-anchored signature (option-1 menu-body row + "usage credits") must match.
+const CLERK_RATE_LIMIT_SCREEN =
+  "  ⎿  You've hit your weekly limit · resets Jun 9, 5am (Australia/Melbourne)\n" +
+  "\n" +
+  "────────────────────────────────────────\n" +
+  "  What do you want to do?\n" +
+  "\n" +
+  "  ❯ 1. Stop and wait for limit to reset\n" +
+  "    2. Add funds to continue with usage credits\n" +
+  "    3. Upgrade your plan\n" +
+  "\n" +
+  "  Enter to confirm · Esc to cancel";
+
 const NORMAL_SCREEN =
   "⏵⏵ accept edits on (shift+tab to cycle) · esc to interrupt\n❯ ";
 
@@ -43,16 +62,25 @@ function recordSend() {
 }
 
 describe("RATE_LIMIT_MENU_SIGNATURE", () => {
-  it("matches the real /rate-limit-options pane", () => {
+  it("matches the real finn pane (prompt line present)", () => {
     expect(RATE_LIMIT_MENU_SIGNATURE.test(RATE_LIMIT_SCREEN)).toBe(true);
+  });
+  it("matches clerk's scroll-off pane: NO /rate-limit-options line + 'Add funds…' wording (the #2218 blind spot)", () => {
+    // This is the case the v0.14.84 detector MISSED — the regression guard.
+    expect(CLERK_RATE_LIMIT_SCREEN).not.toContain("/rate-limit-options");
+    expect(RATE_LIMIT_MENU_SIGNATURE.test(CLERK_RATE_LIMIT_SCREEN)).toBe(true);
   });
   it("does NOT match normal output / a generic modal / empty", () => {
     expect(RATE_LIMIT_MENU_SIGNATURE.test(NORMAL_SCREEN)).toBe(false);
     expect(RATE_LIMIT_MENU_SIGNATURE.test("Which option?\n❯ 1. Yes\n  2. No\nEnter to select · Esc to cancel")).toBe(false);
     expect(RATE_LIMIT_MENU_SIGNATURE.test("")).toBe(false);
     // Needs BOTH anchors — one alone is not enough.
+    // anchor B alone (no option-1 menu-body row):
     expect(RATE_LIMIT_MENU_SIGNATURE.test("see /rate-limit-options docs")).toBe(false);
     expect(RATE_LIMIT_MENU_SIGNATURE.test("you could Upgrade your plan someday")).toBe(false);
+    expect(RATE_LIMIT_MENU_SIGNATURE.test("we ran low on usage credits last month")).toBe(false);
+    // anchor A alone (option-1 row but no usage-credits/upgrade/slash-cmd):
+    expect(RATE_LIMIT_MENU_SIGNATURE.test("Stop and wait for the deploy to finish before retrying")).toBe(false);
   });
   it("the GENERIC wedge signature does NOT match this menu (why a dedicated detector is needed)", () => {
     // The footer is 'Enter to confirm · Esc to cancel' — no 'to select/navigate/↑↓'.
@@ -105,6 +133,28 @@ describe("runWedgeWatchdog — rate-limit branch", () => {
     expect(signals[0].name).toBe("finn");
     expect(signals[0].resetAt).toBe(Date.UTC(2026, 5, 8, 19, 0, 0));
     // COMPLIANCE: the ONLY keystroke ever sent is Escape — never Down/2/3.
+    expect(calls).toEqual([["Escape"]]);
+  });
+
+  it("clerk's scroll-off pane (no /rate-limit-options line) STILL signals failover + Esc-parks", async () => {
+    // End-to-end proof that the re-anchor fixes the #2218 blind spot: the exact
+    // pane shape that left clerk dead now drives the full watchdog branch.
+    const { send, calls } = recordSend();
+    const signals: Array<{ name: string; resetAt: number | null }> = [];
+    const res = await runWedgeWatchdog({
+      agentName: "clerk",
+      now: () => Date.UTC(2026, 5, 7, 0, 0, 0),
+      sleep: () => {},
+      maxPolls: 3,
+      capture: captureSeq([CLERK_RATE_LIMIT_SCREEN]),
+      send,
+      onRateLimitMenu: (name, resetAt) => signals.push({ name, resetAt }),
+    });
+    expect(res.rateLimitFires).toBe(1);
+    expect(signals).toHaveLength(1);
+    expect(signals[0].name).toBe("clerk");
+    expect(signals[0].resetAt).toBe(Date.UTC(2026, 5, 8, 19, 0, 0));
+    // COMPLIANCE preserved on this pane too: Esc only.
     expect(calls).toEqual([["Escape"]]);
   });
 


### PR DESCRIPTION
## Summary

clerk went silently dead on claude's `/rate-limit-options` **weekly-quota TUI menu** — the same wedge #2218 was meant to catch. Deep inspection found the auto-failover chain broken in **three complementary places**; all three are required for a weekly wall to fail over *and stay failed over*.

| RC | Where | Bug | Fix |
|----|-------|-----|-----|
| **#1** | `src/agents/wedge-watchdog.ts` | Detector anchored on the `/rate-limit-options` line, which is printed **above** the menu and scrolls **off the top** of the `tmux capture-pane -p` viewport (no scrollback). clerk wedged exactly that way → detector logged **zero fires**. | Re-anchor `RATE_LIMIT_MENU_SIGNATURE` on the option-1 menu-body row (`Stop and wait for…`, pinned to the bottom where the cursor is) + `usage credits` / `Upgrade your plan` / `/rate-limit-options`. Esc-only park unchanged. |
| **#2** | `telegram-plugin/gateway/gateway.ts` (429 path) | 429 path called `fireFleetAutoFallback(agent)` with **no until** → markExhausted's ~5h default. A weekly wall surfacing as a 429 carries calendar wording (`resets Jun 9, 5am`) that `parseResetTime` **cannot read** → `resetAt` undefined → un-exhausts after 5h. | Shared, unit-tested `resolveExhaustUntil()` (`exhaust-until.ts`) with a **+7d floor that never returns undefined**, called from **both** the menu handler and the 429 path. |
| **#3** | `src/auth/broker/server.ts` | Even with a correct weekly `until`, `mark-exhausted` marks quota + mirrors the fallback **once** but never rewrites `auth.active`. The refresh-tick fanout resolved the effective account as `override ?? auth.active` with **no exhaustion check** → when the walled account's OAuth token refreshed (~1h) it **silently re-mirrored walled creds onto the whole fleet** (rollback / flap). | Route agent serving + fanout through a shared `accountWithFailover()` (generalised from the proven `consumerAccountWithFailover`): serve/mirror the first healthy fallback while walled, fall back to pinned/active when none healthy (retry beats dark), auto-revert when the window passes. Operator serving stays attribution-true. |

## Why

This is the durable resolution of the clerk incident (2026-06-07) and closes the latent flap that made auto-failover unreliable since #2206. RC#1 makes the weekly menu *fire* failover; RC#2 makes the exhaustion *window* long enough to cover a weekly wall; RC#3 makes the broker *honour* that window instead of silently re-mirroring the walled account on the next refresh tick.

**Compliance (vision.md pillar 3):** the wedge park remains **Esc-only** — never selects "Switch to usage credits" / "Add funds…" / "Upgrade your plan". The +7d floor errs toward keeping a walled account out of service (never serving it), which is the compliance-safe direction.

## Test plan

- [x] `tests/rate-limit-menu-detect.test.ts` — CLERK scroll-off fixture (no `/rate-limit-options` line + "Add funds…" wording) **matches**; finn fixture still matches; anchor-A-alone & anchor-B-alone stay false; full-watchdog e2e on the scroll-off pane signals + Esc; compliance (Esc-only, exhaustive banned-key) preserved.
- [x] `telegram-plugin/tests/exhaust-until.test.ts` — `resolveExhaustUntil` floors undefined/past/NaN → +7d, passes finite future through; 429-path composition proves rolling (finite, sub-floor) AND unparseable-weekly (+7d, never undefined) thread a non-undefined until.
- [x] `src/auth/broker/server.test.ts` — agent on a walled `auth.active` served its healthy fallback; refresh-tick fanout during exhaustion never re-mirrors the walled account; a weekly until holds past the ~5h default then auto-reverts; all-walled fleet keeps retrying the active account.
- [x] `tsc --noEmit` clean · `check-bot-api-wrapping.sh` clean · `check-plugin-references.mjs` clean · full build green · 569 vitest + bun IPC tests green.

## Risk

RC#3 touches the broker's hot agent-serving/fanout reads. Mitigated: `accountWithFailover` is a 1:1 generalisation of the production-proven consumer path, diverges from `auth.active` **only** when it's within a mark-exhausted window, and **always** falls back to the pinned/active account when no healthy alternative exists (an all-walled fleet retries, never goes dark). Healthy-case behaviour is identical (all 57 existing broker tests unchanged). RC#3 ships broker-side → the auth-broker **singleton must be recreated explicitly** on rollout (it's skipped by the staggered per-agent restart); RC#1/#2 are gateway-side and ride the per-agent roll.

Follow-up to #2218.