### PR TITLE
feat(cron): make Tier 0 live + observable (escalate-to-main, recovery, report)

### DIFF
--- a/src/agent-scheduler/cheap-cron-wiring.test.ts
+++ b/src/agent-scheduler/cheap-cron-wiring.test.ts
@@ -75,9 +75,10 @@ describe("recoverPendingEscalations", () => {
     poll: { type: "http-diff", url: "https://api.brevo.com/x", method: "GET", secrets: [], diff_jsonpath: "$.a", state_key: "k" },
   };
 
-  it("re-dispatches a dangling pendingEscalation once and clears it", () => {
+  it("re-dispatches a dangling pendingEscalation once, clears it, and audits it", () => {
     const pollState = createMemoryPollStateStore({ k: { value: "9", pendingEscalation: "cursor 9 > 5 (1)" } });
     const dispatcher = capture();
+    const fires: Array<{ tier?: string; outputSummary: string }> = [];
     const n = recoverPendingEscalations({
       entries: [pollEntry],
       pollState,
@@ -86,11 +87,15 @@ describe("recoverPendingEscalations", () => {
       cheapCronEnabled: true,
       now: () => 1000,
       log: () => {},
+      sink: { recordFire: (r) => fires.push(r) },
     });
     expect(n).toBe(1);
     expect(dispatcher.calls).toHaveLength(1);
     expect(dispatcher.calls[0]!.msg.text).toBe("New: cursor 9 > 5 (1)");
     expect(pollState.get("k")?.pendingEscalation).toBeUndefined();
+    // recovered hit is audited so `schedule report` counts it (reviewer note #1)
+    expect(fires).toHaveLength(1);
+    expect(fires[0]).toMatchObject({ tier: "main", outputSummary: "recovered pending escalation (boot)" });
   });
 
   it("no dangling escalation → no dispatch", () => {

--- a/src/agent-scheduler/cheap-cron-wiring.test.ts
+++ b/src/agent-scheduler/cheap-cron-wiring.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Live-wiring + boot recovery tests. All deps are faked — NO real vault
+ * broker or network is touched (vault test-isolation discipline).
+ */
+import { describe, expect, it } from "vitest";
+import type { SwitchroomConfig } from "../config/schema.js";
+import { buildCheapCronHooks } from "./cheap-cron-wiring.js";
+import { recoverPendingEscalations } from "./index.js";
+import { createMemoryPollStateStore } from "../scheduler/poll-state.js";
+import type { InboundDispatcher, InboundMessageWire, SchedulerEntry } from "../scheduler/dispatch.js";
+
+const CONFIG = {
+  cron: { egress: { allowed_hosts: ["api.brevo.com"], secret_bindings: { brevo_api_key: "api.brevo.com" } } },
+} as unknown as SwitchroomConfig;
+
+const ON = { SWITCHROOM_CHEAP_CRON: "1" } as NodeJS.ProcessEnv;
+const OFF = {} as NodeJS.ProcessEnv;
+
+function capture(): InboundDispatcher & { calls: Array<{ agent: string; msg: InboundMessageWire }> } {
+  const calls: Array<{ agent: string; msg: InboundMessageWire }> = [];
+  return { calls, sendToAgent: (agent, msg) => (calls.push({ agent, msg }), true) };
+}
+
+describe("buildCheapCronHooks", () => {
+  it("flag OFF → undefined (no hooks, today's behaviour)", () => {
+    expect(buildCheapCronHooks(CONFIG, OFF)).toBeUndefined();
+  });
+
+  it("flag ON → hooks whose http-diff runPoll respects the config egress allowlist", async () => {
+    const hooks = buildCheapCronHooks(CONFIG, ON, {
+      pollState: createMemoryPollStateStore(),
+      resolveSecret: async () => "secret",
+      lookup: async () => "8.8.8.8",
+      fetchImpl: (async () => new Response(JSON.stringify({ contacts: [{ id: 7 }] }), { status: 200 })) as unknown as typeof fetch,
+      now: () => 1000,
+    });
+    expect(hooks).toBeDefined();
+    const out = await hooks!.runPoll(
+      { type: "http-diff", url: "https://api.brevo.com/x", method: "GET", secrets: ["brevo_api_key"], diff_jsonpath: "$.contacts[*].id", state_key: "k" },
+      "3",
+    );
+    expect(out).toMatchObject({ hit: true, cursor: "7" });
+  });
+
+  it("a poll to a non-allowlisted host is denied by the wired egress guard", async () => {
+    const hooks = buildCheapCronHooks(CONFIG, ON, {
+      pollState: createMemoryPollStateStore(),
+      resolveSecret: async () => "secret",
+      lookup: async () => "8.8.8.8",
+      fetchImpl: (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch,
+    });
+    const out = await hooks!.runPoll(
+      { type: "http-diff", url: "https://evil.example/x", method: "GET", secrets: [], diff_jsonpath: "$.a", state_key: "k" },
+      "1",
+    );
+    expect(out.error).toMatch(/egress denied/);
+  });
+
+  it("telegram-reactions is staged → poll error, never a silent success", async () => {
+    const hooks = buildCheapCronHooks(CONFIG, ON, { pollState: createMemoryPollStateStore() });
+    const out = await hooks!.runPoll({ type: "telegram-reactions", chat_id: "1", emoji: "👨‍💻", lookback: 40, state_key: "k" }, undefined);
+    expect(out.error).toMatch(/not yet wired/);
+    expect(out.hit).toBe(false);
+  });
+});
+
+describe("recoverPendingEscalations", () => {
+  const pollEntry: SchedulerEntry = {
+    agent: "marko",
+    scheduleIndex: 0,
+    cron: "*/15 * * * *",
+    prompt: "New: {{diff}}",
+    promptKey: "p1",
+    kind: "poll",
+    poll: { type: "http-diff", url: "https://api.brevo.com/x", method: "GET", secrets: [], diff_jsonpath: "$.a", state_key: "k" },
+  };
+
+  it("re-dispatches a dangling pendingEscalation once and clears it", () => {
+    const pollState = createMemoryPollStateStore({ k: { value: "9", pendingEscalation: "cursor 9 > 5 (1)" } });
+    const dispatcher = capture();
+    const n = recoverPendingEscalations({
+      entries: [pollEntry],
+      pollState,
+      dispatcher,
+      channel: { chatId: "123" } as never,
+      cheapCronEnabled: true,
+      now: () => 1000,
+      log: () => {},
+    });
+    expect(n).toBe(1);
+    expect(dispatcher.calls).toHaveLength(1);
+    expect(dispatcher.calls[0]!.msg.text).toBe("New: cursor 9 > 5 (1)");
+    expect(pollState.get("k")?.pendingEscalation).toBeUndefined();
+  });
+
+  it("no dangling escalation → no dispatch", () => {
+    const pollState = createMemoryPollStateStore({ k: { value: "9" } });
+    const dispatcher = capture();
+    expect(
+      recoverPendingEscalations({ entries: [pollEntry], pollState, dispatcher, channel: { chatId: "1" } as never, cheapCronEnabled: true, now: () => 1, log: () => {} }),
+    ).toBe(0);
+    expect(dispatcher.calls).toHaveLength(0);
+  });
+
+  it("skips non-poll entries", () => {
+    const pollState = createMemoryPollStateStore({ k: { value: "9", pendingEscalation: "x" } });
+    const dispatcher = capture();
+    const promptEntry: SchedulerEntry = { agent: "marko", scheduleIndex: 1, cron: "0 9 * * *", prompt: "hi", promptKey: "p2" };
+    recoverPendingEscalations({ entries: [promptEntry], pollState, dispatcher, channel: { chatId: "1" } as never, cheapCronEnabled: true, now: () => 1, log: () => {} });
+    expect(dispatcher.calls).toHaveLength(0);
+  });
+});

--- a/src/agent-scheduler/cheap-cron-wiring.ts
+++ b/src/agent-scheduler/cheap-cron-wiring.ts
@@ -1,0 +1,86 @@
+/**
+ * Cheap-cron live wiring — docs/rfcs/cheap-cron-sessions.md.
+ *
+ * Constructs the CheapCronHooks the in-agent scheduler passes to
+ * registerAgentSchedule, from operator config + env + the vault broker.
+ * Returns `undefined` when SWITCHROOM_CHEAP_CRON is off, so main() wires
+ * nothing and behaviour is exactly today's.
+ *
+ * Every external dependency (the vault-broker secret resolver, fetch, DNS,
+ * the poll-state store) is INJECTABLE with a real default. Tests pass fakes
+ * and therefore never touch the real broker or network — the vault test
+ * isolation discipline (CLAUDE.md; the 2026-05-22 clobber incident).
+ */
+
+import { lookup as dnsLookup } from "node:dns/promises";
+import type { PollSpec, SwitchroomConfig } from "../config/schema.js";
+import { isCheapCronEnabled } from "../scheduler/cron-routing.js";
+import type { EgressAllowlist } from "../scheduler/poll-egress.js";
+import { runHttpDiffPoll, type HttpDiffSpec, type PollOutcome } from "../scheduler/poll-engine.js";
+import { createFilePollStateStore, type PollStateStore } from "../scheduler/poll-state.js";
+import { getViaBroker } from "../vault/broker/client.js";
+// type-only (erased) → no runtime import cycle with index.ts.
+import type { CheapCronHooks } from "./index.js";
+
+export interface CheapCronWiringDeps {
+  /** Resolve a vault secret by name. Default: the agent's vault broker (ACL by socket identity). */
+  resolveSecret?: (name: string) => Promise<string>;
+  fetchImpl?: typeof fetch;
+  /** host → resolved IP for the rebind pin. Default: node:dns. */
+  lookup?: (host: string) => Promise<string | null>;
+  pollState?: PollStateStore;
+  now?: () => number;
+}
+
+const defaultResolveSecret = async (name: string): Promise<string> => {
+  const entry = await getViaBroker(name);
+  if (!entry) throw new Error(`secret '${name}' unavailable from vault broker`);
+  if (entry.kind !== "string") throw new Error(`secret '${name}' is not a string secret`);
+  return entry.value;
+};
+
+const defaultLookup = async (host: string): Promise<string | null> => {
+  try {
+    return (await dnsLookup(host)).address;
+  } catch {
+    return null;
+  }
+};
+
+export function buildCheapCronHooks(
+  config: SwitchroomConfig,
+  env: NodeJS.ProcessEnv,
+  deps: CheapCronWiringDeps = {},
+): CheapCronHooks | undefined {
+  if (!isCheapCronEnabled(env)) return undefined;
+
+  const egress: EgressAllowlist = {
+    hosts: config.cron?.egress?.allowed_hosts ?? [],
+    secretBindings: config.cron?.egress?.secret_bindings ?? {},
+  };
+  const pollState =
+    deps.pollState ??
+    createFilePollStateStore(env.SWITCHROOM_AGENT_POLL_STATE ?? "/state/agent/poll-state.json");
+  const resolveSecret = deps.resolveSecret ?? defaultResolveSecret;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const lookup = deps.lookup ?? defaultLookup;
+  const now = deps.now ?? Date.now;
+
+  const runPoll = async (spec: PollSpec, prevCursor: string | undefined): Promise<PollOutcome> => {
+    if (spec.type === "http-diff") {
+      return runHttpDiffPoll(spec as HttpDiffSpec, prevCursor, {
+        fetchImpl,
+        resolveSecret,
+        lookup,
+        allow: egress,
+        now,
+      });
+    }
+    // telegram-reactions is schema-accepted but STAGED — it needs the
+    // net-new internal gateway reactions query verb. Until then it records a
+    // poll-error (no escalation), never a silent success.
+    return { hit: false, baseline: false, error: `poll type '${spec.type}' not yet wired (staged)` };
+  };
+
+  return { enabled: true, pollState, runPoll };
+}

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -31,11 +31,12 @@ import { loadConfig } from "../config/loader.js";
 import {
   collectScheduleEntries,
   dispatchAsInbound,
+  type DispatchResult,
   type InboundDispatcher,
   type InboundMessageWire,
   type SchedulerEntry,
 } from "../scheduler/dispatch.js";
-import { resolveCronRouting, resolveEscalationRouting } from "../scheduler/cron-routing.js";
+import { isCheapCronEnabled, resolveCronRouting, resolveEscalationRouting } from "../scheduler/cron-routing.js";
 import type { PollOutcome } from "../scheduler/poll-engine.js";
 import type { PollStateStore } from "../scheduler/poll-state.js";
 import type { PollSpec } from "../config/schema.js";
@@ -147,6 +148,8 @@ export function recoverPendingEscalations(opts: {
   cheapCronEnabled: boolean;
   now: () => number;
   log: (m: string) => void;
+  /** Optional audit sink so a boot-recovered hit shows in `schedule report`. */
+  sink?: { recordFire: (r: DispatchResult) => void };
 }): number {
   let recovered = 0;
   for (const entry of opts.entries) {
@@ -155,6 +158,7 @@ export function recoverPendingEscalations(opts: {
     if (!st?.pendingEscalation) continue;
     const esc = resolveEscalationRouting(entry, { cheapCronEnabled: opts.cheapCronEnabled });
     const threadId = resolveEntryThreadId(entry, opts.channel);
+    const startedAt = opts.now();
     try {
       const r = dispatchAsInbound(
         { ...entry, prompt: templateEscalationPrompt(entry.prompt, st.pendingEscalation) },
@@ -168,6 +172,17 @@ export function recoverPendingEscalations(opts: {
       } else {
         opts.log(`pending escalation for '${entry.poll.state_key}' not delivered — will retry next boot`);
       }
+      opts.sink?.recordFire({
+        agent: entry.agent,
+        scheduleIndex: entry.scheduleIndex,
+        promptKey: entry.promptKey,
+        exitCode: r.delivered ? 0 : -1,
+        outputSummary: r.delivered ? "recovered pending escalation (boot)" : "pending escalation not delivered (boot)",
+        startedAt,
+        finishedAt: opts.now(),
+        tier: esc.tier === "cheap" ? "cheap" : "main",
+        ...(esc.cronModel ? { modelUsed: esc.cronModel } : {}),
+      });
     } catch (e) {
       opts.log(`pending-escalation recovery failed for '${entry.poll.state_key}': ${(e as Error).message}`);
     }
@@ -543,8 +558,27 @@ export async function main(): Promise<void> {
             .map((m) => `[idx=${m.entry.scheduleIndex} key=${m.entry.promptKey}]`)
             .join(" ") + "\n",
         );
+        const cheapEnabledForReplay = isCheapCronEnabled(process.env);
         for (const m of missed) {
           const startedAt = Date.now();
+          // Cheap-cron: a `kind: poll` entry must NOT replay as a raw prompt —
+          // that would fire its escalation text (with a literal {{diff}}) as a
+          // model turn, bypassing the poll. A poll is stateful (durable cursor),
+          // so a missed fire is harmlessly caught by the next natural tick's
+          // poll (which compares against the advanced cursor). Skip + audit.
+          if (cheapEnabledForReplay && m.entry.kind === "poll") {
+            sink.recordFire({
+              agent: m.entry.agent,
+              scheduleIndex: m.entry.scheduleIndex,
+              promptKey: m.entry.promptKey,
+              exitCode: 0,
+              outputSummary: "poll replay skipped — re-polls on next tick (stateful cursor)",
+              startedAt,
+              finishedAt: Date.now(),
+              tier: "poll",
+            });
+            continue;
+          }
           const threadId = resolveEntryThreadId(m.entry, channel);
           const result = dispatchAsInbound(
             m.entry,
@@ -679,6 +713,7 @@ export async function main(): Promise<void> {
       cheapCronEnabled: true,
       now: Date.now,
       log: (m) => process.stderr.write(`agent-scheduler: ${m}\n`),
+      sink,
     });
     process.stdout.write(
       `agent-scheduler: ${agentName} cheap-cron ENABLED` +

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -39,6 +39,7 @@ import { resolveCronRouting, resolveEscalationRouting } from "../scheduler/cron-
 import type { PollOutcome } from "../scheduler/poll-engine.js";
 import type { PollStateStore } from "../scheduler/poll-state.js";
 import type { PollSpec } from "../config/schema.js";
+import { buildCheapCronHooks } from "./cheap-cron-wiring.js";
 // AgentChannelTarget, resolveChannelTarget, and resolveEntryThreadId
 // live in ./channel-target.js (a node-cron-free leaf) so the gateway's
 // webhook-ingest path can import them without pulling node-cron into
@@ -127,6 +128,51 @@ export interface CheapCronHooks {
 /** Replace {{diff}} in an escalation prompt with the poll's diff summary. */
 function templateEscalationPrompt(prompt: string, diff: string): string {
   return prompt.replace(/\{\{\s*diff\s*\}\}/g, diff);
+}
+
+/**
+ * Boot recovery for the lost-hit window (reviewer note, PR #2244): a crash
+ * AFTER a poll's write-ahead cursor advance but BEFORE its escalation was
+ * delivered leaves a dangling `pendingEscalation` in poll-state. On boot,
+ * re-dispatch each one exactly once and clear it. Without this the cursor is
+ * advanced but the hit was never sent → the lead is silently dropped. Runs
+ * before the live cron loop registers. Pure-ish: side effects are the
+ * dispatcher write + pollState.clearPending + log.
+ */
+export function recoverPendingEscalations(opts: {
+  entries: SchedulerEntry[];
+  pollState: PollStateStore;
+  dispatcher: InboundDispatcher;
+  channel: AgentChannelTarget;
+  cheapCronEnabled: boolean;
+  now: () => number;
+  log: (m: string) => void;
+}): number {
+  let recovered = 0;
+  for (const entry of opts.entries) {
+    if (entry.kind !== "poll" || !entry.poll) continue;
+    const st = opts.pollState.get(entry.poll.state_key);
+    if (!st?.pendingEscalation) continue;
+    const esc = resolveEscalationRouting(entry, { cheapCronEnabled: opts.cheapCronEnabled });
+    const threadId = resolveEntryThreadId(entry, opts.channel);
+    try {
+      const r = dispatchAsInbound(
+        { ...entry, prompt: templateEscalationPrompt(entry.prompt, st.pendingEscalation) },
+        { chatId: opts.channel.chatId, threadId, now: opts.now, session: esc.session ?? "main", model: esc.cronModel },
+        opts.dispatcher,
+      );
+      if (r.delivered) {
+        opts.pollState.clearPending(entry.poll.state_key);
+        recovered += 1;
+        opts.log(`recovered pending escalation for poll '${entry.poll.state_key}'`);
+      } else {
+        opts.log(`pending escalation for '${entry.poll.state_key}' not delivered — will retry next boot`);
+      }
+    } catch (e) {
+      opts.log(`pending-escalation recovery failed for '${entry.poll.state_key}': ${(e as Error).message}`);
+    }
+  }
+  return recovered;
 }
 
 export interface RegisteredTask {
@@ -618,6 +664,28 @@ export async function main(): Promise<void> {
       }
     : undefined;
 
+  // Cheap-cron live wiring (docs/rfcs/cheap-cron-sessions.md). Returns
+  // undefined when SWITCHROOM_CHEAP_CRON is off → registerAgentSchedule sees
+  // no hook → today's behaviour exactly.
+  const cheapCron = buildCheapCronHooks(config, process.env);
+  if (cheapCron) {
+    // Recover any escalation that advanced its cursor but crashed before
+    // delivery (the lost-hit window), before the live loop starts.
+    const recovered = recoverPendingEscalations({
+      entries,
+      pollState: cheapCron.pollState,
+      dispatcher,
+      channel,
+      cheapCronEnabled: true,
+      now: Date.now,
+      log: (m) => process.stderr.write(`agent-scheduler: ${m}\n`),
+    });
+    process.stdout.write(
+      `agent-scheduler: ${agentName} cheap-cron ENABLED` +
+      (recovered > 0 ? ` (recovered ${recovered} pending escalation(s))` : "") + "\n",
+    );
+  }
+
   const tasks = registerAgentSchedule({
     entries,
     channel,
@@ -625,6 +693,7 @@ export async function main(): Promise<void> {
     cronLib,
     dispatcher,
     ...(quotaGate ? { quotaGate } : {}),
+    ...(cheapCron ? { cheapCron } : {}),
   });
 
   process.stdout.write(

--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -60,6 +60,12 @@ import {
   type PendingReasonCode,
 } from "./agent-config-pending.js";
 import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  formatScheduleReport,
+  parseScheduleJsonl,
+  summarizeScheduleReport,
+} from "../scheduler/schedule-report.js";
 import { buildEnvelope, type ErrorEnvelope } from "../host-control/protocol.js";
 
 const MAX_ENTRIES_PER_AGENT = 20;
@@ -842,6 +848,49 @@ export function registerAgentConfigWriteCommands(program: Command): void {
         restart_hint: r.restart_hint,
       }) + "\n");
       appendAudit(resolvedAgent, "schedule.remove", { ...opts, slug: r.slug }, 0);
+    });
+
+  schedule
+    .command("report [agent]")
+    .description("Cheap-cron cost breakdown from the agent's scheduler.jsonl (Tier 0/1/2 fire counts)")
+    .option("--jsonl <path>", "Read a local scheduler.jsonl instead of docker-exec into the container")
+    .option("--since <iso>", "Only count fires at/after this ISO timestamp")
+    .option("--json", "Emit the summary as JSON")
+    .action((agentArg: string | undefined, opts: { jsonl?: string; since?: string; json?: boolean }) => {
+      const agent = agentArg ?? process.env.SWITCHROOM_AGENT_NAME;
+      if (!agent) {
+        process.stderr.write("schedule report: pass an agent name (or set $SWITCHROOM_AGENT_NAME)\n");
+        process.exit(2);
+      }
+      let blob: string;
+      if (opts.jsonl) {
+        blob = existsSync(opts.jsonl) ? readFileSync(opts.jsonl, "utf-8") : "";
+      } else {
+        try {
+          // Mirrors the inspection pattern used elsewhere: read in-container state.
+          blob = execFileSync("docker", ["exec", `switchroom-${agent}`, "cat", "/state/agent/scheduler.jsonl"], {
+            encoding: "utf-8",
+            stdio: ["ignore", "pipe", "ignore"],
+          });
+        } catch {
+          process.stderr.write(
+            `schedule report: could not read scheduler.jsonl from container switchroom-${agent} ` +
+            `(is it running? try --jsonl <path>)\n`,
+          );
+          process.exit(1);
+        }
+      }
+      const sinceMs = opts.since ? Date.parse(opts.since) : undefined;
+      if (opts.since && Number.isNaN(sinceMs)) {
+        process.stderr.write(`schedule report: invalid --since '${opts.since}'\n`);
+        process.exit(2);
+      }
+      const summary = summarizeScheduleReport(parseScheduleJsonl(blob), sinceMs ? { sinceMs } : {});
+      if (opts.json) {
+        process.stdout.write(JSON.stringify({ agent, ...summary }) + "\n");
+      } else {
+        process.stdout.write(formatScheduleReport(agent, summary) + "\n");
+      }
     });
 }
 

--- a/src/scheduler/schedule-report.test.ts
+++ b/src/scheduler/schedule-report.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatScheduleReport,
+  parseScheduleJsonl,
+  summarizeScheduleReport,
+  type ScheduleReportRow,
+} from "./schedule-report.js";
+
+const rows: ScheduleReportRow[] = [
+  { tier: "poll", exitCode: 0, startedAt: 100 },
+  { tier: "poll", exitCode: 0, startedAt: 200 },
+  { tier: "poll", exitCode: -3, startedAt: 250 }, // poll error
+  { tier: "cheap", exitCode: 0, modelUsed: "claude-sonnet-4-6", startedAt: 300 },
+  { tier: "main", exitCode: 0, startedAt: 400 },
+  { tier: "main", exitCode: -2, startedAt: 450 }, // deferred
+  { exitCode: 0, startedAt: 500 }, // legacy untiered → main
+];
+
+describe("summarizeScheduleReport", () => {
+  it("counts by tier, errors, deferred, cost-weight", () => {
+    const s = summarizeScheduleReport(rows);
+    expect(s).toMatchObject({
+      total: 7,
+      pollFires: 3,
+      cheapFires: 1,
+      mainFires: 3, // 2 main + 1 legacy untiered
+      errors: 1, // the -3 poll error (deferred -2 excluded)
+      deferred: 1,
+      costWeight: 0 * 3 + 1 * 1 + 5 * 3, // = 16
+    });
+    expect(s.byModel).toEqual({ "claude-sonnet-4-6": 1 });
+  });
+
+  it("respects --since", () => {
+    const s = summarizeScheduleReport(rows, { sinceMs: 400 });
+    expect(s.total).toBe(3); // startedAt 400, 450, 500
+    expect(s.pollFires).toBe(0);
+  });
+
+  it("empty → all zero", () => {
+    expect(summarizeScheduleReport([])).toMatchObject({ total: 0, pollFires: 0, costWeight: 0 });
+  });
+});
+
+describe("parseScheduleJsonl", () => {
+  it("parses rows and skips blank/malformed lines", () => {
+    const blob = [
+      JSON.stringify({ tier: "poll", exitCode: 0 }),
+      "",
+      "{not json",
+      JSON.stringify({ tier: "main", exitCode: 0 }),
+      JSON.stringify({ noExitCode: true }),
+    ].join("\n");
+    expect(parseScheduleJsonl(blob)).toHaveLength(2);
+  });
+});
+
+describe("formatScheduleReport", () => {
+  it("shows the model-free %", () => {
+    const out = formatScheduleReport("marko", summarizeScheduleReport(rows));
+    expect(out).toContain("marko");
+    expect(out).toContain("43% model-free"); // 3/7
+  });
+});

--- a/src/scheduler/schedule-report.ts
+++ b/src/scheduler/schedule-report.ts
@@ -1,0 +1,103 @@
+/**
+ * Cheap-cron observability — docs/rfcs/cheap-cron-sessions.md §5.
+ *
+ * Aggregates scheduler.jsonl audit rows into a per-tier cost breakdown so
+ * the operator can SEE the saving: how many fires were model-free Tier-0
+ * polls (zero cost) vs actual model fires. Pure — the CLI does the IO.
+ */
+
+export interface ScheduleReportRow {
+  tier?: "poll" | "cheap" | "main";
+  exitCode: number;
+  modelUsed?: string;
+  startedAt?: number;
+  scheduleIndex?: number;
+}
+
+export interface ScheduleReportSummary {
+  total: number;
+  /** Model-free Tier-0 poll fires (no-op/baseline) — the saving, cost 0. */
+  pollFires: number;
+  /** Tier-1 cheap-session model fires. */
+  cheapFires: number;
+  /** Tier-2 main-session model fires (incl. legacy untiered rows). */
+  mainFires: number;
+  /** exitCode < 0 and not a quota-defer (-2). */
+  errors: number;
+  /** Quota-deferred fires (-2). */
+  deferred: number;
+  /**
+   * Rough relative cost proxy (NOT dollars): poll×0 + cheap×1 + main×5,
+   * mirroring the sonnet:opus output ratio. Labelled as a proxy in output.
+   */
+  costWeight: number;
+  /** Count by the model each fire ran at (when recorded). */
+  byModel: Record<string, number>;
+}
+
+// Relative cost weights (sonnet:opus output ≈ 1:5). Tier 0 is free.
+const TIER_WEIGHT: Record<"poll" | "cheap" | "main", number> = { poll: 0, cheap: 1, main: 5 };
+
+export function summarizeScheduleReport(
+  rows: ScheduleReportRow[],
+  opts: { sinceMs?: number } = {},
+): ScheduleReportSummary {
+  const s: ScheduleReportSummary = {
+    total: 0,
+    pollFires: 0,
+    cheapFires: 0,
+    mainFires: 0,
+    errors: 0,
+    deferred: 0,
+    costWeight: 0,
+    byModel: {},
+  };
+  for (const r of rows) {
+    if (opts.sinceMs !== undefined && (r.startedAt ?? 0) < opts.sinceMs) continue;
+    s.total += 1;
+    // Legacy rows (pre-cheap-cron) have no tier → count as main (today's behaviour).
+    const tier = r.tier ?? "main";
+    if (tier === "poll") s.pollFires += 1;
+    else if (tier === "cheap") s.cheapFires += 1;
+    else s.mainFires += 1;
+    s.costWeight += TIER_WEIGHT[tier];
+    if (r.exitCode === -2) s.deferred += 1;
+    else if (r.exitCode < 0) s.errors += 1;
+    if (r.modelUsed) s.byModel[r.modelUsed] = (s.byModel[r.modelUsed] ?? 0) + 1;
+  }
+  return s;
+}
+
+/** Parse a scheduler.jsonl blob into rows, skipping malformed lines. */
+export function parseScheduleJsonl(blob: string): ScheduleReportRow[] {
+  const rows: ScheduleReportRow[] = [];
+  for (const line of blob.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const o = JSON.parse(t) as ScheduleReportRow;
+      if (typeof o.exitCode === "number") rows.push(o);
+    } catch {
+      /* skip malformed audit line */
+    }
+  }
+  return rows;
+}
+
+export function formatScheduleReport(agent: string, s: ScheduleReportSummary): string {
+  const modelFires = s.cheapFires + s.mainFires;
+  const savedPct = s.total > 0 ? Math.round((s.pollFires / s.total) * 100) : 0;
+  const lines = [
+    `cron report — ${agent}`,
+    `  total fires        ${s.total}`,
+    `  Tier 0 poll (free) ${s.pollFires}  (${savedPct}% model-free)`,
+    `  Tier 1 cheap       ${s.cheapFires}`,
+    `  Tier 2 main        ${s.mainFires}`,
+    `  model fires        ${modelFires}`,
+    `  errors / deferred  ${s.errors} / ${s.deferred}`,
+    `  cost-weight proxy  ${s.costWeight}  (poll×0 + cheap×1 + main×5; relative, not $)`,
+  ];
+  const models = Object.entries(s.byModel);
+  if (models.length) lines.push(`  by model           ${models.map(([m, n]) => `${m}=${n}`).join("  ")}`);
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

Follow-up to #2244 (the L1–L3 core, merged). That PR landed the routing,
gateway plumbing, and the Tier-0 engine + SSRF guard, but left the engine
**not wired into the scheduler boot** — dormant. This PR makes **Tier 0 live and
canary-able on `marko` without the second session**, behind the same
`SWITCHROOM_CHEAP_CRON` flag (default **off**).

With `escalate-to-main` (a poll entry with no `model`/`context` → Tier 2), a hit
fires into the live session exactly as today — so Tier 0 delivers its **full
cost saving** (marko's ~96 wasted no-op fires/day → ~0 model tokens) with zero
new session infrastructure.

## What's in this PR

- **`buildCheapCronHooks(config, env)`** — constructs the `CheapCronHooks` from
  `cron.egress` config + env + the **vault-broker secret resolver**, gated on the
  flag (off → `undefined` → `registerAgentSchedule` unchanged). Every external
  dep (broker resolver, fetch, DNS, poll-state) is **injectable with a real
  default**, so tests pass fakes and **never touch the real broker/network** (the
  vault test-isolation discipline — CLAUDE.md + the 2026-05-22 clobber incident).
- **`recoverPendingEscalations()`** at boot — the reviewer's lost-hit fix from
  #2244: a crash after a poll's write-ahead cursor advance but before delivery
  left a dangling `pendingEscalation`; this re-dispatches it once and clears it.
  Closes the window the prior PR's comment flagged as open.
- **`switchroom schedule report [agent]`** (§5 observability) — reads
  scheduler.jsonl and shows the saving: Tier-0 poll (free) vs Tier-1 cheap vs
  Tier-2 main fire counts + a relative cost-weight proxy. This is how the canary
  is measured. `--jsonl <path>` / `--since` / `--json`.

## Still staged (next PR)

**L4** the lazy Sonnet cron session (start.sh fork + trimmed `.mcp.json`), which
makes the *hit* path and non-poll crons cheap too; **L5** `schedule_add`
cheap-default params + escalation staging; the `telegram-reactions` poll (needs
the net-new internal gateway reactions verb) — it's schema-accepted but records a
poll-error (never a silent success) until then.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 7 wiring/recovery tests (all fakes — no broker/network) + 5 report tests
- [x] full scheduler sweep 128 green; existing 22 scheduler tests green (back-compat: flag-off → no hooks)
- [x] `check-plugin-references.mjs` clean
- [ ] **Canary (post-merge):** flag-on `marko` only, re-enable lead-alert as a `kind: poll` http-diff (escalate-to-main), confirm no-op fires record `HEARTBEAT_OK` with zero model tokens via `schedule report`, and a seeded hit escalates + emails.

## Compliance / risk

Flag default-off → dormant. Tier 0 is model-free (outside the inference surface);
escalations are interactive `claude` (no `-p`). The secret resolver goes through
the agent's vault broker (ACL by socket identity) and the §6.1 egress guard
fences where each secret may go. No SDK/API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)