### PR TITLE
fix(auth): hot-reload auth-broker on microsoft enable/disable + pin selector

### DIFF
--- a/docs/microsoft-workspace.md
+++ b/docs/microsoft-workspace.md
@@ -22,19 +22,20 @@ your subscription. (RFC #1873.)
 #    <account> is the Microsoft EMAIL, not a label.
 switchroom auth microsoft account add you@outlook.com
 
-# 2. Allow an agent to use that account (the ACL — enabled_for[]).
+# 2. Allow an agent to use that account. `enable` writes BOTH halves of
+#    the gate — the ACL (microsoft_accounts.you@outlook.com.enabled_for[])
+#    AND the per-agent selector (agents.clerk.microsoft_workspace.account) —
+#    then hot-reloads the running auth-broker so the grant is live at once.
+#    (It won't override a selector already pinned to a different account;
+#    it warns instead.)
 switchroom auth microsoft enable you@outlook.com clerk
 
-# 3. REQUIRED, separate from step 2: set the agent's account selector
-#    in switchroom.yaml, then reconcile. Without this the broker returns
-#    ACCOUNT_NOT_FOUND and the agent silently has no M365.
-#      agents:
-#        clerk:
-#          microsoft_workspace:
-#            account: you@outlook.com
+# 3. Restart the agent so it regenerates its MCP config and surfaces the
+#    Microsoft/OneDrive tools (the broker credential is already live from
+#    step 2 — this step is only about the agent's tool list).
 switchroom agent restart clerk        # or `switchroom update` for the fleet
 
-# 4. Verify (catches the step-3 trap up front):
+# 4. Verify:
 switchroom doctor                     # see "Microsoft 365 (RFC #1873)"
 ```
 
@@ -224,17 +225,25 @@ After consent, the CLI shows:
 
 ## Granting access to agents
 
-Two separate steps (both required):
+The broker needs **two** things to serve a credential: the ACL
+(`microsoft_accounts.<acct>.enabled_for[]` lists the agent) AND the
+per-agent selector (`agents.<agent>.microsoft_workspace.account`). It
+derives the account from the selector, then checks the ACL — missing
+the selector yields `ACCOUNT_NOT_FOUND`; missing the ACL yields
+`ACCESS_DENIED`.
 
-**Step 1**: the ACL — written by the CLI verb:
+`enable` writes **both** in one command and hot-reloads the broker:
 
 ```bash
 switchroom auth microsoft enable you@outlook.com clerk lawgpt
-# Mutates microsoft_accounts.you@outlook.com.enabled_for[] in switchroom.yaml
+# • appends clerk, lawgpt to microsoft_accounts.you@outlook.com.enabled_for[]
+# • pins agents.{clerk,lawgpt}.microsoft_workspace.account = you@outlook.com
+#   (skipped + warned for an agent already pinned to a DIFFERENT account)
+# • SIGHUPs switchroom-auth-broker so the grant is live immediately —
+#   no `docker restart` needed
 ```
 
-**Step 2**: the per-agent account selector — must be set in YAML by
-hand or by your config tooling:
+The resulting YAML:
 
 ```yaml
 agents:
@@ -246,16 +255,14 @@ agents:
       account: you@outlook.com
 ```
 
-The broker derives the account from the per-agent selector, then
-checks the ACL. If you do step 1 without step 2, the broker returns
-`ACCOUNT_NOT_FOUND` silently the first time the agent calls a MS tool.
-If you do step 2 without step 1, the broker returns `ACCESS_DENIED`.
-`switchroom doctor` catches both up front (`microsoft:matrix:*`).
+`switchroom doctor` still catches any hand-edited mismatch up front
+(`microsoft:matrix:*`).
 
-`switchroom auth microsoft disable you@outlook.com clerk` removes
-agent from the ACL, leaving the account in `microsoft_accounts:` with
-empty `enabled_for[]` (dormant — matches shipped Google behavior per
-RFC §6.1).
+`switchroom auth microsoft disable you@outlook.com clerk` removes the
+agent from the ACL, clears its now-dangling selector (when it pointed
+at this account), and hot-reloads the broker. The account stays in
+`microsoft_accounts:` with an empty `enabled_for[]` (dormant — matches
+shipped Google behavior per RFC §6.1).
 
 ## Listing what's configured
 

--- a/src/auth/broker/reload-signal.test.ts
+++ b/src/auth/broker/reload-signal.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  reloadAuthBroker,
+  authBrokerReloadHint,
+  AUTH_BROKER_CONTAINER,
+  type DockerRunner,
+} from "./reload-signal.js";
+
+function runnerReturning(
+  ret: { status: number | null; stderr?: string; error?: Error },
+): { runner: DockerRunner; calls: string[][] } {
+  const calls: string[][] = [];
+  const runner: DockerRunner = (args) => {
+    calls.push(args);
+    return { status: ret.status, stderr: ret.stderr ?? "", error: ret.error };
+  };
+  return { runner, calls };
+}
+
+describe("reloadAuthBroker", () => {
+  it("sends SIGHUP to the auth-broker container (regression: nothing used to)", () => {
+    const { runner, calls } = runnerReturning({ status: 0 });
+    const result = reloadAuthBroker({ runner });
+    expect(result).toEqual({ ok: true });
+    // The exact invocation the hot-reload depends on.
+    expect(calls).toEqual([["kill", "--signal=HUP", AUTH_BROKER_CONTAINER]]);
+  });
+
+  it("honours a custom container name", () => {
+    const { runner, calls } = runnerReturning({ status: 0 });
+    reloadAuthBroker({ runner, container: "switchroom-auth-broker-test" });
+    expect(calls[0]).toEqual([
+      "kill",
+      "--signal=HUP",
+      "switchroom-auth-broker-test",
+    ]);
+  });
+
+  it("reports no-docker when the docker binary is missing (ENOENT)", () => {
+    const err = Object.assign(new Error("spawn docker ENOENT"), {
+      code: "ENOENT",
+    });
+    const { runner } = runnerReturning({ status: null, error: err });
+    expect(reloadAuthBroker({ runner })).toEqual({
+      ok: false,
+      reason: "no-docker",
+    });
+  });
+
+  it("reports not-running when the container is absent", () => {
+    const { runner } = runnerReturning({
+      status: 1,
+      stderr:
+        "Error response from daemon: No such container: switchroom-auth-broker",
+    });
+    expect(reloadAuthBroker({ runner })).toEqual({
+      ok: false,
+      reason: "not-running",
+    });
+  });
+
+  it("reports not-running when the container is stopped", () => {
+    const { runner } = runnerReturning({
+      status: 1,
+      stderr: "Error response from daemon: Cannot kill container: ... is not running",
+    });
+    expect(reloadAuthBroker({ runner })).toEqual({
+      ok: false,
+      reason: "not-running",
+    });
+  });
+
+  it("reports a generic error for other docker failures", () => {
+    const { runner } = runnerReturning({
+      status: 1,
+      stderr: "permission denied while trying to connect to the Docker daemon",
+    });
+    const result = reloadAuthBroker({ runner });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("error");
+      expect(result.detail).toContain("permission denied");
+    }
+  });
+});
+
+describe("authBrokerReloadHint", () => {
+  it("returns null on success (caller prints its own line)", () => {
+    expect(authBrokerReloadHint({ ok: true })).toBeNull();
+  });
+
+  it("treats not-running as informational (next boot picks it up)", () => {
+    const hint = authBrokerReloadHint({ ok: false, reason: "not-running" });
+    expect(hint).toMatch(/not running/i);
+    expect(hint).toMatch(/next start/i);
+  });
+
+  it("points at docker restart when docker is unreachable", () => {
+    const hint = authBrokerReloadHint({ ok: false, reason: "no-docker" });
+    expect(hint).toMatch(/docker restart switchroom-auth-broker/);
+  });
+
+  it("surfaces the detail on a generic error", () => {
+    const hint = authBrokerReloadHint({
+      ok: false,
+      reason: "error",
+      detail: "boom",
+    });
+    expect(hint).toMatch(/boom/);
+    expect(hint).toMatch(/docker restart switchroom-auth-broker/);
+  });
+});

--- a/src/auth/broker/reload-signal.ts
+++ b/src/auth/broker/reload-signal.ts
@@ -1,0 +1,105 @@
+/**
+ * Trigger a hot-reload of the running `switchroom-auth-broker` singleton.
+ *
+ * The broker already supports a full config hot-reload: its SIGHUP handler
+ * (`src/auth/broker/index.ts`) re-reads `switchroom.yaml` from disk and calls
+ * `AuthBroker.reload()`, which swaps `this.config` and reconciles listeners —
+ * so a SIGHUP makes ACL (`microsoft_accounts.<acct>.enabled_for[]`) and
+ * selector (`agents.<name>.microsoft_workspace.account`) edits take effect
+ * live. The machinery exists; the historical gap was that NOTHING sent the
+ * signal. After a config-mutating verb (`auth microsoft enable/disable`,
+ * `account add`, `apply`) the broker kept serving its boot-time config and
+ * returned `ACCOUNT_NOT_FOUND` until the operator manually
+ * `docker restart`ed it.
+ *
+ * This helper closes that gap: it sends SIGHUP to the broker container
+ * (delivered through tini → the bun process) so the change is live without a
+ * restart. It is best-effort and never throws — if Docker is absent or the
+ * broker isn't running, it returns a structured reason and the caller falls
+ * back to telling the operator to restart the broker.
+ */
+
+import { spawnSync } from "node:child_process";
+
+/** The broker's `container_name` in the generated compose file. */
+export const AUTH_BROKER_CONTAINER = "switchroom-auth-broker";
+
+export type AuthBrokerReloadResult =
+  | { ok: true }
+  | { ok: false; reason: "not-running" | "no-docker" | "error"; detail?: string };
+
+/** Injectable for tests — mirrors the relevant slice of `spawnSync`. */
+export type DockerRunner = (
+  args: string[],
+) => { status: number | null; stderr: string; error?: Error };
+
+const defaultRunner: DockerRunner = (args) => {
+  const r = spawnSync("docker", args, { encoding: "utf8" });
+  return {
+    status: r.status,
+    stderr: typeof r.stderr === "string" ? r.stderr : "",
+    error: r.error as Error | undefined,
+  };
+};
+
+/**
+ * Send SIGHUP to the auth-broker container so it hot-reloads switchroom.yaml.
+ * Best-effort, never throws.
+ *
+ * - `{ ok: true }` — the signal was delivered (broker reloaded in place).
+ * - `{ ok: false, reason: "no-docker" }` — `docker` binary not found.
+ * - `{ ok: false, reason: "not-running" }` — no such container / not running.
+ * - `{ ok: false, reason: "error" }` — any other docker failure (detail set).
+ */
+export function reloadAuthBroker(
+  opts: { runner?: DockerRunner; container?: string } = {},
+): AuthBrokerReloadResult {
+  const runner = opts.runner ?? defaultRunner;
+  const container = opts.container ?? AUTH_BROKER_CONTAINER;
+  const { status, stderr, error } = runner([
+    "kill",
+    "--signal=HUP",
+    container,
+  ]);
+
+  if (error) {
+    // ENOENT → docker binary not installed/on PATH.
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ok: false, reason: "no-docker" };
+    }
+    return { ok: false, reason: "error", detail: error.message };
+  }
+  if (status === 0) return { ok: true };
+
+  // docker exits non-zero when the container is absent or stopped — both mean
+  // "no live broker to signal", which the caller surfaces as a restart hint.
+  const lower = stderr.toLowerCase();
+  if (
+    lower.includes("no such container") ||
+    lower.includes("is not running") ||
+    lower.includes("cannot kill")
+  ) {
+    return { ok: false, reason: "not-running" };
+  }
+  return { ok: false, reason: "error", detail: stderr.trim() || `exit ${status}` };
+}
+
+/**
+ * Render a one-line operator hint for a non-ok reload result. Returns null
+ * when the reload succeeded (caller prints its own success line).
+ */
+export function authBrokerReloadHint(
+  result: AuthBrokerReloadResult,
+): string | null {
+  if (result.ok) return null;
+  switch (result.reason) {
+    case "not-running":
+      // No live broker — the next boot reads the new config anyway, so this is
+      // informational, not an error.
+      return "auth-broker is not running — it will pick up this change on next start.";
+    case "no-docker":
+      return "Could not reach Docker to hot-reload the auth-broker; restart it so the change takes effect: docker restart switchroom-auth-broker";
+    case "error":
+      return `Could not hot-reload the auth-broker (${result.detail ?? "unknown error"}); restart it so the change takes effect: docker restart switchroom-auth-broker`;
+  }
+}

--- a/src/cli/auth-microsoft.ts
+++ b/src/cli/auth-microsoft.ts
@@ -24,13 +24,19 @@ import chalk from "chalk";
 import { readFileSync, writeFileSync } from "node:fs";
 
 import {
-  disableAgentsOnMicrosoftAccount,
-  enableAgentsOnMicrosoftAccount,
   getEnabledAgentsForMicrosoftAccount,
   listMicrosoftAccounts,
   removeMicrosoftAccountEntry,
 } from "./microsoft-accounts-yaml.js";
 import { withConfigError, getConfig, getConfigPath } from "./helpers.js";
+import {
+  planMicrosoftEnable,
+  planMicrosoftDisable,
+} from "./microsoft-enable-plan.js";
+import {
+  reloadAuthBroker,
+  authBrokerReloadHint,
+} from "../auth/broker/reload-signal.js";
 import { resolveMicrosoftClientId } from "../auth/default-oauth-clients.js";
 import { selectMicrosoftScopes } from "../microsoft/scopes.js";
 import { buildMicrosoftCredentials as buildMicrosoftCredentialsCore } from "../microsoft/credentials.js";
@@ -69,7 +75,7 @@ function registerEnable(microsoftParent: Command, program: Command): void {
   microsoftParent
     .command("enable <account> <agents...>")
     .description(
-      "Enable a Microsoft account on one or more agents. Use `all` to enable on every declared agent. Appends to microsoft_accounts.<account>.enabled_for[] — does NOT mint the broker credentials (use `auth microsoft account add` for that).",
+      "Enable a Microsoft account on one or more agents. Use `all` to enable on every declared agent. Appends to microsoft_accounts.<account>.enabled_for[] AND pins agents.<agent>.microsoft_workspace.account (both are required, else the broker returns ACCOUNT_NOT_FOUND), then hot-reloads the running auth-broker so it's live immediately. Does NOT mint the broker credentials — use `auth microsoft account add` for that.",
     )
     .action(
       withConfigError(async (account: string, agents: string[]) => {
@@ -79,13 +85,13 @@ function registerEnable(microsoftParent: Command, program: Command): void {
         validateAgentSlugs(agents, config);
         const yamlPath = getConfigPath(program);
         const before = readFileSync(yamlPath, "utf-8");
-        const enabledBefore = getEnabledAgentsBefore(before, normalizedAccount);
 
-        const after = enableAgentsOnMicrosoftAccount(before, normalizedAccount, agents);
-        if (after !== before) writeFileSync(yamlPath, after);
-
-        const enabledAfter = getEnabledAgentsForMicrosoftAccount(after, normalizedAccount) ?? [];
-        const newlyEnabled = enabledAfter.filter((a) => !enabledBefore.includes(a));
+        // Plan + write BOTH halves of the gate (ACL + per-agent selector). The
+        // broker needs both, else it returns ACCOUNT_NOT_FOUND; `enable` used
+        // to write only the ACL. See microsoft-enable-plan.ts.
+        const { text, newlyEnabled, enabledAfter, selectorSet, selectorConflict } =
+          planMicrosoftEnable(before, normalizedAccount, agents);
+        if (text !== before) writeFileSync(yamlPath, text);
 
         console.log();
         if (newlyEnabled.length === 0) {
@@ -103,10 +109,38 @@ function registerEnable(microsoftParent: Command, program: Command): void {
             `  ${chalk.gray("already enabled on:")} ${alreadyEnabled.join(", ")}`,
           );
         }
-        console.log();
-        if (newlyEnabled.length > 0) {
+        if (selectorSet.length > 0) {
           console.log(
-            `Next: ${chalk.bold(`switchroom agent restart ${newlyEnabled.join(" ")}`)} so the wrapper picks up the new ACL.`,
+            `  ${chalk.green("✓")} ${chalk.gray("pinned")} ${chalk.bold("microsoft_workspace.account")} ${chalk.gray("on:")} ${selectorSet.join(", ")}`,
+          );
+        }
+        for (const { agent, current } of selectorConflict) {
+          console.log(
+            chalk.yellow(
+              `  ⚠ ${chalk.bold(agent)} already pins a different account (${chalk.bold(current)}) — left as-is. Repin with \`switchroom auth microsoft disable ${current} ${agent}\` first if that's unintended.`,
+            ),
+          );
+        }
+
+        // 3. Hot-reload the running broker so the new ACL + selector are live
+        //    immediately — no manual `docker restart switchroom-auth-broker`.
+        if (text !== before) {
+          const reload = reloadAuthBroker();
+          if (reload.ok) {
+            console.log(
+              `  ${chalk.green("✓")} ${chalk.gray("auth-broker hot-reloaded — credentials are live.")}`,
+            );
+          } else {
+            const hint = authBrokerReloadHint(reload);
+            if (hint) console.log(chalk.yellow(`  ⚠ ${hint}`));
+          }
+        }
+
+        console.log();
+        if (newlyEnabled.length > 0 || selectorSet.length > 0) {
+          const restartTargets = [...new Set([...newlyEnabled, ...selectorSet])];
+          console.log(
+            `Next: ${chalk.bold(`switchroom agent restart ${restartTargets.join(" ")}`)} to regenerate the agent's MCP config and surface the Microsoft/OneDrive tools.`,
           );
           console.log();
         }
@@ -138,11 +172,11 @@ function registerDisable(microsoftParent: Command, program: Command): void {
           return;
         }
 
-        const after = disableAgentsOnMicrosoftAccount(before, normalizedAccount, agents);
-        if (after !== before) writeFileSync(yamlPath, after);
-
-        const enabledAfter = getEnabledAgentsForMicrosoftAccount(after, normalizedAccount) ?? [];
-        const removed = enabledBefore.filter((a) => !enabledAfter.includes(a));
+        // Plan + write: drop the ACL AND clear each removed agent's now-dangling
+        // selector (symmetry with enable). See microsoft-enable-plan.ts.
+        const { text, removed, enabledAfter, selectorCleared } =
+          planMicrosoftDisable(before, normalizedAccount, agents);
+        if (text !== before) writeFileSync(yamlPath, text);
 
         console.log();
         if (removed.length === 0) {
@@ -163,10 +197,29 @@ function registerDisable(microsoftParent: Command, program: Command): void {
             `  ${chalk.gray("still enabled on:")} ${enabledAfter.join(", ")}`,
           );
         }
+        if (selectorCleared.length > 0) {
+          console.log(
+            `  ${chalk.gray("cleared")} ${chalk.bold("microsoft_workspace.account")} ${chalk.gray("on:")} ${selectorCleared.join(", ")}`,
+          );
+        }
+
+        // Hot-reload the running broker so the dropped access is live now.
+        if (text !== before) {
+          const reload = reloadAuthBroker();
+          if (reload.ok) {
+            console.log(
+              `  ${chalk.green("✓")} ${chalk.gray("auth-broker hot-reloaded — access revoked live.")}`,
+            );
+          } else {
+            const hint = authBrokerReloadHint(reload);
+            if (hint) console.log(chalk.yellow(`  ⚠ ${hint}`));
+          }
+        }
+
         console.log();
         if (removed.length > 0) {
           console.log(
-            `Next: ${chalk.bold(`switchroom agent restart ${removed.join(" ")}`)} so the wrapper drops its access.`,
+            `Next: ${chalk.bold(`switchroom agent restart ${removed.join(" ")}`)} so the agent drops the Microsoft MCP from its config.`,
           );
           console.log();
         }

--- a/src/cli/microsoft-enable-plan.test.ts
+++ b/src/cli/microsoft-enable-plan.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression tests for the enable/disable planners.
+ *
+ * The bug these pin: `auth microsoft enable` used to write ONLY the ACL
+ * (`microsoft_accounts.<acct>.enabled_for[]`) and not the per-agent selector
+ * (`agents.<agent>.microsoft_workspace.account`). The broker needs both, so
+ * the operator hit ACCOUNT_NOT_FOUND even after enable + restart. The planner
+ * must now write both halves.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { planMicrosoftEnable, planMicrosoftDisable } from "./microsoft-enable-plan.js";
+import { getEnabledAgentsForMicrosoftAccount } from "./microsoft-accounts-yaml.js";
+import { getAgentWorkspaceAccount } from "../config/agent-workspace-account.js";
+
+const FIXTURE = `version: "v1"
+agents:
+  marko: {}
+  lawgpt:
+    microsoft_workspace:
+      account: someone-else@outlook.com
+  ziggy:
+    microsoft_workspace:
+      account: lisa@hotmail.com
+`;
+
+const ACCT = "lisa@hotmail.com";
+
+describe("planMicrosoftEnable", () => {
+  it("writes BOTH the ACL and the selector for an agent with no selector", () => {
+    const { text, newlyEnabled, selectorSet, selectorConflict } = planMicrosoftEnable(
+      FIXTURE,
+      ACCT,
+      ["marko"],
+    );
+    // ACL half
+    expect(getEnabledAgentsForMicrosoftAccount(text, ACCT)).toContain("marko");
+    expect(newlyEnabled).toEqual(["marko"]);
+    // Selector half — the regression: this used to be missing.
+    expect(getAgentWorkspaceAccount(text, "microsoft", "marko")).toBe(ACCT);
+    expect(selectorSet).toEqual(["marko"]);
+    expect(selectorConflict).toEqual([]);
+  });
+
+  it("does NOT override a selector pointing at a different account; reports a conflict", () => {
+    const { text, selectorSet, selectorConflict, newlyEnabled } = planMicrosoftEnable(
+      FIXTURE,
+      ACCT,
+      ["lawgpt"],
+    );
+    // ACL is still added...
+    expect(getEnabledAgentsForMicrosoftAccount(text, ACCT)).toContain("lawgpt");
+    expect(newlyEnabled).toEqual(["lawgpt"]);
+    // ...but the existing selector is left untouched and flagged.
+    expect(getAgentWorkspaceAccount(text, "microsoft", "lawgpt")).toBe(
+      "someone-else@outlook.com",
+    );
+    expect(selectorSet).toEqual([]);
+    expect(selectorConflict).toEqual([
+      { agent: "lawgpt", current: "someone-else@outlook.com" },
+    ]);
+  });
+
+  it("is a no-op for an agent already fully wired (ACL + matching selector)", () => {
+    // First fully enable marko, then re-run — should be byte-equal.
+    const first = planMicrosoftEnable(FIXTURE, ACCT, ["marko"]).text;
+    const { text, newlyEnabled, selectorSet } = planMicrosoftEnable(first, ACCT, ["marko"]);
+    expect(text).toBe(first);
+    expect(newlyEnabled).toEqual([]);
+    expect(selectorSet).toEqual([]);
+  });
+
+  it("leaves a matching selector untouched (ziggy already pins this account)", () => {
+    const { selectorSet, selectorConflict } = planMicrosoftEnable(FIXTURE, ACCT, ["ziggy"]);
+    expect(selectorSet).toEqual([]);
+    expect(selectorConflict).toEqual([]);
+  });
+
+  it("handles multiple agents in one call", () => {
+    const { text, selectorSet } = planMicrosoftEnable(FIXTURE, ACCT, ["marko", "ziggy"]);
+    expect(getEnabledAgentsForMicrosoftAccount(text, ACCT)).toEqual(
+      expect.arrayContaining(["marko", "ziggy"]),
+    );
+    // marko needed a selector; ziggy already had a matching one.
+    expect(selectorSet).toEqual(["marko"]);
+  });
+});
+
+describe("planMicrosoftDisable", () => {
+  it("drops the ACL AND clears the selector when it pointed at this account", () => {
+    const enabled = planMicrosoftEnable(FIXTURE, ACCT, ["marko"]).text;
+    const { text, removed, selectorCleared } = planMicrosoftDisable(enabled, ACCT, ["marko"]);
+    expect(removed).toEqual(["marko"]);
+    expect(getEnabledAgentsForMicrosoftAccount(text, ACCT) ?? []).not.toContain("marko");
+    expect(getAgentWorkspaceAccount(text, "microsoft", "marko")).toBeNull();
+    expect(selectorCleared).toEqual(["marko"]);
+  });
+
+  it("does NOT clear a selector pinned to a DIFFERENT account", () => {
+    // Enable ziggy (already pins ACCT) then disable a different account from it.
+    const enabled = planMicrosoftEnable(FIXTURE, ACCT, ["ziggy"]).text;
+    const { selectorCleared, removed } = planMicrosoftDisable(enabled, ACCT, ["ziggy"]);
+    expect(removed).toEqual(["ziggy"]);
+    // ziggy's selector pointed at ACCT, so it IS cleared here — sanity that the
+    // guard is by account-match, not blind.
+    expect(selectorCleared).toEqual(["ziggy"]);
+  });
+});

--- a/src/cli/microsoft-enable-plan.test.ts
+++ b/src/cli/microsoft-enable-plan.test.ts
@@ -98,12 +98,25 @@ describe("planMicrosoftDisable", () => {
   });
 
   it("does NOT clear a selector pinned to a DIFFERENT account", () => {
-    // Enable ziggy (already pins ACCT) then disable a different account from it.
+    // lawgpt is enabled_for ACCT (via the ACL) but its selector points at
+    // someone-else@outlook.com (enable reported it as a conflict, left it).
+    // Disabling ACCT from lawgpt drops the ACL but MUST leave the unrelated
+    // selector intact — only a selector matching the disabled account is cleared.
+    const enabled = planMicrosoftEnable(FIXTURE, ACCT, ["lawgpt"]).text;
+    expect(getAgentWorkspaceAccount(enabled, "microsoft", "lawgpt")).toBe(
+      "someone-else@outlook.com",
+    );
+    const { text, removed, selectorCleared } = planMicrosoftDisable(enabled, ACCT, ["lawgpt"]);
+    expect(removed).toEqual(["lawgpt"]);
+    expect(selectorCleared).toEqual([]); // the negative the guard protects
+    expect(getAgentWorkspaceAccount(text, "microsoft", "lawgpt")).toBe(
+      "someone-else@outlook.com",
+    );
+  });
+
+  it("DOES clear a selector that matched the disabled account", () => {
     const enabled = planMicrosoftEnable(FIXTURE, ACCT, ["ziggy"]).text;
-    const { selectorCleared, removed } = planMicrosoftDisable(enabled, ACCT, ["ziggy"]);
-    expect(removed).toEqual(["ziggy"]);
-    // ziggy's selector pointed at ACCT, so it IS cleared here — sanity that the
-    // guard is by account-match, not blind.
+    const { selectorCleared } = planMicrosoftDisable(enabled, ACCT, ["ziggy"]);
     expect(selectorCleared).toEqual(["ziggy"]);
   });
 });

--- a/src/cli/microsoft-enable-plan.ts
+++ b/src/cli/microsoft-enable-plan.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure YAML-mutation planners for `auth microsoft enable` / `disable`.
+ *
+ * The broker requires BOTH halves of the gate to serve a Microsoft
+ * credential (see `src/config/agent-workspace-account.ts` and
+ * `src/config/microsoft-workspace-acl.ts`):
+ *   1. the ACL — `microsoft_accounts.<acct>.enabled_for[]` lists the agent, and
+ *   2. the selector — `agents.<agent>.microsoft_workspace.account` is pinned.
+ *
+ * `enable` historically wrote only (1), so an operator who ran it (and even
+ * restarted the agent) still hit `ACCOUNT_NOT_FOUND` because (2) was missing.
+ * These planners produce the full both-halves edit so the CLI action and any
+ * future caller stay consistent — and so the behavior is unit-testable without
+ * the CLI/console/docker plumbing. String-in / string-out; no I/O.
+ */
+
+import {
+  enableAgentsOnMicrosoftAccount,
+  disableAgentsOnMicrosoftAccount,
+  getEnabledAgentsForMicrosoftAccount,
+} from "./microsoft-accounts-yaml.js";
+import {
+  setAgentWorkspaceAccount,
+  getAgentWorkspaceAccount,
+  clearAgentWorkspaceAccount,
+} from "../config/agent-workspace-account.js";
+
+export interface MicrosoftEnablePlan {
+  /** Edited YAML text (byte-equal to input when nothing changed). */
+  text: string;
+  /** Agents newly added to enabled_for[] this call. */
+  newlyEnabled: string[];
+  /** Full enabled_for[] after the edit. */
+  enabledAfter: string[];
+  /** Agents whose microsoft_workspace.account we pinned (was unset). */
+  selectorSet: string[];
+  /** Agents already pinned to a DIFFERENT account — left untouched. */
+  selectorConflict: { agent: string; current: string }[];
+}
+
+/**
+ * Plan an enable: append the ACL for every target agent AND pin the per-agent
+ * selector for any target with no selector. Never overrides a selector that
+ * points at a different account (reported as a conflict instead). `account`
+ * must already be normalized (lowercased email).
+ */
+export function planMicrosoftEnable(
+  yamlText: string,
+  account: string,
+  agents: string[],
+): MicrosoftEnablePlan {
+  const enabledBefore = getEnabledAgentsForMicrosoftAccount(yamlText, account) ?? [];
+
+  let text = enableAgentsOnMicrosoftAccount(yamlText, account, agents);
+
+  const selectorSet: string[] = [];
+  const selectorConflict: { agent: string; current: string }[] = [];
+  for (const agent of agents) {
+    const current = getAgentWorkspaceAccount(text, "microsoft", agent);
+    if (current == null) {
+      text = setAgentWorkspaceAccount(text, "microsoft", agent, account);
+      selectorSet.push(agent);
+    } else if (current.toLowerCase() !== account.toLowerCase()) {
+      selectorConflict.push({ agent, current });
+    }
+  }
+
+  const enabledAfter = getEnabledAgentsForMicrosoftAccount(text, account) ?? [];
+  const newlyEnabled = enabledAfter.filter((a) => !enabledBefore.includes(a));
+  return { text, newlyEnabled, enabledAfter, selectorSet, selectorConflict };
+}
+
+export interface MicrosoftDisablePlan {
+  text: string;
+  /** Agents removed from enabled_for[] this call. */
+  removed: string[];
+  /** Full enabled_for[] after the edit. */
+  enabledAfter: string[];
+  /** Agents whose now-dangling selector (pointing at this account) we cleared. */
+  selectorCleared: string[];
+}
+
+/**
+ * Plan a disable: drop the ACL for the target agents AND clear each removed
+ * agent's selector when it still pinned THIS account (a selector pointing at
+ * an account no longer in its enabled_for[] is the mismatch `doctor microsoft`
+ * flags). `account` must already be normalized.
+ */
+export function planMicrosoftDisable(
+  yamlText: string,
+  account: string,
+  agents: string[],
+): MicrosoftDisablePlan {
+  const enabledBefore = getEnabledAgentsForMicrosoftAccount(yamlText, account) ?? [];
+
+  let text = disableAgentsOnMicrosoftAccount(yamlText, account, agents);
+
+  const enabledAfter = getEnabledAgentsForMicrosoftAccount(text, account) ?? [];
+  const removed = enabledBefore.filter((a) => !enabledAfter.includes(a));
+
+  const selectorCleared: string[] = [];
+  for (const agent of removed) {
+    if (
+      getAgentWorkspaceAccount(text, "microsoft", agent)?.toLowerCase() ===
+      account.toLowerCase()
+    ) {
+      text = clearAgentWorkspaceAccount(text, "microsoft", agent);
+      selectorCleared.push(agent);
+    }
+  }
+
+  return { text, removed, enabledAfter, selectorCleared };
+}


### PR DESCRIPTION
## Summary

Connecting + enabling a Microsoft/OneDrive account for an agent was a multi-step footgun that left agents reporting `ACCOUNT_NOT_FOUND` (and "OneDrive not connected") despite seemingly-correct config. This makes `auth microsoft enable/disable` durable end-to-end.

## Why (the missteps this fixes)

1. **`enable` only wrote half the gate.** It appended the ACL (`microsoft_accounts.<acct>.enabled_for[]`) but never the per-agent selector (`agents.<agent>.microsoft_workspace.account`). The broker requires **both** (see `agent-workspace-account.ts`: *"setting the ACL alone yields ACCOUNT_NOT_FOUND"*). The web UI already wrote both; the CLI silently did half the job.
2. **The auth-broker never hot-reloaded after a config change.** It's a long-running singleton that loads config + fans out at boot only. The SIGHUP → `loadConfig()` → `reload()` hot-reload path **already exists end-to-end** (`src/auth/broker/index.ts:118`) and works — but *nothing ever sent the SIGHUP*. So a new ACL/selector sat stale until a manual `docker restart switchroom-auth-broker`.

## What changed

- **`src/auth/broker/reload-signal.ts`** (new) — `reloadAuthBroker()` sends `docker kill --signal=HUP switchroom-auth-broker` (delivered through tini → the bun process) so the broker hot-reloads `switchroom.yaml` in place. Best-effort, never throws; returns a structured result + an operator hint when docker is absent or the broker isn't running.
- **`enable`** now writes **both** halves of the gate and hot-reloads the broker. It never overrides a selector pinned to a *different* account — it warns instead. **`disable`** clears the now-dangling selector (when it pointed at the disabled account) and hot-reloads too.
- **`src/cli/microsoft-enable-plan.ts`** (new) — pure `planMicrosoftEnable` / `planMicrosoftDisable` so the both-halves behavior is unit-testable without CLI/console/docker plumbing.
- Accurate `Next:` messaging + updated `docs/microsoft-workspace.md`.

`account add` / Telegram `/connect` already push creds to the running broker live via the `add-account` IPC, so the credential side was never stale — only the `enable` ACL/selector path was. `apply` is deliberately untouched (it generates files and defers runtime to the operator by design).

## Test plan

- [x] `reload-signal.test.ts` — asserts the exact SIGHUP invocation; graceful `no-docker` (ENOENT) and `not-running` (no-such-container / stopped) fallbacks; hint rendering.
- [x] `microsoft-enable-plan.test.ts` — enable writes ACL **and** selector; never overrides a conflicting selector (reports it); no-op when fully wired; disable drops ACL **and** clears the matching selector.
- [x] 17 new tests pass; `tsc --noEmit` clean; existing `microsoft-accounts-yaml` / `agent-workspace-account` / `doctor-microsoft` suites green (61 total).
- [x] Validated on the live host: `docker kill --signal=HUP switchroom-auth-broker` hot-reloads in place (broker stays up + healthy, no restart).

## Risk

Low. The hot-reload path is pre-existing and battle-tested (SIGHUP handler); this only triggers it. `reloadAuthBroker()` is best-effort and degrades to the prior "restart the broker" guidance if docker is unreachable. The selector auto-pin is conservative (never overrides a different account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NWa7pN79PJFxgThhvd4kR