### PR TITLE
fix(quota-watch): fleet dedup + staleness gate + never send unverified numbers

### DIFF
--- a/src/auth/broker/client.ts
+++ b/src/auth/broker/client.ts
@@ -241,6 +241,11 @@ export interface RefreshAccountData {
   expiresAt?: number;
 }
 
+export interface ClaimNotificationData {
+  /** True for the first claimant of the key inside the window. */
+  granted: boolean;
+}
+
 export interface AddAccountData {
   label: string;
   expiresAt?: number;
@@ -471,6 +476,25 @@ export class AuthBrokerClient {
       : { v: PROTOCOL_VERSION, id: randomUUID(), op: "mark-exhausted" };
     const data = await this.send(req);
     return data as MarkExhaustedData;
+  }
+
+  /**
+   * Fleet notification-dedup claim. Returns `granted: true` only for
+   * the first caller of `key` within `windowMs` — the winner sends the
+   * notification, everyone else stays silent. Callers should FAIL OPEN
+   * on error (send anyway): a broker that predates this op rejects the
+   * request at the protocol layer, and duplicated notifications beat
+   * silently dropped ones during a skewed rollout.
+   */
+  async claimNotification(key: string, windowMs: number): Promise<ClaimNotificationData> {
+    const data = await this.send({
+      v: PROTOCOL_VERSION,
+      id: randomUUID(),
+      op: "claim-notification",
+      key,
+      windowMs,
+    });
+    return data as ClaimNotificationData;
   }
 
   async refreshAccount(account: string): Promise<RefreshAccountData> {

--- a/src/auth/broker/protocol.ts
+++ b/src/auth/broker/protocol.ts
@@ -341,6 +341,36 @@ export const ProbeQuotaRequestSchema = z.object({
   timeoutMs: z.number().int().positive().max(60_000).optional(),
 });
 
+/**
+ * Fleet-wide notification dedup claim (#E4 follow-up — quota-watch
+ * de-duplication). Every agent gateway independently runs the same
+ * watchers (quota-watch, fleet all-exhausted) over the same shared
+ * account pool, so a single transition used to fan out one Telegram
+ * message PER AGENT (×11 on a full fleet). The broker — already the
+ * fleet's shared singleton — arbitrates: the first caller to claim a
+ * `key` within `windowMs` is granted (and should send); everyone else
+ * is denied (and should stay silent but still update local state).
+ *
+ * Keys are caller-defined, e.g.
+ * `quota-watch:<account>:<transition>:<chatId>` — per-chat keys keep
+ * the audience identical to the pre-dedup behaviour (every chat any
+ * agent would have notified still gets exactly one copy).
+ *
+ * ACL: same posture as `list-state` — no identity restriction. A
+ * denied claim is `granted: false`, never an error. Claims are
+ * persisted (`notification-claims.json`) so a broker restart inside
+ * the window does not re-open the gate.
+ */
+export const ClaimNotificationRequestSchema = z.object({
+  v: z.literal(PROTOCOL_VERSION),
+  op: z.literal("claim-notification"),
+  id: z.string().min(1),
+  /** Dedup key. Caller-namespaced (e.g. "quota-watch:<acct>:<edge>:<chat>"). */
+  key: z.string().min(1).max(512),
+  /** Deny subsequent claims for the same key for this long. */
+  windowMs: z.number().int().positive().max(86_400_000),
+});
+
 export const RequestSchema = z.discriminatedUnion("op", [
   GetCredentialsRequestSchema,
   ListStateRequestSchema,
@@ -353,6 +383,7 @@ export const RequestSchema = z.discriminatedUnion("op", [
   ListGoogleAccountsRequestSchema,
   ListMicrosoftAccountsRequestSchema,
   ProbeQuotaRequestSchema,
+  ClaimNotificationRequestSchema,
 ]);
 
 export type Request = z.infer<typeof RequestSchema>;
@@ -425,6 +456,11 @@ export const RmAccountDataSchema = z.object({
 export const SetOverrideDataSchema = z.object({
   agent: z.string(),
   account: z.string().nullable(),
+});
+
+export const ClaimNotificationDataSchema = z.object({
+  /** True for the first claimant inside the window — only they send. */
+  granted: z.boolean(),
 });
 
 /**

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -2270,3 +2270,157 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     broker.stop();
   });
 });
+
+describe("AuthBroker — claim-notification (fleet notification dedup)", () => {
+  function makeClaimBroker(h: Harness, fakeNow: () => number): AuthBroker {
+    const config = makeConfig(h, {
+      active: "default",
+      agents: { ziggy: {}, klanker: {} },
+    });
+    seedAccount(h, "default");
+    mkdirSync(join(h.agentsDir, "ziggy"), { recursive: true });
+    mkdirSync(join(h.agentsDir, "klanker"), { recursive: true });
+    return new AuthBroker(config, {
+      home: h.home,
+      stateDir: h.stateDir,
+      socketRoot: h.socketRoot,
+      disableRefreshLoop: true,
+      now: fakeNow,
+    });
+  }
+
+  it("grants the first claimant and denies the second inside the window — across agents", async () => {
+    const h = makeHarness();
+    let t = 1_000_000;
+    const broker = makeClaimBroker(h, () => t);
+    await broker.start();
+    const key = "quota-watch:acct@example.com:recovered-to-healthy:12345";
+    // ziggy (non-admin) claims first → granted. No ACL on this op.
+    const first = await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1, id: "1", op: "claim-notification", key, windowMs: 30 * 60_000,
+    }) as { ok: boolean; data: { granted: boolean } };
+    expect(first.ok).toBe(true);
+    expect(first.data.granted).toBe(true);
+    // klanker claims the SAME key 5 minutes later → denied.
+    t += 5 * 60_000;
+    const second = await rpc(join(h.socketRoot, "klanker", "sock"), {
+      v: 1, id: "2", op: "claim-notification", key, windowMs: 30 * 60_000,
+    }) as { ok: boolean; data: { granted: boolean } };
+    expect(second.ok).toBe(true);
+    expect(second.data.granted).toBe(false);
+    broker.stop();
+  });
+
+  it("a different key (other chat / other transition) is independent", async () => {
+    const h = makeHarness();
+    const broker = makeClaimBroker(h, () => 1_000_000);
+    await broker.start();
+    const sock = join(h.socketRoot, "ziggy", "sock");
+    const a = await rpc(sock, {
+      v: 1, id: "1", op: "claim-notification",
+      key: "quota-watch:acct@example.com:recovered-to-healthy:111", windowMs: 60_000,
+    }) as { ok: boolean; data: { granted: boolean } };
+    const b = await rpc(sock, {
+      v: 1, id: "2", op: "claim-notification",
+      key: "quota-watch:acct@example.com:recovered-to-healthy:222", windowMs: 60_000,
+    }) as { ok: boolean; data: { granted: boolean } };
+    const c = await rpc(sock, {
+      v: 1, id: "3", op: "claim-notification",
+      key: "quota-watch:acct@example.com:entered-throttling:111", windowMs: 60_000,
+    }) as { ok: boolean; data: { granted: boolean } };
+    expect(a.data.granted).toBe(true);
+    expect(b.data.granted).toBe(true); // other chat
+    expect(c.data.granted).toBe(true); // other edge direction
+    broker.stop();
+  });
+
+  it("re-grants the same key after the window expires", async () => {
+    const h = makeHarness();
+    let t = 1_000_000;
+    const broker = makeClaimBroker(h, () => t);
+    await broker.start();
+    const sock = join(h.socketRoot, "ziggy", "sock");
+    const key = "quota-watch:acct@example.com:entered-throttling:12345";
+    const first = await rpc(sock, {
+      v: 1, id: "1", op: "claim-notification", key, windowMs: 30 * 60_000,
+    }) as { ok: boolean; data: { granted: boolean } };
+    expect(first.data.granted).toBe(true);
+    // 29 min later: still inside the window → denied.
+    t += 29 * 60_000;
+    const inside = await rpc(sock, {
+      v: 1, id: "2", op: "claim-notification", key, windowMs: 30 * 60_000,
+    }) as { ok: boolean; data: { granted: boolean } };
+    expect(inside.data.granted).toBe(false);
+    // Another 2 min (31 total since grant): window expired → granted again
+    // (a genuine re-crossing of the same edge re-notifies).
+    t += 2 * 60_000;
+    const after = await rpc(sock, {
+      v: 1, id: "3", op: "claim-notification", key, windowMs: 30 * 60_000,
+    }) as { ok: boolean; data: { granted: boolean } };
+    expect(after.data.granted).toBe(true);
+    broker.stop();
+  });
+
+  it("claims persist across a broker restart (window survives the bounce)", async () => {
+    const h = makeHarness();
+    let t = 1_000_000;
+    const broker1 = makeClaimBroker(h, () => t);
+    await broker1.start();
+    const key = "quota-watch:acct@example.com:recovered-to-healthy:12345";
+    const first = await rpc(join(h.socketRoot, "ziggy", "sock"), {
+      v: 1, id: "1", op: "claim-notification", key, windowMs: 30 * 60_000,
+    }) as { ok: boolean; data: { granted: boolean } };
+    expect(first.data.granted).toBe(true);
+    broker1.stop();
+    // On-disk file exists with the key.
+    const onDisk = JSON.parse(readFileSync(join(h.stateDir, "notification-claims.json"), "utf-8"));
+    expect(onDisk[key]).toBe(1_000_000);
+    // New broker process, 5 min later (fleet bounce mid-window): still denied.
+    t += 5 * 60_000;
+    const broker2 = makeClaimBroker(h, () => t);
+    await broker2.start();
+    const second = await rpc(join(h.socketRoot, "klanker", "sock"), {
+      v: 1, id: "2", op: "claim-notification", key, windowMs: 30 * 60_000,
+    }) as { ok: boolean; data: { granted: boolean } };
+    expect(second.data.granted).toBe(false);
+    broker2.stop();
+  });
+
+  it("prunes entries older than 24h on the next grant (file stays bounded)", async () => {
+    const h = makeHarness();
+    let t = 1_000_000;
+    const broker = makeClaimBroker(h, () => t);
+    await broker.start();
+    const sock = join(h.socketRoot, "ziggy", "sock");
+    const oldKey = "quota-watch:acct@example.com:entered-throttling:111";
+    await rpc(sock, { v: 1, id: "1", op: "claim-notification", key: oldKey, windowMs: 60_000 });
+    // 25 hours later, a new grant triggers the prune sweep.
+    t += 25 * 60 * 60_000;
+    await rpc(sock, {
+      v: 1, id: "2", op: "claim-notification",
+      key: "quota-watch:acct@example.com:entered-throttling:222", windowMs: 60_000,
+    });
+    const onDisk = JSON.parse(readFileSync(join(h.stateDir, "notification-claims.json"), "utf-8"));
+    expect(onDisk[oldKey]).toBeUndefined();
+    expect(Object.keys(onDisk)).toHaveLength(1);
+    broker.stop();
+  });
+
+  it("two concurrent claims for the same key yield exactly one grant", async () => {
+    const h = makeHarness();
+    const broker = makeClaimBroker(h, () => 1_000_000);
+    await broker.start();
+    const key = "quota-watch:acct@example.com:recovered-to-healthy:999";
+    const [a, b] = await Promise.all([
+      rpc(join(h.socketRoot, "ziggy", "sock"), {
+        v: 1, id: "1", op: "claim-notification", key, windowMs: 60_000,
+      }),
+      rpc(join(h.socketRoot, "klanker", "sock"), {
+        v: 1, id: "2", op: "claim-notification", key, windowMs: 60_000,
+      }),
+    ]) as Array<{ ok: boolean; data: { granted: boolean } }>;
+    const grants = [a, b].filter((r) => r.data.granted).length;
+    expect(grants).toBe(1);
+    broker.stop();
+  });
+});

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -142,6 +142,19 @@ interface QuotaState {
 }
 
 /**
+ * Fleet notification-dedup claims (`claim-notification` op): dedup key →
+ * unix-ms of the last GRANTED claim. Entries older than the largest
+ * permitted window (24h) are pruned on every grant so the file stays
+ * bounded. Persisted as `notification-claims.json`.
+ */
+interface NotificationClaims {
+  [key: string]: number;
+}
+
+/** Hard ceiling on claim retention — matches the protocol's max windowMs. */
+const NOTIFICATION_CLAIM_MAX_AGE_MS = 86_400_000;
+
+/**
  * Per-account cached utilization snapshot, written after each successful
  * `opProbeQuota` call. Consumed by `opListState` so callers (quota-watch
  * loop) can classify account health without triggering a live probe.
@@ -301,6 +314,9 @@ export class AuthBroker {
   private lastQuotaCache: LastQuotaCache = {};
   private shaIndex: ShaIndex = {};
   private thresholdViolations: ThresholdViolations = {};
+  /** Fleet notification-dedup claims: key → unix-ms of last grant.
+   *  Persisted so a broker restart inside the window stays closed. */
+  private notificationClaims: NotificationClaims = {};
   /** Last `expiresAt` the broker wrote per label — drives threshold-violation. */
   private lastWrittenExpiresAt = new Map<string, number | undefined>();
   /** Refresh leases held while a POST is in flight (in-process). */
@@ -936,6 +952,9 @@ export class AuthBroker {
             req.timeoutMs,
           );
           break;
+        case "claim-notification":
+          this.opClaimNotification(socket, reqId, identity, req.key, req.windowMs);
+          break;
       }
     } catch (err) {
       socket.write(
@@ -1341,6 +1360,40 @@ export class AuthBroker {
     const rolledTo = this.nextHealthyAccount(account, this.config.auth?.fallback_order ?? []);
     this.audit({ op: "mark-exhausted", identity, account, ok: true });
     socket.write(encodeSuccess(id, { account, rolled, rolledTo }));
+  }
+
+  /**
+   * Fleet notification-dedup claim. Grants the FIRST caller of a given
+   * `key` inside `windowMs`; everyone else is denied. The check-and-set
+   * is fully synchronous (no awaits), so two agents racing the same key
+   * serialize on the event loop — exactly one grant per window, by
+   * construction.
+   *
+   * Audit: granted claims only. Denials are the designed common case
+   * (N-1 of N agents per event) — auditing them would re-create the
+   * very log spam this op exists to remove.
+   */
+  private opClaimNotification(
+    socket: net.Socket,
+    id: string,
+    identity: Identity,
+    key: string,
+    windowMs: number,
+  ): void {
+    const now = this.now();
+    const prev = this.notificationClaims[key];
+    const granted = prev === undefined || now - prev >= windowMs;
+    if (granted) {
+      this.notificationClaims[key] = now;
+      // Prune anything past the protocol's max window so the file stays
+      // bounded by the set of keys active in the last 24h.
+      for (const [k, ts] of Object.entries(this.notificationClaims)) {
+        if (now - ts > NOTIFICATION_CLAIM_MAX_AGE_MS) delete this.notificationClaims[k];
+      }
+      this.persistNotificationClaims();
+      this.audit({ op: "claim-notification", identity, account: key, ok: true });
+    }
+    socket.write(encodeSuccess(id, { granted }));
   }
 
   private async opRefreshAccount(
@@ -2358,6 +2411,7 @@ export class AuthBroker {
     this.quota = this.readJson<QuotaState>("quota.json") ?? {};
     this.shaIndex = this.readJson<ShaIndex>("sha-index.json") ?? {};
     this.thresholdViolations = this.readJson<ThresholdViolations>("threshold-violations.json") ?? {};
+    this.notificationClaims = this.readJson<NotificationClaims>("notification-claims.json") ?? {};
   }
 
   private readJson<T>(name: string): T | null {
@@ -2367,6 +2421,7 @@ export class AuthBroker {
   }
 
   private persistQuota(): void { atomicWriteJsonSync(join(this.stateDir, "quota.json"), this.quota, 0o600); }
+  private persistNotificationClaims(): void { atomicWriteJsonSync(join(this.stateDir, "notification-claims.json"), this.notificationClaims, 0o600); }
   private persistShaIndex(): void { atomicWriteJsonSync(join(this.stateDir, "sha-index.json"), this.shaIndex, 0o600); }
   private persistThresholdViolations(): void { atomicWriteJsonSync(join(this.stateDir, "threshold-violations.json"), this.thresholdViolations, 0o600); }
 

--- a/telegram-plugin/auth-snapshot-format.ts
+++ b/telegram-plugin/auth-snapshot-format.ts
@@ -43,6 +43,11 @@ export interface AccountSnapshot {
   /** Mirrors the broker's `expiresAt` so the table can show token-life
    *  for accounts whose creds are about to expire. */
   expiresAtMs?: number;
+  /** Unix ms when `quota` was captured. Set for CACHED snapshots
+   *  (`buildSnapshotsFromCachedState`) so consumers can refuse to treat
+   *  stale data as current; undefined for live-probe snapshots (fresh
+   *  by construction). */
+  capturedAtMs?: number;
 }
 
 // ── health classification ────────────────────────────────────────────
@@ -653,6 +658,10 @@ export function buildSnapshotsFromCachedState(
       quota: reviveLastQuota(lq),
       quotaError: lq ? undefined : 'no cached quota (no probe since broker start)',
       expiresAtMs: acc.expiresAt,
+      // Surface the cache age so quota-watch can refuse to classify off
+      // stale data (the 2026-06-09 incident: a recovery latched days
+      // earlier only surfaced — and notified — at the next fleet bounce).
+      capturedAtMs: lq?.capturedAt,
     };
   });
 }

--- a/telegram-plugin/gateway/auth-broker-client.ts
+++ b/telegram-plugin/gateway/auth-broker-client.ts
@@ -34,6 +34,8 @@ export function createAuthBrokerClient(): {
       broker.setOverride(agent, account),
     probeQuota: (accounts: readonly string[], timeoutMs?: number) =>
       broker.probeQuota(accounts, timeoutMs),
+    claimNotification: (key: string, windowMs: number) =>
+      broker.claimNotification(key, windowMs),
   }
   return { client, close: () => broker.close() }
 }

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -238,6 +238,13 @@ export interface AuthBrokerClient {
     accounts: readonly string[],
     timeoutMs?: number,
   ): Promise<{ results: Array<{ label: string; result: import('../quota-check.js').QuotaResult }> }>
+  /**
+   * Fleet notification-dedup claim (quota-watch). First caller of `key`
+   * inside `windowMs` gets `granted: true` and sends; everyone else
+   * stays silent. Callers fail OPEN on error (skewed-rollout brokers
+   * reject the op at the protocol layer).
+   */
+  claimNotification(key: string, windowMs: number): Promise<{ granted: boolean }>
 }
 
 export interface AuthCommandContext {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -422,6 +422,9 @@ import {
   saveQuotaWatchState,
   patchQuotaWatchState,
   emptyAccountState,
+  resolveQuotaWatchTuning,
+  buildQuotaClaimKey,
+  QUOTA_WATCH_CLAIM_WINDOW_MS,
 } from '../quota-watch.js'
 import { buildSnapshotsFromState, buildSnapshotsFromCachedState } from '../auth-snapshot-format.js'
 import {
@@ -14969,9 +14972,34 @@ async function runCreditWatch(): Promise<void> {
  * State persists across restarts via `<stateDir>/quota-watch.json`.
  * Mirrors runCreditWatch's structure and notification routing.
  */
-async function runQuotaWatch(): Promise<void> {
+
+/**
+ * Ask the broker for the fleet-wide dedup claim on one notification key.
+ * FAIL-OPEN on any error: a broker that predates the `claim-notification`
+ * op (skewed rollout) rejects at the protocol layer, and a transient IPC
+ * failure must degrade to duplicated notifications, never dropped ones.
+ */
+async function claimQuotaNotification(
+  brokerClient: NonNullable<Awaited<ReturnType<typeof getAuthBrokerClient>>>,
+  key: string,
+): Promise<boolean> {
+  try {
+    const res = await brokerClient.claimNotification(key, QUOTA_WATCH_CLAIM_WINDOW_MS)
+    return res.granted
+  } catch (err) {
+    process.stderr.write(`telegram gateway: quota-watch: claim failed (fail-open): ${err}\n`)
+    return true
+  }
+}
+
+async function runQuotaWatch(opts: { bootTick?: boolean } = {}): Promise<void> {
   const agentName = getMyAgentName()
   const stateDir = STATE_DIR
+  const bootTick = opts.bootTick ?? false
+  // Hardening knobs (2026-06-09 incident: fleet bounce released stale
+  // recovery latches on all 11 agents at once → 26 duplicate sends).
+  // See QuotaWatchTuning in quota-watch.ts for the env contract.
+  const tuning = resolveQuotaWatchTuning(process.env)
 
   // Read broker state. The listState response now includes last_quota
   // per account — the broker's in-memory cache from previous probeQuota
@@ -15019,6 +15047,20 @@ async function runQuotaWatch(): Promise<void> {
     })
     if (fleetDecision.kind === 'notify') {
       for (const chat_id of access.allowFrom) {
+        // Fleet-level dedup: all 11 gateways detect this same edge within
+        // one poll cycle — only the broker-claim winner sends per chat.
+        if (tuning.fleetDedup) {
+          const granted = await claimQuotaNotification(
+            brokerClient,
+            buildQuotaClaimKey(FLEET_ALL_EXHAUSTED_KEY, fleetDecision.transition, chat_id),
+          )
+          if (!granted) {
+            process.stderr.write(
+              `telegram gateway: quota-watch: fleet-all-exhausted claim denied chat=${chat_id} — another agent notified\n`,
+            )
+            continue
+          }
+        }
         await swallowingApiCall(
           () =>
             bot.api.sendMessage(chat_id, fleetDecision.message, {
@@ -15056,10 +15098,21 @@ async function runQuotaWatch(): Promise<void> {
     snapshots.map((s, i) => [s.label, i]),
   )
 
+  // Reconciled transitions: state advances (latch clears) but nothing is
+  // sent — boot-tick and late recoveries (see QuotaWatchDecision docs).
+  let reconciledCount = 0
+  let mutatedState = watchState
+
   for (const snap of snapshots) {
     const prev = watchState[snap.label] ?? emptyAccountState()
-    const decision = evaluateQuotaWatchAccount({ agentName, snap, prev, now })
-    if (decision.kind !== 'skip') {
+    const decision = evaluateQuotaWatchAccount({ agentName, snap, prev, now, bootTick, tuning })
+    if (decision.kind === 'reconcile') {
+      mutatedState = patchQuotaWatchState(mutatedState, decision.accountLabel, decision.newAccountState)
+      reconciledCount++
+      process.stderr.write(
+        `telegram gateway: quota-watch: reconciled ${decision.transition} for account=${decision.accountLabel} (${decision.reason}) — no notification\n`,
+      )
+    } else if (decision.kind !== 'skip') {
       pendingTransitions.push({
         accountLabel: snap.label,
         snapIndex: labelToSnapIndex.get(snap.label) ?? -1,
@@ -15069,7 +15122,16 @@ async function runQuotaWatch(): Promise<void> {
   }
 
   if (pendingTransitions.length === 0) {
-    return // Steady-state: no notifications, no probes, no state write.
+    // Steady-state: no notifications, no probes. Persist only if a
+    // reconcile advanced the latch (otherwise no state write at all).
+    if (reconciledCount > 0) {
+      try {
+        saveQuotaWatchState(stateDir, mutatedState)
+      } catch (err) {
+        process.stderr.write(`telegram gateway: quota-watch state persist failed: ${err}\n`)
+      }
+    }
+    return
   }
 
   // Transition detected: probe ONLY the crossing accounts to get fresh
@@ -15083,16 +15145,31 @@ async function runQuotaWatch(): Promise<void> {
       freshProbeMap.set(entry.label, entry.result)
     }
   } catch (err) {
-    // Probe failed — still send notifications using cached data.
-    // Don't abort: the user should know about the threshold crossing
-    // even if the message body shows slightly stale numbers.
     process.stderr.write(`telegram gateway: quota-watch: probe for crossing accounts failed: ${err}\n`)
+    if (!tuning.sendOnProbeFail) {
+      // A quota notification must never carry numbers we could not verify
+      // live. Leave the crossing accounts' state untouched — the
+      // transition re-evaluates (and re-probes) on the next 15-min tick.
+      // Persist any reconciles already applied, then bail.
+      if (reconciledCount > 0) {
+        try {
+          saveQuotaWatchState(stateDir, mutatedState)
+        } catch (saveErr) {
+          process.stderr.write(`telegram gateway: quota-watch state persist failed: ${saveErr}\n`)
+        }
+      }
+      process.stderr.write(
+        `telegram gateway: quota-watch: deferring ${pendingTransitions.length} notification(s) until probe succeeds\n`,
+      )
+      return
+    }
+    // Legacy (SWITCHROOM_QUOTA_WATCH_SEND_ON_PROBE_FAIL=1): fall through
+    // and send from cached data.
   }
 
   // Build final notifications, enriching the snapshot with fresh probe
   // data where available.
-  let mutatedState = watchState
-  const notifications: Array<{ message: string; accountLabel: string }> = []
+  const notifications: Array<{ message: string; accountLabel: string; transition: string }> = []
 
   for (const { accountLabel, snapIndex, decision } of pendingTransitions) {
     // Re-evaluate with fresh probe data to get an accurate message body.
@@ -15100,37 +15177,88 @@ async function runQuotaWatch(): Promise<void> {
     const freshResult = freshProbeMap.get(accountLabel)
     let enrichedDecision = decision
     // pendingTransitions only ever holds notify decisions (pushed under
-    // `decision.kind !== 'skip'`). Narrow explicitly so `decision.transition`
-    // type-checks below; this continue never fires at runtime.
+    // `decision.kind !== 'skip'` / `!== 'reconcile'`). Narrow explicitly so
+    // `decision.transition` type-checks below; this continue never fires
+    // at runtime.
     if (decision.kind !== 'notify') continue
     if (freshResult && freshResult.ok && snapIndex >= 0) {
-      const enrichedSnap = { ...snapshots[snapIndex]!, quota: freshResult.data }
+      // Live numbers replace the cache — and capturedAtMs is cleared so the
+      // staleness gate never misfires on data we JUST probed.
+      const enrichedSnap = { ...snapshots[snapIndex]!, quota: freshResult.data, capturedAtMs: undefined }
       const prev = watchState[accountLabel] ?? emptyAccountState()
-      const re = evaluateQuotaWatchAccount({ agentName, snap: enrichedSnap, prev, now })
+      const re = evaluateQuotaWatchAccount({ agentName, snap: enrichedSnap, prev, now, bootTick, tuning })
       // If the fresh probe still shows the same transition, use the
       // enriched message. If it no longer shows a transition (e.g. the
       // account recovered in the 100ms between listState and probe),
       // fall through to skip this notification.
       if (re.kind === 'notify' && re.transition === decision.transition) {
         enrichedDecision = re
+      } else if (re.kind === 'reconcile') {
+        // Fresh data confirms the transition but it isn't news (boot-tick /
+        // late recovery) — advance the latch silently.
+        mutatedState = patchQuotaWatchState(mutatedState, accountLabel, re.newAccountState)
+        reconciledCount++
+        process.stderr.write(
+          `telegram gateway: quota-watch: reconciled ${re.transition} for account=${accountLabel} (${re.reason}) — no notification\n`,
+        )
+        continue
       } else if (re.kind === 'skip') {
         // State normalised by the time of the probe — don't notify.
         continue
       }
+    } else if (!tuning.sendOnProbeFail) {
+      // No verified fresh data for this account (per-account probe failure
+      // or label missing from the batch result). Same rule as the batch
+      // throw above: never send unverified numbers. State untouched —
+      // re-evaluated (and re-probed) next tick.
+      process.stderr.write(
+        `telegram gateway: quota-watch: probe unavailable for account=${accountLabel} — deferring notification\n`,
+      )
+      continue
     }
 
     if (enrichedDecision.kind !== 'notify') continue
-    notifications.push({ message: enrichedDecision.message, accountLabel })
+    notifications.push({
+      message: enrichedDecision.message,
+      accountLabel,
+      transition: enrichedDecision.transition,
+    })
     mutatedState = patchQuotaWatchState(mutatedState, accountLabel, enrichedDecision.newAccountState)
   }
 
   if (notifications.length === 0) {
-    return // All transitions resolved by the time of the live probe.
+    // All transitions resolved/deferred by the time of the live probe.
+    // Reconciles may still have advanced the latch — persist those.
+    if (reconciledCount > 0) {
+      try {
+        saveQuotaWatchState(stateDir, mutatedState)
+      } catch (err) {
+        process.stderr.write(`telegram gateway: quota-watch state persist failed: ${err}\n`)
+      }
+    }
+    return
   }
 
   // Send all notifications (one message per crossing account).
-  for (const { message, accountLabel } of notifications) {
+  for (const { message, accountLabel, transition } of notifications) {
     for (const chat_id of access.allowFrom) {
+      // Fleet-level dedup: every agent gateway independently detects the
+      // same account transition within one poll cycle. The broker claim
+      // grants exactly one sender per (account, transition, chat) per
+      // window — the other ten agents advance their local state silently.
+      // Fail-open on claim error (see claimQuotaNotification).
+      if (tuning.fleetDedup) {
+        const granted = await claimQuotaNotification(
+          brokerClient,
+          buildQuotaClaimKey(accountLabel, transition, chat_id),
+        )
+        if (!granted) {
+          process.stderr.write(
+            `telegram gateway: quota-watch: claim denied account=${accountLabel} chat=${chat_id} — another agent notified\n`,
+          )
+          continue
+        }
+      }
       // Quota-watch notify — best-effort. Wrap via swallowingApiCall so
       // flood-wait / deleted-chat / not-found surface as a stderr log
       // rather than a thrown exception that aborts the loop and leaves
@@ -20453,7 +20581,12 @@ void (async () => {
           // settle after boot (avoids a probe race with the boot-card
           // quota probe that fires in the first few seconds).
           setTimeout(() => {
-            void runQuotaWatch().catch((err) => {
+            // bootTick: recovery edges observed on the FIRST post-boot tick
+            // reconcile silently — a fleet bounce synchronizes all agents'
+            // first ticks, and a just-booted gateway can't tell "just
+            // recovered" from "recovered while we were down" (the
+            // 2026-06-09 26-message flood). Warnings still notify.
+            void runQuotaWatch({ bootTick: true }).catch((err) => {
               process.stderr.write(`telegram gateway: quota-watch initial run failed: ${err}\n`)
             })
           }, 30_000)

--- a/telegram-plugin/quota-watch.ts
+++ b/telegram-plugin/quota-watch.ts
@@ -73,6 +73,76 @@ export function emptyAccountState(): QuotaWatchAccountState {
   return { lastNotifiedHealth: null, lastNotifiedAt: 0 };
 }
 
+// ─── Tuning (env knobs) ───────────────────────────────────────────────────────
+
+/**
+ * Operational tuning for the watch loop, resolved once from env by the
+ * gateway. All three hardening behaviours are individually
+ * kill-switchable (incident 2026-06-09: a fleet bounce released
+ * days-stale recovery latches on all 11 agents at once → 26 duplicate
+ * 🟢 messages in 16 minutes):
+ *
+ *   SWITCHROOM_QUOTA_WATCH_MAX_STALE_MS      0 disables the staleness gate
+ *                                            (default 60 min)
+ *   SWITCHROOM_QUOTA_WATCH_LATE_RECOVERY_MS  0 disables silent late-recovery
+ *                                            reconciliation (default 6 h)
+ *   SWITCHROOM_QUOTA_WATCH_FLEET_DEDUP       "0" disables the broker claim
+ *                                            (every agent sends, pre-incident
+ *                                            behaviour)
+ *   SWITCHROOM_QUOTA_WATCH_SEND_ON_PROBE_FAIL "1" restores sending from
+ *                                            cached data when the pre-send
+ *                                            validation probe fails
+ */
+export interface QuotaWatchTuning {
+  /** Cached snapshots older than this are treated as unknown (no opinion). 0 = off. */
+  maxStaleMs: number;
+  /** Recovery edges whose 🟡 warning is older than this reconcile silently. 0 = off. */
+  lateRecoveryMs: number;
+  /** Route sends through the broker's claim-notification dedup. */
+  fleetDedup: boolean;
+  /** Legacy: send from cached data when the validation probe fails. */
+  sendOnProbeFail: boolean;
+}
+
+export const DEFAULT_QUOTA_WATCH_MAX_STALE_MS = 60 * 60_000;
+export const DEFAULT_QUOTA_WATCH_LATE_RECOVERY_MS = 6 * 60 * 60_000;
+
+/** Broker claim window. Must exceed one full poll cycle (15 min) plus the
+ *  boot-stagger spread so every agent's observation of the SAME edge lands
+ *  inside one window; an account genuinely re-crossing the same edge later
+ *  than this re-notifies. */
+export const QUOTA_WATCH_CLAIM_WINDOW_MS = 30 * 60_000;
+
+export function resolveQuotaWatchTuning(
+  env: Record<string, string | undefined>,
+): QuotaWatchTuning {
+  const num = (raw: string | undefined, fallback: number): number => {
+    if (raw === undefined || raw === "") return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? n : fallback;
+  };
+  return {
+    maxStaleMs: num(env.SWITCHROOM_QUOTA_WATCH_MAX_STALE_MS, DEFAULT_QUOTA_WATCH_MAX_STALE_MS),
+    lateRecoveryMs: num(env.SWITCHROOM_QUOTA_WATCH_LATE_RECOVERY_MS, DEFAULT_QUOTA_WATCH_LATE_RECOVERY_MS),
+    fleetDedup: env.SWITCHROOM_QUOTA_WATCH_FLEET_DEDUP !== "0",
+    sendOnProbeFail: env.SWITCHROOM_QUOTA_WATCH_SEND_ON_PROBE_FAIL === "1",
+  };
+}
+
+/**
+ * Broker dedup-claim key for one (account, transition, chat) cell.
+ * Per-CHAT keys keep the audience identical to pre-dedup behaviour:
+ * every chat that any agent would have notified still receives exactly
+ * one copy — from whichever agent claims it first.
+ */
+export function buildQuotaClaimKey(
+  accountLabel: string,
+  transition: string,
+  chatId: string | number,
+): string {
+  return `quota-watch:${accountLabel}:${transition}:${chatId}`;
+}
+
 // ─── Decision logic ───────────────────────────────────────────────────────────
 
 export type QuotaWatchTransition =
@@ -87,30 +157,73 @@ export type QuotaWatchDecision =
       newAccountState: QuotaWatchAccountState;
       transition: QuotaWatchTransition;
     }
+  | {
+      /**
+       * A real transition was observed, but it is no longer NEWS — persist
+       * the new state so the edge-trigger latch clears, send nothing.
+       * Two producers: boot-tick recoveries (a just-booted gateway cannot
+       * distinguish "just recovered" from "recovered while we were down",
+       * and fleet bounces synchronize all agents' first ticks → flood) and
+       * late recoveries (the matching 🟡 is hours old; an "all clear" now
+       * is state reconciliation, not information).
+       */
+      kind: "reconcile";
+      accountLabel: string;
+      newAccountState: QuotaWatchAccountState;
+      transition: QuotaWatchTransition;
+      reason: "boot-tick-recovery" | "late-recovery";
+    }
   | { kind: "skip"; accountLabel: string; reason: string };
 
 /**
  * Evaluate one account's quota state against its last-notified health.
  *
- * Transition table:
+ * Transition table (after the staleness gate — a cached snapshot older
+ * than `maxStaleMs` is no opinion at all → skip "stale-snapshot"):
  *   healthy → healthy        skip (steady-state)
- *   healthy → throttling     notify (entered-throttling)
+ *   healthy → throttling     notify (entered-throttling) — warnings are
+ *                            level-state news, valid on any tick incl. boot
  *   healthy → blocked        skip (credits-watch covers this)
- *   throttling → healthy     notify (recovered-to-healthy)
+ *   throttling → healthy     notify (recovered-to-healthy), EXCEPT:
+ *                              boot tick           → reconcile silently
+ *                              warning > lateRecoveryMs old → reconcile silently
  *   throttling → throttling  skip (already notified)
  *   throttling → blocked     skip (credits-watch covers blocked)
  *   blocked → *              skip (credits-watch domain)
  *   unknown → *              skip (no quota data — don't spam)
  *   * → unknown              skip (probe failed — transient, don't alarm)
+ *
+ * `bootTick` / `tuning` are optional: omitted (legacy callers/tests) the
+ * behaviour is exactly the pre-hardening table (no stale gate, no
+ * reconciliation).
  */
 export function evaluateQuotaWatchAccount(args: {
   agentName: string;
   snap: AccountSnapshot;
   prev: QuotaWatchAccountState;
   now: number;
+  /** True on the gateway's first watch tick after boot. */
+  bootTick?: boolean;
+  /** Staleness / late-recovery thresholds; 0 disables each. */
+  tuning?: Pick<QuotaWatchTuning, "maxStaleMs" | "lateRecoveryMs">;
 }): QuotaWatchDecision {
   const { agentName, snap, prev, now } = args;
+  const bootTick = args.bootTick ?? false;
+  const maxStaleMs = args.tuning?.maxStaleMs ?? 0;
+  const lateRecoveryMs = args.tuning?.lateRecoveryMs ?? 0;
   const label = snap.label;
+
+  // Staleness gate: a CACHED snapshot (capturedAtMs set) past its shelf
+  // life carries no opinion about the present — neither latch nor release.
+  // Live-probe snapshots (capturedAtMs undefined) are fresh by construction.
+  if (
+    maxStaleMs > 0 &&
+    snap.capturedAtMs !== undefined &&
+    now - snap.capturedAtMs > maxStaleMs
+  ) {
+    return { kind: "skip", accountLabel: label, reason: "stale-snapshot" };
+  }
+
   const currentHealth = classifyHealth(snap);
 
   // Unknown (probe failed) or blocked — skip entirely.
@@ -147,6 +260,31 @@ export function evaluateQuotaWatchAccount(args: {
       lastNotifiedHealth: "healthy",
       lastNotifiedAt: now,
     };
+    // A recovery observed on the first post-boot tick is not attributable
+    // to "just now" — the account may have recovered any time while this
+    // gateway was down, and a fleet bounce synchronizes every agent's
+    // first tick (the 2026-06-09 26-message flood). Reconcile silently.
+    if (bootTick) {
+      return {
+        kind: "reconcile",
+        accountLabel: label,
+        newAccountState: newState,
+        transition: "recovered-to-healthy",
+        reason: "boot-tick-recovery",
+      };
+    }
+    // Recovery whose matching 🟡 warning is hours old: the "all clear" is
+    // no longer actionable news (the user has long moved on; /auth shows
+    // live state on demand). Clear the latch without a message.
+    if (lateRecoveryMs > 0 && now - prev.lastNotifiedAt > lateRecoveryMs) {
+      return {
+        kind: "reconcile",
+        accountLabel: label,
+        newAccountState: newState,
+        transition: "recovered-to-healthy",
+        reason: "late-recovery",
+      };
+    }
     return {
       kind: "notify",
       accountLabel: label,

--- a/telegram-plugin/tests/quota-watch.test.ts
+++ b/telegram-plugin/tests/quota-watch.test.ts
@@ -436,3 +436,269 @@ describe("evaluateFleetAllExhausted", () => {
     if (d.kind === "notify") expect(d.message).toContain("Reset time unknown");
   });
 });
+
+// ── hardening: tuning resolver + claim keys (2026-06-09 incident) ───────────
+
+import {
+  resolveQuotaWatchTuning,
+  buildQuotaClaimKey,
+  DEFAULT_QUOTA_WATCH_MAX_STALE_MS,
+  DEFAULT_QUOTA_WATCH_LATE_RECOVERY_MS,
+  QUOTA_WATCH_CLAIM_WINDOW_MS,
+  type QuotaWatchDecision,
+} from "../quota-watch.js";
+
+describe("resolveQuotaWatchTuning", () => {
+  it("defaults: stale gate 60min, late-recovery 6h, dedup on, probe-fail send off", () => {
+    const t = resolveQuotaWatchTuning({});
+    expect(t.maxStaleMs).toBe(DEFAULT_QUOTA_WATCH_MAX_STALE_MS);
+    expect(t.lateRecoveryMs).toBe(DEFAULT_QUOTA_WATCH_LATE_RECOVERY_MS);
+    expect(t.fleetDedup).toBe(true);
+    expect(t.sendOnProbeFail).toBe(false);
+  });
+
+  it("each knob is individually kill-switchable", () => {
+    const t = resolveQuotaWatchTuning({
+      SWITCHROOM_QUOTA_WATCH_MAX_STALE_MS: "0",
+      SWITCHROOM_QUOTA_WATCH_LATE_RECOVERY_MS: "0",
+      SWITCHROOM_QUOTA_WATCH_FLEET_DEDUP: "0",
+      SWITCHROOM_QUOTA_WATCH_SEND_ON_PROBE_FAIL: "1",
+    });
+    expect(t.maxStaleMs).toBe(0);
+    expect(t.lateRecoveryMs).toBe(0);
+    expect(t.fleetDedup).toBe(false);
+    expect(t.sendOnProbeFail).toBe(true);
+  });
+
+  it("garbage numeric values fall back to defaults", () => {
+    const t = resolveQuotaWatchTuning({
+      SWITCHROOM_QUOTA_WATCH_MAX_STALE_MS: "banana",
+      SWITCHROOM_QUOTA_WATCH_LATE_RECOVERY_MS: "-5",
+    });
+    expect(t.maxStaleMs).toBe(DEFAULT_QUOTA_WATCH_MAX_STALE_MS);
+    expect(t.lateRecoveryMs).toBe(DEFAULT_QUOTA_WATCH_LATE_RECOVERY_MS);
+  });
+
+  it("claim window exceeds one poll cycle (15 min) so all agents' observations of one edge dedup", () => {
+    expect(QUOTA_WATCH_CLAIM_WINDOW_MS).toBeGreaterThan(15 * 60_000);
+  });
+});
+
+describe("buildQuotaClaimKey", () => {
+  it("is namespaced and distinct per account, transition, and chat", () => {
+    const k1 = buildQuotaClaimKey("a@x.com", "entered-throttling", 111);
+    const k2 = buildQuotaClaimKey("a@x.com", "entered-throttling", 222);
+    const k3 = buildQuotaClaimKey("a@x.com", "recovered-to-healthy", 111);
+    const k4 = buildQuotaClaimKey("b@x.com", "entered-throttling", 111);
+    expect(new Set([k1, k2, k3, k4]).size).toBe(4);
+    expect(k1).toBe("quota-watch:a@x.com:entered-throttling:111");
+  });
+});
+
+// ── hardening: staleness gate ────────────────────────────────────────────────
+
+const TUNING = {
+  maxStaleMs: DEFAULT_QUOTA_WATCH_MAX_STALE_MS,
+  lateRecoveryMs: DEFAULT_QUOTA_WATCH_LATE_RECOVERY_MS,
+};
+
+describe("evaluateQuotaWatchAccount — staleness gate", () => {
+  it("a cached snapshot past maxStaleMs carries no opinion (skip, even on a real edge)", () => {
+    const staleHealthy: AccountSnapshot = {
+      ...HEALTHY_SNAP,
+      capturedAtMs: NOW - DEFAULT_QUOTA_WATCH_MAX_STALE_MS - 1,
+    };
+    const d = evaluateQuotaWatchAccount({
+      agentName: "test", snap: staleHealthy, prev: PREV_WAS_THROTTLING, now: NOW, tuning: TUNING,
+    });
+    expect(d.kind).toBe("skip");
+    expect((d as { reason: string }).reason).toBe("stale-snapshot");
+  });
+
+  it("a cached snapshot inside the shelf life classifies normally", () => {
+    const freshEnough: AccountSnapshot = {
+      ...THROTTLING_5H,
+      capturedAtMs: NOW - 5 * 60_000,
+    };
+    const d = evaluateQuotaWatchAccount({
+      agentName: "test", snap: freshEnough, prev: PREV_WAS_HEALTHY, now: NOW, tuning: TUNING,
+    });
+    expect(d.kind).toBe("notify");
+  });
+
+  it("live-probe snapshots (no capturedAtMs) are never stale-gated", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "test", snap: THROTTLING_5H, prev: PREV_WAS_HEALTHY, now: NOW, tuning: TUNING,
+    });
+    expect(d.kind).toBe("notify");
+  });
+
+  it("maxStaleMs=0 disables the gate (legacy behaviour)", () => {
+    const ancient: AccountSnapshot = { ...THROTTLING_5H, capturedAtMs: NOW - 86_400_000 };
+    const d = evaluateQuotaWatchAccount({
+      agentName: "test", snap: ancient, prev: PREV_WAS_HEALTHY, now: NOW,
+      tuning: { maxStaleMs: 0, lateRecoveryMs: 0 },
+    });
+    expect(d.kind).toBe("notify");
+  });
+});
+
+// ── hardening: boot-tick + late-recovery reconciliation ─────────────────────
+
+describe("evaluateQuotaWatchAccount — recovery reconciliation", () => {
+  it("recovery on a boot tick reconciles silently (the fleet-bounce flood case)", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "test", snap: HEALTHY_SNAP, prev: PREV_WAS_THROTTLING, now: NOW,
+      bootTick: true, tuning: TUNING,
+    });
+    expect(d.kind).toBe("reconcile");
+    const r = d as Extract<QuotaWatchDecision, { kind: "reconcile" }>;
+    expect(r.reason).toBe("boot-tick-recovery");
+    expect(r.transition).toBe("recovered-to-healthy");
+    // The latch must clear so the edge never re-fires.
+    expect(r.newAccountState.lastNotifiedHealth).toBe("healthy");
+  });
+
+  it("recovery whose 🟡 warning is older than lateRecoveryMs reconciles silently", () => {
+    const prev = {
+      lastNotifiedHealth: "throttling" as const,
+      lastNotifiedAt: NOW - DEFAULT_QUOTA_WATCH_LATE_RECOVERY_MS - 1,
+    };
+    const d = evaluateQuotaWatchAccount({
+      agentName: "test", snap: HEALTHY_SNAP, prev, now: NOW, tuning: TUNING,
+    });
+    expect(d.kind).toBe("reconcile");
+    expect((d as Extract<QuotaWatchDecision, { kind: "reconcile" }>).reason).toBe("late-recovery");
+  });
+
+  it("a prompt recovery on a normal tick still notifies", () => {
+    const prev = { lastNotifiedHealth: "throttling" as const, lastNotifiedAt: NOW - 30 * 60_000 };
+    const d = evaluateQuotaWatchAccount({
+      agentName: "test", snap: HEALTHY_SNAP, prev, now: NOW, tuning: TUNING,
+    });
+    expect(d.kind).toBe("notify");
+    expect((d as Extract<QuotaWatchDecision, { kind: "notify" }>).transition).toBe("recovered-to-healthy");
+  });
+
+  it("a 🟡 warning still notifies on a boot tick (warnings are level-state news)", () => {
+    const d = evaluateQuotaWatchAccount({
+      agentName: "test", snap: THROTTLING_5H, prev: PREV_WAS_HEALTHY, now: NOW,
+      bootTick: true, tuning: TUNING,
+    });
+    expect(d.kind).toBe("notify");
+    expect((d as Extract<QuotaWatchDecision, { kind: "notify" }>).transition).toBe("entered-throttling");
+  });
+
+  it("lateRecoveryMs=0 disables reconciliation (legacy always-send)", () => {
+    const prev = { lastNotifiedHealth: "throttling" as const, lastNotifiedAt: NOW - 86_400_000 };
+    const d = evaluateQuotaWatchAccount({
+      agentName: "test", snap: HEALTHY_SNAP, prev, now: NOW,
+      tuning: { maxStaleMs: 0, lateRecoveryMs: 0 },
+    });
+    expect(d.kind).toBe("notify");
+  });
+
+  it("omitting bootTick/tuning entirely preserves the pre-hardening table", () => {
+    const prev = { lastNotifiedHealth: "throttling" as const, lastNotifiedAt: NOW - 86_400_000 };
+    const d = evaluateQuotaWatchAccount({
+      agentName: "test", snap: HEALTHY_SNAP, prev, now: NOW,
+    });
+    expect(d.kind).toBe("notify");
+  });
+});
+
+// ── total enumeration: every (state × input) cell of the decision FSM ────────
+//
+// Operator standard (feedback_prove_finite_fsm_not_sample): the decision
+// function is a finite table — prove it by enumerating EVERY cell, not by
+// sampling. Dimensions:
+//   prevHealth      ∈ {null, healthy, throttling}
+//   currentHealth   ∈ {healthy, throttling, blocked, unknown}
+//   staleness       ∈ {live (no capturedAtMs), fresh-cache, stale-cache}
+//   bootTick        ∈ {false, true}
+//   warningAge      ∈ {recent (< lateRecoveryMs), late (> lateRecoveryMs)}
+// = 3 × 4 × 3 × 2 × 2 = 144 cells. The expected kind for every cell is
+// computed from the documented table independently and asserted.
+
+describe("evaluateQuotaWatchAccount — total enumeration (144 cells)", () => {
+  const PREVS = [null, "healthy", "throttling"] as const;
+  const CURRENTS = ["healthy", "throttling", "blocked", "unknown"] as const;
+  const STALENESS = ["live", "fresh-cache", "stale-cache"] as const;
+  const BOOLS = [false, true] as const;
+  const AGES = ["recent", "late"] as const;
+
+  const SNAPS: Record<(typeof CURRENTS)[number], QuotaUtilization | null> = {
+    healthy: makeQuota(30, 40),
+    throttling: makeQuota(85, 40),
+    blocked: makeQuota(99.9, 99.9),
+    unknown: null,
+  };
+
+  it("every cell matches the documented table", () => {
+    let cells = 0;
+    for (const prevHealth of PREVS) {
+      for (const currentHealth of CURRENTS) {
+        for (const staleness of STALENESS) {
+          for (const bootTick of BOOLS) {
+            for (const age of AGES) {
+              cells++;
+              const lastNotifiedAt =
+                prevHealth === null
+                  ? 0
+                  : age === "late"
+                    ? NOW - DEFAULT_QUOTA_WATCH_LATE_RECOVERY_MS - 1
+                    : NOW - 30 * 60_000;
+              const prev = { lastNotifiedHealth: prevHealth, lastNotifiedAt };
+              const snap: AccountSnapshot = {
+                label: "enum@example.com",
+                isActive: false,
+                quota: SNAPS[currentHealth],
+                capturedAtMs:
+                  staleness === "live"
+                    ? undefined
+                    : staleness === "fresh-cache"
+                      ? NOW - 60_000
+                      : NOW - DEFAULT_QUOTA_WATCH_MAX_STALE_MS - 1,
+              };
+              const d = evaluateQuotaWatchAccount({
+                agentName: "enum", snap, prev, now: NOW, bootTick, tuning: TUNING,
+              });
+
+              // Independent expectation, straight from the documented table.
+              let expected: "notify" | "reconcile" | "skip";
+              const effPrev = prevHealth ?? "healthy";
+              if (staleness === "stale-cache") {
+                expected = "skip"; // gate fires before everything else
+              } else if (currentHealth === "blocked" || currentHealth === "unknown") {
+                expected = "skip"; // credits-watch domain / no data
+              } else if (currentHealth === effPrev) {
+                expected = "skip"; // steady-state
+              } else if (currentHealth === "throttling") {
+                expected = "notify"; // warnings always notify
+              } else {
+                // recovery: throttling → healthy
+                expected = bootTick || age === "late" ? "reconcile" : "notify";
+              }
+
+              expect(
+                d.kind,
+                `cell prev=${prevHealth} cur=${currentHealth} stale=${staleness} boot=${bootTick} age=${age}`,
+              ).toBe(expected);
+
+              // Terminal-state invariant: any notify/reconcile lands the
+              // latch on currentHealth, so re-running the SAME cell with the
+              // updated state is always a skip (the FSM cannot loop).
+              if (d.kind === "notify" || d.kind === "reconcile") {
+                const again = evaluateQuotaWatchAccount({
+                  agentName: "enum", snap, prev: d.newAccountState, now: NOW, bootTick, tuning: TUNING,
+                });
+                expect(again.kind, `re-run of cell prev=${prevHealth} cur=${currentHealth}`).toBe("skip");
+              }
+            }
+          }
+        }
+      }
+    }
+    expect(cells).toBe(144);
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the quota-watch notifier against the 2026-06-09 incident: a fleet bounce released days-stale recovery latches on **all 11 agent gateways at once**, flooding the operator with **26 byte-identical 🟢 "Quota back in healthy range" messages in 16 minutes** — recoveries announced 19h (pixsoul) and 3.4 days (ken.outlook) after the fact. Content was technically true; volume and timing made it read as wrong.

Three compounding mechanisms → three fixes, each independently kill-switched:

| # | Mechanism | Fix | Kill-switch |
|---|---|---|---|
| 1 | No fleet dedup: 11 independent watchers × allowFrom fan-out = up to 26 sends per edge | New broker `claim-notification` op — first claimant per **(account, transition, chat)** in a 30-min window sends; the rest advance local state silently. Per-chat keys keep the audience identical. Claims persist across broker restarts; synchronous check-and-set ⇒ exactly one grant per window by construction. Gateways **fail open** on claim error (skewed-rollout safety). | `SWITCHROOM_QUOTA_WATCH_FLEET_DEDUP=0` |
| 2 | No staleness check: classification off the broker's `last_quota` cache (capturedAt dropped in `reviveLastQuota`); latches only release at restart probe-storms → synchronized floods | Thread `capturedAt` → `AccountSnapshot.capturedAtMs`. Cached snapshots >60 min old carry **no opinion** (skip). Recovery edges on the **first post-boot tick** or whose 🟡 warning is **>6h old** reconcile **silently** (latch advances, nothing sent). Warnings (🟡) still notify on any tick — level-state, still actionable. | `SWITCHROOM_QUOTA_WATCH_MAX_STALE_MS=0`, `SWITCHROOM_QUOTA_WATCH_LATE_RECOVERY_MS=0` |
| 3 | Probe-failure fallthrough: a failed pre-send validation probe sent the notification from arbitrarily-stale cache — the only path that could ship outright FALSE numbers (latent in this incident) | Failed/missing fresh probe **defers** the notification to the next 15-min tick (state untouched → re-evaluated and re-probed). | `SWITCHROOM_QUOTA_WATCH_SEND_ON_PROBE_FAIL=1` (legacy) |

The fleet all-exhausted alert (#2215) routes through the same claim gate. With #2239's broker fleet-probe keeping caches ≤10 min warm, genuine recoveries still notify promptly on normal ticks — the reconciliation rules only swallow archaeology.

**Replay of the incident under this PR:** wave 2 (boot-tick recoveries, 19h/3.4d stale) → **0 messages** (silent reconcile on every agent). Wave 1 (genuine 🟡 80% crossing) → **1 message per chat** instead of 13.

## Why

`reference/vision.md` outcome 2 (*you hold the leash — awareness + control, not a feed to babysit*): 26 duplicate stale notifications is the opposite of awareness. JTBD `track-plan-quota-live` anti-pattern explicitly warns against quota noise the user tunes out.

## Test plan

- [x] `telegram-plugin/tests/quota-watch.test.ts` — 46 pass under **both** vitest and `bun test` (no bun-incompatible APIs)
- [x] **Total enumeration** of the decision FSM: 144 cells (prev-health × current-health × staleness × boot-tick × warning-age) asserted against an independently-computed table, plus a terminal-state invariant: any notify/reconcile re-run against its own output state is a skip — the FSM cannot loop (`feedback_prove_finite_fsm_not_sample`)
- [x] `src/auth/broker/server.test.ts` — 65 pass; 6 new claim-op tests in the isolated tmpdir harness: grant/deny across agents, key independence, window expiry re-grant, restart persistence, 24h prune, concurrent-claim race (exactly one grant)
- [x] `tsc --noEmit` clean; `check-plugin-references.mjs` clean; `check-bot-api-wrapping.sh` clean (no new raw `bot.api` callsites — claim gate wraps existing wrapped sends)
- [x] Full vitest + `bun test tests/`: failure set **byte-identical** to a pristine upstream/main baseline worktree (pre-existing environmental failures only; 0 new)

## Risk

- **Version skew (new gateway + old broker):** `claim-notification` is rejected at the protocol layer → gateway fails **open** → behavior identical to today (duplicates). No flag day.
- **Old gateway + new broker:** op simply unused.
- **Claim-then-send-fails loss window:** if the claim winner's Telegram send fails (already swallowed best-effort today), that chat misses one advisory until the next genuine edge. Accepted: quota advisories are non-critical, `/auth` shows live state on demand, and the pre-PR behavior already tolerated send failures.
- **Rollback:** the 4 env kill-switches restore pre-PR behavior per mechanism, with ONE deliberate residual: boot-tick recovery suppression has no env knob (it is the core incident fix and is safe-direction — one fewer advisory, never a wrong or lost warning). Under full kill-switch rollback, a recovery edge landing exactly on a gateway's first post-boot tick still reconciles silently; all other ticks behave exactly as pre-PR.
- **Flap damping (intended):** the 30-min claim window also collapses a genuine re-crossing of the SAME edge fleet-wide within 30 min to one notification.

Incident forensics: 4-lens multi-agent investigation + adversarial verification, 2026-06-10 session (root cause, refuted hypotheses, and log evidence recorded in the session memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
