### PR TITLE
test: fix two host-dependent test failures (isolation + timeout)

### DIFF
--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -786,6 +786,11 @@ describe("runUpdate", () => {
         // switchroom.yaml and the call count would depend on whether
         // the developer running tests has hostd enabled.
         hostControlEnabled: false,
+        // Likewise pin web_service.managed off so the refresh-web step is
+        // skipped — otherwise the host's real switchroom.yaml leaks in and a
+        // dev/operator box with managed: true adds a 7th call (the EACCES
+        // overlay-loader noise + "length 6 got 7" on the live host).
+        webServiceManaged: false,
       });
       expect(code).toBe(0);
       // 6 calls total:
@@ -837,6 +842,9 @@ describe("runUpdate", () => {
         agentNamesFn: () => ["a"],
         syncBundledSkillsFn: () => { /* intentional no-op */ },
         hostControlEnabled: true,
+        // Pin web_service.managed off so the refresh-web step doesn't leak in
+        // from the host's real switchroom.yaml (would make this 7 calls).
+        webServiceManaged: false,
       });
       expect(code).toBe(0);
       // 6 calls total:

--- a/tests/run-hook.test.ts
+++ b/tests/run-hook.test.ts
@@ -136,6 +136,12 @@ describe("run-hook.sh", () => {
     expect(i.occurrences).toBe(1);
   });
 
+  // This and the auto-resolve test below each fork the real `bun dist/cli`
+  // several times (record/resolve/list). A bun cold-start of the ~2.7MB
+  // bundle is ~1s, so 4-5 forks comfortably exceed vitest's 5s default
+  // testTimeout when the box is loaded (full-suite parallel run) — that was
+  // the run-hook flake, a TIMEOUT not a logic failure. Give the spawn-heavy
+  // cases room. (The single-fork tests below stay on the default.)
   it("coalesces repeated failures (occurrences bumps)", () => {
     const script = makeScript("flaky.sh", "echo bad >&2; exit 1");
     runHook("hook:flaky", script);
@@ -144,7 +150,7 @@ describe("run-hook.sh", () => {
     const issues = listIssues() as Array<{ occurrences: number }>;
     expect(issues).toHaveLength(1);
     expect(issues[0].occurrences).toBe(3);
-  });
+  }, 30_000);
 
   it("auto-resolves the matching fingerprint on a subsequent success", () => {
     const failing = makeScript("h.sh", "echo bad >&2; exit 1");
@@ -166,7 +172,7 @@ describe("run-hook.sh", () => {
     expect(issues[0].resolved_at).toBeDefined();
     // Avoid unused-var lint
     void passing;
-  });
+  }, 30_000);
 
   it("forwards stdout from the wrapped command", () => {
     const script = makeScript("out.sh", "echo hello-from-hook");


### PR DESCRIPTION
## Summary
Two tests pass in CI (clean runner) but fail on a host with a live `~/.switchroom/` — found running the full `src/`+`tests/` suite on the operator box. Test-only changes, no product code.

## Fixes
- **`src/cli/update.test.ts` (2 tests)** — "runs the steps in order" + "hostd install … when host_control enabled" pinned `hostControlEnabled` but not `webServiceManaged`, so `runUpdate` fell through to the host's real `switchroom.yaml`, saw `web_service.managed: true`, and added a 7th `refresh-web` step → `expected length 6 got 7` (plus EACCES overlay-loader noise from reading production agent dirs). Pinned `webServiceManaged: false` to match the existing `hostControlEnabled: false` isolation. This was a CLAUDE.md hard-rule violation (tests must never read production `~/.switchroom/`).
- **`tests/run-hook.test.ts` (2 flaky tests)** — the coalesce + auto-resolve E2E cases cold-start `bun dist/cli/switchroom.js` 4–5 times (~1s each); under full-suite parallel load that exceeds vitest's **5s default testTimeout** → an intermittent *timeout* (not a logic failure; verified flaky: failed/passed/failed across runs). Bumped those two spawn-heavy cases to 30s; 5/5 clean after.

## Test plan
- [x] `update.test.ts` 41/41; `run-hook.test.ts` 13/13 across 5 consecutive runs.
- [x] Full `src/`+`tests/` suite: **9193 passed, 0 failed**, 46 skipped (with `dist/` built).
- [x] No product code changed — only test isolation + timeouts.

## Risk
None to runtime — test-only. Both fixes make the suite host-independent (the CI behavior is unchanged; this just makes local/operator-box runs match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)