### PR TITLE
feat(scheduler): deterministic cron tier selector (value-gate, shadow-first)

### DIFF
--- a/src/scheduler/tier-selector.test.ts
+++ b/src/scheduler/tier-selector.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the deterministic cron tier selector (the cheap-crons JTBD
+ * value-gate). The decision space is small and fully enumerated here —
+ * the operator's bar is "prove determinism by enumeration, not sampling".
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  recommendCronTier,
+  resolveFrequentGapMin,
+  DEFAULT_FREQUENT_GAP_MIN,
+  type TierRecommendation,
+} from "./tier-selector.js";
+
+describe("recommendCronTier — explicit hints win (override the cadence default)", () => {
+  it("kind: poll → Tier 0, regardless of cadence", () => {
+    for (const gap of [1, 60, 1440]) {
+      const r = recommendCronTier({ smallestGapMin: gap, kind: "poll" });
+      expect(r.tier).toBe("poll");
+      expect(r.source).toBe("explicit");
+    }
+  });
+
+  it("context: fresh → cheap; context: agent → main (even when cadence would say otherwise)", () => {
+    // context: agent on a frequent cron — explicit beats the frequent→cheap default.
+    expect(recommendCronTier({ smallestGapMin: 5, context: "agent" }).tier).toBe("main");
+    // context: fresh on a daily cron — explicit beats the infrequent→main default.
+    expect(recommendCronTier({ smallestGapMin: 1440, context: "fresh" }).tier).toBe("cheap");
+  });
+
+  it("a known-cheap model → cheap; opus/custom → main", () => {
+    expect(recommendCronTier({ smallestGapMin: 1440, model: "sonnet" }).tier).toBe("cheap");
+    expect(recommendCronTier({ smallestGapMin: 1440, model: "claude-haiku-4-5" }).tier).toBe("cheap");
+    expect(recommendCronTier({ smallestGapMin: 5, model: "opus" }).tier).toBe("main");
+    expect(recommendCronTier({ smallestGapMin: 5, model: "claude-opus-4-8" }).tier).toBe("main");
+    // a custom/unknown id is conservatively the full session, not cheap.
+    expect(recommendCronTier({ smallestGapMin: 5, model: "my-custom-id" }).tier).toBe("main");
+  });
+
+  it("every explicit-hint path is sourced 'explicit'", () => {
+    const explicit: TierRecommendation[] = [
+      recommendCronTier({ smallestGapMin: 5, kind: "poll" }),
+      recommendCronTier({ smallestGapMin: 5, context: "fresh" }),
+      recommendCronTier({ smallestGapMin: 5, context: "agent" }),
+      recommendCronTier({ smallestGapMin: 5, model: "sonnet" }),
+      recommendCronTier({ smallestGapMin: 5, model: "opus" }),
+    ];
+    for (const r of explicit) expect(r.source).toBe("explicit");
+  });
+});
+
+describe("recommendCronTier — cadence default (no explicit hint)", () => {
+  it("frequent (≤ threshold) defaults to cheap", () => {
+    for (const gap of [1, 5, 15, 30, 59, 60]) {
+      const r = recommendCronTier({ smallestGapMin: gap });
+      expect(r.tier).toBe("cheap");
+      expect(r.source).toBe("cadence-default");
+    }
+  });
+
+  it("infrequent (> threshold) defaults to the agent session", () => {
+    for (const gap of [61, 120, 1440, 10080]) {
+      const r = recommendCronTier({ smallestGapMin: gap });
+      expect(r.tier).toBe("main");
+      expect(r.source).toBe("cadence-default");
+    }
+  });
+
+  it("the boundary is inclusive at the threshold (60 → cheap, 61 → main)", () => {
+    expect(recommendCronTier({ smallestGapMin: 60 }).tier).toBe("cheap");
+    expect(recommendCronTier({ smallestGapMin: 61 }).tier).toBe("main");
+  });
+
+  it("respects an overridden threshold", () => {
+    // With a 10-min threshold, a 15-min cron is now 'infrequent' → main.
+    expect(recommendCronTier({ smallestGapMin: 15 }, 10).tier).toBe("main");
+    expect(recommendCronTier({ smallestGapMin: 10 }, 10).tier).toBe("cheap");
+  });
+
+  it("is deterministic — identical input yields identical output", () => {
+    const a = recommendCronTier({ smallestGapMin: 30 });
+    const b = recommendCronTier({ smallestGapMin: 30 });
+    expect(a).toEqual(b);
+  });
+
+  it("always produces a reason string", () => {
+    for (const gap of [5, 60, 61, 1440]) {
+      expect(recommendCronTier({ smallestGapMin: gap }).reason.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("resolveFrequentGapMin", () => {
+  it("defaults to 60 and floors invalid/non-positive overrides", () => {
+    expect(resolveFrequentGapMin({})).toBe(DEFAULT_FREQUENT_GAP_MIN);
+    expect(resolveFrequentGapMin({ SWITCHROOM_CRON_FREQUENT_GAP_MIN: "30" })).toBe(30);
+    expect(resolveFrequentGapMin({ SWITCHROOM_CRON_FREQUENT_GAP_MIN: "0" })).toBe(60);
+    expect(resolveFrequentGapMin({ SWITCHROOM_CRON_FREQUENT_GAP_MIN: "-5" })).toBe(60);
+    expect(resolveFrequentGapMin({ SWITCHROOM_CRON_FREQUENT_GAP_MIN: "nope" })).toBe(60);
+  });
+});

--- a/src/scheduler/tier-selector.test.ts
+++ b/src/scheduler/tier-selector.test.ts
@@ -88,6 +88,26 @@ describe("recommendCronTier — cadence default (no explicit hint)", () => {
       expect(recommendCronTier({ smallestGapMin: gap }).reason.length).toBeGreaterThan(0);
     }
   });
+
+  it("explicit kind: 'prompt' (no model/context) falls through to the cadence default", () => {
+    // 'prompt' is the no-op kind — it must NOT short-circuit; cadence decides.
+    const frequent = recommendCronTier({ smallestGapMin: 5, kind: "prompt" });
+    expect(frequent.tier).toBe("cheap");
+    expect(frequent.source).toBe("cadence-default");
+    const daily = recommendCronTier({ smallestGapMin: 1440, kind: "prompt" });
+    expect(daily.tier).toBe("main");
+    expect(daily.source).toBe("cadence-default");
+  });
+
+  it("degenerate gaps don't crash and resolve deterministically", () => {
+    // smallestGapMin comes from extractCronSmallestGapMin (positive ints) upstream,
+    // but the selector must still be total: 0/negative ≤ threshold → cheap;
+    // NaN/Infinity fail the ≤ comparison → main. Never throws.
+    expect(recommendCronTier({ smallestGapMin: 0 }).tier).toBe("cheap");
+    expect(recommendCronTier({ smallestGapMin: -5 }).tier).toBe("cheap");
+    expect(recommendCronTier({ smallestGapMin: Number.NaN }).tier).toBe("main");
+    expect(recommendCronTier({ smallestGapMin: Number.POSITIVE_INFINITY }).tier).toBe("main");
+  });
 });
 
 describe("resolveFrequentGapMin", () => {

--- a/src/scheduler/tier-selector.ts
+++ b/src/scheduler/tier-selector.ts
@@ -1,0 +1,115 @@
+/**
+ * Deterministic cron tier *selector* — the value-gate from the cheap-crons
+ * JTBD (`reference/crons-use-the-model-only-when-it-earns-it.md`).
+ *
+ * The job: scheduled work should pay for a model only when the model adds
+ * value. Today the cheap tiers are opt-in — an agent or operator must set
+ * `model`/`context`/`kind` — so the *default* is the most expensive tier
+ * (a full live-session turn) for every cron. That fails the Defaults
+ * principle: the cheap, correct behaviour should be chosen for the user,
+ * not configured by them.
+ *
+ * This module takes the tier decision away from the model and makes it a
+ * pure function of observable signals, so the choice is deterministic and
+ * fully enumerable (the operator's bar: be deterministically sure, prove
+ * it by enumeration, never infer determinism from a sampling test). The
+ * agent's explicit hint is an OVERRIDE, never the source of truth.
+ *
+ * Roll-out discipline (also from the JTBD): this is a RECOMMENDATION
+ * surface first. The scheduler logs `recommended` vs what actually fires
+ * (shadow mode) so the divergence and the token/hit-rate it implies can be
+ * measured against the existing audit BEFORE the recommendation is allowed
+ * to drive routing. Nothing here changes a fire's behaviour on its own.
+ *
+ * Signals, in priority order:
+ *   1. Explicit hint (kind / context / known-cheap model) → respected, source=explicit.
+ *   2. Cadence (the smallest gap the cron implies) → the deterministic default.
+ *
+ * Cadence is a deterministic proxy, not ground truth: a frequent cron is
+ * far more likely to be a routine check that doesn't need the agent's full
+ * context than a daily/weekly briefing is. It is the only signal we can read
+ * from the entry WITHOUT a model (reading the prompt's meaning would itself
+ * be a non-deterministic model call — exactly what this job exists to
+ * avoid). The agent/operator overrides per-entry when the proxy is wrong;
+ * shadow mode measures how often it is.
+ */
+
+import { isKnownCheapModel, type CronTier } from "./cron-routing.js";
+
+export type TierSource = "explicit" | "cadence-default";
+
+export interface TierRecommendation {
+  /** poll → Tier 0 (model-free); cheap → Tier 1 (cheap session); main → Tier 2 (live session). */
+  tier: CronTier;
+  /** Where the decision came from: an explicit hint, or the cadence default. */
+  source: TierSource;
+  /** Human-readable justification, surfaced in the recommender + shadow log. */
+  reason: string;
+}
+
+export interface TierSelectorInput {
+  /** The cron's smallest implied gap in minutes (from extractCronSmallestGapMin). */
+  smallestGapMin: number;
+  kind?: "poll" | "prompt";
+  model?: string;
+  context?: "fresh" | "agent";
+}
+
+/**
+ * Default cadence threshold (minutes). A cron whose smallest gap is at or
+ * below this defaults to a cheap session; above it, to the agent session.
+ * One hour is the conservative line: sub-hourly crons are overwhelmingly
+ * routine checks/sweeps (the token sink), while hourly-or-slower are more
+ * often context-dependent briefings. Tunable via env so the shadow data
+ * can move it before enforcement.
+ */
+export const DEFAULT_FREQUENT_GAP_MIN = 60;
+
+export function resolveFrequentGapMin(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number.parseInt(env.SWITCHROOM_CRON_FREQUENT_GAP_MIN ?? "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_FREQUENT_GAP_MIN;
+}
+
+/**
+ * Recommend a tier for a cron entry. Pure and deterministic: same input →
+ * same output, always. Does NOT read env except via the injected
+ * `frequentGapMin` (default resolved by the caller), so it stays a leaf.
+ */
+export function recommendCronTier(
+  input: TierSelectorInput,
+  frequentGapMin: number = DEFAULT_FREQUENT_GAP_MIN,
+): TierRecommendation {
+  // 1. Explicit hints win — the agent/operator asked for a specific tier.
+  if (input.kind === "poll") {
+    return { tier: "poll", source: "explicit", reason: "declared kind: poll (model-free check)" };
+  }
+  if (input.context === "fresh") {
+    return { tier: "cheap", source: "explicit", reason: "declared context: fresh (cheap cron session)" };
+  }
+  if (input.context === "agent") {
+    return { tier: "main", source: "explicit", reason: "declared context: agent (full live session)" };
+  }
+  if (input.model !== undefined) {
+    return isKnownCheapModel(input.model)
+      ? { tier: "cheap", source: "explicit", reason: `cheap model '${input.model}' → cheap cron session` }
+      : { tier: "main", source: "explicit", reason: `model '${input.model}' is not a known-cheap id → full live session` };
+  }
+
+  // 2. No explicit hint — the cadence default. Deterministic from the cron.
+  if (input.smallestGapMin <= frequentGapMin) {
+    return {
+      tier: "cheap",
+      source: "cadence-default",
+      reason:
+        `fires every ~${input.smallestGapMin}min (≤ ${frequentGapMin}min) — defaulting to a cheap ` +
+        `session; set context: agent (or an Opus/custom model) if this needs the agent's full context`,
+    };
+  }
+  return {
+    tier: "main",
+    source: "cadence-default",
+    reason:
+      `fires every ~${input.smallestGapMin}min (> ${frequentGapMin}min) — defaulting to the agent's ` +
+      `full session; set model: sonnet (or context: fresh) to run it cheaply`,
+  };
+}


### PR DESCRIPTION
First step of the **cheap-crons JTBD** value-gate (`reference/crons-use-the-model-only-when-it-earns-it.md`, PR #2296).

## Why

Today the cheap cron tiers are opt-in — every cron defaults to the most expensive tier (full live-session turn). That fails the **Defaults** principle: the cheap-correct behaviour should be chosen *for* the user. This takes the tier decision **away from the model** and makes it a pure, deterministic function — the foundation for making cheap the default.

## What

`recommendCronTier(input)` → `{tier, source, reason}`, deterministic:
1. **Explicit hints win** (kind/context/known-cheap model) → `source: explicit`.
2. **Cadence default** (no hint): sub-hourly (the token sink) → cheap session; hourly-or-slower → agent session. Threshold tunable via `SWITCHROOM_CRON_FREQUENT_GAP_MIN`.

Cadence is the only signal readable from the entry **without a model** (reading the prompt's meaning would itself be a non-deterministic model call — the thing the job avoids). The agent's hint overrides per-entry.

**Changes no behaviour on its own** — it's a recommendation. The next step wires it as a **shadow log** (recommended vs actual + the audit's cost/hit-rate) to measure divergence before it's allowed to drive routing, per the JTBD's shadow-first discipline.

## Test plan

- [x] Decision space **fully enumerated** (operator's determinism bar): explicit-hint precedence, cadence boundary (60→cheap, 61→main), threshold override, determinism, reason always present. 11 tests green; tsc clean.

## Follow-up

(1) shadow-log wiring in the fire path; (2) flip the cadence default to drive routing after shadow data; (3) the model-free **action** tier (mechanical crons at zero tokens).