### PR TITLE
feat(cron): wire Tier-0 action engine to the gateway transport (#2307 PR3)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -231,9 +231,35 @@ Because each fire is a full turn in the live session by default, a frequent cron
 | The fire to act *as the agent* (persona, memory, recent chat) | default (no `model`) — **Tier 2** | full live-session turn |
 | Light, self-contained work (summarise/format) — no memory needed | `model: sonnet` / `context: fresh` — **Tier 1** | a fresh minimal-context cheap session |
 | "Only do something when X changes" (a webpage/API) | `kind: poll` (operator-set; egress-gated) — **Tier 0** | model-free check; a model fire only on a *hit* |
+| "Do this exact mechanical thing on a schedule" (post a fixed message, ping a webhook) | `kind: action` (operator-set) — **Tier 0** | model-free; the action *completes* the work — **no model at all** |
 | "Do something when a message is reacted to" | **`reaction_dispatch`** (event-driven, #2291) — not a cron at all | zero polling; the reaction wakes the agent |
 
-Agents can self-author the `model`/`context` hints (no security gate). `kind: poll` and `reaction_dispatch` need an operator config commit (egress / identity gates), so an agent should *request* them. With the flag off, all hints are inert — every fire is a normal Tier-2 turn (a `kind: poll` entry fires its escalation prompt directly); disabling cheap-cron can never silently drop a cron.
+Agents can self-author the `model`/`context` hints (no security gate). `kind: poll`, `kind: action`, and `reaction_dispatch` need an operator config commit (egress / identity gates), so an agent should *request* them. With the flag off, all hints are inert — every fire is a normal Tier-2 turn (a `kind: poll` entry fires its escalation prompt directly); disabling cheap-cron can never silently drop a cron. **A `kind: action` is the exception: it is model-free regardless of the flag** — the kill-switch governs model tiering, and an action has no model fire to fall back to.
+
+#### `kind: action` — model-free mechanical verbs (#2307)
+
+An action *replaces* a model turn with a deterministic verb. Two types (operator-config only — an agent cannot self-author one):
+
+```yaml
+schedule:
+  # Post a fixed message into the agent's own chat every morning. No model.
+  - cron: "0 8 * * *"
+    kind: action
+    action:
+      type: telegram-message
+      text: "Morning — heartbeat {{date}} ✅"   # {{date}}/{{time}}/{{agent}} only; NO secrets
+  # Ping a status webhook hourly. Same egress fence as a poll.
+  - cron: "0 * * * *"
+    kind: action
+    action:
+      type: webhook
+      url: "https://hooks.example.com/heartbeat"   # host must be in cron.egress.allowed_hosts
+      method: POST
+      secrets: ["status_token"]                     # host-pinned via cron.egress.secret_bindings
+      headers: { authorization: "Bearer {{status_token}}" }
+```
+
+`telegram-message` posts only to the agent's **own** chat (no `chat_id` field — fenced by construction) and substitutes only the deterministic `{{date}}`/`{{time}}`/`{{agent}}` placeholders — **no vault secrets in a message body, no model output**. `webhook` reuses the poll egress allowlist + host-pinned secret bindings. Anything that needs the model to *write* something (a summary, a Linear issue body) is not an action — use `kind: poll` + an escalation prompt, or `reaction_dispatch`.
 
 ## Managing the scheduler
 

--- a/src/agent-scheduler/cheap-cron-wiring.test.ts
+++ b/src/agent-scheduler/cheap-cron-wiring.test.ts
@@ -65,6 +65,65 @@ describe("buildCheapCronHooks", () => {
   });
 });
 
+describe("buildCheapCronHooks — runAction (#2307)", () => {
+  it("telegram-message → posts the substituted text via postOutbound (model-free)", async () => {
+    const posts: Array<{ threadId?: number; text: string; parseMode: string }> = [];
+    const hooks = buildCheapCronHooks(CONFIG, ON, {
+      pollState: createMemoryPollStateStore(),
+      agentName: "clerk",
+      now: () => Date.UTC(2026, 5, 13, 9, 5),
+      postOutbound: (args) => (posts.push(args), true),
+    });
+    const out = await hooks!.runAction!(
+      { type: "telegram-message", text: "Heartbeat {{date}} — {{agent}}", parse_mode: "html" },
+      { threadId: 7 },
+    );
+    expect(out.ok).toBe(true);
+    expect(posts).toHaveLength(1);
+    expect(posts[0]).toMatchObject({ threadId: 7, text: "Heartbeat 2026-06-13 — clerk", parseMode: "html" });
+  });
+
+  it("telegram-message with NO postOutbound wired → graceful not-delivered (no throw)", async () => {
+    const hooks = buildCheapCronHooks(CONFIG, ON, { pollState: createMemoryPollStateStore() });
+    const out = await hooks!.runAction!(
+      { type: "telegram-message", text: "hi", parse_mode: "html" },
+      {},
+    );
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/not delivered/);
+  });
+
+  it("webhook → fires through the wired egress fence, no postOutbound needed", async () => {
+    const fetched: string[] = [];
+    const hooks = buildCheapCronHooks(CONFIG, ON, {
+      pollState: createMemoryPollStateStore(),
+      resolveSecret: async () => "tok",
+      lookup: async () => "8.8.8.8",
+      fetchImpl: (async (url: string) => (fetched.push(url), new Response("ok", { status: 200 }))) as unknown as typeof fetch,
+    });
+    const out = await hooks!.runAction!(
+      { type: "webhook", url: "https://api.brevo.com/ping", method: "POST", secrets: [] },
+      {},
+    );
+    expect(out.ok).toBe(true);
+    expect(fetched).toEqual(["https://api.brevo.com/ping"]);
+  });
+
+  it("webhook to a non-allowlisted host is denied by the wired egress guard", async () => {
+    const hooks = buildCheapCronHooks(CONFIG, ON, {
+      pollState: createMemoryPollStateStore(),
+      lookup: async () => "8.8.8.8",
+      fetchImpl: (async () => new Response("ok", { status: 200 })) as unknown as typeof fetch,
+    });
+    const out = await hooks!.runAction!(
+      { type: "webhook", url: "https://evil.example/x", method: "POST", secrets: [] },
+      {},
+    );
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/egress denied/);
+  });
+});
+
 describe("recoverPendingEscalations", () => {
   const pollEntry: SchedulerEntry = {
     agent: "marko",

--- a/src/agent-scheduler/cheap-cron-wiring.ts
+++ b/src/agent-scheduler/cheap-cron-wiring.ts
@@ -13,14 +13,24 @@
  */
 
 import { lookup as dnsLookup } from "node:dns/promises";
-import type { PollSpec, SwitchroomConfig } from "../config/schema.js";
+import type { ActionSpec, PollSpec, SwitchroomConfig } from "../config/schema.js";
 import { isCheapCronEnabled } from "../scheduler/cron-routing.js";
 import type { EgressAllowlist } from "../scheduler/poll-egress.js";
 import { runHttpDiffPoll, type HttpDiffSpec, type PollOutcome } from "../scheduler/poll-engine.js";
+import { runAction as runActionEngine, type ActionOutcome } from "../scheduler/action-engine.js";
 import { createFilePollStateStore, type PollStateStore } from "../scheduler/poll-state.js";
 import { getViaBroker } from "../vault/broker/client.js";
 // type-only (erased) → no runtime import cycle with index.ts.
 import type { CheapCronHooks } from "./index.js";
+
+/** Post a MODEL-FREE outbound to the agent's OWN chat (bound by the caller in
+ *  main() over the IPC client + the agent's channel target). Returns true iff
+ *  the bytes were accepted by the gateway socket. */
+export type PostOutbound = (args: {
+  threadId?: number;
+  text: string;
+  parseMode: "html" | "text";
+}) => boolean;
 
 export interface CheapCronWiringDeps {
   /** Resolve a vault secret by name. Default: the agent's vault broker (ACL by socket identity). */
@@ -30,6 +40,12 @@ export interface CheapCronWiringDeps {
   lookup?: (host: string) => Promise<string | null>;
   pollState?: PollStateStore;
   now?: () => number;
+  /** Agent slug — drives {{agent}} substitution in telegram-message actions. */
+  agentName?: string;
+  /** Model-free outbound seam for telegram-message actions (#2307). Absent ⟹
+   *  a telegram-message action records "not delivered"; webhook actions are
+   *  unaffected (they use fetch). main() wires this over the IPC sendOutbound. */
+  postOutbound?: PostOutbound;
 }
 
 const defaultResolveSecret = async (name: string): Promise<string> => {
@@ -65,6 +81,8 @@ export function buildCheapCronHooks(
   const fetchImpl = deps.fetchImpl ?? fetch;
   const lookup = deps.lookup ?? defaultLookup;
   const now = deps.now ?? Date.now;
+  const agentName = deps.agentName ?? env.SWITCHROOM_AGENT_NAME ?? "-";
+  const postOutbound = deps.postOutbound;
 
   const runPoll = async (spec: PollSpec, prevCursor: string | undefined): Promise<PollOutcome> => {
     if (spec.type === "http-diff") {
@@ -82,5 +100,26 @@ export function buildCheapCronHooks(
     return { hit: false, baseline: false, error: `poll type '${spec.type}' not yet wired (staged)` };
   };
 
-  return { enabled: true, pollState, runPoll };
+  // Tier-0 action (#2307): model-free, terminal. telegram-message posts to the
+  // agent's own chat via postOutbound (the IPC send_outbound seam); webhook
+  // fires through the shared egress fence. The engine never wakes a model.
+  const runAction = async (
+    spec: ActionSpec,
+    ctx: { threadId?: number },
+  ): Promise<ActionOutcome> => {
+    return runActionEngine(spec, {
+      fetchImpl,
+      resolveSecret,
+      lookup,
+      allow: egress,
+      now,
+      agent: agentName,
+      sendMessage: async (text, opts) =>
+        postOutbound
+          ? postOutbound({ threadId: ctx.threadId, text, parseMode: opts.parseMode })
+          : false,
+    });
+  };
+
+  return { enabled: true, pollState, runPoll, runAction };
 }

--- a/src/agent-scheduler/index.ts
+++ b/src/agent-scheduler/index.ts
@@ -894,7 +894,21 @@ export async function main(): Promise<void> {
   // Cheap-cron live wiring (docs/rfcs/cheap-cron-sessions.md). Returns
   // undefined when SWITCHROOM_CHEAP_CRON is off → registerAgentSchedule sees
   // no hook → today's behaviour exactly.
-  const cheapCron = buildCheapCronHooks(config, process.env);
+  //
+  // postOutbound: the MODEL-FREE send_outbound seam for Tier-0 telegram-message
+  // actions (#2307), bound here over the IPC client + the agent's OWN channel
+  // target. The gateway re-fences chatId to the agent's allowlist; the action
+  // spec carries no chat target, so an action can only post to this chat.
+  const postOutbound = (args: { threadId?: number; text: string; parseMode: "html" | "text" }): boolean =>
+    ipcClient.sendOutbound({
+      type: "send_outbound",
+      agentName,
+      chatId: channel.chatId,
+      ...(args.threadId != null ? { threadId: args.threadId } : {}),
+      text: args.text,
+      parseMode: args.parseMode,
+    });
+  const cheapCron = buildCheapCronHooks(config, process.env, { agentName, postOutbound });
   if (cheapCron) {
     // Recover any escalation that advanced its cursor but crashed before
     // delivery (the lost-hit window), before the live loop starts.


### PR DESCRIPTION
## Summary

PR 3 of 3 for the **Tier-0 model-free action tier** (#2307) — connects the action engine (PR1 #2318, merged) to the model-free `send_outbound` transport (PR2 #2320, merged). A `kind: action` cron now runs **end-to-end**, zero model calls:

```
tick → runAction → ┬ telegram-message → postOutbound → send_outbound IPC → bot.api.sendMessage
                   └ webhook          → fetch (through the shared egress fence)
```

## What

- **`cheap-cron-wiring.ts`** — `buildCheapCronHooks` now returns `runAction`, built over the action engine with the same injected deps as `runPoll` (fetch / vault-secret / dns / egress-allowlist / now) plus a `postOutbound` seam and the agent slug (for `{{agent}}`). `telegram-message` posts via `postOutbound`; `webhook` fires through the shared egress fence. No `postOutbound` wired ⟹ a `telegram-message` records a graceful "not delivered" (webhook unaffected).
- **`index.ts` `main()`** — binds `postOutbound` over the IPC client + the agent's **own** channel target and passes it to `buildCheapCronHooks`. The gateway re-fences `chatId` to the agent's allowlist (PR2), and the action spec carries no chat target → an action can only ever post to the agent's own chat.
- **`docs/scheduling.md`** — `kind: action` row in the tiers table + a worked example (telegram-message + webhook) and the flag-independence note (Docs test).

The tick-loop action branch + routing shipped in PR1; this PR fills the `runAction` it calls.

## Test plan

- [x] `cheap-cron-wiring.test.ts` (+4) — `runAction`: telegram-message posts the substituted text via `postOutbound`; webhook fires through the wired egress fence; no-`postOutbound` graceful "not delivered"; non-allowlisted host denied.
- [x] `cheap-cron-fire.test.ts`, `action-engine.test.ts`, `cron-routing.test.ts` green (the tick-loop branch + engine from PR1).
- [x] `tsc --noEmit` clean.

## Risk

Low. Default-unused: a `kind: action` entry only runs when an operator configures one (and `SWITCHROOM_CHEAP_CRON` is on for the rest of the cron system — though an action is model-free regardless). The two-layer chat fence (spec carries no chat target + gateway `assertAllowedChat`) makes a foreign-chat post impossible. Subscription-honest: the whole path is model-free.

## Canary (post-merge, test-harness)

Add a `kind: action` telegram-message cron `* * * * *` into the harness chat; confirm (a) the message lands, (b) `scheduler.jsonl` shows `tier:action` exit 0, (c) **no model turn / no token spend** in the window — the subscription-honesty proof.

Closes the Tier-0 half of #2307 (the Tier-1 un-starve is the remaining, separate workstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)