### PR TITLE
chore: release v0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.15.5 — ship every agent hook script into the image (turn-pacing 127 fix)
+
+A one-fix release closing the last loose end from the v0.15.4 batch.
+
+### Agent image ships ALL bin hook scripts (#2281)
+
+- `#2273` added `bin/turn-pacing-hook.sh` and wired it into the agent's
+  `UserPromptSubmit` hooks (via `DOCKER_BIN_PATH`) but never added the matching
+  `COPY` line to `Dockerfile.agent` — so the script was absent from the image
+  and the hook exec-failed `127` **every turn, fleet-wide**, losing the
+  turn-pacing directive and logging a 🔴 `hook:turn-pacing::env exited 127`
+  per turn (surfaced as "Finn · 1 issue" on the status board).
+- Fix: replace the drifting explicit per-script `COPY bin/<name>-hook.sh` list
+  with a single `COPY bin/*.sh /opt/switchroom/bin/` glob (+ `chmod +x`), so
+  any hook script the scaffold references is shipped by construction.
+- New build-gate regression guard (`tests/docker/dockerfile-agent-bakes.test.ts`)
+  cross-references every `join(DOCKER_BIN_PATH, "<x>.sh")` reference in
+  `scaffold.ts` against the Dockerfile — a referenced-but-unshipped hook now
+  fails the build instead of the fleet.
+
 ## v0.15.4 — fleet-outage root-cause fixes + /model picker UX + spool de-spam
 
 The headline is **two fleet-killer class bugs**, both root-caused and fixed in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

One-fix release over v0.15.4: ship every agent hook script into the image so the turn-pacing hook stops exec-failing 127 fleet-wide.

## Why

`#2273` wired `bin/turn-pacing-hook.sh` into the agent `UserPromptSubmit` hooks but never added a `COPY` line, so the script was absent from the image — the hook exited `127` every turn, fleet-wide, dropping the turn-pacing directive and logging a 🔴 `hook:turn-pacing::env exited 127` per turn (surfaced as "Finn · 1 issue").

## What

- `#2281` (already merged): `Dockerfile.agent` now `COPY bin/*.sh` (glob, not a drifting explicit list) + build-gate regression guard cross-referencing `scaffold.ts`'s `DOCKER_BIN_PATH` hook references.
- This PR: version bump 0.15.4 → 0.15.5 + CHANGELOG.

## Test plan

- [x] `node scripts/build.mjs` — exit 0, `dist/cli/switchroom.js` ~3.1MB
- [x] #2281 merged with green CI (includes the new bake-list guard test)

## Risk

Trivial — version/changelog only; the code fix already merged and passed CI.