### PR TITLE
docs: vault is passphrase-free + .env auto-loads (stop telling sessions)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@ TELEGRAM_API_HASH=
 TELEGRAM_UAT_DRIVER_SESSION=
 TELEGRAM_TEST_BOT_USERNAME=meken_switchroom_test_bot
 
+# Forum-supergroup chat_id for the supergroup/channel UAT scenarios
+# (the `*-channel` / `supergroup` tests). Non-secret host config — a `-100…`
+# marked id. When unset the channel scenarios self-skip green. See the
+# "Supergroup / channel UAT" steps in CLAUDE.md for how to capture it.
+SWITCHROOM_UAT_CHAT_ID=
+
 # --- Bot tokens (install-validation / blank-server e2e) ---
 # BotFather tokens for the admin + agent bots a fresh `switchroom setup`
 # provisions. Secrets — pull from vault, never paste a real token here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,6 +466,34 @@ misbehaves, the recovery lever is still `workflow_dispatch` re-trigger
   "~25 agent minutes" is the right one. Reserve human-time estimates
   only for work that explicitly needs the user's review or input.
 
+## Secrets on the dev host — `.env` + the auto-unlocked vault
+
+You almost never need a vault passphrase on a running switchroom host, and
+you rarely need to copy secrets around. Two facts an agent working this repo
+should know up front (so a session doesn't have to be *told* each time):
+
+- **The vault is auto-unlocked here.** The broker derives its key from
+  `/etc/machine-id` at boot (see the runtime-architecture § above), so
+  `switchroom vault get <key>` returns the secret **with no passphrase**,
+  both from a plain host shell and from inside an agent container
+  (`docker exec switchroom-<agent> switchroom vault get <key>`). List names
+  with `switchroom vault list`. The passphrase is only a fallback for when
+  the broker is unreachable. **Do not** mirror the vault into plaintext —
+  it holds the operator's entire credential store (SSH keys, every OAuth /
+  bot token); a plaintext copy is a security regression and buys nothing,
+  since reads are already passphrase-free.
+
+- **The repo-root `.env` is a gitignored cache of the dev/UAT secrets**
+  (mtcute driver creds, bot tokens, GitHub PAT, `SWITCHROOM_UAT_CHAT_ID`,
+  …). The **UAT harness auto-loads it** at startup
+  (`telegram-plugin/uat/load-env.ts`), so `bun run --cwd telegram-plugin
+  test:uat …` already has the creds — you do **not** need to source `.env`
+  or unlock the vault to run mtcute UAT. `.env.example` documents every key
+  and the vault-refresh workflow; keep the two key-sets in sync when you add
+  a knob. The file is **not** auto-exported into general shells by design;
+  for an ad-hoc secret in a script, prefer `switchroom vault get <key>` over
+  copying it into `.env`.
+
 ## Repo model & dev flow
 
 Switchroom uses a **fork + canonical** model. Read this before pushing.


### PR DESCRIPTION
## Summary
Closes a discoverability gap: sessions on a running host kept being told to "use the `.env`" or unlock the vault for mtcute UAT and ad-hoc secret reads. **Neither is necessary** — but nothing in the repo said so.

- The broker is **auto-unlocked** (machine-id), so `switchroom vault get <key>` returns secrets **with no passphrase**, from host or container.
- The repo-root **`.env` is already a gitignored cache** that the UAT harness **auto-loads** (`telegram-plugin/uat/load-env.ts`) — mtcute UAT needs no vault unlock and no manual `source`.

## Changes
- **CLAUDE.md**: new *"Secrets on the dev host"* section stating both facts up front, and explicitly warning against mirroring the vault into a plaintext `.env` (it holds SSH keys + every OAuth/bot token — a security regression that buys nothing since reads are already passphrase-free).
- **.env.example**: add the missing `SWITCHROOM_UAT_CHAT_ID` key (present in the live `.env`, previously undocumented) so the example and real key-sets match.

## Why
Operator kept re-explaining the env/vault workflow to fresh sessions. The fix is to tell the agent once, in the file every session reads at startup — not to copy secrets around.

## Test plan
- [x] Docs only; no code paths touched.
- [x] `.env.example` key-set now matches the live `.env` (11 keys).
- [x] AGENTS.md / AGENT.md are symlinks to CLAUDE.md — inherit the change.

## Risk
None — documentation + one example placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)