### PR TITLE
feat(dashboard): per-cron schedule view — title, prompt, own fire history

### DIFF
--- a/src/config/overlay-loader.test.ts
+++ b/src/config/overlay-loader.test.ts
@@ -251,6 +251,21 @@ describe("applyAgentOverlays", () => {
     expect(JSON.stringify(sched[0])).not.toMatch(/overlay-title|school-alerts/i);
   });
 
+  it("does not bleed the next line into the title for a whitespace-only `# name:` header", () => {
+    const dir = overlayDir("foo");
+    // A malformed empty-value `# name:` header must NOT pull `schedule:` (the
+    // next line) in as the title — the regex stays on the comment's own line.
+    writeFileSync(
+      join(dir, "cron-feedface11.yaml"),
+      "# name:   \n" + "schedule:\n  - cron: '0 8 * * *'\n    prompt: p\n",
+    );
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    applyAgentOverlays(cfg);
+    const sched = cfg.agents.foo.schedule as Array<Record<symbol, unknown>>;
+    // No `# name:` value + hash-only filename → no title at all.
+    expect(sched[0][OVERLAY_TITLE]).toBeUndefined();
+  });
+
   it("leaves OVERLAY_TITLE undefined for a hash-only cron-<hash>.yaml with no `# name:`", () => {
     const dir = overlayDir("foo");
     writeFileSync(

--- a/src/config/overlay-loader.test.ts
+++ b/src/config/overlay-loader.test.ts
@@ -19,7 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { applyAgentOverlays, OVERLAY_SOURCE } from "./overlay-loader.js";
+import { applyAgentOverlays, OVERLAY_SOURCE, OVERLAY_TITLE } from "./overlay-loader.js";
 import type { SwitchroomConfig } from "./schema.js";
 
 /**
@@ -231,6 +231,67 @@ describe("applyAgentOverlays", () => {
     // Marker is non-enumerable: JSON.stringify must not surface it.
     const json = JSON.stringify(sched[1]);
     expect(json).not.toMatch(/overlay-source/i);
+  });
+
+  it("stamps OVERLAY_TITLE from a top-of-file `# name:` comment", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(
+      join(dir, "cron-deadbeef99.yaml"),
+      "# name: school-alerts-linear\n" +
+        "schedule:\n  - cron: '0 7 * * *'\n    prompt: check school portal\n",
+    );
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    applyAgentOverlays(cfg);
+    const sched = cfg.agents.foo.schedule as Array<Record<symbol, unknown>>;
+    expect(sched).toHaveLength(1);
+    // The `# name:` comment is authoritative even though the FILENAME is a
+    // generic cron-<hash> auto-name.
+    expect(sched[0][OVERLAY_TITLE]).toBe("school-alerts-linear");
+    // Non-enumerable: JSON.stringify must not surface it.
+    expect(JSON.stringify(sched[0])).not.toMatch(/overlay-title|school-alerts/i);
+  });
+
+  it("leaves OVERLAY_TITLE undefined for a hash-only cron-<hash>.yaml with no `# name:`", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(
+      join(dir, "cron-1a2b3c4d5e.yaml"),
+      "schedule:\n  - cron: '0 8 * * *'\n    prompt: no title here\n",
+    );
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    applyAgentOverlays(cfg);
+    const sched = cfg.agents.foo.schedule as Array<Record<symbol, unknown>>;
+    expect(sched).toHaveLength(1);
+    // A hash is not a meaningful title — must NOT be used as one.
+    expect(sched[0][OVERLAY_TITLE]).toBeUndefined();
+  });
+
+  it("derives OVERLAY_TITLE from a hand-named filename when there's no `# name:` comment", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(
+      join(dir, "weekend-planner.yaml"),
+      "schedule:\n  - cron: '0 9 * * 6'\n    prompt: plan the weekend\n",
+    );
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    applyAgentOverlays(cfg);
+    const sched = cfg.agents.foo.schedule as Array<Record<symbol, unknown>>;
+    expect(sched).toHaveLength(1);
+    expect(sched[0][OVERLAY_TITLE]).toBe("weekend-planner");
+  });
+
+  it("stamps the SAME title on every entry a multi-entry overlay file declares", () => {
+    const dir = overlayDir("foo");
+    writeFileSync(
+      join(dir, "morning-suite.yaml"),
+      "schedule:\n" +
+        "  - cron: '0 7 * * *'\n    prompt: first\n" +
+        "  - cron: '0 8 * * *'\n    prompt: second\n",
+    );
+    const cfg = makeConfig({ foo: { schedule: [] } });
+    applyAgentOverlays(cfg);
+    const sched = cfg.agents.foo.schedule as Array<Record<symbol, unknown>>;
+    expect(sched).toHaveLength(2);
+    expect(sched[0][OVERLAY_TITLE]).toBe("morning-suite");
+    expect(sched[1][OVERLAY_TITLE]).toBe("morning-suite");
   });
 
   it("accepts an empty overlay document (no schedule key)", () => {

--- a/src/config/overlay-loader.ts
+++ b/src/config/overlay-loader.ts
@@ -84,7 +84,10 @@ export const OVERLAY_TITLE = Symbol.for("switchroom.config.overlay-title");
  * `fileName` is the basename (e.g. "weekend-planner.yaml").
  */
 function deriveOverlayTitle(raw: string, fileName: string): string | undefined {
-  const titleFromComment = raw.match(/^#\s*name:\s*(\S.*?)\s*$/m)?.[1];
+  // `[^\S\n]` = whitespace but NOT a newline, so the inter-token spacing
+  // stays on the comment's own line: a whitespace-only `# name:   ` header
+  // can't consume the newline and bleed the NEXT line in as the title.
+  const titleFromComment = raw.match(/^#[^\S\n]*name:[^\S\n]*(\S.*?)[^\S\n]*$/m)?.[1];
   if (titleFromComment) return titleFromComment;
   const base = fileName.replace(/\.ya?ml$/i, "");
   // Generic auto-generated name (cron-<6+ hex>) carries no title.

--- a/src/config/overlay-loader.ts
+++ b/src/config/overlay-loader.ts
@@ -32,7 +32,7 @@
  * is tracked separately for #1163 Phase 2 follow-up).
  */
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { ZodError } from "zod";
 import type { ScheduleEntry, SwitchroomConfig } from "./schema.js";
@@ -50,6 +50,47 @@ import { resolveDualPath } from "./paths.js";
  * agent-facing config view.
  */
 export const OVERLAY_SOURCE = Symbol.for("switchroom.config.overlay-source");
+
+/**
+ * Marker stamped on every overlay-sourced schedule entry carrying the
+ * human-readable *title* for the cron the file defines. Derived from a
+ * top-of-file `# name: <title>` comment if present, else the file's
+ * basename (sans extension) UNLESS that basename is a generic
+ * auto-generated `cron-<hash>` name — in which case there's no
+ * meaningful title and the marker is left unset.
+ *
+ * Read downstream by `collectScheduleEntries` (`scheduler/dispatch.ts`)
+ * to populate `SchedulerEntry.name`, which the dashboard's Schedule tab
+ * renders as the per-cron block header.
+ *
+ * Like {@link OVERLAY_SOURCE} it's a Symbol so it stays invisible to
+ * JSON-serialisation paths (scaffold writes, audit logs) and won't bleed
+ * into the agent-facing config view.
+ */
+export const OVERLAY_TITLE = Symbol.for("switchroom.config.overlay-title");
+
+/**
+ * Derive a human title for the cron(s) declared in an overlay file.
+ *
+ *   1. A top-of-file `# name: <title>` comment wins (authoritative even
+ *      when the filename is a `cron-<hash>.yaml` auto-name).
+ *   2. Otherwise the filename basename without its extension — a
+ *      hand-named `weekend-planner.yaml` → "weekend-planner".
+ *   3. EXCEPT a generic auto-generated `cron-<hash>` basename (the
+ *      overlay-writer's default for an un-named cron): that hash is not
+ *      a meaningful title, so return undefined.
+ *
+ * `raw` is the file's raw text (pre-YAML-parse, so the comment survives);
+ * `fileName` is the basename (e.g. "weekend-planner.yaml").
+ */
+function deriveOverlayTitle(raw: string, fileName: string): string | undefined {
+  const titleFromComment = raw.match(/^#\s*name:\s*(\S.*?)\s*$/m)?.[1];
+  if (titleFromComment) return titleFromComment;
+  const base = fileName.replace(/\.ya?ml$/i, "");
+  // Generic auto-generated name (cron-<6+ hex>) carries no title.
+  if (/^cron-[0-9a-f]{6,}$/i.test(base)) return undefined;
+  return base.length > 0 ? base : undefined;
+}
 
 export interface OverlayWarning {
   agent: string;
@@ -94,7 +135,7 @@ function listYamlFiles(dir: string): string[] {
   return out.sort(); // stable load order for deterministic merging
 }
 
-function stampOverlay(entry: ScheduleEntry): ScheduleEntry {
+function stampOverlay(entry: ScheduleEntry, title?: string): ScheduleEntry {
   // Non-enumerable so JSON.stringify / structured logs ignore it. The
   // marker is read by downstream consumers via `(entry as any)[OVERLAY_SOURCE]`.
   Object.defineProperty(entry, OVERLAY_SOURCE, {
@@ -103,6 +144,17 @@ function stampOverlay(entry: ScheduleEntry): ScheduleEntry {
     configurable: false,
     writable: false,
   });
+  // Stamp the human title only when the file actually carries one (a
+  // `# name:` comment or a meaningful filename) — a hash-only filename
+  // leaves it unset so downstream can fall back to the cron expression.
+  if (title !== undefined) {
+    Object.defineProperty(entry, OVERLAY_TITLE, {
+      value: title,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+  }
   return entry;
 }
 
@@ -148,6 +200,11 @@ export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResul
           const parsed = parseYaml(raw);
           const doc = OverlayDocSchema.parse(parsed);
 
+          // Title is per-FILE (one overlay file = one logical cron the
+          // operator/agent named) — derive once from the raw text +
+          // basename, then stamp every entry the file declares.
+          const title = deriveOverlayTitle(raw, basename(file));
+
           for (const entry of doc.schedule ?? []) {
             if (entry.secrets && entry.secrets.length > 0) {
               const w: OverlayWarning = {
@@ -162,7 +219,7 @@ export function applyAgentOverlays(config: SwitchroomConfig): ApplyOverlaysResul
               );
               continue;
             }
-            merged.push(stampOverlay(entry));
+            merged.push(stampOverlay(entry, title));
           }
 
           // Phase 2 (#1163) — schedule.d files MAY also declare a

--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -2223,8 +2223,14 @@ function tail(s: string, bytes = TAIL_BYTES): string {
 export const SCHEDULE_PROMPT_MAX_CHARS = 160;
 /** Max chars retained from a fire's `outputSummary` in the bounded payload. */
 export const SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS = 100;
-/** Max recent fires retained per agent in the bounded payload. */
-export const SCHEDULE_MAX_FIRES_PER_AGENT = 8;
+/**
+ * Max recent fires retained PER CRON (keyed by promptKey) in the bounded
+ * payload. The dashboard renders each cron's OWN fire history, so fires are
+ * bounded per-cron — a busy cron must not crowd a quiet one out of the
+ * agent's window (the old per-agent cap did exactly that). The frame budget
+ * below is the absolute backstop for an agent with pathologically many crons.
+ */
+export const SCHEDULE_MAX_FIRES_PER_CRON = 8;
 /**
  * Hard ceiling on the bytes the `agent_schedule` payload contributes to the
  * response FRAME. The payload is JSON-encoded then embedded as a STRING in
@@ -2257,6 +2263,9 @@ function slimScheduleEntry(e: SchedulerEntry): SchedulerEntry {
     cron: e.cron,
     promptKey: e.promptKey,
   };
+  // The cron's human title (overlay `# name:` header) — a small string,
+  // and the per-cron block header the dashboard renders, so keep it.
+  if (e.name !== undefined) slim.name = e.name;
   if (e.prompt !== undefined) {
     slim.prompt =
       e.prompt.length > SCHEDULE_PROMPT_MAX_CHARS
@@ -2283,8 +2292,8 @@ function scheduleFrameBytes(view: BoundedScheduleView): number {
  * it can be unit-tested without a daemon). It (a) projects each entry to a
  * render-only slim shape (dropping the unbounded poll/action specs) with a
  * truncated prompt, (b) keeps only the LAST
- * {@link SCHEDULE_MAX_FIRES_PER_AGENT} fires per agent (newest) with each
- * `outputSummary` truncated, and (c) enforces a HARD frame budget: if the
+ * {@link SCHEDULE_MAX_FIRES_PER_CRON} fires PER CRON (by promptKey, newest)
+ * with each `outputSummary` truncated, and (c) enforces a HARD frame budget: if the
  * payload would still exceed {@link SCHEDULE_FRAME_BUDGET_BYTES} (a
  * pathological fleet — hundreds of entries), it sheds the least-essential
  * data first (all fires, then entries from the tail) until it fits, setting
@@ -2296,16 +2305,27 @@ export function boundScheduleView(
   recentByAgent: Record<string, DispatchResult[]>,
 ): BoundedScheduleView {
   const slimEntries = entries.map(slimScheduleEntry);
+  const truncSummary = (r: DispatchResult): DispatchResult =>
+    typeof r.outputSummary === "string" &&
+    r.outputSummary.length > SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS
+      ? { ...r, outputSummary: r.outputSummary.slice(0, SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS) }
+      : { ...r };
   const boundedRecent: Record<string, DispatchResult[]> = {};
   for (const [agent, rows] of Object.entries(recentByAgent)) {
-    boundedRecent[agent] = rows
-      .slice(-SCHEDULE_MAX_FIRES_PER_AGENT)
-      .map((r) =>
-        typeof r.outputSummary === "string" &&
-        r.outputSummary.length > SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS
-          ? { ...r, outputSummary: r.outputSummary.slice(0, SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS) }
-          : { ...r },
-      );
+    // Bound fires PER CRON (promptKey), not per agent — the dashboard renders
+    // each cron's own fire history, so keep the last N of EACH cron. Group
+    // preserving input (chronological) order, keep the newest N per key.
+    const byKey = new Map<string, DispatchResult[]>();
+    for (const r of rows) {
+      const arr = byKey.get(r.promptKey);
+      if (arr) arr.push(r);
+      else byKey.set(r.promptKey, [r]);
+    }
+    const kept: DispatchResult[] = [];
+    for (const arr of byKey.values()) {
+      for (const r of arr.slice(-SCHEDULE_MAX_FIRES_PER_CRON)) kept.push(truncSummary(r));
+    }
+    boundedRecent[agent] = kept;
   }
 
   let view: BoundedScheduleView = { entries: slimEntries, recentByAgent: boundedRecent };

--- a/src/scheduler/collect-entries.test.ts
+++ b/src/scheduler/collect-entries.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, it, expect } from "vitest";
 import { collectScheduleEntries } from "./dispatch.js";
+import { OVERLAY_TITLE } from "../config/overlay-loader.js";
 import type { SwitchroomConfig } from "../config/schema.js";
 
 function configFromAgents(
@@ -137,6 +138,42 @@ describe("collectScheduleEntries — cascade resolution", () => {
     // No prompt on an action; the audit key is still present + non-empty.
     expect(entries[0]?.prompt).toBeUndefined();
     expect(entries[0]?.promptKey).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it("surfaces an OVERLAY_TITLE-stamped raw entry as SchedulerEntry.name", () => {
+    const cfg = configFromAgents({
+      alice: {
+        schedule: [
+          // Mirror what the overlay loader stamps: a non-enumerable
+          // OVERLAY_TITLE symbol on the raw entry object.
+          (() => {
+            const e: Record<string | symbol, unknown> = {
+              cron: "0 7 * * *",
+              prompt: "morning briefing",
+            };
+            Object.defineProperty(e, OVERLAY_TITLE, {
+              value: "school-alerts-linear",
+              enumerable: false,
+              configurable: false,
+              writable: false,
+            });
+            return e;
+          })(),
+        ],
+      },
+    });
+    const entries = collectScheduleEntries(cfg);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.name).toBe("school-alerts-linear");
+  });
+
+  it("leaves SchedulerEntry.name undefined for an un-stamped (base-config) entry", () => {
+    const cfg = configFromAgents({
+      alice: { schedule: [{ cron: "0 8 * * *", prompt: "no title" }] },
+    });
+    const entries = collectScheduleEntries(cfg);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.name).toBeUndefined();
   });
 
   it("empty defaults + empty profile + empty agent yields no entries (no false positives)", () => {

--- a/src/scheduler/dispatch.ts
+++ b/src/scheduler/dispatch.ts
@@ -21,11 +21,21 @@
 import { createHash } from "node:crypto";
 import type { ActionSpec, PollSpec, ScheduleEntry, SwitchroomConfig } from "../config/schema.js";
 import { resolveAgentConfig } from "../config/merge.js";
+import { OVERLAY_TITLE } from "../config/overlay-loader.js";
 
 export interface SchedulerEntry {
   agent: string;
   scheduleIndex: number;
   cron: string;
+  /**
+   * Human-readable title for this cron, surfaced in the dashboard's
+   * Schedule tab as the per-cron block header. Sourced from an overlay
+   * file's top-of-file `# name:` comment (or a meaningful filename) via
+   * the `OVERLAY_TITLE` symbol the overlay loader stamps. Absent for
+   * base-config crons and for hash-only overlay filenames (no
+   * meaningful title) — the UI falls back to the cron expression.
+   */
+  name?: string;
   /** The model-fire text (prompt/poll). Absent for kind=action — an action
    *  never fires a model, so it has no prompt. */
   prompt?: string;
@@ -88,10 +98,16 @@ export function collectScheduleEntries(
       // An action has no prompt; key the audit off its spec instead so the
       // promptKey stays a stable, non-reversible correlation id.
       const auditMaterial = entry.prompt ?? `action:${JSON.stringify(entry.action ?? {})}`;
+      // Human title: stamped by the overlay loader on the raw entry via the
+      // non-enumerable OVERLAY_TITLE symbol (survives the cascade-merge
+      // spread, same as OVERLAY_SOURCE). Absent for base-config crons and
+      // hash-only overlay filenames.
+      const title = (entry as Record<symbol, unknown>)[OVERLAY_TITLE];
       out.push({
         agent,
         scheduleIndex: i,
         cron: entry.cron,
+        ...(typeof title === "string" && title.length > 0 ? { name: title } : {}),
         ...(entry.prompt !== undefined ? { prompt: entry.prompt } : {}),
         promptKey: createHash("sha256").update(auditMaterial).digest("hex").slice(0, 12),
         // Propagate the per-entry topic override (PR1 schema field).

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -1919,37 +1919,81 @@
         return;
       }
       const dim = (s) => `<span style="color:var(--text-dim)">${escapeHtml(s)}</span>`;
-      // Group entries by agent.
+      // Group entries by agent. Agents sorted by name; within an agent the
+      // entries keep their cascade-given order (defaults → profile → agent →
+      // overlays), which is the order the operator/agent declared them.
       const byAgent = {};
       for (const e of entries) (byAgent[e.agent] ||= []).push(e);
-      const cards = Object.keys(byAgent).sort().map(agent => {
-        const rows = byAgent[agent].map(e => `
-          <tr>
-            <td><code>${escapeHtml(e.cron)}</code></td>
-            <td title="${escapeHtml(e.prompt)}">${escapeHtml(e.prompt.length > 70 ? e.prompt.slice(0, 70) + '…' : e.prompt)}</td>
-          </tr>`).join('');
-        const fires = (recent[agent] || []).slice().reverse();
-        const fireRows = fires.length === 0
-          ? `<tr><td colspan="3">${dim('no recorded fires yet')}</td></tr>`
+
+      // One self-contained block per cron: title (or cron expr as fallback
+      // heading) + badges, the prompt, then THIS cron's recent fires right
+      // below it. Fires are matched to a cron by promptKey — both the entry
+      // and each DispatchResult carry the same stable SHA. (Edge: two
+      // entries with an identical prompt share a promptKey, so they'd share
+      // the same fire list — acceptable; identical prompts are
+      // indistinguishable in the audit ledger by design.)
+      const renderCron = (e, agentFires) => {
+        const hasTitle = typeof e.name === 'string' && e.name.length > 0;
+        const heading = hasTitle
+          ? `<span style="font-weight:600;color:var(--text)">${escapeHtml(e.name)}</span>`
+          : `<span style="color:var(--text-dim)">${escapeHtml(e.cron)}</span>`;
+        const badges = []
+          .concat(e.kind ? [e.kind] : [])
+          .concat(e.model ? [e.model] : [])
+          .concat(e.context ? [e.context] : [])
+          .map(b => `<span class="chip">${escapeHtml(String(b))}</span>`)
+          .join('');
+        // Prompt: kind:action entries have no prompt (the action is
+        // model-free), so show a muted marker rather than a blank line.
+        const promptText = typeof e.prompt === 'string' ? e.prompt : '';
+        const promptBlock = promptText
+          ? `<div style="margin:.4rem 0 .55rem;color:var(--text);font-size:.84rem" title="${escapeHtml(promptText)}">${escapeHtml(promptText.length > 140 ? promptText.slice(0, 140) + '…' : promptText)}</div>`
+          : `<div style="margin:.4rem 0 .55rem">${dim(e.kind === 'action' ? 'model-free action' : '—')}</div>`;
+        // Recent fires for THIS cron only — filter the agent's fire list by
+        // matching promptKey, newest-first, last 8.
+        const fires = agentFires
+          .filter(f => f.promptKey === e.promptKey)
+          .slice()
+          .reverse()
+          .slice(0, 8);
+        const fireList = fires.length === 0
+          ? `<div style="font-size:.78rem">${dim('no recorded fires yet')}</div>`
           : fires.map(f => {
               const ok = f.exitCode === 0;
-              return `<tr>
-                <td><span class="status-dot ${ok ? 'active' : 'inactive'}" style="display:inline-block;vertical-align:middle"></span> ${escapeHtml(shortTs(new Date(f.startedAt).toISOString()))}</td>
-                <td>${escapeHtml(String(f.outputSummary || '').slice(0, 80))}</td>
-                <td>${ok ? 'ok' : 'exit ' + escapeHtml(String(f.exitCode))}</td>
-              </tr>`;
+              const when = escapeHtml(shortTs(new Date(f.startedAt).toISOString()));
+              const summary = String(f.outputSummary || '');
+              const summaryHtml = summary
+                ? ' · <span style="color:var(--text-dim)">' + escapeHtml(summary.length > 70 ? summary.slice(0, 70) + '…' : summary) + '</span>'
+                : '';
+              return `<div style="font-size:.78rem;line-height:1.55">
+                <span class="status-dot ${ok ? 'active' : 'inactive'}" style="display:inline-block;vertical-align:middle;margin-right:.35rem"></span>${when} · ${ok ? 'ok' : 'exit ' + escapeHtml(String(f.exitCode))}${summaryHtml}
+              </div>`;
             }).join('');
+        return `
+          <div style="border:1px solid var(--border);border-radius:8px;padding:.7rem .85rem;margin-bottom:.7rem;background:var(--surface-hover)">
+            <div style="display:flex;align-items:center;gap:.5rem;flex-wrap:wrap">
+              ${heading}
+              <code style="font-size:.78rem">${escapeHtml(e.cron)}</code>
+              ${badges}
+            </div>
+            ${promptBlock}
+            <div style="border-top:1px solid var(--border);padding-top:.5rem">
+              <div style="font-size:.72rem;color:var(--text-dim);margin-bottom:.3rem">Recent fires</div>
+              ${fireList}
+            </div>
+          </div>`;
+      };
+
+      const cards = Object.keys(byAgent).sort().map(agent => {
+        const agentFires = recent[agent] || [];
+        const list = byAgent[agent].map(e => renderCron(e, agentFires)).join('');
         return `
         <div class="agent-card" style="margin-bottom:1rem">
           <div class="card-header" style="cursor:default">
             <span class="agent-name">${escapeHtml(agent)}</span>
             <span class="agent-topic">${byAgent[agent].length} schedule entr${byAgent[agent].length === 1 ? 'y' : 'ies'}</span>
           </div>
-          <div style="padding:0 1.25rem 1rem">
-            <table class="accounts-table"><thead><tr><th>Cron</th><th>Prompt</th></tr></thead><tbody>${rows}</tbody></table>
-            <div style="margin-top:0.6rem;font-size:0.8rem;color:var(--text-dim)">Recent fires (from scheduler.jsonl)</div>
-            <table class="accounts-table"><thead><tr><th>When</th><th>Result</th><th>Exit</th></tr></thead><tbody>${fireRows}</tbody></table>
-          </div>
+          <div style="padding:.5rem 1.25rem 1rem">${list}</div>
         </div>`;
       }).join('');
       container.innerHTML = degradedBanner + truncatedNote + cards;

--- a/tests/host-control/bound-schedule-view.test.ts
+++ b/tests/host-control/bound-schedule-view.test.ts
@@ -10,7 +10,7 @@ import {
   boundScheduleView,
   SCHEDULE_PROMPT_MAX_CHARS,
   SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS,
-  SCHEDULE_MAX_FIRES_PER_AGENT,
+  SCHEDULE_MAX_FIRES_PER_CRON,
   SCHEDULE_FRAME_BUDGET_BYTES,
 } from "../../src/host-control/server.js";
 import type { SchedulerEntry, DispatchResult } from "../../src/scheduler/dispatch.js";
@@ -74,17 +74,31 @@ describe("boundScheduleView", () => {
     );
   });
 
-  it("keeps only the LAST N fires per agent (newest)", () => {
-    const many = Array.from({ length: SCHEDULE_MAX_FIRES_PER_AGENT + 5 }, (_, i) =>
-      fire({ startedAt: i, finishedAt: i + 1, exitCode: i }),
+  it("keeps only the LAST N fires of a single cron (newest)", () => {
+    const many = Array.from({ length: SCHEDULE_MAX_FIRES_PER_CRON + 5 }, (_, i) =>
+      fire({ promptKey: "k1", startedAt: i, finishedAt: i + 1, exitCode: i }),
     );
     const { recentByAgent } = boundScheduleView([], { clerk: many });
-    expect(recentByAgent.clerk).toHaveLength(SCHEDULE_MAX_FIRES_PER_AGENT);
+    expect(recentByAgent.clerk).toHaveLength(SCHEDULE_MAX_FIRES_PER_CRON);
     // The last fire (highest startedAt) survives; the oldest is dropped.
     expect(recentByAgent.clerk.at(-1)!.startedAt).toBe(
-      SCHEDULE_MAX_FIRES_PER_AGENT + 4,
+      SCHEDULE_MAX_FIRES_PER_CRON + 4,
     );
     expect(recentByAgent.clerk[0].startedAt).toBe(5);
+  });
+
+  it("bounds fires PER CRON (promptKey) — a busy cron can't crowd a quiet one out", () => {
+    // One agent, two crons: a busy cron (many fires) + a quiet cron (2 fires).
+    const busy = Array.from({ length: SCHEDULE_MAX_FIRES_PER_CRON + 10 }, (_, i) =>
+      fire({ promptKey: "busy", startedAt: i }),
+    );
+    const quiet = [fire({ promptKey: "quiet", startedAt: 1000 }), fire({ promptKey: "quiet", startedAt: 1001 })];
+    const { recentByAgent } = boundScheduleView([], { clerk: [...busy, ...quiet] });
+    const byKey = (k: string) => recentByAgent.clerk.filter((f) => f.promptKey === k);
+    // Busy cron capped at N; quiet cron's 2 fires SURVIVE (the old per-agent
+    // cap would have dropped them entirely).
+    expect(byKey("busy")).toHaveLength(SCHEDULE_MAX_FIRES_PER_CRON);
+    expect(byKey("quiet")).toHaveLength(2);
   });
 
   it("does not mutate the input objects (purity)", () => {
@@ -133,6 +147,43 @@ describe("boundScheduleView", () => {
     // …unbounded specs dropped.
     expect(e.action).toBeUndefined();
     expect(e.poll).toBeUndefined();
+  });
+
+  it("carries the entry's `name` (cron title) through the slim projection", () => {
+    const { entries } = boundScheduleView(
+      [entry({ name: "school-alerts-linear", prompt: "check portal" })],
+      {},
+    );
+    expect(entries[0].name).toBe("school-alerts-linear");
+  });
+
+  it("omits `name` when the entry has none (base-config / hash-only cron)", () => {
+    const { entries } = boundScheduleView([entry({ prompt: "untitled" })], {});
+    expect(entries[0].name).toBeUndefined();
+  });
+
+  it("preserves each fire's promptKey (the cron↔fire match key)", () => {
+    const { recentByAgent } = boundScheduleView([], {
+      clerk: [
+        fire({ promptKey: "cron-a-key", outputSummary: "ok" }),
+        fire({ promptKey: "cron-b-key", outputSummary: "ok" }),
+      ],
+    });
+    expect(recentByAgent.clerk.map((f) => f.promptKey)).toEqual([
+      "cron-a-key",
+      "cron-b-key",
+    ]);
+  });
+
+  it("preserves promptKey even on a fire whose outputSummary is truncated", () => {
+    const long = "y".repeat(SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS + 50);
+    const { recentByAgent } = boundScheduleView([], {
+      clerk: [fire({ promptKey: "kept-key", outputSummary: long })],
+    });
+    expect(recentByAgent.clerk[0].promptKey).toBe("kept-key");
+    expect(recentByAgent.clerk[0].outputSummary).toHaveLength(
+      SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS,
+    );
   });
 
   it("enforces a hard frame budget — a pathological fleet is truncated and fits", () => {


### PR DESCRIPTION
## Summary

The Schedule tab grouped all of an agent's crons into one table, then a single agent-wide fires table — so you couldn't tell which fire belonged to which cron. Now **each cron is a self-contained block**: its **title** (if any), cron expression + kind/model/context badges, **prompt**, and **its own recent fire history right below it**.

## What's added

- **`SchedulerEntry.name`** — the cron's human title. `overlay-loader` captures it from the overlay file's top `# name:` header (authoritative even when the filename is a `cron-<hash>.yaml` auto-name), else a meaningful filename, else none — stamped via a new non-enumerable `OVERLAY_TITLE` symbol (mirrors `OVERLAY_SOURCE`). `collectScheduleEntries` reads it; `slimScheduleEntry` carries it through the hostd `agent_schedule` payload.
- **Per-cron fire matching by `promptKey`** (the stable SHA both the entry and each `DispatchResult` carry). **`boundScheduleView` now bounds fires PER CRON** (last 8 of each `promptKey`), not per agent — the old per-agent cap let a busy cron crowd a quiet one out of the window entirely (a multi-cron agent would show most crons as "no fires").
- **`renderSchedule` rebuilt** into per-cron blocks: bold title (or cron-expr fallback), badges, truncated prompt (full text in `title=`), and this cron's last-8 fires newest-first. `escapeHtml` on every value. Also fixes a **latent crash**: the old renderer called `escapeHtml(e.prompt)` unguarded, which threw on `kind:action` entries that have no prompt.

## Test plan

- [x] overlay title capture (`# name:` wins / `cron-<hash>` → none / filename fallback / multi-entry file)
- [x] `collectScheduleEntries` surfaces `name`; `slimScheduleEntry` keeps it
- [x] **per-cron fire bounding** (busy cron capped at 8, quiet cron's fires survive)
- [x] `tsc` clean; **501** host-control/scheduler/config tests + web suite pass; inline `<script>` `node --check` clean; both lint guards clean

## Risk

Low. Backend is a small data-shape addition (a symbol-stamped title + per-cron fire grouping); UI is render-only. No model call, no docker. Frame budget unchanged (the per-cron payload is bounded by the same hard frame trim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)