### PR TITLE
feat(approvals): "⏱ 30 min" scoped approval tier (conservative)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -420,6 +420,14 @@ import { startIssuesWatcher, type IssuesWatcherHandle } from '../issues-watcher.
 import { list as listIssues, resolve as resolveIssue } from '../../src/issues/index.js'
 import { formatPermissionCardBody, describeGrant, naturalAction, formatPermissionResumeMessage } from '../permission-title.js'
 import { resolveScopedAllowChoices, isRulePersisted } from '../permission-rule.js'
+import {
+  type ScopedGrantStore,
+  scopedApprovalTtlMs,
+  resolveTimeBox,
+  recordScopedGrant,
+  lookupScopedGrant,
+  sweepScopedGrants,
+} from '../scoped-approval.js'
 import { synthesizeAllowRuleDiff, extractAddedAllowRule } from '../permission-diff.js'
 import {
   readClaudeJsonOverage,
@@ -3651,6 +3659,14 @@ function sweepStaleAlwaysAllowCorrelations(now = Date.now()): void {
   }
 }
 
+// "⏱ 30 min" scoped-approval store (the middle tier between Allow-once and
+// 🔁 Always). Operator-tapped, gateway-side ONLY (never pushed to the
+// bridge's untimed sessionAllowRules), fixed-window, fail-closed. Keyed by
+// agent name for per-agent isolation. All policy lives in
+// ../scoped-approval.ts (pure + unit-tested); this gateway only wires it.
+const scopedGrants: ScopedGrantStore = new Map()
+const selfAgentName = (): string => process.env.SWITCHROOM_AGENT_NAME ?? ''
+
 // `ask_user` MCP tool — open prompts awaiting a user button-tap.
 // Keyed by askId (8 hex chars from generateAskId). Each entry holds
 // the deferred promise that resolves the originating tool call, the
@@ -4246,6 +4262,9 @@ const pendingStateReaper = setInterval(() => {
   for (const [k, v] of vaultPassphraseCache) {
     if (now > v.expiresAt) vaultPassphraseCache.delete(k)
   }
+  // Drop expired "⏱ 30 min" scoped grants. (Lookup already fails closed on
+  // expiry; this just keeps the map from accumulating dead entries.)
+  sweepScopedGrants(scopedGrants, now)
   for (const [k, v] of deferredSecrets) {
     if (now - v.staged_at > DEFERRED_SECRET_TTL_MS) deferredSecrets.delete(k)
   }
@@ -5591,10 +5610,18 @@ const pendingPermissionBuffer = createPendingPermissionBuffer()
  * rebuilds this row. callback_data stays tiny (verb + 5-char id) so we
  * never approach Telegram's 64-byte ceiling.
  */
-function buildPermissionActionRow(requestId: string, showAlways: boolean): InlineKeyboard {
+function buildPermissionActionRow(
+  requestId: string,
+  showAlways: boolean,
+  showTimeBox = false,
+): InlineKeyboard {
   const kb = new InlineKeyboard()
     .text('❌ Deny', `perm:deny:${requestId}`)
     .text('✅ Allow once', `perm:allow:${requestId}`)
+  // "⏱ 30 min" sits between once and always. Only shown for a narrow,
+  // non-destructive scope (resolveTimeBox decides); broad/MCP/destructive
+  // requests get once/always only.
+  if (showTimeBox) kb.text('⏱ 30 min', `perm:tmb:${requestId}`)
   if (showAlways) kb.text('🔁 Always…', `perm:always:${requestId}`)
   return kb
 }
@@ -5978,6 +6005,32 @@ const ipcServer: IpcServer = createIpcServer({
 
   onPermissionRequest(_client: IpcClient, msg: PermissionRequestForward) {
     const { requestId, toolName, description, inputPreview } = msg
+    // "⏱ 30 min" short-circuit: if the operator tapped a live scoped grant
+    // covering this exact request, auto-allow without posting a card. CRITICAL:
+    // dispatch WITHOUT a `rule` so the bridge does NOT cache it untimed
+    // (sessionAllowRules has no TTL — a `rule` here would silently promote the
+    // 30-min window to session-forever). The fixed window lives only in
+    // scopedGrants. lookupScopedGrant fails closed on expiry and on a
+    // destructive Bash command matching a family grant. No card, no pending
+    // entry, no awaiting reaction — the turn just continues, silently.
+    const scopedTtl = scopedApprovalTtlMs()
+    if (scopedTtl > 0) {
+      const hit = lookupScopedGrant(scopedGrants, selfAgentName(), toolName, inputPreview, Date.now())
+      if (hit) {
+        // Silent auto-allow — no card was posted and the turn was never parked
+        // on the awaiting glyph, so we intentionally OMIT the resume-glyph flip
+        // and the agent-voiced resume message (posting "got it, continuing" on
+        // every auto-allowed call is the exact noise this tier removes). The
+        // `no-card-verdict` sentinel below exempts this callsite from the
+        // resume-guard pairing test.
+        dispatchPermissionVerdict({ type: 'permission', requestId, behavior: 'allow' }) // no-card-verdict
+        process.stderr.write(
+          `telegram gateway: scoped-approval auto-allow tool=${toolName} rule="${hit}" ` +
+          `request=${requestId} (time-boxed window)\n`,
+        )
+        return
+      }
+    }
     pendingPermissions.set(requestId, { tool_name: toolName, description, input_preview: inputPreview, startedAt: Date.now() })
     // Natural-language card body — a plain sentence ("Gymbro wants to
     // edit: supplement-log.md" + a why-line), never a raw tool id.
@@ -5996,8 +6049,13 @@ const ipcServer: IpcServer = createIpcServer({
     // any file ⚠️). The "🔁 Always…" button only appears when we can
     // synthesize a meaningful rule for this tool; unknown tools get the
     // two-button row only.
-    const showAlways = resolveScopedAllowChoices(toolName, inputPreview) != null
-    const keyboard = buildPermissionActionRow(requestId, showAlways)
+    const scopeChoices = resolveScopedAllowChoices(toolName, inputPreview)
+    const showAlways = scopeChoices != null
+    // Offer "⏱ 30 min" only for a narrow, non-destructive scope, and only
+    // when the tier is enabled (TTL > 0).
+    const showTimeBox = scopedApprovalTtlMs() > 0 &&
+      resolveTimeBox(toolName, inputPreview, scopeChoices) != null
+    const keyboard = buildPermissionActionRow(requestId, showAlways, showTimeBox)
     // Route the card to the SAME place the post-verdict resume message
     // lands (resolvePermissionCardTargets): the ORIGINATING chat+topic when
     // there's an active turn — so a supergroup agent's card appears IN the
@@ -18969,7 +19027,7 @@ bot.on('callback_query:data', async ctx => {
   }
 
   // Permission request buttons.
-  const m = /^perm:(allow|deny|always|asn|asb|back):([a-km-z]{5})$/.exec(data)
+  const m = /^perm:(allow|deny|always|asn|asb|back|tmb):([a-km-z]{5})$/.exec(data)
   if (!m) { await ctx.answerCallbackQuery().catch(() => {}); return }
   const access = loadAccess()
   const senderId = String(ctx.from.id)
@@ -18984,7 +19042,10 @@ bot.on('callback_query:data', async ctx => {
     if (!details) { await ctx.answerCallbackQuery({ text: 'Details no longer available.' }).catch(() => {}); return }
     let keyboard: InlineKeyboard
     if (behavior === 'back') {
-      keyboard = buildPermissionActionRow(request_id, true)
+      const backChoices = resolveScopedAllowChoices(details.tool_name, details.input_preview)
+      const backTimeBox = scopedApprovalTtlMs() > 0 &&
+        resolveTimeBox(details.tool_name, details.input_preview, backChoices) != null
+      keyboard = buildPermissionActionRow(request_id, true, backTimeBox)
     } else {
       const choices = resolveScopedAllowChoices(details.tool_name, details.input_preview)
       if (choices == null) {
@@ -19202,6 +19263,55 @@ bot.on('callback_query:data', async ctx => {
     // card; no synthInbound (would double-fire the verdict).
     await finalizeCallback(ctx, {
       ackText: ackText.slice(0, 200),
+      newText: baseText ? `${baseText}\n\n${editLabel}` : editLabel,
+      parseMode: 'HTML',
+    })
+    return
+  }
+
+  // "⏱ 30 min" — record a fixed-window scoped grant for the NARROW scope,
+  // then allow the in-flight call. Mirrors the asn/asb structure: dispatch
+  // the verdict immediately, then edit the card. CRITICAL: the verdict
+  // carries NO `rule` (unlike asn/asb), so the bridge does not cache it
+  // untimed — the window lives only in scopedGrants, gateway-side.
+  if (behavior === 'tmb') {
+    const details = pendingPermissions.get(request_id)
+    if (!details) { await ctx.answerCallbackQuery({ text: 'Details no longer available.' }).catch(() => {}); return }
+    const ttl = scopedApprovalTtlMs()
+    if (ttl <= 0) { await ctx.answerCallbackQuery({ text: 'Time-boxed approvals are disabled.' }).catch(() => {}); return }
+    const choices = resolveScopedAllowChoices(details.tool_name, details.input_preview)
+    const tb = resolveTimeBox(details.tool_name, details.input_preview, choices)
+    if (!tb) { await ctx.answerCallbackQuery({ text: 'This action can\'t be time-boxed.' }).catch(() => {}); return }
+    const agentName = selfAgentName()
+    if (!agentName) { await ctx.answerCallbackQuery({ text: 'Time-box needs SWITCHROOM_AGENT_NAME — gateway is misconfigured.' }).catch(() => {}); return }
+
+    pendingPermissions.delete(request_id)
+    // (1) Allow the in-flight call NOW — no `rule` (keeps the window
+    // strictly gateway-side; the bridge must not cache it untimed).
+    dispatchPermissionVerdict({ type: 'permission', requestId: request_id, behavior: 'allow' })
+    // (2) Record the fixed-window grant so matching calls auto-allow.
+    recordScopedGrant(scopedGrants, agentName, tb.rule, Date.now(), ttl)
+    resumeReactionAfterVerdict()
+    postPermissionResumeMessage({
+      behavior: 'allow',
+      action: naturalAction(details.tool_name, details.input_preview),
+    })
+    process.stderr.write(
+      `telegram gateway: scoped-approval granted rule="${tb.rule}" agent=${agentName} ` +
+      `ttl_ms=${ttl} (request_id=${request_id})\n`,
+    )
+
+    const mins = Math.max(1, Math.round(ttl / 60_000))
+    // Honest card: state the real BREADTH (e.g. "any `git` command"), not
+    // just the rule, plus the window — consent covers both (access-model
+    // honest-card contract).
+    const sourceMsg = ctx.callbackQuery?.message
+    const baseText = sourceMsg && 'text' in sourceMsg && sourceMsg.text
+      ? escapeHtmlForTg(sourceMsg.text)
+      : ''
+    const editLabel = `⏱ <b>Allowed for ${mins} min — ${escapeHtmlForTg(tb.breadth)}</b> · re-asks after that, and now for anything else`
+    await finalizeCallback(ctx, {
+      ackText: `⏱ Allowed for ${mins} min`.slice(0, 200),
       newText: baseText ? `${baseText}\n\n${editLabel}` : editLabel,
       parseMode: 'HTML',
     })

--- a/telegram-plugin/scoped-approval.ts
+++ b/telegram-plugin/scoped-approval.ts
@@ -203,6 +203,15 @@ export function isDestructiveBashCommand(command: string): boolean {
   if (!command || !command.trim()) return true;
   const c = command.toLowerCase();
 
+  // Backtick command substitution is un-vettable: the destructive op can
+  // hide inside `…` where the command-position anchors below (which include
+  // `$(` but not the backtick) would miss it — e.g. `git status \`rm -rf x\``
+  // matches the `Bash(git:*)` family but its first token is the harmless
+  // `git`. There is no need to time-box a backtick-substituted command, so
+  // fail closed (re-card). `$(…)` substitution stays handled by the `(`
+  // anchor in the rules below.
+  if (c.includes("`")) return true;
+
   // download-and-execute: ... | sh|bash|python|node
   if (/\|\s*(sudo\s+)?(sh|bash|zsh|fish|python\d?|perl|ruby|node)\b/.test(c)) return true;
   // privilege escalation

--- a/telegram-plugin/scoped-approval.ts
+++ b/telegram-plugin/scoped-approval.ts
@@ -1,0 +1,244 @@
+/**
+ * Scoped, time-boxed approval — the "⏱ 30 min" tier, the middle rung
+ * between "✅ Allow once" (re-prompts on the very next call) and
+ * "🔁 Always…" (a durable `tools.allow` write that lasts forever). After
+ * the operator taps "⏱ 30 min" on a permission card, byte-identical
+ * in-scope requests auto-allow for a fixed window without re-carding.
+ *
+ * Design contract (reference/access-model.md — "you hold the leash"):
+ *
+ *  - **Operator-authored only.** Every cache entry is created by an
+ *    `allowFrom`-authenticated Telegram tap. No tool call can seed an
+ *    entry (first contact always cards) or extend one (the window is a
+ *    FIXED box — `recordScopedGrant` sets `expiresAt` once; a matching
+ *    request never moves it). So an agent can never author its own
+ *    authorization.
+ *  - **Gateway-side only.** This store lives in the gateway process. It
+ *    must NOT be pushed down to the bridge's `sessionAllowRules`
+ *    (`bridge.ts`) — that cache is agent-uid, untimed, and would silently
+ *    promote a 30-min grant to session-forever. The gateway dispatches
+ *    the in-flight allow WITHOUT the `rule` field for exactly this reason.
+ *  - **Conservative scope (this tier, v1).** Only the *narrow* scope is
+ *    ever time-boxed: an exact file path (`Edit(/x.ts)`) or a Bash
+ *    command-family (`Bash(git:*)`). Broad scopes ("any file", resource-
+ *    blind MCP, "any command") are NOT offered the ⏱ button — they stay
+ *    once / always. This covers the real fatigue (re-editing the same
+ *    file, re-running a safe command) without fanning one tap across an
+ *    unbounded action set.
+ *  - **Fail-closed on irreversible.** A Bash family grant (`Bash(git:*)`)
+ *    must never auto-allow a destructive member of that family
+ *    (`git push --force`, `git reset --hard`). `isDestructiveBashCommand`
+ *    is re-checked at BOTH grant time (don't offer ⏱) and match time
+ *    (a cached family grant fails closed → re-cards) so per-call consent
+ *    for irreversible actions is preserved.
+ *
+ * Pure + side-effect-free so it unit-tests under vitest AND bun without a
+ * Grammy context (mirrors permission-rule.ts). Callers pass `now`/`ttlMs`
+ * explicitly; nothing reads the clock here.
+ */
+
+import { basename } from "node:path";
+import { matchesAllowRule, type ScopedAllowChoices } from "./permission-rule.js";
+
+/** Default time-box window: 30 minutes. */
+export const SCOPED_APPROVAL_DEFAULT_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Resolve the configured window from the environment. `0` (or negative)
+ * disables the tier — the gateway hides the ⏱ button and never
+ * short-circuits. A blank/garbage value falls back to the 30-min default.
+ * Kill-switch: `SWITCHROOM_SCOPED_APPROVAL_TTL_MS=0`.
+ */
+export function scopedApprovalTtlMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env.SWITCHROOM_SCOPED_APPROVAL_TTL_MS;
+  if (raw === undefined || raw.trim() === "") return SCOPED_APPROVAL_DEFAULT_TTL_MS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return SCOPED_APPROVAL_DEFAULT_TTL_MS;
+  return Math.floor(n);
+}
+
+/** A single operator-tapped, time-boxed grant. */
+export interface ScopedGrant {
+  /** Narrow allow-rule, e.g. `Edit(/state/x.ts)` or `Bash(git:*)`. */
+  readonly rule: string;
+  /** Unix-ms when this grant stops auto-allowing. Fixed at grant time. */
+  readonly expiresAt: number;
+}
+
+/** Per-agent store of live time-boxed grants. Keyed by agent name. */
+export type ScopedGrantStore = Map<string, ScopedGrant[]>;
+
+/** The narrow rule + an honest operator-facing breadth phrase for the card. */
+export interface TimeBoxDecision {
+  readonly rule: string;
+  /** e.g. "edits to x.ts" / "any `git` command" — states the real breadth. */
+  readonly breadth: string;
+}
+
+const FILE_RULE = /^(Edit|Write|MultiEdit|NotebookEdit|Read)\((.+)\)$/;
+const BASH_FAMILY_RULE = /^Bash\(([^:]+):\*\)$/;
+
+/**
+ * Conservative time-box eligibility. Given the already-resolved scope
+ * choices for a permission request, return the NARROW rule to time-box
+ * plus an honest breadth phrase — or `null` when this request must not
+ * get a ⏱ button (broad-only tools, MCP, Skill, a destructive Bash
+ * command, or any tool with no narrow sub-scope).
+ *
+ *  - File tools with an exact path → time-boxable (bounded to the one
+ *    operator-seen file).
+ *  - Bash with a first-token family → time-boxable ONLY when the
+ *    triggering command itself is non-destructive. The family grant
+ *    still covers the whole `<tok>` family for matching, but match-time
+ *    re-checks each later command (see `lookupScopedGrant`).
+ */
+export function resolveTimeBox(
+  toolName: string,
+  inputPreview: string | undefined,
+  choices: ScopedAllowChoices | null,
+): TimeBoxDecision | null {
+  // Only ever time-box the narrow scope, and only when one exists.
+  const specific = choices?.specific;
+  if (!specific || specific.broad) return null;
+  const rule = specific.rule;
+
+  const fileMatch = FILE_RULE.exec(rule);
+  if (fileMatch) {
+    const verb = fileMatch[1] === "Read" ? "reads of" : "edits to";
+    return { rule, breadth: `${verb} ${basename(fileMatch[2]!)}` };
+  }
+
+  const bashMatch = BASH_FAMILY_RULE.exec(rule);
+  if (bashMatch) {
+    const cmd = readBashCommand(inputPreview);
+    // No command text to vet, or a destructive triggering command → don't
+    // offer the time-box at all (fall through to once / always).
+    if (!cmd || isDestructiveBashCommand(cmd)) return null;
+    return { rule, breadth: `any \`${bashMatch[1]}\` command` };
+  }
+
+  // MCP (resource-blind), Skill, broad-only tools → not time-boxed in the
+  // conservative tier.
+  return null;
+}
+
+/**
+ * Record an operator-tapped 30-min grant. The window is a FIXED box: a
+ * re-tap on the same rule resets it (the operator just re-approved), but
+ * nothing else ever moves `expiresAt`. Re-tapping the same rule replaces
+ * the prior entry rather than accumulating duplicates. A non-positive
+ * `ttlMs` is a no-op (tier disabled).
+ */
+export function recordScopedGrant(
+  store: ScopedGrantStore,
+  agent: string,
+  rule: string,
+  now: number,
+  ttlMs: number,
+): void {
+  if (ttlMs <= 0) return;
+  const list = store.get(agent) ?? [];
+  const others = list.filter((g) => g.rule !== rule);
+  others.push({ rule, expiresAt: now + ttlMs });
+  store.set(agent, others);
+}
+
+/**
+ * Is there a LIVE operator-tapped grant covering this request? Returns the
+ * matching rule (for the audit log line) or `null`.
+ *
+ * FAIL-CLOSED in two ways:
+ *   1. an expired grant never matches (→ re-card);
+ *   2. a destructive Bash command never auto-allows even when its family
+ *      grant (`Bash(git:*)`) matches — `git push --force` re-cards even
+ *      after `git status` was time-boxed.
+ *
+ * Never mutates the store (no window-sliding). Pure read.
+ */
+export function lookupScopedGrant(
+  store: ScopedGrantStore,
+  agent: string,
+  toolName: string,
+  inputPreview: string | undefined,
+  now: number,
+): string | null {
+  const list = store.get(agent);
+  if (!list || list.length === 0) return null;
+  for (const g of list) {
+    if (g.expiresAt <= now) continue; // expired → fail closed
+    if (!matchesAllowRule(g.rule, toolName, inputPreview)) continue;
+    if (toolName === "Bash") {
+      const cmd = readBashCommand(inputPreview);
+      // Family grant matched, but re-vet THIS command: destructive or
+      // un-vettable → fail closed, re-card.
+      if (!cmd || isDestructiveBashCommand(cmd)) return null;
+    }
+    return g.rule;
+  }
+  return null;
+}
+
+/** Drop expired grants. Call from the gateway's periodic sweep. */
+export function sweepScopedGrants(store: ScopedGrantStore, now: number): void {
+  for (const [agent, list] of store) {
+    const live = list.filter((g) => g.expiresAt > now);
+    if (live.length === 0) store.delete(agent);
+    else if (live.length !== list.length) store.set(agent, live);
+  }
+}
+
+/**
+ * Heuristic destructive/irreversible-command detector. FAIL-CLOSED: when
+ * a command can't be read or looks risky, return `true` so it is never
+ * time-boxed (it re-prompts instead). Better to re-card a safe command
+ * than auto-allow a destructive one. Covers the access-model crown-jewel
+ * cases that ride the tool-permission channel: pipe-to-shell, privilege
+ * escalation, destructive coreutils/disk ops, recursive perms, device
+ * redirects, destructive git, power/process control, and bulk
+ * docker/package teardown.
+ */
+export function isDestructiveBashCommand(command: string): boolean {
+  if (!command || !command.trim()) return true;
+  const c = command.toLowerCase();
+
+  // download-and-execute: ... | sh|bash|python|node
+  if (/\|\s*(sudo\s+)?(sh|bash|zsh|fish|python\d?|perl|ruby|node)\b/.test(c)) return true;
+  // privilege escalation
+  if (/(^|\s|;|&&|\|\||\()sudo\b/.test(c)) return true;
+  if (/(^|\s|;|&&|\|\||\()(su|doas)\s/.test(c)) return true;
+  // destructive coreutils / disk
+  if (/(^|\s|;|&&|\|\||\()(rm|rmdir|dd|shred|truncate|fdisk|mkfs\S*|wipefs|blkdiscard|fallocate)\b/.test(c)) return true;
+  // recursive permission / ownership changes (-R / --recursive)
+  if (/\b(chmod|chown|chgrp)\b[^|;&]*(\s-(-recursive|[a-z]*r[a-z]*)\b)/.test(c)) return true;
+  // redirection clobbering devices or system dirs
+  if (/>\s*\/(dev|etc|boot|sys|proc)\b/.test(c)) return true;
+  // destructive git
+  if (/\bgit\b/.test(c) &&
+      /(push\b[^|;&]*(--force|-f\b|--force-with-lease)|push\s+[^\s]*\s+\+|reset\s+--hard|clean\s+-[a-z]*[fd]|filter-branch|reflog\s+expire|update-ref\s+-d|branch\s+-d{1,2}\b|checkout\s+--\s|restore\b)/.test(c)) return true;
+  // power / process control
+  if (/(^|\s|;|&&|\|\||\()(shutdown|reboot|halt|poweroff|kill|killall|pkill)\b/.test(c)) return true;
+  if (/(^|\s)init\s+0\b/.test(c)) return true;
+  // bulk docker teardown / package removal
+  if (/\bdocker\b[^|;&]*\b(rm|prune)\b/.test(c)) return true;
+  if (/(^|\s)(apt|apt-get|yum|dnf|brew|pacman|npm|pnpm|yarn|pip\d?)\b[^|;&]*\b(remove|uninstall|purge|prune)\b/.test(c)) return true;
+  // fork bomb
+  if (/:\s*\(\s*\)\s*\{/.test(c)) return true;
+
+  return false;
+}
+
+/** Extract the `command` string from a permission_request input preview. */
+function readBashCommand(inputPreview: string | undefined): string | null {
+  if (!inputPreview || typeof inputPreview !== "string") return null;
+  const trimmed = inputPreview.trim();
+  if (!trimmed.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    const cmd = parsed?.command;
+    return typeof cmd === "string" && cmd.length > 0 ? cmd : null;
+  } catch {
+    return null;
+  }
+}

--- a/telegram-plugin/tests/permission-verdict-resume-guard.test.ts
+++ b/telegram-plugin/tests/permission-verdict-resume-guard.test.ts
@@ -54,6 +54,17 @@ const dispatchCallsites = LINES.flatMap((line, i) =>
     : [],
 )
 
+// A SILENT auto-allow path (the "⏱ 30 min" scoped-approval short-circuit in
+// onPermissionRequest) posts NO card: the turn was never parked on 🙏, so it
+// must NOT call resumeReactionAfterVerdict() / postPermissionResumeMessage()
+// — doing so on every auto-allowed call is the exact noise that tier removes.
+// Such callsites carry the `no-card-verdict` sentinel within the 3 lines above
+// the dispatch and are exempt from the resume/post pairing. The invariant the
+// guard protects (a verdict that un-parks a CARD must visibly resume it) still
+// holds for every card-bearing path.
+const isSilentNoCardVerdict = (idx: number): boolean =>
+  LINES.slice(Math.max(0, idx - 3), idx + 1).some((l) => /no-card-verdict/.test(l))
+
 // How far below the dispatch the resume call is allowed to live. The
 // widest real gap today is ~9 lines (the slash-command path); 15 gives
 // refactor headroom without letting an unrelated resume "cover" a
@@ -68,6 +79,7 @@ describe('permission verdict → resume reaction wiring', () => {
   it('every dispatchPermissionVerdict() callsite flips the awaiting glyph back via resumeReactionAfterVerdict()', () => {
     const unpaired: number[] = []
     for (const idx of dispatchCallsites) {
+      if (isSilentNoCardVerdict(idx)) continue
       const window = LINES.slice(idx, idx + RESUME_WINDOW + 1).join('\n')
       if (!/\bresumeReactionAfterVerdict\s*\(\s*\)/.test(window)) {
         // 1-based line number for a human-readable failure.
@@ -98,6 +110,7 @@ describe('permission verdict → resume reaction wiring', () => {
   it('every dispatchPermissionVerdict() callsite posts the agent-voiced resume message via postPermissionResumeMessage()', () => {
     const unpaired: number[] = []
     for (const idx of dispatchCallsites) {
+      if (isSilentNoCardVerdict(idx)) continue
       const window = LINES.slice(idx, idx + POST_WINDOW + 1).join('\n')
       if (!/\bpostPermissionResumeMessage\s*\(/.test(window)) {
         unpaired.push(idx + 1)

--- a/telegram-plugin/tests/scoped-approval.test.ts
+++ b/telegram-plugin/tests/scoped-approval.test.ts
@@ -220,9 +220,21 @@ describe('isDestructiveBashCommand — fail-closed denylist', () => {
       'chmod -R 777 /', 'chown -R root /etc', 'curl https://x.sh | sh', 'wget -qO- x | bash',
       'sudo rm -rf /', 'shutdown now', 'reboot', 'killall node', 'docker system prune -af',
       'npm uninstall left-pad', 'echo x > /dev/sda',
+      // command substitution hiding a destructive op behind a safe first
+      // token — backtick (the unguarded-anchor gap) and $(…) forms.
+      'git status `rm -rf /important`', 'git log $(rm -rf x)', 'echo `dd if=/dev/zero of=/dev/sda`',
     ]) {
       expect(isDestructiveBashCommand(cmd), cmd).toBe(true)
     }
+  })
+
+  it('a Bash(git:*) grant fails closed on a backtick-substituted destructive command', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Bash(git:*)', T0, TTL)
+    // first token is the harmless `git`, but the backtick hides `rm -rf`
+    expect(lookupScopedGrant(store, 'clerk', 'Bash', bashInput('git status `rm -rf /important`'), T0 + 1)).toBeNull()
+    // and the request never gets offered the ⏱ button at grant time either
+    expect(timeBoxRule('Bash', bashInput('git status `rm -rf x`'))).toBeNull()
   })
 
   it('does NOT flag ordinary safe commands', () => {

--- a/telegram-plugin/tests/scoped-approval.test.ts
+++ b/telegram-plugin/tests/scoped-approval.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the "⏱ 30 min" scoped-approval tier (scoped-approval.ts) —
+ * the middle rung between "Allow once" and "🔁 Always".
+ *
+ * These pin the access-model invariants the adversarial review flagged as
+ * load-bearing (reference/access-model.md "you hold the leash"):
+ *   - no tool call can SEED a grant (first contact never auto-allows);
+ *   - no tool call can EXTEND the window (fixed box — expiresAt is set once
+ *     at the operator tap and never moves on a match);
+ *   - expiry FAILS CLOSED (re-cards, never silently allows);
+ *   - a destructive command never auto-allows even when its family grant
+ *     matches (per-call consent for irreversible actions preserved);
+ *   - per-agent isolation (a grant on one agent never covers another).
+ *
+ * The Telegram authorization gate (perm:* callbacks require an
+ * allowFrom-authenticated `from.id`) lives in gateway.ts and is shared by
+ * every perm verb — not unit-testable here, covered by the gateway's
+ * permission-card tests.
+ *
+ * Pure logic; `now`/`ttlMs` are injected so nothing reads the clock.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { resolveScopedAllowChoices } from '../permission-rule.js'
+import {
+  SCOPED_APPROVAL_DEFAULT_TTL_MS,
+  scopedApprovalTtlMs,
+  resolveTimeBox,
+  recordScopedGrant,
+  lookupScopedGrant,
+  sweepScopedGrants,
+  isDestructiveBashCommand,
+  type ScopedGrantStore,
+} from '../scoped-approval.js'
+
+const T0 = 1_000_000
+const TTL = SCOPED_APPROVAL_DEFAULT_TTL_MS
+
+const editInput = (path: string) => JSON.stringify({ file_path: path })
+const bashInput = (command: string) => JSON.stringify({ command })
+
+// Resolve the narrow rule the gateway would record for a given request.
+function timeBoxRule(tool: string, input: string | undefined): string | null {
+  const choices = resolveScopedAllowChoices(tool, input)
+  return resolveTimeBox(tool, input, choices)?.rule ?? null
+}
+
+describe('scopedApprovalTtlMs', () => {
+  it('defaults to 30 minutes', () => {
+    expect(scopedApprovalTtlMs({})).toBe(SCOPED_APPROVAL_DEFAULT_TTL_MS)
+    expect(SCOPED_APPROVAL_DEFAULT_TTL_MS).toBe(30 * 60 * 1000)
+  })
+  it('0 disables the tier', () => {
+    expect(scopedApprovalTtlMs({ SWITCHROOM_SCOPED_APPROVAL_TTL_MS: '0' })).toBe(0)
+  })
+  it('honors a custom positive value', () => {
+    expect(scopedApprovalTtlMs({ SWITCHROOM_SCOPED_APPROVAL_TTL_MS: '600000' })).toBe(600000)
+  })
+  it('falls back to default on blank / garbage / negative', () => {
+    expect(scopedApprovalTtlMs({ SWITCHROOM_SCOPED_APPROVAL_TTL_MS: '' })).toBe(TTL)
+    expect(scopedApprovalTtlMs({ SWITCHROOM_SCOPED_APPROVAL_TTL_MS: 'abc' })).toBe(TTL)
+    expect(scopedApprovalTtlMs({ SWITCHROOM_SCOPED_APPROVAL_TTL_MS: '-5' })).toBe(TTL)
+  })
+})
+
+describe('resolveTimeBox — conservative eligibility', () => {
+  it('time-boxes a file edit with an exact path (narrow only)', () => {
+    expect(timeBoxRule('Edit', editInput('/state/x.ts'))).toBe('Edit(/state/x.ts)')
+    expect(timeBoxRule('Write', editInput('/state/y.md'))).toBe('Write(/state/y.md)')
+  })
+
+  it('produces an honest breadth phrase', () => {
+    const choices = resolveScopedAllowChoices('Edit', editInput('/state/x.ts'))
+    expect(resolveTimeBox('Edit', editInput('/state/x.ts'), choices)?.breadth).toContain('x.ts')
+    const bashChoices = resolveScopedAllowChoices('Bash', bashInput('git status'))
+    expect(resolveTimeBox('Bash', bashInput('git status'), bashChoices)?.breadth).toContain('git')
+  })
+
+  it('time-boxes a non-destructive Bash command-family', () => {
+    expect(timeBoxRule('Bash', bashInput('git status'))).toBe('Bash(git:*)')
+    expect(timeBoxRule('Bash', bashInput('npm test'))).toBe('Bash(npm:*)')
+  })
+
+  it('does NOT time-box a destructive Bash trigger', () => {
+    expect(timeBoxRule('Bash', bashInput('rm -rf /tmp/x'))).toBeNull()
+    expect(timeBoxRule('Bash', bashInput('git push --force'))).toBeNull()
+    expect(timeBoxRule('Bash', bashInput('sudo systemctl restart x'))).toBeNull()
+  })
+
+  it('does NOT time-box a file edit with no resolvable path (broad-only)', () => {
+    expect(timeBoxRule('Edit', undefined)).toBeNull()
+  })
+
+  it('does NOT time-box MCP tools (resource-blind breadth)', () => {
+    expect(timeBoxRule('mcp__notion__notion-update-page', '{}')).toBeNull()
+  })
+
+  it('does NOT time-box broad-only / unknown tools', () => {
+    expect(timeBoxRule('WebFetch', '{}')).toBeNull()
+    expect(timeBoxRule('Skill', JSON.stringify({ skill: 'deep-research' }))).toBeNull()
+    expect(timeBoxRule('TotallyUnknown', '{}')).toBeNull()
+  })
+})
+
+describe('lookupScopedGrant — no seed, no extend, fail closed', () => {
+  it('first contact never auto-allows (no operator tap = no entry)', () => {
+    const store: ScopedGrantStore = new Map()
+    expect(lookupScopedGrant(store, 'clerk', 'Edit', editInput('/state/x.ts'), T0)).toBeNull()
+  })
+
+  it('auto-allows an identical in-scope request after a grant', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, TTL)
+    expect(lookupScopedGrant(store, 'clerk', 'Edit', editInput('/state/x.ts'), T0 + 60_000))
+      .toBe('Edit(/state/x.ts)')
+  })
+
+  it('does NOT cover a different file (scope drift bounded)', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, TTL)
+    expect(lookupScopedGrant(store, 'clerk', 'Edit', editInput('/state/y.ts'), T0 + 1)).toBeNull()
+  })
+
+  it('FIXED window — a matching call never extends expiresAt', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, TTL)
+    const before = store.get('clerk')![0]!.expiresAt
+    // Many matching lookups deep into the window…
+    for (let i = 0; i < 50; i++) {
+      lookupScopedGrant(store, 'clerk', 'Edit', editInput('/state/x.ts'), T0 + TTL - 1000)
+    }
+    expect(store.get('clerk')![0]!.expiresAt).toBe(before) // unchanged
+    // …and once the original window elapses, it re-cards.
+    expect(lookupScopedGrant(store, 'clerk', 'Edit', editInput('/state/x.ts'), T0 + TTL)).toBeNull()
+  })
+
+  it('expiry fails closed (re-cards, never silently allows)', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, TTL)
+    expect(lookupScopedGrant(store, 'clerk', 'Edit', editInput('/state/x.ts'), T0 + TTL)).toBeNull()
+    expect(lookupScopedGrant(store, 'clerk', 'Edit', editInput('/state/x.ts'), T0 + TTL + 1)).toBeNull()
+  })
+})
+
+describe('lookupScopedGrant — Bash family fail-closed on destructive members', () => {
+  it('a Bash(git:*) grant auto-allows safe git, NOT destructive git', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Bash(git:*)', T0, TTL)
+    // safe member → auto-allow
+    expect(lookupScopedGrant(store, 'clerk', 'Bash', bashInput('git status'), T0 + 1)).toBe('Bash(git:*)')
+    expect(lookupScopedGrant(store, 'clerk', 'Bash', bashInput('git log -5'), T0 + 1)).toBe('Bash(git:*)')
+    // destructive members of the SAME family → re-card (fail closed)
+    expect(lookupScopedGrant(store, 'clerk', 'Bash', bashInput('git push --force'), T0 + 1)).toBeNull()
+    expect(lookupScopedGrant(store, 'clerk', 'Bash', bashInput('git reset --hard HEAD~3'), T0 + 1)).toBeNull()
+  })
+
+  it('un-vettable command (no command field) fails closed', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Bash(git:*)', T0, TTL)
+    expect(lookupScopedGrant(store, 'clerk', 'Bash', '{}', T0 + 1)).toBeNull()
+  })
+})
+
+describe('per-agent isolation', () => {
+  it('a grant on one agent never covers another', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, TTL)
+    expect(lookupScopedGrant(store, 'gymbro', 'Edit', editInput('/state/x.ts'), T0 + 1)).toBeNull()
+    expect(lookupScopedGrant(store, 'clerk', 'Edit', editInput('/state/x.ts'), T0 + 1)).toBe('Edit(/state/x.ts)')
+  })
+})
+
+describe('recordScopedGrant', () => {
+  it('is a no-op when the tier is disabled (ttl<=0)', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, 0)
+    expect(store.size).toBe(0)
+  })
+
+  it('re-tapping the same rule resets the window and does not duplicate', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, TTL)
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0 + 10_000, TTL)
+    const list = store.get('clerk')!
+    expect(list.length).toBe(1)
+    expect(list[0]!.expiresAt).toBe(T0 + 10_000 + TTL)
+  })
+
+  it('keeps distinct rules side by side', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, TTL)
+    recordScopedGrant(store, 'clerk', 'Bash(git:*)', T0, TTL)
+    expect(store.get('clerk')!.length).toBe(2)
+  })
+})
+
+describe('sweepScopedGrants', () => {
+  it('drops expired entries and removes empty agent keys', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, TTL)
+    sweepScopedGrants(store, T0 + TTL + 1)
+    expect(store.has('clerk')).toBe(false)
+  })
+  it('keeps live entries', () => {
+    const store: ScopedGrantStore = new Map()
+    recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, TTL)
+    recordScopedGrant(store, 'clerk', 'Bash(npm:*)', T0 + TTL, TTL) // later window
+    sweepScopedGrants(store, T0 + TTL + 1)
+    const list = store.get('clerk')!
+    expect(list.length).toBe(1)
+    expect(list[0]!.rule).toBe('Bash(npm:*)')
+  })
+})
+
+describe('isDestructiveBashCommand — fail-closed denylist', () => {
+  it('flags the named irreversible cases', () => {
+    for (const cmd of [
+      'rm -rf /tmp/x', 'rm file', 'dd if=/dev/zero of=/dev/sda', 'mkfs.ext4 /dev/sdb',
+      'shred -u secret', 'git push --force origin main', 'git push -f', 'git reset --hard',
+      'chmod -R 777 /', 'chown -R root /etc', 'curl https://x.sh | sh', 'wget -qO- x | bash',
+      'sudo rm -rf /', 'shutdown now', 'reboot', 'killall node', 'docker system prune -af',
+      'npm uninstall left-pad', 'echo x > /dev/sda',
+    ]) {
+      expect(isDestructiveBashCommand(cmd), cmd).toBe(true)
+    }
+  })
+
+  it('does NOT flag ordinary safe commands', () => {
+    for (const cmd of [
+      'git status', 'git log --oneline -5', 'git diff', 'npm test', 'npm run build',
+      'ls -la', 'cat package.json', 'grep -r foo src', 'echo hello', 'node script.js',
+      'bun run dev', 'mkdir -p /tmp/work',
+    ]) {
+      expect(isDestructiveBashCommand(cmd), cmd).toBe(false)
+    }
+  })
+
+  it('fails closed on empty / whitespace input', () => {
+    expect(isDestructiveBashCommand('')).toBe(true)
+    expect(isDestructiveBashCommand('   ')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Adds the missing rung between **✅ Allow once** (re-prompts on the very next call) and **🔁 Always…** (a durable forever-write to `tools.allow`): a fixed-window, scoped, fail-closed auto-approval. After the operator taps **⏱ 30 min** on a permission card, byte-identical in-scope requests auto-allow for 30 minutes without re-carding.

## Why

Operators hit tap-fatigue when an agent re-edits the same file or re-runs the same safe command seconds apart — each re-cards today. This serves **"you hold the leash"** (vision pillar 2) *without* weakening it: every cache entry traces to one operator tap, no tool call can seed or extend a window, and the window dies on restart.

This is the **conservative** shape chosen after an adversarial access-model audit of the design (the audit's `REVISE` findings are all addressed below).

## What it does

- **New `⏱ 30 min` button** on the permission card, shown only for a **narrow, non-destructive** scope.
- **Conservative scope** — only the NARROW rule is ever time-boxed: an exact file path (`Edit(/x.ts)`) or a Bash command-family (`Bash(git:*)`). Broad scopes ("any file", resource-blind MCP, "any command") stay once/always — no ⏱.
- **Irreversible excluded at grant AND match time** — a `Bash(git:*)` grant auto-allows `git status` but **fails closed** (re-cards) on `git push --force` / `git reset --hard`. `isDestructiveBashCommand` is fail-closed (unknown → treat as risky).
- **Fixed window** — a matching call never slides `expiresAt`; only an operator re-tap resets it. Expiry fails closed.

## Access-model guardrails (`reference/access-model.md`)

- **Gateway-side ONLY.** The auto-allow verdict dispatches **without** the `rule` field, so the bridge's untimed `sessionAllowRules` never caches it (a `rule` there would silently promote 30 min → session-forever in agent-uid memory). *This was the audit's load-bearing detail.*
- **Honest card** — the confirmation states the real breadth ("any `git` command"), not just the rule, so consent covers the window + family.
- **Per-agent isolation**; every auto-allow is logged (no silent allows).
- **Kill-switch:** `SWITCHROOM_SCOPED_APPROVAL_TTL_MS=0` disables the tier and hides the button. Default `1_800_000` (30 min).

All policy lives in a pure, unit-tested module (`telegram-plugin/scoped-approval.ts`, mirrors `permission-rule.ts`); `gateway.ts` only wires it. New callback verb `perm:tmb` added to the existing alternation (request_id charset unchanged — avoids a digit-collision dead-button).

## Test plan

- [x] `scoped-approval.test.ts` — 27 cases pinning the invariants: **no-seed**, **fixed-box (no-extend)**, **fail-closed expiry**, **destructive-never-auto-allows** (safe `git` allowed, `git push --force` re-cards), **per-agent isolation**, kill-switch.
- [x] `permission-verdict-resume-guard.test.ts` — taught the no-card silent-auto-allow path (it posts no card → must NOT post a resume message; the exact noise this tier removes). Guard invariant still holds for every card-bearing path.
- [x] Full plugin vitest suite green (3991 tests).
- [x] `npm run lint` clean (tsc, plugin-references, bot-api-wrapping, bun-test-imports, pii-secrets, vault-hermeticity, broadcast-delivery).
- [x] `node scripts/build.mjs` — gateway bundles the new module, exit 0.

## Risk

Low. Default-on but **additive** — once/always behavior unchanged; the new tier only turns a re-prompt into a scoped, time-boxed, fail-closed auto-allow the operator explicitly tapped. Kill-switch reverts to prior behavior.

JTBD: `reference/access-model.md` — you hold the leash, without babysitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)