### PR TITLE
fix(hostd): config_propose_edit deterministic from agents — wire timeout + idempotency

### DIFF
--- a/src/host-control/server.ts
+++ b/src/host-control/server.ts
@@ -40,7 +40,7 @@ import {
   closeSync,
 } from "node:fs";
 import { join, dirname, resolve } from "node:path";
-import { randomUUID, randomBytes } from "node:crypto";
+import { createHash, randomUUID, randomBytes } from "node:crypto";
 import {
   decodeRequest,
   encodeResponse,
@@ -1426,8 +1426,61 @@ export class HostdServer {
         .build(req.request_id, Date.now() - started);
     }
     const callerName = caller.kind === "agent" ? caller.name : "operator";
+    // ── Idempotency: collapse identical in-flight proposals ─────────
+    // A re-fired identical proposal (same caller + same diff) must not
+    // post a SECOND approval card or apply twice. Key by caller+diff
+    // hash and share the in-flight promise so duplicate/concurrent
+    // proposals converge on ONE card and EXACTLY ONE apply. This is
+    // the invariant that survives the 2026-06-15 klanker debacle's
+    // failure class: re-fires (then driven by a 10s wire timeout) had
+    // stacked phantom cards and double-wrote a config entry.
+    const dedupeKey = `${callerName}:${createHash("sha256")
+      .update(req.args.unified_diff)
+      .digest("hex")}`;
+    const pending = this.inflightConfigProposals.get(dedupeKey);
+    if (pending) {
+      process.stderr.write(
+        `hostd: config_propose_edit — collapsed identical in-flight proposal from ${callerName} (dedupe)\n`,
+      );
+      return await pending;
+    }
+    const run = this.runConfigProposeApprovalAndApply(
+      req,
+      caller,
+      callerName,
+      configPath,
+      verdict.postApplyContent,
+      started,
+    );
+    this.inflightConfigProposals.set(dedupeKey, run);
+    try {
+      return await run;
+    } finally {
+      this.inflightConfigProposals.delete(dedupeKey);
+    }
+  }
+
+  /** In-flight config_propose_edit proposals, keyed by caller+diff hash. */
+  private inflightConfigProposals = new Map<string, Promise<HostdResponse>>();
+
+  /**
+   * The approval-card + mutex-serialized apply phase of
+   * `config_propose_edit`, split out so identical in-flight proposals
+   * can be deduped onto a single shared promise (exactly-once apply).
+   * Caller (`handleConfigProposeEdit`) has already validated the diff,
+   * passed the self-scope gate, and confirmed the approval gateway is
+   * wired.
+   */
+  private async runConfigProposeApprovalAndApply(
+    req: Extract<HostdRequest, { op: "config_propose_edit" }>,
+    caller: SocketIdentity,
+    callerName: string,
+    configPath: string,
+    postApply: string,
+    started: number,
+  ): Promise<HostdResponse> {
     const approvalId = (this.opts.generateApprovalId ?? defaultApprovalId)();
-    const approval = await this.opts.approvalGateway.requestApproval({
+    const approval = await this.opts.approvalGateway!.requestApproval({
       requestId: approvalId,
       agentName: callerName,
       reason: req.args.reason,
@@ -1509,7 +1562,6 @@ export class HostdServer {
           started,
         );
       }
-      const postApply = verdict.postApplyContent;
       // In-place write preserving the inode (bind-mount safe). The old
       // `<path>.tmp` → rename() swap returned EBUSY here because
       // switchroom.yaml is itself a read-only bind-mount source mounted

--- a/src/mcp/hostd/server.test.ts
+++ b/src/mcp/hostd/server.test.ts
@@ -395,6 +395,31 @@ describe("dispatchTool — config_propose_edit", () => {
     expect(sent.request_id).toMatch(/^mcp-config-propose-edit-/);
   });
 
+  it("uses a long wire timeout (outlasting the operator approval window)", async () => {
+    // Root cause of the 2026-06-15 klanker debacle: the MCP wire used a
+    // flat 10s for every op, but config_propose_edit BLOCKS server-side
+    // until the operator taps (up to ~10 min). A 10s wire times out by
+    // construction → the agent re-fires → phantom stacked cards. The
+    // wire must outlast the approval window.
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "completed" }));
+    await dispatchTool("config_propose_edit", {
+      unified_diff: VALID_DIFF,
+      reason: "x",
+      target_path: "/state/config/switchroom.yaml",
+    });
+    const wireOpts = hostdRequestMock.mock.calls[0]![0] as { timeoutMs: number };
+    expect(wireOpts.timeoutMs).toBe(11 * 60 * 1000);
+    // And it must comfortably exceed the daemon's 10-min approval window.
+    expect(wireOpts.timeoutMs).toBeGreaterThan(10 * 60 * 1000);
+  });
+
+  it("leaves the snappy default wire timeout on prompt-returning ops", async () => {
+    hostdRequestMock.mockResolvedValueOnce(ok({ result: "started" }));
+    await dispatchTool("update_check", {});
+    const wireOpts = hostdRequestMock.mock.calls[0]![0] as { timeoutMs: number };
+    expect(wireOpts.timeoutMs).toBe(10_000);
+  });
+
   it("rejects missing unified_diff without hitting the wire", async () => {
     const res = await dispatchTool("config_propose_edit", {
       reason: "x",

--- a/src/mcp/hostd/server.ts
+++ b/src/mcp/hostd/server.ts
@@ -54,6 +54,26 @@ function makeRequestId(prefix: string): string {
   return `${prefix}-${Date.now()}-${randomBytes(4).toString("hex")}`;
 }
 
+// Wire timeouts are PER-OP. Almost every hostd op returns promptly
+// (`started`/`completed` within a tick), so a snappy 10s wire keeps the
+// agent responsive. `config_propose_edit` is the exception: the daemon
+// BLOCKS server-side awaiting the operator's approval tap (up to
+// CONFIG_APPROVAL_TIMEOUT_MS = 10 min in host-control/server.ts) before
+// it applies and returns. A 10s wire on that op times out by
+// construction — a human cannot tap in 10s — and the agent misreads the
+// timeout as a wire failure, then re-fires, stacking phantom approval
+// cards (the 2026-06-15 klanker debacle: re-fires double-wrote a config
+// entry). The wire MUST outlast the approval window; this mirrors the
+// web dashboard's PROPOSE_TIMEOUT_MS (src/web/hostd-config-propose.ts).
+const DEFAULT_WIRE_TIMEOUT_MS = 10_000;
+const WIRE_TIMEOUT_MS_BY_OP: Partial<Record<HostdRequest["op"], number>> = {
+  config_propose_edit: 11 * 60 * 1000,
+};
+
+export function wireTimeoutForOp(op: HostdRequest["op"]): number {
+  return WIRE_TIMEOUT_MS_BY_OP[op] ?? DEFAULT_WIRE_TIMEOUT_MS;
+}
+
 interface ToolArgs {
   name?: string;
   reason?: string;
@@ -261,7 +281,13 @@ export const TOOLS = [
       "hostd.config_edit_enabled=true (operator opt-in; default off) — returns " +
       "E_CONFIG_EDIT_DISABLED otherwise. An applied edit is not live in the " +
       "running agent until it restarts (the approval card names which agents " +
-      "to bounce).",
+      "to bounce). This call BLOCKS until the operator taps Allow/Deny (or the " +
+      "~10-min approval window expires) — that is expected, NOT a hang. Issue " +
+      "it ONCE and wait for the single result; do NOT re-fire while waiting " +
+      "(a duplicate identical proposal is collapsed onto the pending one, but " +
+      "re-firing only adds confusion). On a genuine failure you get a " +
+      "structured error (E_*); surface that honestly rather than falling back " +
+      "to asking the operator to hand-edit the yaml.",
     inputSchema: {
       type: "object" as const,
       required: ["unified_diff", "reason", "target_path"],
@@ -489,7 +515,7 @@ export async function dispatchTool(
   let resp: HostdResponse;
   try {
     resp = await hostdRequest(
-      { socketPath: sockPath, timeoutMs: 10_000 },
+      { socketPath: sockPath, timeoutMs: wireTimeoutForOp(req.op) },
       req,
     );
   } catch (err) {

--- a/tests/host-control/config-propose-edit-idempotency.test.ts
+++ b/tests/host-control/config-propose-edit-idempotency.test.ts
@@ -1,0 +1,267 @@
+/**
+ * hostd `config_propose_edit` — IDEMPOTENCY + the failure-class corpus
+ * seed for the 2026-06-15 klanker debacle.
+ *
+ * Failure recap: the agent's MCP wire timed out at 10s on an op that
+ * BLOCKS server-side until the operator taps (up to ~10 min). The agent
+ * misread the timeout as a wire failure and RE-FIRED, stacking phantom
+ * approval cards; multiple taps then double-wrote a config entry
+ * (`postureMintAgents: - marko` appeared twice).
+ *
+ * The timeout itself is fixed on the MCP side (see
+ * `src/mcp/hostd/server.test.ts` — per-op wire timeout). THIS file pins
+ * the deeper invariant that must survive the whole failure CLASS, not
+ * just the one bug: an identical in-flight proposal is collapsed onto a
+ * single approval card and applied EXACTLY ONCE, no matter how many
+ * times it is (re-)fired or how the operator's tap latency varies.
+ *
+ * The `describe("property — ...")` block IS the KEN-29 probabilistic-UAT
+ * seed: a fuzzed corpus over {verdict × burst size × tap latency} that
+ * asserts the invariants on every schedule so this class cannot
+ * silently recur.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HostdServer } from "../../src/host-control/server.js";
+import { hostdRequest } from "../../src/host-control/client.js";
+import type {
+  ApprovalGateway,
+  ApprovalRequest,
+  ApprovalResult,
+  ApprovalVerdict,
+} from "../../src/host-control/approval-gateway.js";
+
+let tmp: string;
+let server: HostdServer;
+let stubBin: string;
+let configPath: string;
+
+const VALID_BASE_YAML =
+  "switchroom:\n" +
+  "  version: 1\n" +
+  "telegram:\n" +
+  '  bot_token: "x"\n' +
+  '  forum_chat_id: "1"\n' +
+  "agents: {}\n";
+
+// Applies cleanly to VALID_BASE_YAML (lines 1-3: switchroom: / version / telegram:).
+const DIFF_A =
+  "--- a/switchroom.yaml\n" +
+  "+++ b/switchroom.yaml\n" +
+  "@@ -1,3 +1,3 @@\n" +
+  " switchroom:\n" +
+  "-  version: 1\n" +
+  "+  version: 1  # touched-a\n" +
+  " telegram:\n";
+
+// A DIFFERENT clean diff (distinct content hash → must NOT dedupe with A).
+const DIFF_B =
+  "--- a/switchroom.yaml\n" +
+  "+++ b/switchroom.yaml\n" +
+  "@@ -1,3 +1,3 @@\n" +
+  " switchroom:\n" +
+  "-  version: 1\n" +
+  "+  version: 1  # touched-b\n" +
+  " telegram:\n";
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function makeServer(approvalGateway: ApprovalGateway) {
+  return new HostdServer({
+    homeDir: tmp,
+    agentUids: { klanker: 10001 },
+    config: {
+      agents: { klanker: { admin: true } },
+      hostd: { config_edit_enabled: true },
+    },
+    switchroomBin: stubBin,
+    auditLogPath: join(tmp, "audit.log"),
+    allowNonLinux: true,
+    configPath,
+    approvalGateway,
+  });
+}
+
+/**
+ * Gateway that holds each approval open for `holdMs` before returning
+ * `verdict`. Holding the card open is what lets a re-fired proposal
+ * arrive WHILE the first is still in flight — the dedupe window.
+ * Counts requestApproval invocations and finalize outcomes.
+ */
+function holdingGateway(verdict: ApprovalVerdict, holdMs: number) {
+  const requests: ApprovalRequest[] = [];
+  const finalizeCalls: Array<{ outcome: string }> = [];
+  const gw: ApprovalGateway = {
+    async requestApproval(req): Promise<ApprovalResult> {
+      requests.push(req);
+      await sleep(holdMs);
+      return {
+        verdict,
+        finalize: async (out) => {
+          finalizeCalls.push({ outcome: out.outcome });
+        },
+      };
+    },
+  };
+  return { gw, requests, finalizeCalls };
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "hostd-cpe-idem-"));
+  stubBin = join(tmp, "switchroom-stub.sh");
+  // Reconcile stub always succeeds.
+  writeFileSync(stubBin, `#!/bin/sh\necho "stub: $@"\nexit 0\n`);
+  chmodSync(stubBin, 0o755);
+  configPath = join(tmp, "switchroom.yaml");
+  writeFileSync(configPath, VALID_BASE_YAML);
+});
+
+afterEach(async () => {
+  if (server) await server.stop();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function sock(owner = "klanker"): string {
+  return server.getBoundPaths().find((p) => p.endsWith(`/${owner}/sock`))!;
+}
+
+function send(unified_diff: string, request_id: string) {
+  return hostdRequest(
+    { socketPath: sock(), timeoutMs: 60_000 },
+    {
+      v: 1,
+      op: "config_propose_edit",
+      request_id,
+      args: { unified_diff, reason: "test", target_path: "/state/config/switchroom.yaml" },
+    },
+  );
+}
+
+describe("config_propose_edit — idempotency (dedupe in-flight)", () => {
+  it("collapses two identical in-flight proposals onto ONE card + ONE apply", async () => {
+    const { gw, requests, finalizeCalls } = holdingGateway("approve", 120);
+    server = makeServer(gw);
+    await server.start();
+
+    // Fire both before the first resolves (the card is held 120ms).
+    const p1 = send(DIFF_A, "dup-1");
+    await sleep(20); // let the first reach the dedupe point
+    const p2 = send(DIFF_A, "dup-2");
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    // Exactly one approval card was raised, one apply finalized.
+    expect(requests.length).toBe(1);
+    expect(finalizeCalls.filter((f) => f.outcome === "applied").length).toBe(1);
+    // Both callers got a terminal, successful result (shared promise).
+    expect(r1.result).toBe("completed");
+    expect(r2.result).toBe("completed");
+    // The edit landed once.
+    expect(readFileSync(configPath, "utf-8")).toContain("# touched-a");
+  });
+
+  it("does NOT dedupe two DISTINCT diffs (different content hash)", async () => {
+    const { gw, requests } = holdingGateway("approve", 80);
+    server = makeServer(gw);
+    await server.start();
+
+    const p1 = send(DIFF_A, "distinct-1");
+    await sleep(15);
+    const p2 = send(DIFF_B, "distinct-2");
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(requests.length).toBe(2); // two separate cards
+    expect(r1.result).toBe("completed");
+    expect(r2.result).toBe("completed");
+  });
+
+  it("releases the dedupe key after resolution — a later identical proposal gets a fresh card", async () => {
+    // Use deny so the file stays at VALID_BASE_YAML and the 2nd identical
+    // proposal still validates (a re-apply of an applied diff would be
+    // rejected by the validator, which is a different, complementary
+    // guard). This isolates the key-release behaviour.
+    const { gw, requests } = holdingGateway("deny", 0);
+    server = makeServer(gw);
+    await server.start();
+
+    const r1 = await send(DIFF_A, "seq-1"); // fully resolves (denied)
+    const r2 = await send(DIFF_A, "seq-2"); // identical, but after release
+    expect(requests.length).toBe(2); // fresh card the second time
+    expect(r1.result).toBe("denied");
+    expect(r2.result).toBe("denied");
+  });
+});
+
+// ── KEN-29 corpus seed ────────────────────────────────────────────────
+// Fuzz the schedule that produced the debacle: a burst of N identical
+// (re-fired) proposals racing a variable operator tap latency, across
+// approve / deny / timeout. Invariants must hold on EVERY schedule.
+describe("property — re-fired identical proposals: exactly-once apply, always terminal", () => {
+  // Seeded LCG so a failing schedule is reproducible (no Math.random).
+  function lcg(seed: number) {
+    let s = seed >>> 0;
+    return () => ((s = (s * 1664525 + 1013904223) >>> 0) / 0x100000000);
+  }
+  const verdicts: ApprovalVerdict[] = ["approve", "deny", "timeout"];
+  const ITERATIONS = 60;
+
+  it(`holds invariants across ${ITERATIONS} fuzzed schedules`, async () => {
+    const rand = lcg(0xc0ffee);
+    for (let i = 0; i < ITERATIONS; i++) {
+      const verdict = verdicts[Math.floor(rand() * verdicts.length)]!;
+      const burst = 2 + Math.floor(rand() * 3); // 2..4 identical re-fires
+      const holdMs = Math.floor(rand() * 60); // 0..59ms tap latency
+      const arrivalJitter = Math.floor(rand() * 12); // stagger re-fires
+
+      // Fresh server + file per schedule.
+      writeFileSync(configPath, VALID_BASE_YAML);
+      const { gw, requests, finalizeCalls } = holdingGateway(verdict, holdMs);
+      server = makeServer(gw);
+      await server.start();
+
+      const inflight: Array<Promise<{ result: string }>> = [];
+      for (let k = 0; k < burst; k++) {
+        inflight.push(send(DIFF_A, `fuzz-${i}-${k}`) as Promise<{ result: string }>);
+        if (arrivalJitter) await sleep(arrivalJitter > 6 ? 1 : 0);
+      }
+      const results = await Promise.all(inflight);
+
+      const ctx = `schedule#${i} verdict=${verdict} burst=${burst} hold=${holdMs} jitter=${arrivalJitter}`;
+
+      // INVARIANT 1 — bounded cards. Re-fires that genuinely OVERLAP in
+      // flight collapse onto one card (proven exactly in the deterministic
+      // dedupe test above). Re-fires that DON'T overlap (tiny tap latency)
+      // are sequential and each may raise its own card — that's correct;
+      // their safety is carried by INVARIANT 2 + validation, not dedupe.
+      // So here we only bound: at least one, never more than the burst.
+      expect(requests.length, `${ctx}: cards in [1,burst]`).toBeGreaterThanOrEqual(1);
+      expect(requests.length, `${ctx}: cards in [1,burst]`).toBeLessThanOrEqual(burst);
+
+      // INVARIANT 2 — exactly-once apply: applied iff approved, never twice.
+      // This is the load-bearing one — the marko-written-twice guarantee.
+      // Holds under overlap (dedupe) AND non-overlap (a late identical
+      // re-fire validates against the already-mutated file and is rejected
+      // before it can apply again).
+      const applies = finalizeCalls.filter((f) => f.outcome === "applied").length;
+      expect(applies, `${ctx}: apply count`).toBe(verdict === "approve" ? 1 : 0);
+
+      // INVARIANT 3 — every caller reaches a terminal state (no hangs).
+      for (const r of results) {
+        expect(["completed", "denied", "error"], `${ctx}: terminal`).toContain(r.result);
+      }
+      // (Under genuine overlap all callers share ONE outcome — proven in
+      //  the deterministic dedupe test. Under non-overlap a late identical
+      //  re-fire is correctly rejected at validation, so outcomes may
+      //  legitimately differ; the safety guarantee is INVARIANT 2, not a
+      //  uniform return code.)
+
+      // INVARIANT 4 — file mutated iff approved.
+      const after = readFileSync(configPath, "utf-8");
+      expect(after.includes("# touched-a"), `${ctx}: file state`).toBe(verdict === "approve");
+
+      await server.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Makes agent-initiated `config_propose_edit` (hostd) actually deliver its job — *config-from-Telegram, operator just taps Approve, no host CLI* — deterministically. Fixes the failure class behind the 2026-06-15 klanker debacle, not just the one bug.

## Why
An admin agent (klanker) tried to add `marko` to `postureMintAgents` via `config_propose_edit`. Every call "timed out at 10s"; the agent misread that as a wire failure, **re-fired**, stacked phantom approval cards, the operator tapped several, and `- marko` got written **twice** — then the agent fell back to hand-feeding the operator `sed … && switchroom apply`. The job's core promise (no SSH) inverted into nothing-but-SSH.

Two root causes:

1. **Per-op wire timeout.** The agent MCP path used a flat **10s** for every hostd op (since #1212), but `config_propose_edit` **blocks server-side** awaiting the operator's tap (`CONFIG_APPROVAL_TIMEOUT_MS` = 10 min). A 10s wire times out by construction — so agent config-edit *never worked end-to-end*. The web dashboard path masked it (`PROPOSE_TIMEOUT_MS` = 11 min). Now per-op: propose gets 11 min, every other op keeps the snappy 10s.
2. **Non-idempotent proposals.** Re-fires / double-taps could double-write. Identical in-flight proposals (caller + diff hash) now collapse onto **one** card and apply **exactly once**.

Solved from the user outcome (per the UX-debug skill we're building): the point-patch (just bump the timeout) passes the happy path but still fails the fuzz corpus on double-fire → it's a patch, not a fix. The corpus is the arbiter.

## Changes
- `src/mcp/hostd/server.ts` — per-op `wireTimeoutForOp()` (propose = 11 min); tool description now states the call blocks (~10 min, not a hang), issue once, surface structured errors honestly instead of degrading to a hand-edit.
- `src/host-control/server.ts` — split approval+apply into `runConfigProposeApprovalAndApply`; dedupe identical in-flight proposals via a shared promise keyed by `caller:sha256(diff)`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] MCP: per-op wire timeout (11 min propose / 10s others)
- [x] New `tests/host-control/config-propose-edit-idempotency.test.ts`: deterministic dedupe (one card / one apply), distinct-diffs-don't-dedupe, key-release, **+ 60-schedule fuzzed property test (KEN-29 corpus seed)** over {verdict × burst × tap latency} pinning exactly-once-apply + always-terminal so this class can't silently recur.
- [x] All existing daemon + MCP suites green (118 passed / 1 skipped)

## Risk
Low. Behaviour-preserving refactor (existing `config-propose-edit` + `server` suites unchanged-green). The longer propose timeout only affects the one op that already blocks server-side; all other ops keep 10s. Dedupe collapses identical in-flight proposals only — distinct diffs and post-resolution re-proposals are unaffected.

## JTBD
Serves *"you hold the leash"* (control from Telegram, not a shell). Passes the Docs + Defaults principle checks that the observed behaviour failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)