### PR TITLE
feat(cron): Tier-1 un-starve — full MCP + liveness isolation (#2307 PR1)

### DIFF
--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -5,10 +5,15 @@
 # container, dedicated to cheap cron fires. It registers to the SAME gateway
 # as a DISTINCT bridge identity `<name>-cron` (start.sh's gateway sidecar
 # routes meta.session=cron fires here and gates all status surfaces off this
-# identity — see telegram-plugin/gateway/cron-session.ts). Minimal context:
-# its own CLAUDE_CONFIG_DIR (separate transcript) + a TRIMMED .mcp.json (only
-# switchroom-telegram) → it pays a fraction of the main session's schema +
-# cache-read tax, at the cheap cron model.
+# identity — see telegram-plugin/gateway/cron-session.ts).
+#
+# Tier-1 (#2307) is "a fresh conversation that STILL has the agent's memory +
+# tools, on a cheaper model." It loads the agent's FULL .mcp.json (its own
+# .claude-cron/.mcp.json — same hindsight bank baked from the BASE name, same
+# tools) with ENABLE_TOOL_SEARCH so the schema set DEFERS (low context cost).
+# The saving is dropping the accumulated main-session conversation context +
+# the cheaper model — NOT lobotomising the session. Its CLAUDE_CONFIG_DIR is
+# separate (own transcript) so each fire starts fresh and /clear-friendly.
 #
 # Forked as a supervised sidecar by start.sh ONLY when {{name}} actually has a
 # Tier-1 (context: fresh) cron entry AND SWITCHROOM_CHEAP_CRON is on — so the
@@ -35,12 +40,13 @@ esac
 CRON_NAME="{{name}}-cron"
 CRON_CONFIG_DIR="{{agentDir}}/.claude-cron"
 MAIN_CONFIG_DIR="{{agentDir}}/.claude"
-# TRIMMED MCP config (scaffold writes .claude-cron/.mcp.json with ONLY
-# switchroom-telegram) → the cron session pays a fraction of the main session's
-# ~31k-token MCP schema tax. The switchroom-telegram BRIDGE reads
-# SWITCHROOM_AGENT_NAME from the process env (exported below), NOT its .mcp.json
-# env block, so it registers as the cron identity. Fall back to the full
-# .mcp.json if the trimmed file is missing (older scaffold) so it still boots.
+# Cron .mcp.json (scaffold writes .claude-cron/.mcp.json with the agent's FULL
+# filtered MCP set — same hindsight bank, same tools — but the switchroom-
+# telegram entry carries a DISTINCT SWITCHROOM_BRIDGE_ALIVE_PATH so its liveness
+# file can't mask the main bridge). The bridge reads SWITCHROOM_AGENT_NAME from
+# the process env (exported below), NOT its .mcp.json env block, so it registers
+# as the cron identity. Fall back to the main .mcp.json if the cron file is
+# missing (older scaffold) so it still boots.
 CRON_MCP_CONFIG="{{agentDir}}/.claude-cron/.mcp.json"
 [ -f "$CRON_MCP_CONFIG" ] || CRON_MCP_CONFIG="{{agentDir}}/.mcp.json"
 CRON_SOCKET="switchroom-${CRON_NAME}"
@@ -63,12 +69,23 @@ fi
 export SWITCHROOM_AGENT_NAME="$CRON_NAME"
 export CLAUDE_CONFIG_DIR="$CRON_CONFIG_DIR"
 
-CRON_APPEND_PROMPT="You are the cheap background cron worker for {{name}}. You handle scheduled tasks only. Do the task, reply once with the result, and keep it brief. You do not have {{name}}'s full memory or persona — if a task needs them, say so rather than guessing."
+# Defer the (now full) MCP schema set via tool-search so the cron session keeps
+# its low-context cost — the heavy servers load on demand; switchroom-telegram
+# + hindsight stay alwaysLoad. Normally inherited from start.sh's env; set here
+# as a belt-and-braces default, honouring the operator kill-switch + any value
+# already in the env.
+if [ "${SWITCHROOM_DISABLE_TOOL_SEARCH:-}" != "1" ]; then
+  export ENABLE_TOOL_SEARCH="${ENABLE_TOOL_SEARCH:-auto}"
+fi
+
+CRON_APPEND_PROMPT="You are the cheap background cron worker for {{name}}. You run scheduled tasks in a fresh, low-context conversation on a cheaper model — but you SHARE {{name}}'s memory (hindsight) and tools, so use them: recall what you need, look things up, reply with real substance. Do the scheduled task, reply once with the result, and keep it tight."
 
 # Launch the cron claude in its OWN tmux session/socket so it never contends
 # with the main session's pane. Interactive (no -p). --strict-mcp-config pins
-# it to the trimmed config (switchroom-telegram only). Fresh each boot (no
-# --continue) — minimal context by construction.
+# it to the cron .mcp.json (full set, tool-search-deferred). Fresh each boot
+# (no --continue) — low context by construction. cd into the workspace so
+# claude's project key matches the pre-seeded trust state (.claude-cron).
+cd "{{agentDir}}" || exit 1
 exec tmux -L "$CRON_SOCKET" \
   new-session -A -s "$CRON_NAME" -x 400 -y 50 \
   claude \

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -414,20 +414,33 @@ function buildCronSessionContext(agentConfig: AgentConfig): {
 }
 
 /**
- * Cheap-cron (L4 refinement): write a TRIMMED .mcp.json for the cron session
- * at <agentDir>/.claude-cron/.mcp.json containing ONLY switchroom-telegram
- * (the bridge it needs to reply). The cron session loads this via
- * `--mcp-config … --strict-mcp-config`, so it pays a fraction of the main
- * session's ~31k-token MCP schema tax (no hindsight/perplexity/webkite/
- * agent-config/hostd). The switchroom-telegram entry is reused verbatim from
- * the main set — its identity comes from the process env SWITCHROOM_AGENT_NAME
- * (=<name>-cron, set by cron-session.sh), NOT a baked .mcp.json field.
+ * Cheap-cron Tier-1 (#2307): write the cron session's .mcp.json at
+ * <agentDir>/.claude-cron/.mcp.json. The cron session loads it via
+ * `--mcp-config … --strict-mcp-config`.
  *
- * No-op unless the agent has a cron session AND actually uses switchroom-
- * telegram (an agent on the official telegram plugin has no bridge to trim to,
- * and couldn't run a cron session anyway). Returns the trimmed path or null.
+ * Tier-1 is "a fresh conversation that STILL has the agent's memory + tools, on
+ * a cheaper model" — so this renders the agent's FULL filtered MCP set (the
+ * same map written to the main .mcp.json), NOT a trimmed one. Crucially:
+ *   - Stateful MCPs (hindsight) baked their bank id from the BASE agent name at
+ *     build time, so the cron session shares the SAME memory bank — zero
+ *     fragmentation (the cron identity `<name>-cron` only affects the telegram
+ *     bridge, which reads it from the process env, not the .mcp.json).
+ *   - The cron session runs with ENABLE_TOOL_SEARCH (cron-session.sh), so the
+ *     full schema set DEFERS — it keeps the low-context cost while having the
+ *     tools available on demand. switchroom-telegram + hindsight stay
+ *     `alwaysLoad`.
+ *   - The switchroom-telegram entry is cloned with one override:
+ *     SWITCHROOM_BRIDGE_ALIVE_PATH points its liveness file at a DISTINCT path
+ *     so a live <name>-cron bridge can't mask a dead main bridge in the
+ *     dashboard/doctor probe (RISK #2). Everything else — TELEGRAM_STATE_DIR
+ *     (access.json/history), the gateway socket — stays SHARED, so the cron
+ *     bridge authorises replies through the same gateway as the main bridge.
+ *
+ * The caller's `mcpServers` map is never mutated (the main .mcp.json source).
+ * No-op unless the agent has a cron session AND a switchroom-telegram bridge.
+ * Returns the cron config path or null.
  */
-export function maybeWriteTrimmedCronMcp(
+export function maybeWriteCronMcp(
   agentDir: string,
   mcpServers: Record<string, McpServerConfig>,
   cronSessionEnabled: boolean,
@@ -435,10 +448,29 @@ export function maybeWriteTrimmedCronMcp(
   if (!cronSessionEnabled) return null;
   const telegram = mcpServers["switchroom-telegram"];
   if (!telegram) return null;
+
+  // Clone the telegram entry with a distinct liveness-file path (RISK #2),
+  // keeping TELEGRAM_STATE_DIR (and thus access.json / history / gateway.sock)
+  // shared with the main bridge.
+  const baseStateDir = telegram.env?.TELEGRAM_STATE_DIR;
+  const cronTelegram: McpServerConfig = {
+    ...telegram,
+    env: {
+      ...telegram.env,
+      ...(baseStateDir
+        ? { SWITCHROOM_BRIDGE_ALIVE_PATH: `${baseStateDir}/.bridge-alive-cron` }
+        : {}),
+    },
+  };
+  const cronServers: Record<string, McpServerConfig> = {
+    ...mcpServers,
+    "switchroom-telegram": cronTelegram,
+  };
+
   const cronDir = join(agentDir, ".claude-cron");
   mkdirSync(cronDir, { recursive: true });
   const path = join(cronDir, ".mcp.json");
-  const content = JSON.stringify({ mcpServers: { "switchroom-telegram": telegram } }, null, 2) + "\n";
+  const content = JSON.stringify({ mcpServers: cronServers }, null, 2) + "\n";
   if (!existsSync(path) || readFileSync(path, "utf-8") !== content) {
     writeFileSync(path, content, { encoding: "utf-8", mode: 0o600 });
   }
@@ -3263,9 +3295,10 @@ export function scaffoldAgent(
       skipped,
       0o600,
     );
-    // Cheap-cron (L4 refinement): trimmed .claude-cron/.mcp.json for the cron
-    // session (switchroom-telegram only) — no-op unless this agent runs one.
-    maybeWriteTrimmedCronMcp(
+    // Cheap-cron Tier-1 (#2307): full-set .claude-cron/.mcp.json for the cron
+    // session (shared memory + tools, tool-search-deferred; cron-only liveness
+    // path) — no-op unless this agent runs a cron session.
+    maybeWriteCronMcp(
       agentDir,
       mcpServers,
       buildCronSessionContext(agentConfig).cronSessionEnabled,
@@ -5464,13 +5497,14 @@ export function reconcileAgent(
       writeFileSync(mcpJsonPath, after, { encoding: "utf-8", mode: 0o600 });
       changes.push(mcpJsonPath);
     }
-    // Cheap-cron (L4 refinement): keep the trimmed cron .mcp.json in sync.
-    const trimmedCronMcp = maybeWriteTrimmedCronMcp(
+    // Cheap-cron Tier-1 (#2307): keep the cron .mcp.json (full set + cron-only
+    // liveness path) in sync on reconcile.
+    const cronMcp = maybeWriteCronMcp(
       agentDir,
       mcpServers,
       buildCronSessionContext(agentConfig).cronSessionEnabled,
     );
-    if (trimmedCronMcp) changes.push(trimmedCronMcp);
+    if (cronMcp) changes.push(cronMcp);
     // Mirror scaffoldAgent: keep every scaffolded server on Claude
     // Code's per-project trust allowlist (idempotent — runs every
     // reconcile so a newly-added gdrive/hostd is trusted on the next

--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -827,7 +827,13 @@ async function main(): Promise<void> {
     onPermission,
     onStatus,
     log: (msg) => process.stderr.write(`telegram bridge: ipc: ${msg}\n`),
-    livenessFilePath: join(STATE_DIR, ".bridge-alive"),
+    // #2307 Tier-1: the cron-session bridge shares the agent's STATE_DIR
+    // (access.json / history / gateway.sock) but writes its liveness file to a
+    // DISTINCT path (SWITCHROOM_BRIDGE_ALIVE_PATH, set in the cron .mcp.json) so
+    // a live <agent>-cron bridge can't mask a dead MAIN bridge in the
+    // dashboard/doctor liveness probe (RISK #2). Unset ⟹ the main bridge's
+    // canonical STATE_DIR/.bridge-alive, exactly as before.
+    livenessFilePath: process.env.SWITCHROOM_BRIDGE_ALIVE_PATH ?? join(STATE_DIR, ".bridge-alive"),
   })
   if (ipc.isConnected()) {
     process.stderr.write(`telegram bridge: connected to gateway at ${SOCKET_PATH}\n`)

--- a/telegram-plugin/tests/bridge-liveness-override.test.ts
+++ b/telegram-plugin/tests/bridge-liveness-override.test.ts
@@ -1,0 +1,21 @@
+/**
+ * #2307 Tier-1 — the cron-session bridge writes its liveness file to a DISTINCT
+ * path so a live `<agent>-cron` bridge can't mask a dead MAIN bridge in the
+ * dashboard/doctor probe (RISK #2). The bridge is an IIFE (can't instantiate
+ * in-process), so this pins the wiring by source-read: the liveness file path
+ * honours `SWITCHROOM_BRIDGE_ALIVE_PATH`, falling back to the canonical
+ * STATE_DIR/.bridge-alive (unchanged for the main bridge).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const bridgeSrc = readFileSync(resolve(__dirname, "..", "bridge", "bridge.ts"), "utf-8");
+
+describe("bridge liveness path override (#2307 Tier-1)", () => {
+  it("honours SWITCHROOM_BRIDGE_ALIVE_PATH, falling back to STATE_DIR/.bridge-alive", () => {
+    expect(bridgeSrc).toMatch(
+      /livenessFilePath:\s*process\.env\.SWITCHROOM_BRIDGE_ALIVE_PATH\s*\?\?\s*join\(STATE_DIR,\s*["']\.bridge-alive["']\)/,
+    );
+  });
+});

--- a/tests/cheap-cron-session-render.test.ts
+++ b/tests/cheap-cron-session-render.test.ts
@@ -79,13 +79,24 @@ describe("cron-session.sh launcher — compliance + identity", () => {
     expect(out).toContain(".claude-cron");
   });
 
-  it("runs at the cheap cron model with the TRIMMED mcp config", () => {
+  it("runs at the cheap cron model with the cron mcp config", () => {
     expect(out).toContain("--model 'claude-sonnet-4-6'");
     expect(out).toContain("--strict-mcp-config");
-    // points at the trimmed cron config (switchroom-telegram only), with a
-    // fallback to the full config for older scaffolds.
+    // points at the cron config (full set, tool-search-deferred), with a
+    // fallback to the main config for older scaffolds.
     expect(out).toContain(".claude-cron/.mcp.json");
     expect(out).toContain('[ -f "$CRON_MCP_CONFIG" ] ||');
+  });
+
+  it("Tier-1 un-starve (#2307): tool-search on, memory-sharing prompt, cwd aligned", () => {
+    // full set defers via tool-search → keeps low context (honours the kill-switch)
+    expect(out).toContain('ENABLE_TOOL_SEARCH="${ENABLE_TOOL_SEARCH:-auto}"');
+    expect(out).toContain("SWITCHROOM_DISABLE_TOOL_SEARCH");
+    // the append-prompt now tells the worker it SHARES memory + tools (not lobotomised)
+    expect(out).toMatch(/SHARE .*memory/);
+    expect(out).not.toMatch(/do not have .* full memory/);
+    // cd into the workspace so claude's project key matches the seeded trust state
+    expect(out).toMatch(/cd ".*" \|\| exit 1/);
   });
 
   it("self-gates on the runtime flag (exit 78, no respawn, only when explicitly disabled)", () => {

--- a/tests/cheap-cron-trim-resources.test.ts
+++ b/tests/cheap-cron-trim-resources.test.ts
@@ -7,39 +7,58 @@ import { describe, expect, it } from "vitest";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { maybeWriteTrimmedCronMcp } from "../src/agents/scaffold.js";
+import { maybeWriteCronMcp } from "../src/agents/scaffold.js";
 import { parseMemToMib, resolveResourceDefaults } from "../src/agents/compose.js";
 
-const tg = { command: "bun", args: ["run", "start"], env: { TELEGRAM_STATE_DIR: "/state" }, alwaysLoad: true } as never;
+const tg = { command: "bun", args: ["run", "start"], env: { TELEGRAM_STATE_DIR: "/state/agents/clerk/telegram" }, alwaysLoad: true } as never;
+const hindsight = { command: "x", env: { HINDSIGHT_BANK_ID: "clerk" }, alwaysLoad: true } as never;
 const full = {
   "switchroom-telegram": tg,
-  hindsight: { command: "x" } as never,
+  hindsight,
   perplexity: { command: "y" } as never,
   "agent-config": { command: "z" } as never,
 };
 
-describe("maybeWriteTrimmedCronMcp", () => {
-  it("writes a switchroom-telegram-ONLY config when cron session enabled", () => {
+describe("maybeWriteCronMcp (Tier-1 un-starve, #2307)", () => {
+  it("writes the FULL MCP set when cron session enabled (shared memory + tools)", () => {
     const dir = mkdtempSync(join(tmpdir(), "cron-mcp-"));
-    const path = maybeWriteTrimmedCronMcp(dir, full, true);
+    const path = maybeWriteCronMcp(dir, full, true);
     expect(path).toBe(join(dir, ".claude-cron", ".mcp.json"));
     const parsed = JSON.parse(readFileSync(path!, "utf-8"));
-    expect(Object.keys(parsed.mcpServers)).toEqual(["switchroom-telegram"]);
-    // the heavy schema servers are gone (the ~31k-token saving)
-    expect(parsed.mcpServers.hindsight).toBeUndefined();
-    expect(parsed.mcpServers["agent-config"]).toBeUndefined();
-    // the bridge entry is reused verbatim (identity comes from process env)
-    expect(parsed.mcpServers["switchroom-telegram"]).toEqual(tg);
+    // the heavy schema servers are PRESENT now (deferred via tool-search), not trimmed
+    expect(Object.keys(parsed.mcpServers).sort()).toEqual(
+      ["agent-config", "hindsight", "perplexity", "switchroom-telegram"],
+    );
+    // hindsight shares the BASE agent's bank (no <name>-cron fragmentation)
+    expect(parsed.mcpServers.hindsight.env.HINDSIGHT_BANK_ID).toBe("clerk");
+    expect(parsed.mcpServers.hindsight.alwaysLoad).toBe(true);
+  });
+
+  it("isolates the cron bridge's liveness file (RISK #2) while sharing STATE_DIR", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cron-mcp-"));
+    const parsed = JSON.parse(readFileSync(maybeWriteCronMcp(dir, full, true)!, "utf-8"));
+    const cronTg = parsed.mcpServers["switchroom-telegram"];
+    // distinct liveness path so a live <name>-cron bridge can't mask main
+    expect(cronTg.env.SWITCHROOM_BRIDGE_ALIVE_PATH).toBe("/state/agents/clerk/telegram/.bridge-alive-cron");
+    // STATE_DIR (access.json / history / gateway.sock) stays SHARED
+    expect(cronTg.env.TELEGRAM_STATE_DIR).toBe("/state/agents/clerk/telegram");
+    expect(cronTg.alwaysLoad).toBe(true);
+  });
+
+  it("does NOT mutate the caller's mcpServers map (the main .mcp.json source)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cron-mcp-"));
+    maybeWriteCronMcp(dir, full, true);
+    expect((full["switchroom-telegram"] as { env: Record<string, string> }).env.SWITCHROOM_BRIDGE_ALIVE_PATH).toBeUndefined();
   });
 
   it("no-op when cron session disabled (the whole fleet today)", () => {
     const dir = mkdtempSync(join(tmpdir(), "cron-mcp-"));
-    expect(maybeWriteTrimmedCronMcp(dir, full, false)).toBeNull();
+    expect(maybeWriteCronMcp(dir, full, false)).toBeNull();
   });
 
   it("no-op when the agent has no switchroom-telegram bridge", () => {
     const dir = mkdtempSync(join(tmpdir(), "cron-mcp-"));
-    expect(maybeWriteTrimmedCronMcp(dir, { hindsight: { command: "x" } as never }, true)).toBeNull();
+    expect(maybeWriteCronMcp(dir, { hindsight: { command: "x" } as never }, true)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

PR 1 of 4 for the **Tier-1 cheap-cron-session un-starve** (#2307). Today the Tier-1 cron session loads a *trimmed* `.mcp.json` (switchroom-telegram only) and its append-prompt tells it *"you do not have the agent's memory or persona"* — so it's lobotomised and can't do real work, defeating the point of routing crons to it. This makes Tier-1 what the issue says it should be: **a fresh, low-context conversation that STILL has the agent's memory + tools, on a cheaper model.** The saving is dropping the accumulated main-session context + the cheaper model — not starving the session.

## What

- **`scaffold.ts`** — `maybeWriteTrimmedCronMcp` → `maybeWriteCronMcp`. Writes the agent's **full filtered MCP set** (the same map as the main `.mcp.json`). Stateful MCPs (hindsight) baked their bank id from the **base** agent name at build time → the cron session shares the **same memory bank**, zero fragmentation (the `<name>-cron` identity only affects the telegram bridge, which reads it from the process env). Never mutates the caller's map. Both scaffold + reconcile call sites updated.
- **Liveness isolation (RISK #2)** — rather than moving the whole `TELEGRAM_STATE_DIR` (which would also move `access.json`/`history` and risk dropping cron replies — the plan's Q2), the cron telegram entry gets a **distinct `SWITCHROOM_BRIDGE_ALIVE_PATH`** (`.bridge-alive-cron`) while `STATE_DIR` + the gateway socket stay **shared**. So a live `<agent>-cron` bridge can't mask a dead main bridge in the dashboard/doctor probe, *and* the cron bridge still authorises replies through the same gateway. `bridge.ts` honours the new env (falls back to `STATE_DIR/.bridge-alive`, unchanged for the main bridge). **This is a deliberate, cleaner deviation from the plan's "move STATE_DIR" approach** — it isolates exactly the masking file and nothing else.
- **`cron-session.sh.hbs`** — `ENABLE_TOOL_SEARCH` on (the full set **defers**, keeping low context; telegram + hindsight stay `alwaysLoad`), honouring the `SWITCHROOM_DISABLE_TOOL_SEARCH` kill-switch; rewrote `CRON_APPEND_PROMPT` (shares memory + tools, *use them* — not "you lack memory"); `cd` into the workspace so claude's project key matches the trust seed (PR2).

## Inert for the fleet

`cronSessionEnabled` is **false fleet-wide** (no agent has a `context:fresh` / frequent-default cron yet — `applyDefaultTier` is still a pass-through until PR4), so `start.sh` and the cron `.mcp.json` are unchanged for every running agent. The boot-wedge seed that makes the cron bridge actually register is **PR2**; observability is **PR3**; re-enabling auto-routing is **PR4** (canary-gated).

## Test plan

- [x] `cheap-cron-trim-resources.test.ts` — `maybeWriteCronMcp` full-set + hindsight-bank-sharing + liveness-isolation (distinct alive path, shared STATE_DIR) + no-caller-mutation + disabled/no-bridge no-ops.
- [x] `cheap-cron-session-render.test.ts` — tool-search export (kill-switch-honoured), memory-sharing prompt, `cd` workspace.
- [x] `bridge-liveness-override.test.ts` — source guard on the `SWITCHROOM_BRIDGE_ALIVE_PATH ?? STATE_DIR/.bridge-alive` line.
- [x] `tsc --noEmit` + `check-plugin-references.mjs` clean; reconcile/scaffold suites green.

## Risk

Low for the fleet (inert — no cron-session agent today). The full-set cron `.mcp.json` only renders for an agent that runs a cron session, which nothing does until PR4. The liveness-path change is backward-compatible (env-gated fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)