### PR TITLE
feat(docker): bump claude CLI 2.1.168 → 2.1.170 across all images

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.168
+ARG CLAUDE_CODE_VERSION=2.1.170
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -41,7 +41,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.168
+ARG CLAUDE_CODE_VERSION=2.1.170
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 


### PR DESCRIPTION
## Summary
Bump the pinned claude CLI from 2.1.168 to 2.1.170 in both lockstep pins (`docker/Dockerfile.base` → agent/broker/kernel/auth-broker/hostd via FROM base; `docker/Dockerfile.hindsight`).

## Why
Fable 5 (`claude-fable-5[1m]`) is now the fleet default model; the in-container CLI banner recommends 2.1.170+ for it. 2.1.170 is npm `latest`.

## Test plan
- [x] Both pins grep-verified at 2.1.170
- [ ] CI image builds (build-base, build-hindsight, build-dependents ×5) green — the Dockerfile `claude --version` RUN step is the install smoke test
- [ ] Post-release: in-container `claude --version` asserted during fleet roll

## Risk
Low — same shape as the 2.1.159→2.1.168 bump (v0.14.89, canaried clean). Rollback = revert pin.