### PR TITLE
feat(hindsight): automated backups, healthcheck, and pg self-maintenance

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -147,6 +147,10 @@ RUN OLD_UID=$(id -u hindsight) && NEW_UID=11000 \
 RUN mkdir -p /usr/local/lib/switchroom && chmod 0755 /usr/local/lib/switchroom
 COPY --chmod=0644 docker/hindsight-fetch-creds.cjs /usr/local/lib/switchroom/hindsight-fetch-creds.cjs
 
+# Periodic maintenance script (rotated pg_dump backup + autovacuum tuning
+# + completed-op retention), invoked by the entrypoint's background loop.
+COPY --chmod=0755 docker/hindsight-maintenance.sh /usr/local/lib/switchroom/hindsight-maintenance.sh
+
 # Entrypoint shim — runs the fetcher at boot, spawns a refresh sidecar,
 # then execs the upstream CMD. See the file header for the boot/refresh
 # flow + env knobs + fail-loud guards.

--- a/docker/hindsight-entrypoint.sh
+++ b/docker/hindsight-entrypoint.sh
@@ -75,6 +75,11 @@ CRED_FILE="${CRED_DIR}/.credentials.json"
 WAIT_TIMEOUT_S="${SWITCHROOM_HINDSIGHT_WAIT_S:-60}"
 REFRESH_S="${SWITCHROOM_HINDSIGHT_REFRESH_S:-1800}"
 FETCHER="${SWITCHROOM_HINDSIGHT_FETCHER:-/usr/local/lib/switchroom/hindsight-fetch-creds.cjs}"
+# Periodic maintenance (backup + autovacuum tuning + op retention). Runs
+# from the same background loop because it needs a live pg (which boots
+# only after the exec below). Best-effort + idempotent. See the script
+# header for the jobs + env knobs. Empty/unset path disables it.
+MAINTENANCE="${SWITCHROOM_HINDSIGHT_MAINTENANCE_SCRIPT:-/usr/local/lib/switchroom/hindsight-maintenance.sh}"
 REAP_STALE_S="${SWITCHROOM_HINDSIGHT_REAP_STALE_S:-1800}"
 # pg0 instance descriptor (holds the embedded-postgres password); the
 # reaper reads it to connect. Overridable for host tests.
@@ -167,6 +172,9 @@ if [ "${REFRESH_S}" -gt 0 ] && [ -f "${FETCHER}" ]; then
       # successfully-fetched credentials until the loop catches up.
       # Same loop drives the stale-claim reaper (fix B) — also best-effort.
       reap_stale_processing || true
+      # ...and periodic maintenance (backup / autovacuum / op retention).
+      # Self-gates on interval + pg-readiness; safe to invoke every tick.
+      [ -f "${MAINTENANCE}" ] && sh "${MAINTENANCE}" || true
     done
   ) &
   log "credential refresh loop started (interval=${REFRESH_S}s, pid=$!)"

--- a/docker/hindsight-maintenance.sh
+++ b/docker/hindsight-maintenance.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# switchroom/hindsight periodic maintenance — runs as a sibling of the
+# entrypoint's background loop (so it executes alongside a live pg,
+# unlike the entrypoint body which runs before start-all.sh boots pg).
+#
+# Three best-effort jobs, all idempotent and safe to run on every tick:
+#
+#   1. Backup     — rotated `pg_dump -Fc` of the embedded pg to a volume
+#                   SEPARATE from the data volume, so a data-volume loss
+#                   or corruption is recoverable. Runs at most once per
+#                   BACKUP_INTERVAL_MIN. Keeps the newest BACKUP_KEEP.
+#   2. Autovacuum — pins per-table autovacuum scale factors on the large
+#                   / high-churn tables. Upstream ships pg defaults (0.2),
+#                   which on a multi-million-row table means autovacuum
+#                   never fires until >1M dead tuples — so memory_links /
+#                   async_operations bloat unbounded and their planner
+#                   stats go stale (mis-estimating the worker's queue
+#                   table by ~80x). Idempotent `ALTER TABLE ... SET`.
+#   3. Retention  — prune COMPLETED async_operations older than
+#                   RETENTION_DAYS. Terminal queue records the worker
+#                   never reads again; left unbounded they accumulate
+#                   (tens of thousands carrying transcript JSON).
+#                   failed/pending/processing rows are NEVER touched.
+#
+# Everything is best-effort: any failure (pg not up yet, missing creds,
+# psql absent) is logged and swallowed so a bad tick can never wedge the
+# loop or the container. No-ops cleanly on a host without the embedded
+# pg (e.g. unit tests).
+#
+# Env knobs (all defaulted):
+#   SWITCHROOM_HINDSIGHT_MAINTENANCE          master switch (1=on, 0=off). default 1
+#   SWITCHROOM_HINDSIGHT_PG0_INSTANCE         pg0 descriptor (holds the pw)
+#   SWITCHROOM_HINDSIGHT_BACKUP_DIR           backup dir. default /backups
+#   SWITCHROOM_HINDSIGHT_BACKUP_INTERVAL_MIN  min minutes between backups. default 1440
+#   SWITCHROOM_HINDSIGHT_BACKUP_KEEP          rotated backups to retain. default 7
+#   SWITCHROOM_HINDSIGHT_RETENTION_DAYS       completed-op prune age. default 30
+set -u
+
+MAINT_ENABLED="${SWITCHROOM_HINDSIGHT_MAINTENANCE:-1}"
+PG0_INSTANCE="${SWITCHROOM_HINDSIGHT_PG0_INSTANCE:-/home/hindsight/.pg0/instances/hindsight/instance.json}"
+BACKUP_DIR="${SWITCHROOM_HINDSIGHT_BACKUP_DIR:-/backups}"
+BACKUP_INTERVAL_MIN="${SWITCHROOM_HINDSIGHT_BACKUP_INTERVAL_MIN:-1440}"
+BACKUP_KEEP="${SWITCHROOM_HINDSIGHT_BACKUP_KEEP:-7}"
+RETENTION_DAYS="${SWITCHROOM_HINDSIGHT_RETENTION_DAYS:-30}"
+
+log() { echo "switchroom-hindsight-maintenance: $*" >&2; }
+
+[ "${MAINT_ENABLED}" = "1" ] || exit 0
+[ -r "${PG0_INSTANCE}" ] || exit 0
+
+# Resolve pg client binaries from the pg0 install (glob the version dir)
+# or PATH. Absent → nothing to do (host/test).
+_bindir="$(ls -d /home/hindsight/.pg0/installation/*/bin 2>/dev/null | head -1)"
+PSQL="$(command -v psql 2>/dev/null || echo "${_bindir:-/nonexistent}/psql")"
+PG_DUMP="$(command -v pg_dump 2>/dev/null || echo "${_bindir:-/nonexistent}/pg_dump")"
+[ -x "${PSQL}" ] || exit 0
+
+# Pull connection fields from the descriptor without a JSON dep in sh.
+if ! { read -r PGUSER_; read -r PGDB_; read -r PGPORT_; read -r PGPW_; } <<EOF
+$(python3 -c 'import json,sys;d=json.load(open(sys.argv[1]));print(d.get("username","hindsight"));print(d.get("database","hindsight"));print(d.get("port",5432));print(d.get("password",""))' "${PG0_INSTANCE}" 2>/dev/null)
+EOF
+then
+  exit 0
+fi
+[ -n "${PGPW_}" ] || exit 0
+
+# Readiness probe — skip this tick if pg isn't accepting connections yet
+# (the entrypoint execs start-all.sh which boots pg AFTER this loop began).
+PGPASSWORD="${PGPW_}" "${PSQL}" -U "${PGUSER_}" -h /tmp -p "${PGPORT_}" -d "${PGDB_}" \
+  -tAc "SELECT 1" >/dev/null 2>&1 || exit 0
+
+_sql() {
+  PGPASSWORD="${PGPW_}" "${PSQL}" -U "${PGUSER_}" -h /tmp -p "${PGPORT_}" -d "${PGDB_}" \
+    -v ON_ERROR_STOP=0 -tAc "$1" 2>/dev/null
+}
+
+# --- 2. Autovacuum tuning (idempotent; ALTER is a no-op if unchanged) ---
+_sql "ALTER TABLE IF EXISTS memory_links SET (autovacuum_vacuum_scale_factor=0.02, autovacuum_analyze_scale_factor=0.02)" >/dev/null
+_sql "ALTER TABLE IF EXISTS async_operations SET (autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.02)" >/dev/null
+_sql "ALTER TABLE IF EXISTS entity_cooccurrences SET (autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.05)" >/dev/null
+_sql "ALTER TABLE IF EXISTS unit_entities SET (autovacuum_vacuum_scale_factor=0.05, autovacuum_analyze_scale_factor=0.05)" >/dev/null
+
+# --- 3. Retention: prune terminal completed ops (never failed/pending/processing) ---
+_pruned="$(_sql "WITH d AS (DELETE FROM async_operations WHERE status='completed' AND created_at < now() - make_interval(days => ${RETENTION_DAYS}) RETURNING 1) SELECT count(*) FROM d")"
+if [ "${_pruned:-0}" -gt 0 ] 2>/dev/null; then
+  log "pruned ${_pruned} completed async_operations older than ${RETENTION_DAYS}d"
+fi
+
+# --- 1. Backup: rotated pg_dump, at most once per interval ---
+[ -x "${PG_DUMP}" ] || exit 0
+mkdir -p "${BACKUP_DIR}" 2>/dev/null || exit 0
+# Skip if a backup already landed within the interval window.
+if [ -z "$(find "${BACKUP_DIR}" -maxdepth 1 -name 'hindsight-*.dump' -mmin "-${BACKUP_INTERVAL_MIN}" 2>/dev/null | head -1)" ]; then
+  _ts="$(date -u +%Y%m%d-%H%M%S)"
+  _tmp="${BACKUP_DIR}/.hindsight-${_ts}.dump.partial"
+  _final="${BACKUP_DIR}/hindsight-${_ts}.dump"
+  if PGPASSWORD="${PGPW_}" "${PG_DUMP}" -U "${PGUSER_}" -h /tmp -p "${PGPORT_}" -d "${PGDB_}" \
+       -Fc --no-owner --no-privileges -f "${_tmp}" 2>/dev/null; then
+    mv -f "${_tmp}" "${_final}" 2>/dev/null \
+      && log "backup written: ${_final} ($(du -h "${_final}" 2>/dev/null | cut -f1))"
+    # Rotate — keep the newest BACKUP_KEEP, drop the rest.
+    _stale="$(ls -1t "${BACKUP_DIR}"/hindsight-*.dump 2>/dev/null | tail -n "+$((BACKUP_KEEP + 1))")"
+    if [ -n "${_stale}" ]; then
+      echo "${_stale}" | while IFS= read -r f; do rm -f "$f" 2>/dev/null; done
+    fi
+  else
+    rm -f "${_tmp}" 2>/dev/null
+    log "backup pg_dump failed (will retry next tick)"
+  fi
+fi
+
+exit 0

--- a/docs/operators/hindsight-memory.md
+++ b/docs/operators/hindsight-memory.md
@@ -1,0 +1,111 @@
+# Operator runbook — Hindsight memory: backups, restore, maintenance
+
+The `switchroom-hindsight` container holds the entire fleet's long-term
+memory in an embedded PostgreSQL (`pg0`) on the
+`switchroom-hindsight-data` volume. This runbook covers keeping it
+backed up, restoring it, and the automatic self-maintenance switchroom
+runs.
+
+## Automatic backups
+
+The entrypoint's background loop runs `hindsight-maintenance.sh`, which
+takes a **rotated `pg_dump`** to the **`switchroom-hindsight-backups`
+volume** — deliberately *separate* from the data volume, so a
+data-volume loss or corruption is recoverable.
+
+- Cadence: at most once per `SWITCHROOM_HINDSIGHT_BACKUP_INTERVAL_MIN`
+  (default `1440` = daily).
+- Retention: keeps the newest `SWITCHROOM_HINDSIGHT_BACKUP_KEEP`
+  (default `7`); older dumps are rotated out.
+- Format: `pg_dump -Fc` (custom/compressed, restored with `pg_restore`).
+- Best-effort: a failed dump is logged (`switchroom-hindsight-maintenance:`
+  on stderr) and retried next tick; it never wedges the container.
+
+These backups live on the same host. **For real disaster recovery,
+periodically copy the volume off-host** (cron on the host):
+
+```bash
+# Copy the newest dumps off the box (adjust destination).
+docker run --rm -v switchroom-hindsight-backups:/b -v "$PWD":/out alpine \
+  sh -c 'cp /b/hindsight-*.dump /out/' && rsync ./hindsight-*.dump backup-host:/backups/
+```
+
+## On-demand backup
+
+```bash
+docker exec switchroom-hindsight sh -lc '
+  PW=$(python3 -c "import json;print(json.load(open(\"/home/hindsight/.pg0/instances/hindsight/instance.json\"))[\"password\"])")
+  PGPASSWORD="$PW" /home/hindsight/.pg0/installation/*/bin/pg_dump \
+    -U hindsight -h /tmp -d hindsight -Fc --no-owner --no-privileges
+' > ~/.switchroom/backups/hindsight-$(date -u +%Y%m%d-%H%M%S).dump
+```
+
+Verify a dump is restorable before trusting it:
+
+```bash
+docker exec -i switchroom-hindsight /home/hindsight/.pg0/installation/*/bin/pg_restore -l \
+  < ~/.switchroom/backups/hindsight-<TS>.dump | head
+```
+
+## Restore
+
+Restoring overwrites live memory — stop dependent traffic first.
+
+```bash
+# 1. Copy the dump into the container.
+docker cp ~/.switchroom/backups/hindsight-<TS>.dump switchroom-hindsight:/tmp/restore.dump
+
+# 2. Restore into the running pg (drops + recreates objects).
+docker exec switchroom-hindsight sh -lc '
+  PW=$(python3 -c "import json;print(json.load(open(\"/home/hindsight/.pg0/instances/hindsight/instance.json\"))[\"password\"])")
+  PGPASSWORD="$PW" /home/hindsight/.pg0/installation/*/bin/pg_restore \
+    -U hindsight -h /tmp -d hindsight --clean --if-exists --no-owner /tmp/restore.dump
+'
+
+# 3. Bounce hindsight so the worker re-reads cleanly.
+switchroom agent restart test-harness --wait --force   # or: docker restart switchroom-hindsight
+```
+
+## Self-maintenance (autovacuum + op retention)
+
+The same maintenance loop also, every tick (best-effort, idempotent):
+
+- **Pins per-table autovacuum** on the large / high-churn tables
+  (`memory_links`, `async_operations`, `entity_cooccurrences`,
+  `unit_entities`). The upstream pg default scale factor (`0.2`) means a
+  multi-million-row table won't autovacuum until >1M dead tuples — so
+  these tables bloat and their planner stats go stale (mis-estimating
+  the worker's queue table by ~80×, degrading queue-poll plans).
+- **Prunes completed `async_operations`** older than
+  `SWITCHROOM_HINDSIGHT_RETENTION_DAYS` (default `30`). These are
+  terminal queue records the worker never reads again; `failed` /
+  `pending` / `processing` rows are never touched.
+
+Plain `VACUUM` returns dead space to the free-space map but does not
+shrink the data files. To reclaim disk after a large prune, run a
+`VACUUM (FULL, ANALYZE)` or `pg_repack` **in a maintenance window** (it
+takes an exclusive lock).
+
+## Env knobs
+
+| Var | Default | Effect |
+|-----|---------|--------|
+| `SWITCHROOM_HINDSIGHT_MAINTENANCE` | `1` | master switch (`0` disables all three jobs) |
+| `SWITCHROOM_HINDSIGHT_BACKUP_INTERVAL_MIN` | `1440` | min minutes between backups |
+| `SWITCHROOM_HINDSIGHT_BACKUP_KEEP` | `7` | rotated backups retained |
+| `SWITCHROOM_HINDSIGHT_RETENTION_DAYS` | `30` | completed-op prune age |
+
+## Health
+
+The container now carries a Docker **healthcheck** (`/health` via
+`python3`), so a wedged or never-booted API reports `unhealthy` and is
+restarted under `restart: unless-stopped`. Check it with:
+
+```bash
+docker inspect switchroom-hindsight --format '{{.State.Health.Status}}'
+```
+
+Note: the healthcheck proves the API + DB are reachable, **not** that the
+consolidation queue is advancing — watch for a stuck queue separately
+(see the stale-claim reaper in `hindsight-entrypoint.sh` and the
+`async_operations` `processing`/`pending` counts).

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -233,6 +233,20 @@ export const HINDSIGHT_DEFAULT_PIDS_LIMIT = 1000;
 export const HINDSIGHT_DEFAULT_SHM_SIZE = "2g";
 
 /**
+ * Container healthcheck. Hits the in-container `/health` endpoint (which
+ * reports DB connectivity) and exits non-zero on any failure — including
+ * connection-refused (URLError) and non-200 (HTTPError), both of which
+ * raise and propagate to a non-zero process exit. `python3` is always
+ * present in the upstream image; `curl`/`wget` are not, so we don't rely
+ * on them. `HINDSIGHT_HEALTHCHECK_PY` is the bare script body (compose
+ * exec-form `["CMD","python3","-c",PY]`); `HINDSIGHT_HEALTHCHECK_CMD` is
+ * the shell string for `docker run --health-cmd`.
+ */
+export const HINDSIGHT_HEALTHCHECK_PY =
+  'import urllib.request,sys; sys.exit(0 if urllib.request.urlopen("http://localhost:8888/health",timeout=4).getcode()==200 else 1)';
+export const HINDSIGHT_HEALTHCHECK_CMD = `python3 -c '${HINDSIGHT_HEALTHCHECK_PY}'`;
+
+/**
  * Check if a TCP port is free for binding on 127.0.0.1.
  * Returns true if free, false if something is already listening.
  */
@@ -387,9 +401,21 @@ export function startHindsight(ports?: { apiPort: number; uiPort: number }): voi
     // HINDSIGHT_DEFAULT_SHM_SIZE) or all writes/queries fail with
     // "No space left on device". Keep in sync with the compose snippet.
     `--shm-size=${HINDSIGHT_DEFAULT_SHM_SIZE}`,
+    // Restart a wedged API: docker had no liveness signal for hindsight,
+    // so an unresponsive server (or a never-booting one) stayed "up"
+    // forever. python3 is always present in the image; curl/wget are not.
+    "--health-cmd", HINDSIGHT_HEALTHCHECK_CMD,
+    "--health-interval", "30s",
+    "--health-timeout", "5s",
+    "--health-retries", "3",
+    "--health-start-period", "60s",
     "-p", `127.0.0.1:${apiPort}:8888`,
     "-p", `127.0.0.1:${uiPort}:9999`,
     "-v", "switchroom-hindsight-data:/home/hindsight/.pg0",
+    // Backups land on a SEPARATE volume from the data, so a data-volume
+    // loss/corruption is recoverable. The entrypoint's maintenance loop
+    // writes rotated pg_dumps here; operators can snapshot/copy it off-host.
+    "-v", "switchroom-hindsight-backups:/backups",
     // Broker UDS — same shape the agent fleet uses. The named volume is
     // populated by the auth-broker singleton (which chowns the socket to
     // the declared consumer UID); inside this container the socket is
@@ -484,8 +510,18 @@ export function generateHindsightComposeSnippet(): string {
     // PostgreSQL shm — see HINDSIGHT_DEFAULT_SHM_SIZE. Without this the
     // container gets Docker's 64MB default and all writes/queries fail.
     `    shm_size: ${HINDSIGHT_DEFAULT_SHM_SIZE}`,
+    // Liveness — restart a wedged/never-booted API (see the docker-run path).
+    "    healthcheck:",
+    `      test: ${JSON.stringify(["CMD", "python3", "-c", HINDSIGHT_HEALTHCHECK_PY])}`,
+    "      interval: 30s",
+    "      timeout: 5s",
+    "      retries: 3",
+    "      start_period: 60s",
     "    volumes:",
     "      - switchroom-hindsight-data:/home/hindsight/.pg0",
+    // Backups on a separate volume from the data — recoverable if the data
+    // volume is lost/corrupted. Written by the entrypoint maintenance loop.
+    "      - switchroom-hindsight-backups:/backups",
     `      - ${HINDSIGHT_BROKER_SOCK_VOLUME}:/run/switchroom/auth-broker`,
     "    tmpfs:",
     `      - /run/claude-creds:rw,mode=0700,uid=${HINDSIGHT_DEFAULT_UID},gid=${HINDSIGHT_DEFAULT_UID}`,
@@ -493,6 +529,7 @@ export function generateHindsightComposeSnippet(): string {
     "",
     "volumes:",
     "  switchroom-hindsight-data:",
+    "  switchroom-hindsight-backups:",
     `  ${HINDSIGHT_BROKER_SOCK_VOLUME}:`,
     "    external: true",
     "    # Bound by the switchroom-auth-broker singleton in the main",

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -100,6 +100,12 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("bakes the maintenance sidecar (backup/autovacuum/retention) as executable", () => {
+    expect(dockerfile).toMatch(
+      /COPY\s+--chmod=0755\s+docker\/hindsight-maintenance\.sh\s+\/usr\/local\/lib\/switchroom\/hindsight-maintenance\.sh/,
+    );
+  });
+
   it("ends as USER hindsight (so the entrypoint runs as UID 11000)", () => {
     expect(dockerfile).toMatch(/^USER\s+hindsight\b/m);
   });

--- a/tests/docker/hindsight-maintenance.test.ts
+++ b/tests/docker/hindsight-maintenance.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for `docker/hindsight-maintenance.sh` — the periodic backup /
+ * autovacuum-tuning / op-retention sidecar invoked by the entrypoint
+ * loop. We can't stand up the embedded postgres in a host unit test, so
+ * we prove (a) it no-ops cleanly + safely when there's no pg, and (b)
+ * the dangerous-to-drift SQL and guards are pinned statically.
+ */
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const SCRIPT = resolve(__dirname, "..", "..", "docker", "hindsight-maintenance.sh");
+
+describe("hindsight-maintenance.sh", () => {
+  it("exits 0 and silently when the embedded pg descriptor is absent (host/test)", () => {
+    const r = spawnSync("sh", [SCRIPT], {
+      env: {
+        ...process.env,
+        SWITCHROOM_HINDSIGHT_PG0_INSTANCE: "/nonexistent/instance.json",
+      },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    expect(r.status).toBe(0);
+    // No backup/prune chatter and no crash leaking from the missing pg.
+    expect(r.stderr).not.toMatch(/backup|pruned|Traceback|psql:/i);
+  });
+
+  it("exits 0 immediately when disabled via SWITCHROOM_HINDSIGHT_MAINTENANCE=0", () => {
+    const r = spawnSync("sh", [SCRIPT], {
+      env: { ...process.env, SWITCHROOM_HINDSIGHT_MAINTENANCE: "0" },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("pins the retention prune to ONLY completed terminal ops", () => {
+    const raw = readFileSync(SCRIPT, "utf-8");
+    // The DELETE must be scoped to status='completed' + an age cutoff.
+    expect(raw).toMatch(/DELETE FROM async_operations WHERE status='completed'/);
+    expect(raw).toMatch(/created_at < now\(\) - make_interval\(days => \$\{RETENTION_DAYS\}\)/);
+    // It must NEVER delete failed/pending/processing rows.
+    expect(raw).not.toMatch(/DELETE FROM async_operations WHERE status='(failed|pending|processing)'/);
+  });
+
+  it("pins the autovacuum tuning on the big/high-churn tables (idempotent ALTERs)", () => {
+    const raw = readFileSync(SCRIPT, "utf-8");
+    expect(raw).toMatch(/ALTER TABLE IF EXISTS memory_links SET \(autovacuum_vacuum_scale_factor=/);
+    expect(raw).toMatch(/ALTER TABLE IF EXISTS async_operations SET \(autovacuum_vacuum_scale_factor=/);
+  });
+
+  it("writes backups to a separate dir + rotates, and is gated on an interval + pg readiness", () => {
+    const raw = readFileSync(SCRIPT, "utf-8");
+    // Rotated pg_dump in custom format to the backup dir.
+    expect(raw).toMatch(/pg_dump|PG_DUMP/);
+    expect(raw).toMatch(/-Fc/);
+    expect(raw).toMatch(/BACKUP_DIR/);
+    expect(raw).toMatch(/BACKUP_KEEP/);
+    // Readiness probe before any work (skips the tick if pg isn't up yet).
+    expect(raw).toMatch(/SELECT 1.*\|\| exit 0/);
+    // Interval gate so it backs up at most once per window.
+    expect(raw).toMatch(/-mmin "?-?\$\{BACKUP_INTERVAL_MIN\}/);
+  });
+});

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -62,6 +62,32 @@ describe("hindsight broker-fed mode (#1245)", () => {
     expect(args).not.toContain("--entrypoint");
   });
 
+  it("adds a container healthcheck so docker restarts a wedged API", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const args = findRunArgs();
+    expect(args).toContain("--health-cmd");
+    const cmd = args[args.indexOf("--health-cmd") + 1] as string;
+    // Hits /health via python3 (always in the image; curl/wget are not).
+    expect(cmd).toContain("python3");
+    expect(cmd).toContain("/health");
+    expect(args).toContain("--health-interval");
+  });
+
+  it("mounts a SEPARATE backups volume so a data-volume loss is recoverable", () => {
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const args = findRunArgs();
+    let found = false;
+    for (let i = 0; i < args.length - 1; i++) {
+      if (args[i] === "-v" && args[i + 1] === "switchroom-hindsight-backups:/backups") {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+    // Must NOT co-locate backups on the data volume (defeats the point).
+    expect(args).not.toContain("switchroom-hindsight-data:/backups");
+  });
+
   it("bind-mounts the auth-broker consumer socket volume", () => {
     startHindsight({ apiPort: 8888, uiPort: 9999 });
     const args = findRunArgs();
@@ -229,6 +255,18 @@ describe("generateHindsightComposeSnippet — tmpfs ownership", () => {
       await import("../../src/setup/hindsight.js");
     const snippet = generateHindsightComposeSnippet();
     expect(snippet).toMatch(new RegExp(`shm_size:\\s*${shm}\\b`));
+  });
+
+  it("emits a healthcheck + separate backups volume (parity with the docker-run path)", async () => {
+    const { generateHindsightComposeSnippet } = await import("../../src/setup/hindsight.js");
+    const snippet = generateHindsightComposeSnippet();
+    expect(snippet).toMatch(/healthcheck:/);
+    expect(snippet).toContain("/health");
+    expect(snippet).toContain("- switchroom-hindsight-backups:/backups");
+    // The backups volume must be declared under top-level `volumes:`.
+    expect(snippet).toMatch(/^ {2}switchroom-hindsight-backups:/m);
+    // Backups must not share the data volume mount.
+    expect(snippet).not.toContain("switchroom-hindsight-data:/backups");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes three operational gaps found in a health audit of the running fleet's hindsight memory service. All fixed at the "how switchroom runs hindsight" layer — no upstream/hindsight code changes.

## Why

1. **No backups.** `switchroom-hindsight-data` held **~5.7 GB of all-fleet long-term memory** in a single docker volume with **zero** backup — one `docker volume rm`, disk failure, or botched image bump = total, unrecoverable amnesia for all agents. (An immediate manual `pg_dump` was already taken on the host to cover the urgent risk; this makes it durable + automatic.)
2. **No healthcheck.** The container had no liveness signal, so a wedged or never-booted API stayed `up` forever — docker couldn't restart it.
3. **Postgres bloat / ineffective autovacuum.** `memory_links` (4 GB, ~5.7M rows) and `async_operations` had **never** been autovacuumed: pg's default `scale_factor=0.2` means autovacuum won't fire until >1M dead tuples, so they bloat and stats go stale — the queue table the worker polls was mis-estimated **~80×** (planner saw 802 rows vs 63k actual). Completed `async_operations` were also never pruned (unbounded growth, tens of thousands carrying transcript JSON). _(A one-off VACUUM/ANALYZE/prune + per-table autovacuum tuning was applied live; this bakes it in durably + for fresh installs.)_

## What

- **`docker/hindsight-maintenance.sh`** (new) — invoked by the entrypoint's existing background loop (so it runs alongside a live pg, which boots only after `exec`). Best-effort + idempotent, three jobs:
  - **Backup:** rotated `pg_dump -Fc` to a **separate** `switchroom-hindsight-backups` volume (recoverable if the data volume is lost), at most once per `BACKUP_INTERVAL_MIN` (default daily), keep newest `BACKUP_KEEP` (7).
  - **Autovacuum:** idempotent per-table `ALTER TABLE ... SET (autovacuum_*_scale_factor=...)` on the big/high-churn tables.
  - **Retention:** prune `completed` `async_operations` older than `RETENTION_DAYS` (30). `failed`/`pending`/`processing` are **never** touched.
  - No-ops cleanly + silently when pg/instance/psql is absent; can't trip `set -e` or wedge the loop.
- **Healthcheck** on both the `docker run` and compose emit paths (`src/setup/hindsight.ts`) — `/health` via `python3` (curl/wget aren't in the image), so a wedged API reports `unhealthy` and restarts under `restart: unless-stopped`.
- **Separate backups volume** mounted in both emit paths.
- **Operator runbook** — `docs/operators/hindsight-memory.md` (backup / on-demand / restore / DR / maintenance / env knobs).

## Test plan

- [x] `tests/docker/hindsight-maintenance.test.ts` — no-op safety (no pg), disabled-switch, static pins of the prune scope (`completed` only), autovacuum ALTERs, rotation + readiness/interval gating.
- [x] `tests/setup/hindsight.test.ts` — healthcheck + separate-backups-volume on both emit paths (and not co-located on the data volume).
- [x] `tests/docker/dockerfile-hindsight-bakes.test.ts` — maintenance script is COPY'd executable.
- [x] 54 targeted tests pass; `compose-generator` (172) + `memory` (19) regression-clean; `tsc --noEmit` clean; `sh -n` on both scripts.

## Risk

Low. The maintenance script is best-effort, idempotent, conservatively gated (readiness probe + interval), and the prune is scoped to terminal `completed` rows only. Healthcheck uses an always-present interpreter. Takes effect after the hindsight image is rebuilt + redeployed; the live host already has the one-off remediation applied. Backups are on-host (separate volume) — the runbook documents off-host copy for full DR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)