### PR TITLE
feat(whoami): let an agent see its own sandbox (config whoami + MCP tool + /whoami)

### DIFF
--- a/src/cli/agent-config-whoami.test.ts
+++ b/src/cli/agent-config-whoami.test.ts
@@ -40,9 +40,12 @@ describe("buildWhoami", () => {
     expect(buildWhoami(CFG, "plain").tier).toBe("standard");
   });
 
-  it("surfaces the agent's resolved tools (allow + deny)", () => {
+  it("surfaces the agent's RESOLVED tools (cascade-merged, not the raw slice)", () => {
     const w = buildWhoami(CFG, "clerk");
-    expect(w.tools.allow).toContain("Edit(/state/x.ts)");
+    expect(w.tools.allow).toContain("Edit(/state/x.ts)"); // agent's own
+    // defaults.tools.allow=["Read"] is merged in — proves whoami reads the
+    // resolved cascade (resolveAgentConfig), not the raw config.agents slice.
+    expect(w.tools.allow).toContain("Read");
     expect(w.tools.deny).toContain("Bash(rm:*)");
   });
 

--- a/src/cli/agent-config-whoami.test.ts
+++ b/src/cli/agent-config-whoami.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for `buildWhoami` — the agent's legible "what am I allowed to do"
+ * view. Pins the access-model contracts: drift-free (computed from the SAME
+ * enforcement functions), resolved-not-raw config, and NO secret values.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildWhoami } from "./agent-config.js";
+import { checkAclByAgent } from "../vault/broker/acl.js";
+import type { SwitchroomConfig } from "../config/schema.js";
+
+const CFG = {
+  switchroom: { agents_dir: "/tmp/agents" },
+  telegram: { forum_chat_id: "0" },
+  defaults: { tools: { allow: ["Read"] } },
+  profiles: {},
+  hostd: { config_edit_enabled: true },
+  memory: { backend: "hindsight" },
+  agents: {
+    clerk: {
+      admin: true,
+      model: "sonnet",
+      description: "desk assistant",
+      tools: { allow: ["Edit(/state/x.ts)"], deny: ["Bash(rm:*)"] },
+      mcp_servers: { hindsight: {}, "agent-config": {} },
+      skills: ["calendar"],
+      secrets: ["clerk/api-key"],
+      bot_token: "vault:clerk-bot-token",
+      schedule: [{ name: "p", at: "0 * * * *" }],
+    },
+    overlord: { root: true },
+    plain: {},
+  },
+} as unknown as SwitchroomConfig;
+
+describe("buildWhoami", () => {
+  it("reports tier from admin/root flags", () => {
+    expect(buildWhoami(CFG, "clerk").tier).toBe("admin");
+    expect(buildWhoami(CFG, "overlord").tier).toBe("root");
+    expect(buildWhoami(CFG, "plain").tier).toBe("standard");
+  });
+
+  it("surfaces the agent's resolved tools (allow + deny)", () => {
+    const w = buildWhoami(CFG, "clerk");
+    expect(w.tools.allow).toContain("Edit(/state/x.ts)");
+    expect(w.tools.deny).toContain("Bash(rm:*)");
+  });
+
+  it("lists MCP servers and skills", () => {
+    const w = buildWhoami(CFG, "clerk");
+    expect(w.mcpServers).toEqual(expect.arrayContaining(["hindsight", "agent-config"]));
+    expect(w.skills).toContain("calendar");
+  });
+
+  it("reports vault KEY NAMES (from secrets[] and vault: refs), never values", () => {
+    const w = buildWhoami(CFG, "clerk");
+    const keys = w.vault.map((v) => v.key);
+    expect(keys).toContain("clerk/api-key"); // from secrets[]
+    expect(keys).toContain("clerk-bot-token"); // from the `vault:` ref, prefix stripped
+    // No secret VALUE / raw `vault:` ref leaks anywhere in the view.
+    const json = JSON.stringify(w);
+    expect(json).not.toContain("vault:clerk-bot-token");
+  });
+
+  it("vault.readable is sourced from the SAME enforcer (anti-drift)", () => {
+    const w = buildWhoami(CFG, "clerk");
+    for (const entry of w.vault) {
+      expect(entry.readable).toBe(checkAclByAgent(CFG, "clerk", entry.key).allow);
+    }
+  });
+
+  it("reports powers from config (admin/root/config-edit/cross-agent)", () => {
+    expect(buildWhoami(CFG, "clerk").powers).toEqual({
+      admin: true,
+      root: false,
+      configEdit: true,
+      crossAgentHostVerbs: true,
+    });
+    expect(buildWhoami(CFG, "plain").powers).toEqual({
+      admin: false,
+      root: false,
+      configEdit: true, // config-edit is a fleet flag, independent of admin
+      crossAgentHostVerbs: false,
+    });
+  });
+
+  it("carries persona, model, schedule count, memory backend", () => {
+    const w = buildWhoami(CFG, "clerk");
+    expect(w.persona).toBe("desk assistant");
+    expect(w.model).toBe("sonnet");
+    expect(w.scheduleCount).toBe(1);
+    expect(w.memoryBackend).toBe("hindsight");
+  });
+
+  it("throws for an unknown agent", () => {
+    expect(() => buildWhoami(CFG, "nope")).toThrow(/not defined/);
+  });
+});

--- a/src/cli/agent-config.ts
+++ b/src/cli/agent-config.ts
@@ -31,6 +31,8 @@ import {
 } from "node:fs";
 import { withConfigError, getConfig } from "./helpers.js";
 import type { SwitchroomConfig } from "../config/schema.js";
+import { resolveAgentConfig } from "../config/merge.js";
+import { checkAclByAgent } from "../vault/broker/acl.js";
 
 // Per-agent audit path. We deliberately do NOT share one log file across
 // all agents — that would let any agent read every other agent's audit
@@ -229,6 +231,127 @@ export function scheduleLiveNote(agent: string): string {
         `Run \`switchroom agent restart ${agent}\` for this to take effect.`;
 }
 
+/**
+ * The legible "what am I allowed to do" view for one agent — the answer to
+ * the access-model's "an agent should be able to see its own sandbox" so it
+ * stops guessing and overreaching (reference/access-model.md, "Dead-ends
+ * breed workarounds").
+ *
+ * DRIFT-FREE BY CONSTRUCTION: every field is computed from the SAME
+ * operator-owned config + the SAME enforcement functions that actually gate
+ * each action — `resolveAgentConfig` (the resolved cascade the scaffold
+ * itself uses, NOT the raw `config.agents[x]` slice `config get` returns)
+ * and `checkAclByAgent` (the vault ACL enforcer). It never maintains a
+ * parallel hand-list that could drift into a comforting lie.
+ *
+ * Secret VALUES never appear — vault is reported as key NAMES + a readable
+ * boolean only.
+ */
+export interface WhoamiView {
+  name: string;
+  persona: string | null;
+  model: string | null;
+  tier: "root" | "admin" | "standard";
+  tools: { allow: string[]; deny: string[] };
+  mcpServers: string[];
+  skills: string[];
+  /** Vault keys this agent's config references, each with the ACL verdict. */
+  vault: { key: string; readable: boolean }[];
+  powers: {
+    admin: boolean;
+    root: boolean;
+    /** Whether agent-proposed config edits are enabled (hostd.config_edit_enabled). */
+    configEdit: boolean;
+    /** True when cross-agent host verbs (restart/logs/exec/doctor/update) are reachable. */
+    crossAgentHostVerbs: boolean;
+  };
+  scheduleCount: number;
+  memoryBackend: string | null;
+}
+
+/** Recursively collect `vault:<key>` references from a resolved config slice. */
+function collectVaultKeys(value: unknown, out: Set<string>): void {
+  if (typeof value === "string") {
+    if (value.startsWith("vault:")) out.add(value.slice("vault:".length));
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) collectVaultKeys(v, out);
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [k, v] of Object.entries(value)) {
+      // `secrets: [names]` is a declared-key list (names, never values).
+      if (k === "secrets" && Array.isArray(v)) {
+        for (const s of v) if (typeof s === "string") out.add(s);
+      } else {
+        collectVaultKeys(v, out);
+      }
+    }
+  }
+}
+
+/**
+ * Build the resolved {@link WhoamiView} for `agentName`. Pure over `config`
+ * — no broker round-trip, no disk read beyond the already-loaded config —
+ * so it works unchanged in-container (config is bind-mounted read-only) and
+ * unit-tests without fixtures. Throws if the agent isn't defined.
+ */
+export function buildWhoami(
+  config: SwitchroomConfig,
+  agentName: string,
+): WhoamiView {
+  const slice = config.agents?.[agentName];
+  if (!slice) throw new Error(`agent "${agentName}" not defined in switchroom.yaml`);
+  const resolved = resolveAgentConfig(config.defaults, config.profiles, slice) as Record<
+    string,
+    unknown
+  >;
+
+  const admin = resolved.admin === true || resolved.root === true;
+  const root = resolved.root === true;
+
+  const toolsBlock = (resolved.tools ?? {}) as { allow?: string[]; deny?: string[] };
+  const allow = [
+    ...(toolsBlock.allow ?? []),
+    ...((resolved.allowed_tools as string[] | undefined) ?? []),
+  ];
+  const deny = [
+    ...(toolsBlock.deny ?? []),
+    ...((resolved.disallowed_tools as string[] | undefined) ?? []),
+  ];
+
+  const mcpServers = Object.keys(
+    (resolved.mcp_servers as Record<string, unknown> | undefined) ?? {},
+  );
+  const skills = ((resolved.skills as string[] | undefined) ?? []).slice();
+
+  const vaultKeys = new Set<string>();
+  collectVaultKeys(resolved, vaultKeys);
+  const vault = [...vaultKeys]
+    .sort()
+    .map((key) => ({ key, readable: checkAclByAgent(config, agentName, key).allow }));
+
+  const configEdit = config.hostd?.config_edit_enabled === true;
+
+  const schedule = (resolved.schedule as unknown[] | undefined) ?? [];
+
+  return {
+    name: agentName,
+    persona: (resolved.description as string | undefined) ?? (resolved.persona as string | undefined) ?? null,
+    model: (resolved.model as string | undefined) ?? null,
+    tier: root ? "root" : admin ? "admin" : "standard",
+    tools: { allow, deny },
+    mcpServers,
+    skills,
+    vault,
+    powers: { admin, root, configEdit, crossAgentHostVerbs: admin },
+    scheduleCount: schedule.length,
+    memoryBackend:
+      ((config.memory as { backend?: string } | undefined)?.backend) ?? null,
+  };
+}
+
 function getAgentSlice(config: SwitchroomConfig, agent: string): unknown {
   const slice = config.agents?.[agent];
   if (!slice) {
@@ -292,6 +415,36 @@ export function registerAgentConfigCommands(program: Command): void {
         } catch (err) {
           process.stderr.write(`${(err as Error).message}\n`);
           appendAudit(agent, "config.get", { ...opts }, 1);
+          process.exit(1);
+        }
+      }),
+    );
+
+  // switchroom config whoami — the agent's own legible sandbox
+  config
+    .command("whoami")
+    .description("Emit what this agent is allowed to do (tools, MCP, vault key-names, powers) as JSON — its own sandbox, computed from live enforcement")
+    .option("--agent <name>", "Target agent (defaults to $SWITCHROOM_AGENT_NAME)")
+    .action(
+      withConfigError(async (opts: { agent?: string }) => {
+        let agent: string;
+        try {
+          agent = resolveTargetAgent(opts.agent);
+        } catch (err) {
+          process.stderr.write(`${(err as Error).message}\n`);
+          appendAudit(opts.agent ?? "<unknown>", "config.whoami", { ...opts }, 7);
+          process.exit(7);
+        }
+        const cfg = getConfig(program);
+        try {
+          // buildWhoami emits key NAMES + booleans only — no secret values —
+          // so no stripSecretValues pass is needed.
+          const view = buildWhoami(cfg, agent);
+          process.stdout.write(JSON.stringify(view) + "\n");
+          appendAudit(agent, "config.whoami", { ...opts }, 0);
+        } catch (err) {
+          process.stderr.write(`${(err as Error).message}\n`);
+          appendAudit(agent, "config.whoami", { ...opts }, 1);
           process.exit(1);
         }
       }),

--- a/src/mcp/agent-config/server.test.ts
+++ b/src/mcp/agent-config/server.test.ts
@@ -49,6 +49,7 @@ describe("TOOLS export", () => {
       "skill_remove",          // #1163 Phase 2
       "skill_remove_personal", // #1819 Phase 1
       "skill_search",          // #1819 Phase 3
+      "whoami",                // legibility — "see your own sandbox"
     ]);
   });
 
@@ -75,6 +76,15 @@ describe("dispatchTool — happy path", () => {
     // Ensure --agent was forwarded.
     const [, args] = spawnSyncMock.mock.calls[0]!;
     expect(args).toEqual(["config", "get", "--agent", "a"]);
+  });
+
+  it("whoami shells `config whoami` and parses the JSON view", () => {
+    okCall(JSON.stringify({ name: "a", tier: "admin", tools: { allow: [], deny: [] } }) + "\n");
+    const res = dispatchTool("whoami", { agent: "a" });
+    expect(res.isError).toBeFalsy();
+    expect(JSON.parse(res.content[0]!.text).tier).toBe("admin");
+    const [, args] = spawnSyncMock.mock.calls[0]!;
+    expect(args).toEqual(["config", "whoami", "--agent", "a"]);
   });
 
   it("cron_list / skill_list parse JSON", () => {

--- a/src/mcp/agent-config/server.ts
+++ b/src/mcp/agent-config/server.ts
@@ -1,8 +1,8 @@
 /**
  * agent-config MCP shim.
  *
- * Tiny stdio MCP server that exposes four read-only tools backed by
- * the corresponding `switchroom <cmd>` CLI subcommands. The shim
+ * Tiny stdio MCP server that exposes read-only + self-service config tools
+ * backed by the corresponding `switchroom <cmd>` CLI subcommands. The shim
  * re-exec's the CLI on every tool call so the audit-log row is
  * written from the same process tree as a direct CLI invocation and
  * the peer-cred-by-construction story holds — both run as the
@@ -99,6 +99,25 @@ export const TOOLS = [
       "Return the agent's merged switchroom config slice as JSON. " +
       "Read-only. Cross-agent reads are denied: if --agent doesn't match " +
       "$SWITCHROOM_AGENT_NAME (the agent's pinned identity), the call fails.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent: {
+          type: "string",
+          description:
+            "Target agent name. Optional — defaults to the env-pinned agent identity.",
+        },
+      },
+    },
+  },
+  {
+    name: "whoami",
+    description:
+      "See your own sandbox: the tools, MCP servers, vault key-NAMES (never " +
+      "values), skills, schedule and privileges (admin/root/config-edit) you " +
+      "actually have, as JSON — computed from live enforcement. Call this " +
+      "FIRST when you hit a permission wall, instead of guessing or asking. " +
+      "Read-only; defaults to your own identity.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -434,6 +453,10 @@ export function dispatchTool(
   switch (name) {
     case "config_get":
       cliArgs = buildArgs(["config", "get"], args);
+      parseMode = "json";
+      break;
+    case "whoami":
+      cliArgs = buildArgs(["config", "whoami"], args);
       parseMode = "json";
       break;
     case "cron_list":

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -18622,6 +18622,55 @@ bot.command('version', async ctx => {
 })
 
 
+// /whoami — the operator's view of THIS agent's sandbox (the same
+// `config whoami` the agent itself can call as an MCP tool, and the host CLI
+// exposes). Read-only, isAuthorizedSender-gated like /version — surfaces
+// tools / MCP / vault key-NAMES (never values) / powers so the operator can
+// see at a glance what this agent is authorized for.
+bot.command('whoami', async ctx => {
+  if (!isAuthorizedSender(ctx)) return
+  try {
+    let raw: string
+    try { raw = switchroomExecCombined(['config', 'whoami'], 10000) }
+    catch (err: unknown) { raw = (err as any).stdout ?? (err as any).message ?? 'whoami failed' }
+    const trimmed = stripAnsi(raw).trim()
+    let card: string
+    try { card = formatWhoamiCard(JSON.parse(trimmed.split('\n').pop() ?? trimmed)) }
+    catch { card = preBlock(formatSwitchroomOutput(trimmed || 'whoami: no output')) }
+    await switchroomReply(ctx, card, { html: true })
+  } catch (err: unknown) {
+    await switchroomReply(ctx, `<b>whoami failed:</b>\n${preBlock(formatSwitchroomOutput((err as any).message ?? 'unknown error'))}`, { html: true })
+  }
+})
+
+/** Compact HTML card from the `config whoami` JSON view. Names/booleans only. */
+function formatWhoamiCard(v: {
+  name?: string; persona?: string | null; model?: string | null; tier?: string;
+  tools?: { allow?: string[]; deny?: string[] }; mcpServers?: string[]; skills?: string[];
+  vault?: { key: string; readable: boolean }[];
+  powers?: { admin?: boolean; root?: boolean; configEdit?: boolean; crossAgentHostVerbs?: boolean };
+  scheduleCount?: number; memoryBackend?: string | null;
+}): string {
+  const esc = escapeHtmlForTg
+  const yn = (b?: boolean) => (b ? '✓' : '✗')
+  const lines: string[] = []
+  lines.push(`👤 <b>${esc(v.name ?? '?')}</b> · ${esc(v.tier ?? 'standard')}`)
+  if (v.persona) lines.push(esc(v.persona))
+  if (v.model) lines.push(`Model: ${esc(v.model)}`)
+  const allow = v.tools?.allow ?? []
+  lines.push(`Tools: ${allow.length ? esc(allow.slice(0, 8).join(', ')) + (allow.length > 8 ? ` …(+${allow.length - 8})` : '') : '—'}`)
+  if ((v.tools?.deny ?? []).length) lines.push(`Denied: ${esc((v.tools!.deny!).join(', '))}`)
+  if ((v.mcpServers ?? []).length) lines.push(`MCP: ${esc(v.mcpServers!.join(', '))}`)
+  if ((v.skills ?? []).length) lines.push(`Skills: ${esc(v.skills!.join(', '))}`)
+  if ((v.vault ?? []).length) {
+    lines.push(`Vault keys (names only): ${v.vault!.map(k => `${esc(k.key)} ${yn(k.readable)}`).join(', ')}`)
+  }
+  const p = v.powers ?? {}
+  lines.push(`Powers: admin ${yn(p.admin)} · root ${yn(p.root)} · config-edit ${yn(p.configEdit)} · cross-agent verbs ${yn(p.crossAgentHostVerbs)}`)
+  lines.push(`Schedule: ${v.scheduleCount ?? 0} cron · Memory: ${esc(v.memoryBackend ?? 'none')}`)
+  return lines.join('\n')
+}
+
 bot.command('commands', async ctx => {
   if (!isAuthorizedSender(ctx)) return
   await switchroomReply(ctx, buildSwitchroomHelpText(getMyAgentName()), { html: true })

--- a/telegram-plugin/welcome-text.ts
+++ b/telegram-plugin/welcome-text.ts
@@ -270,7 +270,7 @@ export const switchroomHelpCommandNames = [
   "agents", "agentstart", "stop", "restart", "logs", "memory",
   // Auth & config — consolidated onto the `/auth` dashboard.
   "auth", "model",
-  "topics", "update", "version",
+  "topics", "update", "version", "whoami",
   "permissions", "grant", "dangerous", "vault", "doctor",
   "commands",
   // Note: "reconcile" is a deprecated alias still handled as a bot command
@@ -374,6 +374,7 @@ export function switchroomHelpText(agentName: string): string {
     `<code>/update</code> — dry-run plan; <code>/update apply</code> — actually pull images, reconcile, restart`,
     `<code>/restart [name|all]</code> — bounce agent (drains in-flight turn by default)`,
     `<code>/version</code> — show versions + running agent health summary`,
+    `<code>/whoami</code> — this agent's sandbox: tools, MCP, vault key-names, powers`,
     ``,
     `<b>Auth &amp; config</b>`,
     `<code>/auth</code> — auth status or actions`,


### PR DESCRIPTION
## Summary

The access-model's "Dead-ends breed workarounds": an agent that can't **see** what it's authorized for escalates to the operator or improvises around the gate — both erode the leash. This adds the legible **self-knowledge** surface, **on demand**, across all three idiomatic consumers.

- **NEW `buildWhoami(config, agent)`** (`src/cli/agent-config.ts`) — the resolved "what am I allowed to do" view: tier, persona, model, resolved tools allow/deny, MCP servers, skills, **vault KEY-NAMES (never values)** each with the ACL verdict, powers (admin/root/config-edit/cross-agent host verbs), schedule count, memory backend. **DRIFT-FREE**: every field comes from the SAME enforcement functions that gate each action — `resolveAgentConfig` (resolved cascade, not the raw slice `config get` returns) and `checkAclByAgent` (the vault ACL enforcer). Pure over config → works **in-container**, no broker round-trip.
- **`switchroom config whoami`** CLI verb (sibling of `config get`).
- **`whoami` MCP tool** on the agent-config server (already scaffolded into every agent) — description tells the agent to call it FIRST when it hits a wall.
- **operator Telegram `/whoami`** (read-only, like `/version`) with a compact card; documented in `/commands` (typable, not in the trimmed mobile menu — same posture as `/doctor`, `/vault`).

**Surface form is on-demand, not a boot-injected context block** (token discipline — a standing block taxes every turn for data needed occasionally).

This is item ① of the admin-agent self-management plan.

## Access-model
Read-only; computes from operator-owned config; **secret VALUES never appear** (key names + booleans only); cross-agent reads denied (exit 7, env-pinned identity).

## Test plan
- [x] `agent-config-whoami` (8) — incl. the **drift contract** (`vault.readable === checkAclByAgent(...)`) and a **no-secret-value-leak** assertion; tier/tools/mcp/vault/powers coverage.
- [x] MCP server (whoami dispatch + tool-list pin), welcome-text (61), full plugin (4027), src cli/mcp (842) green.
- [x] `npm run lint` clean; `config whoami --help` registers; tsc exit 0.

## Risk
Low — read-only, additive; no enforcement change; rides the already-wired agent-config server (scaffold unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)