### PR TITLE
feat(gateway): model-free send_outbound IPC verb for Tier-0 actions (#2307 PR2)

### DIFF
--- a/src/agent-scheduler/ipc-client.test.ts
+++ b/src/agent-scheduler/ipc-client.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect } from "vitest";
 import { EventEmitter } from "node:events";
 import type { Socket } from "node:net";
 import { createInjectIpcClient } from "./ipc-client.js";
-import type { InjectInboundMessage } from "../../telegram-plugin/gateway/ipc-protocol.js";
+import type { InjectInboundMessage, SendOutboundMessage } from "../../telegram-plugin/gateway/ipc-protocol.js";
 
 class FakeSocket extends EventEmitter {
   public writes: string[] = [];
@@ -80,6 +80,34 @@ describe("createInjectIpcClient", () => {
     expect(parsed.agentName).toBe("klanker");
     expect(parsed.inbound.meta.source).toBe("cron");
 
+    client.close();
+  });
+
+  it("sendOutbound returns false before connect, true after, as one NDJSON line", async () => {
+    const fake = new FakeSocket();
+    const client = createInjectIpcClient({
+      socketPath: "/fake.sock",
+      _connect: () => fake as unknown as Socket,
+    });
+    const msg: SendOutboundMessage = {
+      type: "send_outbound",
+      agentName: "clerk",
+      chatId: "12345",
+      threadId: 7,
+      text: "Daily heartbeat 2026-06-13",
+      parseMode: "html",
+    };
+    expect(client.sendOutbound(msg)).toBe(false); // not connected yet
+
+    await tick();
+    fake.emit("connect");
+
+    expect(client.sendOutbound(msg)).toBe(true);
+    expect(fake.writes).toHaveLength(1);
+    const parsed = JSON.parse(fake.writes[0]!.trim());
+    expect(parsed.type).toBe("send_outbound");
+    expect(parsed.chatId).toBe("12345");
+    expect(parsed.text).toBe("Daily heartbeat 2026-06-13");
     client.close();
   });
 

--- a/src/agent-scheduler/ipc-client.ts
+++ b/src/agent-scheduler/ipc-client.ts
@@ -21,7 +21,7 @@
  */
 
 import { createConnection, type Socket } from "node:net";
-import type { InjectInboundMessage } from "../../telegram-plugin/gateway/ipc-protocol.js";
+import type { InjectInboundMessage, SendOutboundMessage } from "../../telegram-plugin/gateway/ipc-protocol.js";
 
 export interface InjectIpcClientOptions {
   socketPath: string;
@@ -52,6 +52,13 @@ export interface InjectIpcClient {
    * or the write fails.
    */
   sendInjectInbound(msg: InjectInboundMessage): boolean;
+  /**
+   * #2307 Tier-0 action tier — send a MODEL-FREE `send_outbound` envelope
+   * (a `kind: action` telegram-message). Same fire-and-forget delivery
+   * semantics as `sendInjectInbound`: true iff the bytes were accepted by
+   * the local socket. The gateway fences the chat to the agent's own.
+   */
+  sendOutbound(msg: SendOutboundMessage): boolean;
   isConnected(): boolean;
   /**
    * Resolve to true once the client is connected, false on timeout.
@@ -157,6 +164,15 @@ export function createInjectIpcClient(
 
   return {
     sendInjectInbound(msg: InjectInboundMessage): boolean {
+      if (!socket || !connected) return false;
+      try {
+        return socket.write(JSON.stringify(msg) + "\n");
+      } catch (err) {
+        log(`scheduler ipc: write failed: ${(err as Error).message}`);
+        return false;
+      }
+    },
+    sendOutbound(msg: SendOutboundMessage): boolean {
       if (!socket || !connected) return false;
       try {
         return socket.write(JSON.stringify(msg) + "\n");

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -363,6 +363,7 @@ import type {
   PtyPartialForward,
   InboundMessage,
   InjectInboundMessage,
+  SendOutboundMessage,
   QuotaWallDetectedMessage,
   PermissionEvent,
 } from './ipc-protocol.js'
@@ -6562,6 +6563,47 @@ const ipcServer: IpcServer = createIpcServer({
     if (!delivered) {
       pendingInboundBuffer.push(target, msg.inbound)
     }
+  },
+
+  // #2307 Tier-0 action tier — a MODEL-FREE outbound post. The agent-scheduler
+  // fires this for a `kind: action` `telegram-message`; the gateway posts the
+  // (already-substituted) text to the agent's OWN chat with NO model: no
+  // inject_inbound, no session wake, no currentTurn mutation. Two fences:
+  //   1. agentName must match this gateway's own SWITCHROOM_AGENT_NAME.
+  //   2. chatId must be an allowlisted chat for this agent (assertAllowedChat).
+  // An action carries no chat target of its own — the scheduler supplies the
+  // agent's own chat — so 2 is belt-and-braces against a malformed/foreign id.
+  onSendOutbound(_client: IpcClient, msg: SendOutboundMessage) {
+    const self = process.env.SWITCHROOM_AGENT_NAME
+    if (self && msg.agentName !== self) {
+      process.stderr.write(
+        `telegram gateway: send_outbound rejected — agent mismatch (${msg.agentName} != ${self})\n`,
+      )
+      return
+    }
+    try {
+      assertAllowedChat(msg.chatId)
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: send_outbound rejected — ${(err as Error).message}\n`,
+      )
+      return
+    }
+    const threadId = msg.threadId
+    const parseMode = msg.parseMode === 'text' ? undefined : 'HTML'
+    // allow-raw-bot-api: wrapped in swallowingApiCall (retry policy); thread-aware send.
+    // General topic (thread 1) sends omit message_thread_id per the outbound convention.
+    void swallowingApiCall(
+      () =>
+        bot.api.sendMessage(msg.chatId, msg.text, {
+          ...(parseMode ? { parse_mode: parseMode } : {}),
+          ...(threadId != null && threadId !== 1 ? { message_thread_id: threadId } : {}),
+        }),
+      { chat_id: msg.chatId, verb: 'cron-action-send', ...(threadId != null ? { threadId } : {}) },
+    )
+    process.stderr.write(
+      `telegram gateway: send_outbound agent=${msg.agentName} chat=${msg.chatId} thread=${threadId ?? '-'} len=${msg.text.length}\n`,
+    )
   },
 
   // The wedge-watchdog detected claude's /rate-limit-options weekly-quota menu

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -413,6 +413,35 @@ export interface QuotaWallDetectedMessage {
   resetAt?: number;
 }
 
+/**
+ * #2307 (Tier-0 action tier) — a MODEL-FREE outbound post. Sent by the
+ * in-agent scheduler when a `kind: action` cron's `telegram-message` fires:
+ * the gateway posts `text` to the agent's OWN chat with no model involvement
+ * (NO `inject_inbound`, NO session wake, NO `currentTurn` mutation). This is
+ * the deliberate counterpart to `inject_inbound` — the one ClientToGateway
+ * verb that produces an outbound WITHOUT a turn.
+ *
+ * Trust model: same as `inject_inbound` — the socket is per-agent inside the
+ * container, only that-UID processes can connect. `agentName` is validated
+ * server-side, and the gateway FENCES `chatId` to the agent's own configured
+ * chat (DM allowlist / forum_chat_id) and rejects a foreign chat — an action
+ * can never post elsewhere (the action spec carries no chat target; the
+ * scheduler supplies the agent's own).
+ */
+export interface SendOutboundMessage {
+  type: "send_outbound";
+  /** Target agent — gateway verifies it matches its own SWITCHROOM_AGENT_NAME. */
+  agentName: string;
+  /** Agent's own chat id (fenced server-side against the agent's config). */
+  chatId: string;
+  /** Forum topic thread id (General/unset omitted; 1 is stripped on send). */
+  threadId?: number;
+  /** Message body — already substitution-resolved by the action engine. */
+  text: string;
+  /** Telegram parse mode. Defaults to HTML. */
+  parseMode?: "html" | "text";
+}
+
 export type ClientToGateway =
   | RegisterMessage
   | ToolCallMessage
@@ -428,4 +457,5 @@ export type ClientToGateway =
   | RequestMs365ApprovalMessage
   | RequestConfigApprovalMessage
   | RequestConfigFinalizeMessage
-  | QuotaWallDetectedMessage;
+  | QuotaWallDetectedMessage
+  | SendOutboundMessage;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -262,7 +262,10 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
       if (typeof m.agentName !== "string"
         || !AGENT_NAME_RE.test(m.agentName as string)) return false;
       if (typeof m.chatId !== "string" || (m.chatId as string).length === 0) return false;
-      if (typeof m.text !== "string" || (m.text as string).length === 0) return false;
+      // text non-empty and bounded — Telegram caps a message at 4096 chars;
+      // reject over-long here (defense in depth against a malformed payload).
+      if (typeof m.text !== "string" || (m.text as string).length === 0
+        || (m.text as string).length > 4096) return false;
       if (m.threadId !== undefined
         && (typeof m.threadId !== "number" || !Number.isInteger(m.threadId as number))) return false;
       if (m.parseMode !== undefined && m.parseMode !== "html" && m.parseMode !== "text") return false;

--- a/telegram-plugin/gateway/ipc-server.ts
+++ b/telegram-plugin/gateway/ipc-server.ts
@@ -4,6 +4,7 @@ import type {
   GatewayToClient,
   HeartbeatMessage,
   InjectInboundMessage,
+  SendOutboundMessage,
   QuotaWallDetectedMessage,
   OperatorEventForward,
   PermissionRequestForward,
@@ -45,6 +46,15 @@ export interface IpcServerOptions {
    * inline scheduler simply ignore inject_inbound messages.
    */
   onInjectInbound?: (client: IpcClient, msg: InjectInboundMessage) => void;
+  /**
+   * #2307 Tier-0 action tier — a model-free outbound post. Invoked when the
+   * agent-scheduler sibling fires a `kind: action` `telegram-message`. The
+   * handler is expected to post `msg.text` to `msg.chatId` (fenced to the
+   * agent's own chat) via the locked bot — with NO model, NO inject_inbound,
+   * NO session wake. Optional: gateways that don't run the inline scheduler
+   * ignore it.
+   */
+  onSendOutbound?: (client: IpcClient, msg: SendOutboundMessage) => void;
   /**
    * The autoaccept-poll wedge-watchdog detected claude's `/rate-limit-options`
    * weekly-quota menu (no 429 ever reached the gateway). Handler is expected to
@@ -246,6 +256,18 @@ export function validateClientMessage(msg: unknown): msg is ClientToGateway {
         && typeof inb.meta === "object"
         && inb.meta !== null;
     }
+    case "send_outbound": {
+      // #2307 Tier-0 action tier — a model-free outbound post. Validate the
+      // wire shape; the gateway handler fences chatId to the agent's own chat.
+      if (typeof m.agentName !== "string"
+        || !AGENT_NAME_RE.test(m.agentName as string)) return false;
+      if (typeof m.chatId !== "string" || (m.chatId as string).length === 0) return false;
+      if (typeof m.text !== "string" || (m.text as string).length === 0) return false;
+      if (m.threadId !== undefined
+        && (typeof m.threadId !== "number" || !Number.isInteger(m.threadId as number))) return false;
+      if (m.parseMode !== undefined && m.parseMode !== "html" && m.parseMode !== "text") return false;
+      return true;
+    }
     case "quota_wall_detected": {
       // wedge-watchdog detected the /rate-limit-options weekly-quota menu.
       if (typeof m.agentName !== "string"
@@ -335,6 +357,7 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
     onOperatorEvent,
     onPtyPartial,
     onInjectInbound,
+    onSendOutbound,
     onQuotaWallDetected,
     onRequestDriveApproval,
     onRequestMs365Approval,
@@ -443,6 +466,9 @@ export function createIpcServer(options: IpcServerOptions): IpcServer {
         break;
       case "inject_inbound":
         if (onInjectInbound) onInjectInbound(client, msg as InjectInboundMessage);
+        break;
+      case "send_outbound":
+        if (onSendOutbound) onSendOutbound(client, msg as SendOutboundMessage);
         break;
       case "quota_wall_detected":
         if (onQuotaWallDetected) onQuotaWallDetected(client, msg as QuotaWallDetectedMessage);

--- a/telegram-plugin/tests/ipc-server-validate-send-outbound.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-send-outbound.test.ts
@@ -34,10 +34,12 @@ describe("validateClientMessage — send_outbound", () => {
     expect(validateClientMessage({ ...base, chatId: 123 })).toBe(false);
   });
 
-  it("rejects a missing / empty text", () => {
+  it("rejects a missing / empty / over-long text", () => {
     expect(validateClientMessage({ ...base, text: undefined })).toBe(false);
     expect(validateClientMessage({ ...base, text: "" })).toBe(false);
     expect(validateClientMessage({ ...base, text: 5 })).toBe(false);
+    expect(validateClientMessage({ ...base, text: "x".repeat(4096) })).toBe(true); // at the cap
+    expect(validateClientMessage({ ...base, text: "x".repeat(4097) })).toBe(false); // over Telegram's limit
   });
 
   it("rejects a non-integer threadId", () => {

--- a/telegram-plugin/tests/ipc-server-validate-send-outbound.test.ts
+++ b/telegram-plugin/tests/ipc-server-validate-send-outbound.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Validation contract for the `send_outbound` IPC verb (#2307 Tier-0 action
+ * tier) — the MODEL-FREE outbound the agent-scheduler sends for a `kind: action`
+ * telegram-message. A rogue process on the same UDS must not inject a malformed
+ * payload: agentName required + name-shaped, chatId + text required non-empty,
+ * threadId (optional) an integer, parseMode (optional) html|text.
+ */
+import { describe, it, expect } from "vitest";
+import { validateClientMessage } from "../gateway/ipc-server.js";
+
+const base = { type: "send_outbound", agentName: "clerk", chatId: "12345", text: "Daily heartbeat" };
+
+describe("validateClientMessage — send_outbound", () => {
+  it("accepts a well-formed minimal message", () => {
+    expect(validateClientMessage(base)).toBe(true);
+  });
+
+  it("accepts threadId + parseMode", () => {
+    expect(validateClientMessage({ ...base, threadId: 7, parseMode: "html" })).toBe(true);
+    expect(validateClientMessage({ ...base, threadId: 1, parseMode: "text" })).toBe(true);
+  });
+
+  it("rejects a missing / non-string / malformed agentName", () => {
+    expect(validateClientMessage({ ...base, agentName: undefined })).toBe(false);
+    expect(validateClientMessage({ ...base, agentName: 123 })).toBe(false);
+    expect(validateClientMessage({ ...base, agentName: "" })).toBe(false);
+    expect(validateClientMessage({ ...base, agentName: "../etc" })).toBe(false);
+    expect(validateClientMessage({ ...base, agentName: "Clerk UPPER" })).toBe(false);
+  });
+
+  it("rejects a missing / empty chatId", () => {
+    expect(validateClientMessage({ ...base, chatId: undefined })).toBe(false);
+    expect(validateClientMessage({ ...base, chatId: "" })).toBe(false);
+    expect(validateClientMessage({ ...base, chatId: 123 })).toBe(false);
+  });
+
+  it("rejects a missing / empty text", () => {
+    expect(validateClientMessage({ ...base, text: undefined })).toBe(false);
+    expect(validateClientMessage({ ...base, text: "" })).toBe(false);
+    expect(validateClientMessage({ ...base, text: 5 })).toBe(false);
+  });
+
+  it("rejects a non-integer threadId", () => {
+    expect(validateClientMessage({ ...base, threadId: 1.5 })).toBe(false);
+    expect(validateClientMessage({ ...base, threadId: "1" })).toBe(false);
+  });
+
+  it("rejects an unknown parseMode", () => {
+    expect(validateClientMessage({ ...base, parseMode: "markdown" })).toBe(false);
+    expect(validateClientMessage({ ...base, parseMode: 1 })).toBe(false);
+  });
+});

--- a/telegram-plugin/tests/send-outbound-wiring.test.ts
+++ b/telegram-plugin/tests/send-outbound-wiring.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Structural wiring guard for the model-free `send_outbound` verb (#2307).
+ *
+ * The gateway handler lives in the createIpcServer({...}) IIFE block, which
+ * can't be imported in a unit test (same constraint as the inject_inbound /
+ * linear-activity wiring tests), so the load-bearing invariants are pinned by
+ * reading the source:
+ *   1. ipc-server routes `send_outbound` → onSendOutbound.
+ *   2. the gateway handler fences agent (agentName === self) AND chat
+ *      (assertAllowedChat) before sending.
+ *   3. it is MODEL-FREE: never markClaudeBusy / currentTurn / inject — a
+ *      send_outbound must not wake a turn (the whole point of Tier-0).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+
+const gw = readFileSync(new URL("../gateway/gateway.ts", import.meta.url), "utf8");
+const ipcServer = readFileSync(new URL("../gateway/ipc-server.ts", import.meta.url), "utf8");
+
+describe("send_outbound — ipc-server routing", () => {
+  it("validates the verb and dispatches to onSendOutbound", () => {
+    expect(ipcServer).toMatch(/case "send_outbound":/);
+    expect(ipcServer).toMatch(/onSendOutbound\(client, msg as SendOutboundMessage\)/);
+    // the validator has a dedicated arm.
+    expect(ipcServer).toMatch(/case "send_outbound": \{/);
+  });
+});
+
+describe("send_outbound — gateway handler invariants", () => {
+  // Isolate the handler body for the assertions below.
+  const start = gw.indexOf("onSendOutbound(_client: IpcClient, msg: SendOutboundMessage)");
+  const handler = gw.slice(start, start + 1600);
+
+  it("the handler exists", () => {
+    expect(start).toBeGreaterThan(0);
+  });
+
+  it("fences the agent (agentName must match this gateway's own)", () => {
+    expect(handler).toMatch(/msg\.agentName !== self/);
+  });
+
+  it("fences the chat to the agent's own allowlist (assertAllowedChat)", () => {
+    expect(handler).toMatch(/assertAllowedChat\(msg\.chatId\)/);
+  });
+
+  it("is MODEL-FREE — never wakes a turn (no markClaudeBusy / currentTurn / inject)", () => {
+    expect(handler).not.toMatch(/markClaudeBusy/);
+    expect(handler).not.toMatch(/currentTurn/);
+    expect(handler).not.toMatch(/sendToAgent/);
+    expect(handler).not.toMatch(/inject/i);
+  });
+
+  it("sends via the wrapped retry path (not a raw bot.api outside swallowingApiCall)", () => {
+    expect(handler).toMatch(/swallowingApiCall\(/);
+    expect(handler).toMatch(/bot\.api\.sendMessage\(msg\.chatId, msg\.text/);
+    // General topic (thread 1) is stripped on send, per the outbound convention.
+    expect(handler).toMatch(/threadId !== 1/);
+  });
+});

--- a/telegram-plugin/tests/send-outbound-wiring.test.ts
+++ b/telegram-plugin/tests/send-outbound-wiring.test.ts
@@ -29,7 +29,11 @@ describe("send_outbound — ipc-server routing", () => {
 describe("send_outbound — gateway handler invariants", () => {
   // Isolate the handler body for the assertions below.
   const start = gw.indexOf("onSendOutbound(_client: IpcClient, msg: SendOutboundMessage)");
-  const handler = gw.slice(start, start + 1600);
+  // Bound the slice at the START of the NEXT handler so the whole onSendOutbound
+  // body is covered regardless of how it grows (no fixed char window to outgrow),
+  // without bleeding into a sibling handler.
+  const next = gw.indexOf("onQuotaWallDetected(", start);
+  const handler = gw.slice(start, next > start ? next : start + 2600);
 
   it("the handler exists", () => {
     expect(start).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

PR 2 of 3 for the **Tier-0 model-free action tier** (#2307). Adds the one `ClientToGateway` verb that produces a Telegram outbound **without a model turn** — the transport a `kind: action` `telegram-message` fires through. PR1 (#2318, merged) landed the engine + schema; **PR3** wires the engine's `sendMessage` seam to this verb + canaries.

## Why

Today every cron→gateway verb wakes the model: `inject_inbound` → a Claude turn. A Tier-0 action must post **model-free** (that's the whole point — zero tokens). There was no such primitive. `send_outbound` is the deliberate counterpart to `inject_inbound`: the gateway posts already-resolved text to the agent's own chat with **no `inject_inbound`, no session wake, no `currentTurn` mutation**.

## What

- **`ipc-protocol.ts`** — `SendOutboundMessage { agentName, chatId, threadId?, text, parseMode? }` added to the `ClientToGateway` union.
- **`ipc-server.ts`** — `validateClientMessage` arm (agentName name-shaped, chatId + text non-empty, threadId integer, parseMode html|text) + `onSendOutbound` handler option + dispatch case.
- **`gateway.ts` `onSendOutbound`** — **two fences before any send**:
  1. `agentName` must equal this gateway's own `SWITCHROOM_AGENT_NAME`;
  2. `assertAllowedChat(chatId)` — the agent's **own allowlisted chat only**. An action carries no chat target of its own (the scheduler supplies the agent's), so this is belt-and-braces against a foreign/malformed id.

  Foreign agent/chat → logged reject, no send. Posts via the wrapped `swallowingApiCall` retry path (passes `check-bot-api-wrapping`), strips General topic (thread 1) per the outbound convention. **Never** touches `markClaudeBusy`/`currentTurn` — model-free by construction.
- **`ipc-client.ts`** (scheduler) — `sendOutbound()`, same fire-and-forget NDJSON-write semantics as `sendInjectInbound`.

## Test plan

- [x] `ipc-server-validate-send-outbound.test.ts` (7) — validation contract (agent name shape, required chatId/text, integer threadId, parseMode enum).
- [x] `send-outbound-wiring.test.ts` (6) — source-wiring guard: ipc-server routing; the agent + chat fences; and the **model-free invariant** (handler body contains no `markClaudeBusy`/`currentTurn`/`sendToAgent`/`inject`).
- [x] `ipc-client.test.ts` (+1) — `sendOutbound` NDJSON wire + connected-gating.
- [x] `tsc --noEmit` + `check-plugin-references.mjs` + `check-bot-api-wrapping.sh` clean; protocol/validator/ipc-server suites green under **both** vitest and bun.

## Risk

Low. Net-new verb with no caller yet (PR3 wires it). The two fences make a foreign-chat post impossible; the handler is model-free by construction (pinned by the wiring guard). No existing IPC path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)