### PR TITLE
feat(memory): surface profile banks on dashboard, doctor, memory stats

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -27,7 +27,7 @@ import { getAllAuthStatuses } from "../auth/manager.js";
 import { getSlotInfos, type SlotInfo } from "../auth/accounts.js";
 import type { AgentConfig, SwitchroomConfig } from "../config/schema.js";
 import { loadManifest, detectDrift, type DriftProbers } from "../manifest.js";
-import { probeHindsight, isHindsightEnabled, fetchHindsightToolsList } from "../memory/hindsight.js";
+import { probeHindsight, isHindsightEnabled, fetchHindsightToolsList, collectProfileBanks } from "../memory/hindsight.js";
 import { inspectBankHealth, staleMentalModels, corruptedMentalModels, recentUnextracted, ageDays } from "../memory/bank-health.js";
 import { checkHindsightContainerHealth, classifyToolContract } from "./doctor-memory.js";
 import { isDockerMode, runDockerChecks } from "./doctor-docker.js";
@@ -969,6 +969,12 @@ export async function checkBankIngestHealth(
     const bankId = agentConfig.memory?.collection ?? agentName;
     banks.set(bankId, [...(banks.get(bankId) ?? []), agentName]);
   }
+  // Profile banks (per-user / shared) — recall routes to them but no agent
+  // owns them; sweep their health alongside the agent banks.
+  const profileBanks = collectProfileBanks(config);
+  for (const bank of profileBanks) {
+    if (!banks.has(bank)) banks.set(bank, []);
+  }
 
   // Inspect banks concurrently — sequential probes against a busy server
   // (e.g. mid-extraction) compound each bank's latency into a doctor stall.
@@ -979,7 +985,13 @@ export async function checkBankIngestHealth(
   );
 
   for (const [bankId, agents, h] of inspected) {
-    const label = `bank ${bankId}` + (agents[0] !== bankId ? ` (${agents.join(", ")})` : "");
+    const label =
+      `bank ${bankId}` +
+      (profileBanks.has(bankId)
+        ? " (profile)"
+        : agents[0] !== bankId
+          ? ` (${agents.join(", ")})`
+          : "");
     if (!h.ok) {
       results.push({
         name: label,

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import {
   getCollectionForAgent,
   isStrictIsolation,
+  collectProfileBanks,
   addMemoryTag,
   DEMOTE_FROM_RECALL_TAG,
 } from "../memory/hindsight.js";
@@ -163,6 +164,28 @@ export function registerMemoryCommand(program: Command): void {
         }
 
         console.log();
+
+        // Profile banks (per-user / shared) — recall routes to them but no
+        // agent owns them, so they don't appear in the agent table above.
+        const profileBanks = collectProfileBanks(config);
+        if (profileBanks.size > 0) {
+          const owners = new Map<string, string[]>();
+          for (const [uname, u] of Object.entries(config.users ?? {})) {
+            if (u.profile_bank) {
+              owners.set(u.profile_bank, [
+                ...(owners.get(u.profile_bank) ?? []),
+                uname,
+              ]);
+            }
+          }
+          console.log(chalk.bold("  Profile banks (per-user / shared):\n"));
+          for (const bank of [...profileBanks].sort()) {
+            const who = owners.get(bank);
+            const label = who ? `user: ${who.join(", ")}` : "shared";
+            console.log(`  ${bank.padEnd(widths[1])}  ${chalk.gray(label)}`);
+          }
+          console.log();
+        }
 
         // Print stats commands
         console.log(chalk.bold("  Hindsight CLI commands:\n"));

--- a/src/memory/hindsight.ts
+++ b/src/memory/hindsight.ts
@@ -1,4 +1,5 @@
 import type { SwitchroomConfig, MemoryBackendConfig } from "../config/schema.js";
+import { resolveUsers } from "../config/users.js";
 
 export interface McpServerConfig {
   type?: string;
@@ -86,6 +87,44 @@ export function getCollectionForAgent(
 ): string {
   const agentConfig = config.agents[agentName];
   return agentConfig?.memory?.collection ?? agentName;
+}
+
+/**
+ * Collect the standalone "profile banks" referenced across the config — the
+ * per-user / shared hindsight banks that recall routes to but that are NOT any
+ * agent's own `memory.collection`. Deduped, drawn from:
+ *   - `users.<name>.profile_bank` (first-class users, even if not yet assigned)
+ *   - every bank any agent actually recalls, via `resolveUsers` (so the cascade
+ *     + `serves`/`knows` + explicit `additional_banks`/`sender_banks` are all
+ *     covered, not just raw per-agent config).
+ *
+ * These are invisible to the agent-driven health surfaces (dashboard Memory
+ * tab, `doctor`, `memory stats`), which only enumerate agent collections — so
+ * each of those surfaces unions this set in to show profile-bank health too.
+ *
+ * With `excludeAgentCollections` (default true) any bank that is already some
+ * agent's collection is dropped, so a bank never shows as both.
+ */
+export function collectProfileBanks(
+  config: SwitchroomConfig,
+  opts: { excludeAgentCollections?: boolean } = {},
+): Set<string> {
+  const { excludeAgentCollections = true } = opts;
+  const banks = new Set<string>();
+  for (const user of Object.values(config.users ?? {})) {
+    if (user.profile_bank) banks.add(user.profile_bank);
+  }
+  for (const agentName of Object.keys(config.agents)) {
+    const { senderBanks, additionalBanks } = resolveUsers(config, agentName);
+    for (const b of Object.values(senderBanks)) banks.add(b);
+    for (const b of additionalBanks) banks.add(b);
+  }
+  if (excludeAgentCollections) {
+    for (const agentName of Object.keys(config.agents)) {
+      banks.delete(getCollectionForAgent(agentName, config));
+    }
+  }
+  return banks;
 }
 
 /**

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -6,7 +6,11 @@ import {
   getAllAgentStatuses,
 } from "../agents/lifecycle.js";
 import { getAllAuthStatuses } from "../auth/manager.js";
-import { getCollectionForAgent, probeHindsight } from "../memory/hindsight.js";
+import {
+  collectProfileBanks,
+  getCollectionForAgent,
+  probeHindsight,
+} from "../memory/hindsight.js";
 import {
   inspectBankHealth,
   getMentalModelDetail,
@@ -1887,6 +1891,12 @@ export interface MemoryBankHealthRow {
   /** ok | warn | fail — same thresholds as `switchroom doctor`. */
   status: "ok" | "warn" | "fail";
   statusDetail: string;
+  /**
+   * `agent` = an agent's own `memory.collection`; `profile` = a standalone
+   * per-user / shared profile bank that recall routes to but no agent owns
+   * (its `agents` list is empty). Lets the UI label profile banks distinctly.
+   */
+  kind: "agent" | "profile";
 }
 
 export interface MemoryHealth {
@@ -1917,6 +1927,14 @@ export async function handleGetMemoryHealth(
   for (const agentName of Object.keys(config.agents)) {
     const bank = getCollectionForAgent(agentName, config);
     banks.set(bank, [...(banks.get(bank) ?? []), agentName]);
+  }
+
+  // Profile banks (per-user / shared) have no owning agent — recall routes to
+  // them but they're not any agent's collection. Add them as agent-less rows
+  // so the operator sees their health alongside the agent banks.
+  const profileBankSet = collectProfileBanks(config);
+  for (const bank of profileBankSet) {
+    if (!banks.has(bank)) banks.set(bank, []);
   }
 
   const rows = await Promise.all(
@@ -1969,6 +1987,7 @@ export async function handleGetMemoryHealth(
         corruptedMentalModelNames: corrupted.map((m) => m.name),
         status,
         statusDetail,
+        kind: profileBankSet.has(bank) ? "profile" : "agent",
       };
     }),
   );
@@ -1996,7 +2015,9 @@ function isKnownBank(config: SwitchroomConfig, bank: string): boolean {
   for (const agentName of Object.keys(config.agents)) {
     if (getCollectionForAgent(agentName, config) === bank) return true;
   }
-  return false;
+  // Profile banks (per-user / shared) are real banks too — allow remediation
+  // (reprocess / refresh model) on them, same as agent banks.
+  return collectProfileBanks(config).has(bank);
 }
 
 /**

--- a/src/web/ui/index.html
+++ b/src/web/ui/index.html
@@ -898,7 +898,7 @@
         return `<div class="agent-card">
           <div class="card-header" style="cursor:default">
             ${statusDot(b.status)}<span class="agent-name">${escapeHtml(b.bank)}</span>
-            <span style="color:var(--text-dim);font-size:.85em;margin-left:.5rem">${escapeHtml((b.agents || []).join(', '))}</span>
+            <span style="color:var(--text-dim);font-size:.85em;margin-left:.5rem">${b.kind === 'profile' ? '<em>profile bank</em>' : escapeHtml((b.agents || []).join(', '))}</span>
           </div>
           <div style="padding:0 1.25rem 1rem">
             <div style="color:var(--text-dim);margin:.1rem 0 .3rem">${escapeHtml(b.statusDetail || '')}</div>

--- a/tests/memory.bank-health.test.ts
+++ b/tests/memory.bank-health.test.ts
@@ -439,6 +439,28 @@ describe("handleGetMemoryHealth (dashboard)", () => {
     expect(byBank.stale.agents).toEqual(["ziggy"]);
   });
 
+  it("surfaces profile banks as agent-less rows with kind:'profile'", async () => {
+    const config = {
+      memory: { backend: "hindsight", config: { url: "http://x/mcp/" } },
+      agents: {
+        clerk: {
+          memory: { collection: "clerk", recall: { additional_banks: ["ken-profile"] } },
+        },
+      },
+    } as unknown as SwitchroomConfig;
+    const health = await handleGetMemoryHealth(config, {
+      fetchImpl: fakeFetchFor({ clerk: HEALTHY_BANK, "ken-profile": HEALTHY_BANK }),
+      now: NOW,
+    });
+    const byBank = Object.fromEntries(health.banks.map((b) => [b.bank, b]));
+    // agent bank: owned, kind 'agent'
+    expect(byBank.clerk.kind).toBe("agent");
+    expect(byBank.clerk.agents).toEqual(["clerk"]);
+    // profile bank: no owning agent, kind 'profile'
+    expect(byBank["ken-profile"].kind).toBe("profile");
+    expect(byBank["ken-profile"].agents).toEqual([]);
+  });
+
   it("reports unreachable without throwing when hindsight is down", async () => {
     const down = (async () => new Response("nope", { status: 502 })) as unknown as typeof fetch;
     const health = await handleGetMemoryHealth(minimalConfig({ a: {} }), {

--- a/tests/memory.bank-health.test.ts
+++ b/tests/memory.bank-health.test.ts
@@ -370,6 +370,23 @@ describe("checkBankIngestHealth (doctor)", () => {
     expect(results[0].status).toBe("warn");
     expect(results[0].detail).toContain("inspection failed");
   });
+
+  it("sweeps profile banks too, labelled '(profile)' (not '()')", async () => {
+    const config = {
+      memory: { backend: "hindsight", config: { url: "http://x/mcp/" } },
+      agents: {
+        clerk: { memory: { collection: "clerk", recall: { additional_banks: ["ken-profile"] } } },
+      },
+    } as unknown as SwitchroomConfig;
+    const results = await checkBankIngestHealth(config, "http://x/mcp/", {
+      fetchImpl: fakeFetchFor({ clerk: HEALTHY_BANK, "ken-profile": HEALTHY_BANK }),
+      now: NOW,
+    });
+    const names = results.map((r) => r.name);
+    expect(names).toContain("bank ken-profile (profile)");
+    // the agent-less profile bank must NOT render the empty "()" label
+    expect(names).not.toContain("bank ken-profile ()");
+  });
 });
 
 const CORRUPT_MODEL_BANK = {

--- a/tests/memory.collect-profile-banks.test.ts
+++ b/tests/memory.collect-profile-banks.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { collectProfileBanks } from "../src/memory/hindsight.js";
+import type { SwitchroomConfig } from "../src/config/schema.js";
+
+/**
+ * collectProfileBanks underpins profile-bank visibility on every health
+ * surface (dashboard Memory tab, `doctor`, `memory stats`). It enumerates the
+ * per-user / shared banks recall routes to — from `users.*.profile_bank`,
+ * `serves`/`knows`, and explicit `additional_banks`/`sender_banks` — minus any
+ * bank that is already an agent's own collection.
+ */
+function cfg(p: Record<string, unknown>): SwitchroomConfig {
+  return {
+    agents: {},
+    memory: { backend: "hindsight", config: { url: "http://localhost:18888/mcp/" } },
+    telegram: { bot_token: "t", forum_chat_id: "c" },
+    ...p,
+  } as unknown as SwitchroomConfig;
+}
+
+const USERS = {
+  ken: { telegram_ids: ["1"], profile_bank: "ken-profile" },
+  lisa: { telegram_ids: ["2"], profile_bank: "lisa-profile" },
+};
+
+describe("collectProfileBanks", () => {
+  it("collects users.profile_bank even when not assigned to any agent", () => {
+    expect([...collectProfileBanks(cfg({ users: USERS, agents: {} }))].sort()).toEqual([
+      "ken-profile",
+      "lisa-profile",
+    ]);
+  });
+
+  it("collects banks from serves (sender_banks) and knows (additional_banks)", () => {
+    const c = cfg({
+      users: USERS,
+      agents: { clerk: { topic_name: "C", serves: ["ken"], knows: ["lisa"] } },
+    });
+    expect([...collectProfileBanks(c)].sort()).toEqual(["ken-profile", "lisa-profile"]);
+  });
+
+  it("collects explicit additional_banks / sender_banks values", () => {
+    const c = cfg({
+      agents: {
+        a: {
+          topic_name: "A",
+          memory: { recall: { additional_banks: ["shared"], sender_banks: { "9": "vip-profile" } } },
+        },
+      },
+    });
+    expect([...collectProfileBanks(c)].sort()).toEqual(["shared", "vip-profile"]);
+  });
+
+  it("excludes banks that are an agent's own collection (default)", () => {
+    const c = cfg({
+      agents: {
+        ziggy: { topic_name: "Z" }, // collection = "ziggy"
+        clerk: { topic_name: "C", memory: { recall: { additional_banks: ["ziggy", "shared"] } } },
+      },
+    });
+    // "ziggy" is an agent collection → dropped; "shared" stays a profile bank.
+    expect([...collectProfileBanks(c)]).toEqual(["shared"]);
+  });
+
+  it("can include agent collections when excludeAgentCollections=false", () => {
+    const c = cfg({
+      agents: {
+        ziggy: { topic_name: "Z" },
+        clerk: { topic_name: "C", memory: { recall: { additional_banks: ["ziggy"] } } },
+      },
+    });
+    expect([...collectProfileBanks(c, { excludeAgentCollections: false })]).toContain("ziggy");
+  });
+
+  it("dedupes a bank referenced by multiple agents/users", () => {
+    const c = cfg({
+      users: USERS,
+      agents: {
+        marko: { topic_name: "M", serves: ["ken", "lisa"] },
+        lawgpt: { topic_name: "L", serves: ["ken", "lisa"] },
+      },
+    });
+    expect([...collectProfileBanks(c)].sort()).toEqual(["ken-profile", "lisa-profile"]);
+  });
+
+  it("empty config → empty set", () => {
+    expect(collectProfileBanks(cfg({ agents: {} })).size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Per-user / shared **profile banks** (`ken-profile`, `lisa-profile`, etc. — from `users.*.profile_bank` + recall `additional_banks`/`sender_banks`) were **invisible** on every operator health surface, because all three enumerate *agent collections* only and profile banks aren't any agent's `memory.collection`. So you couldn't see a profile bank's fact count, staleness, or extraction gaps anywhere. This surfaces them.

## What it does
- **Shared helper** `collectProfileBanks(config, {excludeAgentCollections})` (`src/memory/hindsight.ts`) — enumerates profile banks via `resolveUsers` (covers cascade + `serves`/`knows` + explicit maps), minus any bank already an agent collection.
- **Web `/memory` tab** — profile banks appear as agent-less rows with the same status logic; new `MemoryBankHealthRow.kind` (`'agent' | 'profile'`); UI labels them *"profile bank"*; `isKnownBank()` accepts them so remediation buttons work.
- **`switchroom doctor`** — profile banks swept in the same bank-ingest check, labelled `(profile)`.
- **`switchroom memory stats`** — new *"Profile banks (per-user / shared)"* section listing each bank + owning user(s).

Scope kept to **existing surfaces only**, per request ("only if useful and already existing"). No new commands.

## Behaviour
**Visibility only** — no recall/routing change. A fleet with no profile banks gets an empty set → zero extra rows → behaves exactly as today.

## Test plan
- [x] `collectProfileBanks` unit (7 cases: users / serves / knows / explicit `additional_banks`+`sender_banks`, agent-collection exclusion, dedup, empty).
- [x] `handleGetMemoryHealth` integration: profile bank → `kind:'profile'`, `agents:[]`; agent bank → `kind:'agent'`.
- [x] Existing `doctor` / `memory` / `web` suites green (178 tests).
- [x] `tsc --noEmit` + `npm run lint` clean.

## Risk
Low — additive read-only visibility. Main watch item: the UI assumed every bank row had ≥1 agent name (line 901); now handled via `kind === 'profile'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)