### PR TITLE
fix(gateway): don't repeat the same approval card after a TTL timeout

### DIFF
--- a/telegram-plugin/bridge/bridge.ts
+++ b/telegram-plugin/bridge/bridge.ts
@@ -691,6 +691,12 @@ function onPermission(msg: PermissionEvent): void {
     params: {
       request_id: msg.requestId,
       behavior: msg.behavior,
+      // `message` (deny only) is rendered by claude's channel as
+      // "…the user said: ${message}". We use it to tell the model a deny was
+      // a TIMEOUT, not a human denial — so it doesn't retry the identical
+      // call and re-raise a duplicate card. Omitted → claude's default
+      // "Denied" (safe degradation).
+      ...(msg.message ? { message: msg.message } : {}),
     },
   }).catch((err) => {
     process.stderr.write(`telegram bridge: failed to deliver permission to Claude: ${err}\n`)

--- a/telegram-plugin/bridge/ipc-client.ts
+++ b/telegram-plugin/bridge/ipc-client.ts
@@ -26,7 +26,10 @@ export function validateGatewayMessage(msg: unknown): msg is GatewayToClient {
         && (m.behavior === "allow" || m.behavior === "deny")
         // `rule` is optional (only sent on "🔁 Always allow"); when present
         // it must be a non-empty string. #1138 wire extension.
-        && (m.rule === undefined || (typeof m.rule === "string" && m.rule.length > 0));
+        && (m.rule === undefined || (typeof m.rule === "string" && m.rule.length > 0))
+        // `message` is optional (deny only — the timeout-vs-denial reason);
+        // when present it must be a non-empty string.
+        && (m.message === undefined || (typeof m.message === "string" && m.message.length > 0));
     case "status":
       return typeof m.status === "string";
     case "tool_call_result":

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -67,6 +67,12 @@ import { DeferredDoneReactions } from '../reaction-defer.js'
 import { createWorkerActivityFeed, isWorkerActivityFeedEnabled } from '../worker-activity-feed.js'
 import { formatTurnLifecycle, detectStatusSurfaceDegraded } from './status-surface-log.js'
 import { parseSourceMessageId } from './source-message-id.js'
+import {
+  permissionSignature,
+  timeoutDenyMessage,
+  duplicateDenyMessage,
+  isRecentTimeoutDuplicate,
+} from './permission-timeout.js'
 import { pickRecoveredPermissionOrigin } from './permission-card-origin.js'
 import { isTelegramReplyTool, isTelegramSurfaceTool } from '../tool-names.js'
 import { appendActivityLabel, renderActivityFeedWithNested } from '../tool-activity-summary.js'
@@ -3723,6 +3729,28 @@ const STATUS_QUERY_RE = /^\s*status\??\s*$/i
 const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
 const pendingPermissions = new Map<string, { tool_name: string; description: string; input_preview: string; startedAt: number }>()
 const PERMISSION_TTL_MS = 10 * 60_000
+// No-repeat-on-timeout (marko Rentals-budget loop, 2026-06-17). When a card
+// auto-denies on TTL, the model is told it was a TIMEOUT (not a denial) so it
+// doesn't retry; if it retries the identical (tool, input) anyway while the
+// operator is still absent, we short-circuit-deny it WITHOUT posting a second
+// card. `permissionTimeoutSignatures` maps signature → last-timeout epoch ms;
+// it is cleared the moment the operator is active again (answers any card, or
+// sends a message), so suppression only ever holds during genuine absence.
+// Kill switch: SWITCHROOM_PERMISSION_NO_REPEAT=0.
+const PERMISSION_NO_REPEAT_ENABLED =
+  process.env.SWITCHROOM_PERMISSION_NO_REPEAT !== '0'
+// Safety cap on how long a timed-out signature suppresses retries even if the
+// operator-activity reset is somehow missed; the reset is the primary bound.
+const PERMISSION_DUPLICATE_WINDOW_MS = 60 * 60_000
+const permissionTimeoutSignatures = new Map<string, number>()
+function clearPermissionTimeoutSuppression(reason: string): void {
+  if (permissionTimeoutSignatures.size === 0) return
+  const n = permissionTimeoutSignatures.size
+  permissionTimeoutSignatures.clear()
+  process.stderr.write(
+    `telegram gateway: permission no-repeat suppression cleared (${n} sig(s)) — ${reason}\n`,
+  )
+}
 // Permission/approval-card origin recovery (marko Rentals-budget, 2026-06-17).
 // When `currentTurn` was force-closed by the orphaned-reply backstop but the
 // claude session kept running into a permission-gated tool, recover the card's
@@ -4340,22 +4368,45 @@ const pendingStateReaper = setInterval(() => {
       // permission (or takes a fallback). Routed through
       // dispatchPermissionVerdict so it's buffered+redelivered too if
       // the bridge is also offline at sweep time.
-      dispatchPermissionVerdict({ type: 'permission', requestId: k, behavior: 'deny' })
+      // Carry a TIMEOUT reason to the model (claude renders it as "…the user
+      // said: …") so it can tell a timeout from a real denial and not retry
+      // the identical call — the duplicate-card loop this series closes.
+      const timeoutMinutes = Math.round(PERMISSION_TTL_MS / 60000)
+      dispatchPermissionVerdict({
+        type: 'permission',
+        requestId: k,
+        behavior: 'deny',
+        message: timeoutDenyMessage(timeoutMinutes),
+      })
       // The auto-deny un-parks the suspended turn — flip 🙏 → working so
       // it doesn't sit on the awaiting glyph (or stall) after the timeout.
       resumeReactionAfterVerdict()
       postPermissionResumeMessage({
         behavior: 'deny',
         action: naturalAction(v.tool_name, v.input_preview),
-        timeoutMinutes: Math.round(PERMISSION_TTL_MS / 60000),
+        timeoutMinutes,
       })
+      // Remember this (tool, input) timed out so an immediate identical retry
+      // (while the operator is still absent) is short-circuited without a
+      // second card. Cleared on operator activity.
+      if (PERMISSION_NO_REPEAT_ENABLED) {
+        permissionTimeoutSignatures.set(
+          permissionSignature(v.tool_name, v.input_preview),
+          now,
+        )
+      }
       process.stderr.write(
         `telegram gateway: permission TTL expired — auto-deny request=${k} ` +
         `tool=${v.tool_name} (no operator response in ` +
-        `${Math.round(PERMISSION_TTL_MS / 60000)}m)\n`,
+        `${timeoutMinutes}m)\n`,
       )
       pendingPermissions.delete(k)
     }
+  }
+  // Drop no-repeat suppression entries past the safety-cap window (the primary
+  // bound is the operator-activity reset; this just keeps the map from growing).
+  for (const [sig, at] of permissionTimeoutSignatures) {
+    if (now - at > PERMISSION_DUPLICATE_WINDOW_MS) permissionTimeoutSignatures.delete(sig)
   }
   for (const [k, v] of vaultPassphraseCache) {
     if (now > v.expiresAt) vaultPassphraseCache.delete(k)
@@ -6128,6 +6179,30 @@ const ipcServer: IpcServer = createIpcServer({
         process.stderr.write(
           `telegram gateway: scoped-approval auto-allow tool=${toolName} rule="${hit}" ` +
           `request=${requestId} (time-boxed window)\n`,
+        )
+        return
+      }
+    }
+    // No-repeat short-circuit: this exact (tool, input) already timed out and
+    // the operator hasn't been active since (the suppression map is cleared on
+    // any operator activity). Deny it WITH a timeout-duplicate reason and post
+    // NO second card — the model retrying into an absent operator is the loop
+    // this closes. The turn still unblocks (deny verdict), and a returning
+    // operator resets suppression so the next ask gets a fresh card.
+    if (PERMISSION_NO_REPEAT_ENABLED) {
+      const sig = permissionSignature(toolName, inputPreview)
+      if (isRecentTimeoutDuplicate(permissionTimeoutSignatures, sig, Date.now(), PERMISSION_DUPLICATE_WINDOW_MS)) {
+        // no-card-verdict: no card was posted and the turn was never parked on
+        // the awaiting glyph, so we omit the resume-reaction flip / resume msg.
+        dispatchPermissionVerdict({
+          type: 'permission',
+          requestId,
+          behavior: 'deny',
+          message: duplicateDenyMessage,
+        })
+        process.stderr.write(
+          `telegram gateway: permission no-repeat short-circuit — duplicate of a ` +
+          `timed-out request tool=${toolName} request=${requestId} (no card posted)\n`,
         )
         return
       }
@@ -11615,6 +11690,11 @@ async function handleInbound(
     return
   }
 
+  // A real message from an allowed sender (gate passed) ⇒ the operator is
+  // present, so reset any no-repeat suppression: the next time the agent asks
+  // for something that timed out earlier, they should see a fresh card.
+  clearPermissionTimeoutSuppression('operator inbound')
+
   // Capture wall-clock receive time for inbound_ack metric (#203).
   // Must be after gate() so early-exit paths (drop/pair) don't skew the delta.
   //
@@ -15169,6 +15249,8 @@ async function handlePermissionSlash(ctx: Context, behavior: 'allow' | 'deny'): 
     )
     return
   }
+  // Operator answered via slash ⇒ present; reset no-repeat suppression.
+  clearPermissionTimeoutSuppression('operator answered via /approve|/deny')
   // Forward to connected bridges — same IPC the button handler uses.
   dispatchPermissionVerdict({ type: 'permission', requestId: request_id, behavior })
   resumeReactionAfterVerdict()
@@ -19675,6 +19757,9 @@ bot.on('callback_query:data', async ctx => {
   // scopes (resolveTimeBox → null) and the disabled tier (ttl<=0) stay truly
   // once. The verdict is still dispatched WITHOUT a `rule` (below), so the
   // bridge never caches it untimed — the window lives only in scopedGrants.
+  // Operator tapped a verdict ⇒ they are present; reset no-repeat suppression
+  // so a later identical ask is shown fresh rather than silently short-circuited.
+  clearPermissionTimeoutSuppression('operator answered a permission card')
   const pd = pendingPermissions.get(request_id)
   const resumeAction = pd ? naturalAction(pd.tool_name, pd.input_preview) : ''
   const scopedTtl = scopedApprovalTtlMs()
@@ -20954,6 +21039,7 @@ async function shutdown(signal: string): Promise<void> {
   pendingReauthFlows.clear()
   pendingVaultOps.clear()
   pendingPermissions.clear()
+  permissionTimeoutSignatures.clear()
 
   try {
     await ipcServer.close()

--- a/telegram-plugin/gateway/ipc-protocol.ts
+++ b/telegram-plugin/gateway/ipc-protocol.ts
@@ -38,6 +38,18 @@ export interface PermissionEvent {
    * (`mcp__<server>__*`).
    */
   rule?: string;
+  /**
+   * Optional human-readable reason for the verdict, surfaced to the model
+   * verbatim by claude's permission channel as "…the user said: ${message}".
+   * Only set on `deny`. switchroom uses it to make a TIMEOUT auto-deny (no
+   * operator response within the TTL) distinguishable from a deliberate
+   * operator denial — otherwise both render as the generic "Denied" and the
+   * model retries the identical call, re-raising an identical card 10 min
+   * later (marko Rentals-budget loop, 2026-06-17). When absent, claude falls
+   * back to its default "Denied", so this degrades safely on any claude that
+   * ignores the field.
+   */
+  message?: string;
 }
 
 export interface StatusEvent {

--- a/telegram-plugin/gateway/permission-timeout.ts
+++ b/telegram-plugin/gateway/permission-timeout.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure helpers for permission-card TIMEOUT handling — making a "no operator
+ * responded" auto-deny distinguishable from a deliberate denial, and
+ * suppressing the duplicate card a model raises when it retries the identical
+ * call after such a timeout.
+ *
+ * Background (marko Rentals-budget loop, 2026-06-17). switchroom forwards a
+ * permission verdict to claude as `{ behavior, message? }`; with no `message`,
+ * claude renders the generic "the user said: Denied". A 10-minute TTL
+ * auto-deny was therefore indistinguishable from a real operator "Deny", so
+ * the model read it as transient and retried the SAME tool call — re-raising
+ * an identical card 10 minutes later, in a loop the operator never asked for.
+ *
+ * Two levers, both pure here and wired in gateway.ts:
+ *  1. `timeoutDenyMessage` — the `message` we attach ONLY to a TTL auto-deny,
+ *     telling the model it was a timeout (not a denial) and not to retry.
+ *  2. `permissionSignature` + `isRecentTimeoutDuplicate` — recognise a retry of
+ *     the exact same (tool, input) shortly after it timed out, so the gateway
+ *     can short-circuit it (deny with `duplicateDenyMessage`) WITHOUT posting a
+ *     second identical card. The suppression is reset on operator activity
+ *     (handled gateway-side), so it only ever holds while the operator is
+ *     genuinely absent — re-showing a card to an absent operator is the noise
+ *     this removes.
+ */
+
+// NUL — can appear in neither a tool name nor a rendered input preview, so it
+// safely delimits the two halves of a signature (a printable separator could
+// collide: ("a b","c") vs ("a","b c")). Built at runtime so the SOURCE file
+// stays plain text (a literal NUL byte would make git treat it as binary).
+const SIGNATURE_SEP = String.fromCharCode(0)
+
+/**
+ * Stable identity for a permission request: the tool plus its input preview
+ * (the same string the card renders). Same tool + same preview ⇒ same action.
+ */
+export function permissionSignature(toolName: string, inputPreview: string): string {
+  return toolName + SIGNATURE_SEP + inputPreview
+}
+
+/** The `message` attached to a TTL auto-deny so the model treats it as a
+ *  timeout, not a denial, and does not retry the identical call. */
+export function timeoutDenyMessage(timeoutMinutes: number): string {
+  return (
+    `No operator responded within ${timeoutMinutes} minutes, so this request timed out. ` +
+    `This is a TIMEOUT, not a denial — the operator is likely away. ` +
+    `Do NOT retry this exact action automatically. Tell the user it is still ` +
+    `awaiting their approval, then continue with other work or stop.`
+  )
+}
+
+/** The `message` attached when we short-circuit a duplicate retry of an
+ *  already-timed-out request (no new card posted). */
+export const duplicateDenyMessage =
+  `This exact action already timed out awaiting the operator, and they have not ` +
+  `responded since. Do NOT keep re-requesting it — tell the user it needs their ` +
+  `approval when they are back, and move on to other work or stop.`
+
+/**
+ * True when `sig` timed out within `windowMs` of `now` (so a fresh request for
+ * it is a retry to suppress). `timeouts` maps signature → last-timeout epoch ms.
+ */
+export function isRecentTimeoutDuplicate(
+  timeouts: ReadonlyMap<string, number>,
+  sig: string,
+  now: number,
+  windowMs: number,
+): boolean {
+  const at = timeouts.get(sig)
+  return at != null && now - at <= windowMs
+}

--- a/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
+++ b/telegram-plugin/tests/permission-no-repeat-wiring.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Source-text pins for the no-repeat-on-timeout wiring (marko Rentals-budget
+ * loop, 2026-06-17). gateway.ts / bridge.ts have top-level side effects and
+ * aren't unit-importable; the decision logic is unit-tested in
+ * permission-timeout.test.ts. These pins lock the wiring so it can't silently
+ * regress.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const read = (p: string) => readFileSync(resolve(__dirname, '..', p), 'utf8')
+const GATEWAY = read('gateway/gateway.ts')
+const BRIDGE = read('bridge/bridge.ts')
+const IPC_PROTOCOL = read('gateway/ipc-protocol.ts')
+const IPC_CLIENT = read('bridge/ipc-client.ts')
+
+function slice(src: string, fnHeader: string, span = 1600): string {
+  const start = src.indexOf(fnHeader)
+  expect(start, `expected to find ${fnHeader}`).toBeGreaterThan(-1)
+  return src.slice(start, start + span)
+}
+
+describe('no-repeat-on-timeout wiring', () => {
+  it('PermissionEvent carries an optional message field', () => {
+    const evt = slice(IPC_PROTOCOL, 'export interface PermissionEvent', 2400)
+    expect(evt).toMatch(/message\?:\s*string/)
+  })
+
+  it('the bridge IPC validator accepts an optional non-empty message', () => {
+    expect(IPC_CLIENT).toMatch(/m\.message === undefined/)
+  })
+
+  it('the bridge forwards message on the permission channel notification', () => {
+    const fn = slice(BRIDGE, 'function onPermission(', 1600)
+    expect(fn).toContain('notifications/claude/channel/permission')
+    expect(fn).toMatch(/msg\.message/)
+  })
+
+  it('the TTL auto-deny attaches a timeout message and records the signature', () => {
+    // Within the pending-permission sweep block.
+    const sweep = slice(GATEWAY, 'for (const [k, v] of pendingPermissions)', 2200)
+    expect(sweep).toContain('timeoutDenyMessage(')
+    expect(sweep).toContain('permissionTimeoutSignatures.set(')
+  })
+
+  it('onPermissionRequest short-circuits a recent-timeout duplicate before posting a card', () => {
+    const fn = slice(GATEWAY, 'onPermissionRequest(', 4000)
+    const dupIdx = fn.indexOf('isRecentTimeoutDuplicate(')
+    const cardIdx = fn.indexOf('pendingPermissions.set(requestId')
+    expect(dupIdx).toBeGreaterThan(-1)
+    expect(cardIdx).toBeGreaterThan(-1)
+    // The duplicate check must run BEFORE the card is registered/posted.
+    expect(dupIdx).toBeLessThan(cardIdx)
+    expect(fn).toContain('duplicateDenyMessage')
+  })
+
+  it('suppression is reset on operator activity (inbound + card verdict + slash)', () => {
+    // Three distinct reset points so a returning operator always gets a fresh card.
+    const resets = GATEWAY.match(/clearPermissionTimeoutSuppression\(/g) ?? []
+    // 1 definition call inside the helper + at least 3 reset callsites.
+    expect(resets.length).toBeGreaterThanOrEqual(3)
+    expect(GATEWAY).toContain("clearPermissionTimeoutSuppression('operator inbound')")
+  })
+
+  it('has a kill switch', () => {
+    expect(GATEWAY).toContain('SWITCHROOM_PERMISSION_NO_REPEAT')
+  })
+
+  it('sweeps stale suppression entries past the safety-cap window', () => {
+    expect(GATEWAY).toMatch(/permissionTimeoutSignatures\.delete\(sig\)/)
+  })
+})

--- a/telegram-plugin/tests/permission-timeout.test.ts
+++ b/telegram-plugin/tests/permission-timeout.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the pure permission-timeout helpers (no-repeat-on-timeout).
+ *
+ * Pins the behaviour that closes the marko Rentals-budget retry loop
+ * (2026-06-17): a TTL auto-deny must be distinguishable from a real denial,
+ * and an identical retry shortly after a timeout (operator still absent) must
+ * be recognisable so the gateway can suppress the duplicate card.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  permissionSignature,
+  timeoutDenyMessage,
+  duplicateDenyMessage,
+  isRecentTimeoutDuplicate,
+} from '../gateway/permission-timeout.js'
+
+describe('permissionSignature', () => {
+  it('is stable for the same tool + input', () => {
+    expect(permissionSignature('mcp__meta_ads__set_budget', '{"id":"1","budget":1400}'))
+      .toBe(permissionSignature('mcp__meta_ads__set_budget', '{"id":"1","budget":1400}'))
+  })
+
+  it('differs when the tool differs', () => {
+    expect(permissionSignature('toolA', 'x')).not.toBe(permissionSignature('toolB', 'x'))
+  })
+
+  it('differs when the input differs', () => {
+    expect(permissionSignature('t', 'Rentals $14')).not.toBe(permissionSignature('t', 'Land $60'))
+  })
+
+  it('does not collide across the tool/input boundary (NUL-separated)', () => {
+    // A space separator would make ("a b","c") and ("a","b c") collide.
+    expect(permissionSignature('a b', 'c')).not.toBe(permissionSignature('a', 'b c'))
+  })
+})
+
+describe('timeoutDenyMessage', () => {
+  it('names the timeout, the minutes, and tells the model not to retry', () => {
+    const msg = timeoutDenyMessage(10)
+    expect(msg).toContain('10 minutes')
+    expect(msg).toMatch(/timeout/i)
+    expect(msg).toMatch(/not a denial/i)
+    expect(msg).toMatch(/do not retry/i)
+  })
+
+  it('is a non-empty string (wire-validator requires non-empty)', () => {
+    expect(timeoutDenyMessage(5).length).toBeGreaterThan(0)
+  })
+})
+
+describe('duplicateDenyMessage', () => {
+  it('tells the model to stop re-requesting and is non-empty', () => {
+    expect(duplicateDenyMessage).toMatch(/do not keep re-requesting/i)
+    expect(duplicateDenyMessage.length).toBeGreaterThan(0)
+  })
+})
+
+describe('isRecentTimeoutDuplicate', () => {
+  const WINDOW = 60 * 60_000
+  const NOW = 1_000_000_000_000
+
+  it('false when the signature was never recorded', () => {
+    expect(isRecentTimeoutDuplicate(new Map(), 'sig', NOW, WINDOW)).toBe(false)
+  })
+
+  it('true when the signature timed out within the window', () => {
+    const m = new Map([['sig', NOW - 5 * 60_000]])
+    expect(isRecentTimeoutDuplicate(m, 'sig', NOW, WINDOW)).toBe(true)
+  })
+
+  it('false when the timeout is older than the window', () => {
+    const m = new Map([['sig', NOW - 2 * WINDOW]])
+    expect(isRecentTimeoutDuplicate(m, 'sig', NOW, WINDOW)).toBe(false)
+  })
+
+  it('true exactly at the window boundary', () => {
+    const m = new Map([['sig', NOW - WINDOW]])
+    expect(isRecentTimeoutDuplicate(m, 'sig', NOW, WINDOW)).toBe(true)
+  })
+
+  it('only matches the exact signature', () => {
+    const m = new Map([[permissionSignature('t', 'Rentals'), NOW]])
+    expect(isRecentTimeoutDuplicate(m, permissionSignature('t', 'Land'), NOW, WINDOW)).toBe(false)
+    expect(isRecentTimeoutDuplicate(m, permissionSignature('t', 'Rentals'), NOW, WINDOW)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

A timed-out approval card was being **re-raised identically** in a loop. When a card auto-denies on the 10-minute TTL, the bridge sent claude only `{ behavior: 'deny' }` — and with no `message`, claude renders the generic *"the user said: Denied"*. So a **timeout is indistinguishable from a deliberate denial**: the model reads it as transient and retries the identical tool call, producing an identical card 10 min later.

Real case — **marko, 2026-06-17**: two identical `meta_ads_set_budget` cards (Rentals → $14/day), both TTL-denied, while the operator (Lisa) was simply away from her DM. The model thought it had been *declined twice*.

## Fix (two parts, gateway/bridge-side — no model callsite, stays claude-native)

1. **Timeout-aware deny message.** Thread an optional `message` through `PermissionEvent` → bridge → claude's permission channel (I verified in the CLI binary that the channel renders `{behavior:'deny', message}` as *"…the user said: ${message}"*). Set **only** on the TTL auto-deny — it tells the model this was a *timeout, not a denial*, and not to retry. Absent → claude's default "Denied", so it degrades safely on any claude that ignores the field.

2. **Duplicate-card suppression.** Remember the `(tool, input)` signature of a timed-out request; if the model retries the exact same one **while the operator is still absent**, short-circuit-deny it and post **no** second card. The suppression map is cleared the instant the operator is active again — answers any card (tap or `/approve`·`/deny`) or sends a message — so it only ever holds during genuine absence; a returning operator always gets a fresh card. Bounded by a 60-min safety cap and swept.

Kill switch: `SWITCHROOM_PERMISSION_NO_REPEAT=0`.

## Why / job

Serves **on-leash** (controlled, purposeful approvals): a timeout shouldn't masquerade as a denial, and the operator shouldn't be spammed with identical cards while away.

## Test plan

- [x] Pure helper `permission-timeout.ts` (signature, timeout/duplicate messages, recent-timeout predicate) — 12 unit tests incl. NUL-separator non-collision and window boundary.
- [x] Wiring pins (`permission-no-repeat-wiring.test.ts`): `message` plumbed end-to-end (protocol field + validator + bridge forward), dup-check precedes card post, resets on all 3 operator-activity paths, kill switch present, stale-entry sweep.
- [x] Resume-guard pin still green (the short-circuit deny carries the `no-card-verdict` sentinel; the TTL deny stays paired with `resumeReactionAfterVerdict`).
- [x] `tsc --noEmit` + full lint chain (plugin-refs, bot-api-wrapping, bun-test-imports, no-pii, no-broadcast-delivery) clean.
- [x] Full telegram-plugin suite under **both** runners: bun (4503 pass) + vitest (3838 pass), 0 fail.

## Risk

Low–moderate (touches the approval path). The deny message is additive and degrades safely. The suppression is conservative: it only ever *adds* a short-circuit for an exact-signature retry during operator absence, resets on any operator activity, is capped at 60 min, and is fully behind a kill switch. No `allow` is ever suppressed.

## Follow-up

PR 2 (next) covers batching multiple approvals: coalescing concurrent permission cards + a persona nudge to surface foreseeable approvals together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)