### PR TITLE
fix(approval): time-box read-only Grep/Glob so ✅ Allow stops re-prompting

### DIFF
--- a/telegram-plugin/scoped-approval.ts
+++ b/telegram-plugin/scoped-approval.ts
@@ -83,6 +83,16 @@ export interface TimeBoxDecision {
 const FILE_RULE = /^(Edit|Write|MultiEdit|NotebookEdit|Read)\((.+)\)$/;
 const BASH_FAMILY_RULE = /^Bash\(([^:]+):\*\)$/;
 
+// Read-only whole-tool inspection tools. permission-rule.ts classifies these
+// as BROAD_ONLY (no meaningful path sub-scope — Grep/Glob match a pattern
+// across files), so they only ever offer a broad "any Grep/Glob" grant. They
+// are READ-ONLY — they cannot mutate anything — so time-boxing that broad grant
+// is low-risk and is exactly the dominant "stop re-asking for the same
+// low-risk inspection" case (e.g. grepping a file with several regexes). This
+// deliberately EXCLUDES WebFetch/WebSearch (also BROAD_ONLY): network egress is
+// a different risk class, and webkite denies them anyway.
+const READ_ONLY_WHOLE_TOOLS = new Set(["Grep", "Glob"]);
+
 /**
  * Conservative time-box eligibility. Given the already-resolved scope
  * choices for a permission request, return the NARROW rule to time-box
@@ -96,12 +106,24 @@ const BASH_FAMILY_RULE = /^Bash\(([^:]+):\*\)$/;
  *    triggering command itself is non-destructive. The family grant
  *    still covers the whole `<tok>` family for matching, but match-time
  *    re-checks each later command (see `lookupScopedGrant`).
+ *  - Read-only whole-tool inspection (Grep/Glob) → time-boxable on the
+ *    broad grant: no sub-scope exists, but they cannot mutate anything, so
+ *    "any Grep for 30 min" is the safe, dominant low-risk-repeat case.
  */
 export function resolveTimeBox(
   toolName: string,
   inputPreview: string | undefined,
   choices: ScopedAllowChoices | null,
 ): TimeBoxDecision | null {
+  // Read-only whole-tool inspection (Grep/Glob) has no narrow sub-scope, only
+  // a broad grant — but it is read-only, so the broad grant is safe to
+  // time-box and is the dominant low-risk-repeat case. A stored bare-tool
+  // rule ("Grep") matches every later Grep call (matchesAllowRule: rule ===
+  // toolName), so different regexes/paths all dedup for the window.
+  if (READ_ONLY_WHOLE_TOOLS.has(toolName) && choices?.broad) {
+    return { rule: choices.broad.rule, breadth: `any ${toolName}` };
+  }
+
   // Only ever time-box the narrow scope, and only when one exists.
   const specific = choices?.specific;
   if (!specific || specific.broad) return null;

--- a/telegram-plugin/tests/scoped-approval.test.ts
+++ b/telegram-plugin/tests/scoped-approval.test.ts
@@ -100,6 +100,26 @@ describe('resolveTimeBox — conservative eligibility', () => {
     expect(timeBoxRule('Skill', JSON.stringify({ skill: 'deep-research' }))).toBeNull()
     expect(timeBoxRule('TotallyUnknown', '{}')).toBeNull()
   })
+
+  it('time-boxes read-only whole-tool inspection (Grep/Glob) on the broad grant', () => {
+    // No narrow sub-scope exists (BROAD_ONLY), but they are read-only — so the
+    // broad grant is safe to time-box. This is the dominant "stop re-asking for
+    // the same low-risk inspection" case the operator wants.
+    expect(timeBoxRule('Grep', JSON.stringify({ pattern: 'foo', path: '/state/x.ts' }))).toBe('Grep')
+    expect(timeBoxRule('Glob', JSON.stringify({ pattern: '**/*.ts' }))).toBe('Glob')
+  })
+
+  it('honest breadth for the read-only whole-tool window', () => {
+    const choices = resolveScopedAllowChoices('Grep', JSON.stringify({ pattern: 'foo' }))
+    expect(resolveTimeBox('Grep', JSON.stringify({ pattern: 'foo' }), choices)?.breadth).toBe('any Grep')
+  })
+
+  it('still does NOT time-box network-egress broad-only tools (WebFetch/WebSearch)', () => {
+    // Read-only-of-the-filesystem is the bar; network egress is a different
+    // risk class and is excluded on purpose (also denied via webkite).
+    expect(timeBoxRule('WebFetch', JSON.stringify({ url: 'https://x' }))).toBeNull()
+    expect(timeBoxRule('WebSearch', JSON.stringify({ query: 'x' }))).toBeNull()
+  })
 })
 
 describe('lookupScopedGrant — no seed, no extend, fail closed', () => {
@@ -119,6 +139,19 @@ describe('lookupScopedGrant — no seed, no extend, fail closed', () => {
     const store: ScopedGrantStore = new Map()
     recordScopedGrant(store, 'clerk', 'Edit(/state/x.ts)', T0, TTL)
     expect(lookupScopedGrant(store, 'clerk', 'Edit', editInput('/state/y.ts'), T0 + 1)).toBeNull()
+  })
+
+  it('a Grep grant dedups later Greps with DIFFERENT regexes (the spam case)', () => {
+    // Operator taps ✅ Allow on the first Grep → whole-tool window. The agent
+    // then greps the same file with 2 more regexes — both auto-allow, no
+    // re-prompt, for the life of the window.
+    const store: ScopedGrantStore = new Map()
+    const t = resolveTimeBox('Grep', JSON.stringify({ pattern: 'foo' }), resolveScopedAllowChoices('Grep', JSON.stringify({ pattern: 'foo' })))
+    recordScopedGrant(store, 'clerk', t!.rule, T0, TTL)
+    expect(lookupScopedGrant(store, 'clerk', 'Grep', JSON.stringify({ pattern: 'bar' }), T0 + 1_000)).toBe('Grep')
+    expect(lookupScopedGrant(store, 'clerk', 'Grep', JSON.stringify({ pattern: 'baz', path: '/state/other.ts' }), T0 + 2_000)).toBe('Grep')
+    // …and it still fails closed after the window.
+    expect(lookupScopedGrant(store, 'clerk', 'Grep', JSON.stringify({ pattern: 'bar' }), T0 + TTL)).toBeNull()
   })
 
   it('FIXED window — a matching call never extends expiresAt', () => {


### PR DESCRIPTION
## Summary

The scoped **30-min approval** (tap ✅ Allow on a low-risk action → the same action auto-allows for 30 min, shipped v0.15.13/v0.15.18) had fired **zero times across the entire fleet** (verified: 0 `scoped-approval granted via Allow` / `auto-allow` log lines on all 12 agents, though the code is deployed in the v0.15.23 bundle).

**Why it never fired:** `resolveTimeBox` only time-boxes `FILE_RULE` (Read/Edit/Write/MultiEdit/NotebookEdit of an exact path) and non-destructive Bash families. But those are usually **pre-approved built-ins** → they rarely prompt. The tools that actually prompt *and repeat* — **Grep and Glob** — are `BROAD_ONLY` in `permission-rule.ts` (no path sub-scope), and `resolveTimeBox` refuses **every** broad rule (`if (!specific || specific.broad) return null`). So an agent grepping a file with 3 different regexes re-asked on **every** regex, even after the operator tapped ✅ Allow.

## Fix

Time-box the broad grant for **read-only whole-tool inspection** (`Grep`, `Glob`). They can't mutate anything, so "any Grep for 30 min" is low-risk and is exactly the dominant repeat case. A stored bare-tool rule `"Grep"` matches every later Grep call (`matchesAllowRule`: `rule === toolName`), so different regexes/paths all dedup for the window.

Deliberately **excludes** the other `BROAD_ONLY` tools `WebFetch`/`WebSearch` — network egress is a different risk class (and webkite denies them).

Access-model invariants unchanged: gateway-side only (no rule pushed to the bridge), TTL-bounded, fail-closed on expiry, per-agent isolation, behind the existing `SWITCHROOM_SCOPED_APPROVAL_TTL_MS=0` kill-switch.

JTBD: **you hold the leash** without babysitting — low-risk read-only repeats stop spamming approvals; everything mutating/privileged still prompts.

## Test plan
- [x] `telegram-plugin/tests/scoped-approval.test.ts`: `resolveTimeBox` now boxes Grep/Glob with honest `any Grep` breadth; a Grep grant dedups later Greps with **different regexes**; still fails closed after the window; WebFetch/WebSearch still NOT boxed.
- [x] `vitest run` scoped-approval + permission-rule + permission-title → 117 passed.
- [x] `tsc --noEmit` clean.

## Risk
Low + additive: widens the time-box allowlist by two read-only tools within an already-shipped, TTL-bounded, kill-switchable mechanism. Fleet-wide (gateway runs in-agent) → needs a release + agent roll to take effect.