### PR TITLE
feat(cron): Tier-1 boot-wedge fix — seed the cron session trust state (#2307 PR2)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -474,6 +474,13 @@ export function maybeWriteCronMcp(
   if (!existsSync(path) || readFileSync(path, "utf-8") !== content) {
     writeFileSync(path, content, { encoding: "utf-8", mode: 0o600 });
   }
+  // #2307 Tier-1: seed .claude-cron/.claude.json with onboarding + trust state
+  // for the FULL cron server set, or the cron `claude` wedges on the first-run
+  // wizard (autoaccept-poll watches only the MAIN tmux session) and the
+  // <agent>-cron bridge never registers. Idempotent; runs on both scaffold and
+  // reconcile so the in-container reconcile writes the container-path project
+  // key that matches the cron claude's cwd.
+  seedCronConfigDir(agentDir, Object.keys(cronServers));
   return path;
 }
 import {
@@ -518,6 +525,7 @@ import {
   preTrustWorkspace,
   ensureMcpServersTrusted,
   createMinimalClaudeConfig,
+  seedCronConfigDir,
   loadUserConfig,
 } from "../setup/onboarding.js";
 import { ensureBareClone } from "../repos/bare-clone.js";

--- a/src/setup/onboarding.ts
+++ b/src/setup/onboarding.ts
@@ -53,8 +53,13 @@ export function findExistingClaudeJson(): string | null {
 export function copyOnboardingState(
   sourcePath: string,
   agentDir: string,
+  // #2307 Tier-1: the Tier-1 cron session has its OWN CLAUDE_CONFIG_DIR
+  // (.claude-cron) that needs the same onboarding/trust seed as the main
+  // .claude dir, or its `claude` wedges on the first-run wizard and the
+  // <agent>-cron bridge never registers. Defaults to ".claude" (main session).
+  configDirName = ".claude",
 ): void {
-  const claudeDir = join(agentDir, ".claude");
+  const claudeDir = join(agentDir, configDirName);
   mkdirSync(claudeDir, { recursive: true });
 
   // Claude Code reads onboarding state from .claude.json (with leading dot)
@@ -241,8 +246,8 @@ export function loadUserConfig(): UserConfig | null {
  * Add the agent's working directory to the projects map in .claude.json
  * with hasTrustDialogAccepted: true, so the agent doesn't prompt for trust.
  */
-export function preTrustWorkspace(agentDir: string): void {
-  const configPath = join(agentDir, ".claude", ".claude.json");
+export function preTrustWorkspace(agentDir: string, configDirName = ".claude"): void {
+  const configPath = join(agentDir, configDirName, ".claude.json");
 
   if (!existsSync(configPath)) {
     return;
@@ -293,8 +298,9 @@ export function preTrustWorkspace(agentDir: string): void {
 export function ensureMcpServersTrusted(
   agentDir: string,
   serverKeys: string[],
+  configDirName = ".claude",
 ): void {
-  const configPath = join(agentDir, ".claude", ".claude.json");
+  const configPath = join(agentDir, configDirName, ".claude.json");
 
   if (!existsSync(configPath)) {
     return;
@@ -359,8 +365,8 @@ export function ensureMcpServersTrusted(
  * forever even though the broker has already logged it in. This
  * matches `src/agents/scaffold.ts`'s writer (`true`, numStartups 1).
  */
-export function createMinimalClaudeConfig(agentDir: string): void {
-  const claudeDir = join(agentDir, ".claude");
+export function createMinimalClaudeConfig(agentDir: string, configDirName = ".claude"): void {
+  const claudeDir = join(agentDir, configDirName);
   mkdirSync(claudeDir, { recursive: true });
 
   const configPath = join(claudeDir, ".claude.json");
@@ -374,4 +380,22 @@ export function createMinimalClaudeConfig(agentDir: string): void {
       mode: 0o600,
     });
   }
+}
+
+/**
+ * #2307 Tier-1: seed the cron session's CLAUDE_CONFIG_DIR (.claude-cron) with
+ * the same onboarding + trust state the main .claude dir gets, so the cron
+ * `claude` doesn't wedge on the first-run wizard / trust gate (the
+ * autoaccept-poll sidecar watches only the MAIN tmux session, so nothing
+ * dismisses a cron-session wizard). Idempotent: createMinimalClaudeConfig
+ * early-returns if the file exists, preTrust/ensureMcpServersTrusted
+ * read-modify-write. Runs on BOTH the scaffold and reconcile paths (so the
+ * in-container reconcile writes the in-container project key that matches the
+ * cron claude's cwd). `serverKeys` MUST be the full cron .mcp.json key set or
+ * Claude Code silently ignores those servers.
+ */
+export function seedCronConfigDir(agentDir: string, serverKeys: string[]): void {
+  createMinimalClaudeConfig(agentDir, ".claude-cron");
+  preTrustWorkspace(agentDir, ".claude-cron");
+  ensureMcpServersTrusted(agentDir, serverKeys, ".claude-cron");
 }

--- a/src/setup/seed-cron-config-dir.test.ts
+++ b/src/setup/seed-cron-config-dir.test.ts
@@ -1,0 +1,85 @@
+/**
+ * #2307 Tier-1 — seedCronConfigDir: the cron session's CLAUDE_CONFIG_DIR
+ * (.claude-cron) needs the same onboarding + trust seed as the main .claude
+ * dir, or the cron `claude` wedges on the first-run wizard / trust gate and the
+ * <agent>-cron bridge never registers. These pin that the seed lands in
+ * .claude-cron (NOT .claude), with hasCompletedOnboarding + the trusted project
+ * + the FULL cron server key set, and that the main .claude dir is untouched.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  seedCronConfigDir,
+  createMinimalClaudeConfig,
+  preTrustWorkspace,
+  ensureMcpServersTrusted,
+} from "./onboarding.js";
+
+let agentDir: string;
+beforeEach(() => {
+  agentDir = mkdtempSync(join(tmpdir(), "switchroom-cron-seed-"));
+});
+afterEach(() => {
+  rmSync(agentDir, { recursive: true, force: true });
+});
+
+function readCron(): {
+  hasCompletedOnboarding?: boolean;
+  numStartups?: number;
+  projects?: Record<string, { hasTrustDialogAccepted?: boolean; enabledMcpjsonServers?: string[] }>;
+} {
+  return JSON.parse(readFileSync(join(agentDir, ".claude-cron", ".claude.json"), "utf-8"));
+}
+
+describe("seedCronConfigDir (#2307 Tier-1)", () => {
+  const keys = ["switchroom-telegram", "hindsight", "agent-config", "perplexity"];
+
+  it("writes .claude-cron/.claude.json with onboarding + trusted project + full server set", () => {
+    seedCronConfigDir(agentDir, keys);
+    const cron = readCron();
+    expect(cron.hasCompletedOnboarding).toBe(true);
+    const project = cron.projects![resolve(agentDir)];
+    expect(project.hasTrustDialogAccepted).toBe(true);
+    expect((project.enabledMcpjsonServers ?? []).sort()).toEqual([...keys].sort());
+  });
+
+  it("does NOT touch the main .claude dir", () => {
+    seedCronConfigDir(agentDir, keys);
+    expect(existsSync(join(agentDir, ".claude", ".claude.json"))).toBe(false);
+  });
+
+  it("is idempotent — re-seeding unions new server keys, preserves onboarding", () => {
+    seedCronConfigDir(agentDir, ["switchroom-telegram"]);
+    seedCronConfigDir(agentDir, ["switchroom-telegram", "notion"]);
+    const cron = readCron();
+    expect(cron.hasCompletedOnboarding).toBe(true);
+    expect((cron.projects![resolve(agentDir)].enabledMcpjsonServers ?? []).sort()).toEqual([
+      "notion",
+      "switchroom-telegram",
+    ]);
+  });
+});
+
+describe("onboarding helpers — configDirName param threads to .claude-cron", () => {
+  it("createMinimalClaudeConfig honours configDirName", () => {
+    createMinimalClaudeConfig(agentDir, ".claude-cron");
+    expect(existsSync(join(agentDir, ".claude-cron", ".claude.json"))).toBe(true);
+    expect(existsSync(join(agentDir, ".claude", ".claude.json"))).toBe(false);
+  });
+
+  it("preTrustWorkspace + ensureMcpServersTrusted target the cron dir, keying off resolve(agentDir)", () => {
+    createMinimalClaudeConfig(agentDir, ".claude-cron");
+    preTrustWorkspace(agentDir, ".claude-cron");
+    ensureMcpServersTrusted(agentDir, ["hindsight"], ".claude-cron");
+    const cron = JSON.parse(readFileSync(join(agentDir, ".claude-cron", ".claude.json"), "utf-8"));
+    // project key is the WORKSPACE dir (claude's cwd), not the config dir
+    expect(cron.projects[resolve(agentDir)].enabledMcpjsonServers).toEqual(["hindsight"]);
+  });
+
+  it("default configDirName stays .claude (main session, unchanged)", () => {
+    createMinimalClaudeConfig(agentDir);
+    expect(existsSync(join(agentDir, ".claude", ".claude.json"))).toBe(true);
+  });
+});

--- a/tests/cheap-cron-trim-resources.test.ts
+++ b/tests/cheap-cron-trim-resources.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it } from "vitest";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { maybeWriteCronMcp } from "../src/agents/scaffold.js";
 import { parseMemToMib, resolveResourceDefaults } from "../src/agents/compose.js";
 
@@ -49,6 +49,18 @@ describe("maybeWriteCronMcp (Tier-1 un-starve, #2307)", () => {
     const dir = mkdtempSync(join(tmpdir(), "cron-mcp-"));
     maybeWriteCronMcp(dir, full, true);
     expect((full["switchroom-telegram"] as { env: Record<string, string> }).env.SWITCHROOM_BRIDGE_ALIVE_PATH).toBeUndefined();
+  });
+
+  it("seeds .claude-cron/.claude.json trust state (PR2 boot-wedge) with the full key set", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cron-mcp-"));
+    maybeWriteCronMcp(dir, full, true);
+    const seed = JSON.parse(readFileSync(join(dir, ".claude-cron", ".claude.json"), "utf-8"));
+    expect(seed.hasCompletedOnboarding).toBe(true);
+    const project = seed.projects[resolve(dir)];
+    expect(project.hasTrustDialogAccepted).toBe(true);
+    expect((project.enabledMcpjsonServers as string[]).sort()).toEqual(
+      ["agent-config", "hindsight", "perplexity", "switchroom-telegram"],
+    );
   });
 
   it("no-op when cron session disabled (the whole fleet today)", () => {


### PR DESCRIPTION
## Summary

PR 2 of 4 for the Tier-1 un-starve (#2307). **This is the PR that makes the cron session bridge actually register.**

The Tier-1 cron session runs `claude` against an **unseeded** `CLAUDE_CONFIG_DIR=.claude-cron` — no `.claude.json` — so it wedges on the first-run onboarding wizard / trust gate, and nothing dismisses it (the `autoaccept-poll` sidecar watches only the **main** tmux session, never `switchroom-<name>-cron`). Result: the `<agent>-cron` bridge never registers → 100% fallback to the main session, saving nothing. This is the integration debt that kept Tier-1 from ever running in production.

## Fix (B1 — param-thread the shared helpers, the operator's chosen approach)

- Add an optional `configDirName = ".claude"` to `createMinimalClaudeConfig` / `preTrustWorkspace` / `ensureMcpServersTrusted` (`onboarding.ts`).
- New `seedCronConfigDir(agentDir, serverKeys)` points them at `.claude-cron`: writes `hasCompletedOnboarding: true` + the trusted project (keyed off `resolve(agentDir)` = the cron claude's **cwd**, set by PR1's `cd "{{agentDir}}"`, NOT the config dir) + `enabledMcpjsonServers` for the **full** cron server set (or Claude Code silently ignores them — the exact failure `ensureMcpServersTrusted` already guards for the main session).
- Wired **inside `maybeWriteCronMcp`** (`scaffold.ts`), so it runs on **both** the scaffold and reconcile paths — the in-container reconcile writes the **container-path** project key that matches the cron claude's cwd (the same host-vs-container path discipline the main session already relies on, #1892).

The default `.claude` argument keeps every existing caller **byte-identical** — the proven main-session boot path is untouched.

## Test plan

- [x] `seed-cron-config-dir.test.ts` — writes `.claude-cron` (not `.claude`); onboarding + trusted project (keyed `resolve(agentDir)`) + full key set; idempotent union; main `.claude` dir untouched; the `configDirName` param threads on each helper; default stays `.claude`.
- [x] `cheap-cron-trim-resources.test.ts` — `maybeWriteCronMcp` now also seeds the trust state with the full key set.
- [x] `ensure-mcp-trusted.test.ts` + `scaffold.fresh-agent-mcp-trust.test.ts` (main-path regression) green.
- [x] `tsc --noEmit` clean.

## Risk

Low for the fleet (still inert — `cronSessionEnabled` false until PR4). The param-threaded helpers default to `.claude`, so the main boot path is unchanged. The new seed only writes `.claude-cron` for agents that run a cron session (none today).

## Milestone

With **PR1 + PR2**, a cron-session agent's `<agent>-cron` bridge now **registers instead of wedging** — the canary-provable result (boot the agent, assert the cron `.bridge-alive-cron` goes fresh, no wizard wedge). Observability (PR3) makes a wedge *visible*; re-enabling auto-routing (PR4) flips it on fleet-wide, canary-gated.

## Open items for the combined canary (flagged, not blocking the merge)

- **Q2** (cron reply auth): resolved by PR1's design — STATE_DIR stays shared, so the cron bridge uses the same `access.json`/gateway as main. To confirm live.
- **Q3** (vault-backed MCPs resolving secrets in the cron session): the full set loads under tool-search; a vault-MCP call that can't resolve its secret fails gracefully. To confirm live on the canary; restrict the cron set if it's a problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)