### PR TITLE
fix(webd): default install image tag to release.pin, not hardcoded latest

### DIFF
--- a/src/cli/webd.test.ts
+++ b/src/cli/webd.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { renderWebComposeFile } from "./webd.js";
+import { renderWebComposeFile, resolveWebImageTag } from "./webd.js";
 
 describe("renderWebComposeFile", () => {
   it("renders a valid yaml-shaped string for the switchroom-web service", () => {
@@ -104,5 +104,26 @@ describe("renderWebComposeFile", () => {
   it("uses a 15s stop_grace_period for clean bun shutdown on docker stop", () => {
     const out = renderWebComposeFile({ hostHome: "/h", imageTag: "latest", operatorUid: 1000 });
     expect(out).toContain("stop_grace_period: 15s");
+  });
+});
+
+describe("resolveWebImageTag (honor release.pin like the agent fleet)", () => {
+  it("uses an explicit --tag override above everything", () => {
+    expect(resolveWebImageTag("v9.9.9", { pin: "v0.15.7" })).toBe("v9.9.9");
+    expect(resolveWebImageTag("v9.9.9", undefined)).toBe("v9.9.9");
+  });
+
+  it("defaults to release.pin when no --tag (the gap this closes)", () => {
+    expect(resolveWebImageTag(undefined, { pin: "v0.15.7" })).toBe("v0.15.7");
+    expect(resolveWebImageTag(undefined, { pin: "sha-abc1234" })).toBe("sha-abc1234");
+  });
+
+  it("falls back to a release channel when no pin", () => {
+    expect(resolveWebImageTag(undefined, { channel: "rc" })).toBe("rc");
+  });
+
+  it("falls back to 'latest' when neither --tag nor release is set", () => {
+    expect(resolveWebImageTag(undefined, undefined)).toBe("latest");
+    expect(resolveWebImageTag(undefined, {})).toBe("latest");
   });
 });

--- a/src/cli/webd.ts
+++ b/src/cli/webd.ts
@@ -43,15 +43,34 @@ import { existsSync, mkdirSync, writeFileSync, copyFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
-import { withConfigError } from "./helpers.js";
+import { getConfig, withConfigError } from "./helpers.js";
 import { resolveOperatorUid } from "./operator-uid.js";
+import { resolveImageTag, resolveRelease, type ReleaseBlockShape } from "../config/release-resolve.js";
 
 /**
- * Image tag the install verb pins. Defaults to `:latest`. Override
- * via `--tag <X>` when standing up a specific version (recommended
- * for production deploys; `:latest` is the dev/operator default).
+ * Resolve the web image tag for an install.
+ *
+ * Precedence (highest first), mirroring the agent-fleet generator
+ * (`write-compose.ts` → `resolveImageTag(resolveRelease(...))`) and the
+ * sibling `hostd install`:
+ *   1. explicit `--tag <X>` (operator override)
+ *   2. `release.pin` / `release.channel` from switchroom.yaml
+ *   3. `latest` (resolveImageTag's back-compat default)
+ *
+ * Before this, `webd install` hardcoded `latest` and ignored
+ * `release.pin` — so the web singleton lagged the pinned fleet, and a
+ * plain `webd install` right after a tag push could land the PRIOR
+ * image (`:latest` promotion lags the version-tag build). Honoring the
+ * pin makes web version-coherent with the rest of the fleet by default.
+ * See memory `feedback_singletons_dont_recreate_on_pin_bump`.
  */
-const DEFAULT_IMAGE_TAG = "latest";
+export function resolveWebImageTag(
+  explicitTag: string | undefined,
+  release: ReleaseBlockShape | undefined,
+): string {
+  if (explicitTag) return explicitTag;
+  return resolveImageTag(resolveRelease({ root: release }));
+}
 
 /**
  * Compose project name for the web service. MUST be distinct from
@@ -213,7 +232,7 @@ interface InstallOptions {
   dryRun?: boolean;
 }
 
-async function doInstall(opts: InstallOptions): Promise<void> {
+async function doInstall(opts: InstallOptions, program: Command): Promise<void> {
   // The container MUST run as the operator uid (peercred gate + file
   // ownership). Refuse to write a compose file that would run as root
   // or with an unknown uid — a root-mode forward is silently 503'd by
@@ -236,9 +255,14 @@ async function doInstall(opts: InstallOptions): Promise<void> {
   const composePath = webdComposePath();
   mkdirSync(dir, { recursive: true });
 
+  // Default to the release pin from switchroom.yaml (version-coherent with
+  // the agent fleet); `--tag` overrides; `latest` if neither is set.
+  const cfg = getConfig(program);
+  const imageTag = resolveWebImageTag(opts.tag, cfg.release);
+
   const yaml = renderWebComposeFile({
     hostHome: homedir(),
-    imageTag: opts.tag ?? DEFAULT_IMAGE_TAG,
+    imageTag,
     operatorUid,
   });
 
@@ -260,13 +284,13 @@ async function doInstall(opts: InstallOptions): Promise<void> {
   // glitch, GHCR throttle) surfaces before the up step rather than
   // mid-recreate. `docker compose pull` is idempotent and skips images
   // already at the requested digest.
-  console.log(chalk.dim(`    Pulling ghcr.io/switchroom/switchroom-web:${opts.tag ?? DEFAULT_IMAGE_TAG}…`));
+  console.log(chalk.dim(`    Pulling ghcr.io/switchroom/switchroom-web:${imageTag}…`));
   const pull = runDocker(["compose", "-p", WEB_COMPOSE_PROJECT, "-f", composePath, "pull"]);
   if (!pull.ok) {
     console.error(chalk.red(`  pull failed:\n${pull.stderr}`));
     console.error(
       chalk.yellow(
-        `  Hint: \`ghcr.io/switchroom/switchroom-web:${opts.tag ?? DEFAULT_IMAGE_TAG}\` may not be published yet.\n` +
+        `  Hint: \`ghcr.io/switchroom/switchroom-web:${imageTag}\` may not be published yet.\n` +
           `  Check the docker-images workflow run and verify the tag at:\n` +
           `      https://github.com/switchroom/switchroom/pkgs/container/switchroom-web`,
       ),
@@ -357,11 +381,14 @@ export function registerWebdCommand(program: Command): void {
   webd
     .command("install")
     .description("Install or refresh the web container (writes ~/.switchroom/web/docker-compose.yml + docker compose up -d)")
-    .option("--tag <tag>", "Image tag (default: latest)", DEFAULT_IMAGE_TAG)
+    .option(
+      "--tag <tag>",
+      "Image tag override (default: resolved from release.pin in switchroom.yaml, else latest)",
+    )
     .option("--dry-run", "Print the compose file and the docker commands without writing or running anything")
     .action(
       withConfigError(async (opts: InstallOptions) => {
-        await doInstall(opts);
+        await doInstall(opts, program);
       }),
     );
 


### PR DESCRIPTION
## Summary

Sibling of #2289 (same fix, for the web dashboard singleton). `switchroom webd install` hardcoded its image tag to `latest` and ignored `release.pin` — so the web container lagged the pinned fleet, and a plain `webd install` right after a tag push could land the PRIOR image (`:latest` promotion lags the version-tag build).

## Why

The web singleton is the last component that didn't honor `release.pin` (agents, brokers, kernel, auth-broker, and now hostd via #2289 all do). It goes stale every release — memory `feedback_singletons_dont_recreate_on_pin_bump`.

## What

- New `resolveWebImageTag(explicitTag, release)`: precedence `--tag` > `release.pin`/`channel` > `latest`, identical to `write-compose.ts` and #2289's `resolveHostdImageTag`.
- `doInstall` now loads config (`getConfig(program)`) to read `cfg.release`.
- Dropped the `--tag` option's commander default (it forced `opts.tag="latest"`, shadowing the pin).

## Test plan

- [x] 4 new cases: explicit override, pin (v + sha), channel, latest fallback. 16 `webd.test.ts` green; `tsc --noEmit` clean; PII guard clean.
- [x] Unpinned setups unchanged (still `latest`).

## Risk

Low. Pure tag-resolution change, mirrors the just-merged #2289. Explicit `--tag` and unpinned setups unchanged.

## Note

Out of scope here: `webd install` also resolves `hostHome: homedir()`, but the web container is dockerless by design (no in-container `webd install` path), so the `/host-home` poison class that #2285 fixed for hostd isn't a live path for web. Left as-is.