### PR TITLE
feat(dashboard): surface standing capability grants on the Approvals tab

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -1711,7 +1711,19 @@ export async function handleGetGrants(
   const list = deps.list ?? listGrantsViaBroker;
   // No agent filter → all agents' grants. Pin opts.socket to the operator
   // socket so the broker resolver can't fall through to a non-operator path.
-  const result = await list(undefined, { socket });
+  // listGrantsViaBroker is contractually non-throwing, but wrap defensively
+  // so this handler's documented "never throws" holds even if that contract
+  // ever changes — a thrown error degrades to reachable:false, not a 500.
+  let result: Awaited<ReturnType<typeof list>>;
+  try {
+    result = await list(undefined, { socket });
+  } catch (err) {
+    return {
+      reachable: false,
+      grants: [],
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
   if (result.kind !== "ok") {
     // unreachable | error — surface the broker's reason; never throw.
     return { reachable: false, grants: [], error: result.msg };

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import {
   getAllAgentStatuses,
@@ -32,7 +32,9 @@ import {
   approvalList,
   resolveKernelOperatorSocket,
 } from "../vault/approvals/client.js";
+import { listGrantsViaBroker } from "../vault/broker/client.js";
 import type { ApprovalDecisionMeta } from "../vault/broker/protocol.js";
+import { homedir } from "node:os";
 import { captureEvent, captureException } from "../analytics/posthog.js";
 import { resolveAgentsDir } from "../config/loader.js";
 import { resolveAgentConfig } from "../config/merge.js";
@@ -115,6 +117,7 @@ export const DASHBOARD_CACHE_TTL = {
   agents: 5000,
   accounts: 10000,
   approvals: 15000,
+  grants: 15000,
 } as const;
 
 /** Test-only: reset the shared dashboard cache between cases. */
@@ -1614,6 +1617,121 @@ export async function handleGetApprovals(): Promise<ApprovalsDashboard> {
   // Newest first — most relevant grant at the top of the table.
   const sorted = [...decisions].sort((a, b) => b.granted_at - a.granted_at);
   return { reachable: true, decisions: sorted };
+}
+
+/**
+ * Host-side vault-broker OPERATOR socket path — the host end of the
+ * compose bind `~/.switchroom/broker-operator → /run/switchroom/broker/operator`.
+ * The broker restricts this socket to read-only ops (notably
+ * `list_grants`), so it is safe for the host observer (the web dashboard)
+ * and is what `switchroom vault grants` reads passphrase-free.
+ *
+ * Mirrors `resolveKernelOperatorSocket` (approvals/client.ts): probe the
+ * host fs here and pass the result as `opts.socket` to `listGrantsViaBroker`
+ * — deliberately NOT folded into the broker's own `resolveBrokerSocketPath`,
+ * which stays a pure env/opts function so no other caller's behaviour
+ * depends on whether this socket happens to exist.
+ */
+export function brokerOperatorSocketPath(
+  home: string = process.env.HOME || homedir(),
+): string {
+  return join(home, ".switchroom", "broker-operator", "sock");
+}
+
+/**
+ * Resolve the host broker-operator socket iff it exists, else null. The
+ * read-only host caller uses this to decide whether to talk to the broker;
+ * absent ⇒ the grants view degrades (broker not host-reachable) rather
+ * than silently changing the broker resolver contract.
+ */
+export function resolveBrokerOperatorSocket(
+  home: string = process.env.HOME || homedir(),
+): string | null {
+  const p = brokerOperatorSocketPath(home);
+  return existsSync(p) ? p : null;
+}
+
+/**
+ * Standing capability grants (the vault-broker grants DB) for the dashboard
+ * Approvals tab. The approval-KERNEL decision ledger (`handleGetApprovals`)
+ * is honestly empty on most installs — the daily per-tool Allow/Deny taps
+ * never write it — so the operator's REAL standing grants live here, in the
+ * broker's `list_grants` op (the same data `switchroom vault grants` shows).
+ *
+ * READ-ONLY by construction: this calls `list_grants` over the operator
+ * socket (no agent filter → fleet-wide) and never grants/mints/revokes. No
+ * model call, no docker, no broker WRITE op.
+ *
+ * Three states, each rendered distinctly:
+ *   - operator socket absent  → broker not host-reachable on this install.
+ *     `reachable:false` + an actionable error.
+ *   - socket present, RPC unreachable/error → `reachable:false` + the
+ *     broker's reason.
+ *   - ok → grants[] (newest first for the table).
+ */
+export interface GrantDashboardRow {
+  id: string;
+  agent: string;
+  /** Keys/globs this grant authorizes for READ. */
+  keys: string[];
+  /** Keys/globs this grant authorizes for WRITE. `[]` = read-only. */
+  writeKeys: string[];
+  /** unix MILLISECONDS (converted from the broker's unix seconds) or null. */
+  expiresAt: number | null;
+  /** unix MILLISECONDS (converted from the broker's unix seconds). */
+  createdAt: number;
+  description: string | null;
+}
+
+export interface GrantsDashboard {
+  reachable: boolean;
+  grants: GrantDashboardRow[];
+  error?: string;
+}
+
+export async function handleGetGrants(
+  deps: {
+    socketPath?: string | null;
+    list?: typeof listGrantsViaBroker;
+  } = {},
+): Promise<GrantsDashboard> {
+  // `deps.socketPath` overrides the fs probe (tests / injected); when the
+  // key is OMITTED we probe, when it's explicitly null we honour that.
+  const socket =
+    "socketPath" in deps ? deps.socketPath : resolveBrokerOperatorSocket();
+  if (socket == null) {
+    return {
+      reachable: false,
+      grants: [],
+      error:
+        "vault-broker operator socket not present — host-side grant " +
+        "listing needs a broker-operator bind (re-apply to (re)create it).",
+    };
+  }
+  const list = deps.list ?? listGrantsViaBroker;
+  // No agent filter → all agents' grants. Pin opts.socket to the operator
+  // socket so the broker resolver can't fall through to a non-operator path.
+  const result = await list(undefined, { socket });
+  if (result.kind !== "ok") {
+    // unreachable | error — surface the broker's reason; never throw.
+    return { reachable: false, grants: [], error: result.msg };
+  }
+  // GrantMeta `created_at` / `expires_at` are unix SECONDS (see
+  // src/vault/grants.ts — `Math.floor(Date.now() / 1000)`); the UI's
+  // `formatTimestamp` expects unix MILLISECONDS, so convert at this
+  // boundary (×1000) and document the unit on the row fields.
+  const rows: GrantDashboardRow[] = result.grants.map((g) => ({
+    id: g.id,
+    agent: g.agent_slug,
+    keys: g.key_allow,
+    writeKeys: g.write_allow,
+    expiresAt: g.expires_at == null ? null : g.expires_at * 1000,
+    createdAt: g.created_at * 1000,
+    description: g.description,
+  }));
+  // Newest first — most recent grant at the top of the table.
+  rows.sort((a, b) => b.createdAt - a.createdAt);
+  return { reachable: true, grants: rows };
 }
 
 /**

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -39,6 +39,7 @@ import {
   handleGetNotionWorkspace,
   handleGetSchedule,
   handleGetApprovals,
+  handleGetGrants,
   handleGetSummary,
   dashboardCache,
   DASHBOARD_CACHE_TTL,
@@ -46,6 +47,7 @@ import {
   type SystemHealth,
   type ScheduleDashboard,
   type ApprovalsDashboard,
+  type GrantsDashboard,
   type AccountDashboardInfo,
 } from "./api.js";
 import type { CachedResult } from "./cache.js";
@@ -495,6 +497,13 @@ function parseRoute(
     return { handler: "getApprovals", params: {} };
   }
 
+  // GET /api/grants — standing capability grants from the vault-broker
+  // grants DB (the operator's REAL grants; the kernel decision ledger
+  // above is honestly empty on most installs).
+  if (method === "GET" && pathname === "/api/grants") {
+    return { handler: "getGrants", params: {} };
+  }
+
   // GET /api/accounts
   if (method === "GET" && pathname === "/api/accounts") {
     return { handler: "getAccounts", params: {} };
@@ -628,6 +637,12 @@ export function startWebServer(
       "approvals",
       DASHBOARD_CACHE_TTL.approvals,
       () => handleGetApprovals(),
+    );
+  const cachedGrants = (): Promise<CachedResult<GrantsDashboard>> =>
+    dashboardCache.get(
+      "grants",
+      DASHBOARD_CACHE_TTL.grants,
+      () => handleGetGrants(),
     );
   const cachedAccounts = (): Promise<CachedResult<AccountDashboardInfo[]>> =>
     dashboardCache.get(
@@ -819,6 +834,10 @@ export function startWebServer(
           case "getApprovals":
             return (async () =>
               jsonResponse(withStamp(await cachedApprovals())))();
+
+          case "getGrants":
+            return (async () =>
+              jsonResponse(withStamp(await cachedGrants())))();
 
           case "getAccounts":
             // Array response — bare array, no stamp wrap (see getAgents).

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -830,10 +830,21 @@
     }
 
     async function fetchApprovals() {
+      // Fetch the kernel decision ledger AND the standing capability grants
+      // in parallel, INDEPENDENTLY: a failure of one must not blank the
+      // other (mirror the resilient `safe` pattern in fetchConnections).
+      // Standing grants (the broker grants DB) are the section that's
+      // actually useful — the kernel ledger is honestly empty on most
+      // installs.
+      const safe = (p, fallback) =>
+        p.then(r => r.ok ? r.json() : fallback).catch(() => fallback);
       try {
-        const res = await fetch(`${API}/api/approvals`, { headers: authHeaders() });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        renderApprovals(await res.json());
+        const [approvals, grants] = await Promise.all([
+          safe(fetch(`${API}/api/approvals`, { headers: authHeaders() }), null),
+          safe(fetch(`${API}/api/grants`, { headers: authHeaders() }),
+            { reachable: false, grants: [], error: 'Failed to fetch standing grants.' }),
+        ]);
+        renderApprovals(approvals, grants);
         clearError();
       } catch (err) {
         showError(`Failed to fetch approvals: ${err.message}`);
@@ -1140,6 +1151,17 @@
               kind: 'command',
               label: 'Check the singletons on the host:',
               value: 'docker compose -p switchroom ps',
+            },
+          };
+        case 'grants-unreachable':
+          return {
+            title: 'Standing capability grants unavailable',
+            detail: (ctx.error ? `${ctx.error} ` : '') +
+              'The vault-broker (which owns the grants DB) is not host-reachable, so the operator\'s standing grants can\'t be listed.',
+            remediation: {
+              kind: 'command',
+              label: 'Check broker status on the host:',
+              value: 'switchroom vault broker status',
             },
           };
         case 'connections-degraded':
@@ -1777,17 +1799,81 @@
       container.innerHTML = degradedBanner + truncatedNote + cards;
     }
 
-    function renderApprovals(data) {
+    function renderApprovals(data, grants) {
       const container = document.getElementById('approvals');
+      // Two independent sections: the operator's REAL standing capability
+      // grants (broker grants DB — the actually-useful one), then the
+      // kernel decision ledger (honestly empty on most installs). They
+      // degrade independently — one being unreachable never blanks the
+      // other.
+      container.innerHTML =
+        renderStandingGrants(grants) + renderApprovalDecisions(data);
+    }
+
+    // Standing capability grants from the vault-broker grants DB — what
+    // `switchroom vault grants` lists. write_allow grants are the sensitive
+    // ones (highlighted), mirroring the Drive-scope highlight below.
+    function renderStandingGrants(grants) {
       const dim = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
+      const heading = '<h3 style="margin:0 0 0.5rem;font-size:0.95rem">Standing capability grants</h3>';
+      if (!grants || grants.reachable === false) {
+        return heading +
+          renderProblem(problemFor('grants-unreachable', { error: grants && grants.error }));
+      }
+      const rows = grants.grants || [];
+      if (rows.length === 0) {
+        return heading +
+          '<div class="loading" style="color:var(--text-dim)">No standing capability grants.</div>';
+      }
+      const now = Date.now();
+      const chipList = (keys) => (keys && keys.length)
+        ? keys.map(k => `<span class="chip">${escapeHtml(k)}</span>`).join(' ')
+        : dim('—');
+      const body = rows.map(g => {
+        const expired = g.expiresAt != null && g.expiresAt < now;
+        const writeCell = (g.writeKeys && g.writeKeys.length)
+          ? `<span class="usage-pill primary" title="write grants are the sensitive ones">write</span> ` +
+            g.writeKeys.map(k => `<span class="chip">${escapeHtml(k)}</span>`).join(' ')
+          : dim('read-only');
+        const expiresCell = g.expiresAt == null
+          ? dim('never')
+          : `<span style="${expired ? 'color:var(--text-dim)' : ''}">${formatTimestamp(g.expiresAt)}${expired ? ' (expired)' : ''}</span>`;
+        return `
+        <tr>
+          <td>${escapeHtml(g.agent || '—')}</td>
+          <td>${chipList(g.keys)}</td>
+          <td>${writeCell}</td>
+          <td>${expiresCell}</td>
+          <td>${g.createdAt ? formatTimestamp(g.createdAt) : dim('—')}</td>
+          <td>${g.description ? escapeHtml(g.description) : dim('—')}</td>
+        </tr>`;
+      }).join('');
+      return heading + `
+        <div style="margin-bottom:0.6rem;font-size:0.8rem;color:var(--text-dim)">
+          Read-only view via the vault-broker operator socket — ${rows.length} grant(s). Write grants highlighted.
+        </div>
+        <div class="accounts-table-wrap">
+          <table class="accounts-table">
+            <thead><tr>
+              <th>Agent</th><th>Keys (read)</th><th>Write</th>
+              <th>Expires</th><th>Granted</th><th>Description</th>
+            </tr></thead>
+            <tbody>${body}</tbody>
+          </table>
+        </div>`;
+    }
+
+    // Kernel decision ledger (RFC B) — kept as-is. Honestly empty on most
+    // installs (the daily Allow/Deny taps don't write it); that's correct.
+    function renderApprovalDecisions(data) {
+      const dim = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
+      const heading = '<h3 style="margin:1.25rem 0 0.5rem;font-size:0.95rem">Approval decision ledger</h3>';
       if (!data || data.reachable === false) {
-        container.innerHTML = renderProblem(approvalsProblem(data && data.error));
-        return;
+        return heading + renderProblem(approvalsProblem(data && data.error));
       }
       const decisions = data.decisions || [];
       if (decisions.length === 0) {
-        container.innerHTML = '<div class="loading">No approval decisions recorded yet.</div>';
-        return;
+        return heading + '<div class="loading">No approval decisions recorded yet.</div>';
       }
       const now = Date.now();
       const statusOf = (d) => {
@@ -1815,7 +1901,7 @@
           <td title="${d.revoke_reason ? escapeHtml(d.revoke_reason) : ''}">${d.revoked_at ? formatTimestamp(d.revoked_at) : dim('—')}</td>
         </tr>`;
       }).join('');
-      container.innerHTML = `
+      return heading + `
         <div style="margin-bottom:0.6rem;font-size:0.8rem;color:var(--text-dim)">
           Read-only view via the kernel operator socket — ${decisions.length} decision(s). Drive scopes highlighted.
         </div>

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -1476,15 +1476,16 @@ describe("handleGetGrants (standing capability grants — broker grants DB)", ()
     expect(r.grants.map((g) => g.id)).toEqual(["new", "mid", "old"]);
   });
 
-  it("never throws — a rejecting list surfaces as an error result", async () => {
-    // handleGetGrants awaits `list`; a thrown error would propagate, so the
-    // contract is that injected `list` returns a typed result. Verify the
-    // happy default path doesn't require a real broker by injecting an
-    // unreachable result (the production code path is identical).
-    const list = vi.fn(async () => ({ kind: "unreachable" as const, msg: "ENOENT" }));
+  it("never throws — a genuinely REJECTING list degrades to reachable:false", async () => {
+    // handleGetGrants wraps the await in try/catch so its documented
+    // "never throws" holds even if list's non-throwing contract changes.
+    const list = vi.fn(async () => {
+      throw new Error("socket exploded mid-RPC");
+    });
     const r = await handleGetGrants({ socketPath: "/sock", list });
     expect(r.reachable).toBe(false);
-    expect(r.error).toBe("ENOENT");
+    expect(r.grants).toEqual([]);
+    expect(r.error).toContain("socket exploded");
   });
 });
 

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -112,6 +112,7 @@ import {
   handleGetMicrosoftConnectStatus,
   __resetMicrosoftConnectStatuses,
   handleGetApprovals,
+  handleGetGrants,
   handleRefreshAccountsQuota,
   __resetQuotaCacheForTests,
   __resetAgentStatusCacheForTests,
@@ -1370,6 +1371,120 @@ describe("handleGetApprovals", () => {
     expect(approvalList).toHaveBeenCalledWith(undefined, {
       socket: "/run/op/sock",
     });
+  });
+});
+
+describe("handleGetGrants (standing capability grants — broker grants DB)", () => {
+  // Injectable `list` + `socketPath` deps → no real broker, no fs probe.
+  const fakeGrant = (over: Partial<{
+    id: string;
+    agent_slug: string;
+    key_allow: string[];
+    write_allow: string[];
+    expires_at: number | null;
+    created_at: number;
+    description: string | null;
+  }> = {}) => ({
+    id: "g1",
+    agent_slug: "agent-a",
+    key_allow: ["api/foo"],
+    write_allow: [],
+    expires_at: null,
+    created_at: 1_700_000_000, // unix SECONDS
+    description: null,
+    ...over,
+  });
+
+  it("returns reachable:false + an actionable error when the socket is absent (null)", async () => {
+    const list = vi.fn();
+    const r = await handleGetGrants({ socketPath: null, list });
+    expect(r.reachable).toBe(false);
+    expect(r.grants).toEqual([]);
+    expect(r.error).toMatch(/operator socket not present/i);
+    // Must not attempt the RPC when there's no socket.
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("maps kind:'ok' grants and pins opts.socket (no agent filter)", async () => {
+    const list = vi.fn(async () => ({
+      kind: "ok" as const,
+      grants: [
+        fakeGrant({
+          id: "g1",
+          agent_slug: "alice",
+          key_allow: ["api/key", "api/other"],
+          write_allow: ["api/key"],
+          expires_at: 1_700_000_500,
+          created_at: 1_700_000_000,
+          description: "scoped grant",
+        }),
+      ],
+    }));
+    const r = await handleGetGrants({ socketPath: "/run/broker-op/sock", list });
+    expect(r.reachable).toBe(true);
+    expect(list).toHaveBeenCalledWith(undefined, { socket: "/run/broker-op/sock" });
+    expect(r.grants).toHaveLength(1);
+    const g = r.grants[0];
+    // Projection: agent_slug→agent, key_allow→keys, write_allow→writeKeys.
+    expect(g.id).toBe("g1");
+    expect(g.agent).toBe("alice");
+    expect(g.keys).toEqual(["api/key", "api/other"]);
+    expect(g.writeKeys).toEqual(["api/key"]);
+    expect(g.description).toBe("scoped grant");
+    // Time-unit: GrantMeta is unix SECONDS, UI wants ms → ×1000.
+    expect(g.createdAt).toBe(1_700_000_000_000);
+    expect(g.expiresAt).toBe(1_700_000_500_000);
+  });
+
+  it("keeps a null expires_at as null (never-expiring grant)", async () => {
+    const list = vi.fn(async () => ({
+      kind: "ok" as const,
+      grants: [fakeGrant({ expires_at: null })],
+    }));
+    const r = await handleGetGrants({ socketPath: "/sock", list });
+    expect(r.grants[0].expiresAt).toBeNull();
+    // created_at still converted to ms.
+    expect(r.grants[0].createdAt).toBe(1_700_000_000_000);
+  });
+
+  it("maps kind:'unreachable' to reachable:false + the broker reason", async () => {
+    const list = vi.fn(async () => ({ kind: "unreachable" as const, msg: "broker not answering" }));
+    const r = await handleGetGrants({ socketPath: "/sock", list });
+    expect(r.reachable).toBe(false);
+    expect(r.grants).toEqual([]);
+    expect(r.error).toBe("broker not answering");
+  });
+
+  it("maps kind:'error' to reachable:false + the broker reason", async () => {
+    const list = vi.fn(async () => ({ kind: "error" as const, msg: "denied" }));
+    const r = await handleGetGrants({ socketPath: "/sock", list });
+    expect(r.reachable).toBe(false);
+    expect(r.grants).toEqual([]);
+    expect(r.error).toBe("denied");
+  });
+
+  it("sorts grants newest-first by createdAt", async () => {
+    const list = vi.fn(async () => ({
+      kind: "ok" as const,
+      grants: [
+        fakeGrant({ id: "old", created_at: 1_000 }),
+        fakeGrant({ id: "new", created_at: 9_000 }),
+        fakeGrant({ id: "mid", created_at: 5_000 }),
+      ],
+    }));
+    const r = await handleGetGrants({ socketPath: "/sock", list });
+    expect(r.grants.map((g) => g.id)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("never throws — a rejecting list surfaces as an error result", async () => {
+    // handleGetGrants awaits `list`; a thrown error would propagate, so the
+    // contract is that injected `list` returns a typed result. Verify the
+    // happy default path doesn't require a real broker by injecting an
+    // unreachable result (the production code path is identical).
+    const list = vi.fn(async () => ({ kind: "unreachable" as const, msg: "ENOENT" }));
+    const r = await handleGetGrants({ socketPath: "/sock", list });
+    expect(r.reachable).toBe(false);
+    expect(r.error).toBe("ENOENT");
   });
 });
 


### PR DESCRIPTION
## Summary

The Approvals tab reads the approval-**kernel** decision ledger, which is **honestly empty** — the daily per-tool Allow/Deny taps never write it. The operator's *real* standing grants live in the **vault-broker grants DB**. This surfaces them, so the tab is actually useful (audit ranks 10-core, 21) and directly answers "approvals page doesn't work."

Confirmed live: `switchroom vault grants` reads `list_grants` over the broker operator socket passphrase-free, and that socket (`~/.switchroom/broker-operator/sock`) is reachable from the dockerless web.

## What's added

- **`resolveBrokerOperatorSocket()`** — mirrors `resolveKernelOperatorSocket` (exists → path, else null); does not touch the broker's own resolver.
- **`handleGetGrants()` — READ-ONLY.** Calls `list_grants` over the operator socket (fleet-wide), maps `ok`/`unreachable`/`error` to a typed `GrantsDashboard`, never throws, **never grants/mints/revokes**. `GrantMeta` times are unix **seconds** → converted ×1000 to ms at the projection boundary (the UI's `formatTimestamp` expects ms).
- **`GET /api/grants`** through the shared SWR cache (15s) + the object stamp.
- **UI** — `fetchApprovals` also pulls `/api/grants` (resilient — one failing never blanks the other); a **"Standing capability grants"** table above the (honestly-empty) decision ledger: agent, read keys, a highlighted **write** pill for `write_allow` grants (the sensitive ones), expires, granted, description. Unreachable → the actionable `problemFor('grants-unreachable')` card (`switchroom vault broker status`). `escapeHtml` on every value.

## Test plan

- [x] 7 `handleGetGrants` cases (null-socket→actionable + no RPC, ok projection incl. time-unit, null-expiry, unreachable, error, newest-first sort) — injected socket + list, no real broker
- [x] `tsc --noEmit` clean; **259** web tests pass; inline `<script>` `node --check` clean; PII guard clean

## Risk

Low. Read-only `list_grants` only (no write path reachable). The web degrades cleanly when the broker is unreachable. No model call, no docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)