### PR TITLE
fix(scheduler): cheap-by-default robust — graceful Tier-1 fallback + reconcile classify

### DIFF
--- a/src/agents/cron-hot-reload.test.ts
+++ b/src/agents/cron-hot-reload.test.ts
@@ -27,6 +27,16 @@ describe("classifyChangeKind", () => {
     expect(classifyChangeKind("/state/agents/foo/.mcp.json")).toBe("settings");
   });
 
+  it("tags .claude-cron/ (Tier-1 cron-session infra) as cron, not settings", () => {
+    // Regression: the cron-session trimmed MCP is rendered when a cron routes
+    // to a cheap session. It must classify as cron so a cron-only reconcile
+    // (agent self-authoring a frequent cron) accepts it — otherwise the
+    // .mcp.json rule below would tag it "settings" and the add fails.
+    expect(classifyChangeKind("/state/agents/foo/.claude-cron/.mcp.json")).toBe("cron");
+    // The main agent's .mcp.json is still settings (not under .claude-cron).
+    expect(classifyChangeKind("/state/agents/foo/.mcp.json")).toBe("settings");
+  });
+
   it("tags .claude/skills/ payload as skill", () => {
     expect(classifyChangeKind("/state/agents/foo/.claude/skills/humanizer/SKILL.md")).toBe("skill");
   });

--- a/src/agents/lifecycle.ts
+++ b/src/agents/lifecycle.ts
@@ -804,6 +804,13 @@ export function classifyChangeKind(path: string): ChangeKind {
   // the new form remains on disk. The shared regex lives in
   // `cron-unit-name.ts` so all classifiers stay in lockstep.
   if (/\/telegram\/cron-(?:\d+|[0-9a-f]{12})\.sh$/.test(path)) return "cron";
+  // Cron-session (Tier-1) infrastructure: the trimmed `.claude-cron/.mcp.json`
+  // (+ cron-session.sh) are rendered when a cron routes to a cheap session.
+  // They are a deterministic consequence of a CRON change (the value-gate
+  // flipping a frequent cron to Tier-1), so classify them as cron — otherwise
+  // the `.mcp.json` rule below tags them "settings" and a cron-only reconcile
+  // refuses the change, breaking agent self-authoring of frequent crons.
+  if (path.includes("/.claude-cron/")) return "cron";
   if (path.includes("/.claude/skills/")) return "skill";
   if (path.endsWith("/.claude/settings.json")) return "settings";
   if (path.endsWith("/.mcp.json")) return "settings";

--- a/telegram-plugin/gateway/cron-session.ts
+++ b/telegram-plugin/gateway/cron-session.ts
@@ -43,3 +43,37 @@ export function baseAgent(name: string): string {
 export function resolveInjectTarget(agentName: string, meta: Record<string, string> | undefined): string {
   return meta?.session === "cron" ? cronIdentity(agentName) : agentName;
 }
+
+export interface InjectDelivery {
+  /** The bridge identity the fire was actually delivered to (or last tried). */
+  target: string;
+  delivered: boolean;
+  /** True iff a Tier-1 (cron) fire fell back to the main agent bridge. */
+  fellBackToMain: boolean;
+}
+
+/**
+ * Deliver an inject with graceful Tier-1 fallback (cheap-crons JTBD: a cron
+ * must NEVER be dropped because of tier routing).
+ *
+ * Tries the routed target via `send` (returns true iff delivered). The
+ * cron-session bridge is boot-forked, so a frequent cron added by hot-reload
+ * or agent self-authoring has no live `<agent>-cron` bridge until the next
+ * restart — and a crashed cron session has none either. When a cron-routed
+ * fire isn't delivered, fall back to the MAIN agent bridge so the fire lands
+ * now (full session); it routes cheap again once the cron session is up.
+ * Cheap when available, never broken. Pure: `send` is injected.
+ */
+export function deliverInjectWithFallback(
+  agentName: string,
+  meta: Record<string, string> | undefined,
+  send: (target: string) => boolean,
+): InjectDelivery {
+  const target = resolveInjectTarget(agentName, meta);
+  const wantedCron = target !== agentName;
+  if (send(target)) return { target, delivered: true, fellBackToMain: false };
+  if (wantedCron && send(agentName)) {
+    return { target: agentName, delivered: true, fellBackToMain: true };
+  }
+  return { target, delivered: false, fellBackToMain: false };
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -299,7 +299,7 @@ import { handleRequestDriveApproval } from './drive-write-approval.js'
 import { handleRequestMs365Approval } from './ms365-write-approval.js'
 import { buildDiffPreviewCard } from './diff-preview-card.js'
 import { createPendingInboundBuffer, redeliverBufferedInbound, idleDrainTick } from './pending-inbound-buffer.js'
-import { isCronIdentity, resolveInjectTarget } from './cron-session.js'
+import { isCronIdentity, deliverInjectWithFallback } from './cron-session.js'
 import {
   ObligationLedger,
   buildObligationRepresentInbound,
@@ -6425,19 +6425,34 @@ const ipcServer: IpcServer = createIpcServer({
     // unchanged. Route+buffer share the same target so a fire that lands
     // mid cron-session-spawn buffers under the cron identity and drains to
     // it on register.
-    const target = resolveInjectTarget(msg.agentName, msg.inbound.meta)
-    const toCron = target !== msg.agentName
-    const delivered = ipcServer.sendToAgent(target, msg.inbound)
-    // Status-silent (§2.4): a cron fire must NOT set the MAIN agent's
-    // currentTurn (progress card / silence-poke). The cron session is
-    // fire-and-forget; its reply is its only Telegram surface.
-    if (delivered && !toCron) markClaudeBusyForInbound(msg.inbound)
+    // Graceful Tier-1 fallback (cheap-crons JTBD: a cron must NEVER be
+    // dropped because of tier routing). A cron-routed fire whose `<agent>-cron`
+    // bridge isn't connected (boot-forked session not up yet for a hot-added
+    // frequent cron, or a crashed cron session) falls back to the MAIN agent
+    // bridge so the fire lands now; it routes cheap again once the session is
+    // up. See deliverInjectWithFallback.
+    const { target, delivered, fellBackToMain } = deliverInjectWithFallback(
+      msg.agentName,
+      msg.inbound.meta,
+      (t) => ipcServer.sendToAgent(t, msg.inbound),
+    )
+    if (fellBackToMain) {
+      process.stderr.write(
+        `telegram gateway: cron fire fell back to main session (no cron bridge) agent=${msg.agentName} prompt_key=${promptKey}\n`,
+      )
+    }
+    // Status-silent (§2.4): a cron fire delivered to the CRON session must NOT
+    // set the MAIN agent's currentTurn. But a fire that LANDED on the main
+    // bridge (a non-cron fire, or one that fell back) IS a main-session turn —
+    // surface it on the progress card, or the session looks dark.
+    if (delivered && target === msg.agentName) markClaudeBusyForInbound(msg.inbound)
     process.stderr.write(
-      `telegram gateway: inject_inbound agent=${msg.agentName} target=${target} source=${source} prompt_key=${promptKey} delivered=${delivered}\n`,
+      `telegram gateway: inject_inbound agent=${msg.agentName} target=${target}${fellBackToMain ? " (fellback)" : ""} source=${source} prompt_key=${promptKey} delivered=${delivered}\n`,
     )
     // #1150: same buffer-on-failure pattern as vault_grant_approved.
-    // Cron fires use this path too — if a cron-driven wake-up lands
-    // mid bridge-reconnect, buffer it for the next register.
+    // Only reached if BOTH the cron bridge and the main bridge are down
+    // (e.g. mid-restart) — buffer under the bridge we tried last so it
+    // drains on the next register.
     if (!delivered) {
       pendingInboundBuffer.push(target, msg.inbound)
     }

--- a/telegram-plugin/tests/cron-session.test.ts
+++ b/telegram-plugin/tests/cron-session.test.ts
@@ -5,6 +5,7 @@ import {
   cronIdentity,
   isCronIdentity,
   resolveInjectTarget,
+  deliverInjectWithFallback,
 } from '../gateway/cron-session.js'
 
 describe('cron-session identity helpers', () => {
@@ -28,5 +29,40 @@ describe('cron-session identity helpers', () => {
     expect(resolveInjectTarget('clerk', undefined)).toBe('clerk')
     // back-compat: every legacy caller (no session) is unchanged.
     expect(resolveInjectTarget('clerk', { source: 'telegram' })).toBe('clerk')
+  })
+})
+
+describe('deliverInjectWithFallback — a cron fire is never dropped by tier routing', () => {
+  it('delivers to the cron bridge when it is connected', () => {
+    const sent: string[] = []
+    const r = deliverInjectWithFallback('clerk', { session: 'cron' }, (t) => (sent.push(t), true))
+    expect(r).toEqual({ target: 'clerk-cron', delivered: true, fellBackToMain: false })
+    expect(sent).toEqual(['clerk-cron']) // tried cron only; it delivered
+  })
+
+  it('falls back to the MAIN bridge when the cron bridge is not connected', () => {
+    // The exact gap: a hot-added / agent-authored frequent cron whose
+    // boot-forked cron session isn't up. Must land on main, not vanish.
+    const sent: string[] = []
+    const r = deliverInjectWithFallback('clerk', { session: 'cron' }, (t) => {
+      sent.push(t)
+      return t === 'clerk' // cron bridge down, main up
+    })
+    expect(r).toEqual({ target: 'clerk', delivered: true, fellBackToMain: true })
+    expect(sent).toEqual(['clerk-cron', 'clerk']) // tried cron, then fell back to main
+  })
+
+  it('reports not-delivered only when BOTH cron and main are down (then it buffers)', () => {
+    const sent: string[] = []
+    const r = deliverInjectWithFallback('clerk', { session: 'cron' }, (t) => (sent.push(t), false))
+    expect(r).toEqual({ target: 'clerk-cron', delivered: false, fellBackToMain: false })
+    expect(sent).toEqual(['clerk-cron', 'clerk']) // tried both, both down
+  })
+
+  it('a non-cron (main) fire never tries a fallback', () => {
+    const sent: string[] = []
+    const r = deliverInjectWithFallback('clerk', { session: 'main' }, (t) => (sent.push(t), false))
+    expect(r).toEqual({ target: 'clerk', delivered: false, fellBackToMain: false })
+    expect(sent).toEqual(['clerk']) // only the main bridge, no cron fallback attempted
   })
 })


### PR DESCRIPTION
## Summary

Unblocks the cheap-by-default rollout. The v0.15.9 **canary on test-harness caught a fleet-breaker** (before any real agent saw it): the cheap Tier-1 cron session is **boot-forked**, so a frequent cron added by hot-reload or agent self-authoring has no live `<agent>-cron` bridge — and (a) the add failed `E_RECONCILE_FAILED`, (b) the fire would buffer under the cron identity forever. Two coupled fixes make cheap-by-default durable.

## What

1. **Graceful Tier-1 fallback (gateway).** New pure `deliverInjectWithFallback`: a cron-routed fire whose cron bridge isn't connected **falls back to the MAIN agent bridge** so the fire ALWAYS lands instead of vanishing. Routes cheap again once the session is up. *Cheap when available, never broken* — the JTBD's core invariant. A fire landing on main correctly drives the progress card; cron-session fires stay status-silent (§2.4).
2. **Reconcile classification.** `classifyChangeKind` tags `.claude-cron/` (Tier-1 trimmed MCP + cron-session.sh) as `cron`, not `settings`, so a cron-only reconcile (agent self-authoring a frequent cron) accepts it instead of rejecting + rolling back. `applyCronChangesHot` is non-destructive (logs only) → safe.

## End-to-end after this

Agent adds a frequent cron → reconcile passes → fires on the main session immediately (fallback) → goes cheap automatically once the next restart forks the cron session. **Never breaks.**

## Test plan

- [x] `deliverInjectWithFallback` (4 cases: cron-up delivers, cron-down→main fallback, both-down→buffer, main-fire→no fallback).
- [x] `classifyChangeKind` `.claude-cron/`→cron (+ main `.mcp.json` still settings).
- [x] tsc + plugin-references + bot-api-wrapping guards clean; 61 plugin + scheduler/agents suites green.

## Rollout

Re-canary on test-harness — this time **add a frequent cron and confirm it fires** (via fallback) and the cron session spawns on restart → then fleet (marko last). The `SWITCHROOM_CHEAP_CRON=0` kill-switch remains the revert.