### PR TITLE
fix(scheduler): make Tier-1 routing tool-aware — cadence advisory, opt-in only

### DIFF
--- a/src/scheduler/tier-selector.test.ts
+++ b/src/scheduler/tier-selector.test.ts
@@ -125,38 +125,33 @@ describe("resolveFrequentGapMin", () => {
   });
 });
 
-describe("applyDefaultTier — cheap-by-default for hint-less frequent crons", () => {
-  it("a frequent hint-less cron gets context: fresh (→ cheap Tier-1)", () => {
-    expect(applyDefaultTier(tierable({ cron: "*/30 * * * *" })).context).toBe("fresh");
-    expect(applyDefaultTier(tierable({ cron: "0 * * * *" })).context).toBe("fresh"); // hourly
+describe("applyDefaultTier — tool-aware: cadence is advisory, never FORCES Tier-1", () => {
+  // Holistic-trace finding: the Tier-1 cheap session is tool/memory-starved,
+  // so forcing a hint-less cron into it on cadence alone is unsafe (a
+  // tool-using cron would run starved and fail, uncaught by the bridge-down
+  // fallback). Tier-1 is now OPT-IN. applyDefaultTier passes through; the
+  // cadence recommendation lives in recommendCronTier for shadow/guidance.
+
+  it("a frequent hint-less cron is NOT auto-routed to cheap (no context injected)", () => {
+    expect(applyDefaultTier(tierable({ cron: "*/30 * * * *" })).context).toBeUndefined();
+    expect(applyDefaultTier(tierable({ cron: "0 * * * *" })).context).toBeUndefined(); // hourly
+    expect(applyDefaultTier(tierable({ cron: "*/5 * * * *" })).context).toBeUndefined();
   });
 
-  it("an infrequent hint-less cron is left untouched (stays full-session default)", () => {
-    // The regression that matters: a daily briefing must NOT be downgraded.
-    expect(applyDefaultTier(tierable({ cron: "0 8 * * *" })).context).toBeUndefined();
-    expect(applyDefaultTier(tierable({ cron: "0 18 * * 0" })).context).toBeUndefined(); // weekly
-  });
-
-  it("explicit hints are never overridden", () => {
-    // context: agent on a frequent cron — operator said full session, we obey.
+  it("explicit opt-in hints are preserved unchanged (the author's tool-aware signal)", () => {
+    expect(applyDefaultTier(tierable({ cron: "*/5 * * * *", context: "fresh" })).context).toBe("fresh");
+    expect(applyDefaultTier(tierable({ cron: "0 8 * * *", model: "sonnet" })).model).toBe("sonnet");
     expect(applyDefaultTier(tierable({ cron: "*/5 * * * *", context: "agent" })).context).toBe("agent");
-    // explicit model on a frequent cron — untouched (no context injected).
-    expect(applyDefaultTier(tierable({ cron: "*/5 * * * *", model: "opus" })).context).toBeUndefined();
-    // a poll is explicit — untouched.
-    const poll = applyDefaultTier(tierable({ cron: "*/5 * * * *", kind: "poll" }));
-    expect(poll.context).toBeUndefined();
-    expect(poll.kind).toBe("poll");
+    expect(applyDefaultTier(tierable({ cron: "*/5 * * * *", kind: "poll" })).kind).toBe("poll");
   });
 
-  it("an unreadable cadence is treated as infrequent (conservative — never wrongly cheap)", () => {
-    expect(applyDefaultTier(tierable({ cron: "0-10 * * * *" })).context).toBeUndefined();
-    expect(applyDefaultTier(tierable({ cron: "garbage" })).context).toBeUndefined();
-  });
-
-  it("preserves all other fields", () => {
+  it("is a pure pass-through — nothing injected", () => {
     const out = applyDefaultTier(tierable({ cron: "*/30 * * * *", kind: "prompt" }));
-    expect(out.cron).toBe("*/30 * * * *");
-    expect(out.kind).toBe("prompt");
-    expect(out.context).toBe("fresh");
+    expect(out).toEqual({ cron: "*/30 * * * *", kind: "prompt" });
+  });
+
+  it("recommendCronTier still surfaces the advisory (recommender intact)", () => {
+    // Only the enforcing applyDefaultTier changed; the recommendation stays.
+    expect(recommendCronTier({ smallestGapMin: 30 }).tier).toBe("cheap");
   });
 });

--- a/src/scheduler/tier-selector.ts
+++ b/src/scheduler/tier-selector.ts
@@ -35,7 +35,6 @@
  */
 
 import { isKnownCheapModel, type CronTier } from "./cron-routing.js";
-import { estimateCronGapMin } from "./cron-cadence.js";
 
 export type TierSource = "explicit" | "cadence-default";
 
@@ -124,32 +123,34 @@ export interface TierableEntry {
 }
 
 /**
- * Fill in the cheap-by-default tier when the entry carries NO explicit hint.
+ * Apply the cron tier default to a hint-less entry.
  *
- * This is what makes cheap the *default* (the Defaults-principle fix): a
- * frequent, hint-less cron is augmented with `context: "fresh"` so the
- * router (`resolveCronRouting`) sends it to a cheap Tier-1 session instead
- * of the agent's full session. Explicit entries (kind/model/context set) are
- * returned untouched — the operator/agent's choice always wins. Infrequent
- * crons (and any cadence we can't read confidently → estimateCronGapMin
- * returns Infinity) keep the conservative full-session default, so we never
- * strip context from work that may need it.
+ * IMPORTANT — tool-aware safety (the holistic-trace finding): this used to
+ * inject `context: "fresh"` for any frequent cron, forcing it into the cheap
+ * Tier-1 session. That is UNSAFE to do on cadence alone, because the Tier-1
+ * session is deliberately context- AND tool-minimal (only the telegram bridge
+ * MCP + built-in tools; no memory/persona, no hindsight/drive/web MCPs). A
+ * frequent cron that needs those would run starved and fail its job — and the
+ * graceful main-session fallback does NOT catch that (it only covers a
+ * bridge-down delivery failure, not a capability shortfall). We cannot read a
+ * prompt's tool/memory need deterministically, so cadence is the WRONG signal
+ * to force Tier-1.
  *
- * Pure: cadence comes from the cron string via estimateCronGapMin; no I/O.
+ * The only sound tool-awareness signal is the AUTHOR's: an explicit
+ * `model: sonnet` / `context: fresh` asserts "this cron is self-contained".
+ * So Tier-1 is OPT-IN. Cadence stays ADVISORY — `recommendCronTier` still
+ * surfaces "this could be cheaper" for shadow/guidance, but we no longer
+ * force the routing. The big automatic win lives in Tier-0 (model-free),
+ * which has none of these hazards.
+ *
+ * This function therefore passes the entry through unchanged: explicit hints
+ * are honoured by the router; hint-less crons keep the safe full-session
+ * default. Kept as the seam where a future *tool-aware* auto-router would
+ * plug in. Pure, no I/O.
  */
 export function applyDefaultTier<T extends TierableEntry>(
   entry: T,
-  frequentGapMin: number = DEFAULT_FREQUENT_GAP_MIN,
+  _frequentGapMin: number = DEFAULT_FREQUENT_GAP_MIN,
 ): T {
-  // Any explicit hint → leave it exactly as authored.
-  if (entry.kind === "poll" || entry.context !== undefined || entry.model !== undefined) {
-    return entry;
-  }
-  const rec = recommendCronTier(
-    { smallestGapMin: estimateCronGapMin(entry.cron) },
-    frequentGapMin,
-  );
-  // Only the cheap recommendation changes anything; "main" is already the
-  // router's default for a hint-less entry, so leave it untouched.
-  return rec.tier === "cheap" ? { ...entry, context: "fresh" } : entry;
+  return entry;
 }


### PR DESCRIPTION
## Summary

A holistic trace of the Tier-1 cron-session path found that **cadence is the wrong signal to *force* a cron into the cheap session**. The Tier-1 session is deliberately context/tool-minimal (telegram bridge + built-ins only — no memory, no hindsight/drive/web MCPs). A frequent cron needing those would run **starved and fail its job**, and the graceful fallback does NOT catch it (fallback = bridge-down only, not capability shortfall). Tool-need isn't deterministically readable from a prompt, so cadence can't make Tier-1 safe.

## What

- The only sound tool-awareness signal is the **author's**: explicit `model: sonnet` / `context: fresh` asserts self-contained. **Tier-1 is now opt-in.**
- `applyDefaultTier` no longer injects `context: fresh` on cadence — pass-through. Hint-less crons keep the safe full-session default; explicit opt-ins honoured.
- `recommendCronTier` unchanged — still surfaces the cadence advisory for shadow/guidance; `applyDefaultTier` stays as the seam for a future tool-aware auto-router.

## Why now

This removes the regression the un-fixed Tier-1 boot wedge was *masking*: once the cron session actually boots, forced cadence-routing would have sent tool-using crons into the starved session (silent wrong-answers). De-risking the enforced routing is the regression-guard I committed to before fixing the boot wedge.

## Where the auto-win goes

Tier-0 (model-free poll/action) — no second claude, no tools to starve, zero tokens. That's the automatic cheap-by-default win; this PR clears the unsafe path so it can land cleanly.

## Test plan
- [x] applyDefaultTier is pass-through (no cadence injection); explicit opt-ins preserved; recommendCronTier advisory intact. 132 scheduler tests green; tsc clean.