### PR TITLE
feat(context): surface per-agent context headroom (spec + gateway + doctor)

### DIFF
--- a/reference/rfcs/context-headroom-surface.md
+++ b/reference/rfcs/context-headroom-surface.md
@@ -1,0 +1,85 @@
+---
+artefact: context-headroom visibility surface
+serves: jobs/restart-and-know-what-im-running.md
+relates: vision.md (pillar 2 on-leash / pillar 3 predictable)
+---
+
+# Context-headroom visibility surface
+
+Make each agent's working-context occupancy and headroom-to-compaction
+visible in `switchroom status`, `switchroom doctor`, and the web
+dashboard — turning the predictability won by `ENABLE_TOOL_SEARCH=true`
+(v0.15.40, ~40% baseline cut) into something the operator can see and
+trust.
+
+## Why
+
+After v0.15.40 a fresh agent sits at ~47k of a 300k cap — predictable,
+but **invisible**. The operator can't see how close an agent is to a
+`/compact`, or catch a context-bloated agent before it stalls mid-task.
+
+- **Pillar 2 (you hold the leash).** The vision asks for *"awareness +
+  control, not a tool-call log to babysit."* At-a-glance context headroom
+  is exactly that awareness.
+- **Pillar 3 (subscription-honest & predictable).** Makes "the plan is
+  the ceiling" *legible* — you see the ceiling and each agent's distance
+  from it, instead of inferring it.
+- **Pillar 4 (always available).** A near-cap agent is about to compact
+  (a visible stall); surfacing the band lets the operator act first.
+
+Serves `jobs/restart-and-know-what-im-running.md` — the "know what's
+running" awareness job. Crosses no invariant: pure observability.
+
+## What it surfaces (per agent)
+
+- **occupancy** — current live working-context tokens: the latest
+  usage-bearing assistant turn's `input + cache_read + cache_creation`
+  (the prefix the model re-reads each turn ≈ window fill). This is the
+  *same* metric proactive-compaction reads (`gateway.ts:3000`), so the
+  surface can never disagree with what actually triggers a `/compact`.
+- **cap** — `session.max_context_tokens` (300k on this fleet; `null`
+  when unset → occupancy shown without a ratio, native compaction only).
+- **headroom / pct** — `cap − occupancy` and `occupancy / cap`.
+- **state** — `ok` / `tight` (≥ `TIGHT_FRACTION`, default 0.8) /
+  `unknown` (no snapshot yet).
+
+Example: `marko  context 250k/300k (83% · tight)` · `clerk 47k/300k (16%)`.
+
+## Data path (no new computation, consistency-safe)
+
+The gateway already computes occupancy at the turn-end idle gate for
+proactive-compaction. P1 writes that value (and the resolved cap) to a
+snapshot at `<agentDir>/context-occupancy.json` on every idle pass —
+crucially **even when no cap is configured** (proactive-compact returns
+early without a cap; the snapshot must not). Host surfaces read the
+snapshot (via `docker exec … cat`, the same way `status` already runs
+`claude mcp list` per agent). No per-turn model cost; reads a value the
+gateway already has.
+
+## Surfaces (consistent shape, phased)
+
+1. **P1 — gateway writer.** `context-occupancy.ts`: pure
+   `buildContextOccupancy(occupancy, cap)` → snapshot + best-effort
+   `writeContextOccupancySnapshot`. Called beside `maybeProactiveCompact`.
+2. **P2 — `switchroom doctor`.** A "Context" section that WARNs agents in
+   the `tight` band (mirrors the connection-health section). And a
+   `switchroom status` per-agent context column.
+3. **P3 — web dashboard.** Per-agent context gauge on the fleet view.
+4. **P4 (optional) — Telegram `/status`.** A context row in the Health
+   block (reuses `runAllProbes`, like `probeConnections`).
+
+## Principle checks
+
+- **Docs test:** `context 47k/300k (16%)` is self-explanatory. ✅
+- **Defaults test:** works on a fresh install — occupancy already exists;
+  cap falls back to native (shown as occupancy only). ✅
+- **Consistency test:** same row/section shape as the existing health
+  surfaces + the connection-health probe. ✅
+
+## Non-goals / risk
+
+- Does **not** change compaction behavior — pure observability.
+- No new model calls; reads cached occupancy (no per-turn cost).
+- Read-only; crosses no invariant (claude-native / on-leash /
+  single-tenant untouched). Snapshot is best-effort: a missing/stale file
+  reads as `unknown`, never an error.

--- a/src/cli/doctor-context.ts
+++ b/src/cli/doctor-context.ts
@@ -1,0 +1,96 @@
+/**
+ * Context-headroom doctor probe (RFC reference/rfcs/context-headroom-surface.md).
+ *
+ * The gateway writes a per-agent `/state/agent/context-occupancy.json` snapshot
+ * at each turn-end idle gate (telegram-plugin/gateway/context-occupancy.ts).
+ * This probe reads it (via the injected reader — `docker exec … cat`, since the
+ * agent state dir is 0700 agent-owned) and reports each agent's working-context
+ * headroom, so the operator can see how close an agent is to a `/compact`.
+ *
+ * Pure renderer + injectable reader, mirroring doctor-mcp-secrets. Read-only;
+ * a missing/stale/malformed snapshot reads as `skip` (not yet computed / agent
+ * idle since boot), never a failure.
+ */
+
+import type { SwitchroomConfig } from "../config/schema.js";
+import type { CheckStatus } from "./doctor-status.js";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  detail?: string;
+  fix?: string;
+}
+
+/** Snapshot shape written by the gateway (kept in sync with context-occupancy.ts). */
+export interface ContextSnapshot {
+  occupancy: number;
+  cap: number | null;
+  headroom: number | null;
+  pct: number | null;
+  state: "ok" | "tight" | "unknown";
+  computedAt: number;
+}
+
+export type SnapshotRead =
+  | { kind: "ok"; snapshot: ContextSnapshot }
+  | { kind: "absent" } // agent down / no snapshot yet
+  | { kind: "unreadable"; msg: string };
+
+export interface ContextProbeDeps {
+  /** Reads an agent's context snapshot. Injected; default = docker exec cat. */
+  readSnapshot?: (agent: string) => Promise<SnapshotRead>;
+}
+
+function fmtK(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k` : `${n}`;
+}
+
+/** Pure: one agent's snapshot → a CheckResult row. */
+export function contextRow(agent: string, read: SnapshotRead): CheckResult {
+  const name = `context:${agent}`;
+  if (read.kind === "absent") {
+    return { name, status: "skip", detail: "no snapshot yet (agent idle since boot, or stopped)" };
+  }
+  if (read.kind === "unreadable") {
+    return { name, status: "skip", detail: read.msg };
+  }
+  const s = read.snapshot;
+  if (s.state === "unknown") {
+    return { name, status: "skip", detail: "occupancy not yet measured" };
+  }
+  if (s.cap == null || s.pct == null) {
+    // No cap configured — show occupancy, nothing to be tight against.
+    return { name, status: "ok", detail: `${fmtK(s.occupancy)} tok (no cap — native compaction)` };
+  }
+  const pctLabel = `${Math.round(s.pct * 100)}%`;
+  const detail = `${fmtK(s.occupancy)}/${fmtK(s.cap)} (${pctLabel})`;
+  if (s.state === "tight") {
+    return {
+      name,
+      status: "warn",
+      detail: `${detail} — tight; a /compact is near`,
+      fix: `Working context is ${pctLabel} of the cap. Normal if mid-large-task (it compacts automatically); if persistent, consider raising session.max_context_tokens or trimming this agent's tool/prose surface.`,
+    };
+  }
+  return { name, status: "ok", detail };
+}
+
+/**
+ * Read every agent's context snapshot and render a row each. Agents with no
+ * snapshot (idle/stopped) skip cleanly.
+ */
+export async function runContextChecks(
+  config: SwitchroomConfig,
+  deps: ContextProbeDeps = {},
+): Promise<CheckResult[]> {
+  const agents = Object.keys(config.agents ?? {});
+  if (agents.length === 0) return [];
+  const read =
+    deps.readSnapshot ??
+    (async (): Promise<SnapshotRead> => ({ kind: "absent" }));
+  const results = await Promise.all(
+    agents.sort().map(async (a) => contextRow(a, await read(a))),
+  );
+  return results;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -39,6 +39,7 @@ import { runCronSessionChecks } from "./doctor-cron-session.js";
 import { runMicrosoftChecks } from "./doctor-microsoft.js";
 import { runNotionChecks } from "./doctor-notion.js";
 import { runMcpSecretChecks } from "./doctor-mcp-secrets.js";
+import { runContextChecks } from "./doctor-context.js";
 import { runCredentialsMigrationChecks } from "./doctor-credentials-migration.js";
 import { runSecretAccessChecks } from "./doctor-secret-access.js";
 import { runInlinedSecretChecks } from "./doctor-inlined-secrets.js";
@@ -2787,6 +2788,31 @@ export function registerDoctorCommand(program: Command): void {
           {
             title: "MCP Connections (auth)",
             results: await runMcpSecretChecks(config, { vaultAclReader }),
+          },
+          {
+            title: "Context Headroom",
+            results: await runContextChecks(config, {
+              readSnapshot: async (agent) => {
+                // Snapshot lives at the agent's 0700 state dir → read via
+                // docker exec (mirrors how status queries agents).
+                try {
+                  const { execFileSync } = await import("node:child_process");
+                  const out = execFileSync(
+                    "docker",
+                    ["exec", `switchroom-${agent}`, "cat", "/state/agent/context-occupancy.json"],
+                    { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: 5000 },
+                  );
+                  return { kind: "ok", snapshot: JSON.parse(out) };
+                } catch (err) {
+                  const msg = (err as Error).message ?? String(err);
+                  // No file / container down → absent (skip), not a failure.
+                  if (/No such|cannot|not running|exited|No such container/i.test(msg)) {
+                    return { kind: "absent" };
+                  }
+                  return { kind: "unreadable", msg: `snapshot read failed: ${msg}` };
+                }
+              },
+            }),
           },
           { title: "MFF Skill", results: await checkMff(passphrase, vaultPath, config) },
           { title: "Webkite", results: runWebkiteChecks(config) },

--- a/telegram-plugin/gateway/context-occupancy.ts
+++ b/telegram-plugin/gateway/context-occupancy.ts
@@ -1,0 +1,91 @@
+/**
+ * Context-headroom snapshot (RFC reference/rfcs/context-headroom-surface.md).
+ *
+ * The gateway already computes working-context occupancy at the turn-end idle
+ * gate for proactive-compaction (gateway.ts ~3000). This module turns that
+ * value into a small on-disk snapshot the host surfaces (`switchroom status` /
+ * `doctor` / web) read, so the operator can SEE each agent's headroom-to-
+ * compaction — the predictability won by ENABLE_TOOL_SEARCH=true made visible.
+ *
+ * Pure + side-effect-light so it's unit-testable; the write is best-effort and
+ * never throws (a missing snapshot reads as `unknown`, never an error).
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Filename written under the agent's state dir. Shared with the host reader. */
+export const CONTEXT_OCCUPANCY_FILENAME = "context-occupancy.json";
+
+/** Occupancy ≥ this fraction of the cap → "tight" (compaction imminent). */
+export const TIGHT_FRACTION = 0.8;
+
+export type ContextState = "ok" | "tight" | "unknown";
+
+export interface ContextOccupancy {
+  /** Live working-context tokens (latest turn input + cache_read + cache_creation). */
+  occupancy: number;
+  /** session.max_context_tokens, or null when unset (native compaction only). */
+  cap: number | null;
+  /** cap - occupancy, or null when no cap. */
+  headroom: number | null;
+  /** occupancy / cap (0..1+), or null when no cap. */
+  pct: number | null;
+  /** ok / tight / unknown. `unknown` only when occupancy is unmeasurable. */
+  state: ContextState;
+  /** epoch ms (host/container clock) when computed. */
+  computedAt: number;
+}
+
+/**
+ * Build the snapshot from a measured occupancy + the resolved cap. Pure.
+ *   - cap null → no ratio; state "ok" (occupancy known, just no ceiling set).
+ *   - occupancy < 0 / NaN → "unknown".
+ */
+export function buildContextOccupancy(
+  occupancy: number,
+  cap: number | null | undefined,
+  now: number,
+): ContextOccupancy {
+  if (!Number.isFinite(occupancy) || occupancy < 0) {
+    return { occupancy: 0, cap: cap ?? null, headroom: null, pct: null, state: "unknown", computedAt: now };
+  }
+  const c = cap != null && cap > 0 ? cap : null;
+  if (c == null) {
+    return { occupancy, cap: null, headroom: null, pct: null, state: "ok", computedAt: now };
+  }
+  const pct = occupancy / c;
+  return {
+    occupancy,
+    cap: c,
+    headroom: c - occupancy,
+    pct,
+    state: pct >= TIGHT_FRACTION ? "tight" : "ok",
+    computedAt: now,
+  };
+}
+
+/**
+ * Write `<stateDir>/context-occupancy.json`. Best-effort — callers wrap in
+ * try/catch but this also swallows internally so a write failure never
+ * disrupts the turn-end gate.
+ */
+export function writeContextOccupancySnapshot(
+  stateDir: string,
+  snapshot: ContextOccupancy,
+  deps?: {
+    mkdir?: (p: string, o: { recursive: true }) => void;
+    writeFile?: (p: string, d: string) => void;
+  },
+): void {
+  try {
+    const path = join(stateDir, CONTEXT_OCCUPANCY_FILENAME);
+    (deps?.mkdir ?? ((p, o) => mkdirSync(p, o)))(stateDir, { recursive: true });
+    (deps?.writeFile ?? ((p, d) => writeFileSync(p, d)))(
+      path,
+      JSON.stringify(snapshot, null, 2) + "\n",
+    );
+  } catch {
+    /* best-effort — never break the turn-end gate */
+  }
+}

--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -293,6 +293,7 @@ import { refreshBanner } from '../slot-banner-driver.js'
 import { loadConfig as loadSwitchroomConfig, findConfigFile as findSwitchroomConfigFile } from '../../src/config/loader.js'; import { resolveAgentConfig } from '../../src/config/merge.js'
 import { resolveOutboundTopic as resolveOutboundTopicHelper, topicForRecipient, type TopicRouterConfig as _OutboundRouterConfig } from '../../src/telegram/topic-router.js'
 import { readTurnUsages } from '../../src/agents/perf.js'
+import { buildContextOccupancy, writeContextOccupancySnapshot } from './context-occupancy.js'
 import { decideProactiveCompact, initialCompactState, type CompactState } from './proactive-compact.js'
 import { nextCompactNotify, idleCompactNotifyState, type CompactNotifyState } from './compact-notify.js'
 import {
@@ -2796,6 +2797,45 @@ function purgeReactionTracking(key: string, endingTurn?: CurrentTurn): void {
       // moot, so only evaluate when no restart drained this pass.
       maybeProactiveCompact();
     }
+    // Context-headroom snapshot (RFC context-headroom-surface) — write the
+    // current occupancy + cap so `switchroom status`/`doctor`/web can show
+    // headroom. Independent of proactive-compaction (writes even when no cap
+    // is configured) and best-effort (never throws). Runs on the same idle
+    // signal — never mid-turn.
+    snapshotContextOccupancy();
+  }
+}
+
+/**
+ * Write the per-agent context-occupancy snapshot from the same live occupancy
+ * proactive-compaction reads — but unconditionally (even with no cap set), so
+ * the operator always sees headroom. Best-effort; never throws.
+ */
+function snapshotContextOccupancy(): void {
+  try {
+    const agentName = process.env.SWITCHROOM_AGENT_NAME;
+    const file = lastSessionActiveFile;
+    if (!agentName || !file) return;
+    const turns = readTurnUsages(file, 1);
+    if (turns.length === 0) return;
+    const t = turns[0];
+    const occupancy = t.input + t.cacheRead + t.cacheCreate;
+    let cap: number | null = null;
+    try {
+      const cfg = loadSwitchroomConfig();
+      const rawAgent = cfg.agents?.[agentName] ?? {};
+      const resolved = resolveAgentConfig(cfg.defaults, cfg.profiles, rawAgent);
+      cap = resolved.session?.max_context_tokens ?? null;
+    } catch {
+      cap = null; // config unreadable → show occupancy without a ratio
+    }
+    const stateDir = process.env.SWITCHROOM_AGENT_STATE_DIR ?? "/state/agent";
+    writeContextOccupancySnapshot(
+      stateDir,
+      buildContextOccupancy(occupancy, cap, Date.now()),
+    );
+  } catch {
+    /* best-effort — never disrupt the idle gate */
   }
 }
 

--- a/telegram-plugin/tests/context-occupancy.test.ts
+++ b/telegram-plugin/tests/context-occupancy.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'bun:test'
+import {
+  buildContextOccupancy,
+  writeContextOccupancySnapshot,
+  TIGHT_FRACTION,
+} from '../gateway/context-occupancy.js'
+
+describe('buildContextOccupancy', () => {
+  it('computes headroom + pct + ok state under the cap', () => {
+    const s = buildContextOccupancy(47000, 300000, 123)
+    expect(s).toMatchObject({ occupancy: 47000, cap: 300000, headroom: 253000, state: 'ok', computedAt: 123 })
+    expect(s.pct).toBeCloseTo(0.1567, 3)
+  })
+
+  it('flags "tight" at/above TIGHT_FRACTION of the cap', () => {
+    const atThreshold = buildContextOccupancy(Math.ceil(300000 * TIGHT_FRACTION), 300000, 1)
+    expect(atThreshold.state).toBe('tight')
+    expect(buildContextOccupancy(250000, 300000, 1).state).toBe('tight') // 83% ≥ 80%
+    expect(buildContextOccupancy(231000, 300000, 1).state).toBe('ok')    // 77% < 80%
+    expect(buildContextOccupancy(239999, 300000, 1).state).toBe('ok')    // just under 80%
+  })
+
+  it('no cap → ok, null ratio (occupancy known, no ceiling)', () => {
+    const s = buildContextOccupancy(50000, null, 1)
+    expect(s).toMatchObject({ occupancy: 50000, cap: null, headroom: null, pct: null, state: 'ok' })
+    expect(buildContextOccupancy(50000, 0, 1).cap).toBeNull() // cap<=0 treated as none
+  })
+
+  it('unmeasurable occupancy → unknown', () => {
+    expect(buildContextOccupancy(NaN, 300000, 1).state).toBe('unknown')
+    expect(buildContextOccupancy(-5, 300000, 1).state).toBe('unknown')
+  })
+})
+
+describe('writeContextOccupancySnapshot', () => {
+  it('writes <stateDir>/context-occupancy.json via injected fs', () => {
+    let path = ''
+    let data = ''
+    writeContextOccupancySnapshot('/state/agent', buildContextOccupancy(47000, 300000, 1), {
+      mkdir: () => {},
+      writeFile: (p, d) => { path = p; data = d },
+    })
+    expect(path).toBe('/state/agent/context-occupancy.json')
+    expect(JSON.parse(data).occupancy).toBe(47000)
+  })
+
+  it('never throws when the write fails (best-effort)', () => {
+    expect(() =>
+      writeContextOccupancySnapshot('/x', buildContextOccupancy(1, 2, 1), {
+        mkdir: () => {},
+        writeFile: () => { throw new Error('EACCES') },
+      }),
+    ).not.toThrow()
+  })
+})

--- a/tests/doctor-context.test.ts
+++ b/tests/doctor-context.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  contextRow,
+  runContextChecks,
+  type SnapshotRead,
+  type ContextSnapshot,
+} from "../src/cli/doctor-context.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+function cfg(p: Record<string, unknown>): SwitchroomConfig {
+  return p as unknown as SwitchroomConfig;
+}
+function snap(s: Partial<ContextSnapshot>): SnapshotRead {
+  return {
+    kind: "ok",
+    snapshot: {
+      occupancy: 0,
+      cap: 300000,
+      headroom: 0,
+      pct: 0,
+      state: "ok",
+      computedAt: 1,
+      ...s,
+    },
+  };
+}
+
+describe("contextRow", () => {
+  it("OK with occupancy/cap (%) when comfortably under the cap", () => {
+    const r = contextRow("clerk", snap({ occupancy: 47000, cap: 300000, pct: 0.157, state: "ok" }));
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("47k/300k");
+    expect(r.detail).toContain("16%");
+  });
+
+  it("WARNs (tight) with a fix when occupancy is near the cap", () => {
+    const r = contextRow("marko", snap({ occupancy: 231000, cap: 300000, pct: 0.77, state: "tight" }));
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("tight");
+    expect(r.detail).toContain("77%");
+    expect(r.fix).toBeTruthy();
+  });
+
+  it("OK without a ratio when no cap is configured", () => {
+    const r = contextRow("a", snap({ occupancy: 50000, cap: null, pct: null, state: "ok" }));
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("no cap");
+  });
+
+  it("SKIPs (not a failure) when the snapshot is absent / unreadable / unknown", () => {
+    expect(contextRow("a", { kind: "absent" }).status).toBe("skip");
+    expect(contextRow("a", { kind: "unreadable", msg: "x" }).status).toBe("skip");
+    expect(contextRow("a", snap({ state: "unknown" })).status).toBe("skip");
+  });
+});
+
+describe("runContextChecks", () => {
+  it("renders one row per agent, sorted, reading via the injected reader", async () => {
+    const reads: Record<string, SnapshotRead> = {
+      marko: snap({ occupancy: 231000, cap: 300000, pct: 0.77, state: "tight" }),
+      clerk: snap({ occupancy: 47000, cap: 300000, pct: 0.157, state: "ok" }),
+    };
+    const res = await runContextChecks(
+      cfg({ agents: { marko: {}, clerk: {} } }),
+      { readSnapshot: async (a) => reads[a] ?? { kind: "absent" } },
+    );
+    expect(res.map((r) => r.name)).toEqual(["context:clerk", "context:marko"]);
+    expect(res.find((r) => r.name === "context:marko")?.status).toBe("warn");
+    expect(res.find((r) => r.name === "context:clerk")?.status).toBe("ok");
+  });
+
+  it("returns [] when there are no agents", async () => {
+    expect(await runContextChecks(cfg({ agents: {} }))).toEqual([]);
+  });
+
+  it("default reader (no deps) → all skip (absent), never throws", async () => {
+    const res = await runContextChecks(cfg({ agents: { a: {} } }));
+    expect(res[0].status).toBe("skip");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -165,6 +165,8 @@ export default defineConfig({
       "**/src/vault/broker/server.test.ts",
       "**/src/vault/broker/auto-unlock.test.ts",
       "**/telegram-plugin/tests/boot-probes.test.ts",
+      // context-occupancy.test.ts uses bun:test — excluded here, run via test:bun.
+      "**/telegram-plugin/tests/context-occupancy.test.ts",
       // tool-filter.test.ts uses bun:test — excluded here, run via test:bun.
       "**/telegram-plugin/tests/tool-filter.test.ts",
       // boot-probes-connections.test.ts uses bun:test — excluded here, run via test:bun.


### PR DESCRIPTION
## Summary
Makes the working-context predictability won by `ENABLE_TOOL_SEARCH=true` (~40% baseline cut) **visible** — the operator can see how close each agent is to a `/compact`. Vision: pillar 2 (you hold the leash → awareness) + pillar 3 (predictable → legible). Spec: `reference/rfcs/context-headroom-surface.md`.

## P1 — gateway writer (`telegram-plugin/gateway/context-occupancy.ts`)
- `buildContextOccupancy(occupancy, cap, now)` — pure: headroom + pct + state (`ok` / `tight` ≥80% / `unknown`).
- `writeContextOccupancySnapshot` — best-effort, never throws.
- The gateway already computes occupancy at the turn-end idle gate for proactive-compaction (`gateway.ts:3000`); `snapshotContextOccupancy()` writes that **same value** (so the surface can't disagree with what triggers `/compact`) to `/state/agent/context-occupancy.json` every idle pass — **even when no cap is set** (proactive-compact returns early without a cap; the snapshot must not). Runs beside `maybeProactiveCompact` — **idle only, never mid-turn**.

## P2 — `switchroom doctor` (`src/cli/doctor-context.ts`)
A "Context Headroom" section: reads each agent's snapshot via `docker exec` (state dir is 0700 agent-owned), renders `occupancy/cap (%)`; **WARN + fix** on the tight band, **SKIP** (not fail) when a snapshot is absent/stale (idle/stopped agent). Pure renderer + injectable reader (mirrors `doctor-mcp-secrets`).

## Test plan
- [x] `context-occupancy.test.ts` (6, bun): ok/tight/no-cap/unknown + write via injected fs + never-throws.
- [x] `doctor-context.test.ts` (7, vitest): row rendering (ok/tight/no-cap/skip) + per-agent run + default-reader-skips.
- [x] tsc / check-plugin-references / check-bot-api-wrapping / check-bun-test-imports clean. (bun:test file added to vitest exclude.)

## Risk
Low — read-only observability. The only runtime change is a best-effort file write at the **idle** gate (never mid-turn, never throws). No model calls, no per-turn cost. Crosses no invariant.

## Follow-ups (per RFC)
P3 web dashboard gauge; P4 optional Telegram `/status` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)