### PR TITLE
feat(update): refresh the hindsight singleton on `switchroom update`

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -17,6 +17,8 @@ import {
   getHindsightStatus,
   generateHindsightComposeSnippet,
   pickHindsightPorts,
+  pullHindsightImage,
+  getRunningHindsightPorts,
   HINDSIGHT_DEFAULT_API_PORT,
 } from "../setup/hindsight.js";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -215,8 +217,12 @@ export function registerMemoryCommand(program: Command): void {
     .description("Manage the Hindsight Docker container")
     .option("--stop", "Stop and remove the Hindsight container")
     .option("--status", "Show Hindsight container status")
+    .option(
+      "--recreate",
+      "Pull the latest image and recreate the container (reusing its current port). Used by `switchroom update` to keep the hindsight singleton current.",
+    )
     .option("--provider <provider>", "LLM provider (ollama, openai, anthropic)")
-    .action(async (opts: { stop?: boolean; status?: boolean; provider?: string }) => {
+    .action(async (opts: { stop?: boolean; status?: boolean; recreate?: boolean; provider?: string }) => {
       if (opts.status) {
         if (!isDockerAvailable()) {
           console.log(chalk.red("  Docker is not available."));
@@ -248,31 +254,57 @@ export function registerMemoryCommand(program: Command): void {
         return;
       }
 
-      // Default: start the container
+      // Default: start the container (or, with --recreate, pull the
+      // latest image and recreate it — used by `switchroom update`).
       if (!isDockerAvailable()) {
         console.log(chalk.red("\n  Docker is not available."));
         console.log(chalk.gray("  Install Docker: https://docs.docker.com/get-docker/\n"));
         process.exit(1);
       }
 
-      if (isHindsightRunning()) {
+      const recreate = opts.recreate === true;
+
+      // --recreate rebinds the SAME host ports the running container
+      // currently publishes, so memory.config.url never changes under the
+      // fleet. Read them before we stop the container. (null → fall back
+      // to pickHindsightPorts, e.g. when nothing is running yet.)
+      const reusePorts = recreate ? getRunningHindsightPorts() : null;
+
+      // A plain `setup` on a running container is a no-op; --recreate
+      // proceeds (pull + recreate) even when it's up.
+      if (isHindsightRunning() && !recreate) {
         console.log(chalk.green("\n  Hindsight container is already running (switchroom-hindsight).\n"));
         return;
       }
 
+      if (recreate) {
+        console.log(chalk.gray("  Pulling latest Hindsight image..."));
+        try {
+          pullHindsightImage();
+        } catch (err) {
+          console.error(chalk.red(`\n  Failed to pull Hindsight image: ${(err as Error).message}\n`));
+          process.exit(1);
+        }
+      }
+
       if (isHindsightContainerExists()) {
-        console.log(chalk.gray("  Removing stopped switchroom-hindsight container..."));
+        console.log(chalk.gray("  Removing existing switchroom-hindsight container..."));
         stopHindsight();
       }
 
-      // Pick host ports — try upstream defaults first, fall back to 18888/19999
-      // if anything is already bound on 8888/9999.
+      // Reuse the prior ports on --recreate; otherwise pick host ports —
+      // upstream defaults first, fall back to 18888/19999 if 8888/9999 are
+      // already bound.
       let ports: { apiPort: number; uiPort: number };
-      try {
-        ports = await pickHindsightPorts();
-      } catch (err) {
-        console.error(chalk.red(`\n  ${(err as Error).message}\n`));
-        process.exit(1);
+      if (reusePorts) {
+        ports = reusePorts;
+      } else {
+        try {
+          ports = await pickHindsightPorts();
+        } catch (err) {
+          console.error(chalk.red(`\n  ${(err as Error).message}\n`));
+          process.exit(1);
+        }
       }
       if (ports.apiPort !== HINDSIGHT_DEFAULT_API_PORT) {
         console.log(

--- a/src/cli/update.test.ts
+++ b/src/cli/update.test.ts
@@ -26,7 +26,7 @@ function fakeRunner() {
 }
 
 describe("planUpdate", () => {
-  it("produces 8 steps in default mode (no --rebuild)", () => {
+  it("produces 9 steps in default mode (no --rebuild)", () => {
     const tmp = mkdtempSync(join(tmpdir(), "update-plan-"));
     try {
       const composePath = join(tmp, "docker-compose.yml");
@@ -35,17 +35,44 @@ describe("planUpdate", () => {
         composePath,
         hostControlEnabled: false,
         webServiceManaged: false,
+        memoryBackendHindsight: false,
       });
       expect(steps.map((s) => s.name)).toEqual([
         "pull-images",
         "apply-config",
         "refresh-hostd",
         "refresh-web",
+        "refresh-hindsight",
         "sync-bundled-skills",
         "stamp-restart-marker",
         "recreate-containers",
         "doctor",
       ]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("refresh-hindsight runs when memory.backend is hindsight, skips otherwise / on --skip-images", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "update-hs-"));
+    try {
+      const composePath = join(tmp, "docker-compose.yml");
+      writeFileSync(composePath, "services: {}\n");
+      const find = (steps: ReturnType<typeof planUpdate>) =>
+        steps.find((s) => s.name === "refresh-hindsight")!;
+      // backend = hindsight → step is active (no skipReason).
+      expect(
+        find(planUpdate({ composePath, memoryBackendHindsight: true })).skipReason,
+      ).toBeUndefined();
+      // backend != hindsight → skipped.
+      expect(
+        find(planUpdate({ composePath, memoryBackendHindsight: false })).skipReason,
+      ).toMatch(/not hindsight/);
+      // --skip-images → skipped even when backend is hindsight.
+      expect(
+        find(planUpdate({ composePath, memoryBackendHindsight: true, skipImages: true }))
+          .skipReason,
+      ).toMatch(/skip-images/);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -152,6 +179,7 @@ describe("planUpdate", () => {
         rebuild: true,
         hostControlEnabled: false,
         webServiceManaged: false,
+        memoryBackendHindsight: false,
       });
       expect(steps.map((s) => s.name)).toEqual([
         "pull-images",
@@ -159,6 +187,7 @@ describe("planUpdate", () => {
         "apply-config",
         "refresh-hostd",
         "refresh-web",
+        "refresh-hindsight",
         "sync-bundled-skills",
         "stamp-restart-marker",
         "recreate-containers",
@@ -824,11 +853,12 @@ describe("runUpdate", () => {
         // switchroom.yaml and the call count would depend on whether
         // the developer running tests has hostd enabled.
         hostControlEnabled: false,
-        // Likewise pin web_service.managed off so the refresh-web step is
-        // skipped — otherwise the host's real switchroom.yaml leaks in and a
-        // dev/operator box with managed: true adds a 7th call (the EACCES
-        // overlay-loader noise + "length 6 got 7" on the live host).
+        // Likewise pin web_service.managed + memory.backend off so the
+        // refresh-web / refresh-hindsight steps are skipped — otherwise the
+        // host's real switchroom.yaml leaks in and a dev/operator box adds
+        // extra calls ("length 6 got 7+" on the live host).
         webServiceManaged: false,
+        memoryBackendHindsight: false,
       });
       expect(code).toBe(0);
       // 6 calls total:
@@ -880,9 +910,11 @@ describe("runUpdate", () => {
         agentNamesFn: () => ["a"],
         syncBundledSkillsFn: () => { /* intentional no-op */ },
         hostControlEnabled: true,
-        // Pin web_service.managed off so the refresh-web step doesn't leak in
-        // from the host's real switchroom.yaml (would make this 7 calls).
+        // Pin web_service.managed + memory.backend off so the refresh-web /
+        // refresh-hindsight steps don't leak in from the host's real
+        // switchroom.yaml (would make this 7+ calls).
         webServiceManaged: false,
+        memoryBackendHindsight: false,
       });
       expect(code).toBe(0);
       // 6 calls total:

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -112,6 +112,9 @@ interface UpdateOptions {
   /** Test seam — override `web_service.managed` detection for the
    *  `refresh-web` step instead of reading from switchroom.yaml. */
   webServiceManaged?: boolean;
+  /** Test seam — override `memory.backend === "hindsight"` detection for
+   *  the `refresh-hindsight` step instead of reading from switchroom.yaml. */
+  memoryBackendHindsight?: boolean;
   /** One-shot release-channel override (mirrors `apply --channel`). */
   channel?: "dev" | "rc" | "latest";
   /** One-shot release-pin override (mirrors `apply --pin`). Mutually
@@ -431,6 +434,48 @@ export function planUpdate(opts: UpdateOptions): UpdateStep[] {
     run: () => {
       const r = runner(process.execPath, [scriptPath, "webd", "install"]);
       if (r.status !== 0) throw new Error("switchroom webd install failed");
+    },
+  });
+
+  // refresh-hindsight: pull the latest hindsight image and recreate the
+  // container. Same isolation gap as refresh-hostd/refresh-web — the
+  // hindsight singleton runs as its own standalone `docker run` container
+  // (managed by `memory setup`, NOT in the agent fleet's compose project),
+  // and it uses a floating `:latest` tag that `pull-images` / `--pin`
+  // never touch. So before this step existed, `switchroom update` left
+  // hindsight on whatever stale `:latest` it last started with — even
+  // after the durability fixes (#2412 stable worker_id, #2416 backups /
+  // healthcheck / self-maintenance) were already baked into `:latest`,
+  // the running container kept serving the pre-fix image until an operator
+  // separately ran `memory setup --stop` + `memory setup`. This step folds
+  // that recreate into the update (reusing the container's current port so
+  // memory.config.url never changes under the fleet).
+  //
+  // Skipped when the memory backend isn't hindsight OR --skip-images is set.
+  let memoryBackendHindsight: boolean;
+  if (typeof opts.memoryBackendHindsight === "boolean") {
+    memoryBackendHindsight = opts.memoryBackendHindsight;
+  } else {
+    try {
+      memoryBackendHindsight = loadConfig().memory?.backend === "hindsight";
+    } catch {
+      // Best-effort: skip rather than fail the whole update if config
+      // can't be loaded.
+      memoryBackendHindsight = false;
+    }
+  }
+  steps.push({
+    name: "refresh-hindsight",
+    description:
+      "switchroom memory setup --recreate — pull latest hindsight image + recreate the memory singleton (standalone container, reusing its current port)",
+    skipReason: !memoryBackendHindsight
+      ? "memory.backend is not hindsight — no hindsight singleton to refresh"
+      : opts.skipImages
+        ? "--skip-images flag set"
+        : undefined,
+    run: () => {
+      const r = runner(process.execPath, [scriptPath, "memory", "setup", "--recreate"]);
+      if (r.status !== 0) throw new Error("switchroom memory setup --recreate failed");
     },
   });
 

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -448,6 +448,51 @@ export function stopHindsight(): void {
 }
 
 /**
+ * Pull the latest Hindsight image. `startHindsight` runs `docker run`
+ * against whatever image is locally present — it never pulls — so a
+ * recreate that wants the newest `:latest` must pull first. Inherits
+ * stdio so the operator sees pull progress during `switchroom update`.
+ */
+export function pullHindsightImage(): void {
+  execFileSync("docker", ["pull", HINDSIGHT_IMAGE], { stdio: "inherit" });
+}
+
+/**
+ * Read the host ports the RUNNING hindsight container currently
+ * publishes, so a recreate can rebind the SAME ports and never change
+ * `memory.config.url` under the fleet (a silent port change would point
+ * every agent's MCP client at a dead URL). Returns null if the container
+ * isn't running / can't be read — callers then fall back to
+ * `pickHindsightPorts()`.
+ */
+export function getRunningHindsightPorts(): { apiPort: number; uiPort: number } | null {
+  const readPort = (containerPort: number): number | null => {
+    try {
+      const out = execFileSync(
+        "docker",
+        ["port", "switchroom-hindsight", `${containerPort}/tcp`],
+        { stdio: "pipe", encoding: "utf-8" },
+      );
+      // Output is one or more lines like "127.0.0.1:18888" / "[::]:18888".
+      const m = out.split("\n").map((l) => l.trim()).find((l) => l.length > 0);
+      if (!m) return null;
+      const port = Number(m.slice(m.lastIndexOf(":") + 1));
+      return Number.isInteger(port) && port > 0 ? port : null;
+    } catch {
+      return null;
+    }
+  };
+  const apiPort = readPort(HINDSIGHT_DEFAULT_API_PORT);
+  if (apiPort === null) return null;
+  // The UI port is informational (unused by switchroom); reuse it if
+  // readable, else derive the standard pair (8888→9999, 18888→19999).
+  const uiPort =
+    readPort(HINDSIGHT_DEFAULT_UI_PORT) ??
+    (apiPort === HINDSIGHT_DEFAULT_API_PORT ? HINDSIGHT_DEFAULT_UI_PORT : 19999);
+  return { apiPort, uiPort };
+}
+
+/**
  * Get the status of the Hindsight Docker container.
  */
 export function getHindsightStatus(): string | null {


### PR DESCRIPTION
## Summary

`switchroom update` refreshes the separate-compose singletons (`refresh-hostd`, `refresh-web`) but **never touched hindsight** — which runs as a standalone `docker run` container (managed by `memory setup`, not the agent fleet's compose project) on a floating `:latest` tag that `pull-images` / `--pin` don't touch. So every `update` silently left hindsight on whatever stale `:latest` it last started with.

**This is the exact gap that bit us:** #2412 (stable worker_id + reaper) and #2416 (backups / healthcheck / self-maintenance) were baked into `:latest` weeks ago, but the running hindsight container kept serving the pre-fix image until I recreated it by hand during the v0.15.41 roll. Without this, it would silently drift stale again on the next deploy.

## What

- **`memory setup --recreate`** — pull latest image + recreate the container, **reusing its current published port** so `memory.config.url` never changes under the fleet (a silent port change would point every agent's MCP client at a dead URL). Falls back to `pickHindsightPorts()` when nothing is running.
- **New `refresh-hindsight` step** in the update flow, mirroring `refresh-hostd`/`refresh-web`: invokes `memory setup --recreate`, gated on `memory.backend === "hindsight"`, skipped on `--skip-images`.
- Helpers `pullHindsightImage()` + `getRunningHindsightPorts()` in `src/setup/hindsight.ts`.

After this, `switchroom update` keeps hindsight current like every other component — no separate manual `memory setup` dance.

## Test plan
- [x] `update.test.ts`: `refresh-hindsight` present in the plan (+1 step, count assertions updated); gating verified — active when backend=hindsight, skipped when not / on `--skip-images`.
- [x] `tsc --noEmit` clean; update + rollout suites green (62 tests).
- Manual: the `memory setup --recreate` path is the same recreate I ran live during the v0.15.41 roll (port-reuse landed on 18888, data intact).

## Scope note
Scoped to `switchroom update` (the reported gap). The separate `rollout` command has the same singleton steps and could get `refresh-hindsight` too — quick follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)