### PR TITLE
chore: release v0.15.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## unreleased — Linear agents as first-class actors
+## v0.15.12 — Linear agents as first-class actors (#2298, #2310)
+
+### PR — feat(model): keep `fable` selectable + model regression coverage (#2310)
+
+`fable` is now a first-class `/model` alias (alongside `opus`/`sonnet`/
+`haiku`/`default`) so the latest flagship (Fable 5) stays discoverable. The
+2026-06-13 fleet outage came from pinning the full *codename* `claude-fable-5`
+(retired server-side → 4xx), not the alias; regression tests lock in that
+aliases stay selectable and that the `/model` shape-gate passes any full id
+through to claude (switchroom never allowlists models).
 
 ### PR — feat(linear): Linear agents as first-class actors (#2298)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.15.11",
+  "version": "0.15.12",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v0.15.12 — Linear agents as first-class actors

Ships everything merged since v0.15.11:

- **#2298** — `feat(linear): Linear agents as first-class actors`. New `switchroom linear-agent setup` CLI + the `channels.telegram.linear_agent` config block + `AgentSessionEvent` wake path + the `linear_agent_activity` MCP tool. Lets an agent install into a Linear workspace as an app actor (@-mentionable, delegate-assignable).
- **#2310** — `feat(model): keep fable selectable + model regression coverage`. `fable` is a first-class `/model` alias; regression tests lock alias selectability.

(The 2.1.177 CLI bump #2306 already shipped in v0.15.11.)

Routine release: version bump + CHANGELOG consolidation. Constituent PRs reviewed + merged green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)