### PR TITLE
fix(auth-broker): make live quota authoritative over stale exhaustion marks

### DIFF
--- a/src/auth/broker/account-eligibility.test.ts
+++ b/src/auth/broker/account-eligibility.test.ts
@@ -44,11 +44,11 @@ describe("snapshot predicates", () => {
 });
 
 describe("isAccountBlocked — live truth is authoritative over the mark", () => {
-  it("INCIDENT A (pixsoul): bogus future mark, but fresh healthy probe → NOT blocked", () => {
+  it("INCIDENT A (healthy primary): bogus future mark, but fresh healthy probe → NOT blocked", () => {
     const mark: ExhaustionMark = { exhausted_until: NOW + 7 * 24 * 60 * 60 * 1000, marked_at: NOW - 60_000 };
     expect(isAccountBlocked({ mark, snapshot: snap(4, 20, 30_000), now: NOW })).toBe(false);
   });
-  it("INCIDENT B (outlook): stale PAST mark, but fresh walled probe → blocked", () => {
+  it("INCIDENT B (walled secondary): stale PAST mark, but fresh walled probe → blocked", () => {
     const mark: ExhaustionMark = { exhausted_until: NOW - 60_000, marked_at: NOW - 3 * 60 * 60 * 1000 };
     expect(isAccountBlocked({ mark, snapshot: snap(100, 27, 30_000), now: NOW })).toBe(true);
   });
@@ -91,7 +91,7 @@ describe("snapshotShouldClearMark — self-heal", () => {
 
 describe("clampMarkExpiry — only override a long mark the live data DISPROVES", () => {
   it("clamps a >5h mark when a fresh probe CONTRADICTS the weekly wall (7d healthy)", () => {
-    // The pixsoul misfire shape: a +7d mark proposed while live 7d=20%.
+    // The healthy-primary misfire shape: a +7d mark proposed while live 7d=20%.
     const proposed = NOW + 7 * 24 * 60 * 60 * 1000;
     expect(clampMarkExpiry({ proposedUntil: proposed, now: NOW, shortMs: FIVE_H, snapshot: snap(4, 20, 0) }))
       .toBe(NOW + FIVE_H);

--- a/src/auth/broker/account-eligibility.test.ts
+++ b/src/auth/broker/account-eligibility.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  isAccountBlocked,
+  snapshotShouldClearMark,
+  clampMarkExpiry,
+  snapshotFresh,
+  snapshotWalled,
+  snapshotClearlyHealthy,
+  WALL_PCT,
+  HEALTHY_CLEAR_PCT,
+  SNAPSHOT_STALE_AGE_MS,
+  type QuotaSnapshot,
+  type ExhaustionMark,
+} from "./account-eligibility.js";
+
+const NOW = 1_781_000_000_000;
+const FIVE_H = 5 * 60 * 60 * 1000;
+
+const snap = (five: number, seven: number, ageMs = 0): QuotaSnapshot => ({
+  fiveHourUtilizationPct: five,
+  sevenDayUtilizationPct: seven,
+  capturedAt: NOW - ageMs,
+});
+
+describe("snapshot predicates", () => {
+  it("snapshotFresh respects the 24h ceiling and rejects future-dated", () => {
+    expect(snapshotFresh(snap(0, 0, 0), NOW)).toBe(true);
+    expect(snapshotFresh(snap(0, 0, SNAPSHOT_STALE_AGE_MS - 1), NOW)).toBe(true);
+    expect(snapshotFresh(snap(0, 0, SNAPSHOT_STALE_AGE_MS + 1), NOW)).toBe(false);
+    expect(snapshotFresh(undefined, NOW)).toBe(false);
+    // clock-skew guard: a snapshot far in the future is not "fresh"
+    expect(snapshotFresh({ ...snap(0, 0), capturedAt: NOW + 5 * 60_000 }, NOW)).toBe(false);
+  });
+  it("snapshotWalled fires at/above WALL_PCT on either window", () => {
+    expect(snapshotWalled(snap(WALL_PCT, 10))).toBe(true);
+    expect(snapshotWalled(snap(10, WALL_PCT))).toBe(true);
+    expect(snapshotWalled(snap(99.4, 99.4))).toBe(false);
+  });
+  it("snapshotClearlyHealthy needs BOTH windows under HEALTHY_CLEAR_PCT", () => {
+    expect(snapshotClearlyHealthy(snap(10, 20))).toBe(true);
+    expect(snapshotClearlyHealthy(snap(HEALTHY_CLEAR_PCT, 20))).toBe(false);
+    expect(snapshotClearlyHealthy(snap(10, HEALTHY_CLEAR_PCT))).toBe(false);
+  });
+});
+
+describe("isAccountBlocked — live truth is authoritative over the mark", () => {
+  it("INCIDENT A (pixsoul): bogus future mark, but fresh healthy probe → NOT blocked", () => {
+    const mark: ExhaustionMark = { exhausted_until: NOW + 7 * 24 * 60 * 60 * 1000, marked_at: NOW - 60_000 };
+    expect(isAccountBlocked({ mark, snapshot: snap(4, 20, 30_000), now: NOW })).toBe(false);
+  });
+  it("INCIDENT B (outlook): stale PAST mark, but fresh walled probe → blocked", () => {
+    const mark: ExhaustionMark = { exhausted_until: NOW - 60_000, marked_at: NOW - 3 * 60 * 60 * 1000 };
+    expect(isAccountBlocked({ mark, snapshot: snap(100, 27, 30_000), now: NOW })).toBe(true);
+  });
+  it("legacy mark (no marked_at) is overridden by any fresh probe", () => {
+    const mark: ExhaustionMark = { exhausted_until: NOW + 7 * 24 * 60 * 60 * 1000 };
+    expect(isAccountBlocked({ mark, snapshot: snap(4, 20, 0), now: NOW })).toBe(false);
+  });
+  it("no snapshot → falls back to the mark", () => {
+    expect(isAccountBlocked({ mark: { exhausted_until: NOW + 1000 }, now: NOW })).toBe(true);
+    expect(isAccountBlocked({ mark: { exhausted_until: NOW - 1000 }, now: NOW })).toBe(false);
+    expect(isAccountBlocked({ now: NOW })).toBe(false);
+  });
+  it("STALE snapshot (>24h) is ignored → mark wins", () => {
+    const mark: ExhaustionMark = { exhausted_until: NOW + 1000, marked_at: NOW - 1000 };
+    // even a healthy-looking but 25h-old snapshot must not un-block a live mark
+    expect(isAccountBlocked({ mark, snapshot: snap(4, 20, SNAPSHOT_STALE_AGE_MS + 60_000), now: NOW })).toBe(true);
+  });
+  it("a mark NEWER than the snapshot wins (a just-seen 429 beats an older probe)", () => {
+    const mark: ExhaustionMark = { exhausted_until: NOW + FIVE_H, marked_at: NOW - 1_000 };
+    // snapshot captured 10min ago showed healthy, but the 429 mark is newer
+    expect(isAccountBlocked({ mark, snapshot: snap(10, 10, 10 * 60_000), now: NOW })).toBe(true);
+  });
+});
+
+describe("snapshotShouldClearMark — self-heal", () => {
+  it("clears a stale mark when a newer clearly-healthy probe lands", () => {
+    const mark: ExhaustionMark = { exhausted_until: NOW + 7 * 24 * 60 * 60 * 1000, marked_at: NOW - 60_000 };
+    expect(snapshotShouldClearMark(snap(4, 20, 0), mark, NOW)).toBe(true);
+  });
+  it("never clears a genuine weekly wall (7d still high)", () => {
+    const mark: ExhaustionMark = { exhausted_until: NOW + 3 * 24 * 60 * 60 * 1000, marked_at: NOW - 60_000 };
+    expect(snapshotShouldClearMark(snap(2, 99.6, 0), mark, NOW)).toBe(false);
+  });
+  it("does not clear when there is no mark, or snapshot is older than the mark", () => {
+    expect(snapshotShouldClearMark(snap(4, 20, 0), undefined, NOW)).toBe(false);
+    const mark: ExhaustionMark = { exhausted_until: NOW + 1000, marked_at: NOW };
+    expect(snapshotShouldClearMark(snap(4, 20, 10 * 60_000), mark, NOW)).toBe(false);
+  });
+});
+
+describe("clampMarkExpiry — only override a long mark the live data DISPROVES", () => {
+  it("clamps a >5h mark when a fresh probe CONTRADICTS the weekly wall (7d healthy)", () => {
+    // The pixsoul misfire shape: a +7d mark proposed while live 7d=20%.
+    const proposed = NOW + 7 * 24 * 60 * 60 * 1000;
+    expect(clampMarkExpiry({ proposedUntil: proposed, now: NOW, shortMs: FIVE_H, snapshot: snap(4, 20, 0) }))
+      .toBe(NOW + FIVE_H);
+  });
+  it("preserves a long mark when a fresh probe confirms the 7d wall", () => {
+    const proposed = NOW + 6 * 24 * 60 * 60 * 1000;
+    expect(clampMarkExpiry({ proposedUntil: proposed, now: NOW, shortMs: FIVE_H, snapshot: snap(10, 99.7, 0) }))
+      .toBe(proposed);
+  });
+  it("TRUSTS a long mark when there is NO live evidence (legit gateway-parsed weekly reset)", () => {
+    // #2218 weekly-durability: a real weekly until with no snapshot must HOLD.
+    const proposed = NOW + 6 * 24 * 60 * 60 * 1000;
+    expect(clampMarkExpiry({ proposedUntil: proposed, now: NOW, shortMs: FIVE_H })).toBe(proposed);
+  });
+  it("TRUSTS a long mark when the only snapshot is stale (>24h)", () => {
+    const proposed = NOW + 6 * 24 * 60 * 60 * 1000;
+    expect(clampMarkExpiry({ proposedUntil: proposed, now: NOW, shortMs: FIVE_H, snapshot: snap(4, 20, SNAPSHOT_STALE_AGE_MS + 1) }))
+      .toBe(proposed);
+  });
+  it("leaves a short (<=5h) mark untouched regardless of snapshot", () => {
+    const proposed = NOW + 2 * 60 * 60 * 1000;
+    expect(clampMarkExpiry({ proposedUntil: proposed, now: NOW, shortMs: FIVE_H })).toBe(proposed);
+    expect(clampMarkExpiry({ proposedUntil: proposed, now: NOW, shortMs: FIVE_H, snapshot: snap(4, 20, 0) })).toBe(proposed);
+  });
+});

--- a/src/auth/broker/account-eligibility.ts
+++ b/src/auth/broker/account-eligibility.ts
@@ -1,0 +1,154 @@
+/**
+ * Account eligibility — the pure decision layer for "is this account blocked
+ * from serving / failover right now?".
+ *
+ * The 2026-06-10 outage was a stale-data-over-live-truth inversion: the broker
+ * judged an account healthy-or-not PURELY by a persisted `exhausted_until`
+ * mark, never consulting the live quota probe sitting beside it in
+ * `lastQuotaCache`. One misfired +7d mark on the healthy primary (pixsoul,
+ * live 7d=20%) therefore stranded the whole fleet, and a stale *past* mark on
+ * a live-walled account (outlook, live 5h=100%) made it look eligible — both
+ * failover paths picked wrong because they trusted a timestamp over the truth.
+ *
+ * Principle (operator directive): rely on accurate LIVE status, never stale
+ * JSON — especially older than 24h. Encoded here as MOST-RECENT-SIGNAL-WINS:
+ * a live snapshot that is fresher than the mark (and within the 24h staleness
+ * ceiling) is authoritative; otherwise the mark is the best signal we have.
+ *
+ * PURE — no I/O, no clock except the injected `now`. Fully unit-tested.
+ */
+
+/**
+ * Utilization at/above this on either window is a hard wall. Matches
+ * `EXHAUSTION_PCT` in consumer-quota-sensor.ts and `classifyHealth`'s
+ * 'blocked' threshold so the sensor, the /auth health view, and this
+ * eligibility decision all agree on what "exhausted" means.
+ */
+export const WALL_PCT = 99.5;
+
+/**
+ * Both windows must be below this for a probe to "clearly healthy" — the bar
+ * for self-healing (clearing) a stale exhaustion mark. Deliberately well under
+ * the wall so a genuine weekly wall (7d >= 99.5%) is never mistaken for
+ * healthy and never has its mark cleared.
+ */
+export const HEALTHY_CLEAR_PCT = 80;
+
+/**
+ * Snapshots older than this are STALE — treated as unknown, never used as
+ * truth (the operator's "never trust JSON >24h old"). Beyond it, eligibility
+ * falls back to the persisted mark.
+ */
+export const SNAPSHOT_STALE_AGE_MS = 24 * 60 * 60 * 1000;
+
+/** The minimal live-snapshot shape the eligibility decision needs. */
+export interface QuotaSnapshot {
+  fiveHourUtilizationPct: number;
+  sevenDayUtilizationPct: number;
+  /** Unix ms when this snapshot was captured by a live probe. */
+  capturedAt: number;
+}
+
+/** A persisted exhaustion mark. `markedAt` is when it was written (added
+ *  2026-06-10 so live-vs-mark recency can be compared; legacy marks without
+ *  it are treated as oldest, so any fresh probe overrides them — the safe
+ *  direction, since that's how a bogus legacy mark gets ignored). */
+export interface ExhaustionMark {
+  exhausted_until: number;
+  marked_at?: number;
+}
+
+/** A live snapshot is within the staleness ceiling (still usable as truth). */
+export function snapshotFresh(
+  s: QuotaSnapshot | undefined,
+  now: number,
+  maxAgeMs = SNAPSHOT_STALE_AGE_MS,
+): s is QuotaSnapshot {
+  return !!s && now - s.capturedAt <= maxAgeMs && s.capturedAt <= now + 60_000;
+}
+
+/** A live snapshot shows a hard wall on either window. */
+export function snapshotWalled(s: QuotaSnapshot): boolean {
+  return s.fiveHourUtilizationPct >= WALL_PCT || s.sevenDayUtilizationPct >= WALL_PCT;
+}
+
+/** A live snapshot is clearly healthy on BOTH windows (safe to clear a mark). */
+export function snapshotClearlyHealthy(s: QuotaSnapshot): boolean {
+  return (
+    s.fiveHourUtilizationPct < HEALTHY_CLEAR_PCT &&
+    s.sevenDayUtilizationPct < HEALTHY_CLEAR_PCT
+  );
+}
+
+/**
+ * THE eligibility decision: is `account` blocked from serving / failover now?
+ *
+ * Most-recent-signal-wins:
+ *  - A fresh live snapshot (≤24h) that is NEWER than the mark is authoritative:
+ *      walled → blocked (kills the live-walled-but-stale-past-mark hop);
+ *      healthy → NOT blocked (kills the bogus-future-mark stranding).
+ *  - Otherwise (no snapshot, snapshot >24h stale, or mark is newer than the
+ *    snapshot) the persisted mark is the best signal: blocked iff unexpired.
+ */
+export function isAccountBlocked(opts: {
+  mark?: ExhaustionMark;
+  snapshot?: QuotaSnapshot;
+  now: number;
+}): boolean {
+  const { mark, snapshot, now } = opts;
+  if (snapshotFresh(snapshot, now)) {
+    const markedAt = mark?.marked_at ?? 0;
+    if (snapshot.capturedAt >= markedAt) {
+      // Live truth is the newer signal → it decides, mark ignored.
+      return snapshotWalled(snapshot);
+    }
+  }
+  // No usable live truth (or the mark is newer) → trust the mark.
+  return mark !== undefined && mark.exhausted_until > now;
+}
+
+/**
+ * Should a freshly-captured snapshot self-heal (clear) an existing mark?
+ * True when the snapshot is newer than the mark and clearly healthy on BOTH
+ * windows — so a misfired/expired mark stops lingering on disk, while a real
+ * weekly wall (7d >= 99.5%) is never cleared.
+ */
+export function snapshotShouldClearMark(
+  snapshot: QuotaSnapshot,
+  mark: ExhaustionMark | undefined,
+  now: number,
+): boolean {
+  if (!mark) return false;
+  if (!snapshotFresh(snapshot, now)) return false;
+  if (snapshot.capturedAt < (mark.marked_at ?? 0)) return false;
+  return snapshotClearlyHealthy(snapshot);
+}
+
+/**
+ * Clamp a proposed exhaustion-mark expiry. A mark longer than the short
+ * default (5h) is the misfire-prone case (the +7d weekly default that landed
+ * on the healthy primary on 2026-06-10).
+ *
+ * Clamp to `now + shortMs` ONLY when a fresh live probe POSITIVELY CONTRADICTS
+ * the weekly wall (the account's 7-day window is below the wall right now). In
+ * the absence of live evidence — no snapshot, or a stale one — the caller's
+ * reset is TRUSTED (a genuine gateway-parsed weekly reset must hold; the legit
+ * #2218 weekly-durability path passes exactly such an until). This is the
+ * "don't fight a real mark, only override one the live data disproves"
+ * direction — bogus marks written without contradicting evidence are instead
+ * neutralised within one probe cycle by the live-authoritative eligibility +
+ * self-heal (isAccountBlocked / snapshotShouldClearMark), not by clamping here.
+ */
+export function clampMarkExpiry(opts: {
+  proposedUntil: number;
+  now: number;
+  shortMs: number;
+  snapshot?: QuotaSnapshot;
+}): number {
+  const { proposedUntil, now, shortMs, snapshot } = opts;
+  const shortCeil = now + shortMs;
+  if (proposedUntil <= shortCeil) return proposedUntil;
+  const liveContradictsWeeklyWall =
+    snapshotFresh(snapshot, now) && snapshot.sevenDayUtilizationPct < WALL_PCT;
+  return liveContradictsWeeklyWall ? shortCeil : proposedUntil;
+}

--- a/src/auth/broker/account-eligibility.ts
+++ b/src/auth/broker/account-eligibility.ts
@@ -5,9 +5,9 @@
  * The 2026-06-10 outage was a stale-data-over-live-truth inversion: the broker
  * judged an account healthy-or-not PURELY by a persisted `exhausted_until`
  * mark, never consulting the live quota probe sitting beside it in
- * `lastQuotaCache`. One misfired +7d mark on the healthy primary (pixsoul,
- * live 7d=20%) therefore stranded the whole fleet, and a stale *past* mark on
- * a live-walled account (outlook, live 5h=100%) made it look eligible — both
+ * `lastQuotaCache`. One misfired +7d mark on the healthy primary account
+ * (live 7d=20%) therefore stranded the whole fleet, and a stale *past* mark on
+ * a live-walled secondary account (live 5h=100%) made it look eligible — both
  * failover paths picked wrong because they trusted a timestamp over the truth.
  *
  * Principle (operator directive): rely on accurate LIVE status, never stale

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -2220,6 +2220,75 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     broker.stop();
   });
 
+  // ── Live-quota-authoritative eligibility (2026-06-10 stale-mark outage) ──
+  // A quota fetch seam that returns per-account utilization keyed by the
+  // `at-<label>` token seedAccount writes, so a fleetQuotaProbeTick populates
+  // lastQuotaCache with a chosen live snapshot per account.
+  function liveQuota(util: Record<string, { five: number; seven: number }>) {
+    return async ({ accessToken }: { accessToken: string }) => {
+      const label = accessToken.replace(/^at-/, "");
+      const u = util[label] ?? { five: 0, seven: 0 };
+      return { ok: true as const, data: {
+        fiveHourUtilizationPct: u.five, sevenDayUtilizationPct: u.seven,
+        fiveHourResetAt: null, sevenDayResetAt: null,
+        representativeClaim: null, overageStatus: null, overageDisabledReason: null,
+      } };
+    };
+  }
+
+  it("INCIDENT A: a bogus future mark on a LIVE-HEALTHY account is ignored AND self-healed", async () => {
+    let clock = Date.UTC(2026, 5, 10, 7, 0, 0);
+    const h = makeHarness();
+    const config = makeConfig(h, { active: "default", fallback_order: ["default", "secondary"], agents: { clerk: {} } });
+    seedAccount(h, "default"); seedAccount(h, "secondary");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      now: () => clock,
+      _testFetchQuota: liveQuota({ default: { five: 4, seven: 20 }, secondary: { five: 5, seven: 10 } }),
+    });
+    const clerkSock = join(h.socketRoot, "clerk", "sock");
+    try {
+      await broker.start();
+      // Stamp the bogus +7d mark on the healthy primary (the pixsoul shape).
+      await rpc(clerkSock, { v: 1, id: "1", op: "mark-exhausted", until: clock + 7 * 24 * 3600_000 });
+      // No live data yet → eligibility falls back to the mark → would fail over.
+      // Now a live probe lands showing default healthy (5h=4 / 7d=20).
+      await broker.fleetQuotaProbeTick();
+      // Serving must IGNORE the stale mark and keep default (live-authoritative).
+      const resp = (await rpc(clerkSock, { v: 1, id: "2", op: "get-credentials" })) as { data: { account: string } };
+      expect(resp.data.account).toBe("default");
+      // …and the healthy probe must have SELF-HEALED the mark off disk.
+      const acct = (await new AuthBrokerClient({ socket: clerkSock }).listState()).accounts.find((a) => a.label === "default");
+      expect(acct?.exhausted).toBe(false);
+      expect(acct?.exhausted_until).toBeUndefined();
+    } finally { broker.stop(); }
+  });
+
+  it("INCIDENT B: failover SKIPS a candidate whose mark is past but whose LIVE quota is walled", async () => {
+    let clock = Date.UTC(2026, 5, 10, 7, 0, 0);
+    const h = makeHarness();
+    const config = makeConfig(h, { active: "default", fallback_order: ["default", "secondary", "tertiary"], agents: { clerk: {} } });
+    seedAccount(h, "default"); seedAccount(h, "secondary"); seedAccount(h, "tertiary");
+    mkdirSync(join(h.agentsDir, "clerk"), { recursive: true });
+    const broker = new AuthBroker(config, {
+      home: h.home, stateDir: h.stateDir, socketRoot: h.socketRoot, disableRefreshLoop: true,
+      now: () => clock,
+      // default genuinely walled; secondary LIVE-walled (5h=100) despite no mark;
+      // tertiary healthy. Failover must hop over secondary to tertiary.
+      _testFetchQuota: liveQuota({ default: { five: 100, seven: 30 }, secondary: { five: 100, seven: 27 }, tertiary: { five: 3, seven: 8 } }),
+    });
+    const clerkSock = join(h.socketRoot, "clerk", "sock");
+    try {
+      await broker.start();
+      await broker.fleetQuotaProbeTick(); // live snapshots populate
+      // default walls → mark-exhausted; live shows secondary walled too.
+      await rpc(clerkSock, { v: 1, id: "1", op: "mark-exhausted", until: clock + 3600_000 });
+      const resp = (await rpc(clerkSock, { v: 1, id: "2", op: "get-credentials" })) as { data: { account: string } };
+      expect(resp.data.account).toBe("tertiary"); // NOT secondary (live-walled)
+    } finally { broker.stop(); }
+  });
+
   it("a weekly until holds past markExhausted's ~5h default, then auto-reverts", async () => {
     let clock = Date.UTC(2026, 5, 7, 0, 0, 0);
     const { broker, clerkSock } = failoverHarness({ now: () => clock });

--- a/src/auth/broker/server.test.ts
+++ b/src/auth/broker/server.test.ts
@@ -2250,7 +2250,7 @@ describe("AuthBroker — agent serving-failover (Layer 2, #2218 weekly-wall dura
     const clerkSock = join(h.socketRoot, "clerk", "sock");
     try {
       await broker.start();
-      // Stamp the bogus +7d mark on the healthy primary (the pixsoul shape).
+      // Stamp the bogus +7d mark on the healthy primary (the incident shape).
       await rpc(clerkSock, { v: 1, id: "1", op: "mark-exhausted", until: clock + 7 * 24 * 3600_000 });
       // No live data yet → eligibility falls back to the mark → would fail over.
       // Now a live probe lands showing default healthy (5h=4 / 7d=20).

--- a/src/auth/broker/server.ts
+++ b/src/auth/broker/server.ts
@@ -46,6 +46,11 @@ import {
   quotaIndicatesExhaustion,
   resolveConsumerProbeIntervalMs,
 } from "./consumer-quota-sensor.js";
+import {
+  isAccountBlocked as evalAccountBlocked,
+  snapshotShouldClearMark,
+  clampMarkExpiry,
+} from "./account-eligibility.js";
 import type { AuthConfig, AuthConsumer, SwitchroomConfig } from "../../config/schema.js";
 import { atomicWriteFileSync, atomicWriteJsonSync } from "../../util/atomic.js";
 import {
@@ -136,6 +141,12 @@ interface ThresholdViolations {
 
 interface QuotaEntry {
   exhausted_until: number;
+  /** Unix ms when this mark was written. Lets eligibility compare the mark's
+   *  recency against a live snapshot (most-recent-signal-wins). Optional for
+   *  backward-compat with marks persisted before 2026-06-10 — a legacy mark
+   *  with no `marked_at` is treated as older than any fresh probe, so live
+   *  truth overrides it (the safe direction). */
+  marked_at?: number;
 }
 interface QuotaState {
   [label: string]: QuotaEntry;
@@ -1032,10 +1043,22 @@ export class AuthBroker {
     return this.accountWithFailover(account);
   }
 
-  /** True if `account` is currently within a mark-exhausted window. */
+  /**
+   * True if `account` is blocked from serving / failover right now.
+   *
+   * Live-truth-authoritative (2026-06-10 fix): a fresh quota snapshot
+   * (≤24h, newer than the mark) decides — walled→blocked, healthy→not —
+   * and only when there is no usable live snapshot does the persisted
+   * `exhausted_until` mark govern. This is what stops a bogus future mark
+   * from stranding a live-healthy account, and a stale past mark from
+   * routing onto a live-walled one. See account-eligibility.ts.
+   */
   private isAccountExhausted(account: string): boolean {
-    const q = this.quota[account];
-    return q !== undefined && q.exhausted_until > this.now();
+    return evalAccountBlocked({
+      mark: this.quota[account],
+      snapshot: this.lastQuotaCache[account],
+      now: this.now(),
+    });
   }
 
   /**
@@ -1101,7 +1124,11 @@ export class AuthBroker {
       const creds = readAccountCredentials(label, this.home);
       const meta = readAccountMeta(label, this.home);
       const q = this.quota[label];
-      const exhausted = q !== undefined && q.exhausted_until > this.now();
+      // Report the SAME live-authoritative verdict the failover path uses, so
+      // the dashboard / quota-watch never see `exhausted=true` while live util
+      // is healthy (the contradicting-fields bug). `exhausted_until` still
+      // carries the raw mark for transparency.
+      const exhausted = this.isAccountExhausted(label);
       const lq = this.lastQuotaCache[label];
       return {
         label,
@@ -1238,7 +1265,7 @@ export class AuthBroker {
    *  periodic fleet tick so the snapshot shape stays in one place. */
   private cacheQuotaSnapshot(label: string, result: QuotaResult): void {
     if (!result.ok) return;
-    this.lastQuotaCache[label] = {
+    const snapshot = {
       fiveHourUtilizationPct: result.data.fiveHourUtilizationPct,
       sevenDayUtilizationPct: result.data.sevenDayUtilizationPct,
       fiveHourResetAt: result.data.fiveHourResetAt?.toISOString() ?? null,
@@ -1248,6 +1275,19 @@ export class AuthBroker {
       overageDisabledReason: result.data.overageDisabledReason,
       capturedAt: this.now(),
     };
+    this.lastQuotaCache[label] = snapshot;
+    // Self-heal: a fresh, clearly-healthy probe (both windows well under the
+    // wall) that is newer than the mark CLEARS the persisted mark — so a
+    // misfired/expired exhaustion can't linger on disk and survive restarts
+    // (the sticky-bogus-+7d-mark that outlasted recreate on 2026-06-10). A
+    // genuine weekly wall (7d≥99.5%) is never "clearly healthy" → never cleared.
+    if (snapshotShouldClearMark(snapshot, this.quota[label], this.now())) {
+      delete this.quota[label];
+      this.persistQuota();
+      process.stdout.write(
+        `auth-broker: live probe shows ${label} healthy (5h=${snapshot.fiveHourUtilizationPct}% 7d=${snapshot.sevenDayUtilizationPct}%) — cleared stale exhaustion mark\n`,
+      );
+    }
   }
 
   /**
@@ -1300,13 +1340,27 @@ export class AuthBroker {
         this.logErr(`consumer-quota-probe ${label}: ${(err as Error).message}`);
         continue;
       }
+      // Cache the fresh probe first: keeps the consumer account's snapshot warm
+      // for the dashboard AND makes it the live truth clampMarkExpiry consults
+      // below (so a genuine consumer weekly wall keeps its real reset). A
+      // healthy probe here also self-heals any stale mark via cacheQuotaSnapshot.
+      this.cacheQuotaSnapshot(label, result);
       const decision = quotaIndicatesExhaustion(result);
       if (!decision.exhausted) continue;
-      const exhaustedUntil = decision.until ?? this.now() + MARK_EXHAUSTED_DEFAULT_MS;
+      const now = this.now();
+      // This probe IS the live truth for `label`, so a long until here is
+      // self-corroborated — pass the snapshot so clampMarkExpiry honors a real
+      // weekly reset while still clamping an uncorroborated default.
+      const exhaustedUntil = clampMarkExpiry({
+        proposedUntil: decision.until ?? now + MARK_EXHAUSTED_DEFAULT_MS,
+        now,
+        shortMs: MARK_EXHAUSTED_DEFAULT_MS,
+        snapshot: this.lastQuotaCache[label],
+      });
       // Idempotent: skip the write/persist if already marked at/past this reset.
       const existing = this.quota[label]?.exhausted_until;
       if (existing !== undefined && existing >= exhaustedUntil) continue;
-      this.quota[label] = { exhausted_until: exhaustedUntil };
+      this.quota[label] = { exhausted_until: exhaustedUntil, marked_at: now };
       this.persistQuota();
       this.audit({ op: "mark-exhausted", identity: { kind: "operator" }, account: label, ok: true });
       process.stdout.write(
@@ -1357,8 +1411,19 @@ export class AuthBroker {
       socket.write(encodeError(id, "ACCOUNT_NOT_FOUND", "no active account configured"));
       return;
     }
-    const exhaustedUntil = until ?? this.now() + MARK_EXHAUSTED_DEFAULT_MS;
-    this.quota[account] = { exhausted_until: exhaustedUntil };
+    const now = this.now();
+    // Clamp the misfire-prone case: a mark longer than the 5h default (the +7d
+    // weekly fallback that landed on the healthy primary on 2026-06-10) is only
+    // honored when a FRESH live probe of THIS account confirms its 7-day window
+    // is actually walled. An uncorroborated long mark clamps to 5h, so a
+    // misparsed weekly signal self-expires fast instead of stranding for days.
+    const exhaustedUntil = clampMarkExpiry({
+      proposedUntil: until ?? now + MARK_EXHAUSTED_DEFAULT_MS,
+      now,
+      shortMs: MARK_EXHAUSTED_DEFAULT_MS,
+      snapshot: this.lastQuotaCache[account],
+    });
+    this.quota[account] = { exhausted_until: exhaustedUntil, marked_at: now };
     this.persistQuota();
     // Fan out next-fallback creds to every agent whose active account is `account`.
     const rolled = this.fanoutFailoverFor(account);
@@ -2248,9 +2313,10 @@ export class AuthBroker {
     for (let i = 1; i <= order.length; i++) {
       const cand = order[(start + i) % order.length];
       if (!cand) continue;
-      const q = this.quota[cand];
-      const exhausted = q !== undefined && q.exhausted_until > this.now();
-      if (!exhausted && accountExists(cand, this.home)) return cand;
+      // Live-authoritative: skip a candidate the live probe shows walled even
+      // if its mark expired, and accept one the live probe shows healthy even
+      // if a stale/bogus mark says exhausted. (The 2026-06-10 root predicate.)
+      if (!this.isAccountExhausted(cand) && accountExists(cand, this.home)) return cand;
     }
     return null;
   }


### PR DESCRIPTION
## Summary
The 2026-06-10 fleet failover outage was a **stale-data-over-live-truth inversion**. The broker judged an account eligible-or-not purely by the persisted `exhausted_until` mark, never consulting the live quota probe already cached beside it. One misfired `+7d` weekly mark on the healthy primary (pixsoul, live 7d=20%) stranded the **whole fleet** — every failover returned `no-eligible-target` — and it survived `auth use`/`refresh` **and** a broker recreate because nothing clears a mark on a healthy probe. The one failover that fired sent hindsight onto an account whose mark had *expired* (looked eligible) while its **live 5h was 100%**.

Operator directive: **rely on accurate live status, never stale JSON, especially >24h old.** Encoded as *most-recent-signal-wins*.

## Changes
- **New pure module `src/auth/broker/account-eligibility.ts`** (17 unit tests):
  - `isAccountBlocked` — a fresh (≤24h) snapshot that is *newer than the mark* is authoritative (walled→blocked, healthy→not); otherwise the mark governs.
  - `snapshotShouldClearMark` — self-heal a stale mark on a clearly-healthy probe (both windows <80%); a real weekly wall (7d≥99.5%) is never cleared.
  - `clampMarkExpiry` — override a >5h mark **only** when live data *disproves* the weekly wall; absence of evidence trusts the caller, so the legit #2218 gateway-parsed weekly reset still holds.
- **Wired into the three broker decision points**: `isAccountExhausted` (shared serving/failover predicate), `nextHealthyAccount`, and the `listState` `exhausted` field (stops the dashboard reporting `exhausted=true` while live util is healthy — the contradicting-fields bug).
- Marks carry `marked_at` for recency; legacy marks (no `marked_at`) are overridden by any fresh probe (safe direction — that's how a bogus legacy mark gets ignored).
- **Self-heal** wired in `cacheQuotaSnapshot`; consumer tick now caches its probe so its accounts get the same warmth + self-heal + clamp corroboration.
- Boot reprobe already present (#2239) → a broker recreate is now a real reset, not a stale-mark re-affirmation.

## Test plan
- [x] `account-eligibility.test.ts` — 17 tests incl. both incident shapes, legacy-mark, >24h staleness, newer-mark-wins, clamp-only-on-contradiction.
- [x] `server.test.ts` — **Incident A** (bogus future mark on live-healthy account → served + self-healed) and **Incident B** (failover skips a live-walled candidate whose mark expired) as full broker integration tests.
- [x] 289 broker + 67 server tests green; existing #2218 weekly-durability test still passes; `tsc --noEmit` clean.
- [x] 42 failures in the full `tests/` sweep are **pre-existing on upstream/main** (bundler/CLI suites needing build artifacts) — identical count with my changes stashed.

## Risk
Surgical change to the failover heart, but the predicate is a pure, exhaustively-tested function and the fallback-to-mark path preserves today's behavior whenever live data is absent/stale. Kill path: no new flags — behavior degrades to the old mark-only logic when `lastQuotaCache` is empty. Deploy = broker recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)