### PR TITLE
feat(scheduler): agent-facing cron tier options + accurate post-edit guidance

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -222,6 +222,19 @@ Trade-off: scheduled tasks now share session context (better for "remember what 
 
 If the agent is down at fire time, the in-container sidecar can't deliver — the boot-time replay window catches up to 30 minutes; anything older is explicitly reported via the [skipped-run notice](#skipped-run-notice-downtime-longer-than-the-replay-window), not silently dropped.
 
+### Controlling per-fire cost (tiers)
+
+Because each fire is a full turn in the live session by default, a frequent cron pays the agent's whole context every time — wasteful for routine checks. Entries (and `schedule_add`) take optional tier hints, honoured when `SWITCHROOM_CHEAP_CRON` is enabled (see `docs/rfcs/cheap-cron-sessions.md`):
+
+| You want… | Use | Cost |
+|---|---|---|
+| The fire to act *as the agent* (persona, memory, recent chat) | default (no `model`) — **Tier 2** | full live-session turn |
+| Light, self-contained work (summarise/format) — no memory needed | `model: sonnet` / `context: fresh` — **Tier 1** | a fresh minimal-context cheap session |
+| "Only do something when X changes" (a webpage/API) | `kind: poll` (operator-set; egress-gated) — **Tier 0** | model-free check; a model fire only on a *hit* |
+| "Do something when a message is reacted to" | **`reaction_dispatch`** (event-driven, #2291) — not a cron at all | zero polling; the reaction wakes the agent |
+
+Agents can self-author the `model`/`context` hints (no security gate). `kind: poll` and `reaction_dispatch` need an operator config commit (egress / identity gates), so an agent should *request* them. With the flag off, all hints are inert — every fire is a normal Tier-2 turn (a `kind: poll` entry fires its escalation prompt directly); disabling cheap-cron can never silently drop a cron.
+
 ## Managing the scheduler
 
 ```bash

--- a/profiles/_shared/agent-self-service.md.hbs
+++ b/profiles/_shared/agent-self-service.md.hbs
@@ -28,13 +28,32 @@ tools is to let you do the edit yourself.
 
 ### Tools
 
-- **`schedule_add(cron_expr, prompt, name?, secrets?)`** — append a new schedule
-  entry. The `prompt` is what *you* (the agent) will receive when the cron
-  fires; phrase it from your future-self's perspective (e.g.
-  `"Time for the daily digest — pull yesterday's GitHub activity and DM the
-  summary to chat 12345"`, not `"please send the digest"`). Optional
+- **`schedule_add(cron_expr, prompt, name?, secrets?, model?, context?)`** —
+  append a new schedule entry. Takes effect within **~30s** (the scheduler
+  hot-reloads — no restart needed). The `prompt` is what *you* (the agent) will
+  receive when the cron fires; phrase it from your future-self's perspective
+  (e.g. `"Time for the daily digest — pull yesterday's GitHub activity and DM
+  the summary to chat 12345"`, not `"please send the digest"`). Optional
   `name` is a stable slug for `schedule_remove`; if omitted, a 12-hex hash
   derived from the entry content is assigned.
+
+  **Mind the cost — pick the cheapest tier that does the job:**
+  - *Default (no `model`)* — the fire runs as a **full turn in your live
+    session**: your model, your whole context + memory. Right for work that
+    genuinely needs *you* (your persona, your conversation history). Costly for
+    routine checks — every fire pays your full context.
+  - *`model: "sonnet"`* (or `context: "fresh"`) — routes the fire to a **cheap,
+    minimal-context cron session** (Tier 1): a fresh Sonnet with just the
+    prompt, no heavy context. Use for light, self-contained recurring work
+    (summarise a feed, format a digest) where you don't need your memory. Much
+    cheaper per fire. *(Honoured only when the operator has enabled cheap-cron;
+    otherwise it still runs as a normal turn — never silently dropped.)*
+  - *"Only act when X changes"* — don't poll with a frequent prompt cron (every
+    fire is a wasted turn when nothing changed). Ask the **operator** to set up
+    a **poll** (model-free check, e.g. a webpage/API via `kind: poll`) or, for
+    reaction-triggered work, **`reaction_dispatch`** (an emoji reaction wakes
+    you instantly — zero polling). These need an operator config commit
+    (egress/identity gates), so request them rather than authoring them yourself.
 
 - **`schedule_remove(name | cron_hash)`** — delete by `name` (the slug from
   add) or by 12-hex `cron_hash` (shown in `cron_list` output). Both

--- a/src/cli/agent-config-write.test.ts
+++ b/src/cli/agent-config-write.test.ts
@@ -32,12 +32,45 @@ describe("scheduleAdd — happy path", () => {
     expect(r.cron_hash).toBe(expected);
     expect(r.slug).toBe(`cron-${expected}`);
     expect(r.would_recreate).toBe(false);
-    expect(r.restart_required).toBe(true);
-    expect(r.restart_hint).toContain("alice");
-    expect(r.restart_hint).toMatch(/restart/i);
+    // Since #2293 the scheduler hot-reloads, so an add is live within ~30s
+    // with no restart (hot-reload is on by default).
+    expect(r.restart_required).toBe(false);
+    expect(r.restart_hint).toMatch(/~30s|hot-reload|no restart/i);
     expect(existsSync(r.path)).toBe(true);
     const content = readFileSync(r.path, "utf-8");
     expect(content).toContain("prompt: morning standup");
+  });
+
+  it("reports restart_required + names the agent when hot-reload is disabled", () => {
+    const prev = process.env.SWITCHROOM_SCHEDULER_HOT_RELOAD;
+    process.env.SWITCHROOM_SCHEDULER_HOT_RELOAD = "0";
+    try {
+      const r = scheduleAdd({ agent: "alice", cronExpr: "0 7 * * *", prompt: "frozen", root });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.restart_required).toBe(true);
+      expect(r.restart_hint).toContain("alice");
+      expect(r.restart_hint).toMatch(/restart/i);
+    } finally {
+      if (prev === undefined) delete process.env.SWITCHROOM_SCHEDULER_HOT_RELOAD;
+      else process.env.SWITCHROOM_SCHEDULER_HOT_RELOAD = prev;
+    }
+  });
+
+  it("authors a Tier-1 cheap-cron entry with --model / --context", () => {
+    const r = scheduleAdd({
+      agent: "alice",
+      cronExpr: "0 8 * * *",
+      prompt: "daily digest",
+      model: "sonnet",
+      context: "fresh",
+      root,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const content = readFileSync(r.path, "utf-8");
+    expect(content).toContain("model: sonnet");
+    expect(content).toContain("context: fresh");
   });
 });
 
@@ -144,8 +177,9 @@ describe("scheduleRemove", () => {
     const r = scheduleRemove({ cronHash: add.cron_hash, root });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    expect(r.restart_required).toBe(true);
-    expect(r.restart_hint).toContain("alice");
+    // Hot-reload (#2293): a remove is picked up within ~30s, no restart.
+    expect(r.restart_required).toBe(false);
+    expect(r.restart_hint).toMatch(/~30s|hot-reload|no restart/i);
     expect(existsSync(add.path)).toBe(false);
   });
 

--- a/src/cli/agent-config-write.ts
+++ b/src/cli/agent-config-write.ts
@@ -37,7 +37,8 @@ import { parse as parseYaml, stringify as yamlStringify } from "yaml";
 import {
   appendAudit,
   resolveTargetAgent,
-  restartRequiredNote,
+  scheduleLiveNote,
+  scheduleRestartRequired,
 } from "./agent-config.js";
 import {
   writeOverlayEntry,
@@ -251,6 +252,18 @@ interface AddOpts {
   prompt: string;
   secrets?: string[];
   name?: string;
+  /**
+   * Cheap-cron tier hint (docs/rfcs/cheap-cron-sessions.md). A known-cheap
+   * model id (sonnet/haiku) routes this fire to a fresh, minimal-context
+   * cron session (Tier 1) instead of the agent's full live session (Tier 2),
+   * cutting per-fire token cost. Honoured only when SWITCHROOM_CHEAP_CRON is
+   * on; otherwise inert (the fire still runs as a normal turn). Agent-authorable
+   * — no security gate (unlike `poll`, which needs an operator egress commit).
+   */
+  model?: string;
+  /** Tier hint: 'fresh' → minimal-context cheap session (Tier 1); 'agent' →
+   *  the agent's live session (Tier 2). Unset → inferred from `model`. */
+  context?: "fresh" | "agent";
   /** Test-only: override overlay root. */
   root?: string;
   /**
@@ -277,9 +290,10 @@ export interface ScheduleAddResult {
   path: string;
   cron_hash: string;
   would_recreate: false;
-  /** Entry is on disk but the in-container scheduler captured its
-   *  entries at boot — not live until the agent restarts. */
-  restart_required: true;
+  /** Since #2293 the in-agent scheduler hot-reloads the overlay, so this
+   *  is `false` by default (entry is live within ~30s). It is only `true`
+   *  when hot-reload is disabled (`SWITCHROOM_SCHEDULER_HOT_RELOAD=0`). */
+  restart_required: boolean;
   restart_hint: string;
 }
 
@@ -335,6 +349,10 @@ export function scheduleAdd(opts: AddOpts): ScheduleAddResult | ScheduleErrorRes
   };
   if (opts.secrets && opts.secrets.length > 0) entry.secrets = opts.secrets;
   if (opts.name) entry.name = opts.name;
+  // Cheap-cron tier hints (inert unless SWITCHROOM_CHEAP_CRON is on). Plain
+  // ScheduleEntry fields validated by ScheduleEntrySchema on reconcile.
+  if (opts.model) entry.model = opts.model;
+  if (opts.context) entry.context = opts.context;
 
   // We construct the doc as { schedule: [entry] }. `name` is NOT a
   // schema field on ScheduleEntrySchema today — we stash it in a
@@ -460,8 +478,8 @@ export function scheduleAdd(opts: AddOpts): ScheduleAddResult | ScheduleErrorRes
     path,
     cron_hash: hash,
     would_recreate: false,
-    restart_required: true,
-    restart_hint: restartRequiredNote(agent),
+    restart_required: scheduleRestartRequired(),
+    restart_hint: scheduleLiveNote(agent),
   };
 }
 
@@ -489,12 +507,21 @@ export function scheduleAddOrStage(
   if (stageReason === null) return r;
 
   const agent = resolveTargetAgent(opts.agent);
-  const entry: { cron: string; prompt: string; secrets?: string[]; name?: string } = {
+  const entry: {
+    cron: string;
+    prompt: string;
+    secrets?: string[];
+    name?: string;
+    model?: string;
+    context?: "fresh" | "agent";
+  } = {
     cron: opts.cronExpr,
     prompt: opts.prompt,
   };
   if (opts.secrets && opts.secrets.length > 0) entry.secrets = opts.secrets;
   if (opts.name) entry.name = opts.name;
+  if (opts.model) entry.model = opts.model;
+  if (opts.context) entry.context = opts.context;
 
   // Reconstruct the YAML body we WOULD have written. Mirrors the
   // scheduleAdd doc-build (filter `name` out of the schedule entry;
@@ -536,7 +563,9 @@ export interface ScheduleRemoveResult {
   ok: true;
   slug: string;
   path: string;
-  restart_required: true;
+  /** `false` by default (hot-reload removes the entry within ~30s); `true`
+   *  only when `SWITCHROOM_SCHEDULER_HOT_RELOAD=0`. */
+  restart_required: boolean;
   restart_hint: string;
 }
 
@@ -620,8 +649,8 @@ export function scheduleRemove(opts: RemoveOpts): ScheduleRemoveResult | Schedul
     ok: true,
     slug: match.slug,
     path: match.path,
-    restart_required: true,
-    restart_hint: restartRequiredNote(agent),
+    restart_required: scheduleRestartRequired(),
+    restart_hint: scheduleLiveNote(agent),
   };
 }
 
@@ -639,6 +668,14 @@ export function registerAgentConfigWriteCommands(program: Command): void {
     .option("--secrets <list>", "Comma-separated vault keys (REJECTED for agent-authored overlays)")
     .option("--name <slug>", "Optional human-readable name (a-z 0-9 -)")
     .option(
+      "--model <id>",
+      "Cheap-cron tier hint: a known-cheap model (sonnet/haiku) routes this fire to a fresh, minimal-context cron session (Tier 1) instead of the agent's full live session (Tier 2), cutting token cost. Inert unless SWITCHROOM_CHEAP_CRON is on.",
+    )
+    .option(
+      "--context <mode>",
+      "Tier hint: 'fresh' (minimal-context cheap session) or 'agent' (full live session). Unset → inferred from --model.",
+    )
+    .option(
       "--stage-on-reject",
       "When a security gate trips (secrets/quota/min-interval), stage the entry under .pending/ for operator approval instead of rejecting with exit 9. Used by the MCP path; operator CLI defaults to off.",
     )
@@ -648,8 +685,14 @@ export function registerAgentConfigWriteCommands(program: Command): void {
       prompt: string;
       secrets?: string;
       name?: string;
+      model?: string;
+      context?: string;
       stageOnReject?: boolean;
     }) => {
+      if (opts.context && opts.context !== "fresh" && opts.context !== "agent") {
+        emitError("E_INVALID_PROMPT", "--context must be 'fresh' or 'agent'");
+        process.exit(1);
+      }
       const secrets = opts.secrets
         ? opts.secrets.split(",").map((s) => s.trim()).filter(Boolean)
         : undefined;
@@ -670,6 +713,8 @@ export function registerAgentConfigWriteCommands(program: Command): void {
           prompt: opts.prompt,
           secrets,
           name: opts.name,
+          model: opts.model,
+          context: opts.context as "fresh" | "agent" | undefined,
         });
       } catch (err) {
         // Cross-agent denial path (matches read-side: exit 7).

--- a/src/cli/agent-config.ts
+++ b/src/cli/agent-config.ts
@@ -206,6 +206,29 @@ export function restartRequiredNote(agent: string): string {
   );
 }
 
+/**
+ * Schedule-specific liveness note. Since #2293 the in-agent scheduler
+ * HOT-RELOADS the schedule.d overlay (default on; `SWITCHROOM_SCHEDULER_HOT_RELOAD=0`
+ * freezes it), so a schedule add/remove takes effect within ~30s with NO
+ * restart — unlike skills/MCP, which still load at boot. Kept distinct
+ * from {@link restartRequiredNote} so the agent gets accurate guidance and
+ * doesn't pointlessly bounce itself. The env read mirrors `isHotReloadEnabled`
+ * in src/agent-scheduler/index.ts (kept inline to avoid pulling node-cron
+ * into the CLI bundle).
+ */
+export function scheduleRestartRequired(): boolean {
+  // Hot-reload on (default) ⇒ no restart. Only `=0` (frozen-at-boot) requires one.
+  return (process.env.SWITCHROOM_SCHEDULER_HOT_RELOAD ?? "") === "0";
+}
+
+export function scheduleLiveNote(agent: string): string {
+  const hotReload = (process.env.SWITCHROOM_SCHEDULER_HOT_RELOAD ?? "") !== "0";
+  return hotReload
+    ? `Live within ~30s — the in-agent scheduler hot-reloads the overlay; no restart needed.`
+    : `Not live yet — hot-reload is disabled (SWITCHROOM_SCHEDULER_HOT_RELOAD=0). ` +
+        `Run \`switchroom agent restart ${agent}\` for this to take effect.`;
+}
+
 function getAgentSlice(config: SwitchroomConfig, agent: string): unknown {
   const slice = config.agents?.[agent];
   if (!slice) {

--- a/src/mcp/agent-config/server.ts
+++ b/src/mcp/agent-config/server.ts
@@ -69,6 +69,9 @@ interface ToolArgs {
   secrets?: string[];
   name?: string;
   cron_hash?: string;
+  // schedule_add cheap-cron tier hints
+  model?: string;
+  context?: string;
   // skill_install (#1163 Phase 2)
   source?: string;
   // peers_list
@@ -132,10 +135,17 @@ export const TOOLS = [
   {
     name: "schedule_add",
     description:
-      "Append a cron schedule entry to the agent's overlay dir. " +
-      "Overlay-sourced entries with non-empty `secrets:` are REJECTED " +
-      "(E_OVERLAY_SECRETS_REQUIRES_APPROVAL); operator-authored entries " +
-      "in switchroom.yaml are unaffected.",
+      "Append a cron schedule entry to your overlay. Takes effect within ~30s — " +
+      "the scheduler hot-reloads, no restart needed. Overlay entries with " +
+      "non-empty `secrets:` are REJECTED (E_OVERLAY_SECRETS_REQUIRES_APPROVAL). " +
+      "COST: by default each fire runs as a full turn in your live session " +
+      "(your model, your whole context) — fine for work that needs your memory/" +
+      "persona, but costly for routine checks. For a lighter recurring task, set " +
+      "`model: \"sonnet\"` to run that fire in a cheap, minimal-context cron " +
+      "session instead (saves tokens; needs cheap-cron enabled by the operator). " +
+      "For 'only do something when X changes' (e.g. a webpage, or a reaction), " +
+      "ask the operator to set up a poll or reaction-dispatch instead of a " +
+      "frequent prompt cron — far cheaper than polling with a full turn.",
     inputSchema: {
       type: "object" as const,
       required: ["cron_expr", "prompt"],
@@ -144,6 +154,22 @@ export const TOOLS = [
         prompt: { type: "string", minLength: 1, maxLength: 4000 },
         secrets: { type: "array", items: { type: "string" } },
         name: { type: "string", pattern: "^[a-z0-9-]{1,40}$" },
+        model: {
+          type: "string",
+          description:
+            "Optional cheap-cron tier hint. A known-cheap model ('sonnet'/'haiku') " +
+            "routes this fire to a fresh, minimal-context cron session (Tier 1) " +
+            "instead of your full live session (Tier 2) — cheaper per fire. Omit " +
+            "for context-heavy work that needs your memory/persona. Inert unless " +
+            "the operator has enabled cheap-cron.",
+        },
+        context: {
+          type: "string",
+          enum: ["fresh", "agent"],
+          description:
+            "Tier hint: 'fresh' = minimal-context cheap session (Tier 1); 'agent' " +
+            "= your full live session (Tier 2). Usually inferred from `model`.",
+        },
       },
     },
   },
@@ -447,6 +473,8 @@ export function dispatchTool(
       if (a.agent) base.push("--agent", a.agent);
       if (a.name) base.push("--name", a.name);
       if (a.secrets && a.secrets.length > 0) base.push("--secrets", a.secrets.join(","));
+      if (a.model) base.push("--model", a.model);
+      if (a.context) base.push("--context", a.context);
       cliArgs = base;
       parseMode = "json";
       break;


### PR DESCRIPTION
## Summary

Surfaces the cheap-cron tier controls to agents, and corrects the now-stale "restart required" guidance left by the hot-reload work (#2293). Part 2 of the cron token-optimization work (Part 1 = #2293 hot-reload).

## Why

The tier machinery existed in the schema (`kind`/`poll`/`model`/`context`) but the agent's `schedule_add` tool only accepted `cron`/`prompt`/`secrets`/`name` — so **every self-authored cron was a full live-session (Tier 2) fire** (the most expensive option), and agents had no way to pick a cheaper tier or even know one existed. Separately, #2293 made the overlay hot-reload, so the old `restart_required: true` result was misinforming agents into pointless self-restarts.

## What

- **`schedule_add` gains `--model` / `--context`** (CLI + the agent-config MCP tool). A known-cheap model (`sonnet`/`haiku`) routes that fire to a fresh minimal-context cron session (**Tier 1**) instead of the agent's full session (**Tier 2**). Agent-authorable — no security gate (unlike `poll`, which needs an operator egress commit). Inert unless `SWITCHROOM_CHEAP_CRON` is on; never silently dropped.
- **`restart_required` is hot-reload-aware**: `scheduleAdd`/`scheduleRemove` now return `false` + a "live within ~30s" hint by default, and `true` (with the restart instruction) only when `SWITCHROOM_SCHEDULER_HOT_RELOAD=0`. **Skill writes unchanged** (skills still load at boot → restart still required).
- **Agent context** (the "agents should know via MCP/skills" ask): the `schedule_add` MCP description + the rendered agent self-service doc teach the cost model — default Tier 2 for memory-dependent work, `model: sonnet` Tier 1 for light work, and "ask the operator for a poll / `reaction_dispatch`" for change-triggered work instead of polling with a full turn. `docs/scheduling.md` gains a tier table.

## Test plan

- [x] `--model`/`--context` round-trip into the overlay yaml (new tests).
- [x] `restart_required` false-by-default + true-when-`=0` (env-gated test).
- [x] 909 cli/mcp/scheduler tests green; `tsc --noEmit` clean; PII + bun-test guards clean.
- [x] Skill-write restart tests untouched (skills still need restart).

## Risk

Low. `--model`/`--context` are additive optional fields validated by the existing `ScheduleEntrySchema`; the routing they trigger is gated behind `SWITCHROOM_CHEAP_CRON` (dormant). The `restart_required` type widened `true`→`boolean` — all consumers checked (it's informational, surfaced in the MCP envelope).

## Follow-up

The clerk canary — migrate its `*/30` capture sweep to event-driven `reaction_dispatch` (#2291), eliminating the poll — is a live config change, done separately.