### PR TITLE
chore: release v0.15.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.15.29 — Per-cron Schedule view (#2375)
+
+The dashboard Schedule tab now shows each cron as a self-contained block —
+its title (captured from the overlay file's `# name:` header), cron
+expression + routing badges, prompt, and its OWN recent fire history right
+below it (matched by `promptKey`) — instead of a flat per-agent table with a
+separate agent-wide fires table. Fires are now bounded per-cron, so a busy
+cron no longer crowds a quiet one out of the window.
+
 ## v0.15.28 — Dashboard favicon (#2373)
 
 The admin dashboard now serves the switchroom logo as its favicon (a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.15.28",
+  "version": "0.15.29",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.15.29 — per-cron Schedule view (#2375, fresh-reviewed). Trivial diff; CI-green = ship. 🤖