### PR TITLE
feat(telegram): right-size always-loaded tool surface (gate + defer)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3277,6 +3277,17 @@ export function scaffoldAgent(
     // `schedule_add`. See switchroom#1892.
     const telegramStateDir = `${DOCKER_AGENT_HOME}/.switchroom/agents/${name}/telegram`;
 
+    // Linear connection gate (P4-A): the bridge only advertises the
+    // linear_* tools when this agent actually has the Linear connection
+    // configured. Mirrors the `linearAgentEnabled` derivation in
+    // buildWorkspaceContext (scaffold.ts:2362) so both stay in lockstep.
+    const linearAgentEnabled =
+      (
+        agentConfig.channels?.telegram as
+          | { linear_agent?: { enabled?: boolean } }
+          | undefined
+      )?.linear_agent?.enabled === true;
+
     const mcpServers: Record<string, McpServerConfig> = {
       "switchroom-telegram": {
         command: "bun",
@@ -3285,12 +3296,21 @@ export function scaffoldAgent(
           TELEGRAM_STATE_DIR: telegramStateDir,
           SWITCHROOM_CONFIG: resolvedConfigPath,
           SWITCHROOM_CLI_PATH: switchroomCliPath,
+          // Gate the linear_* tools (P4-A). Only set when the Linear
+          // connection is configured; the bridge drops those 3 tools
+          // otherwise so a non-Linear agent never carries their schema.
+          ...(linearAgentEnabled ? { SWITCHROOM_TELEGRAM_LINEAR: "1" } : {}),
         },
-        // LOAD-BEARING under tool search: reply / stream_reply /
-        // get_recent_messages / react must never defer, or every turn pays a
-        // ToolSearch round-trip before it can answer (the orphaned-reply
-        // failure class). Pin them loaded.
-        alwaysLoad: true,
+        // Tool-search right-sizing (P4-B): the server is NO LONGER pinned
+        // wholesale. The bridge pins the load-bearing hot tools (reply /
+        // stream_reply / get_recent_messages / react / edit_message /
+        // send_typing / download_attachment) individually via the native
+        // per-tool `_meta["anthropic/alwaysLoad"]` annotation, so they
+        // never defer (no orphaned-reply round-trip), while the ~14 cold
+        // tools (linear / vault / checklist / gif / sticker / pin / delete
+        // / forward / ask_user) defer and load on first use — reclaiming
+        // ~5k tokens of always-on baseline per agent.
+        alwaysLoad: false,
       },
       // Read-only agent-config broker. Exposes 4 tools (config_get,
       // cron_list, skill_list, audit_tail) that re-exec the switchroom
@@ -5492,6 +5512,17 @@ export function reconcileAgent(
     // switchroom#1892.
     const telegramStateDir = `${DOCKER_AGENT_HOME}/.switchroom/agents/${name}/telegram`;
 
+    // Linear connection gate (P4-A): the bridge only advertises the
+    // linear_* tools when this agent actually has the Linear connection
+    // configured. Mirrors the `linearAgentEnabled` derivation in
+    // buildWorkspaceContext (scaffold.ts:2362) so both stay in lockstep.
+    const linearAgentEnabled =
+      (
+        agentConfig.channels?.telegram as
+          | { linear_agent?: { enabled?: boolean } }
+          | undefined
+      )?.linear_agent?.enabled === true;
+
     const mcpServers: Record<string, McpServerConfig> = {
       "switchroom-telegram": {
         command: "bun",
@@ -5500,12 +5531,21 @@ export function reconcileAgent(
           TELEGRAM_STATE_DIR: telegramStateDir,
           SWITCHROOM_CONFIG: resolvedConfigPath,
           SWITCHROOM_CLI_PATH: switchroomCliPath,
+          // Gate the linear_* tools (P4-A). Only set when the Linear
+          // connection is configured; the bridge drops those 3 tools
+          // otherwise so a non-Linear agent never carries their schema.
+          ...(linearAgentEnabled ? { SWITCHROOM_TELEGRAM_LINEAR: "1" } : {}),
         },
-        // LOAD-BEARING under tool search: reply / stream_reply /
-        // get_recent_messages / react must never defer, or every turn pays a
-        // ToolSearch round-trip before it can answer (the orphaned-reply
-        // failure class). Pin them loaded.
-        alwaysLoad: true,
+        // Tool-search right-sizing (P4-B): the server is NO LONGER pinned
+        // wholesale. The bridge pins the load-bearing hot tools (reply /
+        // stream_reply / get_recent_messages / react / edit_message /
+        // send_typing / download_attachment) individually via the native
+        // per-tool `_meta["anthropic/alwaysLoad"]` annotation, so they
+        // never defer (no orphaned-reply round-trip), while the ~14 cold
+        // tools (linear / vault / checklist / gif / sticker / pin / delete
+        // / forward / ask_user) defer and load on first use — reclaiming
+        // ~5k tokens of always-on baseline per agent.
+        alwaysLoad: false,
       },
       // Read-only agent-config broker. Exposes 4 tools (config_get,
       // cron_list, skill_list, audit_tail) that re-exec the switchroom

--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -27,6 +27,7 @@ import {
   type PtyTailHandle,
 } from '../pty-tail.js'
 import { createIpcClient, type IpcClientHandle } from './ipc-client.js'
+import { buildEffectiveToolSchemas, LINEAR_ENV } from './tool-filter.js'
 import type { InboundMessage, PermissionEvent, StatusEvent } from '../gateway/ipc-protocol.js'
 import { matchesAllowRule } from '../permission-rule.js'
 
@@ -544,7 +545,17 @@ const TOOL_SCHEMAS = [
   },
 ]
 
-mcp.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_SCHEMAS }))
+// Tool-surface right-sizing (P4): connection-gate linear_* + per-tool
+// alwaysLoad pins for the hot path. See tool-filter.ts for the rationale.
+// Computed once at startup — SWITCHROOM_TELEGRAM_LINEAR is fixed for the
+// process lifetime (set by the gateway in .mcp.json when Linear is wired).
+const EFFECTIVE_TOOL_SCHEMAS = buildEffectiveToolSchemas(TOOL_SCHEMAS, {
+  linearEnabled: process.env[LINEAR_ENV] === '1',
+})
+
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: EFFECTIVE_TOOL_SCHEMAS,
+}))
 
 // ─── MCP CallTool → IPC forward ─────────────────────────────────────────
 

--- a/telegram-plugin/bridge/tool-filter.ts
+++ b/telegram-plugin/bridge/tool-filter.ts
@@ -1,0 +1,77 @@
+/**
+ * Tool-surface right-sizing for the switchroom-telegram MCP server (P4).
+ *
+ * switchroom-telegram is the primary interface, so its tool schemas are
+ * always-loaded on EVERY agent, every turn (~8k tokens). Two reductions,
+ * both native to Claude Code tool-search (honored in 2.1.177; the MCP SDK
+ * preserves `_meta` on tools/list — @modelcontextprotocol/sdk ToolSchema
+ * has `_meta: z.record(...).optional()`):
+ *
+ *   A. Connection gating — linear_* tools are advertised only when the
+ *      agent has the Linear connection configured (the gateway sets
+ *      SWITCHROOM_TELEGRAM_LINEAR=1 from channels.telegram.linear_agent.
+ *      enabled). A non-Linear agent never carries their schema at all.
+ *
+ *   B. Per-tool deferral — the server is no longer pinned wholesale
+ *      (scaffold sets alwaysLoad:false). We pin ONLY the load-bearing hot
+ *      tools via `_meta["anthropic/alwaysLoad"]` so they never defer (the
+ *      reply path must never pay a ToolSearch round-trip before it can
+ *      answer); the ~14 cold tools defer and load on first use.
+ *
+ * Pure + side-effect free so it's unit-testable in isolation (bridge.ts
+ * has import-time side effects). Both reductions are non-destructive — every
+ * tool the agent is entitled to still works; cold ones just load on demand.
+ */
+
+/** Minimal shape we need from a tool schema. */
+export interface NamedTool {
+  name: string
+  [k: string]: unknown
+}
+
+/**
+ * Hot tools pinned loaded — must never defer. The reply path
+ * (reply/stream_reply) plus the frequently-used early-turn ops. Everything
+ * NOT in this set defers under tool-search.
+ */
+export const ALWAYS_LOAD_TOOLS: ReadonlySet<string> = new Set([
+  'reply',
+  'stream_reply',
+  'get_recent_messages',
+  'react',
+  'edit_message',
+  'send_typing',
+  'download_attachment',
+])
+
+/** Linear tools — advertised only when the Linear connection is configured. */
+export const LINEAR_TOOLS: ReadonlySet<string> = new Set([
+  'linear_agent_activity',
+  'linear_create_issue',
+  'linear_agent_setup',
+])
+
+/** The env var the gateway sets (per .mcp.json) when Linear is configured. */
+export const LINEAR_ENV = 'SWITCHROOM_TELEGRAM_LINEAR'
+
+export interface ToolFilterOpts {
+  /** True when the Linear connection is configured for this agent. */
+  linearEnabled: boolean
+}
+
+/**
+ * Apply connection gating (A) + per-tool deferral pins (B) to a tool list.
+ * Returns a NEW array; inputs are not mutated. Order is preserved.
+ */
+export function buildEffectiveToolSchemas<T extends NamedTool>(
+  schemas: ReadonlyArray<T>,
+  opts: ToolFilterOpts,
+): Array<T & { _meta?: { 'anthropic/alwaysLoad': true } }> {
+  return schemas
+    .filter((t) => opts.linearEnabled || !LINEAR_TOOLS.has(t.name))
+    .map((t) =>
+      ALWAYS_LOAD_TOOLS.has(t.name)
+        ? { ...t, _meta: { 'anthropic/alwaysLoad': true as const } }
+        : t,
+    )
+}

--- a/telegram-plugin/tests/tool-filter.test.ts
+++ b/telegram-plugin/tests/tool-filter.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the switchroom-telegram tool-surface right-sizing (P4):
+ * connection gating of linear_* (A) + per-tool alwaysLoad pins for the hot
+ * path (B). Pure function — no bridge.ts import (which has side effects).
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  buildEffectiveToolSchemas,
+  ALWAYS_LOAD_TOOLS,
+  LINEAR_TOOLS,
+  type NamedTool,
+} from '../bridge/tool-filter.js'
+
+// A representative slice mirroring the real TOOL_SCHEMAS names.
+const SAMPLE: NamedTool[] = [
+  { name: 'reply', description: 'r' },
+  { name: 'stream_reply', description: 's' },
+  { name: 'get_recent_messages', description: 'g' },
+  { name: 'react', description: 'k' },
+  { name: 'edit_message', description: 'e' },
+  { name: 'send_typing', description: 't' },
+  { name: 'download_attachment', description: 'd' },
+  { name: 'ask_user', description: 'a' }, // cold
+  { name: 'send_gif', description: 'gif' }, // cold
+  { name: 'vault_request_access', description: 'v' }, // cold
+  { name: 'linear_agent_activity', description: 'la' },
+  { name: 'linear_create_issue', description: 'lc' },
+  { name: 'linear_agent_setup', description: 'ls' },
+]
+
+const names = (tools: NamedTool[]) => tools.map((t) => t.name)
+const metaOf = (tools: Array<NamedTool & { _meta?: unknown }>, n: string) =>
+  tools.find((t) => t.name === n)?._meta
+
+describe('buildEffectiveToolSchemas — connection gating (A)', () => {
+  it('drops all linear_* tools when Linear is NOT enabled', () => {
+    const out = buildEffectiveToolSchemas(SAMPLE, { linearEnabled: false })
+    for (const t of LINEAR_TOOLS) expect(names(out)).not.toContain(t)
+    // non-linear tools all survive
+    expect(names(out)).toContain('reply')
+    expect(names(out)).toContain('ask_user')
+    expect(out.length).toBe(SAMPLE.length - LINEAR_TOOLS.size)
+  })
+
+  it('keeps linear_* tools when Linear IS enabled', () => {
+    const out = buildEffectiveToolSchemas(SAMPLE, { linearEnabled: true })
+    for (const t of LINEAR_TOOLS) expect(names(out)).toContain(t)
+    expect(out.length).toBe(SAMPLE.length)
+  })
+})
+
+describe('buildEffectiveToolSchemas — per-tool deferral pins (B)', () => {
+  it('pins exactly the hot tools with _meta anthropic/alwaysLoad', () => {
+    const out = buildEffectiveToolSchemas(SAMPLE, { linearEnabled: true })
+    for (const hot of ALWAYS_LOAD_TOOLS) {
+      expect(metaOf(out, hot)).toEqual({ 'anthropic/alwaysLoad': true })
+    }
+  })
+
+  it('the reply path (reply/stream_reply) is ALWAYS pinned — never defers', () => {
+    const out = buildEffectiveToolSchemas(SAMPLE, { linearEnabled: false })
+    expect(metaOf(out, 'reply')).toEqual({ 'anthropic/alwaysLoad': true })
+    expect(metaOf(out, 'stream_reply')).toEqual({ 'anthropic/alwaysLoad': true })
+  })
+
+  it('cold tools carry NO _meta (so they defer under tool-search)', () => {
+    const out = buildEffectiveToolSchemas(SAMPLE, { linearEnabled: true })
+    for (const cold of ['ask_user', 'send_gif', 'vault_request_access', 'linear_create_issue']) {
+      expect(metaOf(out, cold)).toBeUndefined()
+    }
+  })
+})
+
+describe('buildEffectiveToolSchemas — purity', () => {
+  it('does not mutate the input array or its objects', () => {
+    const input: NamedTool[] = [{ name: 'reply' }, { name: 'send_gif' }]
+    const snapshot = JSON.stringify(input)
+    buildEffectiveToolSchemas(input, { linearEnabled: true })
+    expect(JSON.stringify(input)).toBe(snapshot)
+  })
+
+  it('preserves order', () => {
+    const out = buildEffectiveToolSchemas(SAMPLE, { linearEnabled: true })
+    expect(names(out)).toEqual(names(SAMPLE))
+  })
+})

--- a/tests/scaffold.tool-search.test.ts
+++ b/tests/scaffold.tool-search.test.ts
@@ -5,9 +5,12 @@
  * schemas so the ~31k-token integration-server surface stops occupying the
  * window every turn. Two halves must stay wired:
  *   1. the ENABLE_TOOL_SEARCH env var (default `auto`, kill-switchable);
- *   2. `alwaysLoad: true` pinned on the LOAD-BEARING framework servers
- *      (switchroom-telegram, hindsight, agent-config) so reply /
- *      get_recent_messages / recall never defer (the orphaned-reply hazard).
+ *   2. The LOAD-BEARING tools never defer (the orphaned-reply hazard).
+ *      - hindsight + agent-config: pinned server-wide via `alwaysLoad: true`.
+ *      - switchroom-telegram (P4): NO LONGER pinned server-wide
+ *        (`alwaysLoad: false`); the bridge pins only the hot tools (reply /
+ *        stream_reply / get_recent_messages / react / …) per-tool via
+ *        `_meta["anthropic/alwaysLoad"]`, so the ~14 cold tools defer.
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
@@ -60,16 +63,43 @@ describe("tool-search wiring (source guards)", () => {
     }
   });
 
-  it("the LOAD-BEARING framework servers carry alwaysLoad:true", () => {
-    // Each server-entry literal closes its env block first, so look in a
-    // window large enough to span past it to the entry's own alwaysLoad.
-    const telegram = scaffoldSrc.split('"switchroom-telegram": {')[1]?.slice(0, 600) ?? "";
-    expect(telegram).toMatch(/alwaysLoad: true/);
+  it("agent-config + hindsight stay pinned server-wide (alwaysLoad:true)", () => {
     const agentConfig = scaffoldSrc.split('"agent-config": {')[1]?.slice(0, 500) ?? "";
     expect(agentConfig).toMatch(/alwaysLoad: true/);
     // hindsight pinned in scaffold-integration.ts.
     const integ = readFileSync(resolve(__dirname, "..", "src", "memory", "scaffold-integration.ts"), "utf-8");
     expect(integ).toMatch(/key: "hindsight", value: \{ \.\.\.mcpConfig, alwaysLoad: true \}/);
+  });
+
+  it("switchroom-telegram is NO LONGER pinned server-wide (P4-B: alwaysLoad:false)", () => {
+    // Both writer sites must agree (byte-for-byte invariant, #1892).
+    const blocks = scaffoldSrc.split('"switchroom-telegram": {').slice(1);
+    expect(blocks.length).toBe(2);
+    for (const b of blocks) {
+      // The FIRST alwaysLoad after the telegram marker is the telegram
+      // entry's own (agent-config's comes later) — must be false now.
+      const m = b.match(/alwaysLoad: (true|false)/);
+      expect(m?.[1]).toBe("false");
+    }
+  });
+
+  it("the bridge pins the hot tools per-tool via _meta anthropic/alwaysLoad", () => {
+    // P4-B: deferral safety now lives in the bridge's tool-filter, not the
+    // server flag. The reply path MUST be in the always-load set.
+    const filterSrc = readFileSync(
+      resolve(__dirname, "..", "telegram-plugin", "bridge", "tool-filter.ts"),
+      "utf-8",
+    );
+    expect(filterSrc).toMatch(/ALWAYS_LOAD_TOOLS/);
+    expect(filterSrc).toMatch(/anthropic\/alwaysLoad/);
+    expect(filterSrc).toMatch(/'reply'/);
+    expect(filterSrc).toMatch(/'stream_reply'/);
+    // and the bridge actually applies it to the tools/list response.
+    const bridgeSrc = readFileSync(
+      resolve(__dirname, "..", "telegram-plugin", "bridge", "bridge.ts"),
+      "utf-8",
+    );
+    expect(bridgeSrc).toMatch(/buildEffectiveToolSchemas\(TOOL_SCHEMAS/);
   });
 
   it("McpServerConfig carries the optional alwaysLoad field", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -165,6 +165,8 @@ export default defineConfig({
       "**/src/vault/broker/server.test.ts",
       "**/src/vault/broker/auto-unlock.test.ts",
       "**/telegram-plugin/tests/boot-probes.test.ts",
+      // tool-filter.test.ts uses bun:test — excluded here, run via test:bun.
+      "**/telegram-plugin/tests/tool-filter.test.ts",
       "**/telegram-plugin/tests/setup-state.test.ts",
       // registry-turns.test.ts uses bun:sqlite — excluded here, run via test:bun.
       "**/telegram-plugin/tests/registry-turns.test.ts",


### PR DESCRIPTION
## Summary

**P4** of the connection workstream. `switchroom-telegram` is the **primary interface**, so its ~8k-token tool schema is always-loaded on **every agent, every turn**. Two native (Claude Code tool-search) reductions — no SDK/API, all within the unmodified-CLI constraint:

**A. Connection gating** — the bridge advertises the 3 `linear_*` tools **only** when the agent has the Linear connection configured. `scaffold` sets `SWITCHROOM_TELEGRAM_LINEAR=1` in the `.mcp.json` env from `channels.telegram.linear_agent.enabled`; the bridge drops those tools otherwise, so a non-Linear agent never carries their ~1.5k of schema.

**B. Per-tool deferral** — `switchroom-telegram` is no longer pinned wholesale (`scaffold`: `alwaysLoad` true→false). The bridge pins **only** the load-bearing hot tools — `reply`, `stream_reply`, `get_recent_messages`, `react`, `edit_message`, `send_typing`, `download_attachment` — via the native per-tool `_meta["anthropic/alwaysLoad"]` annotation, so **the reply path never defers** (no orphaned-reply round-trip). The ~14 cold tools (vault / checklist / gif / sticker / pin / delete / forward / ask_user / linear) defer and load on first use → **~5k tokens/agent** of always-on baseline reclaimed.

## Verified feasibility

- claude **2.1.177** honors per-tool `_meta["anthropic/alwaysLoad"]` (binary: `alwaysLoad = server.config.alwaysLoad || tool._meta["anthropic/alwaysLoad"]`).
- MCP SDK **1.29.0** `ToolSchema` includes `_meta: z.record(...).optional()` and `ListToolsResultSchema = { tools: z.array(ToolSchema) }` — so `_meta` is **preserved on the wire**.

## Implementation notes

- Filter logic extracted to a **pure** `telegram-plugin/bridge/tool-filter.ts` (`bridge.ts` has import-time side effects), unit-tested in isolation.
- `scaffold` edits **both** writer sites (`scaffoldAgent` + `reconcileAgent`) in lockstep — byte-for-byte `.mcp.json` invariant (#1892).

## Test plan

- [x] `bun test tool-filter.test.ts` — 7 (linear drop/keep, hot-tool `_meta` pins, reply path always pinned, cold tools defer, purity, order).
- [x] `tests/scaffold.tool-search.test.ts` updated to the new design (telegram `alwaysLoad:false` both sites; agent-config/hindsight still pinned; bridge pins hot tools) — 8 pass.
- [x] scaffold mcp-json / regenerate / user-declared / reconcile-drift suites (26) + bridge-flap guard green; `tsc`, `check-plugin-references`, `check-bot-api-wrapping` clean.

## ⚠️ Rollout gate

Touches the **reply path**. **Do NOT auto-merge.** Requires, after reviewer APPROVE: `test-harness` canary + the release-critical reply UAT scenarios (`jtbd-fast-trivial-dm`, `jtbd-always-on-after-restart-dm`, channel parity) to confirm (a) the reply path never pays a ToolSearch round-trip and (b) a deferred tool (e.g. `vault_request_access`) still loads + works on first use.

## Risk

Moderate (primary interface), mitigated by: reply path pinned (B keeps it always-loaded); non-destructive (every tool still works, cold ones load on demand); kill-switch available (`SWITCHROOM_DISABLE_TOOL_SEARCH=1` reverts to all-loaded); reviewer + canary + UAT before rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)