### PR TITLE
chore(docker): bump bundled claude CLI 2.1.170 → 2.1.177

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # (`--build-arg CLAUDE_CODE_VERSION=<latest>`) to build a throwaway image on the
 # next version and prove it boots BEFORE the pin is bumped. Keep this default in
 # lockstep with docker/Dockerfile.hindsight's CLAUDE_CODE_VERSION (#1978).
-ARG CLAUDE_CODE_VERSION=2.1.170
+ARG CLAUDE_CODE_VERSION=2.1.177
 # Fail-fast: if the npm install or the resulting binary is broken we
 # want the image build to die here, not produce a base that ships
 # downstream and explodes at agent boot. Previously this had a

--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -41,7 +41,7 @@ USER root
 # claude bundle as the agent containers — a version skew here could reintroduce
 # the thinking-block / thinking-effort class of failures on memory reflection
 # (see #1978). The canary overrides it the same way base does.
-ARG CLAUDE_CODE_VERSION=2.1.170
+ARG CLAUDE_CODE_VERSION=2.1.177
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && claude --version >&2
 


### PR DESCRIPTION
## Summary

Bumps the bundled `@anthropic-ai/claude-code` CLI **2.1.170 → 2.1.177** (latest) across all images, updating both lockstep pins together (#1978 invariant):
- `docker/Dockerfile.base` `ARG CLAUDE_CODE_VERSION` (flows to agent/broker/kernel/auth-broker/hostd via `FROM base`)
- `docker/Dockerfile.hindsight`'s own `ARG`

## Why

Surfaced while diagnosing a fleet-wide `4xx` — every agent was pinned to `defaults.model: claude-fable-5`, which the API now rejects ("model may not exist or you may not have access"). `claude-fable-5` was the **pre-launch codename for `claude-opus-4-8`** (the CLI's model table literally contains `fable5-launch`); the codename was retired server-side.

The CLI bump is **independent of that model fix** (the public id `claude-opus-4-8` already works on 2.1.170) — but it keeps the fleet on the latest CLI and refreshes the `/model` picker's model menu to the current set.

## `/model` model names (the investigation)

`/model` doesn't hardcode a model list:
- `src/agents/model-picker.ts` **parses claude's own `/model` TUI**, so the available models are CLI-version-driven and refresh automatically with the bump.
- The `opus` / `sonnet` / `haiku` / `default` aliases pass through to claude (which resolves them to the current versions), and `/model <full-id>` passes through for validation.

Current valid top models (from the CLI's model table, confirmed): `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`. No hardcoded list needs editing — deliberately, to avoid the same staleness that broke `fable-5`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `model-picker.test.ts` + `model-command.test.ts` green (50 tests)
- The 2.1.170 picker-fixture test stays as a format-stable regression guard. **Post-roll canary**: capture the live 2.1.177 `/model` TUI and confirm the picker still parses it (add a 2.1.177 fixture if the layout changed).

## Risk
Low — a build-arg version bump. The Dockerfile `claude --version` RUN step makes the image build the install smoke test, so a bad version fails the `build-base` check. No TS/behaviour change.

## Follow-up (separate)
The fleet's broken `defaults.model: claude-fable-5` needs repointing to `claude-opus-4-8` (the same model, valid public id) — that's the actual fix for the live 4xx, handled out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)