### PR TITLE
chore: release v0.14.91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.14.91 — Surface orphaned foreground sub-agents (extended autonomous work) (#2240)
+
+When an agent kept working **after its turn ended** — extended autonomous work,
+which is desirable — any foreground sub-agent it dispatched had no live parent
+turn to nest its status into, so the work ran completely **invisible** (no
+progress card, no worker feed). Diagnosed on finn: a `reviewer` sub-agent ran
+for minutes with the operator seeing nothing.
+
+Status visibility no longer depends on the model holding a turn open. A
+foreground sub-agent with no live turn now surfaces via the worker-activity feed
+(the same `🛠 Worker` message, routed to the dispatching chat or the owner DM
+via the existing fallback), exactly like a background worker. In-turn foreground
+sub-agents still nest into the progress card, unchanged. The routing is a pure,
+total-enumeration-proven decision; kill switch `SWITCHROOM_ORPHAN_SUBAGENT_STATUS=0`.
+
 ## v0.14.90 — Framework owns the reply topic, not the model (#2233)
 
 A General-topic question to an agent in a forum supergroup could get its answer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.90",
+  "version": "0.14.91",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {

--- a/tests/docker/ci-image-matrix.test.ts
+++ b/tests/docker/ci-image-matrix.test.ts
@@ -32,6 +32,10 @@ const DOCKER_MATRIX_OPT_OUT: Record<string, string> = {
   // dependent via BASE_IMAGE — it doesn't ship as a separate
   // switchroom-* tag.
   base: "built as build-base; consumed via BASE_IMAGE arg",
+  // uat-runner is the sandboxed self-hosted UAT host image (#2236); it is
+  // built/consumed by the UAT CI workflow, not published as a per-version
+  // fleet GHCR tag, so it is intentionally outside the docker-images matrix.
+  "uat-runner": "CI-only sandboxed UAT host runner (#2236); not a published fleet image",
 };
 
 function dockerfileNames(): string[] {

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -58,8 +58,10 @@ describe("Dockerfile.hindsight shape", () => {
   });
 
   it("installs the @anthropic-ai/claude-code CLI globally", () => {
+    // Allow the install to be quoted + version-pinned, e.g.
+    // `npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"`.
     expect(dockerfile).toMatch(
-      /npm\s+install\s+-g\s+@anthropic-ai\/claude-code/,
+      /npm\s+install\s+-g\s+"?@anthropic-ai\/claude-code/,
     );
   });
 


### PR DESCRIPTION
Release v0.14.91 — surface orphaned foreground sub-agents (#2240). Reviewed (fresh-process APPROVE, mutation-verified) + CI-green on merge.