### PR TITLE
fix(cron): launch the Tier-1 cron session detached — tmux -A needs a TTY (#2307)

### DIFF
--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -86,8 +86,16 @@ CRON_APPEND_PROMPT="You are the cheap background cron worker for {{name}}. You r
 # (no --continue) — low context by construction. cd into the workspace so
 # claude's project key matches the pre-seeded trust state (.claude-cron).
 cd "{{agentDir}}" || exit 1
-exec tmux -L "$CRON_SOCKET" \
-  new-session -A -s "$CRON_NAME" -x 400 -y 50 \
+# Create the cron tmux session DETACHED (-d), not in attach mode. This is a
+# SUPERVISED BACKGROUND sidecar (start.sh forks it with `&`) with no controlling
+# TTY — the MAIN session owns the container's foreground TTY. The attach flag
+# needs a TTY, so it dies "open terminal failed: not a terminal" and the cron
+# bridge never registers (every Tier-1 fire then falls back to main). `-d` runs
+# claude in a detached pane that registers fine; a human can still
+# `tmux -L "$CRON_SOCKET" attach -t "$CRON_NAME"` later. The `-x/-y` give the
+# pane a size since there's no TTY to derive one from.
+tmux -L "$CRON_SOCKET" \
+  new-session -d -s "$CRON_NAME" -x 400 -y 50 \
   claude \
     --dangerously-load-development-channels server:switchroom-telegram \
     --plugin-dir "{{securityPluginDir}}" \
@@ -96,3 +104,12 @@ exec tmux -L "$CRON_SOCKET" \
     --model {{{cronModelQ}}} \
     --append-system-prompt "$CRON_APPEND_PROMPT"{{#if dangerousMode}} \
     --dangerously-skip-permissions{{/if}}
+
+# `new-session -d` returns immediately (tmux daemonizes the session), so block
+# here while the session lives — this keeps cron-session.sh as the supervisor's
+# long-running child. When the cron claude exits (crash / kill), the session
+# ends, the loop exits, and the supervisor respawns us cleanly (with backoff).
+while tmux -L "$CRON_SOCKET" has-session -t "$CRON_NAME" 2>/dev/null; do
+  sleep 5
+done
+echo "cron-session: ${CRON_NAME} tmux session ended — exiting for supervisor respawn" >&2

--- a/tests/cheap-cron-session-render.test.ts
+++ b/tests/cheap-cron-session-render.test.ts
@@ -66,10 +66,20 @@ describe("cron-session.sh launcher — compliance + identity", () => {
   const out = renderTemplate(CRON_SH, baseCtx);
 
   it("is interactive claude — NEVER claude -p (pillar 3)", () => {
-    expect(out).toContain("exec tmux");
+    expect(out).toContain("tmux -L");
     expect(out).toMatch(/\bclaude\b/);
     expect(out).not.toMatch(/claude\s+-p\b/);
     expect(out).not.toContain("--print");
+  });
+
+  it("creates the tmux session DETACHED (-d), not attached (-A) — it's a no-TTY background sidecar", () => {
+    // `new-session -A` (attach) dies "open terminal failed: not a terminal" in
+    // the supervised background fork (no controlling TTY) — the bug that kept
+    // the cron bridge from ever registering. -d runs claude in a detached pane.
+    expect(out).toMatch(/new-session -d -s "\$CRON_NAME"/);
+    expect(out).not.toMatch(/new-session -A/);
+    // and it blocks while the session lives so the supervisor sees a long-running child.
+    expect(out).toMatch(/while tmux -L "\$CRON_SOCKET" has-session -t "\$CRON_NAME"/);
   });
 
   it("registers as the cron bridge identity and its own config dir", () => {


### PR DESCRIPTION
## Summary

Canary finding from the v0.15.14 test-harness canary. With the Tier-1 cron session finally booting far enough to try (PRs #2322/#2323 un-starved it + seeded its trust state), it died in a respawn loop:

```
cron-session: ... open terminal failed: not a terminal
```

## Root cause (pre-existing, only now reachable)

`cron-session.sh` runs `exec tmux new-session -A` (attach-or-create). But it's a **supervised background sidecar** — `start.sh` forks it with `&` — so it has **no controlling TTY** (the *main* session owns the container's foreground TTY). The attach flag needs a TTY → "not a terminal" → the `<agent>-cron` bridge never registers → every Tier-1 fire falls back to the main session (gracefully, but the saving is never realised). It was never caught before because the cron session never booted this far (it always exit-78'd or wedged on the wizard).

## Fix

Create the session **detached** (`new-session -d`) — verified live in-container (detached succeeds with no TTY; attach reproduces the exact error). Because `-d` daemonizes and returns immediately, **block afterwards on `tmux has-session`** so `cron-session.sh` stays the supervisor's long-running child and respawns cleanly when claude exits. A human can still `tmux -L <socket> attach -t <name>-cron`.

## Canary context

This was the **only red** in the v0.15.14 canary — **Tier-0 actions** (`action ok: message sent`, tier:action exit 0, model-free) and **Tier-1 cadence auto-routing** (the hint-less `*/5` cron routed to `tier:cheap`) both **passed**. The cron session's graceful fallback meant nothing broke; just the Tier-1 token saving wasn't realised. With this fix the cron bridge registers and the fire runs cheap.

## Test plan

- [x] `cheap-cron-session-render.test.ts` — asserts `new-session -d`, the `has-session` supervise-block, and no attach flag.
- [x] Verified live in `switchroom-test-harness`: `tmux new-session -d` succeeds with no TTY; `-A` reproduces "open terminal failed: not a terminal".
- [x] `tsc --noEmit` clean.

## Risk

Low. Only the (opt-in, default-off) Tier-1 cron session launch changes; inert for the fleet. Ships in the v0.15.15 follow-up + re-canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)