### PR TITLE
feat(agents): file-delivery guidance — deliver files, never hand back a container path

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -99,6 +99,45 @@ Example response shapes:
   sandbox. Cloning into \`$HOME/workspace\` instead."`;
 
 /**
+ * File delivery. One of the fleet invariant blocks (sibling to
+ * SANDBOX_GUIDANCE — that one covers where files live INSIDE the
+ * container; this one covers how to get a file OUT to the user).
+ *
+ * The recurring failure this fixes: an agent writes a file and hands
+ * back its local container path (\`/state/agent/...\`, \`/tmp/...\`).
+ * The user is not on the box and cannot open it. See SANDBOX_GUIDANCE
+ * above for the constant-vs-\`.hbs\` rationale.
+ */
+const DELIVERY_GUIDANCE = `## Delivering a file to the user
+
+You run in a container. A local path like \`/state/agent/...\` or
+\`/tmp/...\` means **nothing** to the user — they are not on your box and
+cannot open it. When you produce a file the user should have, **deliver
+it**, don't print its path.
+
+### Send it in Telegram (default for most files)
+The \`reply\` tool attaches files: pass \`files: ["/abs/path"]\` (images
+send as photos, everything else as documents; 50 MB max each). This is
+the right channel for almost anything — a report, a CSV, a chart, a
+generated doc — the user gets it straight in the chat. Prefer this.
+
+### Put it in their Drive (for files they'll keep or edit, or > 50 MB)
+If you have Google Drive / OneDrive tools wired (the \`gdrive\` /
+\`ms-365\` MCP), upload the file there and reply with the share link
+instead of a path. Always upload into a **\`Switchroom/<your-agent-name>\`
+folder** at the drive root (create it if it doesn't exist) — never scatter
+files loose in the user's drive. That folder is the one predictable place
+the user knows to look for what you've made.
+
+### If you can't deliver
+No Drive connected and the file is too big for Telegram? Say so plainly
+and offer the fix ("connect a Drive from the dashboard and I'll put it
+there"). Don't fall back to handing over a local path that leads nowhere.
+
+The rule: the user must be able to **reach** what you made. A path on your
+container is not delivery.`;
+
+/**
  * The Telegram pacing contract. One of three fleet invariant blocks.
  * See SANDBOX_GUIDANCE above for the rationale on TypeScript-constant
  * vs `.hbs` file.
@@ -327,6 +366,8 @@ export function renderFleetInvariants(): string {
     "# Switchroom fleet invariants",
     "",
     SANDBOX_GUIDANCE,
+    "",
+    DELIVERY_GUIDANCE,
     "",
     TELEGRAM_GUIDANCE,
     "",

--- a/tests/scaffold.memory-prompt.test.ts
+++ b/tests/scaffold.memory-prompt.test.ts
@@ -65,6 +65,22 @@ describe("Memory prompt guidance (post-#1850)", () => {
     expect(out).toContain("mcp__hindsight__reflect");
   });
 
+  it("renderFleetInvariants() includes the file-delivery guidance (no local-path dumps)", () => {
+    const out = renderFleetInvariants();
+    const deliveryIdx = out.indexOf("## Delivering a file to the user");
+    expect(deliveryIdx).toBeGreaterThan(-1);
+    // It must name the real delivery channels and forbid local-path dumps.
+    expect(out).toContain('files: ["/abs/path"]'); // reply attachment path
+    expect(out).toMatch(/Switchroom\/<your-agent-name>/); // the drive folder convention
+    expect(out).toMatch(/not on your box|cannot open it/i); // the "don't hand back a path" rule
+    // Placed in the sandbox→delivery flow: after the sandbox block, before memory.
+    const sandboxIdx = out.indexOf("## Sandbox: you're running in a switchroom container");
+    const memoryIdx = out.indexOf("## Memory — proactive, conversational");
+    expect(sandboxIdx).toBeGreaterThan(-1);
+    expect(deliveryIdx).toBeGreaterThan(sandboxIdx);
+    expect(memoryIdx).toBeGreaterThan(deliveryIdx);
+  });
+
   it("renderFleetInvariants() orders Telegram pacing BEFORE memory guidance", () => {
     // The fleet invariants file orders sections so the model reads
     // them in the same sequence as the prior --append-system-prompt


### PR DESCRIPTION
## Summary
Adds a `DELIVERY_GUIDANCE` fleet-invariant prompt block so agents **deliver** files instead of replying with a local container path the user can't reach. This is **layer 1** of the file-delivery outcome (operator-requested) and uses capabilities that already exist.

## Why
An agent runs headless in a container. When it writes a file and replies `/state/agent/workspace/report.pdf` (or `/tmp/...`), the user — who is not on the box — can't open it. The work didn't land. There was no guidance telling agents how to get a file *out*.

## The rule it encodes
- **Telegram (default):** the `reply` tool *already* attaches files via `files: ["/abs/path"]` (photos for images, documents otherwise, 50MB). The guidance points agents at it — no new tool needed.
- **Drive/OneDrive (keep/edit, or >50MB):** upload via the existing `gdrive` / `ms-365` MCP into a **`Switchroom/<agent-name>/`** folder + reply with the link.
- **Never:** hand back a local container path.

## Scope / follow-ups
This is layer 1 (guidance) of the full system the operator approved. Layers still to come as separate PRs:
- **Layer 3:** a deterministic `Switchroom/<agent>/` find-or-create helper (so the folder is reliable, not model-guessed).
- **Layer 4:** a standing pre-approval for writes to the agent's *own* delivery folder, so routine delivery doesn't fire a per-write Telegram approval (while writes elsewhere in the user's Drive still gate).

(Layer 2 — Telegram file send — turned out to already exist via `reply.files`, so no new tool was added.)

## Test plan
- [x] `vitest run tests/scaffold.memory-prompt.test.ts` — 7 pass incl. new (delivery block present, names channels, forbids local-path dumps, ordered sandbox→delivery→memory)
- [x] `tsc --noEmit` clean

## Risk
Minimal — prompt-only, additive fleet invariant. Serves the "always available" outcome: a file the user can't open is work that didn't land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)