### PR TITLE
feat(approvals): Always-allow auto-restarts so the grant takes effect

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -438,6 +438,7 @@ import {
   lookupScopedGrant,
   sweepScopedGrants,
 } from '../scoped-approval.js'
+import { grantRestartDecision, type GrantRestartDecision } from './grant-restart.js'
 import { synthesizeAllowRuleDiff, extractAddedAllowRule } from '../permission-diff.js'
 import {
   readClaudeJsonOverage,
@@ -13402,6 +13403,54 @@ async function sweepBeforeSelfRestart(): Promise<void> {
 }
 
 /**
+ * Schedule a marker-safe, turn-deferred SELF-restart so a just-persisted
+ * config change ACTUALLY takes effect. claude loads tools / MCP servers /
+ * settings at process start, so a durable "Always allow" write is inert in
+ * the running session until the next restart — the old "restart agent for
+ * full effect" text asked the operator to do this by hand, and most never
+ * did (so the grant didn't stick and the same prompt reappeared). This
+ * completes the flow the operator already approved.
+ *
+ * CALLER-AGENT ONLY (an "Always allow" edits the calling agent's own
+ * `agents.<self>.tools.allow`, a provably single-agent blast radius). The
+ * restart fires when the CURRENT turn completes (via `pendingRestarts`),
+ * never mid-turn — so the operator-approved action finishes first. If no
+ * turn is in flight, it fires immediately after a short drain delay. A
+ * marker is written first so the post-restart greeting lands in the chat
+ * the operator tapped. Kill-switch: `SWITCHROOM_AUTORESTART_ON_GRANT=0`.
+ *
+ * Returns 'disabled' | 'deferred' | 'now'.
+ */
+function scheduleGrantRestart(
+  agentName: string,
+  chatId: string | number | undefined,
+  threadId: number | undefined,
+  reason: string,
+): GrantRestartDecision {
+  const decision = grantRestartDecision({
+    killSwitch: process.env.SWITCHROOM_AUTORESTART_ON_GRANT,
+    selfAgent: process.env.SWITCHROOM_AGENT_NAME,
+    agentName,
+    turnInFlight: turnInFlightForGate(),
+  })
+  if (decision === "disabled") return decision
+  // Marker first → the post-restart greeting lands in the chat the operator
+  // tapped, not the default operator DM.
+  if (chatId != null) {
+    writeRestartMarker({ chat_id: String(chatId), thread_id: threadId ?? null, ack_message_id: null, ts: Date.now() })
+  }
+  stampUserRestartReason(reason)
+  if (decision === "deferred") {
+    pendingRestarts.set(agentName, Date.now()) // fires at turn-complete (marker-safe)
+  } else {
+    // No turn to drain — restart now, after a short delay so this callback's
+    // card edit flushes first.
+    void sweepBeforeSelfRestart().finally(() => triggerSelfRestart(agentName, reason, 1500))
+  }
+  return decision
+}
+
+/**
  * Shape the `switchroom auth ...` CLI stdout into a Telegram-friendly
  * HTML block. Returns the body text AND the OAuth authorize URL (if
  * one was present in the output) so the caller can wire a tappable
@@ -19356,10 +19405,26 @@ bot.on('callback_query:data', async ctx => {
 
     const ok = durable
     const legacyNote = legacy && durable
+    // Make the durable grant LIVE: config_propose_edit's apply already
+    // regenerated the scaffold (settings.json with the new tools.allow), so a
+    // marker-safe, turn-deferred self-restart loads it — no more "restart by
+    // hand" hint that the operator ignores (leaving the grant inert until the
+    // next bounce). Only on the hostd-durable path (scaffold currency assured);
+    // legacy path keeps the manual hint. Self-agent only; kill-switch
+    // SWITCHROOM_AUTORESTART_ON_GRANT=0.
+    const restartScheduled =
+      ok && !legacy &&
+      scheduleGrantRestart(
+        agentName,
+        ctx.chat?.id,
+        (ctx.callbackQuery?.message as { message_thread_id?: number } | undefined)?.message_thread_id,
+        `always-allow: ${grantPhrase}`,
+      ) !== "disabled"
+    const liveSuffix = restartScheduled ? " — applying now (restarting to take effect)" : ""
     const ackText = ok
       ? (legacyNote
           ? `✅ Saved. ${agentName} can now ${grantPhrase} without asking (legacy path).`
-          : `✅ Saved. ${agentName} can now ${grantPhrase} without asking.`)
+          : `✅ Saved. ${agentName} can now ${grantPhrase} without asking.${liveSuffix}`)
       : (editLockHint
           ? `⚠️ Allowed for now — config edits are locked. Enable hostd.config_edit_enabled.`
           : `⚠️ Allowed for now, but "always" did NOT save — it will ask again after restart. Check gateway log.`)
@@ -19376,7 +19441,9 @@ bot.on('callback_query:data', async ctx => {
     const editLabel = ok
       ? (legacyNote
           ? `✅ <b>${escapeHtmlForTg(agentName)} can now ${escapeHtmlForTg(grantPhrase)}</b> without asking (legacy path); restart agent for full effect`
-          : `✅ <b>${escapeHtmlForTg(agentName)} can now ${escapeHtmlForTg(grantPhrase)}</b> without asking; restart agent for full effect`)
+          : restartScheduled
+            ? `✅ <b>${escapeHtmlForTg(agentName)} can now ${escapeHtmlForTg(grantPhrase)}</b> without asking — applying now (restarting to take effect).`
+            : `✅ <b>${escapeHtmlForTg(agentName)} can now ${escapeHtmlForTg(grantPhrase)}</b> without asking; restart agent for full effect`)
       : (editLockHint
           ? `⚠️ <b>Allowed for now — "always" did NOT save.</b> Config edits are locked; enable <code>hostd.config_edit_enabled</code>.`
           : `⚠️ <b>Allowed for now — "always" did NOT save.</b> It will ask again after restart. Check gateway log.`)

--- a/telegram-plugin/gateway/grant-restart.ts
+++ b/telegram-plugin/gateway/grant-restart.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure decision for the "make a just-persisted grant LIVE" self-restart
+ * (the side-effecting `scheduleGrantRestart` in gateway.ts wraps this).
+ *
+ * Extracted so the gating — kill-switch, self-agent-only, and
+ * turn-deferred-vs-now — unit-tests without gateway.ts's boot side-effects
+ * (same pattern as scoped-approval.ts / admin-commands/index.ts).
+ *
+ * Contract (reference/access-model.md): the restart only ever follows an
+ * operator-approved, single-agent, additive `tools.allow` edit, and only
+ * ever bounces the CALLER's own agent — never a peer, never fleet-wide.
+ */
+export type GrantRestartDecision = "disabled" | "deferred" | "now";
+
+export function grantRestartDecision(opts: {
+  /** SWITCHROOM_AUTORESTART_ON_GRANT value ("0" disables; default on). */
+  killSwitch: string | undefined;
+  /** The gateway's own agent identity ($SWITCHROOM_AGENT_NAME). */
+  selfAgent: string | undefined;
+  /** The agent whose config was edited (must equal selfAgent — self only). */
+  agentName: string;
+  /** Whether a turn is currently in flight (defer the restart to its end). */
+  turnInFlight: boolean;
+}): GrantRestartDecision {
+  if ((opts.killSwitch ?? "") === "0") return "disabled";
+  // Self-only: an "Always allow" edits agents.<self>.tools.allow. We never
+  // bounce a peer or the fleet from this path.
+  if (!opts.selfAgent || opts.selfAgent !== opts.agentName) return "disabled";
+  return opts.turnInFlight ? "deferred" : "now";
+}

--- a/telegram-plugin/tests/grant-restart.test.ts
+++ b/telegram-plugin/tests/grant-restart.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for grantRestartDecision — the gating for the "make a just-persisted
+ * grant LIVE" self-restart (item ② config-edit-takes-effect). Pins: kill-switch,
+ * self-agent-only (never a peer/fleet bounce), and turn-deferred-vs-now.
+ */
+
+import { describe, it, expect } from "vitest";
+import { grantRestartDecision } from "../gateway/grant-restart.js";
+
+const base = { killSwitch: undefined, selfAgent: "clerk", agentName: "clerk", turnInFlight: true };
+
+describe("grantRestartDecision", () => {
+  it("defers to turn-complete when a turn is in flight (marker-safe)", () => {
+    expect(grantRestartDecision({ ...base, turnInFlight: true })).toBe("deferred");
+  });
+
+  it("fires now when no turn is in flight", () => {
+    expect(grantRestartDecision({ ...base, turnInFlight: false })).toBe("now");
+  });
+
+  it("is disabled by the kill-switch (SWITCHROOM_AUTORESTART_ON_GRANT=0)", () => {
+    expect(grantRestartDecision({ ...base, killSwitch: "0" })).toBe("disabled");
+  });
+
+  it("default-on for any non-'0' kill-switch value", () => {
+    expect(grantRestartDecision({ ...base, killSwitch: "" })).toBe("deferred");
+    expect(grantRestartDecision({ ...base, killSwitch: "1" })).toBe("deferred");
+  });
+
+  it("NEVER restarts a peer — self-agent only", () => {
+    // edit targets a different agent than the gateway's own identity
+    expect(grantRestartDecision({ ...base, selfAgent: "clerk", agentName: "gymbro" })).toBe("disabled");
+  });
+
+  it("is disabled when self identity is unknown", () => {
+    expect(grantRestartDecision({ ...base, selfAgent: undefined })).toBe("disabled");
+  });
+});


### PR DESCRIPTION
## Summary

The **config-edit-takes-effect** gap (item ②), self-scoped half: tapping **🔁 Always allow** writes a durable grant to `agents.<self>.tools.allow` (via hostd `config_propose_edit` → apply, which regenerates the scaffold) — but claude loaded settings at boot, so the grant was **inert** until a manual restart. The card said "restart agent for full effect"; operators rarely did, so the grant didn't stick and the same permission re-prompted next time (the "approvals that don't stick" failure the access-model audit flagged).

**Fix:** after a durable Always-allow, schedule a **marker-safe, turn-deferred SELF-restart** so the grant goes live automatically — completing the flow the operator already approved.

- **NEW `grant-restart.ts` `grantRestartDecision()`** — pure gating (kill-switch / self-agent-only / deferred-vs-now), unit-tested without gateway boot side-effects (same pattern as `scoped-approval.ts`).
- gateway `scheduleGrantRestart()` does the side effects: writes the restart marker (greeting lands in the chat the operator tapped) + stamps the reason, then **defers to turn-complete** via the existing `pendingRestarts` map (fires at turn-end — **never mid-turn**), or restarts now if no turn is in flight. **Reuses the existing marker-safe self-restart machinery — no new primitive.**
- Card text: "restart agent for full effect" → "applying now (restarting to take effect)".

## Access-model (verified as B1 = PASS in the plan's audit)
- **Caller-agent ONLY** — an Always-allow edits the caller's own `tools.allow` (provably single-agent); `grantRestartDecision` returns `disabled` if the edit target ≠ the gateway's own identity. Never bounces a peer or the fleet.
- Fires **only downstream of the operator's tap**; the agent authors nothing. Only the hostd-durable path; legacy keeps the manual hint.
- Kill-switch `SWITCHROOM_AUTORESTART_ON_GRANT=0` (default-on).

## Scope note
The **other half of item ②** — a "Restart affected agent(s)" button on the **admin arbitrary-config-edit** card (blast-radius classifier) — is a separate follow-up. This PR handles the common self-scoped case (every "Always allow").

## Test plan
- [x] vitest: `grant-restart` (6 — kill-switch, **self-only/never-peer**, deferred-vs-now) + full plugin suite (4033) green
- [x] `npm run lint` clean; tsc exit 0

## Risk
Low — self-only, turn-deferred (never mid-turn), reuses proven marker-safe restart machinery, kill-switch. Fires only after an operator tap. **Needs a live restart canary** (the one item that bounces an agent on approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)