### PR TITLE
feat(linear): durable token refresh core — store bundle at setup + refresh verb

### DIFF
--- a/src/cli/linear-agent.ts
+++ b/src/cli/linear-agent.ts
@@ -25,17 +25,26 @@ import chalk from "chalk";
 import { readFileSync, writeFileSync } from "node:fs";
 import { getConfigPath, withConfigError } from "./helpers.js";
 import { setLinearAgent, setLinearDefaultTeam } from "./telegram-yaml.js";
-import { vaultPut } from "./telegram.js";
+import { vaultPut, vaultPutQuiet, vaultGet } from "./telegram.js";
+import { performLinearRefresh, serializeBundle } from "../linear/oauth-refresh.js";
 
 interface LinearAgentSetupOpts {
   agent: string;
   token: string;
+  refreshToken?: string;
+  tokenExpiresIn?: string;
   clientId?: string;
   clientSecret?: string;
   redirectUri?: string;
   workspaceId?: string;
   webhookBase?: string;
   dryRun?: boolean;
+}
+
+/** Vault key holding the agent's rotatable OAuth refresh bundle (JSON
+ *  string: {client_id, client_secret, refresh_token, expires_at}). */
+function bundleKeyFor(agent: string): string {
+  return `linear/${agent}/oauth`;
 }
 
 export function registerLinearAgentCommand(program: Command): void {
@@ -55,8 +64,10 @@ export function registerLinearAgentCommand(program: Command): void {
       "--token <token>",
       "The Linear OAuth app token (actor=app), obtained out-of-band via the browser authorize step. Stored in the vault, never in switchroom.yaml.",
     )
-    .option("--client-id <id>", "Linear OAuth app client id (for the printed authorize-URL hint).")
-    .option("--client-secret <secret>", "Linear OAuth app client secret (informational — not stored by this verb).")
+    .option("--client-id <id>", "Linear OAuth app client id. Stored (with --client-secret + --refresh-token) to enable unattended token refresh.")
+    .option("--client-secret <secret>", "Linear OAuth app client secret. Stored in the vault (with --client-id + --refresh-token) so the token can be refreshed without a browser re-auth.")
+    .option("--refresh-token <token>", "The refresh_token from the OAuth exchange. Stored so an expired access token self-heals (see 'linear-agent refresh').")
+    .option("--token-expires-in <seconds>", "expires_in from the OAuth token response (seconds). Records when the access token expires so refresh runs proactively. Defaults to 86400.")
     .option("--redirect-uri <uri>", "OAuth redirect URI registered on the Linear app (for the authorize-URL hint).")
     .option("--workspace-id <id>", "Optional Linear workspace (organization) id to record in config.")
     .option(
@@ -74,10 +85,29 @@ export function registerLinearAgentCommand(program: Command): void {
         }
 
         const vaultKey = `linear/${opts.agent}/token`;
+        const bundleKey = bundleKeyFor(opts.agent);
+        // Auto-refresh needs the full set: refresh_token + the app creds to
+        // exchange it. Anything less stores only the (short-lived) access
+        // token, same as before.
+        const canRefresh = Boolean(opts.refreshToken && opts.clientId && opts.clientSecret);
         if (!opts.dryRun) {
           await vaultPut(program, vaultKey, opts.token);
+          if (canRefresh) {
+            const expiresIn = Number.parseInt(opts.tokenExpiresIn ?? "", 10);
+            const ttl = Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : 86400;
+            const bundle = serializeBundle({
+              clientId: opts.clientId!,
+              clientSecret: opts.clientSecret!,
+              refreshToken: opts.refreshToken!,
+              expiresAt: Math.floor(Date.now() / 1000) + ttl,
+            });
+            await vaultPutQuiet(program, bundleKey, bundle);
+          }
         } else {
           console.log(chalk.gray(`[dry-run] would store the Linear token in the vault as '${vaultKey}'`));
+          if (canRefresh) {
+            console.log(chalk.gray(`[dry-run] would store the refresh bundle as '${bundleKey}' (enables auto-refresh)`));
+          }
         }
 
         const path = getConfigPath(program);
@@ -99,10 +129,72 @@ export function registerLinearAgentCommand(program: Command): void {
           writeFileSync(path, after, "utf-8");
           console.log(chalk.green(`✓ Enabled linear-agent for agent '${opts.agent}'`));
           console.log(chalk.gray(`  Vault key: ${vaultKey}`));
+          if (canRefresh) {
+            console.log(chalk.green(`✓ Auto-refresh enabled — refresh bundle stored at '${bundleKey}'`));
+            console.log(
+              chalk.gray(
+                `  Add '${bundleKey}' to agents.${opts.agent}.secrets[] so the agent can rotate it in-container (broker put).`,
+              ),
+            );
+          } else {
+            console.log(
+              chalk.yellow(
+                `⚠ No refresh bundle stored — the access token will expire (~24h) and need a manual re-auth.`,
+              ),
+            );
+            console.log(
+              chalk.gray(
+                `  To enable auto-refresh, re-run with --refresh-token <rt> --client-id <id> --client-secret <secret> --token-expires-in <sec>.`,
+              ),
+            );
+          }
           console.log(chalk.gray(`  Run 'switchroom agent restart ${opts.agent}' to pick up the change.`));
         }
 
         printLinearInstructions(opts, vaultKey);
+      }),
+    );
+
+  linear
+    .command("refresh")
+    .description(
+      "Refresh <agent>'s Linear app token using the stored refresh bundle (linear/<agent>/oauth). Exchanges the refresh_token for a fresh access token, writes it to linear/<agent>/token, and rotates the stored refresh_token + expiry. Use to recover an expired token or seed automation. Host-side write — the running agent picks it up on its next broker re-mirror / restart.",
+    )
+    .requiredOption("--agent <name>", "Agent name (must have a linear_agent block)")
+    .action(
+      withConfigError(async (opts: { agent: string }) => {
+        if (!/^[a-z][a-z0-9_-]{0,63}$/.test(opts.agent)) {
+          fail(`--agent must be a lowercase agent slug (got '${opts.agent}').`);
+        }
+        const bundleKey = bundleKeyFor(opts.agent);
+        const res = await performLinearRefresh({
+          readBundle: () => vaultGet(program, bundleKey),
+          writeToken: (t) => vaultPutQuiet(program, `linear/${opts.agent}/token`, t),
+          writeBundle: (json) => vaultPutQuiet(program, bundleKey, json),
+        });
+        if (!res.ok) {
+          if (res.reason === "no_bundle") {
+            fail(
+              `No refresh bundle at '${bundleKey}'. Provision one via 'linear-agent setup --agent ${opts.agent} ` +
+                `--token <t> --refresh-token <rt> --client-id <id> --client-secret <secret>'.`,
+            );
+          }
+          if (res.reason === "revoked") {
+            fail(
+              `Refresh token is dead (revoked/expired) — re-authorize in a browser (actor=app) and re-run setup with the new --refresh-token. (${res.detail})`,
+            );
+          }
+          fail(`Refresh failed (${res.reason}): ${res.detail}`);
+        }
+        if (res.ok) {
+          const hours = Math.max(1, Math.round((res.expiresAt - Date.now() / 1000) / 3600));
+          console.log(chalk.green(`✓ Refreshed Linear token for '${opts.agent}' (expires in ~${hours}h).`));
+          console.log(
+            chalk.gray(
+              `  Written to vault:linear/${opts.agent}/token (+ rotated bundle). Restart the agent or wait for the broker to re-mirror.`,
+            ),
+          );
+        }
       }),
     );
 

--- a/src/cli/telegram.ts
+++ b/src/cli/telegram.ts
@@ -25,7 +25,7 @@ import {
 } from "../web/webhook-dispatch.js";
 import { createInterface } from "node:readline";
 import { resolvePath, loadConfig } from "../config/loader.js";
-import { createVault, setStringSecret } from "../vault/vault.js";
+import { createVault, setStringSecret, getStringSecret } from "../vault/vault.js";
 import { getConfig, getConfigPath, withConfigError } from "./helpers.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { resolveStatePath } from "../config/paths.js";
@@ -627,6 +627,33 @@ export async function vaultPut(program: Command, key: string, value: string): Pr
   }
   setStringSecret(passphrase, vaultPath, key, value);
   console.log(chalk.green(`✓ Stored secret in vault as '${key}'`));
+}
+
+/**
+ * Host-side vault write that does NOT print (the quiet sibling of
+ * `vaultPut`). For verbs that store several keys in one operation and
+ * render their own summary (e.g. the linear-agent token+bundle store).
+ */
+export async function vaultPutQuiet(program: Command, key: string, value: string): Promise<void> {
+  const configPath = (program.optsWithGlobals().config as string | undefined) ?? undefined;
+  const vaultPath = resolveVaultPath(configPath);
+  const passphrase = await getVaultPassphrase();
+  if (!existsSync(vaultPath)) createVault(passphrase, vaultPath);
+  setStringSecret(passphrase, vaultPath, key, value);
+}
+
+/**
+ * Host-side vault read (direct file decrypt, operator passphrase). Returns
+ * null when the key is absent. Used by verbs that need to read a stored
+ * secret programmatically — e.g. `linear-agent refresh` reading the OAuth
+ * bundle before exchanging the refresh token.
+ */
+export async function vaultGet(program: Command, key: string): Promise<string | null> {
+  const configPath = (program.optsWithGlobals().config as string | undefined) ?? undefined;
+  const vaultPath = resolveVaultPath(configPath);
+  if (!existsSync(vaultPath)) return null;
+  const passphrase = await getVaultPassphrase();
+  return getStringSecret(passphrase, vaultPath, key);
 }
 
 function resolveVaultPath(configPath?: string): string {

--- a/src/linear/oauth-refresh.ts
+++ b/src/linear/oauth-refresh.ts
@@ -1,0 +1,246 @@
+/**
+ * Linear OAuth app-token refresh — pure logic (#2298 follow-up).
+ *
+ * Linear's `actor=app` token exchange returns a SHORT-LIVED access token
+ * (`expires_in ≈ 24h`) plus a `refresh_token`. The original
+ * `linear-agent setup` stored only the access token, so app actors went
+ * dead every day and needed a manual browser re-auth. This module is the
+ * durable fix's core: exchange the refresh token for a fresh access token
+ * (and possibly-rotated refresh token) so an agent stays a first-class
+ * Linear app actor without operator hand-holding.
+ *
+ * Pure + injectable (`fetchImpl`, `nowSec`) so it is unit-testable without
+ * the network or a clock. The refresh BUNDLE — `{client_id, client_secret,
+ * refresh_token, expires_at}` — is stored in the vault under
+ * `linear/<agent>/oauth` (a JSON string); the access token stays at
+ * `linear/<agent>/token` (what the runtime reads). Both are rotated in
+ * place via the broker `put` op (the #950 in-container rotation path), so
+ * neither the agent nor a scheduled refresh needs the operator passphrase.
+ */
+
+export const LINEAR_TOKEN_ENDPOINT = "https://api.linear.app/oauth/token";
+
+/** Default proactive-refresh skew: refresh when the access token is within
+ *  2h of expiry, so a near-expiry token is replaced on its next use rather
+ *  than failing the call. */
+export const DEFAULT_REFRESH_SKEW_SEC = 2 * 3600;
+
+export interface LinearOAuthBundle {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  /** Epoch SECONDS at which the current access token expires. Optional —
+   *  bundles provisioned before expiry tracking won't carry it. */
+  expiresAt?: number;
+}
+
+export type RefreshResult =
+  | {
+      ok: true;
+      accessToken: string;
+      /** The refresh token to persist — the rotated one if Linear returned
+       *  a new one, else the same one we sent (Linear may or may not
+       *  rotate). */
+      refreshToken: string;
+      /** Epoch seconds the new access token expires. */
+      expiresAt: number;
+      scope?: string;
+    }
+  | {
+      ok: false;
+      /** `revoked` = the refresh token itself is dead (operator must
+       *  re-authorize in a browser); everything else is transient/retryable. */
+      reason: "revoked" | "network" | "http_error" | "bad_response";
+      detail: string;
+    };
+
+/**
+ * Exchange a refresh token for a fresh access token at Linear's token
+ * endpoint. Never throws — returns a tagged result. NEVER logs the token
+ * values (the caller controls logging; this returns data, not side effects).
+ */
+export async function refreshLinearAppToken(
+  bundle: Pick<LinearOAuthBundle, "clientId" | "clientSecret" | "refreshToken">,
+  opts: { fetchImpl?: typeof fetch; nowSec?: () => number } = {},
+): Promise<RefreshResult> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const nowSec = opts.nowSec ?? (() => Math.floor(Date.now() / 1000));
+
+  const form = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: bundle.refreshToken,
+    client_id: bundle.clientId,
+    client_secret: bundle.clientSecret,
+  });
+
+  let resp: Response;
+  try {
+    resp = await fetchImpl(LINEAR_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: form.toString(),
+    });
+  } catch (err) {
+    return { ok: false, reason: "network", detail: (err as Error).message };
+  }
+
+  if (!resp.ok) {
+    const txt = await resp.text().catch(() => "");
+    // A dead refresh token surfaces as 400 invalid_grant — that's the one
+    // case unattended refresh can't fix; the operator must re-authorize.
+    const revoked = resp.status === 400 || /invalid_grant|invalid_token/i.test(txt);
+    return {
+      ok: false,
+      reason: revoked ? "revoked" : "http_error",
+      detail: `HTTP ${resp.status}${txt ? ` ${txt.slice(0, 200)}` : ""}`,
+    };
+  }
+
+  let json: {
+    access_token?: unknown;
+    refresh_token?: unknown;
+    expires_in?: unknown;
+    scope?: unknown;
+  };
+  try {
+    json = (await resp.json()) as typeof json;
+  } catch {
+    return { ok: false, reason: "bad_response", detail: "non-JSON token response" };
+  }
+
+  const accessToken = json.access_token;
+  if (typeof accessToken !== "string" || accessToken.length === 0) {
+    return { ok: false, reason: "bad_response", detail: "no access_token in response" };
+  }
+  const expiresIn = typeof json.expires_in === "number" ? json.expires_in : 86400;
+  const rotated =
+    typeof json.refresh_token === "string" && json.refresh_token.length > 0
+      ? json.refresh_token
+      : bundle.refreshToken;
+
+  return {
+    ok: true,
+    accessToken,
+    refreshToken: rotated,
+    expiresAt: nowSec() + expiresIn,
+    ...(typeof json.scope === "string" ? { scope: json.scope } : {}),
+  };
+}
+
+/**
+ * Whether a proactive refresh is due. True when the access token is at or
+ * past `expiresAt - skew`. Unknown expiry (`undefined`) returns false: we
+ * don't churn on bundles that predate expiry tracking — the on-401 reactive
+ * path still covers them.
+ */
+export function needsRefresh(
+  expiresAt: number | undefined,
+  nowSec: number,
+  skewSec: number = DEFAULT_REFRESH_SKEW_SEC,
+): boolean {
+  if (expiresAt == null) return false;
+  return nowSec >= expiresAt - skewSec;
+}
+
+/** Parse the JSON-string bundle stored at `linear/<agent>/oauth`. Returns
+ *  null on absent / malformed / incomplete (missing required field) input —
+ *  callers treat null as "no refresh capability". */
+export function parseBundle(raw: string | null | undefined): LinearOAuthBundle | null {
+  if (raw == null || raw === "") return null;
+  let o: Record<string, unknown>;
+  try {
+    o = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  if (
+    typeof o.client_id === "string" &&
+    typeof o.client_secret === "string" &&
+    typeof o.refresh_token === "string" &&
+    o.client_id.length > 0 &&
+    o.client_secret.length > 0 &&
+    o.refresh_token.length > 0
+  ) {
+    return {
+      clientId: o.client_id,
+      clientSecret: o.client_secret,
+      refreshToken: o.refresh_token,
+      ...(typeof o.expires_at === "number" ? { expiresAt: o.expires_at } : {}),
+    };
+  }
+  return null;
+}
+
+/** Serialize a bundle to the JSON-string vault shape. */
+export function serializeBundle(b: LinearOAuthBundle): string {
+  return JSON.stringify({
+    client_id: b.clientId,
+    client_secret: b.clientSecret,
+    refresh_token: b.refreshToken,
+    ...(b.expiresAt != null ? { expires_at: b.expiresAt } : {}),
+  });
+}
+
+/**
+ * Injectable I/O for {@link performLinearRefresh} — the same orchestration
+ * the host `linear-agent refresh` verb (vault-backed) and the in-container
+ * runtime auto-refresh (broker-backed) both run. Reads the bundle, exchanges
+ * the refresh token, and persists the new access token + rotated bundle.
+ */
+export interface RefreshIO {
+  /** Return the raw JSON bundle from `linear/<agent>/oauth` (or null). */
+  readBundle: () => Promise<string | null>;
+  /** Persist the fresh access token to `linear/<agent>/token`. */
+  writeToken: (accessToken: string) => Promise<void>;
+  /** Persist the rotated bundle JSON to `linear/<agent>/oauth`. */
+  writeBundle: (json: string) => Promise<void>;
+  fetchImpl?: typeof fetch;
+  nowSec?: () => number;
+}
+
+export type PerformRefreshResult =
+  | { ok: true; expiresAt: number }
+  | {
+      ok: false;
+      reason: "no_bundle" | "revoked" | "network" | "http_error" | "bad_response" | "persist_failed";
+      detail: string;
+    };
+
+/**
+ * Read bundle → refresh → persist token + rotated bundle. Pure orchestration
+ * over injected I/O so it is identical and testable across the host (vault)
+ * and runtime (broker) call sites. On any read/refresh/persist failure it
+ * returns a tagged result and writes nothing further (so a failed persist
+ * can't leave the access token rotated while the bundle still holds the old
+ * refresh token).
+ */
+export async function performLinearRefresh(io: RefreshIO): Promise<PerformRefreshResult> {
+  const raw = await io.readBundle();
+  const bundle = parseBundle(raw);
+  if (!bundle) {
+    return { ok: false, reason: "no_bundle", detail: "no/invalid refresh bundle" };
+  }
+  const res = await refreshLinearAppToken(bundle, {
+    ...(io.fetchImpl ? { fetchImpl: io.fetchImpl } : {}),
+    ...(io.nowSec ? { nowSec: io.nowSec } : {}),
+  });
+  if (!res.ok) return { ok: false, reason: res.reason, detail: res.detail };
+  try {
+    // Persist the rotated bundle FIRST: if the token write then fails, the
+    // bundle still carries the (now-current) refresh token, so a retry can
+    // recover. Persisting the token first and the bundle-write failing would
+    // strand the rotated refresh token (next refresh would use the dead one).
+    await io.writeBundle(
+      serializeBundle({
+        clientId: bundle.clientId,
+        clientSecret: bundle.clientSecret,
+        refreshToken: res.refreshToken,
+        expiresAt: res.expiresAt,
+      }),
+    );
+    await io.writeToken(res.accessToken);
+  } catch (err) {
+    return { ok: false, reason: "persist_failed", detail: (err as Error).message };
+  }
+  return { ok: true, expiresAt: res.expiresAt };
+}

--- a/tests/linear-oauth-refresh.test.ts
+++ b/tests/linear-oauth-refresh.test.ts
@@ -191,3 +191,22 @@ describe("performLinearRefresh (orchestration over injected I/O)", () => {
     if (!res.ok) { expect(res.reason).toBe("persist_failed"); expect(res.detail).toContain("broker denied"); }
   });
 });
+
+describe("performLinearRefresh — rotation-safety on partial persist", () => {
+  it("writeBundle succeeds but writeToken fails → persist_failed, BUT the rotated bundle WAS written (recovery possible)", async () => {
+    let writtenBundle: string | null = null;
+    const res = await performLinearRefresh({
+      readBundle: async () => serializeBundle(BUNDLE),
+      writeBundle: async (j) => { writtenBundle = j; }, // succeeds
+      writeToken: async () => { throw new Error("token write failed"); }, // fails AFTER bundle
+      fetchImpl: fakeFetch(200, { access_token: "lin_new", refresh_token: "lin_refresh_rotated", expires_in: 3600 }),
+      nowSec: () => 0,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe("persist_failed");
+    // The doc's core claim: the rotated refresh token is persisted, so a
+    // retry reads it and recovers — nothing stranded on the dead old one.
+    expect(writtenBundle).not.toBeNull();
+    expect(parseBundle(writtenBundle)).toMatchObject({ refreshToken: "lin_refresh_rotated" });
+  });
+});

--- a/tests/linear-oauth-refresh.test.ts
+++ b/tests/linear-oauth-refresh.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Pure unit tests for the Linear OAuth refresh core.
+ * No network, no clock — fetch + nowSec injected.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  refreshLinearAppToken,
+  needsRefresh,
+  parseBundle,
+  serializeBundle,
+  performLinearRefresh,
+  LINEAR_TOKEN_ENDPOINT,
+  type LinearOAuthBundle,
+} from "../src/linear/oauth-refresh.js";
+
+const BUNDLE: LinearOAuthBundle = {
+  clientId: "cid",
+  clientSecret: "csecret",
+  refreshToken: "lin_refresh_old",
+  expiresAt: 1000,
+};
+
+function fakeFetch(
+  status: number,
+  body: unknown,
+  capture?: (url: string, init: RequestInit) => void,
+): typeof fetch {
+  return (async (url: string, init: RequestInit) => {
+    capture?.(url, init);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+      text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe("refreshLinearAppToken", () => {
+  it("POSTs the refresh grant form to Linear and returns the new token", async () => {
+    let seenUrl = "";
+    let seenBody = "";
+    const fetchImpl = fakeFetch(
+      200,
+      { access_token: "lin_new", refresh_token: "lin_refresh_new", expires_in: 86400, scope: "read write" },
+      (url, init) => {
+        seenUrl = url;
+        seenBody = String(init.body);
+      },
+    );
+    const r = await refreshLinearAppToken(BUNDLE, { fetchImpl, nowSec: () => 5000 });
+    expect(seenUrl).toBe(LINEAR_TOKEN_ENDPOINT);
+    expect(seenBody).toContain("grant_type=refresh_token");
+    expect(seenBody).toContain("refresh_token=lin_refresh_old");
+    expect(seenBody).toContain("client_id=cid");
+    expect(seenBody).toContain("client_secret=csecret");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.accessToken).toBe("lin_new");
+      expect(r.refreshToken).toBe("lin_refresh_new"); // rotated
+      expect(r.expiresAt).toBe(5000 + 86400);
+      expect(r.scope).toBe("read write");
+    }
+  });
+
+  it("keeps the OLD refresh token when Linear doesn't rotate it", async () => {
+    const fetchImpl = fakeFetch(200, { access_token: "lin_new", expires_in: 3600 });
+    const r = await refreshLinearAppToken(BUNDLE, { fetchImpl, nowSec: () => 0 });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.refreshToken).toBe("lin_refresh_old");
+      expect(r.expiresAt).toBe(3600);
+    }
+  });
+
+  it("classifies a dead refresh token (400 invalid_grant) as 'revoked'", async () => {
+    const r = await refreshLinearAppToken(BUNDLE, {
+      fetchImpl: fakeFetch(400, "invalid_grant: token revoked"),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("revoked");
+  });
+
+  it("classifies a 500 as transient http_error (not revoked)", async () => {
+    const r = await refreshLinearAppToken(BUNDLE, { fetchImpl: fakeFetch(503, "upstream down") });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("http_error");
+  });
+
+  it("network failure → reason 'network'", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const r = await refreshLinearAppToken(BUNDLE, { fetchImpl });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("network");
+  });
+
+  it("missing access_token → bad_response", async () => {
+    const r = await refreshLinearAppToken(BUNDLE, { fetchImpl: fakeFetch(200, { expires_in: 3600 }) });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("bad_response");
+  });
+});
+
+describe("needsRefresh", () => {
+  it("true at/after expiry-minus-skew; false comfortably before; false on unknown expiry", () => {
+    // expiresAt=1000, skew=100
+    expect(needsRefresh(1000, 800, 100)).toBe(false); // 200s left > skew
+    expect(needsRefresh(1000, 900, 100)).toBe(true); // exactly at skew boundary
+    expect(needsRefresh(1000, 950, 100)).toBe(true); // inside skew
+    expect(needsRefresh(1000, 2000, 100)).toBe(true); // already expired
+    expect(needsRefresh(undefined, 999999, 100)).toBe(false); // unknown → don't churn
+  });
+});
+
+describe("parseBundle / serializeBundle", () => {
+  it("round-trips a complete bundle", () => {
+    const s = serializeBundle(BUNDLE);
+    const b = parseBundle(s);
+    expect(b).toEqual(BUNDLE);
+  });
+
+  it("parses without expires_at", () => {
+    const b = parseBundle(JSON.stringify({ client_id: "a", client_secret: "b", refresh_token: "c" }));
+    expect(b).toEqual({ clientId: "a", clientSecret: "b", refreshToken: "c" });
+  });
+
+  it("returns null on absent / malformed / incomplete input", () => {
+    expect(parseBundle(null)).toBeNull();
+    expect(parseBundle("")).toBeNull();
+    expect(parseBundle("not json")).toBeNull();
+    expect(parseBundle(JSON.stringify({ client_id: "a", refresh_token: "c" }))).toBeNull(); // missing secret
+    expect(parseBundle(JSON.stringify({ client_id: "", client_secret: "b", refresh_token: "c" }))).toBeNull(); // empty
+  });
+});
+
+describe("performLinearRefresh (orchestration over injected I/O)", () => {
+  it("reads bundle, refreshes, persists rotated bundle THEN token", async () => {
+    const order: string[] = [];
+    let writtenToken = "";
+    let writtenBundle = "";
+    const res = await performLinearRefresh({
+      readBundle: async () => serializeBundle(BUNDLE),
+      writeBundle: async (j) => { order.push("bundle"); writtenBundle = j; },
+      writeToken: async (t) => { order.push("token"); writtenToken = t; },
+      fetchImpl: fakeFetch(200, { access_token: "lin_new", refresh_token: "lin_refresh_new", expires_in: 86400 }),
+      nowSec: () => 100,
+    });
+    expect(res).toEqual({ ok: true, expiresAt: 100 + 86400 });
+    // bundle persisted before token (rotation-safety)
+    expect(order).toEqual(["bundle", "token"]);
+    expect(writtenToken).toBe("lin_new");
+    expect(parseBundle(writtenBundle)).toMatchObject({ refreshToken: "lin_refresh_new", expiresAt: 100 + 86400 });
+  });
+
+  it("no/invalid bundle → no_bundle, nothing written", async () => {
+    let wrote = false;
+    const res = await performLinearRefresh({
+      readBundle: async () => null,
+      writeToken: async () => { wrote = true; },
+      writeBundle: async () => { wrote = true; },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe("no_bundle");
+    expect(wrote).toBe(false);
+  });
+
+  it("revoked refresh token surfaces and writes nothing", async () => {
+    let wrote = false;
+    const res = await performLinearRefresh({
+      readBundle: async () => serializeBundle(BUNDLE),
+      writeToken: async () => { wrote = true; },
+      writeBundle: async () => { wrote = true; },
+      fetchImpl: fakeFetch(400, "invalid_grant"),
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toBe("revoked");
+    expect(wrote).toBe(false);
+  });
+
+  it("persist failure is reported as persist_failed", async () => {
+    const res = await performLinearRefresh({
+      readBundle: async () => serializeBundle(BUNDLE),
+      writeBundle: async () => { throw new Error("broker denied"); },
+      writeToken: async () => {},
+      fetchImpl: fakeFetch(200, { access_token: "lin_new", expires_in: 3600 }),
+      nowSec: () => 0,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) { expect(res.reason).toBe("persist_failed"); expect(res.detail).toContain("broker denied"); }
+  });
+});


### PR DESCRIPTION
## Summary

Linear's `actor=app` token exchange returns a **short-lived access token** (`expires_in ≈ 24h`) + a `refresh_token`. The original `linear-agent setup` stored **only the access token**, so app actors (carrie, clerk) went dead every ~24h and needed a manual browser re-auth. This is the **foundation** of the durable fix.

## What this PR does

- **`src/linear/oauth-refresh.ts`** (new, pure + fully injectable):
  - `refreshLinearAppToken` — exchanges a refresh token at Linear's token endpoint; classifies a dead refresh token (`400 invalid_grant`) as **`revoked`** (the only case needing operator re-auth) vs transient `network`/`http_error`; keeps the old refresh token when Linear doesn't rotate.
  - `needsRefresh` (expiry+skew), `parseBundle`/`serializeBundle` (the `linear/<agent>/oauth` vault shape).
  - `performLinearRefresh` — read→refresh→persist orchestration over injected I/O, persisting the **rotated bundle before the access token** so a failed write can't strand a rotated refresh token.
- **`linear-agent setup`**: new `--refresh-token` / `--token-expires-in`, and now **stores** `--client-id`/`--client-secret` → persists the rotatable bundle at `linear/<agent>/oauth`; prints whether auto-refresh is enabled.
- **`linear-agent refresh --agent <name>`** (new verb): host-side refresh via the stored bundle; rotation-safe; clear "revoked → re-auth" message.
- `vaultGet` / `vaultPutQuiet` host helpers in `cli/telegram.ts`.

## Scope / staging

This makes refresh **possible and rotation-safe** — an operator (or a host cron) runs `linear-agent refresh`, and it takes effect on the agent's next broker re-mirror / restart. A **follow-up PR** wires fully-automatic **in-container refresh-on-use + on-401** via the broker `put` op (#950 — agents rotate keys they can read, no host passphrase), reusing `performLinearRefresh`, plus auto-adding the `linear/<agent>/oauth` ACL grant at setup.

## Test plan

- [x] 14 unit tests: refresh classification (revoked/transient/network/bad), rotation, expiry boundary, bundle parse, orchestration ordering + failure paths
- [x] `tsc --noEmit`, `node scripts/build.mjs` clean
- [x] existing `linear-agent-activity` tests unaffected

## Risk

Low — new pure module + additive CLI options/verb. No change to the runtime token-read path (that's the follow-up). Backward-compatible: agents provisioned without a bundle behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)