### PR TITLE
fix(scaffold): guard the `model: default` footgun — remap to switchroom default

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1041,6 +1041,24 @@ export const SWITCHROOM_DEFAULT_MAIN_MODEL = "claude-sonnet-4-6";
 export const SWITCHROOM_DEFAULT_THINKING_EFFORT = "low";
 
 /**
+ * Resolve a config `model:` value for the agent's claude launch.
+ *
+ * Footgun guard: a bare `model: default` is NOT "use the switchroom default" —
+ * claude passes the literal string through, and Anthropic resolves it to the
+ * *account's* default model (e.g. claude-fable-5). If the account has no access
+ * to that model, EVERY turn 4xx's ("model may not exist or you may not have
+ * access"). That bit test-harness on 2026-06-13. We remap the `default` alias
+ * (and unset) to switchroom's known-good default so a config `model:` can never
+ * resolve to an inaccessible account-default. Any explicit real model id or
+ * other alias (opus/sonnet/haiku/full id) passes through unchanged — operators
+ * who want a specific model still get it.
+ */
+export function resolveMainModel(model: string | undefined): string {
+  if (model === undefined || model === "default") return SWITCHROOM_DEFAULT_MAIN_MODEL;
+  return model;
+}
+
+/**
  * Built-in Claude Code tools. When `tools.allow: [all]` is set in
  * switchroom.yaml, every one of these is pre-approved so the agent never
  * blocks on a permission prompt at runtime.
@@ -2244,7 +2262,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     // (#910). When unset (e.g. tests with no HOME) the template's
     // {{#if hostHomeQ}} guard renders the symlink block as a no-op.
     hostHomeQ: process.env.HOME ? shellSingleQuote(process.env.HOME) : undefined,
-    modelQ: shellSingleQuote(agentConfig.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL),
+    modelQ: shellSingleQuote(resolveMainModel(agentConfig.model)),
     ...buildCronSessionContext(agentConfig),
     thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
     permissionMode: agentConfig.permission_mode,
@@ -3063,7 +3081,7 @@ export function scaffoldAgent(
       // for rationale). Always written to settings.model so the user
       // doesn't have to pass --model on every invocation, and so the
       // doctor / debug surfaces show the resolved choice.
-      settings.model = agentConfig.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL;
+      settings.model = resolveMainModel(agentConfig.model);
 
       // --- Phase 5: settings_raw escape hatch ---
       //
@@ -4836,7 +4854,7 @@ export function reconcileAgent(
       // Mirror buildWorkspaceContext (#910): host home for the
       // $HOME/.switchroom symlink in start.sh's docker preamble.
       hostHomeQ: process.env.HOME ? shellSingleQuote(process.env.HOME) : undefined,
-      modelQ: shellSingleQuote(agentConfig.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL),
+      modelQ: shellSingleQuote(resolveMainModel(agentConfig.model)),
       ...buildCronSessionContext(agentConfig),
       thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
       permissionMode: agentConfig.permission_mode,
@@ -5218,7 +5236,7 @@ export function reconcileAgent(
     // produce the same settings.model byte-for-byte. Apply the switchroom
     // default (Sonnet 4.6) when the operator hasn't set an explicit
     // override in switchroom.yaml.
-    settings.model = agentConfig.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL;
+    settings.model = resolveMainModel(agentConfig.model);
 
     // --- Phase 5: settings_raw escape hatch ---
     //

--- a/tests/reconcile.default-model.test.ts
+++ b/tests/reconcile.default-model.test.ts
@@ -23,6 +23,7 @@ import {
   reconcileAgent,
   scaffoldAgent,
   SWITCHROOM_DEFAULT_MAIN_MODEL,
+  resolveMainModel,
 } from "../src/agents/scaffold.js";
 import type {
   AgentConfig,
@@ -142,5 +143,29 @@ describe("reconcileAgent — default model (#472 #16)", () => {
     // settings_raw is applied AFTER the switchroom-owned default, so it
     // takes precedence — that's the design of the escape hatch.
     expect(settings.model).toBe("claude-haiku-4-5-20251001");
+  });
+});
+
+describe("resolveMainModel — the `model: default` footgun guard", () => {
+  it("remaps the `default` alias to the switchroom default (NOT the account default)", () => {
+    // `model: default` passes the literal string to claude, which resolves it
+    // to the ACCOUNT default (e.g. claude-fable-5) — inaccessible on some
+    // accounts → 4xx every turn (bit test-harness 2026-06-13). Must remap.
+    expect(resolveMainModel("default")).toBe(SWITCHROOM_DEFAULT_MAIN_MODEL);
+    expect(resolveMainModel("default")).not.toBe("default");
+  });
+
+  it("falls back to the switchroom default when unset", () => {
+    expect(resolveMainModel(undefined)).toBe(SWITCHROOM_DEFAULT_MAIN_MODEL);
+  });
+
+  it("passes explicit real models / aliases through unchanged", () => {
+    expect(resolveMainModel("claude-opus-4-8")).toBe("claude-opus-4-8");
+    expect(resolveMainModel("opus")).toBe("opus");
+    expect(resolveMainModel("sonnet")).toBe("sonnet");
+    expect(resolveMainModel("claude-haiku-4-5-20251001")).toBe("claude-haiku-4-5-20251001");
+    // a deliberate fable id (an account that HAS access) is honoured — we only
+    // guard the bare `default` alias, not fable itself.
+    expect(resolveMainModel("claude-fable-5")).toBe("claude-fable-5");
   });
 });


### PR DESCRIPTION
`model: default` in config isn't "use the switchroom default" — claude passes the literal string and Anthropic resolves it to the **account's** default model (claude-fable-5), which 4xx's on accounts without access. Bit test-harness 06-13 (leftover canary line → endless API-error cards).

New `resolveMainModel()` remaps the bare `default` alias (and unset) to `SWITCHROOM_DEFAULT_MAIN_MODEL` (claude-sonnet-4-6) at the 4 launch sites (start.sh modelQ ×2, settings.model ×2). Explicit real models/aliases — incl. a deliberate fable id on an account that has access — pass through unchanged.

7 tests green; tsc clean. Small defensive guard.