### PR TITLE
feat(delivery): Google Drive resumable upload for files > 5MB (OneDrive parity)

### DIFF
--- a/src/delivery/gdrive.test.ts
+++ b/src/delivery/gdrive.test.ts
@@ -5,6 +5,7 @@ import {
   uploadFile,
   createShareLink,
   deliverToGoogleDrive,
+  GDRIVE_MULTIPART_MAX_BYTES,
 } from "./gdrive.js";
 
 function route(
@@ -88,6 +89,47 @@ describe("uploadFile", () => {
     const file = await uploadFile({ accessToken: TOKEN, fetchImpl: f }, "FOLDER", "r.pdf", new Uint8Array([1, 2, 3]));
     expect(file.id).toBe("FILE");
     expect(ct).toContain("multipart/related; boundary=");
+  });
+
+  it("switches to a resumable session for a file over the multipart cap", async () => {
+    // 20 MiB → init session + chunked PUTs (8 MiB each → 3 chunks).
+    const big = new Uint8Array(20 * 1024 * 1024);
+    const ranges: string[] = [];
+    let initted = false;
+    let puts = 0;
+    const f = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "POST" && url.includes("uploadType=resumable")) {
+        initted = true;
+        return { ok: true, status: 200, headers: new Headers({ location: "https://upload.googleapis.com/session/xyz" }), json: async () => ({}), text: async () => "" } as Response;
+      }
+      if (method === "PUT" && url.includes("upload.googleapis.com/session")) {
+        puts++;
+        ranges.push((init?.headers as Record<string, string>)["Content-Range"]);
+        const last = puts === 3;
+        return { ok: last, status: last ? 200 : 308, headers: new Headers(), json: async () => (last ? { id: "BIG", name: "big.bin" } : {}), text: async () => "" } as Response;
+      }
+      throw new Error(`unexpected ${method} ${url}`);
+    }) as typeof fetch;
+    const file = await uploadFile({ accessToken: TOKEN, fetchImpl: f }, "FOLDER", "big.bin", big);
+    expect(initted).toBe(true);
+    expect(file.id).toBe("BIG");
+    expect(puts).toBe(3);
+    const total = 20 * 1024 * 1024;
+    const chunk = 8 * 1024 * 1024;
+    expect(ranges[0]).toBe(`bytes 0-${chunk - 1}/${total}`);
+    expect(ranges[2]).toBe(`bytes ${2 * chunk}-${total - 1}/${total}`);
+  });
+
+  it("errors clearly if the resumable init returns no session URL", async () => {
+    const big = new Uint8Array(GDRIVE_MULTIPART_MAX_BYTES + 1);
+    const f = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "POST") return { ok: true, status: 200, headers: new Headers(), json: async () => ({}), text: async () => "" } as Response;
+      throw new Error("should not PUT without a session");
+    }) as typeof fetch;
+    await expect(uploadFile({ accessToken: TOKEN, fetchImpl: f }, "FOLDER", "big.bin", big)).rejects.toThrow(/no session URL/);
   });
 });
 

--- a/src/delivery/gdrive.ts
+++ b/src/delivery/gdrive.ts
@@ -14,7 +14,8 @@
  * Drive v3 endpoints used:
  *   - GET  /drive/v3/files?q=...              — find a folder by name+parent
  *   - POST /drive/v3/files                    — create a folder
- *   - POST /upload/drive/v3/files?uploadType=multipart — upload a file
+ *   - POST /upload/drive/v3/files?uploadType=multipart — upload a small file
+ *   - POST /upload/drive/v3/files?uploadType=resumable + PUT chunks — large file
  *   - POST /drive/v3/files/<id>/permissions   — make it shareable
  *   - GET  /drive/v3/files/<id>?fields=webViewLink — the link
  */
@@ -96,13 +97,30 @@ export async function ensureSwitchroomFolder(
   return ensureFolder(deps, agentName, top.id);
 }
 
+/** Drive's single-request multipart upload is reliable up to ~5 MB; above
+ *  that we switch to a resumable session. */
+export const GDRIVE_MULTIPART_MAX_BYTES = 5 * 1024 * 1024;
+
 /**
- * Upload `bytes` as `filename` into folder `parentId` via a multipart upload
- * (metadata + content in one request). Drive's simple/multipart upload handles
- * files up to 5 MB inline well; larger files would want a resumable session
- * (follow-up — the common delivery case is small).
+ * Upload `bytes` as `filename` into folder `parentId`. Small files go in one
+ * multipart request; files over the 5 MB cap use a resumable session (so the
+ * "keep/edit, or > 50 MB" case the delivery guidance promises actually works).
  */
 export async function uploadFile(
+  deps: GDriveDeps,
+  parentId: string,
+  filename: string,
+  bytes: Uint8Array,
+  mimeType = "application/octet-stream",
+): Promise<GFile> {
+  if (bytes.byteLength <= GDRIVE_MULTIPART_MAX_BYTES) {
+    return uploadMultipart(deps, parentId, filename, bytes, mimeType);
+  }
+  return uploadResumable(deps, parentId, filename, bytes, mimeType);
+}
+
+/** Single-request multipart upload (metadata + content). Small files only. */
+export async function uploadMultipart(
   deps: GDriveDeps,
   parentId: string,
   filename: string,
@@ -135,6 +153,66 @@ export async function uploadFile(
     throw new Error(`Drive upload failed: HTTP ${resp.status} — ${await readBody(resp)}`);
   }
   return (await resp.json()) as GFile;
+}
+
+/**
+ * Resumable upload for files over the multipart cap. Two phases:
+ *   1. POST metadata to `uploadType=resumable` → session URL in the `Location`
+ *      response header.
+ *   2. PUT the bytes in chunks to that URL with `Content-Range`; Drive replies
+ *      308 (incomplete → keep going) until the final chunk returns 200/201 with
+ *      the file resource.
+ */
+export async function uploadResumable(
+  deps: GDriveDeps,
+  parentId: string,
+  filename: string,
+  bytes: Uint8Array,
+  mimeType = "application/octet-stream",
+): Promise<GFile> {
+  const f = deps.fetchImpl ?? fetch;
+
+  // Phase 1: initiate the session.
+  const init = await f(`${UPLOAD}/files?uploadType=resumable&fields=id,name,webViewLink`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${deps.accessToken}`,
+      "Content-Type": "application/json; charset=UTF-8",
+      "X-Upload-Content-Type": mimeType,
+    },
+    body: JSON.stringify({ name: filename, parents: [parentId] }),
+  });
+  if (!init.ok) {
+    throw new Error(`Drive resumable init failed: HTTP ${init.status} — ${await readBody(init)}`);
+  }
+  const sessionUrl = init.headers.get("location") ?? init.headers.get("Location");
+  if (!sessionUrl) {
+    throw new Error("Drive resumable init returned no session URL (Location header)");
+  }
+
+  // Phase 2: PUT chunks. 256 KiB multiple per Drive's rules.
+  const CHUNK = 8 * 1024 * 1024; // 8 MiB
+  const total = bytes.byteLength;
+  let lastFile: GFile | null = null;
+  for (let start = 0; start < total; start += CHUNK) {
+    const end = Math.min(start + CHUNK, total);
+    const chunk = bytes.subarray(start, end);
+    const put = await f(sessionUrl, {
+      method: "PUT",
+      headers: {
+        "Content-Length": String(chunk.byteLength),
+        "Content-Range": `bytes ${start}-${end - 1}/${total}`,
+      },
+      body: chunk as unknown as BodyInit,
+    });
+    if (put.status === 200 || put.status === 201) {
+      lastFile = (await put.json()) as GFile;
+    } else if (put.status !== 308) {
+      throw new Error(`Drive resumable chunk failed: HTTP ${put.status} — ${await readBody(put)}`);
+    }
+  }
+  if (!lastFile) throw new Error("Drive resumable upload completed without a final file resource");
+  return lastFile;
 }
 
 /** Drive sharing scope, attempted in order. */


### PR DESCRIPTION
## Summary
Adds a **resumable upload** path to the Google Drive provider so `deliver-file` handles large files there too — closing the parity gap a reviewer flagged on #2228.

## Why
The Google provider was multipart-only (reliable to ~5MB), but `DELIVERY_GUIDANCE` tells agents to use `deliver-file` for **"files they'll keep or edit, or > 50MB."** A large delivery on a Google-only agent failed (cleanly, but failed). OneDrive already handles this via a resumable session (`onedrive.ts`); this gives Google the same.

## Change
`uploadFile` dispatches on size:
- **≤ 5MB** → `uploadMultipart` (the existing single-request path)
- **> 5MB** → `uploadResumable`: POST `uploadType=resumable` for a session URL (`Location` header), then PUT 8 MiB chunks with `Content-Range` (308 = continue, 200/201 = done with the file resource).

## Test plan
- [x] `vitest run src/delivery/gdrive.test.ts` — 9 pass, incl. 2 new (>cap → resumable session with 3 correct-Content-Range chunks; missing session URL errors clearly)
- [x] `tsc --noEmit` clean
- [ ] **Canary** validates the real large upload once a Google-Drive-write agent exists (clerk's Google is read-only today). Cloud API isn't live-testable in CI; request shapes asserted with mocked fetch.

## Risk
Low — additive; the ≤5MB path (the common case, and the only one exercised live so far via OneDrive) is unchanged. Bounded to the agent's own `Switchroom/<agent>/` folder as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)