### PR TITLE
feat(memory): retire per-agent user-profile mental models

### DIFF
--- a/profiles/default/CLAUDE.md.hbs
+++ b/profiles/default/CLAUDE.md.hbs
@@ -61,10 +61,10 @@ Hindsight is a memory bank with semantic search, knowledge graph, entity resolut
 - `mcp__hindsight__retain` — store a new memory. The plugin automatically retains the conversation transcript every ~10 turns via the Stop hook, so you usually don't need this. Call manually for significant decisions, corrections, or facts you want immediately searchable.
 - `mcp__hindsight__reflect` — Hindsight's LLM-powered "answer this query using the bank's content + directives". Use when the user asks a question that requires synthesis across multiple past memories.
 
-### Mental Models (replaces hand-curated user profile)
-A mental model is a pre-computed semantic summary backed by reflection over the bank. It's the proper way to maintain things like "what do we know about this user" — semantically populated, automatically refreshed.
+### Mental Models
+A mental model is a pre-computed semantic summary backed by reflection over the bank — a way to maintain a standing answer to a recurring question, semantically populated and refreshed.
 
-- `mcp__hindsight__create_mental_model(name, source_query)` — create one. When the user shares a fact about themselves (preferences, background, goals), don't write a file — instead, retain the fact and (if no User Profile mental model exists yet) create one with `source_query: "what do we know about this user?"`. Hindsight will populate it from the retained memories.
+- `mcp__hindsight__create_mental_model(name, source_query)` — create one for a recurring synthesis you need. When the user shares a fact about themselves (preferences, background, goals), don't write a file — just **retain** the fact. You do NOT need to build or maintain a per-agent "user profile": who the user is lives in dedicated per-user profile banks that the operator curates out-of-band, and recall surfaces it automatically.
 
 ### Directives (replaces feedback rules)
 Hard rules the agent must follow during reflect — guardrails that are always applied.

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -514,7 +514,7 @@ import { shouldEmitNotionMcp } from "../config/notion-workspace-acl.js";
 import { reconcileAgentDefaultSkills } from "./reconcile-default-skills.js";
 import { applyTelegramProgressGuidance } from "./sub-agent-telegram-prompt.js";
 import type { McpServerConfig } from "../memory/hindsight.js";
-import { createBank, updateBankMissions, ensureUserProfileMentalModel, DEFAULT_RETAIN_MISSION, isHindsightEnabled } from "../memory/hindsight.js";
+import { createBank, updateBankMissions, DEFAULT_RETAIN_MISSION, isHindsightEnabled } from "../memory/hindsight.js";
 import { loadTopicState } from "../telegram/state.js";
 import { resolveDualPath } from "../config/paths.js";
 import { resolvePath } from "../config/loader.js";
@@ -4031,18 +4031,6 @@ export function scaffoldAgent(
         .catch((err) => {
           console.warn(`  ${chalk.yellow("⚠")} Bank mission update error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
         });
-
-      ensureUserProfileMentalModel(apiUrl, hindsightBankId, { timeoutMs: 5000 })
-        .then((result) => {
-          if (result.ok) {
-            console.log(`  ${chalk.green("✓")} User-profile Mental Model ready for ${formatAgentBankLabel(name, hindsightBankId)}`);
-          } else {
-            console.warn(`  ${chalk.yellow("⚠")} Failed to create user-profile MM for ${formatAgentBankLabel(name, hindsightBankId)}: ${result.reason}`);
-          }
-        })
-        .catch((err) => {
-          console.warn(`  ${chalk.yellow("⚠")} User-profile MM error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
-        });
     });
   }
 
@@ -4287,17 +4275,10 @@ export function buildSettingsHooksBlock(p: HooksBlockParams): Record<string, unk
       async: true,
     });
   }
-  if (hindsightEnabled) {
-    stopHooks.push({
-      type: "command",
-      command: wrap(
-        "hook:user-profile-refresh",
-        `bash "${join(DOCKER_BIN_PATH, "user-profile-refresh-hook.sh")}"`,
-      ),
-      timeout: 10,
-      async: true,
-    });
-  }
+  // Per-agent user-profile mental models are retired — dedicated profile
+  // banks (users.*.profile_bank, recall additional_banks/sender_banks) are the
+  // source of truth, so we no longer auto-create or refresh a per-bank
+  // "user-profile" mental model. (No user-profile-refresh Stop hook wired.)
   if (useSwitchroomPlugin) {
     stopHooks.push({
       type: "command",
@@ -5944,18 +5925,6 @@ export function reconcileAgent(
             console.warn(`  ${chalk.yellow("⚠")} Bank mission update error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
           });
       }
-
-      ensureUserProfileMentalModel(apiUrl, hindsightBankId, { timeoutMs: 5000 })
-        .then((result) => {
-          if (result.ok) {
-            console.log(`  ${chalk.green("✓")} User-profile Mental Model ready for ${formatAgentBankLabel(name, hindsightBankId)}`);
-          } else {
-            console.warn(`  ${chalk.yellow("⚠")} Failed to create user-profile MM for ${formatAgentBankLabel(name, hindsightBankId)}: ${result.reason}`);
-          }
-        })
-        .catch((err) => {
-          console.warn(`  ${chalk.yellow("⚠")} User-profile MM error for ${formatAgentBankLabel(name, hindsightBankId)}: ${err}`);
-        });
     });
   }
 

--- a/src/agents/scaffold.ts
+++ b/src/agents/scaffold.ts
@@ -3996,8 +3996,7 @@ export function scaffoldAgent(
         return false;
       });
 
-    // Update bank missions and ensure user-profile MM — both gated on the
-    // bank actually existing.
+    // Update bank missions — gated on the bank actually existing.
     //
     // Mission selection: explicit user yaml wins. When the operator hasn't
     // set a `retain_mission`, scaffold (NOT reconcile) seeds the upstream-

--- a/tests/reconcile-hooks-drift.test.ts
+++ b/tests/reconcile-hooks-drift.test.ts
@@ -39,6 +39,20 @@ describe("buildSettingsHooksBlock", () => {
     expect(result.PostToolUse).toBeUndefined();
   });
 
+  it("does NOT wire the retired user-profile-refresh Stop hook, even with hindsight enabled", () => {
+    // Per-agent user-profile mental models are retired in favour of dedicated
+    // profile banks — the refresh Stop hook must no longer be emitted.
+    const result = buildSettingsHooksBlock({
+      agentName: "test-agent",
+      agentConfig: makeAgentConfig(),
+      hindsightEnabled: true,
+      useSwitchroomPlugin: true,
+    });
+    const stop = (result.Stop ?? []) as Array<{ hooks: Array<{ command: string }> }>;
+    const stopCmds = stop.flatMap((e) => e.hooks.map((h) => h.command));
+    expect(stopCmds.some((c) => c.includes("user-profile-refresh-hook.sh"))).toBe(false);
+  });
+
   it("with telegram plugin adds PreToolUse and PostToolUse hooks", () => {
     const agentConfig = makeAgentConfig({
       plugin: "switchroom-telegram",


### PR DESCRIPTION
## Summary
Dedicated **profile banks** (`ken-profile`/`lisa-profile` — from `users.*.profile_bank` + recall `additional_banks`/`sender_banks`) are now the source of truth for "who the user is." The per-agent auto-managed **"user-profile" mental model** is therefore redundant — and actively harmful: empty/failed ones get injected every turn and flagged by `doctor`, and a stale per-agent profile can conflict with the curated profile bank (this is how the recent "Rex" wrong-dog answer happened).

## What it does
Removes the two **automatic** behaviours that create/maintain the per-agent model:
- **Auto-create:** `scaffoldAgent` + `reconcileAgent` no longer call `ensureUserProfileMentalModel` (the "User-profile Mental Model ready" step on every apply/restart).
- **Refresh Stop hook:** no longer wires `user-profile-refresh-hook.sh` (which refreshed the model on every agent stop) — so deleting the existing models actually *sticks* instead of being regenerated.

## Kept (dormant / opt-in)
`ensureUserProfileMentalModel` itself, the dashboard "Build profile" button, and `bin/user-profile-refresh-hook.sh` remain so an operator can still build one by hand. Ripping out that web path is a separate, larger follow-up — flagged, not done here, to keep the blast radius small.

## Rollout note
Existing per-agent user-profile mental models are deleted **out-of-band after this rolls** (so reconcile can't recreate them mid-cleanup). Goes out in v0.15.45 alongside the profile-banks visibility (#2446).

## Test plan
- [x] New `reconcile-hooks-drift` assertion: `buildSettingsHooksBlock` emits **no** `user-profile-refresh` Stop hook, even with hindsight enabled.
- [x] `scaffold.test.ts` / `reconcile-hooks-drift` / `memory.user-profile` suites green (the `ensureUserProfileMentalModel` function + hook-script tests still pass — only the wiring was removed).
- [x] `tsc --noEmit` + `npm run lint` clean.

## Risk
Low. Behaviour subtraction: agents simply stop auto-creating/refreshing a redundant mental model. No recall-path change. Existing good per-agent profiles are untouched by the *code* (removed via the out-of-band data cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)