### PR TITLE
feat(webhook): dispatch for generic + linear sources (#2272)

### DIFF
--- a/docs/webhook-ingest.md
+++ b/docs/webhook-ingest.md
@@ -41,6 +41,58 @@ Use this for in-house tools that can't HMAC-sign:
 
 The body must be JSON. Common fields (`title`, `message`, `text`) are auto-rendered into the stored Telegram-ready text; otherwise a JSON snippet is used.
 
+## Setup — Linear (#2272)
+
+Linear signs its webhooks with a **bare hex HMAC-SHA256 of the raw body** in the `Linear-Signature` header (no `sha256=` prefix, no Bearer auth).
+
+1. `webhook_sources: [ linear ]` in switchroom.yaml.
+2. Put the signing secret in `webhook-secrets.json`: `{ "finn": { "linear": "<linear-webhook-secret>" } }`.
+3. In Linear → Settings → API → Webhooks, point the URL at `https://<your-host>/webhook/finn/linear` and copy the generated signing secret into step 2.
+4. Pick the resources to deliver (Issues, Comments).
+
+`event_type` is the lower-cased Linear `type` (`issue`, `comment`). Issue and comment events render the identifier (e.g. `ENG-42`), action, assignee, title/body and URL.
+
+## Auto-dispatch (waking the agent)
+
+When an event matches a `webhook_dispatch` rule, switchroom injects the rendered prompt as a synthesized turn into the agent's live `claude` session (never a headless `claude -p`). Dispatch works for **github, generic, and linear** sources (#2272 — previously github-only). Rules are keyed by source:
+
+```yaml
+agents:
+  clerk:
+    channels:
+      telegram:
+        webhook_sources: [ linear ]
+        webhook_dispatch:
+          linear:
+            - description: "Act on issues assigned to me"
+              match:
+                event: issue          # linear `type`, lower-cased
+                actions: [create, update]
+                assignee_any: [clerk]  # match on assignee display name
+              prompt: |
+                Linear {{number}} assigned to you: {{title}}
+                {{html_url}}
+              cooldown: 2m
+            - description: "Respond when @mentioned in a comment"
+              match:
+                event: comment
+                mentions_any: ["@clerk"]  # case-insensitive substring of the comment body
+              prompt: "You were mentioned on {{number}} — take a look:\n{{html_url}}"
+```
+
+Matcher knobs by source:
+
+| field | github | linear | generic |
+|---|---|---|---|
+| `event` (required) | event header | `type` (lower) | source name |
+| `actions` | yes | yes | yes |
+| `labels_any` / `labels_all` | yes | yes | yes |
+| `exclude_authors` | yes | yes | yes |
+| `assignee_any` | — | yes | yes |
+| `mentions_any` | — | yes | yes |
+
+All sources support the `cooldown` and `quiet_hours` knobs; the ingest path's `webhook_rate_limit` and github delivery-id dedup apply uniformly. Template fields available in `prompt`: `{{repo}}`, `{{number}}`, `{{title}}`, `{{html_url}}`, `{{author}}`, `{{assignee}}`, `{{labels}}`, `{{action}}`, `{{event}}`.
+
 ## What the agent sees
 
 Each verified event becomes one JSONL line at `<agent>/telegram/webhook-events.jsonl`:
@@ -59,8 +111,10 @@ Tell the agent (or have it know via CLAUDE.md) to `cat` or `tail` this file when
 
 ## Security
 
-- HMAC-SHA256 verification for `github` (constant-time compare).
+- HMAC-SHA256 verification for `github` (`X-Hub-Signature-256`, `sha256=`-prefixed hex, constant-time compare).
+- HMAC-SHA256 verification for `linear` (`Linear-Signature`, bare hex of the raw body, constant-time compare).
 - Bearer token verification for `generic` (constant-time compare, length-pre-checked).
+- Dispatched events are treated as **data, not instructions** — every rendered field is HTML-escaped before it reaches the agent's prompt.
 - Source not in agent's allowlist → 403, no further processing.
 - Source unknown → 400.
 - Verification fails → 401 with a generic body, but the operator log line carries the specific reason for debugging.

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -16,7 +16,9 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   matchesRule,
-  buildGithubContext,
+  buildContext,
+  DISPATCH_SOURCES,
+  type DispatchSource,
   renderTemplate,
   parseDurationMs,
   isQuietHour,
@@ -686,7 +688,15 @@ function registerDispatchVerb(tg: Command, _program: Command): void {
         }
 
         // Collect matches without spawning
-        const rules = opts.source === "github" ? (dispatchConfig.github ?? []) : [];
+        if (!(DISPATCH_SOURCES as readonly string[]).includes(opts.source)) {
+          console.log(
+            chalk.yellow(
+              `Source '${opts.source}' does not support dispatch (known: ${DISPATCH_SOURCES.join(", ")}).`,
+            ),
+          );
+          return;
+        }
+        const rules = dispatchConfig[opts.source as DispatchSource] ?? [];
         if (rules.length === 0) {
           console.log(chalk.yellow(`No dispatch rules for source '${opts.source}'.`));
           return;
@@ -697,7 +707,7 @@ function registerDispatchVerb(tg: Command, _program: Command): void {
 
         for (let i = 0; i < rules.length; i++) {
           const rule = rules[i];
-          const matched = matchesRule(opts.event, payload, rule.match);
+          const matched = matchesRule(opts.source, opts.event, payload, rule.match);
           const prefix = matched ? chalk.green("✓ MATCH") : chalk.dim("✗ no match");
           const desc = rule.description ? ` — ${rule.description}` : ` — rule ${i}`;
           console.log(`${prefix}  rule ${i}${desc}`);
@@ -722,7 +732,7 @@ function registerDispatchVerb(tg: Command, _program: Command): void {
           }
 
           // Rendered prompt
-          const ctx = buildGithubContext(opts.event, payload);
+          const ctx = buildContext(opts.source, opts.event, payload);
           const rendered = renderTemplate(rule.prompt, ctx);
           console.log(chalk.bold("  rendered prompt:"));
           for (const line of rendered.split("\n")) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -535,6 +535,39 @@ export const SessionContinuitySchema = z
  * from env vars at startup but may not act on every field yet. We
  * define them in the schema so users can start setting them now.
  */
+
+/**
+ * A single webhook_dispatch rule (#1625, extended for generic/linear in
+ * #2272). Shared across the per-source rule arrays under
+ * channels.telegram.webhook_dispatch — github / generic / linear all use
+ * the same shape. The matcher fields not relevant to a given source are
+ * simply ignored at evaluation time (e.g. assignee_any/mentions_any are
+ * no-ops for github, exclude_authors is a no-op for generic).
+ */
+const webhookDispatchRule = z.object({
+  description: z.string().optional(),
+  match: z
+    .object({
+      event: z.string(),
+      actions: z.array(z.string()).optional(),
+      labels_any: z.array(z.string()).optional(),
+      labels_all: z.array(z.string()).optional(),
+      exclude_authors: z.array(z.string()).optional(),
+      assignee_any: z.array(z.string()).optional(),
+      mentions_any: z.array(z.string()).optional(),
+    })
+    .passthrough(),
+  prompt: z.string(),
+  cooldown: z.string().optional(),
+  quiet_hours: z
+    .object({
+      start: z.number().int().min(0).max(23),
+      end: z.number().int().min(0).max(23),
+      tz: z.string().optional(),
+    })
+    .optional(),
+});
+
 export const TelegramChannelSchema = z
   .object({
     enabled: z
@@ -821,13 +854,14 @@ export const TelegramChannelSchema = z
         "defaults.channels.telegram.interrupt."
       ),
     webhook_sources: z
-      .array(z.enum(["github", "generic"]))
+      .array(z.enum(["github", "generic", "linear"]))
       .optional()
       .describe(
         "External webhook sources allowed to ingest events into this agent's " +
         "log. POST /webhook/<agent>/<source> on the switchroom web server. " +
         "Each source has its own signature verification ('github' = " +
-        "X-Hub-Signature-256 HMAC-SHA256, 'generic' = Bearer token). " +
+        "X-Hub-Signature-256 HMAC-SHA256, 'generic' = Bearer token, " +
+        "'linear' = Linear-Signature bare-hex HMAC-SHA256 of the raw body). " +
         "Per-source secret read from ~/.switchroom/webhook-secrets.json " +
         "keyed by [agent][source]. Verified events append to " +
         "<agent>/telegram/webhook-events.jsonl for the agent to read on " +
@@ -838,37 +872,17 @@ export const TelegramChannelSchema = z
       ),
     webhook_dispatch: z
       .object({
-        github: z
-          .array(
-            z.object({
-              description: z.string().optional(),
-              match: z
-                .object({
-                  event: z.string(),
-                  actions: z.array(z.string()).optional(),
-                  labels_any: z.array(z.string()).optional(),
-                  labels_all: z.array(z.string()).optional(),
-                  exclude_authors: z.array(z.string()).optional(),
-                })
-                .passthrough(),
-              prompt: z.string(),
-              cooldown: z.string().optional(),
-              quiet_hours: z
-                .object({
-                  start: z.number().int().min(0).max(23),
-                  end: z.number().int().min(0).max(23),
-                  tz: z.string().optional(),
-                })
-                .optional(),
-            }),
-          )
-          .optional(),
+        github: z.array(webhookDispatchRule).optional(),
+        generic: z.array(webhookDispatchRule).optional(),
+        linear: z.array(webhookDispatchRule).optional(),
       })
       .optional()
       .describe(
         "Auto-dispatch rules: when a verified webhook event matches a rule, " +
         "inject the rendered prompt into the agent's live session (#1625). " +
-        "Supports cooldowns, quiet hours, and label/action matchers. " +
+        "Rules are keyed by source — 'github', 'generic', or 'linear' (#2272). " +
+        "Supports cooldowns, quiet hours, label/action matchers, and (for " +
+        "linear/generic) assignee_any / mentions_any matchers. " +
         "Off by default — opt in per agent. See src/web/webhook-dispatch.ts.",
       ),
     webhook_rate_limit: z
@@ -1917,7 +1931,7 @@ export const AgentSchema = z.object({
   // canonical channels.telegram.* spot and logs a deprecation warning.
   // Remove these fields once no live switchroom.yaml uses them.
   webhook_sources: z
-    .array(z.enum(["github", "generic"]))
+    .array(z.enum(["github", "generic", "linear"]))
     .optional()
     .describe(
       "[DEPRECATED — moved to channels.telegram.webhook_sources in #596] " +

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -313,7 +313,7 @@ async function handleWebhookRoute(
       body: bodyBuf,
       headers: req.headers,
       allowedSources,
-      config: { secrets: agentSecrets as Partial<Record<"github" | "generic", string>> },
+      config: { secrets: agentSecrets as Partial<Record<"github" | "generic" | "linear", string>> },
       agentExists: agentConfig !== undefined,
       dispatchConfig: agentConfig?.channels?.telegram?.webhook_dispatch,
       // Docker-runtime: forward to the agent's gateway instead of writing

--- a/src/web/webhook-dispatch.test.ts
+++ b/src/web/webhook-dispatch.test.ts
@@ -15,6 +15,8 @@ import {
   matchesRule,
   renderTemplate,
   buildGithubContext,
+  buildLinearContext,
+  buildGenericContext,
   parseDurationMs,
   isQuietHour,
   evaluateDispatch,
@@ -41,6 +43,9 @@ const prOpened = loadFixture('github-pr-opened.json')
 const prLabeled = loadFixture('github-pr-labeled.json')
 const prDependabot = loadFixture('github-pr-dependabot.json')
 const pushPayload = loadFixture('github-push.json')
+const linearIssue = loadFixture('linear-issue-assigned.json')
+const linearComment = loadFixture('linear-comment-mention.json')
+const genericEvent = loadFixture('generic-event.json')
 
 // ─── parseDurationMs ──────────────────────────────────────────────────────────
 
@@ -92,6 +97,8 @@ describe('renderTemplate', () => {
     labels: 'needs-review',
     action: 'opened',
     event: 'pull_request',
+    assignee: '',
+    body: 'Add dark mode',
   }
 
   it('interpolates known fields', () => {
@@ -117,31 +124,31 @@ describe('matchesRule', () => {
   const baseMatcher: DispatchMatcher = { event: 'pull_request' }
 
   it('matches on event alone', () => {
-    expect(matchesRule('pull_request', prOpened, baseMatcher)).toBe(true)
+    expect(matchesRule('github', 'pull_request', prOpened, baseMatcher)).toBe(true)
   })
 
   it('rejects wrong event', () => {
-    expect(matchesRule('push', prOpened, baseMatcher)).toBe(false)
+    expect(matchesRule('github', 'push', prOpened, baseMatcher)).toBe(false)
   })
 
   it('matches when action is in list', () => {
     const m: DispatchMatcher = { event: 'pull_request', actions: ['opened', 'synchronize'] }
-    expect(matchesRule('pull_request', prOpened, m)).toBe(true)
+    expect(matchesRule('github', 'pull_request', prOpened, m)).toBe(true)
   })
 
   it('rejects when action not in list', () => {
     const m: DispatchMatcher = { event: 'pull_request', actions: ['closed'] }
-    expect(matchesRule('pull_request', prOpened, m)).toBe(false)
+    expect(matchesRule('github', 'pull_request', prOpened, m)).toBe(false)
   })
 
   it('matches labels_any when at least one label present', () => {
     const m: DispatchMatcher = { event: 'pull_request', labels_any: ['needs-review', 'bug'] }
-    expect(matchesRule('pull_request', prOpened, m)).toBe(true)
+    expect(matchesRule('github', 'pull_request', prOpened, m)).toBe(true)
   })
 
   it('rejects labels_any when none match', () => {
     const m: DispatchMatcher = { event: 'pull_request', labels_any: ['bug', 'wontfix'] }
-    expect(matchesRule('pull_request', prOpened, m)).toBe(false)
+    expect(matchesRule('github', 'pull_request', prOpened, m)).toBe(false)
   })
 
   it('matches labels_all when all labels present', () => {
@@ -149,7 +156,7 @@ describe('matchesRule', () => {
       event: 'pull_request',
       labels_all: ['needs-review', 'enhancement'],
     }
-    expect(matchesRule('pull_request', prOpened, m)).toBe(true)
+    expect(matchesRule('github', 'pull_request', prOpened, m)).toBe(true)
   })
 
   it('rejects labels_all when any label missing', () => {
@@ -157,7 +164,7 @@ describe('matchesRule', () => {
       event: 'pull_request',
       labels_all: ['needs-review', 'missing-label'],
     }
-    expect(matchesRule('pull_request', prOpened, m)).toBe(false)
+    expect(matchesRule('github', 'pull_request', prOpened, m)).toBe(false)
   })
 
   it('excludes dependabot author', () => {
@@ -165,7 +172,7 @@ describe('matchesRule', () => {
       event: 'pull_request',
       exclude_authors: ['dependabot[bot]'],
     }
-    expect(matchesRule('pull_request', prDependabot, m)).toBe(false)
+    expect(matchesRule('github', 'pull_request', prDependabot, m)).toBe(false)
   })
 
   it('allows non-excluded author', () => {
@@ -173,7 +180,7 @@ describe('matchesRule', () => {
       event: 'pull_request',
       exclude_authors: ['dependabot[bot]'],
     }
-    expect(matchesRule('pull_request', prOpened, m)).toBe(true)
+    expect(matchesRule('github', 'pull_request', prOpened, m)).toBe(true)
   })
 
   it('full combined rule matches correctly', () => {
@@ -183,9 +190,9 @@ describe('matchesRule', () => {
       labels_any: ['needs-review'],
       exclude_authors: ['dependabot[bot]', 'coolify[bot]'],
     }
-    expect(matchesRule('pull_request', prOpened, m)).toBe(true)
-    expect(matchesRule('pull_request', prDependabot, m)).toBe(false)
-    expect(matchesRule('push', pushPayload, m)).toBe(false)
+    expect(matchesRule('github', 'pull_request', prOpened, m)).toBe(true)
+    expect(matchesRule('github', 'pull_request', prDependabot, m)).toBe(false)
+    expect(matchesRule('github', 'push', pushPayload, m)).toBe(false)
   })
 })
 
@@ -497,5 +504,292 @@ describe('evaluateDispatch', () => {
     expect(count).toBe(2)
     expect(injected).toHaveLength(2)
     expect((injected[1].inbound.meta as Record<string, string>).rule_index).toBe('1')
+  })
+
+  // ── Generic / Linear source dispatch (#2272) ────────────────────────────────
+
+  const captureInjectFor = captureInject
+
+  it('fires a generic-source rule', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const { injected, injectFn } = captureInjectFor()
+    const config: WebhookDispatchConfig = {
+      generic: [
+        {
+          match: { event: 'ci', labels_any: ['prod'] },
+          prompt: 'Deploy event: {{title}}',
+        },
+      ],
+    }
+
+    const count = evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'generic',
+        eventType: 'ci',
+        payload: genericEvent,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
+      { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn },
+    )
+
+    expect(count).toBe(1)
+    expect(injected).toHaveLength(1)
+    expect(injected[0].inbound.text).toBe('Deploy event: Deploy finished')
+    expect((injected[0].inbound.meta as Record<string, string>).event).toBe('ci')
+  })
+
+  it('fires a linear issue rule matched on assignee', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const { injected, injectFn } = captureInjectFor()
+    const config: WebhookDispatchConfig = {
+      linear: [
+        {
+          match: { event: 'issue', actions: ['update'], assignee_any: ['clerk'] },
+          prompt: 'Linear {{number}} assigned: {{title}}\n{{html_url}}',
+        },
+      ],
+    }
+
+    const count = evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'linear',
+        eventType: 'issue',
+        payload: linearIssue,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
+      { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn },
+    )
+
+    expect(count).toBe(1)
+    expect(injected[0].inbound.text).toContain('ENG-42')
+    expect(injected[0].inbound.text).toContain('Investigate flaky webhook test')
+  })
+
+  it('fires a linear comment rule matched on mention', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const { injected, injectFn } = captureInjectFor()
+    const config: WebhookDispatchConfig = {
+      linear: [
+        {
+          match: { event: 'comment', mentions_any: ['@clerk'] },
+          prompt: 'Mentioned on {{number}}',
+        },
+      ],
+    }
+
+    const count = evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'linear',
+        eventType: 'comment',
+        payload: linearComment,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
+      { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn },
+    )
+
+    expect(count).toBe(1)
+    expect(injected[0].inbound.text).toBe('Mentioned on ENG-42')
+  })
+
+  it('does NOT fire a linear rule when assignee does not match', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const { injected, injectFn } = captureInjectFor()
+    const config: WebhookDispatchConfig = {
+      linear: [
+        {
+          match: { event: 'issue', assignee_any: ['someone-else'] },
+          prompt: 'x',
+        },
+      ],
+    }
+
+    const count = evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'linear',
+        eventType: 'issue',
+        payload: linearIssue,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
+      { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn },
+    )
+
+    expect(count).toBe(0)
+    expect(injected).toHaveLength(0)
+  })
+
+  it('respects cooldown for a non-github (linear) source', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const { injected, injectFn } = captureInjectFor()
+    const config: WebhookDispatchConfig = {
+      linear: [
+        {
+          match: { event: 'issue', assignee_any: ['clerk'] },
+          prompt: 'Linear {{number}}',
+          cooldown: '5m',
+        },
+      ],
+    }
+    const deps = { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn }
+
+    evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'linear',
+        eventType: 'issue',
+        payload: linearIssue,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
+      deps,
+    )
+    const count2 = evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'linear',
+        eventType: 'issue',
+        payload: linearIssue,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
+      { ...deps, now: () => 1_060_000 }, // 1 min later — still cooling
+    )
+
+    expect(injected).toHaveLength(1)
+    expect(count2).toBe(0)
+  })
+
+  it('linear and github cooldown keys do not collide (same number)', () => {
+    const resolveAgentDir = makeTmpResolveAgentDir()
+    const { injected, injectFn } = captureInjectFor()
+    const config: WebhookDispatchConfig = {
+      github: [{ match: { event: 'pull_request' }, prompt: 'gh', cooldown: '5m' }],
+      linear: [{ match: { event: 'issue' }, prompt: 'ln', cooldown: '5m' }],
+    }
+    const deps = { resolveAgentDir, now: () => 1_000_000, log: () => {}, injectFn }
+
+    // github PR #42 fires...
+    evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'github',
+        eventType: 'pull_request',
+        payload: prOpened,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
+      deps,
+    )
+    // ...linear issue (rule index 0, repo 'linear') must NOT be coalesced
+    // by the github cooldown entry even though both are rule index 0.
+    const count = evaluateDispatch(
+      {
+        agent: 'reggie',
+        source: 'linear',
+        eventType: 'issue',
+        payload: linearIssue,
+        dispatchConfig: config,
+        chatId: FORUM_CHAT,
+      },
+      deps,
+    )
+
+    expect(count).toBe(1)
+    expect(injected).toHaveLength(2)
+  })
+})
+
+// ─── buildLinearContext / buildGenericContext (#2272) ─────────────────────────
+
+describe('buildLinearContext', () => {
+  it('extracts issue fields', () => {
+    const ctx = buildLinearContext('issue', linearIssue)
+    expect(ctx.number).toBe('ENG-42')
+    expect(ctx.title).toBe('Investigate flaky webhook test')
+    expect(ctx.html_url).toBe('https://linear.app/acme/issue/ENG-42')
+    expect(ctx.assignee).toBe('clerk')
+    expect(ctx.action).toBe('update')
+    expect(ctx.labels).toBe('bug, agent-task')
+    expect(ctx.event).toBe('issue')
+  })
+
+  it('extracts comment fields with the parent issue identifier', () => {
+    const ctx = buildLinearContext('comment', linearComment)
+    expect(ctx.number).toBe('ENG-42')
+    expect(ctx.action).toBe('create')
+    // body carries the comment text for mention matching
+    expect(ctx.body).toContain('@clerk')
+  })
+})
+
+describe('buildGenericContext', () => {
+  it('extracts probed fields and uses source name as repo/event', () => {
+    const ctx = buildGenericContext('ci', genericEvent)
+    expect(ctx.repo).toBe('ci')
+    expect(ctx.event).toBe('ci')
+    expect(ctx.title).toBe('Deploy finished')
+    expect(ctx.assignee).toBe('ops-bot')
+    expect(ctx.labels).toBe('prod, deploy')
+    expect(ctx.html_url).toBe('https://ci.example.com/runs/99')
+  })
+})
+
+// ─── source-aware matchesRule (#2272) ─────────────────────────────────────────
+
+describe('matchesRule (linear/generic)', () => {
+  it('matches linear assignee_any', () => {
+    expect(
+      matchesRule('linear', 'issue', linearIssue, {
+        event: 'issue',
+        assignee_any: ['clerk'],
+      }),
+    ).toBe(true)
+    expect(
+      matchesRule('linear', 'issue', linearIssue, {
+        event: 'issue',
+        assignee_any: ['nobody'],
+      }),
+    ).toBe(false)
+  })
+
+  it('matches linear labels_any', () => {
+    expect(
+      matchesRule('linear', 'issue', linearIssue, {
+        event: 'issue',
+        labels_any: ['agent-task'],
+      }),
+    ).toBe(true)
+  })
+
+  it('matches linear comment mentions_any case-insensitively', () => {
+    expect(
+      matchesRule('linear', 'comment', linearComment, {
+        event: 'comment',
+        mentions_any: ['@CLERK'],
+      }),
+    ).toBe(true)
+    expect(
+      matchesRule('linear', 'comment', linearComment, {
+        event: 'comment',
+        mentions_any: ['@bob'],
+      }),
+    ).toBe(false)
+  })
+
+  it('matches generic action + labels', () => {
+    expect(
+      matchesRule('generic', 'ci', genericEvent, {
+        event: 'ci',
+        actions: ['fired'],
+        labels_all: ['prod', 'deploy'],
+      }),
+    ).toBe(true)
   })
 })

--- a/src/web/webhook-dispatch.ts
+++ b/src/web/webhook-dispatch.ts
@@ -23,6 +23,15 @@
  *     policy (off the subscription) and would spawn a parasitic second
  *     telegram bridge (#1617). See `docs/rfcs/eliminate-claude-p.md`.
  *
+ * Sources (#2272): dispatch is no longer github-only. Rules live under
+ * a per-source key — `github`, `generic`, or `linear`. Each source
+ * gets its own context builder (`buildGithubContext` /
+ * `buildLinearContext` / `buildGenericContext`) so the same static
+ * matcher (event/action/label/author/assignee/mention) and the same
+ * knobs (cooldown, quiet_hours; rate limit + dedup live in the ingest
+ * handler) apply uniformly. The security model is unchanged: rendered
+ * payloads are data, never instructions.
+ *
  * Configuration (in switchroom.yaml under agents.<name>.channels.telegram):
  *
  * ```yaml
@@ -39,6 +48,16 @@
  *         {{html_url}}
  *       cooldown: 5m
  *       quiet_hours: { start: 22, end: 8, tz: Australia/Melbourne }
+ *   linear:
+ *     - description: "Act on issues assigned to me"
+ *       match:
+ *         event: issue
+ *         actions: [create, update]
+ *         assignee_any: [clerk]
+ *       prompt: |
+ *         Linear {{number}} assigned to you: {{title}}
+ *         {{html_url}}
+ *       cooldown: 2m
  * ```
  */
 
@@ -61,6 +80,13 @@ export interface DispatchMatcher {
   labels_all?: string[]
   /** If the author login matches any of these, skip dispatch. */
   exclude_authors?: string[]
+  /** (linear/generic) Match only when the event's assignee is one of
+   *  these names. If absent, assignee is not constrained. */
+  assignee_any?: string[]
+  /** (linear/generic) Match only when the event text mentions one of
+   *  these handles (substring, case-insensitive). Useful for
+   *  "@mention the agent" routing. */
+  mentions_any?: string[]
 }
 
 export interface QuietHours {
@@ -84,7 +110,13 @@ export interface DispatchRule {
 
 export interface WebhookDispatchConfig {
   github?: DispatchRule[]
+  generic?: DispatchRule[]
+  linear?: DispatchRule[]
 }
+
+/** Webhook sources that support dispatch rule evaluation (#2272). */
+export const DISPATCH_SOURCES = ['github', 'generic', 'linear'] as const
+export type DispatchSource = (typeof DISPATCH_SOURCES)[number]
 
 /** Flat helper bag for template interpolation. */
 export interface TemplateContext {
@@ -96,6 +128,11 @@ export interface TemplateContext {
   labels: string
   action: string
   event: string
+  /** (linear/generic) Assignee display name, when the event carries one. */
+  assignee: string
+  /** (linear/generic) Free text searched by `mentions_any` — for linear
+   *  this is the issue title + comment body. */
+  body: string
   [key: string]: string
 }
 
@@ -138,20 +175,161 @@ export function buildGithubContext(
   const rawLabels = (obj?.labels as Array<Record<string, unknown>> | undefined) ?? []
   const labels = rawLabels.map((l) => String(l.name ?? '')).join(', ')
   const action = String(payload.action ?? '')
+  const assignee = String(
+    (obj?.assignee as Record<string, unknown> | undefined)?.login ?? '',
+  )
 
-  return { repo, number, title, html_url, author, labels, action, event: eventType }
+  return {
+    repo,
+    number,
+    title,
+    html_url,
+    author,
+    labels,
+    action,
+    event: eventType,
+    assignee,
+    body: title,
+  }
+}
+
+/**
+ * Build the flat TemplateContext from a Linear webhook envelope (#2272).
+ * `eventType` is the lower-cased Linear `type` ("issue", "comment").
+ *
+ * Linear envelope shape: `{ action, type, url, data: {...} }`.
+ *   - issue:   data.{identifier,title,assignee,labels}
+ *   - comment: data.{body, issue:{identifier,title}}
+ */
+export function buildLinearContext(
+  eventType: string,
+  payload: Record<string, unknown>,
+): TemplateContext {
+  const data = (payload.data as Record<string, unknown> | undefined) ?? {}
+  const issue = (data.issue as Record<string, unknown> | undefined) ?? {}
+
+  const number = String(data.identifier ?? issue.identifier ?? '')
+  const title = String(data.title ?? issue.title ?? '')
+  const html_url = String(payload.url ?? '')
+  const action = String(payload.action ?? '')
+  const assignee = String(
+    (data.assignee as Record<string, unknown> | undefined)?.displayName ??
+      (data.assignee as Record<string, unknown> | undefined)?.name ??
+      '',
+  )
+  const author = String(
+    (data.user as Record<string, unknown> | undefined)?.displayName ??
+      (data.user as Record<string, unknown> | undefined)?.name ??
+      '',
+  )
+  const rawLabels = (data.labels as Array<Record<string, unknown>> | undefined) ?? []
+  const labels = rawLabels.map((l) => String(l.name ?? '')).join(', ')
+  const commentBody = String(data.body ?? '')
+  const body = [title, commentBody].filter(Boolean).join('\n')
+
+  return {
+    repo: 'linear',
+    number,
+    title,
+    html_url,
+    author,
+    labels,
+    action,
+    event: eventType,
+    assignee,
+    body,
+  }
+}
+
+/**
+ * Build the flat TemplateContext for a generic webhook (#2272). The
+ * shape is operator-defined; we probe common fields and treat the
+ * source name as `repo` so `{{repo}}` is meaningful in templates.
+ * `event` is the source name (generic events have no event header).
+ */
+export function buildGenericContext(
+  source: string,
+  payload: Record<string, unknown>,
+): TemplateContext {
+  const title =
+    typeof payload.title === 'string'
+      ? payload.title
+      : typeof payload.message === 'string'
+        ? payload.message
+        : typeof payload.text === 'string'
+          ? payload.text
+          : ''
+  const action = String(payload.action ?? '')
+  const html_url = typeof payload.url === 'string' ? payload.url : ''
+  const number = String(payload.id ?? payload.number ?? '')
+  const author = String(payload.author ?? payload.user ?? '')
+  const assignee = String(payload.assignee ?? '')
+  const rawLabels = Array.isArray(payload.labels)
+    ? (payload.labels as unknown[]).map((l) =>
+        typeof l === 'string' ? l : String((l as Record<string, unknown>)?.name ?? ''),
+      )
+    : []
+  const labels = rawLabels.join(', ')
+
+  return {
+    repo: source,
+    number,
+    title,
+    html_url,
+    author,
+    labels,
+    action,
+    event: source,
+    assignee,
+    body: title,
+  }
+}
+
+/**
+ * Dispatch to the right context builder by source (#2272).
+ */
+export function buildContext(
+  source: string,
+  eventType: string,
+  payload: Record<string, unknown>,
+): TemplateContext {
+  switch (source) {
+    case 'linear':
+      return buildLinearContext(eventType, payload)
+    case 'generic':
+      return buildGenericContext(eventType, payload)
+    default:
+      return buildGithubContext(eventType, payload)
+  }
 }
 
 // ─── Static matcher ───────────────────────────────────────────────────────────
 
+/** Split the comma-joined `labels` context field back into a Set. */
+function labelSetFromContext(ctx: TemplateContext): Set<string> {
+  return new Set(
+    ctx.labels
+      .split(',')
+      .map((l) => l.trim())
+      .filter(Boolean),
+  )
+}
+
 /**
  * Returns true iff the payload matches all constraints in the matcher.
  *
- * @param eventType  The X-GitHub-Event header value.
+ * Source-aware (#2272): label/author/assignee fields are read off the
+ * source-specific TemplateContext, so the same matcher works for
+ * github, linear, and generic events.
+ *
+ * @param source     The webhook source ("github" | "linear" | "generic").
+ * @param eventType  Source event name (github event header / linear
+ *                   type / generic source name).
  * @param payload    Parsed JSON body.
  * @param matcher    Rule matcher constraints.
  */
 export function matchesRule(
+  source: string,
   eventType: string,
   payload: Record<string, unknown>,
   matcher: DispatchMatcher,
@@ -159,8 +337,7 @@ export function matchesRule(
   // Event name must match.
   if (matcher.event !== eventType) return false
 
-  // Build context for label/author access.
-  const ctx = buildGithubContext(eventType, payload)
+  const ctx = buildContext(source, eventType, payload)
 
   // action filter — if specified, the payload's action must be in the list.
   if (matcher.actions && matcher.actions.length > 0) {
@@ -172,26 +349,28 @@ export function matchesRule(
     if (matcher.exclude_authors.includes(ctx.author)) return false
   }
 
+  // assignee_any — at least one assignee in the list must match (linear/generic).
+  if (matcher.assignee_any && matcher.assignee_any.length > 0) {
+    if (!matcher.assignee_any.includes(ctx.assignee)) return false
+  }
+
+  // mentions_any — the event text must mention one of these (case-insensitive substring).
+  if (matcher.mentions_any && matcher.mentions_any.length > 0) {
+    const hay = ctx.body.toLowerCase()
+    const hasMention = matcher.mentions_any.some((m) => hay.includes(m.toLowerCase()))
+    if (!hasMention) return false
+  }
+
   // labels_any — at least one label in the list must be present.
   if (matcher.labels_any && matcher.labels_any.length > 0) {
-    const pr = payload.pull_request as Record<string, unknown> | undefined
-    const issue = payload.issue as Record<string, unknown> | undefined
-    const rawLabels =
-      ((pr ?? issue)?.labels as Array<Record<string, unknown>> | undefined) ?? []
-    const labelNames = new Set(rawLabels.map((l) => String(l.name ?? '')))
-    const hasAny = matcher.labels_any.some((l) => labelNames.has(l))
-    if (!hasAny) return false
+    const labelNames = labelSetFromContext(ctx)
+    if (!matcher.labels_any.some((l) => labelNames.has(l))) return false
   }
 
   // labels_all — every label in the list must be present.
   if (matcher.labels_all && matcher.labels_all.length > 0) {
-    const pr = payload.pull_request as Record<string, unknown> | undefined
-    const issue = payload.issue as Record<string, unknown> | undefined
-    const rawLabels =
-      ((pr ?? issue)?.labels as Array<Record<string, unknown>> | undefined) ?? []
-    const labelNames = new Set(rawLabels.map((l) => String(l.name ?? '')))
-    const hasAll = matcher.labels_all.every((l) => labelNames.has(l))
-    if (!hasAll) return false
+    const labelNames = labelSetFromContext(ctx)
+    if (!matcher.labels_all.every((l) => labelNames.has(l))) return false
   }
 
   return true
@@ -217,8 +396,14 @@ interface CooldownFileShape {
   dispatches: Record<string, number>
 }
 
-function cooldownKey(eventType: string, repo: string, number: string, ruleIndex: number): string {
-  return `${eventType}:${repo}:${number}:${ruleIndex}`
+function cooldownKey(
+  source: string,
+  eventType: string,
+  repo: string,
+  number: string,
+  ruleIndex: number,
+): string {
+  return `${source}:${eventType}:${repo}:${number}:${ruleIndex}`
 }
 
 function loadCooldownFile(path: string): Record<string, number> {
@@ -475,19 +660,21 @@ export function evaluateDispatch(
   const cooldownStore =
     deps.cooldownStore ?? createFileCooldownStore(resolveAgentDir)
 
-  // Only github source is supported for dispatch in this iteration.
-  if (args.source !== 'github') return 0
+  // Dispatch supports github, generic, and linear sources (#2272).
+  // Rules are keyed by source under dispatchConfig; an unknown source
+  // (or one with no rules configured) is a no-op.
+  if (!(DISPATCH_SOURCES as readonly string[]).includes(args.source)) return 0
 
-  const rules = args.dispatchConfig.github
+  const rules = args.dispatchConfig[args.source as DispatchSource]
   if (!rules || rules.length === 0) return 0
 
-  const ctx = buildGithubContext(args.eventType, args.payload)
+  const ctx = buildContext(args.source, args.eventType, args.payload)
   let fired = 0
 
   for (let i = 0; i < rules.length; i++) {
     const rule = rules[i]
 
-    if (!matchesRule(args.eventType, args.payload, rule.match)) continue
+    if (!matchesRule(args.source, args.eventType, args.payload, rule.match)) continue
 
     // Quiet hours check
     if (rule.quiet_hours && isQuietHour(rule.quiet_hours, nowDate())) {
@@ -500,7 +687,7 @@ export function evaluateDispatch(
     // Cooldown check
     const cooldownMs = rule.cooldown ? parseDurationMs(rule.cooldown) : 0
     if (cooldownMs > 0) {
-      const ck = cooldownKey(args.eventType, ctx.repo, ctx.number, i)
+      const ck = cooldownKey(args.source, args.eventType, ctx.repo, ctx.number, i)
       if (cooldownStore.isCoolingDown(args.agent, ck, cooldownMs, now)) {
         log(
           `webhook-dispatch: agent='${args.agent}' rule=${i} skipped (cooldown)\n`,

--- a/src/web/webhook-gateway-record.test.ts
+++ b/src/web/webhook-gateway-record.test.ts
@@ -166,6 +166,62 @@ describe('recordWebhookEvent', () => {
     expect(injected[0].inbound.text).toBe('Review foo/bar #1')
   })
 
+  it('fires a linear-source dispatch rule (#2272)', () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const injected: Array<{ agent: string; inbound: InboundMessageWire }> = []
+    const linearConfig: RecordDeps['loadConfig'] = () =>
+      ({
+        telegram: { forum_chat_id: '-100123' },
+        agents: {
+          reggie: {
+            topic_id: 42,
+            channels: {
+              telegram: {
+                webhook_dispatch: {
+                  linear: [
+                    {
+                      match: { event: 'issue', assignee_any: ['clerk'] },
+                      prompt: 'Linear {{number}} for you',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      }) as unknown as ReturnType<NonNullable<RecordDeps['loadConfig']>>
+
+    const deps: RecordDeps = {
+      resolveAgentDir,
+      dedupStore: makeDedupStore(),
+      log: () => {},
+      loadConfig: linearConfig,
+      inject: (agent, inbound) => {
+        injected.push({ agent, inbound })
+        return true
+      },
+    }
+
+    const rec = baseRecord({
+      source: 'linear',
+      event_type: 'issue',
+      rendered_text: 'Linear ENG-9 updated',
+      delivery_id: undefined,
+      payload: {
+        action: 'update',
+        type: 'Issue',
+        url: 'https://linear.app/x/ENG-9',
+        data: { identifier: 'ENG-9', title: 'Do the thing', assignee: { displayName: 'clerk' } },
+      },
+    })
+
+    const result = recordWebhookEvent(rec, deps)
+    expect(result.status).toBe('ok')
+    expect(result.dispatched).toBe(1)
+    expect(injected).toHaveLength(1)
+    expect(injected[0].inbound.text).toBe('Linear ENG-9 for you')
+  })
+
   it('does not dispatch when there is no chat target configured', () => {
     const { resolveAgentDir } = makeTmpResolveAgentDir()
     const injected: unknown[] = []

--- a/src/web/webhook-gateway-record.ts
+++ b/src/web/webhook-gateway-record.ts
@@ -30,6 +30,7 @@ import {
 } from './webhook-handler.js'
 import {
   evaluateDispatch,
+  DISPATCH_SOURCES,
   type CooldownStore,
   type WebhookDispatchConfig,
 } from './webhook-dispatch.js'
@@ -150,11 +151,12 @@ export function recordWebhookEvent(
     `webhook-gateway: agent='${agent}' source='${rec.source}' event='${rec.event_type}' recorded ts=${now}\n`,
   )
 
-  // ── Fire webhook_dispatch rules (github only) ─────────────────────────────
+  // ── Fire webhook_dispatch rules (github / generic / linear) ───────────────
   // This wires the previously-unreachable evaluateDispatch: the legacy
   // receiver passed dispatchConfig through but never consumed it (#1625
   // shipped the evaluator with no production caller). The gateway holds
   // the bridge IPC server, so delivery is in-process via deps.inject.
+  // #2272 extends dispatch beyond github to generic + linear sources.
   let dispatched = 0
   try {
     const config = (deps.loadConfig ?? loadSwitchroomConfig)()
@@ -164,7 +166,7 @@ export function recordWebhookEvent(
           ?.webhook_dispatch
       : undefined
 
-    if (dispatchConfig && rec.source === 'github') {
+    if (dispatchConfig && (DISPATCH_SOURCES as readonly string[]).includes(rec.source)) {
       const target = resolveChannelTarget(config, agent)
       if (!target) {
         log(

--- a/src/web/webhook-handler.test.ts
+++ b/src/web/webhook-handler.test.ts
@@ -672,3 +672,67 @@ describe('handleWebhookIngest — Cloudflare edge lock (requireEdge)', () => {
     expect(result.status).toBe(401)
   })
 })
+
+// ─── Linear source ingest (#2272) ─────────────────────────────────────────────
+
+function makeLinearSig(body: Uint8Array, secret: string = SECRET): string {
+  // Bare hex digest — no sha256= prefix.
+  return createHmac('sha256', secret).update(body).digest('hex')
+}
+
+function linearArgs(body: Uint8Array, headers: Headers): WebhookHandlerArgs {
+  return {
+    agent: 'myagent',
+    source: 'linear',
+    body,
+    headers,
+    allowedSources: ['linear'],
+    config: { secrets: { linear: SECRET } },
+    agentExists: true,
+  }
+}
+
+describe('linear source ingest', () => {
+  const payload = { action: 'update', type: 'Issue', url: 'https://linear.app/x/ENG-1', data: { identifier: 'ENG-1', title: 'hi' } }
+
+  it('accepts a valid Linear-Signature and records the event', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody(payload)
+    const headers = new Headers()
+    headers.set('linear-signature', makeLinearSig(body))
+    const result = await handleWebhookIngest(
+      linearArgs(body, headers),
+      baseDeps(resolveAgentDir, 1000),
+    )
+    expect(result.status).toBe(202)
+    const logged = JSON.parse(
+      readFileSync(join(resolveAgentDir('myagent'), 'telegram', 'webhook-events.jsonl'), 'utf-8').trim(),
+    ) as Record<string, unknown>
+    expect(logged.source).toBe('linear')
+    // event_type is the lower-cased linear `type`
+    expect(logged.event_type).toBe('issue')
+    expect(String(logged.rendered_text)).toContain('ENG-1')
+  })
+
+  it('rejects an invalid Linear-Signature with 401', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody(payload)
+    const headers = new Headers()
+    headers.set('linear-signature', makeLinearSig(body, 'wrong-secret'))
+    const result = await handleWebhookIngest(
+      linearArgs(body, headers),
+      baseDeps(resolveAgentDir, 1000),
+    )
+    expect(result.status).toBe(401)
+  })
+
+  it('rejects a missing Linear-Signature with 401', async () => {
+    const { resolveAgentDir } = makeTmpResolveAgentDir()
+    const body = makeBody(payload)
+    const result = await handleWebhookIngest(
+      linearArgs(body, new Headers()),
+      baseDeps(resolveAgentDir, 1000),
+    )
+    expect(result.status).toBe(401)
+  })
+})

--- a/src/web/webhook-handler.ts
+++ b/src/web/webhook-handler.ts
@@ -45,9 +45,11 @@ import { join } from 'path'
 import { homedir } from 'os'
 import {
   verifyGithubSignature,
+  verifyLinearSignature,
   verifyBearerToken,
   renderGithubEvent,
   renderGenericEvent,
+  renderLinearEvent,
   type WebhookSource,
 } from './webhook-verify.js'
 import type { WebhookDispatchConfig } from './webhook-dispatch.js'
@@ -138,7 +140,7 @@ export interface WebhookHandlerResult {
   headers?: Record<string, string>
 }
 
-const KNOWN_SOURCES: WebhookSource[] = ['github', 'generic']
+const KNOWN_SOURCES: WebhookSource[] = ['github', 'generic', 'linear']
 
 function jsonReply(
   status: number,
@@ -387,6 +389,11 @@ export async function handleWebhookIngest(
   if (source === 'github') {
     const sigHeader = args.headers.get('x-hub-signature-256')
     verifyResult = verifyGithubSignature(args.body, sigHeader, secret)
+  } else if (source === 'linear') {
+    // Linear sends a bare hex HMAC-SHA256 of the raw body in the
+    // `Linear-Signature` header — no Bearer auth (#2272).
+    const sigHeader = args.headers.get('linear-signature')
+    verifyResult = verifyLinearSignature(args.body, sigHeader, secret)
   } else {
     const authHeader = args.headers.get('authorization')
     verifyResult = verifyBearerToken(authHeader, secret)
@@ -450,12 +457,20 @@ export async function handleWebhookIngest(
 
   // Render to a Telegram-ready string. Stored on the event record so
   // the follow-up "post to Telegram" PR doesn't have to re-render.
-  const eventType = source === 'github'
-    ? (args.headers.get('x-github-event') ?? 'unknown')
-    : args.source
-  const rendered = source === 'github'
-    ? renderGithubEvent(eventType, payload)
-    : renderGenericEvent(args.source, payload)
+  // Event type per source: github from header, linear from the body's
+  // `type` field (lower-cased), generic = the source name.
+  const eventType =
+    source === 'github'
+      ? (args.headers.get('x-github-event') ?? 'unknown')
+      : source === 'linear'
+        ? String(payload.type ?? 'unknown').toLowerCase()
+        : args.source
+  const rendered =
+    source === 'github'
+      ? renderGithubEvent(eventType, payload)
+      : source === 'linear'
+        ? renderLinearEvent(eventType, payload)
+        : renderGenericEvent(args.source, payload)
 
   // ── viaGateway: forward to the in-container gateway (agent UID) ───────────
   // The gateway owns dedup + the jsonl append + dispatch; the receiver is

--- a/src/web/webhook-verify.ts
+++ b/src/web/webhook-verify.ts
@@ -20,6 +20,10 @@
  *     Simple shared-secret model for in-house tools that can't do
  *     HMAC. The token is per-source-per-agent, declared in the
  *     vault under `webhook/<agent>/<source>`.
+ *   - **linear** (#2272): hex HMAC-SHA256 over the raw request body,
+ *     signature in the `Linear-Signature` header. Linear sends a bare
+ *     hex digest (NO `sha256=` prefix) and no Bearer auth. Same
+ *     per-source secret model as github/generic.
  *
  * Both verifiers are CONSTANT-TIME compares to defeat timing attacks.
  * The Node `crypto.timingSafeEqual` requires equal-length buffers;
@@ -74,6 +78,42 @@ export function verifyGithubSignature(
 }
 
 /**
+ * Verify a Linear-style HMAC-SHA256 webhook signature (#2272).
+ *
+ * Header format: a bare 64-char lowercase hex digest in the
+ * `Linear-Signature` header — NO `sha256=` prefix (unlike GitHub).
+ * The signed content is the raw request body bytes; the caller must
+ * pass the body unmodified (no JSON.parse → re-stringify).
+ *
+ * Same reason-leak posture as the other verifiers: every failure mode
+ * returns `{ ok: false }` and the route handler returns a plain 401.
+ */
+export function verifyLinearSignature(
+  body: Uint8Array,
+  signatureHeader: string | null | undefined,
+  secret: string,
+): WebhookVerifyResult {
+  if (!secret || secret.length === 0) {
+    return { ok: false, reason: 'no-secret-configured' }
+  }
+  if (!signatureHeader) {
+    return { ok: false, reason: 'no-signature-header' }
+  }
+  const provided = signatureHeader.trim()
+  if (!/^[0-9a-f]{64}$/.test(provided)) {
+    return { ok: false, reason: 'malformed-hex' }
+  }
+  const expected = createHmac('sha256', secret).update(body).digest('hex')
+  // Constant-time compare. Both are 64-char hex (validated above) so
+  // they're always the same length here.
+  const a = Buffer.from(provided, 'utf-8')
+  const b = Buffer.from(expected, 'utf-8')
+  if (a.length !== b.length) return { ok: false, reason: 'length-mismatch' }
+  if (!timingSafeEqual(a, b)) return { ok: false, reason: 'signature-mismatch' }
+  return { ok: true }
+}
+
+/**
  * Verify a Bearer token from the Authorization header.
  *
  * Header format: `Authorization: Bearer <token>`. Constant-time
@@ -109,7 +149,7 @@ export function verifyBearerToken(
  * purpose-built rather than generic — generic catch-alls invite
  * abuse-by-misuse.
  */
-export type WebhookSource = 'github' | 'generic'
+export type WebhookSource = 'github' | 'generic' | 'linear'
 
 export interface RenderedWebhookMessage {
   text: string
@@ -166,6 +206,76 @@ export function renderGithubEvent(
     default:
       return {
         text: `🐙 <b>${escapeHtml(repo)}</b> ${escapeHtml(eventType)} by @${escapeHtml(sender)}`,
+        disableLinkPreview: true,
+      }
+  }
+}
+
+/**
+ * Render a verified Linear webhook payload into a single-line Telegram
+ * message (#2272). Linear's webhook envelope shape:
+ *
+ * ```json
+ * {
+ *   "action": "create",            // create | update | remove
+ *   "type": "Issue",               // Issue | Comment | ...
+ *   "url": "https://linear.app/...",
+ *   "data": {
+ *     "identifier": "ENG-42",
+ *     "title": "Fix the thing",
+ *     "assignee": { "name": "agent", "displayName": "agent" },
+ *     "labels": [{ "name": "bug" }],
+ *     "body": "...",               // comment text on Comment events
+ *     "issue": { "identifier": "ENG-42", "title": "Fix the thing" }
+ *   }
+ * }
+ * ```
+ *
+ * Every interpolated field is HTML-escaped: the payload is attacker-
+ * influenced data, never instructions (same posture as renderGithubEvent).
+ * Pure — no fetch, no DB. Caller passes the parsed JSON envelope.
+ */
+export function renderLinearEvent(
+  eventType: string,
+  payload: Record<string, unknown>,
+): RenderedWebhookMessage {
+  const action = String(payload.action ?? '')
+  const url = typeof payload.url === 'string' ? payload.url : ''
+  const data = (payload.data as Record<string, unknown> | undefined) ?? {}
+
+  // `eventType` is the Linear `type` field, lower-cased by the handler.
+  switch (eventType) {
+    case 'issue': {
+      const id = String(data.identifier ?? '?')
+      const title = String(data.title ?? '')
+      const assignee =
+        (data.assignee as { displayName?: string; name?: string } | undefined)?.displayName ??
+        (data.assignee as { name?: string } | undefined)?.name ??
+        ''
+      return {
+        text:
+          `📐 <b>Linear</b> issue ${escapeHtml(id)} ${escapeHtml(action)}` +
+          `${assignee ? ` → @${escapeHtml(assignee)}` : ''}\n` +
+          `${escapeHtml(title)}${url ? `\n${url}` : ''}`,
+        disableLinkPreview: true,
+      }
+    }
+    case 'comment': {
+      const issue = (data.issue as { identifier?: string; title?: string } | undefined) ?? {}
+      const id = String(issue.identifier ?? '?')
+      const body = String(data.body ?? '').slice(0, 200)
+      return {
+        text:
+          `📐 <b>Linear</b> comment ${escapeHtml(action)} on ${escapeHtml(id)}\n` +
+          `${escapeHtml(body)}${url ? `\n${url}` : ''}`,
+        disableLinkPreview: true,
+      }
+    }
+    default:
+      return {
+        text:
+          `📐 <b>Linear</b> ${escapeHtml(eventType)} ${escapeHtml(action)}` +
+          `${url ? `\n${url}` : ''}`,
         disableLinkPreview: true,
       }
   }

--- a/tests/fixtures/generic-event.json
+++ b/tests/fixtures/generic-event.json
@@ -1,0 +1,8 @@
+{
+  "action": "fired",
+  "id": "evt-99",
+  "title": "Deploy finished",
+  "url": "https://ci.example.com/runs/99",
+  "assignee": "ops-bot",
+  "labels": ["prod", "deploy"]
+}

--- a/tests/fixtures/linear-comment-mention.json
+++ b/tests/fixtures/linear-comment-mention.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "type": "Comment",
+  "url": "https://linear.app/acme/issue/ENG-42#comment-abc",
+  "data": {
+    "body": "Can @clerk take a look at this regression?",
+    "user": { "name": "alice", "displayName": "Alice" },
+    "issue": {
+      "identifier": "ENG-42",
+      "title": "Investigate flaky webhook test"
+    }
+  }
+}

--- a/tests/fixtures/linear-issue-assigned.json
+++ b/tests/fixtures/linear-issue-assigned.json
@@ -1,0 +1,14 @@
+{
+  "action": "update",
+  "type": "Issue",
+  "url": "https://linear.app/acme/issue/ENG-42",
+  "data": {
+    "identifier": "ENG-42",
+    "title": "Investigate flaky webhook test",
+    "assignee": { "name": "clerk", "displayName": "clerk" },
+    "labels": [
+      { "name": "bug" },
+      { "name": "agent-task" }
+    ]
+  }
+}

--- a/tests/webhook-verify.test.ts
+++ b/tests/webhook-verify.test.ts
@@ -16,9 +16,11 @@ import { describe, it, expect } from 'vitest'
 import { createHmac } from 'crypto'
 import {
   verifyGithubSignature,
+  verifyLinearSignature,
   verifyBearerToken,
   renderGithubEvent,
   renderGenericEvent,
+  renderLinearEvent,
 } from '../src/web/webhook-verify.js'
 
 const SECRET = 'this-is-a-shared-secret'
@@ -206,5 +208,102 @@ describe('renderGenericEvent', () => {
     expect(r.text).not.toContain('<bad>')
     expect(r.text).toContain('&lt;bad&gt;')
     expect(r.text).toContain('&lt;bold&gt;')
+  })
+})
+
+// ─── verifyLinearSignature (#2272) ────────────────────────────────────────────
+
+function linearSig(body: Uint8Array, secret: string): string {
+  // Linear sends a BARE hex digest — no `sha256=` prefix.
+  return createHmac('sha256', secret).update(body).digest('hex')
+}
+
+describe('verifyLinearSignature', () => {
+  const body = new TextEncoder().encode('{"action":"create","type":"Issue"}')
+
+  it('accepts a valid bare-hex signature', () => {
+    const r = verifyLinearSignature(body, linearSig(body, SECRET), SECRET)
+    expect(r.ok).toBe(true)
+  })
+
+  it('rejects missing signature header', () => {
+    const r = verifyLinearSignature(body, undefined, SECRET)
+    expect(r).toMatchObject({ ok: false, reason: 'no-signature-header' })
+  })
+
+  it('rejects a github-style sha256= prefixed value (wrong format)', () => {
+    const r = verifyLinearSignature(body, 'sha256=' + linearSig(body, SECRET), SECRET)
+    expect(r).toMatchObject({ ok: false, reason: 'malformed-hex' })
+  })
+
+  it('rejects malformed hex', () => {
+    const r = verifyLinearSignature(body, 'zz'.repeat(32), SECRET)
+    expect(r).toMatchObject({ ok: false, reason: 'malformed-hex' })
+  })
+
+  it('rejects a signature signed with a different secret', () => {
+    const r = verifyLinearSignature(body, linearSig(body, 'wrong-secret'), SECRET)
+    expect(r).toMatchObject({ ok: false, reason: 'signature-mismatch' })
+  })
+
+  it('rejects a tampered body', () => {
+    const tampered = new TextEncoder().encode('{"action":"remove"}')
+    const r = verifyLinearSignature(tampered, linearSig(body, SECRET), SECRET)
+    expect(r).toMatchObject({ ok: false, reason: 'signature-mismatch' })
+  })
+
+  it('rejects when no secret is configured', () => {
+    const r = verifyLinearSignature(body, linearSig(body, SECRET), '')
+    expect(r).toMatchObject({ ok: false, reason: 'no-secret-configured' })
+  })
+
+  it('tolerates surrounding whitespace in the header', () => {
+    const r = verifyLinearSignature(body, '  ' + linearSig(body, SECRET) + '\n', SECRET)
+    expect(r.ok).toBe(true)
+  })
+})
+
+// ─── renderLinearEvent (#2272) ────────────────────────────────────────────────
+
+describe('renderLinearEvent', () => {
+  it('renders an issue event with identifier, action, assignee, title', () => {
+    const r = renderLinearEvent('issue', {
+      action: 'update',
+      url: 'https://linear.app/acme/issue/ENG-7',
+      data: {
+        identifier: 'ENG-7',
+        title: 'Fix the thing',
+        assignee: { displayName: 'clerk' },
+      },
+    })
+    expect(r.text).toContain('ENG-7')
+    expect(r.text).toContain('update')
+    expect(r.text).toContain('@clerk')
+    expect(r.text).toContain('Fix the thing')
+    expect(r.disableLinkPreview).toBe(true)
+  })
+
+  it('renders a comment event with the parent issue id and body', () => {
+    const r = renderLinearEvent('comment', {
+      action: 'create',
+      data: { body: 'looks good', issue: { identifier: 'ENG-7' } },
+    })
+    expect(r.text).toContain('ENG-7')
+    expect(r.text).toContain('looks good')
+  })
+
+  it('HTML-escapes attacker-controlled fields (data not instructions)', () => {
+    const r = renderLinearEvent('issue', {
+      action: 'create',
+      data: { identifier: 'ENG-9', title: '<script>alert(1)</script>' },
+    })
+    expect(r.text).not.toContain('<script>')
+    expect(r.text).toContain('&lt;script&gt;')
+  })
+
+  it('falls back for unknown linear types', () => {
+    const r = renderLinearEvent('project', { action: 'update', data: {} })
+    expect(r.text).toContain('project')
+    expect(r.text).toContain('update')
   })
 })


### PR DESCRIPTION
## What

Extends webhook dispatch beyond GitHub (epic #717). Today `evaluateDispatch` hard-returns 0 unless `source === "github"` and only reads `dispatchConfig.github`, so any non-GitHub webhook is poll-only. This makes dispatch work for any known source and adds **Linear** as a first-class source.

## Changes

- **Source-generic dispatch.** `evaluateDispatch` + the `webhook_dispatch` schema now key rules by source (`github` / `generic` / `linear`). `matchesRule` and context building dispatch per-source. Cooldown keys are namespaced by source so rule indices can't collide across sources. Wired through the production caller (`webhook-gateway-record.ts`), which previously gated on `rec.source === 'github'`.
- **Linear source.**
  - `verifyLinearSignature` — bare hex HMAC-SHA256 of the raw body in the `Linear-Signature` header (Linear sends no Bearer auth). Per-source secret from `webhook-secrets.json` keyed `[agent][source]`, same as github/generic.
  - `renderLinearEvent` — issue/comment events, HTML-escaped data, strict template. Payloads are data, not instructions.
  - `buildLinearContext` + new `assignee_any` / `mentions_any` matchers (rule matching on event type, assignee, label, @mention).
  - `linear` added to `KNOWN_SOURCES` and the `webhook_sources` enum.
- **Knobs.** cooldown + quiet_hours apply uniformly to generic/linear; the ingest-path rate limit and github delivery-id dedup are unchanged and source-agnostic.
- **Docs.** `docs/webhook-ingest.md` — Linear setup, the auto-dispatch section, and a per-source matcher table.

## Security

Model unchanged: per-source secret, edge lock, rendered payloads HTML-escaped and treated as data not instructions.

## Tests

- Linear signature verify: valid / invalid / missing / tampered / sha256=-prefix-rejected / whitespace-tolerant.
- `renderLinearEvent`: issue, comment, HTML-escape, unknown-type fallback.
- Dispatch evaluation for generic and linear; assignee / label / mention matching; non-github cooldown; cross-source cooldown-key isolation.
- Gateway-record linear dispatch; linear handler ingest (202 + 401 paths).

`npm run build`, `npm run lint` (tsc + guards), and the full webhook + config test suites are green (294 tests in the touched files).

Closes #2272
Part of #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)