### PR TITLE
feat(status): surface orphaned foreground sub-agents (extended autonomous work)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -471,6 +471,10 @@ import {
 } from './resume-inbound-builder.js'
 import { applySubagentsSchema, getSubagentByJsonlId } from '../registry/subagents-schema.js'
 import { resolveWorkerFeedDispatch, type WorkerFeedDispatch } from './worker-feed-dispatch.js'
+import {
+  resolveSubagentStatusSurface,
+  isOrphanSubagentStatusEnabled,
+} from './subagent-status-surface.js'
 import { formatIdleFooter } from '../idle-footer.js'
 import { resolveCallingSubagent } from './resolve-calling-subagent.js'
 
@@ -20410,6 +20414,11 @@ void (async () => {
             // compose draft, so no answer-stream contention). The kill-switch
             // disables only the nesting; the parent's own feed is unaffected.
             const foregroundNestingEnabled = process.env.SWITCHROOM_FOREGROUND_SUBAGENT_NESTING !== '0'
+            // Orphaned-foreground status (2026-06-09): a FOREGROUND sub-agent
+            // with no live parent turn to nest into (dispatched outside a turn,
+            // or the turn ended while it kept running — extended autonomous
+            // work) is surfaced via the worker feed instead of vanishing.
+            const orphanStatusEnabled = isOrphanSubagentStatusEnabled(process.env.SWITCHROOM_ORPHAN_SUBAGENT_STATUS)
             const workerActivityFeed = createWorkerActivityFeed({
               bot: {
                 sendMessage: async (cid, text, sendOpts) => {
@@ -20609,6 +20618,29 @@ void (async () => {
                         }
                       }
                     }
+                    return
+                  }
+                  // Not nested → an orphaned foreground sub-agent that was
+                  // surfaced via the worker feed (no live turn to nest into):
+                  // finalize its message (no-op if none was posted). A
+                  // foreground result returns inline as the Task tool result, so
+                  // there is no handback to deliver — return after.
+                  if (
+                    resolveSubagentStatusSurface({
+                      isBackground: false,
+                      liveTurnPresent: false,
+                      workerFeedEnabled,
+                      orphanStatusEnabled,
+                    }) === 'worker-feed'
+                  ) {
+                    void workerActivityFeed.finish(agentId, {
+                      description: dispatch.feedDescription,
+                      lastTool: null,
+                      toolCount,
+                      latestSummary: resultText,
+                      elapsedMs: durationMs,
+                      state: outcome === 'failed' ? 'failed' : 'done',
+                    })
                   }
                   return
                 }
@@ -20738,8 +20770,39 @@ void (async () => {
                   // activity draft rather than a separate worker message. Pure
                   // jsonl-tail → render (no model call), inside the
                   // subscription-honest boundary.
+                  //
+                  // But a foreground sub-agent with NO live turn to nest into
+                  // (dispatched outside a turn, or the turn ended while it kept
+                  // running — extended autonomous work) has nowhere to nest, and
+                  // pre-fix it silently returned here → invisible. Route through
+                  // the proven decision: an orphaned foreground sub-agent goes to
+                  // the worker feed (owner-DM fallback), not into the void.
+                  const surface = resolveSubagentStatusSurface({
+                    isBackground: false,
+                    liveTurnPresent: currentTurn != null,
+                    workerFeedEnabled,
+                    orphanStatusEnabled,
+                  })
+                  if (surface === 'worker-feed') {
+                    const origin = resolveSubagentOriginChat(agentId)
+                    void workerActivityFeed.update(
+                      agentId,
+                      origin?.chatId || fleetChatId || (loadAccess().allowFrom[0] ?? ''),
+                      {
+                        description: dispatch.feedDescription,
+                        lastTool,
+                        toolCount,
+                        latestSummary,
+                        elapsedMs,
+                        state: 'running',
+                      },
+                      origin?.threadId,
+                    )
+                    return
+                  }
+                  if (surface !== 'nest') return // 'skip' — orphan-status off
                   const turn = currentTurn
-                  if (turn == null) return
+                  if (turn == null) return // defensive: 'nest' implies a live turn
                   // Render regardless of `replyCalled` — a foreground Task
                   // blocks the parent, so any reply seen while it runs is an
                   // interim ack, never the final answer. Gating on replyCalled

--- a/telegram-plugin/gateway/subagent-status-surface.test.ts
+++ b/telegram-plugin/gateway/subagent-status-surface.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveSubagentStatusSurface,
+  isOrphanSubagentStatusEnabled,
+  type SubagentStatusSurface,
+  type SubagentStatusSurfaceInput,
+} from './subagent-status-surface.js'
+
+// ── Human-readable map ──────────────────────────────────────────────────────
+describe('resolveSubagentStatusSurface', () => {
+  const base: SubagentStatusSurfaceInput = {
+    isBackground: false,
+    liveTurnPresent: true,
+    workerFeedEnabled: true,
+    orphanStatusEnabled: true,
+  }
+  it('foreground + live turn → nest (unchanged default)', () => {
+    expect(resolveSubagentStatusSurface(base)).toBe('nest')
+  })
+  it('THE fix: orphaned foreground (no live turn) → worker-feed', () => {
+    expect(resolveSubagentStatusSurface({ ...base, liveTurnPresent: false })).toBe('worker-feed')
+  })
+  it('kill switch: orphaned foreground with orphanStatus OFF → skip (pre-fix invisible)', () => {
+    expect(
+      resolveSubagentStatusSurface({ ...base, liveTurnPresent: false, orphanStatusEnabled: false }),
+    ).toBe('skip')
+  })
+  it('orphaned foreground but feed OFF → skip (nothing to surface through)', () => {
+    expect(
+      resolveSubagentStatusSurface({ ...base, liveTurnPresent: false, workerFeedEnabled: false }),
+    ).toBe('skip')
+  })
+  it('background + feed on → worker-feed', () => {
+    expect(resolveSubagentStatusSurface({ ...base, isBackground: true, liveTurnPresent: false })).toBe('worker-feed')
+  })
+  it('background + feed off → legacy-relay', () => {
+    expect(
+      resolveSubagentStatusSurface({ ...base, isBackground: true, workerFeedEnabled: false }),
+    ).toBe('legacy-relay')
+  })
+})
+
+describe('isOrphanSubagentStatusEnabled — default ON, =0 kill switch', () => {
+  it('undefined / "1" / "" → on; "0" → off', () => {
+    expect(isOrphanSubagentStatusEnabled(undefined)).toBe(true)
+    expect(isOrphanSubagentStatusEnabled('1')).toBe(true)
+    expect(isOrphanSubagentStatusEnabled('')).toBe(true)
+    expect(isOrphanSubagentStatusEnabled('0')).toBe(false)
+  })
+})
+
+// ── TOTAL-ENUMERATION DETERMINISM PROOF ─────────────────────────────────────
+// 4 booleans = 16 reachable inputs. Enumerate all, assert totality, determinism,
+// the documented table (independent spec), and the load-bearing invariants.
+// (operator standard feedback_prove_finite_fsm_not_sample.)
+function allInputs(): SubagentStatusSurfaceInput[] {
+  const rows: SubagentStatusSurfaceInput[] = []
+  for (const isBackground of [false, true])
+    for (const liveTurnPresent of [false, true])
+      for (const workerFeedEnabled of [false, true])
+        for (const orphanStatusEnabled of [false, true])
+          rows.push({ isBackground, liveTurnPresent, workerFeedEnabled, orphanStatusEnabled })
+  return rows
+}
+
+// Independent spec encoding (kept separate from the impl).
+function spec(i: SubagentStatusSurfaceInput): SubagentStatusSurface {
+  if (i.isBackground) return i.workerFeedEnabled ? 'worker-feed' : 'legacy-relay'
+  if (i.liveTurnPresent) return 'nest'
+  if (!i.orphanStatusEnabled) return 'skip'
+  return i.workerFeedEnabled ? 'worker-feed' : 'skip'
+}
+
+describe('resolveSubagentStatusSurface — total enumeration (16 inputs)', () => {
+  const ROWS = allInputs()
+
+  it('exactly 16 reachable inputs (2^4)', () => {
+    expect(ROWS.length).toBe(16)
+  })
+  it('TOTAL + DETERMINISTIC: every input returns one of the four surfaces, idempotently', () => {
+    const surfaces = new Set<SubagentStatusSurface>(['nest', 'worker-feed', 'legacy-relay', 'skip'])
+    for (const i of ROWS) {
+      const a = resolveSubagentStatusSurface(i)
+      expect(surfaces.has(a)).toBe(true)
+      expect(resolveSubagentStatusSurface({ ...i })).toBe(a)
+    }
+  })
+  it('PRECEDENCE: matches the documented spec on all 16 inputs', () => {
+    for (const i of ROWS) expect(resolveSubagentStatusSurface(i)).toBe(spec(i))
+  })
+
+  it('INV-ORPHAN-VISIBLE: an orphaned foreground sub-agent is NEVER skip when orphanStatus + feed are on', () => {
+    for (const i of ROWS) {
+      if (!i.isBackground && !i.liveTurnPresent && i.orphanStatusEnabled && i.workerFeedEnabled) {
+        expect(resolveSubagentStatusSurface(i)).toBe('worker-feed')
+      }
+    }
+  })
+  it('INV-KILL-SWITCH: orphanStatus OFF ⇒ an orphaned foreground sub-agent is exactly the pre-fix behaviour (skip)', () => {
+    for (const i of ROWS) {
+      if (!i.isBackground && !i.liveTurnPresent && !i.orphanStatusEnabled) {
+        expect(resolveSubagentStatusSurface(i)).toBe('skip')
+      }
+    }
+  })
+  it('INV-NEST-UNCHANGED: a foreground sub-agent with a live turn is ALWAYS nest, independent of the other flags', () => {
+    for (const i of ROWS) {
+      if (!i.isBackground && i.liveTurnPresent) expect(resolveSubagentStatusSurface(i)).toBe('nest')
+    }
+  })
+  it('INV-BACKGROUND-UNCHANGED: background routing depends ONLY on the feed flag, never on liveTurn/orphanStatus', () => {
+    for (const i of ROWS) {
+      if (i.isBackground) {
+        expect(resolveSubagentStatusSurface(i)).toBe(i.workerFeedEnabled ? 'worker-feed' : 'legacy-relay')
+      }
+    }
+  })
+})

--- a/telegram-plugin/gateway/subagent-status-surface.ts
+++ b/telegram-plugin/gateway/subagent-status-surface.ts
@@ -1,0 +1,69 @@
+/**
+ * Where does a sub-agent's live status go?
+ *
+ * A sub-agent's progress is surfaced on one of four "surfaces". This pure
+ * decision picks which, so the routing is provable by total enumeration rather
+ * than buried in the gateway's imperative branches.
+ *
+ *   - `nest`         — a FOREGROUND sub-agent running inside a LIVE parent turn:
+ *                      its narrative nests under the parent's activity draft
+ *                      (the progress card). The default, unchanged.
+ *   - `worker-feed`  — a BACKGROUND worker (the `🛠 Worker` edit-in-place
+ *                      message), OR a FOREGROUND sub-agent that has NO live
+ *                      parent turn to nest into (dispatched outside a turn, or
+ *                      the turn ended while it kept running). The latter is the
+ *                      2026-06-09 fix: extended autonomous work was invisible
+ *                      because foreground status was turn-scoped and a sub-agent
+ *                      with no turn silently returned. It now reuses the worker
+ *                      feed (with the same owner-DM fallback background workers
+ *                      already use), so post-turn work is always visible.
+ *   - `legacy-relay` — a BACKGROUND worker when the worker feed is OFF: fall
+ *                      back to the legacy "still working" injected-inbound relay.
+ *   - `skip`         — nothing to surface (kill-switch off for an orphaned
+ *                      foreground, or no feed to surface it through).
+ *
+ * Determinism: the input space is 4 booleans = 16 rows, enumerated and proven
+ * in subagent-status-surface.test.ts (operator standard
+ * feedback_prove_finite_fsm_not_sample). The load-bearing invariant: an
+ * orphaned foreground sub-agent (no live turn) is `worker-feed`, never `skip`,
+ * whenever the orphan-status flag and the feed are both on.
+ */
+
+export type SubagentStatusSurface = 'nest' | 'worker-feed' | 'legacy-relay' | 'skip'
+
+export interface SubagentStatusSurfaceInput {
+  /** run_in_background dispatch (registry `subagents.background`). */
+  isBackground: boolean
+  /**
+   * A LIVE parent turn exists to nest this (foreground) sub-agent into.
+   * onProgress: `currentTurn != null`. onFinish: `currentTurn != null && it was
+   * actually nested` (so a foreground sub-agent that was surfaced via the worker
+   * feed — never nested — finalizes through the feed, not a turn collapse).
+   * Ignored for background sub-agents.
+   */
+  liveTurnPresent: boolean
+  /** SWITCHROOM_WORKER_ACTIVITY_FEED on. */
+  workerFeedEnabled: boolean
+  /** SWITCHROOM_ORPHAN_SUBAGENT_STATUS on — surface no-parent-turn foreground
+   *  sub-agents via the worker feed. Off = pre-fix behaviour (invisible). */
+  orphanStatusEnabled: boolean
+}
+
+export function resolveSubagentStatusSurface(
+  input: SubagentStatusSurfaceInput,
+): SubagentStatusSurface {
+  if (!input.isBackground) {
+    // Foreground sub-agent.
+    if (input.liveTurnPresent) return 'nest'
+    // Orphaned foreground: no live turn to nest into — the invisible case.
+    if (!input.orphanStatusEnabled) return 'skip' // kill switch: pre-fix behaviour
+    return input.workerFeedEnabled ? 'worker-feed' : 'skip' // surfacing needs the feed
+  }
+  // Background worker.
+  return input.workerFeedEnabled ? 'worker-feed' : 'legacy-relay'
+}
+
+/** SWITCHROOM_ORPHAN_SUBAGENT_STATUS — default ON; `=0` restores pre-fix (invisible) behaviour. */
+export function isOrphanSubagentStatusEnabled(envVal: string | undefined): boolean {
+  return envVal !== '0'
+}


### PR DESCRIPTION
## Summary

When an agent keeps working **after its turn ends** (extended autonomous work — desirable), any **foreground** sub-agent it dispatches has no live parent turn to nest its status into. `onProgress` hit `if (currentTurn == null) return` and the work ran **completely invisible**.

Diagnosed on **finn**: a `reviewer` sub-agent ran for minutes with the operator seeing nothing; the registry showed it with `parent_turn_key = NULL` while the last turn had ended **12 minutes** earlier. Background workers already DM-fallback in this case (`origin?.chatId || fleetChatId || loadAccess().allowFrom[0]`); foreground sub-agents did not.

**Status visibility must not depend on the model holding a turn open.** A foreground sub-agent with no live turn now surfaces via the worker-activity feed (the same `🛠 Worker` edit-in-place message, routed to the dispatching chat or the owner DM via the existing fallback) — exactly like a background worker. In-turn foreground sub-agents still nest into the progress card, unchanged.

## Design

The routing is a **pure decision** (`telegram-plugin/gateway/subagent-status-surface.ts`):

```
resolveSubagentStatusSurface(input) → 'nest' | 'worker-feed' | 'legacy-relay' | 'skip'
```

- foreground + live turn → `nest` (unchanged)
- **foreground + NO live turn → `worker-feed`** (the fix; was an invisible `return`)
- background + feed on → `worker-feed`; background + feed off → `legacy-relay`
- orphaned foreground with the flag off → `skip` (exact pre-fix behaviour)

Both `onProgress` and `onFinish` route their foreground branch through it; the background path (and its handback) is untouched. Foreground results return inline as the Task tool result, so the orphan path finalizes the feed message and returns — **no** handback.

Kill switch `SWITCHROOM_ORPHAN_SUBAGENT_STATUS=0` restores the pre-fix behaviour.

## Determinism (proven, not sampled)

Per `feedback_prove_finite_fsm_not_sample`, `resolveSubagentStatusSurface` is proven by **total enumeration of its 4-boolean / 16-row input space**, with an independent spec encoding and the load-bearing invariants:
- **INV-ORPHAN-VISIBLE** — an orphaned foreground sub-agent is never `skip` when the flag and feed are on.
- **INV-KILL-SWITCH** — flag off ⟹ exactly the pre-fix `skip`.
- **INV-NEST-UNCHANGED / INV-BACKGROUND-UNCHANGED** — the existing paths don't move.

## Test plan
- [x] `subagent-status-surface.test.ts` — total-enumeration proof (16) + invariants + flag parser (14 tests).
- [x] No regression across the subagent/worker surface: worker-activity-feed, worker-feed-dispatch (incl. its 20k-row property sweep), subagent-watcher, subagent-tracker-hooks, streaming-orchestration, resolve-calling-subagent.
- [x] `tsc --noEmit` clean · full `bun lint` chain clean · gateway bundle contains the new logic.
- [x] **238 files / 3845 vitest + 77 bun tests green.**

## Risk
Behaviour changes only for a foreground sub-agent with **no live turn** (previously invisible → now a worker-feed message in the dispatching chat / owner DM). In-turn nesting and all background paths are byte-unchanged (proven by the invariants). Kill-switched. Multi-step autonomous agents (finn, etc.) are the beneficiaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)