### PR TITLE
feat(doctor): surface configured-but-unauthed MCP connections

### DIFF
--- a/src/cli/doctor-mcp-secrets.ts
+++ b/src/cli/doctor-mcp-secrets.ts
@@ -1,0 +1,202 @@
+/**
+ * User-declared MCP-server connection health — the "is it actually
+ * authed?" doctor probe.
+ *
+ * Connection model (2026-06): an integration's MCP server is loaded when
+ * it is CONFIGURED for an agent; auth is ASSUMED at load time. A
+ * configured-but-UNAUTHED connection is not a load decision — it is a
+ * health failure surfaced here (and, later, at agent start). This probe
+ * never gates loading; it reports the gap with the exact fix command.
+ *
+ * Framework integrations (gdrive / ms-365 / notion / webkite) already
+ * have their own doctor modules that verify auth. The blind spot this
+ * fills is USER-DECLARED MCP servers (perplexity, postiz, brevo, meta,
+ * google_ads, …): operators declare each server's vault dependencies
+ * inline as `mcp_servers.<name>.secrets[]`, and the vault-broker ACL
+ * grants those keys (src/vault/broker/acl.ts:374) — but nothing verified
+ * that the keys actually EXIST and that the agent is on their ACL. So an
+ * MCP with an expired / never-set token (e.g. marko's invalidated meta
+ * token) loaded silently and failed only at runtime.
+ *
+ * The effective `mcp_servers` cascade (defaults → extends-profile →
+ * per-agent, per-key shallow merge) mirrors `src/vault/broker/acl.ts`
+ * lines 409-423 exactly, so this probe sees the same servers+secrets the
+ * broker authorizes against.
+ *
+ * Mirrors doctor-notion.ts: same CheckResult shape, same `vaultAclReader`
+ * injection, same `vault set … --allow` fix re-statement.
+ */
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/** Vault-ACL read result, matching doctor-notion's reader contract. */
+export type VaultAclResult =
+  | { kind: "ok"; allow: string[] }
+  | { kind: "unreachable"; msg: string }
+  | { kind: "not_found" };
+
+export interface McpSecretProbeDeps {
+  /**
+   * Reads the vault-broker ACL for a key. Returns the agents allowed to
+   * read it, "not_found" if the key is absent, or "unreachable" when the
+   * broker can't be queried. Injected in tests; wired to
+   * getViaBrokerStructured in doctor.ts.
+   */
+  vaultAclReader?: (key: string) => Promise<VaultAclResult>;
+}
+
+/** One user-declared MCP server's vault-key requirement, per agent. */
+export interface McpSecretRequirement {
+  agent: string;
+  server: string;
+  keys: string[];
+}
+
+/**
+ * Enumerate every (agent, user-declared MCP server, required vault keys)
+ * triple from the effective config — the per-agent "connections that
+ * need auth" registry. Reused by the agent-start health surface (P3).
+ *
+ * Cascade order matches src/vault/broker/acl.ts:409-423:
+ *   1. defaults.mcp_servers
+ *   2. profiles.<agent.extends>.mcp_servers   (if extends is set)
+ *   3. agents.<name>.mcp_servers
+ * Per-key shallow merge — a later layer fully replaces an earlier entry
+ * at that key. `false` opt-outs and scalar values are skipped.
+ */
+export function computeMcpSecretRequirements(
+  config: SwitchroomConfig,
+): McpSecretRequirement[] {
+  const cfg = config as {
+    defaults?: { mcp_servers?: Record<string, unknown> };
+    profiles?: Record<string, { mcp_servers?: Record<string, unknown> } | undefined>;
+    agents?: Record<
+      string,
+      { extends?: string; mcp_servers?: Record<string, unknown> } | undefined
+    >;
+  };
+
+  const reqs: McpSecretRequirement[] = [];
+  for (const [agent, agentConfig] of Object.entries(cfg.agents ?? {})) {
+    if (!agentConfig) continue;
+    const profileName = agentConfig.extends;
+    const profileMcp =
+      profileName != null && profileName.length > 0
+        ? (cfg.profiles?.[profileName]?.mcp_servers ?? {})
+        : {};
+    const effectiveMcp: Record<string, unknown> = {
+      ...(cfg.defaults?.mcp_servers ?? {}),
+      ...profileMcp,
+      ...(agentConfig.mcp_servers ?? {}),
+    };
+
+    for (const [server, entry] of Object.entries(effectiveMcp)) {
+      if (!entry || typeof entry !== "object") continue; // false opt-out / scalar
+      const declared = (entry as { secrets?: unknown }).secrets;
+      if (!Array.isArray(declared)) continue;
+      const keys = declared.filter(
+        (k): k is string => typeof k === "string" && k.length > 0,
+      );
+      if (keys.length === 0) continue;
+      reqs.push({ agent, server, keys });
+    }
+  }
+  return reqs;
+}
+
+/**
+ * Probe the auth state of every user-declared MCP connection. Each
+ * (agent, server, key) yields one CheckResult:
+ *   - fail  — key missing, or agent not on its ACL (runtime auth failure)
+ *   - warn  — vault-broker unreachable (can't verify; fail-safe, never fail)
+ *   - ok    — key present and agent on the ACL
+ */
+export async function runMcpSecretChecks(
+  config: SwitchroomConfig,
+  deps: McpSecretProbeDeps = {},
+): Promise<CheckResult[]> {
+  const reqs = computeMcpSecretRequirements(config);
+  if (reqs.length === 0) return [];
+
+  const read =
+    deps.vaultAclReader ??
+    (async (): Promise<VaultAclResult> => ({
+      kind: "unreachable",
+      msg: "no vault reader wired",
+    }));
+
+  // Read each key once; many agents/servers can share a key.
+  const aclCache = new Map<string, VaultAclResult>();
+  const readKey = async (key: string): Promise<VaultAclResult> => {
+    const cached = aclCache.get(key);
+    if (cached) return cached;
+    const r = await read(key);
+    aclCache.set(key, r);
+    return r;
+  };
+
+  // Which agents need each key — drives the `vault set --allow` fix list.
+  const agentsNeedingKey = new Map<string, Set<string>>();
+  for (const r of reqs) {
+    for (const key of r.keys) {
+      let set = agentsNeedingKey.get(key);
+      if (!set) {
+        set = new Set<string>();
+        agentsNeedingKey.set(key, set);
+      }
+      set.add(r.agent);
+    }
+  }
+
+  const results: CheckResult[] = [];
+  for (const r of reqs) {
+    for (const key of r.keys) {
+      const acl = await readKey(key);
+      const name = `mcp-conn:${r.agent}:${r.server}:${key}`;
+      const want = [...(agentsNeedingKey.get(key) ?? new Set())].sort();
+
+      if (acl.kind === "unreachable") {
+        results.push({
+          name,
+          status: "warn",
+          detail: `vault-broker unreachable, can't verify '${key}' for MCP '${r.server}': ${acl.msg}`,
+          fix: "Ensure the vault-broker is running and the operator socket is reachable, then re-run doctor.",
+        });
+        continue;
+      }
+      if (acl.kind === "not_found") {
+        results.push({
+          name,
+          status: "fail",
+          detail: `agent '${r.agent}' loads MCP '${r.server}' which needs vault key '${key}', but the key is missing — '${r.server}' is configured but NOT authed and will fail at runtime`,
+          fix: `switchroom vault set ${key} --allow ${want.join(",")} (then provide the value), or remove '${r.server}' from this agent's mcp_servers.`,
+        });
+        continue;
+      }
+      if (!acl.allow.includes(r.agent)) {
+        const updated = [...new Set([...acl.allow, r.agent])].sort().join(",");
+        results.push({
+          name,
+          status: "fail",
+          detail: `agent '${r.agent}' loads MCP '${r.server}' but is NOT on the vault ACL for '${key}' — the broker will deny it at runtime`,
+          fix: `switchroom vault set ${key} --allow ${updated} (vault set overwrites the scope — re-state the full list including '${r.agent}').`,
+        });
+        continue;
+      }
+      results.push({
+        name,
+        status: "ok",
+        detail: `MCP '${r.server}' → '${key}' present + ACL-allowed`,
+      });
+    }
+  }
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -38,6 +38,7 @@ import { runWebkiteChecks } from "./doctor-webkite.js";
 import { runCronSessionChecks } from "./doctor-cron-session.js";
 import { runMicrosoftChecks } from "./doctor-microsoft.js";
 import { runNotionChecks } from "./doctor-notion.js";
+import { runMcpSecretChecks } from "./doctor-mcp-secrets.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
 import { runSecretAccessChecks } from "./doctor-secret-access.js";
 import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
@@ -2713,6 +2714,29 @@ export function registerDoctorCommand(program: Command): void {
           process.exit(1);
         }
 
+        // Shared vault-broker ACL reader for the connection-health probes
+        // (Notion + user-declared MCP secrets). Soft-fails to "unreachable"
+        // so a down/locked broker yields warnings, never false failures.
+        const vaultAclReader = async (
+          key: string,
+        ): Promise<
+          | { kind: "ok"; allow: string[] }
+          | { kind: "unreachable"; msg: string }
+          | { kind: "not_found" }
+        > => {
+          try {
+            const { getViaBrokerStructured } = await import("../vault/broker/client.js");
+            const result = await getViaBrokerStructured(key);
+            if (result.kind === "ok") {
+              return { kind: "ok", allow: result.entry.scope?.allow ?? [] };
+            }
+            if (result.kind === "not_found") return { kind: "not_found" };
+            return { kind: "unreachable", msg: result.msg };
+          } catch (err) {
+            return { kind: "unreachable", msg: (err as Error).message };
+          }
+        };
+
         const sections: Array<{ title: string; results: CheckResult[] }> = [
           { title: "Dependencies", results: checkDependencies() },
           { title: "Skills Prerequisites", results: checkSkillsPrerequisites() },
@@ -2754,24 +2778,11 @@ export function registerDoctorCommand(program: Command): void {
           },
           {
             title: "Notion (RFC notion-integration)",
-            results: await runNotionChecks(config, {
-              vaultAclReader: async (key: string) => {
-                try {
-                  const { getViaBrokerStructured } = await import("../vault/broker/client.js");
-                  const result = await getViaBrokerStructured(key);
-                  if (result.kind === "ok") {
-                    return {
-                      kind: "ok",
-                      allow: result.entry.scope?.allow ?? [],
-                    };
-                  }
-                  if (result.kind === "not_found") return { kind: "not_found" };
-                  return { kind: "unreachable", msg: result.msg };
-                } catch (err) {
-                  return { kind: "unreachable", msg: (err as Error).message };
-                }
-              },
-            }),
+            results: await runNotionChecks(config, { vaultAclReader }),
+          },
+          {
+            title: "MCP Connections (auth)",
+            results: await runMcpSecretChecks(config, { vaultAclReader }),
           },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath, config) },
           { title: "Webkite", results: runWebkiteChecks(config) },

--- a/tests/doctor-mcp-secrets.test.ts
+++ b/tests/doctor-mcp-secrets.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeMcpSecretRequirements,
+  runMcpSecretChecks,
+  type VaultAclResult,
+} from "../src/cli/doctor-mcp-secrets.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+// Minimal config builder — only the fields the probe reads.
+function cfg(partial: Record<string, unknown>): SwitchroomConfig {
+  return partial as unknown as SwitchroomConfig;
+}
+
+/** A vaultAclReader stub from a key→result map (default: not_found). */
+function reader(map: Record<string, VaultAclResult>) {
+  return async (key: string): Promise<VaultAclResult> =>
+    map[key] ?? { kind: "not_found" };
+}
+
+describe("computeMcpSecretRequirements", () => {
+  it("collects per-agent user-declared MCP secrets", () => {
+    const reqs = computeMcpSecretRequirements(
+      cfg({
+        agents: {
+          marko: {
+            mcp_servers: {
+              meta: { command: "meta-mcp", secrets: ["meta/token"] },
+              postiz: { command: "postiz-mcp", secrets: ["postiz/api-key"] },
+            },
+          },
+        },
+      }),
+    );
+    expect(reqs).toEqual([
+      { agent: "marko", server: "meta", keys: ["meta/token"] },
+      { agent: "marko", server: "postiz", keys: ["postiz/api-key"] },
+    ]);
+  });
+
+  it("applies the defaults → profile → agent cascade (acl.ts parity)", () => {
+    const reqs = computeMcpSecretRequirements(
+      cfg({
+        defaults: {
+          mcp_servers: { perplexity: { command: "px", secrets: ["perplexity/api-key"] } },
+        },
+        profiles: {
+          marketing: { mcp_servers: { brevo: { command: "brevo", secrets: ["brevo/key"] } } },
+        },
+        agents: {
+          marko: {
+            extends: "marketing",
+            mcp_servers: { meta: { command: "meta", secrets: ["meta/token"] } },
+          },
+        },
+      }),
+    );
+    const servers = reqs.map((r) => r.server).sort();
+    // defaults(perplexity) + profile(brevo) + agent(meta) all visible.
+    expect(servers).toEqual(["brevo", "meta", "perplexity"]);
+  });
+
+  it("a per-agent entry fully replaces the defaults entry at that key", () => {
+    const reqs = computeMcpSecretRequirements(
+      cfg({
+        defaults: { mcp_servers: { px: { command: "px", secrets: ["old/key"] } } },
+        agents: { a: { mcp_servers: { px: { command: "px", secrets: ["new/key"] } } } },
+      }),
+    );
+    expect(reqs).toEqual([{ agent: "a", server: "px", keys: ["new/key"] }]);
+  });
+
+  it("skips false opt-outs, scalars, and entries without a secrets[] array", () => {
+    const reqs = computeMcpSecretRequirements(
+      cfg({
+        agents: {
+          a: {
+            mcp_servers: {
+              perplexity: false, // opt-out
+              webkite: { command: "webkite" }, // no secrets[]
+              note: "scalar", // not an object
+              meta: { command: "m", secrets: [] }, // empty
+              real: { command: "r", secrets: ["real/key"] },
+            },
+          },
+        },
+      }),
+    );
+    expect(reqs).toEqual([{ agent: "a", server: "real", keys: ["real/key"] }]);
+  });
+
+  it("returns nothing when no agent declares MCP secrets", () => {
+    expect(computeMcpSecretRequirements(cfg({ agents: { a: {} } }))).toEqual([]);
+  });
+});
+
+describe("runMcpSecretChecks", () => {
+  const base = cfg({
+    agents: {
+      marko: { mcp_servers: { meta: { command: "m", secrets: ["meta/token"] } } },
+    },
+  });
+
+  it("returns [] (silent) when no MCP secrets are declared", async () => {
+    expect(await runMcpSecretChecks(cfg({ agents: { a: {} } }))).toEqual([]);
+  });
+
+  it("FAILs a configured-but-unauthed connection (missing key) with a fix", async () => {
+    const res = await runMcpSecretChecks(base, {
+      vaultAclReader: reader({}), // meta/token not_found
+    });
+    expect(res).toHaveLength(1);
+    expect(res[0].status).toBe("fail");
+    expect(res[0].detail).toContain("configured but NOT authed");
+    expect(res[0].fix).toContain("switchroom vault set meta/token --allow marko");
+  });
+
+  it("FAILs when the key exists but the agent is off its ACL (re-states full list)", async () => {
+    const res = await runMcpSecretChecks(base, {
+      vaultAclReader: reader({ "meta/token": { kind: "ok", allow: ["someoneelse"] } }),
+    });
+    expect(res[0].status).toBe("fail");
+    expect(res[0].detail).toContain("NOT on the vault ACL");
+    // fix re-states the FULL list (existing + marko), sorted.
+    expect(res[0].fix).toContain("--allow marko,someoneelse");
+  });
+
+  it("OKs when the key exists and the agent is on its ACL", async () => {
+    const res = await runMcpSecretChecks(base, {
+      vaultAclReader: reader({ "meta/token": { kind: "ok", allow: ["marko"] } }),
+    });
+    expect(res[0].status).toBe("ok");
+  });
+
+  it("WARNs (never fails) when the broker is unreachable — fail-safe", async () => {
+    const res = await runMcpSecretChecks(base, {
+      vaultAclReader: async () => ({ kind: "unreachable", msg: "socket down" }),
+    });
+    expect(res[0].status).toBe("warn");
+    expect(res[0].detail).toContain("unreachable");
+  });
+
+  it("reads each shared key once and lists all needing agents in the fix", async () => {
+    let reads = 0;
+    const shared = cfg({
+      agents: {
+        a: { mcp_servers: { px: { command: "p", secrets: ["px/key"] } } },
+        b: { mcp_servers: { px: { command: "p", secrets: ["px/key"] } } },
+      },
+    });
+    const res = await runMcpSecretChecks(shared, {
+      vaultAclReader: async (key) => {
+        reads++;
+        return { kind: "not_found" as const, _k: key } as VaultAclResult;
+      },
+    });
+    expect(reads).toBe(1); // cached across both agents
+    // both agents fail, and each fix names both agents (sorted)
+    expect(res.every((r) => r.fix?.includes("--allow a,b"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the **connection-health** workstream. Establishes the model: an integration's MCP server loads when it is **configured** for an agent (auth assumed); a configured-but-**unauthed** connection is a **health problem**, surfaced with a fix — never a silent runtime failure.

Framework integrations (gdrive/ms-365/notion/webkite) already have doctor modules that verify auth. The blind spot was **user-declared MCP servers** (perplexity, postiz, brevo, meta, google_ads, …): operators declare each server's vault deps inline as `mcp_servers.<name>.secrets[]` and the broker ACL grants them (`acl.ts:374`), but nothing verified the keys exist or that the agent is on their ACL. So an MCP with a missing/expired token (e.g. marko's invalidated `meta` token) loaded silently and failed only at runtime.

## What's here

- **`src/cli/doctor-mcp-secrets.ts`**
  - `computeMcpSecretRequirements(config)` — per-agent `(server, keys[])` registry over the **effective** `mcp_servers` cascade (defaults → extends-profile → per-agent, per-key shallow merge), mirroring `src/vault/broker/acl.ts:409-423` exactly so it sees the same servers+secrets the broker authorizes against. Reused by the agent-start health surface (next PR).
  - `runMcpSecretChecks` — per `(agent, server, key)`: **FAIL** on missing key or ACL drift (with the precise `switchroom vault set … --allow` fix), **WARN** (never fail) when the broker is unreachable (fail-safe), **OK** otherwise.
- Wired into `switchroom doctor` as a **"MCP Connections (auth)"** section, reusing a hoisted shared `vaultAclReader` (also repoints the Notion check to it — no behavior change).

## Test plan

- [x] `vitest run tests/doctor-mcp-secrets.test.ts` — 11 tests: cascade parity, opt-out/scalar/empty skips, missing-key fail, ACL-drift fail (full-list re-statement), ok, unreachable→warn, shared-key single-read.
- [x] `src/cli/doctor-notion.test.ts` — 14 tests still green (vaultAclReader hoist).
- [x] `tsc --noEmit` clean.

## Risk

Low. Pure additive read-only probe; no load-path or runtime behavior changes. Fail-safe: a down/locked broker yields WARN, never a false FAIL. The shared-reader hoist is a no-op refactor of the existing Notion wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)