### PR TITLE
feat(dashboard): server-side SWR cache + /api/summary + visibility-gated poll

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -88,6 +88,39 @@ import {
 } from "../auth/broker/client.js";
 import { openTurnsDb, listTurnsForAgent, type Turn } from "../../telegram-plugin/registry/turns-schema.js";
 import { applySubagentsSchema, listSubagents, type Subagent } from "../../telegram-plugin/registry/subagents-schema.js";
+import { SwrCache } from "./cache.js";
+
+/**
+ * Shared stale-while-revalidate cache for the dashboard's read-only
+ * panels. Every expensive READ route (system-health, memory-health,
+ * schedule, agents, accounts, approvals) goes through this so a tab-open
+ * or poll-tick serves a cached value fast and at most one background
+ * refresh hits the host (docker inspect / broker RPC / hindsight probe /
+ * hostd round-trip / per-agent sqlite). The `/api/summary` aggregate
+ * pulls each part through the SAME keys + TTLs, so a Summary open warms
+ * the per-tab caches (and vice-versa) — they can never disagree.
+ *
+ * NOT cached: the billed quota refresh (`handleRefreshAccountsQuota`),
+ * any mutation (start/stop/restart/use/connect/access), webhooks, logs WS.
+ */
+export const dashboardCache = new SwrCache();
+
+/** Cache TTLs (ms), keyed by the dashboard route. Tuned per cost/churn:
+ *  fast-changing + cheap (agents) gets a short TTL; expensive + slow-
+ *  changing (memory-health, one MCP round-trip per bank) gets a long one. */
+export const DASHBOARD_CACHE_TTL = {
+  "system-health": 15000,
+  "memory-health": 60000,
+  schedule: 30000,
+  agents: 5000,
+  accounts: 10000,
+  approvals: 15000,
+} as const;
+
+/** Test-only: reset the shared dashboard cache between cases. */
+export function __resetDashboardCacheForTests(): void {
+  dashboardCache.clear();
+}
 
 export interface AgentInfo {
   name: string;
@@ -1685,4 +1718,86 @@ export async function handleGetMemoryHealth(
 
   rows.sort((a, b) => a.bank.localeCompare(b.bank));
   return { reachable, url, banks: rows };
+}
+
+/**
+ * The default Summary tab's single round-trip. Aggregates the cached
+ * reads the tiles need so the client fetches ONE endpoint instead of
+ * five. Each part is pulled through the SAME per-tab cache key + TTL it
+ * has on its own route — so a Summary open warms the per-tab caches (and
+ * vice-versa) and the two surfaces can never show different numbers.
+ *
+ * Each field degrades INDEPENDENTLY: the parts run under `Promise.all`,
+ * but every producer is wrapped so a throw yields `null` for that field
+ * (and `dataAsOf` 0 for the stamp calc) rather than failing the whole
+ * summary. `dataAsOf` is the OLDEST of the parts' stamps (the summary is
+ * only as fresh as its stalest piece). The caller (server.ts) supplies
+ * the cache-bound producers via `deps`; the default reads are wired there.
+ */
+export interface SummaryDashboard {
+  agents: AgentInfo[] | null;
+  systemHealth: SystemHealth | null;
+  approvals: ApprovalsDashboard | null;
+  schedule: ScheduleDashboard | null;
+  accounts: AccountDashboardInfo[] | null;
+  /** Oldest (min) `dataAsOf` across the parts, unix ms — the summary's
+   *  effective freshness. */
+  dataAsOf: number;
+}
+
+/** One cached part of the summary: the value plus when it was produced. */
+export interface SummaryPart<T> {
+  value: T;
+  dataAsOf: number;
+}
+
+/**
+ * Aggregate the summary from cache-bound producers. Each `deps.<part>`
+ * returns the cached value + its `dataAsOf`; a rejection is caught here
+ * and becomes a null field (the others still render). Pure orchestration
+ * — no broker/docker/hostd knowledge — so it's unit-testable with fakes.
+ */
+export async function handleGetSummary(deps: {
+  agents: () => Promise<SummaryPart<AgentInfo[]>>;
+  systemHealth: () => Promise<SummaryPart<SystemHealth>>;
+  approvals: () => Promise<SummaryPart<ApprovalsDashboard>>;
+  schedule: () => Promise<SummaryPart<ScheduleDashboard>>;
+  accounts: () => Promise<SummaryPart<AccountDashboardInfo[]>>;
+}): Promise<SummaryDashboard> {
+  const safe = async <T>(
+    p: () => Promise<SummaryPart<T>>,
+  ): Promise<{ value: T | null; dataAsOf: number | null }> => {
+    try {
+      const r = await p();
+      return { value: r.value, dataAsOf: r.dataAsOf };
+    } catch {
+      return { value: null, dataAsOf: null };
+    }
+  };
+
+  const [agents, systemHealth, approvals, schedule, accounts] =
+    await Promise.all([
+      safe(deps.agents),
+      safe(deps.systemHealth),
+      safe(deps.approvals),
+      safe(deps.schedule),
+      safe(deps.accounts),
+    ]);
+
+  // The summary is only as fresh as its OLDEST present part. Ignore
+  // nulls (a failed part has no stamp). When every part failed there's no
+  // data to stamp → 0.
+  const stamps = [agents, systemHealth, approvals, schedule, accounts]
+    .map((p) => p.dataAsOf)
+    .filter((d): d is number => typeof d === "number");
+  const dataAsOf = stamps.length > 0 ? Math.min(...stamps) : 0;
+
+  return {
+    agents: agents.value,
+    systemHealth: systemHealth.value,
+    approvals: approvals.value,
+    schedule: schedule.value,
+    accounts: accounts.value,
+    dataAsOf,
+  };
 }

--- a/src/web/cache.test.ts
+++ b/src/web/cache.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import { SwrCache } from "./cache.js";
+
+/**
+ * A controllable clock so the TTL is driven deterministically (no real
+ * timers). `set`/`advance` move it; the cache reads it via the injected
+ * `now`.
+ */
+function fakeClock(start = 1_000_000) {
+  let t = start;
+  return {
+    now: () => t,
+    set: (v: number) => {
+      t = v;
+    },
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+/** A deferred promise we can resolve/reject from the test, to control a
+ *  producer's timing precisely (for single-flight assertions). */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("SwrCache", () => {
+  it("cold read awaits the producer, stores it, returns fresh", async () => {
+    const clock = fakeClock();
+    const cache = new SwrCache(clock.now);
+    let calls = 0;
+    const r = await cache.get("k", 1000, async () => {
+      calls++;
+      return { hi: 1 };
+    });
+    expect(calls).toBe(1);
+    expect(r.value).toEqual({ hi: 1 });
+    expect(r.stale).toBe(false);
+    expect(r.dataAsOf).toBe(clock.now());
+  });
+
+  it("fresh hit returns cached value WITHOUT calling the producer again", async () => {
+    const clock = fakeClock();
+    const cache = new SwrCache(clock.now);
+    let calls = 0;
+    const producer = async () => {
+      calls++;
+      return calls; // distinct value per call, to detect a re-call
+    };
+
+    const first = await cache.get("k", 1000, producer);
+    expect(first.value).toBe(1);
+    expect(calls).toBe(1);
+
+    // Within TTL — must serve cache, producer untouched.
+    clock.advance(500);
+    const second = await cache.get("k", 1000, producer);
+    expect(second.value).toBe(1);
+    expect(second.stale).toBe(false);
+    expect(second.dataAsOf).toBe(first.dataAsOf); // unchanged stamp
+    expect(calls).toBe(1);
+  });
+
+  it("stale read serves last-good immediately and refreshes in the background", async () => {
+    const clock = fakeClock();
+    const cache = new SwrCache(clock.now);
+    let calls = 0;
+    const producer = async () => {
+      calls++;
+      return calls;
+    };
+
+    const cold = await cache.get("k", 1000, producer);
+    expect(cold.value).toBe(1);
+
+    // Cross the TTL boundary (age >= ttlMs).
+    clock.advance(1000);
+    const staleRead = await cache.get("k", 1000, producer);
+    // Served the OLD value immediately, flagged stale.
+    expect(staleRead.value).toBe(1);
+    expect(staleRead.stale).toBe(true);
+    expect(staleRead.dataAsOf).toBe(cold.dataAsOf);
+    // A background refresh was kicked.
+    expect(calls).toBe(2);
+
+    // Let the background refresh settle, then advance past TTL again so the
+    // NEXT read re-evaluates freshness against the refreshed entry.
+    await Promise.resolve();
+    await Promise.resolve();
+    const afterRefresh = await cache.get("k", 1000, producer);
+    // The refreshed value (2) is now fresh — no further producer call.
+    expect(afterRefresh.value).toBe(2);
+    expect(afterRefresh.stale).toBe(false);
+    expect(calls).toBe(2);
+  });
+
+  it("background-refresh error keeps last-good and lets a later read retry", async () => {
+    const clock = fakeClock();
+    const cache = new SwrCache(clock.now);
+    let calls = 0;
+    const producer = async () => {
+      calls++;
+      if (calls === 2) throw new Error("refresh boom");
+      return calls;
+    };
+
+    const cold = await cache.get("k", 1000, producer);
+    expect(cold.value).toBe(1);
+
+    // Stale read #1 → serves last-good, kicks a refresh that THROWS.
+    clock.advance(1000);
+    const stale1 = await cache.get("k", 1000, producer);
+    expect(stale1.value).toBe(1); // never throws
+    expect(stale1.stale).toBe(true);
+    expect(calls).toBe(2);
+
+    // Let the failing refresh reject + clear the guard.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Stale read #2 → still last-good (1), but the guard cleared so it
+    // retries the refresh (call #3 succeeds with value 3).
+    const stale2 = await cache.get("k", 1000, producer);
+    expect(stale2.value).toBe(1); // last-good preserved through the failure
+    expect(stale2.stale).toBe(true);
+    expect(calls).toBe(3);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    const recovered = await cache.get("k", 1000, producer);
+    expect(recovered.value).toBe(3); // recovered to the successful refresh
+    expect(recovered.stale).toBe(false);
+  });
+
+  it("single-flight: concurrent stale reads trigger exactly ONE producer refresh", async () => {
+    const clock = fakeClock();
+    const cache = new SwrCache(clock.now);
+
+    // First producer call resolves immediately (cold seed). The refresh
+    // call is a deferred we hold open so both concurrent reads observe the
+    // SAME in-flight refresh.
+    let calls = 0;
+    const refreshGate = deferred<number>();
+    const producer = async () => {
+      calls++;
+      if (calls === 1) return 1; // cold
+      return refreshGate.promise; // the (single) background refresh
+    };
+
+    await cache.get("k", 1000, producer);
+    expect(calls).toBe(1);
+
+    clock.advance(1000); // now stale
+
+    // Fire several stale reads "simultaneously" before the refresh settles.
+    const reads = await Promise.all([
+      cache.get("k", 1000, producer),
+      cache.get("k", 1000, producer),
+      cache.get("k", 1000, producer),
+    ]);
+    // All served last-good, all stale.
+    for (const r of reads) {
+      expect(r.value).toBe(1);
+      expect(r.stale).toBe(true);
+    }
+    // Exactly ONE refresh kicked despite three concurrent stale reads.
+    expect(calls).toBe(2);
+
+    // Settle the held refresh; a later read sees the fresh value.
+    refreshGate.resolve(42);
+    await Promise.resolve();
+    await Promise.resolve();
+    const after = await cache.get("k", 1000, producer);
+    expect(after.value).toBe(42);
+    expect(after.stale).toBe(false);
+    expect(calls).toBe(2);
+  });
+
+  it("uses the injected clock for freshness (no real time dependence)", async () => {
+    const clock = fakeClock(5_000);
+    const cache = new SwrCache(clock.now);
+    let calls = 0;
+    const producer = async () => {
+      calls++;
+      return calls;
+    };
+
+    const cold = await cache.get("k", 100, producer);
+    expect(cold.dataAsOf).toBe(5_000);
+
+    // Move the clock to exactly the TTL boundary — age == ttl ⇒ stale.
+    clock.set(5_100);
+    const r = await cache.get("k", 100, producer);
+    expect(r.stale).toBe(true);
+    expect(calls).toBe(2);
+  });
+
+  it("clear() drops entries so the next read is cold again", async () => {
+    const clock = fakeClock();
+    const cache = new SwrCache(clock.now);
+    let calls = 0;
+    const producer = async () => {
+      calls++;
+      return calls;
+    };
+    await cache.get("k", 1000, producer);
+    expect(calls).toBe(1);
+    cache.clear();
+    // Cold again → producer re-runs even within what was the TTL.
+    const r = await cache.get("k", 1000, producer);
+    expect(r.value).toBe(2);
+    expect(r.stale).toBe(false);
+    expect(calls).toBe(2);
+  });
+
+  it("keys are independent", async () => {
+    const clock = fakeClock();
+    const cache = new SwrCache(clock.now);
+    const a = await cache.get("a", 1000, async () => "A");
+    const b = await cache.get("b", 1000, async () => "B");
+    expect(a.value).toBe("A");
+    expect(b.value).toBe("B");
+  });
+});

--- a/src/web/cache.ts
+++ b/src/web/cache.ts
@@ -1,0 +1,133 @@
+/**
+ * A tiny stale-while-revalidate (SWR) cache for the dashboard's read-only
+ * panels.
+ *
+ * The dashboard re-computes several expensive panels per request (docker
+ * inspect, broker RPC, hindsight HTTP probes, hostd round-trips, per-agent
+ * sqlite reads). Without a cache, every tab-open / poll-tick hammers the
+ * host. SWR gives the operator a *fast* response (the cached value) while
+ * a single background refresh keeps the value reasonably fresh — the
+ * dashboard is observability, not a transactional surface, so serving a
+ * few-seconds-stale value is the right trade.
+ *
+ * Semantics (per key):
+ *   - **cold** (no entry): await the producer, store it, return it
+ *     fresh. The first read pays the full cost — there's nothing to serve.
+ *   - **fresh** (age < ttlMs): return the cached value WITHOUT calling the
+ *     producer. `stale:false`.
+ *   - **stale** (age >= ttlMs): return the cached (last-good) value
+ *     IMMEDIATELY with `stale:true`, and kick a SINGLE background refresh.
+ *     Concurrent stale reads share that one refresh (single-flight via the
+ *     `refreshing` guard) — they don't stampede the producer. On refresh
+ *     SUCCESS the entry is replaced (value + fetchedAt). On refresh ERROR
+ *     the last-good entry is KEPT and `refreshing` is cleared, so a later
+ *     read retries the refresh — a flapping producer never blanks the
+ *     panel and never throws to the caller.
+ *
+ * A stale read NEVER throws (it always has last-good to serve). Only a
+ * cold read can throw — there's no value yet, so the producer's rejection
+ * propagates (the route handler degrades, as it does today).
+ *
+ * `now` is injectable so tests can drive the TTL deterministically. The
+ * dashboard server is a single long-lived process, so a module-level
+ * instance with a plain Map is the cache (bounded by the small fixed set
+ * of route keys).
+ */
+
+/** A cache read result: the value plus when it was produced and whether
+ *  it's being served past its TTL (a background refresh is/was kicked). */
+export interface CachedResult<T> {
+  value: T;
+  /** Unix ms when `value` was produced by the producer. */
+  dataAsOf: number;
+  /** True when the value is older than its TTL (served stale-while-revalidate). */
+  stale: boolean;
+}
+
+interface Entry {
+  /** Last successfully-produced value. Typed `unknown` — callers assert T. */
+  value: unknown;
+  /** Unix ms when `value` was produced. */
+  fetchedAt: number;
+  /** Single-flight guard: a background refresh is in progress for this key. */
+  refreshing: boolean;
+}
+
+export class SwrCache {
+  private readonly entries = new Map<string, Entry>();
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  /**
+   * Get the cached value for `key`, producing it via `producer` when cold,
+   * and refreshing it in the background when stale. See the class doc for
+   * the full stale-while-revalidate semantics. Never throws on a stale
+   * read; a cold read propagates the producer's rejection.
+   *
+   * @param key       cache key (one per route).
+   * @param ttlMs     freshness window — at/after this age the value is stale.
+   * @param producer  async function that computes a fresh value.
+   */
+  async get<T>(
+    key: string,
+    ttlMs: number,
+    producer: () => Promise<T>,
+  ): Promise<CachedResult<T>> {
+    const existing = this.entries.get(key);
+
+    // Cold: nothing to serve — pay the full cost and store it fresh.
+    if (!existing) {
+      const value = await producer();
+      const fetchedAt = this.now();
+      this.entries.set(key, { value, fetchedAt, refreshing: false });
+      return { value, dataAsOf: fetchedAt, stale: false };
+    }
+
+    const age = this.now() - existing.fetchedAt;
+
+    // Fresh: serve the cached value without touching the producer.
+    if (age < ttlMs) {
+      return {
+        value: existing.value as T,
+        dataAsOf: existing.fetchedAt,
+        stale: false,
+      };
+    }
+
+    // Stale: serve last-good IMMEDIATELY and kick a single background
+    // refresh (single-flight — concurrent stale reads share it).
+    if (!existing.refreshing) {
+      existing.refreshing = true;
+      // Fire-and-forget. We deliberately do NOT await — the caller gets
+      // the stale value now; the refresh updates the entry for the NEXT
+      // read. Errors are swallowed (keep last-good, clear the guard so a
+      // later read retries).
+      void producer().then(
+        (value) => {
+          this.entries.set(key, {
+            value,
+            fetchedAt: this.now(),
+            refreshing: false,
+          });
+        },
+        () => {
+          // Refresh failed — keep the last-good entry, just clear the
+          // in-flight guard so a subsequent stale read can retry.
+          const cur = this.entries.get(key);
+          if (cur) cur.refreshing = false;
+        },
+      );
+    }
+
+    return {
+      value: existing.value as T,
+      dataAsOf: existing.fetchedAt,
+      stale: true,
+    };
+  }
+
+  /** Test hook: drop all cached entries. */
+  clear(): void {
+    this.entries.clear();
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -39,7 +39,16 @@ import {
   handleGetNotionWorkspace,
   handleGetSchedule,
   handleGetApprovals,
+  handleGetSummary,
+  dashboardCache,
+  DASHBOARD_CACHE_TTL,
+  type AgentInfo,
+  type SystemHealth,
+  type ScheduleDashboard,
+  type ApprovalsDashboard,
+  type AccountDashboardInfo,
 } from "./api.js";
+import type { CachedResult } from "./cache.js";
 import { fetchAgentLogsViaHostd } from "./hostd-read-client.js";
 import { handleWebhookIngest } from "./webhook-handler.js";
 import { loadEdgeSecret } from "./webhook-edge.js";
@@ -409,6 +418,12 @@ function parseRoute(
     return { handler: "getAgents", params: {} };
   }
 
+  // GET /api/summary — one aggregate of the cached reads for the Summary
+  // tab, so it needs a single round-trip instead of fanning out to five.
+  if (method === "GET" && pathname === "/api/summary") {
+    return { handler: "getSummary", params: {} };
+  }
+
   // GET /api/agents/:name/logs
   const logsMatch = pathname.match(/^\/api\/agents\/([^/]+)\/logs$/);
   if (method === "GET" && logsMatch) {
@@ -575,6 +590,57 @@ export function startWebServer(
     }
   };
 
+  // ── Cached read producers ────────────────────────────────────────────
+  // Every expensive READ panel routes through `dashboardCache` (a tiny
+  // stale-while-revalidate cache) keyed by the route name, so a tab-open
+  // / poll-tick serves a cached value fast and at most ONE background
+  // refresh hits the host. These producers are shared verbatim by the
+  // per-tab routes AND `/api/summary` — same key + TTL — so a Summary
+  // open warms the tabs (and vice-versa) and the two can never disagree.
+  // Each returns the cached value plus its `dataAsOf` stamp. Producers
+  // re-read `freshConfig()` per refresh (the config can change under us).
+  const cachedAgents = (): Promise<CachedResult<AgentInfo[]>> =>
+    dashboardCache.get(
+      "agents",
+      DASHBOARD_CACHE_TTL.agents,
+      () => handleGetAgents(freshConfig()),
+    );
+  const cachedSystemHealth = (): Promise<CachedResult<SystemHealth>> =>
+    dashboardCache.get(
+      "system-health",
+      DASHBOARD_CACHE_TTL["system-health"],
+      () => handleGetSystemHealth(freshConfig()),
+    );
+  const cachedMemoryHealth = () =>
+    dashboardCache.get(
+      "memory-health",
+      DASHBOARD_CACHE_TTL["memory-health"],
+      () => handleGetMemoryHealth(freshConfig()),
+    );
+  const cachedSchedule = (): Promise<CachedResult<ScheduleDashboard>> =>
+    dashboardCache.get(
+      "schedule",
+      DASHBOARD_CACHE_TTL.schedule,
+      () => handleGetSchedule(freshConfig()),
+    );
+  const cachedApprovals = (): Promise<CachedResult<ApprovalsDashboard>> =>
+    dashboardCache.get(
+      "approvals",
+      DASHBOARD_CACHE_TTL.approvals,
+      () => handleGetApprovals(),
+    );
+  const cachedAccounts = (): Promise<CachedResult<AccountDashboardInfo[]>> =>
+    dashboardCache.get(
+      "accounts",
+      DASHBOARD_CACHE_TTL.accounts,
+      () => handleGetAccounts(freshConfig()),
+    );
+
+  /** Attach the cache stamp to an OBJECT response. Arrays stay bare (the
+   *  UI expects a raw array there) — only object panels carry the stamp. */
+  const withStamp = <T extends object>(part: CachedResult<T>): T =>
+    ({ ...part.value, dataAsOf: part.dataAsOf, stale: part.stale } as T);
+
   // Loopback-only when binding to a localhost address; any other bind address
   // (including 0.0.0.0) is considered a deliberate network-exposure opt-in.
   const localhostOnly =
@@ -643,7 +709,22 @@ export function startWebServer(
 
         switch (route.handler) {
           case "getAgents":
-            return (async () => jsonResponse(await handleGetAgents(freshConfig())))();
+            // Array response — the UI expects a bare array, so DON'T wrap
+            // it; the cache still speeds the poll. Stamp lives on the
+            // object panels + the summary.
+            return (async () => jsonResponse((await cachedAgents()).value))();
+
+          case "getSummary":
+            return (async () =>
+              jsonResponse(
+                await handleGetSummary({
+                  agents: cachedAgents,
+                  systemHealth: cachedSystemHealth,
+                  approvals: cachedApprovals,
+                  schedule: cachedSchedule,
+                  accounts: cachedAccounts,
+                }),
+              ))();
 
           case "getLogs": {
             const agentName = route.params.name;
@@ -714,11 +795,11 @@ export function startWebServer(
 
           case "getSystemHealth":
             return (async () =>
-              jsonResponse(await handleGetSystemHealth(freshConfig())))();
+              jsonResponse(withStamp(await cachedSystemHealth())))();
 
           case "getMemoryHealth":
             return (async () =>
-              jsonResponse(await handleGetMemoryHealth(freshConfig())))();
+              jsonResponse(withStamp(await cachedMemoryHealth())))();
 
           case "getGoogleAccounts":
             return (async () =>
@@ -733,15 +814,15 @@ export function startWebServer(
 
           case "getSchedule":
             return (async () =>
-              jsonResponse(await handleGetSchedule(freshConfig())))();
+              jsonResponse(withStamp(await cachedSchedule())))();
 
           case "getApprovals":
             return (async () =>
-              jsonResponse(await handleGetApprovals()))();
+              jsonResponse(withStamp(await cachedApprovals())))();
 
           case "getAccounts":
-            return (async () =>
-              jsonResponse(await handleGetAccounts(freshConfig())))();
+            // Array response — bare array, no stamp wrap (see getAgents).
+            return (async () => jsonResponse((await cachedAccounts()).value))();
 
           case "useAccount": {
             return (async () => {

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -808,22 +808,29 @@
       if (tab === 'approvals') fetchApprovals();
     }
 
-    // Fleet overview — aggregates the cheap endpoints client-side
-    // (one parallel fan-out; no new server work, no extra docker/probe
-    // cost beyond what those tabs already do). Each tile degrades
-    // independently if its source errors.
+    // Fleet overview — ONE round-trip to the server-side aggregate
+    // (/api/summary), which pulls each part through the same per-tab
+    // cache so a Summary open warms the tabs and they can never disagree.
+    // Each tile still degrades independently: the server nulls any part
+    // whose producer threw, and a whole-fetch failure leaves the prior
+    // render in place.
     async function fetchSummary() {
       const el = document.getElementById('summary');
-      const get = async (p) => {
-        try {
-          const r = await fetch(`${API}${p}`, { headers: authHeaders() });
-          return r.ok ? await r.json() : null;
-        } catch { return null; }
-      };
-      const [ag, sys, appr, sched, accts] = await Promise.all([
-        get('/api/agents'), get('/api/system-health'),
-        get('/api/approvals'), get('/api/schedule'), get('/api/accounts'),
-      ]);
+      let summary;
+      try {
+        const r = await fetch(`${API}/api/summary`, { headers: authHeaders() });
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        summary = await r.json();
+      } catch (err) {
+        // Degraded: keep whatever's already rendered (don't blank the
+        // tab on a transient blip) and surface the error.
+        el.classList.remove('loading');
+        showError(`Failed to fetch summary: ${err.message}`);
+        return;
+      }
+      const ag = summary.agents, sys = summary.systemHealth,
+            appr = summary.approvals, sched = summary.schedule,
+            accts = summary.accounts;
       clearError();
       const tile = (title, body, ok) => `
         <div class="agent-card" style="min-width:220px">
@@ -899,7 +906,13 @@
       } else quotaTile = tile('Quota', dim('unavailable'), null);
 
       el.classList.remove('loading');
-      el.innerHTML = `<div class="agents-grid">${agentsTile}${brokerTile}${hsTile}${hostdTile}${apprTile}${schedTile}${quotaTile}</div>`;
+      // "data as of" — the summary's freshness is its OLDEST part (server
+      // sends the min dataAsOf). A tiny muted line; refreshed on every
+      // tab-open. `formatTimestamp` renders it as "Ns/Nm ago".
+      const asOf = (typeof summary.dataAsOf === 'number' && summary.dataAsOf > 0)
+        ? `<div style="color:var(--text-dim);font-size:.75rem;margin:.25rem 0 .5rem">data as of ${escapeHtml(formatTimestamp(summary.dataAsOf))}</div>`
+        : '';
+      el.innerHTML = `${asOf}<div class="agents-grid">${agentsTile}${brokerTile}${hsTile}${hostdTile}${apprTile}${schedTile}${quotaTile}</div>`;
     }
 
     function showError(msg) {
@@ -1271,7 +1284,13 @@
           <tbody>${rows}</tbody></table>`;
       }
 
+      // Subtle freshness hint: the cached object carries `stale:true` when
+      // it's being served past its TTL while a background refresh runs.
+      const updating = h.stale
+        ? `<span style="color:var(--text-dim);font-size:.7rem;margin-left:.4rem">(updating…)</span>`
+        : '';
       container.innerHTML = `
+        ${updating ? `<div style="margin-bottom:.4rem">System health ${updating}</div>` : ''}
         <div class="agents-grid">
           <div class="agent-card"><div class="card-header" style="cursor:default">
             ${dot(b.reachable)}<span class="agent-name">auth-broker</span></div>
@@ -1757,7 +1776,14 @@
     fetchSummary();
     fetchAgents();
     connectWebSocket();
-    setInterval(fetchAgents, 10000);
+    // Fleet poll — gated on tab visibility. A phone with the dashboard
+    // backgrounded (or a laptop tab the operator switched away from)
+    // shouldn't keep hitting the host every 10s; the cache absorbs the
+    // cost, but skipping the request entirely is strictly better. The
+    // next foregrounded tick refreshes immediately.
+    setInterval(() => {
+      if (document.visibilityState === 'visible') fetchAgents();
+    }, 10000);
   </script>
 </body>
 </html>

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -1519,7 +1519,7 @@ describe("handleGetSummary — cached aggregate for the Summary tab", () => {
     },
   ];
   const fakeSystemHealth: SystemHealth = {
-    broker: { reachable: true, active: "pixsoul", accounts: 2, agents: 1, consumers: 0 },
+    broker: { reachable: true, active: "ops@example.com", accounts: 2, agents: 1, consumers: 0 },
     hindsight: {
       containerStatus: null,
       running: true,

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -115,7 +115,14 @@ import {
   handleRefreshAccountsQuota,
   __resetQuotaCacheForTests,
   __resetAgentStatusCacheForTests,
+  handleGetSummary,
+  __resetDashboardCacheForTests,
   type AgentInfo,
+  type SystemHealth,
+  type ScheduleDashboard,
+  type ApprovalsDashboard,
+  type AccountDashboardInfo,
+  type SummaryPart,
 } from "../src/web/api.js";
 import { resolveAgentsDir } from "../src/config/loader.js";
 import { getAccountInfos } from "../src/auth/account-store.js";
@@ -1482,5 +1489,134 @@ describe("handleRefreshAccountsQuota (cached + manual refresh)", () => {
       expect(a.quotaStale).toBe(true);
     }
     expect(probeCalls).toBe(0); // the cost guarantee
+  });
+});
+
+describe("handleGetSummary — cached aggregate for the Summary tab", () => {
+  beforeEach(() => {
+    __resetDashboardCacheForTests();
+  });
+
+  // The handler is pure orchestration over cache-bound producers, so the
+  // tests inject fakes — no broker/docker/hostd. Each `part(value, at)`
+  // mimics what `dashboardCache.get` returns: the value + its dataAsOf.
+  const part = <T>(value: T, dataAsOf: number): SummaryPart<T> => ({
+    value,
+    dataAsOf,
+  });
+
+  const fakeAgents: AgentInfo[] = [
+    {
+      name: "coach",
+      active: "active",
+      uptime: null,
+      memory: null,
+      extends: "default",
+      topic_name: "Fitness",
+      auth: { authenticated: true },
+      memoryCollection: "coach-mem",
+      lastTurnAt: null,
+    },
+  ];
+  const fakeSystemHealth: SystemHealth = {
+    broker: { reachable: true, active: "pixsoul", accounts: 2, agents: 1, consumers: 0 },
+    hindsight: {
+      containerStatus: null,
+      running: true,
+      model: "x",
+      provider: "y",
+      mcpStateless: true,
+    },
+    hostd: { auditLogPresent: true, recent: [] },
+  };
+  const fakeApprovals: ApprovalsDashboard = { reachable: true, decisions: [] };
+  const fakeSchedule: ScheduleDashboard = { entries: [], recentByAgent: {} };
+  const fakeAccounts: AccountDashboardInfo[] = [];
+
+  it("returns all parts and stamps dataAsOf as the OLDEST part", async () => {
+    const out = await handleGetSummary({
+      agents: async () => part(fakeAgents, 1000),
+      systemHealth: async () => part(fakeSystemHealth, 3000),
+      approvals: async () => part(fakeApprovals, 2000),
+      schedule: async () => part(fakeSchedule, 5000),
+      accounts: async () => part(fakeAccounts, 4000),
+    });
+    expect(out.agents).toEqual(fakeAgents);
+    expect(out.systemHealth).toEqual(fakeSystemHealth);
+    expect(out.approvals).toEqual(fakeApprovals);
+    expect(out.schedule).toEqual(fakeSchedule);
+    expect(out.accounts).toEqual(fakeAccounts);
+    // Oldest of {1000,3000,2000,5000,4000} = 1000.
+    expect(out.dataAsOf).toBe(1000);
+  });
+
+  it("tolerates ONE producer throwing — that field is null, the rest present", async () => {
+    const out = await handleGetSummary({
+      agents: async () => part(fakeAgents, 1000),
+      systemHealth: async () => {
+        throw new Error("broker down");
+      },
+      approvals: async () => part(fakeApprovals, 2000),
+      schedule: async () => part(fakeSchedule, 5000),
+      accounts: async () => part(fakeAccounts, 4000),
+    });
+    expect(out.systemHealth).toBeNull(); // the failed part
+    expect(out.agents).toEqual(fakeAgents); // others unaffected
+    expect(out.approvals).toEqual(fakeApprovals);
+    expect(out.schedule).toEqual(fakeSchedule);
+    expect(out.accounts).toEqual(fakeAccounts);
+    // dataAsOf ignores the null part → oldest of the survivors = 1000.
+    expect(out.dataAsOf).toBe(1000);
+  });
+
+  it("when EVERY producer throws, all fields null and dataAsOf 0", async () => {
+    const boom = async (): Promise<never> => {
+      throw new Error("nope");
+    };
+    const out = await handleGetSummary({
+      agents: boom,
+      systemHealth: boom,
+      approvals: boom,
+      schedule: boom,
+      accounts: boom,
+    });
+    expect(out.agents).toBeNull();
+    expect(out.systemHealth).toBeNull();
+    expect(out.approvals).toBeNull();
+    expect(out.schedule).toBeNull();
+    expect(out.accounts).toBeNull();
+    expect(out.dataAsOf).toBe(0);
+  });
+
+  it("runs the producers concurrently (Promise.all, not sequential)", async () => {
+    // If serialized, the second producer would observe the first already
+    // settled. We assert all five were INVOKED before any resolves by
+    // counting starts before the gate opens.
+    let started = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const mk =
+      <T>(value: T): (() => Promise<SummaryPart<T>>) =>
+      async () => {
+        started++;
+        await gate;
+        return part(value, 1000);
+      };
+    const p = handleGetSummary({
+      agents: mk(fakeAgents),
+      systemHealth: mk(fakeSystemHealth),
+      approvals: mk(fakeApprovals),
+      schedule: mk(fakeSchedule),
+      accounts: mk(fakeAccounts),
+    });
+    // Let the microtasks up to the gate run.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toBe(5); // all kicked before any completed
+    release();
+    const out = await p;
+    expect(out.agents).toEqual(fakeAgents);
   });
 });


### PR DESCRIPTION
## Summary

The "regularly cache to reduce load times" ask from the audit (ranks 9 + 13). Today only quota is cached; every other expensive panel recomputes per request (docker inspect, broker RPC, hindsight HTTP probe, hostd round-trip, per-agent sqlite), and the default **Summary** tab fans out to **five** endpoints on every open.

## What's added

- **`src/web/cache.ts` — a small stale-while-revalidate cache.** Cold awaits the producer; fresh serves the cached value without calling it; stale serves last-good **immediately** + kicks a **single-flight** background refresh that **keeps last-good on error** (a flapping producer never blanks a panel; a stale read never throws). Injectable clock.
- **All read routes cached** — `system-health` 15s, `memory-health` 60s, `schedule` 30s, `agents` 5s, `accounts` 10s, `approvals` 15s. Object responses carry a `{dataAsOf, stale}` stamp; array responses (agents, accounts) stay bare. **Not** cached: the billed quota probe, mutations, webhooks, logs WS.
- **`GET /api/summary`** — one aggregate pulling each part through the **same** cache key+TTL, so a Summary open warms the per-tab caches (and vice-versa) and the two can never disagree. Each field degrades independently; `dataAsOf` = the oldest part.
- **UI** — `fetchSummary` does ONE `/api/summary` fetch (keeps the tile builders + degrade-don't-blank), renders "data as of Ns ago", and the 10s fleet poll is **gated on `document.visibilityState`** so a backgrounded phone tab stops hammering the host.

## Test plan

- [x] 8 SWR cache unit tests: cold-await, fresh-hit (producer not re-called), stale-serves-last-good-and-refreshes, refresh-error-keeps-last-good-and-retries, single-flight under concurrent reads, injected clock, clear, key-independence
- [x] 4 `handleGetSummary` tests: all-parts + oldest stamp, one-producer-throws → that field null, all-throw → nulls + dataAsOf 0, concurrency
- [x] `tsc --noEmit` clean; **252** web tests pass; UI `<script>` `node --check` clean

## Risk

Low. The cache is transparent (serves cached/last-good, never throws on stale); response shapes are unchanged for arrays and only gain optional `dataAsOf`/`stale` on objects (UI ignores unknowns). No new infra, no model calls, no docker. Known minor edge: concurrent *cold* reads aren't single-flighted (first-load only) — harmless double producer call.

## Follow-up (PR4b, same audit)

The error-actionability framework (ProblemDetail + renderProblem), degraded banners, and per-unit System remediation commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)