### PR TITLE
feat(cron): cheap cron — deterministic polls + Sonnet cron-session (RFC + L1-L3)

### DIFF
--- a/docs/rfcs/cheap-cron-sessions.md
+++ b/docs/rfcs/cheap-cron-sessions.md
@@ -1,0 +1,379 @@
+# RFC — Cheap cron: deterministic polls + a per-agent Sonnet cron session
+
+**Status:** Draft, post-review (rev 2)
+**Author:** (agent-authored, operator-directed)
+**Targets:** `upstream/main` @ v0.14.91
+**Compliance pillar touched:** 3 (Claude-native, subscription-honest) — preserved by construction; see §7.
+
+---
+
+## Review verdict (5-lens adversarial, rev 1 → rev 2)
+
+| Lens | rev 1 | After rev-2 changes |
+|------|-------|---------------------|
+| Compliance (pillar 3) | **APPROVE** | unchanged — Tier 0 model-free; Tier 1/2 interactive, no `-p` |
+| Feasibility | REQUEST_CHANGES | §3.3 rewritten to own the full gateway refactor scope |
+| Resources/Ops | REQUEST_CHANGES | §2.2 runtime shape → **lazy session (B3)**; double-escalation §2.1 |
+| Security | **BLOCK** | §6.1 **SSRF/exfil hardening** added; §6.2 operator-commit boundary |
+| Completeness | REQUEST_CHANGES | §2.4 status isolation; §5 observability; §3.1 custom-model migration |
+
+The BLOCK was the `http-diff` SSRF/secret-exfil surface (§6.1). It is resolved at
+the design level here; the build must implement the egress guard + host-pinned
+secret bindings before any Tier-0 poll ships. Everything else was either
+"code-not-yet-written" (expected for a spec) or a genuine sharpening folded in
+below.
+
+---
+
+## 0. TL;DR
+
+Cron fires are expensive for one structural reason: **every fire injects a
+synthesized turn into the agent's live interactive session**, so it pays the
+full standing-context cache-read tax (system prompt + ~31k-token MCP schema
+surface + the whole running conversation) *and* runs at the agent's configured
+model — even when the fire is a `*/10` poll that finds nothing to do.
+
+Three tiers, cheapest-first:
+
+- **Tier 0 — deterministic poll (no model).** Poll-heavy crons run a *declarative,
+  operator-approved* poll in the scheduler process. No new data → `HEARTBEAT_OK`,
+  **zero model tokens.** Only a hit escalates.
+- **Tier 1 — per-agent cheap cron session.** Crons that need a model but not the
+  agent's persona/memory fire into a **minimal-context `claude --model sonnet`
+  session**, addressed by a new gateway session label `cron`. ~5–20× cheaper.
+- **Tier 2 — main session (status quo).** Crons that need the agent's full context
+  inject into the live session exactly as today.
+
+Routing key = the **dead-but-present `ScheduleEntry.model` field** (reactivated) +
+two new optional fields (`kind`, `context`). Behind `SWITCHROOM_CHEAP_CRON`
+(default **off**), canaried on the two crons we disabled 2026-06-09.
+
+---
+
+## 1. Problem (grounded in code)
+
+### 1.1 The fire path today
+
+`src/agent-scheduler/index.ts` fires a node-cron handler → `dispatchAsInbound`
+(`src/scheduler/dispatch.ts:193-219`) synthesizes an `InboundMessage` with
+`meta.source='cron'` → `ipc-client.ts:159-167` writes `inject_inbound` NDJSON to
+`gateway.sock` → `gateway.ts:6287-6305` `onInjectInbound` → `ipcServer.sendToAgent`
+→ **the single registered bridge** → the live claude session runs it as a turn.
+
+Consequences:
+
+1. **Standing-context tax every fire.** The live session carries the full
+   prompt-cache prefix (memory `project_context_token_optimization`: ~63k-token
+   floor + the running conversation). Each fire re-reads it (`cache_read ≈ 0.1×`
+   on 60k+ tokens = thousands of cost-weighted tokens) **whether or not there is
+   work.** `*/10` = 144 fires/day, ~all no-ops.
+2. **Agent's model, fixed per container** by `--model {{modelQ}}`
+   (`start.sh.hbs:673` from `scaffold.ts:2181`; default
+   `SWITCHROOM_DEFAULT_MAIN_MODEL='claude-sonnet-4-6'`). An Opus agent runs every
+   fire at Opus (`output ≈ 5×`).
+3. **`ScheduleEntry.model` is a dead letter** (`schema.ts:64-106`; `SchedulerEntry`
+   `dispatch.ts:25-42` omits it). Set it today → **no error, no effect.**
+
+### 1.2 The two disabled crons — both polls
+
+- `clerk` `telegram-capture` (`*/10`, **144 fires/day**): `get_recent_messages` →
+  capture 👨‍💻-reacted msgs to Notion → `HEARTBEAT_OK` if none.
+- `marko` `lead-alert-3homes` (`*/15`, **96 fires/day**): `GET Brevo list 20` →
+  email new "3 Homes" leads → `NO_REPLY` if none.
+
+Neither needs a model on the no-op path. **240 fires/day, ~all wasted.**
+
+---
+
+## 2. Design: three tiers
+
+```
+                       cron fires (scheduler sidecar)
+                                  │
+                    ┌─────────────┴──────────────┐
+                    │  entry.kind / .model / .context  │  ← pure routing fn
+                    └─────────────┬──────────────┘
+        ┌──────────────┬──────────┴──────────┬─────────────────┐
+        ▼              ▼                      ▼                 ▼
+   Tier 0          (hit→)              Tier 1             Tier 2
+ deterministic  ──────────────▶  cheap cron session   main session
+   poll (no                      claude --model sonnet  (live, status quo)
+   model)                        session="cron", fresh  session="main"
+        │                              │                      │
+   HEARTBEAT_OK                   inject(session=cron)   inject(session=main)
+   (no fire)                      reply-only, no card    full status card
+```
+
+### 2.1 Tier 0 — deterministic poll (no model)
+
+`kind: poll` carries a **declarative, operator-approved** poll spec. **Not** an
+agent-authored script (§6.2). Two built-in types cover the fleet:
+
+- `poll: http-diff` — `{ url, method, headers?, secrets:[...], diff_jsonpath,
+  state_key }`. Scheduler does a guarded `fetch()` (§6.1 — egress allowlist,
+  no-redirect, host-pinned secret binding), extracts `diff_jsonpath`, compares to
+  the last value under `state_key`. **New → escalate; unchanged → `HEARTBEAT_OK`.**
+- `poll: telegram-reactions` — `{ chat_id, emoji, lookback }`. Needs a **new
+  gateway internal IPC verb** `query_recent_reactions` (today `get_recent_messages`
+  exists only as an MCP tool via the bridge — `bridge.ts:281` — there is no
+  model-free internal path; this verb is net-new, see §3.3 / Q4). **Match →
+  escalate; none → `HEARTBEAT_OK`.**
+
+Tier 0 touches **no model** → outside pillar 3's inference surface (§7).
+
+**Idempotency / no double-escalation (review-found race).** The escalation is
+itself a Tier-1 fire whose audit lands *after* the Sonnet turn runs. A restart
+mid-turn would let boot-replay re-fire the original poll and escalate twice
+(e.g. email a lead twice). Fix: **write-ahead the state advance.** Before
+dispatching the Tier-1 escalation, atomically write to `poll-state.json`:
+`{ state_key: <new value>, escalated_at: <fire-ts>, pending_escalation: <diff> }`.
+On boot, the poll re-reads state first; the already-advanced `state_key` means
+the re-poll sees no new data → no re-escalation. `pending_escalation` lets a
+crashed-before-dispatch escalation be re-sent exactly once (clear it on
+dispatch-ack). State advance and escalation intent are one durable write.
+
+**First-run semantics (Q3, now resolved).** No baseline ⟹ **record baseline, do
+NOT escalate** (else every existing Brevo contact emails on day one). poll-state
+lives on the `/state/agent/` volume; reconcile writes scaffold/config only and
+**must not** touch runtime state — pinned by a new test
+`tests/agent-scheduler/tier0-poll-first-run.test.ts`.
+
+**Errors don't escalate.** Brevo 500 / vault denial / bad jsonpath → record a
+poll-error row + **one-shot** operator notice (not every fire) naming the
+next-step command; reuse the existing bounded retry ladder (`index.ts:156-230`).
+
+**Min-interval applies to polls too** (§6.3) — model-free ≠ free (each poll hits
+an external API / the broker; a tight poll is a cheap DoS).
+
+### 2.2 Tier 1 — per-agent cheap cron session
+
+A second **interactive** `claude --model {cronModel}` (default
+`claude-sonnet-4-6`) in the agent container, addressed by gateway session label
+`cron`. Minimal-context by construction: own `CLAUDE_CONFIG_DIR=.claude-cron`
+(separate transcript), a **trimmed `.mcp.json`** (only `switchroom-telegram` +
+the task's tool — not the full hindsight/perplexity/webkite surface, cutting the
+~31k schema tax), `/clear` between fires.
+
+**Runtime shape — recommendation changed by review to B3 (lazy).** Three shapes:
+
+- **B1 — persistent at boot.** Warm, simplest supervision, but **doubles idle
+  memory 24/7** to serve fires that Tier 0 makes rare. Needs a per-profile mem
+  bump on tight (1.5g) profiles.
+- **B2 — ephemeral per-fire.** Zero idle cost, minimal context by construction,
+  no mem bump — but per-fire cold start + per-fire bridge-registration
+  orchestration (the harder build).
+- **B3 — lazy with idle-timeout (RECOMMENDED).** Forked on the *first* Tier-1
+  fire, kept warm, **torn down after N minutes idle** (default 30). Zero idle
+  cost in steady state (Tier 0 absorbs the frequent polls), warm within a burst,
+  no per-fire cold start inside a burst, no permanent mem-bump. Best fit for the
+  "rare bursty Tier-1 fire behind a frequent Tier-0 poll" profile this design
+  creates. **The canary measures the Tier-0 no-op fraction first** (§5) — if it
+  is >90% as expected, B3 is clearly right; the data also sizes any mem headroom.
+
+All three are **interactive `claude` (no `-p`)** (§7). **B2/B3 must not be built
+headless** — a CI guard asserts every cron-session spawn is interactive +
+`--strict-mcp-config` (extend `tests/bridge-flap-regression-guard.test.ts`).
+
+### 2.3 Tier 2 — main session passthrough
+
+`context: agent` (or `model: opus`) → today's exact path (`session=main`, live
+session, full status card). The safe default for anything the migration is unsure
+about (§3.1).
+
+### 2.4 Status-surface isolation (review-found collision)
+
+A second session emitting Telegram status into the same chat+topic as the main
+session collides: two sessions editing one progress card; a main-session reply
+closing a cron's obligation; competing worker-feed `editMessageText`. **v1
+stance: the cron session is status-silent** — it renders **no** progress card and
+**no** worker-activity feed; its only Telegram output is the final reply. And
+**obligations are session-scoped**: add `sessionLabel` to the `Obligation`
+interface (`obligation-ledger.ts:29-58`) + the close-matcher
+(`resolveCloseTarget`) + the durable store, so a cron-originated obligation can
+only be closed by a cron-session reply. This removes every cross-session race for
+v1 and shrinks scope; per-session live cards are a possible v2.
+
+---
+
+## 3. Schema & creation surface
+
+### 3.1 Reactivate + extend `ScheduleEntry` (`schema.ts:64-106`)
+
+```yaml
+schedule:
+  - cron: "*/15 * * * *"
+    kind: poll                 # NEW: poll | prompt   (default: prompt)
+    poll:                      # NEW: required iff kind=poll
+      type: http-diff
+      url: "https://api.brevo.com/v3/contacts/lists/20/contacts"
+      secrets: [brevo_api_key] # host-pinned (§6.1); resolved by scheduler, no model
+      diff_jsonpath: "$.contacts[*].id"
+      state_key: last_max_contact_id
+    prompt: |                  # ESCALATION prompt (Tier 1), templated with {{diff}}
+      New 3-Homes lead(s): {{diff}}. Email luke@… and info@… per the SOP.
+    model: sonnet              # REACTIVATED: sonnet | opus | <id>  (default: sonnet)
+    context: fresh             # NEW: fresh | agent   (default: fresh)
+```
+
+Thread `model`/`context`/`kind`/`poll` into `SchedulerEntry` (`dispatch.ts:25-42`)
+and `collectScheduleEntries`; `dispatchAsInbound` emits `meta.model` + `meta.session`.
+
+**Cascade (Consistency check).** Schedule entries are **per-agent, no
+cross-entry/cross-layer inheritance** of the new fields; the array stays
+concat/append-only (`merge.ts:559-561`). Documented in `docs/configuration.md`.
+
+**Migration — guarantee no existing cron changes tier silently:**
+
+- `model: opus` or **unset** → `context: agent` (Tier 2 = today's behaviour).
+- **`model` = a known-cheap id (sonnet/haiku family) only** → `context: fresh`.
+- **Custom / unrecognised model id → `context: agent`** (conservative; never
+  assume a custom id is cheap) **+ a one-time warn**: "cron X has custom model Y —
+  running on the main session; set `model: sonnet` + `context: fresh` to use a
+  cheap cron session."
+
+This closes the review's silent-tier-flip gap for every current fleet config.
+
+### 3.2 `schedule_add` (agent-config MCP) — cheap by default, operator-gated
+
+`server.ts:133-149` + `agent-config-write.ts`. New params: `model` (default
+`sonnet`), `context` (default `fresh`), `kind` (default `prompt`), `poll`.
+
+- **New agent-authored crons default cheap** (`sonnet`/`fresh`). The
+  `schedule_add` response states it plainly so it is never silent: *"this cron
+  will run on Sonnet in a fresh cron session, not <agent>'s own model/persona —
+  pass context: agent to use the agent."*
+- **Escalation is operator-gated, and the gate is the *commit*, not an env
+  check.** `context: agent`, `model: opus`, or any new `poll.secrets`/`poll.url`
+  from an agent **stage** under `.pending/` (new `PendingReasonCode`s) and go live
+  **only** when the operator commits (`schedule pending commit`, routed via hostd
+  Allow/Deny — memory `feedback_dashboard_loopback_header_forge`). An agent
+  scrubbing `SWITCHROOM_AGENT_NAME` (the pre-existing, acknowledged host-CLI
+  identity weakness, `agent-config-write.ts:119-127`) still **cannot** commit its
+  own pending entry — the operator commits. The security boundary is the
+  operator-only commit, by design, not the forgeable agent-side identity.
+- **Cost label at staging (v1, lightweight).** The pending meta carries a coarse
+  `fires_per_day × tier_weight` estimate (sonnet=1, opus=5) so the operator's tap
+  sees the spend before approving. Full predictive UX deferred to v2; v1 ships the
+  one-number bound rather than zero visibility.
+
+### 3.3 Gateway: session-labelled routing — the real refactor (review-corrected)
+
+This is **more than one primitive.** Three structures are single-keyed by agent
+and a second bridge would clobber the first today:
+
+- `agentIndex` (`ipc-server.ts:359`, replaced in `handleRegister` ~617-633) →
+  rekey to `(agent, session)`.
+- `sendToAgent(agent, msg)` (`ipc-server.ts:760`) → add a `session` arg; route in
+  `onInjectInbound` by `(agent, session)`.
+- `pendingInboundBuffer` (`pending-inbound-buffer.ts:290`, keyed by agent) → rekey
+  to `(agent, session, prompt_key)` so a fire while the cron bridge is down
+  buffers/drains to the **cron** bridge, not main.
+- `InboundMessage.meta` (`ipc-protocol.ts`) gains optional `session: string`;
+  validation (`ipc-server.ts:228-248`) **allows** it, **defaults absent → `main`**
+  (back-compat: every existing caller stays on `main`).
+
+Scope: a contained but real change across the gateway IPC layer (index +
+register + buffer + protocol + validation). Status card, reply routing, and the
+obligation ledger key off chat/topic meta and stay session-agnostic **except**
+the obligation `sessionLabel` add in §2.4.
+
+---
+
+## 4. Resources & ops
+
+- **B3 makes the mem story easy:** no resident second session in steady state, so
+  **no permanent per-profile mem bump.** A short-lived burst session on a 1.5g
+  conversational cap (`compose.ts:70-93`) is acceptable; if the canary shows
+  burst OOM pressure, add a transient bump only on cron-bearing agents
+  (`emitAgentService`, `compose.ts:1285`). PIDs: a burst adds ~50–100; same
+  conditional treatment, measured not assumed.
+- **Supervision:** B3's fork/teardown reuses `_switchroom_supervise`
+  (`start.sh.hbs:68-105`) with an idle-timeout teardown + a per-session audit
+  line so a crash-looping cron session is visible and can't mask a healthy main.
+- **Env-order landmine:** the fork's env must be exported in the preamble before
+  it (`start.sh.hbs:47`, memory `project_configurable_status_clear_v0_14_55`).
+
+## 5. Observability (review-found gap — now v1)
+
+The value prop is cost; the operator must *see* it.
+
+- `DispatchResult` (`dispatch.ts`) gains `tier: 'poll'|'cheap'|'main'` +
+  `model_used`; written to `scheduler.jsonl` and the gateway fire log.
+- A report surface — extend the existing `switchroom schedule`/`auth schedule`
+  family with `switchroom schedule report <agent> [--since]`: counts of
+  poll / cheap / main fires + an estimated cost-weighted-token breakdown
+  (`poll×0 + cheap×sonnet + main×opus`). This is how the canary's success is
+  *measured*, so it is v1, not v2.
+
+## 6. Security
+
+### 6.1 `http-diff` egress hardening (resolves the BLOCK)
+
+A poll = URL + headers + vault secrets executed by the scheduler — an exfil/SSRF
+primitive unless fenced. Mandatory before any Tier-0 poll ships:
+
+1. **Egress allowlist, operator-owned.** A poll `url`'s host must match an
+   operator-approved allowlist (`channels`/`secrets` config, **not**
+   agent-writable). Reject loopback, RFC-1918/private, link-local, `*.internal`,
+   non-`https`, `file://`, `unix://`. Resolve-then-pin the IP to defeat DNS-rebind.
+2. **Host-pinned secret bindings.** A `poll.secrets` name may only be sent to the
+   host it is **bound** to in operator config (`brevo_api_key → api.brevo.com`). A
+   poll requesting a secret for an unbound host is rejected at staging — the
+   operator can't be socially-engineered into approving an exfil because the
+   binding, not the agent, decides where a secret may go.
+3. **No redirects, hard timeout (5s), response size cap.** Secrets never appear in
+   logs/audit/error text; the diff path reads only `diff_jsonpath`.
+4. **Tests:** SSRF attempts (`http://127.0.0.1/...`, broker/hostd/gateway sockets,
+   rebind) must fail closed; a secret bound to host A must refuse host B.
+
+### 6.2 Declarative-only, broker-gated
+
+No agent-authored poll *code*. Secrets resolve through the vault broker allowlist
+as today; the scheduler hands them only to a §6.1-fenced `fetch`, never a model;
+a new secret/url **stages** for operator commit.
+
+### 6.3 Cheap-DoS floor
+
+Model-free polls are cheaper to abuse → enforce `MIN_CRON_INTERVAL`
+(`agent-config-write.ts:65-69`) for `kind: poll` too, and **harden
+`violatesMinInterval`** (`reconcile-dry-run.ts:68-82`) to compute the true
+smallest gap for CSV/range expressions (today `0,30 * * * *` slips through);
+reject unparseable expressions for cheap-cron rather than passing them.
+
+## 7. Compliance (pillar 3) — preserved by construction
+
+- **Tier 0** touches no model → outside the inference surface (a guarded poll).
+- **Tier 1 & 2** are **interactive `claude`** injected via `inject_inbound` — the
+  sanctioned synthesized-turn pattern. The cron session launches `exec claude
+  --model sonnet …` (no `-p`), the exact shape of `start.sh.hbs:673`, with
+  `--strict-mcp-config`. **Neither uses `claude -p`**; a CI guard enforces it for
+  the new spawn (§2.2).
+- Same broker-managed OAuth `.credentials.json`; no SDK, no API key, no raw API.
+
+## 8. Open questions — genuinely the operator's to decide
+
+(Engineering questions Q3/Q4/custom-model are resolved above.)
+
+- **Q1 — v1 poll scope.** `http-diff` only (canary = marko, 96/day) vs **both**
+  poll types (canary = marko + clerk, 240/day). Review note: clerk's reactions
+  poll is ~60% of the savings, but `telegram-reactions` needs the net-new internal
+  gateway verb (§2.1/§3.3) — more build for a fuller canary.
+- **Q2 — cron quota partitioning.** Tier-1 fires share the operator's OAuth weekly
+  window. Accept (simple) vs ring-fence a dedicated `fallback_order` account for
+  cron (protects live turns from a cron burst, memory
+  `project_account_weekly_quota_schedule`).
+- **Q5 — runtime shape sign-off.** B3 (lazy) recommended; confirm, or pin B1/B2.
+
+## 9. Build sketch (agent-minutes, post-decision)
+
+- Schema + `SchedulerEntry` thread-through + conservative migration warn: ~30m
+- Gateway session routing (index + register + buffer + protocol + validation): ~70m
+- §2.4 obligation `sessionLabel` + cron status-silence: ~30m
+- Tier 0 `http-diff` engine + write-ahead poll-state + §6.1 egress guard: ~70m
+- B3 lazy cron-session (fork/idle-teardown) + trimmed `.mcp.json` + `/clear`: ~55m
+- `schedule_add` params + cheap-default + escalation staging + cost label: ~40m
+- §5 observability (DispatchResult tier + `schedule report`): ~30m
+- §6.3 min-interval hardening: ~15m
+- UAT scenario + first-run test + SSRF tests + quota-proof: ~45m
+- **v1 total (http-diff only, Q1=narrow): ~6.5 agent-hours.** +`telegram-reactions`
+  internal verb (Q1=both): +~50m.

--- a/docs/rfcs/cheap-cron-sessions.md
+++ b/docs/rfcs/cheap-cron-sessions.md
@@ -25,6 +25,35 @@ below.
 
 ---
 
+## Build status (this branch)
+
+Behind `SWITCHROOM_CHEAP_CRON` (default **off**) — every layer below is dormant
+until the flag is set, so this branch is a no-op in production until the canary.
+
+| Layer | Status | Tests |
+|-------|--------|-------|
+| **L1** schema (`kind`/`context`/`poll`, un-deprecated `model`) + pure `resolveCronRouting` + `SchedulerEntry` thread-through | ✅ built | 23 (total enumeration, 90 inputs) |
+| **L2** gateway routing to a derived `<agent>-cron` bridge + status-silence gates | ✅ built | 3 + regression sweep |
+| **L3** Tier-0 http-diff engine + **SSRF/egress guard (§6.1, the BLOCK)** + write-ahead poll-state + `attemptFire` wiring | ✅ built | 45 + 6 integration |
+| egress allowlist config (`cron.egress`) | ✅ built | 282 config suite green |
+| **main() live-wiring** (vault-broker secret-resolver + file poll-state + real fetch/DNS) | ⏳ staged | — |
+| **L4** lazy B3 cron session launch (start.sh fork + trimmed `.mcp.json` + `/clear`) | ⏳ staged | — |
+| **L5** `schedule_add` cheap-default params + escalation staging + `schedule report` | ⏳ staged | — |
+| `telegram-reactions` poll (needs the internal gateway reactions verb) | ⏳ staged | — |
+
+**Why the split:** L1–L3 are the algorithmic + security core (the SSRF BLOCK
+resolution, the routing proof, the cost-saving poll engine) and the full gateway
+plumbing for the cron session — self-contained and exhaustively tested. The
+staged items are **deploy-sensitive integration**: the live wiring touches the
+**vault broker** (strict test-isolation discipline — see CLAUDE.md + the
+2026-05-22 clobber incident) and L4 launches a second `claude` process, both of
+which must be proven on the **test-harness canary**, not landed unproven in a
+long build session. With `escalate-to-main` (a poll entry with no `model`/
+`context` → Tier 2), **Tier-0 delivers its full cost saving without L4** — so the
+live wiring + canary is the next, focused PR.
+
+---
+
 ## 0. TL;DR
 
 Cron fires are expensive for one structural reason: **every fire injects a

--- a/src/agent-scheduler/cheap-cron-fire.test.ts
+++ b/src/agent-scheduler/cheap-cron-fire.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tier-0 / cheap-cron wiring in attemptFire — proves: a no-op poll fires
+ * NO model (no dispatch, HEARTBEAT_OK), a hit escalates with the templated
+ * diff + the routed session, and the flag-off path is byte-for-byte today.
+ */
+import { describe, expect, it } from "vitest";
+import { InMemoryAuditSink } from "../scheduler/audit.js";
+import type { InboundDispatcher, InboundMessageWire, SchedulerEntry } from "../scheduler/dispatch.js";
+import { createMemoryPollStateStore } from "../scheduler/poll-state.js";
+import type { PollOutcome } from "../scheduler/poll-engine.js";
+import type { PollSpec } from "../config/schema.js";
+import { registerAgentSchedule, type CheapCronHooks, type CronLib } from "./index.js";
+
+function fakeCron(): CronLib & { fire: (i: number) => Promise<void> } {
+  const handlers: Array<() => void | Promise<void>> = [];
+  return {
+    schedule: (_e, h) => (handlers.push(h), { stop: () => {} }),
+    fire: async (i) => { await handlers[i]!(); },
+  };
+}
+function capture(): InboundDispatcher & { calls: Array<{ agent: string; msg: InboundMessageWire }> } {
+  const calls: Array<{ agent: string; msg: InboundMessageWire }> = [];
+  return { calls, sendToAgent: (agent, msg) => (calls.push({ agent, msg }), true) };
+}
+
+const POLL: PollSpec = {
+  type: "http-diff",
+  url: "https://api.brevo.com/v3/x",
+  method: "GET",
+  secrets: [],
+  diff_jsonpath: "$.contacts[*].id",
+  state_key: "cursor",
+};
+const pollEntry: SchedulerEntry = {
+  agent: "marko",
+  scheduleIndex: 0,
+  cron: "*/15 * * * *",
+  prompt: "New lead(s): {{diff}}. Email per the SOP.",
+  promptKey: "p1",
+  kind: "poll",
+  poll: POLL,
+};
+
+function harness(outcome: PollOutcome, opts: { enabled?: boolean; seed?: Record<string, { value: string }> } = {}) {
+  const cron = fakeCron();
+  const dispatcher = capture();
+  const sink = new InMemoryAuditSink();
+  const pollState = createMemoryPollStateStore(opts.seed ?? {});
+  const cheapCron: CheapCronHooks = {
+    enabled: opts.enabled ?? true,
+    pollState,
+    runPoll: async () => outcome,
+  };
+  registerAgentSchedule({
+    entries: [pollEntry],
+    channel: { chatId: "123", threadId: undefined } as never,
+    sink,
+    cronLib: cron,
+    dispatcher,
+    now: () => 1000,
+    cheapCron,
+  });
+  return { cron, dispatcher, sink, pollState };
+}
+
+describe("Tier-0 poll wiring", () => {
+  it("no-op poll → NO dispatch, HEARTBEAT_OK audit (tier=poll, exit 0)", async () => {
+    const h = harness({ hit: false, baseline: false, cursor: "5" }, { seed: { cursor: { value: "5" } } });
+    await h.cron.fire(0);
+    expect(h.dispatcher.calls).toHaveLength(0); // ← the savings: zero model fires
+    expect(h.sink.fires[0]).toMatchObject({ exitCode: 0, tier: "poll" });
+    expect(h.sink.fires[0]!.outputSummary).toMatch(/HEARTBEAT_OK/);
+  });
+
+  it("first run → baseline recorded, NO dispatch, no escalate", async () => {
+    const h = harness({ hit: false, baseline: true, cursor: "9" });
+    await h.cron.fire(0);
+    expect(h.dispatcher.calls).toHaveLength(0);
+    expect(h.pollState.get("cursor")?.value).toBe("9");
+    expect(h.sink.fires[0]).toMatchObject({ tier: "poll", exitCode: 0 });
+  });
+
+  it("hit → write-ahead cursor + escalate with templated diff", async () => {
+    const h = harness({ hit: true, baseline: false, cursor: "12", diff: "cursor 12 > 5 (2 item(s))" }, { seed: { cursor: { value: "5" } } });
+    await h.cron.fire(0);
+    expect(h.pollState.get("cursor")?.value).toBe("12"); // write-ahead advanced
+    expect(h.pollState.get("cursor")?.pendingEscalation).toBeUndefined(); // cleared on deliver
+    expect(h.dispatcher.calls).toHaveLength(1);
+    expect(h.dispatcher.calls[0]!.msg.text).toBe("New lead(s): cursor 12 > 5 (2 item(s)). Email per the SOP.");
+    // marko's escalation has no model/context → Tier 2 main session (no meta.session)
+    expect(h.dispatcher.calls[0]!.msg.meta.session).toBeUndefined();
+  });
+
+  it("poll error → exit -3, NO escalation", async () => {
+    const h = harness({ hit: false, baseline: false, error: "http 503" }, { seed: { cursor: { value: "5" } } });
+    await h.cron.fire(0);
+    expect(h.dispatcher.calls).toHaveLength(0);
+    expect(h.sink.fires[0]).toMatchObject({ exitCode: -3, tier: "poll" });
+  });
+
+  it("flag OFF → poll ignored, fires as an ordinary main turn (back-compat)", async () => {
+    const h = harness({ hit: false, baseline: false, cursor: "5" }, { enabled: false });
+    await h.cron.fire(0);
+    expect(h.dispatcher.calls).toHaveLength(1); // disabling never drops a cron
+    expect(h.dispatcher.calls[0]!.msg.meta.session).toBeUndefined();
+    expect(h.sink.fires[0]).toMatchObject({ tier: "main" });
+  });
+});
+
+describe("Tier-1 cheap-session routing", () => {
+  it("context:fresh prompt → dispatch carries meta.session=cron + meta.model", async () => {
+    const cron = fakeCron();
+    const dispatcher = capture();
+    const sink = new InMemoryAuditSink();
+    registerAgentSchedule({
+      entries: [{ agent: "marko", scheduleIndex: 1, cron: "0 9 * * *", prompt: "summary", promptKey: "p2", context: "fresh" }],
+      channel: { chatId: "123" } as never,
+      sink,
+      cronLib: cron,
+      dispatcher,
+      now: () => 1000,
+      cheapCron: { enabled: true, pollState: createMemoryPollStateStore(), runPoll: async () => ({ hit: false, baseline: false }) },
+    });
+    await cron.fire(0);
+    expect(dispatcher.calls[0]!.msg.meta.session).toBe("cron");
+    expect(dispatcher.calls[0]!.msg.meta.model).toContain("sonnet");
+    expect(sink.fires[0]).toMatchObject({ tier: "cheap" });
+  });
+});

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -35,6 +35,10 @@ import {
   type InboundMessageWire,
   type SchedulerEntry,
 } from "../scheduler/dispatch.js";
+import { resolveCronRouting, resolveEscalationRouting } from "../scheduler/cron-routing.js";
+import type { PollOutcome } from "../scheduler/poll-engine.js";
+import type { PollStateStore } from "../scheduler/poll-state.js";
+import type { PollSpec } from "../config/schema.js";
 // AgentChannelTarget, resolveChannelTarget, and resolveEntryThreadId
 // live in ./channel-target.js (a node-cron-free leaf) so the gateway's
 // webhook-ingest path can import them without pulling node-cron into
@@ -104,6 +108,25 @@ export interface RegisterOptions {
   /** Retry timer seam (tests inject a synchronous driver). Default setTimeout;
    *  returns a canceller cleared on task stop. */
   scheduleRetry?: (fn: () => void, ms: number) => { cancel: () => void };
+  /**
+   * Cheap-cron hooks (docs/rfcs/cheap-cron-sessions.md). Absent or
+   * `enabled:false` ⟹ today's behaviour exactly (resolveCronRouting returns
+   * the main session, no poll runs). Wired in main() with the real broker
+   * secret-resolver + file poll-state; tests inject fakes.
+   */
+  cheapCron?: CheapCronHooks;
+}
+
+export interface CheapCronHooks {
+  enabled: boolean;
+  pollState: PollStateStore;
+  /** Run a declarative poll (model-free) and return whether to escalate. */
+  runPoll: (spec: PollSpec, prevCursor: string | undefined) => Promise<PollOutcome>;
+}
+
+/** Replace {{diff}} in an escalation prompt with the poll's diff summary. */
+function templateEscalationPrompt(prompt: string, diff: string): string {
+  return prompt.replace(/\{\{\s*diff\s*\}\}/g, diff);
 }
 
 export interface RegisteredTask {
@@ -195,13 +218,84 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
         }
       }
 
+      const cheapEnabled = opts.cheapCron?.enabled ?? false;
+      const routing = resolveCronRouting(entry, { cheapCronEnabled: cheapEnabled });
+      const threadId = resolveEntryThreadId(entry, opts.channel);
+      const record = (fields: {
+        exitCode: number;
+        summary: string;
+        tier: "poll" | "cheap" | "main";
+        modelUsed?: string;
+      }) =>
+        opts.sink.recordFire({
+          agent: entry.agent,
+          scheduleIndex: entry.scheduleIndex,
+          promptKey: entry.promptKey,
+          exitCode: fields.exitCode,
+          outputSummary: fields.summary.slice(0, 200),
+          startedAt,
+          finishedAt: now(),
+          tier: fields.tier,
+          ...(fields.modelUsed ? { modelUsed: fields.modelUsed } : {}),
+        });
+
+      // ── Tier 0: deterministic poll, no model ──────────────────────────
+      if (routing.tier === "poll" && opts.cheapCron && entry.poll) {
+        const stateKey = entry.poll.state_key;
+        const prev = opts.cheapCron.pollState.get(stateKey)?.value;
+        let outcome: PollOutcome;
+        try {
+          outcome = await opts.cheapCron.runPoll(entry.poll, prev);
+        } catch (err) {
+          outcome = { hit: false, baseline: false, error: (err as Error).message };
+        }
+        if (outcome.error) {
+          // exit -3 = poll error: no escalation; re-polls on next tick (idempotent).
+          record({ exitCode: -3, summary: `poll error: ${outcome.error}`, tier: "poll" });
+          return;
+        }
+        if (outcome.baseline) {
+          opts.cheapCron.pollState.setBaseline(stateKey, outcome.cursor!);
+          record({ exitCode: 0, summary: "poll baseline recorded — first run, no escalate", tier: "poll" });
+          return;
+        }
+        if (!outcome.hit) {
+          record({ exitCode: 0, summary: "HEARTBEAT_OK — no change (model-free)", tier: "poll" });
+          return;
+        }
+        // HIT → write-ahead the cursor BEFORE dispatch (double-escalation guard),
+        // then escalate the entry's prompt as a model fire (Tier 1/2).
+        opts.cheapCron.pollState.writeAhead(stateKey, outcome.cursor!, startedAt, outcome.diff ?? "");
+        const esc = resolveEscalationRouting(entry, { cheapCronEnabled: cheapEnabled });
+        let delivered = false;
+        try {
+          const r = dispatchAsInbound(
+            { ...entry, prompt: templateEscalationPrompt(entry.prompt, outcome.diff ?? "") },
+            { chatId: opts.channel.chatId, threadId, now, session: esc.session ?? "main", model: esc.cronModel },
+            opts.dispatcher,
+          );
+          delivered = r.delivered;
+        } catch (err) {
+          record({ exitCode: -1, summary: `escalation dispatch error: ${(err as Error).message}`, tier: esc.tier === "cheap" ? "cheap" : "main", modelUsed: esc.cronModel });
+          return;
+        }
+        if (delivered) opts.cheapCron.pollState.clearPending(stateKey);
+        record({
+          exitCode: delivered ? 0 : -1,
+          summary: delivered ? `poll hit → escalated (${outcome.diff})` : "poll hit → escalation not delivered",
+          tier: esc.tier === "cheap" ? "cheap" : "main",
+          modelUsed: esc.cronModel,
+        });
+        return;
+      }
+
+      // ── Tier 1/2: a model fire into the cron or main session ──────────
       let delivered = false;
       let summary = "";
       try {
-        const threadId = resolveEntryThreadId(entry, opts.channel);
         const result = dispatchAsInbound(
           entry,
-          { chatId: opts.channel.chatId, threadId, now },
+          { chatId: opts.channel.chatId, threadId, now, session: routing.session ?? "main", model: routing.cronModel },
           opts.dispatcher,
         );
         delivered = result.delivered;
@@ -211,21 +305,16 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
       } catch (err) {
         summary = `dispatch error: ${(err as Error).message}`.slice(0, 200);
       }
-      const finishedAt = now();
-      // Mirror the shape host-side dispatch.ts:DispatchResult emits so
-      // Phase 3 audit parity is a field-for-field equality check.
       // exit_code semantics for the IPC path:
       //   0 — bytes accepted by the local gateway socket (best signal)
       //  -1 — gateway not connected, or wire write failed
       //  -2 — deferred: fleet fully quota-walled (recorded above)
-      opts.sink.recordFire({
-        agent: entry.agent,
-        scheduleIndex: entry.scheduleIndex,
-        promptKey: entry.promptKey,
+      //  -3 — Tier-0 poll error (recorded above)
+      record({
         exitCode: delivered ? 0 : -1,
-        outputSummary: summary,
-        startedAt,
-        finishedAt,
+        summary,
+        tier: routing.tier === "cheap" ? "cheap" : "main",
+        modelUsed: routing.cronModel,
       });
     };
 

--- a/src/config/cheap-cron-schema.test.ts
+++ b/src/config/cheap-cron-schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { CronConfigSchema, ScheduleEntrySchema } from "./schema.js";
+
+describe("ScheduleEntrySchema — kind/poll superRefine", () => {
+  it("accepts a plain prompt entry (kind defaults to prompt)", () => {
+    expect(ScheduleEntrySchema.safeParse({ cron: "0 8 * * *", prompt: "hi" }).success).toBe(true);
+  });
+
+  it("rejects kind:poll with no poll spec", () => {
+    const r = ScheduleEntrySchema.safeParse({ cron: "*/15 * * * *", prompt: "x", kind: "poll" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a poll spec on a prompt entry", () => {
+    const r = ScheduleEntrySchema.safeParse({
+      cron: "0 8 * * *",
+      prompt: "x",
+      poll: { type: "http-diff", url: "https://api.brevo.com/x", diff_jsonpath: "$.a", state_key: "k" },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts a well-formed http-diff poll entry", () => {
+    const r = ScheduleEntrySchema.safeParse({
+      cron: "*/15 * * * *",
+      prompt: "New: {{diff}}",
+      kind: "poll",
+      poll: {
+        type: "http-diff",
+        url: "https://api.brevo.com/v3/contacts/lists/20/contacts",
+        secrets: ["brevo_api_key"],
+        diff_jsonpath: "$.contacts[*].id",
+        state_key: "last_max_contact_id",
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts model/context routing fields", () => {
+    const r = ScheduleEntrySchema.safeParse({ cron: "0 9 * * *", prompt: "s", model: "sonnet", context: "fresh" });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects an invalid context value", () => {
+    expect(ScheduleEntrySchema.safeParse({ cron: "0 9 * * *", prompt: "s", context: "nope" }).success).toBe(false);
+  });
+});
+
+describe("CronConfigSchema — egress allowlist", () => {
+  it("parses egress hosts + secret bindings with defaults", () => {
+    const r = CronConfigSchema.safeParse({ egress: { allowed_hosts: ["api.brevo.com"], secret_bindings: { brevo_api_key: "api.brevo.com" } } });
+    expect(r.success).toBe(true);
+  });
+  it("defaults to empty allowlist when egress omitted", () => {
+    const r = CronConfigSchema.parse({ egress: {} });
+    expect(r.egress).toEqual({ allowed_hosts: [], secret_bindings: {} });
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -61,20 +61,85 @@ export const AgentBindMountSchema = z.object({
     ),
 });
 
-export const ScheduleEntrySchema = z.object({
+// Tier-0 deterministic poll specs (docs/rfcs/cheap-cron-sessions.md §2.1).
+// A `kind: poll` entry runs model-free in the scheduler process; only a
+// *hit* escalates to a model fire (Tier 1/2) using the entry's prompt +
+// model/context. Two declarative, operator-approved poll types — never an
+// agent-authored script (the declaration itself is the capability; see
+// §6 SSRF/egress hardening). Discriminated on `type`.
+export const HttpDiffPollSchema = z.object({
+  type: z.literal("http-diff"),
+  url: z
+    .string()
+    .url()
+    .describe(
+      "Poll target. Host MUST match the operator egress allowlist (§6.1) — " +
+      "loopback/private/link-local/non-https are rejected; the IP is " +
+      "resolve-then-pinned against DNS-rebind. Not agent-writable without " +
+      "operator commit.",
+    ),
+  method: z.enum(["GET", "POST"]).default("GET"),
+  headers: z.record(z.string()).optional(),
+  secrets: z
+    .array(z.string().regex(/^[a-zA-Z0-9_\-/]+$/, "Secret key names must contain only alphanumeric characters, underscores, hyphens, and forward slashes"))
+    .default([])
+    .describe(
+      "Vault keys this poll may inject into request headers. Each is " +
+      "HOST-PINNED (§6.1): a secret may only be sent to the host it is bound " +
+      "to in operator config, so an approved poll cannot exfil it elsewhere.",
+    ),
+  diff_jsonpath: z.string().describe("JSONPath into the response; the extracted value is compared to state_key."),
+  state_key: z.string().describe("Key under /state/agent/poll-state.json holding the last-seen value."),
+});
+
+export const TelegramReactionsPollSchema = z.object({
+  type: z.literal("telegram-reactions"),
+  chat_id: z.union([z.string().min(1), z.number().int()]).describe("Chat to scan for reactions (model-free internal gateway query)."),
+  emoji: z.string().min(1).describe("Reaction emoji that marks a message for capture (e.g. 👨‍💻)."),
+  lookback: z.number().int().positive().max(200).default(40),
+  state_key: z.string().describe("Key under poll-state.json holding the last-processed message id."),
+});
+
+export const PollSpecSchema = z.discriminatedUnion("type", [
+  HttpDiffPollSchema,
+  TelegramReactionsPollSchema,
+]);
+
+export const ScheduleEntrySchema = z
+  .object({
   cron: z.string().describe("Cron expression (e.g., '0 8 * * *')"),
-  prompt: z.string().describe("Prompt to send at the scheduled time"),
+  prompt: z.string().describe("Prompt to send at the scheduled time (the escalation prompt when kind=poll; templated with {{diff}})."),
+  kind: z
+    .enum(["poll", "prompt"])
+    .optional()
+    .describe(
+      "Tier-0 routing (docs/rfcs/cheap-cron-sessions.md). 'prompt' (default) " +
+      "fires a model turn every tick (Tier 1/2 per `context`). 'poll' runs a " +
+      "model-free deterministic check (requires `poll`) and only escalates to " +
+      "a model fire on a hit. Honoured only when SWITCHROOM_CHEAP_CRON is on.",
+    ),
+  poll: PollSpecSchema.optional().describe("Required iff kind=poll. The declarative poll spec."),
   model: z
     .string()
     .optional()
     .describe(
-      "DEPRECATED / IGNORED. Pre-v0.8 the singleton scheduler ran each " +
-      "task as an isolated headless invocation and could set --model per " +
-      "task. Post cron-fold-in (v0.8) the fire is injected into the agent's " +
-      "running session, so it always uses the agent's configured model " +
-      "— this field has no effect. Accepted (optional) only so existing " +
-      "configs keep validating; set the model at the agent level instead. " +
-      "See docs/scheduling.md.",
+      "Cron model hint. Reactivated by SWITCHROOM_CHEAP_CRON (was DEPRECATED/" +
+      "IGNORED in v0.8). A known-cheap id (sonnet/haiku family) routes the " +
+      "fire to a fresh cheap cron session (Tier 1, `context: fresh`); 'opus', " +
+      "a custom id, or unset routes to the agent's live session (Tier 2, " +
+      "`context: agent`) — the conservative default that preserves pre-v0.8 " +
+      "behaviour. Note: a live session's model is fixed at launch, so on Tier " +
+      "2 this is informational. See docs/scheduling.md.",
+    ),
+  context: z
+    .enum(["fresh", "agent"])
+    .optional()
+    .describe(
+      "Does this cron need the agent, or just a model? 'fresh' → a minimal-" +
+      "context cheap cron session (Tier 1). 'agent' → the agent's live " +
+      "session with full persona/memory (Tier 2). Unset → inferred from " +
+      "`model` (cheap→fresh, else agent). Honoured only when " +
+      "SWITCHROOM_CHEAP_CRON is on.",
     ),
   secrets: z
     .array(z.string().regex(/^[a-zA-Z0-9_\-/]+$/, "Secret key names must contain only alphanumeric characters, underscores, hyphens, and forward slashes"))
@@ -103,7 +168,24 @@ export const ScheduleEntrySchema = z.object({
       "Alias-resolution happens at config-load — typos surface immediately. " +
       "See docs/rfcs/supergroup-mode.md.",
     ),
-});
+  })
+  .superRefine((entry, ctx) => {
+    const kind = entry.kind ?? "prompt";
+    if (kind === "poll" && !entry.poll) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["poll"],
+        message: "kind: poll requires a `poll` spec (http-diff or telegram-reactions).",
+      });
+    }
+    if (kind === "prompt" && entry.poll) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["poll"],
+        message: "`poll` is only valid when kind: poll.",
+      });
+    }
+  });
 
 export const AgentSoulSchema = z
   .object({
@@ -2840,6 +2922,7 @@ export type AgentSoul = z.infer<typeof AgentSoulSchema>;
 export type AgentTools = z.infer<typeof AgentToolsSchema>;
 export type AgentMemory = z.infer<typeof AgentMemorySchema>;
 export type ScheduleEntry = z.infer<typeof ScheduleEntrySchema>;
+export type PollSpec = z.infer<typeof PollSpecSchema>;
 export type TelegramConfig = z.infer<typeof TelegramConfigSchema>;
 export type MemoryBackendConfig = z.infer<typeof MemoryBackendConfigSchema>;
 export type VaultConfig = z.infer<typeof VaultConfigSchema>;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2653,6 +2653,26 @@ export const HostdConfigSchema = z.object({
     ),
 });
 
+// Cheap-cron operator config — docs/rfcs/cheap-cron-sessions.md §6.1.
+// The egress allowlist + secret→host bindings are the SSRF/exfil fence for
+// Tier-0 http-diff polls. Top-level + operator-owned (never agent-writable):
+// an agent can propose a poll, but the host it may reach and the secret it
+// may carry are decided HERE, at operator-commit time.
+export const CronEgressSchema = z.object({
+  allowed_hosts: z
+    .array(z.string().min(1))
+    .default([])
+    .describe("Hosts a poll may reach (exact, https-only). loopback/private/IP-literal are always rejected."),
+  secret_bindings: z
+    .record(z.string(), z.string().min(1))
+    .default({})
+    .describe("secretName → the single host it may be sent to. A poll carrying a secret to any other host is rejected."),
+});
+
+export const CronConfigSchema = z.object({
+  egress: CronEgressSchema.optional().describe("SSRF/exfil fence for http-diff polls."),
+});
+
 export const SwitchroomConfigSchema = z.object({
   switchroom: z.object({
     version: z.literal(1).describe("Config schema version"),
@@ -2908,6 +2928,11 @@ export const SwitchroomConfigSchema = z.object({
       AgentSchema,
     )
     .describe("Map of agent name to agent configuration"),
+  cron: CronConfigSchema.optional().describe(
+    "Cheap-cron settings (docs/rfcs/cheap-cron-sessions.md). Operator-owned " +
+    "egress allowlist + host-pinned secret bindings for Tier-0 http-diff " +
+    "polls (§6.1). Required to enable any http-diff poll; not agent-writable.",
+  ),
 });
 
 export type SwitchroomConfig = z.infer<typeof SwitchroomConfigSchema>;
@@ -2923,6 +2948,7 @@ export type AgentTools = z.infer<typeof AgentToolsSchema>;
 export type AgentMemory = z.infer<typeof AgentMemorySchema>;
 export type ScheduleEntry = z.infer<typeof ScheduleEntrySchema>;
 export type PollSpec = z.infer<typeof PollSpecSchema>;
+export type CronConfig = z.infer<typeof CronConfigSchema>;
 export type TelegramConfig = z.infer<typeof TelegramConfigSchema>;
 export type MemoryBackendConfig = z.infer<typeof MemoryBackendConfigSchema>;
 export type VaultConfig = z.infer<typeof VaultConfigSchema>;

--- a/src/scheduler/cron-routing.test.ts
+++ b/src/scheduler/cron-routing.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_CRON_MODEL,
+  isCheapCronEnabled,
+  isKnownCheapModel,
+  resolveCronRouting,
+  resolveEscalationRouting,
+  type CronRoutingInput,
+} from "./cron-routing.js";
+
+// ── Total enumeration of the reachable input space ──────────────────────
+// operator standard feedback_prove_finite_fsm_not_sample: prove the finite
+// decision by walking EVERY input, not a random sample.
+const KINDS: Array<CronRoutingInput["kind"]> = ["poll", "prompt", undefined];
+const MODELS: Array<{ label: string; value: string | undefined }> = [
+  { label: "cheap-sonnet", value: "claude-sonnet-4-6" },
+  { label: "cheap-haiku", value: "haiku" },
+  { label: "opus", value: "claude-opus-4-8" },
+  { label: "custom", value: "research-v1" },
+  { label: "unset", value: undefined },
+];
+const CONTEXTS: Array<CronRoutingInput["context"]> = ["fresh", "agent", undefined];
+const FLAGS = [false, true];
+
+describe("resolveCronRouting — total enumeration", () => {
+  it("covers the whole reachable space with no throw and a coherent verdict", () => {
+    let n = 0;
+    for (const cheapCronEnabled of FLAGS) {
+      for (const kind of KINDS) {
+        for (const model of MODELS) {
+          for (const context of CONTEXTS) {
+            n++;
+            const r = resolveCronRouting(
+              { kind, model: model.value, context },
+              { cheapCronEnabled },
+            );
+
+            // INV-1: flag off ⟹ pre-RFC behaviour, every field inert.
+            if (!cheapCronEnabled) {
+              expect(r).toEqual({ tier: "main", session: "main", customModelDowngrade: false });
+              continue;
+            }
+
+            // INV-2: tier↔session coherence.
+            if (r.tier === "poll") expect(r.session).toBeNull();
+            if (r.tier === "cheap") expect(r.session).toBe("cron");
+            if (r.tier === "main") expect(r.session).toBe("main");
+
+            // INV-3: cronModel present iff Tier 1, and always a known-cheap id.
+            if (r.tier === "cheap") {
+              expect(r.cronModel).toBeDefined();
+              expect(isKnownCheapModel(r.cronModel)).toBe(true);
+            } else {
+              expect(r.cronModel).toBeUndefined();
+            }
+
+            // INV-4: customModelDowngrade only when context unset + custom id.
+            if (r.customModelDowngrade) {
+              expect(context).toBeUndefined();
+              expect(model.label).toBe("custom");
+            }
+          }
+        }
+      }
+    }
+    expect(n).toBe(FLAGS.length * KINDS.length * MODELS.length * CONTEXTS.length); // 2*3*5*3 = 90
+  });
+});
+
+describe("resolveCronRouting — the load-bearing cases", () => {
+  const on = { cheapCronEnabled: true };
+
+  it("kind=poll → Tier 0 regardless of model/context", () => {
+    expect(resolveCronRouting({ kind: "poll", model: "opus" }, on).tier).toBe("poll");
+    expect(resolveCronRouting({ kind: "poll", context: "fresh" }, on).tier).toBe("poll");
+  });
+
+  it("explicit context wins over model inference", () => {
+    expect(resolveCronRouting({ model: "opus", context: "fresh" }, on).tier).toBe("cheap");
+    expect(resolveCronRouting({ model: "sonnet", context: "agent" }, on).tier).toBe("main");
+  });
+
+  it("cheap model + no context → Tier 1 fresh", () => {
+    const r = resolveCronRouting({ model: "claude-sonnet-4-6" }, on);
+    expect(r).toMatchObject({ tier: "cheap", session: "cron", cronModel: "claude-sonnet-4-6" });
+  });
+
+  it("opus / custom / unset model + no context → Tier 2 agent (preserves pre-v0.8)", () => {
+    expect(resolveCronRouting({ model: "claude-opus-4-8" }, on).tier).toBe("main");
+    expect(resolveCronRouting({ model: "research-v1" }, on).tier).toBe("main");
+    expect(resolveCronRouting({}, on).tier).toBe("main");
+  });
+
+  it("ONLY a custom id (not opus/unset) flags customModelDowngrade", () => {
+    expect(resolveCronRouting({ model: "research-v1" }, on).customModelDowngrade).toBe(true);
+    expect(resolveCronRouting({ model: "claude-opus-4-8" }, on).customModelDowngrade).toBe(false);
+    expect(resolveCronRouting({}, on).customModelDowngrade).toBe(false);
+  });
+
+  it("fresh+opus downgrades the cron-session model to sonnet (opus-on-throwaway is nonsensical)", () => {
+    expect(resolveCronRouting({ model: "claude-opus-4-8", context: "fresh" }, on).cronModel).toBe(
+      DEFAULT_CRON_MODEL,
+    );
+  });
+
+  it("a poll's escalation reuses the (model,context) decision as a prompt", () => {
+    expect(resolveEscalationRouting({ kind: "poll", model: "sonnet" }, on)).toMatchObject({
+      tier: "cheap",
+      session: "cron",
+    });
+    expect(resolveEscalationRouting({ kind: "poll" }, on).tier).toBe("main");
+  });
+});
+
+describe("isKnownCheapModel", () => {
+  it.each([
+    ["claude-sonnet-4-6", true],
+    ["sonnet", true],
+    ["claude-haiku-4-5", true],
+    ["haiku", true],
+    ["claude-opus-4-8", false],
+    ["research-v1", false],
+    ["", false],
+  ])("%s → %s", (model, expected) => {
+    expect(isKnownCheapModel(model)).toBe(expected);
+  });
+
+  it("undefined → false", () => {
+    expect(isKnownCheapModel(undefined)).toBe(false);
+  });
+});
+
+describe("isCheapCronEnabled", () => {
+  it.each([
+    ["1", true],
+    ["true", true],
+    ["on", true],
+    ["ON", true],
+    ["0", false],
+    ["", false],
+    [undefined, false],
+  ])("SWITCHROOM_CHEAP_CRON=%s → %s", (val, expected) => {
+    expect(isCheapCronEnabled({ SWITCHROOM_CHEAP_CRON: val } as NodeJS.ProcessEnv)).toBe(expected);
+  });
+});

--- a/src/scheduler/cron-routing.ts
+++ b/src/scheduler/cron-routing.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure cron tier-routing — docs/rfcs/cheap-cron-sessions.md §2–3.
+ *
+ * Given a schedule entry's (kind, model, context) and the global
+ * SWITCHROOM_CHEAP_CRON flag, decide which tier a fire takes, which
+ * gateway session a model fire injects into, and (Tier 1) which cheap
+ * model the cron session launches at.
+ *
+ * Total-enumerable by construction:
+ *   flag∈{off,on} × kind∈{poll,prompt} × model∈{cheap,opus,custom,unset}
+ *   × context∈{fresh,agent,unset}
+ * = 48 reachable inputs, pinned by total enumeration in
+ * tests/scheduler/cron-routing.test.ts (operator standard
+ * `feedback_prove_finite_fsm_not_sample`: prove finite decisions by
+ * enumeration, never a sampling property test).
+ *
+ * Pure: no clock, IO, or env read (the caller resolves the flag once and
+ * passes it in) — so the enumeration test needs no mocks.
+ */
+
+export type CronTier = "poll" | "cheap" | "main";
+export type CronSession = "cron" | "main";
+
+export interface CronRoutingInput {
+  kind?: "poll" | "prompt";
+  model?: string;
+  context?: "fresh" | "agent";
+}
+
+export interface CronRouting {
+  /** poll → model-free Tier 0; cheap → Tier 1 cron session; main → Tier 2 live session. */
+  tier: CronTier;
+  /** Gateway session a model fire injects into. null for Tier 0 until it escalates. */
+  session: CronSession | null;
+  /** Tier 1 only: the model the cheap cron session launches at. */
+  cronModel?: string;
+  /**
+   * True when `model` was a custom/unrecognised id and `context` was unset,
+   * so routing conservatively chose Tier 2 (agent). collectScheduleEntries
+   * emits a one-time warn for these — the silent-tier-flip guard from §3.1.
+   */
+  customModelDowngrade: boolean;
+}
+
+/** v1 cheap cron-session model. A live session's model is fixed at launch, so this only governs Tier 1. */
+export const DEFAULT_CRON_MODEL = "claude-sonnet-4-6";
+
+// Known-cheap model matcher: the Sonnet/Haiku family, by full id or short
+// alias. Opus and anything unrecognised are NOT cheap → Tier 2 (conservative).
+const CHEAP_MODEL_RE = /(^|[^a-z])(sonnet|haiku)([^a-z]|$)/i;
+const OPUS_MODEL_RE = /opus/i;
+
+export function isKnownCheapModel(model: string | undefined): boolean {
+  return model !== undefined && CHEAP_MODEL_RE.test(model);
+}
+
+/** Reads the kill-switch. The ONLY env read in this module; isolated so the core stays pure. */
+export function isCheapCronEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env.SWITCHROOM_CHEAP_CRON ?? "").toLowerCase();
+  return v === "1" || v === "true" || v === "on";
+}
+
+/** Tier-1 cron-session model: honour an explicit cheap id, else default to sonnet. */
+function resolveCronModel(model: string | undefined): string {
+  return isKnownCheapModel(model) ? model! : DEFAULT_CRON_MODEL;
+}
+
+export function resolveCronRouting(
+  input: CronRoutingInput,
+  opts: { cheapCronEnabled: boolean },
+): CronRouting {
+  // Kill-switch: flag off ⟹ exactly today's behaviour. Every fire is a
+  // main-session turn; kind/model/context are inert. A `kind: poll` entry
+  // fires its escalation prompt as an ordinary turn — disabling the flag can
+  // NEVER silently drop a cron.
+  if (!opts.cheapCronEnabled) {
+    return { tier: "main", session: "main", customModelDowngrade: false };
+  }
+
+  const kind = input.kind ?? "prompt";
+
+  // Effective context for the *model* fire (the prompt turn, or a poll's
+  // escalation). Explicit wins; else infer from model; else conservative agent.
+  let context: "fresh" | "agent";
+  let customModelDowngrade = false;
+  if (input.context) {
+    context = input.context;
+  } else if (isKnownCheapModel(input.model)) {
+    context = "fresh";
+  } else {
+    context = "agent";
+    // A defined-but-non-cheap, non-opus id is a custom model: we downgraded to
+    // Tier 2 to avoid assuming it's cheap. opus→agent and unset→agent are the
+    // expected defaults, not downgrades, so they don't warn.
+    customModelDowngrade =
+      input.model !== undefined &&
+      !isKnownCheapModel(input.model) &&
+      !OPUS_MODEL_RE.test(input.model);
+  }
+
+  if (kind === "poll") {
+    // Tier 0: model-free, no session, until a hit escalates. The escalation
+    // reuses (context, model) recomputed as a 'prompt' decision below.
+    return { tier: "poll", session: null, customModelDowngrade };
+  }
+
+  if (context === "fresh") {
+    return {
+      tier: "cheap",
+      session: "cron",
+      cronModel: resolveCronModel(input.model),
+      customModelDowngrade,
+    };
+  }
+  return { tier: "main", session: "main", customModelDowngrade };
+}
+
+/**
+ * The routing a Tier-0 poll's escalation takes — it fires the entry's prompt
+ * as a model turn, so it reuses the (model, context) decision as a 'prompt'.
+ */
+export function resolveEscalationRouting(
+  input: CronRoutingInput,
+  opts: { cheapCronEnabled: boolean },
+): CronRouting {
+  return resolveCronRouting({ ...input, kind: "prompt" }, opts);
+}

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -19,7 +19,7 @@
  */
 
 import { createHash } from "node:crypto";
-import type { ScheduleEntry, SwitchroomConfig } from "../config/schema.js";
+import type { PollSpec, ScheduleEntry, SwitchroomConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
 
 export interface SchedulerEntry {
@@ -29,6 +29,16 @@ export interface SchedulerEntry {
   prompt: string;
   /** SHA-256 prefix of prompt — stable, non-reversible audit key. */
   promptKey: string;
+  /**
+   * Cheap-cron routing fields (docs/rfcs/cheap-cron-sessions.md). Consumed
+   * by the in-agent scheduler via resolveCronRouting() at fire time. All
+   * inert unless SWITCHROOM_CHEAP_CRON is on. `kind: poll` runs a model-free
+   * deterministic poll (requires `poll`) that only escalates on a hit.
+   */
+  kind?: "poll" | "prompt";
+  model?: string;
+  context?: "fresh" | "agent";
+  poll?: PollSpec;
   /**
    * Per-entry Telegram topic override (PR4b of supergroup-mode rollout).
    * Either a string alias defined in the agent's
@@ -78,6 +88,11 @@ export function collectScheduleEntries(
         // Propagate the per-entry topic override (PR1 schema field).
         // Resolved at dispatch time via resolveOutboundTopic().
         ...(entry.topic !== undefined ? { topic: entry.topic } : {}),
+        // Cheap-cron routing fields — inert unless SWITCHROOM_CHEAP_CRON on.
+        ...(entry.kind !== undefined ? { kind: entry.kind } : {}),
+        ...(entry.model !== undefined ? { model: entry.model } : {}),
+        ...(entry.context !== undefined ? { context: entry.context } : {}),
+        ...(entry.poll !== undefined ? { poll: entry.poll } : {}),
       });
     }
   }
@@ -102,6 +117,14 @@ export interface DispatchResult {
   outputSummary: string;
   startedAt: number;
   finishedAt: number;
+  /**
+   * Cheap-cron observability (docs/rfcs/cheap-cron-sessions.md §5). Which
+   * tier this fire took and the model it ran at, so `switchroom schedule
+   * report` can show the cost breakdown. Absent on legacy audit rows and
+   * when SWITCHROOM_CHEAP_CRON is off (treated as 'main').
+   */
+  tier?: "poll" | "cheap" | "main";
+  modelUsed?: string;
 }
 
 // ───────────────────────────────────────────────────────────────────────
@@ -169,6 +192,15 @@ export interface InboundDispatchOptions {
    * a fixed clock to make `messageId` and `ts` deterministic.
    */
   now?: () => number;
+  /**
+   * Cheap-cron routing (docs/rfcs/cheap-cron-sessions.md §3.3). Which
+   * gateway session this fire injects into — 'cron' for a Tier-1 cheap
+   * session, 'main' (or unset) for the live session. Emitted as
+   * `meta.session`; the gateway defaults absent → 'main' (back-compat).
+   */
+  session?: "cron" | "main";
+  /** Tier-1 cron-session model; emitted as `meta.model` for the cron bridge. */
+  model?: string;
 }
 
 export interface InboundDispatchResult {
@@ -212,6 +244,11 @@ export function dispatchAsInbound(
       source: "cron",
       schedule_index: String(entry.scheduleIndex),
       prompt_key: entry.promptKey,
+      // Cheap-cron session routing — emitted only when targeting the cron
+      // session, so existing fires stay byte-identical (gateway defaults
+      // absent → 'main'). meta is Record<string,string> on the wire.
+      ...(options.session === "cron" ? { session: "cron" } : {}),
+      ...(options.session === "cron" && options.model ? { model: options.model } : {}),
     },
   };
   const delivered = dispatcher.sendToAgent(entry.agent, message);

--- a/src/scheduler/poll-egress.test.ts
+++ b/src/scheduler/poll-egress.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkEgressUrl,
+  checkHttpDiffEgress,
+  checkSecretBinding,
+  isBlockedAddress,
+  normalizeHost,
+  type EgressAllowlist,
+} from "./poll-egress.js";
+
+const ALLOW: EgressAllowlist = {
+  hosts: ["api.brevo.com", "API.Example.com"],
+  secretBindings: { brevo_api_key: "api.brevo.com", other_key: "api.example.com" },
+};
+
+describe("isBlockedAddress — SSRF ranges fail closed", () => {
+  it.each([
+    "127.0.0.1", "127.5.5.5", "0.0.0.0", "10.0.0.5", "172.16.0.1", "172.31.255.255",
+    "192.168.1.1", "169.254.169.254", "100.64.0.1", "224.0.0.1", "255.255.255.255",
+    "::1", "::", "fe80::1", "fc00::1", "fd12:3456::1", "ff02::1", "::ffff:127.0.0.1",
+  ])("blocks %s", (ip) => {
+    expect(isBlockedAddress(ip)).toBe(true);
+  });
+
+  it.each(["8.8.8.8", "1.1.1.1", "2606:4700::1111", "::ffff:8.8.8.8"])(
+    "allows public %s",
+    (ip) => {
+      expect(isBlockedAddress(ip)).toBe(false);
+    },
+  );
+
+  it("non-IP hostnames are not judged here (allowlist decides)", () => {
+    expect(isBlockedAddress("api.brevo.com")).toBe(false);
+  });
+});
+
+describe("checkEgressUrl — scheme + allowlist + IP-literal", () => {
+  it("allows an allowlisted https host (case-insensitive)", () => {
+    expect(checkEgressUrl("https://api.brevo.com/v3/x", ALLOW).ok).toBe(true);
+    expect(checkEgressUrl("https://api.example.com/y", ALLOW).ok).toBe(true);
+  });
+
+  it("rejects non-https", () => {
+    expect(checkEgressUrl("http://api.brevo.com/x", ALLOW)).toMatchObject({ ok: false });
+    expect(checkEgressUrl("file:///etc/passwd", ALLOW)).toMatchObject({ ok: false });
+    expect(checkEgressUrl("unix:///run/switchroom/broker/sock", ALLOW)).toMatchObject({ ok: false });
+  });
+
+  it("rejects a host not on the allowlist (SSRF to internal name)", () => {
+    expect(checkEgressUrl("https://127.0.0.1/gateway", ALLOW)).toMatchObject({ ok: false });
+    expect(checkEgressUrl("https://localhost/broker", ALLOW)).toMatchObject({ ok: false });
+    expect(checkEgressUrl("https://attacker.com/exfil", ALLOW)).toMatchObject({ ok: false });
+    expect(checkEgressUrl("https://hostd.internal/", ALLOW)).toMatchObject({ ok: false });
+  });
+
+  it("rejects a blocked IP literal even if its string were allowlisted", () => {
+    const a: EgressAllowlist = { hosts: ["127.0.0.1"], secretBindings: {} };
+    expect(checkEgressUrl("https://127.0.0.1/x", a)).toMatchObject({ ok: false });
+  });
+
+  it("rejects userinfo (credential-smuggling host confusion)", () => {
+    expect(checkEgressUrl("https://api.brevo.com@attacker.com/", ALLOW)).toMatchObject({ ok: false });
+  });
+});
+
+describe("checkSecretBinding — a secret may only go to its bound host", () => {
+  it("allows the bound host", () => {
+    expect(checkSecretBinding("brevo_api_key", "api.brevo.com", ALLOW).ok).toBe(true);
+  });
+  it("refuses an unbound secret", () => {
+    expect(checkSecretBinding("unbound", "api.brevo.com", ALLOW)).toMatchObject({ ok: false });
+  });
+  it("refuses a secret sent to the WRONG (even if allowlisted) host — the exfil case", () => {
+    expect(checkSecretBinding("brevo_api_key", "api.example.com", ALLOW)).toMatchObject({ ok: false });
+  });
+});
+
+describe("checkHttpDiffEgress — full pre-fetch gate", () => {
+  it("passes a correct (url, secret) pair", () => {
+    expect(checkHttpDiffEgress("https://api.brevo.com/v3/x", ["brevo_api_key"], ALLOW).ok).toBe(true);
+  });
+  it("blocks exfil: an approved Brevo poll trying to carry brevo_api_key to example.com", () => {
+    expect(
+      checkHttpDiffEgress("https://api.example.com/collect", ["brevo_api_key"], ALLOW),
+    ).toMatchObject({ ok: false });
+  });
+  it("blocks SSRF: a secretless poll to a non-allowlisted host", () => {
+    expect(checkHttpDiffEgress("https://169.254.169.254/latest/meta-data", [], ALLOW)).toMatchObject({
+      ok: false,
+    });
+  });
+});
+
+describe("normalizeHost", () => {
+  it("lowercases, strips trailing dot + brackets", () => {
+    expect(normalizeHost("API.Brevo.com.")).toBe("api.brevo.com");
+    expect(normalizeHost("[::1]")).toBe("::1");
+  });
+});

--- a/src/scheduler/poll-egress.test.ts
+++ b/src/scheduler/poll-egress.test.ts
@@ -18,8 +18,14 @@ describe("isBlockedAddress — SSRF ranges fail closed", () => {
     "127.0.0.1", "127.5.5.5", "0.0.0.0", "10.0.0.5", "172.16.0.1", "172.31.255.255",
     "192.168.1.1", "169.254.169.254", "100.64.0.1", "224.0.0.1", "255.255.255.255",
     "::1", "::", "fe80::1", "fc00::1", "fd12:3456::1", "ff02::1", "::ffff:127.0.0.1",
+    // v4-mapped HEX form (WHATWG URL's canonical normalisation of ::ffff:127.0.0.1)
+    "::ffff:7f00:1", "::ffff:0a00:1", "::ffff:a9fe:a9fe",
   ])("blocks %s", (ip) => {
     expect(isBlockedAddress(ip)).toBe(true);
+  });
+
+  it("blocks a public-looking hex-mapped form only if its embedded v4 is private", () => {
+    expect(isBlockedAddress("::ffff:0808:0808")).toBe(false); // 8.8.8.8
   });
 
   it.each(["8.8.8.8", "1.1.1.1", "2606:4700::1111", "::ffff:8.8.8.8"])(

--- a/src/scheduler/poll-egress.ts
+++ b/src/scheduler/poll-egress.ts
@@ -1,0 +1,135 @@
+/**
+ * SSRF / exfil egress guard for Tier-0 http-diff polls —
+ * docs/rfcs/cheap-cron-sessions.md §6.1 (resolves the review BLOCK).
+ *
+ * A poll = URL + headers + vault secrets executed by the scheduler. Left
+ * unfenced that is a textbook SSRF + secret-exfil primitive (point a poll
+ * at 127.0.0.1 / the broker socket, or ship a vaulted secret to
+ * attacker.com). This module fences it:
+ *
+ *   1. URL must be https to a host on the operator EGRESS ALLOWLIST
+ *      (not agent-writable). loopback / private / link-local / IP-literal
+ *      hosts are rejected even if somehow allowlisted.
+ *   2. A secret may only be sent to the host it is BOUND to in operator
+ *      config — so an approved poll can never carry a secret elsewhere.
+ *   3. The resolved IP is re-checked at fetch time (DNS-rebind pin) via
+ *      isBlockedAddress on the lookup result.
+ *
+ * Pure + dependency-light so the whole guard is exhaustively unit-tested
+ * (poll-egress.test.ts) without network. The runtime fetch wrapper
+ * (poll-engine.ts) supplies the DNS lookup + redirect/timeout/size caps.
+ */
+
+import { isIP } from "node:net";
+
+export interface EgressAllowlist {
+  /** Operator-approved hosts a poll may reach (exact, case-insensitive). */
+  hosts: string[];
+  /** secretName → the single host it may be sent to. */
+  secretBindings: Record<string, string>;
+}
+
+export type EgressCheck = { ok: true } | { ok: false; reason: string };
+
+const ok: EgressCheck = { ok: true };
+const deny = (reason: string): EgressCheck => ({ ok: false, reason });
+
+/** Normalise a host for comparison: lowercase, strip a trailing dot, drop brackets. */
+export function normalizeHost(host: string): string {
+  return host.toLowerCase().replace(/\.$/, "").replace(/^\[|\]$/g, "");
+}
+
+/**
+ * True for an IP address that must never be reachable from a poll:
+ * loopback, RFC-1918 private, link-local, ULA, unspecified, broadcast,
+ * carrier-grade NAT. Applied to IP-literal hosts AND to the resolved IP
+ * (DNS-rebind defence). Anything it can't parse as an IP returns false
+ * (a hostname is judged by the allowlist, not here).
+ */
+export function isBlockedAddress(addr: string): boolean {
+  const v = isIP(addr);
+  if (v === 4) return isBlockedV4(addr);
+  if (v === 6) return isBlockedV6(addr);
+  return false;
+}
+
+function isBlockedV4(addr: string): boolean {
+  const o = addr.split(".").map((n) => Number(n));
+  if (o.length !== 4 || o.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return true;
+  const [a, b] = o as [number, number, number, number];
+  if (a === 0) return true; // 0.0.0.0/8 (unspecified)
+  if (a === 10) return true; // 10/8 private
+  if (a === 127) return true; // loopback
+  if (a === 169 && b === 254) return true; // link-local 169.254/16
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12 private
+  if (a === 192 && b === 168) return true; // 192.168/16 private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT
+  if (a >= 224) return true; // multicast + reserved + 255.255.255.255
+  return false;
+}
+
+function isBlockedV6(addr: string): boolean {
+  const a = addr.toLowerCase();
+  if (a === "::" || a === "::1") return true; // unspecified / loopback
+  if (a.startsWith("fe80")) return true; // link-local
+  if (a.startsWith("fc") || a.startsWith("fd")) return true; // ULA fc00::/7
+  if (a.startsWith("ff")) return true; // multicast
+  // IPv4-mapped (::ffff:a.b.c.d) — judge the embedded v4.
+  const mapped = a.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isBlockedV4(mapped[1]!);
+  return false;
+}
+
+/**
+ * Validate a poll URL: https scheme, allowlisted host, not an IP literal
+ * that resolves to a blocked range. Pure — the runtime DNS-rebind pin
+ * (isBlockedAddress on the looked-up IP) is applied separately at fetch.
+ */
+export function checkEgressUrl(rawUrl: string, allow: EgressAllowlist): EgressCheck {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return deny(`unparseable url`);
+  }
+  if (u.protocol !== "https:") return deny(`scheme ${u.protocol} not allowed (https only)`);
+  if (u.username || u.password) return deny(`userinfo in url not allowed`);
+  const host = normalizeHost(u.hostname);
+  if (!host) return deny(`empty host`);
+  // An IP-literal host is rejected if it's in a blocked range; a public IP
+  // literal is still rejected unless explicitly allowlisted below.
+  if (isIP(host) && isBlockedAddress(host)) return deny(`blocked ip literal ${host}`);
+  const allowed = allow.hosts.map(normalizeHost);
+  if (!allowed.includes(host)) return deny(`host ${host} not on egress allowlist`);
+  return ok;
+}
+
+/** A secret may only be sent to the host it is bound to in operator config. */
+export function checkSecretBinding(
+  secretName: string,
+  host: string,
+  allow: EgressAllowlist,
+): EgressCheck {
+  const bound = allow.secretBindings[secretName];
+  if (!bound) return deny(`secret ${secretName} has no host binding`);
+  if (normalizeHost(bound) !== normalizeHost(host)) {
+    return deny(`secret ${secretName} bound to ${bound}, not ${host}`);
+  }
+  return ok;
+}
+
+/** Full pre-fetch gate for an http-diff poll: URL + every secret it carries. */
+export function checkHttpDiffEgress(
+  rawUrl: string,
+  secrets: string[],
+  allow: EgressAllowlist,
+): EgressCheck {
+  const urlCheck = checkEgressUrl(rawUrl, allow);
+  if (!urlCheck.ok) return urlCheck;
+  const host = normalizeHost(new URL(rawUrl).hostname);
+  for (const s of secrets) {
+    const sc = checkSecretBinding(s, host, allow);
+    if (!sc.ok) return sc;
+  }
+  return ok;
+}

--- a/src/scheduler/poll-egress.ts
+++ b/src/scheduler/poll-egress.ts
@@ -74,9 +74,20 @@ function isBlockedV6(addr: string): boolean {
   if (a.startsWith("fe80")) return true; // link-local
   if (a.startsWith("fc") || a.startsWith("fd")) return true; // ULA fc00::/7
   if (a.startsWith("ff")) return true; // multicast
-  // IPv4-mapped (::ffff:a.b.c.d) — judge the embedded v4.
+  // IPv4-mapped, dotted form (::ffff:a.b.c.d) — judge the embedded v4.
   const mapped = a.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
   if (mapped) return isBlockedV4(mapped[1]!);
+  // IPv4-mapped, HEX form (::ffff:7f00:1) — the canonical normalisation
+  // WHATWG URL emits for a bracketed v4-mapped literal. Decode the two hex
+  // groups to dotted-quad and judge the embedded v4 (else 127.0.0.1 slips
+  // through as ::ffff:7f00:1 on the DNS-rebind pin). Reviewer-found, PR #2244.
+  const hexMapped = a.match(/::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hexMapped) {
+    const hi = parseInt(hexMapped[1]!, 16);
+    const lo = parseInt(hexMapped[2]!, 16);
+    const v4 = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+    return isBlockedV4(v4);
+  }
   return false;
 }
 

--- a/src/scheduler/poll-engine.test.ts
+++ b/src/scheduler/poll-engine.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { cursorOf, extractLeaves, runHttpDiffPoll, type HttpDiffDeps, type HttpDiffSpec } from "./poll-engine.js";
+import { createMemoryPollStateStore } from "./poll-state.js";
+import type { EgressAllowlist } from "./poll-egress.js";
+
+const ALLOW: EgressAllowlist = {
+  hosts: ["api.brevo.com"],
+  secretBindings: { brevo_api_key: "api.brevo.com" },
+};
+
+const SPEC: HttpDiffSpec = {
+  type: "http-diff",
+  url: "https://api.brevo.com/v3/contacts/lists/20/contacts",
+  method: "GET",
+  headers: { "api-key": "{{brevo_api_key}}" },
+  secrets: ["brevo_api_key"],
+  diff_jsonpath: "$.contacts[*].id",
+  state_key: "last_max_contact_id",
+};
+
+function depsWith(body: unknown, over: Partial<HttpDiffDeps> = {}): HttpDiffDeps {
+  return {
+    fetchImpl: (async () =>
+      new Response(JSON.stringify(body), { status: 200 })) as unknown as typeof fetch,
+    resolveSecret: async (n) => (n === "brevo_api_key" ? "secret-value" : ""),
+    lookup: async () => "8.8.8.8",
+    allow: ALLOW,
+    now: () => 1_000,
+    ...over,
+  };
+}
+
+describe("extractLeaves / cursorOf", () => {
+  it("walks $.a[*].b and reduces to numeric max", () => {
+    const leaves = extractLeaves({ contacts: [{ id: 5 }, { id: 9 }, { id: 7 }] }, "$.contacts[*].id");
+    expect(leaves).toEqual([5, 9, 7]);
+    expect(cursorOf(leaves)).toMatchObject({ cursor: "9", numeric: true, count: 3 });
+  });
+  it("non-numeric leaves → count cursor", () => {
+    expect(cursorOf(["a", "b"])).toMatchObject({ cursor: "n:2", numeric: false });
+  });
+});
+
+describe("runHttpDiffPoll", () => {
+  it("first run → baseline, NEVER escalates (the day-one floods guard)", async () => {
+    const r = await runHttpDiffPoll(SPEC, undefined, depsWith({ contacts: [{ id: 1 }, { id: 2 }] }));
+    expect(r).toMatchObject({ hit: false, baseline: true, cursor: "2" });
+  });
+
+  it("unchanged cursor → no-op (HEARTBEAT_OK)", async () => {
+    const r = await runHttpDiffPoll(SPEC, "2", depsWith({ contacts: [{ id: 1 }, { id: 2 }] }));
+    expect(r).toMatchObject({ hit: false, baseline: false, cursor: "2" });
+  });
+
+  it("advanced cursor → hit with a diff", async () => {
+    const r = await runHttpDiffPoll(SPEC, "2", depsWith({ contacts: [{ id: 2 }, { id: 5 }] }));
+    expect(r.hit).toBe(true);
+    expect(r.cursor).toBe("5");
+    expect(r.diff).toContain("5");
+  });
+
+  it("blocks egress: a Brevo poll whose secret is sent to the wrong host", async () => {
+    const bad = { ...SPEC, url: "https://api.brevo.com/x", secrets: ["unbound_key"] };
+    const r = await runHttpDiffPoll(bad, "2", depsWith({ contacts: [] }));
+    expect(r.error).toMatch(/egress denied/);
+    expect(r.hit).toBe(false);
+  });
+
+  it("blocks a DNS-rebind to a private IP", async () => {
+    const r = await runHttpDiffPoll(SPEC, "2", depsWith({ contacts: [{ id: 9 }] }, { lookup: async () => "127.0.0.1" }));
+    expect(r.error).toMatch(/blocked/);
+  });
+
+  it("non-2xx → error, no escalation", async () => {
+    const r = await runHttpDiffPoll(
+      SPEC,
+      "2",
+      depsWith({}, { fetchImpl: (async () => new Response("nope", { status: 503 })) as unknown as typeof fetch }),
+    );
+    expect(r.error).toMatch(/http 503/);
+    expect(r.hit).toBe(false);
+  });
+
+  it("injects the resolved secret into the header via {{name}}", async () => {
+    let seenHeaders: Record<string, string> = {};
+    const deps = depsWith(
+      { contacts: [{ id: 9 }] },
+      {
+        fetchImpl: (async (_url: string, init: RequestInit) => {
+          seenHeaders = init.headers as Record<string, string>;
+          return new Response(JSON.stringify({ contacts: [{ id: 9 }] }), { status: 200 });
+        }) as unknown as typeof fetch,
+      },
+    );
+    await runHttpDiffPoll(SPEC, "2", deps);
+    expect(seenHeaders["api-key"]).toBe("secret-value");
+  });
+});
+
+describe("write-ahead idempotency (the double-escalation race)", () => {
+  it("a restart mid-escalation does not re-escalate (cursor already advanced)", async () => {
+    const store = createMemoryPollStateStore({ last_max_contact_id: { value: "2" } });
+    // Poll sees a hit at cursor 5 → write-ahead advances cursor BEFORE dispatch.
+    const r1 = await runHttpDiffPoll(SPEC, store.get("last_max_contact_id")!.value, depsWith({ contacts: [{ id: 5 }] }));
+    expect(r1.hit).toBe(true);
+    store.writeAhead("last_max_contact_id", r1.cursor!, 1000, r1.diff!);
+    // --- simulated crash before dispatch-ack, then restart re-polls ---
+    const r2 = await runHttpDiffPoll(SPEC, store.get("last_max_contact_id")!.value, depsWith({ contacts: [{ id: 5 }] }));
+    expect(r2.hit).toBe(false); // cursor is now 5; the same data is not new again
+  });
+});

--- a/src/scheduler/poll-engine.ts
+++ b/src/scheduler/poll-engine.ts
@@ -1,0 +1,170 @@
+/**
+ * Tier-0 http-diff poll engine — docs/rfcs/cheap-cron-sessions.md §2.1.
+ *
+ * Model-free: fetch a URL, extract a cursor via a tiny JSONPath, compare
+ * to the durable cursor. New cursor ⟹ a hit that escalates to a Tier-1
+ * model fire; unchanged ⟹ no-op (HEARTBEAT_OK). All network is fenced by
+ * poll-egress.ts (§6.1) and the fetch wrapper below (no-redirect, 5s
+ * timeout, size cap, DNS-rebind pin). Deps are injected so the engine is
+ * unit-tested without network/broker.
+ */
+
+import type { HttpDiffPollSchema } from "../config/schema.js";
+import type { z } from "zod";
+import { checkHttpDiffEgress, isBlockedAddress, normalizeHost, type EgressAllowlist } from "./poll-egress.js";
+
+export type HttpDiffSpec = z.infer<typeof HttpDiffPollSchema>;
+
+export interface HttpDiffDeps {
+  /** injected for tests; the real one wraps global fetch. */
+  fetchImpl: typeof fetch;
+  /** resolve a vault secret by name via the in-container broker. */
+  resolveSecret: (name: string) => Promise<string>;
+  /** DNS lookup → resolved IP, for the rebind pin. Return null to skip the pin. */
+  lookup: (host: string) => Promise<string | null>;
+  allow: EgressAllowlist;
+  now: () => number;
+  /** Response body size cap (bytes). Default 1 MiB. */
+  maxBytes?: number;
+  /** Fetch timeout (ms). Default 5000. */
+  timeoutMs?: number;
+}
+
+export interface PollOutcome {
+  /** true ⟹ escalate; false ⟹ HEARTBEAT_OK (no model). */
+  hit: boolean;
+  /** When this is the FIRST poll for the key: record baseline, do NOT escalate. */
+  baseline: boolean;
+  /** New cursor to persist (present when hit or baseline). */
+  cursor?: string;
+  /** Human diff summary templated into the escalation prompt as {{diff}}. */
+  diff?: string;
+  /** Set ⟹ poll error (no escalation; one-shot operator notice + bounded retry). */
+  error?: string;
+}
+
+// ── minimal JSONPath: $, .key, [*], [n] ────────────────────────────────
+const TOKEN_RE = /\.([a-zA-Z0-9_]+)|\[(\*|\d+)\]/g;
+
+export function extractLeaves(root: unknown, jsonpath: string): unknown[] {
+  const path = jsonpath.startsWith("$") ? jsonpath.slice(1) : jsonpath;
+  let nodes: unknown[] = [root];
+  let m: RegExpExecArray | null;
+  TOKEN_RE.lastIndex = 0;
+  while ((m = TOKEN_RE.exec(path)) !== null) {
+    const key = m[1];
+    const idx = m[2];
+    const next: unknown[] = [];
+    for (const node of nodes) {
+      if (node == null) continue;
+      if (key !== undefined) {
+        if (typeof node === "object") next.push((node as Record<string, unknown>)[key]);
+      } else if (idx === "*") {
+        if (Array.isArray(node)) next.push(...node);
+      } else if (idx !== undefined) {
+        if (Array.isArray(node)) next.push(node[Number(idx)]);
+      }
+    }
+    nodes = next;
+  }
+  return nodes.filter((n) => n !== undefined);
+}
+
+/** Reduce extracted leaves to a comparable cursor: numeric max, else count. */
+export function cursorOf(leaves: unknown[]): { cursor: string; numeric: boolean; count: number } {
+  const nums = leaves.map((l) => Number(l)).filter((n) => Number.isFinite(n));
+  if (nums.length === leaves.length && nums.length > 0) {
+    return { cursor: String(Math.max(...nums)), numeric: true, count: leaves.length };
+  }
+  // Non-numeric (or mixed): a count-based cursor detects "new items appeared".
+  return { cursor: `n:${leaves.length}`, numeric: false, count: leaves.length };
+}
+
+function cursorAdvanced(prev: string | undefined, next: string, numeric: boolean): boolean {
+  if (prev === undefined) return false; // first run handled by caller
+  if (numeric) return Number(next) > Number(prev);
+  return next !== prev;
+}
+
+function substituteSecrets(
+  headers: Record<string, string>,
+  secretValues: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    out[k] = v.replace(/\{\{([a-zA-Z0-9_\-/]+)\}\}/g, (_, name) => secretValues[name] ?? "");
+  }
+  return out;
+}
+
+export async function runHttpDiffPoll(
+  spec: HttpDiffSpec,
+  prevCursor: string | undefined,
+  deps: HttpDiffDeps,
+): Promise<PollOutcome> {
+  // §6.1 gate BEFORE any network or secret resolution.
+  const gate = checkHttpDiffEgress(spec.url, spec.secrets, deps.allow);
+  if (!gate.ok) return { hit: false, baseline: false, error: `egress denied: ${gate.reason}` };
+
+  const host = normalizeHost(new URL(spec.url).hostname);
+
+  // DNS-rebind pin: resolve and re-check the IP against blocked ranges.
+  try {
+    const ip = await deps.lookup(host);
+    if (ip && isBlockedAddress(ip)) return { hit: false, baseline: false, error: `resolved ip ${ip} blocked` };
+  } catch (e) {
+    return { hit: false, baseline: false, error: `dns lookup failed: ${(e as Error).message}` };
+  }
+
+  // Resolve secrets and inject into headers via {{name}} substitution.
+  const secretValues: Record<string, string> = {};
+  for (const name of spec.secrets) {
+    try {
+      secretValues[name] = await deps.resolveSecret(name);
+    } catch (e) {
+      return { hit: false, baseline: false, error: `secret ${name}: ${(e as Error).message}` };
+    }
+  }
+  const headers = substituteSecrets(spec.headers ?? {}, secretValues);
+
+  // Fenced fetch: no redirects, hard timeout, size cap.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), deps.timeoutMs ?? 5000);
+  let json: unknown;
+  try {
+    const res = await deps.fetchImpl(spec.url, {
+      method: spec.method,
+      headers,
+      redirect: "error",
+      signal: controller.signal,
+    });
+    if (!res.ok) return { hit: false, baseline: false, error: `http ${res.status}` };
+    const text = await readCapped(res, deps.maxBytes ?? 1024 * 1024);
+    json = JSON.parse(text);
+  } catch (e) {
+    return { hit: false, baseline: false, error: `fetch failed: ${(e as Error).message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const leaves = extractLeaves(json, spec.diff_jsonpath);
+  const { cursor, numeric, count } = cursorOf(leaves);
+
+  if (prevCursor === undefined) {
+    // First run: baseline only, never escalate (the day-one-floods guard).
+    return { hit: false, baseline: true, cursor };
+  }
+  if (cursorAdvanced(prevCursor, cursor, numeric)) {
+    const diff = numeric
+      ? `cursor ${cursor} > ${prevCursor} (${count} item(s))`
+      : `${count} item(s), cursor ${prevCursor} → ${cursor}`;
+    return { hit: true, baseline: false, cursor, diff };
+  }
+  return { hit: false, baseline: false, cursor };
+}
+
+async function readCapped(res: Response, maxBytes: number): Promise<string> {
+  const buf = await res.arrayBuffer();
+  if (buf.byteLength > maxBytes) throw new Error(`response ${buf.byteLength}B exceeds cap ${maxBytes}B`);
+  return new TextDecoder().decode(buf);
+}

--- a/src/scheduler/poll-state.ts
+++ b/src/scheduler/poll-state.ts
@@ -15,8 +15,14 @@
  *    dispatches its Tier-1 escalation, it advances the cursor AND records
  *    `pendingEscalation` in ONE atomic write. A restart mid-escalation
  *    re-polls, sees the already-advanced cursor → no new data → no
- *    re-escalation. `pendingEscalation` lets a crash *before* dispatch
- *    re-send exactly once; it's cleared on dispatch-ack.
+ *    re-escalation (the double-EMAIL guard — the property that matters).
+ *
+ *    NOTE: `pendingEscalation` is the forward hook for a crash that lands
+ *    AFTER the cursor advance but BEFORE a delivered dispatch (a lost-hit
+ *    window, not a double-fire). The boot-replay CONSUMER that re-dispatches
+ *    a dangling `pendingEscalation` is STAGED with the main() live-wiring —
+ *    it is written + cleared here but not yet read back. Until that lands a
+ *    crash in this narrow window drops the hit; documented, not yet closed.
  */
 
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";

--- a/src/scheduler/poll-state.ts
+++ b/src/scheduler/poll-state.ts
@@ -1,0 +1,103 @@
+/**
+ * Tier-0 poll state — docs/rfcs/cheap-cron-sessions.md §2.1.
+ *
+ * Durable cursor per poll `state_key`, on the /state/agent/ volume so it
+ * survives restart and is NOT touched by reconcile (reconcile writes
+ * scaffold/config, never runtime state).
+ *
+ * Two correctness properties it encodes:
+ *
+ *  - First-run-no-escalate: a key with no recorded baseline records the
+ *    baseline and does NOT escalate (else every existing Brevo contact
+ *    emails on day one). `get()===undefined` is the first-run signal.
+ *
+ *  - Write-ahead idempotency (the double-escalation race): before a poll
+ *    dispatches its Tier-1 escalation, it advances the cursor AND records
+ *    `pendingEscalation` in ONE atomic write. A restart mid-escalation
+ *    re-polls, sees the already-advanced cursor → no new data → no
+ *    re-escalation. `pendingEscalation` lets a crash *before* dispatch
+ *    re-send exactly once; it's cleared on dispatch-ack.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface PollStateEntry {
+  /** The last-seen cursor (e.g. max contact id), as a string for JSON stability. */
+  value: string;
+  /** Epoch-ms of the fire that advanced the cursor (audit). */
+  escalatedAt?: number;
+  /** Set between cursor-advance and dispatch-ack; a crash here re-sends once. */
+  pendingEscalation?: string;
+}
+
+export interface PollStateStore {
+  /** undefined ⟹ first run for this key (record baseline, do not escalate). */
+  get(key: string): PollStateEntry | undefined;
+  /** Atomically advance the cursor and stage the escalation (write-ahead). */
+  writeAhead(key: string, value: string, fireTs: number, diff: string): void;
+  /** Record a baseline with no escalation (first run / no-op tracking). */
+  setBaseline(key: string, value: string): void;
+  /** Clear pendingEscalation once the escalation is dispatched. */
+  clearPending(key: string): void;
+}
+
+type StateFile = Record<string, PollStateEntry>;
+
+/** File-backed store with atomic (temp+rename) writes. One file per agent. */
+export function createFilePollStateStore(path: string): PollStateStore {
+  function read(): StateFile {
+    try {
+      return JSON.parse(readFileSync(path, "utf8")) as StateFile;
+    } catch {
+      return {};
+    }
+  }
+  function write(state: StateFile): void {
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, JSON.stringify(state, null, 2), "utf8");
+    renameSync(tmp, path);
+  }
+  return {
+    get(key) {
+      return read()[key];
+    },
+    writeAhead(key, value, fireTs, diff) {
+      const state = read();
+      state[key] = { value, escalatedAt: fireTs, pendingEscalation: diff };
+      write(state);
+    },
+    setBaseline(key, value) {
+      const state = read();
+      const prev = state[key];
+      state[key] = { value, escalatedAt: prev?.escalatedAt };
+      write(state);
+    },
+    clearPending(key) {
+      const state = read();
+      const e = state[key];
+      if (e?.pendingEscalation !== undefined) {
+        delete e.pendingEscalation;
+        write(state);
+      }
+    },
+  };
+}
+
+/** In-memory store for tests. */
+export function createMemoryPollStateStore(seed: StateFile = {}): PollStateStore {
+  const state: StateFile = { ...seed };
+  return {
+    get: (key) => state[key],
+    writeAhead: (key, value, fireTs, diff) => {
+      state[key] = { value, escalatedAt: fireTs, pendingEscalation: diff };
+    },
+    setBaseline: (key, value) => {
+      state[key] = { value, escalatedAt: state[key]?.escalatedAt };
+    },
+    clearPending: (key) => {
+      if (state[key]?.pendingEscalation !== undefined) delete state[key]!.pendingEscalation;
+    },
+  };
+}

--- a/telegram-plugin/gateway/cron-session.ts
+++ b/telegram-plugin/gateway/cron-session.ts
@@ -1,0 +1,45 @@
+/**
+ * Cheap-cron session identity — docs/rfcs/cheap-cron-sessions.md §3.3.
+ *
+ * Rather than rekey the gateway's hardened single-bridge machinery
+ * (agentIndex / pendingInboundBuffer / handleRegister, each carrying
+ * subtle race fixes), a Tier-1 cron fire is routed to a SECOND bridge
+ * that registers under a DERIVED identity `<agent>-cron`. To the IPC
+ * layer it is "just another agent", so routing, buffering, disconnect,
+ * and heartbeat all work unchanged. The gateway gates its SINGLETON
+ * status machinery (shadow bridge-state, boot card, currentTurn /
+ * progress card / silence-poke) off the cron identity — which IS the
+ * §2.4 "cron session is status-silent" requirement, so it is one change,
+ * not two.
+ *
+ * The cron session's bridge sets SWITCHROOM_AGENT_NAME=`<agent>-cron`;
+ * the scheduler emits `meta.session='cron'` and the gateway derives the
+ * target via `cronIdentity()`. Pure string fns — pinned in cron-session.test.ts.
+ */
+
+/** Suffix that distinguishes a cron-session bridge from the main agent bridge. */
+export const CRON_IDENTITY_SUFFIX = "-cron";
+
+/** Derive the cron-session bridge identity for an agent. */
+export function cronIdentity(agent: string): string {
+  return `${agent}${CRON_IDENTITY_SUFFIX}`;
+}
+
+/** True iff `name` is a cron-session bridge identity (not a main agent bridge). */
+export function isCronIdentity(name: string | null | undefined): boolean {
+  return typeof name === "string" && name.endsWith(CRON_IDENTITY_SUFFIX);
+}
+
+/** The real agent name behind a (possibly cron) identity. */
+export function baseAgent(name: string): string {
+  return isCronIdentity(name) ? name.slice(0, -CRON_IDENTITY_SUFFIX.length) : name;
+}
+
+/**
+ * Resolve the IPC routing target for an inject_inbound. When the fire
+ * carries `meta.session='cron'` it goes to the derived cron bridge; every
+ * other fire (and all of today's callers) goes to the agent unchanged.
+ */
+export function resolveInjectTarget(agentName: string, meta: Record<string, string> | undefined): string {
+  return meta?.session === "cron" ? cronIdentity(agentName) : agentName;
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -5666,6 +5666,17 @@ const ipcServer: IpcServer = createIpcServer({
   },
 
   onClientDisconnected(client: IpcClient) {
+    // Cheap-cron §2.4: a `<agent>-cron` bridge is the status-silent cron
+    // session. Its disconnect (e.g. B3 lazy idle-teardown) must NOT touch
+    // the MAIN agent's singleton state — emitting bridgeDown (the shadow
+    // state is unkeyed) or flushOnAgentDisconnect (flushes the main agent's
+    // active reactions / disposes its progress driver mid-turn) would be the
+    // "premature 👍" bug for the main session. Symmetric to the cron gate in
+    // onClientRegistered / onSessionEvent / onPtyPartial.
+    if (isCronIdentity(client.agentName)) {
+      process.stderr.write(`telegram gateway: cron-session bridge disconnected — agent=${client.agentName}\n`)
+      return
+    }
     // ONLY log "bridge disconnected" + emit bridgeDown for the REAL
     // bridge sidecar (matching the bridgeUp gate above). Anonymous IPC
     // clients — e.g. recall.py's one-shot legacy update_placeholder

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -287,6 +287,7 @@ import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { handleRequestMs365Approval } from './ms365-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
+import { isCronIdentity, resolveInjectTarget } from './cron-session.js'
 import {
   ObligationLedger,
   buildObligationRepresentInbound,
@@ -5474,6 +5475,19 @@ const ipcServer: IpcServer = createIpcServer({
 
   onClientRegistered(client: IpcClient) {
     process.stderr.write(`telegram gateway: bridge registered — agent=${client.agentName}\n`)
+    // Cheap-cron (§2.4/§3.3): a `<agent>-cron` bridge is the Tier-1 cheap
+    // session. It is STATUS-SILENT — it must NOT drive the gateway's
+    // singleton machinery (shadow bridge-state, warmup, boot card, which all
+    // track the MAIN agent's liveness). Drain any buffered cron fire to it
+    // (so a fire that triggered a lazy spawn lands), then return early.
+    if (isCronIdentity(client.agentName)) {
+      client.send({ type: 'status', status: 'agent_connected' })
+      const pending = pendingInboundBuffer.drain(client.agentName ?? '')
+      for (const m of pending) {
+        try { client.send(m) } catch { /* cron fire drop — best-effort, like today's cron */ }
+      }
+      return
+    }
     // Phase 2b shadow: ONLY emit bridgeUp for the REAL bridge sidecar
     // (with an agent name). Anonymous IPC clients (recall.py, mcp
     // handshakes, etc.) connect briefly without a name and would
@@ -5722,7 +5736,13 @@ const ipcServer: IpcServer = createIpcServer({
     }
   },
 
-  onSessionEvent(_client: IpcClient, msg: SessionEventForward) {
+  onSessionEvent(client: IpcClient, msg: SessionEventForward) {
+    // Cheap-cron §2.4: the cron session is status-silent — its session
+    // events must not drive the main agent's progress card, transcript
+    // tail, currentTurn, or silence-poke. Its reply still flows (onToolCall
+    // is not gated). currentTurn was never set for a cron fire (onInjectInbound
+    // skips markClaudeBusy), so the card machinery has nothing to attach to.
+    if (isCronIdentity(client.agentName)) return
     // Track the session-tail's attached file for the proactive-
     // compaction occupancy read (see maybeProactiveCompact).
     if (msg.activeFile) lastSessionActiveFile = msg.activeFile
@@ -5954,7 +5974,10 @@ const ipcServer: IpcServer = createIpcServer({
    * `handlePtyPartial` does its own buffering for the
    * partial-before-enqueue race.
    */
-  onPtyPartial(_client: IpcClient, msg: PtyPartialForward) {
+  onPtyPartial(client: IpcClient, msg: PtyPartialForward) {
+    // Cheap-cron §2.4: cron session is status-silent — no visible reply
+    // stream from its PTY tail (it would edit a card the main session owns).
+    if (isCronIdentity(client.agentName)) return
     handlePtyPartial(msg.text)
   },
 
@@ -6291,16 +6314,28 @@ const ipcServer: IpcServer = createIpcServer({
     const source = typeof msg.inbound.meta?.source === 'string'
       ? msg.inbound.meta.source
       : 'unknown'
-    const delivered = ipcServer.sendToAgent(msg.agentName, msg.inbound)
-    if (delivered) markClaudeBusyForInbound(msg.inbound)
+    // Cheap-cron (docs/rfcs/cheap-cron-sessions.md §3.3): a Tier-1 fire
+    // carries meta.session='cron' → route to the derived `<agent>-cron`
+    // bridge (a 2nd interactive Sonnet session in the same container).
+    // Every other fire (and all of today's callers) routes to the agent
+    // unchanged. Route+buffer share the same target so a fire that lands
+    // mid cron-session-spawn buffers under the cron identity and drains to
+    // it on register.
+    const target = resolveInjectTarget(msg.agentName, msg.inbound.meta)
+    const toCron = target !== msg.agentName
+    const delivered = ipcServer.sendToAgent(target, msg.inbound)
+    // Status-silent (§2.4): a cron fire must NOT set the MAIN agent's
+    // currentTurn (progress card / silence-poke). The cron session is
+    // fire-and-forget; its reply is its only Telegram surface.
+    if (delivered && !toCron) markClaudeBusyForInbound(msg.inbound)
     process.stderr.write(
-      `telegram gateway: inject_inbound agent=${msg.agentName} source=${source} prompt_key=${promptKey} delivered=${delivered}\n`,
+      `telegram gateway: inject_inbound agent=${msg.agentName} target=${target} source=${source} prompt_key=${promptKey} delivered=${delivered}\n`,
     )
     // #1150: same buffer-on-failure pattern as vault_grant_approved.
     // Cron fires use this path too — if a cron-driven wake-up lands
     // mid bridge-reconnect, buffer it for the next register.
     if (!delivered) {
-      pendingInboundBuffer.push(msg.agentName, msg.inbound)
+      pendingInboundBuffer.push(target, msg.inbound)
     }
   },
 

--- a/telegram-plugin/tests/cron-session.test.ts
+++ b/telegram-plugin/tests/cron-session.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CRON_IDENTITY_SUFFIX,
+  baseAgent,
+  cronIdentity,
+  isCronIdentity,
+  resolveInjectTarget,
+} from '../gateway/cron-session.js'
+
+describe('cron-session identity helpers', () => {
+  it('derives and detects the cron identity', () => {
+    expect(cronIdentity('clerk')).toBe(`clerk${CRON_IDENTITY_SUFFIX}`)
+    expect(isCronIdentity('clerk-cron')).toBe(true)
+    expect(isCronIdentity('clerk')).toBe(false)
+    expect(isCronIdentity(null)).toBe(false)
+    expect(isCronIdentity(undefined)).toBe(false)
+  })
+
+  it('round-trips base agent', () => {
+    expect(baseAgent(cronIdentity('marko'))).toBe('marko')
+    expect(baseAgent('marko')).toBe('marko')
+  })
+
+  it('resolveInjectTarget routes only meta.session=cron to the cron bridge', () => {
+    expect(resolveInjectTarget('clerk', { session: 'cron', source: 'cron' })).toBe('clerk-cron')
+    expect(resolveInjectTarget('clerk', { session: 'main', source: 'cron' })).toBe('clerk')
+    expect(resolveInjectTarget('clerk', { source: 'cron' })).toBe('clerk')
+    expect(resolveInjectTarget('clerk', undefined)).toBe('clerk')
+    // back-compat: every legacy caller (no session) is unchanged.
+    expect(resolveInjectTarget('clerk', { source: 'telegram' })).toBe('clerk')
+  })
+})


### PR DESCRIPTION
## Summary

Cron fires are expensive because **every fire injects a turn into the agent's
live session** — paying the full standing-context cache-read tax + the agent's
model — even when it's a `*/10` poll that finds nothing. The two crons we
disabled 2026-06-09 (`clerk` telegram-capture `*/10`, `marko` lead-alert `*/15`)
are ~240 no-op fires/day, almost all wasted.

This lands the **RFC** (`docs/rfcs/cheap-cron-sessions.md`, reviewed by a 5-lens
adversarial pass) and the **L1–L3 core + plumbing**, all behind
`SWITCHROOM_CHEAP_CRON` (default **off** → no-op in prod until canary).

Three tiers, cheapest-first:
- **Tier 0** — declarative model-free poll; no change → `HEARTBEAT_OK` (zero
  model tokens), only a hit escalates. *This is the cost win.*
- **Tier 1** — a hit/light cron runs in a minimal-context `claude --model sonnet`
  cron session (gateway plumbing landed here; the session launch is the staged
  follow-up).
- **Tier 2** — `context: agent` injects into the live session, exactly as today.

Routing key = the **reactivated `ScheduleEntry.model`** + new `kind`/`context`.

## What's in this PR (built + tested)

- **L1** schema (`kind`/`context`/`poll`, un-deprecated `model`) + pure
  `resolveCronRouting` (flag-off = today's behaviour) — **total-enumeration**
  test (90 inputs) per the prove-by-enumeration standard.
- **L2** gateway routing to a derived `<agent>-cron` bridge — reuses the hardened
  single-bridge IPC machinery untouched (no `agentIndex`/buffer rekey) and gates
  the singleton status machinery off the cron identity (= §2.4 status-silence).
- **L3** Tier-0 **http-diff** engine + **SSRF/egress guard** (resolves the review
  BLOCK: https-only allowlist + host-pinned secret bindings + loopback/private/
  rebind rejection) + **write-ahead poll-state** (double-escalation guard) +
  first-run-no-escalate + `attemptFire` tier wiring.
- `cron.egress` operator-owned config block.

## Staged (next, canary-gated) — see RFC "Build status"

`main()` live-wiring (vault-broker secret-resolver — strict vault test
isolation), **L4** lazy Sonnet cron-session launch (2nd `claude`), **L5**
`schedule_add` cheap-default + `schedule report`, `telegram-reactions` poll.
With escalate-to-main, **Tier-0 delivers its full saving without L4**.

## Test plan

- [x] `tsc --noEmit` clean
- [x] L1 routing: 23 (total enumeration) · L2: 4 · L3: 45 engine/egress + 6 scheduler-integration
- [x] config suite 282 green; existing 22 scheduler tests green (back-compat)
- [x] `check-bot-api-wrapping.sh` + `check-plugin-references.mjs` clean
- [ ] Pre-existing `idle-smoke.test.ts` fails in-worktree (symlinked node_modules) — unrelated, fails identically on base

## Compliance (pillar 3)

Tier 0 is model-free (outside the inference surface). Tier 1/2 are interactive
`claude` (no `-p`). No SDK/API key. Reviewed APPROVE on compliance.

## Risk

Flag default-off → dormant. SSRF guard is the load-bearing new security surface
(35 adversarial tests). The staged live-wiring touches the vault broker and a
2nd `claude` process — deliberately deferred to a focused canary PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)