### PR TITLE
fix(compose): config bind source must be a host path, never a container path

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -641,6 +641,44 @@ export function normalizeBindMountPath(p: string): string {
   return out;
 }
 
+/** The in-container path the config is mounted AT (also the SWITCHROOM_CONFIG
+ *  value for containerised services). Never a valid host bind SOURCE. */
+export const CONTAINER_CONFIG_PATH = "/state/config/switchroom.yaml";
+
+/**
+ * Resolve the HOST bind-mount source for the switchroom.yaml config mount.
+ *
+ * `switchroomConfigPath` is the path the *running generator* reads its config
+ * from. On the host that's the real host path; but when `apply` runs INSIDE a
+ * container (the hostd `/update apply` path) it's the in-container path
+ * `/state/config/switchroom.yaml` — which is NOT a host path. Emitting it as a
+ * bind source makes docker auto-create an empty host directory, so the broker
+ * reads a directory and dies with EISDIR (the 2026-06-11 fleet outage).
+ *
+ * A bind source must live on the host filesystem. Any path under `/state/`
+ * (the container-only state tree, including the config-mount target itself)
+ * can never be a host source, so it's replaced with the canonical host config
+ * `<homePrefix>/.switchroom/switchroom.yaml` — the same `homePrefix` every
+ * other mount uses, correct whether the generator runs on the host or in a
+ * container. A genuine custom HOST path is passed through untouched. Returns
+ * `undefined` when no config path was given (back-compat: no config mount).
+ * Pure — no IO.
+ */
+export function resolveConfigMountSource(
+  switchroomConfigPath: string | undefined,
+  homePrefix: string,
+): string | undefined {
+  if (!switchroomConfigPath) return undefined;
+  // `/state/...` is the in-container state mount — never a host source.
+  if (
+    switchroomConfigPath === CONTAINER_CONFIG_PATH ||
+    switchroomConfigPath.startsWith("/state/")
+  ) {
+    return `${homePrefix}/.switchroom/switchroom.yaml`;
+  }
+  return switchroomConfigPath;
+}
+
 /**
  * Validate one entry from an agent's `bind_mounts:` list. Returns the
  * resolved (source, target, mode) on success; throws a descriptive
@@ -785,7 +823,20 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // sudo-bake works), but the existsSync probe must use the real host
   // home. Falls back to process.env.HOME when no homeDir is passed.
   const hostHomeForChecks = opts.homeDir ?? process.env.HOME ?? "";
-  const switchroomConfigPath = opts.switchroomConfigPath;
+  // The config mount SOURCE must be a HOST path — docker bind-mounts it off the
+  // host filesystem. `opts.switchroomConfigPath` is where the RUNNING generator
+  // reads ITS config, which is the in-CONTAINER path `/state/config/
+  // switchroom.yaml` when `apply` runs inside a container (the hostd
+  // `/update apply` path). Emitting that container path as a bind source made
+  // docker auto-create an empty host directory → the brokers read a directory
+  // → `EISDIR` crash-loop → every agent stuck "Created" (the 2026-06-11 fleet
+  // outage). Sanitise here so no caller — host or container — can poison the
+  // mount: a `/state/...` container-only path is replaced with the canonical
+  // host config under `homePrefix`, the same prefix every other mount uses.
+  const switchroomConfigPath = resolveConfigMountSource(
+    opts.switchroomConfigPath,
+    homePrefix,
+  );
   // Bundled-skills pool dir. Default to the live resolver so production
   // calls Just Work; tests pass an explicit path (or "") to override.
   const bundledSkillsPoolDir = opts.bundledSkillsPoolDir ?? getBundledSkillsPoolDir();

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.15.3";
-export const COMMIT_SHA: string | null = "af652154";
-export const COMMIT_DATE: string | null = "2026-06-10T09:15:23Z";
-export const LATEST_PR: number | null = 2266;
-export const COMMITS_AHEAD_OF_TAG: number | null = 0;
+export const COMMIT_SHA: string | null = "544d135b";
+export const COMMIT_DATE: string | null = "2026-06-11T14:14:26+10:00";
+export const LATEST_PR: number | null = 2273;
+export const COMMITS_AHEAD_OF_TAG: number | null = 3;

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -28,6 +28,8 @@ import {
   AGENT_UID_MIN,
   AGENT_UID_MAX,
   describeAgents,
+  resolveConfigMountSource,
+  CONTAINER_CONFIG_PATH,
 } from "../../src/agents/compose.js";
 import type { SwitchroomConfig } from "../../src/config/schema.js";
 
@@ -121,6 +123,52 @@ describe("assertNoAgentUidCollision — sec WS6-F4 (#1419)", () => {
     expect(() =>
       generateCompose({ config: makeConfig({ klanker: {}, bob: {} }) }),
     ).not.toThrow();
+  });
+});
+
+describe("resolveConfigMountSource — config bind source must be a HOST path (2026-06-11 outage)", () => {
+  const HOME = "/home/op";
+  const CANON = `${HOME}/.switchroom/switchroom.yaml`;
+
+  it("undefined → undefined (back-compat: no config mount)", () => {
+    expect(resolveConfigMountSource(undefined, HOME)).toBeUndefined();
+  });
+  it("a real host path passes through untouched", () => {
+    expect(resolveConfigMountSource(CANON, HOME)).toBe(CANON);
+    expect(resolveConfigMountSource("/home/op/custom/switchroom.yaml", HOME)).toBe("/home/op/custom/switchroom.yaml");
+  });
+  it("the in-container config path → canonical host path (the bug: apply run inside a container)", () => {
+    expect(resolveConfigMountSource(CONTAINER_CONFIG_PATH, HOME)).toBe(CANON);
+    expect(resolveConfigMountSource("/state/config/switchroom.yaml", HOME)).toBe(CANON);
+  });
+  it("any /state/… container path → canonical host path", () => {
+    expect(resolveConfigMountSource("/state/whatever.yaml", HOME)).toBe(CANON);
+  });
+});
+
+describe("generateCompose config mount is never a container path", () => {
+  it("rewrites a container-path switchroomConfigPath to the host source (broker/kernel/auth-broker)", () => {
+    const yaml = generateCompose({
+      config: makeConfig({ klanker: {} }),
+      homeDir: "/home/op",
+      // Simulate `apply` running inside a container: the running process reads
+      // its config from the in-container path. This must NOT leak into a bind
+      // source — that auto-created an empty host dir → EISDIR broker crash.
+      switchroomConfigPath: "/state/config/switchroom.yaml",
+    });
+    // No bind line uses the container path as a SOURCE…
+    expect(yaml).not.toMatch(/- \/state\/config\/switchroom\.yaml:\/state\/config\/switchroom\.yaml/);
+    // …and the config IS mounted from the canonical host path.
+    expect(yaml).toContain("/home/op/.switchroom/switchroom.yaml:/state/config/switchroom.yaml:ro");
+  });
+
+  it("preserves a genuine host switchroomConfigPath as the source", () => {
+    const yaml = generateCompose({
+      config: makeConfig({ klanker: {} }),
+      homeDir: "/home/op",
+      switchroomConfigPath: "/home/op/.switchroom/switchroom.yaml",
+    });
+    expect(yaml).toContain("/home/op/.switchroom/switchroom.yaml:/state/config/switchroom.yaml:ro");
   });
 });
 


### PR DESCRIPTION
## Summary
**Root cause of the 2026-06-11 fleet outage.** When `apply` (or hostd's `/update apply`) runs **inside a container**, `getConfigPath()` returns the in-container config location `/state/config/switchroom.yaml` (set via `SWITCHROOM_CONFIG`), and the compose generator emitted it verbatim as a bind-mount **source**:

```
- /state/config/switchroom.yaml:/state/config/switchroom.yaml:ro
```

That path doesn't exist on the host, so **docker auto-created an empty directory** there. The brokers then read a directory as their config → **auth-broker EISDIR**, **vault-broker SQLiteError** (couldn't resolve its grants-DB path) — both crash-looped, so all 12 agents were stuck **"Created"** behind their `depends_on` health gate. Whole fleet down.

## Fix
A bind **source** must live on the host filesystem; `switchroomConfigPath` (where the *running generator* reads its own config) isn't guaranteed to be one. New `resolveConfigMountSource()` sanitises it: any `/state/…` container-only path is replaced with the canonical host config `<homePrefix>/.switchroom/switchroom.yaml` — the same `homePrefix` every other mount already uses, correct whether the generator runs on the host or in a container. A genuine custom **host** path passes through untouched; `undefined` still emits no config mount (back-compat). Resolved once, used at all three emission sites (vault-broker, kernel, auth-broker).

Defence **at the generator** so no caller — host CLI, hostd, or a future in-container path — can poison the mount again.

## Test plan
- [x] `resolveConfigMountSource` unit cases: undefined → undefined; host path → unchanged; `/state/config/switchroom.yaml` and any `/state/…` → canonical host path.
- [x] `generateCompose` end-to-end: a container-path `switchroomConfigPath` **never** becomes a bind source and the config mounts from the canonical host path; a genuine host path is preserved.
- [x] 165 compose-generator + 277 docker/agent tests green; `tsc` clean; build clean.
- [x] **Live-validated by the recovery itself**: regenerating compose from the host shell produced the correct `/home/kenthompson/.switchroom/switchroom.yaml` source and the fleet came back healthy.

## Risk
Low — pure path resolution, no IO. Only rewrites a source that could never have worked (a container path as a host bind source); host paths and the no-mount back-compat case are untouched.

## Follow-up (separate)
Re-pin the fleet to the context-diet build (#2273/#2274) only after this ships — that build is what regenerated the broken compose via the in-container apply path; the fleet is rolled back to v0.15.3 meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)