### PR TITLE
feat(dashboard): restore uptime/mem, schedule overlays, logs via hostd read-ops

### DIFF
--- a/src/host-control/protocol.ts
+++ b/src/host-control/protocol.ts
@@ -225,6 +225,44 @@ export const DoctorRequestSchema = z.object({
   args: z.object({}).optional(),
 });
 
+// ─── Dashboard read-ops (dockerless-web fix) ──────────────────────────────
+//
+// The admin dashboard ships as a DELIBERATELY dockerless container
+// (`switchroom-web`, operator uid, no docker binary/socket). That makes
+// three things impossible from the web vantage:
+//   - agent uptime/memory (needs `docker inspect`/`docker stats`),
+//   - reading each agent's `schedule.d/*.yaml` cron overlays (0600,
+//     owned by the agent container UID → operator/web gets EACCES),
+// hostd runs as root with the docker socket AND `~/.switchroom` mounted,
+// so it can do both. These two verbs are READ-ONLY and ungated for the
+// operator caller (the web reaches hostd over the operator socket, which
+// `checkGate` leaves ungated). Both return their structured result in the
+// `payload` field (JSON-encoded; bounded by the 64 KiB frame) rather than
+// the 4 KiB stdout_tail. Logs reuse the existing `agent_logs` verb.
+
+/** Whole-fleet (name omitted) or single-agent docker status — uptime +
+ *  memory + active. Read-only; result is JSON in `payload`. */
+export const AgentStatusRequestSchema = z.object({
+  ...RequestEnvelope,
+  op: z.literal("agent_status"),
+  args: z.object({
+    /** Narrow to one agent; omit ⇒ whole fleet. */
+    name: AgentNameSchema.optional(),
+  }),
+});
+
+/** Cascade-resolved cron schedule + recent fires, read FRESH so the
+ *  per-agent `schedule.d/*.yaml` overlays (which hostd can read as root)
+ *  are merged. Read-only; result is JSON in `payload`. */
+export const AgentScheduleRequestSchema = z.object({
+  ...RequestEnvelope,
+  op: z.literal("agent_schedule"),
+  args: z.object({
+    /** Narrow to one agent; omit ⇒ whole fleet. */
+    name: AgentNameSchema.optional(),
+  }),
+});
+
 /**
  * Read-only in-agent liveness battery. hostd `docker exec`s a FIXED
  * set of presence/validity probes inside the target agent container
@@ -336,6 +374,8 @@ export const RequestSchema = z.discriminatedUnion("op", [
   AgentExecRequestSchema,
   DoctorRequestSchema,
   AgentSmokeRequestSchema,
+  AgentStatusRequestSchema,
+  AgentScheduleRequestSchema,
   ConfigProposeEditRequestSchema,
 ]);
 
@@ -351,6 +391,8 @@ export type AgentLogsRequest = z.infer<typeof AgentLogsRequestSchema>;
 export type AgentExecRequest = z.infer<typeof AgentExecRequestSchema>;
 export type DoctorRequest = z.infer<typeof DoctorRequestSchema>;
 export type AgentSmokeRequest = z.infer<typeof AgentSmokeRequestSchema>;
+export type AgentStatusRequest = z.infer<typeof AgentStatusRequestSchema>;
+export type AgentScheduleRequest = z.infer<typeof AgentScheduleRequestSchema>;
 export type ConfigProposeEditRequest = z.infer<typeof ConfigProposeEditRequestSchema>;
 export type HostdRequest = z.infer<typeof RequestSchema>;
 
@@ -491,6 +533,19 @@ const ResponseEnvelope = {
   stdout_tail: z.string().optional(),
   /** Last 4 KiB of stderr. */
   stderr_tail: z.string().optional(),
+  /**
+   * Optional JSON-encoded STRUCTURED result for read-only verbs that
+   * return more than a 4 KiB text tail (e.g. `agent_status` →
+   * `{statuses}`, `agent_schedule` → `{entries, recentByAgent}`). The
+   * shape is verb-specific; the wire layer only guarantees it's a string
+   * and that the WHOLE response frame stays under `MAX_FRAME_BYTES`
+   * (64 KiB) — handlers that emit `payload` are responsible for bounding
+   * their own content (truncating prompts / fire summaries / fire counts)
+   * so the encoded frame fits. Distinct from `stdout_tail`, which is a
+   * raw process-output tail; `payload` is producer-shaped data the caller
+   * `JSON.parse`s. Absent on every existing verb (back-compatible).
+   */
+  payload: z.string().optional(),
   /** Operator-visible error message for `denied` / `error`. */
   error: z.string().optional(),
   /** Structured error envelope (#1758 Phase 1). Sibling of `error`;

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -62,6 +62,14 @@ import {
 } from "./config-edit-validator.js";
 import { classifyBlastRadius } from "./config-blast-radius.js";
 import type { ApprovalGateway } from "./approval-gateway.js";
+import { loadConfig, resolveAgentsDir } from "../config/loader.js";
+import { getAllAgentStatuses } from "../agents/lifecycle.js";
+import {
+  collectScheduleEntries,
+  type SchedulerEntry,
+  type DispatchResult,
+} from "../scheduler/dispatch.js";
+import { readRecentFires } from "../agent-scheduler/replay.js";
 
 /** Subset of switchroom.yaml the daemon reads. */
 export interface ServerConfig {
@@ -707,6 +715,13 @@ export class HostdServer {
         case "agent_smoke":
           resp = await this.handleAgentSmoke(req, started);
           break;
+        // ── Dashboard read-ops (dockerless-web fix) ──────────────
+        case "agent_status":
+          resp = this.handleAgentStatus(req, started);
+          break;
+        case "agent_schedule":
+          resp = this.handleAgentSchedule(req, started);
+          break;
         // ── PR 1a (admin-agent-config-edit RFC) ──────────────────
         // Stub dispatcher: flag-gated disabled error or a
         // not-implemented marker. PR 1b adds validation; PR 1c adds
@@ -831,6 +846,24 @@ export class HostdServer {
         return callerAdmin
           ? null
           : `doctor requires admin: true on caller "${caller.name}"`;
+      case "agent_status":
+      case "agent_schedule":
+        // Read-only dashboard observability. The real consumer is the
+        // web, which connects over the OPERATOR socket and returned null
+        // at the top of this method (ungated, by design — see the
+        // dispatcher comment in main.ts and hostd-config-propose.ts).
+        // For an AGENT caller we mirror agent_smoke/agent_logs: a
+        // self-scoped query (its own name) is harmless self-debugging;
+        // a single OTHER agent's view or the whole-fleet view (name
+        // omitted) is broader exposure, so require admin — same posture
+        // as doctor's whole-fleet enumeration. These verbs change
+        // nothing; no fleet-mutation lock applies.
+        if (req.args.name !== undefined && req.args.name === caller.name) {
+          return null;
+        }
+        return callerAdmin
+          ? null
+          : `${req.op} ${req.args.name === undefined ? "fleet view" : "cross-agent"} requires admin: true on caller "${caller.name}"`;
       case "config_propose_edit":
         // Admin callers may propose ANY edit to the central
         // switchroom.yaml. Non-admin callers are admitted here but
@@ -1749,6 +1782,101 @@ export class HostdServer {
     return respond("running", probes);
   }
 
+  /**
+   * Read-only fleet (or single-agent) docker status — uptime + memory +
+   * active. The whole point: hostd HAS the docker socket, so
+   * `getAllAgentStatuses` (which shells `docker inspect`/`docker stats`)
+   * works here, where it throws/returns-null in the dockerless web
+   * container. Result is JSON-encoded into `payload` as `{ statuses }`.
+   *
+   * Always `completed` when the config loads and the status sweep runs
+   * (a down/absent container is a *finding* in the per-agent status, not
+   * a verb failure — same posture as doctor). A genuine fault (config
+   * unreadable, status sweep throws) returns `error` with a message;
+   * never crashes the daemon.
+   */
+  private handleAgentStatus(
+    req: Extract<HostdRequest, { op: "agent_status" }>,
+    started: number,
+  ): HostdResponse {
+    try {
+      const cfg = loadConfig(this.opts.configPath);
+      const all = getAllAgentStatuses(cfg);
+      const statuses = req.args.name
+        ? req.args.name in all
+          ? { [req.args.name]: all[req.args.name]! }
+          : {}
+        : all;
+      return {
+        v: 1,
+        request_id: req.request_id,
+        result: "completed",
+        exit_code: 0,
+        duration_ms: Date.now() - started,
+        payload: JSON.stringify({ statuses }),
+      };
+    } catch (e) {
+      return {
+        v: 1,
+        request_id: req.request_id,
+        result: "error",
+        exit_code: null,
+        duration_ms: Date.now() - started,
+        error: `agent_status failed: ${(e as Error).message}`,
+      };
+    }
+  }
+
+  /**
+   * Read-only cron schedule view — the cascade-resolved schedule entries
+   * PLUS the most-recent fires per agent. Loads config FRESH (not the
+   * daemon's cached startup config): `loadConfig` merges each agent's
+   * `~/.switchroom/agents/<name>/schedule.d/*.yaml` overlays, and those
+   * files are 0600 owned by the agent's container UID — readable here
+   * (hostd runs as root with DAC_OVERRIDE) but EACCES from the
+   * operator/web vantage. That overlay-merge is exactly why this lands
+   * the agent-authored crons the dashboard otherwise misses.
+   *
+   * Result is JSON-encoded into `payload` as `{ entries, recentByAgent }`,
+   * BOUNDED by {@link boundScheduleView} (prompt ≤160 chars, each fire's
+   * outputSummary ≤100 chars, last 8 fires/agent) so the frame stays
+   * under the 64 KiB cap even for a large fleet with long prompts.
+   */
+  private handleAgentSchedule(
+    req: Extract<HostdRequest, { op: "agent_schedule" }>,
+    started: number,
+  ): HostdResponse {
+    try {
+      const cfg = loadConfig(this.opts.configPath);
+      let entries = collectScheduleEntries(cfg);
+      if (req.args.name) entries = entries.filter((e) => e.agent === req.args.name);
+      const agentsDir = resolveAgentsDir(cfg);
+      const recentByAgent: Record<string, DispatchResult[]> = {};
+      for (const agent of new Set(entries.map((e) => e.agent))) {
+        const rows = readRecentFires(resolve(agentsDir, agent, "scheduler.jsonl"));
+        if (rows.length > 0) recentByAgent[agent] = rows;
+      }
+      const bounded = boundScheduleView(entries, recentByAgent);
+      return {
+        v: 1,
+        request_id: req.request_id,
+        result: "completed",
+        exit_code: 0,
+        duration_ms: Date.now() - started,
+        payload: JSON.stringify(bounded),
+      };
+    } catch (e) {
+      return {
+        v: 1,
+        request_id: req.request_id,
+        result: "error",
+        exit_code: null,
+        duration_ms: Date.now() - started,
+        error: `agent_schedule failed: ${(e as Error).message}`,
+      };
+    }
+  }
+
   /** Spawn the host `docker` CLI and capture stdout/stderr. Symmetric
    *  with {@link runSwitchroom}; broken out for testability + so
    *  failures get a "docker binary missing" surface separate from
@@ -2088,6 +2216,49 @@ export class HostdServer {
 function tail(s: string, bytes = TAIL_BYTES): string {
   if (Buffer.byteLength(s, "utf8") <= bytes) return s;
   return s.slice(s.length - bytes);
+}
+
+/** Max chars retained from a schedule entry's `prompt` in the bounded
+ *  `agent_schedule` payload — the web only renders a preview. */
+export const SCHEDULE_PROMPT_MAX_CHARS = 160;
+/** Max chars retained from a fire's `outputSummary` in the bounded payload. */
+export const SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS = 100;
+/** Max recent fires retained per agent in the bounded payload. */
+export const SCHEDULE_MAX_FIRES_PER_AGENT = 8;
+
+/**
+ * Pure, frame-bounding shaper for the `agent_schedule` payload (extracted
+ * so it can be unit-tested without a daemon). It (a) truncates each
+ * entry's `prompt` to {@link SCHEDULE_PROMPT_MAX_CHARS}, (b) keeps only
+ * the LAST {@link SCHEDULE_MAX_FIRES_PER_AGENT} fires per agent (newest),
+ * and (c) truncates each fire's `outputSummary` to
+ * {@link SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS}. Without these bounds a large
+ * fleet with long prompts / verbose fire summaries could blow the 64 KiB
+ * response frame. Returns NEW objects — never mutates the inputs (the
+ * daemon's caller has no other reader, but purity keeps the test honest
+ * and avoids surprising any future caller).
+ */
+export function boundScheduleView(
+  entries: SchedulerEntry[],
+  recentByAgent: Record<string, DispatchResult[]>,
+): { entries: SchedulerEntry[]; recentByAgent: Record<string, DispatchResult[]> } {
+  const boundedEntries = entries.map((e) =>
+    e.prompt !== undefined && e.prompt.length > SCHEDULE_PROMPT_MAX_CHARS
+      ? { ...e, prompt: e.prompt.slice(0, SCHEDULE_PROMPT_MAX_CHARS) }
+      : { ...e },
+  );
+  const boundedRecent: Record<string, DispatchResult[]> = {};
+  for (const [agent, rows] of Object.entries(recentByAgent)) {
+    boundedRecent[agent] = rows
+      .slice(-SCHEDULE_MAX_FIRES_PER_AGENT)
+      .map((r) =>
+        typeof r.outputSummary === "string" &&
+        r.outputSummary.length > SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS
+          ? { ...r, outputSummary: r.outputSummary.slice(0, SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS) }
+          : { ...r },
+      );
+  }
+  return { entries: boundedEntries, recentByAgent: boundedRecent };
 }
 
 /**

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -2225,28 +2225,77 @@ export const SCHEDULE_PROMPT_MAX_CHARS = 160;
 export const SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS = 100;
 /** Max recent fires retained per agent in the bounded payload. */
 export const SCHEDULE_MAX_FIRES_PER_AGENT = 8;
+/**
+ * Hard ceiling on the bytes the `agent_schedule` payload contributes to the
+ * response FRAME. The payload is JSON-encoded then embedded as a STRING in
+ * the response, so its frame cost = `JSON.stringify(JSON.stringify(view))`
+ * length (escaping accounted for exactly). We trim until that's under
+ * `MAX_FRAME_BYTES` minus envelope headroom — so `encodeResponse` can never
+ * throw "frame too large", even for a pathological fleet.
+ */
+export const SCHEDULE_FRAME_BUDGET_BYTES = MAX_FRAME_BYTES - 2048;
+
+export interface BoundedScheduleView {
+  entries: SchedulerEntry[];
+  recentByAgent: Record<string, DispatchResult[]>;
+  /** True when entries/fires were shed to fit the frame budget. */
+  truncated?: boolean;
+}
 
 /**
- * Pure, frame-bounding shaper for the `agent_schedule` payload (extracted
- * so it can be unit-tested without a daemon). It (a) truncates each
- * entry's `prompt` to {@link SCHEDULE_PROMPT_MAX_CHARS}, (b) keeps only
- * the LAST {@link SCHEDULE_MAX_FIRES_PER_AGENT} fires per agent (newest),
- * and (c) truncates each fire's `outputSummary` to
- * {@link SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS}. Without these bounds a large
- * fleet with long prompts / verbose fire summaries could blow the 64 KiB
- * response frame. Returns NEW objects — never mutates the inputs (the
- * daemon's caller has no other reader, but purity keeps the test honest
- * and avoids surprising any future caller).
+ * Render-only projection of a SchedulerEntry. Keeps only the fields the
+ * dashboard renders (+ the small cheap-cron routing scalars) and DROPS the
+ * UNBOUNDED `poll` / `action` specs (a Telegram action's `text`, a webhook
+ * body/headers/url have no schema max). Truncates the prompt. This is what
+ * makes a single entry's encoded size bounded by the prompt cap, not by
+ * arbitrary operator-authored spec content.
+ */
+function slimScheduleEntry(e: SchedulerEntry): SchedulerEntry {
+  const slim: SchedulerEntry = {
+    agent: e.agent,
+    scheduleIndex: e.scheduleIndex,
+    cron: e.cron,
+    promptKey: e.promptKey,
+  };
+  if (e.prompt !== undefined) {
+    slim.prompt =
+      e.prompt.length > SCHEDULE_PROMPT_MAX_CHARS
+        ? e.prompt.slice(0, SCHEDULE_PROMPT_MAX_CHARS)
+        : e.prompt;
+  }
+  if (e.kind !== undefined) slim.kind = e.kind;
+  if (e.model !== undefined) slim.model = e.model;
+  if (e.context !== undefined) slim.context = e.context;
+  if (e.topic !== undefined) slim.topic = e.topic;
+  // poll / action specs intentionally dropped — unbounded + unrendered.
+  return slim;
+}
+
+/** Exact frame cost of a payload object: its JSON encoded, then re-encoded
+ *  as the response's `payload` STRING field (so quote/backslash escaping is
+ *  counted precisely — no 2× guesswork). */
+function scheduleFrameBytes(view: BoundedScheduleView): number {
+  return Buffer.byteLength(JSON.stringify(JSON.stringify(view)), "utf8");
+}
+
+/**
+ * Pure, frame-bounding shaper for the `agent_schedule` payload (extracted so
+ * it can be unit-tested without a daemon). It (a) projects each entry to a
+ * render-only slim shape (dropping the unbounded poll/action specs) with a
+ * truncated prompt, (b) keeps only the LAST
+ * {@link SCHEDULE_MAX_FIRES_PER_AGENT} fires per agent (newest) with each
+ * `outputSummary` truncated, and (c) enforces a HARD frame budget: if the
+ * payload would still exceed {@link SCHEDULE_FRAME_BUDGET_BYTES} (a
+ * pathological fleet — hundreds of entries), it sheds the least-essential
+ * data first (all fires, then entries from the tail) until it fits, setting
+ * `truncated`. This guarantees the response frame can never overflow
+ * `MAX_FRAME_BYTES`. Returns NEW objects — never mutates the inputs.
  */
 export function boundScheduleView(
   entries: SchedulerEntry[],
   recentByAgent: Record<string, DispatchResult[]>,
-): { entries: SchedulerEntry[]; recentByAgent: Record<string, DispatchResult[]> } {
-  const boundedEntries = entries.map((e) =>
-    e.prompt !== undefined && e.prompt.length > SCHEDULE_PROMPT_MAX_CHARS
-      ? { ...e, prompt: e.prompt.slice(0, SCHEDULE_PROMPT_MAX_CHARS) }
-      : { ...e },
-  );
+): BoundedScheduleView {
+  const slimEntries = entries.map(slimScheduleEntry);
   const boundedRecent: Record<string, DispatchResult[]> = {};
   for (const [agent, rows] of Object.entries(recentByAgent)) {
     boundedRecent[agent] = rows
@@ -2258,7 +2307,18 @@ export function boundScheduleView(
           : { ...r },
       );
   }
-  return { entries: boundedEntries, recentByAgent: boundedRecent };
+
+  let view: BoundedScheduleView = { entries: slimEntries, recentByAgent: boundedRecent };
+  if (scheduleFrameBytes(view) <= SCHEDULE_FRAME_BUDGET_BYTES) return view;
+
+  // Over budget. Shed fires first (supplementary), then trim entries from
+  // the tail until it fits. Entries are the point; fires are a bonus.
+  view = { entries: slimEntries, recentByAgent: {}, truncated: true };
+  while (scheduleFrameBytes(view) > SCHEDULE_FRAME_BUDGET_BYTES && view.entries.length > 1) {
+    const keep = Math.max(1, Math.floor(view.entries.length * 0.8));
+    view = { entries: view.entries.slice(0, keep), recentByAgent: {}, truncated: true };
+  }
+  return view;
 }
 
 /**

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -1415,6 +1415,9 @@ export interface ScheduleDashboard {
   degraded?: boolean;
   /** Human-readable explanation when `degraded` is true. */
   reason?: string;
+  /** True when hostd shed entries/fires to fit the response frame (a
+   *  pathologically large fleet) — the view is otherwise accurate. */
+  truncated?: boolean;
 }
 
 /**
@@ -1438,8 +1441,12 @@ export async function handleGetSchedule(
   const viaHostd = await fetchSchedule();
   if (viaHostd) {
     // hostd already bounded the payload (last 8 fires/agent, truncated
-    // prompts/summaries); pass it through unchanged.
-    return { entries: viaHostd.entries, recentByAgent: viaHostd.recentByAgent };
+    // prompts/summaries, slim entries); pass it through unchanged.
+    return {
+      entries: viaHostd.entries,
+      recentByAgent: viaHostd.recentByAgent,
+      ...(viaHostd.truncated ? { truncated: true } : {}),
+    };
   }
 
   // Degraded: hostd unreachable. Base-config-only view (no overlay crons).

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -7,7 +7,6 @@ import {
   startAgent,
   stopAgent,
   restartAgent,
-  containerName,
 } from "../agents/lifecycle.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
 import { getCollectionForAgent, probeHindsight } from "../memory/hindsight.js";
@@ -70,6 +69,12 @@ import {
   resolveHostdOperatorSocket,
   type ProposeOutcome,
 } from "./hostd-config-propose.js";
+import {
+  fetchFleetStatusViaHostd,
+  fetchScheduleViaHostd,
+  fetchAgentLogsViaHostd,
+} from "./hostd-read-client.js";
+import type { AgentStatus } from "../agents/lifecycle.js";
 import { randomUUID } from "node:crypto";
 import {
   startMicrosoftConnect,
@@ -124,11 +129,67 @@ export function agentBridgeAlive(
   }
 }
 
-export function handleGetAgents(config: SwitchroomConfig): AgentInfo[] {
+/**
+ * Short-TTL cache for the hostd-backfilled fleet status. `/api/agents` is
+ * polled every ~10s by the dashboard; without a cache that poll would
+ * round-trip hostd (and thus `docker inspect`/`docker stats` host-side)
+ * every tick → a docker-stats storm. A ~5s TTL means at most one hostd
+ * round-trip per poll cycle. Mirrors the `quotaCache` module-Map pattern.
+ * Single key (`"fleet"`) — the web always asks hostd for the whole fleet.
+ */
+export const AGENT_STATUS_CACHE_TTL_MS = 5000;
+interface StatusCacheEntry {
+  statuses: Record<string, AgentStatus> | null;
+  fetchedAt: number;
+}
+const statusCache = new Map<string, StatusCacheEntry>();
+
+/** Test-only: reset the module status cache between cases. */
+export function __resetAgentStatusCacheForTests(): void {
+  statusCache.clear();
+}
+
+/**
+ * TTL-cached hostd fleet-status fetch. Returns the (possibly null)
+ * backfill map. `fetch` is injectable for tests. A `null` from hostd is
+ * cached too — so a down daemon doesn't get hammered every 10s tick.
+ */
+async function cachedFleetStatus(
+  now: number,
+  fetchImpl: () => Promise<Record<string, AgentStatus> | null> = fetchFleetStatusViaHostd,
+): Promise<Record<string, AgentStatus> | null> {
+  const cached = statusCache.get("fleet");
+  if (cached && now - cached.fetchedAt < AGENT_STATUS_CACHE_TTL_MS) {
+    return cached.statuses;
+  }
+  const statuses = await fetchImpl();
+  statusCache.set("fleet", { statuses, fetchedAt: now });
+  return statuses;
+}
+
+export async function handleGetAgents(
+  config: SwitchroomConfig,
+  deps: {
+    now?: number;
+    fetchFleetStatus?: () => Promise<Record<string, AgentStatus> | null>;
+  } = {},
+): Promise<AgentInfo[]> {
   const statuses = getAllAgentStatuses(config);
   const authStatuses = getAllAuthStatuses(config);
   const agentsDir = resolveAgentsDir(config);
   const agents: AgentInfo[] = [];
+
+  // Dockerless web: `getAllAgentStatuses` shells docker and returns
+  // uptime/memory=null for every agent. hostd (root, docker socket) can
+  // read them — backfill from it when any status is missing them. TTL-
+  // cached so the 10s poll doesn't storm docker-stats. Never throws:
+  // hostd unreachable ⇒ null ⇒ we keep the null uptime/memory.
+  const needsBackfill = Object.values(statuses).some(
+    (s) => s && (s.uptime === null || s.memory === null),
+  );
+  const hostdStatuses = needsBackfill
+    ? await cachedFleetStatus(deps.now ?? Date.now(), deps.fetchFleetStatus)
+    : null;
 
   for (const [name, agentConfig] of Object.entries(config.agents)) {
     const status = statuses[name];
@@ -152,11 +213,19 @@ export function handleGetAgents(config: SwitchroomConfig): AgentInfo[] {
           ? "active"
           : (status?.active ?? "unknown");
 
+    // uptime/memory: prefer the local docker read; backfill from hostd
+    // when the dockerless path left them null. `active` keeps the
+    // docker-or-.bridge-alive logic above (hostd is only consulted for
+    // the two fields the web genuinely cannot read).
+    const hostd = hostdStatuses?.[name];
+    const uptime = status?.uptime ?? hostd?.uptime ?? null;
+    const memory = status?.memory ?? hostd?.memory ?? null;
+
     agents.push({
       name,
       active,
-      uptime: status?.uptime ?? null,
-      memory: status?.memory ?? null,
+      uptime,
+      memory,
       extends: agentConfig.extends ?? "default",
       topic_name: agentConfig.topic_name,
       topic_emoji: agentConfig.topic_emoji,
@@ -207,31 +276,23 @@ export function handleRestartAgent(name: string): { ok: boolean; error?: string 
   }
 }
 
-export function handleGetLogs(
+export async function handleGetLogs(
   name: string,
-  lines: number = 50
-): { ok: boolean; logs?: string; error?: string } {
-  // Agents are Docker containers since v0.7 — there is no
-  // `switchroom-<name>` systemd user unit to journalctl against.
-  // `docker logs` splits the container's stdout/stderr across the two
-  // fds; a container can log to either, so merge both for a complete
-  // view. spawnSync hands back both streams regardless of exit code.
-  const res = spawnSync(
-    "docker",
-    ["logs", "--tail", String(lines), containerName(name)],
-    { encoding: "utf-8", timeout: 5000 },
-  );
-  if (res.error) {
-    return { ok: false, error: res.error.message };
-  }
-  if (res.status !== 0) {
-    const stderr = (res.stderr ?? "").trim();
-    return {
-      ok: false,
-      error: stderr || `docker logs exited ${res.status ?? "non-zero"}`,
-    };
-  }
-  return { ok: true, logs: `${res.stdout ?? ""}${res.stderr ?? ""}` };
+  lines: number = 50,
+  deps: {
+    fetchLogs?: typeof fetchAgentLogsViaHostd;
+  } = {},
+): Promise<{ ok: boolean; logs?: string; error?: string }> {
+  // The web container is dockerless BY DESIGN (no docker binary/socket —
+  // security hardening). It cannot `docker logs`. Route through hostd's
+  // existing `agent_logs` verb (hostd runs as root with the docker
+  // socket). hostd already merges the container's stdout/stderr streams
+  // and caps the tail at 4 KiB — acceptable for this one-shot view; live
+  // streaming is a later PR. When hostd is unreachable the helper returns
+  // an actionable "needs hostd" message instead of a raw
+  // `spawn docker ENOENT`.
+  const fetchLogs = deps.fetchLogs ?? fetchAgentLogsViaHostd;
+  return await fetchLogs(name, lines);
 }
 
 export function handleGetTurns(
@@ -1344,11 +1405,44 @@ export interface ScheduleDashboard {
   entries: SchedulerEntry[];
   /** agent → most-recent DispatchResult rows (newest last), capped. */
   recentByAgent: Record<string, DispatchResult[]>;
+  /**
+   * True when hostd was unreachable and this view is base-config-only —
+   * i.e. it is MISSING the agent-authored `schedule.d/*.yaml` cron
+   * overlays (0600, owned by the agent UID → operator/web gets EACCES;
+   * only hostd, as root, can read them). The UI uses this to warn that
+   * an agent may be firing crons not shown here.
+   */
+  degraded?: boolean;
+  /** Human-readable explanation when `degraded` is true. */
+  reason?: string;
 }
 
-export function handleGetSchedule(
+/**
+ * Cron schedule view. The accurate source is hostd (`agent_schedule`):
+ * it re-loads config FRESH as root, merging each agent's 0600
+ * `schedule.d/*.yaml` overlays the dockerless web can't read — so it's
+ * the SUPERSET (e.g. clerk's 9 agent-authored crons). When hostd is
+ * unreachable we fall back to the base-config-only
+ * `collectScheduleEntries(config)` and mark the response `degraded` so
+ * the UI can say "schedule view needs hostd — showing base-config only".
+ *
+ * `fetchSchedule` is injectable for tests.
+ */
+export async function handleGetSchedule(
   config: SwitchroomConfig,
-): ScheduleDashboard {
+  deps: {
+    fetchSchedule?: typeof fetchScheduleViaHostd;
+  } = {},
+): Promise<ScheduleDashboard> {
+  const fetchSchedule = deps.fetchSchedule ?? fetchScheduleViaHostd;
+  const viaHostd = await fetchSchedule();
+  if (viaHostd) {
+    // hostd already bounded the payload (last 8 fires/agent, truncated
+    // prompts/summaries); pass it through unchanged.
+    return { entries: viaHostd.entries, recentByAgent: viaHostd.recentByAgent };
+  }
+
+  // Degraded: hostd unreachable. Base-config-only view (no overlay crons).
   const entries = collectScheduleEntries(config);
   const agentsDir = resolveAgentsDir(config);
   const recentByAgent: Record<string, DispatchResult[]> = {};
@@ -1361,7 +1455,15 @@ export function handleGetSchedule(
     );
     if (rows.length > 0) recentByAgent[agent] = rows.slice(-10);
   }
-  return { entries, recentByAgent };
+  return {
+    entries,
+    recentByAgent,
+    degraded: true,
+    reason:
+      "schedule view needs hostd — showing base-config only " +
+      "(agent-authored schedule.d crons are not included). " +
+      "Ensure host_control is enabled.",
+  };
 }
 
 /**

--- a/src/web/hostd-read-client.test.ts
+++ b/src/web/hostd-read-client.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import {
+  fetchFleetStatusViaHostd,
+  fetchScheduleViaHostd,
+  fetchAgentLogsViaHostd,
+  HOSTD_UNREACHABLE_LOGS_MESSAGE,
+} from "./hostd-read-client.js";
+import type { HostdResponse } from "../host-control/protocol.js";
+
+function resp(partial: Partial<HostdResponse>): HostdResponse {
+  return {
+    v: 1,
+    request_id: "r1",
+    result: "completed",
+    exit_code: 0,
+    duration_ms: 1,
+    ...partial,
+  } as HostdResponse;
+}
+
+const SOCK = "/x/operator/sock";
+
+describe("fetchFleetStatusViaHostd", () => {
+  it("parses the statuses payload and sends an agent_status request (no name = fleet)", async () => {
+    let sent: unknown;
+    const out = await fetchFleetStatusViaHostd({
+      socketPath: SOCK,
+      send: async (_opts, req) => {
+        sent = req;
+        return resp({
+          payload: JSON.stringify({
+            statuses: {
+              clerk: { active: "active", uptime: "2026-06-15T00:00:00Z", memory: "256MB", pid: 7 },
+            },
+          }),
+        });
+      },
+    });
+    expect(out).toEqual({
+      clerk: { active: "active", uptime: "2026-06-15T00:00:00Z", memory: "256MB", pid: 7 },
+    });
+    expect(sent).toMatchObject({ op: "agent_status", args: {} });
+  });
+
+  it("returns null when the socket is unresolved (hostd not reachable)", async () => {
+    let called = false;
+    const out = await fetchFleetStatusViaHostd({
+      socketPath: null,
+      send: async () => {
+        called = true;
+        return resp({});
+      },
+    });
+    expect(out).toBeNull();
+    // Short-circuits before opening any connection.
+    expect(called).toBe(false);
+  });
+
+  it("returns null when the transport throws (timeout / connection refused)", async () => {
+    const out = await fetchFleetStatusViaHostd({
+      socketPath: SOCK,
+      send: async () => {
+        throw new Error("hostd: request timed out after 4000ms");
+      },
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null on a non-completed result", async () => {
+    const out = await fetchFleetStatusViaHostd({
+      socketPath: SOCK,
+      send: async () => resp({ result: "error", exit_code: null, error: "boom" }),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null on a bad-JSON payload (degrade, never throw)", async () => {
+    const out = await fetchFleetStatusViaHostd({
+      socketPath: SOCK,
+      send: async () => resp({ payload: "{ not json" }),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null when the payload is the wrong shape (no statuses)", async () => {
+    const out = await fetchFleetStatusViaHostd({
+      socketPath: SOCK,
+      send: async () => resp({ payload: JSON.stringify({ nope: 1 }) }),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null when there is no payload at all", async () => {
+    const out = await fetchFleetStatusViaHostd({
+      socketPath: SOCK,
+      send: async () => resp({ stdout_tail: "hi" }),
+    });
+    expect(out).toBeNull();
+  });
+});
+
+describe("fetchScheduleViaHostd", () => {
+  it("parses the schedule payload and sends an agent_schedule request", async () => {
+    let sent: unknown;
+    const out = await fetchScheduleViaHostd({
+      socketPath: SOCK,
+      send: async (_opts, req) => {
+        sent = req;
+        return resp({
+          payload: JSON.stringify({
+            entries: [{ agent: "clerk", scheduleIndex: 0, cron: "*/30 * * * *", promptKey: "k" }],
+            recentByAgent: { clerk: [] },
+          }),
+        });
+      },
+    });
+    expect(out).not.toBeNull();
+    expect(out!.entries).toHaveLength(1);
+    expect(out!.entries[0].agent).toBe("clerk");
+    expect(out!.recentByAgent).toEqual({ clerk: [] });
+    expect(sent).toMatchObject({ op: "agent_schedule", args: {} });
+  });
+
+  it("defaults recentByAgent to {} when the payload omits it", async () => {
+    const out = await fetchScheduleViaHostd({
+      socketPath: SOCK,
+      send: async () =>
+        resp({ payload: JSON.stringify({ entries: [] }) }),
+    });
+    expect(out).toEqual({ entries: [], recentByAgent: {} });
+  });
+
+  it("returns null on a null socket", async () => {
+    const out = await fetchScheduleViaHostd({ socketPath: null, send: async () => resp({}) });
+    expect(out).toBeNull();
+  });
+
+  it("returns null when entries isn't an array (bad shape)", async () => {
+    const out = await fetchScheduleViaHostd({
+      socketPath: SOCK,
+      send: async () => resp({ payload: JSON.stringify({ entries: "nope" }) }),
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null on a throwing transport", async () => {
+    const out = await fetchScheduleViaHostd({
+      socketPath: SOCK,
+      send: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    expect(out).toBeNull();
+  });
+});
+
+describe("fetchAgentLogsViaHostd", () => {
+  it("routes through the existing agent_logs verb and returns stdout_tail", async () => {
+    let sent: unknown;
+    const out = await fetchAgentLogsViaHostd("clerk", 100, {
+      socketPath: SOCK,
+      send: async (_opts, req) => {
+        sent = req;
+        return resp({ stdout_tail: "log line 1\nlog line 2\n" });
+      },
+    });
+    expect(out).toEqual({ ok: true, logs: "log line 1\nlog line 2\n" });
+    expect(sent).toMatchObject({ op: "agent_logs", args: { name: "clerk", tail: 100 } });
+  });
+
+  it("clamps tail to the schema bound (max 2000)", async () => {
+    let sentTail = -1;
+    await fetchAgentLogsViaHostd("clerk", 99999, {
+      socketPath: SOCK,
+      send: async (_opts, req) => {
+        sentTail = (req as { args: { tail: number } }).args.tail;
+        return resp({ stdout_tail: "" });
+      },
+    });
+    expect(sentTail).toBe(2000);
+  });
+
+  it("returns the actionable hostd-down message when the socket is null", async () => {
+    const out = await fetchAgentLogsViaHostd("clerk", 50, {
+      socketPath: null,
+      send: async () => resp({}),
+    });
+    expect(out).toEqual({ ok: false, error: HOSTD_UNREACHABLE_LOGS_MESSAGE });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain("need hostd");
+  });
+
+  it("returns the actionable message when the transport throws", async () => {
+    const out = await fetchAgentLogsViaHostd("clerk", 50, {
+      socketPath: SOCK,
+      send: async () => {
+        throw new Error("spawn-equivalent failure");
+      },
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toBe(HOSTD_UNREACHABLE_LOGS_MESSAGE);
+  });
+
+  it("surfaces hostd's reason on a denied/error result", async () => {
+    const out = await fetchAgentLogsViaHostd("clerk", 50, {
+      socketPath: SOCK,
+      send: async () => resp({ result: "error", exit_code: null, error: "No such container" }),
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain("No such container");
+  });
+});

--- a/src/web/hostd-read-client.ts
+++ b/src/web/hostd-read-client.ts
@@ -1,0 +1,177 @@
+/**
+ * Read-only hostd helpers for the dashboard.
+ *
+ * The dashboard ships as a DELIBERATELY dockerless container
+ * (`switchroom-web`, operator uid, no docker binary/socket — security
+ * hardening, do not change). That makes three things impossible from the
+ * web vantage: reading agent uptime/memory (`docker inspect`/`stats`),
+ * reading agent logs (`docker logs`), and reading each agent's 0600
+ * `schedule.d/*.yaml` cron overlays (owned by the agent container UID →
+ * operator/web gets EACCES). hostd runs as root with the docker socket
+ * AND `~/.switchroom` mounted, so it can do all three.
+ *
+ * These helpers talk to hostd over the OPERATOR socket — which
+ * `checkGate` leaves ungated (the operator is root-equivalent on its own
+ * host) — so the new read-only verbs need no auth plumbing here. Every
+ * helper NEVER throws: an unreachable daemon / timeout / bad payload
+ * degrades to `null`, and the caller falls back to its dockerless path
+ * (or surfaces an actionable "needs hostd" message). The web must never
+ * 500 just because hostd is down.
+ */
+
+import { hostdRequest } from "../host-control/client.js";
+import type { HostdRequest, HostdResponse } from "../host-control/protocol.js";
+import { resolveHostdOperatorSocket } from "./hostd-config-propose.js";
+import type { AgentStatus } from "../agents/lifecycle.js";
+import type { SchedulerEntry, DispatchResult } from "../scheduler/dispatch.js";
+
+/** Default timeout for the (fast, read-only) hostd round-trip. The 10s
+ *  dashboard poll cadence means we want this well under that. */
+const READ_TIMEOUT_MS = 4000;
+
+/** Monotonic-ish request id for a one-shot read. */
+function readRequestId(verb: string): string {
+  return `web-${verb}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+export interface HostdReadOpts {
+  /** Override the resolved operator socket (tests). When the function
+   *  receives `undefined` it resolves via `resolveHostdOperatorSocket()`;
+   *  pass `null` to force the "unreachable" branch. */
+  socketPath?: string | null;
+  timeoutMs?: number;
+  /** Injectable hostd transport (tests). Defaults to the real client. */
+  send?: typeof hostdRequest;
+}
+
+/**
+ * The fleet docker status, keyed by agent name. Mirrors
+ * {@link AgentStatus} minus `pid` (the dashboard doesn't render it). Used
+ * to backfill uptime/memory the dockerless web container can't read.
+ * Returns `null` when hostd is unreachable / the payload is unusable —
+ * the caller then keeps its dockerless `.bridge-alive`-derived view.
+ */
+export async function fetchFleetStatusViaHostd(
+  opts: HostdReadOpts = {},
+): Promise<Record<string, AgentStatus> | null> {
+  const socketPath =
+    opts.socketPath !== undefined ? opts.socketPath : resolveHostdOperatorSocket();
+  if (!socketPath) return null;
+  const send = opts.send ?? hostdRequest;
+  const req: HostdRequest = {
+    v: 1,
+    op: "agent_status",
+    request_id: readRequestId("agent_status"),
+    args: {},
+  };
+  try {
+    const resp: HostdResponse = await send(
+      { socketPath, timeoutMs: opts.timeoutMs ?? READ_TIMEOUT_MS },
+      req,
+    );
+    if (resp.result !== "completed" || !resp.payload) return null;
+    const parsed = JSON.parse(resp.payload) as {
+      statuses?: Record<string, AgentStatus>;
+    };
+    if (!parsed || typeof parsed !== "object" || !parsed.statuses) return null;
+    return parsed.statuses;
+  } catch {
+    // Unreachable / timeout / bad-JSON / wrong-shape — degrade.
+    return null;
+  }
+}
+
+/**
+ * The cascade-resolved cron schedule + recent fires, read FRESH by hostd
+ * (so the 0600 `schedule.d` overlays are merged). Returns `null` when
+ * hostd is unreachable / payload unusable — the caller then falls back to
+ * the base-config-only `collectScheduleEntries`.
+ */
+export async function fetchScheduleViaHostd(
+  opts: HostdReadOpts = {},
+): Promise<{
+  entries: SchedulerEntry[];
+  recentByAgent: Record<string, DispatchResult[]>;
+} | null> {
+  const socketPath =
+    opts.socketPath !== undefined ? opts.socketPath : resolveHostdOperatorSocket();
+  if (!socketPath) return null;
+  const send = opts.send ?? hostdRequest;
+  const req: HostdRequest = {
+    v: 1,
+    op: "agent_schedule",
+    request_id: readRequestId("agent_schedule"),
+    args: {},
+  };
+  try {
+    const resp: HostdResponse = await send(
+      { socketPath, timeoutMs: opts.timeoutMs ?? READ_TIMEOUT_MS },
+      req,
+    );
+    if (resp.result !== "completed" || !resp.payload) return null;
+    const parsed = JSON.parse(resp.payload) as {
+      entries?: SchedulerEntry[];
+      recentByAgent?: Record<string, DispatchResult[]>;
+    };
+    if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.entries)) {
+      return null;
+    }
+    return {
+      entries: parsed.entries,
+      recentByAgent: parsed.recentByAgent ?? {},
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read a peer agent's container logs via the EXISTING `agent_logs` hostd
+ * verb (the dockerless web container can't `docker logs`). Returns the
+ * combined stdout tail (hostd's `docker logs` already merges streams) or
+ * an actionable error when hostd is unreachable. Never throws.
+ */
+export async function fetchAgentLogsViaHostd(
+  name: string,
+  lines: number,
+  opts: HostdReadOpts = {},
+): Promise<{ ok: true; logs: string } | { ok: false; error: string }> {
+  const socketPath =
+    opts.socketPath !== undefined ? opts.socketPath : resolveHostdOperatorSocket();
+  if (!socketPath) {
+    return { ok: false, error: HOSTD_UNREACHABLE_LOGS_MESSAGE };
+  }
+  const send = opts.send ?? hostdRequest;
+  // hostd's agent_logs caps `tail` at 2000; clamp to the schema bound.
+  const tail = Math.max(1, Math.min(lines, 2000));
+  const req: HostdRequest = {
+    v: 1,
+    op: "agent_logs",
+    request_id: readRequestId("agent_logs"),
+    args: { name, tail },
+  };
+  try {
+    const resp: HostdResponse = await send(
+      { socketPath, timeoutMs: opts.timeoutMs ?? READ_TIMEOUT_MS },
+      req,
+    );
+    if (resp.result === "completed") {
+      return { ok: true, logs: resp.stdout_tail ?? "" };
+    }
+    // denied / error — surface hostd's reason if it gave one.
+    return {
+      ok: false,
+      error: resp.error ?? `hostd agent_logs returned '${resp.result}'`,
+    };
+  } catch {
+    return { ok: false, error: HOSTD_UNREACHABLE_LOGS_MESSAGE };
+  }
+}
+
+/** Actionable error shown when logs can't be read because hostd is down.
+ *  The dashboard container has no docker access BY DESIGN, so this points
+ *  the operator at the real levers rather than leaking `spawn docker
+ *  ENOENT`. */
+export const HOSTD_UNREACHABLE_LOGS_MESSAGE =
+  "Logs need hostd (the dashboard container has no docker access by design). " +
+  "Ensure host_control is enabled, or run `switchroom agent logs <name>` on the host.";

--- a/src/web/hostd-read-client.ts
+++ b/src/web/hostd-read-client.ts
@@ -92,6 +92,8 @@ export async function fetchScheduleViaHostd(
 ): Promise<{
   entries: SchedulerEntry[];
   recentByAgent: Record<string, DispatchResult[]>;
+  /** True when hostd shed entries/fires to fit the response frame. */
+  truncated?: boolean;
 } | null> {
   const socketPath =
     opts.socketPath !== undefined ? opts.socketPath : resolveHostdOperatorSocket();
@@ -112,6 +114,7 @@ export async function fetchScheduleViaHostd(
     const parsed = JSON.parse(resp.payload) as {
       entries?: SchedulerEntry[];
       recentByAgent?: Record<string, DispatchResult[]>;
+      truncated?: boolean;
     };
     if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.entries)) {
       return null;
@@ -119,6 +122,7 @@ export async function fetchScheduleViaHostd(
     return {
       entries: parsed.entries,
       recentByAgent: parsed.recentByAgent ?? {},
+      ...(parsed.truncated ? { truncated: true } : {}),
     };
   } catch {
     return null;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -635,7 +635,7 @@ export function startWebServer(
 
         switch (route.handler) {
           case "getAgents":
-            return jsonResponse(handleGetAgents(config));
+            return (async () => jsonResponse(await handleGetAgents(freshConfig())))();
 
           case "getLogs": {
             const agentName = route.params.name;
@@ -647,7 +647,7 @@ export function startWebServer(
               Number.isInteger(rawLines) && rawLines >= 1 && rawLines <= 10000
                 ? rawLines
                 : 50;
-            return jsonResponse(handleGetLogs(agentName, lines));
+            return (async () => jsonResponse(await handleGetLogs(agentName, lines)))();
           }
 
           case "startAgent": {
@@ -705,7 +705,8 @@ export function startWebServer(
           }
 
           case "getSystemHealth":
-            return (async () => jsonResponse(await handleGetSystemHealth(config)))();
+            return (async () =>
+              jsonResponse(await handleGetSystemHealth(freshConfig())))();
 
           case "getMemoryHealth":
             return (async () =>
@@ -723,14 +724,16 @@ export function startWebServer(
             return jsonResponse(handleGetNotionWorkspace(freshConfig()));
 
           case "getSchedule":
-            return jsonResponse(handleGetSchedule(config));
+            return (async () =>
+              jsonResponse(await handleGetSchedule(freshConfig())))();
 
           case "getApprovals":
             return (async () =>
               jsonResponse(await handleGetApprovals()))();
 
           case "getAccounts":
-            return (async () => jsonResponse(await handleGetAccounts(config)))();
+            return (async () =>
+              jsonResponse(await handleGetAccounts(freshConfig())))();
 
           case "useAccount": {
             return (async () => {

--- a/tests/host-control/bound-schedule-view.test.ts
+++ b/tests/host-control/bound-schedule-view.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the pure `boundScheduleView` helper — the frame-bounding
+ * shaper for the hostd `agent_schedule` payload. Truncates entry prompts
+ * + fire outputSummaries and keeps only the last N fires per agent so the
+ * structured payload can't blow the 64 KiB NDJSON frame.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  boundScheduleView,
+  SCHEDULE_PROMPT_MAX_CHARS,
+  SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS,
+  SCHEDULE_MAX_FIRES_PER_AGENT,
+} from "../../src/host-control/server.js";
+import type { SchedulerEntry, DispatchResult } from "../../src/scheduler/dispatch.js";
+
+function entry(over: Partial<SchedulerEntry> = {}): SchedulerEntry {
+  return {
+    agent: "clerk",
+    scheduleIndex: 0,
+    cron: "*/30 * * * *",
+    promptKey: "abc123",
+    ...over,
+  };
+}
+
+function fire(over: Partial<DispatchResult> = {}): DispatchResult {
+  return {
+    agent: "clerk",
+    scheduleIndex: 0,
+    promptKey: "abc123",
+    exitCode: 0,
+    outputSummary: "delivered to bridge via gateway",
+    startedAt: 1,
+    finishedAt: 2,
+    ...over,
+  };
+}
+
+describe("boundScheduleView", () => {
+  it("truncates an entry's prompt to the cap", () => {
+    const long = "x".repeat(SCHEDULE_PROMPT_MAX_CHARS + 200);
+    const { entries } = boundScheduleView([entry({ prompt: long })], {});
+    expect(entries[0].prompt).toHaveLength(SCHEDULE_PROMPT_MAX_CHARS);
+    expect(entries[0].prompt).toBe("x".repeat(SCHEDULE_PROMPT_MAX_CHARS));
+  });
+
+  it("leaves a short prompt untouched", () => {
+    const short = "morning standup";
+    const { entries } = boundScheduleView([entry({ prompt: short })], {});
+    expect(entries[0].prompt).toBe(short);
+  });
+
+  it("handles an entry with no prompt (kind=action)", () => {
+    const { entries } = boundScheduleView([entry({ prompt: undefined })], {});
+    expect(entries[0].prompt).toBeUndefined();
+  });
+
+  it("truncates each fire's outputSummary to the cap", () => {
+    const long = "y".repeat(SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS + 50);
+    const { recentByAgent } = boundScheduleView([], {
+      clerk: [fire({ outputSummary: long })],
+    });
+    expect(recentByAgent.clerk[0].outputSummary).toHaveLength(
+      SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS,
+    );
+  });
+
+  it("keeps only the LAST N fires per agent (newest)", () => {
+    const many = Array.from({ length: SCHEDULE_MAX_FIRES_PER_AGENT + 5 }, (_, i) =>
+      fire({ startedAt: i, finishedAt: i + 1, exitCode: i }),
+    );
+    const { recentByAgent } = boundScheduleView([], { clerk: many });
+    expect(recentByAgent.clerk).toHaveLength(SCHEDULE_MAX_FIRES_PER_AGENT);
+    // The last fire (highest startedAt) survives; the oldest is dropped.
+    expect(recentByAgent.clerk.at(-1)!.startedAt).toBe(
+      SCHEDULE_MAX_FIRES_PER_AGENT + 4,
+    );
+    expect(recentByAgent.clerk[0].startedAt).toBe(5);
+  });
+
+  it("does not mutate the input objects (purity)", () => {
+    const long = "z".repeat(SCHEDULE_PROMPT_MAX_CHARS + 10);
+    const input = entry({ prompt: long });
+    const inputFire = fire({ outputSummary: "w".repeat(SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS + 10) });
+    boundScheduleView([input], { clerk: [inputFire] });
+    // Originals unchanged.
+    expect(input.prompt).toHaveLength(SCHEDULE_PROMPT_MAX_CHARS + 10);
+    expect(inputFire.outputSummary).toHaveLength(SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS + 10);
+  });
+
+  it("passes through multiple agents independently", () => {
+    const { recentByAgent } = boundScheduleView([], {
+      clerk: [fire({ agent: "clerk" })],
+      marko: [fire({ agent: "marko" }), fire({ agent: "marko" })],
+    });
+    expect(recentByAgent.clerk).toHaveLength(1);
+    expect(recentByAgent.marko).toHaveLength(2);
+  });
+});

--- a/tests/host-control/bound-schedule-view.test.ts
+++ b/tests/host-control/bound-schedule-view.test.ts
@@ -11,8 +11,16 @@ import {
   SCHEDULE_PROMPT_MAX_CHARS,
   SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS,
   SCHEDULE_MAX_FIRES_PER_AGENT,
+  SCHEDULE_FRAME_BUDGET_BYTES,
 } from "../../src/host-control/server.js";
 import type { SchedulerEntry, DispatchResult } from "../../src/scheduler/dispatch.js";
+
+/** The exact bytes the payload contributes to the response frame (JSON,
+ *  then re-encoded as the `payload` string field). Mirrors the daemon's
+ *  internal `scheduleFrameBytes`. */
+function frameBytes(view: unknown): number {
+  return Buffer.byteLength(JSON.stringify(JSON.stringify(view)), "utf8");
+}
 
 function entry(over: Partial<SchedulerEntry> = {}): SchedulerEntry {
   return {
@@ -96,5 +104,67 @@ describe("boundScheduleView", () => {
     });
     expect(recentByAgent.clerk).toHaveLength(1);
     expect(recentByAgent.marko).toHaveLength(2);
+  });
+
+  it("projects entries to a render-only slim shape — drops the unbounded poll/action specs", () => {
+    const huge = "A".repeat(50_000); // an operator-authored action text with no schema max
+    const { entries } = boundScheduleView(
+      [
+        entry({
+          kind: "action",
+          model: "sonnet",
+          context: "fresh",
+          topic: "planning",
+          // unbounded specs the wire must NOT carry:
+          action: { kind: "webhook", url: "https://x", body: huge } as unknown as SchedulerEntry["action"],
+          poll: { huge } as unknown as SchedulerEntry["poll"],
+        }),
+      ],
+      {},
+    );
+    const e = entries[0] as SchedulerEntry & { action?: unknown; poll?: unknown };
+    // Rendered + small routing fields kept…
+    expect(e.agent).toBe("clerk");
+    expect(e.cron).toBe("*/30 * * * *");
+    expect(e.kind).toBe("action");
+    expect(e.model).toBe("sonnet");
+    expect(e.context).toBe("fresh");
+    expect(e.topic).toBe("planning");
+    // …unbounded specs dropped.
+    expect(e.action).toBeUndefined();
+    expect(e.poll).toBeUndefined();
+  });
+
+  it("enforces a hard frame budget — a pathological fleet is truncated and fits", () => {
+    // Far more entries than any real fleet, each with a max-length prompt.
+    const many: SchedulerEntry[] = Array.from({ length: 4000 }, (_, i) =>
+      entry({ scheduleIndex: i, prompt: "p".repeat(SCHEDULE_PROMPT_MAX_CHARS) }),
+    );
+    const fires: Record<string, DispatchResult[]> = {
+      clerk: Array.from({ length: 50 }, (_, i) => fire({ startedAt: i, outputSummary: "s".repeat(200) })),
+    };
+    const view = boundScheduleView(many, fires);
+    // The output FITS the frame budget (the whole point)…
+    expect(frameBytes(view)).toBeLessThanOrEqual(SCHEDULE_FRAME_BUDGET_BYTES);
+    // …it was marked truncated, fires were shed first, and entries trimmed.
+    expect(view.truncated).toBe(true);
+    expect(view.entries.length).toBeLessThan(many.length);
+    expect(view.entries.length).toBeGreaterThan(0);
+  });
+
+  it("does NOT mark a normal fleet truncated", () => {
+    // A realistic fleet (a few dozen entries, a handful of fires each) is
+    // well under budget and untouched.
+    const realistic: SchedulerEntry[] = Array.from({ length: 40 }, (_, i) =>
+      entry({ scheduleIndex: i, prompt: "morning routine " + i }),
+    );
+    const fires: Record<string, DispatchResult[]> = {
+      clerk: [fire(), fire()],
+      marko: [fire({ agent: "marko" })],
+    };
+    const view = boundScheduleView(realistic, fires);
+    expect(view.truncated).toBeUndefined();
+    expect(view.entries).toHaveLength(40);
+    expect(view.recentByAgent.clerk).toHaveLength(2);
   });
 });

--- a/tests/host-control/protocol.test.ts
+++ b/tests/host-control/protocol.test.ts
@@ -114,6 +114,96 @@ describe("hostd protocol — framing & schema", () => {
   });
 });
 
+describe("hostd protocol — dashboard read-ops (agent_status / agent_schedule)", () => {
+  it("round-trips an agent_status request (whole fleet — name omitted)", () => {
+    const req: HostdRequest = {
+      v: 1,
+      op: "agent_status",
+      request_id: "st-1",
+      args: {},
+    };
+    const decoded = decodeRequest(encodeRequest(req).trimEnd());
+    expect(decoded).toEqual(req);
+  });
+
+  it("round-trips an agent_status request narrowed to one agent", () => {
+    const req: HostdRequest = {
+      v: 1,
+      op: "agent_status",
+      request_id: "st-2",
+      args: { name: "clerk" },
+    };
+    const decoded = decodeRequest(encodeRequest(req).trimEnd());
+    expect(decoded).toEqual(req);
+  });
+
+  it("round-trips an agent_schedule request (whole fleet)", () => {
+    const req: HostdRequest = {
+      v: 1,
+      op: "agent_schedule",
+      request_id: "sc-1",
+      args: {},
+    };
+    const decoded = decodeRequest(encodeRequest(req).trimEnd());
+    expect(decoded).toEqual(req);
+  });
+
+  it("round-trips an agent_schedule request narrowed to one agent", () => {
+    const req: HostdRequest = {
+      v: 1,
+      op: "agent_schedule",
+      request_id: "sc-2",
+      args: { name: "clerk" },
+    };
+    const decoded = decodeRequest(encodeRequest(req).trimEnd());
+    expect(decoded).toEqual(req);
+  });
+
+  it("rejects an agent name that isn't kebab-case ASCII", () => {
+    const wire = JSON.stringify({
+      v: 1,
+      op: "agent_status",
+      request_id: "st-bad",
+      args: { name: "bad name!" },
+    });
+    expect(() => decodeRequest(wire)).toThrow();
+  });
+
+  it("round-trips the optional structured `payload` field on a completed response", () => {
+    const payload = JSON.stringify({
+      statuses: {
+        clerk: { active: "active", uptime: "2026-06-15T00:00:00Z", memory: "256MB", pid: 7 },
+      },
+    });
+    const resp: HostdResponse = {
+      v: 1,
+      request_id: "st-1",
+      result: "completed",
+      exit_code: 0,
+      duration_ms: 12,
+      payload,
+    };
+    const decoded = decodeResponse(encodeResponse(resp).trimEnd());
+    expect(decoded).toEqual(resp);
+    // The producer-shaped JSON survives intact for the caller to re-parse.
+    expect(JSON.parse(decoded.payload!)).toEqual(JSON.parse(payload));
+  });
+
+  it("ResponseSchema accepts a response WITHOUT payload (backwards-compat)", () => {
+    const resp: HostdResponse = {
+      v: 1,
+      request_id: "no-payload",
+      result: "completed",
+      exit_code: 0,
+      duration_ms: 0,
+      stdout_tail: "hi",
+    };
+    const decoded = decodeResponse(encodeResponse(resp).trimEnd());
+    expect(decoded).toEqual(resp);
+    expect(decoded.payload).toBeUndefined();
+  });
+});
+
 describe("error_envelope — #1758 Phase 1 round-trip", () => {
   const variants: Array<{ name: string; fix: unknown }> = [
     { name: "flip_yaml_flag", fix: { kind: "flip_yaml_flag", yaml_path: "hostd.config_edit_enabled", to: true } },

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -1314,3 +1314,203 @@ describe("hostd server — apply-asset preflight (klanker incident)", () => {
     expect(resp.error).not.toContain(join(partial, "profiles") + ",");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// Dashboard read-ops (dockerless-web fix): the agent_status /
+// agent_schedule verbs. Unlike the other e2e verbs above (which only
+// shell the stub CLI), these LOAD a real config — so this block stands up
+// its own server with `configPath` pointing at a tmp switchroom.yaml.
+//
+// ISOLATION: the overlay loader resolves `schedule.d` under
+// `$HOME/.switchroom/agents/<name>/` (resolveDualPath → process.env.HOME),
+// NOT under config.agents_dir — so this block ALSO overrides HOME to a
+// tmpdir. Both `SWITCHROOM_AGENTS_DIR` (resolveAgentsDir, the scheduler
+// ledger path) and HOME (the overlay tree) point at the SAME isolated
+// `<roTmp>/.switchroom/agents` so NOTHING reads/writes the operator's
+// real ~/.switchroom. (Verified: without the HOME override the loader
+// EACCES'd on the operator's real 0600 overlay files — exactly the
+// production bug this verb fixes, but a test must never touch live state.)
+//
+// Proves: dispatch wiring, the operator-ungated/agent-admin gate, the
+// `payload` round-trip, agent_schedule's recent-fire read against a real
+// scheduler.jsonl, AND that a schedule.d overlay cron is merged in (the
+// load-bearing fix — fresh loadConfig sees the overlay the base config
+// lacks).
+// ─────────────────────────────────────────────────────────────────────
+describe("hostd server — dashboard read-ops (agent_status / agent_schedule)", () => {
+  let roTmp: string;
+  let roServer: HostdServer;
+  let agentsDir: string;
+  let savedAgentsDir: string | undefined;
+  let savedHome: string | undefined;
+
+  beforeAll(async () => {
+    roTmp = mkdtempSync(join(tmpdir(), "hostd-readops-"));
+    // The agents tree lives under <roTmp>/.switchroom/agents so the
+    // overlay loader (HOME-rooted) and the ledger reader (agents_dir-
+    // rooted) resolve to the SAME isolated location.
+    agentsDir = join(roTmp, ".switchroom", "agents");
+    const cfgPath = join(roTmp, "switchroom.yaml");
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      cfgPath,
+      [
+        "switchroom:",
+        "  version: 1",
+        `  agents_dir: "${agentsDir}"`,
+        "telegram:",
+        '  bot_token: "x"',
+        '  forum_chat_id: "1"',
+        "agents:",
+        "  klanker:",
+        "    topic_name: Klanker",
+        "    schedule:",
+        '      - cron: "*/30 * * * *"',
+        `        prompt: "${"p".repeat(300)}"`,
+        "  bob:",
+        "    topic_name: Bob",
+      ].join("\n") + "\n",
+    );
+    // Seed a scheduler.jsonl with > 8 fires + a long outputSummary so the
+    // bound payload exercises both truncation paths.
+    mkdirSync(join(agentsDir, "klanker"), { recursive: true });
+    const rows = Array.from({ length: 12 }, (_, i) =>
+      JSON.stringify({
+        agent: "klanker",
+        scheduleIndex: 0,
+        promptKey: "k",
+        exitCode: 0,
+        outputSummary: i === 11 ? "s".repeat(300) : "ok",
+        startedAt: 1747300000000 + i,
+        finishedAt: 1747300000500 + i,
+      }),
+    );
+    writeFileSync(join(agentsDir, "klanker", "scheduler.jsonl"), rows.join("\n") + "\n");
+
+    // The agent-authored overlay cron the base config doesn't carry —
+    // this is what the operator/web (uid 1000) can't read (0600, agent-
+    // owned) but hostd (root) can. Asserting it surfaces proves the fix.
+    mkdirSync(join(agentsDir, "klanker", "schedule.d"), { recursive: true });
+    writeFileSync(
+      join(agentsDir, "klanker", "schedule.d", "cron-overlay.yaml"),
+      ["schedule:", '  - cron: "0 9 * * *"', '    prompt: "overlay standup"'].join("\n") + "\n",
+    );
+
+    savedAgentsDir = process.env.SWITCHROOM_AGENTS_DIR;
+    savedHome = process.env.HOME;
+    process.env.SWITCHROOM_AGENTS_DIR = agentsDir;
+    process.env.HOME = roTmp;
+
+    roServer = new HostdServer({
+      homeDir: roTmp,
+      agentUids: { klanker: 10001, bob: 10002 },
+      config: { agents: { klanker: { admin: true }, bob: {} } },
+      switchroomBin: stubBin,
+      auditLogPath: join(roTmp, "audit.log"),
+      allowNonLinux: true,
+      configPath: cfgPath,
+    });
+    await roServer.start();
+  });
+
+  afterAll(async () => {
+    if (roServer) await roServer.stop();
+    if (savedAgentsDir === undefined) delete process.env.SWITCHROOM_AGENTS_DIR;
+    else process.env.SWITCHROOM_AGENTS_DIR = savedAgentsDir;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    rmSync(roTmp, { recursive: true, force: true });
+  });
+
+  const adminSock = () =>
+    roServer.getBoundPaths().find((p) => p.endsWith("/klanker/sock"))!;
+  const nonAdminSock = () =>
+    roServer.getBoundPaths().find((p) => p.endsWith("/bob/sock"))!;
+
+  it("agent_status: returns completed with a JSON payload of fleet statuses", async () => {
+    const resp = await hostdRequest(
+      { socketPath: adminSock() },
+      { v: 1, op: "agent_status", request_id: "ro-st-1", args: {} },
+    );
+    expect(resp.result).toBe("completed");
+    expect(resp.exit_code).toBe(0);
+    expect(resp.payload).toBeDefined();
+    const parsed = JSON.parse(resp.payload!) as {
+      statuses: Record<string, { uptime: string | null; memory: string | null }>;
+    };
+    // Both configured agents appear (docker may be absent → uptime null,
+    // which is exactly the dockerless-web case this backfill serves).
+    expect(Object.keys(parsed.statuses).sort()).toEqual(["bob", "klanker"]);
+  });
+
+  it("agent_status: narrows to one agent when name is given", async () => {
+    const resp = await hostdRequest(
+      { socketPath: adminSock() },
+      { v: 1, op: "agent_status", request_id: "ro-st-2", args: { name: "klanker" } },
+    );
+    const parsed = JSON.parse(resp.payload!) as { statuses: Record<string, unknown> };
+    expect(Object.keys(parsed.statuses)).toEqual(["klanker"]);
+  });
+
+  it("agent_status: cross-agent / fleet view denied for a non-admin agent", async () => {
+    const resp = await hostdRequest(
+      { socketPath: nonAdminSock() },
+      { v: 1, op: "agent_status", request_id: "ro-st-3", args: {} },
+    );
+    expect(resp.result).toBe("denied");
+    expect(resp.error).toMatch(/requires admin/);
+  });
+
+  it("agent_status: self-target allowed for a non-admin agent", async () => {
+    const resp = await hostdRequest(
+      { socketPath: nonAdminSock() },
+      { v: 1, op: "agent_status", request_id: "ro-st-4", args: { name: "bob" } },
+    );
+    expect(resp.result).toBe("completed");
+    const parsed = JSON.parse(resp.payload!) as { statuses: Record<string, unknown> };
+    expect(Object.keys(parsed.statuses)).toEqual(["bob"]);
+  });
+
+  it("agent_schedule: returns the cron entries + bounded recent fires", async () => {
+    const resp = await hostdRequest(
+      { socketPath: adminSock() },
+      { v: 1, op: "agent_schedule", request_id: "ro-sc-1", args: {} },
+    );
+    expect(resp.result).toBe("completed");
+    const parsed = JSON.parse(resp.payload!) as {
+      entries: Array<{ agent: string; cron: string; prompt?: string }>;
+      recentByAgent: Record<string, Array<{ outputSummary: string }>>;
+    };
+    const klEntries = parsed.entries.filter((e) => e.agent === "klanker");
+    const baseEntry = klEntries.find((e) => e.cron === "*/30 * * * *")!;
+    expect(baseEntry).toBeDefined();
+    // Prompt truncated to the 160-char cap (was seeded at 300).
+    expect(baseEntry.prompt).toHaveLength(160);
+    // The fix: the agent-authored schedule.d overlay cron — readable by
+    // hostd (root) but not the dockerless web (0600, agent-owned) — is
+    // merged in by the FRESH loadConfig. Without it the dashboard misses
+    // crons the agent actually fires.
+    expect(klEntries.some((e) => e.cron === "0 9 * * *")).toBe(true);
+    // Last 8 fires only; the newest fire's long summary truncated to 100.
+    expect(parsed.recentByAgent.klanker).toHaveLength(8);
+    expect(parsed.recentByAgent.klanker.at(-1)!.outputSummary).toHaveLength(100);
+  });
+
+  it("agent_schedule: filters to one agent when name is given", async () => {
+    const resp = await hostdRequest(
+      { socketPath: adminSock() },
+      { v: 1, op: "agent_schedule", request_id: "ro-sc-2", args: { name: "klanker" } },
+    );
+    const parsed = JSON.parse(resp.payload!) as { entries: Array<{ agent: string }> };
+    expect(parsed.entries.every((e) => e.agent === "klanker")).toBe(true);
+    expect(parsed.entries.length).toBeGreaterThan(0);
+  });
+
+  it("agent_schedule: fleet view denied for a non-admin agent", async () => {
+    const resp = await hostdRequest(
+      { socketPath: nonAdminSock() },
+      { v: 1, op: "agent_schedule", request_id: "ro-sc-3", args: {} },
+    );
+    expect(resp.result).toBe("denied");
+  });
+});

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -112,6 +112,7 @@ import {
   handleGetApprovals,
   handleRefreshAccountsQuota,
   __resetQuotaCacheForTests,
+  __resetAgentStatusCacheForTests,
   type AgentInfo,
 } from "../src/web/api.js";
 import { resolveAgentsDir } from "../src/config/loader.js";
@@ -164,9 +165,11 @@ const mockConfig: SwitchroomConfig = {
 describe("handleGetAgents", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The hostd backfill is TTL-cached at module scope; isolate cases.
+    __resetAgentStatusCacheForTests();
   });
 
-  it("returns combined status and auth info for each agent", () => {
+  it("returns combined status and auth info for each agent", async () => {
     asMock(getAllAgentStatuses).mockReturnValue({
       coach: { active: "active", uptime: "2025-01-01T00:00:00Z", memory: "128MB", pid: 1234 },
       sage: { active: "inactive", uptime: null, memory: null, pid: null },
@@ -177,7 +180,9 @@ describe("handleGetAgents", () => {
       sage: { authenticated: false },
     });
 
-    const result = handleGetAgents(mockConfig);
+    const result = await handleGetAgents(mockConfig, {
+      fetchFleetStatus: async () => null,
+    });
 
     expect(result).toHaveLength(2);
 
@@ -200,7 +205,7 @@ describe("handleGetAgents", () => {
     expect(sage.memoryCollection).toBe("sage"); // Falls back to agent name
   });
 
-  it("returns correct shape with all fields", () => {
+  it("returns correct shape with all fields", async () => {
     asMock(getAllAgentStatuses).mockReturnValue({
       coach: { active: "active", uptime: null, memory: null, pid: null },
       sage: { active: "inactive", uptime: null, memory: null, pid: null },
@@ -210,7 +215,9 @@ describe("handleGetAgents", () => {
       sage: { authenticated: false },
     });
 
-    const result = handleGetAgents(mockConfig);
+    const result = await handleGetAgents(mockConfig, {
+      fetchFleetStatus: async () => null,
+    });
     const expectedKeys: (keyof AgentInfo)[] = [
       "name", "active", "uptime", "memory", "extends",
       "topic_name", "topic_emoji", "auth", "primaryAccount", "memoryCollection",
@@ -222,6 +229,47 @@ describe("handleGetAgents", () => {
       }
       expect(agent.auth).toHaveProperty("authenticated");
     }
+  });
+
+  it("backfills null uptime/memory from hostd (dockerless web)", async () => {
+    // Dockerless: getAllAgentStatuses returns null uptime/memory.
+    asMock(getAllAgentStatuses).mockReturnValue({
+      coach: { active: "inactive", uptime: null, memory: null, pid: null },
+      sage: { active: "inactive", uptime: null, memory: null, pid: null },
+    });
+    asMock(getAllAuthStatuses).mockReturnValue({
+      coach: { authenticated: false },
+      sage: { authenticated: false },
+    });
+
+    const result = await handleGetAgents(mockConfig, {
+      // hostd (root, docker socket) supplies what the web can't read.
+      fetchFleetStatus: async () => ({
+        coach: { active: "active", uptime: "2026-06-15T00:00:00Z", memory: "256MB", pid: 99 },
+      }),
+    });
+
+    const coach = result.find((a) => a.name === "coach")!;
+    expect(coach.uptime).toBe("2026-06-15T00:00:00Z");
+    expect(coach.memory).toBe("256MB");
+    // No hostd row for sage → stays null (graceful).
+    const sage = result.find((a) => a.name === "sage")!;
+    expect(sage.uptime).toBeNull();
+    expect(sage.memory).toBeNull();
+  });
+
+  it("keeps null uptime/memory when hostd is unreachable", async () => {
+    asMock(getAllAgentStatuses).mockReturnValue({
+      coach: { active: "inactive", uptime: null, memory: null, pid: null },
+    });
+    asMock(getAllAuthStatuses).mockReturnValue({ coach: { authenticated: false } });
+
+    const result = await handleGetAgents(mockConfig, {
+      fetchFleetStatus: async () => null, // hostd down
+    });
+    const coach = result.find((a) => a.name === "coach")!;
+    expect(coach.uptime).toBeNull();
+    expect(coach.memory).toBeNull();
   });
 });
 
@@ -296,56 +344,43 @@ describe("handleGetLogs", () => {
     vi.clearAllMocks();
   });
 
-  it("returns merged container stdout+stderr from docker logs", () => {
-    asMock(spawnSync).mockReturnValue({
-      status: 0,
-      stdout: "line 1\nline 2\n",
-      stderr: "boot warn\n",
-    } as any);
-
-    const result = handleGetLogs("coach", 50);
+  it("returns logs from the hostd agent_logs verb", async () => {
+    const result = await handleGetLogs("coach", 50, {
+      fetchLogs: async (name, lines) => {
+        expect(name).toBe("coach");
+        expect(lines).toBe(50);
+        return { ok: true, logs: "line 1\nline 2\nboot warn\n" };
+      },
+    });
     expect(result.ok).toBe(true);
     expect(result.logs).toContain("line 1");
-    // docker logs splits container stdout/stderr; both are surfaced.
     expect(result.logs).toContain("boot warn");
-    expect(spawnSync).toHaveBeenCalledWith(
-      "docker",
-      ["logs", "--tail", "50", "switchroom-coach"],
-      expect.objectContaining({ encoding: "utf-8" })
-    );
   });
 
-  it("uses default of 50 lines", () => {
-    asMock(spawnSync).mockReturnValue({ status: 0, stdout: "output", stderr: "" } as any);
-
-    handleGetLogs("sage");
-    expect(spawnSync).toHaveBeenCalledWith(
-      "docker",
-      ["logs", "--tail", "50", "switchroom-sage"],
-      expect.any(Object)
-    );
+  it("uses default of 50 lines", async () => {
+    let observed = -1;
+    await handleGetLogs("sage", undefined, {
+      fetchLogs: async (_name, lines) => {
+        observed = lines;
+        return { ok: true, logs: "output" };
+      },
+    });
+    expect(observed).toBe(50);
   });
 
-  it("returns error when docker logs exits non-zero (no such container)", () => {
-    asMock(spawnSync).mockReturnValue({
-      status: 1,
-      stdout: "",
-      stderr: "Error: No such container: switchroom-missing\n",
-    } as any);
-
-    const result = handleGetLogs("missing", 10);
+  it("surfaces an actionable error when hostd is unreachable", async () => {
+    const result = await handleGetLogs("coach", 10, {
+      fetchLogs: async () => ({
+        ok: false,
+        error:
+          "Logs need hostd (the dashboard container has no docker access by design). " +
+          "Ensure host_control is enabled, or run `switchroom agent logs <name>` on the host.",
+      }),
+    });
     expect(result.ok).toBe(false);
-    expect(result.error).toContain("No such container");
-  });
-
-  it("returns error when docker binary is unavailable", () => {
-    asMock(spawnSync).mockReturnValue({
-      error: new Error("spawn docker ENOENT"),
-    } as any);
-
-    const result = handleGetLogs("coach", 10);
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain("ENOENT");
+    // No raw `spawn docker ENOENT` — points the operator at the real lever.
+    expect(result.error).toContain("need hostd");
+    expect(result.error).not.toContain("ENOENT");
   });
 });
 
@@ -1116,7 +1151,12 @@ describe("handleGetSchedule", () => {
       },
     }) as unknown as SwitchroomConfig;
 
-  it("returns cascade-resolved entries with recent fires from scheduler.jsonl", () => {
+  // hostd-down ⇒ degraded base-config-only fallback path. Inject a null
+  // hostd fetch so these exercise the local collectScheduleEntries +
+  // readRecentFires path deterministically (no real UDS).
+  const hostdDown = { fetchSchedule: async () => null };
+
+  it("returns cascade-resolved entries with recent fires from scheduler.jsonl", async () => {
     mkdirSync(join(tmp, "coach"), { recursive: true });
     const row = (idx: number, code: number) =>
       JSON.stringify({
@@ -1133,27 +1173,45 @@ describe("handleGetSchedule", () => {
       [row(0, 0), row(1, -1)].join("\n") + "\n",
     );
 
-    const d = handleGetSchedule(cfgWithSchedule());
+    const d = await handleGetSchedule(cfgWithSchedule(), hostdDown);
     expect(d.entries.filter((e) => e.agent === "coach")).toHaveLength(2);
     expect(d.entries[0].cron).toBe("0 9 * * *");
     expect(d.recentByAgent.coach).toHaveLength(2);
     expect(d.recentByAgent.coach[1].exitCode).toBe(-1);
+    // Degraded because hostd was down — UI must warn overlays are missing.
+    expect(d.degraded).toBe(true);
+    expect(d.reason).toContain("hostd");
   });
 
-  it("skips agents with no scheduler.jsonl without failing", () => {
-    const d = handleGetSchedule(cfgWithSchedule());
+  it("skips agents with no scheduler.jsonl without failing", async () => {
+    const d = await handleGetSchedule(cfgWithSchedule(), hostdDown);
     expect(d.entries.length).toBeGreaterThan(0);
     expect(d.recentByAgent.coach).toBeUndefined();
   });
 
-  it("tolerates a torn JSONL line", () => {
+  it("tolerates a torn JSONL line", async () => {
     mkdirSync(join(tmp, "coach"), { recursive: true });
     writeFileSync(
       join(tmp, "coach", "scheduler.jsonl"),
       '{"agent":"coach","exitCode":0,"outputSummary":"ok","startedAt":1,"finishedAt":2,"scheduleIndex":0,"promptKey":"k"}\n{ broken json\n',
     );
-    const d = handleGetSchedule(cfgWithSchedule());
+    const d = await handleGetSchedule(cfgWithSchedule(), hostdDown);
     expect(d.recentByAgent.coach).toHaveLength(1);
+  });
+
+  it("uses the hostd superset (overlays) and is NOT degraded when hostd is reachable", async () => {
+    const d = await handleGetSchedule(cfgWithSchedule(), {
+      // hostd sees an agent-authored schedule.d cron the base config lacks.
+      fetchSchedule: async () => ({
+        entries: [
+          { agent: "clerk", scheduleIndex: 0, cron: "*/30 * * * *", promptKey: "x" },
+        ],
+        recentByAgent: { clerk: [] },
+      }),
+    });
+    expect(d.entries).toHaveLength(1);
+    expect(d.entries[0].agent).toBe("clerk");
+    expect(d.degraded).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Theme A (control plane) of the admin-portal audit, read path. The dashboard ships as a **dockerless** container by design (no docker socket — it's the one internet-facing component). That broke three things the operator reported: agent **uptime/memory** showed `--` for all 12 agents, **logs** failed with `spawn docker ENOENT`, and the **Schedule tab** missed agent-authored cron overlays (clerk shows 0 crons but fires 9).

The fix routes the read path through **hostd** — which runs as root with the docker socket and `~/.switchroom` mounted, and which the web already reaches over its **ungated operator socket**. No docker socket is ever added to the web container; no model calls anywhere.

## What's fixed (audit ranks 3, 4, part of 2)

| Symptom | Fix |
|---|---|
| uptime/mem `--` for all agents | new read-only `agent_status` verb (`getAllAgentStatuses` runs where docker exists); `handleGetAgents` backfills the two null fields, 5s-TTL cached so the 10s poll can't storm `docker stats` |
| Schedule tab misses overlay crons | new read-only `agent_schedule` verb: hostd `loadConfig()`s **fresh** as root, so the loader merges each agent's `0600` `schedule.d/*.yaml` overlays the web gets EACCES on. Verified live: operator (uid 1000) gets *Permission denied* on clerk's files (uid 10821) |
| logs `spawn docker ENOENT` | `handleGetLogs` routes through the **existing** `agent_logs` verb; actionable "needs hostd" message when hostd is down |
| stale config on schedule/health/accounts | those routes now read `freshConfig()` |

## Design notes

- **New `payload` response field** (optional, JSON-encoded, bounded by the 64 KiB frame) carries structured verb results larger than the 4 KiB `stdout_tail`. Back-compatible — absent on every existing verb.
- **Gate**: ungated for the operator caller (the web). Agent callers get the `agent_smoke`/`agent_logs` posture (self-scoped ok; fleet/cross-agent needs `admin`). Both verbs are read-only and take no fleet-mutation lock.
- **`boundScheduleView`** (pure, exported, unit-tested) caps prompt≤160, fire summary≤100, last-8-fires/agent so the payload can't blow the frame.
- **Degrade-don't-die**: every web→hostd helper returns `null`/an actionable message on any failure; `handleGetSchedule` falls back to base-config-only with `degraded:true`+`reason`. The web never 500s because hostd is down.

## Test plan

- [x] protocol round-trip incl the new `payload` field + both verbs
- [x] real-UDS e2e (isolated tmp `HOME`/`SWITCHROOM_AGENTS_DIR`) for both verbs, **including the `schedule.d` overlay-merge** — the load-bearing fix
- [x] pure `boundScheduleView` unit tests
- [x] `hostd-read-client` parse-success / null-socket / throwing-transport / bad-JSON / wrong-shape cases
- [x] web handler async + backfill-when-null + degraded-fallback cases
- [x] `tsc --noEmit` clean; **668 vitest pass** (incl `src/mcp` to confirm the protocol widening didn't break the MCP wrapper)

## Risk

Medium — touches the privileged hostd daemon, but the additions are **read-only**, ungated only for the already-trusted operator socket, take no mutation lock, and can't crash the daemon (handlers catch and return `error`). The web degrades cleanly when hostd is absent. No docker socket added to the web; no model calls.

## Follow-up (PR3, same theme)

Mutations via hostd (start/stop gated by a Telegram card per the operator's choice; restart ungated), live-log WebSocket streaming, and liveness honesty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)