### PR TITLE
feat(cron): Tier-0 model-free action tier — engine + schema (#2307 PR1)

### DIFF
--- a/src/agent-scheduler/cheap-cron-fire.test.ts
+++ b/src/agent-scheduler/cheap-cron-fire.test.ts
@@ -8,7 +8,8 @@ import { InMemoryAuditSink } from "../scheduler/audit.js";
 import type { InboundDispatcher, InboundMessageWire, SchedulerEntry } from "../scheduler/dispatch.js";
 import { createMemoryPollStateStore } from "../scheduler/poll-state.js";
 import type { PollOutcome } from "../scheduler/poll-engine.js";
-import type { PollSpec } from "../config/schema.js";
+import type { ActionOutcome } from "../scheduler/action-engine.js";
+import type { ActionSpec, PollSpec } from "../config/schema.js";
 import { registerAgentSchedule, type CheapCronHooks, type CronLib } from "./index.js";
 
 function fakeCron(): CronLib & { fire: (i: number) => Promise<void> } {
@@ -104,6 +105,94 @@ describe("Tier-0 poll wiring", () => {
     expect(h.dispatcher.calls).toHaveLength(1); // disabling never drops a cron
     expect(h.dispatcher.calls[0]!.msg.meta.session).toBeUndefined();
     expect(h.sink.fires[0]).toMatchObject({ tier: "main" });
+  });
+});
+
+describe("Tier-0 action wiring (#2307)", () => {
+  const ACTION: ActionSpec = { type: "telegram-message", text: "Daily heartbeat {{date}}", parse_mode: "html" };
+  const actionEntry: SchedulerEntry = {
+    agent: "marko",
+    scheduleIndex: 2,
+    cron: "0 9 * * *",
+    promptKey: "a1",
+    kind: "action",
+    action: ACTION,
+  };
+
+  function actionHarness(
+    runAction: ((spec: ActionSpec, ctx: { threadId?: number }) => Promise<ActionOutcome>) | undefined,
+    opts: { enabled?: boolean } = {},
+  ) {
+    const cron = fakeCron();
+    const dispatcher = capture();
+    const sink = new InMemoryAuditSink();
+    const cheapCron: CheapCronHooks = {
+      enabled: opts.enabled ?? true,
+      pollState: createMemoryPollStateStore(),
+      runPoll: async () => ({ hit: false, baseline: false }),
+      ...(runAction ? { runAction } : {}),
+    };
+    registerAgentSchedule({
+      entries: [actionEntry],
+      channel: { chatId: "123", threadId: undefined } as never,
+      sink,
+      cronLib: cron,
+      dispatcher,
+      now: () => 1000,
+      cheapCron,
+    });
+    return { cron, dispatcher, sink };
+  }
+
+  it("runs the action model-free → NO dispatch, tier=action, exit 0", async () => {
+    const calls: Array<{ spec: ActionSpec; ctx: { threadId?: number } }> = [];
+    const h = actionHarness(async (spec, ctx) => {
+      calls.push({ spec, ctx });
+      return { ok: true, summary: "message sent (21 chars)" };
+    });
+    await h.cron.fire(0);
+    expect(h.dispatcher.calls).toHaveLength(0); // ← zero model fires (the whole point)
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.spec).toEqual(ACTION);
+    expect(h.sink.fires[0]).toMatchObject({ exitCode: 0, tier: "action" });
+    expect(h.sink.fires[0]!.outputSummary).toMatch(/action ok/);
+  });
+
+  it("an action error → exit -4, still NO dispatch, sibling-safe", async () => {
+    const h = actionHarness(async () => ({ ok: false, summary: "", error: "http 500" }));
+    await h.cron.fire(0);
+    expect(h.dispatcher.calls).toHaveLength(0);
+    expect(h.sink.fires[0]).toMatchObject({ exitCode: -4, tier: "action" });
+    expect(h.sink.fires[0]!.outputSummary).toMatch(/action error: http 500/);
+  });
+
+  it("a thrown runAction is caught → exit -4, never crashes the tick", async () => {
+    const h = actionHarness(async () => {
+      throw new Error("boom");
+    });
+    await h.cron.fire(0);
+    expect(h.sink.fires[0]).toMatchObject({ exitCode: -4, tier: "action" });
+    expect(h.sink.fires[0]!.outputSummary).toMatch(/boom/);
+  });
+
+  it("transport unwired (runAction absent) → graceful -4 no-op, no dispatch, no fall-through to a model fire", async () => {
+    const h = actionHarness(undefined);
+    await h.cron.fire(0);
+    expect(h.dispatcher.calls).toHaveLength(0);
+    expect(h.sink.fires[0]).toMatchObject({ exitCode: -4, tier: "action" });
+    expect(h.sink.fires[0]!.outputSummary).toMatch(/transport unavailable/);
+  });
+
+  it("FLAG OFF → an action STILL runs model-free (never dropped by the kill-switch)", async () => {
+    const ran: ActionSpec[] = [];
+    const h = actionHarness(async (spec) => {
+      ran.push(spec);
+      return { ok: true, summary: "ok" };
+    }, { enabled: false });
+    await h.cron.fire(0);
+    expect(ran).toHaveLength(1);
+    expect(h.dispatcher.calls).toHaveLength(0);
+    expect(h.sink.fires[0]).toMatchObject({ tier: "action", exitCode: 0 });
   });
 });
 

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -39,8 +39,9 @@ import {
 import { isCheapCronEnabled, resolveCronRouting, resolveEscalationRouting } from "../scheduler/cron-routing.js";
 import { applyDefaultTier } from "../scheduler/tier-selector.js";
 import type { PollOutcome } from "../scheduler/poll-engine.js";
+import type { ActionOutcome } from "../scheduler/action-engine.js";
 import type { PollStateStore } from "../scheduler/poll-state.js";
-import type { PollSpec } from "../config/schema.js";
+import type { ActionSpec, PollSpec } from "../config/schema.js";
 import { buildCheapCronHooks } from "./cheap-cron-wiring.js";
 // AgentChannelTarget, resolveChannelTarget, and resolveEntryThreadId
 // live in ./channel-target.js (a node-cron-free leaf) so the gateway's
@@ -125,11 +126,21 @@ export interface CheapCronHooks {
   pollState: PollStateStore;
   /** Run a declarative poll (model-free) and return whether to escalate. */
   runPoll: (spec: PollSpec, prevCursor: string | undefined) => Promise<PollOutcome>;
+  /**
+   * Run a declarative ACTION (model-free, terminal — no escalation). Posts to
+   * the agent's OWN chat (`ctx.threadId` resolves the entry's topic) or fires a
+   * webhook. Optional: present once the action transport (send_outbound IPC) is
+   * wired; absent ⟹ a `kind: action` fire records a graceful "transport
+   * unavailable" no-op rather than crashing or falling through to a model fire.
+   */
+  runAction?: (spec: ActionSpec, ctx: { threadId?: number }) => Promise<ActionOutcome>;
 }
 
-/** Replace {{diff}} in an escalation prompt with the poll's diff summary. */
-function templateEscalationPrompt(prompt: string, diff: string): string {
-  return prompt.replace(/\{\{\s*diff\s*\}\}/g, diff);
+/** Replace {{diff}} in an escalation prompt with the poll's diff summary.
+ *  Only called for poll entries (which carry a prompt); the `?? ""` keeps the
+ *  type total now that SchedulerEntry.prompt is optional (kind=action). */
+function templateEscalationPrompt(prompt: string | undefined, diff: string): string {
+  return (prompt ?? "").replace(/\{\{\s*diff\s*\}\}/g, diff);
 }
 
 /**
@@ -290,7 +301,7 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
       const record = (fields: {
         exitCode: number;
         summary: string;
-        tier: "poll" | "cheap" | "main";
+        tier: "poll" | "action" | "cheap" | "main";
         modelUsed?: string;
       }) =>
         opts.sink.recordFire({
@@ -355,6 +366,40 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
         return;
       }
 
+      // ── Tier 0: deterministic ACTION, no model, terminal ──────────────
+      // Routing returns tier:"action" FLAG-INDEPENDENTLY (an action is
+      // model-free regardless of SWITCHROOM_CHEAP_CRON). It COMPLETES the work
+      // and never escalates — no dispatchAsInbound, no session wake.
+      if (routing.tier === "action") {
+        if (!opts.cheapCron?.runAction || !entry.action) {
+          // Transport not wired yet (PR2/PR3) or malformed entry: graceful
+          // no-op so a misconfigured action never crashes the tick or falls
+          // through to a (prompt-less) model fire. Audited, not silent.
+          record({
+            exitCode: -4,
+            summary: !entry.action
+              ? "action skipped — no action spec on entry"
+              : "action skipped — action transport unavailable",
+            tier: "action",
+          });
+          return;
+        }
+        let outcome: ActionOutcome;
+        try {
+          outcome = await opts.cheapCron.runAction(entry.action, { threadId });
+        } catch (err) {
+          outcome = { ok: false, summary: "", error: (err as Error).message };
+        }
+        // exit -4 = action error: no escalation; re-runs next tick (we accept a
+        // possibly-missed fire over a double-fire — actions are not replayed).
+        record({
+          exitCode: outcome.ok ? 0 : -4,
+          summary: outcome.ok ? `action ok: ${outcome.summary}` : `action error: ${outcome.error}`,
+          tier: "action",
+        });
+        return;
+      }
+
       // ── Tier 1/2: a model fire into the cron or main session ──────────
       let delivered = false;
       let summary = "";
@@ -376,6 +421,7 @@ export function registerAgentSchedule(opts: RegisterOptions): RegisteredTask[] {
       //  -1 — gateway not connected, or wire write failed
       //  -2 — deferred: fleet fully quota-walled (recorded above)
       //  -3 — Tier-0 poll error (recorded above)
+      //  -4 — Tier-0 action error / skipped (recorded above)
       record({
         exitCode: delivered ? 0 : -1,
         summary,
@@ -689,6 +735,24 @@ export async function main(): Promise<void> {
         const cheapEnabledForReplay = isCheapCronEnabled(process.env);
         for (const m of missed) {
           const startedAt = Date.now();
+          // A `kind: action` entry must NOT replay as a raw prompt (it has no
+          // prompt) and must NOT double-fire a side effect (a re-sent message /
+          // re-fired webhook). We accept a possibly-MISSED action over a
+          // double — the next natural tick runs it. Flag-independent (actions
+          // are model-free regardless of cheap-cron). Skip + audit.
+          if (m.entry.kind === "action") {
+            sink.recordFire({
+              agent: m.entry.agent,
+              scheduleIndex: m.entry.scheduleIndex,
+              promptKey: m.entry.promptKey,
+              exitCode: 0,
+              outputSummary: "action replay skipped — runs on next tick (never double-fired)",
+              startedAt,
+              finishedAt: Date.now(),
+              tier: "action",
+            });
+            continue;
+          }
           // Cheap-cron: a `kind: poll` entry must NOT replay as a raw prompt —
           // that would fire its escalation text (with a literal {{diff}}) as a
           // model turn, bypassing the poll. A poll is stateful (durable cursor),
@@ -732,7 +796,8 @@ export async function main(): Promise<void> {
           `skipped (older than ${windowMinutes}min window) — notifying user\n`,
         );
         const lines = staleSkipped.map((s) => {
-          const oneLine = s.entry.prompt.replace(/\s+/g, " ").trim().slice(0, 80);
+          const label = s.entry.prompt ?? `action: ${s.entry.action?.type ?? "?"}`;
+          const oneLine = label.replace(/\s+/g, " ").trim().slice(0, 80);
           return `- "${oneLine}" — cron \`${s.entry.cron}\`, ` +
             `most recent missed run ~${new Date(s.expectedFireMs).toISOString()}`;
         });

--- a/src/agents/cron-unit-name.ts
+++ b/src/agents/cron-unit-name.ts
@@ -23,11 +23,14 @@ import { createHash } from "node:crypto";
  * comfortably in a unit-name segment while keeping collision odds
  * negligible at typical fleet sizes (<100 entries per agent).
  */
-export function cronUnitHash(cron: string, prompt: string): string {
+export function cronUnitHash(cron: string, prompt: string | undefined): string {
+  // `prompt` is optional now that kind=action entries carry no prompt; coalesce
+  // so the hash stays total (an action entry's unit name is derived from cron
+  // alone, which is sufficient for path classification).
   return createHash("sha256")
     .update(cron)
     .update("\0")
-    .update(prompt)
+    .update(prompt ?? "")
     .digest("hex")
     .slice(0, 12);
 }
@@ -37,14 +40,14 @@ export function cronUnitHash(cron: string, prompt: string): string {
  * extension so callers can append `.sh` (script) or `.source` (the
  * overlay attribution sidecar).
  */
-export function cronUnitName(cron: string, prompt: string): string {
+export function cronUnitName(cron: string, prompt: string | undefined): string {
   return `cron-${cronUnitHash(cron, prompt)}`;
 }
 
 /**
  * Filename used on disk under `<agentDir>/telegram/`.
  */
-export function cronScriptFilename(cron: string, prompt: string): string {
+export function cronScriptFilename(cron: string, prompt: string | undefined): string {
   return `${cronUnitName(cron, prompt)}.sh`;
 }
 

--- a/src/config/cheap-cron-schema.test.ts
+++ b/src/config/cheap-cron-schema.test.ts
@@ -46,6 +46,82 @@ describe("ScheduleEntrySchema — kind/poll superRefine", () => {
   });
 });
 
+describe("ScheduleEntrySchema — kind:action superRefine (#2312/#2307)", () => {
+  it("accepts a well-formed telegram-message action (no prompt)", () => {
+    const r = ScheduleEntrySchema.safeParse({
+      cron: "0 9 * * *",
+      kind: "action",
+      action: { type: "telegram-message", text: "Daily heartbeat {{date}}" },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a well-formed webhook action", () => {
+    const r = ScheduleEntrySchema.safeParse({
+      cron: "*/30 * * * *",
+      kind: "action",
+      action: { type: "webhook", url: "https://hooks.example.com/ping", secrets: ["tok"] },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects kind:action with no action spec", () => {
+    const r = ScheduleEntrySchema.safeParse({ cron: "0 9 * * *", kind: "action" });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error.errors.some((e) => /requires an `action`/.test(e.message))).toBe(true);
+  });
+
+  it("rejects an action spec on a non-action entry", () => {
+    const r = ScheduleEntrySchema.safeParse({
+      cron: "0 9 * * *",
+      prompt: "x",
+      action: { type: "telegram-message", text: "hi" },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a prompt on a kind:action entry (an action never fires a model)", () => {
+    const r = ScheduleEntrySchema.safeParse({
+      cron: "0 9 * * *",
+      kind: "action",
+      prompt: "should not be here",
+      action: { type: "telegram-message", text: "hi" },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a prompt/poll entry with NO prompt (prompt now optional only for actions)", () => {
+    expect(ScheduleEntrySchema.safeParse({ cron: "0 9 * * *" }).success).toBe(false);
+    expect(ScheduleEntrySchema.safeParse({ cron: "0 9 * * *", prompt: "" }).success).toBe(false);
+  });
+
+  it("rejects an unknown action type", () => {
+    const r = ScheduleEntrySchema.safeParse({
+      cron: "0 9 * * *",
+      kind: "action",
+      action: { type: "carrier-pigeon", text: "hi" },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a non-https webhook url", () => {
+    const r = ScheduleEntrySchema.safeParse({
+      cron: "0 9 * * *",
+      kind: "action",
+      action: { type: "webhook", url: "ftp://hooks.example.com/x" },
+    });
+    // url() accepts the parse; the https fence is enforced at egress time, but a
+    // malformed/non-url is rejected here.
+    const r2 = ScheduleEntrySchema.safeParse({
+      cron: "0 9 * * *",
+      kind: "action",
+      action: { type: "webhook", url: "not a url" },
+    });
+    expect(r2.success).toBe(false);
+    void r;
+  });
+});
+
 describe("CronConfigSchema — egress allowlist", () => {
   it("parses egress hosts + secret bindings with defaults", () => {
     const r = CronConfigSchema.safeParse({ egress: { allowed_hosts: ["api.brevo.com"], secret_bindings: { brevo_api_key: "api.brevo.com" } } });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -105,20 +105,86 @@ export const PollSpecSchema = z.discriminatedUnion("type", [
   TelegramReactionsPollSchema,
 ]);
 
+// Tier-0 deterministic ACTION specs (docs/rfcs/cheap-cron-sessions.md §2.1,
+// reference/crons-use-the-model-only-when-it-earns-it.md). A `kind: action`
+// entry runs model-free in the scheduler process and COMPLETES the work — it
+// never escalates to a model (the terminal sibling of `kind: poll`, which
+// escalates on a hit). Zero tokens, no second `claude`, no session wake.
+// Only mechanical verbs whose output is FULLY determined by config +
+// deterministic substitution belong here; anything needing NL synthesis
+// (a Linear issue body, a summary) must stay `kind: poll`/`prompt` and use a
+// model. Discriminated on `type`.
+export const TelegramMessageActionSchema = z.object({
+  type: z.literal("telegram-message"),
+  text: z
+    .string()
+    .min(1)
+    .describe(
+      "Operator-authored message text. Posts to the AGENT'S OWN chat only " +
+      "(the chat is not configurable — fenced by construction), into the " +
+      "entry-level `topic` when set. Supports ONLY deterministic placeholders " +
+      "{{date}} / {{time}} (UTC, from the fire clock) and {{agent}}. NO vault " +
+      "secrets (use a webhook action for secret-bearing requests) and NO model " +
+      "output — the text is fully determined by config.",
+    ),
+  parse_mode: z.enum(["html", "text"]).default("html").describe("Telegram parse mode for the message body."),
+});
+
+export const WebhookActionSchema = z.object({
+  type: z.literal("webhook"),
+  url: z
+    .string()
+    .url()
+    .describe(
+      "Webhook target. SAME egress fence as an http-diff poll (§6.1): https " +
+      "only, host on the operator egress allowlist, loopback/private/link-local " +
+      "rejected, resolved IP DNS-rebind-pinned. Not agent-writable without an " +
+      "operator commit.",
+    ),
+  method: z.enum(["GET", "POST"]).default("POST"),
+  headers: z.record(z.string()).optional().describe("Static headers; {{secret}} substitution applies."),
+  body: z.string().optional().describe("Static request body; {{secret}} substitution applies."),
+  secrets: z
+    .array(z.string().regex(/^[a-zA-Z0-9_\-/]+$/, "Secret key names must contain only alphanumeric characters, underscores, hyphens, and forward slashes"))
+    .default([])
+    .describe(
+      "Vault keys this webhook may inject into headers/body via {{name}}. Each " +
+      "is HOST-PINNED (§6.1): a secret may only be sent to the host it is bound " +
+      "to in operator config, so an approved action cannot exfil it elsewhere.",
+    ),
+});
+
+export const ActionSpecSchema = z.discriminatedUnion("type", [
+  TelegramMessageActionSchema,
+  WebhookActionSchema,
+]);
+
 export const ScheduleEntrySchema = z
   .object({
   cron: z.string().describe("Cron expression (e.g., '0 8 * * *')"),
-  prompt: z.string().describe("Prompt to send at the scheduled time (the escalation prompt when kind=poll; templated with {{diff}})."),
+  prompt: z
+    .string()
+    .optional()
+    .describe(
+      "Prompt to send at the scheduled time (the escalation prompt when " +
+      "kind=poll; templated with {{diff}}). Required for kind prompt/poll; " +
+      "absent for kind=action (an action has no model fire, so no prompt).",
+    ),
   kind: z
-    .enum(["poll", "prompt"])
+    .enum(["poll", "prompt", "action"])
     .optional()
     .describe(
       "Tier-0 routing (docs/rfcs/cheap-cron-sessions.md). 'prompt' (default) " +
       "fires a model turn every tick (Tier 1/2 per `context`). 'poll' runs a " +
       "model-free deterministic check (requires `poll`) and only escalates to " +
-      "a model fire on a hit. Honoured only when SWITCHROOM_CHEAP_CRON is on.",
+      "a model fire on a hit. 'action' runs a model-free deterministic verb " +
+      "(requires `action`) that COMPLETES the work and never escalates — zero " +
+      "tokens, no session. poll/prompt are honoured only when " +
+      "SWITCHROOM_CHEAP_CRON is on; an action is model-free regardless (the " +
+      "kill-switch governs model tiering, not deterministic actions).",
     ),
   poll: PollSpecSchema.optional().describe("Required iff kind=poll. The declarative poll spec."),
+  action: ActionSpecSchema.optional().describe("Required iff kind=action. The declarative action spec (telegram-message or webhook)."),
   model: z
     .string()
     .optional()
@@ -178,11 +244,40 @@ export const ScheduleEntrySchema = z
         message: "kind: poll requires a `poll` spec (http-diff or telegram-reactions).",
       });
     }
-    if (kind === "prompt" && entry.poll) {
+    if (kind !== "poll" && entry.poll) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["poll"],
         message: "`poll` is only valid when kind: poll.",
+      });
+    }
+    if (kind === "action" && !entry.action) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["action"],
+        message: "kind: action requires an `action` spec (telegram-message or webhook).",
+      });
+    }
+    if (kind !== "action" && entry.action) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["action"],
+        message: "`action` is only valid when kind: action.",
+      });
+    }
+    // prompt is the model fire's text — required for prompt/poll, absent for action.
+    if (kind !== "action" && (entry.prompt === undefined || entry.prompt.trim() === "")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["prompt"],
+        message: `kind: ${kind} requires a non-empty \`prompt\`.`,
+      });
+    }
+    if (kind === "action" && entry.prompt !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["prompt"],
+        message: "`prompt` is not valid for kind: action (an action never fires a model).",
       });
     }
   });
@@ -3088,6 +3183,7 @@ export type AgentTools = z.infer<typeof AgentToolsSchema>;
 export type AgentMemory = z.infer<typeof AgentMemorySchema>;
 export type ScheduleEntry = z.infer<typeof ScheduleEntrySchema>;
 export type PollSpec = z.infer<typeof PollSpecSchema>;
+export type ActionSpec = z.infer<typeof ActionSpecSchema>;
 export type CronConfig = z.infer<typeof CronConfigSchema>;
 export type TelegramConfig = z.infer<typeof TelegramConfigSchema>;
 export type MemoryBackendConfig = z.infer<typeof MemoryBackendConfigSchema>;

--- a/src/scheduler/action-engine.test.ts
+++ b/src/scheduler/action-engine.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  runAction,
+  substituteDeterministic,
+  type ActionDeps,
+} from "./action-engine.js";
+import type { ActionSpec } from "../config/schema.js";
+import type { EgressAllowlist } from "./poll-egress.js";
+
+const ALLOW: EgressAllowlist = {
+  hosts: ["hooks.example.com"],
+  secretBindings: { hook_token: "hooks.example.com" },
+};
+
+/** A capturing fake for the model-free send seam + a default-OK webhook fetch. */
+function depsWith(over: Partial<ActionDeps> = {}): {
+  deps: ActionDeps;
+  sent: Array<{ text: string; parseMode: string }>;
+  fetched: Array<{ url: string; init?: RequestInit }>;
+} {
+  const sent: Array<{ text: string; parseMode: string }> = [];
+  const fetched: Array<{ url: string; init?: RequestInit }> = [];
+  const deps: ActionDeps = {
+    fetchImpl: (async (url: string, init?: RequestInit) => {
+      fetched.push({ url, init });
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof fetch,
+    resolveSecret: async (n) => (n === "hook_token" ? "tok-123" : ""),
+    lookup: async () => "8.8.8.8",
+    allow: ALLOW,
+    now: () => Date.UTC(2026, 5, 13, 9, 5), // 2026-06-13T09:05Z
+    agent: "clerk",
+    sendMessage: async (text, opts) => {
+      sent.push({ text, parseMode: opts.parseMode });
+      return true;
+    },
+    ...over,
+  };
+  return { deps, sent, fetched };
+}
+
+describe("substituteDeterministic", () => {
+  it("fills {{date}}/{{time}}/{{agent}} from the fire clock — and nothing else", () => {
+    const out = substituteDeterministic("{{agent}} @ {{date}} {{time}} — {{secret:X}}", {
+      now: Date.UTC(2026, 5, 13, 9, 5),
+      agent: "clerk",
+    });
+    // date/time/agent substituted; an unknown placeholder ({{secret:X}}) is left verbatim
+    // (NO secret substitution in a message — that's the webhook's job).
+    expect(out).toBe("clerk @ 2026-06-13 09:05 — {{secret:X}}");
+  });
+});
+
+describe("runAction — telegram-message", () => {
+  const spec: ActionSpec = { type: "telegram-message", text: "Daily heartbeat {{date}}", parse_mode: "html" };
+
+  it("sends the substituted text to the agent's own chat (model-free)", async () => {
+    const { deps, sent } = depsWith();
+    const r = await runAction(spec, deps);
+    expect(r.ok).toBe(true);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].text).toBe("Daily heartbeat 2026-06-13");
+    expect(sent[0].parseMode).toBe("html");
+  });
+
+  it("reports not-delivered as an error (no throw)", async () => {
+    const { deps } = depsWith({ sendMessage: async () => false });
+    const r = await runAction(spec, deps);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/not delivered/);
+  });
+
+  it("never reaches the network for a message action", async () => {
+    const { deps, fetched } = depsWith();
+    await runAction(spec, deps);
+    expect(fetched).toHaveLength(0);
+  });
+});
+
+describe("runAction — webhook", () => {
+  const spec: ActionSpec = {
+    type: "webhook",
+    url: "https://hooks.example.com/ping",
+    method: "POST",
+    headers: { authorization: "Bearer {{hook_token}}" },
+    body: "token={{hook_token}}",
+    secrets: ["hook_token"],
+  };
+
+  it("fires the request with substituted secrets on the happy path", async () => {
+    const { deps, fetched } = depsWith();
+    const r = await runAction(spec, deps);
+    expect(r.ok).toBe(true);
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0].url).toBe("https://hooks.example.com/ping");
+    expect((fetched[0].init!.headers as Record<string, string>).authorization).toBe("Bearer tok-123");
+    expect(fetched[0].init!.body).toBe("token=tok-123");
+    expect(fetched[0].init!.redirect).toBe("error");
+  });
+
+  it("blocks egress to a non-allowlisted host", async () => {
+    const r = await runAction({ ...spec, url: "https://evil.example.net/x", secrets: [] }, depsWith().deps);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/egress denied/);
+  });
+
+  it("blocks a secret bound to a different host (no exfil)", async () => {
+    const { deps } = depsWith();
+    const r = await runAction({ ...spec, url: "https://hooks.example.com/ping", secrets: ["unbound"] }, deps);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/egress denied/);
+  });
+
+  it("blocks a DNS-rebind to a private IP", async () => {
+    const { deps } = depsWith({ lookup: async () => "127.0.0.1" });
+    const r = await runAction(spec, deps);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/blocked/);
+  });
+
+  it("surfaces a non-2xx status as an error", async () => {
+    const { deps } = depsWith({
+      fetchImpl: (async () => new Response("nope", { status: 500 })) as unknown as typeof fetch,
+    });
+    const r = await runAction(spec, deps);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/http 500/);
+  });
+
+  it("never sends a Telegram message for a webhook action", async () => {
+    const { deps, sent } = depsWith();
+    await runAction(spec, deps);
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/src/scheduler/action-engine.ts
+++ b/src/scheduler/action-engine.ts
@@ -1,0 +1,186 @@
+/**
+ * Tier-0 model-free action engine — docs/rfcs/cheap-cron-sessions.md §2.1,
+ * reference/crons-use-the-model-only-when-it-earns-it.md.
+ *
+ * A `kind: action` entry COMPLETES its work deterministically in the
+ * scheduler process: send a fixed/templated Telegram message to the agent's
+ * OWN chat, or fire a fixed HTTP webhook to an allowlisted host. Zero model
+ * calls — no `claude`, no SDK, no `inject_inbound`, no session wake. The
+ * terminal sibling of poll-engine.ts (a poll escalates on a hit; an action
+ * just does the thing). Deps are injected so the engine is unit-tested
+ * without network, broker, or gateway.
+ *
+ * Subscription-honesty: there is no model/inference seam anywhere in this
+ * module by construction — `ActionDeps` carries only fetch / vault-secret /
+ * dns / egress-allowlist / a model-free `sendMessage`. An action never
+ * returns anything that triggers a dispatch.
+ */
+
+import type {
+  ActionSpecSchema,
+  TelegramMessageActionSchema,
+  WebhookActionSchema,
+} from "../config/schema.js";
+import type { z } from "zod";
+import {
+  checkEgressUrl,
+  checkSecretBinding,
+  isBlockedAddress,
+  normalizeHost,
+  type EgressAllowlist,
+} from "./poll-egress.js";
+
+export type ActionSpec = z.infer<typeof ActionSpecSchema>;
+export type TelegramMessageAction = z.infer<typeof TelegramMessageActionSchema>;
+export type WebhookAction = z.infer<typeof WebhookActionSchema>;
+
+export interface ActionDeps {
+  /** injected for tests; the real one wraps global fetch (webhook only). */
+  fetchImpl: typeof fetch;
+  /** resolve a vault secret by name via the in-container broker (webhook only). */
+  resolveSecret: (name: string) => Promise<string>;
+  /** DNS lookup → resolved IP, for the rebind pin. Return null to skip the pin. */
+  lookup: (host: string) => Promise<string | null>;
+  allow: EgressAllowlist;
+  /** Fire clock — drives {{date}}/{{time}} substitution. */
+  now: () => number;
+  /** Agent slug — drives {{agent}} substitution. */
+  agent: string;
+  /**
+   * Post a model-free outbound to the AGENT'S OWN chat (the chat + thread are
+   * bound by the caller — the engine never sees a chat id, so a
+   * telegram-message action cannot target a foreign chat). Returns false on a
+   * delivery failure. This is the ONLY output seam and it never wakes a model.
+   */
+  sendMessage: (text: string, opts: { parseMode: "html" | "text" }) => Promise<boolean>;
+  /** Webhook response size cap (bytes). Default 1 MiB. */
+  maxBytes?: number;
+  /** Webhook fetch timeout (ms). Default 5000. */
+  timeoutMs?: number;
+}
+
+export interface ActionOutcome {
+  /** true ⟹ the action completed; false ⟹ a (non-fatal) error to audit. */
+  ok: boolean;
+  /** Short human summary for the JSONL audit. */
+  summary: string;
+  /** Set ⟹ the action failed (audited; never throws out of the tick loop). */
+  error?: string;
+}
+
+// Deterministic placeholders ONLY — date/time from the fire clock, agent slug.
+// Crucially NOT secrets and NOT model output: a telegram-message's text is a
+// pure function of config + these.
+const PLACEHOLDER_RE = /\{\{\s*(date|time|agent)\s*\}\}/g;
+
+export function substituteDeterministic(
+  text: string,
+  ctx: { now: number; agent: string },
+): string {
+  const d = new Date(ctx.now);
+  const date = d.toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+  const time = d.toISOString().slice(11, 16); // HH:MM (UTC)
+  return text.replace(PLACEHOLDER_RE, (_, name: string) => {
+    if (name === "date") return date;
+    if (name === "time") return time;
+    return ctx.agent;
+  });
+}
+
+// {{secret-name}} substitution for webhook headers/body (mirrors poll-engine).
+function substituteSecrets(s: string, secretValues: Record<string, string>): string {
+  return s.replace(/\{\{([a-zA-Z0-9_\-/]+)\}\}/g, (_, name: string) => secretValues[name] ?? "");
+}
+
+async function runTelegramMessage(
+  spec: TelegramMessageAction,
+  deps: ActionDeps,
+): Promise<ActionOutcome> {
+  const text = substituteDeterministic(spec.text, { now: deps.now(), agent: deps.agent });
+  let delivered: boolean;
+  try {
+    delivered = await deps.sendMessage(text, { parseMode: spec.parse_mode });
+  } catch (e) {
+    return { ok: false, summary: "", error: `send failed: ${(e as Error).message}` };
+  }
+  return delivered
+    ? { ok: true, summary: `message sent (${text.length} chars)` }
+    : { ok: false, summary: "", error: "message not delivered (no gateway / send rejected)" };
+}
+
+async function runWebhook(spec: WebhookAction, deps: ActionDeps): Promise<ActionOutcome> {
+  // §6.1 gate BEFORE any network or secret resolution — reuse the poll fence.
+  const gate = checkEgressUrl(spec.url, deps.allow);
+  if (!gate.ok) return { ok: false, summary: "", error: `egress denied: ${gate.reason}` };
+  const host = normalizeHost(new URL(spec.url).hostname);
+  for (const s of spec.secrets) {
+    const sc = checkSecretBinding(s, host, deps.allow);
+    if (!sc.ok) return { ok: false, summary: "", error: `egress denied: ${sc.reason}` };
+  }
+
+  // DNS-rebind pin: resolve and re-check the IP against blocked ranges.
+  try {
+    const ip = await deps.lookup(host);
+    if (ip && isBlockedAddress(ip)) return { ok: false, summary: "", error: `resolved ip ${ip} blocked` };
+  } catch (e) {
+    return { ok: false, summary: "", error: `dns lookup failed: ${(e as Error).message}` };
+  }
+
+  // Resolve secrets and substitute into headers + body via {{name}}.
+  const secretValues: Record<string, string> = {};
+  for (const name of spec.secrets) {
+    try {
+      secretValues[name] = await deps.resolveSecret(name);
+    } catch (e) {
+      return { ok: false, summary: "", error: `secret ${name}: ${(e as Error).message}` };
+    }
+  }
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(spec.headers ?? {})) {
+    headers[k] = substituteSecrets(v, secretValues);
+  }
+  const body = spec.body !== undefined ? substituteSecrets(spec.body, secretValues) : undefined;
+
+  // Fenced fetch: no redirects, hard timeout, response discarded (size-capped).
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), deps.timeoutMs ?? 5000);
+  try {
+    const res = await deps.fetchImpl(spec.url, {
+      method: spec.method,
+      headers,
+      ...(body !== undefined ? { body } : {}),
+      redirect: "error",
+      signal: controller.signal,
+    });
+    // Drain (capped) so the socket closes; we don't parse the response.
+    const buf = await res.arrayBuffer();
+    if (buf.byteLength > (deps.maxBytes ?? 1024 * 1024)) {
+      return { ok: false, summary: "", error: `response ${buf.byteLength}B exceeds cap` };
+    }
+    if (!res.ok) return { ok: false, summary: "", error: `http ${res.status}` };
+    return { ok: true, summary: `webhook ${spec.method} ${host} → ${res.status}` };
+  } catch (e) {
+    return { ok: false, summary: "", error: `fetch failed: ${(e as Error).message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Run a declarative action model-free. Never throws — every failure is
+ * returned as `{ ok: false, error }` so the scheduler tick records it and
+ * moves on without affecting sibling entries.
+ */
+export async function runAction(spec: ActionSpec, deps: ActionDeps): Promise<ActionOutcome> {
+  switch (spec.type) {
+    case "telegram-message":
+      return runTelegramMessage(spec, deps);
+    case "webhook":
+      return runWebhook(spec, deps);
+    default: {
+      // Exhaustiveness guard — a new action type without an arm lands here.
+      const _never: never = spec;
+      return { ok: false, summary: "", error: `unknown action type: ${JSON.stringify(_never)}` };
+    }
+  }
+}

--- a/src/scheduler/collect-entries.test.ts
+++ b/src/scheduler/collect-entries.test.ts
@@ -115,6 +115,30 @@ describe("collectScheduleEntries — cascade resolution", () => {
     expect(entries.map((e) => e.scheduleIndex)).toEqual([0, 1, 2]);
   });
 
+  it("propagates a kind:action entry (no prompt) with its action spec + a stable key", () => {
+    const cfg = configFromAgents({
+      alice: {
+        schedule: [
+          {
+            cron: "0 9 * * *",
+            kind: "action",
+            action: { type: "telegram-message", text: "Daily heartbeat {{date}}" },
+          },
+        ],
+      },
+    });
+    const entries = collectScheduleEntries(cfg);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      agent: "alice",
+      kind: "action",
+      action: { type: "telegram-message", text: "Daily heartbeat {{date}}" },
+    });
+    // No prompt on an action; the audit key is still present + non-empty.
+    expect(entries[0]?.prompt).toBeUndefined();
+    expect(entries[0]?.promptKey).toMatch(/^[0-9a-f]{12}$/);
+  });
+
   it("empty defaults + empty profile + empty agent yields no entries (no false positives)", () => {
     const cfg = configFromAgents(
       { alice: { extends: "ops" } },

--- a/src/scheduler/cron-routing.test.ts
+++ b/src/scheduler/cron-routing.test.ts
@@ -11,7 +11,7 @@ import {
 // ── Total enumeration of the reachable input space ──────────────────────
 // operator standard feedback_prove_finite_fsm_not_sample: prove the finite
 // decision by walking EVERY input, not a random sample.
-const KINDS: Array<CronRoutingInput["kind"]> = ["poll", "prompt", undefined];
+const KINDS: Array<CronRoutingInput["kind"]> = ["poll", "prompt", "action", undefined];
 const MODELS: Array<{ label: string; value: string | undefined }> = [
   { label: "cheap-sonnet", value: "claude-sonnet-4-6" },
   { label: "cheap-haiku", value: "haiku" },
@@ -35,6 +35,14 @@ describe("resolveCronRouting — total enumeration", () => {
               { cheapCronEnabled },
             );
 
+            // INV-0: kind=action is FLAG-INDEPENDENT — model-free, no session,
+            // regardless of the kill-switch (an action has no Tier-2 fallback,
+            // so gating it on the flag would silently drop the cron).
+            if (kind === "action") {
+              expect(r).toEqual({ tier: "action", session: null, customModelDowngrade: false });
+              continue;
+            }
+
             // INV-1: flag off ⟹ pre-RFC behaviour, every field inert.
             if (!cheapCronEnabled) {
               expect(r).toEqual({ tier: "main", session: "main", customModelDowngrade: false });
@@ -43,6 +51,7 @@ describe("resolveCronRouting — total enumeration", () => {
 
             // INV-2: tier↔session coherence.
             if (r.tier === "poll") expect(r.session).toBeNull();
+            if (r.tier === "action") expect(r.session).toBeNull();
             if (r.tier === "cheap") expect(r.session).toBe("cron");
             if (r.tier === "main") expect(r.session).toBe("main");
 
@@ -63,7 +72,7 @@ describe("resolveCronRouting — total enumeration", () => {
         }
       }
     }
-    expect(n).toBe(FLAGS.length * KINDS.length * MODELS.length * CONTEXTS.length); // 2*3*5*3 = 90
+    expect(n).toBe(FLAGS.length * KINDS.length * MODELS.length * CONTEXTS.length); // 2*4*5*3 = 120
   });
 });
 
@@ -73,6 +82,16 @@ describe("resolveCronRouting — the load-bearing cases", () => {
   it("kind=poll → Tier 0 regardless of model/context", () => {
     expect(resolveCronRouting({ kind: "poll", model: "opus" }, on).tier).toBe("poll");
     expect(resolveCronRouting({ kind: "poll", context: "fresh" }, on).tier).toBe("poll");
+  });
+
+  it("kind=action → tier:action, model-free, FLAG-INDEPENDENT (never a session)", () => {
+    expect(resolveCronRouting({ kind: "action", model: "opus" }, on)).toEqual({
+      tier: "action",
+      session: null,
+      customModelDowngrade: false,
+    });
+    // even with the kill-switch OFF an action still runs model-free.
+    expect(resolveCronRouting({ kind: "action" }, { cheapCronEnabled: false }).tier).toBe("action");
   });
 
   it("explicit context wins over model inference", () => {

--- a/src/scheduler/cron-routing.ts
+++ b/src/scheduler/cron-routing.ts
@@ -18,11 +18,11 @@
  * passes it in) — so the enumeration test needs no mocks.
  */
 
-export type CronTier = "poll" | "cheap" | "main";
+export type CronTier = "poll" | "action" | "cheap" | "main";
 export type CronSession = "cron" | "main";
 
 export interface CronRoutingInput {
-  kind?: "poll" | "prompt";
+  kind?: "poll" | "prompt" | "action";
   model?: string;
   context?: "fresh" | "agent";
 }
@@ -79,6 +79,17 @@ export function resolveCronRouting(
   input: CronRoutingInput,
   opts: { cheapCronEnabled: boolean },
 ): CronRouting {
+  // kind: action is a model-free deterministic verb — FLAG-INDEPENDENT. The
+  // cheap-cron kill-switch governs MODEL tiering (poll escalation, cheap vs
+  // main session), not whether a zero-token action runs. An action has no
+  // prompt, so it has no Tier-2 fallback; gating it on the flag would silently
+  // drop the cron when disabled, violating "disabling can never drop a cron".
+  // So it always routes to tier:action (model-free, no session), regardless of
+  // the flag. Decided before the kill-switch early-return below.
+  if ((input.kind ?? "prompt") === "action") {
+    return { tier: "action", session: null, customModelDowngrade: false };
+  }
+
   // Kill-switch: flag off ⟹ exactly today's behaviour. Every fire is a
   // main-session turn; kind/model/context are inert. A `kind: poll` entry
   // fires its escalation prompt as an ordinary turn — disabling the flag can

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -19,15 +19,18 @@
  */
 
 import { createHash } from "node:crypto";
-import type { PollSpec, ScheduleEntry, SwitchroomConfig } from "../config/schema.js";
+import type { ActionSpec, PollSpec, ScheduleEntry, SwitchroomConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
 
 export interface SchedulerEntry {
   agent: string;
   scheduleIndex: number;
   cron: string;
-  prompt: string;
-  /** SHA-256 prefix of prompt — stable, non-reversible audit key. */
+  /** The model-fire text (prompt/poll). Absent for kind=action — an action
+   *  never fires a model, so it has no prompt. */
+  prompt?: string;
+  /** SHA-256 prefix of the prompt (or, for an action, its spec) — stable,
+   *  non-reversible audit key. */
   promptKey: string;
   /**
    * Cheap-cron routing fields (docs/rfcs/cheap-cron-sessions.md). Consumed
@@ -35,10 +38,12 @@ export interface SchedulerEntry {
    * inert unless SWITCHROOM_CHEAP_CRON is on. `kind: poll` runs a model-free
    * deterministic poll (requires `poll`) that only escalates on a hit.
    */
-  kind?: "poll" | "prompt";
+  kind?: "poll" | "prompt" | "action";
   model?: string;
   context?: "fresh" | "agent";
   poll?: PollSpec;
+  /** Required iff kind=action. The declarative model-free action spec. */
+  action?: ActionSpec;
   /**
    * Per-entry Telegram topic override (PR4b of supergroup-mode rollout).
    * Either a string alias defined in the agent's
@@ -79,12 +84,15 @@ export function collectScheduleEntries(
     const schedule: ScheduleEntry[] = resolved.schedule ?? [];
     for (let i = 0; i < schedule.length; i++) {
       const entry = schedule[i]!;
+      // An action has no prompt; key the audit off its spec instead so the
+      // promptKey stays a stable, non-reversible correlation id.
+      const auditMaterial = entry.prompt ?? `action:${JSON.stringify(entry.action ?? {})}`;
       out.push({
         agent,
         scheduleIndex: i,
         cron: entry.cron,
-        prompt: entry.prompt,
-        promptKey: createHash("sha256").update(entry.prompt).digest("hex").slice(0, 12),
+        ...(entry.prompt !== undefined ? { prompt: entry.prompt } : {}),
+        promptKey: createHash("sha256").update(auditMaterial).digest("hex").slice(0, 12),
         // Propagate the per-entry topic override (PR1 schema field).
         // Resolved at dispatch time via resolveOutboundTopic().
         ...(entry.topic !== undefined ? { topic: entry.topic } : {}),
@@ -93,6 +101,7 @@ export function collectScheduleEntries(
         ...(entry.model !== undefined ? { model: entry.model } : {}),
         ...(entry.context !== undefined ? { context: entry.context } : {}),
         ...(entry.poll !== undefined ? { poll: entry.poll } : {}),
+        ...(entry.action !== undefined ? { action: entry.action } : {}),
       });
     }
   }
@@ -123,7 +132,7 @@ export interface DispatchResult {
    * report` can show the cost breakdown. Absent on legacy audit rows and
    * when SWITCHROOM_CHEAP_CRON is off (treated as 'main').
    */
-  tier?: "poll" | "cheap" | "main";
+  tier?: "poll" | "action" | "cheap" | "main";
   modelUsed?: string;
 }
 
@@ -239,7 +248,9 @@ export function dispatchAsInbound(
     user: "cron",
     userId: 0,
     ts,
-    text: entry.prompt,
+    // dispatchAsInbound is only called for prompt/poll entries (which carry a
+    // prompt); an action never reaches here. Fallback keeps the type total.
+    text: entry.prompt ?? "",
     meta: {
       source: "cron",
       schedule_index: String(entry.scheduleIndex),

--- a/src/scheduler/schedule-report.test.ts
+++ b/src/scheduler/schedule-report.test.ts
@@ -10,6 +10,8 @@ const rows: ScheduleReportRow[] = [
   { tier: "poll", exitCode: 0, startedAt: 100 },
   { tier: "poll", exitCode: 0, startedAt: 200 },
   { tier: "poll", exitCode: -3, startedAt: 250 }, // poll error
+  { tier: "action", exitCode: 0, startedAt: 260 }, // model-free action (cost 0)
+  { tier: "action", exitCode: -4, startedAt: 270 }, // action error
   { tier: "cheap", exitCode: 0, modelUsed: "claude-sonnet-4-6", startedAt: 300 },
   { tier: "main", exitCode: 0, startedAt: 400 },
   { tier: "main", exitCode: -2, startedAt: 450 }, // deferred
@@ -20,13 +22,14 @@ describe("summarizeScheduleReport", () => {
   it("counts by tier, errors, deferred, cost-weight", () => {
     const s = summarizeScheduleReport(rows);
     expect(s).toMatchObject({
-      total: 7,
+      total: 9,
       pollFires: 3,
+      actionFires: 2,
       cheapFires: 1,
       mainFires: 3, // 2 main + 1 legacy untiered
-      errors: 1, // the -3 poll error (deferred -2 excluded)
+      errors: 2, // the -3 poll error + the -4 action error (deferred -2 excluded)
       deferred: 1,
-      costWeight: 0 * 3 + 1 * 1 + 5 * 3, // = 16
+      costWeight: 0 * 3 + 0 * 2 + 1 * 1 + 5 * 3, // actions are free = 16
     });
     expect(s.byModel).toEqual({ "claude-sonnet-4-6": 1 });
   });
@@ -56,9 +59,9 @@ describe("parseScheduleJsonl", () => {
 });
 
 describe("formatScheduleReport", () => {
-  it("shows the model-free %", () => {
+  it("shows the model-free % (poll + action)", () => {
     const out = formatScheduleReport("marko", summarizeScheduleReport(rows));
     expect(out).toContain("marko");
-    expect(out).toContain("43% model-free"); // 3/7
+    expect(out).toContain("56% model-free"); // (3 poll + 2 action) / 9
   });
 });

--- a/src/scheduler/schedule-report.ts
+++ b/src/scheduler/schedule-report.ts
@@ -7,7 +7,7 @@
  */
 
 export interface ScheduleReportRow {
-  tier?: "poll" | "cheap" | "main";
+  tier?: "poll" | "action" | "cheap" | "main";
   exitCode: number;
   modelUsed?: string;
   startedAt?: number;
@@ -18,6 +18,8 @@ export interface ScheduleReportSummary {
   total: number;
   /** Model-free Tier-0 poll fires (no-op/baseline) — the saving, cost 0. */
   pollFires: number;
+  /** Model-free Tier-0 action fires (mechanical verbs) — cost 0. */
+  actionFires: number;
   /** Tier-1 cheap-session model fires. */
   cheapFires: number;
   /** Tier-2 main-session model fires (incl. legacy untiered rows). */
@@ -35,8 +37,8 @@ export interface ScheduleReportSummary {
   byModel: Record<string, number>;
 }
 
-// Relative cost weights (sonnet:opus output ≈ 1:5). Tier 0 is free.
-const TIER_WEIGHT: Record<"poll" | "cheap" | "main", number> = { poll: 0, cheap: 1, main: 5 };
+// Relative cost weights (sonnet:opus output ≈ 1:5). Tier 0 (poll/action) is free.
+const TIER_WEIGHT: Record<"poll" | "action" | "cheap" | "main", number> = { poll: 0, action: 0, cheap: 1, main: 5 };
 
 export function summarizeScheduleReport(
   rows: ScheduleReportRow[],
@@ -45,6 +47,7 @@ export function summarizeScheduleReport(
   const s: ScheduleReportSummary = {
     total: 0,
     pollFires: 0,
+    actionFires: 0,
     cheapFires: 0,
     mainFires: 0,
     errors: 0,
@@ -58,6 +61,7 @@ export function summarizeScheduleReport(
     // Legacy rows (pre-cheap-cron) have no tier → count as main (today's behaviour).
     const tier = r.tier ?? "main";
     if (tier === "poll") s.pollFires += 1;
+    else if (tier === "action") s.actionFires += 1;
     else if (tier === "cheap") s.cheapFires += 1;
     else s.mainFires += 1;
     s.costWeight += TIER_WEIGHT[tier];
@@ -86,11 +90,12 @@ export function parseScheduleJsonl(blob: string): ScheduleReportRow[] {
 
 export function formatScheduleReport(agent: string, s: ScheduleReportSummary): string {
   const modelFires = s.cheapFires + s.mainFires;
-  const savedPct = s.total > 0 ? Math.round((s.pollFires / s.total) * 100) : 0;
+  const modelFreePct = s.total > 0 ? Math.round(((s.pollFires + s.actionFires) / s.total) * 100) : 0;
   const lines = [
     `cron report — ${agent}`,
     `  total fires        ${s.total}`,
-    `  Tier 0 poll (free) ${s.pollFires}  (${savedPct}% model-free)`,
+    `  Tier 0 poll (free) ${s.pollFires}  (${modelFreePct}% model-free incl. actions)`,
+    `  Tier 0 action(free)${s.actionFires}`,
     `  Tier 1 cheap       ${s.cheapFires}`,
     `  Tier 2 main        ${s.mainFires}`,
     `  model fires        ${modelFires}`,

--- a/src/scheduler/tier-selector.ts
+++ b/src/scheduler/tier-selector.ts
@@ -50,7 +50,7 @@ export interface TierRecommendation {
 export interface TierSelectorInput {
   /** The cron's smallest implied gap in minutes (from extractCronSmallestGapMin). */
   smallestGapMin: number;
-  kind?: "poll" | "prompt";
+  kind?: "poll" | "prompt" | "action";
   model?: string;
   context?: "fresh" | "agent";
 }
@@ -80,6 +80,9 @@ export function recommendCronTier(
   frequentGapMin: number = DEFAULT_FREQUENT_GAP_MIN,
 ): TierRecommendation {
   // 1. Explicit hints win — the agent/operator asked for a specific tier.
+  if (input.kind === "action") {
+    return { tier: "action", source: "explicit", reason: "declared kind: action (model-free verb)" };
+  }
   if (input.kind === "poll") {
     return { tier: "poll", source: "explicit", reason: "declared kind: poll (model-free check)" };
   }
@@ -117,7 +120,7 @@ export function recommendCronTier(
 /** The minimal shape `applyDefaultTier` reads + augments. */
 export interface TierableEntry {
   cron: string;
-  kind?: "poll" | "prompt";
+  kind?: "poll" | "prompt" | "action";
   model?: string;
   context?: "fresh" | "agent";
 }


### PR DESCRIPTION
## Summary

PR 1 of 3 for the **Tier-0 model-free action tier** (#2307 — the cleaner-win-first half of the issue). A `kind: action` cron entry COMPLETES mechanical work deterministically in the scheduler process: **zero model calls, no second `claude`, no session wake**. It is the terminal sibling of `kind: poll` — a poll *escalates* to a model on a hit; an action *just does the thing*.

This PR is the pure **engine + schema + routing**, fully exercised with an injected transport. The gateway `send_outbound` IPC verb (**PR2**) and the wiring + test-harness canary (**PR3**) follow.

## Why

The sharpest cheap-by-default win (`reference/crons-use-the-model-only-when-it-earns-it.md`): many crons are purely mechanical — a daily heartbeat message, a status-page ping. Routing those through a model (even a cheap Tier-1 session) is pure waste. An action tier runs them at zero tokens with none of the Tier-1 hazards (no tool-starvation, no boot-wedge, no second session).

## What

Two action types (both confirmed with the operator):
- **`telegram-message`** — post a fixed/templated text to the agent's **OWN chat** (no `chat_id` field — the chat is not configurable, so a message action cannot target a foreign chat), into the entry-level `topic`. Deterministic `{{date}}`/`{{time}}`/`{{agent}}` substitution **only** — no secrets in a message body, no model output.
- **`webhook`** — fire a fixed HTTP request to an allowlisted host, **reusing the poll egress fence** (`checkEgressUrl` + host-pinned secret bindings + DNS-rebind pin). `{{secret}}` substitution into headers/body, host-pinned.

## Design decisions

- **`kind: action` is flag-independent.** It routes to `tier:"action"` regardless of `SWITCHROOM_CHEAP_CRON`. The kill-switch governs *model* tiering (poll escalation, cheap vs main session); an action has no prompt and thus no Tier-2 fallback, so gating it on the flag would silently drop the cron — violating "disabling can never drop a cron." The total-enumeration routing test grows 90→120 cases with a new INV-0.
- **Operator-config-only by construction.** The `schedule_add` MCP tool builds overlay entries from `{cron, prompt, secrets, name, model, context}` only — no `kind`/`action` field — so an agent **cannot** self-author an action (same posture as `poll`, which needs an operator egress commit).
- **Subscription-honest.** `ActionDeps` carries only `fetch` / vault-secret / dns / egress-allowlist / a model-free `sendMessage`. There is no `claude`/SDK/`inject_inbound` seam anywhere, and `runAction` never returns anything that triggers a dispatch.

## Files

`schema.ts` (ActionSpecSchema discriminated union, `kind` enum + `action`, `prompt` optional-for-actions via superRefine), `action-engine.ts` (pure, injected deps, never-throws), `cron-routing.ts` (`tier:action`), `dispatch.ts` (`SchedulerEntry.action` + optional prompt + propagation + action-keyed audit), `tier-selector.ts`, `schedule-report.ts` (`actionFires`, cost 0), `cron-unit-name.ts` (optional prompt). The `index.ts` tick-loop branch records `tier:action` exit 0/-4, is **terminal** (no dispatch), **replay-skips** (never double-fires a side effect), and falls back to a graceful audited no-op when the transport is unwired (PR2/PR3).

## Test plan

- [x] `action-engine.test.ts` (10) — message substitution, send seam, webhook egress/secret-binding/DNS-rebind/non-2xx, message↔webhook isolation.
- [x] `cheap-cron-schema.test.ts` (+8) — action validation (requires spec, rejects prompt-on-action, rejects action-on-prompt, prompt-required-for-poll/prompt, unknown type, bad url).
- [x] `cron-routing.test.ts` — total enumeration +action (INV-0 flag-independence) + load-bearing case.
- [x] `cheap-cron-fire.test.ts` (+5) — tick-loop: ok → tier:action exit 0 NO dispatch; error → -4; thrown → caught -4; unwired → graceful -4; flag-off → still runs.
- [x] `collect-entries.test.ts`, `schedule-report.test.ts` — propagation + free-tier accounting.
- [x] `tsc --noEmit` clean. (The 9 build-dependent CLI/spawn suites need a prebuilt `dist/`; CI builds first.)

## Risk

Low. Net-new entry kind, default-unused (no agent configures it; the canary is PR3). The engine is pure and never throws into the tick loop. No existing routing/poll/prompt behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)