### PR TITLE
fix(telegram): /model applies the ✔ row to the live session + /status reflects it

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -13767,6 +13767,14 @@ function buildAgentAudit(agentName: string): AgentAudit | undefined {
 // broker's fleet-wide `ListStateData` payload via
 // `buildAuthSummaryFromBroker`, with billingType pulled from the
 // agent's `.claude.json` (the broker doesn't track plan tier).
+/**
+ * Live session-model override set by the `/model` picker (session-only). Held
+ * in gateway memory so it clears on restart, the same point at which claude's
+ * session reverts to the configured model — keeping `/status` honest without
+ * a persisted store. Null when no session switch is active.
+ */
+let activeSessionModelOverride: string | null = null
+
 async function buildAgentMetadata(agentName: string): Promise<AgentMetadata> {
   type AgentListResp = {
     agents: Array<{
@@ -13795,6 +13803,7 @@ async function buildAgentMetadata(agentName: string): Promise<AgentMetadata> {
   return {
     agentName,
     model: a?.model ?? null,
+    sessionModel: activeSessionModelOverride,
     extendsProfile: (a?.extends ?? a?.template) ?? null,
     topicName: a?.topic_name ?? null,
     topicEmoji: a?.topic_emoji ?? null,
@@ -18429,6 +18438,12 @@ bot.on('callback_query:data', async ctx => {
     await ctx.answerCallbackQuery({ text: 'Switching…' }).catch(() => {})
     try {
       const outcome = await handleModelMenuCallback(data, modelDeps)
+      // Record a successful session switch so /status reflects what's
+      // actually running. In-memory only → clears when the gateway (and thus
+      // claude's session) restarts, exactly matching the session-only scope.
+      if (outcome.selectedModel) {
+        activeSessionModelOverride = outcome.selectedModel
+      }
       // toastOnly: a no-op outcome that should not disturb the menu (defence
       // in depth — the isBusy() short-circuit above is the live path).
       if (outcome.toastOnly) return

--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -311,6 +311,13 @@ export interface ModelCallbackOutcome {
    * "try again" line (which read as "nothing happened").
    */
   toastOnly?: boolean
+  /**
+   * On a successful session switch, the live model name now running (parsed
+   * from claude's confirmation, e.g. "Fable 5"). The gateway records this as
+   * the session-model override so `/status` reflects what's actually running.
+   * Absent on every non-switch outcome.
+   */
+  selectedModel?: string
   /** Short toast for answerCallbackQuery. */
   answer: string
   /** Replacement dashboard (message edit). */
@@ -366,13 +373,14 @@ export async function handleModelMenuCallback(
     const fresh = await buildModelMenu(deps)
     return { answer: 'Model list changed — menu refreshed', reply: fresh }
   }
-  if (target.current) {
-    return {
-      answer: `Default is already ${target.label}`,
-      reply: await menuWithBanner(deps, `ℹ️ <b>${deps.escapeHtml(target.label)}</b> is already the default.`),
-    }
-  }
-
+  // NOTE: do NOT short-circuit when target.current is set. The picker's ✔
+  // marks claude's DEFAULT FOR NEW SESSIONS, which is a DIFFERENT axis from
+  // the model the live session is running (set by --model at launch). Tapping
+  // the ✔ row to apply that model to the live session is a legitimate switch
+  // — e.g. an agent launched on Fable tapping "Default (Opus)". Skipping it
+  // here was the "tapped Default, nothing happened" bug. Always drive the
+  // selection; claude harmlessly answers "Kept model as X" if it's already
+  // the session model.
   const result = await deps.select(deps.getAgentName(), target.label)
   if (!result.ok) {
     // Switch failed but the agent is reachable — keep the menu so the
@@ -389,7 +397,23 @@ export async function handleModelMenuCallback(
   return {
     answer: deps.escapeHtml(result.confirmation),
     reply: await menuWithBanner(deps, `✅ ${deps.escapeHtml(result.confirmation)}`),
+    selectedModel: sessionModelFromConfirmation(result.confirmation) ?? target.label,
   }
+}
+
+/**
+ * Pull the model NAME out of claude's session-switch confirmation so it can
+ * be shown in `/status` as the live session model. claude phrases it as
+ * "Set model to <name> for this session only" (or "Switched to <name>").
+ * Returns null when the confirmation doesn't carry a recognizable name (the
+ * caller falls back to the tapped picker label).
+ */
+export function sessionModelFromConfirmation(confirmation: string): string | null {
+  const m = /(?:Set model to|Switched to)\s+(.+?)(?:\s+for (?:this|the) session|\s*\(|\s*$)/i.exec(
+    confirmation.trim(),
+  )
+  const name = m?.[1]?.trim()
+  return name && name.length > 0 ? name : null
 }
 
 /**

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -212,6 +212,7 @@ import {
   buildModelMenu,
   handleModelMenuCallback,
   modelSelectCallbackData,
+  sessionModelFromConfirmation,
   MODEL_CALLBACK_REFRESH,
   type ModelMenuDeps,
 } from "../gateway/model-command.js";
@@ -316,12 +317,14 @@ describe("handleModelMenuCallback", () => {
     expect(out.reply.keyboard).toBeDefined();
   });
 
-  it("tapping the current model is a no-op that keeps the menu interactive", async () => {
+  it("tapping the ✔ (default) row STILL drives a switch — ✔ is the new-session default, not the live session model", async () => {
+    // OPTIONS marks "Sonnet" current (the ✔). An agent launched on a
+    // different model must still be able to apply the ✔ row to its live
+    // session — skipping it was the "tapped Default, nothing happened" bug.
     const { deps, calls } = makeMenuDeps();
     const out = await handleModelMenuCallback(modelSelectCallbackData("Sonnet"), deps);
-    expect(calls.select).toEqual([]);
-    expect(out.answer).toContain("already");
-    // Menu keeps its buttons (a banner + the live menu, not a dead line).
+    expect(calls.select).toEqual(["Sonnet"]);
+    expect(out.reply.text).toContain("✅");
     expect(out.reply.keyboard).toBeDefined();
   });
 
@@ -346,7 +349,7 @@ describe("handleModelMenuCallback", () => {
     expect(out.reply.keyboard).toBeDefined();
   });
 
-  it("a successful switch banners the confirmation and keeps the menu", async () => {
+  it("a successful switch banners the confirmation, keeps the menu, AND reports the live model for /status", async () => {
     const { deps } = makeMenuDeps({
       select: async () => ({ ok: true as const, confirmation: "Set model to Haiku 4.5 for this session only" }),
     });
@@ -355,6 +358,20 @@ describe("handleModelMenuCallback", () => {
     expect(out.reply.text).toContain("✅");
     expect(out.reply.text).toContain("Set model to Haiku 4.5");
     expect(out.reply.keyboard).toBeDefined();
+    // The gateway records this so /status reflects the live session model.
+    expect(out.selectedModel).toBe("Haiku 4.5");
+  });
+});
+
+describe("sessionModelFromConfirmation", () => {
+  it("pulls the model name from claude's session-switch confirmation", () => {
+    expect(sessionModelFromConfirmation("Set model to Fable 5 for this session only")).toBe("Fable 5");
+    expect(sessionModelFromConfirmation("Set model to Opus 4.8 (1M context) for this session only")).toBe("Opus 4.8");
+    expect(sessionModelFromConfirmation("Switched to Haiku 4.5")).toBe("Haiku 4.5");
+  });
+  it("returns null when no recognizable name is present", () => {
+    expect(sessionModelFromConfirmation("Kept model as Opus 4.8 (default)")).toBeNull();
+    expect(sessionModelFromConfirmation("")).toBeNull();
   });
 
   it("mdl:r re-renders the dashboard", async () => {

--- a/telegram-plugin/tests/welcome-text.test.ts
+++ b/telegram-plugin/tests/welcome-text.test.ts
@@ -82,6 +82,17 @@ describe("formatAgentLine", () => {
     const out = formatAgentLine({ ...baseMeta, topicName: "Planning", topicEmoji: "🗓" });
     expect(out).toContain("topic: 🗓 Planning");
   });
+  it("shows the live session model alongside the configured model when a /model switch is active", () => {
+    const out = formatAgentLine({ ...baseMeta, model: "claude-fable-5[1m]", sessionModel: "Opus 4.8 (1M context)" });
+    // Both surfaces present + agree: configured AND what's actually running.
+    expect(out).toContain("<code>claude-fable-5[1m]</code>");
+    expect(out).toContain("live session: <code>Opus 4.8 (1M context)</code>");
+  });
+  it("omits the session line when no override is active", () => {
+    expect(formatAgentLine({ ...baseMeta, sessionModel: null })).not.toContain("live session");
+    expect(formatAgentLine({ ...baseMeta, sessionModel: "" })).not.toContain("live session");
+    expect(formatAgentLine(baseMeta)).not.toContain("live session");
+  });
   it("omits topic when only emoji is set", () => {
     // topicName null → no topic chunk. Keeps the line clean.
     expect(formatAgentLine({ ...baseMeta, topicEmoji: "🗓" })).not.toContain("topic");

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -66,6 +66,14 @@ export type StatusProbeRow = {
 export type AgentMetadata = {
   agentName: string;
   model: string | null;
+  /**
+   * Live session-model override set via the `/model` picker (session-only,
+   * resets on restart). When present it's what the agent is ACTUALLY running
+   * right now, distinct from `model` (the persistent configured model). Null
+   * when no session switch is active — then `/status` just shows `model`.
+   * Surfaced so `/status` and `/model` never silently disagree.
+   */
+  sessionModel?: string | null;
   extendsProfile: string | null;
   topicName: string | null;
   topicEmoji: string | null;
@@ -122,7 +130,14 @@ export function formatAgentLine(meta: AgentMetadata): string {
   const topic = meta.topicName
     ? ` · topic: ${escapeHtml([meta.topicEmoji, meta.topicName].filter(Boolean).join(" "))}`
     : "";
-  return `<b>${escapeHtml(meta.agentName)}</b> · model: <code>${escapeHtml(m)}</code>${topic}`;
+  // A live `/model` session switch overrides what's running. Show it next to
+  // the configured model so the two surfaces agree (the override resets on
+  // restart, when the session reverts to the configured model).
+  const session =
+    meta.sessionModel && meta.sessionModel.length > 0
+      ? ` · live session: <code>${escapeHtml(meta.sessionModel)}</code>`
+      : "";
+  return `<b>${escapeHtml(meta.agentName)}</b> · model: <code>${escapeHtml(m)}</code>${session}${topic}`;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #2270 (the menu-UX fix, already merged). Two related fixes for the operator report *"tapped Default, nothing changed, and /status still says Fable"*:

## 1. Tapping the ✔ row now actually switches the live session
The picker short-circuited on `target.current` — but claude's `✔` marks the **default for new sessions**, a *different axis* from the live session model (set by `--model` at launch). An agent launched on Fable tapping **"Default (Opus)"** is a legitimate session switch, but the `✔` check skipped it → **nothing happened**. Now it always drives the selection; claude harmlessly answers "Kept model as X" if it's already the session model. **This is the exact action the operator took.**

## 2. /status now reflects the live session model
`/status` read switchroom's **configured** model while `/model` drives claude's live **session** model — so they silently disagreed after a switch (status said Fable, the session was Opus). Per the operator's call (keep switches **session-only**), `/status` now mirrors the live override:
- a successful switch returns `selectedModel` (parsed from claude's confirmation via `sessionModelFromConfirmation`),
- the gateway holds it in `activeSessionModelOverride` — **in-memory, clears on restart**, matching the session-only scope (claude's session also reverts on restart),
- `formatAgentLine` renders `model: <configured> · live session: <override>` when active.

## Test plan
- [x] New: `ModelCallbackOutcome.selectedModel`, `AgentMetadata.sessionModel`, `sessionModelFromConfirmation()`.
- [x] Tests: parser cases (paren / Switched-to / Kept / empty), `formatAgentLine` session line present/absent, `selectedModel` on success, ✔-row-still-switches. 92 bun + vitest green; `tsc`, plugin-refs, bot-api clean.
- [x] Live-canaried on overlord (hand-patched bundle; gateway boots clean).

## Known limitation (noted, not blocking)
The override is a best-effort mirror of pane state — an operator who attaches via tmux and types `/model` directly bypasses the gateway, and reverting to the exact session model shows "Kept" (override unchanged). Both narrow; the override clears on restart regardless.

## Risk
Low — parsing + in-memory state + render; no model/API/SDK callsites. `SWITCHROOM_MODEL_MENU=0` still disables the family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)