### PR TITLE
fix(gateway): recover Telegram poll stall by exiting, not hanging in stop()

### DIFF
--- a/telegram-plugin/gateway/gateway.ts
+++ b/telegram-plugin/gateway/gateway.ts
@@ -370,6 +370,7 @@ import {
   foregroundFinishAction,
 } from './foreground-nesting.js'
 import { createPollHealthCheck, type PollHealthCheckHandle } from './poll-health.js'
+import { recoverFromPollStall } from './poll-stall-recovery.js'
 import type {
   ToolCallMessage,
   ToolCallResult,
@@ -21158,54 +21159,32 @@ process.on('uncaughtException', err => {
 let runnerHandle: RunnerHandle | null = null
 
 // Long-poll health-check handle (issue #56). Created once per process, started
-// after the runner comes up, stopped on clean shutdown. The `onStall` callback
-// stops the runner so the outer retry loop can restart it.
+// after the runner comes up, stopped on clean shutdown. On a confirmed stall
+// the gateway EXITS non-zero and the supervisor restarts it with a fresh runner
+// (see recoverFromPollStall + the 2026-06-18 incident note there). It does NOT
+// try to stop()+re-run the runner in place — grammy's stop() blocks on a non-
+// abortable getUpdates retry backoff during a network outage, which hung the
+// whole fleet deaf.
 //
 // Interval and threshold are configurable via env for ops/testing flexibility:
-//   SWITCHROOM_POLL_HEALTH_INTERVAL_MS — default 5 min
-//   SWITCHROOM_POLL_HEALTH_THRESHOLD   — default 3
+//   SWITCHROOM_POLL_HEALTH_INTERVAL_MS — default 60s (fast self-heal after a flap)
+//   SWITCHROOM_POLL_HEALTH_THRESHOLD   — default 3 (a single blip must not trip it)
 const POLL_HEALTH_INTERVAL_MS = Number(
-  process.env.SWITCHROOM_POLL_HEALTH_INTERVAL_MS ?? 5 * 60_000,
+  process.env.SWITCHROOM_POLL_HEALTH_INTERVAL_MS ?? 60_000,
 )
 const POLL_HEALTH_THRESHOLD = Number(
   process.env.SWITCHROOM_POLL_HEALTH_THRESHOLD ?? 3,
 )
-
-/** Sentinel error thrown by onStall so the outer for-loop retries rather
- *  than exiting. The catch block recognises this specific message. */
-class PollStallError extends Error {
-  constructor() {
-    super('poll_stall_restart')
-    this.name = 'PollStallError'
-  }
-}
 
 let pollHealthCheck: PollHealthCheckHandle | null = null
 if (POLL_HEALTH_INTERVAL_MS > 0) {
   pollHealthCheck = createPollHealthCheck({
     ping: () => bot.api.getMe(),
     onStall: async () => {
-      const agentName = process.env.SWITCHROOM_AGENT_NAME ?? '-'
-      process.stderr.write(
-        `telegram gateway: poll.health_check.stall_recovery stopping runner agent=${agentName}\n`,
-      )
-      if (runnerHandle != null && runnerHandle.isRunning()) {
-        try {
-          await runnerHandle.stop()
-        } catch (err) {
-          process.stderr.write(
-            `telegram gateway: poll.health_check.stall_recovery runner.stop error: ${(err as Error).message}\n`,
-          )
-        }
-      }
-      // runnerHandle.stop() causes task() to resolve. That would normally
-      // hit the `return` below and exit the startup IIFE. Instead we throw
-      // PollStallError from inside task()'s continuation by surfacing it
-      // through the outer catch block — but task() itself doesn't throw here.
-      //
-      // The simpler fix: set runnerHandle to a sentinel that the code below
-      // `await runnerHandle.task()` checks to decide continue vs return.
-      runnerHandle = null
+      // Exit non-zero → _switchroom_supervise restarts the gateway sidecar
+      // with a fresh runner. Never awaits runnerHandle.stop() (it hangs on a
+      // wedged source). recoverFromPollStall exits 1, never 78.
+      recoverFromPollStall({ agentName: process.env.SWITCHROOM_AGENT_NAME ?? '-' })
     },
     intervalMs: POLL_HEALTH_INTERVAL_MS,
     failureThreshold: POLL_HEALTH_THRESHOLD,
@@ -22287,20 +22266,10 @@ void (async () => {
       pollHealthCheck?.stop()
       pollHealthCheck?.start()
       await runnerHandle.task()
-      // If onStall fired, it called runnerHandle.stop() which resolved task()
-      // above, then set runnerHandle = null. Detect that here and continue the
-      // loop to restart the runner. A normal clean exit leaves runnerHandle non-
-      // null (the stopped handle is still non-null at this point), so we can
-      // distinguish: null means stall-triggered, non-null means clean exit.
-      if (runnerHandle === null) {
-        const agentName = process.env.SWITCHROOM_AGENT_NAME ?? '-'
-        process.stderr.write(
-          `telegram gateway: poll.health_check.stall_recovery restarting runner agent=${agentName}\n`,
-        )
-        // Brief pause so the Telegram API can close the stalled connection.
-        await new Promise(r => setTimeout(r, 2000))
-        continue
-      }
+      // task() resolves only on clean shutdown (shutdown-drain stops the
+      // runner) — exit the startup IIFE. Stall recovery no longer routes here:
+      // onStall exits the process and the supervisor restarts the gateway
+      // (see recoverFromPollStall). The 409 path below re-runs in place.
       return
     } catch (err) {
       if (err instanceof GrammyError && err.error_code === 409) {

--- a/telegram-plugin/gateway/poll-health.ts
+++ b/telegram-plugin/gateway/poll-health.ts
@@ -10,18 +10,23 @@
  *
  * Fix:
  *   A separate setInterval calls `getMe()` (a lightweight Bot API
- *   endpoint) every HEALTH_INTERVAL_MS. Three consecutive failures
- *   constitute a stall: we stop the runner, wait RESTART_GRACE_MS
- *   for the in-flight request to die, then let the caller restart it.
+ *   endpoint) every `intervalMs`. `failureThreshold` consecutive
+ *   failures constitute a stall and fire `onStall`.
  *
  *   A single failure doesn't count — transient network blips happen.
  *   The threshold must be >= 3 so a brief Telegram outage (e.g. a
  *   data-centre hiccup) doesn't cause thrashing.
  *
+ * Recovery (see gateway.ts onStall → poll-stall-recovery.ts):
+ *   `onStall` does NOT stop()+re-run the runner — grammy's stop() blocks
+ *   on a non-abortable getUpdates retry backoff during an outage, which hung
+ *   the fleet deaf (2026-06-18). It exits the process non-zero and the
+ *   supervisor restarts the gateway with a fresh runner.
+ *
  * Usage:
  *   const hc = createPollHealthCheck({
  *     ping:  () => bot.api.getMe(),
- *     onStall: async () => { await runnerHandle.stop(); … restart … },
+ *     onStall: async () => { recoverFromPollStall({ agentName }); },
  *     log:   (msg) => process.stderr.write(msg),
  *   });
  *   // start after the runner is up:

--- a/telegram-plugin/gateway/poll-stall-recovery.ts
+++ b/telegram-plugin/gateway/poll-stall-recovery.ts
@@ -1,0 +1,59 @@
+/**
+ * Telegram poll stall recovery (incident 2026-06-18: a network flap left the
+ * whole agent fleet alive-but-deaf for ~30 min until a manual restart).
+ *
+ * When the long-poll health-check (poll-health.ts) detects a stall — 3
+ * consecutive `getMe` failures — the OLD recovery did `await runnerHandle.stop()`
+ * then re-ran the runner in place. That HUNG: grammy's `stop()` returns the
+ * runner task promise, which is blocked on a non-abortable `getUpdates` retry
+ * backoff (`@grammyjs/runner` maxRetryTime 15h, exponential, plain setTimeout
+ * that ignores the abort signal). During a network outage the source never
+ * terminates, so `stop()` never resolves, the re-run never fires, and the
+ * gateway stays deaf.
+ *
+ * Recovery is now a clean non-zero process EXIT: `_switchroom_supervise`
+ * (profiles/_base/start.sh.hbs) restarts the gateway sidecar with a fresh
+ * runner. Same mechanism the manual fix used and the run loop's catch-block
+ * already relies on; it restarts only the gateway (claude/tmux untouched,
+ * in-flight turns recovered by boot-resume). Extracted as its own module with
+ * an injectable `exit` so the exit code is unit-testable (mirrors
+ * startup-network-retry.ts) — gateway.ts itself can't be imported in a test.
+ */
+
+export interface PollStallRecoveryDeps {
+  /** Process exit. Injectable for tests; defaults to process.exit. */
+  exit?: (code: number) => void;
+  /** Logger. Defaults to process.stderr. */
+  log?: (msg: string) => void;
+  /** Agent name for the log line. */
+  agentName?: string;
+}
+
+/** Exit code for a poll stall. Always 1 — NEVER 78. */
+export const POLL_STALL_EXIT_CODE = 1;
+
+/**
+ * Recover from a confirmed Telegram poll stall by exiting non-zero so the
+ * supervisor restarts the gateway with a fresh runner.
+ *
+ * MUST exit 1 — NEVER 78. Exit 78 (EX_CONFIG) is the supervisor's permanent-
+ * quarantine sentinel (start.sh.hbs); quarantining on a *transient* network
+ * stall would leave the gateway dead even after connectivity returns — the
+ * exact failure this fix exists to prevent.
+ */
+export function recoverFromPollStall(deps: PollStallRecoveryDeps = {}): void {
+  const exit = deps.exit ?? ((code: number) => process.exit(code));
+  const log =
+    deps.log ??
+    ((msg: string) => {
+      process.stderr.write(msg.endsWith("\n") ? msg : msg + "\n");
+    });
+  const agentName = deps.agentName ?? "-";
+
+  log(
+    `telegram gateway: poll.health_check.stall_recovery exiting code=${POLL_STALL_EXIT_CODE} ` +
+      `pid=${process.pid} agent=${agentName} — supervisor will restart the gateway with a fresh runner ` +
+      `(not awaiting runnerHandle.stop(): grammy stop() blocks on a non-abortable getUpdates retry backoff during an outage)`,
+  );
+  exit(POLL_STALL_EXIT_CODE);
+}

--- a/telegram-plugin/tests/poll-stall-recovery.test.ts
+++ b/telegram-plugin/tests/poll-stall-recovery.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import {
+  recoverFromPollStall,
+  POLL_STALL_EXIT_CODE,
+} from '../gateway/poll-stall-recovery.js'
+
+describe('recoverFromPollStall', () => {
+  it('exits with code 1 — and NEVER 78 (78 = permanent quarantine)', () => {
+    const codes: number[] = []
+    recoverFromPollStall({ exit: (c) => { codes.push(c) }, log: () => {} })
+    expect(codes).toEqual([1])
+    expect(POLL_STALL_EXIT_CODE).toBe(1)
+    expect(codes).not.toContain(78) // the sharp edge: quarantine on a transient stall
+  })
+
+  it('logs a recovery line carrying the agent name + the reason (no stop() await)', () => {
+    const lines: string[] = []
+    recoverFromPollStall({ exit: () => {}, log: (m) => { lines.push(m) }, agentName: 'carrie' })
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('stall_recovery')
+    expect(lines[0]).toContain('agent=carrie')
+    expect(lines[0]).toContain('code=1')
+    // documents WHY we don't await stop() — guards against a future revert
+    expect(lines[0]).toMatch(/backoff|stop\(\)/)
+  })
+
+  it('exits exactly once', () => {
+    let calls = 0
+    recoverFromPollStall({ exit: () => { calls++ }, log: () => {} })
+    expect(calls).toBe(1)
+  })
+})


### PR DESCRIPTION
## Incident
2026-06-18: a network flap (flaky internet) left the **entire agent fleet alive-but-deaf for ~30 min** — no Telegram messages received — until a manual `agent restart`.

## Root cause (validated: carrie's log + grammy source + 2 independent reviews)
The long-poll health-check (`poll-health.ts`) correctly detected the stall (3 failed `getMe` pings) and called `onStall`, which did `await runnerHandle.stop()`. grammy's `stop()` returns the **runner task promise**, blocked on a **non-abortable `getUpdates` retry backoff** (`@grammyjs/runner` maxRetryTime 15h, exponential, a `setTimeout` that ignores the abort signal). During an outage the source never terminates → `stop()` never resolves → `runnerHandle` never nulled → the in-place "restarting runner" path never runs. **Proven:** carrie logged `stopping runner` then *nothing* (no `restarting`, no `onStall error`), with getUpdates still erroring 1m46s after stop was called. Log confirmed not rotated.

## Fix
Replace the fragile in-process stop()+re-run with a **clean non-zero process exit**:
- New `poll-stall-recovery.ts` — `recoverFromPollStall({ exit, log, agentName })`, exits **1, NEVER 78** (78 = supervisor permanent-quarantine). Injectable `exit` so it's unit-testable (gateway.ts can't be imported in a test — mirrors `startup-network-retry.ts`).
- `_switchroom_supervise` restarts the **gateway sidecar** with a fresh runner — the same mechanism the manual fix used + the catch-block already relies on. claude/tmux untouched; in-flight turns recovered by boot-resume; no double-poll.
- Delete the dead `PollStallError` class + the null-detection re-run block.
- Health-check interval default **5 min → 60s** (threshold stays 3; env-overridable) → ~3 min self-heal vs ~15.

## Process (review → plan → review → implement)
1. Root cause + approach independently reviewed: **CONFIRMED / SOUND** (sharpened the mechanism: non-abortable backoff).
2. Implementation plan independently reviewed: **NEEDS-CHANGES** → extracted the recovery into its own testable module; dropped a stale allowlist-drift mitigation.

## Test plan
- [x] `poll-stall-recovery.test.ts` — exit==1 (never 78), logs the reason, exits once.
- [x] tsc + `check-bot-api-wrapping` (no drift) + `check-plugin-references` + `check-bun-test-imports` clean; `poll-health.test.ts` green.

## Risk
Low. Reuses two proven mechanisms (detection worked in the incident; supervised restart = the manual fix). 60s interval → a real Telegram blip could trip 3 failures/3min → one cheap (~30s, claude-undisturbed) gateway restart; env-tunable. No double-poll. **NEVER exits 78** (test-enforced). Takes effect on next release + roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)