### PR TITLE
feat(delivery): Google Drive provider for deliver-file + fix one-shot hang

### DIFF
--- a/src/cli/deliver-file.test.ts
+++ b/src/cli/deliver-file.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { runDeliverFile, resolveLinkScopes, safeAgentName } from "./deliver-file.js";
+import { runDeliverFile, resolveLinkScopes, resolveGoogleLinkScopes, safeAgentName } from "./deliver-file.js";
 
-describe("resolveLinkScopes", () => {
+describe("resolveLinkScopes (OneDrive)", () => {
   it("defaults to anonymous-first", () => {
     expect(resolveLinkScopes({} as NodeJS.ProcessEnv)).toEqual(["anonymous", "organization"]);
   });
@@ -10,6 +10,15 @@ describe("resolveLinkScopes", () => {
   });
   it("honors anonymous-only", () => {
     expect(resolveLinkScopes({ SWITCHROOM_DELIVER_LINK_SCOPE: "anonymous" } as NodeJS.ProcessEnv)).toEqual(["anonymous"]);
+  });
+});
+
+describe("resolveGoogleLinkScopes", () => {
+  it("defaults to anyone-with-link", () => {
+    expect(resolveGoogleLinkScopes({} as NodeJS.ProcessEnv)).toEqual(["anyone"]);
+  });
+  it("maps organization → domain", () => {
+    expect(resolveGoogleLinkScopes({ SWITCHROOM_DELIVER_LINK_SCOPE: "organization" } as NodeJS.ProcessEnv)).toEqual(["domain"]);
   });
 });
 
@@ -24,25 +33,43 @@ describe("safeAgentName (path-traversal guard)", () => {
   });
 });
 
-const okDeps = {
-  agentName: "clerk",
-  fileSize: () => 1234,
-  readFile: () => new Uint8Array([1, 2, 3]),
-  getAccessToken: async () => "tok",
-  deliver: async (a: { agentName: string; localPath: string }) => ({
+const oneDrive = {
+  name: "OneDrive" as const,
+  deliver: async (a: { agentName: string }) => ({
     itemId: "ITEM",
     link: "https://1drv.ms/report",
     folderPath: `Switchroom/${a.agentName}`,
   }),
 };
 
+const okDeps = {
+  agentName: "clerk",
+  fileSize: () => 1234,
+  readFile: () => new Uint8Array([1, 2, 3]),
+  resolveProvider: async () => oneDrive,
+};
+
 describe("runDeliverFile", () => {
-  it("delivers a file and returns the share link + folder path", async () => {
+  it("delivers a file and returns the provider + share link + folder path", async () => {
     const res = await runDeliverFile("/tmp/report.pdf", okDeps);
     expect(res.ok).toBe(true);
+    expect(res.provider).toBe("OneDrive");
     expect(res.link).toBe("https://1drv.ms/report");
     expect(res.folderPath).toBe("Switchroom/clerk");
     expect(res.filename).toBe("report.pdf");
+  });
+
+  it("uses Google Drive when that's the resolved provider", async () => {
+    const res = await runDeliverFile("/tmp/report.pdf", {
+      ...okDeps,
+      resolveProvider: async () => ({
+        name: "Google Drive" as const,
+        deliver: async (a: { agentName: string }) => ({ itemId: "G", link: "https://drive.google.com/x", folderPath: `Switchroom/${a.agentName}` }),
+      }),
+    });
+    expect(res.ok).toBe(true);
+    expect(res.provider).toBe("Google Drive");
+    expect(res.link).toBe("https://drive.google.com/x");
   });
 
   it("fails cleanly when the file is missing", async () => {
@@ -61,10 +88,7 @@ describe("runDeliverFile", () => {
   });
 
   it("gives an actionable error when no drive is connected (points at reply fallback)", async () => {
-    const res = await runDeliverFile("/tmp/report.pdf", {
-      ...okDeps,
-      getAccessToken: async () => { throw new Error("no account"); },
-    });
+    const res = await runDeliverFile("/tmp/report.pdf", { ...okDeps, resolveProvider: async () => null });
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/no connected drive/i);
     expect(res.error).toMatch(/reply tool/i); // tells the agent the 50MB fallback
@@ -73,7 +97,7 @@ describe("runDeliverFile", () => {
   it("surfaces an upload failure without crashing", async () => {
     const res = await runDeliverFile("/tmp/report.pdf", {
       ...okDeps,
-      deliver: async () => { throw new Error("HTTP 507 quota"); },
+      resolveProvider: async () => ({ name: "OneDrive" as const, deliver: async () => { throw new Error("HTTP 507 quota"); } }),
     });
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/upload failed.*507/);

--- a/src/cli/deliver-file.ts
+++ b/src/cli/deliver-file.ts
@@ -20,6 +20,18 @@ import type { Command } from "commander";
 
 import { AuthBrokerClient } from "../auth/broker/client.js";
 import { deliverToOneDrive, type DeliveredFile, type ShareLinkScope } from "../delivery/onedrive.js";
+import { deliverToGoogleDrive, type GDriveShareScope } from "../delivery/gdrive.js";
+
+/**
+ * Google Drive equivalent of {@link resolveLinkScopes}: maps the shared
+ * SWITCHROOM_DELIVER_LINK_SCOPE knob onto Drive sharing scopes. "anonymous"
+ * → `anyone` (anyone-with-link); "organization" → `domain` (same-domain).
+ */
+export function resolveGoogleLinkScopes(env = process.env): GDriveShareScope[] {
+  const raw = (env.SWITCHROOM_DELIVER_LINK_SCOPE ?? "").trim().toLowerCase();
+  if (raw === "organization") return ["domain"];
+  return ["anyone"];
+}
 
 /**
  * Resolve the OneDrive share-link scope order from `SWITCHROOM_DELIVER_LINK_SCOPE`.
@@ -45,44 +57,78 @@ export function safeAgentName(name: string | undefined): string {
   return /^[a-z0-9][a-z0-9_-]{0,50}$/.test(n) ? n : "agent";
 }
 
+/** A connected drive resolved for delivery: a name + an upload fn. */
+export interface ResolvedProvider {
+  name: "OneDrive" | "Google Drive";
+  deliver: (args: { agentName: string; localPath: string; bytes: Uint8Array }) => Promise<DeliveredFile>;
+}
+
 /** Injectable seams so the core is unit-testable without a broker or network. */
 export interface DeliverFileDeps {
   agentName?: string;
-  /** Resolve a provider access token. Defaults to the auth-broker. */
-  getAccessToken?: (provider: "microsoft") => Promise<string>;
-  /** The actual upload. Defaults to the OneDrive provider. */
-  deliver?: (args: {
-    accessToken: string;
-    agentName: string;
-    localPath: string;
-    bytes: Uint8Array;
-  }) => Promise<DeliveredFile>;
+  /** Resolve the first connected drive's delivery fn, or null if none. */
+  resolveProvider?: () => Promise<ResolvedProvider | null>;
   readFile?: (p: string) => Uint8Array;
   fileSize?: (p: string) => number;
 }
 
 export interface DeliverFileResult {
   ok: boolean;
+  provider?: string;
   link?: string;
   folderPath?: string;
   filename?: string;
   error?: string;
 }
 
-async function brokerAccessToken(provider: "microsoft"): Promise<string> {
+/**
+ * Fetch a provider's fresh access token from the auth-broker, or null if the
+ * agent has no connected account for it. The broker keeps both Microsoft and
+ * Google access tokens fresh (background refresh-tick), so we use them directly.
+ * MUST close the client — it keeps a connection open, which would otherwise
+ * hang this one-shot process after it prints its result.
+ */
+async function brokerToken(provider: "microsoft" | "google"): Promise<string | null> {
   const client = new AuthBrokerClient();
-  const data = await client.getCredentials(provider);
-  const creds = data.credentials as { microsoftOauth?: { accessToken?: string } } | undefined;
-  const token = creds?.microsoftOauth?.accessToken;
-  if (!token) {
-    throw new Error("broker returned no Microsoft access token (is an account connected + enabled for this agent?)");
+  try {
+    const data = await client.getCredentials(provider);
+    const creds = data.credentials as {
+      microsoftOauth?: { accessToken?: string };
+      googleOauth?: { accessToken?: string };
+    } | undefined;
+    const token =
+      provider === "microsoft" ? creds?.microsoftOauth?.accessToken : creds?.googleOauth?.accessToken;
+    return token ?? null;
+  } catch {
+    return null; // no account / broker error for this provider → treat as not-connected
+  } finally {
+    await client.close().catch(() => {});
   }
-  return token;
+}
+
+/** Default: OneDrive first, then Google Drive; null when neither is connected. */
+async function defaultResolveProvider(): Promise<ResolvedProvider | null> {
+  const ms = await brokerToken("microsoft");
+  if (ms) {
+    return {
+      name: "OneDrive",
+      deliver: (a) => deliverToOneDrive({ ...a, accessToken: ms, linkScopes: resolveLinkScopes() }),
+    };
+  }
+  const g = await brokerToken("google");
+  if (g) {
+    return {
+      name: "Google Drive",
+      deliver: (a) => deliverToGoogleDrive({ ...a, accessToken: g, linkScopes: resolveGoogleLinkScopes() }),
+    };
+  }
+  return null;
 }
 
 /**
- * Pure-ish core: resolve token → read file → upload → return a result. No
- * process.exit / console here so it's testable; the CLI wrapper formats output.
+ * Pure-ish core: resolve a connected drive → read file → upload → return a
+ * result. No process.exit / console here so it's testable; the CLI wrapper
+ * formats output.
  */
 export async function runDeliverFile(
   localPath: string,
@@ -91,10 +137,7 @@ export async function runDeliverFile(
   const agentName = safeAgentName(deps.agentName ?? process.env.SWITCHROOM_AGENT_NAME);
   const sizeOf = deps.fileSize ?? ((p: string) => statSync(p).size);
   const read = deps.readFile ?? ((p: string) => new Uint8Array(readFileSync(p)));
-  const getToken = deps.getAccessToken ?? brokerAccessToken;
-  const deliver =
-    deps.deliver ??
-    ((a) => deliverToOneDrive({ ...a, linkScopes: resolveLinkScopes() }));
+  const resolveProvider = deps.resolveProvider ?? defaultResolveProvider;
 
   let size: number;
   try {
@@ -106,25 +149,23 @@ export async function runDeliverFile(
     return { ok: false, error: `file is empty: ${localPath}` };
   }
 
-  let accessToken: string;
-  try {
-    accessToken = await getToken("microsoft");
-  } catch (err) {
+  const provider = await resolveProvider();
+  if (!provider) {
     return {
       ok: false,
       error:
-        `no connected drive for delivery — ${(err as Error).message}. ` +
-        `Connect a Microsoft account from the dashboard, or send the file ` +
-        `directly with the reply tool (files: ["${localPath}"]) for files under 50MB.`,
+        `no connected drive for delivery. Connect a Microsoft or Google ` +
+        `account from the dashboard, or send the file directly with the ` +
+        `reply tool (files: ["${localPath}"]) for files under 50MB.`,
     };
   }
 
   try {
     const bytes = read(localPath);
-    const out = await deliver({ accessToken, agentName, localPath, bytes });
-    return { ok: true, link: out.link, folderPath: out.folderPath, filename: basename(localPath) };
+    const out = await provider.deliver({ agentName, localPath, bytes });
+    return { ok: true, provider: provider.name, link: out.link, folderPath: out.folderPath, filename: basename(localPath) };
   } catch (err) {
-    return { ok: false, error: `upload failed: ${(err as Error).message}` };
+    return { ok: false, provider: provider.name, error: `upload failed: ${(err as Error).message}` };
   }
 }
 
@@ -139,7 +180,7 @@ export function registerDeliverFileCommand(program: Command): void {
       const res = await runDeliverFile(path);
       if (res.ok) {
         process.stdout.write(
-          `Delivered ${res.filename} to the user's drive → ${res.folderPath}/\n` +
+          `Delivered ${res.filename} to the user's ${res.provider} → ${res.folderPath}/\n` +
             `Share link (reply with this): ${res.link}\n`,
         );
         return;

--- a/src/delivery/gdrive.test.ts
+++ b/src/delivery/gdrive.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  ensureFolder,
+  ensureSwitchroomFolder,
+  uploadFile,
+  createShareLink,
+  deliverToGoogleDrive,
+} from "./gdrive.js";
+
+function route(
+  handlers: Array<{ method?: string; match: string; status?: number; json?: unknown; record?: (url: string, init?: RequestInit) => void }>,
+): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+    for (const h of handlers) {
+      if (url.includes(h.match) && (h.method ?? "GET").toUpperCase() === method) {
+        h.record?.(url, init);
+        const status = h.status ?? 200;
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          statusText: "",
+          json: async () => h.json ?? {},
+          text: async () => JSON.stringify(h.json ?? {}),
+        } as Response;
+      }
+    }
+    throw new Error(`unmocked ${method} ${url}`);
+  }) as typeof fetch;
+}
+
+const TOKEN = "ya29.access";
+
+describe("ensureFolder", () => {
+  it("returns the existing folder when the query finds one (no create)", async () => {
+    let created = false;
+    const f = route([
+      { method: "GET", match: "/drive/v3/files?q=", json: { files: [{ id: "EXIST", name: "Switchroom" }] } },
+      { method: "POST", match: "/drive/v3/files?fields", record: () => { created = true; }, json: {} },
+    ]);
+    const folder = await ensureFolder({ accessToken: TOKEN, fetchImpl: f }, "Switchroom", "root");
+    expect(folder.id).toBe("EXIST");
+    expect(created).toBe(false);
+  });
+
+  it("creates the folder when the query returns none, with the right parent", async () => {
+    let createBody = "";
+    const f = route([
+      { method: "GET", match: "/drive/v3/files?q=", json: { files: [] } },
+      { method: "POST", match: "/drive/v3/files?fields", json: { id: "NEW", name: "clerk" }, record: (_u, init) => { createBody = String(init?.body); } },
+    ]);
+    const folder = await ensureFolder({ accessToken: TOKEN, fetchImpl: f }, "clerk", "PARENT");
+    expect(folder.id).toBe("NEW");
+    expect(createBody).toContain('"mimeType":"application/vnd.google-apps.folder"');
+    expect(createBody).toContain('"parents":["PARENT"]');
+  });
+});
+
+describe("ensureSwitchroomFolder", () => {
+  it("creates Switchroom under root, then <agent> under Switchroom", async () => {
+    const parents: string[] = [];
+    const f = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/files?q=")) {
+        return { ok: true, status: 200, json: async () => ({ files: [] }), text: async () => "" } as Response;
+      }
+      if (method === "POST" && url.includes("/files?fields")) {
+        const b = JSON.parse(String(init?.body)) as { name: string; parents: string[] };
+        parents.push(`${b.name}<-${b.parents[0]}`);
+        return { ok: true, status: 200, json: async () => ({ id: b.name === "Switchroom" ? "TOP" : "AGENT", name: b.name }), text: async () => "" } as Response;
+      }
+      throw new Error(`unexpected ${method} ${url}`);
+    }) as typeof fetch;
+    const folder = await ensureSwitchroomFolder({ accessToken: TOKEN, fetchImpl: f }, "clerk");
+    expect(folder.id).toBe("AGENT");
+    expect(parents).toEqual(["Switchroom<-root", "clerk<-TOP"]);
+  });
+});
+
+describe("uploadFile", () => {
+  it("uploads via multipart and returns the file with id", async () => {
+    let ct = "";
+    const f = route([
+      { method: "POST", match: "/upload/drive/v3/files?uploadType=multipart", json: { id: "FILE", name: "r.pdf", webViewLink: "https://drive.google.com/file/d/FILE/view" }, record: (_u, init) => { ct = String((init?.headers as Record<string, string>)["Content-Type"]); } },
+    ]);
+    const file = await uploadFile({ accessToken: TOKEN, fetchImpl: f }, "FOLDER", "r.pdf", new Uint8Array([1, 2, 3]));
+    expect(file.id).toBe("FILE");
+    expect(ct).toContain("multipart/related; boundary=");
+  });
+});
+
+describe("createShareLink", () => {
+  it("grants anyone-reader and returns the webViewLink from the upload response", async () => {
+    let permBody = "";
+    const f = route([
+      { method: "POST", match: "/permissions", json: {}, record: (_u, init) => { permBody = String(init?.body); } },
+    ]);
+    const link = await createShareLink({ accessToken: TOKEN, fetchImpl: f }, { id: "FILE", webViewLink: "https://drive.google.com/file/d/FILE/view" });
+    expect(link).toBe("https://drive.google.com/file/d/FILE/view");
+    expect(permBody).toContain('"type":"anyone"');
+    expect(permBody).toContain('"role":"reader"');
+  });
+
+  it("fetches the webViewLink when the upload didn't include it", async () => {
+    const f = route([
+      { method: "POST", match: "/permissions", json: {} },
+      { method: "GET", match: "fields=webViewLink", json: { webViewLink: "https://drive.google.com/fetched" } },
+    ]);
+    const link = await createShareLink({ accessToken: TOKEN, fetchImpl: f }, { id: "FILE" });
+    expect(link).toBe("https://drive.google.com/fetched");
+  });
+});
+
+describe("deliverToGoogleDrive (full orchestration)", () => {
+  it("ensures folders, uploads, shares, and returns link + folderPath", async () => {
+    const f = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "GET" && url.includes("/files?q=")) return { ok: true, status: 200, json: async () => ({ files: [] }), text: async () => "" } as Response;
+      if (method === "POST" && url.includes("/files?fields")) { const b = JSON.parse(String(init?.body)) as { name: string }; return { ok: true, status: 200, json: async () => ({ id: b.name === "Switchroom" ? "TOP" : "AGENT" }), text: async () => "" } as Response; }
+      if (method === "POST" && url.includes("/upload/")) return { ok: true, status: 200, json: async () => ({ id: "FILE", webViewLink: "https://drive.google.com/report" }), text: async () => "" } as Response;
+      if (method === "POST" && url.includes("/permissions")) return { ok: true, status: 200, json: async () => ({}), text: async () => "" } as Response;
+      throw new Error(`unexpected ${method} ${url}`);
+    }) as typeof fetch;
+    const out = await deliverToGoogleDrive({ accessToken: TOKEN, agentName: "clerk", localPath: "/tmp/report.pdf", bytes: new Uint8Array(10), fetchImpl: f });
+    expect(out.itemId).toBe("FILE");
+    expect(out.link).toBe("https://drive.google.com/report");
+    expect(out.folderPath).toBe("Switchroom/clerk");
+  });
+});

--- a/src/delivery/gdrive.ts
+++ b/src/delivery/gdrive.ts
@@ -1,0 +1,192 @@
+/**
+ * Google Drive delivery provider — uploads a local file into the user's
+ * `Switchroom/<agent>/` folder and returns a shareable link.
+ *
+ * Sibling to the OneDrive provider (`./onedrive.ts`), same shape — and the same
+ * cred contract: the auth-broker keeps a FRESH access token on disk for Google
+ * too (its background refresh-tick exchanges the refresh token), so the CLI
+ * passes `googleOauth.accessToken` straight in; no token exchange here.
+ *
+ * All HTTP goes through an injectable `fetchImpl` (mockable; the `docs-get`
+ * pattern) — never live-exercised in unit tests. A canary validates the real
+ * upload.
+ *
+ * Drive v3 endpoints used:
+ *   - GET  /drive/v3/files?q=...              — find a folder by name+parent
+ *   - POST /drive/v3/files                    — create a folder
+ *   - POST /upload/drive/v3/files?uploadType=multipart — upload a file
+ *   - POST /drive/v3/files/<id>/permissions   — make it shareable
+ *   - GET  /drive/v3/files/<id>?fields=webViewLink — the link
+ */
+import { basename } from "node:path";
+
+const DRIVE = "https://www.googleapis.com/drive/v3";
+const UPLOAD = "https://www.googleapis.com/upload/drive/v3";
+const FOLDER_MIME = "application/vnd.google-apps.folder";
+
+export interface GDriveDeps {
+  accessToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface GFile {
+  id: string;
+  name?: string;
+  webViewLink?: string;
+}
+
+export interface DeliveredFile {
+  itemId: string;
+  link: string;
+  folderPath: string;
+}
+
+function authHeaders(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}`, Accept: "application/json" };
+}
+
+async function readBody(resp: Response): Promise<string> {
+  try {
+    const t = await resp.text();
+    return t.length > 300 ? `${t.slice(0, 300)}…` : t;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Find-or-create a folder named `name` under `parentId` ("root" for the drive
+ * root). Idempotent: returns the first existing match, else creates one.
+ */
+export async function ensureFolder(
+  deps: GDriveDeps,
+  name: string,
+  parentId: string,
+): Promise<GFile> {
+  const f = deps.fetchImpl ?? fetch;
+
+  // Escape single quotes in the name for the Drive query language.
+  const safeName = name.replace(/'/g, "\\'");
+  const q = `name='${safeName}' and mimeType='${FOLDER_MIME}' and '${parentId}' in parents and trashed=false`;
+  const listUrl = `${DRIVE}/files?q=${encodeURIComponent(q)}&fields=files(id,name)&spaces=drive`;
+  const list = await f(listUrl, { headers: authHeaders(deps.accessToken) });
+  if (!list.ok) {
+    throw new Error(`Drive folder lookup failed: HTTP ${list.status} — ${await readBody(list)}`);
+  }
+  const found = (await list.json()) as { files?: GFile[] };
+  if (found.files && found.files.length > 0) return found.files[0];
+
+  const created = await f(`${DRIVE}/files?fields=id,name`, {
+    method: "POST",
+    headers: { ...authHeaders(deps.accessToken), "Content-Type": "application/json" },
+    body: JSON.stringify({ name, mimeType: FOLDER_MIME, parents: [parentId] }),
+  });
+  if (!created.ok) {
+    throw new Error(`Drive folder create failed: HTTP ${created.status} — ${await readBody(created)}`);
+  }
+  return (await created.json()) as GFile;
+}
+
+/** Ensure `Switchroom/<agent>` under the drive root; returns its folder. */
+export async function ensureSwitchroomFolder(
+  deps: GDriveDeps,
+  agentName: string,
+): Promise<GFile> {
+  const top = await ensureFolder(deps, "Switchroom", "root");
+  return ensureFolder(deps, agentName, top.id);
+}
+
+/**
+ * Upload `bytes` as `filename` into folder `parentId` via a multipart upload
+ * (metadata + content in one request). Drive's simple/multipart upload handles
+ * files up to 5 MB inline well; larger files would want a resumable session
+ * (follow-up — the common delivery case is small).
+ */
+export async function uploadFile(
+  deps: GDriveDeps,
+  parentId: string,
+  filename: string,
+  bytes: Uint8Array,
+  mimeType = "application/octet-stream",
+): Promise<GFile> {
+  const f = deps.fetchImpl ?? fetch;
+  const boundary = "switchroom-deliver-boundary";
+  const metadata = JSON.stringify({ name: filename, parents: [parentId] });
+  const enc = new TextEncoder();
+  const head = enc.encode(
+    `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n` +
+      `--${boundary}\r\nContent-Type: ${mimeType}\r\n\r\n`,
+  );
+  const tail = enc.encode(`\r\n--${boundary}--`);
+  const body = new Uint8Array(head.length + bytes.length + tail.length);
+  body.set(head, 0);
+  body.set(bytes, head.length);
+  body.set(tail, head.length + bytes.length);
+
+  const resp = await f(`${UPLOAD}/files?uploadType=multipart&fields=id,name,webViewLink`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${deps.accessToken}`,
+      "Content-Type": `multipart/related; boundary=${boundary}`,
+    },
+    body: body as unknown as BodyInit,
+  });
+  if (!resp.ok) {
+    throw new Error(`Drive upload failed: HTTP ${resp.status} — ${await readBody(resp)}`);
+  }
+  return (await resp.json()) as GFile;
+}
+
+/** Drive sharing scope, attempted in order. */
+export type GDriveShareScope = "anyone" | "domain";
+
+/**
+ * Make the file shareable and return its webViewLink. Tries each scope in
+ * order (default `anyone` = anyone-with-link, the right UX for opening from
+ * Telegram). SECURITY NOTE: `anyone` is anyone-with-link, no sign-in — a real
+ * over-share if the link leaks. Operators tighten via the CLI's
+ * SWITCHROOM_DELIVER_LINK_SCOPE knob.
+ */
+export async function createShareLink(
+  deps: GDriveDeps,
+  file: GFile,
+  scopes: GDriveShareScope[] = ["anyone"],
+): Promise<string> {
+  const f = deps.fetchImpl ?? fetch;
+  for (const type of scopes) {
+    const resp = await f(`${DRIVE}/files/${file.id}/permissions`, {
+      method: "POST",
+      headers: { ...authHeaders(deps.accessToken), "Content-Type": "application/json" },
+      body: JSON.stringify(type === "domain" ? { role: "reader", type: "domain" } : { role: "reader", type: "anyone" }),
+    });
+    if (resp.ok) break; // permission set — fall through to fetch the link
+    // else try the next scope
+  }
+  // webViewLink may already be on the upload response; otherwise fetch it.
+  if (file.webViewLink) return file.webViewLink;
+  const meta = await f(`${DRIVE}/files/${file.id}?fields=webViewLink`, {
+    headers: authHeaders(deps.accessToken),
+  });
+  if (meta.ok) {
+    const j = (await meta.json()) as { webViewLink?: string };
+    if (j.webViewLink) return j.webViewLink;
+  }
+  throw new Error("Drive: could not resolve a webViewLink for the uploaded file");
+}
+
+/** Full delivery: ensure folder → upload → shareable link. */
+export async function deliverToGoogleDrive(args: {
+  accessToken: string;
+  agentName: string;
+  localPath: string;
+  bytes: Uint8Array;
+  fetchImpl?: typeof fetch;
+  linkScopes?: GDriveShareScope[];
+}): Promise<DeliveredFile> {
+  const deps: GDriveDeps = { accessToken: args.accessToken, fetchImpl: args.fetchImpl };
+  const folder = await ensureSwitchroomFolder(deps, args.agentName);
+  const filename = basename(args.localPath);
+  const file = await uploadFile(deps, folder.id, filename, args.bytes);
+  const link = await createShareLink(deps, file, args.linkScopes);
+  return { itemId: file.id, link, folderPath: `Switchroom/${args.agentName}` };
+}


### PR DESCRIPTION
## Summary
Completes the file-delivery outcome across **both clouds** and fixes a process hang the OneDrive canary exposed.

- **Google Drive provider** (`src/delivery/gdrive.ts`): find-or-create `Switchroom/<agent>` → multipart upload → shareable link. Same injectable-fetch shape as OneDrive.
- **Provider selection**: `runDeliverFile` resolves the first connected drive (OneDrive, else Google Drive) and reports which.
- **Hang fix**: the broker client keeps a connection open; the one-shot verb now closes it (`finally`) — without this the process hangs after printing its result.

## The token simplification
Google needed no token exchange / client_secret / vault-broker: the auth-broker keeps a **fresh** Google access token on disk (its background refresh-tick, same as Microsoft), so the CLI passes `googleOauth.accessToken` straight in — the Google path is identical to OneDrive. (I'd drafted a refresh-token exchange; the broker made it unnecessary, so it's removed — no dead code.)

## The hang (caught by the live canary)
The OneDrive canary on `clerk` delivered the file and printed a real `1drv.ms` link — but `EXIT=124`: the process didn't exit. Root cause: `AuthBrokerClient` keeps one connection open (built for long-running consumers); a one-shot CLI verb must `close()` it or the open socket keeps the event loop alive and the agent's Bash call hangs after success. Fixed.

## Test plan
- [x] `vitest run src/delivery/ src/cli/deliver-file.test.ts` — 31 pass (gdrive provider: folder find/create, multipart upload, link-fetch fallback, full orchestration; deliver-file: provider selection OneDrive/Google, scope resolvers for both clouds, slug-guard, error paths)
- [x] `tsc --noEmit` clean
- [x] **OneDrive path canary-proven live** on clerk (real upload + share link)
- [ ] **Google canary** once an agent has Google Drive connected (mocked-fetch tested; live validates the real Drive upload)

## Risk
Moderate (writes to the user's drive), bounded: only ever `Switchroom/<agent>/`; agentName slug-guarded; share scope configurable (`SWITCHROOM_DELIVER_LINK_SCOPE`). The hang fix is a pure correctness fix on the merged OneDrive path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)