### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.15.0 — claude CLI 2.1.170 for Fable 5 (#2252)
+
+The fleet default model moved to **Fable 5** (`claude-fable-5[1m]`), and this
+release moves the in-container claude CLI with it.
+
+### claude CLI 2.1.168 → 2.1.170 across all images (#2252)
+
+Both lockstep pins bumped: `docker/Dockerfile.base` (flows to the agent,
+broker, kernel, auth-broker and hostd images via `FROM base`) and
+`docker/Dockerfile.hindsight`. 2.1.170 is the CLI version the Fable 5 banner
+recommends; agents ran Fable fine on 2.1.168, so this is a recommended-floor
+catch-up, not a fix. Rollback is a pin revert.
+
+### Dashboard: resilient connections fetch + always-fresh quota (#2239)
+
+The dashboard's connections panel now tolerates a slow/failed accounts fetch
+without blanking, and quota readings refresh without a manual reload.
+
 ## v0.14.93 — `agent restart` regenerates the compose, so pin bumps apply (#2249)
 
 A `release.pin` bump in `switchroom.yaml` followed by `switchroom agent restart`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.14.93",
+  "version": "0.15.0",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Release **v0.15.0 — claude CLI 2.1.170 for Fable 5**.

Constituent PRs (both already merged + reviewed):
- #2252 — claude CLI 2.1.168 → 2.1.170 across all images (lockstep pins: Dockerfile.base + Dockerfile.hindsight)
- #2239 — dashboard resilient connections fetch + always-fresh quota

## Why
Fleet default model is now `claude-fable-5[1m]`; 2.1.170 is the CLI floor its banner recommends. Minor-version bump (.15) per operator directive.

## Test plan
- [x] `node scripts/build.mjs` exit 0, `dist/cli/switchroom.js` ~3.1MB
- [ ] CI green
- [ ] Post-tag: docker-images workflow, npm publish with tarball verification, staggered fleet roll with in-container `claude --version` assertion

## Risk
Low — version/CHANGELOG only; constituent PRs individually reviewed.