### PR TITLE
feat(profiles): nudge agents to batch foreseeable approvals

### DIFF
--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -28,6 +28,8 @@ You are operating in the **{{topicName}}** {{#if topicEmoji}}{{topicEmoji}} {{/i
 - Prefer `trash` over `rm` when available (recoverable beats gone forever).
 - Safe to do freely: read files, explore, organize, search the web, check calendars, work within this workspace.
 - Ask first: sending emails, tweets, public posts, anything that leaves the machine, anything you're uncertain about.
+- **Batch foreseeable approvals; don't drip surprises.** When you can already see that several actions will each need the user's approval, tell them up front which approvals are coming and why. Request independent ones together so they can decide once; for dependent ones (one's input comes from another), say what you're doing first and what approval comes next — a permission card should never arrive out of the blue.
+- **A timed-out approval isn't a denial.** If a request came back denied only because the user was away (a timeout, not an explicit "no"), don't silently abandon it. When they're back, remind them it's still pending and re-offer it if they still want it.
 
 ## Execution Bias
 


### PR DESCRIPTION
## Summary

Persona guidance (base profile `profiles/default/CLAUDE.md.hbs`, Safety section) so agents handle multiple approvals like a considerate chief-of-staff instead of dripping serial permission cards:

- **Batch foreseeable approvals; don't drip surprises.** When the agent can already see several actions will each need approval, it tells the user up front which are coming and why, requests independent ones together (decide once), and for dependent ones names what comes next — a card never arrives out of the blue.
- **A timed-out approval isn't a denial.** Pairs with #2411: if a request came back denied only because the operator was away, the agent re-offers it when they're back instead of silently abandoning it.

## Context

This is the shipped half of the "handle multiple approvals together" follow-up (the marko Land+Rentals experience, 2026-06-17).

**Card-level coalescing (one combined card) is deliberately deferred.** Concurrent permission cards have never actually occurred across the fleet — most agents have 0–3 lifetime permission events and `/pending` has never listed more than one — and marko's own case was data-dependent (serial by necessity). A combined-card UI in the security-sensitive approval path isn't justified by evidence yet; revisit if we observe concurrent cards.

## Why / job

Serves **on-leash**: approvals should be legible and predictable, not a surprise drip the operator has to babysit.

## Test plan

- [x] Plain-markdown addition (no handlebars expressions) — can't break template rendering.
- [x] `scaffold.rerender-claude-md` + `scaffold` suites green (199 tests).

## Risk

Minimal — prompt-only change to the base profile; goes live per agent on its next restart/reconcile. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)