### PR TITLE
fix(linear): page the operator when a Linear app token can't self-heal

### DIFF
--- a/src/telegram/topic-router.test.ts
+++ b/src/telegram/topic-router.test.ts
@@ -230,6 +230,16 @@ describe("resolveOutboundTopic — ops-lane events (boot, compact-watchdog, comm
     expect(out).toBe(41);
   });
 
+  it("linear-auth: lands in alerts alias", () => {
+    const out = resolveOutboundTopic(SG_CONFIG, { kind: "linear-auth" });
+    expect(out).toBe(41);
+  });
+
+  it("linear-auth: undefined in fleet mode (no default_topic_id)", () => {
+    const out = resolveOutboundTopic({}, { kind: "linear-auth" });
+    expect(out).toBeUndefined();
+  });
+
   it("command-mutation: lands in admin alias", () => {
     const out = resolveOutboundTopic(SG_CONFIG, { kind: "command-mutation" });
     expect(out).toBe(31);

--- a/src/telegram/topic-router.ts
+++ b/src/telegram/topic-router.ts
@@ -52,6 +52,9 @@ export type OutboundEvent =
   | { kind: "cron"; entryTopic: string | number | undefined }
   // Boot card / SessionStart — always alerts.
   | { kind: "boot" }
+  // Linear app-token auth went dead and can't self-heal (no refresh bundle
+  // or a revoked refresh token) — an operator-action alert, ops/alerts lane.
+  | { kind: "linear-auth" }
   // Compact / watchdog — system-initiated notifications.
   | { kind: "compact-watchdog" }
   // Slash-command output classes that always belong in admin.
@@ -129,6 +132,7 @@ export function resolveOutboundTopic(
     }
     case "boot":
     case "compact-watchdog":
+    case "linear-auth":
       if (!inSupergroupMode) return undefined;
       return aliasToId(cfg, ALERTS_ALIAS) ?? cfg.default_topic_id;
     case "command-mutation":

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -487,7 +487,7 @@ import {
   listGrantsViaBroker,
   revokeGrantViaBroker,
 } from '../../src/vault/broker/client.js'
-import { emitLinearAgentActivity, createLinearIssue } from './linear-activity.js'
+import { emitLinearAgentActivity, createLinearIssue, buildLinearAuthDeadMessage, type LinearAuthDeadReason } from './linear-activity.js'
 import {
   approvalRequest,
   approvalConsume,
@@ -6978,13 +6978,12 @@ const LINEAR_AUTH_ALERT_COOLDOWN_MS = 6 * 60 * 60 * 1000
  * log line. Deduped per (agent,reason) and gated by SWITCHROOM_LINEAR_AUTH_ALERT=0.
  * Best-effort: a failed send never affects the agent's turn.
  */
-function notifyLinearAuthDead(info: { agent: string; reason: 'no_bundle' | 'revoked'; detail: string }): void {
+function notifyLinearAuthDead(info: { agent: string; reason: LinearAuthDeadReason; detail: string }): void {
   if (process.env.SWITCHROOM_LINEAR_AUTH_ALERT === '0') return
   const key = `${info.agent}:${info.reason}`
   const now = Date.now()
   const last = linearAuthAlertLast.get(key)
   if (last != null && now - last < LINEAR_AUTH_ALERT_COOLDOWN_MS) return
-  linearAuthAlertLast.set(key, now)
   void (async () => {
     try {
       const chatId = loadAccess().allowFrom[0]
@@ -6994,18 +6993,7 @@ function notifyLinearAuthDead(info: { agent: string; reason: 'no_bundle' | 'revo
         resolvedTopic: resolveAgentOutboundTopic({ kind: 'linear-auth' }) ?? chatThreadMap.get(chatId),
         supergroupChatId: resolveAgentSupergroupChatId(),
       })
-      const agentLabel = escapeHtml(info.agent)
-      const why =
-        info.reason === 'no_bundle'
-          ? `no refresh credentials are stored (<code>linear/${agentLabel}/oauth</code> is missing), so its daily-expiring token can't renew`
-          : `its Linear refresh token was revoked`
-      const text =
-        `🔑 <b>Linear auth needs you</b>\n` +
-        `<b>${agentLabel}</b> can't reach Linear — ${why}. ` +
-        `Its access token will keep failing until you re-authorize.\n\n` +
-        `Re-auth (actor=app) then run <code>switchroom linear-agent setup --agent ${agentLabel} ` +
-        `--token … --refresh-token … --client-id … --client-secret …</code> on the host, ` +
-        `or ask me to walk you through it.`
+      const text = buildLinearAuthDeadMessage(info.agent, info.reason)
       await swallowingApiCall(
         () =>
           bot.api.sendMessage(chatId, text, {
@@ -7014,6 +7002,10 @@ function notifyLinearAuthDead(info: { agent: string; reason: 'no_bundle' | 'revo
           }),
         { chat_id: chatId, verb: 'linearAuthDead' },
       )
+      // Stamp the cooldown only after a successful send so a transient
+      // Telegram failure doesn't burn the 6h window (the 401 recurs and will
+      // retry the page on the next Linear call).
+      linearAuthAlertLast.set(key, now)
       process.stderr.write(`telegram gateway: linear auth-dead alert sent agent=${info.agent} reason=${info.reason}\n`)
     } catch {
       /* best-effort */

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -6963,12 +6963,70 @@ async function executeSendChecklist(args: Record<string, unknown>): Promise<{ co
   return { content: [{ type: 'text', text: `checklist sent (id: ${sent.message_id})` }] }
 }
 
+/**
+ * Per-(agent,reason) cooldown for the Linear-auth-dead operator alert. The
+ * triggering 401 recurs on every Linear call once the token expires, so
+ * without a cooldown the operator would be paged on every capture/activity.
+ * One alert per reason per window is enough to surface the action item.
+ */
+const linearAuthAlertLast = new Map<string, number>()
+const LINEAR_AUTH_ALERT_COOLDOWN_MS = 6 * 60 * 60 * 1000
+
+/**
+ * Surface an un-healable Linear auth failure (no refresh bundle / revoked
+ * refresh token) to the operator as a Telegram message — not just a gateway
+ * log line. Deduped per (agent,reason) and gated by SWITCHROOM_LINEAR_AUTH_ALERT=0.
+ * Best-effort: a failed send never affects the agent's turn.
+ */
+function notifyLinearAuthDead(info: { agent: string; reason: 'no_bundle' | 'revoked'; detail: string }): void {
+  if (process.env.SWITCHROOM_LINEAR_AUTH_ALERT === '0') return
+  const key = `${info.agent}:${info.reason}`
+  const now = Date.now()
+  const last = linearAuthAlertLast.get(key)
+  if (last != null && now - last < LINEAR_AUTH_ALERT_COOLDOWN_MS) return
+  linearAuthAlertLast.set(key, now)
+  void (async () => {
+    try {
+      const chatId = loadAccess().allowFrom[0]
+      if (!chatId) return
+      const threadId = topicForRecipient({
+        recipientChatId: chatId,
+        resolvedTopic: resolveAgentOutboundTopic({ kind: 'linear-auth' }) ?? chatThreadMap.get(chatId),
+        supergroupChatId: resolveAgentSupergroupChatId(),
+      })
+      const agentLabel = escapeHtml(info.agent)
+      const why =
+        info.reason === 'no_bundle'
+          ? `no refresh credentials are stored (<code>linear/${agentLabel}/oauth</code> is missing), so its daily-expiring token can't renew`
+          : `its Linear refresh token was revoked`
+      const text =
+        `🔑 <b>Linear auth needs you</b>\n` +
+        `<b>${agentLabel}</b> can't reach Linear — ${why}. ` +
+        `Its access token will keep failing until you re-authorize.\n\n` +
+        `Re-auth (actor=app) then run <code>switchroom linear-agent setup --agent ${agentLabel} ` +
+        `--token … --refresh-token … --client-id … --client-secret …</code> on the host, ` +
+        `or ask me to walk you through it.`
+      await swallowingApiCall(
+        () =>
+          bot.api.sendMessage(chatId, text, {
+            parse_mode: 'HTML',
+            ...(threadId != null ? { message_thread_id: threadId } : {}),
+          }),
+        { chat_id: chatId, verb: 'linearAuthDead' },
+      )
+      process.stderr.write(`telegram gateway: linear auth-dead alert sent agent=${info.agent} reason=${info.reason}\n`)
+    } catch {
+      /* best-effort */
+    }
+  })()
+}
+
 async function executeLinearAgentActivity(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
-  return emitLinearAgentActivity(args)
+  return emitLinearAgentActivity(args, { onAuthUnrecoverable: notifyLinearAuthDead })
 }
 
 async function executeLinearCreateIssue(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {
-  return createLinearIssue(args)
+  return createLinearIssue(args, { onAuthUnrecoverable: notifyLinearAuthDead })
 }
 
 async function executeUpdateChecklist(args: Record<string, unknown>): Promise<{ content: Array<{ type: string; text: string }> }> {

--- a/telegram-plugin/gateway/linear-activity.ts
+++ b/telegram-plugin/gateway/linear-activity.ts
@@ -24,6 +24,37 @@ import { performLinearRefresh, type RefreshIO } from '../../src/linear/oauth-ref
 
 export const LINEAR_GRAPHQL_ENDPOINT = 'https://api.linear.app/graphql'
 
+/** The two operator-action reasons a Linear 401 can't self-heal. */
+export type LinearAuthDeadReason = 'no_bundle' | 'revoked'
+
+/** Minimal HTML-escape (Telegram parse_mode: 'HTML'). Kept local so the
+ *  message builder is self-contained + unit-testable without reaching into a
+ *  gateway-only escaper (the bug that shipped the first cut of this alert). */
+function escapeHtmlMin(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/**
+ * Build the operator-facing Telegram alert (HTML) for an un-healable Linear
+ * auth failure. Pure + self-escaping so it can be unit-tested directly. The
+ * gateway's `notifyLinearAuthDead` only handles dedup + transport.
+ */
+export function buildLinearAuthDeadMessage(agent: string, reason: LinearAuthDeadReason): string {
+  const a = escapeHtmlMin(agent)
+  const why =
+    reason === 'no_bundle'
+      ? `no refresh credentials are stored (<code>linear/${a}/oauth</code> is missing), so its daily-expiring token can't renew`
+      : `its Linear refresh token was revoked`
+  return (
+    `🔑 <b>Linear auth needs you</b>\n` +
+    `<b>${a}</b> can't reach Linear — ${why}. ` +
+    `Its access token will keep failing until you re-authorize.\n\n` +
+    `Re-auth (actor=app) then run <code>switchroom linear-agent setup --agent ${a} ` +
+    `--token … --refresh-token … --client-id … --client-secret …</code> on the host, ` +
+    `or ask me to walk you through it.`
+  )
+}
+
 export type LinearTokenResult =
   | { ok: true; token: string }
   | { ok: false; reason: 'denied' | 'unreachable' | 'not_found' | 'unknown' }
@@ -51,7 +82,7 @@ export interface LinearActivityDeps {
    *  Telegram alert so a daily-expiring token stops failing invisibly. NOT
    *  called for transient reasons (network/http_error/bad_response) — those
    *  retry on their own. */
-  onAuthUnrecoverable?: (info: { agent: string; reason: 'no_bundle' | 'revoked'; detail: string }) => void
+  onAuthUnrecoverable?: (info: { agent: string; reason: LinearAuthDeadReason; detail: string }) => void
 }
 
 export type ToolTextResult = { content: Array<{ type: string; text: string }> }
@@ -114,7 +145,7 @@ async function linearPostWithRefresh(
   fetchImpl: typeof fetch,
   log: (s: string) => void,
   refreshIO?: (agent: string) => RefreshIO,
-  onAuthUnrecoverable?: (info: { agent: string; reason: 'no_bundle' | 'revoked'; detail: string }) => void,
+  onAuthUnrecoverable?: (info: { agent: string; reason: LinearAuthDeadReason; detail: string }) => void,
 ): Promise<{ resp: Response; token: string }> {
   const post = (t: string) =>
     fetchImpl(LINEAR_GRAPHQL_ENDPOINT, {

--- a/telegram-plugin/gateway/linear-activity.ts
+++ b/telegram-plugin/gateway/linear-activity.ts
@@ -44,6 +44,14 @@ export interface LinearActivityDeps {
   defaultTeamId?: string
   /** Log sink — stderr in production. */
   log?: (line: string) => void
+  /** Invoked when a Linear 401 CANNOT self-heal because the situation needs
+   *  an operator to act: `no_bundle` (no refresh credentials were ever
+   *  stored — the silent-setup-failure case) or `revoked` (the refresh token
+   *  itself is dead). The gateway wires this to a deduped operator-facing
+   *  Telegram alert so a daily-expiring token stops failing invisibly. NOT
+   *  called for transient reasons (network/http_error/bad_response) — those
+   *  retry on their own. */
+  onAuthUnrecoverable?: (info: { agent: string; reason: 'no_bundle' | 'revoked'; detail: string }) => void
 }
 
 export type ToolTextResult = { content: Array<{ type: string; text: string }> }
@@ -106,6 +114,7 @@ async function linearPostWithRefresh(
   fetchImpl: typeof fetch,
   log: (s: string) => void,
   refreshIO?: (agent: string) => RefreshIO,
+  onAuthUnrecoverable?: (info: { agent: string; reason: 'no_bundle' | 'revoked'; detail: string }) => void,
 ): Promise<{ resp: Response; token: string }> {
   const post = (t: string) =>
     fetchImpl(LINEAR_GRAPHQL_ENDPOINT, {
@@ -125,7 +134,21 @@ async function linearPostWithRefresh(
         `telegram gateway: linear token REVOKED agent=${agent} — refresh token is dead; ` +
           `operator must re-authorize (linear-agent setup --refresh-token …)\n`,
       )
+      onAuthUnrecoverable?.({ agent, reason: 'revoked', detail: refreshed.detail })
+    } else if (refreshed.reason === 'no_bundle') {
+      // No refresh bundle was ever stored (the silent-setup-failure case):
+      // the access token expires ~daily and there is nothing to renew from.
+      // This is invisible in the gateway log alone — surface it to the
+      // operator so they can re-provision instead of the agent failing
+      // every day forever.
+      log(
+        `telegram gateway: linear token DEAD agent=${agent} — no refresh bundle stored ` +
+          `(linear/${agent}/oauth absent); operator must re-authorize\n`,
+      )
+      onAuthUnrecoverable?.({ agent, reason: 'no_bundle', detail: refreshed.detail })
     } else {
+      // Transient (network / http_error / bad_response): retries on its own,
+      // no operator action — log only, don't page.
       log(`telegram gateway: linear token refresh failed agent=${agent} reason=${refreshed.reason}\n`)
     }
     return { resp, token } // surface the original 401
@@ -206,6 +229,7 @@ export async function emitLinearAgentActivity(
       fetchImpl,
       log,
       deps.refreshIO,
+      deps.onAuthUnrecoverable,
     ))
   } catch (err) {
     return {
@@ -312,6 +336,7 @@ export async function createLinearIssue(
         fetchImpl,
         log,
         deps.refreshIO,
+        deps.onAuthUnrecoverable,
       )
       resp = out.resp
       activeToken = out.token

--- a/telegram-plugin/tests/linear-agent-activity.test.ts
+++ b/telegram-plugin/tests/linear-agent-activity.test.ts
@@ -197,3 +197,60 @@ describe('linear_agent_activity — auto-refresh on 401 (#2298 durability)', () 
     expect(calls.length).toBe(1)
   })
 })
+
+/** RefreshIO whose bundle is absent → performLinearRefresh returns no_bundle
+ *  (the silent-setup-failure case clerk/carrie hit in prod). */
+function noBundleRefreshIO(): RefreshIO {
+  return { readBundle: async () => null, writeToken: async () => {}, writeBundle: async () => {} }
+}
+
+describe('emitLinearAgentActivity — operator alert when auth is unrecoverable (FIX 1)', () => {
+  it('no refresh bundle → onAuthUnrecoverable(no_bundle) fires', async () => {
+    const { fetchImpl } = refreshAwareFetch()
+    const alerts: Array<{ agent: string; reason: string }> = []
+    const r = await emitLinearAgentActivity(
+      { agent_session_id: 'sess', type: 'thought', body: 'hi' },
+      {
+        agent: 'clerk',
+        resolveToken: okToken('lin_expired'),
+        fetchImpl,
+        refreshIO: () => noBundleRefreshIO(),
+        log: () => {},
+        onAuthUnrecoverable: (i) => alerts.push(i),
+      },
+    )
+    expect(r.content[0].text).toMatch(/Linear API 401/)
+    expect(alerts).toEqual([{ agent: 'clerk', reason: 'no_bundle', detail: expect.any(String) }])
+  })
+
+  it('revoked refresh token → onAuthUnrecoverable(revoked) fires', async () => {
+    const { fetchImpl } = refreshAwareFetch({ tokenStatus: 400, tokenBody: 'invalid_grant' })
+    const alerts: Array<{ agent: string; reason: string }> = []
+    await emitLinearAgentActivity(
+      { agent_session_id: 'sess', type: 'thought', body: 'hi' },
+      { agent: 'carrie', resolveToken: okToken('lin_dead'), fetchImpl, refreshIO: () => fakeRefreshIO().io, log: () => {}, onAuthUnrecoverable: (i) => alerts.push(i) },
+    )
+    expect(alerts.map((a) => a.reason)).toEqual(['revoked'])
+  })
+
+  it('transient refresh failure (HTTP 500) does NOT page the operator', async () => {
+    const { fetchImpl } = refreshAwareFetch({ tokenStatus: 500, tokenBody: 'upstream boom' })
+    const alerts: unknown[] = []
+    await emitLinearAgentActivity(
+      { agent_session_id: 'sess', type: 'thought', body: 'hi' },
+      { agent: 'carrie', resolveToken: okToken('lin_x'), fetchImpl, refreshIO: () => fakeRefreshIO().io, log: () => {}, onAuthUnrecoverable: (i) => alerts.push(i) },
+    )
+    expect(alerts).toEqual([])
+  })
+
+  it('successful auto-refresh does NOT page the operator', async () => {
+    const { fetchImpl } = refreshAwareFetch()
+    const alerts: unknown[] = []
+    const r = await emitLinearAgentActivity(
+      { agent_session_id: 'sess', type: 'thought', body: 'hi' },
+      { agent: 'carrie', resolveToken: okToken('lin_expired'), fetchImpl, refreshIO: () => fakeRefreshIO().io, log: () => {}, onAuthUnrecoverable: (i) => alerts.push(i) },
+    )
+    expect(r.content[0].text).toMatch(/emitted/)
+    expect(alerts).toEqual([])
+  })
+})

--- a/telegram-plugin/tests/linear-agent-activity.test.ts
+++ b/telegram-plugin/tests/linear-agent-activity.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import {
   emitLinearAgentActivity,
+  buildLinearAuthDeadMessage,
   type LinearTokenResult,
 } from '../gateway/linear-activity.js'
 
@@ -241,6 +242,25 @@ describe('emitLinearAgentActivity — operator alert when auth is unrecoverable 
       { agent: 'carrie', resolveToken: okToken('lin_x'), fetchImpl, refreshIO: () => fakeRefreshIO().io, log: () => {}, onAuthUnrecoverable: (i) => alerts.push(i) },
     )
     expect(alerts).toEqual([])
+  })
+
+  it('buildLinearAuthDeadMessage: no_bundle names the missing oauth key + re-auth command', () => {
+    const msg = buildLinearAuthDeadMessage('clerk', 'no_bundle')
+    expect(msg).toMatch(/Linear auth needs you/)
+    expect(msg).toContain('<code>linear/clerk/oauth</code>')
+    expect(msg).toContain('switchroom linear-agent setup --agent clerk')
+  })
+
+  it('buildLinearAuthDeadMessage: revoked says the refresh token was revoked', () => {
+    const msg = buildLinearAuthDeadMessage('carrie', 'revoked')
+    expect(msg).toMatch(/refresh token was revoked/)
+    expect(msg).not.toContain('/oauth</code> is missing')
+  })
+
+  it('buildLinearAuthDeadMessage: HTML-escapes a hostile agent slug', () => {
+    const msg = buildLinearAuthDeadMessage('a<b>&c', 'no_bundle')
+    expect(msg).toContain('a&lt;b&gt;&amp;c')
+    expect(msg).not.toContain('a<b>&c')
   })
 
   it('successful auto-refresh does NOT page the operator', async () => {


### PR DESCRIPTION
## Summary

clerk and carrie have been failing Linear silently — a daily 401 with no operator visibility. Root cause: their `linear/<agent>/oauth` **refresh bundle** was never persisted (the `linear-agent setup` runs happened *in-container*, where the bundle write can't land), so the access token expires (~24h) with nothing to refresh from. At runtime the un-healable 401 was only written to the gateway log; the operator never saw it.

This makes the two operator-action failure modes loud.

## Why

JTBD: *always available* + *you hold the leash*. An agent that's silently dead in Linear is neither. The self-heal (#2298/#2360) only works when a bundle exists; when it doesn't (or the refresh token is revoked), the operator needs to know so they can re-authorize.

## What changed

- **topic-router**: new `linear-auth` outbound event kind, routed to the `alerts` lane (alongside `boot`/`compact-watchdog`).
- **linear-activity**: `onAuthUnrecoverable({agent, reason})` dep, fired **only** on `no_bundle` / `revoked`. Transient reasons (`network`/`http_error`/`bad_response`) still log-only — they retry on their own and shouldn't page.
- **gateway**: `notifyLinearAuthDead` posts a Telegram alert via the wrapped `swallowingApiCall` path (no raw `bot.api`), deduped 6h per `(agent, reason)`, kill-switch `SWITCHROOM_LINEAR_AUTH_ALERT=0`.

## Test plan

- [x] `linear-agent-activity.test.ts`: no_bundle→alert, revoked→alert, transient(500)→no alert, success→no alert
- [x] `topic-router.test.ts`: `linear-auth`→alerts alias; fleet-mode→undefined
- [x] `tsc --noEmit` clean
- [x] `check-bot-api-wrapping.sh` clean
- [x] `check-plugin-references.mjs` clean

## Risk

Low. Additive dep (default undefined = old behaviour), one new router kind, send is best-effort + deduped + kill-switched. No change to the refresh/self-heal path itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)