### PR TITLE
fix(scheduler): cron-session shell gate defaults ON (mirror isCheapCronEnabled)

### DIFF
--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -17,15 +17,19 @@
 set -u
 
 # Runtime kill-switch. The fork is baked into start.sh whenever {{name}} has a
-# context:fresh cron entry (a config property), but the session only actually
-# runs when SWITCHROOM_CHEAP_CRON is on at runtime. Exit 78 (EX_CONFIG) so the
-# supervisor does NOT respawn-loop when the feature is off — a clean idle.
+# cron entry the value-gate routes to a cheap session, but the session only
+# actually runs when cheap-cron is enabled at runtime. Cheap-cron is ON by
+# DEFAULT (matches isCheapCronEnabled in src/scheduler/cron-routing.ts — only
+# SWITCHROOM_CHEAP_CRON=0/false/off disables it); the old "off unless =1" gate
+# here meant the cron session quarantined itself even with cheap-by-default on,
+# so every Tier-1 fire fell back to the main session and saved nothing. Exit 78
+# (EX_CONFIG) on the explicit kill-switch so the supervisor cleanly idles.
 case "${SWITCHROOM_CHEAP_CRON:-}" in
-  1 | true | on | ON) : ;;
-  *)
-    echo "cron-session: SWITCHROOM_CHEAP_CRON off — not starting (exit 78, no respawn)" >&2
+  0 | false | off | OFF | False | FALSE)
+    echo "cron-session: SWITCHROOM_CHEAP_CRON disabled (=0) — not starting (exit 78, no respawn)" >&2
     exit 78
     ;;
+  *) : ;;
 esac
 
 CRON_NAME="{{name}}-cron"

--- a/tests/cheap-cron-session-render.test.ts
+++ b/tests/cheap-cron-session-render.test.ts
@@ -88,9 +88,20 @@ describe("cron-session.sh launcher — compliance + identity", () => {
     expect(out).toContain('[ -f "$CRON_MCP_CONFIG" ] ||');
   });
 
-  it("self-gates on the runtime flag (exit 78, no respawn, when off)", () => {
+  it("self-gates on the runtime flag (exit 78, no respawn, only when explicitly disabled)", () => {
     expect(out).toContain("SWITCHROOM_CHEAP_CRON");
     expect(out).toContain("exit 78");
+    // Cheap-cron is ON by default (mirrors isCheapCronEnabled): the gate must
+    // exit only on the explicit kill-switch values, NOT default-off. The old
+    // `1 | true | on) :;; *) exit 78` quarantined the session even with
+    // cheap-by-default on, so every Tier-1 fire fell back to main and saved
+    // nothing. Assert the disable-values arm and that the wildcard arm runs
+    // (does not exit).
+    expect(out).toMatch(/0 \| false \| off/i);
+    // The non-disabled default arm is a no-op (`*) :`) — the session starts.
+    expect(out).toMatch(/\*\)\s*:\s*;;/);
+    // Guard against regressing to the old default-off gate.
+    expect(out).not.toMatch(/1 \| true \| on \| ON\) : ;;/);
   });
 
   it("shares the broker OAuth creds via symlink (same subscription)", () => {


### PR DESCRIPTION
Canary follow-up. The v0.15.10 canary proved cheap-by-default routes to `tier:cheap` and the fallback never drops a fire — but the Tier-1 cron session quarantined itself (`exit 78`) because its shell gate still used the OLD "off unless =1" logic, so every cheap fire fell back to main and **saved nothing**.

Fix: `cron-session.sh` exits 78 only on the explicit kill-switch (`0/false/off`); unset/anything-else starts the session — mirrors `isCheapCronEnabled` exactly.

Render test extended (asserts default-start + guards the old gate). 11 tests green.

Last shell-side gate needed to actually realize the token savings; re-canary on test-harness will confirm the cron session connects + a fire delivers `tier:cheap` **without** falling back.