### PR TITLE
feat(linear): harden + proactively monitor agent auth

### DIFF
--- a/docs/linear.md
+++ b/docs/linear.md
@@ -169,6 +169,31 @@ Recovery: re-run the **Setup — the OAuth dance** above and `setup` with the ne
 `--refresh-token`. (Everything else — transient network/HTTP errors — is
 treated as retryable and not surfaced as a re-auth ask.)
 
+### Proactive watch (don't wait for a 401)
+
+Refresh + the operator alert used to be **reactive only** — they fired when an
+agent made a live Linear call and got a `401`. A linear-enabled agent that
+rarely calls Linear could sit dead-auth unnoticed. The gateway now runs a
+**proactive Linear-auth watch** on boot (35 s after start) and every 6 h
+(`SWITCHROOM_LINEAR_AUTH_WATCH_POLL_MS`, `0` disables):
+
+- bundle **missing/invalid** → fires the operator alert immediately;
+- access token **within the 2 h refresh skew** → rotates it proactively (so the
+  next real call never eats a 401), surfacing a **revoked** refresh token via
+  the alert;
+- token fresh / expiry-untracked → nothing (the reactive path still covers
+  untracked bundles).
+
+Logged as `telegram gateway: linear-auth-watch agent=<name> status=<…>`.
+
+### Footgun guard: `linear-agent setup`/`refresh` are HOST commands
+
+`setup`/`refresh` write the vault file directly with the operator passphrase.
+Run **inside an agent container** they would silently create a throwaway vault
+and "succeed" (the original clerk/carrie failure). They now **refuse** in a
+sandbox (`SWITCHROOM_RUNTIME=docker`) with a clear error pointing at the
+`linear_agent_setup` MCP tool (in-container) or the host shell.
+
 When auth dies (revoked, OR no refresh bundle was ever stored), the operator
 also gets a **🔑 Linear auth needs you** Telegram alert in the alerts lane —
 no more silent daily 401s (the clerk/carrie incident, 2026-06-16). Kill-switch:

--- a/src/cli/linear-agent.ts
+++ b/src/cli/linear-agent.ts
@@ -47,6 +47,32 @@ function bundleKeyFor(agent: string): string {
   return `linear/${agent}/oauth`;
 }
 
+/**
+ * `setup`/`refresh` write the vault FILE directly (operator passphrase). Inside
+ * an agent container there is no mounted vault + no passphrase, so those writes
+ * silently create a throwaway vault and "succeed" — the exact footgun that left
+ * clerk/carrie with a token but no refresh bundle (a daily 401 with no
+ * self-heal, 2026-06-16). Fail loudly instead and point at the sanctioned
+ * in-container path (the `linear_agent_setup` MCP tool) or the host shell.
+ */
+export function linearSandboxRefusal(
+  verb: string,
+  runtime: string | undefined = process.env.SWITCHROOM_RUNTIME,
+): string | null {
+  if (runtime !== "docker") return null;
+  return (
+    `'linear-agent ${verb}' is a HOST command — it writes the vault file directly, which ` +
+    `doesn't work inside an agent container (no mounted vault, no passphrase) and would ` +
+    `silently no-op.\n  • In-container: use the 'linear_agent_setup' MCP tool (operator-approved).\n` +
+    `  • On the host shell: run this same command there.`
+  );
+}
+
+function refuseInSandbox(verb: string): void {
+  const msg = linearSandboxRefusal(verb);
+  if (msg) fail(msg);
+}
+
 export function registerLinearAgentCommand(program: Command): void {
   const linear = program
     .command("linear-agent")
@@ -77,6 +103,7 @@ export function registerLinearAgentCommand(program: Command): void {
     .option("--dry-run", "Print the YAML diff + instructions without writing or vaulting anything")
     .action(
       withConfigError(async (opts: LinearAgentSetupOpts) => {
+        refuseInSandbox("setup");
         if (!/^[a-z][a-z0-9_-]{0,63}$/.test(opts.agent)) {
           fail(`--agent must be a lowercase agent slug (got '${opts.agent}').`);
         }
@@ -171,6 +198,7 @@ export function registerLinearAgentCommand(program: Command): void {
     .requiredOption("--agent <name>", "Agent name (must have a linear_agent block)")
     .action(
       withConfigError(async (opts: { agent: string }) => {
+        refuseInSandbox("refresh");
         if (!/^[a-z][a-z0-9_-]{0,63}$/.test(opts.agent)) {
           fail(`--agent must be a lowercase agent slug (got '${opts.agent}').`);
         }

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -487,8 +487,10 @@ import {
   listGrantsViaBroker,
   revokeGrantViaBroker,
 } from '../../src/vault/broker/client.js'
-import { emitLinearAgentActivity, createLinearIssue, buildLinearAuthDeadMessage, type LinearAuthDeadReason } from './linear-activity.js'
+import { emitLinearAgentActivity, createLinearIssue, buildLinearAuthDeadMessage, brokerRefreshIO, type LinearAuthDeadReason } from './linear-activity.js'
 import { runLinearAgentSetup } from './linear-setup.js'
+import { runLinearAuthCheck } from './linear-auth-watch.js'
+import { performLinearRefresh } from '../../src/linear/oauth-refresh.js'
 import {
   approvalRequest,
   approvalConsume,
@@ -13237,6 +13239,46 @@ function resolveAgentSupergroupChatId(): string | undefined {
   }
 }
 
+/** Whether THIS agent has `channels.telegram.linear_agent.enabled`. Used by the
+ *  proactive Linear-auth watch to skip agents that aren't Linear actors. */
+function isSelfLinearAgentEnabled(): boolean {
+  const agentName = process.env.SWITCHROOM_AGENT_NAME
+  if (!agentName) return false
+  try {
+    const cfg = loadSwitchroomConfig()
+    const rawAgent = cfg.agents?.[agentName]
+    if (!rawAgent) return false
+    const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent)
+    const la = (resolved.channels?.telegram as { linear_agent?: { enabled?: boolean } } | undefined)?.linear_agent
+    return la?.enabled === true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * One proactive Linear-auth check for this agent (boot + interval). Reads the
+ * refresh bundle via the broker; missing → operator alert, near-expiry →
+ * proactive rotate, revoked → operator alert. Best-effort, never throws.
+ * Disabled with SWITCHROOM_LINEAR_AUTH_WATCH_POLL_MS=0.
+ */
+async function runLinearAuthWatch(): Promise<void> {
+  const agent = process.env.SWITCHROOM_AGENT_NAME
+  if (!agent) return
+  const io = brokerRefreshIO(agent)
+  const status = await runLinearAuthCheck({
+    agent,
+    linearEnabled: isSelfLinearAgentEnabled,
+    readBundle: io.readBundle,
+    refresh: () => performLinearRefresh(io),
+    onAuthDead: notifyLinearAuthDead,
+    log: (s) => process.stderr.write(s),
+  })
+  if (status !== 'disabled' && status !== 'fresh') {
+    process.stderr.write(`telegram gateway: linear-auth-watch agent=${agent} status=${status}\n`)
+  }
+}
+
 /**
  * Stamp a user-facing restart reason into the clean-shutdown marker
  * (same file the SIGTERM handler writes to and the next session greeting
@@ -21457,6 +21499,24 @@ void (async () => {
               process.stderr.write(`telegram gateway: quota-watch scheduled run failed: ${err}\n`)
             })
           }, QUOTA_WATCH_POLL_MS).unref()
+        }
+
+        // Proactive Linear-auth watch (FIX 3): catch a dead/missing/near-expiry
+        // Linear bundle BEFORE the agent needs Linear, instead of only on a live
+        // 401. Boot run (delayed so the broker connection settles) + interval.
+        // SWITCHROOM_LINEAR_AUTH_WATCH_POLL_MS=0 disables it.
+        const LINEAR_AUTH_WATCH_POLL_MS = Number(process.env.SWITCHROOM_LINEAR_AUTH_WATCH_POLL_MS ?? 6 * 60 * 60_000)
+        if (LINEAR_AUTH_WATCH_POLL_MS > 0) {
+          setTimeout(() => {
+            void runLinearAuthWatch().catch((err) => {
+              process.stderr.write(`telegram gateway: linear-auth-watch initial run failed: ${err}\n`)
+            })
+          }, 35_000)
+          setInterval(() => {
+            void runLinearAuthWatch().catch((err) => {
+              process.stderr.write(`telegram gateway: linear-auth-watch scheduled run failed: ${err}\n`)
+            })
+          }, LINEAR_AUTH_WATCH_POLL_MS).unref()
         }
 
         // Restart-watchdog: poll systemd's NRestarts for the agent unit.

--- a/telegram-plugin/gateway/linear-auth-watch.ts
+++ b/telegram-plugin/gateway/linear-auth-watch.ts
@@ -1,0 +1,102 @@
+/**
+ * Proactive Linear auth watch (FIX 3 — observability).
+ *
+ * Before this, Linear auth was only ever checked REACTIVELY: a refresh (and the
+ * "🔑 Linear auth needs you" operator alert) happened only when an agent made a
+ * live Linear call and got a 401. A linear-enabled agent that rarely calls
+ * Linear could therefore sit dead-auth (missing bundle / revoked refresh /
+ * silently-expired token) completely unnoticed until the moment it needed
+ * Linear.
+ *
+ * This runs a small check on boot + on an interval (mirrors quota-watch):
+ *   - bundle missing/invalid  → fire the operator alert (no_bundle) NOW.
+ *   - bundle present + access token within the refresh skew → proactively
+ *     rotate it (so the next real call never eats a 401), and surface a revoked
+ *     refresh token via the operator alert.
+ *   - bundle present + token fresh → nothing.
+ *
+ * Pure orchestration over injected deps so it is unit-testable without a broker
+ * or the network. The gateway wires the broker-backed deps + notifyLinearAuthDead.
+ */
+
+import {
+  parseBundle,
+  needsRefresh,
+  type PerformRefreshResult,
+} from '../../src/linear/oauth-refresh.js'
+
+export type LinearAuthWatchStatus =
+  | 'disabled'
+  | 'fresh'
+  | 'no_bundle'
+  | 'refreshed'
+  | 'revoked'
+  | 'refresh_failed'
+
+export interface LinearAuthWatchDeps {
+  agent: string
+  /** Whether this agent has linear_agent enabled (reads config). */
+  linearEnabled: () => boolean
+  /** Read the raw JSON bundle from linear/<agent>/oauth (broker). */
+  readBundle: () => Promise<string | null>
+  /** Rotate the token via the stored bundle (performLinearRefresh over broker). */
+  refresh: () => Promise<PerformRefreshResult>
+  /** Operator alert (gateway's notifyLinearAuthDead). */
+  onAuthDead: (info: { agent: string; reason: 'no_bundle' | 'revoked'; detail: string }) => void
+  /** Epoch seconds (injectable for tests). */
+  nowSec?: () => number
+  log?: (line: string) => void
+}
+
+/**
+ * One proactive check. Never throws — returns a status the caller can log.
+ */
+export async function runLinearAuthCheck(deps: LinearAuthWatchDeps): Promise<LinearAuthWatchStatus> {
+  const log = deps.log ?? (() => {})
+  if (!deps.linearEnabled()) return 'disabled'
+
+  let raw: string | null
+  try {
+    raw = await deps.readBundle()
+  } catch (err) {
+    // A broker read failure is transient infra, not an auth problem — don't
+    // page the operator, just log.
+    log(`telegram gateway: linear-auth-watch agent=${deps.agent} bundle read error: ${(err as Error).message}\n`)
+    return 'refresh_failed'
+  }
+
+  const bundle = parseBundle(raw)
+  if (!bundle) {
+    // The silent-setup-failure case: linear_agent is enabled but no refresh
+    // bundle was ever stored. Surface it proactively.
+    log(`telegram gateway: linear-auth-watch agent=${deps.agent} — no refresh bundle (proactive)\n`)
+    deps.onAuthDead({ agent: deps.agent, reason: 'no_bundle', detail: 'proactive watch: linear/<agent>/oauth missing or invalid' })
+    return 'no_bundle'
+  }
+
+  const now = deps.nowSec ? deps.nowSec() : Math.floor(Date.now() / 1000)
+  if (!needsRefresh(bundle.expiresAt, now)) {
+    // Fresh, or expiry-untracked (older bundle) — the reactive-on-401 path
+    // covers untracked bundles; nothing to do proactively.
+    return 'fresh'
+  }
+
+  // Within the refresh skew → rotate now so the next real call never 401s.
+  const res = await deps.refresh()
+  if (res.ok) {
+    log(`telegram gateway: linear-auth-watch agent=${deps.agent} proactively refreshed (was near expiry)\n`)
+    return 'refreshed'
+  }
+  if (res.reason === 'revoked') {
+    log(`telegram gateway: linear-auth-watch agent=${deps.agent} refresh REVOKED (proactive)\n`)
+    deps.onAuthDead({ agent: deps.agent, reason: 'revoked', detail: res.detail })
+    return 'revoked'
+  }
+  if (res.reason === 'no_bundle') {
+    deps.onAuthDead({ agent: deps.agent, reason: 'no_bundle', detail: res.detail })
+    return 'no_bundle'
+  }
+  // Transient (network/http_error/bad_response/persist_failed) — log, don't page.
+  log(`telegram gateway: linear-auth-watch agent=${deps.agent} proactive refresh failed reason=${res.reason}\n`)
+  return 'refresh_failed'
+}

--- a/telegram-plugin/tests/linear-auth-watch.test.ts
+++ b/telegram-plugin/tests/linear-auth-watch.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { runLinearAuthCheck, type LinearAuthWatchDeps } from '../gateway/linear-auth-watch.js'
+import { serializeBundle } from '../../src/linear/oauth-refresh.js'
+
+function baseDeps(over: Partial<LinearAuthWatchDeps> = {}): { deps: LinearAuthWatchDeps; alerts: Array<{ reason: string }> } {
+  const alerts: Array<{ reason: string }> = []
+  const deps: LinearAuthWatchDeps = {
+    agent: 'clerk',
+    linearEnabled: () => true,
+    readBundle: async () => serializeBundle({ clientId: 'c', clientSecret: 's', refreshToken: 'rt', expiresAt: 10_000 }),
+    refresh: async () => ({ ok: true, accessToken: 'lin_new', expiresAt: 20_000 }),
+    onAuthDead: (i) => alerts.push(i),
+    nowSec: () => 1_000, // far before expiry → fresh
+    log: () => {},
+    ...over,
+  }
+  return { deps, alerts }
+}
+
+describe('runLinearAuthCheck (proactive Linear auth watch)', () => {
+  it('disabled agent → no-op, no alert', async () => {
+    const { deps, alerts } = baseDeps({ linearEnabled: () => false })
+    expect(await runLinearAuthCheck(deps)).toBe('disabled')
+    expect(alerts).toEqual([])
+  })
+
+  it('fresh token (not near expiry) → fresh, no refresh, no alert', async () => {
+    let refreshed = false
+    const { deps, alerts } = baseDeps({ refresh: async () => { refreshed = true; return { ok: true, accessToken: 'x', expiresAt: 1 } } })
+    expect(await runLinearAuthCheck(deps)).toBe('fresh')
+    expect(refreshed).toBe(false)
+    expect(alerts).toEqual([])
+  })
+
+  it('missing bundle → no_bundle + proactive operator alert', async () => {
+    const { deps, alerts } = baseDeps({ readBundle: async () => null })
+    expect(await runLinearAuthCheck(deps)).toBe('no_bundle')
+    expect(alerts).toEqual([{ agent: 'clerk', reason: 'no_bundle', detail: expect.any(String) }])
+  })
+
+  it('near-expiry token → proactively refreshes, no alert', async () => {
+    // now=9999 is within the 2h skew of expiresAt=10000
+    const { deps, alerts } = baseDeps({ nowSec: () => 9_999 })
+    expect(await runLinearAuthCheck(deps)).toBe('refreshed')
+    expect(alerts).toEqual([])
+  })
+
+  it('near-expiry + revoked refresh token → alert(revoked)', async () => {
+    const { deps, alerts } = baseDeps({
+      nowSec: () => 9_999,
+      refresh: async () => ({ ok: false, reason: 'revoked', detail: 'invalid_grant' }),
+    })
+    expect(await runLinearAuthCheck(deps)).toBe('revoked')
+    expect(alerts.map((a) => a.reason)).toEqual(['revoked'])
+  })
+
+  it('near-expiry + transient refresh failure → no alert (retries later)', async () => {
+    const { deps, alerts } = baseDeps({
+      nowSec: () => 9_999,
+      refresh: async () => ({ ok: false, reason: 'network', detail: 'boom' }),
+    })
+    expect(await runLinearAuthCheck(deps)).toBe('refresh_failed')
+    expect(alerts).toEqual([])
+  })
+
+  it('broker read error → refresh_failed, no alert (transient infra)', async () => {
+    const { deps, alerts } = baseDeps({ readBundle: async () => { throw new Error('broker down') } })
+    expect(await runLinearAuthCheck(deps)).toBe('refresh_failed')
+    expect(alerts).toEqual([])
+  })
+
+  it('expiry-untracked bundle (no expiresAt) → fresh (reactive path covers it)', async () => {
+    const { deps, alerts } = baseDeps({
+      readBundle: async () => serializeBundle({ clientId: 'c', clientSecret: 's', refreshToken: 'rt' }),
+    })
+    expect(await runLinearAuthCheck(deps)).toBe('fresh')
+    expect(alerts).toEqual([])
+  })
+})

--- a/tests/linear-agent-sandbox-guard.test.ts
+++ b/tests/linear-agent-sandbox-guard.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { linearSandboxRefusal } from "../src/cli/linear-agent.js";
+
+describe("linearSandboxRefusal — host-only CLI guard", () => {
+  it("refuses setup inside an agent container (SWITCHROOM_RUNTIME=docker)", () => {
+    const msg = linearSandboxRefusal("setup", "docker");
+    expect(msg).not.toBeNull();
+    expect(msg).toMatch(/HOST command/);
+    expect(msg).toMatch(/linear_agent_setup/); // points at the in-container tool
+  });
+
+  it("refuses refresh too", () => {
+    expect(linearSandboxRefusal("refresh", "docker")).toMatch(/'linear-agent refresh'/);
+  });
+
+  it("allows on the host (runtime undefined or non-docker)", () => {
+    expect(linearSandboxRefusal("setup", undefined)).toBeNull();
+    expect(linearSandboxRefusal("setup", "systemd")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the durability + observability gaps that the clerk/carrie incident exposed (follow-up to #2394 alert + #2396 self-serve tool).

## Why

The operator asked: *is this durable going forward, and do we have proper monitoring/logging?* The honest answer was "mostly, but two real gaps" — this fixes them.

## What changed

1. **Sandbox guard.** `linear-agent setup`/`refresh` are HOST commands (they write the vault file directly with the operator passphrase). Run *inside an agent container* they silently created a throwaway vault and "succeeded" — the **exact footgun** that left clerk/carrie with a token but no refresh bundle. They now refuse under `SWITCHROOM_RUNTIME=docker` with a clear error pointing at the `linear_agent_setup` MCP tool (in-container) or the host shell. Pure `linearSandboxRefusal`, unit-tested.

2. **Proactive Linear-auth watch.** Refresh + the operator alert were **reactive only** (fired on a live 401), so a low-traffic Linear agent could sit dead-auth unnoticed. New gateway watch runs on boot (35 s) + every 6 h (`SWITCHROOM_LINEAR_AUTH_WATCH_POLL_MS=0` disables): missing bundle → operator alert now; near-expiry token → proactive rotate (so the next real call never eats a 401); revoked → alert. Wires the previously-dead `needsRefresh` helper. Pure `runLinearAuthCheck` over injected broker/refresh deps, reuses `notifyLinearAuthDead`.

3. **docs/linear.md** — the proactive watch, the sandbox guard, and the log lines to grep.

## Test plan

- [x] `tests/linear-agent-sandbox-guard.test.ts` — refuse in docker (setup+refresh), allow on host
- [x] `telegram-plugin/tests/linear-auth-watch.test.ts` — disabled/fresh/missing→alert/near-expiry→refresh/revoked→alert/transient→no-alert/broker-error/untracked-expiry (8 cases)
- [x] existing linear suites green; `tsc`, plugin build, `check-plugin-references`, `check-bot-api-wrapping` clean — 59 tests

## Risk

Low. Guard is a pure env check on a host-only CLI. The watch is best-effort (never throws), kill-switchable, and only adds a boot+interval task mirroring quota-watch; the refresh it triggers is the same broker path already used reactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)