### PR TITLE
feat(memory): detect mental models corrupted by LLM-failure messages

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -28,7 +28,7 @@ import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
 import { probeHindsight, isHindsightEnabled, fetchHindsightToolsList } from "../memory/hindsight.js";
-import { inspectBankHealth, staleMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
+import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
 import { checkHindsightContainerHealth, classifyToolContract } from "./doctor-memory.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
 import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
@@ -996,12 +996,24 @@ export async function checkBankIngestHealth(
 
     const gaps = recentUnextracted(h.unextractedDocuments, 30, now);
     const stale = staleMentalModels(h.mentalModels, 7, now);
+    const corrupted = corruptedMentalModels(h.mentalModels);
     const newestAge = ageDays(h.newestDocumentAt, now);
     const summary =
       `${h.totalDocuments} docs · ${h.totalFacts} facts · ` +
       `newest ${h.newestDocumentAt?.slice(0, 10) ?? "?"} · ` +
       `${h.mentalModels.length} mental models`;
 
+    if (corrupted.length > 0) {
+      results.push({
+        name: label,
+        status: "fail",
+        detail: `${corrupted.length} mental model(s) hold a persisted LLM-failure message instead of real content (${corrupted.map((m) => m.name).join(", ")}) — that garbage is injected into every agent turn`,
+        fix:
+          "A refresh ran while the LLM was quota-walled and the error string was stored as content. " +
+          "Once quota recovers: POST /v1/default/banks/<bank>/mental-models/<id>/refresh and verify the content regenerated.",
+      });
+      continue;
+    }
     if (gaps.length > 0) {
       const oldest = gaps[0];
       results.push({

--- a/src/memory/bank-health.ts
+++ b/src/memory/bank-health.ts
@@ -31,6 +31,10 @@ export interface BankMentalModelSummary {
   name: string;
   lastRefreshedAt: string | null;
   createdAt: string | null;
+  /** Length of the rendered content (0 when absent). */
+  contentLength: number;
+  /** First ~200 chars of content — enough for corruption fingerprinting. */
+  contentHead: string;
 }
 
 export interface BankHealth {
@@ -133,6 +137,7 @@ export async function inspectBankHealth(
       name?: string;
       last_refreshed_at?: string | null;
       created_at?: string | null;
+      content?: string | null;
     }>;
   }>(`${base}/v1/default/banks/${bank}/mental-models`, opts);
   if (!models.ok) return { ...empty, reason: models.reason };
@@ -165,7 +170,7 @@ export async function inspectBankHealth(
     newestDocumentAt,
     unextractedDocuments: unextracted,
     mentalModels: (models.data.items ?? [])
-      .filter((m): m is { id: string; name: string; last_refreshed_at?: string | null; created_at?: string | null } =>
+      .filter((m): m is { id: string; name: string; last_refreshed_at?: string | null; created_at?: string | null; content?: string | null } =>
         typeof m?.id === "string" && typeof m?.name === "string",
       )
       .map((m) => ({
@@ -173,6 +178,8 @@ export async function inspectBankHealth(
         name: m.name,
         lastRefreshedAt: m.last_refreshed_at ?? null,
         createdAt: m.created_at ?? null,
+        contentLength: (m.content ?? "").length,
+        contentHead: (m.content ?? "").slice(0, 200),
       })),
   };
 }
@@ -183,6 +190,24 @@ export function ageDays(iso: string | null, now: Date = new Date()): number | nu
   const t = Date.parse(iso);
   if (Number.isNaN(t)) return null;
   return Math.max(0, (now.getTime() - t) / 86_400_000);
+}
+
+/**
+ * Mental models whose content is a persisted LLM-failure message rather than
+ * real synthesis. Observed live 2026-06-10: a refresh during an OAuth quota
+ * wall stored the literal error ("You're out of extra usage · resets 3am
+ * (UTC)") as the model's content — which then gets injected into every agent
+ * turn until the next successful refresh. Fingerprint: tiny content matching
+ * a quota/limit phrase, or empty content on a model that HAS refreshed.
+ */
+export function corruptedMentalModels(
+  models: BankMentalModelSummary[],
+): BankMentalModelSummary[] {
+  const failurePhrase = /out of (extra )?usage|hit your (usage |session )?limit|resets \d|quota exceeded|rate.?limit/i;
+  return models.filter((m) => {
+    if (m.contentLength === 0) return m.lastRefreshedAt !== null;
+    return m.contentLength < 300 && failurePhrase.test(m.contentHead);
+  });
 }
 
 /** Mental models whose last refresh (or creation, if never refreshed) is older than `staleDays`. */

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -14,6 +14,7 @@ import { getCollectionForAgent, probeHindsight } from "../memory/hindsight.js";
 import {
   inspectBankHealth,
   staleMentalModels,
+  corruptedMentalModels,
   recentUnextracted,
   type BankMentalModelSummary,
 } from "../memory/bank-health.js";
@@ -1337,6 +1338,8 @@ export interface MemoryBankHealthRow {
   oldestUnextractedAt: string | null;
   mentalModels: BankMentalModelSummary[];
   staleMentalModelCount: number;
+  /** Models whose content is a persisted LLM-failure message (quota wall during refresh). */
+  corruptedMentalModelNames: string[];
   /** ok | warn | fail — same thresholds as `switchroom doctor`. */
   status: "ok" | "warn" | "fail";
   statusDetail: string;
@@ -1377,11 +1380,15 @@ export async function handleGetMemoryHealth(
       const h = await inspectBankHealth(url, bank, { fetchImpl: opts?.fetchImpl });
       const gaps = recentUnextracted(h.unextractedDocuments, 30, now);
       const stale = staleMentalModels(h.mentalModels, 7, now);
+      const corrupted = corruptedMentalModels(h.mentalModels);
       let status: MemoryBankHealthRow["status"] = "ok";
       let statusDetail = "facts flowing";
       if (!h.ok) {
         status = "warn";
         statusDetail = `inspection failed: ${h.reason ?? "unknown"}`;
+      } else if (corrupted.length > 0) {
+        status = "fail";
+        statusDetail = `${corrupted.length} mental model(s) corrupted by an LLM failure message — injected into every turn until refreshed`;
       } else if (gaps.length > 0) {
         status = "fail";
         statusDetail = `${gaps.length} recent conversation(s) stored with zero extracted facts — invisible to recall`;
@@ -1405,6 +1412,7 @@ export async function handleGetMemoryHealth(
         oldestUnextractedAt: gaps[0]?.createdAt ?? null,
         mentalModels: h.mentalModels,
         staleMentalModelCount: stale.length,
+        corruptedMentalModelNames: corrupted.map((m) => m.name),
         status,
         statusDetail,
       };

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -538,6 +538,9 @@
         const gapLine = b.recentUnextractedCount > 0
           ? `<div style="color:var(--red);margin-top:.4rem">⚠ ${b.recentUnextractedCount} recent conversation(s) stored but NOT extracted (oldest ${fmtDay(b.oldestUnextractedAt)}) — invisible to recall until reprocessed</div>`
           : '';
+        const corruptLine = (b.corruptedMentalModelNames || []).length > 0
+          ? `<div style="color:var(--red);margin-top:.4rem">⚠ corrupted mental model(s): ${escapeHtml(b.corruptedMentalModelNames.join(', '))} — content is an LLM failure message; refresh once quota recovers</div>`
+          : '';
         return `<div class="agent-card">
           <div class="card-header" style="cursor:default">
             ${statusDot(b.status)}<span class="agent-name">${escapeHtml(b.bank)}</span>
@@ -552,6 +555,7 @@
               <div class="meta-item"><label>Mental models </label><span>${(b.mentalModels || []).length}${b.staleMentalModelCount ? ` <span style="color:var(--yellow)">(${b.staleMentalModelCount} stale)</span>` : ''}</span></div>
             </div>
             ${models ? `<div class="card-meta" style="padding:.4rem 0 0">${models}</div>` : ''}
+            ${corruptLine}
             ${gapLine}
           </div>
         </div>`;

--- a/tests/memory.bank-health.test.ts
+++ b/tests/memory.bank-health.test.ts
@@ -3,6 +3,7 @@ import {
   inspectBankHealth,
   hindsightRestBase,
   staleMentalModels,
+  corruptedMentalModels,
   recentUnextracted,
   ageDays,
 } from "../src/memory/bank-health.js";
@@ -59,7 +60,7 @@ const HEALTHY_BANK = {
   },
   models: {
     items: [
-      { id: "m1", name: "Case State", last_refreshed_at: "2026-06-10T01:00:00Z", created_at: "2026-04-01T00:00:00Z" },
+      { id: "m1", name: "Case State", last_refreshed_at: "2026-06-10T01:00:00Z", created_at: "2026-04-01T00:00:00Z", content: "# Case State\n\nA healthy, substantive synthesis of the matter." },
     ],
   },
 };
@@ -85,8 +86,8 @@ const STALE_MODEL_BANK = {
   },
   models: {
     items: [
-      { id: "m1", name: "Old Map", last_refreshed_at: "2026-05-20T00:00:00Z", created_at: "2026-04-01T00:00:00Z" },
-      { id: "m2", name: "Fresh", last_refreshed_at: "2026-06-10T00:00:00Z", created_at: "2026-04-01T00:00:00Z" },
+      { id: "m1", name: "Old Map", last_refreshed_at: "2026-05-20T00:00:00Z", created_at: "2026-04-01T00:00:00Z", content: "# Old Map\n\nReal content, just not refreshed lately." },
+      { id: "m2", name: "Fresh", last_refreshed_at: "2026-06-10T00:00:00Z", created_at: "2026-04-01T00:00:00Z", content: "# Fresh\n\nRecently refreshed real content." },
     ],
   },
 };
@@ -147,6 +148,24 @@ describe("helpers", () => {
       NOW,
     );
     expect(stale.map((m) => m.id)).toEqual(["a"]);
+  });
+
+  it("corruptedMentalModels fingerprints persisted LLM-failure content", () => {
+    const mk = (id: string, contentHead: string, contentLength: number, refreshed: string | null = "2026-06-10T01:39:00Z") =>
+      ({ id, name: id, lastRefreshedAt: refreshed, createdAt: "2026-04-01T00:00:00Z", contentLength, contentHead });
+    const corrupted = corruptedMentalModels([
+      // The live 2026-06-10 incident strings:
+      mk("quota", "You're out of extra usage · resets 3am (UTC)", 44),
+      mk("session", "You've hit your session limit · resets 1pm (Australia/Melbourne)", 65),
+      // Empty content but HAS refreshed → corrupt; never refreshed → fine.
+      mk("empty-refreshed", "", 0),
+      mk("empty-never", "", 0, null),
+      // Real content mentioning limits is NOT corrupt (length >= 300).
+      mk("real", "# Case State — discusses the usage limit of the trust...", 8000),
+      // Short but genuine content without failure phrasing is NOT corrupt.
+      mk("short-real", "## Notes\nNothing recorded yet beyond the kickoff.", 49),
+    ]);
+    expect(corrupted.map((m) => m.id)).toEqual(["quota", "session", "empty-refreshed"]);
   });
 
   it("recentUnextracted windows by age and ignores trivial documents", () => {
@@ -214,6 +233,44 @@ describe("checkBankIngestHealth (doctor)", () => {
     );
     expect(results[0].status).toBe("warn");
     expect(results[0].detail).toContain("inspection failed");
+  });
+});
+
+const CORRUPT_MODEL_BANK = {
+  stats: { total_documents: 5, total_nodes: 50, pending_operations: 0 },
+  documents: {
+    items: [{ id: "d1", created_at: "2026-06-09T00:00:00Z", text_length: 100, memory_unit_count: 2 }],
+  },
+  models: {
+    items: [
+      {
+        id: "m1", name: "Case State",
+        last_refreshed_at: "2026-06-10T01:39:00Z", created_at: "2026-04-01T00:00:00Z",
+        content: "You're out of extra usage · resets 3am (UTC)",
+      },
+    ],
+  },
+};
+
+describe("corruption detection end-to-end", () => {
+  it("doctor fails the bank and names the corrupted model", async () => {
+    const results = await checkBankIngestHealth(
+      minimalConfig({ lawgpt: {} }),
+      "http://x/mcp/",
+      { fetchImpl: fakeFetchFor({ lawgpt: CORRUPT_MODEL_BANK }), now: NOW },
+    );
+    expect(results[0].status).toBe("fail");
+    expect(results[0].detail).toContain("Case State");
+    expect(results[0].detail).toContain("LLM-failure message");
+  });
+
+  it("dashboard row carries fail status + corrupted names", async () => {
+    const health = await handleGetMemoryHealth(minimalConfig({ lawgpt: {} }), {
+      fetchImpl: fakeFetchFor({ lawgpt: CORRUPT_MODEL_BANK }),
+      now: NOW,
+    });
+    expect(health.banks[0].status).toBe("fail");
+    expect(health.banks[0].corruptedMentalModelNames).toEqual(["Case State"]);
   });
 });
 


### PR DESCRIPTION
## Summary
Follow-up to #2257, from a live incident minutes after it merged: mental-model refreshes that run during an OAuth quota wall persist the literal error string (`You're out of extra usage · resets 3am (UTC)`) as the model's **content**, which is then injected into every agent turn until the next successful refresh. Five lawgpt models + carrie/kdogg user-profiles were corrupted this way with zero observability.

- `corruptedMentalModels()` in bank-health: fingerprints tiny (<300 char) content matching quota/limit failure phrasing, or empty content on a refreshed model. Model summaries now carry `contentLength` + `contentHead` (200 chars).
- doctor: per-bank **FAIL** naming the corrupted models (checked above the extraction-gap gate).
- dashboard Memory tab: fail status + red banner listing the corrupted models.

## Test plan
- [x] 15 tests in tests/memory.bank-health.test.ts incl. the exact live incident strings, empty-after-refresh vs never-refreshed, >=300-char real content immune, doctor + dashboard end-to-end.
- [x] tests/web.test.ts (75) + tests/doctor.test.ts (53) green; tsc clean.
- [x] Live-validated: doctor flags exactly the 3 real corrupted banks (lawgpt: Goodfellow Timeline + Case State; carrie + kdogg user-profile), healthy banks unaffected.

## Risk
Low — read-only observability refinement; heuristic tuned against live data with negative cases pinned (real content mentioning 'limit' at length is immune).

🤖 Generated with [Claude Code](https://claude.com/claude-code)