### PR TITLE
chore: release v0.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.15.7 — hostd install resolves the real host home (close #2279 gap)
+
+A fleet-killer hardening release.
+
+### `hostd install` is container-context-safe (#2285)
+
+- `switchroom hostd install` regenerated its OWN compose bind-mount **sources**
+  via bare `homedir()`. When that regen runs inside the hostd container (the
+  `/update apply` → refresh-hostd path), `homedir()` returns `/host-home` — the
+  in-container mount point of the operator home, not a host path. Docker then
+  auto-created empty `/host-home/...` dirs on the host, the config mount was
+  empty, and **hostd crash-looped on `ConfigError: Failed to read config file:
+  /state/config/switchroom.yaml`** (observed live 2026-06-12, all agents cut off
+  from host control). The poison also re-baked into the new compose's
+  `SWITCHROOM_HOST_HOME`, self-perpetuating.
+- #2279 fixed this exact class for the agent-fleet generator but left
+  `hostd install` on bare `homedir()`. New `resolveHostdHostHome()` mirrors the
+  canonical resolver (`SWITCHROOM_HOST_HOME || homedir()`) and **refuses to emit
+  when the resolved home is `/host-home` or under it** — failing loud with the
+  "run from the HOST" recovery path instead of writing a daemon-killing compose.
+  The self-perpetuation guard also rejects a `SWITCHROOM_HOST_HOME` that is
+  itself `/host-home`.
+
 ## v0.15.6 — webhook dispatch for generic + Linear sources
 
 Extends agent-waking webhook dispatch beyond GitHub (epic #717).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release v0.15.7 = v0.15.6 + the hostd install host-home fix (#2285, already merged + fresh-reviewer APPROVE).

## Why

The running hostd image must carry #2285 to be durable — the fix lives in `hostd install`, which runs inside the hostd image. Until rolled, an in-container `/update apply` (refresh-hostd) could re-poison the hostd compose and crash-loop the daemon (the live 2026-06-12 outage).

## What

- Version bump 0.15.6 → 0.15.7 + CHANGELOG.
- Underlying fix (#2285): `resolveHostdHostHome()` = `SWITCHROOM_HOST_HOME || homedir()` with a fail-loud `/host-home` backstop, mirroring #2279's agent-fleet fix.

## Test plan

- [x] `node scripts/build.mjs` exit 0, `dist/cli/switchroom.js` ~3.16MB
- [x] #2285 merged green (19 hostd tests, tsc clean) + reviewer APPROVE

## Risk

Low — version/changelog only here; the fix code already merged + reviewed.