### PR TITLE
chore: release v0.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.15.6 — webhook dispatch for generic + Linear sources
+
+Extends agent-waking webhook dispatch beyond GitHub (epic #717).
+
+### Source-generic webhook dispatch + Linear (#2272, #2283)
+
+- `evaluateDispatch` and the `webhook_dispatch` schema now key rules by
+  **source** — `github` / `generic` / `linear` — so any known source can wake
+  the agent through the same `inject_inbound` path, not just github. Cooldown
+  keys are namespaced by source so rule indices can't collide across sources.
+- **Linear** is a first-class source:
+  - `verifyLinearSignature` — bare-hex HMAC-SHA256 of the raw body in the
+    `Linear-Signature` header (Linear sends no Bearer auth); per-source secret
+    from `webhook-secrets.json` keyed `[agent][source]`.
+  - `renderLinearEvent` — issue/comment events, HTML-escaped, strict template
+    (payloads are data, never instructions).
+  - `buildLinearContext` + new `assignee_any` / `mentions_any` rule matchers.
+- Dispatch knobs (cooldown, quiet_hours) and the ingest-path rate-limit + dedup
+  now apply uniformly across generic/linear. Security model unchanged:
+  per-source secret, edge lock, rendered payloads escaped and treated as data.
+- Docs: `docs/webhook-ingest.md` gains Linear setup + a per-source matcher table.
+
 ## v0.15.5 — ship every agent hook script into the image (turn-pacing 127 fix)
 
 A one-fix release closing the last loose end from the v0.15.4 batch.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release v0.15.6 = v0.15.5 + the webhook-dispatch generic/Linear feature (#2283, already merged to main).

## Why

Get the merged webhook dispatch fix (PR #2283 / #2272) onto a tagged release so the fleet can roll it cleanly under one atomic image tag (rather than a per-sha pin — the fragile pattern behind the recent fleet outage).

## What

- Version bump 0.15.5 → 0.15.6 + CHANGELOG.
- Underlying feature (#2283): source-generic `evaluateDispatch` (github/generic/linear) + Linear as a first-class webhook source (HMAC-SHA256 verify, escaped render, assignee/mention matchers). Security model unchanged.

## Test plan

- [x] `node scripts/build.mjs` exit 0, `dist/cli/switchroom.js` ~3.16MB
- [x] #2283 merged with green CI (294 tests in touched files)

## Risk

Low — version/changelog only here; the feature code already merged + passed CI. Touches the telegram-plugin gateway, so fleet roll uses staggered per-agent restart.