### PR TITLE
fix(telegram): /model picker never leaves a dead menu — keep buttons + clear toast

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.14.72";
-export const COMMIT_SHA: string | null = "0e840d59";
-export const COMMIT_DATE: string | null = "2026-06-06T00:39:32Z";
-export const LATEST_PR: number | null = 2183;
+export const VERSION: string = "0.15.3";
+export const COMMIT_SHA: string | null = "af652154";
+export const COMMIT_DATE: string | null = "2026-06-10T09:15:23Z";
+export const LATEST_PR: number | null = 2266;
 export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -18409,15 +18409,29 @@ bot.on('callback_query:data', async ctx => {
         .catch(() => {})
       return
     }
-    // Answer the callback IMMEDIATELY — the select path drives the
-    // picker up to three times (multi-second); leaving the tap
-    // spinning invites a double-tap, which queues a second drive
-    // behind the pane lock and confuses the user. The final state is
-    // conveyed by the message edit (a callback can only be answered
-    // once).
-    await ctx.answerCallbackQuery({ text: 'Working…' }).catch(() => {})
+    const modelDeps = buildModelDeps()
+    // Mid-turn refusal is INSTANT (a sync isBusy() check, no picker drive),
+    // so handle it before the "Working…" ack: toast WHY and leave the menu
+    // message untouched (buttons intact) so the operator taps again when
+    // idle. Editing the menu into a button-less "try again" line was the
+    // "nothing happened" report — the menu looked dead.
+    if (modelDeps.isBusy()) {
+      await ctx
+        .answerCallbackQuery({ text: '⏳ Agent is mid-turn — tap again when it’s idle', show_alert: false })
+        .catch(() => {})
+      return
+    }
+    // Ack IMMEDIATELY — the select path drives the picker (multi-second);
+    // leaving the tap spinning invites a double-tap, which queues a second
+    // drive behind the pane lock. A callback can only be answered once, so
+    // the rich result (what was set / why it failed) is conveyed by the
+    // message edit — which now ALWAYS keeps the menu buttons.
+    await ctx.answerCallbackQuery({ text: 'Switching…' }).catch(() => {})
     try {
-      const outcome = await handleModelMenuCallback(data, buildModelDeps())
+      const outcome = await handleModelMenuCallback(data, modelDeps)
+      // toastOnly: a no-op outcome that should not disturb the menu (defence
+      // in depth — the isBusy() short-circuit above is the live path).
+      if (outcome.toastOnly) return
       await ctx
         .editMessageText(outcome.reply.text, {
           parse_mode: 'HTML',

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -279,6 +279,11 @@ export async function buildModelMenu(
     }
   }
 
+  // claude's ✔ marks the DEFAULT FOR NEW SESSIONS, which is a different axis
+  // from the model the agent is running right now (set via --model at launch
+  // or a prior session switch). Labelling the ✔ row "Now:" was misleading —
+  // it could read "Opus 4.8" while the live session is on Fable. Call it what
+  // it is, and tell the operator a switch applies to the live session.
   const current = discovered.options.find((o) => o.current)
   const lines: string[] = [`<b>Model — ${deps.escapeHtml(deps.getAgentName())}</b>`]
   if (discovered.dismissFailed) {
@@ -286,18 +291,26 @@ export async function buildModelMenu(
   }
   if (current) {
     const detail = current.detail ? ` · ${deps.escapeHtml(current.detail)}` : ''
-    lines.push(`Now: <b>${deps.escapeHtml(current.label)}</b>${detail}`)
+    lines.push(`Default (new sessions): <b>${deps.escapeHtml(current.label)}</b>${detail}`)
   } else {
-    lines.push('Now: <i>unknown (no ✔ row in picker)</i>')
+    lines.push('Default (new sessions): <i>unknown (no ✔ row in picker)</i>')
   }
   if (quota) lines.push(`Quota: ${deps.escapeHtml(quota)}`)
-  lines.push('', 'Tap to switch (applies to the live session):')
+  lines.push('', 'Tap a model to switch the <b>live session</b>:')
   lines.push(PERSIST_NOTE)
 
   return { text: lines.join('\n'), html: true, keyboard: menuKeyboard(discovered.options) }
 }
 
 export interface ModelCallbackOutcome {
+  /**
+   * When true, the caller should ONLY show the toast (`answer`) and leave
+   * the existing menu message untouched — used for the mid-turn refusal so
+   * the menu keeps its buttons and the operator can simply tap again when
+   * the agent goes idle, instead of the menu collapsing to a button-less
+   * "try again" line (which read as "nothing happened").
+   */
+  toastOnly?: boolean
   /** Short toast for answerCallbackQuery. */
   answer: string
   /** Replacement dashboard (message edit). */
@@ -321,19 +334,30 @@ export async function handleModelMenuCallback(
   if (!data.startsWith(MODEL_CALLBACK_SELECT)) {
     return { answer: 'Unknown action', reply: await buildModelMenu(deps) }
   }
+  // Mid-turn: refuse WITHOUT touching the message. Driving the picker types
+  // into claude's input box, which mid-turn would queue "/model" as user
+  // text. toastOnly keeps the menu (and its buttons) exactly as-is so the
+  // operator just taps again when the agent is idle — no button-less
+  // "try again" line that read as a dead menu.
   if (deps.isBusy()) {
-    return { answer: 'Agent is mid-turn — try again shortly', reply: busyReply(deps) }
+    return {
+      answer: '⏳ Agent is mid-turn — tap again when it’s idle',
+      reply: busyReply(deps),
+      toastOnly: true,
+    }
   }
 
   const tag = data.slice(MODEL_CALLBACK_SELECT.length)
   const discovered = await deps.discover(deps.getAgentName())
   if (!discovered.ok) {
+    // Keep the menu interactive: re-render (falls back to v1 text if even
+    // the show path can't discover) with the failure as a banner.
     return {
       answer: 'Picker unavailable',
-      reply: {
-        text: `❌ Could not open the model picker: ${deps.escapeHtml(discovered.reason)}`,
-        html: true,
-      },
+      reply: await menuWithBanner(
+        deps,
+        `❌ Could not open the model picker: ${deps.escapeHtml(discovered.reason)}`,
+      ),
     }
   }
   const target = discovered.options.find((o) => labelTag(o.label) === tag)
@@ -343,26 +367,46 @@ export async function handleModelMenuCallback(
     return { answer: 'Model list changed — menu refreshed', reply: fresh }
   }
   if (target.current) {
-    const fresh = await buildModelMenu(deps)
-    return { answer: `Already on ${target.label}`, reply: fresh }
+    return {
+      answer: `Default is already ${target.label}`,
+      reply: await menuWithBanner(deps, `ℹ️ <b>${deps.escapeHtml(target.label)}</b> is already the default.`),
+    }
   }
 
   const result = await deps.select(deps.getAgentName(), target.label)
   if (!result.ok) {
+    // Switch failed but the agent is reachable — keep the menu so the
+    // operator can retry, with the reason as a banner.
     return {
-      answer: 'Switch failed',
-      reply: {
-        text: `❌ Switch to <b>${deps.escapeHtml(target.label)}</b> failed: ${deps.escapeHtml(result.reason)}`,
-        html: true,
-      },
+      answer: 'Switch failed — see the menu',
+      reply: await menuWithBanner(
+        deps,
+        `❌ Switch to <b>${deps.escapeHtml(target.label)}</b> failed: ${deps.escapeHtml(result.reason)}`,
+      ),
     }
   }
 
+  return {
+    answer: deps.escapeHtml(result.confirmation),
+    reply: await menuWithBanner(deps, `✅ ${deps.escapeHtml(result.confirmation)}`),
+  }
+}
+
+/**
+ * Re-render the live menu with a one-line banner on top. Used by every
+ * post-tap outcome (success, already-default, failure) so the menu ALWAYS
+ * keeps its buttons and the operator can act again — the consistent
+ * "status line + interactive menu" shape the other dashboards use. Falls
+ * back to the banner alone if the menu can't be rebuilt right now.
+ */
+async function menuWithBanner(
+  deps: ModelMenuDeps & ModelCommandDeps,
+  banner: string,
+): Promise<ModelMenuReply> {
   const fresh = await buildModelMenu(deps)
-  const confirmed: ModelMenuReply = {
-    text: [`✅ ${deps.escapeHtml(result.confirmation)}`, '', fresh.text].join('\n'),
+  return {
+    text: [banner, '', fresh.text].join('\n'),
     html: true,
     ...(fresh.keyboard ? { keyboard: fresh.keyboard } : {}),
   }
-  return { answer: result.confirmation, reply: confirmed }
 }

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -316,27 +316,45 @@ describe("handleModelMenuCallback", () => {
     expect(out.reply.keyboard).toBeDefined();
   });
 
-  it("tapping the current model is a no-op refresh", async () => {
+  it("tapping the current model is a no-op that keeps the menu interactive", async () => {
     const { deps, calls } = makeMenuDeps();
     const out = await handleModelMenuCallback(modelSelectCallbackData("Sonnet"), deps);
     expect(calls.select).toEqual([]);
-    expect(out.answer).toContain("Already on Sonnet");
+    expect(out.answer).toContain("already");
+    // Menu keeps its buttons (a banner + the live menu, not a dead line).
+    expect(out.reply.keyboard).toBeDefined();
   });
 
-  it("busy agent → never selects", async () => {
+  it("busy agent → toastOnly refusal that leaves the menu untouched", async () => {
     const { deps, calls } = makeMenuDeps({ isBusy: () => true });
     const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
     expect(calls.select).toEqual([]);
     expect(out.answer).toContain("mid-turn");
+    // toastOnly tells the gateway to NOT edit the menu — buttons survive.
+    expect(out.toastOnly).toBe(true);
   });
 
-  it("selection failure surfaces the reason", async () => {
+  it("selection failure surfaces the reason AND keeps the menu so the operator can retry", async () => {
     const { deps } = makeMenuDeps({
       select: async () => ({ ok: false as const, reason: "cursor verification failed" }),
     });
     const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
-    expect(out.answer).toBe("Switch failed");
+    expect(out.answer).toContain("failed");
     expect(out.reply.text).toContain("cursor verification failed");
+    // The menu buttons are preserved — a failure no longer collapses the
+    // menu to a button-less error (the "nothing happened" bug).
+    expect(out.reply.keyboard).toBeDefined();
+  });
+
+  it("a successful switch banners the confirmation and keeps the menu", async () => {
+    const { deps } = makeMenuDeps({
+      select: async () => ({ ok: true as const, confirmation: "Set model to Haiku 4.5 for this session only" }),
+    });
+    const out = await handleModelMenuCallback(modelSelectCallbackData("Haiku"), deps);
+    expect(out.answer).toContain("Haiku 4.5");
+    expect(out.reply.text).toContain("✅");
+    expect(out.reply.text).toContain("Set model to Haiku 4.5");
+    expect(out.reply.keyboard).toBeDefined();
   });
 
   it("mdl:r re-renders the dashboard", async () => {


### PR DESCRIPTION
## Summary
Operator hit "/model → tap a model → nothing happens" on overlord. Diagnosed live: the picker **drive itself works** (Down + `s` on an idle pane → "Set model to Fable 5 for this session only"). The failure is **UX**, in three places:

1. **Tapped mid-turn** → the picker correctly refuses, but the gateway edited the menu into a button-less "⏳ try again" line → menu collapsed, looked dead. **Now:** a mid-turn tap is an **instant toast-only refusal** (sync `isBusy()`, no drive) that leaves the menu message untouched — buttons survive, tap again when idle.
2. **The toast was always a generic "Working…"** even though the handler computed a rich `answer`. **Now:** ack "Switching…", and every outcome re-renders the menu **with a banner** (✅ set / ❌ failed: reason / ℹ️ already default) — a failure keeps the buttons so the operator retries instead of re-running `/model`. Same "status line + interactive menu" shape as the other dashboards.
3. **The `✔` marks claude's _default-for-new-sessions_, not the live session model** (overlord launched `--model claude-fable-5` but the ✔ sat on "Opus 4.8", so the menu said "Now: Opus" while `/status` said Fable). Relabelled **"Now:" → "Default (new sessions):"** so it stops claiming to be the running model.

New `menuWithBanner()` helper + `toastOnly` outcome flag. No change to the picker *driver* (it was correct) or the kill-switch.

## Test plan
- [x] `model-command.test.ts` updated/extended — busy = `toastOnly` (gateway leaves menu intact), failure/success/already-default all keep the keyboard; 29 pass under **both** bun and vitest.
- [x] `model-picker.test.ts` 19 green (driver untouched).
- [x] `tsc`, `check-plugin-references`, `check-bot-api-wrapping` all clean (uses `ctx.*`, no raw bot.api).
- [ ] Live canary on overlord (deploy + tap each outcome) — pending.

## Risk
Low — UX-only in the callback handler; the picker drive, auth gate, and kill-switch are unchanged. Worst case degrades to the prior edit behavior; `SWITCHROOM_MODEL_MENU=0` still disables the family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)