### PR TITLE
chore(docker): bump bundled claude CLI 2.1.159 → 2.1.168 (all images + hindsight)

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -166,7 +166,7 @@ ARG CACHE_BUST=default
 # bumps.
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     echo "cache-bust=${CACHE_BUST}" > /dev/null \
- && npm install -g @anthropic-ai/claude-code@2.1.159 \
+ && npm install -g @anthropic-ai/claude-code@2.1.168 \
  && claude --version >&2
 
 # Phase 1b: install bun. The broker server (src/vault/broker/server.ts)

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -40,7 +40,7 @@ USER root
 # hindsight memory provider runs the identical claude bundle as the agent
 # containers — a version skew here could reintroduce the thinking-block /
 # thinking-effort class of failures on memory reflection (see #1978).
-RUN npm install -g @anthropic-ai/claude-code@2.1.159 \
+RUN npm install -g @anthropic-ai/claude-code@2.1.168 \
  && claude --version >&2
 
 # Install claude-agent-sdk into the same venv the hindsight API runs from.


### PR DESCRIPTION
## Summary

Bumps the bundled **Claude CLI** core runtime from **2.1.159 → 2.1.168** (latest). The fleet was 9 releases behind (pinned since v0.14.26 / #1978).

**Two pins, kept in lockstep:**
- `docker/Dockerfile.base:169` — propagates to **agent / broker / kernel / auth-broker / hostd** (all `FROM ${BASE_IMAGE}`), so every singleton gets it on rebuild.
- `docker/Dockerfile.hindsight:43` — hindsight installs claude separately; bumped to the same version per the #1978 invariant (a skew between the agent bundle and the hindsight memory-reflection bundle can reintroduce the thinking-block / thinking-effort failure class).

So **all images carry 2.1.168.**

## What 2.1.160→168 brings (switchroom-relevant)
- Background-agent fixes: worktree sessions no longer crash-loop ("No conversation found"); overnight-retired sessions keep history; failed agent replies queued for next start.
- **Rate-limit / auth / transport errors now surface immediately** — helps the gateway's quota detection → failover.
- Hook outputs can return `additionalContext`; configurable model fallbacks (up to 3) in interactive sessions.

## ⚠️ The one thing to canary
**Cross-session-messaging hardening (2.1.166):** *"relayed messages lose user authority, receivers refuse permission requests."* switchroom's model is synthesized/injected turns (cron `inject_inbound`, gateway-fed inbounds). The canary MUST prove these still deliver and aren't treated as "relayed → lose authority / refuse permissions."

## Verification
- Confirmed `2.1.168` installs + runs clean (`claude --version` → `2.1.168`) in a `node:22-trixie-slim` throwaway matching the base image, before committing — so the publish/install layer is good.
- CI `build-base` / `build-dependents (×N)` / `build-hindsight` rebuild every image against the new pin.

## No source/test changes
The remaining `2.1.159` mentions are historical (CHANGELOG, hook comments documenting when a behavior was observed) — not version assertions. `manifest.test.ts` uses `2.1.123` as a parser fixture, unrelated.

## Rollout (after merge)
Standard release → tag → `docker-images` rebuild → **canary on test-harness with an explicit injected-turn + cron delivery check** → UAT → staggered fleet roll (agents + singletons + hindsight recreate).

## Risk
Moderate — it's the core runtime. Mitigated by: exact-pin determinism, install verified, and a mandatory canary on the cross-session-messaging behavior before fleet roll. Reverting is a one-line pin change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)