### PR TITLE
fix(dashboard): resilient connections fetch + always-fresh quota (no manual refresh)

### DIFF
--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -1628,6 +1628,71 @@ describe("AuthBroker — probe-quota", () => {
       broker.stop();
     }
   });
+
+  it("fleetQuotaProbeTick populates last_quota for ALL accounts with no explicit probe (dashboard always-fresh quota)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, {
+      active: "default",
+      fallback_order: ["default", "secondary"],
+      agents: { ziggy: {} },
+    });
+    seedAccount(h, "default", { expiresAt: 9_999_999_999_999 });
+    seedAccount(h, "secondary", { expiresAt: 9_999_999_999_999 });
+
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => ({ ok: true, data: {
+        fiveHourUtilizationPct: 33,
+        sevenDayUtilizationPct: 12,
+        fiveHourResetAt: null,
+        sevenDayResetAt: null,
+        representativeClaim: null,
+        overageStatus: null,
+        overageDisabledReason: null,
+      } }),
+    });
+    const client = new AuthBrokerClient({ socket: join(h.socketRoot, "ziggy", "sock") });
+    try {
+      await broker.start();
+      // No probe-quota op called — just the background tick the timer would run.
+      await broker.fleetQuotaProbeTick();
+      const state = await client.listState();
+      for (const label of ["default", "secondary"]) {
+        const acct = state.accounts.find((a) => a.label === label);
+        expect(acct?.last_quota, `${label} should have cached quota`).not.toBeNull();
+        expect(acct?.last_quota?.fiveHourUtilizationPct).toBeCloseTo(33, 1);
+        expect(acct?.last_quota?.sevenDayUtilizationPct).toBeCloseTo(12, 1);
+      }
+    } finally {
+      await client.close();
+      broker.stop();
+    }
+  });
+
+  it("fleetQuotaProbeTick keeps a prior snapshot when a probe fails (no eviction)", async () => {
+    const h = makeHarness();
+    const config = makeConfig(h, { active: "default", agents: { ziggy: {} } });
+    seedAccount(h, "default", { expiresAt: 9_999_999_999_999 });
+    let mode: "ok" | "fail" = "ok";
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      _testFetchQuota: async () => mode === "ok"
+        ? { ok: true, data: { fiveHourUtilizationPct: 50, sevenDayUtilizationPct: 20, fiveHourResetAt: null, sevenDayResetAt: null, representativeClaim: null, overageStatus: null, overageDisabledReason: null } }
+        : { ok: false, reason: "HTTP 503" },
+    });
+    const client = new AuthBrokerClient({ socket: join(h.socketRoot, "ziggy", "sock") });
+    try {
+      await broker.start();
+      await broker.fleetQuotaProbeTick(); // ok → cached
+      mode = "fail";
+      await broker.fleetQuotaProbeTick(); // fail → must NOT evict
+      const acct = (await client.listState()).accounts.find((a) => a.label === "default");
+      expect(acct?.last_quota?.fiveHourUtilizationPct).toBeCloseTo(50, 1);
+    } finally {
+      await client.close();
+      broker.stop();
+    }
+  });
 });
 
 describe("AuthBroker — drift detection", () => {

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -274,6 +274,7 @@ export class AuthBroker {
   /** Periodic probe of consumer-pinned accounts → auto mark-exhausted. See
    *  consumer-quota-sensor.ts. Null when disabled or no consumers. */
   private consumerProbeTimer: NodeJS.Timeout | null = null;
+  private fleetProbeTimer: NodeJS.Timeout | null = null;
   /** Quota fetcher — injectable for tests via opts._testFetchQuota. */
   private fetchQuotaImpl: typeof fetchQuota;
   private stateDir: string;
@@ -440,6 +441,23 @@ export class AuthBroker {
         }, probeMs);
         this.consumerProbeTimer.unref();
       }
+
+      // Fleet quota probe: keep every account's 5h/7d snapshot warm so the
+      // dashboard shows live quota with no manual "Refresh all quota" click.
+      // Always armed when probing is enabled (not gated on consumers — the
+      // dashboard wants quota regardless). Run once at boot so data is there
+      // immediately. Disable with SWITCHROOM_DISABLE_FLEET_QUOTA_PROBE=1.
+      if (probeMs > 0 && process.env.SWITCHROOM_DISABLE_FLEET_QUOTA_PROBE !== "1") {
+        void this.fleetQuotaProbeTick().catch((err) => {
+          this.logErr(`fleet-quota-probe (boot) threw: ${(err as Error).message}`);
+        });
+        this.fleetProbeTimer = setInterval(() => {
+          this.fleetQuotaProbeTick().catch((err) => {
+            this.logErr(`fleet-quota-probe threw: ${(err as Error).message}`);
+          });
+        }, probeMs);
+        this.fleetProbeTimer.unref();
+      }
     }
 
     // Boot fanout — write per-agent .credentials.json mirrors for every
@@ -482,6 +500,10 @@ export class AuthBroker {
     if (this.consumerProbeTimer) {
       clearInterval(this.consumerProbeTimer);
       this.consumerProbeTimer = null;
+    }
+    if (this.fleetProbeTimer) {
+      clearInterval(this.fleetProbeTimer);
+      this.fleetProbeTimer = null;
     }
     for (const [sock, lis] of this.listeners) {
       try { lis.server.close(); } catch { /* ignore */ }
@@ -1176,22 +1198,51 @@ export class AuthBroker {
         // Cache the utilization snapshot for listState consumers (quota-watch
         // loop). Only update on success — a failed probe should not evict a
         // valid previous snapshot.
-        if (result.ok) {
-          this.lastQuotaCache[label] = {
-            fiveHourUtilizationPct: result.data.fiveHourUtilizationPct,
-            sevenDayUtilizationPct: result.data.sevenDayUtilizationPct,
-            fiveHourResetAt: result.data.fiveHourResetAt?.toISOString() ?? null,
-            sevenDayResetAt: result.data.sevenDayResetAt?.toISOString() ?? null,
-            representativeClaim: result.data.representativeClaim,
-            overageStatus: result.data.overageStatus,
-            overageDisabledReason: result.data.overageDisabledReason,
-            capturedAt: this.now(),
-          };
-        }
+        if (result.ok) this.cacheQuotaSnapshot(label, result);
         return { label, result };
       }),
     );
     socket.write(encodeSuccess(id, { results }));
+  }
+
+  /** Store a successful quota probe in the in-memory cache that `list-state`
+   *  (and thus the dashboard) reads. Shared by the explicit probe op and the
+   *  periodic fleet tick so the snapshot shape stays in one place. */
+  private cacheQuotaSnapshot(label: string, result: QuotaResult): void {
+    if (!result.ok) return;
+    this.lastQuotaCache[label] = {
+      fiveHourUtilizationPct: result.data.fiveHourUtilizationPct,
+      sevenDayUtilizationPct: result.data.sevenDayUtilizationPct,
+      fiveHourResetAt: result.data.fiveHourResetAt?.toISOString() ?? null,
+      sevenDayResetAt: result.data.sevenDayResetAt?.toISOString() ?? null,
+      representativeClaim: result.data.representativeClaim,
+      overageStatus: result.data.overageStatus,
+      overageDisabledReason: result.data.overageDisabledReason,
+      capturedAt: this.now(),
+    };
+  }
+
+  /**
+   * Periodic background probe of every account's 5h/7d quota, so the dashboard
+   * shows live utilization WITHOUT the operator clicking "Refresh all quota".
+   * Each probe is a 1-token Haiku call (fetchQuota) — negligible spend. Caches
+   * the snapshot for `list-state`; a failed probe is a no-op (keeps the prior
+   * snapshot). Never throws into the timer. Public for tests.
+   */
+  async fleetQuotaProbeTick(): Promise<void> {
+    for (const label of listAccounts(this.home)) {
+      const creds = readAccountCredentials(label, this.home);
+      const token = creds?.claudeAiOauth?.accessToken;
+      if (!token) continue;
+      let result: QuotaResult;
+      try {
+        result = await this.fetchQuotaImpl({ accessToken: token });
+      } catch (err) {
+        this.logErr(`fleet-quota-probe ${label}: ${(err as Error).message}`);
+        continue;
+      }
+      this.cacheQuotaSnapshot(label, result);
+    }
   }
 
   /**

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -440,15 +440,20 @@
       return h;
     }
 
+    // Tolerate a single transient failure on the 10s auto-refresh: one blip
+    // (e.g. the web container restarting) shouldn't flash a scary error over a
+    // healthy dashboard. Only surface the error after two in a row.
+    let agentFetchFails = 0;
     async function fetchAgents() {
       try {
         const res = await fetch(`${API}/api/agents`, { headers: authHeaders() });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         agents = await res.json();
         render();
+        agentFetchFails = 0;
         clearError();
       } catch (err) {
-        showError(`Failed to fetch agents: ${err.message}`);
+        if (++agentFetchFails >= 2) showError(`Failed to fetch agents: ${err.message}`);
       }
     }
 
@@ -494,12 +499,18 @@
     }
 
     async function fetchConnections() {
+      // Each fetch falls back independently (.catch → default). A single
+      // network blip — e.g. one endpoint momentarily unreachable — must NOT
+      // reject the whole batch and blank the connected accounts; the others
+      // still render. (Previously a bare Promise.all meant any one failure
+      // wiped the tab, so a connected Google/Microsoft account "vanished".)
+      const safe = (p, fallback) => p.then(r => r.ok ? r.json() : fallback).catch(() => fallback);
       try {
         const [google, microsoft, notion, agents] = await Promise.all([
-          fetch(`${API}/api/google-accounts`, { headers: authHeaders() }).then(r => r.ok ? r.json() : []),
-          fetch(`${API}/api/microsoft-accounts`, { headers: authHeaders() }).then(r => r.ok ? r.json() : []),
-          fetch(`${API}/api/notion-workspace`, { headers: authHeaders() }).then(r => r.ok ? r.json() : { configured: false, databases: [] }),
-          fetch(`${API}/api/agents`, { headers: authHeaders() }).then(r => r.ok ? r.json() : []),
+          safe(fetch(`${API}/api/google-accounts`, { headers: authHeaders() }), []),
+          safe(fetch(`${API}/api/microsoft-accounts`, { headers: authHeaders() }), []),
+          safe(fetch(`${API}/api/notion-workspace`, { headers: authHeaders() }), { configured: false, databases: [] }),
+          safe(fetch(`${API}/api/agents`, { headers: authHeaders() }), []),
         ]);
         const agentNames = (agents || []).map(a => a.name).sort();
         renderConnections({ google, microsoft, notion, agentNames });


### PR DESCRIPTION
## Summary
Two dashboard-accuracy fixes from operator-reported symptoms:
- **Connections tab** showed no Microsoft/Google accounts (despite both connected) + "Failed to fetch agents".
- **Accounts tab** quota stayed empty until clicking "Refresh all quota".

## 1. Resilient connections fetch (`src/web/ui/index.html`)
`fetchConnections` used a bare `Promise.all`, so a single network blip on **any** of its 4 fetches (e.g. the web container restarting) rejected the whole batch → `renderConnections` never ran → the connected accounts "vanished". Now each fetch falls back independently (`.catch → default`), so Google/Microsoft/Notion render even if one endpoint blips. The 10s auto-refresh also tolerates one transient failure before flashing "Failed to fetch agents" over a healthy board.

## 2. Always-fresh quota (`src/auth/broker/server.ts`)
The 5h/7d quota only populated on the explicit "Refresh all quota" click (the cache started empty → "never probed"). Add a periodic `fleetQuotaProbeTick` that probes every account (a **1-token Haiku call** — negligible spend) and caches the snapshot `list-state` already serves, so the dashboard shows live quota **with no click**. Runs once at boot + on the consumer-probe interval; kill-switch `SWITCHROOM_DISABLE_FLEET_QUOTA_PROBE=1`. The cache-write is extracted into a shared `cacheQuotaSnapshot` helper (used by both the explicit op and the tick).

## Test plan
- [x] `vitest run src/auth/broker/server.test.ts` — 59 pass, incl. 2 new (tick populates `last_quota` for all accounts with no explicit probe; failed probe keeps the prior snapshot)
- [x] `tsc --noEmit` clean; frontend JS validated (`node --check`)
- [ ] Live after deploy: dashboard Connections shows both accounts through a refresh blip; Accounts quota fills in within a probe interval without clicking.

## Deploy note
Frontend change is baked into the `switchroom-web` image; broker change rides the `switchroom-broker`/auth-broker. Needs a release + web/broker recreate (the dashboard + brokers are separate compose projects the fleet roll doesn't auto-bounce — see the related memory).

## Risk
Low. Frontend: strictly more resilient. Broker: additive background probe (cheap, kill-switchable, never throws into the timer, never evicts a good snapshot on failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)