### PR TITLE
fix(hindsight): durable consolidation across worker restarts

### DIFF
--- a/docker/hindsight-entrypoint.sh
+++ b/docker/hindsight-entrypoint.sh
@@ -38,6 +38,31 @@
 #   SWITCHROOM_HINDSIGHT_REFRESH_S  refresh-loop interval in seconds
 #                                   default 1800 (30 min)
 #                                   set to 0 to disable the loop (test only)
+#   SWITCHROOM_HINDSIGHT_WORKER_ID  stable hindsight worker identity
+#                                   default switchroom-hindsight
+#   SWITCHROOM_HINDSIGHT_REAP_STALE_S  lease-timeout reaper threshold in
+#                                   seconds. Stuck 'processing' async ops
+#                                   whose claim is older than this are
+#                                   reset to 'pending' on each loop tick.
+#                                   default 1800 (30 min); 0 disables.
+#
+# Durable consolidation across restarts (incident 2026-06-18):
+#   Hindsight's worker derives its id from the container hostname (the
+#   ephemeral docker id, NEW on every `compose` recreate). Its only
+#   crash-recovery — recover_own_tasks(), which at startup resets stuck
+#   'processing' async_operations WHERE worker_id = <own id> — can
+#   therefore never reclaim a PRIOR incarnation's in-flight tasks: a
+#   worker that dies mid-consolidation strands those ops forever (4 agent
+#   banks went 26 days with zero new observations). We fix this at the
+#   "how switchroom runs hindsight" layer, two ways:
+#     A. Pin HINDSIGHT_API_WORKER_ID to a stable value so every restart
+#        runs recover_own_tasks() against its predecessor's id and
+#        reclaims the stranded ops via hindsight's own tested path. Safe
+#        because hindsight is single-worker (DEFAULT_WORKERS=1).
+#     B. A lease-timeout reaper on the background loop catches the
+#        no-restart wedge (worker hangs but the container never bounces,
+#        so [A]'s startup recovery never fires) — it resets any
+#        'processing' op claimed longer ago than the threshold.
 #
 # Fail-loud — every step has an explicit exit. We never boot hindsight
 # with empty/missing credentials; better to crash-loop with a clear
@@ -50,8 +75,52 @@ CRED_FILE="${CRED_DIR}/.credentials.json"
 WAIT_TIMEOUT_S="${SWITCHROOM_HINDSIGHT_WAIT_S:-60}"
 REFRESH_S="${SWITCHROOM_HINDSIGHT_REFRESH_S:-1800}"
 FETCHER="${SWITCHROOM_HINDSIGHT_FETCHER:-/usr/local/lib/switchroom/hindsight-fetch-creds.cjs}"
+REAP_STALE_S="${SWITCHROOM_HINDSIGHT_REAP_STALE_S:-1800}"
+# pg0 instance descriptor (holds the embedded-postgres password); the
+# reaper reads it to connect. Overridable for host tests.
+PG0_INSTANCE="${SWITCHROOM_HINDSIGHT_PG0_INSTANCE:-/home/hindsight/.pg0/instances/hindsight/instance.json}"
 
 log() { echo "switchroom-hindsight-entrypoint: $*" >&2; }
+
+# Stable worker identity (fix A above). `:=` only sets it when the
+# operator/compose hasn't already pinned HINDSIGHT_API_WORKER_ID, so an
+# explicit override still wins. Exported so the upstream worker
+# (worker/main.py reads ENV_WORKER_ID) picks it up.
+: "${HINDSIGHT_API_WORKER_ID:=${SWITCHROOM_HINDSIGHT_WORKER_ID:-switchroom-hindsight}}"
+export HINDSIGHT_API_WORKER_ID
+
+# Lease-timeout reaper (fix B above). Resets async_operations stuck in
+# 'processing' past the threshold back to 'pending' so the live worker
+# re-claims them — mirroring upstream recover_own_tasks() but keyed on
+# claim age instead of the (ephemeral) worker_id. Best-effort: any
+# failure (pg not up yet, missing instance file, psql absent) is
+# swallowed so it can never wedge the loop or the container. No-ops
+# cleanly on hosts without the embedded pg (e.g. unit tests).
+#   - threshold (REAP_STALE_S, default 30 min) sits well above the
+#     consolidation LLM timeout + the 600s DB statement_timeout, so it
+#     only ever fires on genuinely-dead claims, never a long-but-live one.
+#   - the batch_id guard mirrors upstream: batch-API ops have their own
+#     recovery path (_recover_batch_operations) and must not be reset here.
+reap_stale_processing() {
+  [ "${REAP_STALE_S}" -gt 0 ] || return 0
+  [ -r "${PG0_INSTANCE}" ] || return 0
+  _psql="$(command -v psql 2>/dev/null || ls /home/hindsight/.pg0/installation/*/bin/psql 2>/dev/null | head -1)"
+  [ -n "${_psql}" ] && [ -x "${_psql}" ] || return 0
+  # Pull connection fields from the pg0 descriptor without a JSON dep in sh.
+  if ! { read -r _pguser; read -r _pgdb; read -r _pgport; read -r _pgpw; } <<EOF
+$(python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));print(d.get("username","hindsight"));print(d.get("database","hindsight"));print(d.get("port",5432));print(d.get("password",""))' "${PG0_INSTANCE}" 2>/dev/null)
+EOF
+  then
+    return 0
+  fi
+  [ -n "${_pgpw}" ] || return 0
+  _n="$(PGPASSWORD="${_pgpw}" "${_psql}" -U "${_pguser}" -h /tmp -p "${_pgport}" -d "${_pgdb}" -tAc \
+    "UPDATE async_operations SET status='pending', worker_id=NULL, claimed_at=NULL, updated_at=now() WHERE status='processing' AND claimed_at < now() - make_interval(secs => ${REAP_STALE_S}) AND result_metadata->>'batch_id' IS NULL RETURNING 1" \
+    2>/dev/null | grep -c 1 || true)"
+  if [ "${_n:-0}" -gt 0 ]; then
+    log "stale-claim reaper reset ${_n} stuck 'processing' op(s) older than ${REAP_STALE_S}s -> pending"
+  fi
+}
 
 # 1. Wait for the broker socket. The broker may still be starting on
 # the host when this container boots (no cross-project depends_on).
@@ -96,6 +165,8 @@ if [ "${REFRESH_S}" -gt 0 ] && [ -f "${FETCHER}" ]; then
       # Best-effort: a transient broker outage shouldn't kill the loop.
       # The next tick retries. Hindsight keeps running on the previous
       # successfully-fetched credentials until the loop catches up.
+      # Same loop drives the stale-claim reaper (fix B) — also best-effort.
+      reap_stale_processing || true
     done
   ) &
   log "credential refresh loop started (interval=${REFRESH_S}s, pid=$!)"

--- a/tests/docker/hindsight-entrypoint.test.ts
+++ b/tests/docker/hindsight-entrypoint.test.ts
@@ -400,6 +400,100 @@ describe("hindsight-entrypoint.sh (#1245)", () => {
     }
   }, 10_000);
 
+  it("pins a stable HINDSIGHT_API_WORKER_ID so restart-recovery reclaims stranded ops", async () => {
+    // Durability fix (incident 2026-06-18): the upstream worker_id
+    // defaults to the container hostname (ephemeral docker id), so a
+    // worker that died mid-consolidation stranded its 'processing' ops
+    // forever — recover_own_tasks() only reclaims WHERE worker_id=<own>.
+    // Pinning a stable id makes every restart reclaim its predecessor's
+    // work. `env` as CMD prints the exported environment.
+    stopBroker = await startFakeBroker(socketPath);
+    const result = await runEntrypoint({ socketPath, credDir, cmd: ["env"] });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/^HINDSIGHT_API_WORKER_ID=switchroom-hindsight$/m);
+  });
+
+  it("lets an operator-provided HINDSIGHT_API_WORKER_ID win (`:=` only fills when unset)", async () => {
+    stopBroker = await startFakeBroker(socketPath);
+    const result = await new Promise<{ status: number | null; stdout: string }>(
+      (res) => {
+        const child = spawn("sh", [ENTRYPOINT, "env"], {
+          env: {
+            ...process.env,
+            SWITCHROOM_AUTH_BROKER_SOCKET: socketPath,
+            SWITCHROOM_HINDSIGHT_CRED_DIR: credDir,
+            SWITCHROOM_HINDSIGHT_WAIT_S: "5",
+            SWITCHROOM_HINDSIGHT_REFRESH_S: "0",
+            SWITCHROOM_HINDSIGHT_FETCHER: FETCHER,
+            HINDSIGHT_API_WORKER_ID: "operator-pinned-id",
+          },
+        });
+        let stdout = "";
+        child.stdout.on("data", (d) => (stdout += d.toString("utf8")));
+        child.on("close", (status) => res({ status, stdout }));
+      },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/^HINDSIGHT_API_WORKER_ID=operator-pinned-id$/m);
+  });
+
+  it("ships a lease-timeout reaper that resets stuck 'processing' ops, correctly guarded", () => {
+    // The reaper is the no-restart-wedge backstop. We can't stand up the
+    // embedded pg in a host unit test, so pin its SQL shape + guards
+    // statically (the dangerous-to-drift parts).
+    const raw = readFileSync(ENTRYPOINT, "utf-8");
+    // Only touches stuck 'processing' rows, never anything else.
+    expect(raw).toMatch(/status='processing'/);
+    // Keyed on claim AGE (lease timeout), not the ephemeral worker_id.
+    expect(raw).toMatch(/claimed_at < now\(\) - make_interval\(secs => \$\{REAP_STALE_S\}\)/);
+    // Mirrors upstream recover_own_tasks(): never reset in-flight batch ops.
+    expect(raw).toMatch(/result_metadata->>'batch_id' IS NULL/);
+    // Gated + best-effort: 0 disables, and it rides the existing loop.
+    expect(raw).toMatch(/REAP_STALE_S.*-gt 0.*\|\| return 0/);
+    expect(raw).toMatch(/reap_stale_processing \|\| true/);
+  });
+
+  it("the reaper no-ops cleanly when the embedded pg descriptor is absent (host/test)", async () => {
+    // With REAP_STALE_S>0 (default) but PG0_INSTANCE pointing nowhere, the
+    // reaper must early-return without erroring under `set -e`. Boot with a
+    // live refresh loop (REFRESH_S=1 → reaper fires each tick) and a
+    // resident CMD; after a couple ticks the marker must exist (entrypoint
+    // reached exec) and stderr must carry the loop-started line with no
+    // psql/python crash leaking through. We don't await 'close' — the
+    // background loop holds the stdio pipes open — we kill after the wait,
+    // mirroring the refresh-loop test above.
+    stopBroker = await startFakeBroker(socketPath);
+    const marker = join(dir, "reaper-safe-child-ran");
+    const child = spawn(
+      "sh",
+      [ENTRYPOINT, "sh", "-c", `touch ${marker}; sleep 5`],
+      {
+        env: {
+          ...process.env,
+          SWITCHROOM_AUTH_BROKER_SOCKET: socketPath,
+          SWITCHROOM_HINDSIGHT_CRED_DIR: credDir,
+          SWITCHROOM_HINDSIGHT_WAIT_S: "5",
+          SWITCHROOM_HINDSIGHT_REFRESH_S: "1",
+          SWITCHROOM_HINDSIGHT_FETCHER: FETCHER,
+          SWITCHROOM_HINDSIGHT_PG0_INSTANCE: join(dir, "does-not-exist.json"),
+        },
+      },
+    );
+    let stderr = "";
+    child.stderr.on("data", (d) => (stderr += d.toString("utf8")));
+    try {
+      await new Promise((r) => setTimeout(r, 2500));
+      expect(existsSync(marker)).toBe(true);
+      expect(stderr).toMatch(/credential refresh loop started/);
+      // The reaper fired (REFRESH_S=1) but found no pg → silent no-op:
+      // no reset log, and crucially no leaked psql/python crash.
+      expect(stderr).not.toMatch(/stale-claim reaper reset/);
+      expect(stderr).not.toMatch(/Traceback|psql:|not found/);
+    } finally {
+      try { child.kill("SIGKILL"); } catch { /* ignore */ }
+    }
+  }, 10_000);
+
   it("Dockerfile pins UID 11000 to match HINDSIGHT_DEFAULT_UID", () => {
     // The broker chowns the per-consumer socket to consumer.uid (mode 0600).
     // If the runtime UID inside hindsight didn't match what the operator


### PR DESCRIPTION
## Summary

Makes hindsight's consolidation/observation pipeline survive worker restarts. Today a worker that dies mid-consolidation strands its in-flight `async_operations` **forever**, silently freezing the observation + mental-model layer for the affected agent banks.

## Why

`worker_id` defaults to the container hostname — the ephemeral docker id, regenerated on every `compose` recreate (`worker/main.py:139`). The only crash-recovery, `recover_own_tasks()` (`worker/poller.py:744`), resets stuck `processing` ops `WHERE worker_id = <own id>` **at startup only** — so it can never reclaim a *prior* incarnation's tasks. One mid-task crash → stranded forever.

**This is not hypothetical.** On the operator host (found 2026-06-18): a worker died mid-consolidation on **2026-05-23**, and 4 agent banks (`assistant`, `klanker`, `finn`, `gymbro`) went **26 days with zero new observations** — head-of-line blocked by 4 orphaned `processing` rows owned by a worker id that never returned (the live worker had 2 idle consolidation slots the whole time). Raw retain kept working; only the bottom-up observation/mental-model synthesis froze. The stuck rows have since been manually reset and those banks are now draining.

## What

Fixed at the "how switchroom runs hindsight" layer (no upstream patch), two complementary ways:

- **A — stable worker identity (root cause).** Pin `HINDSIGHT_API_WORKER_ID` (default `switchroom-hindsight`) in the entrypoint. Every restart now runs `recover_own_tasks()` against its predecessor's id and reclaims stranded ops via hindsight's *own tested path*. Safe because hindsight is single-worker (`DEFAULT_WORKERS=1`). Operator/compose override still wins (`:=`).
- **B — lease-timeout reaper (hardening).** Folded into the existing background refresh loop for the no-restart wedge (worker hangs, container never bounces, so A's startup recovery never fires). Resets any `processing` op claimed longer ago than `SWITCHROOM_HINDSIGHT_REAP_STALE_S` (default 30 min — above the consolidation LLM timeout + 600s DB statement timeout) back to `pending`. Mirrors `recover_own_tasks()` but keyed on claim age, same `batch_id` guard. Best-effort: no-ops cleanly when the embedded pg is absent, can never wedge the loop/container. Gated; `0` disables.

## Test plan

- [x] `vitest run tests/docker/hindsight-entrypoint.test.ts` — 15 pass, incl. new: stable id by default, operator override wins, reaper SQL/guards pinned, reaper no-ops safely with no pg.
- [x] `vitest run tests/docker/dockerfile-hindsight-bakes.test.ts` — 11 pass.
- [x] `tsc --noEmit` clean.
- [x] `sh -n` on the entrypoint + behavioral smoke under `set -eu`.

## Risk

Low. (A) is one env var consumed by hindsight's existing recovery; single-worker so no sibling-collision. (B) is best-effort, conservatively thresholded, and the per-bank in-flight guard (`_other_consolidation_op_in_flight`) prevents same-bank double-runs even if it ever reset a live claim. Takes effect after the hindsight image is rebuilt + the container redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)