### PR TITLE
fix(gateway): turn-gate vault/secret resume synthetics (mid-turn strand)

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1748,19 +1748,19 @@ function turnInFlightForGate(): boolean {
  * means "held mid-turn OR bridge-down" — both are "will flush when idle",
  * never "dropped").
  */
-function deliverResumeSyntheticOrBuffer(agent: string, synthetic: InboundMessage): boolean {
+function deliverResumeSyntheticOrBuffer(agent: string, inbound: InboundMessage): boolean {
   const decision = decideInboundDelivery({
     turnInFlight: turnInFlightForGate(),
     isSteering: false,
     isInterrupt: false,
   })
   if (decision === 'buffer-until-idle') {
-    pendingInboundBuffer.push(agent, synthetic)
+    pendingInboundBuffer.push(agent, inbound)
     return false
   }
-  const delivered = ipcServer.sendToAgent(agent, synthetic)
-  if (delivered) markClaudeBusyForInbound(synthetic)
-  else pendingInboundBuffer.push(agent, synthetic)
+  const delivered = ipcServer.sendToAgent(agent, inbound)
+  if (delivered) markClaudeBusyForInbound(inbound)
+  else pendingInboundBuffer.push(agent, inbound)
   return delivered
 }
 
@@ -8954,9 +8954,7 @@ async function captureProvidedSecret(
         stage_id: armed.stageId,
       },
     }
-    const fdelivered = ipcServer.sendToAgent(armed.agent, failMsg)
-    if (fdelivered) markClaudeBusyForInbound(failMsg)
-    else pendingInboundBuffer.push(armed.agent, failMsg)
+    deliverResumeSyntheticOrBuffer(armed.agent, failMsg)
     return true
   }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -1717,6 +1717,53 @@ function formatFeedElapsed(ms: number): string {
 function turnInFlightForGate(): boolean {
   return isDeliveryCutoverEnabled() ? isMachineInTurn() : claudeBusyKeys.size > 0
 }
+
+/**
+ * Deliver a synthetic "resume" inbound — the wake-up the gateway sends
+ * after an operator approves/denies a vault grant, provides/declines a
+ * requested secret, or completes/fails/discards a vault save — turn-gated
+ * exactly like a real Telegram inbound.
+ *
+ * THE BUG (clerk `hotdoc/credentials`, 2026-06-13): these synthetics did a
+ * raw `ipcServer.sendToAgent` and buffered ONLY on `delivered=false`
+ * (bridge disconnected). But approvals routinely land WHILE the agent's
+ * grant-requesting turn is still finishing — the socket write succeeds
+ * (`delivered=true`) yet claude is mid-turn, so the channel notification
+ * is typed into its TUI composer and stranded by the turn-completion race
+ * (#1556, the lawgpt wedge). `delivered=true` → the buffer never rescued
+ * it → the agent sat idle until the operator manually poked it. Observed:
+ * injection 179ms BEFORE turn_end, then 2 minutes of silence.
+ *
+ * Fix: route through the SAME `decideInboundDelivery` gate the Telegram
+ * `handleInbound` path uses. Mid-turn → `buffer-until-idle` (the
+ * turn-complete hook `releaseTurnBufferGate → drainBufferedIfAllowed`,
+ * plus the idle-drain timer, flush it the instant claude goes idle, where
+ * it lands cleanly as a fresh turn). Idle → deliver now; buffer on a
+ * genuine delivery miss exactly as before. Unlike the cron `inject_inbound`
+ * path (deliberately ungated — at-least-once replay), a one-shot resume
+ * synthetic must never strand, so it IS gated.
+ *
+ * Returns true iff delivered to the bridge now (false = buffered/held;
+ * the caller's forensic log records this as `delivered=false`, which now
+ * means "held mid-turn OR bridge-down" — both are "will flush when idle",
+ * never "dropped").
+ */
+function deliverResumeSyntheticOrBuffer(agent: string, synthetic: InboundMessage): boolean {
+  const decision = decideInboundDelivery({
+    turnInFlight: turnInFlightForGate(),
+    isSteering: false,
+    isInterrupt: false,
+  })
+  if (decision === 'buffer-until-idle') {
+    pendingInboundBuffer.push(agent, synthetic)
+    return false
+  }
+  const delivered = ipcServer.sendToAgent(agent, synthetic)
+  if (delivered) markClaudeBusyForInbound(synthetic)
+  else pendingInboundBuffer.push(agent, synthetic)
+  return delivered
+}
+
 const pendingRestarts = new Map<string, number>()  // agentName -> timestamp when restart was requested
 
 // ─── Proactive context compaction (session.max_context_tokens) ──────────
@@ -8942,9 +8989,7 @@ async function captureProvidedSecret(
       stage_id: armed.stageId,
     },
   }
-  const delivered = ipcServer.sendToAgent(armed.agent, synthetic)
-  if (delivered) markClaudeBusyForInbound(synthetic)
-  else pendingInboundBuffer.push(armed.agent, synthetic)
+  const delivered = deliverResumeSyntheticOrBuffer(armed.agent, synthetic)
   process.stderr.write(
     `telegram gateway: secret_provided injection agent=${armed.agent} key=${armed.key} stage=${armed.stageId} delivered=${delivered}\n`,
   )
@@ -9025,9 +9070,7 @@ async function handleSecretRequestCallback(ctx: Context, data: string): Promise<
         stage_id: stageId,
       },
     }
-    const delivered = ipcServer.sendToAgent(pending.agent, synthetic)
-    if (delivered) markClaudeBusyForInbound(synthetic)
-    else pendingInboundBuffer.push(pending.agent, synthetic)
+    deliverResumeSyntheticOrBuffer(pending.agent, synthetic)
     return
   }
 
@@ -16563,22 +16606,14 @@ async function performVaultAccessApproval(
     stageId,
     operatorId: senderId,
   })
-  const delivered = ipcServer.sendToAgent(pending.agent, synthetic)
-  if (delivered) markClaudeBusyForInbound(synthetic)
+  // Turn-gated via deliverResumeSyntheticOrBuffer: mid-turn → buffer
+  // (flushed at turn-end) so the resume never strands in claude's
+  // composer (#1556); idle → deliver; bridge-down → buffer (#1150).
+  const delivered = deliverResumeSyntheticOrBuffer(pending.agent, synthetic)
   process.stderr.write(
     `telegram gateway: vault_grant_approved injection agent=${pending.agent} ` +
     `key=${pending.key} stage=${stageId} delivered=${delivered}\n`,
   )
-  // #1150 root cause: if `delivered=false` the bridge wasn't connected
-  // at send-time (mid-reconnect, claude-session bouncing between
-  // turns, etc). Pre-fix this just logged + dropped — the agent stayed
-  // idle forever and the operator had to poke. Now we buffer the
-  // inbound so the next bridge-register call drains it. Bounded to
-  // 32 entries per agent (see pending-inbound-buffer.ts) — a never-
-  // reconnecting bridge can't fill memory.
-  if (!delivered) {
-    pendingInboundBuffer.push(pending.agent, synthetic)
-  }
 }
 
 async function handleVaultRequestAccessCallback(ctx: Context, data: string): Promise<void> {
@@ -16644,15 +16679,11 @@ async function handleVaultRequestAccessCallback(ctx: Context, data: string): Pro
       stageId,
       operatorId: senderId,
     })
-    const denyDelivered = ipcServer.sendToAgent(pending.agent, denyInbound)
-    if (denyDelivered) markClaudeBusyForInbound(denyInbound)
+    const denyDelivered = deliverResumeSyntheticOrBuffer(pending.agent, denyInbound)
     process.stderr.write(
       `telegram gateway: vault_grant_denied injection agent=${pending.agent} ` +
       `key=${pending.key} stage=${stageId} delivered=${denyDelivered}\n`,
     )
-    if (!denyDelivered) {
-      pendingInboundBuffer.push(pending.agent, denyInbound)
-    }
     return
   }
 
@@ -16823,13 +16854,11 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
       stageId,
       operatorId: senderId,
     })
-    const dDelivered = ipcServer.sendToAgent(pending.agent, discardInbound)
-    if (dDelivered) markClaudeBusyForInbound(discardInbound)
+    const dDelivered = deliverResumeSyntheticOrBuffer(pending.agent, discardInbound)
     process.stderr.write(
       `telegram gateway: vault_save_discarded injection agent=${pending.agent} ` +
       `key=${pending.key} stage=${stageId} delivered=${dDelivered}\n`,
     )
-    if (!dDelivered) pendingInboundBuffer.push(pending.agent, discardInbound)
     return
   }
 
@@ -16952,13 +16981,11 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
         operatorId: senderId,
         reason: failReason,
       })
-      const fDelivered = ipcServer.sendToAgent(pending.agent, failInbound)
-      if (fDelivered) markClaudeBusyForInbound(failInbound)
+      const fDelivered = deliverResumeSyntheticOrBuffer(pending.agent, failInbound)
       process.stderr.write(
         `telegram gateway: vault_save_failed injection agent=${pending.agent} ` +
         `key=${pending.key} stage=${stageId} delivered=${fDelivered}\n`,
       )
-      if (!fDelivered) pendingInboundBuffer.push(pending.agent, failInbound)
       return
     }
 
@@ -16987,13 +17014,11 @@ async function handleVaultRequestSaveCallback(ctx: Context, data: string): Promi
       stageId,
       operatorId: senderId,
     })
-    const okDelivered = ipcServer.sendToAgent(pending.agent, okInbound)
-    if (okDelivered) markClaudeBusyForInbound(okInbound)
+    const okDelivered = deliverResumeSyntheticOrBuffer(pending.agent, okInbound)
     process.stderr.write(
       `telegram gateway: vault_save_completed injection agent=${pending.agent} ` +
       `key=${pending.key} stage=${stageId} delivered=${okDelivered}\n`,
     )
-    if (!okDelivered) pendingInboundBuffer.push(pending.agent, okInbound)
     return
   }
 

--- a/telegram-plugin/tests/vault-grant-auto-resume.test.ts
+++ b/telegram-plugin/tests/vault-grant-auto-resume.test.ts
@@ -39,17 +39,28 @@ function extractPerformBlock(): string {
 describe("performVaultAccessApproval injects a synthetic inbound on success (#1052)", () => {
   const block = extractPerformBlock();
 
-  it("calls ipcServer.sendToAgent AFTER successful mint + token-write", () => {
+  it("routes the resume injection through the turn-gated helper AFTER successful mint + token-write", () => {
     // fails when: the auto-resume injection gets dropped. Pre-fix
     // operator had to message the agent again to resume the task —
     // the injection is the load-bearing wiring.
-    expect(block, "missing ipcServer.sendToAgent call").toMatch(/ipcServer\.sendToAgent\(/);
+    //
+    // The raw `ipcServer.sendToAgent` was replaced by
+    // `deliverResumeSyntheticOrBuffer` (the mid-turn-strand fix,
+    // 2026-06-14): a resume delivered while the grant-requesting turn
+    // is still finishing used to strand in claude's composer
+    // (delivered=true but mid-turn → #1556). The helper turn-gates the
+    // send (buffer-until-idle when a turn is in flight) so the resume
+    // always lands as a fresh turn. Pinning the helper call (not raw
+    // sendToAgent) is the new load-bearing contract.
+    expect(block, "missing deliverResumeSyntheticOrBuffer call").toMatch(
+      /deliverResumeSyntheticOrBuffer\(/,
+    );
     // Must run AFTER the mint-success path (i.e., after the
     // `result.kind === 'error'` early-return guard).
     const errorReturn = block.indexOf("result.kind === 'error'");
-    const sendIdx = block.indexOf("ipcServer.sendToAgent(");
+    const sendIdx = block.indexOf("deliverResumeSyntheticOrBuffer(");
     expect(errorReturn).toBeGreaterThan(0);
-    expect(sendIdx, "sendToAgent must come AFTER the error-return early exit").toBeGreaterThan(errorReturn);
+    expect(sendIdx, "the resume helper must come AFTER the error-return early exit").toBeGreaterThan(errorReturn);
   });
 
   it("delegates inbound construction to buildVaultGrantApprovedInbound", () => {

--- a/telegram-plugin/tests/vault-resume-turn-gated.test.ts
+++ b/telegram-plugin/tests/vault-resume-turn-gated.test.ts
@@ -67,21 +67,31 @@ describe("resume synthetics use the turn-gate (mid-turn → buffer)", () => {
   });
 
   it("no resume synthetic is sent via a raw ungated ipcServer.sendToAgent", () => {
-    // Every *_approved/_denied, secret_provided/_declined,
-    // vault_save_completed/_failed/_discarded resume must route through
-    // the helper. A raw sendToAgent of one of these named inbound vars
-    // would reintroduce the mid-turn strand. The ONLY ipcServer.sendToAgent
-    // referencing these synthetics should be inside the helper itself
-    // (which sends a generic `synthetic` param), so none of the named
-    // resume vars may appear as a raw sendToAgent argument.
+    // Every resume wake-up — vault_grant_approved/denied, secret_provided/
+    // declined, secret_provide_failed, vault_save_completed/failed/discarded
+    // — must route through the helper. A raw sendToAgent of one of these
+    // named inbound vars would reintroduce the mid-turn strand. The helper
+    // deliberately names its param `inbound` (NOT any of these), so the
+    // ONLY legitimate raw sendToAgent is the helper's own
+    // `ipcServer.sendToAgent(agent, inbound)`; every resume-synthetic var
+    // name below must be absent as a raw send argument.
     const rawResumeSends = [
       ...gatewaySrc.matchAll(
-        /ipcServer\.sendToAgent\([^,]+,\s*(denyInbound|discardInbound|failInbound|okInbound)\)/g,
+        /ipcServer\.sendToAgent\([^,]+,\s*(synthetic|failMsg|denyInbound|discardInbound|failInbound|okInbound)\)/g,
       ),
     ];
     expect(
       rawResumeSends.map((m) => m[1]),
       "resume synthetic sent via raw sendToAgent — must use deliverResumeSyntheticOrBuffer",
     ).toEqual([]);
+  });
+
+  it("the helper's send uses a param name distinct from every resume var (keeps the grep guard honest)", () => {
+    // If the helper param were renamed back to `synthetic`, the guard
+    // above would get a false pass (the helper's own send would mask a
+    // regressed callsite). Pin the param name.
+    const start = gatewaySrc.indexOf("function deliverResumeSyntheticOrBuffer");
+    const sig = gatewaySrc.slice(start, start + 120);
+    expect(sig).toMatch(/deliverResumeSyntheticOrBuffer\(agent: string, inbound: InboundMessage\)/);
   });
 });

--- a/telegram-plugin/tests/vault-resume-turn-gated.test.ts
+++ b/telegram-plugin/tests/vault-resume-turn-gated.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression guard — vault/secret RESUME synthetics are turn-gated
+ * (the clerk `hotdoc/credentials` mid-turn-strand, 2026-06-14).
+ *
+ * THE BUG: when an operator approved a vault grant (or provided a
+ * secret, or completed a save) WHILE the agent's grant-requesting turn
+ * was still finishing, the gateway did a raw `ipcServer.sendToAgent` of
+ * the resume synthetic. The socket write succeeded (`delivered=true`)
+ * but claude was mid-turn, so the channel notification was typed into
+ * its TUI composer and stranded by the turn-completion race (#1556).
+ * The pending-inbound buffer never rescued it (it only catches
+ * `delivered=false`), so the agent sat idle until the operator manually
+ * poked it.
+ *
+ * Live proof (clerk, 2026-06-13 22:10:57):
+ *   22:10:57.098  vault_grant_approved injection delivered=true
+ *   22:10:57.277  turn_end #14081 finalAnswer=true   (still mid-turn!)
+ *   22:12:57.713  inbound msg=14085 → turnStart       (operator poke, 2m later)
+ *
+ * THE FIX: every resume synthetic goes through
+ * `deliverResumeSyntheticOrBuffer`, which consults the SAME
+ * `decideInboundDelivery` gate the Telegram handleInbound path uses —
+ * mid-turn → `buffer-until-idle` (flushed cleanly at turn-end). This
+ * file pins (a) the gate decision for a resume synthetic's
+ * shape, and (b) that no resume callsite regressed to a raw
+ * `ipcServer.sendToAgent`.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { decideInboundDelivery } from "../gateway/inbound-delivery-gate.js";
+
+const gatewaySrc = readFileSync(
+  resolve(__dirname, "..", "gateway", "gateway.ts"),
+  "utf-8",
+);
+
+describe("resume synthetics use the turn-gate (mid-turn → buffer)", () => {
+  it("a resume synthetic's gate shape buffers mid-turn, delivers when idle", () => {
+    // A resume synthetic is never steering and never an interrupt — the
+    // exact inputs deliverResumeSyntheticOrBuffer passes to the gate.
+    const shape = { isSteering: false as const, isInterrupt: false as const };
+    expect(decideInboundDelivery({ ...shape, turnInFlight: true })).toBe(
+      "buffer-until-idle",
+    );
+    expect(decideInboundDelivery({ ...shape, turnInFlight: false })).toBe(
+      "deliver",
+    );
+  });
+
+  it("the helper exists and gates on decideInboundDelivery before sending", () => {
+    const start = gatewaySrc.indexOf(
+      "function deliverResumeSyntheticOrBuffer",
+    );
+    expect(start, "deliverResumeSyntheticOrBuffer helper missing").toBeGreaterThan(0);
+    const body = gatewaySrc.slice(start, start + 900);
+    // Gate consulted...
+    expect(body).toMatch(/decideInboundDelivery\(/);
+    // ...and the buffer-until-idle branch buffers BEFORE any send.
+    const gateIdx = body.indexOf("decideInboundDelivery(");
+    const bufferIdx = body.indexOf("pendingInboundBuffer.push(");
+    const sendIdx = body.indexOf("ipcServer.sendToAgent(");
+    expect(gateIdx).toBeGreaterThan(0);
+    expect(bufferIdx, "must buffer in the helper").toBeGreaterThan(gateIdx);
+    expect(sendIdx, "must still deliver in the idle branch").toBeGreaterThan(gateIdx);
+    expect(bufferIdx, "buffer-until-idle branch precedes the send branch").toBeLessThan(sendIdx);
+  });
+
+  it("no resume synthetic is sent via a raw ungated ipcServer.sendToAgent", () => {
+    // Every *_approved/_denied, secret_provided/_declined,
+    // vault_save_completed/_failed/_discarded resume must route through
+    // the helper. A raw sendToAgent of one of these named inbound vars
+    // would reintroduce the mid-turn strand. The ONLY ipcServer.sendToAgent
+    // referencing these synthetics should be inside the helper itself
+    // (which sends a generic `synthetic` param), so none of the named
+    // resume vars may appear as a raw sendToAgent argument.
+    const rawResumeSends = [
+      ...gatewaySrc.matchAll(
+        /ipcServer\.sendToAgent\([^,]+,\s*(denyInbound|discardInbound|failInbound|okInbound)\)/g,
+      ),
+    ];
+    expect(
+      rawResumeSends.map((m) => m[1]),
+      "resume synthetic sent via raw sendToAgent — must use deliverResumeSyntheticOrBuffer",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Approval cards (vault grant approve/deny, secret provide/decline, vault save) inject a synthetic "resume your task" inbound to wake the waiting agent. Lately agents **get the grant but don't continue** — they sit idle until the operator manually pokes them. This fixes the root cause.

## Root cause — mid-turn delivery strand

The resume inject did a raw `ipcServer.sendToAgent` and only buffered on `delivered=false` (bridge disconnected). But approvals routinely land **while the agent's grant-requesting turn is still finishing**: the socket write succeeds (`delivered=true`) yet claude is mid-turn, so the channel notification is typed into its TUI composer and **stranded by the turn-completion race** (the documented #1556 lawgpt-composer wedge). `delivered=true` → the pending-inbound buffer never rescues it → the agent goes idle.

**Live proof** (clerk `hotdoc/credentials`, 2026-06-13):
```
22:10:57.098  vault_grant_approved injection delivered=true
22:10:57.277  turn_end #14081 finalAnswer=true   ← still mid-turn (ends 179ms later)
22:12:57.713  inbound msg=14085 → turnStart       ← only resumes on operator poke, 2m later
```

Normal Telegram inbounds are already turn-gated (`decideInboundDelivery`, the #1556 fix). The **synthetic-resume paths never got that gate**.

**Why it bites "lately":** Telegram-ID auto-unlock + cached passphrase now mint the grant while the requesting turn is still open, so approvals land mid-turn far more often. The gap was always there; the timing change made it routine.

## Fix

Route all seven resume synthetics (`vault_grant_approved`/`denied`, `secret_provided`/`declined`, `vault_save_completed`/`failed`/`discarded`) through a new `deliverResumeSyntheticOrBuffer` helper that consults the **same** `decideInboundDelivery` gate as normal inbounds:

- **mid-turn → `buffer-until-idle`** — the existing turn-end drain (`releaseTurnBufferGate → drainBufferedIfAllowed`) and the idle-drain timer flush it the instant claude goes idle, where it lands cleanly as a fresh turn.
- **idle → deliver now**; **bridge-down → buffer** (unchanged #1150 behaviour).

Unlike the cron `inject_inbound` path (deliberately ungated — at-least-once replay), a one-shot resume must never strand, so it IS gated.

## Test plan

- [x] Updated the #1052 callsite contract pin (`vault-grant-auto-resume.test.ts`) to the helper
- [x] New `vault-resume-turn-gated.test.ts`: gate decision for a resume synthetic's shape (mid-turn → buffer, idle → deliver) + guard that no resume synthetic is sent via a raw ungated `sendToAgent`
- [x] `vault-grant-inbound-builders`, `inbound-delivery-gate` suites green
- [x] Full `bun test`: **0 non-UAT failures**; `tsc --noEmit`, `check-plugin-references`, `check-bot-api-wrapping` clean

## Risk

Low. Reuses the battle-tested #1556 gate + existing drain machinery; the change is "buffer instead of strand" when mid-turn, which is strictly safer than today. Idle and bridge-down behaviour unchanged. Affects only the vault/secret resume wake-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)