### PR TITLE
feat(hindsight): raise mem limit to 8g + expose consolidation throughput knobs

### DIFF
--- a/src/build-info.ts
+++ b/src/build-info.ts
@@ -2,8 +2,8 @@
 // Tracked in git so `tsc --noEmit` works on a fresh clone before `npm run build`.
 // Values are refreshed every time `npm run build` runs.
 
-export const VERSION: string = "0.15.3";
-export const COMMIT_SHA: string | null = "82bd17d8";
-export const COMMIT_DATE: string | null = "2026-06-11T19:51:40+10:00";
-export const LATEST_PR: number | null = 2278;
-export const COMMITS_AHEAD_OF_TAG: number | null = 7;
+export const VERSION: string = "0.15.43";
+export const COMMIT_SHA: string | null = "86f56acb";
+export const COMMIT_DATE: string | null = "2026-06-19T02:04:40Z";
+export const LATEST_PR: number | null = 2437;
+export const COMMITS_AHEAD_OF_TAG: number | null = 0;

--- a/src/setup/hindsight.ts
+++ b/src/setup/hindsight.ts
@@ -214,9 +214,24 @@ export const HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S = 600;
  *   higher) because every slot is a concurrent claude subprocess on the
  *   shared subscription — more would risk contending with the fleet's own
  *   model usage (subscription-honest). Both revert via the env vars.
+ *
+ * Two more (added after the 2026-06-19 backlog dig): these target a
+ * single backed-up bank, where MAX_SLOTS doesn't help (slots parallelise
+ * ACROSS banks, but the bottleneck is one bank's per-op rate). The hard
+ * ceiling on concurrent model calls is MAX_SLOTS × LLM_PARALLELISM, so we
+ * keep it fleet-safe: 3 × 6 = 18 (was 3 × 4 = 12), NOT a reckless
+ * doubling that would starve the fleet's interactive model usage.
+ * - LLM_PARALLELISM 4→6: more tag-groups consolidated concurrently WITHIN
+ *   one op → faster per-op drain on a single bank.
+ * - MAX_MEMORIES_PER_ROUND 100→300: a larger scope clears in one op
+ *   instead of re-queuing, cutting per-op setup overhead.
+ * Pairs with the 8g memory limit below (more in-flight consolidation =
+ * more RSS). All operator-overridable via the generated compose / -e.
  */
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE = 12;
 export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS = 3;
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM = 6;
+export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND = 300;
 
 /**
  * Container resource caps (memory + pids only; CPU intentionally NOT capped).
@@ -243,8 +258,12 @@ export const HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS = 3;
  *
  * PIDs cap is defense-in-depth, matches the agent `coding` profile.
  */
-export const HINDSIGHT_DEFAULT_MEM_LIMIT = "4g";
-export const HINDSIGHT_DEFAULT_MEM_RESERVATION = "2g";
+// 4g→8g (2026-06-19): baseline RSS is ~3.4g on a 9-agent fleet — only
+// ~600m of headroom under the old 4g cap, and the consolidation-throughput
+// bump above (LLM_PARALLELISM 4→6 = more in-flight synthesis) pushes it
+// higher. 8g gives comfortable headroom on the 60g host. Reservation 2g→4g.
+export const HINDSIGHT_DEFAULT_MEM_LIMIT = "8g";
+export const HINDSIGHT_DEFAULT_MEM_RESERVATION = "4g";
 export const HINDSIGHT_DEFAULT_PIDS_LIMIT = 1000;
 
 /**
@@ -422,6 +441,8 @@ export function startHindsight(ports?: { apiPort: number; uiPort: number }): voi
     // one more concurrent bank during backlog recovery. See constants above.
     "-e", `HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`,
     "-e", `HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
+    "-e", `HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
+    "-e", `HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,
   ];
 
   const args = [
@@ -589,6 +610,8 @@ export function generateHindsightComposeSnippet(): string {
     `      - HINDSIGHT_API_REFLECT_WALL_TIMEOUT=${HINDSIGHT_DEFAULT_REFLECT_WALL_TIMEOUT_S}`,
     `      - HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`,
     `      - HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`,
+    `      - HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`,
+    `      - HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`,
     `    mem_limit: ${HINDSIGHT_DEFAULT_MEM_LIMIT}`,
     `    mem_reservation: ${HINDSIGHT_DEFAULT_MEM_RESERVATION}`,
     `    pids_limit: ${HINDSIGHT_DEFAULT_PIDS_LIMIT}`,

--- a/tests/setup/hindsight.test.ts
+++ b/tests/setup/hindsight.test.ts
@@ -179,11 +179,28 @@ describe("hindsight broker-fed mode (#1245)", () => {
     }
     expect(envPairs).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`);
     expect(envPairs).toContain(`HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`);
-    // Kept modest to stay subscription-honest (concurrent claude subprocesses).
-    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS).toBeLessThanOrEqual(4);
+    expect(envPairs).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`);
+    expect(envPairs).toContain(`HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`);
+    // Subscription-honest ceiling: concurrent model calls = slots × parallelism.
+    // Keep it well under a reckless level (was 12; bumped to 18, cap the guard at 24).
+    expect(h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS * h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM).toBeLessThanOrEqual(24);
     const snippet = h.generateHindsightComposeSnippet();
-    expect(snippet).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_BATCH_SIZE=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_BATCH_SIZE}`);
-    expect(snippet).toContain(`HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_SLOTS}`);
+    expect(snippet).toContain(`HINDSIGHT_API_CONSOLIDATION_LLM_PARALLELISM=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_LLM_PARALLELISM}`);
+    expect(snippet).toContain(`HINDSIGHT_API_CONSOLIDATION_MAX_MEMORIES_PER_ROUND=${h.HINDSIGHT_DEFAULT_CONSOLIDATION_MAX_MEMORIES_PER_ROUND}`);
+  });
+
+  it("raises the memory limit to give the throughput bump headroom (8g, was 4g)", async () => {
+    const h = await import("../../src/setup/hindsight.js");
+    // Baseline RSS ~3.4g; 4g was tight, and more in-flight consolidation
+    // raises it. Both emit paths must carry the bumped limit.
+    const m = /^(\d+)g$/.exec(h.HINDSIGHT_DEFAULT_MEM_LIMIT);
+    expect(m, "mem limit should be N gigabytes").not.toBeNull();
+    expect(Number(m![1])).toBeGreaterThanOrEqual(8);
+    startHindsight({ apiPort: 8888, uiPort: 9999 });
+    expect(findRunArgs()).toContain(`--memory=${h.HINDSIGHT_DEFAULT_MEM_LIMIT}`);
+    expect(h.generateHindsightComposeSnippet()).toMatch(
+      new RegExp(`mem_limit:\\s*${h.HINDSIGHT_DEFAULT_MEM_LIMIT}\\b`),
+    );
   });
 
   it("enables stateless MCP (HINDSIGHT_API_MCP_STATELESS=true) so a hindsight bounce doesn't strand agent-side MCP sessions", () => {


### PR DESCRIPTION
## Summary

Two follow-ups from the 2026-06-19 backlog investigation, applied live via the **managed** `memory setup --recreate` (broker-coordinated, no outage).

1. **`MEM_LIMIT` 4 GB → 8 GB** (reservation 2 GB → 4 GB). Baseline RSS is ~3.4 GB on a 9-agent fleet — only ~600 MB headroom under the old 4 GB cap — and the throughput bump below raises it. 8 GB is comfortable on the 60 GB host.
2. **Expose the per-bank consolidation throughput knobs** as switchroom defaults (operator-overridable): `LLM_PARALLELISM` 4→6 and `MAX_MEMORIES_PER_ROUND` 100→300. These target a *single* backed-up bank, where `MAX_SLOTS` doesn't help (slots parallelise *across* banks). The hard ceiling on concurrent model calls is `slots × parallelism`, kept **fleet-safe at 3×6=18** (was 12) — not a reckless doubling that would starve the fleet's interactive subscription usage.

## Why bake them in (not a one-off)

These knobs aren't reachable via the managed `memory setup` path without code, and **hindsight cannot be safely hand-recreated** — a raw `docker run` breaks the auth-broker socket handshake and takes memory down (learned the hard way during this dig). So the only safe way to tune them is in `startHindsight` + the compose snippet. This PR does that; a future `switchroom update` keeps them through recreates.

## Test plan
- [x] `tests/setup/hindsight.test.ts` — both new env on **both** emit paths; the `slots × parallelism ≤ 24` ceiling guard; 8 GB mem on both paths. 25 pass.
- [x] `tsc` clean.
- [x] Applied live + verified: `health=healthy`, auth working, mem=8 GB, `PARALLELISM=6`/`MAX_MEMORIES_PER_ROUND=300` in the worker process, data intact (165,776 memory_units).

🤖 Generated with [Claude Code](https://claude.com/claude-code)