### PR TITLE
feat(linear): capture-on-reaction → Linear as a switchroom default (#2312 PR 2)

### DIFF
--- a/profiles/_shared/agent-self-service.md.hbs
+++ b/profiles/_shared/agent-self-service.md.hbs
@@ -123,6 +123,43 @@ After a successful `schedule_add`, confirm to the user with:
 After a failed write (any `E_*` code from the rails above), surface the
 specific error verbatim, explain which rail tripped, and offer the
 closest legal alternative.
+{{#if linearAgentEnabled}}
+
+## Capture to Linear (👨‍💻 / 📌 reaction → new issue)
+
+You're connected to Linear as a first-class app actor. The operator has the
+**capture reactions** wired: when they react to a Telegram message with **👨‍💻**
+(laptop) or **📌** (pushpin), you're woken with a turn whose inbound is shaped
+`<channel … event="reaction" emoji="👨‍💻" message_id="…" chat_id="…">[the
+reacted message text]</channel>`. That reaction means: **"turn this into a
+Linear issue."**
+
+When you get such a reaction turn:
+
+1. **Read the reacted message + nearby context.** The `[reacted text]` is the
+   seed. Pull the surrounding thread (`get_recent_messages`) when the ask needs
+   it — the issue should stand on its own without the operator re-explaining.
+2. **Call `linear_create_issue`** with:
+   - `title` — a crisp, imperative one-liner ("Fix duplicate Brevo webhook
+     retries"), not a restatement of the chat.
+   - `body` — the ask, the context you gathered, and any acceptance criteria
+     you can reasonably infer. Markdown.
+   - `dedup_key` — set it to `"<chat_id>:<message_id>"` from the reaction event.
+     This makes a re-react of the same message idempotent (it returns the
+     existing issue instead of filing a duplicate).
+   - `team_id` — omit it. A single-team workspace auto-resolves; you'll only be
+     asked for one if the workspace has multiple teams (then tell the operator
+     to set a default via `switchroom linear-agent set-team`).
+3. **Reply in plain text, not an emoji.** On success the tool returns
+   `Filed: <title> → <url>` — reply that link so the operator can click
+   through ("📋 Filed: <url>"). On failure (vault denial, multi-team, API
+   error) the tool returns actionable text — relay it plainly ("Couldn't file
+   it — …") and, if it's a vault denial, follow the `vault_request_access`
+   instruction it gives you, then retry.
+
+Don't acknowledge with only a reaction or a bare "done" — the operator wants
+the link (or the honest reason it didn't file).
+{{/if}}
 
 ### Don't lie about scheduling
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1497,6 +1497,15 @@ function channelsToEnv(agent: AgentConfig): Record<string, string> {
   if (tg.clear_status_on_completion !== undefined) {
     out.SWITCHROOM_TG_CLEAR_STATUS_ON_COMPLETION = tg.clear_status_on_completion ? "1" : "0";
   }
+  // Linear capture default team (#2312) — only needed for multi-team
+  // workspaces, where the create tool can't auto-resolve. Single-team
+  // workspaces leave this unset and the tool resolves the only team.
+  const linearDefaultTeam = (
+    tg as { linear_agent?: { default_team_id?: string } } | undefined
+  )?.linear_agent?.default_team_id;
+  if (linearDefaultTeam) {
+    out.SWITCHROOM_LINEAR_DEFAULT_TEAM_ID = linearDefaultTeam;
+  }
   return out;
 }
 
@@ -2238,6 +2247,19 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     // "true"/"false" string. Default true preserves prior behavior.
     telegramEnabledFlag:
       agentConfig.channels?.telegram?.enabled === false ? "false" : "true",
+    // `{{#if linearAgentEnabled}}` in the agent-self-service fragment keys
+    // off this to render the capture-on-reaction → Linear playbook (#2312).
+    // Set HERE in the shared builder (not at the two render sites) precisely
+    // to avoid the klanker hazard: both scaffoldAgent's `context` and
+    // reconcileAgent's `claudeContext` derive from buildWorkspaceContext, so
+    // the flag resolves identically on both paths — a diverging value would
+    // diff-abort every reconcile.
+    linearAgentEnabled:
+      (
+        agentConfig.channels?.telegram as
+          | { linear_agent?: { enabled?: boolean } }
+          | undefined
+      )?.linear_agent?.enabled === true,
     // sec WS8-F1 / #1416: unconditional read-only image-baked
     // security-hooks plugin dir. Always set — it is the unstrippable
     // tool-safety authority, not an opt-in feature.
@@ -4968,6 +4990,18 @@ export function reconcileAgent(
         // capability block ({{#if root}} in CLAUDE.md.hbs).
         admin: agentConfig.admin === true || agentConfig.root === true,
         root: agentConfig.root === true,
+        // {{#if linearAgentEnabled}} in the agent-self-service fragment.
+        // KLANKER HAZARD: this reconcile-path claudeContext is a hand-curated
+        // subset, NOT buildWorkspaceContext — so this flag MUST mirror the
+        // value buildWorkspaceContext sets (scaffold.ts ~2240) byte-for-byte,
+        // or the self-service fragment renders differently on apply vs
+        // first-scaffold and the diff-abort below trips on every reconcile.
+        linearAgentEnabled:
+          (
+            agentConfig.channels?.telegram as
+              | { linear_agent?: { enabled?: boolean } }
+              | undefined
+          )?.linear_agent?.enabled === true,
       };
 
       // Render template, then append the switchroom-managed

--- a/src/cli/linear-agent.ts
+++ b/src/cli/linear-agent.ts
@@ -24,7 +24,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { readFileSync, writeFileSync } from "node:fs";
 import { getConfigPath, withConfigError } from "./helpers.js";
-import { setLinearAgent } from "./telegram-yaml.js";
+import { setLinearAgent, setLinearDefaultTeam } from "./telegram-yaml.js";
 import { vaultPut } from "./telegram.js";
 
 interface LinearAgentSetupOpts {
@@ -103,6 +103,41 @@ export function registerLinearAgentCommand(program: Command): void {
         }
 
         printLinearInstructions(opts, vaultKey);
+      }),
+    );
+
+  linear
+    .command("set-team")
+    .description(
+      "Set (or clear) the default Linear team captured issues file into for <agent>. Only needed when the workspace has multiple teams — a single-team workspace auto-resolves. Pass --clear to remove the default.",
+    )
+    .requiredOption("--agent <name>", "Agent name (must have a linear_agent block)")
+    .option("--team <id>", "Linear team id new captured issues default to.")
+    .option("--clear", "Remove the configured default team (revert to auto-resolve).")
+    .action(
+      withConfigError(async (opts: { agent: string; team?: string; clear?: boolean }) => {
+        if (!/^[a-z][a-z0-9_-]{0,63}$/.test(opts.agent)) {
+          fail(`--agent must be a lowercase agent slug (got '${opts.agent}').`);
+        }
+        if (!opts.clear && (!opts.team || opts.team.trim().length === 0)) {
+          fail("pass either --team <id> or --clear.");
+        }
+
+        const path = getConfigPath(program);
+        const before = readFileSync(path, "utf-8");
+        let after: string;
+        try {
+          after = setLinearDefaultTeam(before, opts.agent, opts.clear ? null : opts.team!.trim());
+        } catch (err) {
+          fail((err as Error).message);
+        }
+        writeFileSync(path, after, "utf-8");
+        if (opts.clear) {
+          console.log(chalk.green(`✓ Cleared default Linear team for '${opts.agent}' (auto-resolve).`));
+        } else {
+          console.log(chalk.green(`✓ Default Linear team for '${opts.agent}' set to ${opts.team!.trim()}.`));
+        }
+        console.log(chalk.gray(`  Run 'switchroom agent restart ${opts.agent}' to pick up the change.`));
       }),
     );
 }

--- a/src/cli/telegram-yaml.ts
+++ b/src/cli/telegram-yaml.ts
@@ -37,6 +37,35 @@ export function setLinearAgent(
 }
 
 /**
+ * Set `default_team_id` on an agent's existing `linear_agent` block (#2312).
+ *
+ * Only needed for multi-team Linear workspaces — single-team workspaces
+ * auto-resolve. Requires the `linear_agent` block to already exist (run
+ * `linear-agent setup` first); throws otherwise so we never silently create
+ * a half-configured block. Pass `teamId: null` to clear it.
+ */
+export function setLinearDefaultTeam(
+  yamlText: string,
+  agentName: string,
+  teamId: string | null,
+): string {
+  const doc = parseDocument(yamlText);
+  ensureAgent(doc, agentName);
+  if (!doc.hasIn(["agents", agentName, "channels", "telegram", "linear_agent"])) {
+    throw new Error(
+      `agent '${agentName}' has no linear_agent block. Run 'switchroom linear-agent setup --agent ${agentName} --token <token>' first.`,
+    );
+  }
+  const path = ["agents", agentName, "channels", "telegram", "linear_agent", "default_team_id"];
+  if (teamId === null) {
+    if (doc.hasIn(path)) doc.deleteIn(path);
+  } else {
+    doc.setIn(path, teamId);
+  }
+  return String(doc);
+}
+
+/**
  * Set a feature payload under `agents.<agentName>.channels.telegram.<feature>`.
  * Creates intermediate maps if absent. Returns the new YAML string.
  *

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -684,6 +684,38 @@ export function mergeAgentConfig(
       combined;
   }
 
+  // --- linear capture default: 👨‍💻 / 📌 → file a Linear issue (#2312) ---
+  //
+  // When an agent has `channels.telegram.linear_agent.enabled: true` and has
+  // NOT configured a `reaction_dispatch` emoji allowlist, default the capture
+  // emojis ON so the reaction → linear_create_issue flow works out of the box
+  // (Defaults test — zero config). This runs AFTER the reaction_dispatch
+  // cascade above so an explicit per-agent allowlist (including `emojis: []`
+  // to opt out) always wins — we only fill the hole when `emojis` is still
+  // unset. Touching only the (top-level) `reaction_dispatch.emojis`; the
+  // playbook block (gated on `linearAgentEnabled`) tells the agent what the
+  // capture emojis mean.
+  const linearEnabled =
+    (
+      merged.channels?.telegram as
+        | { linear_agent?: { enabled?: boolean } }
+        | undefined
+    )?.linear_agent?.enabled === true;
+  if (linearEnabled) {
+    const rd = (
+      merged as {
+        reaction_dispatch?: { enabled?: boolean; emojis?: unknown };
+      }
+    ).reaction_dispatch;
+    if (!rd || rd.emojis === undefined) {
+      (merged as { reaction_dispatch?: Record<string, unknown> }).reaction_dispatch =
+        {
+          enabled: rd?.enabled ?? true,
+          emojis: ["👨‍💻", "📌"],
+        };
+    }
+  }
+
   // --- resources: shallow per-key merge, agent wins ---
   //
   // Same shape as `experimental` below — operators may set a subset of

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -949,6 +949,16 @@ export const TelegramChannelSchema = z
             "multi-workspace disambiguation; the token already scopes the " +
             "app to its workspace.",
           ),
+        default_team_id: z
+          .string()
+          .optional()
+          .describe(
+            "Optional Linear team id new captured issues file into when the " +
+            "agent doesn't pass an explicit team_id. Unnecessary for a " +
+            "single-team workspace (auto-resolved); set it only when the " +
+            "workspace has multiple teams. Manage via " +
+            "`switchroom linear-agent set-team <agent> <team>`.",
+          ),
       })
       .optional()
       .describe(

--- a/telegram-plugin/gateway/linear-activity.ts
+++ b/telegram-plugin/gateway/linear-activity.ts
@@ -33,6 +33,9 @@ export interface LinearActivityDeps {
   fetchImpl?: typeof fetch
   /** Agent slug (defaults to SWITCHROOM_AGENT_NAME). */
   agent?: string
+  /** Default Linear team id for captured issues (multi-team workspaces);
+   *  defaults to SWITCHROOM_LINEAR_DEFAULT_TEAM_ID. Tests inject directly. */
+  defaultTeamId?: string
   /** Log sink — stderr in production. */
   log?: (line: string) => void
 }
@@ -190,7 +193,13 @@ export async function createLinearIssue(
   const title = args.title as string | undefined
   if (!title || title.trim() === '') throw new Error('linear_create_issue: title is required')
   const body = (args.body as string | undefined) ?? ''
-  const teamIdArg = (args.team_id as string | undefined) ?? undefined
+  // Explicit team_id wins; otherwise the operator's configured default team
+  // (scaffold injects SWITCHROOM_LINEAR_DEFAULT_TEAM_ID for multi-team
+  // workspaces); otherwise we auto-resolve below (zero-config single team).
+  const teamIdArg =
+    (args.team_id as string | undefined) ??
+    (deps.defaultTeamId ?? process.env.SWITCHROOM_LINEAR_DEFAULT_TEAM_ID) ??
+    undefined
   const dedupKey = (args.dedup_key as string | undefined) ?? undefined
   const priority = typeof args.priority === 'number' ? (args.priority as number) : undefined
 

--- a/telegram-plugin/tests/linear-create-issue.test.ts
+++ b/telegram-plugin/tests/linear-create-issue.test.ts
@@ -109,6 +109,28 @@ describe('createLinearIssue — behaviour (#2312)', () => {
     expect(calls[0].variables.input).toMatchObject({ teamId: 'team_explicit' })
   })
 
+  it('uses deps.defaultTeamId when no team_id is passed (multi-team default)', async () => {
+    const { fetchImpl, calls } = routingFetch({ issueCreate: issueOk })
+    const r = await createLinearIssue(
+      { title: 'X', body: 'Y' },
+      { resolveToken: okToken('t'), fetchImpl, defaultTeamId: 'team_default', log: () => {} },
+    )
+    expect(r.content[0].text).toMatch(/Filed:/)
+    // default team skips the teams() resolution entirely.
+    expect(calls).toHaveLength(1)
+    expect(calls[0].query).toMatch(/issueCreate/)
+    expect(calls[0].variables.input).toMatchObject({ teamId: 'team_default' })
+  })
+
+  it('explicit team_id overrides deps.defaultTeamId', async () => {
+    const { fetchImpl, calls } = routingFetch({ issueCreate: issueOk })
+    await createLinearIssue(
+      { title: 'X', body: 'Y', team_id: 'team_explicit' },
+      { resolveToken: okToken('t'), fetchImpl, defaultTeamId: 'team_default', log: () => {} },
+    )
+    expect(calls[0].variables.input).toMatchObject({ teamId: 'team_explicit' })
+  })
+
   it('passes priority through when provided', async () => {
     const { fetchImpl, calls } = routingFetch({ issueCreate: issueOk })
     await createLinearIssue(

--- a/tests/cli.telegram.test.ts
+++ b/tests/cli.telegram.test.ts
@@ -151,7 +151,44 @@ describe("telegram-yaml: removeTelegramFeature", () => {
 
 // ─── #597 phase 2: webhook source array helpers ─────────────────────────────
 
-import { addWebhookSource, removeWebhookSource, setLinearAgent } from "../src/cli/telegram-yaml.js";
+import { addWebhookSource, removeWebhookSource, setLinearAgent, setLinearDefaultTeam } from "../src/cli/telegram-yaml.js";
+
+describe("telegram-yaml: setLinearDefaultTeam (#2312)", () => {
+  const withLinear = setLinearAgent(
+    "agents:\n  carrie:\n    topic_name: C\n",
+    "carrie",
+    { token: "vault:linear/carrie/token" },
+  );
+
+  it("sets default_team_id on an existing linear_agent block", () => {
+    const after = setLinearDefaultTeam(withLinear, "carrie", "team_abc");
+    expect(after).toContain("default_team_id: team_abc");
+    expect(after).toContain("token: vault:linear/carrie/token");
+  });
+
+  it("overwrites an existing default_team_id (idempotent)", () => {
+    const once = setLinearDefaultTeam(withLinear, "carrie", "team_abc");
+    const twice = setLinearDefaultTeam(once, "carrie", "team_xyz");
+    expect(twice).toContain("default_team_id: team_xyz");
+    expect(twice).not.toContain("team_abc");
+  });
+
+  it("clears the default_team_id when passed null", () => {
+    const set = setLinearDefaultTeam(withLinear, "carrie", "team_abc");
+    const cleared = setLinearDefaultTeam(set, "carrie", null);
+    expect(cleared).not.toContain("default_team_id");
+  });
+
+  it("throws when the agent has no linear_agent block", () => {
+    const before = "agents:\n  carrie:\n    topic_name: C\n";
+    expect(() => setLinearDefaultTeam(before, "carrie", "team_abc")).toThrow(/no linear_agent block/);
+  });
+
+  it("throws when the agent isn't declared", () => {
+    const before = "agents:\n  carrie:\n    topic_name: C\n";
+    expect(() => setLinearDefaultTeam(before, "ghost", "team_abc")).toThrow(/not declared/);
+  });
+});
 
 describe("telegram-yaml: setLinearAgent (#2298)", () => {
   it("writes an enabled linear_agent block with a vault token ref", () => {

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -1103,3 +1103,62 @@ describe("mergeAgentConfig reaction_dispatch block", () => {
     expect(rd.emojis).toEqual(["👨‍💻"]);
   });
 });
+
+// ─── linear capture default-emoji injection (#2312) ───────────────────────
+
+function linearAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return baseAgent({
+    channels: { telegram: { linear_agent: { enabled: true, token: "vault:linear/x/token" } } },
+    ...overrides,
+  } as Partial<AgentConfig>);
+}
+
+describe("mergeAgentConfig linear capture default (#2312)", () => {
+  it("defaults the capture emojis ON when linear_agent is enabled and no reaction_dispatch is set", () => {
+    const result = mergeAgentConfig({} as AgentDefaults, linearAgent());
+    const rd = (result as { reaction_dispatch?: Record<string, unknown> }).reaction_dispatch!;
+    expect(rd).toEqual({ enabled: true, emojis: ["👨‍💻", "📌"] });
+  });
+
+  it("does NOT inject when linear_agent is absent", () => {
+    const result = mergeAgentConfig({} as AgentDefaults, baseAgent());
+    expect((result as { reaction_dispatch?: unknown }).reaction_dispatch).toBeUndefined();
+  });
+
+  it("does NOT inject when linear_agent.enabled is false", () => {
+    const agent = baseAgent({
+      channels: { telegram: { linear_agent: { enabled: false, token: "vault:linear/x/token" } } },
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig({} as AgentDefaults, agent);
+    expect((result as { reaction_dispatch?: unknown }).reaction_dispatch).toBeUndefined();
+  });
+
+  it("an explicit reaction_dispatch.emojis allowlist WINS over the default", () => {
+    const agent = linearAgent({
+      reaction_dispatch: { enabled: true, emojis: ["🔖"] },
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig({} as AgentDefaults, agent);
+    const rd = (result as { reaction_dispatch?: Record<string, unknown> }).reaction_dispatch!;
+    expect(rd.emojis).toEqual(["🔖"]);
+  });
+
+  it("respects an explicit opt-out via emojis: [] (does not re-inject)", () => {
+    const agent = linearAgent({
+      reaction_dispatch: { emojis: [] },
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig({} as AgentDefaults, agent);
+    const rd = (result as { reaction_dispatch?: Record<string, unknown> }).reaction_dispatch!;
+    expect(rd.emojis).toEqual([]);
+  });
+
+  it("preserves an operator-set enabled:false when only enabled (not emojis) is given", () => {
+    // emojis still undefined → we fill emojis but keep the operator's enabled.
+    const agent = linearAgent({
+      reaction_dispatch: { enabled: false },
+    } as Partial<AgentConfig>);
+    const result = mergeAgentConfig({} as AgentDefaults, agent);
+    const rd = (result as { reaction_dispatch?: Record<string, unknown> }).reaction_dispatch!;
+    expect(rd.enabled).toBe(false);
+    expect(rd.emojis).toEqual(["👨‍💻", "📌"]);
+  });
+});

--- a/tests/scaffold.linear-capture.test.ts
+++ b/tests/scaffold.linear-capture.test.ts
@@ -1,0 +1,97 @@
+/**
+ * #2312 — capture-on-reaction → Linear playbook gating + the klanker-hazard
+ * regression guard.
+ *
+ * The agent-self-service fragment renders a "Capture to Linear" playbook block
+ * gated on `{{#if linearAgentEnabled}}`. That flag MUST be set identically by
+ * BOTH render paths — scaffoldAgent's buildWorkspaceContext-derived `context`
+ * AND reconcileAgent's hand-curated `claudeContext`. If they diverge, reconcile
+ * diff-aborts CLAUDE.md on every `switchroom apply` (the klanker incident
+ * class). This test pins:
+ *   1. linear_agent.enabled ⇒ the playbook block lands in CLAUDE.md.
+ *   2. no linear_agent ⇒ the block is absent.
+ *   3. scaffold → reconcile is diff-stable for CLAUDE.md (the guard).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { reconcileAgent, scaffoldAgent } from "../src/agents/scaffold.js";
+import type {
+  AgentConfig,
+  SwitchroomConfig,
+  TelegramConfig,
+} from "../src/config/schema.js";
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+const switchroomConfig: SwitchroomConfig = {
+  agents: {},
+  telegram: telegramConfig,
+  defaults: {},
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+const linearEnabled = {
+  channels: { telegram: { linear_agent: { enabled: true, token: "vault:linear/test-agent/token" } } },
+} as Partial<AgentConfig>;
+
+const PLAYBOOK_MARKER = "Capture to Linear";
+
+function readClaudeMd(agentDir: string): string {
+  return readFileSync(join(agentDir, "CLAUDE.md"), "utf-8");
+}
+
+describe("linear capture playbook gating (#2312)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-linear-capture-"));
+  });
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("renders the playbook block when linear_agent is enabled", () => {
+    const config = makeAgentConfig(linearEnabled);
+    const { agentDir } = scaffoldAgent("test-agent", config, tmpDir, telegramConfig);
+    const claude = readClaudeMd(agentDir);
+    expect(claude).toContain(PLAYBOOK_MARKER);
+    expect(claude).toContain("linear_create_issue");
+    expect(claude).toContain("👨‍💻");
+  });
+
+  it("omits the playbook block when linear_agent is absent", () => {
+    const config = makeAgentConfig();
+    const { agentDir } = scaffoldAgent("test-agent", config, tmpDir, telegramConfig);
+    expect(readClaudeMd(agentDir)).not.toContain(PLAYBOOK_MARKER);
+  });
+
+  it("is diff-stable across reconcile (klanker-hazard guard)", () => {
+    // Both render paths must set linearAgentEnabled identically; otherwise the
+    // reconcile re-render differs from the scaffold render and CLAUDE.md shows
+    // up in `changes` on every apply.
+    const config = makeAgentConfig(linearEnabled);
+    const { agentDir } = scaffoldAgent("test-agent", config, tmpDir, telegramConfig);
+    const before = readClaudeMd(agentDir);
+
+    const result = reconcileAgent("test-agent", config, tmpDir, telegramConfig, switchroomConfig);
+
+    expect(result.changes).not.toContain(join(agentDir, "CLAUDE.md"));
+    expect(readClaudeMd(agentDir)).toBe(before);
+    // and the block survived the reconcile re-render.
+    expect(readClaudeMd(agentDir)).toContain(PLAYBOOK_MARKER);
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of **capture-on-reaction → Linear** (#2312), building on the `linear_create_issue` tool from PR 1 (#2314). Makes the 👨‍💻 / 📌 reaction → new Linear issue flow a **switchroom default for any Linear-connected agent**, zero config.

## Why

A `linear_agent`-enabled agent should "just work": react to a Telegram message with 👨‍💻 (laptop) or 📌 (pushpin), the agent files a well-formed Linear issue from that message + context and replies the link. This is the Defaults test (`reference/principles.md`) — works on a fresh setup with no per-agent reaction wiring.

## What

- **Cascade default** (`src/config/merge.ts`): when `channels.telegram.linear_agent.enabled` and the agent hasn't configured a `reaction_dispatch` emoji allowlist, default `reaction_dispatch` ON with `emojis: [👨‍💻, 📌]`. Runs *after* the #2291 cascade so an explicit per-agent allowlist (including `emojis: []` to opt out) always wins.
- **Scaffold flag** (`src/agents/scaffold.ts`): `linearAgentEnabled` set in **both** the shared `buildWorkspaceContext` and the reconcile-path `claudeContext`. This is the **klanker hazard** — a diverging value diff-aborts CLAUDE.md on every `apply` — now pinned by a diff-stability regression test.
- **Playbook** (`profiles/_shared/agent-self-service.md.hbs`): a `{{#if linearAgentEnabled}}` block telling the agent what a 👨‍💻/📌 reaction turn means, to call `linear_create_issue` with `dedup_key = <chat_id>:<message_id>`, and to **reply the link in plain text, not an emoji** (operator's explicit UX call).
- **Multi-team** (forward-looking; single-team stays zero-config): `linear_agent.default_team_id` schema field + `switchroom linear-agent set-team <agent> --team <id> | --clear`. Scaffold injects `SWITCHROOM_LINEAR_DEFAULT_TEAM_ID`; `createLinearIssue` falls back to it (and a `deps.defaultTeamId` test hook) when no `team_id` is passed.

## Test plan

- [x] `vitest run tests/merge.test.ts` — cascade inject / no-inject (absent + enabled:false) / explicit-allowlist-wins / emojis:[] opt-out / enabled:false preserved.
- [x] `vitest run tests/scaffold.linear-capture.test.ts` — playbook renders when enabled, absent when not, **diff-stable across reconcile (klanker guard)**.
- [x] `vitest run tests/cli.telegram.test.ts` — `setLinearDefaultTeam` set / overwrite / clear / throws (no block, no agent).
- [x] `vitest run telegram-plugin/tests/linear-create-issue.test.ts` — `defaultTeamId` precedence (explicit team_id > default > auto-resolve).
- [x] `tsc --noEmit` + `check-plugin-references.mjs` clean; scaffold/reconcile/schema/profiles regression suites green (161 tests).

## Risk

Low–moderate. The cascade default only fires for `linear_agent.enabled` agents (today: clerk-class, opt-in). The klanker hazard is the real risk and is explicitly guarded. No model/inference path touched (subscription-honest). The reaction → turn mechanism is the existing #2291 path; no per-hour cap added (human reaction rate + the tool's `dedup_key` idempotency are the current limiters — a gateway-side storm cap is a noted possible follow-up).

## Canary

test-harness, then clerk: enable `linear_agent`, `switchroom apply` + restart, react 👨‍💻 to a message in a DM, confirm the agent replies `📋 Filed: <url>` and the issue exists in Linear; re-react → "Already filed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)