### PR TITLE
feat(memory): per-speaker recall routing — sender_banks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,24 @@ switchroom memory profile list operator-profile        # inspect what's in the b
 
 `add` retains an operator-authored fact into the named bank (creating it on first write); fact extraction runs in the background, so `list` may lag a few seconds. After authoring, wire the bank in via `additional_banks` (above), then `switchroom apply` + restart the agent(s).
 
+### Per-speaker recall — `memory.recall.sender_banks`
+
+When an agent serves **multiple trusted users**, route recall to the *speaker's* profile bank with a `sender_banks` map. On each inbound, the agent recalls its own bank **plus** the bank mapped to whoever sent the message — so each user gets their own context instead of a blended pool. This is the per-user isolation the [`single-tenant`](../reference/invariants.md#single-tenant) invariant calls for, and it keeps recall relevant + token-efficient.
+
+```yaml
+agents:
+  clerk:
+    memory:
+      recall:
+        sender_banks:
+          "@lisa": lisa-profile      # match by Telegram @username …
+          "123456789": ken-profile   # … or by numeric user_id
+```
+
+The key is matched against the sender's Telegram username (when they have one) or their numeric user id — both are emitted in the message envelope. Author the target banks with `switchroom memory profile add <bank> "..."` (above).
+
+**It is additive recall scoping, never an access boundary.** Who may *drive* an agent stays the per-agent assignment in `access.allowFrom` — the sender hint only changes which memory is *recalled*, never who is allowed to talk to the agent. All banks remain your own data in your own Hindsight instance, fully visible to you. Combine with `additional_banks` for a shared bank everyone sees *plus* a per-person bank.
+
 ### Demoting individual memories from auto-recall
 
 If one specific memory keeps surfacing in the recall block and isn't useful (over-broad world fact, stale context, etc.), tag it with `[demote-from-recall]` — or `demote-from-recall` / `no-recall`, all three work. The memory stays in the bank, `mcp__hindsight__reflect` and manual recall can still find it, but auto-recall skips it.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,11 +141,11 @@ agents:
     memory:
       recall:
         sender_banks:
-          "@lisa": lisa-profile      # match by Telegram @username …
+          "@lisa": lisa-profile      # by Telegram username (leading @ optional) …
           "123456789": ken-profile   # … or by numeric user_id
 ```
 
-The key is matched against the sender's Telegram username (when they have one) or their numeric user id — both are emitted in the message envelope. Author the target banks with `switchroom memory profile add <bank> "..."` (above).
+The key is matched against the sender's Telegram username (when they have one) or their numeric user id — both are emitted in the message envelope. A leading `@` is optional: `@lisa` and `lisa` both match (the gateway emits the bare handle). Author the target banks with `switchroom memory profile add <bank> "..."` (above).
 
 **It is additive recall scoping, never an access boundary.** Who may *drive* an agent stays the per-agent assignment in `access.allowFrom` — the sender hint only changes which memory is *recalled*, never who is allowed to talk to the agent. All banks remain your own data in your own Hindsight instance, fully visible to you. Combine with `additional_banks` for a shared bank everyone sees *plus* a per-person bank.
 

--- a/profiles/_base/start.sh.hbs
+++ b/profiles/_base/start.sh.hbs
@@ -355,6 +355,12 @@ export HINDSIGHT_RECALL_SKIP_TRIVIAL={{hindsightRecallSkipTrivial}}
 {{#if hindsightTopicAliasesJsonQ}}
 export HINDSIGHT_TOPIC_ALIASES_JSON={{{hindsightTopicAliasesJsonQ}}}
 {{/if}}
+# Switchroom (per-speaker memory routing): {sender: bank} map so recall.py
+# routes recall to the speaker's profile bank. Emitted only when the agent
+# has a memory.recall.sender_banks map; absent for single-user agents.
+{{#if hindsightSenderBanksJsonQ}}
+export HINDSIGHT_SENDER_BANKS_JSON={{{hindsightSenderBanksJsonQ}}}
+{{/if}}
 # PR6 — topic filter mode for cross-topic memory recall. Default
 # "soft-preamble": all topic-tagged memories surface and the model
 # decides relevance via the preamble. "hard-filter": drop memories

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -2334,6 +2334,10 @@ interface BuildWorkspaceContextArgs {
   // Optional filter-mode env injected at scaffold time (default
   // "soft-preamble" if unset; "hard-filter" to drop cross-topic memories).
   hindsightTopicAliasesJson?: string;
+  // Switchroom (per-speaker memory routing): JSON map of {sender: bank}
+  // injected as HINDSIGHT_SENDER_BANKS_JSON so recall.py routes recall to
+  // the speaker's profile bank.
+  hindsightSenderBanksJson?: string;
   hindsightTopicFilterMode?: string;
 }
 
@@ -2365,6 +2369,7 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightTopicAliasesJson,
+    hindsightSenderBanksJson,
     hindsightTopicFilterMode,
   } = args;
   return {
@@ -2447,6 +2452,9 @@ function buildWorkspaceContext(args: BuildWorkspaceContextArgs): Record<string, 
     // false-y for fleet-shared / DM agents (the dominant case).
     hindsightTopicAliasesJsonQ: hindsightTopicAliasesJson
       ? shellSingleQuote(hindsightTopicAliasesJson)
+      : undefined,
+    hindsightSenderBanksJsonQ: hindsightSenderBanksJson
+      ? shellSingleQuote(hindsightSenderBanksJson)
       : undefined,
     hindsightTopicFilterMode,
     switchroomConfigPathQ: switchroomConfigPath
@@ -3055,6 +3063,13 @@ export function scaffoldAgent(
   const hindsightTopicAliasesJson = topicAliases && Object.keys(topicAliases).length > 0
     ? JSON.stringify(topicAliases)
     : undefined;
+  // Switchroom (per-speaker memory routing): {sender: bank} map →
+  // HINDSIGHT_SENDER_BANKS_JSON. Sourced from memory.recall.sender_banks
+  // (cascaded). Undefined when no map is set (the env-export block no-ops).
+  const senderBanks = agentConfig.memory?.recall?.sender_banks;
+  const hindsightSenderBanksJson = senderBanks && Object.keys(senderBanks).length > 0
+    ? JSON.stringify(senderBanks)
+    : undefined;
   // PR6 — topic filter mode opt-in. Defaults to undefined (the script
   // falls back to "soft-preamble" internally). Operator sets via
   // memory.recall.topic_filter_mode in switchroom.yaml when binding
@@ -3089,6 +3104,7 @@ export function scaffoldAgent(
     hindsightRecallTypes,
     hindsightRecallSkipTrivial,
     hindsightTopicAliasesJson,
+    hindsightSenderBanksJson,
     hindsightTopicFilterMode,
   });
 
@@ -5040,6 +5056,11 @@ export function reconcileAgent(
   const hindsightTopicAliasesJson = topicAliases && Object.keys(topicAliases).length > 0
     ? JSON.stringify(topicAliases)
     : undefined;
+  // Switchroom (per-speaker memory routing): mirror scaffoldAgent's compute.
+  const senderBanks = agentConfig.memory?.recall?.sender_banks;
+  const hindsightSenderBanksJson = senderBanks && Object.keys(senderBanks).length > 0
+    ? JSON.stringify(senderBanks)
+    : undefined;
   const hindsightTopicFilterMode = (
     agentConfig.memory?.recall as { topic_filter_mode?: string } | undefined
   )?.topic_filter_mode;
@@ -5109,6 +5130,9 @@ export function reconcileAgent(
       // we actually have a topic_aliases map.
       hindsightTopicAliasesJsonQ: hindsightTopicAliasesJson
         ? shellSingleQuote(hindsightTopicAliasesJson)
+        : undefined,
+      hindsightSenderBanksJsonQ: hindsightSenderBanksJson
+        ? shellSingleQuote(hindsightSenderBanksJson)
         : undefined,
       hindsightTopicFilterMode,
       // Mirror buildWorkspaceContext (#910): host home for the
@@ -5781,6 +5805,7 @@ export function reconcileAgent(
       hindsightRecallTypes,
       hindsightRecallSkipTrivial,
       hindsightTopicAliasesJson,
+      hindsightSenderBanksJson,
       hindsightTopicFilterMode,
     });
     // Phase 5 migration: preserve any agent-specific edits to the legacy

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -402,7 +402,8 @@ export const AgentMemorySchema = z
           .describe(
             "Per-speaker recall routing: a map of Telegram sender → extra " +
             "recall bank. When a message arrives, the agent also recalls the " +
-            "speaker's bank (matched by @username or numeric user_id), merged " +
+            "speaker's bank (matched by Telegram username — a leading @ is " +
+            "optional — or numeric user_id), merged " +
             "into its own results — so each trusted user gets their own " +
             "profile context. Additive recall scoping within the single " +
             "tenant: never an access boundary (who may drive an agent stays " +

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -396,6 +396,19 @@ export const AgentMemorySchema = z
             "the operator's Hindsight instance (see the `single-tenant` " +
             "invariant). Defaults to [] (no extra banks).",
           ),
+        sender_banks: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe(
+            "Per-speaker recall routing: a map of Telegram sender → extra " +
+            "recall bank. When a message arrives, the agent also recalls the " +
+            "speaker's bank (matched by @username or numeric user_id), merged " +
+            "into its own results — so each trusted user gets their own " +
+            "profile context. Additive recall scoping within the single " +
+            "tenant: never an access boundary (who may drive an agent stays " +
+            "the per-agent user assignment in `access.allowFrom`). Author the " +
+            "banks via `switchroom memory profile`.",
+          ),
         skip_trivial: z
           .boolean()
           .optional()
@@ -1827,6 +1840,7 @@ const profileFields = {
           cache_ttl_secs: z.number().int().min(0).optional(),
           min_overlap: z.number().min(0).max(1).optional(),
           additional_banks: z.array(z.string()).optional(),
+          sender_banks: z.record(z.string(), z.string()).optional(),
         })
         .optional(),
     })

--- a/tests/scaffold.sender-banks-env.test.ts
+++ b/tests/scaffold.sender-banks-env.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * Per-speaker memory routing (RFC reference/rfcs/per-speaker-memory-routing.md):
+ * `memory.recall.sender_banks` is serialized into start.sh as
+ * HINDSIGHT_SENDER_BANKS_JSON, which the recall hook reads to route recall to
+ * the speaker's profile bank. Mirrors the topic-aliases env wiring — emitted
+ * only when the agent has a sender_banks map (single-user agents get nothing),
+ * and resolved from the CASCADED config so a fleet-wide `defaults` value works.
+ */
+describe("per-speaker routing — sender_banks → HINDSIGHT_SENDER_BANKS_JSON", () => {
+  let tmpDir: string;
+  let telegram: TelegramConfig;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `sender-banks-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    telegram = { bot_token: "t", forum_chat_id: "c" };
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function configWith(opts: { defaults?: unknown; agentMemory?: unknown }): SwitchroomConfig {
+    return {
+      agents: { probe: opts.agentMemory ? ({ memory: opts.agentMemory } as never) : {} },
+      defaults: opts.defaults,
+      memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+      telegram,
+    } as SwitchroomConfig;
+  }
+
+  function startShFor(opts: { defaults?: unknown; agentMemory?: unknown }): string {
+    const config = configWith(opts);
+    const res = scaffoldAgent("probe", config.agents.probe ?? {}, tmpDir, telegram, config);
+    return readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+  }
+
+  function exportedMap(startSh: string): Record<string, string> | null {
+    const m = startSh.match(/export HINDSIGHT_SENDER_BANKS_JSON=(.+)/);
+    if (!m) return null;
+    // shellSingleQuote wraps the JSON in single quotes; JSON has none of its
+    // own, so stripping the surrounding quotes is safe.
+    return JSON.parse(m[1].replace(/^'/, "").replace(/'$/, ""));
+  }
+
+  it("no sender_banks: no HINDSIGHT_SENDER_BANKS_JSON export (single-user agents)", () => {
+    expect(startShFor({})).not.toMatch(/export HINDSIGHT_SENDER_BANKS_JSON=/);
+  });
+
+  it("empty sender_banks map: still no export", () => {
+    expect(startShFor({ agentMemory: { recall: { sender_banks: {} } } })).not.toMatch(
+      /export HINDSIGHT_SENDER_BANKS_JSON=/,
+    );
+  });
+
+  it("per-agent sender_banks → exports the JSON map", () => {
+    const startSh = startShFor({
+      agentMemory: { recall: { sender_banks: { "@lisa": "lisa-profile", "123": "ken-profile" } } },
+    });
+    expect(startSh).toMatch(/export HINDSIGHT_SENDER_BANKS_JSON=/);
+    expect(exportedMap(startSh)).toEqual({ "@lisa": "lisa-profile", "123": "ken-profile" });
+  });
+
+  it("cascade: a fleet-wide defaults.memory.recall.sender_banks reaches an agent with no override", () => {
+    const startSh = startShFor({
+      defaults: { memory: { recall: { sender_banks: { "@lisa": "lisa-profile" } } } },
+    });
+    expect(exportedMap(startSh)).toEqual({ "@lisa": "lisa-profile" });
+  });
+});

--- a/vendor/hindsight-memory/scripts/lib/gateway_ipc.py
+++ b/vendor/hindsight-memory/scripts/lib/gateway_ipc.py
@@ -89,6 +89,35 @@ def extract_topic_from_prompt(
     return chat_id, thread_id
 
 
+# Switchroom (per-speaker memory routing, RFC
+# reference/rfcs/per-speaker-memory-routing.md): extract the sender identity
+# (`user=` attribute) from the channel envelope. The gateway emits
+# `user = from.username ?? String(from.id)`, so this is a username when the
+# sender has one, else their numeric Telegram user id. Used to route recall to
+# the speaker's profile bank — additive recall scoping, never an auth boundary.
+_USER_RE = re.compile(
+    r"<channel\b[^>]*\buser=[\"']([^\"']+)[\"']",
+    re.IGNORECASE,
+)
+
+
+def extract_user_from_prompt(prompt: str) -> Optional[str]:
+    """Pull the sender `user` out of the `<channel ...>` envelope.
+
+    Returns None when the prompt isn't channel-wrapped (interactive
+    sessions, non-Telegram channels, test fixtures). The value is the
+    sender's username when set, else their numeric Telegram user id.
+    """
+    if not prompt or not isinstance(prompt, str):
+        return None
+    head = prompt[:1024]
+    match = _USER_RE.search(head)
+    if not match:
+        return None
+    user = match.group(1).strip()
+    return user or None
+
+
 def gateway_socket_path() -> Optional[str]:
     """Resolve the gateway socket path for the current agent.
 

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -59,7 +59,7 @@ from lib.content import (
 )
 from lib.daemon import get_api_url
 from lib.directives import fetch_active_directives, format_active_directives_block
-from lib.gateway_ipc import extract_chat_id_from_prompt, extract_topic_from_prompt, update_placeholder
+from lib.gateway_ipc import extract_chat_id_from_prompt, extract_topic_from_prompt, extract_user_from_prompt, update_placeholder
 from lib.state import read_state, write_state
 
 LAST_RECALL_STATE = "last_recall.json"
@@ -194,6 +194,7 @@ def _cache_key(
     bank_id: str,
     extra_banks: list,
     active_thread_id: str | None = None,
+    active_sender: str | None = None,
 ) -> str:
     """Stable hash for cache keying. Session_id is included so a new
     session always misses, regardless of the TTL setting. Extra banks
@@ -204,6 +205,11 @@ def _cache_key(
     but different topic) don't collide on the cache. Empty/None
     collapses to the empty string — backward-compatible for
     fleet-shared / DM agents where no thread_id is present.
+
+    Switchroom (per-speaker routing): `active_sender` is included for the
+    same reason — in a multi-user session two speakers sending the same
+    prompt resolve to different recall banks, so the sender must be part of
+    the key or one speaker's recall would be served to the other.
     """
     parts = [
         session_id or "",
@@ -211,6 +217,7 @@ def _cache_key(
         bank_id or "",
         ",".join(sorted(extra_banks or [])),
         active_thread_id or "",
+        active_sender or "",
     ]
     payload = "\x1f".join(parts)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
@@ -640,11 +647,35 @@ def main():
     bank_id = derive_bank_id(hook_input, config)
     additional_banks = config.get("recallAdditionalBanks", []) or []
 
+    # Switchroom (per-speaker memory routing, RFC
+    # reference/rfcs/per-speaker-memory-routing.md): when this agent serves
+    # multiple trusted users, also recall the *speaker's* profile bank. The
+    # sender is in the `<channel user="...">` envelope; the sender→bank map is
+    # injected as HINDSIGHT_SENDER_BANKS_JSON ({"<username-or-id>": "<bank>"}).
+    # Additive — never replaces the agent's own bank, never an auth boundary
+    # (single-tenant). Failure-safe + silent on every error path.
+    active_sender = extract_user_from_prompt(prompt)
+    if active_sender:
+        sender_banks_json = os.environ.get("HINDSIGHT_SENDER_BANKS_JSON", "")
+        if sender_banks_json:
+            try:
+                sender_banks = json.loads(sender_banks_json)
+                if isinstance(sender_banks, dict):
+                    sender_bank = sender_banks.get(active_sender)
+                    if (
+                        sender_bank
+                        and sender_bank != bank_id
+                        and sender_bank not in additional_banks
+                    ):
+                        additional_banks = [*additional_banks, sender_bank]
+            except (json.JSONDecodeError, ValueError, TypeError):
+                pass
+
     # Switchroom #424 phase 4.1 — cache check BEFORE any HTTP traffic.
     # Whole-session-scoped, opt-in via HINDSIGHT_RECALL_CACHE_TTL_SECS.
     cache_ttl = _cache_ttl_secs()
     cache_key = (
-        _cache_key(session_id, prompt, bank_id, additional_banks, active_thread_id)
+        _cache_key(session_id, prompt, bank_id, additional_banks, active_thread_id, active_sender)
         if cache_ttl > 0
         else ""
     )

--- a/vendor/hindsight-memory/scripts/recall.py
+++ b/vendor/hindsight-memory/scripts/recall.py
@@ -188,6 +188,47 @@ def _cache_ttl_secs() -> int:
         return 0
 
 
+def _normalize_sender(sender: str) -> str:
+    """Drop a single leading '@'. The gateway emits a bare username
+    (`from.username`), but operators naturally write `@handle` in config —
+    normalizing both sides lets either form match."""
+    return sender[1:] if sender.startswith("@") else sender
+
+
+def _resolve_sender_bank(
+    sender_banks_json: str,
+    active_sender: str | None,
+    bank_id: str,
+    additional_banks: list,
+) -> list:
+    """Per-speaker memory routing: if `active_sender` maps to a bank in the
+    HINDSIGHT_SENDER_BANKS_JSON map, return ``additional_banks`` with that
+    bank appended (additive — skips dup/self). A leading '@' on either the
+    map keys or the sender is normalized away, so ``@lisa``, ``lisa``, and
+    the gateway's bare-emitted ``lisa`` all resolve together. Failure-safe:
+    any bad input (missing sender/env, non-dict JSON, decode error) returns
+    ``additional_banks`` unchanged. Never replaces the agent's own bank and
+    never touches auth — additive recall scoping only (single-tenant).
+    """
+    if not active_sender or not sender_banks_json:
+        return additional_banks
+    try:
+        sender_banks = json.loads(sender_banks_json)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return additional_banks
+    if not isinstance(sender_banks, dict):
+        return additional_banks
+    normalized = {_normalize_sender(str(k)): v for k, v in sender_banks.items()}
+    sender_bank = normalized.get(_normalize_sender(active_sender))
+    if (
+        sender_bank
+        and sender_bank != bank_id
+        and sender_bank not in additional_banks
+    ):
+        return [*additional_banks, sender_bank]
+    return additional_banks
+
+
 def _cache_key(
     session_id: str,
     prompt: str,
@@ -655,21 +696,12 @@ def main():
     # Additive — never replaces the agent's own bank, never an auth boundary
     # (single-tenant). Failure-safe + silent on every error path.
     active_sender = extract_user_from_prompt(prompt)
-    if active_sender:
-        sender_banks_json = os.environ.get("HINDSIGHT_SENDER_BANKS_JSON", "")
-        if sender_banks_json:
-            try:
-                sender_banks = json.loads(sender_banks_json)
-                if isinstance(sender_banks, dict):
-                    sender_bank = sender_banks.get(active_sender)
-                    if (
-                        sender_bank
-                        and sender_bank != bank_id
-                        and sender_bank not in additional_banks
-                    ):
-                        additional_banks = [*additional_banks, sender_bank]
-            except (json.JSONDecodeError, ValueError, TypeError):
-                pass
+    additional_banks = _resolve_sender_bank(
+        os.environ.get("HINDSIGHT_SENDER_BANKS_JSON", ""),
+        active_sender,
+        bank_id,
+        additional_banks,
+    )
 
     # Switchroom #424 phase 4.1 — cache check BEFORE any HTTP traffic.
     # Whole-session-scoped, opt-in via HINDSIGHT_RECALL_CACHE_TTL_SECS.

--- a/vendor/hindsight-memory/scripts/tests/test_sender_routing.py
+++ b/vendor/hindsight-memory/scripts/tests/test_sender_routing.py
@@ -1,0 +1,74 @@
+"""Unit tests for per-speaker memory routing (Switchroom).
+
+RFC reference/rfcs/per-speaker-memory-routing.md. Covers:
+  - extract_user_from_prompt: sender (`user=`) extraction from the
+    <channel ...> envelope (username, numeric id, quote styles, missing).
+  - _cache_key: the sender is part of the key, so two speakers sending the
+    same prompt in one session don't collide on the recall cache.
+
+Stdlib-only.
+"""
+
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.gateway_ipc import extract_user_from_prompt  # noqa: E402
+import recall  # noqa: E402
+
+
+class ExtractUserTests(unittest.TestCase):
+    def test_username_present(self):
+        p = '<channel source="telegram" chat_id="-100" user="lisa" ts="1">hi</channel>'
+        self.assertEqual(extract_user_from_prompt(p), "lisa")
+
+    def test_numeric_id_when_no_username(self):
+        p = '<channel source="telegram" chat_id="-100" user="987654321">hi</channel>'
+        self.assertEqual(extract_user_from_prompt(p), "987654321")
+
+    def test_single_quotes(self):
+        p = "<channel source='telegram' chat_id='-100' user='ken'>hi</channel>"
+        self.assertEqual(extract_user_from_prompt(p), "ken")
+
+    def test_no_envelope_returns_none(self):
+        self.assertIsNone(extract_user_from_prompt("a plain interactive prompt"))
+
+    def test_empty_user_returns_none(self):
+        p = '<channel source="telegram" chat_id="-100" user="">hi</channel>'
+        self.assertIsNone(extract_user_from_prompt(p))
+
+    def test_non_string_returns_none(self):
+        self.assertIsNone(extract_user_from_prompt(None))
+
+
+class CacheKeySenderTests(unittest.TestCase):
+    """The sender must be part of the cache key so a multi-user session
+    doesn't serve one speaker's recall to another."""
+
+    def test_different_senders_different_keys(self):
+        k_ken = recall._cache_key("s1", "what's on today", "clerk", [], None, "ken")
+        k_lisa = recall._cache_key("s1", "what's on today", "clerk", [], None, "lisa")
+        self.assertNotEqual(k_ken, k_lisa)
+
+    def test_same_sender_same_key(self):
+        a = recall._cache_key("s1", "p", "clerk", [], None, "ken")
+        b = recall._cache_key("s1", "p", "clerk", [], None, "ken")
+        self.assertEqual(a, b)
+
+    def test_no_sender_backward_compatible(self):
+        # Omitting the sender (DM / fleet-shared, single user) collapses to
+        # the empty string — stable, and distinct from any named sender.
+        none1 = recall._cache_key("s1", "p", "clerk", [], None)
+        none2 = recall._cache_key("s1", "p", "clerk", [], None, None)
+        self.assertEqual(none1, none2)
+        self.assertNotEqual(
+            none1, recall._cache_key("s1", "p", "clerk", [], None, "ken")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vendor/hindsight-memory/scripts/tests/test_sender_routing.py
+++ b/vendor/hindsight-memory/scripts/tests/test_sender_routing.py
@@ -70,5 +70,58 @@ class CacheKeySenderTests(unittest.TestCase):
         )
 
 
+class ResolveSenderBankTests(unittest.TestCase):
+    """The map lookup. The gateway emits a BARE username (from.username),
+    while operators naturally write `@handle` in config — both must resolve.
+    Plus additive append, dup/self skip, and fail-safe behaviour."""
+
+    def test_at_keyed_map_resolves_bare_sender(self):
+        # The headline case: operator keys "@lisa", gateway emits "lisa".
+        out = recall._resolve_sender_bank('{"@lisa": "lisa-profile"}', "lisa", "clerk", [])
+        self.assertEqual(out, ["lisa-profile"])
+
+    def test_bare_keyed_map_resolves_bare_sender(self):
+        out = recall._resolve_sender_bank('{"lisa": "lisa-profile"}', "lisa", "clerk", [])
+        self.assertEqual(out, ["lisa-profile"])
+
+    def test_numeric_id_key(self):
+        out = recall._resolve_sender_bank('{"123456789": "ken-profile"}', "123456789", "clerk", [])
+        self.assertEqual(out, ["ken-profile"])
+
+    def test_additive_keeps_existing_extra_banks(self):
+        out = recall._resolve_sender_bank('{"@lisa": "lisa-profile"}', "lisa", "clerk", ["shared"])
+        self.assertEqual(out, ["shared", "lisa-profile"])
+
+    def test_skips_self_bank(self):
+        out = recall._resolve_sender_bank('{"@lisa": "clerk"}', "lisa", "clerk", [])
+        self.assertEqual(out, [])
+
+    def test_skips_duplicate(self):
+        out = recall._resolve_sender_bank('{"@lisa": "lisa-profile"}', "lisa", "clerk", ["lisa-profile"])
+        self.assertEqual(out, ["lisa-profile"])
+
+    def test_unmapped_sender_unchanged(self):
+        out = recall._resolve_sender_bank('{"@lisa": "lisa-profile"}', "stranger", "clerk", ["shared"])
+        self.assertEqual(out, ["shared"])
+
+    def test_no_sender_unchanged(self):
+        self.assertEqual(recall._resolve_sender_bank('{"@lisa": "x"}', None, "clerk", []), [])
+
+    def test_empty_env_unchanged(self):
+        self.assertEqual(recall._resolve_sender_bank("", "lisa", "clerk", ["a"]), ["a"])
+
+    def test_bad_json_unchanged(self):
+        self.assertEqual(recall._resolve_sender_bank("{not json", "lisa", "clerk", []), [])
+
+    def test_non_dict_json_unchanged(self):
+        self.assertEqual(recall._resolve_sender_bank('["lisa"]', "lisa", "clerk", []), [])
+
+    def test_does_not_mutate_input_list(self):
+        original = ["shared"]
+        out = recall._resolve_sender_bank('{"@lisa": "lisa-profile"}', "lisa", "clerk", original)
+        self.assertEqual(original, ["shared"])  # input untouched
+        self.assertEqual(out, ["shared", "lisa-profile"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The **dynamic** half of per-user memory (RFC `reference/rfcs/per-speaker-memory-routing.md`), built on the `additional_banks` foundation from #2441. When an agent serves **multiple trusted users**, recall now also queries the **speaker's** profile bank — so each user gets their own context instead of a blended pool.

This is the per-user memory isolation the clarified `single-tenant` invariant (#2439) calls for. **Additive recall scoping, never an authorization boundary** — who may *drive* an agent stays `access.allowFrom`.

## How
The sender is already in the `<channel user="…">` envelope the recall hook reads. The pieces:
- **Vendor hook** (marked `# Switchroom-local`):
  - `gateway_ipc.py` — `extract_user_from_prompt` pulls the sender (username, else numeric `user_id`) from the envelope head, a sibling of the existing chat-id/topic extractors.
  - `recall.py` — reads `HINDSIGHT_SENDER_BANKS_JSON`, resolves the speaker's bank, **appends** it to `additional_banks` (skips dup/self); adds the sender to `_cache_key` so two speakers in one session don't cross-serve the cache. Failure-safe + silent.
- **Config** — `memory.recall.sender_banks` (map: sender → bank) on both recall tiers.
- **Scaffold** — serializes the **cascaded** `sender_banks` → `HINDSIGHT_SENDER_BANKS_JSON` via `start.sh` (both render paths), mirroring the topic-aliases wiring 1:1. Emitted only when a map is set.

```yaml
agents:
  clerk:
    memory:
      recall:
        sender_banks:
          "@lisa": lisa-profile
          "123456789": ken-profile
```

## Test plan
- [x] `tsc` + full `npm run lint` clean (incl. `check-plugin-references` over the vendor change).
- [x] **53 vendor python tests** pass — new `test_sender_routing.py` (extractor: username/numeric/quotes/missing; cache-key sender separation) + all regression (`gateway_ipc`, `recall_*`).
- [x] **Scaffold env tests** (`tests/scaffold.sender-banks-env.test.ts`) — set / unset / empty + the **defaults-cascade** case (the #2441 lesson: resolve from cascaded config so a fleet-wide `defaults` value works).

## Single-tenant
The sender hint only changes which memory is *recalled*, never who may talk to the agent. All banks are the operator's own data, fully visible to the operator. Cache-key includes the sender to prevent cross-speaker cache bleed in shared sessions.

## Risk
Vendor `recall.py`/`gateway_ipc.py` patch (the resolution must live in the hook — only it sees the per-message sender). All additions are failure-safe and no-op when `sender_banks` is unset (the common single-user case). Config field is optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)