### PR TITLE
test(uat): match shipped /model dashboard wording

### DIFF
--- a/telegram-plugin/uat/scenarios/jtbd-model-command-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-model-command-dm.test.ts
@@ -34,10 +34,13 @@ describe("uat: /model command — show, switch, bad-name", () => {
       const sc = await spinUp({ agent: AGENT });
       try {
         await sc.sendDM("/model");
-        // v2 (picker-driven menu): "Now: <model>"; v1 / fallback path:
-        // "Configured: <model>". Either proves the gateway handled the
-        // command rather than forwarding it to claude as plain text.
-        const shape = /Now:|Configured:/i;
+        // v2 (picker-driven menu) renders the live model as
+        // "Default (new sessions): <model>" (shipped wording, verified
+        // live on test-harness v0.15.21); "Now: <model>" was the
+        // pre-ship wording; v1 / fallback path renders "Configured:
+        // <model>". Any of these proves the gateway handled the command
+        // rather than forwarding it to claude as plain text.
+        const shape = /Default \(new sessions\):|Now:|Configured:/i;
         const reply = await sc.expectMessage(shape, {
           from: "bot",
           timeout: REPLY_TIMEOUT_MS,


### PR DESCRIPTION
Test-only. The v2 /model dashboard renders the live model as `Default (new sessions): <model>` (verified live on test-harness v0.15.21), but the UAT scenario still asserted the pre-ship `Now:|Configured:` wording — a false-red on a working feature, caught during the v0.15.21 canary. Widen the matcher.

Verified: 3/3 pass live against test-harness on v0.15.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)