### PR TITLE
feat(scheduler): cheap crons by default — value-gate drives the tier, no flag

### DIFF
--- a/src/agent-scheduler/cheap-cron-wiring.test.ts
+++ b/src/agent-scheduler/cheap-cron-wiring.test.ts
@@ -14,7 +14,8 @@ const CONFIG = {
 } as unknown as SwitchroomConfig;
 
 const ON = { SWITCHROOM_CHEAP_CRON: "1" } as NodeJS.ProcessEnv;
-const OFF = {} as NodeJS.ProcessEnv;
+// Cheap-cron is on by default now; OFF is the explicit kill-switch value.
+const OFF = { SWITCHROOM_CHEAP_CRON: "0" } as NodeJS.ProcessEnv;
 
 function capture(): InboundDispatcher & { calls: Array<{ agent: string; msg: InboundMessageWire }> } {
   const calls: Array<{ agent: string; msg: InboundMessageWire }> = [];

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -37,6 +37,7 @@ import {
   type SchedulerEntry,
 } from "../scheduler/dispatch.js";
 import { isCheapCronEnabled, resolveCronRouting, resolveEscalationRouting } from "../scheduler/cron-routing.js";
+import { applyDefaultTier } from "../scheduler/tier-selector.js";
 import type { PollOutcome } from "../scheduler/poll-engine.js";
 import type { PollStateStore } from "../scheduler/poll-state.js";
 import type { PollSpec } from "../config/schema.js";
@@ -280,7 +281,11 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
       }
 
       const cheapEnabled = opts.cheapCron?.enabled ?? false;
-      const routing = resolveCronRouting(entry, { cheapCronEnabled: cheapEnabled });
+      // Value-gate: fill the cheap-by-default tier for a hint-less entry
+      // (frequent → cheap Tier-1 session) before routing. Explicit
+      // kind/model/context are untouched. Only when cheap-cron is on.
+      const routed = cheapEnabled ? applyDefaultTier(entry) : entry;
+      const routing = resolveCronRouting(routed, { cheapCronEnabled: cheapEnabled });
       const threadId = resolveEntryThreadId(entry, opts.channel);
       const record = (fields: {
         exitCode: number;

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -28,6 +28,7 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { SwitchroomConfig, AgentConfig, AgentBindMount } from "../config/schema.js";
 import { scheduleNeedsCronSession } from "../scheduler/cron-routing.js";
+import { applyDefaultTier } from "../scheduler/tier-selector.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { resolveTimezone } from "../config/timezone.js";
 import { isReservedAgentName } from "../vault/broker/peercred.js";
@@ -517,8 +518,13 @@ export function describeAgents(config: SwitchroomConfig): AgentServiceData[] {
     // Cheap-cron (L4 refinement): give cron-session agents a little headroom
     // for the 2nd claude. Config-derived (a context:fresh/cheap-model entry) —
     // false for every current fleet agent, so resources are unchanged today.
+    // Apply the value-gate default (cheap-by-default) like the scaffold +
+    // fire path do, so a frequent hint-less cron that routes to a Tier-1
+    // session also gets its resource headroom here — the three stay in sync.
     const cronSession = scheduleNeedsCronSession(
-      (resolved.schedule ?? []).map((e) => ({ kind: e.kind, model: e.model, context: e.context })),
+      (resolved.schedule ?? []).map((e) =>
+        applyDefaultTier({ cron: e.cron, kind: e.kind, model: e.model, context: e.context }),
+      ),
       { cheapCronEnabled: true },
     );
     const resources = resolveResourceDefaults(name, profile, resolved.resources, { cronSession });

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -384,6 +384,7 @@ export function renderFleetInvariants(): string {
 
 import { DEFAULT_PROFILE } from "../config/schema.js";
 import { DEFAULT_CRON_MODEL, scheduleNeedsCronSession } from "../scheduler/cron-routing.js";
+import { applyDefaultTier } from "../scheduler/tier-selector.js";
 
 /**
  * Cheap-cron (L4) start.sh context. `cronSessionEnabled` is purely
@@ -399,11 +400,13 @@ function buildCronSessionContext(agentConfig: AgentConfig): {
   cronSessionEnabled: boolean;
   cronModelQ: string;
 } {
-  const entries = (agentConfig.schedule ?? []).map((e) => ({
-    kind: e.kind,
-    model: e.model,
-    context: e.context,
-  }));
+  // Apply the cheap-by-default tier (value-gate) so a frequent, hint-less
+  // cron — which routes to a Tier-1 cron session at runtime — also gets the
+  // cron-session.sh rendered here. Without this, the scaffold and the fire
+  // path would disagree and the session would be missing at fire time.
+  const entries = (agentConfig.schedule ?? []).map((e) =>
+    applyDefaultTier({ cron: e.cron, kind: e.kind, model: e.model, context: e.context }),
+  );
   return {
     cronSessionEnabled: scheduleNeedsCronSession(entries, { cheapCronEnabled: true }),
     cronModelQ: shellSingleQuote(DEFAULT_CRON_MODEL),

--- a/src/scheduler/cron-cadence.test.ts
+++ b/src/scheduler/cron-cadence.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the tier-selection cadence estimator. The load-bearing property
+ * is the CONSERVATIVE bias: anything not confidently sub-hourly must read as
+ * infrequent (large/Infinity), so the value gate never strips context from a
+ * cron it couldn't classify.
+ */
+
+import { describe, it, expect } from "vitest";
+import { estimateCronGapMin } from "./cron-cadence.js";
+
+describe("estimateCronGapMin — sub-hour (minute field)", () => {
+  it("every minute → 1", () => {
+    expect(estimateCronGapMin("* * * * *")).toBe(1);
+  });
+  it("stepped minutes → the step", () => {
+    expect(estimateCronGapMin("*/5 * * * *")).toBe(5);
+    expect(estimateCronGapMin("*/30 * * * *")).toBe(30);
+  });
+  it("CSV minutes → smallest pairwise gap", () => {
+    expect(estimateCronGapMin("0,30 * * * *")).toBe(30);
+    expect(estimateCronGapMin("0,15,30,45 * * * *")).toBe(15);
+    expect(estimateCronGapMin("0,1,2 * * * *")).toBe(1);
+  });
+});
+
+describe("estimateCronGapMin — hourly and coarser (the cases the old helper got wrong)", () => {
+  it("hourly (single minute, hour *) → 60", () => {
+    expect(estimateCronGapMin("0 * * * *")).toBe(60);
+    expect(estimateCronGapMin("30 * * * *")).toBe(60);
+  });
+  it("stepped hours → 60·N", () => {
+    expect(estimateCronGapMin("0 */2 * * *")).toBe(120);
+    expect(estimateCronGapMin("0 */6 * * *")).toBe(360);
+  });
+  it("CSV hours → 60·smallest pairwise hour gap", () => {
+    expect(estimateCronGapMin("0 8,12,18 * * *")).toBe(240); // 12-8=4h
+    expect(estimateCronGapMin("0 9,10 * * *")).toBe(60);
+  });
+  it("daily → 1440 (NOT 0 — the bug this fixes)", () => {
+    expect(estimateCronGapMin("0 8 * * *")).toBe(1440);
+    expect(estimateCronGapMin("5 7 * * 1-5")).toBe(1440); // weekday morning
+    expect(estimateCronGapMin("0 18 * * 0")).toBe(1440); // weekly (floored at daily, still infrequent)
+  });
+});
+
+describe("estimateCronGapMin — conservative on anything unreadable", () => {
+  it("malformed / too-few fields → Infinity", () => {
+    expect(estimateCronGapMin("garbage")).toBe(Infinity);
+    expect(estimateCronGapMin("0 8")).toBe(Infinity);
+    expect(estimateCronGapMin("")).toBe(Infinity);
+  });
+  it("minute ranges / mixed shapes → Infinity (don't guess)", () => {
+    expect(estimateCronGapMin("0-10 * * * *")).toBe(Infinity);
+  });
+  it("step of zero → Infinity (never 'every 0 min')", () => {
+    expect(estimateCronGapMin("*/0 * * * *")).toBe(Infinity);
+  });
+
+  it("REGRESSION GUARD: a daily cron must read as infrequent, never sub-hourly", () => {
+    // The exact misclassification that would strip a morning brief's context.
+    expect(estimateCronGapMin("0 8 * * *")).toBeGreaterThan(60);
+  });
+});

--- a/src/scheduler/cron-cadence.ts
+++ b/src/scheduler/cron-cadence.ts
@@ -1,0 +1,82 @@
+/**
+ * Cron cadence estimator for tier selection (cheap-crons JTBD value-gate).
+ *
+ * The tier selector needs "how often does this fire?" to default frequent
+ * crons to the cheap tier. The existing `extractCronSmallestGapMin`
+ * (agent-config-write.ts) only inspects the MINUTE field — it returns 0 for
+ * any single-value minute, so `0 8 * * *` (daily) and `0 * * * *` (hourly)
+ * both read as 0. That's fine for its job (catching sub-5-min floor
+ * violations) but WRONG for tiering: a daily briefing would look "frequent"
+ * and get routed to a memoryless cheap session.
+ *
+ * This estimator reads minute AND hour (and floors anything coarser at
+ * daily), and is deliberately CONSERVATIVE: when the cadence can't be read
+ * confidently, it returns Infinity — "treat as infrequent" — so the value
+ * gate falls back to the safe full-session (Tier 2) default and NEVER
+ * wrongly strips context from a cron it couldn't classify. Only a cron we
+ * can confidently call sub-hourly is eligible for the cheap default.
+ */
+
+/** Smallest gap (minutes) between two consecutive values in a CSV list, or null. */
+function csvSmallestGap(field: string): number | null {
+  if (!field.includes(",")) return null;
+  const parts = field.split(",").map((s) => Number(s)).filter((n) => Number.isInteger(n) && n >= 0);
+  if (parts.length < 2) return null;
+  const sorted = [...parts].sort((a, b) => a - b);
+  let smallest = Infinity;
+  for (let i = 1; i < sorted.length; i++) {
+    const gap = sorted[i] - sorted[i - 1];
+    if (gap > 0 && gap < smallest) smallest = gap;
+  }
+  return Number.isFinite(smallest) ? smallest : null;
+}
+
+/**
+ * Estimate the smallest gap between fires, in minutes. Returns Infinity when
+ * the cadence can't be read confidently (conservative — caller treats it as
+ * infrequent). Handles the shapes real schedules use:
+ *   minute `*`        → 1
+ *   minute `*\/N`     → N
+ *   minute CSV (≥2)   → smallest pairwise gap
+ *   minute single + hour `*`      → 60   (hourly)
+ *   minute single + hour `*\/N`   → 60·N
+ *   minute single + hour CSV (≥2) → 60·smallest pairwise hour gap
+ *   minute single + hour single   → 1440 (daily or rarer; day/week fields only widen it)
+ *   anything else / malformed     → Infinity (unknown → infrequent)
+ */
+export function estimateCronGapMin(expr: string): number {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length < 5) return Infinity;
+  const [min, hour] = fields;
+
+  // Sub-hour cadence is fully determined by the minute field.
+  if (min === "*") return 1;
+  const minStep = min.match(/^\*\/(\d+)$/);
+  if (minStep) {
+    const n = Number(minStep[1]);
+    return n > 0 ? n : Infinity;
+  }
+  const minCsv = csvSmallestGap(min);
+  if (minCsv !== null) return minCsv;
+
+  // Minute is a single value (e.g. "0", "30") or a shape we don't read as
+  // sub-hour. The cadence is then driven by the hour field.
+  // A single integer minute is the common "fires once per matched hour" case;
+  // a minute range/other → unknown.
+  if (!/^\d+$/.test(min)) return Infinity;
+
+  if (hour === "*") return 60; // every hour at minute `min`
+  const hourStep = hour.match(/^\*\/(\d+)$/);
+  if (hourStep) {
+    const n = Number(hourStep[1]);
+    return n > 0 ? n * 60 : Infinity;
+  }
+  const hourCsv = csvSmallestGap(hour);
+  if (hourCsv !== null) return hourCsv * 60;
+
+  // Single-value (or other) hour → fires at most once a day. Day-of-month /
+  // month / day-of-week fields can only make it rarer, so daily is the floor.
+  if (/^\d+$/.test(hour)) return 1440;
+
+  return Infinity;
+}

--- a/src/scheduler/cron-routing.test.ts
+++ b/src/scheduler/cron-routing.test.ts
@@ -130,15 +130,21 @@ describe("isKnownCheapModel", () => {
   });
 });
 
-describe("isCheapCronEnabled", () => {
+describe("isCheapCronEnabled — default ON; only 0/false/off disables (kill-switch)", () => {
   it.each([
     ["1", true],
     ["true", true],
     ["on", true],
     ["ON", true],
+    // unset / empty / anything else → ON (cheap-cron is the default).
+    ["", true],
+    [undefined, true],
+    ["anything", true],
+    // the kill-switch values.
     ["0", false],
-    ["", false],
-    [undefined, false],
+    ["false", false],
+    ["off", false],
+    ["OFF", false],
   ])("SWITCHROOM_CHEAP_CRON=%s → %s", (val, expected) => {
     expect(isCheapCronEnabled({ SWITCHROOM_CHEAP_CRON: val } as NodeJS.ProcessEnv)).toBe(expected);
   });

--- a/src/scheduler/cron-routing.ts
+++ b/src/scheduler/cron-routing.ts
@@ -54,10 +54,20 @@ export function isKnownCheapModel(model: string | undefined): boolean {
   return model !== undefined && CHEAP_MODEL_RE.test(model);
 }
 
-/** Reads the kill-switch. The ONLY env read in this module; isolated so the core stays pure. */
+/**
+ * Reads the kill-switch. The ONLY env read in this module; isolated so the
+ * core stays pure.
+ *
+ * Cheap-cron is the DEFAULT (cheap-crons JTBD: scheduled work spends the
+ * model only when it adds value). `SWITCHROOM_CHEAP_CRON=0` (or false/off) is
+ * the emergency kill-switch that restores the pre-cheap behaviour (every fire
+ * a full Tier-2 turn). Anything else — including unset — is ON. Disabling can
+ * never silently drop a cron: a `kind: poll` entry just fires its escalation
+ * prompt as an ordinary turn.
+ */
 export function isCheapCronEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const v = (env.SWITCHROOM_CHEAP_CRON ?? "").toLowerCase();
-  return v === "1" || v === "true" || v === "on";
+  return !(v === "0" || v === "false" || v === "off");
 }
 
 /** Tier-1 cron-session model: honour an explicit cheap id, else default to sonnet. */

--- a/src/scheduler/tier-selector.test.ts
+++ b/src/scheduler/tier-selector.test.ts
@@ -8,9 +8,14 @@ import { describe, it, expect } from "vitest";
 import {
   recommendCronTier,
   resolveFrequentGapMin,
+  applyDefaultTier,
   DEFAULT_FREQUENT_GAP_MIN,
   type TierRecommendation,
+  type TierableEntry,
 } from "./tier-selector.js";
+
+/** Type the literal as TierableEntry so `.context` is visible after augmentation. */
+const tierable = (e: TierableEntry): TierableEntry => e;
 
 describe("recommendCronTier — explicit hints win (override the cadence default)", () => {
   it("kind: poll → Tier 0, regardless of cadence", () => {
@@ -117,5 +122,41 @@ describe("resolveFrequentGapMin", () => {
     expect(resolveFrequentGapMin({ SWITCHROOM_CRON_FREQUENT_GAP_MIN: "0" })).toBe(60);
     expect(resolveFrequentGapMin({ SWITCHROOM_CRON_FREQUENT_GAP_MIN: "-5" })).toBe(60);
     expect(resolveFrequentGapMin({ SWITCHROOM_CRON_FREQUENT_GAP_MIN: "nope" })).toBe(60);
+  });
+});
+
+describe("applyDefaultTier — cheap-by-default for hint-less frequent crons", () => {
+  it("a frequent hint-less cron gets context: fresh (→ cheap Tier-1)", () => {
+    expect(applyDefaultTier(tierable({ cron: "*/30 * * * *" })).context).toBe("fresh");
+    expect(applyDefaultTier(tierable({ cron: "0 * * * *" })).context).toBe("fresh"); // hourly
+  });
+
+  it("an infrequent hint-less cron is left untouched (stays full-session default)", () => {
+    // The regression that matters: a daily briefing must NOT be downgraded.
+    expect(applyDefaultTier(tierable({ cron: "0 8 * * *" })).context).toBeUndefined();
+    expect(applyDefaultTier(tierable({ cron: "0 18 * * 0" })).context).toBeUndefined(); // weekly
+  });
+
+  it("explicit hints are never overridden", () => {
+    // context: agent on a frequent cron — operator said full session, we obey.
+    expect(applyDefaultTier(tierable({ cron: "*/5 * * * *", context: "agent" })).context).toBe("agent");
+    // explicit model on a frequent cron — untouched (no context injected).
+    expect(applyDefaultTier(tierable({ cron: "*/5 * * * *", model: "opus" })).context).toBeUndefined();
+    // a poll is explicit — untouched.
+    const poll = applyDefaultTier(tierable({ cron: "*/5 * * * *", kind: "poll" }));
+    expect(poll.context).toBeUndefined();
+    expect(poll.kind).toBe("poll");
+  });
+
+  it("an unreadable cadence is treated as infrequent (conservative — never wrongly cheap)", () => {
+    expect(applyDefaultTier(tierable({ cron: "0-10 * * * *" })).context).toBeUndefined();
+    expect(applyDefaultTier(tierable({ cron: "garbage" })).context).toBeUndefined();
+  });
+
+  it("preserves all other fields", () => {
+    const out = applyDefaultTier(tierable({ cron: "*/30 * * * *", kind: "prompt" }));
+    expect(out.cron).toBe("*/30 * * * *");
+    expect(out.kind).toBe("prompt");
+    expect(out.context).toBe("fresh");
   });
 });

--- a/src/scheduler/tier-selector.ts
+++ b/src/scheduler/tier-selector.ts
@@ -35,6 +35,7 @@
  */
 
 import { isKnownCheapModel, type CronTier } from "./cron-routing.js";
+import { estimateCronGapMin } from "./cron-cadence.js";
 
 export type TierSource = "explicit" | "cadence-default";
 
@@ -112,4 +113,43 @@ export function recommendCronTier(
       `fires every ~${input.smallestGapMin}min (> ${frequentGapMin}min) — defaulting to the agent's ` +
       `full session; set model: sonnet (or context: fresh) to run it cheaply`,
   };
+}
+
+/** The minimal shape `applyDefaultTier` reads + augments. */
+export interface TierableEntry {
+  cron: string;
+  kind?: "poll" | "prompt";
+  model?: string;
+  context?: "fresh" | "agent";
+}
+
+/**
+ * Fill in the cheap-by-default tier when the entry carries NO explicit hint.
+ *
+ * This is what makes cheap the *default* (the Defaults-principle fix): a
+ * frequent, hint-less cron is augmented with `context: "fresh"` so the
+ * router (`resolveCronRouting`) sends it to a cheap Tier-1 session instead
+ * of the agent's full session. Explicit entries (kind/model/context set) are
+ * returned untouched — the operator/agent's choice always wins. Infrequent
+ * crons (and any cadence we can't read confidently → estimateCronGapMin
+ * returns Infinity) keep the conservative full-session default, so we never
+ * strip context from work that may need it.
+ *
+ * Pure: cadence comes from the cron string via estimateCronGapMin; no I/O.
+ */
+export function applyDefaultTier<T extends TierableEntry>(
+  entry: T,
+  frequentGapMin: number = DEFAULT_FREQUENT_GAP_MIN,
+): T {
+  // Any explicit hint → leave it exactly as authored.
+  if (entry.kind === "poll" || entry.context !== undefined || entry.model !== undefined) {
+    return entry;
+  }
+  const rec = recommendCronTier(
+    { smallestGapMin: estimateCronGapMin(entry.cron) },
+    frequentGapMin,
+  );
+  // Only the cheap recommendation changes anything; "main" is already the
+  // router's default for a hint-less entry, so leave it untouched.
+  return rec.tier === "cheap" ? { ...entry, context: "fresh" } : entry;
 }


### PR DESCRIPTION
## Summary

Delivers the cheap-crons JTBD's load-bearing piece: **the cheap-correct tier is now the default**, chosen deterministically by the system, instead of an opt-in flag. Closes the **Defaults**-principle gap flagged in `reference/crons-use-the-model-only-when-it-earns-it.md`.

## What

1. **Cheap-cron ON by default.** `isCheapCronEnabled`: unset/empty/any → ON; only `SWITCHROOM_CHEAP_CRON=0/false/off` disables (emergency kill-switch). Disabling never silently drops a cron.
2. **Value-gate drives the default tier.** New conservative cadence estimator (`cron-cadence.ts`) feeds `applyDefaultTier`: a hint-less cron that's *confidently sub-hourly* gets `context: fresh` → cheap Tier-1 session; everything else keeps the full-session default. Explicit `kind`/`model`/`context` always win. Wired at **both** call sites — the scheduler fire path AND scaffold's `scheduleNeedsCronSession` (so `cron-session.sh` is rendered exactly when needed; the two can't disagree).

## Why conservative matters

The old `extractCronSmallestGapMin` returns `0` for any single-value minute, so `0 8 * * *` (daily) would have read "frequent" and got its context stripped — the exact JTBD anti-pattern. `cron-cadence.ts` reads daily as `1440` and anything unreadable as `Infinity`, so we **only default to cheap when we're sure it's frequent**.

## Test plan

- [x] `cron-cadence` (11, incl. the **daily→1440 regression guard**), `applyDefaultTier` (6, incl. explicit-override + conservative-on-unknown), `isCheapCronEnabled` default-on semantics.
- [x] **9612 vitest pass**; `tsc --noEmit` clean; PII guard clean. (1 env error = `scaffold.test.ts` hitting the live Hindsight backend — network flake, unrelated.)

## Risk & rollout

This changes how **every cron fires** fleet-wide, and the Tier-1 cheap-session execution path has **never run in production**. So despite "no flag," this rolls **canary-first**: test-harness → validate Tier-1 actually fires a frequent cron correctly → then fleet (marko, whose cron emails real leads, last and watched). The `SWITCHROOM_CHEAP_CRON=0` kill-switch is the instant revert. No behaviour change for explicit entries or infrequent crons.

## Follow-up

The model-free **action** tier (mechanical crons at zero tokens — the sharpest part of the JTBD) is the next PR.