### PR TITLE
fix(docker): ship ALL bin hook scripts into the agent image (glob, not a drifting list)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -171,11 +171,17 @@ WORKDIR /
 COPY telegram-plugin/start.js /opt/switchroom/telegram-plugin/start.js
 COPY telegram-plugin/package.json /opt/switchroom/telegram-plugin/package.json
 COPY telegram-plugin/hooks /opt/switchroom/telegram-plugin/hooks
-COPY bin/run-hook.sh /opt/switchroom/bin/run-hook.sh
-COPY bin/timezone-hook.sh /opt/switchroom/bin/timezone-hook.sh
-COPY bin/user-profile-refresh-hook.sh /opt/switchroom/bin/user-profile-refresh-hook.sh
-COPY bin/workspace-stable-hook.sh /opt/switchroom/bin/workspace-stable-hook.sh
-COPY bin/workspace-dynamic-hook.sh /opt/switchroom/bin/workspace-dynamic-hook.sh
+# Copy ALL bin/ shell scripts as a glob, not an explicit per-script list.
+# An explicit list silently drops any newly-added script: #2273 added
+# bin/turn-pacing-hook.sh (referenced UNCONDITIONALLY by the agent's
+# turn-pacing UserPromptSubmit hook) but no COPY line, so the script was
+# absent from the image and the hook exec-failed 127 every turn, fleet-wide
+# (lost turn-pacing directive + a 🔴 issue per turn). handoff-briefing.sh and
+# boot-self-test.sh were missing the same way (silently, behind command-v/-x
+# guards). The glob includes every current AND future hook script, so this
+# "added a script, forgot the COPY" regression class cannot recur. All are
+# small agent-runtime shell scripts; none are secrets.
+COPY bin/*.sh /opt/switchroom/bin/
 RUN chmod +x /opt/switchroom/bin/*.sh
 
 # ─── Frequently-changed dist COPYs (LAST, only these bust on src-only PRs) ───

--- a/tests/docker/dockerfile-agent-bakes.test.ts
+++ b/tests/docker/dockerfile-agent-bakes.test.ts
@@ -49,6 +49,41 @@ describe("Dockerfile.agent bakes", () => {
   });
 });
 
+describe("Dockerfile.agent ships every hook script the scaffold invokes", () => {
+  // Cross-reference the Dockerfile against scaffold.ts's ACTUAL hook-script
+  // references (via DOCKER_BIN_PATH). #2273 added bin/turn-pacing-hook.sh +
+  // wired it into the agent's UserPromptSubmit hooks but never added the COPY
+  // line, so the script was absent from the image and the hook exec-failed
+  // 127 every turn, fleet-wide. This guard ties the image to what the runtime
+  // needs: any referenced hook script that isn't shipped fails the build gate.
+  const scaffold = readFileSync(resolve(root, "src/agents/scaffold.ts"), "utf8");
+  const referenced = [
+    ...new Set(
+      [...scaffold.matchAll(/join\(DOCKER_BIN_PATH,\s*"([^"]+\.sh)"\)/g)].map((m) => m[1]),
+    ),
+  ];
+  const copiesViaGlob = /COPY\s+bin\/\*\.sh\s+\/opt\/switchroom\/bin\//.test(dockerfile);
+
+  it("sanity: scaffold references the known hook scripts incl. turn-pacing-hook.sh", () => {
+    expect(referenced).toContain("turn-pacing-hook.sh");
+    expect(referenced).toContain("workspace-dynamic-hook.sh");
+    expect(referenced.length).toBeGreaterThanOrEqual(5);
+  });
+
+  for (const script of referenced) {
+    it(`ships ${script} into the agent image (glob or explicit COPY)`, () => {
+      const copiesExplicit = new RegExp(
+        `COPY\\s+bin/${script.replace(/\./g, "\\.")}\\s`,
+      ).test(dockerfile);
+      expect(
+        copiesViaGlob || copiesExplicit,
+        `Dockerfile.agent must COPY bin/${script} (the scaffold runs it via DOCKER_BIN_PATH) — ` +
+        `add it to the bake list, or use the bin/*.sh glob`,
+      ).toBe(true);
+    });
+  }
+});
+
 /**
  * Playwright is delivered through TWO bindings — the JS binding for the
  * `@playwright/mcp` default MCP, and the Python binding for the bundled


### PR DESCRIPTION
## Summary
finn (and **every agent**) logged `🔴 hook:turn-pacing::env exited 127` every turn. Root cause: **#2273** added `bin/turn-pacing-hook.sh` and wired the agent's turn-pacing `UserPromptSubmit` hook to run it (`scaffold.ts:4489`, **unconditionally** — no `command -v`/`-x` guard), but `Dockerfile.agent` copies hook scripts with an **explicit per-name list** and no `COPY` line was added. So the script was **absent from the v0.15.4 image** and `bash …/turn-pacing-hook.sh` exec-failed **127 on every turn, fleet-wide**.

**Effect:** the turn-pacing directive (human-voice reply guidance) was never injected, *and* the failure logged an issue every turn. Agents have a **read-only rootfs**, so no hot-copy is possible — the script must be baked in.

`handoff-briefing.sh` and `boot-self-test.sh` were missing the **same way**, but silently (behind `command -v` / `-x` guards in `start.sh.hbs`) — so session handoff briefing and the boot self-test also weren't running.

## Fix
- **`Dockerfile.agent`**: copy bin/ scripts with a **glob** (`COPY bin/*.sh`) instead of an explicit list that silently drops any newly-added script. Includes every current and future hook script (`chmod` already globs). Fixes all three missing scripts.
- **Regression guard** (`dockerfile-agent-bakes.test.ts`): cross-references `scaffold.ts`'s `DOCKER_BIN_PATH` hook-script references against the Dockerfile — any referenced script not shipped (glob or explicit `COPY`) **fails the gate**. This class can't recur.

## Test plan
- [x] 21 dockerfile-bake tests green, incl. one per scaffold-referenced hook script (turn-pacing-hook.sh, workspace-dynamic/stable, timezone, user-profile-refresh, run-hook).
- [x] Verified the glob covers all 8 `bin/*.sh`.

## Deploy
Needs a new agent image + roll (the script is baked at build time; read-only rootfs precludes a hot-copy). Rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)