### PR TITLE
fix(dashboard): restore per-cron fire history (drop obsolete-cron fires)

### DIFF
--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -2310,13 +2310,29 @@ export function boundScheduleView(
     r.outputSummary.length > SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS
       ? { ...r, outputSummary: r.outputSummary.slice(0, SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS) }
       : { ...r };
+  // The promptKeys of the CURRENT crons, per agent. Fires whose promptKey
+  // isn't a current cron are dropped — they're obsolete (a cron's prompt was
+  // edited → new key) and the dashboard, which matches fires to a cron by
+  // promptKey, would never render them anyway. Critically this also BOUNDS
+  // the payload to (current crons × N): a long-lived agent accumulates fires
+  // for many obsolete keys (e.g. 21 keys / 2638 fires), and keeping 8 of EACH
+  // blew the frame budget → the trim shed ALL fires. Bounding to current crons
+  // keeps it small.
+  const currentKeysByAgent = new Map<string, Set<string>>();
+  for (const e of entries) {
+    let s = currentKeysByAgent.get(e.agent);
+    if (!s) { s = new Set<string>(); currentKeysByAgent.set(e.agent, s); }
+    s.add(e.promptKey);
+  }
   const boundedRecent: Record<string, DispatchResult[]> = {};
   for (const [agent, rows] of Object.entries(recentByAgent)) {
+    const currentKeys = currentKeysByAgent.get(agent) ?? new Set<string>();
     // Bound fires PER CRON (promptKey), not per agent — the dashboard renders
-    // each cron's own fire history, so keep the last N of EACH cron. Group
-    // preserving input (chronological) order, keep the newest N per key.
+    // each cron's own fire history, so keep the last N of EACH current cron.
+    // Group preserving input (chronological) order, keep the newest N per key.
     const byKey = new Map<string, DispatchResult[]>();
     for (const r of rows) {
+      if (!currentKeys.has(r.promptKey)) continue; // drop obsolete-cron fires
       const arr = byKey.get(r.promptKey);
       if (arr) arr.push(r);
       else byKey.set(r.promptKey, [r]);
@@ -2325,7 +2341,7 @@ export function boundScheduleView(
     for (const arr of byKey.values()) {
       for (const r of arr.slice(-SCHEDULE_MAX_FIRES_PER_CRON)) kept.push(truncSummary(r));
     }
-    boundedRecent[agent] = kept;
+    if (kept.length > 0) boundedRecent[agent] = kept;
   }
 
   let view: BoundedScheduleView = { entries: slimEntries, recentByAgent: boundedRecent };

--- a/tests/host-control/bound-schedule-view.test.ts
+++ b/tests/host-control/bound-schedule-view.test.ts
@@ -66,7 +66,7 @@ describe("boundScheduleView", () => {
 
   it("truncates each fire's outputSummary to the cap", () => {
     const long = "y".repeat(SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS + 50);
-    const { recentByAgent } = boundScheduleView([], {
+    const { recentByAgent } = boundScheduleView([entry()], {
       clerk: [fire({ outputSummary: long })],
     });
     expect(recentByAgent.clerk[0].outputSummary).toHaveLength(
@@ -78,7 +78,7 @@ describe("boundScheduleView", () => {
     const many = Array.from({ length: SCHEDULE_MAX_FIRES_PER_CRON + 5 }, (_, i) =>
       fire({ promptKey: "k1", startedAt: i, finishedAt: i + 1, exitCode: i }),
     );
-    const { recentByAgent } = boundScheduleView([], { clerk: many });
+    const { recentByAgent } = boundScheduleView([entry({ promptKey: "k1" })], { clerk: many });
     expect(recentByAgent.clerk).toHaveLength(SCHEDULE_MAX_FIRES_PER_CRON);
     // The last fire (highest startedAt) survives; the oldest is dropped.
     expect(recentByAgent.clerk.at(-1)!.startedAt).toBe(
@@ -93,12 +93,30 @@ describe("boundScheduleView", () => {
       fire({ promptKey: "busy", startedAt: i }),
     );
     const quiet = [fire({ promptKey: "quiet", startedAt: 1000 }), fire({ promptKey: "quiet", startedAt: 1001 })];
-    const { recentByAgent } = boundScheduleView([], { clerk: [...busy, ...quiet] });
+    const { recentByAgent } = boundScheduleView(
+      [entry({ promptKey: "busy" }), entry({ promptKey: "quiet" })],
+      { clerk: [...busy, ...quiet] },
+    );
     const byKey = (k: string) => recentByAgent.clerk.filter((f) => f.promptKey === k);
     // Busy cron capped at N; quiet cron's 2 fires SURVIVE (the old per-agent
     // cap would have dropped them entirely).
     expect(byKey("busy")).toHaveLength(SCHEDULE_MAX_FIRES_PER_CRON);
     expect(byKey("quiet")).toHaveLength(2);
+  });
+
+  it("drops fires for OBSOLETE crons (promptKey not among current entries)", () => {
+    // A long-lived agent accumulates fires for old prompt versions (edited
+    // crons → new keys). Those must be dropped — the UI matches fires to a
+    // current cron by promptKey, and keeping them blew the frame budget.
+    const { recentByAgent } = boundScheduleView([entry({ promptKey: "current" })], {
+      clerk: [
+        fire({ promptKey: "current", startedAt: 1 }),
+        fire({ promptKey: "obsolete-v1", startedAt: 2 }),
+        fire({ promptKey: "obsolete-v2", startedAt: 3 }),
+      ],
+    });
+    expect(recentByAgent.clerk).toHaveLength(1);
+    expect(recentByAgent.clerk[0].promptKey).toBe("current");
   });
 
   it("does not mutate the input objects (purity)", () => {
@@ -112,10 +130,13 @@ describe("boundScheduleView", () => {
   });
 
   it("passes through multiple agents independently", () => {
-    const { recentByAgent } = boundScheduleView([], {
-      clerk: [fire({ agent: "clerk" })],
-      marko: [fire({ agent: "marko" }), fire({ agent: "marko" })],
-    });
+    const { recentByAgent } = boundScheduleView(
+      [entry({ agent: "clerk" }), entry({ agent: "marko" })],
+      {
+        clerk: [fire({ agent: "clerk" })],
+        marko: [fire({ agent: "marko" }), fire({ agent: "marko" })],
+      },
+    );
     expect(recentByAgent.clerk).toHaveLength(1);
     expect(recentByAgent.marko).toHaveLength(2);
   });
@@ -163,12 +184,15 @@ describe("boundScheduleView", () => {
   });
 
   it("preserves each fire's promptKey (the cron↔fire match key)", () => {
-    const { recentByAgent } = boundScheduleView([], {
-      clerk: [
-        fire({ promptKey: "cron-a-key", outputSummary: "ok" }),
-        fire({ promptKey: "cron-b-key", outputSummary: "ok" }),
-      ],
-    });
+    const { recentByAgent } = boundScheduleView(
+      [entry({ promptKey: "cron-a-key" }), entry({ promptKey: "cron-b-key" })],
+      {
+        clerk: [
+          fire({ promptKey: "cron-a-key", outputSummary: "ok" }),
+          fire({ promptKey: "cron-b-key", outputSummary: "ok" }),
+        ],
+      },
+    );
     expect(recentByAgent.clerk.map((f) => f.promptKey)).toEqual([
       "cron-a-key",
       "cron-b-key",
@@ -177,7 +201,7 @@ describe("boundScheduleView", () => {
 
   it("preserves promptKey even on a fire whose outputSummary is truncated", () => {
     const long = "y".repeat(SCHEDULE_OUTPUT_SUMMARY_MAX_CHARS + 50);
-    const { recentByAgent } = boundScheduleView([], {
+    const { recentByAgent } = boundScheduleView([entry({ promptKey: "kept-key" })], {
       clerk: [fire({ promptKey: "kept-key", outputSummary: long })],
     });
     expect(recentByAgent.clerk[0].promptKey).toBe("kept-key");

--- a/tests/host-control/server.test.ts
+++ b/tests/host-control/server.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { mkdtempSync, writeFileSync, chmodSync, rmSync, mkdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 import { HostdServer } from "../../src/host-control/server.js";
 import { hostdRequest } from "../../src/host-control/client.js";
 
@@ -1374,11 +1375,16 @@ describe("hostd server — dashboard read-ops (agent_status / agent_schedule)", 
     // Seed a scheduler.jsonl with > 8 fires + a long outputSummary so the
     // bound payload exercises both truncation paths.
     mkdirSync(join(agentsDir, "klanker"), { recursive: true });
+    // Fires must carry the base cron's REAL promptKey (sha256(prompt) prefix,
+    // as collectScheduleEntries computes it) so boundScheduleView's
+    // current-cron filter keeps them — fires for a key no current cron owns
+    // are dropped as obsolete.
+    const baseKey = createHash("sha256").update("p".repeat(300)).digest("hex").slice(0, 12);
     const rows = Array.from({ length: 12 }, (_, i) =>
       JSON.stringify({
         agent: "klanker",
         scheduleIndex: 0,
-        promptKey: "k",
+        promptKey: baseKey,
         exitCode: 0,
         outputSummary: i === 11 ? "s".repeat(300) : "ok",
         startedAt: 1747300000000 + i,


### PR DESCRIPTION
v0.15.29's per-cron fire bounding kept the last 8 of EVERY distinct promptKey, including obsolete ones (clerk: 21 keys / 2638 fires as crons get edited → new keys). That blew the frame budget so the trim shed ALL fires → dashboard showed 'no fires' for every cron (verified live: truncated:true, recentByAgent:[]).

Fix: boundScheduleView keeps only fires whose promptKey matches a CURRENT cron entry (per agent) — obsolete fires are dropped (the UI matches by promptKey and wouldn't render them anyway), bounding the payload to current-crons × 8.

Tests: new obsolete-key drop case; fire tests pass a matching entry; agent_schedule e2e seeds the base cron's real sha256(prompt) key. tsc clean; 1015 tests pass; pii clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)