### PR TITLE
feat(linear): in-container auto-refresh on 401 — Linear tokens self-heal

### DIFF
--- a/src/cli/linear-agent.ts
+++ b/src/cli/linear-agent.ts
@@ -24,7 +24,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { readFileSync, writeFileSync } from "node:fs";
 import { getConfigPath, withConfigError } from "./helpers.js";
-import { setLinearAgent, setLinearDefaultTeam } from "./telegram-yaml.js";
+import { setLinearAgent, setLinearDefaultTeam, addAgentSecret } from "./telegram-yaml.js";
 import { vaultPut, vaultPutQuiet, vaultGet } from "./telegram.js";
 import { performLinearRefresh, serializeBundle } from "../linear/oauth-refresh.js";
 
@@ -118,6 +118,14 @@ export function registerLinearAgentCommand(program: Command): void {
             token: `vault:${vaultKey}`,
             ...(opts.workspaceId ? { workspaceId: opts.workspaceId } : {}),
           });
+          // Auto-refresh needs the agent to be able to read + rotate its
+          // refresh bundle via the broker — grant it ACL by adding the key
+          // to the agent's standing secrets[] (the access-token key is
+          // already there or added by the operator's standing grant).
+          if (canRefresh) {
+            after = addAgentSecret(after, opts.agent, bundleKey);
+            after = addAgentSecret(after, opts.agent, vaultKey);
+          }
         } catch (err) {
           fail((err as Error).message);
         }
@@ -133,7 +141,7 @@ export function registerLinearAgentCommand(program: Command): void {
             console.log(chalk.green(`✓ Auto-refresh enabled — refresh bundle stored at '${bundleKey}'`));
             console.log(
               chalk.gray(
-                `  Add '${bundleKey}' to agents.${opts.agent}.secrets[] so the agent can rotate it in-container (broker put).`,
+                `  Granted ACL: '${bundleKey}' + '${vaultKey}' added to agents.${opts.agent}.secrets[] (agent rotates them in-container on a 401).`,
               ),
             );
           } else {

--- a/src/cli/telegram-yaml.ts
+++ b/src/cli/telegram-yaml.ts
@@ -180,6 +180,30 @@ export function addWebhookSource(
 }
 
 /**
+ * Add a key to an agent's standing `secrets[]` list (the operator-set
+ * vault grant the broker mints the agent's read/rotate ACL from).
+ * Idempotent. Used by `linear-agent setup` to grant the agent ACL over
+ * its `linear/<agent>/oauth` refresh bundle so it can rotate the token
+ * in-container via the broker `put` op.
+ */
+export function addAgentSecret(yamlText: string, agentName: string, key: string): string {
+  const doc = parseDocument(yamlText);
+  ensureAgent(doc, agentName);
+  const existing = doc.getIn(["agents", agentName, "secrets"]);
+  if (isSeq(existing)) {
+    const seq = existing as YAMLSeq;
+    for (const item of seq.items) {
+      const v = (item as { value?: unknown }).value ?? item;
+      if (v === key) return yamlText; // idempotent
+    }
+    seq.add(key);
+  } else {
+    doc.setIn(["agents", agentName, "secrets"], [key]);
+  }
+  return String(doc);
+}
+
+/**
  * Remove a webhook source from the array. No-op when the source isn't
  * present. When the array becomes empty, the parent webhook_sources
  * entry is dropped (and empty parent maps pruned) so the YAML doesn't

--- a/src/linear/oauth-refresh.ts
+++ b/src/linear/oauth-refresh.ts
@@ -199,7 +199,7 @@ export interface RefreshIO {
 }
 
 export type PerformRefreshResult =
-  | { ok: true; expiresAt: number }
+  | { ok: true; accessToken: string; expiresAt: number }
   | {
       ok: false;
       reason: "no_bundle" | "revoked" | "network" | "http_error" | "bad_response" | "persist_failed";
@@ -242,5 +242,5 @@ export async function performLinearRefresh(io: RefreshIO): Promise<PerformRefres
   } catch (err) {
     return { ok: false, reason: "persist_failed", detail: (err as Error).message };
   }
-  return { ok: true, expiresAt: res.expiresAt };
+  return { ok: true, accessToken: res.accessToken, expiresAt: res.expiresAt };
 }

--- a/telegram-plugin/gateway/linear-activity.ts
+++ b/telegram-plugin/gateway/linear-activity.ts
@@ -17,8 +17,10 @@
 
 import {
   getViaBrokerStructured,
+  putViaBroker,
   readVaultTokenFile,
 } from '../../src/vault/broker/client.js'
+import { performLinearRefresh, type RefreshIO } from '../../src/linear/oauth-refresh.js'
 
 export const LINEAR_GRAPHQL_ENDPOINT = 'https://api.linear.app/graphql'
 
@@ -33,6 +35,10 @@ export interface LinearActivityDeps {
   fetchImpl?: typeof fetch
   /** Agent slug (defaults to SWITCHROOM_AGENT_NAME). */
   agent?: string
+  /** Build the RefreshIO used to auto-refresh on a 401 (tests inject a
+   *  fake; production uses the broker-backed `brokerRefreshIO`). When
+   *  omitted, on-401 refresh uses the broker. */
+  refreshIO?: (agent: string) => RefreshIO
   /** Default Linear team id for captured issues (multi-team workspaces);
    *  defaults to SWITCHROOM_LINEAR_DEFAULT_TEAM_ID. Tests inject directly. */
   defaultTeamId?: string
@@ -54,6 +60,79 @@ export async function defaultResolveLinearToken(agent: string): Promise<LinearTo
   if (result.kind === 'not_found') return { ok: false, reason: 'not_found' }
   if (result.kind === 'denied') return { ok: false, reason: 'denied' }
   return { ok: false, reason: 'unknown' }
+}
+
+/**
+ * Broker-backed RefreshIO: reads `linear/<agent>/oauth` and rotates both
+ * `linear/<agent>/token` and the bundle via the broker `put` op (#950 — an
+ * agent rotates keys it can already read, no operator passphrase, no host
+ * round-trip). Requires `linear/<agent>/oauth` to be in the agent's ACL
+ * (linear-agent setup adds it to `secrets[]`).
+ */
+export function brokerRefreshIO(agent: string, fetchImpl?: typeof fetch): RefreshIO {
+  const token = readVaultTokenFile(agent) ?? undefined
+  const opt = token ? { token } : {}
+  return {
+    readBundle: async () => {
+      const r = await getViaBrokerStructured(`linear/${agent}/oauth`, opt)
+      return r.kind === 'ok' && r.entry.kind === 'string' ? r.entry.value : null
+    },
+    writeToken: async (t) => {
+      const r = await putViaBroker(`linear/${agent}/token`, { kind: 'string', value: t }, opt)
+      if (r.kind !== 'ok') throw new Error(`broker put linear/${agent}/token: ${r.kind}`)
+    },
+    writeBundle: async (j) => {
+      const r = await putViaBroker(`linear/${agent}/oauth`, { kind: 'string', value: j }, opt)
+      if (r.kind !== 'ok') throw new Error(`broker put linear/${agent}/oauth: ${r.kind}`)
+    },
+    ...(fetchImpl ? { fetchImpl } : {}),
+  }
+}
+
+/**
+ * POST to Linear's GraphQL endpoint; on a 401 (expired/invalid app token)
+ * auto-refresh the token once via the stored refresh bundle and retry with
+ * the fresh token. This is the durable self-heal: a Linear app token that
+ * expired (~24h–30d) is silently rotated in-container on its next use rather
+ * than failing the agent's turn. A `revoked` refresh token (the one case
+ * needing operator re-auth) is logged loudly and the original 401 surfaces.
+ *
+ * Returns the final Response and the token in force (callers read the body).
+ */
+async function linearPostWithRefresh(
+  body: string,
+  token: string,
+  agent: string,
+  fetchImpl: typeof fetch,
+  log: (s: string) => void,
+  refreshIO?: (agent: string) => RefreshIO,
+): Promise<{ resp: Response; token: string }> {
+  const post = (t: string) =>
+    fetchImpl(LINEAR_GRAPHQL_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: t },
+      body,
+    })
+
+  let resp = await post(token)
+  if (resp.status !== 401) return { resp, token }
+
+  const io = (refreshIO ?? ((a) => brokerRefreshIO(a, fetchImpl)))(agent)
+  const refreshed = await performLinearRefresh({ ...io, fetchImpl })
+  if (!refreshed.ok) {
+    if (refreshed.reason === 'revoked') {
+      log(
+        `telegram gateway: linear token REVOKED agent=${agent} — refresh token is dead; ` +
+          `operator must re-authorize (linear-agent setup --refresh-token …)\n`,
+      )
+    } else {
+      log(`telegram gateway: linear token refresh failed agent=${agent} reason=${refreshed.reason}\n`)
+    }
+    return { resp, token } // surface the original 401
+  }
+  log(`telegram gateway: linear token auto-refreshed agent=${agent} (was 401)\n`)
+  resp = await post(refreshed.accessToken)
+  return { resp, token: refreshed.accessToken }
 }
 
 /**
@@ -118,14 +197,16 @@ export async function emitLinearAgentActivity(
   const fetchImpl = deps.fetchImpl ?? fetch
   let resp: Response
   try {
-    resp = await fetchImpl(LINEAR_GRAPHQL_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: tokenResult.token,
-      },
-      body: JSON.stringify({ query: mutation, variables }),
-    })
+    // Auto-refresh on a 401 (expired app token) and retry once — see
+    // linearPostWithRefresh.
+    ;({ resp } = await linearPostWithRefresh(
+      JSON.stringify({ query: mutation, variables }),
+      tokenResult.token,
+      agent,
+      fetchImpl,
+      log,
+      deps.refreshIO,
+    ))
   } catch (err) {
     return {
       content: [{ type: 'text', text: `linear_agent_activity failed: request error: ${(err as Error).message}` }],
@@ -217,16 +298,23 @@ export async function createLinearIssue(
       ],
     }
   }
-  const token = tokenResult.token
+  // Mutable so a 401-triggered refresh on one gql call carries the fresh
+  // token to subsequent calls in this issue-create flow.
+  let activeToken = tokenResult.token
 
   const gql = async (query: string, variables: Record<string, unknown>): Promise<{ ok: true; data: any } | { ok: false; text: string }> => {
     let resp: Response
     try {
-      resp = await fetchImpl(LINEAR_GRAPHQL_ENDPOINT, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: token },
-        body: JSON.stringify({ query, variables }),
-      })
+      const out = await linearPostWithRefresh(
+        JSON.stringify({ query, variables }),
+        activeToken,
+        agent,
+        fetchImpl,
+        log,
+        deps.refreshIO,
+      )
+      resp = out.resp
+      activeToken = out.token
     } catch (err) {
       return { ok: false, text: `request error: ${(err as Error).message}` }
     }

--- a/telegram-plugin/tests/linear-agent-activity.test.ts
+++ b/telegram-plugin/tests/linear-agent-activity.test.ts
@@ -122,3 +122,78 @@ describe('emitLinearAgentActivity — behaviour (#2298)', () => {
     expect(r.content[0].text).toMatch(/Linear API 401/)
   })
 })
+
+import { serializeBundle, type RefreshIO } from '../../src/linear/oauth-refresh.js'
+
+/** fetch fake routing by URL: the GraphQL endpoint 401s on the first hit then
+ *  200s; the OAuth token endpoint returns a fresh token. Records the
+ *  Authorization header per call so we can prove the retry used the new token. */
+function refreshAwareFetch(opts: { tokenStatus?: number; tokenBody?: unknown } = {}) {
+  const calls: Array<{ url: string; auth?: string }> = []
+  let graphqlHits = 0
+  const fetchImpl = (async (url: string, init: { headers?: Record<string, string> }) => {
+    const auth = init?.headers?.Authorization
+    calls.push({ url, auth })
+    if (url.includes('/oauth/token')) {
+      const status = opts.tokenStatus ?? 200
+      const body = opts.tokenBody ?? { access_token: 'lin_fresh', refresh_token: 'rt_new', expires_in: 86400 }
+      return { ok: status >= 200 && status < 300, status, json: async () => body, text: async () => (typeof body === 'string' ? body : JSON.stringify(body)) } as unknown as Response
+    }
+    graphqlHits++
+    if (graphqlHits === 1) {
+      return { ok: false, status: 401, json: async () => ({}), text: async () => 'unauthorized' } as unknown as Response
+    }
+    return { ok: true, status: 200, json: async () => ({ data: { agentActivityCreate: { success: true } } }), text: async () => '' } as unknown as Response
+  }) as unknown as typeof fetch
+  return { fetchImpl, calls }
+}
+
+function fakeRefreshIO(): { io: RefreshIO; writes: { token?: string; bundle?: string } } {
+  const writes: { token?: string; bundle?: string } = {}
+  const io: RefreshIO = {
+    readBundle: async () => serializeBundle({ clientId: 'cid', clientSecret: 'csec', refreshToken: 'rt_old', expiresAt: 0 }),
+    writeToken: async (t) => { writes.token = t },
+    writeBundle: async (j) => { writes.bundle = j },
+  }
+  return { io, writes }
+}
+
+describe('linear_agent_activity — auto-refresh on 401 (#2298 durability)', () => {
+  it('refreshes the app token on a 401 and retries once with the fresh token', async () => {
+    const { fetchImpl, calls } = refreshAwareFetch()
+    const { io, writes } = fakeRefreshIO()
+    const r = await emitLinearAgentActivity(
+      { agent_session_id: 'sess', type: 'thought', body: 'hi' },
+      { agent: 'carrie', resolveToken: okToken('lin_expired'), fetchImpl, refreshIO: () => io, log: () => {} },
+    )
+    expect(r.content[0].text).toMatch(/emitted/)
+    // The refresh wrote the new access token; the GraphQL retry used it.
+    expect(writes.token).toBe('lin_fresh')
+    const graphqlAuths = calls.filter((c) => c.url.includes('/graphql')).map((c) => c.auth)
+    expect(graphqlAuths).toEqual(['lin_expired', 'lin_fresh'])
+  })
+
+  it('a revoked refresh token surfaces the 401 (one retry, no loop) and logs REVOKED', async () => {
+    const { fetchImpl } = refreshAwareFetch({ tokenStatus: 400, tokenBody: 'invalid_grant' })
+    const { io } = fakeRefreshIO()
+    const logs: string[] = []
+    const r = await emitLinearAgentActivity(
+      { agent_session_id: 'sess', type: 'thought', body: 'hi' },
+      { agent: 'carrie', resolveToken: okToken('lin_dead'), fetchImpl, refreshIO: () => io, log: (s) => logs.push(s) },
+    )
+    expect(r.content[0].text).toMatch(/Linear API 401/)
+    expect(logs.join('')).toMatch(/REVOKED/)
+  })
+
+  it('no 401 → no refresh attempt (happy path unchanged)', async () => {
+    const { fetchImpl, calls } = fakeFetch(200, { data: { agentActivityCreate: { success: true } } })
+    let refreshBuilt = false
+    const r = await emitLinearAgentActivity(
+      { agent_session_id: 'sess', type: 'message', body: 'ok' },
+      { agent: 'carrie', resolveToken: okToken('lin_good'), fetchImpl, refreshIO: () => { refreshBuilt = true; return fakeRefreshIO().io }, log: () => {} },
+    )
+    expect(r.content[0].text).toMatch(/emitted/)
+    expect(refreshBuilt).toBe(false)
+    expect(calls.length).toBe(1)
+  })
+})

--- a/telegram-plugin/tests/linear-create-issue.test.ts
+++ b/telegram-plugin/tests/linear-create-issue.test.ts
@@ -209,3 +209,45 @@ describe('createLinearIssue — behaviour (#2312)', () => {
     expect(r.content[0].text).toMatch(/Linear API 401/)
   })
 })
+
+import { serializeBundle, type RefreshIO } from '../../src/linear/oauth-refresh.js'
+
+describe('createLinearIssue — token threading across gql calls after a 401 refresh', () => {
+  it('a 401 on the teams resolve refreshes, and issueCreate carries the FRESH token', async () => {
+    // No team_id + no dedup → flow is: teams(query) then issueCreate(mutation).
+    // The teams call 401s → refresh → retry; activeToken must then carry the
+    // fresh token to issueCreate. Pins the mutable-activeToken threading.
+    const auths: Array<{ op: string; auth?: string }> = []
+    let teamsHits = 0
+    const fetchImpl = (async (url: string, init: { headers?: Record<string, string>; body?: string }) => {
+      const auth = init?.headers?.Authorization
+      const body = init?.body ?? ''
+      if (url.includes('/oauth/token')) {
+        return { ok: true, status: 200, json: async () => ({ access_token: 'lin_fresh', expires_in: 3600 }), text: async () => '' } as unknown as Response
+      }
+      if (body.includes('teams(')) {
+        auths.push({ op: 'teams', auth })
+        teamsHits++
+        if (teamsHits === 1) return { ok: false, status: 401, json: async () => ({}), text: async () => 'unauthorized' } as unknown as Response
+        return { ok: true, status: 200, json: async () => ({ data: { teams: { nodes: [{ id: 'team_1', key: 'ENG', name: 'Eng' }] } } }), text: async () => '' } as unknown as Response
+      }
+      // issueCreate
+      auths.push({ op: 'issueCreate', auth })
+      return { ok: true, status: 200, json: async () => ({ data: { issueCreate: { success: true, issue: { identifier: 'ENG-1', url: 'https://linear.app/x/issue/ENG-1' } } } }), text: async () => '' } as unknown as Response
+    }) as unknown as typeof fetch
+
+    const io: RefreshIO = {
+      readBundle: async () => serializeBundle({ clientId: 'c', clientSecret: 's', refreshToken: 'rt', expiresAt: 0 }),
+      writeToken: async () => {},
+      writeBundle: async () => {},
+    }
+    const r = await createLinearIssue(
+      { title: 'a bug' },
+      { agent: 'carrie', resolveToken: okToken('lin_expired'), fetchImpl, refreshIO: () => io, log: () => {} },
+    )
+    expect(r.content[0].text).toMatch(/Filed:/)
+    // teams: expired then fresh (retry); issueCreate: fresh (threaded).
+    expect(auths.find((a) => a.op === 'issueCreate')?.auth).toBe('lin_fresh')
+    expect(auths.filter((a) => a.op === 'teams').map((a) => a.auth)).toEqual(['lin_expired', 'lin_fresh'])
+  })
+})

--- a/tests/cli.telegram.test.ts
+++ b/tests/cli.telegram.test.ts
@@ -152,7 +152,7 @@ describe("telegram-yaml: removeTelegramFeature", () => {
 
 // ─── #597 phase 2: webhook source array helpers ─────────────────────────────
 
-import { addWebhookSource, removeWebhookSource, setLinearAgent, setLinearDefaultTeam } from "../src/cli/telegram-yaml.js";
+import { addWebhookSource, removeWebhookSource, setLinearAgent, setLinearDefaultTeam, addAgentSecret } from "../src/cli/telegram-yaml.js";
 
 describe("telegram-yaml: setLinearDefaultTeam (#2312)", () => {
   const withLinear = setLinearAgent(
@@ -348,5 +348,25 @@ describe("telegram-yaml: removeWebhookSource (#597 phase 2)", () => {
     const before = "agents:\n  klanker:\n    topic_name: K\n";
     const after = removeWebhookSource(before, "ghost", "github");
     expect(after).toBe(before);
+  });
+});
+
+describe("telegram-yaml: addAgentSecret (linear refresh ACL)", () => {
+  it("creates the secrets[] list when absent", () => {
+    const before = "agents:\n  carrie:\n    topic_name: C\n";
+    const after = addAgentSecret(before, "carrie", "linear/carrie/oauth");
+    expect(after).toMatch(/secrets:/);
+    expect(after).toContain("linear/carrie/oauth");
+  });
+
+  it("appends to an existing secrets[] and is idempotent", () => {
+    const before = "agents:\n  carrie:\n    secrets:\n      - linear/carrie/token\n";
+    const once = addAgentSecret(before, "carrie", "linear/carrie/oauth");
+    expect(once).toContain("linear/carrie/token");
+    expect(once).toContain("linear/carrie/oauth");
+    // idempotent: re-adding the same key is a no-op (no duplicate)
+    const twice = addAgentSecret(once, "carrie", "linear/carrie/oauth");
+    expect(twice).toBe(once);
+    expect((twice.match(/linear\/carrie\/oauth/g) ?? []).length).toBe(1);
   });
 });

--- a/tests/linear-oauth-refresh.test.ts
+++ b/tests/linear-oauth-refresh.test.ts
@@ -147,7 +147,7 @@ describe("performLinearRefresh (orchestration over injected I/O)", () => {
       fetchImpl: fakeFetch(200, { access_token: "lin_new", refresh_token: "lin_refresh_new", expires_in: 86400 }),
       nowSec: () => 100,
     });
-    expect(res).toEqual({ ok: true, expiresAt: 100 + 86400 });
+    expect(res).toEqual({ ok: true, accessToken: "lin_new", expiresAt: 100 + 86400 });
     // bundle persisted before token (rotation-safety)
     expect(order).toEqual(["bundle", "token"]);
     expect(writtenToken).toBe("lin_new");


### PR DESCRIPTION
## Summary

Completes the durable Linear app-token fix (builds on the #2360 refresh **core**). The runtime now **refreshes an expired token in-container and retries**, so an agent's Linear calls self-heal with **zero operator touch** — closing the "app actor goes dead every ~24h" gap end-to-end.

## What this PR adds (the automatic layer)

- **`brokerRefreshIO(agent)`** (linear-activity.ts): reads `linear/<agent>/oauth` and rotates both `linear/<agent>/token` and the bundle via the **broker `put` op** (#950 — an agent rotates keys it can already read; no host passphrase, no host round-trip).
- **`linearPostWithRefresh()`**: POST to Linear; on a **401**, run `performLinearRefresh` **once** and retry with the fresh token. A **`revoked`** refresh token (the only case needing operator re-auth) is logged loudly (`grep 'linear token REVOKED'`) and the original 401 surfaces — bounded, **no loop**. Wired into **both** `emit` (linear_agent_activity) and `createLinearIssue` (which threads the refreshed token across its multiple GraphQL calls).
- **`linear-agent setup` auto-grants the ACL** — adds `linear/<agent>/oauth` + `linear/<agent>/token` to `agents.<agent>.secrets[]` (new `addAgentSecret` yaml helper) so the in-container rotation is authorized out of the box.
- `performLinearRefresh` now returns the new `accessToken` (retry uses it directly, no broker re-read).

## How the pieces fit

`setup` (PR #2360) stores the rotatable bundle + (this PR) grants the ACL → on the next 401, the runtime refreshes via the broker and retries → the agent never sees a dead token. The host `linear-agent refresh` verb (PR #2360) remains for ops/seeding. Together: **no-touch durability**, respecting the passphrase boundary (writes happen in-container via the broker, never needing the operator passphrase).

## Test plan

- [x] 3 runtime tests: 401→refresh→retry **uses the fresh token** (asserts the Authorization header sequence); revoked→surface 401 + log REVOKED (no loop); no-401→**no** refresh attempt (happy path unchanged)
- [x] 2 `addAgentSecret` tests (create list / append / idempotent)
- [x] `tsc`, `node scripts/build.mjs`, `check-plugin-references` clean; existing linear-agent-activity + oauth-refresh suites green (11 + 15)

## Risk

Moderate — touches the runtime Linear call path, but the change is purely additive on the **error path** (a 401, which today already fails the call). No 401 = byte-identical behavior. The refresh is bounded to one retry; a revoked token degrades to today's behavior (surfaced 401) plus a loud log. Injectable `refreshIO` keeps it fully tested without a broker.

## Follow-up

carrie's *current* token has no stored bundle (its refresh token wasn't captured during the manual re-provision), so once this lands carrie needs one browser re-auth via `setup --refresh-token …` to seed durability — I'll handle that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)