### PR TITLE
feat(telegram): /model dashboard — live picker-driven menu + quota brief

### DIFF
--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -31,6 +31,7 @@
 
 import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
+import { withPaneLock } from "./pane-lock.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -365,13 +366,19 @@ export async function injectSlashCommand(
   const settleMs = opts.settleMs ?? 2000;
   const timeoutMs = opts.timeoutMs ?? 5000;
 
-  return injectSlashCommandWith(makeTmuxRunner(tmuxBin), {
-    socket,
-    session,
-    command: command.trim(),
-    settleMs,
-    timeoutMs,
-  });
+  // Serialize against every other drive on this pane (other injects,
+  // the /model picker driver) — see src/agents/pane-lock.ts. An
+  // inject's Enter landing while another drive's modal is open would
+  // act as that modal's confirm key.
+  return withPaneLock(`${socket}:${session}`, () =>
+    injectSlashCommandWith(makeTmuxRunner(tmuxBin), {
+      socket,
+      session,
+      command: command.trim(),
+      settleMs,
+      timeoutMs,
+    }),
+  );
 }
 
 /**

--- a/src/agents/model-picker.ts
+++ b/src/agents/model-picker.ts
@@ -1,0 +1,353 @@
+/**
+ * Claude CLI `/model` picker driver — discovery + selection over tmux.
+ *
+ * The Telegram `/model` menu must list whatever models the *installed*
+ * claude CLI offers, without hardcoding names that go stale when
+ * Anthropic ships new models. The only durable source of that list is
+ * claude's own `/model` picker, so this module drives it:
+ *
+ *   discoverModels()  open picker → parse the rendered option rows →
+ *                     ALWAYS Esc out (verified) → return the options.
+ *   selectModel()     open picker → parse → arrow-key the cursor to the
+ *                     target row (matched by label, never by stale
+ *                     index) → press `s` (session-only apply) → capture
+ *                     claude's confirmation. Esc + bail on any mismatch.
+ *
+ * Validated against claude 2.1.170's picker (2026-06-10, test-harness):
+ *
+ *     Select model
+ *     Switch between Claude models. Your pick becomes the default ...
+ *
+ *       1. Default (recommended)  Opus 4.8 with 1M context · Best for
+ *                                 everyday, complex tasks
+ *     ❯ 2. Sonnet ✔               Sonnet 4.6 · Efficient for routine tasks
+ *       3. Haiku                  Haiku 4.5 · Fastest for quick answers
+ *
+ *     ○ Low effort ←/→ to adjust
+ *
+ *     Enter to set as default · s to use this session only · Esc to cancel
+ *
+ * Semantics: `✔` marks the current model, `❯` the cursor (which starts
+ * on the current row), wrapped descriptions continue on indented lines,
+ * and the footer's "Esc to cancel" is the fully-rendered signal. We
+ * press `s` (session-only) rather than Enter — Enter writes claude's
+ * own settings default, which switchroom's scaffold overwrites on the
+ * next reconcile anyway; session-only keeps one source of persistent
+ * truth (`model:` in switchroom.yaml).
+ *
+ * Safety invariants (pinned by tests/model-picker.test.ts):
+ *   - The picker is NEVER left open: every exit path of both verbs
+ *     sends Escape unless a selection keypress already dismissed it,
+ *     and dismissal is verified by re-capture (retry Esc once).
+ *   - Selection navigates relative to the parsed cursor and re-verifies
+ *     the cursor row label before pressing `s` — a pane that shifted
+ *     between parse and keypress aborts instead of selecting blind.
+ */
+
+import { makeTmuxRunner, type TmuxRunner } from "./inject.js";
+
+export interface ModelPickerOption {
+  /** 1-based number as rendered by the picker. */
+  index: number;
+  /** Row label, e.g. "Default (recommended)", "Sonnet" — ✔ stripped. */
+  label: string;
+  /** First-line description column (continuations appended). */
+  detail: string;
+  /** True for the row carrying the ✔ current-model marker. */
+  current: boolean;
+}
+
+export interface ParsedModelPicker {
+  options: ModelPickerOption[];
+  /** 1-based index of the row the ❯ cursor sits on; -1 if not seen. */
+  cursorIndex: number;
+  /** True when the "Esc to cancel" footer rendered (modal complete). */
+  footerSeen: boolean;
+}
+
+const HEADER_RE = /Select model/;
+const OPTION_RE = /^\s*(❯)?\s*(\d+)\.\s+(.*)$/;
+const FOOTER_RE = /Esc to cancel/i;
+const EFFORT_RE = /^\s*○\s/;
+
+/**
+ * Parse the LAST rendered `/model` picker out of a pane capture.
+ * Anchoring on the last "Select model" occurrence makes the parse
+ * immune to older pickers still sitting in scrollback. Returns null
+ * when no picker (or no option rows) is found.
+ */
+export function parseModelPicker(pane: string): ParsedModelPicker | null {
+  const lines = pane.split("\n");
+  let headerIdx = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (HEADER_RE.test(lines[i])) {
+      headerIdx = i;
+      break;
+    }
+  }
+  if (headerIdx < 0) return null;
+
+  const options: ModelPickerOption[] = [];
+  let cursorIndex = -1;
+  let footerSeen = false;
+
+  for (let i = headerIdx + 1; i < lines.length; i++) {
+    const raw = lines[i];
+    if (FOOTER_RE.test(raw)) {
+      footerSeen = true;
+      break;
+    }
+    if (EFFORT_RE.test(raw)) continue; // effort selector row — not an option
+    const m = OPTION_RE.exec(raw);
+    if (m) {
+      const index = Number(m[2]);
+      // Split label from the description column on a run of 2+ spaces.
+      // Labels contain single spaces ("Default (recommended)"); the
+      // picker aligns the description with a wide gap.
+      const rest = m[3].trimEnd();
+      const gap = rest.search(/\s{2,}/);
+      let label = (gap >= 0 ? rest.slice(0, gap) : rest).trim();
+      const detail = gap >= 0 ? rest.slice(gap).trim() : "";
+      let current = false;
+      if (/[✔✓]$/.test(label)) {
+        current = true;
+        label = label.replace(/\s*[✔✓]$/, "").trim();
+      }
+      if (label.length === 0) continue;
+      options.push({ index, label, detail, current });
+      if (m[1]) cursorIndex = index;
+      continue;
+    }
+    // Wrapped description continuation: indented, after at least one
+    // option, no option-number shape. Append to the last option.
+    if (options.length > 0 && /^\s{4,}\S/.test(raw)) {
+      const last = options[options.length - 1];
+      last.detail = `${last.detail} ${raw.trim()}`.trim();
+      continue;
+    }
+    // Header description lines before the first option — skip.
+  }
+
+  if (options.length === 0) return null;
+  return { options, cursorIndex, footerSeen };
+}
+
+/** Stable 8-hex tag for a label — used as Telegram callback identity. */
+export function labelTag(label: string): string {
+  // FNV-1a 32-bit; tiny, deterministic, dependency-free. Collisions
+  // across a <10-row picker are practically impossible, and a stale
+  // tag merely fails the match (re-render), never selects a wrong row.
+  let h = 0x811c9dc5;
+  for (const ch of label) {
+    h ^= ch.codePointAt(0)!;
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+export interface PickerOpts {
+  tmuxBin?: string;
+  socketName?: string;
+  sessionName?: string;
+  /** Per-step settle wait (ms). Default 600. */
+  stepMs?: number;
+  /** Hard ceiling on the whole operation (ms). Default 10000. */
+  timeoutMs?: number;
+  /** Test seam — injected runner + sleep. */
+  _runner?: TmuxRunner;
+  _sleep?: (ms: number) => Promise<void>;
+}
+
+export type DiscoverResult =
+  | { ok: true; options: ModelPickerOption[]; currentLabel: string | null }
+  | { ok: false; reason: string };
+
+export type SelectResult =
+  | { ok: true; confirmation: string }
+  | { ok: false; reason: string };
+
+const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+interface Io {
+  runner: TmuxRunner;
+  socket: string;
+  session: string;
+  stepMs: number;
+  timeoutMs: number;
+  sleep: (ms: number) => Promise<void>;
+  startedAt: number;
+}
+
+function makeIo(agentName: string, opts: PickerOpts): Io {
+  return {
+    runner: opts._runner ?? makeTmuxRunner(opts.tmuxBin ?? "tmux"),
+    socket: opts.socketName ?? `switchroom-${agentName}`,
+    session: opts.sessionName ?? agentName,
+    stepMs: opts.stepMs ?? 600,
+    timeoutMs: opts.timeoutMs ?? 10_000,
+    sleep: opts._sleep ?? realSleep,
+    startedAt: Date.now(),
+  };
+}
+
+function expired(io: Io): boolean {
+  return Date.now() - io.startedAt >= io.timeoutMs;
+}
+
+function sendLiteral(io: Io, text: string): void {
+  io.runner.send(io.socket, io.session, ["send-keys", "-l", text]);
+}
+
+function sendKey(io: Io, key: string): void {
+  io.runner.send(io.socket, io.session, ["send-keys", key]);
+}
+
+/** Open the picker and poll until it parses with a rendered footer. */
+async function openPicker(io: Io): Promise<ParsedModelPicker | null> {
+  sendLiteral(io, "/model");
+  sendKey(io, "Enter");
+  // Poll for the fully-rendered modal (footer visible). The picker
+  // typically renders in well under a second; the loop is bounded by
+  // the overall timeout.
+  for (;;) {
+    await io.sleep(io.stepMs);
+    const pane = io.runner.capture(io.socket, io.session) ?? "";
+    const parsed = parseModelPicker(pane);
+    if (parsed?.footerSeen) return parsed;
+    if (expired(io)) return parsed; // best parse we got (may be null)
+  }
+}
+
+/**
+ * Send Escape and verify the modal actually dismissed (footer no
+ * longer parseable as an open picker). Retries once. Never throws.
+ */
+async function dismissPicker(io: Io): Promise<boolean> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      sendKey(io, "Escape");
+    } catch {
+      return false;
+    }
+    await io.sleep(io.stepMs);
+    const pane = io.runner.capture(io.socket, io.session) ?? "";
+    const parsed = parseModelPicker(pane);
+    // Dismissed when the last picker render no longer shows its footer
+    // *as the live tail* — after Esc claude prints a "Kept model as …"
+    // line below the old render, so the simplest robust check is that
+    // a fresh parse no longer reports a footer-complete modal whose
+    // footer is at the pane tail. We approximate with: no parse, or
+    // text after the footer line (the confirmation).
+    if (!parsed || !parsed.footerSeen) return true;
+    const tail = pane.slice(pane.lastIndexOf("Esc to cancel"));
+    if (tail.split("\n").slice(1).some((l) => l.trim().length > 0)) return true;
+  }
+  return false;
+}
+
+/**
+ * Discover the model options claude's picker offers. Opens the picker,
+ * parses it, and ALWAYS attempts dismissal before returning.
+ */
+export async function discoverModels(
+  agentName: string,
+  opts: PickerOpts = {},
+): Promise<DiscoverResult> {
+  const io = makeIo(agentName, opts);
+  if (!io.runner.hasSession(io.socket, io.session)) {
+    return { ok: false, reason: "tmux session not found" };
+  }
+  let parsed: ParsedModelPicker | null = null;
+  try {
+    parsed = await openPicker(io);
+  } finally {
+    await dismissPicker(io);
+  }
+  if (!parsed || !parsed.footerSeen) {
+    return {
+      ok: false,
+      reason: "picker did not render — agent may be mid-turn or the CLI changed its /model UI",
+    };
+  }
+  const current = parsed.options.find((o) => o.current) ?? null;
+  return { ok: true, options: parsed.options, currentLabel: current?.label ?? null };
+}
+
+/**
+ * Select a model by LABEL via the picker, applying session-only (`s`).
+ * Re-opens and re-parses the picker fresh — never trusts a previously
+ * rendered index. Any mismatch aborts via Escape.
+ */
+export async function selectModel(
+  agentName: string,
+  targetLabel: string,
+  opts: PickerOpts = {},
+): Promise<SelectResult> {
+  const io = makeIo(agentName, opts);
+  if (!io.runner.hasSession(io.socket, io.session)) {
+    return { ok: false, reason: "tmux session not found" };
+  }
+
+  let selected = false;
+  try {
+    const parsed = await openPicker(io);
+    if (!parsed || !parsed.footerSeen) {
+      return { ok: false, reason: "picker did not render — agent may be mid-turn" };
+    }
+    const target = parsed.options.find((o) => o.label === targetLabel);
+    if (!target) {
+      const have = parsed.options.map((o) => o.label).join(", ");
+      return { ok: false, reason: `option "${targetLabel}" not offered (have: ${have})` };
+    }
+    if (parsed.cursorIndex < 0) {
+      return { ok: false, reason: "cursor marker not visible — refusing blind navigation" };
+    }
+
+    // Walk the cursor to the target row one keypress at a time,
+    // verifying position after the walk. Option indices are the
+    // picker's own contiguous numbering.
+    const delta = target.index - parsed.cursorIndex;
+    const key = delta > 0 ? "Down" : "Up";
+    for (let i = 0; i < Math.abs(delta); i++) {
+      if (expired(io)) return { ok: false, reason: "timed out navigating picker" };
+      sendKey(io, key);
+      await io.sleep(Math.min(io.stepMs, 250));
+    }
+    await io.sleep(io.stepMs);
+    const verifyPane = io.runner.capture(io.socket, io.session) ?? "";
+    const verify = parseModelPicker(verifyPane);
+    const atRow = verify?.options.find((o) => o.index === verify.cursorIndex);
+    if (!verify || !atRow || atRow.label !== targetLabel) {
+      return {
+        ok: false,
+        reason: `cursor verification failed (on "${atRow?.label ?? "?"}", wanted "${targetLabel}")`,
+      };
+    }
+
+    // `s` = apply for this session only.
+    sendLiteral(io, "s");
+    selected = true;
+    await io.sleep(io.stepMs);
+    const after = io.runner.capture(io.socket, io.session) ?? "";
+    const confirmation = extractConfirmation(after) ?? `Switched to ${targetLabel} (session)`;
+    return { ok: true, confirmation };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  } finally {
+    if (!selected) await dismissPicker(io);
+  }
+}
+
+/**
+ * Pull claude's post-selection confirmation line from the pane tail —
+ * e.g. "Set model to Haiku 4.5 for this session" / "Kept model as …".
+ * Returns null when no recognizable line is present.
+ */
+export function extractConfirmation(pane: string): string | null {
+  const lines = pane.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const t = lines[i].replace(/^\s*⎿\s*/, "").trim();
+    if (/^(Set model to|Kept model as|Switched to)/i.test(t)) return t;
+  }
+  return null;
+}

--- a/src/agents/model-picker.ts
+++ b/src/agents/model-picker.ts
@@ -45,6 +45,7 @@
  */
 
 import { makeTmuxRunner, type TmuxRunner } from "./inject.js";
+import { withPaneLock } from "./pane-lock.js";
 
 export interface ModelPickerOption {
   /** 1-based number as rendered by the picker. */
@@ -153,18 +154,25 @@ export interface PickerOpts {
   stepMs?: number;
   /** Hard ceiling on the whole operation (ms). Default 10000. */
   timeoutMs?: number;
-  /** Test seam — injected runner + sleep. */
+  /** Test seam — injected runner + sleep + logger. */
   _runner?: TmuxRunner;
   _sleep?: (ms: number) => Promise<void>;
+  _log?: (line: string) => void;
 }
 
 export type DiscoverResult =
-  | { ok: true; options: ModelPickerOption[]; currentLabel: string | null }
-  | { ok: false; reason: string };
+  | {
+      ok: true;
+      options: ModelPickerOption[];
+      currentLabel: string | null;
+      /** Esc + verify failed twice — the modal may still be open. */
+      dismissFailed?: true;
+    }
+  | { ok: false; reason: string; dismissFailed?: true };
 
 export type SelectResult =
   | { ok: true; confirmation: string }
-  | { ok: false; reason: string };
+  | { ok: false; reason: string; dismissFailed?: true };
 
 const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -175,6 +183,7 @@ interface Io {
   stepMs: number;
   timeoutMs: number;
   sleep: (ms: number) => Promise<void>;
+  log: (line: string) => void;
   startedAt: number;
 }
 
@@ -186,8 +195,26 @@ function makeIo(agentName: string, opts: PickerOpts): Io {
     stepMs: opts.stepMs ?? 600,
     timeoutMs: opts.timeoutMs ?? 10_000,
     sleep: opts._sleep ?? realSleep,
+    log: opts._log ?? ((line) => process.stderr.write(`${line}\n`)),
     startedAt: Date.now(),
   };
+}
+
+/**
+ * Dismiss + loudly report a failure. A false return means two
+ * Esc+verify rounds could not confirm the modal closed — the
+ * /rate-limit-options wedge class. The gateway log is the fleet's
+ * wedge forensics surface, so this must never fail silently.
+ */
+async function dismissOrWarn(io: Io, verb: string): Promise<boolean> {
+  const dismissed = await dismissPicker(io);
+  if (!dismissed) {
+    io.log(
+      `model-picker: ${verb}: picker may still be open after Esc retries ` +
+        `(socket=${io.socket} session=${io.session}) — pane needs eyes`,
+    );
+  }
+  return dismissed;
 }
 
 function expired(io: Io): boolean {
@@ -257,20 +284,29 @@ export async function discoverModels(
   if (!io.runner.hasSession(io.socket, io.session)) {
     return { ok: false, reason: "tmux session not found" };
   }
-  let parsed: ParsedModelPicker | null = null;
-  try {
-    parsed = await openPicker(io);
-  } finally {
-    await dismissPicker(io);
-  }
-  if (!parsed || !parsed.footerSeen) {
-    return {
-      ok: false,
-      reason: "picker did not render — agent may be mid-turn or the CLI changed its /model UI",
-    };
-  }
-  const current = parsed.options.find((o) => o.current) ?? null;
-  return { ok: true, options: parsed.options, currentLabel: current?.label ?? null };
+  // Serialize against every other drive on this pane (other /model
+  // dashboards, taps, /inject) — an overlapping drive's Enter landing
+  // in an open picker is the modal's "set as default".
+  return withPaneLock(`${io.socket}:${io.session}`, async () => {
+    io.startedAt = Date.now(); // budget starts when the lock is held
+    let parsed: ParsedModelPicker | null = null;
+    let dismissed = true;
+    try {
+      parsed = await openPicker(io);
+    } finally {
+      dismissed = await dismissOrWarn(io, "discover");
+    }
+    const tail = dismissed ? {} : { dismissFailed: true as const };
+    if (!parsed || !parsed.footerSeen) {
+      return {
+        ok: false,
+        reason: "picker did not render — agent may be mid-turn or the CLI changed its /model UI",
+        ...tail,
+      };
+    }
+    const current = parsed.options.find((o) => o.current) ?? null;
+    return { ok: true, options: parsed.options, currentLabel: current?.label ?? null, ...tail };
+  });
 }
 
 /**
@@ -288,54 +324,62 @@ export async function selectModel(
     return { ok: false, reason: "tmux session not found" };
   }
 
-  let selected = false;
-  try {
-    const parsed = await openPicker(io);
-    if (!parsed || !parsed.footerSeen) {
-      return { ok: false, reason: "picker did not render — agent may be mid-turn" };
-    }
-    const target = parsed.options.find((o) => o.label === targetLabel);
-    if (!target) {
-      const have = parsed.options.map((o) => o.label).join(", ");
-      return { ok: false, reason: `option "${targetLabel}" not offered (have: ${have})` };
-    }
-    if (parsed.cursorIndex < 0) {
-      return { ok: false, reason: "cursor marker not visible — refusing blind navigation" };
-    }
+  // Same per-pane serialization as discoverModels — see that comment.
+  return withPaneLock(`${io.socket}:${io.session}`, async () => {
+    io.startedAt = Date.now(); // budget starts when the lock is held
+    let selected = false;
+    try {
+      const parsed = await openPicker(io);
+      if (!parsed || !parsed.footerSeen) {
+        return { ok: false, reason: "picker did not render — agent may be mid-turn" };
+      }
+      const target = parsed.options.find((o) => o.label === targetLabel);
+      if (!target) {
+        const have = parsed.options.map((o) => o.label).join(", ");
+        return { ok: false, reason: `option "${targetLabel}" not offered (have: ${have})` };
+      }
+      if (parsed.cursorIndex < 0) {
+        return { ok: false, reason: "cursor marker not visible — refusing blind navigation" };
+      }
 
-    // Walk the cursor to the target row one keypress at a time,
-    // verifying position after the walk. Option indices are the
-    // picker's own contiguous numbering.
-    const delta = target.index - parsed.cursorIndex;
-    const key = delta > 0 ? "Down" : "Up";
-    for (let i = 0; i < Math.abs(delta); i++) {
-      if (expired(io)) return { ok: false, reason: "timed out navigating picker" };
-      sendKey(io, key);
-      await io.sleep(Math.min(io.stepMs, 250));
-    }
-    await io.sleep(io.stepMs);
-    const verifyPane = io.runner.capture(io.socket, io.session) ?? "";
-    const verify = parseModelPicker(verifyPane);
-    const atRow = verify?.options.find((o) => o.index === verify.cursorIndex);
-    if (!verify || !atRow || atRow.label !== targetLabel) {
-      return {
-        ok: false,
-        reason: `cursor verification failed (on "${atRow?.label ?? "?"}", wanted "${targetLabel}")`,
-      };
-    }
+      // Walk the cursor to the target row one keypress at a time,
+      // verifying position after the walk. Option indices are the
+      // picker's own contiguous numbering.
+      const delta = target.index - parsed.cursorIndex;
+      const key = delta > 0 ? "Down" : "Up";
+      for (let i = 0; i < Math.abs(delta); i++) {
+        if (expired(io)) return { ok: false, reason: "timed out navigating picker" };
+        sendKey(io, key);
+        await io.sleep(Math.min(io.stepMs, 250));
+      }
+      await io.sleep(io.stepMs);
+      const verifyPane = io.runner.capture(io.socket, io.session) ?? "";
+      const verify = parseModelPicker(verifyPane);
+      const atRow = verify?.options.find((o) => o.index === verify.cursorIndex);
+      if (!verify || !atRow || atRow.label !== targetLabel) {
+        return {
+          ok: false,
+          reason: `cursor verification failed (on "${atRow?.label ?? "?"}", wanted "${targetLabel}")`,
+        };
+      }
 
-    // `s` = apply for this session only.
-    sendLiteral(io, "s");
-    selected = true;
-    await io.sleep(io.stepMs);
-    const after = io.runner.capture(io.socket, io.session) ?? "";
-    const confirmation = extractConfirmation(after) ?? `Switched to ${targetLabel} (session)`;
-    return { ok: true, confirmation };
-  } catch (err) {
-    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
-  } finally {
-    if (!selected) await dismissPicker(io);
-  }
+      // `s` = apply for this session only — the keypress dismisses the
+      // modal itself, so no Escape on this path.
+      sendLiteral(io, "s");
+      selected = true;
+      await io.sleep(io.stepMs);
+      const after = io.runner.capture(io.socket, io.session) ?? "";
+      const confirmation = extractConfirmation(after) ?? `Switched to ${targetLabel} (session)`;
+      return { ok: true, confirmation };
+    } catch (err) {
+      return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+    } finally {
+      if (!selected) {
+        const dismissed = await dismissOrWarn(io, "select");
+        void dismissed; // failure already logged loudly; result shape unchanged here
+      }
+    }
+  });
 }
 
 /**

--- a/src/agents/model-picker.ts
+++ b/src/agents/model-picker.ts
@@ -172,7 +172,7 @@ export type DiscoverResult =
 
 export type SelectResult =
   | { ok: true; confirmation: string }
-  | { ok: false; reason: string; dismissFailed?: true };
+  | { ok: false; reason: string };
 
 const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -375,8 +375,8 @@ export async function selectModel(
       return { ok: false, reason: err instanceof Error ? err.message : String(err) };
     } finally {
       if (!selected) {
-        const dismissed = await dismissOrWarn(io, "select");
-        void dismissed; // failure already logged loudly; result shape unchanged here
+        // Failure is reported loudly inside dismissOrWarn (gateway log).
+        await dismissOrWarn(io, "select");
       }
     }
   });

--- a/src/agents/pane-lock.ts
+++ b/src/agents/pane-lock.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-pane drive serialization (PR #2263 review blocker 1).
+ *
+ * Anything that types keys into a claude tmux pane and reads the
+ * rendered result (the /model picker driver, slash-command inject)
+ * MUST NOT overlap with another such drive on the same pane: a second
+ * drive's Enter landing while the first drive's picker modal is open
+ * acts as the picker's "set as default" — applying whatever row the
+ * cursor happens to be on. A simple promise-chain mutex keyed by
+ * `socket:session` serializes drives; callers queue rather than
+ * interleave.
+ *
+ * The chain never accumulates rejected state (failures are swallowed
+ * in the stored tail; the caller still sees its own rejection), and
+ * entries are dropped once their tail settles so the map can't grow
+ * unboundedly across agent lifetimes.
+ */
+
+const tails = new Map<string, Promise<void>>();
+
+export function withPaneLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const tail = tails.get(key) ?? Promise.resolve();
+  const run = tail.then(() => fn());
+  const next = run.then(
+    () => {},
+    () => {},
+  );
+  tails.set(key, next);
+  void next.then(() => {
+    if (tails.get(key) === next) tails.delete(key);
+  });
+  return run;
+}
+
+/** Test seam — count of currently-tracked pane chains. */
+export function _paneLockSize(): number {
+  return tails.size;
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -18396,9 +18396,28 @@ bot.on('callback_query:data', async ctx => {
       await ctx.answerCallbackQuery({ text: 'Not authorized.' })
       return
     }
+    // Kill-switch covers the callback family too — stale menus keep
+    // their buttons after the flag flips, and the flag exists exactly
+    // for "picker-driving is misbehaving" (#2263 review blocker 2).
+    if (process.env.SWITCHROOM_MODEL_MENU === '0') {
+      await ctx.answerCallbackQuery({ text: 'Model menu is disabled (SWITCHROOM_MODEL_MENU=0).' }).catch(() => {})
+      await ctx
+        .editMessageText('Model menu is disabled on this agent. Use <code>/model &lt;name&gt;</code>.', {
+          parse_mode: 'HTML',
+          reply_markup: { inline_keyboard: [] },
+        })
+        .catch(() => {})
+      return
+    }
+    // Answer the callback IMMEDIATELY — the select path drives the
+    // picker up to three times (multi-second); leaving the tap
+    // spinning invites a double-tap, which queues a second drive
+    // behind the pane lock and confuses the user. The final state is
+    // conveyed by the message edit (a callback can only be answered
+    // once).
+    await ctx.answerCallbackQuery({ text: 'Working…' }).catch(() => {})
     try {
       const outcome = await handleModelMenuCallback(data, buildModelDeps())
-      await ctx.answerCallbackQuery({ text: outcome.answer.slice(0, 190) }).catch(() => {})
       await ctx
         .editMessageText(outcome.reply.text, {
           parse_mode: 'HTML',
@@ -18409,7 +18428,6 @@ bot.on('callback_query:data', async ctx => {
       process.stderr.write(
         `telegram gateway: model-menu callback failed: ${(err as Error)?.message ?? String(err)}\n`,
       )
-      await ctx.answerCallbackQuery({ text: 'Model menu error — check logs.' }).catch(() => {})
     }
     return
   }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -247,6 +247,7 @@ import {
 import {
   fetchQuota,
   formatQuotaBlock,
+  formatQuotaLine,
   type QuotaResult,
 } from '../quota-check.js'
 import {
@@ -258,7 +259,17 @@ import { DEFAULT_SLOT } from '../../src/auth/accounts.js'
 import { currentActiveSlot, type AuthCodeOutcome } from '../../src/auth/manager.js'
 import { injectSlashCommand as injectSlashCommandImpl } from '../../src/agents/inject.js'
 import { handleInjectCommand } from './inject-handler.js'
-import { parseModelCommand, handleModelCommand } from './model-command.js'
+import {
+  parseModelCommand,
+  handleModelCommand,
+  buildModelMenu,
+  handleModelMenuCallback,
+  MODEL_CALLBACK_PREFIX,
+  type ModelMenuDeps,
+  type ModelCommandDeps,
+  type ModelMenuReply,
+} from './model-command.js'
+import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
 import { loadConfig as loadSwitchroomConfig, findConfigFile as findSwitchroomConfigFile } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
@@ -13922,19 +13933,39 @@ bot.command('inject', async ctx => {
   })
 })
 
-// /model — show or switch the Claude model for this agent's live
-// session. The argument form rides the same allowlisted inject
-// primitive as /inject (claude's native `/model <name>` REPL command);
-// the bare form never injects (the no-arg picker is an undriveable TUI
-// modal from Telegram). Implementation in model-command.ts so it's
+// /model — model dashboard + switch for this agent's live session.
+// Bare form: drives claude's own /model picker (open → parse → Esc,
+// src/agents/model-picker.ts) to discover the live option list — no
+// hardcoded model names — and renders it as an inline-keyboard menu
+// with the current model + a brief quota line. A tap re-opens the
+// picker fresh and applies session-only (`s`). Kill-switch
+// SWITCHROOM_MODEL_MENU=0 reverts the bare form to the static v1
+// text. The typed argument form rides the allowlisted inject
+// primitive unchanged. Implementation in model-command.ts so it's
 // unit-testable without booting the bot.
-bot.command('model', async ctx => {
-  if (!isAuthorizedSender(ctx)) return
-  const text = ctx.message?.text ?? ctx.channelPost?.text ?? ''
-  const parsed = parseModelCommand(text) ?? { kind: 'show' as const }
-  const reply = await handleModelCommand(parsed, {
-    inject: injectSlashCommandImpl,
+function buildModelDeps(): ModelMenuDeps & ModelCommandDeps {
+  return {
+    discover: (a) => discoverModels(a),
+    select: (a, label) => selectModel(a, label),
+    isBusy: () => currentTurn !== null,
     getAgentName: getMyAgentName,
+    getQuotaBrief: async () => {
+      // Broker-routed probe first (authoritative), local headers as
+      // fallback — same ladder as the boot card / legacy /usage.
+      try {
+        const probed = await probeQuotaForBootCard(getMyAgentName(), 4000)
+        if (probed?.ok) return formatQuotaLine(probed.data)
+      } catch { /* fall through */ }
+      try {
+        const agentDir = resolveAgentDirFromEnv()
+        if (agentDir) {
+          const local = await fetchQuota({ claudeConfigDir: join(agentDir, '.claude') })
+          if (local.ok) return formatQuotaLine(local.data)
+        }
+      } catch { /* quota is garnish — never block the menu on it */ }
+      return null
+    },
+    inject: injectSlashCommandImpl,
     getConfiguredModel: () => {
       type AgentListResp = { agents: Array<{ name: string; model?: string | null }> }
       const data = switchroomExecJson<AgentListResp>(['agent', 'list'])
@@ -13942,7 +13973,30 @@ bot.command('model', async ctx => {
     },
     escapeHtml: escapeHtmlForTg,
     preBlock,
-  })
+  }
+}
+
+function modelMenuReplyMarkup(reply: ModelMenuReply): InlineKeyboard | undefined {
+  if (!reply.keyboard) return undefined
+  const kb = new InlineKeyboard()
+  for (const row of reply.keyboard) {
+    for (const btn of row) kb.text(btn.text, btn.callback_data)
+    kb.row()
+  }
+  return kb
+}
+
+bot.command('model', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  const text = ctx.message?.text ?? ctx.channelPost?.text ?? ''
+  const parsed = parseModelCommand(text) ?? { kind: 'show' as const }
+  const deps = buildModelDeps()
+  if (parsed.kind === 'show' && process.env.SWITCHROOM_MODEL_MENU !== '0') {
+    const menu = await buildModelMenu(deps)
+    await switchroomReply(ctx, menu.text, { html: true, reply_markup: modelMenuReplyMarkup(menu) })
+    return
+  }
+  const reply = await handleModelCommand(parsed, deps)
   await switchroomReply(ctx, reply.text, { html: reply.html })
 })
 
@@ -18327,6 +18381,36 @@ bot.on('callback_query:data', async ctx => {
   // existing CLI invocations plus dashboard refresh.
   if (data.startsWith('auth:')) {
     await handleAuthDashboardCallback(ctx)
+    return
+  }
+
+  // `mdl:*` — model-menu taps (/model dashboard). `mdl:s:<tag>`
+  // selects a model by label-tag via a fresh picker discovery (never
+  // a stale index); `mdl:r` re-renders. Strict allowFrom gate like
+  // every other mutating callback family — a model switch changes the
+  // fleet's quota burn profile.
+  if (data.startsWith(MODEL_CALLBACK_PREFIX)) {
+    const access = loadAccess()
+    const senderId = String(ctx.from?.id ?? '')
+    if (!access.allowFrom.includes(senderId)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' })
+      return
+    }
+    try {
+      const outcome = await handleModelMenuCallback(data, buildModelDeps())
+      await ctx.answerCallbackQuery({ text: outcome.answer.slice(0, 190) }).catch(() => {})
+      await ctx
+        .editMessageText(outcome.reply.text, {
+          parse_mode: 'HTML',
+          reply_markup: modelMenuReplyMarkup(outcome.reply) ?? { inline_keyboard: [] },
+        })
+        .catch(() => {})
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: model-menu callback failed: ${(err as Error)?.message ?? String(err)}\n`,
+      )
+      await ctx.answerCallbackQuery({ text: 'Model menu error — check logs.' }).catch(() => {})
+    }
     return
   }
 

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -281,6 +281,9 @@ export async function buildModelMenu(
 
   const current = discovered.options.find((o) => o.current)
   const lines: string[] = [`<b>Model — ${deps.escapeHtml(deps.getAgentName())}</b>`]
+  if (discovered.dismissFailed) {
+    lines.push('⚠️ <i>The picker may still be open on the agent pane — check it before switching.</i>')
+  }
   if (current) {
     const detail = current.detail ? ` · ${deps.escapeHtml(current.detail)}` : ''
     lines.push(`Now: <b>${deps.escapeHtml(current.label)}</b>${detail}`)

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -2,13 +2,14 @@
  * Telegram `/model` command — show or switch the Claude model for this
  * agent's live session.
  *
- * `/model` (bare) shows the configured model and the switch options.
- * It deliberately NEVER injects the bare `/model` verb into the claude
- * pane: with no argument the CLI renders an interactive picker modal
- * that nothing on the Telegram side can drive (no arrow keys, no Esc),
- * which would wedge the pane — the same TUI-modal class of wedge as
- * the /rate-limit-options incident. Only the argument form is ever
- * injected.
+ * `/model` (bare) renders the model dashboard: the live model, a brief
+ * quota line, and an inline-keyboard menu of the options claude's own
+ * `/model` picker offers (discovered live via `src/agents/model-picker.ts`
+ * — opened, parsed, Esc'd; never hardcoded, so new models appear the
+ * moment the installed CLI offers them). A button tap re-opens the
+ * picker fresh, matches the row by label, and applies session-only.
+ * When discovery fails (agent mid-turn, CLI UI changed, kill-switched
+ * via SWITCHROOM_MODEL_MENU=0) it falls back to the static v1 text.
  *
  * `/model <alias|full-id>` types claude's own `/model <name>` into the
  * agent's tmux pane via the existing allowlisted inject primitive
@@ -24,6 +25,12 @@
  */
 
 import type { InjectResult } from '../../src/agents/inject.js'
+import {
+  labelTag,
+  type DiscoverResult,
+  type SelectResult,
+  type ModelPickerOption,
+} from '../../src/agents/model-picker.js'
 
 /**
  * Aliases the claude CLI resolves natively. Listed in help text only —
@@ -179,4 +186,180 @@ export async function handleModelCommand(
     text: `❌ ${verbHtml} — ${deps.escapeHtml(result.errorMessage ?? 'inject failed')}`,
     html: true,
   }
+}
+
+// ---------------------------------------------------------------------------
+// Picker-driven model menu (v2) — discovery, render, callback selection.
+// ---------------------------------------------------------------------------
+
+export interface ModelMenuDeps {
+  /** Live picker discovery — src/agents/model-picker.ts discoverModels. */
+  discover: (agent: string) => Promise<DiscoverResult>
+  /** Live picker selection by label — selectModel (session-only `s`). */
+  select: (agent: string, label: string) => Promise<SelectResult>
+  /**
+   * True while the agent is mid-turn. Driving the picker types into
+   * claude's input box; doing that mid-turn would queue "/model" as
+   * user text instead of opening the modal — refuse instead.
+   */
+  isBusy: () => boolean
+  getAgentName: () => string
+  /** One-line quota summary (e.g. "29% / 5h · 33% / 7d") or null. */
+  getQuotaBrief: () => Promise<string | null>
+  escapeHtml: (s: string) => string
+}
+
+/** Raw Telegram inline-keyboard shape (grammY accepts it verbatim). */
+export interface ModelMenuKeyboardButton {
+  text: string
+  callback_data: string
+}
+
+export interface ModelMenuReply {
+  text: string
+  html: true
+  /** Rows of buttons; absent on the no-menu fallback. */
+  keyboard?: ModelMenuKeyboardButton[][]
+}
+
+export const MODEL_CALLBACK_PREFIX = 'mdl:'
+const MODEL_CALLBACK_SELECT = 'mdl:s:'
+export const MODEL_CALLBACK_REFRESH = 'mdl:r'
+
+export function modelSelectCallbackData(label: string): string {
+  // Identity is the label's hash, not its index — a tap re-discovers
+  // the picker and matches by tag, so a list that shifted between
+  // render and tap can never select the wrong row. 8 hex chars keeps
+  // callback_data tiny (well under Telegram's 64-byte cap).
+  return `${MODEL_CALLBACK_SELECT}${labelTag(label)}`
+}
+
+function busyReply(deps: Pick<ModelMenuDeps, 'escapeHtml'>): ModelMenuReply {
+  return {
+    text: '⏳ The agent is mid-turn — the model picker needs an idle prompt. Try again in a moment.',
+    html: true,
+  }
+}
+
+function menuKeyboard(options: ModelPickerOption[]): ModelMenuKeyboardButton[][] {
+  // One option per row (labels + ✔ render cleanly at full width on
+  // mobile), refresh on a trailing row.
+  const rows: ModelMenuKeyboardButton[][] = options.map((o) => [
+    {
+      text: o.current ? `✅ ${o.label}` : o.label,
+      callback_data: modelSelectCallbackData(o.label),
+    },
+  ])
+  rows.push([{ text: '🔄 Refresh', callback_data: MODEL_CALLBACK_REFRESH }])
+  return rows
+}
+
+/**
+ * Build the `/model` dashboard: live model + quota brief + tap menu.
+ * Returns a keyboard-less fallback (v1-shaped static text) when the
+ * picker can't be driven right now — the command never hard-fails.
+ */
+export async function buildModelMenu(
+  deps: ModelMenuDeps & ModelCommandDeps,
+): Promise<ModelMenuReply> {
+  if (deps.isBusy()) return busyReply(deps)
+
+  const [discovered, quota] = await Promise.all([
+    deps.discover(deps.getAgentName()),
+    deps.getQuotaBrief().catch(() => null),
+  ])
+
+  if (!discovered.ok) {
+    // Graceful static fallback — same content as the v1 show path,
+    // with the discovery failure surfaced.
+    const v1 = await handleModelCommand({ kind: 'show' }, deps)
+    return {
+      text: [`<i>(picker unavailable: ${deps.escapeHtml(discovered.reason)})</i>`, v1.text].join('\n'),
+      html: true,
+    }
+  }
+
+  const current = discovered.options.find((o) => o.current)
+  const lines: string[] = [`<b>Model — ${deps.escapeHtml(deps.getAgentName())}</b>`]
+  if (current) {
+    const detail = current.detail ? ` · ${deps.escapeHtml(current.detail)}` : ''
+    lines.push(`Now: <b>${deps.escapeHtml(current.label)}</b>${detail}`)
+  } else {
+    lines.push('Now: <i>unknown (no ✔ row in picker)</i>')
+  }
+  if (quota) lines.push(`Quota: ${deps.escapeHtml(quota)}`)
+  lines.push('', 'Tap to switch (applies to the live session):')
+  lines.push(PERSIST_NOTE)
+
+  return { text: lines.join('\n'), html: true, keyboard: menuKeyboard(discovered.options) }
+}
+
+export interface ModelCallbackOutcome {
+  /** Short toast for answerCallbackQuery. */
+  answer: string
+  /** Replacement dashboard (message edit). */
+  reply: ModelMenuReply
+}
+
+/**
+ * Handle a `mdl:*` callback tap. `mdl:r` re-renders the dashboard;
+ * `mdl:s:<tag>` re-discovers the picker, resolves the tag back to a
+ * live label, and applies it session-only. A tag that no longer
+ * matches (claude updated its options since render) re-renders the
+ * menu instead of guessing.
+ */
+export async function handleModelMenuCallback(
+  data: string,
+  deps: ModelMenuDeps & ModelCommandDeps,
+): Promise<ModelCallbackOutcome> {
+  if (data === MODEL_CALLBACK_REFRESH) {
+    return { answer: 'Refreshed', reply: await buildModelMenu(deps) }
+  }
+  if (!data.startsWith(MODEL_CALLBACK_SELECT)) {
+    return { answer: 'Unknown action', reply: await buildModelMenu(deps) }
+  }
+  if (deps.isBusy()) {
+    return { answer: 'Agent is mid-turn — try again shortly', reply: busyReply(deps) }
+  }
+
+  const tag = data.slice(MODEL_CALLBACK_SELECT.length)
+  const discovered = await deps.discover(deps.getAgentName())
+  if (!discovered.ok) {
+    return {
+      answer: 'Picker unavailable',
+      reply: {
+        text: `❌ Could not open the model picker: ${deps.escapeHtml(discovered.reason)}`,
+        html: true,
+      },
+    }
+  }
+  const target = discovered.options.find((o) => labelTag(o.label) === tag)
+  if (!target) {
+    // Options changed since the menu rendered — never guess; re-render.
+    const fresh = await buildModelMenu(deps)
+    return { answer: 'Model list changed — menu refreshed', reply: fresh }
+  }
+  if (target.current) {
+    const fresh = await buildModelMenu(deps)
+    return { answer: `Already on ${target.label}`, reply: fresh }
+  }
+
+  const result = await deps.select(deps.getAgentName(), target.label)
+  if (!result.ok) {
+    return {
+      answer: 'Switch failed',
+      reply: {
+        text: `❌ Switch to <b>${deps.escapeHtml(target.label)}</b> failed: ${deps.escapeHtml(result.reason)}`,
+        html: true,
+      },
+    }
+  }
+
+  const fresh = await buildModelMenu(deps)
+  const confirmed: ModelMenuReply = {
+    text: [`✅ ${deps.escapeHtml(result.confirmation)}`, '', fresh.text].join('\n'),
+    html: true,
+    ...(fresh.keyboard ? { keyboard: fresh.keyboard } : {}),
+  }
+  return { answer: result.confirmation, reply: confirmed }
 }

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -203,3 +203,147 @@ describe("inject allowlist contract", () => {
     expect(INJECT_COMMANDS.has("/model")).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Picker-driven menu (v2) — buildModelMenu + handleModelMenuCallback
+// ---------------------------------------------------------------------------
+
+import {
+  buildModelMenu,
+  handleModelMenuCallback,
+  modelSelectCallbackData,
+  MODEL_CALLBACK_REFRESH,
+  type ModelMenuDeps,
+} from "../gateway/model-command.js";
+import { labelTag } from "../../src/agents/model-picker.js";
+
+const OPTIONS = [
+  { index: 1, label: "Default (recommended)", detail: "Opus 4.8 with 1M context", current: false },
+  { index: 2, label: "Sonnet", detail: "Sonnet 4.6 · Efficient", current: true },
+  { index: 3, label: "Haiku", detail: "Haiku 4.5 · Fastest", current: false },
+];
+
+function makeMenuDeps(overrides: Partial<ModelMenuDeps> = {}) {
+  const calls = { discover: 0, select: [] as string[] };
+  const base = makeDeps(); // v1 deps (inject/getConfiguredModel/escapeHtml/preBlock)
+  const deps = {
+    ...base.deps,
+    discover: async () => {
+      calls.discover++;
+      return { ok: true as const, options: OPTIONS, currentLabel: "Sonnet" };
+    },
+    select: async (_a: string, label: string) => {
+      calls.select.push(label);
+      return { ok: true as const, confirmation: `Set model to ${label} for this session` };
+    },
+    isBusy: () => false,
+    getQuotaBrief: async () => "29% / 5h · 33% / 7d",
+    ...overrides,
+  };
+  return { deps, calls, injectCalls: base.calls };
+}
+
+describe("buildModelMenu", () => {
+  it("renders current model, quota brief, and one button per discovered option", async () => {
+    const { deps, calls } = makeMenuDeps();
+    const menu = await buildModelMenu(deps);
+    expect(calls.discover).toBe(1);
+    expect(menu.text).toContain("<b>Sonnet</b>");
+    expect(menu.text).toContain("29% / 5h · 33% / 7d");
+    expect(menu.keyboard).toBeDefined();
+    // 3 option rows + refresh row
+    expect(menu.keyboard!.length).toBe(4);
+    expect(menu.keyboard![1][0].text).toBe("✅ Sonnet");
+    expect(menu.keyboard![0][0].text).toBe("Default (recommended)");
+    expect(menu.keyboard![3][0].callback_data).toBe(MODEL_CALLBACK_REFRESH);
+  });
+
+  it("every callback_data fits Telegram's 64-byte cap", async () => {
+    const { deps } = makeMenuDeps();
+    const menu = await buildModelMenu(deps);
+    for (const row of menu.keyboard!) {
+      for (const btn of row) {
+        expect(Buffer.byteLength(btn.callback_data, "utf-8")).toBeLessThanOrEqual(64);
+      }
+    }
+  });
+
+  it("busy agent → no discovery, no keyboard, explanatory text", async () => {
+    const { deps, calls } = makeMenuDeps({ isBusy: () => true });
+    const menu = await buildModelMenu(deps);
+    expect(calls.discover).toBe(0);
+    expect(menu.keyboard).toBeUndefined();
+    expect(menu.text).toContain("mid-turn");
+  });
+
+  it("discovery failure → static v1 fallback with the reason, no keyboard", async () => {
+    const { deps } = makeMenuDeps({
+      discover: async () => ({ ok: false as const, reason: "tmux session not found" }),
+    });
+    const menu = await buildModelMenu(deps);
+    expect(menu.keyboard).toBeUndefined();
+    expect(menu.text).toContain("picker unavailable");
+    expect(menu.text).toContain("Configured:");
+  });
+
+  it("quota failure never blocks the menu", async () => {
+    const { deps } = makeMenuDeps({
+      getQuotaBrief: async () => {
+        throw new Error("broker down");
+      },
+    });
+    const menu = await buildModelMenu(deps);
+    expect(menu.keyboard).toBeDefined();
+    expect(menu.text).not.toContain("Quota:");
+  });
+});
+
+describe("handleModelMenuCallback", () => {
+  it("mdl:s:<tag> selects by re-discovered label", async () => {
+    const { deps, calls } = makeMenuDeps();
+    const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
+    expect(calls.select).toEqual(["Haiku"]);
+    expect(out.answer).toContain("Set model to Haiku");
+    expect(out.reply.text).toContain("✅");
+  });
+
+  it("stale tag (options changed) → never selects, re-renders menu", async () => {
+    const { deps, calls } = makeMenuDeps();
+    const staleTag = `mdl:s:${labelTag("Removed Model")}`;
+    const out = await handleModelMenuCallback(staleTag, deps);
+    expect(calls.select).toEqual([]);
+    expect(out.answer).toContain("refreshed");
+    expect(out.reply.keyboard).toBeDefined();
+  });
+
+  it("tapping the current model is a no-op refresh", async () => {
+    const { deps, calls } = makeMenuDeps();
+    const out = await handleModelMenuCallback(modelSelectCallbackData("Sonnet"), deps);
+    expect(calls.select).toEqual([]);
+    expect(out.answer).toContain("Already on Sonnet");
+  });
+
+  it("busy agent → never selects", async () => {
+    const { deps, calls } = makeMenuDeps({ isBusy: () => true });
+    const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
+    expect(calls.select).toEqual([]);
+    expect(out.answer).toContain("mid-turn");
+  });
+
+  it("selection failure surfaces the reason", async () => {
+    const { deps } = makeMenuDeps({
+      select: async () => ({ ok: false as const, reason: "cursor verification failed" }),
+    });
+    const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
+    expect(out.answer).toBe("Switch failed");
+    expect(out.reply.text).toContain("cursor verification failed");
+  });
+
+  it("mdl:r re-renders the dashboard", async () => {
+    const { deps, calls } = makeMenuDeps();
+    const out = await handleModelMenuCallback(MODEL_CALLBACK_REFRESH, deps);
+    expect(out.answer).toBe("Refreshed");
+    expect(calls.discover).toBe(1);
+    expect(out.reply.keyboard).toBeDefined();
+  });
+});

--- a/telegram-plugin/uat/scenarios/jtbd-model-command-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-model-command-dm.test.ts
@@ -29,19 +29,21 @@ const REPLY_TIMEOUT_MS = 30_000;
 
 describe("uat: /model command — show, switch, bad-name", () => {
   it(
-    "bare /model shows configured model without injecting",
+    "bare /model shows the model dashboard (menu v2) or static fallback (v1)",
     async () => {
       const sc = await spinUp({ agent: AGENT });
       try {
         await sc.sendDM("/model");
-        const reply = await sc.expectMessage(/Configured:/i, {
+        // v2 (picker-driven menu): "Now: <model>"; v1 / fallback path:
+        // "Configured: <model>". Either proves the gateway handled the
+        // command rather than forwarding it to claude as plain text.
+        const shape = /Now:|Configured:/i;
+        const reply = await sc.expectMessage(shape, {
           from: "bot",
           timeout: REPLY_TIMEOUT_MS,
         });
-        expect(reply.text).toMatch(/Configured:/i);
-        // Switch affordances present
-        expect(reply.text).toMatch(/\/model (opus|sonnet|haiku)/);
-        // Persistence caveat present
+        expect(reply.text).toMatch(shape);
+        // Persistence caveat present on both shapes
         expect(reply.text).toMatch(/switchroom\.yaml/i);
       } finally {
         await sc.tearDown();

--- a/tests/model-picker.test.ts
+++ b/tests/model-picker.test.ts
@@ -248,3 +248,92 @@ describe("selectModel", () => {
     expect(sentKeys(sends)).toContain("Escape");
   });
 });
+
+describe("pane-lock serialization (#2263 review blocker 1)", () => {
+  it("two concurrent drives on one pane never interleave keys", async () => {
+    // A slow runner whose captures resolve through real microtasks;
+    // both drives target the same socket:session, so the second must
+    // queue behind the first — the recorded send sequence must be the
+    // first drive's full key sequence followed by the second's, never
+    // interleaved.
+    const sends: string[][] = [];
+    let frameByDrive = 0;
+    const frames = [PICKER, AFTER_ESC, PICKER, AFTER_ESC];
+    const runner: TmuxRunner = {
+      capture: () => frames[Math.min(frameByDrive++, frames.length - 1)],
+      send: (_s, _t, args) => {
+        sends.push(args);
+      },
+      hasSession: () => true,
+    };
+    const opts = { ...fastOpts, _runner: runner };
+    const [a, b] = await Promise.all([
+      discoverModels("samepane", opts),
+      discoverModels("samepane", opts),
+    ]);
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    expect(sentKeys(sends)).toEqual([
+      "/model", "Enter", "Escape",
+      "/model", "Enter", "Escape",
+    ]);
+  });
+
+  it("a select queued behind a discover runs after its Escape", async () => {
+    const sends: string[][] = [];
+    let i = 0;
+    const frames = [
+      // discover: open → esc
+      PICKER, AFTER_ESC,
+      // select: open → walk-verify → s-confirm
+      PICKER, PICKER_CURSOR_3, AFTER_S,
+    ];
+    const runner: TmuxRunner = {
+      capture: () => frames[Math.min(i++, frames.length - 1)],
+      send: (_s, _t, args) => {
+        sends.push(args);
+      },
+      hasSession: () => true,
+    };
+    const opts = { ...fastOpts, _runner: runner };
+    const [d, s] = await Promise.all([
+      discoverModels("samepane2", opts),
+      selectModel("samepane2", "Haiku", opts),
+    ]);
+    expect(d.ok).toBe(true);
+    expect(s).toEqual({ ok: true, confirmation: "Set model to Haiku 4.5 for this session" });
+    expect(sentKeys(sends)).toEqual([
+      "/model", "Enter", "Escape",
+      "/model", "Enter", "Down", "s",
+    ]);
+  });
+});
+
+describe("dismissal failure is loud (#2263 review blocker 3)", () => {
+  it("discover logs + flags dismissFailed when Esc never closes the modal", async () => {
+    // Picker stays rendered with its footer at the tail forever —
+    // dismissal verification can never succeed.
+    const logs: string[] = [];
+    const { runner } = fakeRunner([PICKER]);
+    const res = await discoverModels("agentx", {
+      ...fastOpts,
+      _runner: runner,
+      _log: (l) => logs.push(l),
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.dismissFailed).toBe(true);
+    expect(logs.some((l) => l.includes("may still be open"))).toBe(true);
+  });
+
+  it("failed select logs the stuck-modal warning too", async () => {
+    const logs: string[] = [];
+    const { runner } = fakeRunner([PICKER]);
+    const res = await selectModel("agentx", "Nonexistent Model", {
+      ...fastOpts,
+      _runner: runner,
+      _log: (l) => logs.push(l),
+    });
+    expect(res.ok).toBe(false);
+    expect(logs.some((l) => l.includes("may still be open"))).toBe(true);
+  });
+});

--- a/tests/model-picker.test.ts
+++ b/tests/model-picker.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Claude `/model` picker driver — parser + tmux-driving invariants.
+ *
+ * The PICKER fixture is a verbatim capture from claude CLI 2.1.170 on
+ * the live test-harness agent (2026-06-10) — if claude changes its
+ * picker layout, update the fixture from a fresh capture and the
+ * parser together.
+ *
+ * Headline safety invariants:
+ *   1. Esc-always: every discovery path and every failed selection
+ *      path sends Escape — the picker is never left open to wedge the
+ *      pane (the /rate-limit-options class of wedge).
+ *   2. Never select blind: `selectModel` re-verifies the cursor row's
+ *      LABEL after navigation; any mismatch aborts via Escape and the
+ *      session-only `s` keypress is never sent.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseModelPicker,
+  labelTag,
+  extractConfirmation,
+  discoverModels,
+  selectModel,
+} from "../src/agents/model-picker.js";
+import type { TmuxRunner } from "../src/agents/inject.js";
+
+const IDLE = [
+  "✻ Cooked for 7s",
+  "─".repeat(40),
+  "❯ ",
+  "─".repeat(40),
+  "  ⏵⏵ accept edits on (shift+tab to cycle)",
+].join("\n");
+
+// Verbatim shape from claude 2.1.170 (cursor + ✔ on row 2).
+const PICKER = [
+  "❯ /model",
+  "",
+  "─".repeat(40),
+  "  Select model",
+  "  Switch between Claude models. Your pick becomes the default for new",
+  "  sessions. For other/previous model names, specify with --model.",
+  "",
+  "    1. Default (recommended)  Opus 4.8 with 1M context · Best for everyday,",
+  "                              complex tasks",
+  "  ❯ 2. Sonnet ✔               Sonnet 4.6 · Efficient for routine tasks",
+  "    3. Haiku                  Haiku 4.5 · Fastest for quick answers",
+  "",
+  "  ○ Low effort ←/→ to adjust",
+  "",
+  "  Enter to set as default · s to use this session only · Esc to cancel",
+].join("\n");
+
+const PICKER_CURSOR_3 = PICKER.replace("  ❯ 2. Sonnet ✔ ", "    2. Sonnet ✔ ")
+  .replace("    3. Haiku ", "  ❯ 3. Haiku ");
+
+const AFTER_ESC = [
+  "❯ /model",
+  "  ⎿  Kept model as Sonnet 4.6",
+  "",
+  "─".repeat(40),
+  "❯ ",
+].join("\n");
+
+const AFTER_S = [
+  "❯ /model",
+  "  ⎿  Set model to Haiku 4.5 for this session",
+  "",
+  "─".repeat(40),
+  "❯ ",
+].join("\n");
+
+describe("parseModelPicker", () => {
+  it("parses the real 2.1.170 picker: options, current, cursor, footer", () => {
+    const p = parseModelPicker(PICKER);
+    expect(p).not.toBeNull();
+    expect(p!.footerSeen).toBe(true);
+    expect(p!.options.map((o) => o.label)).toEqual([
+      "Default (recommended)",
+      "Sonnet",
+      "Haiku",
+    ]);
+    expect(p!.options.find((o) => o.current)?.label).toBe("Sonnet");
+    expect(p!.cursorIndex).toBe(2);
+    // Wrapped continuation folded into option 1's detail
+    expect(p!.options[0].detail).toContain("complex tasks");
+    // Effort row is not an option
+    expect(p!.options.some((o) => /effort/i.test(o.label))).toBe(false);
+  });
+
+  it("anchors on the LAST picker when scrollback holds an older one", () => {
+    const older = PICKER.replace("❯ 2. Sonnet ✔", "❯ 2. Sonnet")
+      .replace("1. Default (recommended)", "1. Old Option");
+    const p = parseModelPicker(older + "\n" + PICKER);
+    expect(p!.options[0].label).toBe("Default (recommended)");
+  });
+
+  it("returns null on a pane with no picker", () => {
+    expect(parseModelPicker(IDLE)).toBeNull();
+    expect(parseModelPicker(AFTER_ESC)).toBeNull();
+  });
+
+  it("handles a picker with extra options (future models) without code changes", () => {
+    const extended = PICKER.replace(
+      "    3. Haiku                  Haiku 4.5 · Fastest for quick answers",
+      [
+        "    3. Haiku                  Haiku 4.5 · Fastest for quick answers",
+        "    4. Opus Plan Mode         Plan with Opus, execute with Sonnet",
+      ].join("\n"),
+    );
+    const p = parseModelPicker(extended);
+    expect(p!.options.map((o) => o.label)).toEqual([
+      "Default (recommended)",
+      "Sonnet",
+      "Haiku",
+      "Opus Plan Mode",
+    ]);
+  });
+});
+
+describe("labelTag", () => {
+  it("is stable and distinct across realistic labels", () => {
+    const labels = ["Default (recommended)", "Sonnet", "Haiku", "Opus Plan Mode"];
+    const tags = labels.map(labelTag);
+    expect(new Set(tags).size).toBe(labels.length);
+    expect(labelTag("Sonnet")).toBe(labelTag("Sonnet"));
+    for (const t of tags) expect(t).toMatch(/^[0-9a-f]{8}$/);
+  });
+});
+
+describe("extractConfirmation", () => {
+  it("pulls the ⎿ confirmation line", () => {
+    expect(extractConfirmation(AFTER_S)).toBe("Set model to Haiku 4.5 for this session");
+    expect(extractConfirmation(AFTER_ESC)).toBe("Kept model as Sonnet 4.6");
+    expect(extractConfirmation(IDLE)).toBeNull();
+  });
+});
+
+/**
+ * Scripted fake runner: `frames` is consumed one capture at a time
+ * (last frame repeats); every send is recorded for exact-sequence
+ * assertions.
+ */
+function fakeRunner(frames: string[]): { runner: TmuxRunner; sends: string[][]; framesLeft: () => number } {
+  const sends: string[][] = [];
+  let i = 0;
+  const runner: TmuxRunner = {
+    capture: () => frames[Math.min(i++, frames.length - 1)],
+    send: (_s, _t, args) => {
+      sends.push(args);
+    },
+    hasSession: () => true,
+  };
+  return { runner, sends, framesLeft: () => frames.length - i };
+}
+
+const fastOpts = { stepMs: 1, timeoutMs: 500, _sleep: async () => {} };
+
+function sentKeys(sends: string[][]): string[] {
+  // Normalize: literal sends as their text, key sends as the key name.
+  return sends.map((args) => (args[1] === "-l" ? args[2] : args[1]));
+}
+
+describe("discoverModels", () => {
+  it("opens, parses, and ALWAYS escapes (happy path)", async () => {
+    const { runner, sends } = fakeRunner([PICKER, AFTER_ESC]);
+    const res = await discoverModels("agentx", { ...fastOpts, _runner: runner });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.options.map((o) => o.label)).toEqual(["Default (recommended)", "Sonnet", "Haiku"]);
+      expect(res.currentLabel).toBe("Sonnet");
+    }
+    expect(sentKeys(sends)).toEqual(["/model", "Enter", "Escape"]);
+  });
+
+  it("escapes even when the picker never renders (Esc-always invariant)", async () => {
+    const { runner, sends } = fakeRunner([IDLE]);
+    const res = await discoverModels("agentx", { ...fastOpts, _runner: runner, timeoutMs: 20 });
+    expect(res.ok).toBe(false);
+    expect(sentKeys(sends)).toContain("Escape");
+  });
+
+  it("fails clean when the tmux session is missing (nothing sent)", async () => {
+    const sends: string[][] = [];
+    const runner: TmuxRunner = {
+      capture: () => null,
+      send: (_s, _t, a) => { sends.push(a); },
+      hasSession: () => false,
+    };
+    const res = await discoverModels("agentx", { ...fastOpts, _runner: runner });
+    expect(res.ok).toBe(false);
+    expect(sends.length).toBe(0);
+  });
+});
+
+describe("selectModel", () => {
+  it("navigates cursor→target, verifies the label, presses s — no Escape", async () => {
+    // open → PICKER (cursor 2) → after Down: cursor 3 → verify → s → confirmation
+    const { runner, sends } = fakeRunner([PICKER, PICKER_CURSOR_3, AFTER_S]);
+    const res = await selectModel("agentx", "Haiku", { ...fastOpts, _runner: runner });
+    expect(res).toEqual({ ok: true, confirmation: "Set model to Haiku 4.5 for this session" });
+    expect(sentKeys(sends)).toEqual(["/model", "Enter", "Down", "s"]);
+  });
+
+  it("navigates UP when the target is above the cursor", async () => {
+    const cursorOn3 = PICKER_CURSOR_3;
+    const cursorOn2 = PICKER;
+    const { runner, sends } = fakeRunner([cursorOn3, cursorOn2, AFTER_S]);
+    const res = await selectModel("agentx", "Sonnet", { ...fastOpts, _runner: runner });
+    expect(res.ok).toBe(true);
+    expect(sentKeys(sends)).toEqual(["/model", "Enter", "Up", "s"]);
+  });
+
+  it("aborts via Escape when the label is not offered — never presses s", async () => {
+    const { runner, sends } = fakeRunner([PICKER, AFTER_ESC]);
+    const res = await selectModel("agentx", "Nonexistent Model", { ...fastOpts, _runner: runner });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("not offered");
+    const keys = sentKeys(sends);
+    expect(keys).toContain("Escape");
+    expect(keys).not.toContain("s");
+  });
+
+  it("aborts via Escape when cursor verification fails — never presses s", async () => {
+    // After the Down keypress the pane unexpectedly still shows cursor
+    // on Sonnet (row 2) — e.g. the pane shifted under us.
+    const { runner, sends } = fakeRunner([PICKER, PICKER, AFTER_ESC]);
+    const res = await selectModel("agentx", "Haiku", { ...fastOpts, _runner: runner });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("cursor verification failed");
+    const keys = sentKeys(sends);
+    expect(keys).toContain("Escape");
+    expect(keys).not.toContain("s");
+  });
+
+  it("zero-delta selection (target == cursor row) presses s directly", async () => {
+    const { runner, sends } = fakeRunner([PICKER, PICKER, AFTER_S]);
+    const res = await selectModel("agentx", "Sonnet", { ...fastOpts, _runner: runner });
+    expect(res.ok).toBe(true);
+    expect(sentKeys(sends)).toEqual(["/model", "Enter", "s"]);
+  });
+
+  it("aborts when the picker never renders", async () => {
+    const { runner, sends } = fakeRunner([IDLE]);
+    const res = await selectModel("agentx", "Haiku", { ...fastOpts, _runner: runner, timeoutMs: 20 });
+    expect(res.ok).toBe(false);
+    expect(sentKeys(sends)).not.toContain("s");
+    expect(sentKeys(sends)).toContain("Escape");
+  });
+});


### PR DESCRIPTION
## Summary

`/model` (bare) becomes a model dashboard: **live current model + brief quota + inline-keyboard menu** of exactly the options claude's own `/model` picker offers.

- **No hardcoded models**: options are discovered at request time by driving the CLI's picker over tmux (open → parse → Esc). When Anthropic ships a new model, it appears in the menu the moment the installed CLI offers it.
- **Tap to switch**: re-opens the picker fresh, matches the row **by label** (callback carries a label hash, never a stale index), arrow-keys to it, verifies the cursor row, presses `s` (claude's session-only apply).
- **Quota brief**: `29% / 5h · 33% / 7d` via the existing broker probe → local-headers ladder; never blocks the menu.
- Typed `/model <name>` form unchanged; kill-switch `SWITCHROOM_MODEL_MENU=0` reverts to v1 static text.

## Why session-only (`s`) instead of Enter

Enter persists claude's own settings default — which switchroom's scaffold overwrites on every reconcile. `s` keeps `model:` in switchroom.yaml the single persistent truth (the dashboard says so).

## Safety invariants (pinned by tests)

- **Esc-always**: the picker is never left open — every non-selected exit path sends Escape with verified dismissal (the /rate-limit-options wedge class).
- **Never select blind**: cursor-row label re-verified before `s`; pane drift aborts via Esc.
- **Busy gate**: `currentTurn != null` refuses (driving the picker mid-turn would type '/model' into the prompt as user text).
- **mdl:\* callbacks** carry the strict `allowFrom` gate like every other mutating callback family.

## Parser grounded in reality

`parseModelPicker` is validated against a **verbatim capture of claude 2.1.170's picker** taken on the live test-harness (cursor `❯`, current `✔`, wrapped descriptions, effort row, footer). Layout drift fails discovery gracefully (static v1 fallback + reason) — it cannot mis-select.

## Test plan

- [x] `tests/model-picker.test.ts` — 15 tests: parser on real fixture (+ scrollback anchoring, future extra options), Esc-always invariant, Up/Down/zero-delta navigation, cursor-verify abort, label-not-offered abort
- [x] `telegram-plugin/tests/model-command.test.ts` — 13 new: menu render (current ✅, quota, 64-byte callback cap), busy gates, stale-tag never-selects, no-op on current, failure surfacing, refresh
- [x] Full `bun test`: 0 non-UAT failures; `tsc --noEmit`, plugin-references, bot-api-wrapping all clean
- [x] UAT scenario updated to accept both v1/v2 shapes

## Risk

Medium-low: new tmux interaction is read-mostly (open/parse/Esc) with verified dismissal and a hard timeout; failure mode is a graceful static fallback. Kill-switch reverts the new surface entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)