### PR TITLE
fix(hostd): default install image tag to release.pin, not hardcoded latest

### DIFF
--- a/src/cli/hostd.test.ts
+++ b/src/cli/hostd.test.ts
@@ -8,7 +8,11 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { renderHostdComposeFile, resolveHostdHostHome } from "./hostd.js";
+import {
+  renderHostdComposeFile,
+  resolveHostdHostHome,
+  resolveHostdImageTag,
+} from "./hostd.js";
 
 describe("renderHostdComposeFile", () => {
   it("renders a valid yaml-shaped string", () => {
@@ -175,5 +179,28 @@ describe("resolveHostdHostHome (in-container /host-home guard, #2279 gap)", () =
   it("accepts a real host home unchanged", () => {
     expect(resolveHostdHostHome({}, "/home/operator")).toBe("/home/operator");
     expect(resolveHostdHostHome({ SWITCHROOM_HOST_HOME: "/root" }, "/home/x")).toBe("/root");
+  });
+});
+
+describe("resolveHostdImageTag (honor release.pin like the agent fleet)", () => {
+  it("uses an explicit --tag override above everything", () => {
+    expect(resolveHostdImageTag("v9.9.9", { pin: "v0.15.7" })).toBe("v9.9.9");
+    expect(resolveHostdImageTag("v9.9.9", undefined)).toBe("v9.9.9");
+  });
+
+  it("defaults to release.pin when no --tag (the gap this closes)", () => {
+    // Previously hardcoded "latest" → hostd lagged the pinned fleet. Now it
+    // tracks the same pin the agents/brokers resolve.
+    expect(resolveHostdImageTag(undefined, { pin: "v0.15.7" })).toBe("v0.15.7");
+    expect(resolveHostdImageTag(undefined, { pin: "sha-abc1234" })).toBe("sha-abc1234");
+  });
+
+  it("falls back to a release channel when no pin", () => {
+    expect(resolveHostdImageTag(undefined, { channel: "rc" })).toBe("rc");
+  });
+
+  it("falls back to 'latest' when neither --tag nor release is set", () => {
+    expect(resolveHostdImageTag(undefined, undefined)).toBe("latest");
+    expect(resolveHostdImageTag(undefined, {})).toBe("latest");
   });
 });

--- a/src/cli/hostd.ts
+++ b/src/cli/hostd.ts
@@ -29,6 +29,7 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { getConfig, withConfigError } from "./helpers.js";
 import { resolveOperatorUid } from "./operator-uid.js";
+import { resolveImageTag, resolveRelease, type ReleaseBlockShape } from "../config/release-resolve.js";
 import {
   defaultAuditLogPath,
   formatForCli,
@@ -36,11 +37,29 @@ import {
 } from "../host-control/audit-reader.js";
 
 /**
- * Image tag the install verb pins. Defaults to `:latest`. Override
- * via `--tag <X>` when standing up a specific version (recommended
- * for production deploys; `:latest` is the dev/operator default).
+ * Resolve the hostd image tag for an install.
+ *
+ * Precedence (highest first), mirroring how the agent-fleet generator
+ * resolves its tag (`write-compose.ts` → `resolveImageTag(resolveRelease(...))`):
+ *   1. explicit `--tag <X>` (operator override)
+ *   2. `release.pin` / `release.channel` from switchroom.yaml
+ *   3. `latest` (resolveImageTag's back-compat default)
+ *
+ * Before this, `hostd install` hardcoded `latest` and ignored
+ * `release.pin` — so after a release the singleton lagged the fleet
+ * (the agents/brokers honor the pin, hostd didn't), and a plain
+ * `hostd install` right after a tag push could land the PRIOR image
+ * because `:latest` promotion lags the version-tag build. Honoring the
+ * pin makes hostd version-coherent with the rest of the fleet by
+ * default. See memory `feedback_singletons_dont_recreate_on_pin_bump`.
  */
-const DEFAULT_IMAGE_TAG = "latest";
+export function resolveHostdImageTag(
+  explicitTag: string | undefined,
+  release: ReleaseBlockShape | undefined,
+): string {
+  if (explicitTag) return explicitTag;
+  return resolveImageTag(resolveRelease({ root: release }));
+}
 
 /**
  * Compose project name for the daemon. MUST be distinct from
@@ -256,9 +275,13 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
   const composePath = hostdComposePath();
   mkdirSync(dir, { recursive: true });
 
+  // Default to the release pin from switchroom.yaml (version-coherent with
+  // the agent fleet); `--tag` overrides; `latest` if neither is set.
+  const imageTag = resolveHostdImageTag(opts.tag, cfg.release);
+
   const yaml = renderHostdComposeFile({
     hostHome: resolveHostdHostHome(),
-    imageTag: opts.tag ?? DEFAULT_IMAGE_TAG,
+    imageTag,
     // SUDO_UID-aware (install often runs under sudo); undefined on
     // non-POSIX → operator listener simply not bound.
     operatorUid: resolveOperatorUid(),
@@ -294,13 +317,13 @@ async function doInstall(opts: InstallOptions, program: Command): Promise<void> 
   // glitch, GHCR throttle) surfaces before the up step rather than
   // mid-restart-cycle. `docker compose pull` is idempotent and
   // skips images already at the requested digest.
-  console.log(chalk.dim(`    Pulling ghcr.io/switchroom/switchroom-hostd:${opts.tag ?? DEFAULT_IMAGE_TAG}…`));
+  console.log(chalk.dim(`    Pulling ghcr.io/switchroom/switchroom-hostd:${imageTag}…`));
   const pull = runDocker(["compose", "-p", HOSTD_COMPOSE_PROJECT, "-f", composePath, "pull"]);
   if (!pull.ok) {
     console.error(chalk.red(`  pull failed:\n${pull.stderr}`));
     console.error(
       chalk.yellow(
-        `  Hint: \`ghcr.io/switchroom/switchroom-hostd:${opts.tag ?? DEFAULT_IMAGE_TAG}\` may not be published yet.\n` +
+        `  Hint: \`ghcr.io/switchroom/switchroom-hostd:${imageTag}\` may not be published yet.\n` +
           `  Check the docker-images workflow run and verify the tag at:\n` +
           `      https://github.com/switchroom/switchroom/pkgs/container/switchroom-hostd`,
       ),
@@ -411,7 +434,10 @@ export function registerHostdCommand(program: Command): void {
   hostd
     .command("install")
     .description("Install or refresh the hostd container (writes ~/.switchroom/hostd/docker-compose.yml + docker compose up -d)")
-    .option("--tag <tag>", "Image tag (default: latest)", DEFAULT_IMAGE_TAG)
+    .option(
+      "--tag <tag>",
+      "Image tag override (default: resolved from release.pin in switchroom.yaml, else latest)",
+    )
     .option("--dry-run", "Print the compose file and the docker commands without writing or running anything")
     // withConfigError is a higher-order wrapper (helpers.ts:9) — it
     // accepts a handler and RETURNS a function that catches ConfigError


### PR DESCRIPTION
## Summary

`switchroom hostd install` hardcoded its image tag to `latest` and ignored `release.pin` in switchroom.yaml — so the hostd singleton silently lagged the pinned fleet (agents/brokers all honor the pin). It now resolves the tag from the pin, mirroring the agent-fleet generator.

## Why

Two real failure modes, both hit live:
1. **Version drift** — after a release, hostd stayed on whatever `latest` pointed at while the rest of the fleet moved to the pinned version. `doctor` reports drift; the memory `feedback_singletons_dont_recreate_on_pin_bump` documents the class.
2. **`:latest`-lag** — right after a tag push, the `:latest` promotion lags the version-tag build, so a plain `hostd install` lands the PRIOR image. Rolling v0.15.7 I had to pass `--tag v0.15.7` by hand to get the just-released hostd image onto the daemon.

## What

- New `resolveHostdImageTag(explicitTag, release)`: precedence `--tag` > `release.pin`/`channel` > `latest`, identical to `write-compose.ts`'s `resolveImageTag(resolveRelease(...))`.
- Dropped the `--tag` option's commander default (it forced `opts.tag="latest"`, which would shadow the pin). Unset `--tag` now falls through to the resolved pin.
- Threaded the resolved tag through the compose render + pull log + pull-failure hint.

## Test plan

- [x] 4 new cases: explicit override, pin default (v + sha), channel fallback, latest fallback. 23 `hostd.test.ts` green; `tsc --noEmit` clean; PII guard clean.
- [x] Behaviour preserved for unpinned setups (still `latest`).

## Risk

Low. Pure tag-resolution change. The only behavioural change: a pinned `release` now drives the hostd image by default (the intended fix). Explicit `--tag` and unpinned setups are unchanged.