### PR TITLE
fix(agents): pre-create $HOME/.switchroom symlink for admin/root agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ client into the persistent `$HOME/.local/bin` — gated on
 next restart). `docker ps/logs/exec/inspect` then work out of the box,
 no manual install. See `docs/root-agent.md`.
 
+Also fixes a first-boot bridge break for admin/root agents: the admin
+audit-log bind mounts (`vault-audit.log`, `host-control-audit.log`) target
+paths under `$HOME/.switchroom`, so on a fresh agent's first boot docker
+materialised `$HOME/.switchroom` as a real directory before `start.sh`
+could lay down the `#910` symlink the gateway↔claude bridge relies on —
+the bridge then never registered and the agent silently buffered every
+Telegram DM without answering. `switchroom apply` now pre-creates that
+symlink on the host (create-only, never clobbers an existing link/dir)
+before first boot, so docker resolves the binds through it. Surfaced by
+the first root agent; would have hit any freshly-scaffolded admin agent.
+
 ## v0.15.2 — memory-bank health, /model command, root debugging agent (#2257, #2258, #2238, #2259, #2261)
 
 Built mid-incident on 2026-06-10: every active agent had silent memory

--- a/docs/root-agent.md
+++ b/docs/root-agent.md
@@ -79,6 +79,17 @@ persists across restarts via the `/state` bind mount) — gated on the
 fails the agent still boots, and it retries next restart). After first
 boot, `docker ps/logs/exec/inspect` just work.
 
+**The `$HOME/.switchroom` symlink.** A root agent is also an admin agent,
+so it gets the admin audit-log bind mounts (`vault-audit.log`,
+`host-control-audit.log`) at paths under `$HOME/.switchroom`. Because the
+gateway↔claude bridge locates its socket through `$HOME/.switchroom`,
+`switchroom apply` pre-creates that symlink on the host (pointing at the
+real `~/.switchroom`) *before* the container's first boot — otherwise
+docker would materialise `$HOME/.switchroom` as a real directory to host
+those mounts, the runtime symlink would be skipped, and the bridge would
+never register (DMs would silently buffer and never be answered). This is
+handled automatically; no operator action needed.
+
 ## Security model — read this before granting it
 
 A root agent's **job** is to read other agents' logs and output — which

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -448,6 +448,7 @@ import {
   deepMergeJson,
 } from "../config/merge.js";
 import { resolveTimezone, classifyTimezoneSource } from "../config/timezone.js";
+import { isContainerContext } from "../cli/agent-config.js";
 import {
   getProfilePath,
   getBaseProfilePath,
@@ -3337,6 +3338,44 @@ export function scaffoldAgent(
   mkdirSync(persistentHomeDir, { recursive: true });
   for (const sub of [".local/bin", ".npm-global", "bin"]) {
     mkdirSync(join(persistentHomeDir, sub), { recursive: true });
+  }
+
+  // Pre-create the $HOME/.switchroom symlink on the HOST, before the
+  // container's first boot (#910 host-side companion). start.sh.hbs also
+  // creates this link at runtime, but its guard refuses to clobber a
+  // pre-existing real directory at $HOME/.switchroom — and for ADMIN /
+  // ROOT agents docker creates exactly that: the admin audit-log binds
+  // (`…/vault-audit.log`, `…/host-control-audit.log` in compose.ts) target
+  // paths UNDER $HOME/.switchroom, so on a fresh agent's first boot docker
+  // materialises $HOME/.switchroom as a real dir to host those mount
+  // points BEFORE start.sh runs → the runtime symlink is skipped → the
+  // gateway↔claude bridge can't resolve `$HOME/.switchroom/agents/<name>/
+  // telegram/gateway.sock` and never registers (the agent silently
+  // ingests Telegram DMs into a buffer that never drains). Non-admin
+  // agents dodge this only because they have no mounts under the link.
+  // Seeding the symlink here means docker resolves those binds THROUGH it
+  // (the working klanker shape) and never creates the conflicting dir.
+  // Host-only: in-container reconcile has HOME=/state/agent/home (the
+  // wrong target) and the link already exists, so skip there. Create-only
+  // (never clobbers an existing symlink or a real dir — an already-booted
+  // agent is left to start.sh / operator).
+  if (!isContainerContext() && process.env.HOME) {
+    const dotSwitchroomLink = join(persistentHomeDir, ".switchroom");
+    let linkExists = true;
+    try {
+      lstatSync(dotSwitchroomLink);
+    } catch {
+      linkExists = false;
+    }
+    if (!linkExists) {
+      try {
+        symlinkSync(join(process.env.HOME, ".switchroom"), dotSwitchroomLink);
+        created.push(dotSwitchroomLink);
+      } catch {
+        // Best-effort: a failure here just falls back to start.sh's
+        // runtime attempt (which works for non-admin agents).
+      }
+    }
   }
   const homeEnvBlock = [
     "# switchroom Layer 1: per-agent persistent HOME.",

--- a/tests/scaffold.persistent-home.test.ts
+++ b/tests/scaffold.persistent-home.test.ts
@@ -6,6 +6,9 @@ import {
   readFileSync,
   writeFileSync,
   statSync,
+  lstatSync,
+  readlinkSync,
+  symlinkSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -91,6 +94,51 @@ describe("scaffoldAgent — Layer 1 persistent HOME", () => {
       const p = join(homeDir, sub);
       expect(existsSync(p), `expected ${p} to exist`).toBe(true);
       expect(statSync(p).isDirectory()).toBe(true);
+    }
+  });
+
+  it("pre-creates <agentDir>/home/.switchroom symlink to the host ~/.switchroom", () => {
+    // The host-side companion to start.sh's #910 symlink: it must exist
+    // BEFORE first boot so docker resolves the admin audit-log binds
+    // through it instead of materialising a real dir that breaks the
+    // gateway↔claude bridge (the overlord root-agent incident).
+    const prevHome = process.env.HOME;
+    const fakeHome = mkdtempSync(join(tmpdir(), "switchroom-fakehome-"));
+    process.env.HOME = fakeHome;
+    try {
+      const cfg = makeAgentConfig();
+      const sw = makeSwitchroomConfig("alice", cfg);
+      const res = scaffoldAgent("alice", cfg, tmpDir, telegramConfig, sw);
+
+      const link = join(res.agentDir, "home", ".switchroom");
+      expect(lstatSync(link).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(link)).toBe(join(fakeHome, ".switchroom"));
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  it("does not clobber an existing <agentDir>/home/.switchroom symlink", () => {
+    const prevHome = process.env.HOME;
+    const fakeHome = mkdtempSync(join(tmpdir(), "switchroom-fakehome-"));
+    process.env.HOME = fakeHome;
+    try {
+      const cfg = makeAgentConfig();
+      const sw = makeSwitchroomConfig("alice", cfg);
+      // First scaffold creates the link; a second scaffold (apply re-run)
+      // must leave the existing symlink untouched (idempotent).
+      const res = scaffoldAgent("alice", cfg, tmpDir, telegramConfig, sw);
+      const link = join(res.agentDir, "home", ".switchroom");
+      const before = readlinkSync(link);
+      scaffoldAgent("alice", cfg, tmpDir, telegramConfig, sw);
+      expect(lstatSync(link).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(link)).toBe(before);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      rmSync(fakeHome, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes a first-boot bug where a **fresh admin (or root) agent silently fails to answer Telegram DMs**: the gateway connects and buffers inbound messages, but the gateway↔claude **bridge never registers**, so the buffer never drains. The agent looks alive (typing indicators, `getMe` ok) but never replies.

## Root cause — a first-boot ordering race

The admin audit-log bind mounts (`vault-audit.log`, `host-control-audit.log` in `compose.ts`) target paths **under `$HOME/.switchroom`**. On a fresh agent's first `docker up`, docker materialises `$HOME/.switchroom` as a **real directory** to host those mount points — **before** `start.sh` runs. `start.sh`'s `#910` symlink step then refuses to clobber the now-real dir (by design), so `$HOME/.switchroom` stays a real directory.

The bridge MCP server locates the gateway socket at `$HOME/.switchroom/agents/<name>/telegram/gateway.sock`. With `$HOME/.switchroom` a real dir (not the symlink to the host `~/.switchroom`), that path doesn't resolve to where the gateway actually bound its socket (`/state/agent/telegram/gateway.sock`) → the bridge logs `gateway sidecar not running` and never registers.

- **Non-admin agents** dodge this — they have no mounts under the link, so `start.sh`'s runtime symlink wins on first boot.
- **Existing admin agents** (klanker/carrie) work only because their symlink was created on an early boot and **persisted on the host**.

This surfaced when standing up the **first root agent** (#2261) — it buffered DMs for hours without answering. The live instance was repaired by hand (replace the real dir with the symlink + restart → bridge registered immediately); this PR prevents recurrence.

## Fix

`scaffold` pre-creates the host-side `$HOME/.switchroom` symlink (→ the real `~/.switchroom`) when it lays down the persistent HOME — **before the container ever boots** — so docker resolves the audit binds *through* the symlink (the working klanker shape) instead of creating the conflicting real dir.

- **Host-apply-only** — guarded by `isContainerContext()` + `process.env.HOME` (in-container reconcile has the wrong HOME and the link already exists).
- **Create-only** — never clobbers an existing symlink or a real dir (an already-booted agent is left to the live `start.sh`/operator path; can't safely `rm` live mount points anyway).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `scaffold.persistent-home.test.ts` (+2): symlink created → host `~/.switchroom`; idempotent across re-scaffold (no clobber).
- [x] Full `scaffold.test.ts` + `compose-generator.test.ts` green (362 tests) — the new host-scaffold symlink step doesn't regress any existing scaffold behaviour.
- [x] Validated live: the same symlink-replacement on the running root agent made `bridge registered — agent=overlord` appear within seconds and the buffered DMs were answered.

## Risk
Low. Host-apply-only + create-only, so: non-admin agents are unaffected (their boot already worked), existing agents are untouched (link already exists), and the only new behaviour is laying down a symlink for fresh agents that docker would otherwise turn into a bridge-breaking real dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)