### PR TITLE
feat(scaffold): default ENABLE_TOOL_SEARCH=true (auto never fires on 1M window)

### DIFF
--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -1666,20 +1666,29 @@ function buildHumanizerEnvVars(
  * `alwaysLoad: true` in .mcp.json so reply/get_recent_messages/recall never
  * defer (no per-turn ToolSearch round-trip).
  *
- * Default value `auto` (self-gating: claude only defers once the tool surface
- * exceeds ~10% of the window, which every agent's does — a small-surface agent
- * is left untouched). Override per fleet via SWITCHROOM_TOOL_SEARCH_MODE
- * (e.g. `true` to force always-defer, `auto:N` for an N% threshold). Kill
- * switch SWITCHROOM_DISABLE_TOOL_SEARCH=1 omits the var entirely → claude
- * loads all tools (today's behaviour). A per-agent `env: {ENABLE_TOOL_SEARCH}`
- * in switchroom.yaml still wins (spread after this in the env builder).
+ * Default value `true` (force-defer). `auto` was the prior default but it
+ * NEVER fires on this fleet: `auto`'s char threshold scales with the model
+ * window, and on the 1M-Opus window the whole ~50-80k MCP tool surface fits
+ * under it, so claude loads everything upfront (measured 2026-06-18: clerk
+ * baseline 79,056 tok under `auto`, unchanged even by the per-tool diet).
+ * `true` forces deferral of every tool NOT pinned via
+ * `_meta["anthropic/alwaysLoad"]` — switchroom pins the load-bearing hot path
+ * (reply / stream_reply / etc. in the telegram bridge; hindsight + agent-config
+ * server-wide), so the reply path stays loaded while the heavy business-MCP +
+ * cold-tool surface defers. Canary (test-harness, 2026-06-18): baseline
+ * 79,056 → 47,064 tok (~40%) with the reply UAT still passing.
+ *
+ * Override per fleet via SWITCHROOM_TOOL_SEARCH_MODE (e.g. `auto` / `auto:N`).
+ * Kill switch SWITCHROOM_DISABLE_TOOL_SEARCH=1 omits the var entirely → claude
+ * loads all tools. A per-agent `env: {ENABLE_TOOL_SEARCH}` in switchroom.yaml
+ * still wins (spread after this in the env builder).
  *
  * Consumed by claude (inner start.sh pass), not the gateway, so the
  * env-before-gateway-fork landmine does not constrain placement.
  */
 export function buildToolSearchEnvVars(): Record<string, string> {
   if (process.env.SWITCHROOM_DISABLE_TOOL_SEARCH === "1") return {};
-  return { ENABLE_TOOL_SEARCH: process.env.SWITCHROOM_TOOL_SEARCH_MODE ?? "auto" };
+  return { ENABLE_TOOL_SEARCH: process.env.SWITCHROOM_TOOL_SEARCH_MODE ?? "true" };
 }
 
 /**

--- a/tests/scaffold.tool-search.test.ts
+++ b/tests/scaffold.tool-search.test.ts
@@ -31,16 +31,16 @@ afterEach(() => {
 });
 
 describe("buildToolSearchEnvVars — default, override, kill switch", () => {
-  it("defaults to ENABLE_TOOL_SEARCH=auto (self-gating, transparent on small tool sets)", () => {
+  it("defaults to ENABLE_TOOL_SEARCH=true (force-defer; auto never fires on the 1M window)", () => {
     delete process.env.SWITCHROOM_DISABLE_TOOL_SEARCH;
     delete process.env.SWITCHROOM_TOOL_SEARCH_MODE;
-    expect(buildToolSearchEnvVars()).toEqual({ ENABLE_TOOL_SEARCH: "auto" });
+    expect(buildToolSearchEnvVars()).toEqual({ ENABLE_TOOL_SEARCH: "true" });
   });
 
-  it("SWITCHROOM_TOOL_SEARCH_MODE overrides the value (true / auto:N)", () => {
+  it("SWITCHROOM_TOOL_SEARCH_MODE overrides the value (auto / auto:N)", () => {
     delete process.env.SWITCHROOM_DISABLE_TOOL_SEARCH;
-    process.env.SWITCHROOM_TOOL_SEARCH_MODE = "true";
-    expect(buildToolSearchEnvVars()).toEqual({ ENABLE_TOOL_SEARCH: "true" });
+    process.env.SWITCHROOM_TOOL_SEARCH_MODE = "auto";
+    expect(buildToolSearchEnvVars()).toEqual({ ENABLE_TOOL_SEARCH: "auto" });
     process.env.SWITCHROOM_TOOL_SEARCH_MODE = "auto:20";
     expect(buildToolSearchEnvVars()).toEqual({ ENABLE_TOOL_SEARCH: "auto:20" });
   });


### PR DESCRIPTION
## Summary

Flip the default tool-search mode from `auto` to **`true`** (force-defer). `auto` never deferred on this fleet — its char threshold scales with the model window, and on the 1M-Opus window the whole ~50–80k MCP tool surface fits under it, so claude loaded everything upfront. **Measured:** clerk fresh-boot baseline **79,056 tok under `auto`, unchanged** even after the P4 per-tool diet (the tools were *eligible* to defer; `auto` never triggered).

`true` forces deferral of every tool NOT pinned via `_meta["anthropic/alwaysLoad"]`. switchroom already pins the load-bearing hot path (reply/stream_reply/get_recent_messages/react in the telegram bridge; hindsight + agent-config server-wide), so the reply path stays loaded while the heavy business-MCP + cold-tool surface defers.

## Canary (test-harness, `ENABLE_TOOL_SEARCH=true`)
- Fresh-boot baseline **79,056 → 47,064 tok (~40% reduction)**.
- Reply UAT `jtbd-fast-trivial-dm` **passes**, TTFO 8.3s, reply path **not deferred** (1 ToolSearch call total).
- Clean boot, no wedge.

## Risk / trade-off
- A deferred (cold/business-MCP) tool pays a one-time ToolSearch round-trip on **first use per session** — a once-per-tool cost traded for ~32k of **per-turn** context savings. Net strongly positive.
- Reply path safety rests on P4's `_meta` pins (verified in canary).
- **Override preserved:** `SWITCHROOM_TOOL_SEARCH_MODE=auto`/`auto:N` reverts; `SWITCHROOM_DISABLE_TOOL_SEARCH=1` loads all tools.

## Test plan
- [x] `buildToolSearchEnvVars` default test updated to `true`; override + kill-switch tests intact. tsc clean, 8 pass.
- [x] Live canary on test-harness (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)