### PR TITLE
fix(telegram): coalesce the inbound-spool give-up notice per chat (durable)

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.15.3";
-export const COMMIT_SHA: string | null = "544d135b";
-export const COMMIT_DATE: string | null = "2026-06-11T14:14:26+10:00";
-export const LATEST_PR: number | null = 2273;
-export const COMMITS_AHEAD_OF_TAG: number | null = 3;
+export const COMMIT_SHA: string | null = "5c4a67f1";
+export const COMMIT_DATE: string | null = "2026-06-11T06:42:35Z";
+export const LATEST_PR: number | null = 2276;
+export const COMMITS_AHEAD_OF_TAG: number | null = 6;

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6609,7 +6609,7 @@ if (!STATIC) {
     // promise EXPLICITLY (honest failure) instead of letting it sit
     // forever. This is what makes the guarantee deterministic: every
     // queued message ends either delivered or visibly retracted.
-    inboundSpool?.sweepEscalations((e) => {
+    inboundSpool?.sweepEscalations((e, { postNotice }) => {
       const chat = e.msg.chatId
       const escThread =
         typeof e.msg.meta?.threadId === 'string' && e.msg.meta.threadId
@@ -6620,7 +6620,14 @@ if (!STATIC) {
       // the message is being declared undeliverable, so the queued-status must
       // not dangle beside the "couldn't deliver" notice (idempotent best-effort;
       // a normal turn-start/turn-end reaps far sooner — this is the 15-min edge).
+      // Reaping happens for EVERY dropped entry; only the user-facing notice is
+      // coalesced (postNotice), so a burst of undeliverable inbounds doesn't
+      // leave dangling placeholders even when its notice is suppressed.
       reapQueuedStatus(chat, escThread)
+      // Coalesced per chat by the spool's sliding window — a multi-restart
+      // outage that re-ages a synthetic into the bound every 15 min posts ONE
+      // notice, not one per cycle (the 2026-06-09 marko "please resend" spam).
+      if (!postNotice) return
       void swallowingApiCall(
         () =>
           bot.api.sendMessage(

--- a/telegram-plugin/gateway/inbound-spool.ts
+++ b/telegram-plugin/gateway/inbound-spool.ts
@@ -102,14 +102,31 @@ export function spoolId(msg: InboundMessage): string {
 }
 
 interface SpoolRecord {
-  t: 'put' | 'ack'
-  id: string
+  t: 'put' | 'ack' | 'esc'
+  /** Present on `put`/`ack` (spoolId). Absent on `esc`. */
+  id?: string
   /** Present only on `put`. The full inbound to replay. */
   msg?: InboundMessage
   /** Present only on `put`. Owning agent (replay re-pushes per agent). */
   agent?: string
   /** Present only on `put`. ms epoch first-spooled — drives escalation. */
   firstAt?: number
+  /** Present only on `esc` — the chat the give-up notice was/would be
+   *  posted to, and when. Durably records the per-chat escalation-notice
+   *  window so a burst of undeliverable inbounds (or a multi-restart
+   *  outage) produces ONE "couldn't deliver" notice per chat, not one
+   *  per dropped entry. */
+  chat?: string | number
+  thread?: string
+  at?: number
+}
+
+/** Stable per-(chat,thread) key for coalescing give-up notices. */
+function escChatKey(msg: InboundMessage): string {
+  const threadRaw = msg.meta?.threadId
+  const thread =
+    typeof threadRaw === 'string' && threadRaw.length > 0 ? threadRaw : '-'
+  return `${msg.chatId}:${thread}`
 }
 
 export interface InboundSpoolFsSeam {
@@ -134,6 +151,14 @@ export interface InboundSpoolOptions {
   escalateAfterMs?: number
   /** Rewrite-compact the JSONL once it exceeds this. Default 256 KiB. */
   compactAtBytes?: number
+  /** Coalescing window for the user-facing "couldn't deliver" notice,
+   *  per chat. The window SLIDES on every escalation attempt (posted or
+   *  suppressed), so a sustained burst posts exactly one notice and only
+   *  re-notifies after the burst goes quiet for this long. Must exceed
+   *  the rate at which undeliverable entries age out (the 15-min
+   *  `escalateAfterMs` here) or back-to-back attempts wouldn't coalesce.
+   *  Default 30 min. */
+  escalateNoticeCooldownMs?: number
 }
 
 export interface ReplayEntry {
@@ -165,10 +190,20 @@ export interface InboundSpool {
    *  finished could land on top of the handback turn. Tombstones the
    *  dropped entries durably. */
   dropMatching: (predicate: (id: string) => boolean) => number
-  /** Escalate+drop entries older than `escalateAfterMs`. Calls
-   *  `onEscalate` once per dropped entry (post the "couldn't deliver"
-   *  card there). Returns the count escalated. Safe to call on a timer. */
-  sweepEscalations: (onEscalate: (e: ReplayEntry) => void) => number
+  /** Escalate+drop entries older than `escalateAfterMs`. Every dropped
+   *  entry is tombstoned (the promise is retracted deterministically),
+   *  but the user-facing notice is COALESCED per chat: `onEscalate` is
+   *  called for every dropped entry with `postNotice` indicating whether
+   *  to actually post the "couldn't deliver" card. `postNotice` is true
+   *  only for the first escalation to a given chat within
+   *  `escalateNoticeCooldownMs` — a burst of undeliverable inbounds (e.g.
+   *  a synthetic re-created every 15 min while the agent is down, across
+   *  restarts) yields ONE notice, not one per entry. The window is
+   *  persisted, so it holds across a gateway restart. Returns the count
+   *  of entries dropped. Safe to call on a timer. */
+  sweepEscalations: (
+    onEscalate: (e: ReplayEntry, opts: { postNotice: boolean }) => void,
+  ) => number
   /** Test/observability: count of live (un-acked) ids. */
   liveCount: () => number
 }
@@ -179,11 +214,18 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
   const log = opts.log ?? ((l: string) => process.stderr.write(l))
   const escalateAfterMs = opts.escalateAfterMs ?? 15 * 60 * 1000
   const compactAtBytes = opts.compactAtBytes ?? 256 * 1024
+  const escalateNoticeCooldownMs = opts.escalateNoticeCooldownMs ?? 30 * 60 * 1000
 
   // In-memory projection of the on-disk log, rebuilt from the file at
   // construction. `live` maps spoolId → the put record (insertion order
   // preserved via the Map). An `ack` deletes from `live`.
   const live = new Map<string, { agent: string; msg: InboundMessage; firstAt: number }>()
+  // Per-chat last escalation-ATTEMPT time (posted or suppressed). Drives
+  // the sliding coalescing window so a burst of give-up escalations posts
+  // one notice. Rebuilt from durable `esc` records at construction so the
+  // window survives a gateway restart (the actual 2026-06-09 spam: a
+  // synthetic re-aged into the bound every 15 min across many restarts).
+  const escAttemptByChat = new Map<string, number>()
 
   function parseLine(line: string): SpoolRecord | null {
     const s = line.trim()
@@ -196,7 +238,13 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
     }
     if (rec == null || typeof rec !== 'object') return null
     const r = rec as Record<string, unknown>
-    if (r.t !== 'put' && r.t !== 'ack') return null
+    if (r.t !== 'put' && r.t !== 'ack' && r.t !== 'esc') return null
+    if (r.t === 'esc') {
+      // esc records key on chat, not a spoolId.
+      if (typeof r.chat !== 'string' && typeof r.chat !== 'number') return null
+      if (typeof r.at !== 'number') return null
+      return r as unknown as SpoolRecord
+    }
     if (typeof r.id !== 'string' || r.id.length === 0) return null
     if (r.t === 'put') {
       if (r.msg == null || typeof r.msg !== 'object') return null
@@ -209,6 +257,7 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
   // Rebuild `live` from the file. Tolerates a torn last line.
   function hydrate(): void {
     live.clear()
+    escAttemptByChat.clear()
     if (!fs.existsSync(path)) return
     let raw = ''
     try {
@@ -221,13 +270,17 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
       if (rec == null) continue
       if (rec.t === 'put') {
         // Last put for an id wins; an ack later removes it.
-        live.set(rec.id, {
+        live.set(rec.id as string, {
           agent: rec.agent as string,
           msg: rec.msg as InboundMessage,
           firstAt: rec.firstAt as number,
         })
+      } else if (rec.t === 'esc') {
+        // Last escalation-attempt time per chat wins (records are in
+        // append order). Restores the sliding window across a restart.
+        escAttemptByChat.set(`${rec.chat}:${rec.thread ?? '-'}`, rec.at as number)
       } else {
-        live.delete(rec.id)
+        live.delete(rec.id as string)
       }
     }
   }
@@ -267,6 +320,22 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
     for (const [id, e] of live) {
       lines.push(
         JSON.stringify({ t: 'put', id, agent: e.agent, msg: e.msg, firstAt: e.firstAt } satisfies SpoolRecord),
+      )
+    }
+    // Preserve the latest escalation-attempt time per chat so the sliding
+    // coalescing window isn't reset by compaction (which would let the next
+    // burst re-spam). One record per chat — bounded by the chat count.
+    for (const [key, at] of escAttemptByChat) {
+      const sep = key.lastIndexOf(':')
+      const chat = key.slice(0, sep)
+      const thread = key.slice(sep + 1)
+      lines.push(
+        JSON.stringify({
+          t: 'esc',
+          chat,
+          ...(thread !== '-' ? { thread } : {}),
+          at,
+        } satisfies SpoolRecord),
       )
     }
     const tmp = path + '.compact.tmp'
@@ -328,24 +397,46 @@ export function createInboundSpool(opts: InboundSpoolOptions): InboundSpool {
       return n
     },
     sweepEscalations(onEscalate) {
-      const cutoff = now() - escalateAfterMs
-      let n = 0
+      const tNow = now()
+      const cutoff = tNow - escalateAfterMs
+      let dropped = 0
+      let posted = 0
       for (const [id, e] of [...live.entries()]) {
         if (e.firstAt > cutoff) continue
         live.delete(id)
         appendRecord({ t: 'ack', id }) // tombstone — promise retracted
+        // Coalesce the user-facing notice per chat on a SLIDING window:
+        // post only when the last attempt to this chat was longer ago than
+        // the cooldown; every attempt (posted or not) slides the window, so
+        // a sustained burst stays quiet after the first notice and only
+        // re-notifies once the burst goes quiet. Durable via `esc` records.
+        const key = escChatKey(e.msg)
+        const lastAttempt = escAttemptByChat.get(key)
+        const postNotice =
+          lastAttempt === undefined || tNow - lastAttempt >= escalateNoticeCooldownMs
+        escAttemptByChat.set(key, tNow)
+        const threadRaw = e.msg.meta?.threadId
+        const thread =
+          typeof threadRaw === 'string' && threadRaw.length > 0 ? threadRaw : undefined
+        appendRecord({ t: 'esc', chat: e.msg.chatId, thread, at: tNow })
         try {
-          onEscalate({ agent: e.agent, msg: e.msg })
+          onEscalate({ agent: e.agent, msg: e.msg }, { postNotice })
         } catch (err) {
           log(`inbound-spool: onEscalate threw id=${id}: ${(err as Error).message}\n`)
         }
-        n++
+        if (postNotice) posted++
+        dropped++
       }
-      if (n > 0) {
-        log(`inbound-spool: escalated+dropped ${n} undelivered entr${n === 1 ? 'y' : 'ies'} (older than ${escalateAfterMs}ms)\n`)
+      if (dropped > 0) {
+        const suppressed = dropped - posted
+        log(
+          `inbound-spool: escalated+dropped ${dropped} undelivered entr${dropped === 1 ? 'y' : 'ies'} ` +
+          `(older than ${escalateAfterMs}ms; ${posted} notice${posted === 1 ? '' : 's'} posted` +
+          `${suppressed > 0 ? `, ${suppressed} coalesced` : ''})\n`,
+        )
         maybeCompact()
       }
-      return n
+      return dropped
     },
     liveCount() {
       return live.size

--- a/telegram-plugin/tests/inbound-spool.test.ts
+++ b/telegram-plugin/tests/inbound-spool.test.ts
@@ -285,6 +285,107 @@ describe('inbound-spool — bounded escalation (promise always resolved)', () =>
   })
 })
 
+describe('inbound-spool — give-up notice coalescing (2026-06-09 marko spam)', () => {
+  // Helper: drive a sweep, return the list of postNotice flags per dropped entry.
+  function sweepFlags(s: ReturnType<typeof createInboundSpool>): boolean[] {
+    const flags: boolean[] = []
+    s.sweepEscalations((_e, { postNotice }) => flags.push(postNotice))
+    return flags
+  }
+
+  it('a burst of undeliverable entries in one chat posts exactly ONE notice', () => {
+    const fs = fakeFs()
+    let t = 0
+    const s = createInboundSpool({
+      path: PATH, fs, now: () => t,
+      escalateAfterMs: 100, escalateNoticeCooldownMs: 10_000,
+    })
+    // Three synthetics, same chat, distinct ids (fresh ts → distinct spoolId,
+    // the exact churn shape that produced the spam).
+    s.put('marko', msg({ messageId: 0, ts: 1, meta: { source: 'cron' } }))
+    s.put('marko', msg({ messageId: 0, ts: 2, meta: { source: 'cron' } }))
+    s.put('marko', msg({ messageId: 0, ts: 3, meta: { source: 'cron' } }))
+    t = 1000 // all older than the 100ms bound
+    const flags = sweepFlags(s)
+    expect(flags.length).toBe(3) // all three dropped (promise retracted)
+    expect(flags.filter(Boolean).length).toBe(1) // ONE notice posted
+    expect(s.liveCount()).toBe(0)
+  })
+
+  it('distinct chats each get their own notice', () => {
+    const fs = fakeFs()
+    let t = 0
+    const s = createInboundSpool({ path: PATH, fs, now: () => t, escalateAfterMs: 100 })
+    s.put('marko', msg({ chatId: 'A', messageId: 1 }))
+    s.put('marko', msg({ chatId: 'B', messageId: 2 }))
+    t = 1000
+    expect(sweepFlags(s).filter(Boolean).length).toBe(2)
+  })
+
+  it('same chat, different forum topics are coalesced independently', () => {
+    const fs = fakeFs()
+    let t = 0
+    const s = createInboundSpool({ path: PATH, fs, now: () => t, escalateAfterMs: 100 })
+    s.put('marko', msg({ chatId: 'A', messageId: 1, meta: { threadId: '3' } }))
+    s.put('marko', msg({ chatId: 'A', messageId: 2, meta: { threadId: '4' } }))
+    t = 1000
+    expect(sweepFlags(s).filter(Boolean).length).toBe(2)
+  })
+
+  it('THE BUG: the coalescing window survives a restart — a re-aged synthetic does not re-spam', () => {
+    const fs = fakeFs()
+    let t = 0
+    const opts = { escalateAfterMs: 100, escalateNoticeCooldownMs: 60_000 }
+    // Boot 1: one synthetic ages out → posts the notice.
+    const s1 = createInboundSpool({ path: PATH, fs, now: () => t, ...opts })
+    s1.put('marko', msg({ messageId: 0, ts: 1, meta: { source: 'cron' } }))
+    t = 1000
+    expect(sweepFlags(s1)).toEqual([true])
+    // Restart. A NEW synthetic (fresh ts → fresh id) lands and ages out within
+    // the cooldown. Pre-fix this re-posted every cycle across restarts.
+    t = 5000
+    const s2 = createInboundSpool({ path: PATH, fs, now: () => t, ...opts })
+    s2.put('marko', msg({ messageId: 0, ts: 2, meta: { source: 'cron' } }))
+    t = 6000
+    expect(sweepFlags(s2)).toEqual([false]) // dropped, but notice SUPPRESSED
+  })
+
+  it('compaction preserves the coalescing window (a post-compaction restart does not re-spam)', () => {
+    const fs = fakeFs()
+    let t = 0
+    // Tiny compact threshold so the next append triggers a rewrite.
+    const opts = { escalateAfterMs: 100, escalateNoticeCooldownMs: 60_000, compactAtBytes: 1 }
+    const s1 = createInboundSpool({ path: PATH, fs, now: () => t, ...opts })
+    s1.put('marko', msg({ messageId: 0, ts: 1, meta: { source: 'cron' } }))
+    t = 1000
+    expect(sweepFlags(s1)).toEqual([true]) // posts + appends esc; compaction runs
+    // After compaction the file must still carry the esc record → a restart
+    // hydrates the window → a new re-aged synthetic stays suppressed.
+    t = 5000
+    const s2 = createInboundSpool({ path: PATH, fs, now: () => t, ...opts })
+    s2.put('marko', msg({ messageId: 0, ts: 2, meta: { source: 'cron' } }))
+    t = 6000
+    expect(sweepFlags(s2)).toEqual([false])
+  })
+
+  it('re-notifies after the burst goes quiet for longer than the cooldown', () => {
+    const fs = fakeFs()
+    let t = 0
+    const s = createInboundSpool({
+      path: PATH, fs, now: () => t,
+      escalateAfterMs: 100, escalateNoticeCooldownMs: 1000,
+    })
+    s.put('marko', msg({ messageId: 0, ts: 1, meta: { source: 'cron' } }))
+    t = 200
+    expect(sweepFlags(s)).toEqual([true]) // first notice
+    // Quiet gap longer than the cooldown, then a new stuck synthetic.
+    t = 5000
+    s.put('marko', msg({ messageId: 0, ts: 2, meta: { source: 'cron' } }))
+    t = 5200
+    expect(sweepFlags(s)).toEqual([true]) // genuinely new situation → re-notify
+  })
+})
+
 describe('inbound-spool — robustness', () => {
   it('a failing appendFileSync does not throw and keeps in-memory live state', () => {
     const fs = fakeFs()


### PR DESCRIPTION
## Summary
marko spammed **"⚠️ I couldn't deliver an earlier message … Please resend it."** four times, exactly 15 min apart (2026-06-09). Root cause: the durable inbound-spool's give-up escalation fires **once per dropped entry**, and during the outage a synthetic inbound kept being re-created with a fresh `ts` → a fresh spoolId → a new entry that aged into the 15-min bound **every cycle, across many restarts**. Each tombstoned correctly, but each posted the same generic notice → spam.

## Fix
The notice is generic ("an earlier message"), so posting it more than once per chat is pure noise. Coalesce it on a per-chat **sliding window**:

- `sweepEscalations` still tombstones **every** expired entry (the promise is retracted deterministically — unchanged) and still reaps the queued placeholder for each, but now passes the callback a `postNotice` flag.
- `postNotice` is true only when the last escalation **attempt** to that chat was longer ago than `escalateNoticeCooldownMs` (default 30 min). Every attempt — posted or suppressed — **slides** the window, so a sustained burst posts **one** notice and only re-notifies after the burst goes quiet.
- The window is **durable**: a new `esc` spool record persists the per-chat attempt time, hydrated on boot and preserved through compaction. That's what fixes the across-restarts spam — an in-memory window would reset every boot and re-spam (exactly what happened).

Per-chat **and** per-forum-topic granularity (distinct topics notify independently). The gateway reaps the placeholder for every dropped entry but only sends the card when `postNotice`.

## Test plan
- [x] burst of churned synthetics in one chat → **one** notice; all dropped.
- [x] distinct chats / distinct forum topics each notify.
- [x] **the bug**: coalescing window survives a restart — a re-aged synthetic stays suppressed.
- [x] re-notify after the burst goes quiet longer than the cooldown.
- [x] compaction preserves the window (post-compaction restart doesn't re-spam).
- [x] 28 inbound-spool tests green under **both** bun and vitest; `tsc`, plugin-references, bot-api-wrapping clean.

## Risk
Low — the durability/retraction semantics are unchanged (every entry still tombstoned + placeholder reaped); only the redundant user-facing notice is suppressed. Worst case (a stale `esc` record) just delays a notice by ≤30 min; it can never drop the only notice (first attempt always posts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)