### PR TITLE
fix(gateway): recover permission-card origin topic after a force-closed turn

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -67,6 +67,7 @@ import { DeferredDoneReactions } from '../reaction-defer.js'
 import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
 import { formatTurnLifecycle, detectStatusSurfaceDegraded } from './status-surface-log.js'
 import { parseSourceMessageId } from './source-message-id.js'
+import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel, renderActivityFeedWithNested } from '../tool-activity-summary.js'
 import { toolLabel } from '../tool-labels.js'
@@ -3280,6 +3281,29 @@ function resolvePermissionCardTargets(): Array<{ chatId: string; threadId: numbe
   if (turn != null) {
     return [{ chatId: turn.sessionChatId, threadId: turn.sessionThreadId }]
   }
+  // currentTurn was nulled — most commonly because the orphaned-reply backstop
+  // force-closed the turn while the single claude session kept running and then
+  // hit a permission-gated tool (e.g. a retry after a first card auto-denied:
+  // marko Rentals-budget, 2026-06-17). Recover the originating topic from the
+  // recently-started turn registry so the card lands where the operator is
+  // working, instead of fanning out to operator DMs (thread-stripped) where it
+  // sits unseen until the 10-min TTL auto-denies it. Kill switch (=0) restores
+  // the legacy DM fan-out.
+  if (PERMISSION_CARD_ORIGIN_RECOVERY_ENABLED) {
+    const recovered = pickRecoveredPermissionOrigin(
+      recentTurnsById.values(),
+      Date.now(),
+      PERMISSION_CARD_ORIGIN_MAX_AGE_MS,
+    )
+    if (recovered != null) {
+      process.stderr.write(
+        `telegram gateway: permission-card origin recovered from recent turn ` +
+        `chat=${recovered.chatId} thread=${recovered.threadId ?? '-'} ` +
+        `(currentTurn was null — force-closed turn)\n`,
+      )
+      return [recovered]
+    }
+  }
   const sg = resolveAgentSupergroupChatId()
   const topic = resolveAgentOutboundTopic({
     kind: 'permission',
@@ -3699,6 +3723,17 @@ const STATUS_QUERY_RE = /^\s*status\??\s*$/i
 const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number }>()
 const PERMISSION_TTL_MS = 10 * 60_000
+// Permission/approval-card origin recovery (marko Rentals-budget, 2026-06-17).
+// When `currentTurn` was force-closed by the orphaned-reply backstop but the
+// claude session kept running into a permission-gated tool, recover the card's
+// origin topic from the recently-started turn registry instead of fanning out
+// to operator DMs. Kill switch: SWITCHROOM_PERMISSION_CARD_ORIGIN_RECOVERY=0.
+const PERMISSION_CARD_ORIGIN_RECOVERY_ENABLED =
+  process.env.SWITCHROOM_PERMISSION_CARD_ORIGIN_RECOVERY !== '0'
+// A backstop-closed turn is seconds-to-minutes old; bound recovery so a
+// long-idle agent's stale registry entry can't mis-route a much later
+// permission into an old topic (it falls back to the operator-DM fan-out).
+const PERMISSION_CARD_ORIGIN_MAX_AGE_MS = 30 * 60_000
 
 // #1977 — single-tap correlation for the durable "🔁 Always allow"
 // flow. When the gateway dispatches a `config_propose_edit` to hostd in

--- a/telegram-plugin/gateway/permission-card-origin.ts
+++ b/telegram-plugin/gateway/permission-card-origin.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure origin-recovery for a permission/approval card when the gateway's live
+ * `currentTurn` has already been nulled.
+ *
+ * Why this exists (marko Rentals-budget incident, 2026-06-17). A
+ * supergroup-owned agent that delivers its final answer as plain transcript
+ * text — never calling the `reply` tool — has its turn force-closed by the
+ * gateway's orphaned-reply backstop ~30s later, which nulls `currentTurn`. If
+ * the single claude session is still running and then calls a permission-gated
+ * tool (the real case: retrying `meta_ads_set_budget` after a first card had
+ * auto-denied), the gate fires with `currentTurn == null`. The card emitter
+ * then fell through to broadcasting the card to the operator-DM allowlist,
+ * thread-stripped — so the card never reached the forum topic the operator was
+ * working in. Unanswered there, it hit the 10-minute TTL and auto-denied, and
+ * an explicitly-approved budget change silently never ran.
+ *
+ * A switchroom agent runs exactly ONE claude session, so a tool permission can
+ * only belong to the turn that session most recently had open. We recover that
+ * origin from the bounded recently-started turn registry: the most-recently-
+ * started turn still within `maxAgeMs`. A turn force-closed by the backstop is,
+ * by construction, seconds-to-minutes old, so the freshness ceiling costs
+ * nothing for the incident class while keeping a long-idle agent's stale
+ * registry entry from mis-routing a much later permission into an old topic —
+ * beyond the ceiling we return null and the caller keeps the existing
+ * operator-DM fan-out. This only ever ADDS topic recovery; it never changes the
+ * idle/turn-less path.
+ */
+
+/** The subset of a turn this recovery needs — kept structural so the gateway's
+ *  richer `CurrentTurn` satisfies it without a cast. */
+export interface RecoverableTurn {
+  sessionChatId: string
+  sessionThreadId: number | undefined
+  startedAt: number
+}
+
+export interface PermissionCardOrigin {
+  chatId: string
+  threadId: number | undefined
+}
+
+/**
+ * Pick the most-recently-started turn within the freshness window as the
+ * permission card's origin, or null when none qualifies (caller falls back to
+ * the operator-DM fan-out). Order-independent — selects by `startedAt`, not by
+ * the iteration order of the source registry, so it is robust to any
+ * out-of-order insertion.
+ */
+export function pickRecoveredPermissionOrigin(
+  recentTurns: Iterable<RecoverableTurn>,
+  now: number,
+  maxAgeMs: number,
+): PermissionCardOrigin | null {
+  let best: RecoverableTurn | null = null
+  for (const t of recentTurns) {
+    if (now - t.startedAt > maxAgeMs) continue
+    if (best == null || t.startedAt >= best.startedAt) best = t
+  }
+  return best == null
+    ? null
+    : { chatId: best.sessionChatId, threadId: best.sessionThreadId }
+}

--- a/telegram-plugin/tests/permission-card-origin.test.ts
+++ b/telegram-plugin/tests/permission-card-origin.test.ts
@@ -35,11 +35,11 @@ describe('pickRecoveredPermissionOrigin', () => {
   it('recovers the supergroup chat + topic of the most-recent fresh turn', () => {
     // The marko shape: the force-closed turn was in supergroup topic 3.
     const recovered = pickRecoveredPermissionOrigin(
-      [turn('-1003831053471', 3, 11 * 60_000)],
+      [turn('-1001234567890', 3, 11 * 60_000)],
       NOW,
       MAX_AGE,
     )
-    expect(recovered).toEqual({ chatId: '-1003831053471', threadId: 3 })
+    expect(recovered).toEqual({ chatId: '-1001234567890', threadId: 3 })
   })
 
   it('picks the most-recently-started turn when several are fresh', () => {
@@ -75,11 +75,11 @@ describe('pickRecoveredPermissionOrigin', () => {
 
   it('recovers a DM-origin turn thread-less (threadId undefined)', () => {
     const recovered = pickRecoveredPermissionOrigin(
-      [turn('8248703757', undefined, 3 * 60_000)],
+      [turn('12345', undefined, 3 * 60_000)],
       NOW,
       MAX_AGE,
     )
-    expect(recovered).toEqual({ chatId: '8248703757', threadId: undefined })
+    expect(recovered).toEqual({ chatId: '12345', threadId: undefined })
   })
 
   it('keeps the freshest in-window turn even when stale turns are present', () => {

--- a/telegram-plugin/tests/permission-card-origin.test.ts
+++ b/telegram-plugin/tests/permission-card-origin.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the pure permission-card origin-recovery helper.
+ *
+ * Pins the behaviour that fixes the marko Rentals-budget incident
+ * (2026-06-17): when the gateway's `currentTurn` was force-closed by the
+ * orphaned-reply backstop but the claude session kept running into a
+ * permission-gated tool, the card must recover its origin from the most-recent
+ * still-fresh turn — so it lands in the forum topic the operator is working in
+ * rather than fanning out to operator DMs where it auto-denies on the 10-min
+ * TTL.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  pickRecoveredPermissionOrigin,
+  type RecoverableTurn,
+} from '../gateway/permission-card-origin.js'
+
+const NOW = 1_000_000_000_000
+const MAX_AGE = 30 * 60_000 // 30 min, mirrors PERMISSION_CARD_ORIGIN_MAX_AGE_MS
+
+function turn(
+  chatId: string,
+  threadId: number | undefined,
+  ageMs: number,
+): RecoverableTurn {
+  return { sessionChatId: chatId, sessionThreadId: threadId, startedAt: NOW - ageMs }
+}
+
+describe('pickRecoveredPermissionOrigin', () => {
+  it('returns null for an empty registry (caller keeps the DM fan-out)', () => {
+    expect(pickRecoveredPermissionOrigin([], NOW, MAX_AGE)).toBeNull()
+  })
+
+  it('recovers the supergroup chat + topic of the most-recent fresh turn', () => {
+    // The marko shape: the force-closed turn was in supergroup topic 3.
+    const recovered = pickRecoveredPermissionOrigin(
+      [turn('-1003831053471', 3, 11 * 60_000)],
+      NOW,
+      MAX_AGE,
+    )
+    expect(recovered).toEqual({ chatId: '-1003831053471', threadId: 3 })
+  })
+
+  it('picks the most-recently-started turn when several are fresh', () => {
+    const recovered = pickRecoveredPermissionOrigin(
+      [
+        turn('-100aaa', 1, 20 * 60_000),
+        turn('-100bbb', 3, 2 * 60_000), // most recent
+        turn('-100ccc', 4, 9 * 60_000),
+      ],
+      NOW,
+      MAX_AGE,
+    )
+    expect(recovered).toEqual({ chatId: '-100bbb', threadId: 3 })
+  })
+
+  it('selects by startedAt, not iteration order (robust to out-of-order inserts)', () => {
+    const recovered = pickRecoveredPermissionOrigin(
+      [
+        turn('-100recent', 1, 1 * 60_000), // freshest, but listed first
+        turn('-100older', 2, 15 * 60_000),
+      ],
+      NOW,
+      MAX_AGE,
+    )
+    expect(recovered).toEqual({ chatId: '-100recent', threadId: 1 })
+  })
+
+  it('ignores turns older than the freshness ceiling', () => {
+    expect(
+      pickRecoveredPermissionOrigin([turn('-100stale', 7, 45 * 60_000)], NOW, MAX_AGE),
+    ).toBeNull()
+  })
+
+  it('recovers a DM-origin turn thread-less (threadId undefined)', () => {
+    const recovered = pickRecoveredPermissionOrigin(
+      [turn('8248703757', undefined, 3 * 60_000)],
+      NOW,
+      MAX_AGE,
+    )
+    expect(recovered).toEqual({ chatId: '8248703757', threadId: undefined })
+  })
+
+  it('keeps the freshest in-window turn even when stale turns are present', () => {
+    const recovered = pickRecoveredPermissionOrigin(
+      [
+        turn('-100stale', 1, 90 * 60_000),
+        turn('-100fresh', 3, 5 * 60_000),
+        turn('-100ancient', 2, 600 * 60_000),
+      ],
+      NOW,
+      MAX_AGE,
+    )
+    expect(recovered).toEqual({ chatId: '-100fresh', threadId: 3 })
+  })
+})

--- a/telegram-plugin/tests/permission-card-routing.test.ts
+++ b/telegram-plugin/tests/permission-card-routing.test.ts
@@ -74,4 +74,27 @@ describe('permission card routing', () => {
     const body = GATEWAY_SRC.slice(start, start + 1400)
     expect(body).toContain('resolvePermissionCardTargets()')
   })
+
+  // marko Rentals-budget incident (2026-06-17): a turn force-closed by the
+  // orphaned-reply backstop nulled currentTurn, so a permission gate that
+  // fired afterwards fell through to the operator-DM fan-out instead of the
+  // forum topic. The helper must first try to recover the origin from the
+  // recently-started turn registry.
+  it('resolvePermissionCardTargets recovers origin from recent turns when currentTurn is null', () => {
+    const start = GATEWAY_SRC.indexOf('function resolvePermissionCardTargets(')
+    expect(start).toBeGreaterThan(-1)
+    const end = GATEWAY_SRC.indexOf('\n}', start)
+    const body = GATEWAY_SRC.slice(start, end)
+    // Recovery is attempted via the pure helper over the turn registry...
+    expect(body).toContain('pickRecoveredPermissionOrigin')
+    expect(body).toContain('recentTurnsById')
+    // ...before the operator-DM fan-out (recovery branch precedes allowFrom).
+    expect(body.indexOf('pickRecoveredPermissionOrigin')).toBeLessThan(
+      body.indexOf('allowFrom'),
+    )
+  })
+
+  it('the origin-recovery path has a kill switch', () => {
+    expect(GATEWAY_SRC).toContain('SWITCHROOM_PERMISSION_CARD_ORIGIN_RECOVERY')
+  })
 })


### PR DESCRIPTION
## Summary

A permission/approval card raised by a **supergroup-owned agent** was landing in the operator's DM (fanned out to *all* operators in `allowFrom`) instead of in the forum topic the operator was working in — where it then sat unseen until the 10-minute TTL auto-denied it.

Real incident — **marko, 2026-06-17**: Lisa, in the "Meta Campaigns" topic, explicitly approved a Rentals ad-budget change ("change approved"). marko called `meta_ads_set_budget`; the first card landed in the topic correctly but TTL-expired; the gateway fed the model a synthetic "Denied"; marko retried the identical change; **that second card was routed to Ken's + Lisa's DMs**, never to the topic, and also auto-denied. Net: an approved spend change silently never ran, and Ken got DMed about a request Lisa made in the group.

## Root cause

`resolvePermissionCardTargets()` (telegram-plugin/gateway/gateway.ts) routes the card to the originating chat+topic **only while `currentTurn` is non-null**; otherwise it falls back to the operator-DM fan-out. marko delivers final answers as plain transcript text (no `reply` tool), so the **orphaned-reply backstop force-closes the turn ~30s later and nulls `currentTurn`**. A permission gate that fires after that point (e.g. the retry) loses its origin and hits the fallback.

## Fix

A switchroom agent runs exactly **one** claude session, so a tool permission can only belong to the turn the session most recently had open. When `currentTurn` is null, recover the origin from the bounded recently-started turn registry (`recentTurnsById` — every turn is recorded at *enqueue*, so a force-closed turn is still present): the most-recently-started turn within a 30-min freshness ceiling. Beyond the ceiling, or with no remembered turn, the existing operator-DM fan-out is preserved — so this **only adds topic recovery for the incident class** and never changes the idle/turn-less path. Card + resume message share the helper, so they recover together (no drift).

Kill switch: `SWITCHROOM_PERMISSION_CARD_ORIGIN_RECOVERY=0`.

> Note: the DM fan-out to *all* operators (when there's no recoverable origin) is intentional and unchanged — confirmed desirable by the operator.

## Why / job

Serves the **on-leash** outcome (controlled, purposeful approvals): an approval must surface where the human asked, not vanish into a DM and silently auto-deny.

## Test plan

- [x] New pure helper `pickRecoveredPermissionOrigin` with unit tests (`permission-card-origin.test.ts`) — empty registry, fresh-turn recovery, most-recent selection, order-independence, staleness ceiling, DM-origin thread-less.
- [x] Source-text pins extended (`permission-card-routing.test.ts`): recovery consults the registry **before** `allowFrom`, and a kill switch exists.
- [x] `tsc --noEmit` clean; `check-plugin-references.mjs` clean.
- [x] Full telegram-plugin suite under **both** runners: vitest + `bun test` (4478 pass, 0 fail).

## Risk

Low. Behaviour change is confined to the `currentTurn == null` branch and is gated + bounded; the no-origin path (operator-DM fan-out) is byte-for-byte preserved. Recovery is a read over an existing in-memory registry. Reversible via env kill switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)