### PR TITLE
feat(auth): `auth schedule` — per-account 5h vs weekly quota view

### DIFF
--- a/src/cli/auth-schedule.test.ts
+++ b/src/cli/auth-schedule.test.ts
@@ -46,7 +46,7 @@ describe("formatResetDay (deterministic across host tz)", () => {
     expect(formatResetDay(WEEKLY_RESET, "UTC")).toBe("Sun 01:00");
     // Melbourne is UTC+10 → 01:00 UTC = 11:00 local, still Sunday.
     expect(formatResetDay(WEEKLY_RESET, "Australia/Melbourne")).toBe("Sun 11:00");
-    // ken.outlook's anchor (Mon 19:00 UTC) lands Tuesday morning in Melbourne.
+    // A Mon 19:00 UTC weekly anchor lands Tuesday morning in Melbourne (UTC+10).
     expect(formatResetDay(new Date("2026-06-08T19:00:00Z"), "Australia/Melbourne")).toBe("Tue 05:00");
   });
 });
@@ -111,7 +111,7 @@ describe("classifyState — the 5h-vs-weekly distinction", () => {
   });
 
   it("maxed weekly (>=99.5%) → weekly-walled even when exhausted_until is the sooner 5h reset", () => {
-    // The live ken.outlook case: 5h resets in ~27m, but weekly is 100% till Tue.
+    // The real-world case: the 5h window resets in ~27m, but weekly is 100% till Tue.
     const fiveSoon = new Date("2026-06-07T06:27:00Z");
     const weeklyTue = new Date("2026-06-09T19:00:00Z");
     expect(
@@ -288,7 +288,7 @@ describe("formatScheduleRows (no-color)", () => {
   it("active row shows the ● glyph, pool, and weekly reset day", () => {
     expect(lines[1]).toContain("●");
     expect(lines[1]).toContain("active #1");
-    expect(lines[1]).toContain("Sun 11:00"); // pixsoul-style Sunday anchor, Melbourne
+    expect(lines[1]).toContain("Sun 11:00"); // a Sunday weekly anchor, Melbourne
     expect(lines[1]).toContain("healthy");
   });
 

--- a/src/cli/auth-schedule.test.ts
+++ b/src/cli/auth-schedule.test.ts
@@ -1,0 +1,300 @@
+// Unit tests for the pure helpers behind `switchroom auth schedule`. Broker IO
+// is NOT mocked — we test the model/classify/format helpers directly with the
+// broker response shapes as plain typed args (mirrors auth-google.test.ts).
+// The load-bearing assertion is classifyState: the 5h-vs-weekly distinction.
+
+import { describe, it, expect } from "vitest";
+import { _testing, type WindowSnapshot, type ScheduleRow } from "./auth-schedule.js";
+import type { ListStateData, ProbeQuotaData } from "../auth/broker/client.js";
+
+const {
+  resolveWindow,
+  classifyState,
+  buildScheduleRows,
+  formatDuration,
+  formatResetDay,
+  formatFiveHourCell,
+  formatWeeklyCell,
+  formatStateCell,
+  formatScheduleRows,
+} = _testing;
+
+const NOW = new Date("2026-06-07T06:00:00.000Z"); // Sunday
+const WEEKLY_RESET = new Date("2026-06-14T01:00:00.000Z"); // Sun (next week)
+const FIVE_RESET = new Date("2026-06-07T07:10:00.000Z"); // ~1h out
+
+const NONE: WindowSnapshot = {
+  fiveHourPct: null,
+  fiveHourResetAt: null,
+  weeklyPct: null,
+  weeklyResetAt: null,
+  source: "none",
+};
+
+describe("formatDuration", () => {
+  it("formats days/hours/minutes and collapses to now", () => {
+    expect(formatDuration(0)).toBe("now");
+    expect(formatDuration(-5)).toBe("now");
+    expect(formatDuration(4 * 60_000)).toBe("4m");
+    expect(formatDuration(2 * 3_600_000 + 18 * 60_000)).toBe("2h 18m");
+    expect(formatDuration(5 * 86_400_000 + 3 * 3_600_000)).toBe("5d 3h");
+  });
+});
+
+describe("formatResetDay (deterministic across host tz)", () => {
+  it("renders weekday + 24h time in the requested zone", () => {
+    expect(formatResetDay(WEEKLY_RESET, "UTC")).toBe("Sun 01:00");
+    // Melbourne is UTC+10 → 01:00 UTC = 11:00 local, still Sunday.
+    expect(formatResetDay(WEEKLY_RESET, "Australia/Melbourne")).toBe("Sun 11:00");
+    // ken.outlook's anchor (Mon 19:00 UTC) lands Tuesday morning in Melbourne.
+    expect(formatResetDay(new Date("2026-06-08T19:00:00Z"), "Australia/Melbourne")).toBe("Tue 05:00");
+  });
+});
+
+describe("classifyState — the 5h-vs-weekly distinction", () => {
+  const win = (over: Partial<typeof NONE>) => ({ ...NONE, ...over });
+
+  it("not exhausted with data → healthy", () => {
+    expect(
+      classifyState({ exhausted: false, exhaustedUntil: null, window: win({ weeklyPct: 8 }), now: NOW }),
+    ).toBe("healthy");
+  });
+
+  it("not exhausted, no data, no ledger → unprobed", () => {
+    expect(
+      classifyState({ exhausted: false, exhaustedUntil: null, window: NONE, now: NOW }),
+    ).toBe("unprobed");
+  });
+
+  it("exhausted with until ≈ WEEKLY reset → weekly-walled (precise match)", () => {
+    expect(
+      classifyState({
+        exhausted: true,
+        exhaustedUntil: WEEKLY_RESET,
+        window: win({ weeklyResetAt: WEEKLY_RESET, fiveHourResetAt: FIVE_RESET }),
+        now: NOW,
+      }),
+    ).toBe("weekly-walled");
+  });
+
+  it("exhausted with until ≈ 5h reset → 5h-walled (precise match)", () => {
+    expect(
+      classifyState({
+        exhausted: true,
+        exhaustedUntil: FIVE_RESET,
+        window: win({ weeklyResetAt: WEEKLY_RESET, fiveHourResetAt: FIVE_RESET }),
+        now: NOW,
+      }),
+    ).toBe("5h-walled");
+  });
+
+  it("exhausted, no window data, reset ~2.5h out → 5h-walled (heuristic)", () => {
+    expect(
+      classifyState({
+        exhausted: true,
+        exhaustedUntil: new Date("2026-06-07T08:30:00Z"),
+        window: NONE,
+        now: NOW,
+      }),
+    ).toBe("5h-walled");
+  });
+
+  it("exhausted, no window data, reset ~2d out → weekly-walled (heuristic)", () => {
+    expect(
+      classifyState({
+        exhausted: true,
+        exhaustedUntil: new Date("2026-06-09T05:00:00Z"),
+        window: NONE,
+        now: NOW,
+      }),
+    ).toBe("weekly-walled");
+  });
+
+  it("maxed weekly (>=99.5%) → weekly-walled even when exhausted_until is the sooner 5h reset", () => {
+    // The live ken.outlook case: 5h resets in ~27m, but weekly is 100% till Tue.
+    const fiveSoon = new Date("2026-06-07T06:27:00Z");
+    const weeklyTue = new Date("2026-06-09T19:00:00Z");
+    expect(
+      classifyState({
+        exhausted: true,
+        exhaustedUntil: fiveSoon,
+        window: win({ fiveHourPct: 0, fiveHourResetAt: fiveSoon, weeklyPct: 100, weeklyResetAt: weeklyTue, source: "live" }),
+        now: NOW,
+      }),
+    ).toBe("weekly-walled");
+  });
+
+  it("exhausted_until already in the past → healthy", () => {
+    expect(
+      classifyState({
+        exhausted: true,
+        exhaustedUntil: new Date("2026-06-07T05:00:00Z"),
+        window: NONE,
+        now: NOW,
+      }),
+    ).toBe("healthy");
+  });
+});
+
+describe("resolveWindow — live preferred, cached fallback, ISO→Date", () => {
+  const account = {
+    label: "default",
+    exhausted: false,
+    last_quota: {
+      fiveHourUtilizationPct: 40,
+      sevenDayUtilizationPct: 8,
+      fiveHourResetAt: "2026-06-07T07:10:00.000Z",
+      sevenDayResetAt: "2026-06-14T01:00:00.000Z",
+      representativeClaim: "five_hour",
+      overageStatus: null,
+      overageDisabledReason: null,
+      capturedAt: 1,
+    },
+  };
+
+  it("prefers a live ok probe and keeps Date reset fields", () => {
+    const probe: ProbeQuotaData = {
+      results: [
+        {
+          label: "default",
+          result: {
+            ok: true,
+            data: {
+              fiveHourUtilizationPct: 41,
+              sevenDayUtilizationPct: 9,
+              fiveHourResetAt: FIVE_RESET,
+              sevenDayResetAt: WEEKLY_RESET,
+              representativeClaim: "five_hour",
+              overageStatus: null,
+              overageDisabledReason: null,
+            },
+          },
+        },
+      ],
+    };
+    const w = resolveWindow(account as never, probe);
+    expect(w.source).toBe("live");
+    expect(w.weeklyPct).toBe(9);
+    expect(w.weeklyResetAt?.getTime()).toBe(WEEKLY_RESET.getTime());
+  });
+
+  it("falls back to cached snapshot (ISO strings → Date) when probe is ok:false", () => {
+    const probe: ProbeQuotaData = {
+      results: [{ label: "default", result: { ok: false, reason: "HTTP 429" } }],
+    };
+    const w = resolveWindow(account as never, probe);
+    expect(w.source).toBe("cached");
+    expect(w.weeklyPct).toBe(8);
+    expect(w.weeklyResetAt instanceof Date).toBe(true);
+    expect(w.weeklyResetAt?.toISOString()).toBe("2026-06-14T01:00:00.000Z");
+  });
+
+  it("returns source=none when no probe and no cache", () => {
+    const w = resolveWindow({ label: "x", exhausted: false } as never, undefined);
+    expect(w).toEqual(NONE);
+  });
+});
+
+function makeState(): ListStateData {
+  return {
+    active: "default",
+    fallback_order: ["default", "secondary"],
+    accounts: [
+      {
+        label: "default",
+        exhausted: false,
+        last_quota: {
+          fiveHourUtilizationPct: 40,
+          sevenDayUtilizationPct: 8,
+          fiveHourResetAt: "2026-06-07T07:10:00.000Z",
+          sevenDayResetAt: "2026-06-14T01:00:00.000Z",
+          representativeClaim: "five_hour",
+          overageStatus: null,
+          overageDisabledReason: null,
+          capturedAt: 1,
+        },
+      },
+      { label: "secondary", exhausted: true, exhausted_until: Date.parse("2026-06-07T08:30:00Z") },
+      { label: "bob@example.com", exhausted: true, exhausted_until: Date.parse("2026-06-09T05:00:00Z") },
+    ],
+    agents: [],
+    consumers: [],
+  } as ListStateData;
+}
+
+describe("buildScheduleRows", () => {
+  const rows = buildScheduleRows(makeState(), undefined, NOW);
+
+  it("marks active + fallback ranks + excluded", () => {
+    expect(rows[0]).toMatchObject({ label: "default", isActive: true, fallbackRank: 1 });
+    expect(rows[1]).toMatchObject({ label: "secondary", isActive: false, fallbackRank: 2 });
+    expect(rows[2]).toMatchObject({ label: "bob@example.com", isActive: false, fallbackRank: null });
+  });
+
+  it("classifies each account's window state from the ledger", () => {
+    expect(rows[0].state).toBe("healthy"); // active, cached, not exhausted
+    expect(rows[1].state).toBe("5h-walled"); // ~2.5h out
+    expect(rows[2].state).toBe("weekly-walled"); // ~2d out
+  });
+});
+
+describe("formatStateCell horizon", () => {
+  it("weekly-walled shows the WEEKLY reset horizon, not the sooner 5h reset", () => {
+    const row: ScheduleRow = {
+      label: "x",
+      isActive: false,
+      fallbackRank: 2,
+      window: {
+        fiveHourPct: 0,
+        fiveHourResetAt: new Date("2026-06-07T06:27:00Z"),
+        weeklyPct: 100,
+        weeklyResetAt: new Date("2026-06-09T19:00:00Z"),
+        source: "live",
+      },
+      exhausted: true,
+      exhaustedUntil: new Date("2026-06-07T06:27:00Z"),
+      state: "weekly-walled",
+    };
+    const cell = formatStateCell(row, NOW);
+    expect(cell).toContain("weekly-walled");
+    expect(cell).toContain("2d"); // ~2d to Tuesday, NOT the 27m 5h reset
+    expect(cell).not.toContain("27m");
+  });
+});
+
+describe("cell formatters", () => {
+  it("em-dash on missing data; otherwise pct + day", () => {
+    expect(formatFiveHourCell(NONE, NOW)).toBe("—");
+    expect(formatWeeklyCell(NONE, NOW)).toBe("—");
+    const w = { ...NONE, fiveHourPct: 40, fiveHourResetAt: FIVE_RESET, weeklyPct: 8, weeklyResetAt: WEEKLY_RESET, source: "live" as const };
+    expect(formatFiveHourCell(w, NOW)).toBe("40% · 1h 10m");
+    expect(formatWeeklyCell(w, NOW, "UTC")).toBe("8% · Sun 01:00 (6d 19h)");
+  });
+});
+
+describe("formatScheduleRows (no-color)", () => {
+  const lines = formatScheduleRows(buildScheduleRows(makeState(), undefined, NOW), NOW, {
+    color: false,
+    tz: "Australia/Melbourne",
+  });
+
+  it("emits a header + one line per account, no ANSI", () => {
+    expect(lines).toHaveLength(4); // header + 3 accounts
+    expect(lines[0]).toContain("ACCOUNT");
+    expect(lines[0]).toContain("WEEKLY WINDOW");
+    for (const l of lines) expect(l).not.toMatch(/\[/); // no escape codes
+  });
+
+  it("active row shows the ● glyph, pool, and weekly reset day", () => {
+    expect(lines[1]).toContain("●");
+    expect(lines[1]).toContain("active #1");
+    expect(lines[1]).toContain("Sun 11:00"); // pixsoul-style Sunday anchor, Melbourne
+    expect(lines[1]).toContain("healthy");
+  });
+
+  it("walled rows surface which window walled them", () => {
+    expect(lines[2]).toContain("5h-walled");
+    expect(lines[3]).toContain("weekly-walled");
+    expect(lines[3]).toContain("excluded");
+  });
+});

--- a/src/cli/auth-schedule.ts
+++ b/src/cli/auth-schedule.ts
@@ -331,16 +331,27 @@ export function formatScheduleRows(
 }
 
 /** The freshness/legend footer lines. */
-export function formatFooter(rows: ScheduleRow[], live: boolean, now: Date, tz?: string): string[] {
+export function formatFooter(
+  rows: ScheduleRow[],
+  opts: { liveRequested: boolean; probedLive: boolean },
+  now: Date,
+  tz?: string,
+): string[] {
   const zone = tz ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
   const at = formatResetDay(now, tz);
-  const src = live
+  const src = opts.probedLive
     ? `probed live · ${at} ${zone}`
-    : `cached snapshot (run without --cached for a live probe) · times in ${zone}`;
+    : opts.liveRequested
+      ? `live probe unavailable — showing cached snapshot · times in ${zone}`
+      : `cached snapshot (run without --cached for a live probe) · times in ${zone}`;
   const anyUnprobed = rows.some((r) => r.window.source === "none");
   const lines = [src];
-  if (!live && anyUnprobed) {
-    lines.push("some accounts have no cached probe yet — run without --cached to populate");
+  if (!opts.probedLive && anyUnprobed) {
+    lines.push(
+      opts.liveRequested
+        ? "some accounts have no quota data — the broker may not have served a probe"
+        : "some accounts have no cached probe yet — run without --cached to populate",
+    );
   }
   return lines;
 }
@@ -385,7 +396,7 @@ export function registerAuthScheduleSubcommands(
         console.log();
         for (const l of formatScheduleRows(rows, now)) console.log(l);
         console.log();
-        for (const l of formatFooter(rows, probedLive, now)) {
+        for (const l of formatFooter(rows, { liveRequested: live, probedLive }, now)) {
           console.log(chalk.gray("  " + l));
         }
         console.log();

--- a/src/cli/auth-schedule.ts
+++ b/src/cli/auth-schedule.ts
@@ -1,0 +1,407 @@
+/**
+ * `switchroom auth schedule` — per-account quota-window schedule view.
+ *
+ * `auth list`/`auth show` collapse quota into a single "soonest reset"
+ * column, which hides the thing that actually matters for fleet quota
+ * management: each account has THREE independent windows — a 5-hour
+ * rolling window and a 7-day WEEKLY window (plus an Opus weekly sub-cap
+ * surfaced out-of-band) — and the weekly anchor is a fixed day-of-week
+ * per subscription, DIFFERENT per account (staggered). An account
+ * "exhausted" on the 5h window recovers in hours; one walled on the
+ * weekly window is out for days. This view separates the two so you can
+ * see, per account: 5h % + reset, weekly % + reset DAY, and which window
+ * (if any) is currently walling it.
+ *
+ * Data: `listState()` carries the exhaustion ledger + a CACHED `last_quota`
+ * (often null — the in-memory probe cache is empty after a broker restart).
+ * To show live windows the view does a fresh `probe-quota` by default (the
+ * same broker op the web dashboard uses; operator-initiated, one tiny
+ * max_tokens:1 call per account). `--cached` skips the live probe.
+ *
+ * Pure helpers (buildScheduleRows / classifyState / formatters) are exported
+ * via `_testing` and unit-tested directly — the broker IO is not mocked
+ * (mirrors the auth-google.test.ts pattern).
+ */
+
+import type { Command } from "commander";
+import chalk from "chalk";
+import { brokerCall } from "./broker-call.js";
+import { withConfigError } from "./helpers.js";
+import type {
+  ListStateData,
+  AccountState,
+  ProbeQuotaData,
+} from "../auth/broker/client.js";
+
+// ─── Pure model ──────────────────────────────────────────────────────────
+
+export interface WindowSnapshot {
+  fiveHourPct: number | null;
+  fiveHourResetAt: Date | null;
+  weeklyPct: number | null;
+  weeklyResetAt: Date | null;
+  /** Where the numbers came from: a live probe, the broker's cache, or nothing. */
+  source: "live" | "cached" | "none";
+}
+
+export type AccountWindowState =
+  | "healthy"
+  | "5h-walled"
+  | "weekly-walled"
+  | "walled"
+  | "unprobed";
+
+/** Weekly utilization at/above this is treated as walled (mirrors the broker's sensor). */
+const WEEKLY_WALL_PCT = 99.5;
+
+export interface ScheduleRow {
+  label: string;
+  isActive: boolean;
+  /** 1-based position in fallback_order, or null when not listed. */
+  fallbackRank: number | null;
+  window: WindowSnapshot;
+  exhausted: boolean;
+  exhaustedUntil: Date | null;
+  state: AccountWindowState;
+}
+
+/** Prefer a live probe result; fall back to the broker's cached snapshot. */
+export function resolveWindow(
+  account: AccountState,
+  probe: ProbeQuotaData | undefined,
+): WindowSnapshot {
+  const entry = probe?.results.find((r) => r.label === account.label);
+  if (entry && entry.result.ok) {
+    const d = entry.result.data;
+    return {
+      fiveHourPct: d.fiveHourUtilizationPct,
+      fiveHourResetAt: d.fiveHourResetAt, // already a Date (revived client-side)
+      weeklyPct: d.sevenDayUtilizationPct,
+      weeklyResetAt: d.sevenDayResetAt,
+      source: "live",
+    };
+  }
+  const lq = account.last_quota;
+  if (lq) {
+    return {
+      fiveHourPct: lq.fiveHourUtilizationPct,
+      fiveHourResetAt: lq.fiveHourResetAt ? new Date(lq.fiveHourResetAt) : null,
+      weeklyPct: lq.sevenDayUtilizationPct,
+      weeklyResetAt: lq.sevenDayResetAt ? new Date(lq.sevenDayResetAt) : null,
+      source: "cached",
+    };
+  }
+  return {
+    fiveHourPct: null,
+    fiveHourResetAt: null,
+    weeklyPct: null,
+    weeklyResetAt: null,
+    source: "none",
+  };
+}
+
+/**
+ * Classify which window (if any) is currently walling the account — the
+ * load-bearing distinction. When we have window reset timestamps we match
+ * `exhausted_until` against them precisely; otherwise we fall back to a
+ * duration heuristic (a 5h wall resets within hours, a weekly wall in days).
+ */
+export function classifyState(args: {
+  exhausted: boolean;
+  exhaustedUntil: Date | null;
+  window: WindowSnapshot;
+  now: Date;
+}): AccountWindowState {
+  const { exhausted, exhaustedUntil, window, now } = args;
+  const hasWindowData =
+    window.fiveHourPct !== null ||
+    window.weeklyPct !== null ||
+    window.fiveHourResetAt !== null ||
+    window.weeklyResetAt !== null;
+  // A maxed WEEKLY window is the binding wall, regardless of the exhaustion
+  // ledger: even when `exhausted_until` points at a sooner 5h reset, once that
+  // 5h window clears the weekly cap still blocks the account until its (days-
+  // away) reset. So a near-100% weekly takes precedence over "5h-walled".
+  if (
+    window.weeklyPct !== null &&
+    window.weeklyPct >= WEEKLY_WALL_PCT &&
+    window.weeklyResetAt !== null &&
+    window.weeklyResetAt.getTime() > now.getTime()
+  ) {
+    return "weekly-walled";
+  }
+  if (!exhausted) {
+    // No exhaustion ledger AND no probe/cache data → we genuinely don't know.
+    return hasWindowData || exhaustedUntil !== null ? "healthy" : "unprobed";
+  }
+  const until = exhaustedUntil?.getTime();
+  if (until === undefined) return "walled";
+  const remaining = until - now.getTime();
+  if (remaining <= 0) return "healthy"; // window already passed
+
+  const TOL_MS = 15 * 60 * 1000; // 15 min slack between mark time and reset
+  const near = (d: Date | null) =>
+    d !== null && Math.abs(d.getTime() - until) <= TOL_MS;
+  if (near(window.weeklyResetAt)) return "weekly-walled";
+  if (near(window.fiveHourResetAt)) return "5h-walled";
+
+  // No matching reset timestamp — classify by how far out the reset is.
+  if (remaining < 6 * 3_600_000) return "5h-walled";
+  if (remaining >= 20 * 3_600_000) return "weekly-walled";
+  return "walled";
+}
+
+export function buildScheduleRows(
+  state: ListStateData,
+  probe: ProbeQuotaData | undefined,
+  now: Date,
+): ScheduleRow[] {
+  const rows = state.accounts.map((a) => {
+    const window = resolveWindow(a, probe);
+    const exhaustedUntil =
+      typeof a.exhausted_until === "number" ? new Date(a.exhausted_until) : null;
+    const exhausted = a.exhausted && (exhaustedUntil?.getTime() ?? 0) > now.getTime();
+    const rank = state.fallback_order.indexOf(a.label);
+    return {
+      label: a.label,
+      isActive: a.label === state.active,
+      fallbackRank: rank === -1 ? null : rank + 1,
+      window,
+      exhausted,
+      exhaustedUntil,
+      state: classifyState({ exhausted, exhaustedUntil, window, now }),
+    };
+  });
+  // Pool priority: active first, then fallback_order rank, then excluded.
+  const key = (r: ScheduleRow) => (r.isActive ? -1 : (r.fallbackRank ?? 9999));
+  return rows.sort((a, b) => key(a) - key(b) || a.label.localeCompare(b.label));
+}
+
+// ─── Formatters ──────────────────────────────────────────────────────────
+
+const EM_DASH = "—";
+
+/** "5d 3h" / "2h 18m" / "4m" / "now". */
+export function formatDuration(ms: number): string {
+  if (ms <= 0) return "now";
+  const d = Math.floor(ms / 86_400_000);
+  const h = Math.floor((ms % 86_400_000) / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function tzOpts(tz?: string): { timeZone?: string } {
+  return tz ? { timeZone: tz } : {};
+}
+
+/** "Sun 11:00" in the given (or host) timezone — fixed locales keep it stable. */
+export function formatResetDay(d: Date, tz?: string): string {
+  const opts = tzOpts(tz);
+  const dow = d.toLocaleDateString("en-US", { weekday: "short", ...opts });
+  const hm = d.toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    ...opts,
+  });
+  return `${dow} ${hm}`;
+}
+
+/** 5h cell, raw (uncolored): "40% · 1h 2m" or "—". */
+export function formatFiveHourCell(w: WindowSnapshot, now: Date): string {
+  if (w.fiveHourPct === null) return EM_DASH;
+  const reset = w.fiveHourResetAt
+    ? ` · ${formatDuration(w.fiveHourResetAt.getTime() - now.getTime())}`
+    : "";
+  return `${Math.round(w.fiveHourPct)}%${reset}`;
+}
+
+/** Weekly cell, raw (uncolored): "8% · Sun 11:00 (5d 3h)" or "—". */
+export function formatWeeklyCell(w: WindowSnapshot, now: Date, tz?: string): string {
+  if (w.weeklyPct === null && w.weeklyResetAt === null) return EM_DASH;
+  const pct = w.weeklyPct === null ? EM_DASH : `${Math.round(w.weeklyPct)}%`;
+  if (!w.weeklyResetAt) return pct;
+  const rel = formatDuration(w.weeklyResetAt.getTime() - now.getTime());
+  return `${pct} · ${formatResetDay(w.weeklyResetAt, tz)} (${rel})`;
+}
+
+function poolLabel(row: ScheduleRow): string {
+  if (row.isActive) return row.fallbackRank ? `active #${row.fallbackRank}` : "active";
+  if (row.fallbackRank) return `#${row.fallbackRank}`;
+  return "excluded";
+}
+
+/** State cell, raw (uncolored): "healthy" / "5h-walled · 2h 18m" / etc. */
+export function formatStateCell(row: ScheduleRow, now: Date): string {
+  // Show the horizon that actually matters for the classified wall — the
+  // weekly reset for a weekly wall, the 5h reset for a 5h wall — not just the
+  // exhaustion-ledger timestamp (which can point at the sooner 5h window).
+  const horizon =
+    row.state === "weekly-walled"
+      ? (row.window.weeklyResetAt ?? row.exhaustedUntil)
+      : row.state === "5h-walled"
+        ? (row.window.fiveHourResetAt ?? row.exhaustedUntil)
+        : row.exhaustedUntil;
+  const rel = horizon ? ` · ${formatDuration(horizon.getTime() - now.getTime())}` : "";
+  switch (row.state) {
+    case "healthy":
+      return "healthy";
+    case "unprobed":
+      return "no recent probe";
+    case "5h-walled":
+      return `5h-walled${rel}`;
+    case "weekly-walled":
+      return `weekly-walled${rel}`;
+    case "walled":
+      return `walled${rel}`;
+  }
+}
+
+const W = { label: 30, pool: 11, five: 15, weekly: 26 };
+
+function pad(s: string, n: number): string {
+  // Truncate over-long raw cells so the column never breaks alignment.
+  if (s.length > n) return s.length > 1 ? s.slice(0, n - 1) + "…" : s;
+  return s.padEnd(n);
+}
+
+function glyphFor(row: ScheduleRow, color: boolean): string {
+  const g = row.isActive ? "●" : row.exhausted ? "!" : row.state === "unprobed" ? "·" : "✓";
+  if (!color) return g;
+  return row.isActive
+    ? chalk.green(g)
+    : row.exhausted
+      ? chalk.red(g)
+      : chalk.gray(g);
+}
+
+function colorState(text: string, state: AccountWindowState, color: boolean): string {
+  if (!color) return text;
+  switch (state) {
+    case "healthy":
+      return chalk.green(text);
+    case "weekly-walled":
+      return chalk.red(text);
+    case "5h-walled":
+      return chalk.yellow(text);
+    default:
+      return chalk.gray(text);
+  }
+}
+
+export interface FormatOpts {
+  /** Timezone for reset days; omit for host-local. Tests pin it. */
+  tz?: string;
+  /** Emit ANSI colour. Default true; tests pass false. */
+  color?: boolean;
+}
+
+/**
+ * Render the schedule as an array of lines (no trailing blank). The
+ * glyph and state cells carry colour (applied last, never padEnd'd); the
+ * label/pool/5h/weekly cells are raw text padded to fixed widths — so the
+ * header (built with a blank glyph + raw titles) aligns exactly.
+ */
+export function formatScheduleRows(
+  rows: ScheduleRow[],
+  now: Date,
+  opts: FormatOpts = {},
+): string[] {
+  const color = opts.color ?? true;
+  const line = (glyph: string, label: string, p: string, five: string, weekly: string, state: string) =>
+    `  ${glyph} ${pad(label, W.label)} ${pad(p, W.pool)} ${pad(five, W.five)} ${pad(weekly, W.weekly)} ${state}`;
+
+  const header = line(" ", "ACCOUNT", "POOL", "5H WINDOW", "WEEKLY WINDOW", "STATE");
+  const out = [color ? chalk.bold(header) : header];
+  for (const row of rows) {
+    out.push(
+      line(
+        glyphFor(row, color),
+        row.label,
+        poolLabel(row),
+        formatFiveHourCell(row.window, now),
+        formatWeeklyCell(row.window, now, opts.tz),
+        colorState(formatStateCell(row, now), row.state, color),
+      ),
+    );
+  }
+  return out;
+}
+
+/** The freshness/legend footer lines. */
+export function formatFooter(rows: ScheduleRow[], live: boolean, now: Date, tz?: string): string[] {
+  const zone = tz ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const at = formatResetDay(now, tz);
+  const src = live
+    ? `probed live · ${at} ${zone}`
+    : `cached snapshot (run without --cached for a live probe) · times in ${zone}`;
+  const anyUnprobed = rows.some((r) => r.window.source === "none");
+  const lines = [src];
+  if (!live && anyUnprobed) {
+    lines.push("some accounts have no cached probe yet — run without --cached to populate");
+  }
+  return lines;
+}
+
+// ─── CLI wiring ──────────────────────────────────────────────────────────
+
+export function registerAuthScheduleSubcommands(
+  _program: Command,
+  authParent: Command,
+): void {
+  authParent
+    .command("schedule")
+    .description(
+      "Per-account quota schedule — 5h vs WEEKLY window, % used, and reset day (live probe by default)",
+    )
+    .option("--cached", "Use the broker's cached snapshot; skip the live probe")
+    .option("--json", "Output JSON")
+    .action(
+      withConfigError(async (opts: { cached?: boolean; json?: boolean }) => {
+        const live = !opts.cached;
+        const { state, probe } = await brokerCall(async (client) => {
+          const s = await client.listState();
+          let p: ProbeQuotaData | undefined;
+          if (live) {
+            const labels = s.accounts.map((a) => a.label);
+            p =
+              labels.length > 0
+                ? await client.probeQuota(labels).catch(() => undefined)
+                : undefined;
+          }
+          return { state: s, probe: p };
+        });
+
+        if (opts.json) {
+          console.log(JSON.stringify({ ...state, probe: probe ?? null }, null, 2));
+          return;
+        }
+
+        const now = new Date();
+        const rows = buildScheduleRows(state, probe, now);
+        const probedLive = live && probe !== undefined;
+        console.log();
+        for (const l of formatScheduleRows(rows, now)) console.log(l);
+        console.log();
+        for (const l of formatFooter(rows, probedLive, now)) {
+          console.log(chalk.gray("  " + l));
+        }
+        console.log();
+      }),
+    );
+}
+
+export const _testing = {
+  resolveWindow,
+  classifyState,
+  buildScheduleRows,
+  formatDuration,
+  formatResetDay,
+  formatFiveHourCell,
+  formatWeeklyCell,
+  formatStateCell,
+  formatScheduleRows,
+  formatFooter,
+};

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -13,6 +13,7 @@
  *   auth rotate                 — cycle to next non-exhausted entry
  *   auth rm <label>
  *   auth show [<agent>]
+ *   auth schedule               — per-account 5h vs WEEKLY window + reset day
  *   auth refresh [<label>]      — diagnostic force-tick
  *   auth agent override <agent> (<label> | --clear)
  *
@@ -52,6 +53,7 @@ import {
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
 import { registerAuthGoogleSubcommands } from "./auth-google.js";
 import { registerAuthMicrosoftSubcommands } from "./auth-microsoft.js";
+import { registerAuthScheduleSubcommands } from "./auth-schedule.js";
 import { setAuthActive } from "./auth-active-yaml.js";
 import { atomicWriteFileSync } from "../util/atomic.js";
 import { statSync } from "node:fs";
@@ -470,6 +472,7 @@ export function registerAuthCommand(program: Command): void {
 
   registerAuthGoogleSubcommands(program, auth);
   registerAuthMicrosoftSubcommands(program, auth);
+  registerAuthScheduleSubcommands(program, auth);
 
   // ── auth heal <agent> --json --config-dir <dir> ────────────────────────
   // Minimal surface kept for boot-self-test.sh's structural diagnoser


### PR DESCRIPTION
## Summary

Adds `switchroom auth schedule`: a per-account quota view that separates the **5-hour rolling** window from the **7-day weekly** window, surfacing the staggered weekly reset schedule that `auth list`/`auth show` hide (they collapse quota into a single "soonest reset" column).

Per account it shows pool role (active / fallback rank / excluded), **5h % + reset**, **weekly % + reset DAY**, and a STATE distinguishing `healthy` / `5h-walled` / `weekly-walled`.

```
  ACCOUNT                        POOL        5H WINDOW       WEEKLY WINDOW              STATE
● pixsoul@gmail.com              active #1   9% · 3h 35m     12% · Sun 11:00 (6d 16h)   healthy
! ken.thompson@outlook.com.au    #2          0% · now        100% · Tue 05:00 (1d 10h)  weekly-walled · 1d 10h
✓ me@kenthompson.com.au          excluded    31% · 3h 55m    20% · Sun 20:00 (1h 25m)   healthy
```

## Why

The weekly anchor is a fixed day-of-week per subscription, **different per account** — so the fleet can keep coverage by preferring whichever account has weekly headroom. But "exhausted" in `auth list` is ambiguous: a 5h blip recovers in hours, a weekly wall in days. This view makes the distinction (and the staggered schedule) visible at a glance. Real example above: ken.outlook's 5h window resets in minutes, but it's **weekly-walled till Tuesday** — the view says so instead of mislabelling it "5h-walled".

## Design notes

- **Live probe by default.** Uses the existing broker `probe-quota` op (the same one the web dashboard uses; operator-initiated, one `max_tokens:1` call per account). The cached `last_quota` is empty after a broker restart, so a cached default would render an all-`—` table. `--cached` skips the live probe; `--json` dumps raw state. No new API callsite — it's the broker's existing op.
- **Weekly-maxed precedence.** A weekly window ≥99.5% classifies as `weekly-walled` with the weekly reset as the horizon, even when the exhaustion ledger points at a sooner 5h reset — so a weekly-capped account isn't shown as recovering in minutes.
- **Pure, tested core.** `buildScheduleRows` / `classifyState` / formatters live in `src/cli/auth-schedule.ts` behind `_testing`; tests call them directly (broker IO not mocked — the `auth-google.test.ts` pattern). House-style hand-rolled `chalk`+`padEnd` table, color applied last to dodge the ANSI/pad-width trap.

## Test plan
- [x] 20 unit tests: the 5h-vs-weekly classifier (precise-match + duration heuristic + weekly-maxed precedence), window resolution (live-preferred, cached ISO→Date fallback, none), row building (pool ranks/sort), and deterministic tz-pinned rendering (no ANSI in `--color=false`).
- [x] `tsc --noEmit` clean · full `bun lint` chain clean (PII/bun-test-imports/etc.).
- [x] Ran live against the production broker: default (live probe), `--cached`, `--json` all correct.
- [x] Pre-existing `update.test.ts` env-sensitive failures verified unrelated (fail identically with this change stashed).

## Risk
Additive, read-only CLI verb. Default does a live probe (operator-initiated, trivial cost); `--cached` for a pure read. No change to existing verbs or broker/serving code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)