### PR TITLE
feat(cron): Tier-1 observability — doctor check + fallback metric (#2307 PR3)

### DIFF
--- a/src/cli/doctor-cron-session.test.ts
+++ b/src/cli/doctor-cron-session.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #2307 Tier-1 — runCronSessionChecks doctor probe. Pins: a cron-session agent
+ * with a fresh cron bridge → ok; stale → fail; never-registered (ENOENT) →
+ * fail; unreadable (EACCES) → skip; a non-cron agent → no result.
+ */
+import { describe, it, expect } from "vitest";
+import type { SwitchroomConfig } from "../config/schema.js";
+import { runCronSessionChecks, type CronSessionProbeDeps } from "./doctor-cron-session.js";
+
+function configWith(agents: SwitchroomConfig["agents"]): SwitchroomConfig {
+  return {
+    switchroom: { version: 1, agents_dir: "/agents", skills_dir: "/skills" },
+    telegram: { bot_token: "x", forum_chat_id: "-1001234567890" },
+    vault: { path: "/v.enc" },
+    defaults: {},
+    agents,
+  } as unknown as SwitchroomConfig;
+}
+
+// An agent whose schedule routes to a cron session (context: fresh ⟹ Tier 1).
+const cronAgent = { topic_name: "C", schedule: [{ cron: "*/10 * * * *", prompt: "p", context: "fresh" }] };
+// An agent with only a normal prompt cron → no cron session.
+const plainAgent = { topic_name: "P", schedule: [{ cron: "0 9 * * *", prompt: "p" }] };
+
+const NOW = 1_000_000;
+function deps(over: Partial<CronSessionProbeDeps>): CronSessionProbeDeps {
+  return { now: () => NOW, statMtimeMs: () => NOW, ...over };
+}
+
+describe("runCronSessionChecks (#2307 Tier-1)", () => {
+  it("fresh cron bridge → ok", () => {
+    const r = runCronSessionChecks(configWith({ clerk: cronAgent } as never), deps({ statMtimeMs: () => NOW - 5_000 }));
+    expect(r).toHaveLength(1);
+    expect(r[0]).toMatchObject({ name: "cron-session: clerk", status: "ok" });
+  });
+
+  it("stale heartbeat → fail (session registered then died)", () => {
+    const r = runCronSessionChecks(configWith({ clerk: cronAgent } as never), deps({ statMtimeMs: () => NOW - 120_000 }));
+    expect(r[0]).toMatchObject({ name: "cron-session: clerk", status: "fail" });
+    expect(r[0].detail).toMatch(/stale/);
+  });
+
+  it("never registered (ENOENT) → fail (wedged boot)", () => {
+    const r = runCronSessionChecks(
+      configWith({ clerk: cronAgent } as never),
+      deps({ statMtimeMs: () => { const e = new Error("nope") as NodeJS.ErrnoException; e.code = "ENOENT"; throw e; } }),
+    );
+    expect(r[0]).toMatchObject({ name: "cron-session: clerk", status: "fail" });
+    expect(r[0].detail).toMatch(/not registered/);
+    expect(r[0].fix).toMatch(/agent restart/);
+  });
+
+  it("unreadable (EACCES from the host operator) → skip, never fail", () => {
+    const r = runCronSessionChecks(
+      configWith({ clerk: cronAgent } as never),
+      deps({ statMtimeMs: () => { const e = new Error("denied") as NodeJS.ErrnoException; e.code = "EACCES"; throw e; } }),
+    );
+    expect(r[0]).toMatchObject({ name: "cron-session: clerk", status: "skip" });
+  });
+
+  it("a non-cron agent produces NO result (the fleet today)", () => {
+    const r = runCronSessionChecks(configWith({ plain: plainAgent } as never), deps({}));
+    expect(r).toHaveLength(0);
+  });
+
+  it("mixed fleet → only the cron agent is checked", () => {
+    const r = runCronSessionChecks(
+      configWith({ clerk: cronAgent, plain: plainAgent } as never),
+      deps({ statMtimeMs: () => NOW - 1_000 }),
+    );
+    expect(r.map((x) => x.name)).toEqual(["cron-session: clerk"]);
+  });
+});

--- a/src/cli/doctor-cron-session.ts
+++ b/src/cli/doctor-cron-session.ts
@@ -1,0 +1,124 @@
+/**
+ * Tier-1 cron-session bridge doctor check (#2307).
+ *
+ * The Tier-1 cheap-cron session forks a SECOND `claude` (`<agent>-cron` bridge)
+ * at agent boot — there is no lazy respawn. If that session wedges (an unseeded
+ * config dir, a crash) the `<agent>-cron` bridge never registers and every
+ * Tier-1 cron fire silently falls back to the (expensive) main session, saving
+ * nothing. The boot wedge is invisible: the only symptom is a cost that never
+ * drops.
+ *
+ * This probe makes it visible. For every agent the value-gate routes to a cron
+ * session (`cronSessionEnabled`), it asserts the cron bridge's liveness file
+ * (`telegram/.bridge-alive-cron`, written by the cron bridge with
+ * SWITCHROOM_BRIDGE_ALIVE_PATH — distinct from the main bridge's `.bridge-alive`
+ * so neither masks the other) is fresh:
+ *   - fresh   → ok
+ *   - stale/absent while cronSessionEnabled → FAIL (the session is wedged/down)
+ *   - the file is agent-UID-owned 0600; an EACCES from the host operator reads
+ *     as `skip`, never `fail` (mirrors the webkite/drive probes).
+ * Agents with no cron session produce no result (the fleet-wide case today).
+ *
+ * Filesystem access is dependency-injected so unit tests drive every branch
+ * without a real scaffold tree.
+ */
+
+import { statSync as realStatSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import { resolveAgentsDir } from "../config/loader.js";
+import { resolveAgentConfig } from "../config/merge.js";
+import { scheduleNeedsCronSession } from "../scheduler/cron-routing.js";
+import { applyDefaultTier } from "../scheduler/tier-selector.js";
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+export interface CronSessionProbeDeps {
+  /** stat seam — returns mtimeMs, or throws (ENOENT / EACCES). */
+  statMtimeMs: (path: string) => number;
+  now: () => number;
+}
+
+const defaultDeps: CronSessionProbeDeps = {
+  statMtimeMs: (p) => realStatSync(p).mtimeMs,
+  now: () => Date.now(),
+};
+
+/**
+ * Whether the value-gate routes any of this agent's schedule entries to a cron
+ * session — the same computation `buildCronSessionContext` does in scaffold.ts
+ * (applyDefaultTier → scheduleNeedsCronSession). Cheap-cron is treated as on
+ * (the default); the cron session only actually runs when it's enabled at
+ * runtime, but the scaffold renders the fork whenever the schedule routes to it.
+ */
+function agentRunsCronSession(config: SwitchroomConfig, agent: string): boolean {
+  const raw = config.agents[agent];
+  if (!raw) return false;
+  const resolved = resolveAgentConfig(config.defaults, config.profiles, raw);
+  const entries = (resolved.schedule ?? []).map((e) =>
+    applyDefaultTier({ cron: e.cron, kind: e.kind, model: e.model, context: e.context }),
+  );
+  return scheduleNeedsCronSession(entries, { cheapCronEnabled: true });
+}
+
+const MAX_AGE_MS = 30_000;
+
+export function runCronSessionChecks(
+  config: SwitchroomConfig,
+  deps: CronSessionProbeDeps = defaultDeps,
+): CheckResult[] {
+  const agentsDir = resolveAgentsDir(config);
+  const results: CheckResult[] = [];
+
+  for (const agent of Object.keys(config.agents).sort()) {
+    if (!agentRunsCronSession(config, agent)) continue; // no cron session → nothing to check
+
+    const name = `cron-session: ${agent}`;
+    const alivePath = resolve(agentsDir, agent, "telegram", ".bridge-alive-cron");
+    let mtimeMs: number;
+    try {
+      mtimeMs = deps.statMtimeMs(alivePath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EACCES" || code === "EPERM") {
+        results.push({
+          name,
+          status: "skip",
+          detail: "cron-bridge liveness file present but unreadable by the operator — re-run doctor without sudo",
+        });
+        continue;
+      }
+      // ENOENT (or anything else): the cron bridge has never written its
+      // liveness file → it never registered. With a cron session expected,
+      // that's a wedged boot.
+      results.push({
+        name,
+        status: "fail",
+        detail: `<${agent}-cron> bridge not registered — no liveness file at ${alivePath}. Tier-1 cron fires are falling back to the (expensive) main session.`,
+        fix: `Restart the agent (\`switchroom agent restart ${agent} --wait --force\`) and check /var/log/switchroom/cron-session.log for a wizard wedge.`,
+      });
+      continue;
+    }
+
+    const ageMs = deps.now() - mtimeMs;
+    if (ageMs <= MAX_AGE_MS) {
+      results.push({ name, status: "ok", detail: `<${agent}-cron> bridge live (heartbeat ${Math.round(ageMs / 1000)}s ago)` });
+    } else {
+      results.push({
+        name,
+        status: "fail",
+        detail: `<${agent}-cron> bridge heartbeat is stale (${Math.round(ageMs / 1000)}s > ${MAX_AGE_MS / 1000}s) — the cron session registered then died. Tier-1 fires are falling back to main.`,
+        fix: `Restart the agent (\`switchroom agent restart ${agent} --wait --force\`) and check /var/log/switchroom/cron-session.log.`,
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -35,6 +35,7 @@ import { runAuthBrokerChecks } from "./doctor-auth-broker.js";
 import { runHostdChecks } from "./doctor-hostd.js";
 import { runDriveChecks, runDriveBrokerReachabilityChecks } from "./doctor-drive.js";
 import { runWebkiteChecks } from "./doctor-webkite.js";
+import { runCronSessionChecks } from "./doctor-cron-session.js";
 import { runMicrosoftChecks } from "./doctor-microsoft.js";
 import { runNotionChecks } from "./doctor-notion.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
@@ -2774,6 +2775,10 @@ export function registerDoctorCommand(program: Command): void {
           },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath, config) },
           { title: "Webkite", results: runWebkiteChecks(config) },
+          // #2307 Tier-1: cron-session bridge liveness. Empty (no results) for
+          // the fleet today — only agents the value-gate routes to a cron
+          // session produce a line.
+          { title: "Cron Session", results: runCronSessionChecks(config) },
         ];
 
         // Repo Hygiene (#1072): only when doctor runs from a switchroom

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6547,6 +6547,10 @@ const ipcServer: IpcServer = createIpcServer({
       process.stderr.write(
         `telegram gateway: cron fire fell back to main session (no cron bridge) agent=${msg.agentName} prompt_key=${promptKey}\n`,
       )
+      // #2307 Tier-1 observability: a climbing counter means the cron session is
+      // down (registered then died, or never came up) — the Tier-1 saving is
+      // lost for this fire. Surfaced via the unified runtime-metrics fan-out.
+      emitRuntimeMetric({ kind: 'cron_fell_back_to_main', agent: msg.agentName, prompt_key: promptKey })
     }
     // Status-silent (§2.4): a cron fire delivered to the CRON session must NOT
     // set the MAIN agent's currentTurn. But a fire that LANDED on the main

--- a/telegram-plugin/runtime-metrics.ts
+++ b/telegram-plugin/runtime-metrics.ts
@@ -137,6 +137,20 @@ export type RuntimeMetricEvent =
       // executeReply scrub site. The two new sites close that gap.
       site: 'reply' | 'edit_message' | 'progress_update' | 'answer_stream' | 'stream_reply' | 'turn_flush'
     }
+  /**
+   * #2307 Tier-1: a cron fire routed to the `<agent>-cron` cheap session
+   * (meta.session=cron) fell back to the MAIN session because the cron bridge
+   * wasn't registered (wedged boot, crashed session, or hot-added cron with no
+   * live session yet). Each occurrence means the Tier-1 saving was NOT realised
+   * for that fire — a climbing counter is the runtime signal that a cron
+   * session is down (the doctor check catches a permanently-wedged one at boot;
+   * this catches a session that registered then died).
+   */
+  | {
+      kind: 'cron_fell_back_to_main'
+      agent: string
+      prompt_key: string
+    }
 
 /**
  * The JSONL sink lives under the runtime state dir so it's per-agent

--- a/telegram-plugin/tests/runtime-metrics.test.ts
+++ b/telegram-plugin/tests/runtime-metrics.test.ts
@@ -82,6 +82,15 @@ describe('runtime-metrics — JSONL sink', () => {
     expect(parsed.ended_via).toBe('reply')
   })
 
+  it('cron_fell_back_to_main carries agent + prompt_key (#2307 Tier-1)', () => {
+    emitRuntimeMetric({ kind: 'cron_fell_back_to_main', agent: 'clerk', prompt_key: 'abc123' })
+    const parsed = JSON.parse(readFileSync(metricsPath, 'utf-8').trim())
+    expect(parsed.kind).toBe('cron_fell_back_to_main')
+    expect(parsed.agent).toBe('clerk')
+    expect(parsed.prompt_key).toBe('abc123')
+    expect(typeof parsed.ts).toBe('number')
+  })
+
   it('appends — does not overwrite — across calls', () => {
     for (let i = 0; i < 5; i++) {
       emitRuntimeMetric({


### PR DESCRIPTION
## Summary

PR 3 of 4 for the Tier-1 un-starve (#2307). The Tier-1 cron session is **boot-forked only** (no lazy respawn), so a wedged or crashed `<agent>-cron` bridge is **invisible**: every cron fire silently falls back to the (expensive) main session and the only symptom is a cost that never drops. Two signals make it visible.

## What

- **doctor check** (`src/cli/doctor-cron-session.ts`, `runCronSessionChecks`) — for every agent the value-gate routes to a cron session (`cronSessionEnabled`, recomputed via `applyDefaultTier` + `scheduleNeedsCronSession`, mirroring `buildCronSessionContext`), asserts the cron bridge's liveness file (`telegram/.bridge-alive-cron`, PR1's isolated path) is fresh:
  - fresh → **ok**
  - stale / never-registered (ENOENT) → **fail** (the session is down/wedged, with a `switchroom agent restart` fix hint)
  - EACCES from the host operator → **skip** (the file is agent-UID-owned 0600 — mirrors the webkite/drive probes; never a false fail)
  - an agent with no cron session → **no result** (the "Cron Session" doctor section is empty for the whole fleet today). Catches a permanently-wedged boot.
- **runtime metric** — the existing gateway `cron fire fell back to main (no cron bridge)` log now also emits a `cron_fell_back_to_main{agent, prompt_key}` event through the runtime-metrics fan-out (JSONL + PostHog). A **climbing counter** = a cron session that registered then died — the failure mode the boot-time doctor check can't catch.

## Test plan

- [x] `doctor-cron-session.test.ts` — ok / stale-fail / ENOENT-fail / EACCES-skip / non-cron-no-result / mixed-fleet.
- [x] `runtime-metrics.test.ts` — the new `cron_fell_back_to_main` event shape (agent + prompt_key + ts).
- [x] `tsc --noEmit` + `check-plugin-references.mjs` + `check-bot-api-wrapping.sh` clean; `doctor-status` green.

## Risk

Low. Inert for the fleet (the doctor section is empty — no cron-session agent until PR4; the metric only fires on a fallback that doesn't happen today). No existing doctor check or gateway path changes behaviour.

## Why it matters for PR4

PR4 re-enables auto-routing (canary-gated). This observability is what *proves* a canary cron actually runs in the cron session **without** falling back — and what would catch a regression after fleet rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)