### PR TITLE
fix(scaffold): bake host home into start.sh, not in-container /host-home

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1134,6 +1134,68 @@ function shellSingleQuote(s: string): string {
 }
 
 /**
+ * The real host home for values BAKED into generated artifacts (start.sh's
+ * `cd "{{agentDir}}"`, the `$HOME/.switchroom` symlink target, …).
+ *
+ * `homedir()` / `$HOME` is the right answer when `switchroom apply` runs on
+ * the host. But hostd shells out `switchroom apply` from INSIDE its container
+ * (the `config_propose_edit` reconcile path), where `$HOME` is `/host-home`
+ * (the in-container mount point of the operator's home — a bind, not a host
+ * filesystem path). Baking `/host-home/...` into an agent's start.sh is fatal:
+ * the agent containers mount `~/.switchroom` at its REAL host path (same path
+ * in/out, `network_mode: host`) and have NO `/host-home` mount, so every
+ * `cd "{{agentDir}}"` / `--plugin-dir {{agentDir}}/...` / `$HOME/.switchroom`
+ * symlink dangles and claude falls to the login screen (2026-06-14 carrie/
+ * fleet-wide scaffold poison).
+ *
+ * Filesystem WRITES during apply must still use `$HOME` (`/host-home`, which
+ * bind-resolves to the real dir) — only BAKED values are translated. This
+ * mirrors `write-compose.ts` (`homeDir: SWITCHROOM_HOST_HOME || homedir()`),
+ * which already protects the compose bind SOURCES the same way; the scaffold
+ * path was the unprotected sibling.
+ *
+ * `SWITCHROOM_HOST_HOME` is the generator's authoritative host home, baked
+ * into the hostd container env by `compose.ts`. On the host it is unset (or
+ * equals `$HOME`), so this is a no-op there. Returns `undefined` only when
+ * BOTH are unset (test / non-host context) — the template's
+ * `{{#if hostHomeQ}}` guard then renders the symlink block as a no-op, exactly
+ * as the pre-fix `process.env.HOME ? … : undefined` did.
+ */
+function hostHomeForBake(): string | undefined {
+  return process.env.SWITCHROOM_HOST_HOME || process.env.HOME || undefined;
+}
+
+/** Shell-quoted host home for baking into start.sh, or undefined when unset. */
+function hostHomeQForBake(): string | undefined {
+  const h = hostHomeForBake();
+  return h ? shellSingleQuote(h) : undefined;
+}
+
+/**
+ * Translate a path rooted at the in-container home (`$HOME`, e.g.
+ * `/host-home/.switchroom/agents/foo`) to the real host home
+ * (`SWITCHROOM_HOST_HOME`, e.g. `/home/op/.switchroom/agents/foo`) so it is
+ * safe to BAKE into an agent artifact. No-op when:
+ *   - running on the host (`SWITCHROOM_HOST_HOME` unset or == `$HOME`), or
+ *   - the path is not under `$HOME` (e.g. `/state/config/...`,
+ *     `/opt/switchroom/...`) — those are already container-correct.
+ * See {@link hostHomeForBake} for why this exists.
+ */
+export function toHostHomePath(p: string): string {
+  const hostHome = process.env.SWITCHROOM_HOST_HOME;
+  const containerHome = process.env.HOME;
+  if (
+    hostHome &&
+    containerHome &&
+    hostHome !== containerHome &&
+    (p === containerHome || p.startsWith(containerHome + "/"))
+  ) {
+    return hostHome + p.slice(containerHome.length);
+  }
+  return p;
+}
+
+/**
  * Compose a template-generated file with an optional user sidecar.
  * Result = <rendered template>\n\n---\n\n<sidecar contents> if sidecar exists,
  * else just <rendered template>.
@@ -2242,7 +2304,10 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
   } = args;
   return {
     name,
-    agentDir,
+    // BAKED into start.sh (cd, CLAUDE_CONFIG_DIR, --plugin-dir, …). Must be a
+    // HOST path, not the in-container /host-home, when apply runs inside hostd.
+    // See toHostHomePath. The filesystem writes elsewhere keep the local value.
+    agentDir: toHostHomePath(agentDir),
     repoRoot: REPO_ROOT,
     topicId,
     topicName: agentConfig.topic_name,
@@ -2321,9 +2386,11 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
       ? shellSingleQuote(resolve(switchroomConfigPath))
       : undefined,
     // Host home — baked into start.sh.hbs's $HOME/.switchroom symlink
-    // (#910). When unset (e.g. tests with no HOME) the template's
-    // {{#if hostHomeQ}} guard renders the symlink block as a no-op.
-    hostHomeQ: process.env.HOME ? shellSingleQuote(process.env.HOME) : undefined,
+    // (#910). Prefer SWITCHROOM_HOST_HOME so an in-hostd apply bakes the real
+    // host home, not /host-home (see hostHomeForBake). When neither is set
+    // (e.g. tests with no HOME) the template's {{#if hostHomeQ}} guard renders
+    // the symlink block as a no-op.
+    hostHomeQ: hostHomeQForBake(),
     modelQ: shellSingleQuote(resolveMainModel(agentConfig.model)),
     ...buildCronSessionContext(agentConfig),
     thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,
@@ -4882,7 +4949,10 @@ export function reconcileAgent(
     const basePath = getBaseProfilePath();
     const startShContext: Record<string, unknown> = {
       name,
-      agentDir,
+      // BAKED into start.sh — must be a HOST path, not in-container /host-home,
+      // when reconcile (apply) runs inside hostd. See toHostHomePath. startShPath
+      // above and the FS writes below keep the local container-relative value.
+      agentDir: toHostHomePath(agentDir),
       repoRoot: REPO_ROOT,
       botToken: resolvedBotToken ?? rawBotToken,
       forumChatId: telegramConfig.forum_chat_id,
@@ -4915,8 +4985,10 @@ export function reconcileAgent(
         : undefined,
       hindsightTopicFilterMode,
       // Mirror buildWorkspaceContext (#910): host home for the
-      // $HOME/.switchroom symlink in start.sh's docker preamble.
-      hostHomeQ: process.env.HOME ? shellSingleQuote(process.env.HOME) : undefined,
+      // $HOME/.switchroom symlink in start.sh's docker preamble. Prefer
+      // SWITCHROOM_HOST_HOME so an in-hostd reconcile bakes the real host
+      // home, not /host-home (see hostHomeForBake).
+      hostHomeQ: hostHomeQForBake(),
       modelQ: shellSingleQuote(resolveMainModel(agentConfig.model)),
       ...buildCronSessionContext(agentConfig),
       thinkingEffort: agentConfig.thinking_effort ?? SWITCHROOM_DEFAULT_THINKING_EFFORT,

--- a/tests/scaffold.host-home-bake.test.ts
+++ b/tests/scaffold.host-home-bake.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent, toHostHomePath } from "../src/agents/scaffold.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+// Regression for the 2026-06-14 fleet-wide scaffold poison (carrie + 11
+// landmines). hostd shells out `switchroom apply` from INSIDE its container,
+// where $HOME=/host-home (a bind mount point, not a host filesystem path).
+// The compose bind SOURCES were already protected (write-compose.ts prefers
+// SWITCHROOM_HOST_HOME) but the SCAFFOLD path was the unprotected sibling: it
+// baked $HOME-rooted paths into start.sh's `cd "{{agentDir}}"`,
+// `--plugin-dir {{agentDir}}/...` and the `$HOME/.switchroom` symlink target.
+// Agent containers mount ~/.switchroom at its REAL host path (same path in/out,
+// network_mode: host) and have NO /host-home mount, so every such path dangled
+// and claude fell to the login screen. The config_propose_edit reconcile path
+// (unblocked by the v0.15.23 EROFS fix) is exactly this in-hostd apply.
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  };
+}
+
+describe("toHostHomePath (in-hostd bake translation)", () => {
+  let savedHome: string | undefined;
+  let savedHostHome: string | undefined;
+
+  beforeEach(() => {
+    savedHome = process.env.HOME;
+    savedHostHome = process.env.SWITCHROOM_HOST_HOME;
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedHostHome === undefined) delete process.env.SWITCHROOM_HOST_HOME;
+    else process.env.SWITCHROOM_HOST_HOME = savedHostHome;
+  });
+
+  it("translates a $HOME-rooted path to SWITCHROOM_HOST_HOME when they differ", () => {
+    process.env.HOME = "/host-home";
+    process.env.SWITCHROOM_HOST_HOME = "/home/op";
+    expect(toHostHomePath("/host-home/.switchroom/agents/carrie")).toBe(
+      "/home/op/.switchroom/agents/carrie",
+    );
+    // exact-home match (no trailing slash) also translates
+    expect(toHostHomePath("/host-home")).toBe("/home/op");
+  });
+
+  it("is a no-op on the host (SWITCHROOM_HOST_HOME unset)", () => {
+    process.env.HOME = "/home/op";
+    delete process.env.SWITCHROOM_HOST_HOME;
+    expect(toHostHomePath("/home/op/.switchroom/agents/carrie")).toBe(
+      "/home/op/.switchroom/agents/carrie",
+    );
+  });
+
+  it("is a no-op when SWITCHROOM_HOST_HOME equals $HOME", () => {
+    process.env.HOME = "/home/op";
+    process.env.SWITCHROOM_HOST_HOME = "/home/op";
+    expect(toHostHomePath("/home/op/.switchroom/agents/carrie")).toBe(
+      "/home/op/.switchroom/agents/carrie",
+    );
+  });
+
+  it("leaves non-$HOME paths untouched (e.g. /state/config, /opt)", () => {
+    process.env.HOME = "/host-home";
+    process.env.SWITCHROOM_HOST_HOME = "/home/op";
+    expect(toHostHomePath("/state/config/switchroom.yaml")).toBe(
+      "/state/config/switchroom.yaml",
+    );
+    expect(toHostHomePath("/opt/switchroom/security-plugin")).toBe(
+      "/opt/switchroom/security-plugin",
+    );
+    // a path that merely shares a prefix string but isn't a child must NOT match
+    expect(toHostHomePath("/host-home-evil/x")).toBe("/host-home-evil/x");
+  });
+});
+
+describe("scaffoldAgent: start.sh bakes HOST paths, not /host-home (carrie incident)", () => {
+  let tmpDir: string;
+  let savedHome: string | undefined;
+  let savedHostHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-hosthome-bake-"));
+    savedHome = process.env.HOME;
+    savedHostHome = process.env.SWITCHROOM_HOST_HOME;
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedHostHome === undefined) delete process.env.SWITCHROOM_HOST_HOME;
+    else process.env.SWITCHROOM_HOST_HOME = savedHostHome;
+  });
+
+  it("bakes SWITCHROOM_HOST_HOME into start.sh when apply runs in-hostd ($HOME=container mount)", () => {
+    const name = "carrie";
+    // Simulate the in-hostd shell-out: $HOME is the in-container bind mount
+    // (where files are WRITTEN — keep it inside the tmpdir so the test never
+    // touches the real ~/.switchroom), SWITCHROOM_HOST_HOME is the real host
+    // home (what must be BAKED into start.sh).
+    process.env.HOME = tmpDir;
+    process.env.SWITCHROOM_HOST_HOME = "/home/op";
+
+    // agentsDir under $HOME → agentDir starts with the container home, exactly
+    // as resolveAgentsDir(~/.switchroom/agents) yields inside hostd.
+    const agentsDir = join(tmpDir, ".switchroom", "agents");
+    const config = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig(name, config);
+
+    const res = scaffoldAgent(name, config, agentsDir, telegramConfig, switchroomConfig);
+    const startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+
+    // BAKED agentDir is the HOST path — the agent container can resolve it.
+    expect(startSh).toContain(`/home/op/.switchroom/agents/${name}`);
+    expect(startSh).toContain(`cd "/home/op/.switchroom/agents/${name}"`);
+    // The $HOME/.switchroom symlink target (#910) is the host home, not the
+    // in-container /host-home equivalent. hostHomeQ is shell-single-quoted.
+    expect(startSh).toContain(`ln -sfn '/home/op'/.switchroom "$HOME/.switchroom"`);
+
+    // The container home must NOT leak into any BAKED value — that was the
+    // poison (a /host-home that the agent container can't see).
+    expect(startSh).not.toContain(`${tmpDir}/.switchroom/agents/${name}`);
+  });
+
+  it("bakes $HOME on a plain host apply (SWITCHROOM_HOST_HOME unset)", () => {
+    const name = "carrie";
+    process.env.HOME = tmpDir;
+    delete process.env.SWITCHROOM_HOST_HOME;
+
+    const agentsDir = join(tmpDir, ".switchroom", "agents");
+    const config = makeAgentConfig();
+    const switchroomConfig = makeSwitchroomConfig(name, config);
+
+    const res = scaffoldAgent(name, config, agentsDir, telegramConfig, switchroomConfig);
+    const startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+
+    // No translation on the host: the real (tmp) home is baked, and that IS
+    // the path the file lives at, so the agent resolves it fine.
+    expect(startSh).toContain(`${tmpDir}/.switchroom/agents/${name}`);
+  });
+});

--- a/tests/scaffold.test.ts
+++ b/tests/scaffold.test.ts
@@ -230,7 +230,11 @@ describe("scaffoldAgent", () => {
 
   it("start.sh skips the symlink block when HOME is unset (test/non-host context)", () => {
     const prevHome = process.env.HOME;
+    const prevHostHome = process.env.SWITCHROOM_HOST_HOME;
     delete process.env.HOME;
+    // SWITCHROOM_HOST_HOME now also feeds hostHomeQ (in-hostd bake fix); clear
+    // it too so this stays a true "no host home" context.
+    delete process.env.SWITCHROOM_HOST_HOME;
     try {
       const config = makeAgentConfig();
       const result = scaffoldAgent("no-home-agent", config, tmpDir, telegramConfig);
@@ -241,6 +245,7 @@ describe("scaffoldAgent", () => {
       expect(startSh).not.toContain("ln -sfn");
     } finally {
       if (prevHome !== undefined) process.env.HOME = prevHome;
+      if (prevHostHome !== undefined) process.env.SWITCHROOM_HOST_HOME = prevHostHome;
     }
   });
 


### PR DESCRIPTION
## Summary

When hostd shells out `switchroom apply` from **inside its container** (the `config_propose_edit` reconcile path, unblocked by the v0.15.23 EROFS fix #2350), `$HOME` is `/host-home` — the in-container bind-mount point of the operator's home, not a host filesystem path. `scaffold.ts` baked `$HOME`-rooted values into `start.sh`:

- `cd "{{agentDir}}"`
- `--plugin-dir {{agentDir}}/.claude/plugins/hindsight-memory`
- the `$HOME/.switchroom` and `$HOME/.switchroom-config` symlink targets (`{{{hostHomeQ}}}`)

Agent containers mount `~/.switchroom` at its **real host path** (same path in/out, `network_mode: host`) and have **no** `/host-home` mount. So every baked `/host-home/...` path dangled → claude fell to the login screen.

## Why

This poisoned the **whole fleet's on-disk scaffolds** on 2026-06-14: carrie broke on recreate (18 `/host-home` refs in its `start.sh` + dangling bridge symlink); the other 11 agents were landmines on next recreate. Recovered live by re-running `sudo switchroom apply` **from the host** (correct `homedir()`) + restarting carrie.

The compose bind **sources** were already protected — `write-compose.ts` prefers `SWITCHROOM_HOST_HOME` over `homedir()` (#2279/#2285). The **scaffold** path was the unprotected sibling: same in-container-apply host-home bug class. This closes it.

JTBD: **always-available** (pillar 4) — an agent that boots to a login screen after a config edit is the opposite of always-on; and **you hold the leash** (an admin agent's sanctioned config edit must not silently brick the fleet).

## What changed

New `toHostHomePath()` / `hostHomeForBake()` helpers in `scaffold.ts`. At **both** `start.sh` render sites (scaffold's `buildWorkspaceContext` and the reconcile path's `startShContext`), the **baked** `agentDir` + `hostHomeQ` are translated from the in-container home to `SWITCHROOM_HOST_HOME`. Filesystem **writes** keep using `$HOME` (`/host-home`, which bind-resolves to the real dir) — only baked values change.

- No-op on the host (`SWITCHROOM_HOST_HOME` unset or `== $HOME`).
- No-op for non-`$HOME` paths (`/state/config/...`, `/opt/switchroom/...`).
- Returns `undefined` when no host home at all (test/non-host) — preserves the existing `{{#if hostHomeQ}}` "skip symlink block" contract.

## Test plan

- [x] `tests/scaffold.host-home-bake.test.ts` (new) — reproduces the in-hostd scenario (`$HOME`=container mount, `SWITCHROOM_HOST_HOME`=host home) and asserts `start.sh` bakes the host path, not `/host-home`; plus `toHostHomePath` unit coverage (translate / host no-op / equal-home no-op / non-`$HOME` untouched / prefix-not-child guard).
- [x] Hardened the existing "skips symlink block when HOME unset" test to also clear `SWITCHROOM_HOST_HOME` (now an input to this path).
- [x] `vitest run tests/scaffold tests/reconcile src/agents/scaffold.test.ts src/cli/write-compose.test.ts` → 347 passed.
- [x] `tsc --noEmit` clean.

## Risk

Low. Surgical change to two object-literal keys + a pure helper; no-op on the host (the dominant apply path). Without it, every agent `config_propose_edit` re-poisons all on-disk scaffolds (fleet-wide landmine on next recreate).