### PR TITLE
ci(uat): remove the nightly fuzz cron (burns subscription quota)

### DIFF
--- a/.github/workflows/ci-uat.yml
+++ b/.github/workflows/ci-uat.yml
@@ -54,9 +54,10 @@ on:
       - "telegram-plugin/uat/**"
       - "vitest.uat.config.ts"
       - ".github/workflows/ci-uat.yml"
-  schedule:
-    # Nightly thorough fuzz pass (the uat-fuzz job below is schedule/dispatch-only).
-    - cron: "41 4 * * *"
+  # No `schedule:` — the nightly fuzz cron was removed (2026-06-09): each fuzz
+  # scenario is a real claude turn on the subscription, and an automatic nightly
+  # pass burns quota that competes with the live fleet. The thorough fuzz pool is
+  # now workflow_dispatch-ONLY (run it deliberately during a UAT pass).
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Drops the `schedule: cron "41 4 * * *"` from ci-uat.yml — each fuzz scenario is a real claude turn on the fleet-active account, so an automatic nightly pass burns quota competing with the live fleet. The thorough fuzz pool becomes workflow_dispatch-ONLY (run deliberately during UAT). Fast `uat-gate` unaffected. UAT is disabled fleet-wide (UAT_GATE_ENABLED=false) regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)