### PR TITLE
feat(cron): Tier-1 — re-enable cadence auto-routing (default-off flag) (#2307 PR4)

### DIFF
--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -236,6 +236,8 @@ Because each fire is a full turn in the live session by default, a frequent cron
 
 Agents can self-author the `model`/`context` hints (no security gate). `kind: poll`, `kind: action`, and `reaction_dispatch` need an operator config commit (egress / identity gates), so an agent should *request* them. With the flag off, all hints are inert — every fire is a normal Tier-2 turn (a `kind: poll` entry fires its escalation prompt directly); disabling cheap-cron can never silently drop a cron. **A `kind: action` is the exception: it is model-free regardless of the flag** — the kill-switch governs model tiering, and an action has no model fire to fall back to.
 
+**Automatic Tier-1 routing (`SWITCHROOM_CRON_AUTO_TIER`, default off, #2307).** With this flag enabled, a **hint-less** cron whose cadence is **frequent** (≤ 60 min, tunable via `SWITCHROOM_CRON_FREQUENT_GAP_MIN`) is auto-routed to the cheap Tier-1 session — you no longer have to set `context: fresh` by hand for routine checks. Daily/weekly crons, and any cron whose cadence can't be read, stay on the full session; explicit `kind`/`context`/`model` hints always win. It is **default-off** because it flips routing for every frequent cron on the next `apply` (high blast radius) — enable it only after confirming the cron session is healthy for the agent (`switchroom doctor` → the *Cron Session* section, and the `cron_fell_back_to_main` metric stays flat). Graceful fallback means even a misconfigured flag never drops a cron — a fire with no cron bridge just runs on the main session.
+
 #### `kind: action` — model-free mechanical verbs (#2307)
 
 An action *replaces* a model turn with a deterministic verb. Two types (operator-config only — an agent cannot self-author one):

--- a/src/scheduler/tier-selector.test.ts
+++ b/src/scheduler/tier-selector.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from "vitest";
 import {
   recommendCronTier,
   resolveFrequentGapMin,
+  resolveCronAutoTier,
   applyDefaultTier,
   DEFAULT_FREQUENT_GAP_MIN,
   type TierRecommendation,
@@ -125,33 +126,78 @@ describe("resolveFrequentGapMin", () => {
   });
 });
 
-describe("applyDefaultTier — tool-aware: cadence is advisory, never FORCES Tier-1", () => {
-  // Holistic-trace finding: the Tier-1 cheap session is tool/memory-starved,
-  // so forcing a hint-less cron into it on cadence alone is unsafe (a
-  // tool-using cron would run starved and fail, uncaught by the bridge-down
-  // fallback). Tier-1 is now OPT-IN. applyDefaultTier passes through; the
-  // cadence recommendation lives in recommendCronTier for shadow/guidance.
+describe("applyDefaultTier — DEFAULT-OFF: pass-through (flag unset, today's fleet)", () => {
+  // #2307 PR4: the cadence auto-router is re-enabled but ships default-off
+  // behind SWITCHROOM_CRON_AUTO_TIER. With the flag unset (autoTierEnabled
+  // defaulting false via the explicit arg below), applyDefaultTier is the
+  // #2305 pass-through — inert for the fleet until a canary flips the flag.
+  const off = (e: TierableEntry) => applyDefaultTier(e, DEFAULT_FREQUENT_GAP_MIN, false);
 
-  it("a frequent hint-less cron is NOT auto-routed to cheap (no context injected)", () => {
-    expect(applyDefaultTier(tierable({ cron: "*/30 * * * *" })).context).toBeUndefined();
-    expect(applyDefaultTier(tierable({ cron: "0 * * * *" })).context).toBeUndefined(); // hourly
-    expect(applyDefaultTier(tierable({ cron: "*/5 * * * *" })).context).toBeUndefined();
-  });
-
-  it("explicit opt-in hints are preserved unchanged (the author's tool-aware signal)", () => {
-    expect(applyDefaultTier(tierable({ cron: "*/5 * * * *", context: "fresh" })).context).toBe("fresh");
-    expect(applyDefaultTier(tierable({ cron: "0 8 * * *", model: "sonnet" })).model).toBe("sonnet");
-    expect(applyDefaultTier(tierable({ cron: "*/5 * * * *", context: "agent" })).context).toBe("agent");
-    expect(applyDefaultTier(tierable({ cron: "*/5 * * * *", kind: "poll" })).kind).toBe("poll");
+  it("a frequent hint-less cron is NOT auto-routed to cheap (flag off)", () => {
+    expect(off(tierable({ cron: "*/30 * * * *" })).context).toBeUndefined();
+    expect(off(tierable({ cron: "0 * * * *" })).context).toBeUndefined(); // hourly
+    expect(off(tierable({ cron: "*/5 * * * *" })).context).toBeUndefined();
   });
 
   it("is a pure pass-through — nothing injected", () => {
-    const out = applyDefaultTier(tierable({ cron: "*/30 * * * *", kind: "prompt" }));
+    const out = off(tierable({ cron: "*/30 * * * *", kind: "prompt" }));
     expect(out).toEqual({ cron: "*/30 * * * *", kind: "prompt" });
   });
 
   it("recommendCronTier still surfaces the advisory (recommender intact)", () => {
-    // Only the enforcing applyDefaultTier changed; the recommendation stays.
     expect(recommendCronTier({ smallestGapMin: 30 }).tier).toBe("cheap");
+  });
+});
+
+describe("applyDefaultTier — flag ON: cadence re-enabled (#2307 PR4)", () => {
+  // The cron session is capability-complete (PRs 1–3), so cadence is a sound
+  // automatic signal again. autoTierEnabled passed true explicitly (the canary
+  // sets SWITCHROOM_CRON_AUTO_TIER=1).
+  const on = (e: TierableEntry) => applyDefaultTier(e, DEFAULT_FREQUENT_GAP_MIN, true);
+
+  it("a frequent hint-less cron gets context:fresh injected (→ cheap Tier-1)", () => {
+    expect(on(tierable({ cron: "*/30 * * * *" })).context).toBe("fresh");
+    expect(on(tierable({ cron: "0 * * * *" })).context).toBe("fresh"); // hourly == 60min == frequent
+    expect(on(tierable({ cron: "*/5 * * * *" })).context).toBe("fresh");
+  });
+
+  it("daily / weekly stay on the main session (infrequent → no injection)", () => {
+    expect(on(tierable({ cron: "0 8 * * *" })).context).toBeUndefined(); // daily
+    expect(on(tierable({ cron: "0 9 * * 1" })).context).toBeUndefined(); // weekly
+  });
+
+  it("an UNREADABLE cadence stays full (Infinity → main, never a starved guess)", () => {
+    expect(on(tierable({ cron: "bogus" })).context).toBeUndefined();
+    expect(on(tierable({ cron: "15-30 * * * *" })).context).toBeUndefined(); // minute range → unknown
+  });
+
+  it("explicit author hints are honoured untouched (kind / context / model win)", () => {
+    expect(on(tierable({ cron: "*/5 * * * *", context: "agent" })).context).toBe("agent");
+    expect(on(tierable({ cron: "*/5 * * * *", context: "fresh" })).context).toBe("fresh");
+    expect(on(tierable({ cron: "*/5 * * * *", model: "opus" })).context).toBeUndefined(); // explicit model → no inject
+    expect(on(tierable({ cron: "*/5 * * * *", kind: "poll" })).context).toBeUndefined();
+    expect(on(tierable({ cron: "*/5 * * * *", kind: "action" })).context).toBeUndefined();
+  });
+
+  it("respects a custom frequent-gap threshold", () => {
+    // gap 30min with a 15min threshold → not frequent → main.
+    expect(applyDefaultTier(tierable({ cron: "*/30 * * * *" }), 15, true).context).toBeUndefined();
+  });
+});
+
+describe("resolveCronAutoTier — default OFF; only 1/true/on enables", () => {
+  it.each([
+    ["1", true],
+    ["true", true],
+    ["on", true],
+    ["ON", true],
+    ["", false],
+    [undefined, false],
+    ["0", false],
+    ["false", false],
+    ["off", false],
+    ["yes", false], // only the three canonical truthy values
+  ])("SWITCHROOM_CRON_AUTO_TIER=%s → %s", (val, expected) => {
+    expect(resolveCronAutoTier({ SWITCHROOM_CRON_AUTO_TIER: val } as NodeJS.ProcessEnv)).toBe(expected);
   });
 });

--- a/src/scheduler/tier-selector.ts
+++ b/src/scheduler/tier-selector.ts
@@ -35,6 +35,7 @@
  */
 
 import { isKnownCheapModel, type CronTier } from "./cron-routing.js";
+import { estimateCronGapMin } from "./cron-cadence.js";
 
 export type TierSource = "explicit" | "cadence-default";
 
@@ -68,6 +69,27 @@ export const DEFAULT_FREQUENT_GAP_MIN = 60;
 export function resolveFrequentGapMin(env: NodeJS.ProcessEnv = process.env): number {
   const raw = Number.parseInt(env.SWITCHROOM_CRON_FREQUENT_GAP_MIN ?? "", 10);
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_FREQUENT_GAP_MIN;
+}
+
+/**
+ * Whether the cadence-default AUTO-ROUTER is enabled (#2307 Tier-1).
+ *
+ * Re-enabling cadence-driven Tier-1 routing is only safe now that the cron
+ * session is capability-complete (full MCP + shared memory + a non-wedging
+ * boot — PRs 1–3). But it is a high-blast-radius flip (it routes every
+ * frequent hint-less cron into the cheap session on the next `apply`), so it
+ * ships DEFAULT-OFF behind this flag and is proven on a test-harness canary
+ * before the default is reconsidered. OFF ⟹ `applyDefaultTier` is the #2305
+ * pass-through (today's behaviour). Only `1`/`true`/`on` enables it.
+ *
+ * NOTE: graceful fallback (the cron fire falls back to the main session when no
+ * cron bridge is registered) means a transient scaffold-vs-runtime flag
+ * mismatch is non-fatal — the fire still lands, just not cheaply, and the
+ * cron_fell_back_to_main metric records it.
+ */
+export function resolveCronAutoTier(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env.SWITCHROOM_CRON_AUTO_TIER ?? "").toLowerCase();
+  return v === "1" || v === "true" || v === "on";
 }
 
 /**
@@ -128,32 +150,43 @@ export interface TierableEntry {
 /**
  * Apply the cron tier default to a hint-less entry.
  *
- * IMPORTANT — tool-aware safety (the holistic-trace finding): this used to
- * inject `context: "fresh"` for any frequent cron, forcing it into the cheap
- * Tier-1 session. That is UNSAFE to do on cadence alone, because the Tier-1
- * session is deliberately context- AND tool-minimal (only the telegram bridge
- * MCP + built-in tools; no memory/persona, no hindsight/drive/web MCPs). A
- * frequent cron that needs those would run starved and fail its job — and the
- * graceful main-session fallback does NOT catch that (it only covers a
- * bridge-down delivery failure, not a capability shortfall). We cannot read a
- * prompt's tool/memory need deterministically, so cadence is the WRONG signal
- * to force Tier-1.
+ * History: #2305 turned this into a pass-through because the Tier-1 cron
+ * session was tool/memory-STARVED (telegram bridge + built-ins only) — forcing
+ * a frequent cron into it on cadence alone would run it starved, and the
+ * earlier "you don't have memory" prompt made it punt. That hazard is now
+ * GONE: #2307 PRs 1–3 made the cron session capability-complete (full MCP set,
+ * shared hindsight memory bank, tool-search-deferred, a non-wedging boot, and
+ * observability for a down session). So cadence is once again a sound
+ * automatic signal — a frequent hint-less cron is overwhelmingly a routine
+ * check that doesn't need the live session's accumulated context.
  *
- * The only sound tool-awareness signal is the AUTHOR's: an explicit
- * `model: sonnet` / `context: fresh` asserts "this cron is self-contained".
- * So Tier-1 is OPT-IN. Cadence stays ADVISORY — `recommendCronTier` still
- * surfaces "this could be cheaper" for shadow/guidance, but we no longer
- * force the routing. The big automatic win lives in Tier-0 (model-free),
- * which has none of these hazards.
+ * Re-enabled behaviour (when `autoTierEnabled`): a hint-less entry whose
+ * cadence is frequent (≤ `frequentGapMin`, default 60min) gets `context:
+ * "fresh"` injected → it routes to the cheap Tier-1 session. Daily/weekly and
+ * any cron whose cadence we can't read (`estimateCronGapMin → Infinity`) stay
+ * on the main session. EXPLICIT hints (kind / context / model) are always
+ * honoured untouched — the author's signal wins.
  *
- * This function therefore passes the entry through unchanged: explicit hints
- * are honoured by the router; hint-less crons keep the safe full-session
- * default. Kept as the seam where a future *tool-aware* auto-router would
- * plug in. Pure, no I/O.
+ * High blast radius (it flips routing for every frequent cron on the next
+ * `apply`), so it is DEFAULT-OFF behind `SWITCHROOM_CRON_AUTO_TIER`
+ * (`resolveCronAutoTier`) until a test-harness canary proves the cron session
+ * runs without falling back. OFF ⟹ the #2305 pass-through (today's behaviour),
+ * so this function is inert for the fleet until the flag is set. Pure: env is
+ * read only via the injected `autoTierEnabled` default.
  */
 export function applyDefaultTier<T extends TierableEntry>(
   entry: T,
-  _frequentGapMin: number = DEFAULT_FREQUENT_GAP_MIN,
+  frequentGapMin: number = DEFAULT_FREQUENT_GAP_MIN,
+  autoTierEnabled: boolean = resolveCronAutoTier(),
 ): T {
-  return entry;
+  // Default-off kill-switch: pass-through preserves today's behaviour exactly.
+  if (!autoTierEnabled) return entry;
+  // Explicit author hints win — never override kind/context/model.
+  if (entry.kind !== undefined || entry.context !== undefined || entry.model !== undefined) {
+    return entry;
+  }
+  // Cadence default. Frequent ⟹ cheap (inject context:fresh); infrequent or
+  // unreadable cadence (Infinity) ⟹ leave on the main session.
+  const rec = recommendCronTier({ smallestGapMin: estimateCronGapMin(entry.cron) }, frequentGapMin);
+  return rec.tier === "cheap" ? { ...entry, context: "fresh" as const } : entry;
 }


### PR DESCRIPTION
## Summary

PR **4 of 4** (final) for the Tier-1 un-starve (#2307). Re-enables the cadence auto-router that #2305 disabled — now safe because PRs 1–3 made the cron session capability-complete.

**Why it was disabled (#2305):** the Tier-1 cron session was tool/memory-**starved** (telegram bridge + built-ins only), so auto-routing a frequent cron into it on cadence alone would run it starved and it would punt. **Why it's safe now:** PR1 gave it the full MCP set + shared hindsight memory bank (tool-search-deferred); PR2 fixed the boot wedge so the `<agent>-cron` bridge actually registers; PR3 added a doctor check + fallback metric so a down session is visible. Cadence is a sound automatic signal again.

## What

When `SWITCHROOM_CRON_AUTO_TIER` is on, a **hint-less** entry whose cadence is **frequent** (≤ `frequentGapMin`, default 60 min) gets `context: "fresh"` injected → routes to the cheap Tier-1 session. **Daily/weekly** and any **unreadable** cadence (`estimateCronGapMin → Infinity`) stay on the main session. Explicit `kind`/`context`/`model` hints always win.

## Default-off + canary-gated

It ships **default-off** behind `SWITCHROOM_CRON_AUTO_TIER` (`resolveCronAutoTier`) because it flips routing for every frequent cron on the next `apply` (high blast radius). Flag off ⟹ the #2305 pass-through (today's behaviour) at **both** call sites (`buildCronSessionContext` at scaffold time + the in-agent tick loop), so **the fleet is inert until the flag is set**. Graceful fallback means even a scaffold-vs-runtime flag mismatch never drops a cron — the fire runs on main and is recorded by PR3's `cron_fell_back_to_main` metric.

## Test plan

- [x] `tier-selector.test.ts` — default-off pass-through (frequent stays main); flag-on (frequent → `context:fresh`; daily/weekly/unreadable → main; explicit hints honoured; custom threshold); `resolveCronAutoTier` (only `1`/`true`/`on` enables).
- [x] `cron-cadence.test.ts`, `cheap-cron-session-render.test.ts`, `compose.test.ts`, scheduler suites green (163).
- [x] `tsc --noEmit` clean; `docs/scheduling.md` auto-routing section added.

## Risk

Low at merge (inert — flag default-off, no agent sets it). The behaviour flip is entirely gated by the flag + a test-harness canary before any fleet rollout.

## Canary (test-harness, post-release)

Set `SWITCHROOM_CRON_AUTO_TIER=1`, `apply` + restart, add a frequent hint-less cron, and confirm: (a) it runs in the `<agent>-cron` session (`switchroom doctor` → *Cron Session* = ok; `cron_fell_back_to_main` stays flat; the cron transcript grows, not main), and (b) the agent still recalls memory (shared hindsight bank). Then decide whether to flip the default fleet-wide.

**Completes the Tier-1 half of #2307** (Tier-0 action tier shipped in #2318/#2320/#2321; Tier-1 un-starve in #2322/#2323/#2324/this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)