### PR TITLE
chore(privacy): expand PII gate + scrub two slipped operator handles

### DIFF
--- a/docs/microsoft-workspace.md
+++ b/docs/microsoft-workspace.md
@@ -216,11 +216,11 @@ RFC (audit + revocation semantics differ from drafts).
 After consent, the CLI shows:
 
 ```
-✓ Registered Microsoft account ken@outlook.com with auth-broker.
+✓ Registered Microsoft account bob@example.com with auth-broker.
   Account type: personal (MSA — outlook.com / hotmail.com)
 
   Next: enable on one or more agents:
-    switchroom auth microsoft enable ken@outlook.com <agent> [...]
+    switchroom auth microsoft enable bob@example.com <agent> [...]
 ```
 
 ## Granting access to agents
@@ -314,7 +314,7 @@ Agent: clerk
 Tool: ms-365__upload-file-content
 Item: Q3-Strategy.docx
 ID:   01ABCDEFG
-Account: ken@outlook.com
+Account: bob@example.com
 Size: 14.5KB → 16.2KB (+1.7KB)
 Link: https://onedrive.live.com/...
 💬 Adding the meeting notes from yesterday

--- a/reference/rfcs/microsoft-workspace.md
+++ b/reference/rfcs/microsoft-workspace.md
@@ -423,7 +423,7 @@ in §6.4).
 
 ```yaml
 microsoft_accounts:
-  ken@outlook.com:
+  bob@example.com:
     enabled_for: [clerk, finn, gymbro]
   ken@work.com:
     enabled_for: [clerk, lawgpt]
@@ -446,7 +446,7 @@ Verbs:
 agents:
   clerk:
     microsoft_workspace:
-      account: ken@outlook.com
+      account: bob@example.com
   lawgpt:
     microsoft_workspace:
       account: ken@work.com

--- a/scripts/check-no-pii-secrets.mjs
+++ b/scripts/check-no-pii-secrets.mjs
@@ -66,6 +66,14 @@ const RULES = [
     id: 'shorthand/real outlook account',
     re: new RegExp('ken' + '\\.thompson@outlook' + '|' + '\\bken' + '-outlook\\b', 'i'),
   },
+  {
+    id: 'bare outlook handle "ken' + '@outlook"',
+    re: new RegExp('\\bken' + '@outlook\\b', 'i'),
+  },
+  {
+    id: 'real personal account "lisa' + '_goodfellow"',
+    re: new RegExp('\\blisa' + '_goodfellow\\b', 'i'),
+  },
   { id: 'operator home path', re: new RegExp('/home/' + 'kenthompson') },
   { id: 'real Tailscale tailnet id', re: new RegExp('tail' + 'd78f7', 'i') },
   { id: 'real Telegram id (user)', re: new RegExp('\\b' + '82487' + '03757\\b') },

--- a/src/auth/broker/microsoft-storage.ts
+++ b/src/auth/broker/microsoft-storage.ts
@@ -12,7 +12,7 @@
  * Storage layout:
  *
  *   ~/.switchroom/state/auth-broker/microsoft/
- *     ken@outlook.com/
+ *     bob@example.com/
  *       credentials.json   ← `{ microsoftOauth: { ... } }`, mode 0600
  *     ken@work.example.com/
  *       credentials.json

--- a/src/auth/broker/server-audit-account-kind.test.ts
+++ b/src/auth/broker/server-audit-account-kind.test.ts
@@ -223,7 +223,7 @@ describe("AuthBroker — audit log accountKind field", () => {
     const h = makeHarness();
     // Use the same email string for both the Claude account and the Microsoft
     // account, to demonstrate that accountKind disambiguates them in the log.
-    const sharedEmail = "lisa_goodfellow@hotmail.com";
+    const sharedEmail = "carol@example.com";
     const config = makeConfig(h, {
       active: sharedEmail,
       agents: {

--- a/src/cli/doctor-microsoft.test.ts
+++ b/src/cli/doctor-microsoft.test.ts
@@ -15,11 +15,11 @@ const baseConfig = (overrides: Partial<SwitchroomConfig> = {}): SwitchroomConfig
   ({
     agents: {
       clerk: {
-        microsoft_workspace: { account: "ken@outlook.com" },
+        microsoft_workspace: { account: "bob@example.com" },
       },
     },
     microsoft_accounts: {
-      "ken@outlook.com": { enabled_for: ["clerk"] },
+      "bob@example.com": { enabled_for: ["clerk"] },
     },
     microsoft_workspace: {
       microsoft_client_id: "vault:microsoft-oauth-client-id",
@@ -70,7 +70,7 @@ describe("runMicrosoftChecks — config matrix", () => {
 
   it("agent has account but is NOT in enabled_for → fail", () => {
     const cfg = baseConfig({
-      microsoft_accounts: { "ken@outlook.com": { enabled_for: ["other"] } },
+      microsoft_accounts: { "bob@example.com": { enabled_for: ["other"] } },
     });
     const results = runMicrosoftChecks(cfg, defaultMockDeps());
     const matrix = results.find((r) => r.name === "microsoft:matrix:clerk");
@@ -95,7 +95,7 @@ describe("runMicrosoftChecks — config matrix", () => {
       microsoft_workspace: { account: "ken@contoso.com" },
     } as unknown as SwitchroomConfig["agents"][string];
     cfg.microsoft_accounts = {
-      "ken@outlook.com": { enabled_for: ["clerk"] },
+      "bob@example.com": { enabled_for: ["clerk"] },
     };
     const results = runMicrosoftChecks(cfg, defaultMockDeps());
     const reverse = results.find((r) =>

--- a/src/cli/microsoft-accounts-yaml.test.ts
+++ b/src/cli/microsoft-accounts-yaml.test.ts
@@ -24,29 +24,29 @@ agents:
 
 describe("enableAgentsOnMicrosoftAccount", () => {
   it("adds agents to a fresh entry, creating the parent map", () => {
-    const out = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    const out = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
     expect(out).toContain("microsoft_accounts:");
-    expect(out).toContain("ken@outlook.com:");
+    expect(out).toContain("bob@example.com:");
     expect(out).toContain("enabled_for:");
     expect(out).toContain("- clerk");
   });
 
   it("is idempotent (adding the same agent twice is a no-op)", () => {
-    const once = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
-    const twice = enableAgentsOnMicrosoftAccount(once, "ken@outlook.com", ["clerk"]);
+    const once = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
+    const twice = enableAgentsOnMicrosoftAccount(once, "bob@example.com", ["clerk"]);
     expect(twice).toBe(once);
   });
 
   it("returns the input verbatim when no agents would be added", () => {
-    const once = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
-    const verbatim = enableAgentsOnMicrosoftAccount(once, "ken@outlook.com", []);
+    const once = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
+    const verbatim = enableAgentsOnMicrosoftAccount(once, "bob@example.com", []);
     expect(verbatim).toBe(once);
   });
 
   it("appends new agents preserving existing order", () => {
-    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk", "lawgpt"]);
-    yaml = enableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["finn"]);
-    const agents = getEnabledAgentsForMicrosoftAccount(yaml, "ken@outlook.com");
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk", "lawgpt"]);
+    yaml = enableAgentsOnMicrosoftAccount(yaml, "bob@example.com", ["finn"]);
+    const agents = getEnabledAgentsForMicrosoftAccount(yaml, "bob@example.com");
     expect(agents).toEqual(["clerk", "lawgpt", "finn"]);
   });
 
@@ -57,7 +57,7 @@ agents:
   # clerk is the exec assistant
   clerk: {}
 `;
-    const out = enableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["clerk"]);
+    const out = enableAgentsOnMicrosoftAccount(yaml, "bob@example.com", ["clerk"]);
     expect(out).toContain("# top-level comment");
     expect(out).toContain("# clerk is the exec assistant");
   });
@@ -65,17 +65,17 @@ agents:
 
 describe("disableAgentsOnMicrosoftAccount", () => {
   it("removes named agents, keeps others", () => {
-    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk", "lawgpt"]);
-    yaml = disableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["clerk"]);
-    const agents = getEnabledAgentsForMicrosoftAccount(yaml, "ken@outlook.com");
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk", "lawgpt"]);
+    yaml = disableAgentsOnMicrosoftAccount(yaml, "bob@example.com", ["clerk"]);
+    const agents = getEnabledAgentsForMicrosoftAccount(yaml, "bob@example.com");
     expect(agents).toEqual(["lawgpt"]);
   });
 
   it("leaves enabled_for as empty array (dormant) when all agents removed", () => {
-    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
-    yaml = disableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["clerk"]);
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
+    yaml = disableAgentsOnMicrosoftAccount(yaml, "bob@example.com", ["clerk"]);
     // Dormant — entry stays per RFC #1873 §6.1
-    const agents = getEnabledAgentsForMicrosoftAccount(yaml, "ken@outlook.com");
+    const agents = getEnabledAgentsForMicrosoftAccount(yaml, "bob@example.com");
     expect(agents).toEqual([]);
   });
 
@@ -85,21 +85,21 @@ describe("disableAgentsOnMicrosoftAccount", () => {
   });
 
   it("returns input verbatim when no named agents are in the list", () => {
-    const yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
-    const out = disableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["nonexistent"]);
+    const yaml = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
+    const out = disableAgentsOnMicrosoftAccount(yaml, "bob@example.com", ["nonexistent"]);
     expect(out).toBe(yaml);
   });
 });
 
 describe("getEnabledAgentsForMicrosoftAccount", () => {
   it("returns null when account is absent (vs empty array = dormant)", () => {
-    expect(getEnabledAgentsForMicrosoftAccount(STARTER, "ken@outlook.com")).toBeNull();
+    expect(getEnabledAgentsForMicrosoftAccount(STARTER, "bob@example.com")).toBeNull();
   });
 
   it("returns [] when entry exists with empty enabled_for (dormant)", () => {
-    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
-    yaml = disableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["clerk"]);
-    expect(getEnabledAgentsForMicrosoftAccount(yaml, "ken@outlook.com")).toEqual([]);
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
+    yaml = disableAgentsOnMicrosoftAccount(yaml, "bob@example.com", ["clerk"]);
+    expect(getEnabledAgentsForMicrosoftAccount(yaml, "bob@example.com")).toEqual([]);
   });
 });
 
@@ -109,45 +109,45 @@ describe("listMicrosoftAccounts", () => {
   });
 
   it("lists all accounts in source order", () => {
-    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
     yaml = enableAgentsOnMicrosoftAccount(yaml, "ken@contoso.com", ["lawgpt"]);
     const list = listMicrosoftAccounts(yaml);
     expect(list).toEqual([
-      { account: "ken@outlook.com", enabled_for: ["clerk"] },
+      { account: "bob@example.com", enabled_for: ["clerk"] },
       { account: "ken@contoso.com", enabled_for: ["lawgpt"] },
     ]);
   });
 
   it("includes dormant accounts (empty enabled_for) in the list", () => {
-    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
-    yaml = disableAgentsOnMicrosoftAccount(yaml, "ken@outlook.com", ["clerk"]);
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
+    yaml = disableAgentsOnMicrosoftAccount(yaml, "bob@example.com", ["clerk"]);
     expect(listMicrosoftAccounts(yaml)).toEqual([
-      { account: "ken@outlook.com", enabled_for: [] },
+      { account: "bob@example.com", enabled_for: [] },
     ]);
   });
 });
 
 describe("removeMicrosoftAccountEntry", () => {
   it("removes a configured account", () => {
-    const yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
-    const out = removeMicrosoftAccountEntry(yaml, "ken@outlook.com");
-    expect(out).not.toContain("ken@outlook.com");
+    const yaml = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
+    const out = removeMicrosoftAccountEntry(yaml, "bob@example.com");
+    expect(out).not.toContain("bob@example.com");
     expect(out).not.toContain("microsoft_accounts:");
   });
 
   it("prunes the empty parent map when removing the last entry", () => {
-    const yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
-    const out = removeMicrosoftAccountEntry(yaml, "ken@outlook.com");
+    const yaml = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
+    const out = removeMicrosoftAccountEntry(yaml, "bob@example.com");
     expect(out).not.toContain("microsoft_accounts");
   });
 
   it("keeps the parent map when other accounts remain", () => {
-    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "ken@outlook.com", ["clerk"]);
+    let yaml = enableAgentsOnMicrosoftAccount(STARTER, "bob@example.com", ["clerk"]);
     yaml = enableAgentsOnMicrosoftAccount(yaml, "ken@contoso.com", ["lawgpt"]);
-    const out = removeMicrosoftAccountEntry(yaml, "ken@outlook.com");
+    const out = removeMicrosoftAccountEntry(yaml, "bob@example.com");
     expect(out).toContain("microsoft_accounts");
     expect(out).toContain("ken@contoso.com");
-    expect(out).not.toContain("ken@outlook.com");
+    expect(out).not.toContain("bob@example.com");
   });
 
   it("returns input verbatim when account is absent", () => {

--- a/src/config/microsoft-workspace-acl.test.ts
+++ b/src/config/microsoft-workspace-acl.test.ts
@@ -22,12 +22,12 @@ describe("shouldEmitMs365Mcp", () => {
   });
 
   it("returns false when microsoft_accounts is undefined", () => {
-    expect(shouldEmitMs365Mcp("clerk", "ken@outlook.com", undefined)).toBe(false);
+    expect(shouldEmitMs365Mcp("clerk", "bob@example.com", undefined)).toBe(false);
   });
 
   it("returns false when account is not in microsoft_accounts", () => {
     expect(
-      shouldEmitMs365Mcp("clerk", "ken@outlook.com", {
+      shouldEmitMs365Mcp("clerk", "bob@example.com", {
         "other@outlook.com": { enabled_for: ["clerk"] },
       }),
     ).toBe(false);
@@ -35,32 +35,32 @@ describe("shouldEmitMs365Mcp", () => {
 
   it("returns false when agent is not in enabled_for[]", () => {
     expect(
-      shouldEmitMs365Mcp("clerk", "ken@outlook.com", {
-        "ken@outlook.com": { enabled_for: ["lawgpt"] },
+      shouldEmitMs365Mcp("clerk", "bob@example.com", {
+        "bob@example.com": { enabled_for: ["lawgpt"] },
       }),
     ).toBe(false);
   });
 
   it("returns true when agent is in enabled_for[]", () => {
     expect(
-      shouldEmitMs365Mcp("clerk", "ken@outlook.com", {
-        "ken@outlook.com": { enabled_for: ["clerk", "finn"] },
+      shouldEmitMs365Mcp("clerk", "bob@example.com", {
+        "bob@example.com": { enabled_for: ["clerk", "finn"] },
       }),
     ).toBe(true);
   });
 
   it("normalizes account name (case-insensitive + trim)", () => {
     expect(
-      shouldEmitMs365Mcp("clerk", "  KEN@Outlook.COM  ", {
-        "ken@outlook.com": { enabled_for: ["clerk"] },
+      shouldEmitMs365Mcp("clerk", "  BOB@Example.COM  ", {
+        "bob@example.com": { enabled_for: ["clerk"] },
       }),
     ).toBe(true);
   });
 
   it("handles dormant accounts (empty enabled_for)", () => {
     expect(
-      shouldEmitMs365Mcp("clerk", "ken@outlook.com", {
-        "ken@outlook.com": { enabled_for: [] },
+      shouldEmitMs365Mcp("clerk", "bob@example.com", {
+        "bob@example.com": { enabled_for: [] },
       }),
     ).toBe(false);
   });
@@ -95,11 +95,11 @@ describe("isMicrosoftClientCredentialKeyForAgent", () => {
     ({
       agents: {
         clerk: {
-          microsoft_workspace: { account: "ken@outlook.com" },
+          microsoft_workspace: { account: "bob@example.com" },
         },
       },
       microsoft_accounts: {
-        "ken@outlook.com": { enabled_for: ["clerk"] },
+        "bob@example.com": { enabled_for: ["clerk"] },
       },
       microsoft_workspace: {
         microsoft_client_id: "vault:microsoft-oauth-client-id",
@@ -129,7 +129,7 @@ describe("isMicrosoftClientCredentialKeyForAgent", () => {
   it("returns false when agent is not in enabled_for", () => {
     const cfg = baseConfig({
       microsoft_accounts: {
-        "ken@outlook.com": { enabled_for: ["other-agent"] },
+        "bob@example.com": { enabled_for: ["other-agent"] },
       },
     });
     expect(

--- a/telegram-plugin/gateway/ms365-write-approval.test.ts
+++ b/telegram-plugin/gateway/ms365-write-approval.test.ts
@@ -26,7 +26,7 @@ describe("validateMs365Preview", () => {
     toolName: "mcp__ms-365__upload-file-content",
     itemId: "01ABCDEFG",
     itemDisplayName: "Q3-Strategy.docx",
-    accountEmail: "ken@outlook.com",
+    accountEmail: "bob@example.com",
   };
 
   it("accepts a minimal valid preview", () => {
@@ -93,7 +93,7 @@ describe("buildMs365CardText", () => {
     toolName: "mcp__ms-365__upload-file-content",
     itemId: "01ABCDEFG",
     itemDisplayName: "Q3-Strategy.docx",
-    accountEmail: "ken@outlook.com",
+    accountEmail: "bob@example.com",
   };
 
   it("includes agent, tool, item, account", () => {
@@ -102,7 +102,7 @@ describe("buildMs365CardText", () => {
     expect(text).toContain("ms-365__upload-file-content");
     expect(text).toContain("Q3-Strategy.docx");
     expect(text).toContain("01ABCDEFG");
-    expect(text).toContain("ken@outlook.com");
+    expect(text).toContain("bob@example.com");
   });
 
   it("omits ID line for new files", () => {
@@ -183,7 +183,7 @@ function makeMsg(overrides: Partial<RequestMs365ApprovalMessage> = {}): RequestM
       toolName: "mcp__ms-365__upload-file-content",
       itemId: "01ABC",
       itemDisplayName: "Strategy.docx",
-      accountEmail: "ken@outlook.com",
+      accountEmail: "bob@example.com",
     },
     ttlMs: 5 * 60 * 1000,
     ...overrides,

--- a/tests/web-dashboard-connections-render.test.ts
+++ b/tests/web-dashboard-connections-render.test.ts
@@ -132,7 +132,7 @@ const MOCK = {
   ],
   microsoft: [
     {
-      account: "ken@outlook.com",
+      account: "bob@example.com",
       expiresAt: 1,
       scope: "Mail.ReadWrite",
       clientId: "mid-123456789012",
@@ -166,7 +166,7 @@ describe("Connections tab renders provider cards from data (real inline renderCo
   it("renders Google + Microsoft + Linear cards with their identifiers", () => {
     const out = render(MOCK);
     expect(out).toContain("alice@example.com");
-    expect(out).toContain("ken@outlook.com");
+    expect(out).toContain("bob@example.com");
     expect(out).toContain("carrie");
     // Linear is shown as an OAuth app actor, not a personal token.
     expect(out).toContain("OAuth agent");


### PR DESCRIPTION
## What

Two real operator handles were slipping past the PII gate into committed test fixtures and docs:
- bare `ken@outlook.com` (the existing rule only caught the `ken.thompson@outlook` / `ken-outlook` forms)
- `lisa_goodfellow@hotmail.com` (a Microsoft 365 persona, surfaced during the auth-broker `accountKind` work)

## Changes

- **Gate** (`scripts/check-no-pii-secrets.mjs`): two new fragment-split rules. Both word-boundary anchored so synthetic placeholders like `broken@outlook.com` and `lisa@hotmail.com` don't false-positive. As with every rule, the real identifier never appears as a contiguous literal in the gate source, and failures log only the rule label + `file:line`, never the matched value.
- **Scrub**: `ken@outlook.com` → `bob@example.com` (8 files), `lisa_goodfellow@hotmail.com` → `carol@example.com` (1 file). `broken@outlook.com` placeholders left untouched (word boundary excludes them).

## Verification

- `npm run lint` → exit 0 (all 9 gates, 2111 files)
- affected vitest suites → 124 tests, 0 failures
- gate source confirmed free of contiguous real-handle literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)