### PR TITLE
docs(reference): fold UX/speed/token review into Hindsight synthesis RFC

### DIFF
--- a/reference/rfcs/hindsight-synthesis-layers.md
+++ b/reference/rfcs/hindsight-synthesis-layers.md
@@ -121,14 +121,16 @@ and crosses no invariant.
 Add `observation` to the auto-recall `types`. Turns 45k of paid-for,
 deduped, provenance-carrying observations from dead weight into the
 "curated, by-relevance" recall the job demands. Pure consumption change
-in the same `memory_units`/HNSW index — near-zero added recall latency,
+(retrieval + local rerank, no model call) — it adds one
+per-fact-type retrieval arm, but the cross-encoder rerank stays bounded
+by the 300-candidate cap, so the added latency is *bounded*, not zero;
 and observations are *denser* (one synthesized statement replaces N raw
 facts) so coverage improves inside the same 1024-token cap. **Do not**
-route the hot recall path through `reflect` (an agentic ~5-iteration
-loop, 300s ceiling) — that would blow warm TTFO (~1.7s) into seconds and
-multiply per-turn tokens; reflect stays reserved for explicit
-"what do you know about me" asks. See *Speed & token budget* below — this
-phase may also let the recall budget drop `mid`→`low` (faster + cheaper).
+route the hot recall path through `reflect` (an agentic loop, ~5–10
+iterations / 10 ceiling, 300s wall-timeout) — that would blow warm TTFO
+(~1.7s) into seconds and multiply per-turn tokens; reflect stays reserved
+for explicit "what do you know about me" asks (where it belongs and is
+kept — Phase 5 builds on it).
 
 **Phase 2 — Specialize each bank.** Set a per-agent `retain_mission` /
 `reflect_mission` / `disposition` from the agent's profile (a coach
@@ -156,28 +158,40 @@ side without polling.
 Operator-curated, or agent-proposes → operator-confirms in chat, for
 specialists that earn a pinned model (the gap behind "Hindsight doesn't
 create models as needed"). Deliberately *not* autonomous creation
-(tension 3). Curate **selectively** — each model adds
-post-consolidation refresh spend (bounded ~2048 tokens, but can hit the
-300s reflect timeout, which we already see fail ~9×), so more models is
-more invisible background cost. Their upside is real on the *explicit*
-reflect path (fresh models let reflect short-circuit the lower tiers →
-faster), but they do not speed the hot recall path.
+(tension 3). Curate **selectively** — a model set to
+`refresh_after_consolidation` (which defaults *off*) adds
+post-consolidation refresh spend (bounded ~2048 tokens, and a reflect
+refresh can hit the 300s wall-timeout — observed historically on this
+fleet), so more refresh-enabled models is more invisible background cost.
+Their upside is real on the *explicit* reflect path (fresh models let
+reflect short-circuit the lower tiers → faster), but they do not speed
+the hot recall path.
 
 **Phase 6 — Two near-free hot-path levers (UX + speed + tokens).** Not
 synthesis-tier work, but the largest responsiveness/cost wins and they
 cross no invariant:
-- **Gate recall on need.** Recall fires on *every* turn — a trivial
-  "what time is it" still pays a ~5s recall arm + up to 1024 injected
-  tokens it never uses. Skipping recall for plausibly-stateless/trivial
-  asks speeds exactly the warm-TTFO path the `jtbd-fast-trivial-dm` gate
-  measures *and* saves tokens.
+- **Gate recall on need.** Recall fires on *every* substantive turn — a
+  trivial "what time is it" still pays a ~1–2s recall arm (budget `low`)
+  + up to 1024 injected tokens it never uses. The hook already skips
+  ultra-short and ack-phrase turns; this *extends* that skip to
+  plausibly-stateless/trivial asks, speeding the warm-TTFO path the
+  `jtbd-fast-trivial-dm` gate measures *and* saving tokens. **Caveat
+  (symmetry with 6b):** the failure mode is a false negative — gating a
+  turn that *did* need memory undercuts the job's continuity criteria,
+  so this lever is likewise gated on proving no recall-quality
+  regression, not shipped blind.
 - **Right-size retain cadence.** `retainEveryNTurns=1` means every turn
   triggers background consolidation (sonnet) — the single largest
-  *invisible* subscription draw, and the engine room of tension (1).
-  Retaining every 2–3 turns roughly halves that spend. **Caveat:** the
-  every-turn setting is deliberate (the restart-memory-loss UAT), so
-  this is a real tradeoff to measure, not a free win — hence its own
-  lever, gated on proving no memory-loss regression.
+  *invisible* subscription draw (live: on the order of ~1M consolidation
+  tokens/day/agent, ~100% of an agent's LLM spend), and the engine room
+  of tension (1). Firing retain every 2–3 turns instead cuts that
+  roughly in proportion — an order-of-magnitude estimate, not derived
+  math: switchroom runs `full-session` retain mode (not chunked), so
+  each fire re-consolidates the accumulated transcript and the per-fire
+  cost grows with session length, making the real savings curve
+  non-linear. **Caveat:** the every-turn setting is deliberate (the
+  restart-memory-loss UAT), so this is a real tradeoff to measure, not a
+  free win — gated on proving no memory-loss regression.
 
 ## Speed & token budget
 
@@ -186,25 +200,31 @@ The fit argument above is about *correctness*; this section weighs
 directions:
 
 - **Foreground (per-turn).** The auto-recall hook runs on every
-  `UserPromptSubmit` (budget `mid` ~5s, 12s timeout) and injects up to
-  1024 tokens of context. This is on the critical path for warm TTFO
-  (~1.7s baseline, gated by `jtbd-fast-trivial-dm`). Anything added here
-  is felt directly.
+  substantive `UserPromptSubmit` at budget **`low`** (~1–2s, vector
+  retrieval + local rerank, **no model call**), with an 8s recall
+  timeout inside the 12s hook ceiling, injecting up to 1024 tokens of
+  context. It is on the critical path for warm TTFO (~1.7s baseline,
+  gated by `jtbd-fast-trivial-dm`), so anything added here is felt
+  directly — but it spends *no* model tokens. (`low` is operator-raisable
+  to `mid` ~5s, which adds an LLM rerank pass; switchroom does not.)
 - **Background (invisible).** Every retain triggers consolidation
-  (sonnet) the operator never sees; `retainEveryNTurns=1` makes that
-  per-turn. This is the largest *uncounted* subscription draw and the
-  engine room of invariant tension (1). Mental-model refreshes add to it.
+  (sonnet, on the subscription) the operator never sees;
+  `retainEveryNTurns=1` makes that per-turn. This is the largest
+  *uncounted* subscription draw — live, it is essentially **100% of an
+  agent's model spend** (order ~1M consolidation tokens/day/agent) — and
+  the engine room of invariant tension (1). Mental-model refreshes (when
+  refresh-enabled) add to it.
 
 Per-phase scorecard against the three axes:
 
 | Phase | UX | Speed | Tokens |
 |---|---|---|---|
-| 1. Consume observations | curated, not grab-bag | ~neutral (same index) | denser → ≤ same; may enable `mid`→`low` |
+| 1. Consume observations | curated, not grab-bag | bounded (+1 arm; rerank capped at 300) | denser → ≤ same; no model call |
 | 2. Per-agent missions/disposition | specialized recall | neutral (shapes extraction) | slight win — less noise stored |
 | 3. Directives ("corrections stick") | strong | negligible | small fixed per-turn cost if always injected |
 | 4. Chat-legible (sparse) | legible **iff** sparse | negligible | minor output tokens |
 | 5. Curated mental models | + faster *reflect* | neutral on hot path | background refresh spend; timeout risk |
-| 6a. Gate recall on need | trivial turns feel instant | **win** — skips ~5s arm | **win** — drops ~1024 tok on trivial turns |
+| 6a. Gate recall on need | trivial turns feel instant | **win** — skips ~1–2s arm | **win** — drops ~1024 tok on trivial turns |
 | 6b. Right-size retain cadence | unchanged | unchanged | **win** — ~halves background consolidation |
 
 Net read: **Phase 1(a), 2, 3, 6a** are positive-or-neutral on all three

--- a/reference/rfcs/hindsight-synthesis-layers.md
+++ b/reference/rfcs/hindsight-synthesis-layers.md
@@ -2,7 +2,7 @@
 artefact: Hindsight primitive fit — use the synthesis layers the memory job demands
 serves: jobs/remember-across-sessions.md
 relates: jobs/run-a-fleet-of-specialists.md, jobs/feel-like-a-colleague.md
-status: proposal (2026-06-18) — analysis + phased plan, not yet scheduled
+status: proposal (2026-06-18, rev. speed/token budget) — analysis + phased plan, not yet scheduled
 ---
 
 # Hindsight synthesis layers — what we run vs. what the job asks for
@@ -118,11 +118,17 @@ Ordered by leverage-per-effort. Each phase is independently shippable
 and crosses no invariant.
 
 **Phase 1 — Consume what we already synthesize (cheapest, highest leverage).**
-Include `observation` in the auto-recall types, or route recall through
-`reflect` for queries that warrant synthesis. Turns 45k of paid-for,
+Add `observation` to the auto-recall `types`. Turns 45k of paid-for,
 deduped, provenance-carrying observations from dead weight into the
-"curated, by-relevance" recall the job demands. Pure consumption change;
-no new background work.
+"curated, by-relevance" recall the job demands. Pure consumption change
+in the same `memory_units`/HNSW index — near-zero added recall latency,
+and observations are *denser* (one synthesized statement replaces N raw
+facts) so coverage improves inside the same 1024-token cap. **Do not**
+route the hot recall path through `reflect` (an agentic ~5-iteration
+loop, 300s ceiling) — that would blow warm TTFO (~1.7s) into seconds and
+multiply per-turn tokens; reflect stays reserved for explicit
+"what do you know about me" asks. See *Speed & token budget* below — this
+phase may also let the recall budget drop `mid`→`low` (faster + cheaper).
 
 **Phase 2 — Specialize each bank.** Set a per-agent `retain_mission` /
 `reflect_mission` / `disposition` from the agent's profile (a coach
@@ -136,16 +142,76 @@ verbatim, chat-legible) rather than hoping recall re-surfaces them. The
 most invariant-aligned primitive for the job's "rules set once stay
 respected / correction sticks" criteria.
 
-**Phase 4 — Make memory chat-legible.** Optionally surface a terse
-"remembered: X" / "updated what I know about Y" line so recall and
-consolidation stop being invisible — closing tension (1) and (2). The
-`consolidation.completed` webhook can drive the update side without
-polling.
+**Phase 4 — Make memory chat-legible (sparse, not per-turn).** Surface a
+terse "remembered: X" / "updated what I know about Y" line so recall and
+consolidation stop being invisible — closing tension (1) and (2). **This
+must be sparse and material-only**, never default-on-every-turn:
+the job lists "regurgitating old facts unprompted just to prove it
+remembered" as a top anti-pattern, so a per-turn legibility line would
+*become* that anti-pattern. Surface only on a genuine store/correct, or
+on request. The `consolidation.completed` webhook can drive the update
+side without polling.
 
-**Phase 5 — Curated mental models per specialist.** Operator-curated, or
-agent-proposes → operator-confirms in chat, for specialists that earn a
-pinned model (the gap behind "Hindsight doesn't create models as
-needed"). Deliberately *not* autonomous creation (tension 3).
+**Phase 5 — Curated mental models per specialist (selective).**
+Operator-curated, or agent-proposes → operator-confirms in chat, for
+specialists that earn a pinned model (the gap behind "Hindsight doesn't
+create models as needed"). Deliberately *not* autonomous creation
+(tension 3). Curate **selectively** — each model adds
+post-consolidation refresh spend (bounded ~2048 tokens, but can hit the
+300s reflect timeout, which we already see fail ~9×), so more models is
+more invisible background cost. Their upside is real on the *explicit*
+reflect path (fresh models let reflect short-circuit the lower tiers →
+faster), but they do not speed the hot recall path.
+
+**Phase 6 — Two near-free hot-path levers (UX + speed + tokens).** Not
+synthesis-tier work, but the largest responsiveness/cost wins and they
+cross no invariant:
+- **Gate recall on need.** Recall fires on *every* turn — a trivial
+  "what time is it" still pays a ~5s recall arm + up to 1024 injected
+  tokens it never uses. Skipping recall for plausibly-stateless/trivial
+  asks speeds exactly the warm-TTFO path the `jtbd-fast-trivial-dm` gate
+  measures *and* saves tokens.
+- **Right-size retain cadence.** `retainEveryNTurns=1` means every turn
+  triggers background consolidation (sonnet) — the single largest
+  *invisible* subscription draw, and the engine room of tension (1).
+  Retaining every 2–3 turns roughly halves that spend. **Caveat:** the
+  every-turn setting is deliberate (the restart-memory-loss UAT), so
+  this is a real tradeoff to measure, not a free win — hence its own
+  lever, gated on proving no memory-loss regression.
+
+## Speed & token budget
+
+The fit argument above is about *correctness*; this section weighs
+*cost*. Two latency/token surfaces matter, and they pull in opposite
+directions:
+
+- **Foreground (per-turn).** The auto-recall hook runs on every
+  `UserPromptSubmit` (budget `mid` ~5s, 12s timeout) and injects up to
+  1024 tokens of context. This is on the critical path for warm TTFO
+  (~1.7s baseline, gated by `jtbd-fast-trivial-dm`). Anything added here
+  is felt directly.
+- **Background (invisible).** Every retain triggers consolidation
+  (sonnet) the operator never sees; `retainEveryNTurns=1` makes that
+  per-turn. This is the largest *uncounted* subscription draw and the
+  engine room of invariant tension (1). Mental-model refreshes add to it.
+
+Per-phase scorecard against the three axes:
+
+| Phase | UX | Speed | Tokens |
+|---|---|---|---|
+| 1. Consume observations | curated, not grab-bag | ~neutral (same index) | denser → ≤ same; may enable `mid`→`low` |
+| 2. Per-agent missions/disposition | specialized recall | neutral (shapes extraction) | slight win — less noise stored |
+| 3. Directives ("corrections stick") | strong | negligible | small fixed per-turn cost if always injected |
+| 4. Chat-legible (sparse) | legible **iff** sparse | negligible | minor output tokens |
+| 5. Curated mental models | + faster *reflect* | neutral on hot path | background refresh spend; timeout risk |
+| 6a. Gate recall on need | trivial turns feel instant | **win** — skips ~5s arm | **win** — drops ~1024 tok on trivial turns |
+| 6b. Right-size retain cadence | unchanged | unchanged | **win** — ~halves background consolidation |
+
+Net read: **Phase 1(a), 2, 3, 6a** are positive-or-neutral on all three
+axes (1(a) and 6a are close to free wins). **Phase 4** is UX-positive
+only if kept sparse. **Phase 5** trades background tokens for
+explicit-reflect speed — curate selectively. **Phase 6b** is the biggest
+token lever but a measured tradeoff, not a free win.
 
 ## Verdict check (the four-part rule)
 
@@ -153,9 +219,10 @@ needed"). Deliberately *not* autonomous creation (tension 3).
   job and the specialist job.
 - **Satisfies the job spec?** Moves recall from the job's *bad* column
   (grab-bag/raw) toward its *good* column (curated/legible/by-relevance).
-- **Passes the three principle checks?** Defaults: phases 1–3 are config
-  defaults, no operator assembly. Docs: behavior improves without new
-  user-facing concepts. Consistency: same vault/config cascade.
+- **Passes the three principle checks?** Defaults: phases 1–3 and 6 are
+  config defaults, no operator assembly. Docs: behavior improves without
+  new user-facing concepts. Consistency: same vault/config cascade.
+  Speed/tokens: net-positive or measured (see *Speed & token budget*).
 - **Crosses an invariant?** No — each phase is shaped to avoid the
   tensions named above (no autonomous self-writes; legibility added, not
   removed).


### PR DESCRIPTION
## Summary

Follow-up to #2420. The original RFC argued memory-primitive *fit* but didn't weigh *cost*. This folds in a UX / speed / token-usage review.

## Changes
- **New "Speed & token budget" section** — frames the two surfaces (foreground per-turn recall on the warm-TTFO ~1.7s path vs invisible background consolidation) and a per-phase scorecard across the three axes.
- **Phase 1 corrected (the important one):** consume observations by adding the `observation` recall type **only**. Explicitly do **not** route the hot recall path through `reflect` (agentic ~5-iteration loop, 300s ceiling) — that would blow TTFO into seconds and multiply per-turn tokens. Notes it may enable dropping the recall budget `mid`→`low` (faster + cheaper).
- **Phase 4 re-scoped** to sparse/material-only legibility — a per-turn "remembered: X" line would *be* the job's "regurgitating old facts unprompted" anti-pattern.
- **Phase 5 gated** to selective curation (each model adds background refresh spend + 300s-timeout risk; the speed upside is on the explicit reflect path, not the hot recall path).
- **Phase 6 (new):** two near-free hot-path levers — gate recall on need (skip the ~5s arm + 1024 tokens on trivial turns) and right-size retain cadence (~halves background consolidation; flagged as a measured tradeoff vs the restart-memory-loss UAT, not a free win).

## Scope
Docs-only; no code/job/invariant change. Sharpens an already-merged design record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)