### PR TITLE
fix(compose): keep symlinked + bundled-skills mounts on in-hostd apply (#2387, #2383) + hindsight v0.8.2 (#2392)

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -30,7 +30,17 @@
 # sec WS9-F4 (#1418): pinned by digest — third-party mutable `:latest`
 # from another org; an upstream repoint would otherwise flow into the
 # published hindsight image undetected. Dependabot tracks bumps.
-FROM ghcr.io/vectorize-io/hindsight:latest@sha256:e82b2c051784affa73243108c06402655043999e362bb3b7226b4da1000e1660
+#
+# Pinned to vectorize-io/hindsight v0.8.2 (digest below; label
+# org.opencontainers.image.version=0.8.2, built 2026-06-12). Bumped from
+# v0.7.1 (sha256:e82b2c05…) to pick up the concurrent-retain FK-violation fix
+# (vectorize-io/hindsight #1795 + #1882, closed 2026-06-01) and the 0.8.x
+# entity-link rework — fixes the `batch_retain` ForeignKeyViolation on
+# `unit_entities` that was silently dropping ~2-3% of memory writes
+# (switchroom #2392). NOTE: upstream publishes only `:latest` (no `:vX.Y.Z`
+# tag in ghcr), so the digest IS the version pin. A bump runs DB migrations
+# on the persisted memory volume — back up `switchroom-hindsight-data` first.
+FROM ghcr.io/vectorize-io/hindsight:latest@sha256:7c069db2d7aeeae82d3d3917292b87b14d6547f979c8b1335a42c94d09d57213
 
 USER root
 

--- a/src/agents/compose.ts
+++ b/src/agents/compose.ts
@@ -24,8 +24,8 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, lstatSync, readlinkSync } from "node:fs";
+import { join, isAbsolute, dirname, resolve } from "node:path";
 import type { SwitchroomConfig, AgentConfig, AgentBindMount } from "../config/schema.js";
 import { scheduleNeedsCronSession } from "../scheduler/cron-routing.js";
 import { applyDefaultTier } from "../scheduler/tier-selector.js";
@@ -804,6 +804,47 @@ function readStrippedCaps(agent: AgentConfig): string[] {
   const caps = raw.cap_add;
   if (Array.isArray(caps)) return caps.map(String);
   return [];
+}
+
+/**
+ * Does a conditional-mount SOURCE resolve to a real host path? Used to gate
+ * optional `:ro` bind mounts (docker `up` hard-fails on a missing source).
+ *
+ * `existsSync` (which FOLLOWS symlinks) is the common case and handles real
+ * dirs + symlinks whose target resolves in this filesystem. But some
+ * conditional dirs are symlinks to an ABSOLUTE host path — e.g.
+ * `~/.switchroom/skills -> /home/op/.switchroom-config/skills`. When `apply`
+ * runs INSIDE hostd, `probeHome` is `/host-home` and the symlink's `/home/op`
+ * target is unresolvable there, so plain `existsSync` returns false and the
+ * mount is WRONGLY dropped (#2387 — the in-hostd reconcile silently loses the
+ * skills mount). Detect that case: if the path is a symlink, resolve its
+ * target against `probeHome` (translate a `hostHome`-rooted target to the
+ * container-real home) and check THAT. The baked mount SOURCE stays the
+ * host-home path, which docker resolves host-side at mount time. On the host
+ * (`hostHome === probeHome`) this is identical to `existsSync`.
+ */
+function conditionalMountPresent(
+  probePath: string,
+  hostHome: string,
+  probeHome: string,
+): boolean {
+  if (existsSync(probePath)) return true;
+  try {
+    if (!lstatSync(probePath).isSymbolicLink()) return false;
+    let target = readlinkSync(probePath);
+    if (!isAbsolute(target)) target = resolve(dirname(probePath), target);
+    if (
+      hostHome &&
+      probeHome &&
+      hostHome !== probeHome &&
+      target.startsWith(hostHome + "/")
+    ) {
+      target = probeHome + target.slice(hostHome.length);
+    }
+    return existsSync(target);
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -1958,7 +1999,7 @@ function emitAgentService(
   // missing `:ro` source. skills/ is operator-authored, non-secret
   // content (WS6 audit: LOW info-disclosure only) so it stays
   // fleet-wide.
-  if (existsSync(`${probeHome}/.switchroom/skills`)) {
+  if (conditionalMountPresent(`${probeHome}/.switchroom/skills`, hostHomeForChecks, probeHome)) {
     lines.push(`      - ${homePrefix}/.switchroom/skills:${homePrefix}/.switchroom/skills:ro`);
   }
   // Operator-declared MCP launcher dir (#1786 follow-up). Operators who
@@ -1973,7 +2014,7 @@ function emitAgentService(
   // skills/ pattern above; existsSync-guarded so dev installs without
   // a launcher dir don't hard-fail compose `up`. Pure-URL MCPs (e.g.
   // notion `type: http`) don't need this mount.
-  if (existsSync(`${probeHome}/.switchroom/mcp-launchers`)) {
+  if (conditionalMountPresent(`${probeHome}/.switchroom/mcp-launchers`, hostHomeForChecks, probeHome)) {
     lines.push(
       `      - ${homePrefix}/.switchroom/mcp-launchers:${homePrefix}/.switchroom/mcp-launchers:ro`,
     );
@@ -1988,7 +2029,7 @@ function emitAgentService(
   // agent never writes here; `switchroom apply` is the only writer.
   // Created with seeded files by `ensureHostMountSources` in apply.ts,
   // so existsSync is true on every post-apply install.
-  if (existsSync(`${probeHome}/.switchroom/fleet`)) {
+  if (conditionalMountPresent(`${probeHome}/.switchroom/fleet`, hostHomeForChecks, probeHome)) {
     lines.push(
       `      - ${homePrefix}/.switchroom/fleet:${homePrefix}/.switchroom/fleet:ro`,
     );
@@ -2007,7 +2048,7 @@ function emitAgentService(
   // pre-existing flat `~/.switchroom/credentials/*` files into per-
   // agent subdirs is surfaced as a loud `doctor` warning (see
   // checkFlatCredentialsMigration) — never a silent break.
-  if (existsSync(`${probeHome}/.switchroom/credentials/${a.name}`)) {
+  if (conditionalMountPresent(`${probeHome}/.switchroom/credentials/${a.name}`, hostHomeForChecks, probeHome)) {
     lines.push(
       `      - ${homePrefix}/.switchroom/credentials/${a.name}:${homePrefix}/.switchroom/credentials:ro`,
     );
@@ -2052,7 +2093,7 @@ function emitAgentService(
   // (i.e. ~/.switchroom-config/ exists). Pre-create the per-agent
   // subdir under operator umask so docker doesn't auto-create as root
   // (the chown sweep in alignAgentUid will fix ownership on next apply).
-  if (existsSync(`${probeHome}/.switchroom-config`)) {
+  if (conditionalMountPresent(`${probeHome}/.switchroom-config`, hostHomeForChecks, probeHome)) {
     try {
       mkdirSync(
         `${probeHome}/.switchroom-config/agents/${a.name}/personal-skills`,
@@ -2104,12 +2145,26 @@ function emitAgentService(
   // exotic test setups and docker compose `up` hard-fails on missing
   // `:ro` sources. Skip when the pool path is already covered by the
   // operator skills mount above (no duplicate volume entries).
+  // bundledSkillsPoolDir is homedir()-derived (container-real — `/host-home`
+  // inside hostd). The mount SOURCE must be the HOST path so the agent
+  // (network_mode host, same path in/out) resolves it; and the
+  // dedup-vs-skills-mount `startsWith` below must compare host-rooted paths
+  // or it mismatches in hostd (`/host-home` vs `/home/op`) and wrongly emits
+  // a `/host-home` source (#2383). Translate probeHome→hostHomeForChecks,
+  // like every other mount source.
+  const bundledSkillsBakeDir =
+    probeHome &&
+    hostHomeForChecks &&
+    probeHome !== hostHomeForChecks &&
+    bundledSkillsPoolDir.startsWith(probeHome + "/")
+      ? hostHomeForChecks + bundledSkillsPoolDir.slice(probeHome.length)
+      : bundledSkillsPoolDir;
   if (
     bundledSkillsPoolDir &&
     existsSync(bundledSkillsPoolDir) &&
-    !bundledSkillsPoolDir.startsWith(`${hostHomeForChecks}/.switchroom/skills`)
+    !bundledSkillsBakeDir.startsWith(`${hostHomeForChecks}/.switchroom/skills`)
   ) {
-    lines.push(`      - ${bundledSkillsPoolDir}:${bundledSkillsPoolDir}:ro`);
+    lines.push(`      - ${bundledSkillsBakeDir}:${bundledSkillsBakeDir}:ro`);
   }
   // switchroom.yaml file mount (read-only) — the in-container gateway
   // daemon needs `--config $SWITCHROOM_CONFIG` to talk to the

--- a/tests/docker/compose-generator.test.ts
+++ b/tests/docker/compose-generator.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -2814,5 +2814,39 @@ describe("conditional-mount probe home (in-hostd apply — marko meta_pages regr
     // existsSync(/home/op/.switchroom/mcp-launchers) is false → not mounted.
     // This is exactly the in-hostd failure mode the probeHomeDir split fixes.
     expect(yaml).not.toContain("/.switchroom/mcp-launchers:");
+  });
+
+  // #2387: a conditional dir that is a symlink to an ABSOLUTE host path
+  // (skills -> /home/op/.switchroom-config/skills) is dropped by plain
+  // existsSync inside hostd (follows the link to /home/op, unresolvable there).
+  it("keeps a symlinked conditional dir (skills→absolute host path) on in-hostd apply (#2387)", () => {
+    // skills is a symlink to an absolute HOST path; the target only resolves
+    // when translated to the container-real home (probeHomeDir).
+    mkdirSync(join(tmpDir, ".switchroom-config", "skills"), { recursive: true });
+    symlinkSync("/home/op/.switchroom-config/skills", join(tmpDir, ".switchroom", "skills"));
+    const yaml = generateCompose({
+      config: makeConfig({ klanker: {} }),
+      homeDir: "/home/op",
+      probeHomeDir: tmpDir,
+    });
+    // The symlink-aware probe resolves the target via probeHome → mount emitted
+    // with the HOST-rooted source (docker follows the symlink host-side).
+    expect(yaml).toContain("/home/op/.switchroom/skills:/home/op/.switchroom/skills:ro");
+  });
+
+  // #2383: a bundled-skills pool OUTSIDE ~/.switchroom/skills must bake a
+  // HOST-rooted mount source, not the container-real /host-home path.
+  it("bakes a host-rooted source for an out-of-skills bundled pool on in-hostd apply (#2383)", () => {
+    const pool = join(tmpDir, "ext-skills-pool");
+    mkdirSync(pool, { recursive: true });
+    const yaml = generateCompose({
+      config: makeConfig({ klanker: {} }),
+      homeDir: "/home/op",
+      probeHomeDir: tmpDir,
+      bundledSkillsPoolDir: pool, // probeHome-rooted (container-real)
+    });
+    // Emitted with the translated HOST path, NOT the container-real tmpDir path.
+    expect(yaml).toContain("/home/op/ext-skills-pool:/home/op/ext-skills-pool:ro");
+    expect(yaml).not.toContain(`${pool}:${pool}:ro`);
   });
 });


### PR DESCRIPTION
Completes the unfinished half of #2382 (in-hostd conditional-mount drops) and bumps hindsight to fix the memory-write FK race. All three were filed after the 2026-06-15 marko meta_pages outage.

## #2387 — symlinked conditional dirs (live)
`~/.switchroom/skills` is a symlink to an **absolute host path** (`/home/op/.switchroom-config/skills`). When `apply` runs inside hostd, `probeHome` is `/host-home` and `existsSync` **follows** the symlink to `/home/op`, which hostd can't see → false → the **skills mount is silently dropped** on any in-hostd reconcile (agent self-restart via hostd). #2382 fixed real dirs but not this.

**Fix:** `conditionalMountPresent` — when the probe path is a symlink, resolve its target against `probeHome` (translate a `hostHome`-rooted target to the container-real home) before checking. The baked mount **source** stays the host path (docker follows it host-side at mount time). Applied to the operator-dir mounts (skills, mcp-launchers, fleet, credentials, .switchroom-config).

## #2383 — bundled-skills pool (latent)
`bundledSkillsPoolDir` is `homedir()`-derived (`/host-home` in hostd). The dedup-vs-skills `startsWith` compared it against the `hostHome`-rooted skills path → mismatch in hostd → the mount was wrongly emitted with a `/host-home` source. **Fix:** translate the bake path `probeHome→hostHomeForChecks` for both the dedup and the mount source.

Both are **no-ops on the host** (`hostHome === probeHome`).

## #2392 — hindsight FK race (separate, runtime migration)
Our hindsight was pinned to upstream **v0.7.1** (2026-05-28). The `batch_retain` `ForeignKeyViolation` on `unit_entities` (silently dropping ~2-3% of memory writes) is the concurrent-retain FK class fixed upstream in vectorize-io/hindsight **#1795 + #1882 (closed 2026-06-01)** plus the 0.8.x entity-link rework. Bump the pinned digest to **v0.8.2** (`7c069db2`, label `version=0.8.2`). Upstream ships only `:latest`, so the digest is the version pin.

⚠️ Applying the hindsight bump runs **DB migrations on the persisted memory volume** — recreate is **backup-first** (`switchroom-hindsight-data`), done as a deliberate step separate from the agent/hostd roll.

## Test plan
- [x] `tests/docker/compose-generator.test.ts`: symlinked-skills mount survives in-hostd (#2387); out-of-skills bundled pool bakes a host-rooted source, never `/host-home` (#2383). 181 passed.
- [x] `tsc --noEmit` clean.
- [ ] hindsight migration verified post-recreate (separate backup-first step).

## Risk
Compose changes: no-op on host, additive in-hostd (only mounts that were wrongly dropped/poisoned now resolve). Hindsight bump: the code change is a 1-line digest; the **runtime** migration is the risk, handled separately backup-first.