### PR TITLE
chore: release v0.15.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.15.28 — Dashboard favicon (#2373)
+
+The admin dashboard now serves the switchroom logo as its favicon (a
+transparent multi-size `favicon.ico` + apple-touch icon), instead of the
+generic browser-tab icon.
+
 ## v0.15.27 — Admin dashboard overhaul (#2363–2370)
 
 A full audit and rebuild of the `switchroom-web` admin dashboard. The web

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.15.27",
+  "version": "0.15.28",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.15.28 — dashboard favicon (#2373, already fresh-reviewed). Trivial diff; CI-green = ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)