### PR TITLE
feat(memory): opt-out cascade for observation recall + trivial-skip (on by default)

### DIFF
--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -332,6 +332,21 @@ export HINDSIGHT_RECALL_CACHE_TTL_SECS={{hindsightRecallCacheTtlSecs}}
 {{#if (isNumber hindsightRecallMinOverlap)}}
 export HINDSIGHT_RECALL_MIN_OVERLAP={{hindsightRecallMinOverlap}}
 {{/if}}
+# Recall fact types (memory.recall.types cascade). Switchroom default is
+# world,experience,observation (the synthesized `observation` tier is ON
+# by default, set in the plugin settings.json). Export only when the
+# operator OPTED OUT via switchroom.yaml — comma-separated; the env value
+# wins over settings.json. e.g. ["world","experience"] drops
+# observation-backed recall for this agent.
+{{#if hindsightRecallTypes}}
+export HINDSIGHT_RECALL_TYPES="{{hindsightRecallTypes}}"
+{{/if}}
+# Trivial-turn recall skip (memory.recall.skip_trivial cascade). On by
+# default (plugin settings.json). Export only when the operator overrode
+# it; set false to always run recall.
+{{#if hindsightRecallSkipTrivial}}
+export HINDSIGHT_RECALL_SKIP_TRIVIAL={{hindsightRecallSkipTrivial}}
+{{/if}}
 # PR6 — supergroup-mode topic tagging. JSON map of {alias: thread_id}
 # parsed by retain.py + recall.py to (a) stamp chat_id/thread_id/topic_alias
 # into retained memory metadata and (b) emit a "Current topic: …" preamble

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2225,19 +2225,19 @@ function applyHindsightSettingsOverrides(pluginDestPath: string): void {
   // "grab-bag" the remember-across-sessions job calls bad. An A/B on the
   // test-harness bank showed observations rank top, reconcile contradictory
   // raw facts, and dedup near-duplicates, at neutral recall latency and
-  // zero model spend (recall is retrieval + local rerank). Switchroom
-  // default; not yet wired to a memory.recall.types yaml cascade (a
-  // per-agent override would need a schema field + HINDSIGHT_RECALL_TYPES
-  // env export — tracked as a follow-up).
+  // zero model spend (recall is retrieval + local rerank). This is the
+  // ON-BY-DEFAULT value for every agent on every install; operators opt
+  // OUT per-agent (or fleet-wide under `defaults`) via memory.recall.types
+  // in switchroom.yaml — start.sh exports HINDSIGHT_RECALL_TYPES only when
+  // overridden, and the env value wins over this settings.json default.
   settings.recallTypes = ["world", "experience", "observation"];
   // Phase 6a: on top of the ack-skip, skip recall on plausibly-stateless
   // trivial turns (time/date/day, bare greetings) — saves the ~1-2s
   // recall arm + up to ~1024 injected tokens on turns that never need
   // user memory. Conservative + guarded against any personal/stateful
-  // signal (see recall.py `_is_trivial_stateless`). recall.py honours the
-  // `recallSkipTrivial` setting, so the off-switch today is setting it
-  // false in the agent's plugin settings.json; a memory.recall.skip_trivial
-  // yaml cascade is a tracked follow-up.
+  // signal (see recall.py `_is_trivial_stateless`). On by default; operators
+  // opt OUT via memory.recall.skip_trivial=false in switchroom.yaml
+  // (exported as HINDSIGHT_RECALL_SKIP_TRIVIAL only when overridden).
   settings.recallSkipTrivial = true;
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
 }
@@ -2296,6 +2296,10 @@ interface BuildWorkspaceContextArgs {
   hindsightRecallMaxMemories: number | undefined;
   hindsightRecallCacheTtlSecs: number | undefined;
   hindsightRecallMinOverlap: number | undefined;
+  // Phase 1 / 6a opt-out cascade. Comma-joined types + stringified bool,
+  // each undefined unless the operator overrode the switchroom default.
+  hindsightRecallTypes?: string;
+  hindsightRecallSkipTrivial?: string;
   // PR6 — supergroup-mode topic tagging. JSON map of {alias: thread_id}
   // injected as HINDSIGHT_TOPIC_ALIASES_JSON so retain.py can resolve
   // numeric thread_ids to human alias names in memory metadata.
@@ -2330,6 +2334,8 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallMaxMemories,
     hindsightRecallCacheTtlSecs,
     hindsightRecallMinOverlap,
+    hindsightRecallTypes,
+    hindsightRecallSkipTrivial,
     hindsightTopicAliasesJson,
     hindsightTopicFilterMode,
   } = args;
@@ -2406,6 +2412,8 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallMaxMemories,
     hindsightRecallCacheTtlSecs,
     hindsightRecallMinOverlap,
+    hindsightRecallTypes,
+    hindsightRecallSkipTrivial,
     // PR6 — only emit the env-export blocks when we actually have a
     // value, so `{{#if hindsightTopicAliasesJsonQ}}` and friends are
     // false-y for fleet-shared / DM agents (the dominant case).
@@ -2997,6 +3005,17 @@ export function scaffoldAgent(
   // means "use the plugin's settings.json default of 0.0" (i.e. gate
   // disabled, current behaviour). Set 0.10–0.20 to start filtering.
   const hindsightRecallMinOverlap = agentConfig.memory?.recall?.min_overlap;
+  // Phase 1 / 6a opt-out: undefined unless the operator overrode the
+  // switchroom default (observations on, trivial-skip on). Exported only
+  // when set (see start.sh.hbs), so an unset value leaves the on-by-default
+  // settings.json override in force.
+  const hindsightRecallTypes = agentConfig.memory?.recall?.types?.length
+    ? agentConfig.memory.recall.types.join(",")
+    : undefined;
+  const hindsightRecallSkipTrivial =
+    agentConfig.memory?.recall?.skip_trivial === undefined
+      ? undefined
+      : String(agentConfig.memory.recall.skip_trivial);
 
   // PR6 — supergroup-mode topic tagging. Build the {alias: thread_id}
   // JSON for retain.py + recall.py to resolve numeric thread_ids to
@@ -3039,6 +3058,8 @@ export function scaffoldAgent(
     hindsightRecallMaxMemories,
     hindsightRecallCacheTtlSecs,
     hindsightRecallMinOverlap,
+    hindsightRecallTypes,
+    hindsightRecallSkipTrivial,
     hindsightTopicAliasesJson,
     hindsightTopicFilterMode,
   });
@@ -4974,6 +4995,17 @@ export function reconcileAgent(
   const hindsightRecallMaxMemories = agentConfig.memory?.recall?.max_memories;
   const hindsightRecallCacheTtlSecs = agentConfig.memory?.recall?.cache_ttl_secs;
   const hindsightRecallMinOverlap = agentConfig.memory?.recall?.min_overlap;
+  // Phase 1 / 6a opt-out: undefined unless the operator overrode the
+  // switchroom default (observations on, trivial-skip on). Exported only
+  // when set (see start.sh.hbs), so an unset value leaves the on-by-default
+  // settings.json override in force.
+  const hindsightRecallTypes = agentConfig.memory?.recall?.types?.length
+    ? agentConfig.memory.recall.types.join(",")
+    : undefined;
+  const hindsightRecallSkipTrivial =
+    agentConfig.memory?.recall?.skip_trivial === undefined
+      ? undefined
+      : String(agentConfig.memory.recall.skip_trivial);
   // PR6 — mirror scaffoldAgent's computation. Both paths feed
   // buildWorkspaceContext, so the template sees identical shape.
   const topicAliases = agentConfig.channels?.telegram?.topic_aliases;
@@ -5042,6 +5074,8 @@ export function reconcileAgent(
       hindsightRecallMaxMemories,
       hindsightRecallCacheTtlSecs,
       hindsightRecallMinOverlap,
+      hindsightRecallTypes,
+      hindsightRecallSkipTrivial,
       // PR6 — supergroup-mode topic tagging env vars. Same gate as
       // buildWorkspaceContext: only emit the shell-quoted JSON when
       // we actually have a topic_aliases map.
@@ -5716,6 +5750,8 @@ export function reconcileAgent(
       hindsightRecallMaxMemories,
       hindsightRecallCacheTtlSecs,
       hindsightRecallMinOverlap,
+      hindsightRecallTypes,
+      hindsightRecallSkipTrivial,
       hindsightTopicAliasesJson,
       hindsightTopicFilterMode,
     });

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -383,8 +383,9 @@ export function mergeAgentConfig(
   // dropping max_memories. The doc table at docs/configuration.md:32 says
   // "per-field merge" implying deep behaviour; cascade users expected
   // overriding one knob to leave the rest in place. Now `recall` deep-merges
-  // (one level — sufficient because recall has only scalar children) and
-  // every other top-level memory key keeps the existing override behaviour.
+  // (one level — per-key replace; an override's `types` array replaces the
+  // base array wholesale, which is the intended semantics for that field)
+  // and every other top-level memory key keeps the existing override behaviour.
   if (defaults.memory || merged.memory) {
     const base = defaults.memory ?? {};
     const override = merged.memory ?? {};

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -374,6 +374,26 @@ export const AgentMemorySchema = z
             "current behaviour). Try 0.10–0.20 to start; observe the " +
             "`overlap_dropped` field via `switchroom memory recall-log`.",
           ),
+        types: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Hindsight fact types to recall. Switchroom default is " +
+            "[\"world\", \"experience\", \"observation\"] — the synthesized " +
+            "`observation` tier is on by default. Set to " +
+            "[\"world\", \"experience\"] to opt out of observation-backed " +
+            "recall for this agent (or fleet-wide under defaults).",
+          ),
+        skip_trivial: z
+          .boolean()
+          .optional()
+          .describe(
+            "Skip recall on plausibly-stateless trivial turns (time/date/" +
+            "greeting). Switchroom default true — saves the recall arm + " +
+            "injected tokens on turns that never need memory, guarded so it " +
+            "never skips a turn that references user/project/session state. " +
+            "Set false to always run recall.",
+          ),
         topic_filter_mode: z
           .enum(["soft-preamble", "hard-filter"])
           .optional()

--- a/tests/scaffold.recall-optout-cascade.test.ts
+++ b/tests/scaffold.recall-optout-cascade.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * Opt-out cascade for the on-by-default recall changes (Phase 1 + 6a).
+ * The synthesized `observation` tier and the trivial-turn skip are ON by
+ * default for every agent (written into the plugin settings.json by
+ * applyHindsightSettingsOverrides). An operator opts OUT per-agent (or
+ * fleet-wide under `defaults`) via memory.recall.types /
+ * memory.recall.skip_trivial — which scaffold exports into start.sh as
+ * HINDSIGHT_RECALL_TYPES / HINDSIGHT_RECALL_SKIP_TRIVIAL ONLY when set,
+ * and the env value wins over the settings.json default at plugin load.
+ */
+describe("recall opt-out cascade (Phase 1 + 6a)", () => {
+  let tmpDir: string;
+  let telegram: TelegramConfig;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `recall-optout-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    telegram = { bot_token: "t", forum_chat_id: "c" };
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function startShFor(agentMemoryRecall: Record<string, unknown> | undefined): string {
+    const config: SwitchroomConfig = {
+      agents: agentMemoryRecall
+        ? { probe: { memory: { recall: agentMemoryRecall } } as never }
+        : {},
+      memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+      telegram,
+    } as SwitchroomConfig;
+    const res = scaffoldAgent("probe", config.agents.probe ?? {}, tmpDir, telegram, config);
+    return readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+  }
+
+  it("default (no override) emits NEITHER env export — settings.json default stays in force", () => {
+    const startSh = startShFor(undefined);
+    expect(startSh).not.toMatch(/export HINDSIGHT_RECALL_TYPES=/);
+    expect(startSh).not.toMatch(/export HINDSIGHT_RECALL_SKIP_TRIVIAL=/);
+  });
+
+  it("opt out of observations: memory.recall.types exports a comma-joined HINDSIGHT_RECALL_TYPES", () => {
+    const startSh = startShFor({ types: ["world", "experience"] });
+    expect(startSh).toMatch(/export HINDSIGHT_RECALL_TYPES="world,experience"/);
+  });
+
+  it("opt out of trivial-skip: memory.recall.skip_trivial=false exports the false env (not omitted)", () => {
+    const startSh = startShFor({ skip_trivial: false });
+    // The bool-false case must still emit the export — otherwise the
+    // settings.json default (true) would silently win and the opt-out fail.
+    expect(startSh).toMatch(/export HINDSIGHT_RECALL_SKIP_TRIVIAL=false/);
+  });
+
+  it("skip_trivial=true also exports (explicit re-affirm is harmless)", () => {
+    const startSh = startShFor({ skip_trivial: true });
+    expect(startSh).toMatch(/export HINDSIGHT_RECALL_SKIP_TRIVIAL=true/);
+  });
+});

--- a/vendor/hindsight-memory/scripts/lib/config.py
+++ b/vendor/hindsight-memory/scripts/lib/config.py
@@ -98,6 +98,15 @@ ENV_OVERRIDES = {
     # [0.0, 1.0]. Set by start.sh from agents.<name>.memory.recall.min_overlap
     # (cascading through defaults). 0.0 = off (current behaviour).
     "HINDSIGHT_RECALL_MIN_OVERLAP": ("recallMinOverlap", float),
+    # Switchroom-local: recall fact types (comma-separated). Set by start.sh
+    # from agents.<name>.memory.recall.types only when the operator overrode
+    # the switchroom default (world,experience,observation) — i.e. the
+    # opt-out path for the synthesized `observation` tier.
+    "HINDSIGHT_RECALL_TYPES": ("recallTypes", list),
+    # Switchroom-local: trivial-turn recall skip (Phase 6a). Set by start.sh
+    # from agents.<name>.memory.recall.skip_trivial only on override; the
+    # switchroom default is on (recall.py falls back to True).
+    "HINDSIGHT_RECALL_SKIP_TRIVIAL": ("recallSkipTrivial", bool),
     "HINDSIGHT_RECALL_MAX_QUERY_CHARS": ("recallMaxQueryChars", int),
     "HINDSIGHT_RECALL_CONTEXT_TURNS": ("recallContextTurns", int),
     "HINDSIGHT_API_PORT": ("apiPort", int),
@@ -121,6 +130,9 @@ def _cast_env(value: str, typ):
             return int(value)
         if typ is float:
             return float(value)
+        if typ is list:
+            # Comma-separated → list of trimmed, non-empty strings.
+            return [t.strip() for t in value.split(",") if t.strip()]
         return value
     except (ValueError, AttributeError):
         return None

--- a/vendor/hindsight-memory/tests/test_config.py
+++ b/vendor/hindsight-memory/tests/test_config.py
@@ -42,7 +42,7 @@ class TestLoadConfig:
         cfg = load_config()
         assert cfg["autoRecall"] is True
         assert cfg["autoRetain"] is True
-        assert cfg["recallBudget"] == "mid"
+        assert cfg["recallBudget"] == "low"
         assert cfg["retainEveryNTurns"] == 10
 
     def test_settings_json_overrides_defaults(self, tmp_path, monkeypatch):
@@ -75,7 +75,7 @@ class TestLoadConfig:
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
         (tmp_path / "settings.json").write_text("not valid json{{")
         cfg = load_config()
-        assert cfg["recallBudget"] == "mid"  # default still applies
+        assert cfg["recallBudget"] == "low"  # default still applies
 
     def test_null_values_in_settings_json_not_applied(self, tmp_path, monkeypatch):
         monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
@@ -112,7 +112,7 @@ class TestLoadConfig:
         # HOME points to tmp_path where no .hindsight/claude-code.json exists
         monkeypatch.setenv("HOME", str(tmp_path))
         cfg = load_config()
-        assert cfg["recallBudget"] == "mid"  # default
+        assert cfg["recallBudget"] == "low"  # default
 
     def test_env_var_wins_over_user_config(self, tmp_path, monkeypatch):
         plugin_root = tmp_path / "plugin"


### PR DESCRIPTION
## Summary

Follow-up to #2425. That PR made **observation-backed recall (Phase 1)** and the **trivial-turn recall skip (Phase 6a)** the on-by-default behaviour for every agent on every install. This wires the **opt-out path** so the contract is *"on by default, opt out only"* (the reviewer on #2425 flagged the cascade wasn't wired).

## Changes
- **`schema.ts`** — `memory.recall` gains `types: string[]` and `skip_trivial: boolean` (both optional).
- **`scaffold.ts`** — computes `HINDSIGHT_RECALL_TYPES` (comma-joined) + `HINDSIGHT_RECALL_SKIP_TRIVIAL` (stringified) from the config cascade; `undefined` unless overridden.
- **`start.sh.hbs`** — exports each **only when set** (mirrors the `min_overlap`/`topic_filter_mode` conditional-export precedent). The `skip_trivial` value is stringified so the **bool-`false` opt-out still emits** — a bare `{{#if bool}}` would drop it and the settings.json default (true) would silently win.
- **`config.py`** — `ENV_OVERRIDES` gains `HINDSIGHT_RECALL_TYPES` (new `list` cast) + `HINDSIGHT_RECALL_SKIP_TRIVIAL` (bool); env wins over settings.json.

**Default stays ON** (no env exported → settings.json default in force). Operators opt out per-agent or fleet-wide under `defaults.memory.recall`.

Also fixes 3 **pre-existing** stale assertions in the vendored `test_config.py` (`recallBudget "mid" → "low"` — switchroom's vendored default has been `low`; these failed on `main` before this PR and aren't in switchroom CI).

## Opt-out, concretely
```yaml
# switchroom.yaml — drop observation-backed recall + disable trivial-skip for one agent
agents:
  myagent:
    memory:
      recall:
        types: ["world", "experience"]   # omit "observation"
        skip_trivial: false
# or fleet-wide under defaults.memory.recall
```

## Test plan
- [x] vitest: opt-out cascade — start.sh emits comma-joined types, emits `=false` for the bool opt-out (the trap), omits both when unset. Default agent emits neither.
- [x] config.py: env override casts the list + bool and wins over settings.json default (verified).
- [x] tsc clean; 289 plugin python tests green (incl. the 3 fixed stale ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)