### PR TITLE
feat(linear): linear_create_issue tool (#2312 PR 1)

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -479,6 +479,37 @@ const TOOL_SCHEMAS = [
       required: ['agent_session_id', 'type'],
     },
   },
+  {
+    name: 'linear_create_issue',
+    description:
+      'File a new Linear issue from a Telegram message the operator flagged for capture (#2312). Use this when a turn was triggered by a capture reaction (the inbound carries event="reaction" with a capture emoji like 👨‍💻 or 📌) — turn the reacted message + any relevant thread context into a well-formed issue. Write a crisp imperative title and a body that captures the ask, the context, and any acceptance criteria you can infer; the agent files it AS its own Linear app actor. Team is auto-resolved when the workspace has a single team; if there are multiple it returns text asking for an explicit team_id. Pass dedup_key (e.g. the chat_id:message_id of the reacted message) so a re-react of the same message does not file a duplicate. Resolves the agent\'s Linear app token from the vault; on VAULT-BROKER-DENIED it returns text instructing you to vault_request_access for `linear/<agent>/token`. Returns "Filed: <title> → <url>" on success — reply that link to the operator in plain text.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        title: {
+          type: 'string',
+          description: 'Issue title — a crisp, imperative one-liner (e.g. "Fix duplicate webhook retries on Brevo sync").',
+        },
+        body: {
+          type: 'string',
+          description: 'Issue description (Markdown). Capture the ask, relevant context from the message/thread, and any acceptance criteria you can infer.',
+        },
+        team_id: {
+          type: 'string',
+          description: 'Optional Linear team id. Omit to auto-resolve when the workspace has a single team; required only when the workspace has multiple teams.',
+        },
+        dedup_key: {
+          type: 'string',
+          description: 'Optional idempotency key (use the reacted message identity, e.g. "<chat_id>:<message_id>"). A prior capture with the same key short-circuits to "Already filed: <url>".',
+        },
+        priority: {
+          type: 'number',
+          description: 'Optional Linear priority (0 none, 1 urgent, 2 high, 3 normal, 4 low).',
+        },
+      },
+      required: ['title', 'body'],
+    },
+  },
 ]
 
 mcp.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_SCHEMAS }))

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -467,7 +467,7 @@ import {
   listGrantsViaBroker,
   revokeGrantViaBroker,
 } from '../../src/vault/broker/client.js'
-import { emitLinearAgentActivity } from './linear-activity.js'
+import { emitLinearAgentActivity, createLinearIssue } from './linear-activity.js'
 import {
   approvalRequest,
   approvalConsume,
@@ -6720,6 +6720,7 @@ const ALLOWED_TOOLS = new Set([
   'vault_request_access',
   'request_secret',
   'linear_agent_activity',
+  'linear_create_issue',
 ])
 
 async function executeToolCall(tool: string, args: Record<string, unknown>): Promise<unknown> {
@@ -6767,6 +6768,8 @@ async function executeToolCall(tool: string, args: Record<string, unknown>): Pro
       return executeRequestSecret(args)
     case 'linear_agent_activity':
       return executeLinearAgentActivity(args)
+    case 'linear_create_issue':
+      return executeLinearCreateIssue(args)
     default:
       throw new Error(`unknown tool: ${tool}`)
   }
@@ -6800,6 +6803,10 @@ async function executeSendChecklist(args: Record<string, unknown>): Promise<{ co
 
 async function executeLinearAgentActivity(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
   return emitLinearAgentActivity(args)
+}
+
+async function executeLinearCreateIssue(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
+  return createLinearIssue(args)
 }
 
 async function executeUpdateChecklist(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {

--- a/telegram-plugin/gateway/linear-activity.ts
+++ b/telegram-plugin/gateway/linear-activity.ts
@@ -158,3 +158,139 @@ export async function emitLinearAgentActivity(
   log(`telegram gateway: linear_agent_activity: emitted type=${type} session=${sessionId} agent=${agent}\n`)
   return { content: [{ type: 'text', text: `Linear ${type} emitted on session ${sessionId}` }] }
 }
+
+/** Hidden marker appended to a captured issue's description so a re-capture of
+ *  the same Telegram message can be detected (dedup backstop; the gateway-side
+ *  seen-set is the primary, race-free guard). */
+export function captureDedupMarker(dedupKey: string): string {
+  return `\n\n<!-- switchroom-capture: ${dedupKey} -->`
+}
+
+/**
+ * Create a Linear issue (capture-on-reaction → Linear). Mirrors
+ * emitLinearAgentActivity: validates, resolves the agent's Linear app token,
+ * POSTs `issueCreate`, returns an MCP text result; never throws on vault/
+ * network failure. The issue is filed AS the agent's app actor.
+ *
+ * Team: Linear requires a teamId. If `team_id` is omitted we auto-resolve —
+ * the zero-config single-team case uses the workspace's only team; a
+ * multi-team workspace returns actionable text asking for an explicit team_id.
+ *
+ * Dedup: when `dedup_key` is given we (a) best-effort search for a prior
+ * capture carrying the same marker and short-circuit to "already filed", and
+ * (b) embed the marker in the new issue's description as a durable backstop.
+ */
+export async function createLinearIssue(
+  args: Record<string, unknown>,
+  deps: LinearActivityDeps = {},
+): Promise<ToolTextResult> {
+  const log = deps.log ?? ((s) => process.stderr.write(s))
+  const fetchImpl = deps.fetchImpl ?? fetch
+
+  const title = args.title as string | undefined
+  if (!title || title.trim() === '') throw new Error('linear_create_issue: title is required')
+  const body = (args.body as string | undefined) ?? ''
+  const teamIdArg = (args.team_id as string | undefined) ?? undefined
+  const dedupKey = (args.dedup_key as string | undefined) ?? undefined
+  const priority = typeof args.priority === 'number' ? (args.priority as number) : undefined
+
+  const agent = deps.agent ?? process.env.SWITCHROOM_AGENT_NAME ?? '-'
+  const resolveToken = deps.resolveToken ?? defaultResolveLinearToken
+  const tokenResult = await resolveToken(agent)
+  if (!tokenResult.ok) {
+    const hint =
+      tokenResult.reason === 'denied' || tokenResult.reason === 'not_found'
+        ? ` Call vault_request_access for key 'linear/${agent}/token' (scope read), then retry.`
+        : ''
+    return {
+      content: [
+        { type: 'text', text: `Couldn't file to Linear: no token (vault ${tokenResult.reason}).${hint}` },
+      ],
+    }
+  }
+  const token = tokenResult.token
+
+  const gql = async (query: string, variables: Record<string, unknown>): Promise<{ ok: true; data: any } | { ok: false; text: string }> => {
+    let resp: Response
+    try {
+      resp = await fetchImpl(LINEAR_GRAPHQL_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: token },
+        body: JSON.stringify({ query, variables }),
+      })
+    } catch (err) {
+      return { ok: false, text: `request error: ${(err as Error).message}` }
+    }
+    if (!resp.ok) {
+      const txt = await resp.text().catch(() => '')
+      return { ok: false, text: `Linear API ${resp.status}${txt ? ` — ${txt.slice(0, 200)}` : ''}` }
+    }
+    let json: { data?: any; errors?: Array<{ message?: string }> }
+    try {
+      json = (await resp.json()) as typeof json
+    } catch {
+      return { ok: false, text: 'malformed Linear API response' }
+    }
+    if (json.errors && json.errors.length > 0) {
+      return { ok: false, text: json.errors.map((e) => e.message ?? 'error').join('; ').slice(0, 300) }
+    }
+    return { ok: true, data: json.data }
+  }
+
+  // Dedup backstop: search for a prior capture of the same Telegram message.
+  if (dedupKey) {
+    const search = await gql(
+      'query($term: String!) { searchIssues(term: $term) { nodes { id url title } } }',
+      { term: dedupKey },
+    )
+    if (search.ok) {
+      const hit = (search.data?.searchIssues?.nodes ?? [])[0] as { url?: string } | undefined
+      if (hit?.url) {
+        log(`telegram gateway: linear_create_issue: dedup hit key=${dedupKey} agent=${agent}\n`)
+        return { content: [{ type: 'text', text: `Already filed: ${hit.url}` }] }
+      }
+    }
+    // a failed search is non-fatal — fall through to create (gateway seen-set is primary).
+  }
+
+  // Resolve the team.
+  let teamId = teamIdArg
+  if (!teamId) {
+    const teams = await gql('query { teams(first: 50) { nodes { id key name } } }', {})
+    if (!teams.ok) {
+      return { content: [{ type: 'text', text: `Couldn't file to Linear: ${teams.text}` }] }
+    }
+    const nodes = (teams.data?.teams?.nodes ?? []) as Array<{ id: string; key: string; name: string }>
+    if (nodes.length === 0) {
+      return { content: [{ type: 'text', text: 'Couldn\'t file to Linear: the workspace has no teams.' }] }
+    }
+    if (nodes.length > 1) {
+      const list = nodes.map((t) => `${t.key} (${t.name})`).join(', ')
+      return {
+        content: [
+          { type: 'text', text: `Couldn't file to Linear: multiple teams (${list}) — set a default team (linear_agent.default_team_id) or pass team_id.` },
+        ],
+      }
+    }
+    teamId = nodes[0].id
+  }
+
+  const description = dedupKey ? `${body}${captureDedupMarker(dedupKey)}` : body
+  const input: Record<string, unknown> = { teamId, title, description }
+  if (priority !== undefined) input.priority = priority
+
+  const create = await gql(
+    'mutation($input: IssueCreateInput!) { issueCreate(input: $input) { success issue { id identifier url } } }',
+    { input },
+  )
+  if (!create.ok) {
+    return { content: [{ type: 'text', text: `Couldn't file to Linear: ${create.text}` }] }
+  }
+  const issue = create.data?.issueCreate?.issue as { identifier?: string; url?: string } | undefined
+  if (create.data?.issueCreate?.success === false || !issue?.url) {
+    return { content: [{ type: 'text', text: 'Couldn\'t file to Linear: issue not created (success=false).' }] }
+  }
+
+  log(`telegram gateway: linear_create_issue: filed ${issue.identifier} agent=${agent}${dedupKey ? ` dedup=${dedupKey}` : ''}\n`)
+  return { content: [{ type: 'text', text: `Filed: ${title} → ${issue.url}` }] }
+}

--- a/telegram-plugin/tests/linear-agent-activity.test.ts
+++ b/telegram-plugin/tests/linear-agent-activity.test.ts
@@ -51,7 +51,7 @@ describe('linear_agent_activity — gateway wiring (#2298)', () => {
   })
 
   it('is allow-listed and dispatched', () => {
-    expect(gw).toMatch(/'linear_agent_activity',\n\]\)/)
+    expect(gw).toMatch(/'linear_agent_activity',/)
     expect(gw).toMatch(/case 'linear_agent_activity':\s*\n\s*return executeLinearAgentActivity\(args\)/)
   })
 })

--- a/telegram-plugin/tests/linear-create-issue.test.ts
+++ b/telegram-plugin/tests/linear-create-issue.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  createLinearIssue,
+  captureDedupMarker,
+  type LinearTokenResult,
+} from '../gateway/linear-activity.js'
+
+/**
+ * Tests for the `linear_create_issue` MCP tool (#2312 — capture-on-reaction
+ * → Linear).
+ *
+ * Structural part: assert the tool is declared in bridge/bridge.ts and
+ * allow-listed + dispatched in gateway/gateway.ts (the gateway IIFE can't be
+ * imported in a test, so wiring is verified by reading the source — same
+ * constraint as linear-agent-activity.test.ts).
+ *
+ * Behavioural part: the create logic lives in gateway/linear-activity.ts with
+ * an injectable token-resolver + fetch, so team auto-resolve, dedup, priority,
+ * and the vault-denied path are exercised without a broker or the network.
+ */
+
+const okToken = (token: string) => async (): Promise<LinearTokenResult> => ({ ok: true, token })
+
+/** A fake fetch that routes by GraphQL operation so a single test can answer
+ *  the teams query, the searchIssues query, and the issueCreate mutation
+ *  independently. Each handler returns the `data` payload. */
+function routingFetch(handlers: {
+  teams?: () => unknown
+  searchIssues?: () => unknown
+  issueCreate?: () => unknown
+  status?: number
+}): {
+  fetchImpl: typeof fetch
+  calls: Array<{ url: string; query: string; variables: Record<string, unknown>; headers: Record<string, string> }>
+} {
+  const calls: Array<{ url: string; query: string; variables: Record<string, unknown>; headers: Record<string, string> }> = []
+  const status = handlers.status ?? 200
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const parsed = JSON.parse((init?.body as string) ?? '{}') as { query: string; variables: Record<string, unknown> }
+    calls.push({
+      url,
+      query: parsed.query,
+      variables: parsed.variables,
+      headers: (init?.headers as Record<string, string>) ?? {},
+    })
+    let data: unknown = {}
+    if (parsed.query.includes('teams')) data = handlers.teams?.() ?? {}
+    else if (parsed.query.includes('searchIssues')) data = handlers.searchIssues?.() ?? {}
+    else if (parsed.query.includes('issueCreate')) data = handlers.issueCreate?.() ?? {}
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => ({ data }),
+      text: async () => JSON.stringify({ data }),
+    } as unknown as Response
+  }) as unknown as typeof fetch
+  return { fetchImpl, calls }
+}
+
+const oneTeam = () => ({ teams: { nodes: [{ id: 'team_1', key: 'ENG', name: 'Engineering' }] } })
+const issueOk = () => ({ issueCreate: { success: true, issue: { id: 'i1', identifier: 'ENG-42', url: 'https://linear.app/acme/issue/ENG-42' } } })
+
+describe('linear_create_issue — gateway wiring (#2312)', () => {
+  const gw = readFileSync(new URL('../gateway/gateway.ts', import.meta.url), 'utf8')
+  const bridge = readFileSync(new URL('../bridge/bridge.ts', import.meta.url), 'utf8')
+
+  it('declares the MCP tool with required {title,body}', () => {
+    const idx = bridge.indexOf(`name: 'linear_create_issue'`)
+    expect(idx).toBeGreaterThan(0)
+    const schema = bridge.slice(idx, idx + 2500)
+    expect(schema).toMatch(/required: \['title', 'body'\]/)
+    expect(schema).toMatch(/dedup_key/)
+    expect(schema).toMatch(/team_id/)
+  })
+
+  it('is allow-listed and dispatched', () => {
+    expect(gw).toMatch(/'linear_create_issue',\n\]\)/)
+    expect(gw).toMatch(/case 'linear_create_issue':\s*\n\s*return executeLinearCreateIssue\(args\)/)
+  })
+})
+
+describe('createLinearIssue — behaviour (#2312)', () => {
+  it('auto-resolves the single team and POSTs issueCreate (zero-config)', async () => {
+    const { fetchImpl, calls } = routingFetch({ teams: oneTeam, issueCreate: issueOk })
+    const r = await createLinearIssue(
+      { title: 'Fix Brevo retries', body: 'They double-fire on sync.' },
+      { agent: 'clerk', resolveToken: okToken('lin_tok'), fetchImpl, log: () => {} },
+    )
+    expect(r.content[0].text).toBe('Filed: Fix Brevo retries → https://linear.app/acme/issue/ENG-42')
+    // teams query first, then issueCreate.
+    expect(calls).toHaveLength(2)
+    expect(calls[0].query).toMatch(/teams/)
+    expect(calls[1].query).toMatch(/issueCreate/)
+    expect(calls[1].variables.input).toMatchObject({ teamId: 'team_1', title: 'Fix Brevo retries' })
+    // raw token, no Bearer prefix (Linear convention).
+    expect(calls[1].headers.Authorization).toBe('lin_tok')
+  })
+
+  it('skips team resolution when team_id is passed', async () => {
+    const { fetchImpl, calls } = routingFetch({ issueCreate: issueOk })
+    const r = await createLinearIssue(
+      { title: 'X', body: 'Y', team_id: 'team_explicit' },
+      { agent: 'clerk', resolveToken: okToken('t'), fetchImpl, log: () => {} },
+    )
+    expect(r.content[0].text).toMatch(/Filed:/)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].query).toMatch(/issueCreate/)
+    expect(calls[0].variables.input).toMatchObject({ teamId: 'team_explicit' })
+  })
+
+  it('passes priority through when provided', async () => {
+    const { fetchImpl, calls } = routingFetch({ issueCreate: issueOk })
+    await createLinearIssue(
+      { title: 'X', body: 'Y', team_id: 't', priority: 1 },
+      { resolveToken: okToken('t'), fetchImpl, log: () => {} },
+    )
+    expect((calls[0].variables.input as Record<string, unknown>).priority).toBe(1)
+  })
+
+  it('errors actionably when the workspace has multiple teams and none is given', async () => {
+    const { fetchImpl } = routingFetch({
+      teams: () => ({ teams: { nodes: [{ id: 'a', key: 'ENG', name: 'Engineering' }, { id: 'b', key: 'OPS', name: 'Operations' }] } }),
+    })
+    const r = await createLinearIssue(
+      { title: 'X', body: 'Y' },
+      { resolveToken: okToken('t'), fetchImpl, log: () => {} },
+    )
+    expect(r.content[0].text).toMatch(/multiple teams/)
+    expect(r.content[0].text).toMatch(/ENG \(Engineering\)/)
+    expect(r.content[0].text).toMatch(/default_team_id/)
+  })
+
+  it('short-circuits to "Already filed" on a dedup hit', async () => {
+    const { fetchImpl, calls } = routingFetch({
+      searchIssues: () => ({ searchIssues: { nodes: [{ id: 'old', url: 'https://linear.app/acme/issue/ENG-7', title: 'prior' }] } }),
+      teams: oneTeam,
+      issueCreate: issueOk,
+    })
+    const r = await createLinearIssue(
+      { title: 'X', body: 'Y', dedup_key: 'chat:99' },
+      { resolveToken: okToken('t'), fetchImpl, log: () => {} },
+    )
+    expect(r.content[0].text).toBe('Already filed: https://linear.app/acme/issue/ENG-7')
+    // only the search ran — no team resolve, no create.
+    expect(calls).toHaveLength(1)
+    expect(calls[0].query).toMatch(/searchIssues/)
+  })
+
+  it('falls through to create when the dedup search misses, and embeds the marker', async () => {
+    const { fetchImpl, calls } = routingFetch({
+      searchIssues: () => ({ searchIssues: { nodes: [] } }),
+      teams: oneTeam,
+      issueCreate: issueOk,
+    })
+    const r = await createLinearIssue(
+      { title: 'X', body: 'Y', dedup_key: 'chat:99' },
+      { resolveToken: okToken('t'), fetchImpl, log: () => {} },
+    )
+    expect(r.content[0].text).toMatch(/Filed:/)
+    const create = calls.find((c) => c.query.includes('issueCreate'))!
+    expect((create.variables.input as Record<string, unknown>).description).toContain(captureDedupMarker('chat:99'))
+  })
+
+  it('returns vault_request_access guidance when the token is denied', async () => {
+    const r = await createLinearIssue(
+      { title: 'X', body: 'Y' },
+      { agent: 'clerk', resolveToken: async () => ({ ok: false, reason: 'denied' }), log: () => {} },
+    )
+    expect(r.content[0].text).toMatch(/Couldn't file to Linear: no token/)
+    expect(r.content[0].text).toMatch(/vault_request_access/)
+    expect(r.content[0].text).toMatch(/linear\/clerk\/token/)
+  })
+
+  it('requires a title', async () => {
+    await expect(
+      createLinearIssue({ body: 'Y' }, { resolveToken: okToken('t'), log: () => {} }),
+    ).rejects.toThrow(/title is required/)
+  })
+
+  it('surfaces a Linear API error status', async () => {
+    const { fetchImpl } = routingFetch({ teams: oneTeam, issueCreate: issueOk, status: 401 })
+    const r = await createLinearIssue(
+      { title: 'X', body: 'Y' },
+      { resolveToken: okToken('t'), fetchImpl, log: () => {} },
+    )
+    expect(r.content[0].text).toMatch(/Linear API 401/)
+  })
+})


### PR DESCRIPTION
## Summary

PR 1 of the **capture-on-reaction → Linear** feature (#2312). Adds a single MCP tool, `linear_create_issue`, that lets an agent file a new Linear issue **as its own Linear app actor** — the building block the 👨‍💻/📌 reaction will drive in PR 2.

It mirrors the existing `linear_agent_activity` tool (#2298) exactly: same `LinearActivityDeps` injectable token-resolver + fetch, same raw `Authorization: <token>` header (Linear convention, no `Bearer`), same never-throw-on-vault/network philosophy returning actionable MCP text.

## Why

`linear_agent_activity` only posts *activities against an existing agent session* — there is no tool to **create** an issue. clerk does it today via an operator-installed `personal-linear` python script. To make capture-on-reaction a switchroom default for any Linear-connected agent, the create path has to be first-class and vault-backed.

## What

- **`createLinearIssue(args, deps)`** in `gateway/linear-activity.ts`:
  - **Zero-config team**: single-team workspace auto-uses its only team; multi-team returns actionable text (`multiple teams (ENG (Engineering), …) — set a default team (linear_agent.default_team_id) or pass team_id`).
  - **Dedup**: `dedup_key` short-circuits to `Already filed: <url>` via a `searchIssues` backstop, and embeds a hidden `<!-- switchroom-capture: <key> -->` marker in the description. (Gateway seen-set is the primary, race-free guard — lands PR 2.)
  - **Priority** pass-through; **vault-denied** → `vault_request_access` guidance.
- **bridge**: `linear_create_issue` in `TOOL_SCHEMAS` (required `title` + `body`).
- **gateway**: allow-listed + dispatched via `executeLinearCreateIssue`.

## Test plan

- [x] `vitest run telegram-plugin/tests/linear-create-issue.test.ts` — 11 tests: wiring (declared/allow-listed/dispatched), team auto-resolve, explicit team, priority, multi-team error, dedup hit/miss + marker embed, vault-denied text, title-required, API-error.
- [x] `vitest run telegram-plugin/tests/linear-agent-activity.test.ts` — green (relaxed the assertion that required `linear_agent_activity` be the *last* allow-list entry).
- [x] `tsc --noEmit` clean.

## Risk

Low. Net-new tool; no existing path changes behaviour. The tool is advertised unconditionally (same as `linear_agent_activity`) and gates at token-resolution — agents without a Linear token get actionable text, never a crash. No model/inference path touched (subscription-honest).

## Follow-up (PR 2)

Cascade default-emoji injection (👨‍💻📌 when `linear_agent.enabled`), the `linearAgentEnabled` scaffold flag (both contexts — klanker hazard), the self-service playbook block, gateway seen-set dedup + per-hour cap, and `linear_agent.default_team_id` + a set-team helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)