### PR TITLE
feat(dashboard): Memory remediation buttons (subscription-honest)

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -12,8 +12,15 @@ import {
   staleMentalModels,
   corruptedMentalModels,
   recentUnextracted,
+  ageDays,
   type BankMentalModelSummary,
 } from "../memory/bank-health.js";
+import {
+  reprocessDocuments,
+  refreshMentalModel,
+  buildUserProfile,
+  restBaseFromMcpUrl,
+} from "./memory-remediation.js";
 import {
   getHindsightStatus,
 } from "../setup/hindsight.js";
@@ -1763,6 +1770,13 @@ export interface MemoryBankHealthRow {
   /** Documents ≤30d old retained with zero extracted facts (silent extraction outage). */
   recentUnextractedCount: number;
   oldestUnextractedAt: string | null;
+  /**
+   * IDs of the recent-unextracted gap docs (the reprocess button's
+   * targets), bounded to the first 20 so a huge backlog can't bloat the
+   * payload. Server re-derives these on the POST — the client never
+   * supplies them.
+   */
+  unextractedDocIds: string[];
   mentalModels: BankMentalModelSummary[];
   staleMentalModelCount: number;
   /** Models whose content is a persisted LLM-failure message (quota wall during refresh). */
@@ -1808,6 +1822,11 @@ export async function handleGetMemoryHealth(
       const gaps = recentUnextracted(h.unextractedDocuments, 30, now);
       const stale = staleMentalModels(h.mentalModels, 7, now);
       const corrupted = corruptedMentalModels(h.mentalModels);
+      const newestAge = ageDays(h.newestDocumentAt, now);
+      // Mirror doctor.ts's "pending queue may be stuck" warn: pending
+      // operations AND no new documents for >1d.
+      const pendingStuck =
+        h.pendingOperations > 0 && newestAge !== null && newestAge > 1;
       let status: MemoryBankHealthRow["status"] = "ok";
       let statusDetail = "facts flowing";
       if (!h.ok) {
@@ -1819,6 +1838,10 @@ export async function handleGetMemoryHealth(
       } else if (gaps.length > 0) {
         status = "fail";
         statusDetail = `${gaps.length} recent conversation(s) stored with zero extracted facts — invisible to recall`;
+      } else if (pendingStuck) {
+        // Doctor precedence: after gaps, before stale.
+        status = "warn";
+        statusDetail = `${h.pendingOperations} memory operation(s) pending with no new documents for ${Math.round(newestAge)}d — pipeline may be stuck`;
       } else if (stale.length > 0) {
         status = "warn";
         statusDetail = `${stale.length} mental model(s) not refreshed in >7d`;
@@ -1837,6 +1860,7 @@ export async function handleGetMemoryHealth(
         newestDocumentAt: h.newestDocumentAt,
         recentUnextractedCount: gaps.length,
         oldestUnextractedAt: gaps[0]?.createdAt ?? null,
+        unextractedDocIds: gaps.slice(0, 20).map((d) => d.id),
         mentalModels: h.mentalModels,
         staleMentalModelCount: stale.length,
         corruptedMentalModelNames: corrupted.map((m) => m.name),
@@ -1848,6 +1872,144 @@ export async function handleGetMemoryHealth(
 
   rows.sort((a, b) => a.bank.localeCompare(b.bank));
   return { reachable, url, banks: rows };
+}
+
+/**
+ * Resolve the configured hindsight MCP url (default 127.0.0.1:18888).
+ * Shared by the memory-remediation handlers below.
+ */
+function resolveMemoryUrl(config: SwitchroomConfig): string {
+  return (
+    (config.memory?.config?.url as string | undefined) ??
+    "http://127.0.0.1:18888/mcp/"
+  );
+}
+
+/**
+ * Is `bank` a real memory bank for this fleet? Used to gate the
+ * remediation POSTs so the dashboard can't poke an arbitrary bank.
+ */
+function isKnownBank(config: SwitchroomConfig, bank: string): boolean {
+  for (const agentName of Object.keys(config.agents)) {
+    if (getCollectionForAgent(agentName, config) === bank) return true;
+  }
+  return false;
+}
+
+/**
+ * POST /api/memory/reprocess — re-extract facts from the stuck (gap)
+ * documents of a bank.
+ *
+ * The doc IDs are re-derived SERVER-SIDE from the live inspect result
+ * (NOT trusted from the client) so a loopback-forgeable dashboard POST
+ * can't reprocess arbitrary documents. Triggers only; hindsight runs
+ * the extraction on its own provider — the web makes no model call.
+ * Never throws.
+ */
+export async function handleMemoryReprocess(
+  config: SwitchroomConfig,
+  body: { bank?: unknown },
+  deps?: {
+    fetchImpl?: typeof fetch;
+    trigger?: typeof reprocessDocuments;
+    inspect?: typeof inspectBankHealth;
+    now?: Date;
+  },
+): Promise<{ ok: boolean; triggered?: number; failed?: number; error?: string }> {
+  const bank = typeof body.bank === "string" ? body.bank : "";
+  if (!bank) return { ok: false, error: "Body must include `bank` (string)." };
+  if (!isKnownBank(config, bank)) return { ok: false, error: `Unknown bank: ${bank}` };
+
+  const url = resolveMemoryUrl(config);
+  const inspect = deps?.inspect ?? inspectBankHealth;
+  const trigger = deps?.trigger ?? reprocessDocuments;
+  const now = deps?.now ?? new Date();
+
+  try {
+    const h = await inspect(url, bank, { fetchImpl: deps?.fetchImpl });
+    if (!h.ok) return { ok: false, error: `inspection failed: ${h.reason ?? "unknown"}` };
+    const gaps = recentUnextracted(h.unextractedDocuments, 30, now);
+    const docIds = gaps.slice(0, 20).map((d) => d.id);
+    if (docIds.length === 0) return { ok: true, triggered: 0, failed: 0 };
+
+    const result = await trigger(restBaseFromMcpUrl(url), bank, docIds, {
+      fetchImpl: deps?.fetchImpl,
+    });
+    return {
+      ok: result.failed === 0,
+      triggered: result.triggered,
+      failed: result.failed,
+      ...(result.error ? { error: result.error } : {}),
+    };
+  } catch (err) {
+    return { ok: false, error: String((err as Error).message ?? err) };
+  }
+}
+
+/**
+ * POST /api/memory/refresh-model — regenerate one mental model (fixes a
+ * corrupted or stale model).
+ *
+ * `modelId` is validated against the bank's ACTUAL mental models (live
+ * inspect) before any POST, so the dashboard can't refresh an arbitrary
+ * model id. Triggers only; no model call from the web. Never throws.
+ */
+export async function handleMemoryRefreshModel(
+  config: SwitchroomConfig,
+  body: { bank?: unknown; modelId?: unknown },
+  deps?: {
+    fetchImpl?: typeof fetch;
+    trigger?: typeof refreshMentalModel;
+    inspect?: typeof inspectBankHealth;
+  },
+): Promise<{ ok: boolean; error?: string }> {
+  const bank = typeof body.bank === "string" ? body.bank : "";
+  const modelId = typeof body.modelId === "string" ? body.modelId : "";
+  if (!bank) return { ok: false, error: "Body must include `bank` (string)." };
+  if (!modelId) return { ok: false, error: "Body must include `modelId` (string)." };
+  if (!isKnownBank(config, bank)) return { ok: false, error: `Unknown bank: ${bank}` };
+
+  const url = resolveMemoryUrl(config);
+  const inspect = deps?.inspect ?? inspectBankHealth;
+  const trigger = deps?.trigger ?? refreshMentalModel;
+
+  try {
+    const h = await inspect(url, bank, { fetchImpl: deps?.fetchImpl });
+    if (!h.ok) return { ok: false, error: `inspection failed: ${h.reason ?? "unknown"}` };
+    if (!h.mentalModels.some((m) => m.id === modelId)) {
+      return { ok: false, error: `Unknown mental model for bank ${bank}` };
+    }
+
+    return await trigger(restBaseFromMcpUrl(url), bank, modelId, {
+      fetchImpl: deps?.fetchImpl,
+    });
+  } catch (err) {
+    return { ok: false, error: String((err as Error).message ?? err) };
+  }
+}
+
+/**
+ * POST /api/memory/build-profile — create-if-missing the user-profile
+ * mental model for a bank (the "knows you" feature). Triggers hindsight
+ * to build it on its own provider; no model call from the web. Never
+ * throws.
+ */
+export async function handleMemoryBuildProfile(
+  config: SwitchroomConfig,
+  body: { bank?: unknown },
+  deps?: { fetchImpl?: typeof fetch; trigger?: typeof buildUserProfile },
+): Promise<{ ok: boolean; error?: string }> {
+  const bank = typeof body.bank === "string" ? body.bank : "";
+  if (!bank) return { ok: false, error: "Body must include `bank` (string)." };
+  if (!isKnownBank(config, bank)) return { ok: false, error: `Unknown bank: ${bank}` };
+
+  const url = resolveMemoryUrl(config);
+  const trigger = deps?.trigger ?? buildUserProfile;
+  try {
+    return await trigger(url, bank, { fetchImpl: deps?.fetchImpl });
+  } catch (err) {
+    return { ok: false, error: String((err as Error).message ?? err) };
+  }
 }
 
 /**

--- a/src/web/memory-remediation.test.ts
+++ b/src/web/memory-remediation.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  reprocessDocuments,
+  refreshMentalModel,
+  restBaseFromMcpUrl,
+} from "./memory-remediation.js";
+
+const okResp = () => ({ ok: true, status: 200 }) as unknown as Response;
+const failResp = (status: number) =>
+  ({ ok: false, status }) as unknown as Response;
+
+describe("restBaseFromMcpUrl", () => {
+  it("strips a trailing /mcp/", () => {
+    expect(restBaseFromMcpUrl("http://127.0.0.1:18888/mcp/")).toBe(
+      "http://127.0.0.1:18888",
+    );
+  });
+  it("strips /mcp with no trailing slash", () => {
+    expect(restBaseFromMcpUrl("http://127.0.0.1:18888/mcp")).toBe(
+      "http://127.0.0.1:18888",
+    );
+  });
+  it("strips a trailing slash on a non-/mcp url", () => {
+    expect(restBaseFromMcpUrl("http://host:9000/")).toBe("http://host:9000");
+  });
+});
+
+describe("reprocessDocuments", () => {
+  it("POSTs one reprocess URL per docId and counts all ok", async () => {
+    const calls: Array<{ url: string; method?: string }> = [];
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method });
+      return okResp();
+    }) as unknown as typeof fetch;
+
+    const r = await reprocessDocuments(
+      "http://127.0.0.1:18888",
+      "coach-mem",
+      ["doc-1", "doc-2", "doc-3"],
+      { fetchImpl },
+    );
+
+    expect(r).toEqual({ triggered: 3, failed: 0 });
+    expect(calls).toHaveLength(3);
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe(
+      "http://127.0.0.1:18888/v1/default/banks/coach-mem/documents/doc-1/reprocess",
+    );
+  });
+
+  it("counts ok vs failed when some POSTs return non-2xx", async () => {
+    const fetchImpl = vi.fn(async (url: string) =>
+      url.includes("doc-2") ? failResp(500) : okResp(),
+    ) as unknown as typeof fetch;
+
+    const r = await reprocessDocuments(
+      "http://127.0.0.1:18888",
+      "bank",
+      ["doc-1", "doc-2", "doc-3"],
+      { fetchImpl },
+    );
+
+    expect(r.triggered).toBe(2);
+    expect(r.failed).toBe(1);
+    expect(r.error).toBe("HTTP 500");
+  });
+
+  it("never throws when fetch rejects — counts as failed", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    const r = await reprocessDocuments("http://x", "bank", ["d1", "d2"], {
+      fetchImpl,
+    });
+
+    expect(r.triggered).toBe(0);
+    expect(r.failed).toBe(2);
+    expect(r.error).toContain("ECONNREFUSED");
+  });
+
+  it("encodes bank + docId into the URL", async () => {
+    let seen = "";
+    const fetchImpl = vi.fn(async (url: string) => {
+      seen = url;
+      return okResp();
+    }) as unknown as typeof fetch;
+    await reprocessDocuments("http://x", "a b", ["d/1"], { fetchImpl });
+    expect(seen).toBe("http://x/v1/default/banks/a%20b/documents/d%2F1/reprocess");
+  });
+
+  it("is a no-op (triggered 0) for an empty docId list", async () => {
+    const fetchImpl = vi.fn(async () => okResp()) as unknown as typeof fetch;
+    const r = await reprocessDocuments("http://x", "bank", [], { fetchImpl });
+    expect(r).toEqual({ triggered: 0, failed: 0 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("refreshMentalModel", () => {
+  it("POSTs the refresh URL and returns ok", async () => {
+    let seen = "";
+    let method = "";
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      seen = url;
+      method = init?.method ?? "";
+      return okResp();
+    }) as unknown as typeof fetch;
+
+    const r = await refreshMentalModel(
+      "http://127.0.0.1:18888",
+      "coach-mem",
+      "mm-9",
+      { fetchImpl },
+    );
+
+    expect(r).toEqual({ ok: true });
+    expect(method).toBe("POST");
+    expect(seen).toBe(
+      "http://127.0.0.1:18888/v1/default/banks/coach-mem/mental-models/mm-9/refresh",
+    );
+  });
+
+  it("maps a non-2xx response to ok:false with a reason", async () => {
+    const fetchImpl = vi.fn(async () =>
+      failResp(404),
+    ) as unknown as typeof fetch;
+    const r = await refreshMentalModel("http://x", "bank", "id", { fetchImpl });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("HTTP 404");
+  });
+
+  it("never throws when fetch rejects", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const r = await refreshMentalModel("http://x", "bank", "id", { fetchImpl });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("network down");
+  });
+});

--- a/src/web/memory-remediation.ts
+++ b/src/web/memory-remediation.ts
@@ -1,0 +1,133 @@
+/**
+ * Hindsight remediation TRIGGERS for the dashboard Memory tab.
+ *
+ * The operator's complaint: the Memory tab shows extraction gaps,
+ * corrupted/stale mental models, and missing user-profile models, but
+ * offers no way to FIX them — only a curl recipe in the doctor output.
+ * These helpers turn each problem into a one-click POST to hindsight's
+ * own REST/MCP surface.
+ *
+ * SUBSCRIPTION-HONEST (vision pillar 3): the web makes ZERO model calls.
+ * Each helper is a thin HTTP poke at `127.0.0.1:18888` — hindsight does
+ * the LLM work on ITS OWN claude-code provider
+ * (`HINDSIGHT_API_LLM_PROVIDER=claude-code`). The POST returns the
+ * moment hindsight ACCEPTS the job; we do NOT await the extraction to
+ * finish. Exactly the shape of the existing direct quota-refresh button.
+ *
+ * No Anthropic API / SDK / `claude -p` is imported here. The only
+ * outbound is `fetch` (injectable for tests).
+ *
+ * All functions are best-effort with a short timeout and NEVER throw —
+ * the caller (web handlers) maps the result to a toast.
+ */
+
+import { hindsightRestBase } from "../memory/bank-health.js";
+import { ensureUserProfileMentalModel } from "../memory/hindsight.js";
+
+/** Re-export so callers can derive the REST base without reaching into bank-health. */
+export function restBaseFromMcpUrl(mcpUrl: string): string {
+  return hindsightRestBase(mcpUrl);
+}
+
+interface TriggerOpts {
+  fetchImpl?: typeof fetch;
+  /**
+   * These calls only ENQUEUE work (the LLM runs async on hindsight's
+   * side), so a short timeout is correct — we're waiting for the job to
+   * be accepted, not for extraction to complete.
+   */
+  timeoutMs?: number;
+}
+
+/** POST a URL with a short timeout; never throws. Returns ok / a reason. */
+async function postTrigger(
+  url: string,
+  opts?: TriggerOpts,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const fetchImpl = opts?.fetchImpl ?? fetch;
+  const timeoutMs = opts?.timeoutMs ?? 5_000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const resp = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    if (!resp.ok) return { ok: false, reason: `HTTP ${resp.status}` };
+    return { ok: true };
+  } catch (err) {
+    clearTimeout(timeout);
+    if ((err as Error).name === "AbortError") return { ok: false, reason: "Timeout" };
+    return { ok: false, reason: String((err as Error).message ?? err) };
+  }
+}
+
+/**
+ * Reprocess (re-extract facts from) one or more stuck documents.
+ *
+ * `restBase` is the REST base (NOT the MCP url) — derive it via
+ * `restBaseFromMcpUrl` first. Each docId is POSTed sequentially; a
+ * single failure does not abort the rest. Counts ok vs failed. The
+ * first failure's reason is surfaced. Never throws.
+ */
+export async function reprocessDocuments(
+  restBase: string,
+  bank: string,
+  docIds: string[],
+  opts?: TriggerOpts,
+): Promise<{ triggered: number; failed: number; error?: string }> {
+  let triggered = 0;
+  let failed = 0;
+  let error: string | undefined;
+  const encodedBank = encodeURIComponent(bank);
+  for (const docId of docIds) {
+    const url = `${restBase}/v1/default/banks/${encodedBank}/documents/${encodeURIComponent(docId)}/reprocess`;
+    const r = await postTrigger(url, opts);
+    if (r.ok) {
+      triggered += 1;
+    } else {
+      failed += 1;
+      if (!error) error = r.reason;
+    }
+  }
+  return error ? { triggered, failed, error } : { triggered, failed };
+}
+
+/**
+ * Refresh (regenerate) one mental model — the fix for a corrupted or
+ * stale model. `restBase` is the REST base. Never throws.
+ */
+export async function refreshMentalModel(
+  restBase: string,
+  bank: string,
+  modelId: string,
+  opts?: TriggerOpts,
+): Promise<{ ok: boolean; error?: string }> {
+  const url = `${restBase}/v1/default/banks/${encodeURIComponent(bank)}/mental-models/${encodeURIComponent(modelId)}/refresh`;
+  const r = await postTrigger(url, opts);
+  return r.ok ? { ok: true } : { ok: false, error: r.reason };
+}
+
+/**
+ * Build (create-if-missing) the user-profile mental model for a bank —
+ * the "knows you" feature. Thin wrapper over the exported
+ * `ensureUserProfileMentalModel`, which takes the MCP url (NOT the REST
+ * base) and drives the create over JSON-RPC. Never throws.
+ */
+export async function buildUserProfile(
+  mcpUrl: string,
+  bank: string,
+  opts?: { fetchImpl?: typeof fetch; timeoutMs?: number },
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const r = await ensureUserProfileMentalModel(mcpUrl, bank, {
+      fetchImpl: opts?.fetchImpl,
+      timeoutMs: opts?.timeoutMs,
+    });
+    return r.ok ? { ok: true } : { ok: false, error: r.reason };
+  } catch (err) {
+    return { ok: false, error: String((err as Error).message ?? err) };
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -30,6 +30,9 @@ import {
   handleUseAccount,
   handleGetSystemHealth,
   handleGetMemoryHealth,
+  handleMemoryReprocess,
+  handleMemoryRefreshModel,
+  handleMemoryBuildProfile,
   handleGetGoogleAccounts,
   handleGetMicrosoftAccounts,
   handleSetConnectionAccess,
@@ -470,6 +473,26 @@ function parseRoute(
   // GET /api/memory-health
   if (method === "GET" && pathname === "/api/memory-health") {
     return { handler: "getMemoryHealth", params: {} };
+  }
+
+  // POST /api/memory/reprocess  body: { bank }
+  // Re-extract facts from a bank's stuck (gap) documents. The web only
+  // POKES hindsight's REST API — hindsight does the LLM work on its own
+  // provider; no model call from the dashboard.
+  if (method === "POST" && pathname === "/api/memory/reprocess") {
+    return { handler: "memoryReprocess", params: {} };
+  }
+
+  // POST /api/memory/refresh-model  body: { bank, modelId }
+  // Regenerate one mental model (fixes a corrupted/stale model).
+  if (method === "POST" && pathname === "/api/memory/refresh-model") {
+    return { handler: "memoryRefreshModel", params: {} };
+  }
+
+  // POST /api/memory/build-profile  body: { bank }
+  // Create-if-missing the user-profile mental model for a bank.
+  if (method === "POST" && pathname === "/api/memory/build-profile") {
+    return { handler: "memoryBuildProfile", params: {} };
   }
 
   // GET /api/google-accounts
@@ -926,6 +949,48 @@ export function startWebServer(
               const force = body.force === true;
               const result = await handleRefreshAccountsQuota(labels, force);
               return jsonResponse(result, result.ok ? 200 : 502);
+            })();
+          }
+
+          case "memoryReprocess": {
+            return (async () => {
+              let body: { bank?: unknown } = {};
+              try {
+                const raw = await req.text();
+                body = raw ? JSON.parse(raw) : {};
+              } catch {
+                return jsonResponse({ ok: false, error: "Invalid JSON body" }, 400);
+              }
+              const result = await handleMemoryReprocess(freshConfig(), body);
+              return jsonResponse(result, result.ok ? 200 : 400);
+            })();
+          }
+
+          case "memoryRefreshModel": {
+            return (async () => {
+              let body: { bank?: unknown; modelId?: unknown } = {};
+              try {
+                const raw = await req.text();
+                body = raw ? JSON.parse(raw) : {};
+              } catch {
+                return jsonResponse({ ok: false, error: "Invalid JSON body" }, 400);
+              }
+              const result = await handleMemoryRefreshModel(freshConfig(), body);
+              return jsonResponse(result, result.ok ? 200 : 400);
+            })();
+          }
+
+          case "memoryBuildProfile": {
+            return (async () => {
+              let body: { bank?: unknown } = {};
+              try {
+                const raw = await req.text();
+                body = raw ? JSON.parse(raw) : {};
+              } catch {
+                return jsonResponse({ ok: false, error: "Invalid JSON body" }, 400);
+              }
+              const result = await handleMemoryBuildProfile(freshConfig(), body);
+              return jsonResponse(result, result.ok ? 200 : 400);
             })();
           }
 

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -610,7 +610,16 @@
         if (isNaN(d)) return '';
         return d < 1 ? 'today' : `${Math.round(d)}d ago`;
       };
+      // A bank "has a user-profile model" if any mental model is named
+      // like user-profile (mirrors hindsight's exact-name check, but
+      // tolerant of the "User Profile" display variant for the UI hint).
+      const hasUserProfile = (b) => (b.mentalModels || []).some(mm =>
+        /^user[- ]?profile$/i.test(String(mm.name || '')));
+      // JSON for a single-quoted onclick attribute: escape the quote
+      // chars that could break out of the attribute (', &, <, >).
+      const attrJson = (v) => escapeHtml(JSON.stringify(v));
       const cards = (m.banks || []).map(b => {
+        const bankJs = attrJson(b.bank);
         const models = (b.mentalModels || []).map(mm => {
           const ts = mm.lastRefreshedAt || mm.createdAt;
           const stale = ts && (Date.now() - Date.parse(ts)) > 7 * 86400000;
@@ -621,6 +630,38 @@
           : '';
         const corruptLine = (b.corruptedMentalModelNames || []).length > 0
           ? `<div style="color:var(--red);margin-top:.4rem">⚠ corrupted mental model(s): ${escapeHtml(b.corruptedMentalModelNames.join(', '))} — content is an LLM failure message; refresh once quota recovers</div>`
+          : '';
+        // --- Remediation buttons (audit ranks 7 + 22) ---
+        // Each triggers an HTTP poke at hindsight; hindsight does the LLM
+        // work on its own provider — the dashboard makes NO model call.
+        const buttons = [];
+        // Reprocess the extraction-gap docs.
+        if (b.recentUnextractedCount > 0) {
+          const n = Math.min(b.recentUnextractedCount, (b.unextractedDocIds || []).length) || b.recentUnextractedCount;
+          buttons.push(`<button class="btn" type="button" onclick='memReprocess(${bankJs}, this)'>Reprocess ${n} doc${n === 1 ? '' : 's'}</button>`);
+        }
+        // Refresh each corrupted/stale model (map corrupted NAME → id).
+        const affectedIds = new Set();
+        for (const name of (b.corruptedMentalModelNames || [])) {
+          const mm = (b.mentalModels || []).find(x => x.name === name);
+          if (mm && mm.id) affectedIds.add(mm.id);
+        }
+        for (const mm of (b.mentalModels || [])) {
+          const ts = mm.lastRefreshedAt || mm.createdAt;
+          const stale = ts && (Date.now() - Date.parse(ts)) > 7 * 86400000;
+          if (stale && mm.id) affectedIds.add(mm.id);
+        }
+        for (const mm of (b.mentalModels || [])) {
+          if (!affectedIds.has(mm.id)) continue;
+          const idJs = attrJson(mm.id), nameJs = attrJson(mm.name);
+          buttons.push(`<button class="btn" type="button" onclick='memRefreshModel(${bankJs}, ${idJs}, ${nameJs}, this)'>Refresh ${escapeHtml(mm.name)}</button>`);
+        }
+        // Build the user-profile model when the bank has data but no profile.
+        if (b.totalDocuments > 0 && !hasUserProfile(b)) {
+          buttons.push(`<button class="btn" type="button" onclick='memBuildProfile(${bankJs}, this)'>Build profile</button>`);
+        }
+        const buttonRow = buttons.length
+          ? `<div class="rem-actions" style="margin-top:.6rem;display:flex;flex-wrap:wrap;gap:.4rem">${buttons.join('')}</div>`
           : '';
         return `<div class="agent-card">
           <div class="card-header" style="cursor:default">
@@ -638,10 +679,57 @@
             ${models ? `<div class="card-meta" style="padding:.4rem 0 0">${models}</div>` : ''}
             ${corruptLine}
             ${gapLine}
+            ${buttonRow}
           </div>
         </div>`;
       }).join('');
       container.innerHTML = `<div class="agents-grid">${cards || '<div style="color:var(--text-dim)">No agent banks configured.</div>'}</div>`;
+    }
+
+    // --- Memory remediation actions ---
+    // Each pokes a hindsight REST/MCP endpoint via the web's POST routes.
+    // Hindsight does the LLM extraction on its OWN claude-code provider;
+    // the dashboard never calls a model. A confirm() gates each because
+    // it consumes subscription quota (low-risk, but explicit).
+    const REM_CONFIRM = 'This triggers memory re-processing on the subscription. Continue?';
+
+    // `label` names the action for the failure toast; `successMsg(data)`
+    // builds the success toast from the response body.
+    async function memRemediate(btn, url, payload, working, label, successMsg) {
+      if (!confirm(REM_CONFIRM)) return;
+      const orig = btn ? btn.textContent : '';
+      if (btn) { btn.disabled = true; btn.textContent = working; }
+      try {
+        const res = await fetch(`${API}${url}`, {
+          method: 'POST',
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || !data.ok) {
+          showToast(`${label} failed: ${data.error || `HTTP ${res.status}`}`, false);
+        } else {
+          showToast(successMsg(data), true);
+        }
+      } catch (err) {
+        showToast(`${label} failed: ${err.message}`, false);
+      } finally {
+        if (btn) { btn.disabled = false; btn.textContent = orig; }
+        fetchMemoryHealth();
+      }
+    }
+
+    function memReprocess(bank, btn) {
+      memRemediate(btn, '/api/memory/reprocess', { bank }, 'Reprocessing…', 'Reprocess',
+        (d) => `Reprocess triggered (${d.triggered ?? 0} doc${(d.triggered ?? 0) === 1 ? '' : 's'}${d.failed ? `, ${d.failed} failed` : ''})`);
+    }
+    function memRefreshModel(bank, modelId, name, btn) {
+      memRemediate(btn, '/api/memory/refresh-model', { bank, modelId }, 'Refreshing…', 'Refresh',
+        () => `Refresh triggered for ${name}`);
+    }
+    function memBuildProfile(bank, btn) {
+      memRemediate(btn, '/api/memory/build-profile', { bank }, 'Building…', 'Build profile',
+        () => 'Profile build triggered');
     }
 
     async function fetchConnections() {

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -117,6 +117,9 @@ import {
   __resetQuotaCacheForTests,
   __resetAgentStatusCacheForTests,
   handleGetSummary,
+  handleMemoryReprocess,
+  handleMemoryRefreshModel,
+  handleMemoryBuildProfile,
   __resetDashboardCacheForTests,
   type AgentInfo,
   type SystemHealth,
@@ -1734,5 +1737,263 @@ describe("handleGetSummary — cached aggregate for the Summary tab", () => {
     release();
     const out = await p;
     expect(out.agents).toEqual(fakeAgents);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Memory remediation handlers (audit ranks 7 + 22). These are HTTP pokes at
+// hindsight — they make ZERO model calls. Tests inject the inspect/trigger
+// deps so they never touch a real hindsight instance.
+// ---------------------------------------------------------------------------
+describe("memory remediation handlers", () => {
+  // mockConfig agents: coach (bank "coach-mem"), sage (bank "sage").
+  const mkBankHealth = (over: Partial<{
+    ok: boolean;
+    reason?: string;
+    totalDocuments: number;
+    totalFacts: number;
+    pendingOperations: number;
+    newestDocumentAt: string | null;
+    unextractedDocuments: Array<{ id: string; createdAt: string; textLength: number; memoryUnitCount: number }>;
+    mentalModels: Array<{ id: string; name: string; lastRefreshedAt: string | null; createdAt: string | null; contentLength: number; contentHead: string }>;
+  }> = {}) => ({
+    bankId: "coach-mem",
+    ok: true,
+    totalDocuments: 5,
+    totalFacts: 20,
+    pendingOperations: 0,
+    newestDocumentAt: new Date().toISOString(),
+    unextractedDocuments: [],
+    mentalModels: [],
+    ...over,
+  });
+
+  describe("handleMemoryReprocess", () => {
+    it("rejects an unknown bank without inspecting", async () => {
+      const inspect = vi.fn();
+      const trigger = vi.fn();
+      const r = await handleMemoryReprocess(mockConfig, { bank: "nope" }, {
+        inspect: inspect as never,
+        trigger: trigger as never,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("Unknown bank");
+      expect(inspect).not.toHaveBeenCalled();
+      expect(trigger).not.toHaveBeenCalled();
+    });
+
+    it("rejects a missing bank", async () => {
+      const r = await handleMemoryReprocess(mockConfig, {}, {});
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("bank");
+    });
+
+    it("re-derives gap doc ids server-side and triggers reprocess", async () => {
+      const now = new Date();
+      const recent = new Date(now.getTime() - 86400000).toISOString();
+      const inspect = vi.fn(async () =>
+        mkBankHealth({
+          unextractedDocuments: [
+            { id: "doc-a", createdAt: recent, textLength: 5000, memoryUnitCount: 0 },
+            { id: "doc-b", createdAt: recent, textLength: 5000, memoryUnitCount: 0 },
+          ],
+        }),
+      );
+      let passedIds: string[] = [];
+      const trigger = vi.fn(async (_base: string, _bank: string, ids: string[]) => {
+        passedIds = ids;
+        return { triggered: ids.length, failed: 0 };
+      });
+      const r = await handleMemoryReprocess(mockConfig, { bank: "coach-mem" }, {
+        inspect: inspect as never,
+        trigger: trigger as never,
+        now,
+      });
+      expect(r.ok).toBe(true);
+      expect(r.triggered).toBe(2);
+      expect(r.failed).toBe(0);
+      expect(passedIds.sort()).toEqual(["doc-a", "doc-b"]);
+      // The trigger gets the REST base (no /mcp/), not the raw doc list from the body.
+      expect(trigger.mock.calls[0][0]).toBe("http://127.0.0.1:18888");
+    });
+
+    it("ignores client-supplied doc ids — only inspected gaps are used", async () => {
+      const inspect = vi.fn(async () => mkBankHealth({ unextractedDocuments: [] }));
+      const trigger = vi.fn();
+      const r = await handleMemoryReprocess(
+        mockConfig,
+        { bank: "coach-mem", docIds: ["evil-1"] } as never,
+        { inspect: inspect as never, trigger: trigger as never },
+      );
+      // No gaps from inspect → no-op, trigger never called with arbitrary ids.
+      expect(r.ok).toBe(true);
+      expect(r.triggered).toBe(0);
+      expect(trigger).not.toHaveBeenCalled();
+    });
+
+    it("maps a failed inspection to ok:false", async () => {
+      const inspect = vi.fn(async () => mkBankHealth({ ok: false, reason: "Timeout" }));
+      const r = await handleMemoryReprocess(mockConfig, { bank: "coach-mem" }, {
+        inspect: inspect as never,
+        trigger: vi.fn() as never,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("Timeout");
+    });
+
+    it("reports failed > 0 as ok:false but still surfaces counts", async () => {
+      const now = new Date();
+      const recent = new Date(now.getTime() - 86400000).toISOString();
+      const inspect = vi.fn(async () =>
+        mkBankHealth({
+          unextractedDocuments: [
+            { id: "doc-a", createdAt: recent, textLength: 5000, memoryUnitCount: 0 },
+          ],
+        }),
+      );
+      const trigger = vi.fn(async () => ({ triggered: 0, failed: 1, error: "HTTP 500" }));
+      const r = await handleMemoryReprocess(mockConfig, { bank: "coach-mem" }, {
+        inspect: inspect as never,
+        trigger: trigger as never,
+        now,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.failed).toBe(1);
+      expect(r.error).toBe("HTTP 500");
+    });
+
+    it("never throws — a throwing trigger is caught and mapped to ok:false", async () => {
+      const now = new Date();
+      const recent = new Date(now.getTime() - 86400000).toISOString();
+      const inspect = vi.fn(async () =>
+        mkBankHealth({
+          unextractedDocuments: [
+            { id: "doc-a", createdAt: recent, textLength: 5000, memoryUnitCount: 0 },
+          ],
+        }),
+      );
+      const trigger = vi.fn(async () => {
+        throw new Error("boom");
+      });
+      const r = await handleMemoryReprocess(mockConfig, { bank: "coach-mem" }, {
+        inspect: inspect as never,
+        trigger: trigger as never,
+        now,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("boom");
+    });
+  });
+
+  describe("handleMemoryRefreshModel", () => {
+    it("rejects an unknown bank", async () => {
+      const r = await handleMemoryRefreshModel(mockConfig, { bank: "nope", modelId: "m" }, {
+        inspect: vi.fn() as never,
+        trigger: vi.fn() as never,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("Unknown bank");
+    });
+
+    it("rejects a missing modelId", async () => {
+      const r = await handleMemoryRefreshModel(mockConfig, { bank: "coach-mem" }, {});
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("modelId");
+    });
+
+    it("rejects a modelId not belonging to the bank (no arbitrary POST)", async () => {
+      const inspect = vi.fn(async () =>
+        mkBankHealth({
+          mentalModels: [
+            { id: "mm-1", name: "user-profile", lastRefreshedAt: null, createdAt: null, contentLength: 10, contentHead: "x" },
+          ],
+        }),
+      );
+      const trigger = vi.fn();
+      const r = await handleMemoryRefreshModel(mockConfig, { bank: "coach-mem", modelId: "forged-id" }, {
+        inspect: inspect as never,
+        trigger: trigger as never,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("Unknown mental model");
+      expect(trigger).not.toHaveBeenCalled();
+    });
+
+    it("triggers a refresh for a valid model id", async () => {
+      const inspect = vi.fn(async () =>
+        mkBankHealth({
+          mentalModels: [
+            { id: "mm-1", name: "user-profile", lastRefreshedAt: null, createdAt: null, contentLength: 10, contentHead: "x" },
+          ],
+        }),
+      );
+      const trigger = vi.fn(async () => ({ ok: true as const }));
+      const r = await handleMemoryRefreshModel(mockConfig, { bank: "coach-mem", modelId: "mm-1" }, {
+        inspect: inspect as never,
+        trigger: trigger as never,
+      });
+      expect(r.ok).toBe(true);
+      expect(trigger).toHaveBeenCalledWith(
+        "http://127.0.0.1:18888",
+        "coach-mem",
+        "mm-1",
+        expect.anything(),
+      );
+    });
+
+    it("maps a trigger failure to ok:false with error", async () => {
+      const inspect = vi.fn(async () =>
+        mkBankHealth({
+          mentalModels: [
+            { id: "mm-1", name: "x", lastRefreshedAt: null, createdAt: null, contentLength: 0, contentHead: "" },
+          ],
+        }),
+      );
+      const trigger = vi.fn(async () => ({ ok: false, error: "HTTP 502" }));
+      const r = await handleMemoryRefreshModel(mockConfig, { bank: "coach-mem", modelId: "mm-1" }, {
+        inspect: inspect as never,
+        trigger: trigger as never,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toBe("HTTP 502");
+    });
+  });
+
+  describe("handleMemoryBuildProfile", () => {
+    it("rejects an unknown bank", async () => {
+      const trigger = vi.fn();
+      const r = await handleMemoryBuildProfile(mockConfig, { bank: "nope" }, {
+        trigger: trigger as never,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("Unknown bank");
+      expect(trigger).not.toHaveBeenCalled();
+    });
+
+    it("rejects a missing bank", async () => {
+      const r = await handleMemoryBuildProfile(mockConfig, {}, {});
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("bank");
+    });
+
+    it("triggers buildUserProfile with the MCP url (not the REST base)", async () => {
+      const trigger = vi.fn(async () => ({ ok: true }));
+      const r = await handleMemoryBuildProfile(mockConfig, { bank: "coach-mem" }, {
+        trigger: trigger as never,
+      });
+      expect(r.ok).toBe(true);
+      // buildUserProfile takes the MCP url (with /mcp/), not the REST base.
+      expect(trigger.mock.calls[0][0]).toBe("http://127.0.0.1:18888/mcp/");
+      expect(trigger.mock.calls[0][1]).toBe("coach-mem");
+    });
+
+    it("maps a trigger failure to ok:false", async () => {
+      const trigger = vi.fn(async () => ({ ok: false, error: "MCP error" }));
+      const r = await handleMemoryBuildProfile(mockConfig, { bank: "sage" }, {
+        trigger: trigger as never,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toBe("MCP error");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Directly answers the operator's complaint — *"the memory page doesn't give remediation options on errors"* (audit ranks 7 + 22). Each unhealthy bank state now has a direct fix button. **The web only POSTs to hindsight's REST API to TRIGGER the work; hindsight does the LLM extraction on its OWN `claude-code` provider. The web makes ZERO model calls** (no API/SDK/`claude -p`) — same subscription-honest shape as the existing direct quota-refresh button.

## What's added

- **`src/web/memory-remediation.ts`** — `reprocessDocuments` / `refreshMentalModel` / `buildUserProfile`: short-timeout, never-throwing `fetch` POSTs to the hindsight REST endpoints (`…/documents/<id>/reprocess`, `…/mental-models/<id>/refresh`) and `ensureUserProfileMentalModel`.
- **Three POST routes** (`/api/memory/reprocess`, `/refresh-model`, `/build-profile`) — each handler validates `bank` is a known fleet bank, **re-derives the gap doc ids server-side** from a live `inspectBankHealth` (client-passed ids ignored), and **validates `modelId`** against the bank's actual mental models. So the loopback-forgeable dashboard can't POST arbitrary ids. Never throws.
- **`handleGetMemoryHealth`** — exposes `unextractedDocIds` (first 20) + the rank-22 `pendingOperations` warn at doctor's precedence.
- **UI** — per-bank "Reprocess N docs" / "Refresh `<model>`" / "Build profile" buttons; each gated by `confirm()` (it consumes subscription quota), disabled + "working…" in flight, toast + re-fetch; onclick payloads escaped via `attrJson`.

## Subscription-honest / security

- **No model call from the web** — the new module imports only `bank-health`/`hindsight`; the sole outbound is `fetch` POSTs to hindsight (127.0.0.1:18888). Hindsight does the LLM work on its own provider.
- **Server-side validation** — a forged dashboard request can't target arbitrary docs/models; ids are re-derived/validated against the live bank inspect.

## Test plan

- [x] 11 trigger-helper tests (ok/failed counts, never-throw on a rejecting fetch, restBase strip) + handler tests (unknown-bank reject, client-id-ignored, modelId validation, success/failure)
- [x] `tsc --noEmit` clean; **293** web/memory tests pass; inline `<script>` `node --check` clean; PII guard clean

## Risk

Low–medium. Triggers subscription-quota work (bounded, confirm-gated, server-validated) — but no billed/API call, no docker, no config/credential mutation. Tests inject `fetch`, so no live hindsight is touched in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)