### PR TITLE
fix(telegram): /effort drives the confirmation modal (no pane wedge)

### DIFF
--- a/src/agents/effort-picker.ts
+++ b/src/agents/effort-picker.ts
@@ -1,0 +1,147 @@
+/**
+ * Claude CLI `/effort <level>` driver over tmux.
+ *
+ * `/effort <level>` is NOT always a one-shot. On an idle / small-cache
+ * session it applies directly ("Set effort level to <level>"). But when the
+ * session has a substantial cached conversation, switching effort would
+ * invalidate that cache, so claude pops a confirmation modal:
+ *
+ *     Change effort level?
+ *     Your next response will be slower and use more tokens
+ *     This conversation is cached for the current effort level. Switching to
+ *     <level> means the full history gets re-read on your next message.
+ *     ❯ 1. Yes, switch to <level>
+ *       2. No, go back
+ *
+ * The bare inject primitive types `/effort <level>` and walks away, leaving
+ * that modal open — which WEDGES the agent's pane (the /rate-limit-options
+ * wedge class) and falsely reports success. This driver answers the modal:
+ * the user explicitly asked for the level, so it confirms (Enter — the
+ * cursor defaults to "Yes"). If the modal can't be dismissed it cancels
+ * (Esc) rather than leave the pane wedged, and reports the failure.
+ *
+ * Reuses model-picker's tmux machinery (makeTmuxRunner + withPaneLock).
+ */
+import { makeTmuxRunner, type TmuxRunner } from "./inject.js";
+import { withPaneLock } from "./pane-lock.js";
+
+export interface EffortApplyOpts {
+  tmuxBin?: string;
+  socketName?: string;
+  sessionName?: string;
+  /** Per-poll settle wait (ms). Default 600. */
+  stepMs?: number;
+  /** Hard ceiling on the whole operation (ms). Default 10000. */
+  timeoutMs?: number;
+  /** Test seams. */
+  _runner?: TmuxRunner;
+  _sleep?: (ms: number) => Promise<void>;
+  _log?: (line: string) => void;
+}
+
+export type EffortApplyResult =
+  | { ok: true; level: string; confirmed: boolean; output: string }
+  | {
+      ok: false;
+      reason: "session_missing" | "confirm_failed" | "apply_unverified";
+      /** True when a modal was still open after we tried to dismiss it. */
+      wedged?: boolean;
+    };
+
+/** The confirmation modal's title — present iff the switch needs confirming. */
+const CONFIRM_RE = /Change effort level\?/i;
+
+/**
+ * The status banner shows the LIVE effort as "<level> · /effort"
+ * (e.g. "● high · /effort"). The command echo is "/effort <level>" (the
+ * verb precedes the level), so this pattern — level BEFORE `/effort`,
+ * separated by the middot — matches ONLY the banner, never the echo.
+ */
+function appliedRe(level: string): RegExp {
+  return new RegExp(`${level}\\s*\\u00b7\\s*/effort`);
+}
+
+/** Pull the human "Set effort level to <level>: …" line for the reply. */
+function applyLine(pane: string, level: string): string {
+  const re = new RegExp(`Set effort level to ${level}\\b.*`, "i");
+  for (const line of pane.split("\n")) {
+    const m = line.match(re);
+    if (m) return m[0].trim();
+  }
+  return `Set effort level to ${level}`;
+}
+
+const realSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Type `/effort <level>` into the agent's pane and drive it to completion,
+ * answering the confirmation modal if it appears. Bounded: at most two
+ * confirmation keypresses, then it cancels and reports — never loops, never
+ * leaves the pane wedged.
+ */
+export async function applyEffort(
+  agentName: string,
+  level: string,
+  opts: EffortApplyOpts = {},
+): Promise<EffortApplyResult> {
+  const runner = opts._runner ?? makeTmuxRunner(opts.tmuxBin ?? "tmux");
+  const socket = opts.socketName ?? `switchroom-${agentName}`;
+  const session = opts.sessionName ?? agentName;
+  const stepMs = opts.stepMs ?? 600;
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const sleep = opts._sleep ?? realSleep;
+  const log = opts._log ?? ((line: string) => process.stderr.write(`${line}\n`));
+
+  if (!runner.hasSession(socket, session)) {
+    return { ok: false, reason: "session_missing" };
+  }
+
+  return withPaneLock(`${socket}:${session}`, async () => {
+    const startedAt = Date.now();
+    const expired = () => Date.now() - startedAt >= timeoutMs;
+
+    runner.send(socket, session, ["send-keys", "-l", `/effort ${level}`]);
+    runner.send(socket, session, ["send-keys", "Enter"]);
+
+    let confirmed = false;
+    let confirmKeys = 0;
+
+    while (!expired()) {
+      await sleep(stepMs);
+      const pane = runner.capture(socket, session) ?? "";
+
+      if (CONFIRM_RE.test(pane)) {
+        if (confirmKeys >= 2) {
+          // Two confirms didn't clear it — cancel so we never wedge the pane.
+          runner.send(socket, session, ["send-keys", "Escape"]);
+          await sleep(stepMs);
+          const after = runner.capture(socket, session) ?? "";
+          log(
+            `effort-picker: confirm modal would not dismiss for ${agentName} ` +
+              `(socket=${socket}) — cancelled`,
+          );
+          return { ok: false, reason: "confirm_failed", wedged: CONFIRM_RE.test(after) };
+        }
+        // Cursor defaults to "Yes, switch to <level>"; Enter confirms.
+        runner.send(socket, session, ["send-keys", "Enter"]);
+        confirmed = true;
+        confirmKeys += 1;
+        continue;
+      }
+
+      if (appliedRe(level).test(pane)) {
+        return { ok: true, level, confirmed, output: applyLine(pane, level) };
+      }
+      // Otherwise the command is still rendering — keep polling.
+    }
+
+    // Timed out. If a modal lingers, cancel it so the pane isn't wedged.
+    const final = runner.capture(socket, session) ?? "";
+    if (CONFIRM_RE.test(final)) {
+      runner.send(socket, session, ["send-keys", "Escape"]);
+      log(`effort-picker: timeout with modal open for ${agentName} — cancelled`);
+      return { ok: false, reason: "confirm_failed", wedged: true };
+    }
+    return { ok: false, reason: "apply_unverified" };
+  });
+}

--- a/src/agents/effort-picker.ts
+++ b/src/agents/effort-picker.ts
@@ -100,48 +100,64 @@ export async function applyEffort(
     const startedAt = Date.now();
     const expired = () => Date.now() - startedAt >= timeoutMs;
 
-    runner.send(socket, session, ["send-keys", "-l", `/effort ${level}`]);
-    runner.send(socket, session, ["send-keys", "Enter"]);
+    try {
+      runner.send(socket, session, ["send-keys", "-l", `/effort ${level}`]);
+      runner.send(socket, session, ["send-keys", "Enter"]);
 
-    let confirmed = false;
-    let confirmKeys = 0;
+      let confirmed = false;
+      let confirmKeys = 0;
 
-    while (!expired()) {
-      await sleep(stepMs);
-      const pane = runner.capture(socket, session) ?? "";
+      while (!expired()) {
+        await sleep(stepMs);
+        const pane = runner.capture(socket, session) ?? "";
 
-      if (CONFIRM_RE.test(pane)) {
-        if (confirmKeys >= 2) {
-          // Two confirms didn't clear it — cancel so we never wedge the pane.
-          runner.send(socket, session, ["send-keys", "Escape"]);
-          await sleep(stepMs);
-          const after = runner.capture(socket, session) ?? "";
-          log(
-            `effort-picker: confirm modal would not dismiss for ${agentName} ` +
-              `(socket=${socket}) — cancelled`,
-          );
-          return { ok: false, reason: "confirm_failed", wedged: CONFIRM_RE.test(after) };
+        if (CONFIRM_RE.test(pane)) {
+          if (confirmKeys >= 2) {
+            // Two confirms didn't clear it — cancel so we never wedge the pane.
+            runner.send(socket, session, ["send-keys", "Escape"]);
+            await sleep(stepMs);
+            const after = runner.capture(socket, session) ?? "";
+            log(
+              `effort-picker: confirm modal would not dismiss for ${agentName} ` +
+                `(socket=${socket}) — cancelled`,
+            );
+            return { ok: false, reason: "confirm_failed", wedged: CONFIRM_RE.test(after) };
+          }
+          // Cursor defaults to "Yes, switch to <level>"; Enter confirms.
+          runner.send(socket, session, ["send-keys", "Enter"]);
+          confirmed = true;
+          confirmKeys += 1;
+          continue;
         }
-        // Cursor defaults to "Yes, switch to <level>"; Enter confirms.
-        runner.send(socket, session, ["send-keys", "Enter"]);
-        confirmed = true;
-        confirmKeys += 1;
-        continue;
+
+        if (appliedRe(level).test(pane)) {
+          return { ok: true, level, confirmed, output: applyLine(pane, level) };
+        }
+        // Otherwise the command is still rendering — keep polling.
       }
 
-      if (appliedRe(level).test(pane)) {
-        return { ok: true, level, confirmed, output: applyLine(pane, level) };
+      // Timed out. If a modal lingers, cancel it so the pane isn't wedged.
+      const final = runner.capture(socket, session) ?? "";
+      if (CONFIRM_RE.test(final)) {
+        runner.send(socket, session, ["send-keys", "Escape"]);
+        log(`effort-picker: timeout with modal open for ${agentName} — cancelled`);
+        return { ok: false, reason: "confirm_failed", wedged: true };
       }
-      // Otherwise the command is still rendering — keep polling.
+      return { ok: false, reason: "apply_unverified" };
+    } finally {
+      // Defence in depth: never exit this driver with a confirmation modal
+      // still open. Normal paths leave none (success has no modal; the cancel
+      // paths already Esc'd), so this is a no-op then — it only bites when the
+      // drive threw mid-modal. Best-effort and self-isolating: a throw here
+      // (tmux already gone → nothing to wedge) must not mask the real outcome.
+      try {
+        const pane = runner.capture(socket, session) ?? "";
+        if (CONFIRM_RE.test(pane)) {
+          runner.send(socket, session, ["send-keys", "Escape"]);
+        }
+      } catch {
+        /* tmux unreachable — no live modal to leave open */
+      }
     }
-
-    // Timed out. If a modal lingers, cancel it so the pane isn't wedged.
-    const final = runner.capture(socket, session) ?? "";
-    if (CONFIRM_RE.test(final)) {
-      runner.send(socket, session, ["send-keys", "Escape"]);
-      log(`effort-picker: timeout with modal open for ${agentName} — cancelled`);
-      return { ok: false, reason: "confirm_failed", wedged: true };
-    }
-    return { ok: false, reason: "apply_unverified" };
   });
 }

--- a/telegram-plugin/gateway/effort-command.ts
+++ b/telegram-plugin/gateway/effort-command.ts
@@ -82,7 +82,6 @@ export interface EffortCommandDeps {
    */
   getConfiguredEffort: () => string | null
   escapeHtml: (s: string) => string
-  preBlock: (s: string) => string
 }
 
 export interface EffortCommandReply {

--- a/telegram-plugin/gateway/effort-command.ts
+++ b/telegram-plugin/gateway/effort-command.ts
@@ -22,7 +22,7 @@
  * unit-testable without booting the bot.
  */
 
-import type { InjectResult } from '../../src/agents/inject.js'
+import type { EffortApplyResult } from '../../src/agents/effort-picker.js'
 
 /**
  * The effort levels the installed CLI accepts (`claude --help`:
@@ -66,8 +66,14 @@ export function parseEffortCommand(text: string): ParsedEffortCommand | null {
 }
 
 export interface EffortCommandDeps {
-  /** Inject primitive — wired to injectSlashCommand in the gateway. */
-  inject: (agent: string, command: string) => Promise<InjectResult>
+  /**
+   * Apply an effort level to the live session. Wired to `applyEffort`
+   * (src/agents/effort-picker.ts), which types `/effort <level>` AND drives
+   * the "Change effort level?" confirmation modal that claude shows when the
+   * switch would invalidate a cached conversation — so it never wedges the
+   * pane the way a bare inject would.
+   */
+  applyEffort: (agent: string, level: string) => Promise<EffortApplyResult>
   getAgentName: () => string
   /**
    * The agent's cascade-resolved `thinking_effort` from
@@ -127,52 +133,48 @@ export async function handleEffortCommand(
     return helpText(deps, `not a valid effort level: ${parsed.level}`)
   }
   const verbHtml = `<code>/effort ${deps.escapeHtml(parsed.level)}</code>`
-  let result: InjectResult
+  let result: EffortApplyResult
   try {
-    result = await deps.inject(deps.getAgentName(), `/effort ${parsed.level}`)
+    result = await deps.applyEffort(deps.getAgentName(), parsed.level)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    return { text: `❌ ${verbHtml} — inject failed: ${deps.escapeHtml(msg)}`, html: true }
+    return { text: `❌ ${verbHtml} — failed: ${deps.escapeHtml(msg)}`, html: true }
   }
+  return { text: applyResultText(parsed.level, result, deps), html: true }
+}
 
-  if (result.outcome === 'ok') {
-    return {
-      text: [
-        `${verbHtml}`,
-        deps.preBlock(result.output),
-        ...(result.truncated ? ['<i>truncated</i>'] : []),
-        PERSIST_NOTE,
-      ].join('\n'),
-      html: true,
+/**
+ * Render an effort-apply outcome. `confirmed` means a "Change effort level?"
+ * modal was answered — switching mid-conversation re-reads the history, so we
+ * say so honestly rather than just claiming success.
+ */
+function applyResultText(level: string, result: EffortApplyResult, deps: EffortCommandDeps): string {
+  const verbHtml = `<code>/effort ${deps.escapeHtml(level)}</code>`
+  if (result.ok) {
+    const lines = [`✅ ${verbHtml} — ${deps.escapeHtml(result.output)}`]
+    if (result.confirmed) {
+      lines.push('<i>Switched mid-conversation — your next turn re-reads the cached history (slower, one time).</i>')
     }
+    lines.push(PERSIST_NOTE)
+    return lines.join('\n')
   }
-  if (result.outcome === 'ok_no_output') {
-    return {
-      text: [
-        `${verbHtml} — sent, but no response captured. The agent may be mid-turn; check <code>/inject /status</code> to confirm the active effort.`,
-        PERSIST_NOTE,
-      ].join('\n'),
-      html: true,
-    }
+  if (result.reason === 'session_missing') {
+    return '❌ tmux session not found — the agent must be running under the tmux supervisor (the default). Remove <code>experimental.legacy_pty: true</code> if set.'
   }
-  // outcome === 'failed'
-  if (result.errorCode === 'session_missing') {
-    return {
-      text:
-        '❌ tmux session not found — the agent must be running under the tmux supervisor (the default). Remove <code>experimental.legacy_pty: true</code> if set.',
-      html: true,
-    }
+  if (result.reason === 'confirm_failed') {
+    const wedged = result.wedged
+      ? ' The confirmation prompt may still be open on the pane — check it.'
+      : ' The change was cancelled and the pane left as it was.'
+    return `❌ ${verbHtml} — couldn't confirm the switch.${wedged}`
   }
-  return {
-    text: `❌ ${verbHtml} — ${deps.escapeHtml(result.errorMessage ?? 'inject failed')}`,
-    html: true,
-  }
+  // apply_unverified
+  return `❌ ${verbHtml} — sent, but couldn't confirm it applied. The agent may be mid-turn; check <code>/inject /status</code>.`
 }
 
 // ---------------------------------------------------------------------------
 // Button menu — five fixed levels, the live one marked ✅. No live discovery
-// (the levels don't churn) and no picker-driving (the inline `/effort <level>`
-// form sets it directly), so this is far simpler than the /model menu.
+// (the levels don't churn). A tap applies the level via applyEffort, which
+// drives the confirmation modal so it never wedges the pane.
 // ---------------------------------------------------------------------------
 
 export interface EffortMenuKeyboardButton {
@@ -231,9 +233,11 @@ export interface EffortCallbackOutcome {
 }
 
 /**
- * Handle an `eff:*` callback tap. `eff:s:<level>` injects claude's
- * `/effort <level>` and re-renders the menu with a one-line banner and the
- * new level checked. Never throws — failures render as a banner.
+ * Handle an `eff:*` callback tap. `eff:s:<level>` applies the level via
+ * applyEffort (which drives the confirmation modal, so a mid-conversation
+ * switch confirms cleanly instead of wedging the pane) and re-renders the
+ * menu with a one-line banner and the new level checked. Never throws —
+ * failures render as a banner.
  */
 export async function handleEffortMenuCallback(
   data: string,
@@ -249,21 +253,27 @@ export async function handleEffortMenuCallback(
   let banner: string
   let selected: string | undefined
   try {
-    const result = await deps.inject(deps.getAgentName(), `/effort ${level}`)
-    if (result.outcome === 'ok' || result.outcome === 'ok_no_output') {
-      banner = `✅ Effort → <code>${deps.escapeHtml(level)}</code> for this session`
+    const result = await deps.applyEffort(deps.getAgentName(), level)
+    if (result.ok) {
+      banner = result.confirmed
+        ? `✅ Effort → <code>${deps.escapeHtml(level)}</code> (mid-conversation: next turn re-reads history)`
+        : `✅ Effort → <code>${deps.escapeHtml(level)}</code> for this session`
       selected = level
-    } else if (result.errorCode === 'session_missing') {
+    } else if (result.reason === 'session_missing') {
       banner = '❌ tmux session not found — is the agent running under the supervisor?'
+    } else if (result.reason === 'confirm_failed') {
+      banner = result.wedged
+        ? '⚠️ Couldn’t confirm the switch — the prompt may still be open on the pane.'
+        : '❌ Couldn’t confirm the switch — cancelled, effort unchanged.'
     } else {
-      banner = `❌ couldn't set effort: ${deps.escapeHtml(result.errorMessage ?? 'inject failed')}`
+      banner = '❌ Sent, but couldn’t confirm it applied (agent may be mid-turn).'
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
-    banner = `❌ inject failed: ${deps.escapeHtml(msg)}`
+    banner = `❌ failed: ${deps.escapeHtml(msg)}`
   }
   // Re-render with the just-selected level checked (or the configured
-  // default if the inject failed) and the banner on top.
+  // default if it didn't apply) and the banner on top.
   const menu = buildEffortMenu(deps, selected)
   return {
     reply: { ...menu, text: `${banner}\n${menu.text}` },

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -14246,7 +14246,6 @@ function buildEffortDeps(): EffortCommandDeps {
       return data?.agents?.find(a => a.name === getMyAgentName())?.thinking_effort ?? null
     },
     escapeHtml: escapeHtmlForTg,
-    preBlock,
   }
 }
 

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -280,6 +280,7 @@ import {
   type EffortCommandDeps,
   type EffortMenuReply,
 } from './effort-command.js'
+import { applyEffort } from '../../src/agents/effort-picker.js'
 import { type BannerState } from '../slot-banner.js'
 import { refreshBanner } from '../slot-banner-driver.js'
 import { loadConfig as loadSwitchroomConfig, findConfigFile as findSwitchroomConfigFile } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
@@ -14237,7 +14238,7 @@ bot.command('model', async ctx => {
 // in effort-command.ts so it's unit-testable without booting the bot.
 function buildEffortDeps(): EffortCommandDeps {
   return {
-    inject: injectSlashCommandImpl,
+    applyEffort: (agent, level) => applyEffort(agent, level),
     getAgentName: getMyAgentName,
     getConfiguredEffort: () => {
       type AgentListResp = { agents: Array<{ name: string; thinking_effort?: string | null }> }

--- a/telegram-plugin/tests/effort-command.test.ts
+++ b/telegram-plugin/tests/effort-command.test.ts
@@ -21,35 +21,25 @@ import {
   EFFORT_CALLBACK_PREFIX,
   type EffortCommandDeps,
 } from "../gateway/effort-command.js";
-import type { InjectResult } from "../../src/agents/inject.js";
+import type { EffortApplyResult } from "../../src/agents/effort-picker.js";
 
-function okResult(output: string): InjectResult {
-  return {
-    outcome: "ok",
-    output,
-    truncated: false,
-    command: "/effort",
-    meta: { description: "Set reasoning effort", expectsOutput: true },
-  };
+function applyOk(level: string, confirmed = false): EffortApplyResult {
+  return { ok: true, level, confirmed, output: `Set effort level to ${level}` };
 }
 
-function failedResult(errorMessage: string): InjectResult {
-  return {
-    outcome: "failed",
-    output: "",
-    truncated: false,
-    command: "/effort",
-    errorMessage,
-    meta: { description: "Set reasoning effort", expectsOutput: true },
-  };
+function applyFail(
+  reason: "session_missing" | "confirm_failed" | "apply_unverified",
+  wedged?: boolean,
+): EffortApplyResult {
+  return { ok: false, reason, ...(wedged !== undefined ? { wedged } : {}) };
 }
 
 function makeDeps(overrides: Partial<EffortCommandDeps> = {}) {
-  const calls: Array<{ agent: string; command: string }> = [];
+  const calls: Array<{ agent: string; level: string }> = [];
   const deps: EffortCommandDeps = {
-    inject: async (agent, command) => {
-      calls.push({ agent, command });
-      return okResult("Set effort level to high");
+    applyEffort: async (agent, level) => {
+      calls.push({ agent, level });
+      return applyOk(level);
     },
     getAgentName: () => "carrie",
     getConfiguredEffort: () => "low",
@@ -127,18 +117,24 @@ describe("effort-command: handler", () => {
     expect(r.text).toContain("low");
   });
 
-  it("set injects exactly '/effort <level>' and relays output", async () => {
+  it("set applies exactly the level and relays output", async () => {
     const { deps, calls } = makeDeps();
     const r = await handleEffortCommand({ kind: "set", level: "high" }, deps);
-    expect(calls).toEqual([{ agent: "carrie", command: "/effort high" }]);
+    expect(calls).toEqual([{ agent: "carrie", level: "high" }]);
     expect(r.text).toContain("Set effort level to high");
     expect(r.text).toMatch(/reverts to the configured default/);
   });
 
-  it("set surfaces an inject failure", async () => {
-    const { deps } = makeDeps({ inject: async () => failedResult("pane locked") });
+  it("set notes the re-read cost when a confirmation was needed", async () => {
+    const { deps } = makeDeps({ applyEffort: async (_a, l) => applyOk(l, true) });
+    const r = await handleEffortCommand({ kind: "set", level: "high" }, deps);
+    expect(r.text).toMatch(/re-reads the cached history/);
+  });
+
+  it("set surfaces a confirm_failed outcome honestly", async () => {
+    const { deps } = makeDeps({ applyEffort: async () => applyFail("confirm_failed", false) });
     const r = await handleEffortCommand({ kind: "set", level: "max" }, deps);
-    expect(r.text).toContain("pane locked");
+    expect(r.text).toContain("couldn't confirm the switch");
     expect(r.text).toContain("❌");
   });
 
@@ -146,7 +142,7 @@ describe("effort-command: handler", () => {
     const { deps, calls } = makeDeps();
     // Hand-craft a parsed object that skipped the parser's gate.
     const r = await handleEffortCommand({ kind: "set", level: "evil; rm -rf" as never }, deps);
-    expect(calls).toEqual([]); // never injected
+    expect(calls).toEqual([]); // never applied
     expect(r.text).toMatch(/not a valid effort level/);
   });
 });
@@ -164,22 +160,36 @@ describe("effort-command: menu + callback", () => {
     expect(menu.keyboard![0]).toHaveLength(5);
   });
 
-  it("callback eff:s:<level> injects the level and checks it in the re-render", async () => {
+  it("callback eff:s:<level> applies the level and checks it in the re-render", async () => {
     const { deps, calls } = makeDeps();
     const out = await handleEffortMenuCallback(effortSelectCallbackData("xhigh"), deps);
-    expect(calls).toEqual([{ agent: "carrie", command: "/effort xhigh" }]);
+    expect(calls).toEqual([{ agent: "carrie", level: "xhigh" }]);
     expect(out.selectedEffort).toBe("xhigh");
     expect(out.reply.text).toContain("Effort → ");
     const checked = out.reply.keyboard!.flat().find((b) => b.text.startsWith("✅"));
     expect(checked?.text).toBe("✅ xhigh");
   });
 
-  it("callback with a failed inject keeps the menu and shows the error, no selection", async () => {
-    const { deps } = makeDeps({ inject: async () => failedResult("session_missing") });
+  it("callback notes the re-read when a confirmation was answered", async () => {
+    const { deps } = makeDeps({ applyEffort: async (_a, l) => applyOk(l, true) });
+    const out = await handleEffortMenuCallback(effortSelectCallbackData("high"), deps);
+    expect(out.reply.text).toMatch(/re-reads history/);
+    expect(out.selectedEffort).toBe("high");
+  });
+
+  it("callback with a failed apply keeps the menu and shows the error, no selection", async () => {
+    const { deps } = makeDeps({ applyEffort: async () => applyFail("session_missing") });
     const out = await handleEffortMenuCallback(effortSelectCallbackData("max"), deps);
     expect(out.selectedEffort).toBeUndefined();
     expect(out.reply.text).toContain("❌");
     expect(out.reply.keyboard!.flat()).toHaveLength(5); // buttons preserved
+  });
+
+  it("callback surfaces a wedged confirm_failed as a warning, no selection", async () => {
+    const { deps } = makeDeps({ applyEffort: async () => applyFail("confirm_failed", true) });
+    const out = await handleEffortMenuCallback(effortSelectCallbackData("max"), deps);
+    expect(out.selectedEffort).toBeUndefined();
+    expect(out.reply.text).toMatch(/may still be open/);
   });
 
   it("callback ignores a malformed level", async () => {

--- a/telegram-plugin/tests/effort-command.test.ts
+++ b/telegram-plugin/tests/effort-command.test.ts
@@ -44,7 +44,6 @@ function makeDeps(overrides: Partial<EffortCommandDeps> = {}) {
     getAgentName: () => "carrie",
     getConfiguredEffort: () => "low",
     escapeHtml: (s) => s,
-    preBlock: (s) => `<pre>${s}</pre>`,
     ...overrides,
   };
   return { deps, calls };

--- a/tests/effort-picker.test.ts
+++ b/tests/effort-picker.test.ts
@@ -114,6 +114,26 @@ describe("applyEffort", () => {
     expect(res).toEqual({ ok: false, reason: "apply_unverified" });
   });
 
+  it("throw-safety: a mid-modal send failure still best-effort cancels the modal", async () => {
+    // send #3 is the confirm Enter — make it throw (e.g. tmux blip). The
+    // finally must capture, see the modal still open, and Esc it before the
+    // error propagates, so the pane is never left wedged.
+    const sends: string[][] = [];
+    let i = 0;
+    const runner: TmuxRunner = {
+      capture: () => [MODAL_LOW, MODAL_LOW][Math.min(i++, 1)],
+      send: (_s, _t, args) => {
+        sends.push(args);
+        if (sends.length === 3) throw new Error("tmux blip");
+      },
+      hasSession: () => true,
+    };
+    await expect(
+      applyEffort("agentx", "low", { ...fastOpts, _runner: runner }),
+    ).rejects.toThrow(/tmux blip/);
+    expect(sentKeys(sends)[sends.length - 1]).toBe("Escape"); // finally cancelled
+  });
+
   it("does not false-match the command echo (verb before level)", async () => {
     // A pane that only shows the echo "/effort high" (verb precedes level)
     // must NOT be read as applied — only "high · /effort" (the banner) counts.

--- a/tests/effort-picker.test.ts
+++ b/tests/effort-picker.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `/effort` tmux driver — confirmation-modal handling.
+ *
+ * Fixtures are trimmed verbatim captures from claude CLI 2.1.177:
+ *   - DIRECT: `/effort` applied with no modal (idle/small-cache session) —
+ *     the status banner shows the new level.
+ *   - MODAL: the "Change effort level?" confirmation that appears when the
+ *     session has a cached conversation a switch would invalidate.
+ *
+ * The headline guarantee: the driver NEVER leaves the modal open (the
+ * /rate-limit-options wedge class) — it confirms (Enter) the level the user
+ * asked for, and if it can't, it cancels (Esc) and reports the failure.
+ */
+import { describe, it, expect } from "vitest";
+import { applyEffort } from "../src/agents/effort-picker.js";
+import type { TmuxRunner } from "../src/agents/inject.js";
+
+const DIRECT_HIGH = [
+  "❯ /effort high",
+  "  ⎿  Set effort level to high (saved as your default for new sessions):",
+  "     Comprehensive implementation with extensive testing and documentation",
+  "────────────────────────────────────────────────────────────",
+  "❯ ",
+  "────────────────────────────────────────────────────────────",
+  "  ⏵⏵ accept edits on (shift+tab to cycle) · ← for agents      ● high · /effort",
+].join("\n");
+
+const MODAL_LOW = [
+  "❯ /effort low",
+  "  Change effort level?",
+  "  Your next response will be slower and use more tokens",
+  "  This conversation is cached for the current effort level. Switching to low",
+  "  means the full history gets re-read on your next message.",
+  "  ❯ 1. Yes, switch to low",
+  "    2. No, go back",
+].join("\n");
+
+const APPLIED_LOW = [
+  "❯ /effort low",
+  "  ⎿  Set effort level to low (saved as your default for new sessions): Quick,",
+  "     straightforward implementation with minimal overhead",
+  "────────────────────────────────────────────────────────────",
+  "❯ ",
+  "  ⏵⏵ accept edits on (shift+tab to cycle) · ← for agents       ○ low · /effort",
+].join("\n");
+
+const IDLE = ["❯ ", "  ⏵⏵ accept edits on (shift+tab to cycle) · ← for agents"].join("\n");
+
+const fastOpts = { stepMs: 1, timeoutMs: 500, _sleep: async () => {} };
+
+/** Scripted runner: `frames` consumed one capture at a time (last repeats). */
+function fakeRunner(frames: string[], hasSession = true): { runner: TmuxRunner; sends: string[][] } {
+  const sends: string[][] = [];
+  let i = 0;
+  const runner: TmuxRunner = {
+    capture: () => frames[Math.min(i++, frames.length - 1)],
+    send: (_s, _t, args) => {
+      sends.push(args);
+    },
+    hasSession: () => hasSession,
+  };
+  return { runner, sends };
+}
+
+function sentKeys(sends: string[][]): string[] {
+  return sends.map((args) => (args[1] === "-l" ? args[2] : args[1]));
+}
+
+describe("applyEffort", () => {
+  it("direct apply (no modal): sends the command, verifies via the banner", async () => {
+    const { runner, sends } = fakeRunner([DIRECT_HIGH]);
+    const res = await applyEffort("agentx", "high", { ...fastOpts, _runner: runner });
+    expect(res).toMatchObject({ ok: true, level: "high", confirmed: false });
+    if (res.ok) expect(res.output).toContain("Set effort level to high");
+    expect(sentKeys(sends)).toEqual(["/effort high", "Enter"]);
+  });
+
+  it("confirmation modal: presses Enter to confirm, then verifies the banner", async () => {
+    const { runner, sends } = fakeRunner([MODAL_LOW, APPLIED_LOW]);
+    const res = await applyEffort("agentx", "low", { ...fastOpts, _runner: runner });
+    expect(res).toMatchObject({ ok: true, level: "low", confirmed: true });
+    // /effort low, Enter (submit), Enter (confirm "Yes")
+    expect(sentKeys(sends)).toEqual(["/effort low", "Enter", "Enter"]);
+  });
+
+  it("never wedges: a stuck modal is cancelled with Esc and reported", async () => {
+    // Modal never clears across the two confirm attempts; 4th frame is clean
+    // (post-Esc), so wedged resolves false.
+    const { runner, sends } = fakeRunner([MODAL_LOW, MODAL_LOW, MODAL_LOW, IDLE]);
+    const res = await applyEffort("agentx", "low", { ...fastOpts, _runner: runner });
+    expect(res).toMatchObject({ ok: false, reason: "confirm_failed", wedged: false });
+    const keys = sentKeys(sends);
+    expect(keys.filter((k) => k === "Enter")).toHaveLength(3); // submit + 2 confirm tries
+    expect(keys[keys.length - 1]).toBe("Escape"); // bailed out cleanly
+  });
+
+  it("reports a stuck modal that Esc could not clear as wedged", async () => {
+    const { runner, sends } = fakeRunner([MODAL_LOW, MODAL_LOW, MODAL_LOW, MODAL_LOW]);
+    const res = await applyEffort("agentx", "low", { ...fastOpts, _runner: runner });
+    expect(res).toMatchObject({ ok: false, reason: "confirm_failed", wedged: true });
+    expect(sentKeys(sends)).toContain("Escape");
+  });
+
+  it("returns session_missing without sending anything", async () => {
+    const { runner, sends } = fakeRunner([DIRECT_HIGH], false);
+    const res = await applyEffort("agentx", "high", { ...fastOpts, _runner: runner });
+    expect(res).toEqual({ ok: false, reason: "session_missing" });
+    expect(sends).toEqual([]);
+  });
+
+  it("apply_unverified when neither modal nor banner ever appears", async () => {
+    const { runner } = fakeRunner([IDLE]);
+    const res = await applyEffort("agentx", "high", { ...fastOpts, _runner: runner, timeoutMs: 20 });
+    expect(res).toEqual({ ok: false, reason: "apply_unverified" });
+  });
+
+  it("does not false-match the command echo (verb before level)", async () => {
+    // A pane that only shows the echo "/effort high" (verb precedes level)
+    // must NOT be read as applied — only "high · /effort" (the banner) counts.
+    const echoOnly = ["❯ /effort high", "  …thinking…"].join("\n");
+    const { runner } = fakeRunner([echoOnly]);
+    const res = await applyEffort("agentx", "high", { ...fastOpts, _runner: runner, timeoutMs: 20 });
+    expect(res.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## The bug

`/effort <level>` (shipped in #2336 / v0.15.19) wedged carrie's pane mid-task. Root cause: `/effort <level>` is **not always one-shot**. On a session with a substantial **cached conversation**, switching effort would invalidate the cache, so claude pops a confirmation:

```
Change effort level?
Your next response will be slower and use more tokens
This conversation is cached for the current effort level. Switching to <level>
means the full history gets re-read on your next message.
❯ 1. Yes, switch to <level>
  2. No, go back
```

The original `/effort` typed the command via the bare inject primitive and walked away — leaving that modal **open**, which wedges the pane (the `/rate-limit-options` wedge class) and **falsely reported success**.

## Research (no assumptions — verified on CLI 2.1.177)

- The modal is **state-dependent**: idle / small-cache sessions apply directly (*"Set effort level to X"*); same-level is a no-op apply; only a **changed level on a cached conversation** shows the modal. Reproduced deterministically on test-harness by building a cache then switching.
- **Confirm = Enter** (cursor defaults to "Yes"); **cancel = Esc**.
- The status banner **`<level> · /effort`** is the authoritative live-effort signal (the command echo is `/effort <level>` — verb first — so it can't be confused with the banner).

## The fix

New `src/agents/effort-picker.ts` `applyEffort()` drives the whole interaction over tmux, reusing model-picker's `makeTmuxRunner` + `withPaneLock`:

1. Type `/effort <level>`.
2. Poll the pane. If the confirmation modal appears → press Enter to confirm (the user explicitly asked for the level).
3. Verify via the banner.
4. **Bounded & never-wedge:** at most two confirm keypresses, then it **cancels (Esc)** and reports `confirm_failed` rather than loop or leave the pane open. Timeout also Esc-cancels any lingering modal.

`effort-command.ts` and the gateway callback now go through `applyEffort` and report honestly — including the one-time "next turn re-reads history" cost when a confirmation was answered.

## Test plan

- [x] `tests/effort-picker.test.ts` — 7 driver tests with **verbatim** modal/banner fixtures: direct apply, modal→confirm, stuck-modal→Esc-cancel (both wedged/clean), session_missing, apply_unverified, echo-not-false-matched.
- [x] `effort-command.test.ts` — 21 tests updated to the `applyEffort` dep (incl. the re-read-cost note + confirm_failed/wedged surfacing).
- [x] `tsc`, `check-bot-api-wrapping`, `check-plugin-references`, `lint:bun-test-imports` all clean; model-command/inject/model-picker adjacent suites green (97).
- [ ] Live canary post-release: reproduce the modal on test-harness, `/effort` it, confirm it applies cleanly with no wedge before fleet roll.

## Risk

Low/medium. Replaces the effort inject path with a bounded driver that, by construction, never leaves the modal open. Same Claude-native mechanism (drives claude's own `/effort` REPL command over tmux). No API/SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)