### PR TITLE
feat(hindsight): backup ownership fix + reflect timeout + consolidation tuning + queue-liveness probe

### DIFF
--- a/docker/Dockerfile.hindsight
+++ b/docker/Dockerfile.hindsight
@@ -151,6 +151,17 @@ COPY --chmod=0644 docker/hindsight-fetch-creds.cjs /usr/local/lib/switchroom/hin
 # + completed-op retention), invoked by the entrypoint's background loop.
 COPY --chmod=0755 docker/hindsight-maintenance.sh /usr/local/lib/switchroom/hindsight-maintenance.sh
 
+# Backup mount point, owned by the hindsight user (UID 11000). The
+# maintenance script writes rotated pg_dumps to /backups via a named
+# volume (compose `switchroom-hindsight-backups:/backups`). A fresh named
+# volume inherits the ownership of the image directory it mounts onto, so
+# this dir MUST exist as hindsight-owned BEFORE the volume mounts —
+# otherwise Docker creates the mount point root-owned and the non-root
+# hindsight process gets EACCES on every pg_dump (the backup silently
+# never succeeds — observed live on the v0.15.41 roll, fixed by a manual
+# chown). Creating it 11000-owned here makes backups work out of the box.
+RUN mkdir -p /backups && chown hindsight:hindsight /backups
+
 # Entrypoint shim — runs the fetcher at boot, spawns a refresh sidecar,
 # then execs the upstream CMD. See the file header for the boot/refresh
 # flow + env knobs + fail-loud guards.

--- a/docker/hindsight-maintenance.sh
+++ b/docker/hindsight-maintenance.sh
@@ -34,6 +34,8 @@
 #   SWITCHROOM_HINDSIGHT_BACKUP_INTERVAL_MIN  min minutes between backups. default 1440
 #   SWITCHROOM_HINDSIGHT_BACKUP_KEEP          rotated backups to retain. default 7
 #   SWITCHROOM_HINDSIGHT_RETENTION_DAYS       completed-op prune age. default 30
+#   SWITCHROOM_HINDSIGHT_QUEUE_LAG_WARN_S     warn if oldest pending/processing
+#                                             op older than this. default 7200 (2h). 0=off
 set -u
 
 MAINT_ENABLED="${SWITCHROOM_HINDSIGHT_MAINTENANCE:-1}"
@@ -42,6 +44,14 @@ BACKUP_DIR="${SWITCHROOM_HINDSIGHT_BACKUP_DIR:-/backups}"
 BACKUP_INTERVAL_MIN="${SWITCHROOM_HINDSIGHT_BACKUP_INTERVAL_MIN:-1440}"
 BACKUP_KEEP="${SWITCHROOM_HINDSIGHT_BACKUP_KEEP:-7}"
 RETENTION_DAYS="${SWITCHROOM_HINDSIGHT_RETENTION_DAYS:-30}"
+# Queue-liveness warn threshold: if the oldest pending/processing async
+# op is older than this, the consolidation/retain pipeline is likely
+# wedged (the 26-day strand of 2026-05-23 went unseen because nothing
+# watched this). Default 2h — well above ~510s/op + the 30-min lease
+# reaper. 0 disables. Logs a loud WARNING (picked up by docker logs /
+# any log monitoring); the reaper still auto-heals stuck *processing*
+# ops, so this is visibility, not the heal.
+QUEUE_LAG_WARN_S="${SWITCHROOM_HINDSIGHT_QUEUE_LAG_WARN_S:-7200}"
 
 log() { echo "switchroom-hindsight-maintenance: $*" >&2; }
 
@@ -84,6 +94,20 @@ _sql "ALTER TABLE IF EXISTS unit_entities SET (autovacuum_vacuum_scale_factor=0.
 _pruned="$(_sql "WITH d AS (DELETE FROM async_operations WHERE status='completed' AND created_at < now() - make_interval(days => ${RETENTION_DAYS}) RETURNING 1) SELECT count(*) FROM d")"
 if [ "${_pruned:-0}" -gt 0 ] 2>/dev/null; then
   log "pruned ${_pruned} completed async_operations older than ${RETENTION_DAYS}d"
+fi
+
+# --- 4. Queue-liveness probe: warn (loudly, in the logs) if the
+# consolidation/retain pipeline looks wedged. Catches the strand class
+# that previously hid for 26 days. Reports the oldest pending/processing
+# op's age; if it exceeds the threshold, something isn't draining. ---
+if [ "${QUEUE_LAG_WARN_S}" -gt 0 ] 2>/dev/null; then
+  # "count|oldest_age_seconds" for non-terminal ops (0 rows → "0|0").
+  _q="$(_sql "SELECT count(*)||'|'||coalesce(max(extract(epoch from (now()-created_at)))::bigint,0) FROM async_operations WHERE status IN ('pending','processing')")"
+  _qn="${_q%%|*}"
+  _qage="${_q##*|}"
+  if [ "${_qage:-0}" -gt "${QUEUE_LAG_WARN_S}" ] 2>/dev/null; then
+    log "WARNING: queue may be wedged — ${_qn} pending/processing async op(s), oldest $((_qage/60))m old (> $((QUEUE_LAG_WARN_S/60))m). Consolidation/retain pipeline not draining; inspect async_operations + 'docker logs switchroom-hindsight'."
+  fi
 fi
 
 # --- 1. Backup: rotated pg_dump, at most once per interval ---

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -189,6 +189,36 @@ export const HINDSIGHT_DEFAULT_RERANKER_LOCAL_MAX_CONCURRENT = 4;
 export const HINDSIGHT_DEFAULT_RECALL_MAX_CONCURRENT = 8;
 
 /**
+ * Reflect wall-clock timeout. Vendor default is 300s. Mental-model
+ * refresh re-runs the model's `source_query` through the agentic reflect
+ * loop; on a large bank (observed: 12-13k observations) that legitimately
+ * exceeds 300s, so the refresh times out and the model stays stale —
+ * which is the main reason user-profile models go unpopulated on
+ * high-volume agents (2026-06-19 fleet: refresh timeouts across 8 banks).
+ * 600s lets large-bank refreshes complete. Trade-off: an interactive
+ * `reflect` query also gets the longer ceiling, but those rarely approach
+ * 300s, so the net is strictly more models successfully refreshing.
+ */
+export const HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S = 600;
+
+/**
+ * Consolidation throughput knobs (modest, reversible). Consolidation is
+ * LLM-bound via the claude-code provider (observed ~510s/op), so a deep
+ * backlog (e.g. after a stall) drains slowly. Two conservative levers:
+ *
+ * - LLM_BATCH_SIZE 8→12: more facts per LLM call → fewer round-trips per
+ *   round, so less per-call overhead at ~the same total tokens. Kept
+ *   modest (not 16+) to avoid diluting per-fact synthesis quality.
+ * - CONSOLIDATION_MAX_SLOTS 2→3: one more bank consolidates concurrently,
+ *   which matters during multi-bank backlog recovery. Kept to 3 (not
+ *   higher) because every slot is a concurrent claude subprocess on the
+ *   shared subscription — more would risk contending with the fleet's own
+ *   model usage (subscription-honest). Both revert via the env vars.
+ */
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE = 12;
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS = 3;
+
+/**
  * Container resource caps (memory + pids only; CPU intentionally NOT capped).
  *
  * Live observed RSS on a 9-agent fleet: 3.4 GiB. Capping memory at
@@ -385,6 +415,13 @@ export function startHindsight(ports?: { apiPort: number; uiPort: number }): voi
     "-e", `HINDSIGHT_API_RERANKER_MAX_CANDIDATES=${HINDSIGHT_DEFAULT_RERANKER_MAX_CANDIDATES}`,
     "-e", `HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT=${HINDSIGHT_DEFAULT_RERANKER_LOCAL_MAX_CONCURRENT}`,
     "-e", `HINDSIGHT_API_RECALL_MAX_CONCURRENT=${HINDSIGHT_DEFAULT_RECALL_MAX_CONCURRENT}`,
+    // Reflect wall timeout — let large-bank mental-model refreshes finish
+    // (vendor 300s times out on 12k+ obs banks → stale user-profile models).
+    "-e", `HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S}`,
+    // Consolidation throughput (modest): fewer LLM round-trips per round +
+    // one more concurrent bank during backlog recovery. See constants above.
+    "-e", `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`,
+    "-e", `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
   ];
 
   const args = [
@@ -549,6 +586,9 @@ export function generateHindsightComposeSnippet(): string {
     `      - HINDSIGHT_API_RERANKER_MAX_CANDIDATES=${HINDSIGHT_DEFAULT_RERANKER_MAX_CANDIDATES}`,
     `      - HINDSIGHT_API_RERANKER_LOCAL_MAX_CONCURRENT=${HINDSIGHT_DEFAULT_RERANKER_LOCAL_MAX_CONCURRENT}`,
     `      - HINDSIGHT_API_RECALL_MAX_CONCURRENT=${HINDSIGHT_DEFAULT_RECALL_MAX_CONCURRENT}`,
+    `      - HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S}`,
+    `      - HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`,
+    `      - HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
     `    mem_limit: ${HINDSIGHT_DEFAULT_MEM_LIMIT}`,
     `    mem_reservation: ${HINDSIGHT_DEFAULT_MEM_RESERVATION}`,
     `    pids_limit: ${HINDSIGHT_DEFAULT_PIDS_LIMIT}`,

--- a/tests/docker/dockerfile-hindsight-bakes.test.ts
+++ b/tests/docker/dockerfile-hindsight-bakes.test.ts
@@ -106,6 +106,17 @@ describe("Dockerfile.hindsight shape", () => {
     );
   });
 
+  it("creates /backups owned by hindsight BEFORE `USER hindsight` (so the named volume is writable)", () => {
+    // A root-owned /backups mount point makes the fresh named volume
+    // root-owned → the non-root hindsight process EACCESes on pg_dump and
+    // backups silently never succeed (observed live on the v0.15.41 roll).
+    expect(dockerfile).toMatch(/mkdir -p \/backups && chown hindsight:hindsight \/backups/);
+    const chownIdx = dockerfile.search(/chown hindsight:hindsight \/backups/);
+    const userIdx = dockerfile.search(/^USER\s+hindsight\b/m);
+    expect(chownIdx).toBeGreaterThanOrEqual(0);
+    expect(userIdx).toBeGreaterThan(chownIdx); // chown runs as root, before the USER switch
+  });
+
   it("ends as USER hindsight (so the entrypoint runs as UID 11000)", () => {
     expect(dockerfile).toMatch(/^USER\s+hindsight\b/m);
   });

--- a/tests/docker/hindsight-maintenance.test.ts
+++ b/tests/docker/hindsight-maintenance.test.ts
@@ -64,4 +64,16 @@ describe("hindsight-maintenance.sh", () => {
     // Interval gate so it backs up at most once per window.
     expect(raw).toMatch(/-mmin "?-?\$\{BACKUP_INTERVAL_MIN\}/);
   });
+
+  it("runs a queue-liveness probe that warns (read-only) when the pipeline is wedged", () => {
+    const raw = readFileSync(SCRIPT, "utf-8");
+    // Reads the oldest non-terminal op age — read-only (SELECT, never mutates).
+    expect(raw).toMatch(/FROM async_operations WHERE status IN \('pending','processing'\)/);
+    expect(raw).toMatch(/QUEUE_LAG_WARN_S/);
+    // Gated (0 disables) and emits a WARNING, not a mutation.
+    expect(raw).toMatch(/\$\{QUEUE_LAG_WARN_S\}.*-gt 0/);
+    expect(raw).toMatch(/log "WARNING: queue may be wedged/);
+    // The probe must not DELETE/UPDATE — it's visibility only.
+    expect(raw).not.toMatch(/(DELETE|UPDATE).*status IN \('pending','processing'\)/);
+  });
 });

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -154,6 +154,38 @@ describe("hindsight broker-fed mode (#1245)", () => {
     expect(envPairs).toContain("HINDSIGHT_API_LLM_MODEL=claude-sonnet-4-6");
   });
 
+  it("raises the reflect wall timeout (vendor 300s times out large-bank mental-model refresh)", async () => {
+    const { HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S: t } = await import("../../src/setup/hindsight.js");
+    expect(t).toBeGreaterThan(300);
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const args = findRunArgs();
+    const envPairs: string[] = [];
+    for (let i = 0; i < args.length - 1; i++) {
+      if (args[i] === "-e") envPairs.push(args[i + 1] as string);
+    }
+    expect(envPairs).toContain(`HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${t}`);
+    // Parity in the compose path.
+    const { generateHindsightComposeSnippet } = await import("../../src/setup/hindsight.js");
+    expect(generateHindsightComposeSnippet()).toContain(`HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${t}`);
+  });
+
+  it("sets modest consolidation throughput knobs (batch size + slots) on both emit paths", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    const args = findRunArgs();
+    const envPairs: string[] = [];
+    for (let i = 0; i < args.length - 1; i++) {
+      if (args[i] === "-e") envPairs.push(args[i + 1] as string);
+    }
+    expect(envPairs).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`);
+    expect(envPairs).toContain(`HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`);
+    // Kept modest to stay subscription-honest (concurrent claude subprocesses).
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS).toBeLessThanOrEqual(4);
+    const snippet = h.generateHindsightComposeSnippet();
+    expect(snippet).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`);
+    expect(snippet).toContain(`HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`);
+  });
+
   it("enables stateless MCP (HINDSIGHT_API_MCP_STATELESS=true) so a hindsight bounce doesn't strand agent-side MCP sessions", () => {
     // Stateful MCP makes the server assign an Mcp-Session-Id on
     // initialize that the client must echo on every subsequent call.


### PR DESCRIPTION
## Summary

Four operational fixes found while verifying yesterday's hindsight work on the live fleet (the answer to "is it working?" was "mostly — but the backup silently never succeeded").

1. **Backup volume ownership (the real bug).** `switchroom-hindsight-backups` mounts onto `/backups`, but `/backups` didn't exist in the image — so Docker created the mount point **root-owned**, and the non-root hindsight process (UID 11000) got `EACCES` on every `pg_dump`. **Automated backups silently never succeeded.** Fix: create `/backups` as `11000`-owned before `USER hindsight` so a fresh named volume inherits writable ownership. (Live host already fixed with a manual chown + a 757 MB dump confirmed.)
2. **Reflect wall timeout 300s→600s.** Mental-model refresh times out on large banks (12–13k observations) → models stay stale. This is the main reason user-profile models go unpopulated on high-volume agents (observed: timeouts across **8 banks**). 600s lets them complete; interactive `reflect` rarely approaches 300s.
3. **Consolidation throughput (modest, reversible).** `LLM_BATCH_SIZE 8→12` (fewer LLM round-trips, ~same tokens) + `CONSOLIDATION_MAX_SLOTS 2→3` (one more concurrent bank during backlog recovery). Kept conservative — each slot is a concurrent `claude` subprocess on the shared subscription.
4. **Queue-liveness probe.** The 26-day strand hid because nothing watched the queue. The maintenance loop now **warns (read-only, in the logs)** when the oldest pending/processing op exceeds a threshold (default 2h). The lease reaper still auto-heals stuck *processing* ops; this is the missing **visibility**.

## Test plan
- [x] `tests/setup/hindsight.test.ts` — reflect-timeout + consolidation knobs on **both** emit paths; slots kept ≤4 (subscription-honest).
- [x] `tests/docker/dockerfile-hindsight-bakes.test.ts` — `/backups` chown present **and ordered before `USER hindsight`**.
- [x] `tests/docker/hindsight-maintenance.test.ts` — probe is read-only (`SELECT` only, never DELETE/UPDATE on pending/processing), gated, warns.
- [x] 43 targeted tests pass; `tsc` clean; `sh -n` on the maintenance script.

## Deployment note
The `/backups` chown + maintenance-script probe (#1, #4) are **image** changes (need a hindsight image rebuild); the reflect/consolidation knobs (#2, #3) are **runtime env** (apply on the next hindsight recreate). The live host already has the critical #1 (chown) applied. Full activation rides the next release + roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)