### PR TITLE
fix(hostd,compose): give in-container apply the real host home; reject /host-home bind sources

### DIFF
--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -802,6 +802,30 @@ export function generateCompose(opts: ComposeGeneratorOptions): string {
   // preserves the older `${HOME}` shape for callers that haven't been
   // updated.
   const homePrefix = opts.homeDir ?? "${HOME}";
+  // Backstop (2026-06-11/12 fleet outages): `homePrefix` is the leading
+  // segment of EVERY host-path bind source, so it MUST be a host path. The
+  // one poison value is `/host-home` — the in-container mount point of the
+  // host home that hostd pins HOME to. If an in-container apply runs without
+  // SWITCHROOM_HOST_HOME set, homedir() returns /host-home and it leaks into
+  // every source: docker auto-creates empty `/host-home/...` dirs on the
+  // host, so the agent scaffold mount is empty (start.sh missing → exec
+  // fails 127) and the brokers EISDIR. Worse, that value gets baked back
+  // into the fleet as SWITCHROOM_HOST_HOME, self-perpetuating. Refuse to
+  // emit it — fail loud with the recovery path instead of generating a
+  // fleet-killing compose. (Root cause is fixed by hostd setting
+  // SWITCHROOM_HOST_HOME; this guards every other caller, forever.)
+  if (homePrefix === "/host-home" || homePrefix.startsWith("/host-home/")) {
+    throw new Error(
+      `compose: refusing to generate — the host-home prefix resolved to "${homePrefix}", ` +
+      `which is the IN-CONTAINER mount point, not a host path. Emitting it as a bind-mount ` +
+      `source would make docker create empty dirs on the host and crash the fleet (start.sh ` +
+      `missing → exec 127; broker EISDIR).\n\n` +
+      `Cause: \`apply\` ran inside a container without SWITCHROOM_HOST_HOME set to the real ` +
+      `host home. Recovery: run \`switchroom apply\` once from the HOST shell (not via an ` +
+      `agent / hostd), which regenerates the compose with correct host paths and re-bakes a ` +
+      `correct SWITCHROOM_HOST_HOME into the fleet.`,
+    );
+  }
   // Default container_name prefix matches the compose project name and
   // every operator command in the docs (`docker exec -it switchroom-
   // vault-broker ...`, `journalctl --user -u switchroom-vault-broker`).

--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -3,7 +3,7 @@
 // Values are refreshed every time `npm run build` runs.
 
 export const VERSION: string = "0.15.3";
-export const COMMIT_SHA: string | null = "5c4a67f1";
-export const COMMIT_DATE: string | null = "2026-06-11T06:42:35Z";
-export const LATEST_PR: number | null = 2276;
-export const COMMITS_AHEAD_OF_TAG: number | null = 6;
+export const COMMIT_SHA: string | null = "82bd17d8";
+export const COMMIT_DATE: string | null = "2026-06-11T19:51:40+10:00";
+export const LATEST_PR: number | null = 2278;
+export const COMMITS_AHEAD_OF_TAG: number | null = 7;

--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -46,6 +46,15 @@ describe("renderHostdComposeFile", () => {
     expect(out).toContain("/var/run/docker.sock:/var/run/docker.sock:rw");
   });
 
+  it("exports SWITCHROOM_HOST_HOME = the REAL host home (so in-container apply emits host bind sources, not /host-home)", () => {
+    const out = renderHostdComposeFile({ hostHome: "/home/alice", imageTag: "latest" });
+    // The 2026-06-11/12 outages: without this, in-container apply did
+    // homedir()→/host-home and poisoned every bind source. HOME stays
+    // /host-home (socket convention) but SWITCHROOM_HOST_HOME must be real.
+    expect(out).toContain("HOME: /host-home");
+    expect(out).toContain("SWITCHROOM_HOST_HOME: /home/alice");
+  });
+
   it("pins the image tag exactly as passed", () => {
     const out = renderHostdComposeFile({
       hostHome: "/home/x",

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -125,6 +125,19 @@ services:
       # operator's home), so the socket paths the agent fleet sees
       # (~/.switchroom/hostd/<agent>/sock) match the paths hostd binds.
       HOME: /host-home
+      # The REAL host home path. HOME above is pinned to /host-home (the
+      # in-container mount point) for the socket-path convention, but that
+      # is NOT a host filesystem path. When hostd shells out \`switchroom
+      # apply\` / \`agent restart\`, the compose generator must emit HOST
+      # paths as bind-mount SOURCES — homedir() inside here returns
+      # /host-home, which docker would auto-create as empty dirs on the
+      # host (start.sh missing → every agent exec-fails 127; broker EISDIR
+      # — the 2026-06-11/12 fleet outages). SWITCHROOM_HOST_HOME is the
+      # generator's authoritative host home (write-compose.ts prefers it
+      # over homedir(); compose.ts bakes it into each agent). Without it,
+      # an in-container apply poisons every bind source with /host-home AND
+      # re-bakes /host-home into the fleet, self-perpetuating.
+      SWITCHROOM_HOST_HOME: ${hostHome}
       # Hostd's CLI shellouts (\`switchroom <verb>\`) need to pick up the
       # same config the agent fleet's compose generator did. Point at
       # the resolved /state/config bind so the agent fleet's config-path

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -172,6 +172,32 @@ describe("generateCompose config mount is never a container path", () => {
   });
 });
 
+describe("generateCompose — refuses a /host-home prefix (2026-06-11/12 fleet outages)", () => {
+  it("throws when homeDir is the in-container host-home mount point", () => {
+    // homedir() inside the hostd container returns /host-home when
+    // SWITCHROOM_HOST_HOME is unset — emitting it as a bind source killed the
+    // fleet (agent scaffold mount empty → start.sh missing → exec 127; broker
+    // EISDIR). The generator must fail loud, not produce a fleet-killer.
+    expect(() =>
+      generateCompose({ config: makeConfig({ klanker: {} }), homeDir: "/host-home" }),
+    ).toThrow(/in-container mount point|host path/i);
+  });
+  it("throws for any path under /host-home/", () => {
+    expect(() =>
+      generateCompose({ config: makeConfig({ klanker: {} }), homeDir: "/host-home/nested" }),
+    ).toThrow(/host-home/);
+  });
+  it("accepts a real host home", () => {
+    expect(() =>
+      generateCompose({
+        config: makeConfig({ klanker: {} }),
+        homeDir: "/home/op",
+        switchroomConfigPath: "/home/op/.switchroom/switchroom.yaml",
+      }),
+    ).not.toThrow();
+  });
+});
+
 describe("allocateAgentUid", () => {
   it("returns UID in the reserved range", () => {
     for (const name of ["klanker", "coach", "finn", "ziggy", "alpha", "z9"]) {


### PR DESCRIPTION
## Summary
Root cause of the **2026-06-11/12 fleet outages** (the second one — worse than the config-mount EISDIR). hostd pins `HOME=/host-home` (the in-container mount point of the operator home) for its socket-path convention. When an admin agent triggers `/update apply`, hostd shells out `switchroom apply` **inside that container**; the compose generator resolves the host-home prefix via `SWITCHROOM_HOST_HOME || homedir()`, and **hostd never set `SWITCHROOM_HOST_HOME`** — so `homedir()` returned `/host-home` and it leaked into **every bind-mount source**.

docker then auto-created empty `/host-home` dirs on the host: the agent scaffold mount (`/state/agent`) was **empty**, `start.sh` was missing, and **all 12 agents exec-failed with 127** (vault-broker EISDIR the same way). Worse, `/host-home` got baked back into the fleet as each agent's `SWITCHROOM_HOST_HOME` — **self-perpetuating**.

#2276 and the config-mount guard fixed only **one** mount (the config file). This fixes the **prefix that drives all of them**.

## Fix (two parts)
1. **`hostd.ts`** — export `SWITCHROOM_HOST_HOME=<real host home>` in the hostd container env (it already holds it as `hostHome`, used for the bind mounts). `HOME` stays `/host-home` for the socket convention; `SWITCHROOM_HOST_HOME` is now the generator's authoritative host home, so an in-container apply emits real host bind sources **and** re-bakes a correct value into the fleet.
2. **`compose.ts`** — generator **backstop**: refuse to emit when the host-home prefix is `/host-home` (or under it) — that value can never be a valid host bind source. Fail loud with the recovery path ("run apply from the host") instead of generating a fleet-killer. Guards **every** caller, forever — not just hostd.

## Test plan
- [x] hostd compose exports `SWITCHROOM_HOST_HOME=/home/alice` (real home) while `HOME: /host-home`.
- [x] `generateCompose` throws on `homeDir=/host-home` and any `/host-home/…`; accepts a real host home.
- [x] 268 docker tests + 189 focused green; `tsc` clean; build clean.
- [x] **Live-validated by the recovery**: regenerating bind sources to the real host path brought all 12 agents back.

## Deploy note
Until this ships **and** hostd is reinstalled with the new env, an in-container `/update apply` will re-break the fleet — run `switchroom apply`/`update` **from the host shell** only. The live fleet was recovered by rewriting the compose bind sources to the host path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)