### PR TITLE
feat(memory): profile banks + memory.recall.additional_banks (per-user memory, ship-B)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,35 @@ The cap applies to the *combined* result list across the primary bank and any `r
 
 Operationally: the cap is set via the `HINDSIGHT_RECALL_MAX_MEMORIES` env var that `start.sh` exports. The vendored plugin's `recall.py` slices results client-side before formatting (plugin v0.4.0 has no `recallTopK` setting on the Claude Code integration — only Openclaw exposes it).
 
+### Shared / profile recall banks — `memory.recall.additional_banks`
+
+By default an agent recalls only its own bank. Point `additional_banks` at one or more extra Hindsight banks and the recall hook queries them too on every turn, **merging** their hits into the agent's own results (each extra bank gets an 8s timeout and is non-fatal on failure). Use this for a shared operator/household profile every agent should know — preferences, projects, people — kept consistent fleet-wide.
+
+```yaml
+defaults:
+  memory:
+    recall:
+      additional_banks: ["operator-profile"]   # every agent also recalls this bank
+
+agents:
+  coach:
+    memory:
+      recall:
+        additional_banks: ["operator-profile", "fitness-context"]
+```
+
+This stays within the **single tenant**: every bank is your own data, in your own Hindsight instance, fully visible to you (see the [`single-tenant`](../reference/invariants.md#single-tenant) invariant). It is additive recall scoping, never an access boundary.
+
+**Authoring a profile bank — `switchroom memory profile`:**
+
+```
+switchroom memory profile add operator-profile "Ken prefers concise, direct answers and dislikes preamble."
+switchroom memory profile add operator-profile "Primary project this quarter is the switchroom fleet."
+switchroom memory profile list operator-profile        # inspect what's in the bank
+```
+
+`add` retains an operator-authored fact into the named bank (creating it on first write); fact extraction runs in the background, so `list` may lag a few seconds. After authoring, wire the bank in via `additional_banks` (above), then `switchroom apply` + restart the agent(s).
+
 ### Demoting individual memories from auto-recall
 
 If one specific memory keeps surfacing in the recall block and isn't useful (over-broad world fact, stale context, etc.), tag it with `[demote-from-recall]` — or `demote-from-recall` / `no-recall`, all three work. The memory stays in the bank, `mcp__hindsight__reflect` and manual recall can still find it, but auto-recall skips it.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2161,11 +2161,20 @@ export function installHindsightPlugin(
   // turn is correct.
   // Resolve the effective extra recall banks for this agent — the static
   // shared-bank foundation for per-user memory (ship-B; RFC
-  // reference/rfcs/per-speaker-memory-routing.md). `agentMemory` is the
-  // cascaded per-agent memory (defaults.memory.recall is already merged in by
-  // src/config/merge.ts), so the per-agent value wins and the fleet default
-  // is reflected here too.
-  const additionalBanks = agentMemory?.recall?.additional_banks ?? [];
+  // reference/rfcs/per-speaker-memory-routing.md). Read from the CASCADED
+  // config (defaults → profile → agent), mirroring how the env-export path
+  // reads the sibling recall knobs (max_memories etc.) — so a fleet-wide
+  // `defaults.memory.recall.additional_banks` is honoured, not just a
+  // per-agent value. `switchroomConfig.agents[agentName]` is the raw,
+  // pre-cascade block, so resolve it here.
+  const agentRaw = switchroomConfig.agents[agentName];
+  const additionalBanks = agentRaw
+    ? resolveAgentConfig(
+        switchroomConfig.defaults,
+        switchroomConfig.profiles,
+        agentRaw,
+      ).memory?.recall?.additional_banks ?? []
+    : [];
   applyHindsightSettingsOverrides(destPath, additionalBanks);
 
   // Resolve the agent's bank/collection name and the Hindsight REST URL.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2159,7 +2159,14 @@ export function installHindsightPlugin(
   // (cheap — async POST to a local container). Memory is the moat
   // (reference/jobs/remember-across-sessions.md); paying for it on every
   // turn is correct.
-  applyHindsightSettingsOverrides(destPath);
+  // Resolve the effective extra recall banks for this agent — the static
+  // shared-bank foundation for per-user memory (ship-B; RFC
+  // reference/rfcs/per-speaker-memory-routing.md). `agentMemory` is the
+  // cascaded per-agent memory (defaults.memory.recall is already merged in by
+  // src/config/merge.ts), so the per-agent value wins and the fleet default
+  // is reflected here too.
+  const additionalBanks = agentMemory?.recall?.additional_banks ?? [];
+  applyHindsightSettingsOverrides(destPath, additionalBanks);
 
   // Resolve the agent's bank/collection name and the Hindsight REST URL.
   // The plugin's hooks expect HINDSIGHT_API_URL (the REST base), not the
@@ -2187,7 +2194,10 @@ export function installHindsightPlugin(
  * updates. This function is the single point of switchroom-specific
  * memory tuning.
  */
-function applyHindsightSettingsOverrides(pluginDestPath: string): void {
+function applyHindsightSettingsOverrides(
+  pluginDestPath: string,
+  additionalBanks: readonly string[],
+): void {
   const settingsPath = join(pluginDestPath, "settings.json");
   if (!existsSync(settingsPath)) return; // vendor structure changed; bail safely
   let raw: string;
@@ -2239,6 +2249,15 @@ function applyHindsightSettingsOverrides(pluginDestPath: string): void {
   // opt OUT via memory.recall.skip_trivial=false in switchroom.yaml
   // (exported as HINDSIGHT_RECALL_SKIP_TRIVIAL only when overridden).
   settings.recallSkipTrivial = true;
+  // Static shared-bank recall (RFC reference/rfcs/per-speaker-memory-routing.md,
+  // ship-B): recall these extra banks on every turn, merged into the agent's
+  // own bank results. Sourced from memory.recall.additional_banks (cascaded);
+  // written per-agent because settings.json is per-agent. Left at the vendor
+  // default ([]) when unset. The plugin recalls each with an 8s timeout and is
+  // non-fatal on failure. Single-tenant: all banks are the operator's data.
+  if (additionalBanks.length > 0) {
+    settings.recallAdditionalBanks = [...additionalBanks];
+  }
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
 }
 

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -573,4 +573,154 @@ export function registerMemoryCommand(program: Command): void {
         },
       ),
     );
+
+  // switchroom memory profile — author + inspect operator "profile" banks.
+  // The static shared-bank foundation for per-user memory (RFC
+  // reference/rfcs/per-speaker-memory-routing.md, ship-B): operator-authored
+  // facts live in their own Hindsight bank, wired into agents via
+  // memory.recall.additional_banks. Single-tenant — the operator's own data
+  // in the operator's Hindsight instance.
+  const restBase = (url: string | undefined): string =>
+    (url ?? "http://127.0.0.1:8888/mcp/")
+      .replace(/\/mcp\/?$/, "")
+      .replace(/\/$/, "");
+  const VALID_BANK = /^[a-zA-Z0-9_.-]+$/;
+
+  const profile = memory
+    .command("profile")
+    .description(
+      "Author + inspect operator profile banks (shared/per-user memory; wire via memory.recall.additional_banks)",
+    );
+
+  profile
+    .command("add <bank> <fact...>")
+    .description(
+      "Add an operator-authored fact to a profile bank (creates the bank on first write)",
+    )
+    .option(
+      "--timeout <ms>",
+      "HTTP timeout in milliseconds (retain runs synchronously; default: 60000)",
+      "60000",
+    )
+    .action(
+      withConfigError(
+        async (bank: string, factWords: string[], opts: { timeout: string }) => {
+          const config = getConfig(program);
+          if (!bank || !VALID_BANK.test(bank)) {
+            console.error(
+              chalk.red(
+                "Bank name must be non-empty and contain only letters, digits, '.', '_', or '-'.",
+              ),
+            );
+            process.exit(1);
+          }
+          const content = factWords.join(" ").trim();
+          if (content.length === 0) {
+            console.error(chalk.red("A non-empty fact is required."));
+            process.exit(1);
+          }
+          const base = restBase(config.memory?.config?.url as string | undefined);
+          const url = `${base}/v1/default/banks/${encodeURIComponent(bank)}/memories`;
+          const timeoutMs = Math.max(1000, parseInt(opts.timeout, 10) || 60000);
+          const ctrl = new AbortController();
+          const t = setTimeout(() => ctrl.abort(), timeoutMs);
+          try {
+            const res = await fetch(url, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                items: [{ content, tags: ["operator-authored", "profile"] }],
+                async: false,
+              }),
+              signal: ctrl.signal,
+            });
+            if (!res.ok) {
+              console.error(
+                chalk.red(`✗ Retain failed: HTTP ${res.status}`),
+                chalk.gray(await res.text().catch(() => "")),
+              );
+              process.exit(1);
+            }
+            console.log(chalk.green(`✓ Added to profile bank "${bank}"`));
+            console.log(chalk.gray(`  ${content}`));
+            console.log(
+              chalk.gray(
+                "  (fact extraction runs in the background — `profile list` may lag a few seconds)",
+              ),
+            );
+            console.log(
+              chalk.gray(
+                `\n  Wire it into agents via memory.recall.additional_banks: ["${bank}"] in switchroom.yaml,\n  then \`switchroom apply\` + restart the agent(s).`,
+              ),
+            );
+          } catch (e) {
+            console.error(
+              chalk.red("✗ Retain failed:"),
+              chalk.gray(e instanceof Error ? e.message : String(e)),
+            );
+            process.exit(1);
+          } finally {
+            clearTimeout(t);
+          }
+        },
+      ),
+    );
+
+  profile
+    .command("list <bank>")
+    .description("List the memory units in a profile bank")
+    .option("--limit <n>", "Max units to show (default: 50)", "50")
+    .option("--timeout <ms>", "HTTP timeout in milliseconds (default: 10000)", "10000")
+    .action(
+      withConfigError(
+        async (bank: string, opts: { limit: string; timeout: string }) => {
+          const config = getConfig(program);
+          if (!bank || !VALID_BANK.test(bank)) {
+            console.error(chalk.red("Bank name must contain only letters, digits, '.', '_', or '-'."));
+            process.exit(1);
+          }
+          const base = restBase(config.memory?.config?.url as string | undefined);
+          const limit = Math.max(1, parseInt(opts.limit, 10) || 50);
+          const url = `${base}/v1/default/banks/${encodeURIComponent(bank)}/memories/list?limit=${limit}`;
+          const timeoutMs = Math.max(1000, parseInt(opts.timeout, 10) || 10000);
+          const ctrl = new AbortController();
+          const t = setTimeout(() => ctrl.abort(), timeoutMs);
+          try {
+            const res = await fetch(url, { signal: ctrl.signal });
+            if (!res.ok) {
+              console.error(
+                chalk.red(`✗ List failed: HTTP ${res.status}`),
+                chalk.gray(await res.text().catch(() => "")),
+              );
+              process.exit(1);
+            }
+            const data = (await res.json()) as {
+              results?: unknown[];
+              memories?: unknown[];
+              units?: unknown[];
+            };
+            const units = (data.results ?? data.memories ?? data.units ?? []) as Array<
+              Record<string, unknown>
+            >;
+            console.log(chalk.bold(`\n  Profile bank "${bank}" — ${units.length} unit(s)\n`));
+            for (const u of units) {
+              const ft = ((u.fact_type as string) ?? "?").padEnd(11);
+              const text = String(u.content ?? u.text ?? "")
+                .replace(/\s+/g, " ")
+                .slice(0, 100);
+              console.log(`  ${chalk.gray(ft)} ${text}`);
+            }
+            console.log();
+          } catch (e) {
+            console.error(
+              chalk.red("✗ List failed:"),
+              chalk.gray(e instanceof Error ? e.message : String(e)),
+            );
+            process.exit(1);
+          } finally {
+            clearTimeout(t);
+          }
+        },
+      ),
+    );
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -384,6 +384,18 @@ export const AgentMemorySchema = z
             "[\"world\", \"experience\"] to opt out of observation-backed " +
             "recall for this agent (or fleet-wide under defaults).",
           ),
+        additional_banks: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Extra Hindsight banks to recall from on every turn, merged into " +
+            "the agent's own bank results — e.g. a shared operator/household " +
+            "profile bank authored via `switchroom memory profile`. Each is " +
+            "recalled with an 8s timeout and is non-fatal on failure. Stays " +
+            "within the single tenant: all banks are the operator's data, in " +
+            "the operator's Hindsight instance (see the `single-tenant` " +
+            "invariant). Defaults to [] (no extra banks).",
+          ),
         skip_trivial: z
           .boolean()
           .optional()
@@ -1814,6 +1826,7 @@ const profileFields = {
           max_memories: z.number().int().min(0).optional(),
           cache_ttl_secs: z.number().int().min(0).optional(),
           min_overlap: z.number().min(0).max(1).optional(),
+          additional_banks: z.array(z.string()).optional(),
         })
         .optional(),
     })

--- a/tests/scaffold.recall-additional-banks.test.ts
+++ b/tests/scaffold.recall-additional-banks.test.ts
@@ -63,4 +63,39 @@ describe("hindsight recall — additional_banks → recallAdditionalBanks", () =
     expect(s.recallSkipTrivial).toBe(true);
     expect(s.recallMaxMemories).toBe(8);
   });
+
+  // The headline use case: a shared profile bank set ONCE under `defaults`
+  // must reach every agent. This exercises the cascade (defaults → agent),
+  // which the per-agent-only cases above do not.
+  function settingsForCascade(cfg: {
+    defaults?: unknown;
+    agentMemory?: unknown;
+  }): Record<string, unknown> {
+    const config = {
+      agents: { probe: cfg.agentMemory ? { memory: cfg.agentMemory } : {} },
+      defaults: cfg.defaults,
+      memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+      telegram: { bot_token: "t", forum_chat_id: "c" },
+    } as unknown as SwitchroomConfig;
+    const res = installHindsightPlugin("probe", tmpDir, config);
+    expect(res).not.toBeNull();
+    const p = join(tmpDir, ".claude", "plugins", "hindsight-memory", "settings.json");
+    return JSON.parse(readFileSync(p, "utf-8"));
+  }
+
+  it("cascade: a fleet-wide defaults.memory.recall.additional_banks reaches an agent with no override", () => {
+    const s = settingsForCascade({
+      defaults: { memory: { recall: { additional_banks: ["operator-profile"] } } },
+    });
+    expect(s.recallAdditionalBanks).toEqual(["operator-profile"]);
+  });
+
+  it("cascade: a per-agent additional_banks overrides the fleet default", () => {
+    const s = settingsForCascade({
+      defaults: { memory: { recall: { additional_banks: ["operator-profile"] } } },
+      agentMemory: { recall: { additional_banks: ["probe-only"] } },
+    });
+    // recall deep-merges per-key (replace), so the agent's array wins.
+    expect(s.recallAdditionalBanks).toEqual(["probe-only"]);
+  });
 });

--- a/tests/scaffold.recall-additional-banks.test.ts
+++ b/tests/scaffold.recall-additional-banks.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { installHindsightPlugin } from "../src/agents/scaffold.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+/**
+ * Ship-B (RFC reference/rfcs/per-speaker-memory-routing.md): an agent's
+ * `memory.recall.additional_banks` flows into the copied plugin
+ * settings.json as `recallAdditionalBanks`, so the recall hook merges those
+ * extra (shared / profile) banks into the agent's own bank results. This is
+ * the static foundation for per-user memory routing.
+ */
+describe("hindsight recall — additional_banks → recallAdditionalBanks", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `scaffold-addl-banks-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function settingsFor(agentMemory: unknown): Record<string, unknown> {
+    const config = {
+      agents: { probe: { memory: agentMemory } },
+      memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+      telegram: { bot_token: "t", forum_chat_id: "c" },
+    } as unknown as SwitchroomConfig;
+    const res = installHindsightPlugin("probe", tmpDir, config);
+    expect(res).not.toBeNull();
+    const p = join(tmpDir, ".claude", "plugins", "hindsight-memory", "settings.json");
+    expect(existsSync(p)).toBe(true);
+    return JSON.parse(readFileSync(p, "utf-8"));
+  }
+
+  it("writes recallAdditionalBanks when memory.recall.additional_banks is set", () => {
+    const s = settingsFor({ recall: { additional_banks: ["operator-profile", "household"] } });
+    expect(s.recallAdditionalBanks).toEqual(["operator-profile", "household"]);
+  });
+
+  it("leaves recallAdditionalBanks at the vendor default when unset (no extra banks)", () => {
+    const s = settingsFor({});
+    // switchroom doesn't write the key when there are no extra banks; the
+    // vendor's settings.json default ([]) stands.
+    expect(s.recallAdditionalBanks ?? []).toEqual([]);
+  });
+
+  it("does not write the key for an empty additional_banks array", () => {
+    const s = settingsFor({ recall: { additional_banks: [] } });
+    expect(s.recallAdditionalBanks ?? []).toEqual([]);
+  });
+
+  it("regression: the Phase 1/6a recall overrides still apply alongside", () => {
+    const s = settingsFor({ recall: { additional_banks: ["operator-profile"] } });
+    expect(s.recallAdditionalBanks).toEqual(["operator-profile"]);
+    expect(s.recallTypes).toContain("observation");
+    expect(s.recallSkipTrivial).toBe(true);
+    expect(s.recallMaxMemories).toBe(8);
+  });
+});


### PR DESCRIPTION
## Summary

The **write-side + static recall foundation** for per-user memory routing (RFC `reference/rfcs/per-speaker-memory-routing.md`), unblocked by the single-tenant clarification (#2439). The dynamic per-speaker routing layer (PR2) builds directly on this.

Three pieces:
1. **Config** — new `memory.recall.additional_banks` (`string[]`) on both the defaults and per-agent recall tiers. Extra Hindsight banks recalled on every turn and **merged** into the agent's own results.
2. **Scaffold** — `installHindsightPlugin` resolves the cascaded `additional_banks` and writes them as `recallAdditionalBanks` into each agent's plugin `settings.json` (the sanctioned switchroom override point). Left at the vendor default (`[]`) when unset. The plugin's multi-bank recall (8s timeout per bank, non-fatal on failure) is already built and hardened.
3. **CLI** — `switchroom memory profile add <bank> <fact...>` retains an operator-authored fact into a named bank (creates it on first write); `switchroom memory profile list <bank>` inspects it. Uses the Hindsight retain (`POST .../memories`) / list (`GET .../memories/list`) REST endpoints derived from `memory.config.url`.

## Why
Delivers the per-user memory isolation that #2439 made an explicit goal of `remember-across-sessions` — a shared/profile bank an operator authors once and every agent recalls consistently. Serves both relevance and token efficiency.

## Single-tenant
All banks are the operator's own data, in the operator's Hindsight instance, fully visible to the operator. `additional_banks` is **additive recall scoping, never an access boundary** — consistent with the clarified invariant.

## Test plan
- [x] `tsc` + full `npm run lint` clean.
- [x] `tests/scaffold.recall-additional-banks.test.ts` (new) — writes `recallAdditionalBanks` when set; vendor default when unset/empty; Phase-1/6a regression. + existing `scaffold.recall-observations` — 7 pass.
- [x] **Live smoke test** against the running hindsight: `profile add` → 3 extracted units → `list` → DELETE cleanup, end-to-end.

## Risk
New CLI subcommand + one new optional config field + a per-agent `settings.json` key written only when configured. No change to existing behavior when `additional_banks` is unset (the common case).

## Follow-up
PR2 — per-speaker routing: `memory.recall.sender_banks` map + the vendor recall-hook change to select the bank dynamically by Telegram sender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)