### PR TITLE
feat(cron): L4 — per-agent cheap Sonnet cron session (dormant, flag-gated)

### DIFF
--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Tier-1 cheap cron SESSION launcher — docs/rfcs/cheap-cron-sessions.md §2.2.
+#
+# A SECOND interactive `claude` (no -p — compliance pillar 3) in the agent
+# container, dedicated to cheap cron fires. It registers to the SAME gateway
+# as a DISTINCT bridge identity `<name>-cron` (start.sh's gateway sidecar
+# routes meta.session=cron fires here and gates all status surfaces off this
+# identity — see telegram-plugin/gateway/cron-session.ts). Minimal context:
+# its own CLAUDE_CONFIG_DIR (separate transcript) + a TRIMMED .mcp.json (only
+# switchroom-telegram) → it pays a fraction of the main session's schema +
+# cache-read tax, at the cheap cron model.
+#
+# Forked as a supervised sidecar by start.sh ONLY when {{name}} actually has a
+# Tier-1 (context: fresh) cron entry AND SWITCHROOM_CHEAP_CRON is on — so the
+# whole feature is inert for the rest of the fleet (the start.sh fork block
+# renders empty). This script is a no-op artifact on disk until then.
+set -u
+
+# Runtime kill-switch. The fork is baked into start.sh whenever {{name}} has a
+# context:fresh cron entry (a config property), but the session only actually
+# runs when SWITCHROOM_CHEAP_CRON is on at runtime. Exit 78 (EX_CONFIG) so the
+# supervisor does NOT respawn-loop when the feature is off — a clean idle.
+case "${SWITCHROOM_CHEAP_CRON:-}" in
+  1 | true | on | ON) : ;;
+  *)
+    echo "cron-session: SWITCHROOM_CHEAP_CRON off — not starting (exit 78, no respawn)" >&2
+    exit 78
+    ;;
+esac
+
+CRON_NAME="{{name}}-cron"
+CRON_CONFIG_DIR="{{agentDir}}/.claude-cron"
+MAIN_CONFIG_DIR="{{agentDir}}/.claude"
+# v1: reuse the agent's project .mcp.json. The switchroom-telegram BRIDGE reads
+# SWITCHROOM_AGENT_NAME from the process env (exported below) — NOT its .mcp.json
+# env block — so it registers as the cron identity even off the shared config.
+# The bigger wins (fresh context + the cheap model) already hold; trimming the
+# MCP surface to just switchroom-telegram is a documented canary-time follow-up.
+CRON_MCP_CONFIG="{{agentDir}}/.mcp.json"
+CRON_SOCKET="switchroom-${CRON_NAME}"
+
+mkdir -p "$CRON_CONFIG_DIR"
+
+# Share the broker-managed OAuth creds (same subscription) without sharing the
+# main session's transcript/settings. The broker is the sole writer of
+# .credentials.json into the MAIN config dir; symlink it so the cron session
+# authenticates with the same account and re-reads on refresh. Transcript
+# (projects/) stays separate → minimal, /clear-friendly context.
+if [ -e "$MAIN_CONFIG_DIR/.credentials.json" ]; then
+  ln -sfn "$MAIN_CONFIG_DIR/.credentials.json" "$CRON_CONFIG_DIR/.credentials.json"
+fi
+if [ -e "$MAIN_CONFIG_DIR/settings.json" ]; then
+  ln -sfn "$MAIN_CONFIG_DIR/settings.json" "$CRON_CONFIG_DIR/settings.json"
+fi
+
+# Distinct identity + config dir for the bridge that runs inside claude.
+export SWITCHROOM_AGENT_NAME="$CRON_NAME"
+export CLAUDE_CONFIG_DIR="$CRON_CONFIG_DIR"
+
+CRON_APPEND_PROMPT="You are the cheap background cron worker for {{name}}. You handle scheduled tasks only. Do the task, reply once with the result, and keep it brief. You do not have {{name}}'s full memory or persona — if a task needs them, say so rather than guessing."
+
+# Launch the cron claude in its OWN tmux session/socket so it never contends
+# with the main session's pane. Interactive (no -p). --strict-mcp-config pins
+# it to the trimmed config (switchroom-telegram only). Fresh each boot (no
+# --continue) — minimal context by construction.
+exec tmux -L "$CRON_SOCKET" \
+  new-session -A -s "$CRON_NAME" -x 400 -y 50 \
+  claude \
+    --dangerously-load-development-channels server:switchroom-telegram \
+    --plugin-dir "{{securityPluginDir}}" \
+    --mcp-config "$CRON_MCP_CONFIG" \
+    --strict-mcp-config \
+    --model {{{cronModelQ}}} \
+    --append-system-prompt "$CRON_APPEND_PROMPT"{{#if dangerousMode}} \
+    --dangerously-skip-permissions{{/if}}

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -163,6 +163,19 @@ if [ "$SWITCHROOM_RUNTIME" = "docker" ] && [ -z "$SWITCHROOM_DOCKER_TMUX_INNER" 
       bun /opt/switchroom/agent-scheduler/index.js &
   fi
 
+{{#if cronSessionEnabled}}
+  # 4) cheap cron SESSION (Tier 1, docs/rfcs/cheap-cron-sessions.md §2.2).
+  #    A SECOND interactive claude (no -p) dedicated to context:fresh cron
+  #    fires, registering to the gateway as the cron-suffixed bridge. This
+  #    block is rendered ONLY for an agent that has a Tier-1 cron entry; for
+  #    every other agent the cronSessionEnabled guard is false so the whole
+  #    block is absent and their start.sh is byte-identical to before.
+  if command -v claude >/dev/null 2>&1 && [ -f "$(dirname "$0")/cron-session.sh" ]; then
+    _switchroom_supervise cron-session /var/log/switchroom/cron-session.log \
+      bash "$(dirname "$0")/cron-session.sh" &
+  fi
+{{/if}}
+
   export SWITCHROOM_DOCKER_TMUX_INNER=1
   exec tmux -L "switchroom-{{name}}" \
     new-session -A -s "{{name}}" -x 400 -y 50 \

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -383,6 +383,29 @@ export function renderFleetInvariants(): string {
 }
 
 import { DEFAULT_PROFILE } from "../config/schema.js";
+import { DEFAULT_CRON_MODEL, scheduleNeedsCronSession } from "../scheduler/cron-routing.js";
+
+/**
+ * Cheap-cron (L4) start.sh context. `cronSessionEnabled` is purely
+ * config-derived — true iff the agent has a Tier-1 (context:fresh) cron
+ * entry — so the start.sh fork block renders EMPTY for every current fleet
+ * agent (none have that brand-new field), keeping their boot byte-identical.
+ * The runtime SWITCHROOM_CHEAP_CRON flag self-gates inside cron-session.sh.
+ */
+function buildCronSessionContext(agentConfig: AgentConfig): {
+  cronSessionEnabled: boolean;
+  cronModelQ: string;
+} {
+  const entries = (agentConfig.schedule ?? []).map((e) => ({
+    kind: e.kind,
+    model: e.model,
+    context: e.context,
+  }));
+  return {
+    cronSessionEnabled: scheduleNeedsCronSession(entries, { cheapCronEnabled: true }),
+    cronModelQ: shellSingleQuote(DEFAULT_CRON_MODEL),
+  };
+}
 import {
   resolveAgentConfig,
   translateHooksToClaudeShape,
@@ -2179,6 +2202,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     // {{#if hostHomeQ}} guard renders the symlink block as a no-op.
     hostHomeQ: process.env.HOME ? shellSingleQuote(process.env.HOME) : undefined,
     modelQ: shellSingleQuote(agentConfig.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL),
+    ...buildCronSessionContext(agentConfig),
     thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
     permissionMode: agentConfig.permission_mode,
     fallbackModelQ: agentConfig.fallback_model
@@ -2820,6 +2844,21 @@ export function scaffoldAgent(
   // Make start.sh executable
   if (existsSync(join(agentDir, "start.sh"))) {
     chmodSync(join(agentDir, "start.sh"), 0o700);
+  }
+
+  // Cheap-cron (L4): render the Tier-1 cron-session launcher ONLY when this
+  // agent has a context:fresh entry. No current fleet agent does, so this is
+  // skipped fleet-wide — and the start.sh fork that runs it is empty too.
+  if (context.cronSessionEnabled) {
+    writeIfChanged(
+      join(agentDir, "cron-session.sh"),
+      () => renderTemplate(join(basePath, "cron-session.sh.hbs"), context),
+      created,
+      skipped,
+    );
+    if (existsSync(join(agentDir, "cron-session.sh"))) {
+      chmodSync(join(agentDir, "cron-session.sh"), 0o700);
+    }
   }
 
   writeIfMissing(
@@ -4691,6 +4730,7 @@ export function reconcileAgent(
       // $HOME/.switchroom symlink in start.sh's docker preamble.
       hostHomeQ: process.env.HOME ? shellSingleQuote(process.env.HOME) : undefined,
       modelQ: shellSingleQuote(agentConfig.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL),
+      ...buildCronSessionContext(agentConfig),
       thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
       permissionMode: agentConfig.permission_mode,
       fallbackModelQ: agentConfig.fallback_model
@@ -4759,6 +4799,19 @@ export function reconcileAgent(
       writeFileSync(startShPath, afterStartSh, "utf-8");
       chmodSync(startShPath, 0o755);
       changes.push(startShPath);
+    }
+
+    // Cheap-cron (L4): keep the cron-session launcher in sync on reconcile,
+    // only for agents with a context:fresh entry (none in the fleet today).
+    if (startShContext.cronSessionEnabled) {
+      const cronShPath = join(agentDir, "cron-session.sh");
+      const beforeCronSh = existsSync(cronShPath) ? readFileSync(cronShPath, "utf-8") : "";
+      const afterCronSh = renderTemplate(join(basePath, "cron-session.sh.hbs"), startShContext);
+      if (afterCronSh !== beforeCronSh) {
+        writeFileSync(cronShPath, afterCronSh, "utf-8");
+        chmodSync(cronShPath, 0o755);
+        changes.push(cronShPath);
+      }
     }
   }
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -387,10 +387,13 @@ import { DEFAULT_CRON_MODEL, scheduleNeedsCronSession } from "../scheduler/cron-
 
 /**
  * Cheap-cron (L4) start.sh context. `cronSessionEnabled` is purely
- * config-derived — true iff the agent has a Tier-1 (context:fresh) cron
- * entry — so the start.sh fork block renders EMPTY for every current fleet
- * agent (none have that brand-new field), keeping their boot byte-identical.
- * The runtime SWITCHROOM_CHEAP_CRON flag self-gates inside cron-session.sh.
+ * config-derived — true iff the agent has a schedule entry that routes to the
+ * Tier-1 cron session: an explicit `context: fresh`, OR a cheap (sonnet/haiku)
+ * `model:` with no `context` (which `resolveCronRouting` infers to fresh), OR a
+ * `kind: poll` whose escalation does either. None of those fields exist on any
+ * current fleet config, so the start.sh fork block renders EMPTY for every
+ * current agent, keeping their boot byte-identical. The runtime
+ * SWITCHROOM_CHEAP_CRON flag self-gates again inside cron-session.sh.
  */
 function buildCronSessionContext(agentConfig: AgentConfig): {
   cronSessionEnabled: boolean;

--- a/src/scheduler/cron-routing.ts
+++ b/src/scheduler/cron-routing.ts
@@ -125,3 +125,21 @@ export function resolveEscalationRouting(
 ): CronRouting {
   return resolveCronRouting({ ...input, kind: "prompt" }, opts);
 }
+
+/**
+ * Does this agent's schedule need a Tier-1 cron SESSION spawned? True iff
+ * cheap-cron is on AND ≥1 entry routes (or escalates) to the cron session
+ * (`session: 'cron'`). An agent with only Tier-0 polls that escalate-to-main,
+ * or only Tier-2 entries, needs NO second session — so start.sh / compose
+ * only pay for the cron session where it's actually used (L4).
+ */
+export function scheduleNeedsCronSession(
+  entries: CronRoutingInput[],
+  opts: { cheapCronEnabled: boolean },
+): boolean {
+  if (!opts.cheapCronEnabled) return false;
+  return entries.some((e) => {
+    const r = e.kind === "poll" ? resolveEscalationRouting(e, opts) : resolveCronRouting(e, opts);
+    return r.session === "cron";
+  });
+}

--- a/tests/cheap-cron-session-render.test.ts
+++ b/tests/cheap-cron-session-render.test.ts
@@ -1,0 +1,111 @@
+/**
+ * L4 render safety — docs/rfcs/cheap-cron-sessions.md §2.2.
+ *
+ * The load-bearing property: the cron-session fork in start.sh renders
+ * EMPTY unless `cronSessionEnabled` (a config-derived flag that is false
+ * for every current fleet agent), so adding this feature does not change
+ * any current agent's boot. Plus the cron-session launcher's compliance
+ * (interactive claude, no -p) + correct identity.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { renderTemplate } from "../src/agents/profiles.js";
+import { scheduleNeedsCronSession } from "../src/scheduler/cron-routing.js";
+
+const START_SH = join(__dirname, "..", "profiles", "_base", "start.sh.hbs");
+const CRON_SH = join(__dirname, "..", "profiles", "_base", "cron-session.sh.hbs");
+
+const baseCtx = {
+  name: "marko",
+  agentDir: "/state/agent",
+  securityPluginDir: "/opt/switchroom/security-plugin",
+  useSwitchroomPlugin: true,
+  modelQ: "'claude-sonnet-4-6'",
+  cronModelQ: "'claude-sonnet-4-6'",
+};
+
+// Structural assertion on the template SOURCE (start.sh.hbs uses custom
+// handlebars helpers registered by scaffold, so standalone render isn't
+// representative — mirror gateway-supervisor-backoff.test.ts's raw-source
+// approach). The load-bearing guarantee: every line of the cron fork lives
+// strictly inside a single {{#if cronSessionEnabled}}…{{/if}} block, so the
+// flag-false render is byte-identical to before the feature.
+describe("start.sh cron-session fork — gated by {{#if cronSessionEnabled}}", () => {
+  const src = readFileSync(START_SH, "utf-8");
+
+  it("the fork block exists and references cron-session.sh", () => {
+    expect(src).toContain("cheap cron SESSION");
+    expect(src).toContain("_switchroom_supervise cron-session");
+    expect(src).toContain('bash "$(dirname "$0")/cron-session.sh"');
+  });
+
+  it("EVERY cron-fork line is inside one {{#if cronSessionEnabled}} guard", () => {
+    const lines = src.split("\n");
+    const open = lines.findIndex((l) => l.includes("{{#if cronSessionEnabled}}"));
+    expect(open, "fork guard not found").toBeGreaterThanOrEqual(0);
+    // the matching {{/if}} — the next {{/if}} after open (the block has no nested #if)
+    let close = -1;
+    for (let i = open + 1; i < lines.length; i++) {
+      if (lines[i].includes("{{#if")) throw new Error("unexpected nested #if in cron fork block");
+      if (lines[i].includes("{{/if}}")) { close = i; break; }
+    }
+    expect(close, "fork guard not closed").toBeGreaterThan(open);
+    const block = lines.slice(open, close + 1).join("\n");
+    // all the cron-specific tokens are within the guarded block…
+    expect(block).toContain("cron-session.sh");
+    expect(block).toContain("_switchroom_supervise cron-session");
+    // …and NOT anywhere outside it.
+    const outside = lines.slice(0, open).concat(lines.slice(close + 1)).join("\n");
+    expect(outside).not.toContain("cron-session.sh");
+    expect(outside).not.toContain("cheap cron SESSION");
+  });
+});
+
+describe("cron-session.sh launcher — compliance + identity", () => {
+  const out = renderTemplate(CRON_SH, baseCtx);
+
+  it("is interactive claude — NEVER claude -p (pillar 3)", () => {
+    expect(out).toContain("exec tmux");
+    expect(out).toMatch(/\bclaude\b/);
+    expect(out).not.toMatch(/claude\s+-p\b/);
+    expect(out).not.toContain("--print");
+  });
+
+  it("registers as the cron bridge identity and its own config dir", () => {
+    expect(out).toContain('SWITCHROOM_AGENT_NAME="$CRON_NAME"');
+    expect(out).toContain('CRON_NAME="marko-cron"');
+    expect(out).toContain('CLAUDE_CONFIG_DIR="$CRON_CONFIG_DIR"');
+    expect(out).toContain(".claude-cron");
+  });
+
+  it("runs at the cheap cron model with strict mcp config", () => {
+    expect(out).toContain("--model 'claude-sonnet-4-6'");
+    expect(out).toContain("--strict-mcp-config");
+  });
+
+  it("self-gates on the runtime flag (exit 78, no respawn, when off)", () => {
+    expect(out).toContain("SWITCHROOM_CHEAP_CRON");
+    expect(out).toContain("exit 78");
+  });
+
+  it("shares the broker OAuth creds via symlink (same subscription)", () => {
+    expect(out).toContain(".credentials.json");
+    expect(out).toContain("ln -sfn");
+  });
+});
+
+describe("scheduleNeedsCronSession drives the gate", () => {
+  it("no fresh entry → false (the whole fleet today)", () => {
+    expect(scheduleNeedsCronSession([{ kind: "poll" }, {}], { cheapCronEnabled: true })).toBe(false);
+  });
+  it("a context:fresh entry → true", () => {
+    expect(scheduleNeedsCronSession([{ context: "fresh" }], { cheapCronEnabled: true })).toBe(true);
+  });
+  it("a cheap-model entry → true", () => {
+    expect(scheduleNeedsCronSession([{ model: "sonnet" }], { cheapCronEnabled: true })).toBe(true);
+  });
+  it("flag off → always false", () => {
+    expect(scheduleNeedsCronSession([{ context: "fresh" }], { cheapCronEnabled: false })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The last cheap-cron build piece (after #2244 core + #2245 live-wiring). A
**second interactive `claude`** (no `-p`) in the agent container, dedicated to
Tier-1 (`context: fresh`) cron fires — registering to the gateway as the
`<name>-cron` bridge whose routing + status-silence already landed in #2244. It
gives the *hit* path and non-poll crons a cheap, minimal-context session instead
of the live Opus/Sonnet session.

**Dormant + flag-gated.** `cronSessionEnabled` is purely config-derived — true
iff the agent has a `context: fresh` entry, a brand-new field **no current fleet
agent has** — so the `start.sh` fork block renders **empty** and every current
agent's boot is byte-identical. The runtime `SWITCHROOM_CHEAP_CRON` flag is a
second gate inside the launcher.

## What's in this PR

- **`profiles/_base/cron-session.sh.hbs`** — the launcher. Interactive `claude`
  in its own tmux session/socket, `SWITCHROOM_AGENT_NAME=<name>-cron` (the
  switchroom-telegram bridge reads it from the process env → correct identity),
  own `CLAUDE_CONFIG_DIR` (separate transcript), shares the broker-managed OAuth
  creds via symlink (same subscription). Runtime kill-switch: `exit 78` (no
  respawn) when the flag is off.
- **`start.sh.hbs`** — one `_switchroom_supervise` fork, entirely inside
  `{{#if cronSessionEnabled}}`.
- **`scaffold.ts`** — computes `cronSessionEnabled` (via `scheduleNeedsCronSession`,
  reusing the L1 routing) for both the scaffold and reconcile render paths;
  renders `cron-session.sh` only when enabled.

## Load-bearing safety

The one risk here is the boot path. The structural test asserts **every**
cron-fork line lives inside a single `{{#if cronSessionEnabled}}` guard, and the
existing `start.sh`-render tests (gateway-env-order, reconcile, supervisor-backoff)
confirm the template stays well-formed. A test **caught a real bug** pre-merge: an
explanatory comment that contained a literal handlebars token would have broken
the `start.sh` render fleet-wide — fixed.

## Deliberately v1 (canary-time refinements, RFC §4)

- Reuses the agent's **main `.mcp.json`** (full surface). The bigger wins (fresh
  context + the cheap model) already hold; trimming the MCP to just
  switchroom-telegram is a follow-up.
- **No compose mem/pids bump** — RFC §4 says start at the default cap and bump
  only if the canary shows burst pressure.
- **End-to-end is dormant** — bridge registration / reply delivery / `/clear` for
  the second session need the live canary to validate (you deferred that).

## Test plan

- [x] `tsc --noEmit` clean
- [x] 15 L4 render/gate tests (incl. the byte-identical-when-off guard property)
- [x] existing start.sh-render + cli-contract + mcp-parity suites green (no regression)
- [x] `check-bot-api-wrapping.sh` + `check-plugin-references.mjs` clean
- [ ] **Canary (post-merge, with Tier-0):** an agent with a `context: fresh` cron + flag-on; confirm the `<name>-cron` bridge registers, a fire delivers + replies, and the main session's card/feed stay untouched.

## Compliance / risk

Second session is interactive `claude` (no `-p`); shares the broker OAuth — no
SDK/API key. Flag + config double-gated → dormant fleet-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)