### PR TITLE
chore: release v0.15.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.15.30 — Fix: restore per-cron fire history (#2377)
+
+v0.15.29's per-cron fire bounding kept the last fires of every distinct
+`promptKey`, including obsolete ones a long-lived agent accumulates — which
+blew the response frame budget so the trim shed all fires and the Schedule
+tab showed "no fires" for every cron. `boundScheduleView` now keeps only
+fires whose `promptKey` matches a current cron.
+
 ## v0.15.29 — Per-cron Schedule view (#2375)
 
 The dashboard Schedule tab now shows each cron as a self-contained block —

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchroom",
-  "version": "0.15.29",
+  "version": "0.15.30",
   "description": "Run Claude Code 24/7 on your Claude Pro/Max subscription over Telegram. Open-source alternative to OpenClaw and NanoClaw — no API keys.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.15.30 — fix per-cron fire history (#2377, fresh-reviewed). 🤖