### PR TITLE
feat(web): Linear section on Connections tab (OAuth app actors)

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -1192,6 +1192,74 @@ export function handleGetNotionWorkspace(
   };
 }
 
+export interface LinearAgentInfo {
+  /** Agent name. */
+  agent: string;
+  /** Linear workspace (organization) id, if declared. */
+  workspaceId: string | null;
+  /** Default Linear team id new captured issues file into, if declared. */
+  defaultTeamId: string | null;
+  /**
+   * Vault key REFERENCE for the OAuth access token (e.g.
+   * `vault:linear/<agent>/token`) — never the token itself. Null if the
+   * config field is absent or (defensively) not a `vault:` reference.
+   */
+  tokenVaultKey: string | null;
+}
+
+export interface LinearAgentsDashboard {
+  /** True when at least one agent is connected as a Linear OAuth app actor. */
+  configured: boolean;
+  /** Agents with `channels.telegram.linear_agent.enabled` (cascade-resolved). */
+  agents: LinearAgentInfo[];
+}
+
+/**
+ * Linear view for the dashboard. Linear has exactly ONE integration mode:
+ * the first-class OAuth **app actor** (`channels.telegram.linear_agent`) — an
+ * agent appears in the workspace as its own actor (#2298). There is no
+ * "personal API token for MCP" alternative, so an agent with
+ * `linear_agent.enabled` IS connected as a Linear OAuth agent.
+ *
+ * This is config-only (like Notion): the internet-facing web tier reads the
+ * cascade-resolved per-agent config and returns only metadata + the token's
+ * vault-key REFERENCE. It never reads the vault, so the access token / OAuth
+ * refresh bundle (client_secret, refresh_token) never reach the web tier or
+ * the client. Live token freshness lives with the in-agent gateway's proactive
+ * `linear-auth-watch` (which alerts the operator on Telegram); surfacing it
+ * here would require the web tier to read per-agent vault state, which the
+ * minimal-surface web container deliberately cannot do.
+ */
+export function handleGetLinearAgents(
+  config: SwitchroomConfig,
+): LinearAgentsDashboard {
+  const agentNames = Object.keys(config.agents ?? {});
+  const agents: LinearAgentInfo[] = [];
+  for (const name of agentNames) {
+    const rawAgent = config.agents?.[name];
+    if (!rawAgent) continue;
+    const linear = resolveAgentConfig(
+      config.defaults,
+      config.profiles,
+      rawAgent,
+    ).channels?.telegram?.linear_agent;
+    if (!linear?.enabled) continue;
+    // The schema mandates a `vault:` reference; surface it only when it
+    // actually looks like one so a misconfigured inline literal can't leak.
+    const tok = linear.token;
+    const tokenVaultKey =
+      typeof tok === "string" && tok.startsWith("vault:") ? tok : null;
+    agents.push({
+      agent: name,
+      workspaceId: linear.workspace_id ?? null,
+      defaultTeamId: linear.default_team_id ?? null,
+      tokenVaultKey,
+    });
+  }
+  agents.sort((a, b) => a.agent.localeCompare(b.agent));
+  return { configured: agents.length > 0, agents };
+}
+
 export type ConnectionAccessStatus =
   | { state: "pending"; startedAt: number }
   | { state: "applied"; startedAt: number; restartAgent: string }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -41,6 +41,7 @@ import {
   handleStartMicrosoftConnect,
   handleGetMicrosoftConnectStatus,
   handleGetNotionWorkspace,
+  handleGetLinearAgents,
   handleGetSchedule,
   handleGetApprovals,
   handleGetGrants,
@@ -560,6 +561,11 @@ function parseRoute(
     return { handler: "getNotionWorkspace", params: {} };
   }
 
+  // GET /api/linear-agents
+  if (method === "GET" && pathname === "/api/linear-agents") {
+    return { handler: "getLinearAgents", params: {} };
+  }
+
   // GET /api/schedule
   if (method === "GET" && pathname === "/api/schedule") {
     return { handler: "getSchedule", params: {} };
@@ -904,6 +910,9 @@ export function startWebServer(
 
           case "getNotionWorkspace":
             return jsonResponse(handleGetNotionWorkspace(freshConfig()));
+
+          case "getLinearAgents":
+            return jsonResponse(handleGetLinearAgents(freshConfig()));
 
           case "getSchedule":
             return (async () =>

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -1036,20 +1036,21 @@
         .then(r => r.ok ? r.json().then(d => ({ ok: true, data: d })) : { ok: false, data: fallback })
         .catch(() => ({ ok: false, data: fallback }));
       try {
-        const [g, ms, n, ag] = await Promise.all([
+        const [g, ms, n, li, ag] = await Promise.all([
           safe(fetch(`${API}/api/google-accounts`, { headers: authHeaders() }), []),
           safe(fetch(`${API}/api/microsoft-accounts`, { headers: authHeaders() }), []),
           safe(fetch(`${API}/api/notion-workspace`, { headers: authHeaders() }), { configured: false, databases: [] }),
+          safe(fetch(`${API}/api/linear-agents`, { headers: authHeaders() }), { configured: false, agents: [] }),
           safe(fetch(`${API}/api/agents`, { headers: authHeaders() }), []),
         ]);
-        // Notion legitimately reports unconfigured — not a failure. The OAuth
-        // providers + the agent list are the ones whose failure must not read
-        // as "empty".
+        // Notion + Linear legitimately report unconfigured — not a failure. The
+        // OAuth providers + the agent list are the ones whose failure must not
+        // read as "empty".
         const fetchFailed = !g.ok || !ms.ok || !ag.ok;
         renderConnections({
-          google: g.data, microsoft: ms.data, notion: n.data,
+          google: g.data, microsoft: ms.data, notion: n.data, linear: li.data,
           agentNames: (ag.data || []).map(a => a.name).sort(),
-          googleFailed: !g.ok, microsoftFailed: !ms.ok, fetchFailed,
+          googleFailed: !g.ok, microsoftFailed: !ms.ok, linearFailed: !li.ok, fetchFailed,
         });
         clearError();
         // Self-heal a transient blip without a manual re-click. Bounded
@@ -2150,6 +2151,7 @@
       const google = data.google || [];
       const microsoft = data.microsoft || [];
       const notion = data.notion || { configured: false, databases: [] };
+      const linear = data.linear || { configured: false, agents: [] };
       const agentNames = data.agentNames || [];
 
       // When a provider's fetch FAILED (not genuinely empty), its empty-state
@@ -2213,6 +2215,37 @@
           ${fullAccessBanner}${notionBody}
         </div>`;
 
+      // Linear — first-class OAuth app actors (config-only; the web tier never
+      // reads the per-agent vault, so no token/expiry is shown — and never the
+      // secret). One card per agent with linear_agent.enabled.
+      const linearCards = (linear.agents || []).map(a => {
+        const meta = [];
+        if (a.workspaceId) meta.push(`<div class="meta-item"><label>Workspace </label><span>${escapeHtml(a.workspaceId)}</span></div>`);
+        if (a.defaultTeamId) meta.push(`<div class="meta-item"><label>Default team </label><span>${escapeHtml(a.defaultTeamId)}</span></div>`);
+        if (a.tokenVaultKey) meta.push(`<div class="meta-item"><label>Token </label><span><code>${escapeHtml(a.tokenVaultKey)}</code></span></div>`);
+        return `
+        <div class="account-card">
+          <div class="account-card-header">
+            <div class="account-label">${escapeHtml(a.agent)}</div>
+            <span style="margin-left:auto" class="usage-pill primary">OAuth agent</span>
+          </div>
+          <div class="card-meta" style="padding:0">${meta.join('') || _dimC('—')}</div>
+        </div>`;
+      }).join('');
+      const linearNote = (linear.agents && linear.agents.length)
+        ? `<div style="margin:0 0 .6rem;font-size:.85rem;color:var(--text-dim)">Connected as Linear <b>OAuth app actors</b> — each appears in the workspace as its own actor (not a personal API token for MCP).</div>`
+        : '';
+      const linearBody = linearCards
+        ? `<div class="accounts-grid">${linearCards}</div>`
+        : `<div class="loading" style="padding:.8rem">${data.linearFailed
+            ? "Couldn't load Linear agents — the data source was unreachable (retrying)."
+            : 'No Linear agents connected. Run <code>switchroom linear-agent setup --agent &lt;name&gt;</code> to connect one as a Linear OAuth app actor.'}</div>`;
+      const linearSection = `
+        <div style="margin-bottom:1.5rem">
+          <h3 style="margin:0 0 .6rem;font-size:.95rem;color:var(--text-dim);text-transform:uppercase;letter-spacing:.04em">Linear</h3>
+          ${linearNote}${linearBody}
+        </div>`;
+
       // Tab-level degraded banner: when every OAuth account (Google +
       // Microsoft) is config-only (no live broker slot) and there's at least
       // one, the broker data is unavailable — surface that ABOVE the sections
@@ -2230,7 +2263,7 @@
         ? renderProblem(problemFor('connections-unreachable', {}))
         : '';
 
-      container.innerHTML = unreachableBanner + degradedBanner + googleSection + microsoftSection + notionSection;
+      container.innerHTML = unreachableBanner + degradedBanner + googleSection + microsoftSection + notionSection + linearSection;
     }
 
     function renderSchedule(data) {

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -102,6 +102,7 @@ import {
   handleGetGoogleAccounts,
   handleGetMicrosoftAccounts,
   handleGetNotionWorkspace,
+  handleGetLinearAgents,
   handleGetSchedule,
   handleGetAccounts,
   handleUseAccount,
@@ -947,6 +948,97 @@ describe("handleGetNotionWorkspace", () => {
       "databases",
       "fullAccessAgents",
       "vaultKey",
+    ]);
+  });
+});
+
+describe("handleGetLinearAgents", () => {
+  // linear_agent lives under channels.telegram and is cascade-resolved, so the
+  // test configs set it directly on the agent (no profile needed).
+  const withLinear = (
+    agents: Record<string, unknown>,
+  ): SwitchroomConfig =>
+    ({ ...mockConfig, agents } as unknown as SwitchroomConfig);
+
+  it("reports not-configured when no agent has linear_agent enabled", () => {
+    const out = handleGetLinearAgents(
+      withLinear({ alpha: {}, beta: { channels: { telegram: {} } } }),
+    );
+    expect(out.configured).toBe(false);
+    expect(out.agents).toEqual([]);
+  });
+
+  it("lists only agents with linear_agent.enabled, sorted, with workspace/team", () => {
+    const out = handleGetLinearAgents(
+      withLinear({
+        ziggy: {
+          channels: {
+            telegram: {
+              linear_agent: {
+                enabled: true,
+                token: "vault:linear/ziggy/token",
+                workspace_id: "ws-zzz",
+                default_team_id: "team-zzz",
+              },
+            },
+          },
+        },
+        carrie: {
+          channels: {
+            telegram: {
+              linear_agent: { enabled: true, token: "vault:linear/carrie/token" },
+            },
+          },
+        },
+        // enabled:false → excluded
+        finn: {
+          channels: {
+            telegram: {
+              linear_agent: { enabled: false, token: "vault:linear/finn/token" },
+            },
+          },
+        },
+        // no linear_agent → excluded
+        klanker: {},
+      }),
+    );
+    expect(out.configured).toBe(true);
+    expect(out.agents.map((a) => a.agent)).toEqual(["carrie", "ziggy"]);
+    const ziggy = out.agents.find((a) => a.agent === "ziggy")!;
+    expect(ziggy.workspaceId).toBe("ws-zzz");
+    expect(ziggy.defaultTeamId).toBe("team-zzz");
+    expect(ziggy.tokenVaultKey).toBe("vault:linear/ziggy/token");
+    const carrie = out.agents.find((a) => a.agent === "carrie")!;
+    expect(carrie.workspaceId).toBeNull();
+    expect(carrie.defaultTeamId).toBeNull();
+  });
+
+  it("never leaks a token value — only a vault: reference, and masks an inline literal", () => {
+    const out = handleGetLinearAgents(
+      withLinear({
+        // A schema violation (inline literal, not a vault: ref) must NOT be
+        // surfaced — tokenVaultKey is nulled rather than leaking the secret.
+        rogue: {
+          channels: {
+            telegram: {
+              linear_agent: {
+                enabled: true,
+                token: "lin_" + "api_" + "REALSECRET",
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(out.agents[0].tokenVaultKey).toBeNull();
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("REALSECRET");
+    // Only metadata fields exist on each agent entry — no raw token field.
+    expect(Object.keys(out.agents[0]).sort()).toEqual([
+      "agent",
+      "defaultTeamId",
+      "tokenVaultKey",
+      "workspaceId",
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Adds a **LINEAR** section to the dashboard Connections tab, surfacing which agents are connected to Linear as first-class **OAuth app actors** (`channels.telegram.linear_agent.enabled`) — with workspace id, default team id, and the token's vault-key reference.

The operator asked specifically to see agents "connected as a Linear agent with OAuth, not just a personal API token for MCP." Relevant fact: switchroom's Linear integration has **exactly one mode** — the OAuth app actor (#2298); there is no personal-API-token path. So an `enabled` agent *is* connected as a Linear OAuth agent, and the section labels it as such.

## Design — config-only, secret-safe (mirrors Notion)

The web container is the one internet-facing component and deliberately can't read per-agent vault state (the same isolation behind the `EACCES` overlay-loader log lines). So this handler is **config-only**:

- Reads cascade-resolved `channels.telegram.linear_agent` per agent.
- Returns only metadata + the token's **vault-key reference** (`vault:linear/<agent>/token`), never the token.
- A misconfigured *inline* token literal is masked (`tokenVaultKey: null`), not leaked.
- Live token freshness stays with the in-agent gateway's proactive `linear-auth-watch` (which already alerts the operator on Telegram). Surfacing it here would require the web tier to read per-agent vault secrets — out of scope by the minimal-surface design.

## What changed

- `handleGetLinearAgents(config)` + `LinearAgentsDashboard`/`LinearAgentInfo` types (`src/web/api.ts`)
- `GET /api/linear-agents` route + dispatch (`src/web/server.ts`)
- `fetchConnections` fetches `/api/linear-agents`; `renderConnections` renders a LINEAR section — one card per agent (OAuth-agent pill, workspace/team/token-ref), with a note clarifying these are OAuth app actors, not personal API tokens. Empty + failed states mirror the other providers.
- Tests (`tests/web.test.ts`)

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/web.test.ts` — 135 passed (3 new): not-configured; enabled-only + sorted + workspace/team; **never leaks a token** (vault: ref only; inline literal masked; no raw token field)
- [x] Live config check: `clerk` + `carrie` have `linear_agent.enabled` → section will show them after deploy
- [x] Renders inside the now-fixed `.accounts-grid` (depends on #2409, already merged)

## Risk

Low. Additive, read-only, config-only; no vault/secret access; no change to existing endpoints. The new fetch is independent (a Linear failure doesn't blank the other providers — same treatment as Notion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)