### PR TITLE
fix(dashboard): repair Agents-tab crash + 4 data-accuracy bugs

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -332,15 +332,63 @@ export interface AccountDashboardInfo extends AccountInfo {
   /** Broker-derived quota / exhaustion state. `null` when broker unreachable. */
   quota: AccountState | null;
   /**
-   * Live 5h/7d utilization from the last cached probe, or null if never
-   * probed / probe failed. Populated by the refresh endpoint, never by
-   * this default load (cost — see AccountQuotaUsage).
+   * Live 5h/7d utilization. Sourced (in order) from the in-process probe
+   * cache (the billed ↻ button), else the broker's own `last_quota` snapshot
+   * — which the default-on fleet quota probe populates for FREE, so a cold
+   * tab shows live usage without spending a billed probe. null only when
+   * neither source has data.
    */
   quotaUsage: AccountQuotaUsage | null;
-  /** true when there's no fresh cached probe (UI shows a refresh prompt). */
+  /** Where quotaUsage came from: a billed probe, the free broker snapshot, or nothing. */
+  quotaUsageSource: "probe" | "broker-cache" | null;
+  /** true when the displayed usage is older than the cache TTL (UI hints ↻). */
   quotaStale: boolean;
   /** Agents currently bound to this account (fleet active or per-agent override). */
   usedBy: string[];
+}
+
+/** ISO 8601 → unix ms, or null when absent/unparseable. */
+export function isoToMs(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * Resolve the 5h/7d usage to show for an account, preferring (in order):
+ *   1. the in-process probe cache (freshest — from the billed ↻ button), then
+ *   2. the broker's own `last_quota` snapshot, which the default-on fleet
+ *      quota probe keeps fresh for FREE — so a cold tab shows live usage with
+ *      no billed probe (the ↻ stays a true force-refresh).
+ * null only when neither source has data. Pure + exported for unit testing.
+ */
+export function deriveAccountQuotaView(
+  brokerState: AccountState | null,
+  probe: { usage: AccountQuotaUsage | null; fetchedAt: number } | undefined,
+  now: number,
+): {
+  quotaUsage: AccountQuotaUsage | null;
+  quotaUsageSource: "probe" | "broker-cache" | null;
+  quotaStale: boolean;
+} {
+  const probeFresh = !!probe && now - probe.fetchedAt < QUOTA_CACHE_TTL_MS;
+  let quotaUsage: AccountQuotaUsage | null = probeFresh ? (probe!.usage ?? null) : null;
+  let quotaUsageSource: "probe" | "broker-cache" | null = quotaUsage ? "probe" : null;
+  let quotaStale = !probeFresh;
+
+  if (!quotaUsage && brokerState?.last_quota) {
+    const lq = brokerState.last_quota;
+    quotaUsage = {
+      fiveHourPct: lq.fiveHourUtilizationPct,
+      sevenDayPct: lq.sevenDayUtilizationPct,
+      fiveHourResetAt: isoToMs(lq.fiveHourResetAt),
+      sevenDayResetAt: isoToMs(lq.sevenDayResetAt),
+      capturedAt: lq.capturedAt,
+    };
+    quotaUsageSource = "broker-cache";
+    quotaStale = now - lq.capturedAt >= QUOTA_CACHE_TTL_MS;
+  }
+  return { quotaUsage, quotaUsageSource, quotaStale };
 }
 
 export async function handleGetAccounts(
@@ -374,14 +422,18 @@ export async function handleGetAccounts(
       usedBy.sort();
     }
     const now = Date.now();
-    const ce = quotaCache.get(info.label);
+    const brokerState = brokerAccounts.get(info.label) ?? null;
+    const view = deriveAccountQuotaView(brokerState, quotaCache.get(info.label), now);
+
     return {
       ...info,
-      quota: brokerAccounts.get(info.label) ?? null,
-      // Cache read only — NEVER probe here (cost). Stale/missing → null
-      // + quotaStale:true so the UI can prompt a refresh.
-      quotaUsage: quotaEntryFresh(ce, now) ? (ce!.usage ?? null) : null,
-      quotaStale: !quotaEntryFresh(ce, now),
+      // The on-disk health (from the abandoned meta.json) can never show
+      // quota-exhausted; the broker's exhausted flag is the live authority.
+      health: brokerState?.exhausted ? "quota-exhausted" : info.health,
+      quota: brokerState,
+      quotaUsage: view.quotaUsage,
+      quotaUsageSource: view.quotaUsageSource,
+      quotaStale: view.quotaStale,
       usedBy,
     };
   });
@@ -629,6 +681,18 @@ function inspectEnv(
   return out;
 }
 
+/**
+ * Read-only / health-probe hostd verbs excluded from the "recent privileged
+ * verbs" panel — they aren't mutations and (agent_smoke especially) dominate
+ * the audit log, drowning the real actions the panel is meant to show.
+ */
+const HOSTD_NOISE_OPS = new Set<string>([
+  "agent_smoke",
+  "get_status",
+  "agent_status",
+  "agent_logs",
+]);
+
 export async function handleGetSystemHealth(
   config?: SwitchroomConfig,
   home?: string,
@@ -702,7 +766,12 @@ export async function handleGetSystemHealth(
     if (existsSync(logPath)) {
       hostd.auditLogPresent = true;
       const raw = readFileSync(logPath, "utf-8");
-      hostd.recent = readAndFilter(raw, {}, 10);
+      // Drop read-only/health-probe verbs — agent_smoke alone is the large
+      // majority of rows and buries the actual privileged mutations this
+      // panel exists to surface. Read a wide window, filter, then take 10.
+      hostd.recent = readAndFilter(raw, {}, 1000)
+        .filter((e) => !HOSTD_NOISE_OPS.has(e.op))
+        .slice(-10);
     }
   } catch (err) {
     hostd.error = err instanceof Error ? err.message : String(err);
@@ -747,8 +816,18 @@ export async function handleGetGoogleAccounts(
       }
     });
   } catch (err) {
-    if (!(err instanceof AuthBrokerUnreachableError)) throw err;
-    // Degraded: ACL still renders from config; live fields stay null.
+    // Degraded — never 500 the dashboard: ANY broker error (unreachable OR a
+    // protocol/internal error) falls through to the config-only union so a
+    // configured account never vanishes (the #2239 vanish bug via the
+    // error-response channel). Log the non-unreachable case for diagnosis.
+    if (!(err instanceof AuthBrokerUnreachableError)) {
+      process.stderr.write(
+        `dashboard: live broker error reading workspace accounts ` +
+          `(${err instanceof AuthBrokerError ? err.code : "unknown"}); ` +
+          `showing config-only ACL: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+    // ACL still renders from config; live fields stay null.
   }
   // Union of config-declared accounts and broker-known slots so an
   // account present in only one source is still visible.
@@ -819,8 +898,18 @@ export async function handleGetMicrosoftAccounts(
       }
     });
   } catch (err) {
-    if (!(err instanceof AuthBrokerUnreachableError)) throw err;
-    // Degraded: ACL still renders from config; live fields stay null.
+    // Degraded — never 500 the dashboard: ANY broker error (unreachable OR a
+    // protocol/internal error) falls through to the config-only union so a
+    // configured account never vanishes (the #2239 vanish bug via the
+    // error-response channel). Log the non-unreachable case for diagnosis.
+    if (!(err instanceof AuthBrokerUnreachableError)) {
+      process.stderr.write(
+        `dashboard: live broker error reading workspace accounts ` +
+          `(${err instanceof AuthBrokerError ? err.code : "unknown"}); ` +
+          `showing config-only ACL: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+    // ACL still renders from config; live fields stay null.
   }
   const cfgAccounts =
     (config as { microsoft_accounts?: Record<string, { enabled_for?: string[] }> })

--- a/src/web/dashboard-accounts.test.ts
+++ b/src/web/dashboard-accounts.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { deriveAccountQuotaView, isoToMs, type AccountQuotaUsage } from "./api.js";
+import type { AccountState } from "../auth/broker/client.js";
+
+const TTL = 10 * 60 * 1000;
+const NOW = 1_781_000_000_000;
+
+function brokerWithLastQuota(over: Partial<AccountState["last_quota"]> = {}): AccountState {
+  return {
+    label: "acct@example.com",
+    exhausted: false,
+    last_quota: {
+      fiveHourUtilizationPct: 56,
+      sevenDayUtilizationPct: 12,
+      fiveHourResetAt: "2026-06-15T03:20:00.000Z",
+      sevenDayResetAt: "2026-06-21T10:00:00.000Z",
+      representativeClaim: "five_hour",
+      overageStatus: "rejected",
+      overageDisabledReason: "org_level_disabled",
+      capturedAt: NOW - 60_000, // 1 min ago → fresh
+      ...over,
+    },
+  };
+}
+
+const probeUsage: AccountQuotaUsage = {
+  fiveHourPct: 81,
+  sevenDayPct: 40,
+  fiveHourResetAt: NOW + 3_600_000,
+  sevenDayResetAt: NOW + 86_400_000,
+  capturedAt: NOW - 30_000,
+};
+
+describe("isoToMs", () => {
+  it("parses a valid ISO string to unix ms", () => {
+    expect(isoToMs("2026-06-15T03:20:00.000Z")).toBe(Date.parse("2026-06-15T03:20:00.000Z"));
+  });
+  it("returns null for null / undefined / empty", () => {
+    expect(isoToMs(null)).toBeNull();
+    expect(isoToMs(undefined)).toBeNull();
+    expect(isoToMs("")).toBeNull();
+  });
+  it("returns null for unparseable input", () => {
+    expect(isoToMs("not-a-date")).toBeNull();
+  });
+});
+
+describe("deriveAccountQuotaView", () => {
+  it("prefers a fresh in-process probe (source=probe, not stale)", () => {
+    const v = deriveAccountQuotaView(brokerWithLastQuota(), { usage: probeUsage, fetchedAt: NOW - 1000 }, NOW);
+    expect(v.quotaUsageSource).toBe("probe");
+    expect(v.quotaUsage?.fiveHourPct).toBe(81);
+    expect(v.quotaStale).toBe(false);
+  });
+
+  it("falls back to the broker last_quota snapshot when there is no probe (free, source=broker-cache)", () => {
+    const v = deriveAccountQuotaView(brokerWithLastQuota(), undefined, NOW);
+    expect(v.quotaUsageSource).toBe("broker-cache");
+    expect(v.quotaUsage?.fiveHourPct).toBe(56);
+    expect(v.quotaUsage?.sevenDayPct).toBe(12);
+    // ISO reset strings are converted to ms.
+    expect(v.quotaUsage?.fiveHourResetAt).toBe(Date.parse("2026-06-15T03:20:00.000Z"));
+    expect(v.quotaUsage?.sevenDayResetAt).toBe(Date.parse("2026-06-21T10:00:00.000Z"));
+    expect(v.quotaStale).toBe(false); // captured 1 min ago
+  });
+
+  it("falls back to broker last_quota when the probe cache is STALE (older than TTL)", () => {
+    const v = deriveAccountQuotaView(brokerWithLastQuota(), { usage: probeUsage, fetchedAt: NOW - TTL - 1 }, NOW);
+    expect(v.quotaUsageSource).toBe("broker-cache");
+    expect(v.quotaUsage?.fiveHourPct).toBe(56);
+  });
+
+  it("falls back to broker last_quota when the probe entry has null usage (probe failed)", () => {
+    const v = deriveAccountQuotaView(brokerWithLastQuota(), { usage: null, fetchedAt: NOW - 1000 }, NOW);
+    expect(v.quotaUsageSource).toBe("broker-cache");
+    expect(v.quotaUsage?.fiveHourPct).toBe(56);
+  });
+
+  it("marks broker-cache as stale when the snapshot is older than the TTL", () => {
+    const v = deriveAccountQuotaView(brokerWithLastQuota({ capturedAt: NOW - TTL - 1 }), undefined, NOW);
+    expect(v.quotaUsageSource).toBe("broker-cache");
+    expect(v.quotaStale).toBe(true);
+  });
+
+  it("handles null reset strings gracefully", () => {
+    const v = deriveAccountQuotaView(
+      brokerWithLastQuota({ fiveHourResetAt: null, sevenDayResetAt: null }),
+      undefined,
+      NOW,
+    );
+    expect(v.quotaUsage?.fiveHourResetAt).toBeNull();
+    expect(v.quotaUsage?.sevenDayResetAt).toBeNull();
+  });
+
+  it("returns null usage when neither a probe nor a broker snapshot exists", () => {
+    const v1 = deriveAccountQuotaView(null, undefined, NOW);
+    expect(v1.quotaUsage).toBeNull();
+    expect(v1.quotaUsageSource).toBeNull();
+    expect(v1.quotaStale).toBe(true);
+
+    const brokerNoSnapshot: AccountState = { label: "x", exhausted: false, last_quota: null };
+    const v2 = deriveAccountQuotaView(brokerNoSnapshot, undefined, NOW);
+    expect(v2.quotaUsage).toBeNull();
+    expect(v2.quotaUsageSource).toBeNull();
+  });
+});

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -992,23 +992,39 @@
     }
 
     function renderAgentDetail(name) {
+      // Wrapped so a single malformed detail can NEVER throw into render()'s
+      // agents.map and blank the whole grid. (The accounts.assigned crash this
+      // replaces did exactly that: it read a field the API renamed to
+      // {active, details} post-RFC-H, threw a TypeError on every open panel,
+      // and aborted the map → the entire Agents tab went blank on each poll.)
+      try {
+        return renderAgentDetailInner(name);
+      } catch (err) {
+        return `<div style="color:var(--red)">Detail render failed: ${escapeHtml((err && err.message) || String(err))}</div>`;
+      }
+    }
+
+    function renderAgentDetailInner(name) {
       const d = agentDetails[name];
       if (!d) return '<div style="color:var(--text-dim)">Loading…</div>';
       const accounts = d.accounts;
       const subagents = d.subagents;
       const config = d.config;
 
+      // handleGetAgentAccounts returns { active: string|null, details: AccountInfo[] }
+      // — the single bound account (fleet-active or per-agent auth.override),
+      // NOT the pre-RFC-H assigned[] list.
       let accountsHtml;
-      if (!accounts || accounts.assigned.length === 0) {
-        accountsHtml = '<div style="color:var(--text-dim)">No accounts assigned (falls back to <code>default</code>).</div>';
+      const activeLabel = accounts && accounts.active;
+      if (!activeLabel) {
+        accountsHtml = '<div style="color:var(--text-dim)">No per-agent account override — uses the fleet-active account.</div>';
       } else {
-        const byLabel = new Map((accounts.details || []).map(d => [d.label, d]));
-        accountsHtml = accounts.assigned.map((label, i) => {
-          const info = byLabel.get(label);
-          if (!info) return `<span class="chip missing" title="not in ~/.switchroom/accounts/">${escapeHtml(label)} · missing</span>`;
-          const tag = i === 0 ? ' · primary' : '';
-          return `<span class="chip"><span class="health-badge ${escapeHtml(info.health)}" style="margin-right:0.4rem">${escapeHtml(info.health)}</span>${escapeHtml(label)}${tag}</span>`;
-        }).join('');
+        const info = (accounts.details || []).find(x => x && x.label === activeLabel);
+        if (!info) {
+          accountsHtml = `<span class="chip missing" title="bound account not found in ~/.switchroom/accounts/">${escapeHtml(activeLabel)} · missing</span>`;
+        } else {
+          accountsHtml = `<span class="chip"><span class="health-badge ${escapeHtml(info.health)}" style="margin-right:0.4rem">${escapeHtml(info.health)}</span>${escapeHtml(activeLabel)} · bound</span>`;
+        }
       }
 
       let subHtml;
@@ -1021,7 +1037,7 @@
       const configText = config ? JSON.stringify(config, null, 2) : '(unavailable)';
 
       return `
-        <h4>Accounts</h4>${accountsHtml}
+        <h4>Account</h4>${accountsHtml}
         <h4>Sub-agents</h4>${subHtml}
         <h4>Resolved config</h4><pre class="config-pre">${escapeHtml(configText)}</pre>
       `;
@@ -1071,7 +1087,7 @@
           fiveH: pctCell(u ? u.fiveHourPct : null, '5h', a.quotaStale, u ? u.fiveHourResetAt : null),
           sevenD: pctCell(u ? u.sevenDayPct : null, '7d', a.quotaStale, u ? u.sevenDayResetAt : null),
           captured: u && u.capturedAt
-            ? formatTimestamp(u.capturedAt)
+            ? `${formatTimestamp(u.capturedAt)}${a.quotaUsageSource === 'broker-cache' ? '<div style="font-size:.7rem;color:var(--text-dim)">broker cache (free)</div>' : ''}`
             : '<span style="color:var(--text-dim)">never</span>',
           exhaustedCell: q == null
             ? '<span style="color:var(--text-dim)">broker offline</span>'
@@ -1221,15 +1237,33 @@
       } else if (!hd.recent || hd.recent.length === 0) {
         hostdBody = dim('audit log present, no entries');
       } else {
+        // Tri-state, not a binary ok/!ok — async mutations log a `started`
+        // row (exit_code null) that is NOT a failure; painting it red made the
+        // panel a wall of false-alarm red. Map: error/non-zero exit → red,
+        // denied → grey, started/in-flight → blue, completed+exit0 → green.
+        const verbStatus = (e) => {
+          if (e.result === 'denied') return { cls: 'denied', dotStyle: 'background:var(--text-dim)', label: 'denied' };
+          if (e.result === 'error' || (e.exit_code != null && e.exit_code !== 0))
+            return { cls: 'err', dotStyle: 'background:var(--red)', label: e.result || 'error' };
+          if (e.result === 'started' || e.exit_code == null)
+            return { cls: 'started', dotStyle: 'background:var(--blue);box-shadow:0 0 6px var(--blue)', label: e.result || 'in progress' };
+          return { cls: 'ok', dotStyle: 'background:var(--green);box-shadow:0 0 6px var(--green)', label: e.result || 'ok' };
+        };
         const rows = hd.recent.slice().reverse().map(e => {
           const caller = e.caller && e.caller.kind === 'agent' ? escapeHtml(e.caller.name) : 'operator';
-          const ok = e.result === 'ok' || e.exit_code === 0;
+          const st = verbStatus(e);
+          // The one diagnostic field — stderr_tail/error — was previously
+          // dropped, making EROFS/reconcile failures unreadable. Surface it.
+          const detail = e.stderr_tail || e.error;
+          const detailRow = (st.cls === 'err' || st.cls === 'denied') && detail
+            ? `<tr><td colspan="4" style="color:var(--red);font-size:.72rem;white-space:pre-wrap;word-break:break-word;padding-top:0">${escapeHtml(String(detail).slice(0, 400))}</td></tr>`
+            : '';
           return `<tr>
-            <td>${dot(ok)} ${escapeHtml(e.op || '?')}</td>
+            <td><span class="status-dot" style="display:inline-block;vertical-align:middle;${st.dotStyle}"></span> ${escapeHtml(e.op || '?')}</td>
             <td>${caller}</td>
-            <td>${escapeHtml(e.result || '?')}${e.exit_code != null ? ` (${e.exit_code})` : ''}</td>
+            <td>${escapeHtml(st.label)}${e.exit_code != null ? ` (${e.exit_code})` : ''}</td>
             <td>${escapeHtml(shortTs(e.ts))}</td>
-          </tr>`;
+          </tr>${detailRow}`;
         }).join('');
         hostdBody = `<table class="accounts-table" style="margin-top:0.5rem">
           <thead><tr><th>Verb</th><th>Caller</th><th>Result</th><th>When</th></tr></thead>
@@ -1267,9 +1301,18 @@
     function renderOAuthAccountCard(a, opts) {
       const provider = (opts && opts.provider) || '';
       const agentNames = (opts && opts.agentNames) || [];
-      const expires = a.expiresAt ? formatTimestamp(a.expiresAt) : _dimC('—');
+      // expiresAt is the SHORT-LIVED access-token expiry, NOT connection
+      // health. For a broker-known slot the refresh token keeps it alive, so a
+      // past value means "lazily refreshes on next use" — rendering it as
+      // "Expires 23d ago" made healthy connected accounts look broken (the
+      // "connections aren't accurate" complaint). Don't alarm on it.
+      const expires = !a.expiresAt
+        ? _dimC('—')
+        : (a.brokerKnown && a.expiresAt < Date.now())
+          ? '<span style="color:var(--text-dim)">auto-refreshes</span>'
+          : formatTimestamp(a.expiresAt);
       const known = a.brokerKnown
-        ? '<span class="usage-pill primary">slot present</span>'
+        ? '<span class="usage-pill primary">connected</span>'
         : '<span style="color:var(--yellow)">config-only (no broker slot)</span>';
       const acl = (a.enabledFor && a.enabledFor.length)
         ? a.enabledFor.map(escapeHtml).join(', ')


### PR DESCRIPTION
## Summary

First PR from the admin-portal audit (2026-06-15). These are the **pure-web** fixes — no new hostd ops, no model calls, no docker dependency — so they ship independently of the control-plane work that follows.

The web container is **dockerless by design**; this PR does not touch that. It fixes one critical frontend crash and four data-accuracy bugs.

## What's fixed

| Rank | Fix |
|---|---|
| **1 (critical)** | `renderAgentDetail` read `accounts.assigned` — a field the API renamed to `{active, details}` post-RFC-H. It threw a `TypeError` inside `render()`'s `agents.map` on **every open Details panel**, aborting the map and **blanking the entire Agents grid** on each 10s poll. Rewritten against the real shape + wrapped in try/catch so one bad detail can never blank the grid again. |
| **5** | Accounts no longer spends a **billed** Anthropic probe to show quota the broker already cached for free. `deriveAccountQuotaView()` prefers the in-process probe cache, else the broker's `last_quota` snapshot (kept fresh by the default-on fleet probe). The ↻ button stays a true force-refresh. |
| **14** | Account health badge read the abandoned `meta.json` and could never show `quota-exhausted`; now overridden from the broker's live `exhausted` flag. |
| **6** | Connections: healthy Google/MS accounts showed *"Expires 23d ago"* (the short-lived access-token expiry, not connection health) → now a **"connected"** pill + *"auto-refreshes"*. Broadened the workspace-accounts broker catch to **all** broker errors so a protocol/internal error falls through to the config-only union instead of 500-ing and vanishing a configured account. |
| **8** | System hostd panel dropped the one diagnostic field (`error`/`stderr_tail`) and painted successful async `started` rows **red**. Dot is now tri-state (completed→green, in-flight→blue, error→red, denied→grey), surfaces the error string, and filters health-probe noise (`agent_smoke` et al.). |

## Why

Directly addresses the operator's reports: *"Agents page many errors"* (the render crash), *"connections isn't accurately showing connected accounts"* (the expiry display + the vanish-on-error bug), and *"ensure all data shown is accurate"* (health badge, quota-from-cache, System panel).

## Test plan

- [x] Extracted `deriveAccountQuotaView` + `isoToMs` as pure exports; new `dashboard-accounts.test.ts` covers source-precedence, staleness, null-reset, and ISO-parsing (10 cases).
- [x] Full `src/web` vitest suite green (138 tests).
- [x] `tsc --noEmit` clean.
- [x] Inline UI `<script>` `node --check` clean (catches a broken template literal).

## Risk

Low. Frontend changes are render-only against shapes verified live; the one backend behavioral change (quota-from-cache) is covered by tests and degrades to the prior null behavior if the broker has no snapshot. No new infra, no leash/security surface touched.

## Follow-ups (same audit, later PRs)

Control plane via hostd (uptime/mem, start/stop/restart, logs), schedule `schedule.d` overlays, caching layer, Memory remediation buttons, Approvals grants DB. Tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)