### PR TITLE
fix: tools.allow [all] keeps explicit grants + apply hint host path

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2901,7 +2901,14 @@ export function scaffoldAgent(
   const rawAllow = tools.allow ?? [];
   const hasAllWildcard = rawAllow.includes("all");
   const baseAllow = hasAllWildcard
-    ? ALL_BUILTIN_TOOLS
+    // `[all]` means "all built-ins" — but it must ALSO keep any explicit tools
+    // the operator listed alongside it. A 🔁 "Always allow" tap persists a
+    // privileged hostd / Skill / 3rd-party-MCP rule into tools.allow as
+    // `[all, mcp__hostd__agent_logs]` (those are deliberately NOT in
+    // ALL_BUILTIN_TOOLS — the leash: even an [all] admin approves them once).
+    // Dropping the explicit entries here is why such grants never reached
+    // settings.json and the agent re-asked forever (klanker, 2026-06-15).
+    ? [...ALL_BUILTIN_TOOLS, ...rawAllow.filter((t) => t !== "all")]
     : rawAllow.filter((t) => t !== "all");
   // If the user didn't specify any allowed tools AND dangerous_mode is off,
   // seed a safe read-only default set so routine tool calls don't spam the
@@ -4845,7 +4852,14 @@ export function reconcileAgent(
   const rawAllow = tools.allow ?? [];
   const hasAllWildcard = rawAllow.includes("all");
   const baseAllow = hasAllWildcard
-    ? ALL_BUILTIN_TOOLS
+    // `[all]` means "all built-ins" — but it must ALSO keep any explicit tools
+    // the operator listed alongside it. A 🔁 "Always allow" tap persists a
+    // privileged hostd / Skill / 3rd-party-MCP rule into tools.allow as
+    // `[all, mcp__hostd__agent_logs]` (those are deliberately NOT in
+    // ALL_BUILTIN_TOOLS — the leash: even an [all] admin approves them once).
+    // Dropping the explicit entries here is why such grants never reached
+    // settings.json and the agent re-asked forever (klanker, 2026-06-15).
+    ? [...ALL_BUILTIN_TOOLS, ...rawAllow.filter((t) => t !== "all")]
     : rawAllow.filter((t) => t !== "all");
   const reconcileDangerousMode = agentConfig.dangerous_mode === true;
   const reconcileHadExplicitAllow = rawAllow.length > 0;

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -55,7 +55,7 @@ import {
   findConfigFile,
   ConfigError,
 } from "../config/loader.js";
-import { scaffoldAgent, alignAgentUid, renderFleetInvariants } from "../agents/scaffold.js";
+import { scaffoldAgent, alignAgentUid, renderFleetInvariants, toHostHomePath } from "../agents/scaffold.js";
 import { installUpdatePromptHook } from "./update-prompt-hook.js";
 import { allocateAgentUid } from "../agents/compose.js";
 import { writeComposeFile, resolveHostSwitchroomConfigPath } from "./write-compose.js";
@@ -933,6 +933,14 @@ export async function runApply(
 
   // ── 3. Generate compose file ──────────────────────────────────────
   const composePath = options.outPath ?? DEFAULT_COMPOSE_PATH;
+  // Display-only host path for the operator hints below. When apply runs INSIDE
+  // the hostd container, homedir() is the in-container HOME (/host-home), so
+  // composePath/DEFAULT_COMPOSE_PATH point at a path no host operator can
+  // copy-paste into `docker compose -f …`. Translate to the real host home via
+  // SWITCHROOM_HOST_HOME (same helper that fixes baked scaffold paths). The
+  // file is still WRITTEN to composePath (the bind-mounted container path) —
+  // only the printed strings change. No-op on the host (helper returns input).
+  const displayComposePath = toHostHomePath(composePath);
   // Capture the host operator UID so the broker can chown its operator
   // socket at bind time. Under sudo, `process.getuid()` returns 0 (root)
   // — what we actually want is the underlying user's UID, which sudo
@@ -960,13 +968,13 @@ export async function runApply(
 
   writeOut(
     chalk.bold(`\nWrote `) +
-      composePath +
+      displayComposePath +
       chalk.gray(` (${composeBytes} bytes)\n`),
   );
   writeOut(
     `Bring the fleet up with:\n` +
-      `  docker compose -p ${COMPOSE_PROJECT} -f ${composePath} pull && \\\n` +
-      `    docker compose -p ${COMPOSE_PROJECT} -f ${composePath} up -d --remove-orphans\n`,
+      `  docker compose -p ${COMPOSE_PROJECT} -f ${displayComposePath} pull && \\\n` +
+      `    docker compose -p ${COMPOSE_PROJECT} -f ${displayComposePath} up -d --remove-orphans\n`,
   );
   writeOut(
     chalk.gray(

--- a/tests/scaffold.all-wildcard-keeps-explicit.test.ts
+++ b/tests/scaffold.all-wildcard-keeps-explicit.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { AgentConfig, SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+// Regression for the 2026-06-15 klanker "re-asks the same permission forever"
+// bug. An agent with `tools.allow: [all]` expands to ALL_BUILTIN_TOOLS +
+// switchroom-managed MCP tokens, but DELIBERATELY excludes privileged hostd
+// tools, Skill(...), and 3rd-party MCP (the leash — even an [all] admin
+// approves those once). The intended "stop asking" path is a 🔁 Always tap,
+// which persists the specific rule into the agent's tools.allow as
+// `[all, mcp__hostd__agent_logs]`. The bug: scaffold's `[all]` branch set
+// baseAllow = ALL_BUILTIN_TOOLS and DROPPED every other entry, so the
+// operator-persisted rule never reached settings.json → the agent re-asked on
+// the next turn, every time. Fix: when hasAllWildcard, keep the explicit
+// (non-"all") entries alongside the built-ins.
+
+const telegramConfig: TelegramConfig = {
+  bot_token: "123456:ABC-DEF",
+  forum_chat_id: "-1001234567890",
+};
+
+function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    extends: "default",
+    topic_name: "Test Topic",
+    schedule: [],
+    ...overrides,
+  } as AgentConfig;
+}
+
+function makeSwitchroomConfig(name: string, agentConfig: AgentConfig): SwitchroomConfig {
+  return {
+    switchroom: {
+      version: 1,
+      agents_dir: "~/.switchroom/agents",
+      skills_dir: "~/.switchroom/skills",
+    },
+    telegram: telegramConfig,
+    agents: { [name]: agentConfig },
+  };
+}
+
+function readAllow(agentDir: string): string[] {
+  const settings = JSON.parse(
+    readFileSync(join(agentDir, ".claude", "settings.json"), "utf-8"),
+  );
+  return settings.permissions.allow as string[];
+}
+
+describe("scaffold: tools.allow [all] keeps explicit additions (klanker re-ask fix)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "switchroom-all-explicit-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("keeps an operator-persisted privileged/Skill/3p-MCP rule alongside [all]", () => {
+    // This is exactly what a 🔁 Always tap persists into switchroom.yaml for an
+    // already-[all] admin agent: [all, <the just-approved rule>].
+    const config = makeAgentConfig({
+      tools: {
+        allow: ["all", "mcp__hostd__agent_logs", "Skill(schedule)", "mcp__perplexity-ask__perplexity_ask"],
+        deny: [],
+      },
+    });
+    const switchroomConfig = makeSwitchroomConfig("admin-agent", config);
+    const result = scaffoldAgent("admin-agent", config, tmpDir, telegramConfig, switchroomConfig);
+    const allow = readAllow(result.agentDir);
+
+    // The explicit additions reach settings.json — the agent will NOT re-ask.
+    expect(allow).toContain("mcp__hostd__agent_logs");
+    expect(allow).toContain("Skill(schedule)");
+    expect(allow).toContain("mcp__perplexity-ask__perplexity_ask");
+    // [all] still expands to the built-ins.
+    expect(allow).toContain("Bash");
+    expect(allow).toContain("Read");
+    // The literal "all" token is never emitted (Claude Code rejects it).
+    expect(allow).not.toContain("all");
+  });
+
+  it("[all] alone still expands to built-ins (acceptEdits, no regression)", () => {
+    const config = makeAgentConfig({ tools: { allow: ["all"], deny: [] } });
+    const switchroomConfig = makeSwitchroomConfig("all-agent", config);
+    const result = scaffoldAgent("all-agent", config, tmpDir, telegramConfig, switchroomConfig);
+    const settings = JSON.parse(
+      readFileSync(join(result.agentDir, ".claude", "settings.json"), "utf-8"),
+    );
+    const allow = settings.permissions.allow as string[];
+
+    expect(allow).toContain("Bash");
+    expect(allow).toContain("Edit");
+    expect(allow).not.toContain("all");
+    // hasAllWildcard drives defaultMode acceptEdits.
+    expect(settings.permissions.defaultMode).toBe("acceptEdits");
+  });
+
+  it("non-[all] explicit allow is unchanged (no built-ins injected)", () => {
+    const config = makeAgentConfig({ tools: { allow: ["mcp__hostd__agent_logs"], deny: [] } });
+    const switchroomConfig = makeSwitchroomConfig("narrow-agent", config);
+    const result = scaffoldAgent("narrow-agent", config, tmpDir, telegramConfig, switchroomConfig);
+    const allow = readAllow(result.agentDir);
+
+    expect(allow).toContain("mcp__hostd__agent_logs");
+    // Without [all], the built-ins are NOT force-added (only read-only defaults
+    // when nothing was specified — here something WAS specified).
+    expect(allow).not.toContain("Bash");
+  });
+});


### PR DESCRIPTION
Two independent fixes surfaced while diagnosing why admin agent **klanker re-asks the same permission forever** despite the v0.15.18/v0.15.20 scoped-approval + always-allow work.

## Fix 1 (headline) — `tools.allow: [all]` drops explicit grants → permission re-ask

**Root cause.** An agent with `tools.allow: [all]` expands to `ALL_BUILTIN_TOOLS` + switchroom-managed MCP tokens, **deliberately excluding** privileged hostd tools, `Skill(...)`, and 3rd-party MCP (the leash — even an `[all]` admin approves those once). The intended "stop asking" path is a 🔁 **Always** tap, which now (post v0.15.23 EROFS fix) durably persists the specific rule into the agent's `tools.allow` via hostd `config_propose_edit`, producing `[all, mcp__hostd__agent_logs]`.

But `scaffold.ts` set `baseAllow = ALL_BUILTIN_TOOLS` on the `[all]` branch and **dropped every other entry** in `tools.allow`. So the operator-persisted rule never reached the agent's `settings.json` `permissions.allow` → the agent re-asked on the very next turn. klanker tapped 🔁 Always **22 times**; none ever stuck (gateway log: 22× `always-allow added rule` with the rule never landing in resolved settings.json; `scoped-approval` never fired because `resolveTimeBox` excludes MCP/Skill by design).

**Fix.** Both render sites (`buildWorkspaceContext` + reconcile): when `hasAllWildcard`, keep the explicit non-`"all"` entries alongside the built-ins —
`[...ALL_BUILTIN_TOOLS, ...rawAllow.filter(t => t !== "all")]`. Strictly additive; honors the operator's explicit grant; `[all]`-alone behaviour unchanged.

## Fix 2 (nit) — apply recreate-hint prints `/host-home`

When `switchroom apply` runs inside hostd, the "Wrote …" line + `docker compose -f <path>` hint printed a `/host-home/.switchroom/compose/...` path no host operator can copy-paste. Translate the **displayed** path via the existing `toHostHomePath` helper (#2353). Display-only — the file is still written to `composePath`; the returned value is unchanged. No-op on the host.

## Test plan
- [x] `tests/scaffold.all-wildcard-keeps-explicit.test.ts` (new): `[all, mcp__hostd__agent_logs, Skill(schedule), mcp__perplexity-ask__*]` now lands all three in `settings.json`; `[all]`-alone still expands to built-ins + `defaultMode: acceptEdits`; non-`[all]` explicit allow unchanged. (Fails without the fix.)
- [x] Fix 2 reuses the already-unit-tested `toHostHomePath`.
- [x] `vitest run tests/scaffold tests/reconcile tests/apply src/agents/scaffold.test.ts` → 341 passed.
- [x] `tsc --noEmit` clean.

## Risk
Fix 1 is additive (strictly more permissive, only for tools the operator explicitly listed) and fleet-wide; it takes effect on the next reconcile (host CLI / hostd regenerate `settings.json`). Fix 2 is display-only. Both ride a hostd + host-CLI roll (the generators); agents pick up the new `settings.json` on next reconcile/restart.

## Follow-up (needs operator product call, not in this PR)
`resolveTimeBox` (scoped 30-min approval) excludes all MCP/Skill tools, so tapping ✅ **Allow** (vs Always) gives klanker zero 30-min dedup for its tools. Extending it to time-box *specific* non-broad MCP/Skill tools is a separate PR pending a security decision (MCP args are resource-blind).