### PR TITLE
test(uat): live coverage for this week's Telegram surfaces (#2340, #2336, #2263, #2341)

### DIFF
--- a/telegram-plugin/uat/scenarios/jtbd-effort-command-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-effort-command-dm.test.ts
@@ -1,0 +1,90 @@
+/**
+ * UAT — `/effort` command (#2336, #2342): show + tap-to-switch the
+ * Claude reasoning effort for the live session. The effort sibling of
+ * `/model`; the picker-driven menu is the same shape.
+ *
+ * Verified live on test-harness v0.15.21. Switches are session-only
+ * (revert on restart), so the tap test restores the original level.
+ *
+ * Self-skips green on an unwired host (spinUp can't resolve the chat).
+ */
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+const T = 30_000;
+
+describe("uat: /effort — show, tap-switch, bad-arg", () => {
+  it(
+    "bare /effort shows the effort menu with a tap keyboard",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        await sc.sendDM("/effort");
+        const menu = await sc.expectMessage(/Effort —/, { from: "bot", timeout: T });
+        expect(menu.text).toMatch(/faster → smarter|low · medium · high/i);
+        expect(menu.text).toMatch(/switchroom\.yaml/i);
+        const kb = await sc.driver.getKeyboard(sc.botUserId, menu.messageId);
+        const labels = (kb ?? []).flat().map((b) => b.text);
+        expect(labels.some((t) => /low/i.test(t)), "low button present").toBe(true);
+        expect(labels.some((t) => /max/i.test(t)), "max button present").toBe(true);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    60_000,
+  );
+
+  it(
+    "tapping a level switches the live session, then restores",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        await sc.sendDM("/effort");
+        const menu = await sc.expectMessage(/Effort —/, { from: "bot", timeout: T });
+        const kb = await sc.driver.getKeyboard(sc.botUserId, menu.messageId);
+        const flat = (kb ?? []).flat();
+        // The current level is prefixed with ✅; pick a DIFFERENT one.
+        const current = flat.find((b) => /✅/.test(b.text));
+        const target = flat.find(
+          (b) => b.callbackData && !/✅/.test(b.text) && /medium|high/i.test(b.text),
+        );
+        expect(target, "a non-current effort button to tap").toBeDefined();
+        await sc.driver.pressButton(sc.botUserId, menu.messageId, target!.callbackData!);
+        // The card edits in place to prepend a confirmation line.
+        await new Promise((r) => setTimeout(r, 4000));
+        const after = await sc.driver.getMessage(sc.botUserId, menu.messageId);
+        expect(after?.text ?? "").toMatch(/Effort →|Switched|effort/i);
+
+        // Restore the original level so test-harness isn't left changed.
+        if (current?.callbackData) {
+          const kb2 = await sc.driver.getKeyboard(sc.botUserId, menu.messageId);
+          const restore = (kb2 ?? [])
+            .flat()
+            .find((b) => b.callbackData === current.callbackData);
+          if (restore?.callbackData) {
+            await sc.driver.pressButton(sc.botUserId, menu.messageId, restore.callbackData);
+          }
+        }
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    90_000,
+  );
+
+  it(
+    "/effort bogus → reply (error/help), never silence",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        await sc.sendDM("/effort definitely-not-a-level");
+        const reply = await sc.expectMessage(/\S/, { from: "bot", timeout: T });
+        expect(reply.text.length).toBeGreaterThan(0);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    60_000,
+  );
+});

--- a/telegram-plugin/uat/scenarios/jtbd-grant-resume-telegram-id-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-grant-resume-telegram-id-dm.test.ts
@@ -1,0 +1,97 @@
+/**
+ * End-to-end UAT — agent AUTO-RESUMES after a vault grant approval,
+ * under the live `telegram-id` (single-factor) posture. Regression gate
+ * for the mid-turn-strand fix (#2340).
+ *
+ * THE BUG (#2340, clerk 2026-06-13): the gateway injects a synthetic
+ * "✅ approved — resume your task" inbound after the operator taps
+ * Approve. That inject used a raw `sendToAgent` and only buffered on a
+ * disconnected bridge. When the approval landed WHILE the agent's
+ * grant-requesting turn was still finishing, the socket write succeeded
+ * (`delivered=true`) but claude was mid-turn, so the channel
+ * notification stranded in its TUI composer (the #1556 race) and the
+ * agent sat idle until manually poked. Fix: route the resume through
+ * the same turn-gate as normal inbounds (buffer mid-turn, flush at
+ * turn-end). This scenario proves the agent resumes on its own.
+ *
+ * Posture: the live fleet runs `vault.broker.approvalAuth: telegram-id`
+ * (broker auto-unlocked), so tapping Approve mints silently — NO
+ * passphrase prompt. The sibling `vault-grant-auto-resume-dm.test.ts`
+ * covers the (now-legacy) passphrase posture and stays skipped.
+ *
+ * No sacrificial key needed: `vault_request_access` mints an ACL grant
+ * for the key *pattern*; the card → approve → resume cycle fires
+ * whether or not the key holds a value. We assert the RESUME (a fresh
+ * bot turn after the tap, with no driver nudge), not a secret value —
+ * so nothing sensitive is read or leaked.
+ *
+ * Self-skips green when the driver can't resolve the chat (unwired
+ * host), matching the other opt-in scenarios — uat/** is excluded from
+ * gating CI anyway. Mutates host vault state (mints a short grant on
+ * test-harness); harmless + TTL-expiring.
+ */
+
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+const KEY = "uat/resume-probe";
+
+describe("uat: agent auto-resumes after vault grant approval — telegram-id (#2340)", () => {
+  it(
+    "fires card → operator taps Approve → agent emits a NEW turn with no nudge",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        // 1. Ask the agent to request access then resume. Steer it to
+        //    end its turn after the tool call so the approval lands at
+        //    a turn boundary — the exact window #2340 fixes.
+        await sc.sendDM(
+          `Call your vault_request_access MCP tool with key="${KEY}", ` +
+          `scope="read", reason="UAT #2340 resume gate". After the tool ` +
+          `returns "waiting for operator", END YOUR TURN. When the ` +
+          `operator approves, you should AUTOMATICALLY resume: confirm ` +
+          `the grant landed and that you saw the approval for ${KEY}.`,
+        );
+
+        // 2. Wait for the approval card.
+        const card = await sc.expectMessage(/wants vault access/i, {
+          from: "bot",
+          timeout: 120_000,
+        });
+
+        // 3. Find + tap the Approve button.
+        const kb = await sc.driver.getKeyboard(sc.botUserId, card.messageId);
+        const approve = kb!
+          .flat()
+          .find((b) => b.callbackData !== undefined && /approve/i.test(b.text));
+        expect(approve, "Approve button present on the card").toBeDefined();
+        const tapAtMsgId = card.messageId;
+        await sc.driver.pressButton(sc.botUserId, card.messageId, approve!.callbackData!);
+
+        // 4. Single-factor: card edits to "Granted" with no passphrase
+        //    prompt. Anchor on the grant confirmation.
+        await sc.expectMessage(/Granted|already has|access to/i, {
+          from: "bot",
+          timeout: 30_000,
+        });
+
+        // 5. THE #2340 ASSERTION: the agent auto-resumes — a NEW bot
+        //    turn referencing the approval/grant/key, WITHOUT the driver
+        //    sending anything else. Pre-fix this stranded mid-turn and
+        //    timed out. The resume reply must be a message newer than
+        //    the card we tapped (not the card edit).
+        const resume = await sc.expectMessage(
+          (m) =>
+            m.messageId > tapAtMsgId &&
+            /(approv|grant|access|resume|landed|✅)/i.test(m.text),
+          { from: "bot", timeout: 150_000 },
+        );
+        expect(resume.text.length).toBeGreaterThan(0);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    360_000,
+  );
+});

--- a/telegram-plugin/uat/scenarios/jtbd-model-tap-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-model-tap-dm.test.ts
@@ -1,0 +1,71 @@
+/**
+ * UAT — `/model` v2 dashboard BUTTON TAP (#2263, #2270, #2271). The
+ * existing jtbd-model-command scenario covers the bare dashboard +
+ * typed-arg forms; this one exercises the genuinely new path the
+ * mtcute driver can now drive: tapping a model button to switch the
+ * live session via the picker, and the menu never leaving a dead card
+ * (#2270 — keeps buttons + clears the toast).
+ *
+ * Switches are session-only (revert on restart); the test taps a
+ * different model then restores the original so test-harness isn't
+ * left changed.
+ *
+ * Self-skips green on an unwired host.
+ */
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+
+describe("uat: /model dashboard button tap switches the live session", () => {
+  it(
+    "tap a non-current model → switch confirmation; then restore",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        await sc.sendDM("/model");
+        const menu = await sc.expectMessage(/Default \(new sessions\):|Now:/i, {
+          from: "bot",
+          timeout: 30_000,
+        });
+        const kb = await sc.driver.getKeyboard(sc.botUserId, menu.messageId);
+        const flat = (kb ?? []).flat().filter((b) => b.callbackData);
+        // Model buttons carry mdl:s:<tag>; the current one is prefixed
+        // ✅. Refresh (mdl:r) is excluded — pick a non-current model.
+        const originalLabel = flat
+          .find((b) => /✅/.test(b.text))
+          ?.text.replace(/^✅\s*/, "");
+        const target = flat.find(
+          (b) => /mdl:s:/.test(b.callbackData!) && !/✅/.test(b.text),
+        );
+        expect(target, "a non-current model button to tap").toBeDefined();
+
+        await sc.driver.pressButton(sc.botUserId, menu.messageId, target!.callbackData!);
+        await new Promise((r) => setTimeout(r, 6000));
+        // #2270: the card never goes dead — it edits in place to a
+        // confirmation and KEEPS a keyboard.
+        const after = await sc.driver.getMessage(sc.botUserId, menu.messageId);
+        expect(after?.text ?? "").toMatch(/Set model to|Switched|model/i);
+        const kbAfter = await sc.driver.getKeyboard(sc.botUserId, menu.messageId);
+        expect(
+          (kbAfter ?? []).flat().length,
+          "menu keeps its buttons after a tap (no dead card, #2270)",
+        ).toBeGreaterThan(0);
+
+        // Restore the original model: tap the button whose label now
+        // matches the original (it's no longer the ✅ row).
+        if (originalLabel) {
+          const restore = (kbAfter ?? [])
+            .flat()
+            .find((b) => b.callbackData?.startsWith("mdl:s:") && b.text.replace(/^✅\s*/, "") === originalLabel);
+          if (restore?.callbackData) {
+            await sc.driver.pressButton(sc.botUserId, menu.messageId, restore.callbackData);
+          }
+        }
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    120_000,
+  );
+});

--- a/telegram-plugin/uat/scenarios/jtbd-whoami-dm.test.ts
+++ b/telegram-plugin/uat/scenarios/jtbd-whoami-dm.test.ts
@@ -1,0 +1,40 @@
+/**
+ * UAT — `/whoami` (#2341): the operator's read-only view of THIS
+ * agent's sandbox (same data the agent's `config whoami` MCP tool and
+ * the `switchroom config whoami` host CLI report). Read-only, like
+ * `/version`; mutates nothing.
+ *
+ * Verified live on test-harness v0.15.21. Self-skips green on an
+ * unwired host.
+ */
+import { describe, expect, it } from "vitest";
+import { spinUp } from "../harness.js";
+
+const AGENT = "test-harness";
+
+describe("uat: /whoami shows the agent sandbox card", () => {
+  it(
+    "renders tier, model, tools, MCP, and powers",
+    async () => {
+      const sc = await spinUp({ agent: AGENT });
+      try {
+        await sc.sendDM("/whoami");
+        // Header: "👤 <agent> · <tier>"
+        const reply = await sc.expectMessage(/👤\s*test-harness/i, {
+          from: "bot",
+          timeout: 30_000,
+        });
+        // The card's load-bearing fields — proves whoami resolved the
+        // sandbox (tier/model/tools/mcp/powers), not just echoed a stub.
+        expect(reply.text).toMatch(/Model:/i);
+        expect(reply.text).toMatch(/Tools:/i);
+        expect(reply.text).toMatch(/Powers:/i);
+        // Tier marker present in the header (standard / admin / root).
+        expect(reply.text).toMatch(/·\s*(standard|admin|root)/i);
+      } finally {
+        await sc.tearDown();
+      }
+    },
+    60_000,
+  );
+});


### PR DESCRIPTION
## Summary

This week shipped a lot of Telegram-surface changes with little live UAT. This adds mtcute (real Telegram) coverage for the four biggest gaps — each **verified live against test-harness v0.15.21**.

| Scenario | Covers | Live result |
|---|---|---|
| `jtbd-grant-resume-telegram-id-dm` | **#2340 mid-turn-strand fix, END-TO-END** | 1/1 ✅ |
| `jtbd-effort-command-dm` | `/effort` show + tap-switch + bad-arg (#2336/#2342) | 3/3 ✅ |
| `jtbd-model-tap-dm` | `/model` dashboard button **tap** (#2263/#2270/#2271) | 1/1 ✅ |
| `jtbd-whoami-dm` | `/whoami` sandbox card (#2341) | 1/1 ✅ |

## Why these

- **Grant-resume (#2340):** the existing `vault-grant-auto-resume-dm` scenario is `describe.skip`'d AND written for the legacy passphrase posture — so my mid-turn-strand fix had **zero live coverage**. This new scenario reproduces the exact 'approved but doesn't continue' bug under the live `telegram-id` posture: agent fires a card → driver taps Approve → agent auto-resumes with no nudge. (Confirmed in the gateway log: `buffered source=vault_grant_approved` → `drained` at turn-end → resume.)
- **Button taps:** `/effort`, `/model`, and the approval cards are all picker/keyboard surfaces the suite previously only drove in *skipped* scenarios. These exercise `pressButton`/`getKeyboard` for real, and **restore** any session-only change (model/effort) so test-harness isn't left mutated.

## Test plan

- [x] All four green live against test-harness v0.15.21 (real Telegram round-trips, real button taps)
- [x] `tsc --noEmit` clean
- [x] Self-skip green on an unwired host; uat/** excluded from gating CI

## Notes / not covered (follow-ups)

- Always-allow auto-restart (#2343) and the 30-min approval tier (#2333/#2317) need a dangerous-tool permission card to trigger — deferred.
- Cron Tier-0/Tier-1 (#2307 series) and Linear (#2309/#2314) aren't cleanly mtcute-testable (timing / external creds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)