### PR TITLE
fix(agents): autoaccept boot poller waits for REPL, not a 30s timer

### DIFF
--- a/src/agents/autoaccept.ts
+++ b/src/agents/autoaccept.ts
@@ -47,10 +47,29 @@ export interface PromptRule {
 
 export interface AutoacceptOptions {
   agentName: string;
-  /** Per-prompt timeout in ms. Default 30000. After this many ms with no prompt match, exit cleanly. */
-  idleTimeoutMs?: number;
+  /**
+   * Absolute ceiling (ms) on the boot phase. The poller normally exits the
+   * INSTANT claude reaches the REPL (see `replReadyMatch`); this cap only
+   * bounds the pathological "claude never boots" case so the sidecar can
+   * still hand off to the watch phase instead of looping forever. Default
+   * 600_000 (10 min) — deliberately generous.
+   *
+   * It is NOT an idle timer. The pre-REPL pane (blank, a shell line, a
+   * half-rendered banner, or a not-yet-matched prompt) must never trigger an
+   * early exit: that is precisely what stranded 11/12 agents on the
+   * unanswered dev-channels prompt during the 2026-06-17 cold full-host
+   * restart, where claude — starved for CPU while every agent booted at once
+   * — took well over the old 30s idle window just to render the prompt.
+   */
+  bootHardCapMs?: number;
   /** Per-poll interval in ms. Default 250. */
   pollIntervalMs?: number;
+  /**
+   * Pane signature that means claude has reached the interactive REPL — the
+   * clean signal to end the boot phase and hand off to the wedge-watchdog.
+   * Default: REPL_READY_SIGNATURE.
+   */
+  replReadyMatch?: RegExp;
   /** Override prompt set for tests. Default: built-in PROMPTS. */
   prompts?: PromptRule[];
   /** Test seam: cap total polls before giving up regardless of timer wall-clock. */
@@ -62,7 +81,12 @@ export interface AutoacceptOptions {
 
 export interface AutoacceptResult {
   fired: string[];
-  reason: "idle-timeout" | "manual-stop";
+  /**
+   * - `repl-ready`: claude reached the REPL — the normal, healthy handoff.
+   * - `idle-timeout`: `bootHardCapMs` elapsed without reaching the REPL.
+   * - `manual-stop`: `maxPolls` reached (tests only).
+   */
+  reason: "repl-ready" | "idle-timeout" | "manual-stop";
 }
 
 // Translated from `bin/autoaccept.exp`. The expect script uses `.{1,30}`
@@ -137,7 +161,19 @@ export const PROMPTS: PromptRule[] = [
   },
 ];
 
-const DEFAULT_IDLE_MS = 30_000;
+/**
+ * claude's interactive REPL footer. It is present on both the idle prompt
+ * ("? for shortcuts"), a working turn ("esc to interrupt"), and the
+ * "accept edits on" / "← for agents" affordances. None of these appear on
+ * ANY first-run prompt screen (those show "Enter to confirm · Esc to
+ * cancel"), so a match unambiguously means claude has finished booting and
+ * dispatched all first-run prompts — the clean signal to hand the pane over
+ * to the continuous wedge-watchdog.
+ */
+export const REPL_READY_SIGNATURE =
+  /← for agents|accept edits on|\? for shortcuts|esc to interrupt/;
+
+const DEFAULT_BOOT_HARD_CAP_MS = 600_000;
 const DEFAULT_POLL_MS = 250;
 
 function defaultSleep(ms: number): Promise<void> {
@@ -189,14 +225,24 @@ export function sendKeys(agentName: string, keys: string[]): boolean {
 }
 
 /**
- * Run the autoaccept poller until idle-timeout. Resolves with the list of
- * fired prompt names. Never throws.
+ * Run the autoaccept boot poller. Dispatches first-run TUI prompts as they
+ * render, and returns the moment claude reaches the REPL (`repl-ready`) so
+ * the caller can hand off to the continuous wedge-watchdog. Resolves with
+ * the list of fired prompt names. Never throws.
+ *
+ * Crucially the poller does NOT give up on a quiet pane: it keeps polling
+ * until claude is demonstrably up (REPL footer) or the generous
+ * `bootHardCapMs` ceiling trips. The previous "30s idle since launch"
+ * heuristic gave up before a slow-booting claude had even rendered the
+ * dev-channels prompt, stranding the whole fleet on a cold full-host restart
+ * (2026-06-17) — see `bootHardCapMs`.
  */
 export async function runAutoaccept(
   opts: AutoacceptOptions,
 ): Promise<AutoacceptResult> {
-  const idleTimeoutMs = opts.idleTimeoutMs ?? DEFAULT_IDLE_MS;
+  const bootHardCapMs = opts.bootHardCapMs ?? DEFAULT_BOOT_HARD_CAP_MS;
   const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
+  const replReady = opts.replReadyMatch ?? REPL_READY_SIGNATURE;
   const rules = (opts.prompts ?? PROMPTS).map((r) => ({
     rule: r,
     fired: 0,
@@ -207,11 +253,12 @@ export async function runAutoaccept(
   const sleep = opts.sleep ?? defaultSleep;
   const maxPolls = opts.maxPolls ?? Number.POSITIVE_INFINITY;
 
-  let lastFire = now();
+  const startTime = now();
   let polls = 0;
 
   while (polls < maxPolls) {
     polls++;
+    const t = now();
     const text = capturePane(opts.agentName);
     let matchedThisPoll = false;
     if (text) {
@@ -228,11 +275,24 @@ export async function runAutoaccept(
         }
       }
     }
-    if (matchedThisPoll) {
-      lastFire = now();
-    } else if (now() - lastFire >= idleTimeoutMs) {
-      return { fired, reason: "idle-timeout" };
+
+    // A prompt fired this poll → claude is still mid first-run flow. Keep
+    // polling for the next prompt / the REPL; never give up mid-sequence.
+    if (!matchedThisPoll) {
+      // Clean handoff: claude has reached the interactive REPL.
+      if (text && replReady.test(text)) {
+        return { fired, reason: "repl-ready" };
+      }
+      // Pathological ceiling ONLY: claude never reached the REPL and isn't
+      // prompting. Hand off to the watch phase rather than loop forever. A
+      // blank / pre-REPL / not-yet-matched-prompt pane must never exit early
+      // (the 2026-06-17 cold-restart wedge), so this is the sole giving-up
+      // condition and is measured generously from launch.
+      if (t - startTime >= bootHardCapMs) {
+        return { fired, reason: "idle-timeout" };
+      }
     }
+
     await sleep(pollIntervalMs);
   }
   return { fired, reason: "manual-stop" };

--- a/src/cli/autoaccept-poll.ts
+++ b/src/cli/autoaccept-poll.ts
@@ -8,7 +8,9 @@
 //
 // Two phases in one process:
 //   1. Boot phase — `runAutoaccept` dispatches the first-run TUI prompts
-//      (theme / MCP trust / dev-channels) and returns after idle-timeout.
+//      (theme / MCP trust / dev-channels) and returns once claude reaches
+//      the REPL (or, in the pathological never-boots case, after the
+//      generous boot hard-cap).
 //   2. Watch phase — `runWedgeWatchdog` then runs for the container
 //      lifetime, dismissing any STABLE blocking modal selector that wedges
 //      the agent mid-session (the AskUserQuestion / ExitPlanMode class).

--- a/tests/autoaccept.test.ts
+++ b/tests/autoaccept.test.ts
@@ -60,12 +60,11 @@ describe("runAutoaccept", () => {
     const { sentKeys } = setupTmux([
       // poll 1: theme prompt visible
       "Choose the text style you'd like\n[1] Auto",
-      // poll 2..N: nothing — falls through to idle-timeout
+      // poll 2..N: nothing (no REPL footer) — runs out via maxPolls
       "",
     ]);
     const res = await runAutoaccept({
       agentName: "klanker",
-      idleTimeoutMs: 5,
       pollIntervalMs: 0,
       now: () => 0, // never advances; rely on maxPolls
       sleep: () => {},
@@ -83,7 +82,6 @@ describe("runAutoaccept", () => {
     ]);
     const res = await runAutoaccept({
       agentName: "a",
-      idleTimeoutMs: 1,
       pollIntervalMs: 0,
       now: () => 0,
       sleep: () => {},
@@ -105,7 +103,6 @@ describe("runAutoaccept", () => {
     ]);
     const res = await runAutoaccept({
       agentName: "a",
-      idleTimeoutMs: 1,
       pollIntervalMs: 0,
       now: () => 0,
       sleep: () => {},
@@ -115,16 +112,70 @@ describe("runAutoaccept", () => {
     expect(sentKeys).toHaveLength(1);
   });
 
-  it("exits cleanly with idle-timeout when no prompts match", async () => {
-    setupTmux(["claude > _", "claude > _", "claude > _"]);
+  it("exits repl-ready the moment claude reaches the REPL (clean handoff)", async () => {
+    // Boot screen, then the REPL footer appears → exit cleanly so the
+    // sidecar hands the pane to the wedge-watchdog.
+    setupTmux([
+      "starting up…",
+      "❯ \n────────────\n? for shortcuts · ← for agents",
+    ]);
+    const res = await runAutoaccept({
+      agentName: "a",
+      pollIntervalMs: 0,
+      now: () => 0,
+      sleep: () => {},
+      maxPolls: 50,
+    });
+    expect(res.reason).toBe("repl-ready");
+    expect(res.fired).toEqual([]);
+  });
+
+  it("does NOT give up while claude is still booting, then fires a LATE-rendering dev-channels prompt", async () => {
+    // The 2026-06-17 cold-restart regression: under CPU contention claude
+    // took far longer than the old 30s idle window to render the
+    // dev-channels prompt. The poller must keep waiting through a blank /
+    // pre-REPL pane and still dispatch the prompt when it finally appears.
+    const { sentKeys } = setupTmux([
+      "", // claude not started rendering yet
+      "",
+      "",
+      "",
+      "", // ...well past the retired 30s idle window...
+      "WARNING: Loading development channels\n❯ 1. I am using this for local development\n  2. Exit",
+      "❯ \n? for shortcuts · ← for agents", // REPL after the prompt is dismissed
+    ]);
+    // Clock advances 60s per poll — under the OLD "idle since launch" logic
+    // this would have given up on the first blank poll. The hard cap is far
+    // higher, so the late prompt is still caught.
     let t = 0;
     const res = await runAutoaccept({
       agentName: "a",
-      idleTimeoutMs: 100,
+      bootHardCapMs: 600_000,
       pollIntervalMs: 0,
-      // wall-clock advances 50ms per call → after 3 polls we hit 150ms idle
       now: () => {
-        t += 50;
+        t += 60_000;
+        return t;
+      },
+      sleep: () => {},
+      maxPolls: 50,
+    });
+    expect(res.fired).toContain("dev-channels-loading");
+    expect(sentKeys[0]).toEqual(["Enter"]);
+    expect(res.reason).toBe("repl-ready");
+  });
+
+  it("a blank pane never trips an early exit — only the hard cap does", async () => {
+    // claude never renders anything (truly hung container). The poller must
+    // not exit until bootHardCapMs, then surface idle-timeout so the sidecar
+    // can still enter the watch phase.
+    setupTmux([""]); // setupTmux returns "" once exhausted anyway
+    let t = 0;
+    const res = await runAutoaccept({
+      agentName: "a",
+      bootHardCapMs: 300,
+      pollIntervalMs: 0,
+      now: () => {
+        t += 100;
         return t;
       },
       sleep: () => {},
@@ -145,7 +196,6 @@ describe("runAutoaccept", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const res = await runAutoaccept({
       agentName: "a",
-      idleTimeoutMs: 1,
       pollIntervalMs: 0,
       now: () => 0,
       sleep: () => {},
@@ -171,7 +221,6 @@ describe("runAutoaccept", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const res = await runAutoaccept({
       agentName: "a",
-      idleTimeoutMs: 1,
       pollIntervalMs: 0,
       now: () => 0,
       sleep: () => {},
@@ -192,7 +241,6 @@ describe("runAutoaccept", () => {
     const { sentKeys } = setupTmux(["BLIP", "BLIP", "BLIP", "BLIP"]);
     const res = await runAutoaccept({
       agentName: "a",
-      idleTimeoutMs: 1,
       pollIntervalMs: 0,
       now: () => 0,
       sleep: () => {},
@@ -305,7 +353,6 @@ describe("runAutoaccept — new dev-channels prompt dispatch", () => {
     ]);
     const res = await runAutoaccept({
       agentName: "a",
-      idleTimeoutMs: 1,
       pollIntervalMs: 0,
       now: () => 0,
       sleep: () => {},
@@ -325,7 +372,6 @@ describe("runAutoaccept — new dev-channels prompt dispatch", () => {
     ]);
     const res = await runAutoaccept({
       agentName: "a",
-      idleTimeoutMs: 1,
       pollIntervalMs: 0,
       now: () => 0,
       sleep: () => {},


### PR DESCRIPTION
## Summary

On a **cold full-host restart**, 11 of 12 agents were stranded at claude's
first-run dev-channels confirmation prompt (`❯ 1. I am using this for local
development · Enter to confirm`) and could not process any turns. Operator hit
this on 2026-06-17; recovered manually by sending `Enter` to each stuck tmux pane.

## Root cause

`runAutoaccept` (the boot autoaccept poller, `src/agents/autoaccept.ts`) used a
**30s "idle since launch"** timeout. When every container boots at once, claude
is CPU-starved and takes **longer than 30s to even render** the dev-channels
prompt. The poller exited `fired=(none)` *before the prompt appeared*; the
continuous wedge-watchdog then **defers to first-run prompts forever** (it only
`Esc`-parks generic modals, never `Enter`s a dev-channels prompt), so nobody
dismissed it → permanent wedge. Only the one agent that won the boot race
recovered. Confirmed in `autoaccept.log`: `boot done reason=idle-timeout
fired=(none)` → `entering wedge-watchdog`.

## Fix

The boot poller now polls until claude **demonstrably reaches the REPL**
(`REPL_READY_SIGNATURE` → `reason: "repl-ready"`, the clean handoff). A blank /
pre-REPL / not-yet-matched-prompt pane can no longer cause an early exit. The
sole giving-up condition is a generous `bootHardCapMs` ceiling (default 10 min)
for the pathological never-boots case, still surfacing `idle-timeout` so the
sidecar enters its watch phase rather than looping forever. The misnamed
`idleTimeoutMs` option is removed.

Scoped deliberately to the boot poller: the watch-phase watchdog's documented
"defer to boot poller for first-run prompts" contract (and its test) is left
intact — the boot poller staying alive until REPL is what makes that deferral
safe again.

## Test plan

- [x] `vitest run tests/autoaccept.test.ts` — rewrites the idle-timeout test
  into **repl-ready** + **hard-cap** cases; adds a **slow-cold-boot regression**
  (blank pane held well past the retired 30s window → late dev-channels prompt
  still dispatched). 23 pass.
- [x] `tests/wedge-watchdog.test.ts` (11), `tests/autoaccept-poll-bundled.test.ts`
  (3), `tests/autoaccept-interact.integration.test.ts` (2), `wedge-detect-posttool`
  (18) — all pass.
- [x] `tsc --noEmit` clean.
- [x] `node scripts/build.mjs` clean; `dist/cli/autoaccept-poll.js` bundles.

## Risk

Low. Behavior change is confined to `runAutoaccept`'s exit condition. Normal fast
boots exit `repl-ready` within a poll or two (was: ran a redundant 30s idle wait).
The hard cap only governs the never-boots case and is far more generous than the
old 30s, eliminating the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)