### PR TITLE
feat(web): per-agent context-headroom gauge on the fleet view (P3)

### DIFF
--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -46,6 +46,7 @@ import type { ApprovalDecisionMeta } from "../vault/broker/protocol.js";
 import { homedir } from "node:os";
 import { captureEvent, captureException } from "../analytics/posthog.js";
 import { resolveAgentsDir } from "../config/loader.js";
+import type { ContextSnapshot } from "../cli/doctor-context.js";
 import { resolveAgentConfig } from "../config/merge.js";
 import {
   agentCanAccessNotionDB,
@@ -158,6 +159,34 @@ export interface AgentInfo {
    * quota menu still shows `active`). The UI renders this as "Last turn".
    */
   lastTurnAt: number | null;
+  /**
+   * Working-context headroom snapshot the gateway writes at each idle gate
+   * (RFC context-headroom-surface): occupancy / cap / state. Null when the
+   * agent hasn't run a turn since boot (no snapshot) or it's unreadable. The
+   * UI renders a gauge; pillar 3 (predictable) made visible.
+   */
+  context: ContextSnapshot | null;
+}
+
+/**
+ * Read an agent's context-occupancy snapshot from `<agentsDir>/<name>/
+ * context-occupancy.json` (the gateway writes it in-container to
+ * /state/agent/, host-mounted here). Null on any error — missing snapshot
+ * (idle since boot) / unreadable / malformed → the UI shows "—". Mirrors
+ * readLastTurnAt's degrade-to-null contract.
+ */
+export function readContextOccupancy(
+  agentsDir: string,
+  name: string,
+): ContextSnapshot | null {
+  try {
+    const raw = readFileSync(resolve(agentsDir, name, "context-occupancy.json"), "utf-8");
+    const s = JSON.parse(raw) as ContextSnapshot;
+    if (typeof s?.occupancy !== "number") return null;
+    return s;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -251,9 +280,12 @@ export async function handleGetAgents(
     /** Injectable for tests (default reads the real per-agent turns DB,
      *  which needs `bun:sqlite` — unavailable under vitest). */
     readLastTurn?: (agentsDir: string, name: string) => number | null;
+    /** Injectable for tests (default reads the per-agent snapshot file). */
+    readContext?: (agentsDir: string, name: string) => ContextSnapshot | null;
   } = {},
 ): Promise<AgentInfo[]> {
   const readLastTurn = deps.readLastTurn ?? readLastTurnAt;
+  const readContext = deps.readContext ?? readContextOccupancy;
   const statuses = getAllAgentStatuses(config);
   const authStatuses = getAllAuthStatuses(config);
   const agentsDir = resolveAgentsDir(config);
@@ -320,6 +352,7 @@ export async function handleGetAgents(
       // A real claude-liveness signal (newest turn's start), distinct
       // from `active` (bridge heartbeat only). Null-safe per agent.
       lastTurnAt: readLastTurn(agentsDir, name),
+      context: readContext(agentsDir, name),
     });
   }
 

--- a/src/web/context-occupancy-read.test.ts
+++ b/src/web/context-occupancy-read.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readContextOccupancy } from "./api.js";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ctx-read-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function writeSnap(name: string, body: string): void {
+  mkdirSync(join(dir, name), { recursive: true });
+  writeFileSync(join(dir, name, "context-occupancy.json"), body);
+}
+
+describe("readContextOccupancy", () => {
+  it("reads a valid snapshot from <agentsDir>/<name>/context-occupancy.json", () => {
+    writeSnap("marko", JSON.stringify({ occupancy: 250000, cap: 300000, headroom: 50000, pct: 0.833, state: "tight", computedAt: 1 }));
+    const s = readContextOccupancy(dir, "marko");
+    expect(s).toMatchObject({ occupancy: 250000, cap: 300000, state: "tight" });
+  });
+
+  it("returns null when the snapshot is absent (agent idle since boot)", () => {
+    expect(readContextOccupancy(dir, "clerk")).toBeNull();
+  });
+
+  it("returns null on malformed JSON", () => {
+    writeSnap("clerk", "{not json");
+    expect(readContextOccupancy(dir, "clerk")).toBeNull();
+  });
+
+  it("returns null when occupancy isn't a number (shape guard)", () => {
+    writeSnap("clerk", JSON.stringify({ cap: 300000 }));
+    expect(readContextOccupancy(dir, "clerk")).toBeNull();
+  });
+});

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -122,6 +122,15 @@
 
     .meta-item span { color: var(--text); }
 
+    /* Context-headroom gauge (RFC context-headroom-surface). */
+    .ctx-gauge { display: inline-flex; align-items: center; gap: 0.4rem; }
+    .ctx-text { color: var(--text); font-variant-numeric: tabular-nums; }
+    .ctx-bar {
+      display: inline-block; width: 48px; height: 6px; border-radius: 3px;
+      background: var(--bg-dim, rgba(255,255,255,0.12)); overflow: hidden;
+    }
+    .ctx-fill { display: block; height: 100%; border-radius: 3px; }
+
     .scope-toggle {
       cursor: pointer;
       color: var(--text);
@@ -1659,6 +1668,27 @@
       return 'inactive';
     }
 
+    // Context-headroom gauge (RFC context-headroom-surface): occupancy/cap
+    // with a fill bar, amber when tight (≥80%). '—' when no snapshot yet.
+    function fmtTok(n) {
+      return n >= 1000 ? (n / 1000).toFixed(n >= 10000 ? 0 : 1) + 'k' : String(n);
+    }
+    function formatContext(ctx) {
+      if (!ctx || ctx.state === 'unknown' || typeof ctx.occupancy !== 'number') {
+        return '<span style="color:var(--text-dim)">—</span>';
+      }
+      if (ctx.cap == null || ctx.pct == null) {
+        return `<span>${fmtTok(ctx.occupancy)} <span style="color:var(--text-dim)">(no cap)</span></span>`;
+      }
+      const pct = Math.max(0, Math.min(1, ctx.pct));
+      const tight = ctx.state === 'tight';
+      const col = tight ? 'var(--amber, #d99)' : 'var(--green)';
+      return `<span class="ctx-gauge" title="${fmtTok(ctx.occupancy)} / ${fmtTok(ctx.cap)} tokens — ${Math.round(pct * 100)}% of cap${tight ? ' (tight — /compact near)' : ''}">`
+        + `<span class="ctx-text">${fmtTok(ctx.occupancy)}/${fmtTok(ctx.cap)} (${Math.round(pct * 100)}%)</span>`
+        + `<span class="ctx-bar"><span class="ctx-fill" style="width:${(pct * 100).toFixed(0)}%;background:${col}"></span></span>`
+        + `</span>`;
+    }
+
     function formatUptime(timestamp) {
       if (!timestamp) return '--';
       const d = new Date(timestamp);
@@ -1693,6 +1723,7 @@
             <div class="meta-item"><label>Uptime </label><span>${formatUptime(a.uptime)}</span></div>
             <div class="meta-item"><label>Mem </label><span>${a.memory || '--'}</span></div>
             <div class="meta-item"><label>Last turn </label><span>${a.lastTurnAt ? formatTimestamp(a.lastTurnAt) : '—'}</span></div>
+            <div class="meta-item meta-context"><label>Context </label>${formatContext(a.context)}</div>
             <div class="meta-item"><label>Profile </label><span>${escapeHtml(a.extends)}</span></div>
             <div class="meta-item"><label>Auth </label><span>${a.auth.authenticated ? '✓' : '✗'}</span></div>
             <div class="meta-item"><label>Account </label><span>${a.primaryAccount ? escapeHtml(a.primaryAccount) : '<span style="color:var(--text-dim)">default</span>'}</span></div>


### PR DESCRIPTION
## Summary
P3 of the context-headroom surface (RFC `context-headroom-surface`; P1 gateway writer + P2 doctor shipped in #2429). The web dashboard now shows each agent's working-context headroom — the ~40% predictability win, visible in the UI. Pillars 2 (on-leash/awareness) + 3 (predictable/legible).

## What's here
- **`api.ts`** — `readContextOccupancy(agentsDir, name)` reads the gateway's per-agent `context-occupancy.json` (host-mounted from `/state/agent`), degrade-to-null on absent/unreadable/malformed (mirrors `readLastTurnAt`). New `AgentInfo.context` field, populated in `handleGetAgents` via an injectable `readContext` seam. Reuses the host-side `ContextSnapshot` shape from `doctor-context` (P2) — no new contract.
- **`ui/index.html`** — a "Context" meta-item per agent card: `occupancy/cap (%)` + a fill bar, **amber when tight (≥80%)**, "—" when no snapshot yet (idle since boot). Small gauge CSS.

## Test plan
- [x] `context-occupancy-read.test.ts` (4, vitest): valid / absent / malformed / shape-guard.
- [x] tsc + `check-bun-test-imports` + `check-web-subscription-honest` clean; existing web tests (dashboard-accounts/health, config-diff = 19) green.

## Risk
Low — read-only; no new model calls; crosses no invariant. The gauge populates once agents run the v0.15.40+ image (the gateway writer); until then it shows "—".

## Follow-up
P4 (Telegram `/status` context row) remains per the RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)