### PR TITLE
fix(doctor): connection-health — mirror broker checkEntryScope (empty-allow ok)

### DIFF
--- a/src/agents/connection-health.ts
+++ b/src/agents/connection-health.ts
@@ -26,6 +26,7 @@ import { join } from "node:path";
 import type { SwitchroomConfig } from "../config/schema.js";
 import {
   computeMcpSecretRequirements,
+  entryScopeDenies,
   type VaultAclResult,
 } from "../cli/doctor-mcp-secrets.js";
 
@@ -38,7 +39,12 @@ export interface ConnectionIssue {
   server: string;
   /** The vault key it needs. */
   key: string;
-  /** "missing" = key absent; "acl" = key present but agent not granted. */
+  /**
+   * "missing" = the declared vault key has no value; "acl" = the key exists
+   * but the vault entry scope (allow/deny) denies this agent. Both are real
+   * runtime auth failures. (An EMPTY scope.allow is NOT a denial — that was
+   * the v0.15.38 false-positive.)
+   */
   kind: "missing" | "acl";
   /** One-line human description. */
   detail: string;
@@ -118,14 +124,19 @@ export async function computeAgentConnectionIssues(
         });
         continue;
       }
-      if (!acl.allow.includes(agentName)) {
+      // kind === "ok": key exists and the agent passes the secrets[] ACL
+      // grant by construction — but the broker ALSO applies the entry scope
+      // (checkEntryScope). Only flag when the scope actually denies; an empty
+      // scope.allow imposes no restriction (the v0.15.38 false-positive was
+      // treating empty-allow as "deny everyone").
+      if (entryScopeDenies(agentName, acl.allow, acl.deny)) {
         const updated = [...new Set([...acl.allow, agentName])].sort().join(",");
         issues.push({
           server: r.server,
           key,
           kind: "acl",
-          detail: `MCP '${r.server}' not on the vault ACL for '${key}' — broker will deny at runtime`,
-          fix: `switchroom vault set ${key} --allow ${updated} (re-state the full list)`,
+          detail: `MCP '${r.server}' — vault entry scope for '${key}' denies this agent — broker will deny at runtime`,
+          fix: `switchroom vault set ${key} --allow ${updated} (re-state the full list; drop from --deny if present)`,
         });
       }
     }

--- a/src/cli/apply.ts
+++ b/src/cli/apply.ts
@@ -690,7 +690,11 @@ export async function runApply(
       const { getViaBrokerStructured } = await import("../vault/broker/client.js");
       const result = await getViaBrokerStructured(key);
       if (result.kind === "ok") {
-        return { kind: "ok", allow: result.entry.scope?.allow ?? [] };
+        return {
+          kind: "ok",
+          allow: result.entry.scope?.allow ?? [],
+          deny: result.entry.scope?.deny ?? [],
+        };
       }
       if (result.kind === "not_found") return { kind: "not_found" };
       return { kind: "unreachable", msg: result.msg };

--- a/src/cli/doctor-mcp-secrets.ts
+++ b/src/cli/doctor-mcp-secrets.ts
@@ -37,11 +37,29 @@ export interface CheckResult {
   fix?: string;
 }
 
-/** Vault-ACL read result, matching doctor-notion's reader contract. */
+/** Vault-ACL read result: the entry's scope (allow + deny) on `kind: "ok"`. */
 export type VaultAclResult =
-  | { kind: "ok"; allow: string[] }
+  | { kind: "ok"; allow: string[]; deny: string[] }
   | { kind: "unreachable"; msg: string }
   | { kind: "not_found" };
+
+/**
+ * Mirror of the broker's `checkEntryScope` (src/vault/broker/acl.ts): an
+ * agent that has already passed the `mcp_servers.secrets[]` ACL grant is
+ * STILL subject to the vault entry's scope. The entry denies iff the agent
+ * is in `scope.deny`, OR `scope.allow` is non-empty and the agent is absent
+ * from it. An EMPTY `scope.allow` imposes no restriction (this is why the
+ * v0.15.38 check false-positived: it treated empty-allow as "deny everyone").
+ */
+export function entryScopeDenies(
+  agent: string,
+  allow: string[],
+  deny: string[],
+): boolean {
+  if (deny.includes(agent)) return true;
+  if (allow.length > 0 && !allow.includes(agent)) return true;
+  return false;
+}
 
 export interface McpSecretProbeDeps {
   /**
@@ -181,20 +199,24 @@ export async function runMcpSecretChecks(
         });
         continue;
       }
-      if (!acl.allow.includes(r.agent)) {
-        const updated = [...new Set([...acl.allow, r.agent])].sort().join(",");
+      // kind === "ok": the key exists. The agent passes the secrets[] ACL
+      // grant by construction (every key here is from its mcp_servers
+      // secrets[]), but the broker ALSO applies the entry scope on top
+      // (checkEntryScope). Only flag when the scope actually denies — an
+      // empty scope.allow does NOT (the v0.15.38 false-positive).
+      if (entryScopeDenies(r.agent, acl.allow, acl.deny)) {
         results.push({
           name,
           status: "fail",
-          detail: `agent '${r.agent}' loads MCP '${r.server}' but is NOT on the vault ACL for '${key}' — the broker will deny it at runtime`,
-          fix: `switchroom vault set ${key} --allow ${updated} (vault set overwrites the scope — re-state the full list including '${r.agent}').`,
+          detail: `agent '${r.agent}' loads MCP '${r.server}' but the vault entry scope for '${key}' denies it — the broker will deny at runtime`,
+          fix: `switchroom vault set ${key} --allow ${[...new Set([...acl.allow, r.agent])].sort().join(",")} (vault set overwrites the scope — re-state the full list including '${r.agent}'; and drop it from --deny if present).`,
         });
         continue;
       }
       results.push({
         name,
         status: "ok",
-        detail: `MCP '${r.server}' → '${key}' present + ACL-allowed`,
+        detail: `MCP '${r.server}' → '${key}' present + scope-allowed`,
       });
     }
   }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -2720,7 +2720,7 @@ export function registerDoctorCommand(program: Command): void {
         const vaultAclReader = async (
           key: string,
         ): Promise<
-          | { kind: "ok"; allow: string[] }
+          | { kind: "ok"; allow: string[]; deny: string[] }
           | { kind: "unreachable"; msg: string }
           | { kind: "not_found" }
         > => {
@@ -2728,7 +2728,11 @@ export function registerDoctorCommand(program: Command): void {
             const { getViaBrokerStructured } = await import("../vault/broker/client.js");
             const result = await getViaBrokerStructured(key);
             if (result.kind === "ok") {
-              return { kind: "ok", allow: result.entry.scope?.allow ?? [] };
+              return {
+                kind: "ok",
+                allow: result.entry.scope?.allow ?? [],
+                deny: result.entry.scope?.deny ?? [],
+              };
             }
             if (result.kind === "not_found") return { kind: "not_found" };
             return { kind: "unreachable", msg: result.msg };

--- a/tests/connection-health.test.ts
+++ b/tests/connection-health.test.ts
@@ -11,9 +11,14 @@ import type { SwitchroomConfig } from "../src/config/schema.js";
 function cfg(partial: Record<string, unknown>): SwitchroomConfig {
   return partial as unknown as SwitchroomConfig;
 }
-function reader(map: Record<string, VaultAclResult>) {
-  return async (key: string): Promise<VaultAclResult> =>
-    map[key] ?? { kind: "not_found" };
+// Accepts ok entries as {allow, deny?} and fills deny:[] so fixtures stay terse.
+type OkEntry = { kind: "ok"; allow: string[]; deny?: string[] };
+type ReaderEntry = OkEntry | { kind: "unreachable"; msg: string } | { kind: "not_found" };
+function reader(map: Record<string, ReaderEntry>) {
+  return async (key: string): Promise<VaultAclResult> => {
+    const e = map[key] ?? { kind: "not_found" as const };
+    return e.kind === "ok" ? { kind: "ok", allow: e.allow, deny: e.deny ?? [] } : e;
+  };
 }
 
 const marko = cfg({
@@ -39,14 +44,33 @@ describe("computeAgentConnectionIssues", () => {
     expect(issues[0].fix).toContain("switchroom vault set meta/token --allow marko");
   });
 
-  it("flags ACL drift as an 'acl' issue and re-states the full allowlist", async () => {
+  it("does NOT flag a present key with an EMPTY scope.allow (v0.15.38 false-positive fix)", async () => {
+    // The real fleet case: keys have no scope (allow=[] deny=[]). checkEntryScope
+    // imposes no restriction on empty allow, so the agent is authed.
     const issues = await computeAgentConnectionIssues(marko, "marko", reader({
-      "meta/token": { kind: "ok", allow: ["someoneelse"] },
+      "meta/token": { kind: "ok", allow: [], deny: [] },
+      "postiz/key": { kind: "ok", allow: [], deny: [] },
+    }));
+    expect(issues).toEqual([]);
+  });
+
+  it("flags an 'acl' issue when scope.allow is NON-empty and the agent is absent (real denial)", async () => {
+    const issues = await computeAgentConnectionIssues(marko, "marko", reader({
+      "meta/token": { kind: "ok", allow: ["someoneelse"] }, // non-empty, marko absent → broker denies
       "postiz/key": { kind: "ok", allow: ["marko"] },
     }));
     expect(issues).toHaveLength(1);
     expect(issues[0]).toMatchObject({ server: "meta", kind: "acl" });
     expect(issues[0].fix).toContain("--allow marko,someoneelse");
+  });
+
+  it("flags an 'acl' issue when the agent is in scope.deny (deny wins)", async () => {
+    const issues = await computeAgentConnectionIssues(marko, "marko", reader({
+      "meta/token": { kind: "ok", allow: [], deny: ["marko"] }, // empty allow but explicit deny
+      "postiz/key": { kind: "ok", allow: ["marko"] },
+    }));
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ server: "meta", kind: "acl" });
   });
 
   it("returns no issues when everything is authed", async () => {

--- a/tests/doctor-mcp-secrets.test.ts
+++ b/tests/doctor-mcp-secrets.test.ts
@@ -11,10 +11,15 @@ function cfg(partial: Record<string, unknown>): SwitchroomConfig {
   return partial as unknown as SwitchroomConfig;
 }
 
-/** A vaultAclReader stub from a key→result map (default: not_found). */
-function reader(map: Record<string, VaultAclResult>) {
-  return async (key: string): Promise<VaultAclResult> =>
-    map[key] ?? { kind: "not_found" };
+/** A vaultAclReader stub from a key→result map (default: not_found).
+ *  ok entries may omit `deny` (filled with []). */
+type OkEntry = { kind: "ok"; allow: string[]; deny?: string[] };
+type ReaderEntry = OkEntry | { kind: "unreachable"; msg: string } | { kind: "not_found" };
+function reader(map: Record<string, ReaderEntry>) {
+  return async (key: string): Promise<VaultAclResult> => {
+    const e = map[key] ?? { kind: "not_found" as const };
+    return e.kind === "ok" ? { kind: "ok", allow: e.allow, deny: e.deny ?? [] } : e;
+  };
 }
 
 describe("computeMcpSecretRequirements", () => {
@@ -114,14 +119,28 @@ describe("runMcpSecretChecks", () => {
     expect(res[0].fix).toContain("switchroom vault set meta/token --allow marko");
   });
 
-  it("FAILs when the key exists but the agent is off its ACL (re-states full list)", async () => {
+  it("OKs a present key with an EMPTY scope.allow (v0.15.38 false-positive fix)", async () => {
+    // The real fleet case: no scope → checkEntryScope imposes no restriction.
+    const res = await runMcpSecretChecks(base, {
+      vaultAclReader: reader({ "meta/token": { kind: "ok", allow: [], deny: [] } }),
+    });
+    expect(res[0].status).toBe("ok");
+  });
+
+  it("FAILs when scope.allow is NON-empty and the agent is absent (real denial)", async () => {
     const res = await runMcpSecretChecks(base, {
       vaultAclReader: reader({ "meta/token": { kind: "ok", allow: ["someoneelse"] } }),
     });
     expect(res[0].status).toBe("fail");
-    expect(res[0].detail).toContain("NOT on the vault ACL");
-    // fix re-states the FULL list (existing + marko), sorted.
+    expect(res[0].detail).toContain("scope");
     expect(res[0].fix).toContain("--allow marko,someoneelse");
+  });
+
+  it("FAILs when the agent is in scope.deny (deny wins over empty allow)", async () => {
+    const res = await runMcpSecretChecks(base, {
+      vaultAclReader: reader({ "meta/token": { kind: "ok", allow: [], deny: ["marko"] } }),
+    });
+    expect(res[0].status).toBe("fail");
   });
 
   it("OKs when the key exists and the agent is on its ACL", async () => {


### PR DESCRIPTION
## Summary

Hotfix for a false-positive shipped in v0.15.38. The connection-health check (`switchroom doctor` "MCP Connections (auth)" + agent-start boot card / `/status`) flagged user-declared MCPs as "not authed" whenever the agent wasn't in the vault entry's `scope.allow` — **including when `scope.allow` was empty**, which is the normal case. The whole live fleet false-positived (marko 12, clerk/gymbro/carrie 1 each; every flagged key has empty scope).

## Root cause (corrected after first review)

My first attempt claimed "secrets[] is the whole grant; drop the scope check." **That was wrong** — the reviewer caught that the broker `get` applies **two** gates: `checkAclByAgent` (grants any key in the agent's `mcp_servers.secrets[]`) **AND** `checkEntryScope` on top (`src/vault/broker/acl.ts`). `checkEntryScope` denies iff the agent is in `scope.deny`, OR `scope.allow` is **non-empty** and the agent is absent. Dropping the check would have hidden real denials (false negatives).

The actual bug: an **empty** `scope.allow` imposes no restriction, but the v0.15.38 check treated it as "deny everyone" (`![].includes(agent)` is always true). Verified against the live vault: all flagged keys have `scope.allow = null`.

## Fix

Mirror `checkEntryScope` exactly via a shared `entryScopeDenies(agent, allow, deny)`:
- empty `scope.allow` (and not in deny) → **OK** (the fix)
- non-empty `scope.allow` without the agent → **acl** issue (real denial, preserved)
- agent in `scope.deny` → **acl** issue (now caught; previously the reader dropped deny entirely)

Threads the entry's `scope.deny` through the operator-context reader (`doctor.ts` + `apply.ts`), which previously only returned `allow`.

## Test plan
- [x] empty-allow → ok; non-empty-allow-without-agent → acl fail; deny → acl fail; present+in-allow → ok; not_found → fail. `doctor-mcp-secrets` (13) + `connection-health` (11) green.
- [x] `tsc`, `check-bun-test-imports` clean.

Thanks to the reviewer for catching the two-gate semantics — this is the corrected version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)