### PR TITLE
feat(scheduler): hot-reload schedule.d overlay without a container restart

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -17,7 +17,7 @@ defaults:
       prompt: "Weekly review: summarize this week's progress and next week's goals"
 ```
 
-Run `switchroom agent create <name>` or `switchroom agent reconcile <name>` to materialize the schedule, then `switchroom agent restart <name>` so the in-container scheduler re-registers the new timers.
+Run `switchroom agent create <name>` or `switchroom agent reconcile <name>` to materialize the schedule. The in-container scheduler **hot-reloads** the change within ~30s — no restart needed (see "no restart required" below).
 
 ### 2. Conversational / per-agent overlay (no YAML edit)
 
@@ -40,7 +40,9 @@ switchroom cron list
 
 This same surface is exposed over the **agent-config MCP broker**, so an agent can manage *its own* schedule when you ask it in chat ("set up a daily 8am briefing"). Identity is pinned to `$SWITCHROOM_AGENT_NAME`; cross-agent writes are denied (exit 7). Run `switchroom schedule --help` for the full flag list.
 
-Either way, a schedule change takes effect once the in-container scheduler re-registers — on the next `switchroom agent restart <name>` (or any container restart). There is no hot-reload; the scheduler reads config at boot.
+Either way, a schedule change takes effect **automatically, without a restart**. The in-container scheduler **hot-reloads**: it re-reads `switchroom.yaml` + the `schedule.d` overlay on a short poll (default 30s, `SWITCHROOM_SCHEDULER_RELOAD_POLL_MS`) and, when the effective schedule changes, swaps the live cron timers in place — the tmux/agent session is untouched. So a removed entry stops firing and a new one starts within ~30s. An agent that authors its *first* cron (previously schedule-less) restarts its own scheduler sibling once to activate (a clean ~1s self-restart, no container bounce). A restart is no longer required for schedule edits to take effect.
+
+Hot-reload is on by default; set `SWITCHROOM_SCHEDULER_HOT_RELOAD=0` to freeze the schedule at boot (the pre-reload behaviour). A schedule edit that doesn't take effect within a minute is the signal to check `SWITCHROOM_SCHEDULER_HOT_RELOAD` and the `agent-scheduler.log` for a `reload skipped (config error…)` line (an overlay file caught mid-write keeps the current schedule and retries next tick).
 
 ### Release-triggered fleet restart (opt-in, #1743)
 

--- a/src/agent-scheduler/hot-reload.test.ts
+++ b/src/agent-scheduler/hot-reload.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for the in-process schedule hot-reload — the fix for the
+ * "frozen schedule at boot" class: an agent self-authors a cron (or an
+ * operator edits the schedule.d overlay), but without a reload the edit
+ * never takes effect until the container restarts, so a REMOVED entry
+ * keeps firing (a zombie that burns a wasted turn every interval) and a
+ * NEW entry never runs.
+ *
+ * createScheduleReloader is pure orchestration (fs + node-cron behind
+ * injected callbacks), so these drive it with fakes — no filesystem, no
+ * node-cron, no container.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { SchedulerEntry } from "../scheduler/dispatch.js";
+import {
+  createScheduleReloader,
+  scheduleSignature,
+  resolveReloadPollMs,
+  isHotReloadEnabled,
+  type ScheduleReloader,
+  type RegisteredTask,
+} from "./index.js";
+
+function entry(over: Partial<SchedulerEntry> = {}): SchedulerEntry {
+  return {
+    agent: "clerk",
+    scheduleIndex: 0,
+    cron: "*/30 * * * *",
+    prompt: "sweep",
+    promptKey: "k0",
+    ...over,
+  } as SchedulerEntry;
+}
+
+/** A fake registered task that counts stops, so we can assert the old
+ *  task set is torn down on reload. */
+function fakeTask(): RegisteredTask & { stopped: number } {
+  const t = {
+    entry: entry(),
+    stopped: 0,
+    task: { stop: () => { t.stopped += 1; } },
+  };
+  return t;
+}
+
+function makeReloader(opts: {
+  initialEntries: SchedulerEntry[];
+  sequence: Array<SchedulerEntry[] | Error>; // what loadEntries returns per tick
+}): {
+  reloader: ScheduleReloader;
+  registrations: SchedulerEntry[][];
+  logs: string[];
+  errors: string[];
+  initialTask: RegisteredTask & { stopped: number };
+} {
+  const registrations: SchedulerEntry[][] = [];
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const initialTask = fakeTask();
+  let cursor = 0;
+  const reloader = createScheduleReloader({
+    loadEntries: () => {
+      const next = opts.sequence[cursor++];
+      if (next instanceof Error) throw next;
+      return next ?? [];
+    },
+    register: (es) => {
+      registrations.push(es);
+      // one task per entry, so currentTasks().length tracks entry count
+      return es.map(() => fakeTask());
+    },
+    initialTasks: [initialTask],
+    initialEntries: opts.initialEntries,
+    log: (m) => logs.push(m),
+    onError: (e) => errors.push(e.message),
+  });
+  return { reloader, registrations, logs, errors, initialTask };
+}
+
+describe("scheduleSignature", () => {
+  it("is stable for identical schedules and differs on any change", () => {
+    const a = [entry({ cron: "*/30 * * * *", promptKey: "k1" })];
+    const b = [entry({ cron: "*/30 * * * *", promptKey: "k1" })];
+    expect(scheduleSignature(a)).toBe(scheduleSignature(b));
+
+    // cron change
+    expect(scheduleSignature(a)).not.toBe(
+      scheduleSignature([entry({ cron: "*/10 * * * *", promptKey: "k1" })]),
+    );
+    // prompt change
+    expect(scheduleSignature(a)).not.toBe(
+      scheduleSignature([entry({ cron: "*/30 * * * *", promptKey: "k1", prompt: "other" })]),
+    );
+    // entry added
+    expect(scheduleSignature(a)).not.toBe(scheduleSignature([a[0], entry({ promptKey: "k2" })]));
+    // entry removed
+    expect(scheduleSignature(a)).not.toBe(scheduleSignature([]));
+  });
+});
+
+describe("createScheduleReloader", () => {
+  it("does nothing when the schedule is unchanged", () => {
+    const { reloader, registrations, logs, initialTask } = makeReloader({
+      initialEntries: [entry()],
+      sequence: [[entry()], [entry()]], // same signature both ticks
+    });
+    reloader.tick();
+    reloader.tick();
+    expect(registrations).toHaveLength(0); // never re-registered
+    expect(initialTask.stopped).toBe(0); // boot tasks left running
+    expect(logs).toHaveLength(0);
+    expect(reloader.currentTasks()).toHaveLength(1); // still the boot task
+  });
+
+  it("removes a zombie entry: */10 dropped, */30 remains → re-registers with the new set", () => {
+    // The exact reported bug: boot schedule had a */10 sweep + a daily;
+    // the overlay edit removed */10 and added */30. After reload only the
+    // surviving entries are registered — the zombie */10 is gone.
+    const tenMin = entry({ cron: "*/10 * * * *", promptKey: "zombie" });
+    const daily = entry({ cron: "0 8 * * *", promptKey: "daily", scheduleIndex: 1 });
+    const thirtyMin = entry({ cron: "*/30 * * * *", promptKey: "v3", scheduleIndex: 2 });
+    const { reloader, registrations, logs, initialTask } = makeReloader({
+      initialEntries: [tenMin, daily],
+      sequence: [[daily, thirtyMin]],
+    });
+    reloader.tick();
+    expect(initialTask.stopped).toBe(1); // old task set torn down
+    expect(registrations).toEqual([[daily, thirtyMin]]); // re-registered without the zombie
+    expect(reloader.currentTasks()).toHaveLength(2);
+    expect(logs[0]).toMatch(/schedule reloaded: 1 → 2 task/);
+  });
+
+  it("activates the first cron (0 → 1) on reload", () => {
+    const { reloader, registrations } = makeReloader({
+      initialEntries: [],
+      sequence: [[entry()]],
+    });
+    // boot had 0 entries but reloader was given the boot task list; here
+    // simulate the active-path reloader seeing entries appear.
+    reloader.tick();
+    expect(registrations).toEqual([[entry()]]);
+    expect(reloader.currentTasks()).toHaveLength(1);
+  });
+
+  it("drains to zero tasks when all entries are removed (N → 0)", () => {
+    const { reloader, registrations, initialTask } = makeReloader({
+      initialEntries: [entry()],
+      sequence: [[]],
+    });
+    reloader.tick();
+    expect(initialTask.stopped).toBe(1);
+    expect(registrations).toEqual([[]]);
+    expect(reloader.currentTasks()).toHaveLength(0);
+  });
+
+  it("keeps the current schedule on a transient load error (overlay mid-write)", () => {
+    const { reloader, registrations, errors, initialTask } = makeReloader({
+      initialEntries: [entry()],
+      sequence: [new Error("yaml parse error"), [entry({ cron: "*/15 * * * *" })]],
+    });
+    reloader.tick(); // load throws → keep current, no re-register
+    expect(registrations).toHaveLength(0);
+    expect(initialTask.stopped).toBe(0);
+    expect(errors).toEqual(["yaml parse error"]);
+    expect(reloader.currentTasks()).toHaveLength(1); // boot task untouched
+
+    reloader.tick(); // recovers → now applies the changed schedule
+    expect(registrations).toHaveLength(1);
+    expect(initialTask.stopped).toBe(1);
+  });
+
+  it("re-registers exactly once per distinct change across many no-op ticks", () => {
+    const e1 = [entry({ cron: "*/30 * * * *" })];
+    const e2 = [entry({ cron: "*/45 * * * *" })];
+    const { reloader, registrations } = makeReloader({
+      initialEntries: e1,
+      sequence: [e1, e1, e2, e2, e2], // change happens once (tick 3)
+    });
+    for (let i = 0; i < 5; i++) reloader.tick();
+    expect(registrations).toEqual([e2]); // exactly one re-register
+  });
+});
+
+describe("resolveReloadPollMs", () => {
+  it("defaults to 30s and floors sub-1s overrides", () => {
+    expect(resolveReloadPollMs({})).toBe(30_000);
+    expect(resolveReloadPollMs({ SWITCHROOM_SCHEDULER_RELOAD_POLL_MS: "5000" })).toBe(5000);
+    expect(resolveReloadPollMs({ SWITCHROOM_SCHEDULER_RELOAD_POLL_MS: "500" })).toBe(30_000);
+    expect(resolveReloadPollMs({ SWITCHROOM_SCHEDULER_RELOAD_POLL_MS: "garbage" })).toBe(30_000);
+  });
+});
+
+describe("isHotReloadEnabled", () => {
+  it("is on by default and only '0' disables it", () => {
+    expect(isHotReloadEnabled({})).toBe(true);
+    expect(isHotReloadEnabled({ SWITCHROOM_SCHEDULER_HOT_RELOAD: "1" })).toBe(true);
+    expect(isHotReloadEnabled({ SWITCHROOM_SCHEDULER_HOT_RELOAD: "0" })).toBe(false);
+  });
+});

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -395,6 +395,95 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
 }
 
 /**
+ * Stable change-detection signature for an agent's schedule entries.
+ *
+ * The agent-scheduler loads the schedule (switchroom.yaml + the
+ * `schedule.d/*.yaml` overlay) ONCE at boot. Agents self-author cron
+ * entries via their agent-config tools, and operators edit the overlay
+ * — but without a reload those edits don't take effect until the
+ * container restarts, so a *removed* entry keeps firing (a zombie
+ * schedule that burns a wasted turn every interval) and a *new* entry
+ * never runs. This signature lets the reload watcher cheaply detect
+ * "did the effective schedule change?" by value, independent of file
+ * mtimes (which are unreliable over Docker bind mounts).
+ */
+export function scheduleSignature(entries: SchedulerEntry[]): string {
+  // JSON of the full entry array, in collectScheduleEntries' deterministic
+  // order. Captures cron, prompt, promptKey, scheduleIndex AND the
+  // cheap-cron routing fields (kind/poll/model/session) — any of which
+  // changes scheduling behaviour.
+  return JSON.stringify(entries);
+}
+
+export interface ScheduleReloader {
+  /** One poll: reload entries, and if the signature changed, stop the
+   *  current tasks and re-register. Never throws — a transient config
+   *  parse error (e.g. an overlay caught mid-write) keeps the current
+   *  schedule and is reported via onError. */
+  tick(): void;
+  /** The currently-live tasks (post-reload) — shutdown must stop THESE,
+   *  not the boot set, or a reloaded-away task leaks. */
+  currentTasks(): RegisteredTask[];
+}
+
+/**
+ * In-process schedule hot-reload (no container restart).
+ *
+ * Pure orchestration — fs / node-cron live behind the injected
+ * `loadEntries` and `register` callbacks, so this is unit-testable with
+ * fakes. The container's tmux/agent session is untouched; only the cron
+ * task set is swapped. Replay is a boot-only concern and is deliberately
+ * NOT re-run here (a reload is not a restart — it must not resurrect
+ * missed fires).
+ */
+export function createScheduleReloader(opts: {
+  loadEntries: () => SchedulerEntry[];
+  register: (entries: SchedulerEntry[]) => RegisteredTask[];
+  initialTasks: RegisteredTask[];
+  initialEntries: SchedulerEntry[];
+  log: (msg: string) => void;
+  onError?: (err: Error) => void;
+}): ScheduleReloader {
+  let tasks = opts.initialTasks;
+  let sig = scheduleSignature(opts.initialEntries);
+  return {
+    tick(): void {
+      let next: SchedulerEntry[];
+      try {
+        next = opts.loadEntries();
+      } catch (err) {
+        opts.onError?.(err as Error);
+        return; // keep the current schedule on a transient load error
+      }
+      const nextSig = scheduleSignature(next);
+      if (nextSig === sig) return;
+      const before = tasks.length;
+      for (const t of tasks) t.task.stop();
+      tasks = opts.register(next);
+      sig = nextSig;
+      opts.log(`schedule reloaded: ${before} → ${tasks.length} task(s)`);
+    },
+    currentTasks(): RegisteredTask[] {
+      return tasks;
+    },
+  };
+}
+
+/** Reload poll cadence (ms). Overlay edits are rare and detection within
+ *  ~30s is plenty; the poll is a yaml re-parse + a few overlay file reads,
+ *  negligible CPU. Floored at 1s. */
+export function resolveReloadPollMs(env: NodeJS.ProcessEnv): number {
+  const raw = Number.parseInt(env.SWITCHROOM_SCHEDULER_RELOAD_POLL_MS ?? "", 10);
+  return Number.isFinite(raw) && raw >= 1000 ? raw : 30_000;
+}
+
+/** Hot-reload is on by default; `SWITCHROOM_SCHEDULER_HOT_RELOAD=0` restores
+ *  the pre-reload behaviour (schedule frozen at boot). */
+export function isHotReloadEnabled(env: NodeJS.ProcessEnv): boolean {
+  return env.SWITCHROOM_SCHEDULER_HOT_RELOAD !== "0";
+}
+
+/**
  * Build an `InboundDispatcher` backed by a local IPC client that
  * writes `inject_inbound` envelopes to the gateway. Tests pass a
  * capturing dispatcher directly to `registerAgentSchedule` and skip
@@ -481,12 +570,46 @@ export async function main(): Promise<void> {
     // agent. setInterval is enough to peg the event loop; container
     // restart re-runs main() and re-reads config, so a future
     // `apply` that adds schedule entries gets picked up cleanly.
-    setInterval(() => { /* idle */ }, 1 << 30);
+    //
+    // Hot-reload (cold 0→N): an agent that self-authors its FIRST cron
+    // (or an operator adding one to a previously schedule-less agent)
+    // shouldn't have to wait for a manual bounce. A lightweight watcher
+    // detects entries appearing and exits(0) so the supervisor reboots
+    // straight into the active path above — which sets up the sink / IPC
+    // / replay that a 0-entry boot deliberately skipped. The exit is
+    // clean and the sidecar typically ran ≫60s, so the supervisor's
+    // backoff counter resets (no penalty). Guarded against flapping: we
+    // only exit when entries are genuinely non-empty.
+    let idleTimer: ReturnType<typeof setInterval>;
+    if (isHotReloadEnabled(process.env)) {
+      idleTimer = setInterval(() => {
+        let appeared: SchedulerEntry[];
+        try {
+          appeared = collectScheduleEntries(loadConfig(configPath)).filter(
+            (e) => e.agent === agentName,
+          );
+        } catch {
+          return; // overlay caught mid-write — re-check next tick
+        }
+        if (appeared.length > 0) {
+          process.stdout.write(
+            `agent-scheduler: ${agentName} schedule appeared (${appeared.length} ` +
+            `entr${appeared.length === 1 ? "y" : "ies"}) — restarting to activate\n`,
+          );
+          clearInterval(idleTimer);
+          releaseLock(lockPath);
+          process.exit(0); // supervisor respawns into the active scheduling path
+        }
+      }, resolveReloadPollMs(process.env));
+    } else {
+      idleTimer = setInterval(() => { /* idle */ }, 1 << 30);
+    }
     // Release the lock cleanly on SIGTERM/SIGINT so a subsequent
     // boot doesn't have to fall back to the stale-lock reclaim path
     // in acquireLock. Only matters for log cleanliness — the reclaim
     // path works either way (#895 boot-time freshness check).
     const cleanup = (): never => {
+      clearInterval(idleTimer);
       releaseLock(lockPath);
       process.exit(0);
     };
@@ -721,15 +844,18 @@ export async function main(): Promise<void> {
     );
   }
 
-  const tasks = registerAgentSchedule({
-    entries,
-    channel,
-    sink,
-    cronLib,
-    dispatcher,
-    ...(quotaGate ? { quotaGate } : {}),
-    ...(cheapCron ? { cheapCron } : {}),
-  });
+  const registerForEntries = (es: SchedulerEntry[]): RegisteredTask[] =>
+    registerAgentSchedule({
+      entries: es,
+      channel,
+      sink,
+      cronLib,
+      dispatcher,
+      ...(quotaGate ? { quotaGate } : {}),
+      ...(cheapCron ? { cheapCron } : {}),
+    });
+
+  const tasks = registerForEntries(entries);
 
   process.stdout.write(
     `agent-scheduler: ${agentName} registered ${tasks.length} task(s); ` +
@@ -737,8 +863,34 @@ export async function main(): Promise<void> {
     `socket=${socketPath} jsonl=${jsonlPath}\n`,
   );
 
+  // Hot-reload: pick up schedule.d / switchroom.yaml edits WITHOUT a
+  // container restart (an agent self-authoring crons, or an operator
+  // editing the overlay). Before this, the schedule was frozen at boot,
+  // so a removed entry kept firing (a zombie that burned a wasted turn
+  // every interval) and a new entry never ran until the next bounce.
+  // In-process task swap — the tmux/agent session is untouched.
+  let reloader: ScheduleReloader | undefined;
+  let reloadTimer: ReturnType<typeof setInterval> | undefined;
+  if (isHotReloadEnabled(process.env)) {
+    reloader = createScheduleReloader({
+      loadEntries: () =>
+        collectScheduleEntries(loadConfig(configPath)).filter((e) => e.agent === agentName),
+      register: registerForEntries,
+      initialTasks: tasks,
+      initialEntries: entries,
+      log: (m) => process.stdout.write(`agent-scheduler: ${agentName} ${m}\n`),
+      onError: (e) =>
+        process.stderr.write(
+          `agent-scheduler: ${agentName} reload skipped (config error, keeping current schedule): ${e.message}\n`,
+        ),
+    });
+    reloadTimer = setInterval(() => reloader!.tick(), resolveReloadPollMs(process.env));
+  }
+
   const shutdown = () => {
-    for (const t of tasks) t.task.stop();
+    if (reloadTimer) clearInterval(reloadTimer);
+    // Stop the CURRENTLY-live tasks (post-reload), not the boot set.
+    for (const t of (reloader ? reloader.currentTasks() : tasks)) t.task.stop();
     sink.close();
     ipcClient.close();
     releaseLock(lockPath);


### PR DESCRIPTION
## Summary

The in-agent scheduler froze the schedule at boot. Agents self-author crons (and operators edit the `schedule.d` overlay), but edits didn't take effect until a container restart — so a **removed entry kept firing** (a zombie burning a wasted agent turn every interval) and a **new entry never ran**. This adds in-process hot-reload.

## Why

Observed live: clerk deleted a `*/10` capture-sweep and added a `*/30` v3, but the running sidecar kept firing the deleted `*/10` all night (~144 wasted model turns/day from one zombie). The only fix was a manual restart. Agents increasingly self-author crons, so "edit silently needs a restart" is a recurring token-bleed + correctness trap.

## What

- **Hot-reload watcher**: every `SWITCHROOM_SCHEDULER_RELOAD_POLL_MS` (default 30s) re-reads `switchroom.yaml` + overlay; on a by-value schedule change, stops the current node-cron tasks and re-registers the new set in place. tmux/agent session untouched.
- **By-value signature** (not mtime — bind-mount mtimes are unreliable over Docker).
- **Cold 0→N**: an agent authoring its *first* cron — the idle watcher detects entries appearing and `exit(0)`s so the supervisor reboots into the active path (which sets up sink/IPC/replay a 0-entry boot skips). Clean ~1s self-restart, backoff counter resets.
- **N→0**: drains to zero tasks, watcher keeps running.
- Replay is boot-only and deliberately NOT re-run on reload (a reload isn't a restart — must not resurrect missed fires).
- Transient parse error (overlay mid-write) keeps the current schedule, retries next tick.
- Kill-switch `SWITCHROOM_SCHEDULER_HOT_RELOAD=0`.

`createScheduleReloader` is pure orchestration (fs + node-cron behind injected callbacks) → fully unit-testable.

## Test plan

- [x] 9 new unit tests: zombie removal (`*/10` dropped, `*/30` kept), 0→1 activation, N→0 drain, transient-error hold-then-recover, exactly-once re-register across no-op ticks, signature stability, poll-ms/kill-switch resolution.
- [x] idle-smoke (#921/#928) still green — idle path with the new watcher stays alive + SIGTERM exits 0.
- [x] 191 scheduler tests green; `tsc --noEmit` clean; PII + bun-test-import guards clean.
- [x] `docs/scheduling.md` updated (the "There is no hot-reload" note was now wrong).

## Risk

Medium-low. In-process task swap is the load-bearing part; covered by tests asserting the old set is stopped and the new set registered exactly once. Kill-switch reverts to boot-frozen behaviour. The cold-0→N self-restart reuses the well-tested boot path. No change to fire semantics, replay, quota-preflight, or cheap-cron routing.

## Follow-up (next PR)

This is part 1. Part 2 surfaces the cron **tier/escalation options** (Tier-0 model-free poll / Tier-1 cheap session) to agents via the agent-config MCP + a skill, so agents can author *cheap* crons themselves.