### PR TITLE
feat(boot): surface configured-but-unauthed connections at agent start

### DIFF
--- a/src/agents/connection-health.ts
+++ b/src/agents/connection-health.ts
@@ -1,0 +1,182 @@
+/**
+ * Host-side connection-health computation + on-disk snapshot.
+ *
+ * The agent-start surface (boot card) for connection auth can't query the
+ * vault-broker itself — the in-container boot probe is contractually
+ * forbidden from doing vault/grant work (telegram-plugin/gateway/
+ * boot-probes.ts). So we compute connection health HOST-SIDE during
+ * `apply` (where the broker, config, and ACLs are all reachable) and drop
+ * a small JSON snapshot into the agent dir. The boot card's
+ * `probeConnections` just reads that file.
+ *
+ * Connection model (2026-06): an integration's MCP loads when CONFIGURED;
+ * auth is assumed. A configured-but-unauthed connection is reported here
+ * (and surfaced at boot), never silently broken. Reuses the same
+ * `computeMcpSecretRequirements` registry the `switchroom doctor` "MCP
+ * Connections (auth)" check uses, so doctor and the boot card never
+ * disagree.
+ *
+ * Fail-safe: if the broker is unreachable we cannot verify auth, so we
+ * emit ZERO issues (auth assumed) rather than false-flagging an agent.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import {
+  computeMcpSecretRequirements,
+  type VaultAclResult,
+} from "../cli/doctor-mcp-secrets.js";
+
+/** Filename written under `<agentDir>/.claude/`. Shared contract with the
+ *  boot-card probe (telegram-plugin reads the same JSON shape). */
+export const CONNECTION_HEALTH_FILENAME = "connection-health.json";
+
+export interface ConnectionIssue {
+  /** The MCP server that is configured but not authed. */
+  server: string;
+  /** The vault key it needs. */
+  key: string;
+  /** "missing" = key absent; "acl" = key present but agent not granted. */
+  kind: "missing" | "acl";
+  /** One-line human description. */
+  detail: string;
+  /** Exact remediation command. */
+  fix: string;
+}
+
+export interface ConnectionHealth {
+  /** epoch ms when this snapshot was computed (host clock). */
+  computedAt: number;
+  /** Definitive auth problems. Empty = healthy (or unverifiable → assumed healthy). */
+  issues: ConnectionIssue[];
+}
+
+export interface ConnectionHealthDeps {
+  /** Reads the vault-broker ACL for a key. Injected in tests; wired to
+   *  getViaBrokerStructured by callers. */
+  vaultAclReader: (key: string) => Promise<VaultAclResult>;
+  /** Clock override for tests. */
+  now?: () => number;
+  /** fs overrides for tests. */
+  mkdir?: (path: string, opts: { recursive: true }) => void;
+  writeFile?: (path: string, data: string) => void;
+}
+
+/**
+ * Compute the definitive auth issues for ONE agent's user-declared MCP
+ * connections. Missing key or ACL-drift → issue; ok or broker-unreachable
+ * → no issue (fail-safe: never false-flag when we can't verify).
+ */
+export async function computeAgentConnectionIssues(
+  config: SwitchroomConfig,
+  agentName: string,
+  vaultAclReader: (key: string) => Promise<VaultAclResult>,
+): Promise<ConnectionIssue[]> {
+  const reqs = computeMcpSecretRequirements(config).filter(
+    (r) => r.agent === agentName,
+  );
+  if (reqs.length === 0) return [];
+
+  // Which agents need each key — drives the `vault set --allow` fix list,
+  // matching the doctor check's re-statement semantics.
+  const agentsNeedingKey = new Map<string, Set<string>>();
+  for (const r of computeMcpSecretRequirements(config)) {
+    for (const key of r.keys) {
+      let set = agentsNeedingKey.get(key);
+      if (!set) {
+        set = new Set<string>();
+        agentsNeedingKey.set(key, set);
+      }
+      set.add(r.agent);
+    }
+  }
+
+  const aclCache = new Map<string, VaultAclResult>();
+  const readKey = async (key: string): Promise<VaultAclResult> => {
+    const cached = aclCache.get(key);
+    if (cached) return cached;
+    const r = await vaultAclReader(key);
+    aclCache.set(key, r);
+    return r;
+  };
+
+  const issues: ConnectionIssue[] = [];
+  for (const r of reqs) {
+    for (const key of r.keys) {
+      const acl = await readKey(key);
+      const want = [...(agentsNeedingKey.get(key) ?? new Set())].sort();
+      if (acl.kind === "unreachable") continue; // fail-safe: assume authed
+      if (acl.kind === "not_found") {
+        issues.push({
+          server: r.server,
+          key,
+          kind: "missing",
+          detail: `MCP '${r.server}' needs vault key '${key}', but it is missing — configured but not authed`,
+          fix: `switchroom vault set ${key} --allow ${want.join(",")} (then provide the value)`,
+        });
+        continue;
+      }
+      if (!acl.allow.includes(agentName)) {
+        const updated = [...new Set([...acl.allow, agentName])].sort().join(",");
+        issues.push({
+          server: r.server,
+          key,
+          kind: "acl",
+          detail: `MCP '${r.server}' not on the vault ACL for '${key}' — broker will deny at runtime`,
+          fix: `switchroom vault set ${key} --allow ${updated} (re-state the full list)`,
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+/**
+ * Write `<agentDir>/.claude/connection-health.json`. Best-effort — callers
+ * wrap in try/catch; a write failure must never break `apply`.
+ */
+export function writeConnectionHealthFile(
+  agentDir: string,
+  health: ConnectionHealth,
+  deps?: Pick<ConnectionHealthDeps, "mkdir" | "writeFile">,
+): void {
+  const dir = join(agentDir, ".claude");
+  const path = join(dir, CONNECTION_HEALTH_FILENAME);
+  (deps?.mkdir ?? ((p, o) => mkdirSync(p, o)))(dir, { recursive: true });
+  (deps?.writeFile ?? ((p, d) => writeFileSync(p, d)))(
+    path,
+    JSON.stringify(health, null, 2) + "\n",
+  );
+}
+
+/**
+ * Compute + write connection-health for one agent. Returns the snapshot
+ * (also for callers that want to log it). Best-effort: never throws.
+ */
+export async function refreshAgentConnectionHealth(
+  config: SwitchroomConfig,
+  agentName: string,
+  agentDir: string,
+  deps: ConnectionHealthDeps,
+): Promise<ConnectionHealth> {
+  const now = deps.now ?? Date.now;
+  let issues: ConnectionIssue[] = [];
+  try {
+    issues = await computeAgentConnectionIssues(
+      config,
+      agentName,
+      deps.vaultAclReader,
+    );
+  } catch {
+    issues = []; // fail-safe — never block apply on a probe error
+  }
+  const health: ConnectionHealth = { computedAt: now(), issues };
+  try {
+    writeConnectionHealthFile(agentDir, health, deps);
+  } catch {
+    // best-effort; swallow.
+  }
+  return health;
+}

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -56,6 +56,8 @@ import {
   ConfigError,
 } from "../config/loader.js";
 import { scaffoldAgent, alignAgentUid, renderFleetInvariants, toHostHomePath } from "../agents/scaffold.js";
+import { refreshAgentConnectionHealth } from "../agents/connection-health.js";
+import type { VaultAclResult } from "./doctor-mcp-secrets.js";
 import { installUpdatePromptHook } from "./update-prompt-hook.js";
 import { allocateAgentUid } from "../agents/compose.js";
 import { writeComposeFile, resolveHostSwitchroomConfigPath } from "./write-compose.js";
@@ -679,6 +681,24 @@ export async function runApply(
     );
   }
 
+  // Shared vault-broker ACL reader for the per-agent connection-health
+  // snapshot written below (read by the boot card's probeConnections). Soft-
+  // fails to "unreachable" → refreshAgentConnectionHealth then emits zero
+  // issues (auth assumed), so a down/locked broker never false-flags an agent.
+  const connHealthVaultAclReader = async (key: string): Promise<VaultAclResult> => {
+    try {
+      const { getViaBrokerStructured } = await import("../vault/broker/client.js");
+      const result = await getViaBrokerStructured(key);
+      if (result.kind === "ok") {
+        return { kind: "ok", allow: result.entry.scope?.allow ?? [] };
+      }
+      if (result.kind === "not_found") return { kind: "not_found" };
+      return { kind: "unreachable", msg: result.msg };
+    } catch (err) {
+      return { kind: "unreachable", msg: (err as Error).message };
+    }
+  };
+
   // ── 1. Scaffold each agent ────────────────────────────────────────
   let scaffolded = 0;
   const failures: ScaffoldFailure[] = [];
@@ -722,6 +742,15 @@ export async function runApply(
           ),
         );
       }
+      // Connection-health snapshot for the boot card's probeConnections
+      // (configured-but-unauthed MCP integrations). Computed host-side here
+      // because the in-container boot probe can't query the broker. Written
+      // BEFORE alignAgentUid so the chown below covers the file. Best-effort
+      // (refreshAgentConnectionHealth never throws) — must never break apply.
+      await refreshAgentConnectionHealth(config, name, join(agentsDir, name), {
+        vaultAclReader: connHealthVaultAclReader,
+      });
+
       // Align per-agent dir ownership with the container UID assigned
       // by compose.ts. Without this the bind-mount lands read-only
       // for the in-container UID and the agent fails on first write.

--- a/telegram-plugin/gateway/boot-card.ts
+++ b/telegram-plugin/gateway/boot-card.ts
@@ -46,6 +46,7 @@ import {
   probeBroker,
   probeKernel,
   probeSkills,
+  probeConnections,
   watchAgentProcess,
   AGENT_LIVE_WINDOW_MS,
   AGENT_LIVE_POLL_INTERVAL_MS,
@@ -120,6 +121,7 @@ export type ProbeKey =
   | 'broker'
   | 'kernel'
   | 'skills'
+  | 'connections'
 
 export type ProbeMap = Partial<Record<ProbeKey, ProbeResult | null>>
 
@@ -253,11 +255,12 @@ const PROBE_LABELS: Record<ProbeKey, string> = {
   broker:    'Broker',
   kernel:    'Kernel',
   skills:    'Skills',
+  connections: 'Connections',
 }
 
 const PROBE_KEYS: ReadonlyArray<ProbeKey> = [
   'account', 'agent', 'gateway', 'quota', 'hindsight',
-  'scheduler', 'broker', 'kernel', 'skills',
+  'scheduler', 'broker', 'kernel', 'skills', 'connections',
 ]
 
 const REASON_EMOJI: Record<RestartReason, string> = {
@@ -617,6 +620,7 @@ export async function runAllProbes(opts: RunProbesOpts): Promise<ProbeMap> {
     probeBroker(undefined, { dockerMode: opts.dockerMode }).then(r => { probes.broker = r }),
     probeKernel(undefined, { dockerMode: opts.dockerMode }).then(r => { probes.kernel = r }),
     probeSkills(opts.agentDir, { agentName: opts.agentSlug ?? opts.agentName }).then(r => { probes.skills = r }),
+    probeConnections(opts.agentDir).then(r => { probes.connections = r }),
   ])
 
   return probes

--- a/telegram-plugin/gateway/boot-probes.ts
+++ b/telegram-plugin/gateway/boot-probes.ts
@@ -1421,6 +1421,68 @@ function renderBucketedSkills(switchroom: string[], agent: string[]): string {
   return parts.length === 0 ? 'none resolved' : parts.join(' · ')
 }
 
+// ─── Probe: Connections (configured-but-unauthed MCP integrations) ───────────
+
+/**
+ * Surface configured-but-unauthed MCP connections at agent start. The auth
+ * verdict can't be computed in-container (this boot probe must not do
+ * vault/grant work — see the module header), so `switchroom apply` computes
+ * it host-side and drops a snapshot at
+ * `<agentDir>/.claude/connection-health.json` (src/agents/connection-health.ts).
+ * This probe just reads it.
+ *
+ *   ok       — snapshot missing/unparseable (not yet computed → assume
+ *              healthy, don't nag) OR zero issues
+ *   degraded — ≥1 connection configured but not authed; detail names the
+ *              servers, nextStep carries the first fix
+ *
+ * Never `fail`: an unauthed integration degrades that one capability, it
+ * doesn't take the agent down, and the silent-when-healthy boot card
+ * should not red an agent over a missing third-party token.
+ */
+export interface ConnectionIssueShape {
+  server: string
+  key: string
+  kind: string
+  detail: string
+  fix: string
+}
+
+export async function probeConnections(
+  agentDir: string,
+  opts: { readFileImpl?: (path: string) => string } = {},
+): Promise<ProbeResult> {
+  return withTimeout('Connections', (async (): Promise<ProbeResult> => {
+    const path = join(agentDir, '.claude', 'connection-health.json')
+    const read = opts.readFileImpl ?? ((p: string) => readFileSync(p, 'utf8'))
+    let issues: ConnectionIssueShape[] = []
+    try {
+      const parsed = JSON.parse(read(path)) as { issues?: ConnectionIssueShape[] }
+      issues = Array.isArray(parsed.issues) ? parsed.issues : []
+    } catch {
+      // ENOENT (never applied with this build) or malformed — assume healthy.
+      return { status: 'ok', label: 'Connections', detail: 'no issues' }
+    }
+    if (issues.length === 0) {
+      return { status: 'ok', label: 'Connections', detail: 'all authed' }
+    }
+    const servers = [...new Set(issues.map((i) => i.server))]
+    const named = servers.slice(0, 4).join(', ')
+    const more = servers.length > 4 ? ` +${servers.length - 4} more` : ''
+    const first = issues[0]
+    const extra =
+      issues.length > 1
+        ? ` (+${issues.length - 1} more — run \`switchroom doctor\`)`
+        : ''
+    return {
+      status: 'degraded',
+      label: 'Connections',
+      detail: `${servers.length} integration(s) configured but not authed: ${named}${more}`,
+      nextStep: `${first.fix}${extra}`,
+    }
+  })())
+}
+
 export interface SkillsFsImpl {
   readdir: (p: string) => string[]
   exists: (p: string) => boolean

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -14254,7 +14254,7 @@ async function buildLiveProbeRows(agentName: string): Promise<StatusProbeRow[]> 
     // Render order matches the boot card's PROBE_KEYS so the two
     // surfaces tell the same story in the same order.
     const order = ['account', 'agent', 'gateway', 'quota', 'hindsight',
-      'scheduler', 'broker', 'kernel', 'skills'] as const
+      'scheduler', 'broker', 'kernel', 'skills', 'connections'] as const
     for (const k of order) {
       const r = probes[k]
       if (!r) continue

--- a/telegram-plugin/tests/boot-probes-connections.test.ts
+++ b/telegram-plugin/tests/boot-probes-connections.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for probeConnections — the boot-card surface for
+ * configured-but-unauthed MCP connections (P3). The probe only READS the
+ * host-computed snapshot at <agentDir>/.claude/connection-health.json, so
+ * we drive it with an injected readFileImpl (no fs / no broker).
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { probeConnections } from '../gateway/boot-probes.js'
+
+const ENOENT = () => {
+  const e = new Error('ENOENT') as NodeJS.ErrnoException
+  e.code = 'ENOENT'
+  throw e
+}
+
+describe('probeConnections', () => {
+  it('OK (silent) when the snapshot file is absent — assume healthy', async () => {
+    const r = await probeConnections('/agent', { readFileImpl: ENOENT })
+    expect(r.status).toBe('ok')
+  })
+
+  it('OK when the snapshot is malformed JSON', async () => {
+    const r = await probeConnections('/agent', { readFileImpl: () => 'not json{' })
+    expect(r.status).toBe('ok')
+  })
+
+  it('OK when there are zero issues', async () => {
+    const r = await probeConnections('/agent', {
+      readFileImpl: () => JSON.stringify({ computedAt: 1, issues: [] }),
+    })
+    expect(r.status).toBe('ok')
+    expect(r.detail).toContain('all authed')
+  })
+
+  it('DEGRADED (never fail) with named servers + a fix when connections are unauthed', async () => {
+    const snapshot = {
+      computedAt: 1,
+      issues: [
+        { server: 'meta', key: 'meta/token', kind: 'missing', detail: 'x', fix: 'switchroom vault set meta/token --allow marko' },
+        { server: 'postiz', key: 'postiz/key', kind: 'missing', detail: 'y', fix: 'switchroom vault set postiz/key --allow marko' },
+      ],
+    }
+    const r = await probeConnections('/agent', { readFileImpl: () => JSON.stringify(snapshot) })
+    expect(r.status).toBe('degraded')
+    expect(r.detail).toContain('2 integration(s)')
+    expect(r.detail).toContain('meta')
+    expect(r.detail).toContain('postiz')
+    // nextStep carries the first fix + a pointer to doctor for the rest.
+    expect(r.nextStep).toContain('switchroom vault set meta/token')
+    expect(r.nextStep).toContain('+1 more')
+  })
+
+  it('dedupes servers in the detail count', async () => {
+    const snapshot = {
+      computedAt: 1,
+      issues: [
+        { server: 'meta', key: 'meta/a', kind: 'missing', detail: 'x', fix: 'fixa' },
+        { server: 'meta', key: 'meta/b', kind: 'acl', detail: 'y', fix: 'fixb' },
+      ],
+    }
+    const r = await probeConnections('/agent', { readFileImpl: () => JSON.stringify(snapshot) })
+    expect(r.status).toBe('degraded')
+    expect(r.detail).toContain('1 integration(s)')
+  })
+})

--- a/tests/connection-health.test.ts
+++ b/tests/connection-health.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeAgentConnectionIssues,
+  refreshAgentConnectionHealth,
+  writeConnectionHealthFile,
+  type ConnectionHealth,
+} from "../src/agents/connection-health.js";
+import type { VaultAclResult } from "../src/cli/doctor-mcp-secrets.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+function cfg(partial: Record<string, unknown>): SwitchroomConfig {
+  return partial as unknown as SwitchroomConfig;
+}
+function reader(map: Record<string, VaultAclResult>) {
+  return async (key: string): Promise<VaultAclResult> =>
+    map[key] ?? { kind: "not_found" };
+}
+
+const marko = cfg({
+  agents: {
+    marko: {
+      mcp_servers: {
+        meta: { command: "m", secrets: ["meta/token"] },
+        postiz: { command: "p", secrets: ["postiz/key"] },
+      },
+    },
+    clerk: { mcp_servers: {} },
+  },
+});
+
+describe("computeAgentConnectionIssues", () => {
+  it("flags a missing key as a 'missing' issue with a fix, scoped to the agent", async () => {
+    const issues = await computeAgentConnectionIssues(marko, "marko", reader({
+      "postiz/key": { kind: "ok", allow: ["marko"] }, // authed
+      // meta/token → not_found
+    }));
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ server: "meta", key: "meta/token", kind: "missing" });
+    expect(issues[0].fix).toContain("switchroom vault set meta/token --allow marko");
+  });
+
+  it("flags ACL drift as an 'acl' issue and re-states the full allowlist", async () => {
+    const issues = await computeAgentConnectionIssues(marko, "marko", reader({
+      "meta/token": { kind: "ok", allow: ["someoneelse"] },
+      "postiz/key": { kind: "ok", allow: ["marko"] },
+    }));
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ server: "meta", kind: "acl" });
+    expect(issues[0].fix).toContain("--allow marko,someoneelse");
+  });
+
+  it("returns no issues when everything is authed", async () => {
+    const issues = await computeAgentConnectionIssues(marko, "marko", reader({
+      "meta/token": { kind: "ok", allow: ["marko"] },
+      "postiz/key": { kind: "ok", allow: ["marko"] },
+    }));
+    expect(issues).toEqual([]);
+  });
+
+  it("FAIL-SAFE: broker unreachable → zero issues (auth assumed), never false-flags", async () => {
+    const issues = await computeAgentConnectionIssues(marko, "marko", async () => ({
+      kind: "unreachable",
+      msg: "down",
+    }));
+    expect(issues).toEqual([]);
+  });
+
+  it("returns [] for an agent with no MCP secrets", async () => {
+    const issues = await computeAgentConnectionIssues(marko, "clerk", reader({}));
+    expect(issues).toEqual([]);
+  });
+});
+
+describe("refreshAgentConnectionHealth", () => {
+  it("writes a snapshot with computedAt + issues via injected fs", async () => {
+    const writes: Record<string, string> = {};
+    const mkdirs: string[] = [];
+    const health = await refreshAgentConnectionHealth(marko, "marko", "/agents/marko", {
+      vaultAclReader: reader({}), // both keys missing
+      now: () => 1234,
+      mkdir: (p) => { mkdirs.push(p); },
+      writeFile: (p, d) => { writes[p] = d; },
+    });
+    expect(health.computedAt).toBe(1234);
+    expect(health.issues.map((i) => i.server).sort()).toEqual(["meta", "postiz"]);
+    expect(mkdirs).toContain("/agents/marko/.claude");
+    const written = JSON.parse(writes["/agents/marko/.claude/connection-health.json"]) as ConnectionHealth;
+    expect(written.issues).toHaveLength(2);
+  });
+
+  it("never throws when the ACL reader throws — writes an empty (healthy) snapshot", async () => {
+    const writes: Record<string, string> = {};
+    const health = await refreshAgentConnectionHealth(marko, "marko", "/a/marko", {
+      vaultAclReader: async () => { throw new Error("boom"); },
+      now: () => 7,
+      mkdir: () => {},
+      writeFile: (p, d) => { writes[p] = d; },
+    });
+    expect(health.issues).toEqual([]);
+    expect(Object.keys(writes)).toHaveLength(1);
+  });
+
+  it("never throws when the write fails", async () => {
+    await expect(
+      refreshAgentConnectionHealth(marko, "marko", "/a/marko", {
+        vaultAclReader: reader({}),
+        mkdir: () => {},
+        writeFile: () => { throw new Error("EACCES"); },
+      }),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe("writeConnectionHealthFile", () => {
+  it("targets <agentDir>/.claude/connection-health.json", () => {
+    let path = "";
+    writeConnectionHealthFile("/x/y", { computedAt: 1, issues: [] }, {
+      mkdir: () => {},
+      writeFile: (p) => { path = p; },
+    });
+    expect(path).toBe("/x/y/.claude/connection-health.json");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -165,6 +165,8 @@ export default defineConfig({
       "**/src/vault/broker/server.test.ts",
       "**/src/vault/broker/auto-unlock.test.ts",
       "**/telegram-plugin/tests/boot-probes.test.ts",
+      // boot-probes-connections.test.ts uses bun:test — excluded here, run via test:bun.
+      "**/telegram-plugin/tests/boot-probes-connections.test.ts",
       "**/telegram-plugin/tests/setup-state.test.ts",
       // registry-turns.test.ts uses bun:sqlite — excluded here, run via test:bun.
       "**/telegram-plugin/tests/registry-turns.test.ts",


### PR DESCRIPTION
## Summary

**P3** of the connection-health workstream (builds on #2404). A configured-but-**unauthed** MCP connection is now visible the moment an agent **boots**, with the fix — not just when an operator runs `switchroom doctor`.

## Design (and why)

The in-container boot card **can't** compute the auth verdict itself — the boot-probe contract forbids vault/grant work (`boot-probes.ts` module header). So:

- **`switchroom apply` computes connection-health host-side** (broker + config + ACLs all reachable there), reusing PR1's `computeMcpSecretRequirements`, and writes a snapshot to `<agentDir>/.claude/connection-health.json`. Written in the scaffold loop **before `alignAgentUid`**, so the existing chown covers the file (apply runs self-elevated).
- **The boot card's new `probeConnections(agentDir)` just reads that file** — ENOENT-safe, exactly like `probeAccount` reads `.claude.json`.

## What's here

- `src/agents/connection-health.ts` — `computeAgentConnectionIssues` (missing-key / ACL-drift → issue; ok / broker-unreachable → none) + `refreshAgentConnectionHealth` (never throws). Reuses PR1's registry so doctor and the boot card never disagree.
- `telegram-plugin/gateway/boot-probes.ts` — `probeConnections`: **ok** (silent) when snapshot absent/empty; **degraded** (never `fail`) naming unauthed servers + the first fix when issues exist.
- Wired into the boot-card probe set **and** the `/status` Health block (shared `runAllProbes`; both render orders updated in lockstep).

## Fail-safe

A down/locked broker → zero issues → **no false "unhealthy"**. This never gates loading — auth is assumed; this only reports. An unauthed integration is `degraded`, never `fail` (it degrades one capability, doesn't take the agent down).

## Test plan

- [x] `vitest run tests/connection-health.test.ts` — 9 (missing/acl/ok/unreachable-failsafe, write via injected fs, never-throws on reader/write error).
- [x] `bun test boot-probes-connections.test.ts` — 5 (absent/malformed/empty → ok; issues → degraded + fix; server dedupe).
- [x] Existing boot suites (118) green; `tsc`, `check-plugin-references`, `check-bot-api-wrapping` all clean.

## Risk

Low–moderate. Additive probe; silent-when-healthy preserved. The one host-path change is a guarded best-effort write in `apply.ts` (never throws, never blocks apply). `gateway.ts` change is a single in-place line (no allowlist drift). No runtime/interface behavior changes — the reply path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)