### PR TITLE
feat(dashboard): control plane via hostd — restart, live logs, honest liveness

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -4,9 +4,6 @@ import { resolve } from "node:path";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import {
   getAllAgentStatuses,
-  startAgent,
-  stopAgent,
-  restartAgent,
 } from "../agents/lifecycle.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
 import { getCollectionForAgent, probeHindsight } from "../memory/hindsight.js";
@@ -73,6 +70,7 @@ import {
   fetchFleetStatusViaHostd,
   fetchScheduleViaHostd,
   fetchAgentLogsViaHostd,
+  restartAgentViaHostd,
 } from "./hostd-read-client.js";
 import type { AgentStatus } from "../agents/lifecycle.js";
 import { randomUUID } from "node:crypto";
@@ -107,6 +105,39 @@ export interface AgentInfo {
     expiresAt?: number;
   };
   memoryCollection: string;
+  /**
+   * When the agent last STARTED a turn (newest `turns.started_at`, unix
+   * ms), or null when the agent has no turns DB / no turns yet. A real
+   * claude-liveness signal distinct from `active` — which only reflects
+   * the bridge↔gateway `.bridge-alive` heartbeat (a claude wedged on a
+   * quota menu still shows `active`). The UI renders this as "Last turn".
+   */
+  lastTurnAt: number | null;
+}
+
+/**
+ * Read the newest turn's `started_at` for an agent from its per-agent
+ * turns DB. `started_at` (not `ended_at`) is the field that always
+ * exists and best represents "when the agent last ran a turn" — an
+ * in-flight turn has a null `ended_at` but a real `started_at`, and
+ * `listTurnsForAgent` already orders by `started_at DESC`, so the top
+ * row is the most recent activity. Wrapped in try/catch → null on a
+ * missing DB / read error / `bun:sqlite` unavailable (under vitest the
+ * Bun-only sqlite loader throws — the dashboard runs under Bun, so this
+ * is real there and degrades to null in tests).
+ */
+export function readLastTurnAt(agentsDir: string, name: string): number | null {
+  try {
+    const db = openTurnsDb(resolve(agentsDir, name));
+    try {
+      const turns = listTurnsForAgent(db, { limit: 1 });
+      return turns.length > 0 ? turns[0].started_at : null;
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -172,8 +203,12 @@ export async function handleGetAgents(
   deps: {
     now?: number;
     fetchFleetStatus?: () => Promise<Record<string, AgentStatus> | null>;
+    /** Injectable for tests (default reads the real per-agent turns DB,
+     *  which needs `bun:sqlite` — unavailable under vitest). */
+    readLastTurn?: (agentsDir: string, name: string) => number | null;
   } = {},
 ): Promise<AgentInfo[]> {
+  const readLastTurn = deps.readLastTurn ?? readLastTurnAt;
   const statuses = getAllAgentStatuses(config);
   const authStatuses = getAllAuthStatuses(config);
   const agentsDir = resolveAgentsDir(config);
@@ -237,39 +272,70 @@ export async function handleGetAgents(
         expiresAt: auth?.expiresAt,
       },
       memoryCollection: collection,
+      // A real claude-liveness signal (newest turn's start), distinct
+      // from `active` (bridge heartbeat only). Null-safe per agent.
+      lastTurnAt: readLastTurn(agentsDir, name),
     });
   }
 
   return agents;
 }
 
-export function handleStartAgent(name: string): { ok: boolean; error?: string } {
-  try {
-    startAgent(name);
-    void captureEvent("agent_started", { agent: name, source: "web_api" });
-    return { ok: true };
-  } catch (err) {
-    void captureException(err, { action: "start_agent", agent: name });
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
-  }
+/**
+ * Start/Stop from the dashboard are deferred to a follow-up PR — they
+ * need a new Telegram approval card (start/stop are NOT ungated like
+ * restart). Until then the dashboard does NOT shell docker (the web
+ * container is dockerless BY DESIGN — that would `spawn` ENOENT).
+ * It returns this actionable message pointing the operator at the host
+ * CLI. `verb` is "start" or "stop".
+ */
+export function startStopNeedsOperatorMessage(verb: "start" | "stop"): string {
+  return (
+    `${verb === "start" ? "Start" : "Stop"} from the dashboard needs operator approval (a follow-up). ` +
+    `For now run on the host: \`switchroom agent ${verb} ${"<name>"}\`.`
+  );
 }
 
-export function handleStopAgent(name: string): { ok: boolean; error?: string } {
-  try {
-    stopAgent(name);
-    void captureEvent("agent_stopped", { agent: name, source: "web_api" });
-    return { ok: true };
-  } catch (err) {
-    void captureException(err, { action: "stop_agent", agent: name });
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
-  }
+/** Exported for tests + UI parity — the static start/stop deferral text. */
+export const START_NEEDS_OPERATOR_MESSAGE = startStopNeedsOperatorMessage("start");
+export const STOP_NEEDS_OPERATOR_MESSAGE = startStopNeedsOperatorMessage("stop");
+
+export async function handleStartAgent(
+  _name: string,
+): Promise<{ ok: boolean; error?: string }> {
+  // Deferred to the start/stop-approval PR. Do NOT shell docker (dockerless
+  // web → ENOENT) — return the actionable host-CLI message instead.
+  return { ok: false, error: START_NEEDS_OPERATOR_MESSAGE };
 }
 
-export function handleRestartAgent(name: string): { ok: boolean; error?: string } {
+export async function handleStopAgent(
+  _name: string,
+): Promise<{ ok: boolean; error?: string }> {
+  // Deferred to the start/stop-approval PR. See handleStartAgent.
+  return { ok: false, error: STOP_NEEDS_OPERATOR_MESSAGE };
+}
+
+/**
+ * Restart an agent from the dashboard. The web container is dockerless BY
+ * DESIGN, so this CANNOT shell `restartAgent()` (→ `spawn docker ENOENT`).
+ * It routes through hostd's existing `agent_restart` verb over the
+ * ungated operator socket — the operator chose restart to be UNGATED, so
+ * it acts immediately (no approval card). When hostd is unreachable the
+ * helper returns an actionable "needs hostd" message instead of a raw
+ * docker error. `deps.restart` is injectable for tests.
+ */
+export async function handleRestartAgent(
+  name: string,
+  deps: { restart?: typeof restartAgentViaHostd } = {},
+): Promise<{ ok: boolean; error?: string }> {
+  const restart = deps.restart ?? restartAgentViaHostd;
   try {
-    restartAgent(name);
-    void captureEvent("agent_restarted", { agent: name, source: "web_api" });
-    return { ok: true };
+    const result = await restart(name);
+    if (result.ok) {
+      void captureEvent("agent_restarted", { agent: name, source: "web_api" });
+      return { ok: true };
+    }
+    return { ok: false, error: result.error };
   } catch (err) {
     void captureException(err, { action: "restart_agent", agent: name });
     return { ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/src/web/hostd-read-client.test.ts
+++ b/src/web/hostd-read-client.test.ts
@@ -211,6 +211,18 @@ describe("fetchAgentLogsViaHostd", () => {
     expect(out.ok).toBe(false);
     if (!out.ok) expect(out.error).toContain("No such container");
   });
+
+  it("falls back to stderr_tail when an error result carries no `error` string", async () => {
+    // `docker logs` on a stopped container exits non-zero with the cause in
+    // stderr_tail and NO `error` — the operator should see the real reason.
+    const out = await fetchAgentLogsViaHostd("clerk", 50, {
+      socketPath: SOCK,
+      send: async () =>
+        resp({ result: "error", exit_code: 1, stderr_tail: "Error: container is not running\n" }),
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain("container is not running");
+  });
 });
 
 describe("restartAgentViaHostd", () => {

--- a/src/web/hostd-read-client.test.ts
+++ b/src/web/hostd-read-client.test.ts
@@ -3,7 +3,9 @@ import {
   fetchFleetStatusViaHostd,
   fetchScheduleViaHostd,
   fetchAgentLogsViaHostd,
+  restartAgentViaHostd,
   HOSTD_UNREACHABLE_LOGS_MESSAGE,
+  HOSTD_UNREACHABLE_CONTROL_MESSAGE,
 } from "./hostd-read-client.js";
 import type { HostdResponse } from "../host-control/protocol.js";
 
@@ -208,5 +210,76 @@ describe("fetchAgentLogsViaHostd", () => {
     });
     expect(out.ok).toBe(false);
     if (!out.ok) expect(out.error).toContain("No such container");
+  });
+});
+
+describe("restartAgentViaHostd", () => {
+  it("routes through agent_restart and maps `completed` → ok", async () => {
+    let sent: unknown;
+    const out = await restartAgentViaHostd("clerk", {
+      socketPath: SOCK,
+      send: async (_opts, req) => {
+        sent = req;
+        return resp({ result: "completed" });
+      },
+    });
+    expect(out).toEqual({ ok: true });
+    expect(sent).toMatchObject({
+      op: "agent_restart",
+      args: { name: "clerk", force: true, reason: "restart requested from dashboard" },
+    });
+  });
+
+  it("maps `started` → ok (restart is async — started IS success)", async () => {
+    const out = await restartAgentViaHostd("clerk", {
+      socketPath: SOCK,
+      send: async () => resp({ result: "started", exit_code: null }),
+    });
+    expect(out).toEqual({ ok: true });
+  });
+
+  it("maps `denied` → {ok:false} surfacing hostd's reason", async () => {
+    const out = await restartAgentViaHostd("clerk", {
+      socketPath: SOCK,
+      send: async () =>
+        resp({ result: "denied", exit_code: null, error: "cross-agent restart needs admin" }),
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain("cross-agent restart needs admin");
+  });
+
+  it("maps `error` → {ok:false} surfacing hostd's reason", async () => {
+    const out = await restartAgentViaHostd("clerk", {
+      socketPath: SOCK,
+      send: async () => resp({ result: "error", exit_code: null, error: "recreate failed" }),
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain("recreate failed");
+  });
+
+  it("returns the actionable control message on a null socket", async () => {
+    let called = false;
+    const out = await restartAgentViaHostd("clerk", {
+      socketPath: null,
+      send: async () => {
+        called = true;
+        return resp({});
+      },
+    });
+    expect(out).toEqual({ ok: false, error: HOSTD_UNREACHABLE_CONTROL_MESSAGE });
+    // Short-circuits before opening any connection.
+    expect(called).toBe(false);
+    if (!out.ok) expect(out.error).toContain("needs hostd");
+  });
+
+  it("returns the actionable control message when the transport throws", async () => {
+    const out = await restartAgentViaHostd("clerk", {
+      socketPath: SOCK,
+      send: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toBe(HOSTD_UNREACHABLE_CONTROL_MESSAGE);
   });
 });

--- a/src/web/hostd-read-client.ts
+++ b/src/web/hostd-read-client.ts
@@ -162,10 +162,15 @@ export async function fetchAgentLogsViaHostd(
     if (resp.result === "completed") {
       return { ok: true, logs: resp.stdout_tail ?? "" };
     }
-    // denied / error — surface hostd's reason if it gave one.
+    // denied / error — surface the real cause. `docker logs` on a stopped/
+    // absent container exits non-zero with the diagnostic in `stderr_tail`
+    // and NO `error` string, so fall back to it before the generic message.
     return {
       ok: false,
-      error: resp.error ?? `hostd agent_logs returned '${resp.result}'`,
+      error:
+        resp.error ??
+        (resp.stderr_tail && resp.stderr_tail.trim()) ??
+        `hostd agent_logs returned '${resp.result}'`,
     };
   } catch {
     return { ok: false, error: HOSTD_UNREACHABLE_LOGS_MESSAGE };

--- a/src/web/hostd-read-client.ts
+++ b/src/web/hostd-read-client.ts
@@ -179,3 +179,75 @@ export async function fetchAgentLogsViaHostd(
 export const HOSTD_UNREACHABLE_LOGS_MESSAGE =
   "Logs need hostd (the dashboard container has no docker access by design). " +
   "Ensure host_control is enabled, or run `switchroom agent logs <name>` on the host.";
+
+/** Actionable error shown when agent CONTROL (restart) can't reach hostd.
+ *  The dashboard container has no docker BY DESIGN, so a restart cannot
+ *  `docker` directly — it must go through hostd's `agent_restart` verb.
+ *  When hostd is down/unconfigured we point the operator at the real
+ *  levers rather than leaking `spawn docker ENOENT`. */
+export const HOSTD_UNREACHABLE_CONTROL_MESSAGE =
+  "Agent control needs hostd (the dashboard container has no docker access by design). " +
+  "Ensure host_control is enabled, or run `switchroom agent restart <name>` on the host.";
+
+export interface RestartViaHostdOpts extends HostdReadOpts {
+  /** Operator-visible reason rendered into the hostd audit row. */
+  reason?: string;
+  /** Bypass safety prompts on the host-side CLI. Defaults true (the
+   *  dashboard restart is an explicit operator click). */
+  force?: boolean;
+}
+
+/**
+ * Restart a peer agent via hostd's EXISTING `agent_restart` verb. The
+ * dockerless web container can't `docker` — so the dashboard's Restart
+ * button routes here instead of shelling docker (which `spawn`s ENOENT).
+ *
+ * The verb is reached over the OPERATOR socket, which `checkGate` leaves
+ * ungated — so restart from the dashboard acts immediately (the operator
+ * chose ungated for restart; start/stop are a separate approval-gated PR).
+ *
+ * Never throws. Maps:
+ *   - `completed` / `started` → `{ ok: true }` (restart is async — hostd
+ *     returns `started` after spawning the recreate; that IS success).
+ *   - `denied` / `error`      → `{ ok: false, error: <hostd reason> }`.
+ *   - null socket / transport throw → `{ ok: false, error: <actionable> }`.
+ */
+export async function restartAgentViaHostd(
+  name: string,
+  opts: RestartViaHostdOpts = {},
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const socketPath =
+    opts.socketPath !== undefined ? opts.socketPath : resolveHostdOperatorSocket();
+  if (!socketPath) {
+    return { ok: false, error: HOSTD_UNREACHABLE_CONTROL_MESSAGE };
+  }
+  const send = opts.send ?? hostdRequest;
+  const req: HostdRequest = {
+    v: 1,
+    op: "agent_restart",
+    request_id: readRequestId("agent_restart"),
+    args: {
+      name,
+      reason: opts.reason ?? "restart requested from dashboard",
+      force: opts.force ?? true,
+    },
+  };
+  try {
+    const resp: HostdResponse = await send(
+      { socketPath, timeoutMs: opts.timeoutMs ?? READ_TIMEOUT_MS },
+      req,
+    );
+    // `started` is the expected happy path: hostd spawns the recreate
+    // detached and acks immediately. `completed` covers a fast synchronous
+    // finish. Either is success.
+    if (resp.result === "completed" || resp.result === "started") {
+      return { ok: true };
+    }
+    return {
+      ok: false,
+      error: resp.error ?? `hostd agent_restart returned '${resp.result}'`,
+    };
+  } catch {
+    return { ok: false, error: HOSTD_UNREACHABLE_CONTROL_MESSAGE };
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -10,13 +10,11 @@ import {
 } from "node:fs";
 import { resolve, extname, join, relative, dirname } from "node:path";
 import { homedir } from "node:os";
-import { spawn } from "node:child_process";
 import { timingSafeEqual, randomBytes } from "node:crypto";
 import type { SwitchroomConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import { loadConfig, resolvePath } from "../config/loader.js";
 import { getViaBrokerStructured, resolveBrokerSocketPath } from "../vault/broker/client.js";
-import { containerName } from "../agents/lifecycle.js";
 import {
   handleGetAgents,
   handleStartAgent,
@@ -42,8 +40,18 @@ import {
   handleGetSchedule,
   handleGetApprovals,
 } from "./api.js";
+import { fetchAgentLogsViaHostd } from "./hostd-read-client.js";
 import { handleWebhookIngest } from "./webhook-handler.js";
 import { loadEdgeSecret } from "./webhook-edge.js";
+
+/** Live-log poll cadence (ms) for the WS stream. hostd reads `docker
+ *  logs --tail` each tick — a poll, not a follow, because the dockerless
+ *  web can't `docker logs -f`. 3s balances freshness against host load. */
+const LOG_POLL_INTERVAL_MS = 3000;
+/** Trailing lines requested each poll. hostd caps its `stdout_tail` at
+ *  4 KiB regardless, so a very high-volume container shows only the last
+ *  ~tail; acceptable for this at-a-glance log view. */
+const LOG_POLL_TAIL_LINES = 400;
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html",
@@ -655,7 +663,7 @@ export function startWebServer(
             if (!config.agents[agentName]) {
               return jsonResponse({ ok: false, error: `Unknown agent: ${agentName}` }, 404);
             }
-            return jsonResponse(handleStartAgent(agentName));
+            return (async () => jsonResponse(await handleStartAgent(agentName)))();
           }
 
           case "stopAgent": {
@@ -663,7 +671,7 @@ export function startWebServer(
             if (!config.agents[agentName]) {
               return jsonResponse({ ok: false, error: `Unknown agent: ${agentName}` }, 404);
             }
-            return jsonResponse(handleStopAgent(agentName));
+            return (async () => jsonResponse(await handleStopAgent(agentName)))();
           }
 
           case "restartAgent": {
@@ -671,7 +679,7 @@ export function startWebServer(
             if (!config.agents[agentName]) {
               return jsonResponse({ ok: false, error: `Unknown agent: ${agentName}` }, 404);
             }
-            return jsonResponse(handleRestartAgent(agentName));
+            return (async () => jsonResponse(await handleRestartAgent(agentName)))();
           }
 
           case "getTurns": {
@@ -872,90 +880,104 @@ export function startWebServer(
         // No-op; tracking handled per-subscription
       },
       close(ws) {
-        const proc = (ws as any)._logProcess;
-        if (proc) {
-          proc.kill();
-          (ws as any)._logProcess = null;
+        // Stop the live-log poll loop on disconnect.
+        const interval = (ws as any)._logInterval;
+        if (interval) {
+          clearInterval(interval);
+          (ws as any)._logInterval = null;
         }
       },
       message(ws, message) {
-        // Handle subscription requests for agent logs
+        // Handle subscription requests for agent logs.
+        //
+        // The web container is dockerless BY DESIGN (no docker binary/
+        // socket — security hardening), so it CANNOT `docker logs -f` to
+        // follow a stream. Instead we POLL hostd's `agent_logs` verb (hostd
+        // runs as root with the docker socket) every few seconds and push
+        // the latest tail as a REPLACE. hostd caps its tail at 4 KiB, so a
+        // very high-volume container shows only the last ~tail — acceptable
+        // for this at-a-glance view. The client merges/replaces the panel.
+        let data: any;
         try {
-          const data = JSON.parse(String(message));
-          if (data.type === "subscribe" && data.agent) {
-            const agentName = String(data.agent).replace(/[^a-zA-Z0-9_-]/g, "");
-            // Only allow subscribing to agents that actually exist in config.
-            if (!agentName || !config.agents[agentName]) {
-              try {
-                ws.send(JSON.stringify({ type: "error", error: "Unknown agent" }));
-              } catch {}
-              return;
-            }
+          data = JSON.parse(String(message));
+        } catch {
+          return; // Ignore invalid messages
+        }
 
-            // Kill any existing log process before subscribing to a new one
-            const existing = (ws as any)._logProcess;
-            if (existing) {
-              existing.kill();
-              (ws as any)._logProcess = null;
-            }
+        const clearLogInterval = () => {
+          const existing = (ws as any)._logInterval;
+          if (existing) {
+            clearInterval(existing);
+            (ws as any)._logInterval = null;
+          }
+        };
 
-            // Agents are Docker containers since v0.7 — stream the
-            // container log, not a (nonexistent) systemd user unit.
-            // docker logs splits container stdout/stderr across the
-            // two fds; both are forwarded to the client below.
-            const child = spawn(
-              "docker",
-              ["logs", "-f", "--tail", "20", containerName(agentName)],
-              { stdio: ["ignore", "pipe", "pipe"] }
-            );
+        if (data && data.type === "unsubscribe") {
+          clearLogInterval();
+          return;
+        }
 
-            // A missing `docker` binary (or exec failure) emits an
-            // 'error' event with no stdout/stderr; without a handler
-            // Node treats it as unhandled and crashes the server.
-            // Surface it to the client as a log_error instead.
-            child.on("error", (err: Error) => {
+        if (data && data.type === "subscribe" && data.agent) {
+          const agentName = String(data.agent).replace(/[^a-zA-Z0-9_-]/g, "");
+          // Only allow subscribing to agents that actually exist in config.
+          if (!agentName || !config.agents[agentName]) {
+            try {
+              ws.send(JSON.stringify({ type: "error", error: "Unknown agent" }));
+            } catch {}
+            return;
+          }
+
+          // Drop any existing poll loop before starting a new one (the
+          // client only views one agent's logs at a time per socket).
+          clearLogInterval();
+
+          // One poll: read the tail via hostd, push a REPLACE. On a hard
+          // error (hostd down / denied) surface it once and stop the loop
+          // so we don't spin pushing the same failure every 3s.
+          const poll = async () => {
+            let result: Awaited<ReturnType<typeof fetchAgentLogsViaHostd>>;
+            try {
+              result = await fetchAgentLogsViaHostd(agentName, LOG_POLL_TAIL_LINES);
+            } catch (err) {
+              // fetchAgentLogsViaHostd never throws, but belt-and-braces.
               try {
                 ws.send(JSON.stringify({
                   type: "log_error",
                   agent: agentName,
-                  data: `failed to stream logs: ${err.message}\n`,
+                  data: err instanceof Error ? err.message : String(err),
                 }));
-              } catch {
-                // Client already gone — nothing to clean up; the
-                // process never started so there's no pid to kill.
-              }
-            });
-
-            child.stdout.on("data", (chunk: Buffer) => {
+              } catch {}
+              clearLogInterval();
+              return;
+            }
+            if (result.ok) {
               try {
                 ws.send(JSON.stringify({
                   type: "log",
                   agent: agentName,
-                  data: chunk.toString("utf-8"),
+                  data: result.logs,
+                  replace: true,
                 }));
               } catch {
-                // Client disconnected
-                child.kill();
+                // Client gone mid-send — stop polling.
+                clearLogInterval();
               }
-            });
-
-            child.stderr.on("data", (chunk: Buffer) => {
+            } else {
               try {
                 ws.send(JSON.stringify({
                   type: "log_error",
                   agent: agentName,
-                  data: chunk.toString("utf-8"),
+                  data: result.error,
                 }));
-              } catch {
-                child.kill();
-              }
-            });
+              } catch {}
+              // Don't keep hammering hostd on a hard error.
+              clearLogInterval();
+            }
+          };
 
-            // Store child reference for cleanup
-            (ws as any)._logProcess = child;
-          }
-        } catch {
-          // Ignore invalid messages
+          // Immediate first poll, then a steady cadence.
+          void poll();
+          (ws as any)._logInterval = setInterval(() => void poll(), LOG_POLL_INTERVAL_MS);
         }
       },
     },

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -958,7 +958,7 @@
       container.innerHTML = agents.map(a => `
         <div class="agent-card" data-agent="${escapeHtml(a.name)}">
           <div class="card-header" onclick="toggleLogs('${escapeHtml(a.name)}')">
-            <div class="status-dot ${statusClass(a)}" title="${escapeHtml(a.active)}"></div>
+            <div class="status-dot ${statusClass(a)}" title="${escapeHtml(a.active)} · bridge heartbeat (not a claude-liveness signal)"></div>
             <div class="agent-name">${escapeHtml(a.name)}</div>
             <div class="agent-topic">${a.topic_emoji ? escapeHtml(a.topic_emoji) + ' ' : ''}${escapeHtml(a.topic_name)}</div>
           </div>
@@ -966,6 +966,7 @@
             <div class="meta-item"><label>Status </label><span>${escapeHtml(a.active)}</span></div>
             <div class="meta-item"><label>Uptime </label><span>${formatUptime(a.uptime)}</span></div>
             <div class="meta-item"><label>Mem </label><span>${a.memory || '--'}</span></div>
+            <div class="meta-item"><label>Last turn </label><span>${a.lastTurnAt ? formatTimestamp(a.lastTurnAt) : '—'}</span></div>
             <div class="meta-item"><label>Profile </label><span>${escapeHtml(a.extends)}</span></div>
             <div class="meta-item"><label>Auth </label><span>${a.auth.authenticated ? '✓' : '✗'}</span></div>
             <div class="meta-item"><label>Account </label><span>${a.primaryAccount ? escapeHtml(a.primaryAccount) : '<span style="color:var(--text-dim)">default</span>'}</span></div>
@@ -1647,9 +1648,15 @@
     async function toggleLogs(name) {
       if (openLogs.has(name)) {
         openLogs.delete(name);
+        unsubscribeLogs(name);
       } else {
         openLogs.add(name);
+        // One-shot paint for instant feedback, then subscribe to the
+        // hostd-poll live stream (replaces the panel every few seconds).
         await loadLogs(name);
+        render();
+        subscribeLogs(name);
+        return;
       }
       render();
     }
@@ -1694,11 +1701,29 @@
           if (msg.type === 'log' && msg.agent) {
             const el = document.getElementById(`log-output-${msg.agent}`);
             if (el && openLogs.has(msg.agent)) {
-              el.textContent += msg.data;
+              // hostd-poll stream sends REPLACE (the latest tail). The
+              // legacy docker-follow stream appended; keep both shapes so
+              // an old payload (no `replace`) still works.
+              if (msg.replace) {
+                el.textContent = msg.data || '(no output)';
+              } else {
+                el.textContent += msg.data;
+              }
               el.scrollTop = el.scrollHeight;
+            }
+          } else if (msg.type === 'log_error' && msg.agent) {
+            const el = document.getElementById(`log-output-${msg.agent}`);
+            if (el && openLogs.has(msg.agent)) {
+              el.textContent = `Error: ${msg.data || 'log stream unavailable'}`;
             }
           }
         } catch {}
+      };
+
+      ws.onopen = () => {
+        // Re-subscribe any panels that were left open across a reconnect
+        // so a dropped socket doesn't leave a permanently-dead log panel.
+        for (const name of openLogs) subscribeLogs(name);
       };
 
       ws.onclose = () => {
@@ -1708,6 +1733,20 @@
       ws.onerror = () => {
         ws.close();
       };
+    }
+
+    // Send a {subscribe} for an agent's live-log poll stream, guarded on
+    // an OPEN socket (a closed socket re-subscribes via ws.onopen above).
+    function subscribeLogs(name) {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        try { ws.send(JSON.stringify({ type: 'subscribe', agent: name })); } catch {}
+      }
+    }
+
+    function unsubscribeLogs(name) {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        try { ws.send(JSON.stringify({ type: 'unsubscribe', agent: name })); } catch {}
+      }
     }
 
     // Init. Summary is the default visible tab; fetchAgents still runs

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -95,6 +95,8 @@ import {
   handleStartAgent,
   handleStopAgent,
   handleRestartAgent,
+  START_NEEDS_OPERATOR_MESSAGE,
+  STOP_NEEDS_OPERATOR_MESSAGE,
   handleGetLogs,
   handleGetSystemHealth,
   handleGetGoogleAccounts,
@@ -221,6 +223,7 @@ describe("handleGetAgents", () => {
     const expectedKeys: (keyof AgentInfo)[] = [
       "name", "active", "uptime", "memory", "extends",
       "topic_name", "topic_emoji", "auth", "primaryAccount", "memoryCollection",
+      "lastTurnAt",
     ];
 
     for (const agent of result) {
@@ -271,71 +274,116 @@ describe("handleGetAgents", () => {
     expect(coach.uptime).toBeNull();
     expect(coach.memory).toBeNull();
   });
+
+  it("includes lastTurnAt from the injected turns reader", async () => {
+    asMock(getAllAgentStatuses).mockReturnValue({
+      coach: { active: "active", uptime: null, memory: null, pid: null },
+      sage: { active: "inactive", uptime: null, memory: null, pid: null },
+    });
+    asMock(getAllAuthStatuses).mockReturnValue({
+      coach: { authenticated: false },
+      sage: { authenticated: false },
+    });
+
+    const result = await handleGetAgents(mockConfig, {
+      fetchFleetStatus: async () => null,
+      // Inject so the test never touches the real per-agent turns DB
+      // (which needs `bun:sqlite`, unavailable under vitest).
+      readLastTurn: (_dir, name) => (name === "coach" ? 1_700_000_000_000 : null),
+    });
+
+    const coach = result.find((a) => a.name === "coach")!;
+    const sage = result.find((a) => a.name === "sage")!;
+    expect(coach).toHaveProperty("lastTurnAt", 1_700_000_000_000);
+    // null-safe: an agent with no turns DB / no turns reads null, not a throw.
+    expect(sage).toHaveProperty("lastTurnAt", null);
+  });
+
+  it("is null-safe for lastTurnAt when the default reader hits a missing DB", async () => {
+    // The default readLastTurnAt opens the real turns DB at the mocked
+    // agentsDir (which doesn't exist) and must degrade to null, never throw.
+    asMock(getAllAgentStatuses).mockReturnValue({
+      coach: { active: "inactive", uptime: null, memory: null, pid: null },
+    });
+    asMock(getAllAuthStatuses).mockReturnValue({ coach: { authenticated: false } });
+
+    const result = await handleGetAgents(mockConfig, {
+      fetchFleetStatus: async () => null,
+      // No readLastTurn injected → exercises the real readLastTurnAt path.
+    });
+    const coach = result.find((a) => a.name === "coach")!;
+    expect(coach.lastTurnAt).toBeNull();
+  });
 });
 
-describe("handleStartAgent", () => {
+describe("handleStartAgent (deferred to approval PR — never shells docker)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("calls startAgent and returns ok on success", () => {
-    asMock(startAgent).mockImplementation(() => {});
-    const result = handleStartAgent("coach");
-    expect(result).toEqual({ ok: true });
-    expect(startAgent).toHaveBeenCalledWith("coach");
-  });
-
-  it("returns error when startAgent throws", () => {
-    asMock(startAgent).mockImplementation(() => {
-      throw new Error("service not found");
-    });
-    const result = handleStartAgent("missing");
+  it("returns the actionable host-CLI message and does NOT call startAgent", async () => {
+    const result = await handleStartAgent("coach");
     expect(result.ok).toBe(false);
-    expect(result.error).toContain("service not found");
+    expect(result.error).toBe(START_NEEDS_OPERATOR_MESSAGE);
+    expect(result.error).toContain("switchroom agent start");
+    // The dockerless web must never shell the lifecycle start (→ docker).
+    expect(startAgent).not.toHaveBeenCalled();
   });
 });
 
-describe("handleStopAgent", () => {
+describe("handleStopAgent (deferred to approval PR — never shells docker)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("calls stopAgent and returns ok on success", () => {
-    asMock(stopAgent).mockImplementation(() => {});
-    const result = handleStopAgent("coach");
-    expect(result).toEqual({ ok: true });
-    expect(stopAgent).toHaveBeenCalledWith("coach");
-  });
-
-  it("returns error when stopAgent throws", () => {
-    asMock(stopAgent).mockImplementation(() => {
-      throw new Error("cannot stop");
-    });
-    const result = handleStopAgent("coach");
+  it("returns the actionable host-CLI message and does NOT call stopAgent", async () => {
+    const result = await handleStopAgent("coach");
     expect(result.ok).toBe(false);
-    expect(result.error).toContain("cannot stop");
+    expect(result.error).toBe(STOP_NEEDS_OPERATOR_MESSAGE);
+    expect(result.error).toContain("switchroom agent stop");
+    expect(stopAgent).not.toHaveBeenCalled();
   });
 });
 
-describe("handleRestartAgent", () => {
+describe("handleRestartAgent (hostd-routed, ungated)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("calls restartAgent and returns ok on success", () => {
-    asMock(restartAgent).mockImplementation(() => {});
-    const result = handleRestartAgent("sage");
+  it("routes through the injected hostd restart and returns ok on success", async () => {
+    let calledWith: string | undefined;
+    const result = await handleRestartAgent("sage", {
+      restart: async (name) => {
+        calledWith = name;
+        return { ok: true };
+      },
+    });
     expect(result).toEqual({ ok: true });
-    expect(restartAgent).toHaveBeenCalledWith("sage");
+    expect(calledWith).toBe("sage");
+    // Never shells the dockerful lifecycle restart from the web container.
+    expect(restartAgent).not.toHaveBeenCalled();
   });
 
-  it("returns error when restartAgent throws", () => {
-    asMock(restartAgent).mockImplementation(() => {
-      throw new Error("restart failed");
+  it("surfaces the actionable error when hostd is unreachable", async () => {
+    const result = await handleRestartAgent("sage", {
+      restart: async () => ({
+        ok: false,
+        error: "Agent control needs hostd (the dashboard container has no docker access by design).",
+      }),
     });
-    const result = handleRestartAgent("sage");
     expect(result.ok).toBe(false);
-    expect(result.error).toContain("restart failed");
+    expect(result.error).toContain("needs hostd");
+    expect(restartAgent).not.toHaveBeenCalled();
+  });
+
+  it("degrades gracefully if the restart helper itself throws", async () => {
+    const result = await handleRestartAgent("sage", {
+      restart: async () => {
+        throw new Error("unexpected");
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("unexpected");
   });
 });
 


### PR DESCRIPTION
## Summary

Completes the dockerless-web **control plane** (audit Theme A). The web container has no docker by design, so the Restart button, live logs, and the (now honest) liveness signal all route through hostd. Start/Stop are split into a follow-up (they need a new Telegram approval card — the existing one is config-diff-specific).

## What's fixed

| Rank | Fix |
|---|---|
| **2 (restart)** | The Restart button routed through hostd's existing `agent_restart` verb over the **ungated** operator socket (operator chose restart = ungated, acts immediately). Never throws; `started`/`completed`→ok; hostd-down → actionable message. `handleStart/StopAgent` no longer `spawn docker` (ENOENT) — they return an actionable host-CLI message until the carded path ships. |
| **12** | The live-log WebSocket dropped the dead `docker logs -f` spawn; on `{subscribe}` it **polls** hostd `agent_logs` every 3s and pushes the tail as a REPLACE; clears the interval on `{unsubscribe}`/close/hard-error. The UI now actually **sends** `{subscribe}`/`{unsubscribe}` (it never did — a latent bug), re-subscribes open panels on reconnect, and renders `replace` + `log_error`. |
| **15** | `lastTurnAt` (newest `turns.started_at`, null-safe) added + a **"Last turn"** field; the status dot is relabeled *"bridge heartbeat (not a claude-liveness signal)"*. A claude wedged on a quota menu no longer reads healthy on the bridge dot alone. |

## Notes / deliberate scope

- **Start/Stop deferred to a follow-up** — they must be **gated** (operator's choice), which needs a new lifecycle approval-card type in the telegram-plugin gateway. Until then the dashboard surfaces *"run on the host"* rather than acting silently or ungated.
- **Live logs are a poll, not a follow** — hostd caps its tail at 4 KiB, so a very high-volume container shows only the last ~tail. Acceptable for an at-a-glance view; a true streaming verb is a possible later enhancement.
- **One live stream per socket** — with several log panels open, only the most-recently-opened streams live (others keep their one-shot paint). Acceptable v1.

## Test plan

- [x] `restartAgentViaHostd` mapping: completed/started→ok, denied/error→message, null-socket/throw→actionable
- [x] `handleRestartAgent` async via injected fake (ok + hostd-down); start/stop return the actionable message and never shell docker
- [x] `handleGetAgents` includes `lastTurnAt` via an injected reader + null-safe default (the real reader needs `bun:sqlite`)
- [x] `tsc --noEmit` clean; **265** web/host-control tests pass; UI `<script>` `node --check` clean

## Risk

Low–medium. No docker added to the web; no model calls. Restart uses an existing ungated verb. The WS poll loop only calls the already-tested never-throwing client + guarded `ws.send`, and clears its interval on every exit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)