### PR TITLE
fix(cron): make the Tier-1 cron session boot automatically (#2307 canary)

### DIFF
--- a/profiles/_base/cron-session.sh.hbs
+++ b/profiles/_base/cron-session.sh.hbs
@@ -105,6 +105,21 @@ tmux -L "$CRON_SOCKET" \
     --append-system-prompt "$CRON_APPEND_PROMPT"{{#if dangerousMode}} \
     --dangerously-skip-permissions{{/if}}
 
+# Dismiss the cron session's per-boot first-run prompt. Even with the seeded
+# .claude-cron/.claude.json (copied from the fully-onboarded main config),
+# `--dangerously-load-development-channels` re-prompts EVERY launch ("I am using
+# this for local development") — that ack is not persisted to config. The MAIN
+# autoaccept-poll watches only `switchroom-<name>`; this one watches
+# `switchroom-${CRON_NAME}` (the cron socket) and dispatches the same prompt
+# rule. Boot-phase only (WEDGE_WATCHDOG off → dismiss then exit); re-forked on
+# every cron-session.sh (re)spawn so a later respawn's prompt is caught too.
+# Without this the cron `claude` wedges and the <name>-cron bridge never
+# registers (every Tier-1 fire then falls back to main).
+if [ -f /opt/switchroom/autoaccept-poll.js ] && command -v bun >/dev/null 2>&1; then
+  SWITCHROOM_WEDGE_WATCHDOG=0 bun /opt/switchroom/autoaccept-poll.js "$CRON_NAME" \
+    >> /var/log/switchroom/cron-session.log 2>&1 &
+fi
+
 # `new-session -d` returns immediately (tmux daemonizes the session), so block
 # here while the session lives — this keeps cron-session.sh as the supervisor's
 # long-running child. When the cron claude exits (crash / kill), the session

--- a/src/setup/onboarding.ts
+++ b/src/setup/onboarding.ts
@@ -385,17 +385,47 @@ export function createMinimalClaudeConfig(agentDir: string, configDirName = ".cl
 /**
  * #2307 Tier-1: seed the cron session's CLAUDE_CONFIG_DIR (.claude-cron) with
  * the same onboarding + trust state the main .claude dir gets, so the cron
- * `claude` doesn't wedge on the first-run wizard / trust gate (the
- * autoaccept-poll sidecar watches only the MAIN tmux session, so nothing
- * dismisses a cron-session wizard). Idempotent: createMinimalClaudeConfig
- * early-returns if the file exists, preTrust/ensureMcpServersTrusted
- * read-modify-write. Runs on BOTH the scaffold and reconcile paths (so the
- * in-container reconcile writes the in-container project key that matches the
- * cron claude's cwd). `serverKeys` MUST be the full cron .mcp.json key set or
- * Claude Code silently ignores those servers.
+ * `claude` doesn't wedge on a first-run prompt (the autoaccept-poll sidecar
+ * watches only the MAIN tmux session by default — cron-session.sh forks a
+ * second one for the cron session to dismiss the per-boot dev-channels ack).
+ *
+ * CANARY FINDING (v0.15.15, #2307): a MINIMAL config (hasCompletedOnboarding
+ * only) is NOT enough — the cron claude still wedges on the login-method /
+ * theme prompts because the minimal config lacks `oauthAccount`, the theme
+ * flag, and the various `hasSeenX` first-run markers. The MAIN agent is already
+ * fully onboarded (the auth-broker logged it in; claude wrote `oauthAccount`
+ * etc.), so we COPY the agent's main `.claude/.claude.json` verbatim into the
+ * cron dir — the cron session inherits the exact, working onboarding state —
+ * then layer the cron-project MCP trust on top. Overwrite (not write-if-missing)
+ * so each reconcile RE-SYNCS the cron config as the main config gains fields
+ * (e.g. `oauthAccount` written only after the first login).
+ *
+ * Runs on BOTH the scaffold and reconcile paths (so the in-container reconcile
+ * writes the in-container project key that matches the cron claude's cwd).
+ * `serverKeys` MUST be the full cron .mcp.json key set or Claude Code silently
+ * ignores those servers.
  */
 export function seedCronConfigDir(agentDir: string, serverKeys: string[]): void {
-  createMinimalClaudeConfig(agentDir, ".claude-cron");
+  const mainConfig = join(agentDir, ".claude", ".claude.json");
+  const cronDir = join(agentDir, ".claude-cron");
+  const cronConfig = join(cronDir, ".claude.json");
+  mkdirSync(cronDir, { recursive: true });
+  if (existsSync(mainConfig)) {
+    // Copy the agent's fully-onboarded main config (oauthAccount / theme / all
+    // first-run markers) verbatim, OVERWRITING any stale cron copy so it stays
+    // in sync. Then preTrust/ensureMcpServersTrusted re-apply the cron-project
+    // MCP trust on top.
+    try {
+      copyFileSync(mainConfig, cronConfig);
+    } catch {
+      // If the copy fails (perms / mid-write), fall back to the minimal config
+      // so the cron session at least skips the onboarding WIZARD.
+      createMinimalClaudeConfig(agentDir, ".claude-cron");
+    }
+  } else {
+    // Fresh agent whose main config isn't written yet — minimal is the floor.
+    createMinimalClaudeConfig(agentDir, ".claude-cron");
+  }
   preTrustWorkspace(agentDir, ".claude-cron");
   ensureMcpServersTrusted(agentDir, serverKeys, ".claude-cron");
 }

--- a/src/setup/seed-cron-config-dir.test.ts
+++ b/src/setup/seed-cron-config-dir.test.ts
@@ -7,7 +7,7 @@
  * + the FULL cron server key set, and that the main .claude dir is untouched.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
@@ -59,6 +59,43 @@ describe("seedCronConfigDir (#2307 Tier-1)", () => {
       "notion",
       "switchroom-telegram",
     ]);
+  });
+
+  // CANARY FIX (v0.15.15): the minimal config (hasCompletedOnboarding only) is
+  // NOT enough — the cron claude wedges on login-method/theme without
+  // oauthAccount. seedCronConfigDir copies the agent's fully-onboarded MAIN
+  // config so the cron session inherits the working onboarding state.
+  function writeMainConfig(extra: Record<string, unknown>): void {
+    const mainDir = join(agentDir, ".claude");
+    mkdirSync(mainDir, { recursive: true });
+    writeFileSync(
+      join(mainDir, ".claude.json"),
+      JSON.stringify({ hasCompletedOnboarding: true, oauthAccount: { uuid: "acc-1" }, ...extra }, null, 2),
+    );
+  }
+
+  it("COPIES the fully-onboarded main config (oauthAccount/theme) when it exists", () => {
+    writeMainConfig({ theme: "dark", hasSeenTasksHint: true });
+    seedCronConfigDir(agentDir, keys);
+    const cron = readCron() as Record<string, unknown>;
+    // the onboarding markers that the minimal seed lacked are now present
+    expect(cron.oauthAccount).toEqual({ uuid: "acc-1" });
+    expect(cron.theme).toBe("dark");
+    expect(cron.hasSeenTasksHint).toBe(true);
+    // and the cron-project MCP trust is layered on top
+    const project = (cron.projects as Record<string, { enabledMcpjsonServers?: string[]; hasTrustDialogAccepted?: boolean }>)[resolve(agentDir)];
+    expect(project.hasTrustDialogAccepted).toBe(true);
+    expect((project.enabledMcpjsonServers ?? []).sort()).toEqual([...keys].sort());
+  });
+
+  it("OVERWRITES a stale cron config on re-seed so it re-syncs with the main (e.g. oauthAccount added after first login)", () => {
+    // first seed: no main config yet → minimal (no oauthAccount)
+    seedCronConfigDir(agentDir, keys);
+    expect((readCron() as Record<string, unknown>).oauthAccount).toBeUndefined();
+    // later: main config gains oauthAccount (agent logged in); re-seed copies it
+    writeMainConfig({});
+    seedCronConfigDir(agentDir, keys);
+    expect((readCron() as Record<string, unknown>).oauthAccount).toEqual({ uuid: "acc-1" });
   });
 });
 

--- a/tests/cheap-cron-session-render.test.ts
+++ b/tests/cheap-cron-session-render.test.ts
@@ -82,6 +82,13 @@ describe("cron-session.sh launcher — compliance + identity", () => {
     expect(out).toMatch(/while tmux -L "\$CRON_SOCKET" has-session -t "\$CRON_NAME"/);
   });
 
+  it("forks a boot-phase autoaccept for the CRON socket (dismisses the dev-channels ack)", () => {
+    // The main autoaccept watches switchroom-<name>; the cron session needs its
+    // own (switchroom-<name>-cron) or it wedges on the per-boot dev-channels
+    // prompt. Boot-phase only (WEDGE_WATCHDOG off → dismiss then exit).
+    expect(out).toMatch(/SWITCHROOM_WEDGE_WATCHDOG=0 bun \/opt\/switchroom\/autoaccept-poll\.js "\$CRON_NAME"/);
+  });
+
   it("registers as the cron bridge identity and its own config dir", () => {
     expect(out).toContain('SWITCHROOM_AGENT_NAME="$CRON_NAME"');
     expect(out).toContain('CRON_NAME="marko-cron"');


### PR DESCRIPTION
## Summary

The v0.15.15 canary proved the Tier-1 cron session works **end-to-end** once its boot prompts are dismissed (the `<agent>-cron` bridge registers, liveness is isolated, a fire lands in the cron session with the shared hindsight bank). But it didn't boot **automatically** — two remaining wedges, both because the cron session is a *second* `claude` the main session's boot machinery doesn't cover. I unblocked each manually in the canary to prove the rest works; this automates those two steps.

## Fix 1 — minimal trust seed → login/theme wedge

PR #2323's `createMinimalClaudeConfig` only sets `hasCompletedOnboarding`. The cron `claude` still wedged on the **login-method / theme** prompts because the minimal config lacks `oauthAccount`, the theme flag, and the `hasSeenX` first-run markers. The **main** agent is already fully onboarded (the auth-broker logged it in), so `seedCronConfigDir` now **copies the agent's main `.claude/.claude.json`** verbatim into `.claude-cron` (overwrite, so each reconcile re-syncs as the main gains fields like `oauthAccount` after first login), then layers the cron-project MCP trust on top. The minimal config stays the fresh-agent fallback.

## Fix 2 — no autoaccept on the cron session → dev-channels wedge

`--dangerously-load-development-channels` re-prompts **every** launch (`❯ 1. I am using this for local development`) — that ack isn't persisted to config. The main `autoaccept-poll` watches only `switchroom-<name>`; the cron session got nothing. Now `cron-session.sh` forks a **boot-phase autoaccept-poll for `$CRON_NAME`** (= the `switchroom-<name>-cron` socket) after creating the detached session — autoaccept's existing `PROMPTS` already match the ack. `WEDGE_WATCHDOG=0` so it dismisses then exits; re-forked on every cron-session respawn.

## Validation

Both were proven live in the v0.15.15 canary: manually copying the main config got past login/theme; manually sending the dev-channels keystroke registered the `<agent>-cron` bridge. This PR automates exactly those two steps.

## Test plan

- [x] `seed-cron-config-dir.test.ts` — copies the main config (`oauthAccount`/`theme`) when it exists + overwrites to re-sync; minimal fallback when absent.
- [x] `cheap-cron-session-render.test.ts` — asserts the cron autoaccept fork (`SWITCHROOM_WEDGE_WATCHDOG=0 bun … autoaccept-poll.js "$CRON_NAME"`).
- [x] `tsc --noEmit` clean.

## Risk

Low — inert for the fleet (only the opt-in Tier-1 cron session path changes). Ships v0.15.16 + re-canary to confirm the cron bridge registers with **no** manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)