### PR TITLE
fix(hostd): resolve host home via SWITCHROOM_HOST_HOME in install (close #2279 gap)

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { renderHostdComposeFile } from "./hostd.js";
+import { renderHostdComposeFile, resolveHostdHostHome } from "./hostd.js";
 
 describe("renderHostdComposeFile", () => {
   it("renders a valid yaml-shaped string", () => {
@@ -129,5 +129,51 @@ describe("renderHostdComposeFile", () => {
   it("declares its own network so the hostd project doesn't accidentally join the agent fleet's net", () => {
     const out = renderHostdComposeFile({ hostHome: "/h", imageTag: "latest" });
     expect(out).toContain("name: switchroom-hostd-net");
+  });
+});
+
+describe("resolveHostdHostHome (in-container /host-home guard, #2279 gap)", () => {
+  it("prefers SWITCHROOM_HOST_HOME over homedir()", () => {
+    // In-container: homedir() is the poison /host-home, but the env carries
+    // the real host home (baked by a host-side install). Env wins.
+    expect(
+      resolveHostdHostHome({ SWITCHROOM_HOST_HOME: "/home/operator" }, "/host-home"),
+    ).toBe("/home/operator");
+  });
+
+  it("falls back to homedir() when SWITCHROOM_HOST_HOME is unset", () => {
+    expect(resolveHostdHostHome({}, "/home/alice")).toBe("/home/alice");
+  });
+
+  it("treats empty/whitespace SWITCHROOM_HOST_HOME as unset", () => {
+    expect(resolveHostdHostHome({ SWITCHROOM_HOST_HOME: "   " }, "/home/alice")).toBe(
+      "/home/alice",
+    );
+  });
+
+  it("THROWS when the resolved home is /host-home (the in-container poison)", () => {
+    // The exact fleet-killer: in-container install, no SWITCHROOM_HOST_HOME,
+    // homedir() === /host-home. Must fail loud, not emit a poisoned compose.
+    expect(() => resolveHostdHostHome({}, "/host-home")).toThrow(/refusing to generate/);
+    expect(() => resolveHostdHostHome({}, "/host-home")).toThrow(/run.*from the HOST/i);
+  });
+
+  it("THROWS when SWITCHROOM_HOST_HOME itself is /host-home (self-perpetuation guard)", () => {
+    // A previously-poisoned compose baked SWITCHROOM_HOST_HOME=/host-home;
+    // reading it back must not re-poison — the backstop catches it too.
+    expect(() =>
+      resolveHostdHostHome({ SWITCHROOM_HOST_HOME: "/host-home" }, "/home/alice"),
+    ).toThrow(/refusing to generate/);
+  });
+
+  it("THROWS for any path UNDER /host-home", () => {
+    expect(() => resolveHostdHostHome({}, "/host-home/nested")).toThrow(
+      /refusing to generate/,
+    );
+  });
+
+  it("accepts a real host home unchanged", () => {
+    expect(resolveHostdHostHome({}, "/home/operator")).toBe("/home/operator");
+    expect(resolveHostdHostHome({ SWITCHROOM_HOST_HOME: "/root" }, "/home/x")).toBe("/root");
   });
 });

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -160,6 +160,43 @@ networks:
 `;
 }
 
+/**
+ * Resolve the REAL host home for the hostd compose bind sources.
+ *
+ * Mirrors `write-compose.ts` (the agent-fleet generator, fixed in #2279):
+ * prefer `SWITCHROOM_HOST_HOME` over `homedir()`. `hostd install` regenerates
+ * its OWN compose; when the regen runs INSIDE the hostd container (the
+ * `/update apply` → refresh-hostd path), `homedir()` returns `/host-home` —
+ * the in-container mount point of the operator home that hostd pins `HOME` to,
+ * NOT a host filesystem path. Emitting it as a bind SOURCE makes Docker
+ * auto-create empty `/host-home/...` dirs on the host, so the config mount is
+ * empty → hostd crash-loops on `ConfigError`, and the poison value re-bakes
+ * into the new compose's `SWITCHROOM_HOST_HOME`, self-perpetuating.
+ *
+ * #2279 fixed this for the agent fleet but left `hostd install` on bare
+ * `homedir()`. This closes that gap. The backstop refuses to ever emit a
+ * `/host-home` source — fail loud with the recovery path instead of writing a
+ * compose that crash-loops the daemon.
+ */
+export function resolveHostdHostHome(
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+): string {
+  const fromEnv = env.SWITCHROOM_HOST_HOME?.trim();
+  const resolved = fromEnv && fromEnv.length > 0 ? fromEnv : home;
+  if (resolved === "/host-home" || resolved.startsWith("/host-home/")) {
+    throw new Error(
+      `switchroom hostd install: refusing to generate — the host home resolved to ` +
+        `"${resolved}", the in-container mount point of the operator home (never a valid ` +
+        `host bind source). Emitting it would make Docker create empty /host-home dirs on ` +
+        `the host and crash-loop hostd on a missing config mount.\n\n` +
+        `Recovery: run \`switchroom hostd install\` from the HOST shell (not inside the ` +
+        `hostd container), or set SWITCHROOM_HOST_HOME to the real host home first.`,
+    );
+  }
+  return resolved;
+}
+
 function hostdDir(): string {
   return join(homedir(), ".switchroom", "hostd");
 }
@@ -220,7 +257,7 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
   mkdirSync(dir, { recursive: true });
 
   const yaml = renderHostdComposeFile({
-    hostHome: homedir(),
+    hostHome: resolveHostdHostHome(),
     imageTag: opts.tag ?? DEFAULT_IMAGE_TAG,
     // SUDO_UID-aware (install often runs under sudo); undefined on
     // non-POSIX → operator listener simply not bound.


### PR DESCRIPTION
## Summary

`switchroom hostd install` regenerated its OWN compose bind sources via bare `homedir()`. In-container (the `/update apply` → refresh-hostd path) that's `/host-home`, which Docker auto-creates as empty host dirs → the config mount is empty → **hostd crash-loops on `ConfigError: Failed to read config file: /state/config/switchroom.yaml`**, and the poison re-bakes into the new compose's `SWITCHROOM_HOST_HOME`, self-perpetuating.

#2279 fixed exactly this class for the **agent-fleet** generator (`write-compose.ts`: prefer `SWITCHROOM_HOST_HOME` over `homedir()` + a `/host-home` backstop) but **left `hostd install` on bare `homedir()`**. This closes that gap.

## Why now

Hit live on 2026-06-12: hostd was down, all 12 agents cut off from host control. Live recovery was a hand-patched compose; this is the durable code fix so an in-container `hostd install` can never re-poison.

## What

- New `resolveHostdHostHome()` mirrors `write-compose.ts`: `process.env.SWITCHROOM_HOST_HOME || homedir()`.
- **Backstop**: refuse to emit when the resolved home is `/host-home` (or under it) — fail loud with the "run from the HOST" recovery path instead of writing a compose that crash-loops the daemon.
- **Self-perpetuation guard**: also rejects a `SWITCHROOM_HOST_HOME` that is itself `/host-home` (a previously-poisoned compose baked it in).
- Wired into `doInstall` in place of `hostHome: homedir()`.

## Test plan

- [x] 7 new cases: env-over-homedir precedence, empty/whitespace fallback, throw on `/host-home` (homedir), throw on `/host-home` (env, self-perpetuation), throw on nested, accept real homes.
- [x] 19 `hostd.test.ts` green; `tsc --noEmit` clean.

## Risk

Low. Pure resolution change at compose-generation time; host-side installs (the common path) keep using `homedir()` exactly as before. The only behavioural change is in-container without a valid `SWITCHROOM_HOST_HOME` now throws (loud) instead of silently writing a daemon-killing compose.