### PR TITLE
feat(web): path-based tab routing + no-cache HTML shell

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -78,6 +78,48 @@ const MIME_TYPES: Record<string, string> = {
   ".ico": "image/x-icon",
 };
 
+// Top-level dashboard tabs that the client mirrors into the URL path
+// (history.pushState → `/connections`, `/agents`, …). A full-page load or
+// reload of one of these paths must serve the SPA shell (index.html) instead
+// of 404-ing, so the in-page router can select the right tab on boot. Keep in
+// sync with the `tabs` array in src/web/ui/index.html (switchTab).
+const SPA_TAB_ROUTES = new Set([
+  "summary",
+  "agents",
+  "accounts",
+  "system",
+  "memory",
+  "connections",
+  "schedule",
+  "approvals",
+]);
+
+/**
+ * Map an incoming GET path to the static file to serve. The dashboard is a
+ * single-page app whose active tab is mirrored into the URL path, so the root
+ * and every known tab route (`/connections`, `/agents`, …) resolve to the
+ * index.html shell; the in-page router then selects the tab. Any other path is
+ * returned unchanged so a genuinely missing asset still 404s rather than being
+ * masked by the shell. Exported for unit coverage.
+ */
+export function resolveDashboardFilePath(pathname: string): string {
+  const routeName = pathname.replace(/^\/+/, "").replace(/\/+$/, "");
+  return pathname === "/" || SPA_TAB_ROUTES.has(routeName)
+    ? "/index.html"
+    : pathname;
+}
+
+/**
+ * Cache-Control for a static dashboard asset by extension. The whole app is one
+ * inline HTML document, so a stale cached shell pins stale render code (this is
+ * what made already-fixed bugs — e.g. "my connections don't show" — persist in
+ * the browser). The server sends no validators, so HTML must always revalidate;
+ * other assets get no explicit policy. Exported for unit coverage.
+ */
+export function dashboardCacheControl(ext: string): string | undefined {
+  return ext === ".html" ? "no-cache, must-revalidate" : undefined;
+}
+
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
@@ -1034,8 +1076,9 @@ export function startWebServer(
         }
       }
 
-      // Static files — no auth required
-      let filePath = pathname === "/" ? "/index.html" : pathname;
+      // Static files — no auth required. SPA path routing (root + known tab
+      // routes → index.html shell) lives in resolveDashboardFilePath.
+      const filePath = resolveDashboardFilePath(pathname);
       const fullPath = join(uiDir, filePath);
 
       // Resolve symlinks before comparing so traversal via symlinked uiDir
@@ -1057,9 +1100,10 @@ export function startWebServer(
       const ext = extname(realFullPath);
       const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
       const content = readFileSync(realFullPath);
-      return new Response(content, {
-        headers: { "Content-Type": contentType },
-      });
+      const headers: Record<string, string> = { "Content-Type": contentType };
+      const cacheControl = dashboardCacheControl(ext);
+      if (cacheControl) headers["Cache-Control"] = cacheControl;
+      return new Response(content, { headers });
     },
 
     websocket: {

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -1240,11 +1240,32 @@
       }
     }
 
-    function switchTab(tab) {
-      const tabs = ['summary', 'agents', 'accounts', 'system', 'memory', 'connections', 'schedule', 'approvals'];
-      for (const t of tabs) {
+    // Canonical tab list — kept in sync with the nav buttons above and with
+    // SPA_TAB_ROUTES in src/web/server.ts (the server serves the SPA shell for
+    // these paths so a reload/deep-link doesn't 404).
+    const TAB_NAMES = ['summary', 'agents', 'accounts', 'system', 'memory', 'connections', 'schedule', 'approvals'];
+
+    // Derive the active tab from the URL path (`/connections` → 'connections',
+    // '/' → 'summary'). Unknown paths fall back to summary.
+    function tabFromPath() {
+      const name = location.pathname.replace(/^\/+/, '').replace(/\/+$/, '');
+      return TAB_NAMES.includes(name) ? name : 'summary';
+    }
+
+    // opts.push === false suppresses the history push — used when the switch is
+    // itself driven by navigation (initial load, back/forward) so we don't
+    // double-stack history entries.
+    function switchTab(tab, opts) {
+      if (!TAB_NAMES.includes(tab)) tab = 'summary';
+      for (const t of TAB_NAMES) {
         document.getElementById(`tab-${t}`).classList.toggle('active', tab === t);
         document.getElementById(t).style.display = tab === t ? '' : 'none';
+      }
+      // Mirror the tab into the URL path so reload/deep-link/back-forward all
+      // land here. Summary canonicalises to '/'.
+      if (!opts || opts.push !== false) {
+        const path = tab === 'summary' ? '/' : '/' + tab;
+        if (location.pathname !== path) history.pushState({ tab }, '', path);
       }
       if (tab === 'summary') fetchSummary();
       if (tab === 'accounts') fetchAccounts();
@@ -1254,6 +1275,11 @@
       if (tab === 'schedule') fetchSchedule();
       if (tab === 'approvals') fetchApprovals();
     }
+
+    // Back/forward: restore the tab from the history entry (or the path).
+    window.addEventListener('popstate', (e) => {
+      switchTab((e.state && e.state.tab) || tabFromPath(), { push: false });
+    });
 
     // Fleet overview — ONE round-trip to the server-side aggregate
     // (/api/summary), which pulls each part through the same per-tab
@@ -2635,12 +2661,16 @@
       }
     }
 
-    // Init. Summary is the default visible tab; fetchAgents still runs
-    // (populates the agents tab + keeps the 10s fleet poll warm + the
-    // log WS depends on it). Summary is fetched on init + on tab-switch
-    // only — deliberately NOT on the 10s interval (it fans out to
-    // system-health etc.; on-demand refresh is enough).
-    fetchSummary();
+    // Init. The initial tab comes from the URL path (so a reload/deep-link of
+    // `/connections` opens Connections, not Summary); '/' → Summary. We stamp
+    // the history entry so the first back/forward works, then switchTab
+    // (push:false) shows the tab and fetches just its data. fetchAgents still
+    // runs unconditionally (keeps the 10s fleet poll warm + the log WS depends
+    // on it). Per-tab data is fetched on switch only — deliberately NOT on the
+    // 10s interval (it fans out to system-health etc.; on-demand is enough).
+    const initialTab = tabFromPath();
+    history.replaceState({ tab: initialTab }, '', location.pathname);
+    switchTab(initialTab, { push: false });
     fetchAgents();
     connectWebSocket();
     // Fleet poll — gated on tab visibility. A phone with the dashboard

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -139,7 +139,12 @@ import {
   resolveKernelOperatorSocket,
   approvalList,
 } from "../src/vault/approvals/client.js";
-import { isOriginAllowed, isTailscaleIdentified } from "../src/web/server.js";
+import {
+  isOriginAllowed,
+  isTailscaleIdentified,
+  resolveDashboardFilePath,
+  dashboardCacheControl,
+} from "../src/web/server.js";
 import { getAllAgentStatuses, startAgent, stopAgent, restartAgent } from "../src/agents/lifecycle.js";
 import { getAllAuthStatuses } from "../src/auth/manager.js";
 import { getHindsightStatus } from "../src/setup/hindsight.js";
@@ -2378,5 +2383,64 @@ describe("memory remediation handlers", () => {
       expect(r.ok).toBe(false);
       expect(r.error).toContain("boom");
     });
+  });
+});
+
+describe("resolveDashboardFilePath — SPA tab path routing", () => {
+  const TAB_ROUTES = [
+    "summary",
+    "agents",
+    "accounts",
+    "system",
+    "memory",
+    "connections",
+    "schedule",
+    "approvals",
+  ];
+
+  it("serves the index.html shell for the root path", () => {
+    expect(resolveDashboardFilePath("/")).toBe("/index.html");
+  });
+
+  it("serves the shell for every known tab route (reload/deep-link doesn't 404)", () => {
+    for (const tab of TAB_ROUTES) {
+      expect(resolveDashboardFilePath(`/${tab}`)).toBe("/index.html");
+    }
+  });
+
+  it("tolerates a trailing slash on a tab route", () => {
+    expect(resolveDashboardFilePath("/connections/")).toBe("/index.html");
+  });
+
+  it("passes through real asset paths unchanged (not masked by the shell)", () => {
+    expect(resolveDashboardFilePath("/index.html")).toBe("/index.html");
+    expect(resolveDashboardFilePath("/styles.css")).toBe("/styles.css");
+    expect(resolveDashboardFilePath("/favicon.ico")).toBe("/favicon.ico");
+  });
+
+  it("passes through unknown paths unchanged so they still 404", () => {
+    // A path that is NOT a tab and NOT a real file must stay as-is — the
+    // caller's existsSync check then 404s it, rather than the shell masking
+    // the miss.
+    expect(resolveDashboardFilePath("/nope")).toBe("/nope");
+    expect(resolveDashboardFilePath("/connections-typo")).toBe(
+      "/connections-typo",
+    );
+    expect(resolveDashboardFilePath("/agents/extra/depth")).toBe(
+      "/agents/extra/depth",
+    );
+  });
+});
+
+describe("dashboardCacheControl — stale-shell prevention", () => {
+  it("forces revalidation on the HTML document (kills stale-render bugs)", () => {
+    expect(dashboardCacheControl(".html")).toBe("no-cache, must-revalidate");
+  });
+
+  it("applies no explicit policy to non-HTML assets", () => {
+    expect(dashboardCacheControl(".css")).toBeUndefined();
+    expect(dashboardCacheControl(".js")).toBeUndefined();
+    expect(dashboardCacheControl(".png")).toBeUndefined();
+    expect(dashboardCacheControl("")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

The fleet dashboard is a single-page app with all JS inlined in `index.html`, and the web server sent **no cache headers** for that document. Two user-visible consequences:

1. **Reload/deep-link dropped to Summary** — tab state lived only in the DOM, never in the URL.
2. **Stale render code persisted in the browser** — the inline shell got heuristically cached, so a browser kept running a *pre-fix* bundle even after a fix shipped.

(2) is the root cause of a live "my connections don't show" report: the API returned the operator's Google + Microsoft accounts correctly (verified end-to-end — the deployed render code produces a visible card when run against the real payload), but the operator's browser was executing the cached, pre-fix Connections bundle. A normal reload didn't help (no `Cache-Control`, no service worker, inline app).

## Why

- **`Cache-Control: no-cache, must-revalidate` on the HTML shell** permanently kills the stale-render class of bug — the browser always revalidates the document.
- **Path-based routing** makes reload/deep-link/back-forward land on the right tab.

## What changed

- **Server** (`src/web/server.ts`)
  - `resolveDashboardFilePath(pathname)` — root + the eight known tab routes (`/connections`, `/agents`, …) serve the `index.html` shell; any other unknown path is passed through unchanged so a genuinely missing asset still 404s. The realpath/traversal guard is untouched (SPA routes only ever map to the literal `/index.html`).
  - `dashboardCacheControl(ext)` — `.html` → `no-cache, must-revalidate`; other assets get no explicit policy.
- **Client** (`src/web/ui/index.html`)
  - `switchTab` mirrors the active tab into the URL via `history.pushState`.
  - Boot derives the initial tab from `location.pathname` (`replaceState` to stamp the entry); `popstate` restores it on back/forward.
  - Hoisted a single `TAB_NAMES` list (kept in sync with the server's `SPA_TAB_ROUTES`).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/web.test.ts` — 130 passed (7 new)
  - `resolveDashboardFilePath`: root, every tab route, trailing slash, asset passthrough, unknown→passthrough(404)
  - `dashboardCacheControl`: HTML revalidates, non-HTML undefined
- [ ] Manual: reload on `/connections` stays on Connections; back/forward cycles tabs; first load with cleared cache shows accounts. (Pending deploy to test-harness.)

## Risk

Low. Server change is additive + behind pure helpers; the only behavioral change for non-tab paths is none (passthrough preserved). Worst case for the cache header is slightly more frequent HTML revalidation (the document is small and already re-fetched on every visit). No API routes touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)