### PR TITLE
feat(ci): sandboxed self-hosted UAT runner (uat-host) + setup script

### DIFF
--- a/docker/Dockerfile.uat-runner
+++ b/docker/Dockerfile.uat-runner
@@ -1,0 +1,34 @@
+# Sandboxed GitHub Actions self-hosted runner for switchroom UAT (label: uat-host).
+# Isolation by construction: runs as non-root, NO docker socket, NO host mounts,
+# egress-only networking. It can reach Telegram (to drive the test bot) + GitHub,
+# but cannot touch the host, the vault, the fleet, or docker. The host-mutating
+# jtbd-restart UAT scenarios self-skip here (no sudo) — exactly the boundary we
+# want: behavioural round-trip tests run; nothing on the host can be mutated.
+FROM node:22-trixie-slim
+
+ARG RUNNER_VERSION=2.334.0
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      curl ca-certificates git jq libicu76 unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+# bun (UAT runs under bun, repo convention). Install as root, then copy the
+# real binary to a world-readable path the non-root runner can exec.
+RUN curl -fsSL https://bun.sh/install | bash \
+ && cp -L /root/.bun/bin/bun /usr/local/bin/bun \
+ && chmod 0755 /usr/local/bin/bun \
+ && rm -rf /root/.bun
+
+RUN useradd -m -d /home/runner runner
+WORKDIR /actions-runner
+RUN chown runner:runner /actions-runner
+USER runner
+
+RUN curl -fsSL -o runner.tar.gz \
+      "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
+ && tar xzf runner.tar.gz && rm runner.tar.gz
+
+COPY --chown=runner:runner uat-runner-entrypoint.sh /actions-runner/entrypoint.sh
+ENTRYPOINT ["/actions-runner/entrypoint.sh"]

--- a/docker/uat-runner-entrypoint.sh
+++ b/docker/uat-runner-entrypoint.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Configure once (creds persist in the mounted volume across restarts); a
-# RUNNER_TOKEN is only needed the first time. --ephemeral keeps each job on a
-# clean checkout. Egress-only; no docker, no host access.
+# RUNNER_TOKEN is only needed the first time. This is a PERSISTENT runner (not
+# --ephemeral) — actions/checkout gives each job a fresh checkout, but the
+# uat-runner-data volume carries `_work` residue between jobs. Acceptable here:
+# fork PRs are gated by the all_external_contributors approval, so a job can only
+# run from an approved/merged change. Egress-only; no docker, no host access.
 if [ ! -f .runner ]; then
   if [ -z "${RUNNER_TOKEN:-}" ]; then
     echo "FATAL: first boot needs RUNNER_TOKEN (registration token)" >&2; exit 1

--- a/docker/uat-runner-entrypoint.sh
+++ b/docker/uat-runner-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Configure once (creds persist in the mounted volume across restarts); a
+# RUNNER_TOKEN is only needed the first time. --ephemeral keeps each job on a
+# clean checkout. Egress-only; no docker, no host access.
+if [ ! -f .runner ]; then
+  if [ -z "${RUNNER_TOKEN:-}" ]; then
+    echo "FATAL: first boot needs RUNNER_TOKEN (registration token)" >&2; exit 1
+  fi
+  ./config.sh \
+    --url "https://github.com/switchroom/switchroom" \
+    --token "${RUNNER_TOKEN}" \
+    --name "uat-runner-sandbox" \
+    --labels "uat-host" \
+    --work "_work" \
+    --unattended --replace
+fi
+exec ./run.sh

--- a/docs/operators/claude-cli-updates.md
+++ b/docs/operators/claude-cli-updates.md
@@ -54,26 +54,42 @@ still works — and it needs a self-hosted runner with subscription creds (below
 
 ## Wiring the `uat-host` runner (makes the behavioural gate automatic)
 
-Once registered, `ci-uat.yml` runs the real round-trip UAT (`jtbd-*`,
-`fuzz-*`, `inbound-no-drop`) on every relevant change — turning the manual canary
-in step 6 into an automatic gate, and unlocking "track latest as long as CI
-passes."
+Once registered, `ci-uat.yml` runs the real round-trip UAT (`fuzz-*`,
+`inbound-no-drop`, and on the operator host `jtbd-*`) on every relevant change —
+turning the manual canary in step 6 into an automatic gate, and unlocking
+"track latest as long as CI passes."
 
-1. On the operator host (has the subscription creds + a running `test-harness`
-   agent + NOPASSWD sudo + the `switchroom` CLI on PATH), register a GitHub
-   Actions self-hosted runner with the label **`uat-host`**
-   (repo → Settings → Actions → Runners → New self-hosted runner).
-2. Set the repo **variable** `UAT_GATE_ENABLED=true` (repo → Settings →
-   Secrets and variables → Actions → Variables).
-3. Set the four repo **secrets** the UAT driver needs: `TELEGRAM_API_ID`,
-   `TELEGRAM_API_HASH`, `TELEGRAM_UAT_DRIVER_SESSION`,
-   `TELEGRAM_TEST_BOT_USERNAME` (from the mtcute login — see
-   `telegram-plugin/uat/`).
-4. Confirm a green ci-uat run, then **add `ci-uat` to the required checks**
-   ruleset (`gh api repos/switchroom/switchroom/rulesets/16470166` → append the
-   `ci-uat` context to `required_status_checks`, preserving `bypass_actors: []`
-   + `enforcement: active`). Now a CLI bump can't merge unless a real turn
-   still works.
+**switchroom is a PUBLIC repo, so the runner is SANDBOXED** — a runner is a
+code-execution surface for fork PRs and must never sit unprotected next to the
+vault/fleet. The provided runner runs as a **container** with: non-root user,
+`no-new-privileges`, mem/pids caps, **no docker socket, no host mounts**, and a
+**bridge network (egress only)** — it reaches Telegram + GitHub but cannot touch
+the host's `127.0.0.1` fleet/vault. The host-mutating `jtbd-restart` scenarios
+self-skip there (no sudo); only the network-only round-trips run — exactly the
+boundary we want.
+
+One command does the whole setup (build the image; push the 4 `TELEGRAM_*`
+secrets + `UAT_GATE_ENABLED` from `.env`; set fork-PR approval to
+all-external-contributors; register + run the container):
+
+```bash
+scripts/setup-uat-runner.sh
+```
+
+(See `docker/Dockerfile.uat-runner` + `docker/uat-runner-entrypoint.sh` for the
+image; runner config persists in the `uat-runner-data` volume, so the container
+survives restarts without re-registering.)
+
+Then **confirm a green ci-uat run** and **add `ci-uat` to the required checks**
+ruleset (`gh api repos/switchroom/switchroom/rulesets/16470166` → append the
+`ci-uat` context to `required_status_checks`, preserving `bypass_actors: []` +
+`enforcement: active`). Now a CLI bump can't merge unless a real turn still
+works.
+
+> Security floor for a public-repo runner — all set by the script, do not
+> weaken: fork-PR approval = `all_external_contributors`; the runner has **no**
+> docker socket and **no** host mounts. Re-verify after any Actions-settings
+> change.
 
 To run the behavioural check against **latest** (not just the pinned bundle),
 build a throwaway agent on latest before driving UAT:

--- a/scripts/setup-uat-runner.sh
+++ b/scripts/setup-uat-runner.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Build + register the SANDBOXED GitHub Actions runner that runs switchroom's
+# behavioural UAT (label: uat-host) — a real inbound→reply round-trip on each
+# claude CLI bump (and other UAT-relevant changes).
+#
+# Isolation by construction (the whole point — switchroom is a PUBLIC repo, so a
+# runner must not be a foothold next to the vault/fleet):
+#   - non-root user, no-new-privileges, mem/pids capped
+#   - NO docker socket, NO host bind-mounts
+#   - bridge network = egress only (reaches Telegram + GitHub; cannot touch the
+#     host's 127.0.0.1 fleet/vault services)
+#   - the host-mutating jtbd-restart UAT scenarios self-skip (no sudo) — only the
+#     network-only fuzz / inbound-no-drop round-trips run here.
+#
+# Pair this with (one-time, in the repo's GitHub settings):
+#   - Actions → fork-PR approval = "all external contributors" (so a fork PR
+#     can't run on the runner without an explicit approve). This script sets it.
+#   - repo variable UAT_GATE_ENABLED=true + the 4 TELEGRAM_* secrets (this
+#     script pushes them from ./.env if present).
+#
+# Requires: docker, gh (authenticated with admin on the repo), and a repo-root
+# .env carrying TELEGRAM_API_ID / TELEGRAM_API_HASH / TELEGRAM_TEST_BOT_USERNAME
+# / TELEGRAM_UAT_DRIVER_SESSION (from `bun run uat:login`).
+set -euo pipefail
+
+REPO="${SWITCHROOM_REPO:-switchroom/switchroom}"
+IMAGE="switchroom-uat-runner:local"
+CONTAINER="switchroom-uat-runner"
+VOLUME="uat-runner-data"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "==> build sandboxed runner image"
+docker build -t "$IMAGE" -f "$HERE/docker/Dockerfile.uat-runner" "$HERE/docker"
+
+echo "==> push UAT secrets + gate var from .env (if present)"
+if [ -f "$HERE/.env" ]; then
+  for k in TELEGRAM_API_ID TELEGRAM_API_HASH TELEGRAM_TEST_BOT_USERNAME TELEGRAM_UAT_DRIVER_SESSION; do
+    v="$(grep -E "^${k}=" "$HERE/.env" | head -1 | cut -d= -f2- | sed 's/^"//;s/"$//')"
+    [ -n "$v" ] && printf '%s' "$v" | gh secret set "$k" --repo "$REPO" && echo "   set $k"
+  done
+  gh variable set UAT_GATE_ENABLED --repo "$REPO" --body "true"
+fi
+
+echo "==> harden: require approval for outside-collaborator fork PRs"
+gh api -X PUT "repos/${REPO}/actions/permissions/fork-pr-contributor-approval" \
+  -f approval_policy=all_external_contributors >/dev/null
+
+echo "==> register + run the runner (config persists in the $VOLUME volume)"
+REG_TOKEN="$(gh api -X POST "repos/${REPO}/actions/runners/registration-token" --jq .token)"
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+docker run -d \
+  --name "$CONTAINER" \
+  --restart unless-stopped \
+  --security-opt no-new-privileges \
+  --memory=3g --pids-limit=2000 \
+  -v "${VOLUME}:/actions-runner" \
+  -e RUNNER_TOKEN="$REG_TOKEN" \
+  "$IMAGE"
+
+echo "==> done. Verify: gh api repos/${REPO}/actions/runners --jq '.runners[].status'"
+echo "    Then run the gate: gh workflow run ci-uat.yml --repo ${REPO}"


### PR DESCRIPTION
## Summary

Makes the **behavioural** CLI-bump gate automatic: `ci-uat` runs a real inbound→reply round-trip against `test-harness` on each relevant change, instead of relying on a manual operator canary. This is the piece that unlocks **"track latest claude as long as CI passes"** — the build/flag canaries (#2234) prove install + surface; this proves a real turn still works.

## Sandboxed by construction (switchroom is a PUBLIC repo)
A self-hosted runner is a code-execution surface for fork PRs and must **not** sit unprotected next to the vault/fleet. So the runner:
- runs as a **container**, non-root, `--security-opt no-new-privileges`, mem + pids capped
- **no docker socket, no host bind-mounts**
- **bridge network = egress only** — reaches Telegram + GitHub, **cannot touch the host's `127.0.0.1` fleet/vault**
- the host-mutating `jtbd-restart` scenarios self-skip (no sudo); only the network-only `fuzz-*` / `inbound-no-drop` round-trips run here — exactly the boundary we want

## Files
- `docker/Dockerfile.uat-runner` + `docker/uat-runner-entrypoint.sh` — the runner image (actions/runner v2.334.0 + bun on `node:22-trixie-slim`); config persists in the `uat-runner-data` volume → survives restart without re-register.
- `scripts/setup-uat-runner.sh` — one command: build, push the 4 `TELEGRAM_*` secrets + `UAT_GATE_ENABLED` from `.env`, set **fork-PR approval = `all_external_contributors`** (the critical public-repo lock), register + run.
- `docs/operators/claude-cli-updates.md` — the runner section now documents the sandboxed approach + a **security floor** (fork-PR approval, no socket, no host mounts — do not weaken).

## Validated live
The runner registers **online** (label `uat-host`), picks up `ci-uat`, and checkout/secrets/setup all pass; the fuzz round-trips execute against the live `test-harness`. **`ci-uat` is added to required checks only after a confirmed green run — not in this PR.**

## Security review focus
Please sanity-check the isolation claims in `setup-uat-runner.sh` + `Dockerfile.uat-runner`: no docker socket, no host mounts, non-root, fork-PR approval set to the strictest. That's the load-bearing posture for a runner on a public repo.

## Risk
Low for the repo itself — these are operator artifacts (Dockerfile + script + docs), not runtime code; no required-check change here. The real risk surface is the runner's isolation, addressed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)