### PR TITLE
fix(linear-agent): force webhook_via_gateway on setup (#2298)

### DIFF
--- a/src/cli/telegram-yaml.ts
+++ b/src/cli/telegram-yaml.ts
@@ -22,6 +22,14 @@ export type TelegramFeature = "voice_in" | "telegraph" | "webhook_sources" | "li
  * optional `workspace_id`). The token is a vault reference, never an inline
  * literal — the secret itself is stored in the vault by the CLI's vaultPut.
  * Idempotent on re-run (setIn overwrites the block).
+ *
+ * Also forces `channels.telegram.webhook_via_gateway: true`. A Linear agent
+ * is useless without it: inbound `AgentSessionEvent`s (the mention/delegation
+ * wakes) are handled gateway-side (`recordWebhookEvent`), and the web receiver
+ * only forwards to the gateway when `webhook_via_gateway === true`
+ * (`src/web/server.ts`). Setting the `linear_agent` block without it produces
+ * a configured-but-deaf agent — the gap that silently broke carrie's first
+ * standup until it was patched in by hand (#2298).
  */
 export function setLinearAgent(
   yamlText: string,
@@ -33,6 +41,7 @@ export function setLinearAgent(
   const block: Record<string, unknown> = { enabled: true, token: opts.token };
   if (opts.workspaceId) block.workspace_id = opts.workspaceId;
   doc.setIn(["agents", agentName, "channels", "telegram", "linear_agent"], block);
+  doc.setIn(["agents", agentName, "channels", "telegram", "webhook_via_gateway"], true);
   return String(doc);
 }
 

--- a/tests/cli.telegram.test.ts
+++ b/tests/cli.telegram.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { parse } from "yaml";
 import { setTelegramFeature, removeTelegramFeature } from "../src/cli/telegram-yaml.js";
 
 describe("telegram-yaml: setTelegramFeature", () => {
@@ -161,6 +162,24 @@ describe("telegram-yaml: setLinearAgent (#2298)", () => {
     expect(after).toContain("enabled: true");
     expect(after).toContain("token: vault:linear/carrie/token");
     expect(after).toContain("topic_name: Carrie");
+  });
+
+  it("forces webhook_via_gateway: true so inbound AgentSessionEvents reach the gateway (#2298)", () => {
+    // Without this the linear_agent block is configured-but-deaf: the web
+    // receiver only forwards to the gateway when webhook_via_gateway === true.
+    const before = "agents:\n  carrie:\n    topic_name: Carrie\n";
+    const after = setLinearAgent(before, "carrie", { token: "vault:linear/carrie/token" });
+    expect(after).toContain("webhook_via_gateway: true");
+    const parsed = parse(after) as { agents: { carrie: { channels: { telegram: { webhook_via_gateway?: boolean } } } } };
+    expect(parsed.agents.carrie.channels.telegram.webhook_via_gateway).toBe(true);
+  });
+
+  it("preserves an already-true webhook_via_gateway on re-run", () => {
+    const before =
+      "agents:\n  carrie:\n    channels:\n      telegram:\n        webhook_via_gateway: true\n";
+    const after = setLinearAgent(before, "carrie", { token: "vault:linear/carrie/token" });
+    const parsed = parse(after) as { agents: { carrie: { channels: { telegram: { webhook_via_gateway?: boolean } } } } };
+    expect(parsed.agents.carrie.channels.telegram.webhook_via_gateway).toBe(true);
   });
 
   it("includes workspace_id when provided", () => {


### PR DESCRIPTION
## Summary

\`linear-agent setup\` wrote the \`linear_agent\` block but **not**
\`channels.telegram.webhook_via_gateway: true\`. The result is a
configured-but-deaf Linear agent: inbound \`AgentSessionEvent\`s (the
mention/delegation wakes) never reach it.

## Why

Inbound AgentSessionEvents are handled **gateway-side** (\`recordWebhookEvent\`,
wired in \`telegram-plugin/gateway/gateway.ts\`). The web receiver only forwards
a webhook to the gateway when \`webhook_via_gateway === true\`
(\`src/web/server.ts:383\`). So a \`linear_agent\` block with that flag unset
produces an agent that authenticates the webhook but drops every event on the
floor.

This silently broke carrie's first standup — events 200'd at the receiver but
nothing woke the agent until \`webhook_via_gateway: true\` was patched in by hand.
This makes the CLI do it automatically so the next Linear agent works on the
first \`setup\`.

## Change

\`setLinearAgent\` now sets \`webhook_via_gateway: true\` alongside the
\`linear_agent\` block, idempotently (preserves an already-true value on re-run).

## Test plan

- [x] New test: \`setup\` forces \`webhook_via_gateway: true\` (string + parsed assertion)
- [x] New test: re-run preserves an already-true value
- [x] Existing setLinearAgent tests still green (24/24 in \`tests/cli.telegram.test.ts\`)
- [x] \`tsc --noEmit\` clean

## Risk

Low. Pure YAML-editor change, additive key, idempotent. No runtime/behavioral
change beyond the config it writes.