### PR TITLE
feat(agents): root agent auto-provisions the docker CLI on first boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## unreleased — root agent auto-provisions the docker CLI
+
+Follow-up to the root debugging agent (#2261). A root agent has
+`/var/run/docker.sock` mounted but the shared agent image omits the
+~38 MB docker client (inert for every non-root agent). On a root agent's
+first boot, `start.sh` now fetches a version-pinned static `docker`
+client into the persistent `$HOME/.local/bin` — gated on
+`SWITCHROOM_AGENT_ROOT`, idempotent (skips when present), and non-fatal
+(a fetch failure leaves the agent fully functional minus docker, retried
+next restart). `docker ps/logs/exec/inspect` then work out of the box,
+no manual install. See `docs/root-agent.md`.
+
 ## v0.15.2 — memory-bank health, /model command, root debugging agent (#2257, #2258, #2238, #2259, #2261)
 
 Built mid-incident on 2026-06-10: every active agent had silent memory

--- a/docs/root-agent.md
+++ b/docs/root-agent.md
@@ -70,6 +70,15 @@ host (`docker run -v /:/x …`), so the mounts and uid only make that
 reach *ergonomic*, not *new*. Mem/CPU/PID limits and the tmpfs `/tmp`
 are unchanged.
 
+**The `docker` CLI.** The shared agent image deliberately omits the
+~38 MB docker client (it's inert for the other agents, which have no
+socket). So on a root agent's **first boot**, `start.sh` fetches a
+version-pinned static `docker` client into `$HOME/.local/bin` (which
+persists across restarts via the `/state` bind mount) — gated on the
+`SWITCHROOM_AGENT_ROOT` marker, idempotent, and non-fatal (if the fetch
+fails the agent still boots, and it retries next restart). After first
+boot, `docker ps/logs/exec/inspect` just work.
+
 ## Security model — read this before granting it
 
 A root agent's **job** is to read other agents' logs and output — which

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -243,6 +243,39 @@ for _stray_claude in \
 done
 rm -rf "$HOME/.npm-global/lib/node_modules/@anthropic-ai/claude-code" 2>/dev/null || true
 unset _stray_claude
+
+# ── Root-tier agent: provision the docker CLI ────────────────────────
+# The root debugging agent (`root: true`) has /var/run/docker.sock
+# mounted so it can `docker ps/logs/exec` across the fleet — but the
+# shared agent image deliberately OMITS the ~38MB docker client (it is
+# inert for the 99% of agents without the socket, and bloats every
+# roll/pull). Fetch the version-pinned static client ONCE into the
+# persistent Layer-1 bin dir ($HOME/.local/bin survives restart via the
+# /state bind mount), so the root agent's docs-promised `docker` Just
+# Works without a manual install. Gated on the in-container marker
+# SWITCHROOM_AGENT_ROOT (emitted only for root: true — see compose.ts).
+# Idempotent (skips when already present); NON-FATAL (a fetch failure
+# leaves the agent fully functional minus docker, retried next boot).
+# See docs/root-agent.md.
+if [ "${SWITCHROOM_AGENT_ROOT:-}" = "true" ] && [ ! -x "$HOME/.local/bin/docker" ]; then
+  _dkr_ver="27.3.1"
+  _dkr_arch="$(uname -m)"
+  echo "start.sh: root agent — provisioning docker CLI ${_dkr_ver} (${_dkr_arch}) into \$HOME/.local/bin" >&2
+  mkdir -p "$HOME/.local/bin" "$HOME/.cache" 2>/dev/null || true
+  if curl -fsSL --max-time 120 \
+        "https://download.docker.com/linux/static/stable/${_dkr_arch}/docker-${_dkr_ver}.tgz" \
+        -o "$HOME/.cache/docker-cli.tgz" 2>/dev/null \
+     && tar xzf "$HOME/.cache/docker-cli.tgz" -C "$HOME/.cache" docker/docker 2>/dev/null \
+     && mv "$HOME/.cache/docker/docker" "$HOME/.local/bin/docker" \
+     && chmod 0755 "$HOME/.local/bin/docker"; then
+    echo "start.sh: docker CLI ready ($("$HOME/.local/bin/docker" --version 2>/dev/null))" >&2
+  else
+    echo "start.sh: WARN docker CLI fetch failed — root agent boots without it (retried next restart)" >&2
+  fi
+  rm -rf "$HOME/.cache/docker" "$HOME/.cache/docker-cli.tgz" 2>/dev/null || true
+  unset _dkr_ver _dkr_arch
+fi
+
 export CLAUDE_CONFIG_DIR="{{agentDir}}/.claude"
 # CLAUDE_CODE_OAUTH_TOKEN injection was removed with RFC H (auth-broker).
 # Claude reads .credentials.json directly; the broker is the sole writer

--- a/tests/scaffold.regenerate-start-sh.test.ts
+++ b/tests/scaffold.regenerate-start-sh.test.ts
@@ -112,6 +112,30 @@ describe("scaffoldAgent: start.sh content-aware regeneration (#879)", () => {
     );
   });
 
+  it("provisions the docker CLI for root agents, gated + idempotent + non-fatal", () => {
+    const name = "rooty";
+    const config = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig(name, config);
+
+    const res = scaffoldAgent(name, config, tmpDir, telegramConfig, switchroomConfig);
+    const startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+
+    // Gated on the in-container root marker (emitted only for root: true)
+    // AND skips when already present → idempotent across restarts.
+    expect(startSh).toContain('[ "${SWITCHROOM_AGENT_ROOT:-}" = "true" ]');
+    expect(startSh).toContain('[ ! -x "$HOME/.local/bin/docker" ]');
+    // Version-pinned static client into the persistent Layer-1 bin dir.
+    expect(startSh).toContain("download.docker.com/linux/static/stable");
+    expect(startSh).toContain('mv "$HOME/.cache/docker/docker" "$HOME/.local/bin/docker"');
+    // Non-fatal: a fetch failure warns, doesn't abort the boot.
+    expect(startSh).toContain("docker CLI fetch failed");
+    // Must run before claude is launched (the CLAUDE_CONFIG_DIR export
+    // anchors the runtime block, same invariant as the prune above).
+    const dkrIdx = startSh.indexOf("provisioning docker CLI");
+    expect(dkrIdx).toBeGreaterThan(0);
+    expect(dkrIdx).toBeLessThan(startSh.indexOf("export CLAUDE_CONFIG_DIR="));
+  });
+
   it("does NOT rewrite an existing start.sh when content already matches the template", () => {
     const name = "stable-agent";
     const config = makeAgentConfig();


### PR DESCRIPTION
## Summary

Follow-up to the root debugging agent (#2261). A root agent (`root: true`) has `/var/run/docker.sock` mounted and its `CLAUDE.md` + `docs/root-agent.md` promise `docker ps/logs/exec` for fleet debugging — but the shared agent image deliberately omits the docker client, so on bring-up the binary had to be installed by hand.

This makes it automatic: `start.sh` fetches a version-pinned static `docker` client into the persistent `$HOME/.local/bin` on a root agent's **first boot**.

## Why this, not bake-into-image

The docker client is **~38 MB**. Baking it into the shared agent image is a ~25% size increase on **every** agent (10+), for a feature used by typically **one** root agent — and the docs already flag the heavy agent image as a roll/cache pain point. So instead:

- **gated** on the in-container `SWITCHROOM_AGENT_ROOT` marker (emitted only for `root: true` — see `compose.ts`), so non-root agents are completely untouched
- **idempotent** — skips when `$HOME/.local/bin/docker` is already present → one-time fetch, persists across restarts via the `/state` bind mount
- **non-fatal** — a fetch failure warns and the agent boots fully functional minus docker, retried next restart

Aligns with the persistent-HOME Layer-1 model (`pip --user`, `npm -g`) already used for agent self-provisioned tools.

## What changed
- `profiles/_base/start.sh.hbs` — the gated provisioning block, placed right after the stray-claude prune and before the `CLAUDE_CONFIG_DIR` launch anchor.
- `tests/scaffold.regenerate-start-sh.test.ts` — pins the gate, idempotency guard, non-fatal warn, and ordering-before-claude.
- `docs/root-agent.md`, `CHANGELOG.md`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `scaffold.regenerate-start-sh.test.ts` green (+1)
- [x] Validated live during overlord bring-up: the same static client (27.3.1) installed to `$HOME/.local/bin` reaches the daemon and lists the fleet (`docker ps`).

## Risk
Low. Behaviour for every non-root agent is byte-identical (the block is a runtime `if` on `SWITCHROOM_AGENT_ROOT`, false for them). For root agents the only new behaviour is a one-time, non-fatal network fetch on first boot. No image change, no impact on rolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)