### PR TITLE
feat(model): keep `fable` selectable + regression coverage for alias selection

### DIFF
--- a/telegram-plugin/gateway/model-command.ts
+++ b/telegram-plugin/gateway/model-command.ts
@@ -33,12 +33,20 @@ import {
 } from '../../src/agents/model-picker.js'
 
 /**
- * Aliases the claude CLI resolves natively. Listed in help text only —
- * the handler does NOT restrict to these (a full model id like
- * `claude-opus-4-8` passes through and claude itself validates it, so
- * new aliases/models work without a switchroom release).
+ * Aliases the claude CLI resolves natively (`claude --help`: "an alias for
+ * the latest model (e.g. 'fable', 'opus', or 'sonnet')"). Listed in help
+ * text only — the handler does NOT restrict to these (a full model id like
+ * `claude-opus-4-8` passes through and claude itself validates it, so new
+ * aliases/models work without a switchroom release).
+ *
+ * `fable` is the latest flagship (Fable 5) — kept selectable here on
+ * purpose. NB the alias is NOT the full codename: `claude-fable-5` (a
+ * pinned pre-launch id) was retired server-side and 4xx'd the whole fleet
+ * on 2026-06-13, while the `fable` alias keeps resolving to the current
+ * model. Aliases are the durable way to pick a model — see the model
+ * regression tests.
  */
-export const MODEL_ALIASES = ['opus', 'sonnet', 'haiku', 'default'] as const
+export const MODEL_ALIASES = ['opus', 'sonnet', 'haiku', 'fable', 'default'] as const
 
 /**
  * Shape gate for the model argument. This string is typed literally

--- a/telegram-plugin/tests/model-command.test.ts
+++ b/telegram-plugin/tests/model-command.test.ts
@@ -113,6 +113,46 @@ describe("isValidModelArg", () => {
   });
 });
 
+// Regression for the 2026-06-13 fleet outage: defaults.model was pinned to
+// the full codename `claude-fable-5`, which Anthropic retired server-side →
+// every agent 4xx'd. The fix is to select models by ALIAS (durable) instead
+// of pinned ids. This locks in that `fable` (and the other aliases) stay
+// selectable, and documents the alias-vs-codename distinction.
+describe("model selection: aliases stay selectable (incl. fable)", () => {
+  it("lists fable as a first-class alias", () => {
+    // `fable` is the latest flagship (Fable 5) and must remain pickable.
+    expect(MODEL_ALIASES).toContain("fable");
+    // The standard set is intact alongside it.
+    for (const a of ["opus", "sonnet", "haiku", "default"]) {
+      expect(MODEL_ALIASES, a).toContain(a);
+    }
+  });
+
+  it("each alias is a valid model arg and parses as a set", () => {
+    for (const alias of MODEL_ALIASES) {
+      expect(isValidModelArg(alias), alias).toBe(true);
+      expect(parseModelCommand(`/model ${alias}`)).toEqual({ kind: "set", model: alias });
+    }
+  });
+
+  it("the help text surfaces the fable alias", async () => {
+    const reply = await handleModelCommand({ kind: "help" }, makeDeps());
+    expect(reply.text).toContain("fable");
+  });
+
+  it("passthrough: a full id (incl. the retired claude-fable-5 codename) is shape-accepted, not allowlisted", () => {
+    // switchroom does NOT allowlist models — the SHAPE gate passes any
+    // well-formed id through to claude, which is the sole validator. So the
+    // retired `claude-fable-5` codename still parses here (it just 4xx's at
+    // claude); selection flexibility (any current/future model) is preserved.
+    expect(parseModelCommand("/model claude-fable-5")).toEqual({
+      kind: "set",
+      model: "claude-fable-5",
+    });
+    expect(isValidModelArg("claude-fable-5")).toBe(true);
+  });
+});
+
 describe("handleModelCommand — show / help never inject (picker-wedge guard)", () => {
   it("show renders configured model + switch options without injecting", async () => {
     const { deps, calls } = makeDeps();


### PR DESCRIPTION
## Summary

Regression coverage for the **2026-06-13 fleet outage**: `defaults.model` was pinned to the full codename `claude-fable-5`, which Anthropic **retired server-side** → every agent 4xx'd ("model may not exist or you may not have access"). The durable fix is selecting models by **alias**, not pinned id.

This makes `fable` a first-class, tested option and locks in that aliases stay selectable.

## What changed
- **`fable` added to `MODEL_ALIASES`** — so the latest flagship (Fable 5) stays a discoverable option in `/model`. Canary-verified on test-harness: the `fable` **alias** still resolves (banner: *"Fable 5 with low effort"*, no error) — only the `claude-fable-5` **codename** was retired. `claude --help` documents `fable`/`opus`/`sonnet` as aliases *"for the latest model"*.
- **Regression tests** (`model-command.test.ts`) pin:
  - `fable` (and `opus`/`sonnet`/`haiku`/`default`) are in `MODEL_ALIASES`
  - each alias is a valid arg that parses as `{kind:'set'}`
  - the help text surfaces `fable`
  - the shape-gate **passthrough** still accepts any full id — including the retired `claude-fable-5` codename — documenting that switchroom **never allowlists** models (claude is the sole validator), so any current/future model stays selectable.

## Why this is the right shape
The outage root cause was pinning a *codename*, not the model. `/model`'s handler already passes any well-formed arg through to claude (the `isValidModelArg` shape gate is **not** an allowlist), so selection flexibility was never the problem — this just makes `fable` discoverable again and guards the alias path so a future refactor can't silently drop it.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `model-command.test.ts` — 35 pass (4 new)
- [x] `model-unavailable.test.ts` — 39 pass (snapshot intact)

## Risk
Minimal — adds one alias to a help-text display list + tests. No handler behavior change.

## Related
- CLI bump 2.1.170 → 2.1.177: #2306
- The live fleet fix (`defaults.model: opus`) was applied out-of-band; this PR is the durable `/model` coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)