### PR TITLE
fix(web): Connections cards invisible on desktop (.accounts-grid hidden)

### DIFF
--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -474,7 +474,14 @@
     }
 
     @media (min-width: 701px) {
-      .accounts-grid { display: none; }
+      /* The Accounts tab shows a wide-screen TABLE and a mobile card grid,
+         hiding the grid on desktop. Scope that hide to #accounts: the
+         Connections tab reuses .accounts-grid for its OAuth/Notion cards but
+         has NO table fallback, so an unscoped rule blanked every connection
+         card on any screen wider than 700px (the cards rendered but were
+         display:none, while the empty-state text — not in a grid — still
+         showed). */
+      #accounts .accounts-grid { display: none; }
     }
 
     @media (max-width: 600px) {

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -2444,3 +2444,33 @@ describe("dashboardCacheControl — stale-shell prevention", () => {
     expect(dashboardCacheControl("")).toBeUndefined();
   });
 });
+
+describe("dashboard CSS — .accounts-grid desktop-hide must stay scoped", () => {
+  // Regression guard for the "connections never show on desktop" bug. The
+  // Accounts tab shows a wide-screen table and hides its mobile card grid via
+  // `@media (min-width: 701px) { .accounts-grid { display: none } }`. The
+  // Connections tab REUSES .accounts-grid for its OAuth/Notion cards but has no
+  // table fallback, so an UNSCOPED rule hid every connection card on any screen
+  // wider than 700px (cards rendered but display:none; only the non-grid
+  // empty-state text showed). The fix scopes the hide to `#accounts`. If anyone
+  // reintroduces the unscoped form, this fails.
+  const html = readFileSync(
+    new URL("../src/web/ui/index.html", import.meta.url),
+    "utf8",
+  );
+
+  it("hides .accounts-grid on desktop only within #accounts", () => {
+    expect(html).toContain("#accounts .accounts-grid { display: none; }");
+  });
+
+  it("has no UNSCOPED .accounts-grid display:none rule (would blank Connections)", () => {
+    // Any `.accounts-grid { display: none }` NOT scoped by `#accounts ` is the
+    // exact regression: it hides the Connections tab's cards (which have no
+    // table fallback). The `.accounts-grid` base rule uses `display: grid` and
+    // the 600px rule sets grid-template-columns, so this pattern is specific to
+    // the desktop-hide. The negative lookbehind passes the scoped form.
+    expect(html).not.toMatch(
+      /(?<!#accounts )\.accounts-grid\s*\{\s*display:\s*none/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The **Connections** tab renders **blank on every desktop-width screen** (>700px). The Google + Microsoft account cards are in the DOM but `display:none`; only the non-grid empty-state text (e.g. Notion's "not configured") shows. No JS error, no failed fetch — the API returns the accounts correctly. **Purely CSS.**

This was a confusing one to diagnose because everything *else* checked out: config has the accounts, the broker knows them, the API returns 200 with data, and the raw `/api/google-accounts` URL shows the JSON in the browser. The cards were rendering — just hidden.

## Root cause

The **Accounts** tab shows a wide-screen *table* and a mobile *card grid*, hiding the grid on desktop:

```css
@media (min-width: 701px) { .accounts-grid { display: none; } }
```

The **Connections** tab reuses `.accounts-grid` for its OAuth/Notion cards but has **no table fallback**, so this *unscoped* rule hid every connection card above 700px.

## Fix

Scope the desktop hide to `#accounts .accounts-grid`:

- Connections grids (`#connections`) now render on desktop ✅
- Accounts tab table/grid swap unchanged ✅
- Mobile (<701px) unchanged ✅

One-line CSS change + a regression guard.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/web.test.ts` — 132 passed (2 new)
  - asserts `#accounts .accounts-grid { display: none; }` is present (scoped)
  - asserts no **unscoped** `.accounts-grid { display: none }` (negative lookbehind) — fails if the bug is reintroduced
- [x] Manually verified the rendered card markup is correct (the cards were always built; only CSS hid them)

## Risk

Minimal — one selector scoped tighter. The only behavioral change is that `.accounts-grid` outside `#accounts` (i.e. the Connections tab) is no longer hidden on desktop, which is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)