### PR TITLE
fix(telegram,cli): fallback failure notice + honest quota columns in auth list

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -244,9 +244,36 @@ function formatQuotaReset(state: AccountState): string {
   return `${hours}h ${mins}m`;
 }
 
+/**
+ * Cached-utilization cell. Honesty fix (2026-06-09 incident follow-up):
+ * the table previously rendered ONLY the broker exhausted flag, so a
+ * 99%-utilized account read "available —" — and an agent verbally
+ * parroting `switchroom auth list` under-reported. Shows the broker's
+ * cached 5h·7d utilization with its age; "no data" (never probed) is
+ * distinct from "not exhausted". The (age) suffix is the staleness
+ * disclosure — this is the broker cache, not a live probe.
+ */
+export function formatQuotaUtilCell(
+  a: { last_quota?: { fiveHourUtilizationPct: number; sevenDayUtilizationPct: number; capturedAt: number } | null },
+  now: number = Date.now(),
+): string {
+  const lq = a.last_quota;
+  if (!lq) return "no data";
+  const ageMs = Math.max(0, now - lq.capturedAt);
+  const mins = Math.floor(ageMs / 60_000);
+  const ageStr =
+    mins < 1 ? "just now"
+    : mins < 60 ? `${mins}m ago`
+    : mins < 1440 ? `${Math.floor(mins / 60)}h ago`
+    : `${Math.floor(mins / 1440)}d ago`;
+  const five = Math.round(lq.fiveHourUtilizationPct);
+  const seven = Math.round(lq.sevenDayUtilizationPct);
+  return `${five}%·${seven}% (${ageStr})`;
+}
+
 function printAccountsTable(state: ListStateData): void {
   console.log(
-    chalk.bold("  ACCOUNT                           STATUS       EXPIRES    QUOTA-RESET"),
+    chalk.bold("  ACCOUNT                           STATUS       EXPIRES    QUOTA 5h·7d          QUOTA-RESET"),
   );
   for (const a of state.accounts) {
     const marker =
@@ -263,8 +290,9 @@ function printAccountsTable(state: ListStateData): void {
           : "available";
     const label = a.label.padEnd(32);
     const exp = formatExpiry(a.expiresAt).padEnd(10);
+    const util = formatQuotaUtilCell(a).padEnd(20);
     const quota = formatQuotaReset(a);
-    console.log(`  ${marker} ${label} ${status}    ${exp} ${quota}`);
+    console.log(`  ${marker} ${label} ${status}    ${exp} ${util} ${quota}`);
   }
 }
 

--- a/telegram-plugin/auto-fallback-fleet.ts
+++ b/telegram-plugin/auto-fallback-fleet.ts
@@ -42,6 +42,33 @@ import {
   buildSnapshotsFromState,
 } from './auth-snapshot-format.js';
 
+/**
+ * Failure notice for when the fallback dispatcher itself errors (broker
+ * unreachable, listState/markExhausted throw). The model-unavailable
+ * card renders "Auto-failover in progress — see the announcement below"
+ * BEFORE the outcome is known; every error path must therefore still
+ * produce an announcement or the card's promise is broken (the
+ * 2026-06-06→07 incident: 12 cards promised an announcement while every
+ * dispatch errored "set-active requires admin" — log-only, nothing
+ * arrived). Pure builder so the shape is unit-testable.
+ */
+export function renderFallbackFailureNotice(triggerAgent: string, reason: string): string {
+  return (
+    `⚠️ <b>Auto-failover could not run</b> (trigger: <b>${escFailureHtml(triggerAgent)}</b>)\n` +
+    `${escFailureHtml(reason)}\n\n` +
+    `<i>Switch manually with <code>/auth use &lt;label&gt;</code>, or <code>/auth</code> for fleet status.</i>`
+  );
+}
+
+function escFailureHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export type FleetFallbackOutcome =
   | {
       kind: 'switched';

--- a/telegram-plugin/auto-fallback-fleet.ts
+++ b/telegram-plugin/auto-fallback-fleet.ts
@@ -69,6 +69,38 @@ function escFailureHtml(s: string): string {
     .replace(/'/g, '&#39;');
 }
 
+/**
+ * Cooldown for the failure notice. The fleetFallbackGate's dedup window
+ * deliberately arms ONLY on a successful swap (fleet-fallback-gate.ts:
+ * "No-ops … DO NOT arm the suppression window") — so it bounds nothing
+ * on the error path, and the card-less `quota_wall_detected` trigger
+ * re-signals every ~60s for the duration of a weekly wall. Without a
+ * notice-level bound, a persistent broker outage during a wall would
+ * stream ~60 failure notices/hour to every chat for days.
+ *
+ * Plain time cooldown, per gateway, in-memory. Deliberately NOT keyed
+ * by reason: broker error strings vary per attempt (timeout ms values
+ * etc.), so a new-reason bypass would re-open the spam hole. Worst
+ * case is one notice per gateway per cooldown window.
+ */
+export const FALLBACK_FAILURE_NOTICE_COOLDOWN_MS = 30 * 60_000;
+
+export interface FallbackFailureNoticeState {
+  /** Unix ms of the last failure notice this gateway sent. 0 = never. */
+  lastSentAtMs: number;
+}
+
+export function evaluateFallbackFailureNotice(
+  prev: FallbackFailureNoticeState,
+  now: number,
+  cooldownMs: number = FALLBACK_FAILURE_NOTICE_COOLDOWN_MS,
+): { send: boolean; next: FallbackFailureNoticeState } {
+  if (now - prev.lastSentAtMs >= cooldownMs) {
+    return { send: true, next: { lastSentAtMs: now } };
+  }
+  return { send: false, next: prev };
+}
+
 export type FleetFallbackOutcome =
   | {
       kind: 'switched';

--- a/telegram-plugin/gateway/auth-command.ts
+++ b/telegram-plugin/gateway/auth-command.ts
@@ -785,7 +785,7 @@ export function renderShowText(
 }
 
 function formatAccountsTable(state: ListStateData, now: number): string {
-  const rows: string[][] = [['ACCOUNT', 'STATUS', 'EXPIRES', 'QUOTA-RESET']]
+  const rows: string[][] = [['ACCOUNT', 'STATUS', 'EXPIRES', 'QUOTA 5h·7d', 'QUOTA-RESET']]
   for (const acc of state.accounts) {
     const isActive = acc.label === state.active
     const marker = isActive
@@ -799,9 +799,35 @@ function formatAccountsTable(state: ListStateData, now: number): string {
       acc.exhausted && acc.exhausted_until != null && acc.exhausted_until > now
         ? formatRelativeMs(acc.exhausted_until - now)
         : '—'
-    rows.push([`${marker} ${escapeHtml(acc.label)}`, status, expires, quotaReset])
+    rows.push([
+      `${marker} ${escapeHtml(acc.label)}`,
+      status,
+      expires,
+      formatQuotaUtilCell(acc, now),
+      quotaReset,
+    ])
   }
   return alignTable(rows)
+}
+
+/**
+ * Cached-utilization cell for the legacy accounts table. Honesty fix
+ * (2026-06-09 incident follow-up): the table previously rendered ONLY
+ * the broker exhausted flag, so a 99%-utilized account read
+ * "available —" — and an agent parroting the table under-reported. Now
+ * shows the broker's cached 5h·7d utilization with its age, and
+ * distinguishes "no data" (never probed) from "not exhausted".
+ * Cached, not live: the (age) suffix is the staleness disclosure.
+ */
+export function formatQuotaUtilCell(
+  acc: { last_quota?: { fiveHourUtilizationPct: number; sevenDayUtilizationPct: number; capturedAt: number } | null },
+  now: number,
+): string {
+  const lq = acc.last_quota
+  if (!lq) return 'no data'
+  const age = now - lq.capturedAt
+  const ageStr = age > 0 ? formatRelativeMs(age) : '0s'
+  return `${Math.round(lq.fiveHourUtilizationPct)}%·${Math.round(lq.sevenDayUtilizationPct)}% (${ageStr} ago)`
 }
 
 function formatAgentsTable(state: ListStateData): string {

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -157,7 +157,7 @@ import {
   formatModelUnavailableCard,
   resolveModelUnavailableFromOperatorEvent,
 } from '../model-unavailable.js'
-import { runFleetAutoFallback } from '../auto-fallback-fleet.js'
+import { runFleetAutoFallback, renderFallbackFailureNotice } from '../auto-fallback-fleet.js'
 import { startRestartWatchdog } from './restart-watchdog.js'
 import { validateStringArray } from './access-validator.js'
 
@@ -14807,6 +14807,36 @@ async function fireFleetAutoFallback(triggerAgent: string, untilMs?: number): Pr
   )
 }
 
+/**
+ * Broadcast a fleet-fallback FAILURE notice to every authorized chat.
+ *
+ * Why this exists: the model-unavailable card renders "Auto-failover in
+ * progress — see the announcement below" BEFORE the dispatcher's outcome
+ * is known. When the dispatcher errors (broker down, listState throw,
+ * markExhausted failure), the success announcement never lands and the
+ * card's promise is broken — the 2026-06-06→07 incident sent 12 such
+ * broken-promise cards while every fallback errored "set-active requires
+ * admin". The admin-gating root cause is fixed (#2206), but ANY future
+ * dispatcher error reproduces the broken promise. This notice closes the
+ * loop deterministically: card promised an announcement → an
+ * announcement ALWAYS arrives, success or failure.
+ *
+ * Disable with SWITCHROOM_FLEET_FALLBACK_FAILURE_NOTICE=0 (log-only,
+ * pre-fix behaviour).
+ */
+function broadcastFleetFallbackFailure(triggerAgent: string, reason: string): void {
+  if (process.env.SWITCHROOM_FLEET_FALLBACK_FAILURE_NOTICE === '0') return
+  const access = loadAccess()
+  if (access.allowFrom.length === 0) return
+  const html = renderFallbackFailureNotice(triggerAgent, reason)
+  for (const chat_id of access.allowFrom) {
+    void swallowingApiCall(
+      () => bot.api.sendMessage(chat_id, html, { parse_mode: 'HTML' as const }),
+      { chat_id, verb: 'fleet-fallback:failure-notify' },
+    )
+  }
+}
+
 /** Returns true iff the dispatcher actually performed a swap (and the
  *  user-visible announcement was broadcast). False on no-op /
  *  error / idempotent-skip — caller uses this to decide whether to
@@ -14818,6 +14848,9 @@ async function doFireFleetAutoFallback(triggerAgent: string, untilMs?: number): 
       process.stderr.write(
         `telegram gateway: [fleet-fallback] skipped agent=${triggerAgent} reason=no-broker-client\n`,
       )
+      // The model-unavailable card may have promised an announcement —
+      // keep the promise even though nothing could run.
+      broadcastFleetFallbackFailure(triggerAgent, 'auth-broker unreachable (no client).')
       return false
     }
     const state = await client.listState()
@@ -14881,6 +14914,10 @@ async function doFireFleetAutoFallback(triggerAgent: string, untilMs?: number): 
     process.stderr.write(
       `telegram gateway: [fleet-fallback] error agent=${triggerAgent}: ${(err as Error)?.message ?? err}\n`,
     )
+    // Keep the card's "see the announcement below" promise on the error
+    // path — the 06-06→07 incident sent 12 cards whose promised
+    // announcement never arrived because this catch was log-only.
+    broadcastFleetFallbackFailure(triggerAgent, (err as Error)?.message ?? String(err))
     return false
   }
 }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -157,7 +157,7 @@ import {
   formatModelUnavailableCard,
   resolveModelUnavailableFromOperatorEvent,
 } from '../model-unavailable.js'
-import { runFleetAutoFallback, renderFallbackFailureNotice } from '../auto-fallback-fleet.js'
+import { runFleetAutoFallback, renderFallbackFailureNotice, evaluateFallbackFailureNotice, type FallbackFailureNoticeState } from '../auto-fallback-fleet.js'
 import { startRestartWatchdog } from './restart-watchdog.js'
 import { validateStringArray } from './access-validator.js'
 
@@ -14824,8 +14824,23 @@ async function fireFleetAutoFallback(triggerAgent: string, untilMs?: number): Pr
  * Disable with SWITCHROOM_FLEET_FALLBACK_FAILURE_NOTICE=0 (log-only,
  * pre-fix behaviour).
  */
+let fallbackFailureNoticeState: FallbackFailureNoticeState = { lastSentAtMs: 0 }
+
 function broadcastFleetFallbackFailure(triggerAgent: string, reason: string): void {
   if (process.env.SWITCHROOM_FLEET_FALLBACK_FAILURE_NOTICE === '0') return
+  // Notice-level cooldown (30 min, per gateway). The fleetFallbackGate's
+  // dedup window only arms on SUCCESSFUL swaps, so it bounds nothing
+  // here — and the card-less quota_wall_detected trigger re-fires every
+  // ~60s during a wall. Without this, a persistent broker outage would
+  // stream failure notices for days. See evaluateFallbackFailureNotice.
+  const verdict = evaluateFallbackFailureNotice(fallbackFailureNoticeState, Date.now())
+  if (!verdict.send) {
+    process.stderr.write(
+      `telegram gateway: [fleet-fallback] failure notice suppressed (cooldown) agent=${triggerAgent}: ${reason}\n`,
+    )
+    return
+  }
+  fallbackFailureNoticeState = verdict.next
   const access = loadAccess()
   if (access.allowFrom.length === 0) return
   const html = renderFallbackFailureNotice(triggerAgent, reason)

--- a/telegram-plugin/tests/auth-quota-util-cell.test.ts
+++ b/telegram-plugin/tests/auth-quota-util-cell.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Telegram legacy accounts-table twin of the CLI honesty fix — the
+ * legacy table renders exactly when the live probe FAILED, i.e. when
+ * cached-data disclosure matters most.
+ */
+import { describe, it, expect } from "vitest";
+import { formatQuotaUtilCell } from "../gateway/auth-command.js";
+
+const NOW = 1_780_000_000_000;
+
+describe("formatQuotaUtilCell (Telegram legacy table)", () => {
+  it("no cached snapshot → 'no data'", () => {
+    expect(formatQuotaUtilCell({ last_quota: null }, NOW)).toBe("no data");
+  });
+
+  it("renders both windows with the snapshot age", () => {
+    const cell = formatQuotaUtilCell(
+      { last_quota: { fiveHourUtilizationPct: 84.6, sevenDayUtilizationPct: 12.1, capturedAt: NOW - 90_000 } },
+      NOW,
+    );
+    expect(cell).toBe("85%·12% (1m 30s ago)");
+  });
+});

--- a/telegram-plugin/tests/auto-fallback-fleet.test.ts
+++ b/telegram-plugin/tests/auto-fallback-fleet.test.ts
@@ -173,3 +173,26 @@ describe('runFleetAutoFallback', () => {
     }
   });
 });
+
+// ── failure notice (broken-promise fix, 2026-06-09 incident follow-up) ──────
+
+import { renderFallbackFailureNotice } from "../auto-fallback-fleet.js";
+
+describe("renderFallbackFailureNotice", () => {
+  it("names the trigger agent, the reason, and the manual recovery verbs", () => {
+    const html = renderFallbackFailureNotice("marko", "auth-broker unreachable (no client).");
+    expect(html).toContain("Auto-failover could not run");
+    expect(html).toContain("<b>marko</b>");
+    expect(html).toContain("auth-broker unreachable");
+    expect(html).toContain("/auth use");
+    expect(html).toContain("/auth</code>");
+  });
+
+  it("escapes HTML in the error reason (broker errors can contain angle brackets)", () => {
+    const html = renderFallbackFailureNotice("a<b", 'request <probe-quota> failed & "timed out"');
+    expect(html).toContain("a&lt;b");
+    expect(html).toContain("&lt;probe-quota&gt;");
+    expect(html).toContain("&amp;");
+    expect(html).not.toMatch(/<probe-quota>/);
+  });
+});

--- a/telegram-plugin/tests/auto-fallback-fleet.test.ts
+++ b/telegram-plugin/tests/auto-fallback-fleet.test.ts
@@ -196,3 +196,51 @@ describe("renderFallbackFailureNotice", () => {
     expect(html).not.toMatch(/<probe-quota>/);
   });
 });
+
+// ── failure-notice cooldown (reviewer blocker: gate window never arms on
+//    failure; quota_wall_detected re-fires ~60s → unbounded notice spam) ─────
+
+import {
+  evaluateFallbackFailureNotice,
+  FALLBACK_FAILURE_NOTICE_COOLDOWN_MS,
+} from "../auto-fallback-fleet.js";
+
+describe("evaluateFallbackFailureNotice", () => {
+  const T0 = 1_780_000_000_000;
+
+  it("first failure always sends and arms the cooldown", () => {
+    const r = evaluateFallbackFailureNotice({ lastSentAtMs: 0 }, T0);
+    expect(r.send).toBe(true);
+    expect(r.next.lastSentAtMs).toBe(T0);
+  });
+
+  it("a repeat failure inside the cooldown is suppressed and does NOT extend the window", () => {
+    const armed = { lastSentAtMs: T0 };
+    const r = evaluateFallbackFailureNotice(armed, T0 + 60_000);
+    expect(r.send).toBe(false);
+    expect(r.next).toBe(armed); // unchanged — window not extended by suppressed attempts
+  });
+
+  it("sends again once the cooldown elapses", () => {
+    const r = evaluateFallbackFailureNotice(
+      { lastSentAtMs: T0 },
+      T0 + FALLBACK_FAILURE_NOTICE_COOLDOWN_MS,
+    );
+    expect(r.send).toBe(true);
+    expect(r.next.lastSentAtMs).toBe(T0 + FALLBACK_FAILURE_NOTICE_COOLDOWN_MS);
+  });
+
+  it("bounds the 60s quota_wall_detected re-fire storm to ≤2 notices/hour", () => {
+    // Simulate a wedged agent re-signalling every 60s for one hour with a
+    // dead broker — the incident shape the reviewer flagged.
+    let state = { lastSentAtMs: 0 };
+    let sent = 0;
+    for (let t = T0; t < T0 + 3_600_000; t += 60_000) {
+      const r = evaluateFallbackFailureNotice(state, t);
+      if (r.send) sent++;
+      state = r.next;
+    }
+    expect(sent).toBeLessThanOrEqual(2);
+    expect(sent).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/auth-quota-util-cell.test.ts
+++ b/tests/auth-quota-util-cell.test.ts
@@ -1,0 +1,37 @@
+/**
+ * `switchroom auth list` honesty fix (2026-06-09 incident follow-up):
+ * the accounts table previously rendered only the broker exhausted
+ * flag, so a 99%-utilized account read "available —". The new
+ * QUOTA 5h·7d cell surfaces the broker's cached utilization with its
+ * age, and distinguishes "no data" from "not exhausted".
+ */
+import { describe, it, expect } from "vitest";
+import { formatQuotaUtilCell } from "../src/cli/auth.js";
+
+const NOW = 1_780_000_000_000;
+
+function lq(five: number, seven: number, capturedAt: number) {
+  return { fiveHourUtilizationPct: five, sevenDayUtilizationPct: seven, capturedAt };
+}
+
+describe("formatQuotaUtilCell (CLI)", () => {
+  it("no cached snapshot → 'no data' (distinct from not-exhausted '—')", () => {
+    expect(formatQuotaUtilCell({ last_quota: null }, NOW)).toBe("no data");
+    expect(formatQuotaUtilCell({}, NOW)).toBe("no data");
+  });
+
+  it("renders both windows with rounded percentages and a coarse age", () => {
+    expect(formatQuotaUtilCell({ last_quota: lq(16.4, 1.2, NOW - 3 * 60_000) }, NOW)).toBe("16%·1% (3m ago)");
+    expect(formatQuotaUtilCell({ last_quota: lq(99, 42, NOW - 2 * 3_600_000) }, NOW)).toBe("99%·42% (2h ago)");
+    expect(formatQuotaUtilCell({ last_quota: lq(0, 0, NOW - 3 * 86_400_000) }, NOW)).toBe("0%·0% (3d ago)");
+  });
+
+  it("a snapshot captured seconds ago reads 'just now'", () => {
+    expect(formatQuotaUtilCell({ last_quota: lq(50, 10, NOW - 5_000) }, NOW)).toBe("50%·10% (just now)");
+  });
+
+  it("a 99%-utilized non-exhausted account is no longer invisible (the incident's under-report)", () => {
+    const cell = formatQuotaUtilCell({ last_quota: lq(99, 3, NOW - 60_000) }, NOW);
+    expect(cell).toContain("99%");
+  });
+});


### PR DESCRIPTION
## Summary

Two follow-ups from the 2026-06-09/10 quota-status forensics — sibling of #2254 (which fixed the quota-watch notifier itself):

**1. Fallback broken-promise fix.** The ⚠️ model-unavailable card says *"Auto-failover in progress — see the announcement below"* before the dispatcher's outcome is known. When the dispatcher errors (broker unreachable, `listState`/`markExhausted` throw), no announcement ever arrived — the 06-06→07 incident sent **12 cards whose promised announcement never came** while every dispatch errored `set-active requires admin`. That root cause was fixed (#2206), but any future dispatcher error reproduced the broken promise. Now `doFireFleetAutoFallback`'s error paths broadcast a failure notice (pure builder `renderFallbackFailureNotice`, unit-tested for shape + HTML-escaping) naming the trigger agent, the error, and the manual recovery verbs. **Invariant: card promised an announcement → an announcement always arrives, success or failure.** Kill-switch: `SWITCHROOM_FLEET_FALLBACK_FAILURE_NOTICE=0`.

**2. Honest quota columns.** `switchroom auth list` and the Telegram legacy fleet-snapshot table (which renders exactly when the live probe FAILED — i.e., when cached-data disclosure matters most) showed only the broker exhausted flag: a 99%-utilized account read `available —`, and an agent verbally parroting the table under-reported. Both tables now carry a `QUOTA 5h·7d` column from the broker's cached `last_quota` with the snapshot age as staleness disclosure (`16%·1% (3m ago)`), and `no data` (never probed) is distinct from `—` (not exhausted). Display-only change.

## Why

`reference/vision.md` outcome 2 (awareness + control): a status card that promises an event that never comes, and a status table that hides 99% utilization, both break the operator's trust in the surfaces they're supposed to act on. JTBD `track-plan-quota-live`.

## Test plan

- [x] `renderFallbackFailureNotice` — shape + HTML-escaping of broker error strings (angle brackets/quotes), under vitest AND bun
- [x] `formatQuotaUtilCell` ×2 (CLI + Telegram twin) — no-data vs not-exhausted distinction, rounding, age coarsening, the exact 99%-invisible regression case
- [x] Existing `auth-command-format2` / `vernacular` suites pass (46/46) — Format 2 (live-probe) path untouched
- [x] `tsc --noEmit` clean · `check-bot-api-wrapping.sh` clean (new send is `swallowingApiCall`-wrapped) · `check-plugin-references.mjs` clean

## Risk

- Failure notice fires only on dispatcher **error** paths (no-client + catch), which previously logged-only. Volume bound: a dedicated **30-min per-gateway cooldown** (`evaluateFallbackFailureNotice`, storm-shape regression test: 60s `quota_wall_detected` re-fires for 1h → ≤2 notices). The `fleetFallbackGate` window does NOT bound this (it arms only on successful swaps) — reviewer-caught, fixed in the second commit. All four `runFleetAutoFallback` outcome paths (switched / all-blocked / no-eligible / no-old-active) already produced announcements and are unchanged.
- Table changes are render-only; no behavior, no wire changes. Worst case: a wide row wraps on narrow phones (it's inside `<pre>` — same as today's table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
