### PR TITLE
feat(telegram): /effort command — switch reasoning effort per session

### DIFF
--- a/src/agents/inject.ts
+++ b/src/agents/inject.ts
@@ -59,6 +59,7 @@ export const INJECT_COMMANDS: ReadonlyMap<string, InjectCommandMeta> = new Map([
   ["/hooks", { description: "List configured hooks", expectsOutput: true }],
   ["/memory", { description: "Open memory picker", expectsOutput: true }],
   ["/model", { description: "Open model picker", expectsOutput: true }],
+  ["/effort", { description: "Set reasoning effort", expectsOutput: true }],
   [
     "/clear",
     { description: "Clear session screen", expectsOutput: false },

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -9,7 +9,7 @@ import { resolveAgentsDir, loadConfig } from "../config/loader.js";
 import { isHindsightEnabled } from "../memory/hindsight.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
-import { scaffoldAgent, reconcileAgent, buildSettingsHooksBlock, detectHooksDrift, SWITCHROOM_DEFAULT_MAIN_MODEL } from "../agents/scaffold.js";
+import { scaffoldAgent, reconcileAgent, buildSettingsHooksBlock, detectHooksDrift, SWITCHROOM_DEFAULT_MAIN_MODEL, SWITCHROOM_DEFAULT_THINKING_EFFORT } from "../agents/scaffold.js";
 import { writeComposeFile } from "./write-compose.js";
 import { bareClonePath } from "../repos/bare-clone.js";
 import { removeAgentWorktree } from "../repos/agent-worktree.js";
@@ -797,6 +797,10 @@ export function registerAgentCommand(program: Command): void {
               status: status?.active ?? "unknown",
               uptime: formatUptime(status?.uptime ?? null),
               model: resolved.model ?? SWITCHROOM_DEFAULT_MAIN_MODEL,
+              // Cascade-resolved effort — what start.sh bakes into
+              // `--effort`, and the default the /effort session switch
+              // reverts to on restart. Consumed by the gateway's /effort.
+              thinking_effort: resolved.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
               extends: agentConfig.extends ?? "default",
               topic_name: agentConfig.topic_name,
               topic_emoji: agentConfig.topic_emoji,

--- a/telegram-plugin/gateway/effort-command.ts
+++ b/telegram-plugin/gateway/effort-command.ts
@@ -1,0 +1,272 @@
+/**
+ * Telegram `/effort` command — show or switch the Claude reasoning effort
+ * for this agent's live session. The effort sibling of `/model`.
+ *
+ * `/effort` (bare) renders the effort menu: the configured default plus an
+ * inline keyboard of the five levels the CLI offers
+ * (`low · medium · high · xhigh · max`, faster→smarter), the live level
+ * marked ✅. A tap types claude's own `/effort <level>` into the agent's
+ * tmux pane via the allowlisted inject primitive (`/effort` is on the
+ * inject allowlist) — the Claude-native mechanism: the unmodified CLI's
+ * REPL command, no API, no SDK, no config mutation.
+ *
+ * `/effort <level>` does the same non-interactively.
+ *
+ * The switch is session-scoped. It lasts until the agent restarts, because
+ * `start.sh` always relaunches claude with `--effort <thinking_effort>`
+ * (the cascade-resolved default, "low" out of the box) which re-pins the
+ * session effort on boot. Persisting a new default is a `thinking_effort:`
+ * change in switchroom.yaml + restart, which the reply spells out.
+ *
+ * Split parser/handler shape mirrors `model-command.ts` so the logic is
+ * unit-testable without booting the bot.
+ */
+
+import type { InjectResult } from '../../src/agents/inject.js'
+
+/**
+ * The effort levels the installed CLI accepts (`claude --help`:
+ * "--effort <level> … (low, medium, high, xhigh, max)"). Fixed and
+ * ordered faster→smarter. Unlike model ids these don't churn, so they're
+ * listed here rather than discovered live — a new level needs a one-line
+ * edit, surfaced by the regression test.
+ */
+export const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+export type EffortLevel = (typeof EFFORT_LEVELS)[number]
+
+/** Strict allowlist gate — the arg is typed verbatim into the agent pane. */
+export function isValidEffortArg(arg: string): boolean {
+  return (EFFORT_LEVELS as readonly string[]).includes(arg.toLowerCase())
+}
+
+export type ParsedEffortCommand =
+  | { kind: 'show' }
+  | { kind: 'set'; level: EffortLevel }
+  | { kind: 'help'; reason?: string }
+
+/**
+ * Parse an `/effort` message. Returns null when the text isn't an /effort
+ * command at all (caller bug — bot.command should pre-filter).
+ */
+export function parseEffortCommand(text: string): ParsedEffortCommand | null {
+  const m = text.match(/^\/effort(?:@[A-Za-z0-9_]+)?(?:\s+([\s\S]*))?$/)
+  if (!m) return null
+  const rest = (m[1] ?? '').trim()
+  if (rest.length === 0) return { kind: 'show' }
+  const parts = rest.split(/\s+/)
+  if (parts.length > 1) {
+    return { kind: 'help', reason: 'effort takes a single level' }
+  }
+  const arg = parts[0]
+  if (arg.toLowerCase() === 'help') return { kind: 'help' }
+  if (!isValidEffortArg(arg)) {
+    return { kind: 'help', reason: `not a valid effort level: ${arg}` }
+  }
+  return { kind: 'set', level: arg.toLowerCase() as EffortLevel }
+}
+
+export interface EffortCommandDeps {
+  /** Inject primitive — wired to injectSlashCommand in the gateway. */
+  inject: (agent: string, command: string) => Promise<InjectResult>
+  getAgentName: () => string
+  /**
+   * The agent's cascade-resolved `thinking_effort` from
+   * `switchroom agent list` (the value start.sh bakes into `--effort`).
+   * Null when unreadable — rendered as the built-in default.
+   */
+  getConfiguredEffort: () => string | null
+  escapeHtml: (s: string) => string
+  preBlock: (s: string) => string
+}
+
+export interface EffortCommandReply {
+  text: string
+  html: true
+}
+
+const PERSIST_NOTE =
+  '<i>Session-only — reverts to the configured default on restart. To change the default, set <code>thinking_effort:</code> in switchroom.yaml and restart.</i>'
+
+const LEVELS_INLINE = EFFORT_LEVELS.map(l => `<code>${l}</code>`).join(' · ')
+
+function helpText(deps: EffortCommandDeps, reason?: string): EffortCommandReply {
+  const lines: string[] = []
+  if (reason) lines.push(`⚠️ ${deps.escapeHtml(reason)}`)
+  lines.push(
+    '<b>/effort</b> — show or switch the reasoning effort (faster→smarter)',
+    '<code>/effort</code> — show the configured effort + a tap menu',
+    `<code>/effort &lt;level&gt;</code> — switch the live session (${LEVELS_INLINE})`,
+    PERSIST_NOTE,
+  )
+  return { text: lines.join('\n'), html: true }
+}
+
+export async function handleEffortCommand(
+  parsed: ParsedEffortCommand,
+  deps: EffortCommandDeps,
+): Promise<EffortCommandReply> {
+  if (parsed.kind === 'help') return helpText(deps, parsed.reason)
+
+  if (parsed.kind === 'show') {
+    const configured = deps.getConfiguredEffort()
+    const shown = configured && configured.length > 0 ? configured : 'low'
+    return {
+      text: [
+        `<b>Effort — ${deps.escapeHtml(deps.getAgentName())}</b>`,
+        `Configured default: <code>${deps.escapeHtml(shown)}</code>`,
+        `Switch the live session: ${EFFORT_LEVELS.map(l => `<code>/effort ${l}</code>`).join(' · ')}`,
+        PERSIST_NOTE,
+      ].join('\n'),
+      html: true,
+    }
+  }
+
+  // kind === 'set' — re-gate at the seam so a caller that skipped the
+  // parser can't type arbitrary keys into the pane.
+  if (!isValidEffortArg(parsed.level)) {
+    return helpText(deps, `not a valid effort level: ${parsed.level}`)
+  }
+  const verbHtml = `<code>/effort ${deps.escapeHtml(parsed.level)}</code>`
+  let result: InjectResult
+  try {
+    result = await deps.inject(deps.getAgentName(), `/effort ${parsed.level}`)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { text: `❌ ${verbHtml} — inject failed: ${deps.escapeHtml(msg)}`, html: true }
+  }
+
+  if (result.outcome === 'ok') {
+    return {
+      text: [
+        `${verbHtml}`,
+        deps.preBlock(result.output),
+        ...(result.truncated ? ['<i>truncated</i>'] : []),
+        PERSIST_NOTE,
+      ].join('\n'),
+      html: true,
+    }
+  }
+  if (result.outcome === 'ok_no_output') {
+    return {
+      text: [
+        `${verbHtml} — sent, but no response captured. The agent may be mid-turn; check <code>/inject /status</code> to confirm the active effort.`,
+        PERSIST_NOTE,
+      ].join('\n'),
+      html: true,
+    }
+  }
+  // outcome === 'failed'
+  if (result.errorCode === 'session_missing') {
+    return {
+      text:
+        '❌ tmux session not found — the agent must be running under the tmux supervisor (the default). Remove <code>experimental.legacy_pty: true</code> if set.',
+      html: true,
+    }
+  }
+  return {
+    text: `❌ ${verbHtml} — ${deps.escapeHtml(result.errorMessage ?? 'inject failed')}`,
+    html: true,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Button menu — five fixed levels, the live one marked ✅. No live discovery
+// (the levels don't churn) and no picker-driving (the inline `/effort <level>`
+// form sets it directly), so this is far simpler than the /model menu.
+// ---------------------------------------------------------------------------
+
+export interface EffortMenuKeyboardButton {
+  text: string
+  callback_data: string
+}
+
+export interface EffortMenuReply {
+  text: string
+  html: true
+  keyboard?: EffortMenuKeyboardButton[][]
+}
+
+export const EFFORT_CALLBACK_PREFIX = 'eff:'
+const EFFORT_CALLBACK_SELECT = 'eff:s:'
+
+export function effortSelectCallbackData(level: string): string {
+  return `${EFFORT_CALLBACK_SELECT}${level}`
+}
+
+function menuKeyboard(highlight: string): EffortMenuKeyboardButton[][] {
+  // Five short labels fit one row (Telegram allows up to 8/row). ✅ marks
+  // the level we believe is live.
+  return [
+    EFFORT_LEVELS.map(l => ({
+      text: l === highlight ? `✅ ${l}` : l,
+      callback_data: effortSelectCallbackData(l),
+    })),
+  ]
+}
+
+/**
+ * Build the `/effort` menu: configured default + a tap row of the five
+ * levels. `highlight` marks the level shown as live (defaults to the
+ * configured value; the callback path passes the just-selected level).
+ */
+export function buildEffortMenu(deps: EffortCommandDeps, highlight?: string): EffortMenuReply {
+  const configured = deps.getConfiguredEffort() || 'low'
+  const live = highlight ?? configured
+  return {
+    text: [
+      `<b>Effort — ${deps.escapeHtml(deps.getAgentName())}</b>`,
+      `Default: <code>${deps.escapeHtml(configured)}</code> · faster → smarter: ${LEVELS_INLINE}`,
+      'Tap to switch the live session:',
+      PERSIST_NOTE,
+    ].join('\n'),
+    html: true,
+    keyboard: menuKeyboard(live),
+  }
+}
+
+export interface EffortCallbackOutcome {
+  reply: EffortMenuReply
+  /** The level applied to the live session, if any (gateway records it). */
+  selectedEffort?: string
+}
+
+/**
+ * Handle an `eff:*` callback tap. `eff:s:<level>` injects claude's
+ * `/effort <level>` and re-renders the menu with a one-line banner and the
+ * new level checked. Never throws — failures render as a banner.
+ */
+export async function handleEffortMenuCallback(
+  data: string,
+  deps: EffortCommandDeps,
+): Promise<EffortCallbackOutcome> {
+  if (!data.startsWith(EFFORT_CALLBACK_SELECT)) {
+    return { reply: buildEffortMenu(deps) }
+  }
+  const level = data.slice(EFFORT_CALLBACK_SELECT.length)
+  if (!isValidEffortArg(level)) {
+    return { reply: buildEffortMenu(deps) }
+  }
+  let banner: string
+  let selected: string | undefined
+  try {
+    const result = await deps.inject(deps.getAgentName(), `/effort ${level}`)
+    if (result.outcome === 'ok' || result.outcome === 'ok_no_output') {
+      banner = `✅ Effort → <code>${deps.escapeHtml(level)}</code> for this session`
+      selected = level
+    } else if (result.errorCode === 'session_missing') {
+      banner = '❌ tmux session not found — is the agent running under the supervisor?'
+    } else {
+      banner = `❌ couldn't set effort: ${deps.escapeHtml(result.errorMessage ?? 'inject failed')}`
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    banner = `❌ inject failed: ${deps.escapeHtml(msg)}`
+  }
+  // Re-render with the just-selected level checked (or the configured
+  // default if the inject failed) and the banner on top.
+  const menu = buildEffortMenu(deps, selected)
+  return {
+    reply: { ...menu, text: `${banner}\n${menu.text}` },
+    selectedEffort: selected,
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -271,6 +271,15 @@ import {
   type ModelMenuReply,
 } from './model-command.js'
 import { discoverModels, selectModel } from '../../src/agents/model-picker.js'
+import {
+  parseEffortCommand,
+  handleEffortCommand,
+  buildEffortMenu,
+  handleEffortMenuCallback,
+  EFFORT_CALLBACK_PREFIX,
+  type EffortCommandDeps,
+  type EffortMenuReply,
+} from './effort-command.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
 import { loadConfig as loadSwitchroomConfig, findConfigFile as findSwitchroomConfigFile } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
@@ -14219,6 +14228,51 @@ bot.command('model', async ctx => {
   await switchroomReply(ctx, reply.text, { html: reply.html })
 })
 
+// `/effort` — show or switch the reasoning effort for the live session.
+// The effort sibling of `/model`: bare form renders a five-button menu
+// (low/medium/high/xhigh/max, the live level ✅), a typed form
+// `/effort <level>` sets it directly. Both ride the allowlisted inject
+// primitive (claude's own `/effort` REPL command), session-scoped — boot
+// re-pins the configured default via start.sh's `--effort`. Implementation
+// in effort-command.ts so it's unit-testable without booting the bot.
+function buildEffortDeps(): EffortCommandDeps {
+  return {
+    inject: injectSlashCommandImpl,
+    getAgentName: getMyAgentName,
+    getConfiguredEffort: () => {
+      type AgentListResp = { agents: Array<{ name: string; thinking_effort?: string | null }> }
+      const data = switchroomExecJson<AgentListResp>(['agent', 'list'])
+      return data?.agents?.find(a => a.name === getMyAgentName())?.thinking_effort ?? null
+    },
+    escapeHtml: escapeHtmlForTg,
+    preBlock,
+  }
+}
+
+function effortMenuReplyMarkup(reply: EffortMenuReply): InlineKeyboard | undefined {
+  if (!reply.keyboard) return undefined
+  const kb = new InlineKeyboard()
+  for (const row of reply.keyboard) {
+    for (const btn of row) kb.text(btn.text, btn.callback_data)
+    kb.row()
+  }
+  return kb
+}
+
+bot.command('effort', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  const text = ctx.message?.text ?? ctx.channelPost?.text ?? ''
+  const parsed = parseEffortCommand(text) ?? { kind: 'show' as const }
+  const deps = buildEffortDeps()
+  if (parsed.kind === 'show') {
+    const menu = buildEffortMenu(deps)
+    await switchroomReply(ctx, menu.text, { html: true, reply_markup: effortMenuReplyMarkup(menu) })
+    return
+  }
+  const reply = await handleEffortCommand(parsed, deps)
+  await switchroomReply(ctx, reply.text, { html: reply.html })
+})
+
 bot.command('agentstart', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   const name = ctx.match?.trim() || getMyAgentName()
@@ -18608,6 +18662,33 @@ bot.on('callback_query:data', async ctx => {
   // a stale index); `mdl:r` re-renders. Strict allowFrom gate like
   // every other mutating callback family — a model switch changes the
   // fleet's quota burn profile.
+  if (data.startsWith(EFFORT_CALLBACK_PREFIX)) {
+    const access = loadAccess()
+    const senderId = String(ctx.from?.id ?? '')
+    if (!access.allowFrom.includes(senderId)) {
+      await ctx.answerCallbackQuery({ text: 'Not authorized.' })
+      return
+    }
+    // No picker-driving (the inline `/effort <level>` form sets it
+    // directly via the inject primitive), so no mid-turn guard is needed
+    // here — just ack and apply.
+    await ctx.answerCallbackQuery({ text: 'Setting effort…' }).catch(() => {})
+    try {
+      const outcome = await handleEffortMenuCallback(data, buildEffortDeps())
+      await ctx
+        .editMessageText(outcome.reply.text, {
+          parse_mode: 'HTML',
+          reply_markup: effortMenuReplyMarkup(outcome.reply) ?? { inline_keyboard: [] },
+        })
+        .catch(() => {})
+    } catch (err) {
+      process.stderr.write(
+        `telegram gateway: effort-menu callback failed: ${(err as Error)?.message ?? String(err)}\n`,
+      )
+    }
+    return
+  }
+
   if (data.startsWith(MODEL_CALLBACK_PREFIX)) {
     const access = loadAccess()
     const senderId = String(ctx.from?.id ?? '')

--- a/telegram-plugin/tests/effort-command.test.ts
+++ b/telegram-plugin/tests/effort-command.test.ts
@@ -1,0 +1,191 @@
+/**
+ * `/effort` Telegram command — parser + handler + menu coverage.
+ *
+ * Guarantees mirrored from `/model`:
+ *   1. The argument is allowlist-gated before it's typed into the tmux
+ *      pane — only the five levels claude accepts, nothing else.
+ *   2. The set path injects exactly `/effort <level>` (claude's own REPL
+ *      verb, on the inject allowlist) and relays the captured output with
+ *      the session-only / reverts-on-restart caveat.
+ *   3. The bare form renders a five-button menu; a tap injects the level.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseEffortCommand,
+  handleEffortCommand,
+  isValidEffortArg,
+  EFFORT_LEVELS,
+  buildEffortMenu,
+  handleEffortMenuCallback,
+  effortSelectCallbackData,
+  EFFORT_CALLBACK_PREFIX,
+  type EffortCommandDeps,
+} from "../gateway/effort-command.js";
+import type { InjectResult } from "../../src/agents/inject.js";
+
+function okResult(output: string): InjectResult {
+  return {
+    outcome: "ok",
+    output,
+    truncated: false,
+    command: "/effort",
+    meta: { description: "Set reasoning effort", expectsOutput: true },
+  };
+}
+
+function failedResult(errorMessage: string): InjectResult {
+  return {
+    outcome: "failed",
+    output: "",
+    truncated: false,
+    command: "/effort",
+    errorMessage,
+    meta: { description: "Set reasoning effort", expectsOutput: true },
+  };
+}
+
+function makeDeps(overrides: Partial<EffortCommandDeps> = {}) {
+  const calls: Array<{ agent: string; command: string }> = [];
+  const deps: EffortCommandDeps = {
+    inject: async (agent, command) => {
+      calls.push({ agent, command });
+      return okResult("Set effort level to high");
+    },
+    getAgentName: () => "carrie",
+    getConfiguredEffort: () => "low",
+    escapeHtml: (s) => s,
+    preBlock: (s) => `<pre>${s}</pre>`,
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+describe("effort-command: levels + validation", () => {
+  it("exposes exactly the five CLI levels in faster→smarter order", () => {
+    expect(EFFORT_LEVELS).toEqual(["low", "medium", "high", "xhigh", "max"]);
+  });
+
+  it("isValidEffortArg accepts levels case-insensitively, rejects others", () => {
+    for (const l of EFFORT_LEVELS) {
+      expect(isValidEffortArg(l)).toBe(true);
+      expect(isValidEffortArg(l.toUpperCase())).toBe(true);
+    }
+    for (const bad of ["", "highest", "fast", "/effort", "low high", "9"]) {
+      expect(isValidEffortArg(bad)).toBe(false);
+    }
+  });
+});
+
+describe("effort-command: parser", () => {
+  it("bare /effort → show", () => {
+    expect(parseEffortCommand("/effort")).toEqual({ kind: "show" });
+    expect(parseEffortCommand("/effort   ")).toEqual({ kind: "show" });
+  });
+
+  it("/effort@bot suffix is tolerated", () => {
+    expect(parseEffortCommand("/effort@carrie_bot")).toEqual({ kind: "show" });
+  });
+
+  it("/effort <level> → set, normalized to lowercase", () => {
+    expect(parseEffortCommand("/effort high")).toEqual({ kind: "set", level: "high" });
+    expect(parseEffortCommand("/effort XHIGH")).toEqual({ kind: "set", level: "xhigh" });
+  });
+
+  it("/effort help → help", () => {
+    expect(parseEffortCommand("/effort help")).toEqual({ kind: "help" });
+  });
+
+  it("invalid level → help with a reason", () => {
+    const p = parseEffortCommand("/effort turbo");
+    expect(p?.kind).toBe("help");
+    expect((p as { reason?: string }).reason).toMatch(/not a valid effort level/);
+  });
+
+  it("more than one token → help", () => {
+    const p = parseEffortCommand("/effort high please");
+    expect(p?.kind).toBe("help");
+    expect((p as { reason?: string }).reason).toMatch(/single level/);
+  });
+
+  it("non-/effort text → null", () => {
+    expect(parseEffortCommand("/model opus")).toBeNull();
+    expect(parseEffortCommand("hello")).toBeNull();
+  });
+});
+
+describe("effort-command: handler", () => {
+  it("show renders the configured default", async () => {
+    const { deps } = makeDeps({ getConfiguredEffort: () => "medium" });
+    const r = await handleEffortCommand({ kind: "show" }, deps);
+    expect(r.text).toContain("medium");
+    expect(r.text).toMatch(/reverts to the configured default/);
+  });
+
+  it("show falls back to low when effort is unreadable", async () => {
+    const { deps } = makeDeps({ getConfiguredEffort: () => null });
+    const r = await handleEffortCommand({ kind: "show" }, deps);
+    expect(r.text).toContain("low");
+  });
+
+  it("set injects exactly '/effort <level>' and relays output", async () => {
+    const { deps, calls } = makeDeps();
+    const r = await handleEffortCommand({ kind: "set", level: "high" }, deps);
+    expect(calls).toEqual([{ agent: "carrie", command: "/effort high" }]);
+    expect(r.text).toContain("Set effort level to high");
+    expect(r.text).toMatch(/reverts to the configured default/);
+  });
+
+  it("set surfaces an inject failure", async () => {
+    const { deps } = makeDeps({ inject: async () => failedResult("pane locked") });
+    const r = await handleEffortCommand({ kind: "set", level: "max" }, deps);
+    expect(r.text).toContain("pane locked");
+    expect(r.text).toContain("❌");
+  });
+
+  it("set re-gates the level at the seam (defensive)", async () => {
+    const { deps, calls } = makeDeps();
+    // Hand-craft a parsed object that skipped the parser's gate.
+    const r = await handleEffortCommand({ kind: "set", level: "evil; rm -rf" as never }, deps);
+    expect(calls).toEqual([]); // never injected
+    expect(r.text).toMatch(/not a valid effort level/);
+  });
+});
+
+describe("effort-command: menu + callback", () => {
+  it("buildEffortMenu offers all five levels with the configured one checked", () => {
+    const { deps } = makeDeps({ getConfiguredEffort: () => "high" });
+    const menu = buildEffortMenu(deps);
+    const buttons = menu.keyboard!.flat();
+    expect(buttons.map((b) => b.callback_data)).toEqual(
+      EFFORT_LEVELS.map((l) => effortSelectCallbackData(l)),
+    );
+    const checked = buttons.find((b) => b.text.startsWith("✅"));
+    expect(checked?.text).toBe("✅ high");
+    expect(menu.keyboard![0]).toHaveLength(5);
+  });
+
+  it("callback eff:s:<level> injects the level and checks it in the re-render", async () => {
+    const { deps, calls } = makeDeps();
+    const out = await handleEffortMenuCallback(effortSelectCallbackData("xhigh"), deps);
+    expect(calls).toEqual([{ agent: "carrie", command: "/effort xhigh" }]);
+    expect(out.selectedEffort).toBe("xhigh");
+    expect(out.reply.text).toContain("Effort → ");
+    const checked = out.reply.keyboard!.flat().find((b) => b.text.startsWith("✅"));
+    expect(checked?.text).toBe("✅ xhigh");
+  });
+
+  it("callback with a failed inject keeps the menu and shows the error, no selection", async () => {
+    const { deps } = makeDeps({ inject: async () => failedResult("session_missing") });
+    const out = await handleEffortMenuCallback(effortSelectCallbackData("max"), deps);
+    expect(out.selectedEffort).toBeUndefined();
+    expect(out.reply.text).toContain("❌");
+    expect(out.reply.keyboard!.flat()).toHaveLength(5); // buttons preserved
+  });
+
+  it("callback ignores a malformed level", async () => {
+    const { deps, calls } = makeDeps();
+    const out = await handleEffortMenuCallback(`${EFFORT_CALLBACK_PREFIX}s:bogus`, deps);
+    expect(calls).toEqual([]);
+    expect(out.selectedEffort).toBeUndefined();
+  });
+});

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -318,6 +318,10 @@ export const TELEGRAM_MENU_COMMANDS = [
   // same inject primitive as `/inject /model` but with a typed argument,
   // so it never opens the undriveable no-arg picker modal).
   { command: "model", description: "Show or switch the Claude model" },
+  // /effort — show or switch the reasoning effort (low→max, faster→smarter).
+  // Same Claude-native inject mechanism as /model; session-scoped, reverts
+  // to the configured `thinking_effort` default on restart.
+  { command: "effort", description: "Show or switch the reasoning effort" },
   { command: "doctor", description: "Health check (deps, services, MCP)" },
   { command: "usage", description: "Pro/Max plan quota (5h + 7d windows)" },
   // Vault — secrets + capability grants. /vault is a top-level command
@@ -379,6 +383,7 @@ export function switchroomHelpText(agentName: string): string {
     `<code>/auth rm [agent] &lt;slot&gt; [--force]</code> — remove a slot`,
     `<code>/model</code> — show the configured Claude model`,
     `<code>/model &lt;name&gt;</code> — switch the live session's model (opus · sonnet · haiku or a full id; until restart)`,
+    `<code>/effort</code> — show or switch reasoning effort (low · medium · high · xhigh · max; until restart)`,
     `<code>/topics</code> — topic-to-agent mappings`,
     `<code>/permissions [agent]</code> — show agent permissions`,
     `<code>/grant &lt;tool&gt;</code> — grant a tool permission`,


### PR DESCRIPTION
## Summary

A Telegram **`/effort`** command, mirroring `/model`, to show or switch the Claude **reasoning effort** (`low · medium · high · xhigh · max`, faster→smarter) for an agent's live session.

- **`/effort`** (bare) → five-button menu, the live level marked ✅.
- **`/effort <level>`** → sets it directly.

Both type claude's own **`/effort` REPL command** into the tmux pane via the existing allowlisted inject primitive — Claude-native, no API/SDK/config mutation.

## Why / requested behavior

Operator asked for "a `/effort` that does the same thing as `/model` … and on agent restart it goes back to its default." That falls out for free: `start.sh` already relaunches claude with `--effort <thinking_effort>` (the cascade default, **`low`**), which re-pins the configured effort on every boot. So a `/effort` session change **reverts on restart** by construction. (The CLI's inline `/effort high` otherwise persists as a new user default — the `--effort` flag at launch is what guarantees the revert.)

## What's new vs. already there

The config + launch plumbing already existed (`thinking_effort` cascade field, `start.sh --effort {{thinkingEffort}}`, `SWITCHROOM_DEFAULT_THINKING_EFFORT = "low"`). This PR adds **only the command surface**:

- `telegram-plugin/gateway/effort-command.ts` — parser + handler + 5-button menu + callback, split so it's unit-testable without booting the bot (**18 tests**).
- `/effort` added to the inject allowlist (`src/agents/inject.ts`) — auto-covered by the existing per-entry classifier test.
- `agent list --json` now emits `thinking_effort` (the menu's "configured default" source).
- Gateway wiring: `bot.command('effort')` + `eff:*` callback handler.
- `/effort` added to the slash menu + `/commands` help.

## Feasibility (verified against the installed CLI, 2.1.177)

`/effort` is a live REPL command opening an effort picker; `/effort <level>` works inline; levels are exactly `low/medium/high/xhigh/max` (matches the existing `thinking_effort` schema enum). Confirmed live on the test-harness agent.

## Test plan

- [x] `effort-command.test.ts` — 18 tests (parser, allowlist gate, handler inject/relay, menu buttons, callback apply + failure paths)
- [x] inject classifier test now covers `/effort`
- [x] `agent list --json` test green with the new field
- [x] `tsc --noEmit`, `check-plugin-references`, `check-bot-api-wrapping`, `lint:bun-test-imports` all clean
- [x] 362 tests green across all affected files

## Risk

Low. Additive command surface; the load-bearing launch/revert plumbing was already present and unchanged. No fleet behavior change on deploy (everyone already launches at `--effort low`). Going live needs `apply` + restart (the command code loads at gateway boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)