### PR TITLE
feat(config): first-class users — serves/knows generate the recall maps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,6 +149,29 @@ The key is matched against the sender's Telegram username (when they have one) o
 
 **It is additive recall scoping, never an access boundary.** Who may *drive* an agent stays the per-agent assignment in `access.allowFrom` — the sender hint only changes which memory is *recalled*, never who is allowed to talk to the agent. All banks remain your own data in your own Hindsight instance, fully visible to you. Combine with `additional_banks` for a shared bank everyone sees *plus* a per-person bank.
 
+### First-class users — `users:` + agent `serves` / `knows`
+
+Rather than hand-maintaining `sender_banks` and `additional_banks` maps per agent, define each trusted person **once** as a user and assign them to agents. See [`reference/rfcs/user-concept.md`](../reference/rfcs/user-concept.md).
+
+```yaml
+users:
+  ken:  { telegram_ids: ["mekenthompson"], profile_bank: ken-profile }
+  lisa: { telegram_ids: ["8201250670"],    profile_bank: lisa-profile }
+
+agents:
+  ziggy:  { serves: [lisa] }                       # Lisa's own agent
+  marko:  { serves: [ken, lisa] }                  # serves both
+  gymbro: { serves: [ken] }                        # Ken only
+  clerk:  { serves: [ken], knows: [lisa, kids] }   # Ken drives; always knows the family
+```
+
+- **`serves: [<user>…]`** — users this agent works for. When a served user messages it, their `profile_bank` is recalled (generates `sender_banks`).
+- **`knows: [<user-or-bank>…]`** — profiles this agent always knows as *subjects*, even when that person isn't the speaker (generates `additional_banks`). A user name resolves to their profile bank; any other string is a raw bank name (e.g. a `kids` bank with no Telegram identity).
+
+`serves`/`knows` accept a fleet-wide default (`defaults.serves: [ken]` → every agent serves Ken) which **unions** with per-agent values. Generated maps also union with any explicit per-agent `sender_banks`/`additional_banks`. A `serves` entry must name a user in the `users:` block (a typo is a config error); `knows` is permissive.
+
+> **Note:** this generates the *memory* wiring only. Who may **drive** an agent (`access.allowFrom`) is still paired at agent creation as today — generating access from `users:` is a future phase.
+
 ### Demoting individual memories from auto-recall
 
 If one specific memory keeps surfacing in the recall block and isn't useful (over-broad world fact, stale context, etc.), tag it with `[demote-from-recall]` — or `demote-from-recall` / `no-recall`, all three work. The memory stays in the bank, `mcp__hindsight__reflect` and manual recall can still find it, but auto-recall skips it.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -483,6 +483,7 @@ export function maybeWriteCronMcp(
   seedCronConfigDir(agentDir, Object.keys(cronServers));
   return path;
 }
+import { resolveUsers } from "../config/users.js";
 import {
   resolveAgentConfig,
   translateHooksToClaudeShape,
@@ -2165,16 +2166,10 @@ export function installHindsightPlugin(
   // config (defaults → profile → agent), mirroring how the env-export path
   // reads the sibling recall knobs (max_memories etc.) — so a fleet-wide
   // `defaults.memory.recall.additional_banks` is honoured, not just a
-  // per-agent value. `switchroomConfig.agents[agentName]` is the raw,
-  // pre-cascade block, so resolve it here.
-  const agentRaw = switchroomConfig.agents[agentName];
-  const additionalBanks = agentRaw
-    ? resolveAgentConfig(
-        switchroomConfig.defaults,
-        switchroomConfig.profiles,
-        agentRaw,
-      ).memory?.recall?.additional_banks ?? []
-    : [];
+  // per-agent value. Now also folds in the `knows`-assigned user/bank profiles
+  // (user concept, RFC reference/rfcs/user-concept.md); resolveUsers() handles
+  // the cascade + union (defaults ∪ agent, generated ∪ explicit) itself.
+  const additionalBanks = resolveUsers(switchroomConfig, agentName).additionalBanks;
   applyHindsightSettingsOverrides(destPath, additionalBanks);
 
   // Resolve the agent's bank/collection name and the Hindsight REST URL.
@@ -3066,7 +3061,13 @@ export function scaffoldAgent(
   // Switchroom (per-speaker memory routing): {sender: bank} map →
   // HINDSIGHT_SENDER_BANKS_JSON. Sourced from memory.recall.sender_banks
   // (cascaded). Undefined when no map is set (the env-export block no-ops).
-  const senderBanks = agentConfig.memory?.recall?.sender_banks;
+  // `serves`-assigned users generate sender_banks (speaker routing), unioned
+  // with any explicit map — resolved by resolveUsers() (user concept, RFC
+  // reference/rfcs/user-concept.md). Falls back to the explicit map when no
+  // full config is in scope.
+  const senderBanks = switchroomConfig
+    ? resolveUsers(switchroomConfig, name).senderBanks
+    : agentConfig.memory?.recall?.sender_banks ?? {};
   const hindsightSenderBanksJson = senderBanks && Object.keys(senderBanks).length > 0
     ? JSON.stringify(senderBanks)
     : undefined;
@@ -5057,7 +5058,13 @@ export function reconcileAgent(
     ? JSON.stringify(topicAliases)
     : undefined;
   // Switchroom (per-speaker memory routing): mirror scaffoldAgent's compute.
-  const senderBanks = agentConfig.memory?.recall?.sender_banks;
+  // `serves`-assigned users generate sender_banks (speaker routing), unioned
+  // with any explicit map — resolved by resolveUsers() (user concept, RFC
+  // reference/rfcs/user-concept.md). Falls back to the explicit map when no
+  // full config is in scope.
+  const senderBanks = switchroomConfig
+    ? resolveUsers(switchroomConfig, name).senderBanks
+    : agentConfig.memory?.recall?.sender_banks ?? {};
   const hindsightSenderBanksJson = senderBanks && Object.keys(senderBanks).length > 0
     ? JSON.stringify(senderBanks)
     : undefined;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1788,8 +1788,38 @@ export const NetworkIsolationSchema = z
     "cycle, #1413). Cascades override (agent → profile → defaults).",
   );
 
+// First-class users (RFC reference/rfcs/user-concept.md — memory-routing
+// phase). `serves` / `knows` reference entries in the top-level `users:`
+// block and are resolved (unioned) into the recall maps by resolveUsers().
+// Defined once and mirrored into profileFields (defaults/profiles) and
+// AgentSchema (per-agent), like every other agent field.
+const servesField = z
+  .array(z.string())
+  .optional()
+  .describe(
+    "Users (keys in the top-level `users:` block) this agent works for. When " +
+    "a served user messages this agent, their profile_bank is recalled " +
+    "(speaker routing → memory.recall.sender_banks). Unions with any explicit " +
+    "memory.recall.sender_banks. NOTE: this does not yet generate access " +
+    "(allowFrom) — pair agent access as today; allowFrom generation is a " +
+    "later phase.",
+  );
+const knowsField = z
+  .array(z.string())
+  .optional()
+  .describe(
+    "Users or banks this agent always knows as subjects — recalled and " +
+    "recall-ranked even when that person is not the speaker (→ " +
+    "memory.recall.additional_banks). A `users:` key resolves to that user's " +
+    "profile_bank; any other string is used as a raw bank name (e.g. a `kids` " +
+    "profile bank with no Telegram identity). Unions with any explicit " +
+    "memory.recall.additional_banks.",
+  );
+
 const profileFields = {
   extends: z.string().optional(),
+  serves: servesField,
+  knows: knowsField,
   bot_token: z.string().optional(),
   release: ReleaseBlock.optional().describe(
     "Release-channel pin / pointer. Either `channel` (dev|rc|latest) or " +
@@ -2081,6 +2111,8 @@ export const AgentSchema = z.object({
       "filesystem directory `profiles/<name>/`. Defaults to DEFAULT_PROFILE " +
       "('default') when unset.",
     ),
+  serves: servesField,
+  knows: knowsField,
   bot_token: z
     .string()
     .optional()
@@ -2969,6 +3001,31 @@ export const CronConfigSchema = z.object({
   egress: CronEgressSchema.optional().describe("SSRF/exfil fence for http-diff polls."),
 });
 
+/**
+ * A first-class user — a trusted person the fleet serves, identified by their
+ * Telegram account and carrying their own memory profile bank. RFC
+ * reference/rfcs/user-concept.md. The operator's own trusted people
+ * (single-tenant), assigned to agents via `serves` / `knows`.
+ */
+export const UserSchema = z.object({
+  name: z.string().optional().describe("Display name for the user."),
+  telegram_ids: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      "Telegram username(s) and/or numeric user id(s) identifying this user " +
+      "(a leading @ is optional). Matched against the message sender for " +
+      "per-speaker memory routing.",
+    ),
+  profile_bank: z
+    .string()
+    .describe(
+      "Hindsight bank holding this user's memory profile (author via " +
+      "`switchroom memory profile add <bank> ...`).",
+    ),
+});
+export type User = z.infer<typeof UserSchema>;
+
 export const SwitchroomConfigSchema = z.object({
   switchroom: z.object({
     version: z.literal(1).describe("Config schema version"),
@@ -3216,6 +3273,15 @@ export const SwitchroomConfigSchema = z.object({
       "Inline profiles declared here take priority over filesystem " +
       "profiles/<name>/ directories when both exist.",
     ),
+  users: z
+    .record(z.string(), UserSchema)
+    .optional()
+    .describe(
+      "Trusted users the fleet serves — each a Telegram identity plus a " +
+      "memory profile bank. Assigned to agents via `serves` / `knows`. The " +
+      "operator's own trusted people (single-tenant), not multi-tenant. See " +
+      "reference/rfcs/user-concept.md.",
+    ),
   agents: z
     .record(
       z.string().regex(/^[a-z0-9][a-z0-9_-]{0,50}$/, {
@@ -3229,6 +3295,34 @@ export const SwitchroomConfigSchema = z.object({
     "egress allowlist + host-pinned secret bindings for Tier-0 http-diff " +
     "polls (§6.1). Required to enable any http-diff poll; not agent-writable.",
   ),
+}).superRefine((cfg, ctx) => {
+  // Every `serves` entry must name a user defined in the top-level `users:`
+  // block (a typo would silently route nothing). `knows` is permissive — an
+  // entry may be a user OR a raw bank name, so it is not checked here.
+  const userKeys = new Set(Object.keys(cfg.users ?? {}));
+  const checkServes = (
+    serves: readonly string[] | undefined,
+    path: (string | number)[],
+  ) => {
+    (serves ?? []).forEach((s, i) => {
+      if (!userKeys.has(s)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            `serves references unknown user "${s}" — add it to the top-level ` +
+            "`users:` block (or did you mean `knows` for a raw bank name?)",
+          path: [...path, i],
+        });
+      }
+    });
+  };
+  checkServes(cfg.defaults?.serves, ["defaults", "serves"]);
+  for (const [name, p] of Object.entries(cfg.profiles ?? {})) {
+    checkServes((p as { serves?: string[] }).serves, ["profiles", name, "serves"]);
+  }
+  for (const [name, a] of Object.entries(cfg.agents ?? {})) {
+    checkServes((a as { serves?: string[] }).serves, ["agents", name, "serves"]);
+  }
 });
 
 export type SwitchroomConfig = z.infer<typeof SwitchroomConfigSchema>;

--- a/src/config/users.ts
+++ b/src/config/users.ts
@@ -1,0 +1,74 @@
+import type { SwitchroomConfig, AgentConfig } from "./schema.js";
+import { resolveAgentConfig } from "./merge.js";
+
+/**
+ * First-class users — resolve the `users:` / `serves` / `knows` config for
+ * one agent into the recall maps the scaffold emits (RFC
+ * reference/rfcs/user-concept.md, memory-routing phase).
+ *
+ * UNION semantics, computed HERE (not via the replace-by-default config
+ * cascade, which would drop fleet-wide `defaults.serves`):
+ *   - `serves`/`knows` are unioned across the defaults tier and the cascaded
+ *     agent value.
+ *   - the generated maps are unioned with any explicit per-agent
+ *     `memory.recall.sender_banks` / `additional_banks`.
+ *
+ * Mapping:
+ *   - `serves` → each served user's `telegram_ids` map to their `profile_bank`
+ *     (speaker routing → `sender_banks`).
+ *   - `knows` → each entry resolves to a user's `profile_bank`, else is used
+ *     as a raw bank name (subject knowledge → `additional_banks`).
+ *
+ * Unknown `serves` users are skipped defensively (the schema superRefine
+ * already errors on them). Phase note: this does NOT generate access
+ * (`allowFrom`) — agent access is paired as today.
+ */
+export interface ResolvedUserRecall {
+  senderBanks: Record<string, string>;
+  additionalBanks: string[];
+}
+
+export function resolveUsers(
+  config: SwitchroomConfig,
+  agentName: string,
+): ResolvedUserRecall {
+  const users = config.users ?? {};
+  const agentRaw = config.agents?.[agentName];
+  const agentConfig: AgentConfig | undefined = agentRaw
+    ? resolveAgentConfig(config.defaults, config.profiles, agentRaw)
+    : undefined;
+
+  const uniq = (xs: readonly string[]): string[] => [...new Set(xs)];
+
+  // serves/knows union the defaults tier with the cascaded agent value — the
+  // cascade REPLACES arrays, so a fleet-wide `defaults.serves` would be lost.
+  const serves = uniq([
+    ...(config.defaults?.serves ?? []),
+    ...(agentConfig?.serves ?? []),
+  ]);
+  const knows = uniq([
+    ...(config.defaults?.knows ?? []),
+    ...(agentConfig?.knows ?? []),
+  ]);
+
+  // serves → sender_banks (each served user's telegram_ids → profile_bank)
+  const senderBanks: Record<string, string> = {};
+  for (const userName of serves) {
+    const u = users[userName];
+    if (!u) continue; // unknown user — schema already flags it; stay defensive
+    for (const id of u.telegram_ids) {
+      senderBanks[id] = u.profile_bank;
+    }
+  }
+  // union with explicit per-agent sender_banks (explicit wins on key conflict)
+  Object.assign(senderBanks, agentConfig?.memory?.recall?.sender_banks ?? {});
+
+  // knows → additional_banks (user → profile_bank, else raw bank), unioned
+  // with explicit per-agent additional_banks.
+  const additionalBanks = uniq([
+    ...knows.map((entry) => users[entry]?.profile_bank ?? entry),
+    ...(agentConfig?.memory?.recall?.additional_banks ?? []),
+  ]);
+
+  return { senderBanks, additionalBanks };
+}

--- a/tests/config.resolve-users.test.ts
+++ b/tests/config.resolve-users.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { resolveUsers } from "../src/config/users.js";
+import { SwitchroomConfigSchema } from "../src/config/schema.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+/**
+ * First-class users (RFC reference/rfcs/user-concept.md, memory-routing phase):
+ * `users:` + agent `serves`/`knows` resolve (with UNION semantics) into the
+ * recall maps the scaffold emits — `serves` → sender_banks (speaker routing),
+ * `knows` → additional_banks (subject knowledge).
+ */
+
+function cfg(partial: Record<string, unknown>): SwitchroomConfig {
+  return {
+    agents: {},
+    memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+    telegram: { bot_token: "t", forum_chat_id: "c" },
+    ...partial,
+  } as unknown as SwitchroomConfig;
+}
+
+const USERS = {
+  ken: { telegram_ids: ["mekenthompson", "111"], profile_bank: "ken-profile" },
+  lisa: { telegram_ids: ["8201250670"], profile_bank: "lisa-profile" },
+};
+
+describe("resolveUsers — serves/knows → recall maps", () => {
+  it("serves maps each served user's telegram_ids to their profile_bank", () => {
+    const r = resolveUsers(cfg({ users: USERS, agents: { ziggy: { serves: ["lisa"] } } }), "ziggy");
+    expect(r.senderBanks).toEqual({ "8201250670": "lisa-profile" });
+    expect(r.additionalBanks).toEqual([]);
+  });
+
+  it("multiple served users, multiple ids each", () => {
+    const r = resolveUsers(cfg({ users: USERS, agents: { marko: { serves: ["ken", "lisa"] } } }), "marko");
+    expect(r.senderBanks).toEqual({
+      mekenthompson: "ken-profile",
+      "111": "ken-profile",
+      "8201250670": "lisa-profile",
+    });
+  });
+
+  it("knows resolves a user → profile_bank, and passes a raw bank through", () => {
+    const r = resolveUsers(
+      cfg({ users: USERS, agents: { clerk: { serves: ["ken"], knows: ["lisa", "kids-profile"] } } }),
+      "clerk",
+    );
+    expect(r.senderBanks).toEqual({ mekenthompson: "ken-profile", "111": "ken-profile" });
+    expect(r.additionalBanks.sort()).toEqual(["kids-profile", "lisa-profile"]);
+  });
+
+  it("defaults.serves unions with per-agent serves (not replace)", () => {
+    const r = resolveUsers(
+      cfg({ users: USERS, defaults: { serves: ["ken"] }, agents: { ziggy: { serves: ["lisa"] } } }),
+      "ziggy",
+    );
+    expect(r.senderBanks.mekenthompson).toBe("ken-profile");
+    expect(r.senderBanks["8201250670"]).toBe("lisa-profile");
+  });
+
+  it("explicit memory.recall maps union with the generated maps", () => {
+    const r = resolveUsers(
+      cfg({
+        users: USERS,
+        agents: {
+          marko: {
+            serves: ["lisa"],
+            knows: ["kids-profile"],
+            memory: { recall: { sender_banks: { "999": "ken-profile" }, additional_banks: ["shared"] } },
+          },
+        },
+      }),
+      "marko",
+    );
+    expect(r.senderBanks).toEqual({ "8201250670": "lisa-profile", "999": "ken-profile" });
+    expect(r.additionalBanks.sort()).toEqual(["kids-profile", "shared"]);
+  });
+
+  it("unknown served user is skipped defensively (no throw)", () => {
+    const r = resolveUsers(cfg({ users: USERS, agents: { x: { serves: ["ghost"] } } }), "x");
+    expect(r.senderBanks).toEqual({});
+  });
+
+  it("no users block → empty maps (fleet behaves as today)", () => {
+    const r = resolveUsers(cfg({ agents: { x: {} } }), "x");
+    expect(r.senderBanks).toEqual({});
+    expect(r.additionalBanks).toEqual([]);
+  });
+});
+
+describe("schema — serves must reference a defined user", () => {
+  // The superRefine only runs once the object validly parses, so the test
+  // configs carry the required `telegram` + agent `topic_name` (a real
+  // switchroom.yaml always has them).
+  const TELEGRAM = { bot_token: "t", forum_chat_id: "123" };
+
+  it("flags serves referencing an unknown user", () => {
+    const r = SwitchroomConfigSchema.safeParse({
+      switchroom: { version: 1 },
+      telegram: TELEGRAM,
+      users: { ken: { telegram_ids: ["x"], profile_bank: "ken-profile" } },
+      agents: { ziggy: { topic_name: "Ziggy", serves: ["lisa"] } },
+    });
+    const issues = r.success ? [] : r.error.issues;
+    expect(issues.some((i) => i.message.includes('unknown user "lisa"'))).toBe(true);
+  });
+
+  it("does NOT flag serves referencing a defined user", () => {
+    const r = SwitchroomConfigSchema.safeParse({
+      switchroom: { version: 1 },
+      telegram: TELEGRAM,
+      users: { lisa: { telegram_ids: ["x"], profile_bank: "lisa-profile" } },
+      agents: { ziggy: { topic_name: "Ziggy", serves: ["lisa"] } },
+    });
+    const issues = r.success ? [] : r.error.issues;
+    expect(issues.some((i) => i.message.includes("unknown user"))).toBe(false);
+  });
+
+  it("does NOT flag knows entries (user-or-bank, permissive)", () => {
+    const r = SwitchroomConfigSchema.safeParse({
+      switchroom: { version: 1 },
+      telegram: TELEGRAM,
+      users: { ken: { telegram_ids: ["x"], profile_bank: "ken-profile" } },
+      agents: { clerk: { topic_name: "Clerk", serves: ["ken"], knows: ["lisa", "kids-profile"] } },
+    });
+    const issues = r.success ? [] : r.error.issues;
+    expect(issues.some((i) => i.message.includes("unknown user"))).toBe(false);
+  });
+});

--- a/tests/config.resolve-users.test.ts
+++ b/tests/config.resolve-users.test.ts
@@ -76,6 +76,23 @@ describe("resolveUsers — serves/knows → recall maps", () => {
     expect(r.additionalBanks.sort()).toEqual(["kids-profile", "shared"]);
   });
 
+  it("explicit sender_banks wins on a key conflict with the generated map", () => {
+    const r = resolveUsers(
+      cfg({
+        users: USERS,
+        agents: {
+          marko: {
+            serves: ["lisa"],
+            memory: { recall: { sender_banks: { "8201250670": "override-bank" } } },
+          },
+        },
+      }),
+      "marko",
+    );
+    // lisa's id 8201250670 generates → lisa-profile, but the explicit map wins.
+    expect(r.senderBanks["8201250670"]).toBe("override-bank");
+  });
+
   it("unknown served user is skipped defensively (no throw)", () => {
     const r = resolveUsers(cfg({ users: USERS, agents: { x: { serves: ["ghost"] } } }), "x");
     expect(r.senderBanks).toEqual({});

--- a/tests/scaffold.user-concept.test.ts
+++ b/tests/scaffold.user-concept.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { scaffoldAgent } from "../src/agents/scaffold.js";
+import type { SwitchroomConfig, TelegramConfig } from "../src/config/schema.js";
+
+/**
+ * End-to-end: the `users:` + `serves`/`knows` config (RFC user-concept.md)
+ * resolves through scaffoldAgent → resolveUsers() → the same emit paths the
+ * raw maps use: `serves` → HINDSIGHT_SENDER_BANKS_JSON in start.sh,
+ * `knows` → recallAdditionalBanks in the plugin settings.json.
+ */
+describe("user concept — serves/knows wire through scaffold", () => {
+  let tmpDir: string;
+  const telegram = { bot_token: "t", forum_chat_id: "c" } as TelegramConfig;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `user-concept-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("serves → sender env; knows → additional banks", () => {
+    const config = {
+      users: {
+        ken: { telegram_ids: ["mekenthompson"], profile_bank: "ken-profile" },
+        lisa: { telegram_ids: ["8201250670"], profile_bank: "lisa-profile" },
+      },
+      agents: { clerk: { topic_name: "Clerk", serves: ["ken"], knows: ["lisa", "kids-profile"] } },
+      memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+      telegram,
+    } as unknown as SwitchroomConfig;
+
+    const res = scaffoldAgent("clerk", config.agents.clerk as never, tmpDir, telegram, config);
+
+    // serves Ken → speaker-routing sender map in start.sh
+    const startSh = readFileSync(join(res.agentDir, "start.sh"), "utf-8");
+    const m = startSh.match(/export HINDSIGHT_SENDER_BANKS_JSON=(.+)/);
+    expect(m, "sender env should be emitted from serves").not.toBeNull();
+    expect(JSON.parse(m![1].replace(/^'/, "").replace(/'$/, ""))).toEqual({
+      mekenthompson: "ken-profile",
+    });
+
+    // knows Lisa + kids → subject banks in settings.json
+    const settings = JSON.parse(
+      readFileSync(
+        join(res.agentDir, ".claude", "plugins", "hindsight-memory", "settings.json"),
+        "utf-8",
+      ),
+    );
+    expect((settings.recallAdditionalBanks as string[]).sort()).toEqual([
+      "kids-profile",
+      "lisa-profile",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the **memory-routing phase** of the user-concept RFC (#2443, approved). Define a trusted person **once** as a user, assign to agents via `serves`/`knows` — no more hand-syncing per-agent `sender_banks`/`additional_banks` maps.

```yaml
users:
  ken:  { telegram_ids: ["mekenthompson"], profile_bank: ken-profile }
  lisa: { telegram_ids: ["8201250670"],    profile_bank: lisa-profile }

agents:
  ziggy:  { serves: [lisa] }
  marko:  { serves: [ken, lisa] }
  gymbro: { serves: [ken] }
  clerk:  { serves: [ken], knows: [lisa, kids] }
```

## What it does
- **schema** — top-level `users:` (`UserSchema`) + `serves`/`knows` on agent/defaults/profile tiers. A `superRefine` errors when `serves` names an undefined user; `knows` is permissive (user-or-bank).
- **`src/config/users.ts` (`resolveUsers`)** — expands `serves`/`knows` into the recall maps with **union** semantics computed in-resolver (defaults ∪ agent, generated ∪ explicit) — deliberately *not* the replace-by-default cascade, which would drop a fleet-wide `defaults.serves` (the precise point #2443's review surfaced).
- **scaffold** — `installHindsightPlugin` (additional_banks) + both sender compute sites now source from `resolveUsers`, reusing the **merged #2441/#2442 emit paths**. **No vendor-hook change.**
- **docs** — `docs/configuration.md` users/serves/knows section.

## Scope (per operator decision)
**Memory routing only.** Generating `access.allowFrom` from `serves` is deferred to a later phase — access is paired at agent creation as today. The `serves` describe + docs note this explicitly.

## Invariant compliance
- `single-tenant` — operator's trusted people, their own data.
- `no-self-escalation` — untouched: this PR generates *memory* maps only, never `allowFrom`. Access stays paired.

## Test plan
- [x] `tsc` + full `npm run lint` clean.
- [x] `tests/config.resolve-users.test.ts` — `resolveUsers` (serves→sender_banks, knows→additional_banks, multi-user, defaults-union, explicit-union, unknown-skip, empty) + schema validation (serves must exist; knows permissive). 10 cases.
- [x] `tests/scaffold.user-concept.test.ts` — end-to-end: `users:`/`serves`/`knows` → start.sh sender env + settings additional banks.
- [x] Existing PR1/PR2 scaffold tests still green (explicit maps flow through `resolveUsers`).

## Risk
Additive config layer. `serves`/`knows`/`users:` are optional — a fleet with no `users:` block generates empty maps and behaves exactly as today.

## Follow-up
Phase 2: generate `allowFrom` from `serves`; per-user *retain* routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)