### PR TITLE
feat(dashboard): Memory tab — what models know, the why, and how memory works

### DIFF
--- a/src/memory/bank-health.ts
+++ b/src/memory/bank-health.ts
@@ -35,6 +35,42 @@ export interface BankMentalModelSummary {
   contentLength: number;
   /** First ~200 chars of content — enough for corruption fingerprinting. */
   contentHead: string;
+  /**
+   * The recall question this model answers — hindsight's `source_query`. This
+   * is the "why" of a model: the operator reads it and knows what the model is
+   * FOR without opening its content. Empty string when absent.
+   */
+  sourceQuery: string;
+  /** Refresh trigger mode (`full` | `incremental` | …) from `trigger.mode`. */
+  refreshMode: string | null;
+}
+
+/**
+ * Full detail for one mental model — the content the operator actually wants
+ * to read, plus its provenance (how many source facts it was synthesized
+ * from, by type). Fetched on demand per-model so the memory-health list stays
+ * light: the list carries summaries; the operator expands one model to pull
+ * its full text + provenance.
+ */
+export interface MentalModelDetail {
+  id: string;
+  name: string;
+  /** The recall question this model answers (the "why"). */
+  sourceQuery: string;
+  /** The rendered content injected into the agent's context on recall. */
+  content: string;
+  lastRefreshedAt: string | null;
+  createdAt: string | null;
+  refreshMode: string | null;
+  /**
+   * Count of the source facts this model was synthesized FROM, keyed by fact
+   * type (observation, directives, world, opinion, experience, mental-models).
+   * This is the provenance — it makes "how memory works" concrete: e.g.
+   * `{ observation: 24, directives: 11, "mental-models": 3 }`.
+   */
+  basedOnCounts: Record<string, number>;
+  /** Sum of basedOnCounts — total source facts behind this model. */
+  totalSourceFacts: number;
 }
 
 export interface BankHealth {
@@ -138,6 +174,8 @@ export async function inspectBankHealth(
       last_refreshed_at?: string | null;
       created_at?: string | null;
       content?: string | null;
+      source_query?: string | null;
+      trigger?: { mode?: string | null } | null;
     }>;
   }>(`${base}/v1/default/banks/${bank}/mental-models`, opts);
   if (!models.ok) return { ...empty, reason: models.reason };
@@ -170,7 +208,7 @@ export async function inspectBankHealth(
     newestDocumentAt,
     unextractedDocuments: unextracted,
     mentalModels: (models.data.items ?? [])
-      .filter((m): m is { id: string; name: string; last_refreshed_at?: string | null; created_at?: string | null; content?: string | null } =>
+      .filter((m): m is { id: string; name: string; last_refreshed_at?: string | null; created_at?: string | null; content?: string | null; source_query?: string | null; trigger?: { mode?: string | null } | null } =>
         typeof m?.id === "string" && typeof m?.name === "string",
       )
       .map((m) => ({
@@ -180,7 +218,63 @@ export async function inspectBankHealth(
         createdAt: m.created_at ?? null,
         contentLength: (m.content ?? "").length,
         contentHead: (m.content ?? "").slice(0, 200),
+        sourceQuery: m.source_query ?? "",
+        refreshMode: m.trigger?.mode ?? null,
       })),
+  };
+}
+
+/**
+ * Fetch one mental model's full detail (content + provenance) by id. Used by
+ * the dashboard's on-demand "view model" expander — the operator clicks a
+ * model to read what it actually knows and where it came from. The bank-health
+ * list endpoint deliberately truncates content (corruption fingerprint only);
+ * this is how the full text is pulled, one model at a time. Never throws.
+ */
+export async function getMentalModelDetail(
+  mcpUrl: string,
+  bankId: string,
+  modelId: string,
+  opts?: FetchOpts,
+): Promise<{ ok: true; model: MentalModelDetail } | { ok: false; reason: string }> {
+  const base = hindsightRestBase(mcpUrl);
+  const bank = encodeURIComponent(bankId);
+  const id = encodeURIComponent(modelId);
+  const res = await getJson<{
+    id?: string;
+    name?: string;
+    source_query?: string | null;
+    content?: string | null;
+    last_refreshed_at?: string | null;
+    created_at?: string | null;
+    trigger?: { mode?: string | null } | null;
+    reflect_response?: { based_on?: Record<string, unknown[]> | null } | null;
+  }>(`${base}/v1/default/banks/${bank}/mental-models/${id}`, opts);
+  if (!res.ok) return res;
+
+  const m = res.data;
+  const basedOn = m.reflect_response?.based_on ?? {};
+  const basedOnCounts: Record<string, number> = {};
+  let totalSourceFacts = 0;
+  for (const [type, facts] of Object.entries(basedOn)) {
+    const n = Array.isArray(facts) ? facts.length : 0;
+    basedOnCounts[type] = n;
+    totalSourceFacts += n;
+  }
+
+  return {
+    ok: true,
+    model: {
+      id: m.id ?? modelId,
+      name: m.name ?? modelId,
+      sourceQuery: m.source_query ?? "",
+      content: m.content ?? "",
+      lastRefreshedAt: m.last_refreshed_at ?? null,
+      createdAt: m.created_at ?? null,
+      refreshMode: m.trigger?.mode ?? null,
+      basedOnCounts,
+      totalSourceFacts,
+    },
   };
 }
 

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -9,11 +9,13 @@ import { getAllAuthStatuses } from "../auth/manager.js";
 import { getCollectionForAgent, probeHindsight } from "../memory/hindsight.js";
 import {
   inspectBankHealth,
+  getMentalModelDetail,
   staleMentalModels,
   corruptedMentalModels,
   recentUnextracted,
   ageDays,
   type BankMentalModelSummary,
+  type MentalModelDetail,
 } from "../memory/bank-health.js";
 import {
   reprocessDocuments,
@@ -2007,6 +2009,46 @@ export async function handleMemoryBuildProfile(
   const trigger = deps?.trigger ?? buildUserProfile;
   try {
     return await trigger(url, bank, { fetchImpl: deps?.fetchImpl });
+  } catch (err) {
+    return { ok: false, error: String((err as Error).message ?? err) };
+  }
+}
+
+export interface MentalModelDetailResult {
+  ok: boolean;
+  model?: MentalModelDetail;
+  error?: string;
+}
+
+/**
+ * GET /api/memory/model?bank=&id= — full detail for one mental model (the
+ * content the operator reads + its provenance). On-demand so the memory-health
+ * list stays light.
+ *
+ * SECURITY: `bank` is gated to a known fleet bank (no network); the model id
+ * is then resolved straight against hindsight by-id, which 404s on an unknown
+ * id (a forged loopback request can only READ models that genuinely exist in
+ * the operator's own fleet banks — no write, no model call). This is a pure
+ * read, so — unlike the remediation POSTs that trigger LLM work — it doesn't
+ * pay the extra round-trip to re-validate the id against a full inspect.
+ * Never throws.
+ */
+export async function handleGetMentalModel(
+  config: SwitchroomConfig,
+  bank: string,
+  modelId: string,
+  deps?: { fetchImpl?: typeof fetch; detail?: typeof getMentalModelDetail },
+): Promise<MentalModelDetailResult> {
+  if (!bank) return { ok: false, error: "Query must include `bank`." };
+  if (!modelId) return { ok: false, error: "Query must include `id`." };
+  if (!isKnownBank(config, bank)) return { ok: false, error: `Unknown bank: ${bank}` };
+
+  const url = resolveMemoryUrl(config);
+  const detail = deps?.detail ?? getMentalModelDetail;
+  try {
+    const res = await detail(url, bank, modelId, { fetchImpl: deps?.fetchImpl });
+    if (!res.ok) return { ok: false, error: res.reason };
+    return { ok: true, model: res.model };
   } catch (err) {
     return { ok: false, error: String((err as Error).message ?? err) };
   }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -33,6 +33,7 @@ import {
   handleMemoryReprocess,
   handleMemoryRefreshModel,
   handleMemoryBuildProfile,
+  handleGetMentalModel,
   handleGetGoogleAccounts,
   handleGetMicrosoftAccounts,
   handleSetConnectionAccess,
@@ -493,6 +494,13 @@ function parseRoute(
   // Create-if-missing the user-profile mental model for a bank.
   if (method === "POST" && pathname === "/api/memory/build-profile") {
     return { handler: "memoryBuildProfile", params: {} };
+  }
+
+  // GET /api/memory/model?bank=&id=
+  // On-demand full detail (content + provenance) for one mental model — the
+  // "view what it knows" expander. Pure read; no model call.
+  if (method === "GET" && pathname === "/api/memory/model") {
+    return { handler: "getMentalModel", params: {} };
   }
 
   // GET /api/google-accounts
@@ -995,6 +1003,15 @@ export function startWebServer(
                 return jsonResponse({ ok: false, error: "Invalid JSON body" }, 400);
               }
               const result = await handleMemoryBuildProfile(freshConfig(), body);
+              return jsonResponse(result, result.ok ? 200 : 400);
+            })();
+          }
+
+          case "getMentalModel": {
+            return (async () => {
+              const bank = url.searchParams.get("bank") ?? "";
+              const id = url.searchParams.get("id") ?? "";
+              const result = await handleGetMentalModel(freshConfig(), bank, id);
               return jsonResponse(result, result.ok ? 200 : 400);
             })();
           }

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -636,12 +636,67 @@
       // JSON for a single-quoted onclick attribute: escape the quote
       // chars that could break out of the attribute (', &, <, >).
       const attrJson = (v) => escapeHtml(JSON.stringify(v));
-      const cards = (m.banks || []).map(b => {
+
+      // --- "How memory works" explainer (live fleet totals) ---
+      // The Memory tab's job: make the invisible pipeline legible. The
+      // operator should understand WHAT the agents remember, the WHY behind
+      // each model, and HOW the pipeline turns conversations into recall.
+      const banks = m.banks || [];
+      const totals = banks.reduce((a, b) => {
+        a.docs += b.totalDocuments || 0;
+        a.facts += b.totalFacts || 0;
+        a.models += (b.mentalModels || []).length;
+        return a;
+      }, { docs: 0, facts: 0, models: 0 });
+      const fmtNum = (n) => (n || 0).toLocaleString();
+      const stage = (label, count, desc) => `<div style="flex:1 1 140px;min-width:130px;background:var(--surface-hover);border-radius:8px;padding:.6rem .7rem">
+        <div style="font-weight:600">${escapeHtml(label)}${count !== '' ? ` <span style="color:var(--blue)">${count}</span>` : ''}</div>
+        <div style="color:var(--text-dim);font-size:.78em;margin-top:.25rem;line-height:1.35">${escapeHtml(desc)}</div>
+      </div>`;
+      const arrow = `<div style="display:flex;align-items:center;color:var(--text-dim);font-size:1.1em">→</div>`;
+      const explainer = `<div class="agent-card" style="margin-bottom:1rem">
+        <div class="card-header" style="cursor:default">
+          <span class="agent-name">How memory works</span>
+          <span style="color:var(--text-dim);font-size:.85em;margin-left:.5rem">${banks.length} bank${banks.length === 1 ? '' : 's'} · hindsight</span>
+        </div>
+        <div style="padding:0 1.25rem 1rem">
+          <div style="display:flex;flex-wrap:wrap;align-items:stretch;gap:.5rem;margin:.2rem 0 .7rem">
+            ${stage('Conversations', fmtNum(totals.docs), 'Every agent turn is retained verbatim as a document.')}
+            ${arrow}
+            ${stage('Facts', fmtNum(totals.facts), "Hindsight extracts durable facts from each conversation — on its OWN model, never the agent's quota.")}
+            ${arrow}
+            ${stage('Mental models', fmtNum(totals.models), 'Facts are synthesized into named models, each answering one recall question.')}
+            ${arrow}
+            ${stage('Recall', '', 'On each turn the agent pulls the relevant models back into context — it never re-reads raw history.')}
+          </div>
+          <div style="color:var(--text-dim);font-size:.85em">Expand any model below to read what it knows and where it came from. A <span style="color:var(--yellow)">stale</span> or empty model means the agent is reasoning from an out-of-date picture.</div>
+        </div>
+      </div>`;
+
+      const cards = banks.map((b, bi) => {
         const bankJs = attrJson(b.bank);
-        const models = (b.mentalModels || []).map(mm => {
+        const models = (b.mentalModels || []).map((mm, mi) => {
           const ts = mm.lastRefreshedAt || mm.createdAt;
           const stale = ts && (Date.now() - Date.parse(ts)) > 7 * 86400000;
-          return `<div class="meta-item"><label>${escapeHtml(mm.name)} </label><span style="${stale ? 'color:var(--yellow)' : ''}">${fmtAge(ts) || 'never refreshed'}</span></div>`;
+          const detailId = `memdetail-${bi}-${mi}`;
+          const idJs = attrJson(mm.id);
+          const ageLabel = fmtAge(ts) || 'never refreshed';
+          const why = mm.sourceQuery
+            ? `<div style="color:var(--text-dim);font-size:.84em;margin-top:.15rem">answers: “${escapeHtml(mm.sourceQuery)}”</div>`
+            : '';
+          const modeBadge = mm.refreshMode
+            ? `<span style="color:var(--text-dim);font-size:.78em;border:1px solid var(--border);border-radius:5px;padding:0 .35rem">${escapeHtml(mm.refreshMode)}</span>`
+            : '';
+          return `<div style="border-top:1px solid var(--border);padding:.5rem 0">
+            <div style="display:flex;align-items:baseline;gap:.5rem;flex-wrap:wrap">
+              <strong>${escapeHtml(mm.name)}</strong>
+              <span style="font-size:.82em;${stale ? 'color:var(--yellow)' : 'color:var(--text-dim)'}">${ageLabel}${stale ? ' · stale' : ''}</span>
+              ${modeBadge}
+              <button class="btn" type="button" style="margin-left:auto;padding:.12rem .55rem;font-size:.8em" onclick='memViewModel(${bankJs}, ${idJs}, "${detailId}", this)'>view</button>
+            </div>
+            ${why}
+            <div id="${detailId}" style="display:none;margin-top:.5rem"></div>
+          </div>`;
         }).join('');
         const gapLine = b.recentUnextractedCount > 0
           ? `<div style="color:var(--red);margin-top:.4rem">⚠ ${b.recentUnextractedCount} recent conversation(s) stored but NOT extracted (oldest ${fmtDay(b.oldestUnextractedAt)}) — invisible to recall until reprocessed</div>`
@@ -694,14 +749,14 @@
               <div class="meta-item"><label>Latest activity </label><span>${fmtDay(b.newestDocumentAt)} ${fmtAge(b.newestDocumentAt) ? '(' + fmtAge(b.newestDocumentAt) + ')' : ''}</span></div>
               <div class="meta-item"><label>Mental models </label><span>${(b.mentalModels || []).length}${b.staleMentalModelCount ? ` <span style="color:var(--yellow)">(${b.staleMentalModelCount} stale)</span>` : ''}</span></div>
             </div>
-            ${models ? `<div class="card-meta" style="padding:.4rem 0 0">${models}</div>` : ''}
+            ${models ? `<div style="margin-top:.5rem"><div style="font-size:.74em;color:var(--text-dim);text-transform:uppercase;letter-spacing:.05em;margin-bottom:.1rem">Mental models — what this fleet remembers</div>${models}</div>` : ''}
             ${corruptLine}
             ${gapLine}
             ${buttonRow}
           </div>
         </div>`;
       }).join('');
-      container.innerHTML = `<div class="agents-grid">${cards || '<div style="color:var(--text-dim)">No agent banks configured.</div>'}</div>`;
+      container.innerHTML = explainer + `<div class="agents-grid">${cards || '<div style="color:var(--text-dim)">No agent banks configured.</div>'}</div>`;
     }
 
     // --- Memory remediation actions ---
@@ -748,6 +803,58 @@
     function memBuildProfile(bank, btn) {
       memRemediate(btn, '/api/memory/build-profile', { bank }, 'Building…', 'Build profile',
         () => 'Profile build triggered');
+    }
+
+    // --- View one mental model's full content + provenance ---
+    // Lazy: the memory-health list carries only summaries (name/why/age) so
+    // it stays light across many banks; the full text is pulled on demand
+    // when the operator clicks "view". Pure READ of hindsight's REST — no
+    // model call, no quota. Re-click toggles collapse (content cached after
+    // the first load).
+    async function memViewModel(bank, id, detailId, btn) {
+      const el = document.getElementById(detailId);
+      if (!el) return;
+      if (el.dataset.open === '1') {
+        el.style.display = 'none';
+        el.dataset.open = '0';
+        if (btn) btn.textContent = 'view';
+        return;
+      }
+      el.style.display = 'block';
+      el.dataset.open = '1';
+      if (btn) btn.textContent = 'hide';
+      if (el.dataset.loaded === '1') return;
+      el.innerHTML = '<div style="color:var(--text-dim);font-size:.85em">Loading…</div>';
+      try {
+        const res = await fetch(`${API}/api/memory/model?bank=${encodeURIComponent(bank)}&id=${encodeURIComponent(id)}`, { headers: authHeaders() });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || !data.ok || !data.model) {
+          el.innerHTML = `<div style="color:var(--red);font-size:.85em">Couldn't load model: ${escapeHtml(data.error || ('HTTP ' + res.status))}</div>`;
+          return;
+        }
+        el.innerHTML = renderModelDetail(data.model);
+        el.dataset.loaded = '1';
+      } catch (err) {
+        el.innerHTML = `<div style="color:var(--red);font-size:.85em">Couldn't load model: ${escapeHtml(err.message)}</div>`;
+      }
+    }
+
+    // The "why + how" of a single model: where it came from (provenance) and
+    // the full content the agent actually recalls.
+    function renderModelDetail(model) {
+      const prov = Object.entries(model.basedOnCounts || {})
+        .filter(([, n]) => n > 0)
+        .sort((a, b) => b[1] - a[1])
+        .map(([type, n]) => `${n} ${escapeHtml(type.replace(/-/g, ' '))}`)
+        .join(' · ');
+      const provLine = (model.totalSourceFacts || 0) > 0
+        ? `<div style="color:var(--text-dim);font-size:.82em;margin-bottom:.4rem">Synthesized from ${model.totalSourceFacts} source fact${model.totalSourceFacts === 1 ? '' : 's'}: ${prov}</div>`
+        : `<div style="color:var(--text-dim);font-size:.82em;margin-bottom:.4rem">No source facts recorded — likely a seed or manually set value.</div>`;
+      const content = (model.content || '').trim();
+      const body = content
+        ? `<pre style="white-space:pre-wrap;word-break:break-word;background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:.7rem;max-height:340px;overflow:auto;font-size:.82em;line-height:1.45;margin:0">${escapeHtml(content)}</pre>`
+        : `<div style="color:var(--yellow);font-size:.85em">This model has no content — it's empty, so the agent recalls nothing from it.</div>`;
+      return provLine + body;
     }
 
     async function fetchConnections() {

--- a/tests/memory.bank-health.test.ts
+++ b/tests/memory.bank-health.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   inspectBankHealth,
+  getMentalModelDetail,
   hindsightRestBase,
   staleMentalModels,
   corruptedMentalModels,
@@ -60,7 +61,7 @@ const HEALTHY_BANK = {
   },
   models: {
     items: [
-      { id: "m1", name: "Case State", last_refreshed_at: "2026-06-10T01:00:00Z", created_at: "2026-04-01T00:00:00Z", content: "# Case State\n\nA healthy, substantive synthesis of the matter." },
+      { id: "m1", name: "Case State", last_refreshed_at: "2026-06-10T01:00:00Z", created_at: "2026-04-01T00:00:00Z", content: "# Case State\n\nA healthy, substantive synthesis of the matter.", source_query: "What is the current state of the matter?", trigger: { mode: "full" } },
     ],
   },
 };
@@ -111,6 +112,18 @@ describe("inspectBankHealth", () => {
     expect(h.newestDocumentAt).toBe("2026-06-09T10:00:00Z");
     expect(h.unextractedDocuments).toHaveLength(0);
     expect(h.mentalModels).toHaveLength(1);
+    // The model summary now carries the "why" (source_query) + refresh mode.
+    expect(h.mentalModels[0].sourceQuery).toBe("What is the current state of the matter?");
+    expect(h.mentalModels[0].refreshMode).toBe("full");
+  });
+
+  it("defaults sourceQuery/refreshMode when the model omits them", async () => {
+    const h = await inspectBankHealth("http://x/mcp/", "stale", {
+      fetchImpl: fakeFetchFor({ stale: STALE_MODEL_BANK }),
+    });
+    expect(h.ok).toBe(true);
+    expect(h.mentalModels[0].sourceQuery).toBe("");
+    expect(h.mentalModels[0].refreshMode).toBeNull();
   });
 
   it("collects zero-fact documents oldest-first", async () => {
@@ -127,6 +140,79 @@ describe("inspectBankHealth", () => {
     });
     expect(h.ok).toBe(false);
     expect(h.reason).toContain("503");
+  });
+});
+
+describe("getMentalModelDetail", () => {
+  // The by-id endpoint (/mental-models/<id>) — NOT the list. The full-content
+  // detail with provenance from reflect_response.based_on.
+  function fakeDetailFetch(body: unknown, status = 200): typeof fetch {
+    return (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (!/\/mental-models\/[^/]+$/.test(url)) {
+        return new Response("wrong route", { status: 404 });
+      }
+      if (status !== 200) return new Response("err", { status });
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+  }
+
+  it("returns full content + provenance counts by fact type", async () => {
+    const res = await getMentalModelDetail("http://x/mcp/", "assistant", "mm-1", {
+      fetchImpl: fakeDetailFetch({
+        id: "mm-1",
+        name: "user-profile",
+        source_query: "What do we know about the user?",
+        content: "# User Profile\n\nKen builds switchroom.",
+        last_refreshed_at: "2026-06-15T11:00:00Z",
+        created_at: "2026-06-06T00:00:00Z",
+        trigger: { mode: "full" },
+        reflect_response: {
+          based_on: {
+            observation: [{}, {}, {}],
+            directives: [{}, {}],
+            world: [],
+            "mental-models": [{}],
+          },
+        },
+      }),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.model.sourceQuery).toBe("What do we know about the user?");
+    expect(res.model.content).toContain("Ken builds switchroom");
+    expect(res.model.refreshMode).toBe("full");
+    expect(res.model.basedOnCounts).toEqual({
+      observation: 3,
+      directives: 2,
+      world: 0,
+      "mental-models": 1,
+    });
+    expect(res.model.totalSourceFacts).toBe(6);
+  });
+
+  it("tolerates a missing reflect_response (no provenance)", async () => {
+    const res = await getMentalModelDetail("http://x/mcp/", "assistant", "mm-2", {
+      fetchImpl: fakeDetailFetch({ id: "mm-2", name: "Bare", content: "x" }),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.model.totalSourceFacts).toBe(0);
+    expect(res.model.basedOnCounts).toEqual({});
+    expect(res.model.sourceQuery).toBe("");
+    expect(res.model.refreshMode).toBeNull();
+  });
+
+  it("degrades to ok:false with a reason on HTTP failure (never throws)", async () => {
+    const res = await getMentalModelDetail("http://x/mcp/", "assistant", "mm-3", {
+      fetchImpl: fakeDetailFetch({}, 404),
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toContain("404");
   });
 });
 

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -122,6 +122,7 @@ import {
   handleMemoryReprocess,
   handleMemoryRefreshModel,
   handleMemoryBuildProfile,
+  handleGetMentalModel,
   __resetDashboardCacheForTests,
   type AgentInfo,
   type SystemHealth,
@@ -2306,6 +2307,76 @@ describe("memory remediation handlers", () => {
       });
       expect(r.ok).toBe(false);
       expect(r.error).toBe("MCP error");
+    });
+  });
+
+  describe("handleGetMentalModel", () => {
+    it("rejects a missing bank/id without hitting hindsight", async () => {
+      const detail = vi.fn();
+      const r1 = await handleGetMentalModel(mockConfig, "", "mm-1", { detail: detail as never });
+      expect(r1.ok).toBe(false);
+      expect(r1.error).toContain("bank");
+      const r2 = await handleGetMentalModel(mockConfig, "coach-mem", "", { detail: detail as never });
+      expect(r2.ok).toBe(false);
+      expect(r2.error).toContain("id");
+      expect(detail).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown bank (gate before any network call)", async () => {
+      const detail = vi.fn();
+      const r = await handleGetMentalModel(mockConfig, "nope", "mm-1", {
+        detail: detail as never,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("Unknown bank");
+      expect(detail).not.toHaveBeenCalled();
+    });
+
+    it("returns the model detail for a known bank", async () => {
+      const detail = vi.fn(async () => ({
+        ok: true as const,
+        model: {
+          id: "mm-1",
+          name: "user-profile",
+          sourceQuery: "What do we know about the user?",
+          content: "# User Profile\n\n…",
+          lastRefreshedAt: "2026-06-15T11:00:00Z",
+          createdAt: "2026-06-06T00:00:00Z",
+          refreshMode: "full",
+          basedOnCounts: { observation: 24, directives: 11 },
+          totalSourceFacts: 35,
+        },
+      }));
+      const r = await handleGetMentalModel(mockConfig, "coach-mem", "mm-1", {
+        detail: detail as never,
+      });
+      expect(r.ok).toBe(true);
+      expect(r.model?.sourceQuery).toBe("What do we know about the user?");
+      expect(r.model?.totalSourceFacts).toBe(35);
+      // The MCP url (not the REST base) is passed through to the detail fetcher.
+      expect(detail.mock.calls[0][0]).toBe("http://127.0.0.1:18888/mcp/");
+      expect(detail.mock.calls[0][1]).toBe("coach-mem");
+      expect(detail.mock.calls[0][2]).toBe("mm-1");
+    });
+
+    it("maps a detail failure (e.g. 404 unknown id) to ok:false", async () => {
+      const detail = vi.fn(async () => ({ ok: false as const, reason: "HTTP 404" }));
+      const r = await handleGetMentalModel(mockConfig, "coach-mem", "forged", {
+        detail: detail as never,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toBe("HTTP 404");
+    });
+
+    it("never throws — a throwing detail fetch is mapped to ok:false", async () => {
+      const detail = vi.fn(async () => {
+        throw new Error("boom");
+      });
+      const r = await handleGetMentalModel(mockConfig, "coach-mem", "mm-1", {
+        detail: detail as never,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("boom");
     });
   });
 });


### PR DESCRIPTION
## Summary

The operator's request: *"more insight into memory — be good to see what the mental models are, any insight to why etc, insight into how the memory is working."* The Memory tab previously showed each model's **name + age** only — never the content the agents actually recall, the question each model answers, or the pipeline that turns conversations into recall.

This makes the invisible memory pipeline legible, without the dashboard ever calling a model (subscription-honest — hindsight already holds all of this; the web only reads + renders).

## What changed

- **`src/memory/bank-health.ts`**
  - `BankMentalModelSummary` gains `sourceQuery` (hindsight's `source_query` — the recall question a model answers, i.e. the *why*) and `refreshMode` (`trigger.mode`). Both ride free off the existing `/mental-models` list call.
  - New `getMentalModelDetail(mcpUrl, bank, id)` — fetches one model by id: full `content` + **provenance** (`basedOnCounts` by fact type from `reflect_response.based_on`, e.g. `{observation: 24, directives: 11, "mental-models": 3}`) + `totalSourceFacts`. Best-effort, never throws.
- **`src/web/api.ts`** — `handleGetMentalModel(config, bank, id)`. Bank is gated to a known fleet bank (no network); the id is resolved straight against hindsight by-id (404s on an unknown id). Pure **READ** — no model call. Rows now carry `sourceQuery`/`refreshMode` per model.
- **`src/web/server.ts`** — `GET /api/memory/model?bank=&id=` → `getMentalModel`.
- **`src/web/ui/index.html`**
  - A **"How memory works"** explainer at the top: a live `Conversations → Facts → Mental models → Recall` pipeline with fleet totals and a one-line description of each stage.
  - Each model row now shows `answers: "<source_query>"`, a **stale** badge, refresh mode, and a **view** expander that lazy-loads full content + `Synthesized from N source facts: 24 observations · 11 directives · …` provenance. On-demand fetch keeps the health list light across many banks; re-click toggles collapse.

## Why

Directly serves the operator request and JTBD **"a standing team that knows you"** — the operator can now see *what* each agent remembers, *why* (the recall question), and *how* it was built (provenance), plus a plain-language model of the pipeline. Pairs with the existing remediation buttons (reprocess / refresh / build-profile) shipped in #2369.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `scripts/check-web-subscription-honest.mjs` clean (web makes no model call)
- [x] `scripts/check-no-pii-secrets.mjs` clean
- [x] inline UI JS parses
- [x] 153 web/memory tests pass, including new coverage:
  - `getMentalModelDetail`: provenance counts by type / missing `reflect_response` / HTTP-failure never-throw
  - `inspectBankHealth`: `sourceQuery`/`refreshMode` mapping + defaults when omitted
  - `handleGetMentalModel`: missing args / unknown-bank gate (no network) / success passes MCP url through / detail-failure mapping / never-throw

## Risk

Low. Additive: one new read-only GET endpoint + two optional summary fields + a UI section. No model calls, no writes, no config changes. The new endpoint is gated to known fleet banks and degrades gracefully (never throws; UI shows a load error inline). Web-image-only change — no agent-facing impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)